### PR TITLE
fix(bin): keep fleet-sized JSON off jq's argv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,16 +377,16 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 16 ] || {
+            echo "::error::expected 16 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 42 ] || {
-            echo "::error::expected 42 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 43 ] || {
+            echo "::error::expected 43 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -69,6 +69,9 @@ FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
 # shellcheck source=bin/fm-timeout-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-jq-arg-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-jq-arg-lib.sh"  # fm_jq_inputs: fleet-sized JSON reaches jq on stdin, never argv
 
 # Bounds (overridable for tests / large fleets).
 FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
@@ -259,7 +262,8 @@ EOF
       cnt=$(printf '%s' "$repo_rows" | jq 'length')
       [ "$returned" -gt "$FM_BEARINGS_PR_LIMIT" ] && ncapped=$((ncapped + 1))
       npr=$((npr + cnt))
-      rows=$(jq -n --argjson a "$rows" --argjson b "$repo_rows" '$a + $b')
+      rows=$(fm_jq_inputs "$rows" "$repo_rows" \
+        | jq -n '(input) as $a | (input) as $b | $a + $b')
     done
     PR_REPOS_SHOWN=$nrepos
     PR_ROWS_CAPPED=$ncapped
@@ -283,7 +287,7 @@ case "$BEARINGS_TODAY" in
   [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) : ;;
   *) BEARINGS_TODAY=$(date -u +%Y-%m-%d) ;;
 esac
