### PR TITLE
chore: update pull request

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1442,6 +1442,29 @@ fm_backend_herdr_projection_order_best_effort() {  # <session> <created-workspac
   return 0
 }
 
+# fm_backend_herdr_server_start: start the herdr server for <session> with a
+# process-local environment. The long-lived server must not inherit Firstmate
+# home/override paths or harness identity from the process that happened to
+# launch supervision, and color suppression from a non-TTY hook must not make
+# every later pane monotone. Keep the explicit HERDR_SESSION and trailing
+# --session routing supplied by fm_backend_herdr_cli.
+fm_backend_herdr_server_start() {  # <session>
+  local session=$1 inherited_term=${TERM:-}
+  (
+    unset NO_COLOR FORCE_COLOR FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE \
+      FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE CURSOR_AGENT \
+      CURSOR_INVOKED_AS CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT \
+      FM_SUPERVISION_MODEL
+    if [ -z "$inherited_term" ] || [ "$inherited_term" = dumb ]; then
+      TERM=xterm-256color
+    else
+      TERM=$inherited_term
+    fi
+    export TERM
+    fm_backend_herdr_cli "$session" server
+  )
+}
+
 # fm_backend_herdr_server_ensure: start the herdr server for <session>
 # headless (no TUI client) if not already running, mirroring tmux's `tmux
 # has-session || tmux new-session -d`. Verified: a bare socket CLI call does
