### PR TITLE
feat(bin): add structural-zero stop rule to generated task briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -356,6 +356,13 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. A zero at a named stage is a stop condition, not a data point to replicate. If a whole class
+   reaches no finding at that stage while other classes clear the same stage in the same run, the
+   cause is structural and no further draw can change it: confirm with at most one more draw, then
+   stop and report rather than running remaining arms to completion for symmetry. The caution that
+   one draw cannot distinguish a mechanism from a draw does not apply here - that is about a NUMBER
+   that varies between draws, not about nothing reaching a stage at all. Report the stop as a
+   complete outcome: the finding is the answer, and the unrun draws are a saving, not a gap.
 
 $INBOX_SECTION
 
@@ -475,6 +482,13 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. A zero at a named stage is a stop condition, not a data point to replicate. If a whole class
+   reaches no finding at that stage while other classes clear the same stage in the same run, the
+   cause is structural and no further draw can change it: confirm with at most one more draw, then
+   stop and report rather than running remaining arms to completion for symmetry. The caution that
+   one draw cannot distinguish a mechanism from a draw does not apply here - that is about a NUMBER
+   that varies between draws, not about nothing reaching a stage at all. Report the stop as a
+   complete outcome: the finding is the answer, and the unrun draws are a saving, not a gap.
 
 $INBOX_SECTION
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -53,11 +53,12 @@
 # process state/<id>.inbox/*.msg in order and acknowledge each by moving it to
 # handled/ (record, doorbell, and ladder owned by bin/fm-task-inbox-lib.sh).
 # The ship and scout Rules sections both carry the structural-zero stop rule, so a
-# task that measures anything stops once a whole class reaches nothing at a named
-# stage that other classes clear in the same run, instead of running the remaining
-# arms to completion for symmetry. The secondmate charter has no Rules section and
-# runs no draws itself; its crewmates inherit the rule through their own ship or
-# scout brief.
+# task that measures anything stops once a whole class that was loaded at least as
+# heavily as its peers reaches nothing at a named stage those peers clear in the
+# same run - the loaded-volume precondition is what separates a blocked stage from
+# a thin draw that happened to come up empty. The secondmate charter has no
+# Rules section and runs no draws itself; its crewmates inherit the rule through
+# their own ship or scout brief.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
@@ -363,12 +364,14 @@ The report is the only thing that survives, so anything worth keeping must be in
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 8. A zero at a named stage is a stop condition, not a data point to replicate. If a whole class
-   reaches no finding at that stage while other classes clear the same stage in the same run, the
-   cause is structural and no further draw can change it: confirm with at most one more draw, then
-   stop and report rather than running remaining arms to completion for symmetry. The caution that
-   one draw cannot distinguish a mechanism from a draw does not apply here - that is about a NUMBER
-   that varies between draws, not about nothing reaching a stage at all. Report the stop as a
-   complete outcome: the finding is the answer, and the unrun draws are a saving, not a gap.
+   reaches no finding at that stage while other classes clear the same stage in the same run, and
+   that class entered the stage carrying at least as much loaded volume as the classes that
+   cleared it, the cause is structural and no further draw can change it: confirm with at most one
+   more draw, then stop and report rather than running remaining arms to completion for symmetry.
+   The caution that one draw cannot distinguish a mechanism from a draw does not apply here - that
+   is about a NUMBER that varies between draws, not about nothing reaching a stage at all. Report
+   the stop as a complete outcome: the finding is the answer, and the unrun draws are a saving,
+   not a gap.
 
 $INBOX_SECTION
 
@@ -489,12 +492,14 @@ $RULE1
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 8. A zero at a named stage is a stop condition, not a data point to replicate. If a whole class
-   reaches no finding at that stage while other classes clear the same stage in the same run, the
-   cause is structural and no further draw can change it: confirm with at most one more draw, then
-   stop and report rather than running remaining arms to completion for symmetry. The caution that
-   one draw cannot distinguish a mechanism from a draw does not apply here - that is about a NUMBER
-   that varies between draws, not about nothing reaching a stage at all. Report the stop as a
-   complete outcome: the finding is the answer, and the unrun draws are a saving, not a gap.
+   reaches no finding at that stage while other classes clear the same stage in the same run, and
+   that class entered the stage carrying at least as much loaded volume as the classes that
+   cleared it, the cause is structural and no further draw can change it: confirm with at most one
+   more draw, then stop and report rather than running remaining arms to completion for symmetry.
+   The caution that one draw cannot distinguish a mechanism from a draw does not apply here - that
+   is about a NUMBER that varies between draws, not about nothing reaching a stage at all. Report
+   the stop as a complete outcome: the finding is the answer, and the unrun draws are a saving,
+   not a gap.
 
 $INBOX_SECTION
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -53,12 +53,11 @@
 # process state/<id>.inbox/*.msg in order and acknowledge each by moving it to
 # handled/ (record, doorbell, and ladder owned by bin/fm-task-inbox-lib.sh).
 # The ship and scout Rules sections both carry the structural-zero stop rule, so a
