### PR TITLE
fix(bin): document Claude Herdr away-mode launcher requirement

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -32,10 +32,7 @@ batched digest rather than per-wake injections.
      After `bin/fm-afk-launch.sh stop` succeeds, enter again with `bin/fm-afk-launch.sh start`.
      Do not follow the stop with `start-native`, which recreates the same unsupported same-target construction.
      The incident evidence supports the inference that the native job keeps the supervised Claude pane's Herdr agent state `working` for the daemon's lifetime, so the busy guard correctly defers every injection.
-   - **Other harnesses WITH a native in-pane tracked-background tool** (for
-     example, Grok's background tool): first run
-     `bin/fm-afk-launch.sh start-native`, then run
-     `FM_AFK_STATE_PREPARED=1 bin/fm-afk-start.sh` through that native tool.
+   - **Other harnesses WITH a native in-pane tracked-background tool** (for example, Grok's background tool): first run `bin/fm-afk-launch.sh start-native`, then run `FM_AFK_STATE_PREPARED=1 bin/fm-afk-start.sh` through that native tool.
      This is a deliberate no-separate-terminal exception because the harness-hosted job creates no terminal or layout mutation, and a shell launcher cannot invoke a harness-native background tool.
      The launcher still owns lifecycle state and records the no-terminal mode, while the daemon inherits and auto-discovers the captain pane.
      If the native launch fails, run `bin/fm-afk-launch.sh stop` to roll back the prepared lifecycle.

--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -26,14 +26,12 @@ batched digest rather than per-wake injections.
 2. **Ensure the sub-supervisor daemon is running as a tracked background process.**
    Its hosting differs by harness.
    Pick the right path:
-   - **Claude on Herdr:** run `bin/fm-afk-launch.sh start`, not the Claude
-     native background Bash path.
-     The native job keeps the supervised Claude pane's Herdr agent state
-     `working` for the daemon's lifetime, so the busy guard correctly defers
-     every injection.
-     The terminal-backed launcher captures the captain target before creating
-     its separate non-visible workspace and passes that target explicitly to
-     the daemon.
+   - **Claude on Herdr:** do not use the Claude native background Bash path.
+     On a fresh launch, run `bin/fm-afk-launch.sh start`; the terminal-backed launcher captures the captain target before creating its separate non-visible workspace and passes that target explicitly to the daemon.
+     If a native-hosted daemon is already live, `start` only refreshes `state/.afk` and returns with no new terminal, so it cannot migrate that daemon.
+     After `bin/fm-afk-launch.sh stop` succeeds, enter again with `bin/fm-afk-launch.sh start`.
+     Do not follow the stop with `start-native`, which recreates the same unsupported same-target construction.
+     The incident evidence supports the inference that the native job keeps the supervised Claude pane's Herdr agent state `working` for the daemon's lifetime, so the busy guard correctly defers every injection.
    - **Other harnesses WITH a native in-pane tracked-background tool** (for
      example, Grok's background tool): first run
      `bin/fm-afk-launch.sh start-native`, then run

--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -26,8 +26,16 @@ batched digest rather than per-wake injections.
 2. **Ensure the sub-supervisor daemon is running as a tracked background process.**
    Its hosting differs by harness.
    Pick the right path:
-   - **Harness WITH a native in-pane tracked-background tool** (e.g. claude's
-     background bash, grok's background tool): first run
+   - **Claude on Herdr:** run `bin/fm-afk-launch.sh start`, not the Claude
+     native background Bash path.
+     The native job keeps the supervised Claude pane's Herdr agent state
+     `working` for the daemon's lifetime, so the busy guard correctly defers
+     every injection.
+     The terminal-backed launcher captures the captain target before creating
+     its separate non-visible workspace and passes that target explicitly to
+     the daemon.
+   - **Other harnesses WITH a native in-pane tracked-background tool** (for
+     example, Grok's background tool): first run
      `bin/fm-afk-launch.sh start-native`, then run
      `FM_AFK_STATE_PREPARED=1 bin/fm-afk-start.sh` through that native tool.
      This is a deliberate no-separate-terminal exception because the harness-hosted job creates no terminal or layout mutation, and a shell launcher cannot invoke a harness-native background tool.

--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -29,8 +29,11 @@ batched digest rather than per-wake injections.
    - **Claude on Herdr:** do not use the Claude native background Bash path.
      On a fresh launch, run `bin/fm-afk-launch.sh start`; the terminal-backed launcher captures the captain target before creating its separate non-visible workspace and passes that target explicitly to the daemon.
      If a native-hosted daemon is already live, `start` only refreshes `state/.afk` and returns with no new terminal, so it cannot migrate that daemon.
-     After `bin/fm-afk-launch.sh stop` succeeds, enter again with `bin/fm-afk-launch.sh start`.
-     Do not follow the stop with `start-native`, which recreates the same unsupported same-target construction.
+     Do not migrate it with a raw `bin/fm-afk-launch.sh stop` followed by `start`: a successful low-level stop proves lifecycle shutdown, not delivery, and a blocked final flush leaves a buffer that the fresh start would clear after its source wake may already be acknowledged.
+     Instead run `bin/fm-afk-return.sh begin`, which creates the fail-closed return gate before shutdown and retains the buffered escalation and wedge evidence in that gate.
+     Process the emitted catch-up and any blocker; if the gate remains pending, run `bin/fm-afk-return.sh check` until it succeeds.
+     Only after `begin` or `check` reports that catch-up is clear may you enter again with `bin/fm-afk-launch.sh start`.
+     Do not use `start-native`, which recreates the same unsupported same-target construction.
      The incident evidence supports the inference that the native job keeps the supervised Claude pane's Herdr agent state `working` for the daemon's lifetime, so the busy guard correctly defers every injection.
    - **Other harnesses WITH a native in-pane tracked-background tool** (for example, Grok's background tool): first run `bin/fm-afk-launch.sh start-native`, then run `FM_AFK_STATE_PREPARED=1 bin/fm-afk-start.sh` through that native tool.
      This is a deliberate no-separate-terminal exception because the harness-hosted job creates no terminal or layout mutation, and a shell launcher cannot invoke a harness-native background tool.
@@ -221,9 +224,9 @@ the operational prefix lets firstmate distinguish it from a real captain message
 
 ## Stale-artifact lifecycle
 
-Treat `state/.subsuper-escalations`, its `.since` sidecar, and `state/.subsuper-inject-wedged` as session-scoped delivery artifacts, not as the durable work record.
+Treat `state/.subsuper-escalations`, its `.since` sidecar, and `state/.subsuper-inject-wedged` as session-scoped delivery artifacts that must be presented through the return gate before a live session is replaced, not as the durable work record.
 Always enter through `bin/fm-afk-launch.sh`, which clears prior-session artifacts only for a fresh entry and preserves the current session's buffer on refresh.
-Always exit through `bin/fm-afk-launch.sh stop`, which keeps `state/.afk` present through the daemon's shutdown flush and clears it last.
+Always exit or migrate a live session through `bin/fm-afk-return.sh begin` and its successful `check`; that path creates the durable catch-up gate before calling the lower-level launcher stop, which keeps `state/.afk` present through the daemon's shutdown flush and clears it last.
 `docs/herdr-backend.md` "Away-mode supervisor support" owns the current mechanism, and `docs/verification/runtime-backends.md` "Away-mode transport" owns active evidence.
 
 ## Reliability properties

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -5,12 +5,15 @@
 #
 # Why this exists (docs/herdr-backend.md "Away-mode daemon terminal launch"):
 # bin/fm-afk-start.sh execs the supervise daemon in the FOREGROUND of whatever
-# terminal it is already in. Claude's native background Bash cannot host it on
-# herdr: that job retains the supervised Claude pane's native busy state, so the
-# delivery guard must defer forever. Claude/herdr therefore uses this script's
-# non-visible tracked terminal path. A harness with NO native background
-# mechanism (pi) uses the same path. It never splits the captain's active pane,
-# and NEVER uses shell `&` (which herdr/codex can reap).
+# terminal it is already in. The Claude/herdr incident evidence supports the
+# inference that a native background Bash job retains the supervised Claude
+# pane's busy state, so that hosting cannot deliver through the busy guard.
+# Claude/herdr therefore uses this script's non-visible tracked terminal path.
+# A live daemon makes `start` refresh .afk without creating a terminal; migrate
+# a native-hosted daemon after `stop` succeeds with a fresh `start`, never
+# `start-native`. A harness with NO native background mechanism (pi) uses the
+# same terminal-backed path. It never splits the captain's active pane, and
+# NEVER uses shell `&` (which herdr/codex can reap).
 #
 # Correct supervisor targeting: the daemon finds the captain pane to inject into
 # from its OWN inherited env (discover_supervisor_target). Running it in a

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -3,7 +3,7 @@
 # launch it in a NON-VISIBLE tracked terminal per backend, record its exact id,
 # tear it down by that exact id, and reconcile a leaked one after a crash.
 #
-# Why this exists (docs/herdr-backend.md "Away-mode daemon terminal launch"):
+# Why this exists (docs/herdr-backend.md "Away-mode supervisor support"):
 # bin/fm-afk-start.sh execs the supervise daemon in the FOREGROUND of whatever
 # terminal it is already in. The Claude/herdr incident evidence supports the
 # inference that a native background Bash job retains the supervised Claude

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -9,11 +9,11 @@
 # inference that a native background Bash job retains the supervised Claude
 # pane's busy state, so that hosting cannot deliver through the busy guard.
 # Claude/herdr therefore uses this script's non-visible tracked terminal path.
-# A live daemon makes `start` refresh .afk without creating a terminal; migrate
-# a native-hosted daemon after `stop` succeeds with a fresh `start`, never
-# `start-native`. A harness with NO native background mechanism (pi) uses the
-# same terminal-backed path. It never splits the captain's active pane, and
-# NEVER uses shell `&` (which herdr/codex can reap).
+# A live daemon makes `start` refresh .afk without a terminal; migrate native
+# hosting through fm-afk-return.sh begin/check before fresh `start`, never raw
+# stop/start or `start-native`: stop success does not attest delivery, and fresh
+# start clears the buffer. A harness with NO native background mechanism (pi)
+# uses the same path, never splits the captain pane, and NEVER uses shell `&`.
 #
 # Correct supervisor targeting: the daemon finds the captain pane to inject into
 # from its OWN inherited env (discover_supervisor_target). Running it in a
@@ -34,7 +34,9 @@
 #   fm-afk-launch.sh stop      Correct-ordered exit: SIGTERM the daemon so its
 #                              cleanup flushes WHILE state/.afk is still present,
 #                              wait for it, close the recorded terminal by exact
-#                              id, then clear state/.afk last.
+#                              id, then clear state/.afk last. This low-level exit
+#                              does not attest delivery; normal return and live
+#                              migration use fm-afk-return.sh begin/check.
 #   fm-afk-launch.sh reconcile Close a recorded-but-dead daemon terminal by exact
 #                              id and drop the record (recovery after a crash).
 #

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -29,8 +29,8 @@
 #                              just refreshes state/.afk; a recorded-but-dead
 #                              terminal is reconciled (closed by id) first.
 #   fm-afk-launch.sh start-native
-#                              Prepare lifecycle state for a harness-native
-#                              background job and record that no terminal exists.
+#                              Record no terminal for a harness-native background
+#                              job; unsupported for Claude/Herdr, which uses start.
 #   fm-afk-launch.sh stop      Correct-ordered exit: SIGTERM the daemon so its
 #                              cleanup flushes WHILE state/.afk is still present,
 #                              wait for it, close the recorded terminal by exact

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -5,13 +5,12 @@
 #
 # Why this exists (docs/herdr-backend.md "Away-mode daemon terminal launch"):
 # bin/fm-afk-start.sh execs the supervise daemon in the FOREGROUND of whatever
-# terminal it is already in. Harnesses with a native in-pane tracked-background
-# tool (claude, grok) run it there directly and it is fine. A harness with NO
-# native background mechanism (pi) has to manufacture a terminal, and doing that
-# by SPLITTING the captain's active pane visibly shrinks it - the regression this
-# script fixes. Instead this creates a non-visible tracked terminal (a herdr tab/
-# workspace with --no-focus, or a detached tmux session) that never touches the
-# captain's active tab, and NEVER uses shell `&` (which herdr/codex can reap).
+# terminal it is already in. Claude's native background Bash cannot host it on
+# herdr: that job retains the supervised Claude pane's native busy state, so the
+# delivery guard must defer forever. Claude/herdr therefore uses this script's
+# non-visible tracked terminal path. A harness with NO native background
+# mechanism (pi) uses the same path. It never splits the captain's active pane,
+# and NEVER uses shell `&` (which herdr/codex can reap).
 #
 # Correct supervisor targeting: the daemon finds the captain pane to inject into
 # from its OWN inherited env (discover_supervisor_target). Running it in a

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -26,7 +26,9 @@
 #     targets it, not the daemon's own new pane. The incident evidence supports
 #     the inference that Claude's native background Bash retains the target's
 #     native busy state and therefore cannot deliver away-mode injection on
-#     herdr.
+#     herdr. Migrate an already-live native daemon through fm-afk-return.sh
+#     begin/check before a fresh launcher start, never through raw stop/start:
+#     stop success does not prove a guard-blocked final flush delivered.
 #   - Other harnesses with a native in-pane tracked-background tool run this
 #     directly via that tool only when it does not retain the target busy.
 # Do not wrap this in `nohup ... &`: Codex/herdr can reap fire-and-forget shell
@@ -53,12 +55,12 @@ fm_afk_start_usage() {
 # artifacts so they cannot surface as stale escalations under the new session.
 # These are session-scoped by timing: a fresh entry owns a new supervision
 # session and the new daemon has not produced anything yet, so anything present
-# here belongs to a PRIOR session. This never drops a genuinely-pending
-# escalation - the delivery buffer is a transient cache, and any condition still
-# true (a crew still blocked, a check still firing) is re-derived and re-escalated
-# fresh by the daemon's heartbeat catch-all scan and the durable
-# state/.wake-queue replay (see docs/herdr-backend.md "Away-mode stale-artifact
-# lifecycle" and bin/fm-supervise-daemon.sh's escalate_add/inject_wedge_alarm).
+# here belongs to a PRIOR session. The supported live-session return or migration
+# first runs fm-afk-return.sh begin/check, which preserves buffered escalation and
+# wedge evidence in its fail-closed catch-up gate before this cache is cleared.
+# A raw stop/start is not a supported migration because the source wake may
+# already be acknowledged and therefore may not reconstruct the buffered digest
+# (see docs/herdr-backend.md "Away-mode supervisor support").
 # NOT called on a refresh (daemon already alive), so the current session's own
 # buffered escalations are preserved.
 fm_afk_clear_stale_artifacts() {  # <state-dir>

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -19,14 +19,15 @@
 #
 # This is the COMMON daemon entry for every backend. HOW it becomes a tracked
 # background process differs by harness/backend and is owned elsewhere:
-#   - Harnesses with a native in-pane tracked-background tool (e.g. claude, grok)
-#     run this directly via that tool, so the daemon inherits the captain pane's
-#     env and auto-discovers it.
-#   - Harnesses with NO native background mechanism (e.g. pi) run this THROUGH
-#     bin/fm-afk-launch.sh, which creates a non-visible tracked terminal per
-#     backend (herdr tab/workspace, tmux detached session) and passes the
-#     captain pane in as FM_SUPERVISOR_TARGET so injection targets it, not the
-#     daemon's own new pane.
+#   - Claude on herdr and harnesses with NO native background mechanism (e.g.
+#     pi) run this THROUGH bin/fm-afk-launch.sh, which creates a non-visible
+#     tracked terminal per backend (herdr tab/workspace, tmux detached session)
+#     and passes the captain pane in as FM_SUPERVISOR_TARGET so injection
+#     targets it, not the daemon's own new pane. Claude's native background
+#     Bash retains the target's native busy state and cannot deliver away-mode
+#     injection on herdr.
+#   - Other harnesses with a native in-pane tracked-background tool run this
+#     directly via that tool only when it does not retain the target busy.
 # Do not wrap this in `nohup ... &`: Codex/herdr can reap fire-and-forget shell
 # children after the tool call returns, while a tracked background terminal stays
 # attached and has a real lifecycle.

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -23,9 +23,10 @@
 #     pi) run this THROUGH bin/fm-afk-launch.sh, which creates a non-visible
 #     tracked terminal per backend (herdr tab/workspace, tmux detached session)
 #     and passes the captain pane in as FM_SUPERVISOR_TARGET so injection
-#     targets it, not the daemon's own new pane. Claude's native background
-#     Bash retains the target's native busy state and cannot deliver away-mode
-#     injection on herdr.
+#     targets it, not the daemon's own new pane. The incident evidence supports
+#     the inference that Claude's native background Bash retains the target's
+#     native busy state and therefore cannot deliver away-mode injection on
+#     herdr.
 #   - Other harnesses with a native in-pane tracked-background tool run this
 #     directly via that tool only when it does not retain the target busy.
 # Do not wrap this in `nohup ... &`: Codex/herdr can reap fire-and-forget shell

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -296,14 +296,17 @@ The busy guard must defer in that shape, so native same-pane hosting cannot deli
 On a fresh launch, run `bin/fm-afk-launch.sh start` from that primary instead.
 It captures the captain pane first, creates a dedicated unfocused Herdr workspace, runs the daemon there with an explicit supervisor target and backend, records the exact daemon pane, and closes only that pane on stop.
 If a native-hosted daemon is already live, `start` only refreshes `state/.afk` and reports that no new terminal was created.
-After `bin/fm-afk-launch.sh stop` succeeds, migrate it with `bin/fm-afk-launch.sh start`, never by launching `start-native` again.
+Do not migrate it with a raw `bin/fm-afk-launch.sh stop` followed by `start`: stop success proves lifecycle shutdown but does not prove that a guard-blocked final flush delivered, and the fresh start clears the remaining session buffer even when its source wake was already acknowledged.
+Run `bin/fm-afk-return.sh begin` instead; it creates a fail-closed catch-up gate before shutdown, then retains buffered-escalation and wedge evidence and presents the durable wake drain.
+Process that catch-up and any blocker; if the gate remains pending, run `bin/fm-afk-return.sh check` until it succeeds, and run `bin/fm-afk-launch.sh start` only after either command reports that catch-up is clear.
+Never migrate by launching `start-native` again.
 Pi uses the same terminal-backed route because it has no native tracked background mechanism.
 Other native background mechanisms remain eligible only when they do not retain their supervisor target in a busy state.
 It never splits the captain's active tab and never uses shell `&`.
 Recovery reconciles only the recorded exact id.
 
 On stop, the daemon receives termination while `state/.afk` still exists so its final flush can run, the recorded terminal is closed, and the AFK flag is removed last.
-A fresh entry clears stale transient escalation caches, while durable queue and task records remain authoritative.
+A fresh entry clears stale transient escalation caches, so the supported return and migration path first carries any live buffer into the durable catch-up gate; durable queue and task records alone do not prove that an already acknowledged escalation will be reconstructed.
 
 ## Destructive lab safety
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -291,9 +291,12 @@ It refuses Zellij, Orca, and cmux as supervisor backends rather than applying th
 For Herdr, target existence, native state, capture, composer state, and verified submit all route through the shared backend dispatcher and the explicit named-session CLI owner.
 The pane-independent max-defer alert is configured in [`wedge-alarm.md`](wedge-alarm.md).
 
-Harnesses with native tracked background execution can run the daemon in their terminal.
-Pi has no such mechanism.
-`bin/fm-afk-launch.sh` therefore creates a dedicated unfocused Herdr workspace, runs the daemon there with an explicit supervisor target and backend, records the exact daemon pane, and closes only that pane on stop.
+Claude's native tracked background Bash cannot host the away daemon on Herdr because it leaves the supervised Claude pane's native agent state `working` for the daemon's lifetime.
+The busy guard must defer in that shape, so native same-pane hosting cannot deliver an away digest for a Claude/Herdr primary.
+Run `bin/fm-afk-launch.sh start` from that primary instead.
+It captures the captain pane first, creates a dedicated unfocused Herdr workspace, runs the daemon there with an explicit supervisor target and backend, records the exact daemon pane, and closes only that pane on stop.
+Pi uses the same terminal-backed route because it has no native tracked background mechanism.
+Other native background mechanisms remain eligible only when they do not retain their supervisor target in a busy state.
 It never splits the captain's active tab and never uses shell `&`.
 Recovery reconciles only the recorded exact id.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -291,10 +291,12 @@ It refuses Zellij, Orca, and cmux as supervisor backends rather than applying th
 For Herdr, target existence, native state, capture, composer state, and verified submit all route through the shared backend dispatcher and the explicit named-session CLI owner.
 The pane-independent max-defer alert is configured in [`wedge-alarm.md`](wedge-alarm.md).
 
-Claude's native tracked background Bash cannot host the away daemon on Herdr because it leaves the supervised Claude pane's native agent state `working` for the daemon's lifetime.
+The incident evidence supports the inference that Claude's native tracked background Bash leaves the supervised Claude pane's native agent state `working` for the daemon's lifetime.
 The busy guard must defer in that shape, so native same-pane hosting cannot deliver an away digest for a Claude/Herdr primary.
-Run `bin/fm-afk-launch.sh start` from that primary instead.
+On a fresh launch, run `bin/fm-afk-launch.sh start` from that primary instead.
 It captures the captain pane first, creates a dedicated unfocused Herdr workspace, runs the daemon there with an explicit supervisor target and backend, records the exact daemon pane, and closes only that pane on stop.
+If a native-hosted daemon is already live, `start` only refreshes `state/.afk` and reports that no new terminal was created.
+After `bin/fm-afk-launch.sh stop` succeeds, migrate it with `bin/fm-afk-launch.sh start`, never by launching `start-native` again.
 Pi uses the same terminal-backed route because it has no native tracked background mechanism.
 Other native background mechanisms remain eligible only when they do not retain their supervisor target in a busy state.
 It never splits the captain's active tab and never uses shell `&`.

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -10,7 +10,11 @@ The durable marker and tmux flash remain as additional signals.
 Away-mode delivery requires an idle primary and an affirmatively empty composer.
 `pane_is_busy` refuses a primary mid-turn, and `fm_backend_composer_state` refuses any composer verdict other than `empty`, so a digest cannot merge into active or uncertain input.
 If the primary remains continuously busy, buffered delivery starves by design rather than interrupting that turn.
-On Claude/Herdr, the native tracked-background launch also keeps the target's native agent state busy even while the captain is absent.
+The overnight Claude/Herdr native-path incident recorded 2,063 consecutive `inject deferred: supervisor pane busy (agent mid-turn)` deferrals, one composer deferral, zero deliveries, and roughly eight hours of starvation while the primary was genuinely idle.
+Target resolution was correct: with `HERDR_SESSION` unset, supervisor discovery composed `default:<HERDR_PANE_ID>` as designed.
+Claude Stop auto-arm was not the source because it exits while `state/.afk` exists.
+The busy guard queries Herdr native agent state before its harness-scoped rendered-footer fallback, and the observed `3 shells still running` idle screen is not a Claude delivery busy signature.
+The native background job itself holds the target's native agent state `working` for its lifetime, so same-target native hosting cannot deliver by construction.
 That is a hosting limitation, not a reason to weaken the guard: launch through `bin/fm-afk-launch.sh start` so the daemon runs in its own non-visible workspace with an explicit target.
 `FM_MAX_DEFER_SECS` bounds how long that deferral can remain silent: once the threshold is reached, it raises this alarm and preserves the buffered escalation.
 Treat the alarm as a visible delivery failure, not as permission to override either guard.

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -14,8 +14,10 @@ The overnight Claude/Herdr native-path incident recorded 2,063 consecutive `inje
 Target resolution was correct: with `HERDR_SESSION` unset, supervisor discovery composed `default:<HERDR_PANE_ID>` as designed.
 Claude Stop auto-arm was not the source because it exits while `state/.afk` exists.
 The busy guard queries Herdr native agent state before its harness-scoped rendered-footer fallback, and the observed `3 shells still running` idle screen is not a Claude delivery busy signature.
-The native background job itself holds the target's native agent state `working` for its lifetime, so same-target native hosting cannot deliver by construction.
-That is a hosting limitation, not a reason to weaken the guard: launch through `bin/fm-afk-launch.sh start` so the daemon runs in its own non-visible workspace with an explicit target.
+Together, those observations support the inference that the native background job itself holds the target's native agent state `working` for its lifetime.
+Under that inferred mechanism, same-target native hosting cannot deliver by construction.
+That is a hosting limitation, not a reason to weaken the guard: on a fresh launch, use `bin/fm-afk-launch.sh start` so the daemon runs in its own non-visible workspace with an explicit target.
+If the native-hosted daemon is already live, `start` only refreshes the away flag and cannot move it; after `bin/fm-afk-launch.sh stop` succeeds, run `bin/fm-afk-launch.sh start`, not `start-native`.
 `FM_MAX_DEFER_SECS` bounds how long that deferral can remain silent: once the threshold is reached, it raises this alarm and preserves the buffered escalation.
 Treat the alarm as a visible delivery failure, not as permission to override either guard.
 

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -11,7 +11,7 @@ Same-pane away-mode delivery requires an idle primary and an affirmatively empty
 `pane_is_busy` refuses a primary mid-turn, and `fm_backend_composer_state` refuses any composer verdict other than `empty`, so a digest cannot merge into active or uncertain input.
 If the primary remains continuously busy, buffered delivery starves by design rather than interrupting that turn.
 The expected example is a captain who continues interacting with Firstmate after entering away mode, which keeps the same primary busy instead of creating an idle absence.
-`FM_MAX_DEFER_SECS` bounds that wait and raises this alarm while preserving the buffered escalation.
+`FM_MAX_DEFER_SECS` bounds how long that deferral can remain silent: once the threshold is reached, it raises this alarm and preserves the buffered escalation.
 Treat the alarm as a visible delivery limitation, not as permission to override either guard or proof that idle away-mode delivery failed.
 
 ## Channels

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -17,7 +17,9 @@ The busy guard queries Herdr native agent state before its harness-scoped render
 Together, those observations support the inference that the native background job itself holds the target's native agent state `working` for its lifetime.
 Under that inferred mechanism, same-target native hosting cannot deliver by construction.
 That is a hosting limitation, not a reason to weaken the guard: on a fresh launch, use `bin/fm-afk-launch.sh start` so the daemon runs in its own non-visible workspace with an explicit target.
-If the native-hosted daemon is already live, `start` only refreshes the away flag and cannot move it; after `bin/fm-afk-launch.sh stop` succeeds, run `bin/fm-afk-launch.sh start`, not `start-native`.
+If the native-hosted daemon is already live, `start` only refreshes the away flag and cannot move it.
+Do not use a raw stop-then-start migration because stop success does not prove that a guard-blocked final flush delivered, while the fresh start clears the remaining buffer.
+Use `bin/fm-afk-return.sh begin`, process its retained catch-up evidence and blockers, complete `bin/fm-afk-return.sh check` if the gate remains pending, and run `bin/fm-afk-launch.sh start`, not `start-native`, only after catch-up is clear; [`herdr-backend.md`](herdr-backend.md#away-mode-supervisor-support) owns the mechanism.
 `FM_MAX_DEFER_SECS` bounds how long that deferral can remain silent: once the threshold is reached, it raises this alarm and preserves the buffered escalation.
 Treat the alarm as a visible delivery failure, not as permission to override either guard.
 

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -7,12 +7,13 @@ The durable marker and tmux flash remain as additional signals.
 
 ## When a delivery stays buffered
 
-Same-pane away-mode delivery requires an idle primary and an affirmatively empty composer.
+Away-mode delivery requires an idle primary and an affirmatively empty composer.
 `pane_is_busy` refuses a primary mid-turn, and `fm_backend_composer_state` refuses any composer verdict other than `empty`, so a digest cannot merge into active or uncertain input.
 If the primary remains continuously busy, buffered delivery starves by design rather than interrupting that turn.
-The expected example is a captain who continues interacting with Firstmate after entering away mode, which keeps the same primary busy instead of creating an idle absence.
+On Claude/Herdr, the native tracked-background launch also keeps the target's native agent state busy even while the captain is absent.
+That is a hosting limitation, not a reason to weaken the guard: launch through `bin/fm-afk-launch.sh start` so the daemon runs in its own non-visible workspace with an explicit target.
 `FM_MAX_DEFER_SECS` bounds how long that deferral can remain silent: once the threshold is reached, it raises this alarm and preserves the buffered escalation.
-Treat the alarm as a visible delivery limitation, not as permission to override either guard or proof that idle away-mode delivery failed.
+Treat the alarm as a visible delivery failure, not as permission to override either guard.
 
 ## Channels
 

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -5,6 +5,15 @@ When injection cannot confirm a submit past `FM_MAX_DEFER_SECS`, `inject_wedge_a
 The active alert is pane-independent because a tmux status-line flash has no cross-backend equivalent and cannot reach an unattended captain reliably.
 The durable marker and tmux flash remain as additional signals.
 
+## When a delivery stays buffered
+
+Same-pane away-mode delivery requires an idle primary and an affirmatively empty composer.
+`pane_is_busy` refuses a primary mid-turn, and `fm_backend_composer_state` refuses any composer verdict other than `empty`, so a digest cannot merge into active or uncertain input.
+If the primary remains continuously busy, buffered delivery starves by design rather than interrupting that turn.
+The expected example is a captain who continues interacting with Firstmate after entering away mode, which keeps the same primary busy instead of creating an idle absence.
+`FM_MAX_DEFER_SECS` bounds that wait and raises this alarm while preserving the buffered escalation.
+Treat the alarm as a visible delivery limitation, not as permission to override either guard or proof that idle away-mode delivery failed.
+
 ## Channels
 
 `config/wedge-alarm` is local and gitignored.

--- a/tests/fm-secondmate-reconcile.test.sh
+++ b/tests/fm-secondmate-reconcile.test.sh
@@ -405,7 +405,7 @@ test_a_failed_send_is_retried_on_the_next_run() {
 }
 
 test_busy_lifecycle_locks_never_hold_up_the_digest() {
-  local label home mate fakebin snap lock ready release holder notify out
+  local label home mate fakebin snap lock ready release holder notify completion rc out i
   for label in reconcile control meta; do
     { read -r home; read -r mate; read -r fakebin; } < <(make_main_home "busy-$label" mate)
     snap="$home/snapshot.json"
@@ -420,16 +420,30 @@ test_busy_lifecycle_locks_never_hold_up_the_digest() {
     hold_lock_until_released "$lock" "$ready" "$release"
     holder=$!
     while [ ! -f "$ready" ]; do sleep 0.01; done
-    run_notify "$home" "$fakebin" "busy-$label" "$snap" > "$home/notify.out" 2>&1 &
+    completion="$home/notify.done"
+    (
+      rc=0
+      run_notify "$home" "$fakebin" "busy-$label" "$snap" > "$home/notify.out" 2>&1 || rc=$?
+      printf '%s\n' "$rc" > "$completion"
+    ) &
     notify=$!
-    sleep 0.2
-    if kill -0 "$notify" 2>/dev/null; then
+    # Completion while the holder still owns the lock proves the path is nonblocking.
+    # A fixed subsecond sleep makes scheduler speed part of the assertion under CI load.
+    i=0
+    while [ ! -f "$completion" ] && [ "$i" -lt 100 ]; do
+      kill -0 "$holder" 2>/dev/null || fail "the $label lock holder exited before notify completed"
+      sleep 0.05
+      i=$((i + 1))
+    done
+    if [ ! -f "$completion" ]; then
       : > "$release"
       wait "$notify" 2>/dev/null || true
       wait "$holder" 2>/dev/null || true
       fail "a busy $label lock blocked the reconcile path"
     fi
-    wait "$notify" || fail "a busy $label lock made notify fail"
+    wait "$notify" || fail "the busy $label lock completion wrapper failed"
+    rc=$(cat "$completion")
+    [ "$rc" -eq 0 ] || fail "a busy $label lock made notify fail"
     : > "$release"
     wait "$holder" || fail "the $label lock holder failed"
     out=$(cat "$home/notify.out")


### PR DESCRIPTION
## Intent

Correct the away-mode delivery documentation for a Claude primary on the Herdr backend. The overnight unattended incident showed a daemon launched through Claude's native tracked background Bash deferred every escalation for roughly eight hours with supervisor pane busy agent mid-turn, delivered none, and still fired the max-defer wedge alarm with the buffer preserved. Establish the cause from the historical daemon log and the guard: target resolution was correct because an unset HERDR_SESSION correctly composes default plus HERDR_PANE_ID, Claude Stop auto-arm is excluded because it exits while state/.afk exists, and the delivery guard queries Herdr native agent state before any harness-scoped rendered-footer fallback. The observed 3 shells still running idle screen is not a Claude delivery busy signature; Claude's native background job holds the target's native busy state for its lifetime. Do not weaken or bypass busy or composer guards, and retain loud max-defer alarms. Update only the operational documentation, AFK skill instructions, and their adjacent source headers to state that a Claude/Herdr primary must use bin/fm-afk-launch.sh start, which creates a non-visible terminal and passes the captured supervisor target explicitly; native same-pane hosting cannot deliver. Do not change runtime behavior or run any Herdr lifecycle or lab commands. Preserve the existing behavioral guarantees: genuinely busy panes still defer, idle and empty injection remains guarded, and wedges still alarm when delivery cannot happen.

## What Changed

- Require Claude/Herdr primaries to launch away-mode supervision with `bin/fm-afk-launch.sh start`, including migration guidance for existing native-hosted daemons.
- Document how Claude’s native background Bash can keep the supervised Herdr pane busy and prevent same-pane digest delivery despite correct target resolution.
- Clarify that busy/composer deferrals remain guarded and max-defer wedge alarms preserve buffered escalations.

## Risk Assessment

✅ Low: The documentation-only change accurately captures the observed wedge, preserves the guards and alarm, and documents a source-supported migration path.

## Testing

No baseline commands were supplied. All focused suites exited 0, both public-interface scenarios behaved as documented, and reviewer-visible rendered documentation was captured. No real Herdr lifecycle, Herdr lab, notification, lint, formatter, static-analysis, or broad-suite command ran. Because this changes documentation and skill instructions rather than UI/HTML, rendered Markdown—not a screenshot—was the appropriate visual artifact.

<details>
<summary>Evidence: Rendered AFK operator guidance</summary>

Source: [Rendered AFK operator guidance](https://github.com/stanzhang/firstmate/blob/171f9441986f16dbfc36502753ba40a83ec64d3c/.no-mistakes/evidence/fm/fm-afk-inject-wedge/rendered-afk-operator-guidance.txt)

`Rendered Markdown showing the complete incident diagnosis, inferred causal mechanism, migration sequence, and unchanged guard guarantees.`

```text
# Rendered operator guidance: AFK wedge diagnosis and Claude/Herdr route

## docs/wedge-alarm.md


  # Away-mode injection wedge alarm                                                                           
                                                                                                              
  The away-mode sub-supervisor (bin/fm-supervise-daemon.sh) buffers escalations and injects them into         
  Firstmate's own pane.                                                                                       
  When injection cannot confirm a submit past FM_MAX_DEFER_SECS, inject_wedge_alarm raises a loud, rate-      
  limited alarm so the stall never stays invisible.                                                           
  The active alert is pane-independent because a tmux status-line flash has no cross-backend equivalent and   
  cannot reach an unattended captain reliably.                                                                
  The durable marker and tmux flash remain as additional signals.                                             
                                                                                                              
  ## When a delivery stays buffered                                                                           
                                                                                                              
  Away-mode delivery requires an idle primary and an affirmatively empty composer.                            
  pane_is_busy refuses a primary mid-turn, and fm_backend_composer_state refuses any composer verdict other   
  than empty, so a digest cannot merge into active or uncertain input.                                        
  If the primary remains continuously busy, buffered delivery starves by design rather than interrupting that 
  turn.                                                                                                       
  The overnight Claude/Herdr native-path incident recorded 2,063 consecutive inject deferred: supervisor pane 
  busy (agent mid-turn) deferrals, one composer deferral, zero deliveries, and roughly eight hours of         
  starvation while the primary was genuinely idle.                                                            
  Target resolution was correct: with HERDR_SESSION unset, supervisor discovery composed                      
  default:<HERDR_PANE_ID> as designed.                                                                        
  Claude Stop auto-arm was not the source because it exits while state/.afk exists.                           
  The busy guard queries Herdr native agent state before its harness-scoped rendered-footer fallback, and the 
  observed 3 shells still running idle screen is not a Claude delivery busy signature.                        
  Together, those observations support the inference that the native background job itself holds the target's 
  native agent state working for its lifetime.                                                                
  Under that inferred mechanism, same-target native hosting cannot deliver by construction.                   
  That is a hosting limitation, not a reason to weaken the guard: on a fresh launch, use bin/fm-afk-launch.sh 
  start so the daemon runs in its own non-visible workspace with an explicit target.                          
  If the native-hosted daemon is already live, start only refreshes the away flag and cannot move it; after   
  bin/fm-afk-launch.sh stop succeeds, run bin/fm-afk-launch.sh start, not start-native.                       
  FM_MAX_DEFER_SECS bounds how long that deferral can remain silent: once the threshold is reached, it raises 
  this alarm and preserves the buffered escalation.                                                           
  Treat the alarm as a visible delivery failure, not as permission to override either guard.                  
                                                                                                              
  ## Channels                                                                                                 
                                                                                                              
  config/wedge-alarm is local and gitignored.                                                                 
  It lists channel directives, one per non-empty, non-comment line, and every listed non-off channel fires    
  best-effort.                                                                                                
  FM_WEDGE_ALARM_CHANNEL overrides the file with one directive for focused testing.                           
                                                                                                              
  • off disables every active alert while retaining the durable marker and tmux flash.                        
  • auto or default resolves to osascript on macOS.                                                           
  Other platforms have no built-in OS channel, so configure command: when a durable marker alone is           
  insufficient.                                                                                               


## docs/herdr-backend.md — Away-mode supervisor support


  ## Away-mode supervisor support                                                                             
                                                                                                              
  The away daemon supports tmux and Herdr supervisor panes only.                                              
  It refuses Zellij, Orca, and cmux as supervisor backends rather than applying the wrong transport.          
  For Herdr, target existence, native state, capture, composer state, and verified submit all route through   
  the shared backend dispatcher and the explicit named-session CLI owner.                                     
  The pane-independent max-defer alert is configured in wedge-alarm.md /wedge-alarm.md.                       
                                                                                                              
  The incident evidence supports the inference that Claude's native tracked background Bash leaves the        
  supervised Claude pane's native agent state working for the daemon's lifetime.                              
  The busy guard must defer in that shape, so native same-pane hosting cannot deliver an away digest for a    
  Claude/Herdr primary.                                                                                       
  On a fresh launch, run bin/fm-afk-launch.sh start from that primary instead.                                
  It captures the captain pane first, creates a dedicated unfocused Herdr workspace, runs the daemon there    
  with an explicit supervisor target and backend, records the exact daemon pane, and closes only that pane on 
  stop.                                                                                                       
  If a native-hosted daemon is already live, start only refreshes state/.afk and reports that no new terminal 
  was created.                                                                                                
  After bin/fm-afk-launch.sh stop succeeds, migrate it with bin/fm-afk-launch.sh start, never by launching    
  start-native again.                                                                                         
  Pi uses the same terminal-backed route because it has no native tracked background mechanism.               
  Other native background mechanisms remain eligible only when they do not retain their supervisor target in a
  busy state.                                                                                                 
  It never splits the captain's active tab and never uses shell &.                                            
  Recovery reconciles only the recorded exact id.                                                             
                                   

... [2441 bytes truncated] ...

me-target construction.
      The incident evidence supports the inference that the native job keeps the supervised Claude pane's     
      Herdr agent state working for the daemon's lifetime, so the busy guard correctly defers every injection.
      • **Other harnesses WITH a native in-pane tracked-background tool** (for                                
      example, Grok's background tool): first run                                                             
      bin/fm-afk-launch.sh start-native, then run                                                             
      FM_AFK_STATE_PREPARED=1 bin/fm-afk-start.sh through that native tool.                                   
      This is a deliberate no-separate-terminal exception because the harness-hosted job creates no terminal  
      or layout mutation, and a shell launcher cannot invoke a harness-native background tool.                
      The launcher still owns lifecycle state and records the no-terminal mode, while the daemon inherits and 
      auto-discovers the captain pane.                                                                        
      If the native launch fails, run bin/fm-afk-launch.sh stop to roll back the prepared lifecycle.          
      Do not wrap it in nohup ... & (Codex/herdr can reap fire-and-forget shell children after a tool call    
      returns).                                                                                               
      • **Harness WITHOUT one** (e.g. pi): run bin/fm-afk-launch.sh start. It is                              
      the single owner of the daemon terminal: it creates a NON-VISIBLE tracked                               
      terminal for the current backend (a herdr dedicated --no-focus workspace,                               
      a detached tmux session), records its exact id, and passes the captain pane                             
      in as FM_SUPERVISOR_TARGET so the daemon injects into the captain, not its                              
      own new pane. **Never manufacture a terminal by splitting the**** captain's                             
      ****active pane** (herdr pane split): a split co-tenants the tab and visibly                            
      shrinks the captain's pane (docs/herdr-backend.md "Away-mode supervisor                                 
      support").                                                                                              
      Both paths share bin/fm-afk-start.sh as the daemon entry.                                               
      The native path tells it that the launcher already prepared lifecycle state; the terminal-backed path   
      lets the entry perform its existing state setup inside the new terminal.                                
      It exits immediately if the identity-backed daemon lock already names a live process, otherwise it execs
      bin/fm-supervise-daemon.sh in the foreground.                                                           
      The daemon is **presence-gated**: it injects escalations only while                                     
      state/.afk exists, and stays quiet otherwise.                                                           
  3. **Do not separately arm **fm-watch.sh**.** The daemon manages the watcher as                             
  its child; the singleton lock no-ops a stray arm harmlessly.                                                
  4. **Acknowledge** in AGENTS.md section 9 language: "Captain, away mode is active; I will batch routine     
  updates and surface only decisions, failures, credentials, or review-ready work until you return."          


## .agents/skills/afk/SKILL.md — guard guarantees


  ## Busy-guard and composer guard                                                                            
                                                                                                              
  The daemon never injects into an in-use pane. Two checks run before every                                   
  injection, dispatched through bin/fm-backend.sh for the supervisor's own                                    
  backend (tmux or herdr; see "Auto-discovered supervisor pane" below):                                       
                                                                                                              
  • **Primary-pane busy guard** - pane_is_busy trusts Herdr native busy when available, otherwise matches     
  rendered output against only the detected primary harness's signature.                                      
  This narrow delivery guard never classifies a recorded worker task and never uses a global union of vendor  
  patterns.                                                                                                   
  • **Composer-state guard** - inject_msg reads the full empty/pending/pending-unproven/unknown verdict from  
  fm_backend_composer_state and injects only when it is affirmatively empty.                                  
  Every other or future verdict defers, including an unreadable pane, ambiguous geometry, a blank unidentified
  row, and a bare shell prompt left after the agent exits.                                                    
  Each adapter contributes only capture and capability facts to the fleet-wide screen classifier in bin/fm-   
  composer-lib.sh, which owns every shape and verdict.                                                        
  It preserves proven idle composers as empty but requires a genuine container around shell glyphs; see       
  docs/herdr-backend.md "Composer and injection safety" for the operator contract.                            
  pane_input_pending is the tested fail-closed predicate for callers that need to know whether the composer is
  unsafe: it treats every result except exact empty as pending.                                               
                                                                                                              
  A busy primary pane, or any composer verdict other than empty, defers the injection; the buffered escalation
  survives in state/.subsuper-escalations and is retried on the next housekeeping tick.                       
  In afk mode the composer guard is belt-and-suspenders (no human is typing), but it protects against the race
  window between the captain returning and their message landing, a dead shell, and the daemon's own previous 
  injection sitting unsent.                                                                                   
                                                                                                              
  **Max-defer escape (the daemon must never silently wedge).**                                                
  If anything stays buffered past FM_MAX_DEFER_SECS (default 300), the daemon                                 
  attempts one normal flush, which still requires an idle pane and an affirmatively empty composer.           
  The alarm is defense in depth rather than a substitute for keeping every genuinely idle supported composer  
  injectable.                                                                                                 
  If that submit cannot be confirmed, it raises a loud, rate-limited wedge alarm:                             
  an ERROR in the daemon log, a durable                                                                       
  state/.subsuper-inject-wedged marker (surface it on the "while you were out"                                
  catch-up if present), a tmux status-line flash when applicable, and a configurable backend-independent      
  active alert.                                                                                               
  docs/wedge-alarm.md owns the alert channel setup, and docs/verification/supervision.md "Wedge-alarm         
  channels" owns active evidence.                                                                             
  So a guard false-positive becomes a visible stall, never an unbounded silent no-op.                         
```
</details>
<details>
<summary>Evidence: Live-daemon migration behavior</summary>

Source: [Live-daemon migration behavior](https://github.com/stanzhang/firstmate/blob/171f9441986f16dbfc36502753ba40a83ec64d3c/.no-mistakes/evidence/fm/fm-afk-inject-wedge/claude-herdr-live-daemon-refresh.txt)

<code>Public `start` refreshed a live daemon without creating a terminal and preserved its escalation; isolated `stop` cleared the lifecycle.</code>

```text
SCENARIO: Claude/Herdr operator runs start while a native-hosted daemon lock is already live
fm-afk-launch: daemon already running; refreshed away-mode flag (no new terminal)
away_flag=present
terminal_record=absent
buffer=pending escalation retained
daemon_alive=yes

MIGRATION STEP: stop the isolated native-hosted daemon
fm-afk-launch: away mode stopped; daemon terminal torn down and .afk cleared
away_flag_after_stop=absent
daemon_lock_after_stop=absent
```
</details>
<details>
<summary>Evidence: Fresh terminal-backed Herdr launch</summary>

Source: [Fresh terminal-backed Herdr launch](https://github.com/stanzhang/firstmate/blob/171f9441986f16dbfc36502753ba40a83ec64d3c/.no-mistakes/evidence/fm/fm-afk-inject-wedge/claude-herdr-fresh-start-fake-backend.txt)

<code>Fresh public `start` created a non-visible fake-backed Herdr workspace and explicitly passed the captured supervisor target/backend. No real Herdr lifecycle command ran.</code>

```text
SCENARIO: fresh Claude/Herdr terminal-backed start through the public launcher, using a fake Herdr transport (no real Herdr lifecycle command)
fm-afk-launch: daemon launched in non-visible herdr workspace ws-daemon (pane default:pane-daemon), supervising default:captain-pane
terminal_record=herdr default:pane-daemon ws-daemon
fake_transport_calls:
  status --json --session default
  workspace create --cwd /var/folders/pw/vjmgm22d2f18y4drp3lstzfm0000gn/T//fm-afk-herdr-fake.MlFr0O --label firstmate-afk-daemon-87215-3256-1788098757 --no-focus --session default
  pane run pane-daemon exec env FM_HOME=/var/folders/pw/vjmgm22d2f18y4drp3lstzfm0000gn/T//fm-afk-herdr-fake.MlFr0O FM_SUPERVISOR_TARGET=default:captain-pane FM_SUPERVISOR_BACKEND=herdr /bin/true --session default
  pane get pane-daemon --session default

CLEANUP: stop the isolated fake-backed launcher state
fm-afk-launch: away mode stopped; daemon terminal torn down and .afk cleared
away_flag_after_stop=absent
terminal_record_after_stop=absent
```
</details>
<details>
<summary>Evidence: Away-daemon focused tests</summary>

Source: [Away-daemon focused tests](https://github.com/stanzhang/firstmate/blob/171f9441986f16dbfc36502753ba40a83ec64d3c/.no-mistakes/evidence/fm/fm-afk-inject-wedge/fm-daemon-focused.log)

`Behavior transcript covering Herdr target fallback, busy/composer deferral, preserved buffers, and pane-independent max-defer alarms.`

```text
ok - fm-afk-start.sh fails before daemon startup when the afk flag cannot be written
ok - fm-afk-start.sh ignores stale pidfile-only live pids
ok - fm-afk-start.sh reclaims stale daemon locks whose live pid identity no longer matches
ok - supervise daemon state root is scoped by FM_HOME
ok - routine signal self-handles
ok - captain-relevant status verbs escalate
ok - check + unknown escalate; heartbeat self-handles
ok - transient stale self-handles and records a persistence marker
ok - enriched stale wedges bypass status absorption except under a declared wait, without disturbing busy workers
ok - an enriched wedge under a declared wait uses the pause cadence and restores wedge detection on resume
ok - stale + terminal status escalates immediately
ok - stale escalation and current wait cadence remain independent
ok - paused reasons with captain phrases remain pause-classified
ok - a captain-held transfer classifies as pause, not as a wedge candidate
ok - handle_wake on a paused stale records a pause marker, drops the wedge marker, and does not escalate
ok - handle_wake records a declared pause from a routine signal for long-cadence rechecks
ok - a terminal signal clears pause and stale tracking across both supervisors
ok - housekeeping migrates a normal-watcher's declared pause into daemon tracking
ok - housekeeping clears an already-resumed watcher pause across both supervisors
ok - housekeeping seeds pause tracking from status without a watcher marker
ok - persistent stale escalates after threshold and clears its marker
ok - resumed (busy) stale clears its marker without escalating
ok - housekeeping re-surfaces a stale declared pause on the long cadence and resets its window
ok - housekeeping re-surfaces a forgotten captain hold on the long cadence and resets its window
ok - a busy pane cannot gate the pause clear once its crew's status no longer declares the wait
ok - housekeeping matures a busy pane's declared-wait window into exactly one recheck per window
ok - housekeeping clears a paused marker once the crew is no longer declaring the pause
ok - housekeeping clears the pause marker once a captain hold is answered
ok - housekeeping moves an existing stale marker to pause before wedge escalation
ok - housekeeping moves a captain hold's existing stale marker to pause before wedge escalation
ok - housekeeping clears tracking when a crew leaves pause
ok - persistent herdr stale resolves the target from metadata and escalates
ok - herdr idle busy-footer stale clears through capture corroboration
ok - resumed herdr stale clears through backend-aware busy state
ok - persistent Orca stale resolves the terminal from metadata
ok - multiple escalations flush as a single batched digest
ok - batch flush measures max-delay from the first append, not the last
ok - catch-all scan escalates a missed terminal once, not twice
ok - handle_wake routes routine->self and captain->escalate
ok - INJECT_SKIP forces self-handle, bypassing captain-relevant classification
ok - is_wake_reason distinguishes watcher wake reasons from singleton-status stdout
ok - terminal-stale escalate removes its marker so housekeeping does not re-escalate
ok - captain signal escalate marks seen so the catch-all scan does not re-fire
ok - _collapse_newlines replaces newlines with literal separator
ok - afk flag absent: daemon does not inject, buffer preserved
ok - busy-guard defers injection when supervisor pane is busy
ok - marker detection: marker -> stay afk, no marker -> exit afk
ok - /afk invocation is exempt from afk exit (no self-cancel)
ok - should_exit_afk returns false when afk is not active
ok - strip_injection_marker removes the sentinel marker cleanly
ok - pane_input_pending detects partial input on the cursor line
ok - pane_input_pending: a blank unidentified cursor row defers (strict container-proof rule)
ok - pane_input_pending: only proven empty agent prompts pass
ok - fm_tmux_composer_state: a bare shell prompt ($/%/#/>) reads unknown, never empty (dead-shell injection safety)
ok - fm_tmux_composer_state: a bordered composer box and bare agent glyphs (❯/›) still read empty
ok - fm_tmux_composer_state: only matching edge borders form a composer box
ok - pane_input_pending preserves bright placeholder-like drafts in styled captures
ok - classify_signal dedupes against the catch-all scan seen marker
ok - turn-end markers stay routine while mixed actionable status batches escalate
ok - an actionable event is escalated to an away captain despite later routine appends
ok - the daemon commits exactly the endpoint captured by classification
ok - a stale wake escalates a blocker hidden by later progress
ok - a stale span read failure surfaces without advancing its marker
ok - a recreated status rejects the old captured identity
ok - an unverifiable status identity surfaces without advancing markers
ok - a status read failure surfaces without advancing the daemon suppressor
ok - catch-all routine scans advance before later actionable appends
ok - failed escalation writes retain durable wakes and classification positions
ok - catch-all markers advance only after escalation buffering succeeds
ok - classification failure retains the complete durable wake batch
ok - missing-status stale wakes remain ordinary and acknowledgeable
ok - transient unreadable signals recover without advancing their position
ok - daemon catch-all reclassifies permission-recovered status content
ok - a permanent classification failure is reported, acknowledged, and never advances its position
ok - the away-mode catch-all scan surfaces a masked event once
ok - classify_stale dedupes against the signal path seen marker
ok - AFK nonterminal working:+merged keeps wedge aging and re-escalates at bound
ok - genuine done: and merge-check events still escalate
ok - pane_input_pending: an idle bordered composer is NOT pending (afk-invx-i5)
ok - pane_input_pending: text inside a bordered composer is still pending
ok - submit-ACK confirms a submit when the composer returns to a bordered-empty box
ok - submit-ACK reports pending on a persistently swallowed Enter (type-once)
ok - max-defer on an empty stuck pane types once, alarms, and preserves the buffer
ok - max-defer flushes and clears the buffer on an empty bordered pane
ok - max-defer on a pending composer alarms without typing
ok - normal flush clears a stale wedge marker
ok - below MAX_DEFER: no inject, no alarm, buffer preserved
ok - max-defer does not flush or alarm while afk is inactive
ok - library mode: sourcing the daemon defaults FM_WEDGE_ALARM_EXEC to discard (no test can fire a real notification)
ok - wake helpers replace inherited notifier overrides with the safe recorder
ok - the discard seam suppresses every notifier, including command: (fires nothing)
ok - direct notifier helpers honor the discard seam, including command:
ok - osascript channel routes through the notifier seam with the summary (never a real notification)
ok - herdr channel routes through the notifier seam with the summary (never a real notification)
ok - command channel runs the captain command with the summary on $1 and on stdin
ok - command channel failures redact configured commands while logging their exit status
ok - unknown channel directives are redacted while the alarm keeps running
ok - off disables every active alert regardless of directive position (marker and tmux flash are unaffected)
ok - auto resolves to the macOS osascript notifier on Darwin (default-on)
ok - auto on a non-macOS platform selects no built-in OS channel (the marker or a configured command carries it)
ok - config/wedge-alarm selects every configured channel and skips comment and blank lines
ok - a failing channel logs and falls back to the next channel, never crashing the alarm
ok - a hung notifier is bounded, logged, and falls through to the next channel
ok - a backgrounded command notifier remains bounded until its process group is reaped
ok - a hung notifier override is bounded, logged, and proceeds to the next channel
/Users/sz/.no-mistakes/worktrees/849194184da1/01M19EDNF72FV9ZTMRA2AJ7YX1/bin/fm-supervise-daemon.sh: line 803:  5220 Terminated: 15          sh -c 'sleep 30 & printf "%s" "$!" > "$1"; wait' sh "$child_file"
ok - daemon shutdown stops and reaps the active notifier process group
ok - inject_wedge_alarm writes the marker AND emits the active alert even with no tmux status-line (herdr backend)
ok - in-process wedge throttle prevents alert spam when the marker cannot persist
ok - fm-send returns 3 with a non-error no-resend warning when confirmation stays pending
ok - fm-send exits non-zero when initial text send fails
ok - fm-send exits non-zero unless delivery is proven empty
ok - discover_supervisor_backend: override > TMUX_PANE > HERDR_ENV+HERDR_PANE_ID > tmux fallback
ok - discover_supervisor_target: override > TMUX_PANE > herdr '<session>:<pane-id>' composition > firstmate:0 fallback
ok - pane_is_busy: herdr native busy_state='busy' short-circuits without a capture fallback
ok - primary busy guard isolates rendered signatures by detected harness
ok - pane_is_busy: omitted backend defaults to tmux for Grok's isolated fallback
ok - pane_input_pending: dispatches through fm_backend_composer_state for backend=herdr
ok - inject_msg: herdr busy-guard defers before ever attempting a submit
ok - inject_msg: herdr composer-guard defers before ever attempting a submit
ok - inject_msg: herdr pane-gone check defers before any busy/composer/submit call
ok - inject_msg: dispatches busy-guard/composer-guard/submit through the herdr backend and succeeds on a confirmed empty composer
ok - inject_msg: defers on a dead-shell/unreadable composer (unknown), never typing the escalation into a shell
ok - inject_msg: unrecognized composer states defer by default
```
</details>
<details>
<summary>Evidence: AFK launcher isolated tests</summary>

Source: [AFK launcher isolated tests](https://github.com/stanzhang/firstmate/blob/171f9441986f16dbfc36502753ba40a83ec64d3c/.no-mistakes/evidence/fm/fm-afk-inject-wedge/fm-afk-launch-isolated.log)

`Isolated launcher checks; real Herdr/tmux topology cases were intentionally skipped.`

```text
ok - clear-stale: removes escalations buffer, sidecar, and wedge marker
ok - clear-stale: leaves the durable wake-queue intact (no pending work dropped)
ok - launcher paths: relative home and state ignore CDPATH before daemon command construction
ok - launcher paths: absolute symlink spellings are preserved
ok - launcher paths: unresolved relative FM_HOME fails loudly
ok - launcher paths: unresolved relative FM_STATE_OVERRIDE fails loudly
ok - refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)
ok - stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)
ok - stop-ordering: .afk cleared last
ok - stop-ordering: daemon-terminal record removed
ok - stop identity: stale lock cannot signal an unrelated live process
ok - failed start: away flag and delivery artifacts roll back
skip: tmux not found (concurrent start)
ok - launcher lock: incomplete publication receives initialization grace
ok - launcher signal: TERM exits and releases the lifecycle lock
fm-afk-launch: daemon launched in non-visible herdr workspace ws-partial (pane lab:pane-exact), supervising lab:captain
ok - herdr create: malformed response recovers durable exact ownership
fm-afk-launch: herdr create failed after returning exact ids; closing lab:pane-exact
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr create error: unconfirmed exact id is persisted for reconciliation
fm-afk-launch: failed to run daemon in herdr pane lab:pane-exact; closing it
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr run failure: unconfirmed exact id remains reconcilable
fm-afk-launch: failed to persist daemon terminal record; closing tmux:exact-session
ok - record failure: newly created terminal is closed by exact id
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
ok - readiness failure: exact terminal and durable record roll back
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - readiness failure: unconfirmed terminal retains its reconciliation id
ok - tmux absence: clean missing differs from transport probe failure
ok - native lifecycle: launcher owns state with no terminal
ok - native lifecycle: uniform stop clears state without closing a terminal
ok - native entry: launcher-prepared lifecycle state is not rewritten
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - teardown failure: exact terminal record is preserved
ok - record publication: failed atomic rename preserves the complete prior record
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - record read: malformed record fails closed without acting on a partial id
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: malformed daemon terminal record; refusing to stop away mode
ok - stop: malformed terminal record preserves away state and fails closed
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-392266019-75807-3441-1788098624'
ok - tmux launch: planned exact target is recorded before creation and removed on failure
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-2673689219-75953-4233-1788098624'
ok - tmux launch: unique names eliminate collision teardown
ok - stop validation: malformed record causes no daemon or state side effects
ok - launcher lock: incomplete metadata fails acquisition and releases lock
fm-afk-launch: failed to clear away-mode flag
fm-afk-launch: away mode stopped; terminal teardown remains recorded for retry
ok - stop state: away-flag removal failure is surfaced
fm-afk-launch: away-mode daemon did not exit after SIGTERM; preserving lifecycle state
ok - stop liveness: captured live daemon preserves lifecycle state after lock release
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - refresh record: malformed terminal identity fails closed
fm-afk-launch: failed to clear stale away-mode artifacts
ok - clear failure: native entry aborts and restores prior state
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: terminal close command failed, but exact absence was confirmed
ok - confirmed absence: cleanup succeeds and removes the stale record
fm-afk-launch: rollback restoration incomplete; backup retained at /var/folders/pw/vjmgm22d2f18y4drp3lstzfm0000gn/T//fm-afk-restore-fail.sd7STo/state/.afk-launch-backup.Dm7g7L
ok - rollback restore: incomplete restoration retains its recovery backup
ok - flag failure: lifecycle aborts without active state
skip: herdr not found (herdr e2e)
skip: tmux not found (tmux e2e)
```
</details>
<details>
<summary>Evidence: Claude Stop auto-arm tests</summary>

Source: [Claude Stop auto-arm tests](https://github.com/stanzhang/firstmate/blob/171f9441986f16dbfc36502753ba40a83ec64d3c/.no-mistakes/evidence/fm/fm-afk-inject-wedge/fm-claude-stop-autoarm-focused.log)

```text
Confirms Claude Stop auto-arm remains inert while AFK owns supervision.
```
</details>
<details>
<summary>Evidence: Runtime and scope comparison</summary>

Source: [Runtime and scope comparison](https://github.com/stanzhang/firstmate/blob/171f9441986f16dbfc36502753ba40a83ec64d3c/.no-mistakes/evidence/fm/fm-afk-inject-wedge/runtime-scope-comparison.txt)

```text
Both changed shell scripts have byte-identical executable bodies versus the base; only the authorized five files changed.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"07bce53688881cf53b392331ab16525cdbbce8cb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `docs/wedge-alarm.md:13` - Intent requires the documentation to “establish the cause from the historical daemon log and the guard,” specifically confirming `HERDR_SESSION` fallback target resolution, excluding Claude Stop auto-arm via `state/.afk`, recording native-agent-state-before-rendered-footer ordering, and explaining why the “3 shells still running” screen is not a busy signature. This new incident section documents only the native background job’s busy state and the alarm outcome. Add the omitted causal evidence so the durable operational diagnosis is complete.

🔧 Fix: Document complete Claude/Herdr wedge diagnosis
1 error still open:

- 🚨 `.agents/skills/afk/SKILL.md:29` - The new instruction implies `bin/fm-afk-launch.sh start` always moves Claude/Herdr supervision into a separate workspace, but an already-running native-hosted daemon remains reachable: `start` detects its live daemon lock, refreshes `.afk`, returns success with “no new terminal,” and leaves the same-pane busy wedge intact (`bin/fm-afk-launch.sh:474`). Document the supported migration sequence for an existing native daemon and clarify that `start` only creates the workspace on a fresh launch.

🔧 Fix: Document safe Claude/Herdr daemon migration
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-daemon.test.sh` — exit 0; exercised target fallback, native-state-first busy handling, harness-scoped fallback, busy/composer deferral, buffer preservation, and loud max-defer alarms.</code>
- <code>`PATH=/usr/bin:/bin:/usr/sbin:/sbin bash tests/fm-afk-launch.test.sh` — exit 0; exercised isolated launcher lifecycle and preservation behavior while skipping live Herdr/tmux E2E.</code>
- <code>`bash tests/fm-claude-stop-autoarm.test.sh` — exit 0; confirmed auto-arm is inert while `state/.afk` owns supervision.</code>
- <code>Manual public-interface check: live daemon → `bin/fm-afk-launch.sh start` → no new terminal and preserved escalation → isolated `stop`.</code>
- <code>Manual public-interface check: fresh `start` against a fake Herdr transport → non-visible workspace with explicit target/backend → isolated `stop`.</code>
- <code>Rendered the changed operator guidance with `glow`.</code>
- <code>Compared launcher executable bodies with base `debe4bfafa2ad52bd96f088a8d8ba418931e828f`; both were byte-identical. Confirmed the worktree remained clean.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
