### PR TITLE
feat(bin): add Telegram bridge for inbound notes and outbound escalations

### DIFF
--- a/.agents/skills/process-event-sources/SKILL.md
+++ b/.agents/skills/process-event-sources/SKILL.md
@@ -57,7 +57,8 @@ It keeps polling through unknown quota and wakes when known quota drops below th
 When the optional Telegram bridge is configured, the captain's inbound channel is armed and handled through `bin/fm-procevent-telegram.sh`.
 Its header owns the allowlist, the note write, and the acknowledgement discipline; [`docs/telegram-bridge.md`](../../../docs/telegram-bridge.md) owns operator setup.
 An allowed message becomes an ordinary captain inbox note that wakes you on its own, so a quiet collection cycle is deliberately silent and you only hear about this source when something needs you.
-`classify` returns `unconfigured`, `error`, `disabled`, or `idle`: `unconfigured` means somebody messaged the bot before an allowed chat id was set, and the only action is to relay that chat id to the captain for confirmation - never allowlist it yourself, because the first sender need not be him.
+`classify` returns `unconfigured`, `error`, `disabled`, `busy`, or `idle`: `unconfigured` means somebody messaged the bot before an allowed chat id was set, and the only action is to relay that chat id to the captain for confirmation - never allowlist it yourself, because the first sender need not be him.
+`busy` and `idle` are both silent and need no action; never run `poll` yourself in a conversational turn, because that is the second collector `busy` exists to turn away.
 
 For a "do X as soon as Y is true" request whose condition AND action are both genuinely exact and deterministic, register a condition->action watch instead of re-checking in conversational turns:
 

