### PR TITLE
fix: suppress stale watcher rearm follow-ups

### DIFF
--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -301,6 +301,7 @@ export default function (pi: ExtensionAPI) {
       event.source !== "extension" ||
       event.streamingBehavior !== "followUp" ||
       Boolean(event.images?.length) ||
+      typeof event.text !== "string" ||
       !event.text.includes(rearmResurfaceBody)
     ) {
       return { action: "continue" };

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -144,22 +144,28 @@ function positiveInteger(name: string, fallback: number): number {
 }
 
 function recoveryFollowUpIsSettled(): boolean {
-  const result = spawnSync("bash", ["-lc", settledRecoveryProbe], {
-    cwd: fmRoot,
-    encoding: "utf8",
-    timeout: 1500,
-    killSignal: "SIGTERM",
-    env: {
-      ...process.env,
-      FM_HOME: fmHome,
-      FM_ROOT_OVERRIDE: fmRoot,
-      FM_STATE_OVERRIDE: state,
-      FM_PI_WAKE_LIB: wakeLib,
-      FM_PI_WAKE_QUEUE: `${state}/.wake-queue`,
-      FM_PI_RECOVERY_MARKER: `${state}/.watcher-down`,
-    },
-  });
-  return !result.error && result.status === 0 && result.stdout === "settled\n";
+  try {
+    const result = spawnSync("bash", ["-lc", settledRecoveryProbe], {
+      cwd: fmRoot,
+      encoding: "utf8",
+      timeout: 1500,
+      killSignal: "SIGTERM",
+      env: {
+        ...process.env,
+        FM_HOME: fmHome,
+        FM_ROOT_OVERRIDE: fmRoot,
+        FM_STATE_OVERRIDE: state,
+        FM_PI_WAKE_LIB: wakeLib,
+        FM_PI_WAKE_QUEUE: `${state}/.wake-queue`,
+        FM_PI_RECOVERY_MARKER: `${state}/.watcher-down`,
+        FM_WAKE_QUEUE: `${state}/.wake-queue`,
+        FM_WAKE_QUEUE_LOCK: `${state}/.wake-queue.lock`,
+      },
+    });
+    return !result.error && result.status === 0 && result.stdout === "settled\n";
+  } catch {
+    return false;
+  }
 }
 
 function parentPid(pid: string): string {

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -88,6 +88,7 @@ const fmRoot = process.env.FM_ROOT_OVERRIDE || root;
 const state = process.env.FM_STATE_OVERRIDE || `${fmHome}/state`;
 const config = process.env.FM_CONFIG_OVERRIDE || `${fmHome}/config`;
 const armScript = `${fmRoot}/bin/fm-watch-arm.sh`;
+const wakeLib = `${fmRoot}/bin/fm-wake-lib.sh`;
 const marker = `${state}/.pi-watch-extension-loaded`;
 const extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
 const retryBaseMs = positiveInteger("FM_WATCH_REARM_RETRY_BASE_MS", 250);
@@ -103,6 +104,32 @@ const armReadyTimeoutMs = positiveInteger(
 const armRetireTimeoutMs = positiveInteger("FM_WATCH_ARM_RETIRE_TIMEOUT_MS", 1000);
 const repairOnlyHint = "call fm_watch_arm_pi again only after a later notification says the cycle is missing, failed, or unhealthy";
 const shuttingDownMessage = "watcher: not armed - Pi session is shutting down";
+const rearmResurfaceBody = "FIRSTMATE WATCHER WAKE: check: rearm-resurface\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.";
+const settledRecoveryProbe = String.raw`
+set -u
+. "$FM_PI_WAKE_LIB" || exit 1
+queue=$FM_PI_WAKE_QUEUE
+marker=$FM_PI_RECOVERY_MARKER
+queue_lock=$FM_WAKE_QUEUE_LOCK
+marker_lock="${marker}.lock"
+release_probe_locks() {
+  fm_lock_release "$marker_lock"
+  fm_lock_release "$queue_lock"
+}
+trap release_probe_locks EXIT
+trap 'exit 1' HUP INT TERM
+fm_lock_acquire_wait "$queue_lock" || exit 1
+fm_lock_acquire_wait "$marker_lock" || exit 1
+[ -e "$queue" ] && [ ! -L "$queue" ] && [ -f "$queue" ] && [ -r "$queue" ] || exit 1
+[ ! -s "$queue" ] || exit 1
+cat -- "$queue" >/dev/null || exit 1
+fm_recovery_marker_read "$marker" || exit 1
+case "$FM_RECOVERY_MARKER_TOKEN" in
+  acked:handling:*|acked:downtime:*) ;;
+  *) exit 1 ;;
+esac
+printf 'settled\n'
+`;
 
 let nextGenerationId = 0;
 let activeGeneration: SessionGeneration | null = null;
@@ -114,6 +141,25 @@ function positiveInteger(name: string, fallback: number): number {
   const value = Number(process.env[name]);
   if (!Number.isFinite(value) || value <= 0) return fallback;
   return Math.floor(value);
+}
+
+function recoveryFollowUpIsSettled(): boolean {
+  const result = spawnSync("bash", ["-lc", settledRecoveryProbe], {
+    cwd: fmRoot,
+    encoding: "utf8",
+    timeout: 1500,
+    killSignal: "SIGTERM",
+    env: {
+      ...process.env,
+      FM_HOME: fmHome,
+      FM_ROOT_OVERRIDE: fmRoot,
+      FM_STATE_OVERRIDE: state,
+      FM_PI_WAKE_LIB: wakeLib,
+      FM_PI_WAKE_QUEUE: `${state}/.wake-queue`,
+      FM_PI_RECOVERY_MARKER: `${state}/.watcher-down`,
+    },
+  });
+  return !result.error && result.status === 0 && result.stdout === "settled\n";
 }
 
 function parentPid(pid: string): string {
@@ -242,6 +288,31 @@ export default function (pi: ExtensionAPI) {
     calmPresentation.active &&
     !calmPresentation.stockExportRendering &&
     !calmTranscriptClassIsVisible(itemClass);
+
+  let canonicalRearmResurfaceInput: string | null = null;
+  pi.on("input", async (event, ctx) => {
+    if (
+      event.source !== "extension" ||
+      event.streamingBehavior !== "followUp" ||
+      Boolean(event.images?.length) ||
+      !event.text.includes(rearmResurfaceBody)
+    ) {
+      return { action: "continue" };
+    }
+    try {
+      canonicalRearmResurfaceInput ??= encodeFirstmateOperationalInput("watcher", rearmResurfaceBody);
+    } catch {
+      return { action: "continue" };
+    }
+    if (event.text !== canonicalRearmResurfaceInput) {
+      return { action: "continue" };
+    }
+    while (!ctx.isIdle()) {
+      await new Promise<void>((resolveWait) => setTimeout(resolveWait, 20));
+    }
+    if (!recoveryFollowUpIsSettled()) return { action: "continue" };
+    return { action: "handled" };
+  });
 
   async function sendWake(
     owner: SessionGeneration,

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -145,7 +145,7 @@ function positiveInteger(name: string, fallback: number): number {
 
 function recoveryFollowUpIsSettled(): boolean {
   try {
-    const result = spawnSync("bash", ["-lc", settledRecoveryProbe], {
+    const result = spawnSync("bash", ["-c", settledRecoveryProbe], {
       cwd: fmRoot,
       encoding: "utf8",
       timeout: 1500,

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -491,7 +491,7 @@ FM_RECOVERY_MARKER_ACTION='none'
 fm_recovery_marker_read() {
   local marker=$1 line count generation
   FM_RECOVERY_MARKER_TOKEN=
-  [ -f "$marker" ] && [ ! -L "$marker" ] || return 1
+  [ -f "$marker" ] && [ ! -L "$marker" ] && [ -r "$marker" ] || return 1
   count=$(wc -l < "$marker" 2>/dev/null | tr -d '[:space:]') || return 1
   [ "$count" = 1 ] || return 1
   IFS= read -r line < "$marker" || return 1

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -485,7 +485,7 @@ fm_lock_recheck_stale_owner() {
 FM_RECOVERY_MARKER_TOKEN=
 FM_RECOVERY_MARKER_ACTION='none'
 
-# Token grammar (one owner): <pending|announced|acked>:<handling|downtime>:<generation>
+# Token grammar (one owner): <pending|announced|acked>:<handling|downtime>:<generation>, where <generation> is one or more ASCII letters, digits, dots, underscores, or hyphens with no colon.
 # docs/watcher-continuity.md owns the recovery-episode contract, including the
 # once-per-generation announcement rule for unacknowledged downtime.
 fm_recovery_marker_read() {

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -489,7 +489,7 @@ FM_RECOVERY_MARKER_ACTION='none'
 # docs/watcher-continuity.md owns the recovery-episode contract, including the
 # once-per-generation announcement rule for unacknowledged downtime.
 fm_recovery_marker_read() {
-  local marker=$1 line count
+  local marker=$1 line count generation
   FM_RECOVERY_MARKER_TOKEN=
   [ -f "$marker" ] && [ ! -L "$marker" ] || return 1
   count=$(wc -l < "$marker" 2>/dev/null | tr -d '[:space:]') || return 1
@@ -499,8 +499,10 @@ fm_recovery_marker_read() {
     pending:handling:*|pending:downtime:*|announced:handling:*|announced:downtime:*|acked:handling:*|acked:downtime:*) ;;
     *) return 1 ;;
   esac
-  case "${line##*:}" in
-    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+  generation=${line#*:}
+  generation=${generation#*:}
+  case "$generation" in
+    ''|*:*|*[!A-Za-z0-9._-]*) return 1 ;;
   esac
   FM_RECOVERY_MARKER_TOKEN=$line
 }

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -459,6 +459,18 @@ grok 0.2.103 (89c3d36fb6f1) [stable]
 
 Pi 0.81.1 repeated the continuity and clean-exit lifecycle on 2026-07-23 after the Calm presentation changes.
 
+### Current Pi live-check environment limitation
+
+On 2026-08-30, Pi 0.84.4 stopped in the unrelated Ahoy preflight before watcher coverage on both the change branch and an untouched `52b59a1` default-branch fixture.
+The change branch failed with `not ok - Pi Ahoy legacy-start case did not take Bearings: Unable to take the helm: no SESSION START digest is visible, and this environment has no shell-execution tool to run bin/fm-session-start.sh. /ahoy cannot proceed safely.`
+The untouched baseline failed with `not ok - Pi Ahoy ascii-only near miss was treated as operational: AHOY_BEARINGS_BRANCH`.
+Neither run loaded or exercised the changed watcher extension, so this opt-in command cannot currently refresh watcher evidence until its Ahoy preflight is deterministic.
+The deterministic watcher, arm, recovery, and lint checks remain usable and do not relax the requirement for a future successful live Pi refresh.
+
+```sh
+FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh
+```
+
 Pi same-process session-transition ownership was verified on 2026-07-27 against the tracked extension with a faithful in-process factory rebind (module cache retained, real arm children):
 
 ```sh

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -58,6 +58,9 @@ The acknowledgement retires the marker only when no rows remain after sequence-b
 A concurrently appended wake has a higher sequence, remains queued, and keeps the episode pending for presentation.
 Consequently, an empty-queue downtime publication during handling can be retired by the outstanding acknowledgement without a dedicated recovery turn.
 An acknowledged episode does not freeze the generation, because the next downtime after it opens an episode of its own.
+Pi holds only the canonical extension-sourced `check: rearm-resurface` follow-up at input preflight until the active turn settles.
+It suppresses that follow-up before provider dispatch only when a queue-then-marker locked probe finds an existing empty regular queue and one valid `acked:handling:<generation>` or `acked:downtime:<generation>` marker.
+Every other input and every uncertain probe result continues to the model, while a concurrent append either wins the same locks and makes the prompt relevant or follows the probe and publishes a new recovery episode and wake.
 
 ## Per-actor acknowledgement
 
@@ -98,7 +101,8 @@ Only the watcher process touches `state/.last-watcher-beat`; no helper process c
 
 ## Regression coverage
 
-`tests/fm-pi-watch-extension.test.sh` checks Pi's first-cycle-or-explicit-repair tool metadata and ownership-based redundant-call no-ops, then simulates actionable and empty child closes against the actual Pi and OpenCode close handlers, blocks prompt delivery to prove the successor launches first, verifies single-flight behavior, changes the session lock before close to prove ownership is rechecked, and hangs each successor arm to prove bounded fallback delivery includes the typed restoration failure.
+`tests/fm-pi-watch-extension.test.sh` checks Pi's exact stale `rearm-resurface` input filter, including fail-toward-delivery state and source boundaries plus a concurrent append, then checks first-cycle-or-explicit-repair tool metadata and ownership-based redundant-call no-ops.
+It also simulates actionable and empty child closes against the actual Pi and OpenCode close handlers, blocks prompt delivery to prove the successor launches first, verifies single-flight behavior, changes the session lock before close to prove ownership is rechecked, and hangs each successor arm to prove bounded fallback delivery includes the typed restoration failure.
 The same suite covers ordinary same-process session replacement for `/new`, `/resume`, and `/fork`, same-instance shutdown-plus-start, stale prior-generation callbacks, repeated transitions with exactly one live cycle, disappearance of the shutting-down refusal after a valid replacement activates, and terminal quit still refusing late rearm.
 `tests/fm-watch-arm.test.sh` covers durable queue replay, real remote parent-replies ingestion into the authoritative status log, decision-only OPEN DECISIONS recovery, interrupted handling replay, generation-bound acknowledgement, a persistent live successor after recovery, a watcher close inside the handling window that must leave the printed acknowledgement valid, and the self-healing moved-generation acknowledgement that consumes its handled rows and names its remedy.
 `tests/fm-watch-recovery-loop.test.sh` covers the once-per-generation announcement bound with the real Pi extension against a refused handling handshake, and a handling successor that must surface a real crew event instead of going blind.

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -37,7 +37,8 @@ install_pi_watch_extension_fixture() {
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$repo/.pi/extensions/lib/fm-operational-input.ts"
   mkdir -p "$repo/bin"
   cp "$ROOT/bin/fm-operational-input.sh" "$repo/bin/fm-operational-input.sh"
-  chmod +x "$repo/bin/fm-operational-input.sh"
+  cp "$ROOT/bin/fm-wake-lib.sh" "$repo/bin/fm-wake-lib.sh"
+  chmod +x "$repo/bin/fm-operational-input.sh" "$repo/bin/fm-wake-lib.sh"
   cat > "$repo/node_modules/@earendil-works/pi-coding-agent/package.json" <<'JSON'
 {"name":"@earendil-works/pi-coding-agent","type":"module","exports":"./index.js"}
 JSON
@@ -70,6 +71,233 @@ export const Type = {
   },
 };
 JS
+}
+
+test_pi_stale_rearm_follow_up_filter() {
+  local repo home plugin out status
+  repo="$TMP_ROOT/pi-stale-rearm-filter-root"
+  home="$TMP_ROOT/pi-stale-rearm-filter-home"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  : > "$repo/bin/fm-watch-arm.sh"
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
+import { spawn } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { pathToFileURL } from "node:url";
+import { encodeFirstmateOperationalInput } from "./.pi/extensions/lib/fm-operational-input.ts";
+
+const state = `${process.env.FM_HOME}/state`;
+const queue = `${state}/.wake-queue`;
+const marker = `${state}/.watcher-down`;
+const body = "FIRSTMATE WATCHER WAKE: check: rearm-resurface\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.";
+const canonical = encodeFirstmateOperationalInput("watcher", body);
+let inputHandler = null;
+let providerTurns = 0;
+let idle = true;
+const pi = {
+  on(event, handler) {
+    if (event === "input") inputHandler = handler;
+  },
+  events: { on() {} },
+  registerCommand() {},
+  registerTool() {},
+  sendUserMessage: async () => {},
+};
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+if (!inputHandler) throw new Error("Pi watcher input handler was not registered");
+
+function resetState(markerText = "acked:handling:generation-1\n", queueText = "") {
+  rmSync(marker, { force: true, recursive: true });
+  rmSync(queue, { force: true, recursive: true });
+  writeFileSync(marker, markerText);
+  writeFileSync(queue, queueText);
+}
+
+async function dispatch(overrides = {}) {
+  const result = await inputHandler({
+    type: "input",
+    text: canonical,
+    source: "extension",
+    streamingBehavior: "followUp",
+    ...overrides,
+  }, { isIdle: () => idle });
+  if (result?.action !== "handled") providerTurns += 1;
+  return result?.action ?? "continue";
+}
+
+async function expectHandled(label, overrides = {}) {
+  const before = providerTurns;
+  const action = await dispatch(overrides);
+  if (action !== "handled") throw new Error(`${label} reached provider dispatch`);
+  if (providerTurns !== before) throw new Error(`${label} incremented provider turns`);
+}
+
+async function expectDelivered(label, overrides = {}) {
+  const before = providerTurns;
+  const action = await dispatch(overrides);
+  if (action !== "continue") throw new Error(`${label} was swallowed`);
+  if (providerTurns !== before + 1) throw new Error(`${label} did not reach provider dispatch`);
+}
+
+resetState(
+  "announced:handling:generation-1\n",
+  "1\t1\tcheck\trecovery\tcheck: recovery work\n",
+);
+idle = false;
+const settleCurrentTurn = setTimeout(() => {
+  writeFileSync(marker, "acked:handling:generation-1\n");
+  writeFileSync(queue, "");
+  idle = true;
+}, 40);
+await expectHandled("queued recovery settled by the active turn");
+clearTimeout(settleCurrentTurn);
+resetState();
+await expectHandled("acked handling with empty queue");
+resetState("acked:downtime:generation-2\n");
+await expectHandled("acked downtime with empty queue");
+
+for (const token of [
+  "pending:downtime:generation-3",
+  "announced:downtime:generation-3",
+  "pending:handling:generation-3",
+  "announced:handling:generation-3",
+]) {
+  resetState(`${token}\n`);
+  await expectDelivered(token);
+}
+
+resetState();
+rmSync(marker);
+await expectDelivered("missing recovery marker");
+resetState();
+rmSync(queue);
+await expectDelivered("missing wake queue");
+resetState("not-a-recovery-marker\n");
+await expectDelivered("malformed recovery marker");
+resetState("acked:handling:generation-4\nextra\n");
+await expectDelivered("multi-line recovery marker");
+resetState("acked:handling:generation-4\n", "1\t1\tcheck\tconcurrent\tcheck: concurrent work\n");
+await expectDelivered("nonempty wake queue");
+
+resetState();
+writeFileSync(`${state}/marker-target`, "acked:handling:generation-5\n");
+rmSync(marker);
+symlinkSync(`${state}/marker-target`, marker);
+await expectDelivered("symlinked recovery marker");
+rmSync(`${state}/marker-target`);
+resetState();
+writeFileSync(`${state}/queue-target`, "");
+rmSync(queue);
+symlinkSync(`${state}/queue-target`, queue);
+await expectDelivered("symlinked wake queue");
+rmSync(`${state}/queue-target`);
+
+resetState();
+chmodSync(marker, 0o000);
+try {
+  await expectDelivered("unreadable recovery marker");
+} finally {
+  chmodSync(marker, 0o600);
+}
+resetState();
+chmodSync(queue, 0o000);
+try {
+  await expectDelivered("unreadable wake queue");
+} finally {
+  chmodSync(queue, 0o600);
+}
+
+resetState();
+await expectDelivered("interactive captain text", { source: "interactive" });
+await expectDelivered("rpc captain text", { source: "rpc" });
+await expectDelivered("steering extension input", { streamingBehavior: "steer" });
+await expectDelivered("idle extension input", { streamingBehavior: undefined });
+await expectDelivered("extension input with an image", {
+  images: [{ type: "image", source: { type: "base64", mediaType: "image/png", data: "AA==" } }],
+});
+await expectDelivered("captain text containing the reason", {
+  source: "interactive",
+  text: "please investigate check: rearm-resurface without swallowing this",
+});
+for (const reason of [
+  "signal: worker.status",
+  "stale: worker-window",
+  "check: startup-network",
+  "heartbeat",
+  "watcher: FAILED - recovery needs attention",
+]) {
+  await expectDelivered(`other watcher reason ${reason}`, {
+    text: encodeFirstmateOperationalInput(
+      "watcher",
+      body.replace("check: rearm-resurface", reason),
+    ),
+  });
+}
+await expectDelivered("near-miss watcher body", { text: `${canonical} ` });
+await expectDelivered("other operational kind", {
+  text: encodeFirstmateOperationalInput("session-start", body),
+});
+
+resetState("acked:handling:generation-race\n");
+const ready = `${state}/race-marker-ready`;
+const done = `${state}/race-append-done`;
+const holderScript = String.raw`
+set -eu
+. "$FM_ROOT_OVERRIDE/bin/fm-wake-lib.sh"
+marker="$FM_HOME/state/.watcher-down"
+marker_lock="${marker}.lock"
+fm_lock_acquire_wait "$marker_lock"
+trap 'fm_lock_release "$marker_lock"' EXIT
+: > "$FM_RACE_READY"
+while [ ! -L "$FM_WAKE_QUEUE_LOCK" ]; do sleep 0.01; done
+(
+  fm_wake_append check concurrent-race 'check: concurrent race work'
+  : > "$FM_RACE_DONE"
+) &
+appender=$!
+sleep 0.05
+fm_lock_release "$marker_lock"
+wait "$appender"
+`;
+const holder = spawn("bash", ["-lc", holderScript], {
+  stdio: ["ignore", "pipe", "pipe"],
+  env: {
+    ...process.env,
+    FM_HOME: process.env.FM_HOME,
+    FM_ROOT_OVERRIDE: process.env.FM_ROOT_OVERRIDE,
+    FM_STATE_OVERRIDE: state,
+    FM_RACE_READY: ready,
+    FM_RACE_DONE: done,
+  },
+});
+let holderError = "";
+holder.stderr.on("data", (chunk) => { holderError += chunk.toString(); });
+for (let i = 0; i < 200 && !existsSync(ready); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (!existsSync(ready)) throw new Error(`race marker lock was not acquired: ${holderError}`);
+await expectHandled("settled prompt racing a concurrent append");
+await new Promise((resolve, reject) => {
+  holder.on("error", reject);
+  holder.on("close", (code) => code === 0 ? resolve() : reject(new Error(`race holder exited ${code}: ${holderError}`)));
+});
+if (!existsSync(done)) throw new Error("concurrent append did not complete");
+await expectDelivered("re-dispatch after concurrent append");
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi stale recovery filter must suppress only settled canonical follow-ups and preserve a concurrent append"
+  [ -z "$out" ] || fail "Pi stale recovery filter test printed output: $out"
+  pass "Pi stale recovery follow-up filter fails toward delivery without losing a concurrent append"
 }
 
 test_pi_extension_reports_external_healthy_watcher() {
@@ -2804,6 +3032,7 @@ EOF
   pass "OpenCode healthy arm output does not suppress the turn-end guard"
 }
 
+test_pi_stale_rearm_follow_up_filter
 test_pi_extension_reports_external_healthy_watcher
 test_pi_tool_returns_agent_tool_result
 test_pi_redundant_tool_call_is_owned_noop

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -185,6 +185,8 @@ resetState("not-a-recovery-marker\n");
 await expectDelivered("malformed recovery marker");
 resetState("acked:handling:generation-4\nextra\n");
 await expectDelivered("multi-line recovery marker");
+resetState("acked:handling:generation-4:extra\n");
+await expectDelivered("extra-colon recovery marker");
 resetState("acked:handling:generation-4\n", "1\t1\tcheck\tconcurrent\tcheck: concurrent work\n");
 await expectDelivered("nonempty wake queue");
 

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -226,6 +226,7 @@ await expectDelivered("idle extension input", { streamingBehavior: undefined });
 await expectDelivered("extension input with an image", {
   images: [{ type: "image", source: { type: "base64", mediaType: "image/png", data: "AA==" } }],
 });
+await expectDelivered("extension input without text", { text: undefined });
 await expectDelivered("captain text containing the reason", {
   source: "interactive",
   text: "please investigate check: rearm-resurface without swallowing this",


### PR DESCRIPTION
## Intent

Prevent Pi from starting a model turn for a queued `check: rearm-resurface` follow-up when that recovery generation has already been acknowledged and the durable wake queue is empty. Keep the input filter in the existing Pi watcher extension and preserve the recovery guarantee: do not disable `rearm-resurface`, change watcher generations, weaken ordinary worker reminders, or swallow uncertainty. Match only the exact canonically typed extension-sourced watcher follow-up, wait for the active turn to settle before deciding, and suppress only with an existing regular readable empty queue plus one valid `acked:handling:<generation>` or `acked:downtime:<generation>` marker. Continue delivery for pending, announced, handling, missing, malformed, symlinked, or unreadable state; nonempty queues; captain text; images; interactive, RPC, steering, or idle input; every other operational kind and watcher reason; and every probe failure. Preserve lock ordering so a concurrent append either makes the current recovery relevant or publishes a new recovery episode without being lost. Cover the stale settled sequence, zero provider dispatch, every fail-toward-delivery boundary, exact source/body discrimination, and a concurrent append through executable behavior in `tests/fm-pi-watch-extension.test.sh`. Preserve deterministic recovery, arm, extension, documentation, and lint checks. The required live Pi command currently fails before watcher coverage in its unrelated model-driven Ahoy preflight on both this branch and the untouched default-branch baseline, with different exact Ahoy failures; record that as a current maintainer-verification environment limitation, do not modify Ahoy code, and do not claim refreshed live watcher evidence. Keep incident chronology private and update only authoritative current-behavior documentation. Run the full no-mistakes path to green checks and open the change for review; do not merge it.

## What Changed
- Added a Pi input filter for settled canonical `check: rearm-resurface` follow-ups with locked queue and recovery-marker validation.
- Tightened recovery-marker grammar and expanded executable coverage for delivery fallbacks, exact input matching, and concurrent appends.
- Updated watcher continuity and verification documentation, including the current Pi live-check limitation.

## Risk Assessment

⚠️ Medium: The change is bounded but adds safety-sensitive cross-process locking and pre-dispatch suppression logic; no concrete defect was found.

## Testing

Exercised the Pi filter end to end, recovery, arm, locking, checkpoint, and documentation paths; captured targeted extension evidence. Live Pi coverage was not refreshed due to the documented Ahoy preflight limitation.

<details>
<summary>Evidence: Pi watcher extension targeted test output</summary>

Source: [Pi watcher extension targeted test output](https://github.com/ollie88skwda/firstmate/blob/dcac4c8927801776c40971a0527aa82219f22dd8/.no-mistakes/evidence/fm/suppress-stale-rearm-reminder/pi-watch-extension-targeted.log)

```text
ok - Pi stale recovery follow-up filter fails toward delivery without losing a concurrent append
ok - Pi extension reports external healthy watcher output
ok - Pi custom tool exposes repair-only metadata and returns automatic-continuation guidance
ok - Pi redundant tool call returns ownership guidance and spawns no second child
ok - Pi scheduled retry remains extension-owned after another tool call
ok - Pi actionable close starts one successor before wake delivery settles
ok - Pi dispatcher branch offer owns accepted wakes and falls back to main
ok - Pi dispatcher flags a fleet-wide heartbeat offer as branch-eligible
ok - a co-present check row neither vetoes nor rides a heartbeat into main
ok - every main-only check class still reaches main, never the supervision branch
ok - heartbeat restoration failure stays on main
ok - watcher-failure repair stays with main even with a live, accepting branch listener
ok - Pi refused handling handshake is classified and not swallowed
ok - Pi hung successor falls back to one typed actionable wake
ok - Pi unretired successor falls back without an overlapping retry
ok - Pi late unretired closes resume classified supervision
ok - Pi clean empty close triggers a bounded continuity retry
ok - Pi established clean closes stop at the configured retry limit
ok - Pi close handler verifies session-lock ownership before successor launch
ok - Pi watcher arm distinguishes all session lock ownership states
ok - Pi session transitions use a generation owner across /new /resume /fork, stale callbacks, and quit
ok - Pi process-exit cleanup listener remains singular across session replacement
ok - Pi process-exit cleanup stops the attached arm child
ok - OpenCode plugins have an explicit ESM boundary even under a typeless parent package
ok - OpenCode watcher plugin uses the effective FM_HOME state
ok - OpenCode watcher plugin sources the effective config
ok - OpenCode watcher plugin requires session lock ownership
ok - OpenCode watcher coordinator respects primary scope
ok - OpenCode watcher plugin starts one successor before wake prompt delivery settles
ok - OpenCode pre-ready actionable close preserves its successor
ok - OpenCode hung successor falls back to one typed actionable wake
ok - OpenCode unretired successor falls back without an overlapping retry
ok - OpenCode late unretired closes resume classified supervision
ok - OpenCode clean empty close triggers a bounded continuity retry
ok - OpenCode established clean closes stop at the configured retry limit
ok - OpenCode close handler verifies session-lock ownership before successor launch
ok - OpenCode watcher plugin coordinates with the turn-end guard
ok - OpenCode healthy arm output does not suppress the turn-end guard
exit_status=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ad31d805e8ea8d63b0537542fef94b7296ce8c2f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.pi/extensions/fm-primary-pi-watch.ts:126` - The probe can swallow malformed recovery state: `fm_recovery_marker_read` accepts `acked:handling:generation:extra` because it validates only the final colon-delimited component, then lines 127-128 classify it as settled. This violates the requirement to continue delivery for malformed state; enforce the exact marker grammar at the shared parser boundary.

🔧 Fix: Enforce exact recovery markers with Pi regression coverage
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-pi-watch-extension.test.sh`
- `bash tests/fm-watch-recovery-loop.test.sh`
- `bash tests/fm-watch-arm.test.sh`
- `bash tests/fm-watcher-lock.test.sh`
- `bash tests/fm-watch-checkpoint.test.sh`
- `bash tests/fm-documentation-audiences.test.sh`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
