### PR TITLE
fix(bin): direct third-party PRs to captain forks

### DIFF
--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -42,7 +42,7 @@ Choose that posture when adding or creating the project:
 - `direct-PR` pushes and opens a PR without the no-mistakes pipeline.
 - `local-only` has no required remote or PR and lands only through the approved local fast-forward path.
 - `no-mistakes-prod-only` is a conditional policy rather than one flat mode: genuinely internal-only tooling, automation, contributor or operator process, and release or submission work ships `direct-PR`, while product-facing, mixed, and uncertain work ships `no-mistakes`.
-PRs target the captain's fork when the project's upstream is third-party; the ship brief scaffold (bin/fm-brief.sh) owns that rule.
+PR repository targeting follows the ship brief scaffold in `bin/fm-brief.sh`.
 
 `no-mistakes-prod-only` is the default for a newly added or created remote-backed project when the captain specifies nothing, and a project with no remote defaults to `local-only`.
 State that resolved default while confirming the source, local name, and posture instead of asking the captain to choose from scratch, and record a flat mode instead whenever they ask for one.

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -42,6 +42,7 @@ Choose that posture when adding or creating the project:
 - `direct-PR` pushes and opens a PR without the no-mistakes pipeline.
 - `local-only` has no required remote or PR and lands only through the approved local fast-forward path.
 - `no-mistakes-prod-only` is a conditional policy rather than one flat mode: genuinely internal-only tooling, automation, contributor or operator process, and release or submission work ships `direct-PR`, while product-facing, mixed, and uncertain work ships `no-mistakes`.
+PRs target the captain's fork when the project's upstream is third-party; the ship brief scaffold (bin/fm-brief.sh) owns that rule.
 
 `no-mistakes-prod-only` is the default for a newly added or created remote-backed project when the captain specifies nothing, and a project with no remote defaults to `local-only`.
 State that resolved default while confirming the source, local name, and posture instead of asking the captain to choose from scratch, and record a flat mode instead whenever they ask for one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,7 @@ The path's worker, automated gates, and captain approval remain authoritative:
 - **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
 - **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
 - **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.
+Whichever path ships a PR, it targets the captain's fork when the project's upstream is third-party; the ship brief scaffold (bin/fm-brief.sh) owns that rule.
 
 Delivery mode and `yolo` are orthogonal.
 `yolo` governs merge authority only: with it off, the captain approves every PR merge and every local-only landing; with it on, firstmate merges green, in-scope work itself.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ GitHub Actions and Dependabot are exempt so their automation keeps working, but 
 
 6. Run `no-mistakes` to attach to the pipeline, watch findings, authorize auto-fixes, and review ask-user findings as needed.
    Follow the installed no-mistakes version's SKILL.md and live `axi` help for gate mechanics.
-7. Once the pipeline passes, it pushes the branch to your fork and opens the PR against the parent repo for you.
+7. Once the pipeline passes, it pushes the branch and opens the PR using the repository-target rule owned by [`bin/fm-brief.sh`](bin/fm-brief.sh).
 
 See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ One rule up front:
 We require this to reduce the maintainer's burden of reviewing and merging contributions.
 
 `no-mistakes` puts a local git proxy in front of your real remote.
-Pushing through it runs an AI-driven review/test/lint pipeline in an isolated worktree, forwards the push upstream only after every check passes, and opens a clean PR automatically.
+Pushing through it runs an AI-driven review/test/lint pipeline in an isolated worktree, forwards the branch to the configured push target only after every check passes, and opens a clean PR automatically.
 
 A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and requires both the deterministic signature and a parseable structured attestation from no-mistakes v1.46.0 or newer.
 The attestation must bind to the current PR head commit and report the review, test, and document steps as completed, so a stale attestation, a missing `head_sha`, or a skipped required step fails.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -32,6 +32,7 @@
 # captain's standing posture as context, and this script never reads it:
 #   no-mistakes  implement -> /no-mistakes pipeline -> PR -> configured merge authority
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
+# PR repository targeting is owned by this script's generated ship delivery contract.
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                the configured merge authority approves, firstmate merges to local main
 # no-mistakes-prod-only is a registry policy, not a task mode; resolve it to one of
