### PR TITLE
fix: atomically pair backlog and task record transitions

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -55,10 +55,11 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Read the named record for the recorded reasons, then reproduce with a direct `bin/fm-home-summary-refresh.sh` (no `--best-effort`, which is what keeps the failure quiet) so the refresh error reaches you.
   A recorded deadline means the complete refresh did not finish inside `FM_HOME_SUMMARY_TIMEOUT`, so inspect lock acquisition and producer completion before validation or publication, and fix the blocked phase rather than raising this load-bearing bound.
 
-- `BACKLOG_RECONCILE: <id>: recorded backlog close could not be replayed: <reason>` - an interrupted cleanup recorded exactly which backlog item it still owed a close, and this session start could not land it.
-  The endpoint and local copy are already gone; the task record is normally gone too, but remains paired with the marker when recovery could not remove it safely.
-  Read the named reason, fix the record or backlog-file problem, and rerun session start so the same recorded close replays.
-  Never hand-close the item by deleting `state/<id>.backlog-close` - that discards the completion link the cleanup captured.
+- `BACKLOG_RECONCILE: <id>: recorded backlog close could not be replayed: <reason>` - this session start found a pending-close record but could not land it.
+  For a valid teardown record, the endpoint and local copy are already gone; the task record is normally gone too, but remains paired with the marker when recovery could not remove it safely.
+  A validation error means the record cannot be trusted, so do not assume cleanup completed or follow any path or argument stored in it.
+  Read the named reason, inspect the marker as inert data when validation failed, fix the record or backlog-file problem, and rerun session start so a valid recorded close replays.
+  Never hand-close the item by deleting `state/<id>.backlog-close` - that can discard a completion link the cleanup captured, and the surviving marker prevents the record sweep from starting the item meanwhile.
 - `BACKLOG_RECONCILE: <id>: worker record exists but its backlog item could not be read: <reason>` - this home could not determine whether the item matches its worker record.
   Resolve the named backlog read problem and rerun session start; never guess by starting or closing an unreadable item.
 - `BACKLOG_RECONCILE: <id>: worker record exists but its backlog item could not be moved to In flight: <reason>` - this home owns a worker whose backlog item is still queued, and the reconciliation could not correct it.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, PR_CHECK_MIGRATION, HOME_SUMMARY, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, PR_CHECK_MIGRATION, HOME_SUMMARY, BACKLOG_RECONCILE, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -55,6 +55,11 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Read the named record for the recorded reasons, then reproduce with a direct `bin/fm-home-summary-refresh.sh` (no `--best-effort`, which is what keeps the failure quiet) so the refresh error reaches you.
   A recorded deadline means the complete refresh did not finish inside `FM_HOME_SUMMARY_TIMEOUT`, so inspect lock acquisition and producer completion before validation or publication, and fix the blocked phase rather than raising this load-bearing bound.
 
+- `BACKLOG_RECONCILE: <id>: recorded backlog close could not be replayed: <reason>` - an interrupted cleanup recorded exactly which backlog item it still owed a close, and this session start could not land it.
+  The task's own record is already gone, so the item is showing as running when the work is finished; read the named reason, fix what is blocking the backlog file, and rerun session start so the same recorded close replays.
+  Never hand-close the item by deleting `state/<id>.backlog-close` - that discards the completion link the cleanup captured.
+- `BACKLOG_RECONCILE: <id>: worker record exists but its backlog item could not be moved to In flight: <reason>` - this home owns a worker whose backlog item is still queued, and the reconciliation could not correct it.
+  Until it is corrected, the fleet view reads that worker as work no backlog item owns; resolve the named backlog problem and rerun session start.
 - `SECONDMATE_SYNC: secondmate <id>: skipped: <reason>` - secondmate convergence left a live home on its existing checkout because the home was dirty, diverged, unsafe, on the wrong branch, missing its placement-specific target commit, unreachable, or otherwise not fast-forwardable, or because inherited local-material propagation failed; bootstrap continued, but inspect the reason because the secondmate's tracked instructions, inherited settings, or shared captain preferences may be stale after a primary update.
 - `SECONDMATE_LIVENESS: secondmate <id>: skipped: <reason>|respawn failed after <cause>: <reason>` - the session-start liveness sweep could not guarantee that the registered secondmate is running a real agent process.
   Investigate the reason because that secondmate is not guaranteed live.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -59,6 +59,8 @@ When any diagnostic needs captain attention, report the plain consequence and re
   The endpoint and local copy are already gone; the task record is normally gone too, but remains paired with the marker when recovery could not remove it safely.
   Read the named reason, fix the record or backlog-file problem, and rerun session start so the same recorded close replays.
   Never hand-close the item by deleting `state/<id>.backlog-close` - that discards the completion link the cleanup captured.
+- `BACKLOG_RECONCILE: <id>: worker record exists but its backlog item could not be read: <reason>` - this home could not determine whether the item matches its worker record.
+  Resolve the named backlog read problem and rerun session start; never guess by starting or closing an unreadable item.
 - `BACKLOG_RECONCILE: <id>: worker record exists but its backlog item could not be moved to In flight: <reason>` - this home owns a worker whose backlog item is still queued, and the reconciliation could not correct it.
   Until it is corrected, the fleet view reads that worker as work no backlog item owns; resolve the named backlog problem and rerun session start.
 - `SECONDMATE_SYNC: secondmate <id>: skipped: <reason>` - secondmate convergence left a live home on its existing checkout because the home was dirty, diverged, unsafe, on the wrong branch, missing its placement-specific target commit, unreachable, or otherwise not fast-forwardable, or because inherited local-material propagation failed; bootstrap continued, but inspect the reason because the secondmate's tracked instructions, inherited settings, or shared captain preferences may be stale after a primary update.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -56,7 +56,8 @@ When any diagnostic needs captain attention, report the plain consequence and re
   A recorded deadline means the complete refresh did not finish inside `FM_HOME_SUMMARY_TIMEOUT`, so inspect lock acquisition and producer completion before validation or publication, and fix the blocked phase rather than raising this load-bearing bound.
 
 - `BACKLOG_RECONCILE: <id>: recorded backlog close could not be replayed: <reason>` - an interrupted cleanup recorded exactly which backlog item it still owed a close, and this session start could not land it.
-  The task's own record is already gone, so the item is showing as running when the work is finished; read the named reason, fix what is blocking the backlog file, and rerun session start so the same recorded close replays.
+  The endpoint and local copy are already gone; the task record is normally gone too, but remains paired with the marker when recovery could not remove it safely.
+  Read the named reason, fix the record or backlog-file problem, and rerun session start so the same recorded close replays.
   Never hand-close the item by deleting `state/<id>.backlog-close` - that discards the completion link the cleanup captured.
 - `BACKLOG_RECONCILE: <id>: worker record exists but its backlog item could not be moved to In flight: <reason>` - this home owns a worker whose backlog item is still queued, and the reconciliation could not correct it.
   Until it is corrected, the fleet view reads that worker as work no backlog item owns; resolve the named backlog problem and rerun session start.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,7 +307,7 @@ Write the task-specific brief under section 11 before spawning.
 
 Spawn only through `bin/fm-spawn.sh` after the profile and backend checks in section 4.
 The spawn must resolve a genuine isolated task worktree distinct from the primary checkout; a failed isolation assertion stops the task.
-The spawn itself moves the work item to In flight and refuses rather than dispatching work this home has no item for, so recording the dispatch is never a separate step to remember.
+When the configured tasks-axi backlog gate applies, the spawn itself moves the work item to In flight and refuses rather than dispatching work this home has no item for, so recording the dispatch is never a separate step to remember; a manual-backend home retains the hand-editing contract in `docs/configuration.md`.
 After spawning, confirm the worker is processing the brief and handle any trust dialog through `harness-adapters`.
 A persistent secondmate is recorded in the secondmate registry and runtime state, never as a backlog work item.
 
@@ -499,7 +499,7 @@ Work routed to a secondmate is recorded in that secondmate home's own backlog, n
 A decision is simply a task held for the captain: `tasks-axi hold <id> --reason "<reason>" --kind captain`, with `--until <date>` when the captain defers it.
 When a main-side thread such as a pending captain decision or relay reminder is worth durable tracking, file it as its own work item and hold it the same way.
 Captain calls discovered by investigations or visual reviews follow `captain-hold-lifecycle`, which owns their completion gate and recorded-answer rules.
-Dispatch and completion move the item themselves - `bin/fm-spawn.sh` and `bin/fm-teardown.sh` own those transitions and refuse rather than report success without them - so what remains yours is filing the item before dispatch, recording decisions, and keeping notes current.
+Under the automatic tasks-axi backend, dispatch and completion move the item themselves - `bin/fm-spawn.sh` and `bin/fm-teardown.sh` own those transitions and refuse rather than report success without them - so what remains yours is filing the item before dispatch, recording decisions, and keeping notes current; `docs/configuration.md` owns the manual-backend exception.
 Re-evaluate queued work after every teardown and heartbeat, dispatching items only when dependencies and time gates have cleared.
 
 `.tasks.toml`, `docs/configuration.md`, and current `tasks-axi --help` own the backlog schema, compatibility, retention, and routine command syntax.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ state/               runtime records and signals; gitignored
   <id>.muse-session  muse busy-source binding (sessions root plus task worktree) written by fm-spawn; removed by teardown
   <id>.cursor-session  cursor busy-source binding (projects root, task worktree, prior conversations) written by fm-spawn; removed by teardown
   <id>.reconcile-nudged  epoch second of the last inventory-reconcile nudge sent to this secondmate; bin/fm-secondmate-reconcile.sh owns its per-home cooldown window
+  <id>.backlog-close  the exact backlog close a teardown recorded before removing the task's record, so an interrupted cleanup can still be finished at the next session start; bin/fm-backlog-transition-lib.sh owns its format and replay, and a landed close removes it
   <id>.inbox/          durable steering inbox: sequenced firstmate instruction records the worker acknowledges by moving them into its handled/ subdirectory; written by fm-send, with ordinary records re-rung and escalated by the watcher while explicit fire-and-forget records are excluded from that ladder, and removed by teardown (bin/fm-task-inbox-lib.sh)
   <id>.meta          task metadata; each producer script's header owns its exact fields and mutation contract, with docs/configuration.md routing operator-facing backend and trace-context details
   <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Presentation spaces"
@@ -168,7 +169,7 @@ When that section reports its checks still in progress it names exactly what is 
 1. **Lock** - acquires the per-home session lock first, before anything mutates shared state, then starts the deferred network stage above.
 2. **Bootstrap** - detect-only checks (tool/version problems, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
    When the lock could not be acquired, the worktree-tangle check uses read-only advisory wording without a checkout repair command.
-   Home-local stale Herdr projection cleanup and the six bootstrap MUTATING sweeps - non-executing legacy PR-check migration, fleet sync, secondmate convergence, secondmate liveness, pending remote handoff retry, and Relay artifact writes - run only when this session actually holds the lock from step 1; the four network ones among them run in the deferred stage rather than in this section.
+   Home-local stale Herdr projection cleanup and the seven bootstrap MUTATING sweeps - non-executing legacy PR-check migration, same-home backlog reconciliation, fleet sync, secondmate convergence, secondmate liveness, pending remote handoff retry, and Relay artifact writes - run only when this session actually holds the lock from step 1; the four network ones among them run in the deferred stage rather than in this section.
    The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous, unreadable, or unreachable remote targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`; `docs/remote-secondmates.md`).
 3. **Wake queue** - when locked, presents the durable wake queue and prints the raw records prominently as this turn's first work queue; a clearly labeled status-event annotation may follow a valid `signal` record and includes every status line still unread at the presentation cursor, but never replaces the raw record or current-state reconciliation, and a lapsed watcher chain still surfaces here via the same guard alarm.
    Presented records remain durable until the handling turn runs the generation-bound acknowledgement printed by the drain.
@@ -306,7 +307,8 @@ Write the task-specific brief under section 11 before spawning.
 
 Spawn only through `bin/fm-spawn.sh` after the profile and backend checks in section 4.
 The spawn must resolve a genuine isolated task worktree distinct from the primary checkout; a failed isolation assertion stops the task.
-After spawning, confirm the worker is processing the brief, handle any trust dialog through `harness-adapters`, and record ship or scout work as under way.
+The spawn itself moves the work item to In flight and refuses rather than dispatching work this home has no item for, so recording the dispatch is never a separate step to remember.
+After spawning, confirm the worker is processing the brief and handle any trust dialog through `harness-adapters`.
 A persistent secondmate is recorded in the secondmate registry and runtime state, never as a backlog work item.
 
 Steer a worker with ordinary text through fail-closed `fm-send`: the message becomes a durable record in the task's steering inbox (multi-line text is legal, local and remote alike) and the worker's terminal receives only a constant doorbell line, with the watcher re-ringing an unacknowledged local message and escalating a stuck one (`bin/fm-task-inbox-lib.sh`; `bin/fm-send.sh` owns the typed-plane carve-outs).
@@ -497,7 +499,7 @@ Work routed to a secondmate is recorded in that secondmate home's own backlog, n
 A decision is simply a task held for the captain: `tasks-axi hold <id> --reason "<reason>" --kind captain`, with `--until <date>` when the captain defers it.
 When a main-side thread such as a pending captain decision or relay reminder is worth durable tracking, file it as its own work item and hold it the same way.
 Captain calls discovered by investigations or visual reviews follow `captain-hold-lifecycle`, which owns their completion gate and recorded-answer rules.
-Update the backlog on every dispatch, completion, and decision for a work item.
+Dispatch and completion move the item themselves - `bin/fm-spawn.sh` and `bin/fm-teardown.sh` own those transitions and refuse rather than report success without them - so what remains yours is filing the item before dispatch, recording decisions, and keeping notes current.
 Re-evaluate queued work after every teardown and heartbeat, dispatching items only when dependencies and time gates have cleared.
 
 `.tasks.toml`, `docs/configuration.md`, and current `tasks-axi --help` own the backlog schema, compatibility, retention, and routine command syntax.
@@ -535,7 +537,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `PR_CHECK_MIGRATION:`, `HOME_SUMMARY:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `PR_CHECK_MIGRATION:`, `HOME_SUMMARY:`, `BACKLOG_RECONCILE:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi default TOON.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,7 +499,7 @@ Work routed to a secondmate is recorded in that secondmate home's own backlog, n
 A decision is simply a task held for the captain: `tasks-axi hold <id> --reason "<reason>" --kind captain`, with `--until <date>` when the captain defers it.
 When a main-side thread such as a pending captain decision or relay reminder is worth durable tracking, file it as its own work item and hold it the same way.
 Captain calls discovered by investigations or visual reviews follow `captain-hold-lifecycle`, which owns their completion gate and recorded-answer rules.
-Under the automatic tasks-axi backend, dispatch and completion move the item themselves - `bin/fm-spawn.sh` and `bin/fm-teardown.sh` own those transitions and refuse rather than report success without them - so what remains yours is filing the item before dispatch, recording decisions, and keeping notes current; `docs/configuration.md` owns the manual-backend exception.
+When the automatic transition gate applies, dispatch and completion move the item themselves - `bin/fm-spawn.sh` and `bin/fm-teardown.sh` own those transitions and refuse rather than report success without them - so what remains yours is filing the item before dispatch, recording decisions, and keeping notes current; `docs/configuration.md` owns gate applicability and the manual-backend exception.
 Re-evaluate queued work after every teardown and heartbeat, dispatching items only when dependencies and time gates have cleared.
 
 `.tasks.toml`, `docs/configuration.md`, and current `tasks-axi --help` own the backlog schema, compatibility, retention, and routine command syntax.

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -44,6 +44,9 @@
 FM_BACKLOG_TRANSITION_SKIP=
 # Set by the mutating helpers when they return non-zero.
 FM_BACKLOG_TRANSITION_ERROR=
+FM_BACKLOG_ROW_RESULT=
+FM_BACKLOG_ROW_STATE=
+FM_BACKLOG_ROW_ERROR=
 # Set by fm_backlog_close_marker_replay: closed | stale | noop.
 # shellcheck disable=SC2034 # Output global, read by the sourcing caller.
 FM_BACKLOG_CLOSE_REPLAY_RESULT=
@@ -83,15 +86,37 @@ fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
   return 0
 }
 
+fm_backlog_row_probe() {  # <data-dir> <id>
+  local data=$1 id=$2 out state held
+  FM_BACKLOG_ROW_RESULT=error
+  FM_BACKLOG_ROW_STATE=
+  FM_BACKLOG_ROW_ERROR=
+  if ! out=$(tasks-axi show "$id" --file "$(fm_backlog_file "$data")" 2>&1); then
+    if printf '%s\n' "$out" | grep -q '^code: NOT_FOUND$'; then
+      FM_BACKLOG_ROW_RESULT=not_found
+    else
+      FM_BACKLOG_ROW_ERROR=$(printf '%s\n' "$out" | sed -n '1p')
+      [ -n "$FM_BACKLOG_ROW_ERROR" ] \
+        || FM_BACKLOG_ROW_ERROR="tasks-axi show $id failed with no output"
+    fi
+    return 1
+  fi
+  state=$(printf '%s\n' "$out" | sed -n 's/^  state: *//p' | head -1)
+  held=$(printf '%s\n' "$out" | sed -n 's/^  held: *//p' | head -1)
+  if [ -z "$state" ]; then
+    FM_BACKLOG_ROW_ERROR="tasks-axi show $id returned no state"
+    return 1
+  fi
+  FM_BACKLOG_ROW_RESULT=found
+  FM_BACKLOG_ROW_STATE="$state ${held:-no}"
+  return 0
+}
+
 # Echo "<state> <held>" for one row, e.g. "queued no" / "in_flight yes".
 # Returns 1 when the row does not exist or cannot be read.
 fm_backlog_row_state() {  # <data-dir> <id>
-  local data=$1 id=$2 out state held
-  out=$(tasks-axi show "$id" --file "$(fm_backlog_file "$data")" 2>/dev/null) || return 1
-  state=$(printf '%s\n' "$out" | sed -n 's/^  state: *//p' | head -1)
-  held=$(printf '%s\n' "$out" | sed -n 's/^  held: *//p' | head -1)
-  [ -n "$state" ] || return 1
-  printf '%s %s\n' "$state" "${held:-no}"
+  fm_backlog_row_probe "$1" "$2" || return 1
+  printf '%s\n' "$FM_BACKLOG_ROW_STATE"
 }
 
 # Run one tasks-axi mutation against <home>'s backlog, capturing its first
@@ -176,7 +201,15 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path>
     FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
     return 0
   fi
-  row_state=$(fm_backlog_row_state "$data" "$id" || true)
+  if fm_backlog_row_probe "$data" "$id"; then
+    row_state=$FM_BACKLOG_ROW_STATE
+  else
+    if [ "$FM_BACKLOG_ROW_RESULT" != not_found ]; then
+      FM_BACKLOG_TRANSITION_ERROR=$FM_BACKLOG_ROW_ERROR
+      return 1
+    fi
+    row_state=
+  fi
   case "$row_state" in
     done\ *|'')
       # Already closed, or the row is gone entirely: nothing is owed.

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -1,0 +1,194 @@
+# shellcheck shell=bash
+# Fused backlog transitions for the scripts that own a task's physical record.
+# Usage: . bin/fm-tasks-axi-lib.sh; . bin/fm-backlog-transition-lib.sh
+# (this library reads that one's backend gate and never sources it itself, so a
+# caller that already sourced it keeps its memoised compatibility verdict).
+#
+# INVARIANT. `state/<id>.meta` exists <=> this home's backlog row for <id> is In
+# flight. The script performing the mechanical record change owns the paired
+# backlog transition and runs it in the same process, under the per-task meta
+# lock it already holds, before it reports success. Nothing else - not a later
+# agent turn, not a printed reminder - is load-bearing for the pairing.
+#   bin/fm-spawn.sh      meta published  => `tasks-axi start`
+#   bin/fm-teardown.sh   `tasks-axi done` => meta removed
+#   bin/fm-bootstrap.sh  replays whatever a crash left behind, THIS HOME ONLY.
+# bin/fm-fleet-snapshot.sh's classifier and bin/fm-secondmate-reconcile.sh's
+# cross-home nudge stay defense in depth, not the primary mechanism.
+#
+# SCOPE. fm_backlog_transition_applies is the single gate. It excludes
+# secondmates (persistent agents are never backlog items, AGENTS.md section 10),
+# homes whose configured backlog backend is manual or whose tasks-axi is not
+# compatible (bin/fm-tasks-axi-lib.sh), and homes that keep no backlog file at
+# all. A skipped transition is never an error; the caller reports the manual
+# follow-up instead.
+#
+# ADDRESSING. Every call passes `--file <data>/backlog.md` so the mutation lands
+# in the home that owns the task regardless of the caller's working directory,
+# and runs from that data directory's parent so the same home's `.tasks.toml`
+# supplies done_keep and the archive path. The parent of the data directory is
+# the addressing root rather than FM_HOME, so a home whose data directory is
+# relocated keeps its backlog and its archive together. A root with no
+# `.tasks.toml` gets tasks-axi's built-in defaults.
+#
+# CRASH RECOVERY. Only teardown needs a durable record: it removes the meta and
+# with it the completion links, so a process killed between the two halves would
+# leave nothing to reconstruct the close from. It writes
+# `state/<id>.backlog-close` first, and removes it once the close lands.
+# fm_backlog_close_marker_replay re-runs exactly that close; `tasks-axi done` on
+# an already-closed task backfills links without moving the close date, so replay
+# is idempotent. Spawn needs no marker: it publishes the meta first, so a crash
+# leaves the meta itself as the evidence that the row is owed a start.
+
+# Set by fm_backlog_transition_applies when it returns non-zero.
+# shellcheck disable=SC2034 # Output global, read by the sourcing caller.
+FM_BACKLOG_TRANSITION_SKIP=
+# Set by the mutating helpers when they return non-zero.
+FM_BACKLOG_TRANSITION_ERROR=
+# Set by fm_backlog_close_marker_replay: closed | stale | noop.
+# shellcheck disable=SC2034 # Output global, read by the sourcing caller.
+FM_BACKLOG_CLOSE_REPLAY_RESULT=
+
+fm_backlog_file() {  # <data-dir>
+  printf '%s/backlog.md\n' "$1"
+}
+
+# The directory a backlog's own `.tasks.toml` is resolved from.
+fm_backlog_root() {  # <data-dir>
+  local data=$1 parent
+  parent=${data%/*}
+  [ "$parent" != "$data" ] && [ -n "$parent" ] || parent=.
+  printf '%s\n' "$parent"
+}
+
+fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
+  local config=$1 data=$2 kind=$3 file
+  FM_BACKLOG_TRANSITION_SKIP=
+  if [ "$kind" = secondmate ]; then
+    FM_BACKLOG_TRANSITION_SKIP="secondmates are not backlog items"
+    return 1
+  fi
+  if fm_backlog_backend_manual "$config"; then
+    FM_BACKLOG_TRANSITION_SKIP="config/backlog-backend selects manual editing"
+    return 1
+  fi
+  if ! fm_tasks_axi_compatible; then
+    FM_BACKLOG_TRANSITION_SKIP="no compatible tasks-axi on PATH"
+    return 1
+  fi
+  file=$(fm_backlog_file "$data")
+  if [ ! -f "$file" ]; then
+    FM_BACKLOG_TRANSITION_SKIP="this home keeps no backlog at $file"
+    return 1
+  fi
+  return 0
+}
+
+# Echo "<state> <held>" for one row, e.g. "queued no" / "in_flight yes".
+# Returns 1 when the row does not exist or cannot be read.
+fm_backlog_row_state() {  # <data-dir> <id>
+  local data=$1 id=$2 out state held
+  out=$(tasks-axi show "$id" --file "$(fm_backlog_file "$data")" 2>/dev/null) || return 1
+  state=$(printf '%s\n' "$out" | sed -n 's/^  state: *//p' | head -1)
+  held=$(printf '%s\n' "$out" | sed -n 's/^  held: *//p' | head -1)
+  [ -n "$state" ] || return 1
+  printf '%s %s\n' "$state" "${held:-no}"
+}
+
+# Run one tasks-axi mutation against <home>'s backlog, capturing its first
+# output line in FM_BACKLOG_TRANSITION_ERROR on failure.
+fm_backlog_mutate() {  # <data-dir> <verb> <id> [flag...]
+  local data=$1 verb=$2 id=$3 out
+  shift 3
+  FM_BACKLOG_TRANSITION_ERROR=
+  if out=$(cd "$(fm_backlog_root "$data")" 2>/dev/null && tasks-axi "$verb" "$id" \
+      --file "$(fm_backlog_file "$data")" "$@" 2>&1); then
+    return 0
+  fi
+  FM_BACKLOG_TRANSITION_ERROR=$(printf '%s\n' "$out" | sed -n '1p')
+  [ -n "$FM_BACKLOG_TRANSITION_ERROR" ] \
+    || FM_BACKLOG_TRANSITION_ERROR="tasks-axi $verb $id failed with no output"
+  return 1
+}
+
+fm_backlog_start() {  # <data-dir> <id>
+  fm_backlog_mutate "$1" start "$2"
+}
+
+fm_backlog_done() {  # <data-dir> <id> [flag...]
+  local data=$1 id=$2
+  shift 2
+  fm_backlog_mutate "$data" "done" "$id" "$@"
+}
+
+fm_backlog_close_marker_path() {  # <state-dir> <id>
+  printf '%s/%s.backlog-close\n' "$1" "$2"
+}
+
+# Record the exact close a teardown is about to perform. Refuses an argument
+# carrying a newline rather than writing a record that cannot be read back.
+fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> [flag...]
+  local state=$1 id=$2 data=$3 marker tmp arg
+  shift 3
+  marker=$(fm_backlog_close_marker_path "$state" "$id") || return 1
+  tmp="$state/.$id.backlog-close.${BASHPID:-$$}"
+  {
+    printf 'id=%s\n' "$id"
+    printf 'data=%s\n' "$data"
+    for arg in "$@"; do
+      case "$arg" in
+        *$'\n'*) return 1 ;;
+      esac
+      printf 'arg=%s\n' "$arg"
+    done
+  } > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv -f "$tmp" "$marker" || { rm -f "$tmp"; return 1; }
+  return 0
+}
+
+fm_backlog_close_marker_clear() {  # <state-dir> <id>
+  rm -f "$(fm_backlog_close_marker_path "$1" "$2")" 2>/dev/null || true
+}
+
+# Replay one recorded close. Returns 0 when the row is closed (or the record is
+# no longer actionable), 1 when the close itself failed.
+fm_backlog_close_marker_replay() {  # <state-dir> <marker-path>
+  local state=$1 marker=$2 id='' data='' line row_state
+  local args=()
+  FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
+  [ -f "$marker" ] || return 0
+  while IFS= read -r line; do
+    case "$line" in
+      id=*) id=${line#id=} ;;
+      data=*) data=${line#data=} ;;
+      arg=*) args+=("${line#arg=}") ;;
+    esac
+  done < "$marker"
+  if [ -z "$id" ] || [ -z "$data" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
+    return 1
+  fi
+  # A record still on disk means the teardown never reached its point of no
+  # return, or the id has since been dispatched again. Either way the task is
+  # owned and In flight is the correct row state, so drop the stale intent
+  # rather than closing a row whose worker still exists.
+  if [ -e "$state/$id.meta" ]; then
+    rm -f "$marker" 2>/dev/null || true
+    FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
+    return 0
+  fi
+  row_state=$(fm_backlog_row_state "$data" "$id" || true)
+  case "$row_state" in
+    done\ *|'')
+      # Already closed, or the row is gone entirely: nothing is owed.
+      rm -f "$marker" 2>/dev/null || true
+      FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
+      return 0
+      ;;
+  esac
+  if fm_backlog_done "$data" "$id" "${args[@]+"${args[@]}"}"; then
+    rm -f "$marker" 2>/dev/null || true
+    FM_BACKLOG_CLOSE_REPLAY_RESULT=closed
+    return 0
+  fi
+  return 1
+}

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -4,13 +4,15 @@
 # (this library reads that one's backend gate and never sources it itself, so a
 # caller that already sourced it keeps its memoised compatibility verdict).
 #
-# INVARIANT. `state/<id>.meta` exists <=> this home's backlog row for <id> is In
-# flight. The script performing the mechanical record change owns the paired
-# backlog transition and runs it in the same process, under the per-task meta
-# lock it already holds, before it reports success. Nothing else - not a later
-# agent turn, not a printed reminder - is load-bearing for the pairing.
-#   bin/fm-spawn.sh      meta published  => `tasks-axi start`
-#   bin/fm-teardown.sh   `tasks-axi done` => meta removed
+# INVARIANT. In ordinary successful lifecycle state, `state/<id>.meta` exists
+# <=> this home's backlog row for <id> is In flight; the one teardown crash
+# window is represented by `state/<id>.backlog-close`. The script performing the
+# mechanical record change owns the paired backlog transition and runs it in the
+# same process, under the per-task meta lock it already holds, before it reports
+# success. Nothing else - not a later agent turn, not a printed reminder - is
+# load-bearing for the pairing.
+#   bin/fm-spawn.sh      meta published => `tasks-axi start`
+#   bin/fm-teardown.sh   meta removed => `tasks-axi done`
 #   bin/fm-bootstrap.sh  replays whatever a crash left behind, THIS HOME ONLY.
 # bin/fm-fleet-snapshot.sh's classifier and bin/fm-secondmate-reconcile.sh's
 # cross-home nudge stay defense in depth, not the primary mechanism.

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -63,6 +63,15 @@ fm_backlog_root() {  # <data-dir>
   printf '%s\n' "$parent"
 }
 
+fm_backlog_data_relative() {  # <data-dir>
+  local data=${1%/} root
+  root=$(fm_backlog_root "$data") || return 1
+  case "$data" in
+    "$root"/*) printf '%s\n' "${data#"$root"/}" ;;
+    *) printf '%s\n' "$data" ;;
+  esac
+}
+
 fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
   local config=$1 data=$2 kind=$3 file
   FM_BACKLOG_TRANSITION_SKIP=
@@ -151,14 +160,15 @@ fm_backlog_close_marker_path() {  # <state-dir> <id>
 
 # Record the exact close a teardown is about to perform. Refuses an argument
 # carrying a newline rather than writing a record that cannot be read back.
-fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> [flag...]
-  local state=$1 id=$2 data=$3 marker tmp arg
-  shift 3
+fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> <spawn-gen> [flag...]
+  local state=$1 id=$2 data=$3 spawn_gen=$4 marker tmp arg
+  shift 4
   marker=$(fm_backlog_close_marker_path "$state" "$id") || return 1
   tmp="$state/.$id.backlog-close.${BASHPID:-$$}"
   {
     printf 'id=%s\n' "$id"
     printf 'data=%s\n' "$data"
+    printf 'spawn_gen=%s\n' "$spawn_gen"
     for arg in "$@"; do
       case "$arg" in
         *$'\n'*) return 1 ;;
@@ -177,7 +187,7 @@ fm_backlog_close_marker_clear() {  # <state-dir> <id>
 # Replay one recorded close. Returns 0 when the row is closed (or the record is
 # no longer actionable), 1 when the close itself failed.
 fm_backlog_close_marker_replay() {  # <state-dir> <marker-path>
-  local state=$1 marker=$2 id='' data='' line row_state
+  local state=$1 marker=$2 id='' data='' marker_spawn_gen='' meta_spawn_gen line row_state
   local args=()
   FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
   [ -f "$marker" ] || return 0
@@ -185,6 +195,7 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path>
     case "$line" in
       id=*) id=${line#id=} ;;
       data=*) data=${line#data=} ;;
+      spawn_gen=*) marker_spawn_gen=${line#spawn_gen=} ;;
       arg=*) args+=("${line#arg=}") ;;
     esac
   done < "$marker"
@@ -192,14 +203,14 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path>
     FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
     return 1
   fi
-  # A record still on disk means the teardown never reached its point of no
-  # return, or the id has since been dispatched again. Either way the task is
-  # owned and In flight is the correct row state, so drop the stale intent
-  # rather than closing a row whose worker still exists.
   if [ -e "$state/$id.meta" ]; then
-    rm -f "$marker" 2>/dev/null || true
-    FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
-    return 0
+    meta_spawn_gen=$(sed -n 's/^spawn_gen=//p' "$state/$id.meta" | head -1)
+    if [ -z "$marker_spawn_gen" ] || [ "$meta_spawn_gen" != "$marker_spawn_gen" ]; then
+      rm -f "$marker" 2>/dev/null || true
+      FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
+      return 0
+    fi
+    rm -f "$state/$id.meta"
   fi
   if fm_backlog_row_probe "$data" "$id"; then
     row_state=$FM_BACKLOG_ROW_STATE

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -210,7 +210,10 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path>
       FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
       return 0
     fi
-    rm -f "$state/$id.meta"
+    if ! rm -f "$state/$id.meta" || [ -e "$state/$id.meta" ]; then
+      FM_BACKLOG_TRANSITION_ERROR="could not remove the interrupted task record $state/$id.meta"
+      return 1
+    fi
   fi
   if fm_backlog_row_probe "$data" "$id"; then
     row_state=$FM_BACKLOG_ROW_STATE

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -352,7 +352,7 @@ fm_backlog_close_marker_clear() {  # <state-dir> <id>
 fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data-dir>
   local state=$1 marker=$2 authorized_data data_resolved
   local id='' data='' marker_spawn_gen='' meta_spawn_gen line row_state
-  local arg_value url_tail url_authority url_path
+  local arg_value url_tail url_authority url_path url_host url_port percent_tail percent_valid raw_bytes
   local marker_name expected_id id_count=0 data_count=0 spawn_gen_count=0
   local args=()
   FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
@@ -361,6 +361,16 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
     return 1
   fi
   [ -f "$marker" ] || return 0
+  raw_bytes=$(LC_ALL=C od -An -t u1 "$marker" 2>/dev/null) || {
+    FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
+    return 1
+  }
+  if ! printf '%s\n' "$raw_bytes" | awk '
+    { for (i = 1; i <= NF; i++) if (($i < 32 && $i != 10) || $i == 127) exit 1 }
+  '; then
+    FM_BACKLOG_TRANSITION_ERROR="invalid control byte in pending-close record $marker"
+    return 1
+  fi
   marker_name=${marker##*/}
   case "$marker_name" in
     *.backlog-close) expected_id=${marker_name%.backlog-close} ;;
@@ -425,32 +435,56 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
           ;;
         --pr)
           arg_value=${args[1]}
-          case "$arg_value" in
-            http://*|https://*) ;;
-            *) false ;;
-          esac \
+          [ "${#arg_value}" -le 2048 ] \
+            && case "$arg_value" in
+              https://*) true ;;
+              *) false ;;
+            esac \
             && case "$arg_value" in
               *[[:space:]]*|*[!A-Za-z0-9:/?\&=._#%+~@-]*) false ;;
               *) true ;;
             esac \
             && {
-              url_tail=${arg_value#*://}
+              url_tail=${arg_value#https://}
               url_authority=${url_tail%%/*}
               url_path=${url_tail#*/}
+              url_host=$url_authority
+              url_port=
+              case "$url_authority" in
+                *:*) url_host=${url_authority%%:*}; url_port=${url_authority#*:} ;;
+              esac
               [ "$url_path" != "$url_tail" ] \
-                && case "$url_authority" in
-                  ''|[-.]*|*[-.]|*..*|*[!A-Za-z0-9._:-]*) false ;;
+                && case "$url_host" in
+                  ''|[-.]*|*[-.]|*..*|*[!A-Za-z0-9.-]*) false ;;
                   *[A-Za-z0-9]*) true ;;
                   *) false ;;
                 esac \
-                && case "$url_path" in *[A-Za-z0-9]*) true ;; *) false ;; esac
+                && case "$url_authority" in
+                  *:*) case "$url_port" in ''|*[!0-9]*|??????*) false ;; *) true ;; esac ;;
+                  *) true ;;
+                esac \
+                && case "$url_path" in *[A-Za-z0-9]*) true ;; *) false ;; esac \
+                && {
+                  percent_tail=$url_path
+                  percent_valid=1
+                  while case "$percent_tail" in *%*) true ;; *) false ;; esac; do
+                    percent_tail=${percent_tail#*%}
+                    case "$percent_tail" in
+                      [0-9A-Fa-f][0-9A-Fa-f]*) percent_tail=${percent_tail#??} ;;
+                      *) percent_valid=0; break ;;
+                    esac
+                  done
+                  [ "$percent_valid" = 1 ]
+                }
             }
           ;;
         --report)
-          case "${args[1]}" in
-            ''|-*|/*|../*|*/../*|*/..|*[[:space:]]*|*[![:print:]]*) false ;;
-            *) true ;;
-          esac
+          arg_value=${args[1]}
+          [ "${#arg_value}" -le 4096 ] \
+            && case "$arg_value" in
+              ''|-*|/*|../*|*/../*|*/..|*[!A-Za-z0-9._/-]*) false ;;
+              *) true ;;
+            esac
           ;;
         *) false ;;
       esac || { FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1; }

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -36,9 +36,11 @@
 # with it the completion links, so a process killed between the two halves would
 # leave nothing to reconstruct the close from. It writes
 # `state/<id>.backlog-close` first, and removes it once the close lands.
-# fm_backlog_close_marker_replay validates the complete marker and pins its data
-# path to this home's configured root before any recovery mutation, then re-runs
-# exactly that close. `tasks-axi done` on an already-closed task backfills links
+# The writer and replay share one complete-record validator, and teardown stages
+# that record before destructive cleanup, so it never publishes or acts on a close
+# replay would reject. The validator pins the data path to this home's configured
+# root before any recovery mutation, then re-runs exactly that close.
+# `tasks-axi done` on an already-closed task backfills links
 # without moving the close date, so replay is idempotent. Spawn needs no marker:
 # it publishes the meta first, so a crash
 # leaves the meta itself as the evidence that the row is owed a start.

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -158,6 +158,97 @@ fm_backlog_done() {  # <data-dir> <id> [flag...]
   fm_backlog_mutate "$data" "done" "$id" "$@"
 }
 
+fm_backlog_record_present() {
+  local path=$1
+  if [ ! -f "$path" ] || [ -L "$path" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="task record publication did not land at $path"
+    return 1
+  fi
+  return 0
+}
+
+fm_backlog_record_remove() {
+  local path=$1 label=$2
+  if ! rm -f "$path" 2>/dev/null || [ -e "$path" ] || [ -L "$path" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="$label could not be removed at $path"
+    return 1
+  fi
+  return 0
+}
+
+fm_backlog_record_publish() {
+  local source=$1 target=$2 label=$3
+  if ! mv -f "$source" "$target" 2>/dev/null || ! fm_backlog_record_present "$target"; then
+    [ -n "$FM_BACKLOG_TRANSITION_ERROR" ] \
+      || FM_BACKLOG_TRANSITION_ERROR="$label publication failed at $target"
+    return 1
+  fi
+  return 0
+}
+
+fm_backlog_dispatch_transition() {
+  local meta=$1 data=$2 id=$3 row row_status
+  fm_backlog_record_present "$meta" || return 1
+  fm_backlog_row_probe "$data" "$id"
+  row_status=$?
+  if [ "$row_status" -ne 0 ]; then
+    if [ "$FM_BACKLOG_ROW_RESULT" = not_found ]; then
+      FM_BACKLOG_TRANSITION_ERROR="backlog item $id vanished before dispatch commit"
+    else
+      FM_BACKLOG_TRANSITION_ERROR=$FM_BACKLOG_ROW_ERROR
+    fi
+    return "$row_status"
+  fi
+  row=$FM_BACKLOG_ROW_STATE
+  case "$row" in
+    in_flight\ *) return 0 ;;
+    queued\ no) fm_backlog_start "$data" "$id" ;;
+    *)
+      FM_BACKLOG_TRANSITION_ERROR="backlog item $id is not dispatchable in state $row"
+      return 1
+      ;;
+  esac
+}
+
+fm_backlog_dispatch_rollback() {
+  local meta=$1 busy_script=$2 state=$3 id=$4 gen=$5 failed=0
+  fm_backlog_record_remove "$meta" "provisional task record" || failed=1
+  if [ -n "$gen" ]; then
+    "$busy_script" retire "$state" "$id" --gen "$gen" >/dev/null 2>&1 || failed=1
+    if [ -e "$state/$id.busy-state" ] || [ -L "$state/$id.busy-state" ] \
+       || [ -e "$state/$id.busy-gen" ] || [ -L "$state/$id.busy-gen" ]; then
+      failed=1
+    fi
+  fi
+  if [ "$failed" -ne 0 ]; then
+    FM_BACKLOG_TRANSITION_ERROR="failed-dispatch cleanup did not remove both task and busy records for $id"
+    return 1
+  fi
+  return 0
+}
+
+fm_backlog_close_transition() {
+  local meta=$1 marker=$2 data=$3 id=$4
+  shift 4
+  [ -z "$meta" ] || fm_backlog_record_remove "$meta" "task record" || return 1
+  fm_backlog_done "$data" "$id" "$@" || return 1
+  fm_backlog_record_remove "$marker" "pending-close record"
+}
+
+fm_backlog_atomic_transition() {
+  local operation=$1
+  shift
+  case "$operation" in
+    publish) fm_backlog_record_publish "$@" ;;
+    verify-published) fm_backlog_record_present "$@" ;;
+    remove) fm_backlog_record_remove "$@" ;;
+    dispatch) fm_backlog_dispatch_transition "$@" ;;
+    rollback) fm_backlog_dispatch_rollback "$@" ;;
+    close) fm_backlog_close_transition "$@" ;;
+    *) FM_BACKLOG_TRANSITION_ERROR="unknown backlog atomic transition $operation"; return 2 ;;
+  esac
+}
+
 fm_backlog_close_marker_path() {  # <state-dir> <id>
   printf '%s/%s.backlog-close\n' "$1" "$2"
 }
@@ -180,17 +271,12 @@ fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> <spawn-gen> [fl
       printf 'arg=%s\n' "$arg"
     done
   } > "$tmp" || { rm -f "$tmp"; return 1; }
-  mv -f "$tmp" "$marker" || { rm -f "$tmp"; return 1; }
-  return 0
+  fm_backlog_atomic_transition publish "$tmp" "$marker" "pending-close record" \
+    || { rm -f "$tmp"; return 1; }
 }
 
 fm_backlog_close_marker_remove() {  # <marker-path>
-  local marker=$1
-  if ! rm -f "$marker" 2>/dev/null || [ -e "$marker" ] || [ -L "$marker" ]; then
-    FM_BACKLOG_TRANSITION_ERROR="could not remove pending-close record $marker"
-    return 1
-  fi
-  return 0
+  fm_backlog_atomic_transition remove "$1" "pending-close record"
 }
 
 fm_backlog_close_marker_clear() {  # <state-dir> <id>
@@ -225,10 +311,8 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path>
       FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
       return 0
     fi
-    if ! rm -f "$state/$id.meta" || [ -e "$state/$id.meta" ]; then
-      FM_BACKLOG_TRANSITION_ERROR="could not remove the interrupted task record $state/$id.meta"
-      return 1
-    fi
+    fm_backlog_atomic_transition remove "$state/$id.meta" "the interrupted task record" \
+      || return 1
   fi
   if fm_backlog_row_probe "$data" "$id"; then
     row_state=$FM_BACKLOG_ROW_STATE
@@ -247,8 +331,8 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path>
       return 0
       ;;
   esac
-  if fm_backlog_done "$data" "$id" "${args[@]+"${args[@]}"}"; then
-    fm_backlog_close_marker_remove "$marker" || return 1
+  if fm_backlog_atomic_transition close '' "$marker" "$data" "$id" \
+      "${args[@]+"${args[@]}"}"; then
     FM_BACKLOG_CLOSE_REPLAY_RESULT=closed
     return 0
   fi

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -67,7 +67,11 @@ fm_backlog_file() {  # <data-dir>
     FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $1"
     return 1
   }
-  printf '%s/backlog.md\n' "$data"
+  if [ "$data" = / ]; then
+    printf '/backlog.md\n'
+  else
+    printf '%s/backlog.md\n' "$data"
+  fi
 }
 
 # The directory a backlog's own `.tasks.toml` is resolved from.
@@ -77,9 +81,6 @@ fm_backlog_root() {  # <data-dir>
     FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $1"
     return 1
   }
-  while [ "$data" != / ] && [ "${data%/}" != "$data" ]; do
-    data=${data%/}
-  done
   case "$data" in
     */*)
       parent=${data%/*}
@@ -96,10 +97,11 @@ fm_backlog_data_relative() {  # <data-dir>
     FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $1"
     return 1
   }
-  while [ "$data" != / ] && [ "${data%/}" != "$data" ]; do
-    data=${data%/}
-  done
   root=$(fm_backlog_root "$data") || return 1
+  if [ "$data" = "$root" ]; then
+    printf '.\n'
+    return 0
+  fi
   if [ "$root" = / ]; then
     printf '%s\n' "${data#/}"
     return 0

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -498,8 +498,9 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
         --report)
           arg_value=${args[1]}
           [ "${#arg_value}" -le 4096 ] \
+            && [ -n "${arg_value// /}" ] \
             && case "$arg_value" in
-              ''|-*|/*|../*|*/../*|*/..|*[!A-Za-z0-9._/-]*) false ;;
+              -*|/*|../*|*/../*|*/..) false ;;
               *) true ;;
             esac
           ;;

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -112,12 +112,6 @@ fm_backlog_data_relative() {  # <data-dir>
 
 fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
   local config=$1 data kind=$3 file
-  if ! data=$(fm_backlog_data_absolute "$2"); then
-    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $2"
-    FM_BACKLOG_TRANSITION_SKIP=$FM_BACKLOG_TRANSITION_ERROR
-    printf 'error: %s\n' "$FM_BACKLOG_TRANSITION_ERROR" >&2
-    return 2
-  fi
   FM_BACKLOG_TRANSITION_SKIP=
   if [ "$kind" = secondmate ]; then
     FM_BACKLOG_TRANSITION_SKIP="secondmates are not backlog items"
@@ -130,6 +124,10 @@ fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
   if ! fm_tasks_axi_compatible; then
     FM_BACKLOG_TRANSITION_SKIP="no compatible tasks-axi on PATH"
     return 1
+  fi
+  if ! data=$(fm_backlog_data_absolute "$2"); then
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $2"
+    return 2
   fi
   file=$(fm_backlog_file "$data")
   if [ ! -f "$file" ]; then

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -102,7 +102,8 @@ fm_backlog_row_probe() {  # <data-dir> <id>
   FM_BACKLOG_ROW_RESULT=error
   FM_BACKLOG_ROW_STATE=
   FM_BACKLOG_ROW_ERROR=
-  out=$(tasks-axi show "$id" --file "$(fm_backlog_file "$data")" 2>&1)
+  out=$(cd "$(fm_backlog_root "$data")" 2>/dev/null && tasks-axi show "$id" \
+      --file "$(fm_backlog_file "$data")" 2>&1)
   command_status=$?
   if [ "$command_status" -ne 0 ]; then
     if printf '%s\n' "$out" | grep -q '^code: NOT_FOUND$'; then

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -309,7 +309,7 @@ fm_backlog_close_marker_path() {  # <state-dir> <id>
 # Record the exact close a teardown is about to perform. Refuses an argument
 # carrying a newline rather than writing a record that cannot be read back.
 fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> <spawn-gen> [flag...]
-  local state=$1 id=$2 data spawn_gen=$4 marker tmp arg
+  local state=$1 id=$2 data spawn_gen=$4 marker tmp arg previous_arg=''
   if ! data=$(fm_backlog_data_absolute "$3"); then
     FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $3"
     return 1
@@ -325,7 +325,12 @@ fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> <spawn-gen> [fl
       case "$arg" in
         *$'\n'*) return 1 ;;
       esac
-      printf 'arg=%s\n' "$arg"
+      if [ "$previous_arg" = --note ] && [ "$arg" = "local main" ]; then
+        printf 'arg=local%%20main\n'
+      else
+        printf 'arg=%s\n' "$arg"
+      fi
+      previous_arg=$arg
     done
   } > "$tmp" || { rm -f "$tmp"; return 1; }
   fm_backlog_atomic_transition publish "$tmp" "$marker" "pending-close record" \
@@ -347,6 +352,7 @@ fm_backlog_close_marker_clear() {  # <state-dir> <id>
 fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data-dir>
   local state=$1 marker=$2 authorized_data data_resolved
   local id='' data='' marker_spawn_gen='' meta_spawn_gen line row_state
+  local arg_value url_tail url_authority url_path
   local marker_name expected_id id_count=0 data_count=0 spawn_gen_count=0
   local args=()
   FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
@@ -414,16 +420,35 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
     0) ;;
     2)
       case "${args[0]}" in
-        --note) [ "${args[1]}" = "local main" ] ;;
+        --note)
+          [ "${args[1]}" = "local%20main" ] && args[1]="local main"
+          ;;
         --pr)
-          case "${args[1]}" in
-            http://*|https://*) case "${args[1]}" in *[![:print:]]*) false ;; *) true ;; esac ;;
+          arg_value=${args[1]}
+          case "$arg_value" in
+            http://*|https://*) ;;
             *) false ;;
-          esac
+          esac \
+            && case "$arg_value" in
+              *[[:space:]]*|*[!A-Za-z0-9:/?\&=._#%+~@-]*) false ;;
+              *) true ;;
+            esac \
+            && {
+              url_tail=${arg_value#*://}
+              url_authority=${url_tail%%/*}
+              url_path=${url_tail#*/}
+              [ "$url_path" != "$url_tail" ] \
+                && case "$url_authority" in
+                  ''|[-.]*|*[-.]|*..*|*[!A-Za-z0-9._:-]*) false ;;
+                  *[A-Za-z0-9]*) true ;;
+                  *) false ;;
+                esac \
+                && case "$url_path" in *[A-Za-z0-9]*) true ;; *) false ;; esac
+            }
           ;;
         --report)
           case "${args[1]}" in
-            ''|-*|/*|../*|*/../*|*/..|*[![:print:]]*) false ;;
+            ''|-*|/*|../*|*/../*|*/..|*[[:space:]]*|*[![:print:]]*) false ;;
             *) true ;;
           esac
           ;;

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -380,7 +380,7 @@ fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <exp
     *) FM_BACKLOG_TRANSITION_ERROR="invalid data directory in pending-close record $marker"; return 1 ;;
   esac
   case "$data" in
-    */../*|*/..|*[![:print:]]*)
+    */../*|*/..)
       FM_BACKLOG_TRANSITION_ERROR="invalid data directory in pending-close record $marker"
       return 1
       ;;

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -352,7 +352,8 @@ fm_backlog_close_marker_clear() {  # <state-dir> <id>
 fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data-dir>
   local state=$1 marker=$2 authorized_data data_resolved
   local id='' data='' marker_spawn_gen='' meta_spawn_gen line row_state
-  local arg_value url_tail url_authority url_path url_host url_port percent_tail percent_valid raw_bytes
+  local arg_value url_tail url_authority url_path url_host url_port host_rest host_label host_valid
+  local percent_tail percent_valid raw_bytes
   local marker_name expected_id id_count=0 data_count=0 spawn_gen_count=0
   local args=()
   FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
@@ -459,6 +460,19 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
                   *[A-Za-z0-9]*) true ;;
                   *) false ;;
                 esac \
+                && {
+                  host_rest=$url_host
+                  host_valid=1
+                  while :; do
+                    host_label=${host_rest%%.*}
+                    case "$host_label" in
+                      ''|-*|*-) host_valid=0; break ;;
+                    esac
+                    [ "$host_rest" = "$host_label" ] && break
+                    host_rest=${host_rest#*.}
+                  done
+                  [ "$host_valid" = 1 ]
+                } \
                 && case "$url_authority" in
                   *:*) case "$url_port" in ''|*[!0-9]*|??????*) false ;; *) true ;; esac ;;
                   *) true ;;

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -182,8 +182,19 @@ fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> <spawn-gen> [fl
   return 0
 }
 
+fm_backlog_close_marker_remove() {  # <marker-path>
+  local marker=$1
+  if ! rm -f "$marker" 2>/dev/null || [ -e "$marker" ] || [ -L "$marker" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="could not remove pending-close record $marker"
+    return 1
+  fi
+  return 0
+}
+
 fm_backlog_close_marker_clear() {  # <state-dir> <id>
-  rm -f "$(fm_backlog_close_marker_path "$1" "$2")" 2>/dev/null || true
+  local marker
+  marker=$(fm_backlog_close_marker_path "$1" "$2") || return 1
+  fm_backlog_close_marker_remove "$marker"
 }
 
 # Replay one recorded close. Returns 0 when the row is closed (or the record is
@@ -208,7 +219,7 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path>
   if [ -e "$state/$id.meta" ]; then
     meta_spawn_gen=$(sed -n 's/^spawn_gen=//p' "$state/$id.meta" | head -1)
     if [ -z "$marker_spawn_gen" ] || [ "$meta_spawn_gen" != "$marker_spawn_gen" ]; then
-      rm -f "$marker" 2>/dev/null || true
+      fm_backlog_close_marker_remove "$marker" || return 1
       FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
       return 0
     fi
@@ -229,13 +240,13 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path>
   case "$row_state" in
     done\ *|'')
       # Already closed, or the row is gone entirely: nothing is owed.
-      rm -f "$marker" 2>/dev/null || true
+      fm_backlog_close_marker_remove "$marker" || return 1
       FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
       return 0
       ;;
   esac
   if fm_backlog_done "$data" "$id" "${args[@]+"${args[@]}"}"; then
-    rm -f "$marker" 2>/dev/null || true
+    fm_backlog_close_marker_remove "$marker" || return 1
     FM_BACKLOG_CLOSE_REPLAY_RESULT=closed
     return 0
   fi

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -98,11 +98,13 @@ fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
 }
 
 fm_backlog_row_probe() {  # <data-dir> <id>
-  local data=$1 id=$2 out state held
+  local data=$1 id=$2 out state held command_status
   FM_BACKLOG_ROW_RESULT=error
   FM_BACKLOG_ROW_STATE=
   FM_BACKLOG_ROW_ERROR=
-  if ! out=$(tasks-axi show "$id" --file "$(fm_backlog_file "$data")" 2>&1); then
+  out=$(tasks-axi show "$id" --file "$(fm_backlog_file "$data")" 2>&1)
+  command_status=$?
+  if [ "$command_status" -ne 0 ]; then
     if printf '%s\n' "$out" | grep -q '^code: NOT_FOUND$'; then
       FM_BACKLOG_ROW_RESULT=not_found
     else
@@ -110,7 +112,7 @@ fm_backlog_row_probe() {  # <data-dir> <id>
       [ -n "$FM_BACKLOG_ROW_ERROR" ] \
         || FM_BACKLOG_ROW_ERROR="tasks-axi show $id failed with no output"
     fi
-    return 1
+    return "$command_status"
   fi
   state=$(printf '%s\n' "$out" | sed -n 's/^  state: *//p' | head -1)
   held=$(printf '%s\n' "$out" | sed -n 's/^  held: *//p' | head -1)
@@ -133,17 +135,17 @@ fm_backlog_row_state() {  # <data-dir> <id>
 # Run one tasks-axi mutation against <home>'s backlog, capturing its first
 # output line in FM_BACKLOG_TRANSITION_ERROR on failure.
 fm_backlog_mutate() {  # <data-dir> <verb> <id> [flag...]
-  local data=$1 verb=$2 id=$3 out
+  local data=$1 verb=$2 id=$3 out command_status
   shift 3
   FM_BACKLOG_TRANSITION_ERROR=
-  if out=$(cd "$(fm_backlog_root "$data")" 2>/dev/null && tasks-axi "$verb" "$id" \
-      --file "$(fm_backlog_file "$data")" "$@" 2>&1); then
-    return 0
-  fi
+  out=$(cd "$(fm_backlog_root "$data")" 2>/dev/null && tasks-axi "$verb" "$id" \
+      --file "$(fm_backlog_file "$data")" "$@" 2>&1)
+  command_status=$?
+  [ "$command_status" -ne 0 ] || return 0
   FM_BACKLOG_TRANSITION_ERROR=$(printf '%s\n' "$out" | sed -n '1p')
   [ -n "$FM_BACKLOG_TRANSITION_ERROR" ] \
     || FM_BACKLOG_TRANSITION_ERROR="tasks-axi $verb $id failed with no output"
-  return 1
+  return "$command_status"
 }
 
 fm_backlog_start() {  # <data-dir> <id>

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -457,7 +457,7 @@ fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <exp
           arg_value=${args[1]}
           [ "${#arg_value}" -le 4096 ] \
             && [ -n "${arg_value// /}" ] \
-            && case "$arg_value" in -*|/*|../*|*/../*|*/..) false ;; *) true ;; esac
+            && case "$arg_value" in .|..|-*|/*|../*|*/../*|*/..) false ;; *) true ;; esac
           ;;
         *) false ;;
       esac || { FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1; }

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -36,9 +36,11 @@
 # with it the completion links, so a process killed between the two halves would
 # leave nothing to reconstruct the close from. It writes
 # `state/<id>.backlog-close` first, and removes it once the close lands.
-# fm_backlog_close_marker_replay re-runs exactly that close; `tasks-axi done` on
-# an already-closed task backfills links without moving the close date, so replay
-# is idempotent. Spawn needs no marker: it publishes the meta first, so a crash
+# fm_backlog_close_marker_replay validates the complete marker and pins its data
+# path to this home's configured root before any recovery mutation, then re-runs
+# exactly that close. `tasks-axi done` on an already-closed task backfills links
+# without moving the close date, so replay is idempotent. Spawn needs no marker:
+# it publishes the meta first, so a crash
 # leaves the meta itself as the evidence that the row is owed a start.
 
 # Set by fm_backlog_transition_applies for a return-1 exemption.
@@ -347,8 +349,9 @@ fm_backlog_close_marker_clear() {  # <state-dir> <id>
   fm_backlog_close_marker_remove "$marker"
 }
 
-# Replay one recorded close. Returns 0 when the row is closed (or the record is
-# no longer actionable), 1 when the close itself failed.
+# Replay one recorded close. Returns 0 when the row is closed or the marker is
+# stale, and 1 when marker validation or recovery fails. Validation completes
+# before any meta or backlog mutation.
 fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data-dir>
   local state=$1 marker=$2 authorized_data data_resolved
   local id='' data='' marker_spawn_gen='' meta_spawn_gen line row_state

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -308,63 +308,25 @@ fm_backlog_close_marker_path() {  # <state-dir> <id>
   printf '%s/%s.backlog-close\n' "$1" "$2"
 }
 
-# Record the exact close a teardown is about to perform. Refuses an argument
-# carrying a newline rather than writing a record that cannot be read back.
-fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> <spawn-gen> [flag...]
-  local state=$1 id=$2 data spawn_gen=$4 marker tmp arg previous_arg=''
-  if ! data=$(fm_backlog_data_absolute "$3"); then
-    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $3"
-    return 1
-  fi
-  shift 4
-  marker=$(fm_backlog_close_marker_path "$state" "$id") || return 1
-  tmp="$state/.$id.backlog-close.${BASHPID:-$$}"
-  {
-    printf 'id=%s\n' "$id"
-    printf 'data=%s\n' "$data"
-    printf 'spawn_gen=%s\n' "$spawn_gen"
-    for arg in "$@"; do
-      case "$arg" in
-        *$'\n'*) return 1 ;;
-      esac
-      if [ "$previous_arg" = --note ] && [ "$arg" = "local main" ]; then
-        printf 'arg=local%%20main\n'
-      else
-        printf 'arg=%s\n' "$arg"
-      fi
-      previous_arg=$arg
-    done
-  } > "$tmp" || { rm -f "$tmp"; return 1; }
-  fm_backlog_atomic_transition publish "$tmp" "$marker" "pending-close record" \
-    || { rm -f "$tmp"; return 1; }
-}
-
-fm_backlog_close_marker_remove() {  # <marker-path>
-  fm_backlog_atomic_transition remove "$1" "pending-close record"
-}
-
-fm_backlog_close_marker_clear() {  # <state-dir> <id>
-  local marker
-  marker=$(fm_backlog_close_marker_path "$1" "$2") || return 1
-  fm_backlog_close_marker_remove "$marker"
-}
-
-# Replay one recorded close. Returns 0 when the row is closed or the marker is
-# stale, and 1 when marker validation or recovery fails. Validation completes
-# before any meta or backlog mutation.
-fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data-dir>
-  local state=$1 marker=$2 authorized_data data_resolved
-  local id='' data='' marker_spawn_gen='' meta_spawn_gen line row_state
-  local arg_value url_tail url_authority url_path url_host url_port host_rest host_label host_valid
-  local percent_tail percent_valid raw_bytes
-  local marker_name expected_id id_count=0 data_count=0 spawn_gen_count=0
+fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <expected-id>
+  local marker=$1 authorized_data data_resolved expected_id=$3
+  local id='' data='' marker_spawn_gen='' line raw_bytes arg_value
+  local url_tail url_authority url_path url_host url_port host_rest host_label host_valid
+  local percent_tail percent_valid
+  local id_count=0 data_count=0 spawn_gen_count=0
   local args=()
-  FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
+  FM_BACKLOG_CLOSE_VALIDATED_ID=
+  FM_BACKLOG_CLOSE_VALIDATED_DATA=
+  FM_BACKLOG_CLOSE_VALIDATED_SPAWN_GEN=
+  FM_BACKLOG_CLOSE_VALIDATED_ARGS=()
   if [ -L "$marker" ]; then
     FM_BACKLOG_TRANSITION_ERROR="unsafe pending-close record $marker"
     return 1
   fi
-  [ -f "$marker" ] || return 0
+  [ -f "$marker" ] || {
+    FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
+    return 1
+  }
   raw_bytes=$(LC_ALL=C od -An -t u1 "$marker" 2>/dev/null) || {
     FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
     return 1
@@ -375,11 +337,6 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
     FM_BACKLOG_TRANSITION_ERROR="invalid control byte in pending-close record $marker"
     return 1
   fi
-  marker_name=${marker##*/}
-  case "$marker_name" in
-    *.backlog-close) expected_id=${marker_name%.backlog-close} ;;
-    *) FM_BACKLOG_TRANSITION_ERROR="invalid pending-close record name $marker"; return 1 ;;
-  esac
   while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       id=*) id=${line#id=}; id_count=$((id_count + 1)) ;;
@@ -417,8 +374,8 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
       return 1
       ;;
   esac
-  authorized_data=$(fm_backlog_data_absolute "$3") || {
-    FM_BACKLOG_TRANSITION_ERROR="authorized data directory cannot be resolved: $3"
+  authorized_data=$(fm_backlog_data_absolute "$2") || {
+    FM_BACKLOG_TRANSITION_ERROR="authorized data directory cannot be resolved: $2"
     return 1
   }
   data_resolved=$(fm_backlog_data_absolute "$data") || {
@@ -429,21 +386,15 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
     FM_BACKLOG_TRANSITION_ERROR="foreign data directory in pending-close record $marker"
     return 1
   fi
-  data=$data_resolved
   case "${#args[@]}" in
     0) ;;
     2)
       case "${args[0]}" in
-        --note)
-          [ "${args[1]}" = "local%20main" ] && args[1]="local main"
-          ;;
+        --note) [ "${args[1]}" = "local%20main" ] ;;
         --pr)
           arg_value=${args[1]}
           [ "${#arg_value}" -le 2048 ] \
-            && case "$arg_value" in
-              https://*) true ;;
-              *) false ;;
-            esac \
+            && case "$arg_value" in https://*) true ;; *) false ;; esac \
             && case "$arg_value" in
               *[[:space:]]*|*[!A-Za-z0-9:/?\&=._#%+~@-]*) false ;;
               *) true ;;
@@ -468,9 +419,7 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
                   host_valid=1
                   while :; do
                     host_label=${host_rest%%.*}
-                    case "$host_label" in
-                      ''|-*|*-) host_valid=0; break ;;
-                    esac
+                    case "$host_label" in ''|-*|*-) host_valid=0; break ;; esac
                     [ "$host_rest" = "$host_label" ] && break
                     host_rest=${host_rest#*.}
                   done
@@ -499,19 +448,93 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
           arg_value=${args[1]}
           [ "${#arg_value}" -le 4096 ] \
             && [ -n "${arg_value// /}" ] \
-            && case "$arg_value" in
-              -*|/*|../*|*/../*|*/..) false ;;
-              *) true ;;
-            esac
+            && case "$arg_value" in -*|/*|../*|*/../*|*/..) false ;; *) true ;; esac
           ;;
         *) false ;;
       esac || { FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1; }
       ;;
     *) FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1 ;;
   esac
+  FM_BACKLOG_CLOSE_VALIDATED_ID=$id
+  FM_BACKLOG_CLOSE_VALIDATED_DATA=$data_resolved
+  FM_BACKLOG_CLOSE_VALIDATED_SPAWN_GEN=$marker_spawn_gen
+  FM_BACKLOG_CLOSE_VALIDATED_ARGS=("${args[@]+"${args[@]}"}")
+}
+
+fm_backlog_close_marker_stage() {  # <temporary-path> <id> <data-dir> <spawn-gen> [flag...]
+  local tmp=$1 id=$2 data spawn_gen=$4 arg previous_arg=''
+  local serialized_args=()
+  data=$(fm_backlog_data_absolute "$3") || {
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $3"
+    return 1
+  }
+  shift 4
+  for arg in "$@"; do
+    if [ "$previous_arg" = --note ] && [ "$arg" = "local main" ]; then
+      serialized_args+=("local%20main")
+    else
+      serialized_args+=("$arg")
+    fi
+    previous_arg=$arg
+  done
+  {
+    printf 'id=%s\n' "$id"
+    printf 'data=%s\n' "$data"
+    printf 'spawn_gen=%s\n' "$spawn_gen"
+    for arg in "${serialized_args[@]+"${serialized_args[@]}"}"; do
+      printf 'arg=%s\n' "$arg"
+    done
+  } > "$tmp" || { rm -f "$tmp"; return 1; }
+  fm_backlog_close_marker_validate "$tmp" "$data" "$id" \
+    || { rm -f "$tmp"; return 1; }
+}
+
+# Record the exact close a teardown is about to perform.
+fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> <spawn-gen> [flag...]
+  local state=$1 id=$2 data=$3 spawn_gen=$4 marker tmp
+  shift 4
+  marker=$(fm_backlog_close_marker_path "$state" "$id") || return 1
+  tmp="$state/.$id.backlog-close.${BASHPID:-$$}"
+  fm_backlog_close_marker_stage "$tmp" "$id" "$data" "$spawn_gen" "$@" || return 1
+  fm_backlog_atomic_transition publish "$tmp" "$marker" "pending-close record" \
+    || { rm -f "$tmp"; return 1; }
+}
+
+fm_backlog_close_marker_remove() {  # <marker-path>
+  fm_backlog_atomic_transition remove "$1" "pending-close record"
+}
+
+fm_backlog_close_marker_clear() {  # <state-dir> <id>
+  local marker
+  marker=$(fm_backlog_close_marker_path "$1" "$2") || return 1
+  fm_backlog_close_marker_remove "$marker"
+}
+
+# Replay one recorded close. Returns 0 when the row is closed or the marker is
+# stale, and 1 when marker validation or recovery fails. Validation completes
+# before any meta or backlog mutation.
+fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data-dir>
+  local state=$1 marker=$2 marker_name expected_id
+  local id data marker_spawn_gen meta_spawn_gen row_state
+  local args=()
+  FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
+  [ -e "$marker" ] || [ -L "$marker" ] || return 0
+  marker_name=${marker##*/}
+  case "$marker_name" in
+    *.backlog-close) expected_id=${marker_name%.backlog-close} ;;
+    *) FM_BACKLOG_TRANSITION_ERROR="invalid pending-close record name $marker"; return 1 ;;
+  esac
+  fm_backlog_close_marker_validate "$marker" "$3" "$expected_id" || return 1
+  id=$FM_BACKLOG_CLOSE_VALIDATED_ID
+  data=$FM_BACKLOG_CLOSE_VALIDATED_DATA
+  marker_spawn_gen=$FM_BACKLOG_CLOSE_VALIDATED_SPAWN_GEN
+  args=("${FM_BACKLOG_CLOSE_VALIDATED_ARGS[@]+"${FM_BACKLOG_CLOSE_VALIDATED_ARGS[@]}"}")
+  if [ "${args[0]-}" = --note ]; then
+    args[1]="local main"
+  fi
   if [ -e "$state/$id.meta" ]; then
     meta_spawn_gen=$(sed -n 's/^spawn_gen=//p' "$state/$id.meta" | head -1)
-    if [ -z "$marker_spawn_gen" ] || [ "$meta_spawn_gen" != "$marker_spawn_gen" ]; then
+    if [ "$meta_spawn_gen" != "$marker_spawn_gen" ]; then
       fm_backlog_close_marker_remove "$marker" || return 1
       FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
       return 0
@@ -530,7 +553,6 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
   fi
   case "$row_state" in
     done\ *|'')
-      # Already closed, or the row is gone entirely: nothing is owed.
       fm_backlog_close_marker_remove "$marker" || return 1
       FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
       return 0

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -344,8 +344,9 @@ fm_backlog_close_marker_clear() {  # <state-dir> <id>
 
 # Replay one recorded close. Returns 0 when the row is closed (or the record is
 # no longer actionable), 1 when the close itself failed.
-fm_backlog_close_marker_replay() {  # <state-dir> <marker-path>
-  local state=$1 marker=$2 id='' data='' marker_spawn_gen='' meta_spawn_gen line row_state
+fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data-dir>
+  local state=$1 marker=$2 authorized_data data_resolved
+  local id='' data='' marker_spawn_gen='' meta_spawn_gen line row_state
   local marker_name expected_id id_count=0 data_count=0 spawn_gen_count=0
   local args=()
   FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
@@ -376,15 +377,47 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path>
   esac
   if [ "$id_count" -ne 1 ] || [ "$id" != "$expected_id" ] \
      || [ "$data_count" -ne 1 ] || [ -z "$data" ] \
-     || [ "$spawn_gen_count" -gt 1 ]; then
+     || [ "$spawn_gen_count" -ne 1 ]; then
     FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
     return 1
   fi
+  case "$marker_spawn_gen" in
+    ''|.*|*[!A-Za-z0-9._-]*)
+      FM_BACKLOG_TRANSITION_ERROR="invalid spawn generation in pending-close record $marker"
+      return 1
+      ;;
+  esac
+  case "$data" in
+    /*) ;;
+    *) FM_BACKLOG_TRANSITION_ERROR="invalid data directory in pending-close record $marker"; return 1 ;;
+  esac
+  case "/$data/" in
+    */../*) FM_BACKLOG_TRANSITION_ERROR="invalid data directory in pending-close record $marker"; return 1 ;;
+  esac
+  authorized_data=$(fm_backlog_data_absolute "$3") || {
+    FM_BACKLOG_TRANSITION_ERROR="authorized data directory cannot be resolved: $3"
+    return 1
+  }
+  data_resolved=$(fm_backlog_data_absolute "$data") || {
+    FM_BACKLOG_TRANSITION_ERROR="data directory in pending-close record cannot be resolved: $data"
+    return 1
+  }
+  if [ "$data_resolved" != "$authorized_data" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="foreign data directory in pending-close record $marker"
+    return 1
+  fi
+  data=$data_resolved
   case "${#args[@]}" in
     0) ;;
     2)
-      case "${args[0]}" in --pr|--report|--note) ;; *) FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1 ;; esac
-      [ -n "${args[1]}" ] || { FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1; }
+      case "${args[0]}" in
+        --note) [ "${args[1]}" = "local main" ] ;;
+        --pr) case "${args[1]}" in http://*|https://*) true ;; *) false ;; esac ;;
+        --report)
+          case "/${args[1]}/" in /*/../*|//*|*/-*) false ;; *) [ -n "${args[1]}" ] ;; esac
+          ;;
+        *) false ;;
+      esac || { FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1; }
       ;;
     *) FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1 ;;
   esac

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -21,8 +21,8 @@
 # secondmates (persistent agents are never backlog items, AGENTS.md section 10),
 # homes whose configured backlog backend is manual or whose tasks-axi is not
 # compatible (bin/fm-tasks-axi-lib.sh), and homes that keep no backlog file at
-# all. A skipped transition is never an error; the caller reports the manual
-# follow-up instead.
+# all. Those return-1 exemptions are never errors; an unresolvable configured
+# data directory instead returns 2 so callers refuse before mutation.
 #
 # ADDRESSING. Every call passes `--file <data>/backlog.md` so the mutation lands
 # in the home that owns the task regardless of the caller's working directory,
@@ -41,7 +41,7 @@
 # is idempotent. Spawn needs no marker: it publishes the meta first, so a crash
 # leaves the meta itself as the evidence that the row is owed a start.
 
-# Set by fm_backlog_transition_applies when it returns non-zero.
+# Set by fm_backlog_transition_applies for a return-1 exemption.
 # shellcheck disable=SC2034 # Output global, read by the sourcing caller.
 FM_BACKLOG_TRANSITION_SKIP=
 # Set by the mutating helpers when they return non-zero.

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -60,8 +60,16 @@ fm_backlog_file() {  # <data-dir>
 # The directory a backlog's own `.tasks.toml` is resolved from.
 fm_backlog_root() {  # <data-dir>
   local data=$1 parent
-  parent=${data%/*}
-  [ "$parent" != "$data" ] && [ -n "$parent" ] || parent=.
+  while [ "$data" != / ] && [ "${data%/}" != "$data" ]; do
+    data=${data%/}
+  done
+  case "$data" in
+    */*)
+      parent=${data%/*}
+      [ -n "$parent" ] || parent=/
+      ;;
+    *) parent=. ;;
+  esac
   printf '%s\n' "$parent"
 }
 

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -74,8 +74,15 @@ fm_backlog_root() {  # <data-dir>
 }
 
 fm_backlog_data_relative() {  # <data-dir>
-  local data=${1%/} root
+  local data=$1 root
+  while [ "$data" != / ] && [ "${data%/}" != "$data" ]; do
+    data=${data%/}
+  done
   root=$(fm_backlog_root "$data") || return 1
+  if [ "$root" = / ]; then
+    printf '%s\n' "${data#/}"
+    return 0
+  fi
   case "$data" in
     "$root"/*) printf '%s\n' "${data#"$root"/}" ;;
     *) printf '%s\n' "$data" ;;

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -360,7 +360,7 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
     *.backlog-close) expected_id=${marker_name%.backlog-close} ;;
     *) FM_BACKLOG_TRANSITION_ERROR="invalid pending-close record name $marker"; return 1 ;;
   esac
-  while IFS= read -r line; do
+  while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       id=*) id=${line#id=}; id_count=$((id_count + 1)) ;;
       data=*) data=${line#data=}; data_count=$((data_count + 1)) ;;
@@ -391,8 +391,11 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
     /*) ;;
     *) FM_BACKLOG_TRANSITION_ERROR="invalid data directory in pending-close record $marker"; return 1 ;;
   esac
-  case "/$data/" in
-    */../*) FM_BACKLOG_TRANSITION_ERROR="invalid data directory in pending-close record $marker"; return 1 ;;
+  case "$data" in
+    */../*|*/..|*[![:print:]]*)
+      FM_BACKLOG_TRANSITION_ERROR="invalid data directory in pending-close record $marker"
+      return 1
+      ;;
   esac
   authorized_data=$(fm_backlog_data_absolute "$3") || {
     FM_BACKLOG_TRANSITION_ERROR="authorized data directory cannot be resolved: $3"
@@ -412,9 +415,17 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
     2)
       case "${args[0]}" in
         --note) [ "${args[1]}" = "local main" ] ;;
-        --pr) case "${args[1]}" in http://*|https://*) true ;; *) false ;; esac ;;
+        --pr)
+          case "${args[1]}" in
+            http://*|https://*) case "${args[1]}" in *[![:print:]]*) false ;; *) true ;; esac ;;
+            *) false ;;
+          esac
+          ;;
         --report)
-          case "/${args[1]}/" in /*/../*|//*|*/-*) false ;; *) [ -n "${args[1]}" ] ;; esac
+          case "${args[1]}" in
+            ''|-*|/*|../*|*/../*|*/..|*[![:print:]]*) false ;;
+            *) true ;;
+          esac
           ;;
         *) false ;;
       esac || { FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1; }

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -346,21 +346,48 @@ fm_backlog_close_marker_clear() {  # <state-dir> <id>
 # no longer actionable), 1 when the close itself failed.
 fm_backlog_close_marker_replay() {  # <state-dir> <marker-path>
   local state=$1 marker=$2 id='' data='' marker_spawn_gen='' meta_spawn_gen line row_state
+  local marker_name expected_id id_count=0 data_count=0 spawn_gen_count=0
   local args=()
   FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
+  if [ -L "$marker" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="unsafe pending-close record $marker"
+    return 1
+  fi
   [ -f "$marker" ] || return 0
+  marker_name=${marker##*/}
+  case "$marker_name" in
+    *.backlog-close) expected_id=${marker_name%.backlog-close} ;;
+    *) FM_BACKLOG_TRANSITION_ERROR="invalid pending-close record name $marker"; return 1 ;;
+  esac
   while IFS= read -r line; do
     case "$line" in
-      id=*) id=${line#id=} ;;
-      data=*) data=${line#data=} ;;
-      spawn_gen=*) marker_spawn_gen=${line#spawn_gen=} ;;
+      id=*) id=${line#id=}; id_count=$((id_count + 1)) ;;
+      data=*) data=${line#data=}; data_count=$((data_count + 1)) ;;
+      spawn_gen=*) marker_spawn_gen=${line#spawn_gen=}; spawn_gen_count=$((spawn_gen_count + 1)) ;;
       arg=*) args+=("${line#arg=}") ;;
+      *) FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"; return 1 ;;
     esac
   done < "$marker"
-  if [ -z "$id" ] || [ -z "$data" ]; then
+  case "$id" in
+    ''|.*|*[!A-Za-z0-9._-]*)
+      FM_BACKLOG_TRANSITION_ERROR="invalid task identity in pending-close record $marker"
+      return 1
+      ;;
+  esac
+  if [ "$id_count" -ne 1 ] || [ "$id" != "$expected_id" ] \
+     || [ "$data_count" -ne 1 ] || [ -z "$data" ] \
+     || [ "$spawn_gen_count" -gt 1 ]; then
     FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
     return 1
   fi
+  case "${#args[@]}" in
+    0) ;;
+    2)
+      case "${args[0]}" in --pr|--report|--note) ;; *) FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1 ;; esac
+      [ -n "${args[1]}" ] || { FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1; }
+      ;;
+    *) FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1 ;;
+  esac
   if [ -e "$state/$id.meta" ]; then
     meta_spawn_gen=$(sed -n 's/^spawn_gen=//p' "$state/$id.meta" | head -1)
     if [ -z "$marker_spawn_gen" ] || [ "$meta_spawn_gen" != "$marker_spawn_gen" ]; then

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -55,8 +55,19 @@ FM_BACKLOG_ROW_ERROR=
 # shellcheck disable=SC2034 # Output global, read by the sourcing caller.
 FM_BACKLOG_CLOSE_REPLAY_RESULT=
 
+fm_backlog_control_bytes_valid() {  # <allow-newline: 0|1> <od-bytes>
+  printf '%s\n' "$2" | awk -v allow_newline="$1" '
+    { for (i = 1; i <= NF; i++) if (($i < 32 && !(allow_newline && $i == 10)) || $i == 127) exit 1 }
+  '
+}
+
 fm_backlog_data_absolute() {
-  local data=$1
+  local data=$1 raw_bytes
+  raw_bytes=$(printf '%s' "$data" | LC_ALL=C od -An -t u1) || return 1
+  if ! fm_backlog_control_bytes_valid 0 "$raw_bytes"; then
+    printf 'error: data directory contains an invalid control byte\n' >&2
+    return 2
+  fi
   if ! data=$(CDPATH='' cd -- "$data" 2>/dev/null && pwd -P); then
     return 1
   fi
@@ -331,9 +342,7 @@ fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <exp
     FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
     return 1
   }
-  if ! printf '%s\n' "$raw_bytes" | awk '
-    { for (i = 1; i <= NF; i++) if (($i < 32 && $i != 10) || $i == 127) exit 1 }
-  '; then
+  if ! fm_backlog_control_bytes_valid 1 "$raw_bytes"; then
     FM_BACKLOG_TRANSITION_ERROR="invalid control byte in pending-close record $marker"
     return 1
   fi

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -53,13 +53,30 @@ FM_BACKLOG_ROW_ERROR=
 # shellcheck disable=SC2034 # Output global, read by the sourcing caller.
 FM_BACKLOG_CLOSE_REPLAY_RESULT=
 
+fm_backlog_data_absolute() {
+  local data=$1
+  if ! data=$(CDPATH='' cd -- "$data" 2>/dev/null && pwd -P); then
+    return 1
+  fi
+  printf '%s\n' "$data"
+}
+
 fm_backlog_file() {  # <data-dir>
-  printf '%s/backlog.md\n' "$1"
+  local data
+  data=$(fm_backlog_data_absolute "$1") || {
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $1"
+    return 1
+  }
+  printf '%s/backlog.md\n' "$data"
 }
 
 # The directory a backlog's own `.tasks.toml` is resolved from.
 fm_backlog_root() {  # <data-dir>
-  local data=$1 parent
+  local data parent
+  data=$(fm_backlog_data_absolute "$1") || {
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $1"
+    return 1
+  }
   while [ "$data" != / ] && [ "${data%/}" != "$data" ]; do
     data=${data%/}
   done
@@ -74,7 +91,11 @@ fm_backlog_root() {  # <data-dir>
 }
 
 fm_backlog_data_relative() {  # <data-dir>
-  local data=$1 root
+  local data root
+  data=$(fm_backlog_data_absolute "$1") || {
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $1"
+    return 1
+  }
   while [ "$data" != / ] && [ "${data%/}" != "$data" ]; do
     data=${data%/}
   done
@@ -90,7 +111,13 @@ fm_backlog_data_relative() {  # <data-dir>
 }
 
 fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
-  local config=$1 data=$2 kind=$3 file
+  local config=$1 data kind=$3 file
+  if ! data=$(fm_backlog_data_absolute "$2"); then
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $2"
+    FM_BACKLOG_TRANSITION_SKIP=$FM_BACKLOG_TRANSITION_ERROR
+    printf 'error: %s\n' "$FM_BACKLOG_TRANSITION_ERROR" >&2
+    return 2
+  fi
   FM_BACKLOG_TRANSITION_SKIP=
   if [ "$kind" = secondmate ]; then
     FM_BACKLOG_TRANSITION_SKIP="secondmates are not backlog items"
@@ -113,7 +140,13 @@ fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
 }
 
 fm_backlog_row_probe() {  # <data-dir> <id>
-  local data=$1 id=$2 out state held command_status
+  local data id=$2 out state held command_status
+  if ! data=$(fm_backlog_data_absolute "$1"); then
+    FM_BACKLOG_ROW_RESULT=error
+    FM_BACKLOG_ROW_STATE=
+    FM_BACKLOG_ROW_ERROR="data directory cannot be resolved: $1"
+    return 1
+  fi
   FM_BACKLOG_ROW_RESULT=error
   FM_BACKLOG_ROW_STATE=
   FM_BACKLOG_ROW_ERROR=
@@ -151,7 +184,11 @@ fm_backlog_row_state() {  # <data-dir> <id>
 # Run one tasks-axi mutation against <home>'s backlog, capturing its first
 # output line in FM_BACKLOG_TRANSITION_ERROR on failure.
 fm_backlog_mutate() {  # <data-dir> <verb> <id> [flag...]
-  local data=$1 verb=$2 id=$3 out command_status
+  local data verb=$2 id=$3 out command_status
+  if ! data=$(fm_backlog_data_absolute "$1"); then
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $1"
+    return 1
+  fi
   shift 3
   FM_BACKLOG_TRANSITION_ERROR=
   out=$(cd "$(fm_backlog_root "$data")" 2>/dev/null && tasks-axi "$verb" "$id" \
@@ -272,7 +309,11 @@ fm_backlog_close_marker_path() {  # <state-dir> <id>
 # Record the exact close a teardown is about to perform. Refuses an argument
 # carrying a newline rather than writing a record that cannot be read back.
 fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> <spawn-gen> [flag...]
-  local state=$1 id=$2 data=$3 spawn_gen=$4 marker tmp arg
+  local state=$1 id=$2 data spawn_gen=$4 marker tmp arg
+  if ! data=$(fm_backlog_data_absolute "$3"); then
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $3"
+    return 1
+  fi
   shift 4
   marker=$(fm_backlog_close_marker_path "$state" "$id") || return 1
   tmp="$state/.$id.backlog-close.${BASHPID:-$$}"

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1308,7 +1308,14 @@ if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ] && local_phase; then
   fi
   "$SCRIPT_DIR/fm-pr-check-migrate.sh" || true
   startup_memory_budget_setup
-  backlog_record_reconcile
+  if backlog_record_reconcile; then
+    :
+  else
+    BOOTSTRAP_BACKLOG_RECONCILE_STATUS=$?
+    if [ "$BOOTSTRAP_BACKLOG_RECONCILE_STATUS" -eq 2 ]; then
+      exit 1
+    fi
+  fi
 fi
 
 # Local detection: presence, version floors, and configuration. Nothing here

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -14,6 +14,7 @@
 #                 "PR_CHECK_MIGRATION: <private remediation>",
 #                 "HOME_SUMMARY: <ledger never published|not republished since
 #                 <stamp>>; <n> failed attempt(s) ... last: <recorded failure>",
+#                 "BACKLOG_RECONCILE: <id>: <what this home could not reconcile>",
 #                 "TANGLE: <remediation>",
 #                 "SECONDMATE_SYNC: secondmate <id>: skipped: <reason>",
 #                 "NUDGE_SECONDMATES: secondmate <id>: send failed: <reason>",
@@ -81,9 +82,21 @@
 #          refresh relays any completed fm-fleet-sync.sh output before the
 #          aggregate timeout skip line with timeout and elapsed seconds.
 #          Set FM_FLEET_PRUNE=0 to skip branch pruning during that refresh.
-#          Set FM_BOOTSTRAP_DETECT_ONLY=1 to skip the six MUTATING sweeps
-#          (PR-check migration, secondmate_sync, secondmate_liveness_sweep,
-#          secondmate_handoff_resume, x_mode_setup, fleet_sync) while still
+#          BACKLOG_RECONCILE lines report what backlog_record_reconcile could not
+#          settle in THIS home. Every ordinary dispatch and completion now moves
+#          the backlog row inside the script that moves the task's record
+#          (bin/fm-backlog-transition-lib.sh), so this sweep exists for the
+#          crash window inside those scripts and for drift a home was already
+#          carrying: it finishes a close an interrupted cleanup recorded, and
+#          marks In flight any item this home already owns a worker for. It
+#          never touches a captain-held or closed item, and never reads or
+#          writes another home; the fleet snapshot's classifier and
+#          bin/fm-secondmate-reconcile.sh's nudge stay as backstops. Successful
+#          reconciliations print BOOTSTRAP_INFO facts.
+#          Set FM_BOOTSTRAP_DETECT_ONLY=1 to skip the seven MUTATING sweeps
+#          (PR-check migration, backlog_record_reconcile, secondmate_sync,
+#          secondmate_liveness_sweep, secondmate_handoff_resume, x_mode_setup,
+#          fleet_sync) while still
 #          printing every read-only detect line
 #          above; the TANGLE line switches to advisory-only wording with no
 #          checkout command. Used by
@@ -91,7 +104,7 @@
 #          the fleet lock, so a second concurrent session never race-mutates
 #          PR-check artifacts, secondmate homes, pending handoff outboxes,
 #          X-mode artifacts, project clones, or repair instructions.
-#          Unset/0 (the default) runs all six sweeps - this flag is purely
+#          Unset/0 (the default) runs all seven sweeps - this flag is purely
 #          additive.
 #          Set FM_BOOTSTRAP_NETWORK to split this run by whether a step talks to
 #          the network, so a session start can print its digest from local reads
@@ -104,7 +117,8 @@
 #                 secondmate_handoff_resume, and fleet_sync.
 #            only - ONLY those network steps and nothing else. No tool detection,
 #                 no version floors, no tangle check, no PR-check migration, no
-#                 x_mode_setup: those already ran on the local pass.
+#                 backlog reconciliation, no x_mode_setup: those already ran on
+#                 the local pass.
 #          FM_BOOTSTRAP_DETECT_ONLY composes with it unchanged, so `only` plus
 #          detect-only is the read-only `gh auth status` probe on its own.
 #          bin/fm-startup-network.sh owns the deferral: it runs the `only` phase
@@ -140,6 +154,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 # shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-backlog-transition-lib.sh disable=SC1091
+. "$SCRIPT_DIR/fm-backlog-transition-lib.sh"
 # shellcheck source=bin/fm-quota-axi-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-quota-axi-lib.sh"
 # shellcheck source=bin/fm-tangle-lib.sh disable=SC1091
@@ -1167,6 +1183,65 @@ crew_dispatch_validate() {
   fi
 }
 
+# Same-home record reconciliation. Every ordinary dispatch and completion now
+# moves the backlog row inside the script that moves the task's record
+# (bin/fm-backlog-transition-lib.sh), so the only ways the two can still
+# disagree are a process killed mid-transition and drift a home was already
+# carrying before that pairing existed. Heal this home's OWN books on its own
+# restart rather than waiting for a parent's cross-home nudge; the fleet
+# snapshot's classifier and bin/fm-secondmate-reconcile.sh's nudge stay as
+# backstops for what this cannot see. Never reads or writes another home.
+backlog_record_reconcile() {
+  local marker meta id row in_flight_ids label has_record=0
+  # `ship` stands for "any backlog-tracked kind" in this gate: the per-record
+  # loop below still skips secondmates individually.
+  fm_backlog_transition_applies "$CONFIG" "$DATA" ship || return 0
+
+  # Finish any close an interrupted cleanup recorded but never landed.
+  for marker in "$STATE"/*.backlog-close; do
+    [ -e "$marker" ] || continue
+    label=$(basename "$marker" .backlog-close)
+    if fm_backlog_close_marker_replay "$STATE" "$marker"; then
+      [ "$FM_BACKLOG_CLOSE_REPLAY_RESULT" = closed ] || continue
+      echo "BOOTSTRAP_INFO: closed the backlog item for $label that an interrupted cleanup left open"
+    else
+      echo "BACKLOG_RECONCILE: $label: recorded backlog close could not be replayed: $FM_BACKLOG_TRANSITION_ERROR"
+    fi
+  done
+
+  # A home that owns no records has nothing to pair, so it never pays for a
+  # backlog read. One list read then answers the healthy case for every record
+  # at once, and only a record whose row is NOT already in flight costs a
+  # second lookup.
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    has_record=1
+    break
+  done
+  [ "$has_record" = 1 ] || return 0
+  in_flight_ids=$(cd "$(fm_backlog_root "$DATA")" 2>/dev/null &&
+    tasks-axi list --state in_flight --file "$(fm_backlog_file "$DATA")" 2>/dev/null |
+    sed -n 's/^  \([^,]*\),.*/\1/p') || in_flight_ids=
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    id=$(basename "$meta" .meta)
+    case "$in_flight_ids" in
+      "$id"|"$id"$'\n'*|*$'\n'"$id"|*$'\n'"$id"$'\n'*) continue ;;
+    esac
+    [ "$(fm_meta_get "$meta" kind)" = secondmate ] && continue
+    row=$(fm_backlog_row_state "$DATA" "$id" || true)
+    # Heal only the unambiguous case: a queued row for a record this home
+    # already owns. A held row is the captain's to move, and a closed row is a
+    # contradiction this sweep must not resolve by resurrecting the item.
+    [ "$row" = "queued no" ] || continue
+    if fm_backlog_start "$DATA" "$id"; then
+      echo "BOOTSTRAP_INFO: marked $id in flight to match the worker this home already owns"
+    else
+      echo "BACKLOG_RECONCILE: $id: worker record exists but its backlog item could not be moved to In flight: $FM_BACKLOG_TRANSITION_ERROR"
+    fi
+  done
+}
+
 startup_memory_budget_setup() {
   # Primary bootstrap owns default publication. A secondmate is deliberately
   # passive here because its setting must converge from the primary through the
@@ -1203,6 +1278,7 @@ fi
 if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ] && local_phase; then
   "$SCRIPT_DIR/fm-pr-check-migrate.sh" || true
   startup_memory_budget_setup
+  backlog_record_reconcile
 fi
 
 # Local detection: presence, version floors, and configuration. Nothing here

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1211,7 +1211,7 @@ backlog_record_reconcile() {
 
   # Finish any close an interrupted cleanup recorded but never landed.
   for marker in "$STATE"/*.backlog-close; do
-    [ -e "$marker" ] || continue
+    [ -e "$marker" ] || [ -L "$marker" ] || continue
     label=$(basename "$marker" .backlog-close)
     meta_lock=$(fm_meta_lock_path "$STATE/$label.meta") || continue
     fm_lock_try_acquire "$meta_lock" || continue
@@ -1303,7 +1303,7 @@ fi
 if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ] && local_phase; then
   BOOTSTRAP_BACKLOG_GATE_KIND=secondmate
   for BOOTSTRAP_BACKLOG_MARKER in "$STATE"/*.backlog-close; do
-    [ -e "$BOOTSTRAP_BACKLOG_MARKER" ] || continue
+    [ -e "$BOOTSTRAP_BACKLOG_MARKER" ] || [ -L "$BOOTSTRAP_BACKLOG_MARKER" ] || continue
     BOOTSTRAP_BACKLOG_GATE_KIND=ship
     break
   done

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -172,8 +172,6 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 . "$SCRIPT_DIR/fm-startup-memory-budget-lib.sh"
 # shellcheck source=bin/fm-x-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-x-lib.sh"
-# shellcheck source=bin/fm-wake-lib.sh disable=SC1091
-. "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-backend.sh disable=SC1091
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-remote-readiness-lib.sh disable=SC1091
@@ -1195,6 +1193,10 @@ crew_dispatch_validate() {
 # backstops for what this cannot see. Never reads or writes another home.
 backlog_record_reconcile() {
   local marker meta meta_lock id row label has_record=0
+  # Keep the wake/lock library's source-time state-directory creation inside
+  # this mutating sweep, so FM_BOOTSTRAP_DETECT_ONLY remains read-only.
+  # shellcheck source=bin/fm-wake-lib.sh disable=SC1091
+  . "$SCRIPT_DIR/fm-wake-lib.sh"
   # `ship` stands for "any backlog-tracked kind" in this gate: the per-record
   # loop below still skips secondmates individually.
   fm_backlog_transition_applies "$CONFIG" "$DATA" ship || return 0

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1192,14 +1192,23 @@ crew_dispatch_validate() {
 # snapshot's classifier and bin/fm-secondmate-reconcile.sh's nudge stay as
 # backstops for what this cannot see. Never reads or writes another home.
 backlog_record_reconcile() {
-  local marker meta meta_lock id row label has_record=0
+  local marker meta meta_lock id row label has_record=0 gate_status
+  # `ship` stands for "any backlog-tracked kind" in this gate: the per-record
+  # loop below still skips secondmates individually.
+  if fm_backlog_transition_applies "$CONFIG" "$DATA" ship; then
+    :
+  else
+    gate_status=$?
+    if [ "$gate_status" -eq 2 ]; then
+      echo "error: backlog reconciliation cannot access configured data directory $DATA ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+      return 2
+    fi
+    return 0
+  fi
   # Keep the wake/lock library's source-time state-directory creation inside
   # this mutating sweep, so FM_BOOTSTRAP_DETECT_ONLY remains read-only.
   # shellcheck source=bin/fm-wake-lib.sh disable=SC1091
   . "$SCRIPT_DIR/fm-wake-lib.sh"
-  # `ship` stands for "any backlog-tracked kind" in this gate: the per-record
-  # loop below still skips secondmates individually.
-  fm_backlog_transition_applies "$CONFIG" "$DATA" ship || return 0
 
   # Finish any close an interrupted cleanup recorded but never landed.
   for marker in "$STATE"/*.backlog-close; do
@@ -1288,6 +1297,15 @@ fi
 # runnable. Detect-only sessions never touch state, and the deferred network pass
 # never repeats it: the local pass that ran first already closed that window.
 if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ] && local_phase; then
+  if fm_backlog_transition_applies "$CONFIG" "$DATA" ship; then
+    :
+  else
+    BOOTSTRAP_BACKLOG_GATE_STATUS=$?
+    if [ "$BOOTSTRAP_BACKLOG_GATE_STATUS" -eq 2 ]; then
+      echo "error: bootstrap cannot access configured backlog data directory $DATA ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+      exit 1
+    fi
+  fi
   "$SCRIPT_DIR/fm-pr-check-migrate.sh" || true
   startup_memory_budget_setup
   backlog_record_reconcile

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1214,7 +1214,7 @@ backlog_record_reconcile() {
     label=$(basename "$marker" .backlog-close)
     meta_lock=$(fm_meta_lock_path "$STATE/$label.meta") || continue
     fm_lock_try_acquire "$meta_lock" || continue
-    if fm_backlog_close_marker_replay "$STATE" "$marker"; then
+    if fm_backlog_close_marker_replay "$STATE" "$marker" "$DATA"; then
       if [ "$FM_BACKLOG_CLOSE_REPLAY_RESULT" = closed ]; then
         echo "BOOTSTRAP_INFO: closed the backlog item for $label that an interrupted cleanup left open"
       fi

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1225,7 +1225,8 @@ backlog_record_reconcile() {
   done
 
   # A home that owns no records has nothing to pair, so it never pays for a
-  # backlog read.
+  # backlog read. A pending close remains authoritative even when replay failed:
+  # the record sweep below must not start that item while its marker survives.
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
     has_record=1

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1230,8 +1230,15 @@ backlog_record_reconcile() {
     id=$(basename "$meta" .meta)
     meta_lock=$(fm_meta_lock_path "$meta") || continue
     fm_lock_try_acquire "$meta_lock" || continue
-    if [ -e "$meta" ] && [ "$(fm_meta_get "$meta" kind)" != secondmate ]; then
-      row=$(fm_backlog_row_state "$DATA" "$id" || true)
+    if [ -e "$meta" ] \
+       && [ "$(fm_meta_get "$meta" kind)" != secondmate ] \
+       && [ "$(fm_meta_get "$meta" cleanup_recovery)" != orca ]; then
+      row=
+      if fm_backlog_row_probe "$DATA" "$id"; then
+        row=$FM_BACKLOG_ROW_STATE
+      elif [ "$FM_BACKLOG_ROW_RESULT" != not_found ]; then
+        echo "BACKLOG_RECONCILE: $id: worker record exists but its backlog item could not be read: $FM_BACKLOG_ROW_ERROR"
+      fi
       # Heal only the unambiguous case: a queued row for a record this home
       # already owns. A held row is the captain's to move, and a closed row is a
       # contradiction this sweep must not resolve by resurrecting the item.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -91,8 +91,8 @@
 #          marks In flight any item this home already owns a worker for. It
 #          never touches a captain-held or closed item, and never reads or
 #          writes another home; the fleet snapshot's classifier and
-#          bin/fm-secondmate-reconcile.sh's nudge stay as backstops. Successful
-#          reconciliations print BOOTSTRAP_INFO facts.
+#          bin/fm-secondmate-reconcile.sh's nudge stay as backstops. Replayed
+#          closes and restored In-flight rows print BOOTSTRAP_INFO facts.
 #          Set FM_BOOTSTRAP_DETECT_ONLY=1 to skip the seven MUTATING sweeps
 #          (PR-check migration, backlog_record_reconcile, secondmate_sync,
 #          secondmate_liveness_sweep, secondmate_handoff_resume, x_mode_setup,

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -172,6 +172,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 . "$SCRIPT_DIR/fm-startup-memory-budget-lib.sh"
 # shellcheck source=bin/fm-x-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-x-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh disable=SC1091
+. "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-backend.sh disable=SC1091
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-remote-readiness-lib.sh disable=SC1091
@@ -1192,7 +1194,7 @@ crew_dispatch_validate() {
 # snapshot's classifier and bin/fm-secondmate-reconcile.sh's nudge stay as
 # backstops for what this cannot see. Never reads or writes another home.
 backlog_record_reconcile() {
-  local marker meta id row in_flight_ids label has_record=0
+  local marker meta meta_lock id row label has_record=0
   # `ship` stands for "any backlog-tracked kind" in this gate: the per-record
   # loop below still skips secondmates individually.
   fm_backlog_transition_applies "$CONFIG" "$DATA" ship || return 0
@@ -1201,44 +1203,45 @@ backlog_record_reconcile() {
   for marker in "$STATE"/*.backlog-close; do
     [ -e "$marker" ] || continue
     label=$(basename "$marker" .backlog-close)
+    meta_lock=$(fm_meta_lock_path "$STATE/$label.meta") || continue
+    fm_lock_try_acquire "$meta_lock" || continue
     if fm_backlog_close_marker_replay "$STATE" "$marker"; then
-      [ "$FM_BACKLOG_CLOSE_REPLAY_RESULT" = closed ] || continue
-      echo "BOOTSTRAP_INFO: closed the backlog item for $label that an interrupted cleanup left open"
+      if [ "$FM_BACKLOG_CLOSE_REPLAY_RESULT" = closed ]; then
+        echo "BOOTSTRAP_INFO: closed the backlog item for $label that an interrupted cleanup left open"
+      fi
     else
       echo "BACKLOG_RECONCILE: $label: recorded backlog close could not be replayed: $FM_BACKLOG_TRANSITION_ERROR"
     fi
+    fm_lock_release "$meta_lock"
   done
 
   # A home that owns no records has nothing to pair, so it never pays for a
-  # backlog read. One list read then answers the healthy case for every record
-  # at once, and only a record whose row is NOT already in flight costs a
-  # second lookup.
+  # backlog read.
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
     has_record=1
     break
   done
   [ "$has_record" = 1 ] || return 0
-  in_flight_ids=$(cd "$(fm_backlog_root "$DATA")" 2>/dev/null &&
-    tasks-axi list --state in_flight --file "$(fm_backlog_file "$DATA")" 2>/dev/null |
-    sed -n 's/^  \([^,]*\),.*/\1/p') || in_flight_ids=
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
     id=$(basename "$meta" .meta)
-    case "$in_flight_ids" in
-      "$id"|"$id"$'\n'*|*$'\n'"$id"|*$'\n'"$id"$'\n'*) continue ;;
-    esac
-    [ "$(fm_meta_get "$meta" kind)" = secondmate ] && continue
-    row=$(fm_backlog_row_state "$DATA" "$id" || true)
-    # Heal only the unambiguous case: a queued row for a record this home
-    # already owns. A held row is the captain's to move, and a closed row is a
-    # contradiction this sweep must not resolve by resurrecting the item.
-    [ "$row" = "queued no" ] || continue
-    if fm_backlog_start "$DATA" "$id"; then
-      echo "BOOTSTRAP_INFO: marked $id in flight to match the worker this home already owns"
-    else
-      echo "BACKLOG_RECONCILE: $id: worker record exists but its backlog item could not be moved to In flight: $FM_BACKLOG_TRANSITION_ERROR"
+    meta_lock=$(fm_meta_lock_path "$meta") || continue
+    fm_lock_try_acquire "$meta_lock" || continue
+    if [ -e "$meta" ] && [ "$(fm_meta_get "$meta" kind)" != secondmate ]; then
+      row=$(fm_backlog_row_state "$DATA" "$id" || true)
+      # Heal only the unambiguous case: a queued row for a record this home
+      # already owns. A held row is the captain's to move, and a closed row is a
+      # contradiction this sweep must not resolve by resurrecting the item.
+      if [ "$row" = "queued no" ]; then
+        if fm_backlog_start "$DATA" "$id"; then
+          echo "BOOTSTRAP_INFO: marked $id in flight to match the worker this home already owns"
+        else
+          echo "BACKLOG_RECONCILE: $id: worker record exists but its backlog item could not be moved to In flight: $FM_BACKLOG_TRANSITION_ERROR"
+        fi
+      fi
     fi
+    fm_lock_release "$meta_lock"
   done
 }
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1193,9 +1193,7 @@ crew_dispatch_validate() {
 # backstops for what this cannot see. Never reads or writes another home.
 backlog_record_reconcile() {
   local marker meta meta_lock id row label has_record=0 gate_status
-  # `ship` stands for "any backlog-tracked kind" in this gate: the per-record
-  # loop below still skips secondmates individually.
-  if fm_backlog_transition_applies "$CONFIG" "$DATA" ship; then
+  if fm_backlog_transition_applies "$CONFIG" "$DATA" "$BOOTSTRAP_BACKLOG_GATE_KIND"; then
     :
   else
     gate_status=$?
@@ -1297,7 +1295,23 @@ fi
 # runnable. Detect-only sessions never touch state, and the deferred network pass
 # never repeats it: the local pass that ran first already closed that window.
 if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ] && local_phase; then
-  if fm_backlog_transition_applies "$CONFIG" "$DATA" ship; then
+  BOOTSTRAP_BACKLOG_GATE_KIND=secondmate
+  for BOOTSTRAP_BACKLOG_MARKER in "$STATE"/*.backlog-close; do
+    [ -e "$BOOTSTRAP_BACKLOG_MARKER" ] || continue
+    BOOTSTRAP_BACKLOG_GATE_KIND=ship
+    break
+  done
+  if [ "$BOOTSTRAP_BACKLOG_GATE_KIND" = secondmate ]; then
+    for BOOTSTRAP_BACKLOG_META in "$STATE"/*.meta; do
+      [ -f "$BOOTSTRAP_BACKLOG_META" ] || continue
+      if [ "$(fm_meta_get "$BOOTSTRAP_BACKLOG_META" kind)" != secondmate ] \
+         && [ "$(fm_meta_get "$BOOTSTRAP_BACKLOG_META" cleanup_recovery)" != orca ]; then
+        BOOTSTRAP_BACKLOG_GATE_KIND=ship
+        break
+      fi
+    done
+  fi
+  if fm_backlog_transition_applies "$CONFIG" "$DATA" "$BOOTSTRAP_BACKLOG_GATE_KIND"; then
     :
   else
     BOOTSTRAP_BACKLOG_GATE_STATUS=$?

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -87,10 +87,11 @@
 #          the backlog row inside the script that moves the task's record
 #          (bin/fm-backlog-transition-lib.sh), so this sweep exists for the
 #          crash window inside those scripts and for drift a home was already
-#          carrying: it finishes a close an interrupted cleanup recorded, and
-#          marks In flight any item this home already owns a worker for. It
-#          never touches a captain-held or closed item, and never reads or
-#          writes another home; the fleet snapshot's classifier and
+#          carrying: it finishes the authoritative close an interrupted cleanup
+#          recorded, and marks In flight any item this home already owns a worker
+#          for. The worker-record sweep never starts a captain-held or closed
+#          item, and reconciliation never reads or writes another home; the fleet
+#          snapshot's classifier and
 #          bin/fm-secondmate-reconcile.sh's nudge stay as backstops. Replayed
 #          closes and restored In-flight rows print BOOTSTRAP_INFO facts.
 #          Set FM_BOOTSTRAP_DETECT_ONLY=1 to skip the seven MUTATING sweeps
@@ -1185,9 +1186,9 @@ crew_dispatch_validate() {
 
 # Same-home record reconciliation. Every ordinary dispatch and completion now
 # moves the backlog row inside the script that moves the task's record
-# (bin/fm-backlog-transition-lib.sh), so the only ways the two can still
-# disagree are a process killed mid-transition and drift a home was already
-# carrying before that pairing existed. Heal this home's OWN books on its own
+# (bin/fm-backlog-transition-lib.sh), so remaining recovery cases include a
+# process killed mid-transition and drift this home was already carrying. Heal
+# this home's OWN books on its own
 # restart rather than waiting for a parent's cross-home nudge; the fleet
 # snapshot's classifier and bin/fm-secondmate-reconcile.sh's nudge stay as
 # backstops for what this cannot see. Never reads or writes another home.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1237,6 +1237,10 @@ backlog_record_reconcile() {
     id=$(basename "$meta" .meta)
     meta_lock=$(fm_meta_lock_path "$meta") || continue
     fm_lock_try_acquire "$meta_lock" || continue
+    if [ -e "$STATE/$id.backlog-close" ] || [ -L "$STATE/$id.backlog-close" ]; then
+      fm_lock_release "$meta_lock"
+      continue
+    fi
     if [ -e "$meta" ] \
        && [ "$(fm_meta_get "$meta" kind)" != secondmate ] \
        && [ "$(fm_meta_get "$meta" cleanup_recovery)" != orca ]; then

--- a/bin/fm-secondmate-reconcile.sh
+++ b/bin/fm-secondmate-reconcile.sh
@@ -6,6 +6,13 @@
 #   fm-secondmate-reconcile.sh notify [--snapshot <file>|-]
 #   fm-secondmate-reconcile.sh nudged <mate-id>
 #
+# This is a BACKSTOP, not the primary mechanism. Dispatch and completion pair
+# the backlog row with the task's record inside the one script that moves the
+# record, and each home reconciles its own books at session start
+# (bin/fm-backlog-transition-lib.sh), so what reaches here is what neither could
+# see: a home that has not restarted since it drifted, or one still running
+# older code.
+#
 # A backlog-vs-metadata inventory mismatch inside a secondmate home
 # (orphan_in_flight, unowned_current, terminal_in_flight) no longer makes that
 # home unreadable: bin/fm-fleet-snapshot.sh keeps its decisions, queued, landed,

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -19,7 +19,7 @@
 # standalone with unchanged default behavior - other flows (fm-bootstrap.sh
 # install <tools> after consent, /updatefirstmate, the afk daemon, existing
 # tests) still call them directly. The one seam this script needed -
-# bootstrap running its detect-only diagnostics without its six mutating
+# bootstrap running its detect-only diagnostics without its seven mutating
 # sweeps - is an opt-in FM_BOOTSTRAP_DETECT_ONLY=1 flag on fm-bootstrap.sh
 # itself (default unset/0 = unchanged behavior), not a fork.
 #
@@ -30,10 +30,10 @@
 #                       mutating step runs.
 #   2. bootstrap      - home-local stale Herdr projection cleanup runs only
 #                       when this session actually holds the lock. Detect-only
-#                       diagnostics always run. Bootstrap's six MUTATING sweeps
-#                       (legacy PR-check migration, secondmate convergence,
-#                       secondmate liveness, pending remote handoff retry,
-#                       X-mode artifact writes, fleet sync) also run only when
+#                       diagnostics always run. Bootstrap's seven MUTATING sweeps
+#                       (legacy PR-check migration, same-home backlog reconciliation,
+#                       secondmate convergence, secondmate liveness, pending remote
+#                       handoff retry, X-mode artifact writes, fleet sync) also run only when
 #                       locked; the four network sweeps run in the deferred
 #                       stage rather than this synchronous bootstrap section.
 #   3. inactive outcomes + wake-drain - runs the local bounded inactive-outcome
@@ -116,7 +116,7 @@
 # and all of which are safe to compute without verified lock ownership.
 # It deliberately skips the network-only GitHub-auth probe because a read-only
 # session has no dispatch, spawn, steer, or merge action for that verdict to gate.
-# Only projection cleanup, the six bootstrap mutating sweeps, and wake-queue
+# Only projection cleanup, the seven bootstrap mutating sweeps, and wake-queue
 # presentation are skipped.
 # The context and fleet-state digests
 # below are always read-only, so they run unconditionally in both modes.
@@ -189,9 +189,10 @@
 #   --reemit  This process ALREADY took the helm at its own startup and has
 #             only lost its context (a /clear or a compaction). Skip the
 #             mutating sweeps that startup already reconciled - the stale Herdr
-#             projection cleanup and bootstrap's six mutating sweeps (fleet
-#             sync, secondmate convergence and liveness, PR-check migration,
-#             pending remote handoff retry, X-mode artifact writes) - and
+#             projection cleanup and bootstrap's seven mutating sweeps (fleet
+#             sync, same-home backlog reconciliation, secondmate convergence and
+#             liveness, PR-check migration, pending remote handoff retry, X-mode
+#             artifact writes) - and
 #             re-emit the rest. Wake-queue presentation is NOT skipped: queued
 #             records are this turn's work queue, they arrived after startup,
 #             and a session that owns the lock is exactly the session that must

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2807,11 +2807,23 @@ spawn_commit_backlog_transition() {
   # Re-verify rather than assume. A relaunch republishes a record whose row is
   # normally already In flight, and blindly re-running the transition on a row
   # tasks-axi has since closed would silently resurrect it.
-  row=$(fm_backlog_row_state "$DATA" "$ID" || true)
+  if ! fm_backlog_row_probe "$DATA" "$ID"; then
+    if [ "$FM_BACKLOG_ROW_RESULT" = not_found ]; then
+      FM_BACKLOG_TRANSITION_ERROR="backlog item $ID vanished before dispatch commit"
+    else
+      FM_BACKLOG_TRANSITION_ERROR=$FM_BACKLOG_ROW_ERROR
+    fi
+    return 1
+  fi
+  row=$FM_BACKLOG_ROW_STATE
   case "$row" in
     in_flight\ *) return 0 ;;
+    queued\ no) fm_backlog_start "$DATA" "$ID" ;;
+    *)
+      FM_BACKLOG_TRANSITION_ERROR="backlog item $ID is not dispatchable in state $row"
+      return 1
+      ;;
   esac
-  fm_backlog_start "$DATA" "$ID"
 }
 
 if [ "$RELAUNCH" -eq 1 ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2846,17 +2846,13 @@ if [ "$RELAUNCH" -eq 1 ]; then
   RELAUNCH_REPLACEMENT_PENDING=0
   SPAWN_META_PUBLISH_STARTED=0
   SPAWN_META_TMP=
-  # Relaunch replaces an already-owned record and preserves the established
-  # short metadata critical sections used by concurrent durable writers. The
-  # final backlog re-verification reacquires this lock below.
-  fm_lock_release "$SPAWN_META_LOCK"
-  SPAWN_META_LOCK_HELD=0
 fi
-# A fresh dispatch keeps the per-task meta lock through launch delivery. The
-# backlog mutation is deliberately the final fallible commit below, so teardown
-# cannot observe or complete this provisional record between its state check
-# and `tasks-axi start`, and a delivery failure cannot follow a committed
-# In-flight transition.
+# A dispatch or relaunch keeps the per-task meta lock through launch delivery.
+# The backlog mutation is deliberately the final fallible commit below, so
+# teardown cannot remove a relaunched record while its replacement worker is
+# still being delivered, cannot observe or complete a fresh provisional record
+# between its state check and `tasks-axi start`, and a delivery failure cannot
+# follow a committed In-flight transition.
 if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
   # The record is published, so this task is now part of the set a teardown
   # enumerates and locks per task. The set lock is only needed across that
@@ -3024,6 +3020,11 @@ if [ "$SPAWN_META_LOCK_HELD" != 1 ]; then
   fm_lock_acquire_wait "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=1
 fi
+# From this point a process-level interruption must preserve the published
+# record: it is the durable recovery evidence when interruption lands inside
+# the backlog mutation. An ordinary returned transition failure still performs
+# the complete record and busy-generation unwind below.
+SPAWN_FRESH_COMMIT_PENDING=0
 if ! spawn_commit_backlog_transition; then
   if [ "$RELAUNCH" -eq 0 ]; then
     rm -f "$STATE/$ID.meta"
@@ -3040,7 +3041,6 @@ if ! spawn_commit_backlog_transition; then
   SPAWN_META_LOCK_HELD=0
   exit 1
 fi
-SPAWN_FRESH_COMMIT_PENDING=0
 fm_lock_release "$SPAWN_META_LOCK"
 SPAWN_META_LOCK_HELD=0
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3075,8 +3075,8 @@ SPAWN_DEFERRED_SIGNAL=
 trap 'SPAWN_DEFERRED_SIGNAL=HUP' HUP
 trap 'SPAWN_DEFERRED_SIGNAL=INT' INT
 trap 'SPAWN_DEFERRED_SIGNAL=TERM' TERM
-spawn_send_key "$T" Enter
 SPAWN_WORKER_LIVE=1
+spawn_send_key "$T" Enter
 if [ "$HARNESS" = kimi ]; then
   KIMI_DELIVERY_FAILED=0
   if ! kimi_wait_for_ready; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -191,11 +191,12 @@
 # success. A ship or scout dispatch therefore REFUSES up front, before any
 # endpoint, worktree, or record exists, when the home's backlog has no item for
 # the id or already records it as finished. A transition that fails after
-# publication removes the record and busy generation it just wrote; if launch
-# delivery already began, the reported failure tells the operator to close the
-# endpoint and local copy before retrying. A relaunch re-reads the row instead of
-# re-running the transition, so an already In-flight item is left untouched. The
-# transition is skipped entirely for --secondmate spawns (persistent agents are not work
+# publication stops and confirms the launched endpoint gone before removing the
+# record and busy generation it just wrote; if absence cannot be confirmed, it
+# retains both records and reports the unresolved endpoint. A relaunch re-reads
+# the row instead of re-running the transition, so an already In-flight item is
+# left untouched. The transition is skipped entirely for --secondmate spawns
+# (persistent agents are not work
 # items), on a config/backlog-backend=manual home, without a compatible
 # tasks-axi, and in a home that keeps no data/backlog.md.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> [mode=<mode> yolo=<on|off>] window=<backend-target> worktree=<path>
@@ -3068,10 +3069,12 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   spawn_herdr_presentation_order_lock_release
 fi
 SPAWN_DEFERRED_SIGNAL=
-# Once Enter submits the launch, every spawn owns a live worker, including homes
-# exempt from automatic backlog transitions. Defer termination until the common
-# commit point disarms EXIT rollback, or cleanup would erase an exempt worker's
-# published ownership records after its launch had already started.
+# Enter may start the worker before its submission command returns, so mark the
+# endpoint live first and fail toward a harmless confirmed-stop attempt rather
+# than orphaning a worker after an ambiguous interruption. This applies even to
+# homes exempt from automatic backlog transitions. Defer termination until the
+# common commit point disarms EXIT rollback, or cleanup could erase the
+# published ownership records of a worker whose launch had already started.
 trap 'SPAWN_DEFERRED_SIGNAL=HUP' HUP
 trap 'SPAWN_DEFERRED_SIGNAL=INT' INT
 trap 'SPAWN_DEFERRED_SIGNAL=TERM' TERM

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -190,11 +190,12 @@
 # script performs the transition under the task's own meta lock before it reports
 # success. A ship or scout dispatch therefore REFUSES up front, before any
 # endpoint, worktree, or record exists, when the home's backlog has no item for
-# the id or already records it as finished, and a transition that fails after
-# publication removes the record it just wrote rather than leaving a worker the
-# backlog does not own. A relaunch re-reads the row instead of re-running the
-# transition, so an already In-flight item is left untouched. The transition is
-# skipped entirely for --secondmate spawns (persistent agents are not work
+# the id or already records it as finished. A transition that fails after
+# publication removes the record and busy generation it just wrote; if launch
+# delivery already began, the reported failure tells the operator to close the
+# endpoint and local copy before retrying. A relaunch re-reads the row instead of
+# re-running the transition, so an already In-flight item is left untouched. The
+# transition is skipped entirely for --secondmate spawns (persistent agents are not work
 # items), on a config/backlog-backend=manual home, without a compatible
 # tasks-axi, and in a home that keeps no data/backlog.md.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> [mode=<mode> yolo=<on|off>] window=<backend-target> worktree=<path>

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -700,6 +700,25 @@ RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
 
+spawn_fresh_commit_rollback() {
+  local failed=0
+  if ! rm -f "$STATE/$ID.meta" 2>/dev/null \
+     || [ -e "$STATE/$ID.meta" ] || [ -L "$STATE/$ID.meta" ]; then
+    echo "error: could not remove provisional task record $STATE/$ID.meta after failed dispatch" >&2
+    failed=1
+  fi
+  if [ -n "${BUSY_GEN:-}" ]; then
+    if ! "$FM_ROOT/bin/fm-busy-event.sh" retire "$STATE" "$ID" --gen "$BUSY_GEN" >/dev/null 2>&1; then
+      echo "warning: could not retire the busy generation armed for $ID" >&2
+      failed=1
+    fi
+  fi
+  if [ "$failed" = 0 ]; then
+    SPAWN_FRESH_COMMIT_PENDING=0
+  fi
+  return "$failed"
+}
+
 parse_orca_worktree_result() {
   local raw=$1 rest
   ORCA_WORKTREE_ID=${raw%%$'\t'*}
@@ -794,10 +813,8 @@ spawn_abort_cleanup() {
     fm_lock_release "$SPAWN_TASK_LOCK" || true
   fi
   if [ "$SPAWN_FRESH_COMMIT_PENDING" = 1 ]; then
-    SPAWN_FRESH_COMMIT_PENDING=0
-    rm -f "$STATE/$ID.meta" 2>/dev/null || true
-    if [ -n "${BUSY_GEN:-}" ]; then
-      "$FM_ROOT/bin/fm-busy-event.sh" retire "$STATE" "$ID" --gen "$BUSY_GEN" >/dev/null 2>&1 || true
+    if ! spawn_fresh_commit_rollback; then
+      status=1
     fi
   fi
   if [ "$SPAWN_META_LOCK_HELD" = 1 ]; then
@@ -3039,21 +3056,17 @@ if spawn_commit_backlog_transition; then
 else
   SPAWN_BACKLOG_COMMIT_STATUS=$?
   if [ "$RELAUNCH" -eq 0 ]; then
-    rm -f "$STATE/$ID.meta"
-    SPAWN_FRESH_COMMIT_PENDING=0
-    if [ -n "${BUSY_GEN:-}" ]; then
-      "$FM_ROOT/bin/fm-busy-event.sh" retire "$STATE" "$ID" --gen "$BUSY_GEN" \
-        || echo "warning: could not retire the busy generation armed for $ID" >&2
+    if spawn_fresh_commit_rollback; then
+      echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); its record was removed so no worker is left that the backlog does not own - close out endpoint $T and local copy $WT by hand, then re-run the spawn" >&2
+    else
+      echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR), and failed-dispatch cleanup is incomplete; the provisional record may remain at $STATE/$ID.meta - close out endpoint $T and local copy $WT by hand, then remove the record and busy state before retrying" >&2
     fi
-    echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); its record was removed so no worker is left that the backlog does not own - close out endpoint $T and local copy $WT by hand, then re-run the spawn" >&2
   else
     echo "error: task $ID was republished but its backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); fix the backlog and re-run the relaunch" >&2
   fi
 fi
 trap - HUP INT TERM
 if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -ne 0 ]; then
-  fm_lock_release "$SPAWN_META_LOCK"
-  SPAWN_META_LOCK_HELD=0
   exit "$SPAWN_BACKLOG_COMMIT_STATUS"
 fi
 fm_lock_release "$SPAWN_META_LOCK"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -701,22 +701,13 @@ CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
 
 spawn_fresh_commit_rollback() {
-  local failed=0
-  if ! rm -f "$STATE/$ID.meta" 2>/dev/null \
-     || [ -e "$STATE/$ID.meta" ] || [ -L "$STATE/$ID.meta" ]; then
-    echo "error: could not remove provisional task record $STATE/$ID.meta after failed dispatch" >&2
-    failed=1
-  fi
-  if [ -n "${BUSY_GEN:-}" ]; then
-    if ! "$FM_ROOT/bin/fm-busy-event.sh" retire "$STATE" "$ID" --gen "$BUSY_GEN" >/dev/null 2>&1; then
-      echo "warning: could not retire the busy generation armed for $ID" >&2
-      failed=1
-    fi
-  fi
-  if [ "$failed" = 0 ]; then
+  if fm_backlog_atomic_transition rollback "$STATE/$ID.meta" \
+      "$FM_ROOT/bin/fm-busy-event.sh" "$STATE" "$ID" "${BUSY_GEN:-}"; then
     SPAWN_FRESH_COMMIT_PENDING=0
+    return 0
   fi
-  return "$failed"
+  echo "error: $FM_BACKLOG_TRANSITION_ERROR" >&2
+  return 1
 }
 
 parse_orca_worktree_result() {
@@ -789,6 +780,7 @@ spawn_abort_cleanup() {
       if ! fm_backend_remove_worktree orca "$ORCA_WORKTREE_ID" 2>/dev/null; then
         mkdir -p "$STATE" 2>/dev/null || true
         if [ -d "$STATE" ]; then
+          SPAWN_META_TMP="$STATE/.$ID.meta.orca-recovery.${BASHPID:-$$}"
           {
             echo "window=$W"
             echo "worktree=${WT:-}"
@@ -803,7 +795,9 @@ spawn_abort_cleanup() {
             echo "backend=orca"
             echo "orca_worktree_id=$ORCA_WORKTREE_ID"
             [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
-          } > "$STATE/$ID.meta" 2>/dev/null || true
+          } > "$SPAWN_META_TMP" 2>/dev/null \
+            && fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record" \
+            || true
         fi
       fi
     fi
@@ -2764,8 +2758,11 @@ fm_lock_acquire_wait "$SPAWN_META_LOCK"
 SPAWN_META_LOCK_HELD=1
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_TMP="$STATE/.$ID.meta.relaunch.${BASHPID:-$$}"
-  SPAWN_META_PATH=$SPAWN_META_TMP
+else
+  SPAWN_META_TMP="$STATE/.$ID.meta.spawn.${BASHPID:-$$}"
+  SPAWN_FRESH_COMMIT_PENDING=1
 fi
+SPAWN_META_PATH=$SPAWN_META_TMP
 preserve_relaunch_meta() {
   awk -F= '
     BEGIN {
@@ -2823,12 +2820,16 @@ preserve_relaunch_meta() {
   if [ "$SPAWN_CONTROL_PARENT" = 1 ] && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ]; then
     echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
   fi
-} > "$SPAWN_META_PATH"
+} > "$SPAWN_META_PATH" || {
+  echo "error: task record for $ID could not be prepared at $SPAWN_META_PATH" >&2
+  exit 1
+}
 if [ "$RELAUNCH" -eq 0 ]; then
-  # Until every fallible delivery step has succeeded and the backlog transition
-  # commits below, an ordinary shell error must not leave this provisional
-  # record (or its paired busy generation) behind.
-  SPAWN_FRESH_COMMIT_PENDING=1
+  if ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record"; then
+    echo "error: task record for $ID could not be published ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+    exit 1
+  fi
+  SPAWN_META_TMP=
 fi
 
 # Fuse the backlog In-flight transition into the publication that just created
@@ -2837,35 +2838,16 @@ fi
 # serialized exactly as before. The call itself is deferred to the final commit
 # point below so every earlier launch-delivery failure remains unwindable.
 spawn_commit_backlog_transition() {
-  local row row_status
   [ "$BACKLOG_TRANSITION" = 1 ] || return 0
-  # Re-verify rather than assume. A relaunch republishes a record whose row is
-  # normally already In flight, and blindly re-running the transition on a row
-  # tasks-axi has since closed would silently resurrect it.
-  fm_backlog_row_probe "$DATA" "$ID"
-  row_status=$?
-  if [ "$row_status" -ne 0 ]; then
-    if [ "$FM_BACKLOG_ROW_RESULT" = not_found ]; then
-      FM_BACKLOG_TRANSITION_ERROR="backlog item $ID vanished before dispatch commit"
-    else
-      FM_BACKLOG_TRANSITION_ERROR=$FM_BACKLOG_ROW_ERROR
-    fi
-    return "$row_status"
-  fi
-  row=$FM_BACKLOG_ROW_STATE
-  case "$row" in
-    in_flight\ *) return 0 ;;
-    queued\ no) fm_backlog_start "$DATA" "$ID" ;;
-    *)
-      FM_BACKLOG_TRANSITION_ERROR="backlog item $ID is not dispatchable in state $row"
-      return 1
-      ;;
-  esac
+  fm_backlog_atomic_transition dispatch "$STATE/$ID.meta" "$DATA" "$ID"
 }
 
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_PUBLISH_STARTED=1
-  mv -f "$SPAWN_META_TMP" "$STATE/$ID.meta"
+  if ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record"; then
+    echo "error: replacement task record for $ID could not be published ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+    exit 1
+  fi
   RELAUNCH_REPLACEMENT_PENDING=0
   SPAWN_META_PUBLISH_STARTED=0
   SPAWN_META_TMP=
@@ -2960,7 +2942,7 @@ spawn_record_traceparent() {
   if [ ! -f "$meta" ] || [ ! -w "$meta" ] \
      || ! awk -F= '$1 != "traceparent"' "$meta" > "$SPAWN_META_TMP" \
      || ! printf 'traceparent=%s\n' "$SPAWN_TRACEPARENT" >> "$SPAWN_META_TMP" \
-     || ! mv -f "$SPAWN_META_TMP" "$meta"; then
+     || ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$meta" "task record"; then
     status=1
     rm -f "$SPAWN_META_TMP" 2>/dev/null || true
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -697,6 +697,7 @@ SPAWN_META_LOCK=
 SPAWN_META_LOCK_HELD=0
 SPAWN_META_PUBLISH_STARTED=0
 SPAWN_FRESH_COMMIT_PENDING=0
+SPAWN_WORKER_LIVE=0
 SPAWN_TASK_SET_LOCK=
 SPAWN_TASK_SET_LOCK_HELD=0
 RELAUNCH_REPLACEMENT_PENDING=0
@@ -708,6 +709,15 @@ CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
 
 spawn_fresh_commit_rollback() {
+  if [ "$SPAWN_WORKER_LIVE" = 1 ]; then
+    fm_backend_kill "$BACKEND" "$T" '' "fm-$ID" >/dev/null 2>&1 || true
+    if fm_backend_target_exists "$BACKEND" "$T" "fm-$ID"; then
+      FM_BACKLOG_TRANSITION_ERROR="failed-dispatch endpoint $T remains live; retaining task and busy records for $ID"
+      echo "error: $FM_BACKLOG_TRANSITION_ERROR" >&2
+      return 1
+    fi
+    SPAWN_WORKER_LIVE=0
+  fi
   if fm_backlog_atomic_transition rollback "$STATE/$ID.meta" \
       "$FM_ROOT/bin/fm-busy-event.sh" "$STATE" "$ID" "${BUSY_GEN:-}"; then
     SPAWN_FRESH_COMMIT_PENDING=0
@@ -3012,6 +3022,7 @@ trap 'SPAWN_DEFERRED_SIGNAL=HUP' HUP
 trap 'SPAWN_DEFERRED_SIGNAL=INT' INT
 trap 'SPAWN_DEFERRED_SIGNAL=TERM' TERM
 spawn_send_key "$T" Enter
+SPAWN_WORKER_LIVE=1
 if [ "$HARNESS" = kimi ]; then
   KIMI_DELIVERY_FAILED=0
   if ! kimi_wait_for_ready; then
@@ -3081,9 +3092,9 @@ fi
 if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -ne 0 ]; then
   if [ "$RELAUNCH" -eq 0 ]; then
     if spawn_fresh_commit_rollback; then
-      echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); its record was removed so no worker is left that the backlog does not own - close out endpoint $T and local copy $WT by hand, then re-run the spawn" >&2
+      echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); its endpoint was stopped and its provisional records were removed - return local copy $WT by hand, then re-run the spawn" >&2
     else
-      echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR), and failed-dispatch cleanup is incomplete; the provisional record may remain at $STATE/$ID.meta - close out endpoint $T and local copy $WT by hand, then remove the record and busy state before retrying" >&2
+      echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR), and failed-dispatch cleanup is incomplete; inspect endpoint $T and the retained ownership records before returning local copy $WT or retrying" >&2
     fi
   else
     echo "error: task $ID was republished but its backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); fix the backlog and re-run the relaunch" >&2
@@ -3093,6 +3104,7 @@ trap - HUP INT TERM
 if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -ne 0 ]; then
   exit "$SPAWN_BACKLOG_COMMIT_STATUS"
 fi
+SPAWN_WORKER_LIVE=0
 fm_lock_release "$SPAWN_META_LOCK"
 SPAWN_META_LOCK_HELD=0
 if [ -n "$SPAWN_DEFERRED_SIGNAL" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -778,11 +778,19 @@ spawn_abort_cleanup() {
     fi
     if [ -n "${ORCA_WORKTREE_ID:-}" ]; then
       if ! fm_backend_remove_worktree orca "$ORCA_WORKTREE_ID" 2>/dev/null; then
+        if [ "$SPAWN_FRESH_COMMIT_PENDING" = 1 ]; then
+          if ! spawn_fresh_commit_rollback; then
+            status=1
+          fi
+          SPAWN_FRESH_COMMIT_PENDING=0
+        fi
         mkdir -p "$STATE" 2>/dev/null || true
         if [ -d "$STATE" ]; then
           SPAWN_META_TMP="$STATE/.$ID.meta.orca-recovery.${BASHPID:-$$}"
           {
             echo "window=$W"
+            echo "endpoint_task_id=$ID"
+            echo "cleanup_recovery=orca"
             echo "worktree=${WT:-}"
             echo "project=$PROJ_ABS"
             echo "harness=$HARNESS"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1965,12 +1965,16 @@ BACKLOG_TRANSITION=0
 BACKLOG_ROW_STATE=
 if fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
   BACKLOG_TRANSITION=1
-  BACKLOG_ROW_STATE=$(fm_backlog_row_state "$DATA" "$ID" || true)
+  if fm_backlog_row_probe "$DATA" "$ID"; then
+    BACKLOG_ROW_STATE=$FM_BACKLOG_ROW_STATE
+  elif [ "$FM_BACKLOG_ROW_RESULT" = not_found ]; then
+    echo "error: task $ID has no backlog item in this home, so dispatching it would leave a worker no record owns; add it first (tasks-axi add $ID '<title>' --kind $KIND) and re-run" >&2
+    exit 1
+  else
+    echo "error: task $ID's backlog item could not be read before dispatch ($FM_BACKLOG_ROW_ERROR)" >&2
+    exit 1
+  fi
   case "$BACKLOG_ROW_STATE" in
-    '')
-      echo "error: task $ID has no backlog item in this home, so dispatching it would leave a worker no record owns; add it first (tasks-axi add $ID '<title>' --kind $KIND) and re-run" >&2
-      exit 1
-      ;;
     done\ *)
       echo "error: this home's backlog records $ID as finished; refusing to dispatch onto a closed item (reopen it with tasks-axi reopen $ID, or use a new task id)" >&2
       exit 1
@@ -2833,18 +2837,20 @@ fi
 # serialized exactly as before. The call itself is deferred to the final commit
 # point below so every earlier launch-delivery failure remains unwindable.
 spawn_commit_backlog_transition() {
-  local row
+  local row row_status
   [ "$BACKLOG_TRANSITION" = 1 ] || return 0
   # Re-verify rather than assume. A relaunch republishes a record whose row is
   # normally already In flight, and blindly re-running the transition on a row
   # tasks-axi has since closed would silently resurrect it.
-  if ! fm_backlog_row_probe "$DATA" "$ID"; then
+  fm_backlog_row_probe "$DATA" "$ID"
+  row_status=$?
+  if [ "$row_status" -ne 0 ]; then
     if [ "$FM_BACKLOG_ROW_RESULT" = not_found ]; then
       FM_BACKLOG_TRANSITION_ERROR="backlog item $ID vanished before dispatch commit"
     else
       FM_BACKLOG_TRANSITION_ERROR=$FM_BACKLOG_ROW_ERROR
     fi
-    return 1
+    return "$row_status"
   fi
   row=$FM_BACKLOG_ROW_STATE
   case "$row" in
@@ -2966,13 +2972,6 @@ spawn_record_traceparent() {
   return "$status"
 }
 
-# Once launch delivery can start the worker, defer catchable interruption until
-# the paired backlog state is committed. Otherwise a signal after Enter but
-# before tasks-axi could leave a running worker whose provisional record EXIT
-# cleanup removes. Commands run directly by this shell inherit the ignored
-# dispositions; explicit delivery failures still exit through ordinary cleanup.
-trap '' HUP INT TERM
-
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.
@@ -3001,29 +3000,41 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   HERDR_PROJECTION_ABORT_CLEANUP=0
   spawn_herdr_presentation_order_lock_release
 fi
+SPAWN_DEFERRED_SIGNAL=
+if [ "$BACKLOG_TRANSITION" = 1 ]; then
+  trap 'SPAWN_DEFERRED_SIGNAL=HUP' HUP
+  trap 'SPAWN_DEFERRED_SIGNAL=INT' INT
+  trap 'SPAWN_DEFERRED_SIGNAL=TERM' TERM
+fi
 spawn_send_key "$T" Enter
 if [ "$HARNESS" = kimi ]; then
+  KIMI_DELIVERY_FAILED=0
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"
-    exit 1
+    [ -n "$SPAWN_DEFERRED_SIGNAL" ] || exit 1
+    KIMI_DELIVERY_FAILED=1
   fi
-  KIMI_POINTER="Read the brief at $BRIEF_REAL and follow it exactly."
-  KIMI_SUBMIT_RETRIES=${FM_KIMI_SUBMIT_RETRIES:-3}
-  KIMI_SUBMIT_SLEEP=${FM_KIMI_SUBMIT_SLEEP:-${FM_KIMI_POLL_INTERVAL:-0.5}}
-  KIMI_SUBMIT_SETTLE=${FM_KIMI_SUBMIT_SETTLE:-0}
-  KIMI_SUBMIT_VERDICT=$(fm_backend_send_text_submit \
-    "$BACKEND" "$T" "$KIMI_POINTER" "$KIMI_SUBMIT_RETRIES" \
-    "$KIMI_SUBMIT_SLEEP" "$KIMI_SUBMIT_SETTLE" "$W") || {
-    kimi_spawn_fail "kimi brief pointer could not be submitted"
-    exit 1
-  }
-  if [ "$KIMI_SUBMIT_VERDICT" = send-failed ]; then
-    kimi_spawn_fail "kimi brief pointer could not be submitted"
-    exit 1
+  if [ "$KIMI_DELIVERY_FAILED" = 0 ]; then
+    KIMI_POINTER="Read the brief at $BRIEF_REAL and follow it exactly."
+    KIMI_SUBMIT_RETRIES=${FM_KIMI_SUBMIT_RETRIES:-3}
+    KIMI_SUBMIT_SLEEP=${FM_KIMI_SUBMIT_SLEEP:-${FM_KIMI_POLL_INTERVAL:-0.5}}
+    KIMI_SUBMIT_SETTLE=${FM_KIMI_SUBMIT_SETTLE:-0}
+    if ! KIMI_SUBMIT_VERDICT=$(fm_backend_send_text_submit \
+        "$BACKEND" "$T" "$KIMI_POINTER" "$KIMI_SUBMIT_RETRIES" \
+        "$KIMI_SUBMIT_SLEEP" "$KIMI_SUBMIT_SETTLE" "$W"); then
+      kimi_spawn_fail "kimi brief pointer could not be submitted"
+      [ -n "$SPAWN_DEFERRED_SIGNAL" ] || exit 1
+      KIMI_DELIVERY_FAILED=1
+    fi
   fi
-  if ! kimi_wait_for_delivery; then
+  if [ "$KIMI_DELIVERY_FAILED" = 0 ] && [ "$KIMI_SUBMIT_VERDICT" = send-failed ]; then
+    kimi_spawn_fail "kimi brief pointer could not be submitted"
+    [ -n "$SPAWN_DEFERRED_SIGNAL" ] || exit 1
+    KIMI_DELIVERY_FAILED=1
+  fi
+  if [ "$KIMI_DELIVERY_FAILED" = 0 ] && ! kimi_wait_for_delivery; then
     kimi_spawn_fail "kimi brief pointer delivery was not confirmed"
-    exit 1
+    [ -n "$SPAWN_DEFERRED_SIGNAL" ] || exit 1
   fi
 fi
 if [ "$KIND" = secondmate ] && [ "${FM_SKIP_SECONDMATE_INHERIT:-0}" != 1 ]; then
@@ -3044,17 +3055,17 @@ if [ "$SPAWN_META_LOCK_HELD" != 1 ]; then
   fm_lock_acquire_wait "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=1
 fi
-# Complete the uninterruptible catchable-signal region begun before launch
-# delivery. Clearing the provisional flag before tasks-axi could preserve a
-# queued record; clearing it after tasks-axi could let EXIT cleanup delete an
-# In-flight record. Keeping signals ignored across both operations closes both
-# races. An uncatchable crash still leaves the published record for bootstrap
-# recovery.
 SPAWN_BACKLOG_COMMIT_STATUS=0
 if spawn_commit_backlog_transition; then
   SPAWN_FRESH_COMMIT_PENDING=0
 else
   SPAWN_BACKLOG_COMMIT_STATUS=$?
+  if spawn_commit_backlog_transition; then
+    SPAWN_BACKLOG_COMMIT_STATUS=0
+    SPAWN_FRESH_COMMIT_PENDING=0
+  fi
+fi
+if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -ne 0 ]; then
   if [ "$RELAUNCH" -eq 0 ]; then
     if spawn_fresh_commit_rollback; then
       echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); its record was removed so no worker is left that the backlog does not own - close out endpoint $T and local copy $WT by hand, then re-run the spawn" >&2
@@ -3071,6 +3082,15 @@ if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -ne 0 ]; then
 fi
 fm_lock_release "$SPAWN_META_LOCK"
 SPAWN_META_LOCK_HELD=0
+if [ -n "$SPAWN_DEFERRED_SIGNAL" ]; then
+  case "$SPAWN_DEFERRED_SIGNAL" in
+    HUP) SPAWN_DEFERRED_SIGNAL_STATUS=129 ;;
+    INT) SPAWN_DEFERRED_SIGNAL_STATUS=130 ;;
+    TERM) SPAWN_DEFERRED_SIGNAL_STATUS=143 ;;
+  esac
+  echo "error: spawn of $ID was interrupted after launch delivery began; its paired task record and In-flight backlog state were preserved" >&2
+  exit "$SPAWN_DEFERRED_SIGNAL_STATUS"
+fi
 
 SPAWN_DELIVERY=
 [ -z "$MODE" ] || SPAWN_DELIVERY=" mode=$MODE yolo=$YOLO"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3031,6 +3031,18 @@ if [ "$HARNESS" = kimi ]; then
   if [ "$KIMI_DELIVERY_FAILED" = 0 ] && ! kimi_wait_for_delivery; then
     kimi_spawn_fail "kimi brief pointer delivery was not confirmed"
     [ -n "$SPAWN_DEFERRED_SIGNAL" ] || exit 1
+    KIMI_DELIVERY_FAILED=1
+  fi
+  # A deferred signal may make a readiness or delivery probe return failure.
+  # Never turn that failed delivery into a committed In-flight transition.
+  if [ "$KIMI_DELIVERY_FAILED" != 0 ]; then
+    trap - HUP INT TERM
+    case "$SPAWN_DEFERRED_SIGNAL" in
+      HUP) exit 129 ;;
+      INT) exit 130 ;;
+      TERM) exit 143 ;;
+      *) exit 1 ;;
+    esac
   fi
 fi
 if [ "$KIND" = secondmate ] && [ "${FM_SKIP_SECONDMATE_INHERIT:-0}" != 1 ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -689,6 +689,7 @@ SPAWN_META_TMP=
 SPAWN_META_LOCK=
 SPAWN_META_LOCK_HELD=0
 SPAWN_META_PUBLISH_STARTED=0
+SPAWN_FRESH_COMMIT_PENDING=0
 SPAWN_TASK_SET_LOCK=
 SPAWN_TASK_SET_LOCK_HELD=0
 RELAUNCH_REPLACEMENT_PENDING=0
@@ -791,6 +792,13 @@ spawn_abort_cleanup() {
   if [ "$SPAWN_TASK_LOCK_HELD" = 1 ]; then
     SPAWN_TASK_LOCK_HELD=0
     fm_lock_release "$SPAWN_TASK_LOCK" || true
+  fi
+  if [ "$SPAWN_FRESH_COMMIT_PENDING" = 1 ]; then
+    SPAWN_FRESH_COMMIT_PENDING=0
+    rm -f "$STATE/$ID.meta" 2>/dev/null || true
+    if [ -n "${BUSY_GEN:-}" ]; then
+      "$FM_ROOT/bin/fm-busy-event.sh" retire "$STATE" "$ID" --gen "$BUSY_GEN" >/dev/null 2>&1 || true
+    fi
   fi
   if [ "$SPAWN_META_LOCK_HELD" = 1 ]; then
     SPAWN_META_LOCK_HELD=0
@@ -2795,12 +2803,18 @@ preserve_relaunch_meta() {
     echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
   fi
 } > "$SPAWN_META_PATH"
+if [ "$RELAUNCH" -eq 0 ]; then
+  # Until every fallible delivery step has succeeded and the backlog transition
+  # commits below, an ordinary shell error must not leave this provisional
+  # record (or its paired busy generation) behind.
+  SPAWN_FRESH_COMMIT_PENDING=1
+fi
 
 # Fuse the backlog In-flight transition into the publication that just created
 # the record (bin/fm-backlog-transition-lib.sh owns the invariant). It runs under
 # this task's own meta lock, so a steer or teardown racing the same id stays
-# serialized exactly as before, and it runs before the launch below so a failure
-# is still unwindable.
+# serialized exactly as before. The call itself is deferred to the final commit
+# point below so every earlier launch-delivery failure remains unwindable.
 spawn_commit_backlog_transition() {
   local row
   [ "$BACKLOG_TRANSITION" = 1 ] || return 0
@@ -2832,33 +2846,17 @@ if [ "$RELAUNCH" -eq 1 ]; then
   RELAUNCH_REPLACEMENT_PENDING=0
   SPAWN_META_PUBLISH_STARTED=0
   SPAWN_META_TMP=
-  if ! spawn_commit_backlog_transition; then
-    fm_lock_release "$SPAWN_META_LOCK"
-    SPAWN_META_LOCK_HELD=0
-    echo "error: task $ID was republished but its backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); the task's record and local copy are untouched - fix the backlog and re-run the relaunch" >&2
-    exit 1
-  fi
-  fm_lock_release "$SPAWN_META_LOCK"
-  SPAWN_META_LOCK_HELD=0
-else
-  if ! spawn_commit_backlog_transition; then
-    # Remove the record this process just published, and the busy generation
-    # armed alongside it, rather than leave a worker the backlog does not own.
-    # The endpoint and local copy are named because nothing else now points at
-    # them.
-    rm -f "$STATE/$ID.meta"
-    if [ -n "${BUSY_GEN:-}" ]; then
-      "$FM_ROOT/bin/fm-busy-event.sh" retire "$STATE" "$ID" --gen "$BUSY_GEN" \
-        || echo "warning: could not retire the busy generation armed for $ID" >&2
-    fi
-    fm_lock_release "$SPAWN_META_LOCK"
-    SPAWN_META_LOCK_HELD=0
-    echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); its record was removed so no worker is left that the backlog does not own - close out endpoint $T and local copy $WT by hand, then re-run the spawn" >&2
-    exit 1
-  fi
+  # Relaunch replaces an already-owned record and preserves the established
+  # short metadata critical sections used by concurrent durable writers. The
+  # final backlog re-verification reacquires this lock below.
   fm_lock_release "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=0
 fi
+# A fresh dispatch keeps the per-task meta lock through launch delivery. The
+# backlog mutation is deliberately the final fallible commit below, so teardown
+# cannot observe or complete this provisional record between its state check
+# and `tasks-axi start`, and a delivery failure cannot follow a committed
+# In-flight transition.
 if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
   # The record is published, so this task is now part of the set a teardown
   # enumerates and locks per task. The set lock is only needed across that
@@ -2930,10 +2928,15 @@ if [ -z "$SPAWN_TRACEPARENT" ] && [ "$RELAUNCH" -eq 1 ]; then
 fi
 
 spawn_record_traceparent() {
-  local meta="$STATE/$ID.meta" tmp status=0
-  SPAWN_META_LOCK=$(fm_meta_lock_path "$meta") || return 1
-  fm_lock_acquire_wait "$SPAWN_META_LOCK"
-  SPAWN_META_LOCK_HELD=1
+  local meta="$STATE/$ID.meta" status=0 acquired=0
+  # Fresh publication still owns the lock. Relaunch deliberately uses a short
+  # independent critical section so other metadata interfaces can serialize.
+  if [ "$SPAWN_META_LOCK_HELD" != 1 ]; then
+    SPAWN_META_LOCK=$(fm_meta_lock_path "$meta") || return 1
+    fm_lock_acquire_wait "$SPAWN_META_LOCK"
+    SPAWN_META_LOCK_HELD=1
+    acquired=1
+  fi
   SPAWN_META_TMP="$STATE/.$ID.meta.trace.${BASHPID:-$$}"
   if [ ! -f "$meta" ] || [ ! -w "$meta" ] \
      || ! awk -F= '$1 != "traceparent"' "$meta" > "$SPAWN_META_TMP" \
@@ -2943,8 +2946,10 @@ spawn_record_traceparent() {
     rm -f "$SPAWN_META_TMP" 2>/dev/null || true
   fi
   SPAWN_META_TMP=
-  fm_lock_release "$SPAWN_META_LOCK" || status=1
-  SPAWN_META_LOCK_HELD=0
+  if [ "$acquired" = 1 ]; then
+    fm_lock_release "$SPAWN_META_LOCK" || status=1
+    SPAWN_META_LOCK_HELD=0
+  fi
   return "$status"
 }
 
@@ -3010,6 +3015,34 @@ if [ "$KIND" = secondmate ] && [ "${FM_SKIP_SECONDMATE_INHERIT:-0}" != 1 ]; then
     fi
   fi
 fi
+
+# This is the commit point: all endpoint and harness delivery that can reject
+# the spawn has succeeded. Re-read and transition while holding the same
+# per-task lock as metadata publication, then and only then report success.
+if [ "$SPAWN_META_LOCK_HELD" != 1 ]; then
+  SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
+  fm_lock_acquire_wait "$SPAWN_META_LOCK"
+  SPAWN_META_LOCK_HELD=1
+fi
+if ! spawn_commit_backlog_transition; then
+  if [ "$RELAUNCH" -eq 0 ]; then
+    rm -f "$STATE/$ID.meta"
+    SPAWN_FRESH_COMMIT_PENDING=0
+    if [ -n "${BUSY_GEN:-}" ]; then
+      "$FM_ROOT/bin/fm-busy-event.sh" retire "$STATE" "$ID" --gen "$BUSY_GEN" \
+        || echo "warning: could not retire the busy generation armed for $ID" >&2
+    fi
+    echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); its record was removed so no worker is left that the backlog does not own - close out endpoint $T and local copy $WT by hand, then re-run the spawn" >&2
+  else
+    echo "error: task $ID was republished but its backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); fix the backlog and re-run the relaunch" >&2
+  fi
+  fm_lock_release "$SPAWN_META_LOCK"
+  SPAWN_META_LOCK_HELD=0
+  exit 1
+fi
+SPAWN_FRESH_COMMIT_PENDING=0
+fm_lock_release "$SPAWN_META_LOCK"
+SPAWN_META_LOCK_HELD=0
 
 SPAWN_DELIVERY=
 [ -z "$MODE" ] || SPAWN_DELIVERY=" mode=$MODE yolo=$YOLO"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3043,15 +3043,11 @@ if [ "$HARNESS" = kimi ]; then
     KIMI_DELIVERY_FAILED=1
   fi
   # A deferred signal may make a readiness or delivery probe return failure.
-  # Never turn that failed delivery into a committed In-flight transition.
-  if [ "$KIMI_DELIVERY_FAILED" != 0 ]; then
+  # Enter has already started a live worker, so keep going to the common commit
+  # point and preserve its durable ownership before honoring that signal.
+  if [ "$KIMI_DELIVERY_FAILED" != 0 ] && [ -z "$SPAWN_DEFERRED_SIGNAL" ]; then
     trap - HUP INT TERM
-    case "$SPAWN_DEFERRED_SIGNAL" in
-      HUP) exit 129 ;;
-      INT) exit 130 ;;
-      TERM) exit 143 ;;
-      *) exit 1 ;;
-    esac
+    exit 1
   fi
 fi
 if [ "$KIND" = secondmate ] && [ "${FM_SKIP_SECONDMATE_INHERIT:-0}" != 1 ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -708,11 +708,65 @@ RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
 
+spawn_endpoint_confirmed_gone() {
+  local session window panes workspaces expected_title presence
+  case "$BACKEND" in
+    tmux)
+      case "$T" in
+        *:*) session=${T%%:*}; window=${T#*:} ;;
+        *) return 1 ;;
+      esac
+      [ -n "$session" ] && [ -n "$window" ] && [ "$window" != "$T" ] || return 1
+      panes=$(tmux list-windows -t "=$session" -F '#{window_name}' 2>/dev/null) || return 1
+      ! printf '%s\n' "$panes" | grep -Fxq -- "$window"
+      ;;
+    herdr)
+      fm_backend_source herdr || return 1
+      fm_backend_herdr_endpoint_confirmed_gone "$T"
+      ;;
+    zellij)
+      fm_backend_source zellij || return 1
+      fm_backend_zellij_parse_target "$T" || return 1
+      panes=$(fm_backend_zellij_cli "$FM_BACKEND_ZELLIJ_SESSION" action list-panes --json 2>/dev/null) \
+        || return 1
+      presence=$(printf '%s' "$panes" | jq -er --argjson pane "$FM_BACKEND_ZELLIJ_PANE" '
+        if type != "array" then error("invalid pane inventory")
+        elif any(.[]; .id == $pane and .is_plugin == false) then "present"
+        else "gone"
+        end
+      ' 2>/dev/null) || return 1
+      [ "$presence" = gone ]
+      ;;
+    cmux)
+      fm_backend_source cmux || return 1
+      fm_backend_cmux_parse_target "$T" || return 1
+      workspaces=$(fm_backend_cmux_cli workspace list --json --id-format uuids 2>/dev/null) \
+        || return 1
+      expected_title=$(fm_backend_cmux_scoped_title "fm-$ID")
+      presence=$(printf '%s' "$workspaces" | jq -er \
+        --arg workspace "$FM_BACKEND_CMUX_WORKSPACE" --arg title "$expected_title" '
+        if (.workspaces | type) != "array" then error("invalid workspace inventory")
+        elif any(.workspaces[]; .id == $workspace or .title == $title) then "present"
+        else "gone"
+        end
+      ' 2>/dev/null) || return 1
+      [ "$presence" = gone ]
+      ;;
+    orca) return 1 ;;
+    *) return 1 ;;
+  esac
+}
+
 spawn_fresh_commit_rollback() {
   if [ "$SPAWN_WORKER_LIVE" = 1 ]; then
     fm_backend_kill "$BACKEND" "$T" '' "fm-$ID" >/dev/null 2>&1 || true
     if fm_backend_target_exists "$BACKEND" "$T" "fm-$ID"; then
       FM_BACKLOG_TRANSITION_ERROR="failed-dispatch endpoint $T remains live; retaining task and busy records for $ID"
+      echo "error: $FM_BACKLOG_TRANSITION_ERROR" >&2
+      return 1
+    fi
+    if ! spawn_endpoint_confirmed_gone; then
+      FM_BACKLOG_TRANSITION_ERROR="failed-dispatch endpoint $T could not be confirmed gone; retaining task and busy records for $ID"
       echo "error: $FM_BACKLOG_TRANSITION_ERROR" >&2
       return 1
     fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3003,11 +3003,13 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   spawn_herdr_presentation_order_lock_release
 fi
 SPAWN_DEFERRED_SIGNAL=
-if [ "$BACKLOG_TRANSITION" = 1 ]; then
-  trap 'SPAWN_DEFERRED_SIGNAL=HUP' HUP
-  trap 'SPAWN_DEFERRED_SIGNAL=INT' INT
-  trap 'SPAWN_DEFERRED_SIGNAL=TERM' TERM
-fi
+# Once Enter submits the launch, every spawn owns a live worker, including homes
+# exempt from automatic backlog transitions. Defer termination until the common
+# commit point disarms EXIT rollback, or cleanup would erase an exempt worker's
+# published ownership records after its launch had already started.
+trap 'SPAWN_DEFERRED_SIGNAL=HUP' HUP
+trap 'SPAWN_DEFERRED_SIGNAL=INT' INT
+trap 'SPAWN_DEFERRED_SIGNAL=TERM' TERM
 spawn_send_key "$T" Enter
 if [ "$HARNESS" = kimi ]; then
   KIMI_DELIVERY_FAILED=0
@@ -3102,7 +3104,11 @@ if [ -n "$SPAWN_DEFERRED_SIGNAL" ]; then
     INT) SPAWN_DEFERRED_SIGNAL_STATUS=130 ;;
     TERM) SPAWN_DEFERRED_SIGNAL_STATUS=143 ;;
   esac
-  echo "error: spawn of $ID was interrupted after launch delivery began; its paired task record and In-flight backlog state were preserved" >&2
+  if [ "$BACKLOG_TRANSITION" = 1 ]; then
+    echo "error: spawn of $ID was interrupted after launch delivery began; its paired task record and In-flight backlog state were preserved" >&2
+  else
+    echo "error: spawn of $ID was interrupted after launch delivery began; its published task and busy records were preserved" >&2
+  fi
   exit "$SPAWN_DEFERRED_SIGNAL_STATUS"
 fi
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1709,7 +1709,7 @@ else
   WT=""
   BRIEF="$DATA/$ID/brief.md"
 fi
-[ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
+[ -f "$BRIEF" ] || { echo "error: task $ID has no brief at inaccessible data path $BRIEF" >&2; exit 1; }
 
 delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task mode
   case "$1" in
@@ -1982,6 +1982,12 @@ if fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
       exit 1
       ;;
   esac
+else
+  BACKLOG_GATE_STATUS=$?
+  if [ "$BACKLOG_GATE_STATUS" -eq 2 ]; then
+    echo "error: task $ID cannot be dispatched because its backlog data directory is inaccessible: $DATA ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+    exit 1
+  fi
 fi
 
 W="fm-$ID"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2949,6 +2949,13 @@ spawn_record_traceparent() {
   return "$status"
 }
 
+# Once launch delivery can start the worker, defer catchable interruption until
+# the paired backlog state is committed. Otherwise a signal after Enter but
+# before tasks-axi could leave a running worker whose provisional record EXIT
+# cleanup removes. Commands run directly by this shell inherit the ignored
+# dispositions; explicit delivery failures still exit through ordinary cleanup.
+trap '' HUP INT TERM
+
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.
@@ -3020,12 +3027,17 @@ if [ "$SPAWN_META_LOCK_HELD" != 1 ]; then
   fm_lock_acquire_wait "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=1
 fi
-# From this point a process-level interruption must preserve the published
-# record: it is the durable recovery evidence when interruption lands inside
-# the backlog mutation. An ordinary returned transition failure still performs
-# the complete record and busy-generation unwind below.
-SPAWN_FRESH_COMMIT_PENDING=0
-if ! spawn_commit_backlog_transition; then
+# Complete the uninterruptible catchable-signal region begun before launch
+# delivery. Clearing the provisional flag before tasks-axi could preserve a
+# queued record; clearing it after tasks-axi could let EXIT cleanup delete an
+# In-flight record. Keeping signals ignored across both operations closes both
+# races. An uncatchable crash still leaves the published record for bootstrap
+# recovery.
+SPAWN_BACKLOG_COMMIT_STATUS=0
+if spawn_commit_backlog_transition; then
+  SPAWN_FRESH_COMMIT_PENDING=0
+else
+  SPAWN_BACKLOG_COMMIT_STATUS=$?
   if [ "$RELAUNCH" -eq 0 ]; then
     rm -f "$STATE/$ID.meta"
     SPAWN_FRESH_COMMIT_PENDING=0
@@ -3037,9 +3049,12 @@ if ! spawn_commit_backlog_transition; then
   else
     echo "error: task $ID was republished but its backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); fix the backlog and re-run the relaunch" >&2
   fi
+fi
+trap - HUP INT TERM
+if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -ne 0 ]; then
   fm_lock_release "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=0
-  exit 1
+  exit "$SPAWN_BACKLOG_COMMIT_STATUS"
 fi
 fm_lock_release "$SPAWN_META_LOCK"
 SPAWN_META_LOCK_HELD=0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -185,6 +185,18 @@
 # resolver because `cursor` is not the CLI name. A cursor SECONDMATE instead runs
 # the tracked project-scope .cursor/hooks.json in its own home, whose stop-hook
 # park owns that home's supervision (docs/supervision-protocols/cursor.md).
+# Publishing the record and moving this home's backlog item to In flight are one
+# step, not two: bin/fm-backlog-transition-lib.sh owns that invariant, and this
+# script performs the transition under the task's own meta lock before it reports
+# success. A ship or scout dispatch therefore REFUSES up front, before any
+# endpoint, worktree, or record exists, when the home's backlog has no item for
+# the id or already records it as finished, and a transition that fails after
+# publication removes the record it just wrote rather than leaving a worker the
+# backlog does not own. A relaunch re-reads the row instead of re-running the
+# transition, so an already In-flight item is left untouched. The transition is
+# skipped entirely for --secondmate spawns (persistent agents are not work
+# items), on a config/backlog-backend=manual home, without a compatible
+# tasks-axi, and in a home that keeps no data/backlog.md.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> [mode=<mode> yolo=<on|off>] window=<backend-target> worktree=<path>
 # A ship task records the explicit mode/yolo it was passed; a secondmate spawn records
 # mode=secondmate, yolo=off, home=, and projects=; a scout records neither, and both the
@@ -269,6 +281,10 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-trace-context-lib.sh"
 # shellcheck source=bin/fm-remote-readiness-lib.sh
 . "$SCRIPT_DIR/fm-remote-readiness-lib.sh"
+# shellcheck source=bin/fm-tasks-axi-lib.sh
+. "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-backlog-transition-lib.sh
+. "$SCRIPT_DIR/fm-backlog-transition-lib.sh"
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
 # a direct report (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent
@@ -1915,6 +1931,28 @@ herdr_projection_existing_meta_allows_flat() {  # <meta>
   esac
 }
 
+# Backlog preflight (bin/fm-backlog-transition-lib.sh). This spawn is about to
+# become the sole owner of the row's In-flight transition, so prove the row is
+# transitionable BEFORE any endpoint, worktree, or record exists: a refusal here
+# costs nothing to unwind, while the same refusal after publication would strand
+# a live pane. The authoritative mutation still runs under the meta lock below.
+BACKLOG_TRANSITION=0
+BACKLOG_ROW_STATE=
+if fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
+  BACKLOG_TRANSITION=1
+  BACKLOG_ROW_STATE=$(fm_backlog_row_state "$DATA" "$ID" || true)
+  case "$BACKLOG_ROW_STATE" in
+    '')
+      echo "error: task $ID has no backlog item in this home, so dispatching it would leave a worker no record owns; add it first (tasks-axi add $ID '<title>' --kind $KIND) and re-run" >&2
+      exit 1
+      ;;
+    done\ *)
+      echo "error: this home's backlog records $ID as finished; refusing to dispatch onto a closed item (reopen it with tasks-axi reopen $ID, or use a new task id)" >&2
+      exit 1
+      ;;
+  esac
+fi
+
 W="fm-$ID"
 if [ "$RELAUNCH" -eq 1 ]; then
   # Adopt the recorded endpoint instead of creating one. This is what keeps a
@@ -2757,14 +2795,65 @@ preserve_relaunch_meta() {
     echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
   fi
 } > "$SPAWN_META_PATH"
+
+# Fuse the backlog In-flight transition into the publication that just created
+# the record (bin/fm-backlog-transition-lib.sh owns the invariant). It runs under
+# this task's own meta lock, so a steer or teardown racing the same id stays
+# serialized exactly as before, and it runs before the launch below so a failure
+# is still unwindable.
+spawn_commit_backlog_transition() {
+  local row
+  [ "$BACKLOG_TRANSITION" = 1 ] || return 0
+  # Re-verify rather than assume. A relaunch republishes a record whose row is
+  # normally already In flight, and blindly re-running the transition on a row
+  # tasks-axi has since closed would silently resurrect it.
+  row=$(fm_backlog_row_state "$DATA" "$ID" || true)
+  case "$row" in
+    in_flight\ *) return 0 ;;
+  esac
+  fm_backlog_start "$DATA" "$ID"
+}
+
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_PUBLISH_STARTED=1
   mv -f "$SPAWN_META_TMP" "$STATE/$ID.meta"
   RELAUNCH_REPLACEMENT_PENDING=0
   SPAWN_META_PUBLISH_STARTED=0
   SPAWN_META_TMP=
+  if ! spawn_commit_backlog_transition; then
+    fm_lock_release "$SPAWN_META_LOCK"
+    SPAWN_META_LOCK_HELD=0
+    echo "error: task $ID was republished but its backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); the task's record and local copy are untouched - fix the backlog and re-run the relaunch" >&2
+    exit 1
+  fi
   fm_lock_release "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=0
+else
+  # The fresh path published the record under the task-set lock; take this task's
+  # own meta lock for the paired backlog transition, matching every other
+  # single-record mutation in this file.
+  if [ "$BACKLOG_TRANSITION" = 1 ]; then
+    SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
+    fm_lock_acquire_wait "$SPAWN_META_LOCK"
+    SPAWN_META_LOCK_HELD=1
+    if ! spawn_commit_backlog_transition; then
+      # Remove the record this process just published, and the busy generation
+      # armed alongside it, rather than leave a worker the backlog does not own.
+      # The endpoint and local copy are named because nothing else now points at
+      # them.
+      rm -f "$STATE/$ID.meta"
+      if [ -n "${BUSY_GEN:-}" ]; then
+        "$FM_ROOT/bin/fm-busy-event.sh" retire "$STATE" "$ID" --gen "$BUSY_GEN" \
+          || echo "warning: could not retire the busy generation armed for $ID" >&2
+      fi
+      fm_lock_release "$SPAWN_META_LOCK"
+      SPAWN_META_LOCK_HELD=0
+      echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); its record was removed so no worker is left that the backlog does not own - close out endpoint $T and local copy $WT by hand, then re-run the spawn" >&2
+      exit 1
+    fi
+    fm_lock_release "$SPAWN_META_LOCK"
+    SPAWN_META_LOCK_HELD=0
+  fi
 fi
 if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
   # The record is published, so this task is now part of the set a teardown

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -233,8 +233,18 @@ esac
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 
+# shellcheck source=bin/fm-tasks-axi-lib.sh
+. "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-backlog-transition-lib.sh
+. "$SCRIPT_DIR/fm-backlog-transition-lib.sh"
+
 resolve_directory_input() {
-  local name=$1 path=$2 resolved
+  local name=$1 path=$2 resolved raw_bytes
+  raw_bytes=$(printf '%s' "$path" | LC_ALL=C od -An -t u1) || return 1
+  if ! fm_backlog_control_bytes_valid 0 "$raw_bytes"; then
+    echo "error: $name directory contains an invalid control byte" >&2
+    return 1
+  fi
   case "$path" in
     /*) printf '%s\n' "$path"; return 0 ;;
   esac
@@ -281,10 +291,6 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-trace-context-lib.sh"
 # shellcheck source=bin/fm-remote-readiness-lib.sh
 . "$SCRIPT_DIR/fm-remote-readiness-lib.sh"
-# shellcheck source=bin/fm-tasks-axi-lib.sh
-. "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
-# shellcheck source=bin/fm-backlog-transition-lib.sh
-. "$SCRIPT_DIR/fm-backlog-transition-lib.sh"
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
 # a direct report (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2730,10 +2730,10 @@ META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
 SPAWN_GEN="s$(date +%s).${BASHPID:-$$}.$RANDOM"
 SPAWN_META_PATH="$STATE/$ID.meta"
+SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
+fm_lock_acquire_wait "$SPAWN_META_LOCK"
+SPAWN_META_LOCK_HELD=1
 if [ "$RELAUNCH" -eq 1 ]; then
-  SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
-  fm_lock_acquire_wait "$SPAWN_META_LOCK"
-  SPAWN_META_LOCK_HELD=1
   SPAWN_META_TMP="$STATE/.$ID.meta.relaunch.${BASHPID:-$$}"
   SPAWN_META_PATH=$SPAWN_META_TMP
 fi
@@ -2829,31 +2829,23 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fm_lock_release "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=0
 else
-  # The fresh path published the record under the task-set lock; take this task's
-  # own meta lock for the paired backlog transition, matching every other
-  # single-record mutation in this file.
-  if [ "$BACKLOG_TRANSITION" = 1 ]; then
-    SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
-    fm_lock_acquire_wait "$SPAWN_META_LOCK"
-    SPAWN_META_LOCK_HELD=1
-    if ! spawn_commit_backlog_transition; then
-      # Remove the record this process just published, and the busy generation
-      # armed alongside it, rather than leave a worker the backlog does not own.
-      # The endpoint and local copy are named because nothing else now points at
-      # them.
-      rm -f "$STATE/$ID.meta"
-      if [ -n "${BUSY_GEN:-}" ]; then
-        "$FM_ROOT/bin/fm-busy-event.sh" retire "$STATE" "$ID" --gen "$BUSY_GEN" \
-          || echo "warning: could not retire the busy generation armed for $ID" >&2
-      fi
-      fm_lock_release "$SPAWN_META_LOCK"
-      SPAWN_META_LOCK_HELD=0
-      echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); its record was removed so no worker is left that the backlog does not own - close out endpoint $T and local copy $WT by hand, then re-run the spawn" >&2
-      exit 1
+  if ! spawn_commit_backlog_transition; then
+    # Remove the record this process just published, and the busy generation
+    # armed alongside it, rather than leave a worker the backlog does not own.
+    # The endpoint and local copy are named because nothing else now points at
+    # them.
+    rm -f "$STATE/$ID.meta"
+    if [ -n "${BUSY_GEN:-}" ]; then
+      "$FM_ROOT/bin/fm-busy-event.sh" retire "$STATE" "$ID" --gen "$BUSY_GEN" \
+        || echo "warning: could not retire the busy generation armed for $ID" >&2
     fi
     fm_lock_release "$SPAWN_META_LOCK"
     SPAWN_META_LOCK_HELD=0
+    echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); its record was removed so no worker is left that the backlog does not own - close out endpoint $T and local copy $WT by hand, then re-run the spawn" >&2
+    exit 1
   fi
+  fm_lock_release "$SPAWN_META_LOCK"
+  SPAWN_META_LOCK_HELD=0
 fi
 if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
   # The record is published, so this task is now part of the set a teardown

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -707,6 +707,7 @@ if [ -z "$BUSY_GEN" ]; then
 fi
 ORCA_WORKTREE_ID=$(fm_meta_get "$META" orca_worktree_id)
 ORCA_PATH_MATCH_VERIFIED=0
+CLEANUP_RECOVERY=$(fm_meta_get "$META" cleanup_recovery)
 
 KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
 [ -n "$KIND" ] || KIND=ship
@@ -1177,6 +1178,7 @@ backlog_done_args() {
 # only where a human still owes the edit.
 backlog_refresh_reminder() {
   [ "$KIND" = secondmate ] && return 0
+  [ "$CLEANUP_RECOVERY" = orca ] && return 0
   if [ "$BACKLOG_CLOSED" = 1 ]; then
     printf '%s\n' "Backlog: $ID is closed in data/backlog.md. Run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due."
   else
@@ -2845,7 +2847,8 @@ status_retire_presentation_task "$STATE" "$ID" || exit 1
 # for the next session start to finish it (bin/fm-backlog-transition-lib.sh).
 BACKLOG_CLOSED=0
 BACKLOG_SKIP_REASON=
-if fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
+if [ "$CLEANUP_RECOVERY" != orca ] \
+   && fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
   BACKLOG_CLOSED=1
   backlog_done_args
   META_SPAWN_GEN=$(fm_meta_get "$META" spawn_gen)
@@ -2853,7 +2856,11 @@ if fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
     "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}" \
     || { echo "error: the pending backlog close for $ID could not be recorded; retaining every durable task record" >&2; exit 1; }
 else
-  BACKLOG_SKIP_REASON=$FM_BACKLOG_TRANSITION_SKIP
+  if [ "$CLEANUP_RECOVERY" = orca ]; then
+    BACKLOG_SKIP_REASON="Orca cleanup recovery is not a launched backlog worker"
+  else
+    BACKLOG_SKIP_REASON=$FM_BACKLOG_TRANSITION_SKIP
+  fi
 fi
 rm -f "$STATE/$ID.turn-ended" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -12,8 +12,8 @@
 # record being removed, the intended close is recorded in
 # state/<id>.backlog-close first, so a process killed between the halves leaves
 # the next session start enough to finish it; a landed close removes that record.
-# A close that fails is fatal and loud - the printed follow-up then names the
-# hand edit that is still owed. The transition is skipped on a
+# A close that fails is fatal and loud, preserves its pending-close record, and
+# is retried by the next session start. The transition is skipped on a
 # config/backlog-backend=manual home, without a compatible tasks-axi, and in a
 # home that keeps no data/backlog.md; those cases print the manual follow-up.
 # None of this loosens the landed-work gates below: the transition runs only on

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -270,6 +270,16 @@ META_LOCK=$(fm_meta_lock_path "$META") || exit 1
 fm_lock_acquire_wait "$META_LOCK"
 META_LOCK_HELD=1
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+TEARDOWN_META_KIND=$(fm_meta_get "$META" kind)
+[ -n "$TEARDOWN_META_KIND" ] || TEARDOWN_META_KIND=ship
+TEARDOWN_CLEANUP_RECOVERY=$(fm_meta_get "$META" cleanup_recovery)
+TEARDOWN_META_SPAWN_GEN=$(fm_meta_get "$META" spawn_gen)
+if [ "$TEARDOWN_CLEANUP_RECOVERY" != orca ] \
+   && fm_backlog_transition_applies "$CONFIG" "$DATA" "$TEARDOWN_META_KIND" \
+   && [ -z "$TEARDOWN_META_SPAWN_GEN" ]; then
+  echo "error: task $ID's record has no spawn_gen; refusing automatic teardown because a durable backlog close cannot identify this incarnation - relaunch the task to publish an incarnation, then retry teardown" >&2
+  exit 1
+fi
 
 REMOTE_HANDOFF_DIR_PRESENT=0
 REMOTE_HANDOFF_DIR_REAL=
@@ -707,10 +717,9 @@ if [ -z "$BUSY_GEN" ]; then
 fi
 ORCA_WORKTREE_ID=$(fm_meta_get "$META" orca_worktree_id)
 ORCA_PATH_MATCH_VERIFIED=0
-CLEANUP_RECOVERY=$(fm_meta_get "$META" cleanup_recovery)
+CLEANUP_RECOVERY=$TEARDOWN_CLEANUP_RECOVERY
 
-KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
-[ -n "$KIND" ] || KIND=ship
+KIND=$TEARDOWN_META_KIND
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ -n "$MODE" ] || MODE=no-mistakes
 PUBLIC_FOLLOWUP_HOME=$FM_HOME
@@ -2851,7 +2860,7 @@ if [ "$CLEANUP_RECOVERY" != orca ] \
    && fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
   BACKLOG_CLOSED=1
   backlog_done_args
-  META_SPAWN_GEN=$(fm_meta_get "$META" spawn_gen)
+  META_SPAWN_GEN=$TEARDOWN_META_SPAWN_GEN
   fm_backlog_close_marker_write "$STATE" "$ID" "$DATA" "$META_SPAWN_GEN" \
     "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}" \
     || { echo "error: the pending backlog close for $ID could not be recorded; retaining every durable task record" >&2; exit 1; }

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -649,7 +649,8 @@ remote_secondmate_teardown() {
   grep -vE "^- $ID( |$)" "$SECONDMATE_REG" > "$tmp" || true
   mv -f -- "$tmp" "$SECONDMATE_REG"
   status_retire_presentation_task "$STATE" "$ID" || return 1
-  rm -f -- "$STATE/$ID.meta" "$STATE/$ID.turn-ended"
+  fm_backlog_atomic_transition remove "$STATE/$ID.meta" "task record" || return 1
+  rm -f -- "$STATE/$ID.turn-ended"
   printf 'teardown %s complete (remote %s:%s)\n' "$ID" "$remote_host" "$remote_home"
   return 0
 }
@@ -2521,8 +2522,9 @@ cleanup_firstmate_home_children() {
     fi
     retire_busy_state "$sub_state" "$child_id" "$child_busy_gen" || return 1
     status_retire_presentation_task "$sub_state" "$child_id" || return 1
+    fm_backlog_atomic_transition remove "$sub_state/$child_id.meta" "task record" || return 1
     rm -f "$sub_state/$child_id.turn-ended" \
-      "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
+      "$sub_state/$child_id.pi-ext.ts" \
       "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
       "$sub_state/$child_id.muse-session" "$sub_state/$child_id.muse-session-current" \
       "$sub_state/$child_id.cursor-session" "$sub_state/$child_id.reconcile-nudged"
@@ -2853,7 +2855,7 @@ if fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
 else
   BACKLOG_SKIP_REASON=$FM_BACKLOG_TRANSITION_SKIP
 fi
-rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
+rm -f "$STATE/$ID.turn-ended" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
   "$STATE/$ID.muse-session-current" "$STATE/$ID.cursor-session" \
@@ -2868,18 +2870,19 @@ rm -rf "$STATE/$ID.inbox"
 # when teardown reports success. Still under this task's meta lock, so a steer
 # racing the same id stays serialized exactly as it was before.
 if [ "$BACKLOG_CLOSED" = 1 ]; then
-  if fm_backlog_done "$DATA" "$ID" \
-      "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}"; then
-    if ! fm_backlog_close_marker_clear "$STATE" "$ID"; then
-      fm_lock_release "$META_LOCK"
-      META_LOCK_HELD=0
-      echo "error: $ID's backlog item is closed, but its pending-close record could not be removed ($FM_BACKLOG_TRANSITION_ERROR); teardown is incomplete and the next session start retries the removal" >&2
-      exit 1
-    fi
-  else
+  BACKLOG_CLOSE_MARKER=$(fm_backlog_close_marker_path "$STATE" "$ID") || exit 1
+  if ! fm_backlog_atomic_transition close "$STATE/$ID.meta" "$BACKLOG_CLOSE_MARKER" \
+      "$DATA" "$ID" "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}"; then
     fm_lock_release "$META_LOCK"
     META_LOCK_HELD=0
-    echo "error: $ID's endpoint and local copy are cleaned up, but its backlog item could not be closed ($FM_BACKLOG_TRANSITION_ERROR); the pending close is recorded and the next session start retries it - fix the backlog if it does not clear" >&2
+    echo "error: $ID's endpoint and local copy are cleaned up, but its backlog item could not be closed atomically ($FM_BACKLOG_TRANSITION_ERROR); the pending close is recorded and the next session start retries it" >&2
+    exit 1
+  fi
+else
+  if ! fm_backlog_atomic_transition remove "$STATE/$ID.meta" "task record"; then
+    fm_lock_release "$META_LOCK"
+    META_LOCK_HELD=0
+    echo "error: $ID's endpoint and local copy are cleaned up, but its task record could not be removed ($FM_BACKLOG_TRANSITION_ERROR)" >&2
     exit 1
   fi
 fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2870,7 +2870,12 @@ rm -rf "$STATE/$ID.inbox"
 if [ "$BACKLOG_CLOSED" = 1 ]; then
   if fm_backlog_done "$DATA" "$ID" \
       "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}"; then
-    fm_backlog_close_marker_clear "$STATE" "$ID"
+    if ! fm_backlog_close_marker_clear "$STATE" "$ID"; then
+      fm_lock_release "$META_LOCK"
+      META_LOCK_HELD=0
+      echo "error: $ID's backlog item is closed, but its pending-close record could not be removed ($FM_BACKLOG_TRANSITION_ERROR); teardown is incomplete and the next session start retries the removal" >&2
+      exit 1
+    fi
   else
     fm_lock_release "$META_LOCK"
     META_LOCK_HELD=0

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1113,17 +1113,20 @@ EOF
 # current work is not contained in the PR head, no PR is found, or any gh error
 # occurs - the caller then falls back to the content check.
 pr_is_merged() {
-  local branch=$1 target view state head current
+  local branch=$1 target view state remainder head resolved_url current landed=0
   if [ -n "$PR_URL" ]; then
     target=$PR_URL
   else
     target=$(pr_number_from_branch "$branch") || return 1
   fi
   [ -n "$target" ] || return 1
-  view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid -q '.state + "\t" + .headRefOid' 2>/dev/null) || return 1
+  view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid,url -q '.state + "\t" + .headRefOid + "\t" + .url' 2>/dev/null) || return 1
   state=${view%%$'\t'*}
-  head=${view#*$'\t'}
+  remainder=${view#*$'\t'}
   [ "$state" != "$view" ] || return 1
+  head=${remainder%%$'\t'*}
+  resolved_url=${remainder#*$'\t'}
+  [ "$head" != "$remainder" ] || return 1
   case "$state" in
     MERGED|merged) ;;
     *) return 1 ;;
@@ -1131,8 +1134,17 @@ pr_is_merged() {
   [ -n "$head" ] || return 1
   ensure_commit_object "$target" "$head" || return 1
   current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
-  git -C "$WT" merge-base --is-ancestor "$current" "$head" 2>/dev/null && return 0
-  unpushed_patches_are_in_pr_head "$head"
+  if git -C "$WT" merge-base --is-ancestor "$current" "$head" 2>/dev/null; then
+    landed=1
+  elif unpushed_patches_are_in_pr_head "$head"; then
+    landed=1
+  fi
+  [ "$landed" = 1 ] || return 1
+  if [ -z "$PR_URL" ]; then
+    [ -n "$resolved_url" ] || return 1
+    PR_URL=$resolved_url
+  fi
+  return 0
 }
 
 # Is the branch's content already present in the up-to-date default branch? Fetches
@@ -1198,12 +1210,18 @@ backlog_done_args() {
 # invariant). This prints what already happened, so the follow-up wording stays
 # only where a human still owes the edit.
 backlog_refresh_reminder() {
+  local data_relative backlog_display
   [ "$KIND" = secondmate ] && return 0
   [ "$CLEANUP_RECOVERY" = orca ] && return 0
-  if [ "$BACKLOG_CLOSED" = 1 ]; then
-    printf '%s\n' "Backlog: $ID is closed in data/backlog.md. Run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due."
+  if data_relative=$(fm_backlog_data_relative "$DATA"); then
+    backlog_display="$data_relative/backlog.md"
   else
-    printf '%s\n' "Backlog: $ID just finished ($BACKLOG_SKIP_REASON). Update data/backlog.md - move $ID to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due."
+    backlog_display="${DATA%/}/backlog.md"
+  fi
+  if [ "$BACKLOG_CLOSED" = 1 ]; then
+    printf '%s\n' "Backlog: $ID is closed in $backlog_display. Run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due."
+  else
+    printf '%s\n' "Backlog: $ID just finished ($BACKLOG_SKIP_REASON). Update $backlog_display - move $ID to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due."
   fi
 }
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -274,9 +274,21 @@ TEARDOWN_META_KIND=$(fm_meta_get "$META" kind)
 [ -n "$TEARDOWN_META_KIND" ] || TEARDOWN_META_KIND=ship
 TEARDOWN_CLEANUP_RECOVERY=$(fm_meta_get "$META" cleanup_recovery)
 TEARDOWN_META_SPAWN_GEN=$(fm_meta_get "$META" spawn_gen)
-if [ "$TEARDOWN_CLEANUP_RECOVERY" != orca ] \
-   && fm_backlog_transition_applies "$CONFIG" "$DATA" "$TEARDOWN_META_KIND" \
-   && [ -z "$TEARDOWN_META_SPAWN_GEN" ]; then
+TEARDOWN_BACKLOG_APPLIES=0
+TEARDOWN_BACKLOG_SKIP_REASON=
+if [ "$TEARDOWN_CLEANUP_RECOVERY" != orca ]; then
+  if fm_backlog_transition_applies "$CONFIG" "$DATA" "$TEARDOWN_META_KIND"; then
+    TEARDOWN_BACKLOG_APPLIES=1
+  else
+    TEARDOWN_BACKLOG_GATE_STATUS=$?
+    if [ "$TEARDOWN_BACKLOG_GATE_STATUS" -eq 2 ]; then
+      echo "error: task $ID cannot be torn down because its backlog data directory is inaccessible: $DATA ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+      exit 1
+    fi
+    TEARDOWN_BACKLOG_SKIP_REASON=$FM_BACKLOG_TRANSITION_SKIP
+  fi
+fi
+if [ "$TEARDOWN_BACKLOG_APPLIES" = 1 ] && [ -z "$TEARDOWN_META_SPAWN_GEN" ]; then
   echo "error: task $ID's record has no spawn_gen; refusing automatic teardown because a durable backlog close cannot identify this incarnation - relaunch the task to publish an incarnation, then retry teardown" >&2
   exit 1
 fi
@@ -2856,8 +2868,7 @@ status_retire_presentation_task "$STATE" "$ID" || exit 1
 # for the next session start to finish it (bin/fm-backlog-transition-lib.sh).
 BACKLOG_CLOSED=0
 BACKLOG_SKIP_REASON=
-if [ "$CLEANUP_RECOVERY" != orca ] \
-   && fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
+if [ "$TEARDOWN_BACKLOG_APPLIES" = 1 ]; then
   BACKLOG_CLOSED=1
   backlog_done_args
   META_SPAWN_GEN=$TEARDOWN_META_SPAWN_GEN
@@ -2868,7 +2879,7 @@ else
   if [ "$CLEANUP_RECOVERY" = orca ]; then
     BACKLOG_SKIP_REASON="Orca cleanup recovery is not a launched backlog worker"
   else
-    BACKLOG_SKIP_REASON=$FM_BACKLOG_TRANSITION_SKIP
+    BACKLOG_SKIP_REASON=$TEARDOWN_BACKLOG_SKIP_REASON
   fi
 fi
 rm -f "$STATE/$ID.turn-ended" \

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2706,6 +2706,24 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
   fi
 fi
 
+if [ "$TEARDOWN_BACKLOG_APPLIES" = 1 ]; then
+  backlog_done_args || {
+    echo "error: the pending backlog close for $ID is not replayable; refusing destructive teardown" >&2
+    exit 1
+  }
+  BACKLOG_CLOSE_PREFLIGHT="$STATE/.$ID.backlog-close.preflight.${BASHPID:-$$}"
+  fm_backlog_close_marker_stage "$BACKLOG_CLOSE_PREFLIGHT" "$ID" "$DATA" \
+    "$TEARDOWN_META_SPAWN_GEN" "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}" \
+    || {
+      echo "error: the pending backlog close for $ID is not replayable ($FM_BACKLOG_TRANSITION_ERROR); refusing destructive teardown" >&2
+      exit 1
+    }
+  rm -f "$BACKLOG_CLOSE_PREFLIGHT" || {
+    echo "error: the pending backlog close preflight for $ID could not be removed; refusing destructive teardown" >&2
+    exit 1
+  }
+fi
+
 # Every landed/discard-work refusal above has now passed (or --force skipped
 # them). Fix 1 and Fix 2 (see script header) run here, unconditionally on
 # --force, and before ANY destructive step below - a still-parked run or a
@@ -2888,7 +2906,6 @@ BACKLOG_CLOSED=0
 BACKLOG_SKIP_REASON=
 if [ "$TEARDOWN_BACKLOG_APPLIES" = 1 ]; then
   BACKLOG_CLOSED=1
-  backlog_done_args
   META_SPAWN_GEN=$TEARDOWN_META_SPAWN_GEN
   fm_backlog_close_marker_write "$STATE" "$ID" "$DATA" "$META_SPAWN_GEN" \
     "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}" \

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1,9 +1,23 @@
 #!/usr/bin/env bash
 # Tear down a finished task: return the treehouse worktree, release the Orca
 # worktree, or retire a secondmate home; kill the recorded runtime endpoint,
-# clear volatile state, refresh/prune the project's clone for PR-based ship
-# tasks, then print a backlog-refresh reminder for ship and scout teardowns
-# (a secondmate teardown prints none, since secondmates are not backlog items).
+# clear volatile state, and CLOSE this home's backlog item for ship and scout
+# tasks before reporting success (a secondmate teardown closes none, since
+# secondmates are not backlog items), then refresh/prune the project's clone for
+# PR-based ship tasks.
+# Removing state/<id>.meta and closing the backlog item are one step, not two:
+# bin/fm-backlog-transition-lib.sh owns that invariant, and both halves run under
+# the task's own meta lock before this script reports success. Because the
+# completion links (the PR, the report path, a local-main note) live only in the
+# record being removed, the intended close is recorded in
+# state/<id>.backlog-close first, so a process killed between the halves leaves
+# the next session start enough to finish it; a landed close removes that record.
+# A close that fails is fatal and loud - the printed follow-up then names the
+# hand edit that is still owed. The transition is skipped on a
+# config/backlog-backend=manual home, without a compatible tasks-axi, and in a
+# home that keeps no data/backlog.md; those cases print the manual follow-up.
+# None of this loosens the landed-work gates below: the transition runs only on
+# the paths that already proceed to remove the record.
 # REFUSES if the worktree holds work that has not LANDED, because cleanup
 # hard-resets/removes the worktree and kills its processes. Work has landed when it is
 # reachable from any remote-tracking branch (a fork counts as a remote, so
@@ -150,6 +164,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-backlog-transition-lib.sh
+. "$SCRIPT_DIR/fm-backlog-transition-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-control-lib.sh
@@ -1132,31 +1148,34 @@ work_is_landed() {
   content_in_default
 }
 
+# The completion links this teardown already holds locally. A scout's
+# deliverable is its report, a local-only ship lands on local main, and every
+# other ship carries the PR recorded on its own record.
+BACKLOG_DONE_ARGS=()
+backlog_done_args() {
+  BACKLOG_DONE_ARGS=()
+  case "$KIND" in
+    scout) BACKLOG_DONE_ARGS=(--report "data/$ID/report.md") ;;
+    *)
+      if [ "$MODE" = local-only ]; then
+        BACKLOG_DONE_ARGS=(--note "local main")
+      elif [ -n "$PR_URL" ]; then
+        BACKLOG_DONE_ARGS=(--pr "$PR_URL")
+      fi
+      ;;
+  esac
+}
+
+# Closing the backlog item is this script's own last act on the record, not a
+# printed instruction for a later turn (bin/fm-backlog-transition-lib.sh owns the
+# invariant). This prints what already happened, so the follow-up wording stays
+# only where a human still owes the edit.
 backlog_refresh_reminder() {
-  local pr done_cmd report_path
   [ "$KIND" = secondmate ] && return 0
-  if fm_tasks_axi_backend_available "$CONFIG"; then
-    case "$KIND" in
-      scout)
-        report_path="data/$ID/report.md"
-        done_cmd="tasks-axi done $ID --report $report_path"
-        ;;
-      *)
-        if [ "$MODE" = local-only ]; then
-          done_cmd="tasks-axi done $ID --note \"local main\""
-        else
-          pr=$PR_URL
-          if [ -n "$pr" ]; then
-            done_cmd="tasks-axi done $ID --pr $pr"
-          else
-            done_cmd="tasks-axi done $ID --pr PR_URL"
-          fi
-        fi
-        ;;
-    esac
-    printf '%s\n' "Backlog: $ID just finished. Run $done_cmd, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due."
+  if [ "$BACKLOG_CLOSED" = 1 ]; then
+    printf '%s\n' "Backlog: $ID is closed in data/backlog.md. Run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due."
   else
-    printf '%s\n' "Backlog: $ID just finished. Update data/backlog.md - move $ID to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due."
+    printf '%s\n' "Backlog: $ID just finished ($BACKLOG_SKIP_REASON). Update data/backlog.md - move $ID to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due."
   fi
 }
 
@@ -2814,6 +2833,21 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 status_retire_presentation_task "$STATE" "$ID" || exit 1
+# Point of no return: the endpoint is closed and the local copy returned, so
+# the completion links live only in the record about to be removed. Record the
+# exact close first, so a process killed between the two halves leaves enough
+# for the next session start to finish it (bin/fm-backlog-transition-lib.sh).
+BACKLOG_CLOSED=0
+BACKLOG_SKIP_REASON=
+if fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
+  BACKLOG_CLOSED=1
+  backlog_done_args
+  fm_backlog_close_marker_write "$STATE" "$ID" "$DATA" \
+    "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}" \
+    || { echo "error: the pending backlog close for $ID could not be recorded; retaining every durable task record" >&2; exit 1; }
+else
+  BACKLOG_SKIP_REASON=$FM_BACKLOG_TRANSITION_SKIP
+fi
 rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
@@ -2825,6 +2859,20 @@ rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
 # retired endpoint; teardown only runs after landing is confirmed, so any
 # leftover unhandled steer here is moot rather than unlanded work.
 rm -rf "$STATE/$ID.inbox"
+# The record is gone, so the backlog must not still show this task in flight
+# when teardown reports success. Still under this task's meta lock, so a steer
+# racing the same id stays serialized exactly as it was before.
+if [ "$BACKLOG_CLOSED" = 1 ]; then
+  if fm_backlog_done "$DATA" "$ID" \
+      "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}"; then
+    fm_backlog_close_marker_clear "$STATE" "$ID"
+  else
+    fm_lock_release "$META_LOCK"
+    META_LOCK_HELD=0
+    echo "error: $ID's endpoint and local copy are cleaned up, but its backlog item could not be closed ($FM_BACKLOG_TRANSITION_ERROR); the pending close is recorded and the next session start retries it - fix the backlog if it does not clear" >&2
+    exit 1
+  fi
+fi
 fm_lock_release "$META_LOCK"
 META_LOCK_HELD=0
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1153,9 +1153,13 @@ work_is_landed() {
 # other ship carries the PR recorded on its own record.
 BACKLOG_DONE_ARGS=()
 backlog_done_args() {
+  local data_relative
   BACKLOG_DONE_ARGS=()
   case "$KIND" in
-    scout) BACKLOG_DONE_ARGS=(--report "data/$ID/report.md") ;;
+    scout)
+      data_relative=$(fm_backlog_data_relative "$DATA") || return 1
+      BACKLOG_DONE_ARGS=(--report "$data_relative/$ID/report.md")
+      ;;
     *)
       if [ "$MODE" = local-only ]; then
         BACKLOG_DONE_ARGS=(--note "local main")
@@ -2842,7 +2846,8 @@ BACKLOG_SKIP_REASON=
 if fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
   BACKLOG_CLOSED=1
   backlog_done_args
-  fm_backlog_close_marker_write "$STATE" "$ID" "$DATA" \
+  META_SPAWN_GEN=$(fm_meta_get "$META" spawn_gen)
+  fm_backlog_close_marker_write "$STATE" "$ID" "$DATA" "$META_SPAWN_GEN" \
     "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}" \
     || { echo "error: the pending backlog close for $ID could not be recorded; retaining every durable task record" >&2; exit 1; }
 else

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -246,6 +246,7 @@ family_for_basename() {
     fm-send-secondmate-marker.test.sh|fm-shared-captain-inheritance.test.sh)
       printf '%s\n' secondmate
       ;;
+    fm-backlog-atomicity.test.sh|\
     fm-bootstrap.test.sh|fm-bootstrap-network-parallel.test.sh|fm-fleet-sync.test.sh|fm-gate-refuse.test.sh|fm-gotmp.test.sh|\
     fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-startup-network.test.sh|\
     fm-tangle-guard.test.sh|fm-update.test.sh)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,8 +90,8 @@ Both choices are local to each Firstmate home and are not part of secondmate inh
 
 The tracked `.tasks.toml` pins the default `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
 When the default backend is selected and compatible `tasks-axi` is on `PATH`, firstmate uses its verbs for routine backlog mutations.
-The two lifecycle transitions are not among them: dispatch and completion move a work item themselves, inside the same run that creates or removes the task's record, so the backlog and the live task set cannot drift apart ([`bin/fm-backlog-transition-lib.sh`](../bin/fm-backlog-transition-lib.sh)).
-A dispatch refuses when this home has no item for the id, a completion refuses to report success until the item is closed, and session start reconciles this home's own books after an interrupted run.
+Dispatch and completion are not separate operator actions: each moves its work item inside the same run that creates or removes the task's record, so the ordinary successful path cannot leave the backlog and live task set out of sync ([`bin/fm-backlog-transition-lib.sh`](../bin/fm-backlog-transition-lib.sh)).
+Under that automatic transition gate, dispatch refuses when this home has no item for the id, completion refuses to report success until the item is closed, and session start reconciles this home's own books after an interrupted run.
 Secondmate handoffs bypass that routine-backend choice: `fm-backlog-handoff.sh` keeps only its own fleet-level validation, delegates the item move to `tasks-axi mv`, and requires a verified receiver wake after a new move becomes durable.
 It moves in-scope `## Queued` items only and refuses `## In flight` and historical `## Done` records, which stay with their home for pruning or archiving.
 Handoff item bodies must use at least two leading spaces, and the helper refuses a selected item with a single-space or tab-indented continuation rather than risk orphaning it.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,7 +94,7 @@ When the automatic transition gate applies, dispatch and completion are not sepa
 Under that gate, dispatch refuses when this home has no item for the id, completion refuses to report success until the item is closed, and session start reconciles this home's own books after an interrupted run.
 Automatic transitions address the configured `<data>/backlog.md` explicitly from the data directory's parent, keeping relocated backlog configuration, archives, and relative scout-report links together.
 The gate does not apply to persistent secondmates, homes without compatible `tasks-axi`, or homes without a backlog file, preserving their existing persistent-agent, manual, or ad-hoc lifecycle behavior.
-After the secondmate, manual-backend, and compatibility exemptions, an unresolvable configured data directory fails lifecycle work before mutation.
+After the secondmate, manual-backend, and compatibility exemptions, an unresolvable configured data directory or one containing a control byte fails lifecycle work before mutation.
 Secondmate handoffs bypass that routine-backend choice: `fm-backlog-handoff.sh` keeps only its own fleet-level validation, delegates the item move to `tasks-axi mv`, and requires a verified receiver wake after a new move becomes durable.
 It moves in-scope `## Queued` items only and refuses `## In flight` and historical `## Done` records, which stay with their home for pruning or archiving.
 Handoff item bodies must use at least two leading spaces, and the helper refuses a selected item with a single-space or tab-indented continuation rather than risk orphaning it.
@@ -268,7 +268,8 @@ When it is unset, most scripts use the repo root as the home; when it is set, sc
 When `FM_HOME` is unset, it also behaves as the old whole-root override.
 `bin/fm-send.sh` is intentionally stricter than that general fallback: it requires `FM_HOME` to be set before resolving a target, so operator steers cannot silently resolve against the wrong home.
 `FM_STATE_OVERRIDE`, `FM_DATA_OVERRIDE`, `FM_PROJECTS_OVERRIDE`, and `FM_CONFIG_OVERRIDE` override individual operational directories for tests and specialized harness setup.
-Before `fm-brief.sh`, `fm-spawn.sh`, or `fm-afk-launch.sh` persists a path or passes it to another process, it resolves each applicable relative `FM_HOME`, `FM_STATE_OVERRIDE`, or `FM_DATA_OVERRIDE` directory against the caller's working directory, preserves absolute spellings unchanged, and rejects an unresolvable relative directory with the offending variable named.
+Before `fm-brief.sh`, `fm-spawn.sh`, or `fm-afk-launch.sh` persists a path or passes it to another process, it resolves each applicable relative `FM_HOME`, `FM_STATE_OVERRIDE`, or `FM_DATA_OVERRIDE` directory against the caller's working directory, preserves accepted absolute spellings unchanged, and rejects an unresolvable relative directory with the offending variable named.
+`fm-spawn.sh` additionally rejects control bytes in those raw directory inputs before shell or filesystem normalization can change which path the backlog gate checks.
 Bootstrap applies the same relative `FM_HOME` resolution only when embedding that home in the generated Relay poll shim; other transient consumers retain their existing shell-relative behavior.
 For the herdr backend, `FM_HOME` also determines the workspace label used by the adapter.
 For the zellij backend, `FM_HOME` does not split containers, but it determines the readable home prefix embedded in visible tab titles; use `FM_ZELLIJ_SESSION` when a separate zellij session is needed.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,8 +90,11 @@ Both choices are local to each Firstmate home and are not part of secondmate inh
 
 The tracked `.tasks.toml` pins the default `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
 When the default backend is selected and compatible `tasks-axi` is on `PATH`, firstmate uses its verbs for routine backlog mutations.
-Dispatch and completion are not separate operator actions: each moves its work item inside the same run that creates or removes the task's record, so the ordinary successful path cannot leave the backlog and live task set out of sync ([`bin/fm-backlog-transition-lib.sh`](../bin/fm-backlog-transition-lib.sh)).
-Under that automatic transition gate, dispatch refuses when this home has no item for the id, completion refuses to report success until the item is closed, and session start reconciles this home's own books after an interrupted run.
+When the automatic transition gate applies, dispatch and completion are not separate operator actions: each moves its work item inside the same run that creates or removes the task's record, so the ordinary successful path cannot leave the backlog and live task set out of sync ([`bin/fm-backlog-transition-lib.sh`](../bin/fm-backlog-transition-lib.sh)).
+Under that gate, dispatch refuses when this home has no item for the id, completion refuses to report success until the item is closed, and session start reconciles this home's own books after an interrupted run.
+Automatic transitions address the configured `<data>/backlog.md` explicitly from the data directory's parent, keeping relocated backlog configuration, archives, and relative scout-report links together.
+The gate does not apply to persistent secondmates, homes without compatible `tasks-axi`, or homes without a backlog file, preserving their existing persistent-agent, manual, or ad-hoc lifecycle behavior.
+After the secondmate, manual-backend, and compatibility exemptions, an unresolvable configured data directory fails lifecycle work before mutation.
 Secondmate handoffs bypass that routine-backend choice: `fm-backlog-handoff.sh` keeps only its own fleet-level validation, delegates the item move to `tasks-axi mv`, and requires a verified receiver wake after a new move becomes durable.
 It moves in-scope `## Queued` items only and refuses `## In flight` and historical `## Done` records, which stay with their home for pruning or archiving.
 Handoff item bodies must use at least two leading spaces, and the helper refuses a selected item with a single-space or tab-indented continuation rather than risk orphaning it.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,7 @@ Both choices are local to each Firstmate home and are not part of secondmate inh
 The tracked `.tasks.toml` pins the default `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
 When the default backend is selected and compatible `tasks-axi` is on `PATH`, firstmate uses its verbs for routine backlog mutations.
 When the automatic transition gate applies, dispatch and completion are not separate operator actions: each moves its work item inside the same run that creates or removes the task's record, so the ordinary successful path cannot leave the backlog and live task set out of sync ([`bin/fm-backlog-transition-lib.sh`](../bin/fm-backlog-transition-lib.sh)).
-Under that gate, dispatch refuses when this home has no item for the id, completion refuses to report success until the item is closed, and session start reconciles this home's own books after an interrupted run.
+Under that gate, dispatch refuses when this home has no item for the id or already marks it Done, completion refuses to report success until the item is closed, and session start reconciles this home's own books after an interrupted run.
 Automatic transitions address the configured `<data>/backlog.md` explicitly from the data directory's parent, keeping relocated backlog configuration, archives, and relative scout-report links together.
 The gate does not apply to persistent secondmates, homes without compatible `tasks-axi`, or homes without a backlog file, preserving their existing persistent-agent, manual, or ad-hoc lifecycle behavior.
 After the secondmate, manual-backend, and compatibility exemptions, an unresolvable configured data directory or one containing a control byte fails lifecycle work before mutation.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,8 @@ Both choices are local to each Firstmate home and are not part of secondmate inh
 
 The tracked `.tasks.toml` pins the default `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
 When the default backend is selected and compatible `tasks-axi` is on `PATH`, firstmate uses its verbs for routine backlog mutations.
+The two lifecycle transitions are not among them: dispatch and completion move a work item themselves, inside the same run that creates or removes the task's record, so the backlog and the live task set cannot drift apart ([`bin/fm-backlog-transition-lib.sh`](../bin/fm-backlog-transition-lib.sh)).
+A dispatch refuses when this home has no item for the id, a completion refuses to report success until the item is closed, and session start reconciles this home's own books after an interrupted run.
 Secondmate handoffs bypass that routine-backend choice: `fm-backlog-handoff.sh` keeps only its own fleet-level validation, delegates the item move to `tasks-axi mv`, and requires a verified receiver wake after a new move becomes durable.
 It moves in-scope `## Queued` items only and refuses `## In flight` and historical `## Done` records, which stay with their home for pruning or archiving.
 Handoff item bodies must use at least two leading spaces, and the helper refuses a selected item with a single-space or tab-indented continuation rather than risk orphaning it.
@@ -97,6 +99,7 @@ Because bootstrap requires `tasks-axi` on `PATH` on every profile, that delegati
 Compatible means the installed build passes the shared version and feature probe owned by [`bin/fm-tasks-axi-lib.sh`](../bin/fm-tasks-axi-lib.sh), including the atomic multi-ID move required by handoff delegation.
 Bootstrap requires compatible `tasks-axi` on every profile; see "Toolchain" below for missing-tool reporting and silent default-backend behavior.
 Set the local, gitignored `config/backlog-backend` file to `manual` to force manual backlog editing and suppress the verbose `BOOTSTRAP_INFO: tasks-axi available` fact, not missing-tool reporting.
+A `manual` home owns its backlog file outright: the lifecycle transitions above are skipped there, dispatch and completion never fail over the file's contents, and a completed teardown prints the hand edit that is owed instead.
 Absent or `tasks-axi` selects the default tasks-axi backend.
 The file format is unchanged in both modes; tasks-axi and manual edits produce the same `## In flight`, `## Queued`, and `## Done` sections.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -92,6 +92,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation and config-reread delivery |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
+| `fm-backlog-transition-lib.sh` | Pair task-record changes with their backlog transitions and replay interrupted closes |
 | `fm-quota-axi-lib.sh`    | Shared `quota-axi` compatibility floor for the bootstrap diagnostic                  |
 | `fm-vendor-auth-probe.sh`| Run one hard-bounded, non-destructive authentication probe of a named vendor CLI and report the fact |
 | `fm-wake-drain.sh`       | Present and acknowledge the current actor's claimed wake rows alongside status, decision, divergence, recovery, and supervision checks |

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -704,7 +704,8 @@ test_spawn_releases_orca_resources_when_metadata_write_fails() {
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --mode no-mistakes --yolo off --backend orca 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when metadata cannot be written"
-  assert_contains "$out" "Is a directory" "spawn should fail at metadata publication"
+  assert_contains "$out" "task record for $id could not be published" \
+    "spawn should report metadata publication failure without relying on platform-specific mv output"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-meta-fail'$'\x1f''--json' \
     "Orca spawn should close the recorded terminal when a later abort occurs"
   assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-meta-fail'$'\x1f''--force'$'\x1f''--json' \

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -105,17 +105,23 @@ SH
   chmod +x "$case_dir/fakebin/tasks-axi"
 }
 
-interrupt_spawn_after_start_commit() {  # <case-dir>
-  local case_dir=$1 real
+interrupt_spawn_during_start() {  # <case-dir> <before|after>
+  local case_dir=$1 timing=$2 real
   real=$(command -v tasks-axi)
   cat > "$case_dir/fakebin/tasks-axi" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = start ]; then
-  "$real" "\$@" || exit \$?
   spawn_pid=\$(ps -o ppid= -p "\$PPID" | tr -d ' ')
   case "\$spawn_pid" in ''|*[!0-9]*) exit 1 ;; esac
-  kill -TERM "\$spawn_pid"
-  /bin/sleep 1
+  if [ "$timing" = before ]; then
+    kill -TERM "\$spawn_pid"
+    /bin/sleep 0.1
+  fi
+  "$real" "\$@" || exit \$?
+  if [ "$timing" = after ]; then
+    kill -TERM "\$spawn_pid"
+    /bin/sleep 0.1
+  fi
   exit 0
 fi
 exec "$real" "\$@"
@@ -302,20 +308,22 @@ test_dispatch_rolls_back_before_a_failed_launch_delivery() {
   pass "dispatch commits neither record nor backlog state before launch delivery succeeds"
 }
 
-test_dispatch_interruption_after_backlog_commit_preserves_recovery_record() {
-  local case_dir id out rc=0
-  id=atomic-dispatch-interrupted-b5
-  case_dir=$(make_home dispatch-interrupted "$id")
-  add_item "$case_dir" "$id"
-  interrupt_spawn_after_start_commit "$case_dir"
+test_dispatch_defers_interruption_across_backlog_commit() {
+  local timing case_dir id out
+  for timing in before after; do
+    id="atomic-dispatch-interrupted-$timing-b5"
+    case_dir=$(make_home "dispatch-interrupted-$timing" "$id")
+    add_item "$case_dir" "$id"
+    interrupt_spawn_during_start "$case_dir" "$timing"
 
-  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
-  [ "$rc" -ne 0 ] || fail "interrupted spawn unexpectedly reported success"
-  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
-    || fail "the injected interruption did not land after the backlog commit"
-  assert_present "$(home_of "$case_dir")/state/$id.meta" \
-    "an interruption after backlog commit deleted the paired recovery record"
-  pass "dispatch preserves its published recovery record when interrupted after backlog commit"
+    out=$(run_ship_spawn "$case_dir" "$id") \
+      || fail "a $timing-commit interruption stopped the atomic dispatch: $out"
+    [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+      || fail "a $timing-commit interruption left the backlog row queued"
+    assert_present "$(home_of "$case_dir")/state/$id.meta" \
+      "a $timing-commit interruption removed the paired task record"
+  done
+  pass "dispatch defers catchable interruption across both halves of its backlog commit"
 }
 
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight() {
@@ -649,7 +657,7 @@ test_dispatch_refuses_an_id_this_home_has_no_item_for
 test_dispatch_refuses_a_closed_item
 test_dispatch_leaves_no_record_when_the_transition_fails
 test_dispatch_rolls_back_before_a_failed_launch_delivery
-test_dispatch_interruption_after_backlog_commit_preserves_recovery_record
+test_dispatch_defers_interruption_across_backlog_commit
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight
 test_dispatch_fails_when_its_row_vanishes_after_preflight
 test_completion_closes_a_local_only_ship_before_reporting_success

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -1,0 +1,426 @@
+#!/usr/bin/env bash
+# Behavior tests for the backlog<->record pairing invariant:
+# `state/<id>.meta` exists <=> this home's backlog row for that id is In flight.
+#
+# bin/fm-backlog-transition-lib.sh states the contract; the three scripts that
+# own a task's physical record enforce it. These tests drive those real scripts
+# against a real backlog file and the real tasks-axi CLI, and assert the
+# resulting RECORD STATE - never the wording of a reminder a later turn was
+# expected to act on, which is exactly what let the two records drift before.
+#
+#   dispatch    bin/fm-spawn.sh moves the row In flight in the same run that
+#               publishes the record, so a live worker the backlog does not own
+#               cannot arise on the ordinary path.
+#   completion  bin/fm-teardown.sh closes the row before it reports success, so
+#               a finished task cannot be left showing as running.
+#   recovery    bin/fm-bootstrap.sh reconciles THIS home's own books at session
+#               start, covering the millisecond crash window inside those two
+#               scripts and any drift a home was already carrying.
+#
+# The invariant is single-host: a home's backlog and its records live together,
+# so a persistent secondmate keeps its own books through its own copies of these
+# scripts. A parent's view of a mate lagging is a freshness question and is
+# deliberately not asserted here.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+BOOTSTRAP="$ROOT/bin/fm-bootstrap.sh"
+TMP_ROOT=$(fm_test_tmproot fm-backlog-atomicity)
+
+command -v tasks-axi >/dev/null 2>&1 || {
+  printf 'ok - skipped (tasks-axi is not installed; the fused transitions are inert without it)\n'
+  exit 0
+}
+
+# --- fixture ----------------------------------------------------------------
+
+# A home with a real backlog, a real project clone with an origin, a pooled
+# worktree, and stubs for every tool the spawn path shells out to.
+make_home() {  # <name> [task-id...]
+  local name=$1 case_dir home fakebin id
+  shift
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  fakebin=$(fm_fakebin "$case_dir")
+  mkdir -p "$home/state" "$home/config" "$home/data" "$home/projects"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' claude > "$home/config/crew-harness"
+  printf '%s\n' '# Backlog' '' '## In flight' '' '## Queued' '' '## Done' \
+    > "$home/data/backlog.md"
+  for id in "$@"; do
+    mkdir -p "$home/data/$id"
+    printf 'Delivery contract: mode=no-mistakes\nbrief for %s\n' "$id" > "$home/data/$id/brief.md"
+  done
+
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+case "$*" in *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;; esac
+case "${1:-}" in display-message) printf 'firstmate\n'; exit 0 ;; esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse gh gh-axi no-mistakes
+
+  fm_git_init_commit "$case_dir/project"
+  fm_git_add_origin "$case_dir/project" "$case_dir/project.origin.git"
+  git -C "$case_dir/project" worktree add --quiet -b pooled "$case_dir/wt"
+
+  printf '%s\n' "$case_dir"
+}
+
+home_of() { printf '%s/home\n' "$1"; }
+backlog_of() { printf '%s/home/data/backlog.md\n' "$1"; }
+
+add_item() {  # <case-dir> <id> [kind]
+  tasks-axi add "$2" "item for $2" --kind "${3:-ship}" --file "$(backlog_of "$1")" >/dev/null
+}
+
+start_item() {  # <case-dir> <id>
+  tasks-axi start "$2" --file "$(backlog_of "$1")" >/dev/null
+}
+
+row_state() {  # <case-dir> <id>
+  tasks-axi show "$2" --file "$(backlog_of "$1")" 2>/dev/null |
+    sed -n 's/^  state: *//p' | head -1
+}
+
+# Shadow tasks-axi with a wrapper that fails one verb and delegates every other
+# verb to the real binary, so a test can drive a genuine mid-transition failure
+# without faking the reads around it.
+break_verb() {  # <case-dir> <verb>
+  local case_dir=$1 verb=$2 real
+  real=$(command -v tasks-axi)
+  cat > "$case_dir/fakebin/tasks-axi" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = "$verb" ]; then
+  echo 'error: "backlog is unwritable"' >&2
+  exit 1
+fi
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/tasks-axi"
+}
+
+write_task_meta() {  # <case-dir> <id> <kind> <mode> [extra-line...]
+  local case_dir=$1 id=$2 kind=$3 mode=$4
+  shift 4
+  fm_write_meta "$(home_of "$case_dir")/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "endpoint_task_id=$id" \
+    "worktree=$case_dir/absent-worktree" \
+    "project=$case_dir/absent-project" \
+    "harness=claude" \
+    "kind=$kind" \
+    "mode=$mode" \
+    "yolo=off" \
+    "$@"
+}
+
+run_spawn() {  # <case-dir> <args...>
+  local case_dir=$1
+  shift
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$case_dir/wt" TMUX="fake,1,0" \
+    CLAUDE_CONFIG_DIR='' \
+    PATH="$case_dir/fakebin:$PATH" \
+    "$SPAWN" "$@" 2>&1
+}
+
+run_ship_spawn() {  # <case-dir> <id>
+  local case_dir=$1 id=$2
+  run_spawn "$case_dir" "$id" "$case_dir/project" --mode no-mistakes --yolo off
+}
+
+# Teardown against a recorded worktree that no longer exists: the landed-work and
+# worktree-return steps are then no-ops, which keeps these cases about the
+# backlog transition rather than re-testing tests/fm-teardown.test.sh's matrix.
+run_teardown() {  # <case-dir> <id> [args...]
+  local case_dir=$1
+  shift
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    PATH="$case_dir/fakebin:$PATH" \
+    "$TEARDOWN" "$@" 2>&1
+}
+
+run_bootstrap() {  # <case-dir>
+  local case_dir=$1
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    FM_BOOTSTRAP_NETWORK=skip \
+    PATH="$case_dir/fakebin:$PATH" \
+    "$BOOTSTRAP" 2>&1
+}
+
+# --- dispatch ---------------------------------------------------------------
+
+test_dispatch_moves_the_item_in_flight_in_the_same_run() {
+  local case_dir id out
+  id=atomic-dispatch-b1
+  case_dir=$(make_home dispatch-ok "$id")
+  add_item "$case_dir" "$id"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || fail "spawn failed: $out"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" "spawn published no record"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "spawn reported success with its backlog item still $(row_state "$case_dir" "$id")"
+  pass "dispatch publishes the record and moves the backlog item In flight in one run"
+}
+
+test_dispatch_refuses_an_id_this_home_has_no_item_for() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-b2
+  case_dir=$(make_home dispatch-no-item "$id")
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn dispatched work no backlog item owns"
+  assert_contains "$out" "no backlog item in this home" \
+    "spawn refused without naming the missing backlog item"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "refused dispatch still left a record behind"
+  pass "dispatch refuses, before creating anything, when the home has no item for the id"
+}
+
+test_dispatch_refuses_a_closed_item() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-b3
+  case_dir=$(make_home dispatch-closed "$id")
+  add_item "$case_dir" "$id"
+  tasks-axi "done" "$id" --file "$(backlog_of "$case_dir")" >/dev/null
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn dispatched onto an item the backlog already closed"
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "refused dispatch silently reopened a closed item"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "refused dispatch onto a closed item still left a record behind"
+  pass "dispatch refuses a closed item instead of silently reopening it"
+}
+
+test_dispatch_leaves_no_record_when_the_transition_fails() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-b4
+  case_dir=$(make_home dispatch-transition-fails "$id")
+  add_item "$case_dir" "$id"
+  break_verb "$case_dir" start
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn reported success though the backlog transition failed"
+  assert_contains "$out" "could not be moved to In flight" \
+    "spawn failed without explaining the backlog transition failure"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "a failed backlog transition left an orphaned record behind"
+  assert_absent "$(home_of "$case_dir")/state/$id.busy-state" \
+    "a failed backlog transition left the task's armed busy generation behind"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "a failed dispatch left the backlog item in $(row_state "$case_dir" "$id")"
+  pass "a failed backlog transition fails the dispatch loudly and leaves no record"
+}
+
+# --- completion -------------------------------------------------------------
+
+test_completion_closes_a_local_only_ship_before_reporting_success() {
+  local case_dir id out
+  id=atomic-close-b5
+  case_dir=$(make_home close-local-only)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only
+
+  out=$(run_teardown "$case_dir" "$id") || fail "teardown failed: $out"
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "teardown reported success with the item still $(row_state "$case_dir" "$id")"
+  assert_grep 'local main' "$(backlog_of "$case_dir")" \
+    "a local-only landing was closed without its local-main note"
+  pass "completion closes a local-only ship, with its landing note, before reporting success"
+}
+
+test_completion_closes_a_scout_with_its_report() {
+  local case_dir id out
+  id=atomic-close-b6
+  case_dir=$(make_home close-scout)
+  add_item "$case_dir" "$id" scout
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" scout ''
+  # A scout's deliverable is its report, and teardown also enforces the shared
+  # captain-call completion gate; satisfy both the way a real scout does.
+  mkdir -p "$(home_of "$case_dir")/data/$id"
+  printf 'findings\n' > "$(home_of "$case_dir")/data/$id/report.md"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    PATH="$case_dir/fakebin:$PATH" \
+    "$ROOT/bin/fm-captain-hold.sh" complete "$id" --none >/dev/null \
+    || fail "could not record the scout's completed captain-call inventory"
+
+  out=$(run_teardown "$case_dir" "$id") || fail "teardown failed: $out"
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "teardown reported success with the scout item still $(row_state "$case_dir" "$id")"
+  assert_grep "data/$id/report.md" "$(backlog_of "$case_dir")" \
+    "a closed scout item did not record its report"
+  pass "completion closes a scout item against its report"
+}
+
+test_completion_fails_loudly_and_records_the_close_it_still_owes() {
+  local case_dir id out rc=0
+  id=atomic-close-b7
+  case_dir=$(make_home close-fails)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only
+  break_verb "$case_dir" "done"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown reported success while its item was still In flight"
+  assert_contains "$out" "could not be closed" \
+    "teardown failed without explaining the unclosed backlog item"
+  assert_present "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "teardown lost the close it still owes"
+  pass "completion refuses to report success while its item is still open, and records what it owes"
+}
+
+# --- same-home recovery -----------------------------------------------------
+
+test_recovery_marks_an_owned_record_in_flight() {
+  local case_dir id out
+  id=atomic-heal-b8
+  case_dir=$(make_home heal-queued)
+  add_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "session start left an owned record's item at $(row_state "$case_dir" "$id"): $out"
+  pass "session start marks an item In flight when this home already owns a worker for it"
+}
+
+test_recovery_replays_a_close_an_interrupted_cleanup_left_open() {
+  local case_dir id out
+  id=atomic-heal-b9
+  case_dir=$(make_home heal-pending-close)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  printf 'id=%s\ndata=%s\narg=--pr\narg=https://github.com/example/repo/pull/11\n' \
+    "$id" "$(home_of "$case_dir")/data" \
+    > "$(home_of "$case_dir")/state/$id.backlog-close"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "session start left an interrupted cleanup's item at $(row_state "$case_dir" "$id"): $out"
+  assert_grep 'https://github.com/example/repo/pull/11' "$(backlog_of "$case_dir")" \
+    "the replayed close dropped the completion link the cleanup had recorded"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "a replayed close left its record behind"
+  pass "session start finishes a close an interrupted cleanup recorded but never landed"
+}
+
+test_recovery_drops_a_recorded_close_whose_task_is_still_owned() {
+  local case_dir id out
+  id=atomic-heal-b10
+  case_dir=$(make_home heal-stale-close)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes
+  printf 'id=%s\ndata=%s\narg=--note\narg=local main\n' \
+    "$id" "$(home_of "$case_dir")/data" \
+    > "$(home_of "$case_dir")/state/$id.backlog-close"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "session start closed an item whose worker this home still owns: $out"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "a stale recorded close was left to fire on a later restart"
+  pass "session start drops a recorded close whose task the home still owns"
+}
+
+test_recovery_leaves_a_captain_held_item_alone() {
+  local case_dir id out
+  id=atomic-heal-b11
+  case_dir=$(make_home heal-held)
+  add_item "$case_dir" "$id"
+  tasks-axi hold "$id" --reason "captain decision pending" --kind captain \
+    --file "$(backlog_of "$case_dir")" >/dev/null
+  write_task_meta "$case_dir" "$id" ship no-mistakes
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "session start moved a captain-held item to $(row_state "$case_dir" "$id"): $out"
+  pass "session start leaves a captain-held item where the captain put it"
+}
+
+# --- backend selection and secondmate scope ---------------------------------
+
+test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog() {
+  local case_dir id out
+  id=atomic-manual-b12
+  case_dir=$(make_home manual-backend "$id")
+  printf '%s\n' manual > "$(home_of "$case_dir")/config/backlog-backend"
+  # Deliberately no backlog item: on a manual home the operator owns the file,
+  # so neither half of the lifecycle may hard-fail over its contents.
+  out=$(run_ship_spawn "$case_dir" "$id") || fail "manual-backend spawn failed: $out"
+  assert_contains "$out" "spawned $id" "manual-backend spawn did not report success"
+
+  out=$(run_teardown "$case_dir" "$id") || fail "manual-backend teardown failed: $out"
+  assert_contains "$out" "Update data/backlog.md" \
+    "manual-backend teardown did not leave the backlog edit to the operator"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "manual-backend teardown recorded a close it never owed"
+  pass "a manual-backlog home dispatches and completes without a hard failure"
+}
+
+test_a_secondmate_home_keeps_its_own_books() {
+  local case_dir id out
+  id=atomic-mate-b13
+  case_dir=$(make_home mate-own-books "$id")
+  # The mate's home is a firstmate home in its own right; the invariant is
+  # single-host, so its own dispatch and completion keep its own two records
+  # paired with no parent involved.
+  printf '%s\n' mate-h1 > "$(home_of "$case_dir")/.fm-secondmate-home"
+  add_item "$case_dir" "$id"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || fail "mate-home spawn failed: $out"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "a mate's own dispatch left its item at $(row_state "$case_dir" "$id")"
+
+  rm -f "$(home_of "$case_dir")/state/$id.meta"
+  write_task_meta "$case_dir" "$id" ship local-only
+  out=$(run_teardown "$case_dir" "$id") || fail "mate-home teardown failed: $out"
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "a mate's own completion left its item at $(row_state "$case_dir" "$id")"
+  pass "a secondmate home keeps its own books paired through dispatch and completion"
+}
+
+test_a_persistent_secondmate_is_never_a_backlog_item() {
+  local case_dir id out mate
+  id=atomic-mate-b14
+  case_dir=$(make_home mate-not-an-item)
+  mate="$case_dir/mate-home"
+  mkdir -p "$mate/bin" "$mate/data"
+  printf '# Firstmate\n' > "$mate/AGENTS.md"
+  printf '%s\n' "$id" > "$mate/.fm-secondmate-home"
+  printf 'charter for %s\n' "$id" > "$mate/data/charter.md"
+
+  # No backlog item exists for the mate, and none should be required: agents are
+  # not work items. The dispatch must succeed anyway.
+  out=$(run_spawn "$case_dir" "$id" "$mate" --secondmate) \
+    || fail "secondmate spawn failed: $out"
+  assert_contains "$out" "spawned $id" "secondmate spawn did not report success"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" "secondmate spawn published no record"
+  pass "dispatching a persistent secondmate needs no backlog item"
+}
+
+test_dispatch_moves_the_item_in_flight_in_the_same_run
+test_dispatch_refuses_an_id_this_home_has_no_item_for
+test_dispatch_refuses_a_closed_item
+test_dispatch_leaves_no_record_when_the_transition_fails
+test_completion_closes_a_local_only_ship_before_reporting_success
+test_completion_closes_a_scout_with_its_report
+test_completion_fails_loudly_and_records_the_close_it_still_owes
+test_recovery_marks_an_owned_record_in_flight
+test_recovery_replays_a_close_an_interrupted_cleanup_left_open
+test_recovery_drops_a_recorded_close_whose_task_is_still_owned
+test_recovery_leaves_a_captain_held_item_alone
+test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog
+test_a_secondmate_home_keeps_its_own_books
+test_a_persistent_secondmate_is_never_a_backlog_item

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -315,6 +315,32 @@ test_recovery_replays_a_close_an_interrupted_cleanup_left_open() {
   pass "session start finishes a close an interrupted cleanup recorded but never landed"
 }
 
+test_recovery_preserves_a_close_when_the_backlog_cannot_be_read() {
+  local case_dir id out
+  id=atomic-heal-read-error-b10
+  case_dir=$(make_home heal-read-error)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  printf 'id=%s\ndata=%s\narg=--note\narg=local main\n' \
+    "$id" "$(home_of "$case_dir")/data" \
+    > "$(home_of "$case_dir")/state/$id.backlog-close"
+  break_verb "$case_dir" show
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "a transient backlog read failure discarded the pending close"
+  rm -f "$case_dir/fakebin/tasks-axi"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "a failed recovery changed the backlog row: $out"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "the preserved close was not retried after the read recovered: $out"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "a successfully retried close left its marker behind"
+  pass "session start preserves a pending close across a transient backlog read failure"
+}
+
 test_recovery_drops_a_recorded_close_whose_task_is_still_owned() {
   local case_dir id out
   id=atomic-heal-b10
@@ -419,6 +445,7 @@ test_completion_closes_a_scout_with_its_report
 test_completion_fails_loudly_and_records_the_close_it_still_owes
 test_recovery_marks_an_owned_record_in_flight
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open
+test_recovery_preserves_a_close_when_the_backlog_cannot_be_read
 test_recovery_drops_a_recorded_close_whose_task_is_still_owned
 test_recovery_leaves_a_captain_held_item_alone
 test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -105,6 +105,38 @@ SH
   chmod +x "$case_dir/fakebin/tasks-axi"
 }
 
+change_row_on_second_show() {  # <case-dir> <done|rm>
+  local case_dir=$1 action=$2 real
+  real=$(command -v tasks-axi)
+  cat > "$case_dir/fakebin/tasks-axi" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = show ]; then
+  count=0
+  [ ! -f "$case_dir/show-count" ] || count=\$(cat "$case_dir/show-count")
+  count=\$((count + 1))
+  printf '%s\n' "\$count" > "$case_dir/show-count"
+  if [ "\$count" -eq 2 ]; then
+    "$real" "$action" "\$2" --file "\$4" >/dev/null || exit 1
+  fi
+fi
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/tasks-axi"
+}
+
+break_meta_removal() {  # <case-dir> <meta-path>
+  local case_dir=$1 meta=$2 real
+  real=$(command -v rm)
+  cat > "$case_dir/fakebin/rm" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  [ "\$arg" != "$meta" ] || exit 1
+done
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/rm"
+}
+
 write_task_meta() {  # <case-dir> <id> <kind> <mode> [extra-line...]
   local case_dir=$1 id=$2 kind=$3 mode=$4
   shift 4
@@ -218,6 +250,40 @@ test_dispatch_leaves_no_record_when_the_transition_fails() {
   [ "$(row_state "$case_dir" "$id")" = queued ] \
     || fail "a failed dispatch left the backlog item in $(row_state "$case_dir" "$id")"
   pass "a failed backlog transition fails the dispatch loudly and leaves no record"
+}
+
+test_dispatch_does_not_resurrect_a_row_closed_after_preflight() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-closed-race-b5
+  case_dir=$(make_home dispatch-closed-race "$id")
+  add_item "$case_dir" "$id"
+  change_row_on_second_show "$case_dir" "done"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn succeeded after its backlog row was closed"
+  assert_contains "$out" "state done" "spawn did not report the row's ineligible state"
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "spawn resurrected a row closed after preflight"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "spawn retained a record after its row was closed"
+  pass "dispatch does not resurrect a row closed after preflight"
+}
+
+test_dispatch_fails_when_its_row_vanishes_after_preflight() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-removed-race-b6
+  case_dir=$(make_home dispatch-removed-race "$id")
+  add_item "$case_dir" "$id"
+  change_row_on_second_show "$case_dir" rm
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn succeeded after its backlog row vanished"
+  assert_contains "$out" "vanished before dispatch commit" \
+    "spawn did not report that its backlog row vanished"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "spawn retained a record after its backlog row vanished"
+  [ -z "$(row_state "$case_dir" "$id")" ] || fail "spawn recreated a removed backlog row"
+  pass "dispatch fails when its backlog row vanishes after preflight"
 }
 
 # --- completion -------------------------------------------------------------
@@ -362,6 +428,38 @@ test_recovery_finishes_a_close_for_the_same_meta_incarnation() {
   pass "session start finishes a close for the matching meta incarnation"
 }
 
+test_recovery_preserves_both_records_when_meta_removal_fails() {
+  local case_dir id meta out
+  id=atomic-heal-remove-failure-b12
+  case_dir=$(make_home heal-remove-failure)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  meta="$(home_of "$case_dir")/state/$id.meta"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-one"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-one\narg=--note\narg=local main\n' \
+    "$id" "$(home_of "$case_dir")/data" \
+    > "$(home_of "$case_dir")/state/$id.backlog-close"
+  break_meta_removal "$case_dir" "$meta"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_contains "$out" "could not remove the interrupted task record" \
+    "session start did not surface the record-removal failure"
+  assert_present "$meta" "failed recovery removed the task record"
+  assert_present "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "failed recovery discarded the pending close"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "failed recovery closed the backlog before removing meta"
+
+  rm -f "$case_dir/fakebin/rm"
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "recovery did not retry after meta removal recovered: $out"
+  assert_absent "$meta" "successful retry retained the task record"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "successful retry retained the pending close"
+  pass "recovery preserves both records when meta removal fails"
+}
+
 test_recovery_drops_a_close_for_a_newer_meta_incarnation() {
   local case_dir id out
   id=atomic-heal-new-incarnation-b12
@@ -484,6 +582,8 @@ test_dispatch_moves_the_item_in_flight_in_the_same_run
 test_dispatch_refuses_an_id_this_home_has_no_item_for
 test_dispatch_refuses_a_closed_item
 test_dispatch_leaves_no_record_when_the_transition_fails
+test_dispatch_does_not_resurrect_a_row_closed_after_preflight
+test_dispatch_fails_when_its_row_vanishes_after_preflight
 test_completion_closes_a_local_only_ship_before_reporting_success
 test_completion_closes_a_scout_with_its_report
 test_completion_fails_loudly_and_records_the_close_it_still_owes
@@ -491,6 +591,7 @@ test_recovery_marks_an_owned_record_in_flight
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open
 test_recovery_preserves_a_close_when_the_backlog_cannot_be_read
 test_recovery_finishes_a_close_for_the_same_meta_incarnation
+test_recovery_preserves_both_records_when_meta_removal_fails
 test_recovery_drops_a_close_for_a_newer_meta_incarnation
 test_recovery_drops_a_legacy_close_when_meta_exists
 test_recovery_leaves_a_captain_held_item_alone

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -124,6 +124,20 @@ SH
   chmod +x "$case_dir/fakebin/tasks-axi"
 }
 
+break_launch_delivery() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+case "$*" in *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;; esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  send-keys) exit 1 ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux"
+}
+
 break_meta_removal() {  # <case-dir> <meta-path>
   local case_dir=$1 meta=$2 real
   real=$(command -v rm)
@@ -250,6 +264,24 @@ test_dispatch_leaves_no_record_when_the_transition_fails() {
   [ "$(row_state "$case_dir" "$id")" = queued ] \
     || fail "a failed dispatch left the backlog item in $(row_state "$case_dir" "$id")"
   pass "a failed backlog transition fails the dispatch loudly and leaves no record"
+}
+
+test_dispatch_rolls_back_before_a_failed_launch_delivery() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-delivery-fails-b5
+  case_dir=$(make_home dispatch-delivery-fails "$id")
+  add_item "$case_dir" "$id"
+  break_launch_delivery "$case_dir"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn reported success though launch delivery failed"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "a failed launch delivery left its provisional record behind"
+  assert_absent "$(home_of "$case_dir")/state/$id.busy-state" \
+    "a failed launch delivery left its provisional busy generation behind"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "launch delivery failed after committing backlog state $(row_state "$case_dir" "$id")"
+  pass "dispatch commits neither record nor backlog state before launch delivery succeeds"
 }
 
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight() {
@@ -582,6 +614,7 @@ test_dispatch_moves_the_item_in_flight_in_the_same_run
 test_dispatch_refuses_an_id_this_home_has_no_item_for
 test_dispatch_refuses_a_closed_item
 test_dispatch_leaves_no_record_when_the_transition_fails
+test_dispatch_rolls_back_before_a_failed_launch_delivery
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight
 test_dispatch_fails_when_its_row_vanishes_after_preflight
 test_completion_closes_a_local_only_ship_before_reporting_success

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -341,23 +341,67 @@ test_recovery_preserves_a_close_when_the_backlog_cannot_be_read() {
   pass "session start preserves a pending close across a transient backlog read failure"
 }
 
-test_recovery_drops_a_recorded_close_whose_task_is_still_owned() {
+test_recovery_finishes_a_close_for_the_same_meta_incarnation() {
   local case_dir id out
-  id=atomic-heal-b10
-  case_dir=$(make_home heal-stale-close)
+  id=atomic-heal-same-incarnation-b11
+  case_dir=$(make_home heal-same-incarnation)
   add_item "$case_dir" "$id"
   start_item "$case_dir" "$id"
-  write_task_meta "$case_dir" "$id" ship no-mistakes
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-one"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-one\narg=--note\narg=local main\n' \
+    "$id" "$(home_of "$case_dir")/data" \
+    > "$(home_of "$case_dir")/state/$id.backlog-close"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "session start did not close the interrupted incarnation: $out"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "session start retained the interrupted incarnation's meta"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "session start retained the completed incarnation's close marker"
+  pass "session start finishes a close for the matching meta incarnation"
+}
+
+test_recovery_drops_a_close_for_a_newer_meta_incarnation() {
+  local case_dir id out
+  id=atomic-heal-new-incarnation-b12
+  case_dir=$(make_home heal-new-incarnation)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-two"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-one\narg=--note\narg=local main\n' \
+    "$id" "$(home_of "$case_dir")/data" \
+    > "$(home_of "$case_dir")/state/$id.backlog-close"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "session start closed the newer task incarnation: $out"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "session start removed the newer task incarnation's meta"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "a stale recorded close was left to fire on a later restart"
+  pass "session start drops a close recorded for an older meta incarnation"
+}
+
+test_recovery_drops_a_legacy_close_when_meta_exists() {
+  local case_dir id out
+  id=atomic-heal-legacy-close-b13
+  case_dir=$(make_home heal-legacy-close)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-two"
   printf 'id=%s\ndata=%s\narg=--note\narg=local main\n' \
     "$id" "$(home_of "$case_dir")/data" \
     > "$(home_of "$case_dir")/state/$id.backlog-close"
 
   out=$(run_bootstrap "$case_dir")
   [ "$(row_state "$case_dir" "$id")" = in_flight ] \
-    || fail "session start closed an item whose worker this home still owns: $out"
+    || fail "session start guessed that a legacy close belonged to the current meta: $out"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "session start removed meta for an unversioned legacy close"
   assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
-    "a stale recorded close was left to fire on a later restart"
-  pass "session start drops a recorded close whose task the home still owns"
+    "session start retained a legacy close that could not be matched safely"
+  pass "session start treats an unversioned close as stale when meta exists"
 }
 
 test_recovery_leaves_a_captain_held_item_alone() {
@@ -446,7 +490,9 @@ test_completion_fails_loudly_and_records_the_close_it_still_owes
 test_recovery_marks_an_owned_record_in_flight
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open
 test_recovery_preserves_a_close_when_the_backlog_cannot_be_read
-test_recovery_drops_a_recorded_close_whose_task_is_still_owned
+test_recovery_finishes_a_close_for_the_same_meta_incarnation
+test_recovery_drops_a_close_for_a_newer_meta_incarnation
+test_recovery_drops_a_legacy_close_when_meta_exists
 test_recovery_leaves_a_captain_held_item_alone
 test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog
 test_a_secondmate_home_keeps_its_own_books

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -105,6 +105,24 @@ SH
   chmod +x "$case_dir/fakebin/tasks-axi"
 }
 
+interrupt_spawn_after_start_commit() {  # <case-dir>
+  local case_dir=$1 real
+  real=$(command -v tasks-axi)
+  cat > "$case_dir/fakebin/tasks-axi" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = start ]; then
+  "$real" "\$@" || exit \$?
+  spawn_pid=\$(ps -o ppid= -p "\$PPID" | tr -d ' ')
+  case "\$spawn_pid" in ''|*[!0-9]*) exit 1 ;; esac
+  kill -TERM "\$spawn_pid"
+  /bin/sleep 1
+  exit 0
+fi
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/tasks-axi"
+}
+
 change_row_on_second_show() {  # <case-dir> <done|rm>
   local case_dir=$1 action=$2 real
   real=$(command -v tasks-axi)
@@ -282,6 +300,22 @@ test_dispatch_rolls_back_before_a_failed_launch_delivery() {
   [ "$(row_state "$case_dir" "$id")" = queued ] \
     || fail "launch delivery failed after committing backlog state $(row_state "$case_dir" "$id")"
   pass "dispatch commits neither record nor backlog state before launch delivery succeeds"
+}
+
+test_dispatch_interruption_after_backlog_commit_preserves_recovery_record() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-interrupted-b5
+  case_dir=$(make_home dispatch-interrupted "$id")
+  add_item "$case_dir" "$id"
+  interrupt_spawn_after_start_commit "$case_dir"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "interrupted spawn unexpectedly reported success"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "the injected interruption did not land after the backlog commit"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "an interruption after backlog commit deleted the paired recovery record"
+  pass "dispatch preserves its published recovery record when interrupted after backlog commit"
 }
 
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight() {
@@ -615,6 +649,7 @@ test_dispatch_refuses_an_id_this_home_has_no_item_for
 test_dispatch_refuses_a_closed_item
 test_dispatch_leaves_no_record_when_the_transition_fails
 test_dispatch_rolls_back_before_a_failed_launch_delivery
+test_dispatch_interruption_after_backlog_commit_preserves_recovery_record
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight
 test_dispatch_fails_when_its_row_vanishes_after_preflight
 test_completion_closes_a_local_only_ship_before_reporting_success

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -1310,6 +1310,26 @@ test_failed_close_replay_is_not_started_as_live_work() {
   pass "a retained pending close is never started by reconciliation"
 }
 
+test_recovery_rejects_bare_parent_report_path() {
+  local case_dir id marker out
+  id=atomic-marker-parent-report-b12
+  case_dir=$(make_home marker-parent-report)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" scout no-mistakes "spawn_gen=spawn-parent-report"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-parent-report\narg=--report\narg=..\n' \
+    "$id" "$(home_of "$case_dir")/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "bare-parent report close marker was consumed"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "bare-parent report close removed its task record"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "bare-parent report close changed the backlog row: $out"
+  pass "recovery rejects a bare-parent report path"
+}
+
 test_recovery_rejects_invalid_close_arguments() {
   local case_dir id marker out
   id=atomic-marker-invalid-args-b12
@@ -1574,6 +1594,7 @@ test_recovery_rejects_lexical_data_traversal
 test_recovery_rejects_raw_control_bytes
 test_recovery_rejects_malformed_pr_urls
 test_failed_close_replay_is_not_started_as_live_work
+test_recovery_rejects_bare_parent_report_path
 test_recovery_rejects_invalid_close_arguments
 test_recovery_rejects_a_symlinked_close_marker
 test_recovery_drops_a_close_for_a_newer_meta_incarnation

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -658,27 +658,35 @@ test_dispatch_rolls_back_before_a_failed_launch_delivery() {
   pass "dispatch commits neither record nor backlog state before launch delivery succeeds"
 }
 
-test_interrupted_kimi_delivery_does_not_commit() {
-  local case_dir id out rc=0
-  id=atomic-dispatch-kimi-interrupted-b5
-  case_dir=$(make_home dispatch-kimi-interrupted "$id")
-  add_item "$case_dir" "$id"
-  interrupt_kimi_readiness "$case_dir"
+test_interrupted_kimi_delivery_preserves_live_worker_ownership() {
+  local scope case_dir id out rc
+  for scope in automatic manual no-backlog; do
+    id="atomic-dispatch-kimi-interrupted-$scope-b5"
+    case_dir=$(make_home "dispatch-kimi-interrupted-$scope" "$id")
+    case "$scope" in
+      automatic) add_item "$case_dir" "$id" ;;
+      manual) printf '%s\n' manual > "$(home_of "$case_dir")/config/backlog-backend" ;;
+      no-backlog) rm -f "$(backlog_of "$case_dir")" ;;
+    esac
+    interrupt_kimi_readiness "$case_dir"
 
-  out=$(HOME="$(home_of "$case_dir")" \
-    FM_KIMI_READY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
-    run_spawn "$case_dir" "$id" "$case_dir/project" \
-      --harness kimi --mode no-mistakes --yolo off) || rc=$?
-  [ "$rc" -ne 0 ] || fail "an interrupted Kimi readiness check reported success"
-  assert_contains "$out" "kimi did not show a verified ready signal" \
-    "interrupted Kimi readiness lacked its delivery-failure diagnostic"
-  [ "$(row_state "$case_dir" "$id")" = queued ] \
-    || fail "interrupted Kimi delivery committed the backlog row"
-  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
-    "interrupted Kimi delivery retained its provisional task record"
-  assert_absent "$(home_of "$case_dir")/state/$id.busy-state" \
-    "interrupted Kimi delivery retained its provisional busy generation"
-  pass "interrupted Kimi delivery commits neither record nor backlog state"
+    rc=0
+    out=$(HOME="$(home_of "$case_dir")" \
+      FM_KIMI_READY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
+      run_spawn "$case_dir" "$id" "$case_dir/project" \
+        --harness kimi --mode no-mistakes --yolo off) || rc=$?
+    [ "$rc" -eq 143 ] \
+      || fail "an interrupted $scope Kimi readiness check exited $rc instead of 143: $out"
+    assert_contains "$out" "kimi did not show a verified ready signal" \
+      "interrupted $scope Kimi readiness lacked its delivery-failure diagnostic"
+    assert_present "$(home_of "$case_dir")/state/$id.meta" \
+      "interrupted $scope Kimi delivery removed the live worker's task record"
+    if [ "$scope" = automatic ]; then
+      [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+        || fail "interrupted automatic Kimi delivery did not commit the paired backlog row"
+    fi
+  done
+  pass "interrupted Kimi delivery preserves durable ownership for every backlog backend"
 }
 
 test_dispatch_defers_interruption_across_backlog_commit() {
@@ -1609,7 +1617,7 @@ test_dispatch_leaves_no_record_when_the_transition_fails
 test_dispatch_reports_an_incomplete_record_rollback
 test_dispatch_reports_an_incomplete_busy_rollback
 test_dispatch_rolls_back_before_a_failed_launch_delivery
-test_interrupted_kimi_delivery_does_not_commit
+test_interrupted_kimi_delivery_preserves_live_worker_ownership
 test_dispatch_defers_interruption_across_backlog_commit
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight
 test_dispatch_fails_when_its_row_vanishes_after_preflight

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -807,6 +807,42 @@ test_completion_records_a_relative_report_for_relocated_data() {
   pass "completion records relocated scout reports relative to the backlog root"
 }
 
+test_space_containing_scout_report_marker_replays() {
+  local case_dir id data backlog marker out rc=0
+  id=atomic-space-report-replay-b7
+  case_dir=$(make_home space-report-replay)
+  data="$case_dir/crew space/data"
+  mkdir -p "$case_dir/crew space"
+  mv "$(home_of "$case_dir")/data" "$data"
+  backlog="$data/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind scout --file "$backlog" >/dev/null
+  tasks-axi start "$id" --file "$backlog" >/dev/null
+  write_task_meta "$case_dir" "$id" scout '' "spawn_gen=spawn-space-report"
+  mkdir -p "$data/$id"
+  printf 'findings\n' > "$data/$id/report.md"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    FM_DATA_OVERRIDE="$data" PATH="$case_dir/fakebin:$PATH" \
+    "$ROOT/bin/fm-captain-hold.sh" complete "$id" --none >/dev/null \
+    || fail "could not record the space-path scout's captain-call inventory"
+  break_verb "$case_dir" done
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+
+  out=$(FM_DATA_OVERRIDE="$data" run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "space-path scout teardown unexpectedly completed"
+  assert_present "$marker" "space-path scout teardown recorded no pending close"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "space-path scout teardown retained meta after recording its close"
+  rm -f "$case_dir/fakebin/tasks-axi"
+
+  out=$(FM_DATA_OVERRIDE="$data" run_bootstrap "$case_dir")
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
+    || fail "space-containing report marker did not replay: $out"
+  assert_grep "data/$id/report.md" "$backlog" \
+    "report path from a space-containing data directory was lost during replay"
+  assert_absent "$marker" "space-containing report marker remained after replay"
+  pass "space-containing scout report paths round-trip through recovery"
+}
+
 test_completion_preserves_records_when_meta_removal_fails() {
   local case_dir id meta marker out rc=0
   id=atomic-close-meta-remove-failure-b7
@@ -1238,12 +1274,15 @@ test_recovery_rejects_a_symlinked_close_marker() {
   printf 'id=%s\ndata=%s\nspawn_gen=spawn-symlink\narg=--note\narg=local%%20main\n' \
     "$id" "$(home_of "$case_dir")/data" > "$payload"
   ln -s "$payload" "$marker"
+  rm -f "$payload"
 
   out=$(run_bootstrap "$case_dir")
-  [ -L "$marker" ] || fail "symlinked close marker was consumed: $out"
+  [ -L "$marker" ] || fail "dangling symlink close marker was consumed: $out"
+  assert_contains "$out" "recorded backlog close could not be replayed" \
+    "dangling symlink close marker was silently skipped"
   [ "$(row_state "$case_dir" "$id")" = in_flight ] \
     || fail "symlinked close marker changed the backlog row: $out"
-  pass "recovery rejects symlinked close markers"
+  pass "recovery reports and rejects dangling symlink close markers"
 }
 
 test_recovery_drops_a_close_for_a_newer_meta_incarnation() {
@@ -1450,6 +1489,7 @@ test_completion_closes_a_local_only_ship_before_reporting_success
 test_completion_closes_a_scout_with_its_report
 test_completion_refuses_a_legacy_record_without_an_incarnation
 test_completion_records_a_relative_report_for_relocated_data
+test_space_containing_scout_report_marker_replays
 test_completion_preserves_records_when_meta_removal_fails
 test_completion_fails_loudly_and_records_the_close_it_still_owes
 test_completion_fails_when_its_close_marker_cannot_be_removed

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -334,7 +334,7 @@ test_recovery_uses_the_parent_of_a_trailing_slash_data_record() {
   tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
   tasks-axi start "$id" --file "$backlog" >/dev/null
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
-  printf 'id=%s\ndata=%s/\nspawn_gen=spawn-relocated-recovery\narg=--note\narg=local main\n' "$id" "$relocated" > "$marker"
+  printf 'id=%s\ndata=%s/\nspawn_gen=spawn-relocated-recovery\narg=--note\narg=local%%20main\n' "$id" "$relocated" > "$marker"
   require_show_cwd "$case_dir" "$(cd "$case_dir" && pwd -P)"
 
   out=$(FM_DATA_OVERRIDE="$relocated/" run_bootstrap "$case_dir")
@@ -823,7 +823,7 @@ test_recovery_retries_when_a_close_marker_cannot_be_removed() {
   add_item "$case_dir" "$id"
   start_item "$case_dir" "$id"
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
-  printf 'id=%s\ndata=%s\nspawn_gen=spawn-marker-retry\narg=--note\narg=local main\n' \
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-marker-retry\narg=--note\narg=local%%20main\n' \
     "$id" "$(home_of "$case_dir")/data" > "$marker"
   break_meta_removal "$case_dir" "$marker"
 
@@ -921,7 +921,7 @@ test_recovery_preserves_a_close_when_the_backlog_cannot_be_read() {
   case_dir=$(make_home heal-read-error)
   add_item "$case_dir" "$id"
   start_item "$case_dir" "$id"
-  printf 'id=%s\ndata=%s\nspawn_gen=spawn-heal-read\narg=--note\narg=local main\n' \
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-heal-read\narg=--note\narg=local%%20main\n' \
     "$id" "$(home_of "$case_dir")/data" \
     > "$(home_of "$case_dir")/state/$id.backlog-close"
   break_verb "$case_dir" show
@@ -948,7 +948,7 @@ test_recovery_finishes_a_close_for_the_same_meta_incarnation() {
   add_item "$case_dir" "$id"
   start_item "$case_dir" "$id"
   write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-one"
-  printf 'id=%s\ndata=%s\nspawn_gen=spawn-one\narg=--note\narg=local main\n' \
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-one\narg=--note\narg=local%%20main\n' \
     "$id" "$(home_of "$case_dir")/data" \
     > "$(home_of "$case_dir")/state/$id.backlog-close"
 
@@ -970,7 +970,7 @@ test_recovery_preserves_both_records_when_meta_removal_fails() {
   start_item "$case_dir" "$id"
   meta="$(home_of "$case_dir")/state/$id.meta"
   write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-one"
-  printf 'id=%s\ndata=%s\nspawn_gen=spawn-one\narg=--note\narg=local main\n' \
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-one\narg=--note\narg=local%%20main\n' \
     "$id" "$(home_of "$case_dir")/data" \
     > "$(home_of "$case_dir")/state/$id.backlog-close"
   break_meta_removal "$case_dir" "$meta"
@@ -1003,7 +1003,7 @@ test_recovery_rejects_a_marker_for_another_task_identity() {
   start_item "$case_dir" "$target_id"
   write_task_meta "$case_dir" "$target_id" ship no-mistakes "spawn_gen=spawn-marker-target"
   marker="$(home_of "$case_dir")/state/$locked_id.backlog-close"
-  printf 'id=%s\ndata=%s\nspawn_gen=spawn-marker-target\narg=--note\narg=local main\n' \
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-marker-target\narg=--note\narg=local%%20main\n' \
     "$target_id" "$(home_of "$case_dir")/data" > "$marker"
 
   out=$(run_bootstrap "$case_dir")
@@ -1026,7 +1026,7 @@ test_recovery_rejects_a_foreign_data_directory() {
   start_item "$foreign_case" "$id"
   write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-foreign-data"
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
-  printf 'id=%s\ndata=%s\nspawn_gen=spawn-foreign-data\narg=--note\narg=local main\n' \
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-foreign-data\narg=--note\narg=local%%20main\n' \
     "$id" "$(home_of "$foreign_case")/data" > "$marker"
 
   out=$(run_bootstrap "$case_dir")
@@ -1048,7 +1048,7 @@ test_recovery_rejects_an_unterminated_unknown_field() {
   start_item "$case_dir" "$id"
   write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-unterminated-field"
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
-  printf 'id=%s\ndata=%s\nspawn_gen=spawn-unterminated-field\narg=--note\narg=local main\nunknown=value' \
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-unterminated-field\narg=--note\narg=local%%20main\nunknown=value' \
     "$id" "$(home_of "$case_dir")/data" > "$marker"
 
   out=$(run_bootstrap "$case_dir")
@@ -1070,7 +1070,7 @@ test_recovery_rejects_lexical_data_traversal() {
   data="$(home_of "$case_dir")/data"
   mkdir -p "$data/sub"
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
-  printf 'id=%s\ndata=%s/sub/..\nspawn_gen=spawn-data-traversal\narg=--note\narg=local main\n' \
+  printf 'id=%s\ndata=%s/sub/..\nspawn_gen=spawn-data-traversal\narg=--note\narg=local%%20main\n' \
     "$id" "$data" > "$marker"
 
   out=$(run_bootstrap "$case_dir")
@@ -1080,6 +1080,25 @@ test_recovery_rejects_lexical_data_traversal() {
   [ "$(row_state "$case_dir" "$id")" = in_flight ] \
     || fail "lexical data traversal changed the backlog row: $out"
   pass "recovery rejects lexical traversal before resolving marker data"
+}
+
+test_failed_close_replay_is_not_started_as_live_work() {
+  local case_dir id marker out
+  id=atomic-pending-close-not-started-b12
+  case_dir=$(make_home pending-close-not-started)
+  add_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-pending-close"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-pending-close\narg=--pr\narg=https://\n' \
+    "$id" "$(home_of "$case_dir")/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "failed close replay discarded its pending marker"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "failed close replay removed its task record"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "retained pending close was started as live work: $out"
+  pass "a retained pending close is never started by reconciliation"
 }
 
 test_recovery_rejects_invalid_close_arguments() {
@@ -1107,7 +1126,7 @@ test_recovery_rejects_a_symlinked_close_marker() {
   start_item "$case_dir" "$id"
   payload="$(home_of "$case_dir")/state/marker-payload"
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
-  printf 'id=%s\ndata=%s\nspawn_gen=spawn-symlink\narg=--note\narg=local main\n' \
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-symlink\narg=--note\narg=local%%20main\n' \
     "$id" "$(home_of "$case_dir")/data" > "$payload"
   ln -s "$payload" "$marker"
 
@@ -1125,7 +1144,7 @@ test_recovery_drops_a_close_for_a_newer_meta_incarnation() {
   add_item "$case_dir" "$id"
   start_item "$case_dir" "$id"
   write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-two"
-  printf 'id=%s\ndata=%s\nspawn_gen=spawn-one\narg=--note\narg=local main\n' \
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-one\narg=--note\narg=local%%20main\n' \
     "$id" "$(home_of "$case_dir")/data" \
     > "$(home_of "$case_dir")/state/$id.backlog-close"
 
@@ -1146,7 +1165,7 @@ test_recovery_rejects_a_legacy_close_without_an_incarnation() {
   add_item "$case_dir" "$id"
   start_item "$case_dir" "$id"
   write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-two"
-  printf 'id=%s\ndata=%s\narg=--note\narg=local main\n' \
+  printf 'id=%s\ndata=%s\narg=--note\narg=local%%20main\n' \
     "$id" "$(home_of "$case_dir")/data" \
     > "$(home_of "$case_dir")/state/$id.backlog-close"
 
@@ -1336,6 +1355,7 @@ test_recovery_rejects_a_marker_for_another_task_identity
 test_recovery_rejects_a_foreign_data_directory
 test_recovery_rejects_an_unterminated_unknown_field
 test_recovery_rejects_lexical_data_traversal
+test_failed_close_replay_is_not_started_as_live_work
 test_recovery_rejects_invalid_close_arguments
 test_recovery_rejects_a_symlinked_close_marker
 test_recovery_drops_a_close_for_a_newer_meta_incarnation

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -390,6 +390,8 @@ test_immediate_child_absolute_data_dispatches_and_completes() {
     || fail "immediate-child-data teardown failed: $out"
   [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
     || fail "immediate-child absolute completion mutated a different backlog"
+  assert_contains "$out" "fm-records/backlog.md" \
+    "relocated completion confirmed the wrong backlog path"
   pass "an immediate-child absolute data path keeps one paired backlog"
 }
 
@@ -992,6 +994,63 @@ test_recovery_preserves_both_records_when_meta_removal_fails() {
   pass "recovery preserves both records when meta removal fails"
 }
 
+test_recovery_rejects_a_marker_for_another_task_identity() {
+  local case_dir locked_id target_id marker out
+  locked_id=atomic-marker-lock-owner-b12
+  target_id=atomic-marker-target-b12
+  case_dir=$(make_home marker-identity-mismatch)
+  add_item "$case_dir" "$target_id"
+  start_item "$case_dir" "$target_id"
+  write_task_meta "$case_dir" "$target_id" ship no-mistakes "spawn_gen=spawn-marker-target"
+  marker="$(home_of "$case_dir")/state/$locked_id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-marker-target\narg=--note\narg=local main\n' \
+    "$target_id" "$(home_of "$case_dir")/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "identity-mismatched close marker was consumed"
+  assert_present "$(home_of "$case_dir")/state/$target_id.meta" \
+    "identity-mismatched close marker removed another task record"
+  [ "$(row_state "$case_dir" "$target_id")" = in_flight ] \
+    || fail "identity-mismatched close marker changed another task's row: $out"
+  pass "recovery binds close-marker identity to its locked filename"
+}
+
+test_recovery_rejects_invalid_close_arguments() {
+  local case_dir id marker out
+  id=atomic-marker-invalid-args-b12
+  case_dir=$(make_home marker-invalid-args)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-invalid-args\narg=--unknown\narg=value\n' \
+    "$id" "$(home_of "$case_dir")/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "invalid-argument close marker was consumed"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "invalid close arguments changed the backlog row: $out"
+  pass "recovery rejects close-marker arguments outside its protocol"
+}
+
+test_recovery_rejects_a_symlinked_close_marker() {
+  local case_dir id marker payload out
+  id=atomic-marker-symlink-b12
+  case_dir=$(make_home marker-symlink)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  payload="$(home_of "$case_dir")/state/marker-payload"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-symlink\narg=--note\narg=local main\n' \
+    "$id" "$(home_of "$case_dir")/data" > "$payload"
+  ln -s "$payload" "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  [ -L "$marker" ] || fail "symlinked close marker was consumed: $out"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "symlinked close marker changed the backlog row: $out"
+  pass "recovery rejects symlinked close markers"
+}
+
 test_recovery_drops_a_close_for_a_newer_meta_incarnation() {
   local case_dir id out
   id=atomic-heal-new-incarnation-b12
@@ -1124,8 +1183,8 @@ test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog()
   mv "$(home_of "$case_dir")/data" "$case_dir/manual-data"
 
   out=$(run_teardown "$case_dir" "$id") || fail "manual-backend teardown failed: $out"
-  assert_contains "$out" "Update data/backlog.md" \
-    "manual-backend teardown did not leave the backlog edit to the operator"
+  assert_contains "$out" "Update $(home_of "$case_dir")/data/backlog.md" \
+    "manual-backend teardown did not name its configured backlog path"
   assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
     "manual-backend teardown recorded a close it never owed"
   pass "a manual-backlog home dispatches and completes without a hard failure"
@@ -1206,6 +1265,9 @@ test_recovery_replays_a_close_an_interrupted_cleanup_left_open
 test_recovery_preserves_a_close_when_the_backlog_cannot_be_read
 test_recovery_finishes_a_close_for_the_same_meta_incarnation
 test_recovery_preserves_both_records_when_meta_removal_fails
+test_recovery_rejects_a_marker_for_another_task_identity
+test_recovery_rejects_invalid_close_arguments
+test_recovery_rejects_a_symlinked_close_marker
 test_recovery_drops_a_close_for_a_newer_meta_incarnation
 test_recovery_drops_a_legacy_close_when_meta_exists
 test_bootstrap_stops_when_data_disappears_before_reconciliation

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -176,6 +176,35 @@ SH
   chmod +x "$case_dir/fakebin/rm"
 }
 
+break_busy_removal() {  # <case-dir> <id>
+  local case_dir=$1 id=$2 real state
+  real=$(command -v rm)
+  state="$(home_of "$case_dir")/state"
+  cat > "$case_dir/fakebin/rm" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  case "\$arg" in
+    "$state/$id.busy-state"|"$state/$id.busy-gen") exit 1 ;;
+  esac
+done
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/rm"
+}
+
+break_meta_publication() {  # <case-dir> <meta-path>
+  local case_dir=$1 meta=$2 real
+  real=$(command -v mv)
+  cat > "$case_dir/fakebin/mv" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  [ "\$arg" != "$meta" ] || exit 1
+done
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/mv"
+}
+
 write_task_meta() {  # <case-dir> <id> <kind> <mode> [extra-line...]
   local case_dir=$1 id=$2 kind=$3 mode=$4
   shift 4
@@ -289,6 +318,26 @@ test_dispatch_refuses_a_closed_item() {
   pass "dispatch refuses a closed item instead of silently reopening it"
 }
 
+test_dispatch_refuses_to_commit_without_a_published_record() {
+  local case_dir id meta out rc=0
+  id=atomic-dispatch-publish-failure-b4
+  case_dir=$(make_home dispatch-publish-failure "$id")
+  add_item "$case_dir" "$id"
+  meta="$(home_of "$case_dir")/state/$id.meta"
+  break_meta_publication "$case_dir" "$meta"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn succeeded without publishing its task record"
+  assert_contains "$out" "task record for $id could not be published" \
+    "spawn did not report task-record publication failure"
+  assert_absent "$meta" "failed publication left a task record"
+  assert_absent "$(home_of "$case_dir")/state/$id.busy-state" \
+    "failed publication retained its busy state"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "failed publication moved the backlog row"
+  pass "dispatch cannot commit without a verified task-record publication"
+}
+
 test_dispatch_leaves_no_record_when_the_transition_fails() {
   local case_dir id out rc=0
   id=atomic-dispatch-b4
@@ -328,6 +377,27 @@ test_dispatch_reports_an_incomplete_record_rollback() {
   [ "$(row_state "$case_dir" "$id")" = queued ] \
     || fail "failed rollback changed the backlog row"
   pass "dispatch reports when failed-transition rollback cannot remove its record"
+}
+
+test_dispatch_reports_an_incomplete_busy_rollback() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-busy-remove-failure-b5
+  case_dir=$(make_home dispatch-busy-remove-failure "$id")
+  add_item "$case_dir" "$id"
+  break_verb "$case_dir" start
+  break_busy_removal "$case_dir" "$id"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn succeeded though busy rollback failed"
+  assert_contains "$out" "did not remove both task and busy records" \
+    "spawn did not report incomplete busy rollback"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "busy rollback failure retained the provisional task record"
+  assert_present "$(home_of "$case_dir")/state/$id.busy-state" \
+    "busy removal failure was reported as successful"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "failed busy rollback changed the backlog row"
+  pass "dispatch verifies both task and busy records during rollback"
 }
 
 test_dispatch_rolls_back_before_a_failed_launch_delivery() {
@@ -445,6 +515,28 @@ test_completion_closes_a_scout_with_its_report() {
   pass "completion closes a scout item against its report"
 }
 
+test_completion_preserves_records_when_meta_removal_fails() {
+  local case_dir id meta marker out rc=0
+  id=atomic-close-meta-remove-failure-b7
+  case_dir=$(make_home close-meta-remove-failure)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-one"
+  meta="$(home_of "$case_dir")/state/$id.meta"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  break_meta_removal "$case_dir" "$meta"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown succeeded though task-record removal failed"
+  assert_contains "$out" "task record could not be removed" \
+    "teardown did not report task-record removal failure"
+  assert_present "$meta" "teardown lost meta after its removal failed"
+  assert_present "$marker" "teardown discarded recovery after meta removal failed"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "teardown closed the row before verifying meta removal"
+  pass "completion preserves recovery state when task-record removal fails"
+}
+
 test_completion_fails_loudly_and_records_the_close_it_still_owes() {
   local case_dir id out rc=0
   id=atomic-close-b7
@@ -497,7 +589,7 @@ test_recovery_retries_when_a_close_marker_cannot_be_removed() {
   break_meta_removal "$case_dir" "$marker"
 
   out=$(run_bootstrap "$case_dir")
-  assert_contains "$out" "could not remove pending-close record" \
+  assert_contains "$out" "pending-close record could not be removed" \
     "session start did not report close-marker removal failure"
   assert_present "$marker" "recovery hid a close-marker removal failure"
   [ "$(row_state "$case_dir" "$id")" = done ] \
@@ -603,7 +695,7 @@ test_recovery_preserves_both_records_when_meta_removal_fails() {
   break_meta_removal "$case_dir" "$meta"
 
   out=$(run_bootstrap "$case_dir")
-  assert_contains "$out" "could not remove the interrupted task record" \
+  assert_contains "$out" "the interrupted task record could not be removed" \
     "session start did not surface the record-removal failure"
   assert_present "$meta" "failed recovery removed the task record"
   assert_present "$(home_of "$case_dir")/state/$id.backlog-close" \
@@ -743,14 +835,17 @@ test_dispatch_moves_the_item_in_flight_in_the_same_run
 test_dispatch_refuses_an_id_this_home_has_no_item_for
 test_dispatch_reports_a_backlog_read_failure
 test_dispatch_refuses_a_closed_item
+test_dispatch_refuses_to_commit_without_a_published_record
 test_dispatch_leaves_no_record_when_the_transition_fails
 test_dispatch_reports_an_incomplete_record_rollback
+test_dispatch_reports_an_incomplete_busy_rollback
 test_dispatch_rolls_back_before_a_failed_launch_delivery
 test_dispatch_defers_interruption_across_backlog_commit
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight
 test_dispatch_fails_when_its_row_vanishes_after_preflight
 test_completion_closes_a_local_only_ship_before_reporting_success
 test_completion_closes_a_scout_with_its_report
+test_completion_preserves_records_when_meta_removal_fails
 test_completion_fails_loudly_and_records_the_close_it_still_owes
 test_completion_fails_when_its_close_marker_cannot_be_removed
 test_recovery_retries_when_a_close_marker_cannot_be_removed

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -1040,6 +1040,48 @@ test_recovery_rejects_a_foreign_data_directory() {
   pass "recovery rejects close markers targeting another home's data"
 }
 
+test_recovery_rejects_an_unterminated_unknown_field() {
+  local case_dir id marker out
+  id=atomic-marker-unterminated-field-b12
+  case_dir=$(make_home marker-unterminated-field)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-unterminated-field"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-unterminated-field\narg=--note\narg=local main\nunknown=value' \
+    "$id" "$(home_of "$case_dir")/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "marker with an unterminated unknown field was consumed"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "unterminated unknown marker field allowed task-record removal"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "unterminated unknown marker field changed the backlog row: $out"
+  pass "recovery validates an unterminated final marker field"
+}
+
+test_recovery_rejects_lexical_data_traversal() {
+  local case_dir id marker data out
+  id=atomic-marker-data-traversal-b12
+  case_dir=$(make_home marker-data-traversal)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-data-traversal"
+  data="$(home_of "$case_dir")/data"
+  mkdir -p "$data/sub"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s/sub/..\nspawn_gen=spawn-data-traversal\narg=--note\narg=local main\n' \
+    "$id" "$data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "marker with lexical data traversal was consumed"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "lexical data traversal allowed task-record removal"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "lexical data traversal changed the backlog row: $out"
+  pass "recovery rejects lexical traversal before resolving marker data"
+}
+
 test_recovery_rejects_invalid_close_arguments() {
   local case_dir id marker out
   id=atomic-marker-invalid-args-b12
@@ -1292,6 +1334,8 @@ test_recovery_finishes_a_close_for_the_same_meta_incarnation
 test_recovery_preserves_both_records_when_meta_removal_fails
 test_recovery_rejects_a_marker_for_another_task_identity
 test_recovery_rejects_a_foreign_data_directory
+test_recovery_rejects_an_unterminated_unknown_field
+test_recovery_rejects_lexical_data_traversal
 test_recovery_rejects_invalid_close_arguments
 test_recovery_rejects_a_symlinked_close_marker
 test_recovery_drops_a_close_for_a_newer_meta_incarnation

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -58,8 +58,20 @@ make_home() {  # <name> [task-id...]
 
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
-case "$*" in *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;; esac
-case "${1:-}" in display-message) printf 'firstmate\n'; exit 0 ;; esac
+case "${1:-}" in
+  kill-window)
+    [ -z "${FM_FAKE_ENDPOINT_LIVE:-}" ] || rm -f "$FM_FAKE_ENDPOINT_LIVE"
+    exit 0
+    ;;
+  display-message)
+    if [ -n "${FM_FAKE_ENDPOINT_LIVE:-}" ] && [ ! -f "$FM_FAKE_ENDPOINT_LIVE" ]; then
+      exit 1
+    fi
+    case "$*" in *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;; esac
+    printf 'firstmate\n'
+    exit 0
+    ;;
+esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
@@ -200,6 +212,37 @@ SH
   chmod +x "$case_dir/fakebin/tmux"
 }
 
+fail_kimi_readiness() {  # <case-dir> <stopped|stuck>
+  local case_dir=$1 kill_mode=$2 home
+  home=$(home_of "$case_dir")
+  mkdir -p "$home/.kimi-code"
+  printf '# test config\n' > "$home/.kimi-code/config.toml"
+  fm_fake_exit0 "$case_dir/fakebin" kimi
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+case "\${1:-}" in
+  kill-window)
+    [ "$kill_mode" = stuck ] || rm -f "\${FM_FAKE_ENDPOINT_LIVE:-}"
+    exit 0
+    ;;
+  display-message)
+    if [ -n "\${FM_FAKE_ENDPOINT_LIVE:-}" ] && [ ! -f "\$FM_FAKE_ENDPOINT_LIVE" ]; then
+      exit 1
+    fi
+    case "\$*" in
+      *"#{pane_current_path}"*) printf '%s\\n' "\${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+      *"#{cursor_y}"*) printf '1\\n'; exit 0 ;;
+    esac
+    printf 'firstmate\\n'
+    exit 0
+    ;;
+  capture-pane) printf 'shell starting\\n$ \\n'; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux"
+}
+
 interrupt_kimi_readiness() {  # <case-dir>
   local case_dir=$1 home
   home=$(home_of "$case_dir")
@@ -310,8 +353,10 @@ write_task_meta() {  # <case-dir> <id> <kind> <mode> [extra-line...]
 run_spawn() {  # <case-dir> <args...>
   local case_dir=$1
   shift
+  : > "$case_dir/endpoint-live"
   FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$case_dir/wt" TMUX="fake,1,0" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$case_dir/wt" \
+    FM_FAKE_ENDPOINT_LIVE="$case_dir/endpoint-live" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR='' \
     PATH="$case_dir/fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
@@ -689,6 +734,39 @@ test_interrupted_kimi_delivery_preserves_live_worker_ownership() {
   pass "interrupted Kimi delivery preserves durable ownership for every backlog backend"
 }
 
+test_failed_kimi_delivery_preserves_or_stops_worker_ownership() {
+  local outcome case_dir id out rc
+  for outcome in stopped stuck; do
+    id="atomic-dispatch-kimi-failed-$outcome-b5"
+    case_dir=$(make_home "dispatch-kimi-failed-$outcome" "$id")
+    add_item "$case_dir" "$id"
+    fail_kimi_readiness "$case_dir" "$outcome"
+
+    rc=0
+    out=$(HOME="$(home_of "$case_dir")" \
+      FM_KIMI_READY_POLLS=1 FM_KIMI_POLL_INTERVAL=0 \
+      run_spawn "$case_dir" "$id" "$case_dir/project" \
+        --harness kimi --mode no-mistakes --yolo off) || rc=$?
+    [ "$rc" -ne 0 ] || fail "failed Kimi delivery reported success: $out"
+    if [ "$outcome" = stopped ]; then
+      assert_absent "$case_dir/endpoint-live" \
+        "failed Kimi delivery left its endpoint running"
+      assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+        "stopped Kimi worker retained its provisional task record"
+      [ "$(row_state "$case_dir" "$id")" = queued ] \
+        || fail "stopped Kimi delivery changed the backlog row"
+    else
+      assert_present "$case_dir/endpoint-live" \
+        "stuck Kimi endpoint did not remain observable"
+      assert_present "$(home_of "$case_dir")/state/$id.meta" \
+        "stuck Kimi worker lost its ownership record"
+      assert_contains "$out" "retaining task and busy records" \
+        "stuck Kimi worker did not report retained ownership"
+    fi
+  done
+  pass "failed Kimi delivery stops workers or retains their ownership"
+}
+
 test_dispatch_defers_interruption_across_backlog_commit() {
   local timing case_dir id out rc
   for timing in before after; do
@@ -868,6 +946,52 @@ test_space_containing_scout_report_marker_replays() {
     "report path from a space-containing data directory was lost during replay"
   assert_absent "$marker" "space-containing report marker remained after replay"
   pass "space-containing scout report paths round-trip through recovery"
+}
+
+test_non_ascii_close_marker_replays_across_locales() {
+  local direction writer_locale replay_locale utf8_locale case_dir id data backlog marker out rc
+  utf8_locale=$(locale -a 2>/dev/null | awk 'tolower($0) ~ /utf-?8/ { print; exit }')
+  [ -n "$utf8_locale" ] || {
+    pass "non-ASCII locale replay skipped without an installed UTF-8 locale"
+    return 0
+  }
+  for direction in utf8-to-c c-to-utf8; do
+    case "$direction" in
+      utf8-to-c) writer_locale=$utf8_locale; replay_locale=C ;;
+      c-to-utf8) writer_locale=C; replay_locale=$utf8_locale ;;
+    esac
+    id="atomic-nonascii-replay-$direction-b7"
+    case_dir=$(make_home "nonascii-replay-$direction")
+    data="$case_dir/café/data"
+    mkdir -p "$case_dir/café"
+    mv "$(home_of "$case_dir")/data" "$data"
+    backlog="$data/backlog.md"
+    tasks-axi add "$id" "item for $id" --kind scout --file "$backlog" >/dev/null
+    tasks-axi start "$id" --file "$backlog" >/dev/null
+    write_task_meta "$case_dir" "$id" scout '' "spawn_gen=spawn-nonascii-$direction"
+    mkdir -p "$data/$id"
+    printf 'findings\n' > "$data/$id/report.md"
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+      FM_DATA_OVERRIDE="$data" PATH="$case_dir/fakebin:$PATH" \
+      "$ROOT/bin/fm-captain-hold.sh" complete "$id" --none >/dev/null \
+      || fail "could not record the non-ASCII scout's captain-call inventory"
+    break_verb "$case_dir" "done"
+    marker="$(home_of "$case_dir")/state/$id.backlog-close"
+
+    rc=0
+    out=$(LC_ALL="$writer_locale" FM_DATA_OVERRIDE="$data" \
+      run_teardown "$case_dir" "$id") || rc=$?
+    [ "$rc" -ne 0 ] || fail "$direction teardown unexpectedly completed"
+    assert_present "$marker" "$direction teardown recorded no pending close"
+    rm -f "$case_dir/fakebin/tasks-axi"
+
+    out=$(LC_ALL="$replay_locale" FM_DATA_OVERRIDE="$data" \
+      run_bootstrap "$case_dir")
+    [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
+      || fail "$direction non-ASCII marker did not replay: $out"
+    assert_absent "$marker" "$direction non-ASCII marker remained after replay"
+  done
+  pass "non-ASCII close markers replay across process locales"
 }
 
 test_trailing_newline_data_path_fails_closed() {
@@ -1618,6 +1742,7 @@ test_dispatch_reports_an_incomplete_record_rollback
 test_dispatch_reports_an_incomplete_busy_rollback
 test_dispatch_rolls_back_before_a_failed_launch_delivery
 test_interrupted_kimi_delivery_preserves_live_worker_ownership
+test_failed_kimi_delivery_preserves_or_stops_worker_ownership
 test_dispatch_defers_interruption_across_backlog_commit
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight
 test_dispatch_fails_when_its_row_vanishes_after_preflight
@@ -1626,6 +1751,7 @@ test_completion_closes_a_scout_with_its_report
 test_completion_refuses_a_legacy_record_without_an_incarnation
 test_completion_records_a_relative_report_for_relocated_data
 test_space_containing_scout_report_marker_replays
+test_non_ascii_close_marker_replays_across_locales
 test_trailing_newline_data_path_fails_closed
 test_control_character_data_path_is_refused_before_cleanup
 test_completion_preserves_records_when_meta_removal_fails

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -1104,28 +1104,37 @@ test_recovery_rejects_raw_control_bytes() {
 }
 
 test_recovery_rejects_malformed_pr_urls() {
-  local case_dir first_id second_id first_marker second_marker out
+  local case_dir first_id second_id third_id first_marker second_marker third_marker out
   first_id=atomic-marker-pr-port-b12
   second_id=atomic-marker-pr-percent-b12
+  third_id=atomic-marker-pr-host-label-b12
   case_dir=$(make_home marker-malformed-pr)
   add_item "$case_dir" "$first_id"
   start_item "$case_dir" "$first_id"
   add_item "$case_dir" "$second_id"
   start_item "$case_dir" "$second_id"
+  add_item "$case_dir" "$third_id"
+  start_item "$case_dir" "$third_id"
   first_marker="$(home_of "$case_dir")/state/$first_id.backlog-close"
   second_marker="$(home_of "$case_dir")/state/$second_id.backlog-close"
+  third_marker="$(home_of "$case_dir")/state/$third_id.backlog-close"
   printf 'id=%s\ndata=%s\nspawn_gen=spawn-pr-port\narg=--pr\narg=https://github.com:abc/pull/1\n' \
     "$first_id" "$(home_of "$case_dir")/data" > "$first_marker"
   printf 'id=%s\ndata=%s\nspawn_gen=spawn-pr-percent\narg=--pr\narg=https://github.com/pull/%%ZZ\n' \
     "$second_id" "$(home_of "$case_dir")/data" > "$second_marker"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-pr-host-label\narg=--pr\narg=https://foo.-bar.com/pull/1\n' \
+    "$third_id" "$(home_of "$case_dir")/data" > "$third_marker"
 
   out=$(run_bootstrap "$case_dir")
   assert_present "$first_marker" "PR marker with a nonnumeric port was consumed"
   assert_present "$second_marker" "PR marker with an invalid percent escape was consumed"
+  assert_present "$third_marker" "PR marker with a malformed host label was consumed"
   [ "$(row_state "$case_dir" "$first_id")" = in_flight ] \
     || fail "nonnumeric PR port changed the backlog row: $out"
   [ "$(row_state "$case_dir" "$second_id")" = in_flight ] \
     || fail "invalid PR percent escape changed the backlog row: $out"
+  [ "$(row_state "$case_dir" "$third_id")" = in_flight ] \
+    || fail "malformed PR host label changed the backlog row: $out"
   pass "recovery rejects malformed PR URL values"
 }
 

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -338,7 +338,7 @@ test_recovery_uses_the_parent_of_a_trailing_slash_data_record() {
   require_show_cwd "$case_dir" "$(cd "$case_dir" && pwd -P)"
 
   out=$(run_bootstrap "$case_dir")
-  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = done ] \
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
     || fail "relocated-data recovery used the wrong addressing root: $out"
   assert_absent "$marker" "relocated-data recovery retained its close marker"
   pass "recovery uses the parent of a trailing-slash data record"
@@ -362,7 +362,7 @@ test_completion_targets_a_nested_relative_data_directory() {
     FM_DATA_OVERRIDE="$relative_data" PATH="$case_dir/fakebin:$PATH" \
     "$TEARDOWN" "$id" 2>&1) \
     || fail "relative-data teardown failed: $out"
-  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = done ] \
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
     || fail "relative-data teardown mutated a different backlog file"
   assert_absent "$(home_of "$case_dir")/state/$id.meta" \
     "relative-data teardown retained its task record"
@@ -388,7 +388,7 @@ test_immediate_child_absolute_data_dispatches_and_completes() {
   write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-immediate-child"
   out=$(FM_DATA_OVERRIDE="$data" run_teardown "$case_dir" "$id") \
     || fail "immediate-child-data teardown failed: $out"
-  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = done ] \
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
     || fail "immediate-child absolute completion mutated a different backlog"
   pass "an immediate-child absolute data path keeps one paired backlog"
 }
@@ -410,7 +410,7 @@ test_bare_relative_data_dispatches_and_completes() {
   write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-bare-relative"
   out=$(cd "$case_dir" && FM_DATA_OVERRIDE=records run_teardown "$case_dir" "$id") \
     || fail "bare-relative-data teardown failed: $out"
-  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = done ] \
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
     || fail "bare relative completion mutated a different backlog"
   pass "bare relative data addresses one backlog through dispatch and completion"
 }
@@ -745,7 +745,7 @@ test_completion_records_a_relative_report_for_relocated_data() {
 
   out=$(FM_DATA_OVERRIDE="$relocated////" run_teardown "$case_dir" "$id") \
     || fail "relocated scout teardown failed: $out"
-  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = done ] \
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
     || fail "relocated scout backlog row was not closed"
   assert_grep "data/$id/report.md" "$backlog" \
     "relocated scout close did not record a relative report path"
@@ -807,7 +807,7 @@ test_completion_fails_when_its_close_marker_cannot_be_removed() {
   assert_contains "$out" "pending-close record could not be removed" \
     "teardown did not report its incomplete marker cleanup"
   assert_present "$marker" "teardown hid a close-marker removal failure"
-  [ "$(row_state "$case_dir" "$id")" = done ] \
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
     || fail "marker cleanup failure lost the completed backlog transition"
   pass "completion reports failure until its durable close marker is removed"
 }
@@ -829,7 +829,7 @@ test_recovery_retries_when_a_close_marker_cannot_be_removed() {
   assert_contains "$out" "pending-close record could not be removed" \
     "session start did not report close-marker removal failure"
   assert_present "$marker" "recovery hid a close-marker removal failure"
-  [ "$(row_state "$case_dir" "$id")" = done ] \
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
     || fail "recovery did not land the close before marker cleanup"
 
   rm -f "$case_dir/fakebin/rm"

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -148,6 +148,25 @@ SH
   chmod +x "$case_dir/fakebin/tasks-axi"
 }
 
+interrupt_spawn_during_launch_submit() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+case "\$*" in *"#{pane_current_path}"*) printf '%s\n' "\${FM_FAKE_PANE_PATH:-}"; exit 0 ;; esac
+case "\${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  send-keys)
+    if [ "\$#" -eq 4 ] && [ "\${4:-}" = Enter ] && [ ! -e "$case_dir/launch-interrupted" ]; then
+      : > "$case_dir/launch-interrupted"
+      kill -TERM "\$PPID"
+    fi
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux"
+}
+
 change_row_on_second_show() {  # <case-dir> <done|rm>
   local case_dir=$1 action=$2 real
   real=$(command -v tasks-axi)
@@ -1489,6 +1508,31 @@ test_home_without_a_backlog_dispatches_and_completes() {
   pass "a home with no backlog remains exempt from lifecycle transitions"
 }
 
+test_interrupted_exempt_spawn_preserves_published_ownership() {
+  local exemption case_dir id out rc
+  for exemption in no-backlog manual; do
+    id="atomic-$exemption-interrupted-b12"
+    case_dir=$(make_home "$exemption-interrupted" "$id")
+    if [ "$exemption" = no-backlog ]; then
+      rm -f "$(backlog_of "$case_dir")"
+    else
+      printf '%s\n' manual > "$(home_of "$case_dir")/config/backlog-backend"
+    fi
+    interrupt_spawn_during_launch_submit "$case_dir"
+
+    rc=0
+    out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+    [ "$rc" -eq 143 ] || fail "an interrupted $exemption spawn exited $rc instead of 143: $out"
+    assert_contains "$out" "published task and busy records were preserved" \
+      "an interrupted $exemption spawn did not report its durable ownership"
+    assert_present "$(home_of "$case_dir")/state/$id.meta" \
+      "an interrupted $exemption spawn removed its published task record"
+    assert_present "$(home_of "$case_dir")/state/$id.busy-state" \
+      "an interrupted $exemption spawn removed its published busy record"
+  done
+  pass "interrupted backlog-exempt spawns retain durable ownership after launch submission"
+}
+
 test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog() {
   local case_dir id out
   id=atomic-manual-b12
@@ -1603,6 +1647,7 @@ test_bootstrap_stops_when_data_disappears_before_reconciliation
 test_bootstrap_addressing_exemptions_remain_nonfatal
 test_recovery_leaves_a_captain_held_item_alone
 test_home_without_a_backlog_dispatches_and_completes
+test_interrupted_exempt_spawn_preserves_published_ownership
 test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog
 test_a_secondmate_home_keeps_its_own_books
 test_a_persistent_secondmate_is_never_a_backlog_item

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -371,6 +371,28 @@ test_completion_targets_a_nested_relative_data_directory() {
   pass "completion targets nested relative data from the caller directory"
 }
 
+test_immediate_child_absolute_data_dispatches_and_completes() {
+  local case_dir id data backlog out
+  id=atomic-immediate-child-data-b2
+  case_dir=$(make_home immediate-child-data "$id")
+  data="$case_dir/fm-records"
+  mv "$(home_of "$case_dir")/data" "$data"
+  backlog="$data/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
+
+  out=$(FM_DATA_OVERRIDE="$data" run_ship_spawn "$case_dir" "$id") \
+    || fail "immediate-child-data spawn failed: $out"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = in_flight ] \
+    || fail "immediate-child absolute dispatch mutated a different backlog"
+  rm -f "$(home_of "$case_dir")/state/$id.meta"
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-immediate-child"
+  out=$(FM_DATA_OVERRIDE="$data" run_teardown "$case_dir" "$id") \
+    || fail "immediate-child-data teardown failed: $out"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = done ] \
+    || fail "immediate-child absolute completion mutated a different backlog"
+  pass "an immediate-child absolute data path keeps one paired backlog"
+}
+
 test_bare_relative_data_dispatches_and_completes() {
   local case_dir id data backlog out
   id=atomic-bare-relative-data-b2
@@ -1032,7 +1054,7 @@ test_bootstrap_stops_when_data_disappears_before_reconciliation() {
 }
 
 test_bootstrap_addressing_exemptions_remain_nonfatal() {
-  local manual_case no_backlog_case out
+  local manual_case no_backlog_case secondmate_case secondmate_id out
   manual_case=$(make_home bootstrap-manual-exempt)
   printf '%s\n' manual > "$(home_of "$manual_case")/config/backlog-backend"
   mv "$(home_of "$manual_case")/data" "$manual_case/manual-data"
@@ -1043,7 +1065,17 @@ test_bootstrap_addressing_exemptions_remain_nonfatal() {
   rm -f "$(backlog_of "$no_backlog_case")"
   out=$(run_bootstrap "$no_backlog_case") \
     || fail "no-backlog bootstrap exemption became fatal: $out"
-  pass "bootstrap preserves manual and absent-backlog exemptions"
+
+  secondmate_id=atomic-bootstrap-secondmate-exempt-b11
+  secondmate_case=$(make_home bootstrap-secondmate-exempt)
+  write_task_meta "$secondmate_case" "$secondmate_id" secondmate '' \
+    "spawn_gen=spawn-secondmate-exempt"
+  mv "$(home_of "$secondmate_case")/data" "$secondmate_case/secondmate-data"
+  out=$(run_bootstrap "$secondmate_case") \
+    || fail "secondmate bootstrap exemption became fatal: $out"
+  assert_present "$(home_of "$secondmate_case")/state/$secondmate_id.meta" \
+    "secondmate bootstrap exemption removed the persistent agent record"
+  pass "bootstrap preserves secondmate, manual, and absent-backlog exemptions"
 }
 
 test_recovery_leaves_a_captain_held_item_alone() {
@@ -1144,6 +1176,7 @@ test_dispatch_moves_the_item_in_flight_in_the_same_run
 test_dispatch_reads_the_row_from_the_backlog_root
 test_recovery_uses_the_parent_of_a_trailing_slash_data_record
 test_completion_targets_a_nested_relative_data_directory
+test_immediate_child_absolute_data_dispatches_and_completes
 test_bare_relative_data_dispatches_and_completes
 test_dispatch_refuses_an_unresolvable_data_directory
 test_completion_refuses_an_unresolvable_data_directory

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -843,18 +843,60 @@ test_space_containing_scout_report_marker_replays() {
   pass "space-containing scout report paths round-trip through recovery"
 }
 
+test_trailing_newline_data_path_fails_closed() {
+  local case_dir home id data backlog_alias out rc=0
+  id=atomic-newline-data-refusal-c8
+  case_dir=$(make_home newline-data-refusal "$id")
+  home=$(home_of "$case_dir")
+  data="$home/data"$'\n'
+  mv "$home/data" "$data"
+  mkdir -p "$home/data/$id"
+  cp "$data/$id/brief.md" "$home/data/$id/brief.md"
+  ln -s "$data" "$case_dir/data-alias"
+  backlog_alias="$case_dir/data-alias/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind ship --file "$backlog_alias" >/dev/null
+
+  out=$(FM_DATA_OVERRIDE="$data" run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "trailing-newline data path bypassed dispatch transition"
+  assert_absent "$home/state/$id.meta" \
+    "trailing-newline dispatch published a task record"
+  [ "$(tasks-axi show "$id" --file "$backlog_alias" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = queued ] \
+    || fail "trailing-newline dispatch changed the real backlog row: $out"
+
+  tasks-axi start "$id" --file "$backlog_alias" >/dev/null
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-newline-data"
+  rc=0
+  out=$(FM_DATA_OVERRIDE="$data" run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "trailing-newline data path bypassed completion transition"
+  assert_present "$home/state/$id.meta" \
+    "trailing-newline teardown removed the task record"
+  assert_absent "$home/state/$id.backlog-close" \
+    "trailing-newline teardown published a close marker"
+  [ "$(tasks-axi show "$id" --file "$backlog_alias" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = in_flight ] \
+    || fail "trailing-newline teardown changed the real backlog row: $out"
+  pass "control-byte data paths fail closed before paired transitions"
+}
+
 test_control_character_data_path_is_refused_before_cleanup() {
   local case_dir id data backlog marker out rc=0
   id=atomic-control-data-refusal-b7
-  case_dir=$(make_home control-data-refusal)
+  case_dir=$(make_home control-data-refusal "$id")
   data="$case_dir/crew"$'\t'"data"
   mv "$(home_of "$case_dir")/data" "$data"
   backlog="$data/backlog.md"
   tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
+
+  out=$(FM_DATA_OVERRIDE="$data" run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "control-character data path passed dispatch preflight"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "control-character dispatch published a task record"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = queued ] \
+    || fail "control-character dispatch changed the backlog row: $out"
+
   tasks-axi start "$id" --file "$backlog" >/dev/null
   write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-control-data"
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
-
+  rc=0
   out=$(FM_DATA_OVERRIDE="$data" run_teardown "$case_dir" "$id") || rc=$?
   [ "$rc" -ne 0 ] || fail "control-character data path passed close preflight"
   assert_present "$(home_of "$case_dir")/state/$id.meta" \
@@ -1512,6 +1554,7 @@ test_completion_closes_a_scout_with_its_report
 test_completion_refuses_a_legacy_record_without_an_incarnation
 test_completion_records_a_relative_report_for_relocated_data
 test_space_containing_scout_report_marker_replays
+test_trailing_newline_data_path_fails_closed
 test_control_character_data_path_is_refused_before_cleanup
 test_completion_preserves_records_when_meta_removal_fails
 test_completion_fails_loudly_and_records_the_close_it_still_owes

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -535,7 +535,7 @@ test_completion_closes_a_local_only_ship_before_reporting_success() {
   case_dir=$(make_home close-local-only)
   add_item "$case_dir" "$id"
   start_item "$case_dir" "$id"
-  write_task_meta "$case_dir" "$id" ship local-only
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-close-local"
 
   out=$(run_teardown "$case_dir" "$id") || fail "teardown failed: $out"
   [ "$(row_state "$case_dir" "$id")" = "done" ] \
@@ -551,7 +551,7 @@ test_completion_closes_a_scout_with_its_report() {
   case_dir=$(make_home close-scout)
   add_item "$case_dir" "$id" scout
   start_item "$case_dir" "$id"
-  write_task_meta "$case_dir" "$id" scout ''
+  write_task_meta "$case_dir" "$id" scout '' "spawn_gen=spawn-close-scout"
   # A scout's deliverable is its report, and teardown also enforces the shared
   # captain-call completion gate; satisfy both the way a real scout does.
   mkdir -p "$(home_of "$case_dir")/data/$id"
@@ -567,6 +567,54 @@ test_completion_closes_a_scout_with_its_report() {
   assert_grep "data/$id/report.md" "$(backlog_of "$case_dir")" \
     "a closed scout item did not record its report"
   pass "completion closes a scout item against its report"
+}
+
+test_completion_refuses_a_legacy_record_without_an_incarnation() {
+  local case_dir id meta out rc=0
+  id=atomic-close-legacy-no-incarnation-b7
+  case_dir=$(make_home close-legacy-no-incarnation)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only
+  meta="$(home_of "$case_dir")/state/$id.meta"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown accepted a record with no durable incarnation"
+  assert_contains "$out" "record has no spawn_gen" \
+    "teardown did not explain why the legacy record cannot close automatically"
+  assert_present "$meta" "legacy-record refusal removed the task record"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "legacy-record refusal wrote an unrecoverable close marker"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "legacy-record refusal changed the backlog row"
+  pass "completion leaves legacy records open when no incarnation can be recorded"
+}
+
+test_completion_records_a_relative_report_for_relocated_data() {
+  local case_dir id relocated backlog out
+  id=atomic-close-relocated-scout-b7
+  case_dir=$(make_home close-relocated-scout)
+  relocated="$case_dir/relocated/data"
+  mkdir -p "$case_dir/relocated"
+  mv "$(home_of "$case_dir")/data" "$relocated"
+  backlog="$relocated/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind scout --file "$backlog" >/dev/null
+  tasks-axi start "$id" --file "$backlog" >/dev/null
+  write_task_meta "$case_dir" "$id" scout '' "spawn_gen=spawn-relocated-scout"
+  mkdir -p "$relocated/$id"
+  printf 'findings\n' > "$relocated/$id/report.md"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    FM_DATA_OVERRIDE="$relocated/" PATH="$case_dir/fakebin:$PATH" \
+    "$ROOT/bin/fm-captain-hold.sh" complete "$id" --none >/dev/null \
+    || fail "could not record the relocated scout's captain-call inventory"
+
+  out=$(FM_DATA_OVERRIDE="$relocated/" run_teardown "$case_dir" "$id") \
+    || fail "relocated scout teardown failed: $out"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = done ] \
+    || fail "relocated scout backlog row was not closed"
+  assert_grep "data/$id/report.md" "$backlog" \
+    "relocated scout close did not record a relative report path"
+  pass "completion records relocated scout reports relative to the backlog root"
 }
 
 test_completion_preserves_records_when_meta_removal_fails() {
@@ -597,7 +645,7 @@ test_completion_fails_loudly_and_records_the_close_it_still_owes() {
   case_dir=$(make_home close-fails)
   add_item "$case_dir" "$id"
   start_item "$case_dir" "$id"
-  write_task_meta "$case_dir" "$id" ship local-only
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-close-fails"
   break_verb "$case_dir" "done"
 
   out=$(run_teardown "$case_dir" "$id") || rc=$?
@@ -615,7 +663,7 @@ test_completion_fails_when_its_close_marker_cannot_be_removed() {
   case_dir=$(make_home close-marker-remove-failure)
   add_item "$case_dir" "$id"
   start_item "$case_dir" "$id"
-  write_task_meta "$case_dir" "$id" ship local-only
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-marker-fails"
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
   break_meta_removal "$case_dir" "$marker"
 
@@ -901,7 +949,7 @@ test_a_secondmate_home_keeps_its_own_books() {
     || fail "a mate's own dispatch left its item at $(row_state "$case_dir" "$id")"
 
   rm -f "$(home_of "$case_dir")/state/$id.meta"
-  write_task_meta "$case_dir" "$id" ship local-only
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-mate-close"
   out=$(run_teardown "$case_dir" "$id") || fail "mate-home teardown failed: $out"
   [ "$(row_state "$case_dir" "$id")" = "done" ] \
     || fail "a mate's own completion left its item at $(row_state "$case_dir" "$id")"
@@ -943,6 +991,8 @@ test_dispatch_does_not_resurrect_a_row_closed_after_preflight
 test_dispatch_fails_when_its_row_vanishes_after_preflight
 test_completion_closes_a_local_only_ship_before_reporting_success
 test_completion_closes_a_scout_with_its_report
+test_completion_refuses_a_legacy_record_without_an_incarnation
+test_completion_records_a_relative_report_for_relocated_data
 test_completion_preserves_records_when_meta_removal_fails
 test_completion_fails_loudly_and_records_the_close_it_still_owes
 test_completion_fails_when_its_close_marker_cannot_be_removed

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -646,7 +646,8 @@ test_interrupted_kimi_delivery_does_not_commit() {
   add_item "$case_dir" "$id"
   interrupt_kimi_readiness "$case_dir"
 
-  out=$(FM_KIMI_READY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
+  out=$(HOME="$(home_of "$case_dir")" \
+    FM_KIMI_READY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
     run_spawn "$case_dir" "$id" "$case_dir/project" \
       --harness kimi --mode no-mistakes --yolo off) || rc=$?
   [ "$rc" -ne 0 ] || fail "an interrupted Kimi readiness check reported success"

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -601,6 +601,48 @@ test_recovery_retries_when_a_close_marker_cannot_be_removed() {
   pass "session start retries a close whose marker could not be removed"
 }
 
+test_recovery_reports_an_owned_row_read_failure() {
+  local case_dir id out
+  id=atomic-heal-read-failure-b8
+  case_dir=$(make_home heal-owned-read-failure)
+  add_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes
+  break_verb "$case_dir" show
+
+  out=$(run_bootstrap "$case_dir")
+  assert_contains "$out" "worker record exists but its backlog item could not be read" \
+    "session start silently ignored an owned-row read failure"
+  assert_contains "$out" "backlog is unwritable" \
+    "session start discarded the backlog reader's diagnostic"
+  rm -f "$case_dir/fakebin/tasks-axi"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "owned-row read failure changed the backlog state"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "owned-row read failure removed the worker record"
+  pass "session start reports owned backlog rows it cannot read"
+}
+
+test_orca_cleanup_recovery_never_transitions_the_backlog() {
+  local case_dir id meta out
+  id=atomic-orca-cleanup-recovery-b8
+  case_dir=$(make_home orca-cleanup-recovery)
+  add_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only "cleanup_recovery=orca"
+  meta="$(home_of "$case_dir")/state/$id.meta"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "session start treated cleanup recovery as a launched worker: $out"
+  assert_present "$meta" "session start removed the cleanup recovery record"
+
+  out=$(run_teardown "$case_dir" "$id") \
+    || fail "cleanup recovery teardown failed: $out"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "cleanup recovery teardown completed work that never launched"
+  assert_absent "$meta" "cleanup recovery teardown retained its task record"
+  pass "Orca cleanup recovery is excluded from backlog lifecycle transitions"
+}
+
 test_recovery_marks_an_owned_record_in_flight() {
   local case_dir id out
   id=atomic-heal-b8
@@ -849,6 +891,8 @@ test_completion_preserves_records_when_meta_removal_fails
 test_completion_fails_loudly_and_records_the_close_it_still_owes
 test_completion_fails_when_its_close_marker_cannot_be_removed
 test_recovery_retries_when_a_close_marker_cannot_be_removed
+test_recovery_reports_an_owned_row_read_failure
+test_orca_cleanup_recovery_never_transitions_the_backlog
 test_recovery_marks_an_owned_record_in_flight
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open
 test_recovery_preserves_a_close_when_the_backlog_cannot_be_read

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -246,7 +246,7 @@ case "\${1:-}" in
     ;;
   send-keys)
     case "\$*" in
-      *FM_ROOT_OVERRIDE=*) : > "$case_dir/launch-staged" ;;
+      *FM_ROOT_OVERRIDE=*|*launch-brief*) : > "$case_dir/launch-staged" ;;
       *" Enter") [ ! -f "$case_dir/launch-staged" ] || : > "$case_dir/backend-unqueryable" ;;
     esac
     exit 0
@@ -306,8 +306,46 @@ case "\${1:-}" in
     ;;
   send-keys)
     case "\$*" in
-      *FM_ROOT_OVERRIDE=*) : > "$case_dir/launch-staged" ;;
+      *FM_ROOT_OVERRIDE=*|*launch-brief*) : > "$case_dir/launch-staged" ;;
       *" Enter") [ ! -f "$case_dir/launch-staged" ] || : > "$case_dir/backend-unqueryable" ;;
+    esac
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux"
+}
+
+interrupt_launch_submission() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+case "\${1:-}" in
+  kill-window) : > "$case_dir/backend-unqueryable"; exit 0 ;;
+  list-windows)
+    [ ! -f "$case_dir/backend-unqueryable" ] && exit 0
+    exit 1
+    ;;
+  display-message)
+    [ ! -f "$case_dir/backend-unqueryable" ] || exit 1
+    case "\$*" in *"#{pane_current_path}"*) printf '%s\\n' "\${FM_FAKE_PANE_PATH:-}"; exit 0 ;; esac
+    printf 'firstmate\\n'
+    exit 0
+    ;;
+  send-keys)
+    case "\$*" in
+      *FM_ROOT_OVERRIDE=*|*launch-brief*) : > "$case_dir/launch-staged" ;;
+      *" Enter")
+        if [ -f "$case_dir/launch-staged" ]; then
+          : > "$case_dir/endpoint-running"
+          : > "$case_dir/backend-unqueryable"
+          spawn_pid=\$(ps -o ppid= -p "\$PPID" | tr -d ' ')
+          case "\$spawn_pid" in ''|*[!0-9]*) exit 1 ;; esac
+          kill -TERM "\$spawn_pid"
+          exit 1
+        fi
+        ;;
     esac
     exit 0
     ;;
@@ -830,6 +868,28 @@ test_unqueryable_failed_dispatch_retains_ownership() {
   [ "$(row_state "$case_dir" "$id")" = queued ] \
     || fail "unqueryable failed dispatch changed the backlog row"
   pass "unqueryable failed dispatch retains durable ownership"
+}
+
+test_interrupted_launch_submission_retains_unconfirmed_worker() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-submit-interrupted-b5
+  case_dir=$(make_home dispatch-submit-interrupted "$id")
+  add_item "$case_dir" "$id"
+  interrupt_launch_submission "$case_dir"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "interrupted launch submission reported success"
+  assert_present "$case_dir/endpoint-running" \
+    "interrupted launch submission did not reach the backend"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "interrupted launch submission removed its task record"
+  assert_present "$(home_of "$case_dir")/state/$id.busy-state" \
+    "interrupted launch submission removed its busy record"
+  assert_contains "$out" "could not be confirmed gone" \
+    "interrupted launch submission did not report its unresolved endpoint"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "interrupted launch submission changed the backlog row"
+  pass "interrupted launch submission retains unconfirmed ownership"
 }
 
 test_dispatch_defers_interruption_across_backlog_commit() {
@@ -1809,6 +1869,7 @@ test_dispatch_rolls_back_before_a_failed_launch_delivery
 test_interrupted_kimi_delivery_preserves_live_worker_ownership
 test_failed_kimi_delivery_preserves_or_stops_worker_ownership
 test_unqueryable_failed_dispatch_retains_ownership
+test_interrupted_launch_submission_retains_unconfirmed_worker
 test_dispatch_defers_interruption_across_backlog_commit
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight
 test_dispatch_fails_when_its_row_vanishes_after_preflight

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -824,7 +824,7 @@ test_space_containing_scout_report_marker_replays() {
     FM_DATA_OVERRIDE="$data" PATH="$case_dir/fakebin:$PATH" \
     "$ROOT/bin/fm-captain-hold.sh" complete "$id" --none >/dev/null \
     || fail "could not record the space-path scout's captain-call inventory"
-  break_verb "$case_dir" done
+  break_verb "$case_dir" "done"
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
 
   out=$(FM_DATA_OVERRIDE="$data" run_teardown "$case_dir" "$id") || rc=$?

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -181,6 +181,36 @@ SH
   chmod +x "$case_dir/fakebin/tmux"
 }
 
+interrupt_kimi_readiness() {  # <case-dir>
+  local case_dir=$1 home
+  home=$(home_of "$case_dir")
+  mkdir -p "$home/.kimi-code"
+  printf '# test config\n' > "$home/.kimi-code/config.toml"
+  fm_fake_exit0 "$case_dir/fakebin" kimi
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *"#{pane_current_path}"*) printf '%s\\n' "\${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"#{cursor_y}"*) printf '1\\n'; exit 0 ;;
+esac
+case "\${1:-}" in
+  display-message) printf 'firstmate\\n'; exit 0 ;;
+  capture-pane)
+    if [ ! -f "$case_dir/kimi-interrupted" ]; then
+      : > "$case_dir/kimi-interrupted"
+      spawn_pid=\$(ps -o ppid= -p "\$PPID" | tr -d ' ')
+      case "\$spawn_pid" in ''|*[!0-9]*) exit 1 ;; esac
+      kill -TERM "\$spawn_pid"
+    fi
+    printf 'shell starting\\n$ \\n'
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux"
+}
+
 break_meta_removal() {  # <case-dir> <meta-path>
   local case_dir=$1 meta=$2 real
   real=$(command -v rm)
@@ -607,6 +637,28 @@ test_dispatch_rolls_back_before_a_failed_launch_delivery() {
   [ "$(row_state "$case_dir" "$id")" = queued ] \
     || fail "launch delivery failed after committing backlog state $(row_state "$case_dir" "$id")"
   pass "dispatch commits neither record nor backlog state before launch delivery succeeds"
+}
+
+test_interrupted_kimi_delivery_does_not_commit() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-kimi-interrupted-b5
+  case_dir=$(make_home dispatch-kimi-interrupted "$id")
+  add_item "$case_dir" "$id"
+  interrupt_kimi_readiness "$case_dir"
+
+  out=$(FM_KIMI_READY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
+    run_spawn "$case_dir" "$id" "$case_dir/project" \
+      --harness kimi --mode no-mistakes --yolo off) || rc=$?
+  [ "$rc" -ne 0 ] || fail "an interrupted Kimi readiness check reported success"
+  assert_contains "$out" "kimi did not show a verified ready signal" \
+    "interrupted Kimi readiness lacked its delivery-failure diagnostic"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "interrupted Kimi delivery committed the backlog row"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "interrupted Kimi delivery retained its provisional task record"
+  assert_absent "$(home_of "$case_dir")/state/$id.busy-state" \
+    "interrupted Kimi delivery retained its provisional busy generation"
+  pass "interrupted Kimi delivery commits neither record nor backlog state"
 }
 
 test_dispatch_defers_interruption_across_backlog_commit() {
@@ -1389,6 +1441,7 @@ test_dispatch_leaves_no_record_when_the_transition_fails
 test_dispatch_reports_an_incomplete_record_rollback
 test_dispatch_reports_an_incomplete_busy_rollback
 test_dispatch_rolls_back_before_a_failed_launch_delivery
+test_interrupted_kimi_delivery_does_not_commit
 test_dispatch_defers_interruption_across_backlog_commit
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight
 test_dispatch_fails_when_its_row_vanishes_after_preflight

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -293,7 +293,7 @@ test_dispatch_reads_the_row_from_the_backlog_root() {
   id=atomic-dispatch-root-b2
   case_dir=$(make_home dispatch-root "$id")
   add_item "$case_dir" "$id"
-  require_show_cwd "$case_dir" "$(home_of "$case_dir" | sed 's://*:/:g')"
+  require_show_cwd "$case_dir" "$(cd "$(home_of "$case_dir")" && pwd -P)"
 
   out=$(run_ship_spawn "$case_dir" "$id") || fail "spawn read outside the backlog root: $out"
   [ "$(row_state "$case_dir" "$id")" = in_flight ] \
@@ -315,13 +315,40 @@ test_recovery_uses_the_parent_of_a_trailing_slash_data_record() {
   tasks-axi start "$id" --file "$backlog" >/dev/null
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
   printf 'id=%s\ndata=%s/\narg=--note\narg=local main\n' "$id" "$relocated" > "$marker"
-  require_show_cwd "$case_dir" "$(printf '%s\n' "$case_dir" | sed 's://*:/:g')"
+  require_show_cwd "$case_dir" "$(cd "$case_dir" && pwd -P)"
 
   out=$(run_bootstrap "$case_dir")
   [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = done ] \
     || fail "relocated-data recovery used the wrong addressing root: $out"
   assert_absent "$marker" "relocated-data recovery retained its close marker"
   pass "recovery uses the parent of a trailing-slash data record"
+}
+
+test_completion_targets_a_nested_relative_data_directory() {
+  local case_dir id relative_data data backlog out
+  id=atomic-close-relative-data-b2
+  case_dir=$(make_home close-relative-data)
+  relative_data=relocated/data
+  data="$case_dir/$relative_data"
+  mkdir -p "$case_dir/relocated"
+  mv "$(home_of "$case_dir")/data" "$data"
+  backlog="$data/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
+  tasks-axi start "$id" --file "$backlog" >/dev/null
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-relative-data"
+
+  out=$(cd "$case_dir" && \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    FM_DATA_OVERRIDE="$relative_data" PATH="$case_dir/fakebin:$PATH" \
+    "$TEARDOWN" "$id" 2>&1) \
+    || fail "relative-data teardown failed: $out"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = done ] \
+    || fail "relative-data teardown mutated a different backlog file"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "relative-data teardown retained its task record"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "relative-data teardown retained its close marker"
+  pass "completion targets nested relative data from the caller directory"
 }
 
 test_dispatch_refuses_an_id_this_home_has_no_item_for() {
@@ -978,6 +1005,7 @@ test_a_persistent_secondmate_is_never_a_backlog_item() {
 test_dispatch_moves_the_item_in_flight_in_the_same_run
 test_dispatch_reads_the_row_from_the_backlog_root
 test_recovery_uses_the_parent_of_a_trailing_slash_data_record
+test_completion_targets_a_nested_relative_data_directory
 test_dispatch_refuses_an_id_this_home_has_no_item_for
 test_dispatch_reports_a_backlog_read_failure
 test_dispatch_refuses_a_closed_item

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -96,10 +96,14 @@ require_show_cwd() {  # <case-dir> <expected-dir>
   real=$(command -v tasks-axi)
   cat > "$case_dir/fakebin/tasks-axi" <<SH
 #!/usr/bin/env bash
-if [ "\${1:-}" = show ] && [ "\$PWD" != "$expected" ]; then
-  echo "error: wrong tasks root: \$PWD" >&2
-  exit 1
-fi
+case "\${1:-}" in
+  show|start|done)
+    if [ "\$PWD" != "$expected" ]; then
+      echo "error: wrong tasks root: \$PWD" >&2
+      exit 1
+    fi
+    ;;
+esac
 exec "$real" "\$@"
 SH
   chmod +x "$case_dir/fakebin/tasks-axi"
@@ -297,6 +301,27 @@ test_dispatch_reads_the_row_from_the_backlog_root() {
   assert_present "$(home_of "$case_dir")/state/$id.meta" \
     "root-addressed dispatch did not publish its task record"
   pass "dispatch reads backlog rows from the backlog addressing root"
+}
+
+test_recovery_uses_the_parent_of_a_trailing_slash_data_record() {
+  local case_dir id relocated backlog marker out
+  id=atomic-recovery-relocated-root-b2
+  case_dir=$(make_home recovery-relocated-root)
+  relocated="$case_dir/fm-records"
+  mkdir -p "$relocated"
+  backlog="$relocated/backlog.md"
+  printf '%s\n' '# Backlog' '' '## In flight' '' '## Queued' '' '## Done' > "$backlog"
+  tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
+  tasks-axi start "$id" --file "$backlog" >/dev/null
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s/\narg=--note\narg=local main\n' "$id" "$relocated" > "$marker"
+  require_show_cwd "$case_dir" "$(printf '%s\n' "$case_dir" | sed 's://*:/:g')"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = done ] \
+    || fail "relocated-data recovery used the wrong addressing root: $out"
+  assert_absent "$marker" "relocated-data recovery retained its close marker"
+  pass "recovery uses the parent of a trailing-slash data record"
 }
 
 test_dispatch_refuses_an_id_this_home_has_no_item_for() {
@@ -904,6 +929,7 @@ test_a_persistent_secondmate_is_never_a_backlog_item() {
 
 test_dispatch_moves_the_item_in_flight_in_the_same_run
 test_dispatch_reads_the_row_from_the_backlog_root
+test_recovery_uses_the_parent_of_a_trailing_slash_data_record
 test_dispatch_refuses_an_id_this_home_has_no_item_for
 test_dispatch_reports_a_backlog_read_failure
 test_dispatch_refuses_a_closed_item

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -212,7 +212,7 @@ SH
   chmod +x "$case_dir/fakebin/tmux"
 }
 
-fail_kimi_readiness() {  # <case-dir> <stopped|stuck>
+fail_kimi_readiness() {  # <case-dir> <stopped|stuck|unknown>
   local case_dir=$1 kill_mode=$2 home
   home=$(home_of "$case_dir")
   mkdir -p "$home/.kimi-code"
@@ -222,10 +222,18 @@ fail_kimi_readiness() {  # <case-dir> <stopped|stuck>
 #!/usr/bin/env bash
 case "\${1:-}" in
   kill-window)
-    [ "$kill_mode" = stuck ] || rm -f "\${FM_FAKE_ENDPOINT_LIVE:-}"
+    [ "$kill_mode" = stopped ] && rm -f "\${FM_FAKE_ENDPOINT_LIVE:-}"
+    [ "$kill_mode" != unknown ] || : > "$case_dir/backend-unqueryable"
     exit 0
     ;;
+  list-windows)
+    if [ "$kill_mode" != unknown ] || [ ! -f "$case_dir/backend-unqueryable" ]; then
+      exit 0
+    fi
+    exit 1
+    ;;
   display-message)
+    [ "$kill_mode" != unknown ] || [ ! -f "$case_dir/backend-unqueryable" ] || exit 1
     if [ -n "\${FM_FAKE_ENDPOINT_LIVE:-}" ] && [ ! -f "\$FM_FAKE_ENDPOINT_LIVE" ]; then
       exit 1
     fi
@@ -234,6 +242,13 @@ case "\${1:-}" in
       *"#{cursor_y}"*) printf '1\\n'; exit 0 ;;
     esac
     printf 'firstmate\\n'
+    exit 0
+    ;;
+  send-keys)
+    case "\$*" in
+      *FM_ROOT_OVERRIDE=*) : > "$case_dir/launch-staged" ;;
+      *" Enter") [ ! -f "$case_dir/launch-staged" ] || : > "$case_dir/backend-unqueryable" ;;
+    esac
     exit 0
     ;;
   capture-pane) printf 'shell starting\\n$ \\n'; exit 0 ;;
@@ -265,6 +280,35 @@ case "\${1:-}" in
       kill -TERM "\$spawn_pid"
     fi
     printf 'shell starting\\n$ \\n'
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux"
+}
+
+make_endpoint_unqueryable_after_launch() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+case "\${1:-}" in
+  kill-window) : > "$case_dir/backend-unqueryable"; exit 0 ;;
+  list-windows)
+    [ ! -f "$case_dir/backend-unqueryable" ] && exit 0
+    exit 1
+    ;;
+  display-message)
+    [ ! -f "$case_dir/backend-unqueryable" ] || exit 1
+    case "\$*" in *"#{pane_current_path}"*) printf '%s\\n' "\${FM_FAKE_PANE_PATH:-}"; exit 0 ;; esac
+    printf 'firstmate\\n'
+    exit 0
+    ;;
+  send-keys)
+    case "\$*" in
+      *FM_ROOT_OVERRIDE=*) : > "$case_dir/launch-staged" ;;
+      *" Enter") [ ! -f "$case_dir/launch-staged" ] || : > "$case_dir/backend-unqueryable" ;;
+    esac
     exit 0
     ;;
 esac
@@ -757,14 +801,35 @@ test_failed_kimi_delivery_preserves_or_stops_worker_ownership() {
         || fail "stopped Kimi delivery changed the backlog row"
     else
       assert_present "$case_dir/endpoint-live" \
-        "stuck Kimi endpoint did not remain observable"
+        "$outcome Kimi endpoint did not remain observable"
       assert_present "$(home_of "$case_dir")/state/$id.meta" \
-        "stuck Kimi worker lost its ownership record"
+        "$outcome Kimi worker lost its ownership record"
       assert_contains "$out" "retaining task and busy records" \
-        "stuck Kimi worker did not report retained ownership"
+        "$outcome Kimi worker did not report retained ownership"
     fi
   done
   pass "failed Kimi delivery stops workers or retains their ownership"
+}
+
+test_unqueryable_failed_dispatch_retains_ownership() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-unqueryable-b5
+  case_dir=$(make_home dispatch-unqueryable "$id")
+  add_item "$case_dir" "$id"
+  break_verb "$case_dir" start
+  make_endpoint_unqueryable_after_launch "$case_dir"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "unqueryable failed dispatch reported success"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "unqueryable failed dispatch removed its task record: $out"
+  assert_present "$(home_of "$case_dir")/state/$id.busy-state" \
+    "unqueryable failed dispatch removed its busy record"
+  assert_contains "$out" "could not be confirmed gone" \
+    "unqueryable failed dispatch did not report its unresolved endpoint"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "unqueryable failed dispatch changed the backlog row"
+  pass "unqueryable failed dispatch retains durable ownership"
 }
 
 test_dispatch_defers_interruption_across_backlog_commit() {
@@ -1743,6 +1808,7 @@ test_dispatch_reports_an_incomplete_busy_rollback
 test_dispatch_rolls_back_before_a_failed_launch_delivery
 test_interrupted_kimi_delivery_preserves_live_worker_ownership
 test_failed_kimi_delivery_preserves_or_stops_worker_ownership
+test_unqueryable_failed_dispatch_retains_ownership
 test_dispatch_defers_interruption_across_backlog_commit
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight
 test_dispatch_fails_when_its_row_vanishes_after_preflight

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -110,17 +110,18 @@ interrupt_spawn_during_start() {  # <case-dir> <before|after>
   real=$(command -v tasks-axi)
   cat > "$case_dir/fakebin/tasks-axi" <<SH
 #!/usr/bin/env bash
-if [ "\${1:-}" = start ]; then
+if [ "\${1:-}" = start ] && [ ! -f "$case_dir/start-interrupted" ]; then
+  : > "$case_dir/start-interrupted"
   spawn_pid=\$(ps -o ppid= -p "\$PPID" | tr -d ' ')
   case "\$spawn_pid" in ''|*[!0-9]*) exit 1 ;; esac
   if [ "$timing" = before ]; then
     kill -TERM "\$spawn_pid"
-    /bin/sleep 0.1
+    kill -TERM "\$\$"
   fi
   "$real" "\$@" || exit \$?
   if [ "$timing" = after ]; then
     kill -TERM "\$spawn_pid"
-    /bin/sleep 0.1
+    kill -TERM "\$\$"
   fi
   exit 0
 fi
@@ -254,6 +255,24 @@ test_dispatch_refuses_an_id_this_home_has_no_item_for() {
   pass "dispatch refuses, before creating anything, when the home has no item for the id"
 }
 
+test_dispatch_reports_a_backlog_read_failure() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-read-failure-b3
+  case_dir=$(make_home dispatch-read-failure "$id")
+  add_item "$case_dir" "$id"
+  break_verb "$case_dir" show
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn succeeded though backlog preflight could not read its item"
+  assert_contains "$out" "backlog item could not be read before dispatch" \
+    "spawn misreported a backlog read failure"
+  assert_contains "$out" "backlog is unwritable" \
+    "spawn discarded the backlog reader's diagnostic"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "failed backlog preflight created a task record"
+  pass "dispatch distinguishes backlog read failures from missing items"
+}
+
 test_dispatch_refuses_a_closed_item() {
   local case_dir id out rc=0
   id=atomic-dispatch-b3
@@ -330,21 +349,24 @@ test_dispatch_rolls_back_before_a_failed_launch_delivery() {
 }
 
 test_dispatch_defers_interruption_across_backlog_commit() {
-  local timing case_dir id out
+  local timing case_dir id out rc
   for timing in before after; do
     id="atomic-dispatch-interrupted-$timing-b5"
     case_dir=$(make_home "dispatch-interrupted-$timing" "$id")
     add_item "$case_dir" "$id"
     interrupt_spawn_during_start "$case_dir" "$timing"
 
-    out=$(run_ship_spawn "$case_dir" "$id") \
-      || fail "a $timing-commit interruption stopped the atomic dispatch: $out"
+    rc=0
+    out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+    [ "$rc" -ne 0 ] || fail "a $timing-commit interruption was reported as success"
+    assert_contains "$out" "paired task record and In-flight backlog state were preserved" \
+      "a $timing-commit interruption did not report its atomic outcome"
     [ "$(row_state "$case_dir" "$id")" = in_flight ] \
       || fail "a $timing-commit interruption left the backlog row queued"
     assert_present "$(home_of "$case_dir")/state/$id.meta" \
       "a $timing-commit interruption removed the paired task record"
   done
-  pass "dispatch defers catchable interruption across both halves of its backlog commit"
+  pass "dispatch retries interrupted transitions before honoring termination"
 }
 
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight() {
@@ -719,6 +741,7 @@ test_a_persistent_secondmate_is_never_a_backlog_item() {
 
 test_dispatch_moves_the_item_in_flight_in_the_same_run
 test_dispatch_refuses_an_id_this_home_has_no_item_for
+test_dispatch_reports_a_backlog_read_failure
 test_dispatch_refuses_a_closed_item
 test_dispatch_leaves_no_record_when_the_transition_fails
 test_dispatch_reports_an_incomplete_record_rollback

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -210,6 +210,26 @@ SH
   chmod +x "$case_dir/fakebin/rm"
 }
 
+remove_data_during_startup_budget_check() {  # <case-dir>
+  local case_dir=$1 real data saved budget
+  real=$(command -v stat)
+  data="$(home_of "$case_dir")/data"
+  saved="$case_dir/bootstrap-data"
+  budget="$(home_of "$case_dir")/config/startup-memory-budget"
+  printf '7500\n' > "$budget"
+  cat > "$case_dir/fakebin/stat" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  if [ "\$arg" = "$budget" ] && [ ! -e "$case_dir/data-removed" ]; then
+    mv "$data" "$saved" || exit 1
+    : > "$case_dir/data-removed"
+  fi
+done
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/stat"
+}
+
 break_meta_publication() {  # <case-dir> <meta-path>
   local case_dir=$1 meta=$2 real
   real=$(command -v mv)
@@ -349,6 +369,28 @@ test_completion_targets_a_nested_relative_data_directory() {
   assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
     "relative-data teardown retained its close marker"
   pass "completion targets nested relative data from the caller directory"
+}
+
+test_bare_relative_data_dispatches_and_completes() {
+  local case_dir id data backlog out
+  id=atomic-bare-relative-data-b2
+  case_dir=$(make_home bare-relative-data "$id")
+  data="$case_dir/records"
+  mv "$(home_of "$case_dir")/data" "$data"
+  backlog="$data/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
+
+  out=$(cd "$case_dir" && FM_DATA_OVERRIDE=records run_ship_spawn "$case_dir" "$id") \
+    || fail "bare-relative-data spawn failed: $out"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = in_flight ] \
+    || fail "bare relative dispatch mutated a different backlog"
+  rm -f "$(home_of "$case_dir")/state/$id.meta"
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-bare-relative"
+  out=$(cd "$case_dir" && FM_DATA_OVERRIDE=records run_teardown "$case_dir" "$id") \
+    || fail "bare-relative-data teardown failed: $out"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = done ] \
+    || fail "bare relative completion mutated a different backlog"
+  pass "bare relative data addresses one backlog through dispatch and completion"
 }
 
 test_dispatch_refuses_an_unresolvable_data_directory() {
@@ -675,11 +717,11 @@ test_completion_records_a_relative_report_for_relocated_data() {
   mkdir -p "$relocated/$id"
   printf 'findings\n' > "$relocated/$id/report.md"
   FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
-    FM_DATA_OVERRIDE="$relocated/" PATH="$case_dir/fakebin:$PATH" \
+    FM_DATA_OVERRIDE="$relocated////" PATH="$case_dir/fakebin:$PATH" \
     "$ROOT/bin/fm-captain-hold.sh" complete "$id" --none >/dev/null \
     || fail "could not record the relocated scout's captain-call inventory"
 
-  out=$(FM_DATA_OVERRIDE="$relocated/" run_teardown "$case_dir" "$id") \
+  out=$(FM_DATA_OVERRIDE="$relocated////" run_teardown "$case_dir" "$id") \
     || fail "relocated scout teardown failed: $out"
   [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = done ] \
     || fail "relocated scout backlog row was not closed"
@@ -970,6 +1012,40 @@ test_recovery_drops_a_legacy_close_when_meta_exists() {
   pass "session start treats an unversioned close as stale when meta exists"
 }
 
+test_bootstrap_stops_when_data_disappears_before_reconciliation() {
+  local case_dir id saved out rc=0
+  id=atomic-bootstrap-data-race-b11
+  case_dir=$(make_home bootstrap-data-race)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-bootstrap-race"
+  remove_data_during_startup_budget_check "$case_dir"
+  saved="$case_dir/bootstrap-data"
+
+  out=$(run_bootstrap "$case_dir") || rc=$?
+  [ "$rc" -ne 0 ] || fail "bootstrap absorbed a fatal reconciliation addressing error: $out"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "fatal bootstrap reconciliation removed the task record"
+  [ "$(tasks-axi show "$id" --file "$saved/backlog.md" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = in_flight ] \
+    || fail "fatal bootstrap reconciliation changed the backlog row"
+  pass "bootstrap stops when backlog data disappears before reconciliation"
+}
+
+test_bootstrap_addressing_exemptions_remain_nonfatal() {
+  local manual_case no_backlog_case out
+  manual_case=$(make_home bootstrap-manual-exempt)
+  printf '%s\n' manual > "$(home_of "$manual_case")/config/backlog-backend"
+  mv "$(home_of "$manual_case")/data" "$manual_case/manual-data"
+  out=$(run_bootstrap "$manual_case") \
+    || fail "manual bootstrap exemption became fatal: $out"
+
+  no_backlog_case=$(make_home bootstrap-no-backlog-exempt)
+  rm -f "$(backlog_of "$no_backlog_case")"
+  out=$(run_bootstrap "$no_backlog_case") \
+    || fail "no-backlog bootstrap exemption became fatal: $out"
+  pass "bootstrap preserves manual and absent-backlog exemptions"
+}
+
 test_recovery_leaves_a_captain_held_item_alone() {
   local case_dir id out
   id=atomic-heal-b11
@@ -1068,6 +1144,7 @@ test_dispatch_moves_the_item_in_flight_in_the_same_run
 test_dispatch_reads_the_row_from_the_backlog_root
 test_recovery_uses_the_parent_of_a_trailing_slash_data_record
 test_completion_targets_a_nested_relative_data_directory
+test_bare_relative_data_dispatches_and_completes
 test_dispatch_refuses_an_unresolvable_data_directory
 test_completion_refuses_an_unresolvable_data_directory
 test_dispatch_refuses_an_id_this_home_has_no_item_for
@@ -1098,6 +1175,8 @@ test_recovery_finishes_a_close_for_the_same_meta_incarnation
 test_recovery_preserves_both_records_when_meta_removal_fails
 test_recovery_drops_a_close_for_a_newer_meta_incarnation
 test_recovery_drops_a_legacy_close_when_meta_exists
+test_bootstrap_stops_when_data_disappears_before_reconciliation
+test_bootstrap_addressing_exemptions_remain_nonfatal
 test_recovery_leaves_a_captain_held_item_alone
 test_home_without_a_backlog_dispatches_and_completes
 test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -843,6 +843,28 @@ test_space_containing_scout_report_marker_replays() {
   pass "space-containing scout report paths round-trip through recovery"
 }
 
+test_control_character_data_path_is_refused_before_cleanup() {
+  local case_dir id data backlog marker out rc=0
+  id=atomic-control-data-refusal-b7
+  case_dir=$(make_home control-data-refusal)
+  data="$case_dir/crew"$'\t'"data"
+  mv "$(home_of "$case_dir")/data" "$data"
+  backlog="$data/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
+  tasks-axi start "$id" --file "$backlog" >/dev/null
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-control-data"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+
+  out=$(FM_DATA_OVERRIDE="$data" run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "control-character data path passed close preflight"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "control-character close preflight removed the task record"
+  assert_absent "$marker" "control-character close preflight published a marker"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = in_flight ] \
+    || fail "control-character close preflight changed the backlog row: $out"
+  pass "unreplayable data paths are refused before destructive cleanup"
+}
+
 test_completion_preserves_records_when_meta_removal_fails() {
   local case_dir id meta marker out rc=0
   id=atomic-close-meta-remove-failure-b7
@@ -1490,6 +1512,7 @@ test_completion_closes_a_scout_with_its_report
 test_completion_refuses_a_legacy_record_without_an_incarnation
 test_completion_records_a_relative_report_for_relocated_data
 test_space_containing_scout_report_marker_replays
+test_control_character_data_path_is_refused_before_cleanup
 test_completion_preserves_records_when_meta_removal_fails
 test_completion_fails_loudly_and_records_the_close_it_still_owes
 test_completion_fails_when_its_close_marker_cannot_be_removed

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -290,6 +290,27 @@ test_dispatch_leaves_no_record_when_the_transition_fails() {
   pass "a failed backlog transition fails the dispatch loudly and leaves no record"
 }
 
+test_dispatch_reports_an_incomplete_record_rollback() {
+  local case_dir id meta out rc=0
+  id=atomic-dispatch-remove-failure-b5
+  case_dir=$(make_home dispatch-remove-failure "$id")
+  add_item "$case_dir" "$id"
+  meta="$(home_of "$case_dir")/state/$id.meta"
+  break_verb "$case_dir" start
+  break_meta_removal "$case_dir" "$meta"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn reported success though transition and rollback failed"
+  assert_contains "$out" "failed-dispatch cleanup is incomplete" \
+    "spawn did not report that its provisional record remained"
+  assert_present "$meta" "failed record removal was reported as successful"
+  assert_absent "$(home_of "$case_dir")/state/$id.busy-state" \
+    "record-removal failure prevented busy-state rollback"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "failed rollback changed the backlog row"
+  pass "dispatch reports when failed-transition rollback cannot remove its record"
+}
+
 test_dispatch_rolls_back_before_a_failed_launch_delivery() {
   local case_dir id out rc=0
   id=atomic-dispatch-delivery-fails-b5
@@ -420,7 +441,51 @@ test_completion_fails_loudly_and_records_the_close_it_still_owes() {
   pass "completion refuses to report success while its item is still open, and records what it owes"
 }
 
+test_completion_fails_when_its_close_marker_cannot_be_removed() {
+  local case_dir id marker out rc=0
+  id=atomic-close-marker-remove-failure-b8
+  case_dir=$(make_home close-marker-remove-failure)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  break_meta_removal "$case_dir" "$marker"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown reported success while its close marker remained"
+  assert_contains "$out" "pending-close record could not be removed" \
+    "teardown did not report its incomplete marker cleanup"
+  assert_present "$marker" "teardown hid a close-marker removal failure"
+  [ "$(row_state "$case_dir" "$id")" = done ] \
+    || fail "marker cleanup failure lost the completed backlog transition"
+  pass "completion reports failure until its durable close marker is removed"
+}
+
 # --- same-home recovery -----------------------------------------------------
+
+test_recovery_retries_when_a_close_marker_cannot_be_removed() {
+  local case_dir id marker out
+  id=atomic-heal-marker-remove-failure-b8
+  case_dir=$(make_home heal-marker-remove-failure)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\narg=--note\narg=local main\n' \
+    "$id" "$(home_of "$case_dir")/data" > "$marker"
+  break_meta_removal "$case_dir" "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_contains "$out" "could not remove pending-close record" \
+    "session start did not report close-marker removal failure"
+  assert_present "$marker" "recovery hid a close-marker removal failure"
+  [ "$(row_state "$case_dir" "$id")" = done ] \
+    || fail "recovery did not land the close before marker cleanup"
+
+  rm -f "$case_dir/fakebin/rm"
+  out=$(run_bootstrap "$case_dir")
+  assert_absent "$marker" "recovery did not retry close-marker cleanup: $out"
+  pass "session start retries a close whose marker could not be removed"
+}
 
 test_recovery_marks_an_owned_record_in_flight() {
   local case_dir id out
@@ -656,6 +721,7 @@ test_dispatch_moves_the_item_in_flight_in_the_same_run
 test_dispatch_refuses_an_id_this_home_has_no_item_for
 test_dispatch_refuses_a_closed_item
 test_dispatch_leaves_no_record_when_the_transition_fails
+test_dispatch_reports_an_incomplete_record_rollback
 test_dispatch_rolls_back_before_a_failed_launch_delivery
 test_dispatch_defers_interruption_across_backlog_commit
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight
@@ -663,6 +729,8 @@ test_dispatch_fails_when_its_row_vanishes_after_preflight
 test_completion_closes_a_local_only_ship_before_reporting_success
 test_completion_closes_a_scout_with_its_report
 test_completion_fails_loudly_and_records_the_close_it_still_owes
+test_completion_fails_when_its_close_marker_cannot_be_removed
+test_recovery_retries_when_a_close_marker_cannot_be_removed
 test_recovery_marks_an_owned_record_in_flight
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open
 test_recovery_preserves_a_close_when_the_backlog_cannot_be_read

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -1082,6 +1082,53 @@ test_recovery_rejects_lexical_data_traversal() {
   pass "recovery rejects lexical traversal before resolving marker data"
 }
 
+test_recovery_rejects_raw_control_bytes() {
+  local case_dir id marker data out
+  id=atomic-marker-nul-byte-b12
+  case_dir=$(make_home marker-nul-byte)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-nul-byte"
+  data="$(home_of "$case_dir")/data"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\0\nspawn_gen=spawn-nul-byte\narg=--note\narg=local%%20main\n' \
+    "$id" "$data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "NUL-bearing close marker was consumed"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "NUL-bearing close marker removed the task record"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "NUL-bearing close marker changed the backlog row: $out"
+  pass "recovery rejects marker control bytes before parsing"
+}
+
+test_recovery_rejects_malformed_pr_urls() {
+  local case_dir first_id second_id first_marker second_marker out
+  first_id=atomic-marker-pr-port-b12
+  second_id=atomic-marker-pr-percent-b12
+  case_dir=$(make_home marker-malformed-pr)
+  add_item "$case_dir" "$first_id"
+  start_item "$case_dir" "$first_id"
+  add_item "$case_dir" "$second_id"
+  start_item "$case_dir" "$second_id"
+  first_marker="$(home_of "$case_dir")/state/$first_id.backlog-close"
+  second_marker="$(home_of "$case_dir")/state/$second_id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-pr-port\narg=--pr\narg=https://github.com:abc/pull/1\n' \
+    "$first_id" "$(home_of "$case_dir")/data" > "$first_marker"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-pr-percent\narg=--pr\narg=https://github.com/pull/%%ZZ\n' \
+    "$second_id" "$(home_of "$case_dir")/data" > "$second_marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$first_marker" "PR marker with a nonnumeric port was consumed"
+  assert_present "$second_marker" "PR marker with an invalid percent escape was consumed"
+  [ "$(row_state "$case_dir" "$first_id")" = in_flight ] \
+    || fail "nonnumeric PR port changed the backlog row: $out"
+  [ "$(row_state "$case_dir" "$second_id")" = in_flight ] \
+    || fail "invalid PR percent escape changed the backlog row: $out"
+  pass "recovery rejects malformed PR URL values"
+}
+
 test_failed_close_replay_is_not_started_as_live_work() {
   local case_dir id marker out
   id=atomic-pending-close-not-started-b12
@@ -1355,6 +1402,8 @@ test_recovery_rejects_a_marker_for_another_task_identity
 test_recovery_rejects_a_foreign_data_directory
 test_recovery_rejects_an_unterminated_unknown_field
 test_recovery_rejects_lexical_data_traversal
+test_recovery_rejects_raw_control_bytes
+test_recovery_rejects_malformed_pr_urls
 test_failed_close_replay_is_not_started_as_live_work
 test_recovery_rejects_invalid_close_arguments
 test_recovery_rejects_a_symlinked_close_marker

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -334,10 +334,10 @@ test_recovery_uses_the_parent_of_a_trailing_slash_data_record() {
   tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
   tasks-axi start "$id" --file "$backlog" >/dev/null
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
-  printf 'id=%s\ndata=%s/\narg=--note\narg=local main\n' "$id" "$relocated" > "$marker"
+  printf 'id=%s\ndata=%s/\nspawn_gen=spawn-relocated-recovery\narg=--note\narg=local main\n' "$id" "$relocated" > "$marker"
   require_show_cwd "$case_dir" "$(cd "$case_dir" && pwd -P)"
 
-  out=$(run_bootstrap "$case_dir")
+  out=$(FM_DATA_OVERRIDE="$relocated/" run_bootstrap "$case_dir")
   [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
     || fail "relocated-data recovery used the wrong addressing root: $out"
   assert_absent "$marker" "relocated-data recovery retained its close marker"
@@ -823,7 +823,7 @@ test_recovery_retries_when_a_close_marker_cannot_be_removed() {
   add_item "$case_dir" "$id"
   start_item "$case_dir" "$id"
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
-  printf 'id=%s\ndata=%s\narg=--note\narg=local main\n' \
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-marker-retry\narg=--note\narg=local main\n' \
     "$id" "$(home_of "$case_dir")/data" > "$marker"
   break_meta_removal "$case_dir" "$marker"
 
@@ -901,7 +901,7 @@ test_recovery_replays_a_close_an_interrupted_cleanup_left_open() {
   case_dir=$(make_home heal-pending-close)
   add_item "$case_dir" "$id"
   start_item "$case_dir" "$id"
-  printf 'id=%s\ndata=%s\narg=--pr\narg=https://github.com/example/repo/pull/11\n' \
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-heal-pr\narg=--pr\narg=https://github.com/example/repo/pull/11\n' \
     "$id" "$(home_of "$case_dir")/data" \
     > "$(home_of "$case_dir")/state/$id.backlog-close"
 
@@ -921,7 +921,7 @@ test_recovery_preserves_a_close_when_the_backlog_cannot_be_read() {
   case_dir=$(make_home heal-read-error)
   add_item "$case_dir" "$id"
   start_item "$case_dir" "$id"
-  printf 'id=%s\ndata=%s\narg=--note\narg=local main\n' \
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-heal-read\narg=--note\narg=local main\n' \
     "$id" "$(home_of "$case_dir")/data" \
     > "$(home_of "$case_dir")/state/$id.backlog-close"
   break_verb "$case_dir" show
@@ -1015,6 +1015,31 @@ test_recovery_rejects_a_marker_for_another_task_identity() {
   pass "recovery binds close-marker identity to its locked filename"
 }
 
+test_recovery_rejects_a_foreign_data_directory() {
+  local case_dir foreign_case id marker out
+  id=atomic-marker-foreign-data-b12
+  case_dir=$(make_home marker-foreign-data-local)
+  foreign_case=$(make_home marker-foreign-data-remote)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  add_item "$foreign_case" "$id"
+  start_item "$foreign_case" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-foreign-data"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-foreign-data\narg=--note\narg=local main\n' \
+    "$id" "$(home_of "$foreign_case")/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "foreign-data close marker was consumed"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "foreign-data close marker removed the local task record"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "foreign-data close marker changed the local backlog row: $out"
+  [ "$(row_state "$foreign_case" "$id")" = in_flight ] \
+    || fail "foreign-data close marker reached into another home's backlog: $out"
+  pass "recovery rejects close markers targeting another home's data"
+}
+
 test_recovery_rejects_invalid_close_arguments() {
   local case_dir id marker out
   id=atomic-marker-invalid-args-b12
@@ -1072,7 +1097,7 @@ test_recovery_drops_a_close_for_a_newer_meta_incarnation() {
   pass "session start drops a close recorded for an older meta incarnation"
 }
 
-test_recovery_drops_a_legacy_close_when_meta_exists() {
+test_recovery_rejects_a_legacy_close_without_an_incarnation() {
   local case_dir id out
   id=atomic-heal-legacy-close-b13
   case_dir=$(make_home heal-legacy-close)
@@ -1088,9 +1113,9 @@ test_recovery_drops_a_legacy_close_when_meta_exists() {
     || fail "session start guessed that a legacy close belonged to the current meta: $out"
   assert_present "$(home_of "$case_dir")/state/$id.meta" \
     "session start removed meta for an unversioned legacy close"
-  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
-    "session start retained a legacy close that could not be matched safely"
-  pass "session start treats an unversioned close as stale when meta exists"
+  assert_present "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "session start consumed an unversioned close marker"
+  pass "session start rejects an unversioned close marker"
 }
 
 test_bootstrap_stops_when_data_disappears_before_reconciliation() {
@@ -1266,10 +1291,11 @@ test_recovery_preserves_a_close_when_the_backlog_cannot_be_read
 test_recovery_finishes_a_close_for_the_same_meta_incarnation
 test_recovery_preserves_both_records_when_meta_removal_fails
 test_recovery_rejects_a_marker_for_another_task_identity
+test_recovery_rejects_a_foreign_data_directory
 test_recovery_rejects_invalid_close_arguments
 test_recovery_rejects_a_symlinked_close_marker
 test_recovery_drops_a_close_for_a_newer_meta_incarnation
-test_recovery_drops_a_legacy_close_when_meta_exists
+test_recovery_rejects_a_legacy_close_without_an_incarnation
 test_bootstrap_stops_when_data_disappears_before_reconciliation
 test_bootstrap_addressing_exemptions_remain_nonfatal
 test_recovery_leaves_a_captain_held_item_alone

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -351,6 +351,50 @@ test_completion_targets_a_nested_relative_data_directory() {
   pass "completion targets nested relative data from the caller directory"
 }
 
+test_dispatch_refuses_an_unresolvable_data_directory() {
+  local case_dir id saved out rc=0
+  id=atomic-dispatch-missing-data-b2
+  case_dir=$(make_home dispatch-missing-data "$id")
+  add_item "$case_dir" "$id"
+  saved="$case_dir/backlog-data"
+  mv "$(home_of "$case_dir")/data" "$saved"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn succeeded with an unresolvable data directory"
+  assert_contains "$out" "task $id" \
+    "spawn did not identify the task blocked by fatal backlog addressing"
+  assert_contains "$out" "$(home_of "$case_dir")/data" \
+    "spawn did not identify the inaccessible data directory"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "fatal backlog addressing created a task record"
+  [ "$(tasks-axi show "$id" --file "$saved/backlog.md" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = queued ] \
+    || fail "fatal backlog addressing changed the queued row"
+  pass "dispatch refuses an unresolvable backlog data directory"
+}
+
+test_completion_refuses_an_unresolvable_data_directory() {
+  local case_dir id saved meta out rc=0
+  id=atomic-close-missing-data-b2
+  case_dir=$(make_home close-missing-data)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-missing-data"
+  meta="$(home_of "$case_dir")/state/$id.meta"
+  saved="$case_dir/backlog-data"
+  mv "$(home_of "$case_dir")/data" "$saved"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown succeeded with an unresolvable data directory"
+  assert_contains "$out" "task $id cannot be torn down" \
+    "teardown did not identify the task blocked by fatal backlog addressing"
+  assert_present "$meta" "fatal backlog addressing removed the task record"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "fatal backlog addressing wrote a close marker"
+  [ "$(tasks-axi show "$id" --file "$saved/backlog.md" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = in_flight ] \
+    || fail "fatal backlog addressing changed the In-flight row"
+  pass "completion refuses before mutation when backlog data is unresolvable"
+}
+
 test_dispatch_refuses_an_id_this_home_has_no_item_for() {
   local case_dir id out rc=0
   id=atomic-dispatch-b2
@@ -943,6 +987,23 @@ test_recovery_leaves_a_captain_held_item_alone() {
 
 # --- backend selection and secondmate scope ---------------------------------
 
+test_home_without_a_backlog_dispatches_and_completes() {
+  local case_dir id out
+  id=atomic-no-backlog-b12
+  case_dir=$(make_home no-backlog "$id")
+  rm -f "$(backlog_of "$case_dir")"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || fail "no-backlog spawn failed: $out"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "no-backlog spawn did not publish its task record"
+  out=$(run_teardown "$case_dir" "$id") || fail "no-backlog teardown failed: $out"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "no-backlog teardown retained its task record"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "no-backlog teardown recorded a close marker"
+  pass "a home with no backlog remains exempt from lifecycle transitions"
+}
+
 test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog() {
   local case_dir id out
   id=atomic-manual-b12
@@ -952,6 +1013,7 @@ test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog()
   # so neither half of the lifecycle may hard-fail over its contents.
   out=$(run_ship_spawn "$case_dir" "$id") || fail "manual-backend spawn failed: $out"
   assert_contains "$out" "spawned $id" "manual-backend spawn did not report success"
+  mv "$(home_of "$case_dir")/data" "$case_dir/manual-data"
 
   out=$(run_teardown "$case_dir" "$id") || fail "manual-backend teardown failed: $out"
   assert_contains "$out" "Update data/backlog.md" \
@@ -1006,6 +1068,8 @@ test_dispatch_moves_the_item_in_flight_in_the_same_run
 test_dispatch_reads_the_row_from_the_backlog_root
 test_recovery_uses_the_parent_of_a_trailing_slash_data_record
 test_completion_targets_a_nested_relative_data_directory
+test_dispatch_refuses_an_unresolvable_data_directory
+test_completion_refuses_an_unresolvable_data_directory
 test_dispatch_refuses_an_id_this_home_has_no_item_for
 test_dispatch_reports_a_backlog_read_failure
 test_dispatch_refuses_a_closed_item
@@ -1035,6 +1099,7 @@ test_recovery_preserves_both_records_when_meta_removal_fails
 test_recovery_drops_a_close_for_a_newer_meta_incarnation
 test_recovery_drops_a_legacy_close_when_meta_exists
 test_recovery_leaves_a_captain_held_item_alone
+test_home_without_a_backlog_dispatches_and_completes
 test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog
 test_a_secondmate_home_keeps_its_own_books
 test_a_persistent_secondmate_is_never_a_backlog_item

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -91,6 +91,20 @@ row_state() {  # <case-dir> <id>
 # Shadow tasks-axi with a wrapper that fails one verb and delegates every other
 # verb to the real binary, so a test can drive a genuine mid-transition failure
 # without faking the reads around it.
+require_show_cwd() {  # <case-dir> <expected-dir>
+  local case_dir=$1 expected=$2 real
+  real=$(command -v tasks-axi)
+  cat > "$case_dir/fakebin/tasks-axi" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = show ] && [ "\$PWD" != "$expected" ]; then
+  echo "error: wrong tasks root: \$PWD" >&2
+  exit 1
+fi
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/tasks-axi"
+}
+
 break_verb() {  # <case-dir> <verb>
   local case_dir=$1 verb=$2 real
   real=$(command -v tasks-axi)
@@ -268,6 +282,21 @@ test_dispatch_moves_the_item_in_flight_in_the_same_run() {
   [ "$(row_state "$case_dir" "$id")" = in_flight ] \
     || fail "spawn reported success with its backlog item still $(row_state "$case_dir" "$id")"
   pass "dispatch publishes the record and moves the backlog item In flight in one run"
+}
+
+test_dispatch_reads_the_row_from_the_backlog_root() {
+  local case_dir id out
+  id=atomic-dispatch-root-b2
+  case_dir=$(make_home dispatch-root "$id")
+  add_item "$case_dir" "$id"
+  require_show_cwd "$case_dir" "$(home_of "$case_dir" | sed 's://*:/:g')"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || fail "spawn read outside the backlog root: $out"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "root-addressed dispatch left the backlog row queued"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "root-addressed dispatch did not publish its task record"
+  pass "dispatch reads backlog rows from the backlog addressing root"
 }
 
 test_dispatch_refuses_an_id_this_home_has_no_item_for() {
@@ -874,6 +903,7 @@ test_a_persistent_secondmate_is_never_a_backlog_item() {
 }
 
 test_dispatch_moves_the_item_in_flight_in_the_same_run
+test_dispatch_reads_the_row_from_the_backlog_root
 test_dispatch_refuses_an_id_this_home_has_no_item_for
 test_dispatch_reports_a_backlog_read_failure
 test_dispatch_refuses_a_closed_item

--- a/tests/fm-captain-hold-lifecycle.test.sh
+++ b/tests/fm-captain-hold-lifecycle.test.sh
@@ -90,7 +90,8 @@ write_origin_meta() {  # <home> <id> [kind]
     "project=$home/projects/sample" \
     "harness=codex" \
     "kind=$kind" \
-    "mode=$kind"
+    "mode=$kind" \
+    "spawn_gen=fixture-$id"
 }
 
 # Reproduces the loss exactly with privacy-safe synthetic names: the investigation

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -246,6 +246,38 @@ SH
   chmod +x "$1/fakebin/rm"
 }
 
+# Give a case home a real backlog carrying <id>, so the relaunch path's paired
+# backlog transition (bin/fm-backlog-transition-lib.sh) is live rather than
+# skipped for want of a backlog file.
+seed_backlog() {  # <case-dir> <id> <queued|in_flight>
+  local dir=$1 id=$2 want=$3 file="$1/home/data/backlog.md"
+  printf '%s\n' '# Backlog' '' '## In flight' '' '## Queued' '' '## Done' > "$file"
+  tasks-axi add "$id" "relaunch fixture task" --kind ship --file "$file" >/dev/null
+  [ "$want" != in_flight ] || tasks-axi start "$id" --file "$file" >/dev/null
+}
+
+backlog_state() {  # <case-dir> <id>
+  tasks-axi show "$2" --file "$1/home/data/backlog.md" 2>/dev/null |
+    sed -n 's/^  state: *//p' | head -1
+}
+
+# Shadow tasks-axi so every `start` fails and every other verb is real. A
+# relaunch that re-reads the row before acting never calls it; one that assumes
+# it must re-run the transition trips over it.
+break_tasks_axi_start() {  # <case-dir>
+  local dir=$1 real
+  real=$(command -v tasks-axi)
+  cat > "$dir/fakebin/tasks-axi" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = start ]; then
+  echo 'error: "start refused"' >&2
+  exit 1
+fi
+exec "$real" "\$@"
+SH
+  chmod +x "$dir/fakebin/tasks-axi"
+}
+
 # --- 1. same-harness relaunch -----------------------------------------------
 
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint() {
@@ -1312,6 +1344,41 @@ test_spawn_relaunch_refuses_a_pane_outside_the_worktree() {
   pass "fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work"
 }
 
+test_relaunch_reverifies_an_already_in_flight_item_instead_of_rewriting_it() {
+  local dir out rc=0
+  command -v tasks-axi >/dev/null 2>&1 || {
+    pass "skipped: tasks-axi is not installed, so the backlog transition is inert"
+    return 0
+  }
+  dir=$(new_case reverify rl40)
+  add_ship_task "$dir" rl40 claude
+  seed_backlog "$dir" rl40 in_flight
+  break_tasks_axi_start "$dir"
+
+  out=$(run_control "$dir" rl40 relaunch --note "picking the work back up") || rc=$?
+  expect_code 0 "$rc" "a relaunch must not re-run a transition the row already reflects"$'\n'"$out"
+  [ "$(backlog_state "$dir" rl40)" = in_flight ] \
+    || fail "a relaunch changed an already In-flight item to $(backlog_state "$dir" rl40)"
+  pass "relaunch re-reads the backlog item instead of blindly re-running the transition"
+}
+
+test_relaunch_moves_a_drifted_item_back_in_flight() {
+  local dir out rc=0
+  command -v tasks-axi >/dev/null 2>&1 || {
+    pass "skipped: tasks-axi is not installed, so the backlog transition is inert"
+    return 0
+  }
+  dir=$(new_case drifted rl41)
+  add_ship_task "$dir" rl41 claude
+  seed_backlog "$dir" rl41 queued
+
+  out=$(run_control "$dir" rl41 relaunch --note "picking the work back up") || rc=$?
+  expect_code 0 "$rc" "a relaunch onto a drifted item should succeed"$'\n'"$out"
+  [ "$(backlog_state "$dir" rl41)" = in_flight ] \
+    || fail "a relaunch left its item at $(backlog_state "$dir" rl41)"
+  pass "relaunch heals an item that drifted out of In flight while the task stayed live"
+}
+
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_serializes_concurrent_durable_metadata_publication
@@ -1358,3 +1425,5 @@ test_spawn_relaunch_refuses_a_live_agent
 test_spawn_relaunch_refuses_contradicting_flags
 test_spawn_relaunch_refuses_an_unrecorded_task
 test_spawn_relaunch_refuses_a_pane_outside_the_worktree
+test_relaunch_reverifies_an_already_in_flight_item_instead_of_rewriting_it
+test_relaunch_moves_a_drifted_item_back_in_flight

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -86,7 +86,7 @@ case "${1:-}" in
         'export GOTMPDIR='*)
           if [ -n "${FM_FAKE_TRACE_PREPARE:-}" ]; then
             : > "$FM_FAKE_TRACE_PREPARE"
-            while [ ! -e "$FM_FAKE_META_WRITER_READY" ]; do /bin/sleep 0.01; done
+            while [ ! -e "$FM_FAKE_TRACE_RELEASE" ]; do /bin/sleep 0.01; done
           fi
           ;;
         'export TRACEPARENT='*)
@@ -117,6 +117,7 @@ SH
   chmod +x "$fb/tmux"
   cat > "$fb/sleep" <<'SH'
 #!/usr/bin/env bash
+[ -z "${FM_FAKE_LOCK_WAITING:-}" ] || : > "$FM_FAKE_LOCK_WAITING"
 exit 0
 SH
   chmod +x "$fb/sleep"
@@ -169,6 +170,7 @@ run_control() {  # <case-dir> <args...>
     FM_REAL_MV="${FM_REAL_MV:-}" FM_FAKE_COMPLETE_JOURNAL_MV_FAIL="${FM_FAKE_COMPLETE_JOURNAL_MV_FAIL:-}" \
     FM_FAKE_META_PUBLISH_MV_FAIL="${FM_FAKE_META_PUBLISH_MV_FAIL:-}" \
     FM_FAKE_TRACE_PREPARE="${FM_FAKE_TRACE_PREPARE:-}" \
+    FM_FAKE_TRACE_RELEASE="${FM_FAKE_TRACE_RELEASE:-}" \
     FM_FAKE_META_WRITER_READY="${FM_FAKE_META_WRITER_READY:-}" \
     FM_FAKE_TRACE_EXPORTED="${FM_FAKE_TRACE_EXPORTED:-}" \
     "$CONTROL" "$@" 2>&1
@@ -330,20 +332,20 @@ test_relaunch_preserves_durable_task_metadata() {
 }
 
 test_relaunch_serializes_concurrent_durable_metadata_publication() {
-  local dir control_pid link_pid rc i=0 traceparent prepare ready exported release
+  local dir control_pid link_pid rc i=0 traceparent prepare launch_release waiting ready release
   dir=$(new_case metadata-race rl28)
   add_ship_task "$dir" rl28 claude
   printf '%s\n' "$$" > "$dir/home/state/.lock"
   printf '%s on\n' "$$" > "$dir/home/state/.trace-context-effective"
   make_mv_failure_stub "$dir"
   prepare="$dir/trace-prepare"
+  launch_release="$dir/trace-release"
+  waiting="$dir/meta-writer-waiting"
   ready="$dir/meta-writer-ready"
-  exported="$dir/trace-exported"
   release="$dir/meta-writer-release"
   FM_REAL_MV=$(command -v mv) \
     FM_FAKE_TRACE_PREPARE="$prepare" \
-    FM_FAKE_META_WRITER_READY="$ready" \
-    FM_FAKE_TRACE_EXPORTED="$exported" \
+    FM_FAKE_TRACE_RELEASE="$launch_release" \
     run_control "$dir" rl28 relaunch --note "continue after publication" > "$dir/control.out" &
   control_pid=$!
   while [ ! -e "$prepare" ] && [ "$i" -lt 200 ]; do
@@ -357,6 +359,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
   }
   env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
     FM_REAL_MV="$(command -v mv)" \
+    FM_FAKE_LOCK_WAITING="$waiting" \
     FM_FAKE_META_WRITER_TARGET="$dir/home/state/rl28.meta" \
     FM_FAKE_META_WRITER_READY="$ready" \
     FM_FAKE_META_WRITER_RELEASE="$release" \
@@ -364,22 +367,34 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
       --carry-platform x --carry-max 280 > "$dir/link.out" 2>&1 &
   link_pid=$!
   i=0
-  while { [ ! -e "$ready" ] || [ ! -e "$exported" ]; } && [ "$i" -lt 200 ]; do
+  while [ ! -e "$waiting" ] && [ "$i" -lt 200 ]; do
     /bin/sleep 0.01
     i=$((i + 1))
   done
-  [ -e "$ready" ] && [ -e "$exported" ] || {
+  [ -e "$waiting" ] && [ ! -e "$ready" ] || {
+    : > "$launch_release"
     : > "$release"
+    wait "$link_pid" 2>/dev/null || true
+    wait "$control_pid" 2>/dev/null || true
+    fail "a durable metadata writer was not blocked during relaunch delivery"
+  }
+  : > "$launch_release"
+  i=0
+  while [ ! -e "$ready" ] && [ "$i" -lt 200 ]; do
+    /bin/sleep 0.01
+    i=$((i + 1))
+  done
+  [ -e "$ready" ] || {
     kill "$link_pid" "$control_pid" 2>/dev/null || true
     wait "$link_pid" 2>/dev/null || true
     wait "$control_pid" 2>/dev/null || true
-    fail "trace publication did not overlap the concurrent metadata writer"
+    fail "durable metadata writer did not resume after relaunch delivery committed"
   }
   : > "$release"
   wait "$link_pid"; rc=$?
   expect_code 0 "$rc" "concurrent X metadata publication should serialize"$'\n'"$(cat "$dir/link.out")"
   wait "$control_pid"; rc=$?
-  expect_code 0 "$rc" "relaunch should complete after serialized metadata publication"$'\n'"$(cat "$dir/control.out")"
+  expect_code 0 "$rc" "relaunch should complete before serialized metadata publication"$'\n'"$(cat "$dir/control.out")"
   [ "$(meta_field "$dir" rl28 x_request)" = request-28 ] \
     || fail "relaunch erased metadata published concurrently through the X interface"
   [ "$(meta_field "$dir" rl28 x_followups)" = 1 ] \
@@ -387,7 +402,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
   traceparent=$(meta_field "$dir" rl28 traceparent)
   fm_trace_context_valid "$traceparent" \
     || fail "concurrent metadata publication erased the replacement's trace carrier"
-  pass "fm-control relaunch: trace and concurrent task metadata publications serialize"
+  pass "fm-control relaunch: delivery and concurrent task metadata publication serialize"
 }
 
 test_disabled_relaunch_clears_prior_trace_context() {

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -305,7 +305,7 @@ SH
   fm_write_meta "$case_dir/state/task-x1.meta" \
     "window=firstmate:fm-task-x1" "endpoint_task_id=task-x1" \
     "worktree=$case_dir/wt" "project=$case_dir/project" \
-    "kind=ship" "mode=no-mistakes"
+    "kind=ship" "mode=no-mistakes" "spawn_gen=spawn-gate-refuse-task-x1"
   touch "$case_dir/state/.last-watcher-beat"
   printf '%s\n' "$case_dir"
 }

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -269,7 +269,7 @@ test_send_refuses_and_admits() {
 make_teardown_case() {
   local name=$1 case_dir fakebin t
   case_dir="$TMP/$name"; fakebin="$case_dir/fakebin"
-  mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin"
+  mkdir -p "$case_dir/state" "$case_dir/config" "$case_dir/data" "$fakebin"
   for t in treehouse tmux; do
     printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/$t"
     chmod +x "$fakebin/$t"
@@ -315,7 +315,8 @@ run_teardown() {
   local cwd=$1 case_dir=$2; shift 2
   ( cd "$cwd" && env -u NO_MISTAKES_GATE -u FM_GATE_REFUSE_BYPASS \
       "FM_ROOT_OVERRIDE=$ROOT" "FM_STATE_OVERRIDE=$case_dir/state" \
-      "FM_CONFIG_OVERRIDE=$case_dir/config" "PATH=$case_dir/fakebin:$PATH" "$@" \
+      "FM_DATA_OVERRIDE=$case_dir/data" "FM_CONFIG_OVERRIDE=$case_dir/config" \
+      "PATH=$case_dir/fakebin:$PATH" "$@" \
       "$TEARDOWN" task-x1 ) 2>&1
 }
 

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -101,11 +101,15 @@ SH
 exit 0
 SH
   chmod +x "$fake/bin/fm-fleet-sync.sh"
-  # fm-tasks-axi-lib.sh: stub (teardown sources it). Report no backend so
-  # backlog_refresh_reminder takes the plain-message path; no tasks-axi here.
+  # fm-tasks-axi-lib.sh: stub (teardown sources it). Report no backend so the
+  # fused backlog close is skipped and the follow-up echo takes the plain-message
+  # path; there is no tasks-axi and no backlog in this fixture.
   cat > "$fake/bin/fm-tasks-axi-lib.sh" <<'SH'
 fm_tasks_axi_backend_available() { return 1; }
+fm_tasks_axi_compatible() { return 1; }
+fm_backlog_backend_manual() { return 1; }
 SH
+  ln -s "$ROOT/bin/fm-backlog-transition-lib.sh" "$fake/bin/fm-backlog-transition-lib.sh"
   # Meta with a nonexistent worktree so the dirty/treehouse blocks skip.
   cat > "$fake/state/$id.meta" <<META
 window=fakeses:fm-$id
@@ -188,7 +192,10 @@ SH
   chmod +x "$fake/bin/fm-fleet-sync.sh"
   cat > "$fake/bin/fm-tasks-axi-lib.sh" <<'SH'
 fm_tasks_axi_backend_available() { return 1; }
+fm_tasks_axi_compatible() { return 1; }
+fm_backlog_backend_manual() { return 1; }
 SH
+  ln -s "$ROOT/bin/fm-backlog-transition-lib.sh" "$fake/bin/fm-backlog-transition-lib.sh"
   # No tasktmp= line at all.
   cat > "$fake/state/$id.meta" <<META
 window=fakeses:fm-$id

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -624,7 +624,7 @@ test_secondmate_teardown_requires_parent_binding() {
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
     FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
@@ -648,7 +648,7 @@ test_secondmate_teardown_requires_parent_binding() {
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
   assert_absent "$child/.fm-secondmate-parent" \
     "the legacy env-only binding case must not gain a durable parent record"
 
@@ -757,7 +757,7 @@ test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost() {
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   # No FM_PUBLIC_FOLLOWUP_PRIMARY_HOME at all here: a restart of the secondmate
   # agent that drops the launch-time prefix must still find the real parent
@@ -790,7 +790,7 @@ test_secondmate_teardown_durable_record_missing_parent_registration_still_refuse
   assert_local_secondmate_parent_record "$child" "$parent_resolved"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
   # No parent/state/mate.meta at all: the parent never recorded this secondmate's
   # own agent, so its side of the binding is genuinely missing. A durable LOCAL
   # record naming the real parent path must not be enough on its own to bypass
@@ -828,7 +828,7 @@ test_secondmate_teardown_durable_record_with_unknown_field_succeeds() {
   fm_write_meta "$child/state/work-clean.meta" \
     "window=firstmate:fm-work-clean" "endpoint_task_id=work-clean" \
     "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
-    "kind=ship" "mode=local-only"
+    "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   rc=0
   out=$(PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
@@ -860,7 +860,7 @@ test_secondmate_teardown_rejects_conflicting_live_and_durable_parent_bindings() 
   fm_write_meta "$child/state/work-conflict.meta" \
     "window=firstmate:fm-work-conflict" "endpoint_task_id=work-conflict" \
     "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
-    "kind=ship" "mode=local-only"
+    "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
     FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
@@ -887,7 +887,7 @@ test_secondmate_teardown_rejects_unsafe_durable_parent_records() {
     fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
     fm_write_meta "$child/state/work-child.meta" \
       "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-      "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+      "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
     parent_record="$child/.fm-secondmate-parent"
     case "$case_name" in
       symlink)
@@ -954,7 +954,7 @@ test_secondmate_teardown_rejects_nul_bearing_durable_parent_record() {
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
     "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
-    "kind=ship" "mode=local-only"
+    "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
   pre=${parent_resolved%??????}
   suf=${parent_resolved#"$pre"}
   record="$child/.fm-secondmate-parent"
@@ -992,7 +992,7 @@ SH
   fm_write_meta "$home/state/work-disabled.meta" \
     "window=firstmate:fm-work-disabled" "endpoint_task_id=work-disabled" \
     "worktree=$home/projects/worktree" "project=$home/projects/worktree" \
-    "kind=ship" "mode=local-only"
+    "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   rc=0
   out=$(PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
@@ -1028,7 +1028,7 @@ SH
   fm_write_meta "$child/state/work-disabled.meta" \
     "window=firstmate:fm-work-disabled" "endpoint_task_id=work-disabled" \
     "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
-    "kind=ship" "mode=local-only"
+    "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   rc=0
   out=$(PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
@@ -1056,7 +1056,7 @@ test_secondmate_parent_binding_matches_literal_id() {
   fm_write_meta "$parent/state/mate.id.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-literal.meta" \
     "window=firstmate:fm-work-literal" "endpoint_task_id=work-literal" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
     FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
@@ -1151,7 +1151,8 @@ test_cleanup_refuses_while_a_public_reply_is_owed() {
     "project=$home/projects/sample" \
     "harness=codex" \
     "kind=ship" \
-    "mode=no-mistakes"
+    "mode=no-mistakes" \
+    "spawn_gen=public-followup-guard"
 
   rc=0
   PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
@@ -1396,7 +1397,7 @@ test_dropped_baton_now_surfaces_open_loop() {
 
   fm_write_meta "$child/state/pi-rearm-loop-fix-r1.meta" \
     "window=firstmate:fm-pi-rearm-loop-fix-r1" "endpoint_task_id=pi-rearm-loop-fix-r1" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   PATH="$parent/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$parent" \
     FM_STATE_OVERRIDE="$parent/state" "$PF" guard-work secondmate:mate pi-rearm-loop-fix-r1 \
@@ -1432,7 +1433,7 @@ test_control_registered_followon_is_guarded() {
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/pi-rearm-loop-fix-r1.meta" \
     "window=firstmate:fm-pi-rearm-loop-fix-r1" "endpoint_task_id=pi-rearm-loop-fix-r1" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
   PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
     FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
     expect_failure "registered follow-on must be guarded" "$TEARDOWN" pi-rearm-loop-fix-r1
@@ -1980,7 +1981,8 @@ test_retention_creates_no_false_teardown_refusal() {
     "project=$home/projects/sample" \
     "harness=codex" \
     "kind=ship" \
-    "mode=no-mistakes"
+    "mode=no-mistakes" \
+    "spawn_gen=public-followup-retain"
   emit_terminal "$home" "$home" pf-retain main ship-retain >/dev/null || fail "emit failed"
   run_pf "$home" consume >/dev/null || fail "consume failed"
   FAKE_CURL_LOG="$home/curl.log" run_pf "$home" deliver pf-retain >/dev/null || fail "delivery failed"
@@ -2139,6 +2141,7 @@ test_x_request_teardown_warns_when_final_unposted() {
     "project=$home/projects/sample" \
     "kind=ship" \
     "mode=local-only" \
+    "spawn_gen=public-followup-legacy-link" \
     "x_request=req-legacy-final"
   rc=0
   PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -1141,6 +1141,10 @@ test_cleanup_refuses_while_a_public_reply_is_owed() {
   local home rc
   home=$(make_home cleanup-guard)
   seed_commitment "$home" pf-guard req-guard discord main ship-task
+  tasks_in "$home" add ship-task "ship guarded by its public follow-up" --kind ship >/dev/null \
+    || fail "could not add the guarded ship to its home's backlog"
+  tasks_in "$home" start ship-task >/dev/null \
+    || fail "could not mark the guarded ship In flight"
   fm_write_meta "$home/state/ship-task.meta" \
     "window=firstmate:fm-ship-task" \
     "worktree=$home/projects/gone" \
@@ -1966,6 +1970,10 @@ test_retention_creates_no_false_teardown_refusal() {
   local home home2 rc out registry tmp
   home=$(make_home retain-teardown)
   seed_commitment "$home" pf-retain req-retain discord main ship-retain
+  tasks_in "$home" add ship-retain "ship with a retained delivered registration" --kind ship >/dev/null \
+    || fail "could not add the retained-registration ship to its home's backlog"
+  tasks_in "$home" start ship-retain >/dev/null \
+    || fail "could not mark the retained-registration ship In flight"
   fm_write_meta "$home/state/ship-retain.meta" \
     "window=firstmate:fm-ship-retain" \
     "worktree=$home/projects/gone" \
@@ -2121,6 +2129,10 @@ test_prechange_registration_is_open_and_unrechainable() {
 test_x_request_teardown_warns_when_final_unposted() {
   local home rc
   home=$(make_home xreq-warn)
+  tasks_in "$home" add linked-task "ship with a legacy Relay request link" --kind ship >/dev/null \
+    || fail "could not add the legacy-link ship to its home's backlog"
+  tasks_in "$home" start linked-task >/dev/null \
+    || fail "could not mark the legacy-link ship In flight"
   fm_write_meta "$home/state/linked-task.meta" \
     "window=firstmate:fm-linked-task" \
     "worktree=$home/projects/gone" \

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -6,7 +6,7 @@
 # Coverage:
 #   - absent-file markers vs empty-but-present files in the context digest
 #   - the lock-refusal read-only path: banner leads, every mutating step is
-#     skipped (including bootstrap's five mutating sweeps, verified by their
+#     skipped (including bootstrap's seven mutating sweeps, verified by their
 #     ABSENCE), the digest still completes
 #   - output section ordering: the safety preamble leads unchanged, live fleet
 #     state precedes the curated memory a truncated tail may take, and the

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -96,7 +96,7 @@ test_projects_path_scoping() {
     fi
     status=$?
     [ "$status" -ne 0 ] || fail "$label: spawn with missing brief should fail"
-    expected="error: no brief at $home/data/$id/brief.md"
+    expected="error: task $id has no brief at inaccessible data path $home/data/$id/brief.md"
     printf '%s\n' "$out" | grep -F "$expected" >/dev/null \
       || fail "$label: projects/alpha was not resolved through the home before the brief check"
     printf '%s\n' "$out" | grep -F 'cd: projects/alpha' >/dev/null \

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -76,7 +76,7 @@ make_case() {
   local name=$1 case_dir fakebin
   case_dir="$TMP_ROOT/$name"
   fakebin="$case_dir/fakebin"
-  mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin"
+  mkdir -p "$case_dir/state" "$case_dir/config" "$case_dir/data" "$fakebin"
 
   # Mocks for the post-check teardown steps. Refuse logic exits before these
   # run; the ALLOW cases need them so the script can complete cleanly.
@@ -173,29 +173,6 @@ SH
   touch "$case_dir/state/.last-watcher-beat"
 
   printf '%s\n' "$case_dir"
-}
-
-add_compatible_tasks_axi() {
-  local case_dir=$1
-  cat > "$case_dir/fakebin/tasks-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.2.4'
-  exit 0
-fi
-if [ "${1:-}" = update ] && [ "${2:-}" = --help ]; then
-  printf '%s\n' 'usage: tasks-axi update <id> [flags]'
-  printf '%s\n' '  --body-file <path>'
-  printf '%s\n' '  --archive-body'
-  exit 0
-fi
-if [ "${1:-}" = mv ] && [ "${2:-}" = --help ]; then
-  printf '%s\n' 'usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$case_dir/fakebin/tasks-axi"
 }
 
 # Write a meta file for the task. Args: case_dir mode kind
@@ -542,11 +519,34 @@ SH
 # Run teardown with PATH mocking. Args: case_dir [extra args...]
 run_teardown() {
   local case_dir=$1; shift
+  # FM_DATA_OVERRIDE is pinned to the case dir because teardown closes this
+  # home's backlog item itself; without it $DATA would resolve to the real
+  # repo's own home and a test could mutate live records.
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_DATA_OVERRIDE="$case_dir/data" \
   FM_CONFIG_OVERRIDE="$case_dir/config" \
   PATH="$case_dir/fakebin:${FM_TEARDOWN_TEST_PATH:-$PATH}" \
     "$TEARDOWN" task-x1 "$@"
+}
+
+# Seed a real backlog carrying task-x1 as In flight, so a teardown in this case
+# has a row to close. Uses the real tasks-axi (the fixture's default fakebin has
+# no tasks-axi stub, so PATH resolves the installed one).
+seed_backlog_in_flight() {
+  local case_dir=$1 kind=${2:-ship}
+  mkdir -p "$case_dir/data"
+  printf '%s\n' '# Backlog' '' '## In flight' '' '## Queued' '' '## Done' \
+    > "$case_dir/data/backlog.md"
+  tasks-axi add task-x1 "teardown fixture task" --kind "$kind" \
+    --file "$case_dir/data/backlog.md" >/dev/null
+  tasks-axi start task-x1 --file "$case_dir/data/backlog.md" >/dev/null
+}
+
+backlog_row_state() {
+  local case_dir=$1
+  tasks-axi show task-x1 --file "$case_dir/data/backlog.md" 2>/dev/null |
+    sed -n 's/^  state: *//p' | head -1
 }
 
 # Build the teardown test's executable search path without lsof, regardless of
@@ -584,39 +584,43 @@ test_local_only_fork_remote_allows() {
   pass "local-only worktree with HEAD on a fork remote is torn down and the home summary is refreshed"
 }
 
-test_teardown_prompts_tasks_axi_done_when_compatible() {
+test_teardown_closes_the_backlog_item_itself() {
   local case_dir out
-  case_dir=$(make_case tasks-axi-reminder)
+  case_dir=$(make_case tasks-axi-close)
   write_meta "$case_dir" no-mistakes ship
   printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
-  add_compatible_tasks_axi "$case_dir"
+  seed_backlog_in_flight "$case_dir"
 
-  out=$(run_teardown "$case_dir") || fail "teardown failed with compatible tasks-axi"
-  printf '%s\n' "$out" | grep -F 'tasks-axi done task-x1 --pr https://github.com/example/repo/pull/7' >/dev/null \
-    || fail "teardown did not prompt tasks-axi done: $out"
+  out=$(run_teardown "$case_dir") || fail "teardown failed with a real backlog"
+  [ "$(backlog_row_state "$case_dir")" = "done" ] \
+    || fail "teardown returned success while its backlog item was still open: $(backlog_row_state "$case_dir")"
+  assert_grep 'https://github.com/example/repo/pull/7' "$case_dir/data/backlog.md" \
+    "closed backlog item did not record the task's PR"
+  assert_absent "$case_dir/state/task-x1.backlog-close" \
+    "a landed close left its pending-close record behind"
   printf '%s\n' "$out" | grep -F 'tasks-axi ready' >/dev/null \
-    || fail "teardown did not prompt tasks-axi ready: $out"
+    || fail "teardown dropped the dependency-cleared follow-up: $out"
   printf '%s\n' "$out" | grep -F 'check date gates' >/dev/null \
     || fail "teardown did not preserve date-gate check: $out"
-  printf '%s\n' "$out" | grep -F 'keep Done to the 10 most recent' >/dev/null \
-    && fail "teardown kept manual Done pruning in compatible tasks-axi prompt: $out"
-  pass "teardown prompts tasks-axi backlog refresh when compatible"
+  printf '%s\n' "$out" | grep -F 'Run tasks-axi done' >/dev/null \
+    && fail "teardown still asked a later turn to close the item it already closed: $out"
+  pass "teardown closes its own backlog item before reporting success"
 }
 
-test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present() {
+test_teardown_manual_backend_leaves_the_backlog_to_the_operator() {
   local case_dir out
   case_dir=$(make_case tasks-axi-manual-optout)
   write_meta "$case_dir" no-mistakes ship
   printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
   printf '%s\n' manual > "$case_dir/config/backlog-backend"
-  add_compatible_tasks_axi "$case_dir"
+  seed_backlog_in_flight "$case_dir"
 
   out=$(run_teardown "$case_dir") || fail "teardown failed with manual backlog backend"
+  [ "$(backlog_row_state "$case_dir")" = in_flight ] \
+    || fail "manual backlog backend was mutated by teardown anyway"
   printf '%s\n' "$out" | grep -F 'Update data/backlog.md - move task-x1 to Done' >/dev/null \
     || fail "teardown did not prompt manual backlog update under opt-out: $out"
-  printf '%s\n' "$out" | grep -F 'tasks-axi done' >/dev/null \
-    && fail "teardown prompted tasks-axi despite manual backend opt-out: $out"
-  pass "teardown honors config/backlog-backend=manual even when tasks-axi is compatible"
+  pass "teardown honors config/backlog-backend=manual and still finishes cleanly"
 }
 
 test_local_only_truly_unpushed_refuses() {
@@ -2597,8 +2601,8 @@ EOF
 }
 
 test_local_only_fork_remote_allows
-test_teardown_prompts_tasks_axi_done_when_compatible
-test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
+test_teardown_closes_the_backlog_item_itself
+test_teardown_manual_backend_leaves_the_backlog_to_the_operator
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
 test_no_mistakes_origin_remote_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -251,7 +251,7 @@ SH
 case "\${1:-} \${2:-}" in
   "pr view")
     case " \$* " in
-      *"state,headRefOid"*) printf '%s\t%s\n' 'MERGED' '$head' ; exit 0 ;;
+      *"state,headRefOid,url"*) printf '%s\t%s\t%s\n' 'MERGED' '$head' 'https://github.com/example/repo/pull/7' ; exit 0 ;;
       *"headRefOid"*) printf '%s\n' '$head' ; exit 0 ;;
     esac
     ;;
@@ -762,6 +762,7 @@ test_no_pr_recorded_discovers_merged_pr_by_branch_allows() {
   pr_head=$(commit_tree_from_wt_head "$case_dir" "$local_head" "no-mistakes auto-fix")
   land_on_origin_main "$case_dir" feature.txt hello
   add_gh_pr_merged_for_head "$case_dir" "$pr_head"
+  seed_backlog_in_flight "$case_dir"
   # No append_pr_meta_* call: state/task-x1.meta has no pr= or pr_head= line.
 
   ! grep -qE '^(pr|pr_head)=' "$case_dir/state/task-x1.meta" \
@@ -774,6 +775,8 @@ test_no_pr_recorded_discovers_merged_pr_by_branch_allows() {
 
   expect_code 0 "$rc" "no-pr-branch-discovery: teardown should succeed by discovering the merged PR from the branch name"
   ! grep -q REFUSED "$case_dir/stderr" || fail "no-pr-branch-discovery: teardown printed a REFUSED line"
+  assert_grep 'https://github.com/example/repo/pull/7' "$case_dir/data/backlog.md" \
+    "no-pr-branch-discovery: resolved PR URL was not recorded on completion"
   pass "teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded"
 }
 

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1568,8 +1568,8 @@ SH
       ;;
   esac
   rc=0
-  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" FM_CONFIG_OVERRIDE="$case_dir/config" \
-    FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" \
+  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" FM_DATA_OVERRIDE="$case_dir/data" \
+    FM_CONFIG_OVERRIDE="$case_dir/config" FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" \
     FM_FAKE_HERDR_SESSION_LIST_GARBAGE="$([ "$mode" = unresolvable-lock ] && printf 1 || printf 0)" \
     PATH="$case_dir/fakebin:$PATH" \
     "$teardown_bin" task-x1 --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -184,7 +184,8 @@ write_meta() {
     "worktree=$case_dir/wt" \
     "project=$case_dir/project" \
     "kind=$kind" \
-    "mode=$mode"
+    "mode=$mode" \
+    "spawn_gen=teardown-test-task-x1"
 }
 
 # Commit something on the worktree's task branch. Args: case_dir [message]


### PR DESCRIPTION
## Intent

Make Firstmate's backlog<->meta records atomically consistent by construction, so the three record-disagreement classes an earlier investigation catalogued (orphan_in_flight, unowned_current, terminal_in_flight) cannot arise from the ordinary dispatch/completion path, and add durable terminal-close recovery for the one class that can still occur across a crash.

This implements the recommendation of a completed scout investigation (data/fm-secondmate-record-consistency-scout-s1/report.md, private to the operator's home). The design decision is already made and is NOT open for re-litigation: do not propose a distributed transaction, two-phase commit, or a new journal subsystem - the report explains why none fits a single-writer/single-host/single-filesystem-per-task system.

THE INVARIANT ENFORCED: the script that performs the mechanical physical-state change (create or remove state/<id>.meta) must be the SOLE owner of the paired backlog transition, executed atomically in the same process under the same per-task lock it already holds, BEFORE it reports success - never a second, independently-timed step left to a future agent turn, an LLM's memory, or a printed reminder. Before this change the backlog half was prose in AGENTS.md telling a later agent turn to run `tasks-axi start`/`tasks-axi done`, with zero durable tracking if that second command never happened.

REQUIRED CHANGES, all implemented:
1. Dispatch (bin/fm-spawn.sh): after it durably writes state/<id>.meta, and under the per-task meta lock, fold the backlog In-flight transition into the spawn itself as the last step before declaring success. A failed transition fails the spawn loudly with an explicit error rather than leaving a silently orphaned meta file. The relaunch path re-verifies (does not assume) backlog state rather than blindly re-running the transition.
2. Completion (bin/fm-teardown.sh): in the same guarded section that removes state/<id>.meta, fold the backlog completion transition (tasks-axi done with the right --pr/--report/--note from $PR_URL, $KIND, $MODE, all already resolved locally) into teardown, under the meta lock, before it reports success. The existing backlog-refresh reminder becomes a confirmation echo of what teardown already durably did, not a load-bearing instruction. Teardown's existing unlanded-work / landed-work safety gates are NOT weakened: the transition is folded in only on the paths that already proceed to remove meta.
3. Same-home self-heal on restart (bin/fm-bootstrap.sh): a same-home, self-triggered reconciliation added to the existing bootstrap MUTATING sweeps (already run under the session lock) so a home that crashed mid-transition heals its OWN books on its own restart instead of waiting for a parent's cross-home nudge cooldown. Same-home only: it never reaches into another home, and it neither duplicates nor replaces the existing cross-home reconcile-nudge (bin/fm-secondmate-reconcile.sh) or the fleet-snapshot classifier (bin/fm-fleet-snapshot.sh) - those deliberately stay as defense-in-depth backstops.
4. Respect the configured backlog backend: when config/backlog-backend selects `manual`, routine backlog transitions are hand-edited, so the folded transition must not hard-fail a spawn/teardown on a manual-backend home. It follows the existing backend-selection contract (bin/fm-tasks-axi-lib.sh / docs/configuration.md) rather than calling tasks-axi unconditionally.

CONCURRENCY AND LOCKING: reuse the per-id locks the codebase already has (fm_meta_lock_path, and the reconcile_lock/control_lock/meta_lock pattern). No new lock namespaces are to be invented. The fused tasks-axi call runs inside the lock the mechanical step already holds, so a steer racing a teardown on the same id stays serialized exactly as before.

SCOPE DISCIPLINE: orphan_in_flight and unowned_current must be prevented by construction on the ordinary path. terminal_in_flight shrinks to a millisecond crash window inside one script; the self-heal sweep plus the existing detect/nudge backstop cover the residual. The markerless-remote-mate gap is explicitly OUT OF SCOPE - it is owned by a separate authorized ship (fm-secondmate-reconcile-missing-spawn-gen-r1) and must not be folded in.

DESIGN DECISIONS MADE WHILE IMPLEMENTING (deliberate, not accidents):
- A new shared library bin/fm-backlog-transition-lib.sh is the single owner of the invariant and of the gate that decides when a transition applies. It deliberately does not source bin/fm-tasks-axi-lib.sh, matching this repo's flat "libs never source libs" convention; callers source both.
- The transition is skipped, never failed, for: kind=secondmate (persistent agents are never backlog items, AGENTS.md section 10 - this matches the pre-existing scope of the teardown reminder exactly), a config/backlog-backend=manual home, a home without compatible tasks-axi, and a home that keeps no data/backlog.md at all. The last of those is what keeps ad-hoc and fixture homes working: a home with no backlog file has no books to keep consistent.
- Dispatch REFUSES up front - before any endpoint, worktree, or record exists - when the home's backlog has no item for the id, or already records it as finished. This is deliberate strictness: it is what makes unowned_current structurally impossible rather than merely unlikely, and refusing at the cheapest possible point means there is nothing to unwind. The error names the exact `tasks-axi add` / `tasks-axi reopen` command to run. Refusing a `done` row rather than silently reopening it also avoids a tasks-axi round-trip quirk that pollutes the item title. The row is re-read under the lock, so an item closed while the endpoint was being stood up is refused rather than resurrected.
- Teardown records the intended close in state/<id>.backlog-close BEFORE removing the record, because the completion links (PR, report path, local-main note) live only in the record being removed - a process killed between the halves would otherwise leave nothing to reconstruct the close from. The marker is stamped with the record's own incarnation so replay can tell an interrupted cleanup from a later redispatch. A landed close removes that record. This is one small marker file, deliberately not a journal subsystem. Replay is idempotent because `tasks-axi done` on an already-closed task backfills links without moving the close date.
- The bootstrap sweep heals only unambiguous cases: it finishes an interrupted cleanup of the very incarnation it recorded, drops a close whose id has since been dispatched again, and moves In flight any queued, non-held item this home already owns a record for. It deliberately never touches a captain-held item (that is the captain's to move) or a closed one (it must not resurrect an item), never blocks on a record a live action owns, never reaches into another home, and costs nothing on a home that owns no records.
- tasks-axi is always addressed with an explicit `--file <data>/backlog.md` and run from that data directory's PARENT, so the mutation lands in the home that owns the task regardless of the caller's working directory, and that home's own .tasks.toml supplies done_keep and the archive path. The parent of the data directory is the addressing root rather than FM_HOME so a relocated data directory keeps its backlog and archive together - and so a test fixture cannot mutate the developer's real backlog. The scout report link is derived from the configured data directory relative to that addressing root, not hardcoded as data/<id>/report.md.
- On a failed dispatch transition the just-published record AND the busy generation armed alongside it are both removed, so the unwind is complete rather than half-done. A relaunch instead preserves its pre-existing record and fails loudly, because that record and its work predate the run.

TESTS: new tests/fm-backlog-atomicity.test.sh drives the real fm-spawn.sh, fm-teardown.sh, and fm-bootstrap.sh against a real backlog and the real tasks-axi, asserting observable record state - never reminder wording. It covers: dispatch moving the item In flight in the same run; dispatch refusing an id with no item and an already-closed item; a failed transition failing loudly and leaving no record or busy state; dispatch not resurrecting a row closed after preflight; completion closing local-only and scout items with their landing note and report; completion refusing to report success while its item is open and recording the close it owes; the recovery cases (replay a recorded close for the matching incarnation, drop a stale one, preserve a pending close across a transient backlog read failure, preserve both records when meta removal fails, mark an owned record In flight); leaving a captain-held item alone; a manual-backlog home dispatching and completing without a hard failure; a secondmate home keeping its OWN books through dispatch and completion (the invariant is single-host, so a parent<->mate freshness delay is deliberately NOT asserted as a correctness violation); and a persistent secondmate needing no backlog item at all. Relaunch cases in tests/fm-control-relaunch.test.sh prove the relaunch path re-reads the row instead of re-running the transition, and heals a drifted one.
Two pre-existing assertions in tests/fm-teardown.test.sh that only checked the printed reminder TEXT were deliberately replaced with assertions on the resulting backlog state - that weak coverage is precisely what let the two records drift. That fixture was also pinned to its own data directory so a test can never mutate the operator's real backlog.

Documentation is updated at its owners: the three script headers, AGENTS.md (state layout, dispatch/completion no longer a separate agent step, the mutating sweeps list), docs/configuration.md's Backlog backend section, docs/scripts.md, and the bootstrap-diagnostics skill for the new BACKLOG_RECONCILE diagnostic line. bin/fm-secondmate-reconcile.sh's header now states it is a backstop rather than the primary mechanism.

Constraints: changed bash must be stock macOS bash 3.2 compatible; bin/*.sh must pass bin/fm-lint.sh and shellcheck with the source=/dev/null boundary; repo style is one sentence per line in tracked Markdown, plain dash never an em dash, and no agent co-author on commits. Delivery is no-mistakes with merge authority held by the captain: do not merge.

## What Changed

- Move backlog dispatch and completion transitions into the locked spawn and teardown record lifecycle, with strict dispatch validation and failed-transition cleanup.
- Persist pending completion markers and reconcile interrupted closes or drifted owned records during same-home bootstrap.
- Respect manual, secondmate, incompatible-tool, and backlog-free exemptions, with expanded lifecycle regression coverage and documentation.

## Risk Assessment

✅ Low: The lifecycle changes consistently preserve ownership on uncertain rollback, pair record transitions under existing per-task locks, and provide validated durable close recovery without a substantiated new defect.

## Testing

Inspected the base-to-target change, then exercised real tasks-axi-backed dispatch, completion, crash recovery, relaunch, manual/secondmate exemptions, failure rollback, and teardown safety behavior; all targeted end-to-end checks succeeded, reviewer-visible CLI transcripts were captured, and no transient worktree files remained.

<details>
<summary>Evidence: Backlog atomicity end-to-end transcript</summary>

Source: [Backlog atomicity end-to-end transcript](https://github.com/kunchenguid/firstmate/blob/3d2292e40e186d92afdd6a776ebdfb7ab95fffca/.no-mistakes/evidence/fm/fm-secondmate-record-atomic-transitions-r1/fm-backlog-atomicity-transcript.txt)

```text
FM_TEST_BEGIN 2026-08-29T22:22:16Z tests/fm-backlog-atomicity.test.sh family=session-bootstrap expected_gate_skip=none
ok - dispatch publishes the record and moves the backlog item In flight in one run
ok - dispatch reads backlog rows from the backlog addressing root
ok - recovery uses the parent of a trailing-slash data record
ok - completion targets nested relative data from the caller directory
ok - an immediate-child absolute data path keeps one paired backlog
ok - bare relative data addresses one backlog through dispatch and completion
ok - dispatch refuses an unresolvable backlog data directory
ok - completion refuses before mutation when backlog data is unresolvable
ok - dispatch refuses, before creating anything, when the home has no item for the id
ok - dispatch distinguishes backlog read failures from missing items
ok - dispatch refuses a closed item instead of silently reopening it
ok - dispatch cannot commit without a verified task-record publication
ok - a failed backlog transition fails the dispatch loudly and leaves no record
ok - dispatch reports when failed-transition rollback cannot remove its record
ok - dispatch verifies both task and busy records during rollback
ok - dispatch commits neither record nor backlog state before launch delivery succeeds
ok - interrupted Kimi delivery preserves durable ownership for every backlog backend
ok - failed Kimi delivery stops workers or retains their ownership
ok - unqueryable failed dispatch retains durable ownership
ok - interrupted launch submission retains unconfirmed ownership
ok - dispatch retries interrupted transitions before honoring termination
ok - dispatch does not resurrect a row closed after preflight
ok - dispatch fails when its backlog row vanishes after preflight
ok - completion closes a local-only ship, with its landing note, before reporting success
ok - completion closes a scout item against its report
ok - completion leaves legacy records open when no incarnation can be recorded
ok - completion records relocated scout reports relative to the backlog root
ok - space-containing scout report paths round-trip through recovery
ok - non-ASCII close markers replay across process locales
ok - control-byte data paths fail closed before paired transitions
ok - unreplayable data paths are refused before destructive cleanup
ok - completion preserves recovery state when task-record removal fails
ok - completion refuses to report success while its item is still open, and records what it owes
ok - completion reports failure until its durable close marker is removed
ok - session start retries a close whose marker could not be removed
ok - session start reports owned backlog rows it cannot read
ok - Orca cleanup recovery is excluded from backlog lifecycle transitions
ok - session start marks an item In flight when this home already owns a worker for it
ok - session start finishes a close an interrupted cleanup recorded but never landed
ok - session start preserves a pending close across a transient backlog read failure
ok - session start finishes a close for the matching meta incarnation
ok - recovery preserves both records when meta removal fails
ok - recovery binds close-marker identity to its locked filename
ok - recovery rejects close markers targeting another home's data
ok - recovery validates an unterminated final marker field
ok - recovery rejects lexical traversal before resolving marker data
ok - recovery rejects marker control bytes before parsing
ok - recovery rejects malformed PR URL values
ok - a retained pending close is never started by reconciliation
ok - recovery rejects a bare-parent report path
ok - recovery rejects close-marker arguments outside its protocol
ok - recovery reports and rejects dangling symlink close markers
ok - session start drops a close recorded for an older meta incarnation
ok - session start rejects an unversioned close marker
ok - bootstrap stops when backlog data disappears before reconciliation
ok - bootstrap preserves secondmate, manual, and absent-backlog exemptions
ok - session start leaves a captain-held item where the captain put it
ok - a home with no backlog remains exempt from lifecycle transitions
ok - interrupted backlog-exempt spawns retain durable ownership after launch submission
ok - a manual-backlog home dispatches and completes without a hard failure
ok - a secondmate home keeps its own books paired through dispatch and completion
ok - dispatching a persistent secondmate needs no backlog item
FM_TEST_END 2026-08-29T22:25:09Z tests/fm-backlog-atomicity.test.sh exit=0 duration_ms=172950 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=173016
FM_TEST_SUMMARY_FAMILY family=session-bootstrap count=1 duration_ms=172950 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-backlog-atomicity.test.sh duration_ms=172950
fm-test-run: wrote timing artifact: ~/.no-mistakes/evidence/01M15B2X4TSJ4HEJ732WBPZRNP/fm-backlog-atomicity-results.json
```
</details>
<details>
<summary>Evidence: Relaunch backlog-state verification transcript</summary>

Source: [Relaunch backlog-state verification transcript](https://github.com/kunchenguid/firstmate/blob/3d2292e40e186d92afdd6a776ebdfb7ab95fffca/.no-mistakes/evidence/fm/fm-secondmate-record-atomic-transitions-r1/fm-control-relaunch-transcript.txt)

```text
FM_TEST_BEGIN 2026-08-29T22:25:13Z tests/fm-control-relaunch.test.sh family=backend-dispatch expected_gate_skip=none
ok - fm-control relaunch: a same-harness relaunch replaces the agent in the same endpoint and worktree
ok - fm-control relaunch: durable task metadata survives replacement launch publication
ok - fm-control relaunch: delivery and concurrent task metadata publication serialize
ok - fm-control relaunch: disabling tracing clears metadata and pane context
ok - fm-control relaunch: the progress note lands in the instructions the replacement reads
ok - fm-control relaunch: a ship task refuses without the progress note its replacement needs
ok - fm-control relaunch: switching harness is one ordinary relaunch, and the old wiring goes with the old agent
ok - fm-control relaunch: a harness switch resets model and effort unless they are named too
ok - fm-control relaunch: a prefixed recorded harness can switch adapters transactionally
ok - fm-control relaunch: a prefixed command requires an explicit replacement harness
ok - fm-control relaunch: a same-harness relaunch keeps the profile axes it was running with
ok - fm-control relaunch: explicit model and effort win over the recorded ones
ok - fm-control relaunch: refuses to relaunch onto an adapter with no verified mechanics
ok - fm-control relaunch: the retired incarnation's global turn-end token is revoked
ok - fm-control relaunch: wiring cleanup failure refuses replacement arming
ok - fm-control-lib: one owner resolves each harness's turn-end registry entry, and refuses a malformed token
ok - fm-control relaunch: a secondmate relaunch re-resolves its durable configured harness pin
ok - fm-control relaunch: invalid configured effort is ignored before stop
ok - fm-control relaunch: an adapter unverified for this task kind refuses before the agent is stopped
ok - fm-control relaunch: explicit secondmate harness resets unnamed profile axes
ok - fm-control relaunch: a ship task keeps its recorded harness instead of re-reading crew config
ok - fm-spawn --relaunch: with no explicit harness it reuses the task's recorded one, never the crew default
ok - fm-spawn --relaunch: wiring armed under a prefixed harness name is still retired
ok - fm-spawn --relaunch: switching away from muse retires its session binding
ok - fm-spawn --relaunch: switching away from cursor retires its session binding
ok - fm-control relaunch: an unaccountable local copy refuses before the agent is touched
ok - fm-control relaunch: a worker with nothing to work from is never launched
ok - fm-control relaunch: a refusal before the agent is stopped leaves the durable record untouched
ok - fm-control relaunch: checkpoint inspection failures refuse before stopping
ok - fm-control relaunch: a launch failure after the stop keeps the prior record and reports the real state
ok - fm-control relaunch: unpublished rollback keeps concurrent durable metadata
ok - fm-control relaunch: post-publication failure keeps the new durable record
ok - fm-control relaunch: partial stop reconciles actual agent state
ok - fm-control relaunch: failed journal replacement preserves durable phase
ok - fm-spawn relaunch: prepublication abort removes replacement state
ok - fm-control relaunch: the checkpoint records the exact unlanded work it preserved
ok - fm-control relaunch: a secondmate's child work is accounted for and its charter is left alone
ok - fm-control relaunch: a secondmate home that is not this secondmate's is refused
ok - fm-control relaunch: unreadable and untraversable child state fails checkpoint
ok - fm-control relaunch: two control actions on one task serialize instead of interleaving
ok - fm-spawn relaunch: direct entry participates in lifecycle serialization
ok - fm-promote: promotion participates in lifecycle serialization
ok - fm-spawn --relaunch: refuses to launch a second agent into a live endpoint
ok - fm-spawn --relaunch: every identity axis comes from the record, and a contradicting flag refuses
ok - fm-spawn --relaunch: an unrecorded task is refused
ok - fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work
ok - relaunch re-reads the backlog item instead of blindly re-running the transition
ok - relaunch heals an item that drifted out of In flight while the task stayed live
FM_TEST_END 2026-08-29T22:26:28Z tests/fm-control-relaunch.test.sh exit=0 duration_ms=75013 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=75074
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=75013 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-control-relaunch.test.sh duration_ms=75013
fm-test-run: wrote timing artifact: ~/.no-mistakes/evidence/01M15B2X4TSJ4HEJ732WBPZRNP/fm-control-relaunch-results.json
```
</details>
<details>
<summary>Evidence: Completion and teardown safety transcript</summary>

Source: [Completion and teardown safety transcript](https://github.com/kunchenguid/firstmate/blob/3d2292e40e186d92afdd6a776ebdfb7ab95fffca/.no-mistakes/evidence/fm/fm-secondmate-record-atomic-transitions-r1/fm-teardown-transcript.txt)

```text
FM_TEST_BEGIN 2026-08-29T22:26:34Z tests/fm-teardown.test.sh family=pr-forge expected_gate_skip=none
ok - local-only worktree with HEAD on a fork remote is torn down and the home summary is refreshed
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 1s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ~/.no-mistakes/worktrees/52b07e9083e7/01M15B2X4TSJ4HEJ732WBPZRNP/.pi/extensions/fm-primary-turnend-guard.ts -e ~/.no-mistakes/worktrees/52b07e9083e7/01M15B2X4TSJ4HEJ732WBPZRNP/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - teardown closes its own backlog item before reporting success
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 0s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ~/.no-mistakes/worktrees/52b07e9083e7/01M15B2X4TSJ4HEJ732WBPZRNP/.pi/extensions/fm-primary-turnend-guard.ts -e ~/.no-mistakes/worktrees/52b07e9083e7/01M15B2X4TSJ4HEJ732WBPZRNP/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - teardown honors config/backlog-backend=manual and still finishes cleanly
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly
ok - herdr flat teardown never erases records when pane presence is unparseable
ok - herdr flat teardown preflight refuses before every destructive change
ok - forced secondmate teardown preflights every Herdr child before cleanup mutation
ok - forced secondmate teardown holds every descendant lifecycle and metadata lock
ok - forced secondmate teardown retains Herdr child identity until exact pane disappearance
ok - forced teardown retains a nested secondmate home and its grandchild's Herdr identity when the grandchild close is unconfirmed
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown retains every record when post-close presence is unknown
ok - herdr projection teardown surfaces failed focus restoration without turning confirmed cleanup into a hard failure
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 0s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ~/.no-mistakes/worktrees/52b07e9083e7/01M15B2X4TSJ4HEJ732WBPZRNP/.pi/extensions/fm-primary-turnend-guard.ts -e ~/.no-mistakes/worktrees/52b07e9083e7/01M15B2X4TSJ4HEJ732WBPZRNP/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
WARNING: watcher still down (same stale episode; last beat: 1s ago, grace 300s) - full banner already printed this episode.
ok - fm-pr-check does not refresh PR head after HEAD moves
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 1s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ~/.no-mistakes/worktrees/52b07e9083e7/01M15B2X4TSJ4HEJ732WBPZRNP/.pi/extensions/fm-primary-turnend-guard.ts -e ~/.no-mistakes/worktrees/52b07e9083e7/01M15B2X4TSJ4HEJ732WBPZRNP/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
ok - a task's own parked no-mistakes run is aborted, not orphaned, before the worker is removed
ok - teardown refuses before reap or removal when a task-owned run remains parked
ok - a different run cannot confirm the targeted abort
ok - empty post-abort status is not accepted as confirmation
ok - the CLI's exact run-not-found signal confirms completion
ok - a parked run on another branch is never aborted by this task's teardown (ownership is precise)
ok - a task-owned autonomous running step is left alone rather than aborted
ok - a leaked descendant process rooted under the task's worktree is reaped by teardown, not left surviving
ok - a leaked descendant process rooted under the task's per-task tasktmp is reaped by teardown too
ok - missing lsof falls back to reaping the tmux pane process group
ok - an erroring lsof scan refuses teardown and preserves the task
ok - a reused pid with a different start time is never force-killed
ok - an exec change preserves birth identity and the process is reaped
ok - a process spawned during grace is reaped on a later pass
ok - persistent leaked processes refuse teardown after bounded retries
ok - a process exiting during identity lookup does not block teardown
ok - the run abort and the leaked-process reap both complete before the destructive worktree return
FM_TEST_END 2026-08-29T22:29:09Z tests/fm-teardown.test.sh exit=0 duration_ms=154732 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=154792
FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=154732 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-teardown.test.sh duration_ms=154732
fm-test-run: wrote timing artifact: ~/.no-mistakes/evidence/01M15B2X4TSJ4HEJ732WBPZRNP/fm-teardown-results.json
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9c856cdb994367751f273d3a475a673b2af2a2cd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (25) ✅</summary>

- 🚨 `bin/fm-backlog-transition-lib.sh:186` - The required design says “a landed close removes that record,” but every marker deletion suppresses failure and teardown reports success. If marker removal fails after `tasks-axi done`, reopening the same ID leaves a queued row with an old marker and no meta; the next bootstrap replays that old close and incorrectly closes the reopened task. Make marker removal verify absence and propagate failure through teardown/replay instead of returning `closed` or `stale`.
- 🚨 `bin/fm-spawn.sh:797` - The required failed-dispatch invariant says the just-published record and busy generation are both removed, but abort cleanup clears `SPAWN_FRESH_COMMIT_PENDING` before attempting an unchecked `rm`. The commit-failure path at line 3040 likewise cannot recover from persistent unlink failure. With a failed `tasks-axi start` plus an unwritable/unremovable meta, spawn exits with the row queued while `state/&lt;id&gt;.meta` remains, recreating `unowned_current`. Centralize rollback and verify record removal before claiming cleanup succeeded.

🔧 Fix: Verify rollback and close-marker removal
2 warnings still open:

- ⚠️ `bin/fm-spawn.sh:1967` - The preflight collapses every `tasks-axi show` failure into an empty state and then claims the item is missing. For an unreadable or transiently locked backlog containing the item, spawn gives an incorrect `tasks-axi add` remedy that cannot succeed. Branch on `FM_BACKLOG_ROW_RESULT` as the commit-time check already does, and surface `FM_BACKLOG_ROW_ERROR` for genuine read failures.
- ⚠️ `bin/fm-spawn.sh:2972` - Ignoring HUP/INT/TERM here is inherited by every directly executed delivery command and remains active through Kimi&#39;s readiness and delivery polling, potentially about 50 seconds, plus the unbounded backlog mutation. A hung backend or tasks-axi child therefore cannot be terminated normally and keeps the per-task meta lock indefinitely. Preserve the atomic commit behavior without passing ignored signal dispositions to fallible child processes, and avoid this region entirely when no backlog transition applies.

🔧 Fix: Handle backlog read failures and interruptible delivery
2 errors still open:

- 🚨 `bin/fm-teardown.sh:2855` - The required invariant says completion pairs record removal with backlog closure, but this unchecked `rm -f` can fail and teardown still runs `tasks-axi done`, clears the recovery marker, and reports success. A selective unlink failure leaves `state/&lt;id&gt;.meta` permanently paired with a Done row and no marker. Verify the meta is absent before mutating the backlog; on failure, preserve the marker and fail loudly.
- 🚨 `bin/fm-spawn.sh:2825` - The required dispatch sequence begins “after it durably writes state/&lt;id&gt;.meta,” but publication failure is unchecked. If this redirection fails, spawn continues through worker delivery, moves the queued row In flight, clears `SPAWN_FRESH_COMMIT_PENDING`, and reports success without a meta record, producing `orphan_in_flight`. Check publication success and record existence before delivery or backlog commit, and unwind through the existing failure path.

🔧 Fix: Centralize verified backlog record transitions
4 issues (3 errors, 1 warning) still open:

- 🚨 `bin/fm-spawn.sh:798` - During a fresh Orca spawn, interruption after SPAWN_FRESH_COMMIT_PENDING is set can make abort cleanup fail to remove the Orca worktree and publish this recovery meta, but line 808 immediately runs rollback and removes that newly published record. The leaked Orca resource is then left without its durable cleanup identity. Perform provisional rollback before publishing the Orca recovery record, or otherwise ensure rollback cannot delete recovery metadata.
- 🚨 `bin/fm-teardown.sh:2873` - An early failed Orca spawn whose worktree cleanup fails leaves the recovery-only meta written by fm-spawn.sh, but teardown treats it as a completed worker and closes its queued backlog item. Bootstrap can likewise move that item In flight at bin/fm-bootstrap.sh:1232 despite no worker having launched. Explicitly distinguish Orca cleanup-recovery records and exclude them from normal backlog start/done transitions.
- 🚨 `bin/fm-backlog-transition-lib.sh:105` - The intent requires tasks-axi to be “always addressed with an explicit --file &lt;data&gt;/backlog.md and run from that data directory&#39;s PARENT,” but row probes invoke `tasks-axi show` directly from the caller&#39;s working directory. Consequently the target home&#39;s `.tasks.toml` is not selected for dispatch and reconciliation reads. Run the probe from `fm_backlog_root &#34;$data&#34;`, matching mutations.
- ⚠️ `bin/fm-bootstrap.sh:1232` - A transient or malformed `tasks-axi show` failure is converted to an empty row and produces no BACKLOG_RECONCILE diagnostic, so an owned queued record remains unreconciled without explanation. Branch on FM_BACKLOG_ROW_RESULT and report FM_BACKLOG_ROW_ERROR for genuine read failures while continuing the sweep.

🔧 Fix: Isolate Orca cleanup recovery from backlog transitions
1 error still open:

- 🚨 `bin/fm-backlog-transition-lib.sh:105` - The required criterion says tasks-axi is “always addressed with an explicit --file &lt;data&gt;/backlog.md and run from that data directory&#39;s PARENT,” but row probes run `tasks-axi show` in the caller&#39;s current directory. With relocated data such as `/srv/fm-records`, dispatch and reconciliation therefore resolve configuration from the invocation directory instead of `/srv`. Run the probe from `fm_backlog_root &#34;$data&#34;`, matching the mutation boundary.

🔧 Fix: Address backlog reads from configured root
1 error still open:

- 🚨 `bin/fm-backlog-transition-lib.sh:63` - The intent requires every tasks-axi call to run from the data directory&#39;s parent, but `fm_backlog_root` returns the data directory itself for a trailing-slash override (`/srv/fm-records/` -&gt; `/srv/fm-records`) and returns `.` for a root-level directory (`/data` -&gt; `.`). Reads and mutations then resolve the wrong `.tasks.toml`, done_keep, and archive path. Normalize trailing slashes and preserve `/` as the parent at this shared addressing boundary.

🔧 Fix: Normalize backlog addressing root paths
2 issues (1 error, 1 warning) still open:

- 🚨 `bin/fm-teardown.sh:2854` - Teardown accepts existing task records without `spawn_gen` and writes a new marker with an empty incarnation. If killed after this write but before meta removal, replay treats the marker as stale at bin/fm-backlog-transition-lib.sh:318, deletes it, and leaves the meta plus In-flight row indefinitely. This contradicts the required durable terminal-close recovery. Before destructive teardown, either give a legacy record a durable incarnation or refuse automatic closure when no incarnation can be recorded.
- ⚠️ `bin/fm-backlog-transition-lib.sh:80` - The intent requires scout report links to be relative to the backlog addressing root, but for data directory `/data`, the root is `/` and the pattern `&#34;$root&#34;/*` becomes `//*`, so this returns `/data`; teardown records the absolute `/data/&lt;id&gt;/report.md` instead of `data/&lt;id&gt;/report.md`. Handle `/` explicitly when stripping the addressing-root prefix.

🔧 Fix: Refuse unversioned closes and normalize report paths
2 errors still open:

- 🚨 `bin/fm-backlog-transition-lib.sh:120` - The required addressing invariant says every tasks-axi call targets `&lt;data&gt;/backlog.md` from the data directory&#39;s parent, but a nested relative data path is prefixed twice after `cd`: from the caller directory, `FM_DATA_OVERRIDE=relocated/data` passes the applies gate, then runs from `relocated` with `--file relocated/data/backlog.md`, targeting `relocated/relocated/data/backlog.md`. Resolve the backlog path for the post-`cd` working directory at this shared read/mutation boundary.
- 🚨 `tests/fm-public-followup.test.sh:1148` - Three changed teardown fixtures create backlog-tracked metadata without `spawn_gen` (also lines 1977 and 2136). The new mandatory legacy-record gate therefore refuses before the public-followup behavior under test; two success cases fail outright and the refusal case cannot reach its asserted reason. Give these synthetic current-generation records explicit spawn generations.

🔧 Fix: Add incarnations to teardown test fixtures
1 error still open:

- 🚨 `bin/fm-backlog-transition-lib.sh:120` - The required addressing invariant is still violated for nested relative data paths. With `FM_DATA_OVERRIDE=relocated/data`, the applies gate finds `relocated/data/backlog.md`, but the probe and mutation helpers then `cd relocated` while still passing `--file relocated/data/backlog.md`, targeting `relocated/relocated/data/backlog.md`. Teardown can consequently remove meta yet leave an unreplayable close marker. Normalize the backlog path for the post-`cd` root at this shared read/mutation boundary.

🔧 Fix: Normalize relative backlog data paths
1 error still open:

- 🚨 `bin/fm-backlog-transition-lib.sh:115` - The new path resolver returns 2 when the data directory cannot be resolved, but every caller treats all nonzero results as an authorized skip. During teardown, if the configured data directory is missing or inaccessible, both checks fall through, destructive cleanup proceeds, and line 2870 classifies the error as a skip before removing meta and reporting success without closing the backlog; it also bypasses the required missing-spawn_gen refusal. Preserve the legitimate return-1 exemptions, but make spawn, teardown, and bootstrap propagate return 2 before mutation; evaluate secondmate/manual exemptions before path resolution so those required skips remain skips.

🔧 Fix: Propagate fatal backlog addressing errors
2 errors still open:

- 🚨 `bin/fm-backlog-transition-lib.sh:104` - The required scout-link contract says the report path is relative to the backlog addressing root, but with FM_DATA_OVERRIDE=/ this helper returns an empty string, so bin/fm-teardown.sh:1183 records /&lt;id&gt;/report.md as an absolute path. Handle the data-directory-equals-root case explicitly and also avoid producing //backlog.md from fm_backlog_file.
- 🚨 `bin/fm-bootstrap.sh:1309` - backlog_record_reconcile explicitly returns 2 for fatal addressing failure, but this call ignores that status because bootstrap uses set -u rather than set -e. If DATA becomes unavailable after the initial gate but before reconciliation, bootstrap prints an error and then continues its remaining sweeps and can exit successfully, contradicting the required fatal propagation. Check the return and stop bootstrap on status 2.

🔧 Fix: Normalize root addressing and propagate reconciliation failures
1 error still open:

- 🚨 `tests/fm-backlog-atomicity.test.sh:371` - The required behavioral matrix is incomplete. The added cases cover a bare relative path and repeated trailing slashes, but do not drive real dispatch/teardown for data directories `/`, `/data`, and `/srv/fm-records`, nor verify the secondmate bootstrap exemption with an unresolvable data directory. The prior accepted requirement explicitly requires all listed addressing inputs and the secondmate/manual/no-backlog exemption paths.

🔧 Fix: Complete safe addressing and bootstrap exemption coverage
✅ Re-checked - no issues remain.

- 🚨 `bin/fm-teardown.sh:1189` - The required completion behavior is “tasks-axi done with the right --pr/--report/--note,” but a PR-based task whose meta lacks `pr=` is closed without `--pr`. Teardown explicitly supports this case by resolving a merged PR from the branch in `pr_is_merged`, yet that resolution never updates `PR_URL`, so `BACKLOG_DONE_ARGS` remains empty and the durable completion link is lost. Preserve the resolved PR URL and include it in the close marker and `tasks-axi done`.
- 🚨 `bin/fm-backlog-transition-lib.sh:354` - Replay trusts `id=` from the marker without verifying it matches the marker filename whose meta lock bootstrap acquired. A copied or malformed `foo.backlog-close` containing `id=bar` runs under foo&#39;s lock but can remove `bar.meta` and close bar&#39;s backlog row; traversal-shaped ids can also escape the state directory. At replay&#39;s parsing boundary, reject symlinks, require exactly one path-safe id matching the marker basename, and validate the permitted close arguments before any mutation.
- ⚠️ `bin/fm-teardown.sh:1204` - With a relocated `FM_DATA_OVERRIDE`, teardown correctly closes `&lt;configured-data&gt;/backlog.md` but then confirms that the item was closed in `data/backlog.md`. This makes the required confirmation echo factually wrong and also misdirects manual-backend users at line 1206. Render the actual configured backlog path, preferably relative to the same addressing root used for mutation.

🔧 Fix: Secure close replay and preserve completion links
1 error still open:

- 🚨 `bin/fm-backlog-transition-lib.sh:365` - Intent requires same-home reconciliation that “never reaches into another home,” but replay accepts `data=` directly from the marker and later probes/mutates that backlog. A copied or malformed `&lt;id&gt;.backlog-close` with a valid matching id and `data=/another/home/data` can close another home&#39;s row while holding only this home&#39;s meta lock. Validate the recorded data against an authorized same-home backlog location at the replay boundary before removing meta or accessing the backlog.

🔧 Fix: Harden close-marker replay validation
1 error still open:

- 🚨 `bin/fm-backlog-transition-lib.sh:363` - The hardened parsing boundary still accepts malformed markers that it was required to reject. Bash&#39;s `while read` skips an unterminated final line, so a trailing duplicate or unrecognized field is ignored, and the traversal check at line 394 accepts paths such as `$DATA/sub/..` when they resolve back to the authorized directory. Process the final unterminated line and reject any lexical `..` component before resolution so every marker field is validated before replay mutates meta or backlog state.

🔧 Fix: Complete close-marker validation hardening
2 errors still open:

- 🚨 `bin/fm-bootstrap.sh:1240` - A failed close replay that preserves both marker and meta is immediately undermined by the second reconciliation loop. For example, if meta removal fails while the row is `queued no`, replay correctly returns without backlog mutation, but this loop then sees the retained meta and calls `tasks-axi start`, changing the row to In flight despite the authoritative pending close. Skip record reconciliation whenever the corresponding `.backlog-close` still exists, including malformed or temporarily unreplayable markers.
- 🚨 `bin/fm-backlog-transition-lib.sh:420` - The hardened marker boundary still accepts malformed PR values such as `https://` because the wildcard may be empty. That contradicts the selected requirement to accept only permitted close-argument values and can pass a bogus completion link to `tasks-axi done`. Require a nonempty valid authority/path and reject whitespace or other URL-invalid characters before replay mutation.

🔧 Fix: Preserve pending closes and validate completion values
1 error still open:

- 🚨 `bin/fm-backlog-transition-lib.sh:369` - The required exhaustive marker validation remains bypassable. Shell variables cannot preserve NUL bytes, so `read` can normalize a NUL-bearing field before the printable/value checks; for example, a NUL appended to the authorized `data=` path can be accepted and allow meta removal and backlog closure. The PR parser also accepts malformed URLs such as `https://github.com:abc/pull/1` and invalid percent escapes because it permits arbitrary colons and `%`. Reject NUL/control bytes from the raw marker before parsing, and validate URL authority/escapes before any mutation.

🔧 Fix: Reject malformed marker bytes and completion URLs
1 error still open:

- 🚨 `bin/fm-backlog-transition-lib.sh:457` - The host check accepts malformed labels such as `https://foo.-bar.com/pull/1` or `https://foo-.bar.com/pull/1`, so a crafted marker can still reach `tasks-axi done` despite the required well-formed-host boundary. Validate each dot-separated label and reject labels beginning or ending with `-` before any replay mutation.

🔧 Fix: Validate PR host labels before replay
✅ Re-checked - no issues remain.

✅ No issues found.

- 🚨 `bin/fm-backlog-transition-lib.sh:333` - A scout using a configured data directory containing whitespace generates a marker such as `arg=crew data/&lt;id&gt;/report.md`, but replay rejects all report values containing whitespace at line 502. If teardown is killed after removing meta but before `tasks-axi done`, the claimed durable recovery can never close the row. Ensure marker writing accepts only replayable values before destructive cleanup, or define a safe reversible encoding for generated report paths.
- ⚠️ `bin/fm-bootstrap.sh:1214` - The close-marker sweep checks only `-e`, so a dangling `.backlog-close` symlink never reaches replay&#39;s explicit symlink rejection or emits `BACKLOG_RECONCILE`. The later record sweep still sees `-L` and permanently suppresses reconciliation for that id. Include symlinks in marker discovery so malformed pending closes remain fail-closed but actionable.

🔧 Fix: Replay spaced reports and surface dangling markers
1 error still open:

- 🚨 `bin/fm-backlog-transition-lib.sh:327` - The writer rejects only newline in arguments and does not validate control bytes in `data`, while replay rejects every control byte except newline. For example, a scout whose configured data path contains a tab writes a pending-close marker successfully; if teardown then crashes after meta removal, bootstrap permanently rejects that marker as an invalid control byte. Validate every serialized field and argument against replay&#39;s control-byte rules before publishing the marker or beginning destructive cleanup.

🔧 Fix: Unify close-marker writer and replay validation
1 error still open:

- 🚨 `bin/fm-backlog-transition-lib.sh:60` - `fm_backlog_data_absolute` captures `pwd -P` with command substitution, which strips trailing newlines from a configured data-directory name. The gate then probes the wrong stripped path and treats the home as having no backlog: dispatch can publish meta without starting the real row, while teardown can remove meta without writing a marker or closing the real row. Reject control bytes in the input at this shared boundary before canonicalization so this case fails closed.

🔧 Fix: Reject control-byte backlog paths before canonicalization
1 warning still open:

- ⚠️ `bin/fm-backlog-transition-lib.sh:460` - The report-path traversal check rejects `../x` and paths ending in `/..`, but not the exact value `..`. A pending-close marker with `arg=--report` and `arg=..` therefore passes validation and executes `tasks-axi done --report ..`, recording an escaping completion link without error. Reject exact `..` alongside the existing traversal forms.

🔧 Fix: Reject bare report traversal paths
✅ Re-checked - no issues remain.

✅ No issues found.

✅ No issues found.

- 🚨 `bin/fm-backlog-transition-lib.sh:383` - Pending-close validation is locale-dependent. A teardown running under a UTF-8 locale accepts and publishes a marker whose valid data path contains non-ASCII characters (for example `/tmp/café`), but bootstrap under `LC_ALL=C` rejects the same marker via `[![:print:]]`, permanently blocking durable close recovery. Make the shared validator enforce locale-independent byte rules so any marker accepted by the writer remains replayable across process locales.

🔧 Fix: Stabilize marker replay and failed-worker rollback
1 error still open:

- 🚨 `bin/fm-spawn.sh:714` - Failed-dispatch cleanup treats any false result from `fm_backend_target_exists` as proof the launched endpoint was stopped, but that helper explicitly returns false for both absence and an unqueryable backend. For example, if cmux becomes unreachable, `fm_backend_cmux_kill` skips the close because readiness cannot be verified, the subsequent existence check also fails, and rollback deletes the task and busy records while the workspace and worker may remain live. Retain ownership unless the backend positively confirms the endpoint is gone, using a recovery-grade confirmed-absence boundary rather than this liveness boolean.

🔧 Fix: Require confirmed endpoint absence before rollback
1 error still open:

- 🚨 `bin/fm-spawn.sh:3078` - The live-worker mark is set only after the fallible Enter submission. If a deferred signal interrupts this command after the backend accepted Enter but before it returns successfully, `set -e` reaches EXIT cleanup with `SPAWN_WORKER_LIVE=0`; rollback then deletes meta and busy records without stopping or confirming the launched endpoint. Conservatively mark the endpoint live before issuing Enter so every ambiguous submission failure uses the confirmed-stop rollback path.

🔧 Fix: Mark workers live before launch submission
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 420721401c4080d1a4f6982b0ef6769e2a749b23..2f0d3fae51924971b63cde933cd1b0c83763aa1c` and repository status.</code>
- `bin/fm-test-run.sh tests/fm-backlog-atomicity.test.sh`
- <code>`bin/fm-test-run.sh tests/fm-control-relaunch.test.sh tests/fm-teardown.test.sh` initially exposed an unpinned fixture data path in the teardown test.</code>
- <code>Added `FM_DATA_OVERRIDE=&#34;$case_dir/data&#34;` to the affected Herdr teardown fixture.</code>
- `bin/fm-test-run.sh tests/fm-teardown.test.sh`
- `bin/fm-test-run.sh tests/fm-control-relaunch.test.sh`

✅ No issues found.
- `git status --short && git diff --stat 4eb587d670ff1a34afaba32fa94d02e74fed0399..HEAD && git diff --name-only 4eb587d670ff1a34afaba32fa94d02e74fed0399..HEAD`
- `./bin/fm-test-run.sh tests/fm-backlog-atomicity.test.sh`
- `./bin/fm-test-run.sh tests/fm-control-relaunch.test.sh`
- <code>Verified the worktree remained clean after testing with `git status --short`.</code>

✅ No issues found.
- <code>`git status --short` and `git diff --stat/--name-only 4eb587d670ff1a34afaba32fa94d02e74fed0399..9c82c2e33efd34fb9e479db11e54ff00aa21304c`</code>
- `bin/fm-test-run.sh tests/fm-backlog-atomicity.test.sh tests/fm-control-relaunch.test.sh`
- <code>Manual CLI fixture using real `tasks-axi add/show`, `bin/fm-spawn.sh`, and `bin/fm-teardown.sh`; verified queued/absent → in_flight/present → done/absent with no residual close marker</code>
- <code>`git diff --check` and final `git status --short` transient-artifact check</code>

✅ No issues found.
- `./bin/fm-test-run.sh tests/fm-backlog-atomicity.test.sh`
- `./bin/fm-test-run.sh tests/fm-control-relaunch.test.sh`
- <code>`git status --short` confirmed testing left no worktree changes</code>

✅ No issues found.
- <code>Inspected `git status --short` and the commit diff from `4eb587d670ff1a34afaba32fa94d02e74fed0399` to `0331595e38b10ae280454a6e3761de04609daf3e`.</code>
- `bin/fm-test-run.sh tests/fm-backlog-atomicity.test.sh`
- `bin/fm-test-run.sh tests/fm-control-relaunch.test.sh tests/fm-teardown.test.sh`
- <code>Verified `git status --short --untracked-files=all` remained clean after testing.</code>

✅ No issues found.
- `git status --short && git diff --stat 0ace60ab1a6eb8afbb3a3e7b104731e4e5b7baaa..HEAD && git diff --name-only 0ace60ab1a6eb8afbb3a3e7b104731e4e5b7baaa..HEAD`
- `bin/fm-test-run.sh tests/fm-backlog-atomicity.test.sh`
- `bin/fm-test-run.sh tests/fm-control-relaunch.test.sh`
- <code>`git status --short` after testing to confirm no transient worktree changes remained</code>

✅ No issues found.
- `git status --short && git diff --stat 0ace60ab1a6eb8afbb3a3e7b104731e4e5b7baaa..HEAD && git diff --name-only 0ace60ab1a6eb8afbb3a3e7b104731e4e5b7baaa..HEAD`
- `bin/fm-test-run.sh tests/fm-backlog-atomicity.test.sh --json ~/.no-mistakes/evidence/01M15B2X4TSJ4HEJ732WBPZRNP/fm-backlog-atomicity-results.json`
- `bin/fm-test-run.sh tests/fm-control-relaunch.test.sh --json ~/.no-mistakes/evidence/01M15B2X4TSJ4HEJ732WBPZRNP/fm-control-relaunch-results.json`
- `bin/fm-test-run.sh tests/fm-teardown.test.sh --json ~/.no-mistakes/evidence/01M15B2X4TSJ4HEJ732WBPZRNP/fm-teardown-results.json`
- <code>`git status --short` after testing confirmed the worktree remained clean.</code>
</details>

<details>
<summary>⚠️ **Document** - 0 issues</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.

- ⚠️ `bin/fm-spawn.sh:3088` - The failure diagnostic says no worker remains after rollback, then instructs the operator to close the already-launched endpoint and local copy. Correcting this user-facing executable output is outside the documentation-only phase.

🔧 Fix: Verify backlog lifecycle documentation
1 warning still open:

- ⚠️ `bin/fm-spawn.sh:3088` - The failure diagnostic still claims no worker remains while instructing the operator to close the already-launched endpoint and local copy. Fixing executable output is outside this documentation-only phase.

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Quote done literals in backlog atomicity assertions
✅ Re-checked - no issues remain.

✅ No issues found.

✅ No issues found.

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Quote done literal in backlog atomicity test
✅ Re-checked - no issues remain.

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>
