### PR TITLE
fix(bin): preserve Codex harness ancestry detection

### DIFF
--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -86,14 +86,17 @@ detect_own() {
         case "$(basename -- "$comm")" in
           codex-linux-sandbox) echo codex; return ;;
         esac
-        # Linux can truncate comm to TASK_COMM_LEN, so confirm the exact
-        # executable from argv[0] before accepting a shortened process name.
-        args=$(ps -o args= -p "$pid" 2>/dev/null || true)
-        if [ -n "$args" ]; then
-          case "$(basename -- "${args%% *}")" in
-            codex-linux-sandbox) echo codex; return ;;
-          esac
-        fi
+        # Linux truncates comm to TASK_COMM_LEN, so accept only the known
+        # truncated sandbox name after argv[0] confirms the exact executable.
+        # Do not let an arbitrary PID-1 command borrow Codex's argv[0].
+        case "$(basename -- "$comm")" in
+          codex-linux-san)
+            args=$(ps -o args= -p "$pid" 2>/dev/null || true)
+            case "$(basename -- "${args%% *}")" in
+              codex-linux-sandbox) echo codex; return ;;
+            esac
+            ;;
+        esac
       fi
       break
     fi

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -84,8 +84,16 @@ detect_own() {
     if [ "$pid" -le 1 ]; then
       if [ "$pid" -eq 1 ]; then
         case "$(basename -- "$comm")" in
-          *codex*) echo codex; return ;;
+          codex-linux-sandbox) echo codex; return ;;
         esac
