### PR TITLE
fix(bearings): make Captain’s Call items actionable

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -141,12 +141,26 @@ Rules that keep the contract unambiguous:
 - Do not suppress separately projected decisions, landed records, or gates from a `partial-structured` home merely because that secondmate's own row is `unknown` or its `invalidity` reports an inventory mismatch.
 - Include the required direct address to the captain inside one item or empty-state sentence.
 - Every PR appears as the full `https://...` URL; a shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same digest.
-- The chat follows `AGENTS.md` section 9 and carries one scannable line per item.
+- The chat follows `AGENTS.md` section 9 in every section.
+- Recently Landed, Underway, and Charted Next carry one scannable line per item.
+- Captain's Call items get room to be answerable without a follow-up question: up to two or three short sentences that name what the item is in plain words, give one clause of why it exists, and state the exact ask: the word to say, the click to make, or the thing to paste.
+- Use that room only when an item genuinely needs the context; a self-evident Captain's Call item stays one line, no item runs past three sentences, and the room is for the ask and its provenance, never the full decision record or options list.
+- Example of the shape: "The refund fix is ready and waiting on your merge word, captain. It came out of the double-charge bug you flagged Tuesday, and checks are green. Say 'merge it', or open https://github.com/acme/pay/pull/482 to look first."
 - Detailed decisions, plans, full gate reasons, and evidence stay out of chat; file mode puts them in the report, while lavish mode puts only its payload-backed interactive detail on the board.
 - In file mode, include the report path or link inside the four-section digest without adding another heading.
 - In lavish mode, include the board URL inside the four-section digest the same way.
 
 ## Tone and content rules
+
+Write every digest, in all three modes, in plain, direct prose.
+These practices apply to the Captain's Call sentences, the one-line items in the other three sections, the file-mode report, and the board copy alike; the `/unslop` skill holds the fuller catalog if you want it.
+
+- Cut puffery, hedging, and filler such as "it is important to note", "in order to", "could potentially", and generic wrap-up lines; state what happened and what to do instead.
+- Drop chatbot and sycophancy phrases such as "I hope this helps", "great question", "of course", and "let me know if".
+- Keep sentences short with one idea each, and name concrete nouns and the actor rather than a feeling, so "the staging login expired" beats "there may be an authentication concern".
+- Skip AI-vocabulary filler such as "additionally", "crucial", "delve", "leverage", and "utilize", and skip the forced rule of three; use the natural number of items and the plain word.
+- Use plain dashes, never em dashes, and a colon only before a list or example.
+- Keep the required direct address to the captain, but do not pad prose to reach it.
 
 - The optional file-mode report is a private, captain-facing internal artifact that lives in gitignored `data/`, so unlike normal captain chat it MAY reference task ids, PR URLs, and repo names.
 - The captain works with those directly and needs them to resume; keep the report organized and scannable, not a raw dump.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -143,7 +143,7 @@ Rules that keep the contract unambiguous:
 - Every PR appears as the full `https://...` URL; a shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same digest.
 - The chat follows `AGENTS.md` section 9 in every section.
 - Recently Landed, Underway, and Charted Next carry one scannable line per item.
-- When context is needed, a Captain's Call item gets two or three short sentences so it is answerable without a follow-up question.
+- When context is needed, a Captain's Call item may use two or three short sentences so it is answerable without a follow-up question.
 - Those sentences name the item in plain words, give one clause of provenance, and state the exact ask: the word to say, the click to make, or the thing to paste.
 - Use that room only when an item genuinely needs the context; a self-evident Captain's Call item stays one line, no item runs past three sentences, and the room is for the ask and its provenance, never the full decision record or options list.
 - Here is the shape.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -145,10 +145,10 @@ Rules that keep the contract unambiguous:
 - Recently Landed, Underway, and Charted Next carry one scannable line per item.
 - Captain's Call items get room to be answerable without a follow-up question: up to two or three short sentences that name what the item is in plain words, give one clause of why it exists, and state the exact ask: the word to say, the click to make, or the thing to paste.
 - Use that room only when an item genuinely needs the context; a self-evident Captain's Call item stays one line, no item runs past three sentences, and the room is for the ask and its provenance, never the full decision record or options list.
