### PR TITLE
feat(brief): require a named test scope and a pushed branch in crewmate briefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 ### PR ready, landing, and teardown
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
+A completion report with no pushed branch behind it is not a delivery, whatever it claims: send that worker straight back to finish the push and the PR rather than recording the task as done.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine merge authority.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,6 +510,7 @@ Preserve durable structured identifiers, dependencies, and completion artifact l
 
 `bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, delivery-mode definitions of done, and exact safety mechanics.
 Use its scaffold as the contract, then replace every `{TASK}` placeholder with a clear task description, acceptance criteria, constraints, and necessary context before dispatch or seeding.
+Every crewmate brief also requires an explicit `--test-scope` naming the tests that task should run, or the reserved `full` value when the whole suite is genuinely warranted, so a full-suite run is always a stated decision rather than a scope-less worker's default.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,7 +363,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 ### PR ready, landing, and teardown
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
-A completion report with no pushed branch behind it is not a delivery, whatever it claims: send that worker straight back to finish the push and the PR rather than recording the task as done.
+A completion report that does not meet its mode's Definition of done is not a delivery, whatever it claims: send that worker straight back to finish it rather than recording the task as done.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine merge authority.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -60,7 +60,7 @@
 # pushed branch whose done line carries the full https PR URL, and local-only is done only
 # at a complete committed branch. This scaffold emits text and cannot observe a git push,
 # so it makes no attempt to verify one; enforcement is firstmate sending back a completion
-# report with no pushed branch behind it (AGENTS.md section 7).
+# report that does not meet its mode's Definition of done (AGENTS.md section 7).
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns merge decisions, so yolo is
@@ -509,9 +509,9 @@ $RULE1
    A mid-task \`working:\` line (including setup complete) is nonterminal: do not end the
    turn after it; continue the same stage until a defined \`done:\` gate under Definition of done,
    or until an explicit handoff stop that Definition of done names.
-   Before you write a \`done:\` line, check it against Definition of done: a \`done:\` with no pushed
-   branch behind it is not a delivery and will be sent straight back to you. Firstmate can only
-   evaluate, merge, and deploy work it can actually see.
+   Before you write a \`done:\` line, check it against Definition of done: a \`done:\` that does not
+   meet Definition of done's bar is not a delivery and will be sent straight back to you. Firstmate
+   can only evaluate, merge, and deploy work it can actually see.
    Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,8 +6,8 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
-#        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> --test-scope <scope> [--herdr-lab]
+#        fm-brief.sh <task-id> <repo-name> --scout --test-scope <scope> [--herdr-lab]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
@@ -22,6 +22,20 @@
 #   omitting both still fails loudly so an accidental omission is never silent.
 #   Set FM_SECONDMATE_CHARTER='<charter>' to fill the charter text.
 #   Set FM_SECONDMATE_SCOPE='<scope>' to write a routing scope distinct from the charter text.
+#   --test-scope is REQUIRED on every crewmate brief and names the tests the worker
+#   may run. It exists because a worker with no named scope runs the whole suite,
+#   and suite time and model quota are both scarce. Pass the concrete suites,
+#   paths, or command for this task, e.g. --test-scope 'tests/panel/'. A
+#   genuinely broad task passes the reserved value `full` (or `full: <why>`),
+#   which renders the section as a deliberate full-suite choice rather than a
+#   narrow scope. Both spellings are a positive statement, so an unnamed scope
+#   cannot reach a worker as a silent default; there is no placeholder form,
+#   because a placeholder that survives into a dispatched brief is worth nothing.
+#   The scaffolded text stays generic and never names any repo's suites: this
+#   script is given a caller-supplied repo string it cannot resolve, so the
+#   concrete suite names belong in the value, supplied by whoever knows the project.
+#   --test-scope is refused on a secondmate charter, which dispatches no tests of
+#   its own and briefs its own crewmates.
 #   --herdr-lab is mandatory when the task will issue Herdr lifecycle commands.
 #   It adds the hard isolation contract backed by bin/fm-herdr-lab.sh.
 #   The flag must be explicit because {TASK} is filled after scaffolding and the
@@ -111,6 +125,8 @@ HERDR_LAB=0
 NO_PROJECTS=0
 MODE=
 MODE_SET=0
+TEST_SCOPE=
+TEST_SCOPE_SET=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -120,6 +136,7 @@ for a in "$@"; do
     esac
     case "$want_value" in
       mode) MODE=$a; MODE_SET=1 ;;
+      test-scope) TEST_SCOPE=$a; TEST_SCOPE_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -132,6 +149,8 @@ for a in "$@"; do
     --no-projects) NO_PROJECTS=1 ;;
     --mode) want_value=mode ;;
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
+    --test-scope) want_value=test-scope ;;
+    --test-scope=*) TEST_SCOPE=${a#--test-scope=}; TEST_SCOPE_SET=1 ;;
     # yolo never reaches the worker: it is firstmate's merge authority, not a
     # brief input. Refuse it loudly so it is never silently dropped here and then
     # believed to have been recorded.
@@ -158,6 +177,25 @@ if [ "$KIND" = ship ]; then
 elif [ "$MODE_SET" -eq 1 ]; then
   echo "error: --mode applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract" >&2
   exit 1
+fi
+
+# A crewmate with no named test scope runs everything, so the scope is a required
+# positive statement rather than a placeholder: `full` deliberately authorizes the
+# whole suite, and any other value names what to run instead.
+if [ "$KIND" = secondmate ]; then
+  [ "$TEST_SCOPE_SET" -eq 0 ] || {
+    echo "error: --test-scope applies only to crewmate ship and scout briefs; a charter dispatches no tests of its own and briefs its own crewmates" >&2
+    exit 1
+  }
+else
+  [ "$TEST_SCOPE_SET" -eq 1 ] || {
+    echo "error: crewmate briefs require --test-scope <scope>; name the tests this task should run (e.g. --test-scope 'tests/panel/'), or --test-scope full to deliberately authorize the whole suite" >&2
+    exit 1
+  }
+  case "$TEST_SCOPE" in
+    *[![:space:]]*) ;;
+    *) echo "error: --test-scope must name a scope; pass the tests to run, or --test-scope full to deliberately authorize the whole suite" >&2; exit 1 ;;
+  esac
 fi
 ID=${POS[0]}
 
@@ -289,6 +327,41 @@ fi
 
 REPO=${POS[1]}
 
+# Test scope, rendered for ship and scout alike. `full` and `full: <why>` are the
+# reserved broad spellings that make an intentional whole-suite run visible as a
+# choice; every other value is the concrete list of tests the worker may run.
+# The wording stays generic on purpose: this script cannot resolve the
+# caller-supplied repo string, so the suite names live in the value.
+TEST_SCOPE_LOWER=$(printf '%s' "$TEST_SCOPE" | tr '[:upper:]' '[:lower:]')
+TEST_SCOPE_REASON=
+case "$TEST_SCOPE_LOWER" in
+  full) TEST_SCOPE_BROAD=1 ;;
+  full:*)
+    TEST_SCOPE_BROAD=1
+    TEST_SCOPE_REASON=${TEST_SCOPE#*:}
+    TEST_SCOPE_REASON=${TEST_SCOPE_REASON#"${TEST_SCOPE_REASON%%[![:space:]]*}"}
+    ;;
+  *) TEST_SCOPE_BROAD=0 ;;
+esac
+
+if [ "$TEST_SCOPE_BROAD" -eq 1 ]; then
+IFS= read -r -d '' TEST_SCOPE_SECTION <<EOF || true
+# Test scope - FULL SUITE, deliberately
+This task runs the whole test suite.${TEST_SCOPE_REASON:+ Reason: $TEST_SCOPE_REASON}
+That is an explicit decision recorded for this task, not the default: every other brief names the specific tests to run, because suite time and model quota are both scarce.
+This governs the tests you run yourself; the delivery path still runs whatever it is configured to run.
+EOF
+else
+IFS= read -r -d '' TEST_SCOPE_SECTION <<EOF || true
+# Test scope - run ONLY these
+$TEST_SCOPE
+Do not run the full suite. Suite time and model quota are both scarce, and a change confined to this area does not need every unrelated suite run against it.
+This governs the tests you run yourself; the delivery path still runs whatever it is configured to run.
+If the work turns out to depend on something outside this scope, run the specific extra tests you actually need and say why in your final summary - never fall back to running everything.
+EOF
+fi
+TEST_SCOPE_SECTION=${TEST_SCOPE_SECTION%$'\n'}
+
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
 # shellcheck disable=SC2016  # single quotes are deliberate: these lines are literal brief text whose backtick-wrapped $(...) and "$HERDR_LAB_SESSION" snippets must reach the reading agent verbatim, not expand at scaffold time; only the '"$VAR"' break-outs interpolate.
@@ -329,6 +402,8 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 {TASK}
 
 $HERDR_SECTION
+
+$TEST_SCOPE_SECTION
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
@@ -402,6 +477,8 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 {TASK}
 
 $HERDR_SECTION
+
+$TEST_SCOPE_SECTION
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -55,6 +55,12 @@
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Every ship mode's definition of done requires a branch firstmate can actually act on,
+# stated as a contract rather than advice: no-mistakes and direct-PR are done only at a
+# pushed branch whose done line carries the full https PR URL, and local-only is done only
+# at a complete committed branch. This scaffold emits text and cannot observe a git push,
+# so it makes no attempt to verify one; enforcement is firstmate sending back a completion
+# report with no pushed branch behind it (AGENTS.md section 7).
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns merge decisions, so yolo is
@@ -501,7 +507,11 @@ $RULE1
    needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
    firstmate reads your pane for that.
    A mid-task \`working:\` line (including setup complete) is nonterminal: do not end the
-   turn after it; continue the same stage until a defined \`done:\` gate under Definition of done.
+   turn after it; continue the same stage until a defined \`done:\` gate under Definition of done,
+   or until an explicit handoff stop that Definition of done names.
+   Before you write a \`done:\` line, check it against Definition of done: a \`done:\` with no pushed
+   branch behind it is not a delivery and will be sent straight back to you. Firstmate can only
+   evaluate, merge, and deploy work it can actually see.
    Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -21,8 +21,11 @@ fm_dod_block() {  # <mode> <task-id>
 # Definition of done
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+**Done means a PUSHED branch with a PR behind it. A local commit is not done.**
+A commit that exists only in this disposable worktree has reached nobody: firstmate has nothing to
+evaluate, merge, or deploy, and the worktree cannot even be cleaned up while it holds unlanded work.
+When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append
+\`done: PR {url}\` to the status file and stop. That line MUST carry the full \`https://...\` PR URL.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
       ;;
@@ -31,9 +34,12 @@ EOF
 # Definition of done
 Delivery contract: mode=local-only
 This task ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$id\`. Do NOT push, do NOT open a PR, do NOT merge.
+**Done means a COMPLETE, COMMITTED \`fm/$id\` branch that firstmate can merge. Uncommitted work is not done.**
+Firstmate cannot merge what it cannot see, and this mode has no remote to fall back on: everything you
+intend to land must be committed on that branch before you report done.
+Do NOT push to any remote, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$id\` to the status file and stop.
+When it is implemented and committed, verify nothing is left behind with \`git status --porcelain\`, then append \`done: ready in branch fm/$id\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
       ;;
@@ -41,9 +47,15 @@ EOF
       cat <<EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
+**Done means a PUSHED branch with a green PR behind it. A local commit is not done.**
+A commit that exists only in this disposable worktree has reached nobody: firstmate has nothing to
+evaluate, merge, or deploy, and the worktree cannot even be cleaned up while it holds unlanded work.
+The pipeline is what pushes your branch and opens that PR, so running it is not optional and
+\`tests + lint green\` on your own is not a substitute for it.
+Committing the implementation is a HANDOFF CHECKPOINT, not the finish line: append
+\`working: implementation committed, ready for validation\` and stop there.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+Do NOT report \`done:\` at that point - in this mode the only \`done:\` that ends the task is the PR line below.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
@@ -58,6 +70,7 @@ Two firstmate-specific rules layer on top of that guidance:
   It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+That line MUST carry the full \`https://...\` PR URL; a done report with no pushed branch behind it is not a delivery.
 EOF
       ;;
     *)

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -30,7 +30,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-captain-hold.sh`     | Hold tasks for the captain, record the captain's answers, gate investigation completion, and report record divergence between the status log and the backlog |
 | `fm-decision-hold.sh`    | One-release compatibility shim mapping the retired decision commands onto fm-captain-hold.sh |
