### PR TITLE
fix(bin): bound self-scheduling loops and crewmate task scope

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -356,6 +356,11 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. The task as briefed is the whole scope. Work you discover mid-task that is not required to finish
+   the briefed task - newly appearing items of the same kind, adjacent cleanups, follow-on opportunities -
+   is reported to firstmate, not absorbed into this task. Report it with a status line and keep going
+   on the briefed scope; firstmate decides whether it becomes a separate task. Corrections genuinely
+   required to make the briefed work correct are part of this task, not new scope.
 
 $INBOX_SECTION
 
@@ -475,6 +480,11 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. The task as briefed is the whole scope. Work you discover mid-task that is not required to finish
+   the briefed task - newly appearing items of the same kind, adjacent cleanups, follow-on opportunities -
+   is reported to firstmate, not absorbed into this task. Report it with a status line and keep going
+   on the briefed scope; firstmate decides whether it becomes a separate task. Corrections genuinely
+   required to make the briefed work correct are part of this task, not new scope.
 
 $INBOX_SECTION
 

--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -55,15 +55,22 @@ set -u
 # Lowercase substrings that mark a tool name as delegation-shaped: it creates
 # work, an agent, a schedule, or an isolated workspace that firstmate would not
 # know about. This list is the single owner of the shipped classification.
-DELEGATION_STEMS='agent subagent task workflow cron schedul worktree delegate spawn dispatch handoff remote sendmessage monitor'
+DELEGATION_STEMS='agent subagent task workflow worktree delegate spawn dispatch handoff remote sendmessage monitor'
+
+# Lowercase substrings that mark a tool name as self-scheduling: it re-invokes
+# the caller's own session on a timer. Denied in both a primary and a task
+# worktree because the re-invocation loops compound context costs and bypass
+# supervision.
+SELF_SCHEDULING_STEMS='schedul cron'
 
 # Exact lowercase tool names that match a stem above but only OBSERVE or STOP
-# work that already exists. Reading or ending unaccounted work is not creating
-# it, and denying these would strand already-running work with no way to inspect
-# or end it. A local Claude deny list may still remove these from the
-# schema; this shipped guard deliberately stays narrower so it can never be the
-# reason a runaway task cannot be stopped.
-OBSERVE_ONLY_TOOLS='taskoutput taskstop taskget tasklist cronlist bashoutput killshell'
+# work that already exists (e.g. crondelete stops an existing schedule). Reading
+# or ending unaccounted work is not creating it, and denying these would strand
+# already-running work with no way to inspect or end it. A local Claude deny
+# list may still remove these from the schema; this shipped guard deliberately
+# stays narrower so it can never be the reason a runaway task cannot be stopped.
+# This relaxes the primary too, which is correct and intended.
+OBSERVE_ONLY_TOOLS='taskoutput taskstop taskget tasklist cronlist crondelete bashoutput killshell'
 
 # Exact lowercase tool names that match a stem above but create no RUNNABLE
 # work. These write only the harness's session-local todo list, which has no
@@ -88,17 +95,21 @@ Usage: fm-subagent-pretool-check.sh [--tool <tool-name>] [--claude]
 
 With no --tool, reads a PreToolUse-style JSON payload on stdin (Claude/Codex
 tool_name, or Grok toolName).
-Denies a delegation-SHAPED tool name in a genuine primary home.
+Denies a delegation-SHAPED tool name in a genuine primary home, and denies
+self-scheduling tools in BOTH a primary home and a task worktree.
 Claude primaries may also add an untracked per-home permissions.deny list that
 removes known delegation tools from the model schema before this hook is needed.
 Do not ship that Claude-only list in tracked project settings, because linked
 worktrees inherit it and legitimate crewmates would lose their delegation tools.
 This hook remains as the shipped guard for future delegation-shaped names
 outside any local fixed list.