-- Here is the shape.  
-  "The refund fix is ready and waiting on your merge word, captain.  
-  It came out of the double-charge bug you flagged Tuesday, and checks are green.  
-  Say 'merge it', or open https://github.com/acme/pay/pull/482 to look first."
+- Here is the shape.
+  > The refund fix is ready and waiting on your merge word, captain.
+  > It came out of the double-charge bug you flagged Tuesday, and checks are green.
+  > Say 'merge it', or open https://github.com/acme/pay/pull/482 to look first.
 - Detailed decisions, plans, full gate reasons, and evidence stay out of chat; file mode puts them in the report, while lavish mode puts only its payload-backed interactive detail on the board.
 - In file mode, include the report path or link inside the four-section digest without adding another heading.
 - In lavish mode, include the board URL inside the four-section digest the same way.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -143,9 +143,11 @@ Rules that keep the contract unambiguous:
 - Every PR appears as the full `https://...` URL; a shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same digest.
 - The chat follows `AGENTS.md` section 9 in every section.
 - Recently Landed, Underway, and Charted Next carry one scannable line per item.
-- Captain's Call items get room to be answerable without a follow-up question: up to two or three short sentences that name what the item is in plain words, give one clause of why it exists, and state the exact ask: the word to say, the click to make, or the thing to paste.
+- When context is needed, a Captain's Call item gets two or three short sentences so it is answerable without a follow-up question.
+- Those sentences name the item in plain words, give one clause of provenance, and state the exact ask: the word to say, the click to make, or the thing to paste.
 - Use that room only when an item genuinely needs the context; a self-evident Captain's Call item stays one line, no item runs past three sentences, and the room is for the ask and its provenance, never the full decision record or options list.
 - Here is the shape.
+
   > The refund fix is ready and waiting on your merge word, captain.
   > It came out of the double-charge bug you flagged Tuesday, and checks are green.
   > Say 'merge it', or open https://github.com/acme/pay/pull/482 to look first.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -145,7 +145,10 @@ Rules that keep the contract unambiguous:
 - Recently Landed, Underway, and Charted Next carry one scannable line per item.
 - Captain's Call items get room to be answerable without a follow-up question: up to two or three short sentences that name what the item is in plain words, give one clause of why it exists, and state the exact ask: the word to say, the click to make, or the thing to paste.
 - Use that room only when an item genuinely needs the context; a self-evident Captain's Call item stays one line, no item runs past three sentences, and the room is for the ask and its provenance, never the full decision record or options list.
-- Example of the shape: "The refund fix is ready and waiting on your merge word, captain. It came out of the double-charge bug you flagged Tuesday, and checks are green. Say 'merge it', or open https://github.com/acme/pay/pull/482 to look first."
+- Here is the shape.  
+  "The refund fix is ready and waiting on your merge word, captain.  
+  It came out of the double-charge bug you flagged Tuesday, and checks are green.  
+  Say 'merge it', or open https://github.com/acme/pay/pull/482 to look first."
 - Detailed decisions, plans, full gate reasons, and evidence stay out of chat; file mode puts them in the report, while lavish mode puts only its payload-backed interactive detail on the board.
 - In file mode, include the report path or link inside the four-section digest without adding another heading.
 - In lavish mode, include the board URL inside the four-section digest the same way.
@@ -159,7 +162,7 @@ These practices apply to the Captain's Call sentences, the one-line items in the
 - Drop chatbot and sycophancy phrases such as "I hope this helps", "great question", "of course", and "let me know if".
 - Keep sentences short with one idea each, and name concrete nouns and the actor rather than a feeling, so "the staging login expired" beats "there may be an authentication concern".
 - Skip AI-vocabulary filler such as "additionally", "crucial", "delve", "leverage", and "utilize", and skip the forced rule of three; use the natural number of items and the plain word.
-- Use plain dashes, never em dashes, and a colon only before a list or example.
+- Use plain dashes, never em dashes, and a colon only before a list.
 - Keep the required direct address to the captain, but do not pad prose to reach it.
 
 - The optional file-mode report is a private, captain-facing internal artifact that lives in gitignored `data/`, so unlike normal captain chat it MAY reference task ids, PR URLs, and repo names.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -163,6 +163,7 @@ These practices apply to the Captain's Call sentences, the one-line items in the
 - Keep sentences short with one idea each, and name concrete nouns and the actor rather than a feeling, so "the staging login expired" beats "there may be an authentication concern".
 - Skip AI-vocabulary filler such as "additionally", "crucial", "delve", "leverage", and "utilize", and skip the forced rule of three; use the natural number of items and the plain word.
 - Use plain dashes, never em dashes, and a colon only before a list.