-| `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
+| `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs; crewmate briefs take an explicit `--test-scope`   |
 | `fm-dod-lib.sh`          | One owner of the ship task's mode-specific definition of done, rendered by both the brief scaffold and a scout promotion |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -14,7 +14,7 @@ test_primary_and_secondmate_instruction_generation() {
   mkdir -p "$home/data"
 
   FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
-    "$BRIEF" authority-worker sample --mode no-mistakes >/dev/null 2>&1
+    "$BRIEF" authority-worker sample --mode no-mistakes --test-scope full >/dev/null 2>&1
   ship="$home/data/authority-worker/brief.md"
   assert_grep 'ask-user findings are never yours to answer' "$ship" \
     "generated implementation brief lets the worker own an ask-user decision"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -202,7 +202,7 @@ test_ship_modes_generate_clean_briefs() {
   for id_mode in "brief-nomistakes-a1:no-mistakes" "brief-directpr-a2:direct-PR" "brief-localonly-a3:local-only"; do
     id=${id_mode%%:*}
     mode=${id_mode##*:}
-    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1; status=$?
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" --test-scope full >/dev/null 2>&1; status=$?
     expect_code 0 "$status" "fm-brief.sh $id --mode $mode should exit 0"
     brief="$home/data/$id/brief.md"
     assert_present "$brief" "$id: brief was not scaffolded"
@@ -251,7 +251,7 @@ test_ship_mode_is_explicit_not_registry() {
   local home brief
   home="$TMP_ROOT/explicit-over-registry-home"
   write_registry "$home"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-explicit-a5 direct-proj --mode no-mistakes >/dev/null 2>&1 \
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-explicit-a5 direct-proj --mode no-mistakes --test-scope full >/dev/null 2>&1 \
     || fail "explicit no-mistakes brief on a direct-PR project should scaffold"
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
@@ -260,7 +260,7 @@ test_ship_mode_is_explicit_not_registry() {
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-explicit-a6 never-registered --mode local-only >/dev/null 2>&1 \
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-explicit-a6 never-registered --mode local-only --test-scope full >/dev/null 2>&1 \
     || fail "unregistered project should still scaffold from the explicit mode"
   grep -qx "Delivery contract: mode=local-only" "$home/data/brief-explicit-a6/brief.md" \
     || fail "unregistered project did not honour the explicit --mode"
@@ -295,14 +295,14 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   home="$TMP_ROOT/configured-authority-home"
   write_registry "$home"
   id="brief-direct-authority-a4"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj --mode direct-PR >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj --mode direct-PR --test-scope full >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_grep "The configured merge authority decides whether to merge the PR; firstmate relays the outcome." "$brief" \
     "direct-PR brief lost configured merge authority"
   assert_no_grep "The captain reviews and merges the PR" "$brief" \
     "direct-PR brief hard-coded captain-only authority"
   id="brief-local-authority-a4"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" local-proj --mode local-only >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" local-proj --mode local-only --test-scope full >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_grep "The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path." "$brief" \
     "local-only brief lost configured merge authority and guarded landing"
@@ -313,7 +313,7 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   assert_no_grep "make \`--intent\` preserve all relevant content from this brief" "$home/data/$id/brief.md" \
     "local-only brief must not include the no-mistakes --intent contract"
   id="brief-direct-intent-a4"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj --mode direct-PR >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj --mode direct-PR --test-scope full >/dev/null 2>&1
   assert_no_grep "make \`--intent\` preserve all relevant content from this brief" "$home/data/$id/brief.md" \
     "direct-PR brief must not include the no-mistakes --intent contract"
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
@@ -326,7 +326,7 @@ test_no_mistakes_dod_wording() {
   home="$TMP_ROOT/wording-home"
   mkdir -p "$home/data"
   id="brief-wording-b1"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes --test-scope full >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
   assert_grep "no-mistakes itself provides for the mechanics" "$brief" \
@@ -370,7 +370,7 @@ test_ship_project_memory_wording() {
   home="$TMP_ROOT/project-memory-home"
   mkdir -p "$home/data"
   id="brief-memory-c1"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes --test-scope full >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
   assert_grep "Record only project knowledge useful to almost every future session." "$brief" \
@@ -387,7 +387,7 @@ test_herdr_lab_contract_is_explicit_and_complete() {
   home="$TMP_ROOT/herdr-lab-home"
   mkdir -p "$home/data"
   id="brief-herdr-lab-d1"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes --herdr-lab >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes --herdr-lab --test-scope full >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "Herdr lab brief was not scaffolded"
   assert_grep "# Herdr isolation - HARD SAFETY CONTRACT" "$brief" \
@@ -421,7 +421,7 @@ test_herdr_lab_contract_quotes_foreign_firstmate_path() {
   id="brief-herdr-lab-foreign-d2"
   helper=$(printf '%s' "$foreign_root/bin/fm-herdr-lab.sh" | sed "s/'/'\\\\''/g")
   helper="'$helper'"
-  FM_HOME="$home" FM_ROOT_OVERRIDE="$foreign_root" "$ROOT/bin/fm-brief.sh" "$id" foreign --scout --herdr-lab >/dev/null 2>&1
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$foreign_root" "$ROOT/bin/fm-brief.sh" "$id" foreign --scout --herdr-lab --test-scope full >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_grep "HERDR_LAB_HELPER=$helper" "$brief" \
     "Herdr lab brief must shell-quote an absolute Firstmate helper path"
@@ -437,9 +437,9 @@ test_herdr_lab_omission_is_loud_for_ship_and_scout() {
   for kind in ship scout; do
     id="brief-herdr-gate-$kind"
     if [ "$kind" = scout ]; then
-      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout >/dev/null 2>&1
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout --test-scope full >/dev/null 2>&1
     else
-      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes >/dev/null 2>&1
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes --test-scope full >/dev/null 2>&1
     fi
     brief="$home/data/$id/brief.md"
     assert_grep "# Herdr lifecycle declaration - NOT ENABLED" "$brief" \
@@ -465,9 +465,9 @@ test_documented_global_replace_leaves_the_herdr_gate_intact() {
   for kind in ship scout; do
     id="brief-fill-site-$kind"
     if [ "$kind" = scout ]; then
-      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout >/dev/null 2>&1
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout --test-scope full >/dev/null 2>&1
     else
-      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes >/dev/null 2>&1
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes --test-scope full >/dev/null 2>&1
     fi
     brief="$home/data/$id/brief.md"
     assert_present "$brief" "$kind brief was not scaffolded"
@@ -525,7 +525,7 @@ test_secondmate_no_projects_charter() {
   expect_code 1 "$status" "--no-projects combined with a project list must fail"
 
   # --no-projects applies only to secondmate charters, never a ship/scout brief.
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" oops3 somerepo --no-projects >/dev/null 2>&1; status=$?
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" oops3 somerepo --no-projects --test-scope full >/dev/null 2>&1; status=$?
   expect_code 1 "$status" "--no-projects on a ship brief must fail"
 
   pass "fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse"
@@ -671,7 +671,7 @@ test_herdr_lab_contract_applies_to_scouts_but_not_secondmates() {
   local home brief status=0
   home="$TMP_ROOT/herdr-kind-home"
   mkdir -p "$home/data"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" herdr-scout firstmate --scout --herdr-lab >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" herdr-scout firstmate --scout --herdr-lab --test-scope full >/dev/null 2>&1
   brief="$home/data/herdr-scout/brief.md"
   assert_grep "# Herdr isolation - HARD SAFETY CONTRACT" "$brief" \
     "scout --herdr-lab brief missing the contract"
@@ -693,11 +693,11 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
     case "$kind" in
       ship)
         FM_HOME="$home" FM_CLASSIFY_PAUSED_VERB=awaiting \
-          "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes >/dev/null 2>&1
+          "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes --test-scope full >/dev/null 2>&1
         ;;
       scout)
         FM_HOME="$home" FM_CLASSIFY_PAUSED_VERB=awaiting \
-          "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout >/dev/null 2>&1
+          "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout --test-scope full >/dev/null 2>&1
         ;;
       secondmate)
         FM_HOME="$home" FM_CLASSIFY_PAUSED_VERB=awaiting \
@@ -726,7 +726,7 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   home="$TMP_ROOT/decision-policy-home"
   mkdir -p "$home/data"
   FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
-    "$ROOT/bin/fm-brief.sh" sample-investigation sample --scout >/dev/null 2>&1
+    "$ROOT/bin/fm-brief.sh" sample-investigation sample --scout --test-scope full >/dev/null 2>&1
   scout="$home/data/sample-investigation/brief.md"
   assert_grep "$ROOT/.agents/skills/captain-hold-lifecycle/SKILL.md" "$scout" \
     "scout brief did not load the captain-call policy before done"
@@ -743,7 +743,7 @@ test_scout_and_secondmate_load_decision_hold_policy() {
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
-  FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-scout-q6 alpha --scout >/dev/null 2>&1 \
+  FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-scout-q6 alpha --scout --test-scope full >/dev/null 2>&1 \
     || fail "fm-brief.sh scout scaffold exited non-zero"
   brief="$BRIEF_HOME/data/brief-scout-q6/brief.md"
   assert_present "$brief" "scout brief was not scaffolded"
@@ -760,6 +760,88 @@ test_scout_and_secondmate_scaffold() {
   assert_grep "persistent second mate" "$brief" \
     "secondmate charter must declare its role"
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
+}
+
+# A crewmate with no named test scope runs the whole suite, which costs suite time
+# and model quota on every dispatch. The scope is therefore a required positive
+# statement on every crewmate brief rather than a placeholder that could survive
+# into a dispatched brief unfilled, and a refused scaffold writes nothing.
+test_test_scope_is_required_for_crewmate_briefs() {
+  local home id out status label args expect
+  home="$TMP_ROOT/test-scope-required-home"
+  mkdir -p "$home/data"
+  id=0
+  while IFS='|' read -r label args expect; do
+    [ -n "$label" ] || continue
+    id=$((id + 1))
+    # shellcheck disable=SC2086  # args is an intentional word-split arg list
+    out=$(FM_HOME="$home" FM_SECONDMATE_CHARTER=x "$ROOT/bin/fm-brief.sh" "scope-required-$id" $args 2>&1)
+    status=$?
+    [ "$status" -ne 0 ] || fail "$label: expected a non-zero exit"
+    assert_contains "$out" "$expect" "$label: refusal did not explain the contract"
+    assert_absent "$home/data/scope-required-$id/brief.md" "$label: refused scaffold still wrote a brief"
+  done <<'ROWS'
+ship brief without a scope|some-proj --mode no-mistakes|crewmate briefs require --test-scope
+scout brief without a scope|some-proj --scout|crewmate briefs require --test-scope
+empty --test-scope value|some-proj --mode no-mistakes --test-scope|requires a value
+empty --test-scope= value|some-proj --mode no-mistakes --test-scope=|must name a scope
+scope on a secondmate charter|--secondmate --no-projects --test-scope full|applies only to crewmate ship and scout briefs
+ROWS
+  pass "fm-brief.sh: crewmate briefs require a named test scope and refuse without writing"
+}
+
+# The narrow and the deliberate-full renderings must be distinguishable, because
+# that distinction is the whole point: a full-suite run has to be a stated choice
+# rather than the silent default a scope-less brief produces.
+test_test_scope_renders_named_and_deliberate_broad_scopes() {
+  local home brief kind flags
+  home="$TMP_ROOT/test-scope-render-home"
+  mkdir -p "$home/data"
+  for kind in ship scout; do
+    if [ "$kind" = scout ]; then flags="--scout"; else flags="--mode no-mistakes"; fi
+
+    # shellcheck disable=SC2086  # flags is an intentional word-split arg list
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "scope-named-$kind" some-proj $flags \
+      --test-scope 'tests/panel/*.test.sh' >/dev/null 2>&1 \
+      || fail "$kind: a named test scope should scaffold"
+    brief="$home/data/scope-named-$kind/brief.md"
+    assert_grep "# Test scope - run ONLY these" "$brief" \
+      "$kind: named scope did not render the run-only-these contract"
+    assert_grep "tests/panel/*.test.sh" "$brief" \
+      "$kind: named scope did not render the scope the caller supplied"
+    assert_grep "Do not run the full suite." "$brief" \
+      "$kind: named scope did not forbid the full-suite fallback"
+    assert_grep "run the specific extra tests you actually need" "$brief" \
+      "$kind: named scope did not allow a deliberate, narrow widening"
+    assert_no_grep "FULL SUITE, deliberately" "$brief" \
+      "$kind: named scope rendered the deliberate full-suite heading"
+
+    # shellcheck disable=SC2086  # flags is an intentional word-split arg list
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "scope-full-$kind" some-proj $flags \
+      --test-scope full >/dev/null 2>&1 \
+      || fail "$kind: a deliberate full-suite scope should scaffold"
+    brief="$home/data/scope-full-$kind/brief.md"
+    assert_grep "# Test scope - FULL SUITE, deliberately" "$brief" \
+      "$kind: full scope did not render as a deliberate decision"
+    assert_grep "not the default" "$brief" \
+      "$kind: full scope did not distinguish itself from a silent default"
+    assert_no_grep "run ONLY these" "$brief" \
+      "$kind: full scope rendered the narrow heading"
+  done
+
+  # `full: <why>` records the justification, and the reserved token is matched
+  # case-insensitively so a capitalised spelling is not read as a suite name.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" scope-full-reason some-proj --mode no-mistakes \
+    --test-scope 'full: cross-cutting refactor touches every suite' >/dev/null 2>&1 \
+    || fail "a justified full-suite scope should scaffold"
+  assert_grep "Reason: cross-cutting refactor touches every suite" "$home/data/scope-full-reason/brief.md" \
+    "full: <why> did not record the justification"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" scope-full-upper some-proj --mode no-mistakes \
+    --test-scope FULL >/dev/null 2>&1 \
+    || fail "an upper-case full scope should scaffold"
+  assert_grep "# Test scope - FULL SUITE, deliberately" "$home/data/scope-full-upper/brief.md" \
+    "the reserved full token was not matched case-insensitively"
+  pass "fm-brief.sh: named and deliberately broad test scopes render distinguishably"
 }
 
 test_script_parses
@@ -783,3 +865,5 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_test_scope_is_required_for_crewmate_briefs
+test_test_scope_renders_named_and_deliberate_broad_scopes

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -914,6 +914,21 @@ test_status_protocol_rejects_a_done_with_nothing_behind_it() {
     # shellcheck disable=SC2016  # literal backticks in the brief text, not expansion
     assert_grep 'Before you write a `done:` line, check it against Definition of done' "$brief" \
       "$kind: status protocol did not point the done line at the definition of done"
+    # The status protocol text is shared across modes and must defer to each mode's own
+    # Definition of done rather than hardcoding a requirement of its own: a prior version
+    # hardcoded "no pushed branch" here, contradicting local-only's committed-only bar.
+    case "$kind" in
+      no-mistakes|direct-PR)
+        assert_grep "PUSHED branch" "$brief" \
+          "$kind: brief has no pushed-branch requirement for the status protocol to defer to"
+        ;;
+      local-only)
+        assert_no_grep "with no pushed" "$brief" \
+          "local-only brief's status protocol hardcodes a pushed-branch requirement that contradicts its committed-only Definition of done"
+        assert_grep "COMMITTED" "$brief" \
+          "local-only brief has no committed-branch requirement for the status protocol to defer to"
+        ;;
+    esac
   done
   pass "fm-brief.sh: the status protocol rejects a done line with no delivery behind it"
 }

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -844,6 +844,80 @@ test_test_scope_renders_named_and_deliberate_broad_scopes() {
   pass "fm-brief.sh: named and deliberately broad test scopes render distinguishably"
 }
 
+# A worker that commits locally, reports done, and never pushes strands the change
+# where firstmate cannot evaluate, merge, or deploy it, and leaves a worktree that
+# teardown then refuses to clean up. The scaffold cannot observe a git push, so the
+# guarantee it can actually make is a contract-strength one: every delivery mode must
+# say, in the definition of done, that a local commit is not done.
+test_done_requires_a_pushed_branch_per_mode() {
+  local home brief
+  home="$TMP_ROOT/done-push-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" push-nm some-proj --mode no-mistakes \
+    --test-scope 'tests/x.test.sh' >/dev/null 2>&1 \
+    || fail "no-mistakes brief should scaffold"
+  brief="$home/data/push-nm/brief.md"
+  assert_grep "Done means a PUSHED branch with a green PR behind it. A local commit is not done." "$brief" \
+    "no-mistakes DOD did not make a pushed branch the definition of done"
+  assert_grep "HANDOFF CHECKPOINT, not the finish line" "$brief" \
+    "no-mistakes DOD did not mark the implementation commit as a handoff rather than completion"
+  assert_grep "MUST carry the full" "$brief" \
+    "no-mistakes DOD did not require the full PR URL on the done line"
+  # The premature terminal report is the exact failure this closes: committing must
+  # no longer be described as a point at which the worker writes a `done:` line.
+  # shellcheck disable=SC2016  # literal backticks in the brief text, not expansion
+  assert_no_grep 'append `done: {summary}`' "$brief" \
+    "no-mistakes DOD still tells the worker to report done at the implementation commit"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" push-dpr some-proj --mode direct-PR \
+    --test-scope 'tests/x.test.sh' >/dev/null 2>&1 \
+    || fail "direct-PR brief should scaffold"
+  brief="$home/data/push-dpr/brief.md"
+  assert_grep "Done means a PUSHED branch with a PR behind it. A local commit is not done." "$brief" \
+    "direct-PR DOD did not make a pushed branch the definition of done"
+  assert_grep "MUST carry the full" "$brief" \
+    "direct-PR DOD did not require the full PR URL on the done line"
+
+  # local-only deliberately has no remote, so "pushed" cannot mean a remote push here.
+  # The equivalent guarantee is a complete committed branch firstmate can merge, and the
+  # mode's no-remote rule must survive the change rather than be contradicted by it.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" push-lo some-proj --mode local-only \
+    --test-scope 'tests/x.test.sh' >/dev/null 2>&1 \
+    || fail "local-only brief should scaffold"
+  brief="$home/data/push-lo/brief.md"
+  # shellcheck disable=SC2016  # literal backticks in the brief text, not expansion
+  assert_grep 'COMMITTED `fm/push-lo` branch that firstmate can merge' "$brief" \
+    "local-only DOD did not require a complete committed branch"
+  assert_grep "Uncommitted work is not done." "$brief" \
+    "local-only DOD did not rule out uncommitted work"
+  assert_grep "Do NOT push to any remote" "$brief" \
+    "local-only DOD lost its no-remote rule"
+  pass "fm-brief.sh: every delivery mode makes a pushed, visible branch the definition of done"
+}
+
+# The status protocol is where a worker actually writes its done line, so the same
+# contract has to appear at that point of use, not only in the definition of done.
+test_status_protocol_rejects_a_done_with_nothing_behind_it() {
+  local home brief kind flags
+  home="$TMP_ROOT/done-status-home"
+  mkdir -p "$home/data"
+  for kind in no-mistakes direct-PR local-only; do
+    flags="--mode $kind"
+    # shellcheck disable=SC2086  # flags is an intentional word-split arg list
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "status-$kind" some-proj $flags \
+      --test-scope 'tests/x.test.sh' >/dev/null 2>&1 \
+      || fail "$kind: brief should scaffold"
+    brief="$home/data/status-$kind/brief.md"
+    assert_grep "is not a delivery and will be sent straight back to you" "$brief" \
+      "$kind: status protocol did not warn that an unbacked done goes straight back"
+    # shellcheck disable=SC2016  # literal backticks in the brief text, not expansion
+    assert_grep 'Before you write a `done:` line, check it against Definition of done' "$brief" \
+      "$kind: status protocol did not point the done line at the definition of done"
+  done
+  pass "fm-brief.sh: the status protocol rejects a done line with no delivery behind it"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -867,3 +941,5 @@ test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
 test_test_scope_is_required_for_crewmate_briefs
 test_test_scope_renders_named_and_deliberate_broad_scopes
+test_done_requires_a_pushed_branch_per_mode
+test_status_protocol_rejects_a_done_with_nothing_behind_it

--- a/tests/fm-cmux-claude-composer-live-e2e.test.sh
+++ b/tests/fm-cmux-claude-composer-live-e2e.test.sh
@@ -51,7 +51,7 @@ git -C "$LAB/projects/comms" add README.md
 git -C "$LAB/projects/comms" commit -qm 'fixture: initialize cmux Claude composer probe'
 
 STATUS="$LAB/state/$TASK.status"
-FM_HOME="$LAB" "$ROOT/bin/fm-brief.sh" "$TASK" comms --scout || fail "could not scaffold the Claude probe brief"
+FM_HOME="$LAB" "$ROOT/bin/fm-brief.sh" "$TASK" comms --scout --test-scope full || fail "could not scaffold the Claude probe brief"
 python3 - "$LAB/data/$TASK/brief.md" "$STATUS" <<'PY'
 from pathlib import Path
 import sys

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -59,12 +59,12 @@ test_fm_home_parameterization() {
   out=$(FM_HOME="$home_two" "$ROOT/bin/fm-project-mode.sh" app 2>/dev/null)
   [ "$out" = "no-mistakes off" ] || fail "fm-project-mode did not isolate missing registry by home"
 
-  FM_HOME="$home_one" "$ROOT/bin/fm-brief.sh" task-a app --mode no-mistakes >/dev/null || fail "brief scaffold failed under FM_HOME"
+  FM_HOME="$home_one" "$ROOT/bin/fm-brief.sh" task-a app --mode no-mistakes --test-scope full >/dev/null || fail "brief scaffold failed under FM_HOME"
   brief="$home_one/data/task-a/brief.md"
   [ -f "$brief" ] || fail "brief was not written under FM_HOME/data"
   grep -F ">> '$home_one/state/task-a.status'" "$brief" >/dev/null || fail "brief did not shell-quote FM_HOME state path"
 
-  FM_HOME="$home_one" "$ROOT/bin/fm-brief.sh" task-b app --scout >/dev/null || fail "scout brief scaffold failed under FM_HOME"
+  FM_HOME="$home_one" "$ROOT/bin/fm-brief.sh" task-b app --scout --test-scope full >/dev/null || fail "scout brief scaffold failed under FM_HOME"
   brief="$home_one/data/task-b/brief.md"
   grep -F ">> '$home_one/state/task-b.status'" "$brief" >/dev/null || fail "scout brief did not shell-quote FM_HOME state path"
 

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -128,7 +128,7 @@ test_brief_assertion_precedes_branch() {
   local home brief iso br
   home="$TMP_ROOT/brief-home"
   mkdir -p "$home/data"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" tangle-brief-cc3 alpha --mode no-mistakes >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" tangle-brief-cc3 alpha --mode no-mistakes --test-scope full >/dev/null 2>&1
   brief="$home/data/tangle-brief-cc3/brief.md"
   assert_present "$brief" "brief was not scaffolded"
   assert_grep "blocked: launched in primary checkout, not an isolated worktree" "$brief" \

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -312,7 +312,7 @@ STUB
     # Compare the public outputs of both real generation paths. The promoted
     # payload ends at its Definition of done, as does an ordinary generated
     # brief, so identical suffixes prove both workers receive the same contract.
-    FM_HOME="$home" "$BRIEF" "$id" fixture-project --mode "$mode" >/dev/null 2>&1 \
+    FM_HOME="$home" "$BRIEF" "$id" fixture-project --mode "$mode" --test-scope "tests/fixture-project/" >/dev/null 2>&1 \
       || fail "$mode: ordinary ship brief generation should succeed"
     brief_dod="$TMP_ROOT/promote-dod/brief-dod-$id"
     delivered_dod="$TMP_ROOT/promote-dod/delivered-dod-$id"
@@ -339,7 +339,7 @@ STUB
   # The faster paths keep their own contracts rather than inheriting the pipeline's.
   assert_grep "Do NOT run /no-mistakes" "$payload" \
     "promoted direct-PR worker lost its no-pipeline contract"
-  assert_grep "Do NOT push, do NOT open a PR, do NOT merge" "$TMP_ROOT/promote-dod/payload-promote-dod-local-only" \
+  assert_grep "Do NOT push to any remote, do NOT open a PR, do NOT merge" "$TMP_ROOT/promote-dod/payload-promote-dod-local-only" \
     "promoted local-only worker lost its no-remote contract"
   assert_no_grep "no-mistakes axi respond" "$TMP_ROOT/promote-dod/payload-promote-dod-direct-pr" \
     "promoted direct-PR worker received the pipeline gate contract"


### PR DESCRIPTION
## Intent

Make the brief scaffold require a named test scope.

Crewmates default to running the whole test suite because nothing in the brief tells them not to. Test time and model quota are both scarce, and a change to one panel file does not need the cron, HA, deploy-endpoint and claude-launch suites run against it. The owner's words: "PLEASE BE PARSIMONIOUS ABOUT WHAT TESTS ARE RUN! if we're just touching the panel, just run panel tests ffs. They take time and quota".

Evidence this needs to be structural: every brief written on 2026-08-29 had a hand-written "## TEST SCOPE - run ONLY these" section added by firstmate, because the scaffold does not ask for one. It worked every time - the workers respected it precisely - but it depended entirely on whoever writes the brief remembering. A scaffold that asks for the scope makes the good behaviour the default instead of a habit.

What to do: bin/fm-brief.sh should scaffold a REQUIRED test-scope section, in the same way it already scaffolds the worktree-isolation assertion and the status protocol - as a contract, not a suggestion.

Three design decisions were required to be made deliberately and justified. The decisions taken, which are deliberate and should not be flagged as mistakes:

1. Unfilled scope is a HARD REFUSAL, not a loud placeholder. --test-scope is required on ship and scout scaffolds and the script refuses without writing any file. Rationale: a placeholder that survives into a dispatched brief is worth nothing. The usual objection to refusing - that it makes the scaffold unusable for a genuine "run everything" task - does not apply here, because the reserved `full` value covers exactly that case, so refusing leaves no legitimate blocked path.

2. A legitimately broad scope is EXPRESSED, never defaulted. `--test-scope full` (or `full: <why>`, which records the justification) renders a distinct "FULL SUITE, deliberately" section stating the whole suite was chosen for this task rather than fallen back on. That distinction between a deliberate full-suite decision and today's silent scope-less default IS the feature.

3. The scaffolded text stays GENERIC and names no suites. Rationale: fm-brief.sh is handed a caller-supplied REPO string it cannot resolve, so hardcoded suite names would be wrong for every other project and would go stale in this one. The concrete suite names belong in the flag value, supplied by whoever knows the project.

Additional accepted decisions:
- --test-scope is refused on a secondmate charter, which dispatches no tests of its own and briefs its own crewmates.
- AGENTS.md section 11 gains exactly one line for the new requirement, because the contract that describes the scaffold should say what the scaffold requires. Keeping that always-loaded contract concise is an explicit constraint from AGENTS.md itself, so one line is the deliberate budget, not an oversight.
- The four other existing test files that invoke fm-brief.sh were updated to pass the now-required flag.

Explicit scope constraint from the requester: keep it proportionate. This is a scaffold change, NOT a policy engine. Do not build validation machinery that inspects what tests a worker actually ran. Do not add enforcement beyond requiring the flag and rendering the section.

Declared test scope for this task itself (the irony is deliberate - this task demonstrates the behaviour it adds): the firstmate repo's own tests covering bin/fm-brief.sh, i.e. tests/fm-brief.test.sh, plus the four existing test files whose fm-brief.sh invocations needed the new flag. NOT the whole suite.

This is the firstmate repo's own shared, tracked material, so the firstmate-coding-guidelines skill applies: one sentence per line in tracked Markdown, plain dash never em dash, no agent co-author on commits, bin/*.sh shellcheck-clean, tests colocated in tests/ as <subject>.test.sh extending the existing runner, and tests must exercise behavior through an executable interface rather than asserting implementation-source bytes.

Delivery constraints: the firstmate repo has GitHub issues DISABLED - do not file an issue and do not put "Fixes #N" in the PR body. Merge authority is not automatic; stop at a green PR and do not merge it.

=== SECOND, LATER-ACCEPTED REQUIREMENT (same file, deliberately delivered in this same PR rather than a second one that would collide in bin/fm-brief.sh) ===

Greg: "fix the scaffold so workers cant report done without pushing. If they report back to you anything that isnt a pushed branch for you to evaluate, merge, and deploy, start them back up again"

THE PROBLEM: a worker finishes the code, commits locally, reports "done", and never pushes. The branch sits in a disposable worktree that teardown then refuses to remove, firstmate has nothing to evaluate, and the change reaches nobody. This happened twice in one evening from two different workers, which makes it a scaffold gap and not two careless workers. The scaffold actively invited it: in no-mistakes mode the generated brief said the task was "complete only when committed on your branch" and instructed the worker to append `done: {summary}` at that point, so the premature terminal report was the documented behaviour.

WHAT WAS REQUIRED: the generated brief must make A PUSHED BRANCH part of the DEFINITION OF DONE, per delivery mode, stated as a contract in the same register as the worktree-isolation assertion, not as advice.
- no-mistakes and direct-PR: done means the branch is PUSHED and a PR exists; a done report MUST carry the full https PR URL; a local commit is not done.
- local-only: done means the branch is PUSHED and ready to fast-forward; firstmate cannot merge what it cannot see.
And the STATUS PROTOCOL section must say the same thing at the point a worker writes its done line: a done status with no pushed branch behind it will be sent straight back.

ACCEPTED DESIGN DECISIONS for this second requirement, all deliberate and not to be flagged as mistakes:

1. This is a contract-strength WORDING change, not a check, and that was the explicitly requested honest answer. fm-brief.sh emits text at scaffold time, long before the worker exists, so it cannot observe a git push. No cheap honest check is available to it. The requester explicitly said: do not invent machinery that pretends to verify a push; if there is no honest check, say plainly that enforcement lives with firstmate restarting the worker. The script header states this limitation explicitly, and AGENTS.md section 7 carries the firstmate-side enforcement rule.

2. local-only says COMMITTED rather than PUSHED, and this is a deliberate, justified departure from the literal requested wording. local-only is DEFINED by having no remote and its own rules say "never push to any remote", so a literal remote push would contradict the mode it is being added to. The equivalent guarantee is a complete committed branch that firstmate can merge from the shared ref. A test asserts the mode's no-remote rule survives, so this cannot silently drift into a real push.

3. In no-mistakes mode the implementation commit is relabelled a HANDOFF CHECKPOINT that reports `working: implementation committed, ready for validation` instead of `done: {summary}`. Removing that premature `done:` is required by the rule that a done report must carry a PR URL. Who triggers validation is unchanged: firstmate still instructs the worker to run /no-mistakes, so the supervision handshake in AGENTS.md is untouched.

4. The AGENTS.md line was added to section 7 (PR ready, landing, and teardown), NOT section 11 (crewmate briefs). Section 11 already delegates "delivery-mode definitions of done" to bin/fm-brief.sh, so restating the scaffold's content there would duplicate an already-owned contract and violate the repo's one-owner rule. What is genuinely new is a firstmate-side action rule about how to handle an unbacked completion report, which belongs with the rest of the ready/landing lifecycle. Exactly one line, per the always-loaded contract's size discipline.

5. Three `# shellcheck disable=SC2016` comments were added in the tests. The asserted strings contain literal backticks from the brief text and must stay single-quoted; SC2016 is a false positive there.

PROPORTIONALITY CONSTRAINT, explicitly restated by the requester for this second requirement too: keep it proportionate and keep the always-loaded contract concise. Do not build validation machinery.

TEST SCOPE for the whole task remains the firstmate repo's own tests covering bin/fm-brief.sh, not the full suite. The two new tests were verified to fail against the pre-change scaffold rather than passing vacuously. Note: tests/fm-secondmate-safety.test.sh has one pre-existing environmental failure unrelated to this change - it chmod 000s a file and expects the read to fail, which does not hold when the suite runs as uid 0 - and it exercises bin/fm-home-seed.sh, which this change does not touch.

## What Changed

- `bin/fm-brief.sh` now requires a `--test-scope` flag on every crewmate ship and scout brief (refused on secondmate charters), and refuses to scaffold if it is unset or blank. The reserved `full` (or `full: <why>`) value renders a distinct "FULL SUITE, deliberately" section; any other value renders a "run ONLY these" section naming the tests to run, both inserted into the generated brief alongside the existing worktree-isolation and status-protocol sections.
- `bin/fm-dod-lib.sh`'s per-mode Definition of done text now states that done requires a pushed branch: `no-mistakes` and `direct-PR` require a pushed branch with a PR whose URL is carried in the `done:` line, and `local-only` requires a complete, committed `fm/<id>` branch (verified via `git status --porcelain`) since that mode has no remote to push to. In `no-mistakes` mode, committing the implementation is now reported as `working: implementation committed, ready for validation` (a handoff checkpoint) instead of a premature `done: {summary}`.
- `bin/fm-brief.sh`'s status-protocol section and header comments were updated to state that a `done:` not meeting its mode's Definition of done is sent back to the worker, and `AGENTS.md` gained one line each in section 7 (unbacked completion reports get sent back) and section 11 (crewmate briefs require `--test-scope`).
- Updated `docs/scripts.md` and five existing test files (`fm-ask-user-authority`, `fm-brief`, `fm-cmux-claude-composer-live-e2e`, `fm-secondmate-safety`, `fm-tangle-guard`, `fm-task-delivery`) to pass the now-required `--test-scope` flag and cover the new scope and done-line behavior, including `shellcheck disable=SC2016` annotations for asserted literal-backtick strings.

## Risk Assessment

✅ Low: This fix round is a tightly scoped 15-line test addition that correctly locks in the ede2228 wording fix for the case that mattered (local-only's committed-vs-pushed contradiction); the DOD blocks in bin/fm-dod-lib.sh remain internally consistent across all three modes, and no production code changed in this round.

## Testing

Ran the full declared targeted test scope (fm-brief.test.sh plus its three active dependent test files; the fourth is env-gated and skips by design) and all pass; separately proved the newly added regression test is load-bearing by showing it fails against the pre-fix script and passes against the fix, confirming ede2228's status-protocol wording fix is now locked in against regression.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"840250603ac0423079143bd1832cd5880527264e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `docs/scripts.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `tests/fm-task-delivery.test.sh:315` - test_promotion_delivers_the_real_definition_of_done invokes the real bin/fm-brief.sh with `&#34;$id&#34; fixture-project --mode &#34;$mode&#34;` but no `--test-scope`. bin/fm-brief.sh now refuses (exit 1, no file written) whenever a ship/scout brief omits --test-scope. This call is immediately followed by `|| fail &#34;$mode: ordinary ship brief generation should succeed&#34;`, so this existing test breaks for every mode in the `no-mistakes direct-PR local-only` loop. The user intent explicitly lists &#39;four other existing test files that invoke fm-brief.sh&#39; as updated to pass the new flag (fm-ask-user-authority.test.sh, fm-cmux-claude-composer-live-e2e.test.sh, fm-secondmate-safety.test.sh, fm-tangle-guard.test.sh) - this fifth call site in tests/fm-task-delivery.test.sh was missed.

🔧 Fix: Add --test-scope and fix stale local-only wording assertion
✅ Re-checked - no issues remain.

- ⚠️ `tests/fm-brief.test.sh:915` - The ede2228 commit fixes a real self-contradiction (shared status-protocol text hardcoded &#39;pushed branch&#39;, contradicting local-only&#39;s committed-only DoD), verified by reproducing the pre-fix text (&#39;a `done:` with no pushed branch behind it&#39;) in the local-only brief and confirming it&#39;s gone post-fix. But no test was added or changed to lock in this fix: the existing assertion at tests/fm-brief.test.sh:915 (&#39;Before you write a `done:` line, check it against Definition of done&#39;) is a prefix common to both the buggy and fixed wording, so it passes identically on both sides of the fix and would not catch a regression back to hardcoded &#39;pushed branch&#39; wording.

🔧 Fix: Add per-mode regression test for status protocol wording
1 info still open:

- ℹ️ `tests/fm-brief.test.sh:920` - The new per-mode regression assertions in test_status_protocol_rejects_a_done_with_nothing_behind_it target the whole rendered brief file rather than the status-protocol section specifically. For no-mistakes/direct-PR the `assert_grep &#34;PUSHED branch&#34;` check is satisfied trivially by the pre-existing Definition-of-done block (bin/fm-dod-lib.sh:24,50), which is unchanged by the ede2228 fix and was already present in the pre-fix brief - so those two branches of the new case statement pass identically whether or not the ede2228 fix is applied and don&#39;t by themselves lock in the fix for those modes. The local-only branch (assert_no_grep &#34;with no pushed&#34; + assert_grep &#34;COMMITTED&#34;) does correctly discriminate pre-fix from post-fix text, so the regression this round targeted (round 3&#39;s finding) is still genuinely caught overall.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh (25/25 ok, including new tests: 'crewmate briefs require a named test scope and refuse without writing', 'named and deliberately broad test scopes render distinguishably', 'every delivery mode makes a pushed, visible branch the definition of done', 'the status protocol rejects a done line with no delivery behind it')`
- `bash tests/fm-ask-user-authority.test.sh (ok)`
- `bash tests/fm-tangle-guard.test.sh (6/6 ok)`
- `bash tests/fm-task-delivery.test.sh (all ok, including the fifth call-site fix in test_promotion_delivers_the_real_definition_of_done using --test-scope 'tests/fixture-project/' and the updated local-only 'Do NOT push to any remote' assertion)`
- `bash tests/fm-secondmate-safety.test.sh (5/6 ok; the two fm-brief.sh call sites updated with --test-scope full both pass; the one failure, 'home-seed validation accepted an unreadable registry', is a pre-existing environmental failure from chmod 000 not being honored under uid 0, in an unrelated fm-home-seed.sh code path not touched by this change, matching the explicitly documented known issue)`

✅ No issues found.
- `bash tests/fm-brief.test.sh (25/25 pass, including new per-mode status-protocol regression test)`
- `bash tests/fm-ask-user-authority.test.sh (pass)`
- `bash tests/fm-tangle-guard.test.sh (pass)`
- `bash tests/fm-task-delivery.test.sh (pass)`
- `bash tests/fm-cmux-claude-composer-live-e2e.test.sh (skips, env-gated, as expected)`
- `Regression check: temporarily replaced bin/fm-brief.sh with pre-fix version (git show 9b32c75:bin/fm-brief.sh) and reran tests/fm-brief.test.sh - new local-only assertion failed as expected; restored fixed bin/fm-brief.sh and verified byte-identical to HEAD via diff`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>
