### PR TITLE
fix(bin): stop teardown from stranding unlanded no-mistakes pipeline commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ state/               runtime records and signals; gitignored
   .cursor-park-owner .cursor-park-owner.lock .turnend-cursor-blocks   Cursor stop-hook owner record, publication and commit lock, and bounded repair-nag budget; never touch
   .hash-* .count-* .stale-* .stale-since-* .churn-since-* .paused-* .wedge-escalations-* .writing-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
   .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
-  .discarded-pipeline-commits.log  fleet-wide append-only record of each forced teardown that discarded unlanded or unverified no-mistakes pipeline work (size-capped); deliberately not keyed to the task id teardown erases, so it is the only surviving trace of that work; never delete it
+  .discarded-pipeline-commits.log .discarded-pipeline-commits.lock  fleet-wide append-only record of each forced teardown that discarded unlanded or unverified no-mistakes pipeline work (size-capped), and the lock serializing its append-plus-rotate critical section across concurrent teardowns of different tasks; deliberately not keyed to the task id teardown erases, so it is the only surviving trace of that work; never delete it
   .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
   .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
 .no-mistakes/        local validation state and evidence; gitignored

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,7 @@ state/               runtime records and signals; gitignored
   .cursor-park-owner .cursor-park-owner.lock .turnend-cursor-blocks   Cursor stop-hook owner record, publication and commit lock, and bounded repair-nag budget; never touch
   .hash-* .count-* .stale-* .stale-since-* .churn-since-* .paused-* .wedge-escalations-* .writing-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
   .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
+  .discarded-pipeline-commits.log  fleet-wide append-only record of each forced teardown that discarded unlanded or unverified no-mistakes pipeline work (size-capped); deliberately not keyed to the task id teardown erases, so it is the only surviving trace of that work; never delete it
   .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
   .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
 .no-mistakes/        local validation state and evidence; gitignored

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -99,6 +99,22 @@ fm_nm_branch_sync_state() {  # <toon-output>
   fm_nm_strip_quotes "$s"
 }
 
+# branch_sync.next_action.code from captured `axi status` TOON $1: same
+# first-match-in-block technique as fm_nm_branch_sync_state, since no other
+# branch_sync sub-block (local/pipeline/target/remote) carries a `code:` key.
+# `recover_custody` means the run left pipeline-committed work that never
+# reached this worktree's branch (a fix round the daemon committed in its own
+# gate-repo clone before the run went terminal) - `no-mistakes axi sync
+# --recover` is the only way to land it. fm-teardown.sh's Fix 1 uses this to
+# refuse discarding that work instead of orphaning it under a removed worktree.
+fm_nm_branch_sync_next_action_code() {  # <toon-output>
+  local s
+  s=$(printf '%s\n' "$1" \
+    | sed -n '/^[[:space:]]*branch_sync:[[:space:]]*$/,/^[^[:space:]][^:]*:/s/^[[:space:]]\{1,\}code:[[:space:]]*\(.*\)/\1/p' \
+    | head -1)
+  fm_nm_strip_quotes "$s"
+}
+
 # 0 if the run in captured `axi status` TOON $1 is still in flight: no
 # terminal outcome and no terminal status.
 fm_nm_run_is_active() {  # <toon-output>

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -87,16 +87,26 @@ fm_nm_head_resolvable() {  # <worktree> <head>
 }
 
 # Text of top-level TOON block $2 (e.g. branch_sync) in captured `axi status`
-# output $1: every line from the block's own header through the next
-# top-level (zero-indent) key, header dropped and the block's own
+# output $1: the block's own children only, header dropped and the block's own
 # indentation stripped so its direct children read as top-level - letting a
 # caller re-scope into one of THOSE children by calling this again on the
 # result (fm_nm_branch_sync_next_action_code does exactly that for
 # branch_sync's next_action: child, below).
+#
+# sed ranges are inclusive of their end address, so the next top-level key -
+# the line that TERMINATES the block - is part of the matched range and must be
+# dropped here, at the source. Leaving it in would put a key from OUTSIDE the
+# block into the block text every fm_nm_toon_field search below then scans,
+# which is a false match on the block's own key name (`branch_sync:` followed
+# by a top-level `state:` would answer fm_nm_branch_sync_state). Dropping it
+# here rather than re-tightening fm_nm_toon_field's indentation requirement
+# keeps fm_nm_toon_field usable on already-dedented recursive input, which the
+# next_action lookup below relies on.
 fm_nm_toon_block() {  # <toon-output> <block-key>
   printf '%s\n' "$1" | sed -n "
     /^[[:space:]]*$2:[[:space:]]*\$/,/^[^[:space:]][^:]*:/{
       /^[[:space:]]*$2:[[:space:]]*\$/d
+      /^[^[:space:]][^:]*:/d
       s/^  //
       p
     }"
@@ -140,6 +150,30 @@ fm_nm_branch_sync_next_action_code() {  # <toon-output>
   local branch_sync
   branch_sync=$(fm_nm_toon_block "$1" branch_sync)
   fm_nm_toon_field "$(fm_nm_toon_block "$branch_sync" next_action)" code
+}
+
+# branch_sync.local.head from captured `axi status` TOON $1: the daemon's own
+# reading of the head this branch is at in the CREW's checkout, as opposed to
+# the run's `head:` (the run's lane tip, which for a pipeline-owned run is
+# routinely a gate-repo commit that never reached the worktree). Scoped twice
+# for the same reason next_action.code is: `head:` is not unique to the local:
+# sub-block within branch_sync (pipeline: carries current_head, and a future
+# release could add another head-bearing sibling ordered ahead of local:).
+fm_nm_branch_sync_local_head() {  # <toon-output>
+  local branch_sync
+  branch_sync=$(fm_nm_toon_block "$1" branch_sync)
+  fm_nm_toon_field "$(fm_nm_toon_block "$branch_sync" local)" head
+}
+
+# branch_sync.pipeline.current_head from captured `axi status` TOON $1: the
+# commit the PIPELINE currently holds for this branch in its own gate-repo
+# clone. When that commit is not reachable from the crew worktree's HEAD, the
+# pipeline is holding work the worktree has never seen - the unlanded fix-round
+# commit fm-teardown.sh refuses to strand. Scoped twice, as above.
+fm_nm_branch_sync_pipeline_current_head() {  # <toon-output>
+  local branch_sync
+  branch_sync=$(fm_nm_toon_block "$1" branch_sync)
+  fm_nm_toon_field "$(fm_nm_toon_block "$branch_sync" pipeline)" current_head
 }
 
 # 0 if the run in captured `axi status` TOON $1 is still in flight: no

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -9,16 +9,27 @@
 # direction is unsafe: a false negative hides a genuinely parked run, and a
 # false positive lets teardown act on a run it does not own.
 #
+# Name of the tool this host can bound a subprocess with, or non-zero when it
+# has none. ONE owner for that detection: fm_nm_run_bounded below uses it to
+# pick how to run, and a caller that must tell "the call failed" apart from
+# "this host cannot make a bounded call at all" - which fm_nm_run_bounded
+# reports identically, as a bare exit 1 - asks here FIRST rather than
+# re-deriving the same three probes and drifting from them.
+fm_nm_bounded_tool() {
+  if command -v timeout >/dev/null 2>&1; then printf 'timeout'
+  elif command -v gtimeout >/dev/null 2>&1; then printf 'gtimeout'
+  elif command -v perl >/dev/null 2>&1; then printf 'perl'
+  else return 1
+  fi
+}
+
 # Bounded call to `no-mistakes "$@"` in dir $1, timeout $2 seconds. The bounded
 # form preserves stdout, stderr, and exit status; the checked form discards
 # stderr, while fm_nm_run keeps the fail-open query contract for read-only callers.
 fm_nm_run_bounded() {  # <dir> <timeout_secs> <args...>
-  local dir=$1 timeout_secs=$2 have_timeout=none
+  local dir=$1 timeout_secs=$2 have_timeout
   shift 2
-  if command -v timeout >/dev/null 2>&1; then have_timeout=timeout
-  elif command -v gtimeout >/dev/null 2>&1; then have_timeout=gtimeout
-  elif command -v perl >/dev/null 2>&1; then have_timeout=perl
-  fi
+  have_timeout=$(fm_nm_bounded_tool) || have_timeout=none
   case "$have_timeout" in
     timeout)  ( cd "$dir" && timeout "$timeout_secs" no-mistakes "$@" ) ;;
     gtimeout) ( cd "$dir" && gtimeout "$timeout_secs" no-mistakes "$@" ) ;;

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -86,33 +86,60 @@ fm_nm_head_resolvable() {  # <worktree> <head>
   git -C "$1" rev-parse --verify --quiet "$2^{commit}" >/dev/null 2>&1
 }
 
+# Text of top-level TOON block $2 (e.g. branch_sync) in captured `axi status`
+# output $1: every line from the block's own header through the next
+# top-level (zero-indent) key, header dropped and the block's own
+# indentation stripped so its direct children read as top-level - letting a
+# caller re-scope into one of THOSE children by calling this again on the
+# result (fm_nm_branch_sync_next_action_code does exactly that for
+# branch_sync's next_action: child, below).
+fm_nm_toon_block() {  # <toon-output> <block-key>
+  printf '%s\n' "$1" | sed -n "
+    /^[[:space:]]*$2:[[:space:]]*\$/,/^[^[:space:]][^:]*:/{
+      /^[[:space:]]*$2:[[:space:]]*\$/d
+      s/^  //
+      p
+    }"
+}
+
+# First scalar value of key $2 anywhere in already-scoped TOON block text $1
+# (typically fm_nm_toon_block's output). Safe only when no nested sub-block
+# still present in that scope reuses the same key ahead of the one intended;
+# each caller below names that invariant for its own key.
+fm_nm_toon_field() {  # <block-text> <field-key>
+  local s
+  s=$(printf '%s\n' "$1" \
+    | sed -n "s/^[[:space:]]*$2:[[:space:]]*\(.*\)/\1/p" \
+    | head -1)
+  fm_nm_strip_quotes "$s"
+}
+
 # branch_sync.state from captured `axi status` TOON $1: the scalar directly
 # under the top-level `branch_sync:` block. The first `state:` inside the
 # block is the direct child (the nested local/pipeline/target/remote
 # sub-blocks carry no `state:` key). Empty when the block is absent: no run
 # on the current branch, another branch's run, or a CLI without branch sync.
 fm_nm_branch_sync_state() {  # <toon-output>
-  local s
-  s=$(printf '%s\n' "$1" \
-    | sed -n '/^[[:space:]]*branch_sync:[[:space:]]*$/,/^[^[:space:]][^:]*:/s/^[[:space:]]\{1,\}state:[[:space:]]*\(.*\)/\1/p' \
-    | head -1)
-  fm_nm_strip_quotes "$s"
+  fm_nm_toon_field "$(fm_nm_toon_block "$1" branch_sync)" state
 }
 
-# branch_sync.next_action.code from captured `axi status` TOON $1: same
-# first-match-in-block technique as fm_nm_branch_sync_state, since no other
-# branch_sync sub-block (local/pipeline/target/remote) carries a `code:` key.
+# branch_sync.next_action.code from captured `axi status` TOON $1.
+# `code:` is NOT unique to next_action within branch_sync in general the way
+# `state:` is unique to fm_nm_branch_sync_state's search above - a future
+# no-mistakes release could add another code-bearing branch_sync sub-block
+# ordered before next_action, which would silently mismatch a `state:`-style
+# any-depth search. So this scopes twice instead: first to the branch_sync
+# block, then to its next_action: child specifically, and only then looks for
+# code: - anchored to the one sub-block that actually carries it today.
 # `recover_custody` means the run left pipeline-committed work that never
 # reached this worktree's branch (a fix round the daemon committed in its own
 # gate-repo clone before the run went terminal) - `no-mistakes axi sync
 # --recover` is the only way to land it. fm-teardown.sh's Fix 1 uses this to
 # refuse discarding that work instead of orphaning it under a removed worktree.
 fm_nm_branch_sync_next_action_code() {  # <toon-output>
-  local s
-  s=$(printf '%s\n' "$1" \
-    | sed -n '/^[[:space:]]*branch_sync:[[:space:]]*$/,/^[^[:space:]][^:]*:/s/^[[:space:]]\{1,\}code:[[:space:]]*\(.*\)/\1/p' \
-    | head -1)
-  fm_nm_strip_quotes "$s"
+  local branch_sync
+  branch_sync=$(fm_nm_toon_block "$1" branch_sync)
+  fm_nm_toon_field "$(fm_nm_toon_block "$branch_sync" next_action)" code
 }
 
 # 0 if the run in captured `axi status` TOON $1 is still in flight: no

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -192,10 +192,23 @@
 #           TRACED  - one bounded append-only line lands in
 #                     "$STATE/.discarded-pipeline-commits.log", which is not
 #                     keyed to the task id teardown erases, so the commit is
-#                     never lost from EVERY record at once.
+#                     never lost from EVERY record at once. That record is a
+#                     PRECONDITION, not telemetry: if the append fails (full,
+#                     read-only, unwritable $STATE) --force refuses too rather
+#                     than destroying work nothing afterwards can account for,
+#                     and says it was the record write that failed and not the
+#                     axi status check, so the operator fixes the right thing.
 #         Both that message and the plain refusal say outright that --force is
 #         authorization to discard this specific work, not a convenience
 #         bypass, so an operator reading either one sees the distinction.
+#       - The REMEDY it prints keys off whether the run is still active, never
+#         off which trigger matched. branch_sync keeps reporting
+#         pipeline_owned after a cancellation, so the pipeline-head trigger
+#         fires for terminal runs too; those get the custody-return remedy
+#         (`axi sync --recover`), and only a genuinely in-flight run is told to
+#         let it finish and re-check. A discard whose stakes could not be
+#         verified at all is headlined as unverified rather than as known lost
+#         work, so the loud notice never claims more than teardown established.
 #   Fix 2 - reap leaked descendant processes. A backgrounded/disowned process
 #     started under the worktree (or its per-task tasktmp) does not receive the
 #     SIGHUP/SIGTERM that closing the backend pane sends to its own foreground
@@ -1692,6 +1705,7 @@ conclude_task_no_mistakes_run() {  # <worktree>
 NM_TEARDOWN_UNRECOVERED_REASON=
 NM_TEARDOWN_UNRECOVERED_BRANCH=
 NM_TEARDOWN_UNRECOVERED_HEAD=
+NM_TEARDOWN_UNRECOVERED_RUN_ACTIVE=0
 
 # 0 if pipeline head $2 carries content worktree $1's HEAD does not already
 # have. An unresolvable head, or a comparison git cannot complete, answers 0:
@@ -1712,6 +1726,7 @@ worktree_has_unrecovered_pipeline_commits() {  # <worktree>
   NM_TEARDOWN_UNRECOVERED_REASON=
   NM_TEARDOWN_UNRECOVERED_BRANCH=
   NM_TEARDOWN_UNRECOVERED_HEAD=
+  NM_TEARDOWN_UNRECOVERED_RUN_ACTIVE=0
   [ "$KIND" = ship ] || return 1
   [ -d "$wt" ] || return 1
   command -v no-mistakes >/dev/null 2>&1 || return 1
@@ -1735,6 +1750,7 @@ worktree_has_unrecovered_pipeline_commits() {  # <worktree>
     || fm_nm_run_is_pipeline_owned_active "$out" \
     || return 1
 
+  if fm_nm_run_is_active "$out"; then NM_TEARDOWN_UNRECOVERED_RUN_ACTIVE=1; fi
   pipeline_head=$(fm_nm_branch_sync_pipeline_current_head "$out")
   NM_TEARDOWN_UNRECOVERED_HEAD=$pipeline_head
 
@@ -1747,8 +1763,13 @@ worktree_has_unrecovered_pipeline_commits() {  # <worktree>
   # calls its state. A terminal run whose state is not pipeline_owned and whose
   # next_action is not recover_custody is the one shape AGENTS.md names as
   # "ownership already returned and no recovery required", and still passes.
+  # Note that BOTH arms can hold at once, and the state arm alone can hold for
+  # a TERMINAL run (branch_sync keeps reporting pipeline_owned after a
+  # cancellation), which is why the remedy the caller prints keys off
+  # NM_TEARDOWN_UNRECOVERED_RUN_ACTIVE and never off which arm matched.
   if [ -n "$pipeline_head" ] \
-     && { [ "$(fm_nm_branch_sync_state "$out")" = pipeline_owned ] || fm_nm_run_is_active "$out"; }; then
+     && { [ "$(fm_nm_branch_sync_state "$out")" = pipeline_owned ] \
+          || [ "$NM_TEARDOWN_UNRECOVERED_RUN_ACTIVE" = 1 ]; }; then
     if pipeline_head_carries_unlanded_content "$wt" "$pipeline_head"; then
       if fm_nm_head_resolvable "$wt" "$pipeline_head"; then
         NM_TEARDOWN_UNRECOVERED_REASON=pipeline-ahead-unlanded
@@ -1761,10 +1782,15 @@ worktree_has_unrecovered_pipeline_commits() {  # <worktree>
   return 1
 }
 
-# Durable, fleet-wide record of work discarded under --force, following the
-# same bounded append-only convention as bin/fm-push-transition-lib.sh's
-# triage log. Deliberately NOT keyed under "$STATE/$ID." - teardown erases
-# those, and this record has to outlive the task whose commit it names.
+# Durable, fleet-wide record of work discarded under --force, borrowing the
+# bounded append-only shape of bin/fm-push-transition-lib.sh's triage log but
+# NOT its best-effort contract: that log is supervision telemetry a lost line
+# costs nothing, while this one is the only surviving trace of destroyed work.
+# So the append is REQUIRED - a failure returns non-zero and the caller stops
+# before destroying anything. Only the size rotation stays best-effort, since
+# failing to trim cannot lose the line just written. Deliberately NOT keyed
+# under "$STATE/$ID." - teardown erases those, and this record has to outlive
+# the task whose commit it names.
 NM_DISCARD_LOG="$STATE/.discarded-pipeline-commits.log"
 NM_DISCARD_LOG_MAX_BYTES=${FM_DISCARD_LOG_MAX_BYTES:-262144}
 case "$NM_DISCARD_LOG_MAX_BYTES" in ''|*[!0-9]*|0) NM_DISCARD_LOG_MAX_BYTES=262144 ;; esac
@@ -1772,7 +1798,7 @@ record_discarded_pipeline_commits() {  # <reason> <branch> <pipeline-head> <work
   local sz
   printf '[%s] task=%s reason=%s branch=%s pipeline_head=%s worktree=%s\n' \
     "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$ID" "${1:-unknown}" "${2:-unknown}" \
-    "${3:-unknown}" "${4:-unknown}" >> "$NM_DISCARD_LOG" 2>/dev/null || return 0
+    "${3:-unknown}" "${4:-unknown}" >> "$NM_DISCARD_LOG" || return 1
   sz=$(wc -c < "$NM_DISCARD_LOG" 2>/dev/null | tr -d '[:space:]')
   case "$sz" in ''|*[!0-9]*) return 0 ;; esac
   if [ "$sz" -ge "$NM_DISCARD_LOG_MAX_BYTES" ]; then
@@ -1780,6 +1806,7 @@ record_discarded_pipeline_commits() {  # <reason> <branch> <pipeline-head> <work
       && mv -f "$NM_DISCARD_LOG.tmp" "$NM_DISCARD_LOG" 2>/dev/null
     rm -f "$NM_DISCARD_LOG.tmp" 2>/dev/null || true
   fi
+  return 0
 }
 
 # Fix 2 (see script header): pids of every process whose CURRENT WORKING
@@ -2910,26 +2937,45 @@ if [ "$KIND" != secondmate ]; then
   conclude_task_no_mistakes_run "$WT"
   if worktree_has_unrecovered_pipeline_commits "$WT"; then
     nm_discard_what="branch $NM_TEARDOWN_UNRECOVERED_BRANCH${NM_TEARDOWN_UNRECOVERED_HEAD:+, pipeline commit $NM_TEARDOWN_UNRECOVERED_HEAD}"
+    # The remedy for a pipeline-held commit depends on whether the run is still
+    # going, NOT on which trigger matched: branch_sync keeps reporting
+    # pipeline_owned after a cancellation, so the state arm fires for terminal
+    # runs too, and telling those to "let the run finish" names a wait that
+    # already ended. A terminal run is exactly the custody-return case.
+    if [ "$NM_TEARDOWN_UNRECOVERED_RUN_ACTIVE" = 1 ]; then
+      nm_pipeline_fix="The run is still going, so nothing can be recovered from it yet. Let it finish (or abort it), then re-check with 'no-mistakes axi status' and follow the branch_sync.next_action it reports."
+    else
+      nm_pipeline_fix="The run has already ended, so this is a custody return: run 'no-mistakes axi sync --recover' in that worktree to bring the commit back, then re-check with 'no-mistakes axi status'."
+    fi
     case "$NM_TEARDOWN_UNRECOVERED_REASON" in
       query-failed)
+        nm_discard_head="DISCARDING UNVERIFIED WORKTREE"
         nm_discard_why="cannot ask no-mistakes whether the run for $ID left pipeline-committed work that never reached this worktree ($WT); 'no-mistakes axi status' there did not answer, so what is at stake here is unknown"
-        nm_discard_fix="Retry once it answers." ;;
+        nm_discard_fix="Retry once 'no-mistakes axi status' answers again." ;;
       recover_custody)
+        nm_discard_head="DISCARDING UNLANDED WORK"
         nm_discard_why="no-mistakes run for $ID left pipeline-committed work in the gate that never reached this worktree ($WT)"
         nm_discard_fix="Run 'no-mistakes axi sync --recover' there to land it first." ;;
       pipeline-ahead-unlanded)
-        nm_discard_why="the no-mistakes pipeline for $ID holds commits on $NM_TEARDOWN_UNRECOVERED_BRANCH that are not in this worktree ($WT) and whose changes are in no commit this worktree has; the run has not returned the branch yet, so there is nothing to recover yet"
-        nm_discard_fix="Let the run finish (or abort it), then re-check with 'no-mistakes axi status'; follow the branch_sync.next_action it reports." ;;
+        nm_discard_head="DISCARDING UNLANDED WORK"
+        nm_discard_why="the no-mistakes pipeline for $ID holds commits on $NM_TEARDOWN_UNRECOVERED_BRANCH that are not in this worktree ($WT) and whose changes are in no commit this worktree has"
+        nm_discard_fix=$nm_pipeline_fix ;;
       *)