+- A link or explanation is not a list, so do not introduce one with a colon.
 - Keep the required direct address to the captain, but do not pad prose to reach it.
 
 - The optional file-mode report is a private, captain-facing internal artifact that lives in gitignored `data/`, so unlike normal captain chat it MAY reference task ids, PR URLs, and repo names.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -165,7 +165,7 @@ These practices apply to the Captain's Call sentences, the one-line items in the
 - Keep sentences short with one idea each, and name concrete nouns and the actor rather than a feeling, so "the staging login expired" beats "there may be an authentication concern".
 - Skip AI-vocabulary filler such as "additionally", "crucial", "delve", "leverage", and "utilize", and skip the forced rule of three; use the natural number of items and the plain word.
 - Use plain dashes, never em dashes, and a colon only before a list.
-- A link or explanation is not a list, so do not introduce one with a colon.
+- A link or explanation is not a list; write `The invoice fix landed at https://...` and `The receipt export is waiting on checkout retries` instead of attaching either after a colon.
 - Keep the required direct address to the captain, but do not pad prose to reach it.
 
 - The optional file-mode report is a private, captain-facing internal artifact that lives in gitignored `data/`, so unlike normal captain chat it MAY reference task ids, PR URLs, and repo names.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -143,7 +143,7 @@ Rules that keep the contract unambiguous:
 - Every PR appears as the full `https://...` URL; a shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same digest.
 - The chat follows `AGENTS.md` section 9 in every section.
 - Recently Landed, Underway, and Charted Next carry one scannable line per item.
-- When context is needed, a Captain's Call item may use two or three short sentences so it is answerable without a follow-up question.
+- When context is needed, a Captain's Call item may use up to three short sentences so it is answerable without a follow-up question.
 - Those sentences name the item in plain words, give one clause of provenance, and state the exact ask: the word to say, the click to make, or the thing to paste.
 - Use that room only when an item genuinely needs the context; a self-evident Captain's Call item stays one line, no item runs past three sentences, and the room is for the ask and its provenance, never the full decision record or options list.
 - Here is the shape.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -149,7 +149,7 @@ Rules that keep the contract unambiguous:
 - Here is the shape.
 
   > The refund fix is ready and waiting on your merge word, captain.
-  > It came out of the double-charge bug you flagged Tuesday, and checks are green.
+  > You reported the double-charge bug Tuesday, and checks are green.
   > Say 'merge it', or open https://github.com/acme/pay/pull/482 to look first.
 - Detailed decisions, plans, full gate reasons, and evidence stay out of chat; file mode puts them in the report, while lavish mode puts only its payload-backed interactive detail on the board.
 - In file mode, include the report path or link inside the four-section digest without adding another heading.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -156,7 +156,7 @@ Rules that keep the contract unambiguous:
 ## Tone and content rules
 
 Write every digest, in all three modes, in plain, direct prose.
-These practices apply to the Captain's Call sentences, the one-line items in the other three sections, the file-mode report, and the board copy alike; the `/unslop` skill holds the fuller catalog if you want it.
+These practices apply to the Captain's Call sentences, the one-line items in the other three sections, the file-mode report, and the board copy alike; the `/unslop` skill holds the fuller catalog.
 
 - Cut puffery, hedging, and filler such as "it is important to note", "in order to", "could potentially", and generic wrap-up lines; state what happened and what to do instead.
 - Drop chatbot and sycophancy phrases such as "I hope this helps", "great question", "of course", and "let me know if".


### PR DESCRIPTION
## Intent

Improve firstmate's bearings skill (.agents/skills/bearings/SKILL.md) per the captain's 2026-08-29 feedback. Two changes to the per-item PROSE inside the chat digest, deliberately scoped as a tightening, not an expansion.

1. Captain's Call actionability. The digest's one-line Captain's Call items left the captain unable to act without asking about each one; a full walkthrough was too long. Target the middle: each Captain's Call chat item may use up to two or three short sentences that name what it is in plain words, give one clause of why it exists (provenance), and state the exact ask (the word to say, the click to make, or the thing to paste). Use that room only when an item genuinely needs the context; self-evident items stay one line, nothing runs past three sentences, and the room is for the ask and its provenance, not the full decision record or options list. The other three sections (Recently Landed, Underway, Charted Next) deliberately keep one scannable line per item. Added one worked example that respects AGENTS.md section 9 vocabulary translation.

2. Fold unslop writing practices into the Tone and content rules as composition rules for all digest prose (chat, file report, board copy): cut puffery, hedging, filler, chatbot/sycophancy phrases, AI-vocabulary filler, and forced rule of three; short concrete sentences naming the actor; no em dashes; colon only before a list. Reference the /unslop skill for the fuller catalog rather than duplicating it, since no repo-local unslop skill exists.