--- a/.agents/skills/process-event-sources/SKILL.md
+++ b/.agents/skills/process-event-sources/SKILL.md
@@ -54,6 +54,11 @@ bin/fm-procevent-quota.sh arm [--interval <secs>] [--threshold <percent>] [--pro
 
 It keeps polling through unknown quota and wakes when known quota drops below the configured threshold, runway becomes `exhausted_now`, or polling fails.
 
+When the optional Telegram bridge is configured, the captain's inbound channel is armed and handled through `bin/fm-procevent-telegram.sh`.
+Its header owns the allowlist, the note write, and the acknowledgement discipline; [`docs/telegram-bridge.md`](../../../docs/telegram-bridge.md) owns operator setup.
+An allowed message becomes an ordinary captain inbox note that wakes you on its own, so a quiet collection cycle is deliberately silent and you only hear about this source when something needs you.
+`classify` returns `unconfigured`, `error`, `disabled`, or `idle`: `unconfigured` means somebody messaged the bot before an allowed chat id was set, and the only action is to relay that chat id to the captain for confirmation - never allowlist it yourself, because the first sender need not be him.
+
 For a "do X as soon as Y is true" request whose condition AND action are both genuinely exact and deterministic, register a condition->action watch instead of re-checking in conversational turns:
 
 ```sh
@@ -65,7 +70,7 @@ Eligibility is a firstmate judgment made BEFORE arming, because the scripts cann
 Never bind an action that is destructive, irreversible, or security-sensitive, an action needing captain approval or any gate decision, or an action whose right form depends on what the condition finds - those keep the existing check-fires-then-firstmate-decides flow, for which a plain custom check or another adapter stays correct.
 When in doubt, arm only the condition half as an ordinary check and keep the action as a wake-time decision.
 
-`bin/fm-procevent.sh --help`, `bin/fm-procevent-lavish.sh --help`, `bin/fm-procevent-when.sh --help`, `bin/fm-procevent-quota.sh --help`, and `bin/fm-procevent-remote-reply.sh --help` own the exact commands and flags.
+`bin/fm-procevent.sh --help`, `bin/fm-procevent-lavish.sh --help`, `bin/fm-procevent-when.sh --help`, `bin/fm-procevent-quota.sh --help`, `bin/fm-procevent-remote-reply.sh --help`, and `bin/fm-procevent-telegram.sh --help` own the exact commands and flags.
 
 An explicitly enabled external adapter registers through `bin/fm-procevent.sh register-extension`, never through a package-discovered script or package-supplied argv.
 [`docs/configuration.md`](../../../docs/configuration.md#trusted-external-process-event-adapters-configextensionsd) owns setup and [`docs/extension-bindings.md`](../../../docs/extension-bindings.md) owns the narrow trusted-code and untrusted-evidence boundary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ README.md            public overview and development notes
 .claude/skills       symlink to .agents/skills for claude compatibility
 skills/              standalone public installer-facing skills, committed; not loaded by firstmate
 bin/                 helper scripts, committed; read each script's header before first use
-.env                 optional Relay pairing token; LOCAL, gitignored; presence-gates section 14
+.env                 optional Relay pairing token and Telegram bot credential; LOCAL, gitignored; the Relay token presence-gates section 14, and TELEGRAM_BOT_TOKEN presence-gates the optional Telegram bridge (docs/telegram-bridge.md)
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited as the literal file: a concrete primary adapter value also controls a secondmate home's own crewmates (section 4)
 config/crew-dispatch.json  optional crewmate dispatch profiles; LOCAL, gitignored; firstmate-maintained but human-editable natural-language rules that choose a per-task harness/model/effort profile (section 4). Inherited by secondmate homes
 config/secondmate-harness  harness the PRIMARY uses to launch SECONDMATE agents, optionally followed by a model and effort token on the same line ("<harness> [<model>] [<effort>]"; section 4); LOCAL, gitignored; absent or "default" harness falls back to config/crew-harness then firstmate's own. The primary's own setting; NOT inherited into secondmate homes (secondmates do not spawn secondmates)
@@ -118,6 +118,7 @@ state/               runtime records and signals; gitignored
   procevent/         registered process-to-event sources, one private record per canonical source id; written only by bin/fm-procevent.sh, and their presence alone keeps supervision required (section 13)
   procevent-inbox/   private captured results and their durable handled-acknowledgement markers; source output lives here and never in an event line
   decision-bindings/ private records marking a captured-answer source as feeding the keyed-answer intake, with a legacy origin on pre-collapse records; written only by bin/fm-captain-hold.sh bind, dropped by unbind and by source retirement (section 13; docs/captain-hold-lifecycle.md)
+  telegram/          durable acknowledgement point for the optional Telegram bridge's received messages; written only by bin/fm-procevent-telegram.sh, removed with the bridge's own opt-out
   when/              private condition->action watch specs, their trust bindings, and single-fire markers; written only by bin/fm-procevent-when.sh (section 13's process-event-sources trigger)
   inbox/             captain notes captured out of band by bin/fm-inbox.sh, including the voice handover's queued requests; each note appends one `check` wake and stays pending until acknowledged with `bin/fm-inbox.sh drain --ack <id>`, which moves it to inbox/handled/ (docs/voice-relay.md)
   x-inbox/           generated Relay pending mention payloads; fmx-respond drains it (section 14)
@@ -482,6 +483,8 @@ Reach the captain immediately for:
 - A real blocker or failure after the relevant playbook is exhausted.
 - Anything destructive, irreversible, or security-sensitive.
 - A needed credential or login.
+
+When this home has the optional Telegram bridge configured and the captain is away from the terminal, also send those same escalations outward with `bin/fm-telegram.sh notify <blocker|review-ready|failure>`; that path carries escalations only, so routine progress and digests have no kind and cannot be sent through it.
 
 Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
 When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/remote-secondmates.md](docs/remote-secondmates.md) - current setup, routing, transfer, recovery, and safety behavior for whole-home remote second mates.
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
 - [docs/voice-relay.md](docs/voice-relay.md) - the optional spoken interface: setup on both machines, measured round-trip cost, what a spoken answer may read, and what this build does not do yet.
+- [docs/telegram-bridge.md](docs/telegram-bridge.md) - the optional Telegram bridge: setup, the chat-id allowlist, and what an inbound message may and may not do.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - current setup and limits for the tmux reference backend.
 - [docs/herdr-backend.md](docs/herdr-backend.md) - current setup, safety boundaries, and limits for the experimental Herdr backend.

--- a/bin/fm-env-lib.sh
+++ b/bin/fm-env-lib.sh
@@ -1,0 +1,33 @@
+# shellcheck shell=bash
+# Shared reader for `.env`-style credential files.
+# Usage: . bin/fm-env-lib.sh
+#
+# A firstmate home keeps its credentials in one gitignored `.env`, and more than
+# one opt-in feature now reads from it. This file is the single owner of what a
+# KEY=VALUE line in that file means, so a second feature never grows a second
+# parser that drifts from the first.
+#
+# It defines:
+#   fm_env_get <key> <file>  - read one KEY=VALUE from a .env-style file
+#
+# Deliberately a reader and not a loader: it never sources the file and never
+# exports anything, so a credential file can carry no shell surface at all.
+
+# Read the value of KEY from a .env-style file: last assignment wins; tolerates a
+# leading "export ", surrounding whitespace, and one layer of matching single or
+# double quotes. Prints nothing (and succeeds) when the file or key is absent, so
+# callers can treat empty output as "unset".
+fm_env_get() {
+  local key=$1 file=$2 line val
+  [ -f "$file" ] || return 0
+  line=$(grep -E "^[[:space:]]*(export[[:space:]]+)?${key}=" "$file" 2>/dev/null | tail -n1) || return 0
+  [ -n "$line" ] || return 0
+  val=${line#*=}
+  val=${val#"${val%%[![:space:]]*}"}   # strip leading whitespace
+  val=${val%"${val##*[![:space:]]}"}   # strip trailing whitespace (incl. CR)
+  case "$val" in
+    \"*\") val=${val#\"}; val=${val%\"} ;;
+    \'*\') val=${val#\'}; val=${val%\'} ;;
+  esac
+  printf '%s' "$val"
+}

--- a/bin/fm-inbox.sh
+++ b/bin/fm-inbox.sh
@@ -183,7 +183,14 @@ queue_note() {
     printf 'source=%s\n' "$source"
     [ -z "$extra" ] || printf '%s\n' "$extra"
     printf -- '--\n'
-    printf '%s\n' "$body"
+    # The body verbatim. The record is line-oriented, so it gets a terminating
+    # newline only when the body does not already end in one: appending
+    # unconditionally would invent a blank line the caller never sent, and the
+    # trailing blank lines a caller DID send are content, not padding.
+    case "$body" in
+      *$'\n') printf '%s' "$body" ;;
+      *) printf '%s\n' "$body" ;;
+    esac
   } >"$tmp"
 
   # Publish the completed note atomically.
@@ -239,7 +246,12 @@ cmd_note() {
   if [ "$#" -eq 0 ]; then
     die "usage: fm-inbox.sh note [--source <name>] [--meta <key=value>]... <text>...   (or: note - to read stdin)"
   elif [ "$1" = "-" ]; then
-    body=$(cat)
+    # A bare $(cat) strips EVERY trailing newline, which silently truncates a
+    # body that deliberately ends in blank lines. The sentinel makes the read
+    # byte-exact; the empty-body refusal in queue_note still rejects a body that
+    # is nothing but whitespace.
+    body=$(cat; printf x)
+    body=${body%x}
   else
     body="$*"
   fi

--- a/bin/fm-inbox.sh
+++ b/bin/fm-inbox.sh
@@ -8,6 +8,10 @@
 #           answer. Writes a durable record and appends ONE `check` wake, so the
 #           note survives a crash and is presented at firstmate's next drain.
 #           This is the only subcommand that touches firstmate's wake queue.
+#           `--source` records which channel the note came in through (default
+#           `text`) and `--meta` records one extra `key=value` line for that
+#           channel's own bookkeeping; both are optional and repeatable in the
+#           case of `--meta`.
 #   say     Same as `note`, but the body comes from spoken audio on stdin.
 #           Speech is an INPUT METHOD here, not an architecture: it transcribes
 #           and then takes exactly the `note` path.
@@ -19,7 +23,8 @@
 #           fleet work and must not become fleet work.
 #
 # Usage:
-#   fm-inbox.sh note <text>...          | fm-inbox.sh note -   (body from stdin)
+#   fm-inbox.sh note [--source <name>] [--meta <key=value>]... <text>...
+#   fm-inbox.sh note [--source <name>] [--meta <key=value>]... -   (body from stdin)
 #   fm-inbox.sh say  [<file.wav>]       (default: audio on stdin)
 #   fm-inbox.sh status
 #   fm-inbox.sh ask  <question>...
@@ -195,16 +200,50 @@ queue_note() {
   fi
 }
 
+# `--source` and `--meta` exist so another channel in front of firstmate can
+# record WHERE a note came from without carrying a queue of its own. Both are
+# validated rather than trusted: the values land in the record header above the
+# `--` separator, so an unchecked newline could forge a field, and an unchecked
+# key could overwrite one. A caller that passes neither gets exactly the record
+# it got before.
+valid_meta() {  # <key=value>
+  case "$1" in
+    *$'\n'*) return 1 ;;
+    [a-z_]*=*) ;;
+    *) return 1 ;;
+  esac
+  local key=${1%%=*}
+  case "$key" in
+    *[!a-z0-9_]*) return 1 ;;
+    id|at|source) return 1 ;;
+  esac
+}
+
 cmd_note() {
-  local body
+  local body source=text meta=
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --source)
+        [ "$#" -ge 2 ] || die "--source needs a value"
+        case "$2" in
+          ''|*[!a-z0-9-]*) die "invalid --source: $2" ;;
+        esac
+        source=$2; shift 2 ;;
+      --meta)
+        [ "$#" -ge 2 ] || die "--meta needs a key=value"
+        valid_meta "$2" || die "invalid --meta: $2"
+        meta=${meta:+$meta$'\n'}$2; shift 2 ;;
+      *) break ;;
+    esac
+  done
   if [ "$#" -eq 0 ]; then
-    die "usage: fm-inbox.sh note <text>...   (or: note - to read stdin)"
+    die "usage: fm-inbox.sh note [--source <name>] [--meta <key=value>]... <text>...   (or: note - to read stdin)"
   elif [ "$1" = "-" ]; then
     body=$(cat)
   else
     body="$*"
   fi
-  queue_note text "$body"
+  queue_note "$source" "$body" "$meta"
 }
 
 # ---------------------------------------------------------------- say

--- a/bin/fm-procevent-telegram.sh
+++ b/bin/fm-procevent-telegram.sh
@@ -290,7 +290,6 @@ cmd_poll() {
         if message_has_content "$body"; then
           if queue_note "$update_id" "$body" "$from"; then
             notes=$((notes + 1))
-            fm_telegram_send_text "$FM_TG_CHAT" 'Noted - firstmate will pick this up.' >/dev/null 2>&1 || true
           else
             # Whether the note landed is ambiguous here too: fm-inbox.sh's
             # queue_note moves the note into place before it can still fail

--- a/bin/fm-procevent-telegram.sh
+++ b/bin/fm-procevent-telegram.sh
@@ -145,9 +145,20 @@ read_offset() {
 # mid-write. Both pending and acknowledged notes are searched, because a note
 # handled before the restart is still a note that was queued.
 note_exists_for_update() {  # <update-id>
-  local id=$1 inbox="${FM_TELEGRAM_INBOX_OVERRIDE:-$FM_HOME/state/inbox}"
+  local id=$1 inbox="${FM_TELEGRAM_INBOX_OVERRIDE:-$FM_HOME/state/inbox}" f
   [ -d "$inbox" ] || return 1
-  grep -rlqx "telegram_update_id=$id" "$inbox" 2>/dev/null
+  while IFS= read -r -d '' f; do
+    # Scanned up to the `--` separator only: the body below it is untrusted
+    # captain text and is now written verbatim, so it can legitimately
+    # contain a line that reads like a meta field.
+    awk -v id="$id" '
+      BEGIN { rc = 1 }
+      /^--$/ { exit }
+      $0 == "telegram_update_id=" id { rc = 0; exit }
+      END { exit rc }
+    ' "$f" && return 0
+  done < <(find "$inbox" -type f -name '*.note' -print0 2>/dev/null)
+  return 1
 }
 
 # Resolve an outstanding claim left by a crash between writing a note and
@@ -281,8 +292,11 @@ cmd_poll() {
             notes=$((notes + 1))
             fm_telegram_send_text "$FM_TG_CHAT" 'Noted - firstmate will pick this up.' >/dev/null 2>&1 || true
           else
-            # The note did not land, so the offset must not move past it.
-            rm -f "$CLAIM_FILE"
+            # Whether the note landed is ambiguous here too: fm-inbox.sh's
+            # queue_note moves the note into place before it can still fail
+            # on the wake step. Leave the claim in place so the next start's
+            # recover_claim() resolves it the same way it resolves a crash,
+            # instead of guessing here and risking a duplicate note.
             result error "a received message could not be queued as a note" \
               "notes=$notes" "dropped=$dropped"
             return 0

--- a/bin/fm-procevent-telegram.sh
+++ b/bin/fm-procevent-telegram.sh
@@ -16,7 +16,7 @@
 #            run in a conversational turn. It long-polls Telegram, turns allowed
 #            messages into durable captain notes, and exits with a result.
 # classify   Print what a handler should act on: unconfigured, error, disabled,
-#            idle, or unknown.
+#            busy, idle, or unknown.
 # terminal   Exit 0 only when the bridge has been switched off, so removing the
 #            token retires the registration instead of leaving a dead poller.
 # silent     Exit 0 for a result that carries no news, so a quiet collection
@@ -70,6 +70,19 @@
 # The result is that a message is neither queued twice nor dropped across a
 # restart at any point in the cycle.
 #
+# ONE COLLECTOR AT A TIME, ENFORCED HERE. The runner keeps one registered owner
+# per source, but a `poll` typed at a terminal never asks the runner for that
+# claim, so the header note above is not by itself an enforcement. Two pollers
+# blocked on getUpdates at the same offset are both handed the identical update,
+# and both would write a note for it - a duplicate the offset discipline below
+# cannot see, because each collection is internally correct. So the whole cycle
+# runs under one home-scoped lock, and a collector that cannot take it stands
+# down with a `busy` result rather than waiting: waiting would only queue long
+# polls behind each other. Standing down carries no news, so it wakes nobody,
+# and it is not terminal, so the runner starts a fresh collector on its next
+# reconcile. The lock is the shared one from bin/fm-wake-lib.sh, which reclaims
+# it from a holder that died rather than leaving the bridge wedged.
+#
 # A SUSTAINED OUTAGE DEGRADES QUIETLY. A failed request is retried with capped
 # backoff and reported nowhere; only a long run of consecutive failures ends the
 # cycle with an error result, which the runner publishes as one ordinary wake.
@@ -117,6 +130,7 @@ POLL_FAIL_DELAY=${FM_TELEGRAM_POLL_FAIL_DELAY:-10}
 STATE_DIR=$(fm_telegram_state_dir)
 OFFSET_FILE="$STATE_DIR/offset"
 CLAIM_FILE="$STATE_DIR/claim"
+POLL_LOCK="$STATE_DIR/poll.lock"
 
 read_offset() {
   local v
@@ -158,11 +172,28 @@ recover_claim() {
   rm -f "$CLAIM_FILE"
 }
 
+# Decode one message body back to its bytes. Kept as a pipeline the callers
+# feed into directly, because a command substitution around it would strip every
+# trailing newline of the message - blank lines the captain actually typed.
+decode_body() {  # <base64>
+  printf '%s' "$1" | base64 --decode 2>/dev/null
+}
+
+# Does this message carry anything to queue? Answered on a decoded COPY, whose
+# lost trailing newlines cannot change the answer, so the body itself never has
+# to survive a round trip through a variable.
+message_has_content() {  # <base64>
+  local probe
+  probe=$(decode_body "$1") || return 1
+  [ -n "${probe//[[:space:]]/}" ]
+}
+
 # Write one allowed message as a durable captain note. The body goes in on
-# stdin, so no part of it is ever seen by a shell.
-queue_note() {  # <update-id> <text> <from>
-  local update_id=$1 text=$2 from=$3
-  printf '%s' "$text" | "$FM_ROOT/bin/fm-inbox.sh" note \
+# stdin, straight from the decoder, so no part of it is ever seen by a shell and
+# no part of it is dropped on the way.
+queue_note() {  # <update-id> <base64> <from>
+  local update_id=$1 body=$2 from=$3
+  decode_body "$body" | "$FM_ROOT/bin/fm-inbox.sh" note \
     --source telegram \
     --meta "telegram_update_id=$update_id" \
     --meta "telegram_from=$from" \
@@ -183,10 +214,23 @@ cmd_poll() {
 
   mkdir -p "$STATE_DIR" 2>/dev/null || die "cannot create $STATE_DIR"
   chmod 0700 "$STATE_DIR" 2>/dev/null || true
+
+  # Sourced here rather than at the top of the file so `classify`, `terminal`,
+  # and `silent` - which the runner calls on every captured result - stay leaf
+  # readers that touch no state.
+  # shellcheck source=bin/fm-wake-lib.sh
+  FM_ROOT_OVERRIDE="$FM_ROOT" . "$SCRIPT_DIR/fm-wake-lib.sh"
+  if ! fm_lock_try_acquire "$POLL_LOCK"; then
+    result busy "another collector is already polling this home"
+    return 0
+  fi
+  # shellcheck disable=SC2064 # $POLL_LOCK is fixed by now; expand it here.
+  trap "fm_lock_release '$POLL_LOCK'" EXIT
+
   recover_claim || die "cannot resolve the outstanding update claim"
 
   local cycle=0 failures=0 notes=0 dropped=0 offset response ok
-  local updates update_id chat_id text from
+  local updates update_id chat_id body from
   while [ "$cycle" -lt "$POLL_MAX_CYCLES" ]; do
     cycle=$((cycle + 1))
     offset=$(read_offset)
@@ -225,16 +269,15 @@ cmd_poll() {
 
     [ -n "$updates" ] || continue
 
-    while IFS=$'\t' read -r update_id chat_id text from; do
+    while IFS=$'\t' read -r update_id chat_id body from; do
       [ -n "$update_id" ] || continue
 
       if fm_telegram_allowlisted && [ "$chat_id" = "$FM_TG_CHAT" ]; then
         # Claim first, so a crash anywhere in the next two steps is resolvable.
         fm_telegram_write_atomic "$CLAIM_FILE" "$update_id" \
           || die "cannot record the update claim"
-        text=$(printf '%s' "$text" | base64 --decode 2>/dev/null) || text=
-        if [ -n "${text//[[:space:]]/}" ]; then
-          if queue_note "$update_id" "$text" "$from"; then
+        if message_has_content "$body"; then
+          if queue_note "$update_id" "$body" "$from"; then
             notes=$((notes + 1))
             fm_telegram_send_text "$FM_TG_CHAT" 'Noted - firstmate will pick this up.' >/dev/null 2>&1 || true
           else
@@ -305,7 +348,7 @@ cmd_classify() {
   [ -f "$file" ] || die "result file does not exist: $file"
   status=$(result_field "$file" status)
   case "$status" in
-    unconfigured|error|disabled|idle) printf '%s\n' "$status" ;;
+    unconfigured|error|disabled|busy|idle) printf '%s\n' "$status" ;;
     *) printf 'unknown\n' ;;
   esac
 }
@@ -324,13 +367,15 @@ cmd_terminal() {
 # collection cycle is `idle`, and the notes it did collect announced themselves
 # through the inbox's own wake, so publishing a second wake for them would put a
 # notification in front of firstmate whose entire content is that it already has
-# one. Every other status - unconfigured, error, disabled, unknown, unreadable -
-# stays announced.
+# one. `busy` is the same kind of absence: the collector that holds the lock is
+# doing the work, so the one that stood down has nothing to report. Every other
+# status - unconfigured, error, disabled, unknown, unreadable - stays announced.
 cmd_silent() {
-  local file=${1-}
+  local file=${1-} status
   [ -n "$file" ] || usage
   [ -f "$file" ] || return 1
-  [ "$(result_field "$file" status)" = idle ]
+  status=$(result_field "$file" status)
+  [ "$status" = idle ] || [ "$status" = busy ]
 }
 
 cmd_arm() {

--- a/bin/fm-procevent-telegram.sh
+++ b/bin/fm-procevent-telegram.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+# Telegram adapter for the generic process-to-event runner.
+#
+# Usage:
+#   fm-procevent-telegram.sh arm
+#   fm-procevent-telegram.sh retire
+#   fm-procevent-telegram.sh source-id
+#   fm-procevent-telegram.sh poll
+#   fm-procevent-telegram.sh classify <result-file>
+#   fm-procevent-telegram.sh terminal <result-file>
+#   fm-procevent-telegram.sh silent   <result-file>
+#
+# arm        Register this home's Telegram collector with bin/fm-procevent.sh, so
+#            the watcher keeps a collector alive outside firstmate's turn.
+# poll       The registered listener command `arm` publishes, never a command to
+#            run in a conversational turn. It long-polls Telegram, turns allowed
+#            messages into durable captain notes, and exits with a result.
+# classify   Print what a handler should act on: unconfigured, error, disabled,
+#            idle, or unknown.
+# terminal   Exit 0 only when the bridge has been switched off, so removing the
+#            token retires the registration instead of leaving a dead poller.
+# silent     Exit 0 for a result that carries no news, so a quiet collection
+#            cycle never puts a wake in front of firstmate.
+#
+# WHY THERE IS NO NEW SUPERVISION HERE. A long-poll cannot live inside a
+# conversational turn, and this operation already has a generic runner for
+# exactly that shape. This adapter therefore supplies only what is specific to
+# Telegram - source identity, the argv to run, and how to read a result - while
+# ownership, durable capture, publication, and restart recovery stay in
+# bin/fm-procevent.sh. Nothing here is a second control plane.
+#
+# WHY getUpdates AND NOT setWebhook. A webhook needs a publicly reachable HTTPS
+# endpoint, which a personal machine does not have and should not grow just to
+# receive a handful of messages. getUpdates needs nothing but outbound HTTPS, and
+# because Telegram retains undelivered updates for 24 hours, a message sent while
+# this machine was asleep is collected on the next poll rather than lost. The two
+# mechanisms are mutually exclusive at the API, so this adapter never calls
+# setWebhook and a home that has one set must delete it first.
+#
+# THE ALLOWLIST IS THE SECURITY BOUNDARY. Anyone who discovers the bot's handle
+# can message it, so without an authorization check any stranger could queue work
+# into this operation's inbox. A message is turned into a note ONLY when its chat
+# id equals the configured TELEGRAM_ALLOWED_CHAT_ID. Everything else is consumed
+# and dropped: no note, no wake, no reply, and no echo of its text anywhere.
+#
+# INBOUND TEXT IS UNTRUSTED DATA, NEVER INSTRUCTIONS. A received message becomes
+# the BODY of a note and nothing else. It is passed to bin/fm-inbox.sh on stdin,
+# so it is never interpolated into a shell command, and it is never parsed for
+# commands, keys, or decisions. Telegram authenticates a chat id, not a person:
+# an inbound message can queue an ordinary captain note and can do nothing else.
+# It cannot answer a held decision, approve a merge, or authorize anything.
+#
+# THE ONE EXCEPTION IS FIRST-RUN DISCOVERY, and it deliberately acts on nothing.
+# Before the captain has messaged the bot, nobody knows his chat id, so the
+# allowlist cannot be configured. With no allowed chat id set, this adapter still
+# drops every message, but reports the numeric chat id of the first sender it saw
+# so firstmate can relay it for the captain to confirm. It reports the id alone -
+# never the message text, never the sender's name - and never allowlists anyone.
+# Auto-trusting the first sender would defeat the allowlist entirely, because the
+# first sender need not be the captain.
+#
+# OFFSET DISCIPLINE, owned here. Telegram acknowledges updates by offset: asking
+# for offset N confirms everything below N and drops it server-side forever. So
+# the offset is advanced only AFTER the note is durably written, never before,
+# and it is persisted atomically. A crash between those two steps is the one
+# ambiguous case, and it is closed rather than assumed: the update being handled
+# is recorded in a claim file first, and on the next start an outstanding claim
+# is resolved by looking for a note that already carries that update id. A note
+# that landed advances the offset; one that did not is left to be redelivered.
+# The result is that a message is neither queued twice nor dropped across a
+# restart at any point in the cycle.
+#
+# A SUSTAINED OUTAGE DEGRADES QUIETLY. A failed request is retried with capped
+# backoff and reported nowhere; only a long run of consecutive failures ends the
+# cycle with an error result, which the runner publishes as one ordinary wake.
+# The collector exiting is normal - the runner's reconcile starts a fresh one -
+# and because Telegram holds updates for 24 hours, nothing is lost in the gap.
+#
+# Configuration and the credential are owned by bin/fm-telegram-lib.sh.
+#
+# Environment:
+#   FM_HOME  operational home whose `.env`, state/ and inbox are used.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FM_HOME="${FM_HOME:-$FM_ROOT}"
+
+# shellcheck source=bin/fm-env-lib.sh
+. "$SCRIPT_DIR/fm-env-lib.sh"
+# shellcheck source=bin/fm-telegram-lib.sh
+. "$SCRIPT_DIR/fm-telegram-lib.sh"
+
+die() { printf 'fm-procevent-telegram: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  awk 'NR == 1 { next }
+       /^#/ { sub(/^# ?/, ""); print; next }
+       { exit }' "${BASH_SOURCE[0]}"
+  exit 2
+}
+
+# One home runs one bridge, because one `.env` carries one bot token and one
+# allowed chat. The id is therefore fixed rather than derived from a caller
+# string, and stays stable across restarts so the runner keeps one owner.
+cmd_source_id() { printf 'telegram\n'; }
+
+# How long one getUpdates call blocks, how long the whole collector lives before
+# recycling, and how many consecutive failures end it. Constants because they are
+# properties of the API and of the runner's restart cadence, not operator taste;
+# each takes an override so a test can drive the real path without waiting it out.
+POLL_TIMEOUT=${FM_TELEGRAM_POLL_TIMEOUT:-50}
+POLL_MAX_CYCLES=${FM_TELEGRAM_POLL_MAX_CYCLES:-60}
+POLL_FAIL_LIMIT=${FM_TELEGRAM_POLL_FAIL_LIMIT:-5}
+POLL_FAIL_DELAY=${FM_TELEGRAM_POLL_FAIL_DELAY:-10}
+
+STATE_DIR=$(fm_telegram_state_dir)
+OFFSET_FILE="$STATE_DIR/offset"
+CLAIM_FILE="$STATE_DIR/claim"
+
+read_offset() {
+  local v
+  [ -r "$OFFSET_FILE" ] || { printf '0\n'; return 0; }
+  v=$(tr -dc '0-9' <"$OFFSET_FILE" 2>/dev/null | head -c 32)
+  printf '%s\n' "${v:-0}"
+}
+
+# Has a note carrying this exact update id already been written? This is the
+# whole crash-recovery test, and it is answered from the durable notes
+# themselves rather than from a second bookkeeping file that could also be lost
+# mid-write. Both pending and acknowledged notes are searched, because a note
+# handled before the restart is still a note that was queued.
+note_exists_for_update() {  # <update-id>
+  local id=$1 inbox="${FM_TELEGRAM_INBOX_OVERRIDE:-$FM_HOME/state/inbox}"
+  [ -d "$inbox" ] || return 1
+  grep -rlqx "telegram_update_id=$id" "$inbox" 2>/dev/null
+}
+
+# Resolve an outstanding claim left by a crash between writing a note and
+# advancing the offset. Only that one update is ambiguous, so only that one is
+# checked.
+recover_claim() {
+  local claimed offset
+  [ -r "$CLAIM_FILE" ] || return 0
+  claimed=$(tr -dc '0-9' <"$CLAIM_FILE" 2>/dev/null | head -c 32)
+  if [ -z "$claimed" ]; then
+    rm -f "$CLAIM_FILE"
+    return 0
+  fi
+  offset=$(read_offset)
+  if [ "$offset" -le "$claimed" ] && note_exists_for_update "$claimed"; then
+    # The note landed; the offset simply never caught up. Advance past it so the
+    # message is not collected a second time.
+    fm_telegram_write_atomic "$OFFSET_FILE" "$((claimed + 1))" || return 1
+  fi
+  # Otherwise the note never landed, so the offset is left alone and Telegram
+  # redelivers the update on the next request.
+  rm -f "$CLAIM_FILE"
+}
+
+# Write one allowed message as a durable captain note. The body goes in on
+# stdin, so no part of it is ever seen by a shell.
+queue_note() {  # <update-id> <text> <from>
+  local update_id=$1 text=$2 from=$3
+  printf '%s' "$text" | "$FM_ROOT/bin/fm-inbox.sh" note \
+    --source telegram \
+    --meta "telegram_update_id=$update_id" \
+    --meta "telegram_from=$from" \
+    - >/dev/null
+}
+
+# The collector. Prints its result to stdout, which the runner captures.
+cmd_poll() {
+  [ "$#" -eq 0 ] || usage
+  command -v curl >/dev/null 2>&1 || die "required command not found: curl"
+  command -v jq >/dev/null 2>&1 || die "required command not found: jq"
+
+  fm_telegram_load
+  if ! fm_telegram_configured; then
+    result disabled "the bot token was removed from .env"
+    return 0
+  fi
+
+  mkdir -p "$STATE_DIR" 2>/dev/null || die "cannot create $STATE_DIR"
+  chmod 0700 "$STATE_DIR" 2>/dev/null || true
+  recover_claim || die "cannot resolve the outstanding update claim"
+
+  local cycle=0 failures=0 notes=0 dropped=0 offset response ok
+  local updates update_id chat_id text from
+  while [ "$cycle" -lt "$POLL_MAX_CYCLES" ]; do
+    cycle=$((cycle + 1))
+    offset=$(read_offset)
+    # A transport failure still prints curl's own (already redacted) diagnostic,
+    # so a sustained outage can say WHY rather than reporting an empty detail.
+    response=$(fm_telegram_api getUpdates \
+      --get --data-urlencode "offset=$offset" \
+      --data-urlencode "timeout=$POLL_TIMEOUT" \
+      --data-urlencode 'allowed_updates=["message"]') || true
+
+    ok=$(printf '%s' "$response" | jq -r 'if type == "object" then (.ok // false) else false end' 2>/dev/null) || ok=false
+    if [ "$ok" != "true" ]; then
+      failures=$((failures + 1))
+      if [ "$failures" -ge "$POLL_FAIL_LIMIT" ]; then
+        # Already redacted by fm_telegram_api; still trimmed to one short line.
+        result error "$(printf '%s' "$response" | tr '\n' ' ' | cut -c1-200)" \
+          "notes=$notes" "dropped=$dropped"
+        return 0
+      fi
+      sleep "$POLL_FAIL_DELAY"
+      continue
+    fi
+    failures=0
+
+    # One TSV line per message, with the text base64-encoded so a body carrying
+    # newlines, tabs, quotes, or shell metacharacters cannot break the framing
+    # or reach a shell as anything but opaque bytes.
+    updates=$(printf '%s' "$response" | jq -r '
+      .result[]
+      | select(.message != null)
+      | [ (.update_id | tostring),
+          (.message.chat.id | tostring),
+          ((.message.text // "") | @base64),
+          ((.message.from.id // 0) | tostring) ]
+      | @tsv' 2>/dev/null) || updates=
+
+    [ -n "$updates" ] || continue
+
+    while IFS=$'\t' read -r update_id chat_id text from; do
+      [ -n "$update_id" ] || continue
+
+      if fm_telegram_allowlisted && [ "$chat_id" = "$FM_TG_CHAT" ]; then
+        # Claim first, so a crash anywhere in the next two steps is resolvable.
+        fm_telegram_write_atomic "$CLAIM_FILE" "$update_id" \
+          || die "cannot record the update claim"
+        text=$(printf '%s' "$text" | base64 --decode 2>/dev/null) || text=
+        if [ -n "${text//[[:space:]]/}" ]; then
+          if queue_note "$update_id" "$text" "$from"; then
+            notes=$((notes + 1))
+            fm_telegram_send_text "$FM_TG_CHAT" 'Noted - firstmate will pick this up.' >/dev/null 2>&1 || true
+          else
+            # The note did not land, so the offset must not move past it.
+            rm -f "$CLAIM_FILE"
+            result error "a received message could not be queued as a note" \
+              "notes=$notes" "dropped=$dropped"
+            return 0
+          fi
+        else
+          # A message with no text to queue (a sticker, a photo) is consumed
+          # rather than retried forever.
+          dropped=$((dropped + 1))
+        fi
+        fm_telegram_write_atomic "$OFFSET_FILE" "$((update_id + 1))" \
+          || die "cannot advance the acknowledgement offset"
+        rm -f "$CLAIM_FILE"
+        continue
+      fi
+
+      # Not allowed. Consume it so it is not redelivered forever, and say
+      # nothing about it - no note, no reply, no echo of its text.
+      dropped=$((dropped + 1))
+      fm_telegram_write_atomic "$OFFSET_FILE" "$((update_id + 1))" \
+        || die "cannot advance the acknowledgement offset"
+
+      if ! fm_telegram_allowlisted; then
+        # First-run discovery: report the id alone so the captain can confirm it.
+        result unconfigured "a message arrived from an unconfigured chat" \
+          "chat_id=$chat_id" "notes=$notes" "dropped=$dropped"
+        return 0
+      fi
+    done <<<"$updates"
+  done
+
+  result idle "collected $notes note(s)" "notes=$notes" "dropped=$dropped"
+}
+
+# The result format this adapter's own classify/terminal/silent read. A leading
+# `telegram:` block with indented fields, so a later field can be added without
+# any reader having to change.
+result() {  # <status> <detail> [extra-field...]
+  local status=$1 detail=$2
+  shift 2
+  printf 'telegram:\n'
+  printf '  status: %s\n' "$status"
+  printf '  detail: %s\n' "$(printf '%s' "$detail" | tr '\n' ' ')"
+  local field
+  for field in "$@"; do
+    printf '  %s\n' "${field/=/: }"
+  done
+}
+
+# Read one field of the leading `telegram:` block. Confining the read to that
+# block is what stops a later free-text field from forging a status.
+result_field() {  # <result-file> <field>
+  awk -v field="$2" '
+    $0 == "telegram:" { in_b = 1; next }
+    in_b && $0 !~ /^[[:space:]]/ { exit }
+    in_b && $0 ~ "^[[:space:]]+" field ":[[:space:]]*" {
+      sub("^[[:space:]]+" field ":[[:space:]]*", ""); sub(/[[:space:]]*$/, ""); print; exit }
+  ' "$1"
+}
+
+cmd_classify() {
+  local file=${1-} status
+  [ -n "$file" ] || usage
+  [ -f "$file" ] || die "result file does not exist: $file"
+  status=$(result_field "$file" status)
+  case "$status" in
+    unconfigured|error|disabled|idle) printf '%s\n' "$status" ;;
+    *) printf 'unknown\n' ;;
+  esac
+}
+
+# Only a bridge that has been switched off is terminal. Every other result -
+# including an error - keeps the registration armed, because an outage must not
+# quietly unregister the captain's inbound channel.
+cmd_terminal() {
+  local file=${1-}
+  [ -n "$file" ] || usage
+  [ -f "$file" ] || return 1
+  [ "$(result_field "$file" status)" = disabled ]
+}
+
+# Silence is only ever an absence this adapter can positively see. A quiet
+# collection cycle is `idle`, and the notes it did collect announced themselves
+# through the inbox's own wake, so publishing a second wake for them would put a
+# notification in front of firstmate whose entire content is that it already has
+# one. Every other status - unconfigured, error, disabled, unknown, unreadable -
+# stays announced.
+cmd_silent() {
+  local file=${1-}
+  [ -n "$file" ] || usage
+  [ -f "$file" ] || return 1
+  [ "$(result_field "$file" status)" = idle ]
+}
+
+cmd_arm() {
+  [ "$#" -eq 0 ] || usage
+  command -v curl >/dev/null 2>&1 || die "required command not found: curl"
+  command -v jq >/dev/null 2>&1 || die "required command not found: jq"
+  fm_telegram_load
+  fm_telegram_configured \
+    || die "no bot token is configured: put TELEGRAM_BOT_TOKEN in ${FM_TELEGRAM_ENV_FILE:-$FM_HOME/.env}"
+  "$SCRIPT_DIR/fm-procevent.sh" register telegram "$(cmd_source_id)" \
+    -- "$SCRIPT_DIR/fm-procevent-telegram.sh" poll || exit 1
+  printf 'armed: %s\n' "$(cmd_source_id)"
+  if ! fm_telegram_allowlisted; then
+    printf 'no allowed chat id yet: every message is dropped until\n'
+    printf 'TELEGRAM_ALLOWED_CHAT_ID is set (see docs/telegram-bridge.md).\n'
+  fi
+}
+
+cmd_retire() {
+  [ "$#" -eq 0 ] || usage
+  "$SCRIPT_DIR/fm-procevent.sh" retire "$(cmd_source_id)"
+}
+
+case "${1-}" in
+  arm)       shift; cmd_arm "$@" ;;
+  retire)    shift; cmd_retire "$@" ;;
+  source-id) shift; cmd_source_id ;;
+  poll)      shift; cmd_poll "$@" ;;
+  classify)  shift; cmd_classify "$@" ;;
+  terminal)  shift; cmd_terminal "$@" ;;
+  silent)    shift; cmd_silent "$@" ;;
+  ''|-h|--help|help) usage ;;
+  *) die "unknown subcommand: $1 (try --help)" ;;
+esac

--- a/bin/fm-procevent-telegram.sh
+++ b/bin/fm-procevent-telegram.sh
@@ -275,12 +275,13 @@ cmd_poll() {
       | [ (.update_id | tostring),
           (.message.chat.id | tostring),
           ((.message.text // "") | @base64),
-          ((.message.from.id // 0) | tostring) ]
+          ((.message.from.id // 0) | tostring),
+          ((.message.message_id // 0) | tostring) ]
       | @tsv' 2>/dev/null) || updates=
 
     [ -n "$updates" ] || continue
 
-    while IFS=$'\t' read -r update_id chat_id body from; do
+    while IFS=$'\t' read -r update_id chat_id body from message_id; do
       [ -n "$update_id" ] || continue
 
       if fm_telegram_allowlisted && [ "$chat_id" = "$FM_TG_CHAT" ]; then
@@ -290,6 +291,13 @@ cmd_poll() {
         if message_has_content "$body"; then
           if queue_note "$update_id" "$body" "$from"; then
             notes=$((notes + 1))
+            # Best-effort receipt, deliberately AFTER the note is durable and
+            # deliberately unable to fail the collection: a reaction is a
+            # courtesy to the captain, and losing it must never cost the note
+            # or leave the message unconfirmed to Telegram.
+            [ "$message_id" = 0 ] \
+              || fm_telegram_react "$FM_TG_CHAT" "$message_id" >/dev/null 2>&1 \
+              || true
           else
             # Whether the note landed is ambiguous here too: fm-inbox.sh's
             # queue_note moves the note into place before it can still fail

--- a/bin/fm-telegram-lib.sh
+++ b/bin/fm-telegram-lib.sh
@@ -14,6 +14,7 @@
 #   fm_telegram_redact      - filter stdin, replacing the bot token with a marker
 #   fm_telegram_api         - call one Telegram Bot API method, printing JSON
 #   fm_telegram_send_text   - send one message to a chat id
+#   fm_telegram_react       - react to one message with an emoji
 #   fm_telegram_state_dir   - the home's durable bridge state directory
 #   fm_telegram_write_atomic - replace a state file atomically
 #
@@ -147,6 +148,33 @@ fm_telegram_send_text() {
     return 1
   fi
   fm_telegram_api sendMessage -X POST \
+    -H 'Content-Type: application/json' --data-binary "@$payload" || rc=$?
+  rm -f "$payload"
+  return "$rc"
+}
+
+# React to one message with a single emoji.
+# fm_telegram_react <chat-id> <message-id> [emoji]
+#
+# This is how the bridge confirms receipt. A reaction lands ON the captain's own
+# message instead of adding another message to the chat, so the confirmation is
+# visible without anything to read or dismiss.
+#
+# `message_id` is required to be an integer by the API, so it is converted with
+# jq's tonumber and a non-numeric id fails the payload build rather than being
+# sent as something the API would reject. Telegram also accepts only a fixed set
+# of emoji as reactions; an unsupported one comes back as an API error, which
+# the best-effort caller ignores like any other reaction failure.
+fm_telegram_react() {
+  local chat=$1 message_id=$2 emoji=${3:-👍} payload rc=0
+  payload=$(mktemp "${TMPDIR:-/tmp}/fm-telegram-react.XXXXXX") || return 1
+  if ! jq -n --arg chat "$chat" --arg mid "$message_id" --arg emoji "$emoji" \
+    '{chat_id: $chat, message_id: ($mid | tonumber),
+      reaction: [{type: "emoji", emoji: $emoji}]}' >"$payload" 2>/dev/null; then
+    rm -f "$payload"
+    return 1
+  fi
+  fm_telegram_api setMessageReaction -X POST \
     -H 'Content-Type: application/json' --data-binary "@$payload" || rc=$?
   rm -f "$payload"
   return "$rc"

--- a/bin/fm-telegram-lib.sh
+++ b/bin/fm-telegram-lib.sh
@@ -1,0 +1,168 @@
+# shellcheck shell=bash
+# Shared configuration, transport, and redaction for the Telegram bridge.
+# Usage: . bin/fm-telegram-lib.sh   (requires bin/fm-env-lib.sh on the same path)
+#
+# The bridge gives the captain a second way in and out of a firstmate home:
+# messages sent to the bot become ordinary captain notes, and firstmate can send
+# short escalations back. bin/fm-procevent-telegram.sh owns the inbound half and
+# bin/fm-telegram.sh owns the outbound half; this file owns only what both need.
+#
+# It defines:
+#   fm_telegram_load        - resolve FM_TG_TOKEN, FM_TG_CHAT, FM_TG_NAME, FM_TG_API
+#   fm_telegram_configured  - exit 0 when a bot token is present
+#   fm_telegram_allowlisted - exit 0 when an allowed chat id is configured
+#   fm_telegram_redact      - filter stdin, replacing the bot token with a marker
+#   fm_telegram_api         - call one Telegram Bot API method, printing JSON
+#   fm_telegram_send_text   - send one message to a chat id
+#   fm_telegram_state_dir   - the home's durable bridge state directory
+#   fm_telegram_write_atomic - replace a state file atomically
+#
+# OPT-IN AND INERT BY DEFAULT. Every capability here is gated on a non-empty
+# TELEGRAM_BOT_TOKEN in the home's gitignored `.env`. With no token nothing
+# resolves, nothing polls, and nothing is sent; callers check with
+# fm_telegram_configured rather than discovering it from a failed request.
+#
+# THE TOKEN IS A CREDENTIAL AND NEVER LEAVES THIS PROCESS AS OUTPUT. It is read
+# into a variable, spent as a URL path segment inside curl, and never printed,
+# logged, or written to state. Because the token IS part of every request URL,
+# curl's own diagnostics can quote it back; so every byte this file lets out of a
+# request passes through fm_telegram_redact first. Callers that build their own
+# message text must do the same before it reaches a status line or a note.
+#
+# CONFIGURATION, all from the home's gitignored `.env`:
+#   TELEGRAM_BOT_TOKEN       required; the credential from @BotFather.
+#   TELEGRAM_ALLOWED_CHAT_ID required for inbound; the one chat allowed to queue
+#                            work, and the chat outbound messages are sent to.
+#   TELEGRAM_BOT_NAME        optional; the bot's @handle, for operator messages.
+# Each may be overridden by the matching environment variable, which is how the
+# tests drive this without writing a credential file.
+#
+# FM_TELEGRAM_API_BASE overrides the API root (default https://api.telegram.org).
+# It exists so the test suite can point the bridge at a local fake API and drive
+# the real request/response path; it is not an operator setting.
+
+fm_telegram_state_dir() { printf '%s\n' "${FM_TELEGRAM_STATE_OVERRIDE:-$FM_HOME/state}/telegram"; }
+
+# Resolve configuration into FM_TG_* for the current process. Environment wins
+# over `.env`, matching how Relay resolves its own pairing token.
+fm_telegram_load() {
+  local env_file="${FM_TELEGRAM_ENV_FILE:-$FM_HOME/.env}"
+  if [ -n "${TELEGRAM_BOT_TOKEN+x}" ]; then
+    FM_TG_TOKEN=${TELEGRAM_BOT_TOKEN-}
+  else
+    FM_TG_TOKEN=$(fm_env_get TELEGRAM_BOT_TOKEN "$env_file")
+  fi
+  if [ -n "${TELEGRAM_ALLOWED_CHAT_ID+x}" ]; then
+    FM_TG_CHAT=${TELEGRAM_ALLOWED_CHAT_ID-}
+  else
+    FM_TG_CHAT=$(fm_env_get TELEGRAM_ALLOWED_CHAT_ID "$env_file")
+  fi
+  # Read here so every consumer resolves the handle the same way; only the
+  # operator-facing status view actually prints it.
+  # shellcheck disable=SC2034
+  if [ -n "${TELEGRAM_BOT_NAME+x}" ]; then
+    FM_TG_NAME=${TELEGRAM_BOT_NAME-}
+  else
+    FM_TG_NAME=$(fm_env_get TELEGRAM_BOT_NAME "$env_file")
+  fi
+  FM_TG_API=${FM_TELEGRAM_API_BASE:-https://api.telegram.org}
+
+  # An allowed chat id is an identity the allowlist compares against, so anything
+  # that is not a plain Telegram chat id is refused rather than half-matched. A
+  # chat id is a signed integer; group ids are negative.
+  case "$FM_TG_CHAT" in
+    '') ;;
+    -[0-9]* | [0-9]*)
+      case "${FM_TG_CHAT#-}" in
+        *[!0-9]*) FM_TG_CHAT_INVALID=1 ;;
+        *) FM_TG_CHAT_INVALID=0 ;;
+      esac
+      ;;
+    *) FM_TG_CHAT_INVALID=1 ;;
+  esac
+  : "${FM_TG_CHAT_INVALID:=0}"
+}
+
+fm_telegram_configured() { [ -n "${FM_TG_TOKEN-}" ]; }
+fm_telegram_allowlisted() { [ -n "${FM_TG_CHAT-}" ] && [ "${FM_TG_CHAT_INVALID:-0}" -eq 0 ]; }
+
+# Replace every occurrence of the bot token on stdin with a fixed marker. Used on
+# ANY text derived from a request before it can reach a caller, a status line, a
+# note, or a state file.
+#
+# Two deliberate choices, both load-bearing, both regression-tested. The match is
+# awk index/substr rather than a regex, so a token containing regex
+# metacharacters is still matched literally. And the token reaches awk through
+# ENVIRON rather than `-v`, because `-v` processes backslash escapes in the value
+# it is given: a token containing a backslash would arrive mangled, match
+# nothing, and silently pass the credential straight through. Today's Telegram
+# tokens carry no backslash, but a credential guard must not depend on that.
+fm_telegram_redact() {
+  if [ -z "${FM_TG_TOKEN-}" ]; then
+    cat
+    return 0
+  fi
+  FM_TG_REDACT_TOKEN="$FM_TG_TOKEN" awk '
+    BEGIN { tok = ENVIRON["FM_TG_REDACT_TOKEN"] }
+    {
+      line = $0
+      out = ""
+      while ((i = index(line, tok)) > 0) {
+        out = out substr(line, 1, i - 1) "<redacted>"
+        line = substr(line, i + length(tok))
+      }
+      print out line
+    }
+  '
+}
+
+# Call one Bot API method and print its JSON response.
+# fm_telegram_api <method> [curl-arg...]
+#
+# The token is passed through --url rather than being interpolated into a shell
+# command, and stderr is folded into stdout through the redactor so a curl
+# diagnostic that quotes the request URL cannot leak the credential. Returns
+# curl's exit status; a transport failure prints an empty body, which callers
+# treat as "no answer" rather than as a malformed reply.
+fm_telegram_api() {
+  local method=$1
+  shift
+  local rc=0 out
+  out=$(curl -sS --max-time "${FM_TELEGRAM_HTTP_TIMEOUT:-120}" \
+    --url "$FM_TG_API/bot$FM_TG_TOKEN/$method" "$@" 2>&1) || rc=$?
+  printf '%s\n' "$out" | fm_telegram_redact
+  return "$rc"
+}
+
+# Send one plain-text message. fm_telegram_send_text <chat-id> <text>
+#
+# The body is handed to curl as a JSON file rather than as a command string, so
+# message text is never interpolated anywhere a shell or a URL parser reads it.
+fm_telegram_send_text() {
+  local chat=$1 text=$2 payload rc=0
+  payload=$(mktemp "${TMPDIR:-/tmp}/fm-telegram-send.XXXXXX") || return 1
+  if ! jq -n --arg chat "$chat" --arg text "$text" \
+    '{chat_id: $chat, text: $text, disable_web_page_preview: true}' >"$payload"; then
+    rm -f "$payload"
+    return 1
+  fi
+  fm_telegram_api sendMessage -X POST \
+    -H 'Content-Type: application/json' --data-binary "@$payload" || rc=$?
+  rm -f "$payload"
+  return "$rc"
+}
+
+# Replace a small state file atomically, so a crash mid-write can never leave a
+# half-written offset that would replay or skip messages.
+fm_telegram_write_atomic() {  # <path> <content>
+  local path=$1 content=$2 dir tmp
+  dir=$(dirname "$path")
+  mkdir -p "$dir" || return 1
+  tmp=$(mktemp "$dir/.tmp-XXXXXX") || return 1
+  if ! printf '%s\n' "$content" >"$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  chmod 0600 "$tmp" 2>/dev/null || true
+  mv -f "$tmp" "$path"
+}

--- a/bin/fm-telegram.sh
+++ b/bin/fm-telegram.sh
@@ -7,8 +7,10 @@
 #   fm-telegram.sh status
 #
 # send    Send one plain-text message to the configured chat. This is the raw
-#         path, used for the acknowledgement the inbound poller sends back and
-#         for a reply the captain explicitly asked for.
+#         path, used for a reply the captain explicitly asked for. The inbound
+#         collector deliberately sends nothing of its own: firstmate's real
+#         reply follows shortly, so an automatic receipt was chatter the
+#         captain had to read twice, not reassurance.
 # notify  Send one ESCALATION. <kind> is one of `blocker`, `review-ready`, or
 #         `failure`, and nothing else is accepted.
 # status  Report what is configured, for an operator setting the bridge up. It

--- a/bin/fm-telegram.sh
+++ b/bin/fm-telegram.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# fm-telegram.sh - the outbound half of the Telegram bridge.
+#
+# Usage:
+#   fm-telegram.sh send <text>...          | fm-telegram.sh send -   (body on stdin)
+#   fm-telegram.sh notify <kind> <text>... | fm-telegram.sh notify <kind> -
+#   fm-telegram.sh status
+#
+# send    Send one plain-text message to the configured chat. This is the raw
+#         path, used for the acknowledgement the inbound poller sends back and
+#         for a reply the captain explicitly asked for.
+# notify  Send one ESCALATION. <kind> is one of `blocker`, `review-ready`, or
+#         `failure`, and nothing else is accepted.
+# status  Report what is configured, for an operator setting the bridge up. It
+#         prints whether a token is present, never any part of the token itself.
+#
+# WHAT FLOWS OUTWARD IS ESCALATIONS ONLY, and `notify` is what makes that a
+# mechanism rather than a memo. Firstmate already has a definition of what is
+# worth interrupting the captain for - a real blocker, work ready for review, a
+# failure - and those three kinds are exactly it. Routine progress, empty polls,
+# elapsed time, and no-change updates have no kind here and so cannot be sent
+# through this path at all. There is deliberately no periodic digest: a channel
+# that pings for everything is a channel the captain learns to ignore.
+#
+# Messages sent here LEAVE THIS MACHINE and reach Telegram's servers. Send short
+# outcome summaries: never a credential, a file's contents, or a full record
+# body. That judgement belongs to the caller; this script transports what it is
+# given and only guarantees the bot token is not part of it.
+#
+# Inert until configured. With no TELEGRAM_BOT_TOKEN in the home's `.env` this
+# exits 3 without sending or printing anything, so an unconfigured home can call
+# it unconditionally. Configuration is owned by bin/fm-telegram-lib.sh.
+#
+# Exit status: 0 sent, 2 usage, 3 not configured, 4 the send was refused.
+#
+# Environment:
+#   FM_HOME  operational home whose `.env` and state/ are used.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FM_HOME="${FM_HOME:-$FM_ROOT}"
+
+# shellcheck source=bin/fm-env-lib.sh
+. "$SCRIPT_DIR/fm-env-lib.sh"
+# shellcheck source=bin/fm-telegram-lib.sh
+. "$SCRIPT_DIR/fm-telegram-lib.sh"
+
+die() { printf 'fm-telegram: %s\n' "$*" >&2; exit 2; }
+need() { command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"; }
+
+usage() {
+  awk 'NR == 1 { next }
+       /^#/ { sub(/^# ?/, ""); print; next }
+       { exit }' "${BASH_SOURCE[0]}"
+  exit 2
+}
+
+# Read the message body from the remaining arguments, or from stdin for `-`.
+# stdin is the safe path for anything that might contain shell metacharacters,
+# and the only path for a body with newlines.
+read_body() {
+  if [ "$#" -eq 0 ]; then
+    return 1
+  elif [ "$1" = "-" ]; then
+    cat
+  else
+    printf '%s' "$*"
+  fi
+}
+
+# One place that turns a resolved configuration into a sent message, so `send`
+# and `notify` cannot drift on what "configured" means or what gets reported.
+deliver() {  # <text>
+  local text=$1 response ok
+  [ -n "${text//[[:space:]]/}" ] || die "refusing to send an empty message"
+  need curl
+  need jq
+  fm_telegram_allowlisted || {
+    printf 'fm-telegram: no chat id is configured; set TELEGRAM_ALLOWED_CHAT_ID in %s\n' \
+      "${FM_TELEGRAM_ENV_FILE:-$FM_HOME/.env}" >&2
+    exit 3
+  }
+  response=$(fm_telegram_send_text "$FM_TG_CHAT" "$text") || true
+  ok=$(printf '%s' "$response" | jq -r 'if type == "object" then (.ok // false) else false end' 2>/dev/null) || ok=false
+  if [ "$ok" != "true" ]; then
+    # The response has already been through the redactor, so it is safe to show.
+    printf 'fm-telegram: send was refused: %s\n' \
+      "$(printf '%s' "$response" | tr '\n' ' ' | cut -c1-300)" >&2
+    exit 4
+  fi
+  printf 'sent\n'
+}
+
+cmd_send() {
+  local body
+  body=$(read_body "$@") || usage
+  deliver "$body"
+}
+
+# The escalation tier. An unknown kind is refused rather than sent with a
+# generic prefix, because the whole value of this path is that everything
+# arriving through it is something the captain actually wants interrupting.
+cmd_notify() {
+  local kind=${1-} body label
+  [ -n "$kind" ] || usage
+  shift
+  case "$kind" in
+    blocker)      label='Blocked' ;;
+    review-ready) label='Ready for review' ;;
+    failure)      label='Failed' ;;
+    *) die "unknown escalation kind: $kind (use blocker, review-ready, or failure)" ;;
+  esac
+  body=$(read_body "$@") || usage
+  deliver "$label: $body"
+}
+
+cmd_status() {
+  printf 'home        %s\n' "$FM_HOME"
+  printf 'env file    %s\n' "${FM_TELEGRAM_ENV_FILE:-$FM_HOME/.env}"
+  if fm_telegram_configured; then
+    printf 'bot token   configured\n'
+  else
+    printf 'bot token   absent (bridge is inert)\n'
+  fi
+  printf 'bot handle  %s\n' "${FM_TG_NAME:-unknown}"
+  if fm_telegram_allowlisted; then
+    printf 'allowed chat %s\n' "$FM_TG_CHAT"
+  elif [ -n "${FM_TG_CHAT-}" ]; then
+    printf 'allowed chat INVALID (not a chat id): refusing every message\n'
+  else
+    printf 'allowed chat absent (inbound drops everything; see docs/telegram-bridge.md)\n'
+  fi
+}
+
+fm_telegram_load
+
+case "${1:-}" in
+  send)   shift; fm_telegram_configured || exit 3; cmd_send "$@" ;;
+  notify) shift; fm_telegram_configured || exit 3; cmd_notify "$@" ;;
+  status) shift; cmd_status ;;
+  ''|-h|--help|help) usage ;;
+  *) die "unknown subcommand: $1 (try --help)" ;;
+esac

--- a/bin/fm-telegram.sh
+++ b/bin/fm-telegram.sh
@@ -8,9 +8,9 @@
 #
 # send    Send one plain-text message to the configured chat. This is the raw
 #         path, used for a reply the captain explicitly asked for. The inbound
-#         collector deliberately sends nothing of its own: firstmate's real
-#         reply follows shortly, so an automatic receipt was chatter the
-#         captain had to read twice, not reassurance.
+#         collector deliberately sends no MESSAGE of its own; it confirms a
+#         received message with a reaction instead, which the captain can see
+#         at a glance and has nothing to dismiss.
 # notify  Send one ESCALATION. <kind> is one of `blocker`, `review-ready`, or
 #         `failure`, and nothing else is accepted.
 # status  Report what is configured, for an operator setting the bridge up. It

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -212,6 +212,7 @@ family_for_basename() {
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
     fm-tmux-submit-busy.test.sh|fm-trace-context-lib.test.sh|\
     fm-transition-lib.test.sh|\
+    fm-telegram.test.sh|\
     fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
       printf '%s\n' pure-contract-unit
       ;;

--- a/bin/fm-x-lib.sh
+++ b/bin/fm-x-lib.sh
@@ -8,6 +8,7 @@
 #
 # This file is sourced, never executed. It defines:
 #   fmx_env_get <key> <file>   - read one KEY=VALUE from a .env-style file
+#                                (thin alias for bin/fm-env-lib.sh's fm_env_get)
 #   fmx_load_config            - resolve FMX_TOKEN, FMX_RELAY, FMX_DRY, FMX_MAX,
 #                                and FMX_THREAD_MAX (env wins over .env)
 #   fmx_auth_header_file       - write the bearer header to a 0600 temp file
@@ -56,24 +57,13 @@ if ! command -v fm_backlog_atomic_transition >/dev/null 2>&1; then
   . "$_FM_X_LIB_DIR/fm-backlog-transition-lib.sh"
 fi
 
-# Read the value of KEY from a .env-style file: last assignment wins; tolerates a
-# leading "export ", surrounding whitespace, and one layer of matching single or
-# double quotes. Prints nothing (and succeeds) when the file or key is absent, so
-# callers can treat empty output as "unset".
-fmx_env_get() {
-  local key=$1 file=$2 line val
-  [ -f "$file" ] || return 0
-  line=$(grep -E "^[[:space:]]*(export[[:space:]]+)?${key}=" "$file" 2>/dev/null | tail -n1) || return 0
-  [ -n "$line" ] || return 0
-  val=${line#*=}
-  val=${val#"${val%%[![:space:]]*}"}   # strip leading whitespace
-  val=${val%"${val##*[![:space:]]}"}   # strip trailing whitespace (incl. CR)
-  case "$val" in
-    \"*\") val=${val#\"}; val=${val%\"} ;;
-    \'*\') val=${val#\'}; val=${val%\'} ;;
-  esac
-  printf '%s' "$val"
-}
+# Relay's name for the shared `.env` reader, kept because ten call sites use it.
+# The contract itself is owned once by bin/fm-env-lib.sh; this delegates rather
+# than carrying a second copy that could drift from it.
+# shellcheck source=bin/fm-env-lib.sh
+. "$_FM_X_LIB_DIR/fm-env-lib.sh"
+
+fmx_env_get() { fm_env_get "$@"; }
 
 fmx_poll_shim_content() {
   local home=$1 root=$2

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -741,6 +741,21 @@ The published `lavish-axi poll` clears feedback destructively before returning i
 Never describe this path as at-least-once, no-loss, or lossless.
 `docs/verification/process-event-sources.md` holds the measurements and `.agents/skills/process-event-sources/SKILL.md` owns the handling procedure.
 
+## Telegram bridge (.env)
+
+The optional Telegram bridge lets the captain send work to a firstmate home from a phone and receive escalations back.
+It is off unless the home's gitignored `.env` carries a non-empty `TELEGRAM_BOT_TOKEN`, and it needs `curl` and `jq`.
+[`docs/telegram-bridge.md`](telegram-bridge.md) owns setup, the chat-id allowlist, the security boundary, and what an inbound message may and may not do; only the keys themselves are listed here.
+
+| Key in `.env` | Holds |
+| --- | --- |
+| `TELEGRAM_BOT_TOKEN` | The credential from @BotFather. Its presence is the opt-in; with no token nothing polls, nothing sends, and nothing is written. |
+| `TELEGRAM_ALLOWED_CHAT_ID` | The one chat allowed to queue notes, and the chat escalations are sent to. Required for inbound: with none set every message is dropped. |
+| `TELEGRAM_BOT_NAME` | Optional bot @handle, shown by `bin/fm-telegram.sh status`. |
+
+Each may be overridden by the matching environment variable for a single run.
+The chat id cannot be known until the captain has messaged the bot once, so [`docs/telegram-bridge.md`](telegram-bridge.md) carries that one manual step.
+
 ## Spoken interface and captain inbox (config/voice-*, config/inbox-*)
 
 The spoken interface in [`docs/voice-relay.md`](voice-relay.md) and the model-backed subcommands of `bin/fm-inbox.sh` reach a paid API in a named account, so no region, model id or AWS profile is shipped as a tracked default.
@@ -897,6 +912,17 @@ FM_CRASH_BACKOFF=60                # seconds to wait after crossing the crash th
 FM_CRASH_NORMAL_SLEEP=5            # seconds to wait after an isolated watcher crash
 FM_LOG_MAX_BYTES=1048576           # daemon log size that triggers trimming
 FM_LOG_KEEP_LINES=2000             # daemon log lines kept when trimming
+# Telegram bridge; see "Telegram bridge (.env)" above and docs/telegram-bridge.md
+TELEGRAM_BOT_TOKEN=       # overrides the .env bot token; its presence is the whole opt-in
+TELEGRAM_ALLOWED_CHAT_ID= # overrides the .env allowed chat id; absent or malformed drops every inbound message
+TELEGRAM_BOT_NAME=        # overrides the .env bot @handle
+FM_TELEGRAM_ENV_FILE=     # alternate .env-style file the bridge reads its keys from
+FM_TELEGRAM_API_BASE=https://api.telegram.org  # Bot API root; exists so tests can drive a local stand-in
+FM_TELEGRAM_HTTP_TIMEOUT=120   # seconds before one Bot API request is abandoned
+FM_TELEGRAM_POLL_TIMEOUT=50    # seconds one long-poll waits on Telegram for a new message
+FM_TELEGRAM_POLL_MAX_CYCLES=60 # long-polls before the collector recycles; nothing is lost, Telegram holds messages 24h
+FM_TELEGRAM_POLL_FAIL_LIMIT=5  # consecutive failed requests before the cycle ends and reports the outage once
+FM_TELEGRAM_POLL_FAIL_DELAY=10 # seconds between retries during an outage
 # spoken interface and captain inbox; see "Spoken interface and captain inbox" above
 FM_VOICE_REGION=        # overrides config/voice-region for one relay run
 FM_VOICE_MODEL=         # overrides config/voice-model for one relay run

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -31,7 +31,8 @@
     "docs/zellij-backend.md",
     "docs/orca-backend.md",
     "docs/cmux-backend.md",
-    "docs/remote-secondmates.md"
+    "docs/remote-secondmates.md",
+    "docs/telegram-bridge.md"
   ],
   "requiredOwnerPointers": [
     {
@@ -399,6 +400,10 @@
     {
       "path": "docs/supervision-protocols/unknown.md",
       "audience": "agent-runtime"
+    },
+    {
+      "path": "docs/telegram-bridge.md",
+      "audience": "operator-current"
     },
     {
       "path": "docs/tmux-backend.md",

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -78,6 +78,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-procevent-remote-reply.sh` | Relay the remote-secondmate status stream through non-destructive process-event deltas |
 | `fm-procevent-quota.sh`  | Wake Firstmate when tracked quota drops below a threshold, is exhausted, or cannot be polled |
 | `fm-procevent-when.sh`   | Fire a trust-bound deterministic action at most once when its registered condition holds, then wake with the outcome |
+| `fm-procevent-telegram.sh` | Collect the captain's allowlisted Telegram messages into durable notes, with confirmation only after each note lands ([telegram-bridge.md](telegram-bridge.md)) |
 | `fm-gate-refuse-lib.sh`  | Shared no-mistakes gate-context refusal for fleet lifecycle entrypoints               |
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with loud cycle endings and bounded lifecycle ledger |
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |
@@ -144,3 +145,6 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-voice-client.py`     | The laptop end of the spoken interface: capture, playback, and turn timing over SSH; audio devices unverified |
 | `fm_voice_frame.py`      | The wire format both machines share, copied to the laptop beside the client          |
 | `fm_voice_records.py`    | What a spoken answer may read, and the handover that queues real work                |
+| `fm-telegram.sh`         | Send the captain an escalation or a reply over Telegram ([telegram-bridge.md](telegram-bridge.md)) |
+| `fm-telegram-lib.sh`     | Shared Telegram configuration, transport, and bot-token redaction                    |
+| `fm-env-lib.sh`          | Shared reader for `.env`-style credential files                                      |

--- a/docs/telegram-bridge.md
+++ b/docs/telegram-bridge.md
@@ -12,6 +12,7 @@ In scope:
 
 - **Inbound.** A message from the allowed chat becomes a durable note firstmate picks up at its next check.
 - **Outbound.** Firstmate can send an escalation - a blocker, work ready for review, or a failure.
+- **Receipt.** An accepted message gets a 👍 reaction, so the captain can see it landed.
 
 Deliberately not in scope, and each for a reason:
 
@@ -24,9 +25,10 @@ Deliberately not in scope, and each for a reason:
   Telegram cannot approve a merge, answer a held decision, or authorize anything destructive, irreversible, or security-sensitive.
   An inbound message proves which chat it came from, not who typed it, so it can queue an ordinary captain note and nothing else.
   Those decisions stay on the trusted terminal channel.
-- **No automatic acknowledgement.**
-  An accepted message gets no bot receipt.
-  Firstmate's own reply follows shortly through the ordinary note flow, so an automatic "noted" only made the captain read two messages where one would do.
+- **No automatic reply message.**
+  Receipt is a reaction on the captain's own message, never another message in the chat.
+  A bot message arrived before firstmate had even read the note and had to be read as a separate line, where a reaction is visible at a glance and leaves nothing to dismiss.
+  The reaction is best-effort: if Telegram refuses it, the note is already durable and the message stays confirmed, so nothing is collected twice.
 - **No periodic digest.**
   Only the three escalation kinds go outward, so the channel stays worth reading.
 - **One captain, one chat.**

--- a/docs/telegram-bridge.md
+++ b/docs/telegram-bridge.md
@@ -62,6 +62,7 @@ You need `curl` and `jq`.
      ```
 
    That first message is consumed rather than queued, so send a throwaway one.
+   Only one collector polls a home at a time, so if you come back to this step after arming, that manual run stands down and reports `status: busy` instead - let firstmate report the chat id, or retire the collector first.
 4. Arm the collector with `bin/fm-procevent-telegram.sh arm`.
    Firstmate keeps it running from then on.
 
@@ -105,6 +106,8 @@ Telegram holds undelivered messages for 24 hours, so anything sent while nothing
 Telegram treats a request for the next message as confirmation that the previous ones were received, and confirmed messages are gone for good.
 So the bridge confirms a message only after its note is durably written, records which message it is working on first, and resolves an interrupted one on the next start by checking whether that note actually landed.
 A message whose note could not be written is left unconfirmed, so Telegram sends it again.
+Only one collector polls a home at a time, because two of them waiting on the same message are both handed it and would each queue a note; the second one stands down and firstmate starts it again later.
+A collector that is killed outright does not wedge the next one.
 
 **An outage is quiet.**
 A failed request is retried and reported nowhere.

--- a/docs/telegram-bridge.md
+++ b/docs/telegram-bridge.md
@@ -1,0 +1,126 @@
+# Telegram bridge
+
+A second way in and out of a firstmate home, from a phone.
+Messages the captain sends to a Telegram bot become ordinary captain notes in that home's durable queue, and firstmate can send short escalations back the same way.
+
+It is off unless the home's gitignored `.env` carries a bot token.
+It adds no supervision machinery of its own: inbound collection is one adapter registered against the existing process-to-event runner, and a received message takes the same path as a note typed at the terminal.
+
+## What it does and does not do
+
+In scope:
+
+- **Inbound.** A message from the allowed chat becomes a durable note firstmate picks up at its next check.
+- **Outbound.** Firstmate can send an escalation - a blocker, work ready for review, or a failure.
+- **Acknowledgement.** An accepted message gets a short reply, so the captain knows it landed rather than guessing.
+
+Deliberately not in scope, and each for a reason:
+
+- **No webhook, public endpoint, or tunnel.**
+  Receiving by webhook needs a publicly reachable HTTPS address, which a personal machine does not have and should not grow just to receive a handful of messages.
+  The bridge asks Telegram for messages instead, over ordinary outbound HTTPS.
+- **No command language, menus, or buttons.**
+  Free text only.
+- **No decision authority.**
+  Telegram cannot approve a merge, answer a held decision, or authorize anything destructive, irreversible, or security-sensitive.
+  An inbound message proves which chat it came from, not who typed it, so it can queue an ordinary captain note and nothing else.
+  Those decisions stay on the trusted terminal channel.
+- **No periodic digest.**
+  Only the three escalation kinds go outward, so the channel stays worth reading.
+- **One captain, one chat.**
+  There is no multi-user support.
+
+## Setup
+
+You need `curl` and `jq`.
+
+1. Message [@BotFather](https://t.me/BotFather) on Telegram, create a bot, and copy the token it gives you.
+2. Put the token in this firstmate home's gitignored `.env`:
+
+   ```
+   TELEGRAM_BOT_TOKEN=<token from BotFather>
+   TELEGRAM_BOT_NAME=<your bot's @handle>
+   ```
+
+3. Find your chat id.
+   Nobody knows it until you have messaged the bot at least once, so this step cannot be skipped or guessed.
+   - Send the bot any message, for example `hello`.
+   - Run `bin/fm-procevent-telegram.sh poll` once, or let firstmate report it.
+     It prints the chat id of the sender it saw:
+
+     ```
+     telegram:
+       status: unconfigured
+       detail: a message arrived from an unconfigured chat
+       chat_id: 424242
+     ```
+
+   - Confirm that id is yours, then add it to `.env`:
+
+     ```
+     TELEGRAM_ALLOWED_CHAT_ID=424242
+     ```
+
+   That first message is consumed rather than queued, so send a throwaway one.
+4. Arm the collector with `bin/fm-procevent-telegram.sh arm`.
+   Firstmate keeps it running from then on.
+
+`bin/fm-telegram.sh status` reports what is configured at any point, without printing any part of the token.
+
+The bridge only reports the first sender's chat id; it never allowlists it.
+That is the whole point of the step: the bot's handle is discoverable, so the first person to message it need not be you.
+
+## Security
+
+**The bot token is a credential.**
+Anyone holding it controls the bot completely.
+It lives on one line of `.env`, which is gitignored, and it is never committed, logged, echoed into terminal output, or written into a status line or a note.
+Because the token is part of every request URL, anything derived from a request - including a failure diagnostic that quotes that URL - is filtered before it is printed.
+
+**The chat-id allowlist is the security boundary, not a hardening extra.**
+Anyone who discovers the bot's handle can message it, so without this check any stranger could queue work into the captain's inbox.
+A message becomes a note only when its chat id equals `TELEGRAM_ALLOWED_CHAT_ID`.
+Everything else is dropped with no note, no notification, no reply, and no copy of its text anywhere.
+A malformed `TELEGRAM_ALLOWED_CHAT_ID` refuses every message rather than half-matching one.
+
+**Inbound text is data, never instructions.**
+A received message becomes the body of a note and nothing else.
+It reaches the note surface on standard input, so no part of it is ever seen by a shell, and it is never scanned for commands, keys, or decisions.
+
+**Outbound content leaves this machine.**
+Messages sent to Telegram reach Telegram's servers.
+Send short outcome summaries only - never a credential, a file's contents, or a full record body.
+
+## Behavior worth knowing
+
+**A message is work, not a logbook entry.**
+An accepted message becomes a note in the same durable queue a note typed at the terminal or handed over by the spoken interface lands in, and it wakes firstmate the same way.
+Firstmate acts on it at its next check rather than filing it to be read later, and it stays counted as waiting until it has actually been handled.
+What it cannot do is decide anything: it is an ordinary captain note, so it can ask for work, and it can never approve a merge, answer a held decision, or authorize something destructive, irreversible, or security-sensitive.
+
+**A message sent while the machine is off is not lost.**
+Telegram holds undelivered messages for 24 hours, so anything sent while nothing was running is collected on the next start.
+
+**A message is never queued twice and never silently dropped.**
+Telegram treats a request for the next message as confirmation that the previous ones were received, and confirmed messages are gone for good.
+So the bridge confirms a message only after its note is durably written, records which message it is working on first, and resolves an interrupted one on the next start by checking whether that note actually landed.
+A message whose note could not be written is left unconfirmed, so Telegram sends it again.
+
+**An outage is quiet.**
+A failed request is retried and reported nowhere.
+Only a sustained outage ends the collection cycle, which firstmate reports once and then restarts.
+Nothing wedges, and nothing is lost in the gap.
+
+**Removing the token switches the bridge off.**
+The collector reports itself disabled and is retired rather than left running dead.
+
+## Files this feature owns
+
+| Path | What it is |
+| --- | --- |
+| `bin/fm-procevent-telegram.sh` | The inbound half: collector, allowlist, note writing, and confirmation discipline. |
+| `bin/fm-telegram.sh` | The outbound half: `send`, the `notify` escalation tier, and `status`. |
+| `bin/fm-telegram-lib.sh` | Configuration, transport, and token redaction shared by both. |
+| `state/telegram/` | The home's durable confirmation point for received messages. |
+
+Each script's `--help` owns its exact flags and mechanics.

--- a/docs/telegram-bridge.md
+++ b/docs/telegram-bridge.md
@@ -12,7 +12,6 @@ In scope:
 
 - **Inbound.** A message from the allowed chat becomes a durable note firstmate picks up at its next check.
 - **Outbound.** Firstmate can send an escalation - a blocker, work ready for review, or a failure.
-- **Acknowledgement.** An accepted message gets a short reply, so the captain knows it landed rather than guessing.
 
 Deliberately not in scope, and each for a reason:
 
@@ -25,6 +24,9 @@ Deliberately not in scope, and each for a reason:
   Telegram cannot approve a merge, answer a held decision, or authorize anything destructive, irreversible, or security-sensitive.
   An inbound message proves which chat it came from, not who typed it, so it can queue an ordinary captain note and nothing else.
   Those decisions stay on the trusted terminal channel.
+- **No automatic acknowledgement.**
+  An accepted message gets no bot receipt.
+  Firstmate's own reply follows shortly through the ordinary note flow, so an automatic "noted" only made the captain read two messages where one would do.
 - **No periodic digest.**
   Only the three escalation kinds go outward, so the channel stays worth reading.
 - **One captain, one chat.**

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -82,6 +82,9 @@ make_fake_root() {
   # teardown now requires.
   ln -s "$ROOT/bin/fm-public-followup-lib.sh" "$fake/bin/fm-public-followup-lib.sh"
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
+  # fm-env-lib.sh: the shared `.env` reader fm-x-lib.sh sources. Nothing in this
+  # fixture has a `.env` to read, but the source itself is unconditional.
+  ln -s "$ROOT/bin/fm-env-lib.sh" "$fake/bin/fm-env-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-parent-lib.sh" "$fake/bin/fm-secondmate-parent-lib.sh"
   # Receiver-wake retirement sources the pending-reply library, which in turn
@@ -175,6 +178,9 @@ test_teardown_skips_gracefully_without_tasktmp() {
   # teardown now requires.
   ln -s "$ROOT/bin/fm-public-followup-lib.sh" "$fake/bin/fm-public-followup-lib.sh"
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
+  # fm-env-lib.sh: the shared `.env` reader fm-x-lib.sh sources. Nothing in this
+  # fixture has a `.env` to read, but the source itself is unconditional.
+  ln -s "$ROOT/bin/fm-env-lib.sh" "$fake/bin/fm-env-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-parent-lib.sh" "$fake/bin/fm-secondmate-parent-lib.sh"
   ln -s "$ROOT/bin/fm-pending-reply-lib.sh" "$fake/bin/fm-pending-reply-lib.sh"

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -57,6 +57,12 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  # fm-session-lock-lib.sh: the tmux adapter sources it unguarded (no `||
+  # return 1`). Under set -eu, `.` on a missing file is a special-builtin
+  # failure that set -e never exempts, even inside `fm_backend_kill ... ||
+  # true` - it takes the whole teardown process down before it reaches the
+  # tasktmp removal, rather than just failing the best-effort kill call.
+  ln -s "$ROOT/bin/fm-session-lock-lib.sh" "$fake/bin/fm-session-lock-lib.sh"
   ln -s "$ROOT/bin/fm-cursor-lib.sh" "$fake/bin/fm-cursor-lib.sh"
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"
@@ -113,6 +119,16 @@ fm_tasks_axi_compatible() { return 1; }
 fm_backlog_backend_manual() { return 1; }
 SH
   ln -s "$ROOT/bin/fm-backlog-transition-lib.sh" "$fake/bin/fm-backlog-transition-lib.sh"
+  # lsof: stub. teardown's leaked-process sweep shells out to the real lsof on
+  # PATH and refuses (preserving tasktmp) if it exits non-zero; the host's own
+  # ambient process table can trip that on a busy machine (permission-denied
+  # stats show up as a non-zero exit) with nothing this fixture's tasktmp could
+  # ever hold. Report no cwd matches instead of depending on host state.
+  cat > "$fake/bin/lsof" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fake/bin/lsof"
   # Meta with a nonexistent worktree so the dirty/treehouse blocks skip.
   cat > "$fake/state/$id.meta" <<META
 window=fakeses:fm-$id
@@ -138,8 +154,9 @@ test_teardown_removes_tasktmp_dir() {
   fake=$(make_fake_root "$id" "$task_tmp")
   # Sanity: dir + contents exist before teardown.
   [ -d "$task_tmp/gotmp" ] || fail "precondition: gotmp missing before teardown"
-  # Run the REAL teardown against the fake root.
-  FM_HOME="$fake" bash "$fake/bin/fm-teardown.sh" "$id" >/dev/null 2>&1 \
+  # Run the REAL teardown against the fake root. Fake bin/ first on PATH so
+  # the stub lsof above shadows the real one.
+  FM_HOME="$fake" PATH="$fake/bin:$PATH" bash "$fake/bin/fm-teardown.sh" "$id" >/dev/null 2>&1 \
     || fail "teardown exited non-zero with a valid tasktmp"
   [ ! -e "$task_tmp" ] \
     || fail "teardown did not remove the tasktmp dir ($task_tmp still exists)"
@@ -156,6 +173,9 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  # fm-session-lock-lib.sh: the tmux adapter sources it unguarded, see the
+  # matching comment in make_fake_root above.
+  ln -s "$ROOT/bin/fm-session-lock-lib.sh" "$fake/bin/fm-session-lock-lib.sh"
   ln -s "$ROOT/bin/fm-cursor-lib.sh" "$fake/bin/fm-cursor-lib.sh"
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"

--- a/tests/fm-telegram.test.sh
+++ b/tests/fm-telegram.test.sh
@@ -390,14 +390,20 @@ test_an_unwritable_note_is_never_acknowledged() {
     || fail "a message was acknowledged even though its note could not be written"
   printf '%s' "$out" | grep -q 'status: error' \
     || fail "a failed note write was not reported"
+  # Whether the note landed is ambiguous from here (fm-inbox.sh can still fail
+  # after moving the note into place), so the claim is left for the next
+  # start's recover_claim() to resolve the same way it resolves a crash,
+  # rather than guessed away here and risking a duplicate note.
   [ -f "$home/state/telegram/claim" ] \
-    && fail "a failed note write left a stale in-flight claim behind"
+    || fail "a failed note write discarded the in-flight claim needed to resolve it safely"
 
   # With the inbox writable again the message is still there to collect.
   set_updates "$(message_json 76 555 'must not be acknowledged')"
   run_poll "$home" 555 >/dev/null 2>&1
   [ "$(note_count "$home")" = 2 ] \
     || fail "the unacknowledged message was not collected on the next attempt"
+  [ -f "$home/state/telegram/claim" ] \
+    && fail "the stale claim was not resolved once the message was collected"
   pass "a message whose note cannot be written is never acknowledged to Telegram"
 }
 

--- a/tests/fm-telegram.test.sh
+++ b/tests/fm-telegram.test.sh
@@ -1,0 +1,623 @@
+#!/usr/bin/env bash
+# Behavior tests for the Telegram bridge: the chat-id allowlist, verbatim
+# untrusted message bodies, offset discipline across a restart, credential
+# redaction, quiet degradation under an outage, the escalation tier, and the
+# inert-until-configured guarantee.
+#
+# Every case drives the real scripts against a local stand-in for the Telegram
+# Bot API, so the request/response path, the note write, and the durable offset
+# are all exercised for real rather than asserted about.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+command -v curl >/dev/null 2>&1 || { echo "skip: curl not found"; exit 0; }
+command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found"; exit 0; }
+
+ADAPTER="$ROOT/bin/fm-procevent-telegram.sh"
+SEND="$ROOT/bin/fm-telegram.sh"
+TMP_ROOT=$(fm_test_tmproot fm-telegram)
+API_ROOT="$TMP_ROOT/api"
+TOKEN='123456:AA-test_Token'
+mkdir -p "$API_ROOT"
+
+# --- the stand-in API -------------------------------------------------------
+#
+# It implements the one Telegram behavior the bridge's correctness rests on:
+# asking for offset N permanently drops every update below N. Without that, an
+# offset bug would still look like it worked.
+
+cat > "$API_ROOT/server.py" <<'PY'
+import json, os, sys, threading, time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse, parse_qs
+
+ROOT = sys.argv[1]
+LOCK = threading.Lock()
+
+def load(name, default):
+    p = os.path.join(ROOT, name)
+    if not os.path.exists(p):
+        return default
+    try:
+        with open(p) as f:
+            return json.load(f)
+    except (ValueError, OSError):
+        return default
+
+def save(name, obj):
+    with open(os.path.join(ROOT, name), "w") as f:
+        json.dump(obj, f)
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _reply(self, obj, code=200):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _route(self):
+        parts = [p for p in urlparse(self.path).path.split("/") if p]
+        if len(parts) != 2 or not parts[0].startswith("bot"):
+            return None, None
+        return parts[0][3:], parts[1]
+
+    def _authed(self, token):
+        if token != load("token.json", {"t": ""})["t"]:
+            self._reply({"ok": False, "error_code": 401,
+                         "description": "Unauthorized"}, 401)
+            return False
+        return True
+
+    def do_GET(self):
+        token, method = self._route()
+        if method is None:
+            return self._reply({"ok": False, "description": "bad path"}, 404)
+        if not self._authed(token):
+            return
+        with LOCK:
+            fail = load("fail.json", {"n": 0})
+            if fail["n"] > 0:
+                fail["n"] -= 1
+                save("fail.json", fail)
+                failing = True
+            else:
+                failing = False
+        if failing:
+            return self._reply({"ok": False, "error_code": 502,
+                                "description": "Bad Gateway"}, 502)
+        if method != "getUpdates":
+            return self._reply({"ok": False, "description": "no such method"}, 404)
+        q = parse_qs(urlparse(self.path).query)
+        offset = int(q.get("offset", ["0"])[0])
+        timeout = float(q.get("timeout", ["0"])[0])
+        with LOCK:
+            pend = load("updates.json", [])
+            if offset > 0:
+                kept = [u for u in pend if u["update_id"] >= offset]
+                if len(kept) != len(pend):
+                    save("updates.json", kept)
+                pend = kept
+            ready = list(pend)
+        if not ready and timeout > 0:
+            deadline = time.time() + min(timeout, 2)
+            while time.time() < deadline:
+                time.sleep(0.05)
+                with LOCK:
+                    ready = load("updates.json", [])
+                if ready:
+                    break
+        return self._reply({"ok": True, "result": ready})
+
+    def do_POST(self):
+        token, method = self._route()
+        if method is None:
+            return self._reply({"ok": False, "description": "bad path"}, 404)
+        if not self._authed(token):
+            return
+        n = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(n).decode()
+        if method != "sendMessage":
+            return self._reply({"ok": False, "description": "no such method"}, 404)
+        with LOCK:
+            sent = load("sent.json", [])
+            sent.append(json.loads(raw))
+            save("sent.json", sent)
+        return self._reply({"ok": True, "result": {"message_id": len(sent)}})
+
+srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+with open(os.path.join(ROOT, "port"), "w") as f:
+    f.write(str(srv.server_address[1]))
+srv.serve_forever()
+PY
+
+printf '{"t":"%s"}\n' "$TOKEN" > "$API_ROOT/token.json"
+python3 "$API_ROOT/server.py" "$API_ROOT" >"$API_ROOT/server.log" 2>&1 &
+API_PID=$!
+
+stop_api() {
+  [ -n "${API_PID:-}" ] || return 0
+  kill "$API_PID" 2>/dev/null || true
+  wait "$API_PID" 2>/dev/null || true
+  API_PID=
+}
+trap 'stop_api; fm_test_cleanup' EXIT
+trap 'stop_api; fm_test_cleanup; exit 130' INT
+trap 'stop_api; fm_test_cleanup; exit 143' TERM
+
+for _ in $(seq 1 100); do
+  [ -s "$API_ROOT/port" ] && break
+  sleep 0.1
+done
+[ -s "$API_ROOT/port" ] || fail "the stand-in Telegram API did not start"
+API_BASE="http://127.0.0.1:$(cat "$API_ROOT/port")"
+
+# --- fixture helpers --------------------------------------------------------
+
+set_updates() { printf '%s\n' "$1" > "$API_ROOT/updates.json"; }
+set_failures() { printf '{"n":%s}\n' "$1" > "$API_ROOT/fail.json"; }
+reset_sent() { rm -f "$API_ROOT/sent.json"; }
+sent_count() {
+  [ -f "$API_ROOT/sent.json" ] || { printf '0\n'; return 0; }
+  jq 'length' < "$API_ROOT/sent.json"
+}
+note_count() {  # <home>
+  find "$1/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' '
+}
+note_body() {  # <home>
+  local f
+  f=$(find "$1/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | head -n1)
+  [ -n "$f" ] || return 1
+  sed -n '/^--$/,$p' "$f" | tail -n +2
+}
+
+make_home() {  # <name>
+  local home="$TMP_ROOT/$1"
+  rm -rf "$home"
+  mkdir -p "$home/state" "$home/config"
+  printf '%s\n' "$home"
+}
+
+# Run the inbound collector against the stand-in API. The chat id is passed as
+# the caller gave it, including empty, which is the unconfigured case.
+run_poll() {  # <home> <allowed-chat> [extra-env...]
+  local home=$1 chat=$2
+  shift 2
+  env "$@" FM_HOME="$home" FM_TELEGRAM_API_BASE="$API_BASE" \
+    TELEGRAM_BOT_TOKEN="$TOKEN" TELEGRAM_ALLOWED_CHAT_ID="$chat" \
+    FM_TELEGRAM_POLL_TIMEOUT="${POLL_TIMEOUT:-1}" \
+    FM_TELEGRAM_POLL_MAX_CYCLES="${POLL_CYCLES:-2}" \
+    FM_TELEGRAM_POLL_FAIL_DELAY=1 \
+    FM_TELEGRAM_POLL_FAIL_LIMIT="${POLL_FAIL_LIMIT:-3}" \
+    "$ADAPTER" "${ADAPTER_CMD:-poll}"
+}
+
+run_send() {  # <home> <allowed-chat> <args...>
+  local home=$1 chat=$2
+  shift 2
+  env FM_HOME="$home" FM_TELEGRAM_API_BASE="$API_BASE" \
+    TELEGRAM_BOT_TOKEN="$TOKEN" TELEGRAM_ALLOWED_CHAT_ID="$chat" \
+    "$SEND" "$@"
+}
+
+message_json() {  # <update-id> <chat-id> <text>
+  jq -nc --argjson u "$1" --argjson c "$2" --arg t "$3" \
+    '[{update_id: $u, message: {chat: {id: $c}, from: {id: 77}, text: $t}}]'
+}
+
+# --- cases ------------------------------------------------------------------
+
+test_allowed_message_becomes_a_note() {
+  local home
+  home=$(make_home allowed)
+  reset_sent
+  set_failures 0
+  set_updates "$(message_json 10 555 'ship the thing')"
+  run_poll "$home" 555 >/dev/null 2>&1
+
+  [ "$(note_count "$home")" = 1 ] || fail "an allowed message did not become a note"
+  note_body "$home" | grep -qx 'ship the thing' \
+    || fail "the note body is not the message text"
+  grep -rqx 'source=telegram' "$home/state/inbox" \
+    || fail "the note does not record Telegram as its source"
+  grep -q 'check: captain inbox note' "$home/state/.wake-queue" \
+    || fail "the note did not wake firstmate"
+  [ "$(sent_count)" = 1 ] || fail "the bot did not acknowledge the accepted note"
+  pass "an allowed message becomes a durable, acknowledged captain note"
+}
+
+test_message_body_is_stored_verbatim() {
+  local home hostile
+  # Shell metacharacters, both quote styles, a newline, a tab, and unicode. The
+  # command substitutions are the payload and must reach the note UNEXPANDED, so
+  # they are built with printf rather than written as an expanding literal.
+  home=$(make_home verbatim)
+  hostile=$(printf '%s(touch %s/PWNED); %sid%s; "q" %ss%s\nsecond\tline; ⚓ ünï 日本語 | & > <' \
+    '$' "$TMP_ROOT" '`' '`' "'" "'")
+  set_failures 0
+  set_updates "$(message_json 20 555 "$hostile")"
+  run_poll "$home" 555 >/dev/null 2>&1
+
+  [ -e "$TMP_ROOT/PWNED" ] && fail "message text was executed as a shell command"
+  [ "$(note_body "$home")" = "$hostile" ] \
+    || fail "the message body was altered on its way into the note"
+  pass "a hostile message body is stored verbatim and never interpreted"
+}
+
+test_unallowlisted_chat_is_silently_dropped() {
+  local home
+  home=$(make_home stranger)
+  reset_sent
+  set_failures 0
+  set_updates "$(message_json 30 999 'queue work for me')"
+  run_poll "$home" 555 >/dev/null 2>&1
+
+  [ "$(note_count "$home")" = 0 ] || fail "a stranger's message became a note"
+  [ -f "$home/state/.wake-queue" ] && fail "a stranger's message woke firstmate"
+  [ "$(sent_count)" = 0 ] || fail "the bot replied to a stranger"
+  grep -rq 'queue work for me' "$home" 2>/dev/null \
+    && fail "a stranger's message text was echoed into this home"
+  pass "a message from an unallowlisted chat produces no note, wake, reply, or echo"
+}
+
+test_unconfigured_allowlist_reports_the_id_only() {
+  local home out
+  home=$(make_home discovery)
+  reset_sent
+  set_failures 0
+  set_updates "$(message_json 40 424242 'my first words')"
+  out=$(run_poll "$home" '' 2>&1)
+
+  printf '%s' "$out" | grep -q 'status: unconfigured' \
+    || fail "a first sender was not reported for confirmation"
+  printf '%s' "$out" | grep -q 'chat_id: 424242' \
+    || fail "the first sender's chat id was not reported"
+  printf '%s' "$out" | grep -q 'my first words' \
+    && fail "the first sender's message text was echoed"
+  [ "$(note_count "$home")" = 0 ] \
+    || fail "an unconfigured bridge queued a note anyway"
+  [ "$(sent_count)" = 0 ] || fail "the bot replied to an unconfirmed sender"
+  pass "with no allowlist the first sender's id is reported and nothing is trusted"
+}
+
+test_an_inbound_message_wakes_firstmate_to_act_on_it() {
+  local home out
+  home=$(make_home wakes)
+  set_failures 0
+  set_updates "$(message_json 15 555 'please look at the failing deploy')"
+  run_poll "$home" 555 >/dev/null 2>&1
+
+  # A Telegram message must be WORK firstmate is woken to act on, exactly like a
+  # note typed at the terminal or handed over by the spoken interface - not
+  # something archived for whenever it is next read. The proof is that the real
+  # wake drain presents it as an actionable check wake carrying the message.
+  # Both streams: the queued rows print on stdout, the acknowledgement contract on stderr.
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-wake-drain.sh" 2>&1)
+  printf '%s' "$out" | grep -q "check: captain inbox note" \
+    || fail "an inbound message did not reach firstmate as an actionable wake"
+  printf '%s' "$out" | grep -q "please look at the failing deploy" \
+    || fail "the wake does not carry what the captain actually asked for"
+  printf '%s' "$out" | grep -q "WAKE_ACK_REQUIRED" \
+    || fail "the wake could be dropped without being handled"
+
+  # And it stays outstanding until it is explicitly acknowledged as handled.
+  FM_HOME="$home" "$ROOT/bin/fm-inbox.sh" list | grep -q 'please look at the failing deploy' \
+    || fail "the message stopped counting as waiting for firstmate before it was handled"
+  pass "an inbound message wakes firstmate as work to act on, not an archived record"
+}
+
+test_offset_advances_only_after_the_note_is_written() {
+  local home
+  home=$(make_home offset)
+  set_failures 0
+  set_updates "$(message_json 50 555 'first')"
+  run_poll "$home" 555 >/dev/null 2>&1
+  [ "$(cat "$home/state/telegram/offset")" = 51 ] \
+    || fail "the offset did not advance past a written note"
+  [ -f "$home/state/telegram/claim" ] \
+    && fail "the in-flight claim outlived a completed message"
+  pass "the acknowledgement offset advances only after the note is durably written"
+}
+
+test_restart_after_a_written_note_does_not_duplicate_it() {
+  local home
+  home=$(make_home dup)
+  set_failures 0
+  set_updates "$(message_json 60 555 'exactly once')"
+  run_poll "$home" 555 >/dev/null 2>&1
+  [ "$(note_count "$home")" = 1 ] || fail "the first collection did not write the note"
+
+  # Exactly the durable state a crash between the note write and the offset
+  # advance leaves behind, with the update still pending server-side because
+  # Telegram was never told to drop it.
+  printf '60\n' > "$home/state/telegram/claim"
+  printf '60\n' > "$home/state/telegram/offset"
+  set_updates "$(message_json 60 555 'exactly once')"
+
+  run_poll "$home" 555 >/dev/null 2>&1
+  [ "$(note_count "$home")" = 1 ] \
+    || fail "restarting after the crash window queued the same message twice"
+  [ -f "$home/state/telegram/claim" ] \
+    && fail "the outstanding claim was not resolved on restart"
+  pass "a restart inside the crash window does not queue the same message twice"
+}
+
+test_restart_before_a_written_note_still_collects_it() {
+  local home
+  home=$(make_home lost)
+  mkdir -p "$home/state/telegram"
+  # The other side of the same window: the claim was recorded but the note never
+  # landed, so the message must still be collected rather than skipped.
+  printf '70\n' > "$home/state/telegram/claim"
+  printf '70\n' > "$home/state/telegram/offset"
+  set_failures 0
+  set_updates "$(message_json 70 555 'must not be lost')"
+
+  run_poll "$home" 555 >/dev/null 2>&1
+  [ "$(note_count "$home")" = 1 ] \
+    || fail "a message whose note never landed was dropped on restart"
+  note_body "$home" | grep -qx 'must not be lost' || fail "the recovered note is wrong"
+  pass "a restart before the note landed still collects the message"
+}
+
+test_an_unwritable_note_is_never_acknowledged() {
+  local home out offset_before offset_after
+  home=$(make_home unwritable)
+  set_failures 0
+  # Collect one message normally so the offset has a known starting point.
+  set_updates "$(message_json 75 555 'first one')"
+  run_poll "$home" 555 >/dev/null 2>&1
+  offset_before=$(cat "$home/state/telegram/offset")
+
+  # Now make the note record impossible to write. This is what proves the
+  # ORDER rather than just the recovery: the offset must not move past a message
+  # whose note did not land, or Telegram drops it and it is gone for good.
+  chmod 500 "$home/state/inbox"
+  set_updates "$(message_json 76 555 'must not be acknowledged')"
+  out=$(run_poll "$home" 555 2>&1) || true
+  chmod 700 "$home/state/inbox"
+
+  offset_after=$(cat "$home/state/telegram/offset")
+  [ "$offset_after" = "$offset_before" ] \
+    || fail "a message was acknowledged even though its note could not be written"
+  printf '%s' "$out" | grep -q 'status: error' \
+    || fail "a failed note write was not reported"
+  [ -f "$home/state/telegram/claim" ] \
+    && fail "a failed note write left a stale in-flight claim behind"
+
+  # With the inbox writable again the message is still there to collect.
+  set_updates "$(message_json 76 555 'must not be acknowledged')"
+  run_poll "$home" 555 >/dev/null 2>&1
+  [ "$(note_count "$home")" = 2 ] \
+    || fail "the unacknowledged message was not collected on the next attempt"
+  pass "a message whose note cannot be written is never acknowledged to Telegram"
+}
+
+test_a_message_waiting_while_nothing_polls_is_collected() {
+  local home
+  home=$(make_home retained)
+  set_failures 0
+  set_updates '[]'
+  run_poll "$home" 555 >/dev/null 2>&1
+  [ "$(note_count "$home")" = 0 ] || fail "a note appeared with no message pending"
+
+  # The message arrives while no collector is running.
+  set_updates "$(message_json 80 555 'sent while asleep')"
+  run_poll "$home" 555 >/dev/null 2>&1
+  [ "$(note_count "$home")" = 1 ] \
+    || fail "a message sent while nothing polled was never collected"
+  pass "a message that arrives while nothing is polling is collected on next start"
+}
+
+test_a_transient_outage_is_absorbed() {
+  local home
+  home=$(make_home flap)
+  set_failures 2
+  set_updates "$(message_json 90 555 'survived')"
+  POLL_CYCLES=8 POLL_FAIL_LIMIT=5 run_poll "$home" 555 >/dev/null 2>&1
+  [ "$(note_count "$home")" = 1 ] \
+    || fail "a message was lost across a transient outage"
+  set_failures 0
+  pass "a transient outage is retried through, not reported"
+}
+
+test_a_sustained_outage_ends_the_cycle_without_retiring_it() {
+  local home out result
+  home=$(make_home outage)
+  set_failures 999
+  set_updates '[]'
+  out=$(POLL_CYCLES=8 POLL_FAIL_LIMIT=2 run_poll "$home" 555 2>&1) \
+    || fail "a sustained outage crashed the collector instead of ending cleanly"
+  set_failures 0
+
+  result="$TMP_ROOT/outage-result"
+  printf '%s\n' "$out" > "$result"
+  [ "$("$ADAPTER" classify "$result")" = error ] \
+    || fail "a sustained outage was not classified as an error"
+  "$ADAPTER" silent "$result" && fail "a sustained outage was silently swallowed"
+  "$ADAPTER" terminal "$result" && fail "an outage retired the captain's inbound channel"
+  pass "a sustained outage ends the cycle, is reported once, and stays armed"
+}
+
+test_a_quiet_cycle_is_not_announced() {
+  local home out result
+  home=$(make_home quiet)
+  set_failures 0
+  set_updates '[]'
+  out=$(run_poll "$home" 555 2>&1)
+  result="$TMP_ROOT/quiet-result"
+  printf '%s\n' "$out" > "$result"
+  [ "$("$ADAPTER" classify "$result")" = idle ] || fail "a quiet cycle was misclassified"
+  "$ADAPTER" silent "$result" || fail "a quiet collection cycle would wake firstmate"
+  pass "a quiet collection cycle produces no wake"
+}
+
+test_the_bot_token_is_never_emitted() {
+  local home out
+  home=$(make_home redaction)
+  set_failures 0
+  set_updates '[]'
+  # Force a transport failure so curl's own diagnostic - the one output path
+  # that can quote the request URL, and the token is a path segment of it -
+  # actually runs. That the redaction itself is literal and total is proved
+  # separately by test_redaction_survives_an_awkward_token.
+  out=$(env FM_HOME="$home" FM_TELEGRAM_API_BASE="http://127.0.0.1:1" \
+    TELEGRAM_BOT_TOKEN="$TOKEN" TELEGRAM_ALLOWED_CHAT_ID=555 \
+    FM_TELEGRAM_HTTP_TIMEOUT=2 FM_TELEGRAM_POLL_TIMEOUT=1 \
+    FM_TELEGRAM_POLL_MAX_CYCLES=2 FM_TELEGRAM_POLL_FAIL_DELAY=1 \
+    FM_TELEGRAM_POLL_FAIL_LIMIT=1 "$ADAPTER" poll 2>&1)
+
+  printf '%s' "$out" | grep -qF "$TOKEN" \
+    && fail "the bot token was printed in the collector's own output"
+  printf '%s' "$out" | grep -q 'status: error' \
+    || fail "the failing request did not report an error at all"
+  printf '%s' "$out" | grep -Eq '^  detail: .+' \
+    || fail "the failing request reported no diagnostic to act on"
+  grep -rqF "$TOKEN" "$home" 2>/dev/null \
+    && fail "the bot token was written into this home's durable state"
+  pass "the bot token never reaches output or durable state, even in a diagnostic"
+}
+
+test_redaction_survives_an_awkward_token() {
+  # A token carrying regex metacharacters AND a backslash. The backslash is the
+  # sharp one: passing the token to awk with -v would process it as an escape,
+  # mangle it, match nothing, and pass the credential straight through.
+  local awkward out backslash
+  # Built with printf so the metacharacters are literal bytes of the token
+  # rather than anything this test's own shell interprets.
+  backslash=$(printf '%b' '\0134')
+  awkward="9:AA.*B[x]C\$D^E${backslash}FG+H"
+  out=$(FM_TG_TOKEN="$awkward" FM_TG_ROOT="$ROOT" bash -c '
+    . "$FM_TG_ROOT/bin/fm-env-lib.sh"
+    . "$FM_TG_ROOT/bin/fm-telegram-lib.sh"
+    printf "url=https://api.telegram.org/bot%s/getUpdates\n" "$FM_TG_TOKEN" | fm_telegram_redact')
+  printf '%s' "$out" | grep -qF "$awkward" \
+    && fail "a token containing regex metacharacters or a backslash was not redacted"
+  [ "$out" = 'url=https://api.telegram.org/bot<redacted>/getUpdates' ] \
+    || fail "redaction mangled the surrounding text: $out"
+  pass "redaction is literal and survives a token full of metacharacters"
+}
+
+test_escalation_tier_accepts_only_escalations() {
+  local home
+  home=$(make_home tier)
+  reset_sent
+  run_send "$home" 555 notify blocker 'needs a credential' >/dev/null 2>&1 \
+    || fail "a blocker escalation was refused"
+  run_send "$home" 555 notify review-ready 'PR is green' >/dev/null 2>&1 \
+    || fail "a review-ready escalation was refused"
+  run_send "$home" 555 notify failure 'the build broke' >/dev/null 2>&1 \
+    || fail "a failure escalation was refused"
+  [ "$(sent_count)" = 3 ] || fail "the three escalation kinds did not all send"
+
+  run_send "$home" 555 notify progress 'still working' >/dev/null 2>&1 \
+    && fail "routine progress was accepted as an escalation"
+  run_send "$home" 555 notify digest 'hourly summary' >/dev/null 2>&1 \
+    && fail "a periodic digest was accepted as an escalation"
+  [ "$(sent_count)" = 3 ] || fail "a refused kind was sent anyway"
+  jq -r '.[0].text' < "$API_ROOT/sent.json" | grep -q '^Blocked: ' \
+    || fail "an escalation did not carry its kind"
+  pass "only blockers, review-ready work, and failures can be sent outward"
+}
+
+test_the_bridge_is_inert_with_no_token() {
+  local home rc
+  home=$(make_home inert)
+  set_failures 0
+  set_updates "$(message_json 100 555 'hello')"
+  reset_sent
+
+  rc=0
+  env FM_HOME="$home" FM_TELEGRAM_API_BASE="$API_BASE" \
+    TELEGRAM_BOT_TOKEN= TELEGRAM_ALLOWED_CHAT_ID= \
+    "$ADAPTER" poll >/dev/null 2>&1 || rc=$?
+  [ "$rc" = 0 ] || fail "an unconfigured collector failed instead of reporting itself off"
+
+  rc=0
+  env FM_HOME="$home" TELEGRAM_BOT_TOKEN= "$SEND" send 'nothing' >/dev/null 2>&1 || rc=$?
+  [ "$rc" = 3 ] || fail "an unconfigured send did not report itself unconfigured (got $rc)"
+
+  rc=0
+  env FM_HOME="$home" TELEGRAM_BOT_TOKEN= "$ADAPTER" arm >/dev/null 2>&1 || rc=$?
+  [ "$rc" = 0 ] && fail "an unconfigured bridge registered a collector anyway"
+
+  [ "$(note_count "$home")" = 0 ] || fail "an unconfigured bridge queued a note"
+  [ "$(sent_count)" = 0 ] || fail "an unconfigured bridge sent a message"
+  [ -d "$home/state/telegram" ] && fail "an unconfigured bridge wrote durable state"
+  pass "with no token nothing polls, sends, registers, or is written"
+}
+
+test_a_removed_token_retires_the_source() {
+  local home out result
+  home=$(make_home removed)
+  out=$(env FM_HOME="$home" TELEGRAM_BOT_TOKEN= "$ADAPTER" poll 2>&1)
+  result="$TMP_ROOT/removed-result"
+  printf '%s\n' "$out" > "$result"
+  [ "$("$ADAPTER" classify "$result")" = disabled ] \
+    || fail "a removed token was not classified as disabled"
+  "$ADAPTER" terminal "$result" \
+    || fail "removing the token left a dead collector registered"
+  pass "removing the token retires the collector instead of leaving it dead"
+}
+
+test_an_invalid_allowed_chat_id_refuses_everything() {
+  local home
+  home=$(make_home badchat)
+  reset_sent
+  set_failures 0
+  set_updates "$(message_json 110 555 'should not land')"
+  # An allowlist that is not a chat id must never half-match.
+  run_poll "$home" 'not-a-chat-id' >/dev/null 2>&1
+  [ "$(note_count "$home")" = 0 ] \
+    || fail "a malformed allowlist accepted a message"
+  [ "$(sent_count)" = 0 ] || fail "a malformed allowlist still replied"
+  pass "a malformed allowed chat id refuses every message rather than half-matching"
+}
+
+test_note_metadata_options_are_validated() {
+  local home rc
+  home=$(make_home meta)
+  rc=0
+  env FM_HOME="$home" "$ROOT/bin/fm-inbox.sh" note --source 'bad source' body >/dev/null 2>&1 || rc=$?
+  [ "$rc" = 0 ] && fail "an invalid note source was accepted"
+  rc=0
+  env FM_HOME="$home" "$ROOT/bin/fm-inbox.sh" note --meta $'x=1\nsource=forged' body >/dev/null 2>&1 || rc=$?
+  [ "$rc" = 0 ] && fail "note metadata could forge a second record field"
+  rc=0
+  env FM_HOME="$home" "$ROOT/bin/fm-inbox.sh" note --meta 'source=forged' body >/dev/null 2>&1 || rc=$?
+  [ "$rc" = 0 ] && fail "note metadata could overwrite the record's own source field"
+  env FM_HOME="$home" "$ROOT/bin/fm-inbox.sh" note plain body >/dev/null 2>&1 \
+    || fail "the note contract stopped accepting a plain body"
+  grep -rqx 'source=text' "$home/state/inbox" \
+    || fail "a note with no --source stopped defaulting to text"
+  pass "note metadata is validated and the original note contract still holds"
+}
+
+test_allowed_message_becomes_a_note
+test_message_body_is_stored_verbatim
+test_unallowlisted_chat_is_silently_dropped
+test_unconfigured_allowlist_reports_the_id_only
+test_an_inbound_message_wakes_firstmate_to_act_on_it
+test_offset_advances_only_after_the_note_is_written
+test_restart_after_a_written_note_does_not_duplicate_it
+test_restart_before_a_written_note_still_collects_it
+test_an_unwritable_note_is_never_acknowledged
+test_a_message_waiting_while_nothing_polls_is_collected
+test_a_transient_outage_is_absorbed
+test_a_sustained_outage_ends_the_cycle_without_retiring_it
+test_a_quiet_cycle_is_not_announced
+test_the_bot_token_is_never_emitted
+test_redaction_survives_an_awkward_token
+test_escalation_tier_accepts_only_escalations
+test_the_bridge_is_inert_with_no_token
+test_a_removed_token_retires_the_source
+test_an_invalid_allowed_chat_id_refuses_everything
+test_note_metadata_options_are_validated

--- a/tests/fm-telegram.test.sh
+++ b/tests/fm-telegram.test.sh
@@ -230,8 +230,12 @@ test_allowed_message_becomes_a_note() {
     || fail "the note does not record Telegram as its source"
   grep -q 'check: captain inbox note' "$home/state/.wake-queue" \
     || fail "the note did not wake firstmate"
-  [ "$(sent_count)" = 1 ] || fail "the bot did not acknowledge the accepted note"
-  pass "an allowed message becomes a durable, acknowledged captain note"
+  # The collector sends nothing of its own. An automatic receipt reached the
+  # captain before firstmate had even read the message, so it was removed:
+  # firstmate's own reply is the confirmation.
+  [ "$(sent_count)" = 0 ] \
+    || fail "the collector sent $(sent_count) unprompted message(s) back to the captain"
+  pass "an allowed message becomes a durable captain note with no bot chatter"
 }
 
 test_message_body_is_stored_verbatim() {
@@ -431,8 +435,8 @@ test_concurrent_collectors_never_queue_a_message_twice() {
 
   [ "$(note_count "$home")" = 1 ] \
     || fail "concurrent collectors queued one message $(note_count "$home") time(s)"
-  [ "$(sent_count)" = 1 ] \
-    || fail "concurrent collectors acknowledged one message $(sent_count) time(s)"
+  [ "$(sent_count)" = 0 ] \
+    || fail "a raced collector sent $(sent_count) unprompted message(s) to the captain"
 
   # And the one that stood down said so, rather than looking like a quiet cycle
   # that had simply found nothing.

--- a/tests/fm-telegram.test.sh
+++ b/tests/fm-telegram.test.sh
@@ -401,6 +401,101 @@ test_an_unwritable_note_is_never_acknowledged() {
   pass "a message whose note cannot be written is never acknowledged to Telegram"
 }
 
+test_concurrent_collectors_never_queue_a_message_twice() {
+  local home first second declined result
+  home=$(make_home serialized)
+  reset_sent
+  set_failures 0
+  set_updates '[]'
+
+  # The window a direct `poll` opens next to the registered collector: both are
+  # already blocked in getUpdates on the SAME offset when a message arrives, so
+  # the API hands the identical update to each of them. Nothing in the runner
+  # can close this, because a direct invocation never asks the runner for the
+  # source claim - only the collector itself can refuse to be the second one.
+  POLL_TIMEOUT=3 POLL_CYCLES=2 run_poll "$home" 555 >"$TMP_ROOT/serialized-a" 2>&1 &
+  first=$!
+  POLL_TIMEOUT=3 POLL_CYCLES=2 run_poll "$home" 555 >"$TMP_ROOT/serialized-b" 2>&1 &
+  second=$!
+  sleep 1
+  set_updates "$(message_json 120 555 'say this once')"
+  wait "$first" 2>/dev/null || true
+  wait "$second" 2>/dev/null || true
+  unset POLL_TIMEOUT POLL_CYCLES
+
+  [ "$(note_count "$home")" = 1 ] \
+    || fail "concurrent collectors queued one message $(note_count "$home") time(s)"
+  [ "$(sent_count)" = 1 ] \
+    || fail "concurrent collectors acknowledged one message $(sent_count) time(s)"
+
+  # And the one that stood down said so, rather than looking like a quiet cycle
+  # that had simply found nothing.
+  declined=0
+  for result in "$TMP_ROOT/serialized-a" "$TMP_ROOT/serialized-b"; do
+    grep -q 'status: busy' "$result" || continue
+    declined=$((declined + 1))
+    [ "$("$ADAPTER" classify "$result")" = busy ] \
+      || fail "a collector that stood down was not classified as busy"
+    "$ADAPTER" silent "$result" || fail "standing down would wake firstmate"
+    "$ADAPTER" terminal "$result" \
+      && fail "standing down retired the captain's inbound channel"
+  done
+  [ "$declined" = 1 ] || fail "no collector stood down; polling was not serialized"
+  pass "a second collector stands down instead of collecting the same message twice"
+}
+
+test_a_crashed_collector_does_not_wedge_the_bridge() {
+  local home poller
+  home=$(make_home crashed)
+  reset_sent
+  set_failures 0
+  set_updates '[]'
+
+  # Hold the poll lock, then die the way a crash does: killed outright, so no
+  # cleanup of any kind runs and the lock is left behind. A collector that
+  # could not tell an abandoned lock from a live one would stop collecting the
+  # captain's messages entirely - a silent outage strictly worse than the
+  # duplicate the lock was added to prevent. `env` is backgrounded directly so
+  # the signal reaches the collector itself rather than a wrapper shell.
+  env FM_HOME="$home" FM_TELEGRAM_API_BASE="$API_BASE" \
+    TELEGRAM_BOT_TOKEN="$TOKEN" TELEGRAM_ALLOWED_CHAT_ID=555 \
+    FM_TELEGRAM_POLL_TIMEOUT=5 FM_TELEGRAM_POLL_MAX_CYCLES=5 \
+    "$ADAPTER" poll >/dev/null 2>&1 &
+  poller=$!
+  sleep 1
+  kill -9 "$poller" 2>/dev/null || true
+  wait "$poller" 2>/dev/null || true
+
+  set_updates "$(message_json 140 555 'after the crash')"
+  run_poll "$home" 555 >/dev/null 2>&1
+  [ "$(note_count "$home")" = 1 ] \
+    || fail "the bridge stayed wedged behind a crashed collector's lock"
+  note_body "$home" | grep -qx 'after the crash' \
+    || fail "the message collected after the crash is not the one that was sent"
+  pass "a crashed collector's lock is reclaimed rather than wedging the bridge"
+}
+
+test_a_message_body_keeps_its_trailing_blank_lines() {
+  local home body f
+  home=$(make_home trailing)
+  reset_sent
+  set_failures 0
+  # Trailing blank lines are message CONTENT, and the captain writes them: a
+  # note that ends mid-thought reads as a different message from one that ends
+  # on a deliberate pause. Built with ANSI-C quoting rather than a command
+  # substitution, which would strip them from the fixture itself.
+  body=$'first line\n\nlast line\n\n\n'
+  set_updates "$(message_json 130 555 "$body")"
+  run_poll "$home" 555 >/dev/null 2>&1
+
+  f=$(find "$home/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | head -n1)
+  [ -n "$f" ] || fail "a message ending in blank lines never became a note"
+  sed -n '/^--$/,$p' "$f" | tail -n +2 > "$TMP_ROOT/trailing-body"
+  printf '%s' "$body" | cmp -s - "$TMP_ROOT/trailing-body" \
+    || fail "the note body is not the message byte for byte"
+  pass "a message body keeps its trailing blank lines all the way into the note"
+}
+
 test_a_message_waiting_while_nothing_polls_is_collected() {
   local home
   home=$(make_home retained)
@@ -610,6 +705,9 @@ test_offset_advances_only_after_the_note_is_written
 test_restart_after_a_written_note_does_not_duplicate_it
 test_restart_before_a_written_note_still_collects_it
 test_an_unwritable_note_is_never_acknowledged
+test_concurrent_collectors_never_queue_a_message_twice
+test_a_crashed_collector_does_not_wedge_the_bridge
+test_a_message_body_keeps_its_trailing_blank_lines
 test_a_message_waiting_while_nothing_polls_is_collected
 test_a_transient_outage_is_absorbed
 test_a_sustained_outage_ends_the_cycle_without_retiring_it

--- a/tests/fm-telegram.test.sh
+++ b/tests/fm-telegram.test.sh
@@ -125,6 +125,23 @@ class H(BaseHTTPRequestHandler):
             return
         n = int(self.headers.get("Content-Length", 0))
         raw = self.rfile.read(n).decode()
+        if method == "setMessageReaction":
+            with LOCK:
+                rfail = load("reactfail.json", {"n": 0})
+                if rfail["n"] > 0:
+                    rfail["n"] -= 1
+                    save("reactfail.json", rfail)
+                    failing = True
+                else:
+                    failing = False
+                if not failing:
+                    reacted = load("reacted.json", [])
+                    reacted.append(json.loads(raw))
+                    save("reacted.json", reacted)
+            if failing:
+                return self._reply({"ok": False, "error_code": 400,
+                                    "description": "REACTION_INVALID"}, 400)
+            return self._reply({"ok": True, "result": True})
         if method != "sendMessage":
             return self._reply({"ok": False, "description": "no such method"}, 404)
         with LOCK:
@@ -164,10 +181,19 @@ API_BASE="http://127.0.0.1:$(cat "$API_ROOT/port")"
 
 set_updates() { printf '%s\n' "$1" > "$API_ROOT/updates.json"; }
 set_failures() { printf '{"n":%s}\n' "$1" > "$API_ROOT/fail.json"; }
-reset_sent() { rm -f "$API_ROOT/sent.json"; }
+reset_sent() { rm -f "$API_ROOT/sent.json" "$API_ROOT/reacted.json" "$API_ROOT/reactfail.json"; }
 sent_count() {
   [ -f "$API_ROOT/sent.json" ] || { printf '0\n'; return 0; }
   jq 'length' < "$API_ROOT/sent.json"
+}
+set_reaction_failures() { printf '{"n":%s}\n' "$1" > "$API_ROOT/reactfail.json"; }
+reacted_count() {
+  [ -f "$API_ROOT/reacted.json" ] || { printf '0\n'; return 0; }
+  jq 'length' < "$API_ROOT/reacted.json"
+}
+reacted_field() {  # <jq-path>
+  [ -f "$API_ROOT/reacted.json" ] || return 1
+  jq -r ".[0].$1" < "$API_ROOT/reacted.json"
 }
 note_count() {  # <home>
   find "$1/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' '
@@ -208,9 +234,14 @@ run_send() {  # <home> <allowed-chat> <args...>
     "$SEND" "$@"
 }
 
+# The message_id is deliberately NOT the update_id: they are different
+# identifiers in the API, and a reaction sent against the wrong one would still
+# look correct if the fixture let them share a value.
 message_json() {  # <update-id> <chat-id> <text>
   jq -nc --argjson u "$1" --argjson c "$2" --arg t "$3" \
-    '[{update_id: $u, message: {chat: {id: $c}, from: {id: 77}, text: $t}}]'
+    '[{update_id: $u,
+       message: {message_id: ($u + 1000), chat: {id: $c},
+                 from: {id: 77}, text: $t}}]'
 }
 
 # --- cases ------------------------------------------------------------------
@@ -230,12 +261,52 @@ test_allowed_message_becomes_a_note() {
     || fail "the note does not record Telegram as its source"
   grep -q 'check: captain inbox note' "$home/state/.wake-queue" \
     || fail "the note did not wake firstmate"
-  # The collector sends nothing of its own. An automatic receipt reached the
-  # captain before firstmate had even read the message, so it was removed:
-  # firstmate's own reply is the confirmation.
+  # Receipt is a reaction ON the captain's message, never another message in
+  # the chat: the text ack it replaced reached him before firstmate had even
+  # read the message, and he had to read it as a separate line.
   [ "$(sent_count)" = 0 ] \
     || fail "the collector sent $(sent_count) unprompted message(s) back to the captain"
-  pass "an allowed message becomes a durable captain note with no bot chatter"
+  [ "$(reacted_count)" = 1 ] \
+    || fail "the accepted note was not confirmed with a reaction"
+  [ "$(reacted_field 'message_id')" = 1010 ] \
+    || fail "the reaction targeted $(reacted_field 'message_id'), not the message it confirms"
+  [ "$(reacted_field 'chat_id')" = 555 ] \
+    || fail "the reaction went to the wrong chat"
+  [ "$(reacted_field 'reaction[0].emoji')" = "👍" ] \
+    || fail "the reaction is not the expected emoji"
+  [ "$(reacted_field 'reaction[0].type')" = emoji ] \
+    || fail "the reaction was not sent as an emoji reaction"
+  pass "an allowed message is confirmed by a reaction, not another message"
+}
+
+test_a_failed_reaction_never_costs_the_note() {
+  local home
+  home=$(make_home reactfail)
+  reset_sent
+  set_failures 0
+  # Every reaction attempt is refused, the way Telegram refuses an emoji it
+  # does not accept or a message too old to react to.
+  set_reaction_failures 99
+  set_updates "$(message_json 44 555 'confirm nothing, keep everything')"
+  run_poll "$home" 555 >"$TMP_ROOT/reactfail-out" 2>&1
+
+  [ "$(note_count "$home")" = 1 ] \
+    || fail "a refused reaction cost the note it was only meant to confirm"
+  note_body "$home" | grep -qx 'confirm nothing, keep everything' \
+    || fail "the note body did not survive the failed reaction"
+  [ "$(reacted_count)" = 0 ] || fail "the stand-in API recorded a refused reaction"
+  grep -q '^  status: idle' "$TMP_ROOT/reactfail-out" \
+    || fail "a refused reaction was reported as a collection failure: $(cat "$TMP_ROOT/reactfail-out")"
+  grep -q '^  notes: 1' "$TMP_ROOT/reactfail-out" \
+    || fail "the collector did not report the note it queued"
+
+  # And the message stays confirmed to Telegram, so it is not sent again.
+  set_reaction_failures 0
+  set_updates '[]'
+  run_poll "$home" 555 >/dev/null 2>&1
+  [ "$(note_count "$home")" = 1 ] \
+    || fail "the message was collected twice after its reaction failed"
+  pass "a reaction the API refuses never costs the note or replays the message"
 }
 
 test_message_body_is_stored_verbatim() {
@@ -707,6 +778,7 @@ test_note_metadata_options_are_validated() {
 }
 
 test_allowed_message_becomes_a_note
+test_a_failed_reaction_never_costs_the_note
 test_message_body_is_stored_verbatim
 test_unallowlisted_chat_is_silently_dropped
 test_unconfigured_allowlist_reports_the_id_only


### PR DESCRIPTION
## Intent

Implement the captain-approved Telegram bridge spec for firstmate (data/specs/telegram-bridge-spec.md):
1. Inbound: long-poll Telegram's getUpdates, registered against the existing generic long-poll runner bin/fm-procevent.sh (no new supervision, no setWebhook). A message from the allowlisted chat id becomes a durable note via bin/fm-inbox.sh note, body passed on stdin, never interpolated into a shell command. Acknowledge Telegram's offset only after the note is durably written (verified by an actual restart).
2. Chat-id allowlist is a hard requirement: a message from any chat id other than the configured one produces no note, no wake, and no reply - silently dropped.
3. Outbound: a small script that POSTs Telegram's sendMessage with the bot token and chat id, for firstmate-initiated escalations/confirmations only (blockers, work ready for review, failures) - not a periodic digest, not silent for everything.
4. Acknowledgement of an accepted inbound message: originally a short text reply; the captain later found that automatic text ack ("Noted - firstmate will pick this up.") to be unwanted redundant chatter sent before firstmate even saw the message, since firstmate's own real reply already follows via the ordinary note flow. Per captain instruction, the auto-ack text send was removed entirely, and replaced with a best-effort emoji reaction (Telegram setMessageReaction Bot API) on the specific inbound message once it is successfully queued as a note - captures message.message_id from getUpdates, adds a helper in fm-telegram-lib.sh for setMessageReaction, and never blocks note-queuing on the reaction call succeeding.
5. Telegram cannot answer decisions or authorize anything: an inbound message authenticates a chat id, not a person. It becomes an ordinary captain note like any other, never routed through the decision-resolution path.
6. Credentials: bot token and bot name come from this repo's own gitignored .env (TELEGRAM_BOT_TOKEN, TELEGRAM_BOT_NAME) - never hardcoded, never logged, never echoed in status lines or terminal output.
7. Chat-id bootstrapping gap: on first run with no TELEGRAM_ALLOWED_CHAT_ID configured, the bridge reports (via a status line only, not acting on it) the chat id of the first sender it sees, so firstmate can relay it to the captain to confirm and lock into .env. Never auto-allowlist the first sender. Document the manual step (message the bot once, then set TELEGRAM_ALLOWED_CHAT_ID in .env).
8. Whole feature must be inert with no token configured.
9. Serialize polling so direct poll invocations cannot race the registered collector and enqueue one update multiple times (Greptile review finding, already fixed).
10. The decode/inbox stdin path must not silently strip trailing newline content from Telegram note bodies (Greptile review finding, already fixed) - shell metacharacters, quotes, newlines, and unicode in a message body land verbatim, uninterpreted.
This repo's own shared tracked material (bin/, config/, docs/) - follow firstmate-coding-guidelines: one sentence per line in prose, shellcheck-clean scripts, colocated tests, one-owner rule for contracts, trigger hygiene for any new skill/doc section, no agent co-author on commits.
Full acceptance criteria in spec section 5 (A1-A9); report against each one in the PR description.

## What Changed

- Add `bin/fm-procevent-telegram.sh`, a Telegram adapter registered against the existing generic long-poll runner (`fm-procevent.sh`): it long-polls `getUpdates`, turns messages from the allowlisted `TELEGRAM_ALLOWED_CHAT_ID` into durable notes via `fm-inbox.sh note` (body piped on stdin, never shell-interpolated), advances Telegram's offset only after the note is durably written (with a claim file to resolve ambiguity across a crash/restart), serializes polling under a home-scoped lock to prevent duplicate enqueues, and reports the first unconfigured sender's chat id via a status line only (never auto-allowlisting).
- Add `bin/fm-telegram-lib.sh` (credential loading/config from `.env`, shared `fm_telegram_api` request helper, and a `setMessageReaction` helper) and `bin/fm-env-lib.sh` (shared gitignored `.env` KEY=VALUE reader) used by the new scripts.
- Add `bin/fm-telegram.sh`, an outbound script that POSTs `sendMessage` for firstmate-initiated escalations/confirmations (not a digest).
- Replace the inbound auto-ack text reply with a best-effort `setMessageReaction` emoji reaction on the originating message once it is queued as a note, without blocking note-queuing on the reaction call.
- Extend `bin/fm-inbox.sh` with `--source` and `--meta` options on `note` so channel-of-origin metadata (e.g. `telegram_update_id`, `telegram_from`) can be recorded, and fix the stdin body read to preserve trailing newline content instead of stripping it via bare `$(cat)`.
- Add `tests/fm-telegram.test.sh` and update `tests/fm-gotmp.test.sh`, `bin/fm-test-run.sh`, `bin/fm-x-lib.sh`, and documentation (`docs/telegram-bridge.md`, `docs/configuration.md`, `docs/scripts.md`, `docs/documentation-audiences.json`, `AGENTS.md`, `README.md`, `.agents/skills/process-event-sources/SKILL.md`) for the new bridge.

## Risk Assessment

✅ Low: Both previously-flagged correctness issues (note-header collision, queue_note write/wake ambiguity) are fixed correctly and covered by explicit regression tests; all numbered intent requirements (allowlist, no-webhook, verbatim body, best-effort reaction, credential handling, first-run discovery, inertness, poll serialization, trailing-newline preservation) are implemented and exercised by a thorough 24-test suite exercising real behavior through a fake API stand-in rather than source-text assertions.

## Testing

Targeted test run (`bin/fm-test-run.sh tests/fm-telegram.test.sh tests/fm-gotmp.test.sh`) passed 27/27 cases, exercising the Telegram bridge end-to-end against a real local mock Bot API server with genuine filesystem/state assertions (notes, wake-queue, offset/claim files, reaction calls); both previously-flagged review findings (claim-recovery header scoping, queue-note-failure claim handling) were verified fixed in code and are covered by passing dedicated tests. No findings; working tree left clean.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4b17ed2d18aaa3a29672a5faeed58db23affba89","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./bin/fm-test-run.sh tests/fm-telegram.test.sh tests/fm-gotmp.test.sh (27 cases, exit=0)`
- `Manual code read of bin/fm-procevent-telegram.sh:147-162 (note_exists_for_update header-only scan) confirming the claim-recovery-body-collision fix`
- `Manual code read of bin/fm-procevent-telegram.sh:284-320 (queue_note failure path leaves CLAIM_FILE intact) confirming the queue-note-failure-conflates-write-and-wake-failure fix`
- `Read of tests/fm-telegram.test.sh mock API harness (tests/fm-telegram.test.sh:1-100) confirming tests hit a real local HTTP stand-in server rather than string-matching source`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
