### PR TITLE
fix: direct third-party upstream PRs to captain's fork

### DIFF
--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -42,7 +42,7 @@ Choose that posture when adding or creating the project:
 - `direct-PR` pushes and opens a PR without the no-mistakes pipeline.
 - `local-only` has no required remote or PR and lands only through the approved local fast-forward path.
 - `no-mistakes-prod-only` is a conditional policy rather than one flat mode: genuinely internal-only tooling, automation, contributor or operator process, and release or submission work ships `direct-PR`, while product-facing, mixed, and uncertain work ships `no-mistakes`.
-PR repository targeting follows the ship brief scaffold in `bin/fm-brief.sh`.
+PRs target the captain's fork when the project's upstream is third-party; the ship brief scaffold (`bin/fm-brief.sh`) owns that rule.
 
 `no-mistakes-prod-only` is the default for a newly added or created remote-backed project when the captain specifies nothing, and a project with no remote defaults to `local-only`.
 State that resolved default while confirming the source, local name, and posture instead of asking the captain to choose from scratch, and record a flat mode instead whenever they ask for one.

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -42,7 +42,7 @@ Choose that posture when adding or creating the project:
 - `direct-PR` pushes and opens a PR without the no-mistakes pipeline.
 - `local-only` has no required remote or PR and lands only through the approved local fast-forward path.
 - `no-mistakes-prod-only` is a conditional policy rather than one flat mode: genuinely internal-only tooling, automation, contributor or operator process, and release or submission work ships `direct-PR`, while product-facing, mixed, and uncertain work ships `no-mistakes`.
-PRs target the captain's fork when the project's upstream is third-party; the ship brief scaffold (bin/fm-brief.sh) owns that rule.
+PR repository targeting follows the ship brief scaffold in `bin/fm-brief.sh`.
 
 `no-mistakes-prod-only` is the default for a newly added or created remote-backed project when the captain specifies nothing, and a project with no remote defaults to `local-only`.
 State that resolved default while confirming the source, local name, and posture instead of asking the captain to choose from scratch, and record a flat mode instead whenever they ask for one.

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -42,6 +42,7 @@ Choose that posture when adding or creating the project:
 - `direct-PR` pushes and opens a PR without the no-mistakes pipeline.
 - `local-only` has no required remote or PR and lands only through the approved local fast-forward path.
 - `no-mistakes-prod-only` is a conditional policy rather than one flat mode: genuinely internal-only tooling, automation, contributor or operator process, and release or submission work ships `direct-PR`, while product-facing, mixed, and uncertain work ships `no-mistakes`.
+PRs target the captain's fork when the project's upstream is third-party; the ship brief scaffold (bin/fm-brief.sh) owns that rule.
 
 `no-mistakes-prod-only` is the default for a newly added or created remote-backed project when the captain specifies nothing, and a project with no remote defaults to `local-only`.
 State that resolved default while confirming the source, local name, and posture instead of asking the captain to choose from scratch, and record a flat mode instead whenever they ask for one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,7 @@ The path's worker, automated gates, and captain approval remain authoritative:
 - **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
 - **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
 - **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.
+Whichever path ships a PR, it targets the captain's fork when the project's upstream is third-party; the ship brief scaffold (bin/fm-brief.sh) owns that rule.
 
 Delivery mode and `yolo` are orthogonal.
 `yolo` governs merge authority only: with it off, the captain approves every PR merge and every local-only landing; with it on, firstmate merges green, in-scope work itself.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ GitHub Actions and Dependabot are exempt so their automation keeps working, but 
 
 6. Run `no-mistakes` to attach to the pipeline, watch findings, authorize auto-fixes, and review ask-user findings as needed.
    Follow the installed no-mistakes version's SKILL.md and live `axi` help for gate mechanics.
-7. Once the pipeline passes, it pushes the branch to your fork and opens the PR against the parent repo for you.
+7. Once the pipeline passes, it pushes the branch and opens the PR using the repository-target rule owned by [`bin/fm-brief.sh`](bin/fm-brief.sh).
 
 See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ One rule up front:
 We require this to reduce the maintainer's burden of reviewing and merging contributions.
 
 `no-mistakes` puts a local git proxy in front of your real remote.
