### PR TITLE
fix: add Red Zone fence to generated briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -214,7 +214,7 @@ IFS= read -r -d '' REDZONE_SECTION <<'EOF' || true
 - `docs/adr/0044-unify-suite-redzone-action-architecture.md`
 3. The check that actually works. Ask whether Red Zone RENDERS this file, not whether the path contains `redzone`.
 Red Zone renders shared components that live outside its own directory, so every "is this under redzone/" test passed while four changes altered what Red Zone displayed.
-4. The escape. If a task appears to REQUIRE a Red Zone change, that is NOT a green light - append `blocked: {why}` and return it to the captain.
+4. The escape. If a task appears to REQUIRE a Red Zone change, that is NOT a green light - append `blocked: {why}` and return it through firstmate to the captain.
 Never resolve it by editing, and never by inventing a fork on your own judgement.
 
 The Red Zone tab in the product UI is off limits to QA-style work.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -52,6 +52,9 @@
 # Every scaffold also carries the steering-inbox receive-and-ack section:
 # process state/<id>.inbox/*.msg in order and acknowledge each by moving it to
 # handled/ (record, doorbell, and ladder owned by bin/fm-task-inbox-lib.sh).
+# Every scaffold also carries the captain's standing Red Zone prohibition; the
+# generated section below owns its exact protected paths, render-based check,
+# blocked return and no-fork response, and product QA boundary.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -195,6 +195,31 @@ The move IS the acknowledgement: without it firstmate rings again and eventually
 EOF
 INBOX_SECTION=${INBOX_SECTION%$'\n'}
 
+# This fence is included in every scaffold kind because Red Zone safety survives
+# hand-offs only when it travels with the worker's instructions.
+IFS= read -r -d '' REDZONE_SECTION <<'EOF' || true
+# Red Zone prohibition - permanent safety boundary
+1. The rule. Never edit, and never make a read that leads to a write, anywhere in Red Zone. This is permanent until the captain personally lifts it.
+2. The named paths.
+- `app/(sales)/sales-hub/redzone/**`
+- `app/api/sales/redzone/**`
+- `app/api/redzone/**`
+- `app/api/cron/redzone-followups-sweep/**`
+- `components/sales-hub/redzone/**`
+- `lib/sales-hub/redzone/**`
+- `docs/sales-hub/redzone/**` including the n8n pipeline JSON
+- `docs/adr/0044-unify-suite-redzone-action-architecture.md`
+3. The check that actually works. Ask whether Red Zone RENDERS this file, not whether the path contains `redzone`.
+Red Zone renders shared components that live outside its own directory, so every "is this under redzone/" test passed while four changes altered what Red Zone displayed.
+4. The escape. If a task appears to REQUIRE a Red Zone change, that is NOT a green light - append `blocked: {why}` and return it to the captain.
+Never resolve it by editing, and never by inventing a fork on your own judgement.
+
+The Red Zone tab in the product UI is off limits to QA-style work.
+Do not exercise it, click through it, or file tickets against it.
+A journey that routes into it stops at the boundary and says so.
+EOF
+REDZONE_SECTION=${REDZONE_SECTION%$'\n'}
+
 if [ "$KIND" = secondmate ]; then
 SECONDMATE_PROJECTS=""
 idx=1
@@ -221,6 +246,8 @@ You are a persistent second mate managed by the main firstmate. Work on your own
 
 # Charter
 $SECONDMATE_CHARTER
+
+$REDZONE_SECTION
 
 # Routing scope
 $SECONDMATE_SCOPE
@@ -325,6 +352,8 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 # Task
 {TASK}
+
+$REDZONE_SECTION
 
 $HERDR_SECTION
 
@@ -438,6 +467,8 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 # Task
 {TASK}