-Fires only in a genuine firstmate primary home; it is a silent no-op in a
-crewmate/scout task worktree or any non-firstmate repo, where a worker using
-delegation tools is legitimate.
-Exits 0 to allow and 2 to deny, naming the real crewmate dispatch path instead.
+For ordinary delegation tools (creating work/agents), it fires only in a
+genuine firstmate primary home; it is a silent no-op in a crewmate/scout
+task worktree where a worker using delegation tools is legitimate.
+For self-scheduling tools (timer re-invocation), it fires in a task worktree
+too, because timer loops compound context costs and bypass supervision.
+Both remain a silent no-op in a non-firstmate repo.
+Exits 0 to allow and 2 to deny, naming the appropriate wait or dispatch path.
 Set FM_ALLOW_SUBAGENT=1 in the session environment to allow deliberately.
 Malformed transport fails open.
 EOF
@@ -156,13 +167,23 @@ for allowed in $OBSERVE_ONLY_TOOLS $PLAN_ONLY_TOOLS; do
   [ "$NORMALIZED" != "$allowed" ] || exit 0
 done
 
-MATCHED=""
+MATCHED_DELEGATION=""
 for stem in $DELEGATION_STEMS; do
   case "$NORMALIZED" in
-    *"$stem"*) MATCHED=$stem; break ;;
+    *"$stem"*) MATCHED_DELEGATION=$stem; break ;;
   esac
 done
-[ -n "$MATCHED" ] || exit 0
+
+MATCHED_SCHEDULING=""
+for stem in $SELF_SCHEDULING_STEMS; do
+  case "$NORMALIZED" in
+    *"$stem"*) MATCHED_SCHEDULING=$stem; break ;;
+  esac
+done
+
+if [ -z "$MATCHED_DELEGATION" ] && [ -z "$MATCHED_SCHEDULING" ]; then
+  exit 0
+fi
 
 # The single deliberate escape hatch. It is an environment variable rather than
 # a flag or a state file so it must be set when the session is launched, which