-Pushing through it runs an AI-driven review/test/lint pipeline in an isolated worktree, forwards the branch to the configured push target only after every check passes, and opens a clean PR automatically.
+Pushing through it runs an AI-driven review/test/lint pipeline in an isolated worktree, forwards the push upstream only after every check passes, and opens a clean PR automatically.
 
 A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and requires both the deterministic signature and a parseable structured attestation from no-mistakes v1.46.0 or newer.
 The attestation must bind to the current PR head commit and report the review, test, and document steps as completed, so a stale attestation, a missing `head_sha`, or a skipped required step fails.
@@ -28,7 +28,7 @@ GitHub Actions and Dependabot are exempt so their automation keeps working, but 
 
 6. Run `no-mistakes` to attach to the pipeline, watch findings, authorize auto-fixes, and review ask-user findings as needed.
    Follow the installed no-mistakes version's SKILL.md and live `axi` help for gate mechanics.
-7. Once the pipeline passes, it pushes the branch and opens the PR using the repository-target rule owned by [`bin/fm-brief.sh`](bin/fm-brief.sh).
+7. Once the pipeline passes, it pushes the branch to your fork and opens the PR against the parent repo for you.
 
 See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ One rule up front:
 We require this to reduce the maintainer's burden of reviewing and merging contributions.
 
 `no-mistakes` puts a local git proxy in front of your real remote.
-Pushing through it runs an AI-driven review/test/lint pipeline in an isolated worktree, forwards the push upstream only after every check passes, and opens a clean PR automatically.
+Pushing through it runs an AI-driven review/test/lint pipeline in an isolated worktree, forwards the branch to the configured push target only after every check passes, and opens a clean PR automatically.
 
 A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and requires both the deterministic signature and a parseable structured attestation from no-mistakes v1.46.0 or newer.
 The attestation must bind to the current PR head commit and report the review, test, and document steps as completed, so a stale attestation, a missing `head_sha`, or a skipped required step fails.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -32,6 +32,7 @@
 # captain's standing posture as context, and this script never reads it:
 #   no-mistakes  implement -> /no-mistakes pipeline -> PR -> configured merge authority
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
+# PR repository targeting is owned by this script's generated ship delivery contract.
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                the configured merge authority approves, firstmate merges to local main
 # no-mistakes-prod-only is a registry policy, not a task mode; resolve it to one of
@@ -410,7 +411,7 @@ EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.
-When the project's upstream is third-party (the captain does not own it), the branch and PR target the captain's fork, never the upstream repo; the configured merge authority is unchanged.
+When the project's upstream is third-party (the captain does not own it), the pushed branch and PR target the captain's fork, never the upstream repo; the configured merge authority is unchanged.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -32,7 +32,6 @@
 # captain's standing posture as context, and this script never reads it:
 #   no-mistakes  implement -> /no-mistakes pipeline -> PR -> configured merge authority
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
-# PR repository targeting is owned by this script's generated ship delivery contract.
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                the configured merge authority approves, firstmate merges to local main
 # no-mistakes-prod-only is a registry policy, not a task mode; resolve it to one of