+
+$REDZONE_SECTION
 
 $HERDR_SECTION
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -30,7 +30,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-captain-hold.sh`     | Hold tasks for the captain, record the captain's answers, gate investigation completion, and report record divergence between the status log and the backlog |
 | `fm-decision-hold.sh`    | One-release compatibility shim mapping the retired decision commands onto fm-captain-hold.sh |
-| `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
+| `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs with the standing Red Zone fence |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -733,7 +733,7 @@ assert_redzone_fence() {
     "$label brief missing the renders-this-file check"
   assert_grep 'Red Zone renders shared components that live outside its own directory' "$brief" \
     "$label brief missing the shared-component warning"
-  assert_grep "4. The escape. If a task appears to REQUIRE a Red Zone change, that is NOT a green light - append \`blocked: {why}\` and return it to the captain." "$brief" \
+  assert_grep "4. The escape. If a task appears to REQUIRE a Red Zone change, that is NOT a green light - append \`blocked: {why}\` and return it through firstmate to the captain." "$brief" \
     "$label brief missing the blocked escape"
   assert_grep 'Never resolve it by editing, and never by inventing a fork on your own judgement.' "$brief" \
     "$label brief missing the no-fork escape"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -710,6 +710,64 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
   pass "fm-brief.sh: custom pause verb renders in every scaffold"
 }
 
+assert_redzone_fence() {
+  local brief=$1 label=$2 path
+  assert_grep "# Red Zone prohibition - permanent safety boundary" "$brief" \
+    "$label brief missing the Red Zone fence heading"
+  assert_grep "1. The rule. Never edit, and never make a read that leads to a write, anywhere in Red Zone. This is permanent until the captain personally lifts it." "$brief" \
+    "$label brief missing the permanent Red Zone rule"
+  for path in \
+    'app/(sales)/sales-hub/redzone/**' \
+    'app/api/sales/redzone/**' \
+    'app/api/redzone/**' \
+    'app/api/cron/redzone-followups-sweep/**' \
+    'components/sales-hub/redzone/**' \
+    'lib/sales-hub/redzone/**' \
+    'docs/sales-hub/redzone/**' \
+    'docs/adr/0044-unify-suite-redzone-action-architecture.md'; do
+    assert_grep "$path" "$brief" "$label brief missing named Red Zone path: $path"
+  done
+  assert_grep 'docs/sales-hub/redzone/**` including the n8n pipeline JSON' "$brief" \
+    "$label brief missing the n8n pipeline JSON note"
+  assert_grep "3. The check that actually works. Ask whether Red Zone RENDERS this file, not whether the path contains \`redzone\`." "$brief" \
+    "$label brief missing the renders-this-file check"
+  assert_grep 'Red Zone renders shared components that live outside its own directory' "$brief" \
+    "$label brief missing the shared-component warning"
+  assert_grep "4. The escape. If a task appears to REQUIRE a Red Zone change, that is NOT a green light - append \`blocked: {why}\` and return it to the captain." "$brief" \
+    "$label brief missing the blocked escape"
+  assert_grep 'Never resolve it by editing, and never by inventing a fork on your own judgement.' "$brief" \
+    "$label brief missing the no-fork escape"
+  assert_grep 'The Red Zone tab in the product UI is off limits to QA-style work.' "$brief" \
+    "$label brief missing the QA boundary"
+  assert_grep 'Do not exercise it, click through it, or file tickets against it.' "$brief" \
+    "$label brief missing the QA prohibitions"
+  assert_grep 'A journey that routes into it stops at the boundary and says so.' "$brief" \
+    "$label brief missing the journey boundary"
+}
+
+test_redzone_fence_is_in_every_scaffold() {
+  local home brief
+  home="$TMP_ROOT/redzone-fence-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" redzone-fence-ship firstmate --mode no-mistakes >/dev/null 2>&1 \
+    || fail "ship brief with Red Zone fence exited non-zero"
+  brief="$home/data/redzone-fence-ship/brief.md"
+  assert_redzone_fence "$brief" ship
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" redzone-fence-scout firstmate --scout >/dev/null 2>&1 \
+    || fail "scout brief with Red Zone fence exited non-zero"
+  brief="$home/data/redzone-fence-scout/brief.md"
+  assert_redzone_fence "$brief" scout
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" redzone-fence-charter --secondmate --no-projects >/dev/null 2>&1 \
+    || fail "secondmate charter with Red Zone fence exited non-zero"
+  brief="$home/data/redzone-fence-charter/brief.md"
+  assert_redzone_fence "$brief" secondmate
+
+  pass "fm-brief.sh: Red Zone fence renders in ship, scout, and secondmate scaffolds"
+}
+
 test_scout_and_secondmate_load_decision_hold_policy() {
   local home scout charter
   home="$TMP_ROOT/decision-policy-home"
@@ -770,5 +828,6 @@ test_secondmate_no_projects_charter
 test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
+test_redzone_fence_is_in_every_scaffold
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold


### PR DESCRIPTION
## Intent

Put captain's standing Red Zone prohibition into `bin/fm-brief.sh` so every freshly generated ship brief, scout brief, and secondmate charter carries an unmissable fence.

Preserve all four required parts: never edit or make a read that leads to a write anywhere in Red Zone until captain personally lifts the prohibition; include the exact named paths `app/(sales)/sales-hub/redzone/**`, `app/api/sales/redzone/**`, `app/api/redzone/**`, `app/api/cron/redzone-followups-sweep/**`, `components/sales-hub/redzone/**`, `lib/sales-hub/redzone/**`, `docs/sales-hub/redzone/**` including the n8n pipeline JSON, and `docs/adr/0044-unify-suite-redzone-action-architecture.md`; ask whether Red Zone RENDERS this file rather than checking whether the path contains `redzone` because shared components outside the directory are rendered; and append `blocked:` and return to captain when a task appears to require a Red Zone change, never editing or inventing a worker fork.

Keep the Red Zone product tab off limits to QA-style work: do not exercise it, click through it, file tickets against it, or continue a journey that routes into it past the boundary.

Do not rewrite existing generated briefs.

## What changed

- Added one permanent Red Zone fence to generated ship, scout, and secondmate charter briefs.
- Added executable coverage verifying the complete fence appears in all three scaffold types.
- Added the fence's authoritative script-template documentation without changing unrelated scaffold sections.

## Verification

- TypeScript: not applicable. `tsc` 5.9.3 is installed, but this repository has no TypeScript target or `tsconfig` file, so 0 TypeScript targets were checked.
- Tests: `bash tests/fm-brief.test.sh` passed all 22 checks.
- Local lint: `bin/fm-lint.sh` passed ShellCheck 0.11.0 across the changed shell targets, and actionlint 1.7.12 validated all 3 workflow files.
- Pipeline lint limitation: ShellCheck ran, but actionlint did not run because the pipeline environment lacked the pinned actionlint binary.
- CI: GitHub Actions did not run because repository billing is blocked and its jobs never start.
- Existing generated briefs were not rewritten.

## Deletion guard

Command:

```sh
git diff --name-status origin/main..HEAD | grep '^D'
```

Output: empty.