+        # Linux can truncate comm to TASK_COMM_LEN, so confirm the exact
+        # executable from argv[0] before accepting a shortened process name.
+        args=$(ps -o args= -p "$pid" 2>/dev/null || true)
+        if [ -n "$args" ]; then
+          case "$(basename -- "${args%% *}")" in
+            codex-linux-sandbox) echo codex; return ;;
+          esac
+        fi
       fi
       break
     fi

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -74,7 +74,9 @@ detect_own() {
   # multiplexer's stored environment, which is the precedence hazard above.
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args argv0
-  for _ in 1 2 3 4 5 6 7 8; do
+  # Keep the reach aligned with fm-session-lock-lib.sh so a primary session
+  # deep enough to acquire the fleet lock is still attributed to its harness.
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     argv0=$(fm_cursor_argv0_for_pid "$pid" "$comm" 2>/dev/null || true)
     if fm_cursor_process_matches "$comm" '' "$argv0"; then
@@ -106,10 +108,13 @@ detect_own() {
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac
-    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    if [ -z "$pid" ] || [ "$pid" -le 1 ]; then
+    # A Codex shell tool can put codex-linux-sandbox at PID 1 inside its
+    # process namespace. Inspect that process before terminating the walk.
+    if [ "$pid" -le 1 ]; then
       break
     fi
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    [ -n "$pid" ] || break
   done
   echo unknown
 }

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -78,6 +78,17 @@ detect_own() {
   # deep enough to acquire the fleet lock is still attributed to its harness.
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
+    # Codex shell tools can expose codex-linux-sandbox as PID 1 inside their
+    # process namespace. That is the only verified PID-1 harness signal; keep
+    # every other adapter's previous classification behavior unchanged.
+    if [ "$pid" -le 1 ]; then
+      if [ "$pid" -eq 1 ]; then
+        case "$(basename -- "$comm")" in
+          *codex*) echo codex; return ;;
+        esac
+      fi
+      break
+    fi
     argv0=$(fm_cursor_argv0_for_pid "$pid" "$comm" 2>/dev/null || true)
     if fm_cursor_process_matches "$comm" '' "$argv0"; then
       echo cursor
@@ -108,11 +119,6 @@ detect_own() {
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac
-    # A Codex shell tool can put codex-linux-sandbox at PID 1 inside its
-    # process namespace. Inspect that process before terminating the walk.
-    if [ "$pid" -le 1 ]; then
-      break
-    fi
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] || break
   done

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -146,6 +146,13 @@ EOF
 # True if $1 is a live process that looks like a verified harness.
 fm_harness_pid_alive() {
   local pid=$1 comm args
+  # PID 1 can be a namespace-local Codex sandbox and is useful only for
+  # non-authoritative harness attribution.  It is never valid session-lock
+  # ownership, including when inspecting a lock left by an older process.
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "$pid" -gt 1 ] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   args=$(ps -o args= -p "$pid" 2>/dev/null)

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -119,11 +119,8 @@ fm_harness_ancestry_pids() {
     elif [ "$extending" -eq 1 ]; then
       break
     fi
-    if [ "$pid" -le 1 ]; then
-      break
-    fi
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] || break
+    [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
   done
   [ "$printed" -eq 1 ]
 }

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -119,8 +119,11 @@ fm_harness_ancestry_pids() {
     elif [ "$extending" -eq 1 ]; then
       break
     fi
+    if [ "$pid" -le 1 ]; then
+      break
+    fi
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
+    [ -n "$pid" ] || break
   done
   [ "$printed" -eq 1 ]
 }

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -108,6 +108,10 @@ fm_harness_process_matches() {  # <comm> <args>
 # reported and the callers below decide what they need from it.
 fm_harness_ancestry_pids() {
   local pid=$$ comm args extending=0 printed=0
+  # A namespace-local PID 1 may be a verified Codex sandbox for advisory
+  # harness attribution, but it must never enter the authoritative lock-owner
+  # candidate set.
+  [ "$pid" -gt 1 ] || return 1
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -166,6 +166,13 @@ SH
     [ "$got" = unknown ] \
       || fail "PID-1 $other resolved '$got', expected preserved unknown classification"
   done
+
+  got=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    -u CURSOR_AGENT -u CURSOR_INVOKED_AS FM_FAKE_PID_ONE_COMM=claude \
+    FM_FAKE_PID_ONE_ARGS='/usr/local/bin/codex-linux-sandbox --sandbox-policy-cwd /repo' \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$got" = unknown ] \
+    || fail "a non-truncated PID-1 command borrowed Codex sandbox argv[0]: $got"
   pass "fm-harness classifies only the verified Codex sandbox identity at PID 1"
 }
 

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -122,7 +122,7 @@ SH
 }
 
 test_codex_pid_one_detection() {
-  local dir fakebin got
+  local dir fakebin got other
   dir="$TMP_ROOT/codex-pid-one"
   fakebin=$(fm_fakebin "$dir")
   cat > "$fakebin/ps" <<'SH'
@@ -137,8 +137,8 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 case "$pid:$field" in
-  1:comm=) printf '%s\n' codex ;;
-  1:args=) printf '%s\n' 'codex-linux-sandbox --sandbox-policy-cwd /repo' ;;
+  1:comm=) printf '%s\n' "${FM_FAKE_PID_ONE_COMM:-codex-linux-sandbox}" ;;
+  1:args=) printf '%s\n' "${FM_FAKE_PID_ONE_COMM:-codex-linux-sandbox}" ;;
   1:ppid=) printf '%s\n' 0 ;;
   *:comm=) printf '%s\n' bash ;;
   *:args=) printf '%s\n' bash ;;
@@ -151,7 +151,15 @@ SH
     -u CURSOR_AGENT -u CURSOR_INVOKED_AS PATH="$fakebin:$BASE_PATH" \
     "$ROOT/bin/fm-harness.sh")
   [ "$got" = codex ] || fail "PID-1 Codex sandbox resolved '$got', expected codex"
