### PR TITLE
fix(bin): use system stat for Darwin BSD formats

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -661,7 +661,7 @@ fm_backend_herdr_presentation_lock_namespace() {
 
 fm_backend_herdr_presentation_lock_namespace_mode() {
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    stat -f '%Lp' "$1" 2>/dev/null
+    /usr/bin/stat -f '%Lp' "$1" 2>/dev/null
   else
     stat -c '%a' "$1" 2>/dev/null
   fi
@@ -669,7 +669,7 @@ fm_backend_herdr_presentation_lock_namespace_mode() {
 
 fm_backend_herdr_presentation_lock_namespace_uid() {
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    stat -f '%u' "$1" 2>/dev/null
+    /usr/bin/stat -f '%u' "$1" 2>/dev/null
   else
     stat -c '%u' "$1" 2>/dev/null
   fi

--- a/bin/fm-backlog-receive.sh
+++ b/bin/fm-backlog-receive.sh
@@ -57,7 +57,7 @@ list_keys() { # <file>
 lock_age() {
   local modified now
   if [ "$(uname 2>/dev/null)" = Darwin ]; then
-    modified=$(stat -f '%m' "$1" 2>/dev/null) || return 1
+    modified=$(/usr/bin/stat -f '%m' "$1" 2>/dev/null) || return 1
   else
     modified=$(stat -c '%Y' "$1" 2>/dev/null) || return 1
   fi

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -938,14 +938,14 @@ x_mode_write_if_changed() {
   [ "$parent" != "$dest" ] || return 1
   [ -d "$parent" ] && [ ! -L "$parent" ] || return 1
   if [ "$(uname)" = Darwin ]; then
-    parent_device=$(stat -f %d "$parent" 2>/dev/null) || return 1
+    parent_device=$(/usr/bin/stat -f %d "$parent" 2>/dev/null) || return 1
   else
     parent_device=$(stat -c %d "$parent" 2>/dev/null) || return 1
   fi
   if [ -e "$dest" ] || [ -L "$dest" ]; then
     fmx_single_link_file_valid "$dest" "$parent_device" || return 1
     if [ "$(uname)" = Darwin ]; then
-      current_mode=$(stat -f %Lp "$dest" 2>/dev/null) || return 1
+      current_mode=$(/usr/bin/stat -f %Lp "$dest" 2>/dev/null) || return 1
     else
       current_mode=$(stat -c %a "$dest" 2>/dev/null) || return 1
     fi

--- a/bin/fm-busy-event.sh
+++ b/bin/fm-busy-event.sh
@@ -103,7 +103,7 @@ LOCK="$REC.lock"
 # gets a non-numeric token. Detect the platform once and pick the right form,
 # exactly as bin/fm-watch.sh does.
 if [ "$(uname)" = Darwin ]; then
-  lock_mtime() { stat -f %m "$1" 2>/dev/null; }
+  lock_mtime() { /usr/bin/stat -f %m "$1" 2>/dev/null; }
 else
   lock_mtime() { stat -c %Y "$1" 2>/dev/null; }
 fi

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -652,9 +652,9 @@ _fm_open_decisions_file_ident() {  # <file> -> strongest available identity
     return
   fi
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    ident=$(LC_ALL=C stat -f '%d:%i' "$f" 2>/dev/null) || return 1
-    epoch=$(LC_ALL=C stat -f '%B' "$f" 2>/dev/null) || epoch=0
-    if [ "$epoch" != 0 ]; then birth=$(LC_ALL=C stat -f '%FB' "$f" 2>/dev/null) || birth=''; else birth=''; fi
+    ident=$(LC_ALL=C /usr/bin/stat -f '%d:%i' "$f" 2>/dev/null) || return 1
+    epoch=$(LC_ALL=C /usr/bin/stat -f '%B' "$f" 2>/dev/null) || epoch=0
+    if [ "$epoch" != 0 ]; then birth=$(LC_ALL=C /usr/bin/stat -f '%FB' "$f" 2>/dev/null) || birth=''; else birth=''; fi
   else
     ident=$(LC_ALL=C stat -c '%d:%i' "$f" 2>/dev/null) || return 1
     epoch=$(LC_ALL=C stat -c '%W' "$f" 2>/dev/null) || epoch=0
@@ -671,7 +671,7 @@ _fm_status_file_size() {  # <status-file>
     return
   fi
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    LC_ALL=C stat -f '%z' "$f" 2>/dev/null
+    LC_ALL=C /usr/bin/stat -f '%z' "$f" 2>/dev/null
   else
     LC_ALL=C stat -c '%s' "$f" 2>/dev/null
   fi
@@ -1071,7 +1071,7 @@ status_presentation_marker_parse() {
 
 _status_observed_path_state() {
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    LC_ALL=C stat -f '%HT:%p' "$1" 2>/dev/null
+    LC_ALL=C /usr/bin/stat -f '%HT:%p' "$1" 2>/dev/null
   else
     LC_ALL=C stat -c '%F:%f' "$1" 2>/dev/null
   fi

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -680,7 +680,7 @@ _fm_status_file_size() {  # <status-file>
 _fm_status_file_mtime() {  # <status-file>
   local f=$1
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    LC_ALL=C stat -f '%m' "$f" 2>/dev/null
+    LC_ALL=C /usr/bin/stat -f '%m' "$f" 2>/dev/null
   else
     LC_ALL=C stat -c '%Y' "$f" 2>/dev/null
   fi

--- a/bin/fm-config-inherit-lib.sh
+++ b/bin/fm-config-inherit-lib.sh
@@ -103,7 +103,7 @@ fm_config_source_present() {
 
 fm_inherit_file_mode() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %Lp "$1" 2>/dev/null
+    /usr/bin/stat -f %Lp "$1" 2>/dev/null
   else
     stat -c %a "$1" 2>/dev/null
   fi
@@ -111,7 +111,7 @@ fm_inherit_file_mode() {
 
 fm_inherit_file_device() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %d "$1" 2>/dev/null
+    /usr/bin/stat -f %d "$1" 2>/dev/null
   else
     stat -c %d "$1" 2>/dev/null
   fi
@@ -119,7 +119,7 @@ fm_inherit_file_device() {
 
 fm_inherit_file_link_count() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %l "$1" 2>/dev/null
+    /usr/bin/stat -f %l "$1" 2>/dev/null
   else
     stat -c %h "$1" 2>/dev/null
   fi

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1086,8 +1086,8 @@ case "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" in ''|*[!0-9]*) FM_SNAPSHOT_SECON
 # pollute arithmetic input before failing. Select the platform syntax once.
 if [ "$(uname 2>/dev/null || true)" = Darwin ]; then
   SNAPSHOT_STAT_STYLE=bsd
-  file_mtime_epoch() { stat -f '%m' "$1" 2>/dev/null || true; }
-  file_mode_octal() { stat -f '%Lp' "$1" 2>/dev/null || true; }
+  file_mtime_epoch() { /usr/bin/stat -f '%m' "$1" 2>/dev/null || true; }
+  file_mode_octal() { /usr/bin/stat -f '%Lp' "$1" 2>/dev/null || true; }
 else
   SNAPSHOT_STAT_STYLE=gnu
   file_mtime_epoch() { stat -c '%Y' "$1" 2>/dev/null || true; }
@@ -1440,7 +1440,7 @@ bounded_parent_activities_json() {  # <status-file>
     stat_style=$6
     . "$classify"
     if [ "$stat_style" = bsd ]; then
-      size=$(stat -f "%z" "$f" 2>/dev/null) || exit 3
+      size=$(/usr/bin/stat -f "%z" "$f" 2>/dev/null) || exit 3
     else
       size=$(stat -c "%s" "$f" 2>/dev/null) || exit 3
     fi

--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -121,7 +121,7 @@ if [ "$FM_INACTIVE_RECONCILE_BUDGET_SECS" -gt 30 ]; then
 fi
 
 if [ "$(uname)" = Darwin ]; then
-  file_mtime() { stat -f %m "$1" 2>/dev/null; }
+  file_mtime() { /usr/bin/stat -f %m "$1" 2>/dev/null; }
 else
   file_mtime() { stat -c %Y "$1" 2>/dev/null; }
 fi

--- a/bin/fm-lock-lib.sh
+++ b/bin/fm-lock-lib.sh
@@ -24,7 +24,7 @@ fm_lock_log() {
 # no wake-queue machinery when a caller only needs the staleness proof.
 fm_lock_path_mtime() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %m "$1" 2>/dev/null
+    /usr/bin/stat -f %m "$1" 2>/dev/null
   else
     stat -c %Y "$1" 2>/dev/null
   fi

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -571,7 +571,7 @@ fm_pending_reply_file_signature() {  # <path>
   local path=$1
   [ -f "$path" ] || { printf 'missing'; return 0; }
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    LC_ALL=C stat -f '%d:%i:%z:%m:%c' "$path" 2>/dev/null || printf 'unreadable'
+    LC_ALL=C /usr/bin/stat -f '%d:%i:%z:%m:%c' "$path" 2>/dev/null || printf 'unreadable'
   else
     LC_ALL=C stat -c '%d:%i:%s:%Y:%Z' "$path" 2>/dev/null || printf 'unreadable'
   fi

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -215,7 +215,7 @@ fm_pr_head_valid() {
 
 fm_pr_file_mode() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %Lp "$1" 2>/dev/null
+    /usr/bin/stat -f %Lp "$1" 2>/dev/null
   else
     stat -c %a "$1" 2>/dev/null
   fi
@@ -223,7 +223,7 @@ fm_pr_file_mode() {
 
 fm_pr_file_device() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %d "$1" 2>/dev/null
+    /usr/bin/stat -f %d "$1" 2>/dev/null
   else
     stat -c %d "$1" 2>/dev/null
   fi
@@ -231,7 +231,7 @@ fm_pr_file_device() {
 
 fm_pr_file_link_count() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %l "$1" 2>/dev/null
+    /usr/bin/stat -f %l "$1" 2>/dev/null
   else
     stat -c %h "$1" 2>/dev/null
   fi
@@ -239,7 +239,7 @@ fm_pr_file_link_count() {
 
 fm_pr_file_inode() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %i "$1" 2>/dev/null
+    /usr/bin/stat -f %i "$1" 2>/dev/null
   else
     stat -c %i "$1" 2>/dev/null
   fi

--- a/bin/fm-procevent-lib.sh
+++ b/bin/fm-procevent-lib.sh
@@ -642,7 +642,7 @@ fm_procevent_path_normalize() {
 fm_procevent_directory_owned_by_current_user() {
   local owner
   if [ "$(uname)" = Darwin ]; then
-    owner=$(stat -f %u "$1" 2>/dev/null)
+    owner=$(/usr/bin/stat -f %u "$1" 2>/dev/null)
   else
     owner=$(stat -c %u "$1" 2>/dev/null)
   fi

--- a/bin/fm-remote-file.sh
+++ b/bin/fm-remote-file.sh
@@ -77,7 +77,7 @@ snapshot_bounded_file() { # <file> <max-bytes> <destination> <size-file>
 
 directory_identity() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f '%d:%i' . 2>/dev/null
+    /usr/bin/stat -f '%d:%i' . 2>/dev/null
   else
     stat -c '%d:%i' . 2>/dev/null
   fi

--- a/bin/fm-remote-inherit-push.sh
+++ b/bin/fm-remote-inherit-push.sh
@@ -27,7 +27,7 @@ sha256_file() {
   if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | awk '{print $1}'; else sha256sum "$1" | awk '{print $1}'; fi
 }
 file_link_count() {
-  if [ "$(uname)" = Darwin ]; then stat -f %l "$1" 2>/dev/null; else stat -c %h "$1" 2>/dev/null; fi
+  if [ "$(uname)" = Darwin ]; then /usr/bin/stat -f %l "$1" 2>/dev/null; else stat -c %h "$1" 2>/dev/null; fi
 }
 shared_captain_header_valid() {
   local head

--- a/bin/fm-remote-inherit.sh
+++ b/bin/fm-remote-inherit.sh
@@ -22,7 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 die() { printf 'error: %s\n' "$1" >&2; exit 1; }
 usage() { sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
 file_link_count() {
-  if [ "$(uname)" = Darwin ]; then stat -f %l "$1" 2>/dev/null; else stat -c %h "$1" 2>/dev/null; fi
+  if [ "$(uname)" = Darwin ]; then /usr/bin/stat -f %l "$1" 2>/dev/null; else stat -c %h "$1" 2>/dev/null; fi
 }
 sha256_file() {
   if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | awk '{print $1}'; else sha256sum "$1" | awk '{print $1}'; fi

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -758,7 +758,7 @@ fm_remote_job_reap() { # <account-home> <id>; only removes an exact completed re
 fm_remote_job_path_mtime() { # <path>
   # The platform override controls worker shape in isolated tests, not the host
   # kernel's stat syntax.
-  if [ "$(uname -s 2>/dev/null || true)" = Darwin ]; then stat -f %m "$1" 2>/dev/null; else stat -c %Y "$1" 2>/dev/null; fi
+  if [ "$(uname -s 2>/dev/null || true)" = Darwin ]; then /usr/bin/stat -f %m "$1" 2>/dev/null; else stat -c %Y "$1" 2>/dev/null; fi
 }
 
 fm_remote_job_stage_owner_alive() { # <stage-dir>

--- a/bin/fm-startup-memory-budget-lib.sh
+++ b/bin/fm-startup-memory-budget-lib.sh
@@ -23,7 +23,7 @@ fm_startup_memory_budget_fail() {
 
 fm_startup_memory_budget_link_count() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %l "$1" 2>/dev/null
+    /usr/bin/stat -f %l "$1" 2>/dev/null
   else
     stat -c %h "$1" 2>/dev/null
   fi

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -236,7 +236,7 @@ _state_root() { printf '%s' "${FM_STATE_OVERRIDE:-$FM_HOME/state}"; }
 
 # --- portable stat (same trap as fm-watch.sh: no `stat -f || stat -c`) -------
 if [ "$(uname)" = Darwin ]; then
-  _stat_file_mtime() { stat -f %m "$1" 2>/dev/null; }
+  _stat_file_mtime() { /usr/bin/stat -f %m "$1" 2>/dev/null; }
 else
   _stat_file_mtime() { stat -c %Y "$1" 2>/dev/null; }
 fi

--- a/bin/fm-supervision-lib.sh
+++ b/bin/fm-supervision-lib.sh
@@ -15,7 +15,7 @@
 # Portable mtime; Linux stat lacks -f, macOS stat lacks -c.
 fm_sup_stat_mtime() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %m "$1" 2>/dev/null
+    /usr/bin/stat -f %m "$1" 2>/dev/null
   else
     stat -c %Y "$1" 2>/dev/null
   fi

--- a/bin/fm-test-isolation-proof.sh
+++ b/bin/fm-test-isolation-proof.sh
@@ -216,8 +216,8 @@ EOF
 
 dir_mode() {
   local path=$1
-  if stat -f %Lp "$path" >/dev/null 2>&1; then
-    stat -f %Lp "$path"
+  if /usr/bin/stat -f %Lp "$path" >/dev/null 2>&1; then
+    /usr/bin/stat -f %Lp "$path"
   else
     stat -c %a "$path"
   fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -2273,7 +2273,7 @@ else
       cat "$out"
     fi
     if worker_root_mode_is_enforceable; then
-      mode=$(stat -c %a "$work" 2>/dev/null || stat -f %Lp "$work" 2>/dev/null || echo unknown)
+      mode=$(stat -c %a "$work" 2>/dev/null || /usr/bin/stat -f %Lp "$work" 2>/dev/null || echo unknown)
       case "$mode" in
         700|0700) ;;
         *)

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -92,7 +92,7 @@ fm_pid_identity() {
 
 fm_path_mtime() {
   if [ "$_FM_UNAME" = Darwin ]; then
-    stat -f %m "$1" 2>/dev/null
+    /usr/bin/stat -f %m "$1" 2>/dev/null
   else
     stat -c %Y "$1" 2>/dev/null
   fi
@@ -1780,7 +1780,7 @@ fm_wake_signal_sig() {  # <file> -> reported-state signature
       status_observed_signature "$1"
       ;;
     *)
-      if [ "$_FM_UNAME" = Darwin ]; then stat -f '%z:%Fm' "$1" 2>/dev/null; else stat -c '%s:%Y' "$1" 2>/dev/null; fi
+      if [ "$_FM_UNAME" = Darwin ]; then /usr/bin/stat -f '%z:%Fm' "$1" 2>/dev/null; else stat -c '%s:%Y' "$1" 2>/dev/null; fi
       ;;
   esac
 }

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -156,6 +156,8 @@ WATCHER_STALE_GRACE=${FM_WATCHER_STALE_GRACE:-${FM_GUARD_GRACE:-300}}
 # appended to that garbage. Arithmetic under `set -u` then aborts on the stray
 # token (e.g. the word "File" read as an unset variable), which silently kills the
 # watcher mid-cycle. Detect the platform once and pick the right form.
+# On Darwin, call /usr/bin/stat rather than PATH-resolved stat so GNU coreutils
+# cannot shadow the BSD `-f` syntax.
 if [ "$(uname)" = Darwin ]; then
   stat_mtime() { /usr/bin/stat -f %m "$1" 2>/dev/null; }        # epoch seconds of mtime
 else

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -157,7 +157,7 @@ WATCHER_STALE_GRACE=${FM_WATCHER_STALE_GRACE:-${FM_GUARD_GRACE:-300}}
 # token (e.g. the word "File" read as an unset variable), which silently kills the
 # watcher mid-cycle. Detect the platform once and pick the right form.
 if [ "$(uname)" = Darwin ]; then
-  stat_mtime() { stat -f %m "$1" 2>/dev/null; }        # epoch seconds of mtime
+  stat_mtime() { /usr/bin/stat -f %m "$1" 2>/dev/null; }        # epoch seconds of mtime
 else
   stat_mtime() { stat -c %Y "$1" 2>/dev/null; }
 fi

--- a/bin/fm-x-lib.sh
+++ b/bin/fm-x-lib.sh
@@ -89,8 +89,8 @@ fmx_single_link_file_valid() {
   local file=$1 expected_device=${2-} links device
   [ -f "$file" ] && [ ! -L "$file" ] || return 1
   if [ "$(uname)" = Darwin ]; then
-    links=$(stat -f %l "$file" 2>/dev/null) || return 1
-    device=$(stat -f %d "$file" 2>/dev/null) || return 1
+    links=$(/usr/bin/stat -f %l "$file" 2>/dev/null) || return 1
+    device=$(/usr/bin/stat -f %d "$file" 2>/dev/null) || return 1
   else
     links=$(stat -c %h "$file" 2>/dev/null) || return 1
     device=$(stat -c %d "$file" 2>/dev/null) || return 1
@@ -103,7 +103,7 @@ fmx_single_link_file_mode_valid() {
   local file=$1 expected_mode=$2 expected_device=${3-} mode
   fmx_single_link_file_valid "$file" "$expected_device" || return 1
   if [ "$(uname)" = Darwin ]; then
-    mode=$(stat -f %Lp "$file" 2>/dev/null) || return 1
+    mode=$(/usr/bin/stat -f %Lp "$file" 2>/dev/null) || return 1
   else
     mode=$(stat -c %a "$file" 2>/dev/null) || return 1
   fi
@@ -114,8 +114,8 @@ fmx_private_artifact_dir_device() {
   local dir=$1 mode device
   [ -d "$dir" ] && [ ! -L "$dir" ] || return 1
   if [ "$(uname)" = Darwin ]; then
-    mode=$(stat -f %Lp "$dir" 2>/dev/null) || return 1
-    device=$(stat -f %d "$dir" 2>/dev/null) || return 1
+    mode=$(/usr/bin/stat -f %Lp "$dir" 2>/dev/null) || return 1
+    device=$(/usr/bin/stat -f %d "$dir" 2>/dev/null) || return 1
   else
     mode=$(stat -c %a "$dir" 2>/dev/null) || return 1
     device=$(stat -c %d "$dir" 2>/dev/null) || return 1
@@ -410,7 +410,7 @@ fmx_request_relay_context() {
 
 fmx_context_registry_mtime() {
   local file=$1 mtime
-  mtime=$(stat -f '%m' "$file" 2>/dev/null) || mtime=$(stat -c '%Y' "$file" 2>/dev/null) || return 1
+  mtime=$(/usr/bin/stat -f '%m' "$file" 2>/dev/null) || mtime=$(stat -c '%Y' "$file" 2>/dev/null) || return 1
   case "$mtime" in
     ''|*[!0-9]*) return 1 ;;
   esac

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -64,10 +64,10 @@ Each shard is still strictly serial in itself, and separate runners mean no two 
 `.github/workflows/ci.yml` derives the same `n` from `strategy.job-total` rather than a literal, so changing the shard count in either file without the other fails the lane loudly instead of leaving part of the required suite unrun.
 
 Assignment is longest-processing-time bin packing over per-script duration hints embedded in `bin/fm-test-run.sh`.
-The 141 current hints include the slowest measurements retained from the `fm-test-timing-portable-serial-*` artifacts of three green CI runs on 2026-09-01, [33558082172](https://github.com/kunchenguid/firstmate/actions/runs/33558082172), [33523597838](https://github.com/kunchenguid/firstmate/actions/runs/33523597838), and [33463326167](https://github.com/kunchenguid/firstmate/actions/runs/33463326167), plus the 5121 ms native-Windows focused runner measurement for `tests/fm-pi-windows-shell-invocation.test.sh` from 2026-09-06T21:02Z.
-Those per-script maxima total 3830189 ms of conservative balance weight.
+The 142 current hints include the slowest measurements retained from the `fm-test-timing-portable-serial-*` artifacts of three green CI runs on 2026-09-01, [33558082172](https://github.com/kunchenguid/firstmate/actions/runs/33558082172), [33523597838](https://github.com/kunchenguid/firstmate/actions/runs/33523597838), and [33463326167](https://github.com/kunchenguid/firstmate/actions/runs/33463326167), plus the 5121 ms native-Windows focused runner measurement for `tests/fm-pi-windows-shell-invocation.test.sh` from 2026-09-06T21:02Z.
+Those per-script maxima total 3836189 ms of conservative balance weight.
 Taking the slowest of several CI runs rather than a single run keeps the balance honest on a slow runner: individual scripts varied by up to 20% between those three runs.
-A script with no hint gets the conservative `PORTABLE_SERIAL_DEFAULT_WEIGHT_MS` default; the current 147-script lane has six such scripts, bringing its assignment weight to 3992189 ms.
+A script with no hint gets the conservative `PORTABLE_SERIAL_DEFAULT_WEIGHT_MS` default; the current 152-script lane has ten such scripts, bringing its assignment weight to 4106189 ms.
 Hints only affect balance: the coverage guard keeps the partition complete and disjoint whatever they say, so a stale hint costs a slower shard rather than lost coverage.
 Balance is still worth keeping current, because enough unmeasured scripts let one shard carry more than twice another shard's real work and reach the job cap while another runner sits idle.
 That is not hypothetical: by 2026-09-01 the lane had grown from 116 to 139 scripts and from ~42 to ~63 minutes, 17 scripts were still unmeasured, and several hints were low by 2-5x, so shard 3 of 4 ran 17-20 minutes against its 20-minute cap while shard 1 ran 11.5 minutes and run [33574154856](https://github.com/kunchenguid/firstmate/actions/runs/33574154856) timed out seconds after a passing test.
@@ -76,14 +76,14 @@ Refresh the hints whenever the serial lane gains scripts, rather than waiting fo
 
 | Lane | Script count | Estimated duration |
 |---|---:|---:|
-| `portable-serial-1of5` | 29 | 798443 ms (~13.31 min) |
-| `portable-serial-2of5` | 30 | 798440 ms (~13.31 min) |
-| `portable-serial-3of5` | 29 | 798432 ms (~13.31 min) |
-| `portable-serial-4of5` | 29 | 798434 ms (~13.31 min) |
-| `portable-serial-5of5` | 30 | 798440 ms (~13.31 min) |
-| imbalance | | 11 ms |
+| `portable-serial-1of5` | 29 | 821231 ms (~13.69 min) |
+| `portable-serial-2of5` | 30 | 821243 ms (~13.69 min) |
+| `portable-serial-3of5` | 31 | 821236 ms (~13.69 min) |
+| `portable-serial-4of5` | 31 | 821247 ms (~13.69 min) |
+| `portable-serial-5of5` | 31 | 821232 ms (~13.69 min) |
+| imbalance | | 16 ms |
 
-The current table is generated from the runner's retained maxima plus its default for the six unhinted scripts.
+The current table is generated from the runner's retained maxima plus its default for the ten unhinted scripts.
 The last complete replay against the three source runs put the then-current partition's worst shard at 12.54 min, 63% of the 20-minute job cap.
 
 The single longest script, `tests/fm-watch-triage.test.sh` at 262626 ms, is the floor for any shard count.
@@ -126,7 +126,7 @@ Portable shards, each portable serial shard, and the Herdr lane upload runner-ge
 | Lane | Bound | Rationale |
 |---|---|---|
 | portable parallel 1/2 | job `timeout-minutes: 10` | The measured shard sums are about three minutes and the timeout is a hang tripwire. |
-| portable serial 1-5 | job `timeout-minutes: 20` | Each balanced shard carries about 13.31 minutes of conservative assignment weight, leaving roughly 1.5x hang-tripwire margin for job setup and runner-speed spread. |
+| portable serial 1-5 | job `timeout-minutes: 20` | Each balanced shard carries about 13.69 minutes of conservative assignment weight, leaving roughly 1.5x hang-tripwire margin for job setup and runner-speed spread. |
 | Herdr | family-run step `timeout-minutes: 20`; job `timeout-minutes: 75` backstop | Healthy runs finished around 7 minutes before this lane gained `fm-backend-herdr-focus-flash-e2e`, which measures about 2 minutes against a real lab locally, so the step bound is still the hang tripwire (cleanup and timing artifacts still upload) while the job cap stays a last-resort backstop. Refresh this figure from the lane's uploaded timing artifact. |
 
 Timeouts are hang tripwires rather than expected healthy durations.

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -2366,6 +2366,13 @@ test_bootstrap_refuses_a_symlinked_state_directory_before_reconciliation() {
 
 test_bootstrap_stops_when_data_disappears_before_reconciliation() {
   local case_dir id saved out rc=0
+  # The data-removal fault is injected by a fake stat on PATH; on Darwin the
+  # budget link-count helper now calls /usr/bin/stat directly, so the fake can
+  # never fire there. Skip the Darwin run of this case.
+  if [ "$(uname)" = Darwin ]; then
+    pass "bootstrap data-disappears fault injection is PATH-based; skipped on Darwin where stat is /usr/bin/stat"
+    return
+  fi
   id=atomic-bootstrap-data-race-b11
   case_dir=$(make_home bootstrap-data-race)
   add_item "$case_dir" "$id"

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -964,6 +964,12 @@ test_postrename_poll_validation_revokes_and_retries() {
   local artifact action dir state destination link_target gate
   for artifact in data registration check; do
     for action in type mode device content; do
+      # The device fault is injected by a fake stat on PATH; on Darwin the
+      # device helper now calls /usr/bin/stat directly, so the fake can never
+      # fire there. Skip the device action on Darwin.
+      if [ "$action" = device ] && [ "$(uname)" = Darwin ]; then
+        continue
+      fi
       dir=$(make_case "poll-final-$artifact-$action")
       state="$dir/home/state"
       write_poll_meta "$state" task-a https://github.com/o/r/pull/1

--- a/tests/fm-stat-shadowing.test.sh
+++ b/tests/fm-stat-shadowing.test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# tests/fm-stat-shadowing.test.sh - verify Darwin stat helpers survive GNU coreutils
+# stat shadowing /usr/bin/stat on hosts where ~/.local/bin/stat (GNU) precedes
+# /usr/bin/stat in PATH.
+#
+# When GNU stat shadows BSD stat, `stat -f <fmt>` no longer means "format the
+# output" — it means "print a filesystem dump" and prints the literal text
+# `File: "<path>"` to stdout before failing on the format token. Callers that
+# feed the output into arithmetic (e.g. `age=$(( $(date +%s) - m ))`) crash
+# under `set -u` with "unbound variable" on the stray token.
+#
+# The fix: all Darwin `stat -f` calls in bin/ are prefixed with `/usr/bin/stat`
+# to bypass any PATH-shadowing wrapper.
+#
+# This test proves the fix works by installing a fake GNU-like stat that shadows
+# /usr/bin/stat and asserting the helpers still return correct values.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+[ "$(uname)" = Darwin ] || { echo "skip: Darwin only"; exit 0; }
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-stat-shadowing.XXXXXX") || exit 1
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# --- fake GNU stat that mimics ~/.local/bin/stat shadowing /usr/bin/stat -------
+
+# GNU stat -f <fmt> prints a filesystem dump starting with `File: "<path>"` and
+# exits non-zero when the format token is unrecognized by the filesystem path.
+# We simulate this for the tokens used in our helpers so callers fail or produce
+# garbage when they use the shadowed stat instead of /usr/bin/stat.
+FAKE_STAT="$TMP_ROOT/fakebin/stat"
+mkdir -p "$(dirname "$FAKE_STAT")"
+
+cat > "$FAKE_STAT" <<'FAKESTAT'
+#!/usr/bin/env bash
+# Mimics GNU coreutils stat when it shadows BSD /usr/bin/stat.
+# On Darwin: BSD stat uses %m (mtime), %z (size), etc.
+# GNU stat -f treats its argument as a filesystem-path option, not a format.
+# For the format tokens our code uses, GNU stat prints the filesystem dump
+# starting with `File: "..."` and exits non-zero on the format token.
+# We simulate exactly that failure mode.
+opt1=${1:-} opt2=${2:-}
+if [ "$opt1" = "-f" ]; then
+  case "$opt2" in
+    %m|%l|%z|%d|%Lp|%i|%u|%B|%FB|%HT:%p|%d:%i|%d:%i:%z:%m:%c)
+      printf 'File: "%s"\n' "${3:-}" >&2
+      exit 1
+      ;;
+    *)
+      printf 'GNU stat: unknown -f format: %s\n' "$opt2" >&2
+      exit 1
+      ;;
+  esac
+fi
+printf 'GNU stat: unknown invocation: %s\n' "$*" >&2
+exit 1
+FAKESTAT
+chmod +x "$FAKE_STAT"
+
+# Prepend fakebin so the fake GNU stat shadows /usr/bin/stat
+ORIGINAL_PATH="$PATH"
+export PATH="$TMP_ROOT/fakebin:$ORIGINAL_PATH"
+
+# Verify the shadowing is active: a bare `stat -f %m /` must fail (not use BSD)
+if stat -f %m / >/dev/null 2>&1; then
+  # The fake stat didn't catch this — something is wrong with the PATH setup
+  PATH="$ORIGINAL_PATH"
+  fail "shadowing sanity check: bare stat -f %m / should fail under GNU-shadow but did not"
+fi
+
+# Also verify /usr/bin/stat still works when called directly
+REAL_MTIME=$(/usr/bin/stat -f %m "$0" 2>/dev/null) || true
+[ -n "$REAL_MTIME" ] && [ "$REAL_MTIME" -ge 0 ] || {
+  PATH="$ORIGINAL_PATH"
+  fail "/usr/bin/stat -f %m sanity check failed — /usr/bin/stat is not working"
+}
+pass "shadowing: fake GNU stat shadows /usr/bin/stat in PATH"
+
+# --- test the fixed helpers under shadowing ----------------------------------
+
+. "$ROOT/bin/fm-supervision-lib.sh"
+. "$ROOT/bin/fm-startup-memory-budget-lib.sh"
+
+TESTFILE="$TMP_ROOT/testfile"
+printf 'hello world\n' > "$TESTFILE"
+
+# 1. fm_sup_stat_mtime from bin/fm-supervision-lib.sh
+RESULT_MTIME=$(fm_sup_stat_mtime "$TESTFILE") || true
+EXPECTED_MTIME=$(/usr/bin/stat -f %m "$TESTFILE" 2>/dev/null)
+if [ -z "$RESULT_MTIME" ] || [ "$RESULT_MTIME" != "$EXPECTED_MTIME" ]; then
+  PATH="$ORIGINAL_PATH"
+  fail "fm_sup_stat_mtime: expected $EXPECTED_MTIME, got '$RESULT_MTIME'"
+fi
+pass "fm_sup_stat_mtime returns correct epoch mtime under GNU stat shadowing"
+
+# 2. fm_startup_memory_budget_link_count from bin/fm-startup-memory-budget-lib.sh
+RESULT_LINKS=$(fm_startup_memory_budget_link_count "$TESTFILE") || true
+EXPECTED_LINKS=$(/usr/bin/stat -f %l "$TESTFILE" 2>/dev/null)
+if [ -z "$RESULT_LINKS" ] || [ "$RESULT_LINKS" != "$EXPECTED_LINKS" ]; then
+  PATH="$ORIGINAL_PATH"
+  fail "fm_startup_memory_budget_link_count: expected $EXPECTED_LINKS, got '$RESULT_LINKS'"
+fi
+pass "fm_startup_memory_budget_link_count returns correct link count under GNU stat shadowing"
+
+# 3. _fm_status_file_size from bin/fm-classify-lib.sh (LC_ALL=C stat -f '%z')
+#    We source it and call the internal function directly.
+RESULT_SIZE=$(LC_ALL=C /usr/bin/stat -f '%z' "$TESTFILE" 2>/dev/null) || true
+# The fixed code uses /usr/bin/stat so it should produce the same value as direct call
+if [ -z "$RESULT_SIZE" ]; then
+  PATH="$ORIGINAL_PATH"
+  fail "_fm_status_file_size: could not get size via /usr/bin/stat"
+fi
+# Verify the helper itself works by checking that calling it with /usr/bin/stat prefix matches
+. "$ROOT/bin/fm-classify-lib.sh"
+HELPER_SIZE=$(_fm_status_file_size "$TESTFILE") || true
+if [ -z "$HELPER_SIZE" ] || [ "$HELPER_SIZE" != "$RESULT_SIZE" ]; then
+  PATH="$ORIGINAL_PATH"
+  fail "_fm_status_file_size: expected $RESULT_SIZE, got '$HELPER_SIZE'"
+fi
+pass "_fm_status_file_size returns correct byte size under GNU stat shadowing"
+
+# 4. stat_mtime from bin/fm-watch.sh
+. "$ROOT/bin/fm-watch.sh"
+RESULT_WATCH_MTIME=$(stat_mtime "$TESTFILE") || true
+if [ -z "$RESULT_WATCH_MTIME" ] || [ "$RESULT_WATCH_MTIME" != "$EXPECTED_MTIME" ]; then
+  PATH="$ORIGINAL_PATH"
+  fail "stat_mtime (fm-watch.sh): expected $EXPECTED_MTIME, got '$RESULT_WATCH_MTIME'"
+fi
+pass "stat_mtime from fm-watch.sh returns correct epoch mtime under GNU stat shadowing"
+
+# Restore PATH before exit
+PATH="$ORIGINAL_PATH"

--- a/tests/fm-stat-shadowing.test.sh
+++ b/tests/fm-stat-shadowing.test.sh
@@ -1,18 +1,14 @@
 #!/usr/bin/env bash
-# tests/fm-stat-shadowing.test.sh - verify Darwin stat helpers survive GNU coreutils
-# stat shadowing /usr/bin/stat on hosts where ~/.local/bin/stat (GNU) precedes
-# /usr/bin/stat in PATH.
+# tests/fm-stat-shadowing.test.sh - verify Darwin BSD-stat helpers ignore a GNU
+# stat earlier on PATH.
 #
-# When GNU stat shadows BSD stat, `stat -f <fmt>` no longer means "format the
-# output" — it means "print a filesystem dump" and prints the literal text
-# `File: "<path>"` to stdout before failing on the format token. Callers that
-# feed the output into arithmetic (e.g. `age=$(( $(date +%s) - m ))`) crash
-# under `set -u` with "unbound variable" on the stray token.
+# On Darwin, GNU coreutils can put a GNU stat earlier on PATH than /usr/bin/stat.
+# A bare `stat -f <fmt>` then reaches GNU stat, where `-f` means filesystem stat
+# rather than BSD-format output and can leak a filesystem dump into callers.
+# Runtime Darwin BSD-format calls use /usr/bin/stat so their syntax stays tied
+# to the system BSD implementation.
 #
-# The fix: all Darwin `stat -f` calls in bin/ are prefixed with `/usr/bin/stat`
-# to bypass any PATH-shadowing wrapper.
-#
-# This test proves the fix works by installing a fake GNU-like stat that shadows
+# This test proves the invariant by installing a fake GNU-like stat that shadows
 # /usr/bin/stat and asserting the helpers still return correct values.
 set -u
 
@@ -33,10 +29,9 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 
 # --- fake GNU stat that mimics ~/.local/bin/stat shadowing /usr/bin/stat -------
 
-# GNU stat -f <fmt> prints a filesystem dump starting with `File: "<path>"` and
-# exits non-zero when the format token is unrecognized by the filesystem path.
-# We simulate this for the tokens used in our helpers so callers fail or produce
-# garbage when they use the shadowed stat instead of /usr/bin/stat.
+# A shadowed GNU stat does not interpret `-f <fmt>` as BSD-format output.
+# We fail the tokens used in our helpers so callers cannot accidentally use the
+# shadowed stat instead of /usr/bin/stat.
 FAKE_STAT="$TMP_ROOT/fakebin/stat"
 mkdir -p "$(dirname "$FAKE_STAT")"
 
@@ -45,9 +40,8 @@ cat > "$FAKE_STAT" <<'FAKESTAT'
 # Mimics GNU coreutils stat when it shadows BSD /usr/bin/stat.
 # On Darwin: BSD stat uses %m (mtime), %z (size), etc.
 # GNU stat -f treats its argument as a filesystem-path option, not a format.
-# For the format tokens our code uses, GNU stat prints the filesystem dump
-# starting with `File: "..."` and exits non-zero on the format token.
-# We simulate exactly that failure mode.
+# For the format tokens our code uses, this fake exits non-zero before a helper
+# could consume shadowed output.
 opt1=${1:-} opt2=${2:-}
 if [ "$opt1" = "-f" ]; then
   case "$opt2" in
@@ -72,7 +66,7 @@ export PATH="$TMP_ROOT/fakebin:$ORIGINAL_PATH"
 
 # Verify the shadowing is active: a bare `stat -f %m /` must fail (not use BSD)
 if stat -f %m / >/dev/null 2>&1; then
-  # The fake stat didn't catch this — something is wrong with the PATH setup
+  # The fake stat didn't catch this, so something is wrong with the PATH setup
   PATH="$ORIGINAL_PATH"
   fail "shadowing sanity check: bare stat -f %m / should fail under GNU-shadow but did not"
 fi
@@ -111,7 +105,7 @@ if [ -z "$RESULT_LINKS" ] || [ "$RESULT_LINKS" != "$EXPECTED_LINKS" ]; then
 fi
 pass "fm_startup_memory_budget_link_count returns correct link count under GNU stat shadowing"
 
-# 3. _fm_status_file_size from bin/fm-classify-lib.sh (LC_ALL=C stat -f '%z')
+# 3. _fm_status_file_size from bin/fm-classify-lib.sh
 #    We source it and call the internal function directly.
 RESULT_SIZE=$(LC_ALL=C /usr/bin/stat -f '%z' "$TESTFILE" 2>/dev/null) || true
 # The fixed code uses /usr/bin/stat so it should produce the same value as direct call

--- a/tests/fm-stat-shadowing.test.sh
+++ b/tests/fm-stat-shadowing.test.sh
@@ -19,7 +19,14 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-[ "$(uname)" = Darwin ] || { echo "skip: Darwin only"; exit 0; }
+# Darwin-only: the shadowing assertions require a real BSD /usr/bin/stat to
+# shadow; on Linux the `stat -f` semantics differ and the helpers take the
+# `stat -c` branch instead, so there is nothing meaningful to assert. Skip
+# visibly (after lib.sh so `pass`/`fail` exist) rather than silently.
+if [ "$(uname)" != Darwin ]; then
+  pass "Darwin-only test: shadowing assertions require BSD /usr/bin/stat; skipping on $(uname -s)"
+  exit 0
+fi
 
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-stat-shadowing.XXXXXX") || exit 1
 trap 'rm -rf "$TMP_ROOT"' EXIT
@@ -122,6 +129,10 @@ fi
 pass "_fm_status_file_size returns correct byte size under GNU stat shadowing"
 
 # 4. stat_mtime from bin/fm-watch.sh
+# fm-watch.sh runs a top-level `mkdir -p` on its state dir when sourced; pin it
+# to the temp root via FM_STATE_OVERRIDE so no artifact escapes into the repo's
+# git-ignored state/ directory.
+export FM_STATE_OVERRIDE="$TMP_ROOT/state"
 . "$ROOT/bin/fm-watch.sh"
 RESULT_WATCH_MTIME=$(stat_mtime "$TESTFILE") || true
 if [ -z "$RESULT_WATCH_MTIME" ] || [ "$RESULT_WATCH_MTIME" != "$EXPECTED_MTIME" ]; then

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1601,6 +1601,13 @@ test_non_linked_index_lock_path_is_checked_from_worktree() {
 
 test_index_lock_mtime_read_failure_refuses() {
   local case_dir rc lock
+  # The mtime fault is injected by a fake stat on PATH; on Darwin the lock
+  # helper now calls /usr/bin/stat directly, so the fake can never fire there.
+  # Skip the Darwin run of this case.
+  if [ "$(uname)" = Darwin ]; then
+    pass "index-lock mtime fault injection is PATH-based; skipped on Darwin where stat is /usr/bin/stat"
+    return
+  fi
   case_dir=$(make_case mtime-error-index-lock)
   write_meta "$case_dir" no-mistakes ship
   wt_commit "$case_dir" "shippable work"


### PR DESCRIPTION
## Intent

The developer wanted PR https://github.com/kunchenguid/firstmate/pull/3305 rebased onto current origin/main so GitHub would report it mergeable again. They required preserving the Darwin fix that prefixes `stat -f` invocations with `/usr/bin/stat`, resolving bin-file conflicts by keeping that fix where relevant and main’s other changes elsewhere. They also required work in an isolated worktree, no default-branch pushes or PR merges, targeted tests plus no-mistakes validation, and pushing the corrected PR head when checks passed.

## What Changed
- Prefix Darwin `stat -f` calls across shell helpers with `/usr/bin/stat` so BSD-format invocations bypass GNU/coreutils `stat` earlier on `PATH`.
- Add a Darwin-only regression test that shadows `stat` and verifies key helpers still return expected metadata.
- Skip PATH-fake stat fault-injection cases on Darwin and refresh portable shard documentation for the added test coverage.

## Risk Assessment

✅ Low: The change is a narrow Darwin stat shadowing hardening plus targeted test adjustments, with no substantiated source-level regressions found.

## Testing

I drove a live Darwin PATH-shadowing scenario through `fm-fleet-snapshot.sh`, ran the new stat-shadowing regression test, and ran targeted PR-poll and backlog atomicity suites; backlog needed a temporary local `timeout` shim because this macOS host lacks GNU `timeout`. An exploratory `fm-teardown` run hit an unrelated herdr preflight failure before the Darwin mtime-skip case, so it was not used as evidence for this change.

- Live validation: ✅ go - 1 of 1 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A Darwin user with a GNU-like `stat` earlier in PATH runs `fm-fleet-snapshot.sh --json`, and the snapshot still reads file metadata with BSD `/usr/bin/stat` and emits a valid readable-registry JSON sn… | ✅ pass | live | ~/.no-mistakes/evidence/01M1YT9AV1Y834NGA4N7RQ41G3/fm-fleet-snapshot-shadowing-live.log |

<details>
<summary>Evidence: Darwin stat-shadowing regression test</summary>

Source: [Darwin stat-shadowing regression test](https://github.com/0x7067/firstmate/blob/8778e10b270a64944b667e076221cf954713b40c/.no-mistakes/evidence/fm/darwin-stat-shadowing-fix-21/fm-stat-shadowing-test.log)

```text
FM_TEST_BEGIN 2026-09-07T21:13:28Z tests/fm-stat-shadowing.test.sh family=unclassified expected_gate_skip=none
ok - shadowing: fake GNU stat shadows /usr/bin/stat in PATH
ok - fm_sup_stat_mtime returns correct epoch mtime under GNU stat shadowing
ok - fm_startup_memory_budget_link_count returns correct link count under GNU stat shadowing
ok - _fm_status_file_size returns correct byte size under GNU stat shadowing
ok - stat_mtime from fm-watch.sh returns correct epoch mtime under GNU stat shadowing
FM_TEST_END 2026-09-07T21:13:28Z tests/fm-stat-shadowing.test.sh exit=0 duration_ms=659 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=749
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=659 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-stat-shadowing.test.sh duration_ms=659
```
</details>
<details>
<summary>Evidence: Live fm-fleet-snapshot under PATH-shadowed stat</summary>

Source: [Live fm-fleet-snapshot under PATH-shadowed stat](https://github.com/0x7067/firstmate/blob/8778e10b270a64944b667e076221cf954713b40c/.no-mistakes/evidence/fm/darwin-stat-shadowing-fix-21/fm-fleet-snapshot-shadowing-live.log)

```text
# Scenario: fm-fleet-snapshot on Darwin with a PATH-shadowed stat
uname=Darwin
fake_stat=/var/folders/9p/7pl_yxb55vqf1cg3mrjs19d00000gn/T//fm-live-shadow.xj4AM7/fakebin/stat
bare_stat_rc=42
bare_stat_stderr=fake shadowed stat rejects: -f %m /var/folders/9p/7pl_yxb55vqf1cg3mrjs19d00000gn/T//fm-live-shadow.xj4AM7/home/data/secondmates.md
snapshot_contract=pass
fake_stat_log_lines=1
{"schema":"fm-fleet-snapshot.v1","roots":{"fm_root":"~/.no-mistakes/worktrees/b764898e6d62/01M1YT9AV1Y834NGA4N7RQ41G3"},"secondmate_current":{"registry":{"present":true,"available":true,"complete":true,"records_count":0}}}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6fb16db53a66a2f9b59c4468a5b2dd71f3c5c1dd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 1 of 1 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A Darwin user with a GNU-like `stat` earlier in PATH runs `fm-fleet-snapshot.sh --json`, and the snapshot still reads file metadata with BSD `/usr/bin/stat` and emits a valid readable-registry JSON sn… | ✅ pass | live | ~/.no-mistakes/evidence/01M1YT9AV1Y834NGA4N7RQ41G3/fm-fleet-snapshot-shadowing-live.log |

- `bin/fm-test-run.sh tests/fm-stat-shadowing.test.sh`
- `bin/fm-test-run.sh tests/fm-pr-check-security.test.sh`
- `PATH=<temp timeout wrapper> bin/fm-test-run.sh tests/fm-backlog-atomicity.test.sh`
- <code>`bin/fm-test-run.sh tests/fm-teardown.test.sh` (exploratory; stopped on unrelated herdr-preflight-missing-adapter failure before the Darwin mtime-skip case)</code>
- `PATH=<fake stat> FM_HOME=<isolated home> FM_ROOT_OVERRIDE=$PWD FM_DATA_OVERRIDE=<isolated data> FM_STATE_OVERRIDE=<isolated state> FM_CONFIG_OVERRIDE=<isolated config> FM_PROJECTS_OVERRIDE=<isolated projects> bin/fm-fleet-snapshot.sh --json`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
