### PR TITLE
feat: add remote Herdr harness ancestry diagnostics

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1209,7 +1209,11 @@ fm_backend_herdr_pane_process_info_envelope_valid() {  # <response> <pane-id>
   printf '%s' "$1" | jq -e --arg pane "$2" '
     .result.type == "pane_process_info"
     and .result.process_info.pane_id == $pane
+    and (.result.process_info.shell_pid
+      | type == "number" and . > 1 and . == floor)
     and (.result.process_info.foreground_processes | type == "array")
+    and all(.result.process_info.foreground_processes[];
+      (.pid | type == "number" and . > 1 and . == floor))
   ' >/dev/null 2>&1
 }
 
@@ -1219,7 +1223,7 @@ fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
   info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null) || return 1
   fm_backend_herdr_pane_process_info_envelope_valid "$info" "$pane" || return 1
   shell_pid=$(printf '%s' "$info" | jq -er \
-    '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
+    '.result.process_info.shell_pid' 2>/dev/null) || return 1
   foreground_pgid=$(printf '%s' "$info" | jq -er \
     '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
   [ "$foreground_pgid" = "$shell_pid" ] || return 1
@@ -1227,7 +1231,7 @@ fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
     '.result.process_info.foreground_processes | length' 2>/dev/null) || return 1
   [ "$count" -eq 1 ] || return 1
   process_pid=$(printf '%s' "$info" | jq -er \
-    '.result.process_info.foreground_processes[0].pid | select(type == "number") | floor' 2>/dev/null) || return 1
+    '.result.process_info.foreground_processes[0].pid' 2>/dev/null) || return 1
   [ "$process_pid" = "$shell_pid" ] || return 1
   name=$(printf '%s' "$info" | jq -er \
     '.result.process_info.foreground_processes[0].name | select(type == "string" and length > 0)' 2>/dev/null) || return 1

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1205,21 +1205,26 @@ fm_backend_herdr_pane_idle_shell_pid() {  # <session> <pane-id>
 # fm_backend_herdr_pane_idle_shell_sample: one strict instantaneous
 # observation for fm_backend_herdr_pane_idle_shell_pid, which owns the proof
 # contract and the settle retry.
+fm_backend_herdr_pane_process_info_envelope_valid() {  # <response> <pane-id>
+  printf '%s' "$1" | jq -e --arg pane "$2" '
+    .result.type == "pane_process_info"
+    and .result.process_info.pane_id == $pane
+    and (.result.process_info.foreground_processes | type == "array")
+  ' >/dev/null 2>&1
+}
+
 fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
   local session=$1 pane=$2 info shell_pid foreground_pgid count
   local process_pid name argv0 shell_name rows stat ps_bin
   info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null) || return 1