-  pass "fm-harness inspects a Codex sandbox process at PID 1 before stopping"
+
+  for other in claude opencode grok kimi muse pi pi-signed cursor-agent; do
+    got=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+      -u CURSOR_AGENT -u CURSOR_INVOKED_AS FM_FAKE_PID_ONE_COMM="$other" \
+      PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+    [ "$got" = unknown ] \
+      || fail "PID-1 $other resolved '$got', expected preserved unknown classification"
+  done
+  pass "fm-harness classifies only the verified Codex sandbox signal at PID 1"
 }
 
 # ===========================================================================

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -121,6 +121,39 @@ SH
   pass "fm-harness detects only Cursor Agent CLI's exact invocation marker"
 }
 
+test_codex_pid_one_detection() {
+  local dir fakebin got
+  dir="$TMP_ROOT/codex-pid-one"
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  1:comm=) printf '%s\n' codex ;;
+  1:args=) printf '%s\n' 'codex-linux-sandbox --sandbox-policy-cwd /repo' ;;
+  1:ppid=) printf '%s\n' 0 ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' bash ;;
+  *:ppid=) printf '%s\n' 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  got=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    -u CURSOR_AGENT -u CURSOR_INVOKED_AS PATH="$fakebin:$BASE_PATH" \
+    "$ROOT/bin/fm-harness.sh")
+  [ "$got" = codex ] || fail "PID-1 Codex sandbox resolved '$got', expected codex"
+  pass "fm-harness inspects a Codex sandbox process at PID 1 before stopping"
+}
+
 # ===========================================================================
 # C) fm-harness.sh secondmate-model / secondmate-effort token resolution
 # ===========================================================================
@@ -2549,6 +2582,7 @@ SH
 
 test_harness_resolution
 test_cursor_marker_detection
+test_codex_pid_one_detection
 test_secondmate_model_effort_tokens
 test_pi_signed_detection_and_session_lock_identity
 test_dash_leading_process_names_are_basename_operands

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -2174,7 +2174,8 @@ SH
       "$ROOT/bin/fm-config-push.sh" > "$first_out" 2>&1
   ) &
   first_pid=$!
-  for _ in $(seq 1 100); do
+  # Allow slow filesystems enough time to reach the controlled delivery rendezvous.
+  for _ in $(seq 1 300); do
     [ -e "$entered" ] && break
     sleep 0.02
   done

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -138,7 +138,7 @@ while [ "$#" -gt 0 ]; do
 done
 case "$pid:$field" in
   1:comm=) printf '%s\n' "${FM_FAKE_PID_ONE_COMM:-codex-linux-sandbox}" ;;
-  1:args=) printf '%s\n' "${FM_FAKE_PID_ONE_COMM:-codex-linux-sandbox}" ;;
+  1:args=) printf '%s\n' "${FM_FAKE_PID_ONE_ARGS:-${FM_FAKE_PID_ONE_COMM:-codex-linux-sandbox}}" ;;
   1:ppid=) printf '%s\n' 0 ;;
   *:comm=) printf '%s\n' bash ;;
   *:args=) printf '%s\n' bash ;;
@@ -152,14 +152,21 @@ SH
     "$ROOT/bin/fm-harness.sh")
   [ "$got" = codex ] || fail "PID-1 Codex sandbox resolved '$got', expected codex"
 
-  for other in claude opencode grok kimi muse pi pi-signed cursor-agent; do
+  got=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    -u CURSOR_AGENT -u CURSOR_INVOKED_AS FM_FAKE_PID_ONE_COMM=codex-linux-san \
+    FM_FAKE_PID_ONE_ARGS='/usr/local/bin/codex-linux-sandbox --sandbox-policy-cwd /repo' \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$got" = codex ] \
+    || fail "truncated PID-1 Codex sandbox command resolved '$got', expected codex"
+
+  for other in codex codex-helper mycodex claude opencode grok kimi muse pi pi-signed cursor-agent; do
     got=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
       -u CURSOR_AGENT -u CURSOR_INVOKED_AS FM_FAKE_PID_ONE_COMM="$other" \
       PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
     [ "$got" = unknown ] \
       || fail "PID-1 $other resolved '$got', expected preserved unknown classification"
   done
