### PR TITLE
fix(bin): avoid EPIPE broken-pipe noise in herdr events capability probe

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -3177,8 +3177,11 @@ fm_backend_herdr_events_capable() {  # <session>
   case "$protocol" in ''|*[!0-9]*) return 1 ;; esac
   [ "$protocol" -ge "$FM_BACKEND_HERDR_MIN_EVENTS_PROTOCOL" ] || return 1
   schema=$(herdr api schema --json 2>/dev/null) || return 1
-  printf '%s' "$schema" | grep -Fq 'events.subscribe' || return 1
-  printf '%s' "$schema" | grep -Fq 'pane.agent_status_changed' || return 1
+  # Substring checks stay in-shell: piping into `grep -q` makes grep exit at the
+  # first match and close the pipe, so printf takes EPIPE and bash logs a
+  # "write error: Broken pipe" line into the watcher stderr log on every probe.
+  case "$schema" in *events.subscribe*) ;; *) return 1 ;; esac
+  case "$schema" in *pane.agent_status_changed*) ;; *) return 1 ;; esac
   return 0
 }
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -282,7 +282,7 @@ The push path only shortens latency.
 Polling runs every cycle and remains the permanent fallback when protocol 16, the event schema, Python, connection, subscription, or repeated reader execution is unavailable.
 There is still one watcher process; the event reader is a bounded child of that watcher.
 
-`tests/fm-backend-herdr-eventwait-smoke.test.sh`, `tests/fm-transition-lib.test.sh`, and `tests/fm-supervision-events.test.sh` cover capability, subscribe-then-reconcile ordering, dedupe, exemptions, and polling fallback.
+`tests/fm-backend-herdr.test.sh`, `tests/fm-backend-herdr-eventwait-smoke.test.sh`, `tests/fm-transition-lib.test.sh`, and `tests/fm-supervision-events.test.sh` cover capability, subscribe-then-reconcile ordering, dedupe, exemptions, and polling fallback.
 
 ## Away-mode supervisor support
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -4290,6 +4290,56 @@ test_wait_transition_not_capable_returns_2() {
   pass "fm_backend_herdr_wait_transition: below-capability protocol/schema falls back to polling (rc 2)"
 }
 
