### PR TITLE
feat(bin): add deterministic fleet health checks

### DIFF
--- a/bin/fm-branch-outcome.sh
+++ b/bin/fm-branch-outcome.sh
@@ -152,7 +152,7 @@ case "$CMD" in
     [ -n "$SUMMARY" ] || usage
     case "$VERDICT" in routine|captain) ;; *) usage ;; esac
     case "$SILENT" in true|false) ;; *) usage ;; esac
-    lock_store
+    lock_store || exit 1
     if ! LAST_SEQ=$(last_seq); then
       fm_lock_release "$LOCK"
       echo "error: refusing append because the outcome store has a malformed final record" >&2
@@ -167,7 +167,7 @@ case "$CMD" in
     ;;
   unread)
     [ "$#" -eq 0 ] || usage
-    lock_store
+    lock_store || exit 1
     print_unread
     fm_lock_release "$LOCK"
     ;;
@@ -176,7 +176,7 @@ case "$CMD" in
     THROUGH=${2:-}
     case "$THROUGH" in ''|*[!0-9]*) usage ;; esac
     [ "$#" -eq 2 ] || usage
-    lock_store
+    lock_store || exit 1
     advance_cursor "$THROUGH"
     fm_lock_release "$LOCK"
     ;;
@@ -193,7 +193,7 @@ case "$CMD" in
     ;;
   startup-replay)
     [ "$#" -eq 0 ] || usage
-    lock_store
+    lock_store || exit 1
     UNREAD=$(print_unread)
     if [ -n "$UNREAD" ]; then
       VISIBLE=$(printf '%s\n' "$UNREAD" | jq -c 'select(.silent != true)')

--- a/bin/fm-branch-outcome.sh
+++ b/bin/fm-branch-outcome.sh
@@ -51,6 +51,13 @@ STORE="$STATE/branch-outcomes.jsonl"
 CURSOR="$STATE/.branch-outcomes-cursor"
 LOCK="$STATE/.branch-outcomes.lock"
 
+lock_store() {
+  [ ! -L "$STATE" ] || return 1
+  mkdir -p "$STATE"
+  [ -d "$STATE" ] && [ ! -L "$STATE" ]
+  fm_lock_acquire_wait "$LOCK"
+}
+
 usage() {
   echo "usage: fm-branch-outcome.sh append --task <id> --verdict routine|captain --summary <text> [--wake <text>] [--silent true|false] | unread | mark-read --through <seq> | list [--recent <n>] | startup-replay" >&2
   exit 2
@@ -145,7 +152,7 @@ case "$CMD" in
     [ -n "$SUMMARY" ] || usage
     case "$VERDICT" in routine|captain) ;; *) usage ;; esac
     case "$SILENT" in true|false) ;; *) usage ;; esac
-    fm_lock_acquire_wait "$LOCK"
+    lock_store
     if ! LAST_SEQ=$(last_seq); then
       fm_lock_release "$LOCK"
       echo "error: refusing append because the outcome store has a malformed final record" >&2
@@ -160,7 +167,7 @@ case "$CMD" in
     ;;
   unread)
     [ "$#" -eq 0 ] || usage
-    fm_lock_acquire_wait "$LOCK"
+    lock_store
     print_unread
     fm_lock_release "$LOCK"
     ;;
@@ -169,7 +176,7 @@ case "$CMD" in
     THROUGH=${2:-}
     case "$THROUGH" in ''|*[!0-9]*) usage ;; esac
     [ "$#" -eq 2 ] || usage
-    fm_lock_acquire_wait "$LOCK"
+    lock_store
     advance_cursor "$THROUGH"
     fm_lock_release "$LOCK"
     ;;
@@ -186,7 +193,7 @@ case "$CMD" in
     ;;
   startup-replay)
     [ "$#" -eq 0 ] || usage
-    fm_lock_acquire_wait "$LOCK"
+    lock_store
     UNREAD=$(print_unread)
     if [ -n "$UNREAD" ]; then
       VISIBLE=$(printf '%s\n' "$UNREAD" | jq -c 'select(.silent != true)')

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -50,6 +50,15 @@ case $- in *u*) _fm_classify_nounset=on ;; *) _fm_classify_nounset=off ;; esac
 [ "$_fm_classify_nounset" = on ] || set +u
 unset _fm_classify_nounset
 
+fm_evidence_classify() {
+  local readable=${1:-false} valid=${2:-false}
+  if [ "$readable" = true ] && [ "$valid" = true ]; then
+    printf 'available\n'
+  else
+    printf 'inconclusive\n'
+  fi
+}
+
 # Captain-relevant status verbs. A status line carrying any of these is work
 # firstmate must see. Lines without these verbs are no-verb signals: the watcher
 # absorbs them only with positive provably-working evidence, while the daemon uses

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -75,6 +75,7 @@ FM_CLASSIFY_CAPTAIN_RE_DEFAULT='done:|needs-decision:|blocked:|failed:|PR ready|
 # (status_is_paused) rather than hardcoding the literal, so the vocabulary cannot
 # drift between the two consumers. FM_CLASSIFY_PAUSED_VERB overrides it.
 FM_CLASSIFY_PAUSED_VERB_DEFAULT='paused'
+FM_CLASSIFY_STEP_COMPLETE_VERB_DEFAULT='step-complete'
 
 # Bounded re-surface cadence for a declared pause or a verified captain hold.
 # Far longer than the wedge threshold (FM_STALE_ESCALATE_SECS, default 240s), it
@@ -144,6 +145,13 @@ status_is_paused() {  # <status-line>
   [ -n "$line" ] || return 1
   verb=$(status_line_verb "$line")
   [ "$verb" = "${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}" ]
+}
+
+status_is_step_complete() {  # <status-line>
+  local line=$1 verb
+  [ -n "$line" ] || return 1
+  verb=$(status_line_verb "$line")
+  [ "$verb" = "${FM_CLASSIFY_STEP_COMPLETE_VERB:-$FM_CLASSIFY_STEP_COMPLETE_VERB_DEFAULT}" ]
 }
 
 # 0 if a status line's leading verb is the verified captain-held transfer verb.

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -84,7 +84,6 @@ FM_CLASSIFY_CAPTAIN_RE_DEFAULT='done:|needs-decision:|blocked:|failed:|PR ready|
 # (status_is_paused) rather than hardcoding the literal, so the vocabulary cannot
 # drift between the two consumers. FM_CLASSIFY_PAUSED_VERB overrides it.
 FM_CLASSIFY_PAUSED_VERB_DEFAULT='paused'
-FM_CLASSIFY_STEP_COMPLETE_VERB_DEFAULT='step-complete'
 
 # Bounded re-surface cadence for a declared pause or a verified captain hold.
 # Far longer than the wedge threshold (FM_STALE_ESCALATE_SECS, default 240s), it
@@ -154,13 +153,6 @@ status_is_paused() {  # <status-line>
   [ -n "$line" ] || return 1
   verb=$(status_line_verb "$line")
   [ "$verb" = "${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}" ]
-}
-
-status_is_step_complete() {  # <status-line>
-  local line=$1 verb
-  [ -n "$line" ] || return 1
-  verb=$(status_line_verb "$line")
-  [ "$verb" = "${FM_CLASSIFY_STEP_COMPLETE_VERB:-$FM_CLASSIFY_STEP_COMPLETE_VERB_DEFAULT}" ]
 }
 
 # 0 if a status line's leading verb is the verified captain-held transfer verb.

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -180,6 +180,8 @@ snapshot_shape_valid() {
       and (.endpoint.probe | type) == "string"
       and (.endpoint.probe | endpoint_probe_valid)
       and (.endpoint.codex_session | type) == "object"
+      and (.endpoint.codex_session.collected | type) == "boolean"
+      and (.endpoint.codex_session | nullable_key("reason"; "string"))
       and (.endpoint.codex_session | nullable_key("resume_banner"; "boolean"))
       and (.paths | type) == "object"
       and (.paths.status_log | type) == "object"
@@ -366,6 +368,12 @@ EVALUATED=$(jq -n \
   def terminal_state($s): ($s == "done" or $s == "failed");
   def codex_harness($t): (($t.harness // "") | startswith("codex"));
   def resume_banner($t): ($t.endpoint.codex_session.resume_banner == true);
+  def codex_capture_inconclusive($t):
+    (codex_harness($t)
+     and exists($t) == true
+     and (terminal_state($t.current_state.state) | not)
+     and ((agent_state($t) == "dead" or agent_state($t) == "missing") | not)
+     and $t.endpoint.codex_session.collected == false);
   def inbox_last($id):
     ([ $inbox_activity.records[]? | select(.task_id == $id) | .last_epoch ]
      | if length == 0 then null else max end);
@@ -479,7 +487,9 @@ EVALUATED=$(jq -n \
         | select(remote(.) | not)
         | select(.kind != "secondmate")
         | select(agent_state(.) == "ambiguous" or agent_state(.) == "unreadable"
-                 or agent_state(.) == "unverified" or agent_state(.) == "not_checked")
+                 or agent_state(.) == "unverified" or agent_state(.) == "not_checked"
+                 or codex_capture_inconclusive(.))
+        | select(resume_banner(.) | not)
         | finding("endpoint-inconclusive";.id;"notice";"inconclusive";
                   "agent or endpoint liveness could not be established";agent_state(.);1)),
       ($snapshot.tasks[]?

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -184,7 +184,7 @@ fi
 PENDING_JSON=$(fm_pending_reply_open_json "$STATE") \
   || PENDING_JSON='{"available":false,"now_epoch":null,"invalid_count":0,"records":[]}'
 INBOX_JSON=$(fm_task_inbox_unhandled_json "$STATE") \
-  || INBOX_JSON='{"available":false,"records":[]}'
+  || INBOX_JSON='{"available":false,"invalid_count":0,"unreadable_count":0,"records":[]}'
 LISTENERS_JSON=$(fm_procevent_listeners_json "$STATE") \
   || LISTENERS_JSON='{"available":false,"records":[]}'
 PR_JSON=$(fm_pr_poll_listeners_json "$STATE" "$SCRIPT_DIR/fm-pr-poll.sh") \
@@ -233,6 +233,16 @@ EVALUATED=$(jq -n \
       (if $inbox.available == false then
         finding("steering-inbox-inconclusive";"steering-inbox";"notice";"inconclusive";
                 "steering-inbox records could not be read";"unreadable";1)
+      else empty end),
+      (if ($inbox.invalid_count // 0) > 0 then
+        finding("steering-inbox-inconclusive";"steering-inbox";"notice";"inconclusive";
+                (($inbox.invalid_count | tostring) + " steering-inbox record(s) are invalid");
+                "invalid";$inbox.invalid_count)
+      else empty end),
+      (if ($inbox.unreadable_count // 0) > 0 then
+        finding("steering-inbox-inconclusive";"steering-inbox";"notice";"inconclusive";
+                (($inbox.unreadable_count | tostring) + " steering-inbox record(s) could not be aged");
+                "unreadable-record";$inbox.unreadable_count)
       else empty end),
       (if $listeners.available == false then
         finding("result-listener-inconclusive";"procevent";"notice";"inconclusive";

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -81,6 +81,7 @@ case "${1:-}" in
   "") ;;
   *) usage >&2; exit 2 ;;
 esac
+[ "$#" -le 1 ] || { usage >&2; exit 2; }
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-health: jq not found" >&2; exit 3; }
 
@@ -95,7 +96,7 @@ esac
 if [ "${FM_FLEET_HEALTH_TIMED_WORKER:-0}" != 1 ]; then
   WRAPPED_RC=0
   WRAPPED_OUTPUT=$(FM_FLEET_HEALTH_TIMED_WORKER=1 \
-    fm_run_timed "$FM_FLEET_HEALTH_TIMEOUT" "$0" "${1:-}") || WRAPPED_RC=$?
+    fm_run_timed "$FM_FLEET_HEALTH_TIMEOUT" "$0" "$@") || WRAPPED_RC=$?
   if [ "$WRAPPED_RC" -eq 124 ]; then
     NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     if [ "$OUTPUT_MODE" = json ]; then

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -182,8 +182,24 @@ snapshot_shape_valid() {
     and .schema == "fm-fleet-snapshot.v1"
     and (.generated | type) == "string"
     and (.fm_home | type) == "string"
+    and (.roots | type) == "object"
+    and (.roots.fm_root | type) == "string"
+    and (.roots.state | type) == "string"
+    and (.roots.data | type) == "string"
+    and (.roots.config | type) == "string"
+    and (.roots.projects | type) == "string"
+    and (.backlog | type) == "object"
+    and (.backlog.path | type) == "string"
+    and (.backlog.present | type) == "boolean"
+    and (.backlog.records | type) == "array"
+    and (.backlog.records | all(.[]; type == "object"))
     and (.tasks | type) == "array"
     and (.tasks | all(.[]; task_valid))
+    and (.scout_reports | type) == "array"
+    and (.scout_reports | all(.[]; type == "object"
+      and (.id | type) == "string"
+      and (.path | type) == "string"
+      and (.kind | type) == "string"))
     and (.collection | type) == "object"
     and (.collection.state | type) == "object"
     and (.collection.state.present | type) == "boolean"
@@ -202,6 +218,13 @@ snapshot_shape_valid() {
     and (.secondmate_current.registry.complete | type) == "boolean"
     and (.secondmate_current.registry.input_truncated | type) == "boolean"
     and (.secondmate_current.registry.records_truncated | type) == "boolean"
+    and (.secondmate_landed | type) == "object"
+    and (.secondmate_landed.records | type) == "array"
+    and (.secondmate_landed.truncated | type) == "array"
+    and (.secondmate_landed.unreadable | type) == "array"
+    and (.secondmate_landed.partial | type) == "array"
+    and (.secondmate_guidance | type) == "object"
+    and (.secondmate_guidance.note | type) == "string"
   '
 }
 

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -277,11 +277,19 @@ EVALUATED=$(jq -n \
         finding("supervision-inconclusive";"supervision";"notice";"inconclusive";
                 "supervision continuity could not be established";"unreadable";1)
       else empty end),
-      ($snapshot.tasks[]?
-        | select(remote(.) and (probe(.) == "skipped" or agent_state(.) == "not_collected" or agent_state(.) == "unreadable"))
-        | finding("remote-liveness-inconclusive";.id;"notice";"inconclusive";
-                  "remote liveness was not collected; a local placeholder is not remote evidence";
-                  "not_collected";1)),
+      (([
+          ($snapshot.tasks[]?
+            | select(remote(.) and (probe(.) == "skipped" or agent_state(.) == "not_collected" or agent_state(.) == "unreadable"))
+            | {id:.id}),
+          ($snapshot.secondmate_current.records[]?
+            | select(.current.state == "unknown")
+            | select((.current.failure_kind // "unknown") == "not_collected")
+            | {id:.id})
+        ]
+        | group_by(.id)[]) as $g
+        | finding("remote-liveness-inconclusive";$g[0].id;"notice";"inconclusive";
+                  "remote liveness or summary was not collected; a local placeholder is not remote evidence";
+                  "not_collected";($g | length))),
       ($snapshot.tasks[]?
         | select(remote(.) | not)
         | select(.kind != "secondmate")
@@ -298,6 +306,13 @@ EVALUATED=$(jq -n \
                  or agent_state(.) == "unverified" or agent_state(.) == "not_checked")
         | finding("endpoint-inconclusive";.id;"notice";"inconclusive";
                   "agent or endpoint liveness could not be established";agent_state(.);1)),
+      ($snapshot.tasks[]?
+        | select(remote(.) | not)
+        | select(.kind != "secondmate")
+        | select(agent_state(.) == "alive")
+        | select(.current_state.state == "unknown")
+        | finding("current-state-inconclusive";.id;"notice";"inconclusive";
+                  "worker lifecycle state could not be established";"unknown";1)),
       ($snapshot.tasks[]?
         | select(.kind == "secondmate")
         | select(remote(.) | not)

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -30,12 +30,12 @@
 # symptoms for one owner/cause collapse to one finding.
 #
 # Exit status:
-#   0  healthy: no high-confidence findings (inconclusive rows may still print)
+#   0  healthy: no findings
 #   1  actionable: at least one high-confidence finding
 #   2  usage error
-#   3  incomplete: the checker failed or could not finish
+#   3  inconclusive/incomplete: evidence is unavailable or checking did not finish
 #
-# Bounds: FM_FLEET_HEALTH_TIMEOUT (default 120) bounds snapshot collection.
+# Bounds: FM_FLEET_HEALTH_TIMEOUT (default 120) bounds the complete check.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -92,6 +92,24 @@ case "$FM_FLEET_HEALTH_TIMEOUT" in
     ;;
 esac
 
+if [ "${FM_FLEET_HEALTH_TIMED_WORKER:-0}" != 1 ]; then
+  WRAPPED_RC=0
+  WRAPPED_OUTPUT=$(FM_FLEET_HEALTH_TIMED_WORKER=1 \
+    fm_run_timed "$FM_FLEET_HEALTH_TIMEOUT" "$0" "${1:-}") || WRAPPED_RC=$?
+  if [ "$WRAPPED_RC" -eq 124 ]; then
+    NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    if [ "$OUTPUT_MODE" = json ]; then
+      jq -n --arg generated "$NOW" --arg home "$FM_HOME" \
+        '{schema:"fm-fleet-health.v1",generated:$generated,fm_home:$home,status:"incomplete",snapshot_generated:null,reason:"fleet health check timed out",findings:[]}'
+    else
+      printf '# Fleet Health\nStatus: incomplete\nHome: %s\nfleet health check timed out\n' "$FM_HOME"
+    fi
+    exit 3
+  fi
+  printf '%s\n' "$WRAPPED_OUTPUT"
+  exit "$WRAPPED_RC"
+fi
+
 fingerprint_hex() {
   local key=$1 digest
   if command -v shasum >/dev/null 2>&1; then
@@ -124,8 +142,10 @@ collect_pr_listeners_json() {
     case "$id" in
       x-watch|tool-updates) continue ;;
     esac
-    records=$(jq -n --argjson records "$records" --arg id "$id" \
-      '$records + [{id:$id,armed:true}]')
+    if fm_pr_poll_artifacts_valid "$state" "$id" "$SCRIPT_DIR/fm-pr-poll.sh"; then
+      records=$(jq -n --argjson records "$records" --arg id "$id" \
+        '$records + [{id:$id,armed:true}]')
+    fi
   done
   jq -n --argjson records "$records" '{available:true,records:$records}'
 }
@@ -196,7 +216,6 @@ PR_JSON=$(collect_pr_listeners_json "$STATE") \
 SUPERVISION_JSON=$(collect_supervision_json "$STATE" "$SCRIPT_DIR/fm-watch.sh") \
   || SUPERVISION_JSON='{"available":false,"needed":false,"ok":false,"reason":null,"model":null}'
 
-PENDING_GRACE=$(fm_pending_reply_grace_secs)
 INBOX_GRACE=$(fm_task_inbox_grace_secs)
 
 EVALUATED=$(jq -n \
@@ -207,7 +226,6 @@ EVALUATED=$(jq -n \
   --argjson listeners "$LISTENERS_JSON" \
   --argjson prs "$PR_JSON" \
   --argjson supervision "$SUPERVISION_JSON" \
-  --argjson pending_grace "$PENDING_GRACE" \
   --argjson inbox_grace "$INBOX_GRACE" \
   '
   def finding($kind; $subject; $severity; $confidence; $evidence; $cause; $count):
@@ -246,15 +264,16 @@ EVALUATED=$(jq -n \
       ($snapshot.tasks[]?
         | select(remote(.) | not)
         | select(.kind != "secondmate")
-        | select(exists(.) == false)
+        | select(exists(.) == false or alive(.) == "dead")
         | select(terminal_state(.current_state.state) | not)
         | finding("dead-direct-report";.id;"error";"high";
-                  ("recorded endpoint is absent while current state is " + .current_state.state);
-                  "absent";1)),
+                  (if exists(.) == false then "recorded endpoint is absent while current state is " + .current_state.state
+                   else "direct-report agent is dead while its endpoint remains present" end);
+                  (if exists(.) == false then "absent" else "dead" end);1)),
       ($snapshot.tasks[]?
         | select(remote(.) | not)
         | select(.kind != "secondmate")
-        | select(exists(.) == null)
+        | select(exists(.) == null or alive(.) == "unknown")
         | select(terminal_state(.current_state.state) | not)
         | finding("endpoint-inconclusive";.id;"notice";"inconclusive";
                   "endpoint presence could not be established";"unknown";1)),
@@ -292,19 +311,20 @@ EVALUATED=$(jq -n \
       ($snapshot.secondmate_current.records[]?
         | select(.current.state == "unknown")
         | . as $row
-        | (($row.current.reason // "") ) as $reason
-        | if ($reason | test("not collected")) then
+        | ($row.current.reason // "secondmate current state is unknown") as $reason
+        | ($row.current.failure_kind // "unknown") as $failure
+        | if $failure == "not_collected" then
             empty
-          elif ($reason | test("timed out")) then
+          elif $failure == "timeout" then
             finding("secondmate-summary-unavailable";$row.id;"warning";"high";
                     $reason;"timeout";1)
-          elif ($reason | test("invalid home|malformed|invalid remote|not registered")) then
+          elif $failure == "invalid" then
             finding("secondmate-summary-invalid";$row.id;"error";"high";
                     $reason;"invalid";1)
-          elif ($reason | test("child current state unavailable")) then
+          elif $failure == "child_unavailable" then
             finding("secondmate-summary-inconclusive";$row.id;"notice";"inconclusive";
                     $reason;"child_unavailable";1)
-          elif ($reason | test("failed|unreadable|unavailable")) then
+          elif $failure == "unavailable" then
             finding("secondmate-summary-unavailable";$row.id;"warning";"high";
                     $reason;"unavailable";1)
           else
@@ -313,9 +333,17 @@ EVALUATED=$(jq -n \
                     "unknown";1)
           end),
       (if ($snapshot.secondmate_current.registry.available == false) then
-        finding("secondmate-summary-unavailable";"secondmate-registry";"warning";"high";
+        finding("secondmate-summary-inconclusive";"secondmate-registry";"notice";"inconclusive";
                 ($snapshot.secondmate_current.registry.reason // "registered secondmate table is unavailable");
                 "registry";1)
+      else empty end),
+      (if (($snapshot.secondmate_current.truncated // 0) > 0
+           or $snapshot.secondmate_current.registry.complete == false
+           or $snapshot.secondmate_current.registry.input_truncated == true
+           or $snapshot.secondmate_current.registry.records_truncated == true) then
+        finding("secondmate-summary-inconclusive";"secondmate-inventory";"notice";"inconclusive";
+                "bounded secondmate inventory omitted records or source data";"truncated";
+                (($snapshot.secondmate_current.truncated // 0) + 1))
       else empty end),
       ((($pending.records // [])
         | map(select(.phase == "delivery_unknown" or .phase == "recovery_failed" or .phase == "recovery_unknown"))
@@ -329,14 +357,14 @@ EVALUATED=$(jq -n \
         | map(select(.phase != "escalated"))
         | map(select(
             (.phase == "awaiting_report" and .request_turn_completed_epoch != null
-             and $now != 0 and (($now - .request_turn_completed_epoch) >= $pending_grace))
+             and $now != 0 and (($now - .request_turn_completed_epoch) >= .grace_secs))
             or (.phase == "recovery_sent" and .recovery_turn_completed_epoch != null
-                and $now != 0 and (($now - .recovery_turn_completed_epoch) >= $pending_grace))
+                and $now != 0 and (($now - .recovery_turn_completed_epoch) >= .grace_secs))
           ))
         | group_by(.task_id)[]) as $g
         | ($g | length) as $n
         | finding("pending-reply-overdue";$g[0].task_id;"warning";"high";
-                  ("reply delivery is overdue by at least the pending-reply grace (" + ($pending_grace|tostring) + "s)");
+                  "reply delivery is overdue by at least its recorded pending-reply grace";
                   "overdue";$n)),
       ((($inbox.records // [])
         | map(select(.age_seconds != null and .age_seconds >= $inbox_grace))
@@ -399,9 +427,10 @@ REPORT=$(jq -n \
   --argjson base "$EVALUATED" \
   --argjson findings "$FINDINGS_OUT" '
   ($findings | any(.confidence == "high")) as $actionable
+  | ($findings | any(.confidence == "inconclusive")) as $inconclusive
   | $base
   | .findings = $findings
-  | .status = (if $actionable then "actionable" else "healthy" end)
+  | .status = (if $actionable then "actionable" elif $inconclusive then "inconclusive" else "healthy" end)
 ')
 
 if [ "$OUTPUT_MODE" = json ]; then

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -15,8 +15,7 @@
 #
 # Findings are mechanically provable Firstmate operational failures: dead or
 # missing local agents, a Codex worker whose pane shows the exact resume banner
-# or a bare shell while the task is still in flight, a worker `done:` or
-# canonical `step-complete:` signal
+# or a bare shell while the task is still in flight, a worker `done:` signal
 # with no later status append or steering inbox activity for
 # FM_FLEET_HEALTH_HANDOFF_STALE_SECS (default 1800), unavailable or invalid
 # secondmate summaries, broken or overdue reply delivery, aged unacknowledged
@@ -79,8 +78,8 @@ JSON is the stable machine-readable output contract.
 
 The checker consumes fm-fleet-snapshot.sh --json once, with remote SSH probes
 disabled by default, and never mutates fleet state.
-FM_FLEET_HEALTH_HANDOFF_STALE_SECS (default 1800) is the age after a terminal
-handoff signal with no later status append or steering-inbox activity that
+FM_FLEET_HEALTH_HANDOFF_STALE_SECS (default 1800) is the age after a `done:`
+status line with no later status append or steering-inbox activity that
 becomes a missed-handoff finding.
 EOF
 }
@@ -117,6 +116,9 @@ if [ "${FM_FLEET_HEALTH_TIMED_WORKER:-0}" != 1 ]; then
       printf '# Fleet Health\nStatus: incomplete\nHome: %s\nfleet health check timed out\n' "$FM_HOME"
     fi
     exit 3
+  fi
+  if [ "$WRAPPED_RC" -eq 2 ]; then
+    exit 2
   fi
   if [ "$OUTPUT_MODE" = json ] \
     && ! printf '%s' "$WRAPPED_OUTPUT" | jq -e '.schema == "fm-fleet-health.v1"' >/dev/null 2>&1; then
@@ -183,7 +185,6 @@ snapshot_shape_valid() {
       and (.paths.status_log | type) == "object"
       and (.paths.status_log.last_event | type) == "object"
       and (.paths.status_log.last_event.state | type) == "string"
-      and (.paths.status_log.last_event.handoff_required | type) == "boolean"
       and (.paths.status_log.last_event | nullable_key("mtime_epoch"; "number"))
       and (.pr | type) == "object"
       and (.pr | nullable_key("url"; "string"))
@@ -600,8 +601,7 @@ EVALUATED=$(jq -n \
                   "aged";$n)),
       ($snapshot.tasks[]?
         | select(.kind != "secondmate")
-        | select((.paths.status_log.last_event.state // "") == "done"
-                 or (.paths.status_log.last_event.handoff_required // false) == true)
+        | select((.paths.status_log.last_event.state // "") == "done")
         | . as $t
         | ($t.paths.status_log.last_event.mtime_epoch) as $mtime
         | if ($mtime == null or $now_epoch == 0) then

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -273,6 +273,11 @@ EVALUATED=$(jq -n \
                 ($snapshot.collection.state.reason // "fleet state could not be inventoried");
                 "unavailable";1)
       else empty end),
+      (if ($snapshot.collection.state.invalid_metadata_count // 0) > 0 then
+        finding("fleet-inventory-inconclusive";"metadata";"notice";"inconclusive";
+                (($snapshot.collection.state.invalid_metadata_count | tostring) + " task metadata entrie(s) are invalid or unreadable");
+                "invalid-metadata";$snapshot.collection.state.invalid_metadata_count)
+      else empty end),
       (if $supervision.needed == true and $supervision.available == false then
         finding("supervision-inconclusive";"supervision";"notice";"inconclusive";
                 "supervision continuity could not be established";"unreadable";1)

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -206,7 +206,7 @@ if ! printf '%s' "$SNAPSHOT" | jq -e '.schema == "fm-fleet-snapshot.v1"' >/dev/n
 fi
 
 PENDING_JSON=$(fm_pending_reply_open_json "$STATE") \
-  || PENDING_JSON='{"available":false,"now_epoch":null,"records":[]}'
+  || PENDING_JSON='{"available":false,"now_epoch":null,"invalid_count":0,"records":[]}'
 INBOX_JSON=$(fm_task_inbox_unhandled_json "$STATE") \
   || INBOX_JSON='{"available":false,"records":[]}'
 LISTENERS_JSON=$(fm_procevent_listeners_json "$STATE") \
@@ -249,6 +249,11 @@ EVALUATED=$(jq -n \
       (if $pending.available == false then
         finding("pending-reply-inconclusive";"pending-replies";"notice";"inconclusive";
                 "pending-reply records could not be read";"unreadable";1)
+      else empty end),
+      (if ($pending.invalid_count // 0) > 0 then
+        finding("pending-reply-inconclusive";"pending-replies";"notice";"inconclusive";
+                (($pending.invalid_count | tostring) + " pending-reply record(s) are invalid");
+                "invalid";$pending.invalid_count)
       else empty end),
       (if $inbox.available == false then
         finding("steering-inbox-inconclusive";"steering-inbox";"notice";"inconclusive";

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -235,6 +235,12 @@ EVALUATED=$(jq -n \
   def remote($t): ($t.remote != null);
   def probe($t): ($t.endpoint.probe // "none");
   def alive($t): ($t.endpoint.agent_alive // "not_checked");
+  def agent_state($t): ($t.endpoint.agent_state //
+    (if alive($t) == "alive" then "alive"
+     elif alive($t) == "dead" and $t.endpoint.exists == false then "missing"
+     elif alive($t) == "dead" then "dead"
+     elif alive($t) == "not_collected" then "not_collected"
+     else "unreadable" end));
   def exists($t): $t.endpoint.exists;
   def terminal_state($s): ($s == "done" or $s == "failed");
   def skip_wait($s): ($s == "parked" or $s == "paused" or $s == "blocked");
@@ -257,43 +263,45 @@ EVALUATED=$(jq -n \
                 "supervision continuity could not be established";"unreadable";1)
       else empty end),
       ($snapshot.tasks[]?
-        | select(remote(.) and (probe(.) == "skipped" or alive(.) == "not_collected" or alive(.) == "unknown"))
+        | select(remote(.) and (probe(.) == "skipped" or agent_state(.) == "not_collected" or agent_state(.) == "unreadable"))
         | finding("remote-liveness-inconclusive";.id;"notice";"inconclusive";
                   "remote liveness was not collected; a local placeholder is not remote evidence";
                   "not_collected";1)),
       ($snapshot.tasks[]?
         | select(remote(.) | not)
         | select(.kind != "secondmate")
-        | select(exists(.) == false or alive(.) == "dead")
+        | select(agent_state(.) == "dead" or agent_state(.) == "missing")
         | select(terminal_state(.current_state.state) | not)
         | finding("dead-direct-report";.id;"error";"high";
-                  (if exists(.) == false then "recorded endpoint is absent while current state is " + .current_state.state
+                  (if agent_state(.) == "missing" then "recorded endpoint is absent while current state is " + .current_state.state
                    else "direct-report agent is dead while its endpoint remains present" end);
-                  (if exists(.) == false then "absent" else "dead" end);1)),
+                  agent_state(.);1)),
       ($snapshot.tasks[]?
         | select(remote(.) | not)
         | select(.kind != "secondmate")
-        | select(exists(.) == null or alive(.) == "unknown")
+        | select(agent_state(.) == "ambiguous" or agent_state(.) == "unreadable"
+                 or agent_state(.) == "unverified" or agent_state(.) == "not_checked")
         | select(terminal_state(.current_state.state) | not)
         | finding("endpoint-inconclusive";.id;"notice";"inconclusive";
-                  "endpoint presence could not be established";"unknown";1)),
+                  "agent or endpoint liveness could not be established";agent_state(.);1)),
       ($snapshot.tasks[]?
         | select(.kind == "secondmate")
         | select(remote(.) | not)
-        | select(alive(.) == "dead" or exists(.) == false)
+        | select(agent_state(.) == "dead" or agent_state(.) == "missing")
         | finding("dead-secondmate";.id;"error";"high";
-                  (if exists(.) == false then "recorded secondmate endpoint is absent"
+                  (if agent_state(.) == "missing" then "recorded secondmate endpoint is absent"
                    else "secondmate agent is dead" end);
-                  (if exists(.) == false then "absent" else "dead" end);1)),
+                  agent_state(.);1)),
       ($snapshot.tasks[]?
         | select(.kind == "secondmate")
         | select(remote(.) | not)
-        | select(alive(.) == "unknown" or (alive(.) == "not_checked" and exists(.) == null))
+        | select(agent_state(.) == "ambiguous" or agent_state(.) == "unreadable"
+                 or agent_state(.) == "unverified" or agent_state(.) == "not_checked")
         | finding("endpoint-inconclusive";.id;"notice";"inconclusive";
-                  "secondmate liveness could not be established";"unknown";1)),
+                  "secondmate liveness could not be established";agent_state(.);1)),
       ($snapshot.tasks[]?
         | select(remote(.))
-        | select(probe(.) == "remote" and alive(.) == "dead")
+        | select(probe(.) == "remote" and (agent_state(.) == "dead" or agent_state(.) == "missing"))
         | finding("dead-secondmate";.id;"error";"high";
                   "remote secondmate agent is dead";"remote-dead";1)),
       ($snapshot.tasks[]?
@@ -324,6 +332,9 @@ EVALUATED=$(jq -n \
           elif $failure == "child_unavailable" then
             finding("secondmate-summary-inconclusive";$row.id;"notice";"inconclusive";
                     $reason;"child_unavailable";1)
+          elif $failure == "registry_incomplete" then
+            finding("secondmate-summary-inconclusive";$row.id;"notice";"inconclusive";
+                    $reason;"registry_incomplete";1)
           elif $failure == "unavailable" then
             finding("secondmate-summary-unavailable";$row.id;"warning";"high";
                     $reason;"unavailable";1)

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -155,8 +155,12 @@ snapshot_shape_valid() {
     def nullable($expected): (. == null or type == $expected);
     def nullable_key($key; $expected): has($key)
       and (.[ $key ] == null or (.[ $key] | type) == $expected);
-    def task_state_valid: ["working","parked","done","blocked","paused","failed","unknown"] | index(.) != null;
-    def secondmate_state_valid: ["active_child_work","captain_decision","externally_held","no_active_work","unknown"] | index(.) != null;
+    def enum($values): . as $value | ($values | index($value)) != null;
+    def task_state_valid: enum(["working","parked","done","blocked","paused","failed","unknown"]);
+    def secondmate_state_valid: enum(["active_child_work","captain_decision","externally_held","no_active_work","unknown"]);
+    def endpoint_agent_state_valid: enum(["not_checked","not_collected","alive","dead","missing","ambiguous","unreadable","unverified"]);
+    def endpoint_agent_alive_valid: enum(["not_checked","not_collected","alive","dead","unknown"]);
+    def endpoint_probe_valid: enum(["none","local","remote","skipped"]);
     def task_valid:
       type == "object"
       and (.id | type) == "string"
@@ -168,8 +172,11 @@ snapshot_shape_valid() {
       and (.endpoint | type) == "object"
       and (.endpoint | nullable_key("exists"; "boolean"))
       and (.endpoint.agent_state | type) == "string"
+      and (.endpoint.agent_state | endpoint_agent_state_valid)
       and (.endpoint.agent_alive | type) == "string"
+      and (.endpoint.agent_alive | endpoint_agent_alive_valid)
       and (.endpoint.probe | type) == "string"
+      and (.endpoint.probe | endpoint_probe_valid)
       and (.endpoint.codex_session | type) == "object"
       and (.endpoint.codex_session | nullable_key("resume_banner"; "boolean"))
       and (.paths | type) == "object"
@@ -631,13 +638,12 @@ EVALUATED=$(jq -n \
                     "pr-poll";1)
           else empty end),
       (($listeners.records // [])[]
-        | select(.owner == "missing" or .owner == "stale" or .owner == "orphaned"
-                 or .owner == "invalid")
+        | select(.owner == "missing" or .owner == "stale" or .owner == "orphaned")
         | finding("result-listener-missing";.id;"error";"high";
                   ("process-event source has no live result listener (owner=" + .owner + ")");
                   .owner;1)),
       (($listeners.records // [])[]
-        | select(.owner == "uncertain" or .owner == "unreadable")
+        | select(.owner == "uncertain" or .owner == "unreadable" or .owner == "invalid")
         | finding("result-listener-inconclusive";.id;"notice";"inconclusive";
                   "process-event listener liveness or registration could not be established";.owner;1)),
       (if $supervision.needed == true and $supervision.available == true

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -15,7 +15,7 @@
 #
 # Findings are mechanically provable Firstmate operational failures: dead or
 # missing local agents, a Codex worker whose pane shows the exact resume banner
-# or a bare shell while the task is still in flight, a worker `done:` signal
+# or a bare shell while the task is still in flight, a scaffold-contracted stop signal
 # with no later status append or steering inbox activity for
 # FM_FLEET_HEALTH_HANDOFF_STALE_SECS (default 1800), unavailable or invalid
 # secondmate summaries, broken or overdue reply delivery, aged unacknowledged
@@ -78,8 +78,8 @@ JSON is the stable machine-readable output contract.
 
 The checker consumes fm-fleet-snapshot.sh --json once, with remote SSH probes
 disabled by default, and never mutates fleet state.
-FM_FLEET_HEALTH_HANDOFF_STALE_SECS (default 1800) is the age after a `done:`
-status line with no later status append or steering-inbox activity that
+FM_FLEET_HEALTH_HANDOFF_STALE_SECS (default 1800) is the age after a contracted
+stop status with no later status append or steering-inbox activity that
 becomes a missed-handoff finding.
 EOF
 }
@@ -187,6 +187,7 @@ snapshot_shape_valid() {
       and (.paths.status_log | type) == "object"
       and (.paths.status_log.last_event | type) == "object"
       and (.paths.status_log.last_event.state | type) == "string"
+      and (.paths.status_log.last_event.handoff_required | type) == "boolean"
       and (.paths.status_log.last_event | nullable_key("mtime_epoch"; "number"))
       and (.pr | type) == "object"
       and (.pr | nullable_key("url"; "string"))
@@ -611,7 +612,7 @@ EVALUATED=$(jq -n \
                   "aged";$n)),
       ($snapshot.tasks[]?
         | select(.kind != "secondmate")
-        | select((.paths.status_log.last_event.state // "") == "done")
+        | select(.paths.status_log.last_event.handoff_required == true)
         | . as $t
         | ($t.paths.status_log.last_event.mtime_epoch) as $mtime
         | if ($mtime == null or $now_epoch == 0) then

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -429,7 +429,8 @@ EVALUATED=$(jq -n \
         | select(terminal_state(.current_state.state) | not)
         | select($prs.available == true)
         | .id as $id
-        | select([$prs.records[]?.id] | index($id) | not)
+        | select(any($prs.records[]?;
+                     .id == $id and (.armed == true or .terminal_notified == true)) | not)
         | finding("result-listener-missing";$id;"error";"high";
                   "in-flight ship with a recorded PR has no armed merge-poll listener";
                   "pr-poll";1)),

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -418,8 +418,14 @@ EVALUATED=$(jq -n \
                     + ($prs.unreadable_count | tostring) + " unreadable PR-listener artifact(s)"
                   else ""
                   end)
+                 + (if ($prs.metadata_invalid_count // 0) > 0 then
+                    (if (($prs.invalid_count // 0) + ($prs.unreadable_count // 0)) > 0 then "; " else "" end)
+                    + ($prs.metadata_invalid_count | tostring) + " current PR metadata record(s) are invalid"
+                  else ""
+                  end)
                  | if . == "" then "PR-listener registrations could not be read" else . end);
-                "unreadable";(($prs.invalid_count // 0) + ($prs.unreadable_count // 0)))
+                (if ($prs.metadata_invalid_count // 0) > 0 then "invalid-pr-metadata" else "unreadable" end);
+                (($prs.invalid_count // 0) + ($prs.unreadable_count // 0) + ($prs.metadata_invalid_count // 0)))
       else empty end),
       (if $snapshot.collection.state.available == false then
         finding("fleet-inventory-inconclusive";"state";"notice";"inconclusive";

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -51,6 +51,9 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 # shellcheck source=bin/fm-timeout-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-classify-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-classify-lib.sh"
 # shellcheck source=bin/fm-pending-reply-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-pending-reply-lib.sh"
@@ -147,37 +150,44 @@ fingerprint_hex() {
 }
 
 snapshot_shape_valid() {
-  printf '%s' "$1" | jq -e '
+  local shape_valid=false classification
+  if printf '%s' "$1" | jq -e '
     def nullable($expected): (. == null or type == $expected);
+    def nullable_key($key; $expected): has($key)
+      and (.[ $key ] == null or (.[ $key] | type) == $expected);
+    def task_state_valid: ["working","parked","done","blocked","paused","failed","unknown"] | index(.) != null;
+    def secondmate_state_valid: ["active_child_work","captain_decision","externally_held","no_active_work","unknown"] | index(.) != null;
     def task_valid:
       type == "object"
       and (.id | type) == "string"
       and (.kind | type) == "string"
-      and (.remote | nullable("object"))
+      and nullable_key("remote"; "object")
       and (.current_state | type) == "object"
       and (.current_state.state | type) == "string"
+      and (.current_state.state | task_state_valid)
       and (.endpoint | type) == "object"
-      and (.endpoint.exists | nullable("boolean"))
+      and (.endpoint | nullable_key("exists"; "boolean"))
       and (.endpoint.agent_state | type) == "string"
       and (.endpoint.agent_alive | type) == "string"
       and (.endpoint.probe | type) == "string"
       and (.endpoint.codex_session | type) == "object"
-      and (.endpoint.codex_session.resume_banner | nullable("boolean"))
+      and (.endpoint.codex_session | nullable_key("resume_banner"; "boolean"))
       and (.paths | type) == "object"
       and (.paths.status_log | type) == "object"
       and (.paths.status_log.last_event | type) == "object"
       and (.paths.status_log.last_event.state | type) == "string"
       and (.paths.status_log.last_event.handoff_required | type) == "boolean"
-      and (.paths.status_log.last_event.mtime_epoch | nullable("number"))
+      and (.paths.status_log.last_event | nullable_key("mtime_epoch"; "number"))
       and (.pr | type) == "object"
-      and (.pr.url | nullable("string"))
+      and (.pr | nullable_key("url"; "string"))
       and (.pr.source | type) == "string";
     def secondmate_valid:
       type == "object"
       and (.id | type) == "string"
       and (.current | type) == "object"
       and (.current.state | type) == "string"
-      and (.current.failure_kind | nullable("string"));
+      and (.current.state | secondmate_state_valid)
+      and (.current | nullable_key("failure_kind"; "string"));
     type == "object"
     and .schema == "fm-fleet-snapshot.v1"
     and (.generated | type) == "string"
@@ -225,7 +235,11 @@ snapshot_shape_valid() {
     and (.secondmate_landed.partial | type) == "array"
     and (.secondmate_guidance | type) == "object"
     and (.secondmate_guidance.note | type) == "string"
-  '
+  ' >/dev/null 2>&1; then
+    shape_valid=true
+  fi
+  classification=$(fm_evidence_classify true "$shape_valid")
+  [ "$classification" = available ]
 }
 
 collect_supervision_json() {
@@ -388,7 +402,17 @@ EVALUATED=$(jq -n \
       else empty end),
       (if $prs.available == false then
         finding("result-listener-inconclusive";"pr-polls";"notice";"inconclusive";
-                "PR-listener registrations could not be read";"unreadable";1)
+                ((if ($prs.invalid_count // 0) > 0 then
+                    ($prs.invalid_count | tostring) + " invalid PR-listener artifact(s)"
+                  else ""
+                  end)
+                 + (if ($prs.unreadable_count // 0) > 0 then
+                    (if ($prs.invalid_count // 0) > 0 then "; " else "" end)
+                    + ($prs.unreadable_count | tostring) + " unreadable PR-listener artifact(s)"
+                  else ""
+                  end)
+                 | if . == "" then "PR-listener registrations could not be read" else . end);
+                "unreadable";(($prs.invalid_count // 0) + ($prs.unreadable_count // 0)))
       else empty end),
       (if $snapshot.collection.state.available == false then
         finding("fleet-inventory-inconclusive";"state";"notice";"inconclusive";

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -15,7 +15,8 @@
 #
 # Findings are mechanically provable Firstmate operational failures: dead or
 # missing local agents, a Codex worker whose pane shows the exact resume banner
-# or a bare shell while the task is still in flight, a worker `done:` signal
+# or a bare shell while the task is still in flight, a worker `done:` or
+# canonical `step-complete:` signal
 # with no later status append or steering inbox activity for
 # FM_FLEET_HEALTH_HANDOFF_STALE_SECS (default 1800), unavailable or invalid
 # secondmate summaries, broken or overdue reply delivery, aged unacknowledged
@@ -75,8 +76,8 @@ JSON is the stable machine-readable output contract.
 
 The checker consumes fm-fleet-snapshot.sh --json once, with remote SSH probes
 disabled by default, and never mutates fleet state.
-FM_FLEET_HEALTH_HANDOFF_STALE_SECS (default 1800) is the age after a `done:`
-status line with no later status append or steering-inbox activity that
+FM_FLEET_HEALTH_HANDOFF_STALE_SECS (default 1800) is the age after a terminal
+handoff signal with no later status append or steering-inbox activity that
 becomes a missed-handoff finding.
 EOF
 }
@@ -145,6 +146,65 @@ fingerprint_hex() {
   printf 'sha256:%s' "$digest"
 }
 
+snapshot_shape_valid() {
+  printf '%s' "$1" | jq -e '
+    def nullable($expected): (. == null or type == $expected);
+    def task_valid:
+      type == "object"
+      and (.id | type) == "string"
+      and (.kind | type) == "string"
+      and (.remote | nullable("object"))
+      and (.current_state | type) == "object"
+      and (.current_state.state | type) == "string"
+      and (.endpoint | type) == "object"
+      and (.endpoint.exists | nullable("boolean"))
+      and (.endpoint.agent_state | type) == "string"
+      and (.endpoint.agent_alive | type) == "string"
+      and (.endpoint.probe | type) == "string"
+      and (.endpoint.codex_session | type) == "object"
+      and (.endpoint.codex_session.resume_banner | nullable("boolean"))
+      and (.paths | type) == "object"
+      and (.paths.status_log | type) == "object"
+      and (.paths.status_log.last_event | type) == "object"
+      and (.paths.status_log.last_event.state | type) == "string"
+      and (.paths.status_log.last_event.handoff_required | type) == "boolean"
+      and (.paths.status_log.last_event.mtime_epoch | nullable("number"))
+      and (.pr | type) == "object"
+      and (.pr.url | nullable("string"))
+      and (.pr.source | type) == "string";
+    def secondmate_valid:
+      type == "object"
+      and (.id | type) == "string"
+      and (.current | type) == "object"
+      and (.current.state | type) == "string"
+      and (.current.failure_kind | nullable("string"));
+    type == "object"
+    and .schema == "fm-fleet-snapshot.v1"
+    and (.generated | type) == "string"
+    and (.fm_home | type) == "string"
+    and (.tasks | type) == "array"
+    and (.tasks | all(.[]; task_valid))
+    and (.collection | type) == "object"
+    and (.collection.state | type) == "object"
+    and (.collection.state.present | type) == "boolean"
+    and (.collection.state.available | type) == "boolean"
+    and (.collection.state.invalid_metadata_count | type) == "number"
+    and (.collection.state.invalid_metadata | type) == "array"
+    and (.main_inventory | type) == "object"
+    and (.main_inventory.valid | type) == "boolean"
+    and (.main_inventory.reason | nullable("string"))
+    and (.secondmate_current | type) == "object"
+    and (.secondmate_current.records | type) == "array"
+    and (.secondmate_current.records | all(.[]; secondmate_valid))
+    and (.secondmate_current.truncated | type) == "number"
+    and (.secondmate_current.registry | type) == "object"
+    and (.secondmate_current.registry.available | type) == "boolean"
+    and (.secondmate_current.registry.complete | type) == "boolean"
+    and (.secondmate_current.registry.input_truncated | type) == "boolean"
+    and (.secondmate_current.registry.records_truncated | type) == "boolean"
+  '
+}
+
 collect_supervision_json() {
   local state=$1 watch=$2 needed available ok reason model
   fm_supervision_status "$state" >/dev/null
@@ -195,7 +255,7 @@ if [ "$SNAPSHOT_RC" -ne 0 ]; then
   fi
   exit 3
 fi
-if ! printf '%s' "$SNAPSHOT" | jq -e '.schema == "fm-fleet-snapshot.v1"' >/dev/null 2>&1; then
+if ! snapshot_shape_valid "$SNAPSHOT" >/dev/null 2>&1; then
   if [ "$OUTPUT_MODE" = json ]; then
     jq -n --arg generated "$NOW" --arg home "$FM_HOME" \
       '{schema:"fm-fleet-health.v1",generated:$generated,fm_home:$home,status:"incomplete",snapshot_generated:null,reason:"fleet snapshot was malformed",findings:[]}'
@@ -288,6 +348,16 @@ EVALUATED=$(jq -n \
         finding("steering-inbox-inconclusive";"steering-inbox";"notice";"inconclusive";
                 (($inbox.unreadable_count | tostring) + " steering-inbox record(s) could not be aged");
                 "unreadable-record";$inbox.unreadable_count)
+      else empty end),
+      (if ($inbox_activity.invalid_count // 0) > 0 then
+        finding("steering-inbox-inconclusive";"steering-inbox";"notice";"inconclusive";
+                (($inbox_activity.invalid_count | tostring) + " steering-inbox activity record(s) are invalid");
+                "activity-invalid";$inbox_activity.invalid_count)
+      else empty end),
+      (if ($inbox_activity.unreadable_count // 0) > 0 then
+        finding("steering-inbox-inconclusive";"steering-inbox";"notice";"inconclusive";
+                (($inbox_activity.unreadable_count | tostring) + " steering-inbox activity record(s) could not be read or aged");
+                "activity-unreadable";$inbox_activity.unreadable_count)
       else empty end),
       (if $listeners.available == false then
         finding("result-listener-inconclusive";"procevent";"notice";"inconclusive";
@@ -470,7 +540,8 @@ EVALUATED=$(jq -n \
                   "aged";$n)),
       ($snapshot.tasks[]?
         | select(.kind != "secondmate")
-        | select((.paths.status_log.last_event.state // "") == "done")
+        | select((.paths.status_log.last_event.state // "") == "done"
+                 or (.paths.status_log.last_event.handoff_required // false) == true)
         | . as $t
         | ($t.paths.status_log.last_event.mtime_epoch) as $mtime
         | if ($mtime == null or $now_epoch == 0) then
@@ -478,9 +549,12 @@ EVALUATED=$(jq -n \
                     "done-signal age could not be established";"mtime-unavailable";1)
           elif ($now_epoch - $mtime) < $handoff_stale then
             empty
-          elif $inbox_activity.available == false then
+          elif $inbox_activity.available == false
+               or ($inbox_activity.invalid_count // 0) > 0
+               or ($inbox_activity.unreadable_count // 0) > 0 then
             finding("missed-handoff-inconclusive";$t.id;"notice";"inconclusive";
-                    "steering-inbox activity after done could not be read";"inbox-unavailable";1)
+                    "steering-inbox activity after the handoff signal could not be established";
+                    "inbox-activity-unavailable";1)
           elif ((inbox_last($t.id) != null) and (inbox_last($t.id) >= $mtime)) then
             empty
           else
@@ -493,14 +567,22 @@ EVALUATED=$(jq -n \
         | select(.kind == "ship")
         | select((.pr.url // null) != null)
         | select(.pr.source == "meta")
-        | select(terminal_state(.current_state.state) | not)
         | select($prs.available == true)
         | .id as $id
-        | select(any($prs.records[]?;
-                     .id == $id and (.armed == true or .terminal_notified == true)) | not)
-        | finding("result-listener-missing";$id;"error";"high";
-                  "in-flight ship with a recorded PR has no armed merge-poll listener";
-                  "pr-poll";1)),
+        | if .current_state.state == "unknown" then
+            finding("result-listener-inconclusive";$id;"notice";"inconclusive";
+                    "worker lifecycle state is unknown, so PR-listener requirement cannot be established";
+                    "worker-state-unknown";1)
+          elif (.current_state.state == "working"
+                or .current_state.state == "parked"
+                or .current_state.state == "blocked"
+                or .current_state.state == "paused")
+               and (any($prs.records[]?;
+                        .id == $id and (.armed == true or .terminal_notified == true)) | not) then
+            finding("result-listener-missing";$id;"error";"high";
+                    "in-flight ship with a recorded PR has no armed merge-poll listener";
+                    "pr-poll";1)
+          else empty end),
       (($listeners.records // [])[]
         | select(.owner == "missing" or .owner == "stale" or .owner == "orphaned"
                  or .owner == "invalid")

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -14,11 +14,15 @@
 # no recovery the wake queue and watcher continuity do not already provide.
 #
 # Findings are mechanically provable Firstmate operational failures: dead or
-# missing local agents, unavailable or invalid secondmate summaries, broken or
-# overdue reply delivery, aged unacknowledged steering-inbox messages,
-# inconsistent active-work inventory, terminal workers that still have a live
-# endpoint, missing required result listeners, and unhealthy supervision
-# continuity when `fm_watcher_supervision_verdict` can establish it.
+# missing local agents, a Codex worker whose pane shows the exact resume banner
+# or a bare shell while the task is still in flight, a worker `done:` signal
+# with no later status append or steering inbox activity for
+# FM_FLEET_HEALTH_HANDOFF_STALE_SECS (default 1800), unavailable or invalid
+# secondmate summaries, broken or overdue reply delivery, aged unacknowledged
+# steering-inbox messages, inconsistent active-work inventory, terminal workers
+# that still have a live endpoint, missing required result listeners, and
+# unhealthy supervision continuity when `fm_watcher_supervision_verdict` can
+# establish it.
 # Product decisions, ordinary external waits, and historical status events are
 # out of scope. Unavailable evidence is `inconclusive`, never healthy and never
 # definitely broken. A remote task's local placeholder window is never remote
@@ -71,6 +75,9 @@ JSON is the stable machine-readable output contract.
 
 The checker consumes fm-fleet-snapshot.sh --json once, with remote SSH probes
 disabled by default, and never mutates fleet state.
+FM_FLEET_HEALTH_HANDOFF_STALE_SECS (default 1800) is the age after a `done:`
+status line with no later status append or steering-inbox activity that
+becomes a missed-handoff finding.
 EOF
 }
 
@@ -210,16 +217,32 @@ SUPERVISION_JSON=$(collect_supervision_json "$STATE" "$SCRIPT_DIR/fm-watch.sh") 
   || SUPERVISION_JSON='{"available":false,"needed":false,"ok":false,"reason":null,"model":null}'
 
 INBOX_GRACE=$(fm_task_inbox_grace_secs)
+HANDOFF_STALE=${FM_FLEET_HEALTH_HANDOFF_STALE_SECS:-1800}
+case "$HANDOFF_STALE" in
+  ''|*[!0-9]*)
+    echo "fm-fleet-health: FM_FLEET_HEALTH_HANDOFF_STALE_SECS must be a non-negative integer" >&2
+    exit 2
+    ;;
+esac
+INBOX_ACTIVITY_JSON=$(fm_task_inbox_latest_activity_json "$STATE") \
+  || INBOX_ACTIVITY_JSON='{"available":false,"records":[]}'
+NOW_EPOCH=$(date +%s)
+case "$NOW_EPOCH" in
+  ''|*[!0-9]*) NOW_EPOCH=0 ;;
+esac
 
 EVALUATED=$(jq -n \
   --arg generated "$NOW" \
   --argjson snapshot "$SNAPSHOT" \
   --argjson pending "$PENDING_JSON" \
   --argjson inbox "$INBOX_JSON" \
+  --argjson inbox_activity "$INBOX_ACTIVITY_JSON" \
   --argjson listeners "$LISTENERS_JSON" \
   --argjson prs "$PR_JSON" \
   --argjson supervision "$SUPERVISION_JSON" \
   --argjson inbox_grace "$INBOX_GRACE" \
+  --argjson handoff_stale "$HANDOFF_STALE" \
+  --argjson now_epoch "$NOW_EPOCH" \
   '
   def finding($kind; $subject; $severity; $confidence; $evidence; $cause; $count):
     {kind:$kind,subject:$subject,severity:$severity,confidence:$confidence,
@@ -236,6 +259,11 @@ EVALUATED=$(jq -n \
      else "unreadable" end));
   def exists($t): $t.endpoint.exists;
   def terminal_state($s): ($s == "done" or $s == "failed");
+  def codex_harness($t): (($t.harness // "") | startswith("codex"));
+  def resume_banner($t): ($t.endpoint.codex_session.resume_banner == true);
+  def inbox_last($id):
+    ([ $inbox_activity.records[]? | select(.task_id == $id) | .last_epoch ]
+     | if length == 0 then null else max end);
   ($pending.now_epoch // 0) as $now
   | [
       (if $pending.available == false then
@@ -301,10 +329,21 @@ EVALUATED=$(jq -n \
         | select(.kind != "secondmate")
         | select(agent_state(.) == "dead" or agent_state(.) == "missing")
         | select(terminal_state(.current_state.state) | not)
+        | select((codex_harness(.) and exists(.) == true and agent_state(.) == "dead") | not)
         | finding("dead-direct-report";.id;"error";"high";
                   (if agent_state(.) == "missing" then "recorded endpoint is absent while current state is " + .current_state.state
                    else "direct-report agent is dead while its endpoint remains present" end);
                   agent_state(.);1)),
+      ($snapshot.tasks[]?
+        | select(remote(.) | not)
+        | select(.kind != "secondmate")
+        | select(codex_harness(.))
+        | select(terminal_state(.current_state.state) | not)
+        | select(resume_banner(.) or (exists(.) == true and agent_state(.) == "dead"))
+        | finding("dead-codex-session";.id;"error";"high";
+                  (if resume_banner(.) then "Codex session exited; pane contains the resume banner"
+                   else "Codex session exited; endpoint pane is a bare shell" end);
+                  (if resume_banner(.) then "resume-banner" else "bare-shell" end);1)),
       ($snapshot.tasks[]?
         | select(remote(.) | not)
         | select(.kind != "secondmate")
@@ -317,6 +356,7 @@ EVALUATED=$(jq -n \
         | select(.kind != "secondmate")
         | select(agent_state(.) == "alive")
         | select(.current_state.state == "unknown")
+        | select(resume_banner(.) | not)
         | finding("current-state-inconclusive";.id;"notice";"inconclusive";
                   "worker lifecycle state could not be established";"unknown";1)),
       ($snapshot.tasks[]?
@@ -428,6 +468,27 @@ EVALUATED=$(jq -n \
         | finding("steering-inbox-aged";$g[0].task_id;"warning";"high";
                   ($n|tostring) + " unacknowledged steering message(s) older than grace (" + ($inbox_grace|tostring) + "s)";
                   "aged";$n)),
+      ($snapshot.tasks[]?
+        | select(.kind != "secondmate")
+        | select((.paths.status_log.last_event.state // "") == "done")
+        | . as $t
+        | ($t.paths.status_log.last_event.mtime_epoch) as $mtime
+        | if ($mtime == null or $now_epoch == 0) then
+            finding("missed-handoff-inconclusive";$t.id;"notice";"inconclusive";
+                    "done-signal age could not be established";"mtime-unavailable";1)
+          elif ($now_epoch - $mtime) < $handoff_stale then
+            empty
+          elif $inbox_activity.available == false then
+            finding("missed-handoff-inconclusive";$t.id;"notice";"inconclusive";
+                    "steering-inbox activity after done could not be read";"inbox-unavailable";1)
+          elif ((inbox_last($t.id) != null) and (inbox_last($t.id) >= $mtime)) then
+            empty
+          else
+            finding("missed-handoff";$t.id;"warning";"high";
+                    ("worker signaled done with no later status append or steering message for at least "
+                     + ($handoff_stale|tostring) + "s");
+                    "stale-done";1)
+          end),
       ($snapshot.tasks[]?
         | select(.kind == "ship")
         | select((.pr.url // null) != null)

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -270,7 +270,6 @@ EVALUATED=$(jq -n \
         | select(.kind != "secondmate")
         | select(agent_state(.) == "ambiguous" or agent_state(.) == "unreadable"
                  or agent_state(.) == "unverified" or agent_state(.) == "not_checked")
-        | select(terminal_state(.current_state.state) | not)
         | finding("endpoint-inconclusive";.id;"notice";"inconclusive";
                   "agent or endpoint liveness could not be established";agent_state(.);1)),
       ($snapshot.tasks[]?
@@ -376,6 +375,7 @@ EVALUATED=$(jq -n \
       ($snapshot.tasks[]?
         | select(.kind == "ship")
         | select((.pr.url // null) != null)
+        | select(.pr.source == "meta")
         | select(terminal_state(.current_state.state) | not)
         | select($prs.available == true)
         | .id as $id
@@ -384,14 +384,15 @@ EVALUATED=$(jq -n \
                   "in-flight ship with a recorded PR has no armed merge-poll listener";
                   "pr-poll";1)),
       (($listeners.records // [])[]
-        | select(.owner == "missing" or .owner == "stale" or .owner == "orphaned")
+        | select(.owner == "missing" or .owner == "stale" or .owner == "orphaned"
+                 or .owner == "invalid")
         | finding("result-listener-missing";.id;"error";"high";
                   ("process-event source has no live result listener (owner=" + .owner + ")");
                   .owner;1)),
       (($listeners.records // [])[]
-        | select(.owner == "uncertain")
+        | select(.owner == "uncertain" or .owner == "unreadable")
         | finding("result-listener-inconclusive";.id;"notice";"inconclusive";
-                  "process-event listener liveness could not be established";"uncertain";1)),
+                  "process-event listener liveness or registration could not be established";.owner;1)),
       (if $supervision.needed == true and $supervision.ok == false then
         finding("supervision-unhealthy";"supervision";"error";"high";
                 ("supervision is required but unhealthy (" + ($supervision.reason // "unknown") + ")");

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -181,6 +181,8 @@ snapshot_shape_valid() {
       and (.endpoint.codex_session | nullable_key("resume_banner"; "boolean"))
       and (.paths | type) == "object"
       and (.paths.status_log | type) == "object"
+      and (.paths.status_log.available | type) == "boolean"
+      and (.paths.status_log | nullable_key("reason"; "string"))
       and (.paths.status_log.last_event | type) == "object"
       and (.paths.status_log.last_event.state | type) == "string"
       and (.paths.status_log.last_event.handoff_required | type) == "boolean"
@@ -611,12 +613,18 @@ EVALUATED=$(jq -n \
                   "aged";$n)),
       ($snapshot.tasks[]?
         | select(.kind != "secondmate")
+        | select(.paths.status_log.available == false)
+        | finding("missed-handoff-inconclusive";.id;"notice";"inconclusive";
+                  "task status-log evidence could not be established";"status-log-unavailable";1)),
+      ($snapshot.tasks[]?
+        | select(.kind != "secondmate")
+        | select(.paths.status_log.available == true)
         | select(.paths.status_log.last_event.handoff_required == true)
         | . as $t
         | ($t.paths.status_log.last_event.mtime_epoch) as $mtime
         | if ($mtime == null or $now_epoch == 0) then
             finding("missed-handoff-inconclusive";$t.id;"notice";"inconclusive";
-                    "done-signal age could not be established";"mtime-unavailable";1)
+                    "handoff-signal age could not be established";"mtime-unavailable";1)
           elif ($now_epoch - $mtime) < $handoff_stale then
             empty
           elif inbox_activity_available($t.id) == false then
@@ -627,17 +635,21 @@ EVALUATED=$(jq -n \
             empty
           else
             finding("missed-handoff";$t.id;"warning";"high";
-                    ("worker signaled done with no later status append or steering message for at least "
+                    ("worker signaled " + $t.paths.status_log.last_event.state
+                     + " awaiting the next instruction, with no later status append or steering message for at least "
                      + ($handoff_stale|tostring) + "s");
-                    "stale-done";1)
+                    ("stale-" + $t.paths.status_log.last_event.state);1)
           end),
       ($snapshot.tasks[]?
         | select(.kind == "ship")
         | select((.pr.url // null) != null)
         | select(.pr.source == "meta")
-        | select($prs.available == true)
         | .id as $id
-        | if .current_state.state == "unknown" then
+        | if any((($prs.invalid // []) + ($prs.unreadable // []) + ($prs.metadata_invalid // []))[]?; .id == $id) then
+            finding("result-listener-inconclusive";$id;"notice";"inconclusive";
+                    "PR-listener evidence for this task is invalid or unreadable";
+                    "task-listener-unavailable";1)
+          elif .current_state.state == "unknown" then
             finding("result-listener-inconclusive";$id;"notice";"inconclusive";
                     "worker lifecycle state is unknown, so PR-listener requirement cannot be established";
                     "worker-state-unknown";1)

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -333,7 +333,7 @@ case "$HANDOFF_STALE" in
     ;;
 esac
 INBOX_ACTIVITY_JSON=$(fm_task_inbox_latest_activity_json "$STATE") \
-  || INBOX_ACTIVITY_JSON='{"available":false,"records":[]}'
+  || INBOX_ACTIVITY_JSON='{"available":false,"root_available":false,"records":[]}'
 NOW_EPOCH=$(date +%s)
 case "$NOW_EPOCH" in
   ''|*[!0-9]*) NOW_EPOCH=0 ;;
@@ -378,6 +378,9 @@ EVALUATED=$(jq -n \
   def inbox_last($id):
     ([ $inbox_activity.records[]? | select(.task_id == $id) | .last_epoch ]
      | if length == 0 then null else max end);
+  def inbox_activity_available($id):
+    ([ $inbox_activity.records[]? | select(.task_id == $id) | .available ]
+     | if length == 0 then ($inbox_activity.root_available // false) else all end);
   ($pending.now_epoch // 0) as $now
   | [
       (if $pending.available == false then
@@ -620,9 +623,7 @@ EVALUATED=$(jq -n \
                     "done-signal age could not be established";"mtime-unavailable";1)
           elif ($now_epoch - $mtime) < $handoff_stale then
             empty
-          elif $inbox_activity.available == false
-               or ($inbox_activity.invalid_count // 0) > 0
-               or ($inbox_activity.unreadable_count // 0) > 0 then
+          elif inbox_activity_available($t.id) == false then
             finding("missed-handoff-inconclusive";$t.id;"notice";"inconclusive";
                     "steering-inbox activity after the handoff signal could not be established";
                     "inbox-activity-unavailable";1)

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -106,6 +106,17 @@ if [ "${FM_FLEET_HEALTH_TIMED_WORKER:-0}" != 1 ]; then
     fi
     exit 3
   fi
+  if [ "$OUTPUT_MODE" = json ] \
+    && ! printf '%s' "$WRAPPED_OUTPUT" | jq -e '.schema == "fm-fleet-health.v1"' >/dev/null 2>&1; then
+    NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    jq -n --arg generated "$NOW" --arg home "$FM_HOME" \
+      '{schema:"fm-fleet-health.v1",generated:$generated,fm_home:$home,status:"incomplete",snapshot_generated:null,reason:"fleet health check failed",findings:[]}'
+    exit 3
+  fi
+  if [ "$OUTPUT_MODE" != json ] && [ -z "$WRAPPED_OUTPUT" ] && [ "$WRAPPED_RC" -ne 0 ]; then
+    printf '# Fleet Health\nStatus: incomplete\nHome: %s\nfleet health check failed\n' "$FM_HOME"
+    exit 3
+  fi
   printf '%s\n' "$WRAPPED_OUTPUT"
   exit "$WRAPPED_RC"
 fi
@@ -127,11 +138,15 @@ fingerprint_hex() {
 }
 
 collect_supervision_json() {
-  local state=$1 watch=$2 needed ok reason model
+  local state=$1 watch=$2 needed available ok reason model
   fm_supervision_status "$state" >/dev/null
   needed=$FM_SUP_NEEDED
   fm_watcher_supervision_verdict "$state" "$watch"
-  if [ "$FM_WATCHER_VERDICT_OK" = true ]; then
+  available=$FM_WATCHER_VERDICT_AVAILABLE
+  if [ "$available" != true ]; then
+    ok=false
+    reason=unreadable
+  elif [ "$FM_WATCHER_VERDICT_OK" = true ]; then
     ok=true
     reason=null
   else
@@ -141,11 +156,12 @@ collect_supervision_json() {
   model=$(fm_supervision_model)
   jq -n \
     --argjson needed "$( [ "$needed" = true ] && printf true || printf false )" \
+    --argjson available "$( [ "$available" = true ] && printf true || printf false )" \
     --argjson ok "$( [ "$ok" = true ] && printf true || printf false )" \
     --arg reason "${reason:-}" \
     --arg model "$model" \
     '{
-      available:true,
+      available:$available,
       needed:$needed,
       ok:$ok,
       reason:(if $reason == "null" or $reason == "" then null else $reason end),
@@ -257,7 +273,7 @@ EVALUATED=$(jq -n \
                 ($snapshot.collection.state.reason // "fleet state could not be inventoried");
                 "unavailable";1)
       else empty end),
-      (if $supervision.available == false then
+      (if $supervision.needed == true and $supervision.available == false then
         finding("supervision-inconclusive";"supervision";"notice";"inconclusive";
                 "supervision continuity could not be established";"unreadable";1)
       else empty end),
@@ -355,13 +371,22 @@ EVALUATED=$(jq -n \
                 (($snapshot.secondmate_current.truncated // 0) + 1))
       else empty end),
       ((($pending.records // [])
-        | map(select(.phase == "delivery_unknown" or .phase == "recovery_failed" or .phase == "recovery_unknown"))
+        | map(select(.phase == "delivery_unknown" or .phase == "recovery_failed" or .phase == "recovery_unknown"
+                     or .recovery_verdict == "orphaned" or .recovery_verdict == "failed"
+                     or .recovery_verdict == "unknown"))
         | group_by(.task_id)[]) as $g
         | ($g | length) as $n
         | ($g[0].task_id) as $task
         | finding("pending-reply-broken";$task;"error";"high";
                   ("broken reply delivery (" + ([ $g[].phase ] | unique | join(", ")) + ")");
                   "broken";$n)),
+      ((($pending.records // [])
+        | map(select(.recovery_verdict == "unreadable"))
+        | group_by(.task_id)[]) as $g
+        | ($g | length) as $n
+        | finding("pending-reply-inconclusive";$g[0].task_id;"notice";"inconclusive";
+                  "recovery sender or delivery identity could not be established";
+                  "recovery-unreadable";$n)),
       ((($pending.records // [])
         | map(select(.phase != "escalated"))
         | map(select(
@@ -403,7 +428,8 @@ EVALUATED=$(jq -n \
         | select(.owner == "uncertain" or .owner == "unreadable")
         | finding("result-listener-inconclusive";.id;"notice";"inconclusive";
                   "process-event listener liveness or registration could not be established";.owner;1)),
-      (if $supervision.needed == true and $supervision.ok == false then
+      (if $supervision.needed == true and $supervision.available == true
+          and $supervision.ok == false then
         finding("supervision-unhealthy";"supervision";"error";"high";
                 ("supervision is required but unhealthy (" + ($supervision.reason // "unknown") + ")");
                 ($supervision.reason // "unhealthy");1)

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -7,11 +7,7 @@
 # does not acquire the session lock, drain wakes, arm watchers, steer, relaunch,
 # acknowledge records, or otherwise repair anything.
 #
-# Activation is not in this phase. The smallest later integration is a custom
-# watcher slow-check that runs this command and prints one line only when the
-# high-confidence fingerprint set changes, so a finding enters the durable wake
-# queue and unchanged repeats stay quiet. Cron and Herdr composer injection add
-# no recovery the wake queue and watcher continuity do not already provide.
+# The checker is not scheduled or activated automatically.
 #
 # Findings are mechanically provable Firstmate operational failures: dead or
 # missing local agents, a Codex worker whose pane shows the exact resume banner

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+# fm-fleet-health.sh - read-only fleet operational health checker.
+#
+# Output contract: default human view, `--json` prints one object with schema
+# `fm-fleet-health.v1`. The command consumes `bin/fm-fleet-snapshot.sh --json`
+# once and existing owner helpers for facts the snapshot does not carry. It
+# does not acquire the session lock, drain wakes, arm watchers, steer, relaunch,
+# acknowledge records, or otherwise repair anything.
+#
+# Activation is not in this phase. The smallest later integration is a custom
+# watcher slow-check that runs this command and prints one line only when the
+# high-confidence fingerprint set changes, so a finding enters the durable wake
+# queue and unchanged repeats stay quiet. Cron and Herdr composer injection add
+# no recovery the wake queue and watcher continuity do not already provide.
+#
+# Findings are mechanically provable Firstmate operational failures: dead or
+# missing local agents, unavailable or invalid secondmate summaries, broken or
+# overdue reply delivery, aged unacknowledged steering-inbox messages,
+# inconsistent active-work inventory, terminal workers that still have a live
+# endpoint, missing required result listeners, and unhealthy supervision
+# continuity when `fm_watcher_supervision_verdict` can establish it.
+# Product decisions, ordinary external waits, and historical status events are
+# out of scope. Unavailable evidence is `inconclusive`, never healthy and never
+# definitely broken. A remote task's local placeholder window is never remote
+# liveness; the default collection sets FM_SNAPSHOT_REMOTE_PROBES=0 so this
+# command makes no SSH or GitHub calls.
+#
+# Each finding has kind, subject, evidence, severity, confidence, count, and a
+# deterministic fingerprint (sha256 of kind, subject, and cause). Repeated
+# symptoms for one owner/cause collapse to one finding.
+#
+# Exit status:
+#   0  healthy: no high-confidence findings (inconclusive rows may still print)
+#   1  actionable: at least one high-confidence finding
+#   2  usage error
+#   3  incomplete: the checker failed or could not finish
+#
+# Bounds: FM_FLEET_HEALTH_TIMEOUT (default 120) bounds snapshot collection.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-timeout-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-pending-reply-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-pending-reply-lib.sh"
+# shellcheck source=bin/fm-task-inbox-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-task-inbox-lib.sh"
+# shellcheck source=bin/fm-supervision-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-supervision-lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-procevent-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-procevent-lib.sh"
+
+usage() {
+  cat <<'EOF'
+usage: fm-fleet-health.sh [--json]
+
+Print a read-only operational health report for this Firstmate home.
+JSON is the stable machine-readable output contract.
+
+The checker consumes fm-fleet-snapshot.sh --json once, with remote SSH probes
+disabled by default, and never mutates fleet state.
+EOF
+}
+
+OUTPUT_MODE=human
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  --json) OUTPUT_MODE=json ;;
+  "") ;;
+  *) usage >&2; exit 2 ;;
+esac
+
+command -v jq >/dev/null 2>&1 || { echo "fm-fleet-health: jq not found" >&2; exit 3; }
+
+FM_FLEET_HEALTH_TIMEOUT=${FM_FLEET_HEALTH_TIMEOUT:-120}
+case "$FM_FLEET_HEALTH_TIMEOUT" in
+  ''|*[!0-9]*|0)
+    echo "fm-fleet-health: FM_FLEET_HEALTH_TIMEOUT must be a positive integer" >&2
+    exit 2
+    ;;
+esac
+
+fingerprint_hex() {
+  local key=$1 digest
+  if command -v shasum >/dev/null 2>&1; then
+    digest=$(printf '%s' "$key" | shasum -a 256 | awk '{print $1}')
+  elif command -v sha256sum >/dev/null 2>&1; then
+    digest=$(printf '%s' "$key" | sha256sum | awk '{print $1}')
+  else
+    return 1
+  fi
+  case "$digest" in
+    *[!0-9a-f]*) return 1 ;;
+  esac
+  [ "${#digest}" -eq 64 ] || return 1
+  printf 'sha256:%s' "$digest"
+}
+
+collect_pr_listeners_json() {
+  local state=$1 f id records='[]'
+  if [ ! -d "$state" ]; then
+    jq -n '{available:true,records:[]}'
+    return 0
+  fi
+  if [ ! -r "$state" ]; then
+    jq -n '{available:false,records:[]}'
+    return 0
+  fi
+  for f in "$state"/*.check.sh; do
+    [ -f "$f" ] || continue
+    id=$(basename "$f" .check.sh)
+    case "$id" in
+      x-watch|tool-updates) continue ;;
+    esac
+    records=$(jq -n --argjson records "$records" --arg id "$id" \
+      '$records + [{id:$id,armed:true}]')
+  done
+  jq -n --argjson records "$records" '{available:true,records:$records}'
+}
+
+collect_supervision_json() {
+  local state=$1 watch=$2 needed ok reason model
+  fm_supervision_status "$state" >/dev/null
+  needed=$FM_SUP_NEEDED
+  fm_watcher_supervision_verdict "$state" "$watch"
+  if [ "$FM_WATCHER_VERDICT_OK" = true ]; then
+    ok=true
+    reason=null
+  else
+    ok=false
+    reason=$FM_WATCHER_VERDICT_REASON
+  fi
+  model=$(fm_supervision_model)
+  jq -n \
+    --argjson needed "$( [ "$needed" = true ] && printf true || printf false )" \
+    --argjson ok "$( [ "$ok" = true ] && printf true || printf false )" \
+    --arg reason "${reason:-}" \
+    --arg model "$model" \
+    '{
+      available:true,
+      needed:$needed,
+      ok:$ok,
+      reason:(if $reason == "null" or $reason == "" then null else $reason end),
+      model:$model
+    }'
+}
+
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+SNAPSHOT_RC=0
+SNAPSHOT=$(
+  FM_SNAPSHOT_REMOTE_PROBES=0 \
+    fm_run_timed "$FM_FLEET_HEALTH_TIMEOUT" \
+    "$SCRIPT_DIR/fm-fleet-snapshot.sh" --json
+) || SNAPSHOT_RC=$?
+if [ "$SNAPSHOT_RC" -ne 0 ]; then
+  reason="fleet snapshot failed"
+  [ "$SNAPSHOT_RC" -eq 124 ] && reason="fleet snapshot timed out"
+  if [ "$OUTPUT_MODE" = json ]; then
+    jq -n --arg generated "$NOW" --arg home "$FM_HOME" --arg reason "$reason" \
+      '{schema:"fm-fleet-health.v1",generated:$generated,fm_home:$home,status:"incomplete",snapshot_generated:null,reason:$reason,findings:[]}'
+  else
+    printf '# Fleet Health\nStatus: incomplete\nHome: %s\n%s\n' "$FM_HOME" "$reason"
+  fi
+  exit 3
+fi
+if ! printf '%s' "$SNAPSHOT" | jq -e '.schema == "fm-fleet-snapshot.v1"' >/dev/null 2>&1; then
+  if [ "$OUTPUT_MODE" = json ]; then
+    jq -n --arg generated "$NOW" --arg home "$FM_HOME" \
+      '{schema:"fm-fleet-health.v1",generated:$generated,fm_home:$home,status:"incomplete",snapshot_generated:null,reason:"fleet snapshot was malformed",findings:[]}'
+  else
+    printf '# Fleet Health\nStatus: incomplete\nHome: %s\nfleet snapshot was malformed\n' "$FM_HOME"
+  fi
+  exit 3
+fi
+
+PENDING_JSON=$(fm_pending_reply_open_json "$STATE") \
+  || PENDING_JSON='{"available":false,"now_epoch":null,"records":[]}'
+INBOX_JSON=$(fm_task_inbox_unhandled_json "$STATE") \
+  || INBOX_JSON='{"available":false,"records":[]}'
+LISTENERS_JSON=$(fm_procevent_listeners_json "$STATE") \
+  || LISTENERS_JSON='{"available":false,"records":[]}'
+PR_JSON=$(collect_pr_listeners_json "$STATE") \
+  || PR_JSON='{"available":false,"records":[]}'
+SUPERVISION_JSON=$(collect_supervision_json "$STATE" "$SCRIPT_DIR/fm-watch.sh") \
+  || SUPERVISION_JSON='{"available":false,"needed":false,"ok":false,"reason":null,"model":null}'
+
+PENDING_GRACE=$(fm_pending_reply_grace_secs)
+INBOX_GRACE=$(fm_task_inbox_grace_secs)
+
+EVALUATED=$(jq -n \
+  --arg generated "$NOW" \
+  --argjson snapshot "$SNAPSHOT" \
+  --argjson pending "$PENDING_JSON" \
+  --argjson inbox "$INBOX_JSON" \
+  --argjson listeners "$LISTENERS_JSON" \
+  --argjson prs "$PR_JSON" \
+  --argjson supervision "$SUPERVISION_JSON" \
+  --argjson pending_grace "$PENDING_GRACE" \
+  --argjson inbox_grace "$INBOX_GRACE" \
+  '
+  def finding($kind; $subject; $severity; $confidence; $evidence; $cause; $count):
+    {kind:$kind,subject:$subject,severity:$severity,confidence:$confidence,
+     evidence:$evidence,cause:$cause,count:$count,
+     fingerprint_key:($kind + "\t" + $subject + "\t" + $cause)};
+  def remote($t): ($t.remote != null);
+  def probe($t): ($t.endpoint.probe // "none");
+  def alive($t): ($t.endpoint.agent_alive // "not_checked");
+  def exists($t): $t.endpoint.exists;
+  def terminal_state($s): ($s == "done" or $s == "failed");
+  def skip_wait($s): ($s == "parked" or $s == "paused" or $s == "blocked");
+  ($pending.now_epoch // 0) as $now
+  | [
+      (if $pending.available == false then
+        finding("pending-reply-inconclusive";"pending-replies";"notice";"inconclusive";
+                "pending-reply records could not be read";"unreadable";1)
+      else empty end),
+      (if $inbox.available == false then
+        finding("steering-inbox-inconclusive";"steering-inbox";"notice";"inconclusive";
+                "steering-inbox records could not be read";"unreadable";1)
+      else empty end),
+      (if $listeners.available == false then
+        finding("result-listener-inconclusive";"procevent";"notice";"inconclusive";
+                "process-event registrations could not be read";"unreadable";1)
+      else empty end),
+      (if $supervision.available == false then
+        finding("supervision-inconclusive";"supervision";"notice";"inconclusive";
+                "supervision continuity could not be established";"unreadable";1)
+      else empty end),
+      ($snapshot.tasks[]?
+        | select(remote(.) and (probe(.) == "skipped" or alive(.) == "not_collected" or alive(.) == "unknown"))
+        | finding("remote-liveness-inconclusive";.id;"notice";"inconclusive";
+                  "remote liveness was not collected; a local placeholder is not remote evidence";
+                  "not_collected";1)),
+      ($snapshot.tasks[]?
+        | select(remote(.) | not)
+        | select(.kind != "secondmate")
+        | select(exists(.) == false)
+        | select(terminal_state(.current_state.state) | not)
+        | finding("dead-direct-report";.id;"error";"high";
+                  ("recorded endpoint is absent while current state is " + .current_state.state);
+                  "absent";1)),
+      ($snapshot.tasks[]?
+        | select(remote(.) | not)
+        | select(.kind != "secondmate")
+        | select(exists(.) == null)
+        | select(terminal_state(.current_state.state) | not)
+        | finding("endpoint-inconclusive";.id;"notice";"inconclusive";
+                  "endpoint presence could not be established";"unknown";1)),
+      ($snapshot.tasks[]?
+        | select(.kind == "secondmate")
+        | select(remote(.) | not)
+        | select(alive(.) == "dead" or exists(.) == false)
+        | finding("dead-secondmate";.id;"error";"high";
+                  (if exists(.) == false then "recorded secondmate endpoint is absent"
+                   else "secondmate agent is dead" end);
+                  (if exists(.) == false then "absent" else "dead" end);1)),
+      ($snapshot.tasks[]?
+        | select(.kind == "secondmate")
+        | select(remote(.) | not)
+        | select(alive(.) == "unknown" or (alive(.) == "not_checked" and exists(.) == null))
+        | finding("endpoint-inconclusive";.id;"notice";"inconclusive";
+                  "secondmate liveness could not be established";"unknown";1)),
+      ($snapshot.tasks[]?
+        | select(remote(.))
+        | select(probe(.) == "remote" and alive(.) == "dead")
+        | finding("dead-secondmate";.id;"error";"high";
+                  "remote secondmate agent is dead";"remote-dead";1)),
+      ($snapshot.tasks[]?
+        | select(.kind != "secondmate")
+        | select(terminal_state(.current_state.state))
+        | select(exists(.) == true)
+        | finding("terminal-needs-cleanup";.id;"warning";"high";
+                  ("worker is " + .current_state.state + " but its endpoint is still present");
+                  .current_state.state;1)),
+      (if $snapshot.main_inventory.valid == false then
+        finding("inventory-inconsistent";"main";"error";"high";
+                ("active-work inventory is inconsistent: " + ($snapshot.main_inventory.reason // "unknown reason"));
+                ($snapshot.main_inventory.reason // "invalid");1)
+      else empty end),
+      ($snapshot.secondmate_current.records[]?
+        | select(.current.state == "unknown")
+        | . as $row
+        | (($row.current.reason // "") ) as $reason
+        | if ($reason | test("not collected")) then
+            empty
+          elif ($reason | test("timed out")) then
+            finding("secondmate-summary-unavailable";$row.id;"warning";"high";
+                    $reason;"timeout";1)
+          elif ($reason | test("invalid home|malformed|invalid remote|not registered")) then
+            finding("secondmate-summary-invalid";$row.id;"error";"high";
+                    $reason;"invalid";1)
+          elif ($reason | test("child current state unavailable")) then
+            finding("secondmate-summary-inconclusive";$row.id;"notice";"inconclusive";
+                    $reason;"child_unavailable";1)
+          elif ($reason | test("failed|unreadable|unavailable")) then
+            finding("secondmate-summary-unavailable";$row.id;"warning";"high";
+                    $reason;"unavailable";1)
+          else
+            finding("secondmate-summary-inconclusive";$row.id;"notice";"inconclusive";
+                    ($reason | if . == "" then "secondmate current state is unknown" else . end);
+                    "unknown";1)
+          end),
+      (if ($snapshot.secondmate_current.registry.available == false) then
+        finding("secondmate-summary-unavailable";"secondmate-registry";"warning";"high";
+                ($snapshot.secondmate_current.registry.reason // "registered secondmate table is unavailable");
+                "registry";1)
+      else empty end),
+      ((($pending.records // [])
+        | map(select(.phase == "delivery_unknown" or .phase == "recovery_failed" or .phase == "recovery_unknown"))
+        | group_by(.task_id)[]) as $g
+        | ($g | length) as $n
+        | ($g[0].task_id) as $task
+        | finding("pending-reply-broken";$task;"error";"high";
+                  ("broken reply delivery (" + ([ $g[].phase ] | unique | join(", ")) + ")");
+                  "broken";$n)),
+      ((($pending.records // [])
+        | map(select(.phase != "escalated"))
+        | map(select(
+            (.phase == "awaiting_report" and .request_turn_completed_epoch != null
+             and $now != 0 and (($now - .request_turn_completed_epoch) >= $pending_grace))
+            or (.phase == "recovery_sent" and .recovery_turn_completed_epoch != null
+                and $now != 0 and (($now - .recovery_turn_completed_epoch) >= $pending_grace))
+          ))
+        | group_by(.task_id)[]) as $g
+        | ($g | length) as $n
+        | finding("pending-reply-overdue";$g[0].task_id;"warning";"high";
+                  ("reply delivery is overdue by at least the pending-reply grace (" + ($pending_grace|tostring) + "s)");
+                  "overdue";$n)),
+      ((($inbox.records // [])
+        | map(select(.age_seconds != null and .age_seconds >= $inbox_grace))
+        | group_by(.task_id)[]) as $g
+        | ($g | length) as $n
+        | finding("steering-inbox-aged";$g[0].task_id;"warning";"high";
+                  ($n|tostring) + " unacknowledged steering message(s) older than grace (" + ($inbox_grace|tostring) + "s)";
+                  "aged";$n)),
+      ($snapshot.tasks[]?
+        | select(.kind == "ship")
+        | select((.pr.url // null) != null)
+        | select(terminal_state(.current_state.state) | not)
+        | select(skip_wait(.current_state.state) | not)
+        | .id as $id
+        | select([$prs.records[]?.id] | index($id) | not)
+        | finding("result-listener-missing";$id;"error";"high";
+                  "in-flight ship with a recorded PR has no armed merge-poll listener";
+                  "pr-poll";1)),
+      (($listeners.records // [])[]
+        | select(.owner == "missing" or .owner == "stale" or .owner == "orphaned")
+        | finding("result-listener-missing";.id;"error";"high";
+                  ("process-event source has no live result listener (owner=" + .owner + ")");
+                  .owner;1)),
+      (($listeners.records // [])[]
+        | select(.owner == "uncertain")
+        | finding("result-listener-inconclusive";.id;"notice";"inconclusive";
+                  "process-event listener liveness could not be established";"uncertain";1)),
+      (if $supervision.needed == true and $supervision.ok == false then
+        finding("supervision-unhealthy";"supervision";"error";"high";
+                ("supervision is required but unhealthy (" + ($supervision.reason // "unknown") + ")");
+                ($supervision.reason // "unhealthy");1)
+      else empty end)
+    ]
+  | sort_by([.kind,.subject,.cause])
+  | {
+      schema:"fm-fleet-health.v1",
+      generated:$generated,
+      fm_home:$snapshot.fm_home,
+      snapshot_generated:$snapshot.generated,
+      findings:.
+    }
+') || {
+  echo "fm-fleet-health: evaluation failed" >&2
+  exit 3
+}
+
+FINDINGS_OUT='[]'
+while IFS= read -r row; do
+  [ -n "$row" ] || continue
+  key=$(printf '%s' "$row" | jq -r '.fingerprint_key')
+  fp=$(fingerprint_hex "$key") || {
+    echo "fm-fleet-health: fingerprint hash unavailable" >&2
+    exit 3
+  }
+  FINDINGS_OUT=$(jq -n --argjson acc "$FINDINGS_OUT" --argjson row "$row" --arg fp "$fp" \
+    '$acc + [$row | del(.fingerprint_key,.cause) + {fingerprint:$fp}]')
+done < <(printf '%s' "$EVALUATED" | jq -c '.findings[]?')
+
+REPORT=$(jq -n \
+  --argjson base "$EVALUATED" \
+  --argjson findings "$FINDINGS_OUT" '
+  ($findings | any(.confidence == "high")) as $actionable
+  | $base
+  | .findings = $findings
+  | .status = (if $actionable then "actionable" else "healthy" end)
+')
+
+if [ "$OUTPUT_MODE" = json ]; then
+  printf '%s\n' "$REPORT"
+else
+  printf '%s\n' "$REPORT" | jq -r '
+    "# Fleet Health",
+    "Status: \(.status)",
+    "Home: \(.fm_home)",
+    "Snapshot: \(.snapshot_generated)",
+    "",
+    (if (.findings | length) == 0 then "No operational findings." else "## Findings" end),
+    (.findings[]? | "- [\(.severity)/\(.confidence)] \(.kind)  \(.subject)",
+     "  \(.evidence)",
+     "  fingerprint: \(.fingerprint)")
+  '
+fi
+
+STATUS=$(printf '%s' "$REPORT" | jq -r '.status')
+case "$STATUS" in
+  healthy) exit 0 ;;
+  actionable) exit 1 ;;
+  *) exit 3 ;;
+esac

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -126,30 +126,6 @@ fingerprint_hex() {
   printf 'sha256:%s' "$digest"
 }
 
-collect_pr_listeners_json() {
-  local state=$1 f id records='[]'
-  if [ ! -d "$state" ]; then
-    jq -n '{available:true,records:[]}'
-    return 0
-  fi
-  if [ ! -r "$state" ] || [ ! -x "$state" ]; then
-    jq -n '{available:false,records:[]}'
-    return 0
-  fi
-  for f in "$state"/*.check.sh; do
-    [ -f "$f" ] || continue
-    id=$(basename "$f" .check.sh)
-    case "$id" in
-      x-watch|tool-updates) continue ;;
-    esac
-    if fm_pr_poll_artifacts_valid "$state" "$id" "$SCRIPT_DIR/fm-pr-poll.sh"; then
-      records=$(jq -n --argjson records "$records" --arg id "$id" \
-        '$records + [{id:$id,armed:true}]')
-    fi
-  done
-  jq -n --argjson records "$records" '{available:true,records:$records}'
-}
-
 collect_supervision_json() {
   local state=$1 watch=$2 needed ok reason model
   fm_supervision_status "$state" >/dev/null
@@ -211,7 +187,7 @@ INBOX_JSON=$(fm_task_inbox_unhandled_json "$STATE") \
   || INBOX_JSON='{"available":false,"records":[]}'
 LISTENERS_JSON=$(fm_procevent_listeners_json "$STATE") \
   || LISTENERS_JSON='{"available":false,"records":[]}'
-PR_JSON=$(collect_pr_listeners_json "$STATE") \
+PR_JSON=$(fm_pr_poll_listeners_json "$STATE" "$SCRIPT_DIR/fm-pr-poll.sh") \
   || PR_JSON='{"available":false,"records":[]}'
 SUPERVISION_JSON=$(collect_supervision_json "$STATE" "$SCRIPT_DIR/fm-watch.sh") \
   || SUPERVISION_JSON='{"available":false,"needed":false,"ok":false,"reason":null,"model":null}'

--- a/bin/fm-fleet-health.sh
+++ b/bin/fm-fleet-health.sh
@@ -132,7 +132,7 @@ collect_pr_listeners_json() {
     jq -n '{available:true,records:[]}'
     return 0
   fi
-  if [ ! -r "$state" ]; then
+  if [ ! -r "$state" ] || [ ! -x "$state" ]; then
     jq -n '{available:false,records:[]}'
     return 0
   fi
@@ -243,7 +243,6 @@ EVALUATED=$(jq -n \
      else "unreadable" end));
   def exists($t): $t.endpoint.exists;
   def terminal_state($s): ($s == "done" or $s == "failed");
-  def skip_wait($s): ($s == "parked" or $s == "paused" or $s == "blocked");
   ($pending.now_epoch // 0) as $now
   | [
       (if $pending.available == false then
@@ -262,6 +261,15 @@ EVALUATED=$(jq -n \
       (if $listeners.available == false then
         finding("result-listener-inconclusive";"procevent";"notice";"inconclusive";
                 "process-event registrations could not be read";"unreadable";1)
+      else empty end),
+      (if $prs.available == false then
+        finding("result-listener-inconclusive";"pr-polls";"notice";"inconclusive";
+                "PR-listener registrations could not be read";"unreadable";1)
+      else empty end),
+      (if $snapshot.collection.state.available == false then
+        finding("fleet-inventory-inconclusive";"state";"notice";"inconclusive";
+                ($snapshot.collection.state.reason // "fleet state could not be inventoried");
+                "unavailable";1)
       else empty end),
       (if $supervision.available == false then
         finding("supervision-inconclusive";"supervision";"notice";"inconclusive";
@@ -393,7 +401,7 @@ EVALUATED=$(jq -n \
         | select(.kind == "ship")
         | select((.pr.url // null) != null)
         | select(terminal_state(.current_state.state) | not)
-        | select(skip_wait(.current_state.state) | not)
+        | select($prs.available == true)
         | .id as $id
         | select([$prs.records[]?.id] | index($id) | not)
         | finding("result-listener-missing";$id;"error";"high";
@@ -446,7 +454,7 @@ REPORT=$(jq -n \
   | ($findings | any(.confidence == "inconclusive")) as $inconclusive
   | $base
   | .findings = $findings
-  | .status = (if $actionable then "actionable" elif $inconclusive then "inconclusive" else "healthy" end)
+  | .status = (if $inconclusive then "inconclusive" elif $actionable then "actionable" else "healthy" end)
 ')
 
 if [ "$OUTPUT_MODE" = json ]; then

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -52,7 +52,8 @@
 #     endpoint.codex_session is collected only for local in-flight Codex tasks
 #     whose agent is not already proven dead: resume_banner is true when the
 #     bounded backend pane capture contains the exact Codex exit banner.
-#     paths.status_log.last_event.mtime_epoch is the status-file mtime.
+#     paths.status_log.last_event.mtime_epoch is the status-file mtime, and
+#     handoff_required marks a scaffold-declared stop state that awaits Firstmate.
 #   scout_reports[]: present data/<id>/report.md pointers.
 #   main_inventory: {valid,reason,orphan_in_flight[],unstructured_current_count} -
 #     main-home current-inventory checks shared with secondmate_home_summary_json
@@ -314,12 +315,13 @@ snapshot_file_mtime() {  # <path>
 }
 
 status_event_json() {  # <status-log>
-  local log=$1 present=0 raw='' verb='' note='' mtime_json=null
+  local log=$1 present=0 raw='' verb='' note='' mtime_json=null handoff_required=0
   if [ -f "$log" ]; then
     present=1
     raw=$(last_nonempty_line "$log" || true)
     verb=$(status_line_verb "$raw")
     note=$(status_line_note "$raw")
+    status_is_terminal_verb "$raw" && handoff_required=1
     mtime_json=$(snapshot_file_mtime "$log" || true)
     case "$mtime_json" in
       ''|*[!0-9]*) mtime_json=null ;;
@@ -332,7 +334,8 @@ status_event_json() {  # <status-log>
     --arg note "$note" \
     --argjson present "$(bool_json "$present")" \
     --argjson mtime_epoch "$mtime_json" \
-    '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw,mtime_epoch:$mtime_epoch}}'
+    --argjson handoff_required "$(bool_json "$handoff_required")" \
+    '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw,mtime_epoch:$mtime_epoch,handoff_required:$handoff_required}}'
 }
 
 # Exact Codex-cli exit banner. Health treats this as one of two independent

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -52,8 +52,9 @@
 #     endpoint.codex_session is collected only for local in-flight Codex tasks
 #     whose agent is not already proven dead: resume_banner is true when the
 #     bounded backend pane capture contains the exact Codex exit banner.
-#     paths.status_log.last_event.mtime_epoch is the status-file mtime, and
-#     handoff_required marks a scaffold-declared stop state that awaits Firstmate.
+#     paths.status_log.available preserves invalid or unreadable log evidence;
+#     last_event.mtime_epoch is the status-file mtime, and handoff_required marks
+#     a scaffold-declared stop state that awaits Firstmate.
 #   scout_reports[]: present data/<id>/report.md pointers.
 #   main_inventory: {valid,reason,orphan_in_flight[],unstructured_current_count} -
 #     main-home current-inventory checks shared with secondmate_home_summary_json
@@ -315,14 +316,18 @@ snapshot_file_mtime() {  # <path>
 }
 
 status_event_json() {  # <status-log>
-  local log=$1 present=0 raw='' verb='' note='' mtime_json=null handoff_required=0
+  local log=$1 present=0 available=1 reason='' raw='' verb='' note='' mtime_json=null handoff_required=0
+  if { [ -L "$log" ] && [ ! -e "$log" ]; } || { [ -e "$log" ] && { [ ! -f "$log" ] || [ ! -r "$log" ]; }; }; then
+    available=0
+    reason='status log is invalid or unreadable'
+  fi
   if [ -f "$log" ]; then
     present=1
     raw=$(last_nonempty_line "$log" || true)
     verb=$(status_line_verb "$raw")
     note=$(status_line_note "$raw")
     case "$verb" in
-      done|blocked|failed) handoff_required=1 ;;
+      done|blocked) handoff_required=1 ;;
     esac
     mtime_json=$(snapshot_file_mtime "$log" || true)
     case "$mtime_json" in
@@ -334,10 +339,12 @@ status_event_json() {  # <status-log>
     --arg raw "$raw" \
     --arg verb "$verb" \
     --arg note "$note" \
+    --arg reason "$reason" \
     --argjson present "$(bool_json "$present")" \
+    --argjson available "$(bool_json "$available")" \
     --argjson mtime_epoch "$mtime_json" \
     --argjson handoff_required "$(bool_json "$handoff_required")" \
-    '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw,mtime_epoch:$mtime_epoch,handoff_required:$handoff_required}}'
+    '{path:$path,present:$present,available:$available,reason:(if $reason == "" then null else $reason end),kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw,mtime_epoch:$mtime_epoch,handoff_required:$handoff_required}}'
 }
 
 # Exact Codex-cli exit banner. Health treats this as one of two independent
@@ -560,7 +567,7 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
 
 task_json_lines() {
   local meta id kind harness mode yolo project worktree home projects spawn_gen backend target status_log report_path
-  local remote_host remote_root remote_state remote_rc remote_home_present
+  local remote_host remote_root remote_state remote_home_present
   local pr pr_source event_json current_json endpoint_exists agent_state agent_alive probe meta_json status_json report_json worktree_json home_json
   local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json codex_session_json

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -605,7 +605,11 @@ task_json_lines() {
       pr_source=absent
     fi
 
-    current_json=$(crew_state_json "$id")
+    if [ -n "$remote_host" ] && [ "$FM_SNAPSHOT_REMOTE_PROBES" = 0 ]; then
+      current_json=$(jq -n '{state:"unknown",source:"remote-not-collected",raw:""}')
+    else
+      current_json=$(crew_state_json "$id")
+    fi
     event_json=$(status_event_json "$status_log")
     last_event_raw=$(printf '%s' "$event_json" | jq -r '.last_event.raw // ""')
     current_state=$(printf '%s' "$current_json" | jq -r '.state // ""')
@@ -995,9 +999,19 @@ fi
 
 registry_secondmates_json() {
   local reg="$DATA/secondmates.md" out rc reason mode script parse_filter output_filter
-  if [ ! -f "$reg" ]; then
+  if [ ! -e "$reg" ] && [ ! -L "$reg" ]; then
     jq -n --arg path "$reg" --arg observed "$SNAPSHOT_NOW" \
       '{present:false,available:true,complete:true,reason:null,provenance:"registered-table",path:$path,freshness:{status:"fresh",observed_at:$observed},records:[],input_truncated:false,records_truncated:false,reasons:[],lines_in_window:0,records_in_window:0}'
+    return 0
+  fi
+  if [ -L "$reg" ] && [ ! -e "$reg" ]; then
+    reason="registered secondmate table is dangling"
+  elif [ ! -f "$reg" ]; then
+    reason="registered secondmate table is not a regular file"
+  fi
+  if [ -n "${reason:-}" ]; then
+    jq -n --arg path "$reg" --arg observed "$SNAPSHOT_NOW" --arg reason "$reason" \
+      '{present:true,available:false,complete:false,reason:$reason,provenance:"registered-table",path:$path,freshness:{status:"unavailable",observed_at:$observed},records:[],input_truncated:false,records_truncated:false,reasons:[$reason],lines_in_window:0,records_in_window:0}'
     return 0
   fi
   mode=$(file_mode_octal "$reg")

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -40,8 +40,8 @@
 #     against current_state; hints.pending_decision and hints.blocked_event are
 #     booleans derived from that set.
 #     endpoint.exists is the cheap backend endpoint-presence read.
-#     endpoint.agent_alive is populated for secondmates only, where it is useful
-#     return-channel supervision data; other tasks use "not_checked".
+#     endpoint.agent_alive is populated for every local task with a recorded
+#     backend target.
 #     endpoint.probe names how liveness was observed: local, remote, skipped, or
 #     none. Remote tasks never treat a local placeholder window as remote
 #     liveness. FM_SNAPSHOT_REMOTE_PROBES=0 skips SSH probes and records
@@ -557,7 +557,7 @@ task_json_lines() {
           endpoint_exists=false
         fi
       fi
-      if [ "$kind" = secondmate ] && [ -n "$target" ]; then
+      if [ -n "$target" ]; then
         agent_alive=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null || printf unknown)
       fi
     fi
@@ -935,9 +935,10 @@ BASH
         | (($local == null) and ($remote != null)) as $is_remote
         | {id:$id.id,home:($route.home // null),host:(if $is_remote then $remote.host else null end),root:(if $is_remote then $remote.root else null end),
            remote:$is_remote,registered:true,
-           registry_error:(if $route == null or ($route.home | length) == 0 then "registry entry has no home" else null end)} ]
+           registry_error:(if $route == null or ($route.home | length) == 0 then "registry entry has no home" else null end),
+           registry_failure_kind:(if $route == null or ($route.home | length) == 0 then "invalid" else null end)} ]
       | group_by(.id)
-      | map(if length > 1 then .[0] + {registry_error:"duplicate secondmate id in registry"} else .[0] end)
+      | map(if length > 1 then .[0] + {registry_error:"duplicate secondmate id in registry",registry_failure_kind:"invalid"} else .[0] end)
 JQ
   )
   output_filter=$(cat <<'JQ'
@@ -1172,8 +1173,8 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
 
 secondmate_current_json() {  # <parent-tasks-json>
   local tasks=$1 registry union rows total_registered total shown truncated
-  local row id home host remote registered registry_error task sampled_spawn_gen status_file event_raw event_note event_epoch event_age
-  local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
+  local row id home host remote registered registry_error registry_failure_kind task sampled_spawn_gen status_file event_raw event_note event_epoch event_age
+  local activity_scan activities decisions reconciliation provenance freshness reason failure_kind summary summary_rc summary_bytes summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
   union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
@@ -1188,6 +1189,7 @@ secondmate_current_json() {  # <parent-tasks-json>
               registry_error:(if $registry.complete == true
                               then "secondmate metadata is not registered"
                               else "secondmate registration is unknown because the registry read is incomplete or unavailable" end),
+              registry_failure_kind:(if $registry.complete == true then "invalid" else "unavailable" end),
               parent_task:$t} ])
     | sort_by(.id)
     | {registry:$registry,records:.}') || return 1
@@ -1205,6 +1207,7 @@ secondmate_current_json() {  # <parent-tasks-json>
     remote=$(printf '%s' "$row" | jq -r '.remote // false')
     registered=$(printf '%s' "$row" | jq -r '.registered')
     registry_error=$(printf '%s' "$row" | jq -r '.registry_error // ""')
+    registry_failure_kind=$(printf '%s' "$row" | jq -r '.registry_failure_kind // ""')
     task=$(printf '%s' "$row" | jq -c '.parent_task // {}')
     sampled_spawn_gen=$(printf '%s' "$task" | jq -r '.spawn_gen // ""')
     status_file=$(printf '%s' "$task" | jq -r '.paths.status_log.path // ""')
@@ -1221,29 +1224,34 @@ secondmate_current_json() {  # <parent-tasks-json>
     fi
 
     reason=$registry_error
+    failure_kind=
+    if [ -n "$reason" ]; then
+      failure_kind=${registry_failure_kind:-invalid}
+    fi
     summary='{}'
     summary_sampled=false
     summary_valid=false
-    if [ -z "$reason" ] && [ -z "$home" ]; then reason="no recorded secondmate home"; fi
+    if [ -z "$reason" ] && [ -z "$home" ]; then reason="no recorded secondmate home"; failure_kind=invalid; fi
     if [ -z "$reason" ]; then
       case "$home" in
         /*) : ;;
-        *) reason="invalid home: registered path is not absolute" ;;
+        *) reason="invalid home: registered path is not absolute"; failure_kind=invalid ;;
       esac
     fi
     if [ -z "$reason" ]; then
       if [ "$remote" = true ]; then
-        [ -n "$host" ] || reason="invalid remote route: missing SSH host"
+        if [ -z "$host" ]; then reason="invalid remote route: missing SSH host"; failure_kind=invalid; fi
         case " $seen_homes " in
-          *" $host:$home "*) reason="invalid home: duplicate resolved remote route" ;;
+          *" $host:$home "*) reason="invalid home: duplicate resolved remote route"; failure_kind=invalid ;;
           *) seen_homes="$seen_homes $host:$home" ;;
         esac
       elif ! validate_secondmate_home "$id" "$home" 2>/dev/null; then
         reason="invalid home: $VALIDATION_ERROR"
+        failure_kind=invalid
       else
         home=$VALIDATED_HOME
         case " $seen_homes " in
-          *" local:$home "*) reason="invalid home: duplicate resolved home route" ;;
+          *" local:$home "*) reason="invalid home: duplicate resolved home route"; failure_kind=invalid ;;
           *) seen_homes="$seen_homes local:$home" ;;
         esac
       fi
@@ -1254,6 +1262,7 @@ secondmate_current_json() {  # <parent-tasks-json>
           summary=''
           summary_rc=1
           reason="remote structured home snapshot was not collected"
+          failure_kind=not_collected
         else
           summary=$(fm_run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
             "$SCRIPT_DIR/fm-on.sh" "$id" fm-fleet-snapshot.sh --secondmate-home-summary < /dev/null 2>/dev/null)
@@ -1279,12 +1288,19 @@ secondmate_current_json() {  # <parent-tasks-json>
       if [ "$summary_rc" -ne 0 ]; then
         summary='{}'
         if [ -z "$reason" ]; then
-          [ "$summary_rc" -eq 124 ] && reason="structured home snapshot timed out" || reason="structured home snapshot failed"
+          if [ "$summary_rc" -eq 124 ]; then
+            reason="structured home snapshot timed out"
+            failure_kind=timeout
+          else
+            reason="structured home snapshot failed"
+            failure_kind=unavailable
+          fi
         fi
       else
         summary_bytes=$(printf '%s' "$summary" | LC_ALL=C wc -c | tr -d ' ')
         if [ "$summary_bytes" -gt "$FM_SNAPSHOT_SECONDMATE_MAX_BYTES" ]; then
           reason="structured home snapshot exceeded byte limit"
+          failure_kind=unavailable
         elif ! printf '%s' "$summary" | jq -e --arg home "$home" --arg generated "$SNAPSHOT_NOW" --argjson remote "$remote" '
           .schema == "fm-secondmate-home-summary.v1" and .home == $home
           and (($remote == true) or .generated == $generated)
@@ -1296,6 +1312,7 @@ secondmate_current_json() {  # <parent-tasks-json>
           and (.counts | type) == "object" and (.omitted | type) == "array"
         ' >/dev/null 2>&1; then
           reason="structured home snapshot was malformed or stale"
+          failure_kind=invalid
         else
           summary_sampled=true
           summary_valid=$(printf '%s' "$summary" | jq -r '.valid')
@@ -1304,7 +1321,7 @@ secondmate_current_json() {  # <parent-tasks-json>
             summary_invalidity=$(printf '%s' "$summary" | jq -r '.invalidity.kind // "unknown"')
             case "$summary_invalidity" in
               child_current_unavailable|orphan_in_flight|unowned_current|terminal_in_flight) : ;;
-              *) reason="structured home state invalid: $summary_reason" ;;
+              *) reason="structured home state invalid: $summary_reason"; failure_kind=invalid ;;
             esac
           fi
         fi
@@ -1316,6 +1333,7 @@ secondmate_current_json() {  # <parent-tasks-json>
       current_reason=
       if [ "$summary_valid" != true ]; then
         current_reason="structured home state invalid: $(printf '%s' "$summary" | jq -r '.reason // "unknown reason"')"
+        failure_kind=child_unavailable
       fi
       reconciliation=$(parent_evidence_reconciliation_json "$summary" "$activities" "$decisions")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
@@ -1331,13 +1349,14 @@ secondmate_current_json() {  # <parent-tasks-json>
       record=$(jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
+        --arg failure_kind "$failure_kind" \
         --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
         --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
         --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
         --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
         {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
-         current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
+         current:{state:$state,reason:($current_reason | if . == "" then null else . end),failure_kind:($failure_kind | if . == "" then null else . end)},invalidity:$summary.invalidity,
          reconcile_inventory:$summary.invalidity,
          provenance:{selected:"structured-home",structured_home:$home,summary_valid:$summary_valid,
            trust:(if $summary_valid then "complete" else "partial-structured" end),parent_event_role:"historical-only"},
@@ -1364,12 +1383,13 @@ secondmate_current_json() {  # <parent-tasks-json>
       record=$(jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
+        --arg failure_kind "$failure_kind" \
         --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
         --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
         --argjson decisions "$decisions" --argjson terminal "$terminal" --argjson summary "$summary" --argjson summary_sampled "$summary_sampled" '
         {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
-         current:{state:"unknown",reason:$reason},invalidity:null,
+         current:{state:"unknown",reason:$reason,failure_kind:$failure_kind},invalidity:null,
          reconcile_inventory:(if $summary_sampled then $summary.invalidity else null end),
          provenance:{selected:$provenance,structured_home:($home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
          freshness:{status:$freshness,observed_at:$observed,age_seconds:$event_age},

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -52,7 +52,8 @@
 #     endpoint.codex_session is collected only for local in-flight Codex tasks
 #     whose agent is not already proven dead: resume_banner is true when the
 #     bounded backend pane capture contains the exact Codex exit banner.
-#     paths.status_log.last_event.mtime_epoch is the status-file mtime.
+#     paths.status_log.last_event.mtime_epoch is the status-file mtime, and
+#     handoff_required marks the canonical step-complete status vocabulary.
 #   scout_reports[]: present data/<id>/report.md pointers.
 #   main_inventory: {valid,reason,orphan_in_flight[],unstructured_current_count} -
 #     main-home current-inventory checks shared with secondmate_home_summary_json
@@ -314,12 +315,13 @@ snapshot_file_mtime() {  # <path>
 }
 
 status_event_json() {  # <status-log>
-  local log=$1 present=0 raw='' verb='' note='' mtime_json=null
+  local log=$1 present=0 raw='' verb='' note='' mtime_json=null handoff_required=0
   if [ -f "$log" ]; then
     present=1
     raw=$(last_nonempty_line "$log" || true)
     verb=$(status_line_verb "$raw")
     note=$(status_line_note "$raw")
+    status_is_step_complete "$raw" && handoff_required=1
     mtime_json=$(snapshot_file_mtime "$log" || true)
     case "$mtime_json" in
       ''|*[!0-9]*) mtime_json=null ;;
@@ -332,7 +334,8 @@ status_event_json() {  # <status-log>
     --arg note "$note" \
     --argjson present "$(bool_json "$present")" \
     --argjson mtime_epoch "$mtime_json" \
-    '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw,mtime_epoch:$mtime_epoch}}'
+    --argjson handoff_required "$(bool_json "$handoff_required")" \
+    '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw,mtime_epoch:$mtime_epoch,handoff_required:$handoff_required}}'
 }
 
 # Exact Codex-cli exit banner. Health treats this as one of two independent

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -321,7 +321,9 @@ status_event_json() {  # <status-log>
     raw=$(last_nonempty_line "$log" || true)
     verb=$(status_line_verb "$raw")
     note=$(status_line_note "$raw")
-    status_is_terminal_verb "$raw" && handoff_required=1
+    case "$verb" in
+      done|blocked|failed) handoff_required=1 ;;
+    esac
     mtime_json=$(snapshot_file_mtime "$log" || true)
     case "$mtime_json" in
       ''|*[!0-9]*) mtime_json=null ;;

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -42,6 +42,10 @@
 #     endpoint.exists is the cheap backend endpoint-presence read.
 #     endpoint.agent_alive is populated for secondmates only, where it is useful
 #     return-channel supervision data; other tasks use "not_checked".
+#     endpoint.probe names how liveness was observed: local, remote, skipped, or
+#     none. Remote tasks never treat a local placeholder window as remote
+#     liveness. FM_SNAPSHOT_REMOTE_PROBES=0 skips SSH probes and records
+#     agent_alive=not_collected with probe=skipped instead.
 #   scout_reports[]: present data/<id>/report.md pointers.
 #   main_inventory: {valid,reason,orphan_in_flight[],unstructured_current_count} -
 #     main-home current-inventory checks shared with secondmate_home_summary_json
@@ -147,6 +151,14 @@ validate_positive_bound FM_SNAPSHOT_REGISTRY_LINES "$FM_SNAPSHOT_REGISTRY_LINES"
 validate_positive_bound FM_SNAPSHOT_REGISTRY_BYTES "$FM_SNAPSHOT_REGISTRY_BYTES"
 validate_positive_bound FM_SNAPSHOT_REGISTRY_RECORDS "$FM_SNAPSHOT_REGISTRY_RECORDS"
 validate_positive_bound FM_SNAPSHOT_REGISTRY_TIMEOUT "$FM_SNAPSHOT_REGISTRY_TIMEOUT"
+FM_SNAPSHOT_REMOTE_PROBES=${FM_SNAPSHOT_REMOTE_PROBES:-1}
+case "$FM_SNAPSHOT_REMOTE_PROBES" in
+  0|1) ;;
+  *)
+    echo "fm-fleet-snapshot: FM_SNAPSHOT_REMOTE_PROBES must be 0 or 1" >&2
+    exit 2
+    ;;
+esac
 
 # shellcheck source=bin/fm-backend.sh
 # shellcheck disable=SC1091
@@ -188,6 +200,8 @@ FM_SNAPSHOT_PARENT_ACTIVITY_TIMEOUT, with truncation disclosed in the result.
 The registered secondmate table uses FM_SNAPSHOT_REGISTRY_LINES,
 FM_SNAPSHOT_REGISTRY_BYTES, FM_SNAPSHOT_REGISTRY_RECORDS, and
 FM_SNAPSHOT_REGISTRY_TIMEOUT, with unavailability and truncation disclosed.
+FM_SNAPSHOT_REMOTE_PROBES=0 skips SSH probes for remote endpoint liveness and
+remote home summaries; those surfaces are then marked not-collected.
 EOF
 }
 
@@ -432,7 +446,7 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
 task_json_lines() {
   local meta id kind harness mode yolo project worktree home projects spawn_gen backend target status_log report_path
   local remote_host remote_root remote_state remote_rc remote_home_present
-  local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
+  local pr pr_source event_json current_json endpoint_exists agent_alive probe meta_json status_json report_json worktree_json home_json
   local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
@@ -512,14 +526,16 @@ task_json_lines() {
 
     endpoint_exists=null
     agent_alive=not_checked
+    probe=none
     if [ -n "$remote_host" ]; then
-      if remote_state=$(fm_run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
+      probe=remote
+      if [ "$FM_SNAPSHOT_REMOTE_PROBES" = 0 ]; then
+        probe=skipped
+        endpoint_exists=null
+        agent_alive=not_collected
+        remote_home_present=null
+      elif remote_state=$(fm_run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
         "$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh state "$id" < /dev/null 2>/dev/null); then
-        remote_rc=0
-      else
-        remote_rc=$?
-      fi
-      if [ "$remote_rc" -eq 0 ]; then
         remote_home_present=true
         remote_state=$(printf '%s\n' "$remote_state" | tail -1)
         case "$remote_state" in
@@ -534,6 +550,7 @@ task_json_lines() {
       fi
     else
       if [ -n "$target" ]; then
+        probe=local
         if fm_backend_target_exists "$backend" "$target" "fm-$id" >/dev/null 2>&1; then
           endpoint_exists=true
         else
@@ -576,6 +593,7 @@ task_json_lines() {
       --arg pr "$pr" \
       --arg pr_source "$pr_source" \
       --arg agent_alive "$agent_alive" \
+      --arg probe "$probe" \
       --arg observed_at "$SNAPSHOT_NOW" \
       --arg last_event_raw "$last_event_raw" \
       --argjson current_state "$current_json" \
@@ -609,10 +627,12 @@ task_json_lines() {
         secondmate_projects:($projects | if . == "" then [] else split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(. != "")) end),
         current_state:($current_state + {observed_at:$observed_at,freshness:"fresh"}),
         endpoint:{target:($target | if . == "" then null else . end),exists:$endpoint_exists,agent_alive:$agent_alive,
-          status:(if $endpoint_exists == false then "absent"
+          probe:$probe,
+          status:(if $probe == "skipped" or $agent_alive == "not_collected" then "not_collected"
+                  elif $endpoint_exists == false then "absent"
                   elif $agent_alive == "alive" or $agent_alive == "dead" then $agent_alive
                   else "unknown" end),
-          observed_at:$observed_at,freshness:"fresh"},
+          observed_at:$observed_at,freshness:(if $probe == "skipped" then "not_collected" else "fresh" end)},
         pr:{url:($pr | if . == "" then null else . end),source:$pr_source},
         hints:{
           pending_decision:$pending_decision,
@@ -1230,9 +1250,15 @@ secondmate_current_json() {  # <parent-tasks-json>
     fi
     if [ -z "$reason" ]; then
       if [ "$remote" = true ]; then
-        summary=$(fm_run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
-          "$SCRIPT_DIR/fm-on.sh" "$id" fm-fleet-snapshot.sh --secondmate-home-summary < /dev/null 2>/dev/null)
-        summary_rc=$?
+        if [ "$FM_SNAPSHOT_REMOTE_PROBES" = 0 ]; then
+          summary=''
+          summary_rc=1
+          reason="remote structured home snapshot was not collected"
+        else
+          summary=$(fm_run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
+            "$SCRIPT_DIR/fm-on.sh" "$id" fm-fleet-snapshot.sh --secondmate-home-summary < /dev/null 2>/dev/null)
+          summary_rc=$?
+        fi
       else
         summary=$(fm_run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" env \
           FM_ROOT_OVERRIDE="$FM_ROOT" \
@@ -1252,7 +1278,9 @@ secondmate_current_json() {  # <parent-tasks-json>
       fi
       if [ "$summary_rc" -ne 0 ]; then
         summary='{}'
-        [ "$summary_rc" -eq 124 ] && reason="structured home snapshot timed out" || reason="structured home snapshot failed"
+        if [ -z "$reason" ]; then
+          [ "$summary_rc" -eq 124 ] && reason="structured home snapshot timed out" || reason="structured home snapshot failed"
+        fi
       else
         summary_bytes=$(printf '%s' "$summary" | LC_ALL=C wc -c | tr -d ' ')
         if [ "$summary_bytes" -gt "$FM_SNAPSHOT_SECONDMATE_MAX_BYTES" ]; then

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -11,6 +11,7 @@
 #   generated: UTC observation time for this fresh command execution.
 #   fm_home: resolved operational home.
 #   roots: resolved root/config/data/state/projects directories.
+#   collection.state: whether the state inventory was absent or fully accessible.
 #   backlog: {path,present,records[]} where records are ordered as written in
 #     data/backlog.md and cover In flight, Queued, and Done.
 #     Canonical tasks-axi rows are structured; free-form non-empty lines in
@@ -225,6 +226,16 @@ path_present_json() {  # <path>
   [ -e "$1" ] && present=1
   jq -n --arg path "$1" --argjson present "$(bool_json "$present")" \
     '{path:$path,present:$present}'
+}
+
+state_collection_json() {
+  if [ ! -e "$STATE" ]; then
+    jq -n '{present:false,available:true,reason:null}'
+  elif [ ! -d "$STATE" ] || [ ! -r "$STATE" ] || [ ! -x "$STATE" ]; then
+    jq -n '{present:true,available:false,reason:"state directory is not readable and searchable"}'
+  else
+    jq -n '{present:true,available:true,reason:null}'
+  fi
 }
 
 meta_value() {  # <meta-file> <key>
@@ -1455,6 +1466,7 @@ scout_report_lines() {
 }
 
 BACKLOG_JSON=$(backlog_json) || { echo "fm-fleet-snapshot: backlog read failed" >&2; exit 1; }
+STATE_COLLECTION_JSON=$(state_collection_json) || { echo "fm-fleet-snapshot: state collection check failed" >&2; exit 1; }
 TASKS_JSON=$(task_json_lines) || { echo "fm-fleet-snapshot: task snapshot failed" >&2; exit 1; }
 
 if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
@@ -1480,6 +1492,7 @@ jq -n \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
   --argjson backlog "$BACKLOG_JSON" \
+  --argjson state_collection "$STATE_COLLECTION_JSON" \
   --argjson tasks "$TASKS_JSON" \
   --argjson main_inventory "$MAIN_INVENTORY_JSON" \
   --argjson scout_reports "$SCOUT_REPORTS_JSON" \
@@ -1493,6 +1506,7 @@ jq -n \
      generated:$generated,
      fm_home:$fm_home,
      roots:{fm_root:$fm_root,state:$state,data:$data,config:$config,projects:$projects},
+     collection:{state:$state_collection},
      backlog:$backlog,
      tasks:($tasks | map(. + {backlog:backlog_by_id(.id)})),
      main_inventory:$main_inventory,

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -364,11 +364,6 @@ codex_session_evidence_json() {  # <harness> <remote-host> <backend> <target> <i
       jq -n '{collected:false,reason:"foreground already proved agent-free",resume_banner:null}'
       return 0
       ;;
-    unreadable|not_checked|not_collected|unverified)
-      # Banner capture is only the extra signal for a still-classified-live pane.
-      jq -n --arg reason "$agent_state" '{collected:false,reason:$reason,resume_banner:null}'
-      return 0
-      ;;
   esac
   if [ -z "$target" ] || [ "$exists" = false ]; then
     [ "$exists" = false ] && reason="recorded endpoint is absent" || reason="no recorded endpoint"

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -11,7 +11,8 @@
 #   generated: UTC observation time for this fresh command execution.
 #   fm_home: resolved operational home.
 #   roots: resolved root/config/data/state/projects directories.
-#   collection.state: whether the state inventory was absent or fully accessible.
+#   collection.state: whether the state inventory was absent or fully accessible,
+#     plus invalid metadata entries that could not produce task rows.
 #   backlog: {path,present,records[]} where records are ordered as written in
 #     data/backlog.md and cover In flight, Queued, and Done.
 #     Canonical tasks-axi rows are structured; free-form non-empty lines in
@@ -229,12 +230,29 @@ path_present_json() {  # <path>
 }
 
 state_collection_json() {
+  local meta id reason invalid='[]'
   if [ ! -e "$STATE" ]; then
-    jq -n '{present:false,available:true,reason:null}'
+    jq -n '{present:false,available:true,reason:null,invalid_metadata_count:0,invalid_metadata:[]}'
   elif [ ! -d "$STATE" ] || [ ! -r "$STATE" ] || [ ! -x "$STATE" ]; then
-    jq -n '{present:true,available:false,reason:"state directory is not readable and searchable"}'
+    jq -n '{present:true,available:false,reason:"state directory is not readable and searchable",invalid_metadata_count:0,invalid_metadata:[]}'
   else
-    jq -n '{present:true,available:true,reason:null}'
+    for meta in "$STATE"/*.meta; do
+      [ -e "$meta" ] || [ -L "$meta" ] || continue
+      reason=
+      if [ -L "$meta" ]; then
+        reason="metadata entry is a symlink"
+      elif [ ! -f "$meta" ]; then
+        reason="metadata entry is not a regular file"
+      elif [ ! -r "$meta" ]; then
+        reason="metadata entry is unreadable"
+      fi
+      [ -n "$reason" ] || continue
+      id=$(basename "$meta" .meta)
+      invalid=$(jq -n --argjson invalid "$invalid" --arg id "$id" --arg reason "$reason" \
+        '$invalid + [{id:$id,reason:$reason}]')
+    done
+    jq -n --argjson invalid "$invalid" \
+      '{present:true,available:true,reason:null,invalid_metadata_count:($invalid | length),invalid_metadata:$invalid}'
   fi
 }
 
@@ -463,7 +481,7 @@ task_json_lines() {
   local open_decisions_tsv open_decisions_json
 
   for meta in "$STATE"/*.meta; do
-    [ -e "$meta" ] || continue
+    [ -f "$meta" ] && [ ! -L "$meta" ] && [ -r "$meta" ] || continue
     id=$(basename "$meta" .meta)
     kind=$(meta_value "$meta" kind)
     [ -n "$kind" ] || kind=ship

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -49,6 +49,10 @@
 #     none. Remote tasks never treat a local placeholder window as remote
 #     liveness. FM_SNAPSHOT_REMOTE_PROBES=0 skips SSH probes and records
 #     agent_alive=not_collected with probe=skipped instead.
+#     endpoint.codex_session is collected only for local in-flight Codex tasks
+#     whose agent is not already proven dead: resume_banner is true when the
+#     bounded backend pane capture contains the exact Codex exit banner.
+#     paths.status_log.last_event.mtime_epoch is the status-file mtime.
 #   scout_reports[]: present data/<id>/report.md pointers.
 #   main_inventory: {valid,reason,orphan_in_flight[],unstructured_current_count} -
 #     main-home current-inventory checks shared with secondmate_home_summary_json
@@ -205,6 +209,9 @@ FM_SNAPSHOT_REGISTRY_BYTES, FM_SNAPSHOT_REGISTRY_RECORDS, and
 FM_SNAPSHOT_REGISTRY_TIMEOUT, with unavailability and truncation disclosed.
 FM_SNAPSHOT_REMOTE_PROBES=0 skips SSH probes for remote endpoint liveness and
 remote home summaries; those surfaces are then marked not-collected.
+Local in-flight Codex pane capture uses the same terminal-line/byte/timeout
+bounds and never stores pane text; it records only whether the exact resume
+banner was present.
 EOF
 }
 
@@ -298,13 +305,25 @@ crew_state_json() {  # <id>
     '{state:$state,source:$source,detail:$detail,raw:$raw}'
 }
 
+snapshot_file_mtime() {  # <path>
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %m "$1" 2>/dev/null
+  else
+    stat -c %Y "$1" 2>/dev/null
+  fi
+}
+
 status_event_json() {  # <status-log>
-  local log=$1 present=0 raw='' verb='' note=''
+  local log=$1 present=0 raw='' verb='' note='' mtime_json=null
   if [ -f "$log" ]; then
     present=1
     raw=$(last_nonempty_line "$log" || true)
     verb=$(status_line_verb "$raw")
     note=$(status_line_note "$raw")
+    mtime_json=$(snapshot_file_mtime "$log" || true)
+    case "$mtime_json" in
+      ''|*[!0-9]*) mtime_json=null ;;
+    esac
   fi
   jq -n \
     --arg path "$log" \
@@ -312,7 +331,71 @@ status_event_json() {  # <status-log>
     --arg verb "$verb" \
     --arg note "$note" \
     --argjson present "$(bool_json "$present")" \
-    '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw}}'
+    --argjson mtime_epoch "$mtime_json" \
+    '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw,mtime_epoch:$mtime_epoch}}'
+}
+
+# Exact Codex-cli exit banner. Health treats this as one of two independent
+# dead-session signals; the other is a proven bare-shell foreground.
+CODEX_RESUME_BANNER='To continue this session, run codex resume'
+
+codex_session_evidence_json() {  # <harness> <remote-host> <backend> <target> <id> <exists> <agent-state> <current-state>
+  local harness=$1 remote_host=$2 backend=$3 target=$4 id=$5 exists=$6 agent_state=$7 current_state=$8
+  local expected out rc clean reason='' resume=false
+  case "$harness" in
+    codex|codex-*) ;;
+    *)
+      jq -n '{collected:false,reason:"not_applicable",resume_banner:null}'
+      return 0
+      ;;
+  esac
+  if [ -n "$remote_host" ]; then
+    jq -n '{collected:false,reason:"remote pane capture was not collected",resume_banner:null}'
+    return 0
+  fi
+  case "$current_state" in
+    done|failed)
+      jq -n '{collected:false,reason:"task is terminal",resume_banner:null}'
+      return 0
+      ;;
+  esac
+  case "$agent_state" in
+    dead|missing)
+      jq -n '{collected:false,reason:"foreground already proved agent-free",resume_banner:null}'
+      return 0
+      ;;
+    unreadable|not_checked|not_collected|unverified)
+      # Banner capture is only the extra signal for a still-classified-live pane.
+      jq -n --arg reason "$agent_state" '{collected:false,reason:$reason,resume_banner:null}'
+      return 0
+      ;;
+  esac
+  if [ -z "$target" ] || [ "$exists" = false ]; then
+    [ "$exists" = false ] && reason="recorded endpoint is absent" || reason="no recorded endpoint"
+    jq -n --arg reason "$reason" '{collected:false,reason:$reason,resume_banner:null}'
+    return 0
+  fi
+  expected="fm-$id"
+  # shellcheck disable=SC2016
+  out=$(fm_run_timed "$FM_SNAPSHOT_TERMINAL_TIMEOUT" bash -c \
+    '. "$1"; fm_backend_capture "$2" "$3" "$4" "$5" | LC_ALL=C head -c "$6"; rc=${PIPESTATUS[0]}; [ "$rc" -eq 141 ] && rc=0; exit "$rc"' \
+    fm-codex-pane-capture "$SCRIPT_DIR/fm-backend.sh" "$backend" "$target" "$FM_SNAPSHOT_TERMINAL_LINES" "$expected" "$FM_SNAPSHOT_TERMINAL_BYTES" 2>/dev/null)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    [ "$rc" -eq 124 ] && reason="pane capture timed out" || reason="pane capture unavailable"
+    jq -n --arg reason "$reason" '{collected:false,reason:$reason,resume_banner:null}'
+    return 0
+  fi
+  clean=$(printf '%s' "$out" | tail -n "$FM_SNAPSHOT_TERMINAL_LINES" | LC_ALL=C head -c "$FM_SNAPSHOT_TERMINAL_BYTES")
+  if command -v perl >/dev/null 2>&1; then
+    clean=$(printf '%s' "$clean" | perl -pe 's/\e\[[0-?]*[ -\/]*[@-~]//g; s/[^\x09\x0A\x0D\x20-\x7E]//g')
+  else
+    clean=$(printf '%s' "$clean" | LC_ALL=C tr -cd '\11\12\15\40-\176')
+  fi
+  case "$clean" in
+    *"$CODEX_RESUME_BANNER"*) resume=true ;;
+  esac
+  jq -n --argjson resume "$resume" '{collected:true,reason:null,resume_banner:$resume}'
 }
 
 first_pr_url_in_file() {  # <file>
@@ -480,7 +563,7 @@ task_json_lines() {
   local remote_host remote_root remote_state remote_rc remote_home_present
   local pr pr_source event_json current_json endpoint_exists agent_state agent_alive probe meta_json status_json report_json worktree_json home_json
   local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
-  local open_decisions_tsv open_decisions_json
+  local open_decisions_tsv open_decisions_json codex_session_json
 
   for meta in "$STATE"/*.meta; do
     [ -f "$meta" ] && [ ! -L "$meta" ] && [ -r "$meta" ] || continue
@@ -601,6 +684,10 @@ task_json_lines() {
         esac
       fi
     fi
+    codex_session_json=$(codex_session_evidence_json \
+      "$harness" "$remote_host" "$backend" "$target" "$id" \
+      "$endpoint_exists" "$agent_state" "$current_state") \
+      || codex_session_json='{"collected":false,"reason":"codex session evidence failed","resume_banner":null}'
 
     [ -f "$report_path" ] && report_present=1 || report_present=0
     meta_json=$(path_present_json "$meta")
@@ -644,6 +731,7 @@ task_json_lines() {
       --argjson worktree_path "$worktree_json" \
       --argjson home_path "$home_json" \
       --argjson endpoint_exists "$endpoint_exists" \
+      --argjson codex_session "$codex_session_json" \
       --argjson open_decisions "$open_decisions_json" \
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
@@ -673,7 +761,8 @@ task_json_lines() {
                   elif $endpoint_exists == false and $agent_state == "missing" then "absent"
                   elif $agent_alive == "alive" or $agent_alive == "dead" then $agent_alive
                   else "unknown" end),
-          observed_at:$observed_at,freshness:(if $probe == "skipped" then "not_collected" else "fresh" end)},
+          observed_at:$observed_at,freshness:(if $probe == "skipped" then "not_collected" else "fresh" end),
+          codex_session:$codex_session},
         pr:{url:($pr | if . == "" then null else . end),source:$pr_source},
         hints:{
           pending_decision:$pending_decision,

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -52,8 +52,7 @@
 #     endpoint.codex_session is collected only for local in-flight Codex tasks
 #     whose agent is not already proven dead: resume_banner is true when the
 #     bounded backend pane capture contains the exact Codex exit banner.
-#     paths.status_log.last_event.mtime_epoch is the status-file mtime, and
-#     handoff_required marks the canonical step-complete status vocabulary.
+#     paths.status_log.last_event.mtime_epoch is the status-file mtime.
 #   scout_reports[]: present data/<id>/report.md pointers.
 #   main_inventory: {valid,reason,orphan_in_flight[],unstructured_current_count} -
 #     main-home current-inventory checks shared with secondmate_home_summary_json
@@ -315,13 +314,12 @@ snapshot_file_mtime() {  # <path>
 }
 
 status_event_json() {  # <status-log>
-  local log=$1 present=0 raw='' verb='' note='' mtime_json=null handoff_required=0
+  local log=$1 present=0 raw='' verb='' note='' mtime_json=null
   if [ -f "$log" ]; then
     present=1
     raw=$(last_nonempty_line "$log" || true)
     verb=$(status_line_verb "$raw")
     note=$(status_line_note "$raw")
-    status_is_step_complete "$raw" && handoff_required=1
     mtime_json=$(snapshot_file_mtime "$log" || true)
     case "$mtime_json" in
       ''|*[!0-9]*) mtime_json=null ;;
@@ -334,8 +332,7 @@ status_event_json() {  # <status-log>
     --arg note "$note" \
     --argjson present "$(bool_json "$present")" \
     --argjson mtime_epoch "$mtime_json" \
-    --argjson handoff_required "$(bool_json "$handoff_required")" \
-    '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw,mtime_epoch:$mtime_epoch,handoff_required:$handoff_required}}'
+    '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw,mtime_epoch:$mtime_epoch}}'
 }
 
 # Exact Codex-cli exit banner. Health treats this as one of two independent

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -231,7 +231,9 @@ path_present_json() {  # <path>
 
 state_collection_json() {
   local meta id reason invalid='[]'
-  if [ ! -e "$STATE" ]; then
+  if [ -L "$STATE" ] && [ ! -e "$STATE" ]; then
+    jq -n '{present:true,available:false,reason:"state path is a dangling symlink",invalid_metadata_count:0,invalid_metadata:[]}'
+  elif [ ! -e "$STATE" ]; then
     jq -n '{present:false,available:true,reason:null,invalid_metadata_count:0,invalid_metadata:[]}'
   elif [ ! -d "$STATE" ] || [ ! -r "$STATE" ] || [ ! -x "$STATE" ]; then
     jq -n '{present:true,available:false,reason:"state directory is not readable and searchable",invalid_metadata_count:0,invalid_metadata:[]}'

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -40,8 +40,9 @@
 #     against current_state; hints.pending_decision and hints.blocked_event are
 #     booleans derived from that set.
 #     endpoint.exists is the cheap backend endpoint-presence read.
-#     endpoint.agent_alive is populated for every local task with a recorded
-#     backend target.
+#     endpoint.agent_state preserves the recovery-grade backend verdict for
+#     every local task with a recorded target; endpoint.agent_alive is its
+#     backward-compatible three-state projection.
 #     endpoint.probe names how liveness was observed: local, remote, skipped, or
 #     none. Remote tasks never treat a local placeholder window as remote
 #     liveness. FM_SNAPSHOT_REMOTE_PROBES=0 skips SSH probes and records
@@ -446,7 +447,7 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
 task_json_lines() {
   local meta id kind harness mode yolo project worktree home projects spawn_gen backend target status_log report_path
   local remote_host remote_root remote_state remote_rc remote_home_present
-  local pr pr_source event_json current_json endpoint_exists agent_alive probe meta_json status_json report_json worktree_json home_json
+  local pr pr_source event_json current_json endpoint_exists agent_state agent_alive probe meta_json status_json report_json worktree_json home_json
   local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
@@ -525,6 +526,7 @@ task_json_lines() {
     blocked_event=$(printf '%s' "$open_decisions_json" | jq 'if any(.[]; .verb == "blocked") then 1 else 0 end')
 
     endpoint_exists=null
+    agent_state=not_checked
     agent_alive=not_checked
     probe=none
     if [ -n "$remote_host" ]; then
@@ -532,6 +534,7 @@ task_json_lines() {
       if [ "$FM_SNAPSHOT_REMOTE_PROBES" = 0 ]; then
         probe=skipped
         endpoint_exists=null
+        agent_state=not_collected
         agent_alive=not_collected
         remote_home_present=null
       elif remote_state=$(fm_run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
@@ -539,13 +542,14 @@ task_json_lines() {
         remote_home_present=true
         remote_state=$(printf '%s\n' "$remote_state" | tail -1)
         case "$remote_state" in
-          alive) endpoint_exists=true; agent_alive=alive ;;
-          dead) endpoint_exists=true; agent_alive=dead ;;
-          missing) endpoint_exists=false; agent_alive=dead ;;
-          *) endpoint_exists=null; agent_alive=unknown ;;
+          alive) endpoint_exists=true; agent_state=alive; agent_alive=alive ;;
+          dead) endpoint_exists=true; agent_state=dead; agent_alive=dead ;;
+          missing) endpoint_exists=false; agent_state=missing; agent_alive=dead ;;
+          *) endpoint_exists=null; agent_state=unreadable; agent_alive=unknown ;;
         esac
       else
         endpoint_exists=null
+        agent_state=unreadable
         agent_alive=unknown
       fi
     else
@@ -558,7 +562,12 @@ task_json_lines() {
         fi
       fi
       if [ -n "$target" ]; then
-        agent_alive=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null || printf unknown)
+        agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null || printf unreadable)
+        case "$agent_state" in
+          alive) agent_alive=alive ;;
+          dead|missing) agent_alive=dead ;;
+          *) agent_alive=unknown ;;
+        esac
       fi
     fi
 
@@ -592,6 +601,7 @@ task_json_lines() {
       --arg remote_root "$remote_root" \
       --arg pr "$pr" \
       --arg pr_source "$pr_source" \
+      --arg agent_state "$agent_state" \
       --arg agent_alive "$agent_alive" \
       --arg probe "$probe" \
       --arg observed_at "$SNAPSHOT_NOW" \
@@ -626,10 +636,10 @@ task_json_lines() {
         },
         secondmate_projects:($projects | if . == "" then [] else split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(. != "")) end),
         current_state:($current_state + {observed_at:$observed_at,freshness:"fresh"}),
-        endpoint:{target:($target | if . == "" then null else . end),exists:$endpoint_exists,agent_alive:$agent_alive,
+        endpoint:{target:($target | if . == "" then null else . end),exists:$endpoint_exists,agent_state:$agent_state,agent_alive:$agent_alive,
           probe:$probe,
           status:(if $probe == "skipped" or $agent_alive == "not_collected" then "not_collected"
-                  elif $endpoint_exists == false then "absent"
+                  elif $endpoint_exists == false and $agent_state == "missing" then "absent"
                   elif $agent_alive == "alive" or $agent_alive == "dead" then $agent_alive
                   else "unknown" end),
           observed_at:$observed_at,freshness:(if $probe == "skipped" then "not_collected" else "fresh" end)},
@@ -1189,7 +1199,7 @@ secondmate_current_json() {  # <parent-tasks-json>
               registry_error:(if $registry.complete == true
                               then "secondmate metadata is not registered"
                               else "secondmate registration is unknown because the registry read is incomplete or unavailable" end),
-              registry_failure_kind:(if $registry.complete == true then "invalid" else "unavailable" end),
+              registry_failure_kind:(if $registry.complete == true then "invalid" else "registry_incomplete" end),
               parent_task:$t} ])
     | sort_by(.id)
     | {registry:$registry,records:.}') || return 1

--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -58,6 +58,12 @@ SCAN_MARKER="$STATE/.inactive-outcome-reconcile"
 SCAN_LOCK="$STATE/.inactive-outcome-reconcile.lock"
 CREW_STATE_BIN="${FM_INACTIVE_CREW_STATE_BIN:-$SCRIPT_DIR/fm-crew-state.sh}"
 
+ensure_state_dir() {
+  [ ! -L "$STATE" ] || return 1
+  mkdir -p "$STATE" || return 1
+  [ -d "$STATE" ] && [ ! -L "$STATE" ]
+}
+
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-classify-lib.sh
@@ -504,18 +510,21 @@ case "$mode" in
     ;;
   _scan-locked)
     [ "$#" -eq 2 ] || exit 2
+    ensure_state_dir || exit 1
     fm_lock_acquire_wait "$SCAN_LOCK" || exit 1
     trap 'fm_lock_release "$SCAN_LOCK"' EXIT
     scan "$2"
     ;;
   acknowledge)
     [ "$#" -eq 2 ] || { printf 'usage: fm-inactive-reconcile.sh acknowledge <fingerprint>\n' >&2; exit 2; }
+    ensure_state_dir || exit 1
     fm_lock_acquire_wait "$SCAN_LOCK" || exit 1
     trap 'fm_lock_release "$SCAN_LOCK"' EXIT
     acknowledge "$2"
     ;;
   acknowledge-notice)
     [ "$#" -eq 2 ] || exit 2
+    ensure_state_dir || exit 1
     fm_lock_acquire_wait "$SCAN_LOCK" || exit 1
     trap 'fm_lock_release "$SCAN_LOCK"' EXIT
     acknowledge_notice "$2"

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -177,6 +177,39 @@ fm_pending_reply_get() {  # <record-path> <key>
   grep "^${key}=" "$rec" 2>/dev/null | tail -1 | cut -d= -f2- || true
 }
 
+fm_pending_reply_record_valid() {  # <record-path>
+  local rec=$1 base schema corr task phase key count value
+  [ -f "$rec" ] && [ ! -L "$rec" ] || return 1
+  for key in schema corr_id task_id created_epoch phase request_turn_completed_epoch recovery_turn_completed_epoch grace_secs; do
+    count=$(grep -c "^${key}=" "$rec" 2>/dev/null || true)
+    [ "$count" -eq 1 ] || return 1
+  done
+  schema=$(fm_pending_reply_get "$rec" schema)
+  [ "$schema" = "$FM_PENDING_REPLY_SCHEMA" ] || return 1
+  corr=$(fm_pending_reply_get "$rec" corr_id)
+  base=$(basename "$rec")
+  [ "$corr" = "$base" ] || return 1
+  case "$corr" in
+    [a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]) ;;
+    *) return 1 ;;
+  esac
+  task=$(fm_pending_reply_get "$rec" task_id)
+  case "$task" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac
+  phase=$(fm_pending_reply_get "$rec" phase)
+  case "$phase" in
+    awaiting_report|delivery_unknown|recovery_sending|recovery_sent|recovery_failed|recovery_unknown|escalated|resolved) ;;
+    *) return 1 ;;
+  esac
+  for key in created_epoch grace_secs; do
+    value=$(fm_pending_reply_get "$rec" "$key")
+    case "$value" in ''|*[!0-9]*) return 1 ;; esac
+  done
+  for key in request_turn_completed_epoch recovery_turn_completed_epoch; do
+    value=$(fm_pending_reply_get "$rec" "$key")
+    case "$value" in *[!0-9]*) return 1 ;; esac
+  done
+}
+
 fm_pending_reply_corr_reusable() {  # <state-dir> <corr_id> <task_id>
   local state=$1 corr=$2 task_id=$3 rec phase delivered
   printf '%s' "$corr" | grep -Eq '^[A-Fa-f0-9]{16}$' || return 1
@@ -1412,23 +1445,25 @@ fm_pending_reply_task_has_open() {  # <state-dir> <task_id>
 # Does not tick, recover, escalate, or otherwise mutate records.
 fm_pending_reply_open_json() {  # <state-dir>
   local state=$1 dir rec corr phase task_id created delivered completed recovery_completed grace
-  local now age
+  local now age row records='[]' invalid_count=0
   dir=$(fm_pending_reply_dir "$state")
   now=$(fm_pending_reply_now)
   if [ ! -e "$dir" ]; then
-    jq -n --argjson now "$now" '{available:true,now_epoch:$now,records:[]}'
+    jq -n --argjson now "$now" '{available:true,now_epoch:$now,invalid_count:0,records:[]}'
     return 0
   fi
   if [ ! -d "$dir" ] || [ ! -r "$dir" ]; then
-    jq -n --argjson now "$now" '{available:false,now_epoch:$now,records:[]}'
+    jq -n --argjson now "$now" '{available:false,now_epoch:$now,invalid_count:0,records:[]}'
     return 0
   fi
-  {
-    for rec in "$dir"/*; do
-      [ -f "$rec" ] || continue
+  for rec in "$dir"/*; do
+      [ -e "$rec" ] || [ -L "$rec" ] || continue
       case "$(basename "$rec")" in .*) continue ;; esac
+      if ! fm_pending_reply_record_valid "$rec"; then
+        invalid_count=$((invalid_count + 1))
+        continue
+      fi
       corr=$(fm_pending_reply_get "$rec" corr_id)
-      [ -n "$corr" ] || corr=$(basename "$rec")
       phase=$(fm_pending_reply_get "$rec" phase)
       [ "$phase" != resolved ] || continue
       task_id=$(fm_pending_reply_get "$rec" task_id)
@@ -1443,7 +1478,7 @@ fm_pending_reply_open_json() {  # <state-dir>
         ''|*[!0-9]*) ;;
         *) age=$((now - created)); [ "$age" -lt 0 ] && age=0 ;;
       esac
-      jq -n \
+      row=$(jq -n \
         --arg corr "$corr" \
         --arg task "$task_id" \
         --arg phase "$phase" \
@@ -1463,7 +1498,9 @@ fm_pending_reply_open_json() {  # <state-dir>
           recovery_turn_completed_epoch:(if $recovery_completed == "" then null else (try ($recovery_completed | tonumber) catch null) end),
           grace_secs:($grace | tonumber),
           age_seconds:$age
-        }'
-    done
-  } | jq -s --argjson now "$now" '{available:true,now_epoch:$now,records:.}'
+        }') || return 1
+      records=$(jq -n --argjson records "$records" --argjson row "$row" '$records + [$row]') || return 1
+  done
+  jq -n --argjson now "$now" --argjson invalid "$invalid_count" --argjson records "$records" \
+    '{available:true,now_epoch:$now,invalid_count:$invalid,records:$records}'
 }

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -1452,7 +1452,7 @@ fm_pending_reply_open_json() {  # <state-dir>
     jq -n --argjson now "$now" '{available:true,now_epoch:$now,invalid_count:0,records:[]}'
     return 0
   fi
-  if [ ! -d "$dir" ] || [ ! -r "$dir" ]; then
+  if [ ! -d "$dir" ] || [ ! -r "$dir" ] || [ ! -x "$dir" ]; then
     jq -n --argjson now "$now" '{available:false,now_epoch:$now,invalid_count:0,records:[]}'
     return 0
   fi

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -960,12 +960,42 @@ fm_pending_reply_pid_identity() {  # <pid>
 }
 
 fm_pending_reply_sender_alive() {  # <record-path>
+  [ "$(fm_pending_reply_sender_state "$1")" = alive ]
+}
+
+fm_pending_reply_sender_state() {  # <record-path>
   local rec=$1 pid expected actual
   pid=$(fm_pending_reply_get "$rec" recovery_sender_pid)
   expected=$(fm_pending_reply_get "$rec" recovery_sender_identity)
-  [ -n "$expected" ] || return 1
-  actual=$(fm_pending_reply_pid_identity "$pid") || return 1
-  [ "$actual" = "$expected" ]
+  case "$pid" in ''|*[!0-9]*) printf 'unreadable\n'; return 0 ;; esac
+  [ -n "$expected" ] || { printf 'unreadable\n'; return 0; }
+  if ! fm_pid_alive "$pid"; then
+    printf 'orphaned\n'
+    return 0
+  fi
+  if ! actual=$(fm_pending_reply_pid_identity "$pid"); then
+    if fm_pid_alive "$pid"; then printf 'unreadable\n'; else printf 'orphaned\n'; fi
+    return 0
+  fi
+  if [ "$actual" = "$expected" ]; then printf 'alive\n'; else printf 'orphaned\n'; fi
+}
+
+fm_pending_reply_recovery_verdict() {  # <record-path>
+  local rec=$1 phase outcome
+  phase=$(fm_pending_reply_get "$rec" phase)
+  [ "$phase" = recovery_sending ] || { printf 'none\n'; return 0; }
+  outcome=$(fm_pending_reply_get "$rec" recovery_delivery_outcome)
+  case "$outcome" in
+    confirmed|failed|unknown) printf '%s\n' "$outcome" ;;
+    '')
+      case "$(fm_pending_reply_sender_state "$rec")" in
+        alive) printf 'sending\n' ;;
+        orphaned) printf 'orphaned\n' ;;
+        *) printf 'unreadable\n' ;;
+      esac
+      ;;
+    *) printf 'unreadable\n' ;;
+  esac
 }
 
 fm_pending_reply_finish_recovery() {  # <state-dir> <corr_id> <confirmed|failed>
@@ -1445,7 +1475,7 @@ fm_pending_reply_task_has_open() {  # <state-dir> <task_id>
 # Does not tick, recover, escalate, or otherwise mutate records.
 fm_pending_reply_open_json() {  # <state-dir>
   local state=$1 dir rec corr phase task_id created delivered completed recovery_completed grace
-  local now age row records='[]' invalid_count=0
+  local now age recovery_verdict row records='[]' invalid_count=0
   dir=$(fm_pending_reply_dir "$state")
   now=$(fm_pending_reply_now)
   if [ ! -e "$dir" ]; then
@@ -1471,6 +1501,7 @@ fm_pending_reply_open_json() {  # <state-dir>
       delivered=$(fm_pending_reply_get "$rec" delivered_epoch)
       completed=$(fm_pending_reply_get "$rec" request_turn_completed_epoch)
       recovery_completed=$(fm_pending_reply_get "$rec" recovery_turn_completed_epoch)
+      recovery_verdict=$(fm_pending_reply_recovery_verdict "$rec")
       grace=$(fm_pending_reply_get "$rec" grace_secs)
       case "$grace" in ''|*[!0-9]*) grace=$(fm_pending_reply_grace_secs) ;; esac
       age=null
@@ -1486,6 +1517,7 @@ fm_pending_reply_open_json() {  # <state-dir>
         --arg delivered "$delivered" \
         --arg completed "$completed" \
         --arg recovery_completed "$recovery_completed" \
+        --arg recovery_verdict "$recovery_verdict" \
         --arg grace "$grace" \
         --argjson age "$age" \
         '{
@@ -1496,6 +1528,7 @@ fm_pending_reply_open_json() {  # <state-dir>
           delivered_epoch:(if $delivered == "" then null else (try ($delivered | tonumber) catch null) end),
           request_turn_completed_epoch:(if $completed == "" then null else (try ($completed | tonumber) catch null) end),
           recovery_turn_completed_epoch:(if $recovery_completed == "" then null else (try ($recovery_completed | tonumber) catch null) end),
+          recovery_verdict:(if $recovery_verdict == "none" then null else $recovery_verdict end),
           grace_secs:($grace | tonumber),
           age_seconds:$age
         }') || return 1

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -200,8 +200,10 @@ fm_pending_reply_record_valid() {  # <record-path>
   esac
   task=$(fm_pending_reply_get "$rec" task_id)
   case "$task" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac
-  [ -n "$(fm_pending_reply_get "$rec" parent_home)" ] || return 1
-  [ -n "$(fm_pending_reply_get "$rec" parent_status)" ] || return 1
+  value=$(fm_pending_reply_get "$rec" parent_home)
+  case "$value" in /*) ;; *) return 1 ;; esac
+  value=$(fm_pending_reply_get "$rec" parent_status)
+  case "$value" in /*) ;; *) return 1 ;; esac
   phase=$(fm_pending_reply_get "$rec" phase)
   case "$phase" in
     awaiting_report|delivery_unknown|recovery_sending|recovery_sent|recovery_failed|recovery_unknown|escalated|resolved) ;;
@@ -1491,26 +1493,43 @@ fm_pending_reply_task_has_open() {  # <state-dir> <task_id>
 # Does not tick, recover, escalate, or otherwise mutate records.
 fm_pending_reply_open_json() {  # <state-dir>
   local state=$1 dir rec corr phase task_id created delivered completed recovery_completed grace
-  local now age recovery_verdict row records='[]' invalid_count=0
+  local now age recovery_verdict row records='[]' invalid_count=0 unreadable_count=0
+  local record_readable record_valid classification available=true
   dir=$(fm_pending_reply_dir "$state")
   now=$(fm_pending_reply_now)
   if [ -L "$dir" ] && [ ! -e "$dir" ]; then
-    jq -n --argjson now "$now" '{available:false,now_epoch:$now,invalid_count:0,records:[]}'
+    classification=$(fm_evidence_classify false false)
+    jq -n --argjson now "$now" --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,now_epoch:$now,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
   if [ ! -e "$dir" ]; then
-    jq -n --argjson now "$now" '{available:true,now_epoch:$now,invalid_count:0,records:[]}'
+    classification=$(fm_evidence_classify true true)
+    jq -n --argjson now "$now" --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,now_epoch:$now,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
   if [ ! -d "$dir" ] || [ ! -r "$dir" ] || [ ! -x "$dir" ]; then
-    jq -n --argjson now "$now" '{available:false,now_epoch:$now,invalid_count:0,records:[]}'
+    classification=$(fm_evidence_classify false false)
+    jq -n --argjson now "$now" --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,now_epoch:$now,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
   for rec in "$dir"/*; do
       [ -e "$rec" ] || [ -L "$rec" ] || continue
       case "$(basename "$rec")" in .*) continue ;; esac
-      if ! fm_pending_reply_record_valid "$rec"; then
-        invalid_count=$((invalid_count + 1))
+      record_readable=false
+      [ -f "$rec" ] && [ ! -L "$rec" ] && [ -r "$rec" ] && record_readable=true
+      record_valid=false
+      [ "$record_readable" = true ] && fm_pending_reply_record_valid "$rec" && record_valid=true
+      classification=$(fm_evidence_classify "$record_readable" "$record_valid")
+      if [ "$classification" != available ]; then
+        available=false
+        if [ "$record_readable" = true ]; then
+          invalid_count=$((invalid_count + 1))
+        else
+          unreadable_count=$((unreadable_count + 1))
+        fi
         continue
       fi
       corr=$(fm_pending_reply_get "$rec" corr_id)
@@ -1554,6 +1573,9 @@ fm_pending_reply_open_json() {  # <state-dir>
         }') || return 1
       records=$(jq -n --argjson records "$records" --argjson row "$row" '$records + [$row]') || return 1
   done
-  jq -n --argjson now "$now" --argjson invalid "$invalid_count" --argjson records "$records" \
-    '{available:true,now_epoch:$now,invalid_count:$invalid,records:$records}'
+  classification=$(fm_evidence_classify "$available" true)
+  jq -n --argjson now "$now" \
+    --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+    --argjson invalid "$invalid_count" --argjson unreadable "$unreadable_count" --argjson records "$records" \
+    '{available:$available,now_epoch:$now,invalid_count:$invalid,unreadable_count:$unreadable,records:$records}'
 }

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -1407,3 +1407,59 @@ fm_pending_reply_task_has_open() {  # <state-dir> <task_id>
   done
   return 1
 }
+
+# Read-only list of open (non-resolved) pending-reply records.
+# Does not tick, recover, escalate, or otherwise mutate records.
+fm_pending_reply_open_json() {  # <state-dir>
+  local state=$1 dir rec corr phase task_id created delivered completed recovery_completed
+  local now age
+  dir=$(fm_pending_reply_dir "$state")
+  now=$(fm_pending_reply_now)
+  if [ ! -e "$dir" ]; then
+    jq -n --argjson now "$now" '{available:true,now_epoch:$now,records:[]}'
+    return 0
+  fi
+  if [ ! -d "$dir" ] || [ ! -r "$dir" ]; then
+    jq -n --argjson now "$now" '{available:false,now_epoch:$now,records:[]}'
+    return 0
+  fi
+  {
+    for rec in "$dir"/*; do
+      [ -f "$rec" ] || continue
+      case "$(basename "$rec")" in .*) continue ;; esac
+      corr=$(fm_pending_reply_get "$rec" corr_id)
+      [ -n "$corr" ] || corr=$(basename "$rec")
+      phase=$(fm_pending_reply_get "$rec" phase)
+      [ "$phase" != resolved ] || continue
+      task_id=$(fm_pending_reply_get "$rec" task_id)
+      created=$(fm_pending_reply_get "$rec" created_epoch)
+      delivered=$(fm_pending_reply_get "$rec" delivered_epoch)
+      completed=$(fm_pending_reply_get "$rec" request_turn_completed_epoch)
+      recovery_completed=$(fm_pending_reply_get "$rec" recovery_turn_completed_epoch)
+      age=null
+      case "$created" in
+        ''|*[!0-9]*) ;;
+        *) age=$((now - created)); [ "$age" -lt 0 ] && age=0 ;;
+      esac
+      jq -n \
+        --arg corr "$corr" \
+        --arg task "$task_id" \
+        --arg phase "$phase" \
+        --arg created "$created" \
+        --arg delivered "$delivered" \
+        --arg completed "$completed" \
+        --arg recovery_completed "$recovery_completed" \
+        --argjson age "$age" \
+        '{
+          corr_id:$corr,
+          task_id:$task,
+          phase:$phase,
+          created_epoch:(if $created == "" then null else (try ($created | tonumber) catch null) end),
+          delivered_epoch:(if $delivered == "" then null else (try ($delivered | tonumber) catch null) end),
+          request_turn_completed_epoch:(if $completed == "" then null else (try ($completed | tonumber) catch null) end),
+          recovery_turn_completed_epoch:(if $recovery_completed == "" then null else (try ($recovery_completed | tonumber) catch null) end),
+          age_seconds:$age
+        }'
+    done
+  } | jq -s --argjson now "$now" '{available:true,now_epoch:$now,records:.}'
+}

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -1411,7 +1411,7 @@ fm_pending_reply_task_has_open() {  # <state-dir> <task_id>
 # Read-only list of open (non-resolved) pending-reply records.
 # Does not tick, recover, escalate, or otherwise mutate records.
 fm_pending_reply_open_json() {  # <state-dir>
-  local state=$1 dir rec corr phase task_id created delivered completed recovery_completed
+  local state=$1 dir rec corr phase task_id created delivered completed recovery_completed grace
   local now age
   dir=$(fm_pending_reply_dir "$state")
   now=$(fm_pending_reply_now)
@@ -1436,6 +1436,8 @@ fm_pending_reply_open_json() {  # <state-dir>
       delivered=$(fm_pending_reply_get "$rec" delivered_epoch)
       completed=$(fm_pending_reply_get "$rec" request_turn_completed_epoch)
       recovery_completed=$(fm_pending_reply_get "$rec" recovery_turn_completed_epoch)
+      grace=$(fm_pending_reply_get "$rec" grace_secs)
+      case "$grace" in ''|*[!0-9]*) grace=$(fm_pending_reply_grace_secs) ;; esac
       age=null
       case "$created" in
         ''|*[!0-9]*) ;;
@@ -1449,6 +1451,7 @@ fm_pending_reply_open_json() {  # <state-dir>
         --arg delivered "$delivered" \
         --arg completed "$completed" \
         --arg recovery_completed "$recovery_completed" \
+        --arg grace "$grace" \
         --argjson age "$age" \
         '{
           corr_id:$corr,
@@ -1458,6 +1461,7 @@ fm_pending_reply_open_json() {  # <state-dir>
           delivered_epoch:(if $delivered == "" then null else (try ($delivered | tonumber) catch null) end),
           request_turn_completed_epoch:(if $completed == "" then null else (try ($completed | tonumber) catch null) end),
           recovery_turn_completed_epoch:(if $recovery_completed == "" then null else (try ($recovery_completed | tonumber) catch null) end),
+          grace_secs:($grace | tonumber),
           age_seconds:$age
         }'
     done

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -178,7 +178,7 @@ fm_pending_reply_get() {  # <record-path> <key>
 }
 
 fm_pending_reply_record_valid() {  # <record-path>
-  local rec=$1 base schema corr task phase key count value
+  local rec=$1 base schema corr task phase outcome key count value
   [ -f "$rec" ] && [ ! -L "$rec" ] || return 1
   for key in schema corr_id task_id parent_home parent_status parent_status_scan_signature request_summary \
     created_epoch delivered_epoch phase turn_seen_busy request_turn_completed_epoch \
@@ -222,8 +222,14 @@ fm_pending_reply_record_valid() {  # <record-path>
     value=$(fm_pending_reply_get "$rec" "$key")
     case "$value" in 0|1) ;; *) return 1 ;; esac
   done
-  value=$(fm_pending_reply_get "$rec" recovery_delivery_outcome)
-  case "$value" in ''|confirmed|failed|unknown) ;; *) return 1 ;; esac
+  outcome=$(fm_pending_reply_get "$rec" recovery_delivery_outcome)
+  case "$outcome" in ''|confirmed|failed|unknown) ;; *) return 1 ;; esac
+  case "$phase:$outcome" in
+    awaiting_report:|delivery_unknown:|recovery_sending:|recovery_sent:confirmed|recovery_failed:failed|recovery_unknown:unknown) ;;
+    escalated:|escalated:confirmed|escalated:failed|escalated:unknown) ;;
+    resolved:|resolved:confirmed|resolved:failed|resolved:unknown) ;;
+    *) return 1 ;;
+  esac
   value=$(fm_pending_reply_get "$rec" resolved_via)
   case "$value" in ''|status|document|helper) ;; *) return 1 ;; esac
 }

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -339,6 +339,7 @@ recovery_delivery_outcome=
 recovery_turn_seen_busy=0
 recovery_turn_completed_epoch=
 escalated_epoch=
+escalation_closed_epoch=
 resolved_epoch=
 resolved_via=
 wrong_home_hits=0

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -180,7 +180,12 @@ fm_pending_reply_get() {  # <record-path> <key>
 fm_pending_reply_record_valid() {  # <record-path>
   local rec=$1 base schema corr task phase key count value
   [ -f "$rec" ] && [ ! -L "$rec" ] || return 1
-  for key in schema corr_id task_id created_epoch phase request_turn_completed_epoch recovery_turn_completed_epoch grace_secs; do
+  for key in schema corr_id task_id parent_home parent_status parent_status_scan_signature request_summary \
+    created_epoch delivered_epoch phase turn_seen_busy request_turn_completed_epoch \
+    recovery_attempted_epoch recovery_sender_pid recovery_sender_identity recovery_sent_epoch \
+    recovery_delivery_outcome recovery_turn_seen_busy recovery_turn_completed_epoch \
+    escalated_epoch escalation_closed_epoch resolved_epoch resolved_via wrong_home_hits \
+    wrong_home_sightings wrong_home_scan_signature grace_secs; do
     count=$(grep -c "^${key}=" "$rec" 2>/dev/null || true)
     [ "$count" -eq 1 ] || return 1
   done
@@ -195,19 +200,30 @@ fm_pending_reply_record_valid() {  # <record-path>
   esac
   task=$(fm_pending_reply_get "$rec" task_id)
   case "$task" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac
+  [ -n "$(fm_pending_reply_get "$rec" parent_home)" ] || return 1
+  [ -n "$(fm_pending_reply_get "$rec" parent_status)" ] || return 1
   phase=$(fm_pending_reply_get "$rec" phase)
   case "$phase" in
     awaiting_report|delivery_unknown|recovery_sending|recovery_sent|recovery_failed|recovery_unknown|escalated|resolved) ;;
     *) return 1 ;;
   esac
-  for key in created_epoch grace_secs; do
+  for key in created_epoch grace_secs wrong_home_hits; do
     value=$(fm_pending_reply_get "$rec" "$key")
     case "$value" in ''|*[!0-9]*) return 1 ;; esac
   done
-  for key in request_turn_completed_epoch recovery_turn_completed_epoch; do
+  for key in delivered_epoch request_turn_completed_epoch recovery_attempted_epoch recovery_sender_pid \
+    recovery_sent_epoch recovery_turn_completed_epoch escalated_epoch escalation_closed_epoch resolved_epoch; do
     value=$(fm_pending_reply_get "$rec" "$key")
     case "$value" in *[!0-9]*) return 1 ;; esac
   done
+  for key in turn_seen_busy recovery_turn_seen_busy; do
+    value=$(fm_pending_reply_get "$rec" "$key")
+    case "$value" in 0|1) ;; *) return 1 ;; esac
+  done
+  value=$(fm_pending_reply_get "$rec" recovery_delivery_outcome)
+  case "$value" in ''|confirmed|failed|unknown) ;; *) return 1 ;; esac
+  value=$(fm_pending_reply_get "$rec" resolved_via)
+  case "$value" in ''|status|document|helper) ;; *) return 1 ;; esac
 }
 
 fm_pending_reply_corr_reusable() {  # <state-dir> <corr_id> <task_id>
@@ -1478,6 +1494,10 @@ fm_pending_reply_open_json() {  # <state-dir>
   local now age recovery_verdict row records='[]' invalid_count=0
   dir=$(fm_pending_reply_dir "$state")
   now=$(fm_pending_reply_now)
+  if [ -L "$dir" ] && [ ! -e "$dir" ]; then
+    jq -n --argjson now "$now" '{available:false,now_epoch:$now,invalid_count:0,records:[]}'
+    return 0
+  fi
   if [ ! -e "$dir" ]; then
     jq -n --argjson now "$now" '{available:true,now_epoch:$now,invalid_count:0,records:[]}'
     return 0

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -225,7 +225,7 @@ fm_pending_reply_record_valid() {  # <record-path>
   outcome=$(fm_pending_reply_get "$rec" recovery_delivery_outcome)
   case "$outcome" in ''|confirmed|failed|unknown) ;; *) return 1 ;; esac
   case "$phase:$outcome" in
-    awaiting_report:|delivery_unknown:|recovery_sending:|recovery_sent:confirmed|recovery_failed:failed|recovery_unknown:unknown) ;;
+    awaiting_report:|delivery_unknown:|recovery_sending:|recovery_sending:confirmed|recovery_sent:confirmed|recovery_failed:failed|recovery_unknown:unknown) ;;
     escalated:|escalated:confirmed|escalated:failed|escalated:unknown) ;;
     resolved:|resolved:confirmed|resolved:failed|resolved:unknown) ;;
     *) return 1 ;;

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -618,6 +618,30 @@ fm_pr_poll_artifacts_valid() {
   [ "$FM_PR_META_NUMBER" = "$FM_PR_DATA_NUMBER" ]
 }
 
+fm_pr_poll_listeners_json() {
+  local state=$1 template=$2 f id records='[]'
+  if [ ! -d "$state" ]; then
+    jq -n '{available:true,records:[]}'
+    return 0
+  fi
+  if [ ! -r "$state" ] || [ ! -x "$state" ]; then
+    jq -n '{available:false,records:[]}'
+    return 0
+  fi
+  for f in "$state"/*.check.sh; do
+    [ -f "$f" ] || continue
+    id=$(basename "$f" .check.sh)
+    case "$id" in
+      x-watch|tool-updates) continue ;;
+    esac
+    if fm_pr_poll_artifacts_valid "$state" "$id" "$template"; then
+      records=$(jq -n --argjson records "$records" --arg id "$id" \
+        '$records + [{id:$id,armed:true}]')
+    fi
+  done
+  jq -n --argjson records "$records" '{available:true,records:$records}'
+}
+
 fm_pr_poll_snapshot_capture() {
   local state=$1 id=$2 template=$3 registration
   fm_pr_poll_artifacts_valid "$state" "$id" "$template" || return 1

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -17,6 +17,11 @@
 # The receipt binds the terminal observation to the canonical registration and
 # lets a restart finish fixed-path removal without executing state-file bytes.
 
+_FM_PR_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)" || _FM_PR_LIB_DIR="."
+# shellcheck source=bin/fm-classify-lib.sh
+# shellcheck disable=SC1091
+. "$_FM_PR_LIB_DIR/fm-classify-lib.sh"
+
 FM_PR_PROVIDER=
 FM_PR_URL=
 FM_PR_HOST=
@@ -619,39 +624,92 @@ fm_pr_poll_artifacts_valid() {
 }
 
 fm_pr_poll_listeners_json() {
-  local state=$1 template=$2 f id meta records='[]'
-  if [ ! -d "$state" ]; then
-    jq -n '{available:true,records:[]}'
+  local state=$1 template=$2 f id meta records='[]' invalid='[]' unreadable='[]'
+  local artifact_readable artifact_valid notification_matches classification
+  if [ ! -d "$state" ] && [ ! -L "$state" ]; then
+    classification=$(fm_evidence_classify true true)
+    jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,records:[],invalid_count:0,invalid:[],unreadable_count:0,unreadable:[]}'
     return 0
   fi
-  if [ ! -r "$state" ] || [ ! -x "$state" ]; then
-    jq -n '{available:false,records:[]}'
+  if { [ -L "$state" ] && [ ! -e "$state" ]; } \
+    || { [ -e "$state" ] && { [ ! -d "$state" ] || [ ! -r "$state" ] || [ ! -x "$state" ]; }; }; then
+    classification=$(fm_evidence_classify false false)
+    jq -n --arg path "$state" --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,records:[],invalid_count:0,invalid:[],unreadable_count:1,unreadable:[{path:$path}]}'
     return 0
   fi
   for f in "$state"/*.check.sh; do
-    [ -f "$f" ] || continue
+    [ -e "$f" ] || [ -L "$f" ] || continue
     id=$(basename "$f" .check.sh)
     case "$id" in
       x-watch|tool-updates) continue ;;
     esac
-    if fm_pr_poll_artifacts_valid "$state" "$id" "$template"; then
+    artifact_readable=false
+    if [ -f "$f" ] && [ ! -L "$f" ] && [ -r "$f" ]; then
+      artifact_readable=true
+    fi
+    artifact_valid=false
+    if [ "$artifact_readable" = true ] \
+      && fm_pr_poll_artifacts_valid "$state" "$id" "$template"; then
+      artifact_valid=true
+    fi
+    classification=$(fm_evidence_classify "$artifact_readable" "$artifact_valid")
+    if [ "$classification" = available ]; then
       records=$(jq -n --argjson records "$records" --arg id "$id" \
         '$records + [{id:$id,armed:true,terminal_notified:false}]')
+    elif [ "$artifact_readable" = true ]; then
+      invalid=$(jq -n --argjson invalid "$invalid" --arg id "$id" --arg path "$f" \
+        '$invalid + [{id:$id,path:$path}]')
+    else
+      unreadable=$(jq -n --argjson unreadable "$unreadable" --arg id "$id" --arg path "$f" \
+        '$unreadable + [{id:$id,path:$path}]')
     fi
   done
   for f in "$state"/*.pr-poll-merge-notified; do
-    [ -f "$f" ] && [ ! -L "$f" ] || continue
+    [ -e "$f" ] || [ -L "$f" ] || continue
     id=$(basename "$f" .pr-poll-merge-notified)
-    fm_pr_task_id_valid "$id" || continue
     meta="$state/$id.meta"
-    if fm_pr_metadata_identity_parse "$meta" \
-      && fm_pr_poll_merge_already_notified "$state" "$id" \
-        "$FM_PR_META_PROVIDER" "$FM_PR_META_HOST" "$FM_PR_META_PATH" "$FM_PR_META_NUMBER"; then
+    artifact_readable=false
+    if [ -f "$f" ] && [ ! -L "$f" ] && [ -r "$f" ]; then
+      artifact_readable=true
+    fi
+    artifact_valid=false
+    notification_matches=false
+    if [ "$artifact_readable" = true ] \
+      && fm_pr_task_id_valid "$id" \
+      && fm_pr_poll_merge_marker_valid "$state" "$f"; then
+      artifact_valid=true
+      if fm_pr_metadata_identity_parse "$meta" \
+        && fm_pr_poll_merge_already_notified "$state" "$id" \
+          "$FM_PR_META_PROVIDER" "$FM_PR_META_HOST" "$FM_PR_META_PATH" "$FM_PR_META_NUMBER"; then
+        notification_matches=true
+      fi
+    fi
+    classification=$(fm_evidence_classify "$artifact_readable" "$artifact_valid")
+    if [ "$classification" = available ] && [ "$notification_matches" = true ]; then
       records=$(jq -n --argjson records "$records" --arg id "$id" \
         '$records + [{id:$id,armed:false,terminal_notified:true}]')
+    elif [ "$classification" = available ]; then
+      :
+    elif [ "$artifact_readable" = true ]; then
+      invalid=$(jq -n --argjson invalid "$invalid" --arg id "$id" --arg path "$f" \
+        '$invalid + [{id:$id,path:$path}]')
+    else
+      unreadable=$(jq -n --argjson unreadable "$unreadable" --arg id "$id" --arg path "$f" \
+        '$unreadable + [{id:$id,path:$path}]')
     fi
   done
-  jq -n --argjson records "$records" '{available:true,records:$records}'
+  if [ "$(printf '%s' "$invalid" | jq 'length')" -eq 0 ] \
+    && [ "$(printf '%s' "$unreadable" | jq 'length')" -eq 0 ]; then
+    classification=$(fm_evidence_classify true true)
+  else
+    classification=$(fm_evidence_classify false false)
+  fi
+  jq -n \
+    --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+    --argjson records "$records" --argjson invalid "$invalid" --argjson unreadable "$unreadable" \
+    '{available:$available,records:$records,invalid_count:($invalid|length),invalid:$invalid,unreadable_count:($unreadable|length),unreadable:$unreadable}'
 }
 
 fm_pr_poll_snapshot_capture() {
@@ -989,7 +1047,19 @@ fm_pr_poll_retirement_recover_all() {
 # outcome is published.
 fm_pr_poll_merge_marker_matches() {  # <marker> <device> <provider> <host> <path> <number>
   local marker=$1 device=$2 expected_provider=$3 expected_host=$4 expected_path=$5 expected_number=$6
-  local version provider host path number
+  fm_pr_poll_merge_marker_parse "$marker" "$device" || return 1
+  [ "$FM_PR_MARKER_PROVIDER" = "$expected_provider" ] \
+    && [ "$FM_PR_MARKER_HOST" = "$expected_host" ] \
+    && [ "$FM_PR_MARKER_PATH" = "$expected_path" ] \
+    && [ "$FM_PR_MARKER_NUMBER" = "$expected_number" ]
+}
+
+fm_pr_poll_merge_marker_parse() {
+  local marker=$1 device=$2 version provider host path number _extra
+  FM_PR_MARKER_PROVIDER=
+  FM_PR_MARKER_HOST=
+  FM_PR_MARKER_PATH=
+  FM_PR_MARKER_NUMBER=
   fm_pr_private_file_valid "$marker" 600 "$device" || return 1
   exec 8< "$marker" || return 1
   IFS= read -r version <&8 || { exec 8<&-; return 1; }
@@ -1002,11 +1072,21 @@ fm_pr_poll_merge_marker_matches() {  # <marker> <device> <provider> <host> <path
     return 1
   fi
   exec 8<&-
-  [ "$version" = fm-pr-poll-merge-notified-v1 ] \
-    && [ "$provider" = "$expected_provider" ] \
-    && [ "$host" = "$expected_host" ] \
-    && [ "$path" = "$expected_path" ] \
-    && [ "$number" = "$expected_number" ]
+  [ "$version" = fm-pr-poll-merge-notified-v1 ] || return 1
+  case "$provider" in github|gitlab) ;; *) return 1 ;; esac
+  [ -n "$host" ] && [ -n "$path" ] || return 1
+  case "$number" in ''|*[!0-9]*) return 1 ;; esac
+  FM_PR_MARKER_PROVIDER=$provider
+  FM_PR_MARKER_HOST=$host
+  FM_PR_MARKER_PATH=$path
+  FM_PR_MARKER_NUMBER=$number
+}
+
+fm_pr_poll_merge_marker_valid() {
+  local state=$1 marker=$2 state_device
+  [ -d "$state" ] && [ ! -L "$state" ] || return 1
+  state_device=$(fm_pr_file_device "$state") || return 1
+  fm_pr_poll_merge_marker_parse "$marker" "$state_device"
 }
 
 fm_pr_poll_merge_already_notified() {  # <state> <id> <provider> <host> <path> <number>

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -619,7 +619,7 @@ fm_pr_poll_artifacts_valid() {
 }
 
 fm_pr_poll_listeners_json() {
-  local state=$1 template=$2 f id records='[]'
+  local state=$1 template=$2 f id meta records='[]'
   if [ ! -d "$state" ]; then
     jq -n '{available:true,records:[]}'
     return 0
@@ -636,7 +636,19 @@ fm_pr_poll_listeners_json() {
     esac
     if fm_pr_poll_artifacts_valid "$state" "$id" "$template"; then
       records=$(jq -n --argjson records "$records" --arg id "$id" \
-        '$records + [{id:$id,armed:true}]')
+        '$records + [{id:$id,armed:true,terminal_notified:false}]')
+    fi
+  done
+  for f in "$state"/*.pr-poll-merge-notified; do
+    [ -f "$f" ] && [ ! -L "$f" ] || continue
+    id=$(basename "$f" .pr-poll-merge-notified)
+    fm_pr_task_id_valid "$id" || continue
+    meta="$state/$id.meta"
+    if fm_pr_metadata_identity_parse "$meta" \
+      && fm_pr_poll_merge_already_notified "$state" "$id" \
+        "$FM_PR_META_PROVIDER" "$FM_PR_META_HOST" "$FM_PR_META_PATH" "$FM_PR_META_NUMBER"; then
+      records=$(jq -n --argjson records "$records" --arg id "$id" \
+        '$records + [{id:$id,armed:false,terminal_notified:true}]')
     fi
   done
   jq -n --argjson records "$records" '{available:true,records:$records}'

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -39,6 +39,7 @@ FM_PR_META_URL=
 FM_PR_META_HOST=
 FM_PR_META_PATH=
 FM_PR_META_NUMBER=
+FM_PR_META_DECLARED=false
 FM_PR_REG_ID=
 FM_PR_REG_PROVIDER=
 FM_PR_REG_URL=
@@ -297,6 +298,7 @@ fm_pr_metadata_identity_parse() {
   FM_PR_META_HOST=
   FM_PR_META_PATH=
   FM_PR_META_NUMBER=
+  FM_PR_META_DECLARED=false
   [ -f "$file" ] && [ ! -L "$file" ] || return 1
   [ "$(fm_pr_file_link_count "$file")" = 1 ] || return 1
   while IFS= read -r line || [ -n "$line" ]; do
@@ -313,6 +315,7 @@ fm_pr_metadata_identity_parse() {
           FM_PR_META_NUMBER=$FM_PR_NUMBER
         fi
         seen_pr=1
+        FM_PR_META_DECLARED=true
         ;;
       pr_head=*)
         if [ "$seen_pr" -eq 1 ]; then
@@ -625,20 +628,41 @@ fm_pr_poll_artifacts_valid() {
 
 fm_pr_poll_listeners_json() {
   local state=$1 template=$2 f id meta records='[]' invalid='[]' unreadable='[]'
-  local artifact_readable artifact_valid notification_matches classification
+  local metadata_invalid='[]' artifact_readable artifact_valid metadata_valid
+  local notification_matches classification
   if [ ! -d "$state" ] && [ ! -L "$state" ]; then
     classification=$(fm_evidence_classify true true)
     jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
-      '{available:$available,records:[],invalid_count:0,invalid:[],unreadable_count:0,unreadable:[]}'
+      '{available:$available,records:[],invalid_count:0,invalid:[],unreadable_count:0,unreadable:[],metadata_invalid_count:0,metadata_invalid:[]}'
     return 0
   fi
   if { [ -L "$state" ] && [ ! -e "$state" ]; } \
     || { [ -e "$state" ] && { [ ! -d "$state" ] || [ ! -r "$state" ] || [ ! -x "$state" ]; }; }; then
     classification=$(fm_evidence_classify false false)
     jq -n --arg path "$state" --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
-      '{available:$available,records:[],invalid_count:0,invalid:[],unreadable_count:1,unreadable:[{path:$path}]}'
+      '{available:$available,records:[],invalid_count:0,invalid:[],unreadable_count:1,unreadable:[{path:$path}],metadata_invalid_count:0,metadata_invalid:[]}'
     return 0
   fi
+  for meta in "$state"/*.meta; do
+    [ -e "$meta" ] || [ -L "$meta" ] || continue
+    id=$(basename "$meta" .meta)
+    artifact_readable=false
+    if [ -f "$meta" ] && [ ! -L "$meta" ] && [ -r "$meta" ]; then
+      artifact_readable=true
+    fi
+    metadata_valid=false
+    FM_PR_META_DECLARED=false
+    if [ "$artifact_readable" = true ] \
+      && fm_pr_metadata_identity_parse "$meta"; then
+      metadata_valid=true
+    fi
+    classification=$(fm_evidence_classify "$artifact_readable" "$metadata_valid")
+    if [ "$FM_PR_META_DECLARED" = true ] \
+      && [ "$classification" != available ]; then
+      metadata_invalid=$(jq -n --argjson invalid "$metadata_invalid" --arg id "$id" --arg path "$meta" \
+        '$invalid + [{id:$id,path:$path}]')
+    fi
+  done
   for f in "$state"/*.check.sh; do
     [ -e "$f" ] || [ -L "$f" ] || continue
     id=$(basename "$f" .check.sh)
@@ -701,7 +725,8 @@ fm_pr_poll_listeners_json() {
     fi
   done
   if [ "$(printf '%s' "$invalid" | jq 'length')" -eq 0 ] \
-    && [ "$(printf '%s' "$unreadable" | jq 'length')" -eq 0 ]; then
+    && [ "$(printf '%s' "$unreadable" | jq 'length')" -eq 0 ] \
+    && [ "$(printf '%s' "$metadata_invalid" | jq 'length')" -eq 0 ]; then
     classification=$(fm_evidence_classify true true)
   else
     classification=$(fm_evidence_classify false false)
@@ -709,7 +734,8 @@ fm_pr_poll_listeners_json() {
   jq -n \
     --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
     --argjson records "$records" --argjson invalid "$invalid" --argjson unreadable "$unreadable" \
-    '{available:$available,records:$records,invalid_count:($invalid|length),invalid:$invalid,unreadable_count:($unreadable|length),unreadable:$unreadable}'
+    --argjson metadata_invalid "$metadata_invalid" \
+    '{available:$available,records:$records,invalid_count:($invalid|length),invalid:$invalid,unreadable_count:($unreadable|length),unreadable:$unreadable,metadata_invalid_count:($metadata_invalid|length),metadata_invalid:$metadata_invalid}'
 }
 
 fm_pr_poll_snapshot_capture() {

--- a/bin/fm-procevent-lib.sh
+++ b/bin/fm-procevent-lib.sh
@@ -31,6 +31,11 @@
 
 # Machine-wide claim root. Homes can share one underlying source store, so the
 # "one owner per canonical source" rule cannot live inside a single home.
+FM_PROCEVENT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)" || FM_PROCEVENT_LIB_DIR="."
+# shellcheck source=bin/fm-classify-lib.sh
+# shellcheck disable=SC1091
+. "$FM_PROCEVENT_LIB_DIR/fm-classify-lib.sh"
+
 fm_procevent_claim_root() {
   printf '%s\n' "${FM_PROCEVENT_CLAIM_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/procevent-claims}"
 }
@@ -107,24 +112,41 @@ fm_procevent_any_registered() {
 # owner is live, missing, stale, orphaned, uncertain, or terminal.
 fm_procevent_listeners_json() {  # <state>
   local state=$1 reg root rec id adapter owner status records='[]' available=true
+  local registration_readable registration_valid classification
   reg=$(fm_procevent_registry_dir "$state")
   if [ ! -e "$reg" ] && [ ! -L "$reg" ]; then
-    jq -n '{available:true,records:[]}'
+    classification=$(fm_evidence_classify true true)
+    jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,records:[]}'
     return 0
   fi
   if [ ! -d "$reg" ] || [ ! -r "$reg" ] || [ ! -x "$reg" ]; then
-    jq -n '{available:false,records:[]}'
+    classification=$(fm_evidence_classify false false)
+    jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,records:[]}'
     return 0
   fi
   root=$(fm_procevent_claim_root)
   if { [ -L "$root" ] && [ ! -e "$root" ]; } || { [ -e "$root" ] && { [ ! -d "$root" ] || [ ! -r "$root" ] || [ ! -x "$root" ]; }; }; then
-    jq -n '{available:false,records:[]}'
+    classification=$(fm_evidence_classify false false)
+    jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,records:[]}'
     return 0
   fi
   for rec in "$reg"/*.source; do
     [ -e "$rec" ] || [ -L "$rec" ] || continue
     id=${rec##*/}; id=${id%.source}
-    if fm_procevent_registration_parse "$rec" "$id"; then
+    registration_readable=false
+    [ -f "$rec" ] && [ ! -L "$rec" ] && [ -r "$rec" ] && registration_readable=true
+    registration_valid=false
+    FM_PROCEVENT_REG_FAILURE=invalid
+    if [ "$registration_readable" = true ]; then
+      fm_procevent_registration_parse "$rec" "$id" && registration_valid=true
+    elif [ -f "$rec" ] && [ ! -L "$rec" ]; then
+      FM_PROCEVENT_REG_FAILURE=unreadable
+    fi
+    classification=$(fm_evidence_classify "$registration_readable" "$registration_valid")
+    if [ "$classification" = available ]; then
       adapter=$FM_PROCEVENT_REG_ADAPTER
       fm_procevent_claim_state_locked "$id"
       status=$?
@@ -148,9 +170,11 @@ fm_procevent_listeners_json() {  # <state>
       --arg id "$id" \
       --arg adapter "$adapter" \
       --arg owner "$owner" \
-      '$records + [{id:$id,adapter:$adapter,owner:$owner}]')
+      --arg classification "$classification" \
+      '$records + [{id:$id,adapter:$adapter,owner:$owner,classification:$classification}]')
   done
-  jq -n --argjson available "$available" --argjson records "$records" \
+  classification=$(fm_evidence_classify "$available" true)
+  jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" --argjson records "$records" \
     '{available:$available,records:$records}'
 }
 

--- a/bin/fm-procevent-lib.sh
+++ b/bin/fm-procevent-lib.sh
@@ -108,7 +108,7 @@ fm_procevent_any_registered() {
 fm_procevent_listeners_json() {  # <state>
   local state=$1 reg root rec id adapter owner status records='[]' available=true
   reg=$(fm_procevent_registry_dir "$state")
-  if [ ! -e "$reg" ]; then
+  if [ ! -e "$reg" ] && [ ! -L "$reg" ]; then
     jq -n '{available:true,records:[]}'
     return 0
   fi

--- a/bin/fm-procevent-lib.sh
+++ b/bin/fm-procevent-lib.sh
@@ -300,6 +300,7 @@ fm_procevent_pid_state() {
 fm_procevent_claim_state_locked() {
   local claim registration current_identity
   claim=$(fm_procevent_claim_path "$1")
+  [ -L "$claim" ] && [ ! -e "$claim" ] && return 2
   [ -e "$claim" ] || return 1
   fm_procevent_claim_load_locked "$1" || return 2
   if [ "$FM_PROCEVENT_CLAIM_TERMINAL" = terminal ] && [ -n "$FM_PROCEVENT_CLAIM_REG_IDENTITY" ]; then

--- a/bin/fm-procevent-lib.sh
+++ b/bin/fm-procevent-lib.sh
@@ -71,13 +71,18 @@ fm_procevent_any_registered() {
 # Does not acquire source locks, start runners, or mark results handled.
 # owner is live, missing, stale, orphaned, uncertain, or terminal.
 fm_procevent_listeners_json() {  # <state>
-  local state=$1 reg rec id adapter owner status records='[]' available=true
+  local state=$1 reg root rec id adapter owner status records='[]' available=true
   reg=$(fm_procevent_registry_dir "$state")
   if [ ! -e "$reg" ]; then
     jq -n '{available:true,records:[]}'
     return 0
   fi
-  if [ ! -d "$reg" ] || [ ! -r "$reg" ]; then
+  if [ ! -d "$reg" ] || [ ! -r "$reg" ] || [ ! -x "$reg" ]; then
+    jq -n '{available:false,records:[]}'
+    return 0
+  fi
+  root=$(fm_procevent_claim_root)
+  if [ -e "$root" ] && { [ ! -d "$root" ] || [ ! -r "$root" ] || [ ! -x "$root" ]; }; then
     jq -n '{available:false,records:[]}'
     return 0
   fi

--- a/bin/fm-procevent-lib.sh
+++ b/bin/fm-procevent-lib.sh
@@ -85,6 +85,7 @@ fm_procevent_registration_parse() {  # <registration> <source-id>
     ! IFS= read -r extra || return 1
   } < "$file"
   FM_PROCEVENT_REG_ADAPTER=$adapter
+  # shellcheck disable=SC2034 # Read by callers after the function returns.
   FM_PROCEVENT_REG_ARGV=("${argv[@]}")
   FM_PROCEVENT_REG_FAILURE=
 }

--- a/bin/fm-procevent-lib.sh
+++ b/bin/fm-procevent-lib.sh
@@ -55,6 +55,40 @@ fm_procevent_adapter_valid() {
   [ "${#a}" -le 32 ]
 }
 
+fm_procevent_registration_parse() {  # <registration> <source-id>
+  local file=$1 id=$2 line adapter argc i=0 extra
+  local -a argv=()
+  FM_PROCEVENT_REG_ADAPTER=
+  FM_PROCEVENT_REG_ARGV=()
+  FM_PROCEVENT_REG_FAILURE=invalid
+  fm_procevent_source_id_valid "$id" || return 1
+  case "$file" in */"$id.source") ;; *) return 1 ;; esac
+  [ -f "$file" ] && [ ! -L "$file" ] || return 1
+  if [ ! -r "$file" ]; then
+    FM_PROCEVENT_REG_FAILURE=unreadable
+    return 1
+  fi
+  {
+    IFS= read -r line || return 1
+    case "$line" in adapter=*) adapter=${line#adapter=} ;; *) return 1 ;; esac
+    fm_procevent_adapter_valid "$adapter" || return 1
+    IFS= read -r line || return 1
+    case "$line" in argc=*) argc=${line#argc=} ;; *) return 1 ;; esac
+    case "$argc" in ''|*[!0-9]*|0) return 1 ;; esac
+    IFS= read -r line || return 1
+    [ "$line" = "argv:" ] || return 1
+    while [ "$i" -lt "$argc" ]; do
+      IFS= read -r line || return 1
+      argv+=("$line")
+      i=$((i + 1))
+    done
+    ! IFS= read -r extra || return 1
+  } < "$file"
+  FM_PROCEVENT_REG_ADAPTER=$adapter
+  FM_PROCEVENT_REG_ARGV=("${argv[@]}")
+  FM_PROCEVENT_REG_FAILURE=
+}
+
 # fm_procevent_any_registered <state>
 fm_procevent_any_registered() {
   local reg rec
@@ -87,19 +121,27 @@ fm_procevent_listeners_json() {  # <state>
     return 0
   fi
   for rec in "$reg"/*.source; do
-    [ -f "$rec" ] || continue
+    [ -e "$rec" ] || [ -L "$rec" ] || continue
     id=${rec##*/}; id=${id%.source}
-    adapter=$(awk -F= '$1 == "adapter" { print $2; exit }' "$rec" 2>/dev/null || printf '')
-    fm_procevent_claim_state_locked "$id"
-    status=$?
-    case "$status" in
-      0) owner=live ;;
-      1) owner=missing ;;
-      2) owner=uncertain ;;
-      3) owner=orphaned ;;
-      4) owner=terminal ;;
-      *) owner=uncertain ;;
-    esac
+    if fm_procevent_registration_parse "$rec" "$id"; then
+      adapter=$FM_PROCEVENT_REG_ADAPTER
+      fm_procevent_claim_state_locked "$id"
+      status=$?
+      case "$status" in
+        0) owner=live ;;
+        1) owner=missing ;;
+        2) owner=uncertain ;;
+        3) owner=orphaned ;;
+        4) owner=terminal ;;
+        *) owner=uncertain ;;
+      esac
+    else
+      adapter=
+      case "$FM_PROCEVENT_REG_FAILURE" in
+        unreadable) owner=unreadable ;;
+        *) owner=invalid ;;
+      esac
+    fi
     records=$(jq -n \
       --argjson records "$records" \
       --arg id "$id" \

--- a/bin/fm-procevent-lib.sh
+++ b/bin/fm-procevent-lib.sh
@@ -116,7 +116,7 @@ fm_procevent_listeners_json() {  # <state>
     return 0
   fi
   root=$(fm_procevent_claim_root)
-  if [ -e "$root" ] && { [ ! -d "$root" ] || [ ! -r "$root" ] || [ ! -x "$root" ]; }; then
+  if { [ -L "$root" ] && [ ! -e "$root" ]; } || { [ -e "$root" ] && { [ ! -d "$root" ] || [ ! -r "$root" ] || [ ! -x "$root" ]; }; }; then
     jq -n '{available:false,records:[]}'
     return 0
   fi

--- a/bin/fm-procevent-lib.sh
+++ b/bin/fm-procevent-lib.sh
@@ -67,6 +67,45 @@ fm_procevent_any_registered() {
   return 1
 }
 
+# Read-only registered-source inventory for health checks.
+# Does not acquire source locks, start runners, or mark results handled.
+# owner is live, missing, stale, orphaned, uncertain, or terminal.
+fm_procevent_listeners_json() {  # <state>
+  local state=$1 reg rec id adapter owner status records='[]' available=true
+  reg=$(fm_procevent_registry_dir "$state")
+  if [ ! -e "$reg" ]; then
+    jq -n '{available:true,records:[]}'
+    return 0
+  fi
+  if [ ! -d "$reg" ] || [ ! -r "$reg" ]; then
+    jq -n '{available:false,records:[]}'
+    return 0
+  fi
+  for rec in "$reg"/*.source; do
+    [ -f "$rec" ] || continue
+    id=${rec##*/}; id=${id%.source}
+    adapter=$(awk -F= '$1 == "adapter" { print $2; exit }' "$rec" 2>/dev/null || printf '')
+    fm_procevent_claim_state_locked "$id"
+    status=$?
+    case "$status" in
+      0) owner=live ;;
+      1) owner=missing ;;
+      2) owner=uncertain ;;
+      3) owner=orphaned ;;
+      4) owner=terminal ;;
+      *) owner=uncertain ;;
+    esac
+    records=$(jq -n \
+      --argjson records "$records" \
+      --arg id "$id" \
+      --arg adapter "$adapter" \
+      --arg owner "$owner" \
+      '$records + [{id:$id,adapter:$adapter,owner:$owner}]')
+  done
+  jq -n --argjson available "$available" --argjson records "$records" \
+    '{available:$available,records:$records}'
+}
+
 # --- ownership --------------------------------------------------------------
 # A claim is a private file recording the home, runner pid, claim generation,
 # and process identity. Registration and every ownership transition are

--- a/bin/fm-procevent.sh
+++ b/bin/fm-procevent.sh
@@ -217,25 +217,8 @@ feed_keyed_answers() {  # <adapter> <source-id> <result-file>
 }
 
 read_adapter() {  # <source-id>
-  local f; f=$(source_file "$1")
-  [ -f "$f" ] && [ ! -L "$f" ] || return 1
-  sed -n 's/^adapter=//p' "$f" | head -1
-}
-
-# Read the stored argv into the ARGV array. One argument per line after the
-# argv= count, so an argument containing spaces is not re-split.
-read_argv() {  # <source-id>
-  local f n; f=$(source_file "$1")
-  ARGV=()
-  [ -f "$f" ] && [ ! -L "$f" ] || return 1
-  n=$(sed -n 's/^argc=//p' "$f" | head -1)
-  case "$n" in ''|*[!0-9]*) return 1 ;; esac
-  local i=0 line
-  while IFS= read -r line; do
-    i=$((i + 1))
-    [ "$i" -le "$n" ] && ARGV+=("$line")
-  done < <(sed -n '/^argv:$/,$p' "$f" | tail -n +2)
-  [ "${#ARGV[@]}" -eq "$n" ]
+  fm_procevent_registration_parse "$(source_file "$1")" "$1" || return 1
+  printf '%s\n' "$FM_PROCEVENT_REG_ADAPTER"
 }
 
 cmd_register() {
@@ -359,17 +342,15 @@ cmd_start() {
     fm_procevent_source_lock_release "$id"
     die "source is not registered: $id"
   fi
-  if ! adapter=$(read_adapter "$id"); then
+  if ! fm_procevent_registration_parse "$(source_file "$id")" "$id"; then
     fm_procevent_source_lock_release "$id"
     die "registration is unreadable: $id"
   fi
+  adapter=$FM_PROCEVENT_REG_ADAPTER
+  ARGV=("${FM_PROCEVENT_REG_ARGV[@]}")
   if ! fm_procevent_adapter_valid "$adapter"; then
     fm_procevent_source_lock_release "$id"
     die "registration names an invalid adapter"
-  fi
-  if ! read_argv "$id"; then
-    fm_procevent_source_lock_release "$id"
-    die "registration argv is unreadable: $id"
   fi
   fm_procevent_claim_acquire_locked "$id" "$FM_HOME" "$$" "$(source_file "$id")"
   claimed=$?

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -527,92 +527,118 @@ fm_task_inbox_unhandled_json() {  # <state-dir>
 # Does not ring, escalate, or rewrite ladder bookkeeping.
 fm_task_inbox_latest_activity_json() {  # <state-dir>
   local state=$1 dir handled task rec mtime latest available=true classification
+  local task_available task_invalid task_unreadable
   local invalid_count=0 unreadable_count=0 records='[]' row
   if [ ! -d "$state" ] && [ ! -L "$state" ]; then
     classification=$(fm_evidence_classify true true)
     jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
-      '{available:$available,invalid_count:0,unreadable_count:0,records:[]}'
+      '{available:$available,root_available:$available,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
   if [ -L "$state" ] && [ ! -e "$state" ]; then
     classification=$(fm_evidence_classify false false)
     jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
-      '{available:$available,invalid_count:0,unreadable_count:0,records:[]}'
+      '{available:$available,root_available:$available,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
   if [ ! -r "$state" ] || [ ! -x "$state" ]; then
     classification=$(fm_evidence_classify false false)
     jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
-      '{available:$available,invalid_count:0,unreadable_count:0,records:[]}'
+      '{available:$available,root_available:$available,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
   for dir in "$state"/*.inbox; do
     [ -e "$dir" ] || [ -L "$dir" ] || continue
-    if [ ! -d "$dir" ] || { [ -L "$dir" ] && [ ! -e "$dir" ]; }; then
-      invalid_count=$((invalid_count + 1))
-      available=false
-      continue
-    fi
-    if [ ! -r "$dir" ] || [ ! -x "$dir" ]; then
-      classification=$(fm_evidence_classify false false)
-      available=false
-      continue
-    fi
-    handled="$dir/handled"
-    if [ ! -d "$handled" ] || { [ -L "$handled" ] && [ ! -e "$handled" ]; }; then
-      classification=$(fm_evidence_classify false false)
-      invalid_count=$((invalid_count + 1))
-      available=false
-      continue
-    fi
-    if [ ! -r "$handled" ] || [ ! -x "$handled" ]; then
-      classification=$(fm_evidence_classify false false)
-      available=false
-      continue
-    fi
     task=$(basename "$dir" .inbox)
     latest=
-    for rec in "$dir"/*.msg "$handled"/*.msg; do
-      [ -e "$rec" ] || [ -L "$rec" ] || continue
-      if fm_task_inbox_record_valid "$rec"; then
-        classification=$(fm_evidence_classify true true)
-      else
-        classification=$(fm_evidence_classify true false)
-        [ -e "$rec" ] || [ -L "$rec" ] || continue
-        case "$FM_TASK_INBOX_RECORD_FAILURE" in
-          unreadable) unreadable_count=$((unreadable_count + 1)) ;;
-          *) invalid_count=$((invalid_count + 1)) ;;
-        esac
+    task_available=true
+    task_invalid=0
+    task_unreadable=0
+    if [ ! -d "$dir" ] || { [ -L "$dir" ] && [ ! -e "$dir" ]; }; then
+      invalid_count=$((invalid_count + 1))
+      task_invalid=$((task_invalid + 1))
+      task_available=false
+      available=false
+    elif [ ! -r "$dir" ] || [ ! -x "$dir" ]; then
+      classification=$(fm_evidence_classify false false)
+      unreadable_count=$((unreadable_count + 1))
+      task_unreadable=$((task_unreadable + 1))
+      task_available=false
+      available=false
+    else
+      handled="$dir/handled"
+      if [ ! -d "$handled" ] || { [ -L "$handled" ] && [ ! -e "$handled" ]; }; then
+        classification=$(fm_evidence_classify false false)
+        invalid_count=$((invalid_count + 1))
+        task_invalid=$((task_invalid + 1))
+        task_available=false
         available=false
-        continue
-      fi
-      mtime=$(fm_path_mtime "$rec") || {
-        [ -e "$rec" ] || [ -L "$rec" ] || continue
+      elif [ ! -r "$handled" ] || [ ! -x "$handled" ]; then
         classification=$(fm_evidence_classify false false)
         unreadable_count=$((unreadable_count + 1))
+        task_unreadable=$((task_unreadable + 1))
+        task_available=false
         available=false
-        continue
-      }
-      case "$mtime" in
-        ''|*[!0-9]*)
-          classification=$(fm_evidence_classify false false)
-          unreadable_count=$((unreadable_count + 1))
-          available=false
-          continue
-          ;;
-      esac
-      if [ -z "$latest" ] || [ "$mtime" -gt "$latest" ]; then
-        latest=$mtime
+      else
+        for rec in "$dir"/*.msg "$handled"/*.msg; do
+          [ -e "$rec" ] || [ -L "$rec" ] || continue
+          if fm_task_inbox_record_valid "$rec"; then
+            classification=$(fm_evidence_classify true true)
+          else
+            classification=$(fm_evidence_classify true false)
+            [ -e "$rec" ] || [ -L "$rec" ] || continue
+            case "$FM_TASK_INBOX_RECORD_FAILURE" in
+              unreadable)
+                unreadable_count=$((unreadable_count + 1))
+                task_unreadable=$((task_unreadable + 1))
+                ;;
+              *)
+                invalid_count=$((invalid_count + 1))
+                task_invalid=$((task_invalid + 1))
+                ;;
+            esac
+            task_available=false
+            available=false
+            continue
+          fi
+          mtime=$(fm_path_mtime "$rec") || {
+            [ -e "$rec" ] || [ -L "$rec" ] || continue
+            classification=$(fm_evidence_classify false false)
+            unreadable_count=$((unreadable_count + 1))
+            task_unreadable=$((task_unreadable + 1))
+            task_available=false
+            available=false
+            continue
+          }
+          case "$mtime" in
+            ''|*[!0-9]*)
+              classification=$(fm_evidence_classify false false)
+              unreadable_count=$((unreadable_count + 1))
+              task_unreadable=$((task_unreadable + 1))
+              task_available=false
+              available=false
+              continue
+              ;;
+          esac
+          if [ -z "$latest" ] || [ "$mtime" -gt "$latest" ]; then
+            latest=$mtime
+          fi
+        done
       fi
-    done
-    [ -n "$latest" ] || continue
+    fi
+    classification=$(fm_evidence_classify "$task_available" true)
+    case "$latest" in
+      '') latest=null ;;
+    esac
     row=$(jq -n --arg task "$task" --argjson latest "$latest" \
-      '{task_id:$task,last_epoch:$latest}') || return 1
+      --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      --argjson invalid "$task_invalid" --argjson unreadable "$task_unreadable" \
+      '{task_id:$task,available:$available,invalid_count:$invalid,unreadable_count:$unreadable,last_epoch:$latest}') || return 1
     records=$(jq -n --argjson records "$records" --argjson row "$row" \
       '$records + [$row]') || return 1
   done
   classification=$(fm_evidence_classify "$available" true)
   jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" --argjson invalid "$invalid_count" \
     --argjson unreadable "$unreadable_count" --argjson records "$records" \
-    '{available:$available,invalid_count:$invalid,unreadable_count:$unreadable,records:$records}'
+    '{available:$available,root_available:true,invalid_count:$invalid,unreadable_count:$unreadable,records:$records}'
 }

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -409,17 +409,17 @@ fm_task_inbox_unhandled_json() {  # <state-dir>
     jq -n '{available:true,records:[]}'
     return 0
   fi
-  if [ ! -r "$state" ]; then
+  if [ ! -r "$state" ] || [ ! -x "$state" ]; then
     jq -n '{available:false,records:[]}'
     return 0
   fi
   for dir in "$state"/*.inbox; do
     [ -d "$dir" ] || continue
-    [ -r "$dir" ] || available=false
+    [ -r "$dir" ] && [ -x "$dir" ] || available=false
   done
   {
     for dir in "$state"/*.inbox; do
-      [ -d "$dir" ] && [ -r "$dir" ] || continue
+      [ -d "$dir" ] && [ -r "$dir" ] && [ -x "$dir" ] || continue
       task=$(basename "$dir" .inbox)
       for rec in "$dir"/*.msg; do
         [ -f "$rec" ] || continue

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -440,8 +440,12 @@ fm_task_inbox_unhandled_json() {  # <state-dir>
       ;;
   esac
   for dir in "$state"/*.inbox; do
-    [ -d "$dir" ] || continue
-    [ -r "$dir" ] && [ -x "$dir" ] || available=false
+    [ -e "$dir" ] || [ -L "$dir" ] || continue
+    if [ ! -d "$dir" ] || { [ -L "$dir" ] && [ ! -e "$dir" ]; }; then
+      invalid_count=$((invalid_count + 1))
+    elif [ ! -r "$dir" ] || [ ! -x "$dir" ]; then
+      available=false
+    fi
   done
   for dir in "$state"/*.inbox; do
     [ -d "$dir" ] && [ -r "$dir" ] && [ -x "$dir" ] || continue

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -494,3 +494,53 @@ fm_task_inbox_unhandled_json() {  # <state-dir>
     --argjson records "$records" \
     '{available:$available,invalid_count:$invalid,unreadable_count:$unreadable,records:$records}'
 }
+
+# Read-only latest steering-inbox activity per task, including handled records.
+# Does not ring, escalate, or rewrite ladder bookkeeping.
+fm_task_inbox_latest_activity_json() {  # <state-dir>
+  local state=$1 dir task rec mtime latest available=true
+  local records='[]' row
+  if [ ! -d "$state" ]; then
+    jq -n '{available:true,records:[]}'
+    return 0
+  fi
+  if [ ! -r "$state" ] || [ ! -x "$state" ]; then
+    jq -n '{available:false,records:[]}'
+    return 0
+  fi
+  for dir in "$state"/*.inbox; do
+    [ -e "$dir" ] || [ -L "$dir" ] || continue
+    if [ ! -d "$dir" ] || { [ -L "$dir" ] && [ ! -e "$dir" ]; }; then
+      continue
+    fi
+    if [ ! -r "$dir" ] || [ ! -x "$dir" ]; then
+      available=false
+      continue
+    fi
+    task=$(basename "$dir" .inbox)
+    latest=
+    for rec in "$dir"/*.msg "$dir/handled"/*.msg; do
+      [ -f "$rec" ] && [ ! -L "$rec" ] || continue
+      mtime=$(fm_path_mtime "$rec") || {
+        available=false
+        continue
+      }
+      case "$mtime" in
+        ''|*[!0-9]*)
+          available=false
+          continue
+          ;;
+      esac
+      if [ -z "$latest" ] || [ "$mtime" -gt "$latest" ]; then
+        latest=$mtime
+      fi
+    done
+    [ -n "$latest" ] || continue
+    row=$(jq -n --arg task "$task" --argjson latest "$latest" \
+      '{task_id:$task,last_epoch:$latest}') || return 1
+    records=$(jq -n --argjson records "$records" --argjson row "$row" \
+      '$records + [$row]') || return 1
+  done
+  jq -n --argjson available "$available" --argjson records "$records" \
+    '{available:$available,records:$records}'
+}

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -117,7 +117,10 @@ fm_task_inbox_record_valid() {  # <record-path>
   {
     IFS= read -r line && [ "$line" = "schema=$FM_TASK_INBOX_SCHEMA" ] || return 1
     IFS= read -r line || return 1
-    case "$line" in at=????-??-??T??:??:??Z) ;; *) return 1 ;; esac
+    case "$line" in
+      at=[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z) ;;
+      *) return 1 ;;
+    esac
     IFS= read -r line && [ "$line" = -- ] || return 1
   } < "$rec"
   FM_TASK_INBOX_RECORD_FAILURE=
@@ -422,20 +425,32 @@ fm_task_inbox_record_escalated() {  # <state-dir> <task-id> <record-path>
 # Read-only list of unhandled steering-inbox records with age.
 # Does not ring, escalate, or rewrite ladder bookkeeping.
 fm_task_inbox_unhandled_json() {  # <state-dir>
-  local state=$1 dir task rec seq age mtime now available=true
+  local state=$1 dir task rec seq age mtime now available=true classification
   local invalid_count=0 unreadable_count=0 records='[]' row
-  if [ ! -d "$state" ]; then
-    jq -n '{available:true,invalid_count:0,unreadable_count:0,records:[]}'
+  if [ ! -d "$state" ] && [ ! -L "$state" ]; then
+    classification=$(fm_evidence_classify true true)
+    jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,invalid_count:0,unreadable_count:0,records:[]}'
+    return 0
+  fi
+  if [ -L "$state" ] && [ ! -e "$state" ]; then
+    classification=$(fm_evidence_classify false false)
+    jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
   if [ ! -r "$state" ] || [ ! -x "$state" ]; then
-    jq -n '{available:false,invalid_count:0,unreadable_count:0,records:[]}'
+    classification=$(fm_evidence_classify false false)
+    jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
   now=$(date +%s)
   case "$now" in
     ''|*[!0-9]*)
-      jq -n '{available:false,invalid_count:0,unreadable_count:0,records:[]}'
+      classification=$(fm_evidence_classify false false)
+      jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+        '{available:$available,invalid_count:0,unreadable_count:0,records:[]}'
       return 0
       ;;
   esac
@@ -443,7 +458,9 @@ fm_task_inbox_unhandled_json() {  # <state-dir>
     [ -e "$dir" ] || [ -L "$dir" ] || continue
     if [ ! -d "$dir" ] || { [ -L "$dir" ] && [ ! -e "$dir" ]; }; then
       invalid_count=$((invalid_count + 1))
+      available=false
     elif [ ! -r "$dir" ] || [ ! -x "$dir" ]; then
+      classification=$(fm_evidence_classify false false)
       available=false
     fi
   done
@@ -452,26 +469,36 @@ fm_task_inbox_unhandled_json() {  # <state-dir>
     task=$(basename "$dir" .inbox)
     for rec in "$dir"/*.msg; do
       [ -e "$rec" ] || [ -L "$rec" ] || continue
-      if ! fm_task_inbox_record_valid "$rec"; then
+      if fm_task_inbox_record_valid "$rec"; then
+        classification=$(fm_evidence_classify true true)
+      else
+        classification=$(fm_evidence_classify true false)
         [ -e "$rec" ] || [ -L "$rec" ] || continue
         case "$FM_TASK_INBOX_RECORD_FAILURE" in
           unreadable) unreadable_count=$((unreadable_count + 1)) ;;
           *) invalid_count=$((invalid_count + 1)) ;;
         esac
+        available=false
         continue
       fi
       seq=$(fm_task_inbox_seq_of "${rec##*/}") || {
+        classification=$(fm_evidence_classify true false)
         invalid_count=$((invalid_count + 1))
+        available=false
         continue
       }
       mtime=$(fm_path_mtime "$rec") || {
         [ -e "$rec" ] || [ -L "$rec" ] || continue
+        classification=$(fm_evidence_classify false false)
         unreadable_count=$((unreadable_count + 1))
+        available=false
         continue
       }
       case "$mtime" in
         ''|*[!0-9]*)
+          classification=$(fm_evidence_classify false false)
           unreadable_count=$((unreadable_count + 1))
+          available=false
           continue
           ;;
       esac
@@ -487,8 +514,9 @@ fm_task_inbox_unhandled_json() {  # <state-dir>
         '$records + [$row]') || return 1
     done
   done
+  classification=$(fm_evidence_classify "$available" true)
   jq -n \
-    --argjson available "$available" \
+    --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
     --argjson invalid "$invalid_count" \
     --argjson unreadable "$unreadable_count" \
     --argjson records "$records" \
@@ -498,32 +526,47 @@ fm_task_inbox_unhandled_json() {  # <state-dir>
 # Read-only latest steering-inbox activity per task, including handled records.
 # Does not ring, escalate, or rewrite ladder bookkeeping.
 fm_task_inbox_latest_activity_json() {  # <state-dir>
-  local state=$1 dir handled task rec mtime latest available=true
+  local state=$1 dir handled task rec mtime latest available=true classification
   local invalid_count=0 unreadable_count=0 records='[]' row
-  if [ ! -d "$state" ]; then
-    jq -n '{available:true,invalid_count:0,unreadable_count:0,records:[]}'
+  if [ ! -d "$state" ] && [ ! -L "$state" ]; then
+    classification=$(fm_evidence_classify true true)
+    jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,invalid_count:0,unreadable_count:0,records:[]}'
+    return 0
+  fi
+  if [ -L "$state" ] && [ ! -e "$state" ]; then
+    classification=$(fm_evidence_classify false false)
+    jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
   if [ ! -r "$state" ] || [ ! -x "$state" ]; then
-    jq -n '{available:false,invalid_count:0,unreadable_count:0,records:[]}'
+    classification=$(fm_evidence_classify false false)
+    jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" \
+      '{available:$available,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
   for dir in "$state"/*.inbox; do
     [ -e "$dir" ] || [ -L "$dir" ] || continue
     if [ ! -d "$dir" ] || { [ -L "$dir" ] && [ ! -e "$dir" ]; }; then
       invalid_count=$((invalid_count + 1))
+      available=false
       continue
     fi
     if [ ! -r "$dir" ] || [ ! -x "$dir" ]; then
+      classification=$(fm_evidence_classify false false)
       available=false
       continue
     fi
     handled="$dir/handled"
     if [ ! -d "$handled" ] || { [ -L "$handled" ] && [ ! -e "$handled" ]; }; then
+      classification=$(fm_evidence_classify false false)
       invalid_count=$((invalid_count + 1))
+      available=false
       continue
     fi
     if [ ! -r "$handled" ] || [ ! -x "$handled" ]; then
+      classification=$(fm_evidence_classify false false)
       available=false
       continue
     fi
@@ -531,22 +574,28 @@ fm_task_inbox_latest_activity_json() {  # <state-dir>
     latest=
     for rec in "$dir"/*.msg "$handled"/*.msg; do
       [ -e "$rec" ] || [ -L "$rec" ] || continue
-      if ! fm_task_inbox_record_valid "$rec"; then
+      if fm_task_inbox_record_valid "$rec"; then
+        classification=$(fm_evidence_classify true true)
+      else
+        classification=$(fm_evidence_classify true false)
         [ -e "$rec" ] || [ -L "$rec" ] || continue
         case "$FM_TASK_INBOX_RECORD_FAILURE" in
           unreadable) unreadable_count=$((unreadable_count + 1)) ;;
           *) invalid_count=$((invalid_count + 1)) ;;
         esac
+        available=false
         continue
       fi
       mtime=$(fm_path_mtime "$rec") || {
         [ -e "$rec" ] || [ -L "$rec" ] || continue
+        classification=$(fm_evidence_classify false false)
         unreadable_count=$((unreadable_count + 1))
         available=false
         continue
       }
       case "$mtime" in
         ''|*[!0-9]*)
+          classification=$(fm_evidence_classify false false)
           unreadable_count=$((unreadable_count + 1))
           available=false
           continue
@@ -562,7 +611,8 @@ fm_task_inbox_latest_activity_json() {  # <state-dir>
     records=$(jq -n --argjson records "$records" --argjson row "$row" \
       '$records + [$row]') || return 1
   done
-  jq -n --argjson available "$available" --argjson invalid "$invalid_count" \
+  classification=$(fm_evidence_classify "$available" true)
+  jq -n --argjson available "$( [ "$classification" = available ] && printf true || printf false )" --argjson invalid "$invalid_count" \
     --argjson unreadable "$unreadable_count" --argjson records "$records" \
     '{available:$available,invalid_count:$invalid,unreadable_count:$unreadable,records:$records}'
 }

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -105,6 +105,24 @@ fm_task_inbox_seq_of() {  # <basename>
   printf '%s' "$((10#$n))"
 }
 
+fm_task_inbox_record_valid() {  # <record-path>
+  local rec=$1 line
+  FM_TASK_INBOX_RECORD_FAILURE=invalid
+  fm_task_inbox_seq_of "${rec##*/}" >/dev/null || return 1
+  [ -f "$rec" ] && [ ! -L "$rec" ] || return 1
+  if [ ! -r "$rec" ]; then
+    FM_TASK_INBOX_RECORD_FAILURE=unreadable
+    return 1
+  fi
+  {
+    IFS= read -r line && [ "$line" = "schema=$FM_TASK_INBOX_SCHEMA" ] || return 1
+    IFS= read -r line || return 1
+    case "$line" in at=????-??-??T??:??:??Z) ;; *) return 1 ;; esac
+    IFS= read -r line && [ "$line" = -- ] || return 1
+  } < "$rec"
+  FM_TASK_INBOX_RECORD_FAILURE=
+}
+
 # Next unused sequence, scanning the inbox root AND handled/ so an
 # acknowledged sequence is never reissued. Caller must hold .seq.lock.
 fm_task_inbox_next_seq() {  # <inbox-dir>
@@ -404,35 +422,71 @@ fm_task_inbox_record_escalated() {  # <state-dir> <task-id> <record-path>
 # Read-only list of unhandled steering-inbox records with age.
 # Does not ring, escalate, or rewrite ladder bookkeeping.
 fm_task_inbox_unhandled_json() {  # <state-dir>
-  local state=$1 dir task rec seq age available=true
+  local state=$1 dir task rec seq age mtime now available=true
+  local invalid_count=0 unreadable_count=0 records='[]' row
   if [ ! -d "$state" ]; then
-    jq -n '{available:true,records:[]}'
+    jq -n '{available:true,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
   if [ ! -r "$state" ] || [ ! -x "$state" ]; then
-    jq -n '{available:false,records:[]}'
+    jq -n '{available:false,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
+  now=$(date +%s)
+  case "$now" in
+    ''|*[!0-9]*)
+      jq -n '{available:false,invalid_count:0,unreadable_count:0,records:[]}'
+      return 0
+      ;;
+  esac
   for dir in "$state"/*.inbox; do
     [ -d "$dir" ] || continue
     [ -r "$dir" ] && [ -x "$dir" ] || available=false
   done
-  {
-    for dir in "$state"/*.inbox; do
-      [ -d "$dir" ] && [ -r "$dir" ] && [ -x "$dir" ] || continue
-      task=$(basename "$dir" .inbox)
-      for rec in "$dir"/*.msg; do
-        [ -f "$rec" ] || continue
-        seq=$(fm_task_inbox_seq_of "${rec##*/}") || continue
-        age=$(fm_path_age "$rec")
-        case "$age" in ''|*[!0-9]*) age=null ;; esac
-        jq -n \
-          --arg task "$task" \
-          --arg rec "$rec" \
-          --arg seq "$seq" \
-          --argjson age "$age" \
-          '{task_id:$task,path:$rec,seq:($seq | tonumber),age_seconds:$age}'
-      done
+  for dir in "$state"/*.inbox; do
+    [ -d "$dir" ] && [ -r "$dir" ] && [ -x "$dir" ] || continue
+    task=$(basename "$dir" .inbox)
+    for rec in "$dir"/*.msg; do
+      [ -e "$rec" ] || [ -L "$rec" ] || continue
+      if ! fm_task_inbox_record_valid "$rec"; then
+        [ -e "$rec" ] || [ -L "$rec" ] || continue
+        case "$FM_TASK_INBOX_RECORD_FAILURE" in
+          unreadable) unreadable_count=$((unreadable_count + 1)) ;;
+          *) invalid_count=$((invalid_count + 1)) ;;
+        esac
+        continue
+      fi
+      seq=$(fm_task_inbox_seq_of "${rec##*/}") || {
+        invalid_count=$((invalid_count + 1))
+        continue
+      }
+      mtime=$(fm_path_mtime "$rec") || {
+        [ -e "$rec" ] || [ -L "$rec" ] || continue
+        unreadable_count=$((unreadable_count + 1))
+        continue
+      }
+      case "$mtime" in
+        ''|*[!0-9]*)
+          unreadable_count=$((unreadable_count + 1))
+          continue
+          ;;
+      esac
+      age=$((now - mtime))
+      [ "$age" -ge 0 ] || age=0
+      row=$(jq -n \
+        --arg task "$task" \
+        --arg rec "$rec" \
+        --arg seq "$seq" \
+        --argjson age "$age" \
+        '{task_id:$task,path:$rec,seq:($seq | tonumber),age_seconds:$age}') || return 1
+      records=$(jq -n --argjson records "$records" --argjson row "$row" \
+        '$records + [$row]') || return 1
     done
-  } | jq -s --argjson available "$available" '{available:$available,records:.}'
+  done
+  jq -n \
+    --argjson available "$available" \
+    --argjson invalid "$invalid_count" \
+    --argjson unreadable "$unreadable_count" \
+    --argjson records "$records" \
+    '{available:$available,invalid_count:$invalid,unreadable_count:$unreadable,records:$records}'
 }

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -498,35 +498,56 @@ fm_task_inbox_unhandled_json() {  # <state-dir>
 # Read-only latest steering-inbox activity per task, including handled records.
 # Does not ring, escalate, or rewrite ladder bookkeeping.
 fm_task_inbox_latest_activity_json() {  # <state-dir>
-  local state=$1 dir task rec mtime latest available=true
-  local records='[]' row
+  local state=$1 dir handled task rec mtime latest available=true
+  local invalid_count=0 unreadable_count=0 records='[]' row
   if [ ! -d "$state" ]; then
-    jq -n '{available:true,records:[]}'
+    jq -n '{available:true,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
   if [ ! -r "$state" ] || [ ! -x "$state" ]; then
-    jq -n '{available:false,records:[]}'
+    jq -n '{available:false,invalid_count:0,unreadable_count:0,records:[]}'
     return 0
   fi
   for dir in "$state"/*.inbox; do
     [ -e "$dir" ] || [ -L "$dir" ] || continue
     if [ ! -d "$dir" ] || { [ -L "$dir" ] && [ ! -e "$dir" ]; }; then
+      invalid_count=$((invalid_count + 1))
       continue
     fi
     if [ ! -r "$dir" ] || [ ! -x "$dir" ]; then
       available=false
       continue
     fi
+    handled="$dir/handled"
+    if [ ! -d "$handled" ] || { [ -L "$handled" ] && [ ! -e "$handled" ]; }; then
+      invalid_count=$((invalid_count + 1))
+      continue
+    fi
+    if [ ! -r "$handled" ] || [ ! -x "$handled" ]; then
+      available=false
+      continue
+    fi
     task=$(basename "$dir" .inbox)
     latest=
-    for rec in "$dir"/*.msg "$dir/handled"/*.msg; do
-      [ -f "$rec" ] && [ ! -L "$rec" ] || continue
+    for rec in "$dir"/*.msg "$handled"/*.msg; do
+      [ -e "$rec" ] || [ -L "$rec" ] || continue
+      if ! fm_task_inbox_record_valid "$rec"; then
+        [ -e "$rec" ] || [ -L "$rec" ] || continue
+        case "$FM_TASK_INBOX_RECORD_FAILURE" in
+          unreadable) unreadable_count=$((unreadable_count + 1)) ;;
+          *) invalid_count=$((invalid_count + 1)) ;;
+        esac
+        continue
+      fi
       mtime=$(fm_path_mtime "$rec") || {
+        [ -e "$rec" ] || [ -L "$rec" ] || continue
+        unreadable_count=$((unreadable_count + 1))
         available=false
         continue
       }
       case "$mtime" in
         ''|*[!0-9]*)
+          unreadable_count=$((unreadable_count + 1))
           available=false
           continue
           ;;
@@ -541,6 +562,7 @@ fm_task_inbox_latest_activity_json() {  # <state-dir>
     records=$(jq -n --argjson records "$records" --argjson row "$row" \
       '$records + [$row]') || return 1
   done
-  jq -n --argjson available "$available" --argjson records "$records" \
-    '{available:$available,records:$records}'
+  jq -n --argjson available "$available" --argjson invalid "$invalid_count" \
+    --argjson unreadable "$unreadable_count" --argjson records "$records" \
+    '{available:$available,invalid_count:$invalid,unreadable_count:$unreadable,records:$records}'
 }

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -400,3 +400,39 @@ fm_task_inbox_record_escalated() {  # <state-dir> <task-id> <record-path>
     return 1
   fi
 }
+
+# Read-only list of unhandled steering-inbox records with age.
+# Does not ring, escalate, or rewrite ladder bookkeeping.
+fm_task_inbox_unhandled_json() {  # <state-dir>
+  local state=$1 dir task rec seq age available=true
+  if [ ! -d "$state" ]; then
+    jq -n '{available:true,records:[]}'
+    return 0
+  fi
+  if [ ! -r "$state" ]; then
+    jq -n '{available:false,records:[]}'
+    return 0
+  fi
+  for dir in "$state"/*.inbox; do
+    [ -d "$dir" ] || continue
+    [ -r "$dir" ] || available=false
+  done
+  {
+    for dir in "$state"/*.inbox; do
+      [ -d "$dir" ] && [ -r "$dir" ] || continue
+      task=$(basename "$dir" .inbox)
+      for rec in "$dir"/*.msg; do
+        [ -f "$rec" ] || continue
+        seq=$(fm_task_inbox_seq_of "${rec##*/}") || continue
+        age=$(fm_path_age "$rec")
+        case "$age" in ''|*[!0-9]*) age=null ;; esac
+        jq -n \
+          --arg task "$task" \
+          --arg rec "$rec" \
+          --arg seq "$seq" \
+          --argjson age "$age" \
+          '{task_id:$task,path:$rec,seq:($seq | tonumber),age_seconds:$age}'
+      done
+    done
+  } | jq -s --argjson available "$available" '{available:$available,records:.}'
+}

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -220,7 +220,7 @@ family_for_basename() {
       printf '%s\n' afk
       ;;
     fm-bearings-board-render.test.sh|fm-bearings-snapshot.test.sh|\
-    fm-fleet-snapshot-view.test.sh)
+    fm-fleet-snapshot-view.test.sh|fm-fleet-health.test.sh)
       printf '%s\n' snapshot-bearings
       ;;
     fm-backend-cmux.test.sh|fm-backend-cmux-smoke.test.sh)
@@ -420,6 +420,7 @@ tests/fm-cursor-primary.test.sh 52324
 tests/fm-daemon.test.sh 25834
 tests/fm-documentation-audiences.test.sh 642
 tests/fm-fleet-snapshot-view.test.sh 6995
+tests/fm-fleet-health.test.sh 8000
 tests/fm-fleet-sync.test.sh 20194
 tests/fm-gate-refuse.test.sh 4071
 tests/fm-gitignore-config.test.sh 63
@@ -1017,7 +1018,7 @@ families_for_changed_path() {
       printf '%s\n' watcher-wake-lock
       printf '%s\n' live-harness-optin
       ;;
-    bin/fm-bearings-snapshot.sh|bin/fm-fleet-snapshot.sh|bin/fm-fleet-view.sh)
+    bin/fm-bearings-snapshot.sh|bin/fm-fleet-snapshot.sh|bin/fm-fleet-view.sh|bin/fm-fleet-health.sh)
       printf '%s\n' snapshot-bearings
       ;;
     bin/fm-install-herdr.sh|bin/fm-install-treehouse.sh|bin/fm-herdr-ci-cleanup.sh)

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -60,6 +60,8 @@ ELIGIBLE_ROWS_FILE="$STATE/.branch-eligible-rows"
 ELIGIBLE_OWNER_FILE="$STATE/.branch-eligible-owner"
 MAIN_ROWS_FILE="$STATE/.main-eligible-rows"
 
+mkdir -p "$STATE" || exit 1
+
 rows_file_valid() {
   [ -s "$1" ] && awk 'BEGIN { ok=1 } !/^[0-9]+$/ || seen[$0]++ { ok=0 } END { exit !ok }' "$1"
 }

--- a/bin/fm-wake-grant.sh
+++ b/bin/fm-wake-grant.sh
@@ -22,6 +22,12 @@ trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
+ensure_state_dir() {
+  [ ! -L "$STATE" ] || return 1
+  mkdir -p "$STATE" || return 1
+  [ -d "$STATE" ]
+}
+
 rows_valid() {
   [ -s "$1" ] && awk 'BEGIN { ok=1 } !/^[0-9]+$/ || seen[$0]++ { ok=0 } END { exit !ok }' "$1"
 }
@@ -52,6 +58,7 @@ case "${1:-}" in
     [ "$#" -eq 3 ] || exit 2
     case "$pid" in ''|*[!0-9]*|1) exit 2 ;; esac
     case "$generation" in ''|*[!A-Za-z0-9._-]*) exit 2 ;; esac
+    ensure_state_dir || exit 1
     identity=$(fm_pid_identity "$pid" 2>/dev/null) || exit 1
     [ -n "$identity" ] || exit 1
     TMP=$(mktemp "$STATE/.branch-eligible-owner.tmp.XXXXXX") || exit 1
@@ -68,6 +75,7 @@ case "${1:-}" in
     generation=${2:-}
     [ "$#" -gt 2 ] || exit 2
     case "$generation" in ''|*[!A-Za-z0-9._-]*) exit 2 ;; esac
+    ensure_state_dir || exit 1
     shift 2
     TMP=$(mktemp "$STATE/.branch-eligible-rows.tmp.XXXXXX") || exit 1
     printf '%s\n' "$@" > "$TMP" || exit 1
@@ -102,6 +110,7 @@ case "${1:-}" in
   release)
     generation=${2:-}
     [ "$#" -eq 2 ] || exit 2
+    ensure_state_dir || exit 1
     fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
     LOCK_HELD=true
     owner_matches '' "$generation" || exit 1
@@ -111,6 +120,7 @@ case "${1:-}" in
     pid=${2:-}
     generation=${3:-}
     [ "$#" -eq 3 ] || exit 2
+    ensure_state_dir || exit 1
     fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
     LOCK_HELD=true
     owner_matches "$pid" "$generation" || exit 1

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -127,6 +127,26 @@ fm_watcher_healthy() {
   return 0
 }
 
+fm_watcher_lock_evidence_unreadable() {  # <state> <watch-path> [home]
+  local state=$1 watch_path=$2 home=${3:-$FM_HOME} lockdir file pid
+  lockdir="$state/.watch.lock"
+  [ -e "$lockdir" ] || [ -L "$lockdir" ] || return 1
+  [ -d "$lockdir" ] && [ -r "$lockdir" ] && [ -x "$lockdir" ] || return 0
+  [ -e "$lockdir/pid" ] || [ -L "$lockdir/pid" ] || return 1
+  [ -f "$lockdir/pid" ] && [ ! -L "$lockdir/pid" ] && [ -r "$lockdir/pid" ] || return 0
+  pid=$(cat "$lockdir/pid" 2>/dev/null) || return 0
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  fm_pid_alive "$pid" || return 1
+  for file in fm-home watcher-path pid-identity; do
+    if [ -e "$lockdir/$file" ] || [ -L "$lockdir/$file" ]; then
+      [ -f "$lockdir/$file" ] && [ ! -L "$lockdir/$file" ] && [ -r "$lockdir/$file" ] || return 0
+    fi
+  done
+  fm_watcher_lock_matches_pid "$state" "$watch_path" "$pid" "$home" && return 1
+  fm_pid_identity "$pid" >/dev/null 2>&1 || { fm_pid_alive "$pid" && return 0; }
+  return 1
+}
+
 # fm_watcher_healthy above is the PID-STRICT primitive: true only when a live,
 # identity-matched watcher PROCESS holds this home's lock with a fresh beacon. The
 # arm layer (bin/fm-watch-arm.sh, bin/fm-claude-stop-autoarm.sh) needs exactly
@@ -250,12 +270,15 @@ fm_pi_extension_owns_supervision() {
 # shellcheck disable=SC2034 # Read by callers after the function returns.
 FM_WATCHER_VERDICT_OK=false
 # shellcheck disable=SC2034 # Read by callers after the function returns.
+FM_WATCHER_VERDICT_AVAILABLE=true
+# shellcheck disable=SC2034 # Read by callers after the function returns.
 FM_WATCHER_VERDICT_REASON=stale-beacon
 fm_watcher_supervision_verdict() {
   local state=$1 watch=$2 grace=${3:-${FM_GUARD_GRACE:-300}} home=${4:-$FM_HOME}
   local root=${5:-$FM_ROOT}
   local beat age fresh=false model
   FM_WATCHER_VERDICT_OK=false
+  FM_WATCHER_VERDICT_AVAILABLE=true
   FM_WATCHER_VERDICT_REASON=stale-beacon
   beat="$state/.last-watcher-beat"
   age=$(fm_path_age "$beat")
@@ -272,7 +295,10 @@ fm_watcher_supervision_verdict() {
     # shellcheck disable=SC2034 # Read by callers after the function returns.
     FM_WATCHER_VERDICT_OK=true
   elif [ "$fresh" = true ]; then
-    if [ "$model" = extension ] && fm_watcher_lock_unheld "$state" \
+    if fm_watcher_lock_evidence_unreadable "$state" "$watch" "$home"; then
+      FM_WATCHER_VERDICT_AVAILABLE=false
+      FM_WATCHER_VERDICT_REASON=no-watcher
+    elif [ "$model" = extension ] && fm_watcher_lock_unheld "$state" \
       && fm_pi_extension_owns_supervision "$state" "$root"; then
       # shellcheck disable=SC2034 # Read by callers after the function returns.
       FM_WATCHER_VERDICT_OK=true

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -296,6 +296,7 @@ fm_watcher_supervision_verdict() {
     FM_WATCHER_VERDICT_OK=true
   elif [ "$fresh" = true ]; then
     if fm_watcher_lock_evidence_unreadable "$state" "$watch" "$home"; then
+      # shellcheck disable=SC2034 # Read by callers after the function returns.
       FM_WATCHER_VERDICT_AVAILABLE=false
       FM_WATCHER_VERDICT_REASON=no-watcher
     elif [ "$model" = extension ] && fm_watcher_lock_unheld "$state" \

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -314,12 +314,30 @@ FM_WATCHER_VERDICT_REASON=stale-beacon
 fm_watcher_supervision_verdict() {
   local state=$1 watch=$2 grace=${3:-${FM_GUARD_GRACE:-300}} home=${4:-$FM_HOME}
   local root=${5:-$FM_ROOT}
-  local beat age fresh=false model
+  local beat age fresh=false model beacon_exists=false beacon_readable=false beacon_valid=false beacon_mtime classification
   FM_WATCHER_VERDICT_OK=false
   FM_WATCHER_VERDICT_AVAILABLE=true
   FM_WATCHER_VERDICT_REASON=stale-beacon
   beat="$state/.last-watcher-beat"
-  age=$(fm_path_age "$beat")
+  if [ -e "$beat" ] || [ -L "$beat" ]; then
+    beacon_exists=true
+  fi
+  if [ -f "$beat" ] && [ ! -L "$beat" ] && [ -r "$beat" ]; then
+    beacon_readable=true
+    beacon_mtime=$(fm_path_mtime "$beat") || beacon_readable=false
+  fi
+  [ "$beacon_readable" = true ] && beacon_valid=true
+  classification=$(fm_evidence_classify "$beacon_readable" "$beacon_valid")
+  if [ "$beacon_exists" = true ] && [ "$classification" != available ]; then
+    FM_WATCHER_VERDICT_AVAILABLE=false
+    FM_WATCHER_VERDICT_REASON=unreadable-beacon
+    return 0
+  fi
+  if [ "$classification" = available ]; then
+    age=$(( $(date +%s) - beacon_mtime ))
+  else
+    age=999999
+  fi
   case "$age" in
     ''|*[!0-9]*) ;;
     *) [ "$age" -lt "$grace" ] && fresh=true ;;

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -9,6 +9,10 @@ STATE="${FM_STATE_OVERRIDE:-${STATE:-$FM_HOME/state}}"
 FM_WAKE_QUEUE="${FM_WAKE_QUEUE:-$STATE/.wake-queue}"
 FM_WAKE_QUEUE_LOCK="${FM_WAKE_QUEUE_LOCK:-$STATE/.wake-queue.lock}"
 FM_LOCK_STALE_AFTER="${FM_LOCK_STALE_AFTER:-2}"
+_FM_WAKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)" || _FM_WAKE_LIB_DIR="."
+# shellcheck source=bin/fm-classify-lib.sh
+# shellcheck disable=SC1091
+. "$_FM_WAKE_LIB_DIR/fm-classify-lib.sh"
 # Resolved once at source time: fm_pid_identity and fm_path_mtime run inside 0.2s
 # confirm and 0.5s attach polls, and forking uname per call is a measurable cost on
 # the platform (Git Bash/MSYS) that already pays the highest fork price.
@@ -128,22 +132,56 @@ fm_watcher_healthy() {
 }
 
 fm_watcher_lock_evidence_unreadable() {  # <state> <watch-path> [home]
-  local state=$1 watch_path=$2 home=${3:-$FM_HOME} lockdir file pid
+  local state=$1 watch_path=$2 home=${3:-$FM_HOME} lockdir file pid value classification
   lockdir="$state/.watch.lock"
   [ -e "$lockdir" ] || [ -L "$lockdir" ] || return 1
-  [ -d "$lockdir" ] && [ -r "$lockdir" ] && [ -x "$lockdir" ] || return 0
+  if ! [ -d "$lockdir" ] || ! [ -r "$lockdir" ] || ! [ -x "$lockdir" ]; then
+    classification=$(fm_evidence_classify false false)
+    [ "$classification" = inconclusive ] && return 0
+  fi
   [ -e "$lockdir/pid" ] || [ -L "$lockdir/pid" ] || return 1
-  [ -f "$lockdir/pid" ] && [ ! -L "$lockdir/pid" ] && [ -r "$lockdir/pid" ] || return 0
-  pid=$(cat "$lockdir/pid" 2>/dev/null) || return 0
-  case "$pid" in ''|*[!0-9]*) return 0 ;; esac
+  if ! [ -f "$lockdir/pid" ] || [ -L "$lockdir/pid" ] || ! [ -r "$lockdir/pid" ]; then
+    classification=$(fm_evidence_classify false false)
+    [ "$classification" = inconclusive ] && return 0
+  fi
+  if ! pid=$(cat "$lockdir/pid" 2>/dev/null); then
+    classification=$(fm_evidence_classify false false)
+    [ "$classification" = inconclusive ] && return 0
+  fi
+  case "$pid" in
+    ''|*[!0-9]*)
+      classification=$(fm_evidence_classify false false)
+      [ "$classification" = inconclusive ] && return 0
+      ;;
+  esac
   fm_pid_alive "$pid" || return 1
   for file in fm-home watcher-path pid-identity; do
-    if [ -e "$lockdir/$file" ] || [ -L "$lockdir/$file" ]; then
-      [ -f "$lockdir/$file" ] && [ ! -L "$lockdir/$file" ] && [ -r "$lockdir/$file" ] || return 0
+    if [ ! -e "$lockdir/$file" ] && [ ! -L "$lockdir/$file" ]; then
+      classification=$(fm_evidence_classify false false)
+      [ "$classification" = inconclusive ] && return 0
     fi
+    if ! [ -f "$lockdir/$file" ] || [ -L "$lockdir/$file" ] || ! [ -r "$lockdir/$file" ]; then
+      classification=$(fm_evidence_classify false false)
+      [ "$classification" = inconclusive ] && return 0
+    fi
+    if ! value=$(cat "$lockdir/$file" 2>/dev/null); then
+      classification=$(fm_evidence_classify false false)
+      [ "$classification" = inconclusive ] && return 0
+    fi
+    case "$value" in
+      ''|*$'\n'*)
+        classification=$(fm_evidence_classify false false)
+        [ "$classification" = inconclusive ] && return 0
+        ;;
+    esac
   done
+  classification=$(fm_evidence_classify true true)
+  [ "$classification" = available ] || return 0
   fm_watcher_lock_matches_pid "$state" "$watch_path" "$pid" "$home" && return 1
-  fm_pid_identity "$pid" >/dev/null 2>&1 || { fm_pid_alive "$pid" && return 0; }
+  if ! fm_pid_identity "$pid" >/dev/null 2>&1; then
+    classification=$(fm_evidence_classify false false)
+    [ "$classification" = inconclusive ] && { fm_pid_alive "$pid" && return 0; }
+  fi
   return 1
 }
 

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -135,7 +135,7 @@ fm_watcher_lock_evidence_unreadable() {  # <state> <watch-path> [home]
   [ -e "$lockdir/pid" ] || [ -L "$lockdir/pid" ] || return 1
   [ -f "$lockdir/pid" ] && [ ! -L "$lockdir/pid" ] && [ -r "$lockdir/pid" ] || return 0
   pid=$(cat "$lockdir/pid" 2>/dev/null) || return 0
-  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  case "$pid" in ''|*[!0-9]*) return 0 ;; esac
   fm_pid_alive "$pid" || return 1
   for file in fm-home watcher-path pid-identity; do
     if [ -e "$lockdir/$file" ] || [ -L "$lockdir/$file" ]; then

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -13,7 +13,6 @@ FM_LOCK_STALE_AFTER="${FM_LOCK_STALE_AFTER:-2}"
 # confirm and 0.5s attach polls, and forking uname per call is a measurable cost on
 # the platform (Git Bash/MSYS) that already pays the highest fork price.
 _FM_UNAME=$(uname 2>/dev/null || echo unknown)
-mkdir -p "$STATE"
 
 fm_current_pid() {
   printf '%s\n' "${BASHPID:-$$}"
@@ -1367,6 +1366,7 @@ fm_wake_append() {
   clean_key=$(printf '%s' "$key" | fm_wake_clean_field)
   clean_payload=$(printf '%s' "$payload" | fm_wake_clean_field)
   epoch=$(date +%s)
+  mkdir -p "$STATE" || return 1
   seq_file="$STATE/.wake-queue.seq"
   recovery_marker="$STATE/.watcher-down"
   status=0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,8 @@ In that status-log fallback, a declared external wait reports the distinct `paus
 The semantic branch reports working only on an exact busy verdict and names the source that produced it; an unknown verdict never becomes working, never permits the status-log fallback, and never becomes a silent idle.
 For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, bounded current summaries from registered secondmate homes, and secondmate return-channel guidance.
 `bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so both views consume one structured contract instead of reparsing raw fleet files.
-The script header owns the exact JSON schema.
+`bin/fm-fleet-health.sh` projects the same snapshot, plus existing owner helpers for facts the snapshot does not carry, into a read-only operational health report; the script header owns findings, fingerprints, and exit status.
+The snapshot script header owns the exact JSON schema.
 
 On a Pi primary, supervision is default-on: the watcher extension can hand eligible task-local rows from an ordinary actionable wake, plus selected fleet-wide heartbeat reviews, to a persistent in-process supervision conversation while main-only rows remain on the captain-facing path.
 The branch handles those rows, stores the outcome durably, and merges an append-only note back.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -16,6 +16,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
+| `fm-fleet-health.sh`     | Read-only operational health report over the fleet snapshot (human or `--json`)      |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-bearings-board.sh`   | Build and arm the stable interactive `/bearings lavish` fleet board                  |
 | `fm-secondmate-reconcile.sh` | Ask each secondmate to reconcile an inventory mismatch through its durable inbox, limited by a per-home cooldown |

--- a/tests/fm-branch-supervision.test.sh
+++ b/tests/fm-branch-supervision.test.sh
@@ -169,6 +169,36 @@ test_outcome_store_initializes_fresh_home_before_locking() {
   pass "branch outcome commands initialize fresh homes before locking"
 }
 
+test_outcome_store_rejects_symlinked_state_before_access() {
+  local home target command rc
+  home="$TMP_ROOT/symlink-state-home"
+  target="$TMP_ROOT/symlink-state-target"
+  mkdir -p "$home" "$target"
+  ln -s "$target" "$home/state"
+
+  for command in append unread mark-read startup-replay; do
+    rc=0
+    case "$command" in
+      append)
+        FM_HOME="$home" "$ROOT/bin/fm-branch-outcome.sh" append \
+          --task task-1 --verdict routine --summary ready >/dev/null 2>&1 || rc=$?
+        ;;
+      mark-read)
+        FM_HOME="$home" "$ROOT/bin/fm-branch-outcome.sh" mark-read --through 1 \
+          >/dev/null 2>&1 || rc=$?
+        ;;
+      *)
+        FM_HOME="$home" "$ROOT/bin/fm-branch-outcome.sh" "$command" \
+          >/dev/null 2>&1 || rc=$?
+        ;;
+    esac
+    [ "$rc" -ne 0 ] || fail "$command accepted a symlinked state directory"
+  done
+  [ -z "$(find "$target" -mindepth 1 -print -quit)" ] \
+    || fail "a rejected branch outcome command wrote through the state symlink"
+  pass "branch outcome commands fail closed on symlinked state"
+}
+
 # --- lease contract -----------------------------------------------------------
 
 test_lease_exclusivity_release_stale_and_sweep() {
@@ -565,6 +595,7 @@ test_branch_prompt_is_byte_stable_and_above_cache_floor
 test_outcome_store_is_append_only_with_cursor_reads
 test_outcome_startup_replay_preserves_silence
 test_outcome_store_initializes_fresh_home_before_locking
+test_outcome_store_rejects_symlinked_state_before_access
 test_lease_exclusivity_release_stale_and_sweep
 test_mutating_scripts_refuse_the_other_actors_lease
 test_main_owned_actions_refuse_the_branch_actor

--- a/tests/fm-branch-supervision.test.sh
+++ b/tests/fm-branch-supervision.test.sh
@@ -10,6 +10,8 @@ set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=bin/fm-timeout-lib.sh
+. "$ROOT/bin/fm-timeout-lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-branch-supervision)
 
@@ -138,6 +140,33 @@ test_outcome_startup_replay_preserves_silence() {
   [ -z "$(FM_HOME="$home" "$ROOT/bin/fm-branch-outcome.sh" unread)" ] \
     || fail "startup replay did not mark the legacy row read"
   pass "startup replay skips silent outcomes and preserves visible and legacy rows"
+}
+
+test_outcome_store_initializes_fresh_home_before_locking() {
+  local home out rc=0
+  home="$TMP_ROOT/fresh-unread"
+  mkdir -p "$home"
+  out=$(fm_run_timed 2 env FM_HOME="$home" "$ROOT/bin/fm-branch-outcome.sh" unread) || rc=$?
+  [ "$rc" -ne 124 ] || fail "unread hung while locking a fresh home"
+  [ "$rc" -eq 0 ] && [ -z "$out" ] || fail "fresh unread did not return an empty result"
+  [ -d "$home/state" ] || fail "unread did not initialize state before locking"
+
+  home="$TMP_ROOT/fresh-append"
+  mkdir -p "$home"
+  rc=0
+  out=$(fm_run_timed 2 env FM_HOME="$home" "$ROOT/bin/fm-branch-outcome.sh" append \
+    --task task-1 --verdict routine --summary ready) || rc=$?
+  [ "$rc" -ne 124 ] || fail "append hung while locking a fresh home"
+  [ "$rc" -eq 0 ] && [ "$out" = 1 ] || fail "fresh append did not create its first record"
+
+  home="$TMP_ROOT/fresh-replay"
+  mkdir -p "$home"
+  rc=0
+  out=$(fm_run_timed 2 env FM_HOME="$home" "$ROOT/bin/fm-branch-outcome.sh" startup-replay) || rc=$?
+  [ "$rc" -ne 124 ] || fail "startup replay hung while locking a fresh home"
+  [ "$rc" -eq 0 ] && [ -z "$out" ] || fail "fresh startup replay did not return an empty result"
+  [ -d "$home/state" ] || fail "startup replay did not initialize state before locking"
+  pass "branch outcome commands initialize fresh homes before locking"
 }
 
 # --- lease contract -----------------------------------------------------------
@@ -535,6 +564,7 @@ test_branch_cannot_force_teardown_or_directly_relaunch() {
 test_branch_prompt_is_byte_stable_and_above_cache_floor
 test_outcome_store_is_append_only_with_cursor_reads
 test_outcome_startup_replay_preserves_silence
+test_outcome_store_initializes_fresh_home_before_locking
 test_lease_exclusivity_release_stale_and_sweep
 test_mutating_scripts_refuse_the_other_actors_lease
 test_main_owned_actions_refuse_the_branch_actor

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -95,6 +95,25 @@ run_health() {  # <home> <fakebin>
   PATH="$2:$PATH" FM_HOME="$1" "$HEALTH" --json
 }
 
+make_health_fixture_root() {  # <name>
+  local name=$1 root=$TMP_ROOT/health-command-$1 source base
+  mkdir -p "$root/bin"
+  cp "$HEALTH" "$root/bin/fm-fleet-health.sh"
+  for source in "$ROOT"/bin/*.sh; do
+    base=${source##*/}
+    case "$base" in
+      fm-fleet-health.sh|fm-fleet-snapshot.sh) continue ;;
+    esac
+    ln -s "$source" "$root/bin/$base"
+  done
+  cat > "$root/bin/fm-fleet-snapshot.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${FM_TEST_SNAPSHOT:?}"
+SH
+  chmod +x "$root/bin/fm-fleet-health.sh" "$root/bin/fm-fleet-snapshot.sh"
+  printf '%s\n' "$root"
+}
+
 write_pending() {  # <home> <corr> <task> <phase> [completed_epoch] [grace] [sender-pid] [sender-identity]
   local home=$1 corr=$2 task=$3 phase=$4 completed=${5-} grace=${6:-120}
   local sender_pid=${7-} sender_identity=${8-}
@@ -187,6 +206,21 @@ test_missing_state_home_remains_unmodified() {
   printf '%s' "$out" | jq -e '.status == "healthy"' >/dev/null \
     || fail "missing-state home did not report healthy: $out"
   pass "health check does not create a missing state directory"
+}
+
+test_malformed_snapshot_is_incomplete() {
+  local home fixture out rc=0
+  home=$(make_home malformed-snapshot)
+  fixture=$(make_health_fixture_root malformed-snapshot)
+  out=$(FM_HOME="$home" FM_TEST_SNAPSHOT='{"schema":"fm-fleet-snapshot.v1"}' \
+    FM_FLEET_HEALTH_TIMED_WORKER=1 "$fixture/bin/fm-fleet-health.sh" --json) || rc=$?
+  expect_code 3 "$rc" "a schema-tagged incomplete snapshot should be incomplete"
+  printf '%s' "$out" | jq -e '
+    .status == "incomplete"
+      and .reason == "fleet snapshot was malformed"
+      and (.findings | length) == 0
+  ' >/dev/null || fail "incomplete snapshot was treated as usable: $out"
+  pass "schema-tagged incomplete snapshots remain incomplete"
 }
 
 test_dangling_state_path_is_inconclusive() {
@@ -425,6 +459,46 @@ test_recent_done_signal_is_not_missed_handoff() {
     (any(.findings[]; .kind == "missed-handoff" and .subject == "just-done") | not)
   ' >/dev/null || fail "fresh done signal was treated as missed handoff: $out"
   pass "a fresh done signal is inside the handoff stale window"
+}
+
+test_missed_handoff_after_step_complete_signal() {
+  local home fakebin out rc=0
+  home=$(make_home step-complete-handoff)
+  write_live_ship "$home" step-idle
+  printf 'step-complete: phase 7 complete; send the next instruction\n' > "$home/state/step-idle.status"
+  touch -t 202001011200 "$home/state/step-idle.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    FM_FLEET_HEALTH_HANDOFF_STALE_SECS=60 "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "stale step-complete signal should remain inconclusive when lifecycle state is unknown"
+  printf '%s' "$out" | jq -e '
+    any(.findings[]; .kind == "missed-handoff" and .subject == "step-idle"
+        and .confidence == "high")
+  ' >/dev/null || fail "step-complete missed handoff was not reported: $out"
+  pass "stale step-complete signal is a missed handoff"
+}
+
+test_handled_inbox_corruption_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home handled-inbox-corruption)
+  write_live_ship "$home" handled-task
+  printf 'done: ready for the next step\n' > "$home/state/handled-task.status"
+  touch -t 202001011200 "$home/state/handled-task.status"
+  mkdir -p "$home/state/handled-task.inbox/handled"
+  printf 'not a task inbox record\n' > "$home/state/handled-task.inbox/handled/001.msg"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    FM_FLEET_HEALTH_HANDOFF_STALE_SECS=60 "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "corrupt handled inbox evidence should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "steering-inbox-inconclusive"
+              and (.evidence | contains("activity record(s) are invalid")))
+      and (any(.findings[]; .kind == "missed-handoff" and .subject == "handled-task") | not)
+  ' >/dev/null || fail "corrupt handled inbox evidence was hidden: $out"
+  pass "corrupt handled inbox evidence remains inconclusive"
 }
 
 test_unreadable_local_endpoint_is_inconclusive() {
@@ -972,6 +1046,36 @@ test_paused_ship_still_requires_pr_listener() {
   pass "declared waits retain their required PR listeners"
 }
 
+test_unknown_worker_state_does_not_create_missing_pr_listener() {
+  local home fakebin out rc=0
+  home=$(make_home unknown-pr-listener)
+  mkdir -p "$home/projects/unknown-pr-wt"
+  fm_write_meta "$home/state/unknown-pr.meta" \
+    "window=firstmate:fm-unknown-pr" \
+    "worktree=$home/projects/unknown-pr-wt" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship" \
+    "yolo=off" \
+    "pr=https://github.com/example/alpha/pull/22"
+  printf 'working: waiting on the unknown Codex lifecycle\n' > "$home/state/unknown-pr.status"
+  printf 'fm-unknown-pr\n' > "$home/state/.fake-windows"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "unknown worker state should keep PR listener evidence inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "result-listener-inconclusive"
+              and .subject == "unknown-pr")
+      and (any(.findings[]; .kind == "result-listener-missing"
+               and .subject == "unknown-pr") | not)
+  ' >/dev/null || fail "unknown worker state produced a missing listener finding: $out"
+  pass "unknown worker state does not create a missing PR listener"
+}
+
 test_matching_retired_pr_listener_is_not_missing() {
   local home fakebin marker out rc=0
   home=$(make_home retired-pr-listener)
@@ -1105,6 +1209,7 @@ test_human_view_and_incomplete_exit() {
 test_usage_exit
 test_healthy_empty_fleet
 test_missing_state_home_remains_unmodified
+test_malformed_snapshot_is_incomplete
 test_dangling_state_path_is_inconclusive
 test_unsearchable_state_is_inconclusive
 test_dangling_metadata_is_inconclusive
@@ -1117,6 +1222,8 @@ test_live_codex_without_banner_is_not_dead_session
 test_missed_handoff_after_done_signal
 test_later_inbox_clears_missed_handoff
 test_recent_done_signal_is_not_missed_handoff
+test_missed_handoff_after_step_complete_signal
+test_handled_inbox_corruption_is_inconclusive
 test_unreadable_local_endpoint_is_inconclusive
 test_terminal_unreadable_endpoint_is_inconclusive
 test_historical_status_pr_does_not_require_listener
@@ -1139,6 +1246,7 @@ test_inventory_and_missing_listener
 test_invalid_procevent_registration_is_reported
 test_dangling_procevent_claim_root_is_inconclusive
 test_paused_ship_still_requires_pr_listener
+test_unknown_worker_state_does_not_create_missing_pr_listener
 test_matching_retired_pr_listener_is_not_missing
 test_inconclusive_dominates_actionable_status
 test_unreadable_supervision_lock_is_inconclusive

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -168,6 +168,19 @@ test_healthy_empty_fleet() {
   pass "empty fleet is healthy with no findings"
 }
 
+test_missing_state_home_remains_unmodified() {
+  local home fakebin out rc=0
+  home=$TMP_ROOT/missing-state
+  mkdir -p "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(run_health "$home" "$fakebin") || rc=$?
+  expect_code 0 "$rc" "home without state should remain a healthy empty fleet"
+  [ ! -e "$home/state" ] || fail "read-only health check created the missing state directory"
+  printf '%s' "$out" | jq -e '.status == "healthy"' >/dev/null \
+    || fail "missing-state home did not report healthy: $out"
+  pass "health check does not create a missing state directory"
+}
+
 test_actionable_dead_direct_report() {
   local home fakebin out rc=0
   home=$(make_home dead-agent)
@@ -438,6 +451,24 @@ test_pending_reply_uses_recorded_grace() {
   pass "pending-reply health uses each record's authoritative grace"
 }
 
+test_invalid_pending_reply_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home invalid-pending-reply)
+  mkdir -p "$home/state/pending-replies"
+  printf 'schema=fm-pending-reply.v1\ncorr_id=bad\n' > "$home/state/pending-replies/truncated"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "invalid pending-reply state should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "pending-reply-inconclusive"
+              and .subject == "pending-replies" and .count == 1)
+      and (any(.findings[]; .kind == "pending-reply-broken") | not)
+  ' >/dev/null || fail "invalid pending-reply record was hidden: $out"
+  pass "invalid pending-reply records make health inconclusive"
+}
+
 test_inventory_and_missing_listener() {
   local home fakebin out
   home=$(make_home inventory)
@@ -512,6 +543,7 @@ test_human_view_and_incomplete_exit() {
 
 test_usage_exit
 test_healthy_empty_fleet
+test_missing_state_home_remains_unmodified
 test_actionable_dead_direct_report
 test_dead_agent_with_live_endpoint
 test_unreadable_local_endpoint_is_inconclusive
@@ -523,6 +555,7 @@ test_invalid_secondmate_summary_uses_normalized_kind
 test_truncated_secondmate_inventory_is_inconclusive
 test_incomplete_registry_does_not_break_secondmate_summary
 test_pending_reply_uses_recorded_grace
+test_invalid_pending_reply_is_inconclusive
 test_inventory_and_missing_listener
 test_complete_timeout_covers_fingerprinting
 test_human_view_and_incomplete_exit

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -656,6 +656,22 @@ test_missed_handoff_after_contracted_step_complete_signal() {
   pass "contracted step-complete signal is a missed handoff"
 }
 
+test_captain_decision_wait_is_not_missed_handoff() {
+  local home fakebin out rc=0
+  home=$(make_home captain-decision-wait)
+  write_live_ship "$home" decision-idle
+  printf 'needs-decision [key=shape]: choose an API\n' > "$home/state/decision-idle.status"
+  touch -t 202001011200 "$home/state/decision-idle.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    FM_FLEET_HEALTH_HANDOFF_STALE_SECS=60 "$HEALTH" --json) || rc=$?
+  printf '%s' "$out" | jq -e '
+    any(.findings[]; .kind == "missed-handoff" and .subject == "decision-idle") | not
+  ' >/dev/null || fail "captain decision wait was treated as a missed handoff: $out"
+  pass "captain decision waits stay out of missed handoffs"
+}
+
 test_handled_inbox_corruption_is_inconclusive() {
   local home fakebin out rc=0
   home=$(make_home handled-inbox-corruption)
@@ -1574,6 +1590,7 @@ test_missed_handoff_after_done_signal
 test_later_inbox_clears_missed_handoff
 test_recent_done_signal_is_not_missed_handoff
 test_missed_handoff_after_contracted_step_complete_signal
+test_captain_decision_wait_is_not_missed_handoff
 test_handled_inbox_corruption_is_inconclusive
 test_unreadable_local_endpoint_is_inconclusive
 test_terminal_unreadable_endpoint_is_inconclusive

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -268,7 +268,7 @@ test_snapshot_task_evidence_requires_keys_and_known_states() {
   local home fixture out rc=0 mutation snapshot
   home=$(make_home malformed-task-evidence)
   fixture=$(make_health_fixture_root malformed-task-evidence)
-  snapshot='{"schema":"fm-fleet-snapshot.v1","generated":"2026-01-01T00:00:00Z","fm_home":"/tmp/home","roots":{"fm_root":"/tmp/root","state":"/tmp/state","data":"/tmp/data","config":"/tmp/config","projects":"/tmp/projects"},"backlog":{"path":"/tmp/backlog.md","present":false,"records":[]},"tasks":[{"id":"task","kind":"ship","remote":null,"current_state":{"state":"working"},"endpoint":{"agent_state":"alive","agent_alive":"alive","probe":"local","codex_session":{"collected":true,"reason":null,"resume_banner":null}},"paths":{"status_log":{"last_event":{"state":"working","handoff_required":false,"mtime_epoch":null}}},"pr":{"url":null,"source":"absent"}}],"scout_reports":[],"collection":{"state":{"present":true,"available":true,"invalid_metadata_count":0,"invalid_metadata":[]}},"main_inventory":{"valid":true,"reason":null},"secondmate_current":{"records":[],"truncated":0,"registry":{"available":true,"complete":true,"input_truncated":false,"records_truncated":false}},"secondmate_landed":{"records":[],"truncated":[],"unreadable":[],"partial":[]},"secondmate_guidance":{"note":"fixture"}}'
+  snapshot='{"schema":"fm-fleet-snapshot.v1","generated":"2026-01-01T00:00:00Z","fm_home":"/tmp/home","roots":{"fm_root":"/tmp/root","state":"/tmp/state","data":"/tmp/data","config":"/tmp/config","projects":"/tmp/projects"},"backlog":{"path":"/tmp/backlog.md","present":false,"records":[]},"tasks":[{"id":"task","kind":"ship","remote":null,"current_state":{"state":"working"},"endpoint":{"agent_state":"alive","agent_alive":"alive","probe":"local","codex_session":{"collected":true,"reason":null,"resume_banner":null}},"paths":{"status_log":{"available":true,"reason":null,"last_event":{"state":"working","handoff_required":false,"mtime_epoch":null}}},"pr":{"url":null,"source":"absent"}}],"scout_reports":[],"collection":{"state":{"present":true,"available":true,"invalid_metadata_count":0,"invalid_metadata":[]}},"main_inventory":{"valid":true,"reason":null},"secondmate_current":{"records":[],"truncated":0,"registry":{"available":true,"complete":true,"input_truncated":false,"records_truncated":false}},"secondmate_landed":{"records":[],"truncated":[],"unreadable":[],"partial":[]},"secondmate_guidance":{"note":"fixture"}}'
   for mutation in omit-endpoint-exists invalid-state invalid-agent-state invalid-agent-alive invalid-probe; do
     if [ "$mutation" = omit-endpoint-exists ]; then
       snapshot=$(printf '%s' "$snapshot" | jq 'del(.tasks[0].endpoint.exists)')
@@ -651,9 +651,44 @@ test_missed_handoff_after_contracted_step_complete_signal() {
   expect_code 1 "$rc" "contracted step-complete signal should be actionable"
   printf '%s' "$out" | jq -e '
     any(.findings[]; .kind == "missed-handoff" and .subject == "step-idle"
-        and .confidence == "high")
+        and .confidence == "high"
+        and (.evidence | contains("signaled blocked awaiting the next instruction")))
   ' >/dev/null || fail "contracted step-complete missed handoff was not reported: $out"
   pass "contracted step-complete signal is a missed handoff"
+}
+
+test_failed_status_is_not_missed_handoff() {
+  local home fakebin out rc=0
+  home=$(make_home failed-not-handoff)
+  write_live_ship "$home" failed-task
+  printf 'failed: tests did not pass\n' > "$home/state/failed-task.status"
+  touch -t 202001011200 "$home/state/failed-task.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    FM_FLEET_HEALTH_HANDOFF_STALE_SECS=60 "$HEALTH" --json) || rc=$?
+  printf '%s' "$out" | jq -e '
+    any(.findings[]; .kind == "missed-handoff" and .subject == "failed-task") | not
+  ' >/dev/null || fail "failed status was treated as a completed handoff: $out"
+  pass "failed statuses do not assert a missed handoff"
+}
+
+test_dangling_status_log_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home dangling-status-log)
+  write_live_ship "$home" dangling-status
+  rm "$home/state/dangling-status.status"
+  ln -s "$home/state/missing-status-target" "$home/state/dangling-status.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "dangling task status evidence should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    any(.findings[]; .kind == "missed-handoff-inconclusive"
+        and .subject == "dangling-status"
+        and .evidence == "task status-log evidence could not be established")
+  ' >/dev/null || fail "dangling status-log evidence was hidden: $out"
+  pass "dangling status-log evidence remains inconclusive"
 }
 
 test_captain_decision_wait_is_not_missed_handoff() {
@@ -1016,21 +1051,19 @@ SH
   pass "recovery sender ownership distinguishes orphaned and unreadable"
 }
 
-test_inconsistent_recovery_outcome_is_inconclusive() {
+test_committed_recovery_outcome_transition_is_valid() {
   local home fakebin out rc=0
   home=$(make_home inconsistent-recovery-outcome)
   write_pending "$home" 3333333333333333 half-written recovery_sending "" 120 "$$" sender confirmed
   fakebin=$(make_fakebin "$home")
   out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$HEALTH" --json) || rc=$?
-  expect_code 3 "$rc" "half-written recovery outcome should be inconclusive"
+  expect_code 0 "$rc" "observable recovery outcome transition should remain valid"
   printf '%s' "$out" | jq -e '
-    .status == "inconclusive"
-      and any(.findings[]; .kind == "pending-reply-inconclusive"
-              and .subject == "pending-replies"
-              and .evidence == "1 pending-reply record(s) are invalid")
-      and (any(.findings[]; .kind == "pending-reply-broken" and .subject == "half-written") | not)
-  ' >/dev/null || fail "half-written recovery outcome did not remain inconclusive: $out"
-  pass "half-written recovery outcomes remain inconclusive"
+    .status == "healthy"
+      and (any(.findings[]; .kind == "pending-reply-inconclusive") | not)
+      and (any(.findings[]; .kind == "pending-reply-broken") | not)
+  ' >/dev/null || fail "observable recovery outcome transition was rejected: $out"
+  pass "committed recovery outcomes remain valid before the phase advance"
 }
 
 test_inconclusive_secondmate_summary_not_broken() {
@@ -1299,6 +1332,25 @@ test_dangling_procevent_registry_is_inconclusive() {
   pass "dangling process-event registry remains unavailable"
 }
 
+test_dangling_procevent_source_claim_is_inconclusive() {
+  local home fakebin claim_root out rc=0
+  home=$(make_home dangling-procevent-source-claim)
+  mkdir -p "$home/state/procevent"
+  printf 'adapter=lavish\nargc=1\nargv:\npoll\n' > "$home/state/procevent/source-one.source"
+  claim_root="$home/procevent-claims"
+  mkdir -p "$claim_root"
+  ln -s "$claim_root/missing-claim-target" "$claim_root/source-one.claim"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    FM_PROCEVENT_CLAIM_ROOT="$claim_root" "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "dangling source claim should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    any(.findings[]; .kind == "result-listener-inconclusive" and .subject == "source-one")
+      and (any(.findings[]; .kind == "result-listener-missing" and .subject == "source-one") | not)
+  ' >/dev/null || fail "dangling source claim was classified as missing: $out"
+  pass "dangling process-event source claims remain inconclusive"
+}
+
 test_paused_ship_still_requires_pr_listener() {
   local home fakebin out rc=0
   home=$(make_home paused-pr-listener)
@@ -1391,6 +1443,25 @@ test_invalid_pr_listener_evidence_is_inconclusive() {
       and (any(.findings[]; .kind == "result-listener-missing" and .subject == "invalid-pr") | not)
   ' >/dev/null || fail "invalid PR-listener evidence became actionable: $out"
   pass "invalid PR-listener evidence remains inconclusive"
+}
+
+test_unrelated_pr_listener_corruption_preserves_missing_listener() {
+  local home fakebin out rc=0
+  home=$(make_home unrelated-pr-listener-corruption)
+  write_live_ship "$home" missing-listener
+  printf 'pr=https://github.com/example/alpha/pull/25\n' >> "$home/state/missing-listener.meta"
+  printf 'paused: waiting for CI\n' > "$home/state/missing-listener.status"
+  printf 'not a valid merge-poll listener\n' > "$home/state/unrelated.check.sh"
+  chmod 0600 "$home/state/unrelated.check.sh"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "unrelated PR-listener corruption should preserve both verdicts"
+  printf '%s' "$out" | jq -e '
+    any(.findings[]; .kind == "result-listener-inconclusive" and .subject == "pr-polls")
+      and any(.findings[]; .kind == "result-listener-missing" and .subject == "missing-listener")
+  ' >/dev/null || fail "unrelated PR-listener corruption suppressed a proven missing listener: $out"
+  pass "unrelated PR-listener corruption does not suppress missing listeners"
 }
 
 test_matching_retired_pr_listener_is_not_missing() {
@@ -1612,6 +1683,8 @@ test_missed_handoff_after_done_signal
 test_later_inbox_clears_missed_handoff
 test_recent_done_signal_is_not_missed_handoff
 test_missed_handoff_after_contracted_step_complete_signal
+test_failed_status_is_not_missed_handoff
+test_dangling_status_log_is_inconclusive
 test_captain_decision_wait_is_not_missed_handoff
 test_handled_inbox_corruption_is_inconclusive
 test_unrelated_inbox_corruption_preserves_missed_handoff
@@ -1626,7 +1699,7 @@ test_unknown_worker_state_is_inconclusive
 test_registry_only_remote_evidence_is_inconclusive
 test_pending_reply_broken_and_historical_noise_omitted
 test_recovery_sending_owner_verdicts
-test_inconsistent_recovery_outcome_is_inconclusive
+test_committed_recovery_outcome_transition_is_valid
 test_inconclusive_secondmate_summary_not_broken
 test_invalid_secondmate_summary_uses_normalized_kind
 test_truncated_secondmate_inventory_is_inconclusive
@@ -1639,10 +1712,12 @@ test_inventory_and_missing_listener
 test_invalid_procevent_registration_is_inconclusive
 test_dangling_procevent_claim_root_is_inconclusive
 test_dangling_procevent_registry_is_inconclusive
+test_dangling_procevent_source_claim_is_inconclusive
 test_paused_ship_still_requires_pr_listener
 test_invalid_current_pr_metadata_is_inconclusive
 test_unknown_worker_state_does_not_create_missing_pr_listener
 test_invalid_pr_listener_evidence_is_inconclusive
+test_unrelated_pr_listener_corruption_preserves_missing_listener
 test_matching_retired_pr_listener_is_not_missing
 test_inconclusive_dominates_actionable_status
 test_unreadable_supervision_lock_is_inconclusive

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -94,8 +94,9 @@ run_health() {  # <home> <fakebin>
   PATH="$2:$PATH" FM_HOME="$1" "$HEALTH" --json
 }
 
-write_pending() {  # <home> <corr> <task> <phase> [completed_epoch] [grace]
+write_pending() {  # <home> <corr> <task> <phase> [completed_epoch] [grace] [sender-pid] [sender-identity]
   local home=$1 corr=$2 task=$3 phase=$4 completed=${5-} grace=${6:-120}
+  local sender_pid=${7-} sender_identity=${8-}
   mkdir -p "$home/state/pending-replies"
   cat > "$home/state/pending-replies/$corr" <<EOF
 schema=fm-pending-reply.v1
@@ -111,8 +112,8 @@ phase=$phase
 turn_seen_busy=1
 request_turn_completed_epoch=$completed
 recovery_attempted_epoch=
-recovery_sender_pid=
-recovery_sender_identity=
+recovery_sender_pid=$sender_pid
+recovery_sender_identity=$sender_identity
 recovery_sent_epoch=
 recovery_delivery_outcome=
 recovery_turn_seen_busy=0
@@ -467,6 +468,34 @@ EOF
   pass "broken replies group by owner and product blockers stay out"
 }
 
+test_recovery_sending_owner_verdicts() {
+  local home fakebin real_ps out rc=0
+  home=$(make_home recovery-sending-verdicts)
+  write_pending "$home" 1111111111111111 orphaned-recovery recovery_sending "" 120 999999 dead-sender
+  write_pending "$home" 2222222222222222 unreadable-recovery recovery_sending "" 120 "$$" unreadable-sender
+  fakebin=$(make_fakebin "$home")
+  real_ps=$(command -v ps)
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" -p $FM_TEST_UNREADABLE_PID "*) exit 1 ;;
+esac
+exec "$FM_TEST_REAL_PS" "$@"
+SH
+  chmod +x "$fakebin/ps"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_TEST_REAL_PS="$real_ps" \
+    FM_TEST_UNREADABLE_PID="$$" "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "unreadable recovery ownership should dominate an orphaned sender"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "pending-reply-broken"
+              and .subject == "orphaned-recovery")
+      and any(.findings[]; .kind == "pending-reply-inconclusive"
+              and .subject == "unreadable-recovery")
+  ' >/dev/null || fail "recovery_sending ownership evidence was hidden: $out"
+  pass "recovery sender ownership distinguishes orphaned and unreadable"
+}
+
 test_inconclusive_secondmate_summary_not_broken() {
   local home fakebin out rc=0
   home=$(make_home remote-summary)
@@ -708,6 +737,47 @@ test_inconclusive_dominates_actionable_status() {
   pass "inconclusive evidence dominates overall status without hiding findings"
 }
 
+test_unreadable_supervision_lock_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home unreadable-supervision-lock)
+  write_live_ship "$home" supervised-worker
+  fresh_autoarm_supervision "$home"
+  mkdir -p "$home/state/.watch.lock"
+  printf '999999\n' > "$home/state/.watch.lock/pid"
+  chmod 000 "$home/state/.watch.lock"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=persistent "$HEALTH" --json) || rc=$?
+  chmod 700 "$home/state/.watch.lock"
+  expect_code 3 "$rc" "unreadable watcher-lock evidence should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "supervision-inconclusive")
+      and (any(.findings[]; .kind == "supervision-unhealthy") | not)
+  ' >/dev/null || fail "unreadable supervision evidence became actionable: $out"
+  pass "unreadable watcher-lock evidence remains inconclusive"
+}
+
+test_internal_worker_failure_returns_json() {
+  local home fakebin out rc=0
+  home=$(make_home internal-worker-failure)
+  write_live_ship "$home" hash-failure
+  : > "$home/state/.fake-windows"
+  fakebin=$(make_fakebin "$home")
+  cat > "$fakebin/shasum" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$fakebin/shasum"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "internal worker failure should use the incomplete exit"
+  printf '%s' "$out" | jq -e '
+    .schema == "fm-fleet-health.v1"
+      and .status == "incomplete"
+      and .reason == "fleet health check failed"
+  ' >/dev/null || fail "internal worker failure omitted stable JSON: $out"
+  pass "internal worker failures retain the stable JSON contract"
+}
+
 test_complete_timeout_covers_fingerprinting() {
   local home fakebin out rc=0
   home=$(make_home complete-timeout)
@@ -754,6 +824,7 @@ test_grouped_inbox_and_stable_fingerprints
 test_invalid_inbox_records_are_inconclusive
 test_remote_liveness_is_inconclusive
 test_pending_reply_broken_and_historical_noise_omitted
+test_recovery_sending_owner_verdicts
 test_inconclusive_secondmate_summary_not_broken
 test_invalid_secondmate_summary_uses_normalized_kind
 test_truncated_secondmate_inventory_is_inconclusive
@@ -764,5 +835,7 @@ test_inventory_and_missing_listener
 test_invalid_procevent_registration_is_reported
 test_paused_ship_still_requires_pr_listener
 test_inconclusive_dominates_actionable_status
+test_unreadable_supervision_lock_is_inconclusive
+test_internal_worker_failure_returns_json
 test_complete_timeout_covers_fingerprinting
 test_human_view_and_incomplete_exit

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -1166,6 +1166,28 @@ test_paused_ship_still_requires_pr_listener() {
   pass "declared waits retain their required PR listeners"
 }
 
+test_invalid_current_pr_metadata_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home invalid-current-pr)
+  write_live_ship "$home" invalid-current-pr
+  printf 'pr=not-a-url\n' >> "$home/state/invalid-current-pr.meta"
+  printf 'paused: waiting for CI\n' > "$home/state/invalid-current-pr.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "invalid current PR metadata should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "result-listener-inconclusive"
+              and .subject == "pr-polls"
+              and (.evidence | contains("current PR metadata")))
+      and (any(.findings[]; .kind == "result-listener-missing"
+               and .subject == "invalid-current-pr") | not)
+  ' >/dev/null || fail "invalid current PR metadata became actionable: $out"
+  pass "invalid current PR metadata remains inconclusive"
+}
+
 test_unknown_worker_state_does_not_create_missing_pr_listener() {
   local home fakebin out rc=0
   home=$(make_home unknown-pr-listener)
@@ -1441,6 +1463,7 @@ test_invalid_procevent_registration_is_inconclusive
 test_dangling_procevent_claim_root_is_inconclusive
 test_dangling_procevent_registry_is_inconclusive
 test_paused_ship_still_requires_pr_listener
+test_invalid_current_pr_metadata_is_inconclusive
 test_unknown_worker_state_does_not_create_missing_pr_listener
 test_invalid_pr_listener_evidence_is_inconclusive
 test_matching_retired_pr_listener_is_not_missing

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -358,6 +358,48 @@ test_grouped_inbox_and_stable_fingerprints() {
   pass "aged inbox messages group by task and keep a stable fingerprint"
 }
 
+test_invalid_inbox_records_are_inconclusive() {
+  local home fakebin real_stat out rc=0
+  home=$(make_home invalid-inbox-records)
+  mkdir -p "$home/state/broken.inbox"
+  cat > "$home/state/broken.inbox/bad.msg" <<'EOF'
+schema=fm-task-inbox.v1
+at=2026-08-26T12:00:00Z
+--
+invalid sequence
+EOF
+  printf 'schema=fm-task-inbox.v1\n' > "$home/state/broken.inbox/001.msg"
+  cat > "$home/state/broken.inbox/002.msg" <<'EOF'
+schema=fm-task-inbox.v1
+at=2026-08-26T12:00:00Z
+--
+unageable record
+EOF
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  real_stat=$(command -v stat)
+  cat > "$fakebin/stat" <<'SH'
+#!/usr/bin/env bash
+case "${!#}" in
+  */002.msg) exit 1 ;;
+esac
+exec "$FM_TEST_REAL_STAT" "$@"
+SH
+  chmod +x "$fakebin/stat"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    FM_TEST_REAL_STAT="$real_stat" "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "invalid or unageable inbox records should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "steering-inbox-inconclusive"
+              and .count == 2 and (.evidence | contains("are invalid")))
+      and any(.findings[]; .kind == "steering-inbox-inconclusive"
+              and .count == 1 and (.evidence | contains("could not be aged")))
+      and (any(.findings[]; .kind == "steering-inbox-aged") | not)
+  ' >/dev/null || fail "malformed inbox evidence was hidden: $out"
+  pass "invalid and unageable inbox records remain inconclusive"
+}
+
 test_remote_liveness_is_inconclusive() {
   local home fakebin out rc=0
   home=$(make_home remote-liveness)
@@ -709,6 +751,7 @@ test_unreadable_local_endpoint_is_inconclusive
 test_terminal_unreadable_endpoint_is_inconclusive
 test_historical_status_pr_does_not_require_listener
 test_grouped_inbox_and_stable_fingerprints
+test_invalid_inbox_records_are_inconclusive
 test_remote_liveness_is_inconclusive
 test_pending_reply_broken_and_historical_noise_omitted
 test_inconclusive_secondmate_summary_not_broken

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -252,11 +252,17 @@ test_snapshot_task_evidence_requires_keys_and_known_states() {
   home=$(make_home malformed-task-evidence)
   fixture=$(make_health_fixture_root malformed-task-evidence)
   snapshot='{"schema":"fm-fleet-snapshot.v1","generated":"2026-01-01T00:00:00Z","fm_home":"/tmp/home","roots":{"fm_root":"/tmp/root","state":"/tmp/state","data":"/tmp/data","config":"/tmp/config","projects":"/tmp/projects"},"backlog":{"path":"/tmp/backlog.md","present":false,"records":[]},"tasks":[{"id":"task","kind":"ship","remote":null,"current_state":{"state":"working"},"endpoint":{"agent_state":"alive","agent_alive":"alive","probe":"local","codex_session":{"resume_banner":null}},"paths":{"status_log":{"last_event":{"state":"working","handoff_required":false,"mtime_epoch":null}}},"pr":{"url":null,"source":"absent"}}],"scout_reports":[],"collection":{"state":{"present":true,"available":true,"invalid_metadata_count":0,"invalid_metadata":[]}},"main_inventory":{"valid":true,"reason":null},"secondmate_current":{"records":[],"truncated":0,"registry":{"available":true,"complete":true,"input_truncated":false,"records_truncated":false}},"secondmate_landed":{"records":[],"truncated":[],"unreadable":[],"partial":[]},"secondmate_guidance":{"note":"fixture"}}'
-  for mutation in omit-endpoint-exists invalid-state; do
+  for mutation in omit-endpoint-exists invalid-state invalid-agent-state invalid-agent-alive invalid-probe; do
     if [ "$mutation" = omit-endpoint-exists ]; then
       snapshot=$(printf '%s' "$snapshot" | jq 'del(.tasks[0].endpoint.exists)')
-    else
+    elif [ "$mutation" = invalid-state ]; then
       snapshot=$(printf '%s' "$snapshot" | jq '.tasks[0].current_state.state = "not-a-state"')
+    elif [ "$mutation" = invalid-agent-state ]; then
+      snapshot=$(printf '%s' "$snapshot" | jq '.tasks[0].endpoint.agent_state = "not-a-state"')
+    elif [ "$mutation" = invalid-agent-alive ]; then
+      snapshot=$(printf '%s' "$snapshot" | jq '.tasks[0].endpoint.agent_alive = "not-a-state"')
+    else
+      snapshot=$(printf '%s' "$snapshot" | jq '.tasks[0].endpoint.probe = "not-a-probe"')
     fi
     rc=0
     out=$(FM_HOME="$home" FM_TEST_SNAPSHOT="$snapshot" FM_FLEET_HEALTH_TIMED_WORKER=1 \
@@ -265,7 +271,7 @@ test_snapshot_task_evidence_requires_keys_and_known_states() {
     printf '%s' "$out" | jq -e '.status == "incomplete" and .reason == "fleet snapshot was malformed"' \
       >/dev/null || fail "snapshot with $mutation was accepted: $out"
   done
-  pass "snapshot task evidence requires nullable keys and known states"
+  pass "snapshot task evidence requires nullable keys and known enums"
 }
 
 test_remote_snapshot_probe_disabled_skips_remote_state() {
@@ -692,6 +698,12 @@ at=2026-08-26T12:00:00Z
 --
 unageable record
 EOF
+  cat > "$home/state/broken.inbox/003.msg" <<'EOF'
+schema=fm-task-inbox.v1
+at=xxxx-xx-xxTxx:xx:xxZ
+--
+malformed timestamp
+EOF
   fresh_autoarm_supervision "$home"
   fakebin=$(make_fakebin "$home")
   real_stat=$(command -v stat)
@@ -709,7 +721,7 @@ SH
   printf '%s' "$out" | jq -e '
     .status == "inconclusive"
       and any(.findings[]; .kind == "steering-inbox-inconclusive"
-              and .count == 2 and (.evidence | contains("are invalid")))
+              and .count == 3 and (.evidence | contains("are invalid")))
       and any(.findings[]; .kind == "steering-inbox-inconclusive"
               and .count == 1 and (.evidence | contains("could not be aged")))
       and (any(.findings[]; .kind == "steering-inbox-aged") | not)
@@ -1016,6 +1028,10 @@ test_invalid_pending_reply_is_inconclusive() {
   sed 's/^delivered_epoch=.*/delivered_epoch=not-a-number/' \
     "$home/state/pending-replies/0123012301230123" > "$home/state/pending-replies/invalid.tmp"
   mv "$home/state/pending-replies/invalid.tmp" "$home/state/pending-replies/0123012301230123"
+  write_pending "$home" 4567456745674567 owner-gap awaiting_report
+  sed 's/^parent_home=.*/parent_home=not-an-absolute-path/' \
+    "$home/state/pending-replies/4567456745674567" > "$home/state/pending-replies/owner.tmp"
+  mv "$home/state/pending-replies/owner.tmp" "$home/state/pending-replies/4567456745674567"
   fresh_autoarm_supervision "$home"
   fakebin=$(make_fakebin "$home")
   out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
@@ -1023,7 +1039,7 @@ test_invalid_pending_reply_is_inconclusive() {
   printf '%s' "$out" | jq -e '
     .status == "inconclusive"
       and any(.findings[]; .kind == "pending-reply-inconclusive"
-              and .subject == "pending-replies" and .count == 2)
+              and .subject == "pending-replies" and .count == 3)
       and (any(.findings[]; .kind == "pending-reply-broken") | not)
   ' >/dev/null || fail "invalid pending-reply record was hidden: $out"
   pass "invalid pending-reply records make health inconclusive"
@@ -1081,21 +1097,21 @@ EOF
   pass "inconsistent inventory and missing listeners are actionable"
 }
 
-test_invalid_procevent_registration_is_reported() {
+test_invalid_procevent_registration_is_inconclusive() {
   local home fakebin out rc=0
   home=$(make_home invalid-procevent-registration)
   mkdir -p "$home/state/procevent/broken.source"
   fresh_autoarm_supervision "$home"
   fakebin=$(make_fakebin "$home")
   out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
-  expect_code 1 "$rc" "structurally invalid process-event registration should be actionable"
+  expect_code 3 "$rc" "structurally invalid process-event registration should be inconclusive"
   printf '%s' "$out" | jq -e '
-    .status == "actionable"
-      and any(.findings[]; .kind == "result-listener-missing"
-              and .subject == "broken"
-              and (.evidence | contains("owner=invalid")))
-  ' >/dev/null || fail "invalid process-event registration was hidden: $out"
-  pass "invalid process-event registrations remain visible"
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "result-listener-inconclusive"
+              and .subject == "broken")
+      and (any(.findings[]; .kind == "result-listener-missing" and .subject == "broken") | not)
+  ' >/dev/null || fail "invalid process-event registration became actionable: $out"
+  pass "invalid process-event registrations remain inconclusive"
 }
 
 test_dangling_procevent_claim_root_is_inconclusive() {
@@ -1299,6 +1315,35 @@ test_malformed_supervision_pid_is_inconclusive() {
   pass "malformed watcher-lock PID remains unavailable"
 }
 
+test_incomplete_supervision_lock_is_inconclusive() {
+  local home fakebin out rc=0 watcher_pid identity
+  home=$(make_home incomplete-supervision-lock)
+  write_live_ship "$home" supervised-worker
+  fresh_autoarm_supervision "$home"
+  mkdir -p "$home/state/.watch.lock"
+  sleep 30 &
+  watcher_pid=$!
+  identity=$(fm_pid_identity "$watcher_pid") || {
+    kill "$watcher_pid" 2>/dev/null || true
+    fail "could not identify the supervision fixture process"
+  }
+  printf '%s\n' "$watcher_pid" > "$home/state/.watch.lock/pid"
+  printf '%s\n' "$ROOT/bin/fm-watch.sh" > "$home/state/.watch.lock/watcher-path"
+  printf '%s\n' "$identity" > "$home/state/.watch.lock/pid-identity"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=persistent \
+    "$HEALTH" --json) || rc=$?
+  kill "$watcher_pid" 2>/dev/null || true
+  wait "$watcher_pid" 2>/dev/null || true
+  expect_code 3 "$rc" "incomplete watcher-lock metadata should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "supervision-inconclusive")
+      and (any(.findings[]; .kind == "supervision-unhealthy") | not)
+  ' >/dev/null || fail "incomplete supervision metadata became actionable: $out"
+  pass "incomplete watcher-lock metadata remains unavailable"
+}
+
 test_internal_worker_failure_returns_json() {
   local home fakebin out rc=0
   home=$(make_home internal-worker-failure)
@@ -1392,7 +1437,7 @@ test_pending_reply_uses_recorded_grace
 test_invalid_pending_reply_is_inconclusive
 test_dangling_pending_reply_directory_is_inconclusive
 test_inventory_and_missing_listener
-test_invalid_procevent_registration_is_reported
+test_invalid_procevent_registration_is_inconclusive
 test_dangling_procevent_claim_root_is_inconclusive
 test_dangling_procevent_registry_is_inconclusive
 test_paused_ship_still_requires_pr_listener
@@ -1402,6 +1447,7 @@ test_matching_retired_pr_listener_is_not_missing
 test_inconclusive_dominates_actionable_status
 test_unreadable_supervision_lock_is_inconclusive
 test_malformed_supervision_pid_is_inconclusive
+test_incomplete_supervision_lock_is_inconclusive
 test_internal_worker_failure_returns_json
 test_complete_timeout_covers_fingerprinting
 test_human_view_and_incomplete_exit

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -198,6 +198,31 @@ test_dead_agent_with_live_endpoint() {
   pass "dead agent is detected even when its endpoint remains present"
 }
 
+test_unreadable_local_endpoint_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home unreadable-local-endpoint)
+  mkdir -p "$home/projects/unreadable-wt"
+  fm_write_meta "$home/state/unreadable-worker.meta" \
+    "backend=herdr" \
+    "window=malformed-herdr-target" \
+    "worktree=$home/projects/unreadable-wt" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship"
+  printf 'working: implementing\n' > "$home/state/unreadable-worker.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "unreadable local endpoint evidence should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "endpoint-inconclusive" and .subject == "unreadable-worker")
+      and (any(.findings[]; .kind == "dead-direct-report" and .subject == "unreadable-worker") | not)
+  ' >/dev/null || fail "unreadable Herdr evidence was classified as dead: $out"
+  pass "unreadable local endpoint evidence remains inconclusive"
+}
+
 test_grouped_inbox_and_stable_fingerprints() {
   local home fakebin out1 out2 rc=0 fp1 fp2 count
   home=$(make_home grouped-inbox)
@@ -373,6 +398,31 @@ EOF
   pass "bounded secondmate omissions make fleet health inconclusive"
 }
 
+test_incomplete_registry_does_not_break_secondmate_summary() {
+  local home fakebin out rc=0
+  home=$(make_home incomplete-registry)
+  printf '%s\n' '- some-other-mate' > "$home/data/secondmates.md"
+  chmod 000 "$home/data/secondmates.md"
+  fm_write_meta "$home/state/omitted-mate.meta" \
+    "window=firstmate:fm-omitted-mate" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "home=$home/omitted-home"
+  printf 'working: watching scope\n' > "$home/state/omitted-mate.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "incomplete registry evidence should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "secondmate-summary-inconclusive" and .subject == "omitted-mate")
+      and (any(.findings[]; .kind == "secondmate-summary-unavailable" and .subject == "omitted-mate") | not)
+  ' >/dev/null || fail "incomplete registry evidence became an actionable summary failure: $out"
+  pass "incomplete registry evidence stays distinct from summary failure"
+}
+
 test_pending_reply_uses_recorded_grace() {
   local home fakebin out rc=0
   home=$(make_home recorded-grace)
@@ -464,12 +514,14 @@ test_usage_exit
 test_healthy_empty_fleet
 test_actionable_dead_direct_report
 test_dead_agent_with_live_endpoint
+test_unreadable_local_endpoint_is_inconclusive
 test_grouped_inbox_and_stable_fingerprints
 test_remote_liveness_is_inconclusive
 test_pending_reply_broken_and_historical_noise_omitted
 test_inconclusive_secondmate_summary_not_broken
 test_invalid_secondmate_summary_uses_normalized_kind
 test_truncated_secondmate_inventory_is_inconclusive
+test_incomplete_registry_does_not_break_secondmate_summary
 test_pending_reply_uses_recorded_grace
 test_inventory_and_missing_listener
 test_complete_timeout_covers_fingerprinting

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -247,6 +247,27 @@ test_malformed_snapshot_is_incomplete() {
   pass "schema-tagged snapshots require the complete top-level shape"
 }
 
+test_snapshot_task_evidence_requires_keys_and_known_states() {
+  local home fixture out rc=0 mutation snapshot
+  home=$(make_home malformed-task-evidence)
+  fixture=$(make_health_fixture_root malformed-task-evidence)
+  snapshot='{"schema":"fm-fleet-snapshot.v1","generated":"2026-01-01T00:00:00Z","fm_home":"/tmp/home","roots":{"fm_root":"/tmp/root","state":"/tmp/state","data":"/tmp/data","config":"/tmp/config","projects":"/tmp/projects"},"backlog":{"path":"/tmp/backlog.md","present":false,"records":[]},"tasks":[{"id":"task","kind":"ship","remote":null,"current_state":{"state":"working"},"endpoint":{"agent_state":"alive","agent_alive":"alive","probe":"local","codex_session":{"resume_banner":null}},"paths":{"status_log":{"last_event":{"state":"working","handoff_required":false,"mtime_epoch":null}}},"pr":{"url":null,"source":"absent"}}],"scout_reports":[],"collection":{"state":{"present":true,"available":true,"invalid_metadata_count":0,"invalid_metadata":[]}},"main_inventory":{"valid":true,"reason":null},"secondmate_current":{"records":[],"truncated":0,"registry":{"available":true,"complete":true,"input_truncated":false,"records_truncated":false}},"secondmate_landed":{"records":[],"truncated":[],"unreadable":[],"partial":[]},"secondmate_guidance":{"note":"fixture"}}'
+  for mutation in omit-endpoint-exists invalid-state; do
+    if [ "$mutation" = omit-endpoint-exists ]; then
+      snapshot=$(printf '%s' "$snapshot" | jq 'del(.tasks[0].endpoint.exists)')
+    else
+      snapshot=$(printf '%s' "$snapshot" | jq '.tasks[0].current_state.state = "not-a-state"')
+    fi
+    rc=0
+    out=$(FM_HOME="$home" FM_TEST_SNAPSHOT="$snapshot" FM_FLEET_HEALTH_TIMED_WORKER=1 \
+      "$fixture/bin/fm-fleet-health.sh" --json) || rc=$?
+    expect_code 3 "$rc" "snapshot with $mutation should be incomplete"
+    printf '%s' "$out" | jq -e '.status == "incomplete" and .reason == "fleet snapshot was malformed"' \
+      >/dev/null || fail "snapshot with $mutation was accepted: $out"
+  done
+  pass "snapshot task evidence requires nullable keys and known states"
+}
+
 test_remote_snapshot_probe_disabled_skips_remote_state() {
   local home fixture out rc=0 log
   home=$(make_home remote-probe-disabled)
@@ -1044,8 +1065,6 @@ EOF
     "yolo=off" \
     "pr=https://github.com/example/alpha/pull/9"
   printf 'working: waiting on CI\n' > "$home/state/pr-ship.status"
-  printf '#!/usr/bin/env bash\nprintf "OPEN\\n"\n' > "$home/state/pr-ship.check.sh"
-  chmod 0600 "$home/state/pr-ship.check.sh"
   mkdir -p "$home/state/procevent"
   printf 'adapter=lavish\nargc=1\nargv:\npoll\n' > "$home/state/procevent/board-src.source"
   fakebin=$(make_fakebin "$home")
@@ -1159,6 +1178,29 @@ test_unknown_worker_state_does_not_create_missing_pr_listener() {
                and .subject == "unknown-pr") | not)
   ' >/dev/null || fail "unknown worker state produced a missing listener finding: $out"
   pass "unknown worker state does not create a missing PR listener"
+}
+
+test_invalid_pr_listener_evidence_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home invalid-pr-listener-evidence)
+  write_live_ship "$home" invalid-pr
+  printf 'pr=https://github.com/example/alpha/pull/24\n' >> "$home/state/invalid-pr.meta"
+  printf 'paused: waiting for CI\n' > "$home/state/invalid-pr.status"
+  printf 'not a valid merge-poll listener\n' > "$home/state/invalid-pr.check.sh"
+  chmod 0600 "$home/state/invalid-pr.check.sh"
+  ln -s "$home/state/missing-retirement" "$home/state/retired.pr-poll-merge-notified"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "invalid PR-listener artifacts should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "result-listener-inconclusive" and .subject == "pr-polls"
+              and .count == 2)
+      and (any(.findings[]; .kind == "result-listener-missing" and .subject == "invalid-pr") | not)
+  ' >/dev/null || fail "invalid PR-listener evidence became actionable: $out"
+  pass "invalid PR-listener evidence remains inconclusive"
 }
 
 test_matching_retired_pr_listener_is_not_missing() {
@@ -1314,6 +1356,7 @@ test_usage_exit
 test_healthy_empty_fleet
 test_missing_state_home_remains_unmodified
 test_malformed_snapshot_is_incomplete
+test_snapshot_task_evidence_requires_keys_and_known_states
 test_remote_snapshot_probe_disabled_skips_remote_state
 test_dangling_state_path_is_inconclusive
 test_unsearchable_state_is_inconclusive
@@ -1354,6 +1397,7 @@ test_dangling_procevent_claim_root_is_inconclusive
 test_dangling_procevent_registry_is_inconclusive
 test_paused_ship_still_requires_pr_listener
 test_unknown_worker_state_does_not_create_missing_pr_listener
+test_invalid_pr_listener_evidence_is_inconclusive
 test_matching_retired_pr_listener_is_not_missing
 test_inconclusive_dominates_actionable_status
 test_unreadable_supervision_lock_is_inconclusive

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -114,6 +114,26 @@ SH
   printf '%s\n' "$root"
 }
 
+make_snapshot_fixture_root() {  # <name>
+  local name=$1 root=$TMP_ROOT/snapshot-command-$1 source base
+  mkdir -p "$root/bin"
+  cp "$ROOT/bin/fm-fleet-snapshot.sh" "$root/bin/fm-fleet-snapshot.sh"
+  for source in "$ROOT"/bin/*.sh; do
+    base=${source##*/}
+    case "$base" in
+      fm-fleet-snapshot.sh|fm-on.sh) continue ;;
+    esac
+    ln -s "$source" "$root/bin/$base"
+  done
+  cat > "$root/bin/fm-on.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${FM_TEST_REMOTE_CALL_LOG:?}" >> "$FM_TEST_REMOTE_CALL_LOG"
+exit 1
+SH
+  chmod +x "$root/bin/fm-fleet-snapshot.sh" "$root/bin/fm-on.sh"
+  printf '%s\n' "$root"
+}
+
 write_pending() {  # <home> <corr> <task> <phase> [completed_epoch] [grace] [sender-pid] [sender-identity]
   local home=$1 corr=$2 task=$3 phase=$4 completed=${5-} grace=${6:-120}
   local sender_pid=${7-} sender_identity=${8-}
@@ -209,18 +229,53 @@ test_missing_state_home_remains_unmodified() {
 }
 
 test_malformed_snapshot_is_incomplete() {
-  local home fixture out rc=0
+  local home fixture out rc=0 field snapshot
   home=$(make_home malformed-snapshot)
   fixture=$(make_health_fixture_root malformed-snapshot)
-  out=$(FM_HOME="$home" FM_TEST_SNAPSHOT='{"schema":"fm-fleet-snapshot.v1"}' \
-    FM_FLEET_HEALTH_TIMED_WORKER=1 "$fixture/bin/fm-fleet-health.sh" --json) || rc=$?
-  expect_code 3 "$rc" "a schema-tagged incomplete snapshot should be incomplete"
+  snapshot='{"schema":"fm-fleet-snapshot.v1","generated":"2026-01-01T00:00:00Z","fm_home":"/tmp/home","roots":{"fm_root":"/tmp/root","state":"/tmp/state","data":"/tmp/data","config":"/tmp/config","projects":"/tmp/projects"},"backlog":{"path":"/tmp/backlog.md","present":false,"records":[]},"tasks":[],"scout_reports":[],"collection":{"state":{"present":false,"available":true,"invalid_metadata_count":0,"invalid_metadata":[]}},"main_inventory":{"valid":true,"reason":null},"secondmate_current":{"records":[],"truncated":0,"registry":{"available":true,"complete":true,"input_truncated":false,"records_truncated":false}},"secondmate_landed":{"records":[],"truncated":[],"unreadable":[],"partial":[]},"secondmate_guidance":{"note":"fixture"}}'
+  for field in roots backlog secondmate_landed; do
+    rc=0
+    out=$(FM_HOME="$home" FM_TEST_SNAPSHOT="$(printf '%s' "$snapshot" | jq --arg field "$field" 'del(.[$field])')" \
+      FM_FLEET_HEALTH_TIMED_WORKER=1 "$fixture/bin/fm-fleet-health.sh" --json) || rc=$?
+    expect_code 3 "$rc" "a snapshot missing $field should be incomplete"
+    printf '%s' "$out" | jq -e '
+      .status == "incomplete"
+        and .reason == "fleet snapshot was malformed"
+        and (.findings | length) == 0
+    ' >/dev/null || fail "snapshot missing $field was treated as usable: $out"
+  done
+  pass "schema-tagged snapshots require the complete top-level shape"
+}
+
+test_remote_snapshot_probe_disabled_skips_remote_state() {
+  local home fixture out rc=0 log
+  home=$(make_home remote-probe-disabled)
+  mkdir -p "$home/secondmate-home"
+  fm_write_meta "$home/state/remote-mate.meta" \
+    "window=firstmate:fm-remote-mate" \
+    "worktree=$home/secondmate-home" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "home=/remote/secondmate-home" \
+    "remote_host=example.invalid" \
+    "remote_root=/remote/firstmate"
+  printf 'working: watching scope\n' > "$home/state/remote-mate.status"
+  fixture=$(make_snapshot_fixture_root remote-probe-disabled)
+  log=$TMP_ROOT/remote-probe-disabled.log
+  out=$(PATH="$fixture/bin:$PATH" FM_HOME="$home" FM_SNAPSHOT_REMOTE_PROBES=0 \
+    FM_TEST_REMOTE_CALL_LOG="$log" "$fixture/bin/fm-fleet-snapshot.sh" --json) || rc=$?
+  expect_code 0 "$rc" "disabled remote probes should still produce a snapshot"
+  [ ! -e "$log" ] || fail "disabled remote probes invoked the remote transport"
   printf '%s' "$out" | jq -e '
-    .status == "incomplete"
-      and .reason == "fleet snapshot was malformed"
-      and (.findings | length) == 0
-  ' >/dev/null || fail "incomplete snapshot was treated as usable: $out"
-  pass "schema-tagged incomplete snapshots remain incomplete"
+    any(.tasks[]; .id == "remote-mate"
+        and .current_state.state == "unknown"
+        and .current_state.source == "remote-not-collected"
+        and .endpoint.probe == "skipped"
+        and .endpoint.agent_state == "not_collected")
+  ' >/dev/null || fail "remote current-state evidence was not explicitly unavailable: $out"
+  pass "disabled remote probes skip remote current-state collection"
 }
 
 test_dangling_state_path_is_inconclusive() {
@@ -902,6 +957,20 @@ test_incomplete_registry_does_not_break_secondmate_summary() {
   pass "incomplete registry evidence stays distinct from summary failure"
 }
 
+test_dangling_secondmate_registry_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home dangling-secondmate-registry)
+  ln -s "$home/data/missing-secondmates-target" "$home/data/secondmates.md"
+  fakebin=$(make_fakebin "$home")
+  out=$(run_health "$home" "$fakebin") || rc=$?
+  expect_code 3 "$rc" "dangling secondmate registry should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "secondmate-summary-inconclusive")
+  ' >/dev/null || fail "dangling secondmate registry was treated as healthy: $out"
+  pass "dangling secondmate registry remains unavailable"
+}
+
 test_pending_reply_uses_recorded_grace() {
   local home fakebin out rc=0
   home=$(make_home recorded-grace)
@@ -1029,6 +1098,22 @@ test_dangling_procevent_claim_root_is_inconclusive() {
   pass "dangling process-event claim root remains inconclusive"
 }
 
+test_dangling_procevent_registry_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home dangling-procevent-registry)
+  ln -s "$home/state/missing-procevent-target" "$home/state/procevent"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "dangling process-event registry should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "result-listener-inconclusive" and .subject == "procevent")
+      and (any(.findings[]; .kind == "result-listener-missing") | not)
+  ' >/dev/null || fail "dangling process-event registry was treated as healthy: $out"
+  pass "dangling process-event registry remains unavailable"
+}
+
 test_paused_ship_still_requires_pr_listener() {
   local home fakebin out rc=0
   home=$(make_home paused-pr-listener)
@@ -1153,6 +1238,25 @@ test_unreadable_supervision_lock_is_inconclusive() {
   pass "unreadable watcher-lock evidence remains inconclusive"
 }
 
+test_malformed_supervision_pid_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home malformed-supervision-pid)
+  write_live_ship "$home" supervised-worker
+  fresh_autoarm_supervision "$home"
+  mkdir -p "$home/state/.watch.lock"
+  printf 'not-a-pid\n' > "$home/state/.watch.lock/pid"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=persistent \
+    "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "malformed watcher-lock PID should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "supervision-inconclusive")
+      and (any(.findings[]; .kind == "supervision-unhealthy") | not)
+  ' >/dev/null || fail "malformed supervision PID became actionable: $out"
+  pass "malformed watcher-lock PID remains unavailable"
+}
+
 test_internal_worker_failure_returns_json() {
   local home fakebin out rc=0
   home=$(make_home internal-worker-failure)
@@ -1210,6 +1314,7 @@ test_usage_exit
 test_healthy_empty_fleet
 test_missing_state_home_remains_unmodified
 test_malformed_snapshot_is_incomplete
+test_remote_snapshot_probe_disabled_skips_remote_state
 test_dangling_state_path_is_inconclusive
 test_unsearchable_state_is_inconclusive
 test_dangling_metadata_is_inconclusive
@@ -1239,17 +1344,20 @@ test_inconclusive_secondmate_summary_not_broken
 test_invalid_secondmate_summary_uses_normalized_kind
 test_truncated_secondmate_inventory_is_inconclusive
 test_incomplete_registry_does_not_break_secondmate_summary
+test_dangling_secondmate_registry_is_inconclusive
 test_pending_reply_uses_recorded_grace
 test_invalid_pending_reply_is_inconclusive
 test_dangling_pending_reply_directory_is_inconclusive
 test_inventory_and_missing_listener
 test_invalid_procevent_registration_is_reported
 test_dangling_procevent_claim_root_is_inconclusive
+test_dangling_procevent_registry_is_inconclusive
 test_paused_ship_still_requires_pr_listener
 test_unknown_worker_state_does_not_create_missing_pr_listener
 test_matching_retired_pr_listener_is_not_missing
 test_inconclusive_dominates_actionable_status
 test_unreadable_supervision_lock_is_inconclusive
+test_malformed_supervision_pid_is_inconclusive
 test_internal_worker_failure_returns_json
 test_complete_timeout_covers_fingerprinting
 test_human_view_and_incomplete_exit

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -638,21 +638,22 @@ test_recent_done_signal_is_not_missed_handoff() {
   pass "a fresh done signal is inside the handoff stale window"
 }
 
-test_unsupported_step_complete_signal_is_not_missed_handoff() {
+test_missed_handoff_after_contracted_step_complete_signal() {
   local home fakebin out rc=0
   home=$(make_home step-complete-handoff)
   write_live_ship "$home" step-idle
-  printf 'step-complete: phase 7 complete; send the next instruction\n' > "$home/state/step-idle.status"
+  printf 'blocked: phase 7 complete; send the next instruction\n' > "$home/state/step-idle.status"
   touch -t 202001011200 "$home/state/step-idle.status"
   fresh_autoarm_supervision "$home"
   fakebin=$(make_fakebin "$home")
   out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
     FM_FLEET_HEALTH_HANDOFF_STALE_SECS=60 "$HEALTH" --json) || rc=$?
-  expect_code 3 "$rc" "unsupported step-complete signal should not change health status"
+  expect_code 1 "$rc" "contracted step-complete signal should be actionable"
   printf '%s' "$out" | jq -e '
-    (any(.findings[]; .kind == "missed-handoff" and .subject == "step-idle") | not)
-  ' >/dev/null || fail "unsupported step-complete signal became a missed handoff: $out"
-  pass "unsupported step-complete signal is not a missed handoff"
+    any(.findings[]; .kind == "missed-handoff" and .subject == "step-idle"
+        and .confidence == "high")
+  ' >/dev/null || fail "contracted step-complete missed handoff was not reported: $out"
+  pass "contracted step-complete signal is a missed handoff"
 }
 
 test_handled_inbox_corruption_is_inconclusive() {
@@ -1266,6 +1267,7 @@ test_paused_ship_still_requires_pr_listener() {
   write_live_ship "$home" paused-ship
   printf 'pr=https://github.com/example/alpha/pull/18\n' >> "$home/state/paused-ship.meta"
   printf 'paused: waiting for upstream checks\n' > "$home/state/paused-ship.status"
+  touch -t 202001011200 "$home/state/paused-ship.status"
   fresh_autoarm_supervision "$home"
   fakebin=$(make_fakebin "$home")
   out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
@@ -1273,6 +1275,7 @@ test_paused_ship_still_requires_pr_listener() {
   printf '%s' "$out" | jq -e '
     .status == "actionable"
       and any(.findings[]; .kind == "result-listener-missing" and .subject == "paused-ship")
+      and (any(.findings[]; .kind == "missed-handoff" and .subject == "paused-ship") | not)
   ' >/dev/null || fail "paused ship escaped PR-listener validation: $out"
   pass "declared waits retain their required PR listeners"
 }
@@ -1570,7 +1573,7 @@ test_live_codex_without_banner_is_not_dead_session
 test_missed_handoff_after_done_signal
 test_later_inbox_clears_missed_handoff
 test_recent_done_signal_is_not_missed_handoff
-test_unsupported_step_complete_signal_is_not_missed_handoff
+test_missed_handoff_after_contracted_step_complete_signal
 test_handled_inbox_corruption_is_inconclusive
 test_unreadable_local_endpoint_is_inconclusive
 test_terminal_unreadable_endpoint_is_inconclusive

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -134,9 +134,16 @@ SH
   printf '%s\n' "$root"
 }
 
-write_pending() {  # <home> <corr> <task> <phase> [completed_epoch] [grace] [sender-pid] [sender-identity]
+write_pending() {  # <home> <corr> <task> <phase> [completed_epoch] [grace] [sender-pid] [sender-identity] [recovery-outcome]
   local home=$1 corr=$2 task=$3 phase=$4 completed=${5-} grace=${6:-120}
-  local sender_pid=${7-} sender_identity=${8-}
+  local sender_pid=${7-} sender_identity=${8-} recovery_outcome=${9-}
+  if [ -z "$recovery_outcome" ]; then
+    case "$phase" in
+      recovery_sent) recovery_outcome=confirmed ;;
+      recovery_failed) recovery_outcome=failed ;;
+      recovery_unknown) recovery_outcome=unknown ;;
+    esac
+  fi
   mkdir -p "$home/state/pending-replies"
   cat > "$home/state/pending-replies/$corr" <<EOF
 schema=fm-pending-reply.v1
@@ -155,7 +162,7 @@ recovery_attempted_epoch=
 recovery_sender_pid=$sender_pid
 recovery_sender_identity=$sender_identity
 recovery_sent_epoch=
-recovery_delivery_outcome=
+recovery_delivery_outcome=$recovery_outcome
 recovery_turn_seen_busy=0
 recovery_turn_completed_epoch=
 escalated_epoch=
@@ -261,7 +268,7 @@ test_snapshot_task_evidence_requires_keys_and_known_states() {
   local home fixture out rc=0 mutation snapshot
   home=$(make_home malformed-task-evidence)
   fixture=$(make_health_fixture_root malformed-task-evidence)
-  snapshot='{"schema":"fm-fleet-snapshot.v1","generated":"2026-01-01T00:00:00Z","fm_home":"/tmp/home","roots":{"fm_root":"/tmp/root","state":"/tmp/state","data":"/tmp/data","config":"/tmp/config","projects":"/tmp/projects"},"backlog":{"path":"/tmp/backlog.md","present":false,"records":[]},"tasks":[{"id":"task","kind":"ship","remote":null,"current_state":{"state":"working"},"endpoint":{"agent_state":"alive","agent_alive":"alive","probe":"local","codex_session":{"resume_banner":null}},"paths":{"status_log":{"last_event":{"state":"working","handoff_required":false,"mtime_epoch":null}}},"pr":{"url":null,"source":"absent"}}],"scout_reports":[],"collection":{"state":{"present":true,"available":true,"invalid_metadata_count":0,"invalid_metadata":[]}},"main_inventory":{"valid":true,"reason":null},"secondmate_current":{"records":[],"truncated":0,"registry":{"available":true,"complete":true,"input_truncated":false,"records_truncated":false}},"secondmate_landed":{"records":[],"truncated":[],"unreadable":[],"partial":[]},"secondmate_guidance":{"note":"fixture"}}'
+  snapshot='{"schema":"fm-fleet-snapshot.v1","generated":"2026-01-01T00:00:00Z","fm_home":"/tmp/home","roots":{"fm_root":"/tmp/root","state":"/tmp/state","data":"/tmp/data","config":"/tmp/config","projects":"/tmp/projects"},"backlog":{"path":"/tmp/backlog.md","present":false,"records":[]},"tasks":[{"id":"task","kind":"ship","remote":null,"current_state":{"state":"working"},"endpoint":{"agent_state":"alive","agent_alive":"alive","probe":"local","codex_session":{"collected":true,"reason":null,"resume_banner":null}},"paths":{"status_log":{"last_event":{"state":"working","handoff_required":false,"mtime_epoch":null}}},"pr":{"url":null,"source":"absent"}}],"scout_reports":[],"collection":{"state":{"present":true,"available":true,"invalid_metadata_count":0,"invalid_metadata":[]}},"main_inventory":{"valid":true,"reason":null},"secondmate_current":{"records":[],"truncated":0,"registry":{"available":true,"complete":true,"input_truncated":false,"records_truncated":false}},"secondmate_landed":{"records":[],"truncated":[],"unreadable":[],"partial":[]},"secondmate_guidance":{"note":"fixture"}}'
   for mutation in omit-endpoint-exists invalid-state invalid-agent-state invalid-agent-alive invalid-probe; do
     if [ "$mutation" = omit-endpoint-exists ]; then
       snapshot=$(printf '%s' "$snapshot" | jq 'del(.tasks[0].endpoint.exists)')
@@ -448,6 +455,84 @@ test_codex_resume_banner_is_dead_session() {
       and (any(.findings[]; .kind == "dead-direct-report" and .subject == "codex-resume-task") | not)
   ' >/dev/null || fail "Codex resume banner was missed or duplicated: $out"
   pass "Codex resume banner is a high-confidence dead-session finding"
+}
+
+test_unverified_backend_codex_banner_is_dead_session() {
+  local home fakebin out rc=0
+  home=$(make_home codex-unverified-banner)
+  mkdir -p "$home/projects/codex-unverified-wt"
+  fm_write_meta "$home/state/codex-unverified.meta" \
+    "window=firstmate:7" \
+    "endpoint_task_id=codex-unverified" \
+    "backend=zellij" \
+    "zellij_session=firstmate" \
+    "zellij_tab_id=3" \
+    "zellij_pane_id=7" \
+    "worktree=$home/projects/codex-unverified-wt" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship" \
+    "yolo=off"
+  printf 'working: still in flight\n' > "$home/state/codex-unverified.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  cat > "$fakebin/zellij" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  "list-sessions --short --no-formatting") printf 'firstmate\n' ;;
+  *"action list-panes --json"*) printf '[{"id":7,"tab_id":3,"is_plugin":false}]\n' ;;
+  *"action list-tabs --json"*) printf '[{"tab_id":3,"name":"fm-codex-unverified"}]\n' ;;
+  *"action dump-screen --pane-id 7"*) printf 'session ended\nTo continue this session, run codex resume\n' ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$fakebin/zellij"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 1 "$rc" "Codex resume banner should override unverified backend liveness"
+  printf '%s' "$out" | jq -e '
+    .status == "actionable"
+      and any(.findings[]; .kind == "dead-codex-session" and .subject == "codex-unverified"
+              and .confidence == "high")
+      and (any(.findings[]; .kind == "endpoint-inconclusive" and .subject == "codex-unverified") | not)
+  ' >/dev/null || fail "unverified backend hid a captured Codex resume banner: $out"
+  pass "captured Codex banner overrides unverified backend liveness"
+}
+
+test_failed_codex_capture_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home codex-capture-failed)
+  mkdir -p "$home/projects/codex-capture-failed-wt"
+  fm_write_meta "$home/state/codex-capture-failed.meta" \
+    "window=firstmate:fm-codex-capture-failed" \
+    "worktree=$home/projects/codex-capture-failed-wt" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship" \
+    "yolo=off"
+  printf 'working: still in flight\n' > "$home/state/codex-capture-failed.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  list-windows) printf 'fm-codex-capture-failed\n' ;;
+  display-message)
+    case "$*" in *pane_current_command*) printf 'codex\n' ;; *) printf '%%1\n' ;; esac
+    ;;
+  capture-pane) exit 1 ;;
+esac
+SH
+  chmod +x "$fakebin/tmux"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "failed Codex pane capture should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "endpoint-inconclusive" and .subject == "codex-capture-failed")
+      and (any(.findings[]; .kind == "dead-codex-session" and .subject == "codex-capture-failed") | not)
+  ' >/dev/null || fail "failed Codex pane capture did not remain inconclusive: $out"
+  pass "failed Codex pane capture remains inconclusive"
 }
 
 test_codex_bare_shell_is_dead_session() {
@@ -890,6 +975,23 @@ SH
               and .subject == "unreadable-recovery")
   ' >/dev/null || fail "recovery_sending ownership evidence was hidden: $out"
   pass "recovery sender ownership distinguishes orphaned and unreadable"
+}
+
+test_inconsistent_recovery_outcome_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home inconsistent-recovery-outcome)
+  write_pending "$home" 3333333333333333 half-written recovery_sending "" 120 "$$" sender confirmed
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "half-written recovery outcome should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "pending-reply-inconclusive"
+              and .subject == "pending-replies"
+              and .evidence == "1 pending-reply record(s) are invalid")
+      and (any(.findings[]; .kind == "pending-reply-broken" and .subject == "half-written") | not)
+  ' >/dev/null || fail "half-written recovery outcome did not remain inconclusive: $out"
+  pass "half-written recovery outcomes remain inconclusive"
 }
 
 test_inconclusive_secondmate_summary_not_broken() {
@@ -1461,6 +1563,8 @@ test_unsearchable_nested_inventories_are_inconclusive
 test_actionable_dead_direct_report
 test_dead_agent_with_live_endpoint
 test_codex_resume_banner_is_dead_session
+test_unverified_backend_codex_banner_is_dead_session
+test_failed_codex_capture_is_inconclusive
 test_codex_bare_shell_is_dead_session
 test_live_codex_without_banner_is_not_dead_session
 test_missed_handoff_after_done_signal
@@ -1479,6 +1583,7 @@ test_unknown_worker_state_is_inconclusive
 test_registry_only_remote_evidence_is_inconclusive
 test_pending_reply_broken_and_historical_noise_omitted
 test_recovery_sending_owner_verdicts
+test_inconsistent_recovery_outcome_is_inconclusive
 test_inconclusive_secondmate_summary_not_broken
 test_invalid_secondmate_summary_uses_normalized_kind
 test_truncated_secondmate_inventory_is_inconclusive

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -285,6 +285,53 @@ test_unreadable_local_endpoint_is_inconclusive() {
   pass "unreadable local endpoint evidence remains inconclusive"
 }
 
+test_terminal_unreadable_endpoint_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home terminal-unreadable-endpoint)
+  mkdir -p "$home/projects/terminal-unreadable-wt"
+  fm_write_meta "$home/state/terminal-unreadable.meta" \
+    "backend=herdr" \
+    "window=malformed-herdr-target" \
+    "worktree=$home/projects/terminal-unreadable-wt" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship"
+  printf 'done: worker completed\n' > "$home/state/terminal-unreadable.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "terminal worker with unreadable endpoint evidence should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "endpoint-inconclusive"
+              and .subject == "terminal-unreadable")
+      and (any(.findings[]; .kind == "terminal-needs-cleanup"
+               and .subject == "terminal-unreadable") | not)
+  ' >/dev/null || fail "terminal unreadable endpoint evidence disappeared: $out"
+  pass "terminal endpoint uncertainty remains inconclusive"
+}
+
+test_historical_status_pr_does_not_require_listener() {
+  local home fakebin out rc=0
+  home=$(make_home historical-status-pr)
+  write_live_ship "$home" historical-pr
+  cat > "$home/state/historical-pr.status" <<'EOF'
+update: old delivery was https://github.com/example/alpha/pull/7
+working: implementing the current delivery
+EOF
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 0 "$rc" "historical status PR should not require a current listener"
+  printf '%s' "$out" | jq -e '
+    .status == "healthy"
+      and (any(.findings[]; .kind == "result-listener-missing"
+               and .subject == "historical-pr") | not)
+  ' >/dev/null || fail "historical status PR created a listener requirement: $out"
+  pass "historical status PR events do not require current listeners"
+}
+
 test_grouped_inbox_and_stable_fingerprints() {
   local home fakebin out1 out2 rc=0 fp1 fp2 count
   home=$(make_home grouped-inbox)
@@ -558,6 +605,23 @@ EOF
   pass "inconsistent inventory and missing listeners are actionable"
 }
 
+test_invalid_procevent_registration_is_reported() {
+  local home fakebin out rc=0
+  home=$(make_home invalid-procevent-registration)
+  mkdir -p "$home/state/procevent/broken.source"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 1 "$rc" "structurally invalid process-event registration should be actionable"
+  printf '%s' "$out" | jq -e '
+    .status == "actionable"
+      and any(.findings[]; .kind == "result-listener-missing"
+              and .subject == "broken"
+              and (.evidence | contains("owner=invalid")))
+  ' >/dev/null || fail "invalid process-event registration was hidden: $out"
+  pass "invalid process-event registrations remain visible"
+}
+
 test_paused_ship_still_requires_pr_listener() {
   local home fakebin out rc=0
   home=$(make_home paused-pr-listener)
@@ -642,6 +706,8 @@ test_unsearchable_nested_inventories_are_inconclusive
 test_actionable_dead_direct_report
 test_dead_agent_with_live_endpoint
 test_unreadable_local_endpoint_is_inconclusive
+test_terminal_unreadable_endpoint_is_inconclusive
+test_historical_status_pr_does_not_require_listener
 test_grouped_inbox_and_stable_fingerprints
 test_remote_liveness_is_inconclusive
 test_pending_reply_broken_and_historical_noise_omitted
@@ -652,6 +718,7 @@ test_incomplete_registry_does_not_break_secondmate_summary
 test_pending_reply_uses_recorded_grace
 test_invalid_pending_reply_is_inconclusive
 test_inventory_and_missing_listener
+test_invalid_procevent_registration_is_reported
 test_paused_ship_still_requires_pr_listener
 test_inconclusive_dominates_actionable_status
 test_complete_timeout_covers_fingerprinting

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -694,6 +694,28 @@ test_handled_inbox_corruption_is_inconclusive() {
   pass "corrupt handled inbox evidence remains inconclusive"
 }
 
+test_unrelated_inbox_corruption_preserves_missed_handoff() {
+  local home fakebin out rc=0
+  home=$(make_home unrelated-inbox-corruption)
+  write_live_ship "$home" stale-task
+  write_live_ship "$home" corrupt-task
+  printf 'done: ready for the next step\n' > "$home/state/stale-task.status"
+  touch -t 202001011200 "$home/state/stale-task.status"
+  mkdir -p "$home/state/corrupt-task.inbox/handled"
+  printf 'not a task inbox record\n' > "$home/state/corrupt-task.inbox/handled/001.msg"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    FM_FLEET_HEALTH_HANDOFF_STALE_SECS=60 "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "unrelated inbox corruption should preserve actionable and inconclusive findings"
+  printf '%s' "$out" | jq -e '
+    any(.findings[]; .kind == "steering-inbox-inconclusive")
+      and any(.findings[]; .kind == "missed-handoff" and .subject == "stale-task")
+      and (any(.findings[]; .kind == "missed-handoff-inconclusive" and .subject == "stale-task") | not)
+  ' >/dev/null || fail "unrelated inbox corruption suppressed a proven missed handoff: $out"
+  pass "unrelated inbox corruption does not suppress proven handoffs"
+}
+
 test_unreadable_local_endpoint_is_inconclusive() {
   local home fakebin out rc=0
   home=$(make_home unreadable-local-endpoint)
@@ -1592,6 +1614,7 @@ test_recent_done_signal_is_not_missed_handoff
 test_missed_handoff_after_contracted_step_complete_signal
 test_captain_decision_wait_is_not_missed_handoff
 test_handled_inbox_corruption_is_inconclusive
+test_unrelated_inbox_corruption_preserves_missed_handoff
 test_unreadable_local_endpoint_is_inconclusive
 test_terminal_unreadable_endpoint_is_inconclusive
 test_historical_status_pr_does_not_require_listener

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -750,6 +750,36 @@ test_paused_ship_still_requires_pr_listener() {
   pass "declared waits retain their required PR listeners"
 }
 
+test_matching_retired_pr_listener_is_not_missing() {
+  local home fakebin marker out rc=0
+  home=$(make_home retired-pr-listener)
+  write_live_ship "$home" retired-pr
+  printf 'pr=https://github.com/example/alpha/pull/19\n' >> "$home/state/retired-pr.meta"
+  marker="$home/state/retired-pr.pr-poll-merge-notified"
+  printf '%s\n' fm-pr-poll-merge-notified-v1 github github.com example/alpha 19 > "$marker"
+  chmod 0600 "$marker"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 0 "$rc" "matching terminal PR notification should retire the listener requirement"
+  printf '%s' "$out" | jq -e '
+    .status == "healthy"
+      and (any(.findings[]; .kind == "result-listener-missing"
+               and .subject == "retired-pr") | not)
+  ' >/dev/null || fail "matching retired PR listener was reported missing: $out"
+
+  printf '%s\n' fm-pr-poll-merge-notified-v1 github github.com example/alpha 18 > "$marker"
+  rc=0
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 1 "$rc" "a terminal notification for another PR must not retire the current listener"
+  printf '%s' "$out" | jq -e '
+    .status == "actionable"
+      and any(.findings[]; .kind == "result-listener-missing"
+              and .subject == "retired-pr")
+  ' >/dev/null || fail "mismatched terminal PR notification suppressed a missing listener: $out"
+  pass "only matching terminal PR notifications retire listener requirements"
+}
+
 test_inconclusive_dominates_actionable_status() {
   local home fakebin out rc=0
   home=$(make_home mixed-confidence)
@@ -876,6 +906,7 @@ test_invalid_pending_reply_is_inconclusive
 test_inventory_and_missing_listener
 test_invalid_procevent_registration_is_reported
 test_paused_ship_still_requires_pr_listener
+test_matching_retired_pr_listener_is_not_missing
 test_inconclusive_dominates_actionable_status
 test_unreadable_supervision_lock_is_inconclusive
 test_internal_worker_failure_returns_json

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -96,7 +96,7 @@ run_health() {  # <home> <fakebin>
 }
 
 make_health_fixture_root() {  # <name>
-  local name=$1 root=$TMP_ROOT/health-command-$1 source base
+  local root=$TMP_ROOT/health-command-$1 source base
   mkdir -p "$root/bin"
   cp "$HEALTH" "$root/bin/fm-fleet-health.sh"
   for source in "$ROOT"/bin/*.sh; do
@@ -115,7 +115,7 @@ SH
 }
 
 make_snapshot_fixture_root() {  # <name>
-  local name=$1 root=$TMP_ROOT/snapshot-command-$1 source base
+  local root=$TMP_ROOT/snapshot-command-$1 source base
   mkdir -p "$root/bin"
   cp "$ROOT/bin/fm-fleet-snapshot.sh" "$root/bin/fm-fleet-snapshot.sh"
   for source in "$ROOT"/bin/*.sh; do

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# Behavior tests for the read-only fleet health checker.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=bin/fm-task-inbox-lib.sh
+# shellcheck disable=SC1091
+. "$ROOT/bin/fm-task-inbox-lib.sh"
+
+HEALTH="$ROOT/bin/fm-fleet-health.sh"
+TMP_ROOT=$(fm_test_tmproot fm-fleet-health)
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+export FM_SUPERVISION_MODEL=persistent
+export FM_GUARD_GRACE=300
+export FM_TASK_INBOX_GRACE_SECS=90
+export FM_PENDING_REPLY_GRACE_SECS=120
+
+make_fakebin() {  # <dir>
+  local fb
+  fb=$(fm_fakebin "$1")
+  cat > "$fb/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+target=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-t" ]; then target=$arg; fi
+  prev=$arg
+done
+listed_windows() {
+  if [ -f "${FM_HOME:?}/state/.fake-windows" ]; then
+    cat "${FM_HOME}/state/.fake-windows"
+  else
+    sed -n 's/^window=[^:]*://p' "${FM_HOME:?}"/state/*.meta 2>/dev/null
+  fi
+}
+window_present() {
+  local w
+  while IFS= read -r w; do
+    [ -n "$w" ] || continue
+    case "$target" in
+      *"$w"*) return 0 ;;
+    esac
+  done <<EOF
+$(listed_windows)
+EOF
+  return 1
+}
+case "${1:-}" in
+  list-windows)
+    listed_windows
+    ;;
+  display-message)
+    window_present || exit 1
+    case "$*" in
+      *pane_current_command*)
+        case "$target" in
+          *dead*) printf 'zsh\n' ;;
+          *) printf 'codex\n' ;;
+        esac
+        ;;
+      *) printf '%%1\n' ;;
+    esac
+    ;;
+  capture-pane)
+    window_present || exit 1
+    printf 'work in progress\nesc to interrupt\n'
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/no-mistakes" "$fb/tmux"
+  printf '%s\n' "$fb"
+}
+
+make_home() {  # <name>
+  local home=$TMP_ROOT/$1
+  mkdir -p "$home/state" "$home/data" "$home/projects" "$home/config"
+  printf '%s\n' "$home"
+}
+
+run_health() {  # <home> <fakebin>
+  PATH="$2:$PATH" FM_HOME="$1" "$HEALTH" --json
+}
+
+write_pending() {  # <home> <corr> <task> <phase> [completed_epoch]
+  local home=$1 corr=$2 task=$3 phase=$4 completed=${5-}
+  mkdir -p "$home/state/pending-replies"
+  cat > "$home/state/pending-replies/$corr" <<EOF
+schema=fm-pending-reply.v1
+corr_id=$corr
+task_id=$task
+parent_home=$home
+parent_status=$home/state/${task}.status
+parent_status_scan_signature=
+request_summary=ping
+created_epoch=1000
+delivered_epoch=1001
+phase=$phase
+turn_seen_busy=1
+request_turn_completed_epoch=$completed
+recovery_attempted_epoch=
+recovery_sender_pid=
+recovery_sender_identity=
+recovery_sent_epoch=
+recovery_delivery_outcome=
+recovery_turn_seen_busy=0
+recovery_turn_completed_epoch=
+escalated_epoch=
+escalation_closed_epoch=
+resolved_epoch=
+resolved_via=
+wrong_home_hits=0
+wrong_home_sightings=
+wrong_home_scan_signature=
+grace_secs=120
+EOF
+}
+
+write_live_ship() {  # <home> <id>
+  local home=$1 id=$2
+  mkdir -p "$home/projects/${id}-wt"
+  fm_write_meta "$home/state/${id}.meta" \
+    "window=firstmate:fm-${id}" \
+    "worktree=$home/projects/${id}-wt" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship" \
+    "yolo=off"
+  printf 'working: implementing\n' > "$home/state/${id}.status"
+}
+
+fresh_autoarm_supervision() {  # <home>
+  touch "$1/state/.last-watcher-beat"
+}
+
+kinds_of() {  # <json>
+  printf '%s' "$1" | jq -r '[.findings[].kind] | join(",")'
+}
+
+test_usage_exit() {
+  local rc=0
+  "$HEALTH" --nope >/dev/null 2>&1 || rc=$?
+  expect_code 2 "$rc" "unknown flag must be a usage error"
+  pass "usage errors exit 2"
+}
+
+test_healthy_empty_fleet() {
+  local home fakebin out rc=0
+  home=$(make_home healthy)
+  fakebin=$(make_fakebin "$home")
+  out=$(run_health "$home" "$fakebin") || rc=$?
+  expect_code 0 "$rc" "empty fleet should be healthy"
+  printf '%s' "$out" | jq -e '
+    .schema == "fm-fleet-health.v1"
+      and .status == "healthy"
+      and (.findings | length) == 0
+  ' >/dev/null || fail "empty fleet health JSON wrong: $out"
+  pass "empty fleet is healthy with no findings"
+}
+
+test_actionable_dead_direct_report() {
+  local home fakebin out rc=0
+  home=$(make_home dead-agent)
+  write_live_ship "$home" ship-task
+  : > "$home/state/.fake-windows"
+  fakebin=$(make_fakebin "$home")
+  out=$(run_health "$home" "$fakebin") || rc=$?
+  expect_code 1 "$rc" "dead direct report should be actionable"
+  printf '%s' "$out" | jq -e '
+    .status == "actionable"
+      and any(.findings[]; .kind == "dead-direct-report" and .subject == "ship-task" and .confidence == "high")
+  ' >/dev/null || fail "dead direct report missing: $out"
+  pass "dead local worker is an actionable finding"
+}
+
+test_grouped_inbox_and_stable_fingerprints() {
+  local home fakebin out1 out2 rc=0 fp1 fp2 count
+  home=$(make_home grouped-inbox)
+  write_live_ship "$home" steer-task
+  fakebin=$(make_fakebin "$home")
+  PATH="$fakebin:$PATH" FM_HOME="$home" \
+    fm_task_inbox_write "$home/state" steer-task "first steer" >/dev/null
+  PATH="$fakebin:$PATH" FM_HOME="$home" \
+    fm_task_inbox_write "$home/state" steer-task "second steer" >/dev/null
+  touch -t 202001011200 "$home/state/steer-task.inbox/"*.msg
+  out1=$(run_health "$home" "$fakebin") || rc=$?
+  expect_code 1 "$rc" "aged inbox should be actionable"
+  count=$(printf '%s' "$out1" | jq '[.findings[] | select(.kind == "steering-inbox-aged")] | length')
+  [ "$count" = 1 ] || fail "aged inbox findings were not grouped, count=$count: $out1"
+  printf '%s' "$out1" | jq -e '
+    .findings[] | select(.kind == "steering-inbox-aged")
+    | .subject == "steer-task" and .count == 2
+  ' >/dev/null || fail "grouped inbox count wrong: $out1"
+  fp1=$(printf '%s' "$out1" | jq -r '.findings[] | select(.kind == "steering-inbox-aged") | .fingerprint')
+  out2=$(run_health "$home" "$fakebin")
+  fp2=$(printf '%s' "$out2" | jq -r '.findings[] | select(.kind == "steering-inbox-aged") | .fingerprint')
+  [ "$fp1" = "$fp2" ] || fail "fingerprints were not stable: $fp1 vs $fp2"
+  case "$fp1" in sha256:*) ;; *) fail "fingerprint is not sha256-prefixed: $fp1" ;; esac
+  pass "aged inbox messages group by task and keep a stable fingerprint"
+}
+
+test_remote_liveness_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home remote-liveness)
+  mkdir -p "$home/secondmate-home"
+  cat > "$home/data/secondmates.md" <<'EOF'
+- remote-mate (host: example.invalid; root: /remote/firstmate; home: /remote/secondmate-home; scope: remote work; projects: alpha; added 2026-08-01)
+EOF
+  fm_write_meta "$home/state/remote-mate.meta" \
+    "window=firstmate:fm-remote-mate" \
+    "worktree=$home/secondmate-home" \
+    "project=$home/secondmate-home" \
+    "harness=codex" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "home=/remote/secondmate-home" \
+    "remote_host=example.invalid" \
+    "remote_root=/remote/firstmate" \
+    "projects=alpha"
+  printf 'working: watching delegated scope\n' > "$home/state/remote-mate.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 0 "$rc" "inconclusive remote liveness is not actionable"
+  printf '%s' "$out" | jq -e '
+    .status == "healthy"
+      and any(.findings[]; .kind == "remote-liveness-inconclusive" and .subject == "remote-mate" and .confidence == "inconclusive")
+      and (any(.findings[]; .kind == "dead-secondmate") | not)
+      and (any(.findings[]; .kind == "dead-direct-report") | not)
+  ' >/dev/null || fail "remote placeholder was treated as authoritative liveness: $out"
+  pass "remote local placeholder is inconclusive, not healthy or dead"
+}
+
+test_pending_reply_broken_and_historical_noise_omitted() {
+  local home fakebin out
+  home=$(make_home reply-and-noise)
+  write_live_ship "$home" attorney-data
+  write_pending "$home" abcdabcdabcdabcd attorney-data delivery_unknown
+  write_pending "$home" 1234123412341234 attorney-data recovery_failed
+  mkdir -p "$home/projects/noise-wt"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] attorney-data - Attorney Data (repo: alpha) (kind: ship) (since 2026-08-01)
+
+## Queued
+- [ ] recruit-magic - RecruitMagic blocked-by: attorney-data (repo: alpha) (kind: ship) (hold: waiting on product) (hold-kind: captain) (since 2026-08-02)
+
+## Done
+EOF
+  printf 'working: ping\n' > "$home/state/attorney-data.status"
+  printf 'needs-decision [key=shape]: choose an API\n' >> "$home/state/attorney-data.status"
+  printf 'working: still going\n' >> "$home/state/attorney-data.status"
+  printf 'working: another historical reply event\n' >> "$home/state/attorney-data.status"
+  fakebin=$(make_fakebin "$home")
+  out=$(run_health "$home" "$fakebin")
+  printf '%s' "$out" | jq -e '
+    ([.findings[] | select(.kind == "pending-reply-broken")] | length) == 1
+      and (.findings[] | select(.kind == "pending-reply-broken") | .subject == "attorney-data" and .count == 2)
+      and (any(.findings[]; .kind == "pending-reply-broken") )
+      and (any(.findings[]; .subject == "recruit-magic") | not)
+  ' >/dev/null || fail "historical events or product blockers leaked into health: $out"
+  kinds=$(kinds_of "$out")
+  case "$kinds" in
+    *recruit*) fail "queued product blocker appeared in health kinds: $kinds" ;;
+  esac
+  pass "broken replies group by owner and product blockers stay out"
+}
+
+test_inconclusive_secondmate_summary_not_broken() {
+  local home fakebin out rc=0
+  home=$(make_home remote-summary)
+  mkdir -p "$home/secondmate-home"
+  cat > "$home/data/secondmates.md" <<'EOF'
+- remote-mate (host: example.invalid; root: /remote/firstmate; home: /remote/secondmate-home; scope: remote work; projects: alpha; added 2026-08-01)
+EOF
+  fm_write_meta "$home/state/remote-mate.meta" \
+    "window=firstmate:fm-remote-mate" \
+    "worktree=$home/secondmate-home" \
+    "project=$home/secondmate-home" \
+    "harness=codex" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "home=/remote/secondmate-home" \
+    "remote_host=example.invalid" \
+    "remote_root=/remote/firstmate" \
+    "projects=alpha"
+  printf 'working: watching delegated scope\n' > "$home/state/remote-mate.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 0 "$rc" "uncollected remote summary is not a definite break"
+  printf '%s' "$out" | jq -e '
+    any(.findings[]; .kind == "remote-liveness-inconclusive" and .confidence == "inconclusive")
+      and (any(.findings[]; .kind == "secondmate-summary-invalid") | not)
+      and (any(.findings[]; .kind == "secondmate-summary-unavailable" and .confidence == "high") | not)
+  ' >/dev/null || fail "uncollected remote summary was marked broken: $out"
+  pass "uncollected remote secondmate summary is inconclusive"
+}
+
+test_inventory_and_missing_listener() {
+  local home fakebin out
+  home=$(make_home inventory)
+  mkdir -p "$home/projects/pr-ship-wt"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] orphan-work - Orphan Work (repo: alpha) (kind: ship) (since 2026-08-01)
+- [ ] pr-ship - PR Ship https://github.com/example/alpha/pull/9 (repo: alpha) (kind: ship) (since 2026-08-01)
+
+## Queued
+## Done
+EOF
+  fm_write_meta "$home/state/pr-ship.meta" \
+    "window=firstmate:fm-pr-ship" \
+    "worktree=$home/projects/pr-ship-wt" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship" \
+    "yolo=off" \
+    "pr=https://github.com/example/alpha/pull/9"
+  printf 'working: waiting on CI\n' > "$home/state/pr-ship.status"
+  mkdir -p "$home/state/procevent"
+  printf 'adapter=lavish\nargc=1\nargv:\npoll\n' > "$home/state/procevent/board-src.source"
+  fakebin=$(make_fakebin "$home")
+  out=$(run_health "$home" "$fakebin")
+  printf '%s' "$out" | jq -e '
+    .status == "actionable"
+      and any(.findings[]; .kind == "inventory-inconsistent")
+      and any(.findings[]; .kind == "result-listener-missing" and .subject == "pr-ship")
+      and any(.findings[]; .kind == "result-listener-missing" and .subject == "board-src")
+  ' >/dev/null || fail "inventory or listener findings missing: $out"
+  view=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$HEALTH") || true
+  assert_contains "$view" "result-listener-missing" "human view must print listener findings"
+  assert_contains "$view" "inventory-inconsistent" "human view must print inventory findings"
+  pass "inconsistent inventory and missing listeners are actionable"
+}
+
+test_human_view_and_incomplete_exit() {
+  local home fakebin view rc=0
+  home=$(make_home human)
+  fakebin=$(make_fakebin "$home")
+  view=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$HEALTH") || rc=$?
+  expect_code 0 "$rc" "healthy human view should exit 0"
+  assert_contains "$view" "Status: healthy" "human view should print status"
+  rc=0
+  "$HEALTH" --bogus >/dev/null 2>&1 || rc=$?
+  expect_code 2 "$rc" "human usage error still exits 2"
+  pass "human view and usage exit semantics hold"
+}
+
+test_usage_exit
+test_healthy_empty_fleet
+test_actionable_dead_direct_report
+test_grouped_inbox_and_stable_fingerprints
+test_remote_liveness_is_inconclusive
+test_pending_reply_broken_and_historical_noise_omitted
+test_inconclusive_secondmate_summary_not_broken
+test_inventory_and_missing_listener
+test_human_view_and_incomplete_exit

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -136,7 +136,7 @@ write_live_ship() {  # <home> <id>
     "window=firstmate:fm-${id}" \
     "worktree=$home/projects/${id}-wt" \
     "project=alpha" \
-    "harness=codex" \
+    "harness=grok" \
     "kind=ship" \
     "mode=ship" \
     "yolo=off"
@@ -433,6 +433,46 @@ EOF
   pass "remote local placeholder is inconclusive, not healthy or dead"
 }
 
+test_unknown_worker_state_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home unknown-worker-state)
+  mkdir -p "$home/projects/paused-unknown-wt"
+  fm_write_meta "$home/state/paused-unknown.meta" \
+    "window=firstmate:fm-paused-unknown" \
+    "worktree=$home/projects/paused-unknown-wt" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship" \
+    "yolo=off"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "unknown worker lifecycle state should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "current-state-inconclusive"
+              and .subject == "paused-unknown" and .confidence == "inconclusive")
+  ' >/dev/null || fail "unknown worker lifecycle state was hidden: $out"
+  pass "unknown worker lifecycle state remains inconclusive"
+}
+
+test_registry_only_remote_evidence_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home registry-only-remote)
+  cat > "$home/data/secondmates.md" <<'EOF'
+- registry-only (host: example.invalid; root: /remote/firstmate; home: /remote/registry-only; scope: remote work; projects: alpha; added 2026-08-01)
+EOF
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "registry-only remote evidence should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and ([.findings[] | select(.kind == "remote-liveness-inconclusive"
+                                 and .subject == "registry-only")] | length) == 1
+  ' >/dev/null || fail "registry-only remote evidence was hidden or duplicated: $out"
+  pass "registry-only remote evidence remains grouped and inconclusive"
+}
+
 test_pending_reply_broken_and_historical_noise_omitted() {
   local home fakebin out
   home=$(make_home reply-and-noise)
@@ -652,7 +692,7 @@ EOF
     "window=firstmate:fm-pr-ship" \
     "worktree=$home/projects/pr-ship-wt" \
     "project=alpha" \
-    "harness=codex" \
+    "harness=grok" \
     "kind=ship" \
     "mode=ship" \
     "yolo=off" \
@@ -823,6 +863,8 @@ test_historical_status_pr_does_not_require_listener
 test_grouped_inbox_and_stable_fingerprints
 test_invalid_inbox_records_are_inconclusive
 test_remote_liveness_is_inconclusive
+test_unknown_worker_state_is_inconclusive
+test_registry_only_remote_evidence_is_inconclusive
 test_pending_reply_broken_and_historical_noise_omitted
 test_recovery_sending_owner_verdicts
 test_inconclusive_secondmate_summary_not_broken

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -201,6 +201,35 @@ test_unsearchable_state_is_inconclusive() {
   pass "unsearchable state inventory remains inconclusive"
 }
 
+test_unsearchable_nested_inventories_are_inconclusive() {
+  local home fakebin claim_root out rc=0
+  home=$(make_home unsearchable-nested)
+  claim_root="$home/procevent-claims"
+  mkdir -p "$home/state/pending-replies" "$home/state/hidden.inbox" \
+    "$home/state/procevent" "$claim_root"
+  printf 'adapter=lavish\nargc=1\nargv:\ntrue\n' > "$home/state/procevent/hidden.source"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  chmod 400 "$home/state/pending-replies" "$home/state/hidden.inbox" \
+    "$home/state/procevent" "$claim_root"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    FM_PROCEVENT_CLAIM_ROOT="$claim_root" "$HEALTH" --json) || rc=$?
+  chmod 700 "$home/state/pending-replies" "$home/state/hidden.inbox" \
+    "$home/state/procevent" "$claim_root"
+  expect_code 3 "$rc" "unsearchable nested inventories should make health inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "pending-reply-inconclusive")
+      and any(.findings[]; .kind == "steering-inbox-inconclusive")
+      and any(.findings[]; .kind == "result-listener-inconclusive"
+              and .subject == "procevent")
+      and (any(.findings[]; .kind == "pending-reply-broken") | not)
+      and (any(.findings[]; .kind == "result-listener-missing"
+               and .subject == "hidden") | not)
+  ' >/dev/null || fail "nested inaccessible evidence was treated as healthy or broken: $out"
+  pass "nested inventory access failures remain inconclusive"
+}
+
 test_actionable_dead_direct_report() {
   local home fakebin out rc=0
   home=$(make_home dead-agent)
@@ -609,6 +638,7 @@ test_usage_exit
 test_healthy_empty_fleet
 test_missing_state_home_remains_unmodified
 test_unsearchable_state_is_inconclusive
+test_unsearchable_nested_inventories_are_inconclusive
 test_actionable_dead_direct_report
 test_dead_agent_with_live_endpoint
 test_unreadable_local_endpoint_is_inconclusive

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -201,6 +201,16 @@ test_usage_exit() {
   pass "usage errors exit 2"
 }
 
+test_invalid_handoff_threshold_is_usage_error() {
+  local home fakebin rc=0
+  home=$(make_home invalid-handoff-threshold)
+  fakebin=$(make_fakebin "$home")
+  FM_HOME="$home" PATH="$fakebin:$PATH" \
+    FM_FLEET_HEALTH_HANDOFF_STALE_SECS=not-a-number "$HEALTH" --json >/dev/null 2>&1 || rc=$?
+  expect_code 2 "$rc" "invalid handoff threshold should be a usage error"
+  pass "invalid handoff threshold retains usage-error semantics"
+}
+
 test_healthy_empty_fleet() {
   local home fakebin out rc=0
   home=$(make_home healthy)
@@ -543,7 +553,7 @@ test_recent_done_signal_is_not_missed_handoff() {
   pass "a fresh done signal is inside the handoff stale window"
 }
 
-test_missed_handoff_after_step_complete_signal() {
+test_unsupported_step_complete_signal_is_not_missed_handoff() {
   local home fakebin out rc=0
   home=$(make_home step-complete-handoff)
   write_live_ship "$home" step-idle
@@ -553,12 +563,11 @@ test_missed_handoff_after_step_complete_signal() {
   fakebin=$(make_fakebin "$home")
   out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
     FM_FLEET_HEALTH_HANDOFF_STALE_SECS=60 "$HEALTH" --json) || rc=$?
-  expect_code 3 "$rc" "stale step-complete signal should remain inconclusive when lifecycle state is unknown"
+  expect_code 3 "$rc" "unsupported step-complete signal should not change health status"
   printf '%s' "$out" | jq -e '
-    any(.findings[]; .kind == "missed-handoff" and .subject == "step-idle"
-        and .confidence == "high")
-  ' >/dev/null || fail "step-complete missed handoff was not reported: $out"
-  pass "stale step-complete signal is a missed handoff"
+    (any(.findings[]; .kind == "missed-handoff" and .subject == "step-idle") | not)
+  ' >/dev/null || fail "unsupported step-complete signal became a missed handoff: $out"
+  pass "unsupported step-complete signal is not a missed handoff"
 }
 
 test_handled_inbox_corruption_is_inconclusive() {
@@ -1337,6 +1346,25 @@ test_malformed_supervision_pid_is_inconclusive() {
   pass "malformed watcher-lock PID remains unavailable"
 }
 
+test_unreadable_supervision_beacon_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home unreadable-supervision-beacon)
+  write_live_ship "$home" supervised-worker
+  fresh_autoarm_supervision "$home"
+  rm "$home/state/.last-watcher-beat"
+  ln -s "$home/state/missing-beacon" "$home/state/.last-watcher-beat"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=persistent \
+    "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "unreadable watcher beacon should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "supervision-inconclusive")
+      and (any(.findings[]; .kind == "supervision-unhealthy") | not)
+  ' >/dev/null || fail "unreadable supervision beacon became actionable: $out"
+  pass "unreadable watcher beacon remains inconclusive"
+}
+
 test_incomplete_supervision_lock_is_inconclusive() {
   local home fakebin out rc=0 watcher_pid identity
   home=$(make_home incomplete-supervision-lock)
@@ -1420,6 +1448,7 @@ test_human_view_and_incomplete_exit() {
 }
 
 test_usage_exit
+test_invalid_handoff_threshold_is_usage_error
 test_healthy_empty_fleet
 test_missing_state_home_remains_unmodified
 test_malformed_snapshot_is_incomplete
@@ -1437,7 +1466,7 @@ test_live_codex_without_banner_is_not_dead_session
 test_missed_handoff_after_done_signal
 test_later_inbox_clears_missed_handoff
 test_recent_done_signal_is_not_missed_handoff
-test_missed_handoff_after_step_complete_signal
+test_unsupported_step_complete_signal_is_not_missed_handoff
 test_handled_inbox_corruption_is_inconclusive
 test_unreadable_local_endpoint_is_inconclusive
 test_terminal_unreadable_endpoint_is_inconclusive
@@ -1470,6 +1499,7 @@ test_matching_retired_pr_listener_is_not_missing
 test_inconclusive_dominates_actionable_status
 test_unreadable_supervision_lock_is_inconclusive
 test_malformed_supervision_pid_is_inconclusive
+test_unreadable_supervision_beacon_is_inconclusive
 test_incomplete_supervision_lock_is_inconclusive
 test_internal_worker_failure_returns_json
 test_complete_timeout_covers_fingerprinting

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -73,6 +73,7 @@ case "${1:-}" in
   capture-pane)
     window_present || exit 1
     case "$target" in
+      *codex-resume*) printf 'session ended\nTo continue this session, run codex resume\n' ;;
       *paused*) printf 'all quiet\n> \n' ;;
       *) printf 'work in progress\nesc to interrupt\n' ;;
     esac
@@ -294,6 +295,136 @@ test_dead_agent_with_live_endpoint() {
         and .evidence == "direct-report agent is dead while its endpoint remains present")
   ' >/dev/null || fail "dead agent behind live endpoint was missed: $out"
   pass "dead agent is detected even when its endpoint remains present"
+}
+
+test_codex_resume_banner_is_dead_session() {
+  local home fakebin out rc=0
+  home=$(make_home codex-resume-banner)
+  mkdir -p "$home/projects/codex-resume-wt"
+  fm_write_meta "$home/state/codex-resume-task.meta" \
+    "window=firstmate:fm-codex-resume-task" \
+    "worktree=$home/projects/codex-resume-wt" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship" \
+    "yolo=off"
+  printf 'working: still in flight\n' > "$home/state/codex-resume-task.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 1 "$rc" "Codex resume banner should be an actionable dead session"
+  printf '%s' "$out" | jq -e '
+    .status == "actionable"
+      and any(.findings[]; .kind == "dead-codex-session" and .subject == "codex-resume-task"
+              and .confidence == "high"
+              and .evidence == "Codex session exited; pane contains the resume banner")
+      and (any(.findings[]; .kind == "dead-direct-report" and .subject == "codex-resume-task") | not)
+  ' >/dev/null || fail "Codex resume banner was missed or duplicated: $out"
+  pass "Codex resume banner is a high-confidence dead-session finding"
+}
+
+test_codex_bare_shell_is_dead_session() {
+  local home fakebin out rc=0
+  home=$(make_home codex-bare-shell)
+  mkdir -p "$home/projects/dead-codex-wt"
+  fm_write_meta "$home/state/dead-codex.meta" \
+    "window=firstmate:fm-dead-codex" \
+    "worktree=$home/projects/dead-codex-wt" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship" \
+    "yolo=off"
+  printf 'working: still in flight\n' > "$home/state/dead-codex.status"
+  printf 'fm-dead-codex\n' > "$home/state/.fake-windows"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 1 "$rc" "Codex bare-shell pane should be an actionable dead session"
+  printf '%s' "$out" | jq -e '
+    any(.findings[]; .kind == "dead-codex-session" and .subject == "dead-codex"
+        and .confidence == "high"
+        and .evidence == "Codex session exited; endpoint pane is a bare shell")
+      and (any(.findings[]; .kind == "dead-direct-report" and .subject == "dead-codex") | not)
+  ' >/dev/null || fail "Codex bare-shell session was missed or classified generically: $out"
+  pass "Codex bare-shell pane is a high-confidence dead-session finding"
+}
+
+test_live_codex_without_banner_is_not_dead_session() {
+  local home fakebin out rc=0
+  home=$(make_home live-codex)
+  mkdir -p "$home/projects/codex-live-wt"
+  fm_write_meta "$home/state/codex-live.meta" \
+    "window=firstmate:fm-codex-live" \
+    "worktree=$home/projects/codex-live-wt" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship" \
+    "yolo=off"
+  printf 'working: implementing\n' > "$home/state/codex-live.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "live Codex without resume banner keeps unknown lifecycle inconclusive"
+  printf '%s' "$out" | jq -e '
+    (any(.findings[]; .kind == "dead-codex-session") | not)
+      and any(.findings[]; .kind == "current-state-inconclusive" and .subject == "codex-live")
+  ' >/dev/null || fail "live Codex was reported as a dead session or lost unknown-state evidence: $out"
+  pass "live Codex without resume banner is not a dead-session finding"
+}
+
+test_missed_handoff_after_done_signal() {
+  local home fakebin out rc=0
+  home=$(make_home missed-handoff)
+  write_live_ship "$home" done-idle
+  printf 'done: PR https://example.test/pull/1 checks green\n' > "$home/state/done-idle.status"
+  touch -t 202001011200 "$home/state/done-idle.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    FM_FLEET_HEALTH_HANDOFF_STALE_SECS=60 "$HEALTH" --json) || rc=$?
+  expect_code 1 "$rc" "stale done signal should be an actionable missed handoff"
+  printf '%s' "$out" | jq -e '
+    .status == "actionable"
+      and any(.findings[]; .kind == "missed-handoff" and .subject == "done-idle"
+              and .confidence == "high")
+  ' >/dev/null || fail "missed handoff was not reported: $out"
+  pass "stale done signal with no later inbox is a missed handoff"
+}
+
+test_later_inbox_clears_missed_handoff() {
+  local home fakebin out rc=0
+  home=$(make_home handoff-inbox)
+  write_live_ship "$home" done-followed
+  printf 'done: ready for next step\n' > "$home/state/done-followed.status"
+  touch -t 202001011200 "$home/state/done-followed.status"
+  fakebin=$(make_fakebin "$home")
+  PATH="$fakebin:$PATH" FM_HOME="$home" \
+    fm_task_inbox_write "$home/state" done-followed "next step" >/dev/null
+  fresh_autoarm_supervision "$home"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    FM_FLEET_HEALTH_HANDOFF_STALE_SECS=60 "$HEALTH" --json) || rc=$?
+  printf '%s' "$out" | jq -e '
+    any(.findings[]; .kind == "missed-handoff" and .subject == "done-followed") | not
+  ' >/dev/null || fail "later inbox did not suppress missed handoff: $out"
+  pass "a later steering message suppresses the missed-handoff finding"
+}
+
+test_recent_done_signal_is_not_missed_handoff() {
+  local home fakebin out rc=0
+  home=$(make_home recent-done)
+  write_live_ship "$home" just-done
+  printf 'done: just finished\n' > "$home/state/just-done.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    FM_FLEET_HEALTH_HANDOFF_STALE_SECS=1800 "$HEALTH" --json) || rc=$?
+  printf '%s' "$out" | jq -e '
+    (any(.findings[]; .kind == "missed-handoff" and .subject == "just-done") | not)
+  ' >/dev/null || fail "fresh done signal was treated as missed handoff: $out"
+  pass "a fresh done signal is inside the handoff stale window"
 }
 
 test_unreadable_local_endpoint_is_inconclusive() {
@@ -541,10 +672,12 @@ test_pending_reply_broken_and_historical_noise_omitted() {
 
 ## Done
 EOF
-  printf 'working: ping\n' > "$home/state/attorney-data.status"
-  printf 'needs-decision [key=shape]: choose an API\n' >> "$home/state/attorney-data.status"
-  printf 'working: still going\n' >> "$home/state/attorney-data.status"
-  printf 'working: another historical reply event\n' >> "$home/state/attorney-data.status"
+  {
+    printf 'working: ping\n'
+    printf 'needs-decision [key=shape]: choose an API\n'
+    printf 'working: still going\n'
+    printf 'working: another historical reply event\n'
+  } > "$home/state/attorney-data.status"
   fakebin=$(make_fakebin "$home")
   out=$(run_health "$home" "$fakebin")
   printf '%s' "$out" | jq -e '
@@ -978,6 +1111,12 @@ test_dangling_metadata_is_inconclusive
 test_unsearchable_nested_inventories_are_inconclusive
 test_actionable_dead_direct_report
 test_dead_agent_with_live_endpoint
+test_codex_resume_banner_is_dead_session
+test_codex_bare_shell_is_dead_session
+test_live_codex_without_banner_is_not_dead_session
+test_missed_handoff_after_done_signal
+test_later_inbox_clears_missed_handoff
+test_recent_done_signal_is_not_missed_handoff
 test_unreadable_local_endpoint_is_inconclusive
 test_terminal_unreadable_endpoint_is_inconclusive
 test_historical_status_pr_does_not_require_listener

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -91,8 +91,8 @@ run_health() {  # <home> <fakebin>
   PATH="$2:$PATH" FM_HOME="$1" "$HEALTH" --json
 }
 
-write_pending() {  # <home> <corr> <task> <phase> [completed_epoch]
-  local home=$1 corr=$2 task=$3 phase=$4 completed=${5-}
+write_pending() {  # <home> <corr> <task> <phase> [completed_epoch] [grace]
+  local home=$1 corr=$2 task=$3 phase=$4 completed=${5-} grace=${6:-120}
   mkdir -p "$home/state/pending-replies"
   cat > "$home/state/pending-replies/$corr" <<EOF
 schema=fm-pending-reply.v1
@@ -121,7 +121,7 @@ resolved_via=
 wrong_home_hits=0
 wrong_home_sightings=
 wrong_home_scan_signature=
-grace_secs=120
+grace_secs=$grace
 EOF
 }
 
@@ -183,6 +183,21 @@ test_actionable_dead_direct_report() {
   pass "dead local worker is an actionable finding"
 }
 
+test_dead_agent_with_live_endpoint() {
+  local home fakebin out rc=0
+  home=$(make_home dead-agent-live-endpoint)
+  write_live_ship "$home" dead-worker
+  printf 'fm-dead-worker\n' > "$home/state/.fake-windows"
+  fakebin=$(make_fakebin "$home")
+  out=$(run_health "$home" "$fakebin") || rc=$?
+  expect_code 1 "$rc" "dead agent behind a live endpoint should be actionable"
+  printf '%s' "$out" | jq -e '
+    any(.findings[]; .kind == "dead-direct-report" and .subject == "dead-worker"
+        and .evidence == "direct-report agent is dead while its endpoint remains present")
+  ' >/dev/null || fail "dead agent behind live endpoint was missed: $out"
+  pass "dead agent is detected even when its endpoint remains present"
+}
+
 test_grouped_inbox_and_stable_fingerprints() {
   local home fakebin out1 out2 rc=0 fp1 fp2 count
   home=$(make_home grouped-inbox)
@@ -231,9 +246,9 @@ EOF
   fresh_autoarm_supervision "$home"
   fakebin=$(make_fakebin "$home")
   out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
-  expect_code 0 "$rc" "inconclusive remote liveness is not actionable"
+  expect_code 3 "$rc" "inconclusive remote liveness should use the incomplete exit"
   printf '%s' "$out" | jq -e '
-    .status == "healthy"
+    .status == "inconclusive"
       and any(.findings[]; .kind == "remote-liveness-inconclusive" and .subject == "remote-mate" and .confidence == "inconclusive")
       and (any(.findings[]; .kind == "dead-secondmate") | not)
       and (any(.findings[]; .kind == "dead-direct-report") | not)
@@ -298,13 +313,79 @@ EOF
   fresh_autoarm_supervision "$home"
   fakebin=$(make_fakebin "$home")
   out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
-  expect_code 0 "$rc" "uncollected remote summary is not a definite break"
+  expect_code 3 "$rc" "uncollected remote summary should be inconclusive"
   printf '%s' "$out" | jq -e '
     any(.findings[]; .kind == "remote-liveness-inconclusive" and .confidence == "inconclusive")
       and (any(.findings[]; .kind == "secondmate-summary-invalid") | not)
       and (any(.findings[]; .kind == "secondmate-summary-unavailable" and .confidence == "high") | not)
   ' >/dev/null || fail "uncollected remote summary was marked broken: $out"
   pass "uncollected remote secondmate summary is inconclusive"
+}
+
+test_invalid_secondmate_summary_uses_normalized_kind() {
+  local home fakebin out rc=0
+  home=$(make_home invalid-summary)
+  printf '%s\n' '- missing-home' > "$home/data/secondmates.md"
+  fm_write_meta "$home/state/missing-home.meta" \
+    "window=firstmate:fm-missing-home" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=secondmate" \
+    "mode=secondmate"
+  printf 'working: watching scope\n' > "$home/state/missing-home.status"
+  fakebin=$(make_fakebin "$home")
+  out=$(run_health "$home" "$fakebin") || rc=$?
+  expect_code 1 "$rc" "missing recorded secondmate home should be invalid"
+  printf '%s' "$out" | jq -e '
+    any(.findings[]; .kind == "secondmate-summary-invalid" and .subject == "missing-home"
+        and .evidence == "registry entry has no home")
+  ' >/dev/null || fail "normalized secondmate failure kind was not projected: $out"
+  pass "normalized snapshot failure kinds drive secondmate health findings"
+}
+
+test_truncated_secondmate_inventory_is_inconclusive() {
+  local home fakebin out rc=0 id
+  home=$(make_home truncated-secondmates)
+  cat > "$home/data/secondmates.md" <<'EOF'
+- mate-a (host: example.invalid; root: /remote/firstmate; home: /remote/mate-a; scope: work; projects: alpha; added 2026-08-01)
+- mate-b (host: example.invalid; root: /remote/firstmate; home: /remote/mate-b; scope: work; projects: alpha; added 2026-08-01)
+EOF
+  for id in mate-a mate-b; do
+    fm_write_meta "$home/state/$id.meta" \
+      "window=firstmate:fm-$id" \
+      "project=alpha" \
+      "harness=codex" \
+      "kind=secondmate" \
+      "mode=secondmate" \
+      "home=/remote/$id" \
+      "remote_host=example.invalid" \
+      "remote_root=/remote/firstmate"
+    printf 'working: watching scope\n' > "$home/state/$id.status"
+  done
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm FM_SNAPSHOT_SECONDMATES=1 "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "truncated secondmate inventory should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "secondmate-summary-inconclusive" and .subject == "secondmate-inventory")
+  ' >/dev/null || fail "truncated secondmate inventory was not disclosed: $out"
+  pass "bounded secondmate omissions make fleet health inconclusive"
+}
+
+test_pending_reply_uses_recorded_grace() {
+  local home fakebin out rc=0
+  home=$(make_home recorded-grace)
+  write_live_ship "$home" grace-task
+  write_pending "$home" fedcfedcfedcfedc grace-task awaiting_report 1000 600
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm FM_PENDING_REPLY_NOW=1300 "$HEALTH" --json) || rc=$?
+  expect_code 0 "$rc" "recorded pending-reply grace should suppress a premature overdue finding"
+  printf '%s' "$out" | jq -e '
+    .status == "healthy" and (any(.findings[]; .kind == "pending-reply-overdue") | not)
+  ' >/dev/null || fail "checker ignored the record-owned pending grace: $out"
+  pass "pending-reply health uses each record's authoritative grace"
 }
 
 test_inventory_and_missing_listener() {
@@ -329,6 +410,8 @@ EOF
     "yolo=off" \
     "pr=https://github.com/example/alpha/pull/9"
   printf 'working: waiting on CI\n' > "$home/state/pr-ship.status"
+  printf '#!/usr/bin/env bash\nprintf "OPEN\\n"\n' > "$home/state/pr-ship.check.sh"
+  chmod 0600 "$home/state/pr-ship.check.sh"
   mkdir -p "$home/state/procevent"
   printf 'adapter=lavish\nargc=1\nargv:\npoll\n' > "$home/state/procevent/board-src.source"
   fakebin=$(make_fakebin "$home")
@@ -343,6 +426,25 @@ EOF
   assert_contains "$view" "result-listener-missing" "human view must print listener findings"
   assert_contains "$view" "inventory-inconsistent" "human view must print inventory findings"
   pass "inconsistent inventory and missing listeners are actionable"
+}
+
+test_complete_timeout_covers_fingerprinting() {
+  local home fakebin out rc=0
+  home=$(make_home complete-timeout)
+  write_live_ship "$home" hash-task
+  : > "$home/state/.fake-windows"
+  fakebin=$(make_fakebin "$home")
+  cat > "$fakebin/shasum" <<'SH'
+#!/usr/bin/env bash
+sleep 3
+SH
+  chmod +x "$fakebin/shasum"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_FLEET_HEALTH_TIMEOUT=1 "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "the complete health check should honor its timeout"
+  printf '%s' "$out" | jq -e '
+    .status == "incomplete" and .reason == "fleet health check timed out"
+  ' >/dev/null || fail "post-snapshot timeout did not produce incomplete output: $out"
+  pass "the timeout bounds collection, evaluation, and fingerprinting"
 }
 
 test_human_view_and_incomplete_exit() {
@@ -361,9 +463,14 @@ test_human_view_and_incomplete_exit() {
 test_usage_exit
 test_healthy_empty_fleet
 test_actionable_dead_direct_report
+test_dead_agent_with_live_endpoint
 test_grouped_inbox_and_stable_fingerprints
 test_remote_liveness_is_inconclusive
 test_pending_reply_broken_and_historical_noise_omitted
 test_inconclusive_secondmate_summary_not_broken
+test_invalid_secondmate_summary_uses_normalized_kind
+test_truncated_secondmate_inventory_is_inconclusive
+test_pending_reply_uses_recorded_grace
 test_inventory_and_missing_listener
+test_complete_timeout_covers_fingerprinting
 test_human_view_and_incomplete_exit

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -202,6 +202,22 @@ test_unsearchable_state_is_inconclusive() {
   pass "unsearchable state inventory remains inconclusive"
 }
 
+test_dangling_metadata_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home dangling-metadata)
+  ln -s "$home/state/missing-target" "$home/state/dangling.meta"
+  fakebin=$(make_fakebin "$home")
+  out=$(run_health "$home" "$fakebin") || rc=$?
+  expect_code 3 "$rc" "dangling task metadata should make health inconclusive"
+  [ -L "$home/state/dangling.meta" ] || fail "read-only health changed dangling metadata"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "fleet-inventory-inconclusive"
+              and .subject == "metadata" and .count == 1)
+  ' >/dev/null || fail "dangling task metadata was treated as healthy: $out"
+  pass "dangling task metadata remains visible and inconclusive"
+}
+
 test_unsearchable_nested_inventories_are_inconclusive() {
   local home fakebin claim_root out rc=0
   home=$(make_home unsearchable-nested)
@@ -884,6 +900,7 @@ test_usage_exit
 test_healthy_empty_fleet
 test_missing_state_home_remains_unmodified
 test_unsearchable_state_is_inconclusive
+test_dangling_metadata_is_inconclusive
 test_unsearchable_nested_inventories_are_inconclusive
 test_actionable_dead_direct_report
 test_dead_agent_with_live_endpoint

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -155,6 +155,9 @@ test_usage_exit() {
   local rc=0
   "$HEALTH" --nope >/dev/null 2>&1 || rc=$?
   expect_code 2 "$rc" "unknown flag must be a usage error"
+  rc=0
+  "$HEALTH" --json extra >/dev/null 2>&1 || rc=$?
+  expect_code 2 "$rc" "extra arguments must be a usage error"
   pass "usage errors exit 2"
 }
 
@@ -183,6 +186,22 @@ test_missing_state_home_remains_unmodified() {
   printf '%s' "$out" | jq -e '.status == "healthy"' >/dev/null \
     || fail "missing-state home did not report healthy: $out"
   pass "health check does not create a missing state directory"
+}
+
+test_dangling_state_path_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$TMP_ROOT/dangling-state
+  mkdir -p "$home"
+  ln -s "$home/missing-state-target" "$home/state"
+  fakebin=$(make_fakebin "$home")
+  out=$(run_health "$home" "$fakebin") || rc=$?
+  expect_code 3 "$rc" "dangling state path should make health inconclusive"
+  [ -L "$home/state" ] || fail "read-only health changed dangling state path"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "fleet-inventory-inconclusive" and .subject == "state")
+  ' >/dev/null || fail "dangling state path was treated as healthy: $out"
+  pass "dangling state path remains unavailable and inconclusive"
 }
 
 test_unsearchable_state_is_inconclusive() {
@@ -415,6 +434,23 @@ SH
       and (any(.findings[]; .kind == "steering-inbox-aged") | not)
   ' >/dev/null || fail "malformed inbox evidence was hidden: $out"
   pass "invalid and unageable inbox records remain inconclusive"
+}
+
+test_invalid_inbox_containers_are_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home invalid-inbox-containers)
+  printf 'not a directory\n' > "$home/state/file.inbox"
+  ln -s "$home/state/missing.inbox-target" "$home/state/dangling.inbox"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "invalid inbox containers should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "steering-inbox-inconclusive"
+              and .count == 2 and (.evidence | contains("are invalid")))
+  ' >/dev/null || fail "invalid inbox containers were hidden: $out"
+  pass "invalid inbox containers remain visible and inconclusive"
 }
 
 test_remote_liveness_is_inconclusive() {
@@ -679,6 +715,10 @@ test_invalid_pending_reply_is_inconclusive() {
   home=$(make_home invalid-pending-reply)
   mkdir -p "$home/state/pending-replies"
   printf 'schema=fm-pending-reply.v1\ncorr_id=bad\n' > "$home/state/pending-replies/truncated"
+  write_pending "$home" 0123012301230123 malformed-pending awaiting_report
+  sed 's/^delivered_epoch=.*/delivered_epoch=not-a-number/' \
+    "$home/state/pending-replies/0123012301230123" > "$home/state/pending-replies/invalid.tmp"
+  mv "$home/state/pending-replies/invalid.tmp" "$home/state/pending-replies/0123012301230123"
   fresh_autoarm_supervision "$home"
   fakebin=$(make_fakebin "$home")
   out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
@@ -686,10 +726,24 @@ test_invalid_pending_reply_is_inconclusive() {
   printf '%s' "$out" | jq -e '
     .status == "inconclusive"
       and any(.findings[]; .kind == "pending-reply-inconclusive"
-              and .subject == "pending-replies" and .count == 1)
+              and .subject == "pending-replies" and .count == 2)
       and (any(.findings[]; .kind == "pending-reply-broken") | not)
   ' >/dev/null || fail "invalid pending-reply record was hidden: $out"
   pass "invalid pending-reply records make health inconclusive"
+}
+
+test_dangling_pending_reply_directory_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home dangling-pending-dir)
+  ln -s "$home/state/missing-pending-target" "$home/state/pending-replies"
+  fakebin=$(make_fakebin "$home")
+  out=$(run_health "$home" "$fakebin") || rc=$?
+  expect_code 3 "$rc" "dangling pending-replies directory should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "pending-reply-inconclusive" and .subject == "pending-replies")
+  ' >/dev/null || fail "dangling pending-replies directory was treated as healthy: $out"
+  pass "dangling pending-replies directory remains unavailable"
 }
 
 test_inventory_and_missing_listener() {
@@ -747,6 +801,25 @@ test_invalid_procevent_registration_is_reported() {
               and (.evidence | contains("owner=invalid")))
   ' >/dev/null || fail "invalid process-event registration was hidden: $out"
   pass "invalid process-event registrations remain visible"
+}
+
+test_dangling_procevent_claim_root_is_inconclusive() {
+  local home fakebin claim_root out rc=0
+  home=$(make_home dangling-procevent-root)
+  mkdir -p "$home/state/procevent"
+  printf 'adapter=lavish\nargc=1\nargv:\npoll\n' > "$home/state/procevent/source-one.source"
+  claim_root="$home/missing-claims"
+  ln -s "$home/missing-claims-target" "$claim_root"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm \
+    FM_PROCEVENT_CLAIM_ROOT="$claim_root" "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "dangling process-event claim root should be inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "result-listener-inconclusive" and .subject == "procevent")
+      and (any(.findings[]; .kind == "result-listener-missing" and .subject == "source-one") | not)
+  ' >/dev/null || fail "dangling process-event claim root was classified as missing: $out"
+  pass "dangling process-event claim root remains inconclusive"
 }
 
 test_paused_ship_still_requires_pr_listener() {
@@ -899,6 +972,7 @@ test_human_view_and_incomplete_exit() {
 test_usage_exit
 test_healthy_empty_fleet
 test_missing_state_home_remains_unmodified
+test_dangling_state_path_is_inconclusive
 test_unsearchable_state_is_inconclusive
 test_dangling_metadata_is_inconclusive
 test_unsearchable_nested_inventories_are_inconclusive
@@ -909,6 +983,7 @@ test_terminal_unreadable_endpoint_is_inconclusive
 test_historical_status_pr_does_not_require_listener
 test_grouped_inbox_and_stable_fingerprints
 test_invalid_inbox_records_are_inconclusive
+test_invalid_inbox_containers_are_inconclusive
 test_remote_liveness_is_inconclusive
 test_unknown_worker_state_is_inconclusive
 test_registry_only_remote_evidence_is_inconclusive
@@ -920,8 +995,10 @@ test_truncated_secondmate_inventory_is_inconclusive
 test_incomplete_registry_does_not_break_secondmate_summary
 test_pending_reply_uses_recorded_grace
 test_invalid_pending_reply_is_inconclusive
+test_dangling_pending_reply_directory_is_inconclusive
 test_inventory_and_missing_listener
 test_invalid_procevent_registration_is_reported
+test_dangling_procevent_claim_root_is_inconclusive
 test_paused_ship_still_requires_pr_listener
 test_matching_retired_pr_listener_is_not_missing
 test_inconclusive_dominates_actionable_status

--- a/tests/fm-fleet-health.test.sh
+++ b/tests/fm-fleet-health.test.sh
@@ -72,7 +72,10 @@ case "${1:-}" in
     ;;
   capture-pane)
     window_present || exit 1
-    printf 'work in progress\nesc to interrupt\n'
+    case "$target" in
+      *paused*) printf 'all quiet\n> \n' ;;
+      *) printf 'work in progress\nesc to interrupt\n' ;;
+    esac
     ;;
 esac
 exit 0
@@ -179,6 +182,23 @@ test_missing_state_home_remains_unmodified() {
   printf '%s' "$out" | jq -e '.status == "healthy"' >/dev/null \
     || fail "missing-state home did not report healthy: $out"
   pass "health check does not create a missing state directory"
+}
+
+test_unsearchable_state_is_inconclusive() {
+  local home fakebin out rc=0
+  home=$(make_home unsearchable-state)
+  write_live_ship "$home" hidden-task
+  fakebin=$(make_fakebin "$home")
+  chmod 400 "$home/state"
+  out=$(run_health "$home" "$fakebin") || rc=$?
+  chmod 700 "$home/state"
+  expect_code 3 "$rc" "unsearchable state should make health inconclusive"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "fleet-inventory-inconclusive" and .subject == "state")
+      and (any(.findings[]; .kind == "result-listener-missing") | not)
+  ' >/dev/null || fail "unsearchable state was treated as healthy or definitely broken: $out"
+  pass "unsearchable state inventory remains inconclusive"
 }
 
 test_actionable_dead_direct_report() {
@@ -509,6 +529,50 @@ EOF
   pass "inconsistent inventory and missing listeners are actionable"
 }
 
+test_paused_ship_still_requires_pr_listener() {
+  local home fakebin out rc=0
+  home=$(make_home paused-pr-listener)
+  write_live_ship "$home" paused-ship
+  printf 'pr=https://github.com/example/alpha/pull/18\n' >> "$home/state/paused-ship.meta"
+  printf 'paused: waiting for upstream checks\n' > "$home/state/paused-ship.status"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 1 "$rc" "paused ship without its PR listener should be actionable"
+  printf '%s' "$out" | jq -e '
+    .status == "actionable"
+      and any(.findings[]; .kind == "result-listener-missing" and .subject == "paused-ship")
+  ' >/dev/null || fail "paused ship escaped PR-listener validation: $out"
+  pass "declared waits retain their required PR listeners"
+}
+
+test_inconclusive_dominates_actionable_status() {
+  local home fakebin out rc=0
+  home=$(make_home mixed-confidence)
+  write_live_ship "$home" dead-mixed
+  mkdir -p "$home/projects/unreadable-mixed-wt"
+  fm_write_meta "$home/state/unreadable-mixed.meta" \
+    "backend=herdr" \
+    "window=malformed-herdr-target" \
+    "worktree=$home/projects/unreadable-mixed-wt" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship"
+  printf 'working: implementing\n' > "$home/state/unreadable-mixed.status"
+  : > "$home/state/.fake-windows"
+  fresh_autoarm_supervision "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SUPERVISION_MODEL=autoarm "$HEALTH" --json) || rc=$?
+  expect_code 3 "$rc" "inconclusive evidence should dominate actionable report status"
+  printf '%s' "$out" | jq -e '
+    .status == "inconclusive"
+      and any(.findings[]; .kind == "dead-direct-report" and .subject == "dead-mixed")
+      and any(.findings[]; .kind == "endpoint-inconclusive" and .subject == "unreadable-mixed")
+  ' >/dev/null || fail "mixed-confidence report masked incomplete evidence: $out"
+  pass "inconclusive evidence dominates overall status without hiding findings"
+}
+
 test_complete_timeout_covers_fingerprinting() {
   local home fakebin out rc=0
   home=$(make_home complete-timeout)
@@ -544,6 +608,7 @@ test_human_view_and_incomplete_exit() {
 test_usage_exit
 test_healthy_empty_fleet
 test_missing_state_home_remains_unmodified
+test_unsearchable_state_is_inconclusive
 test_actionable_dead_direct_report
 test_dead_agent_with_live_endpoint
 test_unreadable_local_endpoint_is_inconclusive
@@ -557,5 +622,7 @@ test_incomplete_registry_does_not_break_secondmate_summary
 test_pending_reply_uses_recorded_grace
 test_invalid_pending_reply_is_inconclusive
 test_inventory_and_missing_listener
+test_paused_ship_still_requires_pr_listener
+test_inconclusive_dominates_actionable_status
 test_complete_timeout_covers_fingerprinting
 test_human_view_and_incomplete_exit

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -624,6 +624,35 @@ test_view_renders_dead_secondmate_agent_status() {
   pass "fleet view renders secondmate agent liveness"
 }
 
+test_remote_probe_skip_does_not_use_local_placeholder() {
+  local home fakebin out
+  home=$(make_home remote-placeholder)
+  mkdir -p "$home/secondmate-home"
+  fm_write_meta "$home/state/remote-mate.meta" \
+    "window=firstmate:fm-remote-mate" \
+    "worktree=$home/secondmate-home" \
+    "project=$home/secondmate-home" \
+    "harness=codex" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "home=/remote/secondmate-home" \
+    "remote_host=example.invalid" \
+    "remote_root=/remote/firstmate" \
+    "projects=alpha"
+  printf 'working: watching delegated scope\n' > "$home/state/remote-mate.status"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_REMOTE_PROBES=0 "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e '
+    .tasks[] | select(.id == "remote-mate")
+    | .remote.host == "example.invalid"
+      and .endpoint.probe == "skipped"
+      and .endpoint.agent_alive == "not_collected"
+      and .endpoint.exists == null
+      and .endpoint.status == "not_collected"
+  ' >/dev/null || fail "skipped remote probes must not treat a local placeholder as liveness: $out"
+  pass "skipped remote probes record not_collected instead of local placeholder liveness"
+}
+
 # A still-open decision must survive a LATER, UNRELATED terminal event on the same
 # append-only stream. This is the fmdev masking bug: last-event-wins read the trailing
 # `done` and reported pending_decision=false while a needs-decision was still open. The
@@ -814,3 +843,4 @@ test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot
 test_view_renders_dead_secondmate_agent_status
+test_remote_probe_skip_does_not_use_local_placeholder

--- a/tests/fm-inactive-reconcile.test.sh
+++ b/tests/fm-inactive-reconcile.test.sh
@@ -4,6 +4,8 @@ set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=bin/fm-timeout-lib.sh
+. "$ROOT/bin/fm-timeout-lib.sh"
 
 RECON="$ROOT/bin/fm-inactive-reconcile.sh"
 DRAIN="$ROOT/bin/fm-wake-drain.sh"
@@ -463,6 +465,23 @@ test_reconciliation_never_calls_forge() {
   pass "reconciliation makes zero forge or PR API calls"
 }
 
+test_missing_state_is_initialized_before_locks() {
+  local home rc=0
+  home="$TMP_ROOT/missing-state-ack"
+  mkdir -p "$home"
+  fm_run_timed 2 env FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$RECON" acknowledge deadbeef || rc=$?
+  [ "$rc" -ne 124 ] || fail "acknowledge hung while acquiring a lock without state"
+  [ -d "$home/state" ] || fail "acknowledge did not initialize state before locking"
+
+  home="$TMP_ROOT/missing-state-scan"
+  mkdir -p "$home"
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_INACTIVE_RECONCILE_BUDGET_SECS=1 \
+    "$RECON" scan --startup
+  [ -d "$home/state" ] || fail "scan did not initialize state before locking"
+  pass "inactive reconciliation initializes missing state before locks"
+}
+
 test_main_direct_terminal_presentation_receipt
 test_local_secondmate_reports_terminal_child
 test_local_secondmate_rejects_relative_parent_home
@@ -480,5 +499,6 @@ test_full_scan_budget_includes_wake_lock_wait
 test_notice_recovery_does_not_duplicate_wake
 test_missing_parent_binding_names_itself
 test_reconciliation_never_calls_forge
+test_missing_state_is_initialized_before_locks
 
 echo "all inactive reconciliation tests passed"

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -50,6 +50,28 @@ test_created_pending_reply_is_valid() {
   pass "created pending-reply records satisfy the validator"
 }
 
+test_recovery_phase_requires_matching_outcome() {
+  local home state corr rec
+  home="$TMP_ROOT/recovery-phase-outcome"
+  state="$home/state"
+  mkdir -p "$state"
+  corr=$(fm_pending_reply_create "$home" "$state" hibit "recovery invariant") \
+    || fail "pending-reply creation failed"
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  fm_pending_reply_set "$rec" recovery_attempted_epoch 1000 || fail "recovery attempt setup failed"
+  fm_pending_reply_set "$rec" recovery_sender_pid "$$" || fail "recovery sender setup failed"
+  fm_pending_reply_set "$rec" recovery_sender_identity sender || fail "recovery identity setup failed"
+  fm_pending_reply_set "$rec" phase recovery_sending || fail "recovery phase setup failed"
+  fm_pending_reply_set "$rec" recovery_delivery_outcome confirmed || fail "recovery outcome setup failed"
+  if fm_pending_reply_record_valid "$rec"; then
+    fail "recovery_sending with a committed outcome must be invalid"
+  fi
+  fm_pending_reply_set "$rec" phase recovery_sent || fail "recovery sent setup failed"
+  fm_pending_reply_record_valid "$rec" \
+    || fail "recovery_sent with confirmed outcome should be valid"
+  pass "recovery phases require matching delivery outcomes"
+}
+
 # --- fixtures ---------------------------------------------------------------
 
 make_stubs() {  # <dir> -> fakebin
@@ -1266,6 +1288,7 @@ test_failed_send_discards_undelivered_expectation() {
 # --- run --------------------------------------------------------------------
 
 test_created_pending_reply_is_valid
+test_recovery_phase_requires_matching_outcome
 test_normal_correlated_reply_resolves_once
 test_completed_turn_no_report_triggers_one_recovery
 test_recovery_attempt_is_never_reinjected

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -63,13 +63,12 @@ test_recovery_phase_requires_matching_outcome() {
   fm_pending_reply_set "$rec" recovery_sender_identity sender || fail "recovery identity setup failed"
   fm_pending_reply_set "$rec" phase recovery_sending || fail "recovery phase setup failed"
   fm_pending_reply_set "$rec" recovery_delivery_outcome confirmed || fail "recovery outcome setup failed"
-  if fm_pending_reply_record_valid "$rec"; then
-    fail "recovery_sending with a committed outcome must be invalid"
-  fi
+  fm_pending_reply_record_valid "$rec" \
+    || fail "recovery_sending with a just-committed outcome should remain valid"
   fm_pending_reply_set "$rec" phase recovery_sent || fail "recovery sent setup failed"
   fm_pending_reply_record_valid "$rec" \
     || fail "recovery_sent with confirmed outcome should be valid"
-  pass "recovery phases require matching delivery outcomes"
+  pass "recovery phases accept the writer's observable commit transition"
 }
 
 # --- fixtures ---------------------------------------------------------------

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -38,6 +38,18 @@ TMP_ROOT=$(fm_test_tmproot fm-pending-reply)
 export FM_PENDING_REPLY_GRACE_SECS=0
 export FM_SEND_SETTLE=0
 
+test_created_pending_reply_is_valid() {
+  local home state corr
+  home="$TMP_ROOT/pending-reply-created"
+  state="$home/state"
+  mkdir -p "$state"
+  corr=$(fm_pending_reply_create "$home" "$state" hibit "created record") \
+    || fail "pending-reply creation failed"
+  fm_pending_reply_record_valid "$state/pending-replies/$corr" \
+    || fail "pending-reply create emitted a record rejected by its validator"
+  pass "created pending-reply records satisfy the validator"
+}
+
 # --- fixtures ---------------------------------------------------------------
 
 make_stubs() {  # <dir> -> fakebin
@@ -1253,6 +1265,7 @@ test_failed_send_discards_undelivered_expectation() {
 
 # --- run --------------------------------------------------------------------
 
+test_created_pending_reply_is_valid
 test_normal_correlated_reply_resolves_once
 test_completed_turn_no_report_triggers_one_recovery
 test_recovery_attempt_is_never_reinjected

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -553,7 +553,7 @@ SH
 }
 
 test_enrichment_preserves_all_unread_lines_and_status_file_failures() {
-  local dir state out i raw_count expected
+  local dir state out i raw_count expected actual
   dir=$(make_case complete-enrichment)
   state="$dir/state"
   out="$dir/drain.out"
@@ -579,8 +579,12 @@ test_enrichment_preserves_all_unread_lines_and_status_file_failures() {
   raw_count=$(awk -F '\t' 'NF == 5 { count++ } END { print count + 0 }' "$out")
   [ "$raw_count" -eq 13 ] || fail "missing, unreadable, malformed, empty, or oversized status input hid a raw row"
 
-  expected="wake annotation: latest wake-EVENT observed at drain, not current state: huge.status: $(cat "$state/huge.status")"
-  grep -Fx "$expected" "$out" >/dev/null \
+  expected="$dir/huge.expected"
+  actual="$dir/huge.actual"
+  printf 'wake annotation: latest wake-EVENT observed at drain, not current state: huge.status: ' > "$expected"
+  cat "$state/huge.status" >> "$expected"
+  awk '/^wake annotation: latest wake-EVENT observed at drain, not current state: huge\.status: /' "$out" > "$actual"
+  cmp -s "$expected" "$actual" \
     || fail "the oversized unread status line was truncated or omitted"
   i=1
   while [ "$i" -le 8 ]; do

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -17,6 +17,22 @@ GRANT="$ROOT/bin/fm-wake-grant.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-wake-tests)
 
+# shellcheck source=bin/fm-timeout-lib.sh
+. "$ROOT/bin/fm-timeout-lib.sh"
+
+test_missing_state_drain_initializes_writer_boundary() {
+  local dir state rc=0
+  dir="$TMP_ROOT/missing-state-drain"
+  state="$dir/state"
+  mkdir -p "$dir"
+  fm_run_timed 3 env FM_STATE_OVERRIDE="$state" "$DRAIN" \
+    > "$dir/drain.out" 2> "$dir/drain.err" || rc=$?
+  [ "$rc" -ne 124 ] || fail "wake drain hung while acquiring a lock below a missing state directory"
+  [ "$rc" -eq 0 ] || fail "wake drain failed to initialize missing state: $(cat "$dir/drain.err")"
+  [ -d "$state" ] || fail "wake drain did not create state at its mutating entrypoint"
+  pass "wake drain initializes missing state before locking"
+}
+
 
 test_concurrent_append_and_drain() {
   local dir state out1 out2 pids i pid count unique malformed sequence generation
@@ -1199,6 +1215,7 @@ test_historical_annotation_skips_announced_status() {
 }
 
 test_self_held_lock_reclaims_instead_of_deadlocking
+test_missing_state_drain_initializes_writer_boundary
 test_secondmate_foreign_queue_stall_is_one_shot_and_read_only
 test_secondmate_stall_marker_rejects_symlink
 test_acknowledged_stall_publication_survives_pre_marker_crash

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -33,6 +33,21 @@ test_missing_state_drain_initializes_writer_boundary() {
   pass "wake drain initializes missing state before locking"
 }
 
+test_missing_state_grant_initializes_writer_boundary() {
+  local dir state rc=0
+  dir="$TMP_ROOT/missing-state-grant"
+  state="$dir/state"
+  mkdir -p "$dir"
+  fm_run_timed 3 env FM_STATE_OVERRIDE="$state" "$GRANT" activate "$$" fresh-grant \
+    > "$dir/grant.out" 2> "$dir/grant.err" || rc=$?
+  [ "$rc" -ne 124 ] || fail "wake grant hung while acquiring a lock below a missing state directory"
+  [ "$rc" -eq 0 ] || fail "wake grant failed to initialize missing state: $(cat "$dir/grant.err")"
+  [ -d "$state" ] || fail "wake grant did not create state at its mutating entrypoint"
+  FM_STATE_OVERRIDE="$state" "$GRANT" deactivate "$$" fresh-grant \
+    >/dev/null 2> "$dir/deactivate.err" || fail "wake grant cleanup failed"
+  pass "wake grant initializes missing state before locking"
+}
+
 
 test_concurrent_append_and_drain() {
   local dir state out1 out2 pids i pid count unique malformed sequence generation
@@ -1216,6 +1231,7 @@ test_historical_annotation_skips_announced_status() {
 
 test_self_held_lock_reclaims_instead_of_deadlocking
 test_missing_state_drain_initializes_writer_boundary
+test_missing_state_grant_initializes_writer_boundary
 test_secondmate_foreign_queue_stall_is_one_shot_and_read_only
 test_secondmate_stall_marker_rejects_symlink
 test_acknowledged_stall_publication_survives_pre_marker_crash


### PR DESCRIPTION
## Intent

Create the first proven phase of a deterministic, read-only fleet health checker, using the existing structured fleet snapshot as its canonical input rather than adding a parallel parser or another control plane. The intended public interface is a clearly named bin/ command with a concise human view and stable JSON suitable for later automation. Its job is to identify mechanically provable Firstmate operational failures, not product blockers and not semantic judgments about whether a quiet worker is thinking well.

Required behavior:
- Consume bin/fm-fleet-snapshot.sh --json once and extend an existing canonical owner only when a required fact is genuinely absent.
- Detect high-confidence operational problems such as dead or missing direct-report agents, unavailable/invalid/timed-out secondmate summaries, broken or overdue reply delivery, aged unacknowledged steering inbox messages, structurally inconsistent active-work inventory, terminal workers that clearly require cleanup, missing required result listeners, and unhealthy supervision continuity where existing authoritative helpers can establish it.
- Also detect these two additional high-confidence finding kinds through the same structured finding shape (stable kind/subject/evidence/severity/fingerprint), still read-only: do not repair, relaunch, or steer anything.
1. Dead Codex worker session. A Codex-harness task (state/<id>.meta harness=codex) can have its underlying session exit entirely on a long-running task, leaving a bare shell behind in its endpoint pane. This looks nearly identical to a live pane to every existing signal: fm-crew-state.sh already reports Codex busy-state as permanently unknown by design, and a steering message sent into that dead shell is silently accepted with no error. The reliable tell is the pane's raw content literally containing "To continue this session, run codex resume" (the exact banner Codex prints on exit), or the endpoint's foreground process no longer being the codex process at all (a bare shell instead). Read pane content for Codex-harness tasks via the existing backend read path (tmux capture-pane / herdr pane read, whichever this checker's host uses) and report this as a high-confidence finding when that exact banner or bare-shell signature is present alongside a meta record claiming the task is still in flight.
2. Missed handoff: worker signaled done, nobody sent the next step. A task's own status log can report a terminal-ish line (done:, or a step-complete line whose contract expects firstmate to send the next instruction, per this fleet's ship-task brief contract) with no subsequent status append AND no subsequent inbox message sent to that task for longer than a bounded staleness threshold (configurable duration, default 20-30 minutes). This is the mirror case of aged unacknowledged steering inbox messages. Confirmed real this session on two separate tasks.
- Treat unavailable evidence as inconclusive, never healthy or definitely broken.
- Do not mistake the primary home's local placeholder for a remote endpoint as authoritative remote liveness.
- Do not emit every historical status event or old decision as a separate problem. Use current structured records, group repeated symptoms by the actionable owner/cause where useful, and keep product decisions and ordinary external waits out of this system-health surface.
- Give every finding a stable kind, subject, evidence summary, severity, and deterministic fingerprint so a later notifier can suppress unchanged repeats.
- Define useful exit semantics that distinguish healthy, actionable findings, and checker failure/incomplete execution.
- Default to no network calls, bounded execution, portability across the supported macOS/Linux homes, and no state mutation.
- Do not relaunch, steer, clean up, acknowledge records, or otherwise repair anything.

Verification:
- Add executable-interface regression tests following the repo's existing shell-test patterns. Cover healthy, actionable, grouped/deduplicated, remote-liveness, and inconclusive fixtures, plus stable fingerprints and exit behavior, including the Codex resume-banner / bare-shell and missed-handoff cases.
- Run shellcheck through the repository-owned lint command and run the relevant test suite.
- Run the checker against this home's real structured data and inspect the actual output. It should identify present connection/inventory failures without flooding the report with the many historical Attorney Data reply events or ordinary RecruitMagic blockers.
- Review every affected supported primary/runtime surface required by the coding guidelines, marking non-applicable axes explicitly in delivery evidence.

Scheduling is deliberately not activated in this phase.
Investigate the smallest supported follow-up integration and record a concise recommendation in the PR or delivery evidence: compare the existing watcher's slow-check path, session-start checks, process-event sources, and an OS scheduler. Prefer a durable Firstmate notification path that survives an absent chat over direct Herdr composer injection. Explain whether cron adds any value, how a changed finding would enter Firstmate's durable queue, how unchanged fingerprints would be suppressed, and how recovery works when Firstmate is not currently alive. Do not add cron entries, direct Herdr typing, background daemons, scheduled pings, or automatic repairs yet.

## What Changed

- Add a bounded, read-only fleet health command with concise human output, stable JSON findings and fingerprints, and distinct healthy, actionable, and incomplete exit states.
- Extend the canonical fleet snapshot and existing owner helpers to detect operational failures including dead Codex sessions, missed handoffs, delivery/listener issues, stale steering, inventory inconsistencies, secondmate failures, cleanup needs, and supervision gaps while preserving inconclusive evidence.
- Add executable regression coverage for healthy, actionable, deduplicated, remote, inconclusive, Codex-exit, missed-handoff, fingerprint, and exit-code behavior.

## Risk Assessment

✅ Low: The latest fail-closed lock handling correctly prevents branch-outcome commands from proceeding after state-boundary rejection, and the broader health-check change has no additional material source defect substantiated in this review.

## Testing

Focused health, branch, snapshot, inactive-reconcile, and pending-reply tests passed; real-home human and JSON checks reported healthy, while the supporting wake suite reproducibly encountered an unrelated pre-existing oversized-fixture `grep` resource failure after its relevant new cases passed.

<details>
<summary>Evidence: Real-home human health report</summary>

Source: [Real-home human health report](https://github.com/hsuperman/firstmate/blob/95b419b0d0e7f30581c64a057b5a36f762ed0f87/.no-mistakes/evidence/fm/firstmate-health-check/fleet-health-human.txt)

```text
# Fleet Health
Status: healthy
Home: /Users/byronhsu/.no-mistakes/worktrees/497bd902d278/01M0ZY0AS24JG06J7X87P08A2K
Snapshot: 2026-08-27T12:26:43Z

No operational findings.
```
</details>
<details>
<summary>Evidence: Real-home stable JSON report</summary>

Source: [Real-home stable JSON report](https://github.com/hsuperman/firstmate/blob/95b419b0d0e7f30581c64a057b5a36f762ed0f87/.no-mistakes/evidence/fm/firstmate-health-check/fleet-health.json)

```text
{
  "schema": "fm-fleet-health.v1",
  "generated": "2026-08-27T12:26:43Z",
  "fm_home": "/Users/byronhsu/.no-mistakes/worktrees/497bd902d278/01M0ZY0AS24JG06J7X87P08A2K",
  "snapshot_generated": "2026-08-27T12:26:43Z",
  "findings": [],
  "status": "healthy"
}
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (6m8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"bb2900d683027bd636eb1c8db2a5a1889fb8fe6f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (11) ✅</summary>

- 🚨 `bin/fm-fleet-health.sh:198` - The checker accepts any output whose only validated property is the schema string. A schema-tagged snapshot missing `tasks`, `main_inventory`, or collection fields then passes the check and jq&#39;s optional traversals can produce zero findings, yielding `healthy` instead of incomplete/inconclusive. Validate the required snapshot shape and types before evaluation.
- 🚨 `bin/fm-fleet-health.sh:473` - Required criterion: detect a terminal-ish `done:` or contract-defined step-complete line with no later status append or steering message. The changed selector only accepts `.paths.status_log.last_event.state == &#34;done&#34;`, so any supported step-complete status verb is silently ignored even after the stale threshold. Extend the canonical status classification to include the fleet&#39;s step-complete contract.
- 🚨 `bin/fm-fleet-health.sh:496` - A task with `current_state.state == &#34;unknown&#34;` due unavailable endpoint evidence, metadata containing a PR, and no valid listener passes `terminal_state(...) | not` and emits a high-confidence `result-listener-missing` finding. Unknown does not prove the worker is in flight, so this must remain inconclusive until a known nonterminal state is established.
- 🚨 `bin/fm-task-inbox-lib.sh:490` - `fm_task_inbox_latest_activity_json` checks only the inbox directory and then globs `handled/*.msg` without validating that `handled` exists, is searchable, or contains valid records. A later message moved into an unreadable/malformed handled directory is missed and can produce a false high-confidence `missed-handoff`, while a corrupt regular handled record can suppress the finding without any inconclusive signal. Validate nested handled evidence and expose invalid/unreadable results.

🔧 Fix: Harden fleet health evidence and handoff detection
5 errors still open:

- 🚨 `bin/fm-fleet-snapshot.sh:602` - Required criterion: “Default to no network calls.” Health sets `FM_SNAPSHOT_REMOTE_PROBES=0`, but `task_json_lines` still calls `crew_state_json` for every task before the remote-probe gate. A task with `remote_host` therefore reaches `fm-crew-state.sh` and can perform SSH during an ordinary health check. Gate remote current-state collection at the snapshot boundary and return explicit unavailable evidence when disabled.
- 🚨 `bin/fm-wake-lib.sh:138` - Required criterion: “Treat unavailable evidence as inconclusive, never healthy or definitely broken.” A malformed or empty watcher-lock PID makes `fm_watcher_lock_evidence_unreadable` return false, so a fresh beacon can be classified as `no-watcher` and emitted as high-confidence `supervision-unhealthy`. Malformed lock evidence must remain inconclusive.
- 🚨 `bin/fm-procevent-lib.sh:111` - Required criterion: “Treat unavailable evidence as inconclusive, never healthy.” A dangling `state/procevent` registry symlink satisfies the absent-registry check and is returned as an available empty inventory. Health can then report no listener problems and `healthy` despite unavailable registration evidence. Preserve invalid/unavailable status for dangling registry roots.
- 🚨 `bin/fm-fleet-snapshot.sh:986` - Required criterion: “Treat unavailable evidence as inconclusive, never healthy.” A dangling `data/secondmates.md` symlink is treated as an absent registry and converted into an available empty registry. With no task rows, the checker can report `healthy` while canonical secondmate evidence is unavailable. Distinguish genuinely absent registries from dangling or invalid paths.
- 🚨 `bin/fm-fleet-health.sh:149` - The accepted snapshot-validation fix remains incomplete: `snapshot_shape_valid` checks only a subset of the documented v1 top-level contract, so a schema-tagged snapshot can omit fields such as `backlog`, `roots`, or `secondmate_landed` and still be evaluated as healthy. Validate the complete required top-level shape and types before producing findings.

🔧 Fix: Harden snapshot boundaries and malformed evidence handling
2 errors still open:

- 🚨 `bin/fm-fleet-health.sh:160` - Required criterion: “Validate the required snapshot shape and types before evaluation so a schema-tagged but incomplete snapshot cannot report healthy.” `nullable()` treats omitted jq fields as null, so a task missing `endpoint.exists` passes validation. A working/alive task with otherwise valid evidence then produces no finding and can report healthy. Require required nullable keys to be present, and validate state enums.
- 🚨 `bin/fm-pr-lib.sh:637` - Required criterion: “Treat unavailable evidence as inconclusive, never healthy or definitely broken.” The canonical PR inventory silently drops every malformed or unreadable `.check.sh` and retirement marker while returning `available:true`; health then interprets the absent row at lines 603-607 as a high-confidence missing listener. A present invalid listener artifact can therefore produce `result-listener-missing` instead of an inconclusive result. Expose invalid/unreadable inventory evidence and only assert missing when the current PR identity and inventory are authoritative.

🔧 Fix: Centralize fail-closed evidence classification
5 errors still open:

- 🚨 `bin/fm-fleet-health.sh:170` - The snapshot validator only checks that endpoint.agent_state, agent_alive, and probe are strings, not that they are valid enum values. A schema-tagged task with agent_state=&#34;&#34; can pass validation; agent_state() then returns the empty string, produces no endpoint finding, and the checker may report healthy. This contradicts the required fail-closed rule and the requirement to validate state enums.
- 🚨 `bin/fm-wake-lib.sh:140` - A live watcher PID with missing or empty fm-home, watcher-path, or pid-identity metadata falls through this helper as readable: fm_watcher_lock_matches_pid fails, fm_pid_identity succeeds, and the function returns nonzero. The caller then emits high-confidence supervision-unhealthy instead of inconclusive, even though lock ownership evidence is incomplete.
- 🚨 `bin/fm-pending-reply-lib.sh:203` - The pending-reply validator claims full schema validation but only requires parent_home and parent_status to be nonempty. Values such as parent_home=x and parent_status=not-a-path are accepted as available records, allowing malformed owner evidence to avoid an inconclusive finding. Validate their documented absolute-path contract and the remaining field types.
- 🚨 `bin/fm-task-inbox-lib.sh:115` - The inbox timestamp check uses &#39;?&#39; wildcards, so a value such as at=xxxx-xx-xxTxx:xx:xxZ is accepted as valid. The record is then aged from filesystem mtime and can produce a high-confidence aged-message finding despite malformed evidence. Use digit-constrained validation or classify the record as inconclusive.
- 🚨 `bin/fm-classify-lib.sh:53` - The required criterion says: “Implement these two findings through ONE shared classification helper that every evidence-reading boundary calls.” fm_evidence_classify is added in fm-classify-lib.sh, but the inbox, pending-reply, and process-event readers independently encode available/invalid/unreadable outcomes instead of calling it. Route those canonical boundaries through the shared classifier so malformed or unavailable evidence has one enforced classification policy.

🔧 Fix: Centralize fail-closed evidence classification
1 error still open:

- 🚨 `bin/fm-fleet-health.sh:623` - Required criterion: “Treat unavailable evidence as inconclusive, never healthy or definitely broken.” A readable `state/&lt;id&gt;.meta` containing `pr=not-a-url` is copied into the snapshot as `pr.source:&#34;meta&#34;`; the validator checks only that the URL is a string. With that task still `working` and no listener record, this predicate emits a high-confidence `result-listener-missing` finding instead of classifying the invalid PR identity as inconclusive. Validate the current PR identity through the canonical `fm_pr_url_parse` boundary and surface invalid metadata before applying the missing-listener check.

🔧 Fix: Validate malformed current PR metadata before listener checks
4 issues (3 errors, 1 warning) still open:

- 🚨 `bin/fm-pending-reply-lib.sh:183` - `fm_pending_reply_record_valid` requires `escalation_closed_epoch`, but `fm_pending_reply_create` never writes that key. Every freshly created normal record is therefore rejected as invalid, causing health to lose all pending-reply records and miss broken or overdue delivery findings.
- 🚨 `bin/fm-wake-lib.sh:322` - `fm_path_age` converts beacon stat failures to `999999`, and this verdict only marks evidence unavailable when the beacon is fresh. An unreadable or dangling `.last-watcher-beat` therefore remains `available:true` with `ok:false`, producing high-confidence `supervision-unhealthy` instead of an inconclusive result.
- ⚠️ `bin/fm-fleet-health.sh:121` - Invalid `FM_FLEET_HEALTH_HANDOFF_STALE_SECS` exits 2 inside the timed worker, but the outer wrapper replaces the missing JSON with `status:&#34;incomplete&#34;` and exits 3. Invalid configuration is thus indistinguishable from checker failure rather than retaining usage-error semantics.
- 🚨 `bin/fm-classify-lib.sh:159` - The required criterion limits detection to “a step-complete line whose contract expects firstmate to send the next instruction,” but this new classifier treats every `step-complete:` line as `handoff_required`; the existing ship-task brief defines no such status or task-level contract. A stale `step-complete:` line from a task that proceeds autonomously can therefore produce a false high-confidence `missed-handoff` finding. Define and consume the authoritative contract before asserting this finding.

🔧 Fix: Fixed pending replies, supervision, and handoff evidence
2 errors still open:

- 🚨 `bin/fm-fleet-snapshot.sh:362` - Required behavior says to inspect Codex-harness panes for the exact resume banner. This branch skips capture whenever the canonical agent state is `unverified` or `unreadable`; for a supported backend such as zellij, a present pane containing the banner therefore produces `resume_banner:null` and no `dead-codex-session` finding. Capture when the local endpoint exists, treating only failed capture as inconclusive.
- 🚨 `bin/fm-pending-reply-lib.sh:208` - The validator accepts inconsistent recovery records. `fm_pending_reply_finish_recovery` writes `recovery_delivery_outcome=confirmed` before advancing `phase` to `recovery_sent`; a crash between those writes leaves `phase=recovery_sending` with outcome `confirmed`. The reader returns `recovery_verdict=confirmed`, while health flags only failed/unknown/orphaned or overdue phases, so this open record can yield no finding and a healthy report. Validate phase/outcome lifecycle invariants and classify inconsistent records as inconclusive.

🔧 Fix: Capture Codex exits and reject inconsistent recovery records
1 error still open:

- 🚨 `bin/fm-fleet-health.sh:614` - Required criterion: detect “a step-complete line whose contract expects firstmate to send the next instruction.” This selector now accepts only `last_event.state == &#34;done&#34;`, and the accompanying regression test explicitly declares `step-complete:` unsupported. That contradicts both the authoritative intent and the earlier instruction to establish the ship-task scaffold’s explicit step-complete contract; a stale contracted step-complete signal remains reachable without any `missed-handoff` finding. Restore a canonical contract-derived status classification and consume it here rather than treating every step-complete line as actionable.

🔧 Fix: Restore canonical contracted handoff detection
1 error still open:

- 🚨 `bin/fm-fleet-snapshot.sh:319` - Required criteria say the checker is “not [for] product blockers” and must “keep product decisions … out.” `status_is_terminal_verb` includes every `needs-decision` and `blocked` line, so this marks both as `handoff_required`; after 30 minutes without an inbox append, an ordinary `needs-decision: choose option A` or `blocked: waiting on credentials` becomes a high-confidence `missed-handoff`. Restrict this flag to scaffold states that specifically represent completed work awaiting the next instruction, rather than all captain-relevant stop states.

🔧 Fix: Exclude captain decisions from missed handoffs
1 error still open:

- 🚨 `bin/fm-fleet-health.sh:623` - Missed-handoff detection is globally disabled by corruption in any unrelated inbox. `fm_task_inbox_latest_activity_json` sets one fleet-wide `available:false`/invalid count, and this branch converts every stale contracted handoff into inconclusive. For example, task A has a stale `done:` status and no later steering, while task B has one malformed handled message; task A&#39;s mechanically provable missed handoff is suppressed. Preserve validity per task in the canonical inbox activity result and consult task A&#39;s evidence here, while separately reporting task B&#39;s corruption.

🔧 Fix: Scope inbox corruption to affected handoffs
1 error still open:

- 🚨 `bin/fm-branch-outcome.sh:155` - `lock_store` explicitly rejects a symlinked or uncreatable state directory, but every caller ignores its nonzero return. For example, `append` with `$STATE` symlinked returns from `lock_store` before acquiring `$LOCK`, then appends through the symlink and calls `fm_lock_release` despite owning no lock. This defeats the new boundary check and permits unlocked writes, potentially outside the intended home. Make every call fail closed, e.g. `lock_store || exit 1`.

🔧 Fix: Fail closed when branch outcome locking fails
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-wake-queue.test.sh:583` - The wake-queue suite reproducibly reaches `grep: out of memory` when comparing its pre-existing oversized single-line fixture. The health-check changes did not modify this case, and the newly added wake initialization regressions passed before it.
- `tests/fm-fleet-health.test.sh`
- <code>`bin/fm-fleet-health.sh` against the real worktree home</code>
- <code>`bin/fm-fleet-health.sh --json` against the real worktree home</code>
- `bash tests/fm-branch-supervision.test.sh`
- `bash tests/fm-fleet-snapshot-view.test.sh`
- `bash tests/fm-inactive-reconcile.test.sh`
- `bash tests/fm-pending-reply.test.sh`
- <code>`bash tests/fm-wake-queue.test.sh` (two attempts; relevant new cases passed, later pre-existing oversized fixture hit `grep: out of memory`)</code>
- <code>`git status --short` to verify testing left no worktree artifacts</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Remove unused health test locals
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
