### PR TITLE
fix(pi): gate first provider call on startup context

### DIFF
--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -125,7 +125,6 @@ type SessionstartGeneration = {
   delivered: boolean;
   child: ChildProcess | null;
   processGroupId: number | null;
-  processGroupMonitor: NodeJS.Timeout | null;
   childClosed: boolean;
   childClose: Promise<void> | null;
   stopPromise: Promise<void> | null;
@@ -175,31 +174,6 @@ function sessionstartProcessGroupAlive(processGroupId: number): boolean {
   }
 }
 
-function clearSessionstartProcessGroup(
-  generation: SessionstartGeneration,
-  processGroupId: number,
-): void {
-  if (generation.processGroupId !== processGroupId) return;
-  generation.processGroupId = null;
-  if (generation.processGroupMonitor) clearTimeout(generation.processGroupMonitor);
-  generation.processGroupMonitor = null;
-}
-
-function monitorSessionstartProcessGroup(
-  generation: SessionstartGeneration,
-  processGroupId: number,
-): void {
-  if (process.platform === "win32" || generation.processGroupId !== processGroupId) return;
-  if (!sessionstartProcessGroupAlive(processGroupId)) {
-    clearSessionstartProcessGroup(generation, processGroupId);
-    return;
-  }
-  generation.processGroupMonitor = setTimeout(() => {
-    monitorSessionstartProcessGroup(generation, processGroupId);
-  }, 10);
-  generation.processGroupMonitor.unref();
-}
-
 function waitForSessionstartProcessGroupExit(
   processGroupId: number,
   timeoutMs: number,
@@ -247,12 +221,7 @@ function stopSessionstartGeneration(generation: SessionstartGeneration): Promise
       return;
     }
     const processGroupId = generation.processGroupId;
-    if (!processGroupId) {
-      await generation.result;
-      return;
-    }
-    if (!sessionstartProcessGroupAlive(processGroupId)) {
-      clearSessionstartProcessGroup(generation, processGroupId);
+    if (!child || !processGroupId) {
       await generation.result;
       return;
     }
@@ -268,9 +237,6 @@ function stopSessionstartGeneration(generation: SessionstartGeneration): Promise
       }
       await waitForSessionstartProcessGroupExit(processGroupId, sessionstartRetireTimeoutMs);
     }
-    if (!sessionstartProcessGroupAlive(processGroupId)) {
-      clearSessionstartProcessGroup(generation, processGroupId);
-    }
   })();
   return generation.stopPromise;
 }
@@ -284,14 +250,26 @@ function runSessionstartHook(generation: SessionstartGeneration): Promise<Sessio
       settled = true;
       resolveResult(result);
     };
+    const supervised = process.platform !== "win32";
+    const runner = `${root}/bin/fm-sessionstart-run.sh`;
     let child: ChildProcess;
     try {
       child = spawn(
-        `${root}/bin/fm-sessionstart-run.sh`,
-        ["--source", generation.source, "--pi-prerequisite"],
+        supervised ? process.execPath : runner,
+        supervised
+          ? [
+              `${extensionDir}/lib/fm-sessionstart-supervisor.mjs`,
+              runner,
+              "--source",
+              generation.source,
+              "--pi-prerequisite",
+            ]
+          : ["--source", generation.source, "--pi-prerequisite"],
         {
-          detached: process.platform !== "win32",
-          stdio: ["ignore", "pipe", "ignore"],
+          detached: supervised,
+          stdio: supervised
+            ? ["ignore", "pipe", "ignore", "ipc"]
+            : ["ignore", "pipe", "ignore"],
         },
       );
     } catch {
@@ -304,33 +282,26 @@ function runSessionstartHook(generation: SessionstartGeneration): Promise<Sessio
       closeChild = resolveClose;
     });
     const chunks: Buffer[] = [];
+    let observedBytes = 0;
     let retainedBytes = 0;
     let truncated = false;
+    let pendingCompletion: { code: number | null; bytes: number } | null = null;
+    const unrefSupervisor = (): void => {
+      if (!supervised) return;
+      child.unref();
+      child.channel?.unref();
+      const stdout = child.stdout as (NodeJS.ReadableStream & { unref?: () => void }) | null;
+      stdout?.unref?.();
+    };
     const markClosed = (): void => {
       if (generation.childClosed) return;
       generation.childClosed = true;
       if (generation.child === child) generation.child = null;
-      const processGroupId = generation.processGroupId;
-      if (processGroupId) monitorSessionstartProcessGroup(generation, processGroupId);
+      generation.processGroupId = null;
       closeChild();
     };
-    child.stdout?.on("data", (chunk: Buffer) => {
-      if (retainedBytes >= sessionstartDeliveryBytes) {
-        truncated = true;
-        return;
-      }
-      const remaining = sessionstartDeliveryBytes - retainedBytes;
-      const retained = chunk.length <= remaining ? chunk : chunk.subarray(0, remaining);
-      chunks.push(retained);
-      retainedBytes += retained.length;
-      if (retained.length !== chunk.length) truncated = true;
-    });
-    child.on("error", () => {
-      markClosed();
-      settle(generation.stopping ? { kind: "cancelled" } : { kind: "failed" });
-    });
-    child.on("close", (code) => {
-      markClosed();
+    const complete = (code: number | null): void => {
+      unrefSupervisor();
       if (generation.stopping) {
         settle({ kind: "cancelled" });
         return;
@@ -352,6 +323,47 @@ function runSessionstartHook(generation: SessionstartGeneration): Promise<Sessio
         kind: "ready",
         raw: truncated ? `${raw}${sessionstartTruncatedMarker}` : raw,
       });
+    };
+    const completePending = (): void => {
+      if (!pendingCompletion || observedBytes < pendingCompletion.bytes) return;
+      complete(pendingCompletion.code);
+      pendingCompletion = null;
+    };
+    child.stdout?.on("data", (chunk: Buffer) => {
+      observedBytes += chunk.length;
+      if (retainedBytes >= sessionstartDeliveryBytes) {
+        truncated = true;
+        completePending();
+        return;
+      }
+      const remaining = sessionstartDeliveryBytes - retainedBytes;
+      const retained = chunk.length <= remaining ? chunk : chunk.subarray(0, remaining);
+      chunks.push(retained);
+      retainedBytes += retained.length;
+      if (retained.length !== chunk.length) truncated = true;
+      completePending();
+    });
+    if (supervised) {
+      child.on("message", (message: unknown) => {
+        const result = message as { type?: unknown; code?: unknown; bytes?: unknown };
+        if (result.type !== "result" ||
+            (typeof result.code !== "number" && result.code !== null) ||
+            typeof result.bytes !== "number") return;
+        pendingCompletion = { code: result.code, bytes: result.bytes };
+        completePending();
+      });
+    }
+    child.on("error", () => {
+      markClosed();
+      settle(generation.stopping ? { kind: "cancelled" } : { kind: "failed" });
+    });
+    child.on("close", (code) => {
+      markClosed();
+      if (supervised) {
+        settle(generation.stopping ? { kind: "cancelled" } : { kind: "failed" });
+        return;
+      }
+      complete(code);
     });
   });
 }