@@ -175,27 +196,48 @@ FM_ROOT=${FM_ROOT_OVERRIDE:-$(CDPATH='' cd -- "$SCRIPT_DIR/.." 2>/dev/null && pw
 FM_HOME=${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}
 STATE=${FM_STATE_OVERRIDE:-$FM_HOME/state}
 
-# Scope to a genuine primary home, exactly as the session-start nudge and the
-# turn-end guard do. fm_primary_scope_matches accepts a plain checkout or a
-# marked secondmate home - both operate a fleet and must dispatch through it -
-# and rejects a linked task worktree, which is the shape bin/fm-spawn.sh always
-# hands a crewmate. A crewmate using delegation tools inside its own task
-# worktree is legitimate and stays allowed. Any failure to confirm the home is
-# inert (exit 0), never a block, so a broken environment never denies a call.
 # shellcheck source=bin/fm-primary-scope-lib.sh
 . "$SCRIPT_DIR/fm-primary-scope-lib.sh"
-fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
-# Name the dedicated scout entry point only when this home carries it; degrade
-# to the two-step brief-then-spawn path when it does not, rather than naming a
-# script that is not there.
-if [ -f "$FM_ROOT/bin/fm-scout.sh" ]; then
-  ROUTE='first classify the work under the AGENTS.md intake contract: work already classified as a scout goes to bin/fm-scout.sh "<question>" [project], while authorized ship work and its bounded research go to bin/fm-brief.sh then bin/fm-spawn.sh'
+# Is this ANY firstmate territory (primary, secondmate, or task worktree)?
+# Task worktrees lack git_dir == git_common_dir but still carry firstmate files.
+fm_any_firstmate_scope_matches() {
+  local root=$1 state=$2
+  if ! fm_root_is_secondmate_home "$root"; then
+    git -C "$root" rev-parse --git-dir >/dev/null 2>&1 || return 1
+  fi
+  [ -f "$root/AGENTS.md" ] || return 1
+  [ -d "$root/bin" ] || return 1
+  [ -d "$state" ] || return 1
+}
+
+# If it's not even a firstmate repo, everything is inert.
+fm_any_firstmate_scope_matches "$FM_ROOT" "$STATE" || exit 0
+
+if [ -n "$MATCHED_SCHEDULING" ]; then
+  # Self-scheduling is denied in ANY firstmate territory (primary or task worktree).
+  REASON="[subagent-dispatch] a self-scheduling tool (blocked tool: $TOOL, matched on \"$MATCHED_SCHEDULING\") re-invokes this session on a timer. Each wake replays the whole accumulated context, compounding costs in an unbounded loop that firstmate supervision cannot see. Instead, append a paused: or blocked: status line to let firstmate's supervision-owned poll wake you (firstmate can arm state/<id>.check.sh via bin/fm-check-register.sh for custom conditions). Launch the session with FM_ALLOW_SUBAGENT=1 for a deliberate exception."
 else
-  ROUTE='first classify the work under the AGENTS.md intake contract, then use bin/fm-brief.sh followed by bin/fm-spawn.sh for dispatched work'
-fi
+  # Scope to a genuine primary home, exactly as the session-start nudge and the
+  # turn-end guard do. fm_primary_scope_matches accepts a plain checkout or a
+  # marked secondmate home - both operate a fleet and must dispatch through it -
+  # and rejects a linked task worktree, which is the shape bin/fm-spawn.sh always
+  # hands a crewmate. A crewmate using delegation tools inside its own task
+  # worktree is legitimate and stays allowed. Any failure to confirm the home is
+  # inert (exit 0), never a block, so a broken environment never denies a call.
+  fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
-REASON="[subagent-dispatch] the firstmate primary dispatches through the fleet, not the harness's own delegation tools: work started that way has no durable fleet record, leaves every firstmate guard inert, and dies with this session. Instead, $ROUTE (blocked tool: $TOOL, delegation-shaped on \"$MATCHED\"). Launch the session with FM_ALLOW_SUBAGENT=1 for a deliberate exception."
+  # Name the dedicated scout entry point only when this home carries it; degrade
+  # to the two-step brief-then-spawn path when it does not, rather than naming a
+  # script that is not there.
+  if [ -f "$FM_ROOT/bin/fm-scout.sh" ]; then
+    ROUTE='first classify the work under the AGENTS.md intake contract: work already classified as a scout goes to bin/fm-scout.sh "<question>" [project], while authorized ship work and its bounded research go to bin/fm-brief.sh then bin/fm-spawn.sh'
+  else
+    ROUTE='first classify the work under the AGENTS.md intake contract, then use bin/fm-brief.sh followed by bin/fm-spawn.sh for dispatched work'
+  fi
+
+  REASON="[subagent-dispatch] the firstmate primary dispatches through the fleet, not the harness's own delegation tools: work started that way has no durable fleet record, leaves every firstmate guard inert, and dies with this session. Instead, $ROUTE (blocked tool: $TOOL, delegation-shaped on \"$MATCHED_DELEGATION\"). Launch the session with FM_ALLOW_SUBAGENT=1 for a deliberate exception."
+fi
 
 json_escape() {
   printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr '\n' ' '

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -40,19 +40,48 @@ It says nothing about whether the resulting brief, project, or delivery mode is 
 It classifies the tool NAME by shape rather than against a fixed list.
 The tracked Claude PreToolUse matcher is `.*`, so every Claude tool name reaches the script and the script is the single owner of classification.
 A stem-enumerating matcher would reintroduce the fail-open-by-enumeration problem this guard exists to solve, because any future tool name outside the matcher would be silently missed before the script could inspect it.
+
+The script classifies a name into one of two shapes, because they carry different hazards and therefore different scopes.
 A tool is delegation-shaped when its normalized lowercase name contains one of these stems:
 
 ```text
-agent  subagent  task  workflow  cron  schedul  worktree
+agent  subagent  task  workflow  worktree
 delegate  spawn  dispatch  handoff  remote  sendmessage  monitor
 ```
+
+A tool is self-scheduling-shaped when it contains one of these stems:
+
+```text
+schedul  cron
+```
+
+Ordinary delegation creates a SEPARATE unit of work, so the hazard is work firstmate does not know about, and that hazard exists only where a fleet is operated.
+Self-scheduling creates no separate worker at all: it re-invokes the CALLER'S OWN session on a timer.
+That is a different hazard, and it is worst exactly where the old scope test was inert.
+Each timer wake replays the caller's entire accumulated context, so a one-line "nothing changed yet" turn is billed at the whole session's size, and every additional cycle is more expensive than the last because the session keeps growing.
+Nothing bounds the loop: it has no durable fleet record, no turn ceiling, and no wall-clock ceiling, so supervision can neither see it nor stop it.
+It is also redundant, because firstmate already owns a strictly cheaper way for a worker to wait.
+`bin/fm-watch.sh` runs `state/<id>.check.sh` polls as plain shell in the watcher process and wakes a session only when the check actually prints something, so an empty poll costs no model context at all.
+A worker that must wait therefore appends a `paused:` or `blocked:` status line and lets that supervision-owned poll wake it, with firstmate arming a custom condition through `bin/fm-check-register.sh`.
+
+So the two shapes are scoped differently:
+
+| Shape | Primary or secondmate home | Crewmate/scout task worktree | Non-firstmate repo |
+|---|---|---|---|
+| Ordinary delegation | denied | allowed | inert |
+| Self-scheduling | denied | denied | inert |
+
+A crewmate spawning a sub-agent for a slice of its own task stays legitimate and stays allowed.
+A crewmate putting itself in a timer loop does not, so that one shape follows the worker into its worktree.
+Neither shape ever fires outside firstmate territory: an unrelated repository on the machine is untouched, so a scheduling-shaped name there is never classified.
 
 Three exclusions keep the shape test from producing false positives.
 
 - A name beginning `mcp__` is never classified.
   An MCP server chooses its own tool names, a task or agent noun there is common, and it has no bearing on fleet dispatch.
-- `OBSERVE_ONLY_TOOLS`: the exact names `taskoutput`, `taskstop`, `taskget`, `tasklist`, `cronlist`, `bashoutput`, and `killshell` are allowed.
+- `OBSERVE_ONLY_TOOLS`: the exact names `taskoutput`, `taskstop`, `taskget`, `tasklist`, `cronlist`, `crondelete`, `bashoutput`, and `killshell` are allowed.
   These observe or stop work that already exists rather than creating it, and denying them at this layer could strand already-running work with no way to inspect or end it.
+  `crondelete` is on this list for exactly that reason: cancelling a schedule stops work and creates none, and once self-scheduling denial reaches task worktrees, a worker that already owns a schedule would otherwise have no way to cancel it.
   A Claude primary's optional local deny list may still remove them from the schema.
   The shipped guard stays narrower on purpose so it can never be the reason a runaway task cannot be stopped.
 - `PLAN_ONLY_TOOLS`: the exact names `taskcreate` and `taskupdate` are allowed.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -772,3 +772,38 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+
+test_scope_rule_is_present() {
+  local id="T-SCOPE"
+  local brief="$BRIEF_HOME/data/$id/brief.md"
+  rm -rf "$BRIEF_HOME/data/$id"
+  FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" "$id" sample-project --mode local-only > /dev/null
+
+  assert_grep "The task as briefed is the whole scope." "$brief" \
+    "ship brief missing the bounded scope rule"
+  assert_grep "Work you discover mid-task that is not required to finish" "$brief" \
+    "ship brief missing the adjacent work rule"
+  assert_grep "Report it with a status line and keep going" "$brief" \
+    "ship brief missing the report but don't absorb rule"
+  assert_grep "Corrections genuinely" "$brief" \
+    "ship brief missing the carve-out for necessary corrections"
+
+  pass "ship brief includes the bounded scope rule"
+}
+
+test_scout_scope_rule_is_present() {
+  local id="T-SCOUT-SCOPE"
+  local brief="$BRIEF_HOME/data/$id/brief.md"
+  rm -rf "$BRIEF_HOME/data/$id"
+  FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" "$id" sample-project --scout > /dev/null
+
+  assert_grep "The task as briefed is the whole scope." "$brief" \
+    "scout brief missing the bounded scope rule"
+  assert_grep "Work you discover mid-task that is not required to finish" "$brief" \
+    "scout brief missing the adjacent work rule"
+
+  pass "scout brief includes the bounded scope rule"
+}
+
+test_scope_rule_is_present
+test_scout_scope_rule_is_present

--- a/tests/fm-subagent-pretool-check.test.sh
+++ b/tests/fm-subagent-pretool-check.test.sh
@@ -79,7 +79,7 @@ test_guard_denies_every_currently_known_delegation_tool() {
   local tool
   for tool in $DELEGATION_TOOLS; do
     case "$tool" in
-      TaskOutput|TaskStop|TaskGet|TaskList|CronList) continue ;;
+      TaskOutput|TaskStop|TaskGet|TaskList|CronList|CronDelete) continue ;;
       TaskCreate|TaskUpdate) continue ;;
     esac
     expect_deny "known delegation tool" "$tool"
@@ -276,6 +276,91 @@ test_missing_jq_stdin_transport_fails_open() {
   pass "missing jq for stdin transport fails open rather than denying every tool call"
 }
 
+test_self_scheduling_denied_in_worktree() {
+  local child="$TMP_ROOT/child-sched" rc=0 actual
+  git -C "$PRIMARY" worktree add -q -b fixture-child-sched "$child"
+  mkdir -p "$child/bin" "$child/state"
+  printf '# fixture\n' > "$child/AGENTS.md"
+
+  local tool
+  for tool in ScheduleWakeup CronCreate ScheduleJob CronSchedule; do
+    rc=0
+    : > "$OUT"
+    : > "$ERR"
+    FM_ROOT_OVERRIDE="$child" FM_HOME="$child" FM_STATE_OVERRIDE="$child/state" \
+      "$CHECK" --claude --tool "$tool" > "$OUT" 2> "$ERR" || rc=$?
+    [ "$rc" -eq 2 ] || fail "self-scheduling tool $tool must be denied in task worktree, got exit $rc"
+
+    actual=$(jq -r '.systemMessage' "$ERR")
+    case "$actual" in
+      *"[subagent-dispatch]"*) ;;
+      *) fail "deny message must start with [subagent-dispatch], got: $actual" ;;
+    esac
+    case "$actual" in
+      *"blocked tool: $tool"*) ;;
+      *) fail "deny message must contain blocked tool: $tool, got: $actual" ;;
+    esac
+    case "$actual" in
+      *"paused:"*|*"blocked:"*) ;;
+      *) fail "deny message must mention status line wait path, got: $actual" ;;
+    esac
+    case "$actual" in
+      *"bin/fm-spawn.sh"*) fail "deny message must NOT mention fm-spawn.sh, got: $actual" ;;
+    esac
+  done
+
+  # Allow ordinary delegation
+  for tool in Agent Task SpawnWorker EnterWorktree; do
+    rc=0
+    FM_ROOT_OVERRIDE="$child" FM_HOME="$child" FM_STATE_OVERRIDE="$child/state" \
+      "$CHECK" --claude --tool "$tool" > "$OUT" 2> "$ERR" || rc=$?
+    [ "$rc" -eq 0 ] || fail "ordinary delegation $tool must be allowed in task worktree, got exit $rc"
+  done
+
+  # Allow ordinary tools
+  for tool in Bash Read Write; do
+    rc=0
+    FM_ROOT_OVERRIDE="$child" FM_HOME="$child" FM_STATE_OVERRIDE="$child/state" \
+      "$CHECK" --claude --tool "$tool" > "$OUT" 2> "$ERR" || rc=$?
+    [ "$rc" -eq 0 ] || fail "ordinary tool $tool must be allowed in task worktree, got exit $rc"
+  done
+
+  # Escape hatch allows self-scheduling in worktree
+  rc=0
+  FM_ALLOW_SUBAGENT=1 FM_ROOT_OVERRIDE="$child" FM_HOME="$child" FM_STATE_OVERRIDE="$child/state" \
+    "$CHECK" --claude --tool ScheduleWakeup > "$OUT" 2> "$ERR" || rc=$?
+  [ "$rc" -eq 0 ] || fail "escape hatch must allow self-scheduling in task worktree, got exit $rc"
+
+  # CronDelete and CronList allowed in worktree
+  for tool in CronDelete CronList; do
+    rc=0
+    FM_ROOT_OVERRIDE="$child" FM_HOME="$child" FM_STATE_OVERRIDE="$child/state" \
+      "$CHECK" --claude --tool "$tool" > "$OUT" 2> "$ERR" || rc=$?
+    [ "$rc" -eq 0 ] || fail "$tool must be allowed in task worktree, got exit $rc"
+  done
+
+  # CronDelete and CronList allowed in primary
+  for tool in CronDelete CronList; do
+    expect_allow "observe/stop tool" "$tool"
+  done
+
+  pass "self-scheduling tools are denied in worktree, ordinary delegation allowed, crondelete allowed"
+}
+
+test_self_scheduling_inert_in_non_firstmate_repo() {
+  local plain="$TMP_ROOT/plain-sched" rc=0
+  mkdir -p "$plain/bin"
+  git -C "$plain" init -q
+
+  for tool in ScheduleWakeup CronCreate; do
+    rc=0
+    FM_ROOT_OVERRIDE="$plain" FM_HOME="$plain" FM_STATE_OVERRIDE="$plain/state" \
+      "$CHECK" --claude --tool "$tool" > "$OUT" 2> "$ERR" || rc=$?
+    [ "$rc" -eq 0 ] || fail "self-scheduling $tool must be inert in non-firstmate repo, got exit $rc"
+  done
+  pass "self-scheduling tools are inert in non-firstmate repo"
+}
+
 test_guard_denies_every_currently_known_delegation_tool
 test_guard_denies_hypothetical_future_tools
 test_guard_allows_ordinary_and_observe_only_tools