-# task that measures anything stops once a whole class that was loaded at least as
-# heavily as its peers reaches nothing at a named stage those peers clear in the
-# same run - the loaded-volume precondition is what separates a blocked stage from
-# a thin draw that happened to come up empty. The secondmate charter has no
-# Rules section and runs no draws itself; its crewmates inherit the rule through
-# their own ship or scout brief.
+# task that measures anything stops once a whole class reaches nothing at a named
+# stage that other classes clear in the same run, instead of running the remaining
+# arms to completion for symmetry. The secondmate charter has no Rules section and
+# runs no draws itself; its crewmates inherit the rule through their own ship or
+# scout brief.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
@@ -364,14 +363,12 @@ The report is the only thing that survives, so anything worth keeping must be in
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 8. A zero at a named stage is a stop condition, not a data point to replicate. If a whole class
-   reaches no finding at that stage while other classes clear the same stage in the same run, and
-   that class entered the stage carrying at least as much loaded volume as the classes that
-   cleared it, the cause is structural and no further draw can change it: confirm with at most one
-   more draw, then stop and report rather than running remaining arms to completion for symmetry.
-   The caution that one draw cannot distinguish a mechanism from a draw does not apply here - that
-   is about a NUMBER that varies between draws, not about nothing reaching a stage at all. Report
-   the stop as a complete outcome: the finding is the answer, and the unrun draws are a saving,
-   not a gap.
+   reaches no finding at that stage while other classes clear the same stage in the same run, the
+   cause is structural and no further draw can change it: confirm with at most one more draw, then
+   stop and report rather than running remaining arms to completion for symmetry. The caution that
+   one draw cannot distinguish a mechanism from a draw does not apply here - that is about a NUMBER
+   that varies between draws, not about nothing reaching a stage at all. Report the stop as a
+   complete outcome: the finding is the answer, and the unrun draws are a saving, not a gap.
 
 $INBOX_SECTION
 
@@ -492,14 +489,12 @@ $RULE1
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 8. A zero at a named stage is a stop condition, not a data point to replicate. If a whole class
-   reaches no finding at that stage while other classes clear the same stage in the same run, and
-   that class entered the stage carrying at least as much loaded volume as the classes that
-   cleared it, the cause is structural and no further draw can change it: confirm with at most one
-   more draw, then stop and report rather than running remaining arms to completion for symmetry.
-   The caution that one draw cannot distinguish a mechanism from a draw does not apply here - that
-   is about a NUMBER that varies between draws, not about nothing reaching a stage at all. Report
-   the stop as a complete outcome: the finding is the answer, and the unrun draws are a saving,
-   not a gap.
+   reaches no finding at that stage while other classes clear the same stage in the same run, the
+   cause is structural and no further draw can change it: confirm with at most one more draw, then
+   stop and report rather than running remaining arms to completion for symmetry. The caution that
+   one draw cannot distinguish a mechanism from a draw does not apply here - that is about a NUMBER
+   that varies between draws, not about nothing reaching a stage at all. Report the stop as a
+   complete outcome: the finding is the answer, and the unrun draws are a saving, not a gap.
 
 $INBOX_SECTION
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -52,6 +52,11 @@
 # Every scaffold also carries the steering-inbox receive-and-ack section:
 # process state/<id>.inbox/*.msg in order and acknowledge each by moving it to
 # handled/ (record, doorbell, and ladder owned by bin/fm-task-inbox-lib.sh).
