### PR TITLE
fix(bin): refuse spawns into claimed worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,7 +304,7 @@ Write the task-specific brief under section 11 before spawning.
 ### Dispatch and supervision handoff
 
 Spawn only through `bin/fm-spawn.sh` after the profile and backend checks in section 4.
-The spawn must resolve a genuine isolated task worktree distinct from the primary checkout; a failed isolation assertion stops the task.
+The spawn must resolve a genuine unclaimed task worktree distinct from the primary checkout; a failed isolation or durable-claim assertion stops the task.
 When the configured tasks-axi backlog gate applies, the spawn itself moves the work item to In flight and refuses rather than dispatching work this home has no item for, so recording the dispatch is never a separate step to remember; a manual-backend home retains the hand-editing contract in `docs/configuration.md`.
 After spawning, confirm the worker is processing the brief and handle any trust dialog through `harness-adapters`.
 A persistent secondmate is recorded in the secondmate registry and runtime state, never as a backlog work item.

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -336,8 +336,16 @@ fm_backend_cmux_workspace_id_for_label() {  # <label>
   # inventory before looking for a title: the old jq|head pipeline let head
   # hide jq's parse failure and falsely reported a surviving workspace gone.
   printf '%s' "$workspaces" | jq -e 'type == "object" and (.workspaces | type == "array")' >/dev/null 2>&1 || return 2
+  # Existence is decided by the matched ENTRY, never by its id: a listed
+  # workspace whose entry carries the title but no usable id string is an
+  # unreadable inventory too, not proof the title is free.
   workspace_id=$(printf '%s' "$workspaces" \
-    | jq -r --arg want "$label" '[.workspaces[] | select(.title == $want) | .id][0] // empty' 2>/dev/null) || return 2
+    | jq -r --arg want "$label" '
+        [.workspaces[] | select(.title == $want)] as $matched
+        | if ($matched | length) == 0 then ""
+          elif ($matched[0].id | type) == "string" and (($matched[0].id | length) > 0) then $matched[0].id
+          else error("cmux workspace entry carries no usable id")
+          end' 2>/dev/null) || return 2
   printf '%s' "$workspace_id"
 }
 

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -330,11 +330,15 @@ fm_backend_cmux_scoped_title() {  # <fm-task-label>
 # so this adopts the FIRST match `jq` returns, mirroring herdr's/zellij's own
 # duplicate-check posture.
 fm_backend_cmux_workspace_id_for_label() {  # <label>
-  local label=$1 workspaces
+  local label=$1 workspaces workspace_id
   workspaces=$(fm_backend_cmux_cli workspace list --json --id-format uuids 2>/dev/null) || return 2
-  printf '%s' "$workspaces" \
-    | jq -r --arg want "$label" '.workspaces[]? | select(.title == $want) | .id' 2>/dev/null \
-    | head -1
+  # A successful cmux command can still emit unusable data. Validate the
+  # inventory before looking for a title: the old jq|head pipeline let head
+  # hide jq's parse failure and falsely reported a surviving workspace gone.
+  printf '%s' "$workspaces" | jq -e 'type == "object" and (.workspaces | type == "array")' >/dev/null 2>&1 || return 2
+  workspace_id=$(printf '%s' "$workspaces" \
+    | jq -r --arg want "$label" '[.workspaces[] | select(.title == $want) | .id][0] // empty' 2>/dev/null) || return 2
+  printf '%s' "$workspace_id"
 }
 
 # fm_backend_cmux_workspace_exists: does a live workspace already carry the

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -330,9 +330,11 @@ fm_backend_cmux_scoped_title() {  # <fm-task-label>
 # so this adopts the FIRST match `jq` returns, mirroring herdr's/zellij's own
 # duplicate-check posture.
 fm_backend_cmux_workspace_id_for_label() {  # <label>
-  local label=$1
-  fm_backend_cmux_cli workspace list --json --id-format uuids 2>/dev/null \
-    | jq -r --arg want "$label" '.workspaces[]? | select(.title == $want) | .id' 2>/dev/null | head -1
+  local label=$1 workspaces
+  workspaces=$(fm_backend_cmux_cli workspace list --json --id-format uuids 2>/dev/null) || return 2
+  printf '%s' "$workspaces" \
+    | jq -r --arg want "$label" '.workspaces[]? | select(.title == $want) | .id' 2>/dev/null \
+    | head -1
 }
 
 # fm_backend_cmux_workspace_exists: does a live workspace already carry the
@@ -341,9 +343,12 @@ fm_backend_cmux_workspace_id_for_label() {  # <label>
 # to "would a leftover workspace refuse the next spawn of this task?" - a
 # surface-scoped liveness read answers a different question.
 fm_backend_cmux_workspace_exists() {  # <fm-task-label>
-  local label=$1
+  local label=$1 workspace_id lookup_status
   [ -n "$label" ] || return 1
-  [ -n "$(fm_backend_cmux_workspace_id_for_label "$(fm_backend_cmux_scoped_title "$label")")" ]
+  workspace_id=$(fm_backend_cmux_workspace_id_for_label "$(fm_backend_cmux_scoped_title "$label")")
+  lookup_status=$?
+  [ "$lookup_status" -eq 0 ] || return "$lookup_status"
+  [ -n "$workspace_id" ]
 }
 
 fm_backend_cmux_surface_id_for_workspace() {  # <workspace_id>
@@ -362,17 +367,26 @@ fm_backend_cmux_surface_id_for_workspace() {  # <workspace_id>
 # focus-restore dance is needed, unlike zellij. Echoes "<workspace_id>
 # <surface_id>" on success.
 fm_backend_cmux_create_task() {  # <label> <cwd>
-  local label=$1 cwd=$2 title out wsid sfid
+  local label=$1 cwd=$2 title out wsid sfid exists_status
   title=$(fm_backend_cmux_scoped_title "$label")
   if fm_backend_cmux_workspace_exists "$label"; then
     echo "error: cmux workspace '$title' already exists" >&2
+    return 1
+  else
+    exists_status=$?
+  fi
+  if [ "$exists_status" -ne 1 ]; then
+    echo "error: could not inspect cmux workspaces; refusing to create '$title'" >&2
     return 1
   fi
   out=$(fm_backend_cmux_cli new-workspace --name "$title" --cwd "$cwd" --focus false --id-format uuids 2>&1) || {
     echo "error: cmux new-workspace failed for '$title': $out" >&2
     return 1
   }
-  wsid=$(fm_backend_cmux_workspace_id_for_label "$title")
+  wsid=$(fm_backend_cmux_workspace_id_for_label "$title") || {
+    echo "error: could not inspect cmux workspaces after creating '$title'" >&2
+    return 1
+  }
   [ -n "$wsid" ] || { echo "error: could not resolve a cmux workspace id for '$title' after creation" >&2; return 1; }
   sfid=$(fm_backend_cmux_surface_id_for_workspace "$wsid")
   [ -n "$sfid" ] || { echo "error: could not resolve the default surface for cmux workspace '$title' ($wsid)" >&2; return 1; }

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -335,6 +335,17 @@ fm_backend_cmux_workspace_id_for_label() {  # <label>
     | jq -r --arg want "$label" '.workspaces[]? | select(.title == $want) | .id' 2>/dev/null | head -1
 }
 
+# fm_backend_cmux_workspace_exists: does a live workspace already carry the
+# title <label> resolves to? This is the exact predicate
+# fm_backend_cmux_create_task refuses on, so it is also the only honest answer
+# to "would a leftover workspace refuse the next spawn of this task?" - a
+# surface-scoped liveness read answers a different question.
+fm_backend_cmux_workspace_exists() {  # <fm-task-label>
+  local label=$1
+  [ -n "$label" ] || return 1
+  [ -n "$(fm_backend_cmux_workspace_id_for_label "$(fm_backend_cmux_scoped_title "$label")")" ]
+}
+
 fm_backend_cmux_surface_id_for_workspace() {  # <workspace_id>
   local wsid=$1
   fm_backend_cmux_cli list-panes --workspace "$wsid" --json --id-format uuids 2>/dev/null \
@@ -351,10 +362,9 @@ fm_backend_cmux_surface_id_for_workspace() {  # <workspace_id>
 # focus-restore dance is needed, unlike zellij. Echoes "<workspace_id>
 # <surface_id>" on success.
 fm_backend_cmux_create_task() {  # <label> <cwd>
-  local label=$1 cwd=$2 title dup out wsid sfid
+  local label=$1 cwd=$2 title out wsid sfid
   title=$(fm_backend_cmux_scoped_title "$label")
-  dup=$(fm_backend_cmux_workspace_id_for_label "$title")
-  if [ -n "$dup" ]; then
+  if fm_backend_cmux_workspace_exists "$label"; then
     echo "error: cmux workspace '$title' already exists" >&2
     return 1
   fi

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -71,6 +71,22 @@ fm_backend_tmux_container_ensure() {
   fi
 }
 
+# fm_backend_tmux_window_exists: does <session> hold a window named EXACTLY
+# <window-name>? The session inventory is the only sound source. Verified
+# empirically against tmux 3.7b: `display-message -p -t "$ses:$wname"` resolves
+# an absent window by fnmatch and then by PREFIX, and when nothing matches at
+# all it silently falls back to the client's current window and still exits 0 -
+# anchoring the target (`=ses:=wname`) does not suppress that fallback either.
+# The same fallback is why fm_backend_tmux_agent_state insists on the inventory.
+# This is the exact predicate fm_backend_tmux_create_task refuses on, so it is
+# also the only honest answer to "would a leftover window refuse the next
+# spawn?" - callers needing that proof share this one definition.
+fm_backend_tmux_window_exists() {  # <session> <window-name>
+  local ses=$1 wname=$2
+  [ -n "$ses" ] && [ -n "$wname" ] || return 1
+  tmux list-windows -t "$ses" -F '#{window_name}' | grep -qx "$wname"
+}
+
 # fm_backend_tmux_create_task: create the task's window in <proj-abs>,
 # refusing an existing <window-name> in <session>. Mirrors fm-spawn.sh's
 # duplicate-check-then-new-window sequence, including the exact error text
@@ -88,7 +104,7 @@ fm_backend_tmux_container_ensure() {
 # lost, so worktree discovery cannot fall back to the active client's window.
 fm_backend_tmux_create_task() {  # <session> <window-name> <proj-abs> -> prints window id
   local ses=$1 wname=$2 proj_abs=$3 wid
-  if tmux list-windows -t "$ses" -F '#{window_name}' | grep -qx "$wname"; then
+  if fm_backend_tmux_window_exists "$ses" "$wname"; then
     echo "error: window $ses:$wname already exists" >&2
     return 1
   fi

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -85,7 +85,7 @@ fm_backend_tmux_window_exists() {  # <session> <window-name>
   local ses=$1 wname=$2 windows
   [ -n "$ses" ] && [ -n "$wname" ] || return 1
   windows=$(tmux list-windows -t "$ses" -F '#{window_name}') || return 2
-  printf '%s\n' "$windows" | grep -qx "$wname"
+  printf '%s\n' "$windows" | grep -qxF -- "$wname"
 }
 
 # fm_backend_tmux_create_task: create the task's window in <proj-abs>,

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -82,9 +82,10 @@ fm_backend_tmux_container_ensure() {
 # also the only honest answer to "would a leftover window refuse the next
 # spawn?" - callers needing that proof share this one definition.
 fm_backend_tmux_window_exists() {  # <session> <window-name>
-  local ses=$1 wname=$2
+  local ses=$1 wname=$2 windows
   [ -n "$ses" ] && [ -n "$wname" ] || return 1
-  tmux list-windows -t "$ses" -F '#{window_name}' | grep -qx "$wname"
+  windows=$(tmux list-windows -t "$ses" -F '#{window_name}') || return 2
+  printf '%s\n' "$windows" | grep -qx "$wname"
 }
 
 # fm_backend_tmux_create_task: create the task's window in <proj-abs>,
@@ -103,9 +104,15 @@ fm_backend_tmux_window_exists() {  # <session> <window-name>
 # The returned window id lets callers target the window even if its name is ever
 # lost, so worktree discovery cannot fall back to the active client's window.
 fm_backend_tmux_create_task() {  # <session> <window-name> <proj-abs> -> prints window id
-  local ses=$1 wname=$2 proj_abs=$3 wid
+  local ses=$1 wname=$2 proj_abs=$3 wid exists_status
   if fm_backend_tmux_window_exists "$ses" "$wname"; then
     echo "error: window $ses:$wname already exists" >&2
+    return 1
+  else
+    exists_status=$?
+  fi
+  if [ "$exists_status" -ne 1 ]; then
+    echo "error: could not inspect tmux windows in session '$ses'; refusing to create '$wname'" >&2
     return 1
   fi
   wid=$(tmux new-window -dP -F '#{window_id}' -t "$ses:" -n "$wname" -c "$proj_abs") || return 1

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -183,6 +183,9 @@ fm_backend_zellij_tab_exists() {  # <session> <label>
   local session=$1 label=$2 tabs
   [ -n "$session" ] && [ -n "$label" ] || return 1
   tabs=$(fm_backend_zellij_cli "$session" action list-tabs --json 2>/dev/null) || return 2
+  # Zellij actions can return status 0 while printing a non-JSON missing-session
+  # response. An unreadable inventory cannot prove this task's tab is gone.
+  printf '%s' "$tabs" | jq -e 'type == "array"' >/dev/null 2>&1 || return 2
   [ -n "$(fm_backend_zellij_tab_id_in_list "$tabs" "$(fm_backend_zellij_scoped_title "$label")")" ]
 }
 

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -166,6 +166,26 @@ fm_backend_zellij_scoped_title() {  # <fm-task-label>
   printf 'fm-%s-%s' "$home" "$rest"
 }
 
+# fm_backend_zellij_tab_id_in_list: the first tab id in a `list-tabs --json`
+# payload whose name equals <title>, or empty. One matcher so the duplicate
+# refusal below and the leftover-tab probe cannot drift apart.
+fm_backend_zellij_tab_id_in_list() {  # <tabs-json> <title>
+  printf '%s' "$1" | jq -r --arg want "$2" '.[]? | select(.name == $want) | .tab_id' 2>/dev/null | head -1
+}
+
+# fm_backend_zellij_tab_exists: does <session> already hold a tab titled for
+# <label>? This is the exact predicate fm_backend_zellij_create_task refuses
+# on, so it is also the only honest answer to "would a leftover tab refuse the
+# next spawn of this task?". Pane liveness cannot answer that: closing a tab's
+# only pane leaves the now-empty tab in list-tabs (see this file's header), so
+# a pane-scoped read reports the endpoint gone while the tab still collides.
+fm_backend_zellij_tab_exists() {  # <session> <label>
+  local session=$1 label=$2 tabs
+  [ -n "$session" ] && [ -n "$label" ] || return 1
+  tabs=$(fm_backend_zellij_cli "$session" action list-tabs --json 2>/dev/null)
+  [ -n "$(fm_backend_zellij_tab_id_in_list "$tabs" "$(fm_backend_zellij_scoped_title "$label")")" ]
+}
+
 # fm_backend_zellij_tool_check: refuse loudly if zellij or jq is missing.
 fm_backend_zellij_tool_check() {
   command -v zellij >/dev/null 2>&1 || { echo "error: backend=zellij selected but the 'zellij' CLI is not installed (https://zellij.dev)" >&2; return 1; }
@@ -335,7 +355,7 @@ fm_backend_zellij_create_task() {  # <session> <label> <cwd>
   fm_backend_zellij_session_exists "$session" || { echo "error: zellij session '$session' does not exist; run container_ensure first" >&2; return 1; }
   title=$(fm_backend_zellij_scoped_title "$label")
   tabs=$(fm_backend_zellij_cli "$session" action list-tabs --json 2>/dev/null)
-  dup=$(printf '%s' "$tabs" | jq -r --arg want "$title" '.[]? | select(.name == $want) | .tab_id' 2>/dev/null | head -1)
+  dup=$(fm_backend_zellij_tab_id_in_list "$tabs" "$title")
   if [ -n "$dup" ]; then
     echo "error: zellij tab '$title' already exists in session '$session'" >&2
     return 1

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -359,7 +359,10 @@ fm_backend_zellij_create_task() {  # <session> <label> <cwd>
   title=$(fm_backend_zellij_scoped_title "$label")
   tabs=$(fm_backend_zellij_cli "$session" action list-tabs --json 2>/dev/null)
   list_status=$?
-  if [ "$list_status" -ne 0 ]; then
+  # Zellij actions can return status 0 while printing a non-JSON missing-session
+  # response. An unreadable inventory cannot prove no tab already holds $title,
+  # so it refuses exactly as fm_backend_zellij_tab_exists does.
+  if [ "$list_status" -ne 0 ] || ! printf '%s' "$tabs" | jq -e 'type == "array"' >/dev/null 2>&1; then
     echo "error: could not inspect zellij tabs in session '$session'; refusing to create '$title'" >&2
     return 1
   fi

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -182,7 +182,7 @@ fm_backend_zellij_tab_id_in_list() {  # <tabs-json> <title>
 fm_backend_zellij_tab_exists() {  # <session> <label>
   local session=$1 label=$2 tabs
   [ -n "$session" ] && [ -n "$label" ] || return 1
-  tabs=$(fm_backend_zellij_cli "$session" action list-tabs --json 2>/dev/null)
+  tabs=$(fm_backend_zellij_cli "$session" action list-tabs --json 2>/dev/null) || return 2
   [ -n "$(fm_backend_zellij_tab_id_in_list "$tabs" "$(fm_backend_zellij_scoped_title "$label")")" ]
 }
 
@@ -351,10 +351,15 @@ fm_backend_zellij_tab_matches_label() {  # <session> <tab_id> <label>
 #
 # Echoes "<tab_id> <pane_id>" on success.
 fm_backend_zellij_create_task() {  # <session> <label> <cwd>
-  local session=$1 label=$2 cwd=$3 title tabs dup prev_active tab_id pane_id
+  local session=$1 label=$2 cwd=$3 title tabs dup prev_active tab_id pane_id list_status
   fm_backend_zellij_session_exists "$session" || { echo "error: zellij session '$session' does not exist; run container_ensure first" >&2; return 1; }
   title=$(fm_backend_zellij_scoped_title "$label")
   tabs=$(fm_backend_zellij_cli "$session" action list-tabs --json 2>/dev/null)
+  list_status=$?
+  if [ "$list_status" -ne 0 ]; then
+    echo "error: could not inspect zellij tabs in session '$session'; refusing to create '$title'" >&2
+    return 1
+  fi
   dup=$(fm_backend_zellij_tab_id_in_list "$tabs" "$title")
   if [ -n "$dup" ]; then
     echo "error: zellij tab '$title' already exists in session '$session'" >&2

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -779,7 +779,10 @@ fm_backend_endpoint_blocks_respawn() {  # <backend> <target> <label>
       fm_backend_tmux_window_exists "${target%%:*}" "${target#*:}"
       check_status=$?
       ;;
-    herdr) ! fm_backend_herdr_endpoint_confirmed_gone "$target" ;;
+    herdr)
+      ! fm_backend_herdr_endpoint_confirmed_gone "$target"
+      check_status=$?
+      ;;
     zellij)
       fm_backend_zellij_tab_exists "${target%%:*}" "$label"
       check_status=$?
@@ -788,14 +791,13 @@ fm_backend_endpoint_blocks_respawn() {  # <backend> <target> <label>
       fm_backend_cmux_workspace_exists "$label"
       check_status=$?
       ;;
-    *) fm_backend_target_exists "$backend" "$target" ;;
-  esac
-  case "$backend" in
-    tmux|zellij|cmux)
-      [ "$check_status" -eq 1 ] && return 1
-      return 0
+    *)
+      fm_backend_target_exists "$backend" "$target"
+      check_status=$?
       ;;
   esac
+  [ "$check_status" -eq 1 ] && return 1
+  return 0
 }
 
 fm_backend_remove_worktree() {  # <backend> <worktree-id>

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -756,6 +756,33 @@ fm_backend_kill() {  # <backend> <target>
   esac
 }
 
+# fm_backend_endpoint_blocks_respawn: after a best-effort close, would a
+# leftover endpoint still refuse the NEXT spawn of <label>? This is not
+# liveness. Every backend gates a fresh task on a NAME it already holds - a
+# tmux window name, a herdr tab label, a zellij tab title, a cmux workspace
+# title - so the only sound proof that a close left the slot retryable is the
+# very predicate that backend's create_task refuses on. Asking
+# fm_backend_target_exists instead asks whether a pane/surface id is alive,
+# which can report "gone" while the named container survives and collides:
+# closing a zellij tab's only pane leaves the empty tab in list-tabs.
+# herdr routes through its own fm_backend_herdr_endpoint_confirmed_gone, which
+# is deliberately stricter than a liveness read - only a structured
+# pane_not_found proves absence, and an unknown or unreadable pane refuses -
+# and its duplicate gate prunes husk tabs, so a confirmed-gone pane is exactly
+# a non-colliding tab. Orca has no such name gate; it keeps the liveness read.
+# Conservative by construction: anything short of proof reads as "still there".
+fm_backend_endpoint_blocks_respawn() {  # <backend> <target> <label>
+  local backend=$1 target=$2 label=$3
+  fm_backend_source "$backend" || return 1
+  case "$backend" in
+    tmux) fm_backend_tmux_window_exists "${target%%:*}" "${target#*:}" ;;
+    herdr) ! fm_backend_herdr_endpoint_confirmed_gone "$target" ;;
+    zellij) fm_backend_zellij_tab_exists "${target%%:*}" "$label" ;;
+    cmux) fm_backend_cmux_workspace_exists "$label" ;;
+    *) fm_backend_target_exists "$backend" "$target" ;;
+  esac
+}
+
 fm_backend_remove_worktree() {  # <backend> <worktree-id>
   local backend=$1
   shift

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -774,29 +774,27 @@ fm_backend_kill() {  # <backend> <target>
 fm_backend_endpoint_blocks_respawn() {  # <backend> <target> <label>
   local backend=$1 target=$2 label=$3 check_status
   fm_backend_source "$backend" || return 1
+  check_status=0
   case "$backend" in
     tmux)
-      fm_backend_tmux_window_exists "${target%%:*}" "${target#*:}"
-      check_status=$?
+      fm_backend_tmux_window_exists "${target%%:*}" "${target#*:}" || check_status=$?
       ;;
     herdr)
-      ! fm_backend_herdr_endpoint_confirmed_gone "$target"
-      check_status=$?
+      ! fm_backend_herdr_endpoint_confirmed_gone "$target" || check_status=$?
       ;;
     zellij)
-      fm_backend_zellij_tab_exists "${target%%:*}" "$label"
-      check_status=$?
+      fm_backend_zellij_tab_exists "${target%%:*}" "$label" || check_status=$?
       ;;
     cmux)
-      fm_backend_cmux_workspace_exists "$label"
-      check_status=$?
+      fm_backend_cmux_workspace_exists "$label" || check_status=$?
       ;;
     *)
-      fm_backend_target_exists "$backend" "$target"
-      check_status=$?
+      fm_backend_target_exists "$backend" "$target" || check_status=$?
       ;;
   esac
-  [ "$check_status" -eq 1 ] && return 1
+  if [ "$check_status" -eq 1 ]; then
+    return 1
+  fi
   return 0
 }
 

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -772,14 +772,29 @@ fm_backend_kill() {  # <backend> <target>
 # a non-colliding tab. Orca has no such name gate; it keeps the liveness read.
 # Conservative by construction: anything short of proof reads as "still there".
 fm_backend_endpoint_blocks_respawn() {  # <backend> <target> <label>
-  local backend=$1 target=$2 label=$3
+  local backend=$1 target=$2 label=$3 check_status
   fm_backend_source "$backend" || return 1
   case "$backend" in
-    tmux) fm_backend_tmux_window_exists "${target%%:*}" "${target#*:}" ;;
+    tmux)
+      fm_backend_tmux_window_exists "${target%%:*}" "${target#*:}"
+      check_status=$?
+      ;;
     herdr) ! fm_backend_herdr_endpoint_confirmed_gone "$target" ;;
-    zellij) fm_backend_zellij_tab_exists "${target%%:*}" "$label" ;;
-    cmux) fm_backend_cmux_workspace_exists "$label" ;;
+    zellij)
+      fm_backend_zellij_tab_exists "${target%%:*}" "$label"
+      check_status=$?
+      ;;
+    cmux)
+      fm_backend_cmux_workspace_exists "$label"
+      check_status=$?
+      ;;
     *) fm_backend_target_exists "$backend" "$target" ;;
+  esac
+  case "$backend" in
+    tmux|zellij|cmux)
+      [ "$check_status" -eq 1 ] && return 1
+      return 0
+      ;;
   esac
 }
 

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -773,7 +773,7 @@ fm_backend_kill() {  # <backend> <target>
 # Conservative by construction: anything short of proof reads as "still there".
 fm_backend_endpoint_blocks_respawn() {  # <backend> <target> <label>
   local backend=$1 target=$2 label=$3 check_status
-  fm_backend_source "$backend" || return 1
+  fm_backend_source "$backend" || return 0
   check_status=0
   case "$backend" in
     tmux)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -134,6 +134,8 @@
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
+#   They also refuse when another task's durable metadata already claims that
+#   resolved worktree, without consulting process or treehouse occupancy state.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
@@ -727,6 +729,7 @@ RELAUNCH_REPLACEMENT_STATE=
 RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
+SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP=0
 
 spawn_fresh_commit_rollback() {
   if fm_backlog_atomic_transition rollback "$STATE/$ID.meta" \
@@ -836,6 +839,12 @@ spawn_abort_cleanup() {
             || true
         fi
       fi
+    fi
+  fi
+  if [ "$SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP" = 1 ]; then
+    SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP=0
+    if ! fm_backend_kill "$BACKEND" "$T"; then
+      echo "warning: could not retire the new endpoint after refusing claimed worktree '$WT'" >&2
     fi
   fi
   if [ "$SPAWN_TASK_LOCK_HELD" = 1 ]; then
@@ -1825,6 +1834,27 @@ real_path_or_raw() {  # <path>
   fi
 }
 
+assert_spawn_worktree_unclaimed() {
+  local wt_real meta owner recorded recorded_real
+  wt_real=$(real_path_or_raw "$WT")
+  for meta in "$STATE"/*.meta; do
+    [ -f "$meta" ] && [ ! -L "$meta" ] || continue
+    owner=${meta##*/}
+    owner=${owner%.meta}
+    [ "$owner" != "$ID" ] || continue
+    recorded=$(fm_meta_get "$meta" worktree)
+    [ -n "$recorded" ] || continue
+    recorded_real=$(real_path_or_raw "$recorded")
+    [ "$recorded_real" != "$wt_real" ] || {
+      if [ "$RELAUNCH" -eq 0 ] && [ "$BACKEND" != orca ]; then
+        SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP=1
+      fi
+      echo "error: allocated worktree '$WT' is already claimed by live task $owner; refusing to launch task $ID" >&2
+      return 1
+    }
+  done
+}
+
 # Session-provider container-ensure + task creation. tmux stays exactly as P1
 # left it (same session-name / new-window sequence, see bin/backends/tmux.sh);
 # a herdr spawn goes through the version-gated, workspace-per-HOME,
@@ -2468,6 +2498,9 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   fi
 
   validate_spawn_worktree "treehouse get" "$T"
+fi
+if [ "$KIND" != secondmate ]; then
+  assert_spawn_worktree_unclaimed || exit 1
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -136,9 +136,14 @@
 #   git worktree root distinct from the primary project checkout.
 #   They also refuse when another task's durable metadata already claims that
 #   resolved worktree, without consulting process or treehouse occupancy state.
+#   The refusal names the owning task AND the record file it read, because a
+#   claim is not proof of a live worker: a teardown that aborted after
+#   returning the lease leaves a record whose worktree is genuinely free, and
+#   only removing that record clears the slot.
 #   That refusal retires the endpoint it just created. For every backend but
 #   orca - whose terminal and worktree are retired by the orca abort path
-#   instead - it then reads the endpoint back, because a backend close is only
+#   instead - it then reads back the NAME its next spawn would collide on
+#   (fm_backend_endpoint_blocks_respawn), because a backend close is only
 #   best-effort, and names a survivor so the operator can retire the one thing
 #   that would refuse the retry.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
@@ -763,19 +768,6 @@ parse_orca_worktree_result() {
   fi
 }
 
-# Is <target> still present on <backend> after a best-effort close? tmux gets
-# the window-name inventory (fm_backend_tmux_window_exists) rather than the
-# generic fm_backend_target_exists probe: only the inventory is exact, and only
-# the exact window name is what refuses the next spawn. Every other backend has
-# no such name-collision gate, so the shared liveness read is the best answer
-# available there.
-spawn_endpoint_survives() {  # <backend> <target>
-  case "$1" in
-    tmux) fm_backend_tmux_window_exists "${2%%:*}" "${2#*:}" ;;
-    *) fm_backend_target_exists "$1" "$2" 2>/dev/null ;;
-  esac
-}
-
 spawn_abort_cleanup() {
   local status=$?
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
@@ -863,11 +855,12 @@ spawn_abort_cleanup() {
     SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP=0
     # Every backend's kill is contractually best-effort (fm_backend_kill), so
     # its exit status alone never proves the endpoint is gone. Retryability is
-    # what this cleanup owes the caller, and only a read-back can establish it;
-    # a survivor is named so it can be retired by hand.
+    # what this cleanup owes the caller, and only a read-back of the name that
+    # gates the next spawn can establish it; a survivor is named so it can be
+    # retired by hand.
     if ! fm_backend_kill "$BACKEND" "$T" \
-       || spawn_endpoint_survives "$BACKEND" "$T"; then
-      echo "warning: the new $BACKEND endpoint $T survived the refusal of claimed worktree '$WT'; retire it before retrying task $ID, or the next spawn will refuse the leftover endpoint" >&2
+       || fm_backend_endpoint_blocks_respawn "$BACKEND" "$T" "$W" 2>/dev/null; then
+      echo "warning: the new $BACKEND endpoint $T named $W survived the refusal of claimed worktree '$WT'; retire it before retrying task $ID, or the next spawn will refuse the leftover $W" >&2
     fi
   fi
   if [ "$SPAWN_TASK_LOCK_HELD" = 1 ]; then
@@ -1872,7 +1865,7 @@ assert_spawn_worktree_unclaimed() {
       if [ "$RELAUNCH" -eq 0 ] && [ "$BACKEND" != orca ]; then
         SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP=1
       fi
-      echo "error: allocated worktree '$WT' is already claimed by live task $owner; refusing to launch task $ID" >&2
+      echo "error: allocated worktree '$WT' is already claimed by task $owner in $meta; refusing to launch task $ID. That record claims the worktree; it does not prove a live worker. If $owner has already finished, the record is a leftover from an incomplete cleanup and must be removed before this worktree can be used." >&2
       return 1
     }
   done

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1854,6 +1854,23 @@ real_path_or_raw() {  # <path>
   fi
 }
 
+# assert_spawn_worktree_unclaimed: refuse a candidate worktree that another
+# still-recorded task in THIS home already records as its worktree=.
+#
+# The claim set is deliberately this home's own $STATE/*.meta and nothing else.
+# The invariant it establishes therefore holds within one firstmate home, not
+# across homes. The uncovered condition is two or more homes sharing a single
+# treehouse pool for the same project: treehouse marks a pooled slot in-use by
+# live PROCESS detection, so after a terminal-app or session restart kills every
+# pane, every pooled slot reads AVAILABLE. A spawn in one home can then be handed
+# a worktree that a DIFFERENT home's state/<id>.meta still claims, this scan
+# finds no claim in its own $STATE, and the launch proceeds - after which
+# freshen_spawn_worktree_base resets that worktree to origin's default-branch
+# tip, losing any uncommitted work in it.
+#
+# Widening the scan across sibling homes is tracked separately and is
+# deliberately out of scope here: it would add a cross-home read, and a new
+# failure mode, to the spawn path.
 assert_spawn_worktree_unclaimed() {
   local wt_real meta owner recorded recorded_real
   wt_real=$(real_path_or_raw "$WT")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1884,6 +1884,17 @@ real_path_or_raw() {  # <path>
 # record by hand. The refusal message already names the owning task, the record
 # file, and the unresolvable path, which is what an operator needs to clear it.
 #
+# A --relaunch is exempt from the unresolvable-value refusal and continues past
+# such a record exactly as an absent value is skipped. A relaunch allocates no
+# worktree - $WT is the task's own recorded copy, where its endpoint already
+# sits - and freshen_spawn_worktree_base only runs when RELAUNCH is 0, so the
+# destructive base reset this refusal exists to prevent cannot occur there.
+# Without the exemption a single stale foreign record would refuse every
+# relaunch in the home, so a guard meant to prevent losing work would block the
+# recovery path used to replace a stuck worker. A resolved foreign claim that
+# matches the candidate still refuses on relaunch, as does an unresolvable value
+# on a fresh spawn.
+#
 # Widening the scan across sibling homes is tracked separately and is
 # deliberately out of scope here: it would add a cross-home read, and a new
 # failure mode, to the spawn path.
@@ -1898,7 +1909,8 @@ assert_spawn_worktree_unclaimed() {
     recorded=$(fm_meta_get "$meta" worktree)
     [ -n "$recorded" ] || continue
     if ! recorded_real=$(cd "$recorded" 2>/dev/null && pwd -P); then
-      if [ "$RELAUNCH" -eq 0 ] && [ "$BACKEND" != orca ]; then
+      [ "$RELAUNCH" -eq 0 ] || continue
+      if [ "$BACKEND" != orca ]; then
         SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP=1
       fi
       echo "error: task $owner record $meta has worktree='$recorded', but that recorded path could not be resolved; refusing to launch task $ID because an unresolvable claim is not evidence of a free worktree." >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -862,8 +862,8 @@ spawn_abort_cleanup() {
     # what this cleanup owes the caller, and only a read-back of the name that
     # gates the next spawn can establish it; a survivor is named so it can be
     # retired by hand.
-    if ! fm_backend_kill "$BACKEND" "$T" "${ZELLIJ_TAB_ID:-}" "$W" \
-       || fm_backend_endpoint_blocks_respawn "$BACKEND" "$T" "$W" 2>/dev/null; then
+    fm_backend_kill "$BACKEND" "$T" "${ZELLIJ_TAB_ID:-}" "$W" || true
+    if fm_backend_endpoint_blocks_respawn "$BACKEND" "$T" "$W" 2>/dev/null; then
       echo "warning: the new $BACKEND endpoint $T named $W survived the refusal of claimed worktree '$WT'; retire it before retrying task $ID, or the next spawn will refuse the leftover $W" >&2
     fi
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1868,6 +1868,11 @@ real_path_or_raw() {  # <path>
 # freshen_spawn_worktree_base resets that worktree to origin's default-branch
 # tip, losing any uncommitted work in it.
 #
+# A present worktree= value that cannot resolve to a real path refuses because
+# it cannot prove a candidate is free, while an absent worktree= remains
+# skipped. Failing closed on every unreadable record was rejected because one
+# corrupt or half-written record would wedge every spawn in this home.
+#
 # Widening the scan across sibling homes is tracked separately and is
 # deliberately out of scope here: it would add a cross-home read, and a new
 # failure mode, to the spawn path.
@@ -1881,7 +1886,13 @@ assert_spawn_worktree_unclaimed() {
     [ "$owner" != "$ID" ] || continue
     recorded=$(fm_meta_get "$meta" worktree)
     [ -n "$recorded" ] || continue
-    recorded_real=$(real_path_or_raw "$recorded")
+    if ! recorded_real=$(cd "$recorded" 2>/dev/null && pwd -P); then
+      if [ "$RELAUNCH" -eq 0 ] && [ "$BACKEND" != orca ]; then
+        SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP=1
+      fi
+      echo "error: task $owner record $meta has worktree='$recorded', but that recorded path could not be resolved; refusing to launch task $ID because an unresolvable claim is not evidence of a free worktree." >&2
+      return 1
+    fi
     [ "$recorded_real" != "$wt_real" ] || {
       if [ "$RELAUNCH" -eq 0 ] && [ "$BACKEND" != orca ]; then
         SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP=1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -853,12 +853,16 @@ spawn_abort_cleanup() {
   fi
   if [ "$SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP" = 1 ]; then
     SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP=0
+    # The four-argument kill every other endpoint-retiring call site uses: the
+    # recorded zellij tab id and the expected label keep the close on the TAB
+    # when a transient pane lookup comes up empty, instead of degrading to a
+    # close-pane that leaves the empty tab behind.
     # Every backend's kill is contractually best-effort (fm_backend_kill), so
     # its exit status alone never proves the endpoint is gone. Retryability is
     # what this cleanup owes the caller, and only a read-back of the name that
     # gates the next spawn can establish it; a survivor is named so it can be
     # retired by hand.
-    if ! fm_backend_kill "$BACKEND" "$T" \
+    if ! fm_backend_kill "$BACKEND" "$T" "${ZELLIJ_TAB_ID:-}" "$W" \
        || fm_backend_endpoint_blocks_respawn "$BACKEND" "$T" "$W" 2>/dev/null; then
       echo "warning: the new $BACKEND endpoint $T named $W survived the refusal of claimed worktree '$WT'; retire it before retrying task $ID, or the next spawn will refuse the leftover $W" >&2
     fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -136,9 +136,11 @@
 #   git worktree root distinct from the primary project checkout.
 #   They also refuse when another task's durable metadata already claims that
 #   resolved worktree, without consulting process or treehouse occupancy state.
-#   That refusal retires the endpoint it just created and then PROVES it is
-#   gone, because every backend close is best-effort; a survivor is named so
-#   the operator can retire the one thing that would refuse the retry.
+#   That refusal retires the endpoint it just created. For every backend but
+#   orca - whose terminal and worktree are retired by the orca abort path
+#   instead - it then reads the endpoint back, because a backend close is only
+#   best-effort, and names a survivor so the operator can retire the one thing
+#   that would refuse the retry.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
@@ -761,6 +763,19 @@ parse_orca_worktree_result() {
   fi
 }
 
+# Is <target> still present on <backend> after a best-effort close? tmux gets
+# the window-name inventory (fm_backend_tmux_window_exists) rather than the
+# generic fm_backend_target_exists probe: only the inventory is exact, and only
+# the exact window name is what refuses the next spawn. Every other backend has
+# no such name-collision gate, so the shared liveness read is the best answer
+# available there.
+spawn_endpoint_survives() {  # <backend> <target>
+  case "$1" in
+    tmux) fm_backend_tmux_window_exists "${2%%:*}" "${2#*:}" ;;
+    *) fm_backend_target_exists "$1" "$2" 2>/dev/null ;;
+  esac
+}
+
 spawn_abort_cleanup() {
   local status=$?
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
@@ -848,10 +863,10 @@ spawn_abort_cleanup() {
     SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP=0
     # Every backend's kill is contractually best-effort (fm_backend_kill), so
     # its exit status alone never proves the endpoint is gone. Retryability is
-    # what this cleanup owes the caller, and only the read-only existence probe
-    # can establish it; a survivor is named so it can be retired by hand.
+    # what this cleanup owes the caller, and only a read-back can establish it;
+    # a survivor is named so it can be retired by hand.
     if ! fm_backend_kill "$BACKEND" "$T" \
-       || fm_backend_target_exists "$BACKEND" "$T" 2>/dev/null; then
+       || spawn_endpoint_survives "$BACKEND" "$T"; then
       echo "warning: the new $BACKEND endpoint $T survived the refusal of claimed worktree '$WT'; retire it before retrying task $ID, or the next spawn will refuse the leftover endpoint" >&2
     fi
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1870,8 +1870,19 @@ real_path_or_raw() {  # <path>
 #
 # A present worktree= value that cannot resolve to a real path refuses because
 # it cannot prove a candidate is free, while an absent worktree= remains
-# skipped. Failing closed on every unreadable record was rejected because one
-# corrupt or half-written record would wedge every spawn in this home.
+# skipped. Failing closed on every unreadable record was rejected because a
+# single unreadable record would wedge every spawn in this home.
+#
+# That wedge is not limited to a corrupt or half-written record; there is a
+# routine path into it. bin/fm-teardown.sh deletes an orca task's worktree
+# (fm_backend_remove_worktree) before it removes the durable record, and record
+# removal has an explicitly handled failure exit ("$ID's endpoint and local copy
+# are cleaned up, but its task record could not be removed"). A record that
+# survives that window points at a directory that no longer exists, so it cannot
+# resolve, and from then on EVERY spawn in this home refuses - including spawns
+# targeting entirely unrelated worktrees - until an operator removes the stale
+# record by hand. The refusal message already names the owning task, the record
+# file, and the unresolvable path, which is what an operator needs to clear it.
 #
 # Widening the scan across sibling homes is tracked separately and is
 # deliberately out of scope here: it would add a cross-home read, and a new

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -140,11 +140,11 @@
 #   claim is not proof of a live worker: a teardown that aborted after
 #   returning the lease leaves a record whose worktree is genuinely free, and
 #   only removing that record clears the slot.
-#   That refusal retires the endpoint it just created. For every backend but
-#   orca - whose terminal and worktree are retired by the orca abort path
+#   That refusal attempts to retire the endpoint it just created. For every
+#   backend but orca - whose terminal and worktree use the orca abort path
 #   instead - it then reads back the NAME its next spawn would collide on
 #   (fm_backend_endpoint_blocks_respawn), because a backend close is only
-#   best-effort, and names a survivor so the operator can retire the one thing
+#   best-effort. A survivor is named so the operator can retire the one thing
 #   that would refuse the retry.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -136,6 +136,9 @@
 #   git worktree root distinct from the primary project checkout.
 #   They also refuse when another task's durable metadata already claims that
 #   resolved worktree, without consulting process or treehouse occupancy state.
+#   That refusal retires the endpoint it just created and then PROVES it is
+#   gone, because every backend close is best-effort; a survivor is named so
+#   the operator can retire the one thing that would refuse the retry.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
@@ -843,8 +846,13 @@ spawn_abort_cleanup() {
   fi
   if [ "$SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP" = 1 ]; then
     SPAWN_WORKTREE_CLAIM_ABORT_CLEANUP=0
-    if ! fm_backend_kill "$BACKEND" "$T"; then
-      echo "warning: could not retire the new endpoint after refusing claimed worktree '$WT'" >&2
+    # Every backend's kill is contractually best-effort (fm_backend_kill), so
+    # its exit status alone never proves the endpoint is gone. Retryability is
+    # what this cleanup owes the caller, and only the read-only existence probe
+    # can establish it; a survivor is named so it can be retired by hand.
+    if ! fm_backend_kill "$BACKEND" "$T" \
+       || fm_backend_target_exists "$BACKEND" "$T" 2>/dev/null; then
+      echo "warning: the new $BACKEND endpoint $T survived the refusal of claimed worktree '$WT'; retire it before retrying task $ID, or the next spawn will refuse the leftover endpoint" >&2
     fi
   fi
   if [ "$SPAWN_TASK_LOCK_HELD" = 1 ]; then

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,9 +193,9 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout and unclaimed by another durable task metadata record.
-Its canonical-path claim check lets a task relaunch into its own recorded worktree, while a fresh collision retires its newly created endpoint.
-For every backend but Orca — whose terminal and worktree are retired by the Orca abort path, with no read-back — the collision then verifies the removal so the allocation can be retried, naming an endpoint that survived the best-effort close instead of silently reporting it as retired.
-A claim is a record, not a liveness proof, so the refusal names the record file too: a teardown that aborted after returning its treehouse lease leaves a stale claim on a genuinely free worktree, and removing that record is what clears the slot.
+Its canonical-path claim check lets a task relaunch into its own recorded worktree, while a fresh collision attempts to retire its newly created endpoint.
+For every backend but Orca - whose terminal and worktree use the Orca abort path with no name read-back - the collision verifies that the name no longer blocks a retry, naming an endpoint that survived the best-effort close instead of silently reporting it as retired.
+A claim is a record, not a liveness proof, so the refusal names the record file too: incomplete cleanup can leave a stale claim on a genuinely free worktree, and removing that record is what clears the slot.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-tangle-guard.test.sh` and `tests/fm-spawn-pool-base-freshen.test.sh` own the portable regression coverage.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,7 +193,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout and unclaimed by another durable task metadata record.
-Its canonical-path claim check lets a task relaunch into its own recorded worktree, while a fresh collision retires its newly created endpoint so the allocation can be retried.
+Its canonical-path claim check lets a task relaunch into its own recorded worktree, while a fresh collision retires its newly created endpoint and verifies the removal so the allocation can be retried; an endpoint that survives the best-effort close is named instead of silently reported as retired.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-tangle-guard.test.sh` and `tests/fm-spawn-pool-base-freshen.test.sh` own the portable regression coverage.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,9 +192,10 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
-For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
+For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout and unclaimed by another durable task metadata record.
+Its canonical-path claim check lets a task relaunch into its own recorded worktree, while a fresh collision retires its newly created endpoint so the allocation can be retried.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
-Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
+Its header owns the exact refusal mechanics, while `tests/fm-tangle-guard.test.sh` and `tests/fm-spawn-pool-base-freshen.test.sh` own the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,7 +193,9 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout and unclaimed by another durable task metadata record.
-Its canonical-path claim check lets a task relaunch into its own recorded worktree, while a fresh collision retires its newly created endpoint and verifies the removal so the allocation can be retried; an endpoint that survives the best-effort close is named instead of silently reported as retired.
+Its canonical-path claim check lets a task relaunch into its own recorded worktree, while a fresh collision retires its newly created endpoint.
+For every backend but Orca — whose terminal and worktree are retired by the Orca abort path, with no read-back — the collision then verifies the removal so the allocation can be retried, naming an endpoint that survived the best-effort close instead of silently reporting it as retired.
+A claim is a record, not a liveness proof, so the refusal names the record file too: a teardown that aborted after returning its treehouse lease leaves a stale claim on a genuinely free worktree, and removing that record is what clears the slot.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-tangle-guard.test.sh` and `tests/fm-spawn-pool-base-freshen.test.sh` own the portable regression coverage.
 

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -46,7 +46,8 @@ Verify setup by spawning a small task and confirming its `fm-<id>` window appear
 
 ### Agent liveness probe
 
-A target-existence check proves only that the pane exists.
+A target-existence check proves only that some pane answered, never that the named window exists: tmux resolves an unmatched window name by prefix and otherwise falls back to the client's current window, still exiting 0 ([evidence](verification/runtime-backends.md#window-name-resolution)).
+Exact window identity comes from the session inventory instead, which is also what proves an endpoint was really retired.
 The deeper tmux agent-liveness probe first verifies exact window membership, then reads process names to distinguish a running harness from a bare idle shell.
 It classifies recognized Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, Cursor, and Muse process identities as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
 Only `dead` and `missing` authorize recovery because a false dead result could launch a duplicate agent.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -30,6 +30,29 @@ zsh
 A persistent parent shell waiting for a child remained reported as the parent process, while a shell that directly execed a simple command changed identity with the process itself.
 Pi and pi-signed 0.82.0 were reverified on 2026-07-27 through real isolated `fm-spawn.sh` launches.
 
+### Window-name resolution
+
+Window-name resolution was verified on 2026-08-29 with tmux 3.7b on macOS, on a private socket holding one session with the single window `fm-auth-fix`.
+
+```sh
+tmux -S "$socket" display-message -p -t 'fmdoc:fm-auth' '#{window_name}'
+tmux -S "$socket" display-message -p -t '=fmdoc:=fm-auth' '#{window_name}'
+tmux -S "$socket" display-message -p -t 'fmdoc:nope' '#{window_name}'
+tmux -S "$socket" list-windows -t fmdoc -F '#{window_name}' | grep -qx fm-auth
+```
+
+Observed output:
+
+```text
+fm-auth-fix
+fm-auth-fix
+fm-auth-fix
+# the list-windows match exited 1
+```
+
+Every `display-message` form answered for a window whose name was never asked for and still exited 0: an absent window name resolves by fnmatch and then by prefix, a name matching nothing at all falls back to the client's current window, and anchoring the target (`=session:=window`) suppresses neither fallback.
+Only the session inventory answers window identity exactly, so `fm_backend_tmux_window_exists` is the one definition shared by the create-task duplicate refusal, the agent-liveness probe's window-membership check, and `fm-spawn.sh`'s read-back of an endpoint it retired after refusing a claimed worktree.
+
 ### Agent liveness name sources
 
 The earlier record that every harness is observed under its own `#{pane_current_command}` no longer holds and has been replaced by the per-harness evidence below.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -51,7 +51,7 @@ fm-auth-fix
 ```
 
 Every `display-message` form answered for a window whose name was never asked for and still exited 0: an absent window name resolves by fnmatch and then by prefix, a name matching nothing at all falls back to the client's current window, and anchoring the target (`=session:=window`) suppresses neither fallback.
-Only the session inventory answers window identity exactly, so `fm_backend_tmux_window_exists` is the one definition shared by the create-task duplicate refusal, the agent-liveness probe's window-membership check, and `fm-spawn.sh`'s read-back of an endpoint it retired after refusing a claimed worktree.
+Only the session inventory answers window identity exactly, so `fm_backend_tmux_window_exists` is the one definition shared by the create-task duplicate refusal and `fm-spawn.sh`'s read-back of an endpoint it retired after refusing a claimed worktree. The agent-liveness probe applies the same session-inventory rule through its own `list-windows` read, because it needs that command's stderr to separate a missing window from an unreadable one.
 
 ### Agent liveness name sources
 

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -100,13 +100,26 @@ fm_test_fake_gh_axi() {
 # The pane path defaults to empty when FM_FAKE_PANE_PATH is unset. Window
 # cleanup and option operations are no-ops. Launch logging is env-gated, so
 # suites that do not set FM_FAKE_LAUNCH_LOG keep a silent send-keys.
+#
+# FM_FAKE_PANE_PATH_DIR opts into per-window pane paths: `new-window -n <name>`
+# records <name> and pane_current_path then answers "<dir>/<name>" instead of
+# the one shared FM_FAKE_PANE_PATH. That models the real thing a multi-task
+# spawn depends on - treehouse hands every task its OWN worktree - which a
+# single fixed pane path cannot express once two tasks run in one home.
 fm_test_fake_tmux_spawn() {
   local fakebin=$1
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+fm_fake_pane_path() {
+  if [ -n "${FM_FAKE_PANE_PATH_DIR:-}" ] && [ -r "$FM_FAKE_PANE_PATH_DIR/.last-window" ]; then
+    printf '%s/%s\n' "$FM_FAKE_PANE_PATH_DIR" "$(cat "$FM_FAKE_PANE_PATH_DIR/.last-window")"
+    return 0
+  fi
+  printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
+}
 case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"#{pane_current_path}"*) fm_fake_pane_path; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
@@ -116,7 +129,20 @@ case "${1:-}" in
     fi
     exit 0
     ;;
-  has-session|new-session|new-window|kill-window|set-window-option) exit 0 ;;
+  new-window)
+    if [ -n "${FM_FAKE_PANE_PATH_DIR:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-n" ]; then
+          printf '%s\n' "$a" > "$FM_FAKE_PANE_PATH_DIR/.last-window"
+          break
+        fi
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
+  has-session|new-session|kill-window|set-window-option) exit 0 ;;
   send-keys)
     if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
       prev=

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -1149,6 +1149,23 @@ test_endpoint_blocks_respawn_clear_when_no_workspace_carries_the_title() {
   pass "fm_backend_endpoint_blocks_respawn: an unrelated cmux workspace leaves the slot retryable"
 }
 
+test_endpoint_blocks_respawn_when_workspace_inventory_is_unreadable() {
+  local dir fb out
+  dir="$TMP_ROOT/blocks-respawn-unreadable"; mkdir -p "$dir/responses"
+  printf '1\n' > "$dir/responses/1.exit"
+  fb=$(make_cmux_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
+    FM_HOME="$dir" \
+    bash -c '
+      . "$0/bin/fm-backend.sh"
+      t=aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111
+      if fm_backend_endpoint_blocks_respawn cmux "$t" fm-corph; then echo blocks=yes; else echo blocks=no; fi
+    ' "$ROOT")
+  assert_contains "$out" "blocks=yes" \
+    "an unreadable cmux workspace inventory must not claim the endpoint is retryable"
+  pass "fm_backend_endpoint_blocks_respawn: unreadable cmux inventory blocks a respawn"
+}
+
 test_version_check_accepts_current_version
 test_version_check_accepts_newer_version
 test_version_check_refuses_old_version
@@ -1213,3 +1230,4 @@ test_list_live_filters_by_title_prefix
 test_secondmate_spawn_refuses_cmux_backend
 test_endpoint_blocks_respawn_sees_the_workspace_a_surface_read_misses
 test_endpoint_blocks_respawn_clear_when_no_workspace_carries_the_title
+test_endpoint_blocks_respawn_when_workspace_inventory_is_unreadable

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -1166,6 +1166,26 @@ test_endpoint_blocks_respawn_when_workspace_inventory_is_unreadable() {
   pass "fm_backend_endpoint_blocks_respawn: unreadable cmux inventory blocks a respawn"
 }
 
+# cmux can exit successfully while returning malformed data. That is no more
+# evidence of absence than a nonzero inventory command: a cleanup warning must
+# remain visible until a well-formed workspace inventory proves the title gone.
+test_endpoint_blocks_respawn_when_workspace_inventory_is_malformed() {
+  local dir fb out
+  dir="$TMP_ROOT/blocks-respawn-malformed"; mkdir -p "$dir/responses"
+  printf '{not-json\n' > "$dir/responses/1.out"
+  fb=$(make_cmux_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
+    FM_HOME="$dir" \
+    bash -c '
+      . "$0/bin/fm-backend.sh"
+      t=aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111
+      if fm_backend_endpoint_blocks_respawn cmux "$t" fm-corph; then echo blocks=yes; else echo blocks=no; fi
+    ' "$ROOT")
+  assert_contains "$out" "blocks=yes" \
+    "a malformed cmux workspace inventory must not claim the endpoint is retryable"
+  pass "fm_backend_endpoint_blocks_respawn: malformed cmux inventory blocks a respawn"
+}
+
 test_version_check_accepts_current_version
 test_version_check_accepts_newer_version
 test_version_check_refuses_old_version
@@ -1231,3 +1251,4 @@ test_secondmate_spawn_refuses_cmux_backend
 test_endpoint_blocks_respawn_sees_the_workspace_a_surface_read_misses
 test_endpoint_blocks_respawn_clear_when_no_workspace_carries_the_title
 test_endpoint_blocks_respawn_when_workspace_inventory_is_unreadable
+test_endpoint_blocks_respawn_when_workspace_inventory_is_malformed

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -1103,6 +1103,52 @@ test_secondmate_spawn_refuses_cmux_backend() {
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 
+# --- endpoint-blocks-respawn: the workspace title, not the surface ----------
+
+# cmux gates a fresh task on the workspace TITLE (fm_backend_cmux_create_task),
+# so a surface-scoped liveness read can report the endpoint gone while the
+# workspace that refuses the next spawn is still listed.
+test_endpoint_blocks_respawn_sees_the_workspace_a_surface_read_misses() {
+  local dir fb out
+  dir="$TMP_ROOT/blocks-respawn"; mkdir -p "$dir/responses"
+  cmux_panes_empty_response "$dir" 1
+  cmux_workspace_list_response "$dir" 2 \
+    aaaaaaaa-0000-0000-0000-000000000000 "$(cmux_expected_scoped_title fm-corph "$dir")"
+  fb=$(make_cmux_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
+    FM_HOME="$dir" \
+    bash -c '
+      . "$0/bin/fm-backend.sh"
+      t=aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111
+      if fm_backend_target_exists cmux "$t"; then echo liveness=present; else echo liveness=gone; fi
+      if fm_backend_endpoint_blocks_respawn cmux "$t" fm-corph; then echo blocks=yes; else echo blocks=no; fi
+    ' "$ROOT")
+  assert_contains "$out" "liveness=gone" \
+    "the surface-scoped liveness read should report a closed surface gone"
+  assert_contains "$out" "blocks=yes" \
+    "a workspace still carrying this task's title refuses the next spawn, so the endpoint is not retired"
+  pass "fm_backend_endpoint_blocks_respawn: a cmux workspace outliving its surface still blocks a respawn"
+}
+
+# And it must not invent a collision from another task's workspace.
+test_endpoint_blocks_respawn_clear_when_no_workspace_carries_the_title() {
+  local dir fb out
+  dir="$TMP_ROOT/blocks-respawn-clear"; mkdir -p "$dir/responses"
+  cmux_workspace_list_response "$dir" 1 \
+    aaaaaaaa-0000-0000-0000-000000000000 "$(cmux_expected_scoped_title fm-other "$dir")"
+  fb=$(make_cmux_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
+    FM_HOME="$dir" \
+    bash -c '
+      . "$0/bin/fm-backend.sh"
+      t=aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111
+      if fm_backend_endpoint_blocks_respawn cmux "$t" fm-corph; then echo blocks=yes; else echo blocks=no; fi
+    ' "$ROOT")
+  assert_contains "$out" "blocks=no" \
+    "an unrelated workspace title must not be reported as this task's leftover endpoint"
+  pass "fm_backend_endpoint_blocks_respawn: an unrelated cmux workspace leaves the slot retryable"
+}
+
 test_version_check_accepts_current_version
 test_version_check_accepts_newer_version
 test_version_check_refuses_old_version
@@ -1134,6 +1180,7 @@ test_target_ready_fails_when_target_absent
 test_target_ready_checks_expected_label
 test_target_ready_rejects_label_mismatch
 test_capture_trims_locally
+
 test_capture_fails_when_read_screen_fails_empty
 test_capture_fails_when_target_not_ready
 test_send_key_normalizes_and_targets
@@ -1164,3 +1211,5 @@ test_kill_is_best_effort_when_close_workspace_fails
 test_kill_recovers_stale_target_by_label
 test_list_live_filters_by_title_prefix
 test_secondmate_spawn_refuses_cmux_backend
+test_endpoint_blocks_respawn_sees_the_workspace_a_surface_read_misses
+test_endpoint_blocks_respawn_clear_when_no_workspace_carries_the_title

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -1169,6 +1169,48 @@ test_endpoint_blocks_respawn_when_workspace_inventory_is_unreadable() {
 # cmux can exit successfully while returning malformed data. That is no more
 # evidence of absence than a nonzero inventory command: a cleanup warning must
 # remain visible until a well-formed workspace inventory proves the title gone.
+# A listed entry that carries the title but no usable id is the same class of
+# unreadable inventory: the workspace is demonstrably still there, so nothing
+# about it proves the next spawn's title is free.
+test_endpoint_blocks_respawn_when_matching_entry_has_no_id() {
+  local dir fb out title
+  dir="$TMP_ROOT/blocks-respawn-null-id"; mkdir -p "$dir/responses"
+  title=$(cmux_expected_scoped_title fm-corph "$dir")
+  printf '{"workspaces":[{"title":"%s"}]}\n' "$title" > "$dir/responses/1.out"
+  fb=$(make_cmux_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
+    FM_HOME="$dir" \
+    bash -c '
+      . "$0/bin/fm-backend.sh"
+      t=aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111
+      if fm_backend_endpoint_blocks_respawn cmux "$t" fm-corph; then echo blocks=yes; else echo blocks=no; fi
+    ' "$ROOT")
+  assert_contains "$out" "blocks=yes" \
+    "a listed workspace whose entry carries no usable id must not be reported retired"
+  pass "fm_backend_endpoint_blocks_respawn: a matching cmux entry with no usable id blocks a respawn"
+}
+
+# The same unreadable entry must not license a duplicate workspace either: the
+# create-task duplicate gate refuses instead of adding a second same-titled one.
+test_create_task_refuses_when_matching_entry_has_no_id() {
+  local dir fb out status title
+  dir="$TMP_ROOT/create-task-null-id"; mkdir -p "$dir/responses"
+  title=$(cmux_expected_scoped_title fm-nullid1 "$dir")
+  printf '{"workspaces":[{"title":"%s"}]}\n' "$title" > "$dir/responses/1.out"
+  fb=$(make_cmux_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
+    FM_HOME="$dir" \
+    bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_create_task fm-nullid1 /tmp/proj' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "create_task should refuse when the workspace inventory cannot be read"
+  assert_contains "$out" "could not inspect cmux workspaces" \
+    "create_task did not report the unreadable workspace inventory"
+  if grep -q 'new-workspace' "$dir/log" 2>/dev/null; then
+    fail "create_task created a second workspace despite an unreadable inventory"
+  fi
+  pass "fm_backend_cmux_create_task: refuses a matching entry with no usable id instead of duplicating the title"
+}
+
 test_endpoint_blocks_respawn_when_workspace_inventory_is_malformed() {
   local dir fb out
   dir="$TMP_ROOT/blocks-respawn-malformed"; mkdir -p "$dir/responses"
@@ -1252,3 +1294,5 @@ test_endpoint_blocks_respawn_sees_the_workspace_a_surface_read_misses
 test_endpoint_blocks_respawn_clear_when_no_workspace_carries_the_title
 test_endpoint_blocks_respawn_when_workspace_inventory_is_unreadable
 test_endpoint_blocks_respawn_when_workspace_inventory_is_malformed
+test_endpoint_blocks_respawn_when_matching_entry_has_no_id
+test_create_task_refuses_when_matching_entry_has_no_id

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -1244,9 +1244,11 @@ pass "real Herdr lab: Hi Bit and Wheelhouse-style same-identity restarts reclaim
 
 # A secondmate child binds and reclaims only inside its own home and parent.
 CROSS_RESTART_ID=wheel-child-resume
+CROSS_RESTART_PROJECT="$TMP_ROOT/restart-projects/$CROSS_RESTART_ID"
+make_project "$CROSS_RESTART_PROJECT"
 mkdir -p "$SECOND_HOME_A/data/$CROSS_RESTART_ID"
 printf 'Cross-home restart fixture.\n' > "$SECOND_HOME_A/data/$CROSS_RESTART_ID/brief.md"
-spawn_task "$CROSS_RESTART_ID" "$SECOND_HOME_A" "$PROJECT_DIR" > "$TMP_ROOT/cross-restart-first.out" 2> "$TMP_ROOT/cross-restart-first.err" \
+spawn_task "$CROSS_RESTART_ID" "$SECOND_HOME_A" "$CROSS_RESTART_PROJECT" > "$TMP_ROOT/cross-restart-first.out" 2> "$TMP_ROOT/cross-restart-first.err" \
   || fail "cross-home restart fixture failed: $(cat "$TMP_ROOT/cross-restart-first.err")"
 CROSS_RESTART_META="$SECOND_HOME_A/state/$CROSS_RESTART_ID.meta"
 CROSS_OLD_WT=$(remember_meta_worktree "$CROSS_RESTART_META")
@@ -1262,7 +1264,7 @@ PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION" >/dev/
   || fail "could not stop the isolated session for cross-home restart"
 PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" \
   || fail "could not reprovision the isolated session for cross-home restart"
-spawn_task "$CROSS_RESTART_ID" "$SECOND_HOME_A" "$PROJECT_DIR" > "$TMP_ROOT/cross-restart-resume.out" 2> "$TMP_ROOT/cross-restart-resume.err" \
+spawn_task "$CROSS_RESTART_ID" "$SECOND_HOME_A" "$CROSS_RESTART_PROJECT" > "$TMP_ROOT/cross-restart-resume.out" 2> "$TMP_ROOT/cross-restart-resume.err" \
   || fail "cross-home same-identity reclaim failed: $(cat "$TMP_ROOT/cross-restart-resume.err")"
 CROSS_NEW_WT=$(remember_meta_worktree "$CROSS_RESTART_META")
 CROSS_NEW_WSID=$(grep '^herdr_workspace_id=' "$CROSS_RESTART_META" | cut -d= -f2-)

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -1164,7 +1164,13 @@ pass "real Herdr lab: session lock contention from a secondmate home falls back 
 # Exercise both the leading fm- identity style seen in Hi Bit work and the
 # project-name identity style used by Wheelhouse work.
 for RESTART_ID in fm-hibit-resume-r1 wheelhouse-healing-r1; do
-  spawn_task "$RESTART_ID" "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/$RESTART_ID-first.out" 2> "$TMP_ROOT/$RESTART_ID-first.err" \
+  # Stopping the lab kills every task process, so Treehouse can offer a slot
+  # held by the still-live anchor fixture. Give this restart sequence its own
+  # pool: reclaiming the same task's own recorded worktree remains valid, while
+  # a different task can never be handed the anchor's claimed slot.
+  RESTART_PROJECT_DIR="$TMP_ROOT/restart-projects/$RESTART_ID"
+  make_project "$RESTART_PROJECT_DIR"
+  spawn_task "$RESTART_ID" "$HOME_DIR" "$RESTART_PROJECT_DIR" > "$TMP_ROOT/$RESTART_ID-first.out" 2> "$TMP_ROOT/$RESTART_ID-first.err" \
     || fail "$RESTART_ID fixture's projected spawn failed: $(cat "$TMP_ROOT/$RESTART_ID-first.err")"
   RESTART_META="$HOME_DIR/state/$RESTART_ID.meta"
   OLD_RESTART_WT=$(remember_meta_worktree "$RESTART_META")
@@ -1190,7 +1196,7 @@ for RESTART_ID in fm-hibit-resume-r1 wheelhouse-healing-r1; do
     fail "$RESTART_ID restart fixture unexpectedly retained a registered agent"
   fi
   RECLAIM_FOCUS=$(focus_snapshot)
-  spawn_task "$RESTART_ID" "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/$RESTART_ID-reclaim.out" 2> "$TMP_ROOT/$RESTART_ID-reclaim.err" \
+  spawn_task "$RESTART_ID" "$HOME_DIR" "$RESTART_PROJECT_DIR" > "$TMP_ROOT/$RESTART_ID-reclaim.out" 2> "$TMP_ROOT/$RESTART_ID-reclaim.err" \
     || fail "$RESTART_ID same-identity reclaim failed: $(cat "$TMP_ROOT/$RESTART_ID-reclaim.err")"
   NEW_RESTART_WT=$(remember_meta_worktree "$RESTART_META")
   NEW_RESTART_WSID=$(grep '^herdr_workspace_id=' "$RESTART_META" | cut -d= -f2-)
@@ -1215,7 +1221,7 @@ for RESTART_ID in fm-hibit-resume-r1 wheelhouse-healing-r1; do
       || fail "could not reprovision the isolated session for idempotent reclaim"
     PRIOR_RESTART_WT=$NEW_RESTART_WT
     PRIOR_RESTART_PANE=$NEW_RESTART_PANE
-    spawn_task "$RESTART_ID" "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/$RESTART_ID-idempotent.out" 2> "$TMP_ROOT/$RESTART_ID-idempotent.err" \
+    spawn_task "$RESTART_ID" "$HOME_DIR" "$RESTART_PROJECT_DIR" > "$TMP_ROOT/$RESTART_ID-idempotent.out" 2> "$TMP_ROOT/$RESTART_ID-idempotent.err" \
       || fail "$RESTART_ID repeated reclaim failed: $(cat "$TMP_ROOT/$RESTART_ID-idempotent.err")"
     NEW_RESTART_WT=$(remember_meta_worktree "$RESTART_META")
     NEW_RESTART_WSID=$(grep '^herdr_workspace_id=' "$RESTART_META" | cut -d= -f2-)
@@ -1275,12 +1281,16 @@ pass "real Herdr lab: secondmate restart binding and reclaim stay isolated to th
 # each replace only their own exact husk.
 PRIMARY_WAVE_ID=resume-wave-primary
 BRAVO_WAVE_ID=resume-wave-bravo
+PRIMARY_WAVE_PROJECT="$TMP_ROOT/restart-projects/$PRIMARY_WAVE_ID"
+BRAVO_WAVE_PROJECT="$TMP_ROOT/restart-projects/$BRAVO_WAVE_ID"
+make_project "$PRIMARY_WAVE_PROJECT"
+make_project "$BRAVO_WAVE_PROJECT"
 mkdir -p "$HOME_DIR/data/$PRIMARY_WAVE_ID" "$SECOND_HOME_B/data/$BRAVO_WAVE_ID"
 printf 'Concurrent primary recovery fixture.\n' > "$HOME_DIR/data/$PRIMARY_WAVE_ID/brief.md"
 printf 'Concurrent secondmate recovery fixture.\n' > "$SECOND_HOME_B/data/$BRAVO_WAVE_ID/brief.md"
-spawn_task "$PRIMARY_WAVE_ID" "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/primary-wave-first.out" 2> "$TMP_ROOT/primary-wave-first.err" \
+spawn_task "$PRIMARY_WAVE_ID" "$HOME_DIR" "$PRIMARY_WAVE_PROJECT" > "$TMP_ROOT/primary-wave-first.out" 2> "$TMP_ROOT/primary-wave-first.err" \
   || fail "primary recovery-wave fixture failed: $(cat "$TMP_ROOT/primary-wave-first.err")"
-spawn_task "$BRAVO_WAVE_ID" "$SECOND_HOME_B" "$PROJECT_DIR" > "$TMP_ROOT/bravo-wave-first.out" 2> "$TMP_ROOT/bravo-wave-first.err" \
+spawn_task "$BRAVO_WAVE_ID" "$SECOND_HOME_B" "$BRAVO_WAVE_PROJECT" > "$TMP_ROOT/bravo-wave-first.out" 2> "$TMP_ROOT/bravo-wave-first.err" \
   || fail "secondmate recovery-wave fixture failed: $(cat "$TMP_ROOT/bravo-wave-first.err")"
 PRIMARY_WAVE_META="$HOME_DIR/state/$PRIMARY_WAVE_ID.meta"
 BRAVO_WAVE_META="$SECOND_HOME_B/state/$BRAVO_WAVE_ID.meta"
@@ -1295,9 +1305,9 @@ PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION" >/dev/
 PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" \
   || fail "could not reprovision the isolated session for concurrent recovery"
 CONCURRENT_RECOVERY_FOCUS=$(focus_snapshot)
-spawn_task "$PRIMARY_WAVE_ID" "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/primary-wave-resume.out" 2> "$TMP_ROOT/primary-wave-resume.err" &
+spawn_task "$PRIMARY_WAVE_ID" "$HOME_DIR" "$PRIMARY_WAVE_PROJECT" > "$TMP_ROOT/primary-wave-resume.out" 2> "$TMP_ROOT/primary-wave-resume.err" &
 PRIMARY_WAVE_PID=$!
-spawn_task "$BRAVO_WAVE_ID" "$SECOND_HOME_B" "$PROJECT_DIR" > "$TMP_ROOT/bravo-wave-resume.out" 2> "$TMP_ROOT/bravo-wave-resume.err" &
+spawn_task "$BRAVO_WAVE_ID" "$SECOND_HOME_B" "$BRAVO_WAVE_PROJECT" > "$TMP_ROOT/bravo-wave-resume.out" 2> "$TMP_ROOT/bravo-wave-resume.err" &
 BRAVO_WAVE_PID=$!
 wait "$PRIMARY_WAVE_PID" || fail "concurrent primary recovery failed: $(cat "$TMP_ROOT/primary-wave-resume.err")"
 wait "$BRAVO_WAVE_PID" || fail "concurrent secondmate recovery failed: $(cat "$TMP_ROOT/bravo-wave-resume.err")"

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2227,6 +2227,29 @@ test_endpoint_confirmed_gone_gates_on_structured_presence() {
   pass "endpoint confirmed-gone: only structured not-found permits record removal and ambiguous identity refuses"
 }
 
+# fm_backend_endpoint_blocks_respawn must PROPAGATE the herdr verdict, not
+# hardcode "still there": a pane herdr reports structurally gone leaves the
+# slot retryable, and fm-spawn.sh's post-refusal cleanup warning depends on it.
+test_endpoint_blocks_respawn_propagates_the_herdr_verdict() {
+  local out
+  out=$(bash -c '
+    . "$0/bin/fm-backend.sh"
+    . "$0/bin/backends/herdr.sh"
+    _FM_BACKEND_HERDR_SOURCED=1
+    fm_backend_herdr_cli() { printf "%s\n" "$FM_FAKE_PRESENCE_RESPONSE"; return "${FM_FAKE_PRESENCE_STATUS:-0}"; }
+    check() {  # <label> <response> <status> <expected>
+      FM_FAKE_PRESENCE_RESPONSE=$2 FM_FAKE_PRESENCE_STATUS=$3
+      if fm_backend_endpoint_blocks_respawn herdr fmtest:w2:p2 fm-horph; then verdict=yes; else verdict=no; fi
+      [ "$verdict" = "$4" ] || printf "MISMATCH %s: blocks=%s expected=%s\n" "$1" "$verdict" "$4"
+    }
+    check gone "{\"error\":{\"code\":\"pane_not_found\"}}" 1 no
+    check present "{\"result\":{\"pane\":{\"pane_id\":\"w2:p2\"}}}" 0 yes
+    check unknown "" 1 yes
+  ' "$ROOT" 2>&1)
+  [ -z "$out" ] || fail "herdr endpoint-blocks-respawn verdict mismatch: $out"
+  pass "fm_backend_endpoint_blocks_respawn: a confirmed-gone herdr pane leaves the slot retryable"
+}
+
 test_projection_seeded_prune_refuses_active_tab() {
   local dir log resp fb out status
   dir="$TMP_ROOT/projection-seeded-focus-active-refusal"; mkdir -p "$dir/responses"
@@ -4558,6 +4581,7 @@ test_projection_close_failed_removal_rolls_back_the_reposition
 test_kill_emptying_non_focused_uses_pane_death
 test_kill_focused_workspace_stays_plain_close
 test_endpoint_confirmed_gone_gates_on_structured_presence
+test_endpoint_blocks_respawn_propagates_the_herdr_verdict
 test_kill_refuses_when_presentation_lock_is_unavailable
 test_projection_seeded_prune_refuses_active_tab
 test_projection_label_builder_uses_corner_and_strips_owner_prefixes

--- a/tests/fm-backend-zellij.test.sh
+++ b/tests/fm-backend-zellij.test.sh
@@ -1333,6 +1333,54 @@ test_expected_label_allows_matching_task_tab
 test_expected_label_rejects_reused_pane_id
 test_current_path_probes_with_marker_and_ignores_prompt_paths
 test_current_path_ignores_tilde_prefixed_banner_lines
+# --- endpoint-blocks-respawn: the tab, not the pane -------------------------
+
+# Closing a tab's only pane does NOT close the now-empty tab (this adapter's
+# header, verified against real zellij 0.44.0). A pane-scoped liveness read
+# therefore reports the endpoint gone while the tab that refuses the next
+# spawn is still listed, so the respawn-blocking read has to ask about the TAB.
+test_endpoint_blocks_respawn_sees_the_tab_a_pane_read_misses() {
+  local dir fb title out
+  dir="$TMP_ROOT/blocks-respawn"; mkdir -p "$dir/responses"
+  title=$(zellij_expected_scoped_title fm-zorph "$dir")
+  printf '[]\n' > "$dir/responses/1.out"
+  printf '[{"tab_id":4,"name":"%s"}]\n' "$title" > "$dir/responses/2.out"
+  fb=$(make_zellij_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_ZELLIJ_LOG="$dir/log" FM_ZELLIJ_RESPONSES="$dir/responses" \
+    FM_ZELLIJ_SESSION_LIST="firstmate" FM_HOME="$dir" \
+    bash -c '
+      . "$0/bin/fm-backend.sh"
+      if fm_backend_target_exists zellij firstmate:7; then echo liveness=present; else echo liveness=gone; fi
+      if fm_backend_endpoint_blocks_respawn zellij firstmate:7 fm-zorph; then echo blocks=yes; else echo blocks=no; fi
+    ' "$ROOT")
+  assert_contains "$out" "liveness=gone" \
+    "the pane-scoped liveness read should report a closed pane gone"
+  assert_contains "$out" "blocks=yes" \
+    "an empty tab that outlived its pane still refuses the next spawn, so the endpoint is not retired"
+  pass "fm_backend_endpoint_blocks_respawn: a zellij tab outliving its pane still blocks a respawn"
+}
+
+# The same read must not invent a collision: with no tab carrying this task's
+# scoped title, the slot is genuinely retryable.
+test_endpoint_blocks_respawn_clear_when_no_tab_carries_the_title() {
+  local dir fb out
+  dir="$TMP_ROOT/blocks-respawn-clear"; mkdir -p "$dir/responses"
+  printf '[{"tab_id":4,"name":"%s"}]\n' "$(zellij_expected_scoped_title fm-other "$dir")" \
+    > "$dir/responses/1.out"
+  fb=$(make_zellij_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_ZELLIJ_LOG="$dir/log" FM_ZELLIJ_RESPONSES="$dir/responses" \
+    FM_ZELLIJ_SESSION_LIST="firstmate" FM_HOME="$dir" \
+    bash -c '
+      . "$0/bin/fm-backend.sh"
+      if fm_backend_endpoint_blocks_respawn zellij firstmate:7 fm-zorph; then echo blocks=yes; else echo blocks=no; fi
+    ' "$ROOT")
+  assert_contains "$out" "blocks=no" \
+    "an unrelated tab title must not be reported as this task's leftover endpoint"
+  pass "fm_backend_endpoint_blocks_respawn: an unrelated zellij tab leaves the slot retryable"
+}
+
+test_endpoint_blocks_respawn_sees_the_tab_a_pane_read_misses
+test_endpoint_blocks_respawn_clear_when_no_tab_carries_the_title
 test_kill_resolves_tab_and_closes_by_id
 test_kill_falls_back_to_close_pane_when_tab_lookup_empty
 test_kill_closes_recorded_tab_when_pane_already_gone

--- a/tests/fm-backend-zellij.test.sh
+++ b/tests/fm-backend-zellij.test.sh
@@ -1379,8 +1379,25 @@ test_endpoint_blocks_respawn_clear_when_no_tab_carries_the_title() {
   pass "fm_backend_endpoint_blocks_respawn: an unrelated zellij tab leaves the slot retryable"
 }
 
+test_endpoint_blocks_respawn_when_tab_inventory_is_unreadable() {
+  local dir fb out
+  dir="$TMP_ROOT/blocks-respawn-unreadable"; mkdir -p "$dir/responses"
+  printf '1\n' > "$dir/responses/1.exit"
+  fb=$(make_zellij_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_ZELLIJ_LOG="$dir/log" FM_ZELLIJ_RESPONSES="$dir/responses" \
+    FM_ZELLIJ_SESSION_LIST="firstmate" FM_HOME="$dir" \
+    bash -c '
+      . "$0/bin/fm-backend.sh"
+      if fm_backend_endpoint_blocks_respawn zellij firstmate:7 fm-zorph; then echo blocks=yes; else echo blocks=no; fi
+    ' "$ROOT")
+  assert_contains "$out" "blocks=yes" \
+    "an unreadable zellij tab inventory must not claim the endpoint is retryable"
+  pass "fm_backend_endpoint_blocks_respawn: unreadable zellij inventory blocks a respawn"
+}
+
 test_endpoint_blocks_respawn_sees_the_tab_a_pane_read_misses
 test_endpoint_blocks_respawn_clear_when_no_tab_carries_the_title
+test_endpoint_blocks_respawn_when_tab_inventory_is_unreadable
 test_kill_resolves_tab_and_closes_by_id
 test_kill_falls_back_to_close_pane_when_tab_lookup_empty
 test_kill_closes_recorded_tab_when_pane_already_gone

--- a/tests/fm-backend-zellij.test.sh
+++ b/tests/fm-backend-zellij.test.sh
@@ -463,6 +463,27 @@ test_create_task_refuses_duplicate_label() {
   pass "fm_backend_zellij_create_task: refuses a duplicate home-scoped tab title (zellij's own new-tab has no uniqueness check)"
 }
 
+# A `list-tabs --json` that exits 0 while printing a non-JSON missing-session
+# response cannot prove no tab already holds this title, so create_task must
+# refuse rather than call new-tab on an inventory it never read.
+test_create_task_refuses_when_tab_inventory_is_not_json() {
+  local dir fb out status
+  dir="$TMP_ROOT/dup-task-not-json"; mkdir -p "$dir/responses"
+  printf 'Session firstmate not found\n' > "$dir/responses/1.out"
+  fb=$(make_zellij_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_ZELLIJ_LOG="$dir/log" FM_ZELLIJ_RESPONSES="$dir/responses" \
+    FM_ZELLIJ_SESSION_LIST="firstmate" \
+    bash -c '. "$0/bin/backends/zellij.sh"; fm_backend_zellij_create_task firstmate fm-nonjson1 /tmp/proj' "$ROOT" 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "create_task should refuse a successful non-JSON tab inventory"
+  assert_contains "$out" "could not inspect zellij tabs" \
+    "create_task did not report the unreadable tab inventory"
+  if grep -q 'new-tab' "$dir/log" 2>/dev/null; then
+    fail "create_task created a tab despite never reading the tab inventory"
+  fi
+  pass "fm_backend_zellij_create_task: refuses when list-tabs exits 0 with non-JSON output"
+}
+
 test_create_task_creates_and_parses_ids() {
   local dir fb out title
   dir="$TMP_ROOT/create-task"; mkdir -p "$dir/responses"
@@ -1318,6 +1339,7 @@ test_server_ensure_skips_attach_when_already_exists
 test_dispatch_routes_zellij_backend
 test_dispatch_busy_state_unknown_for_zellij
 test_create_task_refuses_duplicate_label
+test_create_task_refuses_when_tab_inventory_is_not_json
 test_create_task_creates_and_parses_ids
 test_create_task_restores_previously_active_tab
 test_create_task_no_restore_when_new_tab_was_already_active

--- a/tests/fm-backend-zellij.test.sh
+++ b/tests/fm-backend-zellij.test.sh
@@ -1395,9 +1395,28 @@ test_endpoint_blocks_respawn_when_tab_inventory_is_unreadable() {
   pass "fm_backend_endpoint_blocks_respawn: unreadable zellij inventory blocks a respawn"
 }
 
+test_endpoint_blocks_respawn_when_tab_inventory_is_not_json() {
+  local dir fb out
+  dir="$TMP_ROOT/blocks-respawn-not-json"; mkdir -p "$dir/responses"
+  # Zellij actions can exit successfully while printing a non-JSON missing-session
+  # response. That is unreadable inventory, not proof that a named tab is gone.
+  printf 'Session firstmate not found\n' > "$dir/responses/1.out"
+  fb=$(make_zellij_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_ZELLIJ_LOG="$dir/log" FM_ZELLIJ_RESPONSES="$dir/responses" \
+    FM_ZELLIJ_SESSION_LIST="firstmate" FM_HOME="$dir" \
+    bash -c '
+      . "$0/bin/fm-backend.sh"
+      if fm_backend_endpoint_blocks_respawn zellij firstmate:7 fm-zorph; then echo blocks=yes; else echo blocks=no; fi
+    ' "$ROOT")
+  assert_contains "$out" "blocks=yes" \
+    "a successful non-JSON zellij tab inventory must not claim the endpoint is retryable"
+  pass "fm_backend_endpoint_blocks_respawn: successful non-JSON zellij inventory blocks a respawn"
+}
+
 test_endpoint_blocks_respawn_sees_the_tab_a_pane_read_misses
 test_endpoint_blocks_respawn_clear_when_no_tab_carries_the_title
 test_endpoint_blocks_respawn_when_tab_inventory_is_unreadable
+test_endpoint_blocks_respawn_when_tab_inventory_is_not_json
 test_kill_resolves_tab_and_closes_by_id
 test_kill_falls_back_to_close_pane_when_tab_lookup_empty
 test_kill_closes_recorded_tab_when_pane_already_gone

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -829,6 +829,8 @@ test_spawn_relaunch_without_a_harness_reuses_the_recorded_one() {
   [ "$(meta_field "$dir" rl21 harness)" = claude ] \
     || fail "fm-spawn --relaunch without --harness must reuse the recorded harness, got '$(meta_field "$dir" rl21 harness)'"
   assert_contains "$out" "spawned rl21 harness=claude" "the launch should report the recorded harness"
+  assert_not_contains "$out" "already claimed by live task" \
+    "a relaunch must not treat its own recorded worktree as another task's claim"
   pass "fm-spawn --relaunch: with no explicit harness it reuses the task's recorded one, never the crew default"
 }
 

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -829,7 +829,7 @@ test_spawn_relaunch_without_a_harness_reuses_the_recorded_one() {
   [ "$(meta_field "$dir" rl21 harness)" = claude ] \
     || fail "fm-spawn --relaunch without --harness must reuse the recorded harness, got '$(meta_field "$dir" rl21 harness)'"
   assert_contains "$out" "spawned rl21 harness=claude" "the launch should report the recorded harness"
-  assert_not_contains "$out" "already claimed by live task" \
+  assert_not_contains "$out" "is already claimed by task" \
     "a relaunch must not treat its own recorded worktree as another task's claim"
   pass "fm-spawn --relaunch: with no explicit harness it reuses the task's recorded one, never the crew default"
 }

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -136,6 +136,18 @@ test_tmux_agent_state_classifies() {
   pass "fm_backend_tmux_agent_state: separates live, dead, missing, ambiguous, and unreadable"
 }
 
+test_tmux_endpoint_blocks_respawn_when_window_inventory_is_unreadable() {
+  local fb out
+  fb=$(make_failed_probe_tmux "$TMP_ROOT/tmux-blocks-unreadable" unreadable)
+  out=$(PATH="$fb:$BASE_PATH" bash -c '
+    . "$0/bin/fm-backend.sh"
+    if fm_backend_endpoint_blocks_respawn tmux sess:fm-sm1 fm-sm1; then echo blocks=yes; else echo blocks=no; fi
+  ' "$ROOT")
+  assert_contains "$out" "blocks=yes" \
+    "an unreadable tmux window inventory must not claim the endpoint is retryable"
+  pass "fm_backend_endpoint_blocks_respawn: unreadable tmux inventory blocks a respawn"
+}
+
 test_tmux_agent_state_rejects_malformed_targets_before_probe() {
   local fakebin marker target out
   fakebin=$(fm_fakebin "$TMP_ROOT/tmux-malformed")
@@ -541,6 +553,7 @@ test_sweep_noop_with_no_secondmate_meta() {
 }
 
 test_tmux_agent_state_classifies
+test_tmux_endpoint_blocks_respawn_when_window_inventory_is_unreadable
 test_tmux_agent_state_rejects_malformed_targets_before_probe
 test_herdr_agent_state_preserves_husk_classifier
 test_agent_state_dispatcher_and_compatibility

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -148,6 +148,49 @@ test_tmux_endpoint_blocks_respawn_when_window_inventory_is_unreadable() {
   pass "fm_backend_endpoint_blocks_respawn: unreadable tmux inventory blocks a respawn"
 }
 
+test_tmux_endpoint_blocks_respawn_when_adapter_cannot_be_loaded() {
+  local empty out
+  empty="$TMP_ROOT/no-backend-adapters"
+  mkdir -p "$empty"
+  out=$(bash -c '
+    . "$0/bin/fm-backend.sh"
+    FM_BACKEND_LIB_DIR=$1
+    unset _FM_BACKEND_TMUX_SOURCED
+    if fm_backend_endpoint_blocks_respawn tmux sess:fm-sm1 fm-sm1 2>/dev/null; then echo blocks=yes; else echo blocks=no; fi
+  ' "$ROOT" "$empty")
+  assert_contains "$out" "blocks=yes" \
+    "an unloadable backend adapter must not read as a retired endpoint"
+  pass "fm_backend_endpoint_blocks_respawn: an unloadable adapter blocks a respawn"
+}
+
+test_tmux_window_exists_matches_the_name_literally() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/tmux-literal-name")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  list-windows) printf '%s\n' fm-v1a2-fix; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/tmux"
+  out=$(PATH="$fakebin:$BASE_PATH" bash -c '
+    . "$0/bin/fm-backend.sh"
+    fm_backend_source tmux
+    if fm_backend_tmux_window_exists firstmate "fm-v1.2-fix"; then echo dotted=yes; else echo dotted=no; fi
+    if fm_backend_tmux_window_exists firstmate fm-v1a2-fix; then echo exact=yes; else echo exact=no; fi
+    if fm_backend_endpoint_blocks_respawn tmux firstmate:fm-v1.2-fix fm-v1.2-fix; then echo blocks=yes; else echo blocks=no; fi
+  ' "$ROOT")
+  assert_contains "$out" "dotted=no" \
+    "a dot in a task id must not match another window as a regex wildcard"
+  assert_contains "$out" "exact=yes" \
+    "the literal window name present in the inventory must still be found"
+  assert_contains "$out" "blocks=no" \
+    "a window that does not exist must not read as an endpoint surviving cleanup"
+  pass "fm_backend_tmux_window_exists: window names match literally, not as regexes"
+}
+
 test_tmux_agent_state_rejects_malformed_targets_before_probe() {
   local fakebin marker target out
   fakebin=$(fm_fakebin "$TMP_ROOT/tmux-malformed")
@@ -554,6 +597,8 @@ test_sweep_noop_with_no_secondmate_meta() {
 
 test_tmux_agent_state_classifies
 test_tmux_endpoint_blocks_respawn_when_window_inventory_is_unreadable
+test_tmux_endpoint_blocks_respawn_when_adapter_cannot_be_loaded
+test_tmux_window_exists_matches_the_name_literally
 test_tmux_agent_state_rejects_malformed_targets_before_probe
 test_herdr_agent_state_preserves_husk_classifier
 test_agent_state_dispatcher_and_compatibility

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -182,7 +182,7 @@ test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
 }
 
 test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
-  local rec relative_id absolute_id out status launch home_real linked_home
+  local rec relative_id absolute_id out status launch home_real linked_home absolute_wt
   relative_id=profile-relative-home-defaults-z1c
   absolute_id=profile-absolute-home-defaults-z1d
   rec=$(make_spawn_case profile-home-defaults pi "$relative_id" "$absolute_id")
@@ -210,12 +210,17 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
 
   linked_home="$CASE_DIR/home-link"
   ln -s "$HOME_DIR" "$linked_home"
+  # Two independent spawns in one home: the relative-spelling launch above now
+  # holds a durable claim on WT_DIR, so the absolute-spelling launch needs its
+  # own free worktree rather than a slot another recorded task still owns.
+  absolute_wt="$CASE_DIR/wt-absolute"
+  git -C "$PROJ_DIR" worktree add --quiet -b wt-profile-home-defaults-absolute "$absolute_wt"
   : > "$LAUNCH_LOG"
   out=$(
     FM_ROOT_OVERRIDE='' FM_HOME="$linked_home" \
       FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' \
       FM_PROJECTS_OVERRIDE="$linked_home/projects" FM_CONFIG_OVERRIDE="$linked_home/config" \
-      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$absolute_wt" TMUX="fake,1,0" \
       CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
       GROK_HOME="$linked_home/grok-home" PATH="$FAKEBIN_DIR:$PATH" \
       "$SPAWN" "$absolute_id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
@@ -707,14 +712,24 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
 }
 
 test_batch_forwards_shared_profile_flags() {
-  local rec id1 id2 out status
+  local rec id1 id2 out status pane_dir
   id1=profile-batch-a-z9
   id2=profile-batch-b-z10
   rec=$(make_spawn_case profile-batch claude "$id1" "$id2")
   read_case_record "$rec"
   enable_dispatch_profile "$HOME_DIR"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+  # A batch launches several tasks into one home, and treehouse gives each of
+  # them its OWN worktree; two tasks sharing one is the collision fm-spawn now
+  # refuses. Model that with a worktree per created window (fm-<id>) instead of
+  # a single shared pane path.
+  pane_dir="$CASE_DIR/batch-worktrees"
+  mkdir -p "$pane_dir"
+  git -C "$PROJ_DIR" worktree add --quiet -b wt-profile-batch-a "$pane_dir/fm-$id1"
+  git -C "$PROJ_DIR" worktree add --quiet -b wt-profile-batch-b "$pane_dir/fm-$id2"
+
+  out=$(FM_FAKE_PANE_PATH_DIR="$pane_dir" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
     "$id1=$PROJ_DIR" "$id2=$PROJ_DIR" --harness codex --model gpt-5 --effort high)
   status=$?
   expect_code 0 "$status" "batch spawn with shared profile flags should succeed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -82,6 +82,8 @@ test_stale_pool_base_refreshes_before_branching() {
   id='pool-current-base-repeat-r1'
   mkdir -p "$HOME_DIR/data/$id"
   printf 'brief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"
+  # The refresh repeat needs a genuinely free slot, not the first task's live claim.
+  rm "$HOME_DIR/state/pool-current-base-r1.meta"
   out=$(run_spawn "$id" --mode no-mistakes --yolo off)
   status=$?
   expect_code 0 "$status" "repeating the base refresh should be idempotent"
@@ -278,6 +280,8 @@ strand_submodule_pin_via_spawn() {  # <seed-id>
     || fail "the first spawn did not move the pooled base across the moved submodule pin"
   [ "$(git -C "$POOL_DIR/ui" rev-parse HEAD)" = "$SUBPIN1" ] \
     || fail "the first spawn did not strand the submodule on the pin the old base recorded"
+  # Retire the seed task's claim before the next spawn inspects the free slot's residue.
+  rm "$HOME_DIR/state/$id.meta"
 }
 
 test_stale_submodule_pin_explains_itself() {

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -215,7 +215,13 @@ test_spawn_durable_worktree_claims() {
     echo 'kind=ship'
   } > "$home/state/incumbent.meta"
 
-  out=$(FM_TMUX_REC="$rec" run_spawn "$home" collision-gg7 "$proj" "$claimed" "$fakebin")
+  # fm-collision-gg7-fix is an unrelated live task whose window name EXTENDS the
+  # contender's. It is what tmux's fnmatch/prefix resolution (and its fallback to
+  # the current window) would wrongly report as the contender's own surviving
+  # endpoint, and it is also the window an operator would kill if the refusal
+  # named a target that resolves by prefix.
+  out=$(FM_TMUX_REC="$rec" FM_FAKE_WINDOWS='fm-collision-gg7-fix' \
+    run_spawn "$home" collision-gg7 "$proj" "$claimed" "$fakebin")
   status=$?
   expect_code 1 "$status" "spawn into another live task's worktree should refuse"
   assert_contains "$out" "already claimed by live task incumbent" \
@@ -226,7 +232,7 @@ test_spawn_durable_worktree_claims() {
   assert_no_grep 'send-keys -t firstmate:fm-collision-gg7 -l' "$rec" \
     "a collision refusal must not type an agent launch command"
   assert_not_contains "$out" "survived the refusal" \
-    "a retired endpoint must not be reported as a survivor"
+    "a retired endpoint must not be reported as a survivor, even beside a prefix-sharing sibling window"
 
   # A close that reports success while the window survives is not a retirement:
   # the leftover endpoint is exactly what refuses the next attempt, so it has to
@@ -246,7 +252,8 @@ test_spawn_durable_worktree_claims() {
 
   rm "$home/state/incumbent.meta"
   : > "$rec"
-  out=$(FM_TMUX_REC="$rec" run_spawn "$home" collision-gg7 "$proj" "$claimed" "$fakebin")
+  out=$(FM_TMUX_REC="$rec" FM_FAKE_WINDOWS='fm-collision-gg7-fix' \
+    run_spawn "$home" collision-gg7 "$proj" "$claimed" "$fakebin")
   status=$?
   expect_code 0 "$status" "the same spawn should be retryable after the durable claim retires"
   assert_contains "$out" 'spawned collision-gg7' "the retry did not launch after the claim retired"
@@ -297,11 +304,17 @@ test_spawn_durable_worktree_claims() {
 #     OWN pane as the worktree, tangling a hook into the primary checkout.
 # The fake also models WINDOW LIVENESS, because retryability after a refused
 # spawn is a real tmux state question: `new-window` records the created name,
-# `kill-window` retires it, and `list-windows`/`display-message -t` answer from
-# that set - so a spawn that leaves its window behind is refused by the same
+# `kill-window` retires it, and `list-windows` answers from that set - so a
+# spawn that leaves its window behind is refused by the same exact
 # duplicate-name check real tmux enforces. FM_FAKE_TMUX_KILL_NOOP=1 makes
 # kill-window a no-op, reproducing the best-effort close that reports success
 # while the window survives.
+# `display-message` deliberately succeeds for EVERY target, matching tmux 3.7b
+# measured behavior: an absent window resolves by fnmatch, then by prefix, and
+# otherwise falls back to the client's current window, exiting 0 either way -
+# even for `=session:=window` or a session that does not exist. Any endpoint
+# check that trusts it therefore reports a live sibling, so this fake makes
+# that unsoundness observable instead of hiding it behind exact matching.
 make_spawn_record_fakebin() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
@@ -320,10 +333,6 @@ live_names() {
   cat "$FM_FAKE_TMUX_LIVE"
 }
 
-window_live() {  # <window-name>
-  live_names | grep -qx "$1"
-}
-
 flag_value() {  # <flag> <args...>
   local want=$1 prev=
   shift
@@ -339,13 +348,7 @@ case "$*" in
   *"#{pane_current_command}"*) printf '%s\n' "${FM_FAKE_PANE_COMMAND:-zsh}"; exit 0 ;;
 esac
 case "${1:-}" in
-  display-message)
-    target=$(flag_value -t "$@") || target=
-    case "$target" in
-      ''|@*) ;;
-      *:*) window_live "${target#*:}" || exit 1 ;;
-    esac
-    printf 'firstmate\n'; exit 0 ;;
+  display-message) printf 'firstmate\n'; exit 0 ;;
   new-window)
     name=$(flag_value -n "$@") || name=
     [ -z "$name" ] || printf '%s\n' "$name" >> "$FM_FAKE_TMUX_LIVE"

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -190,7 +190,7 @@ test_spawn_isolation_abort() {
 # --- GUARD 1c: fm-spawn durable worktree claims ----------------------------
 
 test_spawn_durable_worktree_claims() {
-  local home proj claimed free own alias fakebin rec out status
+  local home proj claimed free own alias broken fakebin rec out status
   home="$TMP_ROOT/spawn-claim-home"
   mkdir -p "$home/data" "$home/state"
   proj=$(make_repo "$TMP_ROOT/spawn-claim-proj")
@@ -198,10 +198,12 @@ test_spawn_durable_worktree_claims() {
   free="$TMP_ROOT/spawn-free-wt"
   own="$TMP_ROOT/spawn-own-wt"
   alias="$TMP_ROOT/spawn-claim-alias"
+  broken="$TMP_ROOT/spawn-claim-broken"
   git -C "$proj" worktree add -q --detach "$claimed" >/dev/null 2>&1
   git -C "$proj" worktree add -q --detach "$free" >/dev/null 2>&1
   git -C "$proj" worktree add -q --detach "$own" >/dev/null 2>&1
   ln -s "$claimed" "$alias"
+  ln -s "$TMP_ROOT/spawn-claim-removed" "$broken"
   fakebin=$(make_spawn_record_fakebin "$TMP_ROOT/spawn-claim-fake")
   rec="$TMP_ROOT/spawn-claim.log"
   : > "$rec"
@@ -272,10 +274,39 @@ test_spawn_durable_worktree_claims() {
   expect_code 0 "$status" "the same spawn should be retryable after the durable claim retires"
   assert_contains "$out" 'spawned collision-gg7' "the retry did not launch after the claim retired"
 
+  {
+    echo 'window=firstmate:fm-broken-claim'
+    echo "worktree=$broken"
+    echo "project=$proj"
+    echo 'harness=codex'
+    echo 'kind=ship'
+  } > "$home/state/broken-claim.meta"
+  : > "$rec"
+  out=$(FM_TMUX_REC="$rec" \
+    run_spawn "$home" unresolvable-kk1 "$proj" "$free" "$fakebin")
+  status=$?
+  expect_code 1 "$status" "an unresolvable foreign worktree claim should refuse"
+  assert_contains "$out" "task broken-claim record $home/state/broken-claim.meta" \
+    "the unresolvable-claim refusal did not name the owning record"
+  assert_contains "$out" "worktree='$broken'" \
+    "the unresolvable-claim refusal did not report the recorded path"
+  assert_contains "$out" "could not be resolved; refusing to launch task unresolvable-kk1" \
+    "the unresolvable-claim refusal did not explain why it stopped the spawn"
+  assert_grep 'kill-window -t =firstmate:=fm-unresolvable-kk1' "$rec" \
+    "an unresolvable claim refusal must retire the endpoint it created"
+  rm "$home/state/broken-claim.meta"
+
+  {
+    echo 'window=firstmate:fm-missing-claim'
+    echo "project=$proj"
+    echo 'harness=codex'
+    echo 'kind=ship'
+  } > "$home/state/missing-claim.meta"
   out=$(FM_TMUX_REC="$rec" run_spawn "$home" free-hh8 "$proj" "$free" "$fakebin")
   status=$?
   expect_code 0 "$status" "a different, genuinely free worktree should remain launchable"
   assert_contains "$out" 'spawned free-hh8' "the free-worktree spawn did not report success"
+  rm "$home/state/missing-claim.meta"
 
   fm_test_spawn_brief "$home" own-ii9 brief
   {

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -187,7 +187,82 @@ test_spawn_isolation_abort() {
   pass "fm-spawn: aborts unless the resolved worktree is a genuine, isolated worktree"
 }
 
-# --- GUARD 1c: fm-spawn tmux window construction ----------------------------
+# --- GUARD 1c: fm-spawn durable worktree claims ----------------------------
+
+test_spawn_durable_worktree_claims() {
+  local home proj claimed free own alias fakebin rec out status
+  home="$TMP_ROOT/spawn-claim-home"
+  mkdir -p "$home/data" "$home/state"
+  proj=$(make_repo "$TMP_ROOT/spawn-claim-proj")
+  claimed="$TMP_ROOT/spawn-claim-wt"
+  free="$TMP_ROOT/spawn-free-wt"
+  own="$TMP_ROOT/spawn-own-wt"
+  alias="$TMP_ROOT/spawn-claim-alias"
+  git -C "$proj" worktree add -q --detach "$claimed" >/dev/null 2>&1
+  git -C "$proj" worktree add -q --detach "$free" >/dev/null 2>&1
+  git -C "$proj" worktree add -q --detach "$own" >/dev/null 2>&1
+  ln -s "$claimed" "$alias"
+  fakebin=$(make_spawn_record_fakebin "$TMP_ROOT/spawn-claim-fake")
+  rec="$TMP_ROOT/spawn-claim.log"
+  : > "$rec"
+
+  {
+    echo 'window=firstmate:fm-incumbent'
+    echo 'endpoint_task_id=incumbent'
+    echo "worktree=$alias/"
+    echo "project=$proj"
+    echo 'harness=codex'
+    echo 'kind=ship'
+  } > "$home/state/incumbent.meta"
+
+  out=$(FM_TMUX_REC="$rec" run_spawn "$home" collision-gg7 "$proj" "$claimed" "$fakebin")
+  status=$?
+  expect_code 1 "$status" "spawn into another live task's worktree should refuse"
+  assert_contains "$out" "already claimed by live task incumbent" \
+    "the collision refusal did not name the incumbent task"
+  assert_absent "$home/state/collision-gg7.meta" "a collision refusal must not publish contender metadata"
+  assert_grep 'kill-window -t =firstmate:=fm-collision-gg7' "$rec" \
+    "a collision refusal must retire the new endpoint so treehouse can reallocate the slot"
+  assert_no_grep 'send-keys -t firstmate:fm-collision-gg7 -l' "$rec" \
+    "a collision refusal must not type an agent launch command"
+
+  rm "$home/state/incumbent.meta"
+  : > "$rec"
+  out=$(FM_TMUX_REC="$rec" run_spawn "$home" collision-gg7 "$proj" "$claimed" "$fakebin")
+  status=$?
+  expect_code 0 "$status" "the same spawn should be retryable after the durable claim retires"
+  assert_contains "$out" 'spawned collision-gg7' "the retry did not launch after the claim retired"
+
+  out=$(FM_TMUX_REC="$rec" run_spawn "$home" free-hh8 "$proj" "$free" "$fakebin")
+  status=$?
+  expect_code 0 "$status" "a different, genuinely free worktree should remain launchable"
+  assert_contains "$out" 'spawned free-hh8' "the free-worktree spawn did not report success"
+
+  fm_test_spawn_brief "$home" own-ii9 brief
+  {
+    echo 'window=firstmate:fm-own-ii9'
+    echo 'endpoint_task_id=own-ii9'
+    echo "worktree=$own/"
+    echo "project=$proj"
+    echo 'harness=codex'
+    echo 'kind=ship'
+    echo 'mode=no-mistakes'
+    echo 'yolo=off'
+    echo 'tasktmp=/tmp/fm-own-ii9'
+    echo 'model=default'
+    echo 'effort=default'
+  } > "$home/state/own-ii9.meta"
+  out=$(FM_TMUX_REC="$rec" FM_FAKE_WINDOWS='fm-own-ii9' FM_FAKE_PANE_COMMAND=zsh \
+    fm_test_run_spawn "$home" "$own" "$fakebin" own-ii9 --relaunch)
+  status=$?
+  expect_code 0 "$status" "a relaunch into the task's own recorded worktree should remain allowed"
+  assert_contains "$out" 'spawned own-ii9' "the own-worktree relaunch did not report success"
+  assert_not_contains "$out" 'already claimed by live task' \
+    "the own-worktree relaunch treated its own metadata as a collision"
+  pass "fm-spawn: durable canonical worktree claims refuse collisions, release retries, and leave free slots launchable"
+}
+
+# --- GUARD 1d: fm-spawn tmux window construction ----------------------------
 
 # The prevention guard also depends on fm-spawn building robust tmux commands
 # under a non-default tmux config (base-index 1, automatic-rename on). A RECORDING
@@ -211,11 +286,12 @@ set -u
 [ -n "${FM_TMUX_REC:-}" ] && printf 'tmux %s\n' "$*" >> "$FM_TMUX_REC"
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"#{pane_current_command}"*) printf '%s\n' "${FM_FAKE_PANE_COMMAND:-zsh}"; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   new-window) printf '%s\n' "@spawnwid"; exit 0 ;;
-  list-windows) exit 0 ;;
+  list-windows) [ -z "${FM_FAKE_WINDOWS:-}" ] || printf '%s\n' "$FM_FAKE_WINDOWS"; exit 0 ;;
   has-session|new-session|send-keys|set-window-option) exit 0 ;;
 esac
 exit 0
@@ -274,4 +350,5 @@ test_guard_banner
 test_bootstrap_line
 test_brief_assertion_precedes_branch
 test_spawn_isolation_abort
+test_spawn_durable_worktree_claims
 test_spawn_tmux_window_construction

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -240,6 +240,14 @@ test_spawn_durable_worktree_claims() {
   assert_not_contains "$out" "survived the refusal" \
     "a retired endpoint must not be reported as a survivor, even beside a prefix-sharing sibling window"
 
+  : > "$rec"
+  out=$(FM_TMUX_REC="$rec" FM_FAKE_TMUX_KILL_FAIL=1 \
+    run_spawn "$home" kill-failed-ii9 "$proj" "$claimed" "$fakebin")
+  status=$?
+  expect_code 1 "$status" "spawn into another live task's worktree should refuse"
+  assert_not_contains "$out" "survived the refusal" \
+    "a failed close must still read back an already-gone endpoint before warning"
+
   # A close that reports success while the window survives is not a retirement:
   # the leftover endpoint is exactly what refuses the next attempt, so it has to
   # be named rather than swallowed behind the best-effort kill's exit status.
@@ -367,6 +375,7 @@ case "${1:-}" in
       grep -vx "$name" "$FM_FAKE_TMUX_LIVE" > "$FM_FAKE_TMUX_LIVE.next" || true
       mv "$FM_FAKE_TMUX_LIVE.next" "$FM_FAKE_TMUX_LIVE"
     fi
+    [ "${FM_FAKE_TMUX_KILL_FAIL:-0}" != 1 ] || exit 1
     exit 0 ;;
   list-windows) live_names; exit 0 ;;
   has-session|new-session|send-keys|set-window-option) exit 0 ;;

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -422,10 +422,143 @@ test_spawn_tmux_window_construction() {
   pass "fm-spawn: appends windows by session-colon, pins the name, and targets the window id"
 }
 
+# A recording fake `zellij` for a full spawn drive-through. It models the two
+# facts this guard depends on: `new-tab` registers a titled tab that
+# `list-tabs` keeps returning, and `close-pane` does NOT remove the now-empty
+# tab (verified real zellij behavior, recorded in bin/backends/zellij.sh's
+# header) while `close-tab-by-id` does. FM_FAKE_ZJ_PANES_FAIL_AFTER_DUMPS makes
+# `list-panes` start failing once worktree discovery has finished, reproducing
+# the transient CLI failure that leaves the kill with no resolvable owning tab.
+make_spawn_zellij_fakebin() {  # <dir> -> echoes fakebin path
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/zellij" <<SH
+#!/usr/bin/env bash
+set -u
+FM_FAKE_ZJ_STATE=\${FM_FAKE_ZJ_STATE:-"$dir/zjstate"}
+SH
+  cat >> "$fakebin/zellij" <<'SH'
+mkdir -p "$FM_FAKE_ZJ_STATE"
+tabs="$FM_FAKE_ZJ_STATE/tabs"
+dumps="$FM_FAKE_ZJ_STATE/dumps"
+: >> "$tabs"
+[ -f "$dumps" ] || echo 0 > "$dumps"
+[ -z "${FM_ZJ_REC:-}" ] || printf 'zellij %s\n' "$*" >> "$FM_ZJ_REC"
+
+zj_flag_value() {  # <flag> <args...>
+  local want=$1 prev= a
+  shift
+  for a in "$@"; do
+    [ "$prev" = "$want" ] && { printf '%s\n' "$a"; return 0; }
+    prev=$a
+  done
+  return 1
+}
+
+zj_tabs_json() {
+  local id name first=1
+  printf '['
+  while IFS=$'\t' read -r id name; do
+    [ -n "$id" ] || continue
+    [ "$first" = 1 ] || printf ','
+    printf '{"tab_id":%s,"name":"%s","active":false}' "$id" "$name"
+    first=0
+  done < "$tabs"
+  printf ']\n'
+}
+
+case "${1:-}" in
+  --version) printf 'zellij 0.44.0\n'; exit 0 ;;
+  list-sessions) printf '%s\n' "${FM_FAKE_ZJ_SESSION:-firstmate}"; exit 0 ;;
+  attach) exit 0 ;;
+esac
+
+case "${4:-}" in
+  list-tabs) zj_tabs_json; exit 0 ;;
+  new-tab)
+    name=$(zj_flag_value --name "$@") || name=
+    printf '4\t%s\n' "$name" >> "$tabs"
+    printf '4\n'
+    exit 0 ;;
+  list-panes)
+    [ "$(cat "$dumps")" -lt "${FM_FAKE_ZJ_PANES_FAIL_AFTER_DUMPS:-9999}" ] || exit 1
+    printf '[{"id":7,"tab_id":4,"is_plugin":false}]\n'
+    exit 0 ;;
+  dump-screen)
+    echo $(( $(cat "$dumps") + 1 )) > "$dumps"
+    printf '%s\n%s\n%s\n' '__FM_ZELLIJ_CWD_BEGIN__' "${FM_FAKE_PANE_PATH:-}" '__FM_ZELLIJ_CWD_END__'
+    exit 0 ;;
+  close-tab-by-id)
+    grep -v "^${5:-}$(printf '\t')" "$tabs" > "$tabs.next" || true
+    mv "$tabs.next" "$tabs"
+    exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/zellij"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+# The claim refusal must retire the endpoint it just created even when the
+# backend's own pane->tab lookup transiently fails, because the leftover TAB -
+# not the pane - is what refuses the retry. The spawn is holding the tab id it
+# captured at create time, so the close has to carry it.
+test_spawn_claim_cleanup_retires_the_zellij_tab() {
+  local home proj claimed fakebin rec out status blocks
+  home="$TMP_ROOT/spawn-zj-home"
+  mkdir -p "$home/data" "$home/state"
+  proj=$(make_repo "$TMP_ROOT/spawn-zj-proj")
+  claimed="$TMP_ROOT/spawn-zj-wt"
+  git -C "$proj" worktree add -q --detach "$claimed" >/dev/null 2>&1
+  fakebin=$(make_spawn_zellij_fakebin "$TMP_ROOT/spawn-zj-fake")
+  rec="$TMP_ROOT/spawn-zj.log"
+  : > "$rec"
+  {
+    echo 'window=firstmate:9'
+    echo "worktree=$claimed"
+    echo "project=$proj"
+    echo 'harness=codex'
+    echo 'kind=ship'
+    echo 'backend=zellij'
+  } > "$home/state/zincumbent.meta"
+
+  fm_test_spawn_brief "$home" zj-collide-kk1 brief
+  out=$(FM_ZJ_REC="$rec" FM_FAKE_ZJ_PANES_FAIL_AFTER_DUMPS=2 \
+    fm_test_run_spawn "$home" "$claimed" "$fakebin" \
+      zj-collide-kk1 "$proj" codex --backend zellij --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 1 "$status" "a zellij spawn into a claimed worktree should refuse"
+  assert_contains "$out" "claimed by task zincumbent" \
+    "the zellij collision refusal did not name the owning record"
+  assert_grep 'close-tab-by-id 4' "$rec" \
+    "the claim cleanup must close the tab it created, using the tab id the spawn already holds"
+  assert_no_grep 'close-pane' "$rec" \
+    "closing only the pane leaves behind the empty tab that refuses the retry"
+  assert_not_contains "$out" "survived the refusal" \
+    "a fully retired zellij endpoint must not be reported as a survivor"
+
+  # The retryability claim, read from the backend's own tab inventory through
+  # the same predicate a fresh spawn is refused by.
+  blocks=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE='' \
+    bash -c '
+      . "$0/bin/fm-backend.sh"
+      if fm_backend_endpoint_blocks_respawn zellij firstmate:7 fm-zj-collide-kk1; then
+        echo blocks=yes
+      else
+        echo blocks=no
+      fi
+    ' "$ROOT")
+  assert_contains "$blocks" "blocks=no" \
+    "the refused allocation must be retryable without manual cleanup"
+  pass "fm-spawn: a claim refusal retires the zellij tab it created, even when the pane lookup fails"
+}
+
 test_lib_classification
 test_guard_banner
 test_bootstrap_line
 test_brief_assertion_precedes_branch
 test_spawn_isolation_abort
 test_spawn_durable_worktree_claims
+test_spawn_claim_cleanup_retires_the_zellij_tab
 test_spawn_tmux_window_construction

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -190,7 +190,7 @@ test_spawn_isolation_abort() {
 # --- GUARD 1c: fm-spawn durable worktree claims ----------------------------
 
 test_spawn_durable_worktree_claims() {
-  local home proj claimed free own alias broken fakebin rec out status
+  local home proj claimed free own alias broken recover fakebin rec out status
   home="$TMP_ROOT/spawn-claim-home"
   mkdir -p "$home/data" "$home/state"
   proj=$(make_repo "$TMP_ROOT/spawn-claim-proj")
@@ -294,6 +294,36 @@ test_spawn_durable_worktree_claims() {
     "the unresolvable-claim refusal did not explain why it stopped the spawn"
   assert_grep 'kill-window -t =firstmate:=fm-unresolvable-kk1' "$rec" \
     "an unresolvable claim refusal must retire the endpoint it created"
+
+  # The same unresolvable foreign record must NOT wedge the recovery path: a
+  # relaunch allocates no worktree and never refreshes a pooled base, so the
+  # destructive reset the refusal above prevents cannot happen on a relaunch.
+  recover="$TMP_ROOT/spawn-recover-wt"
+  git -C "$proj" worktree add -q --detach "$recover" >/dev/null 2>&1
+  fm_test_spawn_brief "$home" recover-ll2 brief
+  {
+    echo 'window=firstmate:fm-recover-ll2'
+    echo 'endpoint_task_id=recover-ll2'
+    echo "worktree=$recover/"
+    echo "project=$proj"
+    echo 'harness=codex'
+    echo 'kind=ship'
+    echo 'mode=no-mistakes'
+    echo 'yolo=off'
+    echo 'tasktmp=/tmp/fm-recover-ll2'
+    echo 'model=default'
+    echo 'effort=default'
+  } > "$home/state/recover-ll2.meta"
+  : > "$rec"
+  out=$(FM_TMUX_REC="$rec" FM_FAKE_WINDOWS='fm-recover-ll2' FM_FAKE_PANE_COMMAND=zsh \
+    fm_test_run_spawn "$home" "$recover" "$fakebin" recover-ll2 --relaunch)
+  status=$?
+  expect_code 0 "$status" \
+    "an unrelated unresolvable claim must not block relaunching a correctly recorded task"
+  assert_contains "$out" 'spawned recover-ll2' "the relaunch did not report success"
+  assert_not_contains "$out" 'could not be resolved' \
+    "the relaunch must not refuse on another record's unresolvable worktree value"
+  rm "$home/state/recover-ll2.meta"
   rm "$home/state/broken-claim.meta"
 
   {

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -225,6 +225,24 @@ test_spawn_durable_worktree_claims() {
     "a collision refusal must retire the new endpoint so treehouse can reallocate the slot"
   assert_no_grep 'send-keys -t firstmate:fm-collision-gg7 -l' "$rec" \
     "a collision refusal must not type an agent launch command"
+  assert_not_contains "$out" "survived the refusal" \
+    "a retired endpoint must not be reported as a survivor"
+
+  # A close that reports success while the window survives is not a retirement:
+  # the leftover endpoint is exactly what refuses the next attempt, so it has to
+  # be named rather than swallowed behind the best-effort kill's exit status.
+  : > "$rec"
+  out=$(FM_TMUX_REC="$rec" FM_FAKE_TMUX_KILL_NOOP=1 \
+    run_spawn "$home" stuck-jj0 "$proj" "$claimed" "$fakebin")
+  status=$?
+  expect_code 1 "$status" "spawn into another live task's worktree should refuse"
+  assert_contains "$out" "endpoint firstmate:fm-stuck-jj0 survived" \
+    "a surviving endpoint must be named so the operator can retire it"
+  out=$(FM_TMUX_REC="$rec" run_spawn "$home" stuck-jj0 "$proj" "$claimed" "$fakebin")
+  status=$?
+  expect_code 1 "$status" "the leftover endpoint should block the next attempt"
+  assert_contains "$out" "window firstmate:fm-stuck-jj0 already exists" \
+    "the endpoint the warning named is what refuses the retry"
 
   rm "$home/state/incumbent.meta"
   : > "$rec"
@@ -277,21 +295,71 @@ test_spawn_durable_worktree_claims() {
 #     window id, never the (possibly-renamed) name - a lost name would let
 #     display-message fall back to the active client's window and misread firstmate's
 #     OWN pane as the worktree, tangling a hook into the primary checkout.
+# The fake also models WINDOW LIVENESS, because retryability after a refused
+# spawn is a real tmux state question: `new-window` records the created name,
+# `kill-window` retires it, and `list-windows`/`display-message -t` answer from
+# that set - so a spawn that leaves its window behind is refused by the same
+# duplicate-name check real tmux enforces. FM_FAKE_TMUX_KILL_NOOP=1 makes
+# kill-window a no-op, reproducing the best-effort close that reports success
+# while the window survives.
 make_spawn_record_fakebin() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
-  cat > "$fakebin/tmux" <<'SH'
+  cat > "$fakebin/tmux" <<SH
 #!/usr/bin/env bash
 set -u
+FM_FAKE_TMUX_LIVE=\${FM_FAKE_TMUX_LIVE:-"$dir/live-windows"}
+SH
+  cat >> "$fakebin/tmux" <<'SH'
 [ -n "${FM_TMUX_REC:-}" ] && printf 'tmux %s\n' "$*" >> "$FM_TMUX_REC"
+: >> "$FM_FAKE_TMUX_LIVE"
+
+live_names() {
+  local n
+  for n in ${FM_FAKE_WINDOWS:-}; do printf '%s\n' "$n"; done
+  cat "$FM_FAKE_TMUX_LIVE"
+}
+
+window_live() {  # <window-name>
+  live_names | grep -qx "$1"
+}
+
+flag_value() {  # <flag> <args...>
+  local want=$1 prev=
+  shift
+  for a in "$@"; do
+    [ "$prev" = "$want" ] && { printf '%s\n' "$a"; return 0; }
+    prev=$a
+  done
+  return 1
+}
+
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
   *"#{pane_current_command}"*) printf '%s\n' "${FM_FAKE_PANE_COMMAND:-zsh}"; exit 0 ;;
 esac
 case "${1:-}" in
-  display-message) printf 'firstmate\n'; exit 0 ;;
-  new-window) printf '%s\n' "@spawnwid"; exit 0 ;;
-  list-windows) [ -z "${FM_FAKE_WINDOWS:-}" ] || printf '%s\n' "$FM_FAKE_WINDOWS"; exit 0 ;;
+  display-message)
+    target=$(flag_value -t "$@") || target=
+    case "$target" in
+      ''|@*) ;;
+      *:*) window_live "${target#*:}" || exit 1 ;;
+    esac
+    printf 'firstmate\n'; exit 0 ;;
+  new-window)
+    name=$(flag_value -n "$@") || name=
+    [ -z "$name" ] || printf '%s\n' "$name" >> "$FM_FAKE_TMUX_LIVE"
+    printf '%s\n' "@spawnwid"; exit 0 ;;
+  kill-window)
+    if [ "${FM_FAKE_TMUX_KILL_NOOP:-0}" != 1 ]; then
+      target=$(flag_value -t "$@") || target=
+      name=${target#*:}
+      name=${name#=}
+      grep -vx "$name" "$FM_FAKE_TMUX_LIVE" > "$FM_FAKE_TMUX_LIVE.next" || true
+      mv "$FM_FAKE_TMUX_LIVE.next" "$FM_FAKE_TMUX_LIVE"
+    fi
+    exit 0 ;;
+  list-windows) live_names; exit 0 ;;
   has-session|new-session|send-keys|set-window-option) exit 0 ;;
 esac
 exit 0

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -224,8 +224,14 @@ test_spawn_durable_worktree_claims() {
     run_spawn "$home" collision-gg7 "$proj" "$claimed" "$fakebin")
   status=$?
   expect_code 1 "$status" "spawn into another live task's worktree should refuse"
-  assert_contains "$out" "already claimed by live task incumbent" \
-    "the collision refusal did not name the incumbent task"
+  assert_contains "$out" "claimed by task incumbent in $home/state/incumbent.meta" \
+    "the collision refusal must name the owning task and the durable record it read"
+  assert_contains "$out" "does not prove a live worker" \
+    "the refusal must not present a durable claim as proof that a worker is running"
+  assert_contains "$out" "leftover from an incomplete cleanup and must be removed" \
+    "the refusal must tell the operator how to clear a stale claim"
+  assert_not_contains "$out" "claimed by live task" \
+    "the refusal must not assert liveness the record cannot prove"
   assert_absent "$home/state/collision-gg7.meta" "a collision refusal must not publish contender metadata"
   assert_grep 'kill-window -t =firstmate:=fm-collision-gg7' "$rec" \
     "a collision refusal must retire the new endpoint so treehouse can reallocate the slot"
@@ -242,7 +248,7 @@ test_spawn_durable_worktree_claims() {
     run_spawn "$home" stuck-jj0 "$proj" "$claimed" "$fakebin")
   status=$?
   expect_code 1 "$status" "spawn into another live task's worktree should refuse"
-  assert_contains "$out" "endpoint firstmate:fm-stuck-jj0 survived" \
+  assert_contains "$out" "endpoint firstmate:fm-stuck-jj0 named fm-stuck-jj0 survived" \
     "a surviving endpoint must be named so the operator can retire it"
   out=$(FM_TMUX_REC="$rec" run_spawn "$home" stuck-jj0 "$proj" "$claimed" "$fakebin")
   status=$?
@@ -282,7 +288,7 @@ test_spawn_durable_worktree_claims() {
   status=$?
   expect_code 0 "$status" "a relaunch into the task's own recorded worktree should remain allowed"
   assert_contains "$out" 'spawned own-ii9' "the own-worktree relaunch did not report success"
-  assert_not_contains "$out" 'already claimed by live task' \
+  assert_not_contains "$out" 'is already claimed by task' \
     "the own-worktree relaunch treated its own metadata as a collision"
   pass "fm-spawn: durable canonical worktree claims refuse collisions, release retries, and leave free slots launchable"
 }


### PR DESCRIPTION
## Intent

Make bin/fm-spawn.sh refuse to launch into a worktree that another live task already claims. After treehouse or the backend allocates a candidate worktree, compare its resolved absolute path against worktree= values in Firstmate's own durable state/<id>.meta records for every other still-recorded task; do not use process detection, lsof, or treehouse occupancy. Refuse before any agent launch or branch creation, and name the owning task id. Ensure refusal retires the newly created endpoint or backend allocation so a retry is possible without manual cleanup. Canonicalize paths so trailing slashes and symlink/realpath differences compare correctly. Leave genuinely free worktrees unaffected and allow --relaunch into the current task's own recorded worktree. Add behavior-level regression coverage colocated with existing spawn tests for collision refusal, cleanup and retry, free-worktree launch, and own-worktree relaunch. Keep scope to the spawn-side guard only: do not fix resumed-agent cwd behavior and do not modify or vendor treehouse. If task metadata proves unreliable for this guard, stop rather than widening the solution. The implementation places the assertion after isolation validation and before pooled-base refresh, uses regular durable metadata records as the live claim set, and cleans up only a newly created endpoint on collision.

ACCEPTED DECISION [cleanup-not-verified], already applied in this branch: a backend close is only best-effort, so its exit status alone must not be treated as proof the endpoint is gone. Verify the endpoint is actually gone before claiming retryability; where removal cannot be verified, retain the endpoint and surface a clear recoverable failure naming exactly what must be cleaned. This is why the cleanup reads back the name the next spawn would collide on (fm_backend_endpoint_blocks_respawn) and warns about a surviving endpoint, and why the refusal message states that a claim record does not prove a live worker.

CONTEXT FOR THE REVIEWER: this branch was rebased by an earlier pipeline run onto a newer default branch that added the backlog In-flight transition feature; commits titled "no-mistakes: apply CI fixes" and "no-mistakes(review): ..." are that earlier run's own authorized fix rounds, not unreviewed drift. A known open item from the prior run is that tests/fm-backend-herdr-presentation-e2e.test.sh fails at "fm-hibit-resume-r1 same-identity reclaim" because this new guard refuses the fixture's reclaim; whether the guard is over-refusing a legitimate bound reclaim or the fixture leaves a stale claim a correct guard should refuse is not yet settled and needs diagnosis rather than a convenience fix.

TEST SCOPE FOR THIS RUN - READ BEFORE RUNNING TESTS. Do NOT run the full tests/ inventory. It is 175 suites and takes about 9.4 HOURS measured on this machine (avg 3.2 min/suite; the Herdr end-to-end backend suites and fm-arm-pretool-check dominate). CI never runs it as one job - it shards into three lanes. The test step has a hard 30-minute agent limit, so a full-inventory run cannot finish and will be killed mid-flight.

Run a BOUNDED, TARGETED selection instead, sized to finish well inside 30 minutes. The repo's own runner supports this directly:
bin/fm-test-run.sh --changed --base origin/main
and named suites can be run with:
bin/fm-test-run.sh tests/<name>.test.sh [more...]

The suites that actually cover this change are:
tests/fm-tangle-guard.test.sh (collision refusal, free-worktree launch, cleanup/retry)
tests/fm-control-relaunch.test.sh (own-worktree relaunch allowed)
tests/fm-spawn-pool-base-freshen.test.sh (pooled base refresh interaction)
tests/fm-backend-cmux.test.sh (cmux workspace-id fail-closed fix)
tests/fm-backend-zellij.test.sh (zellij tab payload-shape fix)
tests/fm-spawn-dispatch-profile.test.sh
tests/fm-secondmate-liveness.test.sh

Prefer that targeted set. Do NOT trim or weaken any test to fit the clock - the selection is what is bounded, never the coverage. If the selection you choose is still going to exceed the window, say so explicitly in your result rather than being killed by the limit.

## What Changed

- Reject ship and scout launches into worktrees whose canonical path is claimed by another durable task record, while preserving a task’s own-worktree relaunch.
- Attempt to retire a newly allocated endpoint on claim refusal, verify whether its backend-specific name still blocks retry, and harden tmux, cmux, and Zellij endpoint inventory checks.
- Add regression coverage and documentation for worktree-claim refusal, cleanup/retry behavior, and backend endpoint verification.

## Risk Assessment

✅ Low: The durable-claim guard and backend-specific cleanup verification are correctly placed, fail conservatively, and preserve the authorized relaunch behavior.

## Testing

All seven requested targeted behavior suites passed. Evidence covers durable-claim collision/refusal, cleanup and retry, free and relaunch paths, plus pooled-base refresh and safety refusals; no worktree artifacts remain.

<details>
<summary>Evidence: Durable worktree-claim behavior test transcript</summary>

Source: [Durable worktree-claim behavior test transcript](https://github.com/o2themar/firstmate/blob/209e72777bdbcba8c1ad7a9b4691a68d64a7f0a6/.no-mistakes/evidence/fm/firstmate-spawn-refuses-claimed-worktree/fm-tangle-guard-behavior.log)

```text
FM_TEST_BEGIN 2026-09-01T22:21:50Z tests/fm-tangle-guard.test.sh family=session-bootstrap expected_gate_skip=none
ok - fm_primary_tangle_branch: feature branch alarms; default/detached/non-git stay silent
ok - fm-guard: bordered tangle banner fires only for a feature branch and suppresses repair commands in read-only mode
ok - fm-bootstrap: TANGLE problem line fires only for a feature branch and suppresses repair commands in detect-only mode
ok - fm-brief: ship brief asserts worktree isolation before the branch step
ok - fm-spawn: aborts unless the resolved worktree is a genuine, isolated worktree
ok - fm-spawn: durable canonical worktree claims refuse collisions, release retries, and leave free slots launchable
ok - fm-spawn: a claim refusal retires the zellij tab it created, even when the pane lookup fails
ok - fm-spawn: appends windows by session-colon, pins the name, and targets the window id
FM_TEST_END 2026-09-01T22:22:17Z tests/fm-tangle-guard.test.sh exit=0 duration_ms=27013 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=27114
FM_TEST_SUMMARY_FAMILY family=session-bootstrap count=1 duration_ms=27013 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-tangle-guard.test.sh duration_ms=27013
FM_TEST_BUDGET max_wall_ms=300000 duration_ms=27114
```
</details>
<details>
<summary>Evidence: Pooled-worktree refresh behavior transcript</summary>

Source: [Pooled-worktree refresh behavior transcript](https://github.com/o2themar/firstmate/blob/209e72777bdbcba8c1ad7a9b4691a68d64a7f0a6/.no-mistakes/evidence/fm/firstmate-spawn-refuses-claimed-worktree/fm-spawn-pool-base-freshen-behavior.log)

```text
FM_TEST_BEGIN 2026-09-01T22:34:04Z tests/fm-spawn-pool-base-freshen.test.sh family=unclassified expected_gate_skip=none
# observed spawn: spawned pool-current-base-r1 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-pool-current-base-r1 worktree=/var/folders/2b/1c12ydjx3_gb17nw0dn28wc40000gn/T//fm-spawn-pool-base-freshen.up5Pkl/current-base/pool
# observed base: HEAD=7639273aab3ac7fcf348c24bc0c2b6f0baa29500 origin/main=7639273aab3ac7fcf348c24bc0c2b6f0baa29500 advanced-main=must survive a newly spawned branch
ok - a stale pooled worktree refreshes to current origin/main before a crew branch is created
ok - a stale pooled worktree resolves and refreshes a non-main default branch
# observed direct-pr spawn: spawned pool-direct-pr-r3 harness=codex kind=ship mode=direct-PR yolo=off window=firstmate:fm-pool-direct-pr-r3 worktree=/var/folders/2b/1c12ydjx3_gb17nw0dn28wc40000gn/T//fm-spawn-pool-base-freshen.up5Pkl/direct-pr/pool
# observed scout spawn: spawned pool-scout-r3 harness=codex kind=scout window=firstmate:fm-pool-scout-r3 worktree=/var/folders/2b/1c12ydjx3_gb17nw0dn28wc40000gn/T//fm-spawn-pool-base-freshen.up5Pkl/scout/pool
ok - direct-PR ships and scouts both refresh stale pooled worktrees before launch
# observed dirty refusal: error: pooled worktree '/var/folders/2b/1c12ydjx3_gb17nw0dn28wc40000gn/T//fm-spawn-pool-base-freshen.up5Pkl/dirty-refusal/pool' is not clean; refusing to discard uncommitted work while refreshing its base; preserved=keep this local work
ok - a dirty pooled worktree is refused without discarding its local work
# observed unresolved-default refusal: error: could not resolve origin's current default branch for pooled worktree '/var/folders/2b/1c12ydjx3_gb17nw0dn28wc40000gn/T//fm-spawn-pool-base-freshen.up5Pkl/unresolved-default/pool'; refusing to launch from a potentially stale base
ok - an unresolved remote default branch refuses the pooled worktree
# observed unreachable-origin refusal: error: could not fetch origin for pooled worktree '/var/folders/2b/1c12ydjx3_gb17nw0dn28wc40000gn/T//fm-spawn-pool-base-freshen.up5Pkl/unreachable-origin/pool'; refusing to launch from a potentially stale base
ok - an unreachable origin refuses a potentially stale pooled worktree
# observed stale-pin refusal: error: submodule 'ui' is checked out at afeb71dd35b2515a5080b82cfbca8e455a94d559, but this base records 1424dd1747adffda5f45b7f0d0862dcb7b603f26
ok - two consecutive spawns across a moved submodule pin end in a refusal naming both pins and no remedy
ok - an unpushed submodule commit keeps the uncommitted-work refusal and survives it
ok - work inside a submodule is still refused as uncommitted work, not called stale
ok - a stale pin carrying real work is refused conservatively, never called stale
ok - a stale pin beside other dirt yields the conservative refusal alone, with no stale-pin line
# all fm-spawn-pool-base-freshen tests passed
FM_TEST_END 2026-09-01T22:34:34Z tests/fm-spawn-pool-base-freshen.test.sh exit=0 duration_ms=29485 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=29603
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=29485 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-spawn-pool-base-freshen.test.sh duration_ms=29485
FM_TEST_BUDGET max_wall_ms=300000 duration_ms=29603
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ed204ee6092e3d95f73b83b10e2837c147f06bd2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `PATH=~/.no-mistakes/evidence/01M1FAVY53BRMP7Z8Q07HKRGP9/test-bin:$PATH FM_TEST_EVIDENCE=1 bin/fm-test-run.sh --per-script-timeout-secs 600 --max-wall-ms 300000 tests/fm-tangle-guard.test.sh`
- `PATH=~/.no-mistakes/evidence/01M1FAVY53BRMP7Z8Q07HKRGP9/test-bin:$PATH FM_TEST_EVIDENCE=1 bin/fm-test-run.sh --per-script-timeout-secs 600 --max-wall-ms 300000 tests/fm-control-relaunch.test.sh`
- `PATH=~/.no-mistakes/evidence/01M1FAVY53BRMP7Z8Q07HKRGP9/test-bin:$PATH FM_TEST_EVIDENCE=1 bin/fm-test-run.sh --per-script-timeout-secs 600 --max-wall-ms 300000 tests/fm-spawn-pool-base-freshen.test.sh`
- `PATH=~/.no-mistakes/evidence/01M1FAVY53BRMP7Z8Q07HKRGP9/test-bin:$PATH FM_TEST_EVIDENCE=1 bin/fm-test-run.sh --per-script-timeout-secs 600 --max-wall-ms 300000 tests/fm-backend-cmux.test.sh`
- `PATH=~/.no-mistakes/evidence/01M1FAVY53BRMP7Z8Q07HKRGP9/test-bin:$PATH FM_TEST_EVIDENCE=1 bin/fm-test-run.sh --per-script-timeout-secs 600 --max-wall-ms 300000 tests/fm-backend-zellij.test.sh`
- `PATH=~/.no-mistakes/evidence/01M1FAVY53BRMP7Z8Q07HKRGP9/test-bin:$PATH FM_TEST_EVIDENCE=1 bin/fm-test-run.sh --per-script-timeout-secs 600 --max-wall-ms 300000 tests/fm-spawn-dispatch-profile.test.sh`
- `PATH=~/.no-mistakes/evidence/01M1FAVY53BRMP7Z8Q07HKRGP9/test-bin:$PATH FM_TEST_EVIDENCE=1 bin/fm-test-run.sh --per-script-timeout-secs 600 --max-wall-ms 300000 tests/fm-secondmate-liveness.test.sh`
- `git status --short`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