-  printf '%s' "$info" | jq -e --arg pane "$pane" '
-    .result.type == "pane_process_info"
-    and .result.process_info.pane_id == $pane
-  ' >/dev/null 2>&1 || return 1
+  fm_backend_herdr_pane_process_info_envelope_valid "$info" "$pane" || return 1
   shell_pid=$(printf '%s' "$info" | jq -er \
     '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
   foreground_pgid=$(printf '%s' "$info" | jq -er \
     '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
   [ "$foreground_pgid" = "$shell_pid" ] || return 1
   count=$(printf '%s' "$info" | jq -er \
-    '.result.process_info.foreground_processes | select(type == "array") | length' 2>/dev/null) || return 1
+    '.result.process_info.foreground_processes | length' 2>/dev/null) || return 1
   [ "$count" -eq 1 ] || return 1
   process_pid=$(printf '%s' "$info" | jq -er \
     '.result.process_info.foreground_processes[0].pid | select(type == "number") | floor' 2>/dev/null) || return 1

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1225,7 +1225,8 @@ fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
   shell_pid=$(printf '%s' "$info" | jq -er \
     '.result.process_info.shell_pid' 2>/dev/null) || return 1
   foreground_pgid=$(printf '%s' "$info" | jq -er \
-    '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
+    '.result.process_info.foreground_process_group_id
+      | select(type == "number" and . > 1 and . == floor)' 2>/dev/null) || return 1
   [ "$foreground_pgid" = "$shell_pid" ] || return 1
   count=$(printf '%s' "$info" | jq -er \
     '.result.process_info.foreground_processes | length' 2>/dev/null) || return 1

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -29,6 +29,8 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
 # shellcheck source=bin/fm-cursor-lib.sh
 . "$SCRIPT_DIR/fm-cursor-lib.sh"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$SCRIPT_DIR/fm-session-lock-lib.sh"
 
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
@@ -111,6 +113,8 @@ detect_own() {
       break
     fi
   done
+  echo "diagnostic: no verified harness marker or ancestry match; inspected process evidence follows" >&2
+  fm_harness_ancestry_diagnostic >&2
   echo unknown
 }
 

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -33,7 +33,11 @@ if [ "${1:-}" = "status" ]; then
   exit 0
 fi
 
-me=$(fm_harness_ancestry_pid) || { echo "error: cannot locate harness process in ancestry" >&2; exit 1; }
+me=$(fm_harness_ancestry_pid) || {
+  echo "error: cannot locate harness process in ancestry; inspected process evidence follows" >&2
+  fm_harness_ancestry_diagnostic >&2
+  exit 1
+}
 probe=$(mktemp "$STATE/.lock-write.XXXXXX" 2>/dev/null) || {
   echo "error: cannot write session lock; operate read-only until resolved" >&2
   exit 1

--- a/bin/fm-remote-harness-diagnostic.sh
+++ b/bin/fm-remote-harness-diagnostic.sh
@@ -44,10 +44,10 @@ INFO=$(fm_backend_herdr_cli "$SESSION" pane process-info --pane "$PANE" 2>/dev/n
 fm_backend_herdr_pane_process_info_envelope_valid "$INFO" "$PANE" \
   || die "Herdr process information envelope did not match pane $PANE"
 SHELL_PID=$(printf '%s' "$INFO" | jq -er \
-  '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) \
+  '.result.process_info.shell_pid' 2>/dev/null) \
   || die "Herdr did not report a valid pane shell PID"
 FOREGROUND=$(printf '%s' "$INFO" | jq -r \
-  '.result.process_info.foreground_processes[]?.pid | select(type == "number" and . > 1) | floor' 2>/dev/null) \
+  '.result.process_info.foreground_processes[].pid' 2>/dev/null) \
   || die "Herdr did not report foreground process IDs"
 HARNESS=$(fm_meta_get "$META" harness)
 

--- a/bin/fm-remote-harness-diagnostic.sh
+++ b/bin/fm-remote-harness-diagnostic.sh
@@ -41,6 +41,8 @@ PANE=$FM_BACKEND_HERDR_PANE
 
 INFO=$(fm_backend_herdr_cli "$SESSION" pane process-info --pane "$PANE" 2>/dev/null) \
   || die "could not read Herdr process information for pane $PANE in session $SESSION"
+fm_backend_herdr_pane_process_info_envelope_valid "$INFO" "$PANE" \
+  || die "Herdr process information envelope did not match pane $PANE"
 SHELL_PID=$(printf '%s' "$INFO" | jq -er \
   '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) \
   || die "Herdr did not report a valid pane shell PID"

--- a/bin/fm-remote-harness-diagnostic.sh
+++ b/bin/fm-remote-harness-diagnostic.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Inspect the live process evidence for one remote Herdr secondmate without
+# changing its home, endpoint, session, or process state.
+#
+# Usage: fm-remote-harness-diagnostic.sh <secondmate-id>
+#
+# The command is intended for bin/fm-on.sh.  It reads the host-local remote
+# endpoint record, asks Herdr for the pane's shell and foreground process IDs,
+# then prints each candidate's bounded parent chain through the shared session
+# lock matcher.  It never accepts an identity, writes a lock, or signals a
+# process; bin/fm-session-lock-lib.sh remains the only matcher owner.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+CONTROL_STATE="$FM_HOME/state/parent-route"
+
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$SCRIPT_DIR/fm-session-lock-lib.sh"
+
+usage() { sed -n '2,11p' "$0" | sed 's/^# \{0,1\}//' >&2; }
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+[ "$#" -eq 1 ] || { usage; exit 2; }
+ID=$1
+case "$ID" in ''|*[!A-Za-z0-9._-]*) die "invalid secondmate id: $ID" ;; esac
+
+META="$CONTROL_STATE/$ID.meta"
+fm_backend_validate_task_endpoint "$META" "$ID" 2>/dev/null \
+  || die "remote secondmate endpoint metadata is invalid"
+[ "$FM_BACKEND_VALIDATED_BACKEND" = herdr ] \
+  || die "remote secondmate endpoint is not on the Herdr backend"
+TARGET=$FM_BACKEND_VALIDATED_TARGET
+fm_backend_source herdr || die "could not load the Herdr backend adapter"
+fm_backend_herdr_parse_target "$TARGET" || die "remote Herdr endpoint target is invalid: $TARGET"
+SESSION=$FM_BACKEND_HERDR_SESSION
+PANE=$FM_BACKEND_HERDR_PANE
+
+INFO=$(fm_backend_herdr_cli "$SESSION" pane process-info --pane "$PANE" 2>/dev/null) \
+  || die "could not read Herdr process information for pane $PANE in session $SESSION"
+SHELL_PID=$(printf '%s' "$INFO" | jq -er \
+  '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) \
+  || die "Herdr did not report a valid pane shell PID"
+FOREGROUND=$(printf '%s' "$INFO" | jq -r \
+  '.result.process_info.foreground_processes[]?.pid | select(type == "number" and . > 1) | floor' 2>/dev/null) \
+  || die "Herdr did not report foreground process IDs"
+HARNESS=$(fm_meta_get "$META" harness)
+
+printf 'schema=fm-remote-harness-diagnostic.v1 id=%q target=%q harness=%q session=%q pane=%q shell_pid=%s\n' \
+  "$ID" "$TARGET" "$HARNESS" "$SESSION" "$PANE" "$SHELL_PID"
+printf 'source=herdr-pane-process-info foreground_pids=%q\n' "${FOREGROUND//$'\n'/ }"
+
+PIDS="$SHELL_PID"
+while IFS= read -r pid; do
+  case "$pid" in ''|*[!0-9]*|0|1) continue ;; esac
+  case " $PIDS " in *" $pid "*) ;; *) PIDS="$PIDS $pid" ;; esac
+done <<EOF
+$FOREGROUND
+EOF
+
+for pid in $PIDS; do
+  printf 'candidate_pid=%s\n' "$pid"
+  fm_harness_ancestry_diagnostic "$pid"
+done

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -25,6 +25,18 @@ FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
 # bin/fm-claude-stop-autoarm.sh.
 FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi)
 
+# Print the process argv[0] when Linux exposes it, otherwise use the first
+# token from ps args.  The fallback intentionally differs from Cursor's
+# argv0 helper: a session-lock matcher has ps args in hand and must preserve
+# that platform evidence when a portable test fixture has no /proc entry.
+fm_harness_argv0_for_pid() {  # <pid> <args>
+  local pid=$1 args=$2 proc_root=${FM_PROC_ROOT_OVERRIDE:-/proc} argv0=
+  if [ -r "$proc_root/$pid/cmdline" ]; then
+    IFS= read -r -d '' argv0 < "$proc_root/$pid/cmdline" || true
+  fi
+  printf '%s' "${argv0:-${args%% *}}"
+}
+
 # Print the exact harness name carried by executable path $1 - its own basename
 # or any directory component - or return 1.
 #
@@ -58,17 +70,23 @@ fm_harness_path_name() {  # <path>
 #   3. a bare interpreter (node, python) running a harness script path.
 #   4. Cursor's own structural identity, owned by bin/fm-cursor-lib.sh.
 FM_HARNESS_IS_CLAUDE=0
-fm_harness_process_matches() {  # <comm> <args>
+# The last accepted or rejected structural check.  Callers use this only for
+# a refusal diagnostic; it is deliberately not lock or dispatch authority.
+FM_HARNESS_MATCH_REASON=
+fm_harness_process_matches() {  # <comm> <args> [argv0]
   local comm=$1 args=$2 base argv0 name
   FM_HARNESS_IS_CLAUDE=0
+  FM_HARNESS_MATCH_REASON=
   base=$(basename -- "$comm")
   if printf '%s' "$base" | grep -qE "$FM_HARNESS_RE"; then
     case "$base" in *claude*) FM_HARNESS_IS_CLAUDE=1 ;; esac
+    FM_HARNESS_MATCH_REASON="accept:basename=$base"
     return 0
   fi
-  argv0=${args%% *}
+  argv0=${3:-${args%% *}}
   if name=$(fm_harness_path_name "$comm") || name=$(fm_harness_path_name "$argv0"); then
     case "$name" in claude) FM_HARNESS_IS_CLAUDE=1 ;; esac
+    FM_HARNESS_MATCH_REASON="accept:path-component=$name"
     return 0
   fi
   # Bare interpreter (e.g. node): match the harness name in its script path.
@@ -76,6 +94,7 @@ fm_harness_process_matches() {  # <comm> <args>
     *node*|*python*)
       if printf '%s' "$args" | grep -qE "$FM_HARNESS_RE"; then
         case "$args" in *claude*) FM_HARNESS_IS_CLAUDE=1 ;; esac
+        FM_HARNESS_MATCH_REASON="accept:interpreter-args"
         return 0
       fi
       ;;
@@ -84,8 +103,50 @@ fm_harness_process_matches() {  # <comm> <args>
   # in the command path or argv[0]. Without this a Cursor primary can never
   # locate its own harness in the ancestry, so every session start refuses the
   # fleet lock as read-only and the park can never arm.
-  fm_cursor_process_matches "$comm" "$args" "$argv0" && return 0
+  if fm_cursor_process_matches "$comm" "$args" "$argv0"; then
+    FM_HARNESS_MATCH_REASON="accept:cursor-structural"
+    return 0
+  fi
+  FM_HARNESS_MATCH_REASON="reject:basename,path-component,interpreter-args,cursor-structural"
   return 1
+}
+
+# Print a read-only, shell-escaped account of the ancestry inspection for PID
+# $1 (or this shell).  This is the diagnostic owner for both the lock refusal
+# and fm-harness's unknown result, so the evidence and matcher cannot drift.
+# A successful diagnostic means the inspection completed; result=none remains
+# a fail-closed absence of verified harness evidence.
+fm_harness_ancestry_diagnostic() {  # [pid]
+  local pid=${1:-$$} comm args ppid hop=0 matched=0 argv0
+  case "$pid" in ''|*[!0-9]*|0|1) printf 'result=invalid-start-pid pid=%q\n' "$pid"; return 1 ;; esac
+  printf 'schema=fm-harness-ancestry-diagnostic.v1 start_pid=%s max_hops=16\n' "$pid"
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+    hop=$((hop + 1))
+    if ! comm=$(ps -o comm= -p "$pid" 2>/dev/null); then
+      printf 'hop=%s pid=%s result=unreadable-process\n' "$hop" "$pid"
+      break
+    fi
+    args=$(ps -o args= -p "$pid" 2>/dev/null || true)
+    argv0=$(fm_harness_argv0_for_pid "$pid" "$args")
+    ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    if fm_harness_process_matches "$comm" "$args" "$argv0"; then
+      printf 'hop=%s pid=%s ppid=%q comm=%q argv0=%q args=%q match=%q\n' \
+        "$hop" "$pid" "$ppid" "$comm" "$argv0" "$args" "$FM_HARNESS_MATCH_REASON"
+      matched=1
+      [ "$FM_HARNESS_IS_CLAUDE" -eq 1 ] || break
+    else
+      printf 'hop=%s pid=%s ppid=%q comm=%q argv0=%q args=%q match=%q\n' \
+        "$hop" "$pid" "$ppid" "$comm" "$argv0" "$args" "$FM_HARNESS_MATCH_REASON"
+    fi
+    case "$ppid" in ''|*[!0-9]*|0|1) break ;; esac
+    pid=$ppid
+  done
+  if [ "$matched" -eq 1 ]; then
+    printf 'result=verified-harness-found\n'
+  else
+    printf 'result=no-verified-harness\n'
+  fi
+  return 0
 }
 
 # Walk the current process ancestry (up to 16 hops) and print this session's
