### PR TITLE
fix(skills): hide agent-only skills from Pi model catalog

### DIFF
--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   This skill is the single owner of finding-decision policy: firstmate always applies judgment, decides findings that are unambiguous toward accepted intent, and escalates only genuinely ambiguous, expanding, or destructive ones.
   Finding authority is this skill's criteria, not the project's yolo posture.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, HOME_SUMMARY, BACKLOG_RECONCILE, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or reports that an interrupted backlog cleanup may have left an endpoint or local copy, or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
   A silent bootstrap section, or any other BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/captain-hold-lifecycle/SKILL.md
+++ b/.agents/skills/captain-hold-lifecycle/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Agent-only policy for completing investigations and visual reviews without losing unresolved captain calls, and for closing what the captain owns with his actual words.
   Load before treating an investigation, scout report, structured review, or Lavish review as complete, before ending a visual review that exposed a captain decision, when recording or routing the captain's answer, and on any RECORD DIVERGENCE line the wake drain prints.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Renamed pointer kept for in-flight briefs: the decisions concept collapsed into "a task held for the captain".
   Load captain-hold-lifecycle instead; this stub only redirects and will be removed one release after the collapse.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/diagnostic-reasoning/SKILL.md
+++ b/.agents/skills/diagnostic-reasoning/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   Use before scoping a reported bug and before acting on a diagnostic report.
   Owns end-user-aligned reproduction, causal separation, divergent-path and history inspection, counterfactual testing, and disconfirming evidence.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/firstmate-codexapp/SKILL.md
+++ b/.agents/skills/firstmate-codexapp/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Agent-only playbook for coordinating visible Codex Desktop threads alongside Firstmate without pretending they are a selectable shell backend.
   Use before creating, reading, steering, archiving, debugging, or reviewing a Codex App visible thread for Firstmate work, and before responding to requests to make Codex App native to Firstmate.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   Use before editing any of that material, whether working as firstmate directly or as a crewmate briefed on a firstmate-repo task.
   Covers the knowledge-placement decision tree, the one-owner rule for contracts, the inline-stub pattern for content moved into a skill, AGENTS.md size discipline, trigger hygiene for new skills, and repo style rules (one sentence per line, plain dash, no agent co-author, shellcheck-clean bin scripts, colocated tests, and maintainer-verification evidence).
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/firstmate-orca/SKILL.md
+++ b/.agents/skills/firstmate-orca/SKILL.md
@@ -2,6 +2,7 @@
 name: firstmate-orca
 description: Agent-only operator checklist for Firstmate's Orca runtime backend. Use when switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/fmx-respond/SKILL.md
+++ b/.agents/skills/fmx-respond/SKILL.md
@@ -8,6 +8,7 @@ description: >-
   Also use on a "public-followup ..." check wake, and whenever a promised final public reply must be created, reconciled, or delivered.
   Loaded only when Relay is enabled.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
   Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, and muse.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/process-event-sources/SKILL.md
+++ b/.agents/skills/process-event-sources/SKILL.md
@@ -11,6 +11,7 @@ description: >-
   rule, the precise durability boundary, and the Lavish adapter's loss
   limitation.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   Cloning or registering a project is add intake and uses the same trigger.
   Owns project add, create, clone, remove, initialization, registry, delivery-mode, autonomy, and outward-consent decisions.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   orthogonal gates.
   Load when a dispatch rule or default resolves to more than one profile candidate.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   Use when creating, seeding, validating, launching, recovering, handing backlog to, pushing inherited local material into, or retiring a secondmate home, or when editing data/secondmates.md.
   Covers local leases, whole-home remote routes, transactional seeding, record intake for an existing or inherited domain, project clone restrictions, secondmate harness pins, inherited local-material push, idle charter, handoff helper, and teardown safety.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   Use when the session-start digest reports an ordinary direct report's endpoint dead or its metadata has no window, or after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
   Reconciles recorded work before escalating from targeted inspection through safe relaunch or failure.
 user-invocable: false
+disable-model-invocation: true
 metadata:
   internal: true
 ---

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -205,7 +205,7 @@ family_for_basename() {
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-lint-workflows.test.sh|\
-    fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
+    fm-operational-input.test.sh|fm-pi-primary-types.test.sh|fm-pi-skill-catalog.test.sh|\
     fm-harness-adapter-references.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -421,6 +421,10 @@
       "audience": "maintainer-verification"
     },
     {
+      "path": "docs/verification/pi-skill-catalog.md",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/verification/process-event-sources.md",
       "audience": "maintainer-verification"
     },

--- a/docs/verification/pi-skill-catalog.md
+++ b/docs/verification/pi-skill-catalog.md
@@ -1,0 +1,73 @@
+# Pi skill-catalog verification
+
+Audience: maintainer verification.
+
+This record preserves the full-prompt measurement for hiding Firstmate's 15 agent-only skills from Pi's automatic model catalog.
+The behavioral contract remains enforced by `tests/fm-pi-skill-catalog.test.sh`; this record owns the version-scoped byte evidence and its refresh method.
+
+## Full-prompt audit
+
+The audit was run on 2026-08-28 with Pi 0.84.0 on macOS against public base `420721401c4080d1a4f6982b0ef6769e2a749b23` and task head `8abb49e25da4e1211a933ca57e72c4c745b78276`.
+Both captures used the same clean disposable checkout path, the same installed Pi configuration, and the normal discovered project context and skill catalog.
+The only source difference was the task head.
+Pi's command context exposed the complete generated system prompt without starting an agent turn or making a provider request.
+
+Create this test-only hook in `.tmp-skill-catalog-audit/capture-system-prompt.ts` inside the disposable checkout:
+
+```ts
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { writeFileSync } from "node:fs";
+
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand("fm-capture-full-prompt", {
+    description: "Capture Pi's complete generated system prompt",
+    handler: async (_args, ctx) => {
+      const prompt = ctx.getSystemPrompt();
+      writeFileSync(
+        process.env.FM_PI_PROMPT_CAPTURE!,
+        JSON.stringify({
+          prompt,
+          bytes: Buffer.byteLength(prompt, "utf8"),
+          skills: ctx.getSystemPromptOptions().skills,
+        }),
+      );
+    },
+  });
+}
+```
+
+Run this command at the base, save the resulting `before.json`, switch the same clean disposable checkout to the head, and run it again with `LABEL=after`.
+Keeping the checkout path fixed matters because Pi includes each skill's absolute location in the generated catalog.
+
+```sh
+LABEL=before
+AUDIT_DIR="$PWD/.tmp-skill-catalog-audit"
+printf '%s\n' \
+  '{"id":"capture","type":"prompt","message":"/fm-capture-full-prompt"}' \
+  | PI_OFFLINE=1 \
+    FM_PI_PROMPT_CAPTURE="$AUDIT_DIR/$LABEL.json" \
+    pi --mode rpc --approve --no-session --no-extensions \
+      -e "$AUDIT_DIR/capture-system-prompt.ts" \
+      --no-prompt-templates --no-themes \
+      --model openai-codex/gpt-5.6-sol --thinking low \
+      >"$AUDIT_DIR/$LABEL.rpc" \
+      2>"$AUDIT_DIR/$LABEL.stderr"
+jq '{bytes, loadedSkills:(.skills | length)}' "$AUDIT_DIR/$LABEL.json"
+```
+
+The raw bounded output was:
+
+```text
+base=420721401c4080d1a4f6982b0ef6769e2a749b23
+head=8abb49e25da4e1211a933ca57e72c4c745b78276
+pi=0.84.0
+before={"bytes":92325,"loadedSkills":29,"catalogSkills":29}
+after={"bytes":82784,"loadedSkills":29,"catalogSkills":14}
+saved=9541
+providerRequests=0
+```
+
+The 29 loaded skills comprised all 20 Firstmate skills and nine installed global skills in both captures.
+After the change, the automatic catalog retained those nine global skills plus the five captain-invocable Firstmate skills, while all 29 skill records remained loaded.
+The focused behavioral regression separately confirms that Pi retains all 20 Firstmate skill commands.
+The measured reduction was 9,541 UTF-8 bytes in Pi's complete generated system prompt.