@@ -289,3 +374,5 @@ test_secondmate_home_is_in_scope
 test_stdin_transports_and_output_shapes
 test_malformed_transport_fails_open
 test_missing_jq_stdin_transport_fails_open
+test_self_scheduling_denied_in_worktree
+test_self_scheduling_inert_in_non_firstmate_repo


### PR DESCRIPTION
## Problem

`bin/fm-subagent-pretool-check.sh` classifies a harness tool name by shape and denies delegation-shaped names, but it goes inert in a crewmate/scout task worktree. The stated rationale is that "a crewmate using delegation tools inside its own task worktree is legitimate."

That rationale holds for **ordinary delegation**, which creates a *separate* unit of work. It does not hold for **self-scheduling**, which creates no separate worker at all: it re-invokes the caller's **own** session on a timer.

The two carry different hazards:

- Ordinary delegation's hazard is work firstmate does not know about. That only matters where a fleet is operated, so the primary-only scope is right.
- Self-scheduling's hazard is an unbounded loop over one growing session, and it is worst **exactly where the scope test was inert**.

Each timer wake replays the caller's entire accumulated context, so a one-line "nothing changed yet" turn is billed at the whole session's size, and every additional cycle costs more than the last because the session keeps growing. Nothing bounds it: no durable fleet record, no turn ceiling, no wall-clock ceiling. Supervision can neither see the loop nor stop it.

