### PR TITLE
docs(skills): compress skill descriptions down to their load triggers

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: afk
 description: >-
-  Enter away-mode supervision when the captain invokes /afk, says they are going afk, `state/.afk` exists, an incoming message starts with `FM_INJECT_MARK`, or any `state/.subsuper-*` marker is involved.
-  It sets a durable away-mode flag so the sub-supervisor daemon can self-handle routine wakes and escalate captain-relevant events plus bounded declared-external-wait rechecks as batched digests during walk-away stretches, then exits automatically when any real unmarked message returns firstmate to full per-wake responsiveness.
+  Enter away-mode supervision. Load when the captain invokes /afk or says they are going afk, when
+  state/.afk exists, when an incoming message starts with FM_INJECT_MARK, or when any
+  state/.subsuper-* marker is involved. It owns the away daemon and the automatic exit when a real
+  unmarked message returns.
 user-invocable: true
 metadata:
   internal: true

--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: ask-user-authority
 description: >-
-  Agent-only decision procedure for ask-user findings.
-  Use before deciding any ask-user finding.
-  This skill is the single owner of finding-decision policy: firstmate always applies judgment, decides findings that are unambiguous toward accepted intent, and escalates only genuinely ambiguous, expanding, or destructive ones.
-  Finding authority is this skill's criteria, not the project's yolo posture.
+  Agent-only decision procedure for ask-user findings, and the single owner of finding-decision
+  policy. Load before deciding any ask-user finding; its criteria, not the project's yolo posture,
+  set finding authority.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: bearings
 description: >-
-  Generate a "pick up where I left off" fleet digest from firstmate's live fleet state.
-  Use when the captain invokes /bearings or asks for a bearings report, morning brief, status report, catch-up, "where did I leave off", or "what's in the works".
-  Plain /bearings is chat-only by default, /bearings file explicitly writes the dated data/status-report-<YYYY-MM-DD>.md artifact, and /bearings lavish additionally builds and arms the interactive fleet board; live PR enrichment remains opt-in and composes with the other modes.
-  Also load this skill's board-wake handling when a procevent lavish wake's source id matches the canonical source id of the stable bearings board path.
+  Fleet digest so the captain can resume in one read. Load when the captain invokes /bearings or
+  asks for a status report, morning brief, catch-up, bearings, "where did I leave off", or "what's
+  in the works"; the file and lavish modes add the dated report and the interactive board. Also
+  load its board-wake handling when a procevent lavish wake matches the bearings board's source
+  id.
 user-invocable: true
 metadata:
   internal: true

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: bootstrap-diagnostics
 description: >-
-  Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
-  A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
+  Agent-only handling playbook for session-start bootstrap diagnostics. Load whenever the digest's
+  bootstrap or NETWORK CHECKS section, or a standalone bin/fm-bootstrap.sh or
+  bin/fm-startup-network.sh run, prints an actionable diagnostic line such as MISSING:, TANGLE:,
+  NEEDS_GH_AUTH, FLEET_SYNC:, NETWORK_CHECKS:, PR_CHECK_MIGRATION:, or any SECONDMATE_ line.
+  Silence or a BOOTSTRAP_INFO: fact needs no load.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/captain-hold-lifecycle/SKILL.md
+++ b/.agents/skills/captain-hold-lifecycle/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: captain-hold-lifecycle
 description: >-
-  Agent-only policy for completing investigations and visual reviews without losing unresolved captain calls, and for closing what the captain owns with his actual words.
-  Load before treating an investigation, scout report, structured review, or Lavish review as complete, before ending a visual review that exposed a captain decision, when recording or routing the captain's answer, and on any RECORD DIVERGENCE line the wake drain prints.
+  Agent-only policy for closing captain calls in the captain's own words. Load before treating an
+  investigation, scout report, structured review, or Lavish review as complete, before ending a
+  visual review that exposed a captain decision, when recording or routing the captain's answer,
+  and on any RECORD DIVERGENCE line from the wake drain.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: decision-hold-lifecycle
 description: >-
