### PR TITLE
docs: correct Orca platform claims and add Linux backend verification evidence

### DIFF
--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -1,18 +1,19 @@
 # Orca runtime backend
 
-Orca is an experimental macOS backend in which the Orca app owns both the task worktree and terminal endpoint.
+Orca is an experimental backend in which the Orca app owns both the task worktree and terminal endpoint.
 The crewmate harness remains the agent process launched inside that endpoint.
 Firstmate agents load [`firstmate-orca`](../.agents/skills/firstmate-orca/SKILL.md) before operating or recovering this backend.
 
 ## Setup
 
-Pick Orca when you already use the Orca macOS app and want Orca-managed worktrees and terminals instead of Treehouse plus a session multiplexer.
-Orca is macOS-only, explicit-only, and does not support secondmate spawns.
+Pick Orca when you already use the Orca app and want Orca-managed worktrees and terminals instead of Treehouse plus a session multiplexer.
+Orca itself ships desktop builds for macOS, Windows, and Linux plus an iOS/Android mobile companion for remote monitoring, per its own README as of 2026-08-27; the adapter below has only been exercised against the macOS app path.
+Orca is explicit-only and does not support secondmate spawns.
 
 Prerequisites:
 
-- `/Applications/Orca.app` installed, running, and ready.
-- The `orca` CLI, installed with `brew install orca`.
+- The Orca desktop app installed, running, and ready (`/Applications/Orca.app` on macOS; see [onorca.dev/download](https://onorca.dev/download) for the Windows and Linux builds, unexercised by Firstmate).
+- The `orca` CLI, installed with `brew install orca` on macOS or the equivalent package for the other platforms.
 - The universal harness and toolchain requirements in [`configuration.md`](configuration.md#toolchain).
 
 Select Orca with local `config/backend` containing `orca`, `FM_BACKEND=orca` for one launch, or an explicit request to Firstmate.
@@ -66,7 +67,8 @@ It never raw-deletes an Orca worktree.
 
 ## Active limits
 
-- Orca is macOS-only and explicit-only.
+- Orca is explicit-only.
+- Firstmate's own integration is verified against the macOS app only; the Windows and Linux desktop builds and the mobile companion app are unexercised here.
 - The app must be running and report ready.
 - Secondmate spawns are unsupported.
 - Escape is unsupported.

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -13,7 +13,7 @@ Orca is explicit-only and does not support secondmate spawns.
 Prerequisites:
 
 - The Orca desktop app installed, running, and ready (`/Applications/Orca.app` on macOS; see the [Orca repository](https://github.com/stablyai/orca) for the Windows and Linux builds, unexercised by Firstmate).
-- The `orca` CLI, installed with `brew install orca` on macOS or the equivalent package for the other platforms.
+- The `orca` CLI, installed with `brew install orca` on macOS; the non-macOS CLI install path is unverified by Firstmate.
 - The universal harness and toolchain requirements in [`configuration.md`](configuration.md#toolchain).
 
 Select Orca with local `config/backend` containing `orca`, `FM_BACKEND=orca` for one launch, or an explicit request to Firstmate.

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -12,7 +12,7 @@ Orca is explicit-only and does not support secondmate spawns.
 
 Prerequisites:
 
-- The Orca desktop app installed, running, and ready (`/Applications/Orca.app` on macOS; see [onorca.dev/download](https://onorca.dev/download) for the Windows and Linux builds, unexercised by Firstmate).
+- The Orca desktop app installed, running, and ready (`/Applications/Orca.app` on macOS; see the [Orca repository](https://github.com/stablyai/orca) for the Windows and Linux builds, unexercised by Firstmate).
 - The `orca` CLI, installed with `brew install orca` on macOS or the equivalent package for the other platforms.
 - The universal harness and toolchain requirements in [`configuration.md`](configuration.md#toolchain).
 

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -14,6 +14,8 @@ An explicit selection is also the opt-out from Herdr or cmux runtime auto-detect
 
 No provisioning is required before the first task.
 
+tmux being the hard default does not mean every host has it installed: a home with no tmux binary falls through runtime auto-detection or an explicit `config/backend`/`FM_BACKEND` to whichever backend is actually available, and every task on that home runs there instead until tmux is installed or explicitly selected.
+
 ## Watching the crew
 
 For the best visible experience, launch the primary harness inside a tmux session:

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -14,7 +14,7 @@ An explicit selection is also the opt-out from Herdr or cmux runtime auto-detect
 
 No provisioning is required before the first task.
 
-tmux being the hard default does not mean every host has it installed: a home with no tmux binary falls through runtime auto-detection or an explicit `config/backend`/`FM_BACKEND` to whichever backend is actually available, and every task on that home runs there instead until tmux is installed or explicitly selected.
+tmux being the hard default does not mean every host has it installed, and a missing tmux binary is not itself a selection signal: backend selection is driven by `config/backend`/`FM_BACKEND` and runtime auto-detection's environment markers, so a host without tmux runs every task on another backend only when auto-detection or an explicit selection picks one, and otherwise resolves to tmux and fails its `tmux` toolchain requirement until tmux is installed.
 
 ## Watching the crew
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -256,6 +256,25 @@ herdr 0.7.5
 ["pane.output_matched","pane.agent_status_changed","pane.scroll_changed"]
 ```
 
+### Linux host re-check
+
+All prior evidence in this section is from macOS.
+The core read-only probes were re-run on 2026-08-27 on `x86_64 GNU/Linux` (kernel 6.17.0), where this machine has no tmux installed and every task therefore already runs on Herdr, confirming the client-server handshake and basic status read work identically off macOS.
+
+```sh
+herdr --version
+herdr status --json | jq -c '{client:.client.protocol,server:.server.protocol}'
+```
+
+Observed:
+
+```text
+herdr 0.8.0
+{"client":19,"server":19}
+```
+
+This is a status-read smoke only; the pane lifecycle, submit-confirmation, and prune/respawn guarantees below remain verified on macOS only and were not re-exercised here.
+
 The CLI matrix was checked directly:
 
 | Guarantee | Command shape | Result |
@@ -691,6 +710,17 @@ tests/fm-bootstrap.test.sh
 
 The fake-Orca suite covers readiness, registration, create response parsing, metadata routing, popup-safe submit, and path-matched release refusal.
 
+### Platform support re-check
+
+The Orca app itself was re-checked against its own GitHub repository on 2026-08-27; this corrects the docs' prior "macOS-only" framing, which the app has outgrown, but is a documentation claim, not a Firstmate-side platform test.
+
+```sh
+gh api repos/stablyai/orca/readme -H "Accept: application/vnd.github.raw"
+```
+
+Observed: the README's supported-platforms badge reads `macOS | Windows | Linux`, and the Features section documents an iOS/Android "Mobile Companion" for remote monitoring and steering (App Store, TestFlight, and a direct Android APK link).
+No Firstmate machine used for this recheck had the Orca app installed on Windows or Linux, so the adapter's own compatibility with those builds remains unexercised; only the macOS-app path in this doc's Setup section has ever been run against a real `orca status --json`.
+
 ## cmux
 
 The current compatibility floor is cmux 0.64, and the active live evidence uses 0.64.17 build 97 on macOS aarch64.
@@ -746,6 +776,17 @@ tests/fm-backend-cmux-smoke.test.sh
 ```
 
 The real smoke proves socket access, fresh readiness, current-path probing, send and keys, bounded capture, title identity, and guarded exact cleanup.
+
+### Platform support re-check
+
+Re-checked against the upstream repository on 2026-08-27 to confirm the "macOS-only" framing still holds; it does.
+
+```sh
+gh api repos/manaflow-ai/cmux/readme -H "Accept: application/vnd.github.raw"
+```
+
+Observed: the README describes cmux as "A Ghostty-based macOS terminal" throughout, its only download artifact is a `.dmg`, and no Windows or Linux build is mentioned.
+The macOS-only, GUI-first claim in this doc is unchanged.
 
 ### Claude composer confirmation
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -259,7 +259,7 @@ herdr 0.7.5
 ### Linux host re-check
 
 All prior evidence in this section is from macOS.
-The core read-only probes were re-run on 2026-08-27 on `x86_64 GNU/Linux` (kernel 6.17.0), where this machine has no tmux installed and every task therefore already runs on Herdr, confirming the client-server handshake and basic status read work identically off macOS.
+The core read-only probes were re-run on 2026-08-27 on `x86_64 GNU/Linux` (kernel 6.17.0), where tasks run on Herdr through auto-detection (`HERDR_ENV=1`) or an explicit `config/backend` selection rather than through the tmux default, confirming the client-server handshake and basic status read work identically off macOS.
 
 ```sh
 herdr --version


### PR DESCRIPTION
## Intent

Re-verify the herdr, orca, and cmux runtime backends against reality and retire stale experimental/platform-support language where evidence no longer supports it. docs/orca-backend.md called Orca macOS-only, which is false: Orca's own GitHub README (checked 2026-08-27) shows macOS/Windows/Linux desktop builds plus an iOS/Android mobile companion app for remote monitoring. Corrected that doc to state Firstmate's own integration is verified against the macOS app path only, with the Windows/Linux builds and mobile app explicitly unexercised by Firstmate - this is a documentation claim fix, not a code/behavior change to bin/backends/orca.sh. cmux was independently re-checked against its own README and confirmed to still be genuinely macOS-only (Ghostty-based, .dmg-only download) - no claim changed there. Ran herdr's own core read-only probes (herdr --version, herdr status --json) live on this task's Linux x86_64 host, which has no tmux installed and therefore already runs every task on herdr - recorded that as new dated evidence in docs/verification/runtime-backends.md, since the doc previously only had macOS evidence. Added a short note to docs/tmux-backend.md that tmux being the 'hard default' does not guarantee every host has tmux installed - a host without it falls through to auto-detection or explicit config/backend selection. Explicitly did NOT change any 'experimental' maturity label: herdr stays experimental because it is still pre-1.0 upstream (latest release v0.8.2) consistent with existing evidence; orca and cmux stay experimental because their actual lifecycle guarantees (spawn, recovery, submit-confirmation) remain unexercised on this host - only the Orca platform-support factual claim was wrong and corrected, backed by the upstream README fetched via gh api. No backend behavior/code was changed, only documentation in docs/orca-backend.md, docs/tmux-backend.md, and docs/verification/runtime-backends.md. Ran bin/fm-doc-audience-check.sh clean (74 surfaces, 285 local links). The push target was previously blocked (no write access to kunchenguid/firstmate) and has since been reconfigured by the captain to push branches to the fork https://github.com/altave-guilherme-monteiro/firstmate and open PRs against the parent repo.

## What Changed

- `docs/orca-backend.md`: dropped the "Orca is macOS-only" claim; Orca ships macOS/Windows/Linux desktop builds plus an iOS/Android companion per its upstream README (2026-08-27), while Firstmate's own integration is documented as verified against the macOS app path only, with the non-macOS app/CLI paths marked unexercised. Orca stays experimental and explicit-only.
- `docs/verification/runtime-backends.md`: added dated 2026-08-27 evidence sections — live `herdr --version` / `herdr status --json` read-only probes on a Linux x86_64 host (protocol 19 client/server handshake, status-read smoke only), the Orca upstream-README platform re-check, and a cmux re-check confirming it is still macOS-only (Ghostty-based, `.dmg`-only).
- `docs/tmux-backend.md`: noted that tmux being the hard default does not imply every host has tmux installed — selection still comes from `config/backend`/`FM_BACKEND` or auto-detection, and a tmux-less host otherwise resolves to tmux and fails its toolchain requirement.

## Risk Assessment

✅ Low: Documentation-only change whose corrected claims are each backed by recorded probes or by the actual selection logic in bin/fm-backend.sh, with no code or behavior touched and no remaining contradictory statements elsewhere in the docs.

## Testing

I verified the change end-to-end as a reader would consume it. The herdr Linux probes recorded in docs/verification/runtime-backends.md reproduce byte-for-byte on this host (`herdr 0.8.0`, protocol 19/19, no tmux installed). Rather than trust the prose, I exercised the real selection code: sourcing bin/fm-backend.sh, a bare environment on this tmux-less host still resolves to `tmux` and then fails its `tmux` toolchain requirement, while herdr is only selected via `HERDR_ENV=1` auto-detection or an explicit `FM_BACKEND`/`config/backend` — which is exactly what the new tmux-backend.md note asserts, and it also confirms the doc correctly avoided the looser "this host already runs everything on herdr" framing. Both upstream README claims check out via `gh api`: Orca's README shows a macOS|Windows|Linux badge with direct Windows .exe and Linux AppImage downloads plus an iOS/Android mobile companion, so the old "macOS-only" line was genuinely false; cmux's README still says "macOS only, for now" with a .dmg-only artifact, so leaving that claim unchanged is correct. A repo-wide sweep found no surviving stale Orca macOS-only wording, all "experimental" labels are untouched, bin/backends/ has zero diff, fm-doc-audience-check.sh passes clean at 74 surfaces / 285 links, and the worktree is clean with no transient files left behind. No code paths changed, so no rendered-UI artifact applies; the reviewer-visible surface here is the Markdown itself, which I captured.

<details>
<summary>Evidence: Backend resolution + toolchain behavior on this tmux-less Linux host</summary>

<code>host: no tmux binary, no config/backend, TMUX/HERDR_ENV unset&#10;&#10;--- resolved backend (fm_backend_name) ---&#10;bare env (the &#39;hard default&#39; path) -&gt; tmux&#10;HERDR_ENV=1 (auto-detection) -&gt; herdr&#10;FM_BACKEND=herdr (explicit) -&gt; herdr&#10;&#10;--- toolchain requirement check on resolved backend ---&#10;tmux requires: tmux treehouse MISSING: tmux&#10;herdr requires: herdr jq treehouse all present</code>

```text
host: no tmux binary, no config/backend, TMUX/HERDR_ENV unset

--- resolved backend (fm_backend_name) ---
bare env (the 'hard default' path)             -> tmux
HERDR_ENV=1 (auto-detection)                   -> herdr
FM_BACKEND=herdr (explicit)                    -> herdr

--- toolchain requirement check on resolved backend ---
tmux       requires: tmux treehouse           MISSING: tmux
herdr      requires: herdr jq treehouse       all present
```
</details>
<details>
<summary>Evidence: herdr live probes reproduced on Linux x86_64 (matches recorded evidence)</summary>

<code>== uname -a&#10;Linux 6.17.0-41-generic x86_64 GNU/Linux&#10;== which tmux&#10;tmux: NOT INSTALLED&#10;== herdr --version&#10;herdr 0.8.0&#10;== herdr status --json | jq -c&#10;{&#34;client&#34;:19,&#34;server&#34;:19}</code>

```text
== uname -a
Linux altave-Dell-G15-5530 6.17.0-41-generic #41-Ubuntu SMP PREEMPT_DYNAMIC Sat Jun 20 18:01:40 UTC 2026 x86_64 GNU/Linux
== which tmux
tmux: NOT INSTALLED
== herdr --version
herdr 0.8.0
== herdr status --json | jq -c
{"client":19,"server":19}
== HERDR_ENV
HERDR_ENV=<unset>
```
</details>
<details>
<summary>Evidence: Upstream README platform evidence (Orca multi-platform, cmux macOS-only)</summary>

<code>stablyai/orca:&#10;badge: &#34;macOS | Windows | Linux&#34;&#10;builds: macos-arm64.dmg / macos-x64.dmg / orca-windows-setup.exe / orca-linux.AppImage&#10;Mobile Companion: iOS App Store + TestFlight + Android APK 0.0.44&#10;&#10;manaflow-ai/cmux:&#10;&#34;A Ghostty-based macOS terminal ...&#34;&#10;only artifact: cmux-macos.dmg&#10;FAQ: &#34;macOS only, for now. cmux is a native Swift + AppKit app.&#34;</code>

```text
### stablyai/orca README — platform evidence
11:  <img src="https://img.shields.io/badge/macOS%20%7C%20Windows%20%7C%20Linux-4493F8?style=flat-square" alt="Supported platforms: macOS, Windows, and Linux" />
26:  <img src="docs/assets/readme-hero.jpg" alt="Orca desktop app running agents in parallel worktrees, with the Orca mobile companion app in the corner" width="960" />
35:### Mobile Companion
39:[iOS App Store](https://apps.apple.com/us/app/orca-ide/id6766130217) · [TestFlight](https://testflight.apple.com/join/YjeGMQBA) · [Android APK 0.0.44](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.44/app-release.apk) · [Docs →](https://www.onorca.dev/docs/mobile)
43:  <a href="https://www.onorca.dev/docs/mobile"><picture><source srcset="docs/assets/feature-wall/mobile-companion-app-showcase.gif" type="image/gif"><img src="docs/assets/feature-wall/mobile-companion-app-showcase.jpg" alt="Orca desktop with the mobile companion app" width="100%" /></picture></a>
212:### Desktop — macOS, Windows, Linux
215:- Or grab a build directly: [macOS Apple Silicon](https://github.com/stablyai/orca/releases/latest/download/orca-macos-arm64.dmg) · [macOS Intel](https://github.com/stablyai/orca/releases/latest/download/orca-macos-x64.dmg) · [Windows (.exe)](https://github.com/stablyai/orca/releases/latest/download/orca-windows-setup.exe) · [Linux AppImage](https://github.com/stablyai/orca/releases/latest/download/orca-linux.AppImage) · [All builds](https://github.com/stablyai/orca/releases/latest)
216:- Running `orca serve` on a headless Linux server? See the [headless Linux server guide](docs/reference/headless-linux-server.md).
221:# macOS (Homebrew)
224:# Arch Linux (AUR) — or stably-orca-git to build from source
228:### Mobile Companion — iOS, Android
232:- **iOS:** [Download on the App Store](https://apps.apple.com/us/app/orca-ide/id6766130217) or [join TestFlight](https://testflight.apple.com/join/YjeGMQBA)
233:- **Android:** [Download APK 0.0.44](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.44/app-release.apk) · [Install guide](https://www.onorca.dev/docs/android-apk)
265:Windows code signing sponored/provided by [SignPath.io](https://signpath.io), certificate by [SignPath Foundation](https://signpath.org).

### manaflow-ai/cmux README — platform evidence
2:<p align="center">A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents</p>
5:  <a href="https://github.com/manaflow-ai/cmux/releases/latest/download/cmux-macos.dmg">
6:    <img src="./docs/assets/macos-badge.png" alt="Download cmux for macOS" width="180" />
90:- **Native macOS app** — Built with Swift and AppKit, not Electron. Fast startup, low memory.
91:- **Ghostty compatible** — Reads your existing `~/.config/ghostty/config` for themes, fonts, and colors
92:- **GPU-accelerated** — Powered by libghostty for smooth rendering
100:<a href="https://github.com/manaflow-ai/cmux/releases/latest/download/cmux-macos.dmg">
101:  <img src="./docs/assets/macos-badge.png" alt="Download cmux for macOS" width="180" />
104:Open the `.dmg` and drag cmux to your Applications folder. cmux auto-updates via Sparkle, so you only need to download once.
119:On first launch, macOS may ask you to confirm opening an app from an identified developer. Click **Open** to proceed.
123:I run a lot of Claude Code and Codex sessions in parallel. I was using Ghostty with a bunch of split panes, and relying on native macOS notifications to know when an agent needed me. But Claude Code's notification body is always just "Claude is waiting for your input" with no context, and with enough tabs open I couldn't even read the titles anymore.
125:I tried a few coding orchestrators but most of them were Electron/Tauri apps and the performance bugged me. I also just prefer the terminal since GUI orchestrators lock you into their workflow. So I built cmux as a native macOS app in Swift/AppKit. It uses libghostty for terminal rendering and reads your existing Ghostty config for themes, fonts, and colors.
243:[Download cmux NIGHTLY](https://github.com/manaflow-ai/cmux/releases/download/nightly/cmux-nightly-macos.dmg)
324:### How does cmux relate to Ghostty?
326:cmux is not a fork of Ghostty. It uses [libghostty](https://github.com/ghostty-org/ghostty) as a library for terminal rendering, the same way apps use WebKit for web views. Ghostty is a standalone terminal; cmux is a different app built on top of its rendering engine.
330:macOS only, for now. cmux is a native Swift + AppKit app.
350:When a process needs attention, cmux shows notification rings around panes, unread badges in the sidebar, a notification popover, and a macOS desktop notification. These fire automatically via standard terminal escape sequences (OSC 9/99/777), or you can trigger them with the [cmux CLI](https://cmux.com/docs/notifications#cli-usage) and [agent hooks](https://cmux.com/docs/notifications#integration-examples). Any agent that supports hooks or OSC works, including Claude Code, Codex, OpenCode, and pi.
366:Terminal keybindings are read from your Ghostty config file (`~/.config/ghostty/config`). cmux-specific shortcuts (workspaces, splits, browser, notifications) can be customized in Settings. See the [default shortcuts](https://cmux.com/docs/keyboard-shortcuts) for a full list.
370:Yes. Terminal rendering uses your Ghostty config, so themes, fonts, colors, and cursor carry over directly. cmux's own settings in `~/.config/cmux/cmux.json` control the sidebar, tab bar, split panes, and behavior, and every [keyboard shortcut](https://cmux.com/docs/keyboard-shortcuts) is editable. See [configuration](https://cmux.com/docs/configuration).
374:Yes. cmux restores your windows, workspaces, panes, working directories, and scrollback when you relaunch, and the state survives a full computer restart, not just quitting the app. Agent sessions like Claude Code, Codex, and OpenCode come back too. See [session restore](https://cmux.com/docs/session-restore).
378:tmux is a terminal multiplexer that runs inside any terminal. cmux is a native macOS app with a GUI: vertical tabs, split panes, an embedded browser, and a socket API, all built in, no config files or prefix keys needed. That said, lots of people happily run cmux with SSH and tmux together, and cmux can attach to your remote tmux sessions natively ([beta](https://cmux.com/docs/remote-tmux)).
```
</details>
<details>
<summary>Evidence: Corrected doc surface as a reader sees it</summary>

```text
===== docs/orca-backend.md (head) =====
# Orca runtime backend

Orca is an experimental backend in which the Orca app owns both the task worktree and terminal endpoint.
The crewmate harness remains the agent process launched inside that endpoint.
Firstmate agents load [`firstmate-orca`](../.agents/skills/firstmate-orca/SKILL.md) before operating or recovering this backend.

## Setup

Pick Orca when you already use the Orca app and want Orca-managed worktrees and terminals instead of Treehouse plus a session multiplexer.
Orca itself ships desktop builds for macOS, Windows, and Linux plus an iOS/Android mobile companion for remote monitoring, per its own README as of 2026-08-27; the adapter below has only been exercised against the macOS app path.
Orca is explicit-only and does not support secondmate spawns.

Prerequisites:

- The Orca desktop app installed, running, and ready (`/Applications/Orca.app` on macOS; see the [Orca repository](https://github.com/stablyai/orca) for the Windows and Linux builds, unexercised by Firstmate).
- The `orca` CLI, installed with `brew install orca` on macOS; the non-macOS CLI install path is unverified by Firstmate.
- The universal harness and toolchain requirements in [`configuration.md`](configuration.md#toolchain).

Select Orca with local `config/backend` containing `orca`, `FM_BACKEND=orca` for one launch, or an explicit request to Firstmate.
It is never auto-detected.

===== docs/orca-backend.md limits =====
A missing, unreadable, or mismatched identity preserves metadata and stops rather than deleting anything.
After those checks, Firstmate closes the exact terminal and releases the exact worktree with Orca's worktree command.
It never raw-deletes an Orca worktree.

## Active limits

- Orca is explicit-only.
- Firstmate's own integration is verified against the macOS app only; the Windows and Linux desktop builds and the mobile companion app are unexercised here.
- The app must be running and report ready.
- Secondmate spawns are unsupported.
- Escape is unsupported.
- Orca exposes no stable CLI version or protocol marker, so readiness is the compatibility gate rather than a version floor.
- Only the verified terminal-handle and worktree result fields are accepted; speculative response shapes are rejected.

===== docs/tmux-backend.md (new note) =====

tmux is the hard default when no explicit setting or runtime auto-detection selects another backend.
Select it explicitly with local `config/backend` containing `tmux`, with `FM_BACKEND=tmux` for one launch, or by asking Firstmate to use tmux.
An explicit selection is also the opt-out from Herdr or cmux runtime auto-detection.

No provisioning is required before the first task.

tmux being the hard default does not mean every host has it installed, and a missing tmux binary is not itself a selection signal: backend selection is driven by `config/backend`/`FM_BACKEND` and runtime auto-detection's environment markers, so a host without tmux runs every task on another backend only when auto-detection or an explicit selection picks one, and otherwise resolves to tmux and fails its `tmux` toolchain requirement until tmux is installed.

## Watching the crew
```
</details>
<details>
<summary>Evidence: fm-doc-audience-check.sh</summary>

`fm-doc-audience-check: ok surfaces=74 local_links=285 (exit 0)`

```text
fm-doc-audience-check: ok surfaces=74 local_links=285
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5355c7775af020673b9da9e1b0aee55cf6b0759c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `docs/verification/runtime-backends.md:260` - The Linux re-check says the host &#34;has no tmux installed and every task therefore already runs on Herdr&#34;. That causal claim contradicts both bin/fm-backend.sh:140-278 (selection is FM_BACKEND → config/backend → fm_backend_detect on TMUX/HERDR_ENV/CMUX markers → hard tmux default; a missing tmux binary is never a selection input) and the note added in the same commit at docs/tmux-backend.md:17. Tasks run on Herdr here because HERDR_ENV=1 (or config/backend), not because tmux is absent. Reword to state the actual selection signal so the two docs don&#39;t disagree.
- ℹ️ `docs/orca-backend.md:15` - The new external link https://onorca.dev/download is outside the cited evidence (the recorded probe is `gh api repos/stablyai/orca/readme`) and outside fm-doc-audience-check.sh&#39;s local-link coverage, so nothing in this change verifies it resolves. Consider pointing at the repo README/releases page that was actually fetched.

🔧 Fix: docs: fix Herdr selection claim and unverified Orca link
1 info still open:
- ℹ️ `docs/orca-backend.md:16` - &#34;The `orca` CLI, installed with `brew install orca` on macOS or the equivalent package for the other platforms&#34; asserts a non-macOS CLI install path that this task&#39;s evidence (the README probe recorded at docs/verification/runtime-backends.md:715-720) does not cover — it only establishes desktop app builds. Consider saying the non-macOS CLI install path is unverified by Firstmate, consistent with the surrounding &#34;unexercised&#34; framing.

🔧 Fix: docs: mark non-macOS Orca CLI install path unverified
1 info still open:
- ℹ️ `docs/tmux-backend.md:17` - The new note is one 60-word sentence with three clauses stacked on a colon; it is accurate against bin/fm-backend.sh:240-278 but hard to read. Two sentences would carry the same meaning: (1) a missing tmux binary is not a selection signal — selection is FM_BACKEND, then config/backend, then auto-detection markers; (2) a host without tmux still resolves to tmux unless something else is selected, and then fails its `tmux` toolchain requirement.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uname -a` and `which tmux` — confirmed Linux x86_64 host with no tmux binary, matching the newly recorded evidence context</code>
- <code>`herdr --version` and `herdr status --json | jq -c &#39;{client:.client.protocol,server:.server.protocol}&#39;` — reproduced `herdr 0.8.0` and `{&#34;client&#34;:19,&#34;server&#34;:19}` exactly as recorded in docs/verification/runtime-backends.md</code>
- <code>Behavioral backend-resolution probe sourcing `bin/fm-backend.sh` and calling `fm_backend_name` under three environments (bare, `HERDR_ENV=1`, `FM_BACKEND=herdr`) plus `fm_backend_required_tool_available` for tmux/herdr — exercises the new tmux-backend.md claim</code>
- <code>`gh api repos/stablyai/orca/readme -H &#34;Accept: application/vnd.github.raw&#34;` — confirmed the macOS|Windows|Linux platform badge, direct Windows .exe / Linux AppImage builds, and the iOS/Android Mobile Companion section</code>
- <code>`gh api repos/manaflow-ai/cmux/readme -H &#34;Accept: application/vnd.github.raw&#34;` — confirmed cmux is still Ghostty-based, .dmg-only, and states &#34;macOS only, for now&#34;</code>
- <code>`bash bin/fm-doc-audience-check.sh` — 74 surfaces, 285 local links, exit 0</code>
- <code>`grep -rniE &#34;macos[- ]only&#34; --include=*.md --include=*.sh . | grep -i orca` — confirmed no stale Orca macOS-only claim survives anywhere in the repo</code>
- <code>`git diff --stat &lt;base&gt;..HEAD -- bin/backends/` — confirmed zero backend code changes</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