@@ -410,7 +411,7 @@ EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.
-When the project's upstream is third-party (the captain does not own it), the branch and PR target the captain's fork, never the upstream repo; the configured merge authority is unchanged.
+When the project's upstream is third-party (the captain does not own it), the pushed branch and PR target the captain's fork, never the upstream repo; the configured merge authority is unchanged.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -384,6 +384,7 @@ case "$MODE" in
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
+When the project's upstream is third-party (the captain does not own it), push your branch and open the PR against the captain's fork, never the upstream repo; the configured merge authority is unchanged.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
@@ -409,6 +410,7 @@ EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.
+When the project's upstream is third-party (the captain does not own it), the branch and PR target the captain's fork, never the upstream repo; the configured merge authority is unchanged.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -19,7 +19,7 @@
 # Registered modes:
 #   no-mistakes            full pipeline -> PR -> configured merge authority (default)
 #   direct-PR              push + PR via gh-axi, no pipeline
-#   PRs target the captain's fork when the project's upstream is third-party; bin/fm-brief.sh owns that rule.
+#   PR repository targeting follows the ship brief scaffold in bin/fm-brief.sh.
 #   local-only             local branch, no remote/PR, guarded local merge
 #   no-mistakes-prod-only  a conditional policy, not a task mode: firstmate
 #                          classifies each task's surface at intake (the

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -19,6 +19,7 @@
 # Registered modes:
 #   no-mistakes            full pipeline -> PR -> configured merge authority (default)
 #   direct-PR              push + PR via gh-axi, no pipeline
+#   PRs target the captain's fork when the project's upstream is third-party; bin/fm-brief.sh owns that rule.
 #   local-only             local branch, no remote/PR, guarded local merge
 #   no-mistakes-prod-only  a conditional policy, not a task mode: firstmate
 #                          classifies each task's surface at intake (the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,7 +258,7 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 ## Delivery modes are explicit per task
 
 `no-mistakes` tasks run the full validation pipeline, `direct-PR` tasks open PRs without that pipeline, and `local-only` tasks stay local until firstmate performs an approved fast-forward merge.
-A PR targets the captain's fork when the project's upstream is third-party; the ship brief scaffold (`bin/fm-brief.sh`) owns that rule.
+PR repository targeting follows the ship brief scaffold in `bin/fm-brief.sh`.
 Each task's mode and `yolo` merge posture are firstmate's decision at intake.
 The mode is passed explicitly to `bin/fm-brief.sh`, and both values are passed explicitly to `bin/fm-spawn.sh` and `bin/fm-promote.sh`; each command refuses to guess the values it consumes.
 A ship brief records its mode as a fixed machine-readable line and the spawn refuses to launch on a different one, so the worker's instructions and the recorded task delivery cannot diverge.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,6 +258,7 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 ## Delivery modes are explicit per task
 
 `no-mistakes` tasks run the full validation pipeline, `direct-PR` tasks open PRs without that pipeline, and `local-only` tasks stay local until firstmate performs an approved fast-forward merge.
+A PR targets the captain's fork when the project's upstream is third-party; the ship brief scaffold (`bin/fm-brief.sh`) owns that rule.
 Each task's mode and `yolo` merge posture are firstmate's decision at intake.
 The mode is passed explicitly to `bin/fm-brief.sh`, and both values are passed explicitly to `bin/fm-spawn.sh` and `bin/fm-promote.sh`; each command refuses to guess the values it consumes.
 A ship brief records its mode as a fixed machine-readable line and the spawn refuses to launch on a different one, so the worker's instructions and the recorded task delivery cannot diverge.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -321,6 +321,33 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
 
 # Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
 # reference must render as plain prose with no dangling apostrophe artifact.
