### PR TITLE
fix(bearings): make fleet board descriptions readable

### DIFF
--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -241,10 +241,17 @@ a { color: inherit; text-decoration: none; }
 }
 .bb-row:first-child { border-top: none; }
 .bb-row__main { min-width: 0; flex: 1 1 auto; }
+/* Row text wraps before it clips: a one-line clamp hid what these rows were
+   about, so the title gets three lines and its secondary line two.
+   overflow-wrap keeps an unbreakable URL or id from setting a min-content width
+   that the .bb-row__main min-width:0 shrink could not absorb, and overflow
+   hidden keeps whatever passes the clamp off the page's own horizontal axis. */
 .bb-row__title { font-size: var(--fs-sm); font-weight: 700; color: var(--text-strong); line-height: 1.3;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 3;
+  overflow: hidden; text-overflow: ellipsis; overflow-wrap: anywhere; }
 .bb-row__sub { font-size: var(--fs-xs); color: var(--text-muted); line-height: 1.3; margin-top: 1px;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2;
+  overflow: hidden; text-overflow: ellipsis; overflow-wrap: anywhere; }
 .bb-row__id { font-family: var(--font-mono); font-size: var(--fs-2xs); color: var(--text-faint); white-space: nowrap; }
 .bb-row__pr { font-family: var(--font-mono); font-size: var(--fs-xs); font-weight: 600; color: var(--ocean-600); white-space: nowrap; }
 .bb-row__pr:hover { text-decoration: underline; }

--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -188,16 +188,23 @@ a { color: inherit; text-decoration: none; }
 .bb-call > .bb-decision[hidden] { display: none; }
 .bb-decision { display: flex; flex-direction: column; }
 .bb-decision__pad { padding: 18px 20px 16px; display: flex; flex-direction: column; gap: 12px; flex: 1; }
-.bb-decision__top { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.bb-decision__top { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; }
+/* Safety net for the risk-value contract owned by fm-bearings-board.sh: unlike
+   every other badge, this pin may still receive a long bare level. */
+.bb-decision__risk { white-space: normal; overflow-wrap: anywhere; text-align: left;
+  min-width: 0; flex: 0 1 auto; line-height: 1.35; }
 .bb-decision__repo { font-family: var(--font-mono); font-size: var(--fs-2xs); color: var(--text-faint); white-space: nowrap; }
 .bb-decision__title { margin: 0; font-size: var(--fs-h4); font-weight: 800; color: var(--text-strong); line-height: 1.25; }
 .bb-decision__detail { margin: 0; font-size: var(--fs-sm); color: var(--text-muted); line-height: 1.45; }
-/* about / decide / recommended - three scannable context rows */
+/* about / decide / recommended - three scannable context rows.
+   The shared value boundary also receives composed text moved off the risk pin,
+   so it must break a justification even when that text is one unbroken token. */
 .bb-ctx { display: flex; flex-direction: column; gap: 6px; }
 .bb-ctx__row { display: grid; grid-template-columns: 78px minmax(0,1fr); gap: 8px; align-items: baseline; }
 .bb-ctx__k { font-family: var(--font-mono); font-size: var(--fs-2xs); letter-spacing: 0.04em;
   text-transform: uppercase; color: var(--text-faint); white-space: nowrap; }
-.bb-ctx__v { font-size: var(--fs-sm); color: var(--text-muted); line-height: 1.4; min-width: 0; }
+.bb-ctx__v { font-size: var(--fs-sm); color: var(--text-muted); line-height: 1.4; min-width: 0;
+  overflow-wrap: anywhere; }
 .bb-decision__link { font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--ocean-600); font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block; }
 .bb-decision__link:hover { text-decoration: underline; }
 /* One rhythm owner: the answer form is a flex column with the same 12px gap as
@@ -473,6 +480,22 @@ __FM_BEARINGS_BOARD_DATA__
 
   /* Captain's Call deck: every item renders as the same full card */
   var deck = document.getElementById("bb-call");