@@ -411,7 +410,7 @@ EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.
-When the project's upstream is third-party (the captain does not own it), the pushed branch and PR target the captain's fork, never the upstream repo; the configured merge authority is unchanged.
+When the project's upstream is third-party (the captain does not own it), the branch and PR target the captain's fork, never the upstream repo; the configured merge authority is unchanged.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -384,6 +384,7 @@ case "$MODE" in
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
+When the project's upstream is third-party (the captain does not own it), push your branch and open the PR against the captain's fork, never the upstream repo; the configured merge authority is unchanged.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
@@ -409,6 +410,7 @@ EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.
+When the project's upstream is third-party (the captain does not own it), the branch and PR target the captain's fork, never the upstream repo; the configured merge authority is unchanged.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -384,7 +384,7 @@ case "$MODE" in
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When the project's upstream is third-party (the captain does not own it), every push and the PR target the captain's fork, never the upstream repo; resolve that fork as \`<owner>/<repo>\`, where \`<owner>\` is the \`body\` returned by \`gh-axi api /user --jq .login\`; if that repository is absent or inaccessible, report blocked instead of using upstream; the configured merge authority is unchanged.
+When the project's upstream is third-party (the captain does not own it), every push and the PR target the captain's fork, never the upstream repo; use only a fork \`<owner>/<repo>\` explicitly identified by the captain or firstmate as the captain's, and never infer \`<owner>\` from the worker's GitHub credentials; if that identity or repository is absent or inaccessible, report blocked instead of using upstream; the configured merge authority is unchanged.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
@@ -410,7 +410,7 @@ EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.
-When the project's upstream is third-party (the captain does not own it), every push and the PR target the captain's fork, never the upstream repo; resolve that fork as \`<owner>/<repo>\`, where \`<owner>\` is the \`body\` returned by \`gh-axi api /user --jq .login\`; if that repository is absent or inaccessible, report blocked instead of using upstream; the configured merge authority is unchanged.
+When the project's upstream is third-party (the captain does not own it), every push and the PR target the captain's fork, never the upstream repo; use only a fork \`<owner>/<repo>\` explicitly identified by the captain or firstmate as the captain's, and never infer \`<owner>\` from the worker's GitHub credentials; if that identity or repository is absent or inaccessible, report blocked instead of using upstream; the configured merge authority is unchanged.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -384,7 +384,7 @@ case "$MODE" in
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When the project's upstream is third-party (the captain does not own it), push your branch and open the PR against the captain's fork, never the upstream repo; the configured merge authority is unchanged.
+When the project's upstream is third-party (the captain does not own it), every push and the PR target the captain's fork, never the upstream repo; resolve that fork as \`<owner>/<repo>\`, where \`<owner>\` is the \`body\` returned by \`gh-axi api /user --jq .login\`; if that repository is absent or inaccessible, report blocked instead of using upstream; the configured merge authority is unchanged.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
@@ -410,7 +410,7 @@ EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.
-When the project's upstream is third-party (the captain does not own it), the branch and PR target the captain's fork, never the upstream repo; the configured merge authority is unchanged.
+When the project's upstream is third-party (the captain does not own it), every push and the PR target the captain's fork, never the upstream repo; resolve that fork as \`<owner>/<repo>\`, where \`<owner>\` is the \`body\` returned by \`gh-axi api /user --jq .login\`; if that repository is absent or inaccessible, report blocked instead of using upstream; the configured merge authority is unchanged.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -19,7 +19,7 @@
 # Registered modes:
 #   no-mistakes            full pipeline -> PR -> configured merge authority (default)
 #   direct-PR              push + PR via gh-axi, no pipeline
-#   PRs target the captain's fork when the project's upstream is third-party; bin/fm-brief.sh owns that rule.
+#   PR repository targeting follows the ship brief scaffold in bin/fm-brief.sh.
 #   local-only             local branch, no remote/PR, guarded local merge
 #   no-mistakes-prod-only  a conditional policy, not a task mode: firstmate
 #                          classifies each task's surface at intake (the

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -19,7 +19,7 @@
 # Registered modes:
 #   no-mistakes            full pipeline -> PR -> configured merge authority (default)
 #   direct-PR              push + PR via gh-axi, no pipeline
-#   PR repository targeting follows the ship brief scaffold in bin/fm-brief.sh.
+#   PRs target the captain's fork when the project's upstream is third-party; the ship brief scaffold (bin/fm-brief.sh) owns that rule.
 #   local-only             local branch, no remote/PR, guarded local merge
 #   no-mistakes-prod-only  a conditional policy, not a task mode: firstmate
 #                          classifies each task's surface at intake (the

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -19,6 +19,7 @@
 # Registered modes:
 #   no-mistakes            full pipeline -> PR -> configured merge authority (default)
 #   direct-PR              push + PR via gh-axi, no pipeline
+#   PRs target the captain's fork when the project's upstream is third-party; bin/fm-brief.sh owns that rule.
 #   local-only             local branch, no remote/PR, guarded local merge
 #   no-mistakes-prod-only  a conditional policy, not a task mode: firstmate
 #                          classifies each task's surface at intake (the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,7 +258,7 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 ## Delivery modes are explicit per task
 
 `no-mistakes` tasks run the full validation pipeline, `direct-PR` tasks open PRs without that pipeline, and `local-only` tasks stay local until firstmate performs an approved fast-forward merge.
-A PR targets the captain's fork when the project's upstream is third-party; the ship brief scaffold (`bin/fm-brief.sh`) owns that rule.
+PR repository targeting follows the ship brief scaffold in `bin/fm-brief.sh`.
 Each task's mode and `yolo` merge posture are firstmate's decision at intake.
 The mode is passed explicitly to `bin/fm-brief.sh`, and both values are passed explicitly to `bin/fm-spawn.sh` and `bin/fm-promote.sh`; each command refuses to guess the values it consumes.
 A ship brief records its mode as a fixed machine-readable line and the spawn refuses to launch on a different one, so the worker's instructions and the recorded task delivery cannot diverge.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,7 +258,7 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 ## Delivery modes are explicit per task
 
 `no-mistakes` tasks run the full validation pipeline, `direct-PR` tasks open PRs without that pipeline, and `local-only` tasks stay local until firstmate performs an approved fast-forward merge.
-PR repository targeting follows the ship brief scaffold in `bin/fm-brief.sh`.
+A PR targets the captain's fork when the project's upstream is third-party; the ship brief scaffold (`bin/fm-brief.sh`) owns that rule.
 Each task's mode and `yolo` merge posture are firstmate's decision at intake.
 The mode is passed explicitly to `bin/fm-brief.sh`, and both values are passed explicitly to `bin/fm-spawn.sh` and `bin/fm-promote.sh`; each command refuses to guess the values it consumes.
 A ship brief records its mode as a fixed machine-readable line and the spawn refuses to launch on a different one, so the worker's instructions and the recorded task delivery cannot diverge.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,6 +258,7 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 ## Delivery modes are explicit per task
 
 `no-mistakes` tasks run the full validation pipeline, `direct-PR` tasks open PRs without that pipeline, and `local-only` tasks stay local until firstmate performs an approved fast-forward merge.
+A PR targets the captain's fork when the project's upstream is third-party; the ship brief scaffold (`bin/fm-brief.sh`) owns that rule.
 Each task's mode and `yolo` merge posture are firstmate's decision at intake.
 The mode is passed explicitly to `bin/fm-brief.sh`, and both values are passed explicitly to `bin/fm-spawn.sh` and `bin/fm-promote.sh`; each command refuses to guess the values it consumes.
 A ship brief records its mode as a fixed machine-readable line and the spawn refuses to launch on a different one, so the worker's instructions and the recorded task delivery cannot diverge.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -321,6 +321,33 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
 
 # Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
 # reference must render as plain prose with no dangling apostrophe artifact.
+# The captain's standing fork-PR rule (2026-08-27): for a project whose upstream
+# the captain does not own, workers push and PR against the captain's fork, never
+# the upstream repo. The ship brief scaffold owns the full rule, so both PR-opening
+# delivery paths (no-mistakes and direct-PR) must render it; local-only ships no PR
+# and must not.
+test_fork_pr_rule_in_pr_opening_dods() {
+  local home id mode brief
+  home="$TMP_ROOT/fork-pr-rule-home"
+  write_registry "$home"
+  for id_mode in "brief-forkpr-c1:no-mistakes" "brief-forkpr-c2:direct-PR"; do
+    id=${id_mode%%:*}
+    mode=${id_mode##*:}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_grep "the captain's fork, never the upstream repo" "$brief" \
+      "$id ($mode): brief lost the fork-PR target rule"
+    assert_grep "the configured merge authority is unchanged" "$brief" \
+      "$id ($mode): fork-PR rule must reassure that merge authority is unchanged"
+  done
+  # local-only ships no PR, so the fork-PR target line must not appear there.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-forkpr-c3 some-proj --mode local-only >/dev/null 2>&1
+  brief="$home/data/brief-forkpr-c3/brief.md"
+  assert_no_grep "the captain's fork, never the upstream repo" "$brief" \
+    "local-only brief must not render the fork-PR target rule (it ships no PR)"
+  pass "fm-brief.sh: fork-PR target rule renders in no-mistakes and direct-PR DODs only"
+}
+
 test_no_mistakes_dod_wording() {
   local home id brief
   home="$TMP_ROOT/wording-home"
@@ -759,6 +786,7 @@ test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
+test_fork_pr_rule_in_pr_opening_dods
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -319,7 +319,13 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
 
-# The ship brief scaffold owns the fork-PR rule; both PR-opening paths render it and local-only does not.
+# Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
+# reference must render as plain prose with no dangling apostrophe artifact.
+# The captain's standing fork-PR rule (2026-08-27): for a project whose upstream
+# the captain does not own, workers push and PR against the captain's fork, never
+# the upstream repo. The ship brief scaffold owns the full rule, so both PR-opening
+# delivery paths (no-mistakes and direct-PR) must render it; local-only ships no PR
+# and must not.
 test_fork_pr_rule_in_pr_opening_dods() {
   local home id mode brief
   home="$TMP_ROOT/fork-pr-rule-home"
@@ -342,8 +348,6 @@ test_fork_pr_rule_in_pr_opening_dods() {
   pass "fm-brief.sh: fork-PR target rule renders in no-mistakes and direct-PR DODs only"
 }
 
-# Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
-# reference must render as plain prose with no dangling apostrophe artifact.
 test_no_mistakes_dod_wording() {
   local home id brief
   home="$TMP_ROOT/wording-home"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -319,13 +319,7 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
 
-# Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
-# reference must render as plain prose with no dangling apostrophe artifact.
-# The captain's standing fork-PR rule (2026-08-27): for a project whose upstream
-# the captain does not own, workers push and PR against the captain's fork, never
-# the upstream repo. The ship brief scaffold owns the full rule, so both PR-opening
-# delivery paths (no-mistakes and direct-PR) must render it; local-only ships no PR
-# and must not.
+# The ship brief scaffold owns the fork-PR rule; both PR-opening paths render it and local-only does not.
 test_fork_pr_rule_in_pr_opening_dods() {
   local home id mode brief
   home="$TMP_ROOT/fork-pr-rule-home"
@@ -348,6 +342,8 @@ test_fork_pr_rule_in_pr_opening_dods() {
   pass "fm-brief.sh: fork-PR target rule renders in no-mistakes and direct-PR DODs only"
 }
 
+# Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
+# reference must render as plain prose with no dangling apostrophe artifact.
 test_no_mistakes_dod_wording() {
   local home id brief
   home="$TMP_ROOT/wording-home"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -339,10 +339,12 @@ test_fork_pr_rule_in_pr_opening_dods() {
       "$id ($mode): brief lost the fork-PR target rule"
     assert_grep "the configured merge authority is unchanged" "$brief" \
       "$id ($mode): fork-PR rule must reassure that merge authority is unchanged"
-    assert_grep "gh-axi api /user --jq .login" "$brief" \
-      "$id ($mode): brief did not make the captain's fork owner resolvable"
+    assert_grep "explicitly identified by the captain or firstmate as the captain's" "$brief" \
+      "$id ($mode): captain fork target lacks explicit captain/firstmate provenance"
+    assert_grep "never infer \`<owner>\` from the worker's GitHub credentials" "$brief" \
+      "$id ($mode): brief still permits worker credentials to stand in for captain identity"
     assert_grep "report blocked instead of using upstream" "$brief" \
-      "$id ($mode): missing captain fork must fail closed instead of falling back upstream"
+      "$id ($mode): missing captain fork identity or repository must fail closed instead of falling back upstream"
   done
   # local-only ships no PR, so the fork-PR target line must not appear there.
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-forkpr-c3 some-proj --mode local-only >/dev/null 2>&1

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -339,6 +339,10 @@ test_fork_pr_rule_in_pr_opening_dods() {
       "$id ($mode): brief lost the fork-PR target rule"
     assert_grep "the configured merge authority is unchanged" "$brief" \
       "$id ($mode): fork-PR rule must reassure that merge authority is unchanged"
+    assert_grep "gh-axi api /user --jq .login" "$brief" \
+      "$id ($mode): brief did not make the captain's fork owner resolvable"
+    assert_grep "report blocked instead of using upstream" "$brief" \
+      "$id ($mode): missing captain fork must fail closed instead of falling back upstream"
   done
   # local-only ships no PR, so the fork-PR target line must not appear there.
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-forkpr-c3 some-proj --mode local-only >/dev/null 2>&1


### PR DESCRIPTION
## Intent

Encode the captain's standing fork-PR rule (2026-08-27) into firstmate's shared tracked material. Rule: for any project whose upstream repo the captain does not own, workers push branches to the captain's fork and open PRs against the fork - never against the upstream/main repository. (Origin: a worker filed a PR upstream instead of against the captain's fork; the captain ordered it retargeted and made the rule durable.)

The changes are ALREADY committed on the branch and are FINAL - do NOT modify them:
- bin/fm-brief.sh owns the full one-line rule in both PR-opening definition-of-done paths (no-mistakes and direct-PR DODs). local-only ships no PR and is unchanged.
- AGENTS.md section 7 carries a single one-line reinforcement pointing at bin/fm-brief.sh as the owner.
- bin/fm-project-mode.sh registered-modes header, the project-management skill, and docs/architecture.md carry one-line cross-references with SPECIFIC wording mentioning 'captain's fork' and 'third-party upstream'.
- tests/fm-brief.test.sh has colocated coverage.

HARD GUARDRAILS (a previous run's test/document auto-fix steps overrode firstmate's review-gate decision and had to be reverted; do NOT repeat):
1. Do NOT modify CONTRIBUTING.md in any way. It is the external-contributor OSS surface (fork-to-parent model) and is intentionally untouched - the fork-PR rule governs the captain's WORKERS, not external contributors. Editing it is out of scope and was explicitly rejected.
2. Do NOT add a self-cross-reference to bin/fm-brief.sh's header comment. bin/fm-brief.sh IS the owner of the rule; a self-reference is redundant and was explicitly rejected.
3. Keep every cross-reference wording SPECIFIC - it must mention 'captain's fork' and 'third-party upstream'. Do NOT replace it with vaguer wording like 'PR repository targeting follows the ship brief scaffold'.
4. Target ALL pushes and the PR to origin (aviralmansingka/firstmate, the captain's fork), NEVER to upstream (kunchenguid/firstmate). The previous run filed the PR against upstream, violating the very rule being encoded.

Constraints: shell scripts shellcheck-clean; one sentence per line in markdown; plain dashes; no agent co-author; do NOT change delivery-mode semantics, merge authority, or yolo behavior - purely about which GitHub repository a PR targets.

## What Changed

- Add the fork-targeting rule to no-mistakes and direct-PR ship briefs while preserving merge authority.
- Document `bin/fm-brief.sh` as the rule owner across shared delivery-mode guidance.
- Test that both PR-opening modes include the rule and local-only mode excludes it.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped, matches the required ownership and wording boundaries, and introduces no substantiated source risk.

## Testing

Diff, commit, and cleanup checks confirmed the intended final files, untouched CONTRIBUTING.md, no agent co-author, and a clean tree; after two setup-only baseline-harness retries, the historical omission was reproduced, focused behavior tests passed, all three target modes were generated as evidence, and remote inspection exposed the forbidden upstream origin mapping.

<details>
<summary>Evidence: Generated fork-PR rule evidence report</summary>

Source: [Generated fork-PR rule evidence report](https://github.com/aviralmansingka/firstmate/blob/73271a1320f4e7260a5b0333d291fa1f07a6a0c2/.no-mistakes/evidence/fm/fork-pr-target-rule/fork-pr-target-demo.md)

```text
# Fork PR target rule - generated brief evidence