@@ -1451,7 +1474,7 @@ fm_backend_herdr_server_ensure() {  # <session>
   local session=$1 running out i
   running=$(fm_backend_herdr_cli "$session" status --json 2>/dev/null | jq -r '.server.running // false' 2>/dev/null)
   [ "$running" = "true" ] && return 0
-  ( fm_backend_herdr_cli "$session" server >/dev/null 2>&1 & ) || return 1
+  ( fm_backend_herdr_server_start "$session" >/dev/null 2>&1 & ) || return 1
   for i in $(seq 1 20); do
     running=$(fm_backend_herdr_cli "$session" status --json 2>/dev/null | jq -r '.server.running // false' 2>/dev/null)
     [ "$running" = "true" ] && return 0

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -765,8 +765,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -810,8 +810,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/serial_shards_raw" >"$tmp/serial_shards"
-  missing=$(comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
-  extra=$(comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable serial shards must equal the portable serial lane"
     [ -z "$missing" ] || { log "missing from serial shards:"; printf '%s\n' "$missing" >&2; }
@@ -823,7 +823,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -841,8 +841,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -855,7 +855,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -205,6 +205,8 @@ Workspace and tab ids support verification and cleanup but are not inferred from
 The adapter starts and polls a named server before workspace, tab, pane, or agent calls.
 Every Herdr invocation goes through `fm_backend_herdr_cli`, which sets the environment and passes an explicit trailing `--session <name>`.
 An environment variable alone is not reliable when another Herdr server is running.
+When Firstmate starts a server, it removes Firstmate and harness identity plus color-suppression variables from the server environment, normalizes an empty or `dumb` `TERM` to `xterm-256color`, and preserves a real `TERM` value.
+The server retains explicit `HERDR_SESSION` and `--session` routing while unrelated environment variables remain available.
 
 Literal text and Enter are separate operations on `fm-send.sh`'s typed plane; ordinary local text steers instead use the durable steering inbox and send only its best-effort constant doorbell through this adapter.
 Spawn-time fixed commands may use Herdr's atomic run primitive.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -47,6 +47,16 @@ next=$(( $(cat "$COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
   for a in "$@"; do printf '\x1f%s' "$a"; done
   printf '\n'
 } >> "$LOG"
+if [ "${1:-}" = server ]; then
+  [ -z "${FM_HERDR_ENV_LOG:-}" ] || env > "$FM_HERDR_ENV_LOG"
+  [ -z "${FM_HERDR_SERVER_STARTED:-}" ] || : > "$FM_HERDR_SERVER_STARTED"
+fi
+if [ "${1:-}" = status ] && [ "${2:-}" = --json ] &&
+  [ -n "${FM_HERDR_SERVER_STARTED:-}" ] &&
+  [ -e "$FM_HERDR_SERVER_STARTED" ]; then
+  printf '{"server":{"running":true}}\n'
+  exit 0
+fi
 if [ "${1:-}" = status ] && [ "${2:-}" = --json ] && [ "${FM_HERDR_SCRIPT_STATUS:-0}" != 1 ]; then
   printf '{"client":{"version":"0.7.1","protocol":14},"server":{"running":true}}\n'
   exit 0
@@ -287,6 +297,66 @@ test_cli_helper_sets_env_and_appends_trailing_session_flag() {
   assert_contains "$(cat "$log")" $'\x1f''workspace'$'\x1f''list'$'\x1f''--session'$'\x1f''fmtest' \
     "fm_backend_herdr_cli did not append a trailing --session <name> flag (the fix for the env-var-alone routing bug)"
   pass "fm_backend_herdr_cli: sets HERDR_SESSION AND appends a trailing --session flag on every call"
+}
+
+test_server_start_sanitizes_inherited_environment() {
+  local dir log resp envlog started fb out status server_env
+  dir="$TMP_ROOT/server-env-dumb"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; envlog="$dir/env"; started="$dir/started"; : > "$log"
+  printf '{"server":{"running":false}}\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_SCRIPT_STATUS=1 FM_HERDR_ENV_LOG="$envlog" \
+    FM_HERDR_SERVER_STARTED="$started" TERM=dumb \
+    bash -c '
+      . "$0/bin/backends/herdr.sh"
+      export NO_COLOR=1 FORCE_COLOR=0 FM_HOME=home FM_ROOT_OVERRIDE=root
+      export FM_STATE_OVERRIDE=state FM_DATA_OVERRIDE=data FM_PROJECTS_OVERRIDE=projects
+      export FM_CONFIG_OVERRIDE=config CURSOR_AGENT=cursor CURSOR_INVOKED_AS=cursor-agent
+      export CLAUDECODE=claude PI_CODING_AGENT=pi FM_PI_HARNESS=pi
+      export GROK_AGENT=grok FM_SUPERVISION_MODEL=model UNRELATED_SENTINEL=keep-me
+      fm_backend_herdr_server_ensure fmtest
+    ' "$ROOT" 2>&1)
+  status=$?
+  expect_code 0 "$status" "server_ensure should start with a sanitized environment"$'\n'"$out"
+  server_env=$(cat "$envlog")
+  assert_not_contains "$server_env" "NO_COLOR=" "server environment retained NO_COLOR"
+  assert_not_contains "$server_env" "FORCE_COLOR=" "server environment retained FORCE_COLOR"
+  assert_not_contains "$server_env" "FM_HOME=" "server environment retained FM_HOME"
+  assert_not_contains "$server_env" "FM_ROOT_OVERRIDE=" "server environment retained FM_ROOT_OVERRIDE"
+  assert_not_contains "$server_env" "FM_STATE_OVERRIDE=" "server environment retained FM_STATE_OVERRIDE"
+  assert_not_contains "$server_env" "FM_DATA_OVERRIDE=" "server environment retained FM_DATA_OVERRIDE"
+  assert_not_contains "$server_env" "FM_PROJECTS_OVERRIDE=" "server environment retained FM_PROJECTS_OVERRIDE"
+  assert_not_contains "$server_env" "FM_CONFIG_OVERRIDE=" "server environment retained FM_CONFIG_OVERRIDE"
+  assert_not_contains "$server_env" "CURSOR_AGENT=" "server environment retained CURSOR_AGENT"
+  assert_not_contains "$server_env" "CURSOR_INVOKED_AS=" "server environment retained CURSOR_INVOKED_AS"
+  assert_not_contains "$server_env" "CLAUDECODE=" "server environment retained CLAUDECODE"
+  assert_not_contains "$server_env" "PI_CODING_AGENT=" "server environment retained PI_CODING_AGENT"
+  assert_not_contains "$server_env" "FM_PI_HARNESS=" "server environment retained FM_PI_HARNESS"
+  assert_not_contains "$server_env" "GROK_AGENT=" "server environment retained GROK_AGENT"
+  assert_not_contains "$server_env" "FM_SUPERVISION_MODEL=" "server environment retained FM_SUPERVISION_MODEL"
+  assert_contains "$server_env" "TERM=xterm-256color" "TERM=dumb was not normalized for the server"
+  assert_contains "$server_env" "UNRELATED_SENTINEL=keep-me" "unrelated environment was not preserved"
+  assert_contains "$(cat "$log")" "HERDR_SESSION=fmtest"$'\x1f''server'$'\x1f''--session'$'\x1f''fmtest' \
+    "server start lost explicit Herdr session routing"
+  pass "fm_backend_herdr_server_ensure: strips color and identity variables, normalizes dumb TERM, and preserves unrelated environment"
+}
+
+test_server_start_preserves_real_term() {
+  local dir log resp envlog started fb out status server_env
+  dir="$TMP_ROOT/server-env-real-term"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; envlog="$dir/env"; started="$dir/started"; : > "$log"
+  printf '{"server":{"running":false}}\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_SCRIPT_STATUS=1 FM_HERDR_ENV_LOG="$envlog" \
+    FM_HERDR_SERVER_STARTED="$started" TERM=screen-256color \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_server_ensure fmtest' "$ROOT" 2>&1)
+  status=$?
+  expect_code 0 "$status" "server_ensure should preserve a real TERM"$'\n'"$out"
+  server_env=$(cat "$envlog")
+  assert_contains "$server_env" "TERM=screen-256color" "server start downgraded a real TERM"
+  pass "fm_backend_herdr_server_ensure: preserves a real TERM value"
 }
 
 # --- launcher_identity: the exact workspace a worker must be placed in -------
@@ -4432,6 +4502,8 @@ test_workspace_label_secondmate_marker_trims_whitespace
 test_workspace_label_empty_marker_falls_back_to_primary
 test_workspace_label_different_secondmates_get_different_labels
 test_cli_helper_sets_env_and_appends_trailing_session_flag
+test_server_start_sanitizes_inherited_environment
+test_server_start_preserves_real_term
 test_launcher_identity_absent_without_a_herdr_pane
 test_launcher_identity_absent_when_herdr_env_alone_is_set
 test_launcher_identity_resolves_the_exact_pane_tab_and_workspace

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -25,8 +25,8 @@ test_list_all_exact_suite_coverage() {
     done | LC_ALL=C sort
   )
   [ -n "$listed" ] || fail "--list --all printed nothing"
-  missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
-  extra=$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  missing=$(LC_ALL=C comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  extra=$(LC_ALL=C comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
   [ -z "$missing" ] || fail "--list --all missing scripts: $missing"
   [ -z "$extra" ] || fail "--list --all unexpected scripts: $extra"
   # No duplicates.
@@ -595,7 +595,7 @@ test_portable_shard_union_and_coverage_guard() {
   herdr=$("$RUNNER" --list --family real-herdr-gated)
   [ -n "$s1" ] && [ -n "$s2" ] || fail "portable parallel shards must be non-empty"
   # Shards disjoint.
-  overlap=$(comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
+  overlap=$(LC_ALL=C comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
   [ -z "$overlap" ] || fail "portable parallel shards overlap: $overlap"
   # Union of shards equals proven-isolated.
   [ "$(printf '%s\n' "$s1" "$s2" | LC_ALL=C sort -u)" = \


### PR DESCRIPTION
## Intent

Prepare the upstream contribution for Beads task fm-t0s: preserve and validate the existing Herdr isolation fix on feature branch fm/beads-fm-t0s-herdr-upstream-20260830, with the existing PR history preserved. The preserved source branch preserve/herdr-isolate-launch-env and commit e775946c3e801672a723436a5e2d483ceda83ae7 in the primary Firstmate repository are read-only; the contribution was formed by applying only that single preserved commit patch onto the current upstream main base, not by comparing unrelated history. Carry the intended Herdr fix and its necessary documentation and executable behavioral regression coverage: bin/backends/herdr.sh, docs/herdr-backend.md, and tests/fm-backend-herdr.test.sh. Preserve server-launch environment isolation behavior, including explicit named-session isolation and required trailing --session handling, and do not weaken security or lifecycle guarantees. Retain the accepted no-mistakes review scope additions: include bin/fm-test-run.sh with its LC_ALL=C locale-sensitive coverage fix and tests/fm-test-run.test.sh with its LC_ALL=C locale-sensitive coverage fix, because these are the smallest downstream corrections needed to keep the accepted Herdr regression coverage reliable across locales. The PR description must document why those two downstream files ride along. The target is main in upstream repository kunchenguid/firstmate, delivered from the existing RooseveltAdvisors/firstmate fork and existing PR, without creating a duplicate branch or PR. Preserve all existing commits and PR history. Do not manually edit files while validation is active; do not reset, rebase, discard, abort, force-push, bypass protection, or merge. Run the complete no-mistakes validation pipeline and process all gates through its supported response flow, escalating genuinely ambiguous ask-user findings to firstmate. Finish only when checks are green and report the full upstream PR URL; never merge the PR.

## What Changed

Final changed paths and statuses:

```text
M	bin/backends/herdr.sh
M	bin/fm-test-run.sh
M	docs/herdr-backend.md
M	tests/fm-backend-herdr.test.sh
M	tests/fm-test-run.test.sh
```

## Risk Assessment

✅ Low: The change is well-bounded: a single new function wrapping the existing server-launch path with environment sanitization, two targeted regression tests, and mechanical LC_ALL=C locale fixes across two files. All paths are tested, no new failure modes are introduced, and the fix is durable (no other server-start code paths exist).

## Testing

Ran both targeted test suites: `tests/fm-backend-herdr.test.sh` (all herdr backend tests pass, including the two new server environment isolation tests) and `tests/fm-test-run.test.sh` (all 25 contract tests pass, including the three LC_ALL=C comm locale fixes). Zero failures. The new `fm_backend_herdr_server_start` function correctly isolates server launch environment by unsetting color/identity variables, normalizing dumb TERM to xterm-256color, preserving real TERM values, and retaining explicit HERDR_SESSION and --session routing. The downstream LC_ALL=C locale fixes in `bin/fm-test-run.sh` and `tests/fm-test-run.test.sh` are verified functional by the passing coverage-guard and contract tests.

<details>
<summary>Evidence: Herdr backend tests (all passing)</summary>

Source: [Herdr backend tests (all passing)](https://github.com/RooseveltAdvisors/firstmate/blob/d8c3202491df17489ce68c9eb8ab9d6ebc47c7ea/.no-mistakes/evidence/fm/beads-fm-t0s-herdr-upstream-20260830/herdr-backend-tests.log)

```text
ok - fm_backend_herdr_version_check: accepts the current protocol (14)
ok - fm_backend_herdr_version_check: refuses an old protocol loudly
ok - fm_backend_herdr_version_check: refuses loudly when herdr is not installed
ok - fm_backend_herdr_workspace_label: a primary home (no marker) resolves to 'firstmate'
ok - fm_backend_herdr_workspace_label: a secondmate home (.fm-secondmate-home) resolves to '2ndmate-<id>'
ok - fm_backend_herdr_workspace_label: trims whitespace around the marker's secondmate id
ok - fm_backend_herdr_workspace_label: an empty marker file falls back to the primary label 'firstmate'
ok - fm_backend_herdr_workspace_label: two different secondmate homes get two different, non-colliding labels
ok - fm_backend_herdr_cli: sets HERDR_SESSION AND appends a trailing --session flag on every call
ok - fm_backend_herdr_server_ensure: strips color and identity variables, normalizes dumb TERM, and preserves unrelated environment
ok - fm_backend_herdr_server_ensure: preserves a real TERM value
ok - fm_backend_herdr_launcher_identity: a firstmate not running inside herdr has no launcher workspace to inherit
ok - fm_backend_herdr_launcher_identity: HERDR_ENV=1 without a pane id selects the backend but binds no parent
ok - fm_backend_herdr_launcher_identity: resolves the launcher's exact workspace even when a same-labeled workspace sorts first
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane that names a different herdr session
ok - fm_backend_herdr_launcher_identity: refuses a claimed pane without exact server identity
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane whose injected socket belongs to another herdr server
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's own pane no longer resolves
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's pane and tab disagree about their workspace
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's workspace is gone from its own session
ok - fm_backend_herdr_workspace_ensure: places a worker in the launcher's exact workspace, not the first same-labeled one
ok - fm_backend_herdr_workspace_ensure: refuses to guess between two same-labeled home workspaces
ok - fm_backend_herdr_workspace_ensure: a --secondmate container resolves that home's own workspace, not the launcher's
ok - fm_backend_herdr_container_ensure: surfaces the exact ambiguous-placement refusal instead of a generic failure
ok - fm_backend_herdr_container_ensure: version-gates, starts the server, ensures the firstmate workspace, echoes session:workspace_id + the seeded default tab id
ok - fm_backend_herdr_container_ensure: reuses an existing firstmate workspace without recreating it, and reports no seeded default tab (adopted, not created)
ok - fm_backend_herdr_container_ensure: workspace create passes --no-focus
ok - fm_backend_herdr_container_ensure: creates the workspace under the SECONDMATE home's own label, not 'firstmate'
ok - fm_backend_herdr_create_task: prunes exactly the seeded default tab container_ensure identified, once the first real task tab exists
ok - herdr repeated spawn/teardown: one persistent firstmate workspace reused, zero orphans, default tab pruned, create ran once
ok - fm_backend_herdr_create_task: an ADOPTED workspace's pre-existing tab is never pruned (the created-vs-adopted gate)
ok - fm_backend_herdr_create_task: the label-collision startup-workspace scenario (2026-07-02 incident) leaves the captain's live tab untouched
ok - fm_backend_herdr_workspace_prune_seeded_default_tab: refuses to close the seeded default tab when its pane reports a working agent (defense in depth)
ok - fm_backend_herdr_create_task: refuses a duplicate tab label (herdr's own tab create has no uniqueness check)
ok - fm_backend_herdr_create_task: a same-labeled tab with a live (even idle) registered agent still refuses exactly as before
ok - fm_backend_herdr_create_task: scans every same-labeled tab and refuses if any duplicate is live
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is dead (pane_not_found)
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is alive but hosts no registered agent (a restored plain shell)
ok - fm_backend_herdr_create_task: closes every confirmed same-labeled husk only after creating the replacement
ok - fm_backend_herdr_create_task: refuses success when a preexisting husk tab remains after replacement
ok - fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently
ok - fm_backend_herdr_create_task: creates the replacement tab BEFORE closing the husk tab, never the reverse
ok - fm_backend_herdr_create_task: creates a tab and parses tab_id/pane_id from the JSON response, prunes nothing when no seeded tab id is given
ok - fm_backend_herdr_create_task: tab create passes --no-focus
ok - herdr presentation: a home that set nothing gets the projection by default at or above the floor
ok - herdr presentation: an unconfigured home below the floor falls back flat with one naming warning
ok - herdr presentation: an unreadable client release falls back flat instead of guessing
ok - herdr presentation: a deliberate opt-in is never silently downgraded below the floor
ok - herdr presentation: an explicit off opts the home out
ok - herdr presentation: an unrecognized value warns and follows the default instead of failing a spawn
ok - herdr presentation: the below-floor warning is one per home per release, not one per spawn
ok - herdr presentation: warning marker publication is atomic, symlink-safe, and fails visible
ok - herdr presentation: client and selected server floors compose conservatively without overriding explicit opt-in
ok - herdr presentation floor: every measured release, and each signal alone, classifies correctly
ok - herdr presentation floor: either signal alone can carry an above verdict, and each divergence is real
ok - herdr presentation: config parsing separates a deliberate choice from an unconfigured default
ok - herdr presentation journal: atomically publishes one non-authoritative 128-bit correlator and refuses overwrite
ok - herdr presentation journal: version 2 binds exact home/endpoint/parent identities and advances atomically
ok - herdr presentation create: exact response IDs yield one normal task pane with no workspace-close authority
ok - herdr presentation create: concurrent same-label tabs are never prune targets
ok - herdr presentation focus: snapshot requires one exact active workspace and tab
ok - herdr presentation focus: exact pane close restores the exact prior workspace and tab
ok - herdr presentation focus: cleanup refuses rather than close the captain's active tab
ok - herdr presentation focus: pane close fails when exact focus restoration fails
ok - herdr presentation reclaim: live agent state at the close boundary refuses mutation
ok - herdr presentation cleanup: emptying close behind focus ends the exact shell without a move or focus change
ok - herdr presentation cleanup: emptying close before focus moves the doomed workspace to the end and ends its exact shell
ok - herdr presentation cleanup: emptying close with the focused workspace last skips the move
ok - herdr presentation cleanup: emptying close of the last workspace skips the move
ok - herdr presentation cleanup: a non-emptying close stays plain with no proof, move, or signal
ok - herdr presentation cleanup: no-move plain close requires structured pane removal
ok - herdr presentation cleanup: an ambiguous workspace layout falls back to the plain close
ok - herdr presentation cleanup: a failed repositioning move falls back to the plain close with a warning
ok - herdr presentation cleanup: a pane with a live foreground process falls back to the plain close
ok - herdr presentation cleanup: a transient prompt helper settles into the pane-death path instead of the plain close
tests/fm-backend-herdr.test.sh: line 1908: 3711861 Killed                  bash -c 'trap "" HUP; sleep 300'
ok - herdr presentation cleanup: a SIGHUP-surviving shell is escalated to SIGKILL before giving up
tests/fm-

... [3954 bytes truncated] ...

_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd
ok - fm_backend_herdr_busy_state: working -> busy
ok - fm_backend_herdr_busy_state: done -> idle, blocked -> idle (surfaced like a stale pane, not suppressed as busy)
ok - fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown, the regex-fallback cue
ok - fm_backend_herdr_composer_state: a bare '❯' composer row reads empty
ok - fm_backend_herdr_composer_state: bright placeholder-like text stays pending rather than being mistaken for an idle ghost
ok - fm_backend_herdr_composer_state: real composer text reads pending
ok - fm_backend_herdr_composer_state: a slash-command popup's argument-hint placeholder still reads pending (the incident fix)
ok - fm_backend_herdr_composer_state: reports unknown when the pane cannot be captured
ok - fm_backend_herdr_composer_state: reports unknown for bare shell prompts with no composer row
ok - fm_backend_herdr_composer_state: a blocked pi pane parked on a prompt is not an empty composer
ok - fm_backend_herdr_composer_state: a native idle Pi separator composer reads empty
ok - fm_backend_herdr_composer_state: real Pi composer text remains pending
ok - fm_backend_herdr_composer_state: an incomplete lower Pi separator cannot inherit a stale empty row
ok - fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯' prompt row (no border box in view) reads empty
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯ <text>' prompt row reads pending
ok - fm_backend_herdr_composer_state: a live unbordered prompt row below a stale bordered decorative box still wins (not misread as the box's own row)
ok - fm_backend_herdr_composer_state: claude's dim prompt-suggestion ghost (the overnight wedge shape) reads empty
ok - fm_backend_herdr_composer_state: real typed text on the same claude prompt row still reads pending
ok - fm_backend_herdr_composer_state: grok's dark-truecolor placeholder (the TRUECOLOR gap) reads empty
ok - fm_backend_herdr_composer_state: grok's real bright typed input still reads pending
ok - fm_backend_herdr_composer_state: a real-codex unbordered '›' prompt row reads empty
ok - fm_backend_herdr_composer_state: a faint real-codex ghost suggestion reads empty
ok - fm_backend_herdr_composer_state: non-faint codex prompt text still reads pending
ok - fm_backend_herdr_wait_for_working: reports 'busy' immediately on the first poll, without spending the rest of the budget
ok - fm_backend_herdr_wait_for_working: a slow transition landing on a later sample within one window is still caught (robust against the 'slow transition' failure direction)
ok - fm_backend_herdr_wait_for_working: spreads six samples across the full budget endpoint without a final trailing sleep
ok - fm_backend_herdr_send_text_submit: applies the herdr minimum confirmation budget before polling agent-state
ok - fm_backend_herdr_wait_for_working: reports 'idle' (readable, genuinely not yet working) when 'busy' never appears
ok - fm_backend_herdr_wait_for_working: reports 'unknown' (a hard read failure, not a timing race) only when EVERY poll in the window fails
ok - fm_backend_herdr_wait_for_working: treats blocked as submit-active for confirmation without changing watcher busy-state semantics
ok - fm_backend_herdr_send_text_submit: reports 'empty' once agent_status reports working after one Enter, without ever reading the composer
ok - fm_backend_herdr_send_text_submit: reports 'pending' when agent_status stays idle and the composer still holds unsent text after retried Enters (swallowed)
ok - fm_backend_herdr_send_text_submit: a slash-command popup's placeholder fill on Enter #1 never flips agent_status to working, so it does not short-circuit as submitted; Enter #2 is retried and lands it
ok - fm_backend_herdr_send_text_submit: a post-Enter blocked state confirms delivery without retrying into the prompt
ok - fm_backend_herdr_send_text_submit: native working + proven pending after retries reports empty (queued Enter)
ok - fm_backend_herdr_send_text_submit: a failed Enter cannot borrow preexisting working state as queued-delivery proof
ok - fm_backend_herdr_send_text_submit: a failed Enter cannot borrow a later native transition as delivery proof
ok - fm_backend_herdr_send_text_submit: idle native agent-state plus empty composer reports empty (landed Claude turn)
ok - fm_backend_herdr_send_text_submit: idle native baseline uses a rendered busy footer to confirm a queued Enter
ok - fm_backend_herdr_composer_state: cursor's mid-turn placeholder-plus-busy-token row reads pending (why delivery needs a separate signal)
ok - fm_backend_herdr_rendered_busy_state: busy/idle/unknown from the rendered footer, with an unreadable pane never reading idle
ok - fm_backend_herdr_send_text_submit: a rendered-footer idle-to-busy transition confirms delivery when native agent-state never reports idle
ok - fm_backend_herdr_send_text_submit: an already-busy footer baseline is never accepted as proof that this Enter landed
ok - fm_backend_herdr_send_text_submit: confirms submission via native agent-state alone, immune to a codex-style dynamic idle-tip composer that would have misread as 'pending' under the old composer-based confirmation
ok - fm_backend_herdr_composer_state: a faint real-codex dynamic idle-tip composer row reads empty
ok - fm_backend_composer_state (herdr): the pre-injection empty-box guard still refuses a genuinely non-empty composer, unaffected by the submit-confirmation change
ok - fm_backend_herdr_send_text_submit: a slow transition landing on a later sample within one Enter's budget is confirmed WITHOUT sending a needless extra Enter
ok - fm_backend_herdr_send_text_submit: reports 'send-failed' when the literal send-text call itself errors
ok - fm_backend_herdr_send_text_submit: reports 'unknown' when the post-Enter agent-get read fails (never retries past an unreadable target)
ok - fm_backend_herdr_send_text_submit: an unreadable composer stops Enter retries after native status stays idle
ok - fm_backend_validate: herdr is a known backend (P2)
ok - fm_backend_busy_state: tmux (no native primitive) always reports unknown, preserving the P1 regex-only path
error: unknown backend 'bogus' (known: tmux herdr zellij orca cmux)
ok - fm_backend_composer_state dispatches every backend to its named thin classifier, unknown for unrecognized backends
ok - fm-peek/fm-send: explicit stale targets matching metadata use the recorded backend
ok - fm_backend_herdr_normalize_event routes through the shared record with an empty from_status
ok - fm_backend_herdr_escalation_marker keys the dedupe marker exactly like the watcher's .stale-<key>
ok - fm_backend_herdr_apply_transition: blocked dedupe starts only after explicit commit
ok - fm_backend_herdr_apply_transition: a working edge clears the marker so the next ->blocked re-escalates
ok - fm_backend_herdr_clear_transition removes task-owned dedupe state
ok - fm_backend_herdr_apply_transition: idle/done (defer) and unknown/empty (fallback) take no fast action
ok - fm_backend_herdr_wait_transition: a home with no herdr panes falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: below-capability protocol/schema falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: reconnect level-reconcile returns an uncommitted blocked pane
ok - fm_backend_herdr_wait_transition: subscribes before reconnect level-reconcile
ok - fm_backend_herdr_wait_transition: a still-blocked, already-escalated pane is not re-delivered on reconnect
ok - fm_backend_herdr_wait_transition: a streamed ->blocked edge returns the record sub-poll
ok - fm_backend_herdr_wait_transition: streamed working clears the marker, idle/done are deferred (clean timeout)
ok - fm_backend_herdr_wait_transition: a reader/subscribe failure falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: Bash 3.2-safe bad-ack path closes fd 9 and removes its FIFO
ok - fm_backend_herdr_wait_transition: stock macOS Bash clean timeout closes fd 9 and returns 1
```
</details>
<details>
<summary>Evidence: fm-test-run contract tests (all passing)</summary>

Source: [fm-test-run contract tests (all passing)](https://github.com/RooseveltAdvisors/firstmate/blob/d8c3202491df17489ce68c9eb8ab9d6ebc47c7ea/.no-mistakes/evidence/fm/beads-fm-t0s-herdr-upstream-20260830/fm-test-run-tests.log)

```text
ok - exact suite coverage: --all lists every tests/*.test.sh once
ok - family selection returns a proper subset of the suite
ok - single-script selection lists exactly that path
ok - changed-file selection stays conservative (never silent full suite)
ok - runner and its documentation surfaces select their curated family, not just their contract owners
ok - changed selection covers dependents and fails closed for unmapped source
ok - a bin reference selects the referencing scripts, and consumers still select their curated families
ok - changed defaults to bounded automatic scheduling with serial override
ok - empty changed selection emits deterministic text and JSON summaries
ok - timing markers and JSON artifact are valid
ok - aggregate exit reflects any script failure
ok - gate-skip accounting is honest and non-failing
ok - fail-on-gate-skip converts herdr-not-found into a hard failure
ok - exclude-family drops the named primary family after selection
ok - portable shard union, disjointness, and coverage guard hold
ok - portable serial shards are a deterministic disjoint cover of the serial lane
ok - portable serial shard lanes refuse mismatched, out-of-range, and countless names
ok - --jobs refuses non-proven / stateful selections
ok - --jobs admits and schedules a family with a recorded concurrent proof
ok - a concurrent run starts the longest-hint script first
ok - --per-script-timeout-secs turns a hung script into a bounded failure
ok - --max-wall-ms fails an over-budget run and refuses a malformed budget
ok - jobs scheduler runs proven scripts; failure propagates; non-proven refused
ok - Herdr CI family-run step times out at 20 min under a 75 min job backstop
ok - aggregate-json merges lane timing artifacts
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e2adbb1a5a0c781528e295755d1f35509a982247","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-backend-herdr.test.sh` — all herdr backend tests including new `test_server_start_sanitizes_inherited_environment` and `test_server_start_preserves_real_term`</code>
- <code>`bash tests/fm-test-run.test.sh` — all fm-test-run contract tests including the three LC_ALL=C comm locale fixes</code>
- <code>Verified `fm_backend_herdr_server_start` unsets color/identity variables, normalizes dumb TERM to xterm-256color, preserves real TERM, and retains HERDR_SESSION + --session routing</code>
- <code>Verified `fm_backend_herdr_server_ensure` calls `fm_backend_herdr_server_start` instead of `fm_backend_herdr_cli` directly</code>
- `Verified docs/herdr-backend.md documents the environment isolation behavior`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