-  pass "fm-harness classifies only the verified Codex sandbox signal at PID 1"
+  pass "fm-harness classifies only the verified Codex sandbox identity at PID 1"
 }
 
 # ===========================================================================

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -134,41 +134,6 @@ SH
   pass "session-lock: ordinary script paths under a harness directory are not harness processes"
 }
 
-test_pid_one_codex_acquires_session_lock() {
-  local dir fakebin out
-  dir="$TMP_ROOT/pid-one-codex"
-  fakebin=$(fm_fakebin "$dir")
-  mkdir -p "$dir/state"
-  cat > "$fakebin/ps" <<'SH'
-#!/usr/bin/env bash
-set -u
-field= pid=
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    -o) field=$2; shift 2 ;;
-    -p) pid=$2; shift 2 ;;
-    *) shift ;;
-  esac
-done
-case "$pid:$field" in
-  1:comm=) printf '%s\n' codex ;;
-  1:args=) printf '%s\n' 'codex-linux-sandbox --sandbox-policy-cwd /repo' ;;
-  *:comm=) printf '%s\n' bash ;;
-  *:args=) printf '%s\n' bash ;;
-  *:ppid=) printf '%s\n' 1 ;;
-esac
-SH
-  chmod +x "$fakebin/ps"
-
-  out=$(FM_HOME="$dir" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" 2>&1) \
-    || fail "a Codex harness at PID 1 did not acquire the session lock: $out"
-  assert_contains "$out" "lock acquired: harness pid 1" \
-    "the session lock did not resolve the PID-1 Codex harness"
-  [ "$(tr -d '[:space:]' < "$dir/state/.lock")" = 1 ] \
-    || fail "the session lock did not record the PID-1 Codex harness"
-  pass "session-lock: a Codex harness at PID 1 acquires the home"
-}
-
 test_harness_beyond_a_gap_never_owns_the_lock() {
   local dir fakebin got
   dir="$TMP_ROOT/gap"
@@ -393,7 +358,6 @@ test_e2e_daemon_parented_version_named_session_keeps_its_lock() {
 
 test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
-test_pid_one_codex_acquires_session_lock
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
 test_e2e_version_named_session_claims_the_home

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -134,6 +134,41 @@ SH
   pass "session-lock: ordinary script paths under a harness directory are not harness processes"
 }
 
+test_pid_one_codex_acquires_session_lock() {
+  local dir fakebin out
+  dir="$TMP_ROOT/pid-one-codex"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  1:comm=) printf '%s\n' codex ;;
+  1:args=) printf '%s\n' 'codex-linux-sandbox --sandbox-policy-cwd /repo' ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' bash ;;
+  *:ppid=) printf '%s\n' 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(FM_HOME="$dir" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" 2>&1) \
+    || fail "a Codex harness at PID 1 did not acquire the session lock: $out"
+  assert_contains "$out" "lock acquired: harness pid 1" \
+    "the session lock did not resolve the PID-1 Codex harness"
+  [ "$(tr -d '[:space:]' < "$dir/state/.lock")" = 1 ] \
+    || fail "the session lock did not record the PID-1 Codex harness"
+  pass "session-lock: a Codex harness at PID 1 acquires the home"
+}
+
 test_harness_beyond_a_gap_never_owns_the_lock() {
   local dir fakebin got
   dir="$TMP_ROOT/gap"
@@ -358,6 +393,7 @@ test_e2e_daemon_parented_version_named_session_keeps_its_lock() {
 
 test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
+test_pid_one_codex_acquires_session_lock
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
 test_e2e_version_named_session_claims_the_home

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -172,6 +172,13 @@ SH
     "the session lock did not fail closed at PID 1"
   assert_absent "$dir/state/.lock" \
     "the session lock persisted namespace-local PID 1 as authoritative ownership"
+
+  # A stale PID-1 lock from an earlier process must not continue to block the
+  # home as if the namespace-local sandbox were authoritative ownership.
+  printf '1\n' > "$dir/state/.lock"
+  out=$(FM_HOME="$dir" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+  [ "$out" = 'lock: stale (pid 1 dead or not a harness)' ] \
+    || fail "PID-1 lock status resolved '$out', expected a stale lock"
   pass "session-lock: PID 1 classifies Codex but never becomes authoritative ownership"
 }
 

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -134,6 +134,47 @@ SH
   pass "session-lock: ordinary script paths under a harness directory are not harness processes"
 }
 
+test_pid_one_codex_classification_never_owns_session_lock() {
+  local dir fakebin detected out status=0
+  dir="$TMP_ROOT/pid-one-codex"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  1:comm=) printf '%s\n' /usr/local/bin/codex-linux-sandbox ;;
+  1:args=) printf '%s\n' 'codex-linux-sandbox --sandbox-policy-cwd /repo' ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' bash ;;
+  *:ppid=) printf '%s\n' 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  detected=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+    -u CURSOR_AGENT -u CURSOR_INVOKED_AS PATH="$fakebin:$PATH" \
+    "$ROOT/bin/fm-harness.sh")
+  [ "$detected" = codex ] \
+    || fail "PID-1 Codex classification resolved '$detected', expected codex"
+
+  out=$(FM_HOME="$dir" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+  expect_code 1 "$status" "PID-1 Codex session-lock acquisition"
+  assert_contains "$out" "cannot locate harness process in ancestry" \
+    "the session lock did not fail closed at PID 1"
+  assert_absent "$dir/state/.lock" \
+    "the session lock persisted namespace-local PID 1 as authoritative ownership"
+  pass "session-lock: PID 1 classifies Codex but never becomes authoritative ownership"
+}
+
 test_harness_beyond_a_gap_never_owns_the_lock() {
   local dir fakebin got
   dir="$TMP_ROOT/gap"
@@ -358,6 +399,7 @@ test_e2e_daemon_parented_version_named_session_keeps_its_lock() {
 
 test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
+test_pid_one_codex_classification_never_owns_session_lock
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
 test_e2e_version_named_session_claims_the_home

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1966,6 +1966,7 @@ SH
 
   # shellcheck disable=SC2016 # $$ must expand in the launched shell, not here.
   out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+    -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" \
     bash -c 'export FM_FAKE_HARNESS_PID=$$; exec "$1" 8 "$2"' _ "$nest" "$SESSION_START")
 

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1913,6 +1913,48 @@ EOF
   pass "a session start inside its budget prints no truncation banner"
 }
 
+test_codex_pid_one_acquires_lock_and_selects_supervision() {
+  local rec root home fakebin out
+  rec=$(new_world codex-pid-one)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  1:comm=) printf '%s\n' codex ;;
+  1:args=) printf '%s\n' 'codex-linux-sandbox --sandbox-policy-cwd /repo' ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' bash ;;
+  *:ppid=) printf '%s\n' 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+    -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" \
+    "$SESSION_START")
+
+  assert_contains "$out" "lock acquired: harness pid 1" \
+    "session start did not acquire the lock from its PID-1 Codex harness"
+  assert_not_contains "$out" "READ-ONLY SESSION" \
+    "session start became read-only under its PID-1 Codex harness"
+  assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: codex" \
+    "session start lost Codex supervision under its PID-1 harness"
+  pass "a session under a PID-1 Codex harness acquires the lock and selects Codex supervision"
+}
+
 test_runtime_bound_leaves_harness_ancestry_headroom() {
   local rec root home fakebin nest out
   rec=$(new_world runtime-bound-ancestry)
@@ -2507,6 +2549,7 @@ test_pi_diagnostic_rejects_previous_session_loaded_marker
 test_runtime_bound_truncates_loudly_and_exits_zero
 test_portable_timeout_escalates_term_resistant_process
 test_runtime_bound_leaves_a_healthy_digest_untouched
+test_codex_pid_one_acquires_lock_and_selects_supervision
 test_runtime_bound_leaves_harness_ancestry_headroom
 test_reemit_skips_startup_sweeps_but_keeps_the_wake_drain
 test_agents_baseline_stays_at_true_start_and_reemits_on_every_drifted_pi_compact

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1936,11 +1936,11 @@ for argument in "$@"; do
 done
 case "$*" in
   *"comm="*)
