### PR TITLE
fix(bin): preserve committed CLAUDE.md symlinks instead of converting them

### DIFF
--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -4,15 +4,19 @@
 # real regular file whose canonical content is the two-line @AGENTS.md pointer
 # that Claude Code inlines at load time. Creates a minimal AGENTS.md skeleton
 # when neither file exists, promotes a real CLAUDE.md file when it is the only
-# file present (unless it is already the canonical pointer), converts a correct
-# CLAUDE.md -> AGENTS.md symlink into the pointer file, and refuses to clobber
-# distinct real files or wrong symlinks.
+# file present (unless it is already the canonical pointer), preserves a correct
+# CLAUDE.md -> AGENTS.md symlink in place, and refuses to clobber distinct real
+# files or wrong symlinks.
 # Owns the canonical "## Maintaining this file" self-governance wording for
 # project AGENTS.md files, injecting it idempotently into created skeletons,
 # promoted CLAUDE.md files, and any existing AGENTS.md that still lacks it.
 # Owns the canonical CLAUDE.md pointer content (the exact two-line @AGENTS.md
 # form). A real-file pointer cannot follow a write into AGENTS.md, which is why
 # the installer never creates a CLAUDE.md symlink.
+# A correct existing symlink is preserved, never converted: a committed symlink
+# is tracked git state (mode 120000), and rewriting it dirties every spawned
+# crewmate worktree with a typechange that crews have repeatedly committed by
+# accident, while the symlink already resolves to AGENTS.md for Claude Code.
 # Refuses a case-variant real memory file such as a lowercase agents.md, so the
 # pointer's @AGENTS.md import resolves to a real AGENTS.md on a case-sensitive
 # filesystem (issue #389). The real-file pointer also eliminates the old
@@ -115,8 +119,11 @@ is_canonical_claude_pointer() {
 }
 
 # Write the canonical pointer as a regular file. Unlink a symlink first so the