-  Renamed pointer kept for in-flight briefs: the decisions concept collapsed into "a task held for the captain".
-  Load captain-hold-lifecycle instead; this stub only redirects and will be removed one release after the collapse.
+  Deprecated pointer: load captain-hold-lifecycle instead. Kept only for in-flight briefs that
+  still name this skill, and removed one release after the collapse.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/diagnostic-reasoning/SKILL.md
+++ b/.agents/skills/diagnostic-reasoning/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: diagnostic-reasoning
 description: >-
-  Agent-only procedure for diagnosing reported bugs.
-  Use before scoping a reported bug and before acting on a diagnostic report.
-  Owns end-user-aligned reproduction, causal separation, divergent-path and history inspection, counterfactual testing, and disconfirming evidence.
+  Agent-only procedure for diagnosing reported bugs. Load before scoping a reported bug and before
+  acting on a diagnostic report.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/firstmate-codexapp/SKILL.md
+++ b/.agents/skills/firstmate-codexapp/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: firstmate-codexapp
 description: >-
-  Agent-only playbook for coordinating visible Codex Desktop threads alongside Firstmate without pretending they are a selectable shell backend.
-  Use before creating, reading, steering, archiving, debugging, or reviewing a Codex App visible thread for Firstmate work, and before responding to requests to make Codex App native to Firstmate.
+  Agent-only playbook for visible Codex Desktop threads alongside Firstmate. Load before creating,
+  reading, steering, archiving, debugging, or reviewing a Codex App thread for Firstmate work, and
+  before answering a request to make Codex App a native Firstmate backend.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: firstmate-coding-guidelines
 description: >-
-  Agent-only reference for changing firstmate's shared, tracked material per AGENTS.md section 1.
-  Use before editing any of that material, whether working as firstmate directly or as a crewmate briefed on a firstmate-repo task.
-  Covers the knowledge-placement decision tree, the one-owner rule for contracts, the inline-stub pattern for content moved into a skill, AGENTS.md size discipline, trigger hygiene for new skills, and repo style rules (one sentence per line, plain dash, no agent co-author, shellcheck-clean bin scripts, colocated tests, and maintainer-verification evidence).
+  Agent-only reference for changing firstmate's own shared, tracked material as defined by
+  AGENTS.md section 1. Load before editing any of it, whether working as firstmate directly or as
+  a crewmate briefed on a firstmate-repo task.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -72,6 +72,8 @@ Briefs for tasks that touch firstmate's own tracked material should tell the cre
 `bin/fm-brief.sh`'s `REPO` argument is a caller-supplied string with no reliable signal that it names firstmate's own repo, unlike a project registered in `data/projects.md`, so there is no clean point inside the scaffold to detect this case automatically.
 Firstmate adds this skill's load instruction to firstmate-repo briefs by hand instead.
 `CONTRIBUTING.md`'s "Development" section carries the same instruction as a durable reminder.
+A SKILL.md front-matter description states only its load trigger, while the body owns the operating contract.
+The combined name+description listing every session carries must stay within the per-session budget past which entries truncate - re-measure it when adding a skill.
 
 ## Compatibility and enforcement
 

--- a/.agents/skills/firstmate-orca/SKILL.md
+++ b/.agents/skills/firstmate-orca/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: firstmate-orca
-description: Agent-only operator checklist for Firstmate's Orca runtime backend. Use when switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
+description: >-
+  Agent-only operator checklist for Firstmate's Orca runtime backend. Load when switching to Orca,
+  spawning or supervising Orca-backed work, smoke-testing Orca behavior, debugging Orca task
+  state, or reconciling Orca-backed task metadata.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/fmx-respond/SKILL.md
+++ b/.agents/skills/fmx-respond/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: fmx-respond
 description: >-
-  Agent-only playbook for handling Relay mentions and follow-ups.
-  Use on an "x-mention <request_id>" check wake to read the stashed mention, classify it, act autonomously on eligible requests, reply or dismiss, and link spawned work.
-  Also use on an "x-mode-error ..." check wake to report the Relay configuration blocker instead of answering a mention.
-  Also use on milestone and terminal wakes for a Relay-linked task before posting completion follow-ups, using typed promised-final reconciliation when registered and --final otherwise.
-  Also use on a "public-followup ..." check wake, and whenever a promised final public reply must be created, reconciled, or delivered.
-  Loaded only when Relay is enabled.
+  Agent-only playbook for Relay mentions and public follow-ups. Load on an `x-mention
+  <request_id>`, `x-mode-error ...`, or `public-followup ...` check wake, on any milestone or
+  terminal wake for a Relay-linked task before its completion follow-up, and whenever a promised
+  final public reply must be created, reconciled, or delivered. Relay-only.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: harness-adapters
 description: >-