Constraints honored deliberately: the four-section chat contract (sections, order, empty states, mutual exclusivity) is unchanged; only per-item prose changed. Scripts (fm-bearings-snapshot.sh, board mechanics) and the one-owner rules are untouched. Growth is modest (+21/-1). Repo style followed: one sentence per line, plain dashes, no agent co-author. This is firstmate shared tracked material, edited per firstmate-coding-guidelines.

## What Changed

- Make Captain’s Call items actionable with up to three short sentences covering plain-language context, provenance, and the exact response needed, while keeping the other digest sections to one line per item.
- Apply direct, unslopped composition rules across chat digests, file reports, and board copy, including concrete actors, short sentences, plain dashes, and reduced filler, hedging, and chatbot phrasing.

## Risk Assessment

✅ Low: Captain, the change is a well-bounded documentation-only tightening that preserves the four-section contract and now satisfies the stated prose and repository-style constraints.

## Testing

Inspected the branch and targeted-test selection, ran a read-only live Codex consumer twice against the same controlled fleet snapshot, fixed the reproduced colon-before-link failure, and verified the passing reviewer-visible chat transcript. No screenshot was captured because the changed end-user surface is plain chat text, represented directly by the evidence transcript.

<details>
<summary>Evidence: Pre-fix bearings digest</summary>

Source: [Pre-fix bearings digest](https://github.com/alejandroariaszuluaga/firstmate/blob/d68e50f0b91538f26ecfb8d39c803b4945b57bd1/.no-mistakes/evidence/fm/fm-bearings-skill-tighten/bearings-chat-digest.txt)

`Initial live rendering reproduced a colon-before-link violation in Recently Landed.`

```text
## Captain’s Call

- The refund fix is ready and waiting on your merge word, captain. It addresses Tuesday’s double charges, and checks are green. Say “merge it,” or inspect https://github.com/acme/pay/pull/482 first.
- The staging login expired. Paste a replacement token into the existing secure credential prompt.

## Recently Landed

- The receipt wording fix merged: https://github.com/acme/pay/pull/479

## Underway

- A worker is validating the tax-rounding fix against production examples.

## Charted Next

- Mobile refund tests are queued until the refund fix merges.
```
</details>
<details>
<summary>Evidence: Passing bearings digest</summary>

Source: [Passing bearings digest](https://github.com/alejandroariaszuluaga/firstmate/blob/d68e50f0b91538f26ecfb8d39c803b4945b57bd1/.no-mistakes/evidence/fm/fm-bearings-skill-tighten/bearings-chat-digest-fixed.txt)

`The corrected live rendering has exactly four ordered sections, actionable Captain’s Call items, concise one-line items elsewhere, full PR URLs, and no forbidden colon or em dash.`

```text
## Captain's Call

- The refund fix is ready and waiting on your merge word, captain. It addresses the double charges you reported Tuesday, and checks are green. Say “merge it,” or inspect https://github.com/acme/pay/pull/482 first.
- The staging login expired. Paste a replacement token into the existing secure credential prompt.

## Recently Landed

- The receipt wording fix merged at https://github.com/acme/pay/pull/479.

## Underway

- A worker is validating the tax-rounding fix against production examples.

## Charted Next

- Mobile refund tests are queued until the refund fix merges.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2b29b9cb486bfe6dd9c04ce66293a9e8536c07c5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `.agents/skills/bearings/SKILL.md:162` - The required rule says “colon only before a list,” but the new hunk permits a colon “before a list or example.” Decide whether examples are intentionally exempt or remove the exemption and rephrase the example lead-in.
- 🚨 `.agents/skills/bearings/SKILL.md:148` - The intent says the repo’s “one sentence per line” rule was followed, but the new worked example places three complete sentences on one physical Markdown line. Split the quotation across one-sentence lines while preserving one rendered list item, or explicitly approve the exception.

🔧 Fix: Captain, align Bearings prose with style constraints
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --no-ext-diff --unified=25 f66be0f8f7f56f78d09458d909bdd555b9dbcf76..951f1ba5dcead647bba0347a3f40be1fe71bb0f5 -- .agents/skills/bearings/SKILL.md`
- <code>`bin/fm-test-run.sh --list --changed --base f66be0f8f7f56f78d09458d909bdd555b9dbcf76` (selection inspection only; the broad family included forbidden lint/static-analysis checks)</code>
- <code>Pre-fix `codex exec --ephemeral -s read-only` rendering with a controlled snapshot</code>
- <code>Post-fix `codex exec --ephemeral -s read-only` rendering with the identical controlled snapshot</code>
- `Output-contract check of heading order and forbidden colon/em-dash punctuation`
- `Manual comparison against the chat-response contract, tone rules, AGENTS.md section 9, repository Markdown style, and commit metadata`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
