### PR TITLE
feat(bin): support version-safe Codex max effort

### DIFF
--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -12,7 +12,7 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 | Skill invocation | `$<skill>`, for example `$no-mistakes`; `/<skill>` is Claude-only and Codex rejects it as "Unrecognized command". |
 | Resume | `codex resume <session-id>`, using the id printed on quit. |
 | Model flag | `--model <model>`. |
-| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'`, verified on codex-cli 0.142.1 whose installed schema contains `model_reasoning_effort`, active config uses it, and bundled catalog advertises only these four values while omitting `max`. |
+| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'`. Low through xhigh pass on every supported version. `max` passes on codex-cli 0.149.1 or newer; an older or unparseable version refuses the spawn rather than silently downgrading an explicit selection. The max compatibility probe and worker launch use the same resolved executable path. The boundary is anchored by 0.142.1 rejecting max and a live 0.149.1 session selecting `gpt-5.6-sol max`. `ultra` is outside Firstmate's shared effort vocabulary. |
 | Model discovery | Open the current interactive session's `/model` picker. |
 
 A directory trust dialog appears on the first run for a repository root: "Do you trust the contents of this directory?"

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1086,7 +1086,7 @@ crew_dispatch_validate() {
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
+      elif $h == "codex" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1402,11 +1402,10 @@ effort_flag_for_harness() {
       esac
       ;;
     codex)
-      # The installed codex config schema uses model_reasoning_effort, and the
-      # bundled model catalog advertises low|medium|high|xhigh. Omit max rather
-      # than passing an unsupported value.
+      # Codex's model_reasoning_effort config accepts the shared levels through
+      # max. Ultra remains outside firstmate's shared effort vocabulary.
       case "$effort" in
-        low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
       esac
       ;;
     grok)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1423,7 +1423,8 @@ effort_flag_for_harness() {
           if codex_supports_max_effort; then
             printf -- '-c %s ' "$(shell_quote 'model_reasoning_effort="max"')"
           else
-            echo "warning: Codex max effort requires codex-cli 0.149.1 or newer; omitting it for this launch" >&2
+            echo "error: Codex max effort requires codex-cli 0.149.1 or newer with a parseable version; refusing to launch without the explicitly selected effort" >&2
+            return 1
           fi
           ;;
       esac
@@ -2803,7 +2804,7 @@ sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 sq_worktree=$(shell_quote "$WT")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
-EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT") || exit 1
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -159,6 +159,7 @@
 #   $vars and silently breaks ad-hoc `for ... in $pairs` loops).
 #   Launch templates live in launch_template() below; placeholders replaced before launch:
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
+#     __CODEXBIN__  quoted concrete Codex executable path when max needs a version probe
 #     __PIBIN__    quoted concrete Pi-family executable path resolved from PATH
 #     __PITUIMODE__ optional --tui-mode regular when that executable advertises it
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
@@ -1139,9 +1140,9 @@ launch_template() {
     claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' '__CODEXBIN__ __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' '__CODEXBIN__ __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
@@ -1352,6 +1353,25 @@ resolve_muse_binary() {
   return 1
 }
 
+resolve_codex_binary() {
+  local candidate dir
+  candidate=$(command -v codex 2>/dev/null || true)
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    case "$candidate" in
+      /*) printf '%s\n' "$candidate"; return 0 ;;
+      *)
+        dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || dir=
+        if [ -n "$dir" ]; then
+          printf '%s/%s\n' "$dir" "$(basename "$candidate")"
+          return 0
+        fi
+        ;;
+    esac
+  fi
+  echo "error: codex executable not found on PATH; install Codex or select a different verified harness" >&2
+  return 1
+}
+
 # muse_credential_present: 0 when a launched muse pane can reach its provider
 # without an interactive login. muse offers exactly two credential paths
 # (verified, muse 0.1.0-R708.1): the META_API_KEY environment variable, which
@@ -1393,8 +1413,8 @@ model_flag_for_harness() {
 }
 
 codex_supports_max_effort() {
-  local output version major minor patch extra
-  output=$(codex --version 2>/dev/null) || return 1
+  local binary=$1 output version major minor patch extra
+  output=$("$binary" --version 2>/dev/null) || return 1
   version=${output#codex-cli }
   [ "$version" != "$output" ] || return 1
   IFS='.' read -r major minor patch extra <<< "$version"
@@ -1420,7 +1440,7 @@ effort_flag_for_harness() {
       case "$effort" in
         low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
         max)
-          if codex_supports_max_effort; then
+          if codex_supports_max_effort "$CODEX_BIN"; then
             printf -- '-c %s ' "$(shell_quote 'model_reasoning_effort="max"')"
           else
             echo "error: Codex max effort requires codex-cli 0.149.1 or newer with a parseable version; refusing to launch without the explicitly selected effort" >&2
@@ -2803,6 +2823,10 @@ sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 sq_worktree=$(shell_quote "$WT")
+CODEX_BIN=codex
+if [ "$HARNESS" = codex ] && [ "$EFFORT" = max ]; then
+  CODEX_BIN=$(resolve_codex_binary) || exit 1
+fi
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT") || exit 1
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
@@ -2814,6 +2838,13 @@ LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 case "$HARNESS" in
+  codex)
+    if [ "$CODEX_BIN" = codex ]; then
+      LAUNCH=${LAUNCH//__CODEXBIN__/codex}
+    else
+      LAUNCH=${LAUNCH//__CODEXBIN__/"$(shell_quote "$CODEX_BIN")"}
+    fi
+    ;;
   pi|pi-signed) LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"} ;;
   cursor) LAUNCH=${LAUNCH//__CURSORBIN__/"$(shell_quote "$CURSOR_BIN")"} ;;
 esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -288,6 +288,7 @@ TRACEPARENT_ARG=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
+RAW_HARNESS_BIN=
 BACKEND_SET=0
 MODE_SET=0
 YOLO_SET=0
@@ -1211,7 +1212,10 @@ case "$ARG3" in
     LAUNCH=$ARG3
     HARNESS=""
     for word in $LAUNCH; do
-      case "$word" in [A-Za-z_]*=*) continue ;; *) HARNESS=$(basename "$word"); break ;; esac
+      case "$word" in
+        [A-Za-z_]*=*) continue ;;
+        *) RAW_HARNESS_BIN=$word; HARNESS=$(basename "$word"); break ;;
+      esac
     done
     ;;
   '')
@@ -1354,8 +1358,8 @@ resolve_muse_binary() {
 }
 
 resolve_codex_binary() {
-  local candidate dir
-  candidate=$(command -v codex 2>/dev/null || true)
+  local selected=${1:-codex} candidate dir
+  candidate=$(command -v -- "$selected" 2>/dev/null || true)
   if [ -n "$candidate" ] && [ -x "$candidate" ]; then
     case "$candidate" in
       /*) printf '%s\n' "$candidate"; return 0 ;;
@@ -1484,10 +1488,13 @@ effort_flag_for_harness() {
 
 CODEX_BIN=codex
 if [ "$HARNESS" = codex ] && [ "$EFFORT" = max ]; then
-  CODEX_BIN=$(resolve_codex_binary) || exit 1
+  CODEX_BIN=$(resolve_codex_binary "${RAW_HARNESS_BIN:-codex}") || exit 1
   if ! codex_supports_max_effort "$CODEX_BIN"; then
     echo "error: Codex max effort requires codex-cli 0.149.1 or newer with a parseable version; refusing to launch without the explicitly selected effort" >&2
     exit 1
+  fi
+  if [ -n "$RAW_HARNESS_BIN" ]; then
+    LAUNCH=${LAUNCH/"$RAW_HARNESS_BIN"/__CODEXBIN__}
   fi
 fi
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1372,7 +1372,7 @@ resolve_codex_binary() {
         ;;
     esac
   fi
-  echo "error: codex executable not found on PATH; install Codex or select a different verified harness" >&2
+  echo "error: Codex executable '$selected' was not found or is not executable; install Codex or select a different verified harness" >&2
   return 1
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1392,6 +1392,21 @@ model_flag_for_harness() {
   esac
 }
 
+codex_supports_max_effort() {
+  local output version major minor patch extra
+  output=$(codex --version 2>/dev/null) || return 1
+  version=${output#codex-cli }
+  [ "$version" != "$output" ] || return 1
+  IFS='.' read -r major minor patch extra <<< "$version"
+  case "$major.$minor.$patch" in *[!0-9.]*) return 1 ;; esac
+  [ -n "$major" ] && [ -n "$minor" ] && [ -n "$patch" ] && [ -z "$extra" ] || return 1
+  [ "$major" -gt 0 ] && return 0
+  [ "$major" -eq 0 ] || return 1
+  [ "$minor" -gt 149 ] && return 0
+  [ "$minor" -eq 149 ] || return 1
+  [ "$patch" -ge 1 ]
+}
+
 effort_flag_for_harness() {
   local harness=$1 effort=$2
   [ -n "$effort" ] && [ "$effort" != default ] || return 0
@@ -1402,10 +1417,15 @@ effort_flag_for_harness() {
       esac
       ;;
     codex)
-      # Codex's model_reasoning_effort config accepts the shared levels through
-      # max. Ultra remains outside firstmate's shared effort vocabulary.
       case "$effort" in
-        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        max)
+          if codex_supports_max_effort; then
+            printf -- '-c %s ' "$(shell_quote 'model_reasoning_effort="max"')"
+          else
+            echo "warning: Codex max effort requires codex-cli 0.149.1 or newer; omitting it for this launch" >&2
+          fi
+          ;;
       esac
       ;;
     grok)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1439,14 +1439,7 @@ effort_flag_for_harness() {
     codex)
       case "$effort" in
         low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
-        max)
-          if codex_supports_max_effort "$CODEX_BIN"; then
-            printf -- '-c %s ' "$(shell_quote 'model_reasoning_effort="max"')"
-          else
-            echo "error: Codex max effort requires codex-cli 0.149.1 or newer with a parseable version; refusing to launch without the explicitly selected effort" >&2
-            return 1
-          fi
-          ;;
+        max) printf -- '-c %s ' "$(shell_quote 'model_reasoning_effort="max"')" ;;
       esac
       ;;
     grok)
@@ -1488,6 +1481,15 @@ effort_flag_for_harness() {
     # effort flag.
   esac
 }
+
+CODEX_BIN=codex
+if [ "$HARNESS" = codex ] && [ "$EFFORT" = max ]; then
+  CODEX_BIN=$(resolve_codex_binary) || exit 1
+  if ! codex_supports_max_effort "$CODEX_BIN"; then
+    echo "error: Codex max effort requires codex-cli 0.149.1 or newer with a parseable version; refusing to launch without the explicitly selected effort" >&2
+    exit 1
+  fi
+fi
 
 case "$LAUNCH" in
   *__MUSEBIN__*)
@@ -2823,10 +2825,6 @@ sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 sq_worktree=$(shell_quote "$WT")
-CODEX_BIN=codex
-if [ "$HARNESS" = codex ] && [ "$EFFORT" = max ]; then
-  CODEX_BIN=$(resolve_codex_binary) || exit 1
-fi
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT") || exit 1
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1376,6 +1376,30 @@ resolve_codex_binary() {
   return 1
 }
 
+replace_raw_harness_binary() {
+  local command=$1 selected=$2 replacement=$3 remainder prefix='' leading word
+  remainder=$command
+  while [ -n "$remainder" ]; do
+    leading=${remainder%%[![:space:]]*}
+    prefix=$prefix$leading
+    remainder=${remainder#"$leading"}
+    [ -n "$remainder" ] || break
+    word=${remainder%%[[:space:]]*}
+    case "$word" in
+      [A-Za-z_]*=*)
+        prefix=$prefix$word
+        remainder=${remainder#"$word"}
+        ;;
+      *)
+        [ "$word" = "$selected" ] || return 1
+        printf '%s%s%s\n' "$prefix" "$replacement" "${remainder#"$word"}"
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
 # muse_credential_present: 0 when a launched muse pane can reach its provider
 # without an interactive login. muse offers exactly two credential paths
 # (verified, muse 0.1.0-R708.1): the META_API_KEY environment variable, which
@@ -1494,7 +1518,10 @@ if [ "$HARNESS" = codex ] && [ "$EFFORT" = max ]; then
     exit 1
   fi
   if [ -n "$RAW_HARNESS_BIN" ]; then
-    LAUNCH=${LAUNCH/"$RAW_HARNESS_BIN"/__CODEXBIN__}
+    LAUNCH=$(replace_raw_harness_binary "$LAUNCH" "$RAW_HARNESS_BIN" __CODEXBIN__) || {
+      echo "error: could not replace the parsed Codex executable in the raw launch command" >&2
+      exit 1
+    }
   fi
 fi
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -33,6 +33,8 @@ The decisive interactive header output was:
 ```
 
 The opt-in executable refresh guard is `FM_CODEX_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-codex-continuity-live-e2e.test.sh`.
+Firstmate therefore passes explicit max effort on codex-cli 0.149.1 or newer and preserves the compatible omission path with a warning on older or unparseable versions.
+Low through xhigh remain version-independent.
 
 Foreground-process behavior was verified on 2026-07-07 with tmux 3.6a on macOS.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -33,7 +33,7 @@ The decisive interactive header output was:
 ```
 
 The opt-in executable refresh guard is `FM_CODEX_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-codex-continuity-live-e2e.test.sh`.
-Firstmate therefore passes explicit max effort on codex-cli 0.149.1 or newer and preserves the compatible omission path with a warning on older or unparseable versions.
+Firstmate therefore passes explicit max effort on codex-cli 0.149.1 or newer and refuses to spawn on older or unparseable versions rather than silently downgrading the explicit selection.
 Low through xhigh remain version-independent.
 
 Foreground-process behavior was verified on 2026-07-07 with tmux 3.6a on macOS.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -8,6 +8,22 @@ Exact task chronology, branch names, temporary homes, local paths, process ids, 
 
 ## tmux
 
+Codex max-effort launch was verified on 2026-08-27 against codex-cli 0.149.1.
+The real interactive harness was launched with the same configuration shape used by `fm-spawn.sh`:
+
+```sh
+codex -c 'model="gpt-5.6-sol"' -c 'model_reasoning_effort="max"'
+```
+
+The decisive interactive header output was:
+
+```text
+│ model:     gpt-5.6-sol max   /model to change        │
+  gpt-5.6-sol max · <worktree>
+```
+
+The opt-in executable refresh guard is `FM_CODEX_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-codex-continuity-live-e2e.test.sh`.
+
 Foreground-process behavior was verified on 2026-07-07 with tmux 3.6a on macOS.
 
 ```sh

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -9,6 +9,16 @@ Exact task chronology, branch names, temporary homes, local paths, process ids, 
 ## tmux
 
 Codex max-effort launch was verified on 2026-08-27 against codex-cli 0.149.1.
+The installed version was recorded with:
+
+```sh
+codex --version
+```
+
+```text
+codex-cli 0.149.1
+```
+
 The real interactive harness was launched with the same configuration shape used by `fm-spawn.sh`:
 
 ```sh

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -1118,7 +1118,7 @@ test_crew_dispatch_validation() {
   done <<'ROWS'
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
-unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+codex max effort is accepted^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^empty^
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
@@ -1139,7 +1139,7 @@ empty array use is flagged^{"rules":[{"when":"big feature","use":[]}]}^exact^CRE
 array profile without harness is flagged^{"rules":[{"when":"big feature","use":[{"model":"gpt-5.5"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each use profile needs harness
 array profile with malformed model is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","model":5}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - use profile model and effort must be non-empty strings when present
 unknown select is flagged^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"mystery"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unknown select: mystery
-array profile unsupported effort is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+array profile codex max effort is accepted^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^empty^
 empty default array is flagged^{"default":[]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - default needs at least one profile
 non-object default array entry is flagged^{"default":["codex"]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile must be an object
 default array profile without harness is flagged^{"default":[{"model":"gpt-5.5"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile needs harness

--- a/tests/fm-captain-hold-lifecycle.test.sh
+++ b/tests/fm-captain-hold-lifecycle.test.sh
@@ -12,6 +12,7 @@ set -u
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 BEARINGS="$ROOT/bin/fm-bearings-snapshot.sh"
 TMP_ROOT=$(fm_test_tmproot fm-captain-hold)
+TMP_ROOT=$(cd -P -- "$TMP_ROOT" && pwd -P)
 TASKS_AXI_BIN=$(command -v tasks-axi || true)
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
@@ -127,10 +128,11 @@ EOF
       and (.reports | any(.id == "sample-route-review"))
   ' >/dev/null || fail "the pre-policy omission shape was not reproduced: $json"
 
-  set +e
-  run_teardown "$home" "$id" > "$home/teardown.out" 2> "$home/teardown.err"
-  rc=$?
-  set -e
+  if run_teardown "$home" "$id" > "$home/teardown.out" 2> "$home/teardown.err"; then
+    rc=0
+  else
+    rc=$?
+  fi
   [ "$rc" -ne 0 ] || fail "completed investigation teardown erased a report-only unresolved captain call"
   assert_present "$home/state/$id.meta" "refused completion must preserve investigation metadata"
   assert_grep "REFUSED" "$home/teardown.err" "refusal must be explicit"
@@ -708,7 +710,8 @@ SH
   PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$home/adapter-root" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
-    "$ROOT/bin/fm-procevent.sh" start fixture-src >/dev/null 2>&1
+    "$ROOT/bin/fm-procevent.sh" start fixture-src > "$home/start.out" 2> "$home/start.err" \
+    || fail "could not start the fixture channel source: $(cat "$home/start.err")"
   assert_absent "$home/state/procevent-inbox/fixture-src.1.handled" \
     "feeding a captain answer retired the notification firstmate still needs"
   assert_present "$home/state/procevent-inbox/fixture-src.1.result" \
@@ -731,11 +734,12 @@ SH
 
   # Replaying the same capture is a no-op, not a rejected different decision. A
   # run that could not close every answered key still reports nonzero.
-  set +e
-  out=$(run_lavish "$home" answers "$result" \
-    | run_captain "$home" answers --source "the captured result fixture-src sequence 1" 2>&1)
-  rc=$?
-  set -e
+  if out=$(run_lavish "$home" answers "$result" \
+    | run_captain "$home" answers --source "the captured result fixture-src sequence 1" 2>&1); then
+    rc=0
+  else
+    rc=$?
+  fi
   [ "$rc" -ne 0 ] || fail "a run that skipped a key reported success"
   assert_contains "$out" "closed: sample-membership-call" \
     "replaying an identical capture was not idempotent: $out"
@@ -786,10 +790,11 @@ session:
 prompts[1]{uid,prompt,selector,tag,text}:
   "2","Only choice: yes\n\nContext data:\n{\n  \"question\": \"sample-only-call\",\n  \"answer\": \"yes\"\n}","form",choice,"Only choice: yes"
 EOF
-  set +e
-  out=$(run_captain "$home" binding "$sid" 2>&1)
-  rc=$?
-  set -e
+  if out=$(run_captain "$home" binding "$sid" 2>&1); then
+    rc=0
+  else
+    rc=$?
+  fi
   [ "$rc" -ne 0 ] || fail "an unbound source reported a binding"
   [ -z "$out" ] || fail "an unbound source printed a binding: $out"
   show=$(tasks_in "$home" show sample-only-call --full)

--- a/tests/fm-codex-continuity-live-e2e.test.sh
+++ b/tests/fm-codex-continuity-live-e2e.test.sh
@@ -22,6 +22,10 @@ PROJECT="$LAB/project"
 HOME_DIR="$LAB/fmhome"
 TRANSCRIPT="$LAB/codex.jsonl"
 CODEX_VERSION=$(codex --version)
+VERIFIED_CODEX_VERSION="codex-cli 0.149.1"
+
+[ "$CODEX_VERSION" = "$VERIFIED_CODEX_VERSION" ] \
+  || fail "unverified Codex version: $CODEX_VERSION (expected $VERIFIED_CODEX_VERSION)"
 
 cleanup() {
   rm -rf "$LAB"
@@ -47,12 +51,19 @@ PROMPT='Run exactly `bin/fm-watch-checkpoint.sh --seconds 1` as one foreground s
     "$PROMPT"
 ) > "$TRANSCRIPT" 2>&1 || fail "Codex credentialed checkpoint turn failed: $(tail -20 "$TRANSCRIPT")"
 
+THREAD_ID=$(jq -Rr 'fromjson? | select(.type == "thread.started") | .thread_id' "$TRANSCRIPT" | head -1)
+[ -n "$THREAD_ID" ] || fail "Codex $CODEX_VERSION transcript omitted the session id"
+SESSION_FILE=$(find "${CODEX_HOME:-$HOME/.codex}/sessions" -type f -name "*-$THREAD_ID.jsonl" -print -quit 2>/dev/null)
+[ -n "$SESSION_FILE" ] || fail "Codex $CODEX_VERSION omitted persisted metadata for session $THREAD_ID"
+jq -e --arg model "gpt-5.6-sol" --arg effort "max" \
+  'select(.type == "turn_context" and .payload.model == $model and .payload.effort == $effort)' \
+  "$SESSION_FILE" >/dev/null \
+  || fail "Codex $CODEX_VERSION session metadata did not select gpt-5.6-sol max"
+
 grep -F 'checkpoint: no actionable wake within 1s' "$TRANSCRIPT" >/dev/null \
   || fail "Codex transcript omitted the real foreground checkpoint result"
 if grep -F 'watcher: started pid=' "$TRANSCRIPT" >/dev/null; then
   fail "Codex switched to the background arm path"
 fi
 
-grep -E '"type":"turn.completed".*"reasoning_output_tokens":[1-9][0-9]*' "$TRANSCRIPT" >/dev/null \
-  || fail "Codex $CODEX_VERSION completed without maximum-effort reasoning usage"
 printf 'ok - %s live E2E selected max and preserved the one-second foreground checkpoint path\n' "$CODEX_VERSION"

--- a/tests/fm-codex-continuity-live-e2e.test.sh
+++ b/tests/fm-codex-continuity-live-e2e.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Opt-in credentialed Codex regression proving the continuity changes preserve
-# Codex's bounded foreground-checkpoint supervision path.
+# Opt-in credentialed Codex regression proving the continuity path and max
+# reasoning-effort launch configuration against the real installed harness.
 set -u
 
 if [ "${FM_CODEX_LIVE_E2E:-0}" != 1 ]; then
@@ -41,7 +41,8 @@ PROMPT='Run exactly `bin/fm-watch-checkpoint.sh --seconds 1` as one foreground s
     --dangerously-bypass-hook-trust \
     --dangerously-bypass-approvals-and-sandbox \
     --skip-git-repo-check \
-    -c 'model_reasoning_effort="low"' \
+    -c 'model="gpt-5.6-sol"' \
+    -c 'model_reasoning_effort="max"' \
     --json \
     "$PROMPT"
 ) > "$TRANSCRIPT" 2>&1 || fail "Codex credentialed checkpoint turn failed: $(tail -20 "$TRANSCRIPT")"
@@ -52,4 +53,6 @@ if grep -F 'watcher: started pid=' "$TRANSCRIPT" >/dev/null; then
   fail "Codex switched to the background arm path"
 fi
 
-printf 'ok - %s live E2E preserved the one-second foreground checkpoint path\n' "$CODEX_VERSION"
+grep -E '"type":"turn.completed".*"reasoning_output_tokens":[1-9][0-9]*' "$TRANSCRIPT" >/dev/null \
+  || fail "Codex $CODEX_VERSION completed without maximum-effort reasoning usage"
+printf 'ok - %s live E2E selected max and preserved the one-second foreground checkpoint path\n' "$CODEX_VERSION"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -1312,6 +1312,32 @@ test_spawn_relaunch_refuses_a_pane_outside_the_worktree() {
   pass "fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work"
 }
 
+test_spawn_relaunch_preserves_metadata_when_codex_max_is_unsupported() {
+  local dir out rc before
+  dir=$(new_case codexmax rl36)
+  add_ship_task "$dir" rl36 claude
+  printf 'zsh' > "$dir/fake/command"
+  cat > "$dir/fakebin/codex" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' 'codex-cli 0.142.1'
+fi
+SH
+  chmod +x "$dir/fakebin/codex"
+  before=$(cat "$dir/home/state/rl36.meta")
+
+  out=$(run_spawn "$dir" rl36 --relaunch --harness codex --effort max); rc=$?
+
+  expect_code 1 "$rc" "unsupported Codex max relaunch should refuse"
+  assert_contains "$out" "refusing to launch without the explicitly selected effort" \
+    "unsupported Codex max relaunch should name the refusal"
+  [ "$(cat "$dir/home/state/rl36.meta")" = "$before" ] \
+    || fail "unsupported Codex max relaunch must preserve the prior task record"
+  [ -z "$(cat "$dir/fake/literal")" ] \
+    || fail "unsupported Codex max relaunch must deliver no launch bytes"
+  pass "fm-spawn --relaunch: unsupported Codex max preserves prior metadata"
+}
+
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_serializes_concurrent_durable_metadata_publication
@@ -1358,3 +1384,4 @@ test_spawn_relaunch_refuses_a_live_agent
 test_spawn_relaunch_refuses_contradicting_flags
 test_spawn_relaunch_refuses_an_unrecorded_task
 test_spawn_relaunch_refuses_a_pane_outside_the_worktree
+test_spawn_relaunch_preserves_metadata_when_codex_max_is_unsupported

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -417,7 +417,7 @@ test_codex_threads_model_and_effort() {
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
 
-test_codex_omits_invalid_max_effort() {
+test_codex_threads_max_effort() {
   local rec id out status launch
   id=profile-codex-max-z4
   rec=$(make_spawn_case profile-codex-max codex "$id")
@@ -425,13 +425,12 @@ test_codex_omits_invalid_max_effort() {
 
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
   status=$?
-  expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
+  expect_code 0 "$status" "codex spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not preserve the model flag when max effort was omitted"
-  assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
-  pass "codex omits unsupported max effort instead of passing a bad config value"
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not thread max reasoning effort config"
+  pass "codex receives max through model_reasoning_effort"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -805,7 +804,7 @@ test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
-test_codex_omits_invalid_max_effort
+test_codex_threads_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -505,6 +505,25 @@ test_assignment_prefixed_raw_codex_max_replaces_the_command_word() {
   pass "assignment-prefixed raw Codex max launches the same executable it probes"
 }
 
+test_missing_raw_codex_max_refuses_without_path_fallback() {
+  local rec id out status missing_codex launch
+  id=profile-missing-raw-codex-max-z4ab
+  rec=$(make_spawn_case profile-missing-raw-codex-max codex "$id")
+  read_case_record "$rec"
+  missing_codex="$CASE_DIR/missing-bin/codex"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    "$missing_codex __EFFORTFLAG__--raw" --effort max)
+  status=$?
+  expect_code 1 "$status" "missing raw Codex max executable should refuse instead of falling back to PATH"
+  assert_contains "$out" "Codex executable '$missing_codex' was not found or is not executable" \
+    "missing raw Codex max refusal did not identify the selected executable"
+  launch=$(cat "$LAUNCH_LOG")
+  [ -z "$launch" ] || fail "missing raw Codex max fell back to the PATH executable: $launch"
+  assert_absent "$HOME_DIR/state/$id.meta" "missing raw Codex max refusal must happen before metadata publication"
+  pass "missing raw Codex max refuses without falling back to a different PATH executable"
+}
+
 test_old_codex_refuses_max_effort() {
   local rec id out status launch
   id=profile-codex-old-max-z4b
@@ -917,6 +936,7 @@ test_codex_threads_model_and_effort
 test_codex_threads_max_effort
 test_raw_codex_max_probes_the_named_executable
 test_assignment_prefixed_raw_codex_max_replaces_the_command_word
+test_missing_raw_codex_max_refuses_without_path_fallback
 test_old_codex_refuses_max_effort
 test_unparseable_codex_refuses_max_effort
 test_grok_threads_model_and_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -53,6 +53,7 @@ SH
 #!/usr/bin/env bash
 set -u
 if [ "${1:-}" = --version ]; then
+  [ -z "${FM_FAKE_CODEX_PROBE_LOG:-}" ] || printf '%s\n' "$0" >> "$FM_FAKE_CODEX_PROBE_LOG"
   printf 'codex-cli %s\n' "${FM_FAKE_CODEX_VERSION:-0.149.1}"
 fi
 exit 0
@@ -103,6 +104,7 @@ run_spawn() {
   CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
     FM_FAKE_CODEX_VERSION="${FM_TEST_CODEX_VERSION:-0.149.1}" \
+    FM_FAKE_CODEX_PROBE_LOG="${FM_TEST_CODEX_PROBE_LOG:-}" \
     FM_FAKE_CURSOR_MODELS="${FM_TEST_CURSOR_MODELS:-}" \
     FM_FAKE_CURSOR_LIST_STATUS="${FM_TEST_CURSOR_LIST_STATUS:-0}" \
     GROK_HOME="$home/grok-home" \
@@ -428,19 +430,24 @@ test_codex_threads_model_and_effort() {
 }
 
 test_codex_threads_max_effort() {
-  local rec id out status launch
+  local rec id out status launch probe_log probed_binary
   id=profile-codex-max-z4
   rec=$(make_spawn_case profile-codex-max codex "$id")
   read_case_record "$rec"
+  probe_log="$CASE_DIR/codex-probe.log"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5.6-sol --effort max)
+  out=$(FM_TEST_CODEX_PROBE_LOG="$probe_log" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model gpt-5.6-sol --effort max)
   status=$?
   expect_code 0 "$status" "codex spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5.6-sol' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+  probed_binary=$(cat "$probe_log")
+  [ "$probed_binary" = "$FAKEBIN_DIR/codex" ] || fail "Codex max probe did not use the selected executable: $probed_binary"
+  assert_contains "$launch" "'$probed_binary' --model 'gpt-5.6-sol' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
     "codex launch did not thread max reasoning effort config"
-  pass "codex receives max through model_reasoning_effort"
+  pass "codex max probes and launches the same concrete executable"
 }
 
 test_old_codex_refuses_max_effort() {

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -443,7 +443,7 @@ test_codex_threads_max_effort() {
   pass "codex receives max through model_reasoning_effort"
 }
 
-test_old_codex_omits_max_effort() {
+test_old_codex_refuses_max_effort() {
   local rec id out status launch
   id=profile-codex-old-max-z4b
   rec=$(make_spawn_case profile-codex-old-max codex "$id")
@@ -453,15 +453,30 @@ test_old_codex_omits_max_effort() {
     run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
     --model gpt-5 --effort max)
   status=$?
-  expect_code 0 "$status" "older Codex spawn with max effort should preserve the compatible launch path"
-  assert_contains "$out" "Codex max effort requires codex-cli 0.149.1 or newer" \
-    "older Codex max omission was silent"
+  expect_code 1 "$status" "older Codex spawn must refuse an explicit unsupported max effort"
+  assert_contains "$out" "refusing to launch without the explicitly selected effort" \
+    "older Codex max refusal was not actionable"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
-    "older Codex launch did not preserve the model flag"
-  assert_not_contains "$launch" "model_reasoning_effort" \
-    "older Codex launch received unsupported max reasoning effort"
-  pass "older Codex omits max with an actionable compatibility warning"
+  [ -z "$launch" ] || fail "older Codex launched after refusing max effort: $launch"
+  pass "older Codex refuses to launch without explicit max effort"
+}
+
+test_unparseable_codex_refuses_max_effort() {
+  local rec id out status launch
+  id=profile-codex-unparseable-max-z4c
+  rec=$(make_spawn_case profile-codex-unparseable-max codex "$id")
+  read_case_record "$rec"
+
+  out=$(FM_TEST_CODEX_VERSION=development \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model gpt-5 --effort max)
+  status=$?
+  expect_code 1 "$status" "unparseable Codex version must refuse an explicit max effort"
+  assert_contains "$out" "requires codex-cli 0.149.1 or newer with a parseable version" \
+    "unparseable Codex max refusal did not identify the compatibility boundary"
+  launch=$(cat "$LAUNCH_LOG")
+  [ -z "$launch" ] || fail "unparseable Codex launched after refusing max effort: $launch"
+  pass "unparseable Codex version refuses to launch without explicit max effort"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -836,7 +851,8 @@ test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_threads_max_effort
-test_old_codex_omits_max_effort
+test_old_codex_refuses_max_effort
+test_unparseable_codex_refuses_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -482,6 +482,29 @@ SH
   pass "raw Codex max probes the executable named by the launch command"
 }
 
+test_assignment_prefixed_raw_codex_max_replaces_the_command_word() {
+  local rec id out status launch probe_log probed_binary
+  id=profile-assignment-raw-codex-max-z4aa
+  rec=$(make_spawn_case profile-assignment-raw-codex-max codex "$id")
+  read_case_record "$rec"
+  probe_log="$CASE_DIR/raw-codex-probe.log"
+
+  out=$(FM_TEST_CODEX_PROBE_LOG="$probe_log" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    "CODEX_BIN=codex codex __EFFORTFLAG__--raw" --effort max)
+  status=$?
+  expect_code 0 "$status" "assignment-prefixed raw Codex max should launch the probed executable"
+  probed_binary=$(cat "$probe_log")
+  [ "$probed_binary" = "$FAKEBIN_DIR/codex" ] \
+    || fail "assignment-prefixed raw Codex max probed a different executable: $probed_binary"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "CODEX_BIN=codex '$probed_binary' -c 'model_reasoning_effort=\"max\"' --raw" \
+    "assignment-prefixed raw Codex max did not replace the parsed command word"
+  assert_not_contains "$launch" "CODEX_BIN='$probed_binary' codex" \
+    "assignment-prefixed raw Codex max replaced an assignment value instead of the command word"
+  pass "assignment-prefixed raw Codex max launches the same executable it probes"
+}
+
 test_old_codex_refuses_max_effort() {
   local rec id out status launch
   id=profile-codex-old-max-z4b
@@ -893,6 +916,7 @@ test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_threads_max_effort
 test_raw_codex_max_probes_the_named_executable
+test_assignment_prefixed_raw_codex_max_replaces_the_command_word
 test_old_codex_refuses_max_effort
 test_unparseable_codex_refuses_max_effort
 test_grok_threads_model_and_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -450,6 +450,38 @@ test_codex_threads_max_effort() {
   pass "codex max probes and launches the same concrete executable"
 }
 
+test_raw_codex_max_probes_the_named_executable() {
+  local rec id out status launch raw_codex probe_log probed_binary
+  id=profile-raw-codex-max-z4a
+  rec=$(make_spawn_case profile-raw-codex-max codex "$id")
+  read_case_record "$rec"
+  raw_codex="$CASE_DIR/raw-bin/codex"
+  probe_log="$CASE_DIR/raw-codex-probe.log"
+  mkdir -p "$(dirname "$raw_codex")"
+  cat > "$raw_codex" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' "$0" > "$FM_RAW_CODEX_PROBE_LOG"
+  printf '%s\n' 'codex-cli 0.149.1'
+fi
+SH
+  chmod +x "$raw_codex"
+
+  out=$(FM_TEST_CODEX_VERSION=0.142.1 FM_RAW_CODEX_PROBE_LOG="$probe_log" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    "$raw_codex __EFFORTFLAG__--raw" --effort max)
+  status=$?
+  expect_code 0 "$status" "raw Codex max should probe the executable named by the launch command"
+  probed_binary=$(cat "$probe_log")
+  [ "$probed_binary" = "$raw_codex" ] \
+    || fail "raw Codex max probe used a different executable: $probed_binary"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "'$raw_codex' -c 'model_reasoning_effort=\"max\"' --raw" \
+    "raw Codex launch did not preserve the probed executable and max effort"
+  pass "raw Codex max probes the executable named by the launch command"
+}
+
 test_old_codex_refuses_max_effort() {
   local rec id out status launch
   id=profile-codex-old-max-z4b
@@ -860,6 +892,7 @@ test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_threads_max_effort
+test_raw_codex_max_probes_the_named_executable
 test_old_codex_refuses_max_effort
 test_unparseable_codex_refuses_max_effort
 test_grok_threads_model_and_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -49,6 +49,15 @@ SH
   chmod +x "$fakebin/timeout" "$fakebin/cursor-agent"
   make_spawn_pi_probe "$fakebin" pi
   make_spawn_pi_probe "$fakebin" pi-signed
+  cat > "$fakebin/codex" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = --version ]; then
+  printf 'codex-cli %s\n' "${FM_FAKE_CODEX_VERSION:-0.149.1}"
+fi
+exit 0
+SH
+  chmod +x "$fakebin/codex"
   printf '%s\n' "$fakebin"
 }
 
@@ -93,6 +102,7 @@ run_spawn() {
   # A test opts in to the set case via FM_TEST_CLAUDE_CONFIG_DIR.
   CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
+    FM_FAKE_CODEX_VERSION="${FM_TEST_CODEX_VERSION:-0.149.1}" \
     FM_FAKE_CURSOR_MODELS="${FM_TEST_CURSOR_MODELS:-}" \
     FM_FAKE_CURSOR_LIST_STATUS="${FM_TEST_CURSOR_LIST_STATUS:-0}" \
     GROK_HOME="$home/grok-home" \
@@ -423,14 +433,35 @@ test_codex_threads_max_effort() {
   rec=$(make_spawn_case profile-codex-max codex "$id")
   read_case_record "$rec"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5.6-sol --effort max)
   status=$?
   expect_code 0 "$status" "codex spawn with max effort should succeed"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5.6-sol' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
     "codex launch did not thread max reasoning effort config"
   pass "codex receives max through model_reasoning_effort"
+}
+
+test_old_codex_omits_max_effort() {
+  local rec id out status launch
+  id=profile-codex-old-max-z4b
+  rec=$(make_spawn_case profile-codex-old-max codex "$id")
+  read_case_record "$rec"
+
+  out=$(FM_TEST_CODEX_VERSION=0.142.1 \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model gpt-5 --effort max)
+  status=$?
+  expect_code 0 "$status" "older Codex spawn with max effort should preserve the compatible launch path"
+  assert_contains "$out" "Codex max effort requires codex-cli 0.149.1 or newer" \
+    "older Codex max omission was silent"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
+    "older Codex launch did not preserve the model flag"
+  assert_not_contains "$launch" "model_reasoning_effort" \
+    "older Codex launch received unsupported max reasoning effort"
+  pass "older Codex omits max with an actionable compatibility warning"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -805,6 +836,7 @@ test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_threads_max_effort
+test_old_codex_omits_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -463,6 +463,7 @@ test_old_codex_refuses_max_effort() {
   expect_code 1 "$status" "older Codex spawn must refuse an explicit unsupported max effort"
   assert_contains "$out" "refusing to launch without the explicitly selected effort" \
     "older Codex max refusal was not actionable"
+  assert_absent "$HOME_DIR/state/$id.meta" "older Codex refusal must happen before metadata publication"
   launch=$(cat "$LAUNCH_LOG")
   [ -z "$launch" ] || fail "older Codex launched after refusing max effort: $launch"
   pass "older Codex refuses to launch without explicit max effort"
@@ -481,6 +482,7 @@ test_unparseable_codex_refuses_max_effort() {
   expect_code 1 "$status" "unparseable Codex version must refuse an explicit max effort"
   assert_contains "$out" "requires codex-cli 0.149.1 or newer with a parseable version" \
     "unparseable Codex max refusal did not identify the compatibility boundary"
+  assert_absent "$HOME_DIR/state/$id.meta" "unparseable Codex refusal must happen before metadata publication"
   launch=$(cat "$LAUNCH_LOG")
   [ -z "$launch" ] || fail "unparseable Codex launched after refusing max effort: $launch"
   pass "unparseable Codex version refuses to launch without explicit max effort"


### PR DESCRIPTION
## Intent

Rebase the existing upstream pull request https://github.com/kunchenguid/firstmate/pull/3176 onto the current kunchenguid/firstmate:main, preserving its accepted version-safe Codex effort=max behavior, and update that exact PR rather than opening a replacement. This is a history-refresh task, not authorization to redesign or broaden the feature: merging is not authorized.

This branch is intentionally checked out at the pipeline's last known-good pushed head (99dd99d61b4b7e2681259effcf92865c1a9d1586) so the pipeline's own rebase step performs and owns the history update onto current main. A prior manual rebase of these same 6 commits onto current main was already done, fully tested, and validated in an isolated worktree; it is preserved read-only for reference (not as a force-push source) on local branch fm/codex-max-effort-support-v1-rebase-backup-38808e1 at commit 38808e1. The pipeline's rebase step must reach an equivalent result to that preserved reference, in particular for the one real conflict: all 6 commits touch .agents/skills/harness-adapters/SKILL.md, which current upstream main split into a router SKILL.md plus a references/ tree (commit c731c36, "docs(skills): split harness adapter operations reference") since this PR was opened. The correct resolution keeps upstream's new split structure as-is and re-applies each commit's documentation intent (the codex effort-flag row content, evolving across the PR's commits) to the relocated references/harness/codex.md file's "Effort flag" row instead of reviving the obsolete monolithic SKILL.md content. Every other file in the PR (bin/fm-bootstrap.sh, bin/fm-spawn.sh, docs/verification/runtime-backends.md, tests/fm-bootstrap.test.sh, tests/fm-codex-continuity-live-e2e.test.sh, tests/fm-spawn-dispatch-profile.test.sh) auto-merges cleanly with no semantic ambiguity.

Preserve exactly: the deterministic version-safe boundary for passing explicit Codex low, medium, high, xhigh, and max reasoning effort (max requires codex-cli 0.149.1 or newer with a parseable version and refuses the spawn rather than silently downgrading an explicit selection on an older or unparseable version); keep ultra out of Firstmate's shared effort vocabulary; preserve omission behavior for other adapters and model routing; the max compatibility probe and worker launch must resolve and use the same concrete Codex executable path; and retain the non-vacuous real-Codex live E2E verification (opt-in via FM_CODEX_LIVE_E2E=1) without reviving obsolete documentation. Do not weaken that live E2E's exact-version pin (codex-cli 0.149.1); the locally installed Codex being a newer 0.150.1 patch that fails that exact-match gate is expected local-environment drift, not a stale upstream floor, and the pin must not be loosened as part of this rebase.

The captain explicitly authorized rebasing the PR, including the necessary history rewrite of its existing FocalFactotum topic branch, but did not authorize merging it. Validate through the existing no-mistakes delivery path bound to this exact PR and its existing remote head branch (fork target FocalFactotum/firstmate, ref fm/codex-max-effort-support-v1); never open a duplicate PR. Never push to a default branch. Never add an agent co-author.

## What Changed

- Accept and pass explicit `max` reasoning effort to Codex while preserving existing low through xhigh behavior.
- Require a parseable Codex CLI version of 0.149.1 or newer for `max`, using the same resolved executable for compatibility probing and launch and refusing unsupported spawns before publishing state.
- Add unit, relaunch, dispatch, documentation, and opt-in live E2E coverage for the version boundary and verified `gpt-5.6-sol max` selection.

## Risk Assessment

✅ Low: The change is well-bounded, preserves the required version-safe Codex max-effort behavior, and performs compatibility refusal before endpoint or metadata publication.

## Testing

Diff and cleanliness checks plus focused spawn, relaunch, and bootstrap tests passed; CLI evidence captured the version-safe max boundary, metadata behavior, and expected real-Codex exact-pin refusal. No visual artifact was appropriate because this is a CLI/runtime change.

<details>
<summary>Evidence: Codex max spawn behavior</summary>

```text
ok - no --model/--effort records defaults and types the claude launch instructions
ok - non-cursor launches clear inherited Cursor identity markers
ok - relative home overrides ignore CDPATH and become absolute before spawn launch construction
ok - FM_HOME defaults resolve relative paths and preserve absolute spellings
ok - absolute override spellings are preserved in spawn launch paths
ok - unresolvable relative spawn overrides fail with named diagnostics
ok - active crew-dispatch profile requires an explicit harness for ship spawns
ok - active crew-dispatch profile requires an explicit harness for scout spawns
ok - active crew-dispatch profile allows an explicit resolved harness
ok - active crew-dispatch profile allows the legacy positional harness form
ok - active crew-dispatch profile allows the raw launch-command escape hatch
ok - claude receives --model and --effort profile flags
ok - codex receives --model and model_reasoning_effort profile flags
ok - codex max probes and launches the same concrete executable
ok - older Codex refuses to launch without explicit max effort
ok - unparseable Codex version refuses to launch without explicit max effort
ok - grok receives --model and --reasoning-effort profile flags
ok - grok omits unsupported max reasoning effort
ok - grok omits unsupported xhigh reasoning effort
ok - cursor receives its model-qualified reasoning class and exact task workspace
ok - cursor refuses model ids absent from its resolved binary's live catalog
ok - cursor preserves the requested model when its live catalog is unreachable
ok - opencode receives --model and omits the unsupported effort axis
ok - pi receives --model and --thinking max profile flags
ok - Pi launch probing omits --tui-mode on older Pi and preserves it on supporting Pi
ok - pi-signed shares Pi launch semantics while preserving its configured and recorded identity
ok - pi-signed refuses safely and actionably when the selected executable is unavailable
ok - pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics
ok - batch dispatch forwards shared --harness, --model, and --effort to every pair
ok - claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store
ok - claude omits the config-dir prefix when firstmate runs with the single-store default
ok - non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix
ok - active crew-dispatch profile does not block secondmate launches
# all fm-spawn-dispatch-profile tests passed
```
</details>
<details>
<summary>Evidence: Codex max relaunch behavior</summary>

```text
ok - fm-control relaunch: a same-harness relaunch replaces the agent in the same endpoint and worktree
ok - fm-control relaunch: durable task metadata survives replacement launch publication
ok - fm-control relaunch: trace and concurrent task metadata publications serialize
ok - fm-control relaunch: disabling tracing clears metadata and pane context
ok - fm-control relaunch: the progress note lands in the instructions the replacement reads
ok - fm-control relaunch: a ship task refuses without the progress note its replacement needs
ok - fm-control relaunch: switching harness is one ordinary relaunch, and the old wiring goes with the old agent
ok - fm-control relaunch: a harness switch resets model and effort unless they are named too
ok - fm-control relaunch: a prefixed recorded harness can switch adapters transactionally
ok - fm-control relaunch: a prefixed command requires an explicit replacement harness
ok - fm-control relaunch: a same-harness relaunch keeps the profile axes it was running with
ok - fm-control relaunch: explicit model and effort win over the recorded ones
ok - fm-control relaunch: refuses to relaunch onto an adapter with no verified mechanics
ok - fm-control relaunch: the retired incarnation's global turn-end token is revoked
ok - fm-control relaunch: wiring cleanup failure refuses replacement arming
ok - fm-control-lib: one owner resolves each harness's turn-end registry entry, and refuses a malformed token
ok - fm-control relaunch: a secondmate relaunch re-resolves its durable configured harness pin
ok - fm-control relaunch: invalid configured effort is ignored before stop
ok - fm-control relaunch: an adapter unverified for this task kind refuses before the agent is stopped
ok - fm-control relaunch: explicit secondmate harness resets unnamed profile axes
ok - fm-control relaunch: a ship task keeps its recorded harness instead of re-reading crew config
ok - fm-spawn --relaunch: with no explicit harness it reuses the task's recorded one, never the crew default
ok - fm-spawn --relaunch: wiring armed under a prefixed harness name is still retired
ok - fm-spawn --relaunch: switching away from muse retires its session binding
ok - fm-spawn --relaunch: switching away from cursor retires its session binding
ok - fm-control relaunch: an unaccountable local copy refuses before the agent is touched
ok - fm-control relaunch: a worker with nothing to work from is never launched
ok - fm-control relaunch: a refusal before the agent is stopped leaves the durable record untouched
ok - fm-control relaunch: checkpoint inspection failures refuse before stopping
ok - fm-control relaunch: a launch failure after the stop keeps the prior record and reports the real state
ok - fm-control relaunch: unpublished rollback keeps concurrent durable metadata
ok - fm-control relaunch: post-publication failure keeps the new durable record
ok - fm-control relaunch: partial stop reconciles actual agent state
ok - fm-control relaunch: failed journal replacement preserves durable phase
ok - fm-spawn relaunch: prepublication abort removes replacement state
ok - fm-control relaunch: the checkpoint records the exact unlanded work it preserved
ok - fm-control relaunch: a secondmate's child work is accounted for and its charter is left alone
ok - fm-control relaunch: a secondmate home that is not this secondmate's is refused
ok - fm-control relaunch: unreadable and untraversable child state fails checkpoint
ok - fm-control relaunch: two control actions on one task serialize instead of interleaving
ok - fm-spawn relaunch: direct entry participates in lifecycle serialization
ok - fm-promote: promotion participates in lifecycle serialization
ok - fm-spawn --relaunch: refuses to launch a second agent into a live endpoint
ok - fm-spawn --relaunch: every identity axis comes from the record, and a contradicting flag refuses
ok - fm-spawn --relaunch: an unrecorded task is refused
ok - fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work
ok - fm-spawn --relaunch: unsupported Codex max preserves prior metadata
```
</details>
<details>
<summary>Evidence: Crew-dispatch bootstrap validation</summary>

```text
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap reports treehouse lease + tasks-axi/quota-axi bootstrap contracts
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap enforces no-mistakes minimum version
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap enforces gh-axi minimum version
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap enforces lavish-axi minimum version
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap enforces tasks-axi minimum version
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap enforces quota-axi minimum version
ok - bootstrap requires git with an install instruction
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: backend=orca gates the Orca CLI without requiring it on the default backend
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: session-provider backends require their own CLI + jq + treehouse, never tmux
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: a session-provider backend gates its own CLI, never a false tmux requirement
ok - bootstrap: Herdr manual-install guidance is never executed as a shell command
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: the bundled cmux CLI satisfies the active backend dependency
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: unknown resolved backends fail closed with an actionable diagnostic
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: JSON-emitting backends require jq (their genuine dep), never tmux
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: the treehouse lease check follows the resolved backend's worktree provider
ok - bootstrap computes a fleet-size-aware default timeout and preserves partial fleet-sync output
ok - bootstrap keeps the quick 20s default for small fleets
ok - bootstrap preserves FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT as an explicit override
ok - bootstrap treats a blank timeout override as unset
ok - bootstrap computes the timeout before launching fleet sync
ok - bootstrap keeps routine tasks-axi, harness, dispatch, and already-live liveness confirmations silent
ok - bootstrap routine contract runs under system /bin/bash
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: FM_BOOTSTRAP_NETWORK partitions one run into local and network halves
ok - bootstrap: every deferred mutating sweep rechecks fleet-lock ownership
ok - bootstrap: each deferred network phase, secondmate, and clone records its own elapsed time
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: the tasks-axi compatibility verdict travels exactly one process hop
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap surfaces active crew-dispatch rules only as verbose BOOTSTRAP_INFO
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap validates crew-dispatch.json and reports malformed or unverified configs
```
</details>
<details>
<summary>Evidence: Exact live Codex version gate</summary>

`not ok - unverified Codex version: codex-cli 0.150.1 (expected codex-cli 0.149.1)`

```text
not ok - unverified Codex version: codex-cli 0.150.1 (expected codex-cli 0.149.1)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ed183227f81ca8d14bf0431362dfd2d5d8948a5a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `.agents/skills/harness-adapters/SKILL.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-spawn.sh:2828` - The Codex max compatibility check runs after endpoint creation, harness wiring, and `state/$ID.meta` publication. With Codex 0.142.1 or an unparseable version, the script records a new codex/max incarnation and then exits, while the cleanup trap removes neither the published metadata nor an ordinary backend endpoint. A fresh spawn therefore leaves a ghost task; a relaunch causes `fm-control` to preserve the new transaction record even though no replacement agent launched. Resolve the concrete binary and validate max support before endpoint creation or metadata publication, then reuse that path for launch. The refusal tests should also assert that fresh metadata is absent and relaunch metadata remains accurate.

🔧 Fix: Preflight Codex max before publishing spawn state
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff c7fdef92098e3b841921cb0c1a920c6cc43abc83..ed183227f81ca8d14bf0431362dfd2d5d8948a5a` and `git status --short`.</code>
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-control-relaunch.test.sh`
- `bash tests/fm-bootstrap.test.sh`
- <code>`FM_CODEX_LIVE_E2E=1 bash tests/fm-codex-continuity-live-e2e.test.sh` - exercised the real installed harness and received the expected exact-version refusal for codex-cli 0.150.1.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