@@ -107,11 +168,12 @@ fm_harness_process_matches() {  # <comm> <args>
 # session cannot be read off the ancestry at all, so the whole contiguous run is
 # reported and the callers below decide what they need from it.
 fm_harness_ancestry_pids() {
-  local pid=$$ comm args extending=0 printed=0
+  local pid=$$ comm args argv0 extending=0 printed=0
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
-    if fm_harness_process_matches "$comm" "$args"; then
+    argv0=$(fm_harness_argv0_for_pid "$pid" "$args")
+    if fm_harness_process_matches "$comm" "$args" "$argv0"; then
       printf '%s\n' "$pid"
       printed=1
       [ "$FM_HARNESS_IS_CLAUDE" -eq 1 ] || break
@@ -145,11 +207,12 @@ EOF
 
 # True if $1 is a live process that looks like a verified harness.
 fm_harness_pid_alive() {
-  local pid=$1 comm args
+  local pid=$1 comm args argv0
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   args=$(ps -o args= -p "$pid" 2>/dev/null)
-  fm_harness_process_matches "$comm" "$args"
+  argv0=$(fm_harness_argv0_for_pid "$pid" "$args")
+  fm_harness_process_matches "$comm" "$args" "$argv0"
 }
 
 # True when state dir $1 holds a session lock whose pid is ANY harness ancestor

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -117,7 +117,7 @@ fm_harness_process_matches() {  # <comm> <args> [argv0]
 # A successful diagnostic means the inspection completed; result=none remains
 # a fail-closed absence of verified harness evidence.
 fm_harness_ancestry_diagnostic() {  # [pid]
-  local pid=${1:-$$} comm args ppid hop=0 matched=0 argv0
+  local pid=${1:-$$} comm args ppid hop=0 matched=0 extending=0 argv0
   case "$pid" in ''|*[!0-9]*|0|1) printf 'result=invalid-start-pid pid=%q\n' "$pid"; return 1 ;; esac
   printf 'schema=fm-harness-ancestry-diagnostic.v1 start_pid=%s max_hops=16\n' "$pid"
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
@@ -134,9 +134,11 @@ fm_harness_ancestry_diagnostic() {  # [pid]
         "$hop" "$pid" "$ppid" "$comm" "$argv0" "$args" "$FM_HARNESS_MATCH_REASON"
       matched=1
       [ "$FM_HARNESS_IS_CLAUDE" -eq 1 ] || break
+      extending=1
     else
       printf 'hop=%s pid=%s ppid=%q comm=%q argv0=%q args=%q match=%q\n' \
         "$hop" "$pid" "$ppid" "$comm" "$argv0" "$args" "$FM_HARNESS_MATCH_REASON"
+      [ "$extending" -eq 0 ] || break
     fi
     case "$ppid" in ''|*[!0-9]*|0|1) break ;; esac
     pid=$ppid

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -182,6 +182,12 @@ When deduplication finds that the worker already moved the matching record into 
 The remote host runs no doorbell re-ring ladder of its own; a swallowed doorbell for an ordinary reply-bearing request surfaces through the parent's pending-reply recovery and escalation, whose recovery request rings the doorbell again when it is enqueued.
 `fm-peek.sh` and `fm-crew-state.sh` route remote-secondmate reads to the endpoint's host instead of consulting local worktree or backend state.
 An unreachable or unreadable remote read is unknown, not evidence that the endpoint is dead.
+The remote harness diagnostic is an instrument for inspecting the recorded Herdr pane's process ancestry, not a fix for session-lock refusal, and it preserves the existing fail-closed behavior.
+It becomes remotely invocable only after merge and the ordinary remote code-root update deploys the merged code to that host.
+
+```sh
+FM_HOME=<primary-home> bin/fm-on.sh <secondmate-id> fm-remote-harness-diagnostic.sh <secondmate-id>
+```
 
 Marked requests keep the existing correlation contract.
 The remote charter appends replies to `state/parent-replies.status` in the remote home.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -26,6 +26,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-job-worker.sh` | Long-lived remote queue worker for tracked `fm-*.sh` commands in the account runtime |
 | `fm-remote-job-reap-orphans.sh` | Stop remote job workers left running by a pruned code root, never one whose checkout still exists |
 | `fm-remote-doctor.sh`    | Check, and with `--fix` repair, one remote account's second-mate readiness (remote job worker, Herdr, Aqua launch agents, PATH, and required tools) |
+| `fm-remote-harness-diagnostic.sh` | Read Herdr foreground-process ancestry for one remote secondmate without changing endpoint or lock state |
 | `fm-backlog-handoff.sh`  | Move queued backlog items into a secondmate home and durably wake its recorded receiver |
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-captain-hold.sh`     | Hold tasks for the captain, record the captain's answers, gate investigation completion, and report record divergence between the status log and the backlog |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -41,7 +41,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` `@AGENTS.md` pointer, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
-| `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
+| `fm-session-lock-lib.sh` | Shared session-lock harness identity, holder liveness, and read-only ancestry diagnostics |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |

--- a/tests/fm-herdr-session-cleanup.test.sh
+++ b/tests/fm-herdr-session-cleanup.test.sh
@@ -53,7 +53,15 @@ if (
 ) >/dev/null 2>&1; then
   fail "non-string Herdr process argv was accepted"
 fi
-pass "process proof reads Linux Herdr argv arrays and rejects malformed executable identities"
+if (
+  # shellcheck disable=SC2329 # invoked indirectly by the idle-shell proof.
+  fm_backend_herdr_cli() { printf '%s\n' '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w2:p1","shell_pid":67,"foreground_process_group_id":67.9,"foreground_processes":[{"argv":["/bin/sh"],"name":"sh","pid":67}]}}}'; }
+  FM_HERDR_PS_BIN="$FAKE_PS" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    fm_backend_herdr_pane_idle_shell_pid test w2:p1
+) >/dev/null 2>&1; then
+  fail "fractional Herdr foreground process-group identity was accepted"
+fi
+pass "process proof reads Linux argv arrays and rejects malformed executable and process-group identities"
 
 TOKEN=AbCdEfGhIjKlMnOpQrStUv
 ID=task

--- a/tests/fm-remote-harness-diagnostic.test.sh
+++ b/tests/fm-remote-harness-diagnostic.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Read-only remote Herdr harness-diagnostic coverage.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (the Herdr diagnostic parses JSON)"; exit 0; }
+
+TMP_ROOT=$(fm_test_tmproot fm-remote-harness-diagnostic)
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+
+test_remote_harness_diagnostic_reports_herdr_foreground_ancestry() {
+  local dir home fakebin out
+  dir="$TMP_ROOT/foreground"
+  home="$dir/home"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$home/state/parent-route"
+  cat > "$home/state/parent-route/alienware-ml.meta" <<'EOF'
+window=fm-remote:w3:p2
+endpoint_task_id=alienware-ml
+worktree=/home/think/fm-homes/alienware-ml
+project=/home/think/firstmate
+backend=herdr
+herdr_session=fm-remote
+herdr_workspace_id=w3
+herdr_tab_id=t3
+herdr_pane_id=w3:p2
+harness=codex
+EOF
+  cat > "$fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *' pane process-info '*)
+    printf '%s\n' '{"result":{"type":"pane_process_info","process_info":{"shell_pid":701,"foreground_processes":[{"pid":702}]}}}'
+    ;;
+  *) exit 1 ;;
+esac
+SH
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  701:comm=) printf '%s\n' bash ;;
+  701:args=) printf '%s\n' 'bash -l' ;;
+  701:ppid=) printf '%s\n' 1 ;;
+  702:comm=) printf '%s\n' node ;;
+  702:args=) printf '%s\n' 'node /opt/openai/codex/bin/agent.js' ;;
+  702:ppid=) printf '%s\n' 701 ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$fakebin/herdr" "$fakebin/ps"
+
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" PATH="$fakebin:$BASE_PATH" \
+    "$ROOT/bin/fm-remote-harness-diagnostic.sh" alienware-ml) \
+    || fail "read-only remote diagnostic could not inspect a valid Herdr endpoint"
+  assert_contains "$out" 'schema=fm-remote-harness-diagnostic.v1' \
+    "diagnostic identifies its public output protocol"
+  assert_contains "$out" 'source=herdr-pane-process-info foreground_pids=702' \
+    "diagnostic reports Herdr's foreground process evidence"
+  assert_contains "$out" 'candidate_pid=702' \
+    "diagnostic inspects the live foreground candidate rather than its own worker process"
+  assert_contains "$out" 'comm=node' \
+    "diagnostic retains the observed kernel command name"
+  assert_contains "$out" 'args=node\ /opt/openai/codex/bin/agent.js' \
+    "diagnostic retains the observed process arguments"
+  assert_contains "$out" 'result=verified-harness-found' \
+    "diagnostic delegates classification to the shared matcher"
+  pass "remote harness diagnostic: Herdr foreground process ancestry is inspected without a remote write"
+}
+
+test_remote_harness_diagnostic_reports_herdr_foreground_ancestry

--- a/tests/fm-remote-harness-diagnostic.test.sh
+++ b/tests/fm-remote-harness-diagnostic.test.sh
@@ -9,6 +9,7 @@ command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (the Herdr diagnosti
 
 TMP_ROOT=$(fm_test_tmproot fm-remote-harness-diagnostic)
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+export FM_PROC_ROOT_OVERRIDE="$TMP_ROOT/fixture-proc-unavailable"
 
 test_remote_harness_diagnostic_reports_herdr_foreground_ancestry() {
   local dir home fakebin out
@@ -106,7 +107,11 @@ SH
     '{"result":{"type":"other","process_info":{"pane_id":"w3:p2","shell_pid":701,"foreground_processes":[]}}}' \
     '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w9:p9","shell_pid":701,"foreground_processes":[]}}}' \
     '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w3:p2","shell_pid":701}}}' \
-    '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w3:p2","shell_pid":701,"foreground_processes":{}}}}'
+    '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w3:p2","shell_pid":701,"foreground_processes":{}}}}' \
+    '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w3:p2","shell_pid":701.9,"foreground_processes":[]}}}' \
+    '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w3:p2","shell_pid":1,"foreground_processes":[]}}}' \
+    '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w3:p2","shell_pid":701,"foreground_processes":[{"pid":702.9}]}}}' \
+    '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w3:p2","shell_pid":701,"foreground_processes":[{"pid":1}]}}}'
   do
     status=0
     out=$(FM_TEST_HERDR_RESPONSE="$response" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \

--- a/tests/fm-remote-harness-diagnostic.test.sh
+++ b/tests/fm-remote-harness-diagnostic.test.sh
@@ -32,7 +32,7 @@ EOF
 #!/usr/bin/env bash
 case " $* " in
   *' pane process-info '*)
-    printf '%s\n' '{"result":{"type":"pane_process_info","process_info":{"shell_pid":701,"foreground_processes":[{"pid":702}]}}}'
+    printf '%s\n' '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w3:p2","shell_pid":701,"foreground_processes":[{"pid":702}]}}}'
     ;;
   *) exit 1 ;;
 esac
@@ -78,4 +78,48 @@ SH
   pass "remote harness diagnostic: Herdr foreground process ancestry is inspected without a remote write"
 }
 
+test_remote_harness_diagnostic_rejects_invalid_process_info_envelopes() {
+  local dir home fakebin response out status
+  dir="$TMP_ROOT/invalid-envelope"
+  home="$dir/home"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$home/state/parent-route"
+  cat > "$home/state/parent-route/alienware-ml.meta" <<'EOF'
+window=fm-remote:w3:p2
+endpoint_task_id=alienware-ml
+worktree=/home/think/fm-homes/alienware-ml
+project=/home/think/firstmate
+backend=herdr
+herdr_session=fm-remote
+herdr_workspace_id=w3
+herdr_tab_id=t3
+herdr_pane_id=w3:p2
+harness=codex
+EOF
+  cat > "$fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$FM_TEST_HERDR_RESPONSE"
+SH
+  chmod +x "$fakebin/herdr"
+
+  for response in \
+    '{"result":{"type":"other","process_info":{"pane_id":"w3:p2","shell_pid":701,"foreground_processes":[]}}}' \
+    '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w9:p9","shell_pid":701,"foreground_processes":[]}}}' \
+    '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w3:p2","shell_pid":701}}}' \
+    '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w3:p2","shell_pid":701,"foreground_processes":{}}}}'
+  do
+    status=0
+    out=$(FM_TEST_HERDR_RESPONSE="$response" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+      PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-remote-harness-diagnostic.sh" alienware-ml 2>&1) \
+      || status=$?
+    [ "$status" -ne 0 ] || fail "diagnostic accepted an invalid Herdr process-info envelope"
+    assert_contains "$out" 'error: Herdr process information envelope did not match pane w3:p2' \
+      "diagnostic names the rejected Herdr pane-process envelope"
+    assert_not_contains "$out" 'schema=fm-remote-harness-diagnostic.v1' \
+      "diagnostic emits no evidence for an invalid Herdr process-info envelope"
+  done
+  pass "remote harness diagnostic: malformed or mismatched Herdr process-info envelopes are rejected"
+}
+
 test_remote_harness_diagnostic_reports_herdr_foreground_ancestry
+test_remote_harness_diagnostic_rejects_invalid_process_info_envelopes

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -63,6 +63,7 @@ BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 fm_git_identity fmtest fmtest@example.com
 TMP_ROOT=$(fm_test_tmproot fm-secondmate-harness)
 export FM_BACKEND=tmux
+export FM_PROC_ROOT_OVERRIDE="$TMP_ROOT/fixture-proc-unavailable"
 
 # ===========================================================================
 # A) fm-harness.sh secondmate resolution + fallback (deterministic detect_own)

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -121,6 +121,32 @@ SH
   pass "fm-harness detects only Cursor Agent CLI's exact invocation marker"
 }
 
+test_unknown_harness_prints_observed_evidence() {
+  local dir fakebin out err
+  dir="$TMP_ROOT/unknown-harness-diagnostic"
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *'comm='*) printf '%s\n' herdr-worker ;;
+  *'args='*) printf '%s\n' 'herdr worker --lane remote' ;;
+  *'ppid='*) printf '%s\n' 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  err="$dir/fm-harness.err"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh" 2>"$err")
+  [ "$out" = unknown ] || fail "unrecognized process must still resolve to unknown, got '$out'"
+  assert_contains "$(cat "$err")" 'no verified harness marker or ancestry match' \
+    "unknown harness explains why it did not identify a runtime"
+  assert_contains "$(cat "$err")" 'comm=herdr-worker' \
+    "unknown harness reports the observed command"
+  assert_contains "$(cat "$err")" 'result=no-verified-harness' \
+    "unknown harness reports the fail-closed terminal"
+  pass "fm-harness: unknown output carries observed process evidence on stderr"
+}
+
 # ===========================================================================
 # C) fm-harness.sh secondmate-model / secondmate-effort token resolution
 # ===========================================================================
@@ -2549,6 +2575,7 @@ SH
 
 test_harness_resolution
 test_cursor_marker_detection
+test_unknown_harness_prints_observed_evidence
 test_secondmate_model_effort_tokens
 test_pi_signed_detection_and_session_lock_identity
 test_dash_leading_process_names_are_basename_operands

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -220,6 +220,58 @@ SH
   pass "session-lock: a live version-named session holding the lock is not mistaken for a stale owner"
 }
 
+test_unrecognized_ancestry_refuses_with_observed_evidence() {
+  local dir fakebin out err status home
+  dir="$TMP_ROOT/unrecognized-diagnostic"
+  fakebin=$(fm_fakebin "$dir")
+  home="$dir/home"
+  mkdir -p "$home/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  701:comm=) printf '%s\n' herdr-worker ;;
+  701:args=) printf '%s\n' 'herdr worker --lane remote' ;;
+  701:ppid=) printf '%s\n' 702 ;;
+  702:comm=) printf '%s\n' bash ;;
+  702:args=) printf '%s\n' 'bash /opt/remote-job/worker.sh' ;;
+  702:ppid=) printf '%s\n' 1 ;;
+  *:comm=) printf '%s\n' herdr-worker ;;
+  *:args=) printf '%s\n' 'herdr worker --lane remote' ;;
+  *:ppid=) printf '%s\n' 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(PATH="$fakebin:$PATH" bash -c '. "$0"; fm_harness_ancestry_diagnostic 701' "$LIB") \
+    || fail "the read-only ancestry diagnostic failed"
+  assert_contains "$out" 'pid=701' "diagnostic names the inspected pid"
+  assert_contains "$out" 'comm=herdr-worker' "diagnostic names the observed command"
+  assert_contains "$out" 'args=herdr\ worker\ --lane\ remote' "diagnostic names the observed arguments"
+  assert_contains "$out" 'match=reject:basename\,path-component\,interpreter-args\,cursor-structural' \
+    "diagnostic names every rejected shared-matcher check"
+  assert_contains "$out" 'result=no-verified-harness' "diagnostic preserves fail-closed absence of identity"
+
+  err="$dir/fm-lock.err"
+  PATH="$fakebin:$PATH" FM_HOME="$home" "$ROOT/bin/fm-lock.sh" >"$dir/fm-lock.out" 2>"$err"
+  status=$?
+  expect_code 1 "$status" "unrecognized ancestry must still refuse the session lock"
+  assert_contains "$(cat "$err")" 'inspected process evidence follows' \
+    "lock refusal directs the operator to the diagnostic evidence"
+  assert_contains "$(cat "$err")" 'comm=herdr-worker' \
+    "lock refusal includes the observed command"
+  [ ! -e "$home/state/.lock" ] || fail "unrecognized ancestry wrote a session lock"
+  pass "session-lock: unrecognized process ancestry refuses loudly with observed matcher evidence"
+}
+
 # --- end-to-end layer: the real Stop auto-arm in real process trees ----------
 
 install_autoarm_scripts() {
@@ -360,6 +412,7 @@ test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
+test_unrecognized_ancestry_refuses_with_observed_evidence
 test_e2e_version_named_session_claims_the_home
 test_e2e_daemon_parented_session_claims_the_home
 test_e2e_daemon_parented_version_named_session_keeps_its_lock

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -20,6 +20,7 @@ TMP_ROOT=$(fm_test_tmproot fm-session-lock-ancestry)
 fm_git_identity fmtest fmtest@example.invalid
 
 LIB="$ROOT/bin/fm-session-lock-lib.sh"
+FAKE_PROC_ROOT="$TMP_ROOT/fixture-proc-unavailable"
 
 # Claude Code's native installer names the per-session executable by its version,
 # so the harness identity has to survive a basename that says nothing.
@@ -38,7 +39,7 @@ NAMED_CLAUDE="$FAKEBIN/claude"
 # liveness questions are decided by the process table alone.
 lib_eval() {  # <fakebin> <expression>
   local fakebin=$1 expr=$2
-  PATH="$fakebin:$PATH" bash -c "
+  FM_PROC_ROOT_OVERRIDE="$FAKE_PROC_ROOT" PATH="$fakebin:$PATH" bash -c "
     . \"\$0\"
     kill() { return 0; }
     $expr
@@ -135,7 +136,7 @@ SH
 }
 
 test_harness_beyond_a_gap_never_owns_the_lock() {
-  local dir fakebin got
+  local dir fakebin got diagnostic
   dir="$TMP_ROOT/gap"
   fakebin=$(fm_fakebin "$dir")
   mkdir -p "$dir/state"
@@ -176,6 +177,12 @@ SH
   printf '900\n' > "$dir/state/.lock"
   lib_eval "$fakebin" "fm_session_lock_owned_by_self '$dir/state'" \
     || fail "the contiguous harness run did not recognize its own lock"
+  diagnostic=$(lib_eval "$fakebin" 'fm_harness_ancestry_diagnostic 900') \
+    || fail "the gap diagnostic could not inspect the contiguous harness run"
+  assert_contains "$diagnostic" 'pid=910' \
+    "diagnostic reports the non-harness gap that ends the contiguous run"
+  assert_not_contains "$diagnostic" 'hop=3 pid=920' \
+    "diagnostic does not cross the non-harness gap into an unrelated harness"
   pass "session-lock: ownership stops at the first non-harness gap above the contiguous run"
 }
 
@@ -251,7 +258,8 @@ esac
 SH
   chmod +x "$fakebin/ps"
 
-  out=$(PATH="$fakebin:$PATH" bash -c '. "$0"; fm_harness_ancestry_diagnostic 701' "$LIB") \
+  out=$(FM_PROC_ROOT_OVERRIDE="$FAKE_PROC_ROOT" PATH="$fakebin:$PATH" \
+    bash -c '. "$0"; fm_harness_ancestry_diagnostic 701' "$LIB") \
     || fail "the read-only ancestry diagnostic failed"
   assert_contains "$out" 'pid=701' "diagnostic names the inspected pid"
   assert_contains "$out" 'comm=herdr-worker' "diagnostic names the observed command"
@@ -261,7 +269,8 @@ SH
   assert_contains "$out" 'result=no-verified-harness' "diagnostic preserves fail-closed absence of identity"
 
   err="$dir/fm-lock.err"
-  PATH="$fakebin:$PATH" FM_HOME="$home" "$ROOT/bin/fm-lock.sh" >"$dir/fm-lock.out" 2>"$err"
+  FM_PROC_ROOT_OVERRIDE="$FAKE_PROC_ROOT" PATH="$fakebin:$PATH" FM_HOME="$home" \
+    "$ROOT/bin/fm-lock.sh" >"$dir/fm-lock.out" 2>"$err"
   status=$?
   expect_code 1 "$status" "unrecognized ancestry must still refuse the session lock"
   assert_contains "$(cat "$err")" 'inspected process evidence follows' \


### PR DESCRIPTION
## Intent

A remote Herdr secondmate running Codex on Linux refuses its own Firstmate session lock because harness detection returns unknown and the lock ancestry matcher finds no verified process. This stage deliberately ships an instrument, not the lock-refusal fix: add a read-only fm-* diagnostic invocable through fm-on after it lands, using the recorded remote Herdr endpoint to inspect the pane shell and foreground process IDs plus each bounded parent chain. The output must report every PID walked, observed comm, argv0 and args, and the specific shared-matcher check that accepted or rejected it. fm-harness unknown and fm-lock refusal must emit the same self-describing evidence while retaining their existing fail-closed behavior. Do not accept generic node or any unrecognized process, do not bypass ancestry, do not mutate or lock a live remote home, and keep the shared matcher as the one owner. Colocated tests must cover remote Herdr foreground inspection, unknown output diagnostics, and refusal with no lock write. Document that deployment requires the normal merged remote code-root update before fm-on can execute the helper remotely.

## What Changed

- Add a read-only remote Herdr diagnostic that validates the recorded endpoint and reports bounded ancestry for pane shell and foreground process IDs.
- Centralize structured `comm`, `argv0`, arguments, and matcher-result evidence, surfacing it for unknown harness detection and lock refusal while preserving fail-closed behavior.
- Document remote deployment and `fm-on` invocation, with coverage for foreground inspection, malformed responses, unknown ancestry, and refusal without writing a lock.

## Risk Assessment

✅ Low: Captain, the read-only diagnostic is well-bounded, preserves fail-closed lock behavior, and the prior review fixes now align with the shared matcher and stated intent.

## Testing

Change-specific automated suites and end-user CLI checks passed with three reviewer-visible transcripts. An additional broad fm-on run encountered an unrelated pre-existing remote-doctor fixture omission after its relevant transport checks passed; no source changes or transient worktree artifacts remain.

<details>
<summary>Evidence: End-to-end fm-on remote diagnostic</summary>

Source: [End-to-end fm-on remote diagnostic](https://github.com/stanzhang/firstmate/blob/aa103bc96e4de3d4a3e91896edfe6f953df1f2b9/.no-mistakes/evidence/fm/fm-remote-harness-ancestry-detection/remote-harness-fm-on-transcript.txt)

```text
COMMAND: FM_HOME=<primary-home> bin/fm-on.sh ios fm-remote-harness-diagnostic.sh ios
schema=fm-remote-harness-diagnostic.v1 id=ios target=fm-remote:w3:p2 harness=codex session=fm-remote pane=w3:p2 shell_pid=701
source=herdr-pane-process-info foreground_pids=702
candidate_pid=701
schema=fm-harness-ancestry-diagnostic.v1 start_pid=701 max_hops=16
hop=1 pid=701 ppid=1 comm=bash argv0=bash args=bash\ -l match=reject:basename\,path-component\,interpreter-args\,cursor-structural
result=no-verified-harness
candidate_pid=702
schema=fm-harness-ancestry-diagnostic.v1 start_pid=702 max_hops=16
hop=1 pid=702 ppid=701 comm=node argv0=node args=node\ /opt/openai/codex/bin/agent.js match=accept:interpreter-args
result=verified-harness-found
```
</details>
<details>
<summary>Evidence: Fail-closed harness and lock refusal</summary>

Source: [Fail-closed harness and lock refusal](https://github.com/stanzhang/firstmate/blob/aa103bc96e4de3d4a3e91896edfe6f953df1f2b9/.no-mistakes/evidence/fm/fm-remote-harness-ancestry-detection/harness-fail-closed-transcript.txt)

```text
COMMAND: bin/fm-harness.sh (unrecognized remote worker ancestry)
diagnostic: no verified harness marker or ancestry match; inspected process evidence follows
schema=fm-harness-ancestry-diagnostic.v1 start_pid=50151 max_hops=16
hop=1 pid=50151 ppid=1 comm=herdr-worker argv0=herdr args=herdr\ worker\ --lane\ remote match=reject:basename\,path-component\,interpreter-args\,cursor-structural
result=no-verified-harness
unknown
fm-harness_exit=0

COMMAND: FM_HOME=<remote-home> bin/fm-lock.sh (same unrecognized ancestry)
error: cannot locate harness process in ancestry; inspected process evidence follows
schema=fm-harness-ancestry-diagnostic.v1 start_pid=50267 max_hops=16
hop=1 pid=50267 ppid=1 comm=herdr-worker argv0=herdr args=herdr\ worker\ --lane\ remote match=reject:basename\,path-component\,interpreter-args\,cursor-structural
result=no-verified-harness
fm-lock_exit=1
lock_file=absent (fail-closed; no lock write)
```
</details>
<details>
<summary>Evidence: Fractional Herdr PID rejection</summary>

Source: [Fractional Herdr PID rejection](https://github.com/stanzhang/firstmate/blob/aa103bc96e4de3d4a3e91896edfe6f953df1f2b9/.no-mistakes/evidence/fm/fm-remote-harness-ancestry-detection/herdr-invalid-pid-envelope-transcript.txt)

```text
COMMAND: fm-remote-harness-diagnostic.sh alienware-ml (Herdr shell_pid=701.9)
error: Herdr process information envelope did not match pane w3:p2
exit=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ee900d5d9c8f4fbef28b6e154bbd38418ef0b744","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-remote-harness-diagnostic.sh:42` - Validate `.result.type`, `.result.process_info.pane_id`, and that `foreground_processes` is an array before emitting evidence. A successful but mismatched/malformed Herdr response currently gets labeled as belonging to the recorded pane, while a missing foreground array silently becomes an empty PID list. Reuse the response-envelope checks already enforced by `fm_backend_herdr_pane_idle_shell_sample`.
- 🚨 `docs/scripts.md:29` - The required criterion says: “Document that deployment requires the normal merged remote code-root update before fm-on can execute the helper remotely.” The changed documentation only inventories the helper and omits that deployment prerequisite and its `fm-on` invocation. Add the prerequisite and command example to the remote-secondmate documentation.

🔧 Fix: Validate Herdr envelopes and document remote deployment
3 issues (2 errors, 1 warning) still open:

- 🚨 `bin/fm-session-lock-lib.sh:137` - Make the diagnostic stop at the same non-harness gap as the authoritative ancestry matcher. For `bash -&gt; claude(900) -&gt; bash(910) -&gt; claude(920)`, `fm_harness_ancestry_pids` excludes PID 920, but this diagnostic continues past PID 910 and reports the unrelated PID 920 as accepted. Reuse the shared traversal policy or carry the same `extending` state.
- 🚨 `bin/fm-remote-harness-diagnostic.sh:47` - Reject malformed PID values instead of flooring them. A Herdr response containing `shell_pid: 701.9` or foreground PID `702.9` silently inspects unrelated OS PID 701 or 702. Tighten the shared process-info envelope to require integer PIDs greater than 1 for the shell and every foreground entry.
- ⚠️ `bin/fm-session-lock-lib.sh:34` - Isolate fake-process-table tests from the host `/proc`. The new argv0 helper reads real `/proc/&lt;pid&gt;/cmdline` even when `ps` is faked, so an existing host PID such as 700 can be combined with fixture comm/args and make the tests nondeterministic. Set `FM_PROC_ROOT_OVERRIDE` to a fixture-controlled absent or synthetic proc root in these tests.

🔧 Fix: Align ancestry diagnostics and validate Herdr process PIDs
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-remote-harness-diagnostic.test.sh`
- `bin/fm-test-run.sh tests/fm-session-lock-ancestry.test.sh`
- <code>Focused invocation of `test_unknown_harness_prints_observed_evidence` under Bash</code>
- <code>`bin/fm-test-run.sh tests/fm-on.test.sh` (relevant transport assertions passed; a later, base-identical remote-doctor fixture failed because it omits `fm-composer-lib.sh`)</code>
- <code>Fixture-backed `FM_HOME=&lt;primary-home&gt; bin/fm-on.sh ios fm-remote-harness-diagnostic.sh ios`</code>
- <code>Manual `bin/fm-harness.sh` unknown-detection check</code>
- <code>Manual `FM_HOME=&lt;remote-home&gt; bin/fm-lock.sh` refusal and `.lock` absence check</code>
- <code>Manual `shell_pid=701.9` Herdr-envelope rejection check</code>
- <code>`git status --short` and `git diff --exit-code -- .`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
