### PR TITLE
fix(spawn): reject stale secondmate role identity

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -133,7 +133,9 @@
 #   Before a secondmate launch, the home is locally fast-forwarded to the primary
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
-#   git worktree root distinct from the primary project checkout.
+#   git worktree root distinct from the primary project checkout. An ordinary
+#   task worktree carrying a secondmate-home marker is also refused without
+#   mutation, so a reused copy cannot inject that home's charter or fleet state.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
@@ -1734,7 +1736,7 @@ real_path_or_raw() {  # <path>
 # that every downstream operation (send/capture/kill) already treats as opaque
 # per-backend routing (fm_backend_resolve_selector).
 validate_spawn_worktree() {  # <source> <inspect-target>
-  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real
+  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real marker marker_id
   wt_real=
   if ! wt_real=$(cd "$WT" 2>/dev/null && pwd -P); then
     wt_real=
@@ -1747,6 +1749,27 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
   if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
+    exit 1
+  fi
+
+  # Treehouse and Orca may reuse a linked copy whose ignored files survived an
+  # earlier lease. A secondmate marker would make tracked session-start hooks
+  # classify this ordinary worker/scout as that persistent home and inject its
+  # charter and fleet state before the agent's first turn. The spawn knows the
+  # requested role authoritatively, so refuse at this boundary before launch.
+  # Never remove the marker or foreign state here: the pooled path may still be
+  # a legitimate persistent secondmate home that was leased by mistake, and
+  # preserving it is safer than converting or resetting that home in place.
+  marker="$WT/$SUB_HOME_MARKER"
+  if [ -e "$marker" ] || [ -L "$marker" ]; then
+    marker_id=unsafe
+    if [ -f "$marker" ] && [ ! -L "$marker" ]; then
+      IFS= read -r marker_id < "$marker" 2>/dev/null || marker_id=unreadable
+      case "$marker_id" in
+        ''|*[!A-Za-z0-9._-]*) marker_id=unsafe ;;
+      esac
+    fi
+    echo "error: $source yielded an ordinary task worktree that carries secondmate identity '$marker_id'; refusing to launch or mutate the possible persistent secondmate home. Inspect target $inspect_target" >&2
     exit 1
   fi
 }

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -141,7 +141,42 @@ test_already_settled_pane_costs_one_confirm_sleep() {
   pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"
 }
 
+# A pooled copy can retain ignored files from an earlier lease. If that earlier
+# lease was a persistent second-mate home, its identity marker would make the
+# session-start hook treat this linked ordinary task copy as that old home and
+# inject its foreign fleet digest before the worker reads the current project.
+# The ordinary spawn must stop before launch while preserving the marker and
+# foreign state for safe inspection rather than deleting a possibly legitimate
+# persistent home.
+test_stale_secondmate_identity_refuses_ordinary_spawn_without_mutation() {
+  local rec id out status
+  id=settle-stale-role-z3
+  rec=$(make_settle_case settle-stale-role "$id" 0)
+  read_settle_record "$rec"
+  printf '%s\n' '.fm-secondmate-home' 'state/' 'data/' >> "$(git -C "$WT_DIR" rev-parse --git-path info/exclude)"
+  printf '%s\n' redacteur-linkedin > "$WT_DIR/.fm-secondmate-home"
+  mkdir -p "$WT_DIR/state" "$WT_DIR/data"
+  printf '%s\n' 'foreign fleet state' > "$WT_DIR/state/foreign.status"
+  printf '%s\n' 'foreign charter' > "$WT_DIR/data/charter.md"
+
+  out=$(run_settle_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "ordinary spawn accepted a worktree carrying a second-mate identity"
+  assert_contains "$out" "carries secondmate identity 'redacteur-linkedin'" \
+    "spawn did not explain the incompatible role identity"
+  assert_contains "$out" "refusing to launch" \
+    "spawn did not report that launch was refused"
+  assert_grep 'redacteur-linkedin' "$WT_DIR/.fm-secondmate-home" \
+    "spawn mutated the persistent-home identity marker"
+  assert_grep 'foreign fleet state' "$WT_DIR/state/foreign.status" \
+    "spawn mutated foreign fleet state"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "refused ordinary spawn published worker metadata"
+  pass "an ordinary spawn refuses a stale second-mate identity without mutating the possible persistent home"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
+test_stale_secondmate_identity_refuses_ordinary_spawn_without_mutation
 
 echo "# all fm-spawn-worktree-settle tests passed"


### PR DESCRIPTION
## Summary

- reject ordinary worker and scout launches when a reused isolated copy still carries `.fm-secondmate-home`
- preserve the marker and foreign state for inspection rather than mutating a possible persistent secondmate home
- cover the refusal through the public spawn interface

## Validation

- `FM_BACKEND=tmux bin/fm-test-run.sh tests/fm-spawn-worktree-settle.test.sh tests/fm-spawn-pool-base-freshen.test.sh tests/fm-control-relaunch.test.sh tests/fm-sessionstart-nudge.test.sh`
- `bin/fm-lint.sh`
- `bin/fm-doc-audience-check.sh`