### PR TITLE
fix(gate): pin firstmate-repo validation to the claude gate agent

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -9,6 +9,13 @@
 # HEAD-continuity guard; see docs/architecture.md "No-mistakes gate authority boundary."
 disable_project_settings: true
 
+# The gate refuses any agent that cannot honor disable_project_settings above.
+# Only claude and codex implement that neutralization, so pin claude here rather
+# than leaving this repo on the host's shared default, which serves every other
+# repository. Like the other gate-control fields, this is read from the DEFAULT
+# BRANCH copy of this file, so pinning it on a feature branch has no effect.
+agent: claude
+
 # Trusted documentation placement policy for the Document step.
 # The audience inventory and coding guideline own the detail; keep this as a
 # pointer so gate instructions cannot become a second prose policy.


### PR DESCRIPTION
## What

Add `agent: claude` to this repository's `.no-mistakes.yaml`, with a comment recording why the pin exists.

That is the entire change - seven added lines in one file, nothing else touched.

## Why

This repository sets `disable_project_settings: true`, because its `AGENTS.md` installs a fleet-captain identity that a validation agent must never adopt. The gate refuses to launch any agent that cannot honor that setting, and only `claude` and `codex` implement the neutralization. With the host's shared default agent, validation on this repository fails before its first step:

```
gate agent "pi" does not neutralize the target repository's project
agent-instruction files (AGENTS.md/CLAUDE.md); refusing to launch it in the
target checkout. Only codex and claude have a verified neutralization knob
(and only when it is not overridden by agent_args_override); set 'agent' to
codex or claude in ~/.no-mistakes/config.yaml
```

The refusal is correct. The fix belongs here rather than in the host's shared configuration, which serves every other repository on the same daemon: changing it there would move unrelated work onto a different model to solve a problem that is specific to this repository. The shared configuration's own comment already records the per-repo pin as the intended durable fix.

`codex` is not installed on the affected host, so `claude` is the pin. The existing `claude` argument override does not pin `--setting-sources`, so it does not defeat the neutralization (`claudeEffectiveSettingSourcesNeutral`, `internal/agent/claude.go`): the gate appends `--setting-sources user` itself and accepts the agent.

The comment also records that gate-control fields are read from the **default-branch** copy of this file, so nobody loses time pinning it on a feature branch and expecting it to take effect.

## Why this is a direct pull request

This is a bootstrap change, delivered without a validation run because the validation path for this repository is exactly what is unavailable until it lands. Pinning the agent on a feature branch has no effect, since the gate reads `agent` only from the default branch, so the pipeline cannot validate the change that would let the pipeline run here. Once this is on `main`, ordinary validated delivery resumes for this repository, starting with the work that hit the refusal.

## Risk

Configuration only; no executable code paths change. The field is one the gate already reads and validates, and it is scoped to this repository. If the pin is wrong, validation refuses to start exactly as it does today rather than running with a weakened boundary.
