### PR TITLE
test: centralize shared shell fixtures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,8 @@ Family selection is the ordinary local path; `--all` is deliberate full regressi
 CI owns broad regression across required portable parallel shards, the portable serial lane's separate-runner shards, the Herdr lane, lint, invariants, the coverage guard, and stock macOS Bash compatibility in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 Use `bin/fm-test-run.sh --list-lanes` for exact lane names and `--help` for `--jobs` rules and required gate-skip flags when reproducing a lane locally.
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so pass one to `bin/fm-test-run.sh` to focus on a subject with canonical timing output.
+Shared test helpers live in `tests/lib.sh` (reporters, temp roots, git fixtures), `tests/fixtures.sh` (fake toolchain and spawn-world builders), `tests/wake-helpers.sh`, and `tests/secondmate-helpers.sh`.
+Source those instead of copying a fake toolchain into a new suite.
 A fixture may shorten a production timeout to keep a failure path prompt, but never below what the real work inside that window costs on a loaded machine: a fork, an exec, a lock acquisition, a beacon publication, or a first-poll check.
 Where a case's assertion is not about the timeout itself, give that window headroom over the measured loaded cost, and bound the test's own waiting with iteration-counted poll loops, which stretch under load where a wall-clock budget does not.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the portable suite remains safe on machines without those tools.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -598,6 +598,7 @@ tests/fm-task-delivery.test.sh 2414
 tests/fm-teardown-endpoint-safety.test.sh 7295
 tests/fm-teardown.test.sh 87400
 tests/fm-test-fixture-cleanup.test.sh 532
+tests/fm-test-fixtures.test.sh 1045
 tests/fm-test-isolation-proof.test.sh 451
 tests/fm-tmux-agent-liveness.test.sh 4065
 tests/fm-tool-update-check.test.sh 12846