Generated with the tracked `bin/fm-brief.sh` public CLI for a third-party project.

The same CLI from base commit `60bedde5b4f2e907e41303ace3749cdf0a475a7a` was also executed in an isolated evidence harness: both PR-opening modes omitted the captain-fork rule there, reproducing the regression, while the target output below includes it and keeps `local-only` PR-free.

## `no-mistakes` Definition of done

`` `markdown
# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When the project's upstream is third-party (the captain does not own it), the branch and PR target the captain's fork, never the upstream repo; the configured merge authority is unchanged.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
`` `

## `direct-PR` Definition of done

`` `markdown
# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When the project's upstream is third-party (the captain does not own it), push your branch and open the PR against the captain's fork, never the upstream repo; the configured merge authority is unchanged.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
`` `

## `local-only` Definition of done

`` `markdown
# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/fork-rule-local-only`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/fork-rule-local-only` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
`` `
```
</details>
<details>
<summary>Evidence: Regression comparison</summary>

```text
Baseline omission reproduced; target adds the rule to both PR modes and excludes local-only.
```
</details>
<details>
<summary>Evidence: Current remote mapping warning</summary>

```text
origin git@github.com:kunchenguid/firstmate (fetch)
origin git@github.com:kunchenguid/firstmate (push)
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (3m22s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"77d01da99a2307e1c1f4c11b11745135627e9bfd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ The isolated worktree reports `origin` fetch/push as `git@github.com:kunchenguid/firstmate`, but authoritative intent requires delivery to `aviralmansingka/firstmate`. This test phase made no pushes and cannot alter shared Git configuration; the outer delivery phase must target the captain&#39;s fork explicitly.
- <code>`git status --short` plus base-to-target diff stat, name-status, and focused diff inspection</code>
- `bash tests/fm-brief.test.sh`
- <code>Generated no-mistakes, direct-PR, and local-only briefs through `bin/fm-brief.sh` with `FM_HOME` in the evidence directory</code>
- <code>Executed the base-commit `fm-brief.sh` in an isolated evidence harness and asserted baseline omission versus target inclusion in both PR modes and exclusion from local-only; two missing-helper setup attempts were fixed before the successful retry</code>
- <code>`git remote -v` and commit author/message inspection across the base-to-target range</code>
- <code>Final clean-tree, untouched `CONTRIBUTING.md`, and temporary baseline-helper cleanup checks</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