-        nm_discard_why="the no-mistakes pipeline for $ID reports head $NM_TEARDOWN_UNRECOVERED_HEAD on $NM_TEARDOWN_UNRECOVERED_BRANCH, which this worktree ($WT) does not have, so teardown cannot tell whether it carries a fix round that would be lost or is only a rebase of commits this worktree already has; the run has not returned the branch yet, so there is nothing to recover yet"
-        nm_discard_fix="Let the run finish (or abort it), then re-check with 'no-mistakes axi status'; follow the branch_sync.next_action it reports." ;;
+        nm_discard_head="DISCARDING UNVERIFIED WORKTREE"
+        nm_discard_why="the no-mistakes pipeline for $ID reports head $NM_TEARDOWN_UNRECOVERED_HEAD on $NM_TEARDOWN_UNRECOVERED_BRANCH, which this worktree ($WT) does not have, so teardown cannot tell whether it carries a fix round that would be lost or is only a rebase of commits this worktree already has"
+        nm_discard_fix=$nm_pipeline_fix ;;
     esac
     if [ "$FORCE" = "--force" ]; then
-      echo "DISCARDING UNLANDED WORK: $nm_discard_why." >&2
+      echo "$nm_discard_head: $nm_discard_why." >&2
       echo "Proceeding because --force was passed. Treat --force here as your explicit authorization to discard THIS work ($nm_discard_what) - it is not a convenience bypass, and teardown is about to make it unrecoverable." >&2
-      echo "Recording the discard in $NM_DISCARD_LOG." >&2
-      record_discarded_pipeline_commits "$NM_TEARDOWN_UNRECOVERED_REASON" \
-        "$NM_TEARDOWN_UNRECOVERED_BRANCH" "$NM_TEARDOWN_UNRECOVERED_HEAD" "$WT"
+      if record_discarded_pipeline_commits "$NM_TEARDOWN_UNRECOVERED_REASON" \
+        "$NM_TEARDOWN_UNRECOVERED_BRANCH" "$NM_TEARDOWN_UNRECOVERED_HEAD" "$WT"; then
+        echo "Recorded the discard in $NM_DISCARD_LOG." >&2
+      else
+        echo "REFUSED: --force authorized discarding $nm_discard_what, but the durable record of that discard could NOT be written to $NM_DISCARD_LOG, so teardown would destroy work that nothing afterwards can account for." >&2
+        echo "This is a RECORD-WRITE failure, not a no-mistakes failure: the axi status check itself completed. Fix write access to $STATE (permissions, disk space, read-only mount), then re-run with --force." >&2
+        exit 1
+      fi
     else
       echo "REFUSED: $nm_discard_why. Removing the worktree now would make it unrecoverable, so teardown stops instead." >&2
       echo "$nm_discard_fix" >&2

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -167,13 +167,26 @@
 #         content, while the pipeline still owns the branch), so it refuses
 #         WITHOUT claiming lost work: the message names the plain-rebase
 #         possibility and gives the wait-and-re-check remedy.
-#       - It FAILS CLOSED. This precondition stands immediately before an
-#         irreversible step (branch delete plus worktree return), so unlike
-#         task_run_is_own_parked_run's fail-open residual there is no "caught
-#         on the next retry" - the fail-opening invocation is the one that
-#         destroys the evidence. Any query failure (daemon error, timeout
-#         expiry, or no timeout/gtimeout/perl on PATH to bound the call with)
-#         refuses. Only a query that SUCCEEDS can clear the worktree.
+#       - It only APPLIES AT ALL when plain git can see local evidence that a
+#         run could exist for this branch: refs/remotes/no-mistakes/<branch>,
+#         the tracking ref the crew's own `no-mistakes` remote leaves once the
+#         gate knows the branch (verified present for a gated branch and absent
+#         for one that was never gated). No such ref means no pipeline ever
+#         held this branch, so the guard steps aside without querying anything
+#         - otherwise the fail-closed rule below would quietly make a reachable
+#         daemon a precondition for tearing down ANY ship worktree, including
+#         one in a project that was never gated, which is exactly the trap
+#         task_run_is_own_parked_run's own fail-open comment warns about.
+#       - Given that evidence, it FAILS CLOSED. This precondition stands
+#         immediately before an irreversible step (branch delete plus worktree
+#         return), so unlike task_run_is_own_parked_run's fail-open residual
+#         there is no "caught on the next retry" - the fail-opening invocation
+#         is the one that destroys the evidence. A daemon error or timeout
+#         expiry refuses, and so does a host with no timeout/gtimeout/perl to
+#         bound the call with - but those two are reported as DISTINCT reasons,
+#         because "the daemon did not answer" and "this host cannot make a
+#         bounded call at all" need different fixes. Only a query that SUCCEEDS
+#         can clear the worktree.
 #       - It attributes by identity, not by branch name alone, reusing
 #         bin/fm-nm-run-lib.sh's fm_nm_head_matches_worktree (against the run
 #         head or the daemon's own branch_sync.local.head reading of this
@@ -201,14 +214,20 @@
 #         Both that message and the plain refusal say outright that --force is
 #         authorization to discard this specific work, not a convenience
 #         bypass, so an operator reading either one sees the distinction.
-#       - The REMEDY it prints keys off whether the run is still active, never
-#         off which trigger matched. branch_sync keeps reporting
-#         pipeline_owned after a cancellation, so the pipeline-head trigger
-#         fires for terminal runs too; those get the custody-return remedy
-#         (`axi sync --recover`), and only a genuinely in-flight run is told to
-#         let it finish and re-check. A discard whose stakes could not be
-#         verified at all is headlined as unverified rather than as known lost
-#         work, so the loud notice never claims more than teardown established.
+#       - The REMEDY it prints keys off the run's own outcome/status, never off
+#         which trigger matched. branch_sync keeps reporting pipeline_owned
+#         after a cancellation, so the pipeline-head trigger fires for terminal
+#         runs too, and only a genuinely in-flight run is told to let it finish
+#         and re-check. A terminal one is NOT told to run `axi sync --recover`:
+#         the pipeline-head trigger is only reached after next_action.code was
+#         already checked and was not recover_custody, which is precisely the
+#         state AGENTS.md says the guarded recovery must not be used in. It is
+#         told to re-check next_action instead, and that if the daemon reports
+#         ownership returned with nothing to recover then the head is simply
+#         not an object here and --force is the intended way out. A discard
+#         whose stakes could not be verified at all is headlined as unverified
+#         rather than as known lost work, so the loud notice never claims more
+#         than teardown established.
 #   Fix 2 - reap leaked descendant processes. A backgrounded/disowned process
 #     started under the worktree (or its per-task tasktmp) does not receive the
 #     SIGHUP/SIGTERM that closing the backend pane sends to its own foreground
@@ -1733,7 +1752,24 @@ worktree_has_unrecovered_pipeline_commits() {  # <worktree>
   branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
   [ -n "$branch" ] || return 1
   NM_TEARDOWN_UNRECOVERED_BRANCH=$branch
+  # Cheap LOCAL evidence, read with plain git and no daemon call, that a run
+  # can plausibly exist for THIS branch: the remote-tracking ref the crew's
+  # `no-mistakes` remote (fetch refspec +refs/heads/*:refs/remotes/no-mistakes/*)
+  # leaves behind once the gate knows the branch. Without it there is nothing
+  # for a pipeline to have committed, so the whole guard steps aside rather
+  # than making a reachable daemon a precondition for tearing down a ship
+  # worktree that never had a run - which is what the fail-closed query below
+  # would otherwise impose on an ungated project, a stopped daemon, or a host
+  # with no bounded-execution tool.
+  git -C "$wt" rev-parse --verify --quiet "refs/remotes/no-mistakes/$branch" >/dev/null 2>&1 || return 1
 
+  # Asked BEFORE the call: fm_nm_run_bounded reports "no way to bound a call on
+  # this host" with the same bare exit 1 as a genuine query failure, and those
+  # need different remedies (install timeout/gtimeout/perl vs. fix the daemon).
+  if ! fm_nm_bounded_tool >/dev/null 2>&1; then
+    NM_TEARDOWN_UNRECOVERED_REASON=no-bounded-tool
+    return 0
+  fi
   out=$(fm_nm_run_checked "$wt" "$NM_TEARDOWN_TIMEOUT" axi status) || rc=$?
   if [ "$rc" -ne 0 ]; then
     NM_TEARDOWN_UNRECOVERED_REASON=query-failed
@@ -2945,13 +2981,21 @@ if [ "$KIND" != secondmate ]; then
     if [ "$NM_TEARDOWN_UNRECOVERED_RUN_ACTIVE" = 1 ]; then
       nm_pipeline_fix="The run is still going, so nothing can be recovered from it yet. Let it finish (or abort it), then re-check with 'no-mistakes axi status' and follow the branch_sync.next_action it reports."
     else
-      nm_pipeline_fix="The run has already ended, so this is a custody return: run 'no-mistakes axi sync --recover' in that worktree to bring the commit back, then re-check with 'no-mistakes axi status'."
+      # Reaching here means next_action.code was already checked and was NOT
+      # recover_custody, so 'axi sync --recover' is exactly the case AGENTS.md
+      # says the guarded recovery must not be used for. Say what is actually
+      # actionable instead of naming a command the daemon will refuse.
+      nm_pipeline_fix="The run has already ended and the daemon does not report this branch as needing recovery, so there is no 'no-mistakes axi sync --recover' to run here. Re-check with 'no-mistakes axi status' and follow branch_sync.next_action; if it reports ownership already returned with no recovery required, then this head is simply not an object in this worktree (a pipeline rebase carrying nothing new), and --force is the intended way to finish teardown."
     fi
     case "$NM_TEARDOWN_UNRECOVERED_REASON" in
       query-failed)
         nm_discard_head="DISCARDING UNVERIFIED WORKTREE"
         nm_discard_why="cannot ask no-mistakes whether the run for $ID left pipeline-committed work that never reached this worktree ($WT); 'no-mistakes axi status' there did not answer, so what is at stake here is unknown"
         nm_discard_fix="Retry once 'no-mistakes axi status' answers again." ;;
+      no-bounded-tool)
+        nm_discard_head="DISCARDING UNVERIFIED WORKTREE"
+        nm_discard_why="cannot ask no-mistakes whether the run for $ID left pipeline-committed work that never reached this worktree ($WT): this host has no bounded-execution tool, so the check cannot be given a timeout and teardown will not run it unbounded"
+        nm_discard_fix="Install one of 'timeout' (GNU coreutils), 'gtimeout', or 'perl' on this host so the check can run bounded, then retry." ;;
       recover_custody)
         nm_discard_head="DISCARDING UNLANDED WORK"
         nm_discard_why="no-mistakes run for $ID left pipeline-committed work in the gate that never reached this worktree ($WT)"
@@ -2973,7 +3017,12 @@ if [ "$KIND" != secondmate ]; then
         echo "Recorded the discard in $NM_DISCARD_LOG." >&2
       else
         echo "REFUSED: --force authorized discarding $nm_discard_what, but the durable record of that discard could NOT be written to $NM_DISCARD_LOG, so teardown would destroy work that nothing afterwards can account for." >&2
-        echo "This is a RECORD-WRITE failure, not a no-mistakes failure: the axi status check itself completed. Fix write access to $STATE (permissions, disk space, read-only mount), then re-run with --force." >&2
+        case "$NM_TEARDOWN_UNRECOVERED_REASON" in
+          query-failed|no-bounded-tool)
+            echo "TWO separate things failed here: the discard record could not be written, AND the check that would have said what is at stake never completed either. Fix write access to $STATE (permissions, disk space, read-only mount) and the verification problem above, then re-run with --force." >&2 ;;
+          *)
+            echo "This is a RECORD-WRITE failure, not a no-mistakes failure: the axi status check itself completed. Fix write access to $STATE (permissions, disk space, read-only mount), then re-run with --force." >&2 ;;
+        esac
         exit 1
       fi
     else

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -128,6 +128,20 @@
 #     that verified run instance. A run already terminal
 #     (an outcome is set) or not parked at a gate is left untouched. Idempotent:
 #     an already-aborted run reads back terminal and is skipped on retry.
+#     A parked run that already had a fix round applied (the worker answered a
+#     gate with `--action fix` and was removed before answering the resulting
+#     fix-review gate) commits that round in the daemon's own gate-repo clone,
+#     never in this worktree - reproduced live 2026-08-29: aborting such a run
+#     leaves `axi status --run <id>`'s branch_sync.next_action.code set to
+#     `recover_custody`, meaning the commit exists only in the gate and this
+#     worktree's own git log never advanced past the pre-fix head. Removing the
+#     worktree at that point is unlanded-work loss no `git status` check here
+#     ever sees, because the work was never in this worktree to begin with.
+#     conclude_task_no_mistakes_run therefore refuses when abort's confirming
+#     `axi status` still reports `recover_custody`, the same fail-closed shape
+#     as the still-parked refusal below, so the operator runs `no-mistakes axi
+#     sync --recover` to land the commit (or discards it with explicit
+#     authority) before worktree removal can proceed.
 #   Fix 2 - reap leaked descendant processes. A backgrounded/disowned process
 #     started under the worktree (or its per-task tasktmp) does not receive the
 #     SIGHUP/SIGTERM that closing the backend pane sends to its own foreground