+test_events_capable_true_when_both_markers_present() {
+  local dir log resp fb rc
+  dir="$TMP_ROOT/events-capable-true"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"client":{"version":"0.7.5","protocol":16},"server":{"running":true}}' > "$resp/1.out"
+  printf '%s\n' '{"schemas":{"methods":["events.subscribe","pane.agent_status_changed"]}}' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_events_capable sess' "$ROOT"
+  rc=$?
+  [ "$rc" = 0 ] || fail "events_capable must succeed when both markers are present in the schema, got $rc"
+  pass "fm_backend_herdr_events_capable: both markers present in schema returns capable"
+}
+
+test_events_capable_false_when_a_marker_is_missing() {
+  local dir log resp fb rc
+  dir="$TMP_ROOT/events-capable-missing"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"client":{"version":"0.7.5","protocol":16},"server":{"running":true}}' > "$resp/1.out"
+  printf '%s\n' '{"schemas":{"methods":["events.subscribe"]}}' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_events_capable sess' "$ROOT"
+  rc=$?
+  [ "$rc" = 1 ] || fail "events_capable must fail when pane.agent_status_changed is absent from the schema, got $rc"
+  pass "fm_backend_herdr_events_capable: a missing marker returns incapable"
+}
+
+test_events_capable_large_schema_produces_no_broken_pipe_noise() {
+  local dir log resp fb schema pad out rc
+  dir="$TMP_ROOT/events-capable-large"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"client":{"version":"0.7.5","protocol":16},"server":{"running":true}}' > "$resp/1.out"
+  # Put both markers near the start, then pad well past a pipe buffer so a
+  # substring check that still shelled out to `grep -q` would let grep exit
+  # (and close the pipe) long before the padding finished writing, forcing
+  # printf to take EPIPE and bash to log "write error: Broken pipe".
+  pad=$(printf 'x%.0s' $(seq 1 300000))
+  schema="{\"schemas\":{\"methods\":[\"events.subscribe\",\"pane.agent_status_changed\"]},\"pad\":\"$pad\"}"
+  printf '%s\n' "$schema" > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_events_capable sess' "$ROOT" 2>&1)
+  rc=$?
+  [ "$rc" = 0 ] || fail "events_capable must still succeed against a large schema, got $rc: $out"
+  case "$out" in *"Broken pipe"*) fail "events_capable must not leak an EPIPE 'Broken pipe' line on a large schema: $out" ;; esac
+  [ -z "$out" ] || fail "events_capable must print nothing on stdout/stderr for a passing probe: $out"
+  pass "fm_backend_herdr_events_capable: a large schema produces no broken-pipe stderr noise"
+}
+
 test_wait_transition_reconcile_blocked_returns_record() {
   local dir state agent temp fb reader lines out rc marker
   dir="$TMP_ROOT/wt-reconcile"; state="$dir/state"; agent="$dir/agents"; temp="$dir/temp"; mkdir -p "$state" "$agent" "$temp"
@@ -4596,6 +4646,9 @@ test_clear_transition_removes_task_marker
 test_apply_transition_defer_and_fallback_are_noops
 test_wait_transition_no_panes_returns_2
 test_wait_transition_not_capable_returns_2
+test_events_capable_true_when_both_markers_present
+test_events_capable_false_when_a_marker_is_missing
+test_events_capable_large_schema_produces_no_broken_pipe_noise
 test_wait_transition_reconcile_blocked_returns_record
 test_wait_transition_subscribes_before_reconcile
 test_wait_transition_reconcile_dedupes_when_marked


### PR DESCRIPTION
## Intent

Land the saved Herdr events-capability broken-pipe fix in the Firstmate repository through its normal review, test, PR, and CI path. In bin/backends/herdr.sh, fm_backend_herdr_events_capable() checked two schema substrings by piping printf into grep -Fq; because grep -q exits at the first match and closes the pipe, printf could take EPIPE and write 'Broken pipe' noise into the monitoring stderr log on every capability probe. Replaced those two substring probes with in-shell case statements that preserve the exact success/failure semantics (both markers required, same true/false verdict) while avoiding the EPIPE-producing pipe. Added executable behavioral regression coverage in tests/fm-backend-herdr.test.sh via the existing fake-herdr-CLI unit-test harness: a true case (both markers present), a false case (one marker missing), and a large-schema case that reproduces the EPIPE scenario end to end and asserts no 'Broken pipe' stderr leaks - tests exercise the function through its public interface only, no source-byte assertions. Reviewed call sites: fm_backend_herdr_events_capable is dispatched only from bin/fm-backend.sh's herdr) case and used only internally within bin/backends/herdr.sh (fm_backend_herdr_wait_transition), so no other backend (tmux, zellij, orca, cmux) or harness adapter reaches this code path - they are genuinely unaffected, confirmed by grepping all call sites rather than assumed. No documentation changes were needed since public/maintainer behavior and the function's black-box success/failure semantics are unchanged. I independently verified this exact commit locally with the repository-pinned ShellCheck 0.11.0 and actionlint 1.7.12: both clean, no findings. The captain authorized submitting this fix upstream via a fork: the current GitHub account (itivnik-ctrl) has no push permission to kunchenguid/firstmate, so a fork (itivnik-ctrl/firstmate) was created via gh-axi and the gate was reinitialized with --fork-url so the pipeline pushes the branch to the fork and opens the PR against upstream. Never push to upstream main, never bypass or hand-edit during an active run, and do not merge. Never add an agent co-author to commits.

## What Changed
- In `bin/backends/herdr.sh`, replaced the two `printf | grep -Fq` substring probes in `fm_backend_herdr_events_capable()` with in-shell `case` statements, preserving the exact true/false semantics (both markers required) while eliminating the EPIPE that occurred when `grep -q` closed the pipe early and `printf` wrote "Broken pipe" noise to stderr.
- Added regression coverage in `tests/fm-backend-herdr.test.sh` using the existing fake-herdr-CLI harness: a true case (both markers present), a false case (one marker missing), and a large-schema case reproducing the EPIPE scenario end-to-end and asserting no "Broken pipe" stderr leak.
- Updated `docs/herdr-backend.md` to list `tests/fm-backend-herdr.test.sh` as the capability test owner.

## Risk Assessment

✅ Low: Minimal, well-contained change replacing a pipe-based grep with in-shell case statements that preserve exact success/failure semantics, with regression tests covering the true/false/EPIPE-reproduction scenarios; single call site confirmed unaffected elsewhere.

## Testing

Ran the three targeted behavioral regression tests added for the fix (true/false marker cases plus the large-schema EPIPE reproduction) through the existing fake-herdr-CLI test harness; all passed, and the EPIPE case produced no 'Broken pipe' stderr output, confirming the in-shell case-statement replacement preserves success/failure semantics while eliminating the broken-pipe noise. Ran only this targeted subset (not the full 368-test file or repo suite) per the local-test scope boundary.

<details>
<summary>Evidence: Filtered test run output (3 new events-capable regression tests)</summary>

<code>ok - fm_backend_herdr_events_capable: both markers present in schema returns capable&#10;ok - fm_backend_herdr_events_capable: a missing marker returns incapable&#10;ok - fm_backend_herdr_events_capable: a large schema produces no broken-pipe stderr noise</code>

```text
ok - fm_backend_herdr_events_capable: both markers present in schema returns capable
ok - fm_backend_herdr_events_capable: a missing marker returns incapable
ok - fm_backend_herdr_events_capable: a large schema produces no broken-pipe stderr noise
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Extracted the 3 new tests (test_events_capable_true_when_both_markers_present, test_events_capable_false_when_a_marker_is_missing, test_events_capable_large_schema_produces_no_broken_pipe_noise) from tests/fm-backend-herdr.test.sh into a filtered harness copy (sourcing the same tests/lib.sh, tests/herdr-test-safety.sh, and bin/fm-backend.sh) and ran it with `bash filtered-herdr.test.sh` — all 3 passed (&#39;ok&#39;)</code>
- `Confirmed the large-schema case's stdout/stderr was empty and contained no 'Broken pipe' substring, directly demonstrating the EPIPE fix`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