-    if [ "$pid" = "${FM_FAKE_HARNESS_PID:-}" ]; then printf '%s\n' /usr/local/bin/claude
+    if [ "$pid" = "${FM_FAKE_HARNESS_PID:-}" ]; then printf '%s\n' /usr/local/bin/codex
     else printf '%s\n' /bin/bash; fi
     ;;
   *"args="*)
-    if [ "$pid" = "${FM_FAKE_HARNESS_PID:-}" ]; then printf '%s\n' claude
+    if [ "$pid" = "${FM_FAKE_HARNESS_PID:-}" ]; then printf '%s\n' codex
     else printf '%s\n' bash; fi
     ;;
   *"ppid="*) /bin/ps -o ppid= -p "$pid" ;;
@@ -1973,8 +1973,10 @@ SH
     "the runtime bound's wrapper processes pushed the harness out of the bounded ancestry walk"
   assert_not_contains "$out" "READ-ONLY SESSION" \
     "a session start eight shells below its harness was wrongly refused the lock"
+  assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: codex" \
+    "the deep Codex session acquired the lock but lost its harness attribution"
 
-  pass "the runtime bound leaves enough ancestry headroom for a deeply nested session to take the lock"
+  pass "the runtime bound preserves lock ownership and harness attribution for a deeply nested session"
 }
 
 # --- context re-emit (--reemit) ----------------------------------------------

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1913,48 +1913,6 @@ EOF
   pass "a session start inside its budget prints no truncation banner"
 }
 