-  Agent-only reference for firstmate harness operations.
-  Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
-  Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, and muse.
+  Agent-only reference of verified per-harness facts (claude, codex, opencode, pi, pi-signed,
+  grok, kimi, cursor, muse). Load before spawning or recovering a crewmate or secondmate, handling
+  a trust dialog, sending a harness-specific skill invocation, interrupting, exiting or resuming
+  an agent, or verifying a new adapter.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/process-event-sources/SKILL.md
+++ b/.agents/skills/process-event-sources/SKILL.md
@@ -1,15 +1,9 @@
 ---
 name: process-event-sources
 description: >-
-  Agent-only procedure for registered process-to-event sources and their wakes.
-  Use before arming a long-polling source firstmate owns, before registering a
-  deterministic condition->action watch, and on any
+  Agent-only procedure for registered process-to-event sources. Load before arming a long-polling
+  source firstmate owns, before registering a deterministic condition->action watch, and on any
   `procevent <adapter> <source-id> <sequence>` check wake.
-  Owns the arming commands, the condition->action eligibility boundary, the
-  durable result read, which wakes must be routed to their adapter instead of
-  acknowledged generically, the handled acknowledgement contract, the one-owner
-  rule, the precise durability boundary, and the Lavish adapter's loss
-  limitation.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: project-management
 description: >-
-  Agent-only procedure for Firstmate project management.
-  Use before adding, creating, removing, or initializing a project.
-  Cloning or registering a project is add intake and uses the same trigger.
-  Owns project add, create, clone, remove, initialization, registry, delivery-mode, autonomy, and outward-consent decisions.
+  Agent-only procedure for Firstmate project management. Load before adding, creating, removing,
+  or initializing a project; cloning or registering one is add intake and uses the same trigger.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: quota-array-dispatch
 description: >-
-  Agent-only decision procedure for resolving a matched crew-dispatch profile
-  array from quota-axi's default TOON, ranking by spendPriority after three
-  orthogonal gates.
-  Load when a dispatch rule or default resolves to more than one profile candidate.
+  Agent-only decision procedure for resolving a matched crew-dispatch profile array. Load when a
+  dispatch rule or default resolves to more than one profile candidate.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: secondmate-provisioning
 description: >-
-  Agent-only reference for persistent secondmate setup and retirement.
-  Use when creating, seeding, validating, launching, recovering, handing backlog to, pushing inherited local material into, or retiring a secondmate home, or when editing data/secondmates.md.
-  Covers local leases, whole-home remote routes, transactional seeding, record intake for an existing or inherited domain, project clone restrictions, secondmate harness pins, inherited local-material push, idle charter, handoff helper, and teardown safety.
+  Agent-only reference for persistent secondmates. Load before creating, seeding, validating,
+  launching, recovering, handing backlog to, pushing inherited local material into, or retiring a
+  secondmate home, and before editing data/secondmates.md.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: stow
-description: Sweep the current session for uncaptured durable knowledge, file it to disk, persist the open work records this session knows are unfiled or now wrong, and curate the home's tiered, decaying startup memory before a context reset. Use when the captain invokes /stow (e.g. "/stow", "stow what you've learned"), before a session reset or context compaction, or periodically to keep operational memory current.
+description: >-
+  Sweep the session for uncaptured durable knowledge, file it to disk, correct the open work
+  records, and curate the home's startup memory. Load when the captain invokes /stow, before a
+  session reset or context compaction, or periodically to keep operational memory current.
 user-invocable: true
 metadata:
   internal: true

--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: stuck-crewmate-recovery
 description: >-