@@ -1543,7 +1557,7 @@ task_status_is_run_not_found() {  # <status-error> <run-id>
 # worktree (scouts and secondmates never do, mirroring bin/fm-crew-state.sh);
 # a run not attributed to this exact branch+head is left completely alone.
 conclude_task_no_mistakes_run() {  # <worktree>
-  local wt=$1 out run_id
+  local wt=$1 out run_id next_action
   [ "$KIND" = ship ] || return 0
   [ -d "$wt" ] || return 0
   command -v no-mistakes >/dev/null 2>&1 || return 0
@@ -1554,7 +1568,14 @@ conclude_task_no_mistakes_run() {  # <worktree>
   # live-state condition; fully closing the resume race needs upstream compare-and-cancel.
   fm_nm_run_checked "$wt" "$NM_TEARDOWN_TIMEOUT" axi abort --run "$run_id" >/dev/null 2>&1 || true
   if out=$(fm_nm_run_bounded "$wt" "$NM_TEARDOWN_TIMEOUT" axi status --run "$run_id" 2>&1); then
-    task_status_is_terminal_run "$out" "$run_id" && return 0
+    if task_status_is_terminal_run "$out" "$run_id"; then
+      next_action=$(fm_nm_branch_sync_next_action_code "$out")
+      if [ "$next_action" = recover_custody ]; then
+        echo "REFUSED: no-mistakes run for $ID left pipeline-committed work in the gate that never reached this worktree ($wt); run 'no-mistakes axi sync --recover' there to land it, or discard it with explicit authority, before retrying teardown." >&2
+        return 1
+      fi
+      return 0
+    fi
   elif task_status_is_run_not_found "$out" "$run_id"; then
     return 0
   fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -76,7 +76,10 @@
 # Usage: fm-teardown.sh <task-id> [--force]
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
-#   when the captain has explicitly said to discard the work.
+#   when the captain has explicitly said to discard the work. One check it does
+#   NOT skip: the unrecovered-pipeline-commits precondition under "Fix 1" below
+#   still runs, and --force only changes what happens on it (an announced,
+#   recorded discard instead of a refusal) - see that block for the contract.
 #
 # Transient / stale worktree git lock recovery (teardown-lock-race): a crew process
 # killed mid-git-operation can leave a .git/worktrees/<wt>/index.lock (or, for a

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -209,11 +209,17 @@
 #                     "$STATE/.discarded-pipeline-commits.log", which is not
 #                     keyed to the task id teardown erases, so the commit is
 #                     never lost from EVERY record at once. That record is a
-#                     PRECONDITION, not telemetry: if the append fails (full,
-#                     read-only, unwritable $STATE) --force refuses too rather
-#                     than destroying work nothing afterwards can account for,
-#                     and says it was the record write that failed and not the
-#                     axi status check, so the operator fixes the right thing.
+#                     PRECONDITION, not telemetry: if that line cannot be
+#                     written (full, read-only, unwritable $STATE) --force
+#                     refuses too rather than destroying work nothing
+#                     afterwards can account for, and the refusal names which
+#                     checks actually failed - the record write alone when the
+#                     axi status check had completed, or both of them when the
+#                     stakes could not be verified either - so the operator
+#                     fixes the right thing. An unwritable $STATE refuses
+#                     promptly with the concrete cause instead of blocking on
+#                     the log's own lock (see record_discarded_pipeline_commits
+#                     for why the lock itself cannot report that).
 #         Both that message and the plain refusal say outright that --force is
 #         authorization to discard this specific work, not a convenience
 #         bypass, so an operator reading either one sees the distinction.

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -154,10 +154,19 @@
 #     by the second review round (2026-08-29):
 #       - It does NOT wait for a cancellation. `recover_custody` is only the
 #         POST-TERMINAL shape. The same stranding happens with nothing aborted
-#         at all: a live pipeline_owned run whose branch_sync.pipeline
-#         .current_head is not reachable from this worktree's HEAD is holding
-#         a gate-repo commit this checkout has never seen. Either condition
-#         alone refuses.
+#         at all: a run that still holds the branch (state=pipeline_owned) or
+#         is still active reports a branch_sync.pipeline.current_head that this
+#         checkout has never seen. Either condition alone refuses.
+#       - That second trigger is a CONTENT question, not an ancestry one. A
+#         pipeline-driven rebase of the crew's own commits onto a newer base
+#         makes the lane head a non-ancestor while carrying nothing new, so
+#         when this worktree has the object the two are compared by patch
+#         identity and a content-equivalent rebase does NOT refuse. When the
+#         object is absent the answer is unknowable here (the daemon's own
+#         `axi sync --check` reports custody, `blocked_pipeline_owned`, not
+#         content, while the pipeline still owns the branch), so it refuses
+#         WITHOUT claiming lost work: the message names the plain-rebase
+#         possibility and gives the wait-and-re-check remedy.
 #       - It FAILS CLOSED. This precondition stands immediately before an
 #         irreversible step (branch delete plus worktree return), so unlike
 #         task_run_is_own_parked_run's fail-open residual there is no "caught
@@ -175,7 +184,18 @@
 #         validate_worktree_teardown_safety above: hard rule 3 never discards
 #         unlanded work without the captain's explicit word, and passing
 #         --force here IS that word for this specific discard. Nothing else
-#         bypasses the refusal - not a query failure, not a retry.
+#         bypasses the refusal - not a query failure, not a retry. That word
+#         is taken seriously rather than silently: --force does not skip the
+#         check, it changes the ACTION taken on it, so the discard is
+#           LOUD    - before any destructive step, stderr names exactly what is
+#                     about to be stranded (branch and pipeline commit), and
+#           TRACED  - one bounded append-only line lands in
+#                     "$STATE/.discarded-pipeline-commits.log", which is not
+#                     keyed to the task id teardown erases, so the commit is
+#                     never lost from EVERY record at once.
+#         Both that message and the plain refusal say outright that --force is
+#         authorization to discard this specific work, not a convenience
+#         bypass, so an operator reading either one sees the distinction.
 #   Fix 2 - reap leaked descendant processes. A backgrounded/disowned process
 #     started under the worktree (or its per-task tasktmp) does not receive the
 #     SIGHUP/SIGTERM that closing the backend pane sends to its own foreground
@@ -1636,35 +1656,68 @@ conclude_task_no_mistakes_run() {  # <worktree>
 # Two independent triggers, either of which refuses:
 #   - branch_sync.next_action.code=recover_custody: the post-terminal case,
 #     where the daemon itself names `axi sync --recover` as the way back.
-#   - branch_sync.state=pipeline_owned with a branch_sync.pipeline.current_head
-#     that is not reachable from this worktree's HEAD: the pipeline holds a
-#     commit this checkout has never seen. This fires BEFORE any cancellation,
-#     covering the live post-fix-round run whose lane head is a gate-repo
-#     commit - the shape that never reaches recover_custody at all because
-#     nothing aborted it. Unreachable includes unresolvable, so a head this
-#     worktree cannot even name refuses rather than passing.
+#   - a branch_sync.pipeline.current_head carrying commits this worktree has
+#     never seen, while the pipeline still holds the branch or the run is still
+#     active. This fires BEFORE any cancellation, covering the live
+#     post-fix-round run whose lane head is a gate-repo commit - the shape that
+#     never reaches recover_custody at all because nothing aborted it.
+#
+# The second trigger asks a CONTENT question, not a commit-identity one.
+# "pipeline head is not an ancestor of HEAD" is NOT proof of unlanded work:
+# bin/fm-nm-run-lib.sh records that the lane head is routinely a non-ancestor
+# for a reason that carries nothing new (a pipeline-driven rebase of the crew's
+# own commits onto a newer base produces exactly that shape). So when this
+# worktree actually has the object, the commits are compared by patch identity
+# (`git cherry`) and a content-equivalent rebase does NOT refuse.
+#
+# `no-mistakes axi sync --check` is the daemon's own version of that
+# classification, but it cannot serve as the oracle here: while the pipeline
+# owns the branch it answers `blocked_pipeline_owned` - a custody verdict, not
+# a content one - and `axi status`'s branch_sync.safety already carries that
+# same value, so the extra call would add nothing this guard does not have.
+# The unresolvable case therefore falls back to refusing WITHOUT claiming
+# unlanded content: it says so, names the plain-rebase possibility, and gives
+# the wait-and-re-check remedy instead of the recover_custody one.
 #
 # Attribution reuses bin/fm-nm-run-lib.sh's reviewed identity primitives
 # instead of trusting the branch name alone (a reused task slug can hand this
-# checkout a stale foreign run record for the same branch name, and a
-# refusal-only guard with no escape hatch would then wedge permanently):
+# checkout a stale foreign run record for the same branch name):
 # fm_nm_head_matches_worktree against the run head or against the daemon's own
 # branch_sync.local.head reading of this checkout, or the
 # fm_nm_run_is_pipeline_owned_active exemption for the live in-flight case
 # where the pipeline's own head is legitimately not yet a git object here.
+#
+# --force does NOT skip any of this. The query still runs, so the discard is
+# loud and recorded; only the ACTION changes (proceed instead of refuse).
 NM_TEARDOWN_UNRECOVERED_REASON=
+NM_TEARDOWN_UNRECOVERED_BRANCH=
+NM_TEARDOWN_UNRECOVERED_HEAD=
+
+# 0 if pipeline head $2 carries content worktree $1's HEAD does not already
+# have. An unresolvable head, or a comparison git cannot complete, answers 0:
+# this guard stands before an irreversible step, so "cannot tell" is never
+# allowed to read as "nothing to lose".
+pipeline_head_carries_unlanded_content() {  # <worktree> <pipeline-head>
+  local wt=$1 head=$2 out rc=0
+  [ -n "$head" ] || return 1
+  fm_nm_head_resolvable "$wt" "$head" || return 0
+  git -C "$wt" merge-base --is-ancestor "$head" HEAD 2>/dev/null && return 1
+  out=$(git -C "$wt" cherry HEAD "$head" 2>/dev/null) || rc=$?
+  [ "$rc" -eq 0 ] || return 0
+  printf '%s\n' "$out" | grep -q '^+'
+}
+
 worktree_has_unrecovered_pipeline_commits() {  # <worktree>
   local wt=$1 out rc=0 branch run_branch run_head local_head pipeline_head
   NM_TEARDOWN_UNRECOVERED_REASON=
+  NM_TEARDOWN_UNRECOVERED_BRANCH=
+  NM_TEARDOWN_UNRECOVERED_HEAD=
   [ "$KIND" = ship ] || return 1
   [ -d "$wt" ] || return 1
-  # --force is the captain's explicit, deliberate authorization to discard this
-  # worktree, and it is the ONLY bypass: every path below refuses without it,
-  # including the query-failure path.
-  [ "$FORCE" != "--force" ] || return 1
   command -v no-mistakes >/dev/null 2>&1 || return 1
   branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
   [ -n "$branch" ] || return 1
+  NM_TEARDOWN_UNRECOVERED_BRANCH=$branch
 
   out=$(fm_nm_run_checked "$wt" "$NM_TEARDOWN_TIMEOUT" axi status) || rc=$?
   if [ "$rc" -ne 0 ]; then
@@ -1682,19 +1735,51 @@ worktree_has_unrecovered_pipeline_commits() {  # <worktree>
     || fm_nm_run_is_pipeline_owned_active "$out" \
     || return 1
 
+  pipeline_head=$(fm_nm_branch_sync_pipeline_current_head "$out")
+  NM_TEARDOWN_UNRECOVERED_HEAD=$pipeline_head
+
   if [ "$(fm_nm_branch_sync_next_action_code "$out")" = recover_custody ]; then
     NM_TEARDOWN_UNRECOVERED_REASON=recover_custody
     return 0
   fi
-  if [ "$(fm_nm_branch_sync_state "$out")" = pipeline_owned ]; then
-    pipeline_head=$(fm_nm_branch_sync_pipeline_current_head "$out")
-    if [ -n "$pipeline_head" ] \
-       && ! git -C "$wt" merge-base --is-ancestor "$pipeline_head" HEAD 2>/dev/null; then
-      NM_TEARDOWN_UNRECOVERED_REASON=pipeline-ahead
+  # Widened past a strict state=pipeline_owned nesting: a run that is still
+  # ACTIVE has not positively returned ownership either, whatever branch_sync
+  # calls its state. A terminal run whose state is not pipeline_owned and whose
+  # next_action is not recover_custody is the one shape AGENTS.md names as
+  # "ownership already returned and no recovery required", and still passes.
+  if [ -n "$pipeline_head" ] \
+     && { [ "$(fm_nm_branch_sync_state "$out")" = pipeline_owned ] || fm_nm_run_is_active "$out"; }; then
+    if pipeline_head_carries_unlanded_content "$wt" "$pipeline_head"; then
+      if fm_nm_head_resolvable "$wt" "$pipeline_head"; then
+        NM_TEARDOWN_UNRECOVERED_REASON=pipeline-ahead-unlanded
+      else
+        NM_TEARDOWN_UNRECOVERED_REASON=pipeline-ahead-unverifiable
+      fi
       return 0
     fi
   fi
   return 1
+}
+
+# Durable, fleet-wide record of work discarded under --force, following the
+# same bounded append-only convention as bin/fm-push-transition-lib.sh's
+# triage log. Deliberately NOT keyed under "$STATE/$ID." - teardown erases
+# those, and this record has to outlive the task whose commit it names.
+NM_DISCARD_LOG="$STATE/.discarded-pipeline-commits.log"
+NM_DISCARD_LOG_MAX_BYTES=${FM_DISCARD_LOG_MAX_BYTES:-262144}
+case "$NM_DISCARD_LOG_MAX_BYTES" in ''|*[!0-9]*|0) NM_DISCARD_LOG_MAX_BYTES=262144 ;; esac
+record_discarded_pipeline_commits() {  # <reason> <branch> <pipeline-head> <worktree>
+  local sz
+  printf '[%s] task=%s reason=%s branch=%s pipeline_head=%s worktree=%s\n' \
+    "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$ID" "${1:-unknown}" "${2:-unknown}" \
+    "${3:-unknown}" "${4:-unknown}" >> "$NM_DISCARD_LOG" 2>/dev/null || return 0
+  sz=$(wc -c < "$NM_DISCARD_LOG" 2>/dev/null | tr -d '[:space:]')
+  case "$sz" in ''|*[!0-9]*) return 0 ;; esac
+  if [ "$sz" -ge "$NM_DISCARD_LOG_MAX_BYTES" ]; then
+    tail -n 2000 "$NM_DISCARD_LOG" > "$NM_DISCARD_LOG.tmp" 2>/dev/null \
+      && mv -f "$NM_DISCARD_LOG.tmp" "$NM_DISCARD_LOG" 2>/dev/null
+    rm -f "$NM_DISCARD_LOG.tmp" 2>/dev/null || true
+  fi
 }
 
 # Fix 2 (see script header): pids of every process whose CURRENT WORKING
@@ -2824,12 +2909,33 @@ fi
 if [ "$KIND" != secondmate ]; then
   conclude_task_no_mistakes_run "$WT"
   if worktree_has_unrecovered_pipeline_commits "$WT"; then
-    if [ "$NM_TEARDOWN_UNRECOVERED_REASON" = query-failed ]; then
-      echo "REFUSED: cannot ask no-mistakes whether the run for $ID left pipeline-committed work that never reached this worktree ($WT); 'no-mistakes axi status' there did not answer. Removing the worktree now would destroy the only evidence, so teardown stops instead. Retry once it answers, or discard the worktree with explicit authority via --force." >&2
+    nm_discard_what="branch $NM_TEARDOWN_UNRECOVERED_BRANCH${NM_TEARDOWN_UNRECOVERED_HEAD:+, pipeline commit $NM_TEARDOWN_UNRECOVERED_HEAD}"
+    case "$NM_TEARDOWN_UNRECOVERED_REASON" in
+      query-failed)
+        nm_discard_why="cannot ask no-mistakes whether the run for $ID left pipeline-committed work that never reached this worktree ($WT); 'no-mistakes axi status' there did not answer, so what is at stake here is unknown"
+        nm_discard_fix="Retry once it answers." ;;
+      recover_custody)
+        nm_discard_why="no-mistakes run for $ID left pipeline-committed work in the gate that never reached this worktree ($WT)"
+        nm_discard_fix="Run 'no-mistakes axi sync --recover' there to land it first." ;;
+      pipeline-ahead-unlanded)
+        nm_discard_why="the no-mistakes pipeline for $ID holds commits on $NM_TEARDOWN_UNRECOVERED_BRANCH that are not in this worktree ($WT) and whose changes are in no commit this worktree has; the run has not returned the branch yet, so there is nothing to recover yet"
+        nm_discard_fix="Let the run finish (or abort it), then re-check with 'no-mistakes axi status'; follow the branch_sync.next_action it reports." ;;
+      *)
+        nm_discard_why="the no-mistakes pipeline for $ID reports head $NM_TEARDOWN_UNRECOVERED_HEAD on $NM_TEARDOWN_UNRECOVERED_BRANCH, which this worktree ($WT) does not have, so teardown cannot tell whether it carries a fix round that would be lost or is only a rebase of commits this worktree already has; the run has not returned the branch yet, so there is nothing to recover yet"
+        nm_discard_fix="Let the run finish (or abort it), then re-check with 'no-mistakes axi status'; follow the branch_sync.next_action it reports." ;;
+    esac
+    if [ "$FORCE" = "--force" ]; then
+      echo "DISCARDING UNLANDED WORK: $nm_discard_why." >&2
+      echo "Proceeding because --force was passed. Treat --force here as your explicit authorization to discard THIS work ($nm_discard_what) - it is not a convenience bypass, and teardown is about to make it unrecoverable." >&2
+      echo "Recording the discard in $NM_DISCARD_LOG." >&2
+      record_discarded_pipeline_commits "$NM_TEARDOWN_UNRECOVERED_REASON" \
+        "$NM_TEARDOWN_UNRECOVERED_BRANCH" "$NM_TEARDOWN_UNRECOVERED_HEAD" "$WT"
     else
-      echo "REFUSED: no-mistakes run for $ID left pipeline-committed work in the gate that never reached this worktree ($WT); run 'no-mistakes axi sync --recover' there to land it, or discard it with explicit authority via --force, before retrying teardown." >&2
+      echo "REFUSED: $nm_discard_why. Removing the worktree now would make it unrecoverable, so teardown stops instead." >&2
+      echo "$nm_discard_fix" >&2
+      echo "Or, to discard it deliberately, re-run with --force: for this refusal --force is your explicit authorization to throw away THIS work ($nm_discard_what), not a convenience bypass, and the discard is recorded in $NM_DISCARD_LOG." >&2
+      exit 1
     fi
-    exit 1
   fi
   reap_task_worktree_processes worktree "$WT" "$TASK_TMP"
 fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -147,15 +147,35 @@
 #     "parked", skips the check entirely, and destroys the worktree anyway.
 #     Re-reading `axi status` fresh on every invocation, with no memory of a
 #     prior attempt, makes the refusal idempotent by construction: attempt 2,
-#     3, or 10 sees the same unrecovered `recover_custody` state and refuses
-#     identically until the operator actually runs `no-mistakes axi sync
-#     --recover` (landing it, so the worktree's own `git status` now sees it
-#     as ordinary uncommitted-then-committed history) or discards it with
-#     explicit authority. Like the still-parked refusal above, `--force` does
-#     NOT bypass this - unrecovered pipeline commits are unlanded work, and
-#     hard rule 3 never discards that without the captain's explicit word for
-#     that specific discard; the only route past it is the same one available
-#     without `--force` at all (recover it, or resolve it outside teardown).
+#     3, or 10 sees the same unrecovered state and refuses identically until
+#     the operator actually runs `no-mistakes axi sync --recover` (landing it,
+#     so the worktree's own `git status` now sees it as ordinary committed
+#     history) or discards it with explicit authority. Its contract, tightened
+#     by the second review round (2026-08-29):
+#       - It does NOT wait for a cancellation. `recover_custody` is only the
+#         POST-TERMINAL shape. The same stranding happens with nothing aborted
+#         at all: a live pipeline_owned run whose branch_sync.pipeline
+#         .current_head is not reachable from this worktree's HEAD is holding
+#         a gate-repo commit this checkout has never seen. Either condition
+#         alone refuses.
+#       - It FAILS CLOSED. This precondition stands immediately before an
+#         irreversible step (branch delete plus worktree return), so unlike
+#         task_run_is_own_parked_run's fail-open residual there is no "caught
+#         on the next retry" - the fail-opening invocation is the one that
+#         destroys the evidence. Any query failure (daemon error, timeout
+#         expiry, or no timeout/gtimeout/perl on PATH to bound the call with)
+#         refuses. Only a query that SUCCEEDS can clear the worktree.
+#       - It attributes by identity, not by branch name alone, reusing
+#         bin/fm-nm-run-lib.sh's fm_nm_head_matches_worktree (against the run
+#         head or the daemon's own branch_sync.local.head reading of this
+#         checkout) and the fm_nm_run_is_pipeline_owned_active exemption. A
+#         reused task slug can otherwise hand this checkout a stale foreign
+#         run record carrying the same branch name.
+#       - `--force` is the ONE escape hatch, exactly as it is for
+#         validate_worktree_teardown_safety above: hard rule 3 never discards
+#         unlanded work without the captain's explicit word, and passing
+#         --force here IS that word for this specific discard. Nothing else
+#         bypasses the refusal - not a query failure, not a retry.
 #   Fix 2 - reap leaked descendant processes. A backgrounded/disowned process
 #     started under the worktree (or its per-task tasktmp) does not receive the
 #     SIGHUP/SIGTERM that closing the backend pane sends to its own foreground
@@ -1590,32 +1610,91 @@ conclude_task_no_mistakes_run() {  # <worktree>
   return 1
 }
 
-# Independent precondition (see header "Fix 1" for the full rationale): does
-# axi status, read fresh from worktree $1 for whatever run it currently
-# reports on this checked-out branch, show unrecovered pipeline-committed work
-# (branch_sync.next_action.code=recover_custody)? Deliberately separate from
-# conclude_task_no_mistakes_run above and from task_run_is_own_parked_run's
-# parked-only outcome filter - re-evaluated from scratch on every call with no
-# memory of a prior teardown attempt, so a retry after conclude_task_no_mistakes_run's
-# own abort (which sets outcome, so the run no longer "looks parked") still
-# sees the same unrecovered state and refuses identically. Fail-open on a
-# query failure, the same accepted residual task_run_is_own_parked_run already
-# takes above: making no-mistakes availability a hard prerequisite would block
-# every ship-task teardown whenever the daemon has a hiccup, and a real
-# unrecovered-commits case is caught again on the very next retry once it
-# answers.
+# Independent precondition (see header "Fix 1" for the full rationale): may
+# teardown of worktree $1 proceed, or is the pipeline holding committed work
+# that never reached this worktree? Returns 0 when teardown MUST REFUSE and
+# sets NM_TEARDOWN_UNRECOVERED_REASON to why; returns 1 only when a successful
+# query positively cleared this checkout.
+#
+# Deliberately separate from conclude_task_no_mistakes_run above and from
+# task_run_is_own_parked_run's parked-only outcome filter - re-evaluated from
+# scratch on every call with no memory of a prior teardown attempt, so a retry
+# after that abort (which sets outcome, so the run no longer "looks parked")
+# still sees the same unrecovered state and refuses identically.
+#
+# FAIL CLOSED on a query failure. This guard stands immediately before an
+# IRREVERSIBLE step (git branch -D plus the treehouse worktree return), so
+# task_run_is_own_parked_run's fail-open residual does not transfer: its cost
+# is a surviving parked run that a later retry still catches, while the
+# invocation that fail-opens HERE is the one that destroys the evidence, and
+# there is no later retry. A non-zero exit from the bounded call - daemon
+# error, NM_TEARDOWN_TIMEOUT expiry, or no timeout/gtimeout/perl on PATH for
+# fm_nm_run_bounded to bound with - therefore refuses. A SUCCESSFUL query is
+# authoritative: it reporting no run, or a run on another branch, or a
+# branch_sync the pipeline does not own, is an answer, not a failure.
+#
+# Two independent triggers, either of which refuses:
+#   - branch_sync.next_action.code=recover_custody: the post-terminal case,
+#     where the daemon itself names `axi sync --recover` as the way back.
+#   - branch_sync.state=pipeline_owned with a branch_sync.pipeline.current_head
+#     that is not reachable from this worktree's HEAD: the pipeline holds a
+#     commit this checkout has never seen. This fires BEFORE any cancellation,
+#     covering the live post-fix-round run whose lane head is a gate-repo
+#     commit - the shape that never reaches recover_custody at all because
+#     nothing aborted it. Unreachable includes unresolvable, so a head this
+#     worktree cannot even name refuses rather than passing.
+#
+# Attribution reuses bin/fm-nm-run-lib.sh's reviewed identity primitives
+# instead of trusting the branch name alone (a reused task slug can hand this
+# checkout a stale foreign run record for the same branch name, and a
+# refusal-only guard with no escape hatch would then wedge permanently):
+# fm_nm_head_matches_worktree against the run head or against the daemon's own
+# branch_sync.local.head reading of this checkout, or the
+# fm_nm_run_is_pipeline_owned_active exemption for the live in-flight case
+# where the pipeline's own head is legitimately not yet a git object here.
+NM_TEARDOWN_UNRECOVERED_REASON=
 worktree_has_unrecovered_pipeline_commits() {  # <worktree>
-  local wt=$1 out branch run_branch
+  local wt=$1 out rc=0 branch run_branch run_head local_head pipeline_head
+  NM_TEARDOWN_UNRECOVERED_REASON=
   [ "$KIND" = ship ] || return 1
   [ -d "$wt" ] || return 1
+  # --force is the captain's explicit, deliberate authorization to discard this
+  # worktree, and it is the ONLY bypass: every path below refuses without it,
+  # including the query-failure path.
+  [ "$FORCE" != "--force" ] || return 1
   command -v no-mistakes >/dev/null 2>&1 || return 1
   branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
   [ -n "$branch" ] || return 1
-  out=$(fm_nm_run "$wt" "$NM_TEARDOWN_TIMEOUT" axi status)
-  [ -n "$out" ] || return 1
+
+  out=$(fm_nm_run_checked "$wt" "$NM_TEARDOWN_TIMEOUT" axi status) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    NM_TEARDOWN_UNRECOVERED_REASON=query-failed
+    return 0
+  fi
+
   run_branch=$(fm_nm_strip_quotes "$(fm_nm_field "$out" branch)")
   [ -n "$run_branch" ] && [ "$run_branch" = "$branch" ] || return 1
-  [ "$(fm_nm_branch_sync_next_action_code "$out")" = recover_custody ]
+
+  run_head=$(fm_nm_strip_quotes "$(fm_nm_field "$out" head)")
+  local_head=$(fm_nm_branch_sync_local_head "$out")
+  fm_nm_head_matches_worktree "$wt" "$run_head" \
+    || fm_nm_head_matches_worktree "$wt" "$local_head" \
+    || fm_nm_run_is_pipeline_owned_active "$out" \
+    || return 1
+
+  if [ "$(fm_nm_branch_sync_next_action_code "$out")" = recover_custody ]; then
+    NM_TEARDOWN_UNRECOVERED_REASON=recover_custody
+    return 0
+  fi
+  if [ "$(fm_nm_branch_sync_state "$out")" = pipeline_owned ]; then
+    pipeline_head=$(fm_nm_branch_sync_pipeline_current_head "$out")
+    if [ -n "$pipeline_head" ] \
+       && ! git -C "$wt" merge-base --is-ancestor "$pipeline_head" HEAD 2>/dev/null; then
+      NM_TEARDOWN_UNRECOVERED_REASON=pipeline-ahead
+      return 0
+    fi
+  fi
+  return 1
 }
 
 # Fix 2 (see script header): pids of every process whose CURRENT WORKING
@@ -2745,7 +2824,11 @@ fi
 if [ "$KIND" != secondmate ]; then
   conclude_task_no_mistakes_run "$WT"
   if worktree_has_unrecovered_pipeline_commits "$WT"; then