-test_codex_pid_one_acquires_lock_and_selects_supervision() {
-  local rec root home fakebin out
-  rec=$(new_world codex-pid-one)
-  IFS='|' read -r root home fakebin <<EOF
-$rec
-EOF
-  make_fake_toolchain "$fakebin"
-  cat > "$fakebin/ps" <<'SH'
-#!/usr/bin/env bash
-set -u
-field= pid=
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    -o) field=$2; shift 2 ;;
-    -p) pid=$2; shift 2 ;;
-    *) shift ;;
-  esac
-done
-case "$pid:$field" in
-  1:comm=) printf '%s\n' codex ;;
-  1:args=) printf '%s\n' 'codex-linux-sandbox --sandbox-policy-cwd /repo' ;;
-  *:comm=) printf '%s\n' bash ;;
-  *:args=) printf '%s\n' bash ;;
-  *:ppid=) printf '%s\n' 1 ;;
-esac
-SH
-  chmod +x "$fakebin/ps"
-
-  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
-    -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
-    FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" \
-    "$SESSION_START")
-
-  assert_contains "$out" "lock acquired: harness pid 1" \
-    "session start did not acquire the lock from its PID-1 Codex harness"
-  assert_not_contains "$out" "READ-ONLY SESSION" \
-    "session start became read-only under its PID-1 Codex harness"
-  assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: codex" \
-    "session start lost Codex supervision under its PID-1 harness"
-  pass "a session under a PID-1 Codex harness acquires the lock and selects Codex supervision"
-}
-
 test_runtime_bound_leaves_harness_ancestry_headroom() {
   local rec root home fakebin nest out
   rec=$(new_world runtime-bound-ancestry)
@@ -2549,7 +2507,6 @@ test_pi_diagnostic_rejects_previous_session_loaded_marker
 test_runtime_bound_truncates_loudly_and_exits_zero
 test_portable_timeout_escalates_term_resistant_process
 test_runtime_bound_leaves_a_healthy_digest_untouched
-test_codex_pid_one_acquires_lock_and_selects_supervision
 test_runtime_bound_leaves_harness_ancestry_headroom
 test_reemit_skips_startup_sweeps_but_keeps_the_wake_drain
 test_agents_baseline_stays_at_true_start_and_reemits_on_every_drifted_pi_compact


### PR DESCRIPTION
## Intent

Fix Firstmate so Codex launched from nested shells or a namespace where codex-linux-sandbox is PID 1 is detected as codex instead of unknown. Keep the change narrow and current-main-compatible: align the non-authoritative harness classifier with the existing 16-hop session-lock ancestry budget, allow PID 1 only for verified Codex sandbox classification, and preserve the session-lock safety boundary so PID 1 never becomes authoritative lock ownership. Preserve existing behavior for other supported harnesses, add regression coverage for the deep Codex attribution and PID-1 safety cases, and refresh existing PR https://github.com/kunchenguid/firstmate/pull/3243 without opening a replacement.

## What Changed

- Extend `fm-harness.sh` ancestry detection to 16 hops and recognize only the verified `codex-linux-sandbox` identity at PID 1, including a truncated-command fallback.
- Keep PID 1 outside authoritative session-lock ownership while allowing non-authoritative Codex harness attribution.
- Add regression coverage for deep Codex ancestry, PID-1 classification and lock safety, and session-start attribution.

## Risk Assessment

✅ Low: The narrow classifier change extends the existing ancestry budget, recognizes only the exact Codex sandbox identity at PID 1, and leaves PID-1 session-lock ownership fail-closed with behavioral coverage.

## Testing

Executed end-user CLI behavior with deterministic process-table fixtures: a Codex process at ancestry hop 16 reports `codex`; a PID-1 Codex sandbox also reports `codex`, but the real lock command fails closed and leaves no lock file. Reviewer-visible transcripts were saved as evidence; the worktree remains clean.

<details>
<summary>Evidence: Deep Codex ancestry CLI transcript</summary>

Source: [Deep Codex ancestry CLI transcript](https://github.com/racket-raccoon/firstmate/blob/b9399a4c87d119ac85a0185c00b165538ad47514/.no-mistakes/evidence/fix/codex-harness-ancestry/codex-deep-ancestry-cli.log)

<code>Deep ancestry classification (15 shells above tool process, Codex at hop 16):&#10;codex</code>

```text
Deep ancestry classification (15 shells above tool process, Codex at hop 16):
codex
```
</details>
<details>
<summary>Evidence: PID-1 Codex classification and lock-safety CLI transcript</summary>

Source: [PID-1 Codex classification and lock-safety CLI transcript](https://github.com/racket-raccoon/firstmate/blob/b9399a4c87d119ac85a0185c00b165538ad47514/.no-mistakes/evidence/fix/codex-harness-ancestry/codex-pid-one-lock-cli.log)

<code>PID-1 Codex sandbox classification:&#10;codex&#10;PID-1 lock acquisition (must fail closed):&#10;error: cannot locate harness process in ancestry&#10;exit=1; lock-file=absent</code>

```text
PID-1 Codex sandbox classification:
codex
PID-1 lock acquisition (must fail closed):
error: cannot locate harness process in ancestry
exit=1; lock-file=absent
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"481f04d13fb7d6d5cec8777667a7eecd52f2a1cc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`env … bash -c &#39;export FM_START_PID=$$; exec bin/fm-harness.sh&#39;` with deterministic 16-hop ancestry fixture</code>
- <code>`env … bin/fm-harness.sh` and real `bin/fm-lock.sh` with deterministic PID-1 `codex-linux-sandbox` fixture</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
