### PR TITLE
feat(bin): nachlegen on free slots and refuse landing 20+ behind main

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -397,7 +397,7 @@ Delivery contract: mode=local-only
 This task ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+When it is implemented and committed, append \`done: ready in branch fm/$ID · Tests N/0\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
     ;;
@@ -432,6 +432,11 @@ esac
 # $(...) command substitution used to strip. Drop that one newline so generated
 # briefs stay byte-identical to the historical Bash 5 output.
 DOD=${DOD%$'\n'}
+
+SHIP_SELF_TEST_SECTION='# Self-test before done
+Before your terminal \`done:\` status, run this project'\''s test command yourself (for example \`./tests/...\` or the project'\''s documented test entrypoint). Firstmate does not run your tests for you.
+Include the pass/fail count in your terminal status as \`Tests N/0\` (passed/failed), for example \`done: ready in branch fm/'"$ID"' · Tests 42/0\`. A terminal \`done:\` without a self-test report is refused at local-only landing time.
+'
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -475,6 +480,8 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+
+$SHIP_SELF_TEST_SECTION
 
 $INBOX_SECTION
 

--- a/bin/fm-capacity-lib.sh
+++ b/bin/fm-capacity-lib.sh
@@ -1,0 +1,1009 @@
+# shellcheck shell=bash
+# fm-capacity-lib.sh - resource-aware worker slots and compute-host routing.
+#
+# Source this file. bin/fm-capacity.sh is the CLI, and bin/fm-spawn.sh consults
+# fm_capacity_allow_new_worker before a fresh ship or scout launch.
+# docs/configuration.md "Compute hosts and worker slots" owns the optional
+# config/compute-hosts.json schema. This header owns the slot formula, the
+# fresh-probe contract, same-task uniqueness, and the refuse-rather-than-kill
+# spawn gate.
+#
+# What this is not: it does not choose harness, model, or effort, and it does
+# not read config/crew-dispatch.json.
+#
+# Slot formula (local supervisor host, integer arithmetic):
+#   cpu_slots    = max(1, nproc / 3)
+#   ram_slots    = max(0, (mem_avail_mb - 4096) / 3072) when mem_avail_mb is known;
+#                  when RAM cannot be read, ram_slots is the ceiling (CPU and
+#                  load still protect the host)
+#   load_cap     = 0 when load1 is missing or not a number, or when load1 >= nproc;
+#                  1 when load1 >= 0.7 * nproc;
+#                  otherwise the ceiling
+#   slots        = min(cpu_slots, ram_slots, load_cap, 5)
+# The ceiling 5 is a safety cap on the formula, not a rigid agent count.
+#
+# Occupancy is host-scoped, not home-scoped: the budget protects one physical
+# server, so N firstmate homes on this host share one budget instead of taking
+# N independent ones. The scanned set is this home, the local primary home it
+# was seeded from when it is a secondmate home (.fm-secondmate-parent), and
+# every locally routed secondmate registered under that primary
+# (data/secondmates.md). Remote secondmates run on another machine and are not
+# counted. Home paths are canonicalized before they are deduplicated, so the
+# same home reached through a trailing slash, a symlink, or a registry spelling
+# that differs from FM_HOME is counted once rather than twice.
+# `fm-capacity.sh slots` prints homes_scanned so the measurement is auditable.
+#
+# A slot is held by a LIVE worker, not by a metadata record: each ship/scout
+# record's endpoint is classified through fm-backend.sh's agent-state contract.
+# `alive` always keeps the slot and `dead`/`missing` always free it, so a task
+# parked on a captain hold or waiting on a merge with no running worker stops
+# blocking fresh dispatch and a positively live worker is never freed.
+# Every other verdict is a NON-answer, and there are backends where it is the
+# only answer available: zellij, orca and cmux have no recovery classifier at
+# all, so fm_backend_agent_state always prints `unverified` there and liveness
+# can never be proven negative. Treating that as "still live" would let a home
+# on those backends accumulate finished records until the budget is
+# permanently full. So for a non-answer the task's own DECLARED state decides,
+# using the terminal vocabulary bin/fm-classify-lib.sh already owns rather than
+# a second copy of it: done, failed, blocked, needs-decision, paused,
+# captain-held, and the legacy bare lines that carry no leading verb at all
+# (`PR ready ...`, `merged`, `checks green`, each home's own FM_CAPTAIN_RE) all
+# mean parked, merge-waiting, or finished with the pane gone, and all release
+# the slot. A task that is actively working - or that has declared nothing yet,
+# such as a worker one second after launch - keeps it. That second half is the
+# fail-closed carve-out: an unknown endpoint on active work is exactly where a
+# wrong guess would oversubscribe the host, so it is resolved in favour of
+# holding the slot.
+# Task identity is separate from that: same-task uniqueness reads the metadata
+# records themselves, EVERY regular record in the state dir including kinds
+# that never occupy a worker slot. A record that is not an independent worker -
+# a live secondmate's endpoint above all - blocks the id for as long as it
+# exists, because a fresh spawn would rewrite it out from under its owner. A
+# ship or scout record blocks the id only while its worker is still live, so a
+# task can never get a second concurrent worker, while one whose pane died with
+# its worktree and commits intact stays restartable instead of needing its
+# metadata deleted by hand.
+# Idle secondmates do not occupy a worker slot. A relaunch replaces one worker
+# and does not consume an extra slot. The gate never interrupts another task.
+#
+# Host routing (recompute-heavy / host-bound work only):
+#   Session pins (flags/env) merge over config/compute-hosts.json field by
+#   field: pinning only the preferred host keeps the configured fallback, and
+#   an unrecognised pinned kind is rejected exactly like an unrecognised kind
+#   inside the config file rather than coerced to a default.
+#   Probe configured preferred, then fallback, with a bounded SSH call. A host
+#   with no run-queue load average (Windows) is asked for several busy-percent
+#   samples across a short window, and the mean is gated as a percentage
+#   (< FM_CAPACITY_PCT_MAX_BUSY) rather than rescaled into a load1: a
+#   one-second burst cannot demote the preferred host, and a host sitting at
+#   99% busy is still refused. A sample the host could not actually take is
+#   omitted rather than reported as 0%, so a broken CPU counter reads as
+#   unmeasurable - and unsuitable - instead of idle.
+#   Prefer the preferred host when it is freshly reachable and suitable.
+#   Use the fallback only when the preferred is not.
+#   Never assign that class of work onto the protected local supervisor
+#   just because both remotes failed; route=none in that case.
+#   A cpu-kind host is suitable when it has CPU headroom (load1 < nproc, or a
+#   mean busy percent below FM_CAPACITY_PCT_MAX_BUSY on a host that reports
+#   only a percentage) and mem_avail_mb >= 2048.
+#   A gpu-kind host must clear those same host gates AND report nvidia-smi
+#   util <= 90 with at least 1024 MiB free: free VRAM on a machine whose CPU is
+#   pinned or whose RAM is exhausted is not usable capacity, and the fallback
+#   must get its chance. Those host gates also reject an unmeasurable host, on
+#   each axis independently: a host that returned no usable CPU sample at all -
+#   the POSIX probe omits load1 when /proc/loadavg is unreadable, the Windows
+#   probe omits load_pct when the processor query fails - has no headroom
+#   measurement to pass, and an unreadable /proc/meminfo reports
+#   mem_avail_mb=0, which fails the RAM gate. Neither reads as an idle host.
+#   `fm-capacity.sh route` prints the reading each probe actually produced.
+#
+# Freshness: every probe() call measures again. Nothing here caches a prior
+# host snapshot across invocations.
+#
+# Overrides (tests and session pins; never inferred from a stale file):
+#   FM_CAPACITY_NPROC, FM_CAPACITY_MEM_AVAIL_MB, FM_CAPACITY_LOAD1
+#   FM_CAPACITY_SKIP_REMOTE=1
+#   FM_CAPACITY_PREFERRED_SSH, FM_CAPACITY_PREFERRED_KIND
+#   FM_CAPACITY_FALLBACK_SSH, FM_CAPACITY_FALLBACK_KIND
+#   FM_CAPACITY_SSH_TIMEOUT (seconds, default 5)
+
+_FM_CAPACITY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-timeout-lib.sh
+. "$_FM_CAPACITY_LIB_DIR/fm-timeout-lib.sh"
+# Endpoint liveness and the local-home topology come from the surfaces that
+# already own them; a caller that sourced them first keeps its own copy.
+if ! declare -F fm_backend_agent_alive >/dev/null 2>&1; then
+  # shellcheck source=bin/fm-backend.sh
+  . "$_FM_CAPACITY_LIB_DIR/fm-backend.sh"
+fi
+if ! declare -F secondmate_registry_parse_line >/dev/null 2>&1; then
+  # shellcheck source=bin/fm-secondmate-registry-lib.sh
+  . "$_FM_CAPACITY_LIB_DIR/fm-secondmate-registry-lib.sh"
+fi
+if ! declare -F fm_secondmate_parent_record_parse >/dev/null 2>&1; then
+  # shellcheck source=bin/fm-secondmate-parent-lib.sh
+  . "$_FM_CAPACITY_LIB_DIR/fm-secondmate-parent-lib.sh"
+fi
+if ! declare -F status_line_verb >/dev/null 2>&1; then
+  # shellcheck source=bin/fm-classify-lib.sh
+  . "$_FM_CAPACITY_LIB_DIR/fm-classify-lib.sh"
+fi
+
+FM_WORK_LOOP_MIN_REAL=3
+
+FM_CAPACITY_SLOT_CEILING=5
+FM_CAPACITY_CPU_PER_SLOT=3
+FM_CAPACITY_RAM_RESERVE_MB=4096
+FM_CAPACITY_RAM_PER_SLOT_MB=3072
+FM_CAPACITY_GPU_MIN_FREE_MB=1024
+FM_CAPACITY_GPU_MAX_UTIL=90
+FM_CAPACITY_CPU_MIN_MEM_MB=2048
+FM_CAPACITY_CONFIG_FILE=compute-hosts.json
+# A Windows host has no run-queue load average to read, so its busy percentage
+# is sampled several times across a short window and averaged. One sample is a
+# ~1-second CPU-busy reading: a browser or compile burst pins it at 100 and
+# would flip an otherwise healthy Heim-PC to unsuitable, inverting the routing
+# preference. Averaging dilutes a burst that short while a genuinely pinned
+# machine still reads ~100 across every sample, so the sustained-overload gate
+# survives.
+FM_CAPACITY_WIN_LOAD_SAMPLES=3
+FM_CAPACITY_WIN_LOAD_SAMPLE_MS=1000
+# ... and the averaged percentage is then gated as a PERCENTAGE. Rescaling it
+# into a load1 equivalent and reusing `load1 < nproc` would mean "refuse only
+# at literally 100% busy", which lets a machine sitting at 99% through; a busy
+# fraction and a run-queue depth are different measurements and get different
+# thresholds. A mean busy percent at or above this is a sustained overload.
+FM_CAPACITY_PCT_MAX_BUSY=90
+
+fm_capacity_is_uint() {
+  case "${1:-}" in '' | *[!0-9]*) return 1 ;; esac
+  return 0
+}
+
+fm_capacity_is_number() {
+  local v=${1:-}
+  case "$v" in
+    '' | *[!0-9.]* | .) return 1 ;;
+  esac
+  case "${v#*.}" in *.*) return 1 ;; esac
+  return 0
+}
+
+fm_capacity_ssh_alias_ok() {
+  case "${1:-}" in
+    '' | -* | *[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  return 0
+}
+
+fm_capacity_kind_ok() {
+  case "${1:-}" in cpu | gpu) return 0 ;; esac
+  return 1
+}
+
+fm_capacity_load_hundredths() {
+  local v=$1
+  fm_capacity_is_number "$v" || return 1
+  printf '%s\n' "$v" | awk '{ printf "%d", ($1 + 0) * 100 }'
+}
+
+fm_capacity_min() {
+  local a=$1 b=$2
+  [ "$a" -lt "$b" ] && printf '%s\n' "$a" || printf '%s\n' "$b"
+}
+
+fm_capacity_max() {
+  local a=$1 b=$2
+  [ "$a" -gt "$b" ] && printf '%s\n' "$a" || printf '%s\n' "$b"
+}
+
+# Mean of the given numeric samples, to two decimals. Non-numeric samples are
+# skipped; returns 1 when nothing numeric was given.
+fm_capacity_mean() { # <value>...
+  [ "$#" -gt 0 ] || return 1
+  printf '%s\n' "$@" | awk '
+    $1 ~ /^[0-9]+(\.[0-9]+)?$/ { sum += $1; n++ }
+    END { if (n == 0) exit 1; printf "%.2f", sum / n }
+  '
+}
+
+# Integer slot count from one local measurement triple. Unknown RAM (empty or
+# non-numeric mem_avail_mb) skips the RAM axis rather than inventing a size.
+# Unknown load (empty or non-numeric load1) yields 0 slots rather than idle.
+fm_capacity_slots_from_local() { # <nproc> <mem_avail_mb-or-empty> <load1>
+  local nproc=$1 mem=$2 load1=$3 cpu_slots ram_slots load_cap load_h nproc_h slots
+  fm_capacity_is_uint "$nproc" || { printf '0\n'; return 0; }
+  [ "$nproc" -gt 0 ] || { printf '0\n'; return 0; }
+  cpu_slots=$(fm_capacity_max 1 $((nproc / FM_CAPACITY_CPU_PER_SLOT)))
+  if fm_capacity_is_uint "$mem"; then
+    ram_slots=$(fm_capacity_max 0 \
+      $(((mem - FM_CAPACITY_RAM_RESERVE_MB) / FM_CAPACITY_RAM_PER_SLOT_MB)))
+  else
+    ram_slots=$FM_CAPACITY_SLOT_CEILING
+  fi
+  load_h=$(fm_capacity_load_hundredths "$load1") || { printf '0\n'; return 0; }
+  nproc_h=$((nproc * 100))
+  if [ "$load_h" -ge "$nproc_h" ]; then
+    load_cap=0
+  elif [ "$load_h" -ge $((nproc * 70)) ]; then
+    load_cap=1
+  else
+    load_cap=$FM_CAPACITY_SLOT_CEILING
+  fi
+  slots=$(fm_capacity_min "$cpu_slots" "$ram_slots")
+  slots=$(fm_capacity_min "$slots" "$load_cap")
+  slots=$(fm_capacity_min "$slots" "$FM_CAPACITY_SLOT_CEILING")
+  [ "$slots" -ge 0 ] || slots=0
+  printf '%s\n' "$slots"
+}
+
+fm_capacity_read_nproc() {
+  if [ -n "${FM_CAPACITY_NPROC:-}" ]; then
+    printf '%s\n' "$FM_CAPACITY_NPROC"
+    return 0
+  fi
+  if command -v nproc >/dev/null 2>&1; then
+    nproc
+    return 0
+  fi
+  getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || printf '1\n'
+}
+
+fm_capacity_read_mem_avail_mb() {
+  local kb
+  if [ -n "${FM_CAPACITY_MEM_AVAIL_MB:-}" ]; then
+    printf '%s\n' "$FM_CAPACITY_MEM_AVAIL_MB"
+    return 0
+  fi
+  if [ -r /proc/meminfo ]; then
+    kb=$(awk '/^MemAvailable:/ { print $2; exit }' /proc/meminfo)
+    if fm_capacity_is_uint "$kb"; then
+      printf '%s\n' $((kb / 1024))
+      return 0
+    fi
+  fi
+  printf '\n'
+}
+
+fm_capacity_read_load1() {
+  if [ -n "${FM_CAPACITY_LOAD1:-}" ]; then
+    printf '%s\n' "$FM_CAPACITY_LOAD1"
+    return 0
+  fi
+  if [ -r /proc/loadavg ]; then
+    awk '{ print $1; exit }' /proc/loadavg
+    return 0
+  fi
+  sysctl -n vm.loadavg 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^[0-9]/) { print $i; exit } }'
+}
+
+# Every regular task record in one home, whatever its kind. Prints one task id
+# per line. This is the task-IDENTITY view: a fresh spawn that reused any of
+# these ids would overwrite a durable record that something else owns, so the
+# uniqueness gate must see all of them - including a live secondmate's, which
+# is the one kind the occupancy view below deliberately drops.
+fm_capacity_recorded_ids() { # <state-dir>
+  local state=$1 file id
+  [ -d "$state" ] || return 0
+  for file in "$state"/*.meta; do
+    [ -f "$file" ] && [ ! -L "$file" ] || continue
+    id=$(basename "$file" .meta)
+    case "$id" in '' | *[!A-Za-z0-9._-]*) continue ;; esac
+    printf '%s\n' "$id"
+  done
+}
+
+# Independent-worker records in one home: ship and scout metadata. Prints one
+# task id per line. This is the slot-BUDGET view, so a record counts here
+# whether or not its worker is still running; fm_capacity_live_ids applies
+# liveness on top. Secondmates are persistent specialists and never occupy an
+# independent worker slot, so they are excluded from the count - but never from
+# fm_capacity_recorded_ids, which is what protects their id.
+fm_capacity_occupied_ids() { # <state-dir>
+  local state=$1 id kind
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    kind=$(grep -E '^kind=' "$state/$id.meta" 2>/dev/null | head -n 1 | cut -d= -f2-)
+    case "$kind" in
+      scout | ship | '') printf '%s\n' "$id" ;;
+      *) continue ;;
+    esac
+  done < <(fm_capacity_recorded_ids "$state")
+}
+
+# Is <state-dir>/<task-id>.status's last declaration ACTIVE work rather than a
+# finished or held task? `working` and a just-`resolved` decision are active;
+# done, failed, blocked, needs-decision, and the two declared-wait verbs
+# (paused, captain-held) are not. Fail closed on anything else: a missing,
+# blank, or unrecognised declaration reads as ACTIVE, so a worker that has not
+# written its first status line yet still holds its slot.
+#
+# The four standard verbs are matched here directly so they always release,
+# even in a home that overrides FM_CAPTAIN_RE. Beyond them, the terminal
+# vocabulary is NOT this library's to define: bin/fm-classify-lib.sh already
+# owns it for the watcher and the away-mode daemon, including the legacy bare
+# lines that carry no leading verb at all (`PR ready ...`, `checks green`,
+# `merged`) and each home's own FM_CAPTAIN_RE. Restating a narrower list here
+# would let exactly those lines pin a slot forever on a backend whose liveness
+# can never be proven negative, so the shared classifier is consulted instead
+# of a second copy of the vocabulary. It answers "not relevant" for working,
+# resolved, paused and captain-held, so an active crew is never released by it.
+fm_capacity_task_active() { # <state-dir> <task-id>
+  local state=$1 id=$2 line verb
+  declare -F last_status_line >/dev/null 2>&1 || return 0
+  line=$(last_status_line "$state/$id.status")
+  [ -n "$line" ] || return 0
+  status_is_paused_or_captain_held "$line" && return 1
+  verb=$(status_line_verb "$line")
+  case "$verb" in
+    done | failed | blocked | needs-decision) return 1 ;;
+  esac
+  if declare -F status_is_captain_relevant >/dev/null 2>&1; then
+    status_is_captain_relevant "$line" && return 1
+  fi
+  return 0
+}
+
+# Does <meta-file>'s recorded endpoint still hold a worker slot?
+# fm-backend.sh's agent-state contract answers first and its POSITIVE answers
+# are final: `alive` always keeps the slot (a running worker is never freed)
+# and `dead`/`missing` always free it. Everything else is a non-answer, and on
+# a backend with no recovery classifier (zellij, orca, cmux always print
+# `unverified`) it is the only answer that will ever come, so deciding it
+# "still live" would occupy the slot forever and permanently block dispatch on
+# those homes. For a non-answer the task's own declared state decides, and only
+# a task that is actively working or has declared nothing yet keeps its slot -
+# the fail-closed half, because that is the case where a wrong guess would
+# oversubscribe the host.
+fm_capacity_worker_live() { # <meta-file>
+  local meta=$1 backend target endpoint_state
+  [ -f "$meta" ] && [ ! -L "$meta" ] || return 1
+  declare -F fm_backend_agent_state >/dev/null 2>&1 || return 0
+  backend=$(fm_backend_of_meta "$meta")
+  target=$(fm_backend_target_of_meta "$meta")
+  [ -n "$target" ] || return 0
+  endpoint_state=$(fm_backend_agent_state "$backend" "$target")
+  case "$endpoint_state" in
+    alive) return 0 ;;
+    dead | missing) return 1 ;;
+  esac
+  fm_capacity_task_active "$(dirname "$meta")" "$(basename "$meta" .meta)"
+}
+
+# Independent workers in one home that still hold a slot.
+fm_capacity_live_ids() { # <state-dir>
+  local state=$1 id
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    fm_capacity_worker_live "$state/$id.meta" || continue
+    printf '%s\n' "$id"
+  done < <(fm_capacity_occupied_ids "$state")
+}
+
+fm_capacity_occupied_count() { # <state-dir>
+  local n=0
+  while IFS= read -r _; do
+    n=$((n + 1))
+  done < <(fm_capacity_live_ids "$1")
+  printf '%s\n' "$n"
+}
+
+# Independent workers in one home that are actively working: a live worker slot
+# holder that bin/fm-crew-state.sh classifies as provably working (busy pane or
+# active run-step). Idle done-panes with a live endpoint do not count.
+fm_capacity_real_worker_ids() { # <state-dir>
+  local state=$1 id
+  declare -F crew_is_provably_working >/dev/null 2>&1 || return 0
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    fm_capacity_worker_live "$state/$id.meta" || continue
+    crew_is_provably_working "$id" || continue
+    printf '%s\n' "$id"
+  done < <(fm_capacity_occupied_ids "$state")
+}
+
+fm_capacity_real_worker_count() { # <state-dir>
+  local n=0
+  while IFS= read -r _; do
+    n=$((n + 1))
+  done < <(fm_capacity_real_worker_ids "$1")
+  printf '%s\n' "$n"
+}
+
+# Real workers across every local home on this host. Sets FM_CAPACITY_REAL and
+# leaves FM_CAPACITY_HOMES_SCANNED unchanged (call fm_capacity_measure_host_occupancy
+# first when both occupancy and real counts are needed).
+fm_capacity_measure_host_real_workers() { # <state-dir> <home-dir>
+  local state=$1 home=$2 peer peer_state canon_home canon_state
+  FM_CAPACITY_REAL=$(fm_capacity_real_worker_count "$state")
+  [ -n "$home" ] || return 0
+  canon_home=$(fm_capacity_canonical_path "$home")
+  canon_state=$(fm_capacity_canonical_path "$state")
+  while IFS= read -r peer; do
+    [ -n "$peer" ] || continue
+    [ "$peer" != "$canon_home" ] || continue
+    peer_state="$peer/state"
+    [ "$(fm_capacity_canonical_path "$peer_state")" != "$canon_state" ] || continue
+    [ -d "$peer_state" ] || continue
+    FM_CAPACITY_REAL=$((FM_CAPACITY_REAL + $(fm_capacity_real_worker_count "$peer_state")))
+  done < <(fm_capacity_host_homes "$home")
+}
+
+# How many more real workers the section-7 loop should try to launch right now.
+fm_capacity_work_loop_shortfall() { # <real-count> [min-real]
+  local real=$1 min=${2:-$FM_WORK_LOOP_MIN_REAL}
+  fm_capacity_is_uint "$real" || real=0
+  fm_capacity_is_uint "$min" || min=$FM_WORK_LOOP_MIN_REAL
+  if [ "$real" -ge "$min" ]; then
+    printf '0\n'
+    return 0
+  fi
+  printf '%s\n' $((min - real))
+}
+
+# Plan limit for bin/fm-work-loop.sh plan: refill every free slot once the real
+# floor is met; below the floor, spawn only enough to reach it.
+fm_capacity_work_loop_plan_limit() { # <free-slots> <real-count> [min-real]
+  local free=$1 real=$2 min=${3:-$FM_WORK_LOOP_MIN_REAL} shortfall
+  fm_capacity_is_uint "$free" || free=0
+  fm_capacity_is_uint "$real" || real=0
+  shortfall=$(fm_capacity_work_loop_shortfall "$real" "$min")
+  if [ "$shortfall" -gt 0 ]; then
+    fm_capacity_min "$free" "$shortfall"
+    return 0
+  fi
+  printf '%s\n' "$free"
+}
+
+# The kind recorded for <task-id> in this home; `ship` when the record omits it,
+# matching the spawn default, and empty when there is no record at all.
+fm_capacity_record_kind() { # <state-dir> <task-id>
+  local meta=$1/$2.meta kind
+  [ -f "$meta" ] && [ ! -L "$meta" ] || return 0
+  kind=$(grep -E '^kind=' "$meta" 2>/dev/null | head -n 1 | cut -d= -f2-)
+  printf '%s\n' "${kind:-ship}"
+}
+
+# 0 when <task-id>'s record is an independent worker (ship or scout) rather
+# than some other durable record that merely shares the id space.
+fm_capacity_id_is_worker_record() { # <state-dir> <task-id>
+  case "$(fm_capacity_record_kind "$1" "$2")" in
+    ship | scout) return 0 ;;
+  esac
+  return 1
+}
+
+# 0 when a fresh ship or scout must NOT take <task-id>, because taking it would
+# either put a second worker on a task that already has a live one or overwrite
+# a durable record that something else owns.
+#
+# The two halves are deliberately different. A record whose kind is not an
+# independent worker - a live secondmate's endpoint above all - is refused for
+# as long as it exists: a fresh spawn would rewrite state/<id>.meta out from
+# under whoever owns it, and this library is not the surface that decides when
+# such a record may be retired. A ship or scout record is refused only while it
+# still holds its slot: once its worker is positively gone, the record is a
+# durable history entry, not a running worker, and sequential replacement of a
+# task whose pane died (a reboot, a killed server) is exactly what the intake
+# contract allows. Refusing those too would leave a task with an intact
+# worktree and unlanded commits restartable only by deleting its metadata by
+# hand, because fm-control.sh's relaunch also refuses a `missing` endpoint.
+# fm_capacity_worker_live is the same fail-closed predicate the slot budget
+# uses, so an ambiguous or unreadable endpoint still refuses.
+fm_capacity_task_occupies_slot() { # <state-dir> <task-id>
+  local state=$1 want=$2 id
+  [ -n "$want" ] || return 1
+  while IFS= read -r id; do
+    [ "$id" = "$want" ] || continue
+    fm_capacity_id_is_worker_record "$state" "$id" || return 0
+    fm_capacity_worker_live "$state/$id.meta" && return 0
+    return 1
+  done < <(fm_capacity_recorded_ids "$state")
+  return 1
+}
+
+# Physically resolved form of <path>, or the trimmed input when it cannot be
+# resolved (a home recorded for a directory that no longer exists still has to
+# compare equal to itself). Home paths reach this library from three
+# independent sources - FM_HOME verbatim from the environment,
+# data/secondmates.md, and .fm-secondmate-parent - so the same home routinely
+# arrives spelled three ways. Deduplicating on the raw strings counts it once
+# per spelling and inflates occupancy, which refuses fresh dispatch while slots
+# are actually free.
+fm_capacity_canonical_path() { # <path>
+  local p=$1 resolved
+  [ -n "$p" ] || return 0
+  if resolved=$(cd -- "$p" 2>/dev/null && pwd -P); then
+    printf '%s\n' "$resolved"
+    return 0
+  fi
+  while [ "$p" != / ] && [ "${p%/}" != "$p" ]; do
+    p=${p%/}
+  done
+  printf '%s\n' "$p"
+}
+
+# Every local firstmate home that shares this physical host with <home-dir>:
+# this home, the local primary home it was seeded from when it is a secondmate
+# home, and every locally routed secondmate registered under that primary. A
+# remote secondmate lives on another machine and is left out. Unparsable
+# registry lines are skipped rather than trusted.
+fm_capacity_host_homes() { # <home-dir>
+  local home=$1 root reg line seen peer
+  [ -n "$home" ] || return 0
+  home=$(fm_capacity_canonical_path "$home")
+  root=$home
+  if fm_secondmate_parent_record_parse "$home/.fm-secondmate-parent" 2>/dev/null; then
+    if [ "${FM_SECONDMATE_PARENT_ROUTE:-}" = local ] && [ -n "${FM_SECONDMATE_PARENT_HOME:-}" ]; then
+      root=$(fm_capacity_canonical_path "$FM_SECONDMATE_PARENT_HOME")
+    fi
+  fi
+  seen=$'\n'
+  for peer in "$home" "$root"; do
+    case "$seen" in *$'\n'"$peer"$'\n'*) continue ;; esac
+    seen="$seen$peer"$'\n'
+    printf '%s\n' "$peer"
+  done
+  reg="$root/data/secondmates.md"
+  [ -f "$reg" ] && [ ! -L "$reg" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in '- '*) ;; *) continue ;; esac
+    secondmate_registry_parse_line "$line" || continue
+    [ "$SECONDMATE_REGISTRY_REMOTE" -eq 0 ] || continue
+    case "$SECONDMATE_REGISTRY_HOME" in /*) ;; *) continue ;; esac
+    peer=$(fm_capacity_canonical_path "$SECONDMATE_REGISTRY_HOME")
+    case "$seen" in *$'\n'"$peer"$'\n'*) continue ;; esac
+    seen="$seen$peer"$'\n'
+    printf '%s\n' "$peer"
+  done < "$reg"
+}
+
+# Live independent workers across every local home on this host. Sets
+# FM_CAPACITY_OCCUPIED and the auditable FM_CAPACITY_HOMES_SCANNED.
+# shellcheck disable=SC2034
+fm_capacity_measure_host_occupancy() { # <state-dir> <home-dir>
+  local state=$1 home=$2 peer peer_state canon_home canon_state
+  FM_CAPACITY_OCCUPIED=$(fm_capacity_occupied_count "$state")
+  FM_CAPACITY_HOMES_SCANNED=1
+  [ -n "$home" ] || return 0
+  canon_home=$(fm_capacity_canonical_path "$home")
+  canon_state=$(fm_capacity_canonical_path "$state")
+  while IFS= read -r peer; do
+    [ -n "$peer" ] || continue
+    [ "$peer" != "$canon_home" ] || continue
+    peer_state="$peer/state"
+    [ "$(fm_capacity_canonical_path "$peer_state")" != "$canon_state" ] || continue
+    [ -d "$peer_state" ] || continue
+    FM_CAPACITY_HOMES_SCANNED=$((FM_CAPACITY_HOMES_SCANNED + 1))
+    FM_CAPACITY_OCCUPIED=$((FM_CAPACITY_OCCUPIED + $(fm_capacity_occupied_count "$peer_state")))
+  done < <(fm_capacity_host_homes "$home")
+}
+
+# Is a freshly probed host suitable for host-bound work of <kind>?
+# Both kinds must first clear the same HOST gates the local slot formula uses -
+# CPU headroom and at least FM_CAPACITY_CPU_MIN_MEM_MB available - because
+# host-bound work still needs a CPU and RAM to run on wherever it lands. A gpu
+# host then adds its accelerator gates on top; free VRAM behind a pinned CPU or
+# an exhausted RAM is not usable capacity, and treating it as capacity would
+# short-circuit routing and hide a healthy configured fallback.
+# Those host gates are also what rejects an UNMEASURABLE host, on each axis
+# independently. A fabricated 0 load must never read as headroom, so no probe
+# fabricates one: an unreadable /proc/loadavg omits load1 entirely, and an
+# empty load fails the headroom gate here whether or not the host's RAM was
+# readable. An unreadable /proc/meminfo reports mem_avail_mb=0, which fails the
+# RAM gate on its own.
+# CPU headroom is read from whichever measurement the host can actually
+# produce. A host with a run-queue load average is gated on load1 < nproc. A
+# host that only reports a busy percentage (Windows) passes that averaged
+# percentage as <mean_busy_pct> and is gated on it directly, against
+# FM_CAPACITY_PCT_MAX_BUSY: the two are different measurements and the load1
+# rescaling of a percentage can only reach nproc at exactly 100%, which would
+# wave a host sitting at 99% straight through.
+fm_capacity_host_suitable() { # <kind> <nproc> <mem_avail_mb> <load1> <gpu_free_mb> <gpu_util> [mean_busy_pct]
+  local kind=$1 nproc=$2 mem=$3 load1=$4 gpu_free=$5 gpu_util=$6 pct=${7:-}
+  local load_h nproc_h pct_h max_pct_h
+  fm_capacity_kind_ok "$kind" || return 1
+  fm_capacity_is_uint "$nproc" || return 1
+  [ "$nproc" -gt 0 ] || return 1
+  if [ -n "$pct" ]; then
+    pct_h=$(fm_capacity_load_hundredths "$pct") || return 1
+    max_pct_h=$((FM_CAPACITY_PCT_MAX_BUSY * 100))
+    [ "$pct_h" -lt "$max_pct_h" ] || return 1
+  else
+    load_h=$(fm_capacity_load_hundredths "$load1") || return 1
+    nproc_h=$((nproc * 100))
+    [ "$load_h" -lt "$nproc_h" ] || return 1
+  fi
+  fm_capacity_is_uint "$mem" || return 1
+  [ "$mem" -ge "$FM_CAPACITY_CPU_MIN_MEM_MB" ] || return 1
+  case "$kind" in
+    gpu)
+      fm_capacity_is_uint "$gpu_free" || return 1
+      fm_capacity_is_uint "$gpu_util" || return 1
+      [ "$gpu_free" -ge "$FM_CAPACITY_GPU_MIN_FREE_MB" ] || return 1
+      [ "$gpu_util" -le "$FM_CAPACITY_GPU_MAX_UTIL" ] || return 1
+      return 0
+      ;;
+    cpu)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+fm_capacity_parse_gpu_csv() { # <csv> -> sets FM_CAPACITY_GPU_FREE_MB FM_CAPACITY_GPU_UTIL
+  local csv=$1 free util
+  FM_CAPACITY_GPU_FREE_MB=
+  FM_CAPACITY_GPU_UTIL=
+  csv=$(printf '%s' "$csv" | tr -d ' \r' | head -n 1)
+  [ -n "$csv" ] || return 1
+  free=${csv%%,*}
+  util=${csv#*,}
+  util=${util%%,*}
+  fm_capacity_is_uint "$free" || return 1
+  fm_capacity_is_uint "$util" || return 1
+  FM_CAPACITY_GPU_FREE_MB=$free
+  FM_CAPACITY_GPU_UTIL=$util
+  return 0
+}
+
+# An unreadable /proc/loadavg emits NO load1 line, exactly as the Windows probe
+# omits a failed CPU sample rather than reporting 0%: a fabricated zero is
+# indistinguishable from a genuinely idle host and would route host-bound work
+# onto a machine whose CPU was never measured. The absent line leaves
+# FM_CAPACITY_PROBE_LOAD1 empty, which fails fm_capacity_host_suitable's
+# headroom gate on its own, without depending on the RAM half also failing.
+# <proc-dir> defaults to /proc and exists so the emitted command is testable
+# against a constructed /proc.
+fm_capacity_posix_probe_cmd() { # [proc-dir]
+  local proc=${1:-/proc} cmd
+  case $proc in *[!A-Za-z0-9._/-]*) proc=/proc ;; esac
+  cmd=$(cat <<'CMD'
+printf 'FM_CAP nproc=%s\n' "$(getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || printf 0)"
+if [ -r @PROC@/meminfo ]; then awk '/^MemAvailable:/ { printf "FM_CAP mem_avail_mb=%d\n", $2/1024; exit }' @PROC@/meminfo; else printf 'FM_CAP mem_avail_mb=0\n'; fi
+if [ -r @PROC@/loadavg ]; then awk '{ printf "FM_CAP load1=%s\n", $1; exit }' @PROC@/loadavg; fi
+printf 'FM_CAP gpu=%s\n' "$(nvidia-smi --query-gpu=memory.free,utilization.gpu --format=csv,noheader,nounits 2>/dev/null | head -n 1 | tr -d ' ')"
+CMD
+  )
+  printf '%s\n' "${cmd//@PROC@/$proc}"
+}
+
+# Emits one `load_pct` line per SUCCESSFUL sample; fm_capacity_absorb_probe_text
+# averages them. The shell side owns the averaging so the durability of the
+# reading is testable without a Windows host. A sample whose processor query
+# errors or whose processors all report a null LoadPercentage emits NO line
+# rather than a zero (Measure-Object averages a null property as 0, so the
+# nulls are filtered out before the mean, not after): a
+# fabricated 0% would be indistinguishable from a genuinely idle host and would
+# route work onto a machine whose CPU was never measured. With no samples at
+# all the mean stays empty, no CPU-headroom measurement exists, and the host is
+# unsuitable.
+fm_capacity_windows_probe_cmd() {
+  local cmd
+  cmd=$(cat <<'CMD'
+$n = [Environment]::ProcessorCount; $os = Get-CimInstance Win32_OperatingSystem; $avail = 0; if ($os -and $os.FreePhysicalMemory) { $avail = [int]($os.FreePhysicalMemory / 1024) }; $gpu = ''; try { $gpu = (& nvidia-smi --query-gpu=memory.free,utilization.gpu --format=csv,noheader,nounits 2>$null | Select-Object -First 1) } catch {}; Write-Output ("FM_CAP nproc=" + $n); Write-Output ("FM_CAP mem_avail_mb=" + $avail); Write-Output ("FM_CAP gpu=" + $gpu); for ($i = 0; $i -lt @SAMPLES@; $i++) { if ($i -gt 0) { Start-Sleep -Milliseconds @SLEEPMS@ }; $load = $null; try { $cpu = @(Get-CimInstance Win32_Processor -ErrorAction Stop | Where-Object { $null -ne $_.LoadPercentage }); if ($cpu.Count -gt 0) { $avg = ($cpu | Measure-Object -Property LoadPercentage -Average).Average; if ($null -ne $avg) { $load = [int]$avg } } } catch {}; if ($null -ne $load) { Write-Output ("FM_CAP load_pct=" + $load) } }
+CMD
+  )
+  cmd=${cmd//@SAMPLES@/$FM_CAPACITY_WIN_LOAD_SAMPLES}
+  cmd=${cmd//@SLEEPMS@/$FM_CAPACITY_WIN_LOAD_SAMPLE_MS}
+  printf '%s\n' "$cmd"
+}
+
+# Seconds the Windows sampling window adds to a probe, so its SSH call is not
+# cut short by the bound that fits the single-shot POSIX probe.
+fm_capacity_win_probe_extra_secs() {
+  local ms=$((FM_CAPACITY_WIN_LOAD_SAMPLES * FM_CAPACITY_WIN_LOAD_SAMPLE_MS))
+  printf '%s\n' $(((ms + 999) / 1000))
+}
+
+fm_capacity_ssh_raw() { # <host> <remote-cmd> [extra-seconds]
+  local host=$1 cmd=$2 extra=${3:-0} bound
+  fm_capacity_is_uint "$extra" || extra=0
+  bound=$((${FM_CAPACITY_SSH_TIMEOUT:-5} + 3))
+  [ "$bound" -gt 3 ] || bound=8
+  bound=$((bound + extra))
+  fm_run_timed "$bound" ssh \
+    -o BatchMode=yes \
+    -o ConnectTimeout="${FM_CAPACITY_SSH_TIMEOUT:-5}" \
+    -o ServerAliveInterval=2 \
+    -o ServerAliveCountMax=2 \
+    -o ForwardAgent=no \
+    "$host" "$cmd"
+}
+
+# Parse FM_CAP lines from a probe transcript into the FM_CAPACITY_PROBE_* vars.
+fm_capacity_absorb_probe_text() {
+  local text=$1 line key val
+  local -a load_pct=()
+  FM_CAPACITY_PROBE_NPROC=
+  FM_CAPACITY_PROBE_MEM_MB=
+  FM_CAPACITY_PROBE_LOAD1=
+  FM_CAPACITY_PROBE_GPU_FREE=
+  FM_CAPACITY_PROBE_GPU_UTIL=
+  FM_CAPACITY_PROBE_LOAD_PCT=
+  FM_CAPACITY_PROBE_LOAD_SAMPLES=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      FM_CAP\ *)
+        key=${line#FM_CAP }
+        val=${key#*=}
+        key=${key%%=*}
+        case "$key" in
+          nproc) FM_CAPACITY_PROBE_NPROC=$val ;;
+          mem_avail_mb) FM_CAPACITY_PROBE_MEM_MB=$val ;;
+          load1) FM_CAPACITY_PROBE_LOAD1=$val ;;
+          load_pct) fm_capacity_is_number "$val" && load_pct+=("$val") ;;
+          gpu) fm_capacity_parse_gpu_csv "$val" && {
+            FM_CAPACITY_PROBE_GPU_FREE=$FM_CAPACITY_GPU_FREE_MB
+            FM_CAPACITY_PROBE_GPU_UTIL=$FM_CAPACITY_GPU_UTIL
+          } ;;
+        esac
+        ;;
+    esac
+  done <<EOF
+$text
+EOF
+  # A percentage-derived load is the mean of every sample the probe returned,
+  # never a single reading: one ~1-second sample cannot distinguish a burst
+  # from a pinned host, and treating it as a 1-minute average would refuse the
+  # preferred host for the length of a browser tab. It stays a PERCENTAGE all
+  # the way to fm_capacity_host_suitable, which gates it as one; there is no
+  # rescaling into a load1, because a busy fraction rescaled that way can only
+  # reach nproc at exactly 100% and would wave a pinned host through.
+  if [ "${#load_pct[@]}" -gt 0 ]; then
+    FM_CAPACITY_PROBE_LOAD_PCT=$(fm_capacity_mean "${load_pct[@]}") \
+      || FM_CAPACITY_PROBE_LOAD_PCT=
+    FM_CAPACITY_PROBE_LOAD_SAMPLES=${#load_pct[@]}
+  fi
+  fm_capacity_is_uint "$FM_CAPACITY_PROBE_NPROC" || return 1
+  [ "$FM_CAPACITY_PROBE_NPROC" -gt 0 ] || return 1
+  return 0
+}
+
+# Probe one SSH alias. Sets measurement vars when reachable. Does not cache.
+# FM_CAPACITY_PROBE_LOAD_PCT and FM_CAPACITY_PROBE_LOAD_SAMPLES record how CPU
+# headroom was measured on a host with no run-queue load average: the mean
+# busy percent, and how many samples it was averaged over.
+# shellcheck disable=SC2034
+fm_capacity_probe_ssh() { # <ssh-alias>
+  local host=$1 out
+  FM_CAPACITY_PROBE_NPROC=
+  FM_CAPACITY_PROBE_MEM_MB=
+  FM_CAPACITY_PROBE_LOAD1=
+  FM_CAPACITY_PROBE_GPU_FREE=
+  FM_CAPACITY_PROBE_GPU_UTIL=
+  FM_CAPACITY_PROBE_LOAD_PCT=
+  FM_CAPACITY_PROBE_LOAD_SAMPLES=0
+  fm_capacity_ssh_alias_ok "$host" || return 1
+  if [ "${FM_CAPACITY_SKIP_REMOTE:-}" = 1 ]; then
+    return 1
+  fi
+  out=$(fm_capacity_ssh_raw "$host" "$(fm_capacity_posix_probe_cmd)" 2>/dev/null) || out=
+  if fm_capacity_absorb_probe_text "$out"; then
+    return 0
+  fi
+  out=$(fm_capacity_ssh_raw "$host" "$(fm_capacity_windows_probe_cmd)" \
+    "$(fm_capacity_win_probe_extra_secs)" 2>/dev/null) || out=
+  if fm_capacity_absorb_probe_text "$out"; then
+    return 0
+  fi
+  return 1
+}
+
+fm_capacity_config_path() { # <config-dir>
+  printf '%s/%s\n' "$1" "$FM_CAPACITY_CONFIG_FILE"
+}
+
+# Load preferred/fallback from flags/env/config into FM_CAPACITY_PREF_* and
+# FM_CAPACITY_FALL_*. Each session pin merges over its own config-derived
+# counterpart, so pinning one host never discards the other configured one; a
+# pinned kind is validated exactly like a configured kind. Returns 1 for a
+# rejected pin or a present but malformed config file.
+# shellcheck disable=SC2034
+fm_capacity_load_hosts() { # <config-dir>
+  local config_dir=$1 path ssh kind json
+  local pin_pref_ssh=${FM_CAPACITY_PREFERRED_SSH:-} pin_pref_kind=${FM_CAPACITY_PREFERRED_KIND:-}
+  local pin_fall_ssh=${FM_CAPACITY_FALLBACK_SSH:-} pin_fall_kind=${FM_CAPACITY_FALLBACK_KIND:-}
+  local cfg_pref_ssh='' cfg_pref_kind='' cfg_fall_ssh='' cfg_fall_kind=''
+  FM_CAPACITY_PREF_SSH=
+  FM_CAPACITY_PREF_KIND=gpu
+  FM_CAPACITY_FALL_SSH=
+  FM_CAPACITY_FALL_KIND=cpu
+  FM_CAPACITY_CONFIG_ERROR=
+  if [ -n "$pin_pref_ssh" ]; then
+    fm_capacity_ssh_alias_ok "$pin_pref_ssh" || {
+      FM_CAPACITY_CONFIG_ERROR="preferred SSH alias is not a safe host token"
+      return 1
+    }
+  fi
+  if [ -n "$pin_fall_ssh" ]; then
+    fm_capacity_ssh_alias_ok "$pin_fall_ssh" || {
+      FM_CAPACITY_CONFIG_ERROR="fallback SSH alias is not a safe host token"
+      return 1
+    }
+  fi
+  if [ -n "$pin_pref_kind" ]; then
+    fm_capacity_kind_ok "$pin_pref_kind" || {
+      FM_CAPACITY_CONFIG_ERROR="preferred kind must be gpu or cpu"
+      return 1
+    }
+  fi
+  if [ -n "$pin_fall_kind" ]; then
+    fm_capacity_kind_ok "$pin_fall_kind" || {
+      FM_CAPACITY_CONFIG_ERROR="fallback kind must be gpu or cpu"
+      return 1
+    }
+  fi
+  path=$(fm_capacity_config_path "$config_dir")
+  # Both hosts pinned leaves the file nothing to contribute; any partial pin
+  # still needs its configured counterpart.
+  if { [ -z "$pin_pref_ssh" ] || [ -z "$pin_fall_ssh" ]; } && [ -e "$path" ]; then
+    [ -f "$path" ] && [ ! -L "$path" ] || {
+      FM_CAPACITY_CONFIG_ERROR="config/compute-hosts.json must be a regular file"
+      return 1
+    }
+    command -v jq >/dev/null 2>&1 || {
+      FM_CAPACITY_CONFIG_ERROR="jq is required to read config/compute-hosts.json"
+      return 1
+    }
+    json=$(cat "$path") || {
+      FM_CAPACITY_CONFIG_ERROR="could not read config/compute-hosts.json"
+      return 1
+    }
+    printf '%s\n' "$json" | jq -e . >/dev/null 2>&1 || {
+      FM_CAPACITY_CONFIG_ERROR="config/compute-hosts.json is not valid JSON"
+      return 1
+    }
+    ssh=$(printf '%s\n' "$json" | jq -r '.preferred.ssh // empty')
+    kind=$(printf '%s\n' "$json" | jq -r '.preferred.kind // "gpu"')
+    if [ -n "$ssh" ]; then
+      fm_capacity_ssh_alias_ok "$ssh" || {
+        FM_CAPACITY_CONFIG_ERROR="preferred.ssh is not a safe host token"
+        return 1
+      }
+      fm_capacity_kind_ok "$kind" || {
+        FM_CAPACITY_CONFIG_ERROR="preferred.kind must be gpu or cpu"
+        return 1
+      }
+      cfg_pref_ssh=$ssh
+      cfg_pref_kind=$kind
+    fi
+    ssh=$(printf '%s\n' "$json" | jq -r '.fallback.ssh // empty')
+    kind=$(printf '%s\n' "$json" | jq -r '.fallback.kind // "cpu"')
+    if [ -n "$ssh" ]; then
+      fm_capacity_ssh_alias_ok "$ssh" || {
+        FM_CAPACITY_CONFIG_ERROR="fallback.ssh is not a safe host token"
+        return 1
+      }
+      fm_capacity_kind_ok "$kind" || {
+        FM_CAPACITY_CONFIG_ERROR="fallback.kind must be gpu or cpu"
+        return 1
+      }
+      cfg_fall_ssh=$ssh
+      cfg_fall_kind=$kind
+    fi
+  fi
+  FM_CAPACITY_PREF_SSH=${pin_pref_ssh:-$cfg_pref_ssh}
+  FM_CAPACITY_PREF_KIND=${pin_pref_kind:-${cfg_pref_kind:-gpu}}
+  FM_CAPACITY_FALL_SSH=${pin_fall_ssh:-$cfg_fall_ssh}
+  FM_CAPACITY_FALL_KIND=${pin_fall_kind:-${cfg_fall_kind:-cpu}}
+  return 0
+}
+
+# How the last probe measured CPU headroom, as one auditable token for the
+# routing report: the run-queue average a host with /proc/loadavg gave, the
+# mean busy percent and sample count a host without one gave, or `unmeasured`
+# when neither arrived - which is also the reading that makes a host
+# unsuitable, so an operator can see WHY a preferred host was passed over.
+fm_capacity_cpu_headroom_reading() {
+  if [ -n "${FM_CAPACITY_PROBE_LOAD_PCT:-}" ]; then
+    printf 'busy_pct=%s/samples=%s\n' \
+      "$FM_CAPACITY_PROBE_LOAD_PCT" "${FM_CAPACITY_PROBE_LOAD_SAMPLES:-0}"
+    return 0
+  fi
+  if fm_capacity_is_number "${FM_CAPACITY_PROBE_LOAD1:-}"; then
+    printf 'load1=%s\n' "$FM_CAPACITY_PROBE_LOAD1"
+    return 0
+  fi
+  printf 'unmeasured\n'
+}
+
+# Fill FM_CAPACITY_ROUTE* from a freshly loaded host pair. Probes live.
+# shellcheck disable=SC2034
+fm_capacity_route_hosts() {
+  FM_CAPACITY_ROUTE=none
+  FM_CAPACITY_ROUTE_HOST=
+  FM_CAPACITY_ROUTE_REASON='no configured compute host was freshly reachable and suitable'
+  FM_CAPACITY_PREF_REACHABLE=no
+  FM_CAPACITY_PREF_SUITABLE=no
+  FM_CAPACITY_PREF_LOAD=unmeasured
+  FM_CAPACITY_FALL_REACHABLE=no
+  FM_CAPACITY_FALL_SUITABLE=no
+  FM_CAPACITY_FALL_LOAD=unmeasured
+  if [ -n "${FM_CAPACITY_PREF_SSH:-}" ]; then
+    if fm_capacity_probe_ssh "$FM_CAPACITY_PREF_SSH"; then
+      FM_CAPACITY_PREF_REACHABLE=yes
+      FM_CAPACITY_PREF_LOAD=$(fm_capacity_cpu_headroom_reading)
+      if fm_capacity_host_suitable "$FM_CAPACITY_PREF_KIND" \
+        "$FM_CAPACITY_PROBE_NPROC" "$FM_CAPACITY_PROBE_MEM_MB" \
+        "$FM_CAPACITY_PROBE_LOAD1" "$FM_CAPACITY_PROBE_GPU_FREE" \
+        "$FM_CAPACITY_PROBE_GPU_UTIL" "${FM_CAPACITY_PROBE_LOAD_PCT:-}"; then
+        FM_CAPACITY_PREF_SUITABLE=yes
+        FM_CAPACITY_ROUTE=preferred
+        FM_CAPACITY_ROUTE_HOST=$FM_CAPACITY_PREF_SSH
+        FM_CAPACITY_ROUTE_REASON='preferred host is reachable and suitable'
+        return 0
+      fi
+    fi
+  fi
+  if [ -n "${FM_CAPACITY_FALL_SSH:-}" ]; then
+    if fm_capacity_probe_ssh "$FM_CAPACITY_FALL_SSH"; then
+      FM_CAPACITY_FALL_REACHABLE=yes
+      FM_CAPACITY_FALL_LOAD=$(fm_capacity_cpu_headroom_reading)
+      if fm_capacity_host_suitable "$FM_CAPACITY_FALL_KIND" \
+        "$FM_CAPACITY_PROBE_NPROC" "$FM_CAPACITY_PROBE_MEM_MB" \
+        "$FM_CAPACITY_PROBE_LOAD1" "$FM_CAPACITY_PROBE_GPU_FREE" \
+        "$FM_CAPACITY_PROBE_GPU_UTIL" "${FM_CAPACITY_PROBE_LOAD_PCT:-}"; then
+        FM_CAPACITY_FALL_SUITABLE=yes
+        FM_CAPACITY_ROUTE=fallback
+        FM_CAPACITY_ROUTE_HOST=$FM_CAPACITY_FALL_SSH
+        FM_CAPACITY_ROUTE_REASON='preferred host was not usable; fallback is reachable and suitable'
+        return 0
+      fi
+    fi
+  fi
+  if [ -z "${FM_CAPACITY_PREF_SSH:-}" ] && [ -z "${FM_CAPACITY_FALL_SSH:-}" ]; then
+    FM_CAPACITY_ROUTE_REASON='no preferred or fallback compute host is configured'
+  fi
+  return 0
+}
+
+# Snapshot local measurements plus occupied/free into FM_CAPACITY_* vars.
+# Occupancy is host-scoped: <home-dir> anchors the local-home set and defaults
+# to FM_HOME.
+fm_capacity_measure_local() { # <state-dir> [home-dir]
+  FM_CAPACITY_LOCAL_NPROC=$(fm_capacity_read_nproc)
+  FM_CAPACITY_LOCAL_MEM_MB=$(fm_capacity_read_mem_avail_mb)
+  FM_CAPACITY_LOCAL_LOAD1=$(fm_capacity_read_load1)
+  fm_capacity_is_uint "$FM_CAPACITY_LOCAL_NPROC" || FM_CAPACITY_LOCAL_NPROC=1
+  # A missing or non-numeric load is left as-is. slots_from_local then yields 0
+  # rather than treating the failed query as idle (load1=0).
+  FM_CAPACITY_SLOTS=$(fm_capacity_slots_from_local \
+    "$FM_CAPACITY_LOCAL_NPROC" "$FM_CAPACITY_LOCAL_MEM_MB" "$FM_CAPACITY_LOCAL_LOAD1")
+  fm_capacity_measure_host_occupancy "$1" "${2:-${FM_HOME:-}}"
+  FM_CAPACITY_FREE=$((FM_CAPACITY_SLOTS - FM_CAPACITY_OCCUPIED))
+  [ "$FM_CAPACITY_FREE" -ge 0 ] || FM_CAPACITY_FREE=0
+}
+
+# Allow a fresh independent worker. Relaunch and secondmate skip the slot
+# budget. Never interrupts another task. Prints nothing on allow; one error
+# line on refuse.
+fm_capacity_allow_new_worker() { # <state-dir> <task-id> <kind> <relaunch> [home-dir]
+  local state=$1 id=$2 kind=$3 relaunch=$4 home=${5:-${FM_HOME:-}}
+  [ "$relaunch" != 1 ] || return 0
+  [ "$kind" != secondmate ] || return 0
+  # Identity first: it is a pure metadata read and its refusal quotes no
+  # measured value, so an id collision never pays for a host-wide occupancy
+  # scan (one backend agent-state probe per record across every local home).
+  if fm_capacity_task_occupies_slot "$state" "$id"; then
+    if fm_capacity_id_is_worker_record "$state" "$id"; then
+      printf 'error: capacity: task %s already has a worker; sequential replacement uses relaunch, never a second concurrent worker\n' "$id" >&2
+    else
+      printf 'error: capacity: id %s already has a %s record in this home; a fresh worker must not reuse it and overwrite that record\n' \
+        "$id" "$(fm_capacity_record_kind "$state" "$id")" >&2
+    fi
+    return 1
+  fi
+  fm_capacity_measure_local "$state" "$home"
+  if [ "$FM_CAPACITY_FREE" -ge 1 ]; then
+    return 0
+  fi
+  if [ "$FM_CAPACITY_SLOTS" -eq 0 ]; then
+    printf 'error: capacity: supervisor host is at measured capacity (slots=0 occupied=%s homes_scanned=%s nproc=%s load1=%s mem_avail_mb=%s); refusing a new independent worker rather than overloading this host\n' \
+      "$FM_CAPACITY_OCCUPIED" "$FM_CAPACITY_HOMES_SCANNED" "$FM_CAPACITY_LOCAL_NPROC" "${FM_CAPACITY_LOCAL_LOAD1:-unknown}" "${FM_CAPACITY_LOCAL_MEM_MB:-unknown}" >&2
+    return 1
+  fi
+  printf 'error: capacity: no free worker slot (occupied=%s slots=%s homes_scanned=%s); independent work waits until a live worker on this host finishes; running workers were left running\n' \
+    "$FM_CAPACITY_OCCUPIED" "$FM_CAPACITY_SLOTS" "$FM_CAPACITY_HOMES_SCANNED" >&2
+  return 1
+}

--- a/bin/fm-capacity.sh
+++ b/bin/fm-capacity.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Fresh compute-capacity probe, worker-slot budget, and host routing.
+# Usage:
+#   fm-capacity.sh probe
+#   fm-capacity.sh slots
+#   fm-capacity.sh route
+#   fm-capacity.sh spawn-gate [--task-id <id>]
+#
+# `probe` prints one fresh local measurement plus configured preferred/fallback
+# reachability, suitability, the CPU-headroom reading each probe returned,
+# derived slots, the live occupied count across the local firstmate homes on
+# this host, free count, and the host-bound routing verdict. `slots` prints only the local slot budget, including homes_scanned so
+# the host-scoped occupancy is auditable. `route` prints only the host-bound
+# routing verdict. `spawn-gate` exits 0 when a new independent ship/scout worker
+# may start, and 1 when it must wait; it never interrupts a running worker.
+# --task-id refuses when that id already occupies a slot, and probe, slots, and
+# route reject the flag rather than ignoring it.
+#
+# Optional session pins: --preferred <ssh> --fallback <ssh>
+# [--preferred-kind gpu|cpu] [--fallback-kind gpu|cpu]. Each pin overrides only
+# its own field of config/compute-hosts.json for this invocation, so pinning the
+# preferred host keeps the configured fallback, and an unknown kind is rejected
+# rather than coerced. The script header of bin/fm-capacity-lib.sh owns the
+# formula. This command does not choose a harness or model.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+
+# shellcheck source=bin/fm-capacity-lib.sh
+. "$SCRIPT_DIR/fm-capacity-lib.sh"
+
+usage() {
+  sed -n '2,24{s/^# \{0,1\}//;p;}' "$0"
+}
+
+die() {
+  printf 'error: capacity: %s\n' "$1" >&2
+  exit 1
+}
+
+CMD=
+TASK_ID=
+TASK_ID_GIVEN=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    probe | slots | route | spawn-gate)
+      [ -z "$CMD" ] || die "one command only"
+      CMD=$1
+      shift
+      ;;
+    --task-id)
+      [ "$#" -ge 2 ] || die "--task-id requires a value"
+      TASK_ID=$2
+      TASK_ID_GIVEN=1
+      shift 2
+      ;;
+    --task-id=*)
+      TASK_ID=${1#--task-id=}
+      TASK_ID_GIVEN=1
+      shift
+      ;;
+    --preferred)
+      [ "$#" -ge 2 ] || die "--preferred requires a value"
+      FM_CAPACITY_PREFERRED_SSH=$2
+      shift 2
+      ;;
+    --preferred=*)
+      FM_CAPACITY_PREFERRED_SSH=${1#--preferred=}
+      shift
+      ;;
+    --fallback)
+      [ "$#" -ge 2 ] || die "--fallback requires a value"
+      FM_CAPACITY_FALLBACK_SSH=$2
+      shift 2
+      ;;
+    --fallback=*)
+      FM_CAPACITY_FALLBACK_SSH=${1#--fallback=}
+      shift
+      ;;
+    --preferred-kind)
+      [ "$#" -ge 2 ] || die "--preferred-kind requires a value"
+      FM_CAPACITY_PREFERRED_KIND=$2
+      shift 2
+      ;;
+    --preferred-kind=*)
+      FM_CAPACITY_PREFERRED_KIND=${1#--preferred-kind=}
+      shift
+      ;;
+    --fallback-kind)
+      [ "$#" -ge 2 ] || die "--fallback-kind requires a value"
+      FM_CAPACITY_FALLBACK_KIND=$2
+      shift 2
+      ;;
+    --fallback-kind=*)
+      FM_CAPACITY_FALLBACK_KIND=${1#--fallback-kind=}
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+[ -n "$CMD" ] || { usage >&2; exit 2; }
+if [ "$TASK_ID_GIVEN" = 1 ] && [ "$CMD" != spawn-gate ]; then
+  die "--task-id applies only to spawn-gate"
+fi
+
+load_hosts_or_die() {
+  fm_capacity_load_hosts "$CONFIG" || die "${FM_CAPACITY_CONFIG_ERROR:-invalid compute-hosts config}"
+}
+
+print_slots() {
+  fm_capacity_measure_local "$STATE" "$FM_HOME"
+  printf 'slots=%s\n' "$FM_CAPACITY_SLOTS"
+  printf 'occupied=%s\n' "$FM_CAPACITY_OCCUPIED"
+  printf 'free=%s\n' "$FM_CAPACITY_FREE"
+  printf 'homes_scanned=%s\n' "$FM_CAPACITY_HOMES_SCANNED"
+  printf 'nproc=%s\n' "$FM_CAPACITY_LOCAL_NPROC"
+  printf 'mem_avail_mb=%s\n' "${FM_CAPACITY_LOCAL_MEM_MB:-unknown}"
+  printf 'load1=%s\n' "${FM_CAPACITY_LOCAL_LOAD1:-unknown}"
+}
+
+print_route() {
+  load_hosts_or_die
+  fm_capacity_route_hosts
+  printf 'route=%s\n' "$FM_CAPACITY_ROUTE"
+  printf 'route_host=%s\n' "$FM_CAPACITY_ROUTE_HOST"
+  printf 'route_reason=%s\n' "$FM_CAPACITY_ROUTE_REASON"
+  printf 'preferred_ssh=%s\n' "${FM_CAPACITY_PREF_SSH:-}"
+  printf 'preferred_reachable=%s\n' "$FM_CAPACITY_PREF_REACHABLE"
+  printf 'preferred_suitable=%s\n' "$FM_CAPACITY_PREF_SUITABLE"
+  printf 'preferred_cpu=%s\n' "$FM_CAPACITY_PREF_LOAD"
+  printf 'fallback_ssh=%s\n' "${FM_CAPACITY_FALL_SSH:-}"
+  printf 'fallback_reachable=%s\n' "$FM_CAPACITY_FALL_REACHABLE"
+  printf 'fallback_suitable=%s\n' "$FM_CAPACITY_FALL_SUITABLE"
+  printf 'fallback_cpu=%s\n' "$FM_CAPACITY_FALL_LOAD"
+}
+
+print_probe() {
+  printf 'generated=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  print_slots
+  print_route
+}
+
+case "$CMD" in
+  probe) print_probe ;;
+  slots) print_slots ;;
+  route) print_route ;;
+  spawn-gate)
+    fm_capacity_allow_new_worker "$STATE" "${TASK_ID:-}" ship 0 "$FM_HOME"
+    ;;
+esac

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -113,6 +113,63 @@ last_status_line() {
   grep -v '^[[:space:]]*$' "$f" 2>/dev/null | tail -1
 }
 
+# 0 if a status line carries a ship self-test report (Tests N/0).
+status_has_self_test_report() {  # <status-line>
+  local line=$1
+  [ -n "$line" ] || return 1
+  printf '%s\n' "$line" | grep -Eq '[Tt]ests[[:space:]]+[0-9]+/[0-9]+'
+}
+
+# 0 if the status log documents a self-test report on or before its terminal done:.
+status_log_self_test_reported_before_done() {  # <status-file>
+  local f=$1 line
+  [ -e "$f" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=${line//$'\r'/}
+    [ -z "${line//[[:space:]]/}" ] && continue
+    status_has_self_test_report "$line" && return 0
+    if status_is_terminal_verb "$line" && [ "$(status_line_verb "$line")" = done ]; then
+      return 1
+    fi
+  done < "$f"
+  return 1
+}
+
+# Parse Tests N/M from one status line into STATUS_TEST_PASSED and
+# STATUS_TEST_FAILED. Returns 0 when a count pair is present.
+status_parse_self_test_counts() {  # <status-line>
+  local line=$1
+  STATUS_TEST_PASSED=
+  STATUS_TEST_FAILED=
+  [ -n "$line" ] || return 1
+  if ! printf '%s\n' "$line" | grep -Eq '[Tt]ests[[:space:]]+[0-9]+/[0-9]+'; then
+    return 1
+  fi
+  STATUS_TEST_PASSED=$(printf '%s\n' "$line" | sed -n 's/.*[Tt]ests[[:space:]]\+\([0-9]\+\)\/\([0-9]\+\).*/\1/p' | head -1)
+  STATUS_TEST_FAILED=$(printf '%s\n' "$line" | sed -n 's/.*[Tt]ests[[:space:]]\+\([0-9]\+\)\/\([0-9]\+\).*/\2/p' | head -1)
+  case "$STATUS_TEST_PASSED" in ''|*[!0-9]*) return 1 ;; esac
+  case "$STATUS_TEST_FAILED" in ''|*[!0-9]*) return 1 ;; esac
+  return 0
+}
+
+# 0 when the status log documents Tests N/0 on or before its terminal done:.
+status_log_self_test_clean_before_done() {  # <status-file>
+  local f=$1 line
+  [ -e "$f" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=${line//$'\r'/}
+    [ -z "${line//[[:space:]]/}" ] && continue
+    if status_parse_self_test_counts "$line"; then
+      [ "$STATUS_TEST_FAILED" -eq 0 ] && return 0
+      return 1
+    fi
+    if status_is_terminal_verb "$line" && [ "$(status_line_verb "$line")" = done ]; then
+      return 1
+    fi
+  done < "$f"
+  return 1
+}
+
 # 0 if the given (last) status line's leading verb is a real terminal captain verb
 # (done, needs-decision, blocked, failed). Free-text tokens alone never count here;
 # callers that need legacy free-text matching use status_is_captain_relevant.

--- a/bin/fm-land-lib.sh
+++ b/bin/fm-land-lib.sh
@@ -1,0 +1,50 @@
+# shellcheck shell=bash
+# fm-land-lib.sh - shared landing guards for local-only and PR merge paths.
+#
+# Source this file. bin/fm-merge-local.sh and bin/fm-pr-merge.sh consult it
+# before landing work onto a project's default branch. docs/configuration.md
+# "Landing behind-main guard" owns the threshold override.
+#
+# A branch is "behind" the default by the number of commits reachable from the
+# default tip that are not reachable from the branch tip (default..branch in
+# rev-list terms is ahead; branch..default is behind).
+
+FM_LAND_MAX_BEHIND_MAIN_DEFAULT=20
+
+fm_land_max_behind_main() {
+  local max=${FM_LAND_MAX_BEHIND_MAIN:-$FM_LAND_MAX_BEHIND_MAIN_DEFAULT}
+  case "$max" in ''|*[!0-9]*) max=$FM_LAND_MAX_BEHIND_MAIN_DEFAULT ;; esac
+  printf '%s' "$max"
+}
+
+# Echo how many commits on <default> are not reachable from <branch> in <repo>.
+# Returns non-zero when the count cannot be determined.
+fm_land_commits_behind_default() {  # <repo> <branch> <default>
+  local repo=$1 branch=$2 default=$3 count
+  count=$(git -C "$repo" rev-list --count "$branch..$default" 2>/dev/null) || return 1
+  case "$count" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s' "$count"
+}
+
+# 0 when <branch> in <repo> is at or beyond the configured behind-main ceiling.
+fm_land_branch_too_far_behind_default() {  # <repo> <branch> <default>
+  local repo=$1 branch=$2 default=$3 behind max
+  behind=$(fm_land_commits_behind_default "$repo" "$branch" "$default") || return 1
+  max=$(fm_land_max_behind_main)
+  [ "$behind" -ge "$max" ]
+}
+
+# Refuse landing when too far behind; prints a REFUSED line to stderr and returns 1.
+fm_land_refuse_if_too_far_behind_default() {  # <repo> <branch> <default> [<label>]
+  local repo=$1 branch=$2 default=$3 label=${4:-$branch} behind max
+  behind=$(fm_land_commits_behind_default "$repo" "$branch" "$default") || {
+    echo "REFUSED: could not measure how far $label is behind $default" >&2
+    return 1
+  }
+  max=$(fm_land_max_behind_main)
+  if [ "$behind" -ge "$max" ]; then
+    echo "REFUSED: $label is $behind commits behind $default (>= $max); not landing to main; keep the branch and rebase later." >&2
+    return 1
+  fi
+  return 0
+}

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -31,6 +31,20 @@ PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ "$MODE" = local-only ] || { echo "error: task $ID is mode=$MODE, not local-only; merge PR tasks with bin/fm-pr-merge.sh <id> <PR url> after approval" >&2; exit 1; }
 
+# shellcheck source=bin/fm-classify-lib.sh
+. "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-land-lib.sh
+. "$SCRIPT_DIR/fm-land-lib.sh"
+STATUS_FILE="$STATE/$ID.status"
+if ! status_log_self_test_clean_before_done "$STATUS_FILE"; then
+  if status_log_self_test_reported_before_done "$STATUS_FILE"; then
+    echo "REFUSED: task $ID status reports test failures (expected Tests N/0 before terminal done:)" >&2
+  else
+    echo "REFUSED: task $ID status lacks a self-test report (expected Tests N/0 before terminal done:)" >&2
+  fi
+  exit 1
+fi
+
 default_branch() {
   local ref branch
   ref=$(git -C "$PROJ" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
@@ -67,6 +81,15 @@ if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$BRANCH"; then
   echo "Have the crewmate rebase $BRANCH onto $DEFAULT, then retry." >&2
   exit 1
 fi
+
+AHEAD=$(git -C "$PROJ" rev-list --count "$DEFAULT..$BRANCH" 2>/dev/null || echo 0)
+case "$AHEAD" in ''|*[!0-9]*) AHEAD=0 ;; esac
+if [ "$AHEAD" -eq 0 ]; then
+  echo "REFUSED: task $ID branch $BRANCH has no commits ahead of $DEFAULT (0 commits ahead = failed)" >&2
+  exit 1
+fi
+
+fm_land_refuse_if_too_far_behind_default "$PROJ" "$BRANCH" "$DEFAULT" "$BRANCH" || exit 1
 
 before=$(git -C "$PROJ" rev-parse --short "$DEFAULT")
 git -C "$PROJ" merge --ff-only "$BRANCH" >/dev/null

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -75,6 +75,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-merge-outcome-lib.sh
 . "$SCRIPT_DIR/fm-merge-outcome-lib.sh"
+# shellcheck source=bin/fm-land-lib.sh
+. "$SCRIPT_DIR/fm-land-lib.sh"
 # Role partition: merging is MAIN-owned; the Pi supervision branch reports the
 # green PR and never merges (contract: bin/fm-lease-lib.sh; no-op in homes
 # without a branch actor).
@@ -623,10 +625,51 @@ gitlab_confirm_merged() {
   [ "$state" = merged ]
 }
 
+fm_pr_merge_refuse_if_too_far_behind() {
+  local behind max json
+  max=$(fm_land_max_behind_main)
+  case "$PROVIDER" in
+    github)
+      if ! behind=$(gh-axi pr view "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" \
+        --json behindBy -q .behindBy 2>/dev/null); then
+        echo "REFUSED: could not read how far $URL is behind its base branch" >&2
+        return 1
+      fi
+      ;;
+    gitlab)
+      if ! json=$(GITLAB_HOST="$FM_PR_HOST" glab mr view "$PR_NUMBER" \
+        -R "$PROJECT_URL" -F json 2>/dev/null) || [ -z "$json" ]; then
+        echo "REFUSED: could not read how far $URL is behind its target branch" >&2
+        return 1
+      fi
+      if ! behind=$(printf '%s' "$json" | jq -r '
+          if type == "object" and (.diverged_commits_count | type == "number") then
+            (.diverged_commits_count | floor | tostring)
+          else
+            error("missing diverged_commits_count")
+          end' 2>/dev/null); then
+        echo "REFUSED: could not read how far $URL is behind its target branch" >&2
+        return 1
+      fi
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+  case "$behind" in ''|*[!0-9]*) behind=0 ;; esac
+  if [ "$behind" -ge "$max" ]; then
+    echo "REFUSED: $URL is $behind commits behind its base (>= $max); not merging to main; keep the branch and rebase later." >&2
+    return 1
+  fi
+  return 0
+}
+
 # Record before either forge call. This arms the merge poll without claiming a
 # landed outcome, so even a provider read failure after a real merge cannot
 # leave teardown without the PR identity it needs to verify the result.
 record_pr_metadata || exit 1
+
+fm_pr_merge_refuse_if_too_far_behind || exit 1
 
 case "$PROVIDER" in
   github)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -132,6 +132,17 @@
 #   provisioned firstmate home; the default is kind=ship.
 #   Before a secondmate launch, the home is locally fast-forwarded to the primary
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
+#   A fresh ship or scout spawn consults bin/fm-capacity-lib.sh and refuses when
+#   this host has no free measured worker slot, when this task id already has a
+#   LIVE worker, or when it belongs to a record that is not an independent
+#   worker - a live secondmate's above all - which a launch would overwrite.
+#   A ship or scout record whose worker is positively gone releases its id, so
+#   a task whose pane died is restartable through an ordinary fresh spawn.
+#   The gate never interrupts another task's running worker.
+#   Relaunch and --secondmate skip the slot budget: replacement is sequential,
+#   and a persistent secondmate is not an independent worker slot. Host-bound
+#   routing is a separate probe (bin/fm-capacity.sh route) and does not move
+#   the agent pane off this supervisor host.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
@@ -269,6 +280,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-trace-context-lib.sh"
 # shellcheck source=bin/fm-remote-readiness-lib.sh
 . "$SCRIPT_DIR/fm-remote-readiness-lib.sh"
+# shellcheck source=bin/fm-capacity-lib.sh
+. "$SCRIPT_DIR/fm-capacity-lib.sh"
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
 # a direct report (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent
@@ -645,7 +658,6 @@ spawn_remote_secondmate() {
   fm_lock_release "$remote_lock" || true
   fm_lock_release "$registry_lock" || true
   fm_lock_release "$SPAWN_TASK_LOCK" || true
-  "$SCRIPT_DIR/fm-home-summary-refresh.sh" --best-effort || true
   if ! "$SCRIPT_DIR/fm-procevent-remote-reply.sh" arm "$id" >/dev/null; then
     echo "error: remote secondmate $id launched, but its reply source could not be armed; endpoint metadata is preserved" >&2
     return 1
@@ -1700,6 +1712,13 @@ if [ "$KIND" = ship ]; then
      && [ "$(delivery_rigor_rank "$MODE")" -lt "$(delivery_rigor_rank "$STANDING_MODE")" ]; then
     echo "notice: $ID ships mode=$MODE while the standing posture for $PROJ_NAME is $STANDING_MODE - less rigor than the captain's standing posture; proceed only on a current explicit captain instruction or an intake judgment you can state" >&2
   fi
+fi
+
+# Resource-aware slot gate: measured local capacity, never a fixed agent count.
+# Relaunch is sequential replacement and is exempt; --secondmate is persistent
+# and is exempt. Refusing here leaves every other running worker untouched.
+if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
+  fm_capacity_allow_new_worker "$STATE" "$ID" "$KIND" 0 "$FM_HOME" || exit 1
 fi
 
 BRIEF_DIR_REAL=$(cd "$(dirname "$BRIEF")" && pwd -P)
@@ -2773,7 +2792,6 @@ if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
   SPAWN_TASK_SET_LOCK_HELD=0
   fm_lock_release "$SPAWN_TASK_SET_LOCK"
 fi
-"$SCRIPT_DIR/fm-home-summary-refresh.sh" --best-effort || true
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -158,6 +158,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-lock-lib.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-land-lib.sh
+. "$SCRIPT_DIR/fm-land-lib.sh"
 # shellcheck source=bin/fm-gate-refuse-lib.sh
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
@@ -1114,7 +1116,7 @@ backlog_refresh_reminder() {
         fi
         ;;
     esac
-    printf '%s\n' "Backlog: $ID just finished. Run $done_cmd, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due."
+    printf '%s\n' "Backlog: $ID just finished. Run $done_cmd, then bin/fm-work-loop.sh plan and spawn every listed item until free worker slots are full or the plan is empty."
   else
     printf '%s\n' "Backlog: $ID just finished. Update data/backlog.md - move $ID to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due."
   fi
@@ -1334,6 +1336,17 @@ teardown_treehouse_return() {
   return 1
 }
 
+# A ship that finished with clean Tests N/0 but is too far behind the default
+# branch is intentionally not landed; teardown may remove the pane while the
+# branch ref remains in git.
+worktree_kept_for_behind_main_deferral() {
+  local default
+  [ -d "$WT" ] || return 1
+  status_log_self_test_clean_before_done "$STATE/$ID.status" || return 1
+  default=$(default_branch) || return 1
+  fm_land_branch_too_far_behind_default "$WT" HEAD "$default"
+}
+
 validate_worktree_teardown_safety() {
   local dirty_raw dirty unpushed_raw unpushed DEFAULT unmerged_raw unmerged branch
   [ -d "$WT" ] || return 0
@@ -1374,6 +1387,9 @@ validate_worktree_teardown_safety() {
     fi
     unmerged=$(printf '%s\n' "$unmerged_raw" | head -5)
     if [ -n "$dirty" ] || [ -n "$unmerged" ]; then
+      if [ -z "$dirty" ] && worktree_kept_for_behind_main_deferral; then
+        return 0
+      fi
       echo "REFUSED: local-only worktree $WT has work not yet merged into $DEFAULT and not on any remote." >&2
       [ -n "$dirty" ] && echo "uncommitted changes present" >&2
       [ -n "$unmerged" ] && printf 'commits not yet on %s:\n%s\n' "$DEFAULT" "$unmerged" >&2
@@ -1392,6 +1408,9 @@ validate_worktree_teardown_safety() {
       TEARDOWN_WORKTREE_BRANCH_FOR_SAFETY=$branch
     fi
     if ! work_is_landed "$branch"; then
+      if worktree_kept_for_behind_main_deferral; then
+        return 0
+      fi
       echo "REFUSED: worktree $WT has work not on any remote and not landed." >&2
       printf 'unpushed commits:\n%s\n' "$unpushed" >&2
       echo "Push the branch, land its PR, or get the captain's explicit OK to discard, then --force." >&2

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -198,8 +198,12 @@ family_for_basename() {
     fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|\
     fm-bearings-board.test.sh|\
     fm-brief.test.sh|fm-vendor-auth-probe.test.sh|\
+    fm-capacity.test.sh|\
     fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
     fm-classify-decision-key.test.sh|\
+    fm-land-behind-main.test.sh|\
+    fm-ship-self-test-status.test.sh|\
+    fm-work-loop.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-captain-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
@@ -374,6 +378,7 @@ tests/fm-supervision-instructions.test.sh
 tests/fm-test-run.test.sh
 tests/fm-tmux-submit-busy.test.sh
 tests/fm-transition-lib.test.sh
+tests/fm-work-loop.test.sh
 tests/fm-x-mode.test.sh
 EOF
 }
@@ -588,6 +593,10 @@ tests/fm-sessionstart-nudge.test.sh 26684
 tests/fm-shared-captain-inheritance.test.sh 10672
 tests/fm-spawn-dispatch-profile.test.sh 57765
 tests/fm-spawn-pool-base-freshen.test.sh 13257
+tests/fm-capacity.test.sh 45000
+tests/fm-work-loop.test.sh 2300
+tests/fm-land-behind-main.test.sh 12000
+tests/fm-ship-self-test-status.test.sh 8000
 tests/fm-spawn-worktree-settle.test.sh 4828
 tests/fm-startup-memory-budget.test.sh 6550
 tests/fm-startup-network.test.sh 48888
@@ -1212,6 +1221,7 @@ families_for_changed_path() {
     bin/fm-captain-hold.sh|bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-vendor-auth-probe.sh|\
+    bin/fm-work-loop.sh|bin/fm-capacity-lib.sh|bin/fm-land-lib.sh|\
     bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
     bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)
       printf '%s\n' pure-contract-unit

--- a/bin/fm-work-loop.sh
+++ b/bin/fm-work-loop.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# Measure free worker slots and plan parallel backlog refill for section 7's work loop.
+# Usage:
+#   fm-work-loop.sh status
+#   fm-work-loop.sh plan [--backlog <path>] [--list <path>]
+#   fm-work-loop.sh supply [--backlog <path>] [--list <path>]
+#
+# `status` prints one machine-readable line:
+#   FM_WORK_LOOP slots=<n> occupied=<n> free=<n> real=<n> min_real=<n> shortfall=<n> homes_scanned=<n> [source=list]
+#
+# `real` counts only provably working workers: active run-step, or a busy pane
+# while the task has not declared terminal completion. Idle done-panes with a
+# live endpoint and Herdr cards that lag behind done: do not count. `shortfall`
+# is how many more real
+# workers the loop should try to launch before the host slot ceiling.
+#
+# `plan` prints up to the plan limit dispatchable task ids, one per line, skipping
+# ids that already occupy a live worker slot. Below min_real it tops up toward the
+# floor; once the floor is met it fills every measured free slot. Prints nothing
+# when the plan limit is 0.
+#
+# When gitignored `config/work-loop-list` (or `--list`) exists with at least one
+# task id, `plan` walks that fixed list in file order and offers only ids that are
+# still tasks-axi ready, so empty slots refill without manual resupply. Without a
+# non-empty list, `plan` falls back to the tasks-axi ready backlog ordering.
+#
+# When the ready queue is empty, a free worker slot remains, and a fixed list is
+# active, `plan` and `supply` immediately reopen the next done list id or add the
+# next missing id that carries a tab-separated `id<TAB>repo<TAB>title<TAB>kind`
+# row, so the loop does not idle waiting for manual backlog edits.
+#
+# Slot measurement is owned by bin/fm-capacity-lib.sh; this command never spawns.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+
+# shellcheck source=bin/fm-capacity-lib.sh
+. "$SCRIPT_DIR/fm-capacity-lib.sh"
+# shellcheck source=bin/fm-tasks-axi-lib.sh
+. "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+
+usage() {
+  sed -n '2,28{s/^# \{0,1\}//;p;}' "$0"
+}
+
+die() {
+  printf 'error: work-loop: %s\n' "$1" >&2
+  exit 1
+}
+
+CMD=
+BACKLOG="$DATA/backlog.md"
+LIST="$CONFIG/work-loop-list"
+WORK_LOOP_READY_IDS_CACHE=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    status | plan | supply)
+      [ -z "$CMD" ] || die "one command only"
+      CMD=$1
+      shift
+      ;;
+    --backlog)
+      [ "$#" -ge 2 ] || die "--backlog requires a path"
+      BACKLOG=$2
+      shift 2
+      ;;
+    --backlog=*)
+      BACKLOG=${1#--backlog=}
+      shift
+      ;;
+    --list)
+      [ "$#" -ge 2 ] || die "--list requires a path"
+      LIST=$2
+      shift 2
+      ;;
+    --list=*)
+      LIST=${1#--list=}
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+[ -n "$CMD" ] || {
+  usage >&2
+  exit 1
+}
+
+work_loop_measure() {
+  fm_capacity_measure_local "$STATE" "$FM_HOME"
+  fm_capacity_measure_host_real_workers "$STATE" "$FM_HOME"
+  FM_CAPACITY_SHORTFALL=$(fm_capacity_work_loop_shortfall "$FM_CAPACITY_REAL")
+  FM_CAPACITY_PLAN_LIMIT=$(fm_capacity_work_loop_plan_limit \
+    "$FM_CAPACITY_FREE" "$FM_CAPACITY_REAL")
+}
+
+work_loop_list_active() {
+  local list=$1 line trimmed
+  [ -f "$list" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    trimmed=${line%%#*}
+    trimmed=${trimmed#"${trimmed%%[![:space:]]*}"}
+    trimmed=${trimmed%"${trimmed##*[![:space:]]}"}
+    [ -n "$trimmed" ] && return 0
+  done < "$list"
+  return 1
+}
+
+work_loop_list_line_trimmed() {
+  local line=$1
+  line=${line%%#*}
+  line=${line#"${line%%[![:space:]]*}"}
+  line=${line%"${line##*[![:space:]]}"}
+  printf '%s' "$line"
+}
+
+work_loop_list_line_id() {
+  local trimmed=${1:-}
+  trimmed=$(work_loop_list_line_trimmed "$trimmed")
+  trimmed=${trimmed%%[[:space:]$'\t']*}
+  printf '%s' "$trimmed"
+}
+
+# Parse one list row. Id-only rows leave repo/title/kind empty.
+work_loop_list_parse_spec() {
+  local line=$1 trimmed id repo title kind
+  WORK_LOOP_SPEC_ID=
+  WORK_LOOP_SPEC_REPO=
+  WORK_LOOP_SPEC_TITLE=
+  WORK_LOOP_SPEC_KIND=
+  trimmed=$(work_loop_list_line_trimmed "$line")
+  [ -n "$trimmed" ] || return 1
+  IFS=$'\t' read -r id repo title kind _rest <<< "$trimmed"
+  if [ -z "$repo" ] || [ -z "$title" ] || [ -z "$kind" ]; then
+    WORK_LOOP_SPEC_ID=$(work_loop_list_line_id "$trimmed")
+    return 0
+  fi
+  WORK_LOOP_SPEC_ID=$id
+  WORK_LOOP_SPEC_REPO=$repo
+  WORK_LOOP_SPEC_TITLE=$title
+  WORK_LOOP_SPEC_KIND=$kind
+  return 0
+}
+
+# Emit task ids from a fixed list file: one per line, # comments, blanks skipped.
+work_loop_fixed_list_ids() {
+  local list=$1 line id
+  [ -f "$list" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    id=$(work_loop_list_line_id "$line")
+    [ -n "$id" ] || continue
+    printf '%s\n' "$id"
+  done < "$list"
+}
+
+work_loop_print_status() {
+  local source=
+  work_loop_measure
+  work_loop_list_active "$LIST" && source=' source=list'
+  printf 'FM_WORK_LOOP slots=%s occupied=%s free=%s real=%s min_real=%s shortfall=%s homes_scanned=%s%s\n' \
+    "$FM_CAPACITY_SLOTS" "$FM_CAPACITY_OCCUPIED" "$FM_CAPACITY_FREE" \
+    "$FM_CAPACITY_REAL" "$FM_WORK_LOOP_MIN_REAL" "$FM_CAPACITY_SHORTFALL" \
+    "$FM_CAPACITY_HOMES_SCANNED" "$source"
+}
+
+# Print one task id per line from a tasks-axi ready listing.
+work_loop_emit_ready_ids() {
+  local ready=$1
+  printf '%s\n' "$ready" | awk '
+    /^help\[/ { exit }
+    /^ready\[/ { rows = 1; next }
+    rows && /^[[:space:]]/ {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      split(line, a, ",")
+      if (a[1] != "") print a[1]
+      next
+    }
+    { rows = 0 }
+  '
+}
+
+work_loop_ready_ids() {
+  local ready err
+  [ -f "$BACKLOG" ] || return 0
+  if ! fm_tasks_axi_backend_available "$CONFIG"; then
+    die "tasks-axi backlog backend is required for plan; got $(fm_backlog_backend_value "$CONFIG")"
+  fi
+  if ! ready=$(tasks-axi ready --file "$BACKLOG" 2>&1); then
+    die "tasks-axi ready failed: $ready"
+  fi
+  work_loop_emit_ready_ids "$ready"
+}
+
+work_loop_ready_ids_cached() {
+  if [ -z "$WORK_LOOP_READY_IDS_CACHE" ]; then
+    WORK_LOOP_READY_IDS_CACHE=$(work_loop_ready_ids)
+  fi
+  printf '%s\n' "$WORK_LOOP_READY_IDS_CACHE"
+}
+
+work_loop_id_is_ready() {
+  local id=$1 rid
+  while IFS= read -r rid; do
+    [ "$rid" = "$id" ] && return 0
+  done < <(work_loop_ready_ids_cached)
+  return 1
+}
+
+work_loop_ready_queue_empty() {
+  local head
+  head=$(work_loop_ready_ids_cached | sed -n '/./{p;q;}')
+  [ -z "$head" ]
+}
+
+work_loop_task_backlog_state() {
+  local id=$1 state
+  [ -f "$BACKLOG" ] || {
+    printf '%s' 'missing'
+    return 0
+  }
+  state=$(tasks-axi show "$id" --file "$BACKLOG" 2>/dev/null | awk '/^  state:/{print $2; exit}')
+  if [ -z "$state" ]; then
+    printf '%s' 'missing'
+    return 0
+  fi
+  printf '%s' "$state"
+}
+
+work_loop_invalidate_ready_cache() {
+  WORK_LOOP_READY_IDS_CACHE=
+}
+
+# Re-queue one known list item when the ready queue is empty.
+work_loop_supply_one() {
+  local line id state
+  work_loop_list_active "$LIST" || return 1
+  work_loop_ready_queue_empty || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    work_loop_list_parse_spec "$line" || continue
+    id=$WORK_LOOP_SPEC_ID
+    [ -n "$id" ] || continue
+    fm_capacity_task_occupies_slot "$STATE" "$id" && continue
+    state=$(work_loop_task_backlog_state "$id")
+    case "$state" in
+      missing)
+        [ -n "$WORK_LOOP_SPEC_REPO" ] && [ -n "$WORK_LOOP_SPEC_TITLE" ] && [ -n "$WORK_LOOP_SPEC_KIND" ] || continue
+        tasks-axi add "$id" "$WORK_LOOP_SPEC_TITLE" --repo "$WORK_LOOP_SPEC_REPO" \
+          --kind "$WORK_LOOP_SPEC_KIND" --file "$BACKLOG" >/dev/null \
+          || die "tasks-axi add failed for $id"
+        work_loop_invalidate_ready_cache
+        printf '%s\n' "$id"
+        return 0
+        ;;
+      done)
+        tasks-axi reopen "$id" --file "$BACKLOG" >/dev/null \
+          || die "tasks-axi reopen failed for $id"
+        work_loop_invalidate_ready_cache
+        printf '%s\n' "$id"
+        return 0
+        ;;
+    esac
+  done < "$LIST"
+  return 1
+}
+
+work_loop_ensure_ready_supply() {
+  work_loop_list_active "$LIST" || return 0
+  work_loop_ready_queue_empty || return 0
+  work_loop_supply_one >/dev/null || true
+}
+
+work_loop_plan_candidate_ids() {
+  local id
+  if work_loop_list_active "$LIST"; then
+    while IFS= read -r id; do
+      [ -n "$id" ] || continue
+      work_loop_id_is_ready "$id" || continue
+      printf '%s\n' "$id"
+    done < <(work_loop_fixed_list_ids "$LIST")
+    return 0
+  fi
+  work_loop_ready_ids
+}
+
+work_loop_print_plan() {
+  local free=$1 id n=0
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    fm_capacity_task_occupies_slot "$STATE" "$id" && continue
+    printf '%s\n' "$id"
+    n=$((n + 1))
+    [ "$n" -lt "$free" ] || return 0
+  done < <(work_loop_plan_candidate_ids)
+}
+
+case "$CMD" in
+  status)
+    work_loop_print_status
+    ;;
+  plan)
+    work_loop_measure
+    [ "$FM_CAPACITY_PLAN_LIMIT" -gt 0 ] || exit 0
+    work_loop_ensure_ready_supply
+    work_loop_print_plan "$FM_CAPACITY_PLAN_LIMIT"
+    ;;
+  supply)
+    work_loop_measure
+    [ "$FM_CAPACITY_PLAN_LIMIT" -gt 0 ] || exit 0
+    id=$(work_loop_supply_one) || exit 0
+    printf 'FM_WORK_LOOP supplied=%s\n' "$id"
+    ;;
+esac

--- a/docs/examples/work-loop-list
+++ b/docs/examples/work-loop-list
@@ -1,0 +1,8 @@
+# Fixed Bauleitung dispatch order for bin/fm-work-loop.sh plan.
+# One task id per line. Blank lines and # comments are ignored.
+# Copy to gitignored config/work-loop-list when this home should refill empty
+# worker slots from a predetermined sequence instead of tasks-axi ready order.
+#
+# example-task-alpha
+# example-task-beta
+# example-task-gamma	demo	Example gamma task	ship

--- a/tests/fm-capacity.test.sh
+++ b/tests/fm-capacity.test.sh
@@ -1,0 +1,1124 @@
+#!/usr/bin/env bash
+# Behavior tests for resource-aware parallel dispatch: slot formula, live
+# host-scoped occupancy, same-task uniqueness, refuse-rather-than-kill spawn
+# gating, and preferred-then-fallback host routing from fresh probes.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=bin/fm-capacity-lib.sh
+. "$ROOT/bin/fm-capacity-lib.sh"
+
+SCRIPT="$ROOT/bin/fm-capacity.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-capacity)
+
+setup_home() {
+  local dir=$1
+  mkdir -p "$dir/state" "$dir/config" "$dir/data" "$dir/projects/demo"
+}
+
+run_capacity() {
+  local home=$1
+  shift
+  FM_HOME="$home" FM_ROOT_OVERRIDE="" \
+    FM_STATE_OVERRIDE="" FM_CONFIG_OVERRIDE="" \
+    "$SCRIPT" "$@"
+}
+
+write_ship_meta() {
+  local home=$1 id=$2
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "endpoint_task_id=$id" \
+    "kind=ship" \
+    "harness=echo"
+}
+
+# A ship record on a backend that has no recovery classifier (zellij, orca and
+# cmux always report `unverified`), which is exactly where endpoint liveness
+# can never be proven negative.
+write_unverified_ship_meta() {
+  local home=$1 id=$2 backend=${3:-zellij}
+  fm_write_meta "$home/state/$id.meta" \
+    "window=fm-$id" \
+    "endpoint_task_id=$id" \
+    "kind=ship" \
+    "backend=$backend" \
+    "harness=echo"
+}
+
+# Append one line to a task's append-only status log.
+write_status() {
+  local home=$1 id=$2 line=$3
+  printf '%s\n' "$line" >> "$home/state/$id.status"
+}
+
+# A tmux stand-in whose session window list is the fixture: a task whose window
+# is listed has a live agent pane, a task whose window is absent is an
+# authoritatively gone endpoint. That is exactly the distinction the capacity
+# budget must draw between a running worker and a parked record.
+make_fake_tmux() {
+  local fakebin=$1
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ -z "${FM_CAPACITY_PROBE_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_CAPACITY_PROBE_LOG"
+cmd=${1:-}
+shift || true
+session=; fmt=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -p) shift ;;
+    -t) session=${2%%:*}; shift 2 ;;
+    -F) shift 2 ;;
+    *) fmt=$1; shift ;;
+  esac
+done
+dir=${FM_FAKE_TMUX_DIR:-}
+case "$cmd" in
+  list-windows)
+    if [ -n "$dir" ] && [ -f "$dir/$session" ]; then
+      cat "$dir/$session"
+      exit 0
+    fi
+    printf "can't find session: %s\n" "$session" >&2
+    exit 1
+    ;;
+  display-message)
+    [ "$fmt" = '#{pane_current_command}' ] && printf 'claude\n'
+    exit 0
+    ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/tmux"
+}
+
+# Declare which task windows are live in the fake tmux session for <home>.
+set_live_windows() {
+  local home=$1
+  shift
+  local id
+  mkdir -p "$home/tmux"
+  : > "$home/tmux/firstmate"
+  for id in "$@"; do
+    printf 'fm-%s\n' "$id" >> "$home/tmux/firstmate"
+  done
+}
+
+# Run <home>'s capacity CLI with the fake tmux answering endpoint liveness.
+run_capacity_live() {
+  local home=$1
+  shift
+  local fakebin
+  fakebin=$(fm_fakebin "$home")
+  make_fake_tmux "$fakebin"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_DIR="$home/tmux" \
+    run_capacity "$home" "$@"
+}
+
+make_fake_ssh() {
+  local fakebin=$1
+  cat > "$fakebin/ssh" <<'SH'
+#!/usr/bin/env bash
+set -u
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) shift 2 ;;
+    -*) shift ;;
+    *) break ;;
+  esac
+done
+host=${1:-}
+shift || true
+dir=${FM_FAKE_SSH_DIR:-}
+if [ -n "$dir" ] && [ -f "$dir/$host" ]; then
+  cat "$dir/$host"
+  exit 0
+fi
+exit 255
+SH
+  chmod +x "$fakebin/ssh"
+}
+
+test_slots_allow_five_on_healthy_supervisor() {
+  local got
+  got=$(fm_capacity_slots_from_local 16 24576 0.4)
+  [ "$got" = 5 ] || fail "healthy 16-CPU/24GiB host should yield 5 slots, got $got"
+  pass "healthy supervisor measurements yield five worker slots"
+}
+
+test_slots_drop_to_zero_when_load_saturates() {
+  local got
+  got=$(fm_capacity_slots_from_local 16 24576 16)
+  [ "$got" = 0 ] || fail "load1==nproc should yield 0 slots, got $got"
+  pass "saturated load yields zero new slots"
+}
+
+test_slots_drop_when_ram_is_tight() {
+  local got
+  got=$(fm_capacity_slots_from_local 16 4096 0.4)
+  [ "$got" = 0 ] || fail "mem at the reserve floor should yield 0 slots, got $got"
+  got=$(fm_capacity_slots_from_local 16 7168 0.4)
+  [ "$got" = 1 ] || fail "one RAM slot of headroom should yield 1, got $got"
+  pass "RAM axis cuts slots without a hardcoded agent count"
+}
+
+test_slots_small_host_keeps_one_when_healthy() {
+  local got
+  got=$(fm_capacity_slots_from_local 2 24576 0.2)
+  [ "$got" = 1 ] || fail "healthy 2-CPU host should keep 1 slot, got $got"
+  pass "small healthy hosts keep a single slot rather than a rigid zero"
+}
+
+test_slots_high_but_not_full_load_caps_at_one() {
+  local got
+  got=$(fm_capacity_slots_from_local 16 24576 11.2)
+  [ "$got" = 1 ] || fail "70 percent load should cap at 1 slot, got $got"
+  pass "elevated load caps new parallelism at one"
+}
+
+test_occupied_counts_ship_and_scout_not_secondmates() {
+  local home n
+  home="$TMP_ROOT/occupied"
+  setup_home "$home"
+  write_ship_meta "$home" ship-a1
+  write_ship_meta "$home" ship-b2
+  fm_write_meta "$home/state/scout-c3.meta" kind=scout window=firstmate:fm-scout-c3
+  fm_write_secondmate_meta "$home/state/jarvis.meta" "$home/jarvis-home"
+  set_live_windows "$home" ship-a1 ship-b2 scout-c3 jarvis
+  n=$(run_capacity_live "$home" slots | sed -n 's/^occupied=//p')
+  [ "$n" = 3 ] || fail "occupied should count 2 ship + 1 scout, not the secondmate; got $n"
+  pass "occupied slots are live ship and scout workers, not idle secondmates"
+}
+
+test_parked_task_without_a_live_worker_frees_its_slot() {
+  local home out rc i
+  home="$TMP_ROOT/parked"
+  setup_home "$home"
+  for i in 1 2 3 4 5; do
+    write_ship_meta "$home" "occ-$i"
+  done
+  # occ-1 and occ-2 still run; the other three are parked records whose panes
+  # are gone (captain hold, merge wait, exited pane).
+  set_live_windows "$home" occ-1 occ-2
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+      run_capacity_live "$home" slots
+  )
+  assert_contains "$out" "occupied=2" "only live workers hold slots"
+  assert_contains "$out" "free=3" "parked records must not consume the budget"
+  set +e
+  FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    run_capacity_live "$home" spawn-gate --task-id fresh-x7 >/dev/null 2>&1
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "spawn-gate with parked records only"
+  [ -f "$home/state/occ-5.meta" ] || fail "a parked record must survive as a durable record"
+  pass "parked tasks with no running worker do not block fresh dispatch"
+}
+
+test_live_workers_in_a_local_secondmate_home_share_the_host_budget() {
+  local home mate out rc i
+  home="$TMP_ROOT/host-budget"
+  mate="$TMP_ROOT/host-budget/jarvis-home"
+  setup_home "$home"
+  setup_home "$mate"
+  printf -- '- jarvis - platform work (home: %s; scope: platform work; projects: alpha; added 2026-08-27)\n' \
+    "$mate" > "$home/data/secondmates.md"
+  printf 'schema=fm-secondmate-parent.v1\nroute=local\nparent_home=%s\n' "$home" \
+    > "$mate/.fm-secondmate-parent"
+  write_ship_meta "$home" prim-a1
+  for i in 1 2 3 4; do
+    write_ship_meta "$mate" "mate-$i"
+  done
+  set_live_windows "$home" prim-a1 mate-1 mate-2 mate-3 mate-4
+  cp -R "$home/tmux" "$mate/tmux"
+  set +e
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+      run_capacity_live "$home" spawn-gate --task-id extra-p6 2>&1
+  )
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "host-wide budget from the primary home"
+  assert_contains "$out" "occupied=5" "the primary home must see the secondmate home's live workers"
+  assert_contains "$out" "homes_scanned=2" "the measurement must name how many homes it counted"
+  set +e
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+      run_capacity_live "$mate" spawn-gate --task-id extra-m6 2>&1
+  )
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "host-wide budget from the secondmate home"
+  assert_contains "$out" "occupied=5" "a secondmate home must not take a second independent budget"
+  pass "local firstmate homes share one measured budget for this host"
+}
+
+test_same_task_refuses_a_second_concurrent_worker() {
+  local home out rc
+  home="$TMP_ROOT/same-task"
+  setup_home "$home"
+  write_ship_meta "$home" live-task-a1
+  set_live_windows "$home" live-task-a1
+  set +e
+  out=$(run_capacity_live "$home" spawn-gate --task-id live-task-a1 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "same-task spawn-gate"
+  assert_contains "$out" "already has a worker" "same-task refuse must name the duplicate worker"
+  pass "spawn-gate refuses a second worker on the same task"
+}
+
+test_full_budget_refuses_without_touching_running_workers() {
+  local home before after out rc i
+  home="$TMP_ROOT/full-budget"
+  setup_home "$home"
+  for i in 1 2 3 4 5; do
+    write_ship_meta "$home" "occ-$i"
+  done
+  set_live_windows "$home" occ-1 occ-2 occ-3 occ-4 occ-5
+  before=$(cat "$home/state/occ-1.meta" "$home/state/occ-2.meta" "$home/state/occ-3.meta" \
+    "$home/state/occ-4.meta" "$home/state/occ-5.meta")
+  set +e
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+      run_capacity_live "$home" spawn-gate --task-id extra-w6 2>&1
+  )
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "full-budget spawn-gate"
+  assert_contains "$out" "no free worker slot" "full budget must refuse a new independent worker"
+  assert_contains "$out" "left running" "refuse path must leave running workers running"
+  after=$(cat "$home/state/occ-1.meta" "$home/state/occ-2.meta" "$home/state/occ-3.meta" \
+    "$home/state/occ-4.meta" "$home/state/occ-5.meta")
+  [ "$before" = "$after" ] || fail "occupied worker records changed during a capacity refuse"
+  pass "full slot budget refuses a new worker and leaves running workers untouched"
+}
+
+test_free_slot_allows_a_new_independent_worker() {
+  local home rc
+  home="$TMP_ROOT/free-slot"
+  setup_home "$home"
+  write_ship_meta "$home" occ-a1
+  write_ship_meta "$home" occ-b2
+  set +e
+  FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    run_capacity "$home" spawn-gate --task-id extra-c3 >/dev/null 2>&1
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "free-slot spawn-gate"
+  pass "a new independent worker is allowed while free slots remain"
+}
+
+test_relaunch_and_secondmate_skip_the_slot_budget() {
+  local home rc
+  home="$TMP_ROOT/skip-kinds"
+  setup_home "$home"
+  write_ship_meta "$home" occ-a1
+  FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=4096 FM_CAPACITY_LOAD1=16
+  fm_capacity_measure_local "$home/state" "$home"
+  [ "$FM_CAPACITY_SLOTS" = 0 ] || fail "preload should force slots=0, got $FM_CAPACITY_SLOTS"
+  set +e
+  fm_capacity_allow_new_worker "$home/state" new-b2 ship 1 "$home"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "relaunch skip"
+  set +e
+  fm_capacity_allow_new_worker "$home/state" mate-c3 secondmate 0 "$home"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "secondmate skip"
+  pass "relaunch and secondmate spawns skip the independent-worker slot budget"
+}
+
+test_cli_slots_print_measured_budget() {
+  local home out
+  home="$TMP_ROOT/cli-slots"
+  setup_home "$home"
+  write_ship_meta "$home" occ-a1
+  set_live_windows "$home" occ-a1
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+      run_capacity_live "$home" slots
+  )
+  assert_contains "$out" "slots=5" "slots line"
+  assert_contains "$out" "occupied=1" "occupied line"
+  assert_contains "$out" "free=4" "free line"
+  assert_contains "$out" "homes_scanned=1" "homes scanned line"
+  pass "slots command prints measured slots, live occupancy, free, and homes scanned"
+}
+
+test_preferred_gpu_host_wins_when_freshly_suitable() {
+  local home fakebin out
+  home="$TMP_ROOT/route-pref"
+  setup_home "$home"
+  fakebin=$(fm_fakebin "$home")
+  make_fake_ssh "$fakebin"
+  mkdir -p "$home/ssh"
+  cat > "$home/ssh/Valentino" <<'OUT'
+FM_CAP nproc=24
+FM_CAP mem_avail_mb=32000
+FM_CAP load1=2.0
+FM_CAP gpu=8192,10
+OUT
+  cat > "$home/ssh/Valentino-Arbeit" <<'OUT'
+FM_CAP nproc=16
+FM_CAP mem_avail_mb=16000
+FM_CAP load1=1.0
+FM_CAP gpu=
+OUT
+  printf '%s\n' '{"preferred":{"ssh":"Valentino","kind":"gpu"},"fallback":{"ssh":"Valentino-Arbeit","kind":"cpu"}}' \
+    > "$home/config/compute-hosts.json"
+  out=$(
+    PATH="$fakebin:$PATH" FM_CAPACITY_SKIP_REMOTE='' \
+      FM_FAKE_SSH_DIR="$home/ssh" \
+      run_capacity "$home" route
+  )
+  assert_contains "$out" "route=preferred" "preferred route"
+  assert_contains "$out" "route_host=Valentino" "preferred host"
+  assert_contains "$out" "preferred_reachable=yes" "preferred reachable"
+  assert_contains "$out" "preferred_suitable=yes" "preferred suitable"
+  pass "reachable suitable Heim-PC GPU host is preferred"
+}
+
+test_fallback_used_when_preferred_is_unsuitable() {
+  local home fakebin out
+  home="$TMP_ROOT/route-fall"
+  setup_home "$home"
+  fakebin=$(fm_fakebin "$home")
+  make_fake_ssh "$fakebin"
+  mkdir -p "$home/ssh"
+  cat > "$home/ssh/Valentino" <<'OUT'
+FM_CAP nproc=24
+FM_CAP mem_avail_mb=32000
+FM_CAP load1=2.0
+FM_CAP gpu=512,95
+OUT
+  cat > "$home/ssh/Valentino-Arbeit" <<'OUT'
+FM_CAP nproc=16
+FM_CAP mem_avail_mb=16000
+FM_CAP load1=1.0
+FM_CAP gpu=
+OUT
+  printf '%s\n' '{"preferred":{"ssh":"Valentino","kind":"gpu"},"fallback":{"ssh":"Valentino-Arbeit","kind":"cpu"}}' \
+    > "$home/config/compute-hosts.json"
+  out=$(
+    PATH="$fakebin:$PATH" FM_CAPACITY_SKIP_REMOTE='' \
+      FM_FAKE_SSH_DIR="$home/ssh" \
+      run_capacity "$home" route
+  )
+  assert_contains "$out" "route=fallback" "fallback route"
+  assert_contains "$out" "route_host=Valentino-Arbeit" "fallback host"
+  assert_contains "$out" "preferred_reachable=yes" "preferred still reachable"
+  assert_contains "$out" "preferred_suitable=no" "preferred unsuitable GPU"
+  pass "Arbeits-PC is the fallback when the Heim-PC GPU is not suitable"
+}
+
+test_no_route_when_both_hosts_are_down() {
+  local home fakebin out
+  home="$TMP_ROOT/route-none"
+  setup_home "$home"
+  fakebin=$(fm_fakebin "$home")
+  make_fake_ssh "$fakebin"
+  mkdir -p "$home/ssh"
+  printf '%s\n' '{"preferred":{"ssh":"Valentino","kind":"gpu"},"fallback":{"ssh":"Valentino-Arbeit","kind":"cpu"}}' \
+    > "$home/config/compute-hosts.json"
+  out=$(
+    PATH="$fakebin:$PATH" FM_CAPACITY_SKIP_REMOTE='' \
+      FM_FAKE_SSH_DIR="$home/ssh" \
+      run_capacity "$home" route
+  )
+  assert_contains "$out" "route=none" "no route onto the supervisor"
+  assert_not_contains "$out" "route_host=Valentino" "must not claim a down preferred host"
+  pass "host-bound work is not piled onto the supervisor when both remotes fail"
+}
+
+test_preferred_pin_keeps_the_configured_fallback() {
+  local home fakebin out
+  home="$TMP_ROOT/route-pin-merge"
+  setup_home "$home"
+  fakebin=$(fm_fakebin "$home")
+  make_fake_ssh "$fakebin"
+  mkdir -p "$home/ssh"
+  # Heim-PC is down; only the configured Arbeits-PC answers.
+  cat > "$home/ssh/Valentino-Arbeit" <<'OUT'
+FM_CAP nproc=16
+FM_CAP mem_avail_mb=16000
+FM_CAP load1=1.0
+FM_CAP gpu=
+OUT
+  printf '%s\n' '{"preferred":{"ssh":"Valentino","kind":"gpu"},"fallback":{"ssh":"Valentino-Arbeit","kind":"cpu"}}' \
+    > "$home/config/compute-hosts.json"
+  out=$(
+    PATH="$fakebin:$PATH" FM_CAPACITY_SKIP_REMOTE='' \
+      FM_FAKE_SSH_DIR="$home/ssh" \
+      run_capacity "$home" route --preferred Valentino
+  )
+  assert_contains "$out" "route=fallback" "a preferred-only pin must keep the configured fallback"
+  assert_contains "$out" "route_host=Valentino-Arbeit" "fallback host survives the pin"
+  assert_contains "$out" "fallback_ssh=Valentino-Arbeit" "the configured fallback is still loaded"
+  pass "pinning only the preferred host preserves the configured Arbeits-PC fallback"
+}
+
+test_invalid_pinned_kind_is_rejected() {
+  local home out rc
+  home="$TMP_ROOT/route-bad-kind"
+  setup_home "$home"
+  set +e
+  out=$(run_capacity "$home" route --preferred Valentino-Arbeit --preferred-kind CPU 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "invalid pinned kind"
+  assert_contains "$out" "must be gpu or cpu" "an unknown pinned kind must be reported, not coerced"
+  assert_not_contains "$out" "preferred_suitable" "a rejected pin must not produce a routing verdict"
+  pass "an unknown pinned host kind is rejected instead of silently coerced"
+}
+
+test_spawn_refuses_at_capacity_without_launching() {
+  local home fakebin out rc id=cap-new-z9
+  home="$TMP_ROOT/spawn-refuse"
+  setup_home "$home"
+  write_ship_meta "$home" occ-a1
+  write_ship_meta "$home" occ-b2
+  fakebin=$(fm_fakebin "$home")
+  make_fake_tmux "$fakebin"
+  set_live_windows "$home" occ-a1 occ-b2
+  mkdir -p "$home/data/$id"
+  printf 'Delivery contract: mode=no-mistakes\n' > "$home/data/$id/brief.md"
+  set +e
+  out=$(
+    PATH="$fakebin:$PATH" FM_FAKE_TMUX_DIR="$home/tmux" \
+      FM_CAPACITY_NPROC=6 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.2 \
+      FM_HOME="$home" FM_ROOT_OVERRIDE="" \
+      FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux \
+      "$SPAWN" "$id" projects/demo --mode no-mistakes --yolo off 2>&1
+  )
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "spawn at capacity"
+  assert_contains "$out" "error: capacity:" "spawn must refuse through the capacity gate"
+  assert_not_contains "$out" "spawned $id" "spawn must not report a launch"
+  pass "fm-spawn refuses a new independent worker when no slot remains"
+}
+
+test_gpu_suitability_requires_headroom() {
+  fm_capacity_host_suitable gpu 24 32000 2.0 8192 10 \
+    || fail "healthy GPU host should be suitable"
+  fm_capacity_host_suitable gpu 24 32000 2.0 512 10 \
+    && fail "low VRAM should be unsuitable"
+  fm_capacity_host_suitable gpu 24 32000 2.0 8192 95 \
+    && fail "high GPU util should be unsuitable"
+  fm_capacity_host_suitable gpu 24 32000 48.0 8192 10 \
+    && fail "free VRAM behind a pinned CPU should be unsuitable"
+  fm_capacity_host_suitable gpu 24 256 2.0 8192 10 \
+    && fail "free VRAM with no usable RAM should be unsuitable"
+  fm_capacity_host_suitable gpu 24 0 0 8192 10 \
+    && fail "an unmeasurable host reporting mem=0 load=0 must not read as idle"
+  fm_capacity_host_suitable cpu 16 16000 1.0 "" "" \
+    || fail "healthy CPU host should be suitable"
+  fm_capacity_host_suitable cpu 16 16000 16.0 0 0 \
+    && fail "saturated CPU host should be unsuitable"
+  pass "gpu and cpu suitability follow measured headroom"
+}
+
+test_unverified_backend_releases_finished_records_but_not_active_work() {
+  local home out rc i
+  home="$TMP_ROOT/unverified-backend"
+  setup_home "$home"
+  for i in 1 2 3 4 5; do
+    write_unverified_ship_meta "$home" "occ-$i"
+  done
+  # occ-1 is still working and occ-2 has not declared anything yet (a worker one
+  # second after launch); the other three are finished or held. Nothing on this
+  # backend can be proven dead, so the declared state is the only evidence.
+  write_status "$home" occ-1 'working: implementing the parser'
+  write_status "$home" occ-3 'done: merged in PR 42'
+  write_status "$home" occ-4 'needs-decision: which schema wins?'
+  write_status "$home" occ-5 'paused: waiting on the upstream release'
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+      run_capacity "$home" slots
+  )
+  assert_contains "$out" "occupied=2" \
+    "only actively working and not-yet-declared work may hold a slot on an unverifiable backend"
+  assert_contains "$out" "free=3" \
+    "done, needs-decision and paused records must not permanently consume the budget"
+  set +e
+  FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    run_capacity "$home" spawn-gate --task-id fresh-u7 >/dev/null 2>&1
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "spawn-gate on a backend whose liveness is unverifiable"
+  [ -f "$home/state/occ-3.meta" ] || fail "a released record must survive as a durable record"
+  pass "finished work on an unverifiable backend releases its slot while active work keeps it"
+}
+
+test_live_worker_keeps_its_slot_despite_a_finished_status_line() {
+  local home out
+  home="$TMP_ROOT/live-beats-log"
+  setup_home "$home"
+  write_ship_meta "$home" occ-a1
+  set_live_windows "$home" occ-a1
+  # The append-only log is an EVENT history: a done line can precede more work.
+  # A positively live worker is never freed on the strength of that line.
+  write_status "$home" occ-a1 'done: first slice shipped'
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+      run_capacity_live "$home" slots
+  )
+  assert_contains "$out" "occupied=1" "a positively live worker must never be freed"
+  pass "a running worker keeps its slot even after a terminal status line"
+}
+
+test_uniqueness_refuses_reusing_a_live_secondmate_id() {
+  local home out rc
+  home="$TMP_ROOT/secondmate-id"
+  setup_home "$home"
+  fm_write_secondmate_meta "$home/state/jarvis.meta" "$home/jarvis-home"
+  set +e
+  out=$(run_capacity "$home" spawn-gate --task-id jarvis 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "spawn-gate on an id a secondmate already owns"
+  assert_contains "$out" "secondmate record" \
+    "the refusal must name the record a fresh worker would have overwritten"
+  pass "a fresh ship or scout may not reuse a live secondmate's task id"
+}
+
+test_home_paths_are_deduplicated_by_canonical_path() {
+  local home mate out i
+  home="$TMP_ROOT/canonical"
+  mate="$TMP_ROOT/canonical/jarvis-home"
+  setup_home "$home"
+  setup_home "$mate"
+  printf -- '- jarvis - platform work (home: %s; scope: platform work; projects: alpha; added 2026-08-27)\n' \
+    "$mate" > "$home/data/secondmates.md"
+  printf 'schema=fm-secondmate-parent.v1\nroute=local\nparent_home=%s\n' "$home" \
+    > "$mate/.fm-secondmate-parent"
+  write_ship_meta "$home" prim-a1
+  for i in 1 2; do
+    write_ship_meta "$mate" "mate-$i"
+  done
+  set_live_windows "$home" prim-a1 mate-1 mate-2
+  cp -R "$home/tmux" "$mate/tmux"
+  # FM_HOME spelled with a trailing slash: the registry records the same home
+  # without one, so a raw string dedupe counts this home's workers twice.
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+      run_capacity_live "$mate/" slots
+  )
+  assert_contains "$out" "homes_scanned=2" \
+    "one home spelled two ways is still one home"
+  assert_contains "$out" "occupied=3" \
+    "a non-canonical FM_HOME must not double-count its own live workers"
+  assert_contains "$out" "free=2" "the inflated count must not eat free slots"
+  pass "host homes are deduplicated by canonical path, not by spelling"
+}
+
+test_legacy_terminal_line_releases_a_slot_on_an_unverifiable_backend() {
+  local home out rc
+  home="$TMP_ROOT/legacy-terminal"
+  setup_home "$home"
+  write_unverified_ship_meta "$home" occ-a1
+  write_unverified_ship_meta "$home" occ-b2
+  write_unverified_ship_meta "$home" occ-c3
+  # Legacy lines that carry no leading verb at all. bin/fm-classify-lib.sh owns
+  # this vocabulary; nothing on this backend can ever be proven dead, so a line
+  # it reads as captain-relevant must release the slot too.
+  write_status "$home" occ-a1 'PR ready for review, captain: https://example.test/pull/42'
+  write_status "$home" occ-b2 'merged'
+  write_status "$home" occ-c3 'working: still building the parser'
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+      run_capacity "$home" slots
+  )
+  assert_contains "$out" "occupied=1" \
+    "a bare legacy terminal line must not pin a slot forever"
+  assert_contains "$out" "free=4" "released legacy records must return their slots"
+  set +e
+  FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    run_capacity "$home" spawn-gate --task-id fresh-l9 >/dev/null 2>&1
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "spawn-gate behind bare legacy terminal lines"
+  pass "legacy terminal status lines release their slot on an unverifiable backend"
+}
+
+test_percentage_load_is_averaged_across_probe_samples() {
+  local got
+  # One ~1s burst inside an otherwise idle window must not read as a pinned
+  # host: the mean of every sample is the measurement, not the last sample.
+  fm_capacity_absorb_probe_text 'FM_CAP nproc=24
+FM_CAP mem_avail_mb=32000
+FM_CAP load_pct=10
+FM_CAP load_pct=10
+FM_CAP load_pct=100
+FM_CAP gpu=8192,10' || fail "a multi-sample Windows probe transcript should absorb"
+  [ "$FM_CAPACITY_PROBE_LOAD_SAMPLES" = 3 ] \
+    || fail "every load_pct sample must count, got $FM_CAPACITY_PROBE_LOAD_SAMPLES"
+  [ "$FM_CAPACITY_PROBE_LOAD_PCT" = "40.00" ] \
+    || fail "the mean of 10/10/100 should be 40.00, got $FM_CAPACITY_PROBE_LOAD_PCT"
+  [ -z "$FM_CAPACITY_PROBE_LOAD1" ] \
+    || fail "a percentage host reports no run-queue load1, got $FM_CAPACITY_PROBE_LOAD1"
+  got=$(fm_capacity_cpu_headroom_reading)
+  [ "$got" = "busy_pct=40.00/samples=3" ] \
+    || fail "the route report must name the averaged reading, got $got"
+  fm_capacity_host_suitable gpu 24 32000 "" 8192 10 "$FM_CAPACITY_PROBE_LOAD_PCT" \
+    || fail "a one-second burst must not demote a healthy preferred GPU host"
+  # A host sitting near 100% in every sample is a sustained overload. Rescaled
+  # into a load1 it would be 23.84, still below nproc, so the percentage itself
+  # has to be the gate or a pinned machine walks straight through.
+  fm_capacity_absorb_probe_text 'FM_CAP nproc=24
+FM_CAP mem_avail_mb=32000
+FM_CAP load_pct=100
+FM_CAP load_pct=98
+FM_CAP load_pct=100
+FM_CAP gpu=8192,10' || fail "a pinned Windows probe transcript should absorb"
+  fm_capacity_host_suitable gpu 24 32000 "" 8192 10 "$FM_CAPACITY_PROBE_LOAD_PCT" \
+    && fail "a sustained pin must still fail the CPU-headroom gate"
+  # A real run-queue load average keeps its own gate: no percentage, no change.
+  fm_capacity_host_suitable cpu 16 16000 1.0 "" "" \
+    || fail "a loadavg host must still be judged on load1"
+  fm_capacity_host_suitable cpu 16 16000 16.0 "" "" \
+    && fail "a saturated loadavg host must still be refused"
+  pass "a percentage-derived load is averaged and gated as a percentage"
+}
+
+test_burst_on_the_preferred_windows_host_keeps_heim_preference() {
+  local home fakebin out
+  home="$TMP_ROOT/route-win-burst"
+  setup_home "$home"
+  fakebin=$(fm_fakebin "$home")
+  make_fake_ssh "$fakebin"
+  mkdir -p "$home/ssh"
+  # The Heim-PC reports no load1 at all (Windows), just busy-percent samples.
+  # The burst lands on the LAST sample, which is what a last-sample-wins read
+  # would hand to the gate.
+  cat > "$home/ssh/Valentino" <<'OUT'
+FM_CAP nproc=24
+FM_CAP mem_avail_mb=32000
+FM_CAP gpu=8192,10
+FM_CAP load_pct=12
+FM_CAP load_pct=8
+FM_CAP load_pct=100
+OUT
+  cat > "$home/ssh/Valentino-Arbeit" <<'OUT'
+FM_CAP nproc=16
+FM_CAP mem_avail_mb=16000
+FM_CAP load1=1.0
+FM_CAP gpu=
+OUT
+  printf '%s\n' '{"preferred":{"ssh":"Valentino","kind":"gpu"},"fallback":{"ssh":"Valentino-Arbeit","kind":"cpu"}}' \
+    > "$home/config/compute-hosts.json"
+  out=$(
+    PATH="$fakebin:$PATH" FM_CAPACITY_SKIP_REMOTE='' \
+      FM_FAKE_SSH_DIR="$home/ssh" \
+      run_capacity "$home" route
+  )
+  assert_contains "$out" "route=preferred" \
+    "a single burst sample must not force the Arbeits-PC"
+  assert_contains "$out" "route_host=Valentino" "the Heim-PC keeps the route"
+  pass "a transient burst on the Windows Heim-PC does not invert the routing preference"
+}
+
+test_sustained_windows_pin_falls_through_to_the_fallback() {
+  local home fakebin out
+  home="$TMP_ROOT/route-win-pinned"
+  setup_home "$home"
+  fakebin=$(fm_fakebin "$home")
+  make_fake_ssh "$fakebin"
+  mkdir -p "$home/ssh"
+  cat > "$home/ssh/Valentino" <<'OUT'
+FM_CAP nproc=24
+FM_CAP mem_avail_mb=32000
+FM_CAP gpu=8192,10
+FM_CAP load_pct=100
+FM_CAP load_pct=100
+FM_CAP load_pct=99
+OUT
+  cat > "$home/ssh/Valentino-Arbeit" <<'OUT'
+FM_CAP nproc=16
+FM_CAP mem_avail_mb=16000
+FM_CAP load1=1.0
+FM_CAP gpu=
+OUT
+  printf '%s\n' '{"preferred":{"ssh":"Valentino","kind":"gpu"},"fallback":{"ssh":"Valentino-Arbeit","kind":"cpu"}}' \
+    > "$home/config/compute-hosts.json"
+  out=$(
+    PATH="$fakebin:$PATH" FM_CAPACITY_SKIP_REMOTE='' \
+      FM_FAKE_SSH_DIR="$home/ssh" \
+      run_capacity "$home" route
+  )
+  assert_contains "$out" "route=fallback" "a sustained pin must still yield to the fallback"
+  assert_contains "$out" "preferred_suitable=no" "the overload gate must still fire"
+  pass "a sustained pin on the Windows Heim-PC still routes host-bound work to the Arbeits-PC"
+}
+
+test_duplicate_id_refuses_without_measuring_the_host() {
+  local home fakebin out rc i
+  home="$TMP_ROOT/identity-first"
+  setup_home "$home"
+  for i in 1 2 3; do
+    write_ship_meta "$home" "occ-$i"
+  done
+  fakebin=$(fm_fakebin "$home")
+  make_fake_tmux "$fakebin"
+  set_live_windows "$home" occ-1 occ-2 occ-3
+  : > "$home/probe.log"
+  # Every liveness read costs backend subprocesses. An id collision is decided
+  # from the colliding record alone, so refusing it must not walk the host-wide
+  # occupancy scan and probe every other task's endpoint.
+  set +e
+  out=$(
+    PATH="$fakebin:$PATH" FM_FAKE_TMUX_DIR="$home/tmux" \
+      FM_CAPACITY_PROBE_LOG="$home/probe.log" \
+      FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+      run_capacity "$home" spawn-gate --task-id occ-2 2>&1
+  )
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "duplicate-id spawn-gate"
+  assert_contains "$out" "already has a worker" "the identity refusal must still name the duplicate"
+  grep -q -- "fm-occ-1" "$home/probe.log" \
+    && fail "an identity refusal must not probe an unrelated task's endpoint"
+  grep -q -- "fm-occ-3" "$home/probe.log" \
+    && fail "an identity refusal must not probe an unrelated task's endpoint"
+  # The same gate on a free id does measure, so the fixture really can record
+  # the reads the identity refusal skipped.
+  set +e
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_DIR="$home/tmux" \
+    FM_CAPACITY_PROBE_LOG="$home/probe.log" \
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    run_capacity "$home" spawn-gate --task-id fresh-i8 >/dev/null 2>&1
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "free-id spawn-gate"
+  grep -q -- "fm-occ-1" "$home/probe.log" \
+    || fail "the occupancy scan should have probed every recorded endpoint"
+  grep -q -- "fm-occ-3" "$home/probe.log" \
+    || fail "the occupancy scan should have probed every recorded endpoint"
+  pass "a duplicate id is refused without the host-wide occupancy scan"
+}
+
+test_unmeasurable_windows_cpu_is_not_read_as_idle() {
+  local got
+  # Win32_Processor unavailable while the OS class answers: the probe emits no
+  # load_pct line at all rather than a fabricated 0%.
+  fm_capacity_absorb_probe_text 'FM_CAP nproc=24
+FM_CAP mem_avail_mb=32000
+FM_CAP gpu=8192,10' || fail "a transcript with no CPU sample should still absorb"
+  [ "$FM_CAPACITY_PROBE_LOAD_SAMPLES" = 0 ] \
+    || fail "no CPU sample means no samples, got $FM_CAPACITY_PROBE_LOAD_SAMPLES"
+  [ -z "$FM_CAPACITY_PROBE_LOAD_PCT" ] \
+    || fail "an absent CPU reading must not become a percentage, got $FM_CAPACITY_PROBE_LOAD_PCT"
+  got=$(fm_capacity_cpu_headroom_reading)
+  [ "$got" = unmeasured ] || fail "the route report must say unmeasured, got $got"
+  fm_capacity_host_suitable gpu 24 32000 "$FM_CAPACITY_PROBE_LOAD1" 8192 10 \
+    "$FM_CAPACITY_PROBE_LOAD_PCT" \
+    && fail "a host whose CPU was never measured must be unsuitable, not idle"
+  # A zero that the host genuinely measured is still a real reading.
+  fm_capacity_absorb_probe_text 'FM_CAP nproc=24
+FM_CAP mem_avail_mb=32000
+FM_CAP load_pct=0
+FM_CAP gpu=8192,10' || fail "a genuinely idle transcript should absorb"
+  fm_capacity_host_suitable gpu 24 32000 "" 8192 10 "$FM_CAPACITY_PROBE_LOAD_PCT" \
+    || fail "a measured idle host must stay suitable"
+  pass "an unreadable Windows CPU counter reads as unmeasurable, never as idle"
+}
+
+test_unmeasurable_preferred_host_falls_through_to_the_fallback() {
+  local home fakebin out
+  home="$TMP_ROOT/route-win-unmeasured"
+  setup_home "$home"
+  fakebin=$(fm_fakebin "$home")
+  make_fake_ssh "$fakebin"
+  mkdir -p "$home/ssh"
+  # Reachable, plenty of RAM and VRAM, but the CPU counter answered nothing.
+  cat > "$home/ssh/Valentino" <<'OUT'
+FM_CAP nproc=24
+FM_CAP mem_avail_mb=32000
+FM_CAP gpu=8192,10
+OUT
+  cat > "$home/ssh/Valentino-Arbeit" <<'OUT'
+FM_CAP nproc=16
+FM_CAP mem_avail_mb=16000
+FM_CAP load1=1.0
+FM_CAP gpu=
+OUT
+  printf '%s\n' '{"preferred":{"ssh":"Valentino","kind":"gpu"},"fallback":{"ssh":"Valentino-Arbeit","kind":"cpu"}}' \
+    > "$home/config/compute-hosts.json"
+  out=$(
+    PATH="$fakebin:$PATH" FM_CAPACITY_SKIP_REMOTE='' \
+      FM_FAKE_SSH_DIR="$home/ssh" \
+      run_capacity "$home" route
+  )
+  assert_contains "$out" "route=fallback" \
+    "an unmeasured CPU must not be routed to as if it were idle"
+  assert_contains "$out" "preferred_reachable=yes" "the host did answer the probe"
+  assert_contains "$out" "preferred_suitable=no" "but it is not suitable"
+  assert_contains "$out" "preferred_cpu=unmeasured" \
+    "the report must say why the preferred host was passed over"
+  assert_contains "$out" "fallback_cpu=load1=1.0" \
+    "a run-queue host reports its own load average"
+  pass "a preferred host whose CPU could not be measured yields to the fallback"
+}
+
+test_gone_worker_releases_its_id_for_a_sequential_restart() {
+  local home out rc
+  home="$TMP_ROOT/restart-gone"
+  setup_home "$home"
+  write_ship_meta "$home" reboot-a1
+  write_ship_meta "$home" alive-b2
+  # The server was killed: alive-b2's window is listed, reboot-a1's is not, so
+  # its endpoint reads `missing` - positively gone, worktree and commits intact.
+  set_live_windows "$home" alive-b2
+  set +e
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+      run_capacity_live "$home" spawn-gate --task-id reboot-a1 2>&1
+  )
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "restart of a task whose endpoint is gone"
+  [ -f "$home/state/reboot-a1.meta" ] || fail "the durable record must survive the gate"
+  # The still-running worker's id stays refused: no second concurrent worker.
+  set +e
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+      run_capacity_live "$home" spawn-gate --task-id alive-b2 2>&1
+  )
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "spawn-gate against a live worker"
+  assert_contains "$out" "already has a worker" "a live worker still blocks its id"
+  pass "a task whose worker is positively gone can be restarted; a live one cannot"
+}
+
+test_undeclared_work_on_an_unverifiable_backend_still_blocks_its_id() {
+  local home out rc
+  home="$TMP_ROOT/restart-unknown"
+  setup_home "$home"
+  write_unverified_ship_meta "$home" unknown-a1
+  # Nothing can prove this endpoint dead and the task has declared nothing, so
+  # the fail-closed half of the liveness predicate keeps holding the id.
+  set +e
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+      run_capacity "$home" spawn-gate --task-id unknown-a1 2>&1
+  )
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "spawn-gate against unverifiable active work"
+  assert_contains "$out" "already has a worker" "an unproven endpoint must fail closed"
+  pass "an unverifiable endpoint on undeclared work still blocks a duplicate spawn"
+}
+
+# Run the real emitted Windows probe under pwsh with <stub> standing in for the
+# CIM layer, and echo the FM_CAP transcript it produces. The probe command is a
+# generated interface delivered to a remote shell, so it is executed rather than
+# inspected.
+run_windows_probe() { # <stub-powershell>
+  local stub=$1 cmd
+  FM_CAPACITY_WIN_LOAD_SAMPLES=2 FM_CAPACITY_WIN_LOAD_SAMPLE_MS=1
+  cmd=$(fm_capacity_windows_probe_cmd)
+  FM_CAPACITY_WIN_LOAD_SAMPLES=3 FM_CAPACITY_WIN_LOAD_SAMPLE_MS=1000
+  # The transcript is the contract under test, not pwsh's exit code: a probe
+  # whose CPU query failed is exactly the case being exercised.
+  pwsh -NoProfile -NonInteractive -Command "$stub
+$cmd" 2>/dev/null || true
+  return 0
+}
+
+# PowerShell stubs for the probe under test; $-expressions here are PowerShell's.
+# shellcheck disable=SC2016
+FM_TEST_CIM_OK='function Get-CimInstance { [CmdletBinding()] param([Parameter(Position=0)]$ClassName)
+  if ($ClassName -eq "Win32_OperatingSystem") { [pscustomobject]@{ FreePhysicalMemory = 32768000 } }
+  else { [pscustomobject]@{ LoadPercentage = 42 } } }'
+# shellcheck disable=SC2016
+FM_TEST_CIM_CPU_THROWS='function Get-CimInstance { [CmdletBinding()] param([Parameter(Position=0)]$ClassName)
+  if ($ClassName -eq "Win32_OperatingSystem") { [pscustomobject]@{ FreePhysicalMemory = 32768000 } }
+  else { throw "WMI processor class unavailable" } }'
+# shellcheck disable=SC2016
+FM_TEST_CIM_CPU_NULL='function Get-CimInstance { [CmdletBinding()] param([Parameter(Position=0)]$ClassName)
+  if ($ClassName -eq "Win32_OperatingSystem") { [pscustomobject]@{ FreePhysicalMemory = 32768000 } }
+  else { [pscustomobject]@{ LoadPercentage = $null } } }'
+
+test_windows_probe_omits_a_sample_it_could_not_take() {
+  local out
+  command -v pwsh >/dev/null 2>&1 \
+    || { echo "skip: pwsh not found (Windows probe execution)"; return 0; }
+  out=$(run_windows_probe "$FM_TEST_CIM_OK")
+  assert_contains "$out" "FM_CAP mem_avail_mb=32000" "the probe must report available RAM"
+  assert_contains "$out" "FM_CAP load_pct=42" "a readable CPU counter must be reported"
+  [ "$(printf '%s\n' "$out" | grep -c 'FM_CAP load_pct=')" = 2 ] \
+    || fail "each configured sample should emit one line"
+  # The processor class errors: no line at all, never a fabricated 0%.
+  out=$(run_windows_probe "$FM_TEST_CIM_CPU_THROWS")
+  assert_contains "$out" "FM_CAP mem_avail_mb=32000" "the rest of the probe must still report"
+  assert_not_contains "$out" "FM_CAP load_pct=" \
+    "a failed processor query must emit no sample rather than 0%"
+  fm_capacity_absorb_probe_text "$out
+FM_CAP gpu=8192,10" || fail "the transcript should still absorb"
+  fm_capacity_host_suitable gpu 24 "$FM_CAPACITY_PROBE_MEM_MB" \
+    "$FM_CAPACITY_PROBE_LOAD1" 8192 10 "$FM_CAPACITY_PROBE_LOAD_PCT" \
+    && fail "a host whose CPU query failed must be unsuitable, not idle"
+  # A null LoadPercentage is the same non-answer, not [int]$null = 0.
+  out=$(run_windows_probe "$FM_TEST_CIM_CPU_NULL")
+  assert_not_contains "$out" "FM_CAP load_pct=" \
+    "a null LoadPercentage must emit no sample rather than 0%"
+  pass "the Windows probe omits an unreadable CPU sample instead of fabricating idle"
+}
+
+test_posix_probe_omits_a_load_it_could_not_read() {
+  local proc out
+  proc="$TMP_ROOT/posix-proc"
+  mkdir -p "$proc"
+  printf 'MemTotal:       32768000 kB\nMemAvailable:    8192000 kB\n' > "$proc/meminfo"
+  printf '0.40 0.35 0.30 1/900 1234\n' > "$proc/loadavg"
+  out=$(sh -c "$(fm_capacity_posix_probe_cmd "$proc")")
+  assert_contains "$out" "FM_CAP mem_avail_mb=8000" "a readable meminfo must report available RAM"
+  assert_contains "$out" "FM_CAP load1=0.40" "a readable loadavg must report the run-queue average"
+  fm_capacity_absorb_probe_text "$out" || fail "a healthy POSIX transcript should absorb"
+  fm_capacity_host_suitable cpu "$FM_CAPACITY_PROBE_NPROC" "$FM_CAPACITY_PROBE_MEM_MB" \
+    "$FM_CAPACITY_PROBE_LOAD1" "" "" "$FM_CAPACITY_PROBE_LOAD_PCT" \
+    || fail "a measured idle POSIX host must stay suitable"
+  # RAM still readable, load average not: the probe emits no load1 line at all,
+  # so the missing measurement cannot be mistaken for an idle host.
+  rm -f "$proc/loadavg"
+  out=$(sh -c "$(fm_capacity_posix_probe_cmd "$proc")")
+  assert_contains "$out" "FM_CAP mem_avail_mb=8000" "the rest of the probe must still report"
+  assert_not_contains "$out" "FM_CAP load1=" \
+    "an unreadable loadavg must emit no line rather than a fabricated 0"
+  fm_capacity_absorb_probe_text "$out" || fail "the transcript should still absorb"
+  [ -z "$FM_CAPACITY_PROBE_LOAD1" ] \
+    || fail "an absent loadavg must leave no load reading, got $FM_CAPACITY_PROBE_LOAD1"
+  [ "$(fm_capacity_cpu_headroom_reading)" = unmeasured ] \
+    || fail "the route report must say unmeasured for a host with no CPU sample"
+  fm_capacity_host_suitable cpu "$FM_CAPACITY_PROBE_NPROC" "$FM_CAPACITY_PROBE_MEM_MB" \
+    "$FM_CAPACITY_PROBE_LOAD1" "" "" "$FM_CAPACITY_PROBE_LOAD_PCT" \
+    && fail "readable RAM with no CPU measurement must be unsuitable, not idle"
+  if [ "$(id -u)" != 0 ]; then
+    printf '0.40 0.35 0.30 1/900 1234\n' > "$proc/loadavg"
+    chmod 000 "$proc/loadavg"
+    out=$(sh -c "$(fm_capacity_posix_probe_cmd "$proc")")
+    assert_not_contains "$out" "FM_CAP load1=" \
+      "a permission-denied loadavg must emit no line either"
+    chmod 644 "$proc/loadavg"
+  fi
+  pass "the POSIX probe omits an unreadable load average instead of fabricating idle"
+}
+
+test_unreadable_local_load_is_not_read_as_idle() {
+  local home out rc
+  home="$TMP_ROOT/local-load-unreadable"
+  setup_home "$home"
+  # A failed platform query is a non-numeric override, not a measured 0.
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=unavailable \
+      run_capacity "$home" slots
+  )
+  assert_contains "$out" "slots=0" "unreadable load must yield zero slots, not idle headroom"
+  assert_contains "$out" "load1=unavailable" "the failed reading must stay visible"
+  assert_not_contains "$out" "load1=0" "a missing load must not be rewritten as idle"
+  set +e
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=unavailable \
+      run_capacity "$home" spawn-gate --task-id fresh-u0 2>&1
+  )
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "spawn-gate with unreadable load"
+  assert_contains "$out" "slots=0" "the refuse must cite a zero budget"
+  assert_not_contains "$out" "load1=0" "the refuse must not claim idle load"
+  # A host that actually measured 0 is idle and still has headroom.
+  out=$(
+    FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0 \
+      run_capacity "$home" slots
+  )
+  assert_contains "$out" "slots=5" "a measured idle load must keep the full budget"
+  assert_contains "$out" "load1=0" "a genuine zero must remain a zero"
+  pass "an unreadable local load yields zero slots rather than idle headroom"
+}
+
+test_task_id_is_refused_on_probe_slots_and_route() {
+  local home out rc cmd
+  home="$TMP_ROOT/task-id-commands"
+  setup_home "$home"
+  for cmd in probe slots route; do
+    set +e
+    out=$(run_capacity "$home" "$cmd" --task-id ghost-a1 2>&1)
+    rc=$?
+    set -e
+    expect_code 1 "$rc" "$cmd --task-id"
+    assert_contains "$out" "--task-id applies only to spawn-gate" \
+      "$cmd must refuse --task-id rather than ignore it"
+    assert_not_contains "$out" "slots=" "$cmd --task-id must not print a slot budget"
+    assert_not_contains "$out" "route=" "$cmd --task-id must not print a routing verdict"
+    assert_not_contains "$out" "generated=" "$cmd --task-id must not print a probe"
+  done
+  set +e
+  out=$(run_capacity "$home" slots --task-id=ghost-b2 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "slots --task-id="
+  assert_contains "$out" "--task-id applies only to spawn-gate" \
+    "the equals form must also be refused on slots"
+  set +e
+  out=$(run_capacity "$home" --task-id ghost-c3 probe 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "--task-id before probe"
+  assert_contains "$out" "--task-id applies only to spawn-gate" \
+    "flag-before-command must also be refused"
+  set +e
+  FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    run_capacity "$home" spawn-gate --task-id fresh-t9 >/dev/null 2>&1
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "spawn-gate --task-id"
+  pass "probe, slots, and route refuse --task-id; spawn-gate still accepts it"
+}
+
+test_slots_allow_five_on_healthy_supervisor
+test_slots_drop_to_zero_when_load_saturates
+test_slots_drop_when_ram_is_tight
+test_slots_small_host_keeps_one_when_healthy
+test_slots_high_but_not_full_load_caps_at_one
+test_occupied_counts_ship_and_scout_not_secondmates
+test_parked_task_without_a_live_worker_frees_its_slot
+test_live_workers_in_a_local_secondmate_home_share_the_host_budget
+test_same_task_refuses_a_second_concurrent_worker
+test_full_budget_refuses_without_touching_running_workers
+test_free_slot_allows_a_new_independent_worker
+test_relaunch_and_secondmate_skip_the_slot_budget
+test_cli_slots_print_measured_budget
+test_preferred_gpu_host_wins_when_freshly_suitable
+test_fallback_used_when_preferred_is_unsuitable
+test_no_route_when_both_hosts_are_down
+test_preferred_pin_keeps_the_configured_fallback
+test_invalid_pinned_kind_is_rejected
+test_spawn_refuses_at_capacity_without_launching
+test_gpu_suitability_requires_headroom
+test_unverified_backend_releases_finished_records_but_not_active_work
+test_live_worker_keeps_its_slot_despite_a_finished_status_line
+test_uniqueness_refuses_reusing_a_live_secondmate_id
+test_home_paths_are_deduplicated_by_canonical_path
+test_legacy_terminal_line_releases_a_slot_on_an_unverifiable_backend
+test_percentage_load_is_averaged_across_probe_samples
+test_burst_on_the_preferred_windows_host_keeps_heim_preference
+test_sustained_windows_pin_falls_through_to_the_fallback
+test_duplicate_id_refuses_without_measuring_the_host
+test_unmeasurable_windows_cpu_is_not_read_as_idle
+test_unmeasurable_preferred_host_falls_through_to_the_fallback
+test_gone_worker_releases_its_id_for_a_sequential_restart
+test_undeclared_work_on_an_unverifiable_backend_still_blocks_its_id
+test_windows_probe_omits_a_sample_it_could_not_take
+test_posix_probe_omits_a_load_it_could_not_read
+test_unreadable_local_load_is_not_read_as_idle
+test_task_id_is_refused_on_probe_slots_and_route
+
+echo "# all fm-capacity tests passed"

--- a/tests/fm-land-behind-main.test.sh
+++ b/tests/fm-land-behind-main.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# tests/fm-land-behind-main.test.sh - refuse landing when a branch is too far behind main.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=bin/fm-land-lib.sh
+. "$ROOT/bin/fm-land-lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-land-behind-main)
+
+make_stale_ship_repo() {  # <dir> <behind-count>
+  local dir=$1 behind=$2 i
+  git init -q -b main "$dir"
+  git -C "$dir" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -q --allow-empty -m base
+  git -C "$dir" checkout -q -b ship
+  git -C "$dir" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -q --allow-empty -m ship
+  git -C "$dir" checkout -q main
+  i=0
+  while [ "$i" -lt "$behind" ]; do
+    git -C "$dir" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+      commit -q --allow-empty -m "advance-$i"
+    i=$((i + 1))
+  done
+}
+
+make_ff_ship_repo() {  # <dir> <behind-count>
+  local dir=$1 behind=$2 i
+  git init -q -b main "$dir"
+  i=0
+  while [ "$i" -lt "$behind" ]; do
+    git -C "$dir" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+      commit -q --allow-empty -m "main-$i"
+    i=$((i + 1))
+  done
+  git -C "$dir" checkout -q -b ship
+  git -C "$dir" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -q --allow-empty -m ship
+  git -C "$dir" checkout -q main
+}
+
+setup_merge_fixture() {  # <home> <id> <fixture-fn> <arg>
+  local home=$1 id=$2 fn=$3 arg=$4 proj="$home/proj"
+  "$fn" "$proj" "$arg"
+  git -C "$proj" branch -f "fm/$id" ship
+  git -C "$proj" checkout -q main
+  mkdir -p "$home/state"
+  printf 'project=%s\nmode=local-only\n' "$proj" > "$home/state/$id.meta"
+}
+
+test_land_lib_counts_behind_default() {
+  local repo="$TMP_ROOT/count"
+  make_stale_ship_repo "$repo" 25
+  [ "$(fm_land_commits_behind_default "$repo" ship main)" = 25 ] \
+    || fail "expected ship to be 25 commits behind main"
+  fm_land_branch_too_far_behind_default "$repo" ship main \
+    || fail "25 behind should exceed the default ceiling"
+  pass "fm-land-lib measures commits behind the default branch"
+}
+
+test_land_refuse_reports_stale_branch() {
+  local repo="$TMP_ROOT/refuse-lib" out status
+  make_stale_ship_repo "$repo" 25
+  out=$(fm_land_refuse_if_too_far_behind_default "$repo" ship main ship 2>&1) || status=$?
+  status=${status:-0}
+  [ "$status" -ne 0 ] || fail "land guard succeeded for a branch 25 commits behind main"
+  assert_contains "$out" '25 commits behind main' \
+    "refusal did not report how far behind the branch is"
+  pass "fm-land-lib refuses landing when the branch is too far behind main"
+}
+
+test_merge_local_allows_when_close_enough() {
+  local home="$TMP_ROOT/allow-behind" id=close-task out status before after
+  setup_merge_fixture "$home" "$id" make_ff_ship_repo 5
+  printf 'done: ready in branch fm/%s · Tests 1/0\n' "$id" > "$home/state/$id.status"
+  before=$(git -C "$home/proj" rev-parse --short main)
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" "$id" 2>&1) || status=$?
+  status=${status:-0}
+  expect_code 0 "$status" "merge-local refused a fast-forward branch only 0 behind main: $out"
+  after=$(git -C "$home/proj" rev-parse --short main)
+  [ "$before" != "$after" ] || fail "merge-local did not advance main"
+  pass "fm-merge-local still lands a fast-forward branch within the behind-main ceiling"
+}
+
+test_land_lib_counts_behind_default
+test_land_refuse_reports_stale_branch
+test_merge_local_allows_when_close_enough
+
+echo "# all fm-land-behind-main tests passed"

--- a/tests/fm-ship-self-test-status.test.sh
+++ b/tests/fm-ship-self-test-status.test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# tests/fm-ship-self-test-status.test.sh - ship workers must report Tests N/0
+# before terminal done:. fm-classify-lib.sh owns detection; fm-merge-local.sh
+# refuses local-only landing without it; fm-brief.sh and fm-spawn.sh carry the
+# scaffold contract.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=bin/fm-classify-lib.sh
+. "$ROOT/bin/fm-classify-lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-ship-self-test-status)
+
+test_status_has_self_test_report_accepts_common_shapes() {
+  status_has_self_test_report 'done: ready in branch fm/x · Tests 42/0' \
+    || fail "done line with middle-dot Tests N/0 was rejected"
+  status_has_self_test_report 'working: tests 3/0 gelaufen' \
+    || fail "lowercase tests N/0 was rejected"
+  status_has_self_test_report 'done: PR https://example.com/pull/1 · Tests 10/0' \
+    || fail "PR done line with Tests N/0 was rejected"
+  pass "status_has_self_test_report accepts common Tests N/0 shapes"
+}
+
+test_status_has_self_test_report_rejects_missing_counts() {
+  status_has_self_test_report 'done: ready in branch fm/x' && fail "bare done was accepted"
+  status_has_self_test_report 'done: ready in branch fm/x · Tests ok' && fail "prose without N/0 was accepted"
+  pass "status_has_self_test_report rejects lines without Tests N/0"
+}
+
+test_status_log_self_test_reported_before_done() {
+  local dir="$TMP_ROOT/log-fold"
+  mkdir -p "$dir"
+
+  printf 'working: setup\n\ndone: ready in branch fm/x\n' > "$dir/missing.status"
+  status_log_self_test_reported_before_done "$dir/missing.status" && fail "done without Tests N/0 was accepted"
+
+  printf 'working: Tests 5/0\n\ndone: ready in branch fm/x\n' > "$dir/working.status"
+  status_log_self_test_reported_before_done "$dir/working.status" \
+    || fail "working-line Tests N/0 before done was rejected"
+
+  printf 'done: ready in branch fm/x · Tests 5/0\n' > "$dir/done.status"
+  status_log_self_test_reported_before_done "$dir/done.status" \
+    || fail "Tests N/0 on the done line was rejected"
+  pass "status_log_self_test_reported_before_done honors working and done lines"
+}
+
+test_status_parse_self_test_counts_and_clean_log() {
+  status_parse_self_test_counts 'done: ready · Tests 42/0' \
+    || fail "could not parse Tests 42/0"
+  [ "$STATUS_TEST_PASSED" = 42 ] && [ "$STATUS_TEST_FAILED" = 0 ] \
+    || fail "parsed counts were $STATUS_TEST_PASSED/$STATUS_TEST_FAILED, expected 42/0"
+
+  local dir="$TMP_ROOT/clean-fold"
+  mkdir -p "$dir"
+  printf 'done: ready in branch fm/x · Tests 5/2\n' > "$dir/failed-tests.status"
+  status_log_self_test_clean_before_done "$dir/failed-tests.status" \
+    && fail "Tests N/2 was accepted as clean"
+  printf 'done: ready in branch fm/x · Tests 5/0\n' > "$dir/clean.status"
+  status_log_self_test_clean_before_done "$dir/clean.status" \
+    || fail "Tests 5/0 was rejected as unclean"
+  pass "status_parse_self_test_counts and clean-log fold honor zero failures"
+}
+
+setup_merge_fixture() {  # <home> <id>
+  local home=$1 id=$2 proj="$home/proj"
+  git init -q -b main "$proj"
+  git -C "$proj" commit -q --allow-empty -m init
+  git -C "$proj" checkout -q -b "fm/$id"
+  git -C "$proj" commit -q --allow-empty -m ship
+  git -C "$proj" checkout -q main
+  mkdir -p "$home/state"
+  printf 'project=%s\nmode=local-only\n' "$proj" > "$home/state/$id.meta"
+}
+
+test_merge_local_refuses_done_without_self_test_report() {
+  local home="$TMP_ROOT/refuse-home" id=task-refuse out status
+  setup_merge_fixture "$home" "$id"
+  printf 'done: ready in branch fm/%s\n' "$id" > "$home/state/$id.status"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-merge-local.sh" "$id" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "merge-local succeeded without Tests N/0"
+  assert_contains "$out" "self-test report" "merge-local refusal lost its reason"
+  pass "fm-merge-local refuses local-only landing without Tests N/0"
+}
+
+test_merge_local_lands_when_self_test_reported() {
+  local home="$TMP_ROOT/land-home" id=task-land out status
+  setup_merge_fixture "$home" "$id"
+  printf 'done: ready in branch fm/%s · Tests 3/0\n' "$id" > "$home/state/$id.status"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-merge-local.sh" "$id" 2>&1)
+  status=$?
+  expect_code 0 "$status" "merge-local with Tests N/0 failed: $out"
+  assert_contains "$out" "merged fm/$id" "merge-local did not land the branch"
+  pass "fm-merge-local lands when Tests N/0 precedes terminal done:"
+}
+
+test_merge_local_refuses_test_failures() {
+  local home="$TMP_ROOT/fail-tests-home" id=task-fail-tests out status
+  setup_merge_fixture "$home" "$id"
+  printf 'done: ready in branch fm/%s · Tests 3/2\n' "$id" > "$home/state/$id.status"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-merge-local.sh" "$id" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "merge-local succeeded with test failures"
+  assert_contains "$out" "test failures" "merge-local refusal lost its failure reason"
+  pass "fm-merge-local refuses local-only landing when Tests N/M has M > 0"
+}
+
+test_merge_local_refuses_zero_commits_ahead() {
+  local home="$TMP_ROOT/zero-ahead-home" id=task-zero proj out status
+  proj="$home/proj"
+  git init -q -b main "$proj"
+  git -C "$proj" commit -q --allow-empty -m init
+  git -C "$proj" branch -q "fm/$id"
+  mkdir -p "$home/state"
+  printf 'project=%s\nmode=local-only\n' "$proj" > "$home/state/$id.meta"
+  printf 'done: ready in branch fm/%s · Tests 1/0\n' "$id" > "$home/state/$id.status"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-merge-local.sh" "$id" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "merge-local succeeded with zero commits ahead"
+  assert_contains "$out" "0 commits ahead" "merge-local refusal lost its zero-ahead reason"
+  pass "fm-merge-local refuses local-only landing with zero commits ahead"
+}
+
+test_ship_brief_scaffold_carries_self_test_contract() {
+  local home="$TMP_ROOT/brief-home" brief
+  mkdir -p "$home/data"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-selftest ship-proj --mode local-only >/dev/null 2>&1 \
+    || fail "local-only brief scaffold failed"
+  brief="$home/data/brief-selftest/brief.md"
+  assert_grep '# Self-test before done' "$brief" "ship brief missing self-test section"
+  assert_grep 'Tests N/0' "$brief" "ship brief missing Tests N/0 contract"
+  assert_grep 'done: ready in branch fm/brief-selftest · Tests N/0' "$brief" \
+    "local-only DOD did not require Tests N/0 on done"
+  pass "fm-brief.sh: ship scaffolds carry the self-test contract"
+}
+
+test_status_has_self_test_report_accepts_common_shapes
+test_status_has_self_test_report_rejects_missing_counts
+test_status_log_self_test_reported_before_done
+test_status_parse_self_test_counts_and_clean_log
+test_merge_local_refuses_done_without_self_test_report
+test_merge_local_lands_when_self_test_reported
+test_merge_local_refuses_test_failures
+test_merge_local_refuses_zero_commits_ahead
+test_ship_brief_scaffold_carries_self_test_contract

--- a/tests/fm-work-loop.test.sh
+++ b/tests/fm-work-loop.test.sh
@@ -1,0 +1,510 @@
+#!/usr/bin/env bash
+# tests/fm-work-loop.test.sh - parallel slot refill planning for section 7's work loop.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=bin/fm-capacity-lib.sh
+. "$ROOT/bin/fm-capacity-lib.sh"
+
+SCRIPT="$ROOT/bin/fm-work-loop.sh"
+TMP_ROOT=$(fm_test_tmproot fm-work-loop)
+
+setup_home() {
+  local home=$1
+  mkdir -p "$home/state" "$home/config" "$home/data" "$home/projects/demo"
+  printf '%s\n' '- [ ] alpha-one - Alpha one (repo: demo) (kind: ship)' > "$home/data/backlog.md"
+}
+
+write_ship_meta() {
+  local home=$1 id=$2
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "endpoint_task_id=$id" \
+    "kind=ship" \
+    "harness=echo"
+}
+
+make_fake_tmux() {
+  local fakebin=$1
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+cmd=${1:-}
+shift || true
+session=; fmt=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -p) shift ;;
+    -t) session=${2%%:*}; shift 2 ;;
+    -F) shift 2 ;;
+    *) fmt=$1; shift ;;
+  esac
+done
+dir=${FM_FAKE_TMUX_DIR:-}
+case "$cmd" in
+  list-windows)
+    if [ -n "$dir" ] && [ -f "$dir/$session" ]; then
+      cat "$dir/$session"
+      exit 0
+    fi
+    printf "can't find session: %s\n" "$session" >&2
+    exit 1
+    ;;
+  display-message)
+    [ "$fmt" = '#{pane_current_command}' ] && printf 'claude\n'
+    exit 0
+    ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/tmux"
+}
+
+set_live_windows() {
+  local home=$1
+  shift
+  local id
+  mkdir -p "$home/tmux"
+  : > "$home/tmux/firstmate"
+  for id in "$@"; do
+    printf 'fm-%s\n' "$id" >> "$home/tmux/firstmate"
+  done
+}
+
+install_fake_crew_state() {
+  local fakebin=$1
+  cat > "$fakebin/fm-crew-state.sh" <<'SH'
+#!/usr/bin/env bash
+set -u
+id=${1:-}
+case "$id" in
+  live-a|live-b|live-c|live-d|live-e|alpha-one|busy-a|busy-b|busy-c|done-idle|validating-a)
+    printf 'state: working · source: pane · harness busy\n'
+    ;;
+  validating-run)
+    printf 'state: working · source: run-step · validating (running)\n'
+    ;;
+  card-a|card-b|done-live-busy)
+    printf 'state: working · source: pane · harness busy\n'
+    ;;
+  done-a|done-b|done-c)
+    printf 'state: done · source: status-log · crew finished\n'
+    ;;
+  *)
+    printf 'state: unknown · source: none\n'
+    ;;
+esac
+SH
+  chmod +x "$fakebin/fm-crew-state.sh"
+}
+
+run_work_loop() {
+  local home=$1
+  shift
+  local fakebin
+  fakebin=$(fm_fakebin "$home")
+  make_fake_tmux "$fakebin"
+  install_fake_crew_state "$fakebin"
+  PATH="$fakebin:${PATH:-/usr/bin:/bin}" FM_FAKE_TMUX_DIR="$home/tmux" \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_DATA_OVERRIDE="$home/data" \
+    FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+  "$SCRIPT" "$@"
+}
+
+add_compatible_tasks_axi() {
+  local home=$1
+  mkdir -p "$home/bin"
+  cat > "$home/bin/tasks-axi" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  --version) printf '0.2.4\n'; exit 0 ;;
+  update)
+    [ "${2:-}" = --help ] && { printf 'usage: tasks-axi update <id> [--archive-body]\n'; exit 0; }
+    ;;
+  mv)
+    [ "${2:-}" = --help ] && { printf 'usage: tasks-axi mv <dest> [<id>...]\n'; exit 0; }
+    ;;
+  ready)
+  shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --file) shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  printf 'count: 3\n'
+  printf 'ready[3]{id,state,kind,repo,title}:\n'
+  printf '  alpha-one,queued,ship,demo,Alpha one\n'
+  printf '  alpha-two,queued,ship,demo,Alpha two\n'
+  printf '  alpha-three,queued,ship,demo,Alpha three\n'
+  printf 'ready_public_followups: 0 delivery-ready obligations\n'
+  exit 0
+  ;;
+esac
+exit 1
+SH
+  chmod +x "$home/bin/tasks-axi"
+}
+
+test_status_reports_measured_slots() {
+  local home out
+  home="$TMP_ROOT/status"
+  setup_home "$home"
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    run_work_loop "$home" status)
+  assert_contains "$out" 'FM_WORK_LOOP slots=5 occupied=0 free=5 real=0 min_real=3 shortfall=3 homes_scanned=1' \
+    "status did not report measured slot budget and real-worker floor: $out"
+  pass "fm-work-loop status reports measured slot budget"
+}
+
+test_plan_fills_up_to_free_slots() {
+  local home out n
+  home="$TMP_ROOT/plan-fill"
+  setup_home "$home"
+  add_compatible_tasks_axi "$home"
+  write_ship_meta "$home" busy-a
+  write_ship_meta "$home" busy-b
+  write_ship_meta "$home" busy-c
+  set_live_windows "$home" busy-a busy-b busy-c
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    PATH="$home/bin:$PATH" run_work_loop "$home" plan)
+  n=$(printf '%s\n' "$out" | sed '/^$/d' | wc -l)
+  [ "$n" -eq 2 ] || fail "expected 2 planned spawns with 3 real workers and 2 free slots, got $n: $out"
+  pass "fm-work-loop plan lists every dispatchable id up to the free budget once the real floor is met"
+}
+
+test_plan_tops_up_below_real_floor() {
+  local home out n
+  home="$TMP_ROOT/plan-floor"
+  setup_home "$home"
+  add_compatible_tasks_axi "$home"
+  write_ship_meta "$home" busy-a
+  set_live_windows "$home" busy-a
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    PATH="$home/bin:$PATH" run_work_loop "$home" plan)
+  n=$(printf '%s\n' "$out" | sed '/^$/d' | wc -l)
+  [ "$n" -eq 2 ] || fail "expected 2 planned spawns to reach min_real=3, got $n: $out"
+  pass "fm-work-loop plan tops up toward min_real when fewer than three workers are busy"
+}
+
+test_plan_ignores_idle_done_panes_for_real_floor() {
+  local home out n
+  home="$TMP_ROOT/plan-done-idle"
+  setup_home "$home"
+  add_compatible_tasks_axi "$home"
+  write_ship_meta "$home" done-a
+  write_ship_meta "$home" done-b
+  write_ship_meta "$home" busy-a
+  set_live_windows "$home" done-a done-b busy-a
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    PATH="$home/bin:$PATH" run_work_loop "$home" plan)
+  n=$(printf '%s\n' "$out" | sed '/^$/d' | wc -l)
+  [ "$n" -eq 2 ] || fail "idle done-panes should not count toward min_real; expected 2 spawns, got $n: $out"
+  pass "fm-work-loop plan ignores idle done-panes when topping up the real-worker floor"
+}
+
+test_plan_ignores_live_done_panes_with_stale_busy_pane() {
+  local home out n
+  home="$TMP_ROOT/plan-done-live-busy"
+  setup_home "$home"
+  add_compatible_tasks_axi "$home"
+  write_ship_meta "$home" done-live-busy
+  write_ship_meta "$home" card-a
+  write_ship_meta "$home" busy-a
+  printf 'done: fertig · Tests 3/0\n' > "$home/state/done-live-busy.status"
+  printf 'done: Karte idle · Tests 1/0\n' > "$home/state/card-a.status"
+  set_live_windows "$home" done-live-busy card-a busy-a
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    PATH="$home/bin:$PATH" run_work_loop "$home" plan)
+  n=$(printf '%s\n' "$out" | sed '/^$/d' | wc -l)
+  [ "$n" -eq 2 ] || fail "stale busy panes after done: should not count; expected 2 spawns, got $n: $out"
+  pass "fm-work-loop plan ignores done-panes whose endpoint still looks busy"
+}
+
+test_plan_counts_validating_run_step_despite_done_status_log() {
+  local home out n
+  home="$TMP_ROOT/plan-validating-run"
+  setup_home "$home"
+  add_compatible_tasks_axi "$home"
+  write_ship_meta "$home" validating-run
+  write_ship_meta "$home" card-a
+  write_ship_meta "$home" card-b
+  write_ship_meta "$home" busy-a
+  printf 'done: alter Eintrag vor Validierung\n' > "$home/state/validating-run.status"
+  printf 'done: Karte idle\n' > "$home/state/card-a.status"
+  printf 'done: Karte idle\n' > "$home/state/card-b.status"
+  printf 'done: schon fertig\n' > "$home/state/busy-a.status"
+  set_live_windows "$home" validating-run card-a card-b busy-a
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    PATH="$home/bin:$PATH" run_work_loop "$home" plan)
+  n=$(printf '%s\n' "$out" | sed '/^$/d' | wc -l)
+  [ "$n" -eq 1 ] || fail "active run-step should count even with stale done status; expected 1 spawn, got $n: $out"
+  pass "fm-work-loop plan still counts an active run-step over a stale done status line"
+}
+
+test_plan_skips_tasks_that_already_occupy_slots() {
+  local home out
+  home="$TMP_ROOT/plan-skip"
+  setup_home "$home"
+  add_compatible_tasks_axi "$home"
+  write_ship_meta "$home" alpha-one
+  set_live_windows "$home" alpha-one
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    PATH="$home/bin:$PATH" run_work_loop "$home" plan)
+  assert_not_contains "$out" 'alpha-one' "plan should skip a task that already holds a live slot"
+  assert_contains "$out" 'alpha-two' "plan should still offer other dispatchable tasks"
+  pass "fm-work-loop plan skips ids that already occupy a live worker slot"
+}
+
+test_plan_prints_nothing_when_no_free_slots() {
+  local home out rc
+  home="$TMP_ROOT/plan-full"
+  setup_home "$home"
+  add_compatible_tasks_axi "$home"
+  write_ship_meta "$home" live-a
+  write_ship_meta "$home" live-b
+  write_ship_meta "$home" live-c
+  write_ship_meta "$home" live-d
+  write_ship_meta "$home" live-e
+  set_live_windows "$home" live-a live-b live-c live-d live-e
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    PATH="$home/bin:$PATH" run_work_loop "$home" plan)
+  [ -z "$out" ] || fail "plan should be silent when free=0, got: $out"
+  pass "fm-work-loop plan stays silent when every slot is occupied"
+}
+
+write_fixed_list() {
+  local home=$1
+  shift
+  mkdir -p "$home/config"
+  : > "$home/config/work-loop-list"
+  while [ "$#" -gt 0 ]; do
+    printf '%s\n' "$1" >> "$home/config/work-loop-list"
+    shift
+  done
+}
+
+test_status_reports_list_source_when_fixed_list_active() {
+  local home out
+  home="$TMP_ROOT/status-list"
+  setup_home "$home"
+  write_fixed_list "$home" alpha-one
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    run_work_loop "$home" status)
+  assert_contains "$out" 'source=list' "status should name fixed-list source: $out"
+  pass "fm-work-loop status reports source=list when a fixed list is active"
+}
+
+test_plan_uses_fixed_list_order() {
+  local home out first second
+  home="$TMP_ROOT/plan-list-order"
+  setup_home "$home"
+  add_compatible_tasks_axi "$home"
+  write_fixed_list "$home" alpha-three alpha-one alpha-two
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    PATH="$home/bin:$PATH" run_work_loop "$home" plan)
+  first=$(printf '%s\n' "$out" | sed -n '1p')
+  second=$(printf '%s\n' "$out" | sed -n '2p')
+  [ "$first" = alpha-three ] || fail "fixed list should preserve file order, first=$first"
+  [ "$second" = alpha-one ] || fail "fixed list should preserve file order, second=$second"
+  pass "fm-work-loop plan walks the fixed list in file order"
+}
+
+test_plan_fixed_list_skips_not_ready_ids() {
+  local home out
+  home="$TMP_ROOT/plan-list-skip"
+  setup_home "$home"
+  add_compatible_tasks_axi "$home"
+  write_fixed_list "$home" alpha-missing alpha-two
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    PATH="$home/bin:$PATH" run_work_loop "$home" plan)
+  assert_not_contains "$out" 'alpha-missing' "plan should skip list ids that are not ready"
+  assert_contains "$out" 'alpha-two' "plan should still offer ready list ids"
+  pass "fm-work-loop plan skips fixed-list ids that are not tasks-axi ready"
+}
+
+test_plan_fixed_list_skips_tasks_that_already_occupy_slots() {
+  local home out
+  home="$TMP_ROOT/plan-list-occupied"
+  setup_home "$home"
+  add_compatible_tasks_axi "$home"
+  write_fixed_list "$home" alpha-one alpha-two alpha-three
+  write_ship_meta "$home" alpha-one
+  set_live_windows "$home" alpha-one
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    PATH="$home/bin:$PATH" run_work_loop "$home" plan)
+  assert_not_contains "$out" 'alpha-one' "fixed-list plan should skip a task that already holds a live slot"
+  assert_contains "$out" 'alpha-two' "fixed-list plan should still offer other ready list ids"
+  pass "fm-work-loop fixed-list plan skips ids that already occupy a live worker slot"
+}
+
+add_empty_ready_tasks_axi() {
+  local home=$1
+  mkdir -p "$home/bin" "$home/state"
+  cat > "$home/bin/tasks-axi" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  --version) printf '0.2.4\n'; exit 0 ;;
+  update)
+    [ "${2:-}" = --help ] && { printf 'usage: tasks-axi update <id> [--archive-body]\n'; exit 0; }
+    ;;
+  mv)
+    [ "${2:-}" = --help ] && { printf 'usage: tasks-axi mv <dest> [<id>...]\n'; exit 0; }
+    ;;
+  ready)
+    shift
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --file) shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [ -f "${FM_SUPPLY_READY_FILE:-}" ]; then
+      cat "${FM_SUPPLY_READY_FILE}"
+      exit 0
+    fi
+    printf 'count: 0\n'
+    printf 'ready[0]{id,state,kind,repo,title}:\n'
+    printf 'ready_public_followups: 0 delivery-ready obligations\n'
+    exit 0
+    ;;
+  show)
+    id=${2:-}
+    shift 2 || true
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --file) shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    case "$id" in
+      alpha-done)
+        printf 'task:\n  id: alpha-done\n  title: "Done task"\n  state: done\n'
+        ;;
+      alpha-live)
+        printf 'task:\n  id: alpha-live\n  title: "Live task"\n  state: in_flight\n'
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
+  reopen)
+    id=${2:-}
+    shift 2 || true
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --file) shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    printf '%s\n' "$id" >> "${FM_SUPPLY_REOPEN_LOG:-/dev/null}"
+    printf 'ready[1]{id,state,kind,repo,title}:\n' > "${FM_SUPPLY_READY_FILE:-}"
+    printf '  %s,queued,ship,demo,Done task\n' "$id" >> "${FM_SUPPLY_READY_FILE:-}"
+    exit 0
+    ;;
+  add)
+    id=$2
+    shift 2 || true
+  title=; repo=; kind=
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --repo) repo=$2; shift 2 ;;
+      --kind) kind=$2; shift 2 ;;
+      --file) shift 2 ;;
+      *) title=$1; shift ;;
+    esac
+  done
+    printf '%s\t%s\t%s\t%s\n' "$id" "$repo" "$title" "$kind" >> "${FM_SUPPLY_ADD_LOG:-/dev/null}"
+    printf 'ready[1]{id,state,kind,repo,title}:\n' > "${FM_SUPPLY_READY_FILE:-}"
+    printf '  %s,queued,%s,%s,%s\n' "$id" "$kind" "$repo" "$title" >> "${FM_SUPPLY_READY_FILE:-}"
+    exit 0
+    ;;
+esac
+exit 1
+SH
+  chmod +x "$home/bin/tasks-axi"
+}
+
+test_supply_reopens_done_list_id_when_ready_queue_empty() {
+  local home out log
+  home="$TMP_ROOT/supply-reopen"
+  setup_home "$home"
+  add_empty_ready_tasks_axi "$home"
+  write_fixed_list "$home" alpha-done
+  log="$home/reopen.log"
+  : > "$log"
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    FM_SUPPLY_REOPEN_LOG="$log" FM_SUPPLY_READY_FILE="$home/ready.txt" \
+    PATH="$home/bin:$PATH" run_work_loop "$home" supply)
+  assert_contains "$out" 'FM_WORK_LOOP supplied=alpha-done' "supply should report reopened id: $out"
+  grep -F 'alpha-done' "$log" >/dev/null || fail "supply should reopen the done list id"
+  pass "fm-work-loop supply reopens the next done fixed-list id when ready is empty"
+}
+
+test_plan_supplies_done_list_id_before_printing_candidates() {
+  local home out
+  home="$TMP_ROOT/plan-supply"
+  setup_home "$home"
+  add_empty_ready_tasks_axi "$home"
+  write_fixed_list "$home" alpha-done
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    FM_SUPPLY_REOPEN_LOG="$home/reopen.log" FM_SUPPLY_READY_FILE="$home/ready.txt" \
+    PATH="$home/bin:$PATH" run_work_loop "$home" plan)
+  assert_contains "$out" 'alpha-done' "plan should offer a resupplied list id: $out"
+  pass "fm-work-loop plan resupplies the next known id when ready is empty"
+}
+
+test_supply_adds_missing_spec_row_when_ready_queue_empty() {
+  local home out log
+  home="$TMP_ROOT/supply-add"
+  setup_home "$home"
+  add_empty_ready_tasks_axi "$home"
+  write_fixed_list "$home" 'alpha-new'$'\t''demo'$'\t''New task'$'\t''ship'
+  log="$home/add.log"
+  : > "$log"
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    FM_SUPPLY_ADD_LOG="$log" FM_SUPPLY_READY_FILE="$home/ready.txt" \
+    PATH="$home/bin:$PATH" run_work_loop "$home" supply)
+  assert_contains "$out" 'FM_WORK_LOOP supplied=alpha-new' "supply should report added id: $out"
+  grep -F $'alpha-new\tdemo\tNew task\tship' "$log" >/dev/null \
+    || fail "supply should add the missing spec row"
+  pass "fm-work-loop supply adds a missing tab-separated list row when ready is empty"
+}
+
+test_supply_skips_when_ready_queue_has_candidates() {
+  local home out
+  home="$TMP_ROOT/supply-skip-ready"
+  setup_home "$home"
+  add_compatible_tasks_axi "$home"
+  write_fixed_list "$home" alpha-done
+  out=$(FM_CAPACITY_NPROC=16 FM_CAPACITY_MEM_AVAIL_MB=24576 FM_CAPACITY_LOAD1=0.4 \
+    FM_SUPPLY_REOPEN_LOG="$home/reopen.log" \
+    PATH="$home/bin:$PATH" run_work_loop "$home" supply)
+  [ -z "$out" ] || fail "supply should stay silent while ready work remains: $out"
+  pass "fm-work-loop supply does nothing while the ready queue still has candidates"
+}
+
+test_status_reports_measured_slots
+test_plan_fills_up_to_free_slots
+test_plan_tops_up_below_real_floor
+test_plan_ignores_idle_done_panes_for_real_floor
+test_plan_ignores_live_done_panes_with_stale_busy_pane
+test_plan_counts_validating_run_step_despite_done_status_log
+test_plan_skips_tasks_that_already_occupy_slots
+test_plan_prints_nothing_when_no_free_slots
+test_status_reports_list_source_when_fixed_list_active
+test_plan_uses_fixed_list_order
+test_plan_fixed_list_skips_not_ready_ids
+test_plan_fixed_list_skips_tasks_that_already_occupy_slots
+test_supply_reopens_done_list_id_when_ready_queue_empty
+test_plan_supplies_done_list_id_before_printing_candidates
+test_supply_adds_missing_spec_row_when_ready_queue_empty
+test_supply_skips_when_ready_queue_has_candidates


### PR DESCRIPTION
## Summary
- Add `fm-work-loop.sh` and capacity measurement so free worker slots refill immediately (nachlegen when a slot opens).
- Add `fm-land-lib.sh` guards that block local-only and PR landing when a branch is 20+ commits behind the default branch, while still allowing teardown that keeps the branch.

## Test plan
- [x] `./tests/fm-work-loop.test.sh` (16 tests)
- [x] `./tests/fm-land-behind-main.test.sh` (3 tests)
- [x] `./tests/fm-capacity.test.sh` (37 tests)
- [x] `./tests/fm-ship-self-test-status.test.sh` (9 tests)