-    echo "REFUSED: no-mistakes run for $ID left pipeline-committed work in the gate that never reached this worktree ($WT); run 'no-mistakes axi sync --recover' there to land it, or discard it with explicit authority, before retrying teardown." >&2
+    if [ "$NM_TEARDOWN_UNRECOVERED_REASON" = query-failed ]; then
+      echo "REFUSED: cannot ask no-mistakes whether the run for $ID left pipeline-committed work that never reached this worktree ($WT); 'no-mistakes axi status' there did not answer. Removing the worktree now would destroy the only evidence, so teardown stops instead. Retry once it answers, or discard the worktree with explicit authority via --force." >&2
+    else
+      echo "REFUSED: no-mistakes run for $ID left pipeline-committed work in the gate that never reached this worktree ($WT); run 'no-mistakes axi sync --recover' there to land it, or discard it with explicit authority via --force, before retrying teardown." >&2
+    fi
     exit 1
   fi
   reap_task_worktree_processes worktree "$WT" "$TASK_TMP"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1847,9 +1847,43 @@ NM_DISCARD_LOG="$STATE/.discarded-pipeline-commits.log"
 NM_DISCARD_LOG_LOCK="$STATE/.discarded-pipeline-commits.lock"
 NM_DISCARD_LOG_MAX_BYTES=${FM_DISCARD_LOG_MAX_BYTES:-262144}
 case "$NM_DISCARD_LOG_MAX_BYTES" in ''|*[!0-9]*|0) NM_DISCARD_LOG_MAX_BYTES=262144 ;; esac