-  Agent-only playbook for stuck or missing ordinary Firstmate direct reports.
-  Use when the session-start digest reports an ordinary direct report's endpoint dead or its metadata has no window, or after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
-  Reconciles recorded work before escalating from targeted inspection through safe relaunch or failure.
+  Agent-only playbook for stuck or missing ordinary direct reports. Load when the session-start
+  digest reports a direct report's endpoint dead or its metadata has no window, or after a stale
+  wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate,
+  or a failed steer.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/updatefirstmate/SKILL.md
+++ b/.agents/skills/updatefirstmate/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: updatefirstmate
 description: >-
-  Self-update a running firstmate and its secondmates to the latest from origin.
-  Use when the captain invokes /updatefirstmate (e.g. "/updatefirstmate", "update firstmate", "pull the latest firstmate").
-  Fast-forwards this firstmate repo's default branch and every local or remote secondmate through its guarded update path (never forced, never disruptive), then re-reads AGENTS.md and nudges each updated secondmate to do the same, so the whole tree runs the latest bin/ and instructions.
+  Self-update a running firstmate and its secondmates to the latest from origin through the
+  guarded fast-forward path. Load when the captain invokes /updatefirstmate or asks to update
+  firstmate or pull the latest firstmate.
 user-invocable: true
 metadata:
   internal: true


### PR DESCRIPTION
## Intent

Ship the skill-description compression for the firstmate repo: 19 of the 20 .agents/skills/*/SKILL.md front-matter descriptions rewritten from full contract summaries down to their load triggers, so the skill listing every session carries fits its budget again. This repo is firstmate itself: follow firstmate-coding-guidelines (one sentence per line in tracked Markdown, plain dashes, bin/fm-lint.sh before done, never an agent name as a commit co-author). The change was pre-written as a patch by firstmate and applied verbatim with git apply, not redone; the patch touches front-matter description: fields only, no body changes. Why: measured 2026-08-22 the listing was 9,691 chars / ~2,422 est. tokens across 21 skills, at or over the ~1% context budget past which entries get truncated and routing silently degrades; long descriptions restated each skill's whole operating contract, but the body owns the contract and the description only has to make the load trigger unambiguous. Re-measured on this base (20 skills): before 8,891 chars / ~2,222 est. tokens, after 5,507 chars / ~1,376 est. tokens (-38%); state both figures in the PR body. Acceptance: (1) patch applies cleanly and every one of the 20 skill front-matter blocks still parses with non-empty name and description; (2) every distinct load trigger named in AGENTS.md section 13 is still recognisable in its skill's description - compression, not deletion (bootstrap-diagnostics intentionally lists diagnostic prefixes as examples plus 'any SECONDMATE_ line' and defers the exhaustive list to section 13, its one owner); (3) before/after combined name+description size stated in the PR body; (4) bin/fm-lint.sh passes and bin/fm-test-run.sh --changed passes - firstmate decided at a previous run's test gate that the full pure-contract-unit family run is CI's lane for this metadata-only change, since the two skill-consuming tests pass and the 3 local failures are missing tooling only (no ruby, Python 3.10 lacks tomllib, Node cannot load .ts); (5) ahoy is untouched and no skill body changed EXCEPT one captain-approved exception already committed as the second commit on this branch: the previous run's document gate (finding doc-1) added a two-sentence rule to the Trigger hygiene section of .agents/skills/firstmate-coding-guidelines/SKILL.md stating that a description states only its load trigger while the body owns the contract, and that the combined name+description listing must stay within the per-session budget - re-measure when adding a skill. That is the only permitted body change. Descriptions use YAML folded block scalars wrapped across lines, which is deliberate for front matter. Push goes to the fork arsamasif/firstmate; the PR opens against kunchenguid/firstmate main; merge authority is the captain's, do not merge.

## What Changed

- Rewrote the front-matter `description:` field of 19 of the 20 `.agents/skills/*/SKILL.md` files from full operating-contract summaries down to their load triggers, keeping every trigger named in AGENTS.md section 13 recognisable (bootstrap-diagnostics now lists diagnostic prefixes as examples plus "any SECONDMATE_ line" and defers the exhaustive list to section 13); descriptions stay as YAML folded block scalars wrapped across lines.
- Combined name+description listing across the 20 skills measured on this base: before 8,891 chars / ~2,222 est. tokens, after 5,507 chars / ~1,376 est. tokens (-38%), bringing the per-session skill listing back under the budget past which entries truncate.
- Added a two-sentence rule to the Trigger hygiene section of `.agents/skills/firstmate-coding-guidelines/SKILL.md`: a description states only its load trigger while the body owns the contract, and the combined name+description listing must stay within the per-session budget - re-measure when adding a skill. This is the only skill body change; `ahoy` is untouched.

## Risk Assessment

✅ Low: Metadata-only change: all 20 skill front-matter blocks parse with non-empty name/description, before/after sizes (8,891 -> 5,507 chars) match the stated figures exactly, every section-13 and captain-invocable trigger remains recognisable, the sole body change is the captain-approved two-line rule in the correct section, and no script or test parses the description field in a way the folded scalars could break.

## Testing

Ran the two skill-consuming test scripts (both pass) and a YAML-parser-backed acceptance check over base and target that confirms all 20 front-matter blocks parse with non-empty name/description, the listing shrinks from 8,891 to 5,507 chars (-38%, matching the PR-body figures), every section-13 trigger survives compression, ahoy is untouched, and the only body edit is the approved Trigger hygiene rule; the full --changed family was left to CI per the recorded test-1 decision.

<details>
<summary>Evidence: Skill listing acceptance check (front-matter parse, before/after size, section-13 trigger survival, body-change audit)</summary>

Source: [Skill listing acceptance check (front-matter parse, before/after size, section-13 trigger survival, body-change audit)](https://github.com/arsamasif/firstmate/blob/f75edda17182c378df39e532f4dedc7ecf8f5c50/.no-mistakes/evidence/fm/fm-skill-listing-budget/skill-listing-acceptance.txt)

<code>(1) front matter: 20 skills at target all parse (yaml.safe_load) with non-empty name+description&#10;(3) combined name+description listing size&#10;before: 8891 chars / ~2222 est. tokens (chars/4)&#10;after: 5507 chars / ~1376 est. tokens (chars/4)&#10;delta: -38%&#10;(5) body changes between base and target:&#10;body changed: firstmate-coding-guidelines&#10;(2) AGENTS.md section 13 triggers still recognisable in compressed descriptions: 14/14 ok</code>

```text
(1) front matter: 20 skills at target all parse (yaml.safe_load) with non-empty name+description
    base skills=20 target skills=20