It is also redundant. Firstmate already owns a strictly cheaper wait: `bin/fm-watch.sh` runs `state/<id>.check.sh` polls as plain shell in the watcher process and wakes a session **only when a check actually prints something**, so an empty poll costs no model context at all. The generated brief already tells workers to use a `paused:` status line for a bounded external wait — the guard simply never stopped a worker from reaching for a timer instead.

The asymmetry before this change:

| Tool | Primary home | Task worktree |
|---|---|---|
| `ScheduleWakeup` | deny | **allow** |
| `CronCreate` | deny | **allow** |
| `Agent` | deny | allow |

The same name firstmate refuses in a primary was freely available in the worktree where long-running workers actually run.

## Change

Split the classification so each shape gets the scope its hazard needs.

- New `SELF_SCHEDULING_STEMS` (`schedul`, `cron`), moved out of `DELEGATION_STEMS` so each stem has exactly one owner.
- Self-scheduling is denied in a task worktree **as well as** a primary or secondmate home. Ordinary delegation keeps today's behavior exactly and stays allowed in a worktree — a crewmate spawning a sub-agent for a slice of its own task is still legitimate.
- Neither shape fires outside firstmate territory, so an unrelated repository on the machine is untouched and a scheduling-shaped name there is never classified.
- The self-scheduling deny names the supported wait path (a `paused:`/`blocked:` status line, with firstmate arming a custom condition via `bin/fm-check-register.sh`) rather than the brief-then-spawn route, which is wrong advice for a worker that only needs to wait.
- `crondelete` joins `OBSERVE_ONLY_TOOLS`. Cancelling a schedule stops work and creates none, and without it a worker that already owns a schedule would have no way to cancel one once denial reaches worktrees. This relaxes the primary too, which that list's own stated rationale ("never the reason a runaway task cannot be stopped") intends.

