### PR TITLE
fix(spawn): support originless local-only bases

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -134,10 +134,13 @@
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
-#   Before a fresh ship or scout worker starts, its clean task worktree fetches
-#   origin, resolves the current remote default branch, and resets to its tip.
-#   An unreachable origin, unresolved default branch, or non-clean worktree
-#   refuses the spawn rather than risking a PR based on stale history.
+#   Before a fresh ship or scout worker starts, its clean task worktree uses the
+#   fetched tip of origin's resolved default branch when origin exists. An
+#   originless scout or local-only ship instead uses the local main or master
+#   branch without creating a remote. An originless no-mistakes or direct-PR ship
+#   is refused because it cannot safely publish. An unreachable origin,
+#   unresolved default branch, or non-clean worktree refuses the spawn rather
+#   than risking work from an unverifiable base.
 #   A slot whose only deviation is a stale submodule gitlink is refused by that
 #   same clean check, but is reported as a stale checkout naming each submodule
 #   and both pins; nothing is converged or removed, and no remedy is suggested.
@@ -1792,8 +1795,63 @@ EOF
   printf '%s' "$lines" >&2
 }
 
-freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual status
+freshen_spawn_worktree_local_base() {  # <worktree>
+  local worktree=$1 default target expected actual status branch
+  default=
+  for branch in main master; do
+    if git -C "$worktree" show-ref --verify --quiet "refs/heads/$branch"; then
+      default=$branch
+      break
+    fi
+  done
+  if [ -z "$default" ]; then
+    echo "error: could not determine local main or master branch for originless pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    return 1
+  fi
+  target="refs/heads/$default"
+  expected=$(git -C "$worktree" rev-parse --verify --quiet "$target^{commit}" 2>/dev/null) || {
+    echo "error: local base '$default' is not a commit for originless pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    return 1
+  }
+  status=$(git -C "$worktree" -c core.quotePath=false status --porcelain) || {
+    echo "error: could not inspect originless pooled worktree '$worktree' before refreshing its base" >&2
+    return 1
+  }
+  if [ -n "$status" ]; then
+    if describe_stale_submodule_pins "$worktree" "$status"; then
+      echo "error: pooled worktree '$worktree' has a stale submodule checkout, not uncommitted work; refusing to launch and leaving it untouched" >&2
+    else
+      echo "error: pooled worktree '$worktree' is not clean; refusing to discard uncommitted work while refreshing its local base" >&2
+    fi
+    return 1
+  fi
+  if ! git -C "$worktree" reset --hard "$target" >/dev/null; then
+    echo "error: could not reset originless pooled worktree '$worktree' to '$default'; refusing to launch from a potentially stale base" >&2
+    return 1
+  fi
+  actual=$(git -C "$worktree" rev-parse --verify --quiet HEAD 2>/dev/null || true)
+  if [ "$actual" != "$expected" ]; then
+    echo "error: originless pooled worktree '$worktree' is at '${actual:-unknown}', not current '$default' ('$expected'); refusing to launch" >&2
+    return 1
+  fi
+}
+
+freshen_spawn_worktree_base() {  # <worktree> <kind> <mode>
+  local worktree=$1 kind=$2 mode=$3 origin_remotes
+  if ! origin_remotes=$(git -C "$worktree" remote); then
+    echo "error: could not inspect remotes for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    return 1
+  fi
+  if ! printf '%s\n' "$origin_remotes" | grep -Fxq origin; then
+    if [ "$kind" = scout ] || { [ "$kind" = ship ] && [ "$mode" = local-only ]; }; then
+      freshen_spawn_worktree_local_base "$worktree"
+      return $?
+    fi
+    echo "error: pooled worktree '$worktree' has no origin; refusing to launch an originless $mode ship because only local-only ships and scouts may use a local base" >&2
+    return 1
+  fi
+
+  local default target expected actual status
   if ! git -C "$worktree" fetch --quiet origin; then
     echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
@@ -2330,7 +2388,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   validate_spawn_worktree "treehouse get" "$T"
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
-  freshen_spawn_worktree_base "$WT" || exit 1
+  freshen_spawn_worktree_base "$WT" "$KIND" "$MODE" || exit 1
 fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -179,8 +179,9 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
-`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
-Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
+`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: an origin-backed task worktree matches the fetched tip of origin's resolved default branch, while an originless scout or local-only ship matches the local `main` or `master` branch without creating a remote.
+An originless no-mistakes or direct-PR ship remains refused, and any unsafe or unverifiable base stops the spawn.
+Its header owns the exact policy and refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -5,7 +5,9 @@
 # advanced after the worktree was allocated.
 # These tests drive the real spawn path with a fake terminal, then prove it
 # starts the worker from the fetched origin/main tip or stops when origin is
-# unreachable.
+# unreachable. Originless cases prove a scout or local-only ship instead
+# starts from the local main or master tip without adding a remote, and that
+# an originless no-mistakes or direct-PR ship is still refused.
 set -u
 
 # shellcheck source=tests/lib.sh

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -67,6 +67,33 @@ make_case() {
   printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
 }
 
+make_originless_case() {
+  local name=$1 id=$2 default=${3:-main} case_dir home project pool fakebin initial
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  pool="$case_dir/pool"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b "$default" "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+
+  printf 'must survive an originless local-base refresh\n' > "$project/advanced-local-base.txt"
+  git -C "$project" add advanced-local-base.txt
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-local-base
+
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
+}
+
 read_case_record() {
   IFS='|' read -r CASE_DIR HOME_DIR PROJECT_DIR POOL_DIR FAKEBIN_DIR INITIAL_SHA DEFAULT_BRANCH <<EOF
 $1
@@ -450,6 +477,135 @@ test_stale_pin_beside_other_dirt_reports_one_verdict() {
   pass "a stale pin beside other dirt yields the conservative refusal alone, with no stale-pin line"
 }
 
+test_originless_local_bases_for_scout_and_local_ship() {
+  local rec id out status current remote_before remote_after
+
+  id='originless-scout-local-base-r12'
+  rec=$(make_originless_case originless-scout "$id" main)
+  read_case_record "$rec"
+  remote_before=$(git -C "$PROJECT_DIR" remote -v)
+  out=$(run_spawn "$id" --scout)
+  status=$?
+  expect_code 0 "$status" "originless scout should launch from the local default branch"
+  assert_contains "$out" "spawned $id" "originless scout did not report success"
+  current=$(git -C "$PROJECT_DIR" rev-parse main)
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$current" ] \
+    || fail "originless scout did not refresh to the local main branch"
+  assert_grep 'must survive an originless local-base refresh' "$POOL_DIR/advanced-local-base.txt" \
+    "originless scout omitted the local main branch content"
+  [ -z "$(git -C "$POOL_DIR" status --porcelain)" ] \
+    || fail "originless scout left the pooled worktree dirty"
+  remote_after=$(git -C "$PROJECT_DIR" remote -v)
+  [ "$remote_after" = "$remote_before" ] \
+    || fail "originless scout changed the project's remote configuration"
+  [ -z "$(git -C "$POOL_DIR" remote -v)" ] \
+    || fail "originless scout added a remote to the pooled worktree"
+  assert_present "$HOME_DIR/state/$id.meta" "originless scout did not publish task metadata"
+  assert_grep 'kind=scout' "$HOME_DIR/state/$id.meta" "originless scout metadata has the wrong kind"
+
+  id='originless-local-ship-local-base-r12'
+  rec=$(make_originless_case originless-local-ship "$id" master)
+  read_case_record "$rec"
+  printf 'Delivery contract: mode=local-only\nbrief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"
+  remote_before=$(git -C "$PROJECT_DIR" remote -v)
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  expect_code 0 "$status" "originless local-only ship should launch from the local default branch"
+  assert_contains "$out" "spawned $id" "originless local-only ship did not report success"
+  current=$(git -C "$PROJECT_DIR" rev-parse master)
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$current" ] \
+    || fail "originless local-only ship did not refresh to the local master branch"
+  assert_grep 'must survive an originless local-base refresh' "$POOL_DIR/advanced-local-base.txt" \
+    "originless local-only ship omitted the local master branch content"
+  [ -z "$(git -C "$POOL_DIR" status --porcelain)" ] \
+    || fail "originless local-only ship left the pooled worktree dirty"
+  remote_after=$(git -C "$PROJECT_DIR" remote -v)
+  [ "$remote_after" = "$remote_before" ] \
+    || fail "originless local-only ship changed the project's remote configuration"
+  [ -z "$(git -C "$POOL_DIR" remote -v)" ] \
+    || fail "originless local-only ship added a remote to the pooled worktree"
+  assert_present "$HOME_DIR/state/$id.meta" "originless local-only ship did not publish task metadata"
+  assert_grep 'kind=ship' "$HOME_DIR/state/$id.meta" "originless local-only ship metadata has the wrong kind"
+  assert_grep 'mode=local-only' "$HOME_DIR/state/$id.meta" "originless local-only ship metadata has the wrong mode"
+  pass "originless scouts and local-only ships refresh clean pooled worktrees from local main or master without adding a remote"
+}
+
+test_originless_publish_modes_refuse_without_origin() {
+  local rec id out status before mode
+  for mode in no-mistakes direct-PR; do
+    id="originless-$mode-refusal-r13"
+    rec=$(make_originless_case "originless-$mode-refusal" "$id")
+    read_case_record "$rec"
+    before=$(git -C "$POOL_DIR" rev-parse HEAD)
+    out=$(run_spawn "$id" --mode "$mode" --yolo off)
+    status=$?
+    [ "$status" -ne 0 ] || fail "originless $mode ship launched without an origin"
+    assert_contains "$out" "has no origin" "originless $mode ship did not explain the missing origin refusal"
+    assert_contains "$out" "refusing to launch" "originless $mode ship did not refuse launch"
+    [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+      || fail "originless $mode refusal moved the pooled worktree"
+    [ -z "$(git -C "$PROJECT_DIR" remote -v)" ] \
+      || fail "originless $mode refusal changed the project's remote configuration"
+    [ -z "$(git -C "$POOL_DIR" remote -v)" ] \
+      || fail "originless $mode refusal added a remote to the pooled worktree"
+    assert_absent "$HOME_DIR/state/$id.meta" "originless $mode refusal published task metadata"
+  done
+  pass "originless no-mistakes and direct-PR ships remain refused without a remote"
+}
+
+test_originless_allowed_modes_refuse_dirty_pool() {
+  local rec id out status before contract
+  for contract in scout local-only; do
+    id="originless-dirty-$contract-r14"
+    rec=$(make_originless_case "originless-dirty-$contract" "$id")
+    read_case_record "$rec"
+    if [ "$contract" = local-only ]; then
+      printf 'Delivery contract: mode=local-only\nbrief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"
+    fi
+    before=$(git -C "$POOL_DIR" rev-parse HEAD)
+    printf 'keep this originless local work\n' > "$POOL_DIR/uncommitted.txt"
+    if [ "$contract" = scout ]; then
+      out=$(run_spawn "$id" --scout)
+    else
+      out=$(run_spawn "$id" --mode local-only --yolo off)
+    fi
+    status=$?
+    [ "$status" -ne 0 ] || fail "originless $contract launched despite a dirty pooled worktree"
+    assert_contains "$out" "is not clean" "originless $contract did not refuse a dirty pooled worktree"
+    [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+      || fail "originless $contract refusal moved the pooled worktree"
+    assert_grep 'keep this originless local work' "$POOL_DIR/uncommitted.txt" \
+      "originless $contract refusal discarded local work"
+    assert_absent "$HOME_DIR/state/$id.meta" "originless $contract refusal published task metadata"
+  done
+  pass "originless scouts and local-only ships refuse dirty pooled worktrees without discarding local work"
+}
+
+test_originless_missing_local_default_refuses() {
+  local rec id out status before
+  id='originless-missing-default-r15'
+  rec=$(make_originless_case missing-local-default "$id" feature)
+  read_case_record "$rec"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  out=$(run_spawn "$id" --scout)
+  status=$?
+  [ "$status" -ne 0 ] || fail "originless scout launched without a local main or master branch"
+  assert_contains "$out" "could not determine local main or master branch" \
+    "originless scout did not refuse an unsafe missing local default"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "missing local default refusal moved the pooled worktree"
+  [ -z "$(git -C "$PROJECT_DIR" remote -v)" ] \
+    || fail "missing local default refusal changed the project's remote configuration"
+  [ -z "$(git -C "$POOL_DIR" remote -v)" ] \
+    || fail "missing local default refusal added a remote to the pooled worktree"
+  assert_absent "$HOME_DIR/state/$id.meta" "missing local default refusal published task metadata"
+  pass "an originless spawn refuses when no local main or master branch can be proven"
+}
+
+test_originless_local_bases_for_scout_and_local_ship
+test_originless_publish_modes_refuse_without_origin
+test_originless_allowed_modes_refuse_dirty_pool
+test_originless_missing_local_default_refuses
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch


### PR DESCRIPTION
## Intent

Implement the narrowly scoped Firstmate fix from data/firstmate-originless-repro/report.md so clean originless local-only projects can launch scouts and local-only ship tasks without inventing a remote. Preserve origin-backed refresh behavior, including remote default-branch discovery, cleanliness checks, reset, and final commit verification. Add an originless local-base path using local main or master for fresh scouts and local-only ships, while continuing to refuse originless no-mistakes and direct-PR ships. Do not create, infer, or add a remote. Add executable-interface regression coverage to tests/fm-spawn-pool-base-freshen.test.sh for originless scouts and local-only ships, including successful preparation, local base selection, unchanged remotes, and refusal from dirty or unsafe state. Update the authoritative spawn header and docs/architecture.md without duplicating policy. Keep shell scripts shellcheck-clean, run the documented lint and relevant tests, and do not open an upstream issue. Include the implementation rationale and any unresolved uncertainty in the PR description.

## What Changed

- `freshen_spawn_worktree_base` in `bin/fm-spawn.sh` now checks the pooled worktree's remotes first. When `origin` exists, it keeps the prior fetch, `remote set-head`, default-branch resolution, cleanliness check, hard reset, and final commit verification unchanged.
- When `origin` is absent, a new `freshen_spawn_worktree_local_base` path handles scouts and `local-only` ships: it resolves the local `main` or `master` branch, runs the same cleanliness check (including stale-submodule-pin diagnosis) and hard reset/verification against that local ref, and never fetches or creates a remote. Originless `no-mistakes` and `direct-PR` ships are still refused with an explicit "has no origin" error, and a missing local `main`/`master` also refuses.
- Updated the `fm-spawn.sh` header comment and `docs/architecture.md` to document the two base policies (origin-backed vs. originless local-base) without duplicating the mechanics, which stay owned by the header.
- Added regression coverage to `tests/fm-spawn-pool-base-freshen.test.sh`: successful originless scout/local-only-ship launches from the local default branch with the remote configuration unchanged, refusal of originless `no-mistakes`/`direct-PR` ships, refusal of a dirty originless pooled worktree, and refusal when no local `main`/`master` can be resolved.
</body>

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves the origin-backed refresh path byte-for-byte, adds a correctly-gated originless local-base path (scout or local-only ship only, exhaustively covering the three possible KIND values) with no remote creation, and is backed by executable-interface tests that exercise success, local-base selection, unchanged remotes, and refusal from dirty/missing-default/no-origin-disallowed-mode states.

## Testing

The targeted regression suite for this change (tests/fm-spawn-pool-base-freshen.test.sh) drives the real fm-spawn.sh executable through a fake-terminal harness and passes 15/15 on the target commit, covering originless scout/local-only-ship success from local main/master, refusal of originless no-mistakes/direct-PR ships, refusal of dirty originless worktrees, refusal when no local main/master exists, and unchanged origin-backed refresh/refusal behavior; a pre-fix check with the base commit's fm-spawn.sh confirmed the new originless-scout case fails without the fix, validating it as a genuine regression test. No issues found; worktree left clean with no transient artifacts.

<details>
<summary>Evidence: Full run of tests/fm-spawn-pool-base-freshen.test.sh against target commit 974da38</summary>

```text
ok - originless scouts and local-only ships refresh clean pooled worktrees from local main or master without adding a remote
ok - originless no-mistakes and direct-PR ships remain refused without a remote
ok - originless scouts and local-only ships refuse dirty pooled worktrees without discarding local work
ok - an originless spawn refuses when no local main or master branch can be proven
ok - a stale pooled worktree refreshes to current origin/main before a crew branch is created
ok - a stale pooled worktree resolves and refreshes a non-main default branch
ok - direct-PR ships and scouts both refresh stale pooled worktrees before launch
ok - a dirty pooled worktree is refused without discarding its local work
ok - an unresolved remote default branch refuses the pooled worktree
ok - an unreachable origin refuses a potentially stale pooled worktree
ok - two consecutive spawns across a moved submodule pin end in a refusal naming both pins and no remedy
ok - an unpushed submodule commit keeps the uncommitted-work refusal and survives it
ok - work inside a submodule is still refused as uncommitted work, not called stale
ok - a stale pin carrying real work is refused conservatively, never called stale
ok - a stale pin beside other dirt yields the conservative refusal alone, with no stale-pin line
# all fm-spawn-pool-base-freshen tests passed
```
</details>
<details>
<summary>Evidence: Pre-fix regression check: same test file against base commit&#39;s fm-spawn.sh</summary>

```text
not ok - originless scout should launch from the local default branch: expected exit 0, got 1
(test run aborted at first failure, confirming the new originless-local-base coverage genuinely exercises behavior introduced by the fix, not a vacuous test)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"974da38855d2576e7a9fde096dbbb9f82321bccd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `bin/fm-spawn.sh:1811` - freshen_spawn_worktree_local_base (bin/fm-spawn.sh:1811-1836) duplicates the clean-check/reset/verify sequence (resolve target commit, check status with stale-submodule diagnosis, reset --hard, verify actual==expected) that already exists in freshen_spawn_worktree_base&#39;s origin-backed branch (bin/fm-spawn.sh:1872-1896). The two blocks are structurally identical apart from the target ref and message wording. This is a legitimate dedup opportunity (e.g. a shared `freshen_spawn_worktree_to_ref &lt;worktree&gt; &lt;target&gt; &lt;label&gt;` helper) that would reduce the chance a future fix to this sequence is applied to only one copy.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-spawn-pool-base-freshen.test.sh (target commit 974da38, real fm-spawn.sh executable interface, fake terminal/pool harness) - 15/15 passed`
- <code>Regression check: same test file run against base commit&#39;s bin/fm-spawn.sh (7ee0c19) with target fm-spawn.sh temporarily swapped in-place - new originless-scout test fails as expected (&#39;expected exit 0, got 1&#39;), proving the new coverage genuinely exercises the introduced behavior rather than being vacuous; original file restored afterward and worktree verified clean via `git status --porcelain`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