(3) combined name+description listing size
    before: 8891 chars / ~2222 est. tokens (chars/4)
    after:  5507 chars / ~1376 est. tokens (chars/4)
    delta:  -38%

    per-skill chars (before -> after):
      afk                                532 ->   306
      ahoy                               215 ->   215
      ask-user-authority                 416 ->   231
      bearings                           682 ->   391
      bootstrap-diagnostics              626 ->   428
      captain-hold-lifecycle             460 ->   361
      decision-hold-lifecycle            247 ->   182
      diagnostic-reasoning               292 ->   147
      firstmate-codexapp                 355 ->   284
      firstmate-coding-guidelines        610 ->   256
      firstmate-orca                     257 ->   250
      fmx-respond                        714 ->   355
      harness-adapters                   394 ->   337
      process-event-sources              591 ->   267
      project-management                 335 ->   207
      quota-array-dispatch               269 ->   184
      secondmate-provisioning            537 ->   267
      stow                               410 ->   276
      stuck-crewmate-recovery            448 ->   327
      updatefirstmate                    501 ->   236

(5) body changes between base and target:
    body changed: firstmate-coding-guidelines
    (only firstmate-coding-guidelines expected - the captain-approved doc-1 exception)

(2) AGENTS.md section 13 triggers still recognisable in compressed descriptions:
    ok  bootstrap-diagnostics         
    ok  diagnostic-reasoning          
    ok  ask-user-authority            
    ok  quota-array-dispatch          
    ok  harness-adapters              
    ok  firstmate-orca                
    ok  project-management            
    ok  stuck-crewmate-recovery       
    ok  secondmate-provisioning       
    ok  captain-hold-lifecycle        
    ok  process-event-sources         
    ok  fmx-respond                   
    ok  firstmate-codexapp            
    ok  firstmate-coding-guidelines   