Classification stays **shape-based**, not a fixed name list, so a future scheduling tool nobody has seen is still caught.

Resulting scope:

| Shape | Primary / secondmate | Task worktree | Non-firstmate repo |
|---|---|---|---|
| Ordinary delegation | denied | allowed | inert |
| Self-scheduling | denied | **denied** | inert |

### Second, smaller fix

The generated crewmate brief bounded delivery and escalation but said nothing about work **discovered mid-task**, so a mission that keeps finding new items of the same kind had no terminal condition — it could absorb newly appearing work into the current task indefinitely.

`AGENTS.md` already carries that rule ("prefer routing new requirements to follow-up work rather than expanding the current task"), but a crewmate runs in a worktree of the *target project* and never loads firstmate's `AGENTS.md`, so the contract never reached the worker who needed it. The secondmate charter has the idea in stronger form; crewmates had no equivalent.

Added one rule to the ship and scout scaffolds: the briefed task is the whole scope, discovered adjacent work is reported rather than absorbed, and firstmate decides whether it becomes a separate task. It carries an explicit carve-out so corrections genuinely required to make the briefed work correct stay in scope — without that, the rule would tell workers to escalate ordinary bug-fixing.

## Preserved invariants

Every existing safety property is intact and still covered by the original tests: `mcp__*` is never classified; both exclusion lists stay exact-name; `FM_ALLOW_SUBAGENT=1` remains the single escape hatch and releases the new denial too; malformed/empty stdin, a missing tool name, and a missing `jq` all still fail open; a broken environment fails open rather than denying; deny output shape is unchanged (exit 2, empty stdout under `--claude`, Claude object on stderr, Grok object on stdout otherwise); the message still starts with `[subagent-dispatch]` and contains `blocked tool: <name>`; a marked secondmate home stays guarded. The primary-home guard is not weakened anywhere.