--- a/docs/verification/pi-skill-catalog.md
+++ b/docs/verification/pi-skill-catalog.md
@@ -9,11 +9,11 @@ This record owns the version-scoped byte evidence and its refresh method.
 
 ## Full-prompt audit
 
-The audit was run on 2026-08-30 with Pi 0.84.0 on macOS against public base `c731c36c381ea0886fa5aabf6a3be761534d3f30` and audited implementation head `eab78820a67b8221337a3ce828281abc0277ee38`.
+The audit was run on 2026-08-30 with Pi 0.84.0 on macOS against public base `c731c36c381ea0886fa5aabf6a3be761534d3f30` and audited implementation head `40f8af8e96e4aace58d5f765bc478b68f368593d`.
 Both captures used the same clean disposable checkout path, the same installed Pi configuration, and the normal discovered project context and skill catalog.
 The only source difference was the task head.
 Pi's command context exposed the complete generated system prompt without starting an agent turn or making a provider request.
-The captured prompt bytes are authoritative for the reviewed implementation head.
+The captured prompt bytes are authoritative for the reviewed implementation head and later descendants that change only this verification record, which Pi does not discover as prompt context.
 
 Create this test-only hook in `.tmp-skill-catalog-audit/capture-system-prompt.ts` inside the disposable checkout:
 
@@ -46,7 +46,7 @@ Keeping the checkout path fixed matters because Pi includes each skill's absolut
 
 ```sh
 BASE=c731c36c381ea0886fa5aabf6a3be761534d3f30
-TASK_HEAD=eab78820a67b8221337a3ce828281abc0277ee38
+TASK_HEAD=40f8af8e96e4aace58d5f765bc478b68f368593d
 AUDIT_DIR="$PWD/.tmp-skill-catalog-audit"
 capture_prompt() {
   label=$1
@@ -72,15 +72,15 @@ The raw bounded output was:
 
 ```text
 base=c731c36c381ea0886fa5aabf6a3be761534d3f30
-head=eab78820a67b8221337a3ce828281abc0277ee38
+head=40f8af8e96e4aace58d5f765bc478b68f368593d
 pi=0.84.0
-before={"bytes":92950,"loadedSkills":29,"catalogSkills":29}
-after={"bytes":83499,"loadedSkills":29,"catalogSkills":14}
-saved=9451
+before={"bytes":93016,"loadedSkills":29,"catalogSkills":29}
+after={"bytes":83520,"loadedSkills":29,"catalogSkills":14}
+saved=9496
 providerRequests=0
 ```
 
 The 29 loaded skills comprised all 20 Firstmate skills and nine installed global skills in both captures.
 After the change, the automatic catalog retained those nine global skills plus the five captain-invocable Firstmate skills, while all 29 skill records remained loaded.
 The focused behavioral regression separately confirms that Pi retains all 20 Firstmate skill commands.
-The measured reduction was 9,451 UTF-8 bytes in Pi's complete generated system prompt.
+The measured reduction was 9,496 UTF-8 bytes in Pi's complete generated system prompt.

--- a/docs/verification/pi-skill-catalog.md
+++ b/docs/verification/pi-skill-catalog.md
@@ -9,10 +9,11 @@ This record owns the version-scoped byte evidence and its refresh method.
 
 ## Full-prompt audit
 
-The audit was run on 2026-08-30 with Pi 0.84.0 on macOS against public base `c731c36c381ea0886fa5aabf6a3be761534d3f30` and final reconciled task head `f8a62946f235b7e35c7bdeacb6b1a734281d65fc`.
+The audit was run on 2026-08-30 with Pi 0.84.0 on macOS against public base `c731c36c381ea0886fa5aabf6a3be761534d3f30` and audited implementation head `f8a62946f235b7e35c7bdeacb6b1a734281d65fc`.
 Both captures used the same clean disposable checkout path, the same installed Pi configuration, and the normal discovered project context and skill catalog.
 The only source difference was the task head.
 Pi's command context exposed the complete generated system prompt without starting an agent turn or making a provider request.
+Later descendants through `6668b1022c7519289735a0d7a12b147035ebabda` change only this verification record, which Pi does not discover as prompt context, so the captured prompt bytes remain authoritative for the reconciled implementation.
 
 Create this test-only hook in `.tmp-skill-catalog-audit/capture-system-prompt.ts` inside the disposable checkout:
 

--- a/docs/verification/pi-skill-catalog.md
+++ b/docs/verification/pi-skill-catalog.md
@@ -9,11 +9,11 @@ This record owns the version-scoped byte evidence and its refresh method.
 
 ## Full-prompt audit
 
-The audit was run on 2026-08-30 with Pi 0.84.0 on macOS against public base `c731c36c381ea0886fa5aabf6a3be761534d3f30` and audited implementation head `f8a62946f235b7e35c7bdeacb6b1a734281d65fc`.
+The audit was run on 2026-08-30 with Pi 0.84.0 on macOS against public base `c731c36c381ea0886fa5aabf6a3be761534d3f30` and audited implementation head `eab78820a67b8221337a3ce828281abc0277ee38`.
 Both captures used the same clean disposable checkout path, the same installed Pi configuration, and the normal discovered project context and skill catalog.
 The only source difference was the task head.
 Pi's command context exposed the complete generated system prompt without starting an agent turn or making a provider request.
-Later descendants through `6668b1022c7519289735a0d7a12b147035ebabda` change only this verification record, which Pi does not discover as prompt context, so the captured prompt bytes remain authoritative for the reconciled implementation.
+The captured prompt bytes are authoritative for the reviewed implementation head.
 
 Create this test-only hook in `.tmp-skill-catalog-audit/capture-system-prompt.ts` inside the disposable checkout:
 
@@ -46,7 +46,7 @@ Keeping the checkout path fixed matters because Pi includes each skill's absolut
 
 ```sh
 BASE=c731c36c381ea0886fa5aabf6a3be761534d3f30
