### PR TITLE
fix(codex): detect managed sessions and require host watcher context

### DIFF
--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -33,8 +33,9 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
   # Keep marker detection before ancestry detection as an explicit precedence rule.
-  # Claude, Pi, Grok, and Cursor set verified markers of their own; codex,
-  # opencode, Kimi, and Muse are markerless, so a foreign marker retained in a terminal
+  # Claude, Pi, Grok, Cursor, and current Codex managed surfaces set verified
+  # markers of their own; opencode, Kimi, and Muse are markerless, so a foreign
+  # marker retained in a terminal
   # multiplexer's stored environment can silently misidentify one of them before
   # ancestry is consulted. This is a precedence hazard, not evidence that
   # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
@@ -65,6 +66,11 @@ detect_own() {
   # identified, and any rule that must be RELIABLE under grok has to test the hook
   # markers too (see .claude/settings.json Stop entries, docs/turnend-guard.md).
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # Current Codex managed sessions publish both identifiers to hook and tool
+  # subprocesses. Require the pair so a single unrelated CODEX_* variable is not
+  # promoted into harness identity.
+  [ -n "${CODEX_SESSION_ID:-}" ] && [ -n "${CODEX_THREAD_ID:-}" ] \
+    && { echo codex; return; }
   # muse (Muse Code) publishes no harness-identity marker of its own. The only
   # MUSE_* variable it is documented to hand a child is MUSE_CURRENT_SESSION_LOG,
   # a per-session log PATH rather than an identity, and its export to tool
@@ -107,9 +113,7 @@ detect_own() {
         esac ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    if [ -z "$pid" ] || [ "$pid" -le 1 ]; then
-      break
-    fi
+    case "$pid" in ''|*[!0-9]*|0) break ;; esac
   done
   echo unknown
 }

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -138,7 +138,7 @@ repair_line() {
       printf '%s%s\n' "$prefix" 'watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.'
       ;;
     codex)
-      printf '%s%s%s%s\n' "$prefix" 'repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds ' "$checkpoint_seconds" '.'
+      printf '%s%s%s%s\n' "$prefix" 'repair missing watcher supervision with a foreground checkpoint, using host-context approval when Codex reports its managed PID sandbox: bin/fm-watch-checkpoint.sh --seconds ' "$checkpoint_seconds" '.'
       ;;
     pi|pi-signed)
       printf '%s%s%s%s%s%s\n' "$prefix" 'repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ' "$pi_turnend_ext" ' -e ' "$pi_ext" ' if the extensions are not loaded.'

--- a/bin/fm-watch-checkpoint.sh
+++ b/bin/fm-watch-checkpoint.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Run one bounded foreground watcher checkpoint for harnesses that should not
 # rely on background-task completion to wake the model.
+# A Codex managed PID sandbox cannot safely reconcile host-owned process-event
+# runner PIDs, so that surface fails before starting the watcher and must be
+# retried through Codex's host-context approval path.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -13,7 +16,19 @@ Usage: fm-watch-checkpoint.sh [--seconds <n>]
 Run bin/fm-watch.sh in the foreground for a bounded checkpoint.
 On an actionable watcher wake, pass through the watcher output and exit 0.
 On a quiet checkpoint, print "checkpoint: no actionable wake within <n>s" and exit 124.
+Inside Codex's managed PID sandbox, refuse before starting the watcher and ask
+the caller to rerun this same command with host-context approval.
 EOF
+}
+
+codex_managed_pid_sandbox() {
+  local pid1
+  [ -n "${CODEX_PERMISSION_PROFILE:-}" ] || return 1
+  pid1=$(ps -o comm= -p 1 2>/dev/null | tr -d '[:space:]') || return 1
+  case "$pid1" in
+    codex|codex-*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 while [ "$#" -gt 0 ]; do
@@ -43,6 +58,12 @@ case "$SECONDS_ARG" in
   ''|*[!0-9]*) echo "error: --seconds must be a positive integer" >&2; exit 2 ;;
   0) echo "error: --seconds must be greater than zero" >&2; exit 2 ;;
 esac