-MODEL=$(printf '%s' "$SNAP" | jq \
+MODEL=$(fm_jq_inputs "$SNAP" "$CANDIDATE_PRS" | jq \
   --arg home "$HOME_LABEL" \
   --arg now "$NOW" \
   --arg today "$BEARINGS_TODAY" \
@@ -311,7 +315,8 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson pr_repos_shown "$PR_REPOS_SHOWN" \
   --argjson pr_rows_capped "$PR_ROWS_CAPPED" \
   --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" \
-  --argjson candidate_prs "$CANDIDATE_PRS" '
+  '(input) as $candidate_prs
+  |
   def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
   def round_robin_landed($n):

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -157,6 +157,9 @@ validate_positive_bound FM_SNAPSHOT_REGISTRY_TIMEOUT "$FM_SNAPSHOT_REGISTRY_TIME
 # shellcheck source=bin/fm-ff-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-ff-lib.sh"  # validate_secondmate_home: shared seeded-home boundary checks
+# shellcheck source=bin/fm-jq-arg-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-jq-arg-lib.sh"  # fm_jq_inputs: fleet-sized JSON reaches jq on stdin, never argv
 # shellcheck source=bin/fm-timeout-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-timeout-lib.sh"  # fm_run_timed: the shared hard bound
@@ -559,7 +562,8 @@ task_json_lines() {
       home_json=$(jq -n '{path:null,present:false}')
     fi
 
-    jq -n \
+    fm_jq_inputs "$open_decisions_json" \
+      | jq -n \
       --arg id "$id" \
       --arg kind "$kind" \
       --arg harness "$harness" \
@@ -586,11 +590,12 @@ task_json_lines() {
       --argjson worktree_path "$worktree_json" \
       --argjson home_path "$home_json" \
       --argjson endpoint_exists "$endpoint_exists" \
-      --argjson open_decisions "$open_decisions_json" \
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
       --argjson report_present "$(bool_json "$report_present")" \
-      '{
+      '(input) as $open_decisions
+       |
+      {
         id:$id,
         kind:$kind,
         harness:($harness // ""),
@@ -641,9 +646,11 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
-  jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+  fm_jq_inputs "$1" "$2" \
+    | jq -n '
+    (input) as $backlog
+    | (input) as $tasks
+    |
     ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
@@ -669,16 +676,18 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
-  jq -n \
+  fm_jq_inputs "$1" "$2" \
+    | jq -n \
     --arg generated "$SNAPSHOT_NOW" \
     --argjson generated_epoch "$SNAPSHOT_EPOCH" \
     --arg home "$FM_HOME" \
     --argjson child_n "$FM_SNAPSHOT_SECONDMATE_CHILDREN" \
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
-    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '
+    (input) as $backlog
+    | (input) as $tasks
+    |
     def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
@@ -1094,7 +1103,11 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
+  fm_jq_inputs "$1" "$2" "$3" | jq -n '
+    (input) as $summary
+    | (input) as $activities
+    | (input) as $decisions
+    |
     def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
@@ -1159,7 +1172,10 @@ secondmate_current_json() {  # <parent-tasks-json>
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
+  union=$(fm_jq_inputs "$registry" "$tasks" | jq -n '
+    (input) as $registry
+    | (input) as $tasks
+    |
     ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
@@ -1303,13 +1319,19 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
-      record=$(jq -n \
+      record=$(fm_jq_inputs "$summary" "$activities" "$decisions" "$activity_scan" "$reconciliation" \
+        | jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
-        --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
+        --argjson registered "$registered" --argjson summary_valid "$summary_valid" \
+        --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
         --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
+        (input) as $summary
+        | (input) as $activities
+        | (input) as $decisions
+        | (input) as $activity_scan
+        | (input) as $reconciliation
+        |
         {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
@@ -1336,12 +1358,18 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
-      record=$(jq -n \
+      record=$(fm_jq_inputs "$summary" "$activities" "$decisions" "$activity_scan" \
+        | jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
         --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
-        --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" --argjson summary "$summary" --argjson summary_sampled "$summary_sampled" '
+        --argjson registered "$registered" --argjson event_age "$event_age" \
+        --argjson terminal "$terminal" --argjson summary_sampled "$summary_sampled" '
+        (input) as $summary
+        | (input) as $activities
+        | (input) as $decisions
+        | (input) as $activity_scan
+        |
         {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:"unknown",reason:$reason},invalidity:null,
@@ -1352,22 +1380,26 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    records=$(fm_jq_inputs "$records" "$record" \
+      | jq -n '(input) as $records | (input) as $record | $records + [$record]')
   done <<EOF
 $rows
 EOF
-  jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+  fm_jq_inputs "$(printf '%s' "$union" | jq '.registry')" "$records" \
+    | jq -n \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
     --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    '(input) as $registry
+     | (input) as $records
+     | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
+  fm_jq_inputs "$1" | jq -n '
+    (input) as $current
+    |
     {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
@@ -1416,7 +1448,9 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
-jq -n \
+fm_jq_inputs "$BACKLOG_JSON" "$TASKS_JSON" "$MAIN_INVENTORY_JSON" "$SCOUT_REPORTS_JSON" \
+  "$SECONDMATE_CURRENT_JSON" "$SECONDMATE_LANDED_JSON" \
+  | jq -n \
   --arg generated "$SNAPSHOT_NOW" \
   --arg fm_home "$FM_HOME" \
   --arg fm_root "$FM_ROOT" \
@@ -1424,13 +1458,14 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  '(input) as $backlog
+   | (input) as $tasks
+   | (input) as $main_inventory
+   | (input) as $scout_reports
+   | (input) as $secondmate_current
+   | (input) as $secondmate_landed
+   |
+   def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/bin/fm-jq-arg-lib.sh
+++ b/bin/fm-jq-arg-lib.sh
@@ -1,0 +1,50 @@
+# shellcheck shell=bash
+# fm-jq-arg-lib.sh - the single owner of handing large JSON payloads to jq.
+# Usage: . bin/fm-jq-arg-lib.sh; fm_jq_inputs "$a" "$b" | jq -n '(input) as $a | (input) as $b | ...'
+#
+# Sourced, never executed.
+#
+#   fm_jq_inputs <json> [<json>...]
+#       Writes each payload to stdout as one element of a JSON stream, in the
+#       order given, for a jq filter that binds them with `input`.
+#
+# WHY: a jq argument carrying a whole backlog, task inventory, home summary, or
+# fleet snapshot cannot ride on argv. The kernel caps a SINGLE argument at
+# MAX_ARG_STRLEN - 128 KiB on Linux, independent of the far larger ARG_MAX -
+# so `jq --argjson backlog "$BACKLOG_JSON"` makes execve reject the whole
+# command with "Argument list too long" once a home's backlog grows past that.
+# The failure is total rather than degraded: the snapshot exits non-zero and
+# every view built on it, bearings included, returns nothing. It also gets
+# worse the longer a fleet has been used, so it strikes the busiest homes.
+# A payload that grows with the fleet - a collection of backlog records, task
+# rows, secondmate records, or PR rows - belongs on stdin for that reason, even
+# where a documented bound currently keeps it small, because those bounds are
+# environment-overridable and the failure mode is loss of the whole command.
+#
+# BINDING CONTRACT: pipe fm_jq_inputs into jq and bind each payload in the same
+# order with `input`. With `jq -n`, every payload is an `input`:
+#
+#     fm_jq_inputs "$backlog" "$tasks" \
+#       | jq -n '(input) as $backlog
+#                | (input) as $tasks
+#                | ...'
+#
+# Without `-n`, jq consumes the FIRST payload as `.` and each `input` returns
+# the next, which keeps a filter that already reads `.` unchanged:
+#
+#     fm_jq_inputs "$snapshot" "$rows" | jq '(input) as $rows | ...'
+#
+# `input` preserves --argjson's fail-closed behavior: an empty or malformed
+# payload aborts jq non-zero rather than binding null, so a caller checking the
+# exit status keeps refusing bad data instead of reporting an empty fleet.
+#
+# Small fixed-size values - a path, a bound, a boolean, an id, one status line -
+# stay on argv with --arg/--argjson, where they are readable and cost nothing.
+
+fm_jq_inputs() {  # <json> [<json>...]
+  if [ "$#" -eq 0 ]; then
+    echo "fm_jq_inputs: at least one payload is required" >&2
+    return 2
+  fi
+  printf '%s\n' "$@"
+}

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -18,6 +18,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-home-summary-refresh.sh` | Atomically publish this home's structured summary ledger                         |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
+| `fm-jq-arg-lib.sh`       | Single owner of handing fleet-sized JSON to jq on stdin, past the kernel's per-argument limit |
 | `fm-bearings-board.sh`   | Build and arm the stable interactive `/bearings lavish` fleet board                  |
 | `fm-secondmate-reconcile.sh` | Ask each secondmate to reconcile an inventory mismatch through its durable inbox, limited by a per-home cooldown |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and local or remote secondmate homes       |

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -1963,6 +1963,33 @@ test_default_is_bounded_and_local_only
 test_toon_json_parity
 test_landed_includes_secondmate_home_merges
 test_landed_default_balances_dominant_and_sparse_homes
+# The reported failure, end to end: in a home whose backlog has outgrown the
+# kernel's per-argument limit, `/bearings` returned NOTHING at all, because the
+# canonical snapshot underneath could not exec jq with the serialized backlog on
+# argv. The fixture is sized from the host's real limit, and the size is
+# asserted, so the case cannot pass without actually crossing that limit.
+test_oversized_backlog_still_renders_bearings() {
+  local home fakebin out json limit rows
+  limit=$(fm_max_single_arg_bytes)
+  [ "$limit" -gt 0 ] || limit=131072
+  home=$(make_home oversized-backlog)
+  rows=$(fm_write_oversized_backlog "$home/data/backlog.md" "$limit")
+  fakebin=$(make_fakebin "$home")
+  out=$(run "$home" "$fakebin") \
+    || fail "bearings must still render with a backlog past the $limit-byte argument limit"
+  assert_contains "$out" "schema: fm-bearings.v1" "oversized-backlog bearings lost its projection"
+  assert_contains "$out" "landed[" "oversized-backlog bearings lost its landed section"
+  json=$(run "$home" "$fakebin" --json) || fail "bearings --json must survive the same backlog"
+  printf '%s' "$json" | jq -e --argjson rows "$rows" '
+    .schema == "fm-bearings.v1"
+      and (.landed | length) > 0
+      and (.gates | length) == 0
+      and ([.omitted[] | select(.surface | test("landed"))] | length) == 1
+  ' >/dev/null || fail "oversized-backlog bearings model is incomplete: $json"
+  [ "$rows" -gt 0 ] || fail "oversized backlog fixture wrote no rows"
+  pass "bearings renders its normal projection when the backlog outgrows the argument limit"
+}
+
 test_landed_default_refills_capacity_after_sparse_homes_exhaust
 test_landed_default_uses_deterministic_home_order_when_homes_exceed_cap
 test_landed_default_preserves_internal_order_for_ties
@@ -1988,3 +2015,4 @@ test_collapsed_captain_call_deferral_and_landed
 test_pr_repository_cap_and_expansion
 test_per_repository_pr_cap_is_disclosed
 test_projection_and_toon_fail_closed
+test_oversized_backlog_still_renders_bearings

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -799,8 +799,36 @@ test_parked_scout_decision_stays_pending() {
   pass "a scout still parked at a decision stays pending (terminal clear does not over-fire)"
 }
 
+# Size-dependent regression: a home whose backlog outgrew the kernel's
+# per-argument limit used to lose the ENTIRE snapshot, because jq could not be
+# exec'd with the serialized backlog on argv ("Argument list too long"). The
+# fixture is sized from the host's real limit so the case cannot go vacuous on a
+# platform with a different ceiling, and the payload size is asserted so a
+# shrunken fixture fails loudly instead of passing without testing anything.
+test_oversized_backlog_survives_argument_limit() {
+  local home fakebin out limit rows payload
+  limit=$(fm_max_single_arg_bytes)
+  [ "$limit" -gt 0 ] || limit=131072
+  home=$(make_home oversized)
+  rows=$(fm_write_oversized_backlog "$home/data/backlog.md" "$limit")
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "snapshot must survive a backlog larger than the $limit-byte argument limit"
+  payload=$(printf '%s' "$out" | jq -c '.backlog' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$payload" -gt "$limit" ] \
+    || fail "fixture is too small to test the argument limit: backlog payload $payload bytes, limit $limit"
+  printf '%s' "$out" | jq -e --argjson rows "$rows" '
+    (.backlog.records | length) == $rows
+      and (.backlog.records | all(.structured and .state == "done"))
+      and (.backlog.records[-1].pr_url != null)
+      and .main_inventory.valid == true
+  ' >/dev/null || fail "oversized backlog must still parse into complete records"
+  pass "a backlog larger than the host argument limit still produces a complete snapshot"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
+test_oversized_backlog_survives_argument_limit
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness
 test_event_hints_follow_reconciled_current_state

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -260,6 +260,55 @@ fm_write_secondmate_meta() {
     "projects=$projects"
 }
 
+# --- oversized-payload fixtures ---------------------------------------------
+#
+# A firstmate home whose backlog has grown past the kernel's per-argument limit
+# used to lose the whole fleet snapshot, because a jq argument carrying the
+# serialized backlog could not be exec'd at all (bin/fm-jq-arg-lib.sh owns the
+# mechanism and the fix). These primitives let a size-dependent regression size
+# its fixture from the host's REAL limit instead of a hardcoded guess, so the
+# case stays meaningful on Linux (a 128 KiB per-argument cap far below ARG_MAX)
+# and on macOS (no separate per-argument cap, so the whole ~1 MiB ARG_MAX must
+# be crossed instead).
+
+# fm_max_single_arg_bytes: print the smallest power-of-two argument size this
+# host REFUSES to exec, probed with a real exec rather than assumed. Prints 0
+# when no ceiling appears below 16 MiB, so a caller can tell "no observable
+# limit" apart from a small one.
+fm_max_single_arg_bytes() {
+  local n=65536 pad
+  while [ "$n" -le 16777216 ]; do
+    pad=$(printf '%*s' "$n" '')
+    if ! /usr/bin/env true "$pad" 2>/dev/null; then
+      printf '%s\n' "$n"
+      return 0
+    fi
+    n=$((n * 2))
+  done
+  printf '0\n'
+}
+
+# fm_write_oversized_backlog <backlog-path> <min-bytes>: write a canonical
+# tasks-axi backlog of landed work whose own text is at least <min-bytes>, so
+# the snapshot's serialized backlog - which carries every row's title - is
+# larger still. Landed rows keep the fixture a HEALTHY home that simply grew,
+# which is the shape a long-running fleet actually reaches. Prints the row count.
+fm_write_oversized_backlog() {  # <backlog-path> <min-bytes>
+  local file=$1 min=$2 filler row i=0 written=0
+  filler=$(printf 'detail %.0s' $(seq 1 120))
+  {
+    printf '## In flight\n\n## Queued\n\n## Done\n'
+    while [ "$written" -lt "$min" ]; do
+      i=$((i + 1))
+      row=$(printf -- '- [x] bulk-%04d - Bulk task %d %s https://github.com/acme/repo/pull/%d (repo: alpha) (kind: ship) (merged 2026-07-06)' \
+        "$i" "$i" "$filler" "$i")
+      printf '%s\n' "$row"
+      written=$((written + ${#row} + 1))
+    done
+  } > "$file"
+  printf '%s\n' "$i"
+}
+
 # --- common assertions ------------------------------------------------------
 
 # assert_contains <haystack> <needle> <msg>


### PR DESCRIPTION
## The failure

In a home whose backlog has grown past the kernel's per-argument limit, `/bearings` returns nothing at all:

```
$ bin/fm-bearings-snapshot.sh
bin/fm-fleet-snapshot.sh: line 644: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed
```

**This is not specific to one home.** Any firstmate loses bearings entirely once its backlog crosses that threshold, and it fails harder the more the fleet is used, so it strikes the busiest homes first. The home this was found on has a 160 KB backlog across 180 tasks.

## Root cause

`main_inventory_json()` passed the whole serialized backlog as a single jq argument:

```sh
jq -n --argjson backlog "$1" --argjson tasks "$2" '...'
```

A single argv entry is capped at `MAX_ARG_STRLEN`, which on Linux is 128 KiB and is **independent of the much larger `ARG_MAX`** (2 MiB on the affected host). Once the serialized backlog crosses 128 KiB, `execve` refuses the whole command, so the snapshot exits non-zero and every view built on it returns nothing. Measured on the affected host:

```
$ getconf ARG_MAX
2097152
$ python3 -c "import subprocess; subprocess.run(['/bin/true','x'*131071])"   # ok
$ python3 -c "import subprocess; subprocess.run(['/bin/true','x'*131072])"   # OSError: Argument list too long
```

## The fix

`bin/fm-jq-arg-lib.sh` is a new single owner for the mechanism: payloads that grow with the fleet are piped into jq and bound with `input`, so only small fixed-size flags ride on argv. `input` preserves `--argjson`'s fail-closed behavior - an empty or malformed payload aborts jq non-zero rather than binding `null`, so a caller checking the exit status keeps refusing bad data instead of reporting an empty fleet. Small fixed-size values (a path, a bound, a boolean, an id, one status line) stay on argv, where they are readable and cost nothing.

## Audit of the other call sites

Patching only the line that broke today would leave the next one waiting, so every call site that can receive a payload growing with the fleet moved with it:

| Site | Payload |
| --- | --- |
| `main_inventory_json` | backlog, task inventory |
| `secondmate_home_summary_json` | backlog, task inventory |
| per-task row builder | the task's open-decision set (grows with its status log; no cap) |
| `parent_evidence_reconciliation_json` | home summary, activities, decisions |
| secondmate registry/task union | task inventory, registry |
| both secondmate record builders | home summary (up to 256 KiB), activities, decisions, activity scan, reconciliation |
| secondmate record accumulator | the whole accumulated record set |
| final secondmate object | registry, records |
| `secondmate_landed_from_current_json` | the whole secondmate-current object |
| final snapshot object | backlog, tasks, main inventory, scout reports, secondmate current, secondmate landed |
| `fm-bearings-snapshot.sh` PR-row accumulator and projection | PR rows, unbounded under `--all-pr-repos` |

The remaining `--argjson` sites in both files carry fixed-size scalars - a path, a bound, a boolean, an id, one status line - and stay on argv. A scan of the other `bin/*.sh` `--argjson` call sites found no other fleet-sized payload: they carry per-task deliverables, post chunks, key lists, and container ids.

## Output is unchanged for a small backlog

Captured before and after the change against small fixtures with the observation time and repo root pinned, over fixtures covering both the structured-home and the fallback secondmate record paths:

```
IDENTICAL: small-backlog --json output byte-for-byte unchanged (15185 bytes)
IDENTICAL: --secondmate-home-summary output unchanged (3129 bytes)
IDENTICAL: secondmate-aggregation snapshot unchanged (24488 bytes)
IDENTICAL: fallback secondmate record path unchanged (29965 bytes)
IDENTICAL: bearings default output unchanged (rc=0, 2352 bytes)
IDENTICAL: bearings --json output unchanged (rc=0, 3929 bytes)
```

## The regression test is size-based

The bug only appears past the single-argument limit, so only a size-based test catches it coming back. `tests/lib.sh` gains two primitives: `fm_max_single_arg_bytes` probes the host's **real** per-argument ceiling with an actual exec rather than assuming one, and `fm_write_oversized_backlog` writes a landed-work backlog sized from that probe. Sizing from the measured limit keeps the case meaningful on Linux (a 128 KiB per-argument cap far below `ARG_MAX`) and on macOS (no separate per-argument cap, so the whole ~1 MiB `ARG_MAX` must be crossed instead), and each test also asserts the payload actually exceeds the probed limit, so a shrunken fixture fails loudly instead of passing without testing anything.

Both new tests fail on the pre-change code with the exact reported error and pass on this branch:

```
# tests/fm-fleet-snapshot-view.test.sh, pre-change code
bin/fm-fleet-snapshot.sh: line 644: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed
not ok - snapshot must survive a backlog larger than the 131072-byte argument limit

# tests/fm-bearings-snapshot.test.sh, pre-change code (42 other tests pass)
not ok - bearings must still render with a backlog past the 131072-byte argument limit
```

## Verification

Against a real 180-task, 160 KB backlog - the exact case that was aborting - `bin/fm-bearings-snapshot.sh` now renders its normal projection:

```
schema: fm-bearings.v1
home: dev/firstmate
generated: "2026-08-29T14:39:16Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight[3]{id,kind,state,doing}:
  ...
decisions_open[20]{id,key,verb,summary,owner}:
  ...
```

Suites, all green on this branch:

- `tests/fm-fleet-snapshot-view.test.sh` - 16 tests
- `tests/fm-bearings-snapshot.test.sh` - 43 tests
- `tests/fm-bearings-board.test.sh`, `tests/fm-bearings-board-render.test.sh`

`bin/fm-lint.sh` passes with the pinned ShellCheck 0.11.0 and actionlint 1.7.12, and `bin/fm-doc-audience-check.sh` passes.

## Note on the gate

`CONTRIBUTING.md` routes contributions through `no-mistakes`, but this repo is not initialized for it (`no-mistakes axi status` answers "repo not initialized" and there is no `.no-mistakes` directory), so this PR is raised directly with the before-and-after evidence above in place of a pipeline attestation.