+# Does $STATE still accept new entries? fm_lock_acquire_wait cannot answer
+# that: it spins until fm_lock_try_acquire succeeds and never returns non-zero,
+# and fm_lock_try_acquire itself cannot fail cleanly when the directory refuses
+# new entries - mktemp for the owner dir fails, so it falls through to the
+# stale-owner steal and recurses on "$lockdir.steal", ".steal.steal", ... So the
+# same mktemp the lock would do is attempted here first, and its own error text
+# is what names the concrete cause. Without this, a $STATE that went read-only
+# or filled up AFTER teardown started (the control lock proves it was writable
+# at startup) turns the refusal below into a hang that holds
+# "$STATE/.control-$ID.lock" until the process is killed, wedging every later
+# lifecycle action for the task.
+NM_DISCARD_LOG_WRITE_ERROR=
+nm_discard_log_dir_accepts_writes() {
+  local probe
+  NM_DISCARD_LOG_WRITE_ERROR=
+  if probe=$(mktemp -d "$NM_DISCARD_LOG_LOCK.probe.XXXXXX" 2>&1); then
+    rmdir "$probe" 2>/dev/null || true
+    return 0
+  fi
+  NM_DISCARD_LOG_WRITE_ERROR=$(printf '%s' "$probe" | tr '\n' ' ')
+  [ -n "$NM_DISCARD_LOG_WRITE_ERROR" ] \
+    || NM_DISCARD_LOG_WRITE_ERROR="mktemp could not create a directory in $STATE"
+  return 1
+}
+
 record_discarded_pipeline_commits() {  # <reason> <branch> <pipeline-head> <worktree>
   local sz rc=0
-  fm_lock_acquire_wait "$NM_DISCARD_LOG_LOCK" || return 1
+  # Re-probed on every pass, not once before the wait: the directory can go
+  # unwritable while this loop is parked behind another task's forced discard,
+  # and entering fm_lock_try_acquire after that is the unbounded-recursion case.
+  until nm_discard_log_dir_accepts_writes && fm_lock_try_acquire "$NM_DISCARD_LOG_LOCK"; do
+    if [ -n "$NM_DISCARD_LOG_WRITE_ERROR" ]; then
+      echo "Cannot take the discard-log lock $NM_DISCARD_LOG_LOCK: $NM_DISCARD_LOG_WRITE_ERROR" >&2
+      return 1
+    fi
+    sleep 0.1
+  done
   printf '[%s] task=%s reason=%s branch=%s pipeline_head=%s worktree=%s\n' \
     "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$ID" "${1:-unknown}" "${2:-unknown}" \
     "${3:-unknown}" "${4:-unknown}" >> "$NM_DISCARD_LOG" || rc=1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -132,16 +132,30 @@
 #     gate with `--action fix` and was removed before answering the resulting
 #     fix-review gate) commits that round in the daemon's own gate-repo clone,
 #     never in this worktree - reproduced live 2026-08-29: aborting such a run
-#     leaves `axi status --run <id>`'s branch_sync.next_action.code set to
+#     leaves `axi status`'s branch_sync.next_action.code set to
 #     `recover_custody`, meaning the commit exists only in the gate and this
 #     worktree's own git log never advanced past the pre-fix head. Removing the
 #     worktree at that point is unlanded-work loss no `git status` check here
 #     ever sees, because the work was never in this worktree to begin with.
-#     conclude_task_no_mistakes_run therefore refuses when abort's confirming
-#     `axi status` still reports `recover_custody`, the same fail-closed shape
-#     as the still-parked refusal below, so the operator runs `no-mistakes axi
-#     sync --recover` to land the commit (or discards it with explicit
-#     authority) before worktree removal can proceed.
+#     worktree_has_unrecovered_pipeline_commits (below) is a SEPARATE, always-
+#     evaluated precondition guarding exactly this - not a tail branch of the
+#     abort above, and deliberately not gated by task_run_is_own_parked_run's
+#     parked-only outcome filter: a first review round (2026-08-29) caught that
+#     an abort-tail-branch version only protects the FIRST teardown attempt,
+#     because its own successful abort sets `outcome`, so a retry - the actual
+#     path a supervisor takes after this exact refusal - no longer reads as
+#     "parked", skips the check entirely, and destroys the worktree anyway.
+#     Re-reading `axi status` fresh on every invocation, with no memory of a
+#     prior attempt, makes the refusal idempotent by construction: attempt 2,
+#     3, or 10 sees the same unrecovered `recover_custody` state and refuses
+#     identically until the operator actually runs `no-mistakes axi sync
+#     --recover` (landing it, so the worktree's own `git status` now sees it
+#     as ordinary uncommitted-then-committed history) or discards it with
+#     explicit authority. Like the still-parked refusal above, `--force` does
+#     NOT bypass this - unrecovered pipeline commits are unlanded work, and
+#     hard rule 3 never discards that without the captain's explicit word for
+#     that specific discard; the only route past it is the same one available
+#     without `--force` at all (recover it, or resolve it outside teardown).
 #   Fix 2 - reap leaked descendant processes. A backgrounded/disowned process
 #     started under the worktree (or its per-task tasktmp) does not receive the
 #     SIGHUP/SIGTERM that closing the backend pane sends to its own foreground
@@ -1557,7 +1571,7 @@ task_status_is_run_not_found() {  # <status-error> <run-id>
 # worktree (scouts and secondmates never do, mirroring bin/fm-crew-state.sh);
 # a run not attributed to this exact branch+head is left completely alone.
 conclude_task_no_mistakes_run() {  # <worktree>
-  local wt=$1 out run_id next_action
+  local wt=$1 out run_id
   [ "$KIND" = ship ] || return 0
   [ -d "$wt" ] || return 0
   command -v no-mistakes >/dev/null 2>&1 || return 0
@@ -1568,19 +1582,40 @@ conclude_task_no_mistakes_run() {  # <worktree>
   # live-state condition; fully closing the resume race needs upstream compare-and-cancel.
   fm_nm_run_checked "$wt" "$NM_TEARDOWN_TIMEOUT" axi abort --run "$run_id" >/dev/null 2>&1 || true
   if out=$(fm_nm_run_bounded "$wt" "$NM_TEARDOWN_TIMEOUT" axi status --run "$run_id" 2>&1); then
-    if task_status_is_terminal_run "$out" "$run_id"; then
-      next_action=$(fm_nm_branch_sync_next_action_code "$out")
-      if [ "$next_action" = recover_custody ]; then
-        echo "REFUSED: no-mistakes run for $ID left pipeline-committed work in the gate that never reached this worktree ($wt); run 'no-mistakes axi sync --recover' there to land it, or discard it with explicit authority, before retrying teardown." >&2
-        return 1
-      fi
-      return 0
-    fi
+    task_status_is_terminal_run "$out" "$run_id" && return 0
   elif task_status_is_run_not_found "$out" "$run_id"; then
     return 0
   fi
   echo "REFUSED: no-mistakes run for $ID is still parked after axi abort; confirm it stopped (no-mistakes axi status) or abort it manually (no-mistakes axi abort --run <id>) before retrying teardown." >&2
   return 1
+}
+
+# Independent precondition (see header "Fix 1" for the full rationale): does
+# axi status, read fresh from worktree $1 for whatever run it currently
+# reports on this checked-out branch, show unrecovered pipeline-committed work
+# (branch_sync.next_action.code=recover_custody)? Deliberately separate from
+# conclude_task_no_mistakes_run above and from task_run_is_own_parked_run's
+# parked-only outcome filter - re-evaluated from scratch on every call with no
+# memory of a prior teardown attempt, so a retry after conclude_task_no_mistakes_run's
+# own abort (which sets outcome, so the run no longer "looks parked") still
+# sees the same unrecovered state and refuses identically. Fail-open on a
+# query failure, the same accepted residual task_run_is_own_parked_run already
+# takes above: making no-mistakes availability a hard prerequisite would block
+# every ship-task teardown whenever the daemon has a hiccup, and a real
+# unrecovered-commits case is caught again on the very next retry once it
+# answers.
+worktree_has_unrecovered_pipeline_commits() {  # <worktree>
+  local wt=$1 out branch run_branch
+  [ "$KIND" = ship ] || return 1
+  [ -d "$wt" ] || return 1
+  command -v no-mistakes >/dev/null 2>&1 || return 1
+  branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
+  [ -n "$branch" ] || return 1
+  out=$(fm_nm_run "$wt" "$NM_TEARDOWN_TIMEOUT" axi status)
+  [ -n "$out" ] || return 1
+  run_branch=$(fm_nm_strip_quotes "$(fm_nm_field "$out" branch)")
+  [ -n "$run_branch" ] && [ "$run_branch" = "$branch" ] || return 1
+  [ "$(fm_nm_branch_sync_next_action_code "$out")" = recover_custody ]
 }
 
 # Fix 2 (see script header): pids of every process whose CURRENT WORKING
@@ -2698,6 +2733,27 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
     fi
   fi
 fi
+
+
+# Every landed/discard-work refusal above has now passed (or --force skipped
+# them). Fix 1 and Fix 2 (see script header) run here, unconditionally on
+# --force, and before ANY destructive step below - a still-parked run or a
+# leaked process can own live work in this exact worktree. Not for
+# kind=secondmate: a secondmate home's own runtime lifecycle is owned by the
+# dedicated process-event and firstmate-home removal machinery further below,
+# not by task-worktree cleanup.
+if [ "$KIND" != secondmate ]; then
+  conclude_task_no_mistakes_run "$WT"
+  if worktree_has_unrecovered_pipeline_commits "$WT"; then
+    echo "REFUSED: no-mistakes run for $ID left pipeline-committed work in the gate that never reached this worktree ($WT); run 'no-mistakes axi sync --recover' there to land it, or discard it with explicit authority, before retrying teardown." >&2
+    exit 1
+  fi
+  reap_task_worktree_processes worktree "$WT" "$TASK_TMP"
+fi
+
+# Fix 3 (see script header): sweep remote job workers abandoned by an already
+# pruned code root. Best effort - a sweep failure never blocks this teardown.
+"$SCRIPT_DIR/fm-remote-job-reap-orphans.sh" >&2 || true
 
 # A Herdr close may reposition shared workspace order, so the whole
 # destructive sequence below (worktree return, pane close, record removal)

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1853,15 +1853,15 @@ NM_DISCARD_LOG="$STATE/.discarded-pipeline-commits.log"
 NM_DISCARD_LOG_LOCK="$STATE/.discarded-pipeline-commits.lock"
 NM_DISCARD_LOG_MAX_BYTES=${FM_DISCARD_LOG_MAX_BYTES:-262144}
 case "$NM_DISCARD_LOG_MAX_BYTES" in ''|*[!0-9]*|0) NM_DISCARD_LOG_MAX_BYTES=262144 ;; esac
-# Does $STATE still accept new entries? fm_lock_acquire_wait cannot answer
-# that: it spins until fm_lock_try_acquire succeeds and never returns non-zero,
-# and fm_lock_try_acquire itself cannot fail cleanly when the directory refuses
-# new entries - mktemp for the owner dir fails, so it falls through to the
-# stale-owner steal and recurses on "$lockdir.steal", ".steal.steal", ... So the
-# same mktemp the lock would do is attempted here first, and its own error text
-# is what names the concrete cause. Without this, a $STATE that went read-only
-# or filled up AFTER teardown started (the control lock proves it was writable
-# at startup) turns the refusal below into a hang that holds
+# Does $STATE still accept new entries? Neither lock helper can answer that.
+# fm_lock_acquire_wait spins until fm_lock_try_acquire succeeds and never
+# returns non-zero, and fm_lock_try_acquire reports only "not acquired" - it
+# cannot distinguish a contended lock, which waiting resolves, from a directory
+# that refuses new entries, which waiting never resolves. So the same mktemp
+# the lock would do is attempted here first, and its own error text is what
+# names the concrete cause. Without this, a $STATE that went read-only or
+# filled up AFTER teardown started (the control lock proves it was writable at
+# startup) turns the refusal below into an endless retry loop holding
 # "$STATE/.control-$ID.lock" until the process is killed, wedging every later
 # lifecycle action for the task.
 NM_DISCARD_LOG_WRITE_ERROR=
@@ -1881,8 +1881,12 @@ nm_discard_log_dir_accepts_writes() {
 record_discarded_pipeline_commits() {  # <reason> <branch> <pipeline-head> <worktree>
   local sz rc=0
   # Re-probed on every pass, not once before the wait: the directory can go
-  # unwritable while this loop is parked behind another task's forced discard,
-  # and entering fm_lock_try_acquire after that is the unbounded-recursion case.
+  # unwritable at any point after a probe has already passed - while this loop
+  # is parked behind another task's forced discard, or inside the window
+  # between the probe and the acquire on this very pass. fm_lock_try_acquire
+  # then just reports "not acquired", indistinguishable from contention, so
+  # without a re-probe the loop would spin here forever holding the control
+  # lock. Re-probing turns the very next pass into the named refusal below.
   until nm_discard_log_dir_accepts_writes && fm_lock_try_acquire "$NM_DISCARD_LOG_LOCK"; do
     if [ -n "$NM_DISCARD_LOG_WRITE_ERROR" ]; then
       echo "Cannot take the discard-log lock $NM_DISCARD_LOG_LOCK: $NM_DISCARD_LOG_WRITE_ERROR" >&2

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1826,26 +1826,48 @@ worktree_has_unrecovered_pipeline_commits() {  # <worktree>
 # NOT its best-effort contract: that log is supervision telemetry a lost line
 # costs nothing, while this one is the only surviving trace of destroyed work.
 # So the append is REQUIRED - a failure returns non-zero and the caller stops
-# before destroying anything. Only the size rotation stays best-effort, since
-# failing to trim cannot lose the line just written. Deliberately NOT keyed
-# under "$STATE/$ID." - teardown erases those, and this record has to outlive
-# the task whose commit it names.
+# before destroying anything. Deliberately NOT keyed under "$STATE/$ID." -
+# teardown erases those, and this record has to outlive the task whose commit
+# it names.
+#
+# The rotation is NOT best-effort with respect to OTHER tasks' appends: it
+# reads the whole file then replaces it wholesale (tail | mv), which is a
+# read-modify-write, not an append. Two different tasks' forced teardowns can
+# call this concurrently - there is no other lock shared across tasks that
+# would serialize them - and an append that already returned success can still
+# be wiped out: task A appends, sees the size threshold crossed, and starts
+# tail-then-mv; task B appends its own line to the live file in the gap
+# between A's tail read and A's mv; A's mv then replaces the file with its
+# stale pre-B snapshot, silently discarding B's already-acknowledged record.
+# That defeats the one property this log exists for - a --force discard must
+# leave a surviving trace - so the whole append-plus-rotate section is one
+# critical section under a fleet-wide lock, not just individually atomic
+# pieces.
 NM_DISCARD_LOG="$STATE/.discarded-pipeline-commits.log"
+NM_DISCARD_LOG_LOCK="$STATE/.discarded-pipeline-commits.lock"
 NM_DISCARD_LOG_MAX_BYTES=${FM_DISCARD_LOG_MAX_BYTES:-262144}
 case "$NM_DISCARD_LOG_MAX_BYTES" in ''|*[!0-9]*|0) NM_DISCARD_LOG_MAX_BYTES=262144 ;; esac
 record_discarded_pipeline_commits() {  # <reason> <branch> <pipeline-head> <worktree>
-  local sz
+  local sz rc=0
+  fm_lock_acquire_wait "$NM_DISCARD_LOG_LOCK" || return 1
   printf '[%s] task=%s reason=%s branch=%s pipeline_head=%s worktree=%s\n' \
     "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$ID" "${1:-unknown}" "${2:-unknown}" \
-    "${3:-unknown}" "${4:-unknown}" >> "$NM_DISCARD_LOG" || return 1
-  sz=$(wc -c < "$NM_DISCARD_LOG" 2>/dev/null | tr -d '[:space:]')
-  case "$sz" in ''|*[!0-9]*) return 0 ;; esac
-  if [ "$sz" -ge "$NM_DISCARD_LOG_MAX_BYTES" ]; then
-    tail -n 2000 "$NM_DISCARD_LOG" > "$NM_DISCARD_LOG.tmp" 2>/dev/null \
-      && mv -f "$NM_DISCARD_LOG.tmp" "$NM_DISCARD_LOG" 2>/dev/null
-    rm -f "$NM_DISCARD_LOG.tmp" 2>/dev/null || true
+    "${3:-unknown}" "${4:-unknown}" >> "$NM_DISCARD_LOG" || rc=1
+  if [ "$rc" -eq 0 ]; then
+    sz=$(wc -c < "$NM_DISCARD_LOG" 2>/dev/null | tr -d '[:space:]')
+    case "$sz" in
+      ''|*[!0-9]*) : ;;
+      *)
+        if [ "$sz" -ge "$NM_DISCARD_LOG_MAX_BYTES" ]; then
+          tail -n 2000 "$NM_DISCARD_LOG" > "$NM_DISCARD_LOG.tmp" 2>/dev/null \
+            && mv -f "$NM_DISCARD_LOG.tmp" "$NM_DISCARD_LOG" 2>/dev/null
+          rm -f "$NM_DISCARD_LOG.tmp" 2>/dev/null || true
+        fi
+        ;;
+    esac
   fi
-  return 0
+  fm_lock_release "$NM_DISCARD_LOG_LOCK"
+  return "$rc"
 }
 
 # Fix 2 (see script header): pids of every process whose CURRENT WORKING

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -801,6 +801,20 @@ fm_lock_try_acquire() {
     return 0
   fi
 
+  # A create failure with NO lock present at all is not contention: the owner
+  # dir or its pid file could not be created (a $STATE that went read-only or
+  # full), or a symlink race was lost. Everything below reclaims an EXISTING
+  # stale owner, and it does that through a helper lock at "$lockdir.steal"
+  # taken via this same function - so when creation is impossible, every level
+  # fails identically and the "steal" recursion walks ".steal", ".steal.steal",
+  # ... without end. That turns a bounded "try" into an unbounded hang for
+  # every caller, including ones holding a task's control lock. There is no
+  # owner to reclaim here, so refuse and let the caller decide - a contract
+  # every caller already handles.
+  if [ ! -e "$lockdir" ] && [ ! -L "$lockdir" ]; then
+    return 1
+  fi
+
   # Compare against ${BASHPID:-$$} inline, never via a command substitution:
   # $() forks a subshell whose BASHPID is not this frame's pid.
   pid=$(cat "$lockdir/pid" 2>/dev/null || true)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -299,7 +299,8 @@ Every GitHub refusal states what it could not observe as plainly as what it did,
 A confirmed merge leaves a durable role-routed outcome instead of living only in the merging agent's memory, and [`bin/fm-merge-outcome-lib.sh`](../bin/fm-merge-outcome-lib.sh)'s header owns its destination, shape, identity, normal-case deduplication, and at-least-once recovery.
 The same emitter handles a merge firstmate performed and one its poll detected, while the watcher immediately delivers the emitter's local actionable poll row.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
-[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
+That safety reaches past the worktree's own history: where the local `no-mistakes` tracking ref shows the branch was gated, teardown also refuses while the pipeline still holds commits this checkout has never seen, and a `--force` discard of them is announced and appended to the fleet-wide `state/.discarded-pipeline-commits.log` before anything is removed.
+[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, the unrecovered-pipeline-commit precondition, the PR-discovery fallback, and the stale-lock recovery procedure.
 
 ## Optional Relay
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -816,6 +816,7 @@ FM_WHEN_OUTPUT_TAIL_BYTES=8192          # bound on the command-output tail insid
 FM_CODEX_WATCH_CHECKPOINT=180   # seconds per foreground watcher checkpoint in Codex primary supervision
 FM_CREW_STATE_NM_TIMEOUT=10   # seconds allowed per no-mistakes query inside fm-crew-state.sh
 FM_TEARDOWN_NM_TIMEOUT=10    # seconds allowed per no-mistakes query or abort inside fm-teardown.sh
+FM_DISCARD_LOG_MAX_BYTES=262144   # size cap for state/.discarded-pipeline-commits.log, fm-teardown.sh's durable record of unlanded or unverified no-mistakes pipeline work discarded under --force, before it is trimmed to the newest 2000 lines; invalid or zero values use 262144
 FM_CREW_STATE_RUNS_LIMIT=200  # recent no-mistakes run rows scanned when axi status cannot be attributed directly
 FM_CREW_STATE_BIN=bin/fm-crew-state.sh   # test override for the current-state reader used by working/paused watcher triage
 FMX_PAIRING_TOKEN=      # Relay pairing token; .env opt-in authorizes replies and eligible lifecycle actions

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -2084,6 +2084,63 @@ test_parked_own_run_is_aborted_before_teardown() {
   pass "a task's own parked no-mistakes run is aborted, not orphaned, before the worker is removed"
 }
 
+# A terminal (aborted) `axi status --run <id>` payload whose branch_sync block
+# reports recover_custody: the shape observed live 2026-08-29 when a run is
+# aborted after a fix round already committed in the daemon's own gate-repo
+# clone, before that commit ever reached this worktree's branch.
+recover_custody_axi_status_toon() {  # <branch> <head> [run-id]
+  cat <<EOF
+run:
+  id: "${3:-01RUN}"
+  branch: $1
+  status: cancelled
+  head: fix0head
+  findings: 1 info
+outcome: cancelled
+error: "cancelled: aborted by user"
+branch_sync:
+  state: pipeline_owned
+  changed: false
+  local:
+    branch: $1
+    head: "$2"
+    clean: true
+  pipeline:
+    run: "${3:-01RUN}"
+    status: cancelled
+    current_head: fix0head
+  safety: blocked_pipeline_owned_recoverable
+  next_action:
+    code: recover_custody
+    command: no-mistakes axi sync --recover
+EOF
+}
+
+test_parked_run_abort_leaves_unrecovered_commits_refuses() {
+  local case_dir rc head
+  case_dir=$(make_case parked-run-recover-custody)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  head=$(git -C "$case_dir/wt" rev-parse HEAD)
+
+  local rc=0
+  FM_FAKE_AXI_STATUS="$(parked_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_AXI_STATUS_AFTER_ABORT="$(recover_custody_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 1 "$rc" "parked-run-recover-custody: teardown should refuse rather than strand pipeline-committed work"
+  assert_grep "abort --run 01RUN" "$case_dir/nm-abort.log" \
+    "parked-run-recover-custody: teardown did not abort the run before checking for unrecovered work"
+  assert_grep "axi sync --recover" "$case_dir/stderr" \
+    "parked-run-recover-custody: teardown did not tell the operator how to land the preserved commit"
+  assert_present "$case_dir/wt" \
+    "parked-run-recover-custody: teardown removed the worktree while pipeline-committed work was still unrecovered"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "parked-run-recover-custody: teardown removed task metadata while pipeline-committed work was still unrecovered"
+  pass "teardown refuses to remove a worktree when the aborted run left commits only in the gate"
+}
+
 test_mismatched_run_after_abort_refuses_unconfirmed() {
   local case_dir rc head
   case_dir=$(make_case parked-run-replaced)
@@ -2647,6 +2704,7 @@ test_persistent_index_lock_exhausts_retries_and_refuses_loudly
 test_empty_retry_wait_uses_default_without_aborting
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
 test_parked_own_run_is_aborted_before_teardown
+test_parked_run_abort_leaves_unrecovered_commits_refuses
 test_parked_own_run_refuses_when_abort_is_unconfirmed
 test_mismatched_run_after_abort_refuses_unconfirmed
 test_empty_status_after_abort_refuses_unconfirmed

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -116,6 +116,15 @@ SH
   # `command -v no-mistakes` would fall through to whatever real binary
   # happens to be on the test runner's own PATH. Tests exercising the run-abort
   # path override FM_FAKE_AXI_STATUS/FM_FAKE_NM_ABORT_LOG before run_teardown.
+  #
+  # A bare `axi status` (no --run) reads as "aborted" once ANY abort line was
+  # logged, not just an exact `--run <this-id>` match: the real CLI's bare
+  # status always reports whatever run is currently active-or-most-recent for
+  # the checked-out branch, so once that run is aborted a later bare call
+  # keeps reflecting it - verified live 2026-08-29. This is what lets
+  # worktree_has_unrecovered_pipeline_commits's precondition (bin/fm-teardown.sh)
+  # see the same still-unrecovered state on a second, unrelated teardown
+  # invocation that never re-discovers or re-passes the run id.
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 case "${1:-}" in
@@ -126,9 +135,15 @@ case "${1:-}" in
         shift
         run_id=""
         if [ "${1:-}" = --run ]; then run_id=${2:-}; fi
-        if [ -n "${FM_FAKE_NM_ABORT_LOG:-}" ] \
-           && grep -Fxq "abort --run $run_id" "$FM_FAKE_NM_ABORT_LOG" 2>/dev/null \
-           && [ "${FM_FAKE_NM_ABORT_NOOP:-0}" != 1 ]; then
+        aborted=0
+        if [ -n "${FM_FAKE_NM_ABORT_LOG:-}" ]; then
+          if [ -n "$run_id" ]; then
+            grep -Fxq "abort --run $run_id" "$FM_FAKE_NM_ABORT_LOG" 2>/dev/null && aborted=1
+          else
+            grep -Eq '^abort --run ' "$FM_FAKE_NM_ABORT_LOG" 2>/dev/null && aborted=1
+          fi
+        fi
+        if [ "$aborted" = 1 ] && [ "${FM_FAKE_NM_ABORT_NOOP:-0}" != 1 ]; then
           if [ "${FM_FAKE_NM_NOT_FOUND_AFTER_ABORT:-0}" = 1 ]; then
             printf 'error: "run \\"%s\\" not found"\n' "$run_id" >&2
             exit 1
@@ -2116,29 +2131,80 @@ branch_sync:
 EOF
 }
 
+# The reviewer's exact reproduction (2026-08-29): an abort-tail-branch version
+# of this guard only protects the FIRST teardown attempt, because its own
+# successful abort sets `outcome`, and a retry - the real path a supervisor
+# takes right after this exact refusal - no longer reads as "parked" and
+# skips the check entirely. Drives teardown twice in a row against the same
+# case and asserts the SECOND call refuses identically, with the worktree and
+# task metadata still present after both.
 test_parked_run_abort_leaves_unrecovered_commits_refuses() {
-  local case_dir rc head
+  local case_dir rc1 rc2 head
   case_dir=$(make_case parked-run-recover-custody)
   write_meta "$case_dir" no-mistakes ship
   land_shippable_commit "$case_dir"
   head=$(git -C "$case_dir/wt" rev-parse HEAD)
 
-  local rc=0
+  rc1=0
   FM_FAKE_AXI_STATUS="$(parked_axi_status_toon fm/task-x1 "$head")" \
   FM_FAKE_AXI_STATUS_AFTER_ABORT="$(recover_custody_axi_status_toon fm/task-x1 "$head")" \
   FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
-    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+    run_teardown "$case_dir" > "$case_dir/stdout.1" 2> "$case_dir/stderr.1" || rc1=$?
 
-  expect_code 1 "$rc" "parked-run-recover-custody: teardown should refuse rather than strand pipeline-committed work"
+  expect_code 1 "$rc1" "parked-run-recover-custody: first teardown attempt should refuse rather than strand pipeline-committed work"
   assert_grep "abort --run 01RUN" "$case_dir/nm-abort.log" \
-    "parked-run-recover-custody: teardown did not abort the run before checking for unrecovered work"
-  assert_grep "axi sync --recover" "$case_dir/stderr" \
-    "parked-run-recover-custody: teardown did not tell the operator how to land the preserved commit"
+    "parked-run-recover-custody: first attempt did not abort the run before checking for unrecovered work"
+  assert_grep "axi sync --recover" "$case_dir/stderr.1" \
+    "parked-run-recover-custody: first attempt did not tell the operator how to land the preserved commit"
   assert_present "$case_dir/wt" \
-    "parked-run-recover-custody: teardown removed the worktree while pipeline-committed work was still unrecovered"
+    "parked-run-recover-custody: first attempt removed the worktree while pipeline-committed work was still unrecovered"
+
+  # Retry exactly as a supervisor would after that refusal. The run is now
+  # terminal (outcome=cancelled from the first attempt's own abort), so
+  # task_status_is_own_parked_run no longer reads it as parked - this is the
+  # bypass the reviewer found, and the precondition must catch it anyway.
+  rc2=0
+  FM_FAKE_AXI_STATUS="$(parked_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_AXI_STATUS_AFTER_ABORT="$(recover_custody_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout.2" 2> "$case_dir/stderr.2" || rc2=$?
+
+  expect_code 1 "$rc2" "parked-run-recover-custody: SECOND teardown attempt should refuse identically, not silently destroy the worktree"
+  assert_grep "axi sync --recover" "$case_dir/stderr.2" \
+    "parked-run-recover-custody: second attempt did not tell the operator how to land the preserved commit"
+  assert_present "$case_dir/wt" \
+    "parked-run-recover-custody: second attempt removed the worktree while pipeline-committed work was still unrecovered"
   assert_present "$case_dir/state/task-x1.meta" \
-    "parked-run-recover-custody: teardown removed task metadata while pipeline-committed work was still unrecovered"
-  pass "teardown refuses to remove a worktree when the aborted run left commits only in the gate"
+    "parked-run-recover-custody: second attempt removed task metadata while pipeline-committed work was still unrecovered"
+  [ "$(git -C "$case_dir/wt" rev-parse HEAD)" = "$head" ] \
+    || fail "parked-run-recover-custody: worktree HEAD moved even though teardown refused both times"
+  pass "teardown refuses identically on a second attempt, so unrecovered pipeline commits are never silently stranded"
+}
+
+# --force skips validate_worktree_teardown_safety (the uncommitted/unpushed
+# checks) but must NOT skip this precondition: unrecovered pipeline commits
+# are unlanded work, and hard rule 3 never discards unlanded work without the
+# captain's explicit word for that specific discard - --force alone is a
+# different, broader escape hatch than that, so it must not double as this one.
+test_parked_run_abort_leaves_unrecovered_commits_refuses_under_force() {
+  local case_dir rc head
+  case_dir=$(make_case parked-run-recover-custody-force)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  head=$(git -C "$case_dir/wt" rev-parse HEAD)
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(parked_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_AXI_STATUS_AFTER_ABORT="$(recover_custody_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 1 "$rc" "parked-run-recover-custody-force: --force should still refuse rather than discard unrecovered pipeline commits"
+  assert_grep "axi sync --recover" "$case_dir/stderr" \
+    "parked-run-recover-custody-force: --force path did not tell the operator how to land the preserved commit"
+  assert_present "$case_dir/wt" \
+    "parked-run-recover-custody-force: --force removed the worktree while pipeline-committed work was still unrecovered"
+  pass "--force does not bypass the unrecovered-pipeline-commits refusal"
 }
 
 test_mismatched_run_after_abort_refuses_unconfirmed() {
@@ -2705,6 +2771,7 @@ test_empty_retry_wait_uses_default_without_aborting
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
 test_parked_own_run_is_aborted_before_teardown
 test_parked_run_abort_leaves_unrecovered_commits_refuses
+test_parked_run_abort_leaves_unrecovered_commits_refuses_under_force
 test_parked_own_run_refuses_when_abort_is_unconfirmed
 test_mismatched_run_after_abort_refuses_unconfirmed
 test_empty_status_after_abort_refuses_unconfirmed

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -583,13 +583,20 @@ backlog_row_state() {
     sed -n 's/^  state: *//p' | head -1
 }
 
-# Build the teardown test's executable search path without lsof, regardless of
-# whether the host installs it in /usr/bin, /usr/sbin, or a package-manager bin.
-make_path_without_lsof() {  # <case-dir>
-  local case_dir=$1 path_dir="$1/path-without-lsof" cmd resolved
+# Build the teardown test's executable search path with the named commands
+# left out, regardless of whether the host installs them in /usr/bin,
+# /usr/sbin, or a package-manager bin. One helper for every "teardown on a host
+# without X" case, so the command list cannot drift between them when teardown
+# picks up a new dependency.
+make_path_excluding() {  # <case-dir> <path-dir-name> <excluded-cmd>...
+  local case_dir=$1 path_dir="$1/$2" cmd resolved excluded
+  shift 2
   mkdir -p "$path_dir"
   for cmd in awk bash basename cat chmod cp cut date dirname env find git grep head hostname id ln \
-    mkdir mktemp mv perl ps readlink realpath rm sed sh sleep sort stat tail timeout tr uname wc xargs; do
+    lsof mkdir mktemp mv perl ps readlink realpath rm sed sh sleep sort stat tail timeout tr uname wc xargs; do
+    for excluded in "$@"; do
+      [ "$cmd" != "$excluded" ] || continue 2
+    done
     resolved=$(command -v "$cmd" 2>/dev/null) || continue
     case "$resolved" in /*) ln -sf "$resolved" "$path_dir/$cmd" ;; esac
   done
@@ -2344,20 +2351,9 @@ test_gated_branch_still_refuses_on_unanswerable_query() {
   pass "the same unanswerable query still refuses on a branch the gate demonstrably knows"
 }
 
-# Build a PATH with no timeout, gtimeout, or perl, so fm_nm_run_bounded has no
-# way to bound the CLI call at all - a condition it reports with the same bare
-# exit 1 as a genuine query failure, but which needs a completely different fix.
-make_path_without_bounded_tools() {  # <case-dir>
-  local case_dir=$1 path_dir="$1/path-without-bounded" cmd resolved
-  mkdir -p "$path_dir"
-  for cmd in awk bash basename cat chmod cp cut date dirname env find git grep head hostname id ln \
-    mkdir mktemp mv ps readlink realpath rm sed sh sleep sort stat tail tr uname wc xargs; do
-    resolved=$(command -v "$cmd" 2>/dev/null) || continue
-    case "$resolved" in /*) ln -sf "$resolved" "$path_dir/$cmd" ;; esac
-  done
-  printf '%s\n' "$path_dir"
-}
-
+# With no timeout, gtimeout, or perl on PATH, fm_nm_run_bounded has no way to
+# bound the CLI call at all - a condition it reports with the same bare exit 1
+# as a genuine query failure, but which needs a completely different fix.
 test_missing_bounded_execution_tool_is_named_in_the_refusal() {
   local case_dir rc head
   case_dir=$(make_case no-bounded-tool)
@@ -2367,7 +2363,7 @@ test_missing_bounded_execution_tool_is_named_in_the_refusal() {
   head=$(git -C "$case_dir/wt" rev-parse HEAD)
 
   rc=0
-  FM_TEARDOWN_TEST_PATH="$(make_path_without_bounded_tools "$case_dir")" \
+  FM_TEARDOWN_TEST_PATH="$(make_path_excluding "$case_dir" path-without-bounded timeout gtimeout perl)" \
   FM_FAKE_AXI_STATUS="$(recover_custody_axi_status_toon fm/task-x1 "$head")" \
   FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
     run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
@@ -2415,6 +2411,69 @@ test_unrecordable_discard_under_force_refuses() {
   assert_present "$case_dir/state/task-x1.meta" \
     "unrecordable-discard-force: teardown removed task metadata after refusing"
   pass "--force refuses when the durable discard record cannot be written, rather than destroying untraceable work"
+}
+
+# Model the window this refusal actually has to survive: $STATE was writable at
+# startup (teardown's own control lock proves it), then goes read-only or fills
+# up before the discard is recorded. Sealing it from the fake CLI's own bare
+# `axi status` puts the change exactly between the verification query and the
+# record write, with no cooperation from teardown itself.
+seal_state_dir_after_status_query() {  # <case-dir>
+  local case_dir=$1
+  mv "$case_dir/fakebin/no-mistakes" "$case_dir/fakebin/no-mistakes.inner"
+  cat > "$case_dir/fakebin/no-mistakes" <<EOF
+#!/usr/bin/env bash
+"$case_dir/fakebin/no-mistakes.inner" "\$@"
+rc=\$?
+[ "\$*" != "axi status" ] || chmod 555 "$case_dir/state"
+exit \$rc
+EOF
+  chmod +x "$case_dir/fakebin/no-mistakes"
+}
+
+# Regression (round 1 review): the durable record is taken under a fleet-wide
+# lock, and the lock library cannot report a failure to CREATE that lock - the
+# waiter loops until success, and the acquire recurses on <lock>.steal forever
+# when the directory refuses new entries. So an unwritable $STATE turned this
+# refusal into a hang that never released "$STATE/.control-<id>.lock", wedging
+# every later lifecycle action for the task. It must instead refuse promptly and
+# name the concrete cause. The whole run is time-bounded so a regression shows
+# up as a failure rather than a stuck suite.
+test_unwritable_state_refuses_promptly_instead_of_hanging() {
+  local case_dir rc head bound
+  case_dir=$(make_case unwritable-state-discard-force)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  log_treehouse_returns "$case_dir"
+  head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  seal_state_dir_after_status_query "$case_dir"
+
+  bound=$(command -v timeout || command -v gtimeout || true)
+  [ -n "$bound" ] || { pass "unwritable-state: skipped, no timeout available to bound the run"; return 0; }
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(recover_custody_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_CONFIG_OVERRIDE="$case_dir/config" \
+  PATH="$case_dir/fakebin:$PATH" \
+    "$bound" 30 "$TEARDOWN" task-x1 --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+  chmod 755 "$case_dir/state"
+
+  [ "$rc" -ne 124 ] || fail "unwritable-state: teardown hung on a lock it could never create instead of refusing"
+  expect_code 1 "$rc" "unwritable-state: an unrecordable discard must refuse"
+  assert_grep "Cannot take the discard-log lock" "$case_dir/stderr" \
+    "unwritable-state: the refusal did not name the concrete cause of the record-write failure"
+  assert_grep "Permission denied" "$case_dir/stderr" \
+    "unwritable-state: the refusal did not surface the underlying filesystem error"
+  assert_grep "REFUSED" "$case_dir/stderr" \
+    "unwritable-state: teardown did not refuse the unrecordable discard"
+  assert_absent "$case_dir/treehouse.log" \
+    "unwritable-state: teardown returned the worktree despite being unable to record the discard"
+  assert_present "$case_dir/wt" \
+    "unwritable-state: teardown removed the worktree it could not account for"
+  pass "an unwritable state refuses the forced discard promptly and names the cause, instead of hanging on the lock"
 }
 
 # A second ship worktree/branch/meta in the SAME case, so its forced teardown
@@ -2959,7 +3018,7 @@ test_lsof_absent_reaps_tmux_process_group() {
   case_dir=$(make_case lsof-absent-process-group-reap)
   write_meta "$case_dir" no-mistakes ship
   land_shippable_commit "$case_dir"
-  path_without_lsof=$(make_path_without_lsof "$case_dir")
+  path_without_lsof=$(make_path_excluding "$case_dir" path-without-lsof lsof)
   PATH="$path_without_lsof" command -v lsof >/dev/null 2>&1 \
     && fail "lsof-absent-process-group-reap: fixture path unexpectedly exposes lsof"
 
@@ -3336,6 +3395,7 @@ test_ungated_branch_tears_down_despite_unanswerable_query
 test_gated_branch_still_refuses_on_unanswerable_query
 test_missing_bounded_execution_tool_is_named_in_the_refusal
 test_unrecordable_discard_under_force_refuses
+test_unwritable_state_refuses_promptly_instead_of_hanging
 test_concurrent_forced_discards_do_not_lose_records
 test_live_pipeline_commit_ahead_of_worktree_refuses_before_any_abort
 test_terminal_pipeline_owned_run_gets_reachable_remedy_not_wait

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -2268,11 +2268,48 @@ test_unanswerable_status_query_under_force_is_loud_and_recorded() {
   expect_code 0 "$rc" "unrecovered-query-failure-force: --force authorizes the discard and teardown should complete"
   assert_present "$case_dir/treehouse.log" \
     "unrecovered-query-failure-force: --force did not reach the worktree return"
-  assert_grep "DISCARDING UNLANDED WORK" "$case_dir/stderr" \
-    "unrecovered-query-failure-force: teardown discarded an unverifiable worktree silently"
+  # The headline must not claim work was lost in the same breath as admitting
+  # teardown could not find out whether any exists.
+  assert_grep "DISCARDING UNVERIFIED WORKTREE" "$case_dir/stderr" \
+    "unrecovered-query-failure-force: teardown discarded an unverifiable worktree silently, or claimed more than it knew"
+  assert_not_contains "$(cat "$case_dir/stderr")" "DISCARDING UNLANDED WORK" \
+    "unrecovered-query-failure-force: teardown asserted lost work it never managed to verify"
   assert_grep "query-failed" "$case_dir/state/.discarded-pipeline-commits.log" \
     "unrecovered-query-failure-force: the unverifiable discard was not recorded durably"
   pass "an unanswerable status query under --force still announces and records what it could not verify"
+}
+
+# The durable record is the ONLY trace that survives the worktree, so it is a
+# precondition for the discard, not telemetry. If it cannot be written, --force
+# must stop rather than destroy work nothing afterwards can account for.
+# A directory standing where the log file goes makes every append fail the same
+# way a full or read-only $STATE would, without disturbing teardown's other
+# state writes.
+test_unrecordable_discard_under_force_refuses() {
+  local case_dir rc head
+  case_dir=$(make_case unrecordable-discard-force)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  log_treehouse_returns "$case_dir"
+  head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  mkdir -p "$case_dir/state/.discarded-pipeline-commits.log"
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(parked_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_AXI_STATUS_AFTER_ABORT="$(recover_custody_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 1 "$rc" "unrecordable-discard-force: --force must refuse when the discard cannot be recorded durably"
+  assert_grep "RECORD-WRITE failure" "$case_dir/stderr" \
+    "unrecordable-discard-force: teardown did not say which of the two checks failed"
+  assert_absent "$case_dir/treehouse.log" \
+    "unrecordable-discard-force: teardown returned the worktree despite being unable to record the discard"
+  assert_present "$case_dir/wt" \
+    "unrecordable-discard-force: teardown removed the worktree it could not account for"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "unrecordable-discard-force: teardown removed task metadata after refusing"
+  pass "--force refuses when the durable discard record cannot be written, rather than destroying untraceable work"
 }
 
 # The precondition guards an IRREVERSIBLE step, so a query that cannot answer
@@ -2373,6 +2410,62 @@ test_live_pipeline_commit_ahead_of_worktree_refuses_before_any_abort() {
 # carrying no content the worktree is missing. Ancestry alone calls that
 # stranded work; patch identity does not. Builds a real rebased copy (same
 # tree, same parent, different commit) so `git cherry` sees an equivalent.
+# branch_sync keeps reporting state=pipeline_owned after a cancellation - this
+# change's own recover_custody fixture shows that shape - so the pipeline-head
+# trigger fires for TERMINAL runs too, via the state arm rather than the active
+# arm. next_action.code is not recover_custody here, so trigger 1 misses and
+# only trigger 2 catches it. The remedy must not tell the operator to wait for
+# a run that already ended.
+terminal_pipeline_owned_axi_status_toon() {  # <branch> <local-head> [run-id]
+  cat <<EOF
+run:
+  id: "${3:-01RUN}"
+  branch: $1
+  status: cancelled
+  head: fix7head
+  findings: none
+outcome: cancelled
+branch_sync:
+  state: pipeline_owned
+  changed: true
+  local:
+    branch: $1
+    head: "$2"
+    clean: true
+  pipeline:
+    run: "${3:-01RUN}"
+    status: cancelled
+    current_head: fix7head
+  safety: blocked_pipeline_owned
+  next_action:
+    code: none
+    command: ""
+EOF
+}
+
+test_terminal_pipeline_owned_run_gets_custody_remedy_not_wait() {
+  local case_dir rc head
+  case_dir=$(make_case pipeline-ahead-terminal)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  log_treehouse_returns "$case_dir"
+  head=$(git -C "$case_dir/wt" rev-parse HEAD)
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(terminal_pipeline_owned_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 1 "$rc" "pipeline-ahead-terminal: teardown should still refuse when a terminal run left a pipeline head this worktree lacks"
+  assert_grep "axi sync --recover" "$case_dir/stderr" \
+    "pipeline-ahead-terminal: an ended run needs the custody-return remedy, which teardown did not give"
+  assert_not_contains "$(cat "$case_dir/stderr")" "Let it finish" \
+    "pipeline-ahead-terminal: teardown told the operator to wait for a run that already ended"
+  assert_absent "$case_dir/treehouse.log" \
+    "pipeline-ahead-terminal: teardown returned the worktree while a pipeline commit was unaccounted for"
+  pass "a terminal run holding a pipeline commit gets the custody-return remedy, not a wait for a finished run"
+}
+
 test_content_equivalent_rebase_does_not_refuse_teardown() {
   local case_dir rc head rebased tree parent
   case_dir=$(make_case pipeline-ahead-rebase-equivalent)
@@ -3055,7 +3148,9 @@ test_parked_run_abort_leaves_unrecovered_commits_refuses
 test_unrecovered_pipeline_commits_are_discarded_under_force
 test_unanswerable_status_query_refuses_teardown
 test_unanswerable_status_query_under_force_is_loud_and_recorded
+test_unrecordable_discard_under_force_refuses
 test_live_pipeline_commit_ahead_of_worktree_refuses_before_any_abort
+test_terminal_pipeline_owned_run_gets_custody_remedy_not_wait
 test_content_equivalent_rebase_does_not_refuse_teardown
 test_resolvable_pipeline_commit_with_new_content_refuses_teardown
 test_toplevel_key_after_branch_sync_is_not_read_as_its_child

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -135,6 +135,13 @@ case "${1:-}" in
         shift
         run_id=""
         if [ "${1:-}" = --run ]; then run_id=${2:-}; fi
+        # A bare `axi status` that cannot answer at all: the daemon erroring
+        # out, or the bounded call timing out. Scoped to the bare form because
+        # that is the one the unrecovered-pipeline-commits precondition uses.
+        if [ -z "$run_id" ] && [ "${FM_FAKE_NM_STATUS_FAILS:-0}" = 1 ]; then
+          echo 'error: could not reach the no-mistakes daemon' >&2
+          exit 1
+        fi
         aborted=0
         if [ -n "${FM_FAKE_NM_ABORT_LOG:-}" ]; then
           if [ -n "$run_id" ]; then
@@ -144,9 +151,14 @@ case "${1:-}" in
           fi
         fi
         if [ "$aborted" = 1 ] && [ "${FM_FAKE_NM_ABORT_NOOP:-0}" != 1 ]; then
-          if [ "${FM_FAKE_NM_NOT_FOUND_AFTER_ABORT:-0}" = 1 ]; then
+          if [ "${FM_FAKE_NM_NOT_FOUND_AFTER_ABORT:-0}" = 1 ] && [ -n "$run_id" ]; then
+            # Only the `--run <id>` form can report THAT run as not found; the
+            # bare form reports whatever run the branch currently has, or
+            # nothing, and never errors just because one run id is gone.
             printf 'error: "run \\"%s\\" not found"\n' "$run_id" >&2
             exit 1
+          elif [ "${FM_FAKE_NM_NOT_FOUND_AFTER_ABORT:-0}" = 1 ]; then
+            exit 0
           elif [ "${FM_FAKE_NM_EMPTY_AFTER_ABORT:-0}" = 1 ]; then
             exit 0
           elif [ -n "${FM_FAKE_AXI_STATUS_AFTER_ABORT:-}" ]; then
@@ -2181,16 +2193,28 @@ test_parked_run_abort_leaves_unrecovered_commits_refuses() {
   pass "teardown refuses identically on a second attempt, so unrecovered pipeline commits are never silently stranded"
 }
 
-# --force skips validate_worktree_teardown_safety (the uncommitted/unpushed
-# checks) but must NOT skip this precondition: unrecovered pipeline commits
-# are unlanded work, and hard rule 3 never discards unlanded work without the
-# captain's explicit word for that specific discard - --force alone is a
-# different, broader escape hatch than that, so it must not double as this one.
-test_parked_run_abort_leaves_unrecovered_commits_refuses_under_force() {
+# Record every treehouse invocation so the ALLOW cases below can prove teardown
+# actually reached the irreversible worktree return, not merely exited 0.
+log_treehouse_returns() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/fakebin/treehouse" <<EOF
+#!/usr/bin/env bash
+printf 'returned\n' >> "$case_dir/treehouse.log"
+EOF
+  chmod +x "$case_dir/fakebin/treehouse"
+}
+
+# --force is the ONE escape hatch past this precondition, exactly as it is for
+# validate_worktree_teardown_safety: hard rule 3 never discards unlanded work
+# without the captain's explicit word for that specific discard, and passing
+# --force here IS that word. Without it the same case refuses (above); with it
+# teardown runs all the way through the worktree return.
+test_unrecovered_pipeline_commits_are_discarded_under_force() {
   local case_dir rc head
   case_dir=$(make_case parked-run-recover-custody-force)
   write_meta "$case_dir" no-mistakes ship
   land_shippable_commit "$case_dir"
+  log_treehouse_returns "$case_dir"
   head=$(git -C "$case_dir/wt" rev-parse HEAD)
 
   rc=0
@@ -2199,12 +2223,148 @@ test_parked_run_abort_leaves_unrecovered_commits_refuses_under_force() {
   FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
     run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
 
-  expect_code 1 "$rc" "parked-run-recover-custody-force: --force should still refuse rather than discard unrecovered pipeline commits"
+  expect_code 0 "$rc" "parked-run-recover-custody-force: --force is the captain's explicit authorization to discard, so teardown should complete"
+  ! grep -q REFUSED "$case_dir/stderr" \
+    || fail "parked-run-recover-custody-force: --force still hit a refusal"
+  assert_present "$case_dir/treehouse.log" \
+    "parked-run-recover-custody-force: --force did not reach the worktree return"
+  pass "--force is an explicit, working escape hatch past the unrecovered-pipeline-commits refusal"
+}
+
+# The precondition guards an IRREVERSIBLE step, so a query that cannot answer
+# must NOT read as "nothing to preserve": the invocation that fail-opens is the
+# one that destroys the evidence, and there is no later retry to catch it.
+test_unanswerable_status_query_refuses_teardown() {
+  local case_dir rc
+  case_dir=$(make_case unrecovered-query-failure)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  log_treehouse_returns "$case_dir"
+
+  rc=0
+  FM_FAKE_NM_STATUS_FAILS=1 \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 1 "$rc" "unrecovered-query-failure: an unanswerable axi status must refuse, not fail open into an irreversible removal"
+  assert_grep "did not answer" "$case_dir/stderr" \
+    "unrecovered-query-failure: teardown did not explain that it could not confirm the worktree was safe to remove"
+  assert_absent "$case_dir/treehouse.log" \
+    "unrecovered-query-failure: teardown returned the worktree without ever confirming there was no unrecovered work"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "unrecovered-query-failure: teardown removed task metadata after refusing"
+  pass "an unanswerable axi status refuses teardown instead of destroying the evidence"
+}
+
+# A LIVE pipeline-owned run mid fix-round: the daemon holds a gate-repo commit
+# (branch_sync.pipeline.current_head) this worktree has never seen, and nothing
+# has been cancelled, so next_action.code is an in-flight code and never
+# recover_custody. Fix 1's own abort cannot fire either - the run head does not
+# resolve here, so it is not attributable as a parked run - which is exactly why
+# waiting for recover_custody would strand this commit.
+pipeline_owned_ahead_axi_status_toon() {  # <branch> <local-head> [run-id]
+  cat <<EOF
+run:
+  id: "${3:-01RUN}"
+  branch: $1
+  status: fixing
+  head: fix9head
+  pr: ""
+branch_sync:
+  state: pipeline_owned
+  changed: true
+  local:
+    branch: $1
+    head: "$2"
+    clean: true
+  pipeline:
+    run: "${3:-01RUN}"
+    status: fixing
+    current_head: fix9head
+  safety: blocked_pipeline_owned
+  next_action:
+    code: continue_active_run
+    command: no-mistakes axi status
+EOF
+}
+
+test_live_pipeline_commit_ahead_of_worktree_refuses_before_any_abort() {
+  local case_dir rc head
+  case_dir=$(make_case pipeline-ahead-live)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  log_treehouse_returns "$case_dir"
+  head=$(git -C "$case_dir/wt" rev-parse HEAD)
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(pipeline_owned_ahead_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 1 "$rc" "pipeline-ahead-live: teardown should refuse while the pipeline holds a commit this worktree has never seen"
+  assert_absent "$case_dir/nm-abort.log" \
+    "pipeline-ahead-live: the refusal must not depend on a cancellation having happened first"
   assert_grep "axi sync --recover" "$case_dir/stderr" \
-    "parked-run-recover-custody-force: --force path did not tell the operator how to land the preserved commit"
-  assert_present "$case_dir/wt" \
-    "parked-run-recover-custody-force: --force removed the worktree while pipeline-committed work was still unrecovered"
-  pass "--force does not bypass the unrecovered-pipeline-commits refusal"
+    "pipeline-ahead-live: teardown did not tell the operator how to land the pipeline-held commit"
+  assert_absent "$case_dir/treehouse.log" \
+    "pipeline-ahead-live: teardown returned the worktree while the pipeline held an unlanded commit"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "pipeline-ahead-live: teardown removed task metadata after refusing"
+  pass "a live pipeline-owned run whose commit never reached this worktree refuses teardown, with no cancellation required"
+}
+
+# The shared TOON extractors scope by block, and a sed range is inclusive of the
+# line that TERMINATES the block - so the first top-level key AFTER branch_sync
+# must not be read as one of branch_sync's own children. Here branch_sync
+# carries no `state:` of its own and an unrelated top-level `state:
+# pipeline_owned` follows it: leaking that key across the boundary turns this
+# ordinary, already-synced run into a false "the pipeline owns the branch"
+# refusal. No no-mistakes release emits this shape today; it is the same class
+# of future-shape false match next_action.code is anchored against.
+toplevel_key_after_branch_sync_axi_status_toon() {  # <branch> <head> [run-id]
+  cat <<EOF
+run:
+  id: "${3:-01RUN}"
+  branch: $1
+  status: running
+  head: "$2"
+  pr: ""
+branch_sync:
+  changed: false
+  local:
+    branch: $1
+    head: "$2"
+    clean: true
+  pipeline:
+    run: "${3:-01RUN}"
+    status: running
+    current_head: fix0head
+  next_action:
+    code: continue_active_run
+    command: no-mistakes axi status
+state: pipeline_owned
+EOF
+}
+
+test_toplevel_key_after_branch_sync_is_not_read_as_its_child() {
+  local case_dir rc head
+  case_dir=$(make_case toplevel-key-leak)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  log_treehouse_returns "$case_dir"
+  head=$(git -C "$case_dir/wt" rev-parse HEAD)
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(toplevel_key_after_branch_sync_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "toplevel-key-leak: a top-level key after branch_sync must not be read as branch_sync.state"
+  ! grep -q REFUSED "$case_dir/stderr" \
+    || fail "toplevel-key-leak: teardown refused on a branch_sync that never reported pipeline_owned"
+  assert_present "$case_dir/treehouse.log" \
+    "toplevel-key-leak: teardown never reached the worktree return"
+  pass "block extraction stops at the block boundary, so a following top-level key cannot answer for a missing child"
 }
 
 test_mismatched_run_after_abort_refuses_unconfirmed() {
@@ -2771,7 +2931,10 @@ test_empty_retry_wait_uses_default_without_aborting
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
 test_parked_own_run_is_aborted_before_teardown
 test_parked_run_abort_leaves_unrecovered_commits_refuses
-test_parked_run_abort_leaves_unrecovered_commits_refuses_under_force
+test_unrecovered_pipeline_commits_are_discarded_under_force
+test_unanswerable_status_query_refuses_teardown
+test_live_pipeline_commit_ahead_of_worktree_refuses_before_any_abort
+test_toplevel_key_after_branch_sync_is_not_read_as_its_child
 test_parked_own_run_refuses_when_abort_is_unconfirmed
 test_mismatched_run_after_abort_refuses_unconfirmed
 test_empty_status_after_abort_refuses_unconfirmed

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -195,6 +195,12 @@ SH
   git -C "$case_dir/project" remote set-head origin main 2>/dev/null || true
   # Add a worktree on a fresh task branch; that branch is where the crewmate commits.
   git -C "$case_dir/project" worktree add -q -b fm/task-x1 "$case_dir/wt" main
+  # The local evidence the unrecovered-pipeline-commits guard requires before it
+  # queries anything: the remote-tracking ref a crew repo's `no-mistakes` remote
+  # (fetch refspec +refs/heads/*:refs/remotes/no-mistakes/*) carries once the
+  # gate knows the branch. Present here because these cases model a GATED ship
+  # project; unmark_branch_gated below models one that was never gated.
+  git -C "$case_dir/project" update-ref "refs/remotes/no-mistakes/fm/task-x1" main
 
   # Fresh watcher beacon so fm-guard stays quiet.
   touch "$case_dir/state/.last-watcher-beat"
@@ -2279,6 +2285,105 @@ test_unanswerable_status_query_under_force_is_loud_and_recorded() {
   pass "an unanswerable status query under --force still announces and records what it could not verify"
 }
 
+# Model a ship project that was never gated: no `no-mistakes` remote ever
+# fetched this branch, so no refs/remotes/no-mistakes/<branch> exists.
+unmark_branch_gated() {  # <case-dir>
+  git -C "$1/project" update-ref -d "refs/remotes/no-mistakes/fm/task-x1"
+}
+
+# Without local evidence that a pipeline ever held this branch there is nothing
+# for it to have committed, so the guard must not run at all - not even the
+# query. Otherwise a reachable daemon becomes a hard precondition for tearing
+# down ANY ship worktree, including one in a project that was never gated.
+test_ungated_branch_tears_down_despite_unanswerable_query() {
+  local case_dir rc
+  case_dir=$(make_case ungated-branch-query-failure)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  log_treehouse_returns "$case_dir"
+  unmark_branch_gated "$case_dir"
+
+  rc=0
+  FM_FAKE_NM_STATUS_FAILS=1 \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "ungated-branch: a branch no pipeline ever held must tear down even when axi status cannot answer"
+  ! grep -q REFUSED "$case_dir/stderr" \
+    || fail "ungated-branch: teardown refused a worktree with no local evidence a run ever existed"
+  assert_present "$case_dir/treehouse.log" \
+    "ungated-branch: teardown never reached the worktree return"
+  assert_absent "$case_dir/state/.discarded-pipeline-commits.log" \
+    "ungated-branch: teardown recorded a discard for work that never existed"
+  pass "a ship worktree whose branch was never gated tears down normally even when the daemon cannot answer"
+}
+
+# The counterpart, and the case the fail-closed rule exists for: the same
+# unanswerable query on a branch the gate demonstrably knows must still refuse.
+# test_unanswerable_status_query_refuses_teardown covers the plain refusal; this
+# pins that the local-evidence ref is what separates the two.
+test_gated_branch_still_refuses_on_unanswerable_query() {
+  local case_dir rc
+  case_dir=$(make_case gated-branch-query-failure)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  log_treehouse_returns "$case_dir"
+  git -C "$case_dir/project" rev-parse --verify --quiet "refs/remotes/no-mistakes/fm/task-x1" >/dev/null \
+    || fail "gated-branch: fixture did not carry the local gated-branch evidence"
+
+  rc=0
+  FM_FAKE_NM_STATUS_FAILS=1 \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 1 "$rc" "gated-branch: an unanswerable query on a gated branch must still refuse"
+  assert_grep "did not answer" "$case_dir/stderr" \
+    "gated-branch: teardown did not explain that it could not verify what was at stake"
+  assert_absent "$case_dir/treehouse.log" \
+    "gated-branch: teardown returned the worktree without confirming there was no unrecovered work"
+  pass "the same unanswerable query still refuses on a branch the gate demonstrably knows"
+}
+
+# Build a PATH with no timeout, gtimeout, or perl, so fm_nm_run_bounded has no
+# way to bound the CLI call at all - a condition it reports with the same bare
+# exit 1 as a genuine query failure, but which needs a completely different fix.
+make_path_without_bounded_tools() {  # <case-dir>
+  local case_dir=$1 path_dir="$1/path-without-bounded" cmd resolved
+  mkdir -p "$path_dir"
+  for cmd in awk bash basename cat chmod cp cut date dirname env find git grep head hostname id ln \
+    mkdir mktemp mv ps readlink realpath rm sed sh sleep sort stat tail tr uname wc xargs; do
+    resolved=$(command -v "$cmd" 2>/dev/null) || continue
+    case "$resolved" in /*) ln -sf "$resolved" "$path_dir/$cmd" ;; esac
+  done
+  printf '%s\n' "$path_dir"
+}
+
+test_missing_bounded_execution_tool_is_named_in_the_refusal() {
+  local case_dir rc head
+  case_dir=$(make_case no-bounded-tool)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  log_treehouse_returns "$case_dir"
+  head=$(git -C "$case_dir/wt" rev-parse HEAD)
+
+  rc=0
+  FM_TEARDOWN_TEST_PATH="$(make_path_without_bounded_tools "$case_dir")" \
+  FM_FAKE_AXI_STATUS="$(recover_custody_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 1 "$rc" "no-bounded-tool: teardown should refuse when it cannot bound the verification call"
+  assert_grep "no bounded-execution tool" "$case_dir/stderr" \
+    "no-bounded-tool: teardown did not name the missing-tool condition, leaving an unexplained refusal"
+  assert_grep "timeout" "$case_dir/stderr" \
+    "no-bounded-tool: teardown did not name which tools would fix it"
+  assert_not_contains "$(cat "$case_dir/stderr")" "did not answer" \
+    "no-bounded-tool: teardown reported a daemon failure for a missing local tool"
+  assert_absent "$case_dir/treehouse.log" \
+    "no-bounded-tool: teardown returned the worktree without verifying anything"
+  pass "a host with no timeout, gtimeout, or perl gets a refusal that names the missing tool, not a generic query failure"
+}
+
 # The durable record is the ONLY trace that survives the worktree, so it is a
 # precondition for the discard, not telemetry. If it cannot be written, --force
 # must stop rather than destroy work nothing afterwards can account for.
@@ -2443,7 +2548,7 @@ branch_sync:
 EOF
 }
 
-test_terminal_pipeline_owned_run_gets_custody_remedy_not_wait() {
+test_terminal_pipeline_owned_run_gets_reachable_remedy_not_wait() {
   local case_dir rc head
   case_dir=$(make_case pipeline-ahead-terminal)
   write_meta "$case_dir" no-mistakes ship
@@ -2457,13 +2562,21 @@ test_terminal_pipeline_owned_run_gets_custody_remedy_not_wait() {
     run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
 
   expect_code 1 "$rc" "pipeline-ahead-terminal: teardown should still refuse when a terminal run left a pipeline head this worktree lacks"
-  assert_grep "axi sync --recover" "$case_dir/stderr" \
-    "pipeline-ahead-terminal: an ended run needs the custody-return remedy, which teardown did not give"
+  # The run already ended, so telling the operator to wait for it is nonsense.
   assert_not_contains "$(cat "$case_dir/stderr")" "Let it finish" \
     "pipeline-ahead-terminal: teardown told the operator to wait for a run that already ended"
+  # next_action.code is `none` here, and AGENTS.md permits axi sync's guarded
+  # recovery ONLY when that code is recover_custody - so teardown must not hand
+  # over a command the daemon will refuse.
+  assert_grep "does not report this branch as needing recovery" "$case_dir/stderr" \
+    "pipeline-ahead-terminal: teardown did not say the guarded recovery does not apply to this state"
+  assert_grep "follow branch_sync.next_action" "$case_dir/stderr" \
+    "pipeline-ahead-terminal: teardown did not point at the one signal that is actually authoritative here"
+  assert_grep "--force is the intended way to finish teardown" "$case_dir/stderr" \
+    "pipeline-ahead-terminal: teardown left the operator with no reachable way out"
   assert_absent "$case_dir/treehouse.log" \
     "pipeline-ahead-terminal: teardown returned the worktree while a pipeline commit was unaccounted for"
-  pass "a terminal run holding a pipeline commit gets the custody-return remedy, not a wait for a finished run"
+  pass "a terminal run holding a pipeline commit gets a remedy that actually applies, not a wait nor a forbidden recovery"
 }
 
 test_content_equivalent_rebase_does_not_refuse_teardown() {
@@ -3148,9 +3261,12 @@ test_parked_run_abort_leaves_unrecovered_commits_refuses
 test_unrecovered_pipeline_commits_are_discarded_under_force
 test_unanswerable_status_query_refuses_teardown
 test_unanswerable_status_query_under_force_is_loud_and_recorded
+test_ungated_branch_tears_down_despite_unanswerable_query
+test_gated_branch_still_refuses_on_unanswerable_query
+test_missing_bounded_execution_tool_is_named_in_the_refusal
 test_unrecordable_discard_under_force_refuses
 test_live_pipeline_commit_ahead_of_worktree_refuses_before_any_abort
-test_terminal_pipeline_owned_run_gets_custody_remedy_not_wait
+test_terminal_pipeline_owned_run_gets_reachable_remedy_not_wait
 test_content_equivalent_rebase_does_not_refuse_teardown
 test_resolvable_pipeline_commit_with_new_content_refuses_teardown
 test_toplevel_key_after_branch_sync_is_not_read_as_its_child

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -2417,6 +2417,77 @@ test_unrecordable_discard_under_force_refuses() {
   pass "--force refuses when the durable discard record cannot be written, rather than destroying untraceable work"
 }
 
+# A second ship worktree/branch/meta in the SAME case, so its forced teardown
+# shares the one fleet-wide $STATE/.discarded-pipeline-commits.log with every
+# other task built this way - the exact sharing the rotation race needs two
+# DIFFERENT tasks' teardowns to reach it concurrently.
+add_extra_ship_task() {  # <case_dir> <suffix>
+  local case_dir=$1 suffix=$2 branch wt
+  branch="fm/task-$suffix"
+  wt="$case_dir/wt-$suffix"
+  git -C "$case_dir/project" worktree add -q -b "$branch" "$wt" main
+  git -C "$case_dir/project" update-ref "refs/remotes/no-mistakes/$branch" main
+  fm_write_meta "$case_dir/state/task-$suffix.meta" \
+    "window=firstmate:fm-task-$suffix" \
+    "endpoint_task_id=task-$suffix" \
+    "worktree=$wt" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+}
+
+# Greptile-flagged race (2026-08-30): record_discarded_pipeline_commits's size
+# rotation reads the whole log then replaces it wholesale (tail | mv) - a
+# read-modify-write, not an append. Nothing shared across DIFFERENT tasks'
+# teardowns serialized that against a concurrent append (each teardown only
+# takes its own per-task META_LOCK/CONTROL_LOCK), so one task's rotation could
+# read the log before another task's own already-successful append landed,
+# then overwrite the file with that stale snapshot - silently dropping a
+# record the append had already reported as durably written. Reproduced by
+# forcing rotation on nearly every append (a tiny FM_DISCARD_LOG_MAX_BYTES)
+# across many concurrently torn-down tasks sharing one state dir, then
+# checking every task's record survived.
+test_concurrent_forced_discards_do_not_lose_records() {
+  local case_dir n i suffix branch wt head pids pid failures survivors
+  n=20
+  case_dir=$(make_case concurrent-discard-race)
+  for i in $(seq 1 "$n"); do
+    add_extra_ship_task "$case_dir" "c$i"
+  done
+
+  failures="$case_dir/failures"
+  : > "$failures"
+  pids=
+  for i in $(seq 1 "$n"); do
+    suffix="c$i"
+    branch="fm/task-$suffix"
+    wt="$case_dir/wt-$suffix"
+    head=$(git -C "$wt" rev-parse HEAD)
+    (
+      FM_ROOT_OVERRIDE="$ROOT" \
+      FM_STATE_OVERRIDE="$case_dir/state" \
+      FM_CONFIG_OVERRIDE="$case_dir/config" \
+      PATH="$case_dir/fakebin:$PATH" \
+      FM_DISCARD_LOG_MAX_BYTES=80 \
+      FM_FAKE_AXI_STATUS="$(recover_custody_axi_status_toon "$branch" "$head" "run-$suffix")" \
+        "$TEARDOWN" "task-$suffix" --force > "$case_dir/stdout-$suffix" 2> "$case_dir/stderr-$suffix" \
+        || printf 'task-%s exited %s\n' "$suffix" "$?" >> "$failures"
+    ) &
+    pids="$pids $!"
+  done
+  for pid in $pids; do
+    wait "$pid" 2>/dev/null || true
+  done
+
+  [ ! -s "$failures" ] || fail "concurrent-discard-race: a forced teardown failed unexpectedly: $(cat "$failures")"
+  assert_present "$case_dir/state/.discarded-pipeline-commits.log" \
+    "concurrent-discard-race: no discard log survived at all"
+  survivors=$(grep -oE 'task=task-c[0-9]+' "$case_dir/state/.discarded-pipeline-commits.log" | sort -u | wc -l | tr -d ' ')
+  [ "$survivors" -eq "$n" ] \
+    || fail "concurrent-discard-race: expected all $n concurrently discarded tasks' records to survive rotation, only $survivors did"
+  pass "concurrent forced discards across different tasks never lose an already-recorded discard to a racing rotation"
+}
+
 # The precondition guards an IRREVERSIBLE step, so a query that cannot answer
 # must NOT read as "nothing to preserve": the invocation that fail-opens is the
 # one that destroys the evidence, and there is no later retry to catch it.
@@ -3265,6 +3336,7 @@ test_ungated_branch_tears_down_despite_unanswerable_query
 test_gated_branch_still_refuses_on_unanswerable_query
 test_missing_bounded_execution_tool_is_named_in_the_refusal
 test_unrecordable_discard_under_force_refuses
+test_concurrent_forced_discards_do_not_lose_records
 test_live_pipeline_commit_ahead_of_worktree_refuses_before_any_abort
 test_terminal_pipeline_owned_run_gets_reachable_remedy_not_wait
 test_content_equivalent_rebase_does_not_refuse_teardown

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -2228,7 +2228,51 @@ test_unrecovered_pipeline_commits_are_discarded_under_force() {
     || fail "parked-run-recover-custody-force: --force still hit a refusal"
   assert_present "$case_dir/treehouse.log" \
     "parked-run-recover-custody-force: --force did not reach the worktree return"
-  pass "--force is an explicit, working escape hatch past the unrecovered-pipeline-commits refusal"
+  assert_grep "DISCARDING UNLANDED WORK" "$case_dir/stderr" \
+    "parked-run-recover-custody-force: --force discarded pipeline-committed work silently"
+  assert_grep "fm/task-x1" "$case_dir/stderr" \
+    "parked-run-recover-custody-force: the discard notice did not name the branch being stranded"
+  assert_grep "fix0head" "$case_dir/stderr" \
+    "parked-run-recover-custody-force: the discard notice did not name the pipeline commit being stranded"
+  assert_grep "not a convenience bypass" "$case_dir/stderr" \
+    "parked-run-recover-custody-force: the discard notice did not frame --force as authorization for this specific discard"
+  # The durable record is deliberately NOT keyed under state/<id>., which
+  # teardown erases; it has to outlive the task whose commit it names.
+  assert_absent "$case_dir/state/task-x1.meta" \
+    "parked-run-recover-custody-force: task metadata survived a completed teardown"
+  assert_present "$case_dir/state/.discarded-pipeline-commits.log" \
+    "parked-run-recover-custody-force: no durable record of the discarded pipeline commit survived teardown"
+  assert_grep "task=task-x1" "$case_dir/state/.discarded-pipeline-commits.log" \
+    "parked-run-recover-custody-force: the discard record does not name the task"
+  assert_grep "pipeline_head=fix0head" "$case_dir/state/.discarded-pipeline-commits.log" \
+    "parked-run-recover-custody-force: the discard record does not name the stranded commit"
+  assert_grep "branch=fm/task-x1" "$case_dir/state/.discarded-pipeline-commits.log" \
+    "parked-run-recover-custody-force: the discard record does not name the branch"
+  pass "--force discards unrecovered pipeline commits only loudly and with a durable record that outlives the task"
+}
+
+# Fail-closed still applies under --force: teardown cannot say WHAT it is
+# discarding, so it must at least say that, and record it.
+test_unanswerable_status_query_under_force_is_loud_and_recorded() {
+  local case_dir rc
+  case_dir=$(make_case unrecovered-query-failure-force)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  log_treehouse_returns "$case_dir"
+
+  rc=0
+  FM_FAKE_NM_STATUS_FAILS=1 \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "unrecovered-query-failure-force: --force authorizes the discard and teardown should complete"
+  assert_present "$case_dir/treehouse.log" \
+    "unrecovered-query-failure-force: --force did not reach the worktree return"
+  assert_grep "DISCARDING UNLANDED WORK" "$case_dir/stderr" \
+    "unrecovered-query-failure-force: teardown discarded an unverifiable worktree silently"
+  assert_grep "query-failed" "$case_dir/state/.discarded-pipeline-commits.log" \
+    "unrecovered-query-failure-force: the unverifiable discard was not recorded durably"
+  pass "an unanswerable status query under --force still announces and records what it could not verify"
 }
 
 # The precondition guards an IRREVERSIBLE step, so a query that cannot answer
@@ -2262,13 +2306,14 @@ test_unanswerable_status_query_refuses_teardown() {
 # recover_custody. Fix 1's own abort cannot fire either - the run head does not
 # resolve here, so it is not attributable as a parked run - which is exactly why
 # waiting for recover_custody would strand this commit.
-pipeline_owned_ahead_axi_status_toon() {  # <branch> <local-head> [run-id]
+pipeline_owned_ahead_axi_status_toon() {  # <branch> <local-head> [run-id] [pipeline-head]
+  local pipeline_head=${4:-fix9head}
   cat <<EOF
 run:
   id: "${3:-01RUN}"
   branch: $1
   status: fixing
-  head: fix9head
+  head: $pipeline_head
   pr: ""
 branch_sync:
   state: pipeline_owned
@@ -2280,7 +2325,7 @@ branch_sync:
   pipeline:
     run: "${3:-01RUN}"
     status: fixing
-    current_head: fix9head
+    current_head: $pipeline_head
   safety: blocked_pipeline_owned
   next_action:
     code: continue_active_run
@@ -2304,8 +2349,18 @@ test_live_pipeline_commit_ahead_of_worktree_refuses_before_any_abort() {
   expect_code 1 "$rc" "pipeline-ahead-live: teardown should refuse while the pipeline holds a commit this worktree has never seen"
   assert_absent "$case_dir/nm-abort.log" \
     "pipeline-ahead-live: the refusal must not depend on a cancellation having happened first"
-  assert_grep "axi sync --recover" "$case_dir/stderr" \
-    "pipeline-ahead-live: teardown did not tell the operator how to land the pipeline-held commit"
+  # The run is STILL ACTIVE and the pipeline still owns the branch, so
+  # axi sync's guarded recovery does not apply yet (AGENTS.md: use it only when
+  # next_action.code is recover_custody). The remedy has to be the one that
+  # actually runs.
+  assert_grep "no-mistakes axi status" "$case_dir/stderr" \
+    "pipeline-ahead-live: teardown did not give the re-check remedy for a still-active run"
+  assert_not_contains "$(cat "$case_dir/stderr")" "axi sync --recover" \
+    "pipeline-ahead-live: teardown offered the recover_custody remedy for a run that has not returned the branch"
+  # This head is not an object here at all, so teardown cannot know whether it
+  # is a fix round or a plain rebase, and must not claim the former.
+  assert_grep "rebase" "$case_dir/stderr" \
+    "pipeline-ahead-live: teardown asserted lost work without acknowledging the plain-rebase possibility"
   assert_absent "$case_dir/treehouse.log" \
     "pipeline-ahead-live: teardown returned the worktree while the pipeline held an unlanded commit"
   assert_present "$case_dir/state/task-x1.meta" \
@@ -2313,22 +2368,88 @@ test_live_pipeline_commit_ahead_of_worktree_refuses_before_any_abort() {
   pass "a live pipeline-owned run whose commit never reached this worktree refuses teardown, with no cancellation required"
 }
 
+# A pipeline-driven rebase of the crew's OWN commits onto a newer base makes
+# branch_sync.pipeline.current_head a non-ancestor of the worktree HEAD while
+# carrying no content the worktree is missing. Ancestry alone calls that
+# stranded work; patch identity does not. Builds a real rebased copy (same
+# tree, same parent, different commit) so `git cherry` sees an equivalent.
+test_content_equivalent_rebase_does_not_refuse_teardown() {
+  local case_dir rc head rebased tree parent
+  case_dir=$(make_case pipeline-ahead-rebase-equivalent)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  log_treehouse_returns "$case_dir"
+  head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  tree=$(git -C "$case_dir/wt" rev-parse 'HEAD^{tree}')
+  parent=$(git -C "$case_dir/wt" rev-parse 'HEAD^')
+  rebased=$(GIT_COMMITTER_DATE="2030-01-01T00:00:00 +0000" \
+    git -C "$case_dir/wt" -c user.email=t@t -c user.name=t \
+    commit-tree "$tree" -p "$parent" -m "shippable work")
+  [ "$rebased" != "$head" ] || fail "pipeline-ahead-rebase: fixture did not produce a distinct rebased commit"
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(pipeline_owned_ahead_axi_status_toon fm/task-x1 "$head" 01RUN "$rebased")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "pipeline-ahead-rebase: a content-equivalent rebase strands nothing and must not refuse teardown"
+  ! grep -q REFUSED "$case_dir/stderr" \
+    || fail "pipeline-ahead-rebase: teardown refused a rebase that carries no content the worktree is missing"
+  assert_present "$case_dir/treehouse.log" \
+    "pipeline-ahead-rebase: teardown never reached the worktree return"
+  pass "a pipeline rebase whose commits are patch-equivalent to the worktree's own does not refuse teardown"
+}
+
+# The other side of the same comparison: a pipeline head this worktree DOES
+# have, carrying a change no commit here has. That is proven stranded work, and
+# the message may say so plainly rather than hedging about a rebase.
+test_resolvable_pipeline_commit_with_new_content_refuses_teardown() {
+  local case_dir rc head blob tree gate_commit
+  case_dir=$(make_case pipeline-ahead-real-content)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  log_treehouse_returns "$case_dir"
+  head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  blob=$(printf 'gate-only fix round\n' | git -C "$case_dir/wt" hash-object -w --stdin)
+  tree=$(printf '100644 blob %s\tgate-fix.txt\n' "$blob" | git -C "$case_dir/wt" mktree)
+  gate_commit=$(git -C "$case_dir/wt" -c user.email=t@t -c user.name=t \
+    commit-tree "$tree" -p "$head" -m "gate-only fix round")
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(pipeline_owned_ahead_axi_status_toon fm/task-x1 "$head" 01RUN "$gate_commit")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 1 "$rc" "pipeline-ahead-real-content: teardown should refuse when the pipeline holds a change no commit here has"
+  assert_grep "no-mistakes axi status" "$case_dir/stderr" \
+    "pipeline-ahead-real-content: teardown did not give the re-check remedy for a still-active run"
+  assert_not_contains "$(cat "$case_dir/stderr")" "rebase" \
+    "pipeline-ahead-real-content: teardown hedged about a rebase for content it proved is missing"
+  assert_absent "$case_dir/treehouse.log" \
+    "pipeline-ahead-real-content: teardown returned the worktree while the pipeline held a genuinely unlanded change"
+  pass "a resolvable pipeline commit carrying content absent from this worktree refuses teardown without hedging"
+}
+
 # The shared TOON extractors scope by block, and a sed range is inclusive of the
 # line that TERMINATES the block - so the first top-level key AFTER branch_sync
 # must not be read as one of branch_sync's own children. Here branch_sync
 # carries no `state:` of its own and an unrelated top-level `state:
 # pipeline_owned` follows it: leaking that key across the boundary turns this
-# ordinary, already-synced run into a false "the pipeline owns the branch"
-# refusal. No no-mistakes release emits this shape today; it is the same class
-# of future-shape false match next_action.code is anchored against.
+# ordinary run into a false "the pipeline owns the branch" refusal. The run is
+# TERMINAL and needs no recovery - AGENTS.md's "ownership already returned and
+# no recovery required" shape - so branch_sync.state is the only thing that
+# could still trigger the pipeline-head check, which is what isolates the leak.
+# No no-mistakes release emits this shape today; it is the same class of
+# future-shape false match next_action.code is anchored against.
 toplevel_key_after_branch_sync_axi_status_toon() {  # <branch> <head> [run-id]
   cat <<EOF
 run:
   id: "${3:-01RUN}"
   branch: $1
-  status: running
+  status: completed
   head: "$2"
   pr: ""
+outcome: passed
 branch_sync:
   changed: false
   local:
@@ -2337,11 +2458,11 @@ branch_sync:
     clean: true
   pipeline:
     run: "${3:-01RUN}"
-    status: running
+    status: completed
     current_head: fix0head
   next_action:
-    code: continue_active_run
-    command: no-mistakes axi status
+    code: none
+    command: ""
 state: pipeline_owned
 EOF
 }
@@ -2933,7 +3054,10 @@ test_parked_own_run_is_aborted_before_teardown
 test_parked_run_abort_leaves_unrecovered_commits_refuses
 test_unrecovered_pipeline_commits_are_discarded_under_force
 test_unanswerable_status_query_refuses_teardown
+test_unanswerable_status_query_under_force_is_loud_and_recorded
 test_live_pipeline_commit_ahead_of_worktree_refuses_before_any_abort
+test_content_equivalent_rebase_does_not_refuse_teardown
+test_resolvable_pipeline_commit_with_new_content_refuses_teardown
 test_toplevel_key_after_branch_sync_is_not_read_as_its_child
 test_parked_own_run_refuses_when_abort_is_unconfirmed
 test_mismatched_run_after_abort_refuses_unconfirmed

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -308,6 +308,50 @@ test_lock_live_steal_mutex_is_not_reclaimed() {
   pass "live steal mutex is not reclaimed"
 }
 
+# Regression: fm_lock_try_acquire is a bounded "try", but its stale-owner
+# recovery takes a helper lock at "$lockdir.steal" through this same function.
+# When the containing directory accepts no new entries at all - a state dir
+# that went read-only or full - every level fails identically at the same
+# mktemp, so the recovery recursed on ".steal", ".steal.steal", ... and never
+# returned. Callers that already hold another lock while acquiring (the forced
+# discard record in bin/fm-teardown.sh holds the task control lock) then hung
+# instead of refusing, and no writability probe can close that window: the
+# directory can be sealed after the probe passes and before the acquire. So
+# the acquire itself must return promptly - both when no lock is present and
+# when a reclaimable-looking stale one is.
+test_lock_try_acquire_refuses_when_lock_cannot_be_created() {
+  local dir state bound rc dead
+  dir=$(make_case lock-unwritable-dir)
+  state="$dir/state"
+  bound=$(command -v timeout || command -v gtimeout || true)
+  [ -n "$bound" ] || { pass "unwritable lock dir: skipped, no timeout available to bound the run"; return 0; }
+
+  mkdir -p "$state/sealed-empty" "$state/sealed-stale/.contend.lock"
+  dead=$(dead_pid)
+  printf '%s\n' "$dead" > "$state/sealed-stale/.contend.lock/pid"
+  chmod a-w "$state/sealed-empty" "$state/sealed-stale"
+
+  rc=0
+  FM_STATE_OVERRIDE="$state" "$bound" 15 bash -c '
+    . "$1"
+    fm_lock_try_acquire "$2"
+  ' _ "$LIB" "$state/sealed-empty/.contend.lock" || rc=$?
+  [ "$rc" -ne 124 ] || fail "acquire on an unwritable dir hung instead of refusing"
+  [ "$rc" -eq 1 ] || fail "acquire on an unwritable dir returned $rc, expected a plain refusal"
+
+  rc=0
+  FM_LOCK_STALE_AFTER=0 FM_STATE_OVERRIDE="$state" "$bound" 15 bash -c '
+    . "$1"
+    fm_lock_try_acquire "$2"
+  ' _ "$LIB" "$state/sealed-stale/.contend.lock" || rc=$?
+  chmod u+w "$state/sealed-empty" "$state/sealed-stale"
+  [ "$rc" -ne 124 ] || fail "acquire of an unreclaimable stale lock hung instead of refusing"
+  [ "$rc" -eq 1 ] || fail "acquire of an unreclaimable stale lock returned $rc, expected a plain refusal"
+  [ "$(cat "$state/sealed-stale/.contend.lock/pid" 2>/dev/null || true)" = "$dead" ] \
+    || fail "stale lock pid was clobbered by a refused acquire"
+  pass "an uncreatable lock is refused promptly instead of recursing on .steal forever"
+}
+
 test_lock_does_not_steal_live_lock() {
   local dir state lockdir live out lockpid
   dir=$(make_case lock-live-noop)
@@ -1114,6 +1158,7 @@ test_lock_single_winner_under_concurrency
 test_lock_steals_dead_pid_lock
 test_lock_stale_steal_single_winner_under_concurrency
 test_lock_live_steal_mutex_is_not_reclaimed
+test_lock_try_acquire_refuses_when_lock_cannot_be_created
 test_lock_does_not_steal_live_lock
 test_lock_empty_pid_uses_minimum_grace
 test_lock_late_claim_loses_after_recreate

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -332,6 +332,7 @@ test_lock_try_acquire_refuses_when_lock_cannot_be_created() {
   chmod a-w "$state/sealed-empty" "$state/sealed-stale"
 
   rc=0
+  # shellcheck disable=SC2016  # $1/$2 are the bounded child's positional args.
   FM_STATE_OVERRIDE="$state" "$bound" 15 bash -c '
     . "$1"
     fm_lock_try_acquire "$2"
@@ -340,6 +341,7 @@ test_lock_try_acquire_refuses_when_lock_cannot_be_created() {
   [ "$rc" -eq 1 ] || fail "acquire on an unwritable dir returned $rc, expected a plain refusal"
 
   rc=0
+  # shellcheck disable=SC2016  # $1/$2 are the bounded child's positional args.
   FM_LOCK_STALE_AFTER=0 FM_STATE_OVERRIDE="$state" "$bound" 15 bash -c '
     . "$1"
     fm_lock_try_acquire "$2"


### PR DESCRIPTION
## Intent

Finish PR 3291 by authenticating the reviewed fix that serializes rejection-log rotation through a complete no-mistakes pipeline run. Preserve the existing teardown safety behavior and published review fix, publish the resulting head to the configured cisrd fork, and let the pipeline write the PR attestation. Do not skip any pipeline step or hand-compose the attestation.

## What Changed

- `bin/fm-teardown.sh` gains an always-evaluated, fail-closed precondition (`worktree_has_unrecovered_pipeline_commits`) that runs before the irreversible branch delete and worktree return for ship worktrees. It only engages when `refs/remotes/no-mistakes/<branch>` shows the branch was gated locally, then refuses when `axi status` reports `branch_sync.next_action.code=recover_custody`, or when `branch_sync.pipeline.current_head` carries content this checkout lacks (compared by patch identity via `git cherry`, so a content-equivalent pipeline rebase passes) while the pipeline still owns the branch or the run is still active. Query failure, timeout, and a host with no `timeout`/`gtimeout`/`perl` refuse as distinct, separately-remedied reasons; the printed remedy keys off whether the run is still in flight rather than off which trigger matched.
- `--force` no longer skips the check — it changes the action to an announced discard that first appends a line to the fleet-wide, size-capped `state/.discarded-pipeline-commits.log` (cap via new `FM_DISCARD_LOG_MAX_BYTES`, default 262144, trimmed to the newest 2000 lines). The record is a precondition: if the append fails, `--force` refuses and names whether only the record write failed or the verification query failed too. The append-plus-rotate section runs under `state/.discarded-pipeline-commits.lock` so a concurrent teardown's rotation cannot wipe an already-acknowledged line, and an unwritable `$STATE` is probed each pass so it reports the concrete cause instead of hanging in the lock's steal recursion.
- `bin/fm-nm-run-lib.sh` adds `fm_nm_bounded_tool` (so callers can tell "no bounded-execution tool" from "call failed") plus reusable TOON scoping helpers `fm_nm_toon_block`/`fm_nm_toon_field` and the doubly-scoped `fm_nm_branch_sync_next_action_code`, `fm_nm_branch_sync_local_head`, and `fm_nm_branch_sync_pipeline_current_head`; `fm_nm_branch_sync_state` is reimplemented on top of them. `tests/fm-teardown.test.sh` adds coverage for repeated-teardown idempotence after abort, the forced discard path, unverifiable and unanswerable queries, ungated vs. gated branches, a missing bounded-execution tool, an unrecordable discard, and `$STATE` going unwritable between query and record. `AGENTS.md`, `docs/architecture.md`, and `docs/configuration.md` document the new log, lock, and knob.

## Risk Assessment

⚠️ Medium: The fix-round commit is small, targeted, and correct - it closes the reported unbounded-recursion hang with the same mktemp probe the lock itself performs, preserves the fleet-wide serialization the intent requires, and its regression test genuinely fails before the fix - but the branch as a whole adds a fail-closed refusal in front of an irreversible step for every gated ship worktree, so a daemon outage or missing bounded-execution tool now blocks teardown until --force is used; that blast radius is an accepted captain decision, leaving only informational follow-ups here.

## Testing

Ran the smallest relevant slice of tests/fm-teardown.test.sh (the discard-log rotation, unwritable-state refusal, forced-discard recording, refactored PATH-helper, and neighboring teardown-safety cases) — all pass — and confirmed both fixed defects genuinely regress against the pre-fix product code with the identical tests. Beyond unit results, I drove bin/fm-teardown.sh --force directly to capture end-user CLI transcripts and the persisted fleet-wide discard log: ten concurrent forced teardowns under an aggressive rotation cap keep all ten durable records, and a state dir that goes read-only mid-teardown now refuses in about a second naming the concrete Permission denied cause, leaving the worktree untouched instead of hanging on an uncreatable lock. This is a CLI/state change with no rendered UI surface, so the evidence is command transcripts and log state rather than screenshots. No failures or flakiness observed; transient test files were removed and the worktree is clean.

<details>
<summary>Evidence: Concurrent forced discards: CLI output + surviving discard log (10/10)</summary>

Source: [Concurrent forced discards: CLI output + surviving discard log (10/10)](https://github.com/cisrd/firstmate/blob/0d556fbe7bf4e97b8cfad2caf4ab2ac91d7678c3/.no-mistakes/evidence/fm/fm-nomistakes-fix-agent-deadlock/concurrent-forced-discards.txt)

```text
$ fm-teardown.sh task-d1 --force        # (10 such teardowns run concurrently, FM_DISCARD_LOG_MAX_BYTES=80)
DISCARDING UNLANDED WORK: no-mistakes run for task-d1 left pipeline-committed work in the gate that never reached this worktree (<case>/wt-d1).
Proceeding because --force was passed. Treat --force here as your explicit authorization to discard THIS work (branch fm/task-d1, pipeline commit fix0head) - it is not a convenience bypass, and teardown is about to make it unrecoverable.
Recorded the discard in <case>/state/.discarded-pipeline-commits.log.
warning: lsof is unavailable; cannot resolve the tmux pane process group for task-d1

$ cat $STATE/.discarded-pipeline-commits.log
[2026-08-30T12:17:48+0200] task=task-d1 reason=recover_custody branch=fm/task-d1 pipeline_head=fix0head worktree=<case>/wt-d1
[2026-08-30T12:17:48+0200] task=task-d5 reason=recover_custody branch=fm/task-d5 pipeline_head=fix0head worktree=<case>/wt-d5
[2026-08-30T12:17:48+0200] task=task-d10 reason=recover_custody branch=fm/task-d10 pipeline_head=fix0head worktree=<case>/wt-d10
[2026-08-30T12:17:48+0200] task=task-d7 reason=recover_custody branch=fm/task-d7 pipeline_head=fix0head worktree=<case>/wt-d7
[2026-08-30T12:17:48+0200] task=task-d3 reason=recover_custody branch=fm/task-d3 pipeline_head=fix0head worktree=<case>/wt-d3
[2026-08-30T12:17:48+0200] task=task-d4 reason=recover_custody branch=fm/task-d4 pipeline_head=fix0head worktree=<case>/wt-d4
[2026-08-30T12:17:49+0200] task=task-d2 reason=recover_custody branch=fm/task-d2 pipeline_head=fix0head worktree=<case>/wt-d2
[2026-08-30T12:17:49+0200] task=task-d9 reason=recover_custody branch=fm/task-d9 pipeline_head=fix0head worktree=<case>/wt-d9
[2026-08-30T12:17:49+0200] task=task-d6 reason=recover_custody branch=fm/task-d6 pipeline_head=fix0head worktree=<case>/wt-d6
[2026-08-30T12:17:49+0200] task=task-d8 reason=recover_custody branch=fm/task-d8 pipeline_head=fix0head worktree=<case>/wt-d8

records surviving rotation: 10 of 10 forced discards
```
</details>
<details>
<summary>Evidence: Unwritable state dir: prompt refusal transcript naming the cause</summary>

Source: [Unwritable state dir: prompt refusal transcript naming the cause](https://github.com/cisrd/firstmate/blob/0d556fbe7bf4e97b8cfad2caf4ab2ac91d7678c3/.no-mistakes/evidence/fm/fm-nomistakes-fix-agent-deadlock/unwritable-state-refusal.txt)

<code>Cannot take the discard-log lock &lt;case&gt;/state/.discarded-pipeline-commits.lock: mktemp: failed to create directory ... Permission denied&#10;REFUSED: --force authorized discarding branch fm/task-x1, pipeline commit fix0head, but the durable record of that discard could NOT be written ...&#10;exit status: 1 (elapsed: 1s; pre-fix this hung until killed, holding $STATE/.control-task-x1.lock)&#10;worktree still present: yes&#10;treehouse return invoked: no</code>

```text
# $STATE goes read-only after the verification query, before the discard record is written
$ fm-teardown.sh task-x1 --force
DISCARDING UNLANDED WORK: no-mistakes run for task-x1 left pipeline-committed work in the gate that never reached this worktree (<case>/wt).
Proceeding because --force was passed. Treat --force here as your explicit authorization to discard THIS work (branch fm/task-x1, pipeline commit fix0head) - it is not a convenience bypass, and teardown is about to make it unrecoverable.
Cannot take the discard-log lock <case>/state/.discarded-pipeline-commits.lock: mktemp: failed to create directory via template ‘<case>/state/.discarded-pipeline-commits.lock.probe.XXXXXX’: Permission denied
REFUSED: --force authorized discarding branch fm/task-x1, pipeline commit fix0head, but the durable record of that discard could NOT be written to <case>/state/.discarded-pipeline-commits.log, so teardown would destroy work that nothing afterwards can account for.
This is a RECORD-WRITE failure, not a no-mistakes failure: the axi status check itself completed. Fix write access to <case>/state (permissions, disk space, read-only mount), then re-run with --force.

exit status: 1   (elapsed: 1s; pre-fix this hung until killed, holding $STATE/.control-task-x1.lock)
worktree still present: yes
treehouse return invoked: no
```
</details>
<details>
<summary>Evidence: Pre-fix vs target regression check for both fixes</summary>

Source: [Pre-fix vs target regression check for both fixes](https://github.com/cisrd/firstmate/blob/0d556fbe7bf4e97b8cfad2caf4ab2ac91d7678c3/.no-mistakes/evidence/fm/fm-nomistakes-fix-agent-deadlock/prefix-regression-check.txt)

<code>@101bd07: not ok - unwritable-state: teardown hung on a lock it could never create instead of refusing&#10;@d4de08e: not ok - concurrent-discard-race: expected all 20 ... records to survive rotation, only 4 did&#10;@61674ff: ok (both)</code>

```text
Regression check: the two new tests run against the PRE-FIX product code (tests kept at target commit)

--- bin/fm-teardown.sh @ 101bd07 (before 'refuse promptly when the state dir is unwritable') ---
$ bash tests/fm-teardown.test.sh  # test_unwritable_state_refuses_promptly_instead_of_hanging
not ok - unwritable-state: teardown hung on a lock it could never create instead of refusing

--- bin/fm-teardown.sh @ d4de08e (before 'serialize the discard-log rotation') ---
$ bash tests/fm-teardown.test.sh  # test_concurrent_forced_discards_do_not_lose_records
not ok - concurrent-discard-race: expected all 20 concurrently discarded tasks' records to survive rotation, only 4 did

--- both at target commit 61674ff ---
ok - an unwritable state refuses the forced discard promptly and names the cause, instead of hanging on the lock
ok - --force refuses when the durable discard record cannot be written, rather than destroying untraceable work
ok - concurrent forced discards across different tasks never lose an already-recorded discard to a racing rotation
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0fbbcb67d5e7d756fc6051973e815c83870937e8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ⚠️ `bin/fm-teardown.sh:1775` - `fm_lock_acquire_wait &#34;$NM_DISCARD_LOG_LOCK&#34; || return 1` can never take the `|| return 1` arm: fm_lock_acquire_wait (bin/fm-wake-lib.sh:895) is `while ! fm_lock_try_acquire &#34;$lockdir&#34;; do sleep 0.1; done`, so it only exits on success. Worse, when the lock cannot be created at all, fm_lock_try_acquire does not return either - it falls through to the steal branch and recursively calls itself on `$lockdir.steal`, then `$lockdir.steal.steal`, without bound. Verified by sourcing bin/fm-wake-lib.sh and calling fm_lock_acquire_wait against a chmod 555 directory: no return within 25s and no output; with FUNCNEST=200 it reports `maximum function nesting level exceeded` from fm_lock_owner_dir/fm_path_age. Failure scenario: `$STATE` becomes unwritable or hits ENOSPC after teardown started (the control lock at bin/fm-teardown.sh:344 proves it was writable at startup, so this is the fill-up-mid-run window), then a `--force` teardown trips the unrecovered-pipeline-commits guard. The header contract at bin/fm-teardown.sh:196-199 and the refusal at bin/fm-teardown.sh:2986 promise &#34;REFUSED: ... the durable record of that discard could NOT be written&#34;; instead record_discarded_pipeline_commits never returns, so teardown hangs while still holding `$STATE/.control-$ID.lock` (acquired at line 344, released only by the EXIT trap), and every later lifecycle action for that task exits 1 with &#34;another lifecycle action is already running&#34; until the hung process is killed. The existing test simulates the unwritable case by placing a directory at the log path (tests/fm-teardown.test.sh:2391), which leaves `$STATE` itself writable, so the lock acquires and this path is never exercised. Fix: before acquiring, confirm the log&#39;s directory is writable (or otherwise bound the acquisition) and `return 1` so the already-implemented refusal path runs.
- ℹ️ `bin/fm-teardown.sh:1786` - The 262144-byte trigger and `tail -n 2000` retention are copied from bin/fm-push-transition-lib.sh:81-82, but discard-log lines are much longer than triage lines. A realistic record - `[2026-08-30T14:03:11+0200] task=task-a1b2 reason=pipeline-ahead-unverifiable branch=fm/... pipeline_head=&lt;40 hex&gt; worktree=/home/.../treehouse/...` - runs ~230 bytes, so 2000 retained lines is ~460 KB, still above the 262144 threshold. Consequence: once the log first crosses the cap it stays permanently above it, and every subsequent forced discard re-runs the full `tail -n 2000` + `mv` inside the fleet-wide lock rather than trimming below the threshold. The file is still bounded (2000 records), and docs/configuration.md:799 accurately describes the trim, so nothing is lost or mislabelled - but the documented 256 KiB &#34;size cap&#34; is never actually reached. Retaining fewer lines (or deriving the count from the byte budget) would make the cap bind and make rotation a rare event.
- ℹ️ `tests/fm-teardown.test.sh:2341` - `make_path_without_bounded_tools` is a verbatim copy of `make_path_without_lsof` (tests/fm-teardown.test.sh:587) apart from the command list - the new one simply omits `timeout` and `perl` from the same symlink loop. The two can be one helper parameterized by the excluded commands (e.g. `make_path_excluding &lt;case-dir&gt; &lt;dir-name&gt; &lt;cmd&gt;...`), removing ~10 duplicated lines and the risk of the two lists drifting when a new command dependency is added to teardown. Non-functional, test-only.

🔧 Fix: refuse promptly when the discard log&#39;s state dir is unwritable
3 infos still open:

- ℹ️ `tests/fm-teardown.test.sh:2459` - The new regression test asserts on coreutils&#39; own error text (`assert_grep &#34;Permission denied&#34;`) rather than only on teardown&#39;s own message. `mktemp -d`&#39;s failure string is locale-translated, and neither tests/fm-teardown.test.sh nor bin/fm-teardown.sh pins LC_ALL for this path (the script only sets LC_ALL=C for `ps` at bin/fm-teardown.sh:1879 and `sort` at :2493). On a runner with e.g. LANG=fr_FR.UTF-8, mktemp emits &#34;Permission non accordee&#34;, the assert fails, and the suite reports a regression in code that is behaving exactly as designed. Every other permission-denial test in this repo (tests/fm-watch-triage.test.sh:970, tests/fm-daemon.test.sh:455, tests/fm-secondmate-safety.test.sh:184) asserts behavior, not the OS error string. Fix: add LC_ALL=C to the bounded teardown invocation&#39;s env in this case (the run already sets FM_ROOT_OVERRIDE/FM_STATE_OVERRIDE/PATH inline), which also makes the assertion a genuine contract rather than an accident of the host locale. The sibling assert on &#34;Cannot take the discard-log lock&#34; is teardown&#39;s own text and is fine as-is.
- ℹ️ `bin/fm-teardown.sh:1803` - Residual, acknowledged rather than actionable in this PR&#39;s scope. The probe closes the reported hang for every non-racing case (I confirmed it re-probes on each pass, so a $STATE that goes unwritable while parked behind another task&#39;s discard is caught on the next iteration). What remains is the gap between a successful `nm_discard_log_dir_accepts_writes` and `fm_lock_try_acquire` on the same line: if $STATE loses writability inside that window, fm_lock_try_create&#39;s mktemp still fails, and fm_lock_try_acquire still falls through to the unbounded `$lockdir.steal` recursion (bin/fm-wake-lib.sh:832), hanging teardown while it holds $STATE/.control-$ID.lock. The earliest shared boundary that would make the invariant hold for all callers is fm_lock_try_acquire returning 1 when fm_lock_owner_dir fails, instead of treating an uncreatable owner dir as a stale-owner steal - which would also fix bin/fm-teardown.sh:344&#39;s own single-try control-lock acquisition, where the identical hang is already reachable today with no race at all. Round 1&#39;s recorded decision explicitly scoped the fix to the call site (&#34;Fix the lock failure path within the accepted PR scope&#34;), so this is noted, not requested: the sub-millisecond residual is a strict improvement over the unconditional hang and the shared-boundary change is a separate, wider blast radius.
- ℹ️ `bin/fm-teardown.sh:2994` - On the unrecordable-discard path the loud notice is emitted before the record write is attempted, so stderr reads &#34;Proceeding because --force was passed... teardown is about to make it unrecoverable&#34; and then, three lines later, &#34;REFUSED: ... the durable record of that discard could NOT be written&#34;. An operator or log scan reading only the first sentence concludes the worktree was discarded when it was in fact preserved. This is a sequencing wart, not a defect: the exit code is 1, the worktree and task meta survive (asserted by test_unrecordable_discard_under_force_refuses and the new unwritable-state case), and I found no consumer in bin/ that parses teardown&#39;s stderr - fm-control.sh and the supervisor paths key off the exit status. Emitting the &#34;Proceeding&#34; line only after record_discarded_pipeline_commits succeeds would remove the contradiction, but it also changes ordering the round-3/round-4 decisions settled (the notice is deliberately &#34;before any destructive step&#34;), so it is the author&#39;s call rather than a mechanical fix.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-teardown.test.sh` filtered to `test_unwritable_state_refuses_promptly_instead_of_hanging`, `test_unrecordable_discard_under_force_refuses`, `test_concurrent_forced_discards_do_not_lose_records`, `test_unanswerable_status_query_under_force_is_loud_and_recorded`, `test_unrecovered_pipeline_commits_are_discarded_under_force`, `test_missing_bounded_execution_tool_is_named_in_the_refusal`, `test_lsof_absent_reaps_tmux_process_group` — all pass</code>
- <code>Regression proof: same `test_unwritable_state_refuses_promptly_instead_of_hanging` run against `bin/fm-teardown.sh` @ 101bd07 (pre-fix) fails with `teardown hung on a lock it could never create`</code>
- <code>Regression proof: same `test_concurrent_forced_discards_do_not_lose_records` run against `bin/fm-teardown.sh` @ d4de08e (pre-serialization) fails, only 4–8 of 20 records survive rotation</code>
- <code>Manual end-to-end: 10 concurrent `bin/fm-teardown.sh task-dN --force` runs sharing one $STATE with `FM_DISCARD_LOG_MAX_BYTES=80`, then `cat $STATE/.discarded-pipeline-commits.log` — 10/10 records present</code>
- <code>Manual end-to-end: `bin/fm-teardown.sh task-x1 --force` with $STATE made read-only after the axi status query — exit 1 in ~1s, refusal names `Permission denied` on the lock probe, worktree still present, no treehouse return</code>
- <code>Safety-preservation set: `test_no_mistakes_origin_remote_allows`, `test_no_mistakes_truly_unpushed_refuses`, `test_parked_own_run_is_aborted_before_teardown`, `test_parked_run_abort_leaves_unrecovered_commits_refuses`, `test_unanswerable_status_query_refuses_teardown`, `test_gated_branch_still_refuses_on_unanswerable_query`, `test_ungated_branch_tears_down_despite_unanswerable_query` — all pass</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