## Tests

Extended the two already-registered suites rather than adding files, so the coverage manifest and per-file timing budgets are unaffected.

New coverage: self-scheduling denied in a task worktree (including invented future names `ScheduleJob`, `CronSchedule` to pin the shape match); ordinary delegation still allowed there (`Agent`, `Task`, `SpawnWorker`, `EnterWorktree`) to pin the fix's narrowness; ordinary tools still allowed; the escape hatch releasing the new denial; the deny message being the wait-path text and *not* the spawn text; `CronDelete`/`CronList` allowed in both scopes; inertness in a non-firstmate repo; and the brief scope rule in both scaffolds.

Both new tests were confirmed red on the pre-change code and green after:

```
not ok - self-scheduling tool ScheduleWakeup must be denied in task worktree, got exit 0
not ok - ship brief missing the bounded scope rule
```

Results:

```
tests/fm-subagent-pretool-check.test.sh    PASS (15 checks)
tests/fm-brief.test.sh                     PASS (23 checks)
```

Suites that consume generated briefs, checked for ripple, all passing:

```
fm-ask-user-authority   fm-secondmate-safety (77)   fm-tangle-guard (6)
fm-classify-corr-token (12)                         fm-voice-relay (40)
```

Gates:

```
bin/fm-lint.sh                  exit 0  (ShellCheck 0.11.0 extended, actionlint 1.7.12)
bin/fm-test-run.sh --check-coverage
  FM_TEST_COVERAGE ok total=166 parallel=24 serial=130 serial_shards=4 herdr=12
```

Also verified against a real on-disk task worktree in the `fm-spawn` environment shape (`FM_HOME` at the primary home, overrides cleared): `ScheduleWakeup`, `CronCreate`, `ScheduleJob` deny; `Agent`, `Task`, `SpawnWorker`, `Bash`, `CronDelete`, `CronList` allow.
