### PR TITLE
fix(bin): make session-lock harness identity work on Windows Git Bash

### DIFF
--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -58,15 +58,37 @@ fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> 
   fm_tmux_submit_core "$@"
 }
 
+# fm_backend_tmux_pane_shell: on Windows, the native path of the shell firstmate's
+# panes must run. psmux (the Windows tmux) defaults panes to PowerShell, but
+# firstmate drives its panes with bash commands (treehouse get, the harness
+# launch, status appends), so every session/window it creates must launch Git
+# Bash instead. Resolve the running MSYS bash to a forward-slash Windows path
+# psmux can spawn. Prints nothing on non-Windows, where the platform default is
+# already a POSIX shell - keeping firstmate self-contained without a per-machine
+# ~/.tmux.conf.
+fm_backend_tmux_pane_shell() {
+  local bash_path
+  case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*) ;;
+    *) return 0 ;;
+  esac
+  bash_path=$(command -v bash 2>/dev/null) || return 0
+  cygpath -m "$bash_path" 2>/dev/null || printf '%s\n' "$bash_path"
+}
+
 # fm_backend_tmux_container_ensure: reuse the current tmux session when
 # firstmate itself runs inside tmux, else ensure a dedicated detached
 # "firstmate" session exists. Mirrors fm-spawn.sh's container-ensure block;
 # prints the resolved session name.
 fm_backend_tmux_container_ensure() {
+  local shell
+  local -a shell_arg=()
+  shell=$(fm_backend_tmux_pane_shell)
+  [ -n "$shell" ] && shell_arg=("$shell")
   if [ -n "${TMUX:-}" ]; then
     tmux display-message -p '#S'
   else
-    tmux has-session -t firstmate 2>/dev/null || tmux new-session -d -s firstmate
+    tmux has-session -t firstmate 2>/dev/null || tmux new-session -d -s firstmate "${shell_arg[@]}"
     printf 'firstmate'
   fi
 }
@@ -87,12 +109,15 @@ fm_backend_tmux_container_ensure() {
 # The returned window id lets callers target the window even if its name is ever
 # lost, so worktree discovery cannot fall back to the active client's window.
 fm_backend_tmux_create_task() {  # <session> <window-name> <proj-abs> -> prints window id
-  local ses=$1 wname=$2 proj_abs=$3 wid
+  local ses=$1 wname=$2 proj_abs=$3 wid shell
+  local -a shell_arg=()
   if tmux list-windows -t "$ses" -F '#{window_name}' | grep -qx "$wname"; then
     echo "error: window $ses:$wname already exists" >&2
     return 1
   fi
-  wid=$(tmux new-window -dP -F '#{window_id}' -t "$ses:" -n "$wname" -c "$proj_abs") || return 1
+  shell=$(fm_backend_tmux_pane_shell)
+  [ -n "$shell" ] && shell_arg=("$shell")
+  wid=$(tmux new-window -dP -F '#{window_id}' -t "$ses:" -n "$wname" -c "$proj_abs" "${shell_arg[@]}") || return 1
   tmux set-window-option -t "$wid" automatic-rename off 2>/dev/null || true
   tmux set-window-option -t "$wid" allow-rename off 2>/dev/null || true
   printf '%s\n' "$wid"

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -124,8 +124,14 @@ fm_backend_tmux_send_literal() {  # <target> <text>
 # fm_backend_tmux_kill: remove one explicitly named task window, best-effort.
 # Empty, omitted, and malformed targets return nonzero before invoking tmux so
 # tmux can never interpret an empty target as the caller's current window.
+#
+# The `=name` exact-match target prefix that keeps this from fuzzy-matching a
+# different window is a real-tmux feature psmux (Windows) does not implement -
+# `kill-window -t "=s:=w"` fails there with "can't find window: =w" and the
+# window leaks. On Windows resolve the window id by an EXACT name match instead,
+# which is equally unambiguous, then kill by that id.
 fm_backend_tmux_kill() {  # <target>
-  local target=${1:-} session window
+  local target=${1:-} session window wid
   case "$target" in
     *:*)
       session=${target%%:*}
@@ -136,7 +142,16 @@ fm_backend_tmux_kill() {  # <target>
   case "$session:$window" in
     :*|*:|*:*:*) return 1 ;;
   esac
-  tmux kill-window -t "=$session:=$window" 2>/dev/null || true
+  case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*)
+      wid=$(tmux list-windows -t "$session" -F '#{window_id} #{window_name}' 2>/dev/null \
+        | awk -v n="$window" '$2 == n { print $1; exit }')
+      [ -n "$wid" ] && tmux kill-window -t "$wid" 2>/dev/null || true
+      ;;
+    *)
+      tmux kill-window -t "=$session:=$window" 2>/dev/null || true
+      ;;
+  esac
 }
 
 # fm_backend_tmux_current_command: <target>'s live foreground process name -

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -88,6 +88,106 @@ fm_harness_process_matches() {  # <comm> <args>
   return 1
 }
 