-# write cannot follow it and destroy AGENTS.md. Never overwrite a distinct real
-# file; callers classify that as a conflict before invoking this.
+# write cannot follow it and destroy AGENTS.md. Callers preserve correct
+# symlinks and never invoke this while one exists; the unlink remains as a
+# guard so a stray call cannot clobber AGENTS.md through the link. Never
+# overwrite a distinct real file; callers classify that as a conflict before
+# invoking this.
 install_claude_pointer() {
   if is_canonical_claude_pointer; then
     return 0
@@ -182,11 +189,10 @@ if [ -e "$AGENTS" ]; then
   if [ -L "$CLAUDE" ]; then
     if is_correct_claude_symlink; then
       ensure_maintenance_section
-      install_claude_pointer
       if [ "$MAINT_INJECTED" -eq 1 ]; then
-        echo "updated: added ## Maintaining this file to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in $DIR"
+        echo "updated: added ## Maintaining this file to AGENTS.md; preserved CLAUDE.md symlink in $DIR"
       else
-        echo "updated: replaced CLAUDE.md symlink with @AGENTS.md pointer in $DIR"
+        echo "unchanged: AGENTS.md with preserved CLAUDE.md symlink in $DIR"
       fi
       exit 0
     fi
@@ -223,8 +229,7 @@ fi
 if [ -L "$CLAUDE" ]; then
   if is_correct_claude_symlink; then
     write_skeleton
-    install_claude_pointer
-    echo "created: AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in $DIR"
+    echo "created: AGENTS.md with preserved CLAUDE.md symlink in $DIR"
     exit 0
   fi
   echo "conflict: CLAUDE.md is a symlink in $DIR but AGENTS.md is missing and the link does not point to AGENTS.md" >&2

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -338,6 +338,7 @@ The [Relay configuration reference](configuration.md#promised-public-replies-sta
 Durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a real `@AGENTS.md` import pointer.
 Ship briefs prompt crewmates to create or update those files through the normal delivery path; `data/projects.md` stays a thin private registry.
 Each project `AGENTS.md` carries a short `## Maintaining this file` self-governance section; `bin/fm-ensure-agents-md.sh` owns the canonical wording and injects it idempotently when creating the skeleton, promoting an existing `CLAUDE.md`, or reconciling an existing `AGENTS.md` that still lacks it.
+It preserves a committed correct `CLAUDE.md -> AGENTS.md` symlink in place instead of converting it to a pointer file, so a spawned worktree never shows a conversion diff a crewmate could commit; the script header owns the rationale.
 It refuses a case-variant real memory file such as a lowercase `agents.md`, so the pointer's `@AGENTS.md` import resolves to a real `AGENTS.md` on a case-sensitive filesystem, and surfaces the mismatch for manual reconciliation.
 The full ownership rule - what is project-intrinsic versus fleet-private, and how firstmate keeps the two apart without writing into project clones - is owned by [`AGENTS.md`](../AGENTS.md) (project and knowledge management).
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -37,7 +37,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-herdr-ci-cleanup.sh` | Snapshot and tear down only job-owned `fm-lab-*` sessions in the Herdr CI lane       |
 | `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, bounded concurrency, budgets, coverage guard, timing/JSON |
 | `fm-test-isolation-proof.sh` | Concurrent isolation harness and portable candidate set owner |
-| `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` `@AGENTS.md` pointer, and the canonical self-governance section |
+| `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` `@AGENTS.md` pointer (preserving a committed correct `CLAUDE.md -> AGENTS.md` symlink), and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -19,6 +19,14 @@ assert_claude_pointer() {
 EOF
 }
 
+# Public contract: a committed correct CLAUDE.md -> AGENTS.md symlink survives
+# the utility untouched, so spawned worktrees never show a conversion diff.
+assert_claude_symlink_preserved() {
+  local path=$1
+  [ -L "$path" ] || fail "CLAUDE.md is no longer a symlink; the tracked symlink was converted to a regular file"
+  [ "$(readlink "$path")" = "AGENTS.md" ] || fail "CLAUDE.md symlink retargeted to $(readlink "$path")"
+}
+
 write_fixture_claude_pointer() {
   cat > "$1/CLAUDE.md" <<'EOF'
 <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
@@ -111,46 +119,35 @@ test_existing_agents_md_with_symlink_gains_self_governance() {
   assert_grep "## Maintaining this file" "$agents" "existing AGENTS.md did not gain the self-governance section"
   count=$(grep -Fc "## Maintaining this file" "$agents")
   [ "$count" -eq 1 ] || fail "injection wrote $count self-governance sections"
-  assert_claude_pointer "$repo/CLAUDE.md"
+  assert_claude_symlink_preserved "$repo/CLAUDE.md"
   # Re-run must be a byte-exact no-op reporting unchanged.
   cp "$agents" "$repo/.after-first"
-  cp "$repo/CLAUDE.md" "$repo/.claude-after-first"
   out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
     || fail "fm-ensure-agents-md.sh failed on idempotent re-run"
   assert_contains "$out" "unchanged:" "idempotent re-run did not report unchanged"
   diff "$repo/.after-first" "$agents" >/dev/null \
     || fail "idempotent re-run modified AGENTS.md"
-  cmp -s "$repo/.claude-after-first" "$repo/CLAUDE.md" \
-    || fail "idempotent re-run modified CLAUDE.md"
+  assert_claude_symlink_preserved "$repo/CLAUDE.md"
   pass "fm-ensure-agents-md.sh: existing symlinked AGENTS.md gains the section idempotently"
 }
 
-test_correct_symlink_migrates_to_pointer_without_clobbering_agents() {
+test_correct_symlink_is_preserved_without_clobbering_agents() {
   local repo agents out
-  repo="$TMP_ROOT/symlink-migrate-project"
+  repo="$TMP_ROOT/symlink-preserve-project"
   mkdir -p "$repo"
   printf '# Unique agent memory\n\nDo not clobber this payload.\n\n## Maintaining this file\n\nKeep this file for knowledge useful to almost every future agent session in this project.\nDo not repeat what the codebase already shows; point to the authoritative file or command instead.\nPrefer rewriting or pruning existing entries over appending new ones.\nWhen updating this file, preserve this bar for all agents and keep entries concise.\n' > "$repo/AGENTS.md"
   ln -s AGENTS.md "$repo/CLAUDE.md"
   agents="$repo/AGENTS.md"
   cp "$agents" "$repo/.before"
   out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
-    || fail "fm-ensure-agents-md.sh failed migrating a correct CLAUDE.md symlink"
-  assert_contains "$out" "updated:" "symlink migration did not report an update"
-  assert_claude_pointer "$repo/CLAUDE.md"
+    || fail "fm-ensure-agents-md.sh failed on a correct CLAUDE.md symlink"
+  assert_contains "$out" "unchanged:" "preserved-symlink run did not report unchanged"
+  assert_claude_symlink_preserved "$repo/CLAUDE.md"
   cmp -s "$repo/.before" "$agents" \
-    || fail "symlink migration clobbered AGENTS.md"
+    || fail "preserved-symlink run clobbered AGENTS.md"
   assert_grep "Do not clobber this payload." "$agents" \
-    "symlink migration lost unique AGENTS.md content"
-  cp "$agents" "$repo/.after-first"
-  cp "$repo/CLAUDE.md" "$repo/.claude-after-first"
-  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
-    || fail "fm-ensure-agents-md.sh failed on post-migration re-run"
-  assert_contains "$out" "unchanged:" "post-migration re-run did not report unchanged"
-  cmp -s "$repo/.after-first" "$agents" \
-    || fail "post-migration re-run modified AGENTS.md"
-  cmp -s "$repo/.claude-after-first" "$repo/CLAUDE.md" \
-    || fail "post-migration re-run modified CLAUDE.md"
-  pass "fm-ensure-agents-md.sh: correct symlink migrates to pointer without clobbering AGENTS.md"
+    "preserved-symlink run lost unique AGENTS.md content"
+  pass "fm-ensure-agents-md.sh: correct symlink is preserved without touching AGENTS.md"
 }
 
 test_existing_agents_md_without_claude_gains_section_and_pointer() {
@@ -245,15 +242,13 @@ test_existing_crlf_agents_md_without_section_preserves_crlf() {
     'When updating this file, preserve this bar for all agents and keep entries concise.' > "$repo/.expected"
   cmp -s "$repo/.expected" "$agents" \
     || fail "CRLF AGENTS.md injection did not preserve CRLF line endings"
-  assert_claude_pointer "$repo/CLAUDE.md"
+  assert_claude_symlink_preserved "$repo/CLAUDE.md"
   cp "$agents" "$repo/.after-first"
-  cp "$repo/CLAUDE.md" "$repo/.claude-after-first"
   "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 \
     || fail "fm-ensure-agents-md.sh failed on idempotent CRLF re-run"
   cmp -s "$repo/.after-first" "$agents" \
     || fail "idempotent CRLF re-run modified AGENTS.md"
-  cmp -s "$repo/.claude-after-first" "$repo/CLAUDE.md" \
-    || fail "idempotent CRLF re-run modified CLAUDE.md"
+  assert_claude_symlink_preserved "$repo/CLAUDE.md"
   pass "fm-ensure-agents-md.sh: CRLF injection preserves line endings idempotently"
 }
 
@@ -353,12 +348,44 @@ test_lowercase_agents_md_refuses_case_fragile_pointer() {
   pass "fm-ensure-agents-md.sh: refuses a case-variant lowercase agents.md (issue #389)"
 }
 
+test_symlinked_claude_md_survives_worktree_creation_and_ensure_as_mode_120000() {
+  local repo wt out tracked_mode
+  repo="$TMP_ROOT/symlink-tracked-project"
+  wt="$TMP_ROOT/symlink-tracked-project.wt"
+  fm_git_init_commit "$repo"
+  printf '# Project agent memory\n' > "$repo/AGENTS.md"
+  ln -s AGENTS.md "$repo/CLAUDE.md"
+  git -C "$repo" add AGENTS.md CLAUDE.md
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm 'track CLAUDE.md symlink'
+  tracked_mode=$(git -C "$repo" ls-files -s CLAUDE.md | awk '{print $1}')
+  [ "$tracked_mode" = "120000" ] || fail "fixture did not track CLAUDE.md as a 120000 symlink (got: $tracked_mode)"
+  # Spawn-path worktree creation: the derived worktree must materialize the
+  # committed symlink, not a regular file.
+  git -C "$repo" worktree add --quiet "$wt" 2>/dev/null \
+    || fail "git worktree add failed for the symlink fixture"
+  [ -L "$wt/CLAUDE.md" ] || fail "worktree creation converted the tracked CLAUDE.md symlink into a regular file"
+  tracked_mode=$(git -C "$wt" ls-files -s CLAUDE.md | awk '{print $1}')
+  [ "$tracked_mode" = "120000" ] || fail "spawned worktree's CLAUDE.md is not mode 120000 (got: $tracked_mode)"
+  # The conversion site: running the utility in a spawned worktree must leave
+  # the tracked symlink and leave nothing for a crew to accidentally commit.
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$wt" 2>&1) \
+    || fail "fm-ensure-agents-md.sh failed in a worktree with a tracked CLAUDE.md symlink"
+  assert_claude_symlink_preserved "$wt/CLAUDE.md"
+  tracked_mode=$(git -C "$wt" ls-files -s CLAUDE.md | awk '{print $1}')
+  [ "$tracked_mode" = "120000" ] || fail "post-ensure CLAUDE.md is not mode 120000 (got: $tracked_mode)"
+  [ -z "$(git -C "$wt" status --porcelain -- CLAUDE.md)" ] \
+    || fail "fm-ensure-agents-md.sh dirtied CLAUDE.md in the worktree; a crew would commit the conversion"
+  assert_grep "## Maintaining this file" "$wt/AGENTS.md" \
+    "worktree AGENTS.md did not gain the self-governance section"
+  pass "fm-ensure-agents-md.sh: tracked CLAUDE.md symlink survives worktree creation and ensure as mode 120000"
+}
+
 test_created_agents_md_includes_self_governance
 test_fresh_setup_writes_real_claude_pointer
 test_promoted_claude_md_includes_self_governance
 test_promoted_claude_md_without_trailing_newline_keeps_blank_separator
 test_existing_agents_md_with_symlink_gains_self_governance
-test_correct_symlink_migrates_to_pointer_without_clobbering_agents
+test_correct_symlink_is_preserved_without_clobbering_agents
 test_existing_agents_md_without_claude_gains_section_and_pointer
 test_existing_agents_md_with_section_reports_unchanged
 test_existing_crlf_agents_md_with_section_stays_unchanged
@@ -369,3 +396,4 @@ test_agents_md_symlink_is_refused
 test_wrong_target_symlink_is_refused
 test_non_regular_claude_md_is_refused
 test_lowercase_agents_md_refuses_case_fragile_pointer
+test_symlinked_claude_md_survives_worktree_creation_and_ensure_as_mode_120000


### PR DESCRIPTION
## Problem

When a project's `CLAUDE.md` is a committed symlink to `AGENTS.md` (git mode 120000), the crewmate setup path destroyed it. `bin/fm-ensure-agents-md.sh` - which ship briefs tell every crewmate to run in the task worktree - classified a correct `CLAUDE.md -> AGENTS.md` symlink as something to convert, unlinking it and writing a real `@AGENTS.md` pointer file over it.

In a spawned crewmate worktree that conversion shows up as a typechange of the project's tracked symlink (mode 120000 -> 100644), which crews have repeatedly committed by accident, destroying the project's committed link.

## Fix

`bin/fm-ensure-agents-md.sh` now preserves a correct `CLAUDE.md -> AGENTS.md` symlink in place and only reconciles `AGENTS.md` (skeleton creation and self-governance injection unchanged, still idempotent):

- existing `AGENTS.md` + correct symlink: inject the section if missing, leave the symlink, report `updated:`/`unchanged:`
- missing `AGENTS.md` + correct symlink: create the skeleton, leave the symlink, report `created:`
- fresh installs still get the real-file pointer (the installer never creates a symlink, keeping the issue #389 case-fragility protections), and wrong-target symlinks are still refused

`install_claude_pointer` keeps its unlink-before-write guard so a stray future call can never clobber `AGENTS.md` through a symlink.

## Regression check

`tests/fm-ensure-agents-md.test.sh` gains `test_symlinked_claude_md_survives_worktree_creation_and_ensure_as_mode_120000`: it tracks a `CLAUDE.md` symlink in a fixture repo, asserts `git worktree add` (the spawn-path worktree mechanism) materializes it as mode 120000, then asserts the utility leaves it a symlink, still mode 120000, with a clean `git status` for `CLAUDE.md` - nothing a crew could accidentally commit. Existing symlink-fixture tests were updated to pin the preserve contract.

## Verification

- `bin/fm-test-run.sh tests/fm-ensure-agents-md.test.sh`: 17/17 pass
- `bin/fm-lint.sh bin/fm-ensure-agents-md.sh tests/fm-ensure-agents-md.test.sh`: clean (pinned ShellCheck 0.11.0)
- `bin/fm-doc-audience-check.sh`: ok