target descriptions:
  afk: Enter away-mode supervision. Load when the captain invokes /afk or says they are going afk, when state/.afk exists, when an incoming message starts with FM_INJECT_MARK, or when any state/.subsuper-* marker is involved. It owns the away daemon and the automatic exit when a real unmarked message returns.
  ahoy: Recap visible session events and guide the captain through visibly unanswered decisions when the captain explicitly invokes /ahoy, with a Bearings fallback when /ahoy is the session's first real captain message.
  ask-user-authority: Agent-only decision procedure for ask-user findings, and the single owner of finding-decision policy. Load before deciding any ask-user finding; its criteria, not the project's yolo posture, set finding authority.
  bearings: Fleet digest so the captain can resume in one read. Load when the captain invokes /bearings or asks for a status report, morning brief, catch-up, bearings, "where did I leave off", or "what's in the works"; the file and lavish modes add the dated report and the interactive board. Also load its board-wake handling when a procevent lavish wake matches the bearings board's source id.
  bootstrap-diagnostics: Agent-only handling playbook for session-start bootstrap diagnostics. Load whenever the digest's bootstrap or NETWORK CHECKS section, or a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run, prints an actionable diagnostic line such as MISSING:, TANGLE:, NEEDS_GH_AUTH, FLEET_SYNC:, NETWORK_CHECKS:, PR_CHECK_MIGRATION:, or any SECONDMATE_ line. Silence or a BOOTSTRAP_INFO: fact needs no load.
  captain-hold-lifecycle: Agent-only policy for closing captain calls in the captain's own words. Load before treating an investigation, scout report, structured review, or Lavish review as complete, before ending a visual review that exposed a captain decision, when recording or routing the captain's answer, and on any RECORD DIVERGENCE line from the wake drain.
  decision-hold-lifecycle: Deprecated pointer: load captain-hold-lifecycle instead. Kept only for in-flight briefs that still name this skill, and removed one release after the collapse.
  diagnostic-reasoning: Agent-only procedure for diagnosing reported bugs. Load before scoping a reported bug and before acting on a diagnostic report.
  firstmate-codexapp: Agent-only playbook for visible Codex Desktop threads alongside Firstmate. Load before creating, reading, steering, archiving, debugging, or reviewing a Codex App thread for Firstmate work, and before answering a request to make Codex App a native Firstmate backend.
  firstmate-coding-guidelines: Agent-only reference for changing firstmate's own shared, tracked material as defined by AGENTS.md section 1. Load before editing any of it, whether working as firstmate directly or as a crewmate briefed on a firstmate-repo task.
  firstmate-orca: Agent-only operator checklist for Firstmate's Orca runtime backend. Load when switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
  fmx-respond: Agent-only playbook for Relay mentions and public follow-ups. Load on an `x-mention <request_id>`, `x-mode-error ...`, or `public-followup ...` check wake, on any milestone or terminal wake for a Relay-linked task before its completion follow-up, and whenever a promised final public reply must be created, reconciled, or delivered. Relay-only.
  harness-adapters: Agent-only reference of verified per-harness facts (claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, muse). Load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting, exiting or resuming an agent, or verifying a new adapter.
  process-event-sources: Agent-only procedure for registered process-to-event sources. Load before arming a long-polling source firstmate owns, before registering a deterministic condition->action watch, and on any `procevent <adapter> <source-id> <sequence>` check wake.
  project-management: Agent-only procedure for Firstmate project management. Load before adding, creating, removing, or initializing a project; cloning or registering one is add intake and uses the same trigger.
  quota-array-dispatch: Agent-only decision procedure for resolving a matched crew-dispatch profile array. Load when a dispatch rule or default resolves to more than one profile candidate.
  secondmate-provisioning: Agent-only reference for persistent secondmates. Load before creating, seeding, validating, launching, recovering, handing backlog to, pushing inherited local material into, or retiring a secondmate home, and before editing data/secondmates.md.
  stow: Sweep the session for uncaptured durable knowledge, file it to disk, correct the open work records, and curate the home's startup memory. Load when the captain invokes /stow, before a session reset or context compaction, or periodically to keep operational memory current.
  stuck-crewmate-recovery: Agent-only playbook for stuck or missing ordinary direct reports. Load when the session-start digest reports a direct report's endpoint dead or its metadata has no window, or after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
  updatefirstmate: Self-update a running firstmate and its secondmates to the latest from origin through the guarded fast-forward path. Load when the captain invokes /updatefirstmate or asks to update firstmate or pull the latest firstmate.