+# --- portable process inspection ---------------------------------------------
+#
+# The ancestry walk and the liveness predicate both need three facts about a
+# process - its command name, full argument string, and parent pid. On Linux and
+# macOS `ps -o comm=/args=/ppid= -p <pid>` supplies them. On Windows under Git
+# Bash / MSYS it does NOT: the bundled ps rejects -o and only knows Cygwin/MSYS
+# processes, so the Claude harness - a real ancestor two hops up the native
+# Windows process tree (bash -> bash -> claude.exe) - is invisible, the ancestry
+# walk finds nothing, and every session refuses the home's lock as read-only.
+#
+# The fix is to read the true tree from a Windows-aware source while keeping the
+# harness-identity policy below unchanged. On Windows the ancestry comes from
+# Win32_Process (fm-win-ancestry.ps1) and liveness from `ps -W`, which does list
+# native processes with their Windows pids. Pids are reported in the platform's
+# own space - Unix pids on Unix, Windows pids (WINPID) on Windows - and the lock
+# stores whatever this layer reports, so every consumer compares like with like.
+
+# Selected process-inspection platform: "windows" or "unix". FM_LOCK_PLATFORM
+# overrides detection so the Windows path is exercisable from a Unix test host.
+_fm_lock_platform() {
+  if [ -n "${FM_LOCK_PLATFORM:-}" ]; then printf '%s\n' "$FM_LOCK_PLATFORM"; return 0; fi
+  case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*) printf 'windows\n' ;;
+    *) printf 'unix\n' ;;
+  esac
+}
+
+# Windows data sources, each a single seam a test can shadow (as the suite
+# already shadows `kill`): this shell's Windows pid, the Win32_Process ancestry
+# walk from a start pid, and the native-process table.
+_fm_win_self_winpid() { cat "/proc/$$/winpid" 2>/dev/null; }
+_fm_win_walk_rows() {  # <start-winpid> -> pid<TAB>name<TAB>commandline, innermost first
+  local start=$1 script
+  script="$(dirname -- "${BASH_SOURCE[0]}")/fm-win-ancestry.ps1"
+  powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$script" -Start "$start" 2>/dev/null | tr -d '\r'
+}
+_fm_win_ps_w() { ps -W 2>/dev/null; }
+
+# Emit the process ancestry innermost-first as: pid<TAB>comm<TAB>args, one row
+# per hop, bounded to 16 hops and stopping at the first unresolvable parent.
+# This is the only platform-specific step; the harness-identity policy in
+# fm_harness_ancestry_pids consumes these rows without caring which host they
+# came from.
+_fm_ancestry_rows() {
+  if [ "$(_fm_lock_platform)" = windows ]; then
+    _fm_win_ancestry_rows
+  else
+    _fm_unix_ancestry_rows
+  fi
+}
+
+_fm_unix_ancestry_rows() {
+  local pid=$$ comm args
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
+    args=$(ps -o args= -p "$pid" 2>/dev/null)
+    printf '%s\t%s\t%s\n' "$pid" "$comm" "$args"
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    { [ -n "$pid" ] && [ "$pid" -gt 1 ] 2>/dev/null; } || break
+  done
+}
+
+# The walker already emits pid<TAB>name<TAB>commandline innermost-first, with the
+# executable name playing the role of comm and the command line the role of args.
+_fm_win_ancestry_rows() {
+  local start
+  start=$(_fm_win_self_winpid | tr -d '[:space:]')
+  [ -n "$start" ] || return 0
+  _fm_win_walk_rows "$start"
+}
+
+# Look up a live Windows process by its WINPID in the native-process table.
+# Prints comm<TAB>args - the executable path serving as both, which is all the
+# harness matcher needs - or returns 1 when the pid is not a live native process
+# with a resolvable executable path. `ps -W` columns are:
+#   PID PPID PGID WINPID TTY UID STIME COMMAND...
+# COMMAND is an absolute path that may contain spaces, and STIME is one token for
+# recent processes (HH:MM:SS) but two for older ones (MMM DD), so the column
+# offset of COMMAND is not fixed. Anchor on the first drive-letter or UNC path
+# token instead and rejoin to end of line. A native process whose COMMAND is a
+# bare name (System, Registry) has no such token and is never a harness, so it
+# is correctly reported as not found.
+_fm_win_proc_info() {  # <winpid>
+  _fm_win_ps_w | awk -v w="$1" '
+    $4 == w {
+      start = 0
+      for (i = 5; i <= NF; i++) {
+        if ($i ~ /^[A-Za-z]:[\\\/]/ || $i ~ /^\\\\/) { start = i; break }
+      }
+      if (start == 0) next
+      cmd = ""
+      for (i = start; i <= NF; i++) cmd = cmd (i > start ? " " : "") $i
+      printf "%s\t%s\n", cmd, cmd
+      found = 1
+      exit
+    }
+    END { if (!found) exit 1 }
+  '
+}
+
 # Walk the current process ancestry (up to 16 hops) and print this session's
 # contiguous verified-harness ancestry, innermost pid first.
 #