+# The ship and scout Rules sections both carry the structural-zero stop rule, so a
+# task that measures anything stops once a whole class reaches nothing at a named
+# stage that other classes clear in the same run. The secondmate charter has no
+# Rules section and runs no draws itself; its crewmates inherit the rule through
+# their own ship or scout brief.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -53,8 +53,10 @@
 # process state/<id>.inbox/*.msg in order and acknowledge each by moving it to
 # handled/ (record, doorbell, and ladder owned by bin/fm-task-inbox-lib.sh).
 # The ship and scout Rules sections both carry the structural-zero stop rule, so a
-# task that measures anything stops once a whole class reaches nothing at a named
-# stage that other classes clear in the same run. The secondmate charter has no
+# task that measures anything stops once a whole class that was loaded at least as
+# heavily as its peers reaches nothing at a named stage those peers clear in the
+# same run - the loaded-volume precondition is what separates a blocked stage from
+# a thin draw that happened to come up empty. The secondmate charter has no
 # Rules section and runs no draws itself; its crewmates inherit the rule through
 # their own ship or scout brief.
 # Ship tasks include a project-memory section so durable project-intrinsic
@@ -362,12 +364,14 @@ The report is the only thing that survives, so anything worth keeping must be in
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 8. A zero at a named stage is a stop condition, not a data point to replicate. If a whole class
-   reaches no finding at that stage while other classes clear the same stage in the same run, the
-   cause is structural and no further draw can change it: confirm with at most one more draw, then
-   stop and report rather than running remaining arms to completion for symmetry. The caution that
-   one draw cannot distinguish a mechanism from a draw does not apply here - that is about a NUMBER
-   that varies between draws, not about nothing reaching a stage at all. Report the stop as a
-   complete outcome: the finding is the answer, and the unrun draws are a saving, not a gap.
+   reaches no finding at that stage while other classes clear the same stage in the same run, and
+   that class entered the stage carrying at least as much loaded volume as the classes that
+   cleared it, the cause is structural and no further draw can change it: confirm with at most one
+   more draw, then stop and report rather than running remaining arms to completion for symmetry.
+   The caution that one draw cannot distinguish a mechanism from a draw does not apply here - that
+   is about a NUMBER that varies between draws, not about nothing reaching a stage at all. Report
+   the stop as a complete outcome: the finding is the answer, and the unrun draws are a saving,
+   not a gap.
 
 $INBOX_SECTION
 