```
</details>
<details>
<summary>Evidence: tests/fm-ask-user-authority.test.sh output</summary>

Source: [tests/fm-ask-user-authority.test.sh output](https://github.com/arsamasif/firstmate/blob/f75edda17182c378df39e532f4dedc7ecf8f5c50/.no-mistakes/evidence/fm/fm-skill-listing-budget/fm-ask-user-authority.test.log)

```text
ok - primary workers and secondmates receive the authority rule through generated instructions
exit=0
```
</details>
<details>
<summary>Evidence: tests/fm-captain-hold-lifecycle.test.sh output</summary>

Source: [tests/fm-captain-hold-lifecycle.test.sh output](https://github.com/arsamasif/firstmate/blob/f75edda17182c378df39e532f4dedc7ecf8f5c50/.no-mistakes/evidence/fm/fm-skill-listing-budget/fm-captain-hold-lifecycle.test.log)

```text
ok - report-only unresolved captain call is reproduced and completion refuses before loss
ok - the completion gate attests captain-held inventory and transfers open status decisions
ok - answer records the captain's words, closes idempotently, and releases routed work
ok - release frees held work with the captain's words recorded and the body preserved
ok - a deferred captain call leaves the live Captain's Call until its date and stays answerable
ok - an out-of-band close is recordable with the captain's word and nothing else
ok - ended visual review follows the same captain-hold completion owner
ok - resolved findings and decision-like prose do not create captain-held tasks
ok - terminal single-owner stale status decisions do not block empty inventory
ok - main-home and secondmate-home captain calls remain correctly routed
ok - a bound channel's captured answers close their captain-held tasks at answer time
ok - a channel source with no decision binding closes nothing
ok - legacy identities, metadata, bindings, and the shim keep working
ok - the chat channel feeds the same keyed-answer intake a captured review does
ok - completion and verification validate origins before constructing paths
ok - a status resolution over a still-open captain-held task is signalled, not closed
ok - a captain call with no routed work, a verified transfer, an open decision, and an answered call all stay silent
exit=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7cb2b466d9ff195edf9de4ff1686a3d7d1676750","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `.agents/skills/firstmate-codexapp/SKILL.md:4` - AGENTS.md section 13 names a third trigger for this skill - &#39;reconciling Codex Desktop host-tool smoke evidence for Firstmate work&#39; - that the description does not state; only thread operations and the native-backend request are named. This is pre-existing (the base description omitted it too), so it is not introduced by the compression and does not violate acceptance item (2)&#39;s &#39;still recognisable&#39; bar, but if the author wants the description to cover every section-13 trigger for this skill, adding &#39;or reconciling Codex Desktop host-tool smoke evidence&#39; costs about 55 chars.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-ask-user-authority.test.sh` (passes, exit 0)</code>
- <code>`bash tests/fm-captain-hold-lifecycle.test.sh` (passes, exit 0)</code>
- <code>Parsed all 20 `.agents/skills/*/SKILL.md` front-matter blocks at base 7ee0c19 and target 7cb2b46 with `yaml.safe_load`, asserting non-empty `name` and `description` for each</code>
- `Measured combined name+description listing size at base vs target (8,891 -> 5,507 chars, ~2,222 -> ~1,376 est. tokens at chars/4, -38%) with a per-skill breakdown`
- `Checked each AGENTS.md section-13 load trigger's key phrases against its skill's compressed description (14/14 recognisable)`
- <code>Diffed skill bodies base..target: only firstmate-coding-guidelines body changed (the approved doc-1 rule); `git diff --stat 7ee0c19..7cb2b46 -- .agents/skills/ahoy` is empty</code>
- <code>Confirmed the diff touches only `description:` folded scalars plus the two approved body lines</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