+  /* Implements the fm-bearings-board.v1 risk contract documented in the
+     builder header. */
+  function splitRisk(value) {
+    var text = String(value == null ? "" : value).trim();
+    var cut = text.indexOf(".");
+    if (cut < 0) return { level: text, detail: "" };
+    return { level: text.slice(0, cut).trim(), detail: text.slice(cut + 1).trim() };
+  }
+
+  /* Do not broaden this to substring matching; see the builder header's
+     fail-cautious tone contract. */
+  var LOW_RISK_LEVELS = ["low", "faible"];
+  function isLowRisk(level) {
+    return LOW_RISK_LEVELS.indexOf(String(level == null ? "" : level).trim().toLowerCase()) >= 0;
+  }
+
   function ctxRow(k, v, rec) {
     var row = el("div", "bb-ctx__row" + (rec ? " bb-ctx__row--rec" : ""));
     row.appendChild(el("span", "bb-ctx__k", k));
@@ -483,11 +506,18 @@ __FM_BEARINGS_BOARD_DATA__
   data.captains_call.forEach(function (item) {
     var card = el("div", "fm-card fm-card--poster bb-decision");
     var pad = el("div", "bb-decision__pad");
+    var risk = item.type === "merge" ? splitRisk(item.risk) : null;
 
     var top = el("div", "bb-decision__top");
     if (item.type === "merge") {
       top.appendChild(badge("online", "checks green"));
-      top.appendChild(badge(item.risk === "low" ? "neutral" : "warn", "risk " + item.risk));
+      /* Preserve the builder header's empty-level rule: never announce a bare,
+         alert-colored "risk" badge. */
+      if (risk.level) {
+        var riskPin = badge(isLowRisk(risk.level) ? "neutral" : "warn", "risk " + risk.level);
+        riskPin.className += " bb-decision__risk";
+        top.appendChild(riskPin);
+      }
     } else {
       top.appendChild(badge("solid", "decision"));
       top.appendChild(el("span", "bb-decision__repo", item.repo));
@@ -498,6 +528,11 @@ __FM_BEARINGS_BOARD_DATA__
 
     if (item.type === "merge") {
       if (item.detail) pad.appendChild(el("p", "bb-decision__detail", item.detail));
+      if (risk.detail) {
+        var riskCtx = el("div", "bb-ctx");
+        riskCtx.appendChild(ctxRow("risk", risk.detail));
+        pad.appendChild(riskCtx);
+      }
       if (item.pr_url) {
         var pr = el("a", "bb-decision__link", item.pr_url);
         pr.href = item.pr_url; pr.target = "_blank"; pr.rel = "noopener";

--- a/bin/fm-bearings-board.sh
+++ b/bin/fm-bearings-board.sh
@@ -72,6 +72,17 @@
 # the template may display the routing id. Anything else refuses before the
 # existing board is touched.
 #
+# A merge item's `risk` is one display string with one parsing rule: trimmed
+# text before the first period is the level shown on the pin, and trimmed text
+# after it is the justification shown in the card body. With no period, the
+# whole value is a bare level and no justification row is rendered. A
+# whitespace-only level renders no pin, even though the field itself must be a
+# non-empty string. Only the trimmed, lower-cased levels `low` and `faible`
+# receive the neutral tone; every unrecognized level stays alert. The renderer
+# wraps either part, including an unbroken token, so neither can escape its
+# card. The body placement keeps the justification available on touch and in
+# print instead of hiding it behind hover.
+#
 # The board path is stable - $FM_HOME/.lavish/bearings-board.html - so a
 # re-invocation rebuilds the same file in place, which keeps the same Lavish
 # session URL and the same canonical process-event source id. Injection escapes

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -351,7 +351,8 @@ family_for_basename() {
     fm-afk-inject-e2e.test.sh|fm-afk-return.test.sh)
       printf '%s\n' afk
       ;;
-    fm-bearings-board-render.test.sh|fm-bearings-snapshot.test.sh|\
+    fm-bearings-board-layout.test.sh|fm-bearings-board-render.test.sh|\
+    fm-bearings-snapshot.test.sh|\
     fm-fleet-snapshot-view.test.sh|fm-home-summary-refresh.test.sh)
       printf '%s\n' snapshot-bearings
       ;;
@@ -1134,10 +1135,11 @@ select_family() {
 }
 
 families_for_test_reference() {
-  local needle=$1 s
+  local needle=$1 excluded_script=${2:-} s
   local found=0
   while IFS= read -r s; do
     [ -n "$s" ] || continue
+    [ "$s" = "$excluded_script" ] && continue
     if grep -Fq "$needle" "$s"; then
       family_for_basename "$(basename "$s")"
       found=1
@@ -1429,6 +1431,15 @@ families_for_changed_path() {
     tests/lib.sh|tests/*-helpers.sh|tests/fixtures.sh)
       families_for_test_reference "$(basename "$path")" \
         || printf '%s\n' "__unmapped__:$path"
+      ;;
+    tests/assets/*)
+      # The selector suite embeds asset paths as fixture data; it exercises
+      # this mapping but does not consume those assets. Scan references even
+      # after deletion so an unchanged consumer still gets selected.
+      if ! families_for_test_reference "$path" tests/fm-test-run.test.sh \
+          && [ -e "$path" ]; then
+        printf '%s\n' "__unmapped__:$path"
+      fi
       ;;
     tests/fixtures/*/*)
       # A fixture belongs to whichever suite reads its directory, found by the

--- a/tests/assets/board-render-harness.mjs
+++ b/tests/assets/board-render-harness.mjs
@@ -3,7 +3,9 @@
 // asserted through the real template rather than by reading its source.
 //
 // Usage: node board-render-harness.mjs <built-board.html>
-// Prints one JSON document: { stats:[{n,label}], charted:[{title,sub,badges,pickable}] }
+// Prints one JSON document:
+//   { stats:[{n,label}], charted:[{title,sub,badges,pickable}],
+//     calls:[{title,badges,ctx:[{k,v}]}] }
 import { readFileSync } from "node:fs";
 
 const html = readFileSync(process.argv[2], "utf8");
@@ -22,9 +24,18 @@ class Node {
     this.type = "";
     this.value = "";
     this.checked = false;
+    const tokens = () => this.className.split(/\s+/).filter(Boolean);
     this.classList = {
       add: (c) => { this.className = (this.className + " " + c).trim(); },
-      contains: (c) => this.className.split(/\s+/).includes(c),
+      contains: (c) => tokens().includes(c),
+      remove: (c) => { this.className = tokens().filter((t) => t !== c).join(" "); },
+      // Card-deck navigation drives the class it wants with an explicit second
+      // argument, so honour force before falling back to flipping.
+      toggle: (c, force) => {
+        const on = force === undefined ? !tokens().includes(c) : Boolean(force);
+        if (on) this.classList.add(c); else this.classList.remove(c);
+        return on;
+      },
     };
   }
   get textContent() {
@@ -85,7 +96,12 @@ new Function(script)();
 const badgesOf = (row) =>
   row.children
     .filter((c) => c.className.includes("fm-badge"))
-    .map((c) => ({ tone: c.className.replace(/.*fm-badge--/, "").trim(), text: c.textContent }));
+    // A badge may carry further classes after its tone, so read the tone token
+    // itself rather than everything that follows the prefix.
+    .map((c) => ({
+      tone: (c.className.match(/fm-badge--([\w-]+)/) || [, ""])[1],
+      text: c.textContent,
+    }));
 
 const strip = byId.get("bb-stats") || new Node("div");
 const stats = strip.children.map((t) => ({
@@ -105,6 +121,25 @@ const charted = ch.children
       pickable: row.children.some((c) => c.className.includes("bb-pick") && !c.className.includes("spacer")),
     };
   });
+// Captain's Call cards: the badges each card wears and the context rows in its
+// body, so what the risk value renders as is asserted through the template.
+const deck = byId.get("bb-call") || new Node("div");
+const calls = deck.children
+  .filter((c) => c.className.split(/\s+/).includes("bb-decision"))
+  .map((card) => {
+    const pad = card.children.find((c) => c.className.includes("bb-decision__pad"));
+    const top = pad?.children.find((c) => c.className.includes("bb-decision__top"));
+    const ctx = pad?.children.find((c) => c.className.includes("bb-ctx"));
+    return {
+      title: pad?.children.find((c) => c.className.includes("bb-decision__title"))?.textContent ?? "",
+      badges: top ? badgesOf(top) : [],
+      ctx: (ctx?.children ?? []).map((row) => ({
+        k: row.children.find((c) => c.className.includes("bb-ctx__k"))?.textContent ?? "",
+        v: row.children.find((c) => c.className.includes("bb-ctx__v"))?.textContent ?? "",
+      })),
+    };
+  });
+
 // A fail-closed render replaces the page body instead of the board sections, so
 // surface it rather than reporting an empty board as a successful render.
 const errorText = [...byId.entries()]
@@ -114,4 +149,4 @@ const errorText = [...byId.entries()]
 const empty = ch.children.filter((c) => c.className.includes("bb-empty")).map((c) => c.textContent);
 const more = ch.children.filter((c) => c.className.includes("bb-morechip")).map((c) => c.textContent);
 
-process.stdout.write(JSON.stringify({ stats, charted, empty, more, error: errorText }) + "\n");
+process.stdout.write(JSON.stringify({ stats, charted, calls, empty, more, error: errorText }) + "\n");

--- a/tests/fm-bearings-board-layout.test.sh
+++ b/tests/fm-bearings-board-layout.test.sh
@@ -8,6 +8,15 @@ set -u
 
 BOARD="$ROOT/bin/fm-bearings-board.sh"
 TMP_ROOT=$(fm_test_tmproot fm-bearings-board-layout)
+LAYOUT_HOME="$TMP_ROOT/home"
+
+layout_teardown() {
+  FM_HOME="$LAYOUT_HOME" FM_STATE_OVERRIDE="$LAYOUT_HOME/state" FM_DATA_OVERRIDE="$LAYOUT_HOME/data" \
+    FM_PROCEVENT_CLAIM_ROOT="$LAYOUT_HOME/procevent-claims" \
+    "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
+  fm_test_cleanup
+}
+trap layout_teardown EXIT
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
 command -v node >/dev/null 2>&1 || { echo "skip: node not found"; exit 0; }
@@ -76,7 +85,7 @@ smoke_browser() {
 }
 
 make_board() {
-  local home="$TMP_ROOT/home" fakebin data long_title long_reason long_level long_detail board
+  local home="$LAYOUT_HOME" fakebin data long_title long_reason long_level long_detail board
   mkdir -p "$home/state" "$home/data"
   fakebin=$(fm_fakebin "$home")
   # The build proves the board session is live before it arms anything, so the

--- a/tests/fm-bearings-board-layout.test.sh
+++ b/tests/fm-bearings-board-layout.test.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Browser-level layout regressions for the shipped bearings fleet board.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BOARD="$ROOT/bin/fm-bearings-board.sh"
+TMP_ROOT=$(fm_test_tmproot fm-bearings-board-layout)
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+command -v node >/dev/null 2>&1 || { echo "skip: node not found"; exit 0; }
+
+find_chrome() {
+  local candidate
+  if [ -n "${FM_CHROME_BIN:-}" ] && [ -x "$FM_CHROME_BIN" ]; then
+    printf '%s\n' "$FM_CHROME_BIN"
+    return 0
+  fi
+  for candidate in \
+    google-chrome \
+    google-chrome-stable \
+    chromium \
+    chromium-browser \
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      command -v "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+CHROME=$(find_chrome) || { echo "skip: Chrome or Chromium not found"; exit 0; }
+
+dump_dom() {
+  local source=$1 dom=$2 profile=$3 width=$4 marker=$5
+  local chrome_pid chrome_wait=0 rendered=false
+  "$CHROME" \
+    --headless=new \
+    --disable-gpu \
+    --disable-dev-shm-usage \
+    --no-sandbox \
+    --user-data-dir="$profile" \
+    --window-size="$width,900" \
+    --virtual-time-budget=2000 \
+    --dump-dom \
+    "$source" > "$dom" 2>/dev/null &
+  chrome_pid=$!
+  while kill -0 "$chrome_pid" 2>/dev/null && [ "$chrome_wait" -lt 300 ]; do
+    if grep -Fq '</html>' "$dom" 2>/dev/null && grep -Fq "$marker" "$dom" 2>/dev/null; then
+      rendered=true
+      break
+    fi
+    sleep 0.1
+    chrome_wait=$((chrome_wait + 1))
+  done
+  kill "$chrome_pid" 2>/dev/null || true
+  wait "$chrome_pid" 2>/dev/null || true
+  if grep -Fq '</html>' "$dom" 2>/dev/null && grep -Fq "$marker" "$dom" 2>/dev/null; then
+    rendered=true
+  fi
+  [ "$rendered" = true ]
+}
+
+smoke_browser() {
+  local dom="$TMP_ROOT/smoke.html" profile="$TMP_ROOT/chrome-smoke"
+  if ! dump_dom \
+    'data:text/html,<html><body><div id="fm-browser-smoke">ready</div></body></html>' \
+    "$dom" "$profile" 800 'id="fm-browser-smoke"'; then
+    echo "skip: Chrome or Chromium could not render headless"
+    exit 0
+  fi
+}
+
+make_board() {
+  local home="$TMP_ROOT/home" fakebin data long_title long_reason long_level long_detail board
+  mkdir -p "$home/state" "$home/data"
+  fakebin=$(fm_fakebin "$home")
+  # The build proves the board session is live before it arms anything, so the
+  # stub reports the opened shape the real lavish-axi emits. This suite is about
+  # how the built board lays out, not about session liveness, which
+  # tests/fm-bearings-board.test.sh owns.
+  cat > "$fakebin/lavish-axi" <<'SH'
+#!/usr/bin/env bash
+case "${1-}" in
+  --version) printf '0.1.61\n' ;;
+  '')
+    printf 'sessions[1]{file,status,url,pending_prompts}:\n'
+    [ ! -s "$FM_HOME/lavish-open" ] \
+      || printf '  %s,open,"http://127.0.0.1/session/layout",0\n' "$(cat "$FM_HOME/lavish-open")"
+    ;;
+  poll) while :; do sleep 1; done ;;
+  *)
+    real=$(cd "$(dirname "$1")" && pwd -P)/$(basename "$1")
+    printf '%s\n' "$real" > "$FM_HOME/lavish-open"
+    printf 'session:\n  status: opened\n'
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/lavish-axi"
+  data="$home/payload.json"
+  long_title="$(printf 'Readable title segment %.0s' {1..24})"
+  long_reason="$(printf 'Readable secondary context %.0s' {1..18})"
+  long_level="$(printf 'x%.0s' {1..180})"
+  long_detail="$(printf 'y%.0s' {1..180})"
+  jq -n \
+    --arg title "$long_title" \
+    --arg reason "$long_reason" \
+    --arg long_level "$long_level" \
+    --arg long_detail "$long_detail" '{
+      schema:"fm-bearings-board.v1",
+      home:"layout-home",
+      generated:"2026-08-27T00:00Z",
+      prs_live:false,
+      captains_call:[
+        {
+          key:"long-level",
+          type:"merge",
+          repo:"sample",
+          title:"Keep an unbroken risk level inside its card",
+          risk:$long_level,
+          options:[{value:"merge", label:"Merge"}]
+        },
+        {
+          key:"long-detail",
+          type:"merge",
+          repo:"sample",
+          title:"Keep a moved risk justification readable",
+          risk:("faible. " + $long_detail),
+          options:[{value:"merge", label:"Merge"}]
+        }
+      ],
+      underway:[],
+      landed:[],
+      charted:[{
+        id:"long-row",
+        repo:"sample",
+        title:$title,
+        reason:$reason,
+        dispatchable:true
+      }],
+      charted_more:0,
+      charted_warning_more:0
+    }' > "$data"
+  PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
+    "$BOARD" build "$data" >/dev/null || fail "the layout fixture board did not build"
+  board="$home/.lavish/bearings-board.html"
+  node - "$board" <<'JS' || fail "the browser layout probe could not be installed"
+const fs = require("node:fs");
+const path = process.argv[2];
+const html = fs.readFileSync(path, "utf8");
+const probe = String.raw`<script>
+(function () {
+  function lineCount(element) {
+    var style = getComputedStyle(element);
+    return element.getBoundingClientRect().height / parseFloat(style.lineHeight);
+  }
+  function within(inner, outer) {
+    var innerRect = inner.getBoundingClientRect();
+    var outerRect = outer.getBoundingClientRect();
+    return innerRect.left >= outerRect.left - 0.5 && innerRect.right <= outerRect.right + 0.5;
+  }
+  var title = document.querySelector("#bb-charted .bb-row__title");
+  var subtitle = document.querySelector("#bb-charted .bb-row__sub");
+  var firstCard = document.querySelector("#bb-call .bb-decision:not([hidden])");
+  var riskPin = firstCard.querySelector(".bb-decision__risk");
+  var result = {
+    titleLines: lineCount(title),
+    subtitleLines: lineCount(subtitle),
+    riskPinInsideCard: within(riskPin, firstCard),
+    scrollWidth: document.documentElement.scrollWidth,
+    viewportWidth: document.documentElement.clientWidth,
+    windowWidth: window.innerWidth
+  };
+  document.getElementById("bb-stack-next").click();
+  var secondCard = document.querySelector("#bb-call .bb-decision:not([hidden])");
+  var riskValue = secondCard.querySelector(".bb-ctx__v");
+  result.riskValueInsideCard = within(riskValue, secondCard);
+  result.riskValueLines = lineCount(riskValue);
+  result.riskValueScrollWidth = riskValue.scrollWidth;
+  result.riskValueClientWidth = riskValue.clientWidth;
+  var output = document.createElement("pre");
+  output.id = "fm-layout-result";
+  output.textContent = JSON.stringify(result);
+  document.body.appendChild(output);
+}());
+</script>`;
+if (!html.includes("</body>")) process.exit(1);
+fs.writeFileSync(path, html.replace("</body>", `${probe}\n</body>`));
+JS
+  printf '%s\n' "$board"
+}
+
+render_viewport() {
+  local board=$1 width=$2 dom="$TMP_ROOT/layout-$2.html" profile="$TMP_ROOT/chrome-$2"
+  if ! dump_dom "file://$board" "$dom" "$profile" "$width" 'id="fm-layout-result"'; then
+    fail "the board did not render in a ${width}px browser viewport"
+  fi
+  node - "$dom" "$width" <<'JS' || fail "the board layout escaped its bounds at ${width}px"
+const fs = require("node:fs");
+const dom = fs.readFileSync(process.argv[2], "utf8");
+const width = Number(process.argv[3]);
+const match = dom.match(/<pre id="fm-layout-result">([^<]+)<\/pre>/);
+if (!match) throw new Error("the browser did not emit layout measurements");
+const result = JSON.parse(match[1]);
+const close = (actual, expected) => Math.abs(actual - expected) <= 0.08;
+const failures = [];
+if (!(result.titleLines > 1.5 && result.titleLines <= 3.08)) failures.push(`title lines=${result.titleLines}`);
+if (!(result.subtitleLines > 1.5 && result.subtitleLines <= 2.08)) failures.push(`subtitle lines=${result.subtitleLines}`);
+if (!result.riskPinInsideCard) failures.push("risk pin left its card");
+if (!result.riskValueInsideCard) failures.push("risk detail box left its card");
+if (!(result.riskValueLines > 1.5)) failures.push(`risk detail lines=${result.riskValueLines}`);
+if (result.riskValueScrollWidth > result.riskValueClientWidth + 1) {
+  failures.push(`risk detail scroll=${result.riskValueScrollWidth}, client=${result.riskValueClientWidth}`);
+}
+// The layout viewport excludes a classic scrollbar while innerWidth does not,
+// so compare overflow to clientWidth and the requested size to innerWidth.
+if (result.scrollWidth !== result.viewportWidth || result.windowWidth !== width) {
+  failures.push(`document=${result.scrollWidth}, viewport=${result.viewportWidth}, window=${result.windowWidth}, requested=${width}`);
+}
+if (failures.length) throw new Error(failures.join("; "));
+if (!close(result.titleLines, 3)) throw new Error(`long title did not reach its three-line clamp: ${result.titleLines}`);
+if (!close(result.subtitleLines, 2)) throw new Error(`long subtitle did not reach its two-line clamp: ${result.subtitleLines}`);
+JS
+}
+
+smoke_browser
+board=$(make_board) || exit 1
+render_viewport "$board" 1440
+render_viewport "$board" 620
+pass "bearings rows and risk text stay readable and contained at desktop and narrow widths"

--- a/tests/fm-bearings-board-render.test.sh
+++ b/tests/fm-bearings-board-render.test.sh
@@ -64,19 +64,39 @@ SH
   printf '%s\n' "$home"
 }
 
-# Build the board from <charted-json> and return what the renderer produced.
-render() {  # <home> <charted-json> [charted_more] [charted_warning_more]
-  local home=$1 charted=$2 more=${3:-0} warning_more=${4:-0} data="$1/payload.json"
-  jq -n --argjson charted "$charted" --argjson more "$more" --argjson warning_more "$warning_more" '{
-    schema:"fm-bearings-board.v1", home:"render-home", generated:"2026-08-26T00:00Z",
-    prs_live:false, captains_call:[], underway:[], landed:[],
-    charted:$charted, charted_more:$more, charted_warning_more:$warning_more}' > "$data"
+# Build a board from a full payload and return what the renderer produced.
+render_payload() {  # <home> <payload-json>
+  local home=$1 data="$1/payload.json"
+  printf '%s' "$2" > "$data"
   PATH="$home/fakebin:$PATH" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
     "$BOARD" build "$data" >/dev/null || fail "the board did not build"
   node "$HARNESS" "$home/.lavish/bearings-board.html" \
     || fail "the built board could not be rendered"
+}
+
+# Build the board from <charted-json> and return what the renderer produced.
+render() {  # <home> <charted-json> [charted_more] [charted_warning_more]
+  local home=$1 charted=$2 more=${3:-0} warning_more=${4:-0}
+  render_payload "$home" "$(jq -n \
+    --argjson charted "$charted" --argjson more "$more" --argjson warning_more "$warning_more" '{
+    schema:"fm-bearings-board.v1", home:"render-home", generated:"2026-08-26T00:00Z",
+    prs_live:false, captains_call:[], underway:[], landed:[],
+    charted:$charted, charted_more:$more, charted_warning_more:$warning_more}')"
+}
+
+# Build a board whose only item is one merge call carrying <risk-json>, which is
+# a JSON value so an absent field can be tested as well as an empty one.
+render_merge_risk() {  # <home> <risk-json>
+  local home=$1
+  render_payload "$home" "$(jq -n --argjson risk "$2" '{
+    schema:"fm-bearings-board.v1", home:"render-home", generated:"2026-08-26T00:00Z",
+    prs_live:false, underway:[], landed:[], charted:[], charted_more:0,
+    captains_call:[({
+      key:"merge-one", type:"merge", repo:"sample", title:"Merge one",
+      options:[{value:"merge", label:"Merge"}]
+    } + (if $risk == null then {} else {risk:$risk} end))]}')"
 }
 
 charted_next_count() {  # <render-json>
@@ -166,8 +186,92 @@ test_an_omitted_kind_keeps_the_existing_queued_rendering() {
   pass "an omitted kind renders exactly as queued work always did"
 }
 
+test_a_composed_risk_leaves_only_the_level_on_the_pin() {
+  local home out
+  home=$(make_home risk-composed)
+  out=$(render_merge_risk "$home" '"faible. Une vue derivee et un index par paragraphe"')
+  printf '%s' "$out" | jq -e '
+    (.calls | length) == 1
+      and ([.calls[0].badges[] | .text] == ["checks green", "risk faible"])
+      and (.calls[0].ctx == [{k:"risk", v:"Une vue derivee et un index par paragraphe"}])
+  ' >/dev/null || fail "the justification did not move off the pin into the card: $out"
+  pass "a composed risk keeps the level on the pin and reads its justification in the card"
+}
+
+test_a_bare_level_adds_no_context_row() {
+  local home out
+  home=$(make_home risk-bare)
+  out=$(render_merge_risk "$home" '"faible"')
+  printf '%s' "$out" | jq -e '
+    ([.calls[0].badges[] | .text] == ["checks green", "risk faible"])
+      and (.calls[0].ctx == [])
+  ' >/dev/null || fail "a bare level produced an orphan row: $out"
+  pass "a bare risk level renders as the pin alone, with no context row"
+}
+
+test_a_low_level_reads_as_low_in_either_language() {
+  local home out tone
+  for risk in '"faible"' '"  Faible  "' '"low"' '"LOW"'; do
+    home=$(make_home "risk-low-$(printf '%s' "$risk" | tr -cd '[:alnum:]')")
+    out=$(render_merge_risk "$home" "$risk")
+    tone=$(printf '%s' "$out" | jq -r '[.calls[0].badges[] | select(.text | startswith("risk"))][0].tone')
+    [ "$tone" = "neutral" ] \
+      || fail "risk $risk wore the $tone tone instead of reading as low: $out"
+  done
+  pass "a low level reads as low in either language, whatever its casing or spacing"
+}
+
+test_an_unrecognised_level_keeps_the_alert_tone() {
+  local home out
+  home=$(make_home risk-unrecognised)
+  out=$(render_merge_risk "$home" '"eleve. Touche la migration de donnees"')
+  printf '%s' "$out" | jq -e '
+    ([.calls[0].badges[] | select(.text | startswith("risk")) | .tone] == ["warn"])
+  ' >/dev/null || fail "an unrecognised level lost the alert tone: $out"
+  pass "an unrecognised level keeps the alert tone rather than erring toward calm"
+}
+
+test_a_blank_risk_wears_no_pin_at_all() {
+  local home out
+  home=$(make_home risk-blank)
+  out=$(render_merge_risk "$home" '"   "')
+  printf '%s' "$out" | jq -e '
+    ([.calls[0].badges[] | .text] == ["checks green"]) and (.calls[0].ctx == [])
+  ' >/dev/null || fail "a blank risk announced a risk the record never stated: $out"
+  pass "a blank risk wears no pin and leaves no orphan row"
+}
+
+# A merge call with no risk at all never reaches the renderer, so the guarantee
+# is asserted where it is actually enforced rather than assumed downstream.
+test_a_merge_call_without_a_risk_is_refused_at_build() {
+  local home data risk
+  home=$(make_home risk-refused)
+  for risk in 'null' '""'; do
+    data="$home/refused.json"
+    jq -n --argjson risk "$risk" '{
+      schema:"fm-bearings-board.v1", home:"render-home", generated:"2026-08-26T00:00Z",
+      prs_live:false, underway:[], landed:[], charted:[], charted_more:0,
+      captains_call:[({key:"merge-one", type:"merge", repo:"sample", title:"Merge one",
+        options:[{value:"merge", label:"Merge"}]}
+        + (if $risk == null then {} else {risk:$risk} end))]}' > "$data"
+    if PATH="$home/fakebin:$PATH" FM_HOME="$home" \
+      FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+      FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
+      "$BOARD" build "$data" >/dev/null 2>&1; then
+      fail "a merge call with risk $risk was built instead of refused"
+    fi
+  done
+  pass "a merge call with no risk value is refused at build rather than rendered"
+}
+
 test_a_warning_row_reads_as_a_repair_not_as_queued_work
 test_warnings_are_excluded_from_the_charted_next_count
 test_a_board_of_only_warnings_still_reports_nothing_queued
 test_omitted_warnings_never_count_as_more_queued
 test_an_omitted_kind_keeps_the_existing_queued_rendering
+test_a_composed_risk_leaves_only_the_level_on_the_pin
+test_a_bare_level_adds_no_context_row
+test_a_low_level_reads_as_low_in_either_language
+test_an_unrecognised_level_keeps_the_alert_tone
+test_a_blank_risk_wears_no_pin_at_all
+test_a_merge_call_without_a_risk_is_refused_at_build

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -95,6 +95,7 @@ init_changed_fixture_repo() {
   chmod +x "$repo/bin/fm-test-run.sh"
   for script in \
     fm-brief.test.sh \
+    fm-test-run.test.sh \
     fm-ask-user-authority.test.sh \
     fm-documentation-audiences.test.sh \
     fm-test-isolation-proof.test.sh \
@@ -146,7 +147,8 @@ init_changed_fixture_repo() {
   mkdir -p \
     "$repo/.agents/skills/example" \
     "$repo/.agents/skills/harness-adapters/references/common" \
-    "$repo/.claude" "$repo/.pi/extensions" "$repo/docs" "$repo/src"
+    "$repo/.claude" "$repo/.pi/extensions" "$repo/docs" "$repo/src" \
+    "$repo/tests/assets"
   : >"$repo/.agents/skills/example/SKILL.md"
   : >"$repo/.agents/skills/harness-adapters/SKILL.md"
   : >"$repo/.agents/skills/harness-adapters/references/common/dispatch.md"
@@ -158,6 +160,11 @@ init_changed_fixture_repo() {
   : >"$repo/docs/fm-test-isolation-proof.md"
   : >"$repo/CONTRIBUTING.md"
   : >"$repo/src/unmapped.ts"
+  : >"$repo/tests/assets/board-render-harness.mjs"
+  : >"$repo/tests/assets/unreferenced-helper.mjs"
+  printf '# tests/assets/board-render-harness.mjs\n' >>"$repo/tests/fm-bearings-snapshot.test.sh"
+  printf '# tests/assets/board-render-harness.mjs\n# tests/assets/unreferenced-helper.mjs\n' \
+    >>"$repo/tests/fm-test-run.test.sh"
   git -C "$repo" init -q
   git -C "$repo" add .
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm baseline
@@ -298,6 +305,38 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-bearings-snapshot.test.sh" "shared helper selects snapshot dependents"
   git -C "$repo" add tests/lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm helper-change
+
+  printf '\n' >>"$repo/tests/assets/board-render-harness.mjs"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-bearings-snapshot.test.sh" \
+    "test asset selects its consuming test family"
+  assert_not_contains "$listed" "tests/fm-test-run.test.sh" \
+    "selector fixture literals are not treated as dependencies"
+  git -C "$repo" add tests/assets/board-render-harness.mjs
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm test-asset-change
+
+  printf '\n' >>"$repo/tests/assets/unreferenced-helper.mjs"
+  set +e
+  (cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD) >"$tmp/out" 2>"$tmp/err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "unreferenced test asset must fail with exit 2, got $rc"
+  grep -Fq 'no changed-test mapping for source path: tests/assets/unreferenced-helper.mjs' "$tmp/err" \
+    || fail "unreferenced test asset failure is not actionable: $(cat "$tmp/err")"
+  git -C "$repo" add tests/assets/unreferenced-helper.mjs
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm unmapped-test-asset-change
+
+  rm "$repo/tests/assets/board-render-harness.mjs"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-bearings-snapshot.test.sh" \
+    "removed test asset selects its unchanged consumer"
+  printf '#!/usr/bin/env bash\n# tests/lib.sh\n' >"$repo/tests/fm-bearings-snapshot.test.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-bearings-snapshot.test.sh" \
+    "removed test asset with an updated consumer remains selected"
+  git -C "$repo" add tests/assets/board-render-harness.mjs
+  git -C "$repo" add tests/fm-bearings-snapshot.test.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm removed-test-asset
 
   printf '\n' >>"$repo/tests/fm-backend-herdr-eventwait.test.py"
   listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)


### PR DESCRIPTION
## Intent

The captain, 2026-09-07, from his board: RESUME pull request 3173.

Context of his choice. A triage of his six open pull requests established that this one was ORPHANED - no task of ours tracked it - and that its defect is STILL LIVE on trunk. He was offered three paths: resume his own, fall in behind a competing pull request from another contributor proposing the solution he had set aside, or let it sleep. He resumes his own.

One fact to hold without over-interpreting it: this pull request is two weeks old and the MAINTAINER HAS NEVER WRITTEN ON IT. The five comments come from the captain or the review bot. The triage could not establish whether that is a deliberate choice or an effect of volume - four other pull requests touching the same template are also asleep. So it is not a rejection, it is silence.

Pull request: https://github.com/kunchenguid/firstmate/pull/3173

The captain's ask above refers to that pull request by pointer, so here is its substance. The bearings fleet board was unreadable. Every Underway, Landed and Charted row clamped its title and its secondary line to a single line with an ellipsis, so a row read as a truncated fragment - "Cinq chemins d'acceptation sur six sont atomiques. La revue durcit la front..." - and told the captain nothing about the work it named. Two further corrections the captain requested himself while looking at the board belong to the same underlying defect, that the board clipped or overflowed text instead of letting it read: a merge call's risk pin rendered the entire risk value, so a level followed by a sentence of justification pushed the pin outside its card; and the pin's tone compared the raw value against the English "low" alone, so a level written in the captain's own language wore the alert tone rather than the calm one.

What the captain wants from the board: rows that wrap over a few lines instead of clipping to one, a risk level that stays on its pin with its justification readable inside the card, and a low level recognised in either language.

## What Changed

- Let Underway, Landed, and Charted board rows wrap across capped lines while containing long unbroken text.
- Split merge risk values into a level pin and an in-card justification, recognizing `low` and `faible` as neutral risk levels.
- Add browser/render regression coverage and map board test assets to the snapshot-bearings test family.

## Why this is now three commits

This branch was 78 commits behind and has been rebased onto current `main`.

The defect it fixes is still live there, re-checked line by line against today's template: `.bb-row__title` and `.bb-row__sub` still carry `white-space: nowrap`, and the merge-risk pin still compares the raw value against `"low"` alone and renders `"risk " + item.risk` whole.
The new layout regression was also run against a real headless browser on the current tree: it fails on `main`'s template and passes on this branch.

The rebase dropped three of the ten files this branch previously touched, because `main` had meanwhile settled them another way:

- `tests/fm-on.test.sh` - `main` landed an equivalent `cleanup()` calling `fm_remote_job_stop_worker_tree`, so this branch's version was redundant.
- `docs/fm-test-portable-shards.md` - this branch refreshed a four-shard capacity table, and `main` has since moved the serial lane to five shards, so the edit no longer described anything real. The coverage guard passes unchanged at `serial_shards=5`.
- `tests/fm-watch-triage.test.sh` - a test de-flake unrelated to board rendering, left out so this change stays on the defect it names.

Nothing that fixes the reported defect was dropped.

## Risk Assessment

✅ Low: The change is narrowly scoped to board text rendering and its regression coverage, with the risk split, bilingual low-level tone, wrapping behavior, and test-poller cleanup coherently implemented.

## Testing

Focused renderer and runner tests passed, and a real generated board was visually reviewed in Brave at desktop width: the long Charted Next title/subtitle wrap within the card, while “RISK FAIBLE” stays compact with its full justification readable in-card. The automated headless layout probe could not run on this host’s available Brave launcher; the visual evidence fixture and its listener cleanup were completed manually.

<details>
<summary>Evidence: Rendered bearings fleet board showing wrapped Charted Next text and compact bilingual low-risk pin with in-card justification</summary>

Source: [Rendered bearings fleet board showing wrapped Charted Next text and compact bilingual low-risk pin with in-card justification](https://github.com/mremond/firstmate/blob/00c8d2dec67b50e9cdc28ca1c74b1e885f072728/.no-mistakes/evidence/fm/tableau-descriptifs-tronques/bearings-board-visual/home/.lavish/bearings-board.html)

```text
<!doctype html>
<html lang="en">
<head>
<meta charset="utf-8" />
<meta name="viewport" content="width=device-width, initial-scale=1" />
<title>Bearings - fleet board</title>
<style>
/* ============================================================
   Bearings board - Firstmate Design System, inlined for portability.
   Tokens copied verbatim from myfirstmate priv/static/assets/app.css
   (the compiled adoption of .agents/skills/firstmate-design).
   ============================================================ */
@import url("https://fonts.googleapis.com/css2?family=Chango&family=Jost:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap");

:root {
  --rust-700: #8f2f17; --rust-600: #a93a1f; --rust-500: #c0452a;
  --rust-400: #d35f3f; --rust-300: #e08365; --rust-100: #f4d8c9; --rust-050: #fbece3;
  --navy-700: #1a2238; --navy-600: #222c49; --navy-500: #2a3656;
  --navy-300: #6c7796; --navy-100: #d9deea;
  --gold-600: #b5791c; --gold-500: #e0a52e; --gold-300: #f0d38c; --gold-100: #f8ecc9;
  --ocean-600: #2f6688; --ocean-500: #3c7ea6; --ocean-200: #b6d4e2; --ocean-050: #e8f1f5;
  --sea-700: #234e3a; --sea-500: #2f6b4f; --sea-200: #b9d4c5; --sea-050: #e9f2ec;
  --paper-000: #fbf4e2; --paper-100: #f6ecd3; --paper-200: #f0e3c4; --paper-300: #e7d6ae;
  --cream-line: #ddc89c;
  --ink-900: #241c14; --ink-700: #3f3224; --ink-500: #6f5e46; --ink-300: #9c8a6c;
  --white: #fffdf7;
  --bg-page: var(--paper-100);
  --surface-card: var(--white);
  --surface-card-warm: var(--paper-000);
  --text-strong: var(--ink-900); --text-body: var(--ink-700);
  --text-muted: var(--ink-500); --text-faint: var(--ink-300);
  --border-default: var(--cream-line); --border-soft: var(--paper-300);
  --status-online: var(--sea-500); --status-online-soft: var(--sea-050);
  --status-warn: var(--gold-600); --status-warn-soft: var(--gold-100);
  --status-danger: var(--rust-600); --status-danger-soft: var(--rust-050);
  --status-info: var(--ocean-500); --status-info-soft: var(--ocean-050);
  --font-display: "Chango", "Cooper Black", Rockwell, Georgia, serif;
  --font-sans: "Jost", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
  --fs-h3: 1.4rem; --fs-h4: 1.15rem; --fs-base: 1rem; --fs-sm: 0.9375rem;
  --fs-xs: 0.8125rem; --fs-2xs: 0.6875rem;
  --ls-caps: 0.16em;
  --radius-xs: 6px; --radius-sm: 9px; --radius-md: 12px; --radius-banner: 7px;
  --radius-lg: 18px; --radius-pill: 999px;
  --shadow-sm: 0 1px 2px rgba(36, 28, 20, 0.06), 0 4px 10px rgba(36, 28, 20, 0.06);
  --shadow-hard: 4px 4px 0 var(--ink-900);
  --shadow-hard-sm: 3px 3px 0 var(--ink-900);
  --texture-paper: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.045'/%3E%3C/svg%3E");
  --focus-ring: 0 0 0 3px var(--gold-300);
  --container-app: 1180px;
}

* { box-sizing: border-box; }
html, body { margin: 0; padding: 0; }
body {
  font-family: var(--font-sans);
  color: var(--text-body);
  background: var(--bg-page);
  background-image: var(--texture-paper);
  line-height: 1.55;
  -webkit-font-smoothing: antialiased;
}
a { color: inherit; text-decoration: none; }

/* ---- fm-badge (enamel sign-pin), verbatim contract ---- */
.fm-badge {
  display: inline-flex; align-items: center; gap: 6px;
  font-size: var(--fs-2xs); font-weight: 800; line-height: 1;
  padding: 5px 9px 4px; text-transform: uppercase; letter-spacing: 0.07em;
  border-radius: var(--radius-xs); border: 1.5px solid var(--ink-900);
  box-shadow: 2px 2px 0 var(--ink-900); white-space: nowrap;
}
.fm-badge--online  { background: var(--sea-500);  color: var(--paper-000); }
.fm-badge--warn    { background: var(--gold-500); color: var(--navy-700); }
.fm-badge--danger  { background: var(--rust-600); color: var(--paper-000); }
.fm-badge--info    { background: var(--ocean-500); color: var(--paper-000); }
.fm-badge--neutral { background: var(--paper-000); color: var(--ink-900); }
.fm-badge--solid   { background: var(--rust-500); color: var(--paper-000); }

/* ---- fm-btn ---- */
.fm-btn {
  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
  font-family: var(--font-sans); font-weight: 800; line-height: 1; white-space: nowrap;
  border: 2px solid transparent; border-radius: var(--radius-banner); cursor: pointer;
  text-decoration: none; transition: background 120ms, border-color 120ms, transform 120ms, box-shadow 120ms;
}
.fm-btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
.fm-btn:active { transform: translateY(1px); }
.fm-btn--sm { font-size: var(--fs-xs); padding: 8px 16px; }
.fm-btn--primary { background: var(--rust-500); color: var(--white); border-color: var(--ink-900); box-shadow: var(--shadow-hard-sm); }
.fm-btn--primary:hover { background: var(--rust-600); }
.fm-btn--gold { background: var(--gold-500); color: var(--navy-700); border-color: var(--ink-900); box-shadow: var(--shadow-hard-sm); }
.fm-btn--gold:hover { background: var(--gold-600); color: var(--white); }
.fm-btn[disabled] { opacity: 0.5; cursor: not-allowed; }

/* ---- fm-card ---- */
.fm-card {
  background: var(--surface-card); border: 1px solid var(--border-default);
  border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); overflow: hidden;
}
.fm-card--poster { border: 2px solid var(--ink-900); box-shadow: var(--shadow-hard); border-radius: var(--radius-md); }
.fm-card--warm { background: var(--surface-card-warm); }

/* ---- fm-sign (eyebrow section label) ---- */
.fm-sign {
  display: inline-flex; align-items: center; gap: 8px; font-weight: 800;
  text-transform: uppercase; letter-spacing: var(--ls-caps); font-size: var(--fs-xs);
  line-height: 1; white-space: nowrap;
}
.fm-sign--eyebrow { color: var(--rust-500); }
.fm-sign--muted { color: var(--ink-500); }
.fm-sign svg { width: 14px; height: 14px; }
.fm-ico { width: 1.15em; height: 1.15em; flex: none; vertical-align: -0.18em; }

/* ============================================================
   Board chrome (bb-*) - built on the same tokens
   ============================================================ */
.bb-nav {
  position: sticky; top: 0; z-index: 20;
  background: color-mix(in srgb, var(--paper-100) 86%, transparent);
  backdrop-filter: saturate(150%) blur(10px);
  border-bottom: 1px solid var(--border-default);
}
.bb-nav__inner {
  max-width: var(--container-app); margin: 0 auto; padding: 0 28px; height: 64px;
  display: flex; align-items: center; justify-content: space-between; gap: 16px;
}
.bb-brand { display: inline-flex; align-items: center; gap: 12px; }
.bb-brand__disc {
  display: grid; place-items: center; width: 34px; height: 34px; flex: none;
  border-radius: 999px; background: var(--rust-500); color: var(--paper-000);
  border: 2px solid var(--ink-900); box-shadow: var(--shadow-hard-sm);
}
.bb-brand__disc svg { width: 60%; height: 60%; }
.bb-brand__wm { font-family: var(--font-display); font-size: 23px; color: var(--text-strong); line-height: 1; }
.bb-meta-mono { font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--text-faint); white-space: nowrap; }

.bb-main {
  max-width: var(--container-app); margin: 0 auto;
  padding: 26px 28px 72px; display: flex; flex-direction: column; gap: 22px;
}

/* stat strip */
.bb-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; }
.bb-stat {
  display: flex; flex-direction: column; gap: 4px; padding: 14px 16px; min-width: 0;
  background: var(--surface-card-warm); border: 1px solid var(--border-soft); border-radius: var(--radius-md);
}
.bb-stat--call { background: var(--rust-050); border: 2px solid var(--rust-500); }
.bb-stat__num { font-family: var(--font-mono); font-size: var(--fs-h3); font-weight: 600; line-height: 1; color: var(--text-strong); }
.bb-stat--call .bb-stat__num { color: var(--rust-600); }
.bb-stat__label { font-family: var(--fon

... [23788 bytes truncated] ...

imit");
    answerLimit.setAttribute("role", "alert");
    foot.appendChild(answerLimit);
    form.appendChild(foot);

    form.addEventListener("submit", function (ev) {
      ev.preventDefault();
      answerLimit.classList.remove("is-visible");
      var fd = new FormData(form);
      var value = fd.get("answer");
      var note = (fd.get("note") || "").trim();
      var displayAnswer = value ? (note ? value + " - " + note : value) : note;
      if (!displayAnswer) return;
      if (utf8ByteLength(displayAnswer) > 512) {
        answerLimit.textContent = "Answer is too long to queue (512 bytes maximum).";
        answerLimit.classList.add("is-visible");
        return;
      }
      if (window.lavish && window.lavish.queuePrompt) {
        /* The versioned context keeps the selected option separate from its
           note, while close carries the composer-declared completion mode. */
        var ctxData = {
          schema: "fm-bearings-answer.v1",
          question: item.key,
          selection: value || "",
          note: note
        };
        if (item.close) ctxData.close = item.close;
        window.lavish.queuePrompt(
          "Captain's Call answer - " + item.title + ": " + displayAnswer,
          { tag: "choice", text: item.title + " -> " + displayAnswer, element: form,
            data: ctxData }
        );
      }
      card.classList.add("is-queued");
      /* deal the next card once this one is answered */
      setTimeout(function () { showCard(active < cards.length - 1 ? active + 1 : active); }, 450);
    });

    pad.appendChild(form);
    card.appendChild(pad);
    deck.appendChild(card);
  });

  /* stack navigation: one card at a time, dealt off the pile */
  var cards = Array.prototype.slice.call(deck.children);
  var active = 0;
  var stackCount = document.getElementById("bb-stack-count");
  var stackPrev = document.getElementById("bb-stack-prev");
  var stackNext = document.getElementById("bb-stack-next");
  var stackNav = stackCount.parentNode;
  function showCard(i) {
    active = Math.max(0, Math.min(cards.length - 1, i));
    cards.forEach(function (c, j) { c.hidden = j !== active; });
    var answered = deck.querySelectorAll(".is-queued").length;
    stackCount.textContent = "card " + (active + 1) + " of " + cards.length +
      (answered ? " · " + answered + " answered" : "");
    stackPrev.disabled = active === 0;
    stackNext.disabled = active === cards.length - 1;
    /* the pile thins as the deal approaches the bottom */
    deck.classList.toggle("bb-call--penult", active === cards.length - 2);
    deck.classList.toggle("bb-call--last", active === cards.length - 1);
  }
  if (cards.length) {
    stackPrev.addEventListener("click", function () { showCard(active - 1); });
    stackNext.addEventListener("click", function () { showCard(active + 1); });
    showCard(0);
  } else {
    deck.classList.add("bb-call--empty");
    deck.appendChild(el("div", "bb-empty", "Nothing needs your action right now."));
    stackNav.hidden = true;
  }

  /* Underway */
  var uw = document.getElementById("bb-underway");
  if (!data.underway.length) uw.appendChild(el("div", "bb-empty", "Nothing is underway."));
  data.underway.forEach(function (t) {
    var row = el("div", "bb-row");
    row.appendChild(badge(t.state === "working" ? "online" : "info", t.state));
    var main = el("div", "bb-row__main");
    main.appendChild(el("div", "bb-row__title", t.doing));
    /* captain-facing rows name the repo; the internal task id shows only when
       no repo is known */
    main.appendChild(el("div", "bb-row__sub", t.kind + " · " + (t.repo || t.id)));
    row.appendChild(main);
    uw.appendChild(row);
  });

  /* Landed */
  var ld = document.getElementById("bb-landed");
  if (!data.landed.length) ld.appendChild(el("div", "bb-empty", "No recent completions are in the current baseline."));
  data.landed.forEach(function (t) {
    var row = el("div", "bb-row");
    var chk = el("span", "bb-row__check");
    chk.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>';
    row.appendChild(chk);
    var main = el("div", "bb-row__main");
    main.appendChild(el("div", "bb-row__title", t.what));
    main.appendChild(el("div", "bb-row__sub", (t.repo || t.id) + " · " + t.owner));
    row.appendChild(main);
    if (t.pr_url) {
      var a = el("a", "bb-row__pr", "#" + t.pr_url.split("/").pop());
      a.href = t.pr_url; a.title = t.pr_url; a.target = "_blank"; a.rel = "noopener";
      row.appendChild(a);
    }
    ld.appendChild(row);
  });

  /* Charted Next + dispatch picker */
  var ch = document.getElementById("bb-charted");
  var bar = document.getElementById("bb-dispatch");
  var barCount = document.getElementById("bb-dispatch-count");
  var barBtn = document.getElementById("bb-dispatch-btn");
  var anyPickable = false;

  function pickedIds() {
    return Array.prototype.map.call(ch.querySelectorAll(".bb-pick:checked"), function (c) { return c.value; });
  }
  function refreshBar(limitMessage) {
    var n = pickedIds().length;
    barCount.textContent = limitMessage || (n ? n + " picked for dispatch" : "pick queued work to dispatch");
    barBtn.disabled = !n;
  }

  if (!chartedQueued(data.charted).length && !chartedMoreQueued) {
    ch.appendChild(el("div", "bb-empty", "Nothing is queued."));
  }
  data.charted.forEach(function (t) {
    var row = el("div", "bb-row");
    if (t.dispatchable && !isWarning(t)) {
      anyPickable = true;
      var pick = document.createElement("input");
      pick.type = "checkbox"; pick.className = "bb-pick"; pick.value = t.id;
      pick.setAttribute("aria-label", "Pick " + t.id + " for dispatch");
      pick.addEventListener("change", function () {
        if (pick.checked && utf8ByteLength(pickedIds().join(",")) > 512) {
          pick.checked = false;
          refreshBar("Selection limit reached (512 bytes maximum). ");
          return;
        }
        refreshBar();
      });
      row.appendChild(pick);
    } else {
      row.appendChild(el("span", "bb-pick-spacer"));
    }
    var main = el("div", "bb-row__main");
    main.appendChild(el("div", "bb-row__title", t.title));
    /* second line keeps the title uncrowded in the half-width column */
    var chSub = t.repo || t.id;
    main.appendChild(el("div", "bb-row__sub", t.reason ? t.reason + " · " + chSub : chSub));
    row.appendChild(main);
    if (isWarning(t)) row.appendChild(badge("danger", "needs repair"));
    else if (t.reason) row.appendChild(badge("warn", "waiting"));
    ch.appendChild(row);
  });
  var chartedShown = chartedQueued(data.charted).length;
  var chartedTotal = chartedShown + chartedMoreQueued;
  document.getElementById("bb-charted-sub").textContent =
    chartedMoreQueued ? "showing " + chartedShown + " of " + chartedTotal : "";
  if (chartedMoreQueued) {
    ch.appendChild(el("span", "bb-morechip", "+" + chartedMoreQueued + " more queued - ask firstmate for the full chart"));
  }
  if (chartedMoreWarnings) {
    ch.appendChild(el("span", "bb-morechip", "+" + chartedMoreWarnings + " more repair warning" + (chartedMoreWarnings === 1 ? "" : "s") + " - ask firstmate for the full chart"));
  }

  if (anyPickable) {
    bar.hidden = false;
    refreshBar();
    barBtn.addEventListener("click", function () {
      var ids = pickedIds();
      var dispatchAnswer = ids.join(",");
      if (!ids.length) return;
      if (utf8ByteLength(dispatchAnswer) > 512) {
        refreshBar("Selection is too long to queue (512 bytes maximum). ");
        return;
      }
      if (window.lavish && window.lavish.queuePrompt) {
        window.lavish.queuePrompt(
          "Dispatch order - start this queued work now: " + ids.join(", "),
          { tag: "choice", text: "Dispatch: " + ids.join(", "), element: bar,
            queueKey: "dispatch.charted",
            data: { question: "dispatch.charted", answer: dispatchAnswer } }
        );
      }
      bar.classList.add("is-queued");
    });
  }
  } catch (e) {
    renderBoardError("The board data could not be rendered");
  }
})();
</script>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5affdecc4b7a4d0c35c6ce0195515dd12119c829","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"skipped"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

- ⚠️ `tests/fm-on.test.sh` - merge conflict rebasing onto refs/remotes/no-mistakes-push/fm/tableau-descriptifs-tronques
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-bearings-board-layout.test.sh:234` - This test builds and arms a real process-event listener, while its fake `lavish-axi poll` loops forever. The inherited temp-directory cleanup only removes the fixture files, so each successful run leaves the listener/poll process alive. Add an EXIT teardown that calls `fm-procevent.sh sweep-home` with this fixture’s environment before `fm_test_cleanup`, as the renderer test does.

🔧 Fix: Clean up layout test poller
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-bearings-board-render.test.sh`
- `bash tests/fm-test-run.test.sh`
- <code>`bash tests/fm-bearings-board-layout.test.sh` (skipped: Chrome/Chromium not installed)</code>
- <code>`FM_CHROME_BIN=&#39;/Applications/Brave Browser.app/Contents/MacOS/Brave Browser&#39; bash tests/fm-bearings-board-layout.test.sh` (Brave headless did not emit its smoke DOM; interrupted and cleaned up)</code>
- <code>Built the evidence fixture with `bin/fm-bearings-board.sh build …/payload.json`, inspected the rendered page in Brave, then ran `bin/fm-procevent.sh sweep-home` to retire its listener.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

