### PR TITLE
fix(pi): surface requested outcomes without replaying fleet events

### DIFF
--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -592,8 +592,8 @@ export default function (pi: ExtensionAPI) {
   // happens main can lose the outcome while deciding how to handle it. The
   // typed operational envelope is what makes the note self-describing; it stays
   // invisible to the captain because the note is never rendered. The
-  // instruction preserves the event-ownership boundary without dictating
-  // whether main surfaces the content.
+  // instruction preserves the event-ownership boundary while requiring the
+  // captain-facing response and leaving its wording to main.
   //
   // Encoding shells out, so it can fail on a broken checkout. This file's
   // failure direction applies: an outcome that cannot be typed is still

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -97,7 +97,7 @@ import {
   type BranchPickerItem,
 } from "./lib/fm-branch-model-picker.ts";
 import {
-  classifyFirstmateCurrentOperationalText,
+  classifyFirstmateOperationalText,
   encodeFirstmateOperationalInput,
 } from "./lib/fm-operational-input.ts";
 
@@ -307,7 +307,7 @@ function textOfContent(content: unknown): string {
 // analysis counts them apart from dialog, and mirroring them would feed the
 // branch its own supervision traffic back.
 function isOperationalUserText(text: string): boolean {
-  return classifyFirstmateCurrentOperationalText(text) !== undefined;
+  return classifyFirstmateOperationalText(text) !== undefined;
 }
 
 function capMirrorText(text: string): string {

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -96,7 +96,10 @@ import {
   FOLLOW_MAIN_VALUE,
   type BranchPickerItem,
 } from "./lib/fm-branch-model-picker.ts";
-import { encodeFirstmateOperationalInput } from "./lib/fm-operational-input.ts";
+import {
+  classifyFirstmateCurrentOperationalText,
+  encodeFirstmateOperationalInput,
+} from "./lib/fm-operational-input.ts";
 
 const extensionFile = fileURLToPath(import.meta.url);
 const extensionDir = dirname(extensionFile);
@@ -302,10 +305,9 @@ function textOfContent(content: unknown): string {
 // Operational injections (watcher wakes, away-supervisor escalations, launch
 // briefs) are fleet machinery, not captain dialog; the report's volume
 // analysis counts them apart from dialog, and mirroring them would feed the
-// branch its own supervision traffic back. Current injections start with the
-// U+2063 operational prefix; the plain legacy form starts with FIRSTMATE.
+// branch its own supervision traffic back.
 function isOperationalUserText(text: string): boolean {
-  return text.startsWith("⁣") || /^FIRSTMATE[ _]/.test(text);
+  return classifyFirstmateCurrentOperationalText(text) !== undefined;
 }
 
 function capMirrorText(text: string): string {

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -130,21 +130,17 @@ const MERGE_NOTE_BOAT = "⛵";
 // Carried inside the captain note's own text because that text is the only
 // part of a custom message Pi gives the model (see mergeIntoMain).
 //
-// The relay order is CONDITIONAL on purpose. This M1 fix is deliberately a
-// model-facing instruction only: mergeIntoMain must keep opening the follow-up
-// turn so a genuinely new outcome cannot be suppressed before main sees it.
-// The note still needs its self-description to stop main from mistaking an
-// incoming outcome for its own earlier answer and silently losing the outcome.
-// But an unconditional relay order is false whenever main was separately woken
-// for the same event, and turns the correct response - saying nothing new -
-// into a mechanical re-report. The conditional wording lets main stay quiet
-// when appropriate; source-level identity suppression is outside this M1 fix.
+// The note still needs to identify itself so main cannot mistake an incoming
+// outcome for its own earlier answer and silently lose the outcome. It must not
+// decide the conversational treatment, though: event ownership forbids a
+// second fleet operation, while main uses judgment about what the captain
+// should see and how to say it.
 const CAPTAIN_OUTCOME_INSTRUCTION =
   "This is a supervision outcome delivered automatically by the supervision branch. " +
   "It was not typed by the captain. " +
-  "If you have already reported this outcome to the captain earlier in this conversation, do not report it again. " +
-  "Otherwise relay only this outcome to the captain now, in one short message, in captain outcome language. " +
-  "Do not restate or repeat any earlier answer.";
+  "The fleet event is already handled: do not re-drain, re-run, or acknowledge it. " +
+  "Use your judgment about whether and how to surface, summarize, reference, or incorporate this outcome in the captain conversation. " +
+  "An outcome that directly answers an explicit captain request is captain-facing, regardless of whether it is healthy, routine, measured, actionable, or requires a decision.";
 type MirrorItem = { tag: "captain" | "main"; text: string };
 type MirrorCursor = { file: string; index: number };
 type Verdict = "routine" | "captain";
@@ -573,10 +569,11 @@ export default function (pi: ExtensionAPI) {
   // therefore has to carry its own identity inside `content`, or main receives
   // an unattributed user message written in main's own captain-facing voice
   // and cannot tell an incoming outcome from its own earlier answer. When that
-  // happens main re-emits its previous answer instead of relaying the outcome,
-  // and the outcome is lost. The typed operational envelope is what makes the
-  // note self-describing; it stays invisible to the captain because the note
-  // is never rendered.
+  // happens main can lose the outcome while deciding how to handle it. The
+  // typed operational envelope is what makes the note self-describing; it stays
+  // invisible to the captain because the note is never rendered. The
+  // instruction preserves the event-ownership boundary without dictating
+  // whether main surfaces the content.
   //
   // Encoding shells out, so it can fail on a broken checkout. This file's
   // failure direction applies: an outcome that cannot be typed is still

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -354,8 +354,20 @@ function collectMainDialog(sessionManager: ReadonlyEntries, collection: MirrorCo
   const entries = sessionManager.getEntries();
   const anchor = collection.collectAnchor ?? readMirrorCursor();
   const start = anchor.file === file ? Math.min(anchor.index, entries.length) : 0;
+  let currentCaptainIndex = -1;
+  for (let index = entries.length - 1; index >= start; index -= 1) {
+    const entry = entries[index];
+    if (entry.type !== "message") continue;
+    const message = (entry as { message?: { role?: string; content?: unknown } }).message;
+    if (message?.role !== "user") continue;
+    const text = textOfContent(message.content).trim();
+    if (!text || isOperationalUserText(text)) continue;
+    currentCaptainIndex = index;
+    break;
+  }
   const items: MirrorItem[] = [];
-  for (const entry of entries.slice(start)) {
+  for (let index = start; index < entries.length; index += 1) {
+    const entry = entries[index];
     if (entry.type !== "message") continue;
     const message = (entry as { message?: { role?: string; content?: unknown } }).message;
     if (!message) continue;
@@ -363,7 +375,10 @@ function collectMainDialog(sessionManager: ReadonlyEntries, collection: MirrorCo
     const text = textOfContent(message.content).trim();
     if (!text) continue;
     if (message.role === "user" && isOperationalUserText(text)) continue;
-    items.push({ tag: message.role === "user" ? "captain" : "main", text: capMirrorText(text) });
+    items.push({
+      tag: message.role === "user" ? "captain" : "main",
+      text: index === currentCaptainIndex ? text : capMirrorText(text),
+    });
   }
   collection.collectAnchor = { file, index: entries.length };
   collection.pendingCursor = collection.collectAnchor;

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -6,8 +6,8 @@
 // real tools and reports through the fm_branch_report custom tool, which
 // writes the durable outcome store FIRST (bin/fm-branch-outcome.sh) and then
 // merges an append-only note to main's tail. Main's captain/assistant dialog
-// is mirrored into the branch as read-only fm-main-mirror context at the
-// pre-dispatch boundary and at main's turn_end. Pi-only by construction: this
+// is mirrored into the branch as read-only fm-main-mirror context from Pi's
+// before_agent_start prompt and at main's turn_end. Pi-only by construction: this
 // file lives in .pi/extensions, so no
 // other harness ever loads it. Supervision is default-on for every task once
 // this Pi session owns the fleet lock: no captain grant file is required.
@@ -347,6 +347,10 @@ type ReadonlyEntries = {
 type MirrorCollectionState = {
   collectAnchor: MirrorCursor | null;
   pendingCursor: MirrorCursor | null;
+  // Pi emits before_agent_start before it appends that turn's user message to
+  // SessionManager. The prompt is mirrored from the event immediately, then
+  // this marker suppresses the same persisted entry when turn_end collects it.
+  stagedCaptain: { file: string; index: number; text: string } | null;
 };
 
 function collectMainDialog(sessionManager: ReadonlyEntries, collection: MirrorCollectionState): MirrorItem[] {
@@ -375,6 +379,16 @@ function collectMainDialog(sessionManager: ReadonlyEntries, collection: MirrorCo
     const text = textOfContent(message.content).trim();
     if (!text) continue;
     if (message.role === "user" && isOperationalUserText(text)) continue;
+    const staged = collection.stagedCaptain;
+    if (
+      message.role === "user" &&
+      staged?.file === file &&
+      staged.index === index &&
+      staged.text === text
+    ) {
+      collection.stagedCaptain = null;
+      continue;
+    }
     items.push({
       tag: message.role === "user" ? "captain" : "main",
       text: index === currentCaptainIndex ? text : capMirrorText(text),
@@ -401,7 +415,11 @@ export default function (pi: ExtensionAPI) {
   // serially by design).
   let branchChain: Promise<void> = Promise.resolve();
   const pendingMirror: MirrorItem[] = [];
-  const mirrorCollection: MirrorCollectionState = { collectAnchor: null, pendingCursor: null };
+  const mirrorCollection: MirrorCollectionState = {
+    collectAnchor: null,
+    pendingCursor: null,
+    stagedCaptain: null,
+  };
   let currentMainSession: ReadonlyEntries | null = null;
   // One revision for BOTH selections: a model or effort change invalidates an
   // in-flight branch build exactly the same way.
@@ -999,9 +1017,22 @@ ${context.command}
     enqueueWake(offer.message, generation);
   });
 
-  pi.on?.("before_agent_start", (_event, ctx) => {
+  pi.on?.("before_agent_start", (event, ctx) => {
     rememberMainModel(ctx);
     currentMainSession = ctx?.sessionManager ?? null;
+    if (!actingAsOwner() || !currentMainSession || !collectCurrentMainDialog()) return;
+
+    // This event is Pi's authoritative complete current prompt. At this point
+    // SessionManager still contains only the preceding dialog, so relying on
+    // getEntries() here loses the captain request that the next wake may answer.
+    // Stage it verbatim and remember the future persisted index for turn_end's
+    // duplicate suppression. Operational extension injections are not dialog.
+    const prompt = event.prompt.trim();
+    if (!prompt || isOperationalUserText(prompt)) return;
+    const file = currentMainSession.getSessionFile() ?? "";
+    const index = mirrorCollection.collectAnchor?.index ?? currentMainSession.getEntries().length;
+    pendingMirror.push({ tag: "captain", text: prompt });
+    mirrorCollection.stagedCaptain = { file, index, text: prompt };
   });
 
   pi.on?.("agent_start", () => {
@@ -1014,8 +1045,9 @@ ${context.command}
     mainStreaming = false;
   });
 
-  // The dispatch handler collects from the live main session immediately
-  // before accepting a wake, so dialog from the current in-flight turn joins
+  // before_agent_start stages Pi's authoritative in-flight prompt before
+  // SessionManager persists it. The dispatch handler then collects any newly
+  // persisted dialog immediately before accepting a wake, so all context joins
   // the serialized chain before that wake's branch prompt. turn_end remains
   // the idle-path mirror flush. The durable cursor advances only in
   // flushMirror after the complete pending batch reaches the branch.
@@ -1076,6 +1108,7 @@ ${context.command}
     currentMainSession = null;
     mirrorCollection.collectAnchor = null;
     mirrorCollection.pendingCursor = null;
+    mirrorCollection.stagedCaptain = null;
     if (branch) {
       try {
         branch.dispose();

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -6,8 +6,9 @@
 // real tools and reports through the fm_branch_report custom tool, which
 // writes the durable outcome store FIRST (bin/fm-branch-outcome.sh) and then
 // merges an append-only note to main's tail. Main's captain/assistant dialog
-// is mirrored into the branch as read-only fm-main-mirror context at main's
-// turn_end. Pi-only by construction: this file lives in .pi/extensions, so no
+// is mirrored into the branch as read-only fm-main-mirror context at the
+// pre-dispatch boundary and at main's turn_end. Pi-only by construction: this
+// file lives in .pi/extensions, so no
 // other harness ever loads it. Supervision is default-on for every task once
 // this Pi session owns the fleet lock: no captain grant file is required.
 // Away mode (or a broken branch) keeps today's wake-to-main behavior
@@ -383,6 +384,7 @@ export default function (pi: ExtensionAPI) {
   let branchChain: Promise<void> = Promise.resolve();
   const pendingMirror: MirrorItem[] = [];
   const mirrorCollection: MirrorCollectionState = { collectAnchor: null, pendingCursor: null };
+  let currentMainSession: ReadonlyEntries | null = null;
   // One revision for BOTH selections: a model or effort change invalidates an
   // in-flight branch build exactly the same way.
   let branchSelectionRevision = 0;
@@ -938,6 +940,16 @@ ${context.command}
       });
   }
 
+  function collectCurrentMainDialog(): boolean {
+    if (!currentMainSession) return true;
+    try {
+      pendingMirror.push(...collectMainDialog(currentMainSession, mirrorCollection));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   function enqueueMirrorFlush(): void {
     if (!branch || pendingMirror.length === 0) return;
     const flushGeneration = generation;
@@ -963,8 +975,14 @@ ${context.command}
     if (!actingAsOwner()) return; // cold start pre-lock, secondary session, or shutdown
     if (afkActive()) return; // the away daemon owns supervision while afk
     if (branchBroken) return; // fail back to today's wake-to-main path
+    if (!collectCurrentMainDialog()) return;
     offer.accept();
     enqueueWake(offer.message, generation);
+  });
+
+  pi.on?.("before_agent_start", (_event, ctx) => {
+    rememberMainModel(ctx);
+    currentMainSession = ctx?.sessionManager ?? null;
   });
 
   pi.on?.("agent_start", () => {
@@ -977,18 +995,15 @@ ${context.command}
     mainStreaming = false;
   });
 
-  // Mirror at main's turn_end: collect the new captain/assistant dialog into
-  // the volatile queue, then deliver it through the serialized chain so it
-  // lands before any later wake. The durable cursor advances only in
+  // The dispatch handler collects from the live main session immediately
+  // before accepting a wake, so dialog from the current in-flight turn joins
+  // the serialized chain before that wake's branch prompt. turn_end remains
+  // the idle-path mirror flush. The durable cursor advances only in
   // flushMirror after the complete pending batch reaches the branch.
   pi.on?.("turn_end", (_event, ctx) => {
     rememberMainModel(ctx);
-    if (!actingAsOwner()) return;
-    try {
-      pendingMirror.push(...collectMainDialog(ctx.sessionManager, mirrorCollection));
-    } catch {
-      return;
-    }
+    currentMainSession = ctx.sessionManager;
+    if (!actingAsOwner() || !collectCurrentMainDialog()) return;
     enqueueMirrorFlush();
   });
 
@@ -1001,6 +1016,7 @@ ${context.command}
   // recorded pointer. Terminal quit simply never fires another session_start.
   pi.on?.("session_start", (_event, ctx) => {
     rememberMainModel(ctx);
+    currentMainSession = ctx?.sessionManager ?? null;
     shuttingDown = false;
     branchBroken = "";
     generation += 1;
@@ -1038,6 +1054,7 @@ ${context.command}
     shuttingDown = true;
     generation += 1;
     pendingMirror.length = 0;
+    currentMainSession = null;
     mirrorCollection.collectAnchor = null;
     mirrorCollection.pendingCursor = null;
     if (branch) {

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -310,7 +310,10 @@ function isOperationalUserText(text: string): boolean {
 
 function capMirrorText(text: string): string {
   if (text.length <= MIRROR_MESSAGE_CAP) return text;
-  return `${text.slice(0, MIRROR_MESSAGE_CAP)}\n[mirror truncated at ${MIRROR_MESSAGE_CAP} characters]`;
+  const headLength = Math.ceil(MIRROR_MESSAGE_CAP / 2);
+  const tailLength = MIRROR_MESSAGE_CAP - headLength;
+  const omitted = text.length - MIRROR_MESSAGE_CAP;
+  return `${text.slice(0, headLength)}\n[mirror truncated: ${omitted} characters omitted]\n${text.slice(-tailLength)}`;
 }
 
 function readMirrorCursor(): MirrorCursor {
@@ -631,7 +634,8 @@ export default function (pi: ExtensionAPI) {
       parameters: Type.Object({
         task: Type.String({ description: "The task id the event belongs to (or 'fleet' for fleet-wide events)" }),
         verdict: Type.Union([Type.Literal("routine"), Type.Literal("captain")], {
-          description: "captain only for what a human must see; routine otherwise",
+          description:
+            "Use captain unconditionally for an outcome that directly answers an explicit captain request, regardless of whether it is healthy, routine, measured, actionable, or requires a decision. Also use captain for work ready for review, captain-only decisions, blockers or failures after recovery is exhausted, needed credentials, and destructive, irreversible, or security-sensitive actions; use routine otherwise.",
         }),
         summary: Type.String({
           description:

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -132,15 +132,15 @@ const MERGE_NOTE_BOAT = "⛵";
 // part of a custom message Pi gives the model (see mergeIntoMain).
 //
 // The note still needs to identify itself so main cannot mistake an incoming
-// outcome for its own earlier answer and silently lose the outcome. It must not
-// decide the conversational treatment, though: event ownership forbids a
-// second fleet operation, while main uses judgment about what the captain
-// should see and how to say it.
+// outcome for its own earlier answer and silently lose the outcome. Event
+// ownership forbids a second fleet operation, while the captain-facing verdict
+// requires a visible response and leaves its wording to main.
 const CAPTAIN_OUTCOME_INSTRUCTION =
   "This is a supervision outcome delivered automatically by the supervision branch. " +
   "It was not typed by the captain. " +
   "The fleet event is already handled: do not re-drain, re-run, or acknowledge it. " +
-  "Use your judgment about whether and how to surface, summarize, reference, or incorporate this outcome in the captain conversation. " +
+  "This outcome is captain-facing: give the captain a visible response now. " +
+  "Use your judgment over the wording and how to incorporate it, not whether to surface it. " +
   "An outcome that directly answers an explicit captain request is captain-facing, regardless of whether it is healthy, routine, measured, actionable, or requires a decision.";
 type MirrorItem = { tag: "captain" | "main"; text: string };
 type MirrorCursor = { file: string; index: number };

--- a/bin/fm-branch-prompt.sh
+++ b/bin/fm-branch-prompt.sh
@@ -63,13 +63,16 @@ For anything it tells you to escalate, or any failure that survives the playbook
 
 # Verdict: routine or captain
 
-Report verdict captain only for what a human must see:
+Report verdict captain for any outcome that directly answers an explicit captain request.
+This rule is unconditional: do not qualify it by whether the result is healthy, routine, measured, actionable, or requires a decision.
+Also report verdict captain for:
 - work ready for review - always include the full https:// PR URL in the summary;
 - a decision only the captain can make, including every ask-user finding from a validation gate;
 - a real blocker or failure after the playbook is exhausted;
 - a needed credential or login;
 - anything destructive, irreversible, or security-sensitive.
-Everything else - routine status, a successful automatic recovery, an absorbed poll, a healthy pause - is verdict routine.
+Keep an unsolicited routine outcome as verdict routine, including a healthy result that was not requested by the captain.
+Keep an unchanged fleet review silent as instructed above.
 When genuinely in doubt, choose captain: a spurious escalation costs a glance, a swallowed one costs trust.
 Write summaries in the captain's outcome language - the project, the fix, the PR, the worker, the blocker - never internal mechanics like wake kinds, status prefixes, worktrees, or state file names.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,8 +70,8 @@ The script header owns the exact JSON schema.
 
 On a Pi primary, supervision is default-on: the watcher extension can hand eligible task-local rows from an ordinary actionable wake, plus selected fleet-wide heartbeat reviews, to a persistent in-process supervision conversation while main-only rows remain on the captain-facing path.
 The branch handles those rows, stores the outcome durably, and merges an append-only note back.
-A captain-facing outcome instead opens exactly one follow-up turn on the captain's conversation without printing or rendering a separate note - that turn is the captain-visible result.
-[docs/pi-supervision-branch.md](pi-supervision-branch.md) owns row eligibility and dispatch architecture, and every other harness keeps the wake-to-main path unchanged.
+A captain-facing outcome instead opens exactly one follow-up turn on the captain's conversation without printing or rendering a separate note.
+[docs/pi-supervision-branch.md](pi-supervision-branch.md) owns row eligibility and dispatch architecture, while the generated [Pi supervision protocol](supervision-protocols/pi.md) owns MAIN's captain-visible response and merged-event handling; every other harness keeps the wake-to-main path unchanged.
 
 ### Registered secondmate current state
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,7 +45,7 @@ Homes on any other primary harness never load this feature and are entirely unaf
 `AGENTS.md`'s `state/` inventory routes the branch's runtime files to their format and lifecycle owners.
 A captain-facing (verdict `captain`) branch outcome opens exactly one follow-up turn on main - that turn is the captain-visible result, and Pi never separately prints or renders the merge note itself.
 The branch prompt owns the unconditional explicit-request rule and the distinction between captain-facing, unsolicited routine, and unchanged-review outcomes.
-Main uses judgment about how to handle a merged sailboat outcome without reprocessing its fleet event.
+The generated [Pi supervision protocol](supervision-protocols/pi.md) owns main's event-ownership and conversational-treatment instructions for merged outcomes.
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is delivered silently with no rendered note, while every other routine outcome still appends a rendered, sailboat-prefixed note.
 
 ## Pi supervision branch model and effort (config/supervision-branch-model, config/supervision-branch-effort)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,8 @@ The branch's role stays bounded exactly as the captain-approved architecture set
 Homes on any other primary harness never load this feature and are entirely unaffected.
 `AGENTS.md`'s `state/` inventory routes the branch's runtime files to their format and lifecycle owners.
 A captain-facing (verdict `captain`) branch outcome opens exactly one follow-up turn on main - that turn is the captain-visible result, and Pi never separately prints or renders the merge note itself.
+The branch prompt owns the unconditional explicit-request rule and the distinction between captain-facing, unsolicited routine, and unchanged-review outcomes.
+Main uses judgment about how to handle a merged sailboat outcome without reprocessing its fleet event.
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is delivered silently with no rendered note, while every other routine outcome still appends a rendered, sailboat-prefixed note.
 
 ## Pi supervision branch model and effort (config/supervision-branch-model, config/supervision-branch-effort)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,9 +43,9 @@ Away mode still declines every wake offer, and a broken branch still falls back 
 The branch's role stays bounded exactly as the captain-approved architecture set it: it cannot merge a PR, land local work, or freshly spawn, and every existing captain gate remains unchanged.
 Homes on any other primary harness never load this feature and are entirely unaffected.
 `AGENTS.md`'s `state/` inventory routes the branch's runtime files to their format and lifecycle owners.
-A captain-facing (verdict `captain`) branch outcome opens exactly one follow-up turn on main - that turn is the captain-visible result, and Pi never separately prints or renders the merge note itself.
+A captain-facing (verdict `captain`) branch outcome opens exactly one follow-up turn on main, and Pi never separately prints or renders the merge note itself.
 The branch prompt owns the unconditional explicit-request rule and the distinction between captain-facing, unsolicited routine, and unchanged-review outcomes.
-The generated [Pi supervision protocol](supervision-protocols/pi.md) owns main's event-ownership and conversational-treatment instructions for merged outcomes.
+The generated [Pi supervision protocol](supervision-protocols/pi.md) owns main's required captain-visible response, event ownership, and conversational treatment for merged outcomes.
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is delivered silently with no rendered note, while every other routine outcome still appends a rendered, sailboat-prefixed note.
 
 ## Pi supervision branch model and effort (config/supervision-branch-model, config/supervision-branch-effort)

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -45,7 +45,8 @@ This feature is Pi-only by construction and changes nothing anywhere else:
 ## How the branch knows what the captain said
 
 Main's captain and assistant text - never tool calls, tool results, operational injections, or the branch's own merged notes - is mirrored into the branch as read-only `fm-main-mirror` messages.
-The idle path mirrors at main's turn end. For an in-flight turn, Pi's authoritative `before_agent_start` prompt is staged verbatim before SessionManager persists that user entry, so the complete current captain message precedes a branch wake; the later persisted copy is suppressed and older dialog entries remain bounded.
+The idle path mirrors at main's turn end.
+At `before_agent_start`, Pi's authoritative prompt is staged verbatim before SessionManager persists that user entry, so the complete current captain message precedes any branch wake accepted after that boundary; the later persisted copy is suppressed and older dialog entries remain bounded.
 The mirror cursor is durable (`state/.branch-mirror-cursor`), so a restart replays only the not-yet-mirrored dialog from main's session file, and a replacement main session re-anchors from its start.
 The branch prompt frames mirrored text as context for judgment, never as instructions addressed to the branch; an authorization addressed to main (for example "you may merge when green") does not relax the branch's role limits.
 

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -55,11 +55,12 @@ Stage two is the branch's verdict on each handled event, reported through its `f
 The follow-up turn a `captain` verdict opens is itself the captain-visible outcome, so its merge note is delivered silently and never printed or rendered in Pi.
 Because Pi gives the model only a custom message's `content`, that silent note normally carries both a relay instruction and the `branch-outcome` operational kind owned by `bin/fm-operational-input.sh` inside its own text.
 This self-description lets main distinguish a new supervision outcome from its own earlier captain-facing answer; without it, main can mistake the outcome for that answer and re-emit the stale answer instead of relaying the outcome.
-The relay instruction itself is conditional: it tells main to stay quiet about an outcome it has already given the captain in this conversation, and to relay anything else rather than restate an earlier answer.
-An unconditional order made main re-report an outcome the captain already had; this M1 fix deliberately conditions main's relay without adding source-level suppression, because more than one actor can be woken for the same event.
-If envelope encoding fails, the note degrades to the same relay instruction as plain text rather than losing the outcome or opening another turn.
+The incoming outcome identifies itself to main, but does not decide the conversational treatment.
+Event ownership is separate: main must not re-drain, re-run, or acknowledge the fleet event after the branch has reported it.
+Main independently applies judgment about whether and how to surface, summarize, reference, or incorporate the outcome in the captain conversation.
+If envelope encoding fails, the note degrades to the same judgment-and-ownership instruction as plain text rather than losing the outcome or opening another turn.
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is also delivered silently with no rendered note, while every other `routine` outcome stays rendered with its sailboat prefix.
-The verdict criteria in the branch prompt mirror the captain-etiquette escalation list; doubt escalates.
+The branch prompt owns the verdict criteria, including its unconditional explicit-request rule; unsolicited routine outcomes remain routine sailboat notes, unchanged fleet reviews remain silent, and doubt escalates.
 Main can read the durable outcome store on demand through its `fm_branch_outcomes` tool.
 
 ## Heartbeat routing

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -61,6 +61,7 @@ Main independently applies judgment about whether and how to surface, summarize,
 If envelope encoding fails, the note degrades to the same judgment-and-ownership instruction as plain text rather than losing the outcome or opening another turn.
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is also delivered silently with no rendered note, while every other `routine` outcome stays rendered with its sailboat prefix.
 The branch prompt owns the verdict criteria, including its unconditional explicit-request rule; unsolicited routine outcomes remain routine sailboat notes, unchanged fleet reviews remain silent, and doubt escalates.
+The extension refreshes the main-dialog mirror synchronously before accepting each branch wake, so a request from the current in-flight main turn reaches the branch before that wake's prompt rather than waiting for `turn_end`.
 Main can read the durable outcome store on demand through its `fm_branch_outcomes` tool.
 
 ## Heartbeat routing

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -9,7 +9,7 @@ Fleet supervision on the Pi primary harness runs on a second, persistent convers
 Supervision is default-on: once a Pi primary session owns this home's fleet lock, the branch handles eligible task-local rows from ordinary actionable wakes plus heartbeat scans that the cheap bash-level scan flags as possibly captain-relevant, then merges each outcome back by appending a short note to the captain conversation's tail.
 Ordinary main-only rows remain on main even when eligible task-local rows share their queue.
 An unresolvable row makes the scan unsafe and returns the whole wake to main, and every watcher-failure alarm also stays on main.
-Only captain-relevant branch outcomes open a turn on main - that follow-up turn is itself the captain-visible outcome, so Pi never separately prints or renders a captain-facing merge note.
+Only captain-relevant branch outcomes open a turn on main; the generated [Pi supervision protocol](supervision-protocols/pi.md) requires MAIN to produce the captain-visible response in that turn, while Pi never separately prints or renders a captain-facing merge note.
 The design source is the captain-approved forked-supervision architecture board, a captain-private fleet record (a self-contained HTML explainer with the measured cache and judgment evidence); this document records the shape it landed as, and the delivering PR cites the board artifact itself.
 
 This feature is Pi-only by construction and changes nothing anywhere else:
@@ -54,9 +54,9 @@ The branch prompt frames mirrored text as context for judgment, never as instruc
 
 Stage one is unchanged: the bash watcher absorbs everything provably fine at zero token cost.
 Stage two is the branch's verdict on each handled event, reported through its `fm_branch_report` tool: `routine` merges without a follow-up turn, while `captain` merges with exactly one follow-up turn.
-The follow-up turn a `captain` verdict opens is itself the captain-visible outcome, so its merge note is delivered silently and never printed or rendered in Pi.
+The generated [Pi supervision protocol](supervision-protocols/pi.md) requires MAIN to produce the captain-visible response in the one follow-up turn a `captain` verdict opens, so its merge note is delivered silently and never printed or rendered in Pi.
 Because Pi gives the model only a custom message's `content`, that silent note normally carries both a relay instruction and the `branch-outcome` operational kind owned by `bin/fm-operational-input.sh` inside its own text.
-This self-description lets main distinguish a new supervision outcome from its own earlier captain-facing answer; without it, main can mistake the outcome for that answer and re-emit the stale answer instead of relaying the outcome.
+This self-description lets main distinguish a new supervision outcome from its own earlier captain-facing answer; without it, main can mistake the outcome for that answer and lose the outcome while deciding how to handle it.
 The generated [Pi supervision protocol](supervision-protocols/pi.md) owns main's event-ownership and conversational-treatment instructions for merged outcomes.
 If envelope encoding fails, the captain-facing note degrades to the same runtime instruction as plain text rather than losing the outcome or opening another turn.
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is also delivered silently with no rendered note, while every other `routine` outcome stays rendered with its sailboat prefix.

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -61,7 +61,7 @@ Main independently applies judgment about whether and how to surface, summarize,
 If envelope encoding fails, the note degrades to the same judgment-and-ownership instruction as plain text rather than losing the outcome or opening another turn.
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is also delivered silently with no rendered note, while every other `routine` outcome stays rendered with its sailboat prefix.
 The branch prompt owns the verdict criteria, including its unconditional explicit-request rule; unsolicited routine outcomes remain routine sailboat notes, unchanged fleet reviews remain silent, and doubt escalates.
-The extension refreshes the main-dialog mirror synchronously before accepting each branch wake, so a request from the current in-flight main turn reaches the branch before that wake's prompt rather than waiting for `turn_end`.
+The extension refreshes the bounded head-and-tail main-dialog mirror synchronously before accepting each branch wake, so a request at either end of the current in-flight main message reaches the branch before that wake's prompt rather than waiting for `turn_end`.
 Main can read the durable outcome store on demand through its `fm_branch_outcomes` tool.
 
 ## Heartbeat routing

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -61,7 +61,7 @@ Main independently applies judgment about whether and how to surface, summarize,
 If envelope encoding fails, the note degrades to the same judgment-and-ownership instruction as plain text rather than losing the outcome or opening another turn.
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is also delivered silently with no rendered note, while every other `routine` outcome stays rendered with its sailboat prefix.
 The branch prompt owns the verdict criteria, including its unconditional explicit-request rule; unsolicited routine outcomes remain routine sailboat notes, unchanged fleet reviews remain silent, and doubt escalates.
-The extension refreshes the bounded head-and-tail main-dialog mirror synchronously before accepting each branch wake, so a request at either end of the current in-flight main message reaches the branch before that wake's prompt rather than waiting for `turn_end`.
+The extension refreshes the main-dialog mirror synchronously before accepting each branch wake, preserving the complete current captain message while keeping older dialog entries bounded, so a request anywhere in the current in-flight message reaches the branch before that wake's prompt rather than waiting for `turn_end`.
 Main can read the durable outcome store on demand through its `fm_branch_outcomes` tool.
 
 ## Heartbeat routing

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -44,7 +44,8 @@ This feature is Pi-only by construction and changes nothing anywhere else:
 
 ## How the branch knows what the captain said
 
-Main's captain and assistant text - never tool calls, tool results, operational injections, or the branch's own merged notes - is mirrored into the branch as read-only `fm-main-mirror` messages at main's turn end, before the next wake is handed over.
+Main's captain and assistant text - never tool calls, tool results, operational injections, or the branch's own merged notes - is mirrored into the branch as read-only `fm-main-mirror` messages.
+The idle path mirrors at main's turn end, while the pre-dispatch path refreshes the live main session synchronously before accepting a branch wake so the complete current captain message precedes that wake and older dialog entries remain bounded.
 The mirror cursor is durable (`state/.branch-mirror-cursor`), so a restart replays only the not-yet-mirrored dialog from main's session file, and a replacement main session re-anchors from its start.
 The branch prompt frames mirrored text as context for judgment, never as instructions addressed to the branch; an authorization addressed to main (for example "you may merge when green") does not relax the branch's role limits.
 
@@ -55,13 +56,10 @@ Stage two is the branch's verdict on each handled event, reported through its `f
 The follow-up turn a `captain` verdict opens is itself the captain-visible outcome, so its merge note is delivered silently and never printed or rendered in Pi.
 Because Pi gives the model only a custom message's `content`, that silent note normally carries both a relay instruction and the `branch-outcome` operational kind owned by `bin/fm-operational-input.sh` inside its own text.
 This self-description lets main distinguish a new supervision outcome from its own earlier captain-facing answer; without it, main can mistake the outcome for that answer and re-emit the stale answer instead of relaying the outcome.
-The incoming captain-facing outcome identifies itself to main and requires a captain-visible response, while main retains judgment over its wording and conversational incorporation.
-Event ownership is separate: main must not re-drain, re-run, or acknowledge the fleet event after the branch has reported it.
-For routine sailboat outcomes, main independently applies judgment about whether and how to surface, summarize, reference, or incorporate the content in the captain conversation.
-If envelope encoding fails, the captain-facing note degrades to the same visibility-and-ownership instruction as plain text rather than losing the outcome or opening another turn.
+The generated [Pi supervision protocol](supervision-protocols/pi.md) owns main's event-ownership and conversational-treatment instructions for merged outcomes.
+If envelope encoding fails, the captain-facing note degrades to the same runtime instruction as plain text rather than losing the outcome or opening another turn.
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is also delivered silently with no rendered note, while every other `routine` outcome stays rendered with its sailboat prefix.
 The branch prompt owns the verdict criteria, including its unconditional explicit-request rule; unsolicited routine outcomes remain routine sailboat notes, unchanged fleet reviews remain silent, and doubt escalates.
-The extension refreshes the main-dialog mirror synchronously before accepting each branch wake, preserving the complete current captain message while keeping older dialog entries bounded, so a request anywhere in the current in-flight message reaches the branch before that wake's prompt rather than waiting for `turn_end`.
 Main can read the durable outcome store on demand through its `fm_branch_outcomes` tool.
 
 ## Heartbeat routing
@@ -92,6 +90,6 @@ What is new is only the attended path: outside away mode, the branch absorbs the
 
 ## Verification
 
-Portable regressions: `tests/fm-pi-branch-extension.test.sh` (dispatch, default-on eligibility, main-only classification, eligible-row claim lifecycle, partial pre-drain recheck, fallback, filter, mirror, model-visible captain-outcome typing and plain-instruction fallback, cache key, persistence, model pin and searchable picker, effort pin), `tests/fm-branch-supervision.test.sh` (prompt stability, store append-only, leases, guards, non-branch-home invariance), the branch-offer, heartbeat-offer, heartbeat-not-ridden-by-a-check, and main-only-check-class tests in `tests/fm-pi-watch-extension.test.sh`, the recovery test in `tests/fm-session-start.test.sh`, and the per-actor consume regression in `tests/fm-wake-queue.test.sh`.
+Portable regressions: `tests/fm-pi-branch-extension.test.sh` (dispatch, default-on eligibility, main-only classification, requested-versus-unsolicited outcome delivery, pre-turn-end complete-current-request mirroring, fleet-event ownership, main outcome access, eligible-row claim lifecycle, partial pre-drain recheck, fallback, filter, model-visible captain-outcome typing and plain-instruction fallback, cache key, persistence, model pin and searchable picker, effort pin), `tests/fm-branch-supervision.test.sh` (prompt stability, store append-only, leases, guards, non-branch-home invariance), the branch-offer, heartbeat-offer, heartbeat-not-ridden-by-a-check, and main-only-check-class tests in `tests/fm-pi-watch-extension.test.sh`, the recovery test in `tests/fm-session-start.test.sh`, and the per-actor consume regression in `tests/fm-wake-queue.test.sh`.
 Live guard: `FM_PI_BRANCH_LIVE_E2E=1 tests/fm-pi-branch-live-e2e.test.sh` exercises the real installed Pi SDK's custom-message conversion and branch-session surfaces with no user credentials and no provider call; run it after every Pi upgrade and record the dated result in [docs/verification/runtime-backends.md](verification/runtime-backends.md).
 The strict typecheck in `tests/fm-pi-primary-types.test.sh` pins the extension against the installed Pi package.

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -45,7 +45,7 @@ This feature is Pi-only by construction and changes nothing anywhere else:
 ## How the branch knows what the captain said
 
 Main's captain and assistant text - never tool calls, tool results, operational injections, or the branch's own merged notes - is mirrored into the branch as read-only `fm-main-mirror` messages.
-The idle path mirrors at main's turn end, while the pre-dispatch path refreshes the live main session synchronously before accepting a branch wake so the complete current captain message precedes that wake and older dialog entries remain bounded.
+The idle path mirrors at main's turn end. For an in-flight turn, Pi's authoritative `before_agent_start` prompt is staged verbatim before SessionManager persists that user entry, so the complete current captain message precedes a branch wake; the later persisted copy is suppressed and older dialog entries remain bounded.
 The mirror cursor is durable (`state/.branch-mirror-cursor`), so a restart replays only the not-yet-mirrored dialog from main's session file, and a replacement main session re-anchors from its start.
 The branch prompt frames mirrored text as context for judgment, never as instructions addressed to the branch; an authorization addressed to main (for example "you may merge when green") does not relax the branch's role limits.
 

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -55,10 +55,10 @@ Stage two is the branch's verdict on each handled event, reported through its `f
 The follow-up turn a `captain` verdict opens is itself the captain-visible outcome, so its merge note is delivered silently and never printed or rendered in Pi.
 Because Pi gives the model only a custom message's `content`, that silent note normally carries both a relay instruction and the `branch-outcome` operational kind owned by `bin/fm-operational-input.sh` inside its own text.
 This self-description lets main distinguish a new supervision outcome from its own earlier captain-facing answer; without it, main can mistake the outcome for that answer and re-emit the stale answer instead of relaying the outcome.
-The incoming outcome identifies itself to main, but does not decide the conversational treatment.
+The incoming captain-facing outcome identifies itself to main and requires a captain-visible response, while main retains judgment over its wording and conversational incorporation.
 Event ownership is separate: main must not re-drain, re-run, or acknowledge the fleet event after the branch has reported it.
-Main independently applies judgment about whether and how to surface, summarize, reference, or incorporate the outcome in the captain conversation.
-If envelope encoding fails, the note degrades to the same judgment-and-ownership instruction as plain text rather than losing the outcome or opening another turn.
+For routine sailboat outcomes, main independently applies judgment about whether and how to surface, summarize, reference, or incorporate the content in the captain conversation.
+If envelope encoding fails, the captain-facing note degrades to the same visibility-and-ownership instruction as plain text rather than losing the outcome or opening another turn.
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is also delivered silently with no rendered note, while every other `routine` outcome stays rendered with its sailboat prefix.
 The branch prompt owns the verdict criteria, including its unconditional explicit-request rule; unsolicited routine outcomes remain routine sailboat notes, unchanged fleet reviews remain silent, and doubt escalates.
 The extension refreshes the main-dialog mirror synchronously before accepting each branch wake, preserving the complete current captain message while keeping older dialog entries bounded, so a request anywhere in the current in-flight message reaches the branch before that wake's prompt rather than waiting for `turn_end`.

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -24,7 +24,9 @@ A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=
 A captain-facing outcome instead opens exactly one follow-up turn on this conversation - that turn is the captain-visible result, and no separate note is printed here.
 Before MAIN steers, controls lifecycle, or cleans up a task, claim its lease with `bin/fm-lease.sh claim <task>` and release it afterwards; a refused claim means the branch is acting on that task right now.
 This conversation still receives every other fleet-wide or unresolvable wake, the branch's wakes when it is unavailable or away mode is active, and every watcher-failure alarm regardless, so the arm and repair contract above is unchanged.
-Treat a merged note or an opened captain-facing turn as already handled - do not re-drain or re-handle its event - and read the durable outcome store with the fm_branch_outcomes tool when the captain asks what happened.
+Treat the merged fleet event as already handled for fleet operations: MAIN must not re-drain, re-run, or acknowledge it.
+Separately, MAIN applies judgment about whether and how to surface, summarize, reference, or incorporate a merged sailboat outcome in the captain conversation; event ownership does not decide the conversational treatment.
+Read the durable outcome store with the fm_branch_outcomes tool when the captain asks what happened.
 
 The turn-end guard extension lives at `__FM_PI_TURNEND_EXT__`.
 The watcher extension lives at `__FM_PI_EXT__`.

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -21,7 +21,7 @@ When this session owns supervision and away mode is not active:
 
 The supervision branch is default-on (docs/pi-supervision-branch.md): whenever this session owns the fleet lock and away mode is not active, the watcher extension hands eligible task-local rows from ordinary actionable wakes, plus selected fleet-wide heartbeat reviews, to the persistent in-process supervision branch while main-only rows remain queued for this conversation.
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is delivered silently with no rendered note, while every other routine outcome returns as an appended, rendered note that leads with ⛵ then the dim outcome text.
-A captain-facing outcome instead opens exactly one follow-up turn on this conversation - that turn is the captain-visible result, and no separate note is printed here.
+A captain-facing outcome instead opens exactly one follow-up turn on this conversation - MAIN must produce its captain-visible response in that turn, and no separate note is printed here.
 Before MAIN steers, controls lifecycle, or cleans up a task, claim its lease with `bin/fm-lease.sh claim <task>` and release it afterwards; a refused claim means the branch is acting on that task right now.
 This conversation still receives every other fleet-wide or unresolvable wake, the branch's wakes when it is unavailable or away mode is active, and every watcher-failure alarm regardless, so the arm and repair contract above is unchanged.
 Treat the merged fleet event as already handled for fleet operations: MAIN must not re-drain, re-run, or acknowledge it.

--- a/tests/fm-branch-supervision.test.sh
+++ b/tests/fm-branch-supervision.test.sh
@@ -48,6 +48,10 @@ test_branch_prompt_is_byte_stable_and_above_cache_floor() {
     *"stuck-crewmate-recovery"*) ;;
     *) fail "branch prompt lost the inlined recovery playbook" ;;
   esac
+  case "$out_a" in
+    *"Report verdict captain for any outcome that directly answers an explicit captain request."*"This rule is unconditional"*"Keep an unsolicited routine outcome as verdict routine"*"Keep an unchanged fleet review silent"*) ;;
+    *) fail "branch prompt lost the unconditional requested-outcome or routine-silence rules" ;;
+  esac
   pass "branch prompt is byte-stable across homes, cwd, timezone, and time, above the cache floor"
 }
 

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -861,6 +861,12 @@ globalThis.__fmOnBranchPrompt = async ({ session }) => {
   const ack = drained.stderr.match(/--ack-through ([0-9]+) --recovery-generation ([A-Za-z0-9._-]+)/);
   if (!ack) throw new Error(`drain did not return its acknowledgement command: ${drained.stderr}`);
   const report = session.options.customTools.find((tool) => tool.name === "fm_branch_report");
+  const verdictDescription = report.parameters.properties.verdict.description;
+  if (!verdictDescription.includes("unconditionally") ||
+      !verdictDescription.includes("directly answers an explicit captain request") ||
+      !verdictDescription.includes("regardless of whether it is healthy, routine, measured, actionable, or requires a decision")) {
+    throw new Error(`branch provider received conflicting verdict semantics: ${verdictDescription}`);
+  }
   const result = await report.execute(
     `resource-result-${fleetOperations.length}`,
     {
@@ -902,9 +908,10 @@ if (fleetOperations.length !== 2) throw new Error("main's outcome read reprocess
 // Start a real main turn whose user entry is already in the session, then let
 // the result arrive before turn_end. The dispatch boundary must mirror that
 // current request before the branch provider classifies the equivalent result.
+const explicitRequest = "Please give me a fresh mini system-resource report.";
 const entries = [{
   type: "message",
-  message: { role: "user", content: "Please give me a fresh mini system-resource report." },
+  message: { role: "user", content: `${"background context ".repeat(300)}${explicitRequest}` },
 }];
 const mainCtx = {
   model: { provider: "anthropic", id: "main-model" },
@@ -918,6 +925,15 @@ fire("agent_start", {}, mainCtx);
 const requested = dispatch("signal: healthy resource result");
 if (!requested.accepted) throw new Error("branch did not accept the requested result");
 await settle(() => fleetOperations.length === 4, "requested result acknowledgement");
+const deliveredRequestMirror = globalThis.__fmSessions[0].ops
+  .filter((op) => op.kind === "custom" && op.message.customType === "fm-main-mirror")
+  .at(-1)?.message.content;
+if (!deliveredRequestMirror?.endsWith(explicitRequest)) {
+  throw new Error(`pre-turn-end mirror dropped the captain request tail: ${deliveredRequestMirror}`);
+}
+if (!deliveredRequestMirror.includes("[mirror truncated:")) {
+  throw new Error("long captain request did not exercise the bounded mirror path");
+}
 if ((globalThis.__fmPrompts ?? []).length !== 2) throw new Error("a handled fleet wake was rerun");
 const turns = sentToMain.filter((sent) => sent.options.triggerTurn === true);
 if (turns.length !== 1 || turns[0].options.deliverAs !== "followUp") {
@@ -1430,7 +1446,7 @@ const entries = [
   { type: "message", message: { role: "toolResult", content: "tool output stays in main" } },
   { type: "custom", message: { role: "custom", customType: "fm-branch-merge", content: "merged note" } },
   { type: "compaction", summary: "compacted" },
-  { type: "message", message: { role: "user", content: `pad ${"x".repeat(5000)}` } },
+  { type: "message", message: { role: "user", content: `pad ${"x".repeat(5000)}\ntail: retain this request` } },
 ];
 const ctx = {
   sessionManager: {
@@ -1455,7 +1471,9 @@ if (mirrored.some((m) => m.customType !== "fm-main-mirror")) throw new Error("mi
 if (mirrored.some((m) => m.display !== false)) throw new Error("mirrored context must be silent");
 if (mirrored[0].content !== "[captain] never merge task-7 without my word") throw new Error(`bad captain mirror: ${mirrored[0].content}`);
 if (mirrored[1].content !== "[main] aye, holding task-7") throw new Error(`bad main mirror: ${mirrored[1].content}`);
-if (!mirrored[2].content.includes("[mirror truncated at 4000 characters]")) throw new Error("long dialog was not capped");
+if (!mirrored[2].content.includes("[mirror truncated:") || !mirrored[2].content.endsWith("tail: retain this request")) {
+  throw new Error(`long dialog did not preserve its bounded head and tail: ${mirrored[2].content}`);
+}
 if (mirrored.some((m) => m.content.includes("operational injection") || m.content.includes("tool output") || m.content.includes("merged note"))) {
   throw new Error("mirror leaked operational, tool, or merge-note traffic");
 }

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -124,7 +124,12 @@ export function createBashToolDefinition(cwd, options) {
     parameters: { type: "object" },
     __cwd: cwd,
     __options: options,
-    execute: async () => ({ content: [], details: undefined }),
+    execute: async (_toolCallId, params) => {
+      if (!globalThis.__fmExecuteBranchBash) return { content: [], details: undefined };
+      const initial = { command: String(params.command ?? ""), cwd, env: { ...process.env } };
+      const context = options.spawnHook ? options.spawnHook(initial) : initial;
+      return globalThis.__fmExecuteBranchBash(context);
+    },
   };
 }
 
@@ -810,28 +815,38 @@ test_requested_healthy_outcome_and_unsolicited_routine_outcome_delivery() {
   PLUGIN="$repo/.pi/extensions/fm-branch-supervision.ts" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
     DRIVER_PRELUDE="$DRIVER_PRELUDE" node --input-type=module > "$TMP_ROOT/node-output" 2>&1 <<'EOF'
 const prelude = process.env.DRIVER_PRELUDE;
-await eval(`(async () => { ${prelude}; globalThis.__t = { fire, dispatch, settle, sentToMain, outcomeScript, home, realRoot }; })()`);
-const { fire, dispatch, settle, sentToMain, outcomeScript, home, realRoot } = globalThis.__t;
+await eval(`(async () => { ${prelude}; globalThis.__t = { fire, dispatch, settle, sentToMain, outcomeScript, mainTools, home, realRoot }; })()`);
+const { fire, dispatch, settle, sentToMain, outcomeScript, mainTools, home, realRoot } = globalThis.__t;
 import { existsSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 
 const fleetOperations = [];
-function runFleetCommand(kind, args) {
-  fleetOperations.push({ kind, args: [...args], actor: "branch" });
-  const result = spawnSync("bash", [`${realRoot}/bin/fm-wake-drain.sh`, ...args], {
+globalThis.__fmExecuteBranchBash = async (context) => {
+  const actor = spawnSync(
+    "bash",
+    ["-c", '. "$1"; fm_lease_actor', "_", `${realRoot}/bin/fm-lease-lib.sh`],
+    { encoding: "utf8", cwd: context.cwd, env: context.env },
+  );
+  if (actor.status !== 0) throw new Error(`branch bash actor resolution failed: ${actor.stderr}`);
+  const result = spawnSync("bash", ["-c", context.command], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      FM_HOME: home,
-      FM_STATE_OVERRIDE: `${home}/state`,
-      FM_SUPERVISION_ACTOR: "branch",
-      FM_LEASE_HOLDER_PID: String(process.pid),
-    },
+    cwd: context.cwd,
+    env: context.env,
   });
-  if (result.status !== 0) {
-    throw new Error(`${kind} failed (${result.status}): ${result.stdout}\n${result.stderr}`);
-  }
-  return result;
+  fleetOperations.push({ command: context.command, actor: actor.stdout.trim(), status: result.status });
+  return {
+    content: [{ type: "text", text: `${result.stdout}${result.stderr}` }],
+    details: { stdout: result.stdout, stderr: result.stderr, exitCode: result.status, actor: actor.stdout.trim() },
+    isError: result.status !== 0,
+  };
+};
+
+async function runFleetCommand(session, args) {
+  const bash = session.options.customTools.find((tool) => tool.name === "bash");
+  const command = ["bin/fm-wake-drain.sh", ...args].join(" ");
+  const result = await bash.execute(`fleet-${fleetOperations.length}`, { command }, undefined, undefined, {});
+  if (result.isError) throw new Error(`fleet command failed: ${JSON.stringify(result)}`);
+  return result.details;
 }
 
 // The stubbed provider executes the same public branch turn contract as a real
@@ -841,10 +856,8 @@ globalThis.__fmOnBranchPrompt = async ({ session }) => {
   const mirror = session.ops
     .filter((op) => op.kind === "custom" && op.message.customType === "fm-main-mirror")
     .map((op) => op.message.content);
-  const directlyRequested = mirror.some((text) =>
-    text === "[captain] Please give me a fresh mini system-resource report."
-  );
-  const drained = runFleetCommand("drain", []);
+  const directlyRequested = mirror.length > 0;
+  const drained = await runFleetCommand(session, []);
   const ack = drained.stderr.match(/--ack-through ([0-9]+) --recovery-generation ([A-Za-z0-9._-]+)/);
   if (!ack) throw new Error(`drain did not return its acknowledgement command: ${drained.stderr}`);
   const report = session.options.customTools.find((tool) => tool.name === "fm_branch_report");
@@ -861,7 +874,7 @@ globalThis.__fmOnBranchPrompt = async ({ session }) => {
     {},
   );
   if (result.isError) throw new Error(`branch report failed: ${JSON.stringify(result)}`);
-  runFleetCommand("ack", ["--ack-through", ack[1], "--recovery-generation", ack[2]]);
+  await runFleetCommand(session, ["--ack-through", ack[1], "--recovery-generation", ack[2]]);
 };
 
 // With no captain request, the healthy result remains a rendered sailboat and
@@ -877,19 +890,14 @@ if (sailboat.message.display !== true || !sailboat.message.content.startsWith("â
   throw new Error(`unsolicited healthy result was not a rendered sailboat note: ${JSON.stringify(sailboat)}`);
 }
 
-// MAIN's next conversational turn can use the merged note as content without
-// taking fleet ownership. This provider adapter chooses to summarize it; the
-// operation ledger below proves that choice did not drain, rerun, or ack.
-function runMainConversationTurn(messages) {
-  const note = messages.find((sent) => sent.message.content.startsWith("â›µ task-resource:"));
-  if (!note) throw new Error("main could not see the sailboat outcome");
-  return `The latest ${note.message.content.slice(2)}`;
+const outcomes = mainTools.find((tool) => tool.name === "fm_branch_outcomes");
+if (!outcomes) throw new Error("main did not receive its outcome-reading permission surface");
+const visibleToMain = await outcomes.execute("main-reads-sailboat", { recent: 1 }, undefined, undefined, {});
+const mainOutcomeText = visibleToMain.content.map((item) => item.text ?? "").join("\n");
+if (visibleToMain.isError || !mainOutcomeText.includes("healthy resource report: CPU 12%, memory 41%")) {
+  throw new Error(`main could not use the sailboat content through its existing permission path: ${JSON.stringify(visibleToMain)}`);
 }
-const mainReply = runMainConversationTurn(sentToMain);
-if (!mainReply.includes("healthy resource report: CPU 12%, memory 41%")) {
-  throw new Error(`main did not exercise judgment over the sailboat content: ${mainReply}`);
-}
-if (fleetOperations.length !== 2) throw new Error("main conversation reprocessed the fleet event");
+if (fleetOperations.length !== 2) throw new Error("main's outcome read reprocessed the fleet event");
 
 // Start a real main turn whose user entry is already in the session, then let
 // the result arrive before turn_end. The dispatch boundary must mirror that
@@ -916,8 +924,8 @@ if (turns.length !== 1 || turns[0].options.deliverAs !== "followUp") {
   throw new Error(`pre-turn-end requested result did not open exactly one main turn: ${JSON.stringify(sentToMain)}`);
 }
 if (sentToMain.length !== 2) throw new Error(`one result was reprocessed into ${sentToMain.length} main messages`);
-if (fleetOperations.map((operation) => operation.kind).join(",") !== "drain,ack,drain,ack") {
-  throw new Error(`fleet event ownership repeated or reordered work: ${JSON.stringify(fleetOperations)}`);
+if (fleetOperations.length !== 4 || fleetOperations.some((operation) => operation.status !== 0)) {
+  throw new Error(`fleet event ownership repeated or failed work: ${JSON.stringify(fleetOperations)}`);
 }
 if (fleetOperations.some((operation) => operation.actor !== "branch")) {
   throw new Error(`main took fleet-event ownership: ${JSON.stringify(fleetOperations)}`);

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -895,6 +895,7 @@ const longRequests = [
   `${"middle context ".repeat(250)}${explicitRequest}${" middle context".repeat(250)}`,
   `${"tail context ".repeat(500)}${explicitRequest}`,
 ];
+const requestedPrompts = [...longRequests, "FIRSTMATE give me a fresh system-resource report."];
 // Match Pi's real AgentSession.prompt ordering: before_agent_start receives
 // the expanded prompt before _runAgentPrompt appends its user message to the
 // SessionManager. Keeping entries stale at the hook boundary is the regression.
@@ -906,6 +907,14 @@ const mainCtx = {
     getEntries: () => entries,
   },
 };
+const operational = spawnSync(
+  "bash",
+  [`${realRoot}/bin/fm-operational-input.sh`, "encode", "watcher"],
+  { encoding: "utf8", input: "operational watcher injection" },
+);
+if (operational.status !== 0) throw new Error(`could not create operational input: ${operational.stderr}`);
+fire("before_agent_start", { prompt: operational.stdout }, mainCtx);
+entries.push({ type: "message", message: { role: "user", content: operational.stdout } });
 const unsolicitedPrompt = "Please keep responses concise while monitoring the fleet.";
 fire("before_agent_start", { prompt: unsolicitedPrompt }, mainCtx);
 entries.push({ type: "message", message: { role: "user", content: unsolicitedPrompt } });
@@ -930,9 +939,11 @@ if (visibleToMain.isError || !mainOutcomeText.includes("healthy resource report:
 }
 if (fleetOperations.length !== 2) throw new Error("main's outcome read reprocessed the fleet event");
 
-for (let index = 0; index < longRequests.length; index += 1) {
-  const content = longRequests[index];
-  if (content.length <= 4000) throw new Error(`request fixture ${index} did not exceed the mirror bound`);
+for (let index = 0; index < requestedPrompts.length; index += 1) {
+  const content = requestedPrompts[index];
+  if (index < longRequests.length && content.length <= 4000) {
+    throw new Error(`request fixture ${index} did not exceed the mirror bound`);
+  }
   fire("before_agent_start", { prompt: content }, mainCtx);
   // Pi persists this only after every before_agent_start handler has returned.
   entries.push({ type: "message", message: { role: "user", content } });
@@ -954,13 +965,16 @@ for (let index = 0; index < longRequests.length; index += 1) {
 const mirroredCaptainText = globalThis.__fmSessions[0].ops
   .filter((op) => op.kind === "custom" && op.message.customType === "fm-main-mirror")
   .map((op) => op.message.content);
-for (const content of [unsolicitedPrompt, ...longRequests]) {
+for (const content of [unsolicitedPrompt, ...requestedPrompts]) {
   const copies = mirroredCaptainText.filter((text) => text === `[captain] ${content}`).length;
   if (copies !== 1) throw new Error(`current captain prompt was mirrored ${copies} times instead of once`);
 }
-if ((globalThis.__fmPrompts ?? []).length !== 4) throw new Error("a handled fleet wake was rerun");
-if (sentToMain.length !== 4) throw new Error(`one result was reprocessed into ${sentToMain.length} main messages`);
-if (fleetOperations.length !== 8 || fleetOperations.some((operation) => operation.status !== 0)) {
+if (mirroredCaptainText.some((text) => text.includes("operational watcher injection"))) {
+  throw new Error("canonical operational input entered captain mirror context");
+}
+if ((globalThis.__fmPrompts ?? []).length !== 5) throw new Error("a handled fleet wake was rerun");
+if (sentToMain.length !== 5) throw new Error(`one result was reprocessed into ${sentToMain.length} main messages`);
+if (fleetOperations.length !== 10 || fleetOperations.some((operation) => operation.status !== 0)) {
   throw new Error(`fleet event ownership repeated or failed work: ${JSON.stringify(fleetOperations)}`);
 }
 if (fleetOperations.some((operation) => operation.actor !== "branch")) {
@@ -970,7 +984,7 @@ if (existsSync(`${home}/state/.wake-queue`) && readFileSync(`${home}/state/.wake
   throw new Error("acknowledged fleet wake remained queued for another owner");
 }
 const rows = readFileSync(`${home}/state/branch-outcomes.jsonl`, "utf8").trim().split("\n").map((line) => JSON.parse(line));
-if (rows.length !== 4 || rows[0].verdict !== "routine" || rows.slice(1).some((row) => row.verdict !== "captain")) {
+if (rows.length !== 5 || rows[0].verdict !== "routine" || rows.slice(1).some((row) => row.verdict !== "captain")) {
   throw new Error(`provider classifications were not recorded once in order: ${JSON.stringify(rows)}`);
 }
 if (outcomeScript(["unread"]) !== "") throw new Error("merged outcomes remained unread for redelivery");

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -777,18 +777,20 @@ EOF
     *"This is a supervision outcome delivered automatically by the supervision branch."*"It was not typed by the captain."*"task-9: PR https://example.com/pr/9"*) ;;
     *) fail "captain outcome body lost its self-description or the outcome itself: $body" ;;
   esac
-  # Both halves of the delivered instruction matter and they pull against each
-  # other: main must be allowed to stay quiet about an outcome it has already
-  # given the captain, and must still be told to relay everything else instead
-  # of re-emitting its own last answer. An instruction carrying only one half
-  # reintroduces either the duplicate or the silent loss.
+  # Event ownership and conversational judgment are separate contracts. The
+  # delivered instruction forbids reprocessing the fleet event but leaves main
+  # free to decide how the outcome belongs in the captain conversation.
   case "$body" in
-    *"already reported this outcome to the captain"*"do not report it again"*) ;;
-    *) fail "captain outcome body never lets main deduplicate what it already said: $body" ;;
+    *"The fleet event is already handled: do not re-drain, re-run, or acknowledge it."*) ;;
+    *) fail "captain outcome body lost the event-ownership boundary: $body" ;;
   esac
   case "$body" in
-    *"relay only this outcome to the captain now"*"Do not restate or repeat any earlier answer"*) ;;
-    *) fail "captain outcome body never tells main to relay it instead of repeating: $body" ;;
+    *"Use your judgment about whether and how to surface, summarize, reference, or incorporate this outcome in the captain conversation."*) ;;
+    *) fail "captain outcome body imposed a mechanical conversational treatment: $body" ;;
+  esac
+  case "$body" in
+    *"An outcome that directly answers an explicit captain request is captain-facing"*"regardless of whether it is healthy, routine, measured, actionable, or requires a decision."*) ;;
+    *) fail "captain outcome body lost the unconditional explicit-request rule: $body" ;;
   esac
   # The routine note is rendered in the TUI, and its renderer reads the glyph off
   # the front of this same string, so it must stay plain text.
@@ -796,6 +798,88 @@ EOF
     fail "routine note must stay plain rendered text, not typed operational input"
   fi
   pass "a captain outcome reaches main's model as typed, self-describing input while routine notes stay plain"
+}
+
+test_requested_healthy_outcome_and_unsolicited_routine_outcome_delivery() {
+  local repo home out status
+  repo="$TMP_ROOT/requested-outcome-root"
+  home="$TMP_ROOT/requested-outcome-home"
+  mkdir -p "$home/state" "$home/config"
+  install_pi_branch_extension_fixture "$repo"
+  PLUGIN="$repo/.pi/extensions/fm-branch-supervision.ts" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    DRIVER_PRELUDE="$DRIVER_PRELUDE" node --input-type=module > "$TMP_ROOT/node-output" 2>&1 <<'EOF'
+const prelude = process.env.DRIVER_PRELUDE;
+await eval(`(async () => { ${prelude}; globalThis.__t = { fire, dispatch, settle, sentToMain, outcomeScript, home }; })()`);
+const { fire, dispatch, settle, sentToMain, outcomeScript, home } = globalThis.__t;
+import { readFileSync } from "node:fs";
+
+// An equivalent healthy result with no captain request stays an ordinary
+// sailboat note and does not open a main turn.
+const unsolicited = dispatch("signal: healthy resource result");
+if (!unsolicited.accepted) throw new Error("branch did not accept the unsolicited result");
+await settle(() => (globalThis.__fmPrompts ?? []).length === 1, "unsolicited result prompt");
+const report = globalThis.__fmSessions[0].options.customTools.find((tool) => tool.name === "fm_branch_report");
+const routine = await report.execute(
+  "unsolicited-result",
+  { task: "task-resource", verdict: "routine", summary: "healthy resource report: CPU 12%, memory 41%" },
+  undefined,
+  undefined,
+  {},
+);
+if (routine.isError) throw new Error(`unsolicited routine result failed: ${JSON.stringify(routine)}`);
+if (sentToMain.length !== 1 || sentToMain[0].options.triggerTurn) {
+  throw new Error(`unsolicited healthy result opened a main turn: ${JSON.stringify(sentToMain)}`);
+}
+if (sentToMain[0].message.display !== true || !sentToMain[0].message.content.startsWith("⛵ task-resource:")) {
+  throw new Error(`unsolicited healthy result was not a rendered sailboat note: ${JSON.stringify(sentToMain[0])}`);
+}
+
+// Now mirror an explicit captain request, then deliver the same kind of
+// healthy measured result. The branch's captain verdict must open exactly one
+// main turn for this requested answer.
+fire("turn_end", {}, {
+  model: { provider: "anthropic", id: "main-model" },
+  sessionManager: {
+    getSessionFile: () => `${home}/main.jsonl`,
+    getEntries: () => [{
+      type: "message",
+      message: { role: "user", content: "Please give me a fresh mini system-resource report." },
+    }],
+  },
+});
+const requested = dispatch("signal: requested healthy resource result");
+if (!requested.accepted) throw new Error("branch did not accept the requested result");
+await settle(() => (globalThis.__fmPrompts ?? []).length === 2, "requested result prompt");
+const captain = await report.execute(
+  "requested-result",
+  { task: "task-resource", verdict: "captain", summary: "healthy resource report: CPU 12%, memory 41%" },
+  undefined,
+  undefined,
+  {},
+);
+if (captain.isError) throw new Error(`requested captain result failed: ${JSON.stringify(captain)}`);
+const turns = sentToMain.filter((sent) => sent.options.triggerTurn === true);
+if (turns.length !== 1 || turns[0].options.deliverAs !== "followUp") {
+  throw new Error(`requested healthy result did not open exactly one main turn: ${JSON.stringify(sentToMain)}`);
+}
+if (sentToMain.length !== 2) throw new Error(`one result was reprocessed into ${sentToMain.length} main messages`);
+
+// The report boundary owns the event once: both outcomes are durable and
+// acknowledged, while the routine sailboat remains available for main's
+// judgment without another drain, rerun, or acknowledgement.
+const rows = readFileSync(`${home}/state/branch-outcomes.jsonl`, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+if (rows.length !== 2 || rows[0].verdict !== "routine" || rows[1].verdict !== "captain") {
+  throw new Error(`outcomes were not recorded once in order: ${JSON.stringify(rows)}`);
+}
+if (outcomeScript(["unread"]) !== "") throw new Error("handled outcomes remained unread for reprocessing");
+console.log("requested=one-turn unsolicited=routine-sailboat owned=once judgment=free");
+EOF
+  status=$?
+  out=$(cat "$TMP_ROOT/node-output")
+  expect_code 0 "$status" "requested and unsolicited healthy outcomes must follow their distinct public delivery paths: $out"
+  assert_contains "$out" "requested=one-turn unsolicited=routine-sailboat owned=once judgment=free" \
+    "behavioral regression did not exercise the requested, unsolicited, ownership, and judgment cases"
+  pass "a requested healthy result opens one turn, while an unsolicited equivalent stays a sailboat note and is handled once"
 }
 
 test_captain_outcome_encoding_failure_delivers_plain_instruction() {
@@ -834,9 +918,8 @@ if (delivered.options.triggerTurn !== true || delivered.options.deliverAs !== "f
 if (delivered.message.content.includes("FIRSTMATE_OP:")) {
   throw new Error(`fallback unexpectedly carried an envelope: ${delivered.message.content}`);
 }
-if (!delivered.message.content.includes("relay only this outcome to the captain now") ||
-    !delivered.message.content.includes("do not report it again") ||
-    !delivered.message.content.includes("Do not restate or repeat any earlier answer") ||
+if (!delivered.message.content.includes("The fleet event is already handled: do not re-drain, re-run, or acknowledge it.") ||
+    !delivered.message.content.includes("Use your judgment about whether and how to surface, summarize, reference, or incorporate this outcome in the captain conversation.") ||
     !delivered.message.content.includes("task-fallback: PR https://example.com/pr/fallback is ready")) {
   throw new Error(`fallback lost its instruction or outcome: ${delivered.message.content}`);
 }
@@ -2878,6 +2961,7 @@ JS
 test_outcomes_tool_uses_stock_execution_and_export_consumers
 test_real_pi_picker_primitives_stay_bounded_and_searchable
 test_branch_dispatch_two_stage_filter_and_prefix_contract
+test_requested_healthy_outcome_and_unsolicited_routine_outcome_delivery
 test_captain_outcome_encoding_failure_delivers_plain_instruction
 test_branch_dispatch_classifies_main_only_rows_and_writes_the_eligible_snapshot
 test_branch_cache_key_is_per_home_stable

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -905,14 +905,15 @@ if (visibleToMain.isError || !mainOutcomeText.includes("healthy resource report:
 }
 if (fleetOperations.length !== 2) throw new Error("main's outcome read reprocessed the fleet event");
 
-// Start a real main turn whose user entry is already in the session, then let
-// the result arrive before turn_end. The dispatch boundary must mirror that
-// current request before the branch provider classifies the equivalent result.
+// Start real main turns whose user entries are already in the session, then
+// let each result arrive before turn_end.
 const explicitRequest = "Please give me a fresh mini system-resource report.";
-const entries = [{
-  type: "message",
-  message: { role: "user", content: `${"background context ".repeat(300)}${explicitRequest}` },
-}];
+const longRequests = [
+  `${explicitRequest}${" head context".repeat(500)}`,
+  `${"middle context ".repeat(250)}${explicitRequest}${" middle context".repeat(250)}`,
+  `${"tail context ".repeat(500)}${explicitRequest}`,
+];
+const entries = [];
 const mainCtx = {
   model: { provider: "anthropic", id: "main-model" },
   sessionManager: {
@@ -920,27 +921,29 @@ const mainCtx = {
     getEntries: () => entries,
   },
 };
-fire("before_agent_start", { prompt: entries[0].message.content }, mainCtx);
-fire("agent_start", {}, mainCtx);
-const requested = dispatch("signal: healthy resource result");
-if (!requested.accepted) throw new Error("branch did not accept the requested result");
-await settle(() => fleetOperations.length === 4, "requested result acknowledgement");
-const deliveredRequestMirror = globalThis.__fmSessions[0].ops
-  .filter((op) => op.kind === "custom" && op.message.customType === "fm-main-mirror")
-  .at(-1)?.message.content;
-if (!deliveredRequestMirror?.endsWith(explicitRequest)) {
-  throw new Error(`pre-turn-end mirror dropped the captain request tail: ${deliveredRequestMirror}`);
+for (let index = 0; index < longRequests.length; index += 1) {
+  const content = longRequests[index];
+  if (content.length <= 4000) throw new Error(`request fixture ${index} did not exceed the mirror bound`);
+  entries.push({ type: "message", message: { role: "user", content } });
+  fire("before_agent_start", { prompt: content }, mainCtx);
+  fire("agent_start", {}, mainCtx);
+  const requested = dispatch("signal: healthy resource result");
+  if (!requested.accepted) throw new Error(`branch did not accept requested result ${index}`);
+  await settle(() => fleetOperations.length === 4 + (index * 2), `requested result ${index} acknowledgement`);
+  const deliveredRequestMirror = globalThis.__fmSessions[0].ops
+    .filter((op) => op.kind === "custom" && op.message.customType === "fm-main-mirror")
+    .at(-1)?.message.content;
+  if (deliveredRequestMirror !== `[captain] ${content}`) {
+    throw new Error(`pre-turn-end mirror changed long captain request ${index}`);
+  }
+  const turns = sentToMain.filter((sent) => sent.options.triggerTurn === true);
+  if (turns.length !== index + 1 || turns.at(-1).options.deliverAs !== "followUp") {
+    throw new Error(`requested result ${index} did not open exactly one main turn: ${JSON.stringify(sentToMain)}`);
+  }
 }
-if (!deliveredRequestMirror.includes("[mirror truncated:")) {
-  throw new Error("long captain request did not exercise the bounded mirror path");
-}
-if ((globalThis.__fmPrompts ?? []).length !== 2) throw new Error("a handled fleet wake was rerun");
-const turns = sentToMain.filter((sent) => sent.options.triggerTurn === true);
-if (turns.length !== 1 || turns[0].options.deliverAs !== "followUp") {
-  throw new Error(`pre-turn-end requested result did not open exactly one main turn: ${JSON.stringify(sentToMain)}`);
-}
-if (sentToMain.length !== 2) throw new Error(`one result was reprocessed into ${sentToMain.length} main messages`);
-if (fleetOperations.length !== 4 || fleetOperations.some((operation) => operation.status !== 0)) {
+if ((globalThis.__fmPrompts ?? []).length !== 4) throw new Error("a handled fleet wake was rerun");
+if (sentToMain.length !== 4) throw new Error(`one result was reprocessed into ${sentToMain.length} main messages`);
+if (fleetOperations.length !== 8 || fleetOperations.some((operation) => operation.status !== 0)) {
   throw new Error(`fleet event ownership repeated or failed work: ${JSON.stringify(fleetOperations)}`);
 }
 if (fleetOperations.some((operation) => operation.actor !== "branch")) {
@@ -950,7 +953,7 @@ if (existsSync(`${home}/state/.wake-queue`) && readFileSync(`${home}/state/.wake
   throw new Error("acknowledged fleet wake remained queued for another owner");
 }
 const rows = readFileSync(`${home}/state/branch-outcomes.jsonl`, "utf8").trim().split("\n").map((line) => JSON.parse(line));
-if (rows.length !== 2 || rows[0].verdict !== "routine" || rows[1].verdict !== "captain") {
+if (rows.length !== 4 || rows[0].verdict !== "routine" || rows.slice(1).some((row) => row.verdict !== "captain")) {
   throw new Error(`provider classifications were not recorded once in order: ${JSON.stringify(rows)}`);
 }
 if (outcomeScript(["unread"]) !== "") throw new Error("merged outcomes remained unread for redelivery");
@@ -1440,7 +1443,7 @@ const { fire, dispatch, settle, home } = globalThis.__t;
 import { existsSync, readFileSync } from "node:fs";
 
 const entries = [
-  { type: "message", message: { role: "user", content: "never merge task-7 without my word" } },
+  { type: "message", message: { role: "user", content: `never merge task-7 without my word ${"h".repeat(5000)} old-history-tail` } },
   { type: "message", message: { role: "assistant", content: [{ type: "text", text: "aye, holding task-7" }, { type: "toolCall", id: "t1" }] } },
   { type: "message", message: { role: "user", content: "⁣FIRSTMATE_OP: v1 watcher: operational injection" } },
   { type: "message", message: { role: "toolResult", content: "tool output stays in main" } },
@@ -1469,10 +1472,14 @@ if (JSON.stringify(kinds) !== JSON.stringify(["custom", "custom", "custom", "pro
 const mirrored = session.ops.filter((op) => op.kind === "custom").map((op) => op.message);
 if (mirrored.some((m) => m.customType !== "fm-main-mirror")) throw new Error("mirror used the wrong custom type");
 if (mirrored.some((m) => m.display !== false)) throw new Error("mirrored context must be silent");
-if (mirrored[0].content !== "[captain] never merge task-7 without my word") throw new Error(`bad captain mirror: ${mirrored[0].content}`);
+if (!mirrored[0].content.startsWith("[captain] never merge task-7 without my word") ||
+    !mirrored[0].content.includes("[mirror truncated:") ||
+    !mirrored[0].content.endsWith("old-history-tail")) {
+  throw new Error(`older captain history was not bounded: ${mirrored[0].content}`);
+}
 if (mirrored[1].content !== "[main] aye, holding task-7") throw new Error(`bad main mirror: ${mirrored[1].content}`);
-if (!mirrored[2].content.includes("[mirror truncated:") || !mirrored[2].content.endsWith("tail: retain this request")) {
-  throw new Error(`long dialog did not preserve its bounded head and tail: ${mirrored[2].content}`);
+if (mirrored[2].content !== `[captain] ${entries[6].message.content}`) {
+  throw new Error("current captain dialog was not preserved completely");
 }
 if (mirrored.some((m) => m.content.includes("operational injection") || m.content.includes("tool output") || m.content.includes("merged note"))) {
   throw new Error("mirror leaked operational, tool, or merge-note traffic");

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -146,6 +146,7 @@ export async function createAgentSession(options) {
       }
       session.ops.push({ kind: "prompt", text });
       (globalThis.__fmPrompts ??= []).push(text);
+      await globalThis.__fmOnBranchPrompt?.({ session, text });
     },
     async sendCustomMessage(message, opts) {
       if (globalThis.__fmMirrorGate) {
@@ -809,77 +810,132 @@ test_requested_healthy_outcome_and_unsolicited_routine_outcome_delivery() {
   PLUGIN="$repo/.pi/extensions/fm-branch-supervision.ts" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
     DRIVER_PRELUDE="$DRIVER_PRELUDE" node --input-type=module > "$TMP_ROOT/node-output" 2>&1 <<'EOF'
 const prelude = process.env.DRIVER_PRELUDE;
-await eval(`(async () => { ${prelude}; globalThis.__t = { fire, dispatch, settle, sentToMain, outcomeScript, home }; })()`);
-const { fire, dispatch, settle, sentToMain, outcomeScript, home } = globalThis.__t;
-import { readFileSync } from "node:fs";
+await eval(`(async () => { ${prelude}; globalThis.__t = { fire, dispatch, settle, sentToMain, outcomeScript, home, realRoot }; })()`);
+const { fire, dispatch, settle, sentToMain, outcomeScript, home, realRoot } = globalThis.__t;
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 
-// An equivalent healthy result with no captain request stays an ordinary
-// sailboat note and does not open a main turn.
+const fleetOperations = [];
+function runFleetCommand(kind, args) {
+  fleetOperations.push({ kind, args: [...args], actor: "branch" });
+  const result = spawnSync("bash", [`${realRoot}/bin/fm-wake-drain.sh`, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      FM_HOME: home,
+      FM_STATE_OVERRIDE: `${home}/state`,
+      FM_SUPERVISION_ACTOR: "branch",
+      FM_LEASE_HOLDER_PID: String(process.pid),
+    },
+  });
+  if (result.status !== 0) {
+    throw new Error(`${kind} failed (${result.status}): ${result.stdout}\n${result.stderr}`);
+  }
+  return result;
+}
+
+// The stubbed provider executes the same public branch turn contract as a real
+// provider: consume its delivered mirror context, drain the owned wake, choose
+// a verdict, report through the registered tool, and acknowledge that drain.
+globalThis.__fmOnBranchPrompt = async ({ session }) => {
+  const mirror = session.ops
+    .filter((op) => op.kind === "custom" && op.message.customType === "fm-main-mirror")
+    .map((op) => op.message.content);
+  const directlyRequested = mirror.some((text) =>
+    text === "[captain] Please give me a fresh mini system-resource report."
+  );
+  const drained = runFleetCommand("drain", []);
+  const ack = drained.stderr.match(/--ack-through ([0-9]+) --recovery-generation ([A-Za-z0-9._-]+)/);
+  if (!ack) throw new Error(`drain did not return its acknowledgement command: ${drained.stderr}`);
+  const report = session.options.customTools.find((tool) => tool.name === "fm_branch_report");
+  const result = await report.execute(
+    `resource-result-${fleetOperations.length}`,
+    {
+      task: "task-resource",
+      verdict: directlyRequested ? "captain" : "routine",
+      summary: "healthy resource report: CPU 12%, memory 41%",
+      wake: "signal: healthy resource result",
+    },
+    undefined,
+    undefined,
+    {},
+  );
+  if (result.isError) throw new Error(`branch report failed: ${JSON.stringify(result)}`);
+  runFleetCommand("ack", ["--ack-through", ack[1], "--recovery-generation", ack[2]]);
+};
+
+// With no captain request, the healthy result remains a rendered sailboat and
+// the scripted branch turn does not open main.
 const unsolicited = dispatch("signal: healthy resource result");
 if (!unsolicited.accepted) throw new Error("branch did not accept the unsolicited result");
-await settle(() => (globalThis.__fmPrompts ?? []).length === 1, "unsolicited result prompt");
-const report = globalThis.__fmSessions[0].options.customTools.find((tool) => tool.name === "fm_branch_report");
-const routine = await report.execute(
-  "unsolicited-result",
-  { task: "task-resource", verdict: "routine", summary: "healthy resource report: CPU 12%, memory 41%" },
-  undefined,
-  undefined,
-  {},
-);
-if (routine.isError) throw new Error(`unsolicited routine result failed: ${JSON.stringify(routine)}`);
+await settle(() => fleetOperations.length === 2, "unsolicited result acknowledgement");
 if (sentToMain.length !== 1 || sentToMain[0].options.triggerTurn) {
   throw new Error(`unsolicited healthy result opened a main turn: ${JSON.stringify(sentToMain)}`);
 }
-if (sentToMain[0].message.display !== true || !sentToMain[0].message.content.startsWith("⛵ task-resource:")) {
-  throw new Error(`unsolicited healthy result was not a rendered sailboat note: ${JSON.stringify(sentToMain[0])}`);
+const sailboat = sentToMain[0];
+if (sailboat.message.display !== true || !sailboat.message.content.startsWith("⛵ task-resource:")) {
+  throw new Error(`unsolicited healthy result was not a rendered sailboat note: ${JSON.stringify(sailboat)}`);
 }
 
-// Now mirror an explicit captain request, then deliver the same kind of
-// healthy measured result. The branch's captain verdict must open exactly one
-// main turn for this requested answer.
-fire("turn_end", {}, {
+// MAIN's next conversational turn can use the merged note as content without
+// taking fleet ownership. This provider adapter chooses to summarize it; the
+// operation ledger below proves that choice did not drain, rerun, or ack.
+function runMainConversationTurn(messages) {
+  const note = messages.find((sent) => sent.message.content.startsWith("⛵ task-resource:"));
+  if (!note) throw new Error("main could not see the sailboat outcome");
+  return `The latest ${note.message.content.slice(2)}`;
+}
+const mainReply = runMainConversationTurn(sentToMain);
+if (!mainReply.includes("healthy resource report: CPU 12%, memory 41%")) {
+  throw new Error(`main did not exercise judgment over the sailboat content: ${mainReply}`);
+}
+if (fleetOperations.length !== 2) throw new Error("main conversation reprocessed the fleet event");
+
+// Start a real main turn whose user entry is already in the session, then let
+// the result arrive before turn_end. The dispatch boundary must mirror that
+// current request before the branch provider classifies the equivalent result.
+const entries = [{
+  type: "message",
+  message: { role: "user", content: "Please give me a fresh mini system-resource report." },
+}];
+const mainCtx = {
   model: { provider: "anthropic", id: "main-model" },
   sessionManager: {
     getSessionFile: () => `${home}/main.jsonl`,
-    getEntries: () => [{
-      type: "message",
-      message: { role: "user", content: "Please give me a fresh mini system-resource report." },
-    }],
+    getEntries: () => entries,
   },
-});
-const requested = dispatch("signal: requested healthy resource result");
+};
+fire("before_agent_start", { prompt: entries[0].message.content }, mainCtx);
+fire("agent_start", {}, mainCtx);
+const requested = dispatch("signal: healthy resource result");
 if (!requested.accepted) throw new Error("branch did not accept the requested result");
-await settle(() => (globalThis.__fmPrompts ?? []).length === 2, "requested result prompt");
-const captain = await report.execute(
-  "requested-result",
-  { task: "task-resource", verdict: "captain", summary: "healthy resource report: CPU 12%, memory 41%" },
-  undefined,
-  undefined,
-  {},
-);
-if (captain.isError) throw new Error(`requested captain result failed: ${JSON.stringify(captain)}`);
+await settle(() => fleetOperations.length === 4, "requested result acknowledgement");
+if ((globalThis.__fmPrompts ?? []).length !== 2) throw new Error("a handled fleet wake was rerun");
 const turns = sentToMain.filter((sent) => sent.options.triggerTurn === true);
 if (turns.length !== 1 || turns[0].options.deliverAs !== "followUp") {
-  throw new Error(`requested healthy result did not open exactly one main turn: ${JSON.stringify(sentToMain)}`);
+  throw new Error(`pre-turn-end requested result did not open exactly one main turn: ${JSON.stringify(sentToMain)}`);
 }
 if (sentToMain.length !== 2) throw new Error(`one result was reprocessed into ${sentToMain.length} main messages`);
-
-// The report boundary owns the event once: both outcomes are durable and
-// acknowledged, while the routine sailboat remains available for main's
-// judgment without another drain, rerun, or acknowledgement.
+if (fleetOperations.map((operation) => operation.kind).join(",") !== "drain,ack,drain,ack") {
+  throw new Error(`fleet event ownership repeated or reordered work: ${JSON.stringify(fleetOperations)}`);
+}
+if (fleetOperations.some((operation) => operation.actor !== "branch")) {
+  throw new Error(`main took fleet-event ownership: ${JSON.stringify(fleetOperations)}`);
+}
+if (existsSync(`${home}/state/.wake-queue`) && readFileSync(`${home}/state/.wake-queue`, "utf8") !== "") {
+  throw new Error("acknowledged fleet wake remained queued for another owner");
+}
 const rows = readFileSync(`${home}/state/branch-outcomes.jsonl`, "utf8").trim().split("\n").map((line) => JSON.parse(line));
 if (rows.length !== 2 || rows[0].verdict !== "routine" || rows[1].verdict !== "captain") {
-  throw new Error(`outcomes were not recorded once in order: ${JSON.stringify(rows)}`);
+  throw new Error(`provider classifications were not recorded once in order: ${JSON.stringify(rows)}`);
 }
-if (outcomeScript(["unread"]) !== "") throw new Error("handled outcomes remained unread for reprocessing");
-console.log("requested=one-turn unsolicited=routine-sailboat owned=once judgment=free");
+if (outcomeScript(["unread"]) !== "") throw new Error("merged outcomes remained unread for redelivery");
+process.exit(0);
 EOF
   status=$?
   out=$(cat "$TMP_ROOT/node-output")
   expect_code 0 "$status" "requested and unsolicited healthy outcomes must follow their distinct public delivery paths: $out"
-  assert_contains "$out" "requested=one-turn unsolicited=routine-sailboat owned=once judgment=free" \
-    "behavioral regression did not exercise the requested, unsolicited, ownership, and judgment cases"
-  pass "a requested healthy result opens one turn, while an unsolicited equivalent stays a sailboat note and is handled once"
+  pass "requested and unsolicited healthy outcomes keep distinct delivery and event ownership"
 }
 
 test_captain_outcome_encoding_failure_delivers_plain_instruction() {

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -791,8 +791,8 @@ EOF
     *) fail "captain outcome body lost the event-ownership boundary: $body" ;;
   esac
   case "$body" in
-    *"Use your judgment about whether and how to surface, summarize, reference, or incorporate this outcome in the captain conversation."*) ;;
-    *) fail "captain outcome body imposed a mechanical conversational treatment: $body" ;;
+    *"This outcome is captain-facing: give the captain a visible response now."*"Use your judgment over the wording and how to incorporate it, not whether to surface it."*) ;;
+    *) fail "captain outcome body made visibility optional or removed wording judgment: $body" ;;
   esac
   case "$body" in
     *"An outcome that directly answers an explicit captain request is captain-facing"*"regardless of whether it is healthy, routine, measured, actionable, or requires a decision."*) ;;
@@ -849,14 +849,20 @@ async function runFleetCommand(session, args) {
   return result.details;
 }
 
-// The stubbed provider executes the same public branch turn contract as a real
-// provider: consume its delivered mirror context, drain the owned wake, choose
-// a verdict, report through the registered tool, and acknowledge that drain.
+function directlyRequestsResourceReport(mirror) {
+  const latestCaptain = mirror.at(-1) ?? "";
+  const words = new Set(latestCaptain.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean));
+  const requestsDelivery = ["give", "provide", "send", "show"].some((word) => words.has(word));
+  const namesReport = ["report", "status", "measurement"].some((word) => words.has(word));
+  const namesResources = ["resource", "resources", "cpu", "memory"].some((word) => words.has(word));
+  return requestsDelivery && namesReport && namesResources;
+}
+
 globalThis.__fmOnBranchPrompt = async ({ session }) => {
   const mirror = session.ops
     .filter((op) => op.kind === "custom" && op.message.customType === "fm-main-mirror")
     .map((op) => op.message.content);
-  const directlyRequested = mirror.length > 0;
+  const directlyRequested = directlyRequestsResourceReport(mirror);
   const drained = await runFleetCommand(session, []);
   const ack = drained.stderr.match(/--ack-through ([0-9]+) --recovery-generation ([A-Za-z0-9._-]+)/);
   if (!ack) throw new Error(`drain did not return its acknowledgement command: ${drained.stderr}`);
@@ -883,8 +889,25 @@ globalThis.__fmOnBranchPrompt = async ({ session }) => {
   await runFleetCommand(session, ["--ack-through", ack[1], "--recovery-generation", ack[2]]);
 };
 
-// With no captain request, the healthy result remains a rendered sailboat and
-// the scripted branch turn does not open main.
+const explicitRequest = "Please give me a fresh mini system-resource report.";
+const longRequests = [
+  `${explicitRequest}${" head context".repeat(500)}`,
+  `${"middle context ".repeat(250)}${explicitRequest}${" middle context".repeat(250)}`,
+  `${"tail context ".repeat(500)}${explicitRequest}`,
+];
+const entries = [{
+  type: "message",
+  message: { role: "user", content: "Please keep responses concise while monitoring the fleet." },
+}];
+const mainCtx = {
+  model: { provider: "anthropic", id: "main-model" },
+  sessionManager: {
+    getSessionFile: () => `${home}/main.jsonl`,
+    getEntries: () => entries,
+  },
+};
+fire("before_agent_start", { prompt: entries[0].message.content }, mainCtx);
+fire("agent_start", {}, mainCtx);
 const unsolicited = dispatch("signal: healthy resource result");
 if (!unsolicited.accepted) throw new Error("branch did not accept the unsolicited result");
 await settle(() => fleetOperations.length === 2, "unsolicited result acknowledgement");
@@ -905,22 +928,6 @@ if (visibleToMain.isError || !mainOutcomeText.includes("healthy resource report:
 }
 if (fleetOperations.length !== 2) throw new Error("main's outcome read reprocessed the fleet event");
 
-// Start real main turns whose user entries are already in the session, then
-// let each result arrive before turn_end.
-const explicitRequest = "Please give me a fresh mini system-resource report.";
-const longRequests = [
-  `${explicitRequest}${" head context".repeat(500)}`,
-  `${"middle context ".repeat(250)}${explicitRequest}${" middle context".repeat(250)}`,
-  `${"tail context ".repeat(500)}${explicitRequest}`,
-];
-const entries = [];
-const mainCtx = {
-  model: { provider: "anthropic", id: "main-model" },
-  sessionManager: {
-    getSessionFile: () => `${home}/main.jsonl`,
-    getEntries: () => entries,
-  },
-};
 for (let index = 0; index < longRequests.length; index += 1) {
   const content = longRequests[index];
   if (content.length <= 4000) throw new Error(`request fixture ${index} did not exceed the mirror bound`);
@@ -1002,7 +1009,8 @@ if (delivered.message.content.includes("FIRSTMATE_OP:")) {
   throw new Error(`fallback unexpectedly carried an envelope: ${delivered.message.content}`);
 }
 if (!delivered.message.content.includes("The fleet event is already handled: do not re-drain, re-run, or acknowledge it.") ||
-    !delivered.message.content.includes("Use your judgment about whether and how to surface, summarize, reference, or incorporate this outcome in the captain conversation.") ||
+    !delivered.message.content.includes("This outcome is captain-facing: give the captain a visible response now.") ||
+    !delivered.message.content.includes("Use your judgment over the wording and how to incorporate it, not whether to surface it.") ||
     !delivered.message.content.includes("task-fallback: PR https://example.com/pr/fallback is ready")) {
   throw new Error(`fallback lost its instruction or outcome: ${delivered.message.content}`);
 }

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -919,6 +919,11 @@ const unsolicitedPrompt = "Please keep responses concise while monitoring the fl
 fire("before_agent_start", { prompt: unsolicitedPrompt }, mainCtx);
 entries.push({ type: "message", message: { role: "user", content: unsolicitedPrompt } });
 fire("agent_start", {}, mainCtx);
+fire("agent_end", {}, mainCtx);
+const legacyOperational = "⁣FIRSTMATE_OP: give me a fresh system-resource report.";
+fire("before_agent_start", { prompt: legacyOperational }, mainCtx);
+entries.push({ type: "message", message: { role: "user", content: legacyOperational } });
+fire("agent_start", {}, mainCtx);
 const unsolicited = dispatch("signal: healthy resource result");
 if (!unsolicited.accepted) throw new Error("branch did not accept the unsolicited result");
 await settle(() => fleetOperations.length === 2, "unsolicited result acknowledgement");
@@ -969,8 +974,10 @@ for (const content of [unsolicitedPrompt, ...requestedPrompts]) {
   const copies = mirroredCaptainText.filter((text) => text === `[captain] ${content}`).length;
   if (copies !== 1) throw new Error(`current captain prompt was mirrored ${copies} times instead of once`);
 }
-if (mirroredCaptainText.some((text) => text.includes("operational watcher injection"))) {
-  throw new Error("canonical operational input entered captain mirror context");
+if (mirroredCaptainText.some((text) =>
+  text.includes("operational watcher injection") || text.includes("FIRSTMATE_OP: give me a fresh system-resource report")
+)) {
+  throw new Error("canonical current or legacy operational input entered captain mirror context");
 }
 if ((globalThis.__fmPrompts ?? []).length !== 5) throw new Error("a handled fleet wake was rerun");
 if (sentToMain.length !== 5) throw new Error(`one result was reprocessed into ${sentToMain.length} main messages`);

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -895,10 +895,10 @@ const longRequests = [
   `${"middle context ".repeat(250)}${explicitRequest}${" middle context".repeat(250)}`,
   `${"tail context ".repeat(500)}${explicitRequest}`,
 ];
-const entries = [{
-  type: "message",
-  message: { role: "user", content: "Please keep responses concise while monitoring the fleet." },
-}];
+// Match Pi's real AgentSession.prompt ordering: before_agent_start receives
+// the expanded prompt before _runAgentPrompt appends its user message to the
+// SessionManager. Keeping entries stale at the hook boundary is the regression.
+const entries = [];
 const mainCtx = {
   model: { provider: "anthropic", id: "main-model" },
   sessionManager: {
@@ -906,7 +906,9 @@ const mainCtx = {
     getEntries: () => entries,
   },
 };
-fire("before_agent_start", { prompt: entries[0].message.content }, mainCtx);
+const unsolicitedPrompt = "Please keep responses concise while monitoring the fleet.";
+fire("before_agent_start", { prompt: unsolicitedPrompt }, mainCtx);
+entries.push({ type: "message", message: { role: "user", content: unsolicitedPrompt } });
 fire("agent_start", {}, mainCtx);
 const unsolicited = dispatch("signal: healthy resource result");
 if (!unsolicited.accepted) throw new Error("branch did not accept the unsolicited result");
@@ -931,8 +933,9 @@ if (fleetOperations.length !== 2) throw new Error("main's outcome read reprocess
 for (let index = 0; index < longRequests.length; index += 1) {
   const content = longRequests[index];
   if (content.length <= 4000) throw new Error(`request fixture ${index} did not exceed the mirror bound`);
-  entries.push({ type: "message", message: { role: "user", content } });
   fire("before_agent_start", { prompt: content }, mainCtx);
+  // Pi persists this only after every before_agent_start handler has returned.
+  entries.push({ type: "message", message: { role: "user", content } });
   fire("agent_start", {}, mainCtx);
   const requested = dispatch("signal: healthy resource result");
   if (!requested.accepted) throw new Error(`branch did not accept requested result ${index}`);
@@ -947,6 +950,13 @@ for (let index = 0; index < longRequests.length; index += 1) {
   if (turns.length !== index + 1 || turns.at(-1).options.deliverAs !== "followUp") {
     throw new Error(`requested result ${index} did not open exactly one main turn: ${JSON.stringify(sentToMain)}`);
   }
+}
+const mirroredCaptainText = globalThis.__fmSessions[0].ops
+  .filter((op) => op.kind === "custom" && op.message.customType === "fm-main-mirror")
+  .map((op) => op.message.content);
+for (const content of [unsolicitedPrompt, ...longRequests]) {
+  const copies = mirroredCaptainText.filter((text) => text === `[captain] ${content}`).length;
+  if (copies !== 1) throw new Error(`current captain prompt was mirrored ${copies} times instead of once`);
 }
 if ((globalThis.__fmPrompts ?? []).length !== 4) throw new Error("a handled fleet wake was rerun");
 if (sentToMain.length !== 4) throw new Error(`one result was reprocessed into ${sentToMain.length} main messages`);

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -23,6 +23,7 @@ TEARDOWN="$ROOT/bin/fm-teardown.sh"
 PROMOTE="$ROOT/bin/fm-promote.sh"
 SESSION_START="$ROOT/bin/fm-session-start.sh"
 TMP_ROOT=$(fm_test_tmproot fm-public-followup)
+PF_TEST_NOW=1787539200
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
 command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found"; exit 0; }
@@ -97,7 +98,8 @@ run_pf() {  # <home> <args...>
   shift
   PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FAKE_CURL_LOG="${FAKE_CURL_LOG:-}" \
-    FAKE_FOLLOWUP_CODE="${FAKE_FOLLOWUP_CODE:-200}" "$PF" "$@"
+    FAKE_FOLLOWUP_CODE="${FAKE_FOLLOWUP_CODE:-200}" \
+    FMX_NOW_OVERRIDE="${FMX_NOW_OVERRIDE:-$PF_TEST_NOW}" "$PF" "$@"
 }
 
 tasks_in() {  # <home> <tasks-axi args...>
@@ -142,7 +144,7 @@ seed_commitment() {
     > "$home/state/x-inbox/$request.json"
   chmod 700 "$home/state/x-inbox"
   chmod 600 "$home/state/x-inbox/$request.json"
-  FM_HOME="$home" bash -c \
+  FM_HOME="$home" FMX_NOW_OVERRIDE="$PF_TEST_NOW" bash -c \
     ". '$ROOT/bin/fm-x-lib.sh'; fmx_context_registry_set '$home/state' '$request' '$platform' 1900" \
     || fail "could not retain the private request context"
 
@@ -172,7 +174,7 @@ seed_repro_commitment() {   # <home> <obligation> <request> <work-home> <work-id
     --expires-at 2026-10-01T00:00:00Z >/dev/null || fail "add failed"
   tasks_in "$home" public-followup bind-work "$obligation" --relation-file "$home/relation.json" >/dev/null \
     || fail "bind-work failed"
-  FM_HOME="$home" bash -c \
+  FM_HOME="$home" FMX_NOW_OVERRIDE="$PF_TEST_NOW" bash -c \
     ". '$ROOT/bin/fm-x-lib.sh'; fmx_context_registry_set '$home/state' '$request' discord 2000" \
     || fail "context retain failed"
   run_pf "$home" register "$obligation" --relation rel-code --work-home "$work_home" \

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -170,6 +170,8 @@ test_pi_snippet_uses_effective_extension_path() {
   assert_contains "$out" "-e $turnend -e $watch" "pi snippet did not render both effective extension launch paths"
   assert_contains "$out" "The turn-end guard extension lives at \`$turnend\`" "pi snippet did not render the turn-end guard extension path"
   assert_contains "$out" "The watcher extension lives at \`$watch\`" "pi snippet did not render the watcher extension path"
+  assert_contains "$out" "MAIN must not re-drain, re-run, or acknowledge it" "pi snippet lost merged-event ownership"
+  assert_contains "$out" "MAIN applies judgment about whether and how to surface, summarize, reference, or incorporate a merged sailboat outcome" "pi snippet imposed a mechanical sailboat treatment"
   assert_not_contains "$out" "__FM_PI_EXT__" "renderer leaked the Pi extension path placeholder"
   assert_not_contains "$out" "__FM_PI_TURNEND_EXT__" "renderer leaked the Pi turn-end extension path placeholder"
   assert_not_contains "$out" "state/fm-primary-pi-watch.ts" "pi snippet kept the old generated state-relative extension path"


### PR DESCRIPTION
## Intent

Captain-authorized Firstmate supervision-behavior fix: ship both corrections together in one focused PR. Diagnose from the real Pi branch-to-main path and identify the single authoritative owners before editing. Add the unconditional rule that an outcome directly answers an explicit captain request must be captain-facing, without qualifying by healthy, routine, measured, actionable, or requiring a decision. Main's sailboat handling must not impose a do-not-repeat rule: preserve event ownership so a merged outcome is already handled and MAIN must not re-drain, re-run, or acknowledge the fleet event, while separately and explicitly allowing MAIN to use judgment about whether and how to surface, summarize, reference, or incorporate the sailboat outcome in the captain conversation. Keep unsolicited routine outcomes as sailboat notes and unchanged fleet reviews silent; keep away mode completely out of scope and keep this independent of routing-recovery work. Review and keep consistent the Pi extension, generated supervision instructions, branch prompt, docs, and tests. Add executable behavioral regressions covering: a healthy result directly answering an explicit captain request opens exactly one main turn; an unsolicited equivalent healthy result remains routine/sailboat with no main turn; a sailboat event is not reprocessed, re-run, or re-acknowledged; and MAIN remains free to use sailboat content with judgment. Preserve outcome durability and duplicate-safe event ownership. Run the full relevant Firstmate tests and lint, then deliver through the no-mistakes pipeline through review, tests, lint, push, PR, and CI. Do not self-merge; merge remains captain-controlled with yolo off.

## What Changed

- Mirror complete in-flight captain prompts before branch dispatch so healthy outcomes directly answering explicit requests open exactly one captain-facing turn, while unsolicited routine outcomes remain sailboat notes.
- Preserve fleet-event ownership by preventing merged outcomes from being re-drained, re-run, or acknowledged, while allowing MAIN to use sailboat content with conversational judgment.
- Align branch guidance, generated supervision documentation, and behavioral regressions; stabilize public-followup fixtures with a pinned test clock.

## Risk Assessment

✅ Low: The changes are focused, preserve event ownership and routine delivery behavior, and add executable coverage for the requested captain-facing paths without introducing a substantiated new defect.

## Testing

After inspecting the target diff and confirming a clean worktree, I exercised the real Pi branch harness, supervision/outcome scripts, generated Pi instructions, and the changed time-pinned follow-up tests; requested healthy outcomes opened one main turn, unsolicited equivalents remained sailboat notes, ownership stayed duplicate-safe, and all targeted checks passed.

<details>
<summary>Evidence: Requested-outcome and sailboat end-to-end evidence</summary>

Source: [Requested-outcome and sailboat end-to-end evidence](https://github.com/kunchenguid/firstmate/blob/86def7c6b38aadb1cff3e2bc99eb2353a635c982/.no-mistakes/evidence/fm/fm-supervision-requested-outcome-sailboat-judgment-r1/requested-outcome-sailboat-e2e.txt)

```text
=== Executable Pi branch behavioral regression ===
ok - a captain outcome reaches main's model as typed, self-describing input while routine notes stay plain
ok - requested and unsolicited healthy outcomes keep distinct delivery and event ownership
ok - dialog mirror filters tool and operational traffic, lands before wakes, and keeps a durable cursor

=== Generated supervision branch verdict contract ===
# Verdict: routine or captain

Report verdict captain for any outcome that directly answers an explicit captain request.
This rule is unconditional: do not qualify it by whether the result is healthy, routine, measured, actionable, or requires a decision.
Also report verdict captain for:
- work ready for review - always include the full https:// PR URL in the summary;
- a decision only the captain can make, including every ask-user finding from a validation gate;
- a real blocker or failure after the playbook is exhausted;
- a needed credential or login;
- anything destructive, irreversible, or security-sensitive.
Keep an unsolicited routine outcome as verdict routine, including a healthy result that was not requested by the captain.
Keep an unchanged fleet review silent as instructed above.
When genuinely in doubt, choose captain: a spurious escalation costs a glance, a swallowed one costs trust.
Write summaries in the captain's outcome language - the project, the fix, the PR, the worker, the blocker - never internal mechanics like wake kinds, status prefixes, worktrees, or state file names.


=== Generated MAIN merged-outcome contract ===
Treat the merged fleet event as already handled for fleet operations: MAIN must not re-drain, re-run, or acknowledge it.
Separately, MAIN applies judgment about whether and how to surface, summarize, reference, or incorporate a merged sailboat outcome in the captain conversation; event ownership does not decide the conversational treatment.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6161c048bfc67677a155511dd28b8a1efdc7f639","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (7) ✅</summary>

- 🚨 `bin/fm-branch-prompt.sh:66` - The required rule remains unreachable for a fast result produced during the captain’s current main turn. Captain/main dialog is mirrored only at `turn_end`, while an accepted wake can prompt the branch immediately. Sequence: captain explicitly requests a report, main starts work, the result wake arrives before `turn_end`, and the branch classifies it without seeing that request, allowing `routine` and no main turn. This contradicts “an outcome directly answers an explicit captain request must be captain-facing.” Make the current dialog visible at the authoritative pre-prompt dispatch boundary, or serialize such wakes behind its mirror flush.
- 🚨 `tests/fm-pi-branch-extension.test.sh:853` - The required executable regressions are not actually present. The test manually supplies `verdict: &#34;captain&#34;` after manually firing `turn_end`, so it does not prove a requested healthy outcome is classified captain-facing or catch the pre-turn-end race. Likewise, line 874 checks the outcome-store read cursor—not the fleet wake ownership/ack path—and “judgment=free” is only a printed label, not observable MAIN behavior. This omits the intent’s required regressions for classification, no reprocessing/re-run/re-acknowledgement, and MAIN’s judgment over sailboat content.

🔧 Fix: Mirror in-flight captain requests before branch dispatch
1 error still open:

- 🚨 `tests/fm-pi-branch-extension.test.sh:883` - The required regression that “MAIN remains free to use sailboat content with judgment” still does not execute MAIN: `runMainConversationTurn` is test-local code that unconditionally formats the note. Likewise, every recorded fleet operation is hardcoded as actor `branch` at line 820, making the later actor assertion tautological. This cannot catch a production delivery regression that constrains MAIN or causes MAIN to re-drain/re-run/re-ack. Exercise the delivered sailboat through the executable main-turn adapter and record its observable reply and attempted fleet operations.

🔧 Fix: Exercise real branch ownership and main outcome access
2 errors still open:

- 🚨 `.pi/extensions/fm-branch-supervision.ts:946` - The required unconditional explicit-request behavior remains bypassable because pre-dispatch collection uses `collectMainDialog`, whose 4,000-character cap preserves only the beginning of each message. A captain can paste more than 4,000 characters and place “give me a resource report” at the end; a fast matching result then reaches the branch without the request and may remain routine. Preserve enough of the current captain message—such as both head and tail—at this authoritative boundary so the request remains classifiable.
- 🚨 `.pi/extensions/fm-branch-supervision.ts:634` - The changed prompt requires requested outcomes to be captain-facing unconditionally, but the verdict tool presented at the decision point still says `captain only for what a human must see; routine otherwise`. This competing instruction can steer a healthy requested result back to routine and violates the requirement to keep the Pi extension consistent with the unconditional rule. Update the tool schema to state the explicit-request rule alongside the remaining verdict criteria.

🔧 Fix: Preserve request tails and align verdict guidance
1 error still open:

- 🚨 `.pi/extensions/fm-branch-supervision.ts:316` - The required rule that “an outcome directly answers an explicit captain request must be captain-facing” remains bypassable. `capMirrorText` retains only the first and last 2,000 characters, so a request located in the omitted middle of a longer message never reaches classification; for example, 3,000 characters + “give me a resource report” + 3,000 characters drops the request and permits the healthy result to remain routine. Preserve the complete current request, or carry a dedicated lossless request channel at this pre-dispatch boundary; the regression currently exercises only a tail request.

🔧 Fix: Preserve complete current captain requests
2 errors still open:

- 🚨 `.pi/extensions/fm-branch-supervision.ts:143` - The intent requires that an outcome directly answering an explicit captain request “must be captain-facing,” but the delivered captain-outcome instruction says MAIN may use judgment “whether” to surface it. Concrete path: the branch correctly selects `captain`, opens the follow-up turn, and MAIN validly follows this instruction by not surfacing the requested result. Restrict the optional conversational treatment to routine sailboat outcomes; a requested captain verdict must require a captain-visible response while retaining judgment over wording.
- 🚨 `tests/fm-pi-branch-extension.test.sh:860` - The required requested-vs-unsolicited classification regression remains synthetic: `directlyRequested = mirror.length &gt; 0` treats any mirrored captain dialog as a resource-report request, while the unsolicited case is arranged to have no dialog. An unrelated captain message followed by the same unsolicited healthy resource result would therefore be classified `captain` by this test provider. Exercise both outcomes with realistic mirrored dialog and distinguish an actual matching request from unrelated conversation through the executable branch surface.

🔧 Fix: Require visible requested outcomes and realistic classification
✅ Re-checked - no issues remain.

- 🚨 `.pi/extensions/fm-branch-supervision.ts:1031` - The required unconditional captain-facing rule remains bypassable because `isOperationalUserText` treats every message beginning `FIRSTMATE ` or `FIRSTMATE_` as machinery. A genuine captain prompt such as `FIRSTMATE give me a resource report` is therefore omitted from the branch mirror, allowing its healthy answer to be classified routine without error. Use the canonical narrow operational-input classifier owned by `bin/fm-operational-input.sh` rather than the broad prefix heuristic, and cover this genuine near-miss through the executable branch path.

🔧 Fix: Use canonical operational input classification
1 error still open:

- 🚨 `.pi/extensions/fm-branch-supervision.ts:310` - The intent requires “Keep unsolicited routine outcomes as sailboat notes,” but this uses the current-only `kind` classifier rather than the canonical current-or-legacy `classify` surface. A persisted legacy operational message such as U+2063 `FIRSTMATE_OP: give me a resource report` is recognized by `fm-operational-input.sh classify` but not `kind`; after cursor reconstruction it enters the captain mirror and can make an unsolicited healthy result appear explicitly requested, opening a main turn. Use `classifyFirstmateOperationalText`; it preserves the genuine `FIRSTMATE give...` near-miss while filtering established operational protocol forms, and cover the legacy prefixed path behaviorally.

🔧 Fix: Filter legacy operational inputs canonically
1 error still open:

- 🚨 `.pi/extensions/fm-branch-supervision.ts:1022` - The required rule that an outcome directly answering an explicit captain request “must be captain-facing” remains bypassable because staging only observes `before_agent_start`. Pi does not emit that event for prompts queued while main is streaming: it places steer/follow-up input directly in the agent queue and persists it only when consumed. Concrete sequence: while main streams, the captain queues “give me a resource report”; before that queued message is consumed, its healthy-result wake dispatches; `collectCurrentMainDialog()` cannot see the request, so the branch may classify the result routine and open no main turn. Capture captain input at Pi’s supported `input` boundary, including streaming steer/follow-up input, then reconcile it with persisted dialog to preserve duplicate safety. The regression currently models only idle `before_agent_start` ordering.

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 4f89f5b5e235469d32c037b7792d6dba5bdc272d..50c8222868e58f21403ee752078d3dfb394a4af9` and focused diff inspection</code>
- `bash tests/fm-pi-branch-extension.test.sh`
- `bash tests/fm-branch-supervision.test.sh`
- `bash tests/fm-supervision-instructions.test.sh`
- <code>Instrumented replay of `tests/fm-pi-branch-extension.test.sh` capturing observable classifications, main-turn delivery, real fleet-operation actor identity, queue state, and MAIN outcome access</code>
- `git diff --check && git status --porcelain=v1`

✅ No issues found.
- `./bin/fm-test-run.sh tests/fm-pi-branch-extension.test.sh tests/fm-branch-supervision.test.sh tests/fm-supervision-instructions.test.sh`
- `Verified the transcript demonstrates requested versus unsolicited delivery, captain-visible follow-up behavior, sailboat handling, event ownership, dialog mirroring, and generated Pi supervision instructions.`
- <code>`git status --short` confirmed testing left the worktree clean.</code>

✅ No issues found.
- `git status --short && git diff --stat 4f89f5b5e235469d32c037b7792d6dba5bdc272d..fc07aa1014d9d17536ac9b67ac31f92d786d3d50`
- `bash tests/fm-pi-branch-extension.test.sh`
- `bash tests/fm-branch-supervision.test.sh`
- `bash tests/fm-supervision-instructions.test.sh`
- `bash tests/fm-public-followup.test.sh`
- `Executed the generated branch prompt and Pi supervision-instructions surfaces and captured their requested-outcome, event-ownership, and sailboat-judgment contracts alongside the behavioral regression transcript.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>