@@ -369,7 +381,6 @@ function createSessionstartGeneration(
     delivered: false,
     child: null,
     processGroupId: null,
-    processGroupMonitor: null,
     childClosed: false,
     childClose: null,
     stopPromise: null,
@@ -389,8 +400,10 @@ function sessionstartMessage(
   result: SessionstartResult,
 ): SessionstartMessage | undefined {
   let raw = result.kind === "ready" ? result.raw : "";
-  if (!raw && ["startup", "clear", "compact"].includes(generation.source) &&
-      (result.kind === "empty" || result.kind === "failed")) {
+  if (!raw && result.kind === "failed") {
+    raw = sessionstartManualFallback;
+  } else if (!raw && ["startup", "clear", "compact"].includes(generation.source) &&
+      result.kind === "empty") {
     raw = sessionstartManualFallback;
   }
   if (!raw) return undefined;
@@ -482,10 +495,6 @@ export default function (pi: ExtensionAPI) {
     const processGroupId = generation.processGroupId;
     if (!processGroupId) {
       if (generation.child) signalSessionstartChild(generation.child, "SIGKILL");
-      return;
-    }
-    if (!sessionstartProcessGroupAlive(processGroupId)) {
-      clearSessionstartProcessGroup(generation, processGroupId);
       return;
     }
     try {

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -434,11 +434,35 @@ function runCdCheck(command: string): Promise<{ code: number; stderr: string }> 
 
 export default function (pi: ExtensionAPI) {
   let sessionstartGeneration: SessionstartGeneration | null = null;
+  let sessionstartExitListenerRegistered = false;
   const cleanupSessionstartOnProcessExit = (): void => {
     const generation = sessionstartGeneration;
-    if (generation?.child) signalSessionstartChild(generation.child, "SIGKILL");
+    if (!generation) return;
+    if (process.platform === "win32") {
+      if (generation.child) signalSessionstartChild(generation.child, "SIGKILL");
+      return;
+    }
+    const processGroupId = generation.processGroupId;
+    if (!processGroupId) {
+      if (generation.child) signalSessionstartChild(generation.child, "SIGKILL");
+      return;
+    }
+    try {
+      process.kill(-processGroupId, "SIGKILL");
+    } catch {
+    }
   };
-  process.once("exit", cleanupSessionstartOnProcessExit);
+  const registerSessionstartExitListener = (): void => {
+    if (sessionstartExitListenerRegistered) return;
+    process.once("exit", cleanupSessionstartOnProcessExit);
+    sessionstartExitListenerRegistered = true;
+  };
+  const removeSessionstartExitListener = (): void => {
+    if (!sessionstartExitListenerRegistered) return;
+    process.removeListener("exit", cleanupSessionstartOnProcessExit);
+    sessionstartExitListenerRegistered = false;
+  };
+  registerSessionstartExitListener();
 
   pi.on?.("session_start", (event, ctx) => {
     const reason = String((event as { reason?: unknown }).reason ?? "");
@@ -447,6 +471,7 @@ export default function (pi: ExtensionAPI) {
       : { new: "clear", resume: "resume", fork: "fork" }[reason];
     markLoaded();
     if (!source) return;
+    registerSessionstartExitListener();
     sessionstartGeneration = createSessionstartGeneration(
       source as SessionstartSource,
       sessionIdFromContext(ctx),
@@ -464,6 +489,7 @@ export default function (pi: ExtensionAPI) {
   // may retry without another before_agent_start, so the event keeps its
   // existing delivery path while sharing generation ownership and cancellation.
   pi.on?.("session_compact", async (_event, ctx) => {
+    registerSessionstartExitListener();
     const generation = createSessionstartGeneration("compact", sessionIdFromContext(ctx));
     sessionstartGeneration = generation;
     const message = await claimSessionstartMessage(generation, ctx);
@@ -481,7 +507,7 @@ export default function (pi: ExtensionAPI) {
       if (generation) await stopSessionstartGeneration(generation);
     } finally {
       if (sessionstartGeneration === generation) sessionstartGeneration = null;
-      process.removeListener("exit", cleanupSessionstartOnProcessExit);
+      removeSessionstartExitListener();
     }
   });
 

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -66,6 +66,7 @@ const sessionstartDeliveryBytes = 512 * 1024;
 type SessionStartContext = {
   sessionManager?: {
     getHeader?: () => { timestamp?: unknown } | null | undefined;
+    getSessionId?: () => unknown;
   };
 };
 
@@ -98,16 +99,138 @@ function startupRebuildSource(ctx: SessionStartContext): "resume" | "fork" | und
 const sessionstartTruncatedMarker =
   "\n\nPI SESSION-START DELIVERY TRUNCATED - the digest exceeded 512 KiB. " +
   "Treat omitted context as unread and inspect the named files directly before acting on it.";
+const sessionstartManualFallback =
+  "Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.";
+const sessionstartIneligibleExit = 3;
+const sessionstartRetireTimeoutMs = 1000;
 
-function runSessionstartHook(source: string): Promise<string> {
+// One active generation owns native startup from child launch through context
+// claim. Replacement activates first, serially retires every predecessor, and
+// lets only the matching session id claim one persistent provider prerequisite.
+type SessionstartSource = "startup" | "clear" | "resume" | "fork" | "compact";
+type SessionstartResult =
+  | { kind: "ready"; raw: string }
+  | { kind: "empty" | "failed" | "ineligible" | "cancelled" };
+type SessionstartMessage = {
+  customType: "firstmate-sessionstart-nudge";
+  content: string;
+  display: false;
+  details: { kind: "session-start" };
+};
+type SessionstartGeneration = {
+  id: number;
+  sessionId: string;
+  source: SessionstartSource;
+  stopping: boolean;
+  delivered: boolean;
+  child: ChildProcess | null;
+  childClosed: boolean;
+  childClose: Promise<void> | null;
+  stopPromise: Promise<void> | null;
+  result: Promise<SessionstartResult>;
+};
+
+let nextSessionstartGenerationId = 0;
+let activeSessionstartGeneration: SessionstartGeneration | null = null;
+
+function sessionIdFromContext(ctx: SessionStartContext): string {
+  try {
+    return String(ctx.sessionManager?.getSessionId?.() ?? "");
+  } catch {
+    return "";
+  }
+}
+
+function sessionstartGenerationIsLive(generation: SessionstartGeneration): boolean {
+  return activeSessionstartGeneration === generation && !generation.stopping;
+}
+
+function signalSessionstartChild(child: ChildProcess, signal: NodeJS.Signals): void {
+  const pid = child.pid;
+  if (!pid) return;
+  if (process.platform === "win32") {
+    const args = ["/pid", String(pid), "/t"];
+    if (signal === "SIGKILL") args.push("/f");
+    spawnSync("taskkill", args, { stdio: "ignore" });
+    return;
+  }
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+    }
+  }
+}
+
+function waitForSessionstartClose(generation: SessionstartGeneration, timeoutMs: number): Promise<void> {
+  if (generation.childClosed || !generation.childClose) return Promise.resolve();
+  return new Promise((resolveWait) => {
+    const timer = setTimeout(resolveWait, timeoutMs);
+    void generation.childClose?.then(() => {
+      clearTimeout(timer);
+      resolveWait();
+    });
+  });
+}
+
+function stopSessionstartGeneration(generation: SessionstartGeneration): Promise<void> {
+  if (generation.stopPromise) return generation.stopPromise;
+  generation.stopping = true;
+  generation.stopPromise = (async () => {
+    const child = generation.child;
+    if (!child || generation.childClosed) {
+      await generation.result;
+      return;
+    }
+    signalSessionstartChild(child, "SIGTERM");
+    await waitForSessionstartClose(generation, sessionstartRetireTimeoutMs);
+    if (!generation.childClosed) {
+      signalSessionstartChild(child, "SIGKILL");
+      await waitForSessionstartClose(generation, sessionstartRetireTimeoutMs);
+    }
+  })();
+  return generation.stopPromise;
+}
+
+function runSessionstartHook(generation: SessionstartGeneration): Promise<SessionstartResult> {
   return new Promise((resolveResult) => {
-    const child = spawn(`${root}/bin/fm-sessionstart-run.sh`, ["--source", source], {
-      stdio: ["ignore", "pipe", "ignore"],
+    let settled = false;
+    let closeChild: () => void = () => {};
+    const settle = (result: SessionstartResult): void => {
+      if (settled) return;
+      settled = true;
+      resolveResult(result);
+    };
+    let child: ChildProcess;
+    try {
+      child = spawn(
+        `${root}/bin/fm-sessionstart-run.sh`,
+        ["--source", generation.source, "--pi-prerequisite"],
+        {
+          detached: process.platform !== "win32",
+          stdio: ["ignore", "pipe", "ignore"],
+        },
+      );
+    } catch {
+      settle(generation.stopping ? { kind: "cancelled" } : { kind: "failed" });
+      return;
+    }
+    generation.child = child;
+    generation.childClose = new Promise<void>((resolveClose) => {
+      closeChild = resolveClose;
     });
     const chunks: Buffer[] = [];
     let retainedBytes = 0;
     let truncated = false;
-    child.stdout.on("data", (chunk: Buffer) => {
+    const markClosed = (): void => {
+      if (generation.childClosed) return;
+      generation.childClosed = true;
+      if (generation.child === child) generation.child = null;
+      closeChild();
+    };
+    child.stdout?.on("data", (chunk: Buffer) => {
       if (retainedBytes >= sessionstartDeliveryBytes) {
         truncated = true;
         return;
@@ -118,39 +241,109 @@ function runSessionstartHook(source: string): Promise<string> {
       retainedBytes += retained.length;
       if (retained.length !== chunk.length) truncated = true;
     });
-    child.on("error", () => resolveResult(""));
+    child.on("error", () => {
+      markClosed();
+      settle(generation.stopping ? { kind: "cancelled" } : { kind: "failed" });
+    });
     child.on("close", (code) => {
+      markClosed();
+      if (generation.stopping) {
+        settle({ kind: "cancelled" });
+        return;
+      }
+      if (code === sessionstartIneligibleExit) {
+        settle({ kind: "ineligible" });
+        return;
+      }
       if (code !== 0) {
-        resolveResult("");
+        settle({ kind: "failed" });
         return;
       }
       const raw = Buffer.concat(chunks).toString("utf8").trim();
-      resolveResult(truncated ? `${raw}${sessionstartTruncatedMarker}` : raw);
+      if (!raw) {
+        settle({ kind: "empty" });
+        return;
+      }
+      settle({
+        kind: "ready",
+        raw: truncated ? `${raw}${sessionstartTruncatedMarker}` : raw,
+      });
     });
   });
 }
 
-async function injectSessionstart(pi: ExtensionAPI, source: string): Promise<void> {
-  const raw = await runSessionstartHook(source);
-  if (!raw) return;
+function createSessionstartGeneration(
+  source: SessionstartSource,
+  sessionId: string,
+): SessionstartGeneration {
+  const previous = activeSessionstartGeneration;
+  const generation: SessionstartGeneration = {
+    id: ++nextSessionstartGenerationId,
+    sessionId,
+    source,
+    stopping: false,
+    delivered: false,
+    child: null,
+    childClosed: false,
+    childClose: null,
+    stopPromise: null,
+    result: Promise.resolve({ kind: "cancelled" }),
+  };
+  activeSessionstartGeneration = generation;
+  generation.result = (async (): Promise<SessionstartResult> => {
+    if (previous) await stopSessionstartGeneration(previous);
+    if (!sessionstartGenerationIsLive(generation)) return { kind: "cancelled" };
+    return runSessionstartHook(generation);
+  })();
+  return generation;
+}
+
+function sessionstartMessage(
+  generation: SessionstartGeneration,
+  result: SessionstartResult,
+): SessionstartMessage | undefined {
+  let raw = result.kind === "ready" ? result.raw : "";
+  if (!raw && ["startup", "clear", "compact"].includes(generation.source) &&
+      (result.kind === "empty" || result.kind === "failed")) {
+    raw = sessionstartManualFallback;
+  }
+  if (!raw) return undefined;
   try {
-    // Pi is the only adapter that injects a MESSAGE rather than hook stdout, so
-    // whatever it injects must carry operational provenance or the Ahoy skill
-    // would have to guess whether it was captain-authored. The wrapper already
-    // returns an encoded nudge on a context-preserving open, so only an
-    // unencoded digest needs the marker added here.
+    // The wrapper already returns an encoded nudge on a context-preserving
+    // open, so only an unencoded digest or fallback needs the marker added.
     const content = classifyFirstmateCurrentOperationalText(raw)
       ? raw
       : encodeFirstmateOperationalInput("session-start", raw);
-    pi.sendMessage({
+    return {
       customType: "firstmate-sessionstart-nudge",
       content,
       display: false,
       details: { kind: "session-start" },
-    });
+    };
   } catch {
+    return undefined;
   }
 }
+
+async function claimSessionstartMessage(
+  generation: SessionstartGeneration,
+  ctx?: SessionStartContext,
+): Promise<SessionstartMessage | undefined> {
+  const result = await generation.result;
+  if (!sessionstartGenerationIsLive(generation) || generation.delivered) return undefined;
+  const currentSessionId = ctx ? sessionIdFromContext(ctx) : "";
+  if (generation.sessionId && currentSessionId && generation.sessionId !== currentSessionId) {
+    return undefined;
+  }
+  generation.delivered = true;
+  return sessionstartMessage(generation, result);
+}
+
+const cleanupSessionstartOnProcessExit = (): void => {
+  const generation = activeSessionstartGeneration;
+  if (generation?.child) signalSessionstartChild(generation.child, "SIGKILL");
+};
+process.once("exit", cleanupSessionstartOnProcessExit);
 
 function runGuard(): Promise<{ code: number; stderr: string }> {
   return new Promise((resolveResult) => {
@@ -197,20 +390,46 @@ function runCdCheck(command: string): Promise<{ code: number; stderr: string }> 
 }
 
 export default function (pi: ExtensionAPI) {
-  pi.on?.("session_start", async (event, ctx) => {
+  let sessionstartGeneration: SessionstartGeneration | null = null;
+
+  pi.on?.("session_start", (event, ctx) => {
     const reason = String((event as { reason?: unknown }).reason ?? "");
     const source = reason === "startup"
       ? startupRebuildSource(ctx) ?? "startup"
       : { new: "clear", resume: "resume", fork: "fork" }[reason];
     markLoaded();
     if (!source) return;
-    await injectSessionstart(pi, source);
+    sessionstartGeneration = createSessionstartGeneration(
+      source as SessionstartSource,
+      sessionIdFromContext(ctx),
+    );
   });
 
-  // Pi's compaction equivalent. The digest is what a compacted session has just
-  // lost, so re-emitting it here is the point rather than a side effect.
-  pi.on?.("session_compact", async () => {
-    await injectSessionstart(pi, "compact");
+  pi.on?.("before_agent_start", async (_event, ctx) => {
+    const generation = sessionstartGeneration;
+    if (!generation) return;
+    const message = await claimSessionstartMessage(generation, ctx);
+    return message ? { message } : undefined;
+  });
+
+  // Pi's compaction equivalent. Manual compaction is idle and auto-compaction
+  // may retry without another before_agent_start, so the event keeps its
+  // existing delivery path while sharing generation ownership and cancellation.
+  pi.on?.("session_compact", async (_event, ctx) => {
+    const generation = createSessionstartGeneration("compact", sessionIdFromContext(ctx));
+    sessionstartGeneration = generation;
+    const message = await claimSessionstartMessage(generation, ctx);
+    if (!message || !sessionstartGenerationIsLive(generation)) return;
+    try {
+      pi.sendMessage(message);
+    } catch {
+      generation.delivered = false;
+    }
+  });
+
+  pi.on?.("session_shutdown", async () => {
+    const generation = sessionstartGeneration;
+    if (generation) await stopSessionstartGeneration(generation);
   });
 
   pi.on("tool_call", async (event) => {

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -124,6 +124,7 @@ type SessionstartGeneration = {
   stopping: boolean;
   delivered: boolean;
   child: ChildProcess | null;
+  processGroupId: number | null;
   childClosed: boolean;
   childClose: Promise<void> | null;
   stopPromise: Promise<void> | null;
@@ -164,6 +165,32 @@ function signalSessionstartChild(child: ChildProcess, signal: NodeJS.Signals): v
   }
 }
 
+function sessionstartProcessGroupAlive(processGroupId: number): boolean {
+  try {
+    process.kill(-processGroupId, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function waitForSessionstartProcessGroupExit(
+  processGroupId: number,
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise((resolveWait) => {
+    const startedAt = Date.now();
+    const poll = (): void => {
+      if (!sessionstartProcessGroupAlive(processGroupId) || Date.now() - startedAt >= timeoutMs) {
+        resolveWait();
+        return;
+      }
+      setTimeout(poll, 10);
+    };
+    poll();
+  });
+}
+
 function waitForSessionstartClose(generation: SessionstartGeneration, timeoutMs: number): Promise<void> {
   if (generation.childClosed || !generation.childClose) return Promise.resolve();
   return new Promise((resolveWait) => {
@@ -180,15 +207,35 @@ function stopSessionstartGeneration(generation: SessionstartGeneration): Promise
   generation.stopping = true;
   generation.stopPromise = (async () => {
     const child = generation.child;
-    if (!child || generation.childClosed) {
+    if (process.platform === "win32") {
+      if (!child || generation.childClosed) {
+        await generation.result;
+        return;
+      }
+      signalSessionstartChild(child, "SIGTERM");
+      await waitForSessionstartClose(generation, sessionstartRetireTimeoutMs);
+      if (!generation.childClosed) {
+        signalSessionstartChild(child, "SIGKILL");
+        await waitForSessionstartClose(generation, sessionstartRetireTimeoutMs);
+      }
+      return;
+    }
+    const processGroupId = generation.processGroupId;
+    if (!processGroupId) {
       await generation.result;
       return;
     }
-    signalSessionstartChild(child, "SIGTERM");
-    await waitForSessionstartClose(generation, sessionstartRetireTimeoutMs);
-    if (!generation.childClosed) {
-      signalSessionstartChild(child, "SIGKILL");
-      await waitForSessionstartClose(generation, sessionstartRetireTimeoutMs);
+    try {
+      process.kill(-processGroupId, "SIGTERM");
+    } catch {
+    }
+    await waitForSessionstartProcessGroupExit(processGroupId, sessionstartRetireTimeoutMs);
+    if (sessionstartProcessGroupAlive(processGroupId)) {
+      try {
+        process.kill(-processGroupId, "SIGKILL");
+      } catch {
+      }
+      await waitForSessionstartProcessGroupExit(processGroupId, sessionstartRetireTimeoutMs);
     }
   })();
   return generation.stopPromise;
@@ -218,6 +265,7 @@ function runSessionstartHook(generation: SessionstartGeneration): Promise<Sessio
       return;
     }
     generation.child = child;
+    generation.processGroupId = child.pid ?? null;
     generation.childClose = new Promise<void>((resolveClose) => {
       closeChild = resolveClose;
     });
@@ -284,6 +332,7 @@ function createSessionstartGeneration(
     stopping: false,
     delivered: false,
     child: null,
+    processGroupId: null,
     childClosed: false,
     childClose: null,
     stopPromise: null,

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -388,12 +388,6 @@ async function claimSessionstartMessage(
   return sessionstartMessage(generation, result);
 }
 
-const cleanupSessionstartOnProcessExit = (): void => {
-  const generation = activeSessionstartGeneration;
-  if (generation?.child) signalSessionstartChild(generation.child, "SIGKILL");
-};
-process.once("exit", cleanupSessionstartOnProcessExit);
-
 function runGuard(): Promise<{ code: number; stderr: string }> {
   return new Promise((resolveResult) => {
     const child = spawn(`${root}/bin/fm-turnend-guard.sh`, {
@@ -440,6 +434,11 @@ function runCdCheck(command: string): Promise<{ code: number; stderr: string }> 
 
 export default function (pi: ExtensionAPI) {
   let sessionstartGeneration: SessionstartGeneration | null = null;
+  const cleanupSessionstartOnProcessExit = (): void => {
+    const generation = sessionstartGeneration;
+    if (generation?.child) signalSessionstartChild(generation.child, "SIGKILL");
+  };
+  process.once("exit", cleanupSessionstartOnProcessExit);
 
   pi.on?.("session_start", (event, ctx) => {
     const reason = String((event as { reason?: unknown }).reason ?? "");
@@ -478,7 +477,12 @@ export default function (pi: ExtensionAPI) {
 
   pi.on?.("session_shutdown", async () => {
     const generation = sessionstartGeneration;
-    if (generation) await stopSessionstartGeneration(generation);
+    try {
+      if (generation) await stopSessionstartGeneration(generation);
+    } finally {
+      if (sessionstartGeneration === generation) sessionstartGeneration = null;
+      process.removeListener("exit", cleanupSessionstartOnProcessExit);
+    }
   });
 
   pi.on("tool_call", async (event) => {

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -59,7 +59,7 @@ function markLoaded(): void {
 }
 
 // Pi's session_start reasons are startup | reload | new | resume | fork, and a
-// separate session_compact event fires after a compaction. "new" is Pi's /clear
+// separate session_compact event fires after a compaction. "new" is Pi's /new
 // while reload, resume, and fork all keep prior context.
 const sessionstartDeliveryBytes = 512 * 1024;
 

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -125,6 +125,7 @@ type SessionstartGeneration = {
   delivered: boolean;
   child: ChildProcess | null;
   processGroupId: number | null;
+  processGroupMonitor: NodeJS.Timeout | null;
   childClosed: boolean;
   childClose: Promise<void> | null;
   stopPromise: Promise<void> | null;
@@ -172,6 +173,31 @@ function sessionstartProcessGroupAlive(processGroupId: number): boolean {
   } catch {
     return false;
   }
+}
+
+function clearSessionstartProcessGroup(
+  generation: SessionstartGeneration,
+  processGroupId: number,
+): void {
+  if (generation.processGroupId !== processGroupId) return;
+  generation.processGroupId = null;
+  if (generation.processGroupMonitor) clearTimeout(generation.processGroupMonitor);
+  generation.processGroupMonitor = null;
+}
+
+function monitorSessionstartProcessGroup(
+  generation: SessionstartGeneration,
+  processGroupId: number,
+): void {
+  if (process.platform === "win32" || generation.processGroupId !== processGroupId) return;
+  if (!sessionstartProcessGroupAlive(processGroupId)) {
+    clearSessionstartProcessGroup(generation, processGroupId);
+    return;
+  }
+  generation.processGroupMonitor = setTimeout(() => {
+    monitorSessionstartProcessGroup(generation, processGroupId);
+  }, 10);
+  generation.processGroupMonitor.unref();
 }
 
 function waitForSessionstartProcessGroupExit(
@@ -225,6 +251,11 @@ function stopSessionstartGeneration(generation: SessionstartGeneration): Promise
       await generation.result;
       return;
     }
+    if (!sessionstartProcessGroupAlive(processGroupId)) {
+      clearSessionstartProcessGroup(generation, processGroupId);
+      await generation.result;
+      return;
+    }
     try {
       process.kill(-processGroupId, "SIGTERM");
     } catch {
@@ -236,6 +267,9 @@ function stopSessionstartGeneration(generation: SessionstartGeneration): Promise
       } catch {
       }
       await waitForSessionstartProcessGroupExit(processGroupId, sessionstartRetireTimeoutMs);
+    }
+    if (!sessionstartProcessGroupAlive(processGroupId)) {
+      clearSessionstartProcessGroup(generation, processGroupId);
     }
   })();
   return generation.stopPromise;
@@ -276,6 +310,8 @@ function runSessionstartHook(generation: SessionstartGeneration): Promise<Sessio
       if (generation.childClosed) return;
       generation.childClosed = true;
       if (generation.child === child) generation.child = null;
+      const processGroupId = generation.processGroupId;
+      if (processGroupId) monitorSessionstartProcessGroup(generation, processGroupId);
       closeChild();
     };
     child.stdout?.on("data", (chunk: Buffer) => {
@@ -333,6 +369,7 @@ function createSessionstartGeneration(
     delivered: false,
     child: null,
     processGroupId: null,
+    processGroupMonitor: null,
     childClosed: false,
     childClose: null,
     stopPromise: null,
@@ -445,6 +482,10 @@ export default function (pi: ExtensionAPI) {
     const processGroupId = generation.processGroupId;
     if (!processGroupId) {
       if (generation.child) signalSessionstartChild(generation.child, "SIGKILL");
+      return;
+    }
+    if (!sessionstartProcessGroupAlive(processGroupId)) {
+      clearSessionstartProcessGroup(generation, processGroupId);
       return;
     }
     try {

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -255,7 +255,7 @@ function runSessionstartHook(generation: SessionstartGeneration): Promise<Sessio
     let child: ChildProcess;
     try {
       child = spawn(
-        supervised ? process.execPath : runner,
+        supervised ? "node" : runner,
         supervised
           ? [
               `${extensionDir}/lib/fm-sessionstart-supervisor.mjs`,
@@ -289,7 +289,7 @@ function runSessionstartHook(generation: SessionstartGeneration): Promise<Sessio
     const unrefSupervisor = (): void => {
       if (!supervised) return;
       child.unref();
-      child.channel?.unref();
+      child.channel?.unref?.();
       const stdout = child.stdout as (NodeJS.ReadableStream & { unref?: () => void }) | null;
       stdout?.unref?.();
     };

--- a/.pi/extensions/lib/fm-sessionstart-supervisor.mjs
+++ b/.pi/extensions/lib/fm-sessionstart-supervisor.mjs
@@ -1,0 +1,43 @@
+import { spawn } from "node:child_process";
+
+const [runner, ...args] = process.argv.slice(2);
+let runnerCode;
+let outputBytes = 0;
+let pendingWrites = 0;
+let resultSent = false;
+
+const sendResult = () => {
+  if (resultSent || runnerCode === undefined || pendingWrites !== 0) return;
+  resultSent = true;
+  process.send?.({ type: "result", code: runnerCode, bytes: outputBytes });
+};
+
+process.on("SIGTERM", () => {});
+process.on("disconnect", () => {
+  try {
+    process.kill(-process.pid, "SIGKILL");
+  } catch {
+    process.exit(1);
+  }
+});
+
+const child = spawn(runner, args, {
+  env: { ...process.env, FM_SESSIONSTART_SUPERVISOR_PID: String(process.pid) },
+  stdio: ["ignore", "pipe", "ignore"],
+});
+child.stdout.on("data", (chunk) => {
+  outputBytes += chunk.length;
+  pendingWrites += 1;
+  process.stdout.write(chunk, () => {
+    pendingWrites -= 1;
+    sendResult();
+  });
+});
+child.on("error", () => {
+  runnerCode = null;
+  sendResult();
+});
+child.on("close", (code) => {
+  runnerCode = code;
+  sendResult();
+});

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -159,14 +159,16 @@
 # status log path, and AGENTS.md section 8 treats a status line as a wake EVENT
 # rather than current state - bin/fm-crew-state.sh owns current state.
 #
-# RUNTIME BOUND: the digest is now executed on a session-open hook (see
-# bin/fm-sessionstart-run.sh), which blocks session initialization while it
-# runs, so an unbounded digest is no longer merely slow - it can strand a whole
-# session behind one hung subprocess. Every remaining step is local, but local is
-# not the same as bounded: tool version probes, the backlog listing, and the
-# per-task endpoint reads are all unbounded subprocesses. So the whole digest
-# still runs as ONE bounded child of this script (FM_SESSION_START_TIMEOUT,
-# default 120s). The deferred network stage deliberately sits OUTSIDE that bound,
+# RUNTIME BOUND: the digest is now executed through a native session-open
+# adapter (see bin/fm-sessionstart-run.sh), which blocks either hook-driven
+# session initialization or Pi's first provider preflight while it runs, so an
+# unbounded digest is no longer merely slow - it can strand a whole session or
+# first turn behind one hung subprocess. Every remaining step is local, but
+# local is not the same as bounded: tool version probes, the backlog listing,
+# and the per-task endpoint reads are all unbounded subprocesses. So the whole
+# digest still runs as ONE bounded child of this script
+# (FM_SESSION_START_TIMEOUT, default 120s). The deferred network stage
+# deliberately sits OUTSIDE that bound,
 # in its own process group under its own aggregate deadline, so a truncated
 # digest neither waits for it nor orphans it unbounded. The
 # child writes the digest straight to this script's stdout, so everything it

--- a/bin/fm-sessionstart-run.sh
+++ b/bin/fm-sessionstart-run.sh
@@ -10,12 +10,17 @@
 # model context, running the digest here removes that discretion - the helm is
 # taken before the model's first turn, whatever the first turn is.
 #
-# Usage: fm-sessionstart-run.sh [--source <source>]
+# Usage: fm-sessionstart-run.sh [--source <source>] [--pi-prerequisite]
 #   --source  The harness's own session-open source. When omitted, the source is
 #             read from a Claude/Codex-shaped JSON hook payload on stdin
 #             (the `source` field). An unreadable or unrecognized source is
 #             treated as `startup`, because taking the helm redundantly is
 #             cheap and idempotent while not taking it is the whole bug.
+#   --pi-prerequisite
+#             Internal Pi extension mode. An intentional gate/scope stand-down
+#             exits 3 so provider preflight can distinguish it from an eligible
+#             native attempt that settled without output. Every ordinary hook
+#             invocation retains the always-zero compatibility contract below.
 #
 # Source routing (see docs/sessionstart-nudge.md for the per-harness names):
 #   startup, new            full digest - this process has not taken the helm
@@ -28,12 +33,14 @@
 #                           silent) and a plain instruction is enough when a new
 #                           process resumed an old session (the nudge fires).
 #
-# Every path exits 0, exactly like the nudge wrapper: a Claude SessionStart
-# exit 2 blocks session initialization, so a failed session start must reach the
-# agent as digest text it can act on, never as a refusal to open the session.
-# A lock another live session holds and a truncated digest are reported inside
-# the digest, while broken GitHub auth arrives through the deferred network
-# result inline or as a wake, for exactly that reason.
+# Every ordinary transport path exits 0, exactly like the nudge wrapper: a
+# Claude SessionStart exit 2 blocks session initialization, so a failed session
+# start must reach the agent as digest text it can act on, never as a refusal to
+# open the session. The internal Pi prerequisite's silent exit 3 never reaches a
+# harness hook; it only distinguishes intentional ineligibility before provider
+# preflight. A lock another live session holds and a truncated digest are
+# reported inside the digest, while broken GitHub auth arrives through the
+# deferred network result inline or as a wake, for exactly that reason.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -52,6 +59,7 @@ COMPLETION_FILE="$STATE/.session-start-complete"
 . "$SCRIPT_DIR/fm-hook-host-lib.sh"
 
 SOURCE=
+PI_PREREQUISITE=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --source)
@@ -61,15 +69,24 @@ while [ $# -gt 0 ]; do
       if [ $# -ge 2 ]; then shift 2; else shift; fi
       ;;
     --source=*) SOURCE=${1#--source=}; shift ;;
+    --pi-prerequisite) PI_PREREQUISITE=1; shift ;;
     *) shift ;;
   esac
 done
 
+stand_down() {
+  if [ "$PI_PREREQUISITE" = 1 ]; then
+    exit 3
+  fi
+  exit 0
+}
+
 # The same two eligibility owners the nudge wrapper uses, so a no-mistakes gate
 # agent and an unmarked task worktree can never run a session start for a home
-# they do not own.
-fm_is_gate_agent "$FM_ROOT" && exit 0
-fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
+# they do not own. Pi's preflight-only status preserves that intentional silence
+# without mistaking it for a failed eligible attempt that needs the manual nudge.
+fm_is_gate_agent "$FM_ROOT" && stand_down
+fm_primary_scope_matches "$FM_ROOT" "$STATE" || stand_down
 
 session_start_completed() {
   local lock_pid completion_pid

--- a/bin/fm-sessionstart-run.sh
+++ b/bin/fm-sessionstart-run.sh
@@ -6,9 +6,10 @@
 #
 # Why running beats nudging: bin/fm-sessionstart-nudge.sh can only ASK the agent
 # to take the helm, and an agent can defer that, including when a first-command
-# skill has its own read-only path. When the harness injects hook stdout into
-# model context, running the digest here removes that discretion - the helm is
-# taken before the model's first turn, whatever the first turn is.
+# skill has its own read-only path. When the native adapter injects this
+# command's stdout into model context, running the digest here removes that
+# discretion - the helm is taken before the model's first turn, whatever the
+# first turn is.
 #
 # Usage: fm-sessionstart-run.sh [--source <source>] [--pi-prerequisite]
 #   --source  The harness's own session-open source. When omitted, the source is

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -40,7 +40,7 @@ On a run-tier harness the nudge cannot also fire: `resume`, `reload`, and `fork`
 
 ## Runtime bound
 
-The run tier blocks session initialization while the digest runs, so `bin/fm-session-start.sh` bounds itself rather than betting on each harness's own hook timeout.
+The run tier blocks either hook-driven session initialization or Pi's first provider preflight while the digest runs, so `bin/fm-session-start.sh` bounds itself rather than betting on an unbounded prerequisite.
 The digest makes no external-network call at all: every one it owes runs off the blocking path in the separately bounded deferred stage owned by `bin/fm-startup-network.sh`, so an unreachable host can no longer consume this budget.
 What remains is still not individually bounded - tool version probes, the backlog listing, and the per-task endpoint reads are all local but unbounded subprocesses - so the whole digest runs as one bounded child, default 120s via `FM_SESSION_START_TIMEOUT`.
 The shared timeout owner falls back to a pure-Bash process-group watchdog when timeout, gtimeout, and perl are unavailable, so no supported host runs the digest unbounded.
@@ -60,7 +60,8 @@ The Ahoy skill owns the rule that this marked operational input is never a capta
 
 Before printing, the nudge wrapper reads `state/.lock` and walks at most eight parents from its own pid in its own separate, hard-coded loop, independent of `bin/fm-lock.sh`'s ancestry walk (`fm_harness_ancestry_pid()` in `bin/fm-session-lock-lib.sh`, which now walks up to sixteen parents and can extend past a claude-named match to a still-more-ancestral one) and of Pi's `lockOwnership()`.
 If the lock names a live pid in that ancestry, session start already ran in this harness session and the wrapper stays silent.
-Every path in both wrappers exits 0, including malformed state and adapter errors, because a Claude SessionStart exit 2 blocks session initialization.
+Every ordinary transport path in both wrappers exits 0, including malformed state and adapter errors, because a Claude SessionStart exit 2 blocks session initialization.
+The run wrapper's internal `--pi-prerequisite` mode uses silent exit 3 only for an intentional gate or scope stand-down, letting Pi distinguish ineligibility from an eligible empty native result without changing any harness hook's exit contract.
 A lock another session holds and a truncated digest therefore surface as digest text, while broken GitHub auth surfaces through the deferred network result inline or as a wake; none becomes a refusal to open the session.
 
 ## Harness transports
@@ -70,7 +71,7 @@ A lock another session holds and a truncated digest therefore surface as digest 
 | Claude | Run | `.claude/settings.json` registers one unmatched `SessionStart` hook, invoked through `CLAUDE_PROJECT_DIR` with a 180s timeout; the wrapper reads `source` from the hook payload. | Native stdout context injection is supported. |
 | Codex exec | Run | `.codex/hooks.json` anchors to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and pipes the hook payload into the wrapper with a 180s timeout. | Native stdout context injection is supported under `codex exec`. |
 | Codex interactive TUI | Uncovered | None. | Codex 0.146.0 does not fire the tracked project `SessionStart` hook in its interactive TUI; Firstmate ships no global hook, has no tracked compaction or re-emit channel, and does not claim instruction-refresh delivery for this surface. |
-| Pi / pi-signed | Run | `.pi/extensions/fm-primary-turnend-guard.ts` maps `session_start` reasons `startup`, `new`, `resume`, and `fork` onto wrapper sources, refines a Pi-reported `startup` to `resume` only when a continuation, resume-selection, or explicit-session flag accompanies a session header older than the current process, maps a fork flag to `fork`, handles `session_compact` as the compaction equivalent, and injects the output with `pi.sendMessage`; setup-created entries such as `--name` are not restoration evidence. | The custom message reaches model context without racing an initial positional prompt; Pi's `reload` reason is deliberately unmapped, as it always was. |
+| Pi / pi-signed | Run | `.pi/extensions/fm-primary-turnend-guard.ts` maps `session_start` reasons `startup`, `new`, `resume`, and `fork` onto wrapper sources, refines a Pi-reported `startup` to `resume` only when a continuation, resume-selection, or explicit-session flag accompanies a session header older than the current process, maps a fork flag to `fork`, and handles `session_compact` as the compaction equivalent; setup-created entries such as `--name` are not restoration evidence. | Each session generation starts one native prerequisite, and `before_agent_start` awaits its matching result and returns one persistent context message before the first provider call; Pi's `reload` reason is deliberately unmapped, as it always was. |
 | OpenCode | Nudge | `.opencode/plugins/fm-primary-sessionstart-nudge.js` listens for `session.created`, runs once per session id, and calls `client.session.promptAsync` only when the wrapper prints a nudge. | Interactive TUI delivery is supported; headless `opencode run` is intentionally fail-open because the process can exit before the queued turn. That early exit is also why OpenCode cannot use the run tier. |
 | Grok | Nudge | `.grok/hooks/fm-primary-sessionstart-nudge.json` registers a project `SessionStart` hook and invokes the wrapper through inline-defaulted `${GROK_WORKSPACE_ROOT:-}`. | The project hook runs when the checkout is trusted, but Grok currently discards hook stdout from model context, so this path is intentionally fail-open and cannot use the run tier. |
 | Cursor | Run | `.cursor/hooks.json` registers `sessionStart`, anchored through `$CURSOR_PROJECT_DIR` with a 180s timeout, invoking `bin/fm-sessionstart-cursor.sh`. | Cursor's payload has no `source` field, so the registration supplies `--source` itself, and the adapter returns the digest as `additional_context`. Project hooks load only when the workspace is launched with `--trust`. |
@@ -80,7 +81,12 @@ Cursor's `sessionStart` fires at every session open with no source distinction, 
 Cursor's compaction surface is uncovered in the same sense as Codex's interactive TUI above: Firstmate registers nothing for `preCompact`, so a compacted Cursor session keeps whatever context survived rather than receiving a fresh digest.
 
 Pi is the only adapter that injects a message rather than hook stdout, so whatever it injects must carry operational provenance or the Ahoy skill would have to guess whether it was captain-authored.
-The extension therefore encodes an unencoded digest as `session-start` operational input before sending it, and leaves the already-encoded nudge alone.
+For `session_start`, the extension activates a session-id and monotonic-generation owner synchronously, starts the wrapper once, and makes `before_agent_start` await that same promise before returning Pi's persistent `message` result.
+Replacement or shutdown stops the matching process group, and stale generations cannot deliver into the active session.
+An eligible native failure or empty result settles before the extension returns the existing exact manual instruction, so native and manual startup never run concurrently.
+An intentional gate or non-primary stand-down returns no message, and context-preserving sources retain their existing silent result when the current process already holds the lock.
+Manual and automatic compaction retain the existing persistent delivery path because an automatic retry may have no new `before_agent_start`, but that path shares the same generation cancellation and exactly-once claim.
+The extension encodes an unencoded digest or fallback as `session-start` operational input and leaves an already-encoded nudge alone.
 It streams the hook to completion and retains at most 512 KiB for message delivery; this approved containment keeps the prefix and appends a loud `PI SESSION-START DELIVERY TRUNCATED` marker with direct-inspection guidance whenever the digest is incomplete.
 
 The OpenCode nudge runs only on `session.created`.
@@ -92,14 +98,16 @@ That alternative expands trust and writes outside this repository, so Firstmate 
 ## Regression coverage
 
 `tests/fm-sessionstart-nudge.test.sh` proves the nudge wrapper's silence for both gate signals, an unmarked linked worktree, a missing state directory, and an already-owned lock, plus its exact U+2063 `FIRSTMATE_OP:`-prefixed, `session-start`-typed one-line output.
-It separately proves the run wrapper's silence for the gate environment and an unmarked linked worktree.
+It separately proves the run wrapper's silence for the gate environment and an unmarked linked worktree, including the internal Pi prerequisite's explicit silent stand-down.
 It proves the run wrapper's source routing end to end against a real `fm-session-start.sh`, including completion-gated `--reemit` selection, resume delegation, Pi CLI continuation classification, an unrecognized source falling through to the full digest, and bounded loud delivery of an oversized Pi digest.
+The same portable suite proves provider exclusion until settlement, exactly-one execution and context delivery, interruption, process-tree retirement, two rapid replacements, stale completion, eligible empty output, spawn error, wrapper timeout output, truncation, ineligible stand-down, and compaction cancellation through the extension's public event surface.
 `tests/fm-session-start.test.sh` proves the runtime bound through the forced pure-Bash fallback: a TERM-resistant digest that exceeds its budget is force-killed with its grandchild, still emits its completed stages, names the incomplete stage and every stage it never reached, leaves no completion proof, and exits 0.
 `tests/fm-pi-primary-live-e2e.test.sh` and `tests/fm-opencode-primary-live-e2e.test.sh` exercise native startup paths with first-message and later-message Ahoy regressions.
 `tests/fm-cursor-primary.test.sh` proves the Cursor adapter over real processes: `sessionStart` emits the whole digest as `additional_context` with a caller-supplied `--source`, stays silent in a child worktree, lets the run wrapper stand down on the Cursor-delivered duplicate, and keeps `preCompact` unregistered so the deferred surface cannot be reintroduced unnoticed.
 `FM_CURSOR_PRIMARY_LIVE_E2E=1 tests/fm-cursor-primary-live-e2e.test.sh` proves the injected digest actually reaches model context in a real cursor-agent session.
 `tests/fm-sessionstart-hook-live-e2e.test.sh` is the opt-in live guard for the Claude, Codex exec, and Pi run-tier adapters; it confirms each installed adapter in that suite invokes the run wrapper and delivers its output into context.
 It verifies context-preserving reopen sources for those adapters and context-reset delivery wherever their tracked TUI surface is reachable.
+Its separate `FM_PI_SESSIONSTART_RACE_LIVE_E2E=1` mode uses real Pi with an offline deterministic provider and a barrier-controlled `/new` digest, proving both an immediate prompt and a completed-before-prompt control make their first provider call with exactly one native startup context and no manual execution.
 Cursor uses the separate primary live guard named above because its source-free `sessionStart` and stop-hook park are validated together.
 `tests/fm-sessionstart-instruction-refresh-live-e2e.test.sh` is the separate opt-in real-Pi guard for a post-start AGENTS.md update followed by compaction.
 `tests/fm-turnend-guard.test.sh`, `tests/fm-pi-watch-extension.test.sh`, and `tests/fm-daemon.test.sh` cover marked guard, monitoring, and away-mode delivery.

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -7,13 +7,13 @@ Firstmate ships two session-open tiers, and the tier is a property of the harnes
 
 | Tier | What the adapter does | Used by |
 | --- | --- | --- |
-| Run | Executes `bin/fm-session-start.sh` in the hook and lets its ordered digest land in model context before the first turn. | Claude, `codex exec`, Pi / pi-signed, Cursor |
+| Run | Executes `bin/fm-session-start.sh` through the native session-open adapter and gates its ordered digest into model context before the first turn. | Claude, `codex exec`, Pi / pi-signed, Cursor |
 | Nudge | Asks the agent to run the digest through the native adapter or the tracked session-start instruction. | Grok, OpenCode, and run-tier sources routed to the nudge |
 
 Codex's interactive TUI has no tracked session-open, compaction, or re-emit channel and is not covered by either tier.
 The run tier exists because the nudge can only ask.
 An agent can defer an instruction, including when a first-command skill has its own read-only path.
-Running the digest inside the hook removes that discretion, so even a session whose first command is a skill has already taken the helm.
+Running the digest through the native adapter removes that discretion, so even a session whose first command is a skill has already taken the helm.
 The nudge tier remains the floor for harnesses that cannot carry hook stdout into model context, and it is never a second contract: both tiers end in the same `bin/fm-session-start.sh`.
 
 ## Source routing
@@ -44,7 +44,7 @@ The run tier blocks either hook-driven session initialization or Pi's first prov
 The digest makes no external-network call at all: every one it owes runs off the blocking path in the separately bounded deferred stage owned by `bin/fm-startup-network.sh`, so an unreachable host can no longer consume this budget.
 What remains is still not individually bounded - tool version probes, the backlog listing, and the per-task endpoint reads are all local but unbounded subprocesses - so the whole digest runs as one bounded child, default 120s via `FM_SESSION_START_TIMEOUT`.
 The shared timeout owner falls back to a pure-Bash process-group watchdog when timeout, gtimeout, and perl are unavailable, so no supported host runs the digest unbounded.
-Because the child writes straight to the hook's stdout, everything emitted before the bound was hit is already delivered; the parent then prints a `STARTUP TRUNCATED` banner naming the stage that did not finish and the stages that were therefore never emitted, and still exits 0.
+Because the child streams into the native transport as it runs, everything emitted before the bound was hit is retained for delivery; the parent then prints a `STARTUP TRUNCATED` banner naming the stage that did not finish and the stages that were therefore never emitted, and still exits 0.
 The registered hook timeouts sit above that budget so the harness never preempts the banner.
 The deferred network stage deliberately runs in its own process group under its own deadline, so a truncated digest neither kills work it was not waiting for nor orphans unbounded network work.
 
@@ -71,7 +71,7 @@ A lock another session holds and a truncated digest therefore surface as digest 
 | Claude | Run | `.claude/settings.json` registers one unmatched `SessionStart` hook, invoked through `CLAUDE_PROJECT_DIR` with a 180s timeout; the wrapper reads `source` from the hook payload. | Native stdout context injection is supported. |
 | Codex exec | Run | `.codex/hooks.json` anchors to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and pipes the hook payload into the wrapper with a 180s timeout. | Native stdout context injection is supported under `codex exec`. |
 | Codex interactive TUI | Uncovered | None. | Codex 0.146.0 does not fire the tracked project `SessionStart` hook in its interactive TUI; Firstmate ships no global hook, has no tracked compaction or re-emit channel, and does not claim instruction-refresh delivery for this surface. |
-| Pi / pi-signed | Run | `.pi/extensions/fm-primary-turnend-guard.ts` maps `session_start` reasons `startup`, `new`, `resume`, and `fork` onto wrapper sources, refines a Pi-reported `startup` to `resume` only when a continuation, resume-selection, or explicit-session flag accompanies a session header older than the current process, maps a fork flag to `fork`, and handles `session_compact` as the compaction equivalent; setup-created entries such as `--name` are not restoration evidence. | Each session generation starts one native prerequisite, and `before_agent_start` awaits its matching result and returns one persistent context message before the first provider call; Pi's `reload` reason is deliberately unmapped, as it always was. |
+| Pi / pi-signed | Run | `.pi/extensions/fm-primary-turnend-guard.ts` maps `session_start` reasons `startup`, `new`, `resume`, and `fork` onto wrapper sources, refines a Pi-reported `startup` to `resume` only when a continuation, resume-selection, or explicit-session flag accompanies a session header older than the current process, maps a fork flag to `fork`, and handles `session_compact` as the compaction equivalent; setup-created entries such as `--name` are not restoration evidence. | Each mapped session generation starts one native prerequisite, and `before_agent_start` awaits its matching result and returns one persistent context message before the first provider call; Pi's `reload` reason is deliberately unmapped, as it always was. |
 | OpenCode | Nudge | `.opencode/plugins/fm-primary-sessionstart-nudge.js` listens for `session.created`, runs once per session id, and calls `client.session.promptAsync` only when the wrapper prints a nudge. | Interactive TUI delivery is supported; headless `opencode run` is intentionally fail-open because the process can exit before the queued turn. That early exit is also why OpenCode cannot use the run tier. |
 | Grok | Nudge | `.grok/hooks/fm-primary-sessionstart-nudge.json` registers a project `SessionStart` hook and invokes the wrapper through inline-defaulted `${GROK_WORKSPACE_ROOT:-}`. | The project hook runs when the checkout is trusted, but Grok currently discards hook stdout from model context, so this path is intentionally fail-open and cannot use the run tier. |
 | Cursor | Run | `.cursor/hooks.json` registers `sessionStart`, anchored through `$CURSOR_PROJECT_DIR` with a 180s timeout, invoking `bin/fm-sessionstart-cursor.sh`. | Cursor's payload has no `source` field, so the registration supplies `--source` itself, and the adapter returns the digest as `additional_context`. Project hooks load only when the workspace is launched with `--trust`. |

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -85,7 +85,7 @@ Their continuation classification is covered by portable tests, not claimed as l
 
 ### Pi `/new` provider prerequisite
 
-The real offline Pi regression ran on 2026-08-27 with Pi 0.84.0, an isolated home and session directory, a barrier-controlled native digest, and a deterministic local `streamSimple` provider.
+The real offline Pi regression ran on 2026-08-26 with Pi 0.84.0, an isolated home and session directory, a barrier-controlled native digest, and a deterministic local `streamSimple` provider.
 The provider makes no HTTP request and requires no user credential.
 Its missing-native branch deliberately requests `bin/fm-session-start.sh`, so an escaped first call reproduces the duplicate-producing manual path rather than passing vacuously.
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -44,8 +44,8 @@ pi -p -e .pi/extensions/fm-primary-turnend-guard.ts \
 ```
 
 Observed result: `PI_SMOKE_DONE`, with one session-start execution.
-The earlier `sendUserMessage` counterfactual raced the positional prompt; the current non-triggering `pi.sendMessage` custom message did not.
-The installed pi-signed 0.82.0 wrapper repeated the Pi primary extension and session-start path on 2026-07-27.
+That cold positional-prompt check established eventual custom-message delivery, but it did not submit immediately after `/new` while native digest generation was still running, so its earlier race-free inference is superseded by the provider-prerequisite evidence below.
+The installed pi-signed 0.82.0 wrapper repeated the shared Pi primary extension and session-start path on 2026-07-27.
 [`runtime-backends.md`](runtime-backends.md#tmux) owns the shared-ancestry evidence and authoritative selection-marker boundary.
 
 ### Run-tier source vocabulary and context-reset injection
@@ -82,6 +82,30 @@ compact
 Pi disagrees with Claude and Codex on `resume`: a new Pi process continuing a session reports `startup`, and Pi's `resume` reason is reserved for an in-process session switch.
 The current adapter classification and baseline mechanics are owned by [`../sessionstart-nudge.md`](../sessionstart-nudge.md#harness-transports) and the `bin/fm-session-start.sh` header.
 Their continuation classification is covered by portable tests, not claimed as live validation in this record.
+
+### Pi `/new` provider prerequisite
+
+The real offline Pi regression ran on 2026-08-27 with Pi 0.84.0, an isolated home and session directory, a barrier-controlled native digest, and a deterministic local `streamSimple` provider.
+The provider makes no HTTP request and requires no user credential.
+Its missing-native branch deliberately requests `bin/fm-session-start.sh`, so an escaped first call reproduces the duplicate-producing manual path rather than passing vacuously.
+
+```sh
+FM_PI_SESSIONSTART_RACE_LIVE_E2E=1 \
+  tests/fm-sessionstart-hook-live-e2e.test.sh
+```
+
+Observed output:
+
+```text
+ok - Pi 0.84.0: immediate and completed-before-prompt /new paths each made one first provider call with exactly one native startup context and no manual execution
+# fm-sessionstart-hook-live-e2e.test.sh: offline Pi /new race assertions passed
+```
+
+The immediate case submitted its first prompt only after the native `clear` child published `started`, held the child behind a release barrier, and proved the provider log remained absent for 500 milliseconds before release.
+After release, the first payload reported one native context and no manual result, the session persisted one matching custom message, and the fixture recorded one native execution.
+The control case let native generation complete before prompt submission and produced the same first-payload result.
+The portable public-event regression in `tests/fm-sessionstart-nudge.test.sh` separately covers interruption, process-tree retirement, two rapid replacements, stale completion, empty output, spawn error, timeout output, truncation, ineligible stand-down, and compaction cancellation.
+Pi and pi-signed load the same tracked extension bytes; pi-signed was not installed on this host for a separate 0.84.0 live rerun.
 
 ### Post-start instruction refresh
 
@@ -158,6 +182,7 @@ tests/fm-sessionstart-nudge.test.sh
 tests/fm-session-start.test.sh
 tests/fm-startup-network.test.sh
 FM_SESSIONSTART_HOOK_LIVE_E2E=1 tests/fm-sessionstart-hook-live-e2e.test.sh
+FM_PI_SESSIONSTART_RACE_LIVE_E2E=1 tests/fm-sessionstart-hook-live-e2e.test.sh
 FM_SESSIONSTART_INSTRUCTION_REFRESH_LIVE_E2E=1 tests/fm-sessionstart-instruction-refresh-live-e2e.test.sh
 FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh
 FM_OPENCODE_LIVE_E2E=1 tests/fm-opencode-primary-live-e2e.test.sh

--- a/tests/fm-sessionstart-hook-live-e2e.test.sh
+++ b/tests/fm-sessionstart-hook-live-e2e.test.sh
@@ -33,11 +33,16 @@
 #
 #   FM_SESSIONSTART_HOOK_LIVE_E2E=1 tests/fm-sessionstart-hook-live-e2e.test.sh
 #
-# It costs real model turns on every installed adapter in this suite.
+# That mode costs real model turns on every installed adapter in this suite.
+# The Pi `/new` provider-prerequisite regression has a separate offline mode
+# using a deterministic local provider and no user credentials:
+#
+#   FM_PI_SESSIONSTART_RACE_LIVE_E2E=1 tests/fm-sessionstart-hook-live-e2e.test.sh
 set -u
 
-if [ "${FM_SESSIONSTART_HOOK_LIVE_E2E:-0}" != 1 ]; then
-  echo "skip: set FM_SESSIONSTART_HOOK_LIVE_E2E=1 to run the live session-open hook regression"
+if [ "${FM_SESSIONSTART_HOOK_LIVE_E2E:-0}" != 1 ] && \
+   [ "${FM_PI_SESSIONSTART_RACE_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_SESSIONSTART_HOOK_LIVE_E2E=1 for the cross-harness guard or FM_PI_SESSIONSTART_RACE_LIVE_E2E=1 for the offline Pi /new race regression"
   exit 0
 fi
 
@@ -319,6 +324,266 @@ probe_context_reset() {  # <harness> <version> <lab> <clear-command> <launch-arg
 
   tmux -L "$SOCKET" kill-session -t "$session" >/dev/null 2>&1 || true
 }
+
+# --- real Pi provider prerequisite -------------------------------------------
+#
+# This is the end-user `/new` path, not an SDK simulation. A barrier holds the
+# native clear digest open while the first prompt is submitted. The local
+# provider would deterministically request the manual startup command if that
+# first payload lacked native context, reproducing the historical duplicate.
+# The fixed path must make no provider call before release and must expose one
+# native message on the first call. A second case proves the already-complete
+# path reaches the same result.
+probe_pi_sessionstart_prerequisite() {
+  local version lab project home config sessions session=pi-race
+  local pane i session_file first_line second_line
+  command -v pi >/dev/null 2>&1 || fail "pi not found for the offline /new provider-prerequisite regression"
+  version=$(pi --version 2>/dev/null | head -n 1)
+  [ -n "$version" ] || version=unknown
+  lab="$LAB/pi-race"
+  project="$lab/project"
+  home="$lab/home"
+  config="$lab/config"
+  sessions="$lab/sessions"
+  mkdir -p "$project/.pi/extensions/lib" "$project/bin" "$home/state" "$config" "$sessions"
+  git init -q -b main "$project"
+  git -C "$project" config user.email fmtest@example.invalid
+  git -C "$project" config user.name fmtest
+  printf '# Offline Pi startup-prerequisite lab\n' > "$project/AGENTS.md"
+  cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$project/.pi/extensions/"
+  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$project/.pi/extensions/lib/"
+  cp "$ROOT/bin/fm-operational-input.sh" "$project/bin/"
+  cat > "$project/bin/fm-turnend-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$project/bin/fm-sessionstart-run.sh" <<'SH'
+#!/usr/bin/env bash
+set -u
+state=${FM_HOME:?}/state
+source_name=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source) source_name=${2:-}; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ "$source_name" != clear ]; then
+  printf 'INITIAL_STARTUP source=%s\n' "$source_name"
+  exit 0
+fi
+count=$(( $(grep -c '^clear-start:' "$state/events" 2>/dev/null || true) + 1 ))
+printf 'clear-start:%s:%s\n' "$count" "$$" >> "$state/events"
+: > "$state/native-started-$count"
+while [ ! -f "$state/release-native-$count" ]; do sleep 0.02; done
+printf 'RACE_NATIVE generation=%s\n' "$count"
+: > "$state/native-completed-$count"
+printf 'clear-complete:%s:%s\n' "$count" "$$" >> "$state/events"
+SH
+  cat > "$project/bin/fm-session-start.sh" <<'SH'
+#!/usr/bin/env bash
+set -u
+state=${FM_HOME:?}/state
+: > "$state/manual-started"
+printf 'RACE_MANUAL\n'
+SH
+  cat > "$project/.pi/extensions/race-local-provider.ts" <<'TS'
+import { appendFileSync } from "node:fs";
+import {
+  type AssistantMessage,
+  createAssistantMessageEventStream,
+} from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+function textOf(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((item): item is { type: "text"; text: string } =>
+      typeof item === "object" && item !== null &&
+      (item as { type?: unknown }).type === "text" &&
+      typeof (item as { text?: unknown }).text === "string")
+    .map((item) => item.text)
+    .join("\n");
+}
+
+function assistant(model: { api: string; provider: string; id: string }): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+export default function (pi: ExtensionAPI): void {
+  pi.registerProvider("race-local", {
+    baseUrl: "http://127.0.0.1/unused",
+    apiKey: "offline-test-only",
+    api: "race-local-api",
+    models: [{
+      id: "deterministic",
+      name: "Deterministic startup prerequisite provider",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 16384,
+      maxTokens: 128,
+    }],
+    streamSimple(model, context) {
+      const stream = createAssistantMessageEventStream();
+      const texts = context.messages.map((message) => textOf(message.content));
+      const all = texts.join("\n");
+      const prompt = all.includes("IMMEDIATE_RACE_PROMPT")
+        ? "immediate"
+        : all.includes("PROVEN_RACE_PROMPT")
+          ? "proven"
+          : "other";
+      const nativeCount = texts.filter((text) => text.includes("RACE_NATIVE generation=")).length;
+      const manual = all.includes("RACE_MANUAL");
+      if (prompt !== "other") {
+        appendFileSync(
+          `${process.env.FM_HOME}/state/provider-calls`,
+          `prompt=${prompt} native_count=${nativeCount} manual=${manual}\n`,
+        );
+      }
+      const output = assistant(model);
+      queueMicrotask(() => {
+        stream.push({ type: "start", partial: output });
+        if (prompt !== "other" && nativeCount === 0 && !manual) {
+          output.stopReason = "toolUse";
+          const toolCall = {
+            type: "toolCall" as const,
+            id: `manual-${Date.now()}`,
+            name: "bash",
+            arguments: { command: "bin/fm-session-start.sh" },
+          };
+          output.content.push(toolCall);
+          stream.push({ type: "toolcall_start", contentIndex: 0, partial: output });
+          stream.push({
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: JSON.stringify(toolCall.arguments),
+            partial: output,
+          });
+          stream.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial: output });
+          stream.push({ type: "done", reason: "toolUse", message: output });
+          stream.end();
+          return;
+        }
+        const responseText = `RACE_RESULT prompt=${prompt} native_count=${nativeCount} manual=${manual}`;
+        const block = { type: "text" as const, text: responseText };
+        output.content.push(block);
+        stream.push({ type: "text_start", contentIndex: 0, partial: output });
+        stream.push({ type: "text_delta", contentIndex: 0, delta: responseText, partial: output });
+        stream.push({ type: "text_end", contentIndex: 0, content: responseText, partial: output });
+        stream.push({ type: "done", reason: "stop", message: output });
+        stream.end();
+      });
+      return stream;
+    },
+  });
+}
+TS
+  chmod +x "$project/bin/"*.sh
+  git -C "$project" add -A
+  git -C "$project" commit -q -m init
+
+  tmux -L "$SOCKET" new-session -d -s "$session" -c "$project" -x 180 -y 50 \
+    "env FM_HOME='$home' FM_ROOT_OVERRIDE='$project' PI_CODING_AGENT_DIR='$config' PI_OFFLINE=1 pi --approve --session-dir '$sessions' --no-context-files --no-skills --no-prompt-templates --tools bash --model race-local/deterministic; rc=\$?; printf '\nPI_EXIT=%s\n' \"\$rc\"; sleep 60" \
+    || fail "Pi $version: could not start the offline /new lab"
+  i=0
+  while [ "$i" -lt 200 ]; do
+    pane=$(capture "$session")
+    printf '%s\n' "$pane" | grep -Fq 'race-local-provider.ts' && \
+      printf '%s\n' "$pane" | grep -Fq 'deterministic' && break
+    sleep 0.05
+    i=$((i + 1))
+  done
+  printf '%s\n' "$pane" | grep -Fq 'deterministic' \
+    || { printf '%s\n' "$pane" >&2; fail "Pi $version: offline local provider did not reach the ready composer"; }
+
+  tmux -L "$SOCKET" send-keys -t "$session" -l /new
+  tmux -L "$SOCKET" send-keys -t "$session" Enter
+  i=0
+  while [ "$i" -lt 500 ] && [ ! -f "$home/state/native-started-1" ]; do sleep 0.01; i=$((i + 1)); done
+  [ -f "$home/state/native-started-1" ] \
+    || { capture "$session" >&2; fail "Pi $version: immediate /new native generation never started"; }
+  tmux -L "$SOCKET" send-keys -t "$session" -l IMMEDIATE_RACE_PROMPT
+  tmux -L "$SOCKET" send-keys -t "$session" Enter
+  sleep 0.5
+  [ ! -s "$home/state/provider-calls" ] \
+    || fail "Pi $version: the immediate first provider call escaped before native startup settled"
+  [ ! -f "$home/state/manual-started" ] \
+    || fail "Pi $version: manual startup ran concurrently with the native generation"
+  : > "$home/state/release-native-1"
+  i=0
+  while [ "$i" -lt 1000 ] && ! grep -Fq 'prompt=immediate native_count=1 manual=false' "$home/state/provider-calls" 2>/dev/null; do
+    sleep 0.01
+    i=$((i + 1))
+  done
+  grep -Fqx 'prompt=immediate native_count=1 manual=false' "$home/state/provider-calls" \
+    || { capture "$session" >&2; fail "Pi $version: immediate first payload lacked exactly one native startup context"; }
+  wait_for_text "$session" 'RACE_RESULT prompt=immediate native_count=1 manual=false' 60 \
+    || fail "Pi $version: immediate local-provider turn did not settle"
+  session_file=$(find "$sessions" -type f -name '*.jsonl' -exec grep -l IMMEDIATE_RACE_PROMPT {} + 2>/dev/null | head -1 || true)
+  [ -n "$session_file" ] || fail "Pi $version: immediate /new session file was not found"
+  [ "$(grep -Fc 'RACE_NATIVE generation=1' "$session_file")" -eq 1 ] \
+    || fail "Pi $version: immediate generation persisted other than one native startup context"
+  [ "$(grep -c '^clear-start:1:' "$home/state/events")" -eq 1 ] \
+    || fail "Pi $version: immediate generation executed native startup other than once"
+  [ ! -f "$home/state/manual-started" ] \
+    || fail "Pi $version: immediate fixed path still executed manual startup"
+
+  tmux -L "$SOCKET" send-keys -t "$session" -l /new
+  tmux -L "$SOCKET" send-keys -t "$session" Enter
+  i=0
+  while [ "$i" -lt 500 ] && [ ! -f "$home/state/native-started-2" ]; do sleep 0.01; i=$((i + 1)); done
+  [ -f "$home/state/native-started-2" ] \
+    || { capture "$session" >&2; fail "Pi $version: proven /new native generation never started"; }
+  : > "$home/state/release-native-2"
+  i=0
+  while [ "$i" -lt 500 ] && [ ! -f "$home/state/native-completed-2" ]; do sleep 0.01; i=$((i + 1)); done
+  [ -f "$home/state/native-completed-2" ] || fail "Pi $version: proven native generation did not complete"
+  tmux -L "$SOCKET" send-keys -t "$session" -l PROVEN_RACE_PROMPT
+  tmux -L "$SOCKET" send-keys -t "$session" Enter
+  wait_for_text "$session" 'RACE_RESULT prompt=proven native_count=1 manual=false' 60 \
+    || fail "Pi $version: proven completed-before-prompt path lacked exactly one native context"
+  first_line=$(sed -n '1p' "$home/state/provider-calls")
+  second_line=$(sed -n '2p' "$home/state/provider-calls")
+  [ "$first_line" = 'prompt=immediate native_count=1 manual=false' ] \
+    || fail "Pi $version: immediate provider evidence changed unexpectedly: $first_line"
+  [ "$second_line" = 'prompt=proven native_count=1 manual=false' ] \
+    || fail "Pi $version: proven provider evidence changed unexpectedly: $second_line"
+  [ "$(grep -c '^clear-start:' "$home/state/events")" -eq 2 ] \
+    || fail "Pi $version: two /new generations did not execute native startup exactly once each"
+  [ ! -f "$home/state/manual-started" ] \
+    || fail "Pi $version: proven fixed path executed manual startup"
+
+  tmux -L "$SOCKET" send-keys -t "$session" -l /quit
+  tmux -L "$SOCKET" send-keys -t "$session" Enter
+  wait_for_text "$session" 'PI_EXIT=0' 30 || fail "Pi $version: offline /new lab did not exit cleanly"
+  pass "Pi $version: immediate and completed-before-prompt /new paths each made one first provider call with exactly one native startup context and no manual execution"
+}
+
+if [ "${FM_PI_SESSIONSTART_RACE_LIVE_E2E:-0}" = 1 ]; then
+  probe_pi_sessionstart_prerequisite
+  if [ "${FM_SESSIONSTART_HOOK_LIVE_E2E:-0}" != 1 ]; then
+    echo "# fm-sessionstart-hook-live-e2e.test.sh: offline Pi /new race assertions passed"
+    exit 0
+  fi
+fi
 
 # --- per-harness drivers ------------------------------------------------------
 

--- a/tests/fm-sessionstart-hook-live-e2e.test.sh
+++ b/tests/fm-sessionstart-hook-live-e2e.test.sh
@@ -176,7 +176,8 @@ SH
     pi)
       mkdir -p "$lab/.pi/extensions/lib"
       cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$lab/.pi/extensions/"
-      cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$lab/.pi/extensions/lib/"
+      cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" \
+        "$ROOT/.pi/extensions/lib/fm-sessionstart-supervisor.mjs" "$lab/.pi/extensions/lib/"
       cp "$ROOT/bin/fm-operational-input.sh" "$lab/bin/"
       printf '%s\n' '{"compaction":{"keepRecentTokens":200}}' > "$lab/.pi/settings.json"
       ;;
@@ -351,7 +352,8 @@ probe_pi_sessionstart_prerequisite() {
   git -C "$project" config user.name fmtest
   printf '# Offline Pi startup-prerequisite lab\n' > "$project/AGENTS.md"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$project/.pi/extensions/"
-  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$project/.pi/extensions/lib/"
+  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" \
+    "$ROOT/.pi/extensions/lib/fm-sessionstart-supervisor.mjs" "$project/.pi/extensions/lib/"
   cp "$ROOT/bin/fm-operational-input.sh" "$project/bin/"
   cat > "$project/bin/fm-turnend-guard.sh" <<'SH'
 #!/usr/bin/env bash

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -333,7 +333,14 @@ test_pi_startup_classifies_cli_continuations() {
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$fixture/.pi/extensions/lib/"
   cat > "$fixture/bin/fm-sessionstart-run.sh" <<'SH'
 #!/usr/bin/env bash
-printf '%s\n' "$*" >> "${FM_HOME:?}/state/sources"
+source_name=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source) source_name=${2:-}; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '%s\n' "$source_name" >> "${FM_HOME:?}/state/sources"
 SH
   cat > "$fixture/bin/fm-turnend-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -352,12 +359,19 @@ const pi = {
 };
 const extension = await import(`${pathToFileURL(process.env.EXT).href}?continuation=${Date.now()}`);
 extension.default(pi);
+let sessionNumber = 0;
 const fire = async (args, entries = [], timestamp = new Date().toISOString()) => {
   process.argv.splice(1, process.argv.length, "pi", ...args);
-  await handlers.get("session_start")(
-    { reason: "startup" },
-    { sessionManager: { getEntries: () => entries, getHeader: () => ({ timestamp }) } },
-  );
+  const sessionId = `continuation-${++sessionNumber}`;
+  const ctx = {
+    sessionManager: {
+      getEntries: () => entries,
+      getHeader: () => ({ timestamp }),
+      getSessionId: () => sessionId,
+    },
+  };
+  handlers.get("session_start")({ reason: "startup" }, ctx);
+  await handlers.get("before_agent_start")({ prompt: "test" }, ctx);
 };
 const oldTimestamp = "2000-01-01T00:00:00.000Z";
 const nameEntry = [{ type: "session_info", name: "named" }];
@@ -382,26 +396,314 @@ JS
   expect_code 0 "$status" "Pi continuation classification"
   [ -z "$out" ] || fail "Pi continuation classification printed output: $out"
   expected=$(printf '%s\n' \
-    '--source startup' \
-    '--source startup' \
-    '--source resume' \
-    '--source startup' \
-    '--source resume' \
-    '--source startup' \
-    '--source resume' \
-    '--source startup' \
-    '--source resume' \
-    '--source resume' \
-    '--source startup' \
-    '--source resume' \
-    '--source startup' \
-    '--source resume' \
-    '--source fork' \
-    '--source startup')
+    'startup' \
+    'startup' \
+    'resume' \
+    'startup' \
+    'resume' \
+    'startup' \
+    'resume' \
+    'startup' \
+    'resume' \
+    'resume' \
+    'startup' \
+    'resume' \
+    'startup' \
+    'resume' \
+    'fork' \
+    'startup')
   actual=$(cat "$fixture/state/sources")
   [ "$actual" = "$expected" ] \
     || fail "Pi continuation classification produced unexpected sources: $actual"
   pass "Pi distinguishes header-proven restored CLI sessions from named create-if-missing startups"
+}
+
+test_pi_sessionstart_generation_prerequisite() {
+  local fixture out status=0
+  command -v node >/dev/null 2>&1 || {
+    echo "skip: node not found for Pi session-start generation prerequisite test"
+    return 0
+  }
+  fixture="$TMP_ROOT/pi-sessionstart-generation"
+  mkdir -p "$fixture/.pi/extensions/lib" "$fixture/bin" "$fixture/state"
+  cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$fixture/.pi/extensions/"
+  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$fixture/.pi/extensions/lib/"
+  cp "$ROOT/bin/fm-operational-input.sh" "$fixture/bin/"
+  cat > "$fixture/bin/fm-turnend-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fixture/bin/fm-sessionstart-run.sh" <<'SH'
+#!/usr/bin/env bash
+set -u
+state=${FM_HOME:?}/state
+source_name=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source) source_name=${2:-}; shift 2 ;;
+    *) shift ;;
+  esac
+done
+count=$(( $(wc -l < "$state/launches" 2>/dev/null || printf '0') + 1 ))
+behavior=$(cat "$state/behavior-$count")
+printf 'launch:%s:%s:%s:%s\n' "$count" "$behavior" "$source_name" "$$" >> "$state/launches"
+printf 'launch:%s\n' "$count" >> "$state/events"
+case "$behavior" in
+  success)
+    printf 'GENERATION_DIGEST_%s source=%s\n' "$count" "$source_name"
+    : > "$state/completed-$count"
+    ;;
+  slow|timeout)
+    sleep 30 &
+    grandchild=$!
+    printf '%s\n' "$grandchild" > "$state/grandchild-$count"
+    trap 'printf "term:'"$count"'\n" >> "$state/events"; exit 143' TERM INT
+    : > "$state/started-$count"
+    while [ ! -f "$state/release-$count" ]; do sleep 0.02; done
+    if [ "$behavior" = timeout ]; then
+      printf 'STARTUP TRUNCATED - stage=bootstrap generation=%s\n' "$count"
+    else
+      printf 'GENERATION_DIGEST_%s source=%s\n' "$count" "$source_name"
+    fi
+    : > "$state/completed-$count"
+    kill "$grandchild" 2>/dev/null || true
+    wait "$grandchild" 2>/dev/null || true
+    ;;
+  stale)
+    trap 'printf "stale-close:'"$count"'\n" >> "$state/events"; printf "STALE_DIGEST_'"$count"'\n"; : > "$state/completed-'"$count"'"; exit 0' TERM INT
+    : > "$state/started-$count"
+    while [ ! -f "$state/release-$count" ]; do sleep 0.02; done
+    printf 'STALE_DIGEST_%s\n' "$count"
+    : > "$state/completed-$count"
+    ;;
+  empty)
+    : > "$state/completed-$count"
+    ;;
+  ineligible)
+    : > "$state/completed-$count"
+    exit 3
+    ;;
+  error)
+    : > "$state/completed-$count"
+    exit 7
+    ;;
+  truncate)
+    printf 'TRUNCATION_PREFIX_%s\n' "$count"
+    i=0
+    while [ "$i" -lt 700 ]; do
+      printf '%01024d' 0
+      i=$((i + 1))
+    done
+    printf '\nTRUNCATION_SUFFIX_%s\n' "$count"
+    : > "$state/completed-$count"
+    ;;
+  *)
+    exit 9
+    ;;
+esac
+SH
+  chmod +x "$fixture/bin/"*.sh
+  : > "$fixture/state/launches"
+  : > "$fixture/state/events"
+
+  out=$(EXT="$fixture/.pi/extensions/fm-primary-turnend-guard.ts" \
+    FM_HOME="$fixture" FM_ROOT_OVERRIDE="$fixture" \
+    node --input-type=module 2>&1 <<'JS'
+import {
+  existsSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const state = `${process.env.FM_HOME}/state`;
+const runner = `${process.env.FM_HOME}/bin/fm-sessionstart-run.sh`;
+const handlers = new Map();
+const sent = [];
+const pi = {
+  on(event, handler) { handlers.set(event, handler); },
+  sendMessage(message) { sent.push(message); },
+};
+const extension = await import(`${pathToFileURL(process.env.EXT).href}?generation=${Date.now()}`);
+extension.default(pi);
+process.argv.splice(1, process.argv.length, "pi");
+
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message);
+};
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const waitFor = async (predicate, message) => {
+  for (let i = 0; i < 400; i += 1) {
+    if (predicate()) return;
+    await delay(5);
+  }
+  throw new Error(message);
+};
+const alive = (pid) => {
+  try { process.kill(Number(pid), 0); return true; } catch { return false; }
+};
+const waitDead = async (pid, message) => {
+  await waitFor(() => !alive(pid), message);
+};
+const ctx = (sessionId) => ({
+  sessionManager: {
+    getHeader: () => ({ timestamp: new Date().toISOString() }),
+    getSessionId: () => sessionId,
+  },
+});
+const begin = (reason, sessionId) => {
+  const current = ctx(sessionId);
+  handlers.get("session_start")({ reason }, current);
+  return current;
+};
+const providerCalls = [];
+const providerCall = async (current, prompt) => {
+  const preflight = await handlers.get("before_agent_start")({ prompt }, current);
+  providerCalls.push({ prompt, message: preflight?.message });
+  return preflight;
+};
+const plan = (index, behavior) => {
+  writeFileSync(`${state}/behavior-${index}`, `${behavior}\n`);
+};
+const release = (index) => writeFileSync(`${state}/release-${index}`, "\n");
+const launchLines = () => readFileSync(`${state}/launches`, "utf8").trim().split("\n").filter(Boolean);
+const pidFor = (index) => Number(launchLines().find((line) => line.startsWith(`launch:${index}:`))?.split(":")[4]);
+const grandchildFor = (index) => Number(readFileSync(`${state}/grandchild-${index}`, "utf8").trim());
+const startupMessages = () => providerCalls.map((call) => call.message).filter(Boolean);
+
+// The failing immediate-prompt path is now a prerequisite: no provider call is
+// observable until the matching slow native generation settles.
+plan(1, "slow");
+const immediate = begin("startup", "session-immediate");
+await waitFor(() => existsSync(`${state}/started-1`), "immediate generation never started");
+const immediateCall = providerCall(immediate, "immediate prompt");
+await delay(100);
+assert(providerCalls.length === 0, "provider call escaped before the startup prerequisite settled");
+release(1);
+const immediateResult = await immediateCall;
+assert(immediateResult?.message?.content.includes("GENERATION_DIGEST_1"), "first payload lost matching startup context");
+assert(launchLines().length === 1, "immediate generation executed more than once");
+assert((await handlers.get("before_agent_start")({ prompt: "second prompt" }, immediate)) === undefined,
+  "one generation delivered startup context more than once");
+assert(startupMessages().length === 1, "immediate generation produced more than one model-visible startup context");
+assert(sent.length === 0, "session start still used asynchronous sendMessage delivery");
+
+// Proven non-racing path: native completion before submission produces the same
+// first-payload guarantee without a manual fallback.
+plan(2, "success");
+const proven = begin("new", "session-proven");
+await waitFor(() => existsSync(`${state}/completed-2`), "proven generation never completed");
+const provenResult = await providerCall(proven, "proven prompt");
+assert(provenResult?.message?.content.includes("GENERATION_DIGEST_2"), "proven path lost startup context");
+assert(!provenResult.message.content.includes("Run `bin/fm-session-start.sh`"), "proven path used manual fallback");
+
+// Shutdown owns interruption and the whole child process group. The pending
+// preflight settles without stale delivery.
+plan(3, "slow");
+const interrupted = begin("new", "session-interrupted");
+await waitFor(() => existsSync(`${state}/started-3`) && existsSync(`${state}/grandchild-3`),
+  "interrupted generation never started its process tree");
+const interruptedCall = handlers.get("before_agent_start")({ prompt: "interrupted" }, interrupted);
+const interruptedPid = pidFor(3);
+const interruptedGrandchild = grandchildFor(3);
+await handlers.get("session_shutdown")({ reason: "new" }, interrupted);
+assert((await interruptedCall) === undefined, "shutdown delivered cancelled startup context");
+await waitDead(interruptedPid, "shutdown left the startup child alive");
+await waitDead(interruptedGrandchild, "shutdown left a startup grandchild alive");
+
+// Two rapid replacements serialize retirement. The middle generation never
+// starts, stale completion is ignored, and only the newest generation delivers.
+plan(4, "stale");
+plan(5, "success");
+const stale = begin("new", "session-stale");
+await waitFor(() => existsSync(`${state}/started-4`), "stale generation never started");
+const staleCall = handlers.get("before_agent_start")({ prompt: "stale" }, stale);
+begin("new", "session-replaced-once");
+const newest = begin("new", "session-replaced-twice");
+const newestResult = await providerCall(newest, "newest");
+assert(newestResult?.message?.content.includes("GENERATION_DIGEST_5"), "newest replacement lost its context");
+assert((await staleCall) === undefined, "stale generation delivered after replacement");
+assert(launchLines().length === 5, "rapid replacements launched the cancelled middle generation");
+assert(!startupMessages().some((message) => message.content.includes("STALE_DIGEST_4")),
+  "stale completion reached model context");
+const events = readFileSync(`${state}/events`, "utf8");
+assert(events.indexOf("stale-close:4") < events.indexOf("launch:5"),
+  "newest generation started before stale child retirement completed");
+
+// Empty output and spawn failure settle first, then inject the existing exact
+// manual instruction. Intentional ineligibility remains silent.
+plan(6, "empty");
+const empty = begin("new", "session-empty");
+const emptyResult = await providerCall(empty, "empty");
+assert(existsSync(`${state}/completed-6`), "empty attempt had not settled before fallback delivery");
+assert(emptyResult?.message?.content.includes("Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions."),
+  "empty output lost the exact manual fallback");
+
+renameSync(runner, `${runner}.missing`);
+const spawnError = begin("new", "session-spawn-error");
+const spawnErrorResult = await providerCall(spawnError, "spawn error");
+renameSync(`${runner}.missing`, runner);
+assert(spawnErrorResult?.message?.content.includes("Run `bin/fm-session-start.sh` now, exactly once"),
+  "spawn error lost the manual fallback");
+
+plan(7, "ineligible");
+const ineligible = begin("new", "session-ineligible");
+assert((await providerCall(ineligible, "ineligible")) === undefined,
+  "intentional gate/scope stand-down injected a manual fallback");
+
+plan(8, "error");
+const failed = begin("new", "session-failed");
+const failedResult = await providerCall(failed, "failed");
+assert(failedResult?.message?.content.includes("Run `bin/fm-session-start.sh` now, exactly once"),
+  "failed eligible attempt lost the manual fallback");
+
+// The wrapper's bounded timeout result and the extension's 512 KiB containment
+// remain loud provider prerequisites rather than falling back or going stale.
+plan(9, "timeout");
+const timed = begin("new", "session-timeout");
+await waitFor(() => existsSync(`${state}/started-9`), "timeout generation never started");
+const timedCall = providerCall(timed, "timeout");
+await delay(100);
+assert(!providerCalls.some((call) => call.prompt === "timeout"), "timeout provider call escaped before settlement");
+release(9);
+const timedResult = await timedCall;
+assert(timedResult?.message?.content.includes("STARTUP TRUNCATED - stage=bootstrap"), "timeout banner was lost");
+assert(!timedResult.message.content.includes("Run `bin/fm-session-start.sh`"), "bounded timeout incorrectly used manual fallback");
+
+plan(10, "truncate");
+const truncated = begin("new", "session-truncated");
+const truncatedResult = await providerCall(truncated, "truncated");
+assert(truncatedResult?.message?.content.includes("TRUNCATION_PREFIX_10"), "truncated digest lost its prefix");
+assert(truncatedResult.message.content.includes("PI SESSION-START DELIVERY TRUNCATED"), "truncated digest was not loud");
+assert(!truncatedResult.message.content.includes("TRUNCATION_SUFFIX_10"), "truncated digest exceeded its bound");
+
+// Compaction keeps its supported asynchronous transport for retry-without-
+// preflight, but it shares the same generation cancellation and exactly-once claim.
+plan(11, "success");
+const compactContext = ctx("session-truncated");
+await handlers.get("session_compact")({}, compactContext);
+assert(sent.length === 1 && sent[0].content.includes("GENERATION_DIGEST_11"),
+  "compaction lost its existing persistent delivery");
+assert((await handlers.get("before_agent_start")({ prompt: "post compact" }, compactContext)) === undefined,
+  "compaction delivered the same context twice");
+
+plan(12, "slow");
+const compactPending = handlers.get("session_compact")({}, compactContext);
+await waitFor(() => existsSync(`${state}/started-12`) && existsSync(`${state}/grandchild-12`),
+  "cancelled compaction generation never started");
+const compactPid = pidFor(12);
+const compactGrandchild = grandchildFor(12);
+await handlers.get("session_shutdown")({ reason: "quit" }, compactContext);
+await compactPending;
+assert(sent.length === 1, "cancelled compaction delivered stale context");
+await waitDead(compactPid, "shutdown left the compaction child alive");
+await waitDead(compactGrandchild, "shutdown left a compaction grandchild alive");
+JS
+  ) || status=$?
+  expect_code 0 "$status" "Pi session-start generation prerequisite"
+  [ -z "$out" ] || fail "Pi session-start generation prerequisite printed output: $out"
+  pass "Pi provider preflight owns one generation-bound startup prerequisite with deterministic fallback, replacement, cancellation, timeout, and truncation"
 }
 
 test_pi_large_sessionstart_digest_is_delivered_loudly() {
@@ -438,19 +740,17 @@ SH
     node --input-type=module 2>&1 <<'JS'
 import { pathToFileURL } from "node:url";
 const handlers = new Map();
-const messages = [];
 const pi = {
   on(event, handler) { handlers.set(event, handler); },
-  sendMessage(message) { messages.push(message); },
+  sendMessage() { throw new Error("session start must use provider preflight"); },
 };
 const extension = await import(`${pathToFileURL(process.env.EXT).href}?large=${Date.now()}`);
 extension.default(pi);
-await handlers.get("session_start")(
-  { reason: "startup" },
-  { sessionManager: { getEntries: () => [] } },
-);
-if (messages.length !== 1) throw new Error(`expected one message, got ${messages.length}`);
-const content = messages[0].content;
+const ctx = { sessionManager: { getEntries: () => [], getSessionId: () => "large-digest" } };
+handlers.get("session_start")({ reason: "startup" }, ctx);
+const result = await handlers.get("before_agent_start")({ prompt: "test" }, ctx);
+if (!result?.message) throw new Error("expected one persistent preflight message");
+const content = result.message.content;
 if (!content.includes("PI_LARGE_DIGEST_PREFIX")) throw new Error("digest prefix was lost");
 if (!content.includes("PI SESSION-START DELIVERY TRUNCATED")) throw new Error("truncation marker was lost");
 if (content.includes("PI_LARGE_DIGEST_SUFFIX")) throw new Error("delivery exceeded its declared bound");
@@ -459,7 +759,7 @@ JS
   ) || status=$?
   expect_code 0 "$status" "Pi large session-start delivery"
   [ -z "$out" ] || fail "Pi large session-start delivery printed output: $out"
-  pass "Pi retains a bounded digest prefix and loudly marks oversized delivery"
+  pass "Pi retains a bounded digest prefix and loudly marks oversized preflight delivery"
 }
 
 test_run_resume_delegates_to_the_nudge() {
@@ -509,17 +809,27 @@ test_run_unknown_source_takes_the_helm() {
 
 test_run_gate_and_scope_are_silent() {
   local root="$TMP_ROOT/run-gate" base="$TMP_ROOT/run-linked-base" linked="$TMP_ROOT/run-linked"
+  local out status=0
   make_run_primary "$root"
   expect_silent_zero "gate env run" env NO_MISTAKES_GATE=1 FM_GATE_REFUSE_BYPASS=0 \
     FM_ROOT_OVERRIDE="$root" FM_HOME="$root" PATH="$RUN_PATH" "$RUN" --source startup
   assert_absent "$root/state/.lock" "a gate agent's session open still took the fleet lock"
+  out=$(env NO_MISTAKES_GATE=1 FM_GATE_REFUSE_BYPASS=0 \
+    FM_ROOT_OVERRIDE="$root" FM_HOME="$root" PATH="$RUN_PATH" \
+    "$RUN" --source startup --pi-prerequisite 2>&1) || status=$?
+  expect_code 3 "$status" "gate env Pi prerequisite stand-down"
+  [ -z "$out" ] || fail "gate env Pi prerequisite stand-down must be silent, got: $out"
 
   fm_git_worktree "$base" "$linked" fm/run-linked
   mkdir -p "$linked/bin" "$linked/state"
   : > "$linked/AGENTS.md"
   expect_silent_zero "linked worktree run" run_hook "$linked" --source startup
+  status=0
+  out=$(run_hook "$linked" --source startup --pi-prerequisite 2>&1) || status=$?
+  expect_code 3 "$status" "linked worktree Pi prerequisite stand-down"
+  [ -z "$out" ] || fail "linked worktree Pi prerequisite stand-down must be silent, got: $out"
   assert_absent "$linked/state/.lock" "an unmarked task worktree still took the fleet lock"
-  pass "run wrapper: a gate agent and an unmarked task worktree never run a session start"
+  pass "run wrapper: ordinary ineligible opens stay silent-zero and Pi preflight gets an explicit silent stand-down"
 }
 
 test_run_reports_a_failed_session_start_as_digest_text() {
@@ -553,4 +863,5 @@ test_run_unknown_source_takes_the_helm
 test_run_gate_and_scope_are_silent
 test_run_reports_a_failed_session_start_as_digest_text
 test_pi_startup_classifies_cli_continuations
+test_pi_sessionstart_generation_prerequisite
 test_pi_large_sessionstart_digest_is_delivered_loudly

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -330,7 +330,8 @@ test_pi_startup_classifies_cli_continuations() {
   fixture="$TMP_ROOT/pi-continuation-source"
   mkdir -p "$fixture/.pi/extensions/lib" "$fixture/bin" "$fixture/state"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$fixture/.pi/extensions/"
-  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$fixture/.pi/extensions/lib/"
+  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" \
+    "$ROOT/.pi/extensions/lib/fm-sessionstart-supervisor.mjs" "$fixture/.pi/extensions/lib/"
   cat > "$fixture/bin/fm-sessionstart-run.sh" <<'SH'
 #!/usr/bin/env bash
 source_name=
@@ -427,7 +428,8 @@ test_pi_sessionstart_generation_prerequisite() {
   fixture="$TMP_ROOT/pi-sessionstart-generation"
   mkdir -p "$fixture/.pi/extensions/lib" "$fixture/bin" "$fixture/state"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$fixture/.pi/extensions/"
-  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$fixture/.pi/extensions/lib/"
+  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" \
+    "$ROOT/.pi/extensions/lib/fm-sessionstart-supervisor.mjs" "$fixture/.pi/extensions/lib/"
   cp "$ROOT/bin/fm-operational-input.sh" "$fixture/bin/"
   cat > "$fixture/bin/fm-turnend-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -446,7 +448,8 @@ while [ $# -gt 0 ]; do
 done
 count=$(( $(wc -l < "$state/launches" 2>/dev/null || printf '0') + 1 ))
 behavior=$(cat "$state/behavior-$count")
-printf 'launch:%s:%s:%s:%s\n' "$count" "$behavior" "$source_name" "$$" >> "$state/launches"
+printf 'launch:%s:%s:%s:%s:%s\n' \
+  "$count" "$behavior" "$source_name" "$$" "${FM_SESSIONSTART_SUPERVISOR_PID:-}" >> "$state/launches"
 printf 'launch:%s\n' "$count" >> "$state/events"
 case "$behavior" in
   success)
@@ -572,6 +575,7 @@ const plan = (index, behavior) => {
 const release = (index) => writeFileSync(`${state}/release-${index}`, "\n");
 const launchLines = () => readFileSync(`${state}/launches`, "utf8").trim().split("\n").filter(Boolean);
 const pidFor = (index) => Number(launchLines().find((line) => line.startsWith(`launch:${index}:`))?.split(":")[4]);
+const supervisorFor = (index) => Number(launchLines().find((line) => line.startsWith(`launch:${index}:`))?.split(":")[5]);
 const grandchildFor = (index) => Number(readFileSync(`${state}/grandchild-${index}`, "utf8").trim());
 const startupMessages = () => providerCalls.map((call) => call.message).filter(Boolean);
 
@@ -600,11 +604,12 @@ await waitFor(() => existsSync(`${state}/completed-2`), "proven generation never
 const provenResult = await providerCall(proven, "proven prompt");
 assert(provenResult?.message?.content.includes("GENERATION_DIGEST_2"), "proven path lost startup context");
 assert(!provenResult.message.content.includes("Run `bin/fm-session-start.sh`"), "proven path used manual fallback");
-const provenPid = pidFor(2);
+const provenSupervisor = supervisorFor(2);
+assert(alive(provenSupervisor), "completed generation lost its stable supervisor owner");
 const originalKill = process.kill;
-let staleGroupUseCount = 0;
+let ownedGroupSignalCount = 0;
 process.kill = (pid, signal) => {
-  if (pid === -provenPid) staleGroupUseCount += 1;
+  if (pid === -provenSupervisor && signal !== 0) ownedGroupSignalCount += 1;
   return Reflect.apply(originalKill, process, [pid, signal]);
 };
 
@@ -613,7 +618,7 @@ process.kill = (pid, signal) => {
 plan(3, "slow");
 const interrupted = begin("new", "session-interrupted");
 process.kill = originalKill;
-assert(staleGroupUseCount === 0, "replacement reused a completed generation's empty process group id");
+assert(ownedGroupSignalCount > 0, "replacement did not retire the completed generation's stable owner");
 await waitFor(() => existsSync(`${state}/started-3`) && existsSync(`${state}/grandchild-3`),
   "interrupted generation never started its process tree");
 const interruptedCall = handlers.get("before_agent_start")({ prompt: "interrupted" }, interrupted);
@@ -670,42 +675,64 @@ const failedResult = await providerCall(failed, "failed");
 assert(failedResult?.message?.content.includes("Run `bin/fm-session-start.sh` now, exactly once"),
   "failed eligible attempt lost the manual fallback");
 
+plan(9, "error");
+const failedResume = begin("resume", "session-failed-resume");
+const failedResumeResult = await providerCall(failedResume, "failed resume");
+assert(failedResumeResult?.message?.content.includes("Run `bin/fm-session-start.sh` now, exactly once"),
+  "failed eligible resume lost the manual fallback");
+
+plan(10, "error");
+const failedFork = begin("fork", "session-failed-fork");
+const failedForkResult = await providerCall(failedFork, "failed fork");
+assert(failedForkResult?.message?.content.includes("Run `bin/fm-session-start.sh` now, exactly once"),
+  "failed eligible fork lost the manual fallback");
+
+plan(11, "empty");
+const emptyResume = begin("resume", "session-empty-resume");
+assert((await providerCall(emptyResume, "empty resume")) === undefined,
+  "empty context-restored resume injected a manual fallback");
+
+plan(12, "empty");
+const emptyFork = begin("fork", "session-empty-fork");
+assert((await providerCall(emptyFork, "empty fork")) === undefined,
+  "empty context-restored fork injected a manual fallback");
+
 // The wrapper's bounded timeout result and the extension's 512 KiB containment
 // remain loud provider prerequisites rather than falling back or going stale.
-plan(9, "timeout");
+plan(13, "timeout");
 const timed = begin("new", "session-timeout");
-await waitFor(() => existsSync(`${state}/started-9`), "timeout generation never started");
+await waitFor(() => existsSync(`${state}/started-13`), "timeout generation never started");
 const timedCall = providerCall(timed, "timeout");
 await delay(100);
 assert(!providerCalls.some((call) => call.prompt === "timeout"), "timeout provider call escaped before settlement");
-release(9);
+release(13);
 const timedResult = await timedCall;
 assert(timedResult?.message?.content.includes("STARTUP TRUNCATED - stage=bootstrap"), "timeout banner was lost");
 assert(!timedResult.message.content.includes("Run `bin/fm-session-start.sh`"), "bounded timeout incorrectly used manual fallback");
 
-plan(10, "truncate");
+plan(14, "truncate");
 const truncated = begin("new", "session-truncated");
 const truncatedResult = await providerCall(truncated, "truncated");
-assert(truncatedResult?.message?.content.includes("TRUNCATION_PREFIX_10"), "truncated digest lost its prefix");
+assert(truncatedResult?.message?.content.includes("TRUNCATION_PREFIX_14"), "truncated digest lost its prefix");
 assert(truncatedResult.message.content.includes("PI SESSION-START DELIVERY TRUNCATED"), "truncated digest was not loud");
-assert(!truncatedResult.message.content.includes("TRUNCATION_SUFFIX_10"), "truncated digest exceeded its bound");
+assert(!truncatedResult.message.content.includes("TRUNCATION_SUFFIX_14"), "truncated digest exceeded its bound");
 
 // Compaction keeps its supported asynchronous transport for retry-without-
 // preflight, but it shares the same generation cancellation and exactly-once claim.
-plan(11, "success");
+plan(15, "success");
 const compactContext = ctx("session-truncated");
 await handlers.get("session_compact")({}, compactContext);
-assert(sent.length === 1 && sent[0].content.includes("GENERATION_DIGEST_11"),
+assert(sent.length === 1 && sent[0].content.includes("GENERATION_DIGEST_15"),
   "compaction lost its existing persistent delivery");
 assert((await handlers.get("before_agent_start")({ prompt: "post compact" }, compactContext)) === undefined,
   "compaction delivered the same context twice");
 
-plan(12, "slow");
+plan(16, "slow");
 const compactPending = handlers.get("session_compact")({}, compactContext);
-await waitFor(() => existsSync(`${state}/started-12`) && existsSync(`${state}/grandchild-12`),
+await waitFor(() => existsSync(`${state}/started-16`) && existsSync(`${state}/grandchild-16`),
   "cancelled compaction generation never started");
-const compactPid = pidFor(12);
-const compactGrandchild = grandchildFor(12);
+const compactPid = pidFor(16);
+const compactGrandchild = grandchildFor(16);
 await handlers.get("session_shutdown")({ reason: "quit" }, compactContext);
 await compactPending;
 assert(sent.length === 1, "cancelled compaction delivered stale context");
@@ -727,7 +754,8 @@ test_pi_reload_releases_sessionstart_exit_listener() {
   fixture="$TMP_ROOT/pi-reload-exit-listener"
   mkdir -p "$fixture/.pi/extensions/lib" "$fixture/bin" "$fixture/state"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$fixture/.pi/extensions/"
-  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$fixture/.pi/extensions/lib/"
+  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" \
+    "$ROOT/.pi/extensions/lib/fm-sessionstart-supervisor.mjs" "$fixture/.pi/extensions/lib/"
   cp "$ROOT/bin/fm-operational-input.sh" "$fixture/bin/"
   cat > "$fixture/bin/fm-turnend-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -738,7 +766,7 @@ SH
 set -u
 state=${FM_HOME:?}/state
 index=$(( $(wc -l < "$state/launches" 2>/dev/null || printf '0') + 1 ))
-printf '%s:%s\n' "$index" "$$" >> "$state/launches"
+printf '%s:%s:%s\n' "$index" "$$" "${FM_SESSIONSTART_SUPERVISOR_PID:-}" >> "$state/launches"
 (
   trap '' TERM INT HUP
   while :; do sleep 30; done
@@ -812,10 +840,12 @@ for (let instance = 1; instance <= 2; instance += 1) {
       `reload ${instance} session ${session} startup generation never started`);
     const launch = readFileSync(`${state}/launches`, "utf8").trim().split("\n")[launchIndex - 1];
     const child = Number(launch.split(":")[1]);
+    const supervisor = Number(launch.split(":")[2]);
     const grandchild = Number(readFileSync(`${state}/grandchild-${launchIndex}`, "utf8").trim());
     if (launchIndex === 3) {
       await waitFor(() => !alive(child), "leader did not close before process-exit cleanup");
       assert(alive(grandchild), "TERM-resistant descendant exited with its leader");
+      assert(alive(supervisor), "leader close lost the stable supervisor owner");
       assert(process.listenerCount("exit") === baselineCount + 1,
         "leader close removed the active instance exit listener");
       const ownedListener = process.listeners("exit").find(
@@ -858,7 +888,8 @@ test_pi_large_sessionstart_digest_is_delivered_loudly() {
   git -C "$fixture" commit -q --allow-empty -m init
   : > "$fixture/AGENTS.md"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$fixture/.pi/extensions/"
-  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$fixture/.pi/extensions/lib/"
+  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" \
+    "$ROOT/.pi/extensions/lib/fm-sessionstart-supervisor.mjs" "$fixture/.pi/extensions/lib/"
   cp "$ROOT/bin/fm-sessionstart-run.sh" "$ROOT/bin/fm-sessionstart-nudge.sh" \
     "$ROOT/bin/fm-primary-scope-lib.sh" "$ROOT/bin/fm-gate-refuse-lib.sh" \
     "$ROOT/bin/fm-hook-host-lib.sh" \

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -454,7 +454,10 @@ case "$behavior" in
     : > "$state/completed-$count"
     ;;
   slow|timeout)
-    sleep 30 &
+    (
+      trap '' TERM INT
+      while :; do sleep 30; done
+    ) </dev/null >/dev/null 2>&1 &
     grandchild=$!
     printf '%s\n' "$grandchild" > "$state/grandchild-$count"
     trap 'printf "term:'"$count"'\n" >> "$state/events"; exit 143' TERM INT
@@ -466,7 +469,7 @@ case "$behavior" in
       printf 'GENERATION_DIGEST_%s source=%s\n' "$count" "$source_name"
     fi
     : > "$state/completed-$count"
-    kill "$grandchild" 2>/dev/null || true
+    kill -KILL "$grandchild" 2>/dev/null || true
     wait "$grandchild" 2>/dev/null || true
     ;;
   stale)

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -600,11 +600,20 @@ await waitFor(() => existsSync(`${state}/completed-2`), "proven generation never
 const provenResult = await providerCall(proven, "proven prompt");
 assert(provenResult?.message?.content.includes("GENERATION_DIGEST_2"), "proven path lost startup context");
 assert(!provenResult.message.content.includes("Run `bin/fm-session-start.sh`"), "proven path used manual fallback");
+const provenPid = pidFor(2);
+const originalKill = process.kill;
+let staleGroupUseCount = 0;
+process.kill = (pid, signal) => {
+  if (pid === -provenPid) staleGroupUseCount += 1;
+  return Reflect.apply(originalKill, process, [pid, signal]);
+};
 
 // Shutdown owns interruption and the whole child process group. The pending
 // preflight settles without stale delivery.
 plan(3, "slow");
 const interrupted = begin("new", "session-interrupted");
+process.kill = originalKill;
+assert(staleGroupUseCount === 0, "replacement reused a completed generation's empty process group id");
 await waitFor(() => existsSync(`${state}/started-3`) && existsSync(`${state}/grandchild-3`),
   "interrupted generation never started its process tree");
 const interruptedCall = handlers.get("before_agent_start")({ prompt: "interrupted" }, interrupted);

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -731,13 +731,16 @@ state=${FM_HOME:?}/state
 index=$(( $(wc -l < "$state/launches" 2>/dev/null || printf '0') + 1 ))
 printf '%s:%s\n' "$index" "$$" >> "$state/launches"
 (
-  trap '' TERM INT
+  trap '' TERM INT HUP
   while :; do sleep 30; done
 ) </dev/null >/dev/null 2>&1 &
 grandchild=$!
 printf '%s\n' "$grandchild" > "$state/grandchild-$index"
-trap 'exit 143' TERM INT
 : > "$state/started-$index"
+if [ "$index" -eq 3 ]; then
+  exit 0
+fi
+trap 'exit 143' TERM INT
 while :; do sleep 30; done
 SH
   chmod +x "$fixture/bin/"*.sh
@@ -747,6 +750,7 @@ SH
     FM_HOME="$fixture" FM_ROOT_OVERRIDE="$fixture" \
     node --input-type=module 2>&1 <<'JS'
 import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 
 const state = `${process.env.FM_HOME}/state`;
@@ -764,7 +768,9 @@ const waitFor = async (predicate, message) => {
   throw new Error(message);
 };
 const alive = (pid) => {
-  try { process.kill(Number(pid), 0); return true; } catch { return false; }
+  try { process.kill(Number(pid), 0); } catch { return false; }
+  const status = spawnSync("ps", ["-o", "stat=", "-p", String(pid)], { encoding: "utf8" });
+  return status.status === 0 && !status.stdout.trim().startsWith("Z");
 };
 const ctx = (sessionId) => ({
   sessionManager: {
@@ -773,46 +779,61 @@ const ctx = (sessionId) => ({
   },
 });
 
-for (let index = 1; index <= 3; index += 1) {
+let launchIndex = 0;
+for (let instance = 1; instance <= 2; instance += 1) {
   const handlers = new Map();
   const pi = {
     on(event, handler) { handlers.set(event, handler); },
     sendMessage() {},
   };
   const extension = await import(
-    `${pathToFileURL(process.env.EXT).href}?reload=${index}-${Date.now()}`
+    `${pathToFileURL(process.env.EXT).href}?reload=${instance}-${Date.now()}`
   );
   extension.default(pi);
   assert(process.listenerCount("exit") === baselineCount + 1,
-    `reload ${index} did not own exactly one exit listener`);
-  const current = ctx(`reload-${index}`);
-  handlers.get("session_start")({ reason: "new" }, current);
-  await waitFor(() => existsSync(`${state}/started-${index}`),
-    `reload ${index} startup generation never started`);
-  const launch = readFileSync(`${state}/launches`, "utf8").trim().split("\n")[index - 1];
-  const child = Number(launch.split(":")[1]);
-  const grandchild = Number(readFileSync(`${state}/grandchild-${index}`, "utf8").trim());
-  if (index === 3) {
-    const ownedListener = process.listeners("exit").find(
-      (listener) => !baselineListeners.includes(listener)
-    );
-    assert(ownedListener, "active reload had no process-exit cleanup listener");
-    ownedListener(0);
-    await waitFor(() => !alive(child) && !alive(grandchild),
-      "active process-exit cleanup left the startup process group alive");
+    `reload ${instance} did not own exactly one exit listener`);
+  const sessionCount = instance === 1 ? 2 : 1;
+  for (let session = 1; session <= sessionCount; session += 1) {
+    launchIndex += 1;
+    const current = ctx(`reload-${instance}-session-${session}`);
+    handlers.get("session_start")({ reason: "new" }, current);
+    assert(process.listenerCount("exit") === baselineCount + 1,
+      `reload ${instance} session ${session} did not own exactly one exit listener`);
+    await waitFor(() => existsSync(`${state}/started-${launchIndex}`),
+      `reload ${instance} session ${session} startup generation never started`);
+    const launch = readFileSync(`${state}/launches`, "utf8").trim().split("\n")[launchIndex - 1];
+    const child = Number(launch.split(":")[1]);
+    const grandchild = Number(readFileSync(`${state}/grandchild-${launchIndex}`, "utf8").trim());
+    if (launchIndex === 3) {
+      await waitFor(() => !alive(child), "leader did not close before process-exit cleanup");
+      assert(alive(grandchild), "TERM-resistant descendant exited with its leader");
+      assert(process.listenerCount("exit") === baselineCount + 1,
+        "leader close removed the active instance exit listener");
+      const ownedListener = process.listeners("exit").find(
+        (listener) => !baselineListeners.includes(listener)
+      );
+      assert(ownedListener, "active reload had no process-exit cleanup listener");
+      ownedListener(0);
+      await waitFor(() => !alive(grandchild),
+        "active process-exit cleanup left the leaderless process group alive");
+    }
+    await handlers.get("session_shutdown")({ reason: "reload" }, current);
+    assert(process.listenerCount("exit") === baselineCount,
+      `reload ${instance} session ${session} retained its exit listener after shutdown`);
+    assert((await handlers.get("before_agent_start")({ prompt: "stale" }, current)) === undefined,
+      `reload ${instance} session ${session} retained model-visible startup context after shutdown`);
+    assert(!alive(child) && !alive(grandchild),
+      `reload ${instance} session ${session} retained its stale startup process group`);
+    if (session < sessionCount) {
+      assert(process.listenerCount("exit") === baselineCount,
+        "same-instance replacement started with a stale exit listener");
+    }
   }
-  await handlers.get("session_shutdown")({ reason: "reload" }, current);
-  assert(process.listenerCount("exit") === baselineCount,
-    `reload ${index} retained its exit listener after shutdown`);
-  assert((await handlers.get("before_agent_start")({ prompt: "stale" }, current)) === undefined,
-    `reload ${index} retained model-visible startup context after shutdown`);
-  assert(!alive(child) && !alive(grandchild),
-    `reload ${index} retained its stale startup process group`);
 }
 JS
   ) || status=$?
-  expect_code 0 "$status" "Pi reload exit-listener ownership"
   [ -z "$out" ] || fail "Pi reload exit-listener ownership printed output: $out"
+  expect_code 0 "$status" "Pi reload exit-listener ownership"
   pass "Pi reload shutdown releases its exit listener and stale startup generation"
 }
 

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -709,6 +709,113 @@ JS
   pass "Pi provider preflight owns one generation-bound startup prerequisite with deterministic fallback, replacement, cancellation, timeout, and truncation"
 }
 
+test_pi_reload_releases_sessionstart_exit_listener() {
+  local fixture out status=0
+  command -v node >/dev/null 2>&1 || {
+    echo "skip: node not found for Pi reload exit-listener test"
+    return 0
+  }
+  fixture="$TMP_ROOT/pi-reload-exit-listener"
+  mkdir -p "$fixture/.pi/extensions/lib" "$fixture/bin" "$fixture/state"
+  cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$fixture/.pi/extensions/"
+  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$fixture/.pi/extensions/lib/"
+  cp "$ROOT/bin/fm-operational-input.sh" "$fixture/bin/"
+  cat > "$fixture/bin/fm-turnend-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fixture/bin/fm-sessionstart-run.sh" <<'SH'
+#!/usr/bin/env bash
+set -u
+state=${FM_HOME:?}/state
+index=$(( $(wc -l < "$state/launches" 2>/dev/null || printf '0') + 1 ))
+printf '%s:%s\n' "$index" "$$" >> "$state/launches"
+(
+  trap '' TERM INT
+  while :; do sleep 30; done
+) </dev/null >/dev/null 2>&1 &
+grandchild=$!
+printf '%s\n' "$grandchild" > "$state/grandchild-$index"
+trap 'exit 143' TERM INT
+: > "$state/started-$index"
+while :; do sleep 30; done
+SH
+  chmod +x "$fixture/bin/"*.sh
+  : > "$fixture/state/launches"
+
+  out=$(EXT="$fixture/.pi/extensions/fm-primary-turnend-guard.ts" \
+    FM_HOME="$fixture" FM_ROOT_OVERRIDE="$fixture" \
+    node --input-type=module 2>&1 <<'JS'
+import { existsSync, readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const state = `${process.env.FM_HOME}/state`;
+const baselineListeners = process.listeners("exit");
+const baselineCount = baselineListeners.length;
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message);
+};
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const waitFor = async (predicate, message) => {
+  for (let i = 0; i < 600; i += 1) {
+    if (predicate()) return;
+    await delay(5);
+  }
+  throw new Error(message);
+};
+const alive = (pid) => {
+  try { process.kill(Number(pid), 0); return true; } catch { return false; }
+};
+const ctx = (sessionId) => ({
+  sessionManager: {
+    getHeader: () => ({ timestamp: new Date().toISOString() }),
+    getSessionId: () => sessionId,
+  },
+});
+
+for (let index = 1; index <= 3; index += 1) {
+  const handlers = new Map();
+  const pi = {
+    on(event, handler) { handlers.set(event, handler); },
+    sendMessage() {},
+  };
+  const extension = await import(
+    `${pathToFileURL(process.env.EXT).href}?reload=${index}-${Date.now()}`
+  );
+  extension.default(pi);
+  assert(process.listenerCount("exit") === baselineCount + 1,
+    `reload ${index} did not own exactly one exit listener`);
+  const current = ctx(`reload-${index}`);
+  handlers.get("session_start")({ reason: "new" }, current);
+  await waitFor(() => existsSync(`${state}/started-${index}`),
+    `reload ${index} startup generation never started`);
+  const launch = readFileSync(`${state}/launches`, "utf8").trim().split("\n")[index - 1];
+  const child = Number(launch.split(":")[1]);
+  const grandchild = Number(readFileSync(`${state}/grandchild-${index}`, "utf8").trim());
+  if (index === 3) {
+    const ownedListener = process.listeners("exit").find(
+      (listener) => !baselineListeners.includes(listener)
+    );
+    assert(ownedListener, "active reload had no process-exit cleanup listener");
+    ownedListener(0);
+    await waitFor(() => !alive(child) && !alive(grandchild),
+      "active process-exit cleanup left the startup process group alive");
+  }
+  await handlers.get("session_shutdown")({ reason: "reload" }, current);
+  assert(process.listenerCount("exit") === baselineCount,
+    `reload ${index} retained its exit listener after shutdown`);
+  assert((await handlers.get("before_agent_start")({ prompt: "stale" }, current)) === undefined,
+    `reload ${index} retained model-visible startup context after shutdown`);
+  assert(!alive(child) && !alive(grandchild),
+    `reload ${index} retained its stale startup process group`);
+}
+JS
+  ) || status=$?
+  expect_code 0 "$status" "Pi reload exit-listener ownership"
+  [ -z "$out" ] || fail "Pi reload exit-listener ownership printed output: $out"
+  pass "Pi reload shutdown releases its exit listener and stale startup generation"
+}
+
 test_pi_large_sessionstart_digest_is_delivered_loudly() {
   local fixture out status=0
   command -v node >/dev/null 2>&1 || {
@@ -867,4 +974,5 @@ test_run_gate_and_scope_are_silent
 test_run_reports_a_failed_session_start_as_digest_text
 test_pi_startup_classifies_cli_continuations
 test_pi_sessionstart_generation_prerequisite
+test_pi_reload_releases_sessionstart_exit_listener
 test_pi_large_sessionstart_digest_is_delivered_loudly


### PR DESCRIPTION
## Intent

Fix the reproducible Pi `/new` startup-context race on the fetched current `origin/main` implementation base and publish one PR whose canonical base is exactly `github.com/kunchenguid/firstmate`, without merging it. The user-visible failure is triggered by submitting the first prompt immediately after `/new` while native startup digest generation is still running: the first provider call can occur before native delivery, lacks startup context, causes the documented manual fallback to run, and a later call then contains both manual and native startup digests. Preserve the comparison with the proven path where native startup completes before prompt submission, retain the deterministic local-provider reproduction as the regression basis, and seek disconfirming evidence for the ownership fix.

Implement the smallest current-code-aligned generation-bound owner in `.pi/extensions/fm-primary-turnend-guard.ts`: activate one generation on `session_start`, bind it to the Pi session and monotonic generation, make `before_agent_start` await that matching startup result and return the persistent context message immediately upstream of the first provider call, prevent asynchronous native delivery from racing that call, ignore stale generations, and terminate the matching child process group with no late delivery on shutdown or replacement. If an eligible native attempt fails or yields no digest, let that exact attempt settle before injecting the existing exact manual fallback instruction so native and manual generation never run concurrently. Preserve conservative full-start behavior, lock/refusal behavior, loud truncation and direct-inspection guidance, context-preserving source behavior, compaction behavior, and every supported Pi and pi-signed source route. Do not implement the investigation report's unrelated context-efficiency items 1-7.

Acceptance requires an end-to-end immediate-`/new` regression proving no provider call occurs before the matching prerequisite settles; exactly one startup execution and one model-visible startup context for each generation; the first provider payload contains that context; and deterministic executable coverage for interruption, shutdown, child/grandchild retirement, two rapid replacements, stale completion, empty output, spawn error, nonzero failure, intentional ineligibility, timeout, and truncation with no stale delivery. Keep existing startup, supervision, wake, and harness behavior passing across applicable Pi and pi-signed surfaces. Correct maintained documentation that previously claimed race-free delivery, keep one sentence per Markdown line, and route evidence to its proper owner. Run repository-prescribed syntax and lint checks, `bin/fm-doc-audience-check.sh`, documentation validation, applicable startup suites, and the real no-network Pi 0.84.0 regression using an isolated home, barrier-controlled digest, and deterministic local provider.

The preserved read-only investigation at `/Users/cmagana/cerebro/data/firstmate-public-head-context-plan-v1-s6/report.md` must remain unchanged. A later bounded base-vs-branch counterfactual established that the unchanged bootstrap-parallelism overlap assertion fails identically on exact `origin/main` under equivalent conditions, with byte-identical normalized timelines and no task diff touching its owners; preserve that as a pre-existing or environment-sensitive limitation and do not weaken, skip, or edit the unrelated bootstrap regression merely to obtain green. Publish only the task branch through the full no-mistakes pipeline, use GitHub author and committer identity exactly `M00NLIG7 <57321738+M00NLIG7@users.noreply.github.com>` with no agent co-author, verify that identity again before publication, open the authorized upstream PR against exactly `github.com/kunchenguid/firstmate`, and stop when its required CI is green. Never merge the PR.

## What Changed

- Gate Pi’s first provider call on the matching session-start generation and inject its startup context exactly once, with manual fallback only after an eligible native attempt settles unsuccessfully.
- Supervise and retire startup process groups on replacement, shutdown, interruption, or stale completion, while distinguishing intentional Pi prerequisite stand-downs from failures.
- Expand portable and offline Pi regression coverage for immediate `/new`, lifecycle and failure paths, and update documentation to reflect prerequisite-based delivery.

## Risk Assessment

✅ Low: Captain, the generation-bound prerequisite, supervised process-group lifecycle, failure fallback, and fixture dependency changes are coherent and no material source risk remains.

## Testing

With no prior baseline results supplied, I verified the required runtime, passed the targeted executable lifecycle/failure regression, and passed the real isolated no-network Pi 0.84.0 `/new` reproduction; the saved transcript demonstrates prompt blocking, exactly one native context per generation, and no manual fallback for both immediate and completed-before-prompt paths.

<details>
<summary>Evidence: Offline Pi `/new` race transcript</summary>

Source: [Offline Pi `/new` race transcript](https://github.com/M00NLIG7/firstmate/blob/545ca4e7904e540239520379c6388359d03a6a1b/.no-mistakes/evidence/fm/firstmate-pi-new-startup-race-fix-v1-f9/pi-0.84.0-immediate-new-race-transcript.txt)

<code>Pi 0.84.0: immediate and completed-before-prompt `/new` paths each made one first provider call with exactly one native startup context and no manual execution.</code>

```text
ok - Pi 0.84.0: immediate and completed-before-prompt /new paths each made one first provider call with exactly one native startup context and no manual execution
# fm-sessionstart-hook-live-e2e.test.sh: offline Pi /new race assertions passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a2d755e50509e9d617e0ebc33a565e3127e088ec","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (6) ✅</summary>

- 🚨 `.pi/extensions/fm-primary-turnend-guard.ts:189` - Retirement treats the direct child&#39;s `close` as proof that the entire process group exited. If a descendant ignores SIGTERM and has redirected/closed stdio, the leader can close first, `childClosed` becomes true, and SIGKILL is skipped, leaving that descendant running after replacement or shutdown. After the grace period, probe/kill the captured process group independently of the leader&#39;s close state, and cover a TERM-resistant descendant with closed stdio.

🔧 Fix: Captain, fix startup process-group retirement after leader exit
1 warning still open:
- ⚠️ `.pi/extensions/fm-primary-turnend-guard.ts:395` - The module-level exit listener is never removed. Pi clears and reloads extension modules on `/reload`, so each reload adds another retained `process.once(&#34;exit&#34;)` callback holding that module generation and potentially its 512 KiB result. Repeated reloads cause memory growth and eventually `MaxListenersExceededWarning`. Register cleanup per bound extension instance and remove it during `session_shutdown` so the replacement instance owns the sole exit fallback.

🔧 Fix: Captain, release reload exit listeners on shutdown
2 errors still open:
- 🚨 `.pi/extensions/fm-primary-turnend-guard.ts:484` - Pi supports same-bound-instance `session_shutdown` → `session_start` replacement, but shutdown permanently removes this instance&#39;s exit listener and session start never restores it. After `/new`, `/resume`, or `/fork`, a later active startup generation therefore lacks process-exit cleanup. Re-register the listener idempotently when each session activates, and add same-instance replacement coverage.
- 🚨 `.pi/extensions/fm-primary-turnend-guard.ts:439` - The process-exit fallback still depends on `generation.child`. If the leader closes while a TERM-resistant descendant with closed stdio remains, `markClosed()` clears that field, so exit cleanup skips the captured process group and orphans the descendant. On non-Windows platforms, signal the retained `processGroupId` directly even after leader close; preserve the current Windows path and cover this sequence.

🔧 Fix: Captain, complete startup exit lifecycle ownership
1 error still open:
- 🚨 `.pi/extensions/fm-primary-turnend-guard.ts:445` - A completed generation retains its numeric process-group ID indefinitely. After the child closes and that ID is reused, `/new`, shutdown, or process-exit cleanup can send TERM/SIGKILL to an unrelated process group. Monitor the retained group after leader close and clear `processGroupId` as soon as the group becomes empty, while preserving it for verified surviving descendants.

🔧 Fix: Captain, release empty startup process-group ownership promptly
2 errors still open:
- 🚨 `.pi/extensions/fm-primary-turnend-guard.ts:392` - The required criterion says, “If an eligible native attempt fails or yields no digest ... inject[] the existing exact manual fallback instruction,” but this allowlist suppresses fallback for `resume` and `fork` even when their child has a spawn error or nonzero exit. Preserve intentional context-restored silence for expected empty results, but return the exact fallback for failed eligible attempts on every source.
- 🚨 `.pi/extensions/fm-primary-turnend-guard.ts:193` - The 10 ms existence polling still retains only a reusable numeric process-group ID: after a successful probe, the matching group can empty and its ID can be reused before the next tick; the monitor then accepts the unrelated group as alive, and later replacement or process-exit cleanup sends it SIGTERM/SIGKILL. This leaves the previously reported unrelated-process termination reachable. Move retained ownership to a stable launch boundary—such as a supervisor that remains the group leader until ownership is released—rather than retaining an unidentifiable bare PGID after the leader closes.

🔧 Fix: Captain, supervise startup ownership and restore failure fallback
1 error still open:
- 🚨 `tests/fm-sessionstart-hook-live-e2e.test.sh:354` - Both isolated Pi fixture builders in this file copy the extension without its new `lib/fm-sessionstart-supervisor.mjs` runtime dependency (also see line 179). Node therefore exits with a missing-module error, and the required `/new` regression reaches fallback instead of producing `RACE_NATIVE` context. Copy the supervisor into each fixture’s `lib` directory so the live tests exercise the production path.

🔧 Fix: Captain, restore live Pi supervisor execution
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pi --version` and `tmux -V` confirmed Pi 0.84.0 and tmux 3.6a.</code>
- `tests/fm-sessionstart-nudge.test.sh`
- `FM_PI_SESSIONSTART_RACE_LIVE_E2E=1 tests/fm-sessionstart-hook-live-e2e.test.sh`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