+
+if codex_managed_pid_sandbox; then
+  printf '%s\n' "error: Codex's managed PID sandbox cannot safely own Firstmate watcher supervision." >&2
+  printf '%s\n' 'Rerun this foreground checkpoint with host-context approval.' >&2
+  exit 1
+fi
 
 OUT=$(mktemp "${TMPDIR:-/tmp}/fm-watch-checkpoint.out.XXXXXX") || exit 1
 ERR=$(mktemp "${TMPDIR:-/tmp}/fm-watch-checkpoint.err.XXXXXX") || {

--- a/docs/supervision-protocols/codex.md
+++ b/docs/supervision-protocols/codex.md
@@ -5,6 +5,7 @@ When this session owns supervision and away mode is not active:
    After handling all emitted wakes and reconciling open decisions and unread status lines, run the exact `--ack-through` command printed as `WAKE_ACK_REQUIRED`; until then the work remains durable for idempotent re-handling after interruption.
 2. Source `__FM_X_MODE_ENV__` first when Relay is active.
 3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`.
+   If the helper reports Codex's managed PID sandbox, rerun that same checkpoint with host-context approval so Firstmate can safely reconcile host-owned process-event runners.
 4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
 5. If the command prints `checkpoint:` or exits 124 with no wake, drain queued wakes anyway, process any queued user message now visible to Codex, then start the next checkpoint.
 6. Never use shell `&` or Codex background tasks for firstmate watcher supervision.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -432,6 +432,12 @@ grok 0.2.103 (89c3d36fb6f1) [stable]
 | Pi | `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` | One initial tool call led to extension-owned successors and clean child retirement on exit. |
 | Grok | `FM_GROK_LIVE_E2E=1 tests/fm-grok-continuity-live-e2e.test.sh` | Native task completion surfaced the actionable close and the cycle ledger recorded `reason=actionable-signal`. |
 
+Codex managed-shell compatibility was reverified on 2026-08-28 against `codex-cli 0.150.1`.
+The live managed tool surface published paired `CODEX_SESSION_ID` and `CODEX_THREAD_ID` markers, and the patched `bin/fm-harness.sh` returned `codex` despite the isolated PID namespace.
+Inside the managed PID sandbox, `bin/fm-watch-checkpoint.sh --seconds 1` refused before starting watcher state with `error: Codex's managed PID sandbox cannot safely own Firstmate watcher supervision.` and directed a host-context retry.
+A ten-second checkpoint against the live home with Codex host-context approval delivered the registered GitHub issue-label check without the prior process-event reconciliation segmentation fault.
+The portable regression commands were `tests/fm-watch-checkpoint.test.sh`, `tests/fm-supervision-instructions.test.sh`, and `tests/fm-secondmate-harness.test.sh`; all passed, with the harness suite proving both the paired-marker path and Codex-at-PID-1 ancestry.
+
 Pi 0.81.1 repeated the continuity and clean-exit lifecycle on 2026-07-23 after the Calm presentation changes.
 
 Pi same-process session-transition ownership was verified on 2026-07-27 against the tracked extension with a faithful in-process factory rebind (module cache retained, real arm children):

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -58,6 +58,7 @@ set -u
 # ambient markers so what this suite asserts does not depend on which harness it
 # was launched from; every case states the marker it means to test.
 unset CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT CURSOR_AGENT CURSOR_INVOKED_AS
+unset CODEX_PERMISSION_PROFILE CODEX_SESSION_ID CODEX_THREAD_ID
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 fm_git_identity fmtest fmtest@example.com
@@ -119,6 +120,51 @@ SH
     PATH="$fakebin:$BASE_PATH" CURSOR_INVOKED_AS=cursor "$ROOT/bin/fm-harness.sh")
   [ "$got" != cursor ] || fail "an inexact Cursor marker value was accepted as Cursor Agent CLI"
   pass "fm-harness detects only Cursor Agent CLI's exact invocation marker"
+}
+
+test_codex_managed_marker_and_pid_one_detection() {
+  local dir fakebin got
+  dir="$TMP_ROOT/codex-managed-identity"
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "${FM_TEST_PID1_CODEX:-0}:$pid:$field" in
+  1:1:comm=) printf '%s\n' codex ;;
+  1:1:args=) printf '%s\n' 'codex managed shell' ;;
+  1:1:ppid=) printf '%s\n' 0 ;;
+  1:*:ppid=) printf '%s\n' 1 ;;
+  *:*:comm=) printf '%s\n' bash ;;
+  *:*:args=) printf '%s\n' bash ;;
+  *:*:ppid=) printf '%s\n' 0 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  got=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    CODEX_SESSION_ID=session CODEX_THREAD_ID=thread FM_TEST_PID1_CODEX=0 \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$got" = codex ] || fail "paired Codex managed markers resolved '$got', expected codex"
+
+  got=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u CODEX_THREAD_ID \
+    CODEX_SESSION_ID=session FM_TEST_PID1_CODEX=0 \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$got" = unknown ] || fail "a lone Codex session marker resolved '$got', expected unknown"
+
+  got=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    -u CODEX_SESSION_ID -u CODEX_THREAD_ID -u CODEX_PERMISSION_PROFILE \
+    FM_TEST_PID1_CODEX=1 PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$got" = codex ] || fail "Codex at PID 1 resolved '$got', expected codex"
+
+  pass "fm-harness detects paired Codex managed markers and inspects PID 1 ancestry"
 }
 
 # ===========================================================================