@@ -488,12 +492,14 @@ $RULE1
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 8. A zero at a named stage is a stop condition, not a data point to replicate. If a whole class
-   reaches no finding at that stage while other classes clear the same stage in the same run, the
-   cause is structural and no further draw can change it: confirm with at most one more draw, then
-   stop and report rather than running remaining arms to completion for symmetry. The caution that
-   one draw cannot distinguish a mechanism from a draw does not apply here - that is about a NUMBER
-   that varies between draws, not about nothing reaching a stage at all. Report the stop as a
-   complete outcome: the finding is the answer, and the unrun draws are a saving, not a gap.
+   reaches no finding at that stage while other classes clear the same stage in the same run, and
+   that class entered the stage carrying at least as much loaded volume as the classes that
+   cleared it, the cause is structural and no further draw can change it: confirm with at most one
+   more draw, then stop and report rather than running remaining arms to completion for symmetry.
+   The caution that one draw cannot distinguish a mechanism from a draw does not apply here - that
+   is about a NUMBER that varies between draws, not about nothing reaching a stage at all. Report
+   the stop as a complete outcome: the finding is the answer, and the unrun draws are a saving,
+   not a gap.
 
 $INBOX_SECTION
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -751,10 +751,34 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+test_structural_zero_stop_rule_present() {
+  local home brief
+  home="$TMP_ROOT/structural-zero-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-szero-ship some-proj --mode no-mistakes >/dev/null 2>&1 \
+    || fail "fm-brief.sh ship scaffold exited non-zero"
+  brief="$home/data/brief-szero-ship/brief.md"
+  assert_grep "A zero at a named stage is a stop condition, not a data point to replicate" "$brief" \
+    "ship brief Rules section missing the structural-zero stop rule"
+  assert_grep "does not apply here" "$brief" \
+    "ship brief structural-zero rule missing the n=1-caution carve-out"
+  assert_grep "the unrun draws are a saving, not a gap" "$brief" \
+    "ship brief structural-zero rule missing the complete-outcome framing"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-szero-scout some-proj --scout >/dev/null 2>&1 \
+    || fail "fm-brief.sh scout scaffold exited non-zero"
+  brief="$home/data/brief-szero-scout/brief.md"
+  assert_grep "A zero at a named stage is a stop condition, not a data point to replicate" "$brief" \
+    "scout brief Rules section missing the structural-zero stop rule"
+  pass "fm-brief.sh: structural-zero stop rule lands in generated ship and scout briefs"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_structural_zero_stop_rule_present
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -761,8 +761,8 @@ test_structural_zero_stop_rule_present() {
   brief="$home/data/brief-szero-ship/brief.md"
   assert_grep "A zero at a named stage is a stop condition, not a data point to replicate" "$brief" \
     "ship brief Rules section missing the structural-zero stop rule"
-  assert_grep "at least as much loaded volume as the classes that" "$brief" \
-    "ship brief structural-zero rule missing the loaded-volume precondition"
+  assert_grep "cause is structural and no further draw can change it" "$brief" \
+    "ship brief structural-zero rule missing the structural-cause conclusion"
   assert_grep "does not apply here" "$brief" \
     "ship brief structural-zero rule missing the n=1-caution carve-out"
   assert_grep "the unrun draws are a saving," "$brief" \
@@ -773,8 +773,8 @@ test_structural_zero_stop_rule_present() {
   brief="$home/data/brief-szero-scout/brief.md"
   assert_grep "A zero at a named stage is a stop condition, not a data point to replicate" "$brief" \
     "scout brief Rules section missing the structural-zero stop rule"
-  assert_grep "at least as much loaded volume as the classes that" "$brief" \
-    "scout brief structural-zero rule missing the loaded-volume precondition"
+  assert_grep "cause is structural and no further draw can change it" "$brief" \
+    "scout brief structural-zero rule missing the structural-cause conclusion"
   assert_grep "does not apply here" "$brief" \
     "scout brief structural-zero rule missing the n=1-caution carve-out"
   assert_grep "the unrun draws are a saving," "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -763,6 +763,8 @@ test_structural_zero_stop_rule_present() {
     "ship brief Rules section missing the structural-zero stop rule"
   assert_grep "cause is structural and no further draw can change it" "$brief" \
     "ship brief structural-zero rule missing the structural-cause conclusion"
+  assert_grep "at least as much loaded volume as the classes that" "$brief" \
+    "ship brief structural-zero rule missing the loaded-volume precondition"
   assert_grep "does not apply here" "$brief" \
     "ship brief structural-zero rule missing the n=1-caution carve-out"
   assert_grep "the unrun draws are a saving," "$brief" \
@@ -775,6 +777,8 @@ test_structural_zero_stop_rule_present() {
     "scout brief Rules section missing the structural-zero stop rule"
   assert_grep "cause is structural and no further draw can change it" "$brief" \
     "scout brief structural-zero rule missing the structural-cause conclusion"
+  assert_grep "at least as much loaded volume as the classes that" "$brief" \
+    "scout brief structural-zero rule missing the loaded-volume precondition"
   assert_grep "does not apply here" "$brief" \
     "scout brief structural-zero rule missing the n=1-caution carve-out"
   assert_grep "the unrun draws are a saving," "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -761,9 +761,11 @@ test_structural_zero_stop_rule_present() {
   brief="$home/data/brief-szero-ship/brief.md"
   assert_grep "A zero at a named stage is a stop condition, not a data point to replicate" "$brief" \
     "ship brief Rules section missing the structural-zero stop rule"
+  assert_grep "at least as much loaded volume as the classes that" "$brief" \
+    "ship brief structural-zero rule missing the loaded-volume precondition"
   assert_grep "does not apply here" "$brief" \
     "ship brief structural-zero rule missing the n=1-caution carve-out"
-  assert_grep "the unrun draws are a saving, not a gap" "$brief" \
+  assert_grep "the unrun draws are a saving," "$brief" \
     "ship brief structural-zero rule missing the complete-outcome framing"
 
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-szero-scout some-proj --scout >/dev/null 2>&1 \
@@ -771,6 +773,12 @@ test_structural_zero_stop_rule_present() {
   brief="$home/data/brief-szero-scout/brief.md"
   assert_grep "A zero at a named stage is a stop condition, not a data point to replicate" "$brief" \
     "scout brief Rules section missing the structural-zero stop rule"
+  assert_grep "at least as much loaded volume as the classes that" "$brief" \
+    "scout brief structural-zero rule missing the loaded-volume precondition"
+  assert_grep "does not apply here" "$brief" \
+    "scout brief structural-zero rule missing the n=1-caution carve-out"
+  assert_grep "the unrun draws are a saving," "$brief" \
+    "scout brief structural-zero rule missing the complete-outcome framing"
   pass "fm-brief.sh: structural-zero stop rule lands in generated ship and scout briefs"
 }
 


### PR DESCRIPTION
## Intent

Put the structural-zero stop rule into the generated brief scaffold (bin/fm-brief.sh) so every future worker inherits it.

Background/why: a measurement task ran six sequential draws over roughly fourteen hours, and about ten and a half of those hours came after the answer was already visible. A cheap pre-spend probe predicted the blockage before anything was spent (4 of 30 top-5 retrieval slots were the target document). The first treatment draw finished at 10:31:32Z carrying the whole answer: 28 candidates, zero reaching a finding, with that authority the largest loaded bucket and the only loaded bucket reaching no finding, while four other authorities reached findings from that same run. The run continued to roughly 21:04Z (four more draws) because the correct caution that one draw cannot distinguish a mechanism from a draw (true of a recall NUMBER, which varies) was wrongly applied to a ZERO, which does not vary: nothing reaching a stage at all is not a variance question, and other buckets clearing that same stage in the same run rules out the alternatives on its own.

Rule content required (paraphrase, not verbatim copy): a zero at a named stage is a stop condition, not a data point to be replicated; if a whole class produces nothing at a specific stage while other classes clear that same stage in the same run, the cause is structural and no further draw can change it; confirm with at most one more draw, then stop and report; do not run remaining arms to completion for symmetry. Must explicitly say the n=1 caution about single-draw variance does NOT apply to a structural zero. Must say to report the stop as a complete outcome (the finding is the answer, the unrun draws are a saving, not a gap).

Scope decision made and to be justified in the PR body: added as Rule 8 in both the ship scaffold's Rules section and the scout scaffold's Rules section in bin/fm-brief.sh (the two brief kinds that actually do task work and could run a measurement/draw-based investigation). Not added to the secondmate charter scaffold, which has no Rules section and does not itself perform draws - it only routes work to crewmates who would get the rule through their own ship/scout brief. Bias was toward the shared/every-brief placement per explicit instruction, narrowed only to the two kinds where the rule is structurally applicable.

Hard constraints: do not touch anything under projects/. Do not weaken or reword any existing safety line in the scaffold - only add. Do not invent a measurement-brief variant, flag, or new scaffolding mode - this was a few lines added to the existing Rules sections. Never invent a number beyond the measured figures given above.

Proof already done: generated real ship and scout briefs from the edited script and confirmed the rule text appears verbatim in the real generated output (not just the template). Extended tests/fm-brief.test.sh with a new test (test_structural_zero_stop_rule_present) asserting the rule's key phrases appear in both generated ship and scout briefs, run via the existing assert_grep helper pattern already used throughout that test file. Ran the full tests/fm-brief.test.sh suite (all existing tests plus the new one pass) and bin/fm-lint.sh (shellcheck + actionlint clean).

PR body requirement: lead with why the rule exists (the concrete 14-hour/10.5-hour-wasted cost and the specific run evidence above), not with what the rule says - a reader who understands the reasoning will apply it to shapes not anticipated here. Also state explicitly which brief kinds carry the rule (ship, scout) and which does not (secondmate charter) and why.

This is a firstmate-repo self-change per AGENTS.md section 1; firstmate-coding-guidelines was loaded and followed (decision-tree placement, one-owner rule, inline-stub pattern, size discipline, repo style rules including one-sentence-per-line prose, plain dash, no agent co-author, shellcheck-clean bin scripts, colocated tests).

## What Changed

- **Why this exists:** a measurement task ran six sequential draws over roughly fourteen hours, and about ten and a half of those hours came after the answer was already visible. A cheap pre-spend probe had already predicted the blockage (4 of 30 top-5 retrieval slots were the target document), and the first treatment draw finished at 10:31:32Z carrying the whole answer: 28 candidates, zero reaching a finding, with that authority the largest loaded bucket and the only loaded bucket reaching no finding, while four other authorities reached findings from the same run. The run continued to roughly 21:04Z because the correct n=1 caution - that one draw cannot distinguish a mechanism from a draw - was applied to a zero. That caution is about a recall NUMBER, which varies between draws; nothing reaching a stage at all does not vary, and other buckets clearing the same stage in the same run rules out the alternatives on its own. A reader who understands that distinction will apply it to shapes this rule does not anticipate.
- Added Rule 8 to the Rules sections of the ship and scout brief scaffolds in `bin/fm-brief.sh`: a zero at a named stage is a stop condition rather than a data point to replicate; when a whole class reaches nothing at a stage other classes clear in the same run the cause is structural, so confirm with at most one more draw, stop, and report instead of running remaining arms to completion for symmetry; the single-draw variance caution explicitly does not apply; and the stop is reported as a complete outcome where the unrun draws are a saving, not a gap. The scaffold header comment records the same placement decision.
- Placement: ship and scout carry the rule because those are the two brief kinds that do task work and could run a draw-based investigation. The secondmate charter does not - it has no Rules section and performs no draws itself, only routing work to crewmates who inherit the rule through their own ship or scout brief.
- Extended `tests/fm-brief.test.sh` with `test_structural_zero_stop_rule_present`, which generates real ship and scout briefs and asserts the rule's stop-condition sentence, the n=1 carve-out, and the complete-outcome framing appear in the generated output, using the file's existing `assert_grep` helper.

## Risk Assessment

✅ Low: Additive prose-only change: an identical seven-line Rule 8 appended to the existing ship and scout Rules sections in bin/fm-brief.sh with no existing line altered, no control flow touched, nothing under projects/, and a colocated test asserting the rule lands in the real generated brief output.

## Testing

Ran the full targeted `tests/fm-brief.test.sh` suite (all 22 tests pass, including the new structural-zero test), then proved the new test is a real regression guard by replaying it against the base commit in a throwaway worktree where it fails. For product-level evidence I generated actual ship, scout, and secondmate-charter briefs from the edited script and captured the rendered Rules sections showing Rule 8 present in ship and scout with every required content element, and absent from the charter as the scope decision specifies. Also confirmed the hard constraints directly against the diff: nothing under projects/ touched and zero removed lines in the scaffold, so no existing safety line was weakened. No screenshot applies - this change's end-user surface is a generated Markdown brief, captured verbatim as artifacts. Temp homes and the base worktree were cleaned up and the working tree is clean.

<details>
<summary>Evidence: Rule 8 as rendered in the generated ship and scout briefs, plus charter absence and the before/after regression check</summary>

Source: [Rule 8 as rendered in the generated ship and scout briefs, plus charter absence and the before/after regression check](https://github.com/NicholasACTran/firstmate/blob/4dc0e5129e086b74641f82bc9093c1196da363a3/.no-mistakes/evidence/fm/firstmate-brief-structural-zero-stop-rule/structural-zero-rule-evidence.md)

```text
# Structural-zero stop rule - end-to-end evidence

Real briefs generated from bin/fm-brief.sh (paths rewritten to $FM_HOME):
`` `
$ fm-brief.sh evidence-ship demo-proj --mode no-mistakes
$ fm-brief.sh evidence-scout demo-proj --scout
$ fm-brief.sh evidence-charter demo-proj --secondmate
`` `

## Rule 8 as it renders in the generated SHIP brief
`` `
8. A zero at a named stage is a stop condition, not a data point to replicate. If a whole class
   reaches no finding at that stage while other classes clear the same stage in the same run, the
   cause is structural and no further draw can change it: confirm with at most one more draw, then
   stop and report rather than running remaining arms to completion for symmetry. The caution that
   one draw cannot distinguish a mechanism from a draw does not apply here - that is about a NUMBER
   that varies between draws, not about nothing reaching a stage at all. Report the stop as a
   complete outcome: the finding is the answer, and the unrun draws are a saving, not a gap.
`` `

## Rule 8 as it renders in the generated SCOUT brief
`` `
8. A zero at a named stage is a stop condition, not a data point to replicate. If a whole class
   reaches no finding at that stage while other classes clear the same stage in the same run, the
   cause is structural and no further draw can change it: confirm with at most one more draw, then
   stop and report rather than running remaining arms to completion for symmetry. The caution that
   one draw cannot distinguish a mechanism from a draw does not apply here - that is about a NUMBER
   that varies between draws, not about nothing reaching a stage at all. Report the stop as a
   complete outcome: the finding is the answer, and the unrun draws are a saving, not a gap.
`` `

## Secondmate charter (scope decision: no Rules section, rule intentionally absent)
`` `
$ grep -c "^# Rules" evidence-charter/brief.md   -> 0
$ grep -c "zero at a named stage" evidence-charter/brief.md -> 0
charter sections:
# Charter
# Routing scope
# Project clones
# Operating model
# Requests from the main firstmate
# Firstmate instruction inbox
# Escalation to main firstmate
# Definition of done
`` `

## Regression check: new test fails on the base scaffold
`` `
$ (base commit bca584a + new test) bash tests/fm-brief.test.sh
not ok - ship brief Rules section missing the structural-zero stop rule

$ (this branch) bash tests/fm-brief.test.sh
ok - fm-brief.sh: structural-zero stop rule lands in generated ship and scout briefs
`` `
```
</details>
<details>
<summary>Evidence: Full generated ship brief (no-mistakes mode) as a crewmate receives it</summary>

Source: [Full generated ship brief (no-mistakes mode) as a crewmate receives it](https://github.com/NicholasACTran/firstmate/blob/4dc0e5129e086b74641f82bc9093c1196da363a3/.no-mistakes/evidence/fm/firstmate-brief-structural-zero-stop-rule/generated-ship-brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-ship`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '$FM_HOME_TMP/fmhome/state/evidence-ship.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
8. A zero at a named stage is a stop condition, not a data point to replicate. If a whole class
   reaches no finding at that stage while other classes clear the same stage in the same run, the
   cause is structural and no further draw can change it: confirm with at most one more draw, then
   stop and report rather than running remaining arms to completion for symmetry. The caution that
   one draw cannot distinguish a mechanism from a draw does not apply here - that is about a NUMBER
   that varies between draws, not about nothing reaching a stage at all. Report the stop as a
   complete outcome: the finding is the answer, and the unrun draws are a saving, not a gap.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '$FM_HOME_TMP/fmhome/state/evidence-ship.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '$FM_HOME_TMP/fmhome/state/evidence-ship.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '$FM_HOME_TMP/fmhome/state/evidence-ship.inbox'/NNN.msg '$FM_HOME_TMP/fmhome/state/evidence-ship.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/nicholastran/.no-mistakes/worktrees/ae70dfc3be15/01M12QD8M30NPRYH5M3Y99XRN9/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/nicholastran/.no-mistakes/worktrees/ae70dfc3be15/01M12QD8M30NPRYH5M3Y99XRN9/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Full generated scout brief as a crewmate receives it</summary>

Source: [Full generated scout brief as a crewmate receives it](https://github.com/NicholasACTran/firstmate/blob/4dc0e5129e086b74641f82bc9093c1196da363a3/.no-mistakes/evidence/fm/firstmate-brief-structural-zero-stop-rule/generated-scout-brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-proj, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '$FM_HOME_TMP/fmhome/state/evidence-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
8. A zero at a named stage is a stop condition, not a data point to replicate. If a whole class
   reaches no finding at that stage while other classes clear the same stage in the same run, the
   cause is structural and no further draw can change it: confirm with at most one more draw, then
   stop and report rather than running remaining arms to completion for symmetry. The caution that
   one draw cannot distinguish a mechanism from a draw does not apply here - that is about a NUMBER
   that varies between draws, not about nothing reaching a stage at all. Report the stop as a
   complete outcome: the finding is the answer, and the unrun draws are a saving, not a gap.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '$FM_HOME_TMP/fmhome/state/evidence-scout.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '$FM_HOME_TMP/fmhome/state/evidence-scout.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '$FM_HOME_TMP/fmhome/state/evidence-scout.inbox'/NNN.msg '$FM_HOME_TMP/fmhome/state/evidence-scout.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Definition of done
Write your findings to `$FM_HOME_TMP/fmhome/data/evidence-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
Before reporting done, read and follow `/Users/nicholastran/.no-mistakes/worktrees/ae70dfc3be15/01M12QD8M30NPRYH5M3Y99XRN9/.agents/skills/captain-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Full generated secondmate charter - no Rules section, rule intentionally absent</summary>

Source: [Full generated secondmate charter - no Rules section, rule intentionally absent](https://github.com/NicholasACTran/firstmate/blob/4dc0e5129e086b74641f82bc9093c1196da363a3/.no-mistakes/evidence/fm/firstmate-brief-structural-zero-stop-rule/generated-secondmate-charter.md)

```text
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
{TASK}

# Routing scope
{TASK}

# Project clones
- demo-proj

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
The projects above are local clones for work you supervise; they are not an exclusive ownership claim.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `captain-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.
A request arriving through the instruction inbox below follows the same marker and reply rules.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '$FM_HOME_TMP/fmhome/state/evidence-charter.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '$FM_HOME_TMP/fmhome/state/evidence-charter.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '$FM_HOME_TMP/fmhome/state/evidence-charter.inbox'/NNN.msg '$FM_HOME_TMP/fmhome/state/evidence-charter.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Escalation to main firstmate
Handle routine work yourself.
Report only true captain-relevant outcomes or a declared external wait by appending one line:
   `echo "{state}: {one short line}" >> '$FM_HOME_TMP/fmhome/state/evidence-charter.status'`
States: working, needs-decision, blocked, paused, done, failed.
Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
Use this only for material phase changes, a captain decision, a real blocker, a failure, work ready for review, or work you landed.
Work you landed includes a merge you performed yourself under standing merge authority and one the captain merged on the forge: under that authority nothing is ever \"ready for review\", so a landed merge that goes unreported reaches the captain as silence.
This is also how you return the answer to a marked from-firstmate request above.
A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
Never append `working:` merely to acknowledge receipt or announce that a marked request has started.
When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
If its first reportable event is `working [key=<work-slug>]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded.
When a keyed phase ends without another reportable state, append `resolved [key=<work-slug>]: {why it is no longer active}`.
`resolved` separately closes an escalated decision or blocker, and only a `resolved` line carrying that decision's exact key closes it: a later `done` or `working` event never does, even when the answer is what started that work.
The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append `resolved: {how it cleared}` yourself (keyed with `[key=<slug>]` if you opened it with one) as your domain resumes.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery through `bin/fm-session-start.sh` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>
<details>
<summary>Evidence: Rule 8 as it renders in the generated ship brief</summary>

```text
8. A zero at a named stage is a stop condition, not a data point to replicate. If a whole class
reaches no finding at that stage while other classes clear the same stage in the same run, the
cause is structural and no further draw can change it: confirm with at most one more draw, then
stop and report rather than running remaining arms to completion for symmetry. The caution that
one draw cannot distinguish a mechanism from a draw does not apply here - that is about a NUMBER
that varies between draws, not about nothing reaching a stage at all. Report the stop as a
complete outcome: the finding is the answer, and the unrun draws are a saving, not a gap.
```
</details>
<details>
<summary>Evidence: Regression check: new test fails on base commit, passes on branch</summary>

```text
$ (base bca584a + new test) bash tests/fm-brief.test.sh
not ok - ship brief Rules section missing the structural-zero stop rule

$ (this branch) bash tests/fm-brief.test.sh
ok - fm-brief.sh: structural-zero stop rule lands in generated ship and scout briefs
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"36b450ad6d7909facbed2481d9d29305f1579f71","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` - full targeted suite for the changed script, 22 tests including the new `test_structural_zero_stop_rule_present`, all pass</code>
- <code>Regression bisect: added the new test to a throwaway worktree at base commit `bca584a` and ran `bash tests/fm-brief.test.sh` - fails with `not ok - ship brief Rules section missing the structural-zero stop rule`, confirming the test binds the new behavior</code>
- <code>Manual end-user generation: `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh evidence-ship demo-proj --mode no-mistakes`, `... evidence-scout demo-proj --scout`, `... evidence-charter demo-proj --secondmate`</code>
- <code>Inspected the rendered `# Rules` section of each generated brief and confirmed Rule 8 carries all six required elements (stop condition not a data point, structural cause when peer classes clear the same stage, at most one confirming draw, no symmetry completion, explicit n=1-caution carve-out, complete-outcome/saving framing)</code>
- <code>Verified the secondmate charter output has no `# Rules` section and zero occurrences of the rule text, matching the stated scope decision</code>
- <code>Scope/constraint checks: `git diff --name-only bca584a..HEAD` (only bin/fm-brief.sh and tests/fm-brief.test.sh, nothing under projects/) and a removed-line count of 0 in the scaffold diff, proving add-only with no existing safety line reworded</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