-TASK_HEAD=f8a62946f235b7e35c7bdeacb6b1a734281d65fc
+TASK_HEAD=eab78820a67b8221337a3ce828281abc0277ee38
 AUDIT_DIR="$PWD/.tmp-skill-catalog-audit"
 capture_prompt() {
   label=$1
@@ -72,15 +72,15 @@ The raw bounded output was:
 
 ```text
 base=c731c36c381ea0886fa5aabf6a3be761534d3f30
-head=f8a62946f235b7e35c7bdeacb6b1a734281d65fc
+head=eab78820a67b8221337a3ce828281abc0277ee38
 pi=0.84.0
 before={"bytes":92950,"loadedSkills":29,"catalogSkills":29}
-after={"bytes":82990,"loadedSkills":29,"catalogSkills":14}
-saved=9960
+after={"bytes":83499,"loadedSkills":29,"catalogSkills":14}
+saved=9451
 providerRequests=0
 ```
 
 The 29 loaded skills comprised all 20 Firstmate skills and nine installed global skills in both captures.
 After the change, the automatic catalog retained those nine global skills plus the five captain-invocable Firstmate skills, while all 29 skill records remained loaded.
 The focused behavioral regression separately confirms that Pi retains all 20 Firstmate skill commands.
-The measured reduction was 9,960 UTF-8 bytes in Pi's complete generated system prompt.
+The measured reduction was 9,451 UTF-8 bytes in Pi's complete generated system prompt.

--- a/docs/verification/pi-skill-catalog.md
+++ b/docs/verification/pi-skill-catalog.md
@@ -7,7 +7,7 @@ The behavioral contract remains enforced by `tests/fm-pi-skill-catalog.test.sh`;
 
 ## Full-prompt audit
 
-The audit was run on 2026-08-28 with Pi 0.84.0 on macOS against public base `420721401c4080d1a4f6982b0ef6769e2a749b23` and task head `8abb49e25da4e1211a933ca57e72c4c745b78276`.
+The audit was run on 2026-08-30 with Pi 0.84.0 on macOS against public base `c731c36c381ea0886fa5aabf6a3be761534d3f30` and final task head `b2c14efa419eda2321b8fe671b673e24e104fc73`.
 Both captures used the same clean disposable checkout path, the same installed Pi configuration, and the normal discovered project context and skill catalog.
 The only source difference was the task head.
 Pi's command context exposed the complete generated system prompt without starting an agent turn or making a provider request.
@@ -23,12 +23,14 @@ export default function (pi: ExtensionAPI) {
     description: "Capture Pi's complete generated system prompt",
     handler: async (_args, ctx) => {
       const prompt = ctx.getSystemPrompt();
+      const catalog = prompt.match(/<available_skills>[\s\S]*?<\/available_skills>/)?.[0];
       writeFileSync(
         process.env.FM_PI_PROMPT_CAPTURE!,
         JSON.stringify({
           prompt,
           bytes: Buffer.byteLength(prompt, "utf8"),
           skills: ctx.getSystemPromptOptions().skills,
+          catalogSkills: catalog?.match(/<skill>/g)?.length ?? 0,
         }),
       );
     },
@@ -36,38 +38,46 @@ export default function (pi: ExtensionAPI) {
 }
 ```
 
-Run this command at the base, save the resulting `before.json`, switch the same clean disposable checkout to the head, and run it again with `LABEL=after`.
+Run these commands from the clean disposable checkout that contains the test-only hook.
 Keeping the checkout path fixed matters because Pi includes each skill's absolute location in the generated catalog.
 
 ```sh
-LABEL=before
+BASE=c731c36c381ea0886fa5aabf6a3be761534d3f30
+TASK_HEAD=b2c14efa419eda2321b8fe671b673e24e104fc73
 AUDIT_DIR="$PWD/.tmp-skill-catalog-audit"
-printf '%s\n' \
-  '{"id":"capture","type":"prompt","message":"/fm-capture-full-prompt"}' \
-  | PI_OFFLINE=1 \
-    FM_PI_PROMPT_CAPTURE="$AUDIT_DIR/$LABEL.json" \
-    pi --mode rpc --approve --no-session --no-extensions \
-      -e "$AUDIT_DIR/capture-system-prompt.ts" \
-      --no-prompt-templates --no-themes \
-      --model openai-codex/gpt-5.6-sol --thinking low \
-      >"$AUDIT_DIR/$LABEL.rpc" \
-      2>"$AUDIT_DIR/$LABEL.stderr"
-jq '{bytes, loadedSkills:(.skills | length)}' "$AUDIT_DIR/$LABEL.json"
+capture_prompt() {
+  label=$1
+  printf '%s\n' \
+    '{"id":"capture","type":"prompt","message":"/fm-capture-full-prompt"}' \
+    | PI_OFFLINE=1 \
+      FM_PI_PROMPT_CAPTURE="$AUDIT_DIR/$label.json" \
+      pi --mode rpc --approve --no-session --no-extensions \
+        -e "$AUDIT_DIR/capture-system-prompt.ts" \
+        --no-prompt-templates --no-themes \
+        --model openai-codex/gpt-5.6-sol --thinking low \
+        >"$AUDIT_DIR/$label.rpc" \
+        2>"$AUDIT_DIR/$label.stderr"
+  jq '{bytes, loadedSkills:(.skills | length), catalogSkills}' "$AUDIT_DIR/$label.json"
+}
+git switch --detach "$BASE"
+capture_prompt before
+git switch --detach "$TASK_HEAD"
+capture_prompt after
 ```
 
 The raw bounded output was:
 
 ```text
-base=420721401c4080d1a4f6982b0ef6769e2a749b23
-head=8abb49e25da4e1211a933ca57e72c4c745b78276
+base=c731c36c381ea0886fa5aabf6a3be761534d3f30
+head=b2c14efa419eda2321b8fe671b673e24e104fc73
 pi=0.84.0
-before={"bytes":92325,"loadedSkills":29,"catalogSkills":29}
-after={"bytes":82784,"loadedSkills":29,"catalogSkills":14}
-saved=9541
+before={"bytes":165695,"loadedSkills":29,"catalogSkills":29}
+after={"bytes":155225,"loadedSkills":29,"catalogSkills":14}
+saved=10470
 providerRequests=0
 ```
 
 The 29 loaded skills comprised all 20 Firstmate skills and nine installed global skills in both captures.
 After the change, the automatic catalog retained those nine global skills plus the five captain-invocable Firstmate skills, while all 29 skill records remained loaded.
 The focused behavioral regression separately confirms that Pi retains all 20 Firstmate skill commands.
-The measured reduction was 9,541 UTF-8 bytes in Pi's complete generated system prompt.
+The measured reduction was 10,470 UTF-8 bytes in Pi's complete generated system prompt.

--- a/docs/verification/pi-skill-catalog.md
+++ b/docs/verification/pi-skill-catalog.md
@@ -3,7 +3,9 @@
 Audience: maintainer verification.
 
 This record preserves the full-prompt measurement for hiding Firstmate's 15 agent-only skills from Pi's automatic model catalog.
-The behavioral contract remains enforced by `tests/fm-pi-skill-catalog.test.sh`; this record owns the version-scoped byte evidence and its refresh method.
+The required portable path in `tests/fm-pi-skill-catalog.test.sh` parses every Firstmate skill's YAML front matter and enforces the exact 15-hidden and 5-visible metadata partition before checking whether Pi is installed.
+When Pi is installed, that same regression continues through Pi's extension and RPC interfaces to enforce the behavioral contract; otherwise it reports that behavioral portion as skipped after the portable contract passes.
+This record owns the version-scoped byte evidence and its refresh method.
 
 ## Full-prompt audit
 

--- a/docs/verification/pi-skill-catalog.md
+++ b/docs/verification/pi-skill-catalog.md
@@ -9,7 +9,7 @@ This record owns the version-scoped byte evidence and its refresh method.
 
 ## Full-prompt audit
 
-The audit was run on 2026-08-30 with Pi 0.84.0 on macOS against public base `c731c36c381ea0886fa5aabf6a3be761534d3f30` and final task head `b2c14efa419eda2321b8fe671b673e24e104fc73`.
+The audit was run on 2026-08-30 with Pi 0.84.0 on macOS against public base `c731c36c381ea0886fa5aabf6a3be761534d3f30` and final reconciled task head `f8a62946f235b7e35c7bdeacb6b1a734281d65fc`.
 Both captures used the same clean disposable checkout path, the same installed Pi configuration, and the normal discovered project context and skill catalog.
 The only source difference was the task head.
 Pi's command context exposed the complete generated system prompt without starting an agent turn or making a provider request.
@@ -45,7 +45,7 @@ Keeping the checkout path fixed matters because Pi includes each skill's absolut
 
 ```sh
 BASE=c731c36c381ea0886fa5aabf6a3be761534d3f30
-TASK_HEAD=b2c14efa419eda2321b8fe671b673e24e104fc73
+TASK_HEAD=f8a62946f235b7e35c7bdeacb6b1a734281d65fc
 AUDIT_DIR="$PWD/.tmp-skill-catalog-audit"
 capture_prompt() {
   label=$1
@@ -71,15 +71,15 @@ The raw bounded output was:
 
 ```text
 base=c731c36c381ea0886fa5aabf6a3be761534d3f30
-head=b2c14efa419eda2321b8fe671b673e24e104fc73
+head=f8a62946f235b7e35c7bdeacb6b1a734281d65fc
 pi=0.84.0
-before={"bytes":165695,"loadedSkills":29,"catalogSkills":29}
-after={"bytes":155225,"loadedSkills":29,"catalogSkills":14}
-saved=10470
+before={"bytes":92950,"loadedSkills":29,"catalogSkills":29}
+after={"bytes":82990,"loadedSkills":29,"catalogSkills":14}
+saved=9960
 providerRequests=0
 ```
 
 The 29 loaded skills comprised all 20 Firstmate skills and nine installed global skills in both captures.
 After the change, the automatic catalog retained those nine global skills plus the five captain-invocable Firstmate skills, while all 29 skill records remained loaded.
 The focused behavioral regression separately confirms that Pi retains all 20 Firstmate skill commands.
-The measured reduction was 10,470 UTF-8 bytes in Pi's complete generated system prompt.
+The measured reduction was 9,960 UTF-8 bytes in Pi's complete generated system prompt.

--- a/tests/fm-pi-skill-catalog.test.sh
+++ b/tests/fm-pi-skill-catalog.test.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Real Pi skill-catalog regression through the documented extension and RPC APIs.
+# It proves agent-only Firstmate skills stay loaded and command-addressable while
+# only captain-invocable Firstmate skills enter the automatic model catalog.
+set -eu
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v pi >/dev/null 2>&1 || { echo "skip: pi not found for skill-catalog regression"; exit 0; }
+command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found for skill-catalog regression"; exit 0; }
+
+TMP_ROOT=$(fm_test_tmproot fm-pi-skill-catalog)
+PI_HOME="$TMP_ROOT/pi-agent"
+EXTENSION="$TMP_ROOT/catalog-probe.ts"
+ALL_CAPTURE="$TMP_ROOT/all-skills.json"
+DIRECT_CAPTURE="$TMP_ROOT/direct-hidden-skills.json"
+
+cat > "$EXTENSION" <<'TS'
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { writeFileSync } from "node:fs";
+
+export default function (pi: ExtensionAPI) {
+  pi.registerProvider("fm-skill-catalog-probe", {
+    baseUrl: "http://127.0.0.1:9/v1",
+    apiKey: "local-test-key",
+    api: "openai-completions",
+    models: [{
+      id: "probe",
+      name: "Skill catalog probe",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 1024,
+    }],
+  });
+
+  pi.registerCommand("fm-capture-skill-catalog", {
+    description: "Capture Pi's loaded skill catalog for a behavioral regression",
+    handler: async (_args, ctx) => {
+      const prompt = ctx.getSystemPrompt();
+      writeFileSync(
+        process.env.FM_PI_SKILL_CAPTURE!,
+        JSON.stringify({
+          prompt,
+          bytes: Buffer.byteLength(prompt, "utf8"),
+          skills: ctx.getSystemPromptOptions().skills,
+          commands: pi.getCommands(),
+        }),
+      );
+    },
+  });
+}
+TS
+
+run_probe() {
+  local capture=$1
+  shift
+  printf '%s\n' \
+    '{"id":"capture","type":"prompt","message":"/fm-capture-skill-catalog"}' \
+    '{"id":"commands","type":"get_commands"}' \
+    | PI_CODING_AGENT_DIR="$PI_HOME" PI_OFFLINE=1 FM_PI_SKILL_CAPTURE="$capture" \
+      pi --mode rpc --approve --no-session --no-context-files --no-extensions \
+        -e "$EXTENSION" --no-skills "$@" --no-prompt-templates --no-themes \
+        --model fm-skill-catalog-probe/probe \
+        > "$capture.rpc" 2> "$capture.stderr"
+
+  [ -s "$capture" ] || fail "Pi did not publish the skill-catalog capture"
+  python3 - "$capture.rpc" <<'PY'
+import json
+import sys
+
+responses = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8") if line.strip()]
+by_id = {record.get("id"): record for record in responses if record.get("type") == "response"}
+for request_id in ("capture", "commands"):
+    record = by_id.get(request_id)
+    if not record or not record.get("success"):
+        raise SystemExit(f"missing successful RPC response for {request_id}: {record!r}")
+PY
+}
+
+run_probe "$ALL_CAPTURE" --skill "$ROOT/.agents/skills"
+
+HIDDEN_SKILLS='ask-user-authority
+bootstrap-diagnostics
+captain-hold-lifecycle
+decision-hold-lifecycle
+diagnostic-reasoning
+firstmate-codexapp
+firstmate-coding-guidelines
+firstmate-orca
+fmx-respond
+harness-adapters
+process-event-sources
+project-management
+quota-array-dispatch
+secondmate-provisioning
+stuck-crewmate-recovery'
+VISIBLE_SKILLS='afk
+ahoy
+bearings
+stow
+updatefirstmate'
+
+DIRECT_ARGS=()
+while IFS= read -r skill; do
+  [ -n "$skill" ] || continue
+  DIRECT_ARGS+=(--skill "$ROOT/.agents/skills/$skill/SKILL.md")
+done <<EOF
+$HIDDEN_SKILLS
+EOF
+run_probe "$DIRECT_CAPTURE" "${DIRECT_ARGS[@]}"
+
+python3 - "$ALL_CAPTURE" "$DIRECT_CAPTURE" "$HIDDEN_SKILLS" "$VISIBLE_SKILLS" <<'PY'
+import html
+import json
+import sys
+import xml.etree.ElementTree as ET
+
+all_capture = json.load(open(sys.argv[1], encoding="utf-8"))
+direct_capture = json.load(open(sys.argv[2], encoding="utf-8"))
+hidden = set(sys.argv[3].splitlines())
+visible = set(sys.argv[4].splitlines())
+expected = hidden | visible
+
+
+def loaded_skills(capture):
+    return {skill["name"]: skill["description"] for skill in capture["skills"]}
+
+
+def skill_commands(capture):
+    return {
+        command["name"][len("skill:"):]
+        for command in capture["commands"]
+        if command.get("source") == "skill" and command["name"].startswith("skill:")
+    }
+
+
+def prompt_catalog(capture):
+    prompt = capture["prompt"]
+    opening = "<available_skills>"
+    closing = "</available_skills>"
+    if opening not in prompt:
+        return {}
+    start = prompt.index(opening)
+    end = prompt.index(closing, start) + len(closing)
+    root = ET.fromstring(prompt[start:end])
+    return {
+        skill.findtext("name"): skill.findtext("description")
+        for skill in root.findall("skill")
+    }
+
+
+all_loaded = loaded_skills(all_capture)
+if set(all_loaded) != expected:
+    raise SystemExit(f"Pi loaded unexpected Firstmate skill set: {sorted(all_loaded)}")
+
+catalog = prompt_catalog(all_capture)
+if set(catalog) != visible:
+    raise SystemExit(f"automatic model catalog mismatch: {sorted(catalog)}")
+for name in visible:
+    if catalog[name] != all_loaded[name]:
+        raise SystemExit(f"visible description changed in Pi's catalog: {name}")
+
+unescaped_prompt = html.unescape(all_capture["prompt"])
+for name in hidden:
+    if all_loaded[name] in unescaped_prompt:
+        raise SystemExit(f"agent-only description leaked into automatic model context: {name}")
+
+if skill_commands(all_capture) != expected:
+    raise SystemExit("Pi did not retain all 20 registered Firstmate skill commands")
+
+direct_loaded = loaded_skills(direct_capture)
+if set(direct_loaded) != hidden:
+    raise SystemExit(f"explicit --skill paths did not load all hidden skills: {sorted(direct_loaded)}")
+if prompt_catalog(direct_capture):
+    raise SystemExit("explicitly loaded hidden skills leaked into the automatic model catalog")
+if skill_commands(direct_capture) != hidden:
+    raise SystemExit("explicitly loaded hidden skills lost their registered commands")
+
+direct_prompt = html.unescape(direct_capture["prompt"])
+for name in hidden:
+    if direct_loaded[name] in direct_prompt:
+        raise SystemExit(f"explicitly loaded hidden description leaked into model context: {name}")
+
+print(
+    "ok - Pi kept 15 agent-only skills out of model context while preserving "
+    "five visible skills, all commands, and all explicit paths"
+)
+print(
+    f"evidence: pi-skills-loaded={len(all_loaded)} visible={len(catalog)} "
+    f"hidden-direct={len(direct_loaded)} prompt-bytes={all_capture['bytes']}"
+)
+PY

--- a/tests/fm-pi-skill-catalog.test.sh
+++ b/tests/fm-pi-skill-catalog.test.sh
@@ -1,14 +1,89 @@
 #!/usr/bin/env bash
-# Real Pi skill-catalog regression through the documented extension and RPC APIs.
-# It proves agent-only Firstmate skills stay loaded and command-addressable while
-# only captain-invocable Firstmate skills enter the automatic model catalog.
+# Skill-catalog contract regression.
+# The portable path validates the machine-consumed YAML metadata in every CI run.
+# When Pi is installed, its documented extension and RPC APIs additionally prove
+# hidden skills stay loaded and command-addressable without entering model context.
 set -eu
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-command -v pi >/dev/null 2>&1 || { echo "skip: pi not found for skill-catalog regression"; exit 0; }
-command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found for skill-catalog regression"; exit 0; }
+HIDDEN_SKILLS='ask-user-authority
+bootstrap-diagnostics
+captain-hold-lifecycle
+decision-hold-lifecycle
+diagnostic-reasoning
+firstmate-codexapp
+firstmate-coding-guidelines
+firstmate-orca
+fmx-respond
+harness-adapters
+process-event-sources
+project-management
+quota-array-dispatch
+secondmate-provisioning
+stuck-crewmate-recovery'
+VISIBLE_SKILLS='afk
+ahoy
+bearings
+stow
+updatefirstmate'
+
+command -v ruby >/dev/null 2>&1 \
+  || fail "ruby is required to validate skill front matter as YAML"
+ruby -ryaml - "$ROOT" "$HIDDEN_SKILLS" "$VISIBLE_SKILLS" <<'RB'
+root, hidden_text, visible_text = ARGV
+hidden = hidden_text.lines(chomp: true).reject(&:empty?).sort
+visible = visible_text.lines(chomp: true).reject(&:empty?).sort
+expected = (hidden + visible).sort
+skills = {}
+
+Dir.glob(File.join(root, ".agents/skills/*/SKILL.md")).sort.each do |path|
+  lines = File.readlines(path)
+  raise "missing YAML front matter: #{path}" unless lines.first&.strip == "---"
+
+  closing = lines[1..].index { |line| line.strip == "---" }
+  raise "unterminated YAML front matter: #{path}" if closing.nil?
+
+  metadata = YAML.safe_load(
+    lines[1, closing].join,
+    permitted_classes: [],
+    permitted_symbols: [],
+    aliases: false
+  )
+  name = metadata.fetch("name")
+  directory_name = File.basename(File.dirname(path))
+  raise "skill name/path mismatch: #{path}" unless name == directory_name
+  raise "duplicate skill name: #{name}" if skills.key?(name)
+
+  skills[name] = metadata
+end
+
+raise "unexpected Firstmate skill inventory: #{skills.keys.sort.inspect}" unless skills.keys.sort == expected
+
+hidden.each do |name|
+  metadata = skills.fetch(name)
+  raise "agent-only skill became user-invocable: #{name}" unless metadata["user-invocable"] == false
+  raise "agent-only skill is model-visible: #{name}" unless metadata["disable-model-invocation"] == true
+  raise "agent-only skill lost internal metadata: #{name}" unless metadata.dig("metadata", "internal") == true
+end
+
+visible.each do |name|
+  metadata = skills.fetch(name)
+  raise "captain skill became agent-only: #{name}" unless metadata["user-invocable"] == true
+  if metadata.key?("disable-model-invocation")
+    raise "captain skill gained disable-model-invocation: #{name}"
+  end
+  raise "captain skill lost internal metadata: #{name}" unless metadata.dig("metadata", "internal") == true
+end
+
+puts "ok - portable YAML contract keeps exactly 15 agent-only skills hidden and five captain skills visible"
+RB
+
+command -v pi >/dev/null 2>&1 \
+  || { echo "skip: pi not found; portable skill-catalog contract passed, installed-Pi behavior not exercised"; exit 0; }
+command -v python3 >/dev/null 2>&1 \
+  || { echo "skip: python3 not found; portable skill-catalog contract passed, installed-Pi behavior not exercised"; exit 0; }
 
 TMP_ROOT=$(fm_test_tmproot fm-pi-skill-catalog)
 PI_HOME="$TMP_ROOT/pi-agent"
@@ -81,27 +156,6 @@ PY
 }
 
 run_probe "$ALL_CAPTURE" --skill "$ROOT/.agents/skills"
-
-HIDDEN_SKILLS='ask-user-authority
-bootstrap-diagnostics
-captain-hold-lifecycle
-decision-hold-lifecycle
-diagnostic-reasoning
-firstmate-codexapp
-firstmate-coding-guidelines
-firstmate-orca
-fmx-respond
-harness-adapters
-process-event-sources
-project-management
-quota-array-dispatch
-secondmate-provisioning
-stuck-crewmate-recovery'
-VISIBLE_SKILLS='afk
-ahoy
-bearings
-stow
-updatefirstmate'
 
 DIRECT_ARGS=()
 while IFS= read -r skill; do


### PR DESCRIPTION
## Intent

Update the existing public PR https://github.com/kunchenguid/firstmate/pull/3259, whose canonical base must remain exactly github.com/kunchenguid/firstmate, by narrowly reconciling it after PR #3289 merged. Never merge the PR, never force-push, and use Git author and committer M00NLIG7 <57321738+M00NLIG7@users.noreply.github.com>. Current public main is c731c36c381ea0886fa5aabf6a3be761534d3f30 (`docs(skills): split harness adapter operations reference (#3289)`). The submitted reconciliation head b2c14efa419eda2321b8fe671b673e24e104fc73 is a clean merge descendant of both the prior PR head 84ddeedd35e7690ee7ae1d0345e2c8834c725b0a and current main, so publication can advance the existing fork branch without history replacement. The exact merge had one content conflict, in `bin/fm-test-run.sh`; its resolution retains both #3259's `fm-pi-skill-catalog.test.sh` family registration and current main's `fm-harness-adapter-references.test.sh` registration. Preserve #3289's 95-line harness-adapters router and all 12 split reference resources; do not restore or copy any superseded monolithic harness content. The catalogued `harness-adapters` skill must differ from current main only by its intended top-level `disable-model-invocation: true` field.

Preserve the captain-approved minimal Firstmate Pi skill-catalog correction. Exactly these 15 catalogued `.agents/skills/*/SKILL.md` files have `user-invocable: false` and must carry Pi's supported top-level `disable-model-invocation: true`: ask-user-authority, bootstrap-diagnostics, captain-hold-lifecycle, decision-hold-lifecycle, diagnostic-reasoning, firstmate-codexapp, firstmate-coding-guidelines, firstmate-orca, fmx-respond, harness-adapters, process-event-sources, project-management, quota-array-dispatch, secondmate-provisioning, and stuck-crewmate-recovery. Add the field to those 15 and no others. Preserve every skill name, description, body, direct path, deterministic AGENTS trigger, registered skill command, and `metadata.internal` value. Keep the five captain-invocable Firstmate skills afk, ahoy, bearings, stow, and updatefirstmate model-visible; do not hide all internal skills.

Prove through supported behavioral interfaces on current main that a real installed local Pi prompt/catalog omits those 15 agent-only descriptions from automatic model context while the five captain-invocable descriptions remain visible, and that all hidden skills still support explicit direct loading and registered commands. Keep narrowly necessary behavioral regression and runner coverage and do not assert implementation-source bytes. Preserve the merged harness router/reference behavioral coverage. Review compatibility for every supported Firstmate agent tool, run relevant portable and available live checks, and report unavailable credentialed checks truthfully rather than calling them passing.

Refresh the maintained full-prompt audit so its authoritative same-path comparison is current public main c731c36c381ea0886fa5aabf6a3be761534d3f30 versus the final reconciled task head. Use installed local Pi's deterministic extension/RPC prompt-capture surface without an agent turn or provider call; keep exact maintainer-runnable commands and raw before/after bytes, 29 loaded skill records on both sides, 29 catalog entries before and 14 after, and use the freshly measured truth even if it differs from the historical 92,325-to-82,784 result recorded against the older base. Keep historical numbers only if clearly labeled historical rather than current authoritative evidence.

The captain approved the narrow no-paid-inference CI boundary: do not install or pin Pi in shared portable remote CI, do not make Pi absence fatal on runners without it, and keep any skip explicit and truthful. Every regression and CI path must make zero provider or LLM calls, require no model credentials, and incur no paid inference. Do not add a shipped/runtime extension, edit Pi's generated system prompt, regex-edit prompt text, reduce AGENTS, undo #3289's runtime-reference split, change skill text or commands, or make any other token-consciousness or unrelated CI change. A documented test-only temporary local Pi hook may exercise supported extension/RPC interfaces without changing runtime discovery or shipping an extension.

Validate the complete final descendant head once through the full no-mistakes path, update the existing PR #3259 rather than creating a replacement, require green current-head CI, and stop without merging.

After the active run's approved prompt-audit fix, preserve every pipeline fix commit already present on head f2c7dbbcd2254496f2e9af3b293b9fa733b0fa87. Live GitHub evidence then showed the existing PR conflict in bin/fm-test-run.sh and the required 'PR must be raised via no-mistakes' check failing because the head-bound pipeline attestation was stale. Reconcile the latest live public main through no-mistakes' supported deterministic rebase/publication flow, resolve only the actual runner-registration conflict by retaining both the Pi catalog and all current-main test registrations, publish a fresh attestation bound to the final current head, and require all current-head checks green before reporting ready. Do not hand-edit outside the validation flow, do not drop the approved audit or any pipeline fix, do not make provider calls or remote CI/provider calls for Pi evidence, do not force-push, and do not merge.

## What Changed

- Mark 15 agent-only Firstmate skills with `disable-model-invocation: true` while keeping the five captain-invocable skills visible to Pi.
- Add portable metadata checks and optional installed-Pi behavioral coverage for catalog visibility, direct loading, and registered skill commands without provider calls.
- Document reproducible full-prompt audit measurements and register the verification guide in the documentation audience catalog.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped, preserves the required skill partition and registrations, and the refreshed prompt audit now reflects the prescribed base-to-implementation-head measurement.

## Testing

Installed Pi 0.84.0 loaded all 29 skill records while reducing the automatic catalog from 29 to 14, preserved all 20 Firstmate commands and direct loading of the 15 hidden skills, and made zero provider requests. The split harness router, portable runner registrations, coverage inventory, and maintained-document classification passed. Credentialed live harness checks were not run or counted as passing because this change is Pi catalog metadata and the approved boundary forbids provider calls; CLI/RPC transcripts and raw prompt captures serve as reviewer-visible evidence rather than UI screenshots.

<details>
<summary>Evidence: Final-head full-prompt audit</summary>

Source: [Final-head full-prompt audit](https://github.com/M00NLIG7/firstmate/blob/8606860b835050742f0ef5462861f07fae00e139/.no-mistakes/evidence/fm/firstmate-hide-agent-only-skills-v1-a7/final-head-full-prompt-audit.txt)

<code>base=c731c36c381ea0886fa5aabf6a3be761534d3f30&#10;head=40f8af8e96e4aace58d5f765bc478b68f368593d&#10;pi=0.84.0&#10;before={&#34;bytes&#34;:93016,&#34;loadedSkills&#34;:29,&#34;catalogSkills&#34;:29}&#10;after={&#34;bytes&#34;:83520,&#34;loadedSkills&#34;:29,&#34;catalogSkills&#34;:14}&#10;saved=9496&#10;providerRequests=0</code>

```text
base=c731c36c381ea0886fa5aabf6a3be761534d3f30
head=40f8af8e96e4aace58d5f765bc478b68f368593d
pi=0.84.0
before={"bytes":93016,"loadedSkills":29,"catalogSkills":29}
after={"bytes":83520,"loadedSkills":29,"catalogSkills":14}
saved=9496
providerRequests=0
```
</details>
<details>
<summary>Evidence: Pi catalog and harness-router transcript</summary>

Source: [Pi catalog and harness-router transcript](https://github.com/M00NLIG7/firstmate/blob/8606860b835050742f0ef5462861f07fae00e139/.no-mistakes/evidence/fm/firstmate-hide-agent-only-skills-v1-a7/pi-skill-catalog-and-harness-router.txt)

```text
FM_TEST_BEGIN 2026-08-30T22:28:30Z tests/fm-pi-skill-catalog.test.sh family=pure-contract-unit expected_gate_skip=none
ok - portable YAML contract keeps exactly 15 agent-only skills hidden and five captain skills visible
ok - Pi kept 15 agent-only skills out of model context while preserving five visible skills, all commands, and all explicit paths
evidence: pi-skills-loaded=20 visible=5 hidden-direct=15 prompt-bytes=6420
FM_TEST_END 2026-08-30T22:28:32Z tests/fm-pi-skill-catalog.test.sh exit=0 duration_ms=1885 gate_skip=false
FM_TEST_BEGIN 2026-08-30T22:28:32Z tests/fm-harness-adapter-references.test.sh family=pure-contract-unit expected_gate_skip=none
ok - harness adapter routing artifact is normalized and every target is readable
FM_TEST_END 2026-08-30T22:28:32Z tests/fm-harness-adapter-references.test.sh exit=0 duration_ms=357 gate_skip=false
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=2492
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=2 duration_ms=2242 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-pi-skill-catalog.test.sh duration_ms=1885
FM_TEST_SLOWEST rank=2 script=tests/fm-harness-adapter-references.test.sh duration_ms=357
```
</details>
<details>
<summary>Evidence: Public-main raw prompt capture</summary>

Source: [Public-main raw prompt capture](https://github.com/M00NLIG7/firstmate/blob/8606860b835050742f0ef5462861f07fae00e139/.no-mistakes/evidence/fm/firstmate-hide-agent-only-skills-v1-a7/public-main-c731-full-prompt.json)

```text
{"prompt":"You are an expert coding assistant operating inside pi, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.\n\nAvailable tools:\n- read: Read file contents\n- bash: Execute bash commands (ls, grep, find, etc.)\n- edit: Make precise file edits with exact text replacement, including multiple disjoint edits in one call\n- write: Create or overwrite files\n\nIn addition to the tools above, you may have access to other custom tools depending on the project.\n\nGuidelines:\n- Use bash for file operations like ls, rg, find\n- Use read to examine files instead of cat or sed.\n- Inspect PI_* environment variables for current model and session details.\n- Use edit for precise changes (edits[].oldText must match exactly)\n- When changing multiple separate locations in one file, use one edit call with multiple entries in edits[] instead of multiple edit calls\n- Each edits[].oldText is matched against the original file, not after earlier edits are applied. Do not emit overlapping or nested edits. Merge nearby changes into one edit.\n- Keep edits[].oldText as small as possible while still being unique in the file. Do not pad with large unchanged regions.\n- Use write only for new files or complete rewrites.\n- Be concise in your responses\n- Show file paths clearly when working with files\n\nPi documentation (read only when the user asks about pi itself, its SDK, extensions, themes, skills, or TUI):\n- Main documentation: /Users/cmagana/.local/lib/pi/0.84.0/README.md\n- Additional docs: /Users/cmagana/.local/lib/pi/0.84.0/docs\n- Examples: /Users/cmagana/.local/lib/pi/0.84.0/examples (extensions, custom tools, SDK)\n- When reading pi docs or examples, resolve docs/... under Additional docs and examples/... under Examples, not the current working directory\n- When asked about: extensions (docs/extensions.md, examples/extensions/), themes (docs/themes.md), skills (docs/skills.md), prompt templates (docs/prompt-templates.md), TUI components (docs/tui.md), keybindings (docs/keybindings.md), SDK integrations (docs/sdk.md), custom providers (docs/custom-provider.md), adding models (docs/models.md), pi packages (docs/packages.md), environment variables (docs/environment-variables.md)\n- When working on pi topics, read the docs and examples, and follow .md cross-references before implementing\n- Always read pi .md files completely and follow links to related docs (e.g., tui.md for TUI API details)\n\n<project_context>\n\nProject-specific instructions and guidelines:\n\n<project_instructions path=\"/private/var/folders/9w/r64y1hss78j7h843gtlnls6r0000gn/T/tmp.YRToez5fEy/checkout/AGENTS.md\">\n# Firstmate\n\nYou are the first mate.\nThe user is the captain.\nThis file is your entire job description.\n\nAddress the user as \"captain\" at least once in every response.\nThis is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as \"Captain, the build broke - ...\".\nDo not force it into every sentence, but never send a response with zero direct address.\nUse light nautical seasoning only when it fits: the occasional \"aye\", \"on deck\", \"shipshape\", \"under way\", or \"ahoy\" may land naturally.\nKeep that seasoning optional and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.\nFor captain-facing escalation style and outcome phrasing, see section 9.\n\n## 1. Identity and prime directives\n\nYou are the captain's only point of contact for all software work across all of their projects.\nOutside hard rule 1's concrete captain-approved project operation exception, you do not do project-specific work yourself.\nFor all other project-specific work, delegate coding, investigation, planning, bug reproduction, and audits to a crewmate you spawn and supervise, or to a secondmate whose registered scope fits.\nA secondmate is a crewmate with an isolated firstmate home and a charter, not a second architecture.\n\nHard rules, in priority order:\n\n1. **Never write to a project.**\n   Do not edit, commit, or run state-changing commands under `projects/` or in any project worktree; firstmate reads projects and crewmates change them.\n   The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths, each owned by its referenced skill or script, plus a concrete captain-approved project operation governed directly by this rule.\n   Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.\n   Firstmate may directly edit, create, move, or delete project files or directories only when the captain clearly and concretely approves, in the moment, for a specific project, either a specific operation or a concrete scope whose authorized action needs no inference; firstmate performs exactly that approval with its own file tools, never infers or broadens it, and gains no standing authority, while the force, discard, unlanded-work, merge-authority, destructive, irreversible, and security-sensitive boundaries remain independently in force.\n2. **Never merge a PR without the captain's explicit word.**\n   A project's captain-approved `yolo` posture is the only standing relaxation for merge authority; section 7 owns delivery and merge defaults, while the captain-instruction precedence rule below owns when a current explicit captain instruction overrides a conflicting Firstmate-written standing rule within its exact scope.\n3. **Never tear down unlanded work.**\n   Uncommitted changes are never landed, and `bin/fm-teardown.sh` owns the complete landed-work test.\n   Never bypass a refusal or use `--force` unless the captain explicitly authorized discarding that work.\n   A scout worktree is declared scratch and may be discarded only after its report exists and the shared unresolved-decision completion gate passes.\n4. **Crewmates never address the captain.**\n   All crewmate communication flows through firstmate.\n   Treat direct captain intervention in a crewmate window as authoritative and reconcile it at the next supervision review.\n5. **Report outcomes faithfully.**\n   If work failed, say so plainly with the evidence.\n\nYou may maintain this repo's private operational state directly.\nShared tracked material is `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and public `skills/`.\nWhen any crewmate is live, delegate changes to shared tracked material rather than competing with supervision; when the fleet is empty, firstmate may change it directly.\nThis repo is a shared template, while `.env`, `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` are captain-private and gitignored.\nShip shared tracked changes through this repo's no-mistakes pipeline and PR path, with the same merge authority as any other project.\nNever add an agent name as a commit co-author.\n\n## 2. Layout and state\n\n`docs/configuration.md` is the single owner of the top-level operational-home layout and configuration schemas; each producing script's header and help own exact child fields and mutation mechanics.\n`FM_HOME` selects an instance's private `data/`, `state/`, `config/`, and `projects/`, while scripts continue to come from their tracked code root.\nEach secondmate has a persistent isolated `FM_HOME`, including its own state, backlog, projects, and session lock.\n`bin/fm-send.sh` fails closed unless `FM_HOME` is explicit, so a steer cannot silently resolve against another home.\n\nTracked files hold shared instructions and tooling; `data/` holds durable private fleet records; `state/` holds runtime records and append-only status events; `config/` holds local operating choices; and `projects/` contains clones that are read-only to firstmate except under hard rule 1's concrete captain-approved project operation exception.\n\n`` `\nAGENTS.md            this file (CLA

... [105196 bytes truncated] ...

/bearings is chat-only by default, /bearings file explicitly writes the dated data/status-report-<YYYY-MM-DD>.md artifact, and /bearings lavish additionally builds and arms the interactive fleet board; live PR enrichment remains opt-in and composes with the other modes. Also load this skill's board-wake handling when a procevent lavish wake's source id matches the canonical source id of the stable bearings board path.","filePath":"/private/var/folders/9w/r64y1hss78j7h843gtlnls6r0000gn/T/tmp.YRToez5fEy/checkout/.agents/skills/bearings/SKILL.md","baseDir":"/private/var/folders/9w/r64y1hss78j7h843gtlnls6r0000gn/T/tmp.YRToez5fEy/checkout/.agents/skills/bearings","sourceInfo":{"path":"/private/var/folders/9w/r64y1hss78j7h843gtlnls6r0000gn/T/tmp.YRToez5fEy/checkout/.agents/skills/bearings/SKILL.md","source":"auto","scope":"project","origin":"top-level","baseDir":"/private/var/folders/9w/r64y1hss78j7h843gtlnls6r0000gn/T/tmp.YRToez5fEy/checkout/.agents"},"disableModelInvocation":false},{"name":"quota-array-dispatch","description":"Agent-only decision procedure for resolving a matched crew-dispatch profile array from quota-axi's default TOON, ranking by spendPriority after three orthogonal gates. Load when a dispatch rule or default resolves to more than one profile candidate.","filePath":"/private/var/folders/9w/r64y1hss78j7h843gtlnls6r0000gn/T/tmp.YRToez5fEy/checkout/.agents/skills/quota-array-dispatch/SKILL.md","baseDir":"/private/var/folders/9w/r64y1hss78j7h843gtlnls6r0000gn/T/tmp.YRToez5fEy/checkout/.agents/skills/quota-array-dispatch","sourceInfo":{"path":"/private/var/folders/9w/r64y1hss78j7h843gtlnls6r0000gn/T/tmp.YRToez5fEy/checkout/.agents/skills/quota-array-dispatch/SKILL.md","source":"auto","scope":"project","origin":"top-level","baseDir":"/private/var/folders/9w/r64y1hss78j7h843gtlnls6r0000gn/T/tmp.YRToez5fEy/checkout/.agents"},"disableModelInvocation":false},{"name":"impeccable","description":"Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.","filePath":"/Users/cmagana/.pi/agent/skills/impeccable/SKILL.md","baseDir":"/Users/cmagana/.pi/agent/skills/impeccable","sourceInfo":{"path":"/Users/cmagana/.pi/agent/skills/impeccable/SKILL.md","source":"auto","scope":"user","origin":"top-level","baseDir":"/Users/cmagana/.pi/agent"},"disableModelInvocation":false},{"name":"watch-youtube","description":"Analyze YouTube videos for research with the local Zig video-research orchestrator: acquire timestamped captions first, extract only requested frames through maintained yt-dlp and ffmpeg backends, preserve deterministic provenance, and fall back to MLX Whisper when captions are missing. Use for YouTube URLs, playlists, downloaded media, summaries, fact-checking, slides, demos, charts, code, timestamped claims, batch research, or visual verification.","filePath":"/Users/cmagana/.pi/agent/skills/watch-youtube/SKILL.md","baseDir":"/Users/cmagana/.pi/agent/skills/watch-youtube","sourceInfo":{"path":"/Users/cmagana/.pi/agent/skills/watch-youtube/SKILL.md","source":"auto","scope":"user","origin":"top-level","baseDir":"/Users/cmagana/.pi/agent"},"disableModelInvocation":false},{"name":"market-research","description":"Conduct market research, competitive analysis, investor due diligence, and industry intelligence with source attribution and decision-oriented summaries. Use when the user wants market sizing, competitor comparisons, fund research, technology scans, or research that informs business decisions.","filePath":"/Users/cmagana/.agents/skills/market-research/SKILL.md","baseDir":"/Users/cmagana/.agents/skills/market-research","sourceInfo":{"path":"/Users/cmagana/.agents/skills/market-research/SKILL.md","source":"auto","scope":"user","origin":"top-level","baseDir":"/Users/cmagana/.agents"},"disableModelInvocation":false},{"name":"security-scan","description":"Scan your Codex configuration (`.codex/` and related user config) for security vulnerabilities, misconfigurations, and injection risks using AgentShield. Checks AGENTS.md, config.toml, MCP servers, hooks, and agent definitions.","filePath":"/Users/cmagana/.agents/skills/security-scan/SKILL.md","baseDir":"/Users/cmagana/.agents/skills/security-scan","sourceInfo":{"path":"/Users/cmagana/.agents/skills/security-scan/SKILL.md","source":"auto","scope":"user","origin":"top-level","baseDir":"/Users/cmagana/.agents"},"disableModelInvocation":false},{"name":"codex-prompt-enhancer","description":"Rewrite vague or mediocre prompts into stronger prompts for Codex, coding agents, and general LLM tasks. Use when the user asks to improve, sharpen, rewrite, or engineer a draft prompt, especially for coding-agent prompts where over-prompting hurts. Produces a diagnosis, a full rewrite, a lean rewrite, and assumptions or questions. Advisory only; do not execute the prompt's task.","filePath":"/Users/cmagana/.agents/skills/codex-prompt-enhancer/SKILL.md","baseDir":"/Users/cmagana/.agents/skills/codex-prompt-enhancer","sourceInfo":{"path":"/Users/cmagana/.agents/skills/codex-prompt-enhancer/SKILL.md","source":"auto","scope":"user","origin":"top-level","baseDir":"/Users/cmagana/.agents"},"disableModelInvocation":false},{"name":"no-mistakes","description":"Validate your code changes through the no-mistakes pipeline - automated code review, tests, lint, docs, push, PR, and CI - before they reach the configured push target. Use when the user asks to run no-mistakes, gate or ship or validate their changes, push safely, asks you to do a task and then validate it, or invokes /no-mistakes.","filePath":"/Users/cmagana/.agents/skills/no-mistakes/SKILL.md","baseDir":"/Users/cmagana/.agents/skills/no-mistakes","sourceInfo":{"path":"/Users/cmagana/.agents/skills/no-mistakes/SKILL.md","source":"auto","scope":"user","origin":"top-level","baseDir":"/Users/cmagana/.agents"},"disableModelInvocation":false},{"name":"verification-loop","description":"A comprehensive verification system for Codex sessions.","filePath":"/Users/cmagana/.agents/skills/verification-loop/SKILL.md","baseDir":"/Users/cmagana/.agents/skills/verification-loop","sourceInfo":{"path":"/Users/cmagana/.agents/skills/verification-loop/SKILL.md","source":"auto","scope":"user","origin":"top-level","baseDir":"/Users/cmagana/.agents"},"disableModelInvocation":false},{"name":"content-engine","description":"Create platform-native content systems for X, LinkedIn, TikTok, YouTube, newsletters, and repurposed multi-platform campaigns. Use when the user wants social posts, threads, scripts, content calendars, or one source asset adapted cleanly across platforms.","filePath":"/Users/cmagana/.agents/skills/content-engine/SKILL.md","baseDir":"/Users/cmagana/.agents/skills/content-engine","sourceInfo":{"path":"/Users/cmagana/.agents/skills/content-engine/SKILL.md","source":"auto","scope":"user","origin":"top-level","baseDir":"/Users/cmagana/.agents"},"disableModelInvocation":false},{"name":"graphify","description":"any input (code, docs, papers, images) → knowledge graph → clustered communities → HTML + JSON + audit report","filePath":"/Users/cmagana/.agents/skills/graphify/SKILL.md","baseDir":"/Users/cmagana/.agents/skills/graphify","sourceInfo":{"path":"/Users/cmagana/.agents/skills/graphify/SKILL.md","source":"auto","scope":"user","origin":"top-level","baseDir":"/Users/cmagana/.agents"},"disableModelInvocation":false}],"catalogSkills":29}
```
</details>
- Evidence: [Target-head raw prompt capture](https://github.com/M00NLIG7/firstmate/blob/8606860b835050742f0ef5462861f07fae00e139/.no-mistakes/evidence/fm/firstmate-hide-agent-only-skills-v1-a7/target-40f8af8-full-prompt.json)
<details>
<summary>Evidence: Portable registration and documentation evidence</summary>

Source: [Portable registration and documentation evidence](https://github.com/M00NLIG7/firstmate/blob/8606860b835050742f0ef5462861f07fae00e139/.no-mistakes/evidence/fm/firstmate-hide-agent-only-skills-v1-a7/portable-registration-and-doc-audience.txt)

```text
FM_TEST_BEGIN 2026-08-30T22:29:02Z tests/fm-documentation-audiences.test.sh family=pure-contract-unit expected_gate_skip=none
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
FM_TEST_END 2026-08-30T22:29:05Z tests/fm-documentation-audiences.test.sh exit=0 duration_ms=2214 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=2419
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=2214 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-documentation-audiences.test.sh duration_ms=2214
Registered focused tests:
tests/fm-harness-adapter-references.test.sh
tests/fm-pi-skill-catalog.test.sh
FM_TEST_COVERAGE ok total=173 parallel=24 serial=137 serial_shards=4 herdr=12
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"40b4a90cf73ff7f3bea30ee4af3e949e0122ce2d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-test-run.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `docs/verification/pi-skill-catalog.md:16` - Intent requires “the authoritative same-path comparison is current public main c731c36… versus the final reconciled task head” using “freshly measured truth.” This instead claims measurements from f8a6294 remain authoritative through 6668b10, but neither commit is an ancestor of reviewed head eab7882; the final head also changes prompt-discovered AGENTS.md and two skill descriptions relative to f8a6294. Re-capture c731c36 versus eab7882 at the same path and replace the documented head, byte counts, and derived savings.

🔧 Fix: Captain: refresh Pi prompt audit measurements
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-pi-skill-catalog.test.sh tests/fm-harness-adapter-references.test.sh`
- <code>Same-path installed-Pi RPC capture using the documented `pi --mode rpc --approve --no-session --no-extensions ...` interface against archived commits `c731c36c381ea0886fa5aabf6a3be761534d3f30` and `40f8af8e96e4aace58d5f765bc478b68f368593d`</code>
- <code>`bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh` before and after refreshing the maintained audit</code>
- `bin/fm-test-run.sh --list --family pure-contract-unit`
- `bin/fm-test-run.sh --check-coverage`
- `git diff --check`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