@@ -2549,6 +2595,7 @@ SH
 
 test_harness_resolution
 test_cursor_marker_detection
+test_codex_managed_marker_and_pid_one_detection
 test_secondmate_model_effort_tokens
 test_pi_signed_detection_and_session_lock_identity
 test_dash_leading_process_names_are_basename_operands

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -48,6 +48,7 @@ test_repair_lines() {
   mkdir -p "$home/state" "$home/config"
   out=$(FM_HOME="$home" FM_CODEX_WATCH_CHECKPOINT=7 "$RENDER" --harness codex --repair-line)
   assert_contains "$out" "bin/fm-watch-checkpoint.sh --seconds 7" "codex repair line did not use checkpoint helper and env override"
+  assert_contains "$out" "host-context approval" "codex repair line omitted the managed PID sandbox retry"
 
   out=$(FM_HOME="$home" "$RENDER" --harness claude --queue-pending 1 --repair-line)
   assert_contains "$out" "After draining queued wakes" "queue-pending prefix missing"
@@ -116,6 +117,7 @@ test_cross_harness_ordinary_continuation_and_repair_matrix() {
   out=$("$RENDER" --harness codex --repair-line)
   assert_contains "$out" "foreground checkpoint" "codex recovery line lost its checkpoint repair"
   assert_contains "$out" "bin/fm-watch-checkpoint.sh" "codex recovery line lost the checkpoint command"
+  assert_contains "$out" "host-context approval" "codex recovery line lost the managed PID sandbox retry"
 
   pass "renderer preserves every harness ordinary-continuation and missing-cycle repair path"
 }

--- a/tests/fm-watch-checkpoint.test.sh
+++ b/tests/fm-watch-checkpoint.test.sh
@@ -7,6 +7,7 @@ set -u
 
 CHECKPOINT="$ROOT/bin/fm-watch-checkpoint.sh"
 TMP_ROOT=$(fm_test_tmproot fm-watch-checkpoint)
+unset CODEX_PERMISSION_PROFILE CODEX_SESSION_ID CODEX_THREAD_ID
 
 make_home() {
   local name=$1 home
@@ -87,7 +88,35 @@ test_existing_singleton_watcher_is_not_success() {
   pass "checkpoint rejects an existing watcher singleton as unowned"
 }
 
+test_codex_managed_pid_sandbox_refuses_before_watcher_start() {
+  local home fakebin out err status base_path
+  home=$(make_home codex-pid-sandbox)
+  fakebin=$(fm_fakebin "$home/fakebin")
+  base_path=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+if [ "$*" = '-o comm= -p 1' ]; then
+  printf '%s\n' codex
+  exit 0
+fi
+exec "$FM_TEST_REAL_PS" "$@"
+SH
+  chmod +x "$fakebin/ps"
+  out="$home/out.txt"
+  err="$home/err.txt"
+  status=0
+  CODEX_PERMISSION_PROFILE=managed FM_TEST_REAL_PS=$(command -v ps) \
+    PATH="$fakebin:$base_path" FM_HOME="$home" "$CHECKPOINT" --seconds 1 \
+    >"$out" 2>"$err" || status=$?
+  expect_code 1 "$status" "Codex managed PID sandbox checkpoint exit"
+  assert_contains "$(cat "$err")" "managed PID sandbox" "checkpoint did not identify the unsafe Codex PID sandbox"
+  assert_contains "$(cat "$err")" "host-context approval" "checkpoint did not direct the safe retry path"
+  assert_absent "$home/state/.watch.lock/pid" "checkpoint started a watcher inside the managed PID sandbox"
+  pass "checkpoint refuses Codex's managed PID sandbox before touching watcher state"
+}
+
 test_quiet_checkpoint_exits_124_cleanly
 test_signal_passes_through_and_exits_zero
 test_registered_check_uses_preserved_watcher_environment
 test_existing_singleton_watcher_is_not_success
+test_codex_managed_pid_sandbox_refuses_before_watcher_start


### PR DESCRIPTION
## Summary
- detect Codex managed sessions from paired session/thread identifiers and PID 1 ancestry
- refuse watcher checkpoints inside Codex's managed PID sandbox before touching watcher state
- direct Codex supervision to retry the checkpoint with host-context approval

## Why
In a Herdr-managed Codex primary, Herdr reported agent=codex while fm-harness.sh returned unknown because the tool subprocess ancestry ended at PID 1. That selected the unknown supervision protocol, stopped recurring GitHub checks, and left firstmate:go notifications unhandled.

## Verification
- tests/fm-watch-checkpoint.test.sh
- tests/fm-supervision-instructions.test.sh
- tests/fm-secondmate-harness.test.sh
- bin/fm-doc-audience-check.sh

Live verification on the affected home: the patched detector reports codex; a host-context checkpoint recovered issues #203-#206 from state/gh-issue-go.check.sh.