@@ -107,10 +207,9 @@ fm_harness_process_matches() {  # <comm> <args>
 # session cannot be read off the ancestry at all, so the whole contiguous run is
 # reported and the callers below decide what they need from it.
 fm_harness_ancestry_pids() {
-  local pid=$$ comm args extending=0 printed=0
-  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
-    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
-    args=$(ps -o args= -p "$pid" 2>/dev/null)
+  local pid comm args extending=0 printed=0
+  while IFS=$'\t' read -r pid comm args; do
+    [ -n "$pid" ] || continue
     if fm_harness_process_matches "$comm" "$args"; then
       printf '%s\n' "$pid"
       printed=1
@@ -119,9 +218,9 @@ fm_harness_ancestry_pids() {
     elif [ "$extending" -eq 1 ]; then
       break
     fi
-    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
-  done
+  done <<EOF
+$(_fm_ancestry_rows)
+EOF
   [ "$printed" -eq 1 ]
 }
 
@@ -143,9 +242,19 @@ EOF
   printf '%s\n' "$outermost"
 }
 
-# True if $1 is a live process that looks like a verified harness.
+# True if $1 is a live process that looks like a verified harness. On Windows the
+# pid is a WINPID: `kill -0` would test the wrong (MSYS) pid space, so existence
+# and identity are read together from the native-process table instead.
 fm_harness_pid_alive() {
-  local pid=$1 comm args
+  local pid=$1 comm args info
+  if [ "$(_fm_lock_platform)" = windows ]; then
+    info=$(_fm_win_proc_info "$pid") || return 1
+    [ -n "$info" ] || return 1
+    comm=${info%%$'\t'*}
+    args=${info#*$'\t'}
+    fm_harness_process_matches "$comm" "$args"
+    return
+  fi
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   args=$(ps -o args= -p "$pid" 2>/dev/null)

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -116,9 +116,12 @@ _fm_lock_platform() {
 }
 
 # Windows data sources, each a single seam a test can shadow (as the suite
-# already shadows `kill`): this shell's Windows pid, the Win32_Process ancestry
-# walk from a start pid, and the native-process table.
+# already shadows `kill`): this shell's MSYS pid and Windows pid, the MSYS
+# logical process table, the Win32_Process ancestry walk from a start pid, and
+# the native-process table.
+_fm_win_self_msyspid() { printf '%s\n' "$$"; }
 _fm_win_self_winpid() { cat "/proc/$$/winpid" 2>/dev/null; }
+_fm_win_ps() { ps 2>/dev/null; }
 _fm_win_walk_rows() {  # <start-winpid> -> pid<TAB>name<TAB>commandline, innermost first
   local start=$1 script
   script="$(dirname -- "${BASH_SOURCE[0]}")/fm-win-ancestry.ps1"
@@ -152,11 +155,49 @@ _fm_unix_ancestry_rows() {
 
 # The walker already emits pid<TAB>name<TAB>commandline innermost-first, with the
 # executable name playing the role of comm and the command line the role of args.
+# It must start from a shell with a valid Windows parent link (see
+# _fm_win_ancestry_start_winpid).
 _fm_win_ancestry_rows() {
   local start
-  start=$(_fm_win_self_winpid | tr -d '[:space:]')
+  start=$(_fm_win_ancestry_start_winpid)
   [ -n "$start" ] || return 0
   _fm_win_walk_rows "$start"
+}
+
+# Print the Windows pid the ancestry walk must start from. Not simply this
+# shell's own winpid: an MSYS / Git Bash subprocess is fork/exec-orphaned - its
+# Windows ParentProcessId points at a launcher stub that has already exited - so
+# a Win32 walk from here stops at the first hop and never reaches the harness.
+# The MSYS ps table still records the logical parent chain though, and the
+# topmost MSYS shell in it was spawned directly by the harness (claude.exe ->
+# bash), so THAT shell keeps an intact Windows parent link. Climb the MSYS chain
+# to it and start the Win32 walk from its winpid. Fall back to this shell's own
+# winpid when the MSYS table cannot be read.
+_fm_win_ancestry_start_winpid() {
+  local top
+  top=$(_fm_win_top_msys_winpid)
+  if [ -n "$top" ]; then printf '%s\n' "$top"; return 0; fi
+  _fm_win_self_winpid | tr -d '[:space:]'
+}
+
+# Walk the MSYS logical process table from this shell to the topmost MSYS
+# ancestor (the one whose parent is not itself an MSYS process) and print that
+# ancestor's Windows pid. Columns are: PID PPID PGID WINPID ...
+_fm_win_top_msys_winpid() {
+  _fm_win_ps | awk -v self="$(_fm_win_self_msyspid)" '
+    NR == 1 { next }
+    { par[$1] = $2; win[$1] = $4 }
+    END {
+      if (!(self in win)) exit
+      cur = self; top = self
+      for (i = 0; i < 64 && (cur in par); i++) {
+        p = par[cur]
+        if (!(p in win)) break
+        top = p; cur = p
+      }
+      print win[top]
+    }
+  '
 }
 
 # Look up a live Windows process by its WINPID in the native-process table.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2132,6 +2132,39 @@ spawn_current_path() {  # <target>
     cmux) fm_backend_cmux_current_path "$1" "$W" ;;
   esac
 }
+
+# On Windows (Git Bash + psmux) `#{pane_current_path}` follows only the pane's
+# ROOT shell, never a subshell, and `treehouse get` opens a subshell in the
+# worktree - so the pane-path poll never sees the move and worktree discovery
+# times out though treehouse succeeded. Read the subshell's real $PWD instead:
+# have the pane print it wrapped in a unique marker and recover it from the
+# captured buffer. tmux-only, the sole Windows-capable backend.
+spawn_is_windows() {
+  case "$(uname -s 2>/dev/null)" in MINGW*|MSYS*|CYGWIN*) return 0 ;; *) return 1 ;; esac
+}
+spawn_pane_pwd_sentinel() {  # <target> <nonce>
+  local target=$1 nonce=$2 cap marker path
+  spawn_send_text_line "$target" "printf '\\nFMWT${nonce}[%s]FMWT${nonce}\\n' \"\$PWD\""
+  sleep 0.4
+  cap=$(fm_backend_tmux_capture "$target" 50 2>/dev/null) || return 1
+  # The typed command line echoes back too, carrying a literal `[%s]`; keep only
+  # the resolved output marker, and the last of it if the pane scrolled.
+  marker=$(printf '%s\n' "$cap" | grep -oE "FMWT${nonce}\[[^]]*\]FMWT${nonce}" | grep -v '%s' | tail -1)
+  [ -n "$marker" ] || return 1
+  path=${marker#"FMWT${nonce}["}
+  path=${path%"]FMWT${nonce}"}
+  [ -n "$path" ] || return 1
+  printf '%s\n' "$path"
+}
+# The pane's effective worktree cwd: the sentinel read on Windows, the backend's
+# native current-path read everywhere else.
+spawn_worktree_probe_path() {  # <target> <nonce>
+  if spawn_is_windows && [ "$BACKEND" = tmux ]; then
+    spawn_pane_pwd_sentinel "$1" "$2"
+  else
+    spawn_current_path "$1"
+  fi
+}
 spawn_send_literal() {  # <target> <text>
   case "$BACKEND" in
     tmux) fm_backend_tmux_send_literal "$1" "$2" ;;
@@ -2227,6 +2260,13 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
+  # On Windows psmux implements `new-window -c <dir>` by sending a PowerShell cd
+  # to the pane, which errors in our bash pane and leaves it in the wrong repo -
+  # so `treehouse get` would worktree whatever repo the pane happened to land in.
+  # Put the pane in the project explicitly with a bash cd first.
+  if spawn_is_windows && [ "$BACKEND" = tmux ]; then
+    spawn_send_text_line "$WT_TARGET" "cd \"$PROJ_ABS\""
+  fi
   spawn_send_text_line "$WT_TARGET" 'treehouse get'
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
@@ -2250,8 +2290,9 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # pane that is already settled by the first real read only costs the one existing
   # inter-poll sleep as confirmation, not a whole extra cycle on top.
   candidate=""
+  wt_nonce="wt$$"
   for _ in $(seq 1 60); do
-    p=$(spawn_current_path "$WT_TARGET" || true)
+    p=$(spawn_worktree_probe_path "$WT_TARGET" "$wt_nonce" || true)
     if [ -n "$p" ]; then
       p_real=$(real_path_or_raw "$p")
       if [ "$p_real" != "$PROJ_ABS_REAL" ]; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1242,6 +1242,27 @@ treehouse_return_is_index_lock_error() {
   printf '%s\n' "$text" | grep -Eq "Unable to create ['\"].*index\\.lock['\"]: File exists"
 }
 
+# On Windows a `treehouse return` can fail because a just-killed launcher or
+# harness process (the `env` that exec'd claude, a detached node hook, a shell)
+# is still exiting when treehouse takes its liveness snapshot. There is no Unix
+# process group to make this deterministic here, but the processes DO die a
+# moment later, so it is a transient worth the same bounded retry as a git
+# index.lock. Matched on Windows only.
+treehouse_return_is_windows_process_race() {
+  local text=$1
+  case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*) ;;
+    *) return 1 ;;
+  esac
+  printf '%s\n' "$text" | grep -Eq "still has live processes after termination"
+}
+
+# A treehouse-return failure eligible for the bounded retry: a transient git
+# index.lock, or (Windows) a still-exiting process caught by the liveness snapshot.
+treehouse_return_is_retryable_transient() {
+  treehouse_return_is_index_lock_error "$1" || treehouse_return_is_windows_process_race "$1"
+}
+
 # Absolute path to the git index lock for a worktree/repo dir, or empty when it
 # cannot be resolved (dir missing or not a git worktree at all).
 worktree_git_lock_path() {
@@ -1298,7 +1319,7 @@ cleanup_stale_lock_for_safety_check() {
 # stale git index.lock left by a killed crew process. See the script header.
 teardown_treehouse_return() {
   local dir=$1 cd_dir=$2 label=$3 post_cleanup_check=${4:-}
-  local out lock attempt=0 max_retries lock_desc
+  local out lock attempt=0 max_retries lock_desc retry_reason
 
   # Capture stdout+stderr so non-lock failures stay visible and lock failures can
   # be matched by signature even when the lock file is already gone mid-check.
@@ -1308,15 +1329,20 @@ teardown_treehouse_return() {
   fi
   [ -n "$out" ] && printf '%s\n' "$out" >&2
 
-  if ! treehouse_return_is_index_lock_error "$out"; then
+  if ! treehouse_return_is_retryable_transient "$out"; then
     return 1
   fi
 
   lock=$(worktree_git_lock_path "$dir") || lock=""
   if [ -n "$lock" ]; then
     lock_desc=$lock
+    retry_reason="transient git lock ($lock_desc)"
+  elif treehouse_return_is_windows_process_race "$out"; then
+    lock_desc="index.lock"
+    retry_reason="a process still exiting"
   else
     lock_desc="index.lock"
+    retry_reason="transient git lock ($lock_desc)"
   fi
 
   max_retries=$TREEHOUSE_RETURN_LOCK_RETRIES
@@ -1324,18 +1350,18 @@ teardown_treehouse_return() {
 
   while [ "$attempt" -lt "$max_retries" ]; do
     attempt=$(( attempt + 1 ))
-    echo "teardown: $label return failed with transient git lock ($lock_desc); waiting ${TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS}s and retrying ($attempt/${max_retries})" >&2
+    echo "teardown: $label return failed ($retry_reason); waiting ${TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS}s and retrying ($attempt/${max_retries})" >&2
     sleep "$TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS"
 
     if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
       [ -n "$out" ] && printf '%s\n' "$out"
-      echo "teardown: $label return succeeded on retry; lock cleared on its own" >&2
+      echo "teardown: $label return succeeded on retry" >&2
       return 0
     fi
     [ -n "$out" ] && printf '%s\n' "$out" >&2
 
-    if ! treehouse_return_is_index_lock_error "$out"; then
-      echo "teardown: $label return failed with a non-lock error after retry; aborting" >&2
+    if ! treehouse_return_is_retryable_transient "$out"; then
+      echo "teardown: $label return failed with a non-transient error after retry; aborting" >&2
       return 1
     fi
   done
@@ -1616,6 +1642,15 @@ reap_task_backend_process_group() {  # <label>
     echo "warning: lsof is unavailable; cannot resolve the tmux pane process group for $ID" >&2
     return 0
     ;;
+  esac
+  # Windows (Git Bash + psmux) has neither lsof nor Unix process groups, so a
+  # process-group reap is impossible here. Defer to the worktree return below:
+  # treehouse terminates the pane's processes (shell, subshell, harness, and
+  # their children) as it reclaims the worktree, and it kills them in tree order
+  # rather than force-killing the pane root first - which would orphan the
+  # harness's detached children and defeat the return's own liveness check.
+  case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*) return 0 ;;
   esac
   leader_start=$(task_process_identity "$leader") || {
     echo "warning: lsof is unavailable; cannot identify the tmux pane process group for $ID" >&2

--- a/bin/fm-win-ancestry.ps1
+++ b/bin/fm-win-ancestry.ps1
@@ -1,0 +1,39 @@
+# fm-win-ancestry.ps1 - Windows process-ancestry source for fm-session-lock-lib.sh.
+#
+# Git Bash / MSYS ps cannot see native Windows processes, so firstmate's session
+# lock reads the true parent chain here instead. Given a start Windows pid, walk
+# up the Win32_Process tree and print one tab-separated row per hop, innermost
+# first:
+#
+#   <pid>\t<name>\t<commandline>
+#
+# name plays the role of `ps -o comm=` and commandline the role of `ps -o args=`
+# for the harness matcher. Bounded to 16 hops; stops at the first parent that is
+# not a live process (or a self/zero parent). All processes are fetched once so a
+# single CIM query serves the whole walk.
+
+param([Parameter(Mandatory = $true)][int]$Start)
+
+$ErrorActionPreference = 'Stop'
+
+$byPid = @{}
+Get-CimInstance Win32_Process -ErrorAction Stop | ForEach-Object {
+  $byPid[[int]$_.ProcessId] = $_
+}
+
+$TAB = [char]9
+$cur = $Start
+for ($hop = 0; $hop -lt 16; $hop++) {
+  $p = $byPid[$cur]
+  if (-not $p) { break }
+  $name = $p.Name
+  $cmd = $p.CommandLine
+  # A tab or newline inside a value would corrupt the row the bash side splits on.
+  if ($name) { $name = ($name -replace "[`t`r`n]", ' ') } else { $name = '' }
+  if ($cmd)  { $cmd  = ($cmd  -replace "[`t`r`n]", ' ') } else { $cmd  = '' }
+  # Emit a bare LF, not the platform CRLF, so the bash reader sees clean rows.
+  [Console]::Out.Write(('{0}{1}{2}{1}{3}' -f $p.ProcessId, $TAB, $name, $cmd) + "`n")
+  $parent = [int]$p.ParentProcessId
+  if ($parent -le 0 -or $parent -eq $cur) { break }
+  $cur = $parent
+}

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -35,12 +35,30 @@ NAMED_CLAUDE="$FAKEBIN/claude"
 # --- unit layer: identity behind a deterministic process table ---------------
 
 # Run one library expression with <fakebin> shadowing ps. kill is stubbed so
-# liveness questions are decided by the process table alone.
+# liveness questions are decided by the process table alone. The fixtures below
+# model the `ps -o comm=/args=/ppid=` world, so the unix inspection path is
+# pinned explicitly - otherwise a Windows (MSYS) test host would select the
+# native-tree path and never touch the faked ps at all.
 lib_eval() {  # <fakebin> <expression>
   local fakebin=$1 expr=$2
-  PATH="$fakebin:$PATH" bash -c "
+  FM_LOCK_PLATFORM=unix PATH="$fakebin:$PATH" bash -c "
     . \"\$0\"
     kill() { return 0; }
+    $expr
+  " "$LIB"
+}
+
+# Run one library expression on the Windows inspection path. The three native
+# data seams are shadowed from fixture files (as lib_eval shadows kill): this
+# shell's Windows pid, the Win32_Process ancestry walk, and the `ps -W` table.
+# WIN_SELF, WIN_CHAIN, and WIN_PSW are read from the environment.
+win_eval() {  # <expression>
+  local expr=$1
+  FM_LOCK_PLATFORM=windows bash -c "
+    . \"\$0\"
+    _fm_win_self_winpid() { printf '%s\n' \"\$WIN_SELF\"; }
+    _fm_win_walk_rows() { cat \"\$WIN_CHAIN\"; }
+    _fm_win_ps_w() { cat \"\$WIN_PSW\"; }
     $expr
   " "$LIB"
 }
@@ -220,6 +238,84 @@ SH
   pass "session-lock: a live version-named session holding the lock is not mistaken for a stale owner"
 }
 
+# --- unit layer: the Windows native-tree inspection path ---------------------
+
+# Build the Windows fixtures for one scenario under <dir> and export the seams
+# win_eval reads. The chain is the real Git Bash shape: two bash.exe hops - whose
+# command lines mention ~/.claude, which must NOT be read as a harness - below the
+# claude.exe session, then cmd.exe and the terminal. Paths carry literal
+# backslashes, so every field is passed as a %s argument rather than baked into
+# the printf format.
+win_fixture() {  # <dir>
+  local dir=$1
+  mkdir -p "$dir/state"
+  {
+    printf '%s\t%s\t%s\n' 100 bash.exe '"C:\Program Files\Git\bin\..\usr\bin\bash.exe" -c "source /c/Users/u/.claude/shell-snapshots/snap.sh && eval cmd"'
+    printf '%s\t%s\t%s\n' 101 bash.exe '"C:\Program Files\Git\bin\bash.exe" -c "source /c/Users/u/.claude/shell-snapshots/snap.sh"'
+    printf '%s\t%s\t%s\n' 200 claude.exe claude
+    printf '%s\t%s\t%s\n' 300 cmd.exe 'C:\WINDOWS\system32\cmd.exe'
+    printf '%s\t%s\t%s\n' 400 wezterm-gui.exe '"C:\Program Files\WezTerm\wezterm-gui.exe" start'
+  } > "$dir/chain"
+  # ps -W table. STIME is two tokens ("Jul 30") on the claude row to prove the
+  # COMMAND parser anchors on the drive-letter path, not a fixed column offset;
+  # System has a bare COMMAND (no path) and must never resolve as a harness.
+  {
+    printf '%s\n' '      PID    PPID    PGID     WINPID   TTY         UID    STIME COMMAND'
+    printf '%s\n' '  4217716       0       0        200   ?              0 Jul 30 C:\Users\u\AppData\Local\claude.exe'
+    printf '%s\n' '  4194308       0       0          4   ?              0 Jul 30 System'
+    printf '%s\n' '  4207384       0       0        101   ?              0 10:02:04 C:\Program Files\Git\usr\bin\bash.exe'
+  } > "$dir/psw"
+  export WIN_SELF=100 WIN_CHAIN="$dir/chain" WIN_PSW="$dir/psw"
+}
+
+test_windows_harness_is_found_beyond_the_bash_hops() {
+  local dir got
+  dir="$TMP_ROOT/win-found"
+  win_fixture "$dir"
+  # This is the whole bug: the MSYS ps saw only the bash hops and reported no
+  # harness, so every session refused the lock. The native-tree walk climbs past
+  # the two bash.exe hops - whose ~/.claude command lines are not harness
+  # evidence - to the claude.exe session.
+  got=$(win_eval 'fm_harness_ancestry_pid') \
+    || fail "windows: the claude.exe session was not found in the native ancestry at all"
+  [ "$got" = 200 ] || fail "windows: ancestry resolved '$got', expected the claude.exe pid 200"
+  printf '200\n' > "$dir/state/.lock"
+  win_eval "fm_session_lock_owned_by_self '$dir/state'" \
+    || fail "windows: the session holding the lock did not recognize itself as the owner"
+  pass "session-lock: on Windows the claude.exe session is found above the Git Bash hops"
+}
+
+test_windows_liveness_reads_the_native_process_table() {
+  local dir
+  dir="$TMP_ROOT/win-live"
+  win_fixture "$dir"
+  win_eval 'fm_harness_pid_alive 200' \
+    || fail "windows: a live claude.exe was not recognized as a harness (COMMAND parse under a two-token STIME)"
+  if win_eval 'fm_harness_pid_alive 101'; then
+    fail "windows: a live bash.exe passed the harness-liveness predicate"
+  fi
+  if win_eval 'fm_harness_pid_alive 4'; then
+    fail "windows: a bare-name native process (System) was treated as a harness"
+  fi
+  if win_eval 'fm_harness_pid_alive 999999'; then
+    fail "windows: a pid absent from the native-process table was reported alive"
+  fi
+  pass "session-lock: on Windows liveness and identity come from the native-process table"
+}
+
+test_windows_lock_above_the_harness_is_not_owned() {
+  local dir
+  dir="$TMP_ROOT/win-gap"
+  win_fixture "$dir"
+  # cmd.exe (300) sits above the contiguous harness run; a lock naming it is not
+  # this session's, exactly as on Unix ownership stops at the first non-harness.
+  printf '300\n' > "$dir/state/.lock"
+  if win_eval "fm_session_lock_owned_by_self '$dir/state'"; then
+    fail "windows: a lock held by a process above the harness was claimed as this session's own"
+  fi
+  pass "session-lock: on Windows ownership stops at the first non-harness above the session"
+}
+
 # --- end-to-end layer: the real Stop auto-arm in real process trees ----------
 
 install_autoarm_scripts() {
@@ -360,6 +456,9 @@ test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
+test_windows_harness_is_found_beyond_the_bash_hops
+test_windows_liveness_reads_the_native_process_table
+test_windows_lock_above_the_harness_is_not_owned
 test_e2e_version_named_session_claims_the_home
 test_e2e_daemon_parented_session_claims_the_home
 test_e2e_daemon_parented_version_named_session_keeps_its_lock

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -48,17 +48,20 @@ lib_eval() {  # <fakebin> <expression>
   " "$LIB"
 }
 
-# Run one library expression on the Windows inspection path. The three native
-# data seams are shadowed from fixture files (as lib_eval shadows kill): this
-# shell's Windows pid, the Win32_Process ancestry walk, and the `ps -W` table.
-# WIN_SELF, WIN_CHAIN, and WIN_PSW are read from the environment.
+# Run one library expression on the Windows inspection path. The native data
+# seams are shadowed from fixtures (as lib_eval shadows kill): this shell's MSYS
+# pid, the MSYS logical process table, the Win32_Process ancestry walk, the
+# `ps -W` native table, and the /proc winpid fallback. WIN_MSYSSELF, WIN_MSYSPS,
+# WIN_CHAIN, WIN_PSW, and WIN_SELF are read from the environment.
 win_eval() {  # <expression>
   local expr=$1
   FM_LOCK_PLATFORM=windows bash -c "
     . \"\$0\"
-    _fm_win_self_winpid() { printf '%s\n' \"\$WIN_SELF\"; }
-    _fm_win_walk_rows() { cat \"\$WIN_CHAIN\"; }
+    _fm_win_self_msyspid() { printf '%s\n' \"\$WIN_MSYSSELF\"; }
+    _fm_win_ps() { cat \"\$WIN_MSYSPS\"; }
+    _fm_win_walk_rows() { [ \"\$1\" = \"\${WIN_EXPECT_START:-100}\" ] && cat \"\$WIN_CHAIN\"; }
     _fm_win_ps_w() { cat \"\$WIN_PSW\"; }
+    _fm_win_self_winpid() { printf '%s\n' \"\$WIN_SELF\"; }
     $expr
   " "$LIB"
 }
@@ -265,7 +268,16 @@ win_fixture() {  # <dir>
     printf '%s\n' '  4194308       0       0          4   ?              0 Jul 30 System'
     printf '%s\n' '  4207384       0       0        101   ?              0 10:02:04 C:\Program Files\Git\usr\bin\bash.exe'
   } > "$dir/psw"
-  export WIN_SELF=100 WIN_CHAIN="$dir/chain" WIN_PSW="$dir/psw"
+  # MSYS logical process table: this subprocess (msys 50, winpid 3856 - orphaned,
+  # never a valid Win32 walk start) under the topmost MSYS shell (msys 51, winpid
+  # 100), which was spawned directly by the harness and whose winpid IS the valid
+  # Win32 walk entry point. The chain above is keyed to start at winpid 100.
+  {
+    printf '%s\n' '      PID    PPID    PGID     WINPID   TTY   UID STIME COMMAND'
+    printf '%s\n' '   50 51 50 3856 ? 197609 17:31 /usr/bin/bash'
+    printf '%s\n' '   51 1 51 100 ? 197609 17:31 /usr/bin/bash'
+  } > "$dir/msysps"
+  export WIN_MSYSSELF=50 WIN_MSYSPS="$dir/msysps" WIN_CHAIN="$dir/chain" WIN_PSW="$dir/psw" WIN_SELF=999
 }
 
 test_windows_harness_is_found_beyond_the_bash_hops() {
@@ -314,6 +326,33 @@ test_windows_lock_above_the_harness_is_not_owned() {
     fail "windows: a lock held by a process above the harness was claimed as this session's own"
   fi
   pass "session-lock: on Windows ownership stops at the first non-harness above the session"
+}
+
+test_windows_ancestry_start_bridges_msys_to_windows() {
+  local dir got
+  dir="$TMP_ROOT/win-bridge"
+  win_fixture "$dir"
+  # A Git Bash subprocess is fork-orphaned: its own winpid (WIN_SELF=999) has no
+  # valid Win32 parent. The start pid must instead be the topmost MSYS shell's
+  # winpid (100), resolved by climbing the MSYS logical table.
+  got=$(win_eval '_fm_win_ancestry_start_winpid') \
+    || fail "windows: could not resolve an ancestry start winpid"
+  [ "$got" = 100 ] \
+    || fail "windows: start winpid resolved '$got', expected the top MSYS shell's winpid 100 (not the orphaned self)"
+  pass "session-lock: on Windows the ancestry start bridges the MSYS chain to the top shell's winpid"
+}
+
+test_windows_ancestry_start_falls_back_when_msys_table_lacks_self() {
+  local dir got
+  dir="$TMP_ROOT/win-fallback"
+  win_fixture "$dir"
+  # If the MSYS table cannot place this shell, fall back to its own winpid.
+  printf '%s\n' '      PID    PPID    PGID     WINPID   TTY   UID STIME COMMAND' > "$dir/msysps"
+  got=$(WIN_SELF=4242 win_eval '_fm_win_ancestry_start_winpid') \
+    || fail "windows: fallback did not produce a start winpid"
+  [ "$got" = 4242 ] \
+    || fail "windows: fallback resolved '$got', expected this shell's own winpid 4242"
+  pass "session-lock: on Windows the ancestry start falls back to the own winpid when the MSYS table lacks self"
 }
 
 # --- end-to-end layer: the real Stop auto-arm in real process trees ----------
@@ -459,6 +498,8 @@ test_competing_version_named_session_is_seen_as_live
 test_windows_harness_is_found_beyond_the_bash_hops
 test_windows_liveness_reads_the_native_process_table
 test_windows_lock_above_the_harness_is_not_owned
+test_windows_ancestry_start_bridges_msys_to_windows
+test_windows_ancestry_start_falls_back_when_msys_table_lacks_self
 test_e2e_version_named_session_claims_the_home
 test_e2e_daemon_parented_session_claims_the_home
 test_e2e_daemon_parented_version_named_session_keeps_its_lock


### PR DESCRIPTION
## Problem

On Windows under Git Bash / MSYS, every firstmate session comes up read-only. The session lock identifies the owning session by walking the process ancestry for the harness process (`fm_harness_ancestry_pids`), and it did this exclusively through `ps -o comm=/args=/ppid= -p <pid>`.

The MSYS `ps` bundled with Git Bash does not support that syntax (it rejects `-o`) and cannot see native Windows processes anyway. The Claude harness is a real ancestor two hops up the *native* Windows process tree:

```
bash.exe (tool)  ->  bash.exe (wrapper)  ->  claude.exe  ->  cmd.exe  ->  terminal
```

So the walk terminates immediately, finds no harness, and `bin/fm-lock.sh` reports `cannot locate harness process in ancestry`. The whole home is then held read-only: no spawn, steer, merge, drain, or supervision repair.

## Fix

Introduce a platform-aware process-inspection layer under the two low-level primitives, leaving the harness-identity **policy** (and therefore all Linux and macOS behavior) unchanged:

- `_fm_ancestry_rows` emits the ancestry innermost-first as `pid<TAB>comm<TAB>args`. On Unix it uses the existing `ps -o` walk; on Windows it reads the true tree from `Win32_Process` via a new `bin/fm-win-ancestry.ps1`.
- `fm_harness_pid_alive` reads liveness+identity from `ps -W` (which lists native processes with their Windows pids) instead of `kill -0` + `ps -o`, since the stored pid is a WINPID on Windows.
- Pids are reported in the platform's own space and stored in the lock consistently, so no consumer mixes spaces.
- `FM_LOCK_PLATFORM` overrides detection so the Windows path is exercisable from a Unix test host.

Every existing consumer - lock acquire/inspect, the Claude Stop auto-arm, the turn-end guards, and session start - routes through these two primitives, so all are fixed by this one change.

## Tests

- The existing unix-shaped unit fixtures are pinned to `FM_LOCK_PLATFORM=unix` (they model the `ps -o` world), so they stay valid even on a Windows test host.
- A new Windows-path unit group shadows the three native seams and covers: harness discovery above the Git Bash hops (with `~/.claude` command lines correctly *not* treated as harness evidence), native-table liveness including a two-token `STIME` column, and ownership stopping at the first non-harness above the session.

Verified end-to-end on real Windows 11 Git Bash (harness resolved, liveness and ownership correct) and linted clean with the repo's pinned ShellCheck 0.11.0.

## Scope

This fixes the session lock only. Other scripts (`fm-harness.sh`, `fm-backend.sh`, `fm-teardown.sh`, `fm-watch.sh`, and more) use the same Unix-process pattern and will need equivalent treatment for full Windows operation; those are follow-ups.