+# The captain's standing fork-PR rule (2026-08-27): for a project whose upstream
+# the captain does not own, workers push and PR against the captain's fork, never
+# the upstream repo. The ship brief scaffold owns the full rule, so both PR-opening
+# delivery paths (no-mistakes and direct-PR) must render it; local-only ships no PR
+# and must not.
+test_fork_pr_rule_in_pr_opening_dods() {
+  local home id mode brief
+  home="$TMP_ROOT/fork-pr-rule-home"
+  write_registry "$home"
+  for id_mode in "brief-forkpr-c1:no-mistakes" "brief-forkpr-c2:direct-PR"; do
+    id=${id_mode%%:*}
+    mode=${id_mode##*:}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_grep "the captain's fork, never the upstream repo" "$brief" \
+      "$id ($mode): brief lost the fork-PR target rule"
+    assert_grep "the configured merge authority is unchanged" "$brief" \
+      "$id ($mode): fork-PR rule must reassure that merge authority is unchanged"
+  done
+  # local-only ships no PR, so the fork-PR target line must not appear there.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-forkpr-c3 some-proj --mode local-only >/dev/null 2>&1
+  brief="$home/data/brief-forkpr-c3/brief.md"
+  assert_no_grep "the captain's fork, never the upstream repo" "$brief" \
+    "local-only brief must not render the fork-PR target rule (it ships no PR)"
+  pass "fm-brief.sh: fork-PR target rule renders in no-mistakes and direct-PR DODs only"
+}
+
 test_no_mistakes_dod_wording() {
   local home id brief
   home="$TMP_ROOT/wording-home"
@@ -759,6 +786,7 @@ test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
+test_fork_pr_rule_in_pr_opening_dods
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -319,13 +319,7 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
 
-# Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
-# reference must render as plain prose with no dangling apostrophe artifact.
-# The captain's standing fork-PR rule (2026-08-27): for a project whose upstream
-# the captain does not own, workers push and PR against the captain's fork, never
-# the upstream repo. The ship brief scaffold owns the full rule, so both PR-opening
-# delivery paths (no-mistakes and direct-PR) must render it; local-only ships no PR
-# and must not.
+# The ship brief scaffold owns the fork-PR rule; both PR-opening paths render it and local-only does not.
 test_fork_pr_rule_in_pr_opening_dods() {
   local home id mode brief
   home="$TMP_ROOT/fork-pr-rule-home"
@@ -348,6 +342,8 @@ test_fork_pr_rule_in_pr_opening_dods() {
   pass "fm-brief.sh: fork-PR target rule renders in no-mistakes and direct-PR DODs only"
 }
 
+# Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
+# reference must render as plain prose with no dangling apostrophe artifact.
 test_no_mistakes_dod_wording() {
   local home id brief
   home="$TMP_ROOT/wording-home"


### PR DESCRIPTION
## Intent

Encode the captain's standing fork-PR rule (2026-08-27) into firstmate's shared tracked material. Rule: for any project whose upstream repo the captain does not own, workers push branches to the captain's fork and open PRs AGAINST THE FORK - never against the upstream/main repository. (Origin: a worker filed a PR upstream instead of against the captain's fork; the captain ordered it retargeted and made the rule durable.)

Required changes:
1. bin/fm-brief.sh - the ship contract scaffold (both no-mistakes and direct-PR definition-of-done paths) states the fork-PR rule so every briefed worker sees it: push and PR target the captain's fork when the task's upstream is third-party. One line in the scaffold text, not an essay.
2. AGENTS.md - a single one-line reinforcement in section 7's 'Selected delivery path and merge authority' area only; no full contract restatement. Follow the one-owner rule: the fm-brief.sh scaffold is the owner of the full statement, every other mention is a one-line cross-reference.
3. Other places describing PR opening (docs, skills, script headers) updated as one-line cross-references rather than duplicating the contract.
4. Colocated tests (tests/fm-brief.test.sh) add coverage for the new scaffold line.

Constraints: shell scripts shellcheck-clean; one sentence per line in markdown; plain dashes; no agent co-author; do NOT change delivery-mode semantics, merge authority, or yolo behavior - purely about which GitHub repository a PR targets.

## What Changed

- Add the fork-target rule to no-mistakes and direct-PR ship briefs without changing merge authority.
- Point delivery documentation and script guidance to `bin/fm-brief.sh` as the rule owner.
- Test that both PR paths include the rule while local-only briefs omit it.

## Risk Assessment

🚨 High: The generated briefs are correct, but contradictory contributor guidance leaves the prohibited upstream-PR path explicitly documented.

## Testing

Inspected the committed delta, ran the focused fm-brief behavior suite, reproduced the base scaffold after resolving a fixture-only helper dependency, and captured current end-user briefs showing the fork rule only in both PR modes while preserving local-only and merge-authority behavior; the worktree remained clean.

<details>
<summary>Evidence: Before-and-after Definition-of-done diff</summary>

Source: [Before-and-after Definition-of-done diff](https://github.com/aviralmansingka/firstmate/blob/078f558cadc2b0221db1c0be3825f75f8d4016fc/.no-mistakes/evidence/fm/fork-pr-target-rule/fork-pr-target/before-after-dod.diff)

```text
--- base/no-mistakes-definition-of-done
+++ current/no-mistakes-definition-of-done
@@ -1,6 +1,7 @@
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.
+When the project's upstream is third-party (the captain does not own it), the branch and PR target the captain's fork, never the upstream repo; the configured merge authority is unchanged.
 When you believe it is complete, append `done: {summary}` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
--- base/direct-PR-definition-of-done
+++ current/direct-PR-definition-of-done
@@ -2,5 +2,6 @@
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
+When the project's upstream is third-party (the captain does not own it), push your branch and open the PR against the captain's fork, never the upstream repo; the configured merge authority is unchanged.
 When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Current scaffold generation transcript</summary>

Source: [Current scaffold generation transcript](https://github.com/aviralmansingka/firstmate/blob/078f558cadc2b0221db1c0be3825f75f8d4016fc/.no-mistakes/evidence/fm/fork-pr-target-rule/fork-pr-target/cli-transcript.txt)

```text
$ FM_HOME=/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home bin/fm-brief.sh evidence-no-mistakes third-party-project --mode no-mistakes
scaffolded: /tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/data/evidence-no-mistakes/brief.md (ship, mode=no-mistakes; replace {TASK})

$ FM_HOME=/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home bin/fm-brief.sh evidence-direct-PR third-party-project --mode direct-PR
scaffolded: /tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/data/evidence-direct-PR/brief.md (ship, mode=direct-PR; replace {TASK})

$ FM_HOME=/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home bin/fm-brief.sh evidence-local-only third-party-project --mode local-only
scaffolded: /tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/data/evidence-local-only/brief.md (ship, mode=local-only; replace {TASK})
```
</details>
<details>
<summary>Evidence: Generated no-mistakes brief</summary>

Source: [Generated no-mistakes brief](https://github.com/aviralmansingka/firstmate/blob/078f558cadc2b0221db1c0be3825f75f8d4016fc/.no-mistakes/evidence/fm/fork-pr-target-rule/fork-pr-target/home/data/evidence-no-mistakes/brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of third-party-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-no-mistakes`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-no-mistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-no-mistakes.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-no-mistakes.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-no-mistakes.inbox'/NNN.msg '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-no-mistakes.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/avirus/.no-mistakes/worktrees/b34fbd1ddf86/01M10ASYYFF5D2CCZN0MDRWY6A/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/avirus/.no-mistakes/worktrees/b34fbd1ddf86/01M10ASYYFF5D2CCZN0MDRWY6A/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When the project's upstream is third-party (the captain does not own it), the branch and PR target the captain's fork, never the upstream repo; the configured merge authority is unchanged.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated direct-PR brief</summary>

Source: [Generated direct-PR brief](https://github.com/aviralmansingka/firstmate/blob/078f558cadc2b0221db1c0be3825f75f8d4016fc/.no-mistakes/evidence/fm/fork-pr-target-rule/fork-pr-target/home/data/evidence-direct-PR/brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of third-party-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-direct-PR`

# Rules
1. Never push to the default branch (push only your `fm/evidence-direct-PR` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-direct-PR.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-direct-PR.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-direct-PR.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-direct-PR.inbox'/NNN.msg '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-direct-PR.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/avirus/.no-mistakes/worktrees/b34fbd1ddf86/01M10ASYYFF5D2CCZN0MDRWY6A/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/avirus/.no-mistakes/worktrees/b34fbd1ddf86/01M10ASYYFF5D2CCZN0MDRWY6A/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When the project's upstream is third-party (the captain does not own it), push your branch and open the PR against the captain's fork, never the upstream repo; the configured merge authority is unchanged.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated local-only control brief</summary>

Source: [Generated local-only control brief](https://github.com/aviralmansingka/firstmate/blob/078f558cadc2b0221db1c0be3825f75f8d4016fc/.no-mistakes/evidence/fm/fork-pr-target-rule/fork-pr-target/home/data/evidence-local-only/brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of third-party-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-local-only`

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/evidence-local-only` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-local-only.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-local-only.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-local-only.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-local-only.inbox'/NNN.msg '/tmp/no-mistakes-evidence/01M10ASYYFF5D2CCZN0MDRWY6A/fork-pr-target/home/state/evidence-local-only.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/avirus/.no-mistakes/worktrees/b34fbd1ddf86/01M10ASYYFF5D2CCZN0MDRWY6A/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/avirus/.no-mistakes/worktrees/b34fbd1ddf86/01M10ASYYFF5D2CCZN0MDRWY6A/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/evidence-local-only`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/evidence-local-only` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (4m29s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a1635fc9af1280ec5eb3efc7a4f6f0d208f4127b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `bin/fm-brief.sh:33` - Required criterion 3 says: &#34;Other places describing PR opening (docs, skills, script headers) updated as one-line cross-references.&#34; The diff adds the owned scaffold rule at lines 387 and 413 and updates a doc and skill, but no script header was updated; this PR-opening header and bin/fm-project-mode.sh:20-21 still lack the required owner cross-reference.

🔧 Fix: Add fork PR owner cross-reference
1 error still open:
- 🚨 `CONTRIBUTING.md:31` - Required criterion 3 says PR-opening docs must carry a one-line cross-reference to the fork-target rule, but this workflow still directs no-mistakes to open the PR against the parent repo. Replace this conflicting guidance with the required one-line cross-reference to bin/fm-brief.sh.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `CONTRIBUTING.md:31` - Contributor guidance still says no-mistakes opens the PR against the parent repository. This contradicts the required fork-target rule and leaves a PR-opening document without the required one-line cross-reference to bin/fm-brief.sh.
- `tests/fm-brief.test.sh`
- <code>Generated no-mistakes, direct-PR, and local-only briefs through `bin/fm-brief.sh` with isolated `FM_HOME` evidence data.</code>
- <code>Audited tracked Markdown and shell references with `rg` for PR-opening and repository-target guidance.</code>
- `git diff --check 60bedde5b4f2e907e41303ace3749cdf0a475a7a..4d5e8b5b94ef069f01b9c0b2eeb67c2d030b70b8`

🔧 Fix: Align contributor guidance with fork-target contract
✅ Re-checked - no issues remain.
- `git diff --check 60bedde5b4f2e907e41303ace3749cdf0a475a7a..HEAD`
- `bin/fm-test-run.sh tests/fm-brief.test.sh`
- <code>Generated no-mistakes, direct-PR, and local-only briefs via `bin/fm-brief.sh` with an isolated evidence home.</code>
- <code>Executed the base-commit `fm-brief.sh` with its base helpers, then compared generated Definition-of-done sections against current output.</code>
- <code>`git status --short` after evidence capture and fixture cleanup.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