@@ -1228,7 +1229,7 @@ families_for_changed_path() {
     docs/configuration.md|docs/supervision-protocols/*)
       printf '%s\n' pure-contract-unit
       ;;
-    tests/lib.sh|tests/*-helpers.sh)
+    tests/lib.sh|tests/*-helpers.sh|tests/fixtures.sh)
       families_for_test_reference "$(basename "$path")" \
         || printf '%s\n' "__unmapped__:$path"
       ;;

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# tests/fixtures.sh - shared fake-toolchain and spawn-world builders.
+#
+# Source this from a test file:
+#   # shellcheck source=tests/fixtures.sh
+#   . "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+#
+# Generic reporters, temp roots, git fixtures, and fail/pass/fm_test_cleanup
+# come from tests/lib.sh, pulled in below. This file owns the fake no-mistakes,
+# gh, gh-axi, tmux, ssh, and spawn-world helpers that used to be copied into
+# each suite. Wake-queue mocks stay in wake-helpers.sh; secondmate-lifecycle
+# mocks stay in secondmate-helpers.sh.
+#
+# A version-floor bump for the fake no-mistakes banner is a one-line change of
+# FM_TEST_NO_MISTAKES_VERSION below. Override a single case with
+# FM_FAKE_NO_MISTAKES_VERSION rather than editing a stub body.
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+if [ -n "${FM_TEST_FIXTURES_SOURCED:-}" ]; then
+  return 0
+fi
+FM_TEST_FIXTURES_SOURCED=1
+
+# Production floor lives in bin/fm-bootstrap.sh (NO_MISTAKES_MIN). Keep this
+# equal to that floor so a bump is one constant here plus that production pin.
+export FM_TEST_NO_MISTAKES_VERSION=1.46.0
+export FM_TEST_NO_MISTAKES_FAKE_VERSION="no-mistakes version v${FM_TEST_NO_MISTAKES_VERSION} (fake)"
+export FM_TEST_NO_MISTAKES_FAKE_VERSION_TS="${FM_TEST_NO_MISTAKES_FAKE_VERSION} 2026-06-27T00:02:18Z"
+export FM_TEST_GH_AXI_VERSION=0.1.29
+
+# --- fake no-mistakes -------------------------------------------------------
+
+# fm_test_fake_no_mistakes <fakebin>
+# Drops a no-mistakes stub that answers --version with
+# FM_TEST_NO_MISTAKES_FAKE_VERSION (or FM_FAKE_NO_MISTAKES_VERSION when set)
+# and exits 0 for every other invocation.
+fm_test_fake_no_mistakes() {
+  local fakebin=$1
+  cat > "$fakebin/no-mistakes" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = --version ]; then
+  printf '%s\\n' "\${FM_FAKE_NO_MISTAKES_VERSION:-$FM_TEST_NO_MISTAKES_FAKE_VERSION}"
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/no-mistakes"
+}
+
+# fm_test_fake_no_mistakes_init_doctor <fakebin>
+# Secondmate-lifecycle stub: init/doctor touch marker files; other verbs exit 2.
+# Does not answer --version (those suites never probe the floor).
+fm_test_fake_no_mistakes_init_doctor() {
+  local fakebin=$1
+  cat > "$fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+set -eu
+case "${1:-}" in
+  init) touch .no-mistakes-init ;;
+  doctor) touch .no-mistakes-doctor ;;
+  *) exit 2 ;;
+esac
+SH
+  chmod +x "$fakebin/no-mistakes"
+}
+
+# --- fake gh / gh-axi -------------------------------------------------------
+
+# fm_test_fake_gh <fakebin>
+# Authenticates (`gh auth status` exits 0) and otherwise exits 0. A superset of
+# the exit-0-only copies.
+fm_test_fake_gh() {
+  local fakebin=$1
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = auth ] && [ "${2:-}" = status ]; then
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/gh"
+}
+
+# fm_test_fake_gh_axi <fakebin>
+# Answers --version with FM_FAKE_GH_AXI_VERSION or FM_TEST_GH_AXI_VERSION.
+fm_test_fake_gh_axi() {
+  local fakebin=$1
+  fm_fake_version_tool "$fakebin" gh-axi FM_FAKE_GH_AXI_VERSION "$FM_TEST_GH_AXI_VERSION"
+}
+
+# --- fake tmux / ssh / sleep ------------------------------------------------
+
+# fm_test_fake_tmux_spawn <fakebin>
+# Spawn-world tmux: pane_current_path from FM_FAKE_PANE_PATH, session named
+# firstmate, window ops succeed, send-keys succeed. When FM_FAKE_LAUNCH_LOG is
+# set, each send-keys -l payload is appended one per line. Optional
+# FM_FAKE_DUPLICATE_WINDOW is printed from list-windows.
+#
+# Converged from the spawn-suite copies. Divergences reconciled here:
+# - pane path uses ${FM_FAKE_PANE_PATH:-} (8 of 9 copies); the pool-freshen
+#   copy used :? and failed closed when unset. Callers always set the var.
+# - kill-window and set-window-option are no-ops (gate-refuse and grok
+#   included them; the others ignored unknown verbs by exiting 0 at the
+#   bottom anyway).
+# - send-keys launch logging is env-gated, so suites that never set the log
+#   keep a silent send-keys.
+fm_test_fake_tmux_spawn() {
+  local fakebin=$1
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows)
+    if [ -n "${FM_FAKE_DUPLICATE_WINDOW:-}" ]; then
+      printf '%s\n' "$FM_FAKE_DUPLICATE_WINDOW"
+    fi
+    exit 0
+    ;;
+  has-session|new-session|new-window|kill-window|set-window-option) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-l" ]; then
+          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
+        fi
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+}
+
+# fm_test_fake_tmux_send <fakebin>
+# Send-world tmux: logs send-keys -l payloads to FM_SEND_LOG, reports a numeric
+# cursor_y, and renders an empty bordered composer so the submit path reads
+# empty. Env knobs:
+#   FM_FAKE_TMUX_SEND_FAIL=1  send-keys exits 1
+#   FM_FAKE_TMUX_COMPOSER=pending  capture-pane shows leftover composer text
+fm_test_fake_tmux_send() {
+  local fakebin=$1
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  send-keys)
+    [ "${FM_FAKE_TMUX_SEND_FAIL:-0}" = 1 ] && exit 1
+    shift
+    literal=0
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -t) shift 2 ;;
+        -l) literal=1; shift ;;
+        *) break ;;
+      esac
+    done
+    if [ "$literal" = 1 ]; then
+      printf '%s' "${1:-}" >> "${FM_SEND_LOG:-/dev/null}"
+    fi
+    exit 0
+    ;;
+  display-message)
+    for a in "$@"; do
+      case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac
+    done
+    printf 'fakepane\n'
+    exit 0
+    ;;
+  capture-pane)
+    if [ "${FM_FAKE_TMUX_COMPOSER:-}" = pending ]; then
+      printf '╭──────────────╮\n│ leftover txt │\n╰──────────────╯\n'
+    else
+      printf '╭────╮\n│    │\n╰────╯\n'
+    fi
+    exit 0
+    ;;
+  list-windows) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+}
+
+# fm_test_fake_ssh <fakebin> [name]
+# Records argv to FM_SSH_LOG, consumes stdin, exits FM_FAKE_SSH_RC (default 0).
+# Default name is fake-ssh so tests can point FM_SSH_BIN at it without
+# shadowing a real ssh on PATH.
+fm_test_fake_ssh() {
+  local fakebin=$1 name=${2:-fake-ssh}
+  cat > "$fakebin/$name" <<'SH'
+#!/usr/bin/env bash
+cat > /dev/null
+printf '%s\n' "$*" >> "${FM_SSH_LOG:-/dev/null}"
+exit "${FM_FAKE_SSH_RC:-0}"
+SH
+  chmod +x "$fakebin/$name"
+}
+
+# fm_test_fake_sleep_noop <fakebin>
+fm_test_fake_sleep_noop() {
+  local fakebin=$1
+  cat > "$fakebin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fakebin/sleep"
+}
+
+# fm_test_fake_sleep_log <fakebin>
+# Records each requested duration to FM_SLEEP_LOG instead of sleeping.
+fm_test_fake_sleep_log() {
+  local fakebin=$1
+  cat > "$fakebin/sleep" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-}" >> "${FM_SLEEP_LOG:-/dev/null}"
+exit 0
+SH
+  chmod +x "$fakebin/sleep"
+}
+
+# --- spawn-world ------------------------------------------------------------
+
+# fm_test_spawn_home <home> [harness]
+# Minimal firstmate home layout plus watcher-liveness beat. Optional harness
+# pin is written to config/crew-harness.
+fm_test_spawn_home() {
+  local home=$1 harness=${2-}
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  touch "$home/state/.last-watcher-beat"
+  if [ -n "$harness" ]; then
+    printf '%s\n' "$harness" > "$home/config/crew-harness"
+  fi
+}
+
+# fm_test_spawn_brief <home> <id> [text]
+fm_test_spawn_brief() {
+  local home=$1 id=$2 text=${3:-brief for $2}
+  mkdir -p "$home/data/$id"
+  printf '%s\n' "$text" > "$home/data/$id/brief.md"
+}
+
+# fm_test_make_spawn_fakebin <dir> [extra-exit0-tool...]
+# Creates <dir>/fakebin with the spawn tmux stub, a no-op treehouse, and any
+# extra exit-0 tools. Echoes the fakebin path.
+fm_test_make_spawn_fakebin() {
+  local dir=$1 fakebin
+  shift
+  fakebin=$(fm_fakebin "$dir")
+  fm_test_fake_tmux_spawn "$fakebin"
+  fm_fake_exit0 "$fakebin" treehouse "$@"
+  printf '%s\n' "$fakebin"
+}
+
+# Drop-in name used by the spawn suites. Extra args are additional exit-0 tools
+# (gh, gh-axi, pi, ...).
+make_spawn_fakebin() {
+  fm_test_make_spawn_fakebin "$@"
+}
+
+# fm_test_run_spawn <home> <pane-path> <fakebin> [fm-spawn args...]
+# Common spawn env. Extra variables in the caller (GROK_HOME, FM_FAKE_LAUNCH_LOG,
+# CLAUDE_CONFIG_DIR, ...) are inherited. Does not add --mode/--yolo; ship tests
+# that need a delivery contract pass those flags themselves.
+fm_test_run_spawn() {
+  local home=$1 pane=$2 fakebin=$3
+  shift 3
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="${TMUX:-fake,1,0}" \
+    PATH="$fakebin:$PATH" \
+    "$ROOT/bin/fm-spawn.sh" "$@" 2>&1
+}
+
+# --- send-world stubs -------------------------------------------------------
+
+# make_stubs <dir>
+# Send-world fakebin: send tmux + no-op sleep. Echoes the fakebin path.
+# Suites that need recording sleep, herdr, or ssh add those on top of this
+# fakebin (or replace sleep via fm_test_fake_sleep_log).
+make_stubs() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  fm_test_fake_tmux_send "$fakebin"
+  fm_test_fake_sleep_noop "$fakebin"
+  printf '%s\n' "$fakebin"
+}

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -6,14 +6,14 @@
 #   . "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 #
 # Generic reporters, temp roots, git fixtures, and fail/pass/fm_test_cleanup
-# come from tests/lib.sh, pulled in below. This file owns the fake no-mistakes,
-# gh, gh-axi, tmux, ssh, and spawn-world helpers that used to be copied into
-# each suite. Wake-queue mocks stay in wake-helpers.sh; secondmate-lifecycle
-# mocks stay in secondmate-helpers.sh.
+# come from tests/lib.sh, pulled in below. This file owns the shared fake
+# no-mistakes, gh, gh-axi, tmux, ssh, and spawn-world helpers. Wake-queue mocks
+# stay in wake-helpers.sh; secondmate-lifecycle mocks stay in
+# secondmate-helpers.sh.
 #
-# A version-floor bump for the fake no-mistakes banner is a one-line change of
-# FM_TEST_NO_MISTAKES_VERSION below. Override a single case with
-# FM_FAKE_NO_MISTAKES_VERSION rather than editing a stub body.
+# FM_TEST_NO_MISTAKES_VERSION is the single default version for the shared fake
+# no-mistakes banner. Override a single case with FM_FAKE_NO_MISTAKES_VERSION
+# rather than editing a stub body.
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
@@ -69,8 +69,7 @@ SH
 # --- fake gh / gh-axi -------------------------------------------------------
 
 # fm_test_fake_gh <fakebin>
-# Authenticates (`gh auth status` exits 0) and otherwise exits 0. A superset of
-# the exit-0-only copies.
+# Authenticates (`gh auth status` exits 0) and otherwise exits 0.
 fm_test_fake_gh() {
   local fakebin=$1
   cat > "$fakebin/gh" <<'SH'
@@ -98,14 +97,9 @@ fm_test_fake_gh_axi() {
 # set, each send-keys -l payload is appended one per line. Optional
 # FM_FAKE_DUPLICATE_WINDOW is printed from list-windows.
 #
-# Converged from the spawn-suite copies. Divergences reconciled here:
-# - pane path uses ${FM_FAKE_PANE_PATH:-} (8 of 9 copies); the pool-freshen
-#   copy used :? and failed closed when unset. Callers always set the var.
-# - kill-window and set-window-option are no-ops (gate-refuse and grok
-#   included them; the others ignored unknown verbs by exiting 0 at the
-#   bottom anyway).
-# - send-keys launch logging is env-gated, so suites that never set the log
-#   keep a silent send-keys.
+# The pane path defaults to empty when FM_FAKE_PANE_PATH is unset. Window
+# cleanup and option operations are no-ops. Launch logging is env-gated, so
+# suites that do not set FM_FAKE_LAUNCH_LOG keep a silent send-keys.
 fm_test_fake_tmux_spawn() {
   local fakebin=$1
   cat > "$fakebin/tmux" <<'SH'

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -9,35 +9,13 @@
 # with no live harness session.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-busy-lib.sh"
 
-SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-busy-adapter-wiring)
-
-make_spawn_fakebin() {
-  local dir=$1 fakebin
-  fakebin=$(fm_fakebin "$dir")
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-set -u
-case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
-esac
-case "${1:-}" in
-  display-message) printf 'firstmate\n'; exit 0 ;;
-  list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
-esac
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse pi opencode claude codex
-  printf '%s\n' "$fakebin"
-}
 
 make_spawn_case() {  # <name> <harness> <id>
   local name=$1 harness=$2 id=$3 case_dir home proj wt fakebin
@@ -45,13 +23,10 @@ make_spawn_case() {  # <name> <harness> <id>
   home="$case_dir/home"
   proj="$case_dir/project"
   wt="$case_dir/wt"
-  fakebin=$(make_spawn_fakebin "$case_dir/fake")
-  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
-  printf '%s\n' "$harness" > "$home/config/crew-harness"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake" pi opencode claude codex)
+  fm_test_spawn_home "$home" "$harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
-  touch "$home/state/.last-watcher-beat"
-  mkdir -p "$home/data/$id"
-  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  fm_test_spawn_brief "$home" "$id"
   printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin"
 }
 
@@ -61,13 +36,8 @@ run_spawn() {  # <home> <wt> <fakebin> <spawn-args...>
   # fixed valid one.
   local home=$1 wt=$2 fakebin=$3
   shift 3
-  set -- "$@" --mode no-mistakes --yolo off
-  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
-    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
-    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
-    GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
-    "$SPAWN" "$@" 2>&1
+  GROK_HOME="$home/grok-home" \
+    fm_test_run_spawn "$home" "$wt" "$fakebin" "$@" --mode no-mistakes --yolo off
 }
 
 read_case_record() {

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -27,8 +27,8 @@
 # agents' project instructions on the no-mistakes side).
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 GATE_LIB="$ROOT/bin/fm-gate-refuse-lib.sh"
 SPAWN="$ROOT/bin/fm-spawn.sh"
@@ -133,40 +133,18 @@ test_helper_normal_is_noop() {
 
 # --- fm-spawn ---------------------------------------------------------------
 
-# A fake tmux/treehouse so fm-spawn resolves the crew worktree from a controlled
-# pane path and completes without a live terminal (mirrors tests/fm-tangle-guard).
-make_spawn_fakebin() {
-  local dir=$1 fakebin
-  fakebin=$(fm_fakebin "$dir")
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-set -u
-case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
-esac
-case "${1:-}" in
-  display-message) printf 'firstmate\n'; exit 0 ;;
-  list-windows) exit 0 ;;
-  has-session|new-session|new-window|send-keys|set-window-option) exit 0 ;;
-esac
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
-  printf '%s\n' "$fakebin"
-}
-
 # run_spawn <cwd> <home> <id> <proj> <pane> <fakebin> [ASSIGN...] -> combined output
+# Gate-refuse cases must cd into a controlled cwd and drop both refusal signals
+# so the suite stays hermetic when it itself runs inside a real gate worktree.
 run_spawn() {
   local cwd=$1 home=$2 id=$3 proj=$4 pane=$5 fakebin=$6; shift 6
-  mkdir -p "$home/data/$id"
-  printf 'brief\n' > "$home/data/$id/brief.md"
+  fm_test_spawn_brief "$home" "$id" brief
   ( cd "$cwd" && env -u NO_MISTAKES_GATE -u FM_GATE_REFUSE_BYPASS \
-      "FM_ROOT_OVERRIDE=" "FM_HOME=$home" \
-      "FM_STATE_OVERRIDE=$home/state" "FM_DATA_OVERRIDE=$home/data" \
-      "FM_PROJECTS_OVERRIDE=$home/projects" "FM_CONFIG_OVERRIDE=$home/config" \
-      "FM_SPAWN_NO_GUARD=1" "FM_FAKE_PANE_PATH=$pane" "TMUX=fake,1,0" \
-      "PATH=$fakebin:$PATH" "$@" \
+      FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+      FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+      FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX=fake,1,0 \
+      PATH="$fakebin:$PATH" "$@" \
       "$SPAWN" "$id" "$proj" codex --mode no-mistakes --yolo off ) 2>&1
 }
 

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -2,33 +2,11 @@
 # Behavior tests for Grok-harness hook authentication, teardown cleanup, and session-lock holder detection.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
-SPAWN="$ROOT/bin/fm-spawn.sh"
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 TMP_ROOT=$(fm_test_tmproot fm-grok-harness)
-
-make_spawn_fakebin() {
-  local dir=$1 fakebin
-  fakebin=$(fm_fakebin "$dir")
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-set -u
-case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
-esac
-case "${1:-}" in
-  display-message) printf 'firstmate\n'; exit 0 ;;
-  list-windows) exit 0 ;;
-  has-session|new-session|new-window|send-keys|kill-window) exit 0 ;;
-esac
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
-  printf '%s\n' "$fakebin"
-}
 
 make_spawn_case() {
   local name=$1 case_dir home proj wt fakebin grok_home id
@@ -36,24 +14,21 @@ make_spawn_case() {
   home="$case_dir/home"
   proj="$case_dir/project"
   wt="$case_dir/wt"
-  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  fakebin=$(make_spawn_fakebin "$case_dir/fake" gh-axi gh)
   grok_home="$case_dir/grok"
   id="grok-$name-x1"
-  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config" "$grok_home"
-  printf 'brief\n' > "$home/data/$id/brief.md"
+  mkdir -p "$grok_home"
+  fm_test_spawn_home "$home"
+  fm_test_spawn_brief "$home" "$id" brief
   fm_git_worktree "$proj" "$wt" "fm/$id"
-  touch "$home/state/.last-watcher-beat"
   printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$grok_home|$id"
 }
 
 run_grok_spawn() {
   local home=$1 proj=$2 wt=$3 fakebin=$4 grok_home=$5 id=$6
-  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
-    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
-    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
-    GROK_HOME="$grok_home" PATH="$fakebin:$PATH" \
-    "$SPAWN" "$id" "$proj" grok --mode no-mistakes --yolo off 2>&1
+  GROK_HOME="$grok_home" \
+    fm_test_run_spawn "$home" "$wt" "$fakebin" \
+    "$id" "$proj" grok --mode no-mistakes --yolo off
 }
 
 test_grok_hook_requires_registered_token() {

--- a/tests/fm-inactive-reconcile.test.sh
+++ b/tests/fm-inactive-reconcile.test.sh
@@ -115,9 +115,7 @@ outcome_count() { # <home> <suffix>
 prime_seen() { # <state> <status>
   FM_STATE_OVERRIDE="$1" bash -c '
     . "$1"
-    size=$(_fm_status_file_size "$3") || exit 1
-    ident=$(_fm_open_decisions_file_ident "$3") || exit 1
-    fm_wake_status_seen_commit "$2" "$3" "$size" "$ident"
+    fm_wake_status_mark_current "$2" "$3"
   ' _ "$ROOT/bin/fm-wake-lib.sh" "$1" "$2"
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -7,8 +7,8 @@
 # command firstmate would run without starting any real harness.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-dispatch-profile)
@@ -32,34 +32,7 @@ SH
 
 make_spawn_fakebin() {
   local dir=$1 fakebin
-  fakebin=$(fm_fakebin "$dir")
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-set -u
-case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
-esac
-case "${1:-}" in
-  display-message) printf 'firstmate\n'; exit 0 ;;
-  list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window) exit 0 ;;
-  send-keys)
-    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
-      prev=
-      for a in "$@"; do
-        if [ "$prev" = "-l" ]; then
-          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
-        fi
-        prev=$a
-      done
-    fi
-    exit 0
-    ;;
-esac
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fakebin=$(fm_test_make_spawn_fakebin "$dir")
   cat > "$fakebin/timeout" <<'SH'
 #!/usr/bin/env bash
 shift
@@ -88,13 +61,10 @@ make_spawn_case() {
   wt="$case_dir/wt"
   launchlog="$case_dir/launch.log"
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
-  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
-  printf '%s\n' "$harness" > "$home/config/crew-harness"
+  fm_test_spawn_home "$home" "$harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
-  touch "$home/state/.last-watcher-beat"
   for id in "$@"; do
-    mkdir -p "$home/data/$id"
-    printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+    fm_test_spawn_brief "$home" "$id"
   done
   printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$launchlog"
 }
@@ -121,16 +91,12 @@ run_spawn() {
   # explicitly (empty by default) instead of leaking the invoking shell's value,
   # which would make launch assertions depend on the developer's environment.
   # A test opts in to the set case via FM_TEST_CLAUDE_CONFIG_DIR.
-  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
-    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
-    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
-    CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
+  CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
     FM_FAKE_CURSOR_MODELS="${FM_TEST_CURSOR_MODELS:-}" \
     FM_FAKE_CURSOR_LIST_STATUS="${FM_TEST_CURSOR_LIST_STATUS:-0}" \
-    GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
-    "$SPAWN" "$@" 2>&1
+    GROK_HOME="$home/grok-home" \
+    fm_test_run_spawn "$home" "$wt" "$fakebin" "$@"
 }
 
 # Ship spawns carry an explicit delivery contract (AGENTS.md section 7); these

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -8,31 +8,10 @@
 # unreachable.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
-SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-pool-base-freshen)
-
-make_spawn_fakebin() {
-  local dir=$1 fakebin
-  fakebin=$(fm_fakebin "$dir")
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-set -u
-case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}"; exit 0 ;;
-esac
-case "${1:-}" in
-  display-message) printf 'firstmate\n'; exit 0 ;;
-  list-windows|has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
-esac
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
-  printf '%s\n' "$fakebin"
-}
 
 make_case() {
   local name=$1 id=$2 default=${3:-main} case_dir home project origin pool publisher fakebin initial
@@ -76,12 +55,8 @@ EOF
 run_spawn() {
   local id=$1
   shift
-  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
-    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
-    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
-    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$POOL_DIR" \
-    PATH="$FAKEBIN_DIR:$PATH" \
-    "$SPAWN" "$id" "$PROJECT_DIR" "$@" 2>&1
+  fm_test_run_spawn "$HOME_DIR" "$POOL_DIR" "$FAKEBIN_DIR" \
+    "$id" "$PROJECT_DIR" "$@"
 }
 
 test_stale_pool_base_refreshes_before_branching() {

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -15,8 +15,8 @@
 # abort - all hermetic over temp git repos and fakebins.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-tangle-lib.sh"
@@ -150,40 +150,12 @@ test_brief_assertion_precedes_branch() {
 
 # --- GUARD 1b: fm-spawn isolation abort -------------------------------------
 
-# A fake tmux that reports FM_FAKE_PANE_PATH as the post-`treehouse get` pane cwd
-# (so the spawn's worktree-resolution loop resolves to a path we control), names
-# the session on '#S', and swallows window ops. Echoes the fakebin dir.
-make_spawn_fakebin() {
-  local dir=$1 fakebin
-  fakebin=$(fm_fakebin "$dir")
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-set -u
-case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
-esac
-case "${1:-}" in
-  display-message) printf 'firstmate\n'; exit 0 ;;
-  list-windows) exit 0 ;;
-  has-session|new-session|new-window|send-keys) exit 0 ;;
-esac
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
-  printf '%s\n' "$fakebin"
-}
-
+# Spawn isolation uses the shared spawn fakebin (pane path + window ops).
 run_spawn() {
   local home=$1 id=$2 proj=$3 pane=$4 fakebin=$5
-  mkdir -p "$home/data/$id"
-  printf 'brief\n' > "$home/data/$id/brief.md"
-  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
-    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
-    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
-    PATH="$fakebin:$PATH" \
-    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex --mode no-mistakes --yolo off 2>&1
+  fm_test_spawn_brief "$home" "$id" brief
+  fm_test_run_spawn "$home" "$pane" "$fakebin" \
+    "$id" "$proj" codex --mode no-mistakes --yolo off
 }
 
 test_spawn_isolation_abort() {
@@ -255,15 +227,10 @@ SH
 
 run_spawn_record() {
   local home=$1 id=$2 proj=$3 pane=$4 fakebin=$5 rec=$6
-  mkdir -p "$home/data/$id"
-  printf 'brief\n' > "$home/data/$id/brief.md"
-  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
-    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
-    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
-    FM_TMUX_REC="$rec" \
-    PATH="$fakebin:$PATH" \
-    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex --mode no-mistakes --yolo off 2>&1
+  fm_test_spawn_brief "$home" "$id" brief
+  FM_TMUX_REC="$rec" \
+    fm_test_run_spawn "$home" "$pane" "$fakebin" \
+    "$id" "$proj" codex --mode no-mistakes --yolo off
 }
 
 test_spawn_tmux_window_construction() {

--- a/tests/fm-test-fixtures.test.sh
+++ b/tests/fm-test-fixtures.test.sh
@@ -77,6 +77,8 @@ test_spawn_tmux_and_fakebin() {
   : > "$log"
   out=$(FM_FAKE_PANE_PATH=/tmp/wt "$fakebin/tmux" display-message -p '#{pane_current_path}')
   [ "$out" = /tmp/wt ] || fail "spawn tmux pane path should be FM_FAKE_PANE_PATH, got '$out'"
+  out=$(unset FM_FAKE_PANE_PATH; "$fakebin/tmux" display-message -p '#{pane_current_path}')
+  [ -z "$out" ] || fail "spawn tmux pane path should default to empty, got '$out'"
   out=$("$fakebin/tmux" display-message -p '#S')
   [ "$out" = firstmate ] || fail "spawn tmux session name should be firstmate, got '$out'"
   FM_FAKE_LAUNCH_LOG="$log" "$fakebin/tmux" send-keys -t @w -l 'codex --yolo'

--- a/tests/fm-test-fixtures.test.sh
+++ b/tests/fm-test-fixtures.test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Behavior tests for tests/fixtures.sh fake-toolchain and spawn-world builders.
+#
+# These cases drive the builders as a test would: they write stubs into a
+# fakebin and exec those stubs. Assertions are on the binaries' observable
+# output, exit status, and files they create - never on fixtures.sh source
+# text. Migrated spawn suites cover fm_test_run_spawn through the real
+# fm-spawn.sh; this file pins the stubs those suites now share.
+set -u
+
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-test-fixtures)
+
+test_no_mistakes_version_constant() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/nm")
+  fm_test_fake_no_mistakes "$fakebin"
+  out=$("$fakebin/no-mistakes" --version)
+  [ "$out" = "$FM_TEST_NO_MISTAKES_FAKE_VERSION" ] || \
+    fail "fake no-mistakes --version should be the shared constant, got '$out'"
+  out=$(FM_FAKE_NO_MISTAKES_VERSION="$FM_TEST_NO_MISTAKES_FAKE_VERSION_TS" \
+    "$fakebin/no-mistakes" --version)
+  [ "$out" = "$FM_TEST_NO_MISTAKES_FAKE_VERSION_TS" ] || \
+    fail "timestamped banner override should round-trip, got '$out'"
+  case "$out" in
+    "$FM_TEST_NO_MISTAKES_FAKE_VERSION "*) ;;
+    *) fail "timestamped banner '$out' is not the shared constant plus a suffix" ;;
+  esac
+  out=$(FM_FAKE_NO_MISTAKES_VERSION='no-mistakes version v9.9.9 (fake)' \
+    "$fakebin/no-mistakes" --version)
+  [ "$out" = 'no-mistakes version v9.9.9 (fake)' ] || \
+    fail "FM_FAKE_NO_MISTAKES_VERSION should override the default banner, got '$out'"
+  "$fakebin/no-mistakes" doctor
+  expect_code 0 $? "fake no-mistakes non-version verbs should exit 0"
+  pass "fake no-mistakes --version is the shared constant and overridable"
+}
+
+test_no_mistakes_init_doctor_markers() {
+  local fakebin dir rc
+  dir="$TMP_ROOT/nm-init"
+  mkdir -p "$dir"
+  fakebin=$(fm_fakebin "$dir")
+  fm_test_fake_no_mistakes_init_doctor "$fakebin"
+  ( cd "$dir" && "$fakebin/no-mistakes" init )
+  assert_present "$dir/.no-mistakes-init" "init did not touch the marker"
+  ( cd "$dir" && "$fakebin/no-mistakes" doctor )
+  assert_present "$dir/.no-mistakes-doctor" "doctor did not touch the marker"
+  rc=0
+  ( cd "$dir" && "$fakebin/no-mistakes" axi ) || rc=$?
+  expect_code 2 "$rc" "unknown no-mistakes verb should exit 2"
+  pass "init/doctor no-mistakes stub touches markers and refuses other verbs"
+}
+
+test_fake_gh_and_gh_axi() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/gh")
+  fm_test_fake_gh "$fakebin"
+  fm_test_fake_gh_axi "$fakebin"
+  "$fakebin/gh" auth status
+  expect_code 0 $? "fake gh auth status should succeed"
+  "$fakebin/gh" pr list
+  expect_code 0 $? "fake gh other verbs should exit 0"
+  out=$("$fakebin/gh-axi" --version)
+  [ "$out" = "$FM_TEST_GH_AXI_VERSION" ] || \
+    fail "fake gh-axi --version should be $FM_TEST_GH_AXI_VERSION, got '$out'"
+  out=$(FM_FAKE_GH_AXI_VERSION=0.9.9 "$fakebin/gh-axi" --version)
+  [ "$out" = 0.9.9 ] || fail "FM_FAKE_GH_AXI_VERSION should override, got '$out'"
+  pass "fake gh authenticates and fake gh-axi reports the shared version"
+}
+
+test_spawn_tmux_and_fakebin() {
+  local fakebin out log
+  fakebin=$(make_spawn_fakebin "$TMP_ROOT/spawn" gh-axi)
+  log="$TMP_ROOT/spawn/launch.log"
+  : > "$log"
+  out=$(FM_FAKE_PANE_PATH=/tmp/wt "$fakebin/tmux" display-message -p '#{pane_current_path}')
+  [ "$out" = /tmp/wt ] || fail "spawn tmux pane path should be FM_FAKE_PANE_PATH, got '$out'"
+  out=$("$fakebin/tmux" display-message -p '#S')
+  [ "$out" = firstmate ] || fail "spawn tmux session name should be firstmate, got '$out'"
+  FM_FAKE_LAUNCH_LOG="$log" "$fakebin/tmux" send-keys -t @w -l 'codex --yolo'
+  assert_grep 'codex --yolo' "$log" "send-keys -l payload was not logged"
+  [ -x "$fakebin/treehouse" ] || fail "spawn fakebin should include treehouse"
+  [ -x "$fakebin/gh-axi" ] || fail "extra exit-0 tools should land in the spawn fakebin"
+  "$fakebin/treehouse" get
+  expect_code 0 $? "fake treehouse should exit 0"
+  pass "spawn fakebin answers pane path, logs -l payloads, and installs extra tools"
+}
+
+test_send_stubs_and_ssh() {
+  local fakebin log ssh_log out
+  fakebin=$(make_stubs "$TMP_ROOT/send")
+  log="$TMP_ROOT/send/send.log"
+  ssh_log="$TMP_ROOT/send/ssh.log"
+  : > "$log"
+  fm_test_fake_ssh "$fakebin"
+  FM_SEND_LOG="$log" "$fakebin/tmux" send-keys -t sess:w -l 'hello steer'
+  assert_grep 'hello steer' "$log" "send stubs did not log the -l payload"
+  out=$("$fakebin/tmux" display-message -p '#{cursor_y}')
+  [ "$out" = 1 ] || fail "send tmux cursor_y should be 1, got '$out'"
+  out=$("$fakebin/tmux" capture-pane -p)
+  case "$out" in
+    *'╭────╮'*) ;;
+    *) fail "send tmux capture-pane should render an empty composer, got '$out'" ;;
+  esac
+  printf 'ignored\n' | FM_SSH_LOG="$ssh_log" "$fakebin/fake-ssh" host -- cmd
+  assert_grep 'host -- cmd' "$ssh_log" "fake ssh did not record argv"
+  FM_FAKE_SSH_RC=7 "$fakebin/fake-ssh" x
+  expect_code 7 $? "fake ssh should honor FM_FAKE_SSH_RC"
+  pass "send stubs log typed text and fake ssh records argv with a controllable exit"
+}
+
+test_spawn_home_layout() {
+  local home="$TMP_ROOT/home"
+  fm_test_spawn_home "$home" claude
+  fm_test_spawn_brief "$home" t1 'do the thing'
+  assert_present "$home/data" "spawn home missing data/"
+  assert_present "$home/state/.last-watcher-beat" "spawn home missing watcher beat"
+  assert_grep claude "$home/config/crew-harness" "crew-harness was not pinned"
+  assert_grep 'do the thing' "$home/data/t1/brief.md" "brief text was not written"
+  pass "spawn-home layout writes harness pin, beat, and brief"
+}
+
+test_no_mistakes_version_constant
+test_no_mistakes_init_doctor_markers
+test_fake_gh_and_gh_axi
+test_spawn_tmux_and_fakebin
+test_send_stubs_and_ssh
+test_spawn_home_layout

--- a/tests/fm-test-fixtures.test.sh
+++ b/tests/fm-test-fixtures.test.sh
@@ -106,7 +106,7 @@ test_send_stubs_and_ssh() {
   esac
   printf 'ignored\n' | FM_SSH_LOG="$ssh_log" "$fakebin/fake-ssh" host -- cmd
   assert_grep 'host -- cmd' "$ssh_log" "fake ssh did not record argv"
-  FM_FAKE_SSH_RC=7 "$fakebin/fake-ssh" x
+  FM_FAKE_SSH_RC=7 "$fakebin/fake-ssh" x < /dev/null
   expect_code 7 $? "fake ssh should honor FM_FAKE_SSH_RC"
   pass "send stubs log typed text and fake ssh records argv with a controllable exit"
 }

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -2518,7 +2518,10 @@ test_timer_repair_drops_a_finished_write_deferral_chain() {
     FM_STALE_ESCALATE_SECS=240 FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
-  wait_numeric_file "$state/.stale-since-$key" 30 \
+  # Watcher startup performs bounded recovery scans before its first stale poll;
+  # give this positive marker assertion the same loaded-runner budget as the
+  # suite's other startup-sensitive waits instead of failing after only 3s.
+  wait_numeric_file "$state/.stale-since-$key" 100 \
     || { reap "$pid"; fail "the corrupt idle-window timer was not repaired"; }
   [ ! -e "$state/.writing-since-$key" ] \
     || { reap "$pid"; fail "an idle-window timer repair kept a finished write-deferral chain"; }

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -8,18 +8,19 @@
 # It provides the boilerplate every test file used to re-roll: ok/not-ok
 # reporters, a self-cleaning temp root, fakebin/PATH-shim helpers, deterministic
 # git identity and fixture builders, state/<id>.meta writers, and the common
-# string/exit-code/file assertions. It deliberately does NOT bundle the
-# behavior-specific fake tmux/treehouse/no-mistakes mocks: those encode terminal
-# and lifecycle assumptions that differ per suite and belong with the tests that
-# own them.
+# string/exit-code/file assertions. Shared fake-toolchain and spawn-world
+# builders live in tests/fixtures.sh; wake-queue mocks in wake-helpers.sh;
+# secondmate-lifecycle mocks in secondmate-helpers.sh. Suite-specific fakes
+# that encode a single test's terminal or lifecycle assumptions still belong
+# with the tests that own them.
 #
 # ROOT is exported as the firstmate repo root (this file lives in tests/), so a
 # sourcing test can use "$ROOT/bin/..." without recomputing it.
 
 # Idempotent guard: behavior-area helper files (secondmate-helpers.sh,
-# wake-helpers.sh) source this library for ROOT/fail/pass, and the test that
-# includes them may also source it directly. Re-sourcing must not wipe the
-# registered-cleanup array or reset state.
+# wake-helpers.sh, fixtures.sh) source this library for ROOT/fail/pass, and the
+# test that includes them may also source it directly. Re-sourcing must not wipe
+# the registered-cleanup array or reset state.
 if [ -n "${FM_TEST_LIB_SOURCED:-}" ]; then
   return 0
 fi


### PR DESCRIPTION
## Intent

Create a shared test-fixture library for Firstmate's bash test suite and start migrating to it, so future test files start from a shared world instead of rebuilding one. This is a test-only, low-risk refactor: do not change bin/ production script behavior.

Promote the common fake-toolchain and spawn-world builders into tests/fixtures.sh (the existing helper convention: wake-helpers.sh and secondmate-helpers.sh source tests/lib.sh; lib.sh stays generic reporters/temp/git and does not own behavior-specific fakes). At minimum centralize: a fake no-mistakes binary with the version string behind ONE shared constant so a version-floor bump is a one-line change; fake gh and gh-axi builders; fake tmux and ssh builders; the spawn-world builders (make_spawn_fakebin, make_stubs, run_spawn) and the ubiquitous cleanup/fail helpers de-duplicated into one definition each (fail/cleanup already live in tests/lib.sh; fixtures.sh sources that rather than copying them). Keep each helper's behavior identical to the current copies; where copies drifted, converge on the most-complete behavior (spawn tmux pane path uses ${FM_FAKE_PANE_PATH:-} like 8 of 9 copies, not the one :? variant).

Migration is incremental, not a big-bang rewrite of all ~30+ files. This PR builds the shared library and migrates a first coherent batch of spawn-world test files (the make_spawn_fakebin / run_spawn cluster) enough to prove the seam end to end and delete real duplication while staying reviewable. Leave remaining files on their local copies for opportunistic future migration. The PR must note which files were migrated and which remain. EXCLUSION: do not touch tests/fm-pr-check-security.test.sh; a concurrent task owns that file's deletion. Every migrated test must still pass and still assert the same observable behavior through the same real interfaces; a migration that changes what a test proves is a bug. One concept per PR: shared fixtures plus the first migration batch only, no unrelated cleanup.

## What Changed

- Add `tests/fixtures.sh` with shared fake-toolchain, version, tmux/SSH, and spawn-world builders, plus behavioral fixture tests and test-runner mapping.
- Migrate `fm-busy-adapter-wiring`, `fm-gate-refuse`, `fm-grok-harness`, `fm-spawn-dispatch-profile`, `fm-spawn-pool-base-freshen`, and `fm-tangle-guard` tests to the shared fixtures.
- Document fixture ownership; leave `fm-backend`, `fm-kimi-harness`, `fm-muse-harness`, `fm-trace-context-spawn`, and other suite-specific copies for later migration, with `fm-pr-check-security` untouched.

## Risk Assessment

✅ Low: The change is a well-bounded test-only fixture refactor, preserves migrated test behavior, documents deferred migrations, and the prior stdin-blocking issue is correctly fixed.

## Testing

Exercised the shared fake binaries directly, then ran every migrated spawn-world suite through the real test runner and real Firstmate executable interfaces, including observable spawn success/refusal and persisted Git-state evidence. Changed-file selection recognized the new fixture library, all targeted behavior succeeded, and testing left the worktree clean.

<details>
<summary>Evidence: Shared fixtures and migrated spawn-world end-to-end transcript</summary>

Source: [Shared fixtures and migrated spawn-world end-to-end transcript](https://github.com/kunchenguid/firstmate/blob/fd41fae7c1b95d853368dff531039e761d9f0077/.no-mistakes/evidence/fm/fm-shared-test-fixtures-r1/shared-fixtures-e2e.txt)

```text
Firstmate shared-fixture end-to-end validation
Commit: 522348f65b79ce69696b46833a6a1a61f3ee3f44

===== tests/fm-test-fixtures.test.sh =====
FM_TEST_BEGIN 2026-08-29T19:19:07Z tests/fm-test-fixtures.test.sh family=unclassified expected_gate_skip=none
ok - fake no-mistakes --version is the shared constant and overridable
ok - init/doctor no-mistakes stub touches markers and refuses other verbs
ok - fake gh authenticates and fake gh-axi reports the shared version
ok - spawn fakebin answers pane path, logs -l payloads, and installs extra tools
ok - send stubs log typed text and fake ssh records argv with a controllable exit
ok - spawn-home layout writes harness pin, beat, and brief
FM_TEST_END 2026-08-29T19:19:08Z tests/fm-test-fixtures.test.sh exit=0 duration_ms=967 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=1030
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=967 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-test-fixtures.test.sh duration_ms=967

===== tests/fm-busy-adapter-wiring.test.sh =====
FM_TEST_BEGIN 2026-08-29T19:19:08Z tests/fm-busy-adapter-wiring.test.sh family=unclassified expected_gate_skip=none
ok - pi extension reports agent_start busy, settles idle only via ctx.isIdle(), and keeps turn_end a notification
ok - pi extension awaits agent_settled before the next agent_start without a test delay
ok - pi extension events from a superseded incarnation are rejected as stale
ok - kimi and grok install no unverified semantic wiring and classify through their own gates
ok - opencode plugin classifies from session.status, scoped to the latched worker session
ok - claude hooks open on UserPromptSubmit and close on Stop, StopFailure, and SessionEnd
ok - claude hook events from a superseded incarnation are rejected without breaking the hook
ok - codex classifies unknown until a semantic source is verified, never idle or footer-matched
all fm-busy-adapter-wiring tests passed
FM_TEST_END 2026-08-29T19:19:34Z tests/fm-busy-adapter-wiring.test.sh exit=0 duration_ms=25370 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=25438
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=25370 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-busy-adapter-wiring.test.sh duration_ms=25370

===== tests/fm-gate-refuse.test.sh =====
FM_TEST_BEGIN 2026-08-29T19:19:34Z tests/fm-gate-refuse.test.sh family=session-bootstrap expected_gate_skip=none
ok - fm-gate-refuse-lib: refuses when NO_MISTAKES_GATE is set
ok - fm-gate-refuse-lib: refuses when NO_MISTAKES_GATE is set empty
ok - fm-gate-refuse-lib: refuses from a gate worktree via git-common-dir (marker unset)
ok - fm-gate-refuse-lib: no-op for a normal session (neither signal, set -eu clean)
ok - fm-spawn: refuses on marker and gate-worktree backstop; a normal crew spawn is unaffected
ok - fm-send: refuses on marker and gate-worktree backstop; a normal steer uses the inbox
ok - fm-teardown: refuses on marker and gate-worktree backstop; a normal teardown is unaffected
FM_TEST_END 2026-08-29T19:19:42Z tests/fm-gate-refuse.test.sh exit=0 duration_ms=8568 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=8636
FM_TEST_SUMMARY_FAMILY family=session-bootstrap count=1 duration_ms=8568 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-gate-refuse.test.sh duration_ms=8568

===== tests/fm-grok-harness.test.sh =====
FM_TEST_BEGIN 2026-08-29T19:19:43Z tests/fm-grok-harness.test.sh family=pure-contract-unit expected_gate_skip=none
ok - grok global hook requires a firstmate registry token
ok - grok teardown removes pointer and token state
ok - fm-lock recognizes grok harness processes
FM_TEST_END 2026-08-29T19:19:51Z tests/fm-grok-harness.test.sh exit=0 duration_ms=8897 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=8974
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=8897 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-grok-harness.test.sh duration_ms=8897

===== tests/fm-spawn-dispatch-profile.test.sh =====
FM_TEST_BEGIN 2026-08-29T19:19:52Z tests/fm-spawn-dispatch-profile.test.sh family=backend-dispatch expected_gate_skip=none
ok - no --model/--effort records defaults and types the claude launch instructions
ok - non-cursor launches clear inherited Cursor identity markers
ok - relative home overrides ignore CDPATH and become absolute before spawn launch construction
ok - FM_HOME defaults resolve relative paths and preserve absolute spellings
ok - absolute override spellings are preserved in spawn launch paths
ok - unresolvable relative spawn overrides fail with named diagnostics
ok - active crew-dispatch profile requires an explicit harness for ship spawns
ok - active crew-dispatch profile requires an explicit harness for scout spawns
ok - active crew-dispatch profile allows an explicit resolved harness
ok - active crew-dispatch profile allows the legacy positional harness form
ok - active crew-dispatch profile allows the raw launch-command escape hatch
ok - claude receives --model and --effort profile flags
ok - codex receives --model and model_reasoning_effort profile flags
ok - codex omits unsupported max effort instead of passing a bad config value
ok - grok receives --model and --reasoning-effort profile flags
ok - grok omits unsupported max reasoning effort
ok - grok omits unsupported xhigh reasoning effort
ok - cursor receives its model-qualified reasoning class and exact task workspace
ok - cursor refuses model ids absent from its resolved binary's live catalog
ok - cursor preserves the requested model when its live catalog is unreachable
ok - opencode receives --model and omits the unsupported effort axis
ok - pi receives --model and --thinking max profile flags
ok - Pi launch probing omits --tui-mode on older Pi and preserves it on supporting Pi
ok - pi-signed shares Pi launch semantics while preserving its configured and recorded identity
ok - pi-signed refuses safely and actionably when the selected executable is unavailable
ok - pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics
ok - batch dispatch forwards shared --harness, --model, and --effort to every pair
ok - claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store
ok - claude omits the config-dir prefix when firstmate runs with the single-store default
ok - non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix
ok - active crew-dispatch profile does not block secondmate launches
# all fm-spawn-dispatch-profile tests passed
FM_TEST_END 2026-08-29T19:21:18Z tests/fm-spawn-dispatch-profile.test.sh exit=0 duration_ms=86804 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=86869
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=86804 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-spawn-dispatch-profile.test.sh duration_ms=86804

===== tests/fm-spawn-pool-base-freshen.test.sh =====
FM_TEST_BEGIN 2026-08-29T19:21:18Z tests/fm-spawn-pool-base-freshen.test.sh family=unclassified expected_gate_skip=none
# observed spawn: spawned pool-current-base-r1 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-pool-current-base-r1 worktree=/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pool-base-freshen.ZKHCTV/current-base/pool
# observed base: HEAD=4d66118e8b2e9eb25e0cd9570c03d232baf7fc01 origin/main=4d66118e8b2e9eb25e0cd9570c03d232baf7fc01 advanced-main=must survive a newly spawned branch
ok - a stale pooled worktree refreshes to current origin/main before a crew branch is created
ok - a stale pooled worktree resolves and refreshes a non-main default branch
# observed direct-pr spawn: spawned pool-direct-pr-r3 harness=codex kind=ship mode=direct-PR yolo=off window=firstmate:fm-pool-direct-pr-r3 worktree=/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pool-base-freshen.ZKHCTV/direct-pr/pool
# observed scout spawn: spawned pool-scout-r3 harness=codex kind=scout window=firstmate:fm-pool-scout-r3 worktree=/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pool-base-freshen.ZKHCTV/scout/pool
ok - direct-PR ships and scouts both refresh stale pooled worktrees before launch
# observed dirty refusal: error: pooled worktree '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pool-base-freshen.ZKHCTV/dirty-refusal/pool' is not clean; refusing to discard uncommitted work while refreshing its base; preserved=keep this local work
ok - a dirty pooled worktree is refused without discarding its local work
# observed unresolved-default refusal: error: could not resolve origin's current default branch for pooled worktree '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pool-base-freshen.ZKHCTV/unresolved-default/pool'; refusing to launch from a potentially stale base
ok - an unresolved remote default branch refuses the pooled worktree
# observed unreachable-origin refusal: error: could not fetch origin for pooled worktree '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pool-base-freshen.ZKHCTV/unreachable-origin/pool'; refusing to launch from a potentially stale base
ok - an unreachable origin refuses a potentially stale pooled worktree
# observed stale-pin refusal: error: submodule 'ui' is checked out at cf1788937bc0a8e8e7760f7e3c0ecfc8ba90d86c, but this base records fc9d6b36ec6d6251e773e22e94ce105e1083c0c1
ok - two consecutive spawns across a moved submodule pin end in a refusal naming both pins and no remedy
ok - an unpushed submodule commit keeps the uncommitted-work refusal and survives it
ok - work inside a submodule is still refused as uncommitted work, not called stale
ok - a stale pin carrying real work is refused conservatively, never called stale
ok - a stale pin beside other dirt yields the conservative refusal alone, with no stale-pin line
# all fm-spawn-pool-base-freshen tests passed
FM_TEST_END 2026-08-29T19:22:07Z tests/fm-spawn-pool-base-freshen.test.sh exit=0 duration_ms=48673 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=48725
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=48673 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-spawn-pool-base-freshen.test.sh duration_ms=48673

===== tests/fm-tangle-guard.test.sh =====
FM_TEST_BEGIN 2026-08-29T19:22:07Z tests/fm-tangle-guard.test.sh family=session-bootstrap expected_gate_skip=none
ok - fm_primary_tangle_branch: feature branch alarms; default/detached/non-git stay silent
ok - fm-guard: bordered tangle banner fires only for a feature branch and suppresses repair commands in read-only mode
ok - fm-bootstrap: TANGLE problem line fires only for a feature branch and suppresses repair commands in detect-only mode
ok - fm-brief: ship brief asserts worktree isolation before the branch step
ok - fm-spawn: aborts unless the resolved worktree is a genuine, isolated worktree
ok - fm-spawn: appends windows by session-colon, pins the name, and targets the window id
FM_TEST_END 2026-08-29T19:22:20Z tests/fm-tangle-guard.test.sh exit=0 duration_ms=12989 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=13047
FM_TEST_SUMMARY_FAMILY family=session-bootstrap count=1 duration_ms=12989 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-tangle-guard.test.sh duration_ms=12989
```
</details>
<details>
<summary>Evidence: Changed-file test selection recognizing shared fixtures</summary>

Source: [Changed-file test selection recognizing shared fixtures](https://github.com/kunchenguid/firstmate/blob/fd41fae7c1b95d853368dff531039e761d9f0077/.no-mistakes/evidence/fm/fm-shared-test-fixtures-r1/shared-fixtures-changed-selection.txt)

```text
Changed-file test selection for shared fixtures:
tests/fm-arm-pretool-check.test.sh
tests/fm-ask-user-authority.test.sh
tests/fm-bearings-board.test.sh
tests/fm-brief.test.sh
tests/fm-calm-pi-extension.test.sh
tests/fm-captain-hold-lifecycle.test.sh
tests/fm-cd-pretool-check.test.sh
tests/fm-classify-decision-key.test.sh
tests/fm-composer-ghost.test.sh
tests/fm-composer-lib.test.sh
tests/fm-crew-state.test.sh
tests/fm-documentation-audiences.test.sh
tests/fm-ensure-agents-md.test.sh
tests/fm-grok-harness.test.sh
tests/fm-harness-adapter-references.test.sh
tests/fm-herdr-lab.test.sh
tests/fm-kimi-harness.test.sh
tests/fm-lint-workflows.test.sh
tests/fm-lint.test.sh
tests/fm-muse-harness.test.sh
tests/fm-operational-input.test.sh
tests/fm-pi-primary-types.test.sh
tests/fm-send-popup-settle.test.sh
tests/fm-send-settle.test.sh
tests/fm-subagent-pretool-check.test.sh
tests/fm-supervision-instructions.test.sh
tests/fm-task-delivery.test.sh
tests/fm-test-isolation-proof.test.sh
tests/fm-test-run.test.sh
tests/fm-tmux-submit-busy.test.sh
tests/fm-trace-context-lib.test.sh
tests/fm-transition-lib.test.sh
tests/fm-vendor-auth-probe.test.sh
tests/fm-backend-herdr-focus-flash-e2e.test.sh
tests/fm-branch-supervision.test.sh
tests/fm-busy-adapter-wiring.test.sh
tests/fm-busy-state.test.sh
tests/fm-classify-corr-token.test.sh
tests/fm-claude-stop-autoarm-live-e2e.test.sh
tests/fm-claude-stop-autoarm.test.sh
tests/fm-cursor-harness.test.sh
tests/fm-gitignore-config.test.sh
tests/fm-no-mistakes-required.test.sh
tests/fm-peek-remote.test.sh
tests/fm-pending-reply.test.sh
tests/fm-pi-branch-extension.test.sh
tests/fm-procevent-when.test.sh
tests/fm-procevent.test.sh
tests/fm-project-origin.test.sh
tests/fm-public-followup.test.sh
tests/fm-remote-entrypoint.test.sh
tests/fm-remote-secondmate-parent-binding.test.sh
tests/fm-send-remote-delivery.test.sh
tests/fm-spawn-pool-base-freshen.test.sh
tests/fm-test-fixture-cleanup.test.sh
tests/fm-test-fixtures.test.sh
tests/fm-voice-relay.test.sh
tests/fm-wake-drain-open-decisions-cursor.test.sh
tests/fm-wake-drain-open-decisions.test.sh
tests/fm-bootstrap-network-parallel.test.sh
tests/fm-bootstrap.test.sh
tests/fm-fleet-sync.test.sh
tests/fm-gate-refuse.test.sh
tests/fm-gotmp.test.sh
tests/fm-session-start.test.sh
tests/fm-sessionstart-nudge.test.sh
tests/fm-startup-network.test.sh
tests/fm-tangle-guard.test.sh
tests/fm-update.test.sh
tests/fm-backend-herdr.test.sh
tests/fm-backend-tmux-smoke.test.sh
tests/fm-backend.test.sh
tests/fm-control-relaunch.test.sh
tests/fm-control.test.sh
tests/fm-herdr-session-cleanup.test.sh
tests/fm-send-inbox.test.sh
tests/fm-send-resolve-key.test.sh
tests/fm-send-strict.test.sh
tests/fm-spawn-batch.test.sh
tests/fm-spawn-dispatch-profile.test.sh
tests/fm-spawn-worktree-settle.test.sh
tests/fm-teardown-endpoint-safety.test.sh
tests/fm-tmux-agent-liveness.test.sh
tests/fm-trace-context-spawn.test.sh
tests/fm-afk-inject-herdr-e2e.test.sh
tests/fm-afk-launch.test.sh
tests/fm-backend-autodetect-smoke.test.sh
tests/fm-backend-herdr-eventwait-smoke.test.sh
tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
tests/fm-backend-herdr-presentation-e2e.test.sh
tests/fm-backend-herdr-prune-safety-e2e.test.sh
tests/fm-backend-herdr-respawn-idem-e2e.test.sh
tests/fm-backend-herdr-smoke.test.sh
tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
tests/fm-control-herdr-smoke.test.sh
tests/fm-herdr-session-cleanup-e2e.test.sh
tests/fm-afk-pi-herdr-return-e2e.test.sh
tests/fm-cmux-claude-composer-live-e2e.test.sh
tests/fm-codex-continuity-live-e2e.test.sh
tests/fm-composer-matrix-live-e2e.test.sh
tests/fm-cursor-primary-live-e2e.test.sh
tests/fm-grok-continuity-live-e2e.test.sh
tests/fm-grok-stop-live-e2e.test.sh
tests/fm-harness-adapter-instructions-live-e2e.test.sh
tests/fm-harness-liveness-drift-live-e2e.test.sh
tests/fm-herdr-submit-confirm-live-e2e.test.sh
tests/fm-herdr-version-floor-live-e2e.test.sh
tests/fm-muse-signals-live-e2e.test.sh
tests/fm-opencode-primary-live-e2e.test.sh
tests/fm-pi-branch-live-e2e.test.sh
tests/fm-pi-primary-live-e2e.test.sh
tests/fm-quota-array-dispatch-live-e2e.test.sh
tests/fm-send-inbox-doorbell-live-e2e.test.sh
tests/fm-send-secondmate-marker-herdr-e2e.test.sh
tests/fm-sessionstart-hook-live-e2e.test.sh
tests/fm-sessionstart-instruction-refresh-live-e2e.test.sh
tests/fm-afk-inject-e2e.test.sh
tests/fm-afk-return.test.sh
tests/fm-backend-cmux-smoke.test.sh
tests/fm-backend-cmux.test.sh
tests/fm-backend-orca.test.sh
tests/fm-backend-zellij-smoke.test.sh
tests/fm-backend-zellij.test.sh
tests/fm-backlog-handoff.test.sh
tests/fm-on.test.sh
tests/fm-remote-backlog-handoff.test.sh
tests/fm-remote-doctor.test.sh
tests/fm-remote-job-orphan-reap.test.sh
tests/fm-remote-job.test.sh
tests/fm-remote-reply.test.sh
tests/fm-remote-secondmate-lifecycle-e2e.test.sh
tests/fm-remote-secondmate-trace-context.test.sh
tests/fm-remote-transport-lanes.test.sh
tests/fm-secondmate-harness.test.sh
tests/fm-secondmate-lifecycle-e2e.test.sh
tests/fm-secondmate-liveness.test.sh
tests/fm-secondmate-reconcile.test.sh
tests/fm-secondmate-safety.test.sh
tests/fm-secondmate-sync.test.sh
tests/fm-send-secondmate-marker.test.sh
tests/fm-shared-captain-inheritance.test.sh
tests/fm-startup-memory-budget.test.sh
tests/fm-stow-cascade.test.sh
tests/fm-bearings-board-render.test.sh
tests/fm-bearings-snapshot.test.sh
tests/fm-fleet-snapshot-view.test.sh
tests/fm-home-summary-refresh.test.sh
tests/fm-cursor-primary.test.sh
tests/fm-daemon.test.sh
tests/fm-guard-stale-banner.test.sh
tests/fm-inactive-reconcile.test.sh
tests/fm-pi-watch-extension.test.sh
tests/fm-session-lock-ancestry.test.sh
tests/fm-supervision-events.test.sh
tests/fm-task-inbox.test.sh
tests/fm-tool-update-check.test.sh
tests/fm-turnend-guard.test.sh
tests/fm-wake-daemon-lifecycle-e2e.test.sh
tests/fm-wake-drain-unread-status.test.sh
tests/fm-wake-queue.test.sh
tests/fm-watch-arm.test.sh
tests/fm-watch-checkpoint.test.sh
tests/fm-watch-recovery-loop.test.sh
tests/fm-watch-triage.test.sh
tests/fm-watcher-lock.test.sh
tests/fm-pr-check-security.test.sh
tests/fm-pr-merge.test.sh
tests/fm-review-diff.test.sh
tests/fm-teardown.test.sh
tests/fm-x-mode.test.sh
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"164b1d33de18ab706a3dfb207a216fa53f21b3cd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `tests/fm-test-fixtures.test.sh:109` - This invocation inherits stdin, while fake-ssh runs `cat &gt; /dev/null` before returning. Under the documented interactive test-runner path, it waits for terminal EOF and eventually times out instead of asserting exit 7. Redirect stdin from `/dev/null` for this invocation.

🔧 Fix: Prevent fake SSH test from blocking on stdin
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `FM_TEST_EVIDENCE=1 bin/fm-test-run.sh tests/fm-test-fixtures.test.sh`
- `FM_TEST_EVIDENCE=1 bin/fm-test-run.sh tests/fm-busy-adapter-wiring.test.sh`
- `FM_TEST_EVIDENCE=1 bin/fm-test-run.sh tests/fm-gate-refuse.test.sh`
- `FM_TEST_EVIDENCE=1 bin/fm-test-run.sh tests/fm-grok-harness.test.sh`
- `FM_TEST_EVIDENCE=1 bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh`
- `FM_TEST_EVIDENCE=1 bin/fm-test-run.sh tests/fm-spawn-pool-base-freshen.test.sh`
- `FM_TEST_EVIDENCE=1 bin/fm-test-run.sh tests/fm-tangle-guard.test.sh`
- `bin/fm-test-run.sh --list --changed --base c731c36c381ea0886fa5aabf6a3be761534d3f30`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
