### PR TITLE
fix(pi): restore Pi 0.84.4 renderer compatibility

### DIFF
--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -1447,7 +1447,11 @@ ${context.command}
         .map((item) => normalizeOutcomesToolOutput(item.text))
         .join("\n");
       const shellState = context.state as OutcomesToolShellState;
-      shellState.result = output ? new Text(theme.fg("toolOutput", output), 0, 0) : new Container();
+      // Keep each line's ANSI scope independent, matching Pi's stock fallback.
+      // Pi 0.84.4 no longer supplies an implicit reset at multiline boundaries.
+      shellState.result = output
+        ? new Text(output.split("\n").map((line) => theme.fg("toolOutput", line)).join("\n"), 0, 0)
+        : new Container();
       refreshOutcomesToolShell(shellState, theme, context);
       return new Container();
     },

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -69,6 +69,7 @@ import {
   keyHint,
   ModelRuntime,
   SessionManager,
+  ToolExecutionComponent,
   type AgentSession,
   type ExtensionAPI,
   type ExtensionCommandContext,
@@ -132,7 +133,6 @@ const branchCacheKey = `fm-branch-${createHash("sha256").update(fmHome).digest("
 
 const MIRROR_MESSAGE_CAP = 4000;
 const MERGE_NOTE_BOAT = "⛵";
-const OUTCOMES_TOOL_PREVIEW_LINES = 10;
 // Carried inside the captain note's own text because that text is the only
 // part of a custom message Pi gives the model (see mergeIntoMain).
 //
@@ -1400,6 +1400,43 @@ ${context.command}
       .replace(/\r/g, "");
   };
 
+  let stockOutcomesPreviewLines: number | null | undefined;
+  const getStockOutcomesPreviewLines = (): number | undefined => {
+    if (stockOutcomesPreviewLines !== undefined) return stockOutcomesPreviewLines ?? undefined;
+    const probeTokens = Array.from(
+      { length: 64 },
+      (_, index) => `FM_OUTCOMES_PREVIEW_PROBE_${String(index).padStart(2, "0")}`,
+    );
+    try {
+      const probeDefinition: ToolDefinition = {
+        name: "fm_outcomes_preview_probe",
+        label: "Preview probe",
+        description: "Preview probe",
+        parameters: Type.Object({}),
+        execute: async () => ({ content: [], details: undefined }),
+      };
+      const probe = new ToolExecutionComponent(
+        probeDefinition.name,
+        "fm-outcomes-preview-probe",
+        {},
+        { showImages: false },
+        probeDefinition,
+        { requestRender() {} } as ConstructorParameters<typeof ToolExecutionComponent>[5],
+        root,
+      );
+      probe.updateResult({
+        content: [{ type: "text", text: probeTokens.join("\n") }],
+        isError: false,
+      });
+      const rendered = probe.render(4096).join("\n");
+      const visibleLines = probeTokens.filter((token) => rendered.includes(token)).length;
+      stockOutcomesPreviewLines = visibleLines > 0 && visibleLines < probeTokens.length ? visibleLines : null;
+    } catch {
+      stockOutcomesPreviewLines = null;
+    }
+    return stockOutcomesPreviewLines ?? undefined;
+  };
+
   type OutcomesToolShellState = {
     shell?: Box;
     call?: Text;
@@ -1452,7 +1489,8 @@ ${context.command}
       // Keep each line's ANSI scope independent, matching Pi's stock fallback.
       // Pi 0.84.4 no longer supplies an implicit reset at multiline boundaries.
       const lines = output.split("\n");
-      const displayLines = options.expanded ? lines : lines.slice(0, OUTCOMES_TOOL_PREVIEW_LINES);
+      const previewLines = getStockOutcomesPreviewLines();
+      const displayLines = options.expanded || previewLines === undefined ? lines : lines.slice(0, previewLines);
       const remaining = lines.length - displayLines.length;
       let renderedOutput = displayLines.map((line) => theme.fg("toolOutput", line)).join("\n");
       if (remaining > 0) {

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -66,6 +66,7 @@ import {
   DefaultResourceLoader,
   DynamicBorder,
   getAgentDir,
+  keyHint,
   ModelRuntime,
   SessionManager,
   type AgentSession,
@@ -131,6 +132,7 @@ const branchCacheKey = `fm-branch-${createHash("sha256").update(fmHome).digest("
 
 const MIRROR_MESSAGE_CAP = 4000;
 const MERGE_NOTE_BOAT = "⛵";
+const OUTCOMES_TOOL_PREVIEW_LINES = 10;
 // Carried inside the captain note's own text because that text is the only
 // part of a custom message Pi gives the model (see mergeIntoMain).
 //
@@ -1439,7 +1441,7 @@ ${context.command}
       shellState.call = new Text(theme.fg("toolTitle", theme.bold("fm_branch_outcomes")), 0, 0);
       return refreshOutcomesToolShell(shellState, theme, context);
     },
-    renderResult: (result, _options, theme, context) => {
+    renderResult: (result, options, theme, context) => {
       if (calmPresentation.stockExportRendering) throw new Error("Use Pi stock export rendering");
       if (calmHides("tool-result")) return new Container();
       const output = result.content
@@ -1449,9 +1451,14 @@ ${context.command}
       const shellState = context.state as OutcomesToolShellState;
       // Keep each line's ANSI scope independent, matching Pi's stock fallback.
       // Pi 0.84.4 no longer supplies an implicit reset at multiline boundaries.
-      shellState.result = output
-        ? new Text(output.split("\n").map((line) => theme.fg("toolOutput", line)).join("\n"), 0, 0)
-        : new Container();
+      const lines = output.split("\n");
+      const displayLines = options.expanded ? lines : lines.slice(0, OUTCOMES_TOOL_PREVIEW_LINES);
+      const remaining = lines.length - displayLines.length;
+      let renderedOutput = displayLines.map((line) => theme.fg("toolOutput", line)).join("\n");
+      if (remaining > 0) {
+        renderedOutput += `${theme.fg("muted", `\n... (${remaining} more lines,`)} ${keyHint("app.tools.expand", "to expand")}${theme.fg("muted", ")")}`;
+      }
+      shellState.result = output ? new Text(renderedOutput, 0, 0) : new Container();
       refreshOutcomesToolShell(shellState, theme, context);
       return new Container();
     },

--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -1,6 +1,6 @@
 // Firstmate's home-persistent Pi transcript presentation toggle.
 //
-// Verified against Pi 0.81.1 and 0.82.0, which expose built-in ToolDefinitions, per-slot
+// Verified against Pi 0.81.1, 0.82.0, and 0.84.4, which expose built-in ToolDefinitions, per-slot
 // renderers, renderShell: "self", session_start replacement reasons, agent_start and
 // agent_settled, ExtensionUIContext.setToolsExpanded(), setWorkingVisible(), setWidget()
 // with a disposable component factory, and setHiddenThinkingLabel().

--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -424,7 +424,7 @@ export default function (pi: ExtensionAPI) {
     ctx.ui.setStatus("firstmate-calm", undefined);
     removeTerminalInputHandler?.();
     removeTerminalInputHandler = ctx.ui.onTerminalInput((data) => {
-      if (!getKeybindings().matches(data, "tui.input.submit")) return;
+      if (!getKeybindings().matches(data, "tui.input.submit")) return undefined;
 
       const input = ctx.ui.getEditorText().trim();
       if (
@@ -432,7 +432,7 @@ export default function (pi: ExtensionAPI) {
         input !== "/export" &&
         !input.startsWith("/export ")
       ) {
-        return;
+        return undefined;
       }
 
       exportRendering = true;
@@ -454,6 +454,7 @@ export default function (pi: ExtensionAPI) {
         repaintCalmToolRows();
         ctx.ui.setStatus("firstmate-calm", undefined);
       }, 0);
+      return undefined;
     });
   });
 

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -204,7 +204,7 @@ Every tool registered or supplied by Firstmate under `.pi/extensions` has this d
 | --- | --- | --- |
 | `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls` | Calm wrappers for Pi's seven main-session built-ins | Their call and text-result shells hide while Calm is active; ordinary and stock export rendering delegate to Pi's original renderers. |
 | `fm_watch_arm_pi` | Main-session custom tool in `fm-primary-pi-watch.ts` | Its complete self-rendered shell hides while Calm is active and returns unchanged when Calm is off or stock export rendering is active. |
-| `fm_branch_outcomes` | Main-session custom tool in `fm-branch-supervision.ts` | Its complete self-rendered shell hides while Calm is active; the self-renderer reconstructs Pi's ordinary boxed fallback shell when visible, while stock export rendering deliberately falls through to Pi's structured fallback. |
+| `fm_branch_outcomes` | Main-session custom tool in `fm-branch-supervision.ts` | Its complete self-rendered shell hides while Calm is active; when visible, the self-renderer reconstructs Pi's ordinary boxed fallback shell and probes Pi's rendered stock fallback to preserve that installed surface's collapsed or all-line output policy plus expanded state, while stock export rendering deliberately falls through to Pi's structured fallback. |
 | `fm_branch_report` | Branch-session custom tool supplied directly to `createAgentSession` | It runs only in the headless supervision session and has no main-session `ToolExecutionComponent`; successful execution writes the outcome store and merges a branch note through the separately audited delivery path, so the tool cannot emit a dump-shaped row in the captain's transcript. |
 | branch-local `read` built-in | Branch-session built-in enabled through `createAgentSession` | It runs only in the headless supervision session and has no main-session `ToolExecutionComponent`, so its file output cannot emit a row in the captain's transcript. |
 | branch-local `bash` override | Branch-session replacement supplied directly to `createAgentSession` | It runs only in the headless supervision session and has no main-session `ToolExecutionComponent`, so its command output cannot emit a row in the captain's transcript. |
@@ -241,7 +241,7 @@ The test fixture enumerates every class below through the centralized policy, an
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 
 The installed extension API has no supported global transcript filter, user-message renderer, assistant-message renderer, chat-container API, or generic custom-tool wrapper.
-Pi 0.81.1 through 0.82.0 export `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](calm.md#pi-compatibility) for how a future Pi lacking one of those exports is handled.
+Pi 0.81.1 through 0.82.0 and Pi 0.84.4 export `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](calm.md#pi-compatibility) for how a future Pi lacking one of those exports is handled.
 General component replacement, ANSI cursor erasure, provider-context mutation, and installed-file patching remain rejected as unsupported or preservation-breaking workarounds.
 
 ## Cross-harness verification record
@@ -277,7 +277,7 @@ Only Pi's Calm presentation implementation changed; every producer and non-Pi tr
 
 ## Regression coverage
 
-`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers and verifies all seven built-ins plus `fm_watch_arm_pi`; `tests/fm-pi-branch-extension.test.sh` verifies `fm_branch_outcomes` Calm toggling and export rendering.
+`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers and verifies all seven built-ins plus `fm_watch_arm_pi`; `tests/fm-pi-branch-extension.test.sh` verifies `fm_branch_outcomes` Calm toggling, capability-probed all-line versus collapsed stock output, exact expanded output, and export rendering.
 Together they exercise redraw of already-rendered tool, thinking, current operational-user, and legacy synthetic rows, and cover every policy class.
 It covers persisted preference restoration across every session-start reason and a real restart, proves the working-ship presentation and Calm-off stock `Working...` row through a delayed deterministic provider, asserts no Calm status row, verifies operational messages remain exact ordinary user-role session entries and complete exports, and drives genuine 100 by 44, 160 by 36, and 180 by 44 terminal fixtures.
 A native deterministic `/skill:ahoy` turn produces thinking, tool-call, and tool-result blocks, asserts that the collapsed skill-to-final gap equals the two-row visible-only baseline, expands and re-collapses original thinking, restores Calm-off rendering, verifies persisted hidden history, and repeats the geometry assertion after restart with `terminal.clearOnShrink` explicitly off.
@@ -285,7 +285,7 @@ The operational provider path covers Calm loaded on, loaded off, default prefere
 It asserts one persisted and rendered captain answer, exact user-role operational envelopes in order, no replacement custom messages, one processing result, zero operational transcript rows, and the two-row neighboring-assistant geometry for live, adjacent, and restart paths.
 Quoted current markers, ASCII-only labels, ordinary text before a marker, unrelated U+2063 placement, and image-bearing input remain visible in component and native transcript checks.
 `tests/fm-pi-primary-live-e2e.test.sh` also proves the working ship replaces the built-in `Working...` row while Calm is active on the credentialed provider path, and that it clears when the run settles, before continuing its ordinary watcher lifecycle.
-`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi declarations, currently package version 0.81.1.
+`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi declarations, currently package version 0.84.4.
 
 The relevant commands are:
 
@@ -517,3 +517,25 @@ FM_TEST_SUMMARY total=46 failed=0 skipped_gate=16 duration_ms=279390
 FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=16 duration_ms=431 failed=0
 FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=30 duration_ms=277700 failed=0
 ```
+
+## 2026-08-28 Pi 0.84.4 outcome-renderer compatibility verification
+
+Pi 0.84.4's stock `ToolExecutionComponent` collapses a text result longer than ten lines, adds Pi's expansion hint, and renders every line when expanded, while the previously verified Pi 0.81.1 stock fallback renders every line in both states.
+The `fm_branch_outcomes` self-renderer now probes the installed component's rendered capability once rather than branching on a version number, then applies that discovered preview policy while preserving Pi's exact expanded result.
+Calm still hides the complete row while active, restores the probed stock behavior when turned off, and delegates stock HTML export rendering to Pi.
+
+The real installed-package comparison and the portable legacy-capability case are both executable through:
+
+```sh
+bin/fm-test-run.sh tests/fm-pi-branch-extension.test.sh
+```
+
+Observed against installed `@earendil-works/pi-coding-agent` 0.84.4:
+
+```text
+ok - fm_branch_outcomes hides through ToolExecutionComponent while Calm-off and HTML export stay stock
+ok - the installed Pi still bounds the picker's list and ranks its search
+FM_TEST_END 2026-08-29T01:01:30Z tests/fm-pi-branch-extension.test.sh exit=0 duration_ms=22418 gate_skip=false
+```
+
+The real renderer comparison exercised twelve outcome lines and reported collapsed and expanded parity with Pi stock, zero visible rows under Calm, restored stock parity after toggling Calm off, and delegated stock HTML export fallback.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -966,5 +966,26 @@ Evidence produced 2026-08-25 on macOS 26.5.2 arm64, Node v24.13.1:
 - Custom-message provider conversion: on 2026-08-26, `FM_PI_BRANCH_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-pi-branch-live-e2e.test.sh` against installed `@earendil-works/pi-coding-agent` 0.84.1 printed `ok - real Pi SDK 0.84.1 delivers a custom message to the provider as user text carrying only content, so the captain outcome's typed envelope is what reaches the model`.
   The guard passes a typed captain outcome and a plain rendered routine note through Pi's exported `convertToLlm`, proves that `customType` and `display` are not model-visible identity, and classifies the resulting provider text with `bin/fm-operational-input.sh`.
 
-Scope of this evidence: the installed signed `pi` CLI (0.82.0 at verification time) is a compiled binary whose bundled SDK is not importable from Node, so the importable npm package is the only surface the guard and the typecheck can pin.
+### 2026-08-28 Pi 0.84.4 SDK compatibility refresh
+
+The credential-free live guard and strict typecheck were rerun against the installed `@earendil-works/pi-coding-agent` 0.84.4 package after the Pi primary compatibility repair.
+The live guard used an isolated empty `PI_CODING_AGENT_DIR`, inspected no credentials, and made no provider call.
+
+```sh
+npm exec --yes --package=typescript@5.9.3 -- bash tests/fm-pi-primary-types.test.sh
+FM_PI_BRANCH_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-pi-branch-live-e2e.test.sh
+```
+
+```text
+ok - tracked Pi extensions pass strict no-emit typecheck against Pi 0.84.4
+ok - real Pi SDK 0.84.4 accepts the branch session construction and preserves an unpromptable wake
+ok - real Pi SDK 0.84.4 applies an explicit branch model on create and over a reopened session's recorded model
+ok - real Pi SDK 0.84.4 reports its own supported effort levels and applies an explicit branch effort over a reopened session's recorded level
+ok - real Pi SDK 0.84.4 delivers a custom message to the provider as user text carrying only content, so the captain outcome's typed envelope is what reaches the model
+FM_TEST_END 2026-08-29T01:01:01Z tests/fm-pi-branch-live-e2e.test.sh exit=0 duration_ms=2520 gate_skip=false
+```
+
+The focused extension suite also exercised the installed Pi 0.84.4 picker and outcome-renderer consumers; [`calm-mode-feasibility.md`](../calm-mode-feasibility.md#2026-08-28-pi-0844-outcome-renderer-compatibility-verification) owns the version-scoped renderer evidence.
+
+Scope of the earlier evidence: the installed signed `pi` CLI (0.82.0 at verification time) is a compiled binary whose bundled SDK is not importable from Node, so the importable npm package is the only surface the guard and the typecheck can pin.
 The extension executes inside the signed CLI's own runtime, so a CLI upgrade can drift ahead of the pinned npm surface; refresh this record after every Pi upgrade by re-running the live guard, picker regression, and strict typecheck above (point `FM_PI_PACKAGE_DIR` at a matching npm install when one exists) and by watching the branch's own fallback line - every branch failure degrades to the pre-branch wake-to-main path by construction, which `tests/fm-pi-branch-extension.test.sh` holds with a broken generator and the live guard holds with the real SDK.

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -51,6 +51,17 @@ export function keyHint(_keybinding, description) {
   return `ctrl+o ${description}`;
 }
 
+export class ToolExecutionComponent {
+  updateResult(result) {
+    this.result = result;
+  }
+  render() {
+    return (this.result?.content ?? [])
+      .filter((item) => item.type === "text")
+      .flatMap((item) => item.text.split("\n"));
+  }
+}
+
 export class UserMessageComponent {}
 
 export class DynamicBorder {
@@ -694,6 +705,23 @@ if (calmOffCall.constructor.name !== "Box" || calmOffCall.paddingX !== 1 || calm
 }
 if (calmOffResult.constructor.name !== "Container" || calmOffCall.children[0]?.text !== "fm_branch_outcomes" || calmOffCall.children[1]?.text !== "OUTCOME_DUMP") {
   throw new Error("fm_branch_outcomes changed its ordinary call or result rendering");
+}
+const legacyStockResult = {
+  content: [{
+    type: "text",
+    text: Array.from({ length: 12 }, (_, index) => `LEGACY_OUTCOME_${String(index + 1).padStart(2, "0")}`).join("\n"),
+  }],
+};
+const legacyRenderContext = { state: {}, isError: false, isPartial: false };
+const legacyCall = outcomesTool.renderCall({}, renderTheme, legacyRenderContext);
+outcomesTool.renderResult(legacyStockResult, { expanded: false, isPartial: false }, renderTheme, legacyRenderContext);
+const collapsedLegacyText = legacyCall.children[1]?.text;
+if (!collapsedLegacyText?.includes("LEGACY_OUTCOME_12") || collapsedLegacyText.includes("more lines")) {
+  throw new Error("legacy all-line stock capability did not preserve collapsed Calm-off output");
+}
+outcomesTool.renderResult(legacyStockResult, { expanded: true, isPartial: false }, renderTheme, legacyRenderContext);
+if (legacyCall.children[1]?.text !== collapsedLegacyText) {
+  throw new Error("legacy all-line stock capability changed expanded Calm-off output");
 }
 pi.events.emit("firstmate:calm-presentation", { active: true, stockExportRendering: false });
 const calmOnCall = outcomesTool.renderCall({}, renderTheme, renderContext);

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -47,6 +47,10 @@ export function getMarkdownTheme() {
   return {};
 }
 
+export function keyHint(_keybinding, description) {
+  return `ctrl+o ${description}`;
+}
+
 export class UserMessageComponent {}
 
 export class DynamicBorder {
@@ -3042,7 +3046,23 @@ delete stockDefinition.renderResult;
 
 const args = { recent: 2 };
 const result = {
-  content: [{ type: "text", text: "\x1b[31mOUTCOME_ONE\x1b[0m\r\nOUT\u0000COME_TWO\uFFF9" }],
+  content: [{
+    type: "text",
+    text: [
+      "\x1b[31mOUTCOME_ONE\x1b[0m",
+      "OUT\u0000COME_TWO\uFFF9",
+      "OUTCOME_THREE",
+      "OUTCOME_FOUR",
+      "OUTCOME_FIVE",
+      "OUTCOME_SIX",
+      "OUTCOME_SEVEN",
+      "OUTCOME_EIGHT",
+      "OUTCOME_NINE",
+      "OUTCOME_TEN",
+      "OUTCOME_ELEVEN",
+      "OUTCOME_TWELVE",
+    ].join("\r\n"),
+  }],
   details: { ok: true },
   isError: false,
 };
@@ -3054,8 +3074,24 @@ for (const row of [stockRow, actualRow]) {
   row.setArgsComplete();
   row.updateResult(result);
 }
-if (JSON.stringify(actualRow.render(100)) !== JSON.stringify(stockRow.render(100))) {
+const collapsedStock = stockRow.render(100);
+const collapsedActual = actualRow.render(100);
+if (JSON.stringify(collapsedActual) !== JSON.stringify(collapsedStock)) {
   throw new Error("Calm-off ToolExecutionComponent rendering differs from Pi stock");
+}
+const collapsedText = collapsedStock.join("\n");
+if (collapsedText.includes("OUTCOME_TWELVE") || !collapsedText.includes("more lines") || !collapsedText.includes("to expand")) {
+  throw new Error("stock rendering fixture did not exercise its collapsed preview and expansion hint");
+}
+stockRow.setExpanded(true);
+actualRow.setExpanded(true);
+const expandedStock = stockRow.render(100);
+const expandedActual = actualRow.render(100);
+if (JSON.stringify(expandedActual) !== JSON.stringify(expandedStock)) {
+  throw new Error("expanded Calm-off ToolExecutionComponent rendering differs from Pi stock");
+}
+if (!expandedStock.join("\n").includes("OUTCOME_TWELVE") || JSON.stringify(expandedStock) === JSON.stringify(collapsedStock)) {
+  throw new Error("stock rendering fixture did not exercise expanded output");
 }
 pi.events.emit("firstmate:calm-presentation", { active: true, stockExportRendering: false });
 actualRow.invalidate();


### PR DESCRIPTION
## Intent

Restore the existing FirstMate Pi primary integration against the installed @earendil-works/pi-coding-agent@0.84.4 with the smallest compatible tracked maintenance repair, not a new integration or redesign. Preserve FirstMate's existing Pi supervision branch, turn-end guard, Calm presentation, stock behavior when Calm is off, and stock export behavior. Keep compatibility with the existing verified Pi surfaces where reasonably supported and use API/capability probing rather than brittle version-number branching when the current design already follows that pattern. Make the smallest change in the existing extension/test surface; do not add a new harness, provider, daemon, routing layer, or architecture. Do not invoke /login, trust a project, inspect or create Pi credentials, make provider/model calls, or change private FirstMate configuration. Do not change config/crew-harness, config/secondmate-harness, or any Qwen, Claude, Codex, Herdr, or project routing configuration. Do not weaken or delete the failing assertions merely to make the suite pass; update tests only if needed to express the same stock/Calm behavioral contract across the supported Pi API. All acceptance commands must execute, not gate-skip, and pass against installed Pi 0.84.4: npm exec --yes --package=typescript@5.9.3 -- bash tests/fm-pi-primary-types.test.sh; FM_PI_BRANCH_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-pi-branch-live-e2e.test.sh; bin/fm-test-run.sh tests/fm-pi-branch-extension.test.sh tests/fm-supervision-instructions.test.sh. Run proportionate focused regression tests for every touched compatibility surface. Do not merge; deliver through this existing no-mistakes PR path.

## What Changed

- Adapt Calm’s terminal-input callback to Pi 0.84.4 and capability-probe Pi’s stock outcome preview behavior, preserving collapsed and expanded rendering across supported Pi surfaces.
- Preserve Calm row hiding, Calm-off rendering, and stock export fallback while adding focused renderer regressions.
- Document verified Pi 0.84.4 typecheck, live SDK, and outcome-renderer compatibility.

## Risk Assessment

✅ Low: The change is confined to the existing Pi renderer seam, preserves capability-specific stock behavior, and introduces no source-verifiable regression or intent contradiction.

## Testing

No separate baseline result was supplied. All authoritative acceptance commands executed against installed Pi 0.84.4, passed without gate-skipping, and the focused extension test also exercised the capability-probed legacy all-line behavior. Direct TUI evidence shows the ten-line collapsed preview and hint, twelve-line expanded output, zero Calm-on rows, restored stock parity, and stock export delegation. No bitmap screenshot was captured because this is a terminal TUI surface; the artifact contains the actual rendered rows with terminal control codes removed only for readability.

<details>
<summary>Evidence: Installed Pi 0.84.4 TUI rendering evidence</summary>

Source: [Installed Pi 0.84.4 TUI rendering evidence](https://github.com/stanzhang/firstmate/blob/228a8a6ee119e04c6de4aae13307f7529e501916/.no-mistakes/evidence/fm/pi-0844-compat-repair/pi-renderer-user-surface.txt)

```text
Installed Pi: @earendil-works/pi-coding-agent@0.84.4
Calm off, collapsed parity: true
--- collapsed FirstMate row (actual TUI text) ---

                                                                                                    
 fm_branch_outcomes                                                                                 
 OUTCOME_01                                                                                         
 OUTCOME_02                                                                                         
 OUTCOME_03                                                                                         
 OUTCOME_04                                                                                         
 OUTCOME_05                                                                                         
 OUTCOME_06                                                                                         
 OUTCOME_07                                                                                         
 OUTCOME_08                                                                                         
 OUTCOME_09                                                                                         
 OUTCOME_10                                                                                         
 ... (2 more lines,  to expand)                                                                     
                                                                                                    
Calm off, expanded parity: true
--- expanded FirstMate row (actual TUI text) ---

                                                                                                    
 fm_branch_outcomes                                                                                 
 OUTCOME_01                                                                                         
 OUTCOME_02                                                                                         
 OUTCOME_03                                                                                         
 OUTCOME_04                                                                                         
 OUTCOME_05                                                                                         
 OUTCOME_06                                                                                         
 OUTCOME_07                                                                                         
 OUTCOME_08                                                                                         
 OUTCOME_09                                                                                         
 OUTCOME_10                                                                                         
 OUTCOME_11                                                                                         
 OUTCOME_12                                                                                         
                                                                                                    
Calm on, visible TUI rows: 0
Calm toggled off, stock parity restored: true
Stock HTML export fallback delegated: true
```
</details>
<details>
<summary>Evidence: Focused extension and supervision tests</summary>

Source: [Focused extension and supervision tests](https://github.com/stanzhang/firstmate/blob/228a8a6ee119e04c6de4aae13307f7529e501916/.no-mistakes/evidence/fm/pi-0844-compat-repair/pi-extension-supervision.log)

```text
FM_TEST_BEGIN 2026-08-29T01:01:07Z tests/fm-pi-branch-extension.test.sh family=unclassified expected_gate_skip=none
ok - fm_branch_outcomes hides through ToolExecutionComponent while Calm-off and HTML export stay stock
ok - the installed Pi still bounds the picker's list and ranks its search
ok - branch owns accepted wakes with a stable prefix contract and verdict-driven merge delivery
ok - a captain outcome reaches main's model as typed, self-describing input while routine notes stay plain
ok - requested and unsolicited healthy outcomes keep distinct delivery and event ownership
ok - a broken operational encoder still delivers one invisible instructed captain outcome as a follow-up
ok - scopeForUnreadWake excludes every main-only class without vetoing eligible task-local rows, and writes the eligible snapshot
ok - branch prompt_cache_key is stable per home across sessions and distinct between homes
ok - branch default-on eligibility (task-scoped, heartbeat, afk) binds and a broken branch falls back to main
ok - a heartbeat review survives a check row arriving before its drain
ok - pre-drain eligibility re-check excludes a newly main-owned row without deferring eligible work
ok - a settled branch turn releases an unacknowledged grant for main replay
ok - a stale main claim cannot silently suppress later wake delivery
ok - pre-drain eligibility re-check no-ops an already-drained wake
ok - dialog mirror filters tool and operational traffic, lands before wakes, and keeps a durable cursor
ok - branch session persists across process restarts through the recorded pointer
ok - the current pin state binds every branch create and reopen, and clearing it returns the branch to main's model
ok - unpinned branches follow main model changes live while pinned branches stay fixed
ok - supervision-model command persists the captain's pick and rebinds the live branch
ok - supervision-model opens a bounded searchable list, follow main first, and pins the branch alone
ok - branch model picker keeps follow main first and filters the eligible catalog
ok - the effort pin binds every branch create and reopen, and clearing it returns the branch to main's effort
ok - unpinned branches follow main effort changes live while pinned branches stay fixed
ok - supervision-model runs an effort picker after the model picker and persists both independently
ok - an unusable model pin falls back to main and an unparseable one is treated as no pin
ok - replacement activation cleans old branch leases and retries failed cleanup
ok - branch activates on a cold start once the lock is acquired, never before
ok - queued wakes and mirrors stop mutating branch state after lock ownership is lost
ok - stale reports, shells, mirrors, cursors, leases, and prompts perform no side effects
ok - a Pi session that does not own the lock accepts nothing and mutates no branch state
ok - an extension rebind re-mirrors undelivered dialog instead of dropping it
FM_TEST_END 2026-08-29T01:01:30Z tests/fm-pi-branch-extension.test.sh exit=0 duration_ms=22418 gate_skip=false
FM_TEST_BEGIN 2026-08-29T01:01:30Z tests/fm-supervision-instructions.test.sh family=pure-contract-unit expected_gate_skip=none
ok - renderer prints exactly the selected harness block
ok - renderer falls back to unknown.md for unverified harness names
ok - renderer includes read-only, afk, and effective x-mode current-state stanzas
ok - renderer repair-line mode is harness-aware and honors conditional state
ok - renderer preserves every harness ordinary-continuation and missing-cycle repair path
ok - pi-signed keeps its identity while sharing Pi's supervision protocol
ok - grok supervision is Claude-shaped background notify with passive Stop-hook backstop
ok - grok rendered command sources the effective x-mode config
ok - pi supervision snippet renders the effective extension path
FM_TEST_END 2026-08-29T01:01:30Z tests/fm-supervision-instructions.test.sh exit=0 duration_ms=280 gate_skip=false
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=22785
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=280 failed=0
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=22418 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-pi-branch-extension.test.sh duration_ms=22418
FM_TEST_SLOWEST rank=2 script=tests/fm-supervision-instructions.test.sh duration_ms=280
```
</details>
<details>
<summary>Evidence: Live Pi SDK E2E tests</summary>

Source: [Live Pi SDK E2E tests](https://github.com/stanzhang/firstmate/blob/228a8a6ee119e04c6de4aae13307f7529e501916/.no-mistakes/evidence/fm/pi-0844-compat-repair/pi-branch-live-e2e.log)

```text
FM_TEST_BEGIN 2026-08-29T01:00:59Z tests/fm-pi-branch-live-e2e.test.sh family=live-harness-optin expected_gate_skip=optin-env
ok - real Pi SDK 0.84.4 accepts the branch session construction and preserves an unpromptable wake
ok - real Pi SDK 0.84.4 applies an explicit branch model on create and over a reopened session's recorded model
ok - real Pi SDK 0.84.4 reports its own supported effort levels and applies an explicit branch effort over a reopened session's recorded level
ok - real Pi SDK 0.84.4 delivers a custom message to the provider as user text carrying only content, so the captain outcome's typed envelope is what reaches the model
FM_TEST_END 2026-08-29T01:01:01Z tests/fm-pi-branch-live-e2e.test.sh exit=0 duration_ms=2520 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=2572
FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=1 duration_ms=2520 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-pi-branch-live-e2e.test.sh duration_ms=2520
```
</details>
<details>
<summary>Evidence: Strict Pi 0.84.4 typecheck</summary>

Source: [Strict Pi 0.84.4 typecheck](https://github.com/stanzhang/firstmate/blob/228a8a6ee119e04c6de4aae13307f7529e501916/.no-mistakes/evidence/fm/pi-0844-compat-repair/pi-primary-types.log)

```text
ok - tracked Pi extensions pass strict no-emit typecheck against Pi 0.84.4
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"57a048ede64370887a073cf8f12ec5b55b58e2a3","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `.pi/extensions/fm-branch-supervision.ts:1453` - Intent requires “Preserve ... stock behavior when Calm is off,” but this changed expression renders every `output.split(&#34;\n&#34;)` line and ignores `_options.expanded`. For an 11-line outcome with Calm off, Pi 0.84.4’s stock fallback shows 10 lines plus its expansion hint, while this path shows all 11 with no hint. Honor the collapsed/expanded option and stock preview behavior before applying per-line coloring; extend the executable parity case beyond 10 lines.

🔧 Fix: Restore Pi collapsed and expanded outcome parity
1 error still open:

- 🚨 `.pi/extensions/fm-branch-supervision.ts:1455` - Intent requires “stock behavior when Calm is off” and compatibility with “existing verified Pi surfaces.” This unconditionally applies Pi 0.84.4’s 10-line collapse, but verified Pi 0.81.1’s stock fallback renders all lines ([source](https://github.com/earendil-works/pi/blob/v0.81.1/packages/coding-agent/src/modes/interactive/components/tool-execution.ts#L127-L133)). Thus an 11-line Calm-off outcome silently hides line 11 on 0.81.1 while stock does not. Preserve each supported surface’s capability-probed stock behavior at this renderer boundary instead of imposing the 0.84.4 policy universally.

🔧 Fix: Preserve Pi stock previews through capability probing
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm exec --yes --package=typescript@5.9.3 -- bash tests/fm-pi-primary-types.test.sh`
- `FM_PI_BRANCH_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-pi-branch-live-e2e.test.sh`
- `bin/fm-test-run.sh tests/fm-pi-branch-extension.test.sh tests/fm-supervision-instructions.test.sh`
- <code>Manual `node --input-type=module` exercise of installed Pi’s `ToolExecutionComponent` and `createToolHtmlRenderer` using a 12-line `fm_branch_outcomes` result plus live Calm/export events</code>
- <code>`git status --short --branch` and evidence-integrity checks over the generated logs and renderer transcript</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
