### PR TITLE
fix: keep task records and backlog transitions atomic

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -46,7 +46,7 @@ When any diagnostic needs captain attention, report the plain consequence and re
   A recorded deadline means the complete refresh did not finish inside `FM_HOME_SUMMARY_TIMEOUT`, so inspect lock acquisition and producer completion before validation or publication, and fix the blocked phase rather than raising this load-bearing bound.
 
 - `BACKLOG_RECONCILE: <id>: recorded backlog close could not be replayed: <reason>` - this session start found a pending-close record but could not land it.
-  For a valid teardown record, the endpoint and local copy are already gone; the task record is normally gone too, but remains paired with the marker when recovery could not remove it safely.
+  A valid teardown record proves the close was authorized and recorded, but physical cleanup may be partial: verify process reaping, the local-copy return, and endpoint closure before assuming those resources are gone.
   A validation error means the record cannot be trusted, so do not assume cleanup completed or follow any path or argument stored in it.
   Read the named reason, inspect the marker as inert data when validation failed, fix the record or backlog-file problem, and rerun session start so a valid recorded close replays.
   Never hand-close the item by deleting `state/<id>.backlog-close` - that can discard a completion link the cleanup captured, and the surviving marker prevents the record sweep from starting the item meanwhile.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, HOME_SUMMARY, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, HOME_SUMMARY, BACKLOG_RECONCILE, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -45,6 +45,15 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Read the named record for the recorded reasons, then reproduce with a direct `bin/fm-home-summary-refresh.sh` (no `--best-effort`, which is what keeps the failure quiet) so the refresh error reaches you.
   A recorded deadline means the complete refresh did not finish inside `FM_HOME_SUMMARY_TIMEOUT`, so inspect lock acquisition and producer completion before validation or publication, and fix the blocked phase rather than raising this load-bearing bound.
 
+- `BACKLOG_RECONCILE: <id>: recorded backlog close could not be replayed: <reason>` - this session start found a pending-close record but could not land it.
+  For a valid teardown record, the endpoint and local copy are already gone; the task record is normally gone too, but remains paired with the marker when recovery could not remove it safely.
+  A validation error means the record cannot be trusted, so do not assume cleanup completed or follow any path or argument stored in it.
+  Read the named reason, inspect the marker as inert data when validation failed, fix the record or backlog-file problem, and rerun session start so a valid recorded close replays.
+  Never hand-close the item by deleting `state/<id>.backlog-close` - that can discard a completion link the cleanup captured, and the surviving marker prevents the record sweep from starting the item meanwhile.
+- `BACKLOG_RECONCILE: <id>: worker record exists but its backlog item could not be read: <reason>` - this home could not determine whether the item matches its worker record.
+  Resolve the named backlog read problem and rerun session start; never guess by starting or closing an unreadable item.
+- `BACKLOG_RECONCILE: <id>: worker record exists but its backlog item could not be moved to In flight: <reason>` - this home owns a worker whose backlog item is still queued, and the reconciliation could not correct it.
+  Until it is corrected, the fleet view reads that worker as work no backlog item owns; resolve the named backlog problem and rerun session start.
 - `SECONDMATE_SYNC: secondmate <id>: skipped: <reason>` - secondmate convergence left a live home on its existing checkout because the home was dirty, diverged, unsafe, on the wrong branch, missing its placement-specific target commit, unreachable, or otherwise not fast-forwardable, or because inherited local-material propagation failed; bootstrap continued, but inspect the reason because the secondmate's tracked instructions, inherited settings, or shared captain preferences may be stale after a primary update.
 - `SECONDMATE_LIVENESS: secondmate <id>: skipped: <reason>|respawn failed after <cause>: <reason>` - the session-start liveness sweep could not guarantee that the registered secondmate is running a real agent process.
   Investigate the reason because that secondmate is not guaranteed live.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,8 +2,8 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, HOME_SUMMARY, BACKLOG_RECONCILE, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
-  A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
+  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, HOME_SUMMARY, BACKLOG_RECONCILE, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or reports that an interrupted backlog cleanup may have left an endpoint or local copy, or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
+  A silent bootstrap section, or any other BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
   internal: true
@@ -45,6 +45,8 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Read the named record for the recorded reasons, then reproduce with a direct `bin/fm-home-summary-refresh.sh` (no `--best-effort`, which is what keeps the failure quiet) so the refresh error reaches you.
   A recorded deadline means the complete refresh did not finish inside `FM_HOME_SUMMARY_TIMEOUT`, so inspect lock acquisition and producer completion before validation or publication, and fix the blocked phase rather than raising this load-bearing bound.
 
+- `BOOTSTRAP_INFO: closed the backlog item for <id> after interrupted cleanup; its endpoint or local copy may remain and should be reconciled` - replay closed the item, but the durable close says physical cleanup was interrupted.
+  Verify process reaping, the local-copy return, and endpoint closure, then reconcile any surviving resource.
 - `BACKLOG_RECONCILE: <id>: recorded backlog close could not be replayed: <reason>` - this session start found a pending-close record but could not land it.
   A valid teardown record proves the close was authorized and recorded, but physical cleanup may be partial: verify process reaping, the local-copy return, and endpoint closure before assuming those resources are gone.
   A validation error means the record cannot be trusted, so do not assume cleanup completed or follow any path or argument stored in it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ state/               runtime records and signals; gitignored
   <id>.muse-session  muse busy-source binding (sessions root plus task worktree) written by fm-spawn; removed by teardown
   <id>.cursor-session  cursor busy-source binding (projects root, task worktree, prior conversations) written by fm-spawn; removed by teardown
   <id>.reconcile-nudged  epoch second of the last inventory-reconcile nudge sent to this secondmate; bin/fm-secondmate-reconcile.sh owns its per-home cooldown window
+  <id>.backlog-close  the exact backlog close a teardown recorded before removing the task's record, so an interrupted cleanup can still be finished at the next session start; bin/fm-backlog-transition-lib.sh owns its format and replay, and a landed close removes it
   <id>.inbox/          durable steering inbox: sequenced firstmate instruction records the worker acknowledges by moving them into its handled/ subdirectory; written by fm-send, with ordinary records re-rung and escalated by the watcher while explicit fire-and-forget records are excluded from that ladder, and removed by teardown (bin/fm-task-inbox-lib.sh)
   <id>.meta          task metadata; each producer script's header owns its exact fields and mutation contract, with docs/configuration.md routing operator-facing backend and trace-context details
   <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Presentation spaces"
@@ -165,7 +166,7 @@ When that section reports its checks still in progress it names exactly what is 
 1. **Lock** - acquires the per-home session lock first, before anything mutates shared state, then starts the deferred network stage above.
 2. **Bootstrap** - detect-only checks (tool/version problems, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
    When the lock could not be acquired, the worktree-tangle check uses read-only advisory wording without a checkout repair command.
-   Home-local stale Herdr projection cleanup and the five bootstrap MUTATING sweeps - fleet sync, secondmate convergence, secondmate liveness, pending remote handoff retry, and Relay artifact writes - run only when this session actually holds the lock from step 1; the four network ones among them run in the deferred stage rather than in this section.
+   Home-local stale Herdr projection cleanup and the six bootstrap MUTATING sweeps - same-home backlog reconciliation, fleet sync, secondmate convergence, secondmate liveness, pending remote handoff retry, and Relay artifact writes - run only when this session actually holds the lock from step 1; the four network ones among them run in the deferred stage rather than in this section.
    The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous, unreadable, or unreachable remote targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`; `docs/remote-secondmates.md`).
 3. **Wake queue** - when locked, presents the durable wake queue and prints the raw records prominently as this turn's first work queue; a clearly labeled status-event annotation may follow a valid `signal` record and includes every status line still unread at the presentation cursor, but never replaces the raw record or current-state reconciliation, and a lapsed watcher chain still surfaces here via the same guard alarm.
    Presented records remain durable until the handling turn runs the generation-bound acknowledgement printed by the drain.
@@ -303,7 +304,8 @@ Write the task-specific brief under section 11 before spawning.
 
 Spawn only through `bin/fm-spawn.sh` after the profile and backend checks in section 4.
 The spawn must resolve a genuine isolated task worktree distinct from the primary checkout; a failed isolation assertion stops the task.
-After spawning, confirm the worker is processing the brief, handle any trust dialog through `harness-adapters`, and record ship or scout work as under way.
+When the configured tasks-axi backlog gate applies, the spawn itself moves the work item to In flight and refuses rather than dispatching work this home has no item for, so recording the dispatch is never a separate step to remember; a manual-backend home retains the hand-editing contract in `docs/configuration.md`.
+After spawning, confirm the worker is processing the brief and handle any trust dialog through `harness-adapters`.
 A persistent secondmate is recorded in the secondmate registry and runtime state, never as a backlog work item.
 
 Steer a worker with ordinary text through fail-closed `fm-send`: the message becomes a durable record in the task's steering inbox (multi-line text is legal, local and remote alike) and the worker's terminal receives only a constant doorbell line, with the watcher re-ringing an unacknowledged local message and escalating a stuck one (`bin/fm-task-inbox-lib.sh`; `bin/fm-send.sh` owns the typed-plane carve-outs).
@@ -494,7 +496,7 @@ Work routed to a secondmate is recorded in that secondmate home's own backlog, n
 A decision is simply a task held for the captain: `tasks-axi hold <id> --reason "<reason>" --kind captain`, with `--until <date>` when the captain defers it.
 When a main-side thread such as a pending captain decision or relay reminder is worth durable tracking, file it as its own work item and hold it the same way.
 Captain calls discovered by investigations or visual reviews follow `captain-hold-lifecycle`, which owns their completion gate and recorded-answer rules.
-Update the backlog on every dispatch, completion, and decision for a work item.
+When the automatic transition gate applies, dispatch and completion move the item themselves - `bin/fm-spawn.sh` and `bin/fm-teardown.sh` own those transitions and refuse rather than report success without them - so what remains yours is filing the item before dispatch, recording decisions, and keeping notes current; `docs/configuration.md` owns gate applicability and the manual-backend exception.
 Re-evaluate queued work after every teardown and heartbeat, dispatching items only when dependencies and time gates have cleared.
 
 `.tasks.toml`, `docs/configuration.md`, and current `tasks-axi --help` own the backlog schema, compatibility, retention, and routine command syntax.
@@ -532,7 +534,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `HOME_SUMMARY:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `HOME_SUMMARY:`, `BACKLOG_RECONCILE:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi default TOON.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -534,7 +534,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `HOME_SUMMARY:`, `BACKLOG_RECONCILE:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `HOME_SUMMARY:`, `BACKLOG_RECONCILE:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`), or when `BOOTSTRAP_INFO:` says an interrupted backlog cleanup may have left an endpoint or local copy; silence and other `BOOTSTRAP_INFO:` facts need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi default TOON.

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -75,13 +75,20 @@ fm_backlog_directory_present() {
 }
 
 fm_backlog_data_absolute() {
-  local data=$1 raw_bytes
+  local data=$1 raw_bytes check
   raw_bytes=$(printf '%s' "$data" | LC_ALL=C od -An -t u1) || return 1
   if ! fm_backlog_control_bytes_valid 0 "$raw_bytes"; then
     printf 'error: data directory contains an invalid control byte\n' >&2
     return 2
   fi
-  fm_backlog_directory_present "$data" "data directory" || return 1
+  check=$data
+  while [ "$check" != / ] && [ "${check%/}" != "$check" ]; do
+    check=${check%/}
+  done
+  if [ ! -d "$check" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="data directory is not a directory at $data"
+    return 1
+  fi
   if ! data=$(CDPATH='' cd -- "$data" 2>/dev/null && pwd -P); then
     return 1
   fi
@@ -140,7 +147,7 @@ fm_backlog_data_relative() {  # <data-dir>
 }
 
 fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
-  local config=$1 data kind=$3 file
+  local config=$1 data authorized_data=$2 kind=$3 file
   FM_BACKLOG_TRANSITION_SKIP=
   if [ "$kind" = secondmate ]; then
     FM_BACKLOG_TRANSITION_SKIP="secondmates are not backlog items"
@@ -159,7 +166,7 @@ fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
     FM_BACKLOG_TRANSITION_SKIP="this home keeps no backlog at $file"
     return 1
   fi
-  if ! fm_backlog_record_present "$file" "backlog file" "$data"; then
+  if ! fm_backlog_record_present "$file" "backlog file" "$authorized_data"; then
     return 2
   fi
   if ! fm_tasks_axi_compatible; then
@@ -170,7 +177,7 @@ fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
 }
 
 fm_backlog_row_probe() {  # <data-dir> <id>
-  local data file id=$2 out state held command_status
+  local data authorized_data=$1 file id=$2 out state held command_status
   if ! data=$(fm_backlog_data_absolute "$1"); then
     FM_BACKLOG_ROW_RESULT=error
     FM_BACKLOG_ROW_STATE=
@@ -184,7 +191,7 @@ fm_backlog_row_probe() {  # <data-dir> <id>
     FM_BACKLOG_ROW_ERROR=$FM_BACKLOG_TRANSITION_ERROR
     return 1
   }
-  if ! fm_backlog_record_present "$file" "backlog file" "$data"; then
+  if ! fm_backlog_record_present "$file" "backlog file" "$authorized_data"; then
     FM_BACKLOG_ROW_ERROR=$FM_BACKLOG_TRANSITION_ERROR
     return 1
   fi
@@ -222,7 +229,7 @@ fm_backlog_row_state() {  # <data-dir> <id>
 # Run one tasks-axi mutation against <home>'s backlog, capturing its first
 # output line in FM_BACKLOG_TRANSITION_ERROR on failure.
 fm_backlog_mutate() {  # <data-dir> <verb> <id> [flag...]
-  local data file verb=$2 id=$3 out command_status
+  local data authorized_data=$1 file verb=$2 id=$3 out command_status
   if ! data=$(fm_backlog_data_absolute "$1"); then
     FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $1"
     return 1
@@ -230,7 +237,7 @@ fm_backlog_mutate() {  # <data-dir> <verb> <id> [flag...]
   shift 3
   FM_BACKLOG_TRANSITION_ERROR=
   file=$(fm_backlog_file "$data") || return 1
-  fm_backlog_record_present "$file" "backlog file" "$data" || return 1
+  fm_backlog_record_present "$file" "backlog file" "$authorized_data" || return 1
   out=$(cd "$(fm_backlog_root "$data")" 2>/dev/null && tasks-axi "$verb" "$id" \
       --file "$file" "$@" 2>&1)
   command_status=$?
@@ -251,25 +258,70 @@ fm_backlog_done() {  # <data-dir> <id> [flag...]
   fm_backlog_mutate "$data" "done" "$id" "$@"
 }
 
+fm_backlog_canonical_existing() {
+  LC_ALL=C perl -MCwd=realpath -e '
+    my $resolved = realpath($ARGV[0]);
+    exit 1 unless defined $resolved;
+    print $resolved;
+  ' "$1" 2>/dev/null
+}
+
 fm_backlog_record_parent_authorized() {
-  local path=$1 label=$2 root=$3 parent parent_resolved root_resolved
+  local path=$1 label=$2 root=$3 parent base path_resolved root_resolved home_resolved
   parent=${path%/*}
   [ "$parent" != "$path" ] || parent=.
-  fm_backlog_directory_present "$root" "$label authorized directory" || return 1
-  fm_backlog_directory_present "$parent" "$label parent directory" || return 1
-  parent_resolved=$(CDPATH='' cd -- "$parent" 2>/dev/null && pwd -P) || return 1
-  root_resolved=$(CDPATH='' cd -- "$root" 2>/dev/null && pwd -P) || return 1
-  if [ "$parent_resolved" != "$root_resolved" ]; then
-    FM_BACKLOG_TRANSITION_ERROR="$label is outside its authorized directory at $path"
+  base=${path##*/}
+  root_resolved=$(fm_backlog_canonical_existing "$root") || {
+    FM_BACKLOG_TRANSITION_ERROR="$label authorized directory cannot be resolved at $root"
     return 1
+  }
+  [ -d "$root_resolved" ] || {
+    FM_BACKLOG_TRANSITION_ERROR="$label authorized directory is not a directory at $root"
+    return 1
+  }
+  if [ -n "${FM_HOME:-}" ]; then
+    case "$root" in
+      "$FM_HOME"|"$FM_HOME"/*)
+        home_resolved=$(fm_backlog_canonical_existing "$FM_HOME") || {
+          FM_BACKLOG_TRANSITION_ERROR="$label home directory cannot be resolved at $FM_HOME"
+          return 1
+        }
+        case "$root_resolved" in
+          "$home_resolved"|"$home_resolved"/*) ;;
+          *)
+            FM_BACKLOG_TRANSITION_ERROR="$label authorized directory resolves outside this home at $root"
+            return 1
+            ;;
+        esac
+        ;;
+    esac
   fi
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    path_resolved=$(fm_backlog_canonical_existing "$path") || {
+      FM_BACKLOG_TRANSITION_ERROR="$label cannot be resolved at $path"
+      return 1
+    }
+  else
+    parent=$(fm_backlog_canonical_existing "$parent") || {
+      FM_BACKLOG_TRANSITION_ERROR="$label parent directory cannot be resolved at $path"
+      return 1
+    }
+    path_resolved=${parent%/}/$base
+  fi
+  case "$path_resolved" in
+    "$root_resolved"/*) ;;
+    *)
+      FM_BACKLOG_TRANSITION_ERROR="$label resolves outside its authorized directory at $path"
+      return 1
+      ;;
+  esac
 }
 
 fm_backlog_record_present() {
   local path=$1 label=${2:-record} root=$3
   fm_backlog_record_parent_authorized "$path" "$label" "$root" || return 1
-  if [ ! -f "$path" ] || [ -L "$path" ]; then
-    FM_BACKLOG_TRANSITION_ERROR="$label is not a regular non-symlink file at $path"
+  if [ ! -f "$path" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="$label is not a regular file at $path"
     return 1
   fi
   return 0
@@ -289,13 +341,7 @@ fm_backlog_record_remove() {
 }
 
 fm_backlog_record_publish() {
-  local source=$1 target=$2 label=$3 root=$4 source_parent target_parent
-  source_parent=${source%/*}
-  [ "$source_parent" != "$source" ] || source_parent=.
-  target_parent=${target%/*}
-  [ "$target_parent" != "$target" ] || target_parent=.
-  fm_backlog_directory_present "$source_parent" "$label source directory" || return 1
-  fm_backlog_directory_present "$target_parent" "$label target directory" || return 1
+  local source=$1 target=$2 label=$3 root=$4
   fm_backlog_record_present "$source" "$label staged record" "$root" || return 1
   fm_backlog_record_parent_authorized "$target" "$label target" "$root" || return 1
   if [ -e "$target" ] || [ -L "$target" ]; then

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -563,7 +563,15 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
     row_state=
   fi
   case "$row_state" in
-    done\ *|'')
+    done\ *)
+      if fm_backlog_atomic_transition close '' "$marker" "$data" "$id" \
+          "${args[@]+"${args[@]}"}"; then
+        FM_BACKLOG_CLOSE_REPLAY_RESULT=closed
+        return 0
+      fi
+      return 1
+      ;;
+    '')
       fm_backlog_close_marker_remove "$marker" || return 1
       FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
       return 0

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -150,10 +150,6 @@ fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
     FM_BACKLOG_TRANSITION_SKIP="config/backlog-backend selects manual editing"
     return 1
   fi
-  if ! fm_tasks_axi_compatible; then
-    FM_BACKLOG_TRANSITION_SKIP="no compatible tasks-axi on PATH"
-    return 1
-  fi
   if ! data=$(fm_backlog_data_absolute "$2"); then
     FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $2"
     return 2
@@ -164,6 +160,10 @@ fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
     return 1
   fi
   if ! fm_backlog_record_present "$file" "backlog file"; then
+    return 2
+  fi
+  if ! fm_tasks_axi_compatible; then
+    FM_BACKLOG_TRANSITION_ERROR="automatic backlog transitions require tasks-axi $FM_TASKS_AXI_MIN or newer with the required update and mv features"
     return 2
   fi
   return 0
@@ -252,7 +252,10 @@ fm_backlog_done() {  # <data-dir> <id> [flag...]
 }
 
 fm_backlog_record_present() {
-  local path=$1 label=${2:-record}
+  local path=$1 label=${2:-record} parent
+  parent=${path%/*}
+  [ "$parent" != "$path" ] || parent=.
+  fm_backlog_directory_present "$parent" "$label parent directory" || return 1
   if [ ! -f "$path" ] || [ -L "$path" ]; then
     FM_BACKLOG_TRANSITION_ERROR="$label is not a regular non-symlink file at $path"
     return 1

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -53,7 +53,7 @@ FM_BACKLOG_TRANSITION_ERROR=
 FM_BACKLOG_ROW_RESULT=
 FM_BACKLOG_ROW_STATE=
 FM_BACKLOG_ROW_ERROR=
-# Set by fm_backlog_close_marker_replay: closed | stale | noop.
+# Set by fm_backlog_close_marker_replay: closed | closed_incomplete | stale | noop.
 # shellcheck disable=SC2034 # Output global, read by the sourcing caller.
 FM_BACKLOG_CLOSE_REPLAY_RESULT=
 
@@ -526,7 +526,7 @@ fm_backlog_close_marker_clear() {  # <state-dir> <id>
 # before any meta or backlog mutation.
 fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data-dir>
   local state=$1 marker=$2 marker_name expected_id
-  local id data marker_spawn_gen meta_spawn_gen row_state
+  local id data marker_spawn_gen meta_spawn_gen row_state cleanup_incomplete=0
   local args=()
   FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
   [ -e "$marker" ] || [ -L "$marker" ] || return 0
@@ -550,6 +550,7 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
       FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
       return 0
     fi
+    cleanup_incomplete=1
     fm_backlog_atomic_transition remove "$state/$id.meta" "the interrupted task record" \
       || return 1
   fi
@@ -566,7 +567,11 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
     done\ *)
       if fm_backlog_atomic_transition close '' "$marker" "$data" "$id" \
           "${args[@]+"${args[@]}"}"; then
-        FM_BACKLOG_CLOSE_REPLAY_RESULT=closed
+        if [ "$cleanup_incomplete" = 1 ]; then
+          FM_BACKLOG_CLOSE_REPLAY_RESULT=closed_incomplete
+        else
+          FM_BACKLOG_CLOSE_REPLAY_RESULT=closed
+        fi
         return 0
       fi
       return 1
@@ -579,7 +584,11 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
   esac
   if fm_backlog_atomic_transition close '' "$marker" "$data" "$id" \
       "${args[@]+"${args[@]}"}"; then
-    FM_BACKLOG_CLOSE_REPLAY_RESULT=closed
+    if [ "$cleanup_incomplete" = 1 ]; then
+      FM_BACKLOG_CLOSE_REPLAY_RESULT=closed_incomplete
+    else
+      FM_BACKLOG_CLOSE_REPLAY_RESULT=closed
+    fi
     return 0
   fi
   return 1

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -1,0 +1,578 @@
+# shellcheck shell=bash
+# Fused backlog transitions for the scripts that own a task's physical record.
+# Usage: . bin/fm-tasks-axi-lib.sh; . bin/fm-backlog-transition-lib.sh
+# (this library reads that one's backend gate and never sources it itself, so a
+# caller that already sourced it keeps its memoised compatibility verdict).
+#
+# INVARIANT. In ordinary successful lifecycle state, `state/<id>.meta` exists
+# <=> this home's backlog row for <id> is In flight; the one teardown crash
+# window is represented by `state/<id>.backlog-close`. The script performing the
+# mechanical record change owns the paired backlog transition and runs it in the
+# same process, under the per-task meta lock it already holds, before it reports
+# success. Nothing else - not a later agent turn, not a printed reminder - is
+# load-bearing for the pairing.
+#   bin/fm-spawn.sh      meta published => `tasks-axi start`
+#   bin/fm-teardown.sh   meta removed => `tasks-axi done`
+#   bin/fm-bootstrap.sh  replays whatever a crash left behind, THIS HOME ONLY.
+# bin/fm-fleet-snapshot.sh's classifier and bin/fm-secondmate-reconcile.sh's
+# cross-home nudge stay defense in depth, not the primary mechanism.
+#
+# SCOPE. fm_backlog_transition_applies is the single gate. It excludes
+# secondmates (persistent agents are never backlog items, AGENTS.md section 10),
+# homes whose configured backlog backend is manual or whose tasks-axi is not
+# compatible (bin/fm-tasks-axi-lib.sh), and homes that keep no backlog file at
+# all. Those return-1 exemptions are never errors; an unresolvable configured
+# data directory instead returns 2 so callers refuse before mutation.
+#
+# ADDRESSING. Every call passes `--file <data>/backlog.md` so the mutation lands
+# in the home that owns the task regardless of the caller's working directory,
+# and runs from that data directory's parent so the same home's `.tasks.toml`
+# supplies done_keep and the archive path. The parent of the data directory is
+# the addressing root rather than FM_HOME, so a home whose data directory is
+# relocated keeps its backlog and its archive together. A root with no
+# `.tasks.toml` gets tasks-axi's built-in defaults.
+#
+# CRASH RECOVERY. Only teardown needs a durable record: it removes the meta and
+# with it the completion links, so a process killed between the two halves would
+# leave nothing to reconstruct the close from. It writes
+# `state/<id>.backlog-close` first, and removes it once the close lands.
+# The writer and replay share one complete-record validator, and teardown stages
+# that record before destructive cleanup, so it never publishes or acts on a close
+# replay would reject. The validator pins the data path to this home's configured
+# root before any recovery mutation, then re-runs exactly that close.
+# `tasks-axi done` on an already-closed task backfills links
+# without moving the close date, so replay is idempotent. Spawn needs no marker:
+# it publishes the meta first, so a crash
+# leaves the meta itself as the evidence that the row is owed a start.
+
+# Set by fm_backlog_transition_applies for a return-1 exemption.
+# shellcheck disable=SC2034 # Output global, read by the sourcing caller.
+FM_BACKLOG_TRANSITION_SKIP=
+# Set by the mutating helpers when they return non-zero.
+FM_BACKLOG_TRANSITION_ERROR=
+FM_BACKLOG_ROW_RESULT=
+FM_BACKLOG_ROW_STATE=
+FM_BACKLOG_ROW_ERROR=
+# Set by fm_backlog_close_marker_replay: closed | stale | noop.
+# shellcheck disable=SC2034 # Output global, read by the sourcing caller.
+FM_BACKLOG_CLOSE_REPLAY_RESULT=
+
+fm_backlog_control_bytes_valid() {  # <allow-newline: 0|1> <od-bytes>
+  printf '%s\n' "$2" | awk -v allow_newline="$1" '
+    { for (i = 1; i <= NF; i++) if (($i < 32 && !(allow_newline && $i == 10)) || $i == 127) exit 1 }
+  '
+}
+
+fm_backlog_data_absolute() {
+  local data=$1 raw_bytes
+  raw_bytes=$(printf '%s' "$data" | LC_ALL=C od -An -t u1) || return 1
+  if ! fm_backlog_control_bytes_valid 0 "$raw_bytes"; then
+    printf 'error: data directory contains an invalid control byte\n' >&2
+    return 2
+  fi
+  if ! data=$(CDPATH='' cd -- "$data" 2>/dev/null && pwd -P); then
+    return 1
+  fi
+  printf '%s\n' "$data"
+}
+
+fm_backlog_file() {  # <data-dir>
+  local data
+  data=$(fm_backlog_data_absolute "$1") || {
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $1"
+    return 1
+  }
+  if [ "$data" = / ]; then
+    printf '/backlog.md\n'
+  else
+    printf '%s/backlog.md\n' "$data"
+  fi
+}
+
+# The directory a backlog's own `.tasks.toml` is resolved from.
+fm_backlog_root() {  # <data-dir>
+  local data parent
+  data=$(fm_backlog_data_absolute "$1") || {
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $1"
+    return 1
+  }
+  case "$data" in
+    */*)
+      parent=${data%/*}
+      [ -n "$parent" ] || parent=/
+      ;;
+    *) parent=. ;;
+  esac
+  printf '%s\n' "$parent"
+}
+
+fm_backlog_data_relative() {  # <data-dir>
+  local data root
+  data=$(fm_backlog_data_absolute "$1") || {
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $1"
+    return 1
+  }
+  root=$(fm_backlog_root "$data") || return 1
+  if [ "$data" = "$root" ]; then
+    printf '.\n'
+    return 0
+  fi
+  if [ "$root" = / ]; then
+    printf '%s\n' "${data#/}"
+    return 0
+  fi
+  case "$data" in
+    "$root"/*) printf '%s\n' "${data#"$root"/}" ;;
+    *) printf '%s\n' "$data" ;;
+  esac
+}
+
+fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
+  local config=$1 data kind=$3 file
+  FM_BACKLOG_TRANSITION_SKIP=
+  if [ "$kind" = secondmate ]; then
+    FM_BACKLOG_TRANSITION_SKIP="secondmates are not backlog items"
+    return 1
+  fi
+  if fm_backlog_backend_manual "$config"; then
+    FM_BACKLOG_TRANSITION_SKIP="config/backlog-backend selects manual editing"
+    return 1
+  fi
+  if ! fm_tasks_axi_compatible; then
+    FM_BACKLOG_TRANSITION_SKIP="no compatible tasks-axi on PATH"
+    return 1
+  fi
+  if ! data=$(fm_backlog_data_absolute "$2"); then
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $2"
+    return 2
+  fi
+  file=$(fm_backlog_file "$data")
+  if [ ! -f "$file" ]; then
+    FM_BACKLOG_TRANSITION_SKIP="this home keeps no backlog at $file"
+    return 1
+  fi
+  return 0
+}
+
+fm_backlog_row_probe() {  # <data-dir> <id>
+  local data id=$2 out state held command_status
+  if ! data=$(fm_backlog_data_absolute "$1"); then
+    FM_BACKLOG_ROW_RESULT=error
+    FM_BACKLOG_ROW_STATE=
+    FM_BACKLOG_ROW_ERROR="data directory cannot be resolved: $1"
+    return 1
+  fi
+  FM_BACKLOG_ROW_RESULT=error
+  FM_BACKLOG_ROW_STATE=
+  FM_BACKLOG_ROW_ERROR=
+  out=$(cd "$(fm_backlog_root "$data")" 2>/dev/null && tasks-axi show "$id" \
+      --file "$(fm_backlog_file "$data")" 2>&1)
+  command_status=$?
+  if [ "$command_status" -ne 0 ]; then
+    if printf '%s\n' "$out" | grep -q '^code: NOT_FOUND$'; then
+      FM_BACKLOG_ROW_RESULT=not_found
+    else
+      FM_BACKLOG_ROW_ERROR=$(printf '%s\n' "$out" | sed -n '1p')
+      [ -n "$FM_BACKLOG_ROW_ERROR" ] \
+        || FM_BACKLOG_ROW_ERROR="tasks-axi show $id failed with no output"
+    fi
+    return "$command_status"
+  fi
+  state=$(printf '%s\n' "$out" | sed -n 's/^  state: *//p' | head -1)
+  held=$(printf '%s\n' "$out" | sed -n 's/^  held: *//p' | head -1)
+  if [ -z "$state" ]; then
+    FM_BACKLOG_ROW_ERROR="tasks-axi show $id returned no state"
+    return 1
+  fi
+  FM_BACKLOG_ROW_RESULT=found
+  FM_BACKLOG_ROW_STATE="$state ${held:-no}"
+  return 0
+}
+
+# Echo "<state> <held>" for one row, e.g. "queued no" / "in_flight yes".
+# Returns 1 when the row does not exist or cannot be read.
+fm_backlog_row_state() {  # <data-dir> <id>
+  fm_backlog_row_probe "$1" "$2" || return 1
+  printf '%s\n' "$FM_BACKLOG_ROW_STATE"
+}
+
+# Run one tasks-axi mutation against <home>'s backlog, capturing its first
+# output line in FM_BACKLOG_TRANSITION_ERROR on failure.
+fm_backlog_mutate() {  # <data-dir> <verb> <id> [flag...]
+  local data verb=$2 id=$3 out command_status
+  if ! data=$(fm_backlog_data_absolute "$1"); then
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $1"
+    return 1
+  fi
+  shift 3
+  FM_BACKLOG_TRANSITION_ERROR=
+  out=$(cd "$(fm_backlog_root "$data")" 2>/dev/null && tasks-axi "$verb" "$id" \
+      --file "$(fm_backlog_file "$data")" "$@" 2>&1)
+  command_status=$?
+  [ "$command_status" -ne 0 ] || return 0
+  FM_BACKLOG_TRANSITION_ERROR=$(printf '%s\n' "$out" | sed -n '1p')
+  [ -n "$FM_BACKLOG_TRANSITION_ERROR" ] \
+    || FM_BACKLOG_TRANSITION_ERROR="tasks-axi $verb $id failed with no output"
+  return "$command_status"
+}
+
+fm_backlog_start() {  # <data-dir> <id>
+  fm_backlog_mutate "$1" start "$2"
+}
+
+fm_backlog_done() {  # <data-dir> <id> [flag...]
+  local data=$1 id=$2
+  shift 2
+  fm_backlog_mutate "$data" "done" "$id" "$@"
+}
+
+fm_backlog_record_present() {
+  local path=$1
+  if [ ! -f "$path" ] || [ -L "$path" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="task record publication did not land at $path"
+    return 1
+  fi
+  return 0
+}
+
+fm_backlog_record_remove() {
+  local path=$1 label=$2
+  if ! rm -f "$path" 2>/dev/null || [ -e "$path" ] || [ -L "$path" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="$label could not be removed at $path"
+    return 1
+  fi
+  return 0
+}
+
+fm_backlog_record_publish() {
+  local source=$1 target=$2 label=$3
+  if ! mv -f "$source" "$target" 2>/dev/null || ! fm_backlog_record_present "$target"; then
+    [ -n "$FM_BACKLOG_TRANSITION_ERROR" ] \
+      || FM_BACKLOG_TRANSITION_ERROR="$label publication failed at $target"
+    return 1
+  fi
+  return 0
+}
+
+fm_backlog_dispatch_transition() {
+  local meta=$1 data=$2 id=$3 row row_status
+  fm_backlog_record_present "$meta" || return 1
+  fm_backlog_row_probe "$data" "$id"
+  row_status=$?
+  if [ "$row_status" -ne 0 ]; then
+    if [ "$FM_BACKLOG_ROW_RESULT" = not_found ]; then
+      FM_BACKLOG_TRANSITION_ERROR="backlog item $id vanished before dispatch commit"
+    else
+      FM_BACKLOG_TRANSITION_ERROR=$FM_BACKLOG_ROW_ERROR
+    fi
+    return "$row_status"
+  fi
+  row=$FM_BACKLOG_ROW_STATE
+  case "$row" in
+    in_flight\ *) return 0 ;;
+    queued\ no) fm_backlog_start "$data" "$id" ;;
+    *)
+      FM_BACKLOG_TRANSITION_ERROR="backlog item $id is not dispatchable in state $row"
+      return 1
+      ;;
+  esac
+}
+
+fm_backlog_dispatch_rollback() {
+  local meta=$1 busy_script=$2 state=$3 id=$4 gen=$5 failed=0
+  fm_backlog_record_remove "$meta" "provisional task record" || failed=1
+  if [ -n "$gen" ]; then
+    "$busy_script" retire "$state" "$id" --gen "$gen" >/dev/null 2>&1 || failed=1
+    if [ -e "$state/$id.busy-state" ] || [ -L "$state/$id.busy-state" ] \
+       || [ -e "$state/$id.busy-gen" ] || [ -L "$state/$id.busy-gen" ]; then
+      failed=1
+    fi
+  fi
+  if [ "$failed" -ne 0 ]; then
+    FM_BACKLOG_TRANSITION_ERROR="failed-dispatch cleanup did not remove both task and busy records for $id"
+    return 1
+  fi
+  return 0
+}
+
+fm_backlog_close_transition() {
+  local meta=$1 marker=$2 data=$3 id=$4
+  shift 4
+  [ -z "$meta" ] || fm_backlog_record_remove "$meta" "task record" || return 1
+  fm_backlog_done "$data" "$id" "$@" || return 1
+  fm_backlog_record_remove "$marker" "pending-close record"
+}
+
+fm_backlog_atomic_transition() {
+  local operation=$1
+  shift
+  case "$operation" in
+    publish) fm_backlog_record_publish "$@" ;;
+    verify-published) fm_backlog_record_present "$@" ;;
+    remove) fm_backlog_record_remove "$@" ;;
+    dispatch) fm_backlog_dispatch_transition "$@" ;;
+    rollback) fm_backlog_dispatch_rollback "$@" ;;
+    close) fm_backlog_close_transition "$@" ;;
+    *) FM_BACKLOG_TRANSITION_ERROR="unknown backlog atomic transition $operation"; return 2 ;;
+  esac
+}
+
+fm_backlog_close_marker_path() {  # <state-dir> <id>
+  printf '%s/%s.backlog-close\n' "$1" "$2"
+}
+
+fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <expected-id>
+  local marker=$1 authorized_data data_resolved expected_id=$3
+  local id='' data='' marker_spawn_gen='' line raw_bytes arg_value
+  local url_tail url_authority url_path url_host url_port host_rest host_label host_valid
+  local percent_tail percent_valid
+  local id_count=0 data_count=0 spawn_gen_count=0
+  local args=()
+  FM_BACKLOG_CLOSE_VALIDATED_ID=
+  FM_BACKLOG_CLOSE_VALIDATED_DATA=
+  FM_BACKLOG_CLOSE_VALIDATED_SPAWN_GEN=
+  FM_BACKLOG_CLOSE_VALIDATED_ARGS=()
+  if [ -L "$marker" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="unsafe pending-close record $marker"
+    return 1
+  fi
+  [ -f "$marker" ] || {
+    FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
+    return 1
+  }
+  raw_bytes=$(LC_ALL=C od -An -t u1 "$marker" 2>/dev/null) || {
+    FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
+    return 1
+  }
+  if ! fm_backlog_control_bytes_valid 1 "$raw_bytes"; then
+    FM_BACKLOG_TRANSITION_ERROR="invalid control byte in pending-close record $marker"
+    return 1
+  fi
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      id=*) id=${line#id=}; id_count=$((id_count + 1)) ;;
+      data=*) data=${line#data=}; data_count=$((data_count + 1)) ;;
+      spawn_gen=*) marker_spawn_gen=${line#spawn_gen=}; spawn_gen_count=$((spawn_gen_count + 1)) ;;
+      arg=*) args+=("${line#arg=}") ;;
+      *) FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"; return 1 ;;
+    esac
+  done < "$marker"
+  case "$id" in
+    ''|.*|*[!A-Za-z0-9._-]*)
+      FM_BACKLOG_TRANSITION_ERROR="invalid task identity in pending-close record $marker"
+      return 1
+      ;;
+  esac
+  if [ "$id_count" -ne 1 ] || [ "$id" != "$expected_id" ] \
+     || [ "$data_count" -ne 1 ] || [ -z "$data" ] \
+     || [ "$spawn_gen_count" -ne 1 ]; then
+    FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
+    return 1
+  fi
+  case "$marker_spawn_gen" in
+    ''|.*|*[!A-Za-z0-9._-]*)
+      FM_BACKLOG_TRANSITION_ERROR="invalid spawn generation in pending-close record $marker"
+      return 1
+      ;;
+  esac
+  case "$data" in
+    /*) ;;
+    *) FM_BACKLOG_TRANSITION_ERROR="invalid data directory in pending-close record $marker"; return 1 ;;
+  esac
+  case "$data" in
+    */../*|*/..)
+      FM_BACKLOG_TRANSITION_ERROR="invalid data directory in pending-close record $marker"
+      return 1
+      ;;
+  esac
+  authorized_data=$(fm_backlog_data_absolute "$2") || {
+    FM_BACKLOG_TRANSITION_ERROR="authorized data directory cannot be resolved: $2"
+    return 1
+  }
+  data_resolved=$(fm_backlog_data_absolute "$data") || {
+    FM_BACKLOG_TRANSITION_ERROR="data directory in pending-close record cannot be resolved: $data"
+    return 1
+  }
+  if [ "$data_resolved" != "$authorized_data" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="foreign data directory in pending-close record $marker"
+    return 1
+  fi
+  case "${#args[@]}" in
+    0) ;;
+    2)
+      case "${args[0]}" in
+        --note) [ "${args[1]}" = "local%20main" ] ;;
+        --pr)
+          arg_value=${args[1]}
+          [ "${#arg_value}" -le 2048 ] \
+            && case "$arg_value" in https://*) true ;; *) false ;; esac \
+            && case "$arg_value" in
+              *[[:space:]]*|*[!A-Za-z0-9:/?\&=._#%+~@-]*) false ;;
+              *) true ;;
+            esac \
+            && {
+              url_tail=${arg_value#https://}
+              url_authority=${url_tail%%/*}
+              url_path=${url_tail#*/}
+              url_host=$url_authority
+              url_port=
+              case "$url_authority" in
+                *:*) url_host=${url_authority%%:*}; url_port=${url_authority#*:} ;;
+              esac
+              [ "$url_path" != "$url_tail" ] \
+                && case "$url_host" in
+                  ''|[-.]*|*[-.]|*..*|*[!A-Za-z0-9.-]*) false ;;
+                  *[A-Za-z0-9]*) true ;;
+                  *) false ;;
+                esac \
+                && {
+                  host_rest=$url_host
+                  host_valid=1
+                  while :; do
+                    host_label=${host_rest%%.*}
+                    case "$host_label" in ''|-*|*-) host_valid=0; break ;; esac
+                    [ "$host_rest" = "$host_label" ] && break
+                    host_rest=${host_rest#*.}
+                  done
+                  [ "$host_valid" = 1 ]
+                } \
+                && case "$url_authority" in
+                  *:*) case "$url_port" in ''|*[!0-9]*|??????*) false ;; *) true ;; esac ;;
+                  *) true ;;
+                esac \
+                && case "$url_path" in *[A-Za-z0-9]*) true ;; *) false ;; esac \
+                && {
+                  percent_tail=$url_path
+                  percent_valid=1
+                  while case "$percent_tail" in *%*) true ;; *) false ;; esac; do
+                    percent_tail=${percent_tail#*%}
+                    case "$percent_tail" in
+                      [0-9A-Fa-f][0-9A-Fa-f]*) percent_tail=${percent_tail#??} ;;
+                      *) percent_valid=0; break ;;
+                    esac
+                  done
+                  [ "$percent_valid" = 1 ]
+                }
+            }
+          ;;
+        --report)
+          arg_value=${args[1]}
+          [ "${#arg_value}" -le 4096 ] \
+            && [ -n "${arg_value// /}" ] \
+            && case "$arg_value" in .|..|-*|/*|../*|*/../*|*/..) false ;; *) true ;; esac
+          ;;
+        *) false ;;
+      esac || { FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1; }
+      ;;
+    *) FM_BACKLOG_TRANSITION_ERROR="invalid pending-close arguments in $marker"; return 1 ;;
+  esac
+  FM_BACKLOG_CLOSE_VALIDATED_ID=$id
+  FM_BACKLOG_CLOSE_VALIDATED_DATA=$data_resolved
+  FM_BACKLOG_CLOSE_VALIDATED_SPAWN_GEN=$marker_spawn_gen
+  FM_BACKLOG_CLOSE_VALIDATED_ARGS=("${args[@]+"${args[@]}"}")
+}
+
+fm_backlog_close_marker_stage() {  # <temporary-path> <id> <data-dir> <spawn-gen> [flag...]
+  local tmp=$1 id=$2 data spawn_gen=$4 arg previous_arg=''
+  local serialized_args=()
+  data=$(fm_backlog_data_absolute "$3") || {
+    FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $3"
+    return 1
+  }
+  shift 4
+  for arg in "$@"; do
+    if [ "$previous_arg" = --note ] && [ "$arg" = "local main" ]; then
+      serialized_args+=("local%20main")
+    else
+      serialized_args+=("$arg")
+    fi
+    previous_arg=$arg
+  done
+  {
+    printf 'id=%s\n' "$id"
+    printf 'data=%s\n' "$data"
+    printf 'spawn_gen=%s\n' "$spawn_gen"
+    for arg in "${serialized_args[@]+"${serialized_args[@]}"}"; do
+      printf 'arg=%s\n' "$arg"
+    done
+  } > "$tmp" || { rm -f "$tmp"; return 1; }
+  fm_backlog_close_marker_validate "$tmp" "$data" "$id" \
+    || { rm -f "$tmp"; return 1; }
+}
+
+# Record the exact close a teardown is about to perform.
+fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> <spawn-gen> [flag...]
+  local state=$1 id=$2 data=$3 spawn_gen=$4 marker tmp
+  shift 4
+  marker=$(fm_backlog_close_marker_path "$state" "$id") || return 1
+  tmp="$state/.$id.backlog-close.${BASHPID:-$$}"
+  fm_backlog_close_marker_stage "$tmp" "$id" "$data" "$spawn_gen" "$@" || return 1
+  fm_backlog_atomic_transition publish "$tmp" "$marker" "pending-close record" \
+    || { rm -f "$tmp"; return 1; }
+}
+
+fm_backlog_close_marker_remove() {  # <marker-path>
+  fm_backlog_atomic_transition remove "$1" "pending-close record"
+}
+
+fm_backlog_close_marker_clear() {  # <state-dir> <id>
+  local marker
+  marker=$(fm_backlog_close_marker_path "$1" "$2") || return 1
+  fm_backlog_close_marker_remove "$marker"
+}
+
+# Replay one recorded close. Returns 0 when the row is closed or the marker is
+# stale, and 1 when marker validation or recovery fails. Validation completes
+# before any meta or backlog mutation.
+fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data-dir>
+  local state=$1 marker=$2 marker_name expected_id
+  local id data marker_spawn_gen meta_spawn_gen row_state
+  local args=()
+  FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
+  [ -e "$marker" ] || [ -L "$marker" ] || return 0
+  marker_name=${marker##*/}
+  case "$marker_name" in
+    *.backlog-close) expected_id=${marker_name%.backlog-close} ;;
+    *) FM_BACKLOG_TRANSITION_ERROR="invalid pending-close record name $marker"; return 1 ;;
+  esac
+  fm_backlog_close_marker_validate "$marker" "$3" "$expected_id" || return 1
+  id=$FM_BACKLOG_CLOSE_VALIDATED_ID
+  data=$FM_BACKLOG_CLOSE_VALIDATED_DATA
+  marker_spawn_gen=$FM_BACKLOG_CLOSE_VALIDATED_SPAWN_GEN
+  args=("${FM_BACKLOG_CLOSE_VALIDATED_ARGS[@]+"${FM_BACKLOG_CLOSE_VALIDATED_ARGS[@]}"}")
+  if [ "${args[0]-}" = --note ]; then
+    args[1]="local main"
+  fi
+  if [ -e "$state/$id.meta" ]; then
+    meta_spawn_gen=$(sed -n 's/^spawn_gen=//p' "$state/$id.meta" | head -1)
+    if [ "$meta_spawn_gen" != "$marker_spawn_gen" ]; then
+      fm_backlog_close_marker_remove "$marker" || return 1
+      FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
+      return 0
+    fi
+    fm_backlog_atomic_transition remove "$state/$id.meta" "the interrupted task record" \
+      || return 1
+  fi
+  if fm_backlog_row_probe "$data" "$id"; then
+    row_state=$FM_BACKLOG_ROW_STATE
+  else
+    if [ "$FM_BACKLOG_ROW_RESULT" != not_found ]; then
+      FM_BACKLOG_TRANSITION_ERROR=$FM_BACKLOG_ROW_ERROR
+      return 1
+    fi
+    row_state=
+  fi
+  case "$row_state" in
+    done\ *|'')
+      fm_backlog_close_marker_remove "$marker" || return 1
+      FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
+      return 0
+      ;;
+  esac
+  if fm_backlog_atomic_transition close '' "$marker" "$data" "$id" \
+      "${args[@]+"${args[@]}"}"; then
+    FM_BACKLOG_CLOSE_REPLAY_RESULT=closed
+    return 0
+  fi
+  return 1
+}

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -267,7 +267,8 @@ fm_backlog_canonical_existing() {
 }
 
 fm_backlog_record_parent_authorized() {
-  local path=$1 label=$2 root=$3 parent base path_resolved root_resolved home_resolved
+  local path=$1 label=$2 root=$3 parent base parent_resolved expected_path
+  local path_resolved root_resolved home_resolved final_matches=1
   parent=${path%/*}
   [ "$parent" != "$path" ] || parent=.
   base=${path##*/}
@@ -296,17 +297,19 @@ fm_backlog_record_parent_authorized() {
         ;;
     esac
   fi
+  parent_resolved=$(fm_backlog_canonical_existing "$parent") || {
+    FM_BACKLOG_TRANSITION_ERROR="$label parent directory cannot be resolved at $path"
+    return 1
+  }
+  expected_path=${parent_resolved%/}/$base
   if [ -e "$path" ] || [ -L "$path" ]; then
     path_resolved=$(fm_backlog_canonical_existing "$path") || {
       FM_BACKLOG_TRANSITION_ERROR="$label cannot be resolved at $path"
       return 1
     }
+    [ "$path_resolved" = "$expected_path" ] || final_matches=0
   else
-    parent=$(fm_backlog_canonical_existing "$parent") || {
-      FM_BACKLOG_TRANSITION_ERROR="$label parent directory cannot be resolved at $path"
-      return 1
-    }
-    path_resolved=${parent%/}/$base
+    path_resolved=$expected_path
   fi
   case "$path_resolved" in
     "$root_resolved"/*) ;;
@@ -315,6 +318,10 @@ fm_backlog_record_parent_authorized() {
       return 1
       ;;
   esac
+  if [ "$final_matches" != 1 ]; then
+    FM_BACKLOG_TRANSITION_ERROR="$label resolves through a different final path at $path"
+    return 1
+  fi
 }
 
 fm_backlog_record_present() {

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -63,6 +63,17 @@ fm_backlog_control_bytes_valid() {  # <allow-newline: 0|1> <od-bytes>
   '
 }
 
+fm_backlog_directory_present() {
+  local path=$1 label=$2 check=$1
+  while [ "$check" != / ] && [ "${check%/}" != "$check" ]; do
+    check=${check%/}
+  done
+  if [ ! -d "$check" ] || [ -L "$check" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="$label is not a real directory at $path"
+    return 1
+  fi
+}
+
 fm_backlog_data_absolute() {
   local data=$1 raw_bytes
   raw_bytes=$(printf '%s' "$data" | LC_ALL=C od -An -t u1) || return 1
@@ -70,6 +81,7 @@ fm_backlog_data_absolute() {
     printf 'error: data directory contains an invalid control byte\n' >&2
     return 2
   fi
+  fm_backlog_directory_present "$data" "data directory" || return 1
   if ! data=$(CDPATH='' cd -- "$data" 2>/dev/null && pwd -P); then
     return 1
   fi
@@ -147,15 +159,18 @@ fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
     return 2
   fi
   file=$(fm_backlog_file "$data")
-  if [ ! -f "$file" ]; then
+  if [ ! -e "$file" ] && [ ! -L "$file" ]; then
     FM_BACKLOG_TRANSITION_SKIP="this home keeps no backlog at $file"
     return 1
+  fi
+  if ! fm_backlog_record_present "$file" "backlog file"; then
+    return 2
   fi
   return 0
 }
 
 fm_backlog_row_probe() {  # <data-dir> <id>
-  local data id=$2 out state held command_status
+  local data file id=$2 out state held command_status
   if ! data=$(fm_backlog_data_absolute "$1"); then
     FM_BACKLOG_ROW_RESULT=error
     FM_BACKLOG_ROW_STATE=
@@ -165,8 +180,16 @@ fm_backlog_row_probe() {  # <data-dir> <id>
   FM_BACKLOG_ROW_RESULT=error
   FM_BACKLOG_ROW_STATE=
   FM_BACKLOG_ROW_ERROR=
+  file=$(fm_backlog_file "$data") || {
+    FM_BACKLOG_ROW_ERROR=$FM_BACKLOG_TRANSITION_ERROR
+    return 1
+  }
+  if ! fm_backlog_record_present "$file" "backlog file"; then
+    FM_BACKLOG_ROW_ERROR=$FM_BACKLOG_TRANSITION_ERROR
+    return 1
+  fi
   out=$(cd "$(fm_backlog_root "$data")" 2>/dev/null && tasks-axi show "$id" \
-      --file "$(fm_backlog_file "$data")" 2>&1)
+      --file "$file" 2>&1)
   command_status=$?
   if [ "$command_status" -ne 0 ]; then
     if printf '%s\n' "$out" | grep -q '^code: NOT_FOUND$'; then
@@ -199,15 +222,17 @@ fm_backlog_row_state() {  # <data-dir> <id>
 # Run one tasks-axi mutation against <home>'s backlog, capturing its first
 # output line in FM_BACKLOG_TRANSITION_ERROR on failure.
 fm_backlog_mutate() {  # <data-dir> <verb> <id> [flag...]
-  local data verb=$2 id=$3 out command_status
+  local data file verb=$2 id=$3 out command_status
   if ! data=$(fm_backlog_data_absolute "$1"); then
     FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $1"
     return 1
   fi
   shift 3
   FM_BACKLOG_TRANSITION_ERROR=
+  file=$(fm_backlog_file "$data") || return 1
+  fm_backlog_record_present "$file" "backlog file" || return 1
   out=$(cd "$(fm_backlog_root "$data")" 2>/dev/null && tasks-axi "$verb" "$id" \
-      --file "$(fm_backlog_file "$data")" "$@" 2>&1)
+      --file "$file" "$@" 2>&1)
   command_status=$?
   [ "$command_status" -ne 0 ] || return 0
   FM_BACKLOG_TRANSITION_ERROR=$(printf '%s\n' "$out" | sed -n '1p')
@@ -227,16 +252,22 @@ fm_backlog_done() {  # <data-dir> <id> [flag...]
 }
 
 fm_backlog_record_present() {
-  local path=$1
+  local path=$1 label=${2:-record}
   if [ ! -f "$path" ] || [ -L "$path" ]; then
-    FM_BACKLOG_TRANSITION_ERROR="task record publication did not land at $path"
+    FM_BACKLOG_TRANSITION_ERROR="$label is not a regular non-symlink file at $path"
     return 1
   fi
   return 0
 }
 
 fm_backlog_record_remove() {
-  local path=$1 label=$2
+  local path=$1 label=$2 parent
+  parent=${path%/*}
+  [ "$parent" != "$path" ] || parent=.
+  fm_backlog_directory_present "$parent" "$label parent directory" || return 1
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    fm_backlog_record_present "$path" "$label" || return 1
+  fi
   if ! rm -f "$path" 2>/dev/null || [ -e "$path" ] || [ -L "$path" ]; then
     FM_BACKLOG_TRANSITION_ERROR="$label could not be removed at $path"
     return 1
@@ -245,8 +276,18 @@ fm_backlog_record_remove() {
 }
 
 fm_backlog_record_publish() {
-  local source=$1 target=$2 label=$3
-  if ! mv -f "$source" "$target" 2>/dev/null || ! fm_backlog_record_present "$target"; then
+  local source=$1 target=$2 label=$3 source_parent target_parent
+  source_parent=${source%/*}
+  [ "$source_parent" != "$source" ] || source_parent=.
+  target_parent=${target%/*}
+  [ "$target_parent" != "$target" ] || target_parent=.
+  fm_backlog_directory_present "$source_parent" "$label source directory" || return 1
+  fm_backlog_directory_present "$target_parent" "$label target directory" || return 1
+  fm_backlog_record_present "$source" "$label staged record" || return 1
+  if [ -e "$target" ] || [ -L "$target" ]; then
+    fm_backlog_record_present "$target" "$label target" || return 1
+  fi
+  if ! mv -f "$source" "$target" 2>/dev/null || ! fm_backlog_record_present "$target" "$label"; then
     [ -n "$FM_BACKLOG_TRANSITION_ERROR" ] \
       || FM_BACKLOG_TRANSITION_ERROR="$label publication failed at $target"
     return 1
@@ -354,7 +395,7 @@ fm_backlog_close_marker_path() {  # <state-dir> <id>
 }
 
 fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <expected-id>
-  local marker=$1 authorized_data data_resolved expected_id=$3
+  local marker=$1 authorized_data data_resolved expected_id=$3 parent
   local id='' data='' marker_spawn_gen='' line raw_bytes arg_value
   local url_tail url_authority url_path url_host url_port host_rest host_label host_valid
   local percent_tail percent_valid
@@ -364,14 +405,10 @@ fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <exp
   FM_BACKLOG_CLOSE_VALIDATED_DATA=
   FM_BACKLOG_CLOSE_VALIDATED_SPAWN_GEN=
   FM_BACKLOG_CLOSE_VALIDATED_ARGS=()
-  if [ -L "$marker" ]; then
-    FM_BACKLOG_TRANSITION_ERROR="unsafe pending-close record $marker"
-    return 1
-  fi
-  [ -f "$marker" ] || {
-    FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
-    return 1
-  }
+  parent=${marker%/*}
+  [ "$parent" != "$marker" ] || parent=.
+  fm_backlog_directory_present "$parent" "pending-close record directory" || return 1
+  fm_backlog_record_present "$marker" "pending-close record" || return 1
   raw_bytes=$(LC_ALL=C od -An -t u1 "$marker" 2>/dev/null) || {
     FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
     return 1
@@ -505,12 +542,19 @@ fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <exp
 }
 
 fm_backlog_close_marker_stage() {  # <temporary-path> <id> <data-dir> <spawn-gen> [flag...]
-  local tmp=$1 id=$2 data spawn_gen=$4 arg previous_arg=''
+  local tmp=$1 id=$2 data spawn_gen=$4 arg previous_arg='' parent
   local serialized_args=()
   data=$(fm_backlog_data_absolute "$3") || {
     FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $3"
     return 1
   }
+  parent=${tmp%/*}
+  [ "$parent" != "$tmp" ] || parent=.
+  fm_backlog_directory_present "$parent" "pending-close staging directory" || return 1
+  if [ -e "$tmp" ] || [ -L "$tmp" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="unsafe pending-close staging path $tmp"
+    return 1
+  fi
   shift 4
   for arg in "$@"; do
     if [ "$previous_arg" = --note ] && [ "$arg" = "local main" ]; then
@@ -535,6 +579,7 @@ fm_backlog_close_marker_stage() {  # <temporary-path> <id> <data-dir> <spawn-gen
 # Record the exact close a teardown is about to perform.
 fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> <spawn-gen> [flag...]
   local state=$1 id=$2 data=$3 spawn_gen=$4 marker tmp
+  fm_backlog_directory_present "$state" "state directory" || return 1
   shift 4
   marker=$(fm_backlog_close_marker_path "$state" "$id") || return 1
   tmp="$state/.$id.backlog-close.${BASHPID:-$$}"
@@ -558,9 +603,10 @@ fm_backlog_close_marker_clear() {  # <state-dir> <id>
 # before any meta or backlog mutation.
 fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data-dir>
   local state=$1 marker=$2 marker_name expected_id
-  local id data marker_spawn_gen meta meta_spawn_gen row_state cleanup_incomplete=1
+  local id data marker_spawn_gen meta meta_spawn_gen row_state cleanup_incomplete=0
   local args=()
   FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
+  fm_backlog_directory_present "$state" "state directory" || return 1
   [ -e "$marker" ] || [ -L "$marker" ] || return 0
   marker_name=${marker##*/}
   case "$marker_name" in

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -463,14 +463,15 @@ fm_backlog_close_marker_path() {  # <state-dir> <id>
 
 fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <expected-id> <state-dir>
   local marker=$1 authorized_data data_resolved expected_id=$3 state=$4
-  local id='' data='' marker_spawn_gen='' line raw_bytes arg_value
+  local id='' data='' marker_spawn_gen='' cleanup_incomplete=0 line raw_bytes arg_value
   local url_tail url_authority url_path url_host url_port host_rest host_label host_valid
   local percent_tail percent_valid
-  local id_count=0 data_count=0 spawn_gen_count=0
+  local id_count=0 data_count=0 spawn_gen_count=0 cleanup_incomplete_count=0
   local args=()
   FM_BACKLOG_CLOSE_VALIDATED_ID=
   FM_BACKLOG_CLOSE_VALIDATED_DATA=
   FM_BACKLOG_CLOSE_VALIDATED_SPAWN_GEN=
+  FM_BACKLOG_CLOSE_VALIDATED_CLEANUP_INCOMPLETE=0
   FM_BACKLOG_CLOSE_VALIDATED_ARGS=()
   fm_backlog_record_present "$marker" "pending-close record" "$state" || return 1
   raw_bytes=$(LC_ALL=C od -An -t u1 "$marker" 2>/dev/null) || {
@@ -486,6 +487,7 @@ fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <exp
       id=*) id=${line#id=}; id_count=$((id_count + 1)) ;;
       data=*) data=${line#data=}; data_count=$((data_count + 1)) ;;
       spawn_gen=*) marker_spawn_gen=${line#spawn_gen=}; spawn_gen_count=$((spawn_gen_count + 1)) ;;
+      cleanup_incomplete=*) cleanup_incomplete=${line#cleanup_incomplete=}; cleanup_incomplete_count=$((cleanup_incomplete_count + 1)) ;;
       arg=*) args+=("${line#arg=}") ;;
       *) FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"; return 1 ;;
     esac
@@ -505,6 +507,17 @@ fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <exp
   case "$marker_spawn_gen" in
     ''|.*|*[!A-Za-z0-9._-]*)
       FM_BACKLOG_TRANSITION_ERROR="invalid spawn generation in pending-close record $marker"
+      return 1
+      ;;
+  esac
+  if [ "$cleanup_incomplete_count" -gt 1 ]; then
+    FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
+    return 1
+  fi
+  case "$cleanup_incomplete" in
+    0|1) ;;
+    *)
+      FM_BACKLOG_TRANSITION_ERROR="invalid cleanup state in pending-close record $marker"
       return 1
       ;;
   esac
@@ -602,11 +615,12 @@ fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <exp
   FM_BACKLOG_CLOSE_VALIDATED_ID=$id
   FM_BACKLOG_CLOSE_VALIDATED_DATA=$data_resolved
   FM_BACKLOG_CLOSE_VALIDATED_SPAWN_GEN=$marker_spawn_gen
+  FM_BACKLOG_CLOSE_VALIDATED_CLEANUP_INCOMPLETE=$cleanup_incomplete
   FM_BACKLOG_CLOSE_VALIDATED_ARGS=("${args[@]+"${args[@]}"}")
 }
 
-fm_backlog_close_marker_stage() {  # <temporary-path> <id> <data-dir> <spawn-gen> <state-dir> [flag...]
-  local tmp=$1 id=$2 data spawn_gen=$4 state=$5 arg previous_arg=''
+fm_backlog_close_marker_stage() {  # <temporary-path> <id> <data-dir> <spawn-gen> <state-dir> <cleanup-incomplete: 0|1> [flag...]
+  local tmp=$1 id=$2 data spawn_gen=$4 state=$5 cleanup_incomplete=$6 arg previous_arg=''
   local serialized_args=()
   data=$(fm_backlog_data_absolute "$3") || {
     FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $3"
@@ -617,7 +631,11 @@ fm_backlog_close_marker_stage() {  # <temporary-path> <id> <data-dir> <spawn-gen
     FM_BACKLOG_TRANSITION_ERROR="unsafe pending-close staging path $tmp"
     return 1
   fi
-  shift 5
+  case "$cleanup_incomplete" in
+    0|1) ;;
+    *) FM_BACKLOG_TRANSITION_ERROR="invalid pending-close cleanup state"; return 1 ;;
+  esac
+  shift 6
   for arg in "$@"; do
     if [ "$previous_arg" = --note ] && [ "$arg" = "local main" ]; then
       serialized_args+=("local%20main")
@@ -630,6 +648,7 @@ fm_backlog_close_marker_stage() {  # <temporary-path> <id> <data-dir> <spawn-gen
     printf 'id=%s\n' "$id"
     printf 'data=%s\n' "$data"
     printf 'spawn_gen=%s\n' "$spawn_gen"
+    printf 'cleanup_incomplete=%s\n' "$cleanup_incomplete"
     for arg in "${serialized_args[@]+"${serialized_args[@]}"}"; do
       printf 'arg=%s\n' "$arg"
     done
@@ -645,7 +664,16 @@ fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> <spawn-gen> [fl
   shift 4
   marker=$(fm_backlog_close_marker_path "$state" "$id") || return 1
   tmp="$state/.$id.backlog-close.${BASHPID:-$$}"
-  fm_backlog_close_marker_stage "$tmp" "$id" "$data" "$spawn_gen" "$state" "$@" || return 1
+  fm_backlog_close_marker_stage "$tmp" "$id" "$data" "$spawn_gen" "$state" 0 "$@" || return 1
+  fm_backlog_atomic_transition publish "$tmp" "$marker" "pending-close record" "$state" \
+    || { rm -f "$tmp"; return 1; }
+}
+
+fm_backlog_close_marker_mark_cleanup_incomplete() {  # <state-dir> <marker-path> <id> <data-dir> <spawn-gen> [flag...]
+  local state=$1 marker=$2 id=$3 data=$4 spawn_gen=$5 tmp
+  shift 5
+  tmp="$state/.$id.backlog-close.${BASHPID:-$$}"
+  fm_backlog_close_marker_stage "$tmp" "$id" "$data" "$spawn_gen" "$state" 1 "$@" || return 1
   fm_backlog_atomic_transition publish "$tmp" "$marker" "pending-close record" "$state" \
     || { rm -f "$tmp"; return 1; }
 }
@@ -665,7 +693,7 @@ fm_backlog_close_marker_clear() {  # <state-dir> <id>
 # before any meta or backlog mutation.
 fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data-dir>
   local state=$1 marker=$2 marker_name expected_id
-  local id data marker_spawn_gen meta meta_spawn_gen row_state cleanup_incomplete=0
+  local id data marker_spawn_gen meta meta_spawn_gen row_state cleanup_incomplete
   local args=()
   FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
   fm_backlog_directory_present "$state" "state directory" || return 1
@@ -679,6 +707,7 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
   id=$FM_BACKLOG_CLOSE_VALIDATED_ID
   data=$FM_BACKLOG_CLOSE_VALIDATED_DATA
   marker_spawn_gen=$FM_BACKLOG_CLOSE_VALIDATED_SPAWN_GEN
+  cleanup_incomplete=$FM_BACKLOG_CLOSE_VALIDATED_CLEANUP_INCOMPLETE
   args=("${FM_BACKLOG_CLOSE_VALIDATED_ARGS[@]+"${FM_BACKLOG_CLOSE_VALIDATED_ARGS[@]}"}")
   if [ "${args[0]-}" = --note ]; then
     args[1]="local main"
@@ -696,6 +725,8 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
       FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
       return 0
     fi
+    fm_backlog_close_marker_mark_cleanup_incomplete "$state" "$marker" "$id" "$data" \
+      "$marker_spawn_gen" "${args[@]+"${args[@]}"}" || return 1
     cleanup_incomplete=1
     fm_backlog_atomic_transition remove "$meta" "the interrupted task record" "$state" \
       || return 1

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -19,10 +19,10 @@
 #
 # SCOPE. fm_backlog_transition_applies is the single gate. It excludes
 # secondmates (persistent agents are never backlog items, AGENTS.md section 10),
-# homes whose configured backlog backend is manual or whose tasks-axi is not
-# compatible (bin/fm-tasks-axi-lib.sh), and homes that keep no backlog file at
-# all. Those return-1 exemptions are never errors; an unresolvable configured
-# data directory instead returns 2 so callers refuse before mutation.
+# homes whose configured backlog backend is manual and homes that keep no
+# backlog file at all. Those return-1 exemptions are never errors; an
+# unresolvable configured data directory or incompatible tasks-axi instead
+# returns 2 so callers refuse before mutation.
 #
 # ADDRESSING. Every call passes `--file <data>/backlog.md` so the mutation lands
 # in the home that owns the task regardless of the caller's working directory,
@@ -159,7 +159,7 @@ fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
     FM_BACKLOG_TRANSITION_SKIP="this home keeps no backlog at $file"
     return 1
   fi
-  if ! fm_backlog_record_present "$file" "backlog file"; then
+  if ! fm_backlog_record_present "$file" "backlog file" "$data"; then
     return 2
   fi
   if ! fm_tasks_axi_compatible; then
@@ -184,7 +184,7 @@ fm_backlog_row_probe() {  # <data-dir> <id>
     FM_BACKLOG_ROW_ERROR=$FM_BACKLOG_TRANSITION_ERROR
     return 1
   }
-  if ! fm_backlog_record_present "$file" "backlog file"; then
+  if ! fm_backlog_record_present "$file" "backlog file" "$data"; then
     FM_BACKLOG_ROW_ERROR=$FM_BACKLOG_TRANSITION_ERROR
     return 1
   fi
@@ -230,7 +230,7 @@ fm_backlog_mutate() {  # <data-dir> <verb> <id> [flag...]
   shift 3
   FM_BACKLOG_TRANSITION_ERROR=
   file=$(fm_backlog_file "$data") || return 1
-  fm_backlog_record_present "$file" "backlog file" || return 1
+  fm_backlog_record_present "$file" "backlog file" "$data" || return 1
   out=$(cd "$(fm_backlog_root "$data")" 2>/dev/null && tasks-axi "$verb" "$id" \
       --file "$file" "$@" 2>&1)
   command_status=$?
@@ -251,11 +251,23 @@ fm_backlog_done() {  # <data-dir> <id> [flag...]
   fm_backlog_mutate "$data" "done" "$id" "$@"
 }
 
-fm_backlog_record_present() {
-  local path=$1 label=${2:-record} parent
+fm_backlog_record_parent_authorized() {
+  local path=$1 label=$2 root=$3 parent parent_resolved root_resolved
   parent=${path%/*}
   [ "$parent" != "$path" ] || parent=.
+  fm_backlog_directory_present "$root" "$label authorized directory" || return 1
   fm_backlog_directory_present "$parent" "$label parent directory" || return 1
+  parent_resolved=$(CDPATH='' cd -- "$parent" 2>/dev/null && pwd -P) || return 1
+  root_resolved=$(CDPATH='' cd -- "$root" 2>/dev/null && pwd -P) || return 1
+  if [ "$parent_resolved" != "$root_resolved" ]; then
+    FM_BACKLOG_TRANSITION_ERROR="$label is outside its authorized directory at $path"
+    return 1
+  fi
+}
+
+fm_backlog_record_present() {
+  local path=$1 label=${2:-record} root=$3
+  fm_backlog_record_parent_authorized "$path" "$label" "$root" || return 1
   if [ ! -f "$path" ] || [ -L "$path" ]; then
     FM_BACKLOG_TRANSITION_ERROR="$label is not a regular non-symlink file at $path"
     return 1
@@ -264,12 +276,10 @@ fm_backlog_record_present() {
 }
 
 fm_backlog_record_remove() {
-  local path=$1 label=$2 parent
-  parent=${path%/*}
-  [ "$parent" != "$path" ] || parent=.
-  fm_backlog_directory_present "$parent" "$label parent directory" || return 1
+  local path=$1 label=$2 root=$3
+  fm_backlog_record_parent_authorized "$path" "$label" "$root" || return 1
   if [ -e "$path" ] || [ -L "$path" ]; then
-    fm_backlog_record_present "$path" "$label" || return 1
+    fm_backlog_record_present "$path" "$label" "$root" || return 1
   fi
   if ! rm -f "$path" 2>/dev/null || [ -e "$path" ] || [ -L "$path" ]; then
     FM_BACKLOG_TRANSITION_ERROR="$label could not be removed at $path"
@@ -279,18 +289,19 @@ fm_backlog_record_remove() {
 }
 
 fm_backlog_record_publish() {
-  local source=$1 target=$2 label=$3 source_parent target_parent
+  local source=$1 target=$2 label=$3 root=$4 source_parent target_parent
   source_parent=${source%/*}
   [ "$source_parent" != "$source" ] || source_parent=.
   target_parent=${target%/*}
   [ "$target_parent" != "$target" ] || target_parent=.
   fm_backlog_directory_present "$source_parent" "$label source directory" || return 1
   fm_backlog_directory_present "$target_parent" "$label target directory" || return 1
-  fm_backlog_record_present "$source" "$label staged record" || return 1
+  fm_backlog_record_present "$source" "$label staged record" "$root" || return 1
+  fm_backlog_record_parent_authorized "$target" "$label target" "$root" || return 1
   if [ -e "$target" ] || [ -L "$target" ]; then
-    fm_backlog_record_present "$target" "$label target" || return 1
+    fm_backlog_record_present "$target" "$label target" "$root" || return 1
   fi
-  if ! mv -f "$source" "$target" 2>/dev/null || ! fm_backlog_record_present "$target" "$label"; then
+  if ! mv -f "$source" "$target" 2>/dev/null || ! fm_backlog_record_present "$target" "$label" "$root"; then
     [ -n "$FM_BACKLOG_TRANSITION_ERROR" ] \
       || FM_BACKLOG_TRANSITION_ERROR="$label publication failed at $target"
     return 1
@@ -299,9 +310,9 @@ fm_backlog_record_publish() {
 }
 
 fm_backlog_meta_spawn_gen() {
-  local meta=$1 count value
+  local meta=$1 state=$2 count value
   FM_BACKLOG_META_SPAWN_GEN=
-  fm_backlog_record_present "$meta" || return 1
+  fm_backlog_record_present "$meta" "task record" "$state" || return 1
   count=$(LC_ALL=C awk -F= '$1 == "spawn_gen" { count++ } END { print count + 0 }' "$meta" 2>/dev/null) || {
     FM_BACKLOG_TRANSITION_ERROR="unreadable spawn generation in task record $meta"
     return 1
@@ -331,8 +342,8 @@ fm_backlog_row_dispatchable() {
 }
 
 fm_backlog_dispatch_transition() {
-  local meta=$1 data=$2 id=$3 row row_status
-  fm_backlog_record_present "$meta" || return 1
+  local meta=$1 data=$2 id=$3 state=$4 row row_status
+  fm_backlog_record_present "$meta" "task record" "$state" || return 1
   fm_backlog_row_probe "$data" "$id"
   row_status=$?
   if [ "$row_status" -ne 0 ]; then
@@ -356,7 +367,7 @@ fm_backlog_dispatch_transition() {
 
 fm_backlog_dispatch_rollback() {
   local meta=$1 busy_script=$2 state=$3 id=$4 gen=$5 failed=0
-  fm_backlog_record_remove "$meta" "provisional task record" || failed=1
+  fm_backlog_record_remove "$meta" "provisional task record" "$state" || failed=1
   if [ -n "$gen" ]; then
     "$busy_script" retire "$state" "$id" --gen "$gen" >/dev/null 2>&1 || failed=1
     if [ -e "$state/$id.busy-state" ] || [ -L "$state/$id.busy-state" ] \
@@ -372,11 +383,11 @@ fm_backlog_dispatch_rollback() {
 }
 
 fm_backlog_close_transition() {
-  local meta=$1 marker=$2 data=$3 id=$4
-  shift 4
-  [ -z "$meta" ] || fm_backlog_record_remove "$meta" "task record" || return 1
+  local meta=$1 marker=$2 data=$3 id=$4 state=$5
+  shift 5
+  [ -z "$meta" ] || fm_backlog_record_remove "$meta" "task record" "$state" || return 1
   fm_backlog_done "$data" "$id" "$@" || return 1
-  fm_backlog_record_remove "$marker" "pending-close record"
+  fm_backlog_record_remove "$marker" "pending-close record" "$state"
 }
 
 fm_backlog_atomic_transition() {
@@ -397,8 +408,8 @@ fm_backlog_close_marker_path() {  # <state-dir> <id>
   printf '%s/%s.backlog-close\n' "$1" "$2"
 }
 
-fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <expected-id>
-  local marker=$1 authorized_data data_resolved expected_id=$3 parent
+fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <expected-id> <state-dir>
+  local marker=$1 authorized_data data_resolved expected_id=$3 state=$4
   local id='' data='' marker_spawn_gen='' line raw_bytes arg_value
   local url_tail url_authority url_path url_host url_port host_rest host_label host_valid
   local percent_tail percent_valid
@@ -408,10 +419,7 @@ fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <exp
   FM_BACKLOG_CLOSE_VALIDATED_DATA=
   FM_BACKLOG_CLOSE_VALIDATED_SPAWN_GEN=
   FM_BACKLOG_CLOSE_VALIDATED_ARGS=()
-  parent=${marker%/*}
-  [ "$parent" != "$marker" ] || parent=.
-  fm_backlog_directory_present "$parent" "pending-close record directory" || return 1
-  fm_backlog_record_present "$marker" "pending-close record" || return 1
+  fm_backlog_record_present "$marker" "pending-close record" "$state" || return 1
   raw_bytes=$(LC_ALL=C od -An -t u1 "$marker" 2>/dev/null) || {
     FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
     return 1
@@ -544,21 +552,19 @@ fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <exp
   FM_BACKLOG_CLOSE_VALIDATED_ARGS=("${args[@]+"${args[@]}"}")
 }
 
-fm_backlog_close_marker_stage() {  # <temporary-path> <id> <data-dir> <spawn-gen> [flag...]
-  local tmp=$1 id=$2 data spawn_gen=$4 arg previous_arg='' parent
+fm_backlog_close_marker_stage() {  # <temporary-path> <id> <data-dir> <spawn-gen> <state-dir> [flag...]
+  local tmp=$1 id=$2 data spawn_gen=$4 state=$5 arg previous_arg=''
   local serialized_args=()
   data=$(fm_backlog_data_absolute "$3") || {
     FM_BACKLOG_TRANSITION_ERROR="data directory cannot be resolved: $3"
     return 1
   }
-  parent=${tmp%/*}
-  [ "$parent" != "$tmp" ] || parent=.
-  fm_backlog_directory_present "$parent" "pending-close staging directory" || return 1
+  fm_backlog_record_parent_authorized "$tmp" "pending-close staging path" "$state" || return 1
   if [ -e "$tmp" ] || [ -L "$tmp" ]; then
     FM_BACKLOG_TRANSITION_ERROR="unsafe pending-close staging path $tmp"
     return 1
   fi
-  shift 4
+  shift 5
   for arg in "$@"; do
     if [ "$previous_arg" = --note ] && [ "$arg" = "local main" ]; then
       serialized_args+=("local%20main")
@@ -575,7 +581,7 @@ fm_backlog_close_marker_stage() {  # <temporary-path> <id> <data-dir> <spawn-gen
       printf 'arg=%s\n' "$arg"
     done
   } > "$tmp" || { rm -f "$tmp"; return 1; }
-  fm_backlog_close_marker_validate "$tmp" "$data" "$id" \
+  fm_backlog_close_marker_validate "$tmp" "$data" "$id" "$state" \
     || { rm -f "$tmp"; return 1; }
 }
 
@@ -586,19 +592,19 @@ fm_backlog_close_marker_write() {  # <state-dir> <id> <data-dir> <spawn-gen> [fl
   shift 4
   marker=$(fm_backlog_close_marker_path "$state" "$id") || return 1
   tmp="$state/.$id.backlog-close.${BASHPID:-$$}"
-  fm_backlog_close_marker_stage "$tmp" "$id" "$data" "$spawn_gen" "$@" || return 1
-  fm_backlog_atomic_transition publish "$tmp" "$marker" "pending-close record" \
+  fm_backlog_close_marker_stage "$tmp" "$id" "$data" "$spawn_gen" "$state" "$@" || return 1
+  fm_backlog_atomic_transition publish "$tmp" "$marker" "pending-close record" "$state" \
     || { rm -f "$tmp"; return 1; }
 }
 
-fm_backlog_close_marker_remove() {  # <marker-path>
-  fm_backlog_atomic_transition remove "$1" "pending-close record"
+fm_backlog_close_marker_remove() {  # <marker-path> <state-dir>
+  fm_backlog_atomic_transition remove "$1" "pending-close record" "$2"
 }
 
 fm_backlog_close_marker_clear() {  # <state-dir> <id>
   local marker
   marker=$(fm_backlog_close_marker_path "$1" "$2") || return 1
-  fm_backlog_close_marker_remove "$marker"
+  fm_backlog_close_marker_remove "$marker" "$1"
 }
 
 # Replay one recorded close. Returns 0 when the row is closed or the marker is
@@ -616,7 +622,7 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
     *.backlog-close) expected_id=${marker_name%.backlog-close} ;;
     *) FM_BACKLOG_TRANSITION_ERROR="invalid pending-close record name $marker"; return 1 ;;
   esac
-  fm_backlog_close_marker_validate "$marker" "$3" "$expected_id" || return 1
+  fm_backlog_close_marker_validate "$marker" "$3" "$expected_id" "$state" || return 1
   id=$FM_BACKLOG_CLOSE_VALIDATED_ID
   data=$FM_BACKLOG_CLOSE_VALIDATED_DATA
   marker_spawn_gen=$FM_BACKLOG_CLOSE_VALIDATED_SPAWN_GEN
@@ -626,19 +632,19 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
   fi
   meta="$state/$id.meta"
   if [ -e "$meta" ] || [ -L "$meta" ]; then
-    if ! fm_backlog_record_present "$meta"; then
+    if ! fm_backlog_record_present "$meta" "task record" "$state"; then
       FM_BACKLOG_TRANSITION_ERROR="unsafe interrupted task record at $meta"
       return 1
     fi
-    fm_backlog_meta_spawn_gen "$meta" || return 1
+    fm_backlog_meta_spawn_gen "$meta" "$state" || return 1
     meta_spawn_gen=$FM_BACKLOG_META_SPAWN_GEN
     if [ "$meta_spawn_gen" != "$marker_spawn_gen" ]; then
-      fm_backlog_close_marker_remove "$marker" || return 1
+      fm_backlog_close_marker_remove "$marker" "$state" || return 1
       FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
       return 0
     fi
     cleanup_incomplete=1
-    fm_backlog_atomic_transition remove "$meta" "the interrupted task record" \
+    fm_backlog_atomic_transition remove "$meta" "the interrupted task record" "$state" \
       || return 1
   fi
   if fm_backlog_row_probe "$data" "$id"; then
@@ -652,7 +658,7 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
   fi
   case "$row_state" in
     done\ *)
-      if fm_backlog_atomic_transition close '' "$marker" "$data" "$id" \
+      if fm_backlog_atomic_transition close '' "$marker" "$data" "$id" "$state" \
           "${args[@]+"${args[@]}"}"; then
         if [ "$cleanup_incomplete" = 1 ]; then
           FM_BACKLOG_CLOSE_REPLAY_RESULT=closed_incomplete
@@ -664,12 +670,12 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
       return 1
       ;;
     '')
-      fm_backlog_close_marker_remove "$marker" || return 1
+      fm_backlog_close_marker_remove "$marker" "$state" || return 1
       FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
       return 0
       ;;
   esac
-  if fm_backlog_atomic_transition close '' "$marker" "$data" "$id" \
+  if fm_backlog_atomic_transition close '' "$marker" "$data" "$id" "$state" \
       "${args[@]+"${args[@]}"}"; then
     if [ "$cleanup_incomplete" = 1 ]; then
       FM_BACKLOG_CLOSE_REPLAY_RESULT=closed_incomplete

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -57,6 +57,20 @@ FM_BACKLOG_ROW_ERROR=
 # shellcheck disable=SC2034 # Output global, read by the sourcing caller.
 FM_BACKLOG_CLOSE_REPLAY_RESULT=
 
+# Emit each byte of a value as a decimal number, locale-independently.
+# Deliberately perl rather than od: the spawn and teardown lifecycle runs under a
+# curated PATH (tests/fm-teardown.test.sh make_path_without_lsof pins that set)
+# that excludes od, and a validator that cannot run must never wedge dispatch or
+# cleanup. perl is already in that curated set and is already used elsewhere in
+# this repo for the same portability reason.
+fm_backlog_bytes_of_string() {  # <string>
+  perl -e 'print join(" ", unpack("C*", $ARGV[0])), "\n"' -- "$1"
+}
+
+fm_backlog_bytes_of_file() {  # <path>
+  perl -e 'open(my $f, "<", $ARGV[0]) or exit 1; binmode $f; local $/; my $c = <$f>; $c = "" unless defined $c; print join(" ", unpack("C*", $c)), "\n"' -- "$1"
+}
+
 fm_backlog_control_bytes_valid() {  # <allow-newline: 0|1> <od-bytes>
   printf '%s\n' "$2" | awk -v allow_newline="$1" '
     { for (i = 1; i <= NF; i++) if (($i < 32 && !(allow_newline && $i == 10)) || $i == 127) exit 1 }
@@ -76,7 +90,7 @@ fm_backlog_directory_present() {
 
 fm_backlog_data_absolute() {
   local data=$1 raw_bytes check
-  raw_bytes=$(printf '%s' "$data" | LC_ALL=C od -An -t u1) || return 1
+  raw_bytes=$(fm_backlog_bytes_of_string "$data") || return 1
   if ! fm_backlog_control_bytes_valid 0 "$raw_bytes"; then
     printf 'error: data directory contains an invalid control byte\n' >&2
     return 2
@@ -474,7 +488,7 @@ fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <exp
   FM_BACKLOG_CLOSE_VALIDATED_CLEANUP_INCOMPLETE=0
   FM_BACKLOG_CLOSE_VALIDATED_ARGS=()
   fm_backlog_record_present "$marker" "pending-close record" "$state" || return 1
-  raw_bytes=$(LC_ALL=C od -An -t u1 "$marker" 2>/dev/null) || {
+  raw_bytes=$(fm_backlog_bytes_of_file "$marker" 2>/dev/null) || {
     FM_BACKLOG_TRANSITION_ERROR="unreadable pending-close record $marker"
     return 1
   }

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -526,7 +526,7 @@ fm_backlog_close_marker_clear() {  # <state-dir> <id>
 # before any meta or backlog mutation.
 fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data-dir>
   local state=$1 marker=$2 marker_name expected_id
-  local id data marker_spawn_gen meta_spawn_gen row_state cleanup_incomplete=0
+  local id data marker_spawn_gen meta_spawn_gen row_state cleanup_incomplete=1
   local args=()
   FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
   [ -e "$marker" ] || [ -L "$marker" ] || return 0

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -254,6 +254,31 @@ fm_backlog_record_publish() {
   return 0
 }
 
+fm_backlog_meta_spawn_gen() {
+  local meta=$1 count value
+  FM_BACKLOG_META_SPAWN_GEN=
+  fm_backlog_record_present "$meta" || return 1
+  count=$(LC_ALL=C awk -F= '$1 == "spawn_gen" { count++ } END { print count + 0 }' "$meta" 2>/dev/null) || {
+    FM_BACKLOG_TRANSITION_ERROR="unreadable spawn generation in task record $meta"
+    return 1
+  }
+  if [ "$count" -ne 1 ]; then
+    FM_BACKLOG_TRANSITION_ERROR="task record $meta has $count spawn generation fields; exactly one is required"
+    return 1
+  fi
+  value=$(LC_ALL=C awk -F= '$1 == "spawn_gen" { sub(/^[^=]*=/, ""); print }' "$meta" 2>/dev/null) || {
+    FM_BACKLOG_TRANSITION_ERROR="unreadable spawn generation in task record $meta"
+    return 1
+  }
+  case "$value" in
+    ''|.*|*[!A-Za-z0-9._-]*)
+      FM_BACKLOG_TRANSITION_ERROR="invalid spawn generation in task record $meta"
+      return 1
+      ;;
+  esac
+  FM_BACKLOG_META_SPAWN_GEN=$value
+}
+
 fm_backlog_row_dispatchable() {
   case "$1" in
     in_flight\ *|queued\ no) return 0 ;;
@@ -556,7 +581,8 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
       FM_BACKLOG_TRANSITION_ERROR="unsafe interrupted task record at $meta"
       return 1
     fi
-    meta_spawn_gen=$(sed -n 's/^spawn_gen=//p' "$meta" | head -1)
+    fm_backlog_meta_spawn_gen "$meta" || return 1
+    meta_spawn_gen=$FM_BACKLOG_META_SPAWN_GEN
     if [ "$meta_spawn_gen" != "$marker_spawn_gen" ]; then
       fm_backlog_close_marker_remove "$marker" || return 1
       FM_BACKLOG_CLOSE_REPLAY_RESULT=stale

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -254,6 +254,13 @@ fm_backlog_record_publish() {
   return 0
 }
 
+fm_backlog_row_dispatchable() {
+  case "$1" in
+    in_flight\ *|queued\ no) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 fm_backlog_dispatch_transition() {
   local meta=$1 data=$2 id=$3 row row_status
   fm_backlog_record_present "$meta" || return 1
@@ -268,13 +275,13 @@ fm_backlog_dispatch_transition() {
     return "$row_status"
   fi
   row=$FM_BACKLOG_ROW_STATE
+  if ! fm_backlog_row_dispatchable "$row"; then
+    FM_BACKLOG_TRANSITION_ERROR="backlog item $id is not dispatchable in state $row"
+    return 1
+  fi
   case "$row" in
     in_flight\ *) return 0 ;;
     queued\ no) fm_backlog_start "$data" "$id" ;;
-    *)
-      FM_BACKLOG_TRANSITION_ERROR="backlog item $id is not dispatchable in state $row"
-      return 1
-      ;;
   esac
 }
 
@@ -526,7 +533,7 @@ fm_backlog_close_marker_clear() {  # <state-dir> <id>
 # before any meta or backlog mutation.
 fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data-dir>
   local state=$1 marker=$2 marker_name expected_id
-  local id data marker_spawn_gen meta_spawn_gen row_state cleanup_incomplete=1
+  local id data marker_spawn_gen meta meta_spawn_gen row_state cleanup_incomplete=1
   local args=()
   FM_BACKLOG_CLOSE_REPLAY_RESULT=noop
   [ -e "$marker" ] || [ -L "$marker" ] || return 0
@@ -543,15 +550,20 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
   if [ "${args[0]-}" = --note ]; then
     args[1]="local main"
   fi
-  if [ -e "$state/$id.meta" ]; then
-    meta_spawn_gen=$(sed -n 's/^spawn_gen=//p' "$state/$id.meta" | head -1)
+  meta="$state/$id.meta"
+  if [ -e "$meta" ] || [ -L "$meta" ]; then
+    if ! fm_backlog_record_present "$meta"; then
+      FM_BACKLOG_TRANSITION_ERROR="unsafe interrupted task record at $meta"
+      return 1
+    fi
+    meta_spawn_gen=$(sed -n 's/^spawn_gen=//p' "$meta" | head -1)
     if [ "$meta_spawn_gen" != "$marker_spawn_gen" ]; then
       fm_backlog_close_marker_remove "$marker" || return 1
       FM_BACKLOG_CLOSE_REPLAY_RESULT=stale
       return 0
     fi
     cleanup_incomplete=1
-    fm_backlog_atomic_transition remove "$state/$id.meta" "the interrupted task record" \
+    fm_backlog_atomic_transition remove "$meta" "the interrupted task record" \
       || return 1
   fi
   if fm_backlog_row_probe "$data" "$id"; then

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -191,7 +191,7 @@ fm_backlog_transition_applies() {  # <config-dir> <data-dir> <kind>
 }
 
 fm_backlog_row_probe() {  # <data-dir> <id>
-  local data authorized_data=$1 file id=$2 out state held command_status
+  local data authorized_data=$1 file id=$2 out state held blocked command_status
   if ! data=$(fm_backlog_data_absolute "$1"); then
     FM_BACKLOG_ROW_RESULT=error
     FM_BACKLOG_ROW_STATE=
@@ -224,16 +224,17 @@ fm_backlog_row_probe() {  # <data-dir> <id>
   fi
   state=$(printf '%s\n' "$out" | sed -n 's/^  state: *//p' | head -1)
   held=$(printf '%s\n' "$out" | sed -n 's/^  held: *//p' | head -1)
+  blocked=$(printf '%s\n' "$out" | sed -n 's/^  blocked: *//p' | head -1)
   if [ -z "$state" ]; then
     FM_BACKLOG_ROW_ERROR="tasks-axi show $id returned no state"
     return 1
   fi
   FM_BACKLOG_ROW_RESULT=found
-  FM_BACKLOG_ROW_STATE="$state ${held:-no}"
+  FM_BACKLOG_ROW_STATE="$state ${held:-no} ${blocked:-no}"
   return 0
 }
 
-# Echo "<state> <held>" for one row, e.g. "queued no" / "in_flight yes".
+# Echo "<state> <held> <blocked>" for one row, e.g. "queued no no".
 # Returns 1 when the row does not exist or cannot be read.
 fm_backlog_row_state() {  # <data-dir> <id>
   fm_backlog_row_probe "$1" "$2" || return 1
@@ -403,7 +404,7 @@ fm_backlog_meta_spawn_gen() {
 
 fm_backlog_row_dispatchable() {
   case "$1" in
-    in_flight\ *|queued\ no) return 0 ;;
+    in_flight\ no\ no|queued\ no\ no) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -427,8 +428,8 @@ fm_backlog_dispatch_transition() {
     return 1
   fi
   case "$row" in
-    in_flight\ *) return 0 ;;
-    queued\ no) fm_backlog_start "$data" "$id" ;;
+    in_flight\ no\ no) return 0 ;;
+    queued\ no\ no) fm_backlog_start "$data" "$id" ;;
   esac
 }
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -13,6 +13,7 @@
 #                 "FLEET_SYNC: <repo>: skipped|recovered|STUCK: <detail>",
 #                 "HOME_SUMMARY: <ledger never published|not republished since
 #                 <stamp>>; <n> failed attempt(s) ... last: <recorded failure>",
+#                 "BACKLOG_RECONCILE: <id>: <what this home could not reconcile>",
 #                 "TANGLE: <remediation>",
 #                 "SECONDMATE_SYNC: secondmate <id>: skipped: <reason>",
 #                 "NUDGE_SECONDMATES: secondmate <id>: send failed: <reason>",
@@ -80,9 +81,22 @@
 #          refresh relays any completed fm-fleet-sync.sh output before the
 #          aggregate timeout skip line with timeout and elapsed seconds.
 #          Set FM_FLEET_PRUNE=0 to skip branch pruning during that refresh.
-#          Set FM_BOOTSTRAP_DETECT_ONLY=1 to skip the five MUTATING sweeps
-#          (secondmate_sync, secondmate_liveness_sweep,
-#          secondmate_handoff_resume, x_mode_setup, fleet_sync) while still
+#          BACKLOG_RECONCILE lines report what backlog_record_reconcile could not
+#          settle in THIS home. Every ordinary dispatch and completion now moves
+#          the backlog row inside the script that moves the task's record
+#          (bin/fm-backlog-transition-lib.sh), so this sweep exists for the
+#          crash window inside those scripts and for drift a home was already
+#          carrying: it finishes the authoritative close an interrupted cleanup
+#          recorded, and marks In flight any item this home already owns a worker
+#          for. The worker-record sweep never starts a captain-held or closed
+#          item, and reconciliation never reads or writes another home; the fleet
+#          snapshot's classifier and
+#          bin/fm-secondmate-reconcile.sh's nudge stay as backstops. Replayed
+#          closes and restored In-flight rows print BOOTSTRAP_INFO facts.
+#          Set FM_BOOTSTRAP_DETECT_ONLY=1 to skip the six MUTATING sweeps
+#          (backlog_record_reconcile, secondmate_sync,
+#          secondmate_liveness_sweep, secondmate_handoff_resume, x_mode_setup,
+#          fleet_sync) while still
 #          printing every read-only detect line
 #          above; the TANGLE line switches to advisory-only wording with no
 #          checkout command. Used by
@@ -90,7 +104,7 @@
 #          the fleet lock, so a second concurrent session never race-mutates
 #          secondmate homes, pending handoff outboxes,
 #          X-mode artifacts, project clones, or repair instructions.
-#          Unset/0 (the default) runs all five sweeps - this flag is purely
+#          Unset/0 (the default) runs all six sweeps - this flag is purely
 #          additive.
 #          Set FM_BOOTSTRAP_NETWORK to split this run by whether a step talks to
 #          the network, so a session start can print its digest from local reads
@@ -102,8 +116,9 @@
 #                 `gh auth status`, secondmate_liveness_sweep, secondmate_sync,
 #                 secondmate_handoff_resume, and fleet_sync.
 #            only - ONLY those network steps and nothing else. No tool detection,
-#                 no version floors, no tangle check, no x_mode_setup: those
-#                 already ran on the local pass.
+#                 no version floors, no tangle check, no backlog
+#                 reconciliation, no x_mode_setup: those already ran on the
+#                 local pass.
 #          FM_BOOTSTRAP_DETECT_ONLY composes with it unchanged, so `only` plus
 #          detect-only is the read-only `gh auth status` probe on its own.
 #          bin/fm-startup-network.sh owns the deferral: it runs the `only` phase
@@ -139,6 +154,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 # shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-backlog-transition-lib.sh disable=SC1091
+. "$SCRIPT_DIR/fm-backlog-transition-lib.sh"
 # shellcheck source=bin/fm-quota-axi-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-quota-axi-lib.sh"
 # shellcheck source=bin/fm-tangle-lib.sh disable=SC1091
@@ -1166,6 +1183,89 @@ crew_dispatch_validate() {
   fi
 }
 
+# Same-home record reconciliation. Every ordinary dispatch and completion now
+# moves the backlog row inside the script that moves the task's record
+# (bin/fm-backlog-transition-lib.sh), so remaining recovery cases include a
+# process killed mid-transition and drift this home was already carrying. Heal
+# this home's OWN books on its own
+# restart rather than waiting for a parent's cross-home nudge; the fleet
+# snapshot's classifier and bin/fm-secondmate-reconcile.sh's nudge stay as
+# backstops for what this cannot see. Never reads or writes another home.
+backlog_record_reconcile() {
+  local marker meta meta_lock id row label has_record=0 gate_status
+  if fm_backlog_transition_applies "$CONFIG" "$DATA" "$BOOTSTRAP_BACKLOG_GATE_KIND"; then
+    :
+  else
+    gate_status=$?
+    if [ "$gate_status" -eq 2 ]; then
+      echo "error: backlog reconciliation cannot access configured data directory $DATA ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+      return 2
+    fi
+    return 0
+  fi
+  # Keep the wake/lock library's source-time state-directory creation inside
+  # this mutating sweep, so FM_BOOTSTRAP_DETECT_ONLY remains read-only.
+  # shellcheck source=bin/fm-wake-lib.sh disable=SC1091
+  . "$SCRIPT_DIR/fm-wake-lib.sh"
+
+  # Finish any close an interrupted cleanup recorded but never landed.
+  for marker in "$STATE"/*.backlog-close; do
+    [ -e "$marker" ] || [ -L "$marker" ] || continue
+    label=$(basename "$marker" .backlog-close)
+    meta_lock=$(fm_meta_lock_path "$STATE/$label.meta") || continue
+    fm_lock_try_acquire "$meta_lock" || continue
+    if fm_backlog_close_marker_replay "$STATE" "$marker" "$DATA"; then
+      if [ "$FM_BACKLOG_CLOSE_REPLAY_RESULT" = closed ]; then
+        echo "BOOTSTRAP_INFO: closed the backlog item for $label that an interrupted cleanup left open"
+      fi
+    else
+      echo "BACKLOG_RECONCILE: $label: recorded backlog close could not be replayed: $FM_BACKLOG_TRANSITION_ERROR"
+    fi
+    fm_lock_release "$meta_lock"
+  done
+
+  # A home that owns no records has nothing to pair, so it never pays for a
+  # backlog read. A pending close remains authoritative even when replay failed:
+  # the record sweep below must not start that item while its marker survives.
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    has_record=1
+    break
+  done
+  [ "$has_record" = 1 ] || return 0
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    id=$(basename "$meta" .meta)
+    meta_lock=$(fm_meta_lock_path "$meta") || continue
+    fm_lock_try_acquire "$meta_lock" || continue
+    if [ -e "$STATE/$id.backlog-close" ] || [ -L "$STATE/$id.backlog-close" ]; then
+      fm_lock_release "$meta_lock"
+      continue
+    fi
+    if [ -e "$meta" ] \
+       && [ "$(fm_meta_get "$meta" kind)" != secondmate ] \
+       && [ "$(fm_meta_get "$meta" cleanup_recovery)" != orca ]; then
+      row=
+      if fm_backlog_row_probe "$DATA" "$id"; then
+        row=$FM_BACKLOG_ROW_STATE
+      elif [ "$FM_BACKLOG_ROW_RESULT" != not_found ]; then
+        echo "BACKLOG_RECONCILE: $id: worker record exists but its backlog item could not be read: $FM_BACKLOG_ROW_ERROR"
+      fi
+      # Heal only the unambiguous case: a queued row for a record this home
+      # already owns. A held row is the captain's to move, and a closed row is a
+      # contradiction this sweep must not resolve by resurrecting the item.
+      if [ "$row" = "queued no" ]; then
+        if fm_backlog_start "$DATA" "$id"; then
+          echo "BOOTSTRAP_INFO: marked $id in flight to match the worker this home already owns"
+        else
+          echo "BACKLOG_RECONCILE: $id: worker record exists but its backlog item could not be moved to In flight: $FM_BACKLOG_TRANSITION_ERROR"
+        fi
+      fi
+    fi
+    fm_lock_release "$meta_lock"
+  done
+}
+
 startup_memory_budget_setup() {
   # Primary bootstrap owns default publication. A secondmate is deliberately
   # passive here because its setting must converge from the primary through the
@@ -1198,7 +1298,41 @@ fi
 # sessions never touch state, and the deferred network pass never repeats it:
 # the local pass that ran first already closed that window.
 if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ] && local_phase; then
+  BOOTSTRAP_BACKLOG_GATE_KIND=secondmate
+  for BOOTSTRAP_BACKLOG_MARKER in "$STATE"/*.backlog-close; do
+    [ -e "$BOOTSTRAP_BACKLOG_MARKER" ] || [ -L "$BOOTSTRAP_BACKLOG_MARKER" ] || continue
+    BOOTSTRAP_BACKLOG_GATE_KIND=ship
+    break
+  done
+  if [ "$BOOTSTRAP_BACKLOG_GATE_KIND" = secondmate ]; then
+    for BOOTSTRAP_BACKLOG_META in "$STATE"/*.meta; do
+      [ -f "$BOOTSTRAP_BACKLOG_META" ] || continue
+      if [ "$(fm_meta_get "$BOOTSTRAP_BACKLOG_META" kind)" != secondmate ] \
+         && [ "$(fm_meta_get "$BOOTSTRAP_BACKLOG_META" cleanup_recovery)" != orca ]; then
+        BOOTSTRAP_BACKLOG_GATE_KIND=ship
+        break
+      fi
+    done
+  fi
+  if fm_backlog_transition_applies "$CONFIG" "$DATA" "$BOOTSTRAP_BACKLOG_GATE_KIND"; then
+    :
+  else
+    BOOTSTRAP_BACKLOG_GATE_STATUS=$?
+    if [ "$BOOTSTRAP_BACKLOG_GATE_STATUS" -eq 2 ]; then
+      echo "error: bootstrap cannot access configured backlog data directory $DATA ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+      exit 1
+    fi
+  fi
+  "$SCRIPT_DIR/fm-pr-check-migrate.sh" || true
   startup_memory_budget_setup
+  if backlog_record_reconcile; then
+    :
+  else
+    BOOTSTRAP_BACKLOG_RECONCILE_STATUS=$?
+    if [ "$BOOTSTRAP_BACKLOG_RECONCILE_STATUS" -eq 2 ]; then
+      exit 1
+    fi
+  fi
 fi
 
 # Local detection: presence, version floors, and configuration. Nothing here

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1215,9 +1215,14 @@ backlog_record_reconcile() {
     meta_lock=$(fm_meta_lock_path "$STATE/$label.meta") || continue
     fm_lock_try_acquire "$meta_lock" || continue
     if fm_backlog_close_marker_replay "$STATE" "$marker" "$DATA"; then
-      if [ "$FM_BACKLOG_CLOSE_REPLAY_RESULT" = closed ]; then
-        echo "BOOTSTRAP_INFO: closed the backlog item for $label that an interrupted cleanup left open"
-      fi
+      case "$FM_BACKLOG_CLOSE_REPLAY_RESULT" in
+        closed)
+          echo "BOOTSTRAP_INFO: closed the backlog item for $label that an interrupted cleanup left open"
+          ;;
+        closed_incomplete)
+          echo "BOOTSTRAP_INFO: closed the backlog item for $label after interrupted cleanup; its endpoint or local copy may remain and should be reconciled"
+          ;;
+      esac
     else
       echo "BACKLOG_RECONCILE: $label: recorded backlog close could not be replayed: $FM_BACKLOG_TRANSITION_ERROR"
     fi

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1215,6 +1215,10 @@ backlog_record_reconcile() {
   # Finish any close an interrupted cleanup recorded but never landed.
   for marker in "$STATE"/*.backlog-close; do
     [ -e "$marker" ] || [ -L "$marker" ] || continue
+    if ! fm_backlog_record_present "$marker" "pending-close record" "$STATE"; then
+      echo "BACKLOG_RECONCILE: unsafe pending close refused: $FM_BACKLOG_TRANSITION_ERROR"
+      return 2
+    fi
     label=$(basename "$marker" .backlog-close)
     meta_lock=$(fm_meta_lock_path "$STATE/$label.meta") || continue
     fm_lock_try_acquire "$meta_lock" || continue
@@ -1237,13 +1241,21 @@ backlog_record_reconcile() {
   # backlog read. A pending close remains authoritative even when replay failed:
   # the record sweep below must not start that item while its marker survives.
   for meta in "$STATE"/*.meta; do
-    [ -f "$meta" ] && [ ! -L "$meta" ] || continue
+    [ -e "$meta" ] || [ -L "$meta" ] || continue
+    if ! fm_backlog_record_present "$meta" "task record" "$STATE"; then
+      echo "BACKLOG_RECONCILE: unsafe worker record refused: $FM_BACKLOG_TRANSITION_ERROR"
+      return 2
+    fi
     has_record=1
     break
   done
   [ "$has_record" = 1 ] || return 0
   for meta in "$STATE"/*.meta; do
-    [ -f "$meta" ] && [ ! -L "$meta" ] || continue
+    [ -e "$meta" ] || [ -L "$meta" ] || continue
+    if ! fm_backlog_record_present "$meta" "task record" "$STATE"; then
+      echo "BACKLOG_RECONCILE: unsafe worker record refused: $FM_BACKLOG_TRANSITION_ERROR"
+      return 2
+    fi
     id=$(basename "$meta" .meta)
     meta_lock=$(fm_meta_lock_path "$meta") || continue
     fm_lock_try_acquire "$meta_lock" || continue
@@ -1251,8 +1263,12 @@ backlog_record_reconcile() {
       fm_lock_release "$meta_lock"
       continue
     fi
-    if [ -f "$meta" ] && [ ! -L "$meta" ] \
-       && [ "$(fm_meta_get "$meta" kind)" != secondmate ] \
+    if ! fm_backlog_record_present "$meta" "task record" "$STATE"; then
+      echo "BACKLOG_RECONCILE: $id: post-lock worker record check refused: $FM_BACKLOG_TRANSITION_ERROR"
+      fm_lock_release "$meta_lock"
+      return 2
+    fi
+    if [ "$(fm_meta_get "$meta" kind)" != secondmate ] \
        && [ "$(fm_meta_get "$meta" cleanup_recovery)" != orca ]; then
       row=
       if fm_backlog_row_probe "$DATA" "$id"; then
@@ -1314,12 +1330,20 @@ if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ] && local_phase; then
   BOOTSTRAP_BACKLOG_GATE_KIND=secondmate
   for BOOTSTRAP_BACKLOG_MARKER in "$STATE"/*.backlog-close; do
     [ -e "$BOOTSTRAP_BACKLOG_MARKER" ] || [ -L "$BOOTSTRAP_BACKLOG_MARKER" ] || continue
+    if ! fm_backlog_record_present "$BOOTSTRAP_BACKLOG_MARKER" "pending-close record" "$STATE"; then
+      echo "error: bootstrap refused unsafe pending close ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+      exit 1
+    fi
     BOOTSTRAP_BACKLOG_GATE_KIND=ship
     break
   done
   if [ "$BOOTSTRAP_BACKLOG_GATE_KIND" = secondmate ]; then
     for BOOTSTRAP_BACKLOG_META in "$STATE"/*.meta; do
-      [ -f "$BOOTSTRAP_BACKLOG_META" ] && [ ! -L "$BOOTSTRAP_BACKLOG_META" ] || continue
+      [ -e "$BOOTSTRAP_BACKLOG_META" ] || [ -L "$BOOTSTRAP_BACKLOG_META" ] || continue
+      if ! fm_backlog_record_present "$BOOTSTRAP_BACKLOG_META" "task record" "$STATE"; then
+        echo "error: bootstrap refused unsafe worker record ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+        exit 1
+      fi
       if [ "$(fm_meta_get "$BOOTSTRAP_BACKLOG_META" kind)" != secondmate ] \
          && [ "$(fm_meta_get "$BOOTSTRAP_BACKLOG_META" cleanup_recovery)" != orca ]; then
         BOOTSTRAP_BACKLOG_GATE_KIND=ship

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1233,13 +1233,13 @@ backlog_record_reconcile() {
   # backlog read. A pending close remains authoritative even when replay failed:
   # the record sweep below must not start that item while its marker survives.
   for meta in "$STATE"/*.meta; do
-    [ -e "$meta" ] || continue
+    [ -f "$meta" ] && [ ! -L "$meta" ] || continue
     has_record=1
     break
   done
   [ "$has_record" = 1 ] || return 0
   for meta in "$STATE"/*.meta; do
-    [ -e "$meta" ] || continue
+    [ -f "$meta" ] && [ ! -L "$meta" ] || continue
     id=$(basename "$meta" .meta)
     meta_lock=$(fm_meta_lock_path "$meta") || continue
     fm_lock_try_acquire "$meta_lock" || continue
@@ -1247,7 +1247,7 @@ backlog_record_reconcile() {
       fm_lock_release "$meta_lock"
       continue
     fi
-    if [ -e "$meta" ] \
+    if [ -f "$meta" ] && [ ! -L "$meta" ] \
        && [ "$(fm_meta_get "$meta" kind)" != secondmate ] \
        && [ "$(fm_meta_get "$meta" cleanup_recovery)" != orca ]; then
       row=
@@ -1311,7 +1311,7 @@ if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ] && local_phase; then
   done
   if [ "$BOOTSTRAP_BACKLOG_GATE_KIND" = secondmate ]; then
     for BOOTSTRAP_BACKLOG_META in "$STATE"/*.meta; do
-      [ -f "$BOOTSTRAP_BACKLOG_META" ] || continue
+      [ -f "$BOOTSTRAP_BACKLOG_META" ] && [ ! -L "$BOOTSTRAP_BACKLOG_META" ] || continue
       if [ "$(fm_meta_get "$BOOTSTRAP_BACKLOG_META" kind)" != secondmate ] \
          && [ "$(fm_meta_get "$BOOTSTRAP_BACKLOG_META" cleanup_recovery)" != orca ]; then
         BOOTSTRAP_BACKLOG_GATE_KIND=ship

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1323,7 +1323,6 @@ if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ] && local_phase; then
       exit 1
     fi
   fi
-  "$SCRIPT_DIR/fm-pr-check-migrate.sh" || true
   startup_memory_budget_setup
   if backlog_record_reconcile; then
     :

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1193,6 +1193,10 @@ crew_dispatch_validate() {
 # backstops for what this cannot see. Never reads or writes another home.
 backlog_record_reconcile() {
   local marker meta meta_lock id row label has_record=0 gate_status
+  if ! fm_backlog_directory_present "$STATE" "state directory"; then
+    echo "error: backlog reconciliation refused: $FM_BACKLOG_TRANSITION_ERROR" >&2
+    return 2
+  fi
   if fm_backlog_transition_applies "$CONFIG" "$DATA" "$BOOTSTRAP_BACKLOG_GATE_KIND"; then
     :
   else
@@ -1303,6 +1307,10 @@ fi
 # sessions never touch state, and the deferred network pass never repeats it:
 # the local pass that ran first already closed that window.
 if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ] && local_phase; then
+  if ! fm_backlog_directory_present "$STATE" "state directory"; then
+    echo "error: bootstrap cannot reconcile task state ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+    exit 1
+  fi
   BOOTSTRAP_BACKLOG_GATE_KIND=secondmate
   for BOOTSTRAP_BACKLOG_MARKER in "$STATE"/*.backlog-close; do
     [ -e "$BOOTSTRAP_BACKLOG_MARKER" ] || [ -L "$BOOTSTRAP_BACKLOG_MARKER" ] || continue

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1193,6 +1193,9 @@ crew_dispatch_validate() {
 # backstops for what this cannot see. Never reads or writes another home.
 backlog_record_reconcile() {
   local marker meta meta_lock id row label has_record=0 gate_status
+  # A fresh home with no state directory has no physical task records to pair.
+  # Keep bootstrap diagnostics working without creating state just for a no-op.
+  [ -e "$STATE" ] || [ -L "$STATE" ] || return 0
   if ! fm_backlog_directory_present "$STATE" "state directory"; then
     echo "error: backlog reconciliation refused: $FM_BACKLOG_TRANSITION_ERROR" >&2
     return 2
@@ -1323,33 +1326,35 @@ fi
 # sessions never touch state, and the deferred network pass never repeats it:
 # the local pass that ran first already closed that window.
 if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ] && local_phase; then
-  if ! fm_backlog_directory_present "$STATE" "state directory"; then
-    echo "error: bootstrap cannot reconcile task state ($FM_BACKLOG_TRANSITION_ERROR)" >&2
-    exit 1
-  fi
   BOOTSTRAP_BACKLOG_GATE_KIND=secondmate
-  for BOOTSTRAP_BACKLOG_MARKER in "$STATE"/*.backlog-close; do
-    [ -e "$BOOTSTRAP_BACKLOG_MARKER" ] || [ -L "$BOOTSTRAP_BACKLOG_MARKER" ] || continue
-    if ! fm_backlog_record_present "$BOOTSTRAP_BACKLOG_MARKER" "pending-close record" "$STATE"; then
-      echo "error: bootstrap refused unsafe pending close ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+  if [ -e "$STATE" ] || [ -L "$STATE" ]; then
+    if ! fm_backlog_directory_present "$STATE" "state directory"; then
+      echo "error: bootstrap cannot reconcile task state ($FM_BACKLOG_TRANSITION_ERROR)" >&2
       exit 1
     fi
-    BOOTSTRAP_BACKLOG_GATE_KIND=ship
-    break
-  done
-  if [ "$BOOTSTRAP_BACKLOG_GATE_KIND" = secondmate ]; then
-    for BOOTSTRAP_BACKLOG_META in "$STATE"/*.meta; do
-      [ -e "$BOOTSTRAP_BACKLOG_META" ] || [ -L "$BOOTSTRAP_BACKLOG_META" ] || continue
-      if ! fm_backlog_record_present "$BOOTSTRAP_BACKLOG_META" "task record" "$STATE"; then
-        echo "error: bootstrap refused unsafe worker record ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+    for BOOTSTRAP_BACKLOG_MARKER in "$STATE"/*.backlog-close; do
+      [ -e "$BOOTSTRAP_BACKLOG_MARKER" ] || [ -L "$BOOTSTRAP_BACKLOG_MARKER" ] || continue
+      if ! fm_backlog_record_present "$BOOTSTRAP_BACKLOG_MARKER" "pending-close record" "$STATE"; then
+        echo "error: bootstrap refused unsafe pending close ($FM_BACKLOG_TRANSITION_ERROR)" >&2
         exit 1
       fi
-      if [ "$(fm_meta_get "$BOOTSTRAP_BACKLOG_META" kind)" != secondmate ] \
-         && [ "$(fm_meta_get "$BOOTSTRAP_BACKLOG_META" cleanup_recovery)" != orca ]; then
-        BOOTSTRAP_BACKLOG_GATE_KIND=ship
-        break
-      fi
+      BOOTSTRAP_BACKLOG_GATE_KIND=ship
+      break
     done
+    if [ "$BOOTSTRAP_BACKLOG_GATE_KIND" = secondmate ]; then
+      for BOOTSTRAP_BACKLOG_META in "$STATE"/*.meta; do
+        [ -e "$BOOTSTRAP_BACKLOG_META" ] || [ -L "$BOOTSTRAP_BACKLOG_META" ] || continue
+        if ! fm_backlog_record_present "$BOOTSTRAP_BACKLOG_META" "task record" "$STATE"; then
+          echo "error: bootstrap refused unsafe worker record ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+          exit 1
+        fi
+        if [ "$(fm_meta_get "$BOOTSTRAP_BACKLOG_META" kind)" != secondmate ] \
+           && [ "$(fm_meta_get "$BOOTSTRAP_BACKLOG_META" cleanup_recovery)" != orca ]; then
+          BOOTSTRAP_BACKLOG_GATE_KIND=ship
+          break
+        fi
+      done
+    fi
   fi
   if fm_backlog_transition_applies "$CONFIG" "$DATA" "$BOOTSTRAP_BACKLOG_GATE_KIND"; then
     :

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1282,7 +1282,7 @@ backlog_record_reconcile() {
       # Heal only the unambiguous case: a queued row for a record this home
       # already owns. A held row is the captain's to move, and a closed row is a
       # contradiction this sweep must not resolve by resurrecting the item.
-      if [ "$row" = "queued no" ]; then
+      if [ "$row" = "queued no no" ]; then
         if fm_backlog_start "$DATA" "$id"; then
           echo "BOOTSTRAP_INFO: marked $id in flight to match the worker this home already owns"
         else

--- a/bin/fm-secondmate-reconcile.sh
+++ b/bin/fm-secondmate-reconcile.sh
@@ -6,6 +6,13 @@
 #   fm-secondmate-reconcile.sh notify [--snapshot <file>|-]
 #   fm-secondmate-reconcile.sh nudged <mate-id>
 #
+# This is a BACKSTOP, not the primary mechanism. Dispatch and completion pair
+# the backlog row with the task's record inside the one script that moves the
+# record, and each home reconciles its own books at session start
+# (bin/fm-backlog-transition-lib.sh), so what reaches here is what neither could
+# see: a home that has not restarted since it drifted, or one still running
+# older code.
+#
 # A backlog-vs-metadata inventory mismatch inside a secondmate home
 # (orphan_in_flight, unowned_current, terminal_in_flight) no longer makes that
 # home unreadable: bin/fm-fleet-snapshot.sh keeps its decisions, queued, landed,

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -19,7 +19,7 @@
 # standalone with unchanged default behavior - other flows (fm-bootstrap.sh
 # install <tools> after consent, /updatefirstmate, the afk daemon, existing
 # tests) still call them directly. The one seam this script needed -
-# bootstrap running its detect-only diagnostics without its five mutating
+# bootstrap running its detect-only diagnostics without its six mutating
 # sweeps - is an opt-in FM_BOOTSTRAP_DETECT_ONLY=1 flag on fm-bootstrap.sh
 # itself (default unset/0 = unchanged behavior), not a fork.
 #
@@ -30,8 +30,9 @@
 #                       mutating step runs.
 #   2. bootstrap      - home-local stale Herdr projection cleanup runs only
 #                       when this session actually holds the lock. Detect-only
-#                       diagnostics always run. Bootstrap's five MUTATING sweeps
-#                       (secondmate convergence, secondmate liveness, pending remote
+#                       diagnostics always run. Bootstrap's six MUTATING sweeps
+#                       (same-home backlog reconciliation,
+#                       secondmate convergence, secondmate liveness, pending remote
 #                       handoff retry, X-mode artifact writes, fleet sync) also run only when
 #                       locked; the four network sweeps run in the deferred
 #                       stage rather than this synchronous bootstrap section.
@@ -115,7 +116,7 @@
 # and all of which are safe to compute without verified lock ownership.
 # It deliberately skips the network-only GitHub-auth probe because a read-only
 # session has no dispatch, spawn, steer, or merge action for that verdict to gate.
-# Only projection cleanup, the five bootstrap mutating sweeps, and wake-queue
+# Only projection cleanup, the six bootstrap mutating sweeps, and wake-queue
 # presentation are skipped.
 # The context and fleet-state digests
 # below are always read-only, so they run unconditionally in both modes.
@@ -188,9 +189,10 @@
 #   --reemit  This process ALREADY took the helm at its own startup and has
 #             only lost its context (a /clear or a compaction). Skip the
 #             mutating sweeps that startup already reconciled - the stale Herdr
-#             projection cleanup and bootstrap's five mutating sweeps (fleet
-#             sync, secondmate convergence and liveness,
-#             pending remote handoff retry, X-mode artifact writes) - and
+#             projection cleanup and bootstrap's six mutating sweeps (fleet
+#             sync, same-home backlog reconciliation, secondmate convergence and
+#             liveness, pending remote handoff retry, X-mode
+#             artifact writes) - and
 #             re-emit the rest. Wake-queue presentation is NOT skipped: queued
 #             records are this turn's work queue, they arrived after startup,
 #             and a session that owns the lock is exactly the session that must

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -195,8 +195,9 @@
 # backlog does not own. A relaunch re-reads the row instead of re-running the
 # transition, so an already In-flight item is left untouched. The transition is
 # skipped entirely for --secondmate spawns (persistent agents are not work
-# items), on a config/backlog-backend=manual home, without a compatible
-# tasks-axi, and in a home that keeps no data/backlog.md.
+# items), on a config/backlog-backend=manual home, and in a home that keeps no
+# data/backlog.md. An automatic-backend home with a backlog but no compatible
+# tasks-axi refuses before creating any lifecycle state.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> [mode=<mode> yolo=<on|off>] window=<backend-target> worktree=<path>
 # A ship task records the explicit mode/yolo it was passed; a secondmate spawn records
 # mode=secondmate, yolo=off, home=, and projects=; a scout records neither, and both the

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -185,6 +185,18 @@
 # resolver because `cursor` is not the CLI name. A cursor SECONDMATE instead runs
 # the tracked project-scope .cursor/hooks.json in its own home, whose stop-hook
 # park owns that home's supervision (docs/supervision-protocols/cursor.md).
+# Publishing the record and moving this home's backlog item to In flight are one
+# step, not two: bin/fm-backlog-transition-lib.sh owns that invariant, and this
+# script performs the transition under the task's own meta lock before it reports
+# success. A ship or scout dispatch therefore REFUSES up front, before any
+# endpoint, worktree, or record exists, when the home's backlog has no item for
+# the id or already records it as finished, and a transition that fails after
+# publication removes the record it just wrote rather than leaving a worker the
+# backlog does not own. A relaunch re-reads the row instead of re-running the
+# transition, so an already In-flight item is left untouched. The transition is
+# skipped entirely for --secondmate spawns (persistent agents are not work
+# items), on a config/backlog-backend=manual home, without a compatible
+# tasks-axi, and in a home that keeps no data/backlog.md.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> [mode=<mode> yolo=<on|off>] window=<backend-target> worktree=<path>
 # A ship task records the explicit mode/yolo it was passed; a secondmate spawn records
 # mode=secondmate, yolo=off, home=, and projects=; a scout records neither, and both the
@@ -221,8 +233,18 @@ esac
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 
+# shellcheck source=bin/fm-tasks-axi-lib.sh
+. "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-backlog-transition-lib.sh
+. "$SCRIPT_DIR/fm-backlog-transition-lib.sh"
+
 resolve_directory_input() {
-  local name=$1 path=$2 resolved
+  local name=$1 path=$2 resolved raw_bytes
+  raw_bytes=$(printf '%s' "$path" | LC_ALL=C od -An -t u1) || return 1
+  if ! fm_backlog_control_bytes_valid 0 "$raw_bytes"; then
+    echo "error: $name directory contains an invalid control byte" >&2
+    return 1
+  fi
   case "$path" in
     /*) printf '%s\n' "$path"; return 0 ;;
   esac
@@ -673,6 +695,7 @@ SPAWN_META_TMP=
 SPAWN_META_LOCK=
 SPAWN_META_LOCK_HELD=0
 SPAWN_META_PUBLISH_STARTED=0
+SPAWN_FRESH_COMMIT_PENDING=0
 SPAWN_TASK_SET_LOCK=
 SPAWN_TASK_SET_LOCK_HELD=0
 RELAUNCH_REPLACEMENT_PENDING=0
@@ -682,6 +705,16 @@ RELAUNCH_REPLACEMENT_STATE=
 RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
+
+spawn_fresh_commit_rollback() {
+  if fm_backlog_atomic_transition rollback "$STATE/$ID.meta" \
+      "$FM_ROOT/bin/fm-busy-event.sh" "$STATE" "$ID" "${BUSY_GEN:-}"; then
+    SPAWN_FRESH_COMMIT_PENDING=0
+    return 0
+  fi
+  echo "error: $FM_BACKLOG_TRANSITION_ERROR" >&2
+  return 1
+}
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -751,10 +784,19 @@ spawn_abort_cleanup() {
     fi
     if [ -n "${ORCA_WORKTREE_ID:-}" ]; then
       if ! fm_backend_remove_worktree orca "$ORCA_WORKTREE_ID" 2>/dev/null; then
+        if [ "$SPAWN_FRESH_COMMIT_PENDING" = 1 ]; then
+          if ! spawn_fresh_commit_rollback; then
+            status=1
+          fi
+          SPAWN_FRESH_COMMIT_PENDING=0
+        fi
         mkdir -p "$STATE" 2>/dev/null || true
         if [ -d "$STATE" ]; then
+          SPAWN_META_TMP="$STATE/.$ID.meta.orca-recovery.${BASHPID:-$$}"
           {
             echo "window=$W"
+            echo "endpoint_task_id=$ID"
+            echo "cleanup_recovery=orca"
             echo "worktree=${WT:-}"
             echo "project=$PROJ_ABS"
             echo "harness=$HARNESS"
@@ -767,7 +809,9 @@ spawn_abort_cleanup() {
             echo "backend=orca"
             echo "orca_worktree_id=$ORCA_WORKTREE_ID"
             [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
-          } > "$STATE/$ID.meta" 2>/dev/null || true
+          } > "$SPAWN_META_TMP" 2>/dev/null \
+            && fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record" \
+            || true
         fi
       fi
     fi
@@ -775,6 +819,11 @@ spawn_abort_cleanup() {
   if [ "$SPAWN_TASK_LOCK_HELD" = 1 ]; then
     SPAWN_TASK_LOCK_HELD=0
     fm_lock_release "$SPAWN_TASK_LOCK" || true
+  fi
+  if [ "$SPAWN_FRESH_COMMIT_PENDING" = 1 ]; then
+    if ! spawn_fresh_commit_rollback; then
+      status=1
+    fi
   fi
   if [ "$SPAWN_META_LOCK_HELD" = 1 ]; then
     SPAWN_META_LOCK_HELD=0
@@ -1666,7 +1715,7 @@ else
   WT=""
   BRIEF="$DATA/$ID/brief.md"
 fi
-[ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
+[ -f "$BRIEF" ] || { echo "error: task $ID has no brief at inaccessible data path $BRIEF" >&2; exit 1; }
 
 delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task mode
   case "$1" in
@@ -1914,6 +1963,38 @@ herdr_projection_existing_meta_allows_flat() {  # <meta>
       ;;
   esac
 }
+
+# Backlog preflight (bin/fm-backlog-transition-lib.sh). This spawn is about to
+# become the sole owner of the row's In-flight transition, so prove the row is
+# transitionable BEFORE any endpoint, worktree, or record exists: a refusal here
+# costs nothing to unwind, while the same refusal after publication would strand
+# a live pane. The authoritative mutation still runs under the meta lock below.
+BACKLOG_TRANSITION=0
+BACKLOG_ROW_STATE=
+if fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
+  BACKLOG_TRANSITION=1
+  if fm_backlog_row_probe "$DATA" "$ID"; then
+    BACKLOG_ROW_STATE=$FM_BACKLOG_ROW_STATE
+  elif [ "$FM_BACKLOG_ROW_RESULT" = not_found ]; then
+    echo "error: task $ID has no backlog item in this home, so dispatching it would leave a worker no record owns; add it first (tasks-axi add $ID '<title>' --kind $KIND) and re-run" >&2
+    exit 1
+  else
+    echo "error: task $ID's backlog item could not be read before dispatch ($FM_BACKLOG_ROW_ERROR)" >&2
+    exit 1
+  fi
+  case "$BACKLOG_ROW_STATE" in
+    done\ *)
+      echo "error: this home's backlog records $ID as finished; refusing to dispatch onto a closed item (reopen it with tasks-axi reopen $ID, or use a new task id)" >&2
+      exit 1
+      ;;
+  esac
+else
+  BACKLOG_GATE_STATUS=$?
+  if [ "$BACKLOG_GATE_STATUS" -eq 2 ]; then
+    echo "error: task $ID cannot be dispatched because its backlog data directory is inaccessible: $DATA ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+    exit 1
+  fi
+fi
 
 W="fm-$ID"
 if [ "$RELAUNCH" -eq 1 ]; then
@@ -2692,13 +2773,16 @@ META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
 SPAWN_GEN="s$(date +%s).${BASHPID:-$$}.$RANDOM"
 SPAWN_META_PATH="$STATE/$ID.meta"
+SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
+fm_lock_acquire_wait "$SPAWN_META_LOCK"
+SPAWN_META_LOCK_HELD=1
 if [ "$RELAUNCH" -eq 1 ]; then
-  SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
-  fm_lock_acquire_wait "$SPAWN_META_LOCK"
-  SPAWN_META_LOCK_HELD=1
   SPAWN_META_TMP="$STATE/.$ID.meta.relaunch.${BASHPID:-$$}"
-  SPAWN_META_PATH=$SPAWN_META_TMP
+else
+  SPAWN_META_TMP="$STATE/.$ID.meta.spawn.${BASHPID:-$$}"
+  SPAWN_FRESH_COMMIT_PENDING=1
 fi
+SPAWN_META_PATH=$SPAWN_META_TMP
 preserve_relaunch_meta() {
   awk -F= '
     BEGIN {
@@ -2756,16 +2840,44 @@ preserve_relaunch_meta() {
   if [ "$SPAWN_CONTROL_PARENT" = 1 ] && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ]; then
     echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
   fi
-} > "$SPAWN_META_PATH"
+} > "$SPAWN_META_PATH" || {
+  echo "error: task record for $ID could not be prepared at $SPAWN_META_PATH" >&2
+  exit 1
+}
+if [ "$RELAUNCH" -eq 0 ]; then
+  if ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record"; then
+    echo "error: task record for $ID could not be published ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+    exit 1
+  fi
+  SPAWN_META_TMP=
+fi
+
+# Fuse the backlog In-flight transition into the publication that just created
+# the record (bin/fm-backlog-transition-lib.sh owns the invariant). It runs under
+# this task's own meta lock, so a steer or teardown racing the same id stays
+# serialized exactly as before. The call itself is deferred to the final commit
+# point below so every earlier launch-delivery failure remains unwindable.
+spawn_commit_backlog_transition() {
+  [ "$BACKLOG_TRANSITION" = 1 ] || return 0
+  fm_backlog_atomic_transition dispatch "$STATE/$ID.meta" "$DATA" "$ID"
+}
+
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_PUBLISH_STARTED=1
-  mv -f "$SPAWN_META_TMP" "$STATE/$ID.meta"
+  if ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record"; then
+    echo "error: replacement task record for $ID could not be published ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+    exit 1
+  fi
   RELAUNCH_REPLACEMENT_PENDING=0
   SPAWN_META_PUBLISH_STARTED=0
   SPAWN_META_TMP=
-  fm_lock_release "$SPAWN_META_LOCK"
-  SPAWN_META_LOCK_HELD=0
 fi
+# A dispatch or relaunch keeps the per-task meta lock through launch delivery.
+# The backlog mutation is deliberately the final fallible commit below, so
+# teardown cannot remove a relaunched record while its replacement worker is
+# still being delivered, cannot observe or complete a fresh provisional record
+# between its state check and `tasks-axi start`, and a delivery failure cannot
+# follow a committed In-flight transition.
 if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
   # The record is published, so this task is now part of the set a teardown
   # enumerates and locks per task. The set lock is only needed across that
@@ -2837,21 +2949,28 @@ if [ -z "$SPAWN_TRACEPARENT" ] && [ "$RELAUNCH" -eq 1 ]; then
 fi
 
 spawn_record_traceparent() {
-  local meta="$STATE/$ID.meta" tmp status=0
-  SPAWN_META_LOCK=$(fm_meta_lock_path "$meta") || return 1
-  fm_lock_acquire_wait "$SPAWN_META_LOCK"
-  SPAWN_META_LOCK_HELD=1
+  local meta="$STATE/$ID.meta" status=0 acquired=0
+  # Fresh publication still owns the lock. Relaunch deliberately uses a short
+  # independent critical section so other metadata interfaces can serialize.
+  if [ "$SPAWN_META_LOCK_HELD" != 1 ]; then
+    SPAWN_META_LOCK=$(fm_meta_lock_path "$meta") || return 1
+    fm_lock_acquire_wait "$SPAWN_META_LOCK"
+    SPAWN_META_LOCK_HELD=1
+    acquired=1
+  fi
   SPAWN_META_TMP="$STATE/.$ID.meta.trace.${BASHPID:-$$}"
   if [ ! -f "$meta" ] || [ ! -w "$meta" ] \
      || ! awk -F= '$1 != "traceparent"' "$meta" > "$SPAWN_META_TMP" \
      || ! printf 'traceparent=%s\n' "$SPAWN_TRACEPARENT" >> "$SPAWN_META_TMP" \
-     || ! mv -f "$SPAWN_META_TMP" "$meta"; then
+     || ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$meta" "task record"; then
     status=1
     rm -f "$SPAWN_META_TMP" 2>/dev/null || true
   fi
   SPAWN_META_TMP=
-  fm_lock_release "$SPAWN_META_LOCK" || status=1
-  SPAWN_META_LOCK_HELD=0
+  if [ "$acquired" = 1 ]; then
+    fm_lock_release "$SPAWN_META_LOCK" || status=1
+    SPAWN_META_LOCK_HELD=0
+  fi
   return "$status"
 }
 
@@ -2883,29 +3002,41 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   HERDR_PROJECTION_ABORT_CLEANUP=0
   spawn_herdr_presentation_order_lock_release
 fi
+SPAWN_DEFERRED_SIGNAL=
+if [ "$BACKLOG_TRANSITION" = 1 ]; then
+  trap 'SPAWN_DEFERRED_SIGNAL=HUP' HUP
+  trap 'SPAWN_DEFERRED_SIGNAL=INT' INT
+  trap 'SPAWN_DEFERRED_SIGNAL=TERM' TERM
+fi
 spawn_send_key "$T" Enter
 if [ "$HARNESS" = kimi ]; then
+  KIMI_DELIVERY_FAILED=0
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"
-    exit 1
+    [ -n "$SPAWN_DEFERRED_SIGNAL" ] || exit 1
+    KIMI_DELIVERY_FAILED=1
   fi
-  KIMI_POINTER="Read the brief at $BRIEF_REAL and follow it exactly."
-  KIMI_SUBMIT_RETRIES=${FM_KIMI_SUBMIT_RETRIES:-3}
-  KIMI_SUBMIT_SLEEP=${FM_KIMI_SUBMIT_SLEEP:-${FM_KIMI_POLL_INTERVAL:-0.5}}
-  KIMI_SUBMIT_SETTLE=${FM_KIMI_SUBMIT_SETTLE:-0}
-  KIMI_SUBMIT_VERDICT=$(fm_backend_send_text_submit \
-    "$BACKEND" "$T" "$KIMI_POINTER" "$KIMI_SUBMIT_RETRIES" \
-    "$KIMI_SUBMIT_SLEEP" "$KIMI_SUBMIT_SETTLE" "$W") || {
-    kimi_spawn_fail "kimi brief pointer could not be submitted"
-    exit 1
-  }
-  if [ "$KIMI_SUBMIT_VERDICT" = send-failed ]; then
-    kimi_spawn_fail "kimi brief pointer could not be submitted"
-    exit 1
+  if [ "$KIMI_DELIVERY_FAILED" = 0 ]; then
+    KIMI_POINTER="Read the brief at $BRIEF_REAL and follow it exactly."
+    KIMI_SUBMIT_RETRIES=${FM_KIMI_SUBMIT_RETRIES:-3}
+    KIMI_SUBMIT_SLEEP=${FM_KIMI_SUBMIT_SLEEP:-${FM_KIMI_POLL_INTERVAL:-0.5}}
+    KIMI_SUBMIT_SETTLE=${FM_KIMI_SUBMIT_SETTLE:-0}
+    if ! KIMI_SUBMIT_VERDICT=$(fm_backend_send_text_submit \
+        "$BACKEND" "$T" "$KIMI_POINTER" "$KIMI_SUBMIT_RETRIES" \
+        "$KIMI_SUBMIT_SLEEP" "$KIMI_SUBMIT_SETTLE" "$W"); then
+      kimi_spawn_fail "kimi brief pointer could not be submitted"
+      [ -n "$SPAWN_DEFERRED_SIGNAL" ] || exit 1
+      KIMI_DELIVERY_FAILED=1
+    fi
   fi
-  if ! kimi_wait_for_delivery; then
+  if [ "$KIMI_DELIVERY_FAILED" = 0 ] && [ "$KIMI_SUBMIT_VERDICT" = send-failed ]; then
+    kimi_spawn_fail "kimi brief pointer could not be submitted"
+    [ -n "$SPAWN_DEFERRED_SIGNAL" ] || exit 1
+    KIMI_DELIVERY_FAILED=1
+  fi
+  if [ "$KIMI_DELIVERY_FAILED" = 0 ] && ! kimi_wait_for_delivery; then
     kimi_spawn_fail "kimi brief pointer delivery was not confirmed"
-    exit 1
+    [ -n "$SPAWN_DEFERRED_SIGNAL" ] || exit 1
   fi
 fi
 if [ "$KIND" = secondmate ] && [ "${FM_SKIP_SECONDMATE_INHERIT:-0}" != 1 ]; then
@@ -2916,6 +3047,51 @@ if [ "$KIND" = secondmate ] && [ "${FM_SKIP_SECONDMATE_INHERIT:-0}" != 1 ]; then
       echo "CONFIG_REREAD: secondmate $ID: cleanup failed; pre-relaunch generations were force-cleared where possible (destination=$PROJ_ABS source=$FM_HOME)" >&2
     fi
   fi
+fi
+
+# This is the commit point: all endpoint and harness delivery that can reject
+# the spawn has succeeded. Re-read and transition while holding the same
+# per-task lock as metadata publication, then and only then report success.
+if [ "$SPAWN_META_LOCK_HELD" != 1 ]; then
+  SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
+  fm_lock_acquire_wait "$SPAWN_META_LOCK"
+  SPAWN_META_LOCK_HELD=1
+fi
+SPAWN_BACKLOG_COMMIT_STATUS=0
+if spawn_commit_backlog_transition; then
+  SPAWN_FRESH_COMMIT_PENDING=0
+else
+  SPAWN_BACKLOG_COMMIT_STATUS=$?
+  if spawn_commit_backlog_transition; then
+    SPAWN_BACKLOG_COMMIT_STATUS=0
+    SPAWN_FRESH_COMMIT_PENDING=0
+  fi
+fi
+if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -ne 0 ]; then
+  if [ "$RELAUNCH" -eq 0 ]; then
+    if spawn_fresh_commit_rollback; then
+      echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); its record was removed so no worker is left that the backlog does not own - close out endpoint $T and local copy $WT by hand, then re-run the spawn" >&2
+    else
+      echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR), and failed-dispatch cleanup is incomplete; the provisional record may remain at $STATE/$ID.meta - close out endpoint $T and local copy $WT by hand, then remove the record and busy state before retrying" >&2
+    fi
+  else
+    echo "error: task $ID was republished but its backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); fix the backlog and re-run the relaunch" >&2
+  fi
+fi
+trap - HUP INT TERM
+if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -ne 0 ]; then
+  exit "$SPAWN_BACKLOG_COMMIT_STATUS"
+fi
+fm_lock_release "$SPAWN_META_LOCK"
+SPAWN_META_LOCK_HELD=0
+if [ -n "$SPAWN_DEFERRED_SIGNAL" ]; then
+  case "$SPAWN_DEFERRED_SIGNAL" in
+    HUP) SPAWN_DEFERRED_SIGNAL_STATUS=129 ;;
+    INT) SPAWN_DEFERRED_SIGNAL_STATUS=130 ;;
+    TERM) SPAWN_DEFERRED_SIGNAL_STATUS=143 ;;
+  esac
+  echo "error: spawn of $ID was interrupted after launch delivery began; its paired task record and In-flight backlog state were preserved" >&2
+  exit "$SPAWN_DEFERRED_SIGNAL_STATUS"
 fi
 
 SPAWN_DELIVERY=

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1996,14 +1996,12 @@ else
   fi
 fi
 
-if [ "$RELAUNCH" -eq 0 ]; then
-  SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
-  fm_lock_acquire_wait "$SPAWN_META_LOCK"
-  SPAWN_META_LOCK_HELD=1
-  if [ -e "$STATE/$ID.backlog-close" ] || [ -L "$STATE/$ID.backlog-close" ]; then
-    echo "error: task $ID has a pending authoritative backlog close at $STATE/$ID.backlog-close; finish or repair that close before dispatching a new worker" >&2
-    exit 1
-  fi
+SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
+fm_lock_acquire_wait "$SPAWN_META_LOCK"
+SPAWN_META_LOCK_HELD=1
+if [ -e "$STATE/$ID.backlog-close" ] || [ -L "$STATE/$ID.backlog-close" ]; then
+  echo "error: task $ID has a pending authoritative backlog close at $STATE/$ID.backlog-close; finish or repair that close before dispatching a new worker" >&2
+  exit 1
 fi
 
 W="fm-$ID"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2028,9 +2028,11 @@ else
   fi
 fi
 
-SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
-fm_lock_acquire_wait "$SPAWN_META_LOCK"
-SPAWN_META_LOCK_HELD=1
+if [ "$SPAWN_META_LOCK_HELD" != 1 ]; then
+  SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
+  fm_lock_acquire_wait "$SPAWN_META_LOCK"
+  SPAWN_META_LOCK_HELD=1
+fi
 if [ -e "$STATE/$ID.backlog-close" ] || [ -L "$STATE/$ID.backlog-close" ]; then
   echo "error: task $ID has a pending authoritative backlog close at $STATE/$ID.backlog-close; finish or repair that close before dispatching a new worker" >&2
   exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2776,6 +2776,11 @@ SPAWN_META_PATH="$STATE/$ID.meta"
 SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
 fm_lock_acquire_wait "$SPAWN_META_LOCK"
 SPAWN_META_LOCK_HELD=1
+if [ "$RELAUNCH" -eq 0 ] \
+   && { [ -e "$STATE/$ID.backlog-close" ] || [ -L "$STATE/$ID.backlog-close" ]; }; then
+  echo "error: task $ID has a pending authoritative backlog close at $STATE/$ID.backlog-close; finish or repair that close before dispatching a new worker" >&2
+  exit 1
+fi
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_TMP="$STATE/.$ID.meta.relaunch.${BASHPID:-$$}"
 else
@@ -3002,41 +3007,29 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   HERDR_PROJECTION_ABORT_CLEANUP=0
   spawn_herdr_presentation_order_lock_release
 fi
-SPAWN_DEFERRED_SIGNAL=
-if [ "$BACKLOG_TRANSITION" = 1 ]; then
-  trap 'SPAWN_DEFERRED_SIGNAL=HUP' HUP
-  trap 'SPAWN_DEFERRED_SIGNAL=INT' INT
-  trap 'SPAWN_DEFERRED_SIGNAL=TERM' TERM
-fi
 spawn_send_key "$T" Enter
 if [ "$HARNESS" = kimi ]; then
-  KIMI_DELIVERY_FAILED=0
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"
-    [ -n "$SPAWN_DEFERRED_SIGNAL" ] || exit 1
-    KIMI_DELIVERY_FAILED=1
+    exit 1
   fi
-  if [ "$KIMI_DELIVERY_FAILED" = 0 ]; then
-    KIMI_POINTER="Read the brief at $BRIEF_REAL and follow it exactly."
-    KIMI_SUBMIT_RETRIES=${FM_KIMI_SUBMIT_RETRIES:-3}
-    KIMI_SUBMIT_SLEEP=${FM_KIMI_SUBMIT_SLEEP:-${FM_KIMI_POLL_INTERVAL:-0.5}}
-    KIMI_SUBMIT_SETTLE=${FM_KIMI_SUBMIT_SETTLE:-0}
-    if ! KIMI_SUBMIT_VERDICT=$(fm_backend_send_text_submit \
-        "$BACKEND" "$T" "$KIMI_POINTER" "$KIMI_SUBMIT_RETRIES" \
-        "$KIMI_SUBMIT_SLEEP" "$KIMI_SUBMIT_SETTLE" "$W"); then
-      kimi_spawn_fail "kimi brief pointer could not be submitted"
-      [ -n "$SPAWN_DEFERRED_SIGNAL" ] || exit 1
-      KIMI_DELIVERY_FAILED=1
-    fi
-  fi
-  if [ "$KIMI_DELIVERY_FAILED" = 0 ] && [ "$KIMI_SUBMIT_VERDICT" = send-failed ]; then
+  KIMI_POINTER="Read the brief at $BRIEF_REAL and follow it exactly."
+  KIMI_SUBMIT_RETRIES=${FM_KIMI_SUBMIT_RETRIES:-3}
+  KIMI_SUBMIT_SLEEP=${FM_KIMI_SUBMIT_SLEEP:-${FM_KIMI_POLL_INTERVAL:-0.5}}
+  KIMI_SUBMIT_SETTLE=${FM_KIMI_SUBMIT_SETTLE:-0}
+  if ! KIMI_SUBMIT_VERDICT=$(fm_backend_send_text_submit \
+      "$BACKEND" "$T" "$KIMI_POINTER" "$KIMI_SUBMIT_RETRIES" \
+      "$KIMI_SUBMIT_SLEEP" "$KIMI_SUBMIT_SETTLE" "$W"); then
     kimi_spawn_fail "kimi brief pointer could not be submitted"
-    [ -n "$SPAWN_DEFERRED_SIGNAL" ] || exit 1
-    KIMI_DELIVERY_FAILED=1
+    exit 1
   fi
-  if [ "$KIMI_DELIVERY_FAILED" = 0 ] && ! kimi_wait_for_delivery; then
+  if [ "$KIMI_SUBMIT_VERDICT" = send-failed ]; then
+    kimi_spawn_fail "kimi brief pointer could not be submitted"
+    exit 1
+  fi
+  if ! kimi_wait_for_delivery; then
     kimi_spawn_fail "kimi brief pointer delivery was not confirmed"
-    [ -n "$SPAWN_DEFERRED_SIGNAL" ] || exit 1
+    exit 1
   fi
 fi
 if [ "$KIND" = secondmate ] && [ "${FM_SKIP_SECONDMATE_INHERIT:-0}" != 1 ]; then
@@ -3056,6 +3049,12 @@ if [ "$SPAWN_META_LOCK_HELD" != 1 ]; then
   SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
   fm_lock_acquire_wait "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=1
+fi
+SPAWN_DEFERRED_SIGNAL=
+if [ "$BACKLOG_TRANSITION" = 1 ]; then
+  trap 'SPAWN_DEFERRED_SIGNAL=HUP' HUP
+  trap 'SPAWN_DEFERRED_SIGNAL=INT' INT
+  trap 'SPAWN_DEFERRED_SIGNAL=TERM' TERM
 fi
 SPAWN_BACKLOG_COMMIT_STATUS=0
 if spawn_commit_backlog_transition; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -267,10 +267,20 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 SUB_HOME_MARKER=".fm-secondmate-home"
+if [ -e "$STATE" ] || [ -L "$STATE" ]; then
+  fm_backlog_directory_present "$STATE" "state directory" || {
+    echo "error: spawn refused: $FM_BACKLOG_TRANSITION_ERROR" >&2
+    exit 1
+  }
+fi
 # shellcheck source=bin/fm-ff-lib.sh
 . "$SCRIPT_DIR/fm-ff-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+fm_backlog_directory_present "$STATE" "state directory" || {
+  echo "error: spawn refused: $FM_BACKLOG_TRANSITION_ERROR" >&2
+  exit 1
+}
 # shellcheck source=bin/fm-secondmate-nudge-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-nudge-lib.sh"
 # shellcheck source=bin/fm-config-inherit-lib.sh
@@ -946,6 +956,15 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
 fi
 ID=${POS[0]}
 fm_task_id_creation_valid "$ID" || { echo "error: invalid task id" >&2; exit 2; }
+if [ -e "$STATE" ] || [ -L "$STATE" ]; then
+  fm_backlog_directory_present "$STATE" "state directory" || {
+    echo "error: spawn refused: $FM_BACKLOG_TRANSITION_ERROR" >&2
+    exit 1
+  }
+elif [ "$RELAUNCH" -eq 1 ]; then
+  echo "error: spawn refused: state directory does not exist at $STATE" >&2
+  exit 1
+fi
 # Role partition: spawning NEW work is MAIN-owned. A relaunch of an existing
 # task is legitimate branch recovery (fm-control drives it through this same
 # entrypoint), so only a fresh spawn refuses the branch actor (contract:
@@ -976,6 +995,10 @@ fi
 if [ "$RELAUNCH" -eq 0 ]; then
   mkdir -p "$STATE" || {
     echo "error: could not create parent state directory" >&2
+    exit 1
+  }
+  fm_backlog_directory_present "$STATE" "state directory" || {
+    echo "error: spawn refused: $FM_BACKLOG_TRANSITION_ERROR" >&2
     exit 1
   }
   # A FRESH spawn changes which tasks this home has, so it must not interleave
@@ -1060,8 +1083,19 @@ if [ "$RELAUNCH" -eq 1 ]; then
     exit 1
   }
   RELAUNCH_META="$STATE/$ID.meta"
-  [ -f "$RELAUNCH_META" ] || {
+  if [ ! -e "$RELAUNCH_META" ] && [ ! -L "$RELAUNCH_META" ]; then
     echo "error: --relaunch needs an existing task record; no $RELAUNCH_META" >&2
+    exit 1
+  fi
+  fm_backlog_record_present "$RELAUNCH_META" "task record" || {
+    echo "error: --relaunch refused: $FM_BACKLOG_TRANSITION_ERROR" >&2
+    exit 1
+  }
+  SPAWN_META_LOCK=$(fm_meta_lock_path "$RELAUNCH_META") || exit 1
+  fm_lock_acquire_wait "$SPAWN_META_LOCK"
+  SPAWN_META_LOCK_HELD=1
+  fm_backlog_record_present "$RELAUNCH_META" "task record" || {
+    echo "error: --relaunch refused after locking: $FM_BACKLOG_TRANSITION_ERROR" >&2
     exit 1
   }
   fm_backend_validate_task_endpoint "$RELAUNCH_META" "$ID" || exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -524,7 +524,7 @@ spawn_remote_secondmate() {
   esac
   meta="$STATE/$id.meta"
   if [ -e "$meta" ] || [ -L "$meta" ]; then
-    if [ ! -f "$meta" ] || [ -L "$meta" ] \
+    if ! fm_backlog_record_present "$meta" "task record" "$STATE" \
       || [ "$(fm_meta_get "$meta" kind)" != secondmate ] \
       || [ "$(fm_meta_get "$meta" remote_host)" != "$host" ] \
       || [ "$(fm_meta_get "$meta" remote_root)" != "$root" ] \
@@ -820,7 +820,7 @@ spawn_abort_cleanup() {
             echo "orca_worktree_id=$ORCA_WORKTREE_ID"
             [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
           } > "$SPAWN_META_TMP" 2>/dev/null \
-            && fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record" \
+            && fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record" "$STATE" \
             || true
         fi
       fi
@@ -1087,14 +1087,14 @@ if [ "$RELAUNCH" -eq 1 ]; then
     echo "error: --relaunch needs an existing task record; no $RELAUNCH_META" >&2
     exit 1
   fi
-  fm_backlog_record_present "$RELAUNCH_META" "task record" || {
+  fm_backlog_record_present "$RELAUNCH_META" "task record" "$STATE" || {
     echo "error: --relaunch refused: $FM_BACKLOG_TRANSITION_ERROR" >&2
     exit 1
   }
   SPAWN_META_LOCK=$(fm_meta_lock_path "$RELAUNCH_META") || exit 1
   fm_lock_acquire_wait "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=1
-  fm_backlog_record_present "$RELAUNCH_META" "task record" || {
+  fm_backlog_record_present "$RELAUNCH_META" "task record" "$STATE" || {
     echo "error: --relaunch refused after locking: $FM_BACKLOG_TRANSITION_ERROR" >&2
     exit 1
   }
@@ -1680,7 +1680,11 @@ validate_firstmate_operational_dirs() {
 }
 
 if [ "$KIND" = secondmate ]; then
-  if [ -z "$FIRSTMATE_HOME" ] && [ -f "$STATE/$ID.meta" ]; then
+  if [ -z "$FIRSTMATE_HOME" ] && { [ -e "$STATE/$ID.meta" ] || [ -L "$STATE/$ID.meta" ]; }; then
+    fm_backlog_record_present "$STATE/$ID.meta" "task record" "$STATE" || {
+      echo "error: secondmate task record is unsafe: $FM_BACKLOG_TRANSITION_ERROR" >&2
+      exit 1
+    }
     FIRSTMATE_HOME=$(grep '^home=' "$STATE/$ID.meta" | cut -d= -f2- || true)
   fi
   if [ -z "$FIRSTMATE_HOME" ]; then
@@ -2889,7 +2893,7 @@ preserve_relaunch_meta() {
   exit 1
 }
 if [ "$RELAUNCH" -eq 0 ]; then
-  if ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record"; then
+  if ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record" "$STATE"; then
     echo "error: task record for $ID could not be published ($FM_BACKLOG_TRANSITION_ERROR)" >&2
     exit 1
   fi
@@ -2903,12 +2907,12 @@ fi
 # point below so every earlier launch-delivery failure remains unwindable.
 spawn_commit_backlog_transition() {
   [ "$BACKLOG_TRANSITION" = 1 ] || return 0
-  fm_backlog_atomic_transition dispatch "$STATE/$ID.meta" "$DATA" "$ID"
+  fm_backlog_atomic_transition dispatch "$STATE/$ID.meta" "$DATA" "$ID" "$STATE"
 }
 
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_PUBLISH_STARTED=1
-  if ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record"; then
+  if ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record" "$STATE"; then
     echo "error: replacement task record for $ID could not be published ($FM_BACKLOG_TRANSITION_ERROR)" >&2
     exit 1
   fi
@@ -3006,7 +3010,7 @@ spawn_record_traceparent() {
   if [ ! -f "$meta" ] || [ ! -w "$meta" ] \
      || ! awk -F= '$1 != "traceparent"' "$meta" > "$SPAWN_META_TMP" \
      || ! printf 'traceparent=%s\n' "$SPAWN_TRACEPARENT" >> "$SPAWN_META_TMP" \
-     || ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$meta" "task record"; then
+     || ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$meta" "task record" "$STATE"; then
     status=1
     rm -f "$SPAWN_META_TMP" 2>/dev/null || true
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1996,6 +1996,16 @@ else
   fi
 fi
 
+if [ "$RELAUNCH" -eq 0 ]; then
+  SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
+  fm_lock_acquire_wait "$SPAWN_META_LOCK"
+  SPAWN_META_LOCK_HELD=1
+  if [ -e "$STATE/$ID.backlog-close" ] || [ -L "$STATE/$ID.backlog-close" ]; then
+    echo "error: task $ID has a pending authoritative backlog close at $STATE/$ID.backlog-close; finish or repair that close before dispatching a new worker" >&2
+    exit 1
+  fi
+fi
+
 W="fm-$ID"
 if [ "$RELAUNCH" -eq 1 ]; then
   # Adopt the recorded endpoint instead of creating one. This is what keeps a
@@ -2773,13 +2783,10 @@ META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
 SPAWN_GEN="s$(date +%s).${BASHPID:-$$}.$RANDOM"
 SPAWN_META_PATH="$STATE/$ID.meta"
-SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
-fm_lock_acquire_wait "$SPAWN_META_LOCK"
-SPAWN_META_LOCK_HELD=1
-if [ "$RELAUNCH" -eq 0 ] \
-   && { [ -e "$STATE/$ID.backlog-close" ] || [ -L "$STATE/$ID.backlog-close" ]; }; then
-  echo "error: task $ID has a pending authoritative backlog close at $STATE/$ID.backlog-close; finish or repair that close before dispatching a new worker" >&2
-  exit 1
+if [ "$SPAWN_META_LOCK_HELD" != 1 ]; then
+  SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
+  fm_lock_acquire_wait "$SPAWN_META_LOCK"
+  SPAWN_META_LOCK_HELD=1
 fi
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_TMP="$STATE/.$ID.meta.relaunch.${BASHPID:-$$}"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1982,12 +1982,10 @@ if fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
     echo "error: task $ID's backlog item could not be read before dispatch ($FM_BACKLOG_ROW_ERROR)" >&2
     exit 1
   fi
-  case "$BACKLOG_ROW_STATE" in
-    done\ *)
-      echo "error: this home's backlog records $ID as finished; refusing to dispatch onto a closed item (reopen it with tasks-axi reopen $ID, or use a new task id)" >&2
-      exit 1
-      ;;
-  esac
+  if ! fm_backlog_row_dispatchable "$BACKLOG_ROW_STATE"; then
+    echo "error: this home's backlog item $ID is not dispatchable in state $BACKLOG_ROW_STATE; refusing before creating its endpoint or local copy" >&2
+    exit 1
+  fi
 else
   BACKLOG_GATE_STATUS=$?
   if [ "$BACKLOG_GATE_STATUS" -eq 2 ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -241,7 +241,7 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 
 resolve_directory_input() {
   local name=$1 path=$2 resolved raw_bytes
-  raw_bytes=$(printf '%s' "$path" | LC_ALL=C od -An -t u1) || return 1
+  raw_bytes=$(fm_backlog_bytes_of_string "$path") || return 1
   if ! fm_backlog_control_bytes_valid 0 "$raw_bytes"; then
     echo "error: $name directory contains an invalid control byte" >&2
     return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -670,7 +670,17 @@ spawn_remote_secondmate() {
     echo "remote_target=$remote_target"
     [ -z "$remote_recorded_traceparent" ] || echo "traceparent=$remote_recorded_traceparent"
   } > "$tmp"
-  mv -f -- "$tmp" "$meta"
+  if ! fm_backlog_atomic_transition publish "$tmp" "$meta" "task record" "$STATE"; then
+    if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
+      SPAWN_TASK_SET_LOCK_HELD=0
+      fm_lock_release "$SPAWN_TASK_SET_LOCK" || true
+    fi
+    fm_lock_release "$remote_lock" || true
+    fm_lock_release "$registry_lock" || true
+    fm_lock_release "$SPAWN_TASK_LOCK" || true
+    echo "error: remote secondmate $id launched, but its task record could not be published ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+    return 1
+  fi
   if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
     SPAWN_TASK_SET_LOCK_HELD=0
     fm_lock_release "$SPAWN_TASK_SET_LOCK"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -189,11 +189,12 @@
 # step, not two: bin/fm-backlog-transition-lib.sh owns that invariant, and this
 # script performs the transition under the task's own meta lock before it reports
 # success. A ship or scout dispatch therefore REFUSES up front, before any
-# endpoint, worktree, or record exists, when the home's backlog has no item for
-# the id or already records it as finished, and a transition that fails after
-# publication removes the record it just wrote rather than leaving a worker the
-# backlog does not own. A relaunch re-reads the row instead of re-running the
-# transition, so an already In-flight item is left untouched. The transition is
+# endpoint, worktree, or record exists, unless the home's backlog has an
+# unheld, unblocked Queued or In flight item for the id; a transition that fails
+# after publication removes the record it just wrote rather than leaving a
+# worker the backlog does not own. A relaunch re-reads the row instead of
+# re-running the transition, so an eligible In-flight item is left untouched.
+# The transition is
 # skipped entirely for --secondmate spawns (persistent agents are not work
 # items), on a config/backlog-backend=manual home, and in a home that keeps no
 # data/backlog.md. An automatic-backend home with a backlog but no compatible

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -14,8 +14,9 @@
 # the next session start enough to finish it; a landed close removes that record.
 # A close that fails is fatal and loud, preserves its pending-close record, and
 # is retried by the next session start. The transition is skipped on a
-# config/backlog-backend=manual home, without a compatible tasks-axi, and in a
-# home that keeps no data/backlog.md; those cases print the manual follow-up.
+# config/backlog-backend=manual home and in a home that keeps no
+# data/backlog.md; those cases print the manual follow-up. An automatic-backend
+# home with a backlog but no compatible tasks-axi refuses before cleanup.
 # None of this loosens the landed-work gates below: the transition runs only on
 # the paths that already proceed to remove the record.
 # REFUSES if the worktree holds work that has not LANDED, because cleanup

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2696,7 +2696,7 @@ if [ "$TEARDOWN_BACKLOG_APPLIES" = 1 ]; then
   META_SPAWN_GEN=$TEARDOWN_META_SPAWN_GEN
   fm_backlog_close_marker_write "$STATE" "$ID" "$DATA" "$META_SPAWN_GEN" \
     "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}" \
-    || { echo "error: the pending backlog close for $ID could not be recorded; retaining every durable task record" >&2; exit 1; }
+    || { echo "error: the pending backlog close for $ID could not be recorded ($FM_BACKLOG_TRANSITION_ERROR); retaining every durable task record" >&2; exit 1; }
 else
   if [ "$CLEANUP_RECOVERY" = orca ]; then
     BACKLOG_SKIP_REASON="Orca cleanup recovery is not a launched backlog worker"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -184,8 +184,6 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 # shellcheck source=bin/fm-secondmate-parent-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-parent-lib.sh"
-# shellcheck source=bin/fm-wake-lib.sh
-. "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-pending-reply-lib.sh
 . "$SCRIPT_DIR/fm-pending-reply-lib.sh"
 # shellcheck source=bin/fm-nm-run-lib.sh
@@ -196,6 +194,10 @@ if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
 fi
 ID=$1
 FORCE=${2:-}
+fm_backlog_directory_present "$STATE" "state directory" || {
+  echo "error: teardown refused: $FM_BACKLOG_TRANSITION_ERROR" >&2
+  exit 1
+}
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # Supervision lease guard: post-landing cleanup is overlap territory between
@@ -265,11 +267,17 @@ fm_refuse_if_gate_agent
 FM_LOCK_LOG_PREFIX=teardown
 
 META="$STATE/$ID.meta"
-[ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+fm_backlog_record_present "$META" "task record" || {
+  echo "error: teardown refused: $FM_BACKLOG_TRANSITION_ERROR" >&2
+  exit 1
+}
 META_LOCK=$(fm_meta_lock_path "$META") || exit 1
 fm_lock_acquire_wait "$META_LOCK"
 META_LOCK_HELD=1
-[ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+fm_backlog_record_present "$META" "task record" || {
+  echo "error: teardown refused after locking: $FM_BACKLOG_TRANSITION_ERROR" >&2
+  exit 1
+}
 TEARDOWN_META_KIND=$(fm_meta_get "$META" kind)
 [ -n "$TEARDOWN_META_KIND" ] || TEARDOWN_META_KIND=ship
 TEARDOWN_CLEANUP_RECOVERY=$(fm_meta_get "$META" cleanup_recovery)

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1173,11 +1173,11 @@ backlog_done_args() {
 # invariant). This prints what already happened, so the follow-up wording stays
 # only where a human still owes the edit.
 backlog_refresh_reminder() {
-  local data_relative backlog_display
+  local backlog_display
   [ "$KIND" = secondmate ] && return 0
   [ "$CLEANUP_RECOVERY" = orca ] && return 0
-  if data_relative=$(fm_backlog_data_relative "$DATA"); then
-    backlog_display="$data_relative/backlog.md"
+  if backlog_display=$(fm_backlog_file "$DATA"); then
+    :
   else
     backlog_display="${DATA%/}/backlog.md"
   fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -267,14 +267,14 @@ fm_refuse_if_gate_agent
 FM_LOCK_LOG_PREFIX=teardown
 
 META="$STATE/$ID.meta"
-fm_backlog_record_present "$META" "task record" || {
+fm_backlog_record_present "$META" "task record" "$STATE" || {
   echo "error: teardown refused: $FM_BACKLOG_TRANSITION_ERROR" >&2
   exit 1
 }
 META_LOCK=$(fm_meta_lock_path "$META") || exit 1
 fm_lock_acquire_wait "$META_LOCK"
 META_LOCK_HELD=1
-fm_backlog_record_present "$META" "task record" || {
+fm_backlog_record_present "$META" "task record" "$STATE" || {
   echo "error: teardown refused after locking: $FM_BACKLOG_TRANSITION_ERROR" >&2
   exit 1
 }
@@ -297,7 +297,7 @@ if [ "$TEARDOWN_CLEANUP_RECOVERY" != orca ]; then
   fi
 fi
 if [ "$TEARDOWN_BACKLOG_APPLIES" = 1 ]; then
-  if ! fm_backlog_meta_spawn_gen "$META"; then
+  if ! fm_backlog_meta_spawn_gen "$META" "$STATE"; then
     echo "error: task $ID's record has no spawn_gen that identifies one exact incarnation ($FM_BACKLOG_TRANSITION_ERROR); refusing automatic teardown - relaunch the task to publish an unambiguous incarnation, then retry teardown" >&2
     exit 1
   fi
@@ -682,7 +682,7 @@ remote_secondmate_teardown() {
   grep -vE "^- $ID( |$)" "$SECONDMATE_REG" > "$tmp" || true
   mv -f -- "$tmp" "$SECONDMATE_REG"
   status_retire_presentation_task "$STATE" "$ID" || return 1
-  fm_backlog_atomic_transition remove "$STATE/$ID.meta" "task record" || return 1
+  fm_backlog_atomic_transition remove "$STATE/$ID.meta" "task record" "$STATE" || return 1
   rm -f -- "$STATE/$ID.turn-ended"
   printf 'teardown %s complete (remote %s:%s)\n' "$ID" "$remote_host" "$remote_home"
   return 0
@@ -2534,7 +2534,7 @@ cleanup_firstmate_home_children() {
     fi
     retire_busy_state "$sub_state" "$child_id" "$child_busy_gen" || return 1
     status_retire_presentation_task "$sub_state" "$child_id" || return 1
-    fm_backlog_atomic_transition remove "$sub_state/$child_id.meta" "task record" || return 1
+    fm_backlog_atomic_transition remove "$sub_state/$child_id.meta" "task record" "$sub_state" || return 1
     rm -f "$sub_state/$child_id.turn-ended" \
       "$sub_state/$child_id.pi-ext.ts" \
       "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
@@ -2888,14 +2888,14 @@ rm -rf "$STATE/$ID.inbox"
 if [ "$BACKLOG_CLOSED" = 1 ]; then
   BACKLOG_CLOSE_MARKER=$(fm_backlog_close_marker_path "$STATE" "$ID") || exit 1
   if ! fm_backlog_atomic_transition close "$STATE/$ID.meta" "$BACKLOG_CLOSE_MARKER" \
-      "$DATA" "$ID" "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}"; then
+      "$DATA" "$ID" "$STATE" "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}"; then
     fm_lock_release "$META_LOCK"
     META_LOCK_HELD=0
     echo "error: $ID's endpoint and local copy are cleaned up, but its backlog item could not be closed atomically ($FM_BACKLOG_TRANSITION_ERROR); the pending close is recorded and the next session start retries it" >&2
     exit 1
   fi
 else
-  if ! fm_backlog_atomic_transition remove "$STATE/$ID.meta" "task record"; then
+  if ! fm_backlog_atomic_transition remove "$STATE/$ID.meta" "task record" "$STATE"; then
     fm_lock_release "$META_LOCK"
     META_LOCK_HELD=0
     echo "error: $ID's endpoint and local copy are cleaned up, but its task record could not be removed ($FM_BACKLOG_TRANSITION_ERROR)" >&2

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2666,22 +2666,40 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
   fi
 fi
 
+# A Herdr close may reposition shared workspace order, so the whole
+# destructive sequence below (worktree return, pane close, record removal)
+# runs under the named-session presentation lock, acquired BEFORE anything is
+# returned or erased: a contended lock refuses here while the isolated copy,
+# every durable record, and the endpoint are all still intact for a plain
+# rerun. An unresolvable lock path (for example an unreachable server) also
+# refuses before any destructive step.
+TEARDOWN_HERDR_SESSION=
+TEARDOWN_HERDR_PANE=
+if [ "$BACKEND" = herdr ]; then
+  teardown_herdr_preflight_target "$T" "$ID" || exit 1
+  fm_backend_herdr_parse_target "$T" || exit 1
+  TEARDOWN_HERDR_SESSION=$FM_BACKEND_HERDR_SESSION
+  TEARDOWN_HERDR_PANE=$FM_BACKEND_HERDR_PANE
+fi
+
+BACKLOG_CLOSED=0
+BACKLOG_SKIP_REASON=
 if [ "$TEARDOWN_BACKLOG_APPLIES" = 1 ]; then
   backlog_done_args || {
     echo "error: the pending backlog close for $ID is not replayable; refusing destructive teardown" >&2
     exit 1
   }
-  BACKLOG_CLOSE_PREFLIGHT="$STATE/.$ID.backlog-close.preflight.${BASHPID:-$$}"
-  fm_backlog_close_marker_stage "$BACKLOG_CLOSE_PREFLIGHT" "$ID" "$DATA" \
-    "$TEARDOWN_META_SPAWN_GEN" "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}" \
-    || {
-      echo "error: the pending backlog close for $ID is not replayable ($FM_BACKLOG_TRANSITION_ERROR); refusing destructive teardown" >&2
-      exit 1
-    }
-  rm -f "$BACKLOG_CLOSE_PREFLIGHT" || {
-    echo "error: the pending backlog close preflight for $ID could not be removed; refusing destructive teardown" >&2
-    exit 1
-  }
+  BACKLOG_CLOSED=1
+  META_SPAWN_GEN=$TEARDOWN_META_SPAWN_GEN
+  fm_backlog_close_marker_write "$STATE" "$ID" "$DATA" "$META_SPAWN_GEN" \
+    "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}" \
+    || { echo "error: the pending backlog close for $ID could not be recorded; retaining every durable task record" >&2; exit 1; }
+else
+  if [ "$CLEANUP_RECOVERY" = orca ]; then
+    BACKLOG_SKIP_REASON="Orca cleanup recovery is not a launched backlog worker"
+  else
+    BACKLOG_SKIP_REASON=$TEARDOWN_BACKLOG_SKIP_REASON
+  fi
 fi
 
 # Every landed/discard-work refusal above has now passed (or --force skipped
@@ -2699,22 +2717,6 @@ fi
 # Fix 3 (see script header): sweep remote job workers abandoned by an already
 # pruned code root. Best effort - a sweep failure never blocks this teardown.
 "$SCRIPT_DIR/fm-remote-job-reap-orphans.sh" >&2 || true
-
-# A Herdr close may reposition shared workspace order, so the whole
-# destructive sequence below (worktree return, pane close, record removal)
-# runs under the named-session presentation lock, acquired BEFORE anything is
-# returned or erased: a contended lock refuses here while the isolated copy,
-# every durable record, and the endpoint are all still intact for a plain
-# rerun. An unresolvable lock path (for example an unreachable server) also
-# refuses before any destructive step.
-TEARDOWN_HERDR_SESSION=
-TEARDOWN_HERDR_PANE=
-if [ "$BACKEND" = herdr ]; then
-  teardown_herdr_preflight_target "$T" "$ID" || exit 1
-  fm_backend_herdr_parse_target "$T" || exit 1
-  TEARDOWN_HERDR_SESSION=$FM_BACKEND_HERDR_SESSION
-  TEARDOWN_HERDR_PANE=$FM_BACKEND_HERDR_PANE
-fi
 
 # Best-effort: drop the local task branch so the shared repo does not accumulate refs.
 if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
@@ -2858,25 +2860,6 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 status_retire_presentation_task "$STATE" "$ID" || exit 1
-# Point of no return: the endpoint is closed and the local copy returned, so
-# the completion links live only in the record about to be removed. Record the
-# exact close first, so a process killed between the two halves leaves enough
-# for the next session start to finish it (bin/fm-backlog-transition-lib.sh).
-BACKLOG_CLOSED=0
-BACKLOG_SKIP_REASON=
-if [ "$TEARDOWN_BACKLOG_APPLIES" = 1 ]; then
-  BACKLOG_CLOSED=1
-  META_SPAWN_GEN=$TEARDOWN_META_SPAWN_GEN
-  fm_backlog_close_marker_write "$STATE" "$ID" "$DATA" "$META_SPAWN_GEN" \
-    "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}" \
-    || { echo "error: the pending backlog close for $ID could not be recorded; retaining every durable task record" >&2; exit 1; }
-else
-  if [ "$CLEANUP_RECOVERY" = orca ]; then
-    BACKLOG_SKIP_REASON="Orca cleanup recovery is not a launched backlog worker"
-  else
-    BACKLOG_SKIP_REASON=$TEARDOWN_BACKLOG_SKIP_REASON
-  fi
-fi
 rm -f "$STATE/$ID.turn-ended" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2895,6 +2895,11 @@ if [ "$BACKLOG_CLOSED" = 1 ]; then
     echo "error: $ID's endpoint and local copy are cleaned up, but its backlog item could not be closed atomically ($FM_BACKLOG_TRANSITION_ERROR); the pending close is recorded and the next session start retries it" >&2
     exit 1
   fi
+elif [ "$KIND" = secondmate ] && [ ! -e "$STATE" ] && [ ! -L "$STATE" ]; then
+  # A nested remote retirement can keep its route record inside the home being
+  # removed. remove_firstmate_home above already performed that physical
+  # deletion; do not turn its confirmed absence into a false cleanup failure.
+  :
 else
   if ! fm_backlog_atomic_transition remove "$STATE/$ID.meta" "task record" "$STATE"; then
     fm_lock_release "$META_LOCK"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -273,7 +273,7 @@ META_LOCK_HELD=1
 TEARDOWN_META_KIND=$(fm_meta_get "$META" kind)
 [ -n "$TEARDOWN_META_KIND" ] || TEARDOWN_META_KIND=ship
 TEARDOWN_CLEANUP_RECOVERY=$(fm_meta_get "$META" cleanup_recovery)
-TEARDOWN_META_SPAWN_GEN=$(fm_meta_get "$META" spawn_gen)
+TEARDOWN_META_SPAWN_GEN=
 TEARDOWN_BACKLOG_APPLIES=0
 TEARDOWN_BACKLOG_SKIP_REASON=
 if [ "$TEARDOWN_CLEANUP_RECOVERY" != orca ]; then
@@ -288,9 +288,12 @@ if [ "$TEARDOWN_CLEANUP_RECOVERY" != orca ]; then
     TEARDOWN_BACKLOG_SKIP_REASON=$FM_BACKLOG_TRANSITION_SKIP
   fi
 fi
-if [ "$TEARDOWN_BACKLOG_APPLIES" = 1 ] && [ -z "$TEARDOWN_META_SPAWN_GEN" ]; then
-  echo "error: task $ID's record has no spawn_gen; refusing automatic teardown because a durable backlog close cannot identify this incarnation - relaunch the task to publish an incarnation, then retry teardown" >&2
-  exit 1
+if [ "$TEARDOWN_BACKLOG_APPLIES" = 1 ]; then
+  if ! fm_backlog_meta_spawn_gen "$META"; then
+    echo "error: task $ID's record has no spawn_gen that identifies one exact incarnation ($FM_BACKLOG_TRANSITION_ERROR); refusing automatic teardown - relaunch the task to publish an unambiguous incarnation, then retry teardown" >&2
+    exit 1
+  fi
+  TEARDOWN_META_SPAWN_GEN=$FM_BACKLOG_META_SPAWN_GEN
 fi
 
 REMOTE_HANDOFF_DIR_PRESENT=0

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1,9 +1,23 @@
 #!/usr/bin/env bash
 # Tear down a finished task: return the treehouse worktree, release the Orca
 # worktree, or retire a secondmate home; kill the recorded runtime endpoint,
-# clear volatile state, refresh/prune the project's clone for PR-based ship
-# tasks, then print a backlog-refresh reminder for ship and scout teardowns
-# (a secondmate teardown prints none, since secondmates are not backlog items).
+# clear volatile state, and CLOSE this home's backlog item for ship and scout
+# tasks before reporting success (a secondmate teardown closes none, since
+# secondmates are not backlog items), then refresh/prune the project's clone for
+# PR-based ship tasks.
+# Removing state/<id>.meta and closing the backlog item are one step, not two:
+# bin/fm-backlog-transition-lib.sh owns that invariant, and both halves run under
+# the task's own meta lock before this script reports success. Because the
+# completion links (the PR, the report path, a local-main note) live only in the
+# record being removed, the intended close is recorded in
+# state/<id>.backlog-close first, so a process killed between the halves leaves
+# the next session start enough to finish it; a landed close removes that record.
+# A close that fails is fatal and loud, preserves its pending-close record, and
+# is retried by the next session start. The transition is skipped on a
+# config/backlog-backend=manual home, without a compatible tasks-axi, and in a
+# home that keeps no data/backlog.md; those cases print the manual follow-up.
+# None of this loosens the landed-work gates below: the transition runs only on
+# the paths that already proceed to remove the record.
 # REFUSES if the worktree holds work that has not LANDED, because cleanup
 # hard-resets/removes the worktree and kills its processes. Work has landed when it is
 # reachable from any remote-tracking branch (a fork counts as a remote, so
@@ -150,6 +164,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-backlog-transition-lib.sh
+. "$SCRIPT_DIR/fm-backlog-transition-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-control-lib.sh
@@ -254,6 +270,28 @@ META_LOCK=$(fm_meta_lock_path "$META") || exit 1
 fm_lock_acquire_wait "$META_LOCK"
 META_LOCK_HELD=1
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+TEARDOWN_META_KIND=$(fm_meta_get "$META" kind)
+[ -n "$TEARDOWN_META_KIND" ] || TEARDOWN_META_KIND=ship
+TEARDOWN_CLEANUP_RECOVERY=$(fm_meta_get "$META" cleanup_recovery)
+TEARDOWN_META_SPAWN_GEN=$(fm_meta_get "$META" spawn_gen)
+TEARDOWN_BACKLOG_APPLIES=0
+TEARDOWN_BACKLOG_SKIP_REASON=
+if [ "$TEARDOWN_CLEANUP_RECOVERY" != orca ]; then
+  if fm_backlog_transition_applies "$CONFIG" "$DATA" "$TEARDOWN_META_KIND"; then
+    TEARDOWN_BACKLOG_APPLIES=1
+  else
+    TEARDOWN_BACKLOG_GATE_STATUS=$?
+    if [ "$TEARDOWN_BACKLOG_GATE_STATUS" -eq 2 ]; then
+      echo "error: task $ID cannot be torn down because its backlog data directory is inaccessible: $DATA ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+      exit 1
+    fi
+    TEARDOWN_BACKLOG_SKIP_REASON=$FM_BACKLOG_TRANSITION_SKIP
+  fi
+fi
+if [ "$TEARDOWN_BACKLOG_APPLIES" = 1 ] && [ -z "$TEARDOWN_META_SPAWN_GEN" ]; then
+  echo "error: task $ID's record has no spawn_gen; refusing automatic teardown because a durable backlog close cannot identify this incarnation - relaunch the task to publish an incarnation, then retry teardown" >&2
+  exit 1
+fi
 
 REMOTE_HANDOFF_DIR_PRESENT=0
 REMOTE_HANDOFF_DIR_REAL=
@@ -633,7 +671,8 @@ remote_secondmate_teardown() {
   grep -vE "^- $ID( |$)" "$SECONDMATE_REG" > "$tmp" || true
   mv -f -- "$tmp" "$SECONDMATE_REG"
   status_retire_presentation_task "$STATE" "$ID" || return 1
-  rm -f -- "$STATE/$ID.meta" "$STATE/$ID.turn-ended"
+  fm_backlog_atomic_transition remove "$STATE/$ID.meta" "task record" || return 1
+  rm -f -- "$STATE/$ID.turn-ended"
   printf 'teardown %s complete (remote %s:%s)\n' "$ID" "$remote_host" "$remote_home"
   return 0
 }
@@ -690,9 +729,9 @@ if [ -z "$BUSY_GEN" ]; then
 fi
 ORCA_WORKTREE_ID=$(fm_meta_get "$META" orca_worktree_id)
 ORCA_PATH_MATCH_VERIFIED=0
+CLEANUP_RECOVERY=$TEARDOWN_CLEANUP_RECOVERY
 
-KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
-[ -n "$KIND" ] || KIND=ship
+KIND=$TEARDOWN_META_KIND
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ -n "$MODE" ] || MODE=no-mistakes
 PUBLIC_FOLLOWUP_HOME=$FM_HOME
@@ -1034,17 +1073,20 @@ EOF
 # current work is not contained in the PR head, no PR is found, or any gh error
 # occurs - the caller then falls back to the content check.
 pr_is_merged() {
-  local branch=$1 target view state head current
+  local branch=$1 target view state remainder head resolved_url current landed=0
   if [ -n "$PR_URL" ]; then
     target=$PR_URL
   else
     target=$(pr_number_from_branch "$branch") || return 1
   fi
   [ -n "$target" ] || return 1
-  view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid -q '.state + "\t" + .headRefOid' 2>/dev/null) || return 1
+  view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid,url -q '.state + "\t" + .headRefOid + "\t" + .url' 2>/dev/null) || return 1
   state=${view%%$'\t'*}
-  head=${view#*$'\t'}
+  remainder=${view#*$'\t'}
   [ "$state" != "$view" ] || return 1
+  head=${remainder%%$'\t'*}
+  resolved_url=${remainder#*$'\t'}
+  [ "$head" != "$remainder" ] || return 1
   case "$state" in
     MERGED|merged) ;;
     *) return 1 ;;
@@ -1052,8 +1094,17 @@ pr_is_merged() {
   [ -n "$head" ] || return 1
   ensure_commit_object "$target" "$head" || return 1
   current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
-  git -C "$WT" merge-base --is-ancestor "$current" "$head" 2>/dev/null && return 0
-  unpushed_patches_are_in_pr_head "$head"
+  if git -C "$WT" merge-base --is-ancestor "$current" "$head" 2>/dev/null; then
+    landed=1
+  elif unpushed_patches_are_in_pr_head "$head"; then
+    landed=1
+  fi
+  [ "$landed" = 1 ] || return 1
+  if [ -z "$PR_URL" ]; then
+    [ -n "$resolved_url" ] || return 1
+    PR_URL=$resolved_url
+  fi
+  return 0
 }
 
 # Is the branch's content already present in the up-to-date default branch? Fetches
@@ -1092,31 +1143,45 @@ work_is_landed() {
   content_in_default
 }
 
+# The completion links this teardown already holds locally. A scout's
+# deliverable is its report, a local-only ship lands on local main, and every
+# other ship carries the PR recorded on its own record.
+BACKLOG_DONE_ARGS=()
+backlog_done_args() {
+  local data_relative
+  BACKLOG_DONE_ARGS=()
+  case "$KIND" in
+    scout)
+      data_relative=$(fm_backlog_data_relative "$DATA") || return 1
+      BACKLOG_DONE_ARGS=(--report "$data_relative/$ID/report.md")
+      ;;
+    *)
+      if [ "$MODE" = local-only ]; then
+        BACKLOG_DONE_ARGS=(--note "local main")
+      elif [ -n "$PR_URL" ]; then
+        BACKLOG_DONE_ARGS=(--pr "$PR_URL")
+      fi
+      ;;
+  esac
+}
+
+# Closing the backlog item is this script's own last act on the record, not a
+# printed instruction for a later turn (bin/fm-backlog-transition-lib.sh owns the
+# invariant). This prints what already happened, so the follow-up wording stays
+# only where a human still owes the edit.
 backlog_refresh_reminder() {
-  local pr done_cmd report_path
+  local data_relative backlog_display
   [ "$KIND" = secondmate ] && return 0
-  if fm_tasks_axi_backend_available "$CONFIG"; then
-    case "$KIND" in
-      scout)
-        report_path="data/$ID/report.md"
-        done_cmd="tasks-axi done $ID --report $report_path"
-        ;;
-      *)
-        if [ "$MODE" = local-only ]; then
-          done_cmd="tasks-axi done $ID --note \"local main\""
-        else
-          pr=$PR_URL
-          if [ -n "$pr" ]; then
-            done_cmd="tasks-axi done $ID --pr $pr"
-          else
-            done_cmd="tasks-axi done $ID --pr PR_URL"
-          fi
-        fi
-        ;;
-    esac
-    printf '%s\n' "Backlog: $ID just finished. Run $done_cmd, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due."
+  [ "$CLEANUP_RECOVERY" = orca ] && return 0
+  if data_relative=$(fm_backlog_data_relative "$DATA"); then
+    backlog_display="$data_relative/backlog.md"
   else
-    printf '%s\n' "Backlog: $ID just finished. Update data/backlog.md - move $ID to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due."
+    backlog_display="${DATA%/}/backlog.md"
+  fi
+  if [ "$BACKLOG_CLOSED" = 1 ]; then
+    printf '%s\n' "Backlog: $ID is closed in $backlog_display. Run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due."
+  else
+    printf '%s\n' "Backlog: $ID just finished ($BACKLOG_SKIP_REASON). Update $backlog_display - move $ID to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due."
   fi
 }
 
@@ -2458,8 +2523,9 @@ cleanup_firstmate_home_children() {
     fi
     retire_busy_state "$sub_state" "$child_id" "$child_busy_gen" || return 1
     status_retire_presentation_task "$sub_state" "$child_id" || return 1
+    fm_backlog_atomic_transition remove "$sub_state/$child_id.meta" "task record" || return 1
     rm -f "$sub_state/$child_id.turn-ended" \
-      "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
+      "$sub_state/$child_id.pi-ext.ts" \
       "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
       "$sub_state/$child_id.muse-session" "$sub_state/$child_id.muse-session-current" \
       "$sub_state/$child_id.cursor-session" "$sub_state/$child_id.reconcile-nudged"
@@ -2598,6 +2664,24 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
       exit 1
     fi
   fi
+fi
+
+if [ "$TEARDOWN_BACKLOG_APPLIES" = 1 ]; then
+  backlog_done_args || {
+    echo "error: the pending backlog close for $ID is not replayable; refusing destructive teardown" >&2
+    exit 1
+  }
+  BACKLOG_CLOSE_PREFLIGHT="$STATE/.$ID.backlog-close.preflight.${BASHPID:-$$}"
+  fm_backlog_close_marker_stage "$BACKLOG_CLOSE_PREFLIGHT" "$ID" "$DATA" \
+    "$TEARDOWN_META_SPAWN_GEN" "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}" \
+    || {
+      echo "error: the pending backlog close for $ID is not replayable ($FM_BACKLOG_TRANSITION_ERROR); refusing destructive teardown" >&2
+      exit 1
+    }
+  rm -f "$BACKLOG_CLOSE_PREFLIGHT" || {
+    echo "error: the pending backlog close preflight for $ID could not be removed; refusing destructive teardown" >&2
+    exit 1
+  }
 fi
 
 # Every landed/discard-work refusal above has now passed (or --force skipped
@@ -2774,7 +2858,26 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 status_retire_presentation_task "$STATE" "$ID" || exit 1
-rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
+# Point of no return: the endpoint is closed and the local copy returned, so
+# the completion links live only in the record about to be removed. Record the
+# exact close first, so a process killed between the two halves leaves enough
+# for the next session start to finish it (bin/fm-backlog-transition-lib.sh).
+BACKLOG_CLOSED=0
+BACKLOG_SKIP_REASON=
+if [ "$TEARDOWN_BACKLOG_APPLIES" = 1 ]; then
+  BACKLOG_CLOSED=1
+  META_SPAWN_GEN=$TEARDOWN_META_SPAWN_GEN
+  fm_backlog_close_marker_write "$STATE" "$ID" "$DATA" "$META_SPAWN_GEN" \
+    "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}" \
+    || { echo "error: the pending backlog close for $ID could not be recorded; retaining every durable task record" >&2; exit 1; }
+else
+  if [ "$CLEANUP_RECOVERY" = orca ]; then
+    BACKLOG_SKIP_REASON="Orca cleanup recovery is not a launched backlog worker"
+  else
+    BACKLOG_SKIP_REASON=$TEARDOWN_BACKLOG_SKIP_REASON
+  fi
+fi
+rm -f "$STATE/$ID.turn-ended" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
   "$STATE/$ID.muse-session-current" "$STATE/$ID.cursor-session" \
@@ -2785,6 +2888,26 @@ rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
 # retired endpoint; teardown only runs after landing is confirmed, so any
 # leftover unhandled steer here is moot rather than unlanded work.
 rm -rf "$STATE/$ID.inbox"
+# The record is gone, so the backlog must not still show this task in flight
+# when teardown reports success. Still under this task's meta lock, so a steer
+# racing the same id stays serialized exactly as it was before.
+if [ "$BACKLOG_CLOSED" = 1 ]; then
+  BACKLOG_CLOSE_MARKER=$(fm_backlog_close_marker_path "$STATE" "$ID") || exit 1
+  if ! fm_backlog_atomic_transition close "$STATE/$ID.meta" "$BACKLOG_CLOSE_MARKER" \
+      "$DATA" "$ID" "${BACKLOG_DONE_ARGS[@]+"${BACKLOG_DONE_ARGS[@]}"}"; then
+    fm_lock_release "$META_LOCK"
+    META_LOCK_HELD=0
+    echo "error: $ID's endpoint and local copy are cleaned up, but its backlog item could not be closed atomically ($FM_BACKLOG_TRANSITION_ERROR); the pending close is recorded and the next session start retries it" >&2
+    exit 1
+  fi
+else
+  if ! fm_backlog_atomic_transition remove "$STATE/$ID.meta" "task record"; then
+    fm_lock_release "$META_LOCK"
+    META_LOCK_HELD=0
+    echo "error: $ID's endpoint and local copy are cleaned up, but its task record could not be removed ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+    exit 1
+  fi
+fi
 fm_lock_release "$META_LOCK"
 META_LOCK_HELD=0
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -246,6 +246,7 @@ family_for_basename() {
     fm-send-secondmate-marker.test.sh|fm-shared-captain-inheritance.test.sh)
       printf '%s\n' secondmate
       ;;
+    fm-backlog-atomicity.test.sh|\
     fm-bootstrap.test.sh|fm-bootstrap-network-parallel.test.sh|fm-fleet-sync.test.sh|fm-gate-refuse.test.sh|fm-gotmp.test.sh|\
     fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-startup-network.test.sh|\
     fm-tangle-guard.test.sh|fm-update.test.sh)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,8 +93,8 @@ When the default backend is selected and compatible `tasks-axi` is on `PATH`, fi
 When the automatic transition gate applies, dispatch and completion are not separate operator actions: each moves its work item inside the same run that creates or removes the task's record, so the ordinary successful path cannot leave the backlog and live task set out of sync ([`bin/fm-backlog-transition-lib.sh`](../bin/fm-backlog-transition-lib.sh)).
 Under that gate, dispatch refuses when this home has no item for the id or already marks it Done, completion refuses to report success until the item is closed, and session start reconciles this home's own books after an interrupted run.
 Automatic transitions address the configured `<data>/backlog.md` explicitly from the data directory's parent, keeping relocated backlog configuration, archives, and relative scout-report links together.
-The gate does not apply to persistent secondmates, homes without compatible `tasks-axi`, or homes without a backlog file, preserving their existing persistent-agent, manual, or ad-hoc lifecycle behavior.
-After the secondmate, manual-backend, and compatibility exemptions, an unresolvable configured data directory or one containing a control byte fails lifecycle work before mutation.
+The gate does not apply to persistent secondmates, manual-backend homes, or homes without a backlog file, preserving their existing persistent-agent, manual, or ad-hoc lifecycle behavior.
+On an automatic-backend home with a backlog, missing or incompatible `tasks-axi`, an unresolvable configured data directory, or one containing a control byte fails lifecycle work before mutation.
 Secondmate handoffs bypass that routine-backend choice: `fm-backlog-handoff.sh` keeps only its own fleet-level validation, delegates the item move to `tasks-axi mv`, and requires a verified receiver wake after a new move becomes durable.
 It moves in-scope `## Queued` items only and refuses `## In flight` and historical `## Done` records, which stay with their home for pruning or archiving.
 Handoff item bodies must use at least two leading spaces, and the helper refuses a selected item with a single-space or tab-indented continuation rather than risk orphaning it.
@@ -378,7 +378,7 @@ A herdr, zellij, or cmux home is therefore never told `tmux` is missing, and the
 When `config/crew-dispatch.json` exists, bootstrap also requires `jq` for dispatch profile validation.
 When Relay is opted in, bootstrap also requires `curl` and `jq` before arming the relay poll shim.
 `tasks-axi` and `quota-axi` are required bootstrap tools in every profile, the same class as `lavish-axi`.
-An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm install -g tasks-axi)`; when `config/backlog-backend` is not `manual` and compatible `tasks-axi` is on `PATH`, bootstrap stays silent and firstmate uses its verbs for routine backlog mutations, otherwise it hand-edits `data/backlog.md` until installation is approved and completed.
+An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm install -g tasks-axi)`; when `config/backlog-backend` is not `manual`, a home with a backlog refuses lifecycle mutation until compatible `tasks-axi` is on `PATH`, while a manual-backend home keeps its backlog hand-edited.
 An absent or incompatible `gh-axi` reports `MISSING: gh-axi (install: npm install -g gh-axi && gh-axi setup hooks)`.
 An absent or incompatible `lavish-axi` reports `MISSING: lavish-axi (install: npm install -g lavish-axi && lavish-axi setup hooks)`.
 An absent or too-old `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; firstmate cannot resolve a profile array without a compatible binary.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,6 +270,7 @@ When `FM_HOME` is unset, it also behaves as the old whole-root override.
 `FM_STATE_OVERRIDE`, `FM_DATA_OVERRIDE`, `FM_PROJECTS_OVERRIDE`, and `FM_CONFIG_OVERRIDE` override individual operational directories for tests and specialized harness setup.
 Before `fm-brief.sh`, `fm-spawn.sh`, or `fm-afk-launch.sh` persists a path or passes it to another process, it resolves each applicable relative `FM_HOME`, `FM_STATE_OVERRIDE`, or `FM_DATA_OVERRIDE` directory against the caller's working directory, preserves accepted absolute spellings unchanged, and rejects an unresolvable relative directory with the offending variable named.
 `fm-spawn.sh` additionally rejects control bytes in those raw directory inputs before shell or filesystem normalization can change which path the backlog gate checks.
+Lifecycle access to a backlog, task record, or pending-close record must resolve within its configured data or state root, and a final-component symlink is refused even when its target remains within that root.
 Bootstrap applies the same relative `FM_HOME` resolution only when embedding that home in the generated Relay poll shim; other transient consumers retain their existing shell-relative behavior.
 For the herdr backend, `FM_HOME` also determines the workspace label used by the adapter.
 For the zellij backend, `FM_HOME` does not split containers, but it determines the readable home prefix embedded in visible tab titles; use `FM_ZELLIJ_SESSION` when a separate zellij session is needed.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,11 @@ Both choices are local to each Firstmate home and are not part of secondmate inh
 
 The tracked `.tasks.toml` pins the default `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
 When the default backend is selected and compatible `tasks-axi` is on `PATH`, firstmate uses its verbs for routine backlog mutations.
+When the automatic transition gate applies, dispatch and completion are not separate operator actions: each moves its work item inside the same run that creates or removes the task's record, so the ordinary successful path cannot leave the backlog and live task set out of sync ([`bin/fm-backlog-transition-lib.sh`](../bin/fm-backlog-transition-lib.sh)).
+Under that gate, dispatch refuses when this home has no item for the id or already marks it Done, completion refuses to report success until the item is closed, and session start reconciles this home's own books after an interrupted run.
+Automatic transitions address the configured `<data>/backlog.md` explicitly from the data directory's parent, keeping relocated backlog configuration, archives, and relative scout-report links together.
+The gate does not apply to persistent secondmates, homes without compatible `tasks-axi`, or homes without a backlog file, preserving their existing persistent-agent, manual, or ad-hoc lifecycle behavior.
+After the secondmate, manual-backend, and compatibility exemptions, an unresolvable configured data directory or one containing a control byte fails lifecycle work before mutation.
 Secondmate handoffs bypass that routine-backend choice: `fm-backlog-handoff.sh` keeps only its own fleet-level validation, delegates the item move to `tasks-axi mv`, and requires a verified receiver wake after a new move becomes durable.
 It moves in-scope `## Queued` items only and refuses `## In flight` and historical `## Done` records, which stay with their home for pruning or archiving.
 Handoff item bodies must use at least two leading spaces, and the helper refuses a selected item with a single-space or tab-indented continuation rather than risk orphaning it.
@@ -97,6 +102,7 @@ Because bootstrap requires `tasks-axi` on `PATH` on every profile, that delegati
 Compatible means the installed build passes the shared version and feature probe owned by [`bin/fm-tasks-axi-lib.sh`](../bin/fm-tasks-axi-lib.sh), including the atomic multi-ID move required by handoff delegation.
 Bootstrap requires compatible `tasks-axi` on every profile; see "Toolchain" below for missing-tool reporting and silent default-backend behavior.
 Set the local, gitignored `config/backlog-backend` file to `manual` to force manual backlog editing and suppress the verbose `BOOTSTRAP_INFO: tasks-axi available` fact, not missing-tool reporting.
+A `manual` home owns its backlog file outright: the lifecycle transitions above are skipped there, dispatch and completion never fail over the file's contents, and a completed teardown prints the hand edit that is owed instead.
 Absent or `tasks-axi` selects the default tasks-axi backend.
 The file format is unchanged in both modes; tasks-axi and manual edits produce the same `## In flight`, `## Queued`, and `## Done` sections.
 
@@ -262,7 +268,8 @@ When it is unset, most scripts use the repo root as the home; when it is set, sc
 When `FM_HOME` is unset, it also behaves as the old whole-root override.
 `bin/fm-send.sh` is intentionally stricter than that general fallback: it requires `FM_HOME` to be set before resolving a target, so operator steers cannot silently resolve against the wrong home.
 `FM_STATE_OVERRIDE`, `FM_DATA_OVERRIDE`, `FM_PROJECTS_OVERRIDE`, and `FM_CONFIG_OVERRIDE` override individual operational directories for tests and specialized harness setup.
-Before `fm-brief.sh`, `fm-spawn.sh`, or `fm-afk-launch.sh` persists a path or passes it to another process, it resolves each applicable relative `FM_HOME`, `FM_STATE_OVERRIDE`, or `FM_DATA_OVERRIDE` directory against the caller's working directory, preserves absolute spellings unchanged, and rejects an unresolvable relative directory with the offending variable named.
+Before `fm-brief.sh`, `fm-spawn.sh`, or `fm-afk-launch.sh` persists a path or passes it to another process, it resolves each applicable relative `FM_HOME`, `FM_STATE_OVERRIDE`, or `FM_DATA_OVERRIDE` directory against the caller's working directory, preserves accepted absolute spellings unchanged, and rejects an unresolvable relative directory with the offending variable named.
+`fm-spawn.sh` additionally rejects control bytes in those raw directory inputs before shell or filesystem normalization can change which path the backlog gate checks.
 Bootstrap applies the same relative `FM_HOME` resolution only when embedding that home in the generated Relay poll shim; other transient consumers retain their existing shell-relative behavior.
 For the herdr backend, `FM_HOME` also determines the workspace label used by the adapter.
 For the zellij backend, `FM_HOME` does not split containers, but it determines the readable home prefix embedded in visible tab titles; use `FM_ZELLIJ_SESSION` when a separate zellij session is needed.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,8 @@ Both choices are local to each Firstmate home and are not part of secondmate inh
 The tracked `.tasks.toml` pins the default `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
 When the default backend is selected and compatible `tasks-axi` is on `PATH`, firstmate uses its verbs for routine backlog mutations.
 When the automatic transition gate applies, dispatch and completion are not separate operator actions: each moves its work item inside the same run that creates or removes the task's record, so the ordinary successful path cannot leave the backlog and live task set out of sync ([`bin/fm-backlog-transition-lib.sh`](../bin/fm-backlog-transition-lib.sh)).
-Under that gate, dispatch refuses when this home has no item for the id or already marks it Done, completion refuses to report success until the item is closed, and session start reconciles this home's own books after an interrupted run.
+Under that gate, dispatch accepts only an unheld, unblocked Queued or In flight item in this home; a missing, Done, held, or dependency-blocked item is refused before any endpoint or local copy is created.
+Completion refuses to report success until the item is closed, and session start reconciles this home's own books after an interrupted run.
 Automatic transitions address the configured `<data>/backlog.md` explicitly from the data directory's parent, keeping relocated backlog configuration, archives, and relative scout-report links together.
 The gate does not apply to persistent secondmates, manual-backend homes, or homes without a backlog file, preserving their existing persistent-agent, manual, or ad-hoc lifecycle behavior.
 On an automatic-backend home with a backlog, missing or incompatible `tasks-axi`, an unresolvable configured data directory, or one containing a control byte fails lifecycle work before mutation.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -97,6 +97,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation and config-reread delivery |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
+| `fm-backlog-transition-lib.sh` | Pair task-record changes with their backlog transitions and replay interrupted closes |
 | `fm-quota-axi-lib.sh`    | Shared `quota-axi` compatibility floor for the bootstrap diagnostic                  |
 | `fm-vendor-auth-probe.sh`| Run one hard-bounded, non-destructive authentication probe of a named vendor CLI and report the fact |
 | `fm-wake-drain.sh`       | Present and acknowledge the current actor's claimed wake rows alongside status, decision, divergence, recovery, and supervision checks |

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -704,7 +704,8 @@ test_spawn_releases_orca_resources_when_metadata_write_fails() {
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --mode no-mistakes --yolo off --backend orca 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when metadata cannot be written"
-  assert_contains "$out" "Is a directory" "spawn should fail at metadata publication"
+  assert_contains "$out" "task record for $id could not be published" \
+    "spawn should report metadata publication failure without relying on platform-specific mv output"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-meta-fail'$'\x1f''--json' \
     "Orca spawn should close the recorded terminal when a later abort occurs"
   assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-meta-fail'$'\x1f''--force'$'\x1f''--json' \

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -1409,7 +1409,7 @@ test_recovery_preserves_a_close_when_the_backlog_cannot_be_read() {
   pass "session start preserves a pending close across a transient backlog read failure"
 }
 
-test_recovery_retry_without_metadata_avoids_incomplete_cleanup_warning() {
+test_recovery_retry_preserves_incomplete_cleanup_warning() {
   local case_dir home id marker out
   id=atomic-heal-retry-warning-b10
   case_dir=$(make_home heal-retry-warning)
@@ -1431,10 +1431,10 @@ test_recovery_retry_without_metadata_avoids_incomplete_cleanup_warning() {
   out=$(run_bootstrap "$case_dir")
   [ "$(row_state "$case_dir" "$id")" = "done" ] \
     || fail "retried recovery left the item In flight: $out"
-  assert_not_contains "$out" "endpoint or local copy may remain" \
-    "retry claimed incomplete cleanup after metadata was already removed"
+  assert_contains "$out" "endpoint or local copy may remain" \
+    "retry lost the incomplete-cleanup evidence after removing metadata"
   assert_absent "$marker" "retried recovery retained its applied marker"
-  pass "recovery without metadata avoids incomplete-cleanup warnings"
+  pass "recovery preserves incomplete-cleanup evidence across a failed replay"
 }
 
 test_recovery_finishes_a_close_for_the_same_meta_incarnation() {
@@ -2198,7 +2198,7 @@ test_recovery_ignores_a_symlinked_worker_record
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open
 test_recovery_backfills_a_recorded_link_on_an_already_done_item
 test_recovery_preserves_a_close_when_the_backlog_cannot_be_read
-test_recovery_retry_without_metadata_avoids_incomplete_cleanup_warning
+test_recovery_retry_preserves_incomplete_cleanup_warning
 test_recovery_finishes_a_close_for_the_same_meta_incarnation
 test_recovery_preserves_a_close_for_ambiguous_incarnation_metadata
 test_recovery_preserves_both_records_when_meta_removal_fails

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -538,6 +538,29 @@ test_bare_relative_data_dispatches_and_completes() {
   pass "bare relative data addresses one backlog through dispatch and completion"
 }
 
+test_dispatch_refuses_a_symlinked_backlog_without_crossing_homes() {
+  local case_dir foreign_case id local_backlog foreign_backlog out rc=0
+  id=atomic-dispatch-symlink-backlog-b2
+  case_dir=$(make_home dispatch-symlink-backlog "$id")
+  foreign_case=$(make_home dispatch-symlink-backlog-foreign)
+  add_item "$foreign_case" "$id"
+  local_backlog=$(backlog_of "$case_dir")
+  foreign_backlog=$(backlog_of "$foreign_case")
+  rm -f "$local_backlog"
+  ln -s "$foreign_backlog" "$local_backlog"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn accepted a symlinked backlog"
+  assert_contains "$out" "backlog file is not a regular non-symlink file" \
+    "spawn did not identify the unsafe backlog boundary"
+  [ -L "$local_backlog" ] || fail "spawn replaced the local backlog symlink"
+  [ "$(row_state "$foreign_case" "$id")" = queued ] \
+    || fail "spawn mutated the foreign backlog row"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "unsafe backlog dispatch published a local task record"
+  pass "dispatch refuses symlinked backlogs without crossing homes"
+}
+
 test_dispatch_refuses_an_unresolvable_data_directory() {
   local case_dir id saved out rc=0
   id=atomic-dispatch-missing-data-b2
@@ -1085,6 +1108,33 @@ test_interrupted_destructive_cleanup_leaves_a_recoverable_close() {
   pass "restart recovers closes recorded before destructive cleanup"
 }
 
+test_completion_refuses_a_close_target_symlinked_to_a_directory() {
+  local case_dir home id marker external out rc=0
+  id=atomic-close-target-directory-symlink-b8
+  case_dir=$(make_home close-target-directory-symlink)
+  home=$(home_of "$case_dir")
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-target-symlink"
+  marker="$home/state/$id.backlog-close"
+  external="$case_dir/external-directory"
+  mkdir -p "$external"
+  ln -s "$external" "$marker"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown published through a directory symlink"
+  assert_contains "$out" "pending-close record target is not a regular non-symlink file" \
+    "teardown did not report the unsafe publication target"
+  [ -L "$marker" ] || fail "teardown replaced the unsafe close target"
+  [ -z "$(find "$external" -mindepth 1 -maxdepth 1 -print -quit)" ] \
+    || fail "teardown wrote a staged close outside the home"
+  assert_present "$home/state/$id.meta" \
+    "unsafe close publication removed the task record"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "unsafe close publication changed the backlog row"
+  pass "completion refuses directory-symlink close targets"
+}
+
 test_completion_fails_when_its_close_marker_cannot_be_removed() {
   local case_dir id marker out rc=0
   id=atomic-close-marker-remove-failure-b8
@@ -1221,6 +1271,8 @@ test_recovery_replays_a_close_an_interrupted_cleanup_left_open() {
     "the replayed close dropped the completion link the cleanup had recorded"
   assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
     "a replayed close left its record behind"
+  assert_not_contains "$out" "endpoint or local copy may remain" \
+    "recovery claimed incomplete cleanup without task metadata"
   pass "session start finishes a close an interrupted cleanup recorded but never landed"
 }
 
@@ -1270,7 +1322,7 @@ test_recovery_preserves_a_close_when_the_backlog_cannot_be_read() {
   pass "session start preserves a pending close across a transient backlog read failure"
 }
 
-test_recovery_retry_preserves_incomplete_cleanup_warning() {
+test_recovery_retry_without_metadata_avoids_incomplete_cleanup_warning() {
   local case_dir home id marker out
   id=atomic-heal-retry-warning-b10
   case_dir=$(make_home heal-retry-warning)
@@ -1292,10 +1344,10 @@ test_recovery_retry_preserves_incomplete_cleanup_warning() {
   out=$(run_bootstrap "$case_dir")
   [ "$(row_state "$case_dir" "$id")" = done ] \
     || fail "retried recovery left the item In flight: $out"
-  assert_contains "$out" "endpoint or local copy may remain" \
-    "retry lost the incomplete physical-cleanup warning"
+  assert_not_contains "$out" "endpoint or local copy may remain" \
+    "retry claimed incomplete cleanup after metadata was already removed"
   assert_absent "$marker" "retried recovery retained its applied marker"
-  pass "recovery retries preserve incomplete-cleanup warnings"
+  pass "recovery without metadata avoids incomplete-cleanup warnings"
 }
 
 test_recovery_finishes_a_close_for_the_same_meta_incarnation() {
@@ -1794,6 +1846,7 @@ test_recovery_uses_the_parent_of_a_trailing_slash_data_record
 test_completion_targets_a_nested_relative_data_directory
 test_immediate_child_absolute_data_dispatches_and_completes
 test_bare_relative_data_dispatches_and_completes
+test_dispatch_refuses_a_symlinked_backlog_without_crossing_homes
 test_dispatch_refuses_an_unresolvable_data_directory
 test_completion_refuses_an_unresolvable_data_directory
 test_dispatch_refuses_an_id_this_home_has_no_item_for
@@ -1819,6 +1872,7 @@ test_control_character_data_path_is_refused_before_cleanup
 test_completion_preserves_records_when_meta_removal_fails
 test_completion_fails_loudly_and_records_the_close_it_still_owes
 test_interrupted_destructive_cleanup_leaves_a_recoverable_close
+test_completion_refuses_a_close_target_symlinked_to_a_directory
 test_completion_fails_when_its_close_marker_cannot_be_removed
 test_recovery_retries_when_a_close_marker_cannot_be_removed
 test_recovery_reports_an_owned_row_read_failure
@@ -1828,7 +1882,7 @@ test_recovery_ignores_a_symlinked_worker_record
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open
 test_recovery_backfills_a_recorded_link_on_an_already_done_item
 test_recovery_preserves_a_close_when_the_backlog_cannot_be_read
-test_recovery_retry_preserves_incomplete_cleanup_warning
+test_recovery_retry_without_metadata_avoids_incomplete_cleanup_warning
 test_recovery_finishes_a_close_for_the_same_meta_incarnation
 test_recovery_preserves_a_close_for_ambiguous_incarnation_metadata
 test_recovery_preserves_both_records_when_meta_removal_fails

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -1298,7 +1298,7 @@ test_recovery_marks_an_owned_record_in_flight() {
 }
 
 test_recovery_ignores_a_symlinked_worker_record() {
-  local case_dir home id target out
+  local case_dir home id target out rc=0
   id=atomic-heal-symlink-meta-b8
   case_dir=$(make_home heal-symlink-meta)
   home=$(home_of "$case_dir")
@@ -1307,12 +1307,15 @@ test_recovery_ignores_a_symlinked_worker_record() {
   printf 'kind=ship\nspawn_gen=unpublished\n' > "$target"
   ln -s "$target" "$home/state/$id.meta"
 
-  out=$(run_bootstrap "$case_dir")
+  out=$(run_bootstrap "$case_dir") || rc=$?
+  [ "$rc" -ne 0 ] || fail "session start accepted a symlinked worker record"
+  assert_contains "$out" "bootstrap refused unsafe worker record" \
+    "session start did not report the unsafe worker record"
   [ "$(row_state "$case_dir" "$id")" = queued ] \
     || fail "session start treated a symlink as an owned worker record: $out"
   [ -L "$home/state/$id.meta" ] \
     || fail "session start replaced or removed the inert symlinked record"
-  pass "session start ignores symlinked worker records"
+  pass "session start rejects symlinked worker records"
 }
 
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open() {
@@ -1694,7 +1697,7 @@ test_recovery_rejects_invalid_close_arguments() {
 }
 
 test_recovery_rejects_a_symlinked_close_marker() {
-  local case_dir id marker payload out
+  local case_dir id marker payload out rc=0
   id=atomic-marker-symlink-b12
   case_dir=$(make_home marker-symlink)
   add_item "$case_dir" "$id"
@@ -1706,9 +1709,10 @@ test_recovery_rejects_a_symlinked_close_marker() {
   ln -s "$payload" "$marker"
   rm -f "$payload"
 
-  out=$(run_bootstrap "$case_dir")
+  out=$(run_bootstrap "$case_dir") || rc=$?
+  [ "$rc" -ne 0 ] || fail "bootstrap accepted a symlinked close marker"
   [ -L "$marker" ] || fail "dangling symlink close marker was consumed: $out"
-  assert_contains "$out" "recorded backlog close could not be replayed" \
+  assert_contains "$out" "bootstrap refused unsafe pending close" \
     "dangling symlink close marker was silently skipped"
   [ "$(row_state "$case_dir" "$id")" = in_flight ] \
     || fail "symlinked close marker changed the backlog row: $out"
@@ -1755,6 +1759,42 @@ test_recovery_rejects_a_legacy_close_without_an_incarnation() {
   assert_present "$(home_of "$case_dir")/state/$id.backlog-close" \
     "session start consumed an unversioned close marker"
   pass "session start rejects an unversioned close marker"
+}
+
+test_bootstrap_rechecks_worker_record_boundary_after_locking() {
+  local case_dir foreign_case home foreign_state id real_ln out rc=0
+  id=atomic-bootstrap-state-swap-b13
+  case_dir=$(make_home bootstrap-state-swap)
+  foreign_case=$(make_home bootstrap-state-swap-foreign)
+  home=$(home_of "$case_dir")
+  foreign_state="$(home_of "$foreign_case")/state"
+  add_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=local-worker"
+  write_task_meta "$foreign_case" "$id" ship no-mistakes "spawn_gen=foreign-worker"
+  real_ln=$(command -v ln)
+  cat > "$case_dir/fakebin/ln" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *"$home/state/.meta-$id.lock"*)
+    if [ ! -e "$case_dir/state-swapped" ]; then
+      : > "$case_dir/state-swapped"
+      mv "$home/state" "$home/state-original" || exit 1
+      "$real_ln" -s "$foreign_state" "$home/state" || exit 1
+    fi
+    ;;
+esac
+exec "$real_ln" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/ln"
+
+  out=$(run_bootstrap "$case_dir") || rc=$?
+  [ "$rc" -ne 0 ] || fail "bootstrap trusted a worker record after its state boundary changed"
+  assert_contains "$out" "post-lock worker record check refused" \
+    "bootstrap did not report the post-lock state-boundary failure"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "bootstrap changed the local row after reading through a swapped state path"
+  assert_present "$foreign_state/$id.meta" "bootstrap removed the foreign worker record"
+  pass "bootstrap rechecks worker-record containment after locking"
 }
 
 test_bootstrap_refuses_a_symlinked_state_directory_before_reconciliation() {
@@ -1903,7 +1943,7 @@ SH
 
   out=$(run_teardown "$case_dir" "$id") || rc=$?
   [ "$rc" -ne 0 ] || fail "teardown trusted a record after its parent was swapped"
-  assert_contains "$out" "task record parent directory is not a real directory" \
+  assert_contains "$out" "task record authorized directory is not a real directory" \
     "post-lock record check did not report the swapped parent"
   assert_present "$foreign_state/$id.meta" "teardown removed the foreign record"
   assert_present "$foreign_worktree" "teardown removed the foreign local copy"
@@ -2085,6 +2125,7 @@ test_recovery_rejects_invalid_close_arguments
 test_recovery_rejects_a_symlinked_close_marker
 test_recovery_drops_a_close_for_a_newer_meta_incarnation
 test_recovery_rejects_a_legacy_close_without_an_incarnation
+test_bootstrap_rechecks_worker_record_boundary_after_locking
 test_bootstrap_refuses_a_symlinked_state_directory_before_reconciliation
 test_bootstrap_stops_when_data_disappears_before_reconciliation
 test_bootstrap_addressing_exemptions_remain_nonfatal

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -391,6 +391,40 @@ SH
   pass "dispatch refuses to supersede a pending authoritative close"
 }
 
+test_dispatch_refuses_a_held_row_before_creating_resources() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-held-b1
+  case_dir=$(make_home dispatch-held "$id")
+  add_item "$case_dir" "$id"
+  tasks-axi hold "$id" --reason "captain decision pending" --kind captain \
+    --file "$(backlog_of "$case_dir")" >/dev/null
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *new-window*) : > "$case_dir/task-endpoint-created" ;;
+  *treehouse\\ get*) : > "$case_dir/local-copy-requested" ;;
+  *"#{pane_current_path}"*) printf '%s\n' "\${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "\${1:-}" in display-message) printf 'firstmate\n'; exit 0 ;; esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn accepted a held backlog row"
+  assert_contains "$out" "state queued yes" \
+    "held-row refusal did not name the actual ineligible state"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "held-row refusal published a task record"
+  assert_absent "$case_dir/task-endpoint-created" \
+    "held-row refusal created an unowned endpoint"
+  assert_absent "$case_dir/local-copy-requested" \
+    "held-row refusal requested an unowned local copy"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "held-row refusal changed the backlog state"
+  pass "dispatch refuses held rows before creating resources"
+}
+
 test_dispatch_reads_the_row_from_the_backlog_root() {
   local case_dir id out
   id=atomic-dispatch-root-b2
@@ -1291,6 +1325,31 @@ test_recovery_preserves_both_records_when_meta_removal_fails() {
   pass "recovery preserves both records when meta removal fails"
 }
 
+test_recovery_preserves_a_close_beside_symlinked_metadata() {
+  local case_dir home id marker target out
+  id=atomic-heal-symlink-meta-close-b12
+  case_dir=$(make_home heal-symlink-meta-close)
+  home=$(home_of "$case_dir")
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  target="$case_dir/foreign-meta-target"
+  printf 'kind=ship\nspawn_gen=other-incarnation\n' > "$target"
+  ln -s "$target" "$home/state/$id.meta"
+  marker="$home/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=closing-incarnation\narg=--note\narg=local%%20main\n' \
+    "$id" "$home/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_contains "$out" "unsafe interrupted task record" \
+    "recovery did not report unsafe metadata beside the close"
+  assert_present "$marker" "unsafe metadata caused recovery to discard the close"
+  [ -L "$home/state/$id.meta" ] \
+    || fail "recovery replaced or removed the unsafe metadata path"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "unsafe metadata allowed recovery to close the backlog row"
+  pass "recovery preserves closes beside symlinked metadata"
+}
+
 test_recovery_rejects_a_marker_for_another_task_identity() {
   local case_dir locked_id target_id marker out
   locked_id=atomic-marker-lock-owner-b12
@@ -1675,6 +1734,7 @@ test_a_persistent_secondmate_is_never_a_backlog_item() {
 
 test_dispatch_moves_the_item_in_flight_in_the_same_run
 test_dispatch_refuses_a_pending_authoritative_close
+test_dispatch_refuses_a_held_row_before_creating_resources
 test_dispatch_reads_the_row_from_the_backlog_root
 test_recovery_uses_the_parent_of_a_trailing_slash_data_record
 test_completion_targets_a_nested_relative_data_directory
@@ -1716,6 +1776,7 @@ test_recovery_preserves_a_close_when_the_backlog_cannot_be_read
 test_recovery_retry_preserves_incomplete_cleanup_warning
 test_recovery_finishes_a_close_for_the_same_meta_incarnation
 test_recovery_preserves_both_records_when_meta_removal_fails
+test_recovery_preserves_a_close_beside_symlinked_metadata
 test_recovery_rejects_a_marker_for_another_task_identity
 test_recovery_rejects_a_foreign_data_directory
 test_recovery_rejects_an_unterminated_unknown_field

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -1,0 +1,1563 @@
+#!/usr/bin/env bash
+# Behavior tests for the backlog<->record pairing invariant:
+# `state/<id>.meta` exists <=> this home's backlog row for that id is In flight.
+#
+# bin/fm-backlog-transition-lib.sh states the contract; the three scripts that
+# own a task's physical record enforce it. These tests drive those real scripts
+# against a real backlog file and the real tasks-axi CLI, and assert the
+# resulting RECORD STATE - never the wording of a reminder a later turn was
+# expected to act on, which is exactly what let the two records drift before.
+#
+#   dispatch    bin/fm-spawn.sh moves the row In flight in the same run that
+#               publishes the record, so a live worker the backlog does not own
+#               cannot arise on the ordinary path.
+#   completion  bin/fm-teardown.sh closes the row before it reports success, so
+#               a finished task cannot be left showing as running.
+#   recovery    bin/fm-bootstrap.sh reconciles THIS home's own books at session
+#               start, covering the millisecond crash window inside those two
+#               scripts and any drift a home was already carrying.
+#
+# The invariant is single-host: a home's backlog and its records live together,
+# so a persistent secondmate keeps its own books through its own copies of these
+# scripts. A parent's view of a mate lagging is a freshness question and is
+# deliberately not asserted here.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+BOOTSTRAP="$ROOT/bin/fm-bootstrap.sh"
+TMP_ROOT=$(fm_test_tmproot fm-backlog-atomicity)
+
+command -v tasks-axi >/dev/null 2>&1 || {
+  printf 'ok - skipped (tasks-axi is not installed; the fused transitions are inert without it)\n'
+  exit 0
+}
+
+# --- fixture ----------------------------------------------------------------
+
+# A home with a real backlog, a real project clone with an origin, a pooled
+# worktree, and stubs for every tool the spawn path shells out to.
+make_home() {  # <name> [task-id...]
+  local name=$1 case_dir home fakebin id
+  shift
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  fakebin=$(fm_fakebin "$case_dir")
+  mkdir -p "$home/state" "$home/config" "$home/data" "$home/projects"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' claude > "$home/config/crew-harness"
+  printf '%s\n' '# Backlog' '' '## In flight' '' '## Queued' '' '## Done' \
+    > "$home/data/backlog.md"
+  for id in "$@"; do
+    mkdir -p "$home/data/$id"
+    printf 'Delivery contract: mode=no-mistakes\nbrief for %s\n' "$id" > "$home/data/$id/brief.md"
+  done
+
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+case "$*" in *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;; esac
+case "${1:-}" in display-message) printf 'firstmate\n'; exit 0 ;; esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse gh gh-axi no-mistakes
+
+  fm_git_init_commit "$case_dir/project"
+  fm_git_add_origin "$case_dir/project" "$case_dir/project.origin.git"
+  git -C "$case_dir/project" worktree add --quiet -b pooled "$case_dir/wt"
+
+  printf '%s\n' "$case_dir"
+}
+
+home_of() { printf '%s/home\n' "$1"; }
+backlog_of() { printf '%s/home/data/backlog.md\n' "$1"; }
+
+add_item() {  # <case-dir> <id> [kind]
+  tasks-axi add "$2" "item for $2" --kind "${3:-ship}" --file "$(backlog_of "$1")" >/dev/null
+}
+
+start_item() {  # <case-dir> <id>
+  tasks-axi start "$2" --file "$(backlog_of "$1")" >/dev/null
+}
+
+row_state() {  # <case-dir> <id>
+  tasks-axi show "$2" --file "$(backlog_of "$1")" 2>/dev/null |
+    sed -n 's/^  state: *//p' | head -1
+}
+
+# Shadow tasks-axi with a wrapper that fails one verb and delegates every other
+# verb to the real binary, so a test can drive a genuine mid-transition failure
+# without faking the reads around it.
+require_show_cwd() {  # <case-dir> <expected-dir>
+  local case_dir=$1 expected=$2 real
+  real=$(command -v tasks-axi)
+  cat > "$case_dir/fakebin/tasks-axi" <<SH
+#!/usr/bin/env bash
+case "\${1:-}" in
+  show|start|done)
+    if [ "\$PWD" != "$expected" ]; then
+      echo "error: wrong tasks root: \$PWD" >&2
+      exit 1
+    fi
+    ;;
+esac
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/tasks-axi"
+}
+
+break_verb() {  # <case-dir> <verb>
+  local case_dir=$1 verb=$2 real
+  real=$(command -v tasks-axi)
+  cat > "$case_dir/fakebin/tasks-axi" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = "$verb" ]; then
+  echo 'error: "backlog is unwritable"' >&2
+  exit 1
+fi
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/tasks-axi"
+}
+
+interrupt_spawn_during_start() {  # <case-dir> <before|after>
+  local case_dir=$1 timing=$2 real
+  real=$(command -v tasks-axi)
+  cat > "$case_dir/fakebin/tasks-axi" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = start ] && [ ! -f "$case_dir/start-interrupted" ]; then
+  : > "$case_dir/start-interrupted"
+  spawn_pid=\$(ps -o ppid= -p "\$PPID" | tr -d ' ')
+  case "\$spawn_pid" in ''|*[!0-9]*) exit 1 ;; esac
+  if [ "$timing" = before ]; then
+    kill -TERM "\$spawn_pid"
+    kill -TERM "\$\$"
+  fi
+  "$real" "\$@" || exit \$?
+  if [ "$timing" = after ]; then
+    kill -TERM "\$spawn_pid"
+    kill -TERM "\$\$"
+  fi
+  exit 0
+fi
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/tasks-axi"
+}
+
+change_row_on_second_show() {  # <case-dir> <done|rm>
+  local case_dir=$1 action=$2 real
+  real=$(command -v tasks-axi)
+  cat > "$case_dir/fakebin/tasks-axi" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = show ]; then
+  count=0
+  [ ! -f "$case_dir/show-count" ] || count=\$(cat "$case_dir/show-count")
+  count=\$((count + 1))
+  printf '%s\n' "\$count" > "$case_dir/show-count"
+  if [ "\$count" -eq 2 ]; then
+    "$real" "$action" "\$2" --file "\$4" >/dev/null || exit 1
+  fi
+fi
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/tasks-axi"
+}
+
+break_launch_delivery() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+case "$*" in *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;; esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  send-keys) exit 1 ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux"
+}
+
+interrupt_kimi_readiness() {  # <case-dir>
+  local case_dir=$1 home
+  home=$(home_of "$case_dir")
+  mkdir -p "$home/.kimi-code"
+  printf '# test config\n' > "$home/.kimi-code/config.toml"
+  fm_fake_exit0 "$case_dir/fakebin" kimi
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *"#{pane_current_path}"*) printf '%s\\n' "\${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"#{cursor_y}"*) printf '1\\n'; exit 0 ;;
+esac
+case "\${1:-}" in
+  display-message) printf 'firstmate\\n'; exit 0 ;;
+  capture-pane)
+    if [ ! -f "$case_dir/kimi-interrupted" ]; then
+      : > "$case_dir/kimi-interrupted"
+      spawn_pid=\$(ps -o ppid= -p "\$PPID" | tr -d ' ')
+      case "\$spawn_pid" in ''|*[!0-9]*) exit 1 ;; esac
+      kill -TERM "\$spawn_pid"
+    fi
+    printf 'shell starting\\n$ \\n'
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux"
+}
+
+break_meta_removal() {  # <case-dir> <meta-path>
+  local case_dir=$1 meta=$2 real
+  real=$(command -v rm)
+  cat > "$case_dir/fakebin/rm" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  [ "\$arg" != "$meta" ] || exit 1
+done
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/rm"
+}
+
+break_busy_removal() {  # <case-dir> <id>
+  local case_dir=$1 id=$2 real state
+  real=$(command -v rm)
+  state="$(home_of "$case_dir")/state"
+  cat > "$case_dir/fakebin/rm" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  case "\$arg" in
+    "$state/$id.busy-state"|"$state/$id.busy-gen") exit 1 ;;
+  esac
+done
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/rm"
+}
+
+remove_data_during_startup_budget_check() {  # <case-dir>
+  local case_dir=$1 real data saved budget
+  real=$(command -v stat)
+  data="$(home_of "$case_dir")/data"
+  saved="$case_dir/bootstrap-data"
+  budget="$(home_of "$case_dir")/config/startup-memory-budget"
+  printf '7500\n' > "$budget"
+  cat > "$case_dir/fakebin/stat" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  if [ "\$arg" = "$budget" ] && [ ! -e "$case_dir/data-removed" ]; then
+    mv "$data" "$saved" || exit 1
+    : > "$case_dir/data-removed"
+  fi
+done
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/stat"
+}
+
+break_meta_publication() {  # <case-dir> <meta-path>
+  local case_dir=$1 meta=$2 real
+  real=$(command -v mv)
+  cat > "$case_dir/fakebin/mv" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  [ "\$arg" != "$meta" ] || exit 1
+done
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/mv"
+}
+
+write_task_meta() {  # <case-dir> <id> <kind> <mode> [extra-line...]
+  local case_dir=$1 id=$2 kind=$3 mode=$4
+  shift 4
+  fm_write_meta "$(home_of "$case_dir")/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "endpoint_task_id=$id" \
+    "worktree=$case_dir/absent-worktree" \
+    "project=$case_dir/absent-project" \
+    "harness=claude" \
+    "kind=$kind" \
+    "mode=$mode" \
+    "yolo=off" \
+    "$@"
+}
+
+run_spawn() {  # <case-dir> <args...>
+  local case_dir=$1
+  shift
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$case_dir/wt" TMUX="fake,1,0" \
+    CLAUDE_CONFIG_DIR='' \
+    PATH="$case_dir/fakebin:$PATH" \
+    "$SPAWN" "$@" 2>&1
+}
+
+run_ship_spawn() {  # <case-dir> <id>
+  local case_dir=$1 id=$2
+  run_spawn "$case_dir" "$id" "$case_dir/project" --mode no-mistakes --yolo off
+}
+
+# Teardown against a recorded worktree that no longer exists: the landed-work and
+# worktree-return steps are then no-ops, which keeps these cases about the
+# backlog transition rather than re-testing tests/fm-teardown.test.sh's matrix.
+run_teardown() {  # <case-dir> <id> [args...]
+  local case_dir=$1
+  shift
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    PATH="$case_dir/fakebin:$PATH" \
+    "$TEARDOWN" "$@" 2>&1
+}
+
+run_bootstrap() {  # <case-dir>
+  local case_dir=$1
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    FM_BOOTSTRAP_NETWORK=skip \
+    PATH="$case_dir/fakebin:$PATH" \
+    "$BOOTSTRAP" 2>&1
+}
+
+# --- dispatch ---------------------------------------------------------------
+
+test_dispatch_moves_the_item_in_flight_in_the_same_run() {
+  local case_dir id out
+  id=atomic-dispatch-b1
+  case_dir=$(make_home dispatch-ok "$id")
+  add_item "$case_dir" "$id"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || fail "spawn failed: $out"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" "spawn published no record"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "spawn reported success with its backlog item still $(row_state "$case_dir" "$id")"
+  pass "dispatch publishes the record and moves the backlog item In flight in one run"
+}
+
+test_dispatch_reads_the_row_from_the_backlog_root() {
+  local case_dir id out
+  id=atomic-dispatch-root-b2
+  case_dir=$(make_home dispatch-root "$id")
+  add_item "$case_dir" "$id"
+  require_show_cwd "$case_dir" "$(cd "$(home_of "$case_dir")" && pwd -P)"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || fail "spawn read outside the backlog root: $out"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "root-addressed dispatch left the backlog row queued"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "root-addressed dispatch did not publish its task record"
+  pass "dispatch reads backlog rows from the backlog addressing root"
+}
+
+test_recovery_uses_the_parent_of_a_trailing_slash_data_record() {
+  local case_dir id relocated backlog marker out
+  id=atomic-recovery-relocated-root-b2
+  case_dir=$(make_home recovery-relocated-root)
+  relocated="$case_dir/fm-records"
+  mkdir -p "$relocated"
+  backlog="$relocated/backlog.md"
+  printf '%s\n' '# Backlog' '' '## In flight' '' '## Queued' '' '## Done' > "$backlog"
+  tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
+  tasks-axi start "$id" --file "$backlog" >/dev/null
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s/\nspawn_gen=spawn-relocated-recovery\narg=--note\narg=local%%20main\n' "$id" "$relocated" > "$marker"
+  require_show_cwd "$case_dir" "$(cd "$case_dir" && pwd -P)"
+
+  out=$(FM_DATA_OVERRIDE="$relocated/" run_bootstrap "$case_dir")
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
+    || fail "relocated-data recovery used the wrong addressing root: $out"
+  assert_absent "$marker" "relocated-data recovery retained its close marker"
+  pass "recovery uses the parent of a trailing-slash data record"
+}
+
+test_completion_targets_a_nested_relative_data_directory() {
+  local case_dir id relative_data data backlog out
+  id=atomic-close-relative-data-b2
+  case_dir=$(make_home close-relative-data)
+  relative_data=relocated/data
+  data="$case_dir/$relative_data"
+  mkdir -p "$case_dir/relocated"
+  mv "$(home_of "$case_dir")/data" "$data"
+  backlog="$data/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
+  tasks-axi start "$id" --file "$backlog" >/dev/null
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-relative-data"
+
+  out=$(cd "$case_dir" && \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    FM_DATA_OVERRIDE="$relative_data" PATH="$case_dir/fakebin:$PATH" \
+    "$TEARDOWN" "$id" 2>&1) \
+    || fail "relative-data teardown failed: $out"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
+    || fail "relative-data teardown mutated a different backlog file"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "relative-data teardown retained its task record"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "relative-data teardown retained its close marker"
+  pass "completion targets nested relative data from the caller directory"
+}
+
+test_immediate_child_absolute_data_dispatches_and_completes() {
+  local case_dir id data backlog out
+  id=atomic-immediate-child-data-b2
+  case_dir=$(make_home immediate-child-data "$id")
+  data="$case_dir/fm-records"
+  mv "$(home_of "$case_dir")/data" "$data"
+  backlog="$data/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
+
+  out=$(FM_DATA_OVERRIDE="$data" run_ship_spawn "$case_dir" "$id") \
+    || fail "immediate-child-data spawn failed: $out"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = in_flight ] \
+    || fail "immediate-child absolute dispatch mutated a different backlog"
+  rm -f "$(home_of "$case_dir")/state/$id.meta"
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-immediate-child"
+  out=$(FM_DATA_OVERRIDE="$data" run_teardown "$case_dir" "$id") \
+    || fail "immediate-child-data teardown failed: $out"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
+    || fail "immediate-child absolute completion mutated a different backlog"
+  assert_contains "$out" "fm-records/backlog.md" \
+    "relocated completion confirmed the wrong backlog path"
+  pass "an immediate-child absolute data path keeps one paired backlog"
+}
+
+test_bare_relative_data_dispatches_and_completes() {
+  local case_dir id data backlog out
+  id=atomic-bare-relative-data-b2
+  case_dir=$(make_home bare-relative-data "$id")
+  data="$case_dir/records"
+  mv "$(home_of "$case_dir")/data" "$data"
+  backlog="$data/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
+
+  out=$(cd "$case_dir" && FM_DATA_OVERRIDE=records run_ship_spawn "$case_dir" "$id") \
+    || fail "bare-relative-data spawn failed: $out"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = in_flight ] \
+    || fail "bare relative dispatch mutated a different backlog"
+  rm -f "$(home_of "$case_dir")/state/$id.meta"
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-bare-relative"
+  out=$(cd "$case_dir" && FM_DATA_OVERRIDE=records run_teardown "$case_dir" "$id") \
+    || fail "bare-relative-data teardown failed: $out"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
+    || fail "bare relative completion mutated a different backlog"
+  pass "bare relative data addresses one backlog through dispatch and completion"
+}
+
+test_dispatch_refuses_an_unresolvable_data_directory() {
+  local case_dir id saved out rc=0
+  id=atomic-dispatch-missing-data-b2
+  case_dir=$(make_home dispatch-missing-data "$id")
+  add_item "$case_dir" "$id"
+  saved="$case_dir/backlog-data"
+  mv "$(home_of "$case_dir")/data" "$saved"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn succeeded with an unresolvable data directory"
+  assert_contains "$out" "task $id" \
+    "spawn did not identify the task blocked by fatal backlog addressing"
+  assert_contains "$out" "$(home_of "$case_dir")/data" \
+    "spawn did not identify the inaccessible data directory"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "fatal backlog addressing created a task record"
+  [ "$(tasks-axi show "$id" --file "$saved/backlog.md" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = queued ] \
+    || fail "fatal backlog addressing changed the queued row"
+  pass "dispatch refuses an unresolvable backlog data directory"
+}
+
+test_completion_refuses_an_unresolvable_data_directory() {
+  local case_dir id saved meta out rc=0
+  id=atomic-close-missing-data-b2
+  case_dir=$(make_home close-missing-data)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-missing-data"
+  meta="$(home_of "$case_dir")/state/$id.meta"
+  saved="$case_dir/backlog-data"
+  mv "$(home_of "$case_dir")/data" "$saved"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown succeeded with an unresolvable data directory"
+  assert_contains "$out" "task $id cannot be torn down" \
+    "teardown did not identify the task blocked by fatal backlog addressing"
+  assert_present "$meta" "fatal backlog addressing removed the task record"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "fatal backlog addressing wrote a close marker"
+  [ "$(tasks-axi show "$id" --file "$saved/backlog.md" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = in_flight ] \
+    || fail "fatal backlog addressing changed the In-flight row"
+  pass "completion refuses before mutation when backlog data is unresolvable"
+}
+
+test_dispatch_refuses_an_id_this_home_has_no_item_for() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-b2
+  case_dir=$(make_home dispatch-no-item "$id")
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn dispatched work no backlog item owns"
+  assert_contains "$out" "no backlog item in this home" \
+    "spawn refused without naming the missing backlog item"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "refused dispatch still left a record behind"
+  pass "dispatch refuses, before creating anything, when the home has no item for the id"
+}
+
+test_dispatch_reports_a_backlog_read_failure() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-read-failure-b3
+  case_dir=$(make_home dispatch-read-failure "$id")
+  add_item "$case_dir" "$id"
+  break_verb "$case_dir" show
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn succeeded though backlog preflight could not read its item"
+  assert_contains "$out" "backlog item could not be read before dispatch" \
+    "spawn misreported a backlog read failure"
+  assert_contains "$out" "backlog is unwritable" \
+    "spawn discarded the backlog reader's diagnostic"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "failed backlog preflight created a task record"
+  pass "dispatch distinguishes backlog read failures from missing items"
+}
+
+test_dispatch_refuses_a_closed_item() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-b3
+  case_dir=$(make_home dispatch-closed "$id")
+  add_item "$case_dir" "$id"
+  tasks-axi "done" "$id" --file "$(backlog_of "$case_dir")" >/dev/null
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn dispatched onto an item the backlog already closed"
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "refused dispatch silently reopened a closed item"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "refused dispatch onto a closed item still left a record behind"
+  pass "dispatch refuses a closed item instead of silently reopening it"
+}
+
+test_dispatch_refuses_to_commit_without_a_published_record() {
+  local case_dir id meta out rc=0
+  id=atomic-dispatch-publish-failure-b4
+  case_dir=$(make_home dispatch-publish-failure "$id")
+  add_item "$case_dir" "$id"
+  meta="$(home_of "$case_dir")/state/$id.meta"
+  break_meta_publication "$case_dir" "$meta"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn succeeded without publishing its task record"
+  assert_contains "$out" "task record for $id could not be published" \
+    "spawn did not report task-record publication failure"
+  assert_absent "$meta" "failed publication left a task record"
+  assert_absent "$(home_of "$case_dir")/state/$id.busy-state" \
+    "failed publication retained its busy state"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "failed publication moved the backlog row"
+  pass "dispatch cannot commit without a verified task-record publication"
+}
+
+test_dispatch_leaves_no_record_when_the_transition_fails() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-b4
+  case_dir=$(make_home dispatch-transition-fails "$id")
+  add_item "$case_dir" "$id"
+  break_verb "$case_dir" start
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn reported success though the backlog transition failed"
+  assert_contains "$out" "could not be moved to In flight" \
+    "spawn failed without explaining the backlog transition failure"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "a failed backlog transition left an orphaned record behind"
+  assert_absent "$(home_of "$case_dir")/state/$id.busy-state" \
+    "a failed backlog transition left the task's armed busy generation behind"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "a failed dispatch left the backlog item in $(row_state "$case_dir" "$id")"
+  pass "a failed backlog transition fails the dispatch loudly and leaves no record"
+}
+
+test_dispatch_reports_an_incomplete_record_rollback() {
+  local case_dir id meta out rc=0
+  id=atomic-dispatch-remove-failure-b5
+  case_dir=$(make_home dispatch-remove-failure "$id")
+  add_item "$case_dir" "$id"
+  meta="$(home_of "$case_dir")/state/$id.meta"
+  break_verb "$case_dir" start
+  break_meta_removal "$case_dir" "$meta"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn reported success though transition and rollback failed"
+  assert_contains "$out" "failed-dispatch cleanup is incomplete" \
+    "spawn did not report that its provisional record remained"
+  assert_present "$meta" "failed record removal was reported as successful"
+  assert_absent "$(home_of "$case_dir")/state/$id.busy-state" \
+    "record-removal failure prevented busy-state rollback"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "failed rollback changed the backlog row"
+  pass "dispatch reports when failed-transition rollback cannot remove its record"
+}
+
+test_dispatch_reports_an_incomplete_busy_rollback() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-busy-remove-failure-b5
+  case_dir=$(make_home dispatch-busy-remove-failure "$id")
+  add_item "$case_dir" "$id"
+  break_verb "$case_dir" start
+  break_busy_removal "$case_dir" "$id"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn succeeded though busy rollback failed"
+  assert_contains "$out" "did not remove both task and busy records" \
+    "spawn did not report incomplete busy rollback"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "busy rollback failure retained the provisional task record"
+  assert_present "$(home_of "$case_dir")/state/$id.busy-state" \
+    "busy removal failure was reported as successful"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "failed busy rollback changed the backlog row"
+  pass "dispatch verifies both task and busy records during rollback"
+}
+
+test_dispatch_rolls_back_before_a_failed_launch_delivery() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-delivery-fails-b5
+  case_dir=$(make_home dispatch-delivery-fails "$id")
+  add_item "$case_dir" "$id"
+  break_launch_delivery "$case_dir"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn reported success though launch delivery failed"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "a failed launch delivery left its provisional record behind"
+  assert_absent "$(home_of "$case_dir")/state/$id.busy-state" \
+    "a failed launch delivery left its provisional busy generation behind"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "launch delivery failed after committing backlog state $(row_state "$case_dir" "$id")"
+  pass "dispatch commits neither record nor backlog state before launch delivery succeeds"
+}
+
+test_dispatch_defers_interruption_across_backlog_commit() {
+  local timing case_dir id out rc
+  for timing in before after; do
+    id="atomic-dispatch-interrupted-$timing-b5"
+    case_dir=$(make_home "dispatch-interrupted-$timing" "$id")
+    add_item "$case_dir" "$id"
+    interrupt_spawn_during_start "$case_dir" "$timing"
+
+    rc=0
+    out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+    [ "$rc" -ne 0 ] || fail "a $timing-commit interruption was reported as success"
+    assert_contains "$out" "paired task record and In-flight backlog state were preserved" \
+      "a $timing-commit interruption did not report its atomic outcome"
+    [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+      || fail "a $timing-commit interruption left the backlog row queued"
+    assert_present "$(home_of "$case_dir")/state/$id.meta" \
+      "a $timing-commit interruption removed the paired task record"
+  done
+  pass "dispatch retries interrupted transitions before honoring termination"
+}
+
+test_dispatch_does_not_resurrect_a_row_closed_after_preflight() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-closed-race-b5
+  case_dir=$(make_home dispatch-closed-race "$id")
+  add_item "$case_dir" "$id"
+  change_row_on_second_show "$case_dir" "done"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn succeeded after its backlog row was closed"
+  assert_contains "$out" "state done" "spawn did not report the row's ineligible state"
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "spawn resurrected a row closed after preflight"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "spawn retained a record after its row was closed"
+  pass "dispatch does not resurrect a row closed after preflight"
+}
+
+test_dispatch_fails_when_its_row_vanishes_after_preflight() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-removed-race-b6
+  case_dir=$(make_home dispatch-removed-race "$id")
+  add_item "$case_dir" "$id"
+  change_row_on_second_show "$case_dir" rm
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn succeeded after its backlog row vanished"
+  assert_contains "$out" "vanished before dispatch commit" \
+    "spawn did not report that its backlog row vanished"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "spawn retained a record after its backlog row vanished"
+  [ -z "$(row_state "$case_dir" "$id")" ] || fail "spawn recreated a removed backlog row"
+  pass "dispatch fails when its backlog row vanishes after preflight"
+}
+
+# --- completion -------------------------------------------------------------
+
+test_completion_closes_a_local_only_ship_before_reporting_success() {
+  local case_dir id out
+  id=atomic-close-b5
+  case_dir=$(make_home close-local-only)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-close-local"
+
+  out=$(run_teardown "$case_dir" "$id") || fail "teardown failed: $out"
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "teardown reported success with the item still $(row_state "$case_dir" "$id")"
+  assert_grep 'local main' "$(backlog_of "$case_dir")" \
+    "a local-only landing was closed without its local-main note"
+  pass "completion closes a local-only ship, with its landing note, before reporting success"
+}
+
+test_completion_closes_a_scout_with_its_report() {
+  local case_dir id out
+  id=atomic-close-b6
+  case_dir=$(make_home close-scout)
+  add_item "$case_dir" "$id" scout
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" scout '' "spawn_gen=spawn-close-scout"
+  # A scout's deliverable is its report, and teardown also enforces the shared
+  # captain-call completion gate; satisfy both the way a real scout does.
+  mkdir -p "$(home_of "$case_dir")/data/$id"
+  printf 'findings\n' > "$(home_of "$case_dir")/data/$id/report.md"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    PATH="$case_dir/fakebin:$PATH" \
+    "$ROOT/bin/fm-captain-hold.sh" complete "$id" --none >/dev/null \
+    || fail "could not record the scout's completed captain-call inventory"
+
+  out=$(run_teardown "$case_dir" "$id") || fail "teardown failed: $out"
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "teardown reported success with the scout item still $(row_state "$case_dir" "$id")"
+  assert_grep "data/$id/report.md" "$(backlog_of "$case_dir")" \
+    "a closed scout item did not record its report"
+  pass "completion closes a scout item against its report"
+}
+
+test_completion_refuses_a_legacy_record_without_an_incarnation() {
+  local case_dir id meta out rc=0
+  id=atomic-close-legacy-no-incarnation-b7
+  case_dir=$(make_home close-legacy-no-incarnation)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only
+  meta="$(home_of "$case_dir")/state/$id.meta"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown accepted a record with no durable incarnation"
+  assert_contains "$out" "record has no spawn_gen" \
+    "teardown did not explain why the legacy record cannot close automatically"
+  assert_present "$meta" "legacy-record refusal removed the task record"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "legacy-record refusal wrote an unrecoverable close marker"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "legacy-record refusal changed the backlog row"
+  pass "completion leaves legacy records open when no incarnation can be recorded"
+}
+
+test_completion_records_a_relative_report_for_relocated_data() {
+  local case_dir id relocated backlog out
+  id=atomic-close-relocated-scout-b7
+  case_dir=$(make_home close-relocated-scout)
+  relocated="$case_dir/relocated/data"
+  mkdir -p "$case_dir/relocated"
+  mv "$(home_of "$case_dir")/data" "$relocated"
+  backlog="$relocated/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind scout --file "$backlog" >/dev/null
+  tasks-axi start "$id" --file "$backlog" >/dev/null
+  write_task_meta "$case_dir" "$id" scout '' "spawn_gen=spawn-relocated-scout"
+  mkdir -p "$relocated/$id"
+  printf 'findings\n' > "$relocated/$id/report.md"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    FM_DATA_OVERRIDE="$relocated////" PATH="$case_dir/fakebin:$PATH" \
+    "$ROOT/bin/fm-captain-hold.sh" complete "$id" --none >/dev/null \
+    || fail "could not record the relocated scout's captain-call inventory"
+
+  out=$(FM_DATA_OVERRIDE="$relocated////" run_teardown "$case_dir" "$id") \
+    || fail "relocated scout teardown failed: $out"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
+    || fail "relocated scout backlog row was not closed"
+  assert_grep "data/$id/report.md" "$backlog" \
+    "relocated scout close did not record a relative report path"
+  pass "completion records relocated scout reports relative to the backlog root"
+}
+
+test_space_containing_scout_report_marker_replays() {
+  local case_dir id data backlog marker out rc=0
+  id=atomic-space-report-replay-b7
+  case_dir=$(make_home space-report-replay)
+  data="$case_dir/crew space/data"
+  mkdir -p "$case_dir/crew space"
+  mv "$(home_of "$case_dir")/data" "$data"
+  backlog="$data/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind scout --file "$backlog" >/dev/null
+  tasks-axi start "$id" --file "$backlog" >/dev/null
+  write_task_meta "$case_dir" "$id" scout '' "spawn_gen=spawn-space-report"
+  mkdir -p "$data/$id"
+  printf 'findings\n' > "$data/$id/report.md"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$(home_of "$case_dir")" \
+    FM_DATA_OVERRIDE="$data" PATH="$case_dir/fakebin:$PATH" \
+    "$ROOT/bin/fm-captain-hold.sh" complete "$id" --none >/dev/null \
+    || fail "could not record the space-path scout's captain-call inventory"
+  break_verb "$case_dir" "done"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+
+  out=$(FM_DATA_OVERRIDE="$data" run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "space-path scout teardown unexpectedly completed"
+  assert_present "$marker" "space-path scout teardown recorded no pending close"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "space-path scout teardown retained meta after recording its close"
+  rm -f "$case_dir/fakebin/tasks-axi"
+
+  out=$(FM_DATA_OVERRIDE="$data" run_bootstrap "$case_dir")
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
+    || fail "space-containing report marker did not replay: $out"
+  assert_grep "data/$id/report.md" "$backlog" \
+    "report path from a space-containing data directory was lost during replay"
+  assert_absent "$marker" "space-containing report marker remained after replay"
+  pass "space-containing scout report paths round-trip through recovery"
+}
+
+test_trailing_newline_data_path_fails_closed() {
+  local case_dir home id data backlog_alias out rc=0
+  id=atomic-newline-data-refusal-c8
+  case_dir=$(make_home newline-data-refusal "$id")
+  home=$(home_of "$case_dir")
+  data="$home/data"$'\n'
+  mv "$home/data" "$data"
+  mkdir -p "$home/data/$id"
+  cp "$data/$id/brief.md" "$home/data/$id/brief.md"
+  ln -s "$data" "$case_dir/data-alias"
+  backlog_alias="$case_dir/data-alias/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind ship --file "$backlog_alias" >/dev/null
+
+  out=$(FM_DATA_OVERRIDE="$data" run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "trailing-newline data path bypassed dispatch transition"
+  assert_absent "$home/state/$id.meta" \
+    "trailing-newline dispatch published a task record"
+  [ "$(tasks-axi show "$id" --file "$backlog_alias" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = queued ] \
+    || fail "trailing-newline dispatch changed the real backlog row: $out"
+
+  tasks-axi start "$id" --file "$backlog_alias" >/dev/null
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-newline-data"
+  rc=0
+  out=$(FM_DATA_OVERRIDE="$data" run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "trailing-newline data path bypassed completion transition"
+  assert_present "$home/state/$id.meta" \
+    "trailing-newline teardown removed the task record"
+  assert_absent "$home/state/$id.backlog-close" \
+    "trailing-newline teardown published a close marker"
+  [ "$(tasks-axi show "$id" --file "$backlog_alias" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = in_flight ] \
+    || fail "trailing-newline teardown changed the real backlog row: $out"
+  pass "control-byte data paths fail closed before paired transitions"
+}
+
+test_control_character_data_path_is_refused_before_cleanup() {
+  local case_dir id data backlog marker out rc=0
+  id=atomic-control-data-refusal-b7
+  case_dir=$(make_home control-data-refusal "$id")
+  data="$case_dir/crew"$'\t'"data"
+  mv "$(home_of "$case_dir")/data" "$data"
+  backlog="$data/backlog.md"
+  tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
+
+  out=$(FM_DATA_OVERRIDE="$data" run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "control-character data path passed dispatch preflight"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "control-character dispatch published a task record"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = queued ] \
+    || fail "control-character dispatch changed the backlog row: $out"
+
+  tasks-axi start "$id" --file "$backlog" >/dev/null
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-control-data"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  rc=0
+  out=$(FM_DATA_OVERRIDE="$data" run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "control-character data path passed close preflight"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "control-character close preflight removed the task record"
+  assert_absent "$marker" "control-character close preflight published a marker"
+  [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = in_flight ] \
+    || fail "control-character close preflight changed the backlog row: $out"
+  pass "unreplayable data paths are refused before destructive cleanup"
+}
+
+test_completion_preserves_records_when_meta_removal_fails() {
+  local case_dir id meta marker out rc=0
+  id=atomic-close-meta-remove-failure-b7
+  case_dir=$(make_home close-meta-remove-failure)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-one"
+  meta="$(home_of "$case_dir")/state/$id.meta"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  break_meta_removal "$case_dir" "$meta"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown succeeded though task-record removal failed"
+  assert_contains "$out" "task record could not be removed" \
+    "teardown did not report task-record removal failure"
+  assert_present "$meta" "teardown lost meta after its removal failed"
+  assert_present "$marker" "teardown discarded recovery after meta removal failed"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "teardown closed the row before verifying meta removal"
+  pass "completion preserves recovery state when task-record removal fails"
+}
+
+test_completion_fails_loudly_and_records_the_close_it_still_owes() {
+  local case_dir id out rc=0
+  id=atomic-close-b7
+  case_dir=$(make_home close-fails)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-close-fails"
+  break_verb "$case_dir" "done"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown reported success while its item was still In flight"
+  assert_contains "$out" "could not be closed" \
+    "teardown failed without explaining the unclosed backlog item"
+  assert_present "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "teardown lost the close it still owes"
+  pass "completion refuses to report success while its item is still open, and records what it owes"
+}
+
+test_completion_fails_when_its_close_marker_cannot_be_removed() {
+  local case_dir id marker out rc=0
+  id=atomic-close-marker-remove-failure-b8
+  case_dir=$(make_home close-marker-remove-failure)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-marker-fails"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  break_meta_removal "$case_dir" "$marker"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown reported success while its close marker remained"
+  assert_contains "$out" "pending-close record could not be removed" \
+    "teardown did not report its incomplete marker cleanup"
+  assert_present "$marker" "teardown hid a close-marker removal failure"
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "marker cleanup failure lost the completed backlog transition"
+  pass "completion reports failure until its durable close marker is removed"
+}
+
+# --- same-home recovery -----------------------------------------------------
+
+test_recovery_retries_when_a_close_marker_cannot_be_removed() {
+  local case_dir id marker out
+  id=atomic-heal-marker-remove-failure-b8
+  case_dir=$(make_home heal-marker-remove-failure)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-marker-retry\narg=--note\narg=local%%20main\n' \
+    "$id" "$(home_of "$case_dir")/data" > "$marker"
+  break_meta_removal "$case_dir" "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_contains "$out" "pending-close record could not be removed" \
+    "session start did not report close-marker removal failure"
+  assert_present "$marker" "recovery hid a close-marker removal failure"
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "recovery did not land the close before marker cleanup"
+
+  rm -f "$case_dir/fakebin/rm"
+  out=$(run_bootstrap "$case_dir")
+  assert_absent "$marker" "recovery did not retry close-marker cleanup: $out"
+  pass "session start retries a close whose marker could not be removed"
+}
+
+test_recovery_reports_an_owned_row_read_failure() {
+  local case_dir id out
+  id=atomic-heal-read-failure-b8
+  case_dir=$(make_home heal-owned-read-failure)
+  add_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes
+  break_verb "$case_dir" show
+
+  out=$(run_bootstrap "$case_dir")
+  assert_contains "$out" "worker record exists but its backlog item could not be read" \
+    "session start silently ignored an owned-row read failure"
+  assert_contains "$out" "backlog is unwritable" \
+    "session start discarded the backlog reader's diagnostic"
+  rm -f "$case_dir/fakebin/tasks-axi"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "owned-row read failure changed the backlog state"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "owned-row read failure removed the worker record"
+  pass "session start reports owned backlog rows it cannot read"
+}
+
+test_orca_cleanup_recovery_never_transitions_the_backlog() {
+  local case_dir id meta out
+  id=atomic-orca-cleanup-recovery-b8
+  case_dir=$(make_home orca-cleanup-recovery)
+  add_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only "cleanup_recovery=orca"
+  meta="$(home_of "$case_dir")/state/$id.meta"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "session start treated cleanup recovery as a launched worker: $out"
+  assert_present "$meta" "session start removed the cleanup recovery record"
+
+  out=$(run_teardown "$case_dir" "$id") \
+    || fail "cleanup recovery teardown failed: $out"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "cleanup recovery teardown completed work that never launched"
+  assert_absent "$meta" "cleanup recovery teardown retained its task record"
+  pass "Orca cleanup recovery is excluded from backlog lifecycle transitions"
+}
+
+test_recovery_marks_an_owned_record_in_flight() {
+  local case_dir id out
+  id=atomic-heal-b8
+  case_dir=$(make_home heal-queued)
+  add_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "session start left an owned record's item at $(row_state "$case_dir" "$id"): $out"
+  pass "session start marks an item In flight when this home already owns a worker for it"
+}
+
+test_recovery_replays_a_close_an_interrupted_cleanup_left_open() {
+  local case_dir id out
+  id=atomic-heal-b9
+  case_dir=$(make_home heal-pending-close)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-heal-pr\narg=--pr\narg=https://github.com/example/repo/pull/11\n' \
+    "$id" "$(home_of "$case_dir")/data" \
+    > "$(home_of "$case_dir")/state/$id.backlog-close"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "session start left an interrupted cleanup's item at $(row_state "$case_dir" "$id"): $out"
+  assert_grep 'https://github.com/example/repo/pull/11' "$(backlog_of "$case_dir")" \
+    "the replayed close dropped the completion link the cleanup had recorded"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "a replayed close left its record behind"
+  pass "session start finishes a close an interrupted cleanup recorded but never landed"
+}
+
+test_recovery_preserves_a_close_when_the_backlog_cannot_be_read() {
+  local case_dir id out
+  id=atomic-heal-read-error-b10
+  case_dir=$(make_home heal-read-error)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-heal-read\narg=--note\narg=local%%20main\n' \
+    "$id" "$(home_of "$case_dir")/data" \
+    > "$(home_of "$case_dir")/state/$id.backlog-close"
+  break_verb "$case_dir" show
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "a transient backlog read failure discarded the pending close"
+  rm -f "$case_dir/fakebin/tasks-axi"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "a failed recovery changed the backlog row: $out"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "the preserved close was not retried after the read recovered: $out"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "a successfully retried close left its marker behind"
+  pass "session start preserves a pending close across a transient backlog read failure"
+}
+
+test_recovery_finishes_a_close_for_the_same_meta_incarnation() {
+  local case_dir id out
+  id=atomic-heal-same-incarnation-b11
+  case_dir=$(make_home heal-same-incarnation)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-one"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-one\narg=--note\narg=local%%20main\n' \
+    "$id" "$(home_of "$case_dir")/data" \
+    > "$(home_of "$case_dir")/state/$id.backlog-close"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "session start did not close the interrupted incarnation: $out"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "session start retained the interrupted incarnation's meta"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "session start retained the completed incarnation's close marker"
+  pass "session start finishes a close for the matching meta incarnation"
+}
+
+test_recovery_preserves_both_records_when_meta_removal_fails() {
+  local case_dir id meta out
+  id=atomic-heal-remove-failure-b12
+  case_dir=$(make_home heal-remove-failure)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  meta="$(home_of "$case_dir")/state/$id.meta"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-one"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-one\narg=--note\narg=local%%20main\n' \
+    "$id" "$(home_of "$case_dir")/data" \
+    > "$(home_of "$case_dir")/state/$id.backlog-close"
+  break_meta_removal "$case_dir" "$meta"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_contains "$out" "the interrupted task record could not be removed" \
+    "session start did not surface the record-removal failure"
+  assert_present "$meta" "failed recovery removed the task record"
+  assert_present "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "failed recovery discarded the pending close"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "failed recovery closed the backlog before removing meta"
+
+  rm -f "$case_dir/fakebin/rm"
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "recovery did not retry after meta removal recovered: $out"
+  assert_absent "$meta" "successful retry retained the task record"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "successful retry retained the pending close"
+  pass "recovery preserves both records when meta removal fails"
+}
+
+test_recovery_rejects_a_marker_for_another_task_identity() {
+  local case_dir locked_id target_id marker out
+  locked_id=atomic-marker-lock-owner-b12
+  target_id=atomic-marker-target-b12
+  case_dir=$(make_home marker-identity-mismatch)
+  add_item "$case_dir" "$target_id"
+  start_item "$case_dir" "$target_id"
+  write_task_meta "$case_dir" "$target_id" ship no-mistakes "spawn_gen=spawn-marker-target"
+  marker="$(home_of "$case_dir")/state/$locked_id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-marker-target\narg=--note\narg=local%%20main\n' \
+    "$target_id" "$(home_of "$case_dir")/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "identity-mismatched close marker was consumed"
+  assert_present "$(home_of "$case_dir")/state/$target_id.meta" \
+    "identity-mismatched close marker removed another task record"
+  [ "$(row_state "$case_dir" "$target_id")" = in_flight ] \
+    || fail "identity-mismatched close marker changed another task's row: $out"
+  pass "recovery binds close-marker identity to its locked filename"
+}
+
+test_recovery_rejects_a_foreign_data_directory() {
+  local case_dir foreign_case id marker out
+  id=atomic-marker-foreign-data-b12
+  case_dir=$(make_home marker-foreign-data-local)
+  foreign_case=$(make_home marker-foreign-data-remote)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  add_item "$foreign_case" "$id"
+  start_item "$foreign_case" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-foreign-data"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-foreign-data\narg=--note\narg=local%%20main\n' \
+    "$id" "$(home_of "$foreign_case")/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "foreign-data close marker was consumed"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "foreign-data close marker removed the local task record"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "foreign-data close marker changed the local backlog row: $out"
+  [ "$(row_state "$foreign_case" "$id")" = in_flight ] \
+    || fail "foreign-data close marker reached into another home's backlog: $out"
+  pass "recovery rejects close markers targeting another home's data"
+}
+
+test_recovery_rejects_an_unterminated_unknown_field() {
+  local case_dir id marker out
+  id=atomic-marker-unterminated-field-b12
+  case_dir=$(make_home marker-unterminated-field)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-unterminated-field"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-unterminated-field\narg=--note\narg=local%%20main\nunknown=value' \
+    "$id" "$(home_of "$case_dir")/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "marker with an unterminated unknown field was consumed"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "unterminated unknown marker field allowed task-record removal"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "unterminated unknown marker field changed the backlog row: $out"
+  pass "recovery validates an unterminated final marker field"
+}
+
+test_recovery_rejects_lexical_data_traversal() {
+  local case_dir id marker data out
+  id=atomic-marker-data-traversal-b12
+  case_dir=$(make_home marker-data-traversal)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-data-traversal"
+  data="$(home_of "$case_dir")/data"
+  mkdir -p "$data/sub"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s/sub/..\nspawn_gen=spawn-data-traversal\narg=--note\narg=local%%20main\n' \
+    "$id" "$data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "marker with lexical data traversal was consumed"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "lexical data traversal allowed task-record removal"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "lexical data traversal changed the backlog row: $out"
+  pass "recovery rejects lexical traversal before resolving marker data"
+}
+
+test_recovery_rejects_raw_control_bytes() {
+  local case_dir id marker data out
+  id=atomic-marker-nul-byte-b12
+  case_dir=$(make_home marker-nul-byte)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-nul-byte"
+  data="$(home_of "$case_dir")/data"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\0\nspawn_gen=spawn-nul-byte\narg=--note\narg=local%%20main\n' \
+    "$id" "$data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "NUL-bearing close marker was consumed"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "NUL-bearing close marker removed the task record"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "NUL-bearing close marker changed the backlog row: $out"
+  pass "recovery rejects marker control bytes before parsing"
+}
+
+test_recovery_rejects_malformed_pr_urls() {
+  local case_dir first_id second_id third_id first_marker second_marker third_marker out
+  first_id=atomic-marker-pr-port-b12
+  second_id=atomic-marker-pr-percent-b12
+  third_id=atomic-marker-pr-host-label-b12
+  case_dir=$(make_home marker-malformed-pr)
+  add_item "$case_dir" "$first_id"
+  start_item "$case_dir" "$first_id"
+  add_item "$case_dir" "$second_id"
+  start_item "$case_dir" "$second_id"
+  add_item "$case_dir" "$third_id"
+  start_item "$case_dir" "$third_id"
+  first_marker="$(home_of "$case_dir")/state/$first_id.backlog-close"
+  second_marker="$(home_of "$case_dir")/state/$second_id.backlog-close"
+  third_marker="$(home_of "$case_dir")/state/$third_id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-pr-port\narg=--pr\narg=https://github.com:abc/pull/1\n' \
+    "$first_id" "$(home_of "$case_dir")/data" > "$first_marker"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-pr-percent\narg=--pr\narg=https://github.com/pull/%%ZZ\n' \
+    "$second_id" "$(home_of "$case_dir")/data" > "$second_marker"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-pr-host-label\narg=--pr\narg=https://foo.-bar.com/pull/1\n' \
+    "$third_id" "$(home_of "$case_dir")/data" > "$third_marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$first_marker" "PR marker with a nonnumeric port was consumed"
+  assert_present "$second_marker" "PR marker with an invalid percent escape was consumed"
+  assert_present "$third_marker" "PR marker with a malformed host label was consumed"
+  [ "$(row_state "$case_dir" "$first_id")" = in_flight ] \
+    || fail "nonnumeric PR port changed the backlog row: $out"
+  [ "$(row_state "$case_dir" "$second_id")" = in_flight ] \
+    || fail "invalid PR percent escape changed the backlog row: $out"
+  [ "$(row_state "$case_dir" "$third_id")" = in_flight ] \
+    || fail "malformed PR host label changed the backlog row: $out"
+  pass "recovery rejects malformed PR URL values"
+}
+
+test_failed_close_replay_is_not_started_as_live_work() {
+  local case_dir id marker out
+  id=atomic-pending-close-not-started-b12
+  case_dir=$(make_home pending-close-not-started)
+  add_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-pending-close"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-pending-close\narg=--pr\narg=https://\n' \
+    "$id" "$(home_of "$case_dir")/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "failed close replay discarded its pending marker"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "failed close replay removed its task record"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "retained pending close was started as live work: $out"
+  pass "a retained pending close is never started by reconciliation"
+}
+
+test_recovery_rejects_invalid_close_arguments() {
+  local case_dir id marker out
+  id=atomic-marker-invalid-args-b12
+  case_dir=$(make_home marker-invalid-args)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-invalid-args\narg=--unknown\narg=value\n' \
+    "$id" "$(home_of "$case_dir")/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_present "$marker" "invalid-argument close marker was consumed"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "invalid close arguments changed the backlog row: $out"
+  pass "recovery rejects close-marker arguments outside its protocol"
+}
+
+test_recovery_rejects_a_symlinked_close_marker() {
+  local case_dir id marker payload out
+  id=atomic-marker-symlink-b12
+  case_dir=$(make_home marker-symlink)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  payload="$(home_of "$case_dir")/state/marker-payload"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-symlink\narg=--note\narg=local%%20main\n' \
+    "$id" "$(home_of "$case_dir")/data" > "$payload"
+  ln -s "$payload" "$marker"
+  rm -f "$payload"
+
+  out=$(run_bootstrap "$case_dir")
+  [ -L "$marker" ] || fail "dangling symlink close marker was consumed: $out"
+  assert_contains "$out" "recorded backlog close could not be replayed" \
+    "dangling symlink close marker was silently skipped"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "symlinked close marker changed the backlog row: $out"
+  pass "recovery reports and rejects dangling symlink close markers"
+}
+
+test_recovery_drops_a_close_for_a_newer_meta_incarnation() {
+  local case_dir id out
+  id=atomic-heal-new-incarnation-b12
+  case_dir=$(make_home heal-new-incarnation)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-two"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-one\narg=--note\narg=local%%20main\n' \
+    "$id" "$(home_of "$case_dir")/data" \
+    > "$(home_of "$case_dir")/state/$id.backlog-close"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "session start closed the newer task incarnation: $out"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "session start removed the newer task incarnation's meta"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "a stale recorded close was left to fire on a later restart"
+  pass "session start drops a close recorded for an older meta incarnation"
+}
+
+test_recovery_rejects_a_legacy_close_without_an_incarnation() {
+  local case_dir id out
+  id=atomic-heal-legacy-close-b13
+  case_dir=$(make_home heal-legacy-close)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-two"
+  printf 'id=%s\ndata=%s\narg=--note\narg=local%%20main\n' \
+    "$id" "$(home_of "$case_dir")/data" \
+    > "$(home_of "$case_dir")/state/$id.backlog-close"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "session start guessed that a legacy close belonged to the current meta: $out"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "session start removed meta for an unversioned legacy close"
+  assert_present "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "session start consumed an unversioned close marker"
+  pass "session start rejects an unversioned close marker"
+}
+
+test_bootstrap_stops_when_data_disappears_before_reconciliation() {
+  local case_dir id saved out rc=0
+  id=atomic-bootstrap-data-race-b11
+  case_dir=$(make_home bootstrap-data-race)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-bootstrap-race"
+  remove_data_during_startup_budget_check "$case_dir"
+  saved="$case_dir/bootstrap-data"
+
+  out=$(run_bootstrap "$case_dir") || rc=$?
+  [ "$rc" -ne 0 ] || fail "bootstrap absorbed a fatal reconciliation addressing error: $out"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "fatal bootstrap reconciliation removed the task record"
+  [ "$(tasks-axi show "$id" --file "$saved/backlog.md" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = in_flight ] \
+    || fail "fatal bootstrap reconciliation changed the backlog row"
+  pass "bootstrap stops when backlog data disappears before reconciliation"
+}
+
+test_bootstrap_addressing_exemptions_remain_nonfatal() {
+  local manual_case no_backlog_case secondmate_case secondmate_id out
+  manual_case=$(make_home bootstrap-manual-exempt)
+  printf '%s\n' manual > "$(home_of "$manual_case")/config/backlog-backend"
+  mv "$(home_of "$manual_case")/data" "$manual_case/manual-data"
+  out=$(run_bootstrap "$manual_case") \
+    || fail "manual bootstrap exemption became fatal: $out"
+
+  no_backlog_case=$(make_home bootstrap-no-backlog-exempt)
+  rm -f "$(backlog_of "$no_backlog_case")"
+  out=$(run_bootstrap "$no_backlog_case") \
+    || fail "no-backlog bootstrap exemption became fatal: $out"
+
+  secondmate_id=atomic-bootstrap-secondmate-exempt-b11
+  secondmate_case=$(make_home bootstrap-secondmate-exempt)
+  write_task_meta "$secondmate_case" "$secondmate_id" secondmate '' \
+    "spawn_gen=spawn-secondmate-exempt"
+  mv "$(home_of "$secondmate_case")/data" "$secondmate_case/secondmate-data"
+  out=$(run_bootstrap "$secondmate_case") \
+    || fail "secondmate bootstrap exemption became fatal: $out"
+  assert_present "$(home_of "$secondmate_case")/state/$secondmate_id.meta" \
+    "secondmate bootstrap exemption removed the persistent agent record"
+  pass "bootstrap preserves secondmate, manual, and absent-backlog exemptions"
+}
+
+test_recovery_leaves_a_captain_held_item_alone() {
+  local case_dir id out
+  id=atomic-heal-b11
+  case_dir=$(make_home heal-held)
+  add_item "$case_dir" "$id"
+  tasks-axi hold "$id" --reason "captain decision pending" --kind captain \
+    --file "$(backlog_of "$case_dir")" >/dev/null
+  write_task_meta "$case_dir" "$id" ship no-mistakes
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "session start moved a captain-held item to $(row_state "$case_dir" "$id"): $out"
+  pass "session start leaves a captain-held item where the captain put it"
+}
+
+# --- backend selection and secondmate scope ---------------------------------
+
+test_home_without_a_backlog_dispatches_and_completes() {
+  local case_dir id out
+  id=atomic-no-backlog-b12
+  case_dir=$(make_home no-backlog "$id")
+  rm -f "$(backlog_of "$case_dir")"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || fail "no-backlog spawn failed: $out"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" \
+    "no-backlog spawn did not publish its task record"
+  out=$(run_teardown "$case_dir" "$id") || fail "no-backlog teardown failed: $out"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "no-backlog teardown retained its task record"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "no-backlog teardown recorded a close marker"
+  pass "a home with no backlog remains exempt from lifecycle transitions"
+}
+
+test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog() {
+  local case_dir id out
+  id=atomic-manual-b12
+  case_dir=$(make_home manual-backend "$id")
+  printf '%s\n' manual > "$(home_of "$case_dir")/config/backlog-backend"
+  # Deliberately no backlog item: on a manual home the operator owns the file,
+  # so neither half of the lifecycle may hard-fail over its contents.
+  out=$(run_ship_spawn "$case_dir" "$id") || fail "manual-backend spawn failed: $out"
+  assert_contains "$out" "spawned $id" "manual-backend spawn did not report success"
+  mv "$(home_of "$case_dir")/data" "$case_dir/manual-data"
+
+  out=$(run_teardown "$case_dir" "$id") || fail "manual-backend teardown failed: $out"
+  assert_contains "$out" "Update $(home_of "$case_dir")/data/backlog.md" \
+    "manual-backend teardown did not name its configured backlog path"
+  assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
+    "manual-backend teardown recorded a close it never owed"
+  pass "a manual-backlog home dispatches and completes without a hard failure"
+}
+
+test_a_secondmate_home_keeps_its_own_books() {
+  local case_dir id out
+  id=atomic-mate-b13
+  case_dir=$(make_home mate-own-books "$id")
+  # The mate's home is a firstmate home in its own right; the invariant is
+  # single-host, so its own dispatch and completion keep its own two records
+  # paired with no parent involved.
+  printf '%s\n' mate-h1 > "$(home_of "$case_dir")/.fm-secondmate-home"
+  add_item "$case_dir" "$id"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || fail "mate-home spawn failed: $out"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "a mate's own dispatch left its item at $(row_state "$case_dir" "$id")"
+
+  rm -f "$(home_of "$case_dir")/state/$id.meta"
+  write_task_meta "$case_dir" "$id" ship local-only "spawn_gen=spawn-mate-close"
+  out=$(run_teardown "$case_dir" "$id") || fail "mate-home teardown failed: $out"
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "a mate's own completion left its item at $(row_state "$case_dir" "$id")"
+  pass "a secondmate home keeps its own books paired through dispatch and completion"
+}
+
+test_a_persistent_secondmate_is_never_a_backlog_item() {
+  local case_dir id out mate
+  id=atomic-mate-b14
+  case_dir=$(make_home mate-not-an-item)
+  mate="$case_dir/mate-home"
+  mkdir -p "$mate/bin" "$mate/data"
+  printf '# Firstmate\n' > "$mate/AGENTS.md"
+  printf '%s\n' "$id" > "$mate/.fm-secondmate-home"
+  printf 'charter for %s\n' "$id" > "$mate/data/charter.md"
+
+  # No backlog item exists for the mate, and none should be required: agents are
+  # not work items. The dispatch must succeed anyway.
+  out=$(run_spawn "$case_dir" "$id" "$mate" --secondmate) \
+    || fail "secondmate spawn failed: $out"
+  assert_contains "$out" "spawned $id" "secondmate spawn did not report success"
+  assert_present "$(home_of "$case_dir")/state/$id.meta" "secondmate spawn published no record"
+  pass "dispatching a persistent secondmate needs no backlog item"
+}
+
+test_dispatch_moves_the_item_in_flight_in_the_same_run
+test_dispatch_reads_the_row_from_the_backlog_root
+test_recovery_uses_the_parent_of_a_trailing_slash_data_record
+test_completion_targets_a_nested_relative_data_directory
+test_immediate_child_absolute_data_dispatches_and_completes
+test_bare_relative_data_dispatches_and_completes
+test_dispatch_refuses_an_unresolvable_data_directory
+test_completion_refuses_an_unresolvable_data_directory
+test_dispatch_refuses_an_id_this_home_has_no_item_for
+test_dispatch_reports_a_backlog_read_failure
+test_dispatch_refuses_a_closed_item
+test_dispatch_refuses_to_commit_without_a_published_record
+test_dispatch_leaves_no_record_when_the_transition_fails
+test_dispatch_reports_an_incomplete_record_rollback
+test_dispatch_reports_an_incomplete_busy_rollback
+test_dispatch_rolls_back_before_a_failed_launch_delivery
+test_dispatch_defers_interruption_across_backlog_commit
+test_dispatch_does_not_resurrect_a_row_closed_after_preflight
+test_dispatch_fails_when_its_row_vanishes_after_preflight
+test_completion_closes_a_local_only_ship_before_reporting_success
+test_completion_closes_a_scout_with_its_report
+test_completion_refuses_a_legacy_record_without_an_incarnation
+test_completion_records_a_relative_report_for_relocated_data
+test_space_containing_scout_report_marker_replays
+test_trailing_newline_data_path_fails_closed
+test_control_character_data_path_is_refused_before_cleanup
+test_completion_preserves_records_when_meta_removal_fails
+test_completion_fails_loudly_and_records_the_close_it_still_owes
+test_completion_fails_when_its_close_marker_cannot_be_removed
+test_recovery_retries_when_a_close_marker_cannot_be_removed
+test_recovery_reports_an_owned_row_read_failure
+test_orca_cleanup_recovery_never_transitions_the_backlog
+test_recovery_marks_an_owned_record_in_flight
+test_recovery_replays_a_close_an_interrupted_cleanup_left_open
+test_recovery_preserves_a_close_when_the_backlog_cannot_be_read
+test_recovery_finishes_a_close_for_the_same_meta_incarnation
+test_recovery_preserves_both_records_when_meta_removal_fails
+test_recovery_rejects_a_marker_for_another_task_identity
+test_recovery_rejects_a_foreign_data_directory
+test_recovery_rejects_an_unterminated_unknown_field
+test_recovery_rejects_lexical_data_traversal
+test_recovery_rejects_raw_control_bytes
+test_recovery_rejects_malformed_pr_urls
+test_failed_close_replay_is_not_started_as_live_work
+test_recovery_rejects_invalid_close_arguments
+test_recovery_rejects_a_symlinked_close_marker
+test_recovery_drops_a_close_for_a_newer_meta_incarnation
+test_recovery_rejects_a_legacy_close_without_an_incarnation
+test_bootstrap_stops_when_data_disappears_before_reconciliation
+test_bootstrap_addressing_exemptions_remain_nonfatal
+test_recovery_leaves_a_captain_held_item_alone
+test_home_without_a_backlog_dispatches_and_completes
+test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog
+test_a_secondmate_home_keeps_its_own_books
+test_a_persistent_secondmate_is_never_a_backlog_item

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -1160,7 +1160,7 @@ test_interrupted_destructive_cleanup_leaves_a_recoverable_close() {
     || fail "interrupted cleanup changed the backlog before recovery"
 
   out=$(run_bootstrap "$case_dir")
-  [ "$(row_state "$case_dir" "$id")" = done ] \
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
     || fail "restart left interrupted cleanup In flight: $out"
   assert_absent "$marker" "restart retained the recovered close marker"
   assert_absent "$home/state/$id.meta" "restart retained the interrupted task record"
@@ -1369,7 +1369,7 @@ test_recovery_backfills_a_recorded_link_on_an_already_done_item() {
   case_dir=$(make_home heal-done-backfill)
   add_item "$case_dir" "$id"
   start_item "$case_dir" "$id"
-  tasks-axi done "$id" --file "$(backlog_of "$case_dir")" >/dev/null
+  tasks-axi "done" "$id" --file "$(backlog_of "$case_dir")" >/dev/null
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
   printf 'id=%s\ndata=%s\nspawn_gen=spawn-heal-done\narg=--pr\narg=https://github.com/example/repo/pull/13\n' \
     "$id" "$(home_of "$case_dir")/data" > "$marker"
@@ -1429,7 +1429,7 @@ test_recovery_retry_without_metadata_avoids_incomplete_cleanup_warning() {
   rm -f "$case_dir/fakebin/tasks-axi"
 
   out=$(run_bootstrap "$case_dir")
-  [ "$(row_state "$case_dir" "$id")" = done ] \
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
     || fail "retried recovery left the item In flight: $out"
   assert_not_contains "$out" "endpoint or local copy may remain" \
     "retry claimed incomplete cleanup after metadata was already removed"

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -363,6 +363,17 @@ test_dispatch_refuses_a_pending_authoritative_close() {
   marker="$(home_of "$case_dir")/state/$id.backlog-close"
   printf 'id=%s\ndata=%s\nspawn_gen=spawn-closing\narg=--pr\narg=https://github.com/example/repo/pull/12\n' \
     "$id" "$(home_of "$case_dir")/data" > "$marker"
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *new-window*) : > "$case_dir/task-endpoint-created" ;;
+  *treehouse\\ get*) : > "$case_dir/local-copy-requested" ;;
+  *"#{pane_current_path}"*) printf '%s\n' "\${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "\${1:-}" in display-message) printf 'firstmate\n'; exit 0 ;; esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux"
 
   out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
   [ "$rc" -ne 0 ] || fail "spawn accepted work with an authoritative close still pending"
@@ -371,6 +382,10 @@ test_dispatch_refuses_a_pending_authoritative_close() {
   assert_present "$marker" "spawn discarded the pending authoritative close"
   assert_absent "$(home_of "$case_dir")/state/$id.meta" \
     "spawn published a new worker over a pending close"
+  assert_absent "$case_dir/task-endpoint-created" \
+    "spawn created an unowned endpoint before refusing the pending close"
+  assert_absent "$case_dir/local-copy-requested" \
+    "spawn requested an unowned local copy before refusing the pending close"
   [ "$(row_state "$case_dir" "$id")" = in_flight ] \
     || fail "refused dispatch changed the pending close's backlog row"
   pass "dispatch refuses to supersede a pending authoritative close"

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -181,6 +181,22 @@ SH
   chmod +x "$case_dir/fakebin/tmux"
 }
 
+interrupt_teardown_during_treehouse_return() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = return ] && [ ! -f "$case_dir/teardown-interrupted" ]; then
+  : > "$case_dir/teardown-interrupted"
+  teardown_pid=\$(ps -o ppid= -p "\$PPID" | tr -d ' ')
+  case "\$teardown_pid" in ''|*[!0-9]*) exit 1 ;; esac
+  kill -TERM "\$teardown_pid"
+  kill -TERM "\$\$"
+fi
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+}
+
 interrupt_kimi_readiness() {  # <case-dir>
   local case_dir=$1 home
   home=$(home_of "$case_dir")
@@ -965,6 +981,35 @@ test_completion_fails_loudly_and_records_the_close_it_still_owes() {
   pass "completion refuses to report success while its item is still open, and records what it owes"
 }
 
+test_interrupted_destructive_cleanup_leaves_a_recoverable_close() {
+  local case_dir home id marker out rc=0
+  id=atomic-close-destructive-interrupt-b8
+  case_dir=$(make_home close-destructive-interrupt "$id")
+  home=$(home_of "$case_dir")
+  add_item "$case_dir" "$id"
+  out=$(run_ship_spawn "$case_dir" "$id") || fail "spawn failed: $out"
+  marker="$home/state/$id.backlog-close"
+  interrupt_teardown_during_treehouse_return "$case_dir"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "interrupted destructive cleanup reported success"
+  assert_present "$marker" \
+    "destructive cleanup began before recording its authoritative close"
+  assert_present "$home/state/$id.meta" \
+    "interrupted destructive cleanup lost the task incarnation"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "interrupted cleanup changed the backlog before recovery"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = done ] \
+    || fail "restart left interrupted cleanup In flight: $out"
+  assert_absent "$marker" "restart retained the recovered close marker"
+  assert_absent "$home/state/$id.meta" "restart retained the interrupted task record"
+  assert_contains "$out" "endpoint or local copy may remain" \
+    "restart silently hid potentially incomplete physical cleanup"
+  pass "restart recovers closes recorded before destructive cleanup"
+}
+
 test_completion_fails_when_its_close_marker_cannot_be_removed() {
   local case_dir id marker out rc=0
   id=atomic-close-marker-remove-failure-b8
@@ -1597,6 +1642,7 @@ test_trailing_newline_data_path_fails_closed
 test_control_character_data_path_is_refused_before_cleanup
 test_completion_preserves_records_when_meta_removal_fails
 test_completion_fails_loudly_and_records_the_close_it_still_owes
+test_interrupted_destructive_cleanup_leaves_a_recoverable_close
 test_completion_fails_when_its_close_marker_cannot_be_removed
 test_recovery_retries_when_a_close_marker_cannot_be_removed
 test_recovery_reports_an_owned_row_read_failure

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -338,6 +338,28 @@ test_dispatch_moves_the_item_in_flight_in_the_same_run() {
   pass "dispatch publishes the record and moves the backlog item In flight in one run"
 }
 
+test_dispatch_refuses_a_pending_authoritative_close() {
+  local case_dir id marker out rc=0
+  id=atomic-dispatch-pending-close-b1
+  case_dir=$(make_home dispatch-pending-close "$id")
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-closing\narg=--pr\narg=https://github.com/example/repo/pull/12\n' \
+    "$id" "$(home_of "$case_dir")/data" > "$marker"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn accepted work with an authoritative close still pending"
+  assert_contains "$out" "pending authoritative backlog close" \
+    "spawn did not explain why the pending close blocks dispatch"
+  assert_present "$marker" "spawn discarded the pending authoritative close"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "spawn published a new worker over a pending close"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "refused dispatch changed the pending close's backlog row"
+  pass "dispatch refuses to supersede a pending authoritative close"
+}
+
 test_dispatch_reads_the_row_from_the_backlog_root() {
   local case_dir id out
   id=atomic-dispatch-root-b2
@@ -658,6 +680,25 @@ test_dispatch_defers_interruption_across_backlog_commit() {
       "a $timing-commit interruption removed the paired task record"
   done
   pass "dispatch retries interrupted transitions before honoring termination"
+}
+
+test_dispatch_interruption_during_kimi_readiness_fails_before_commit() {
+  local case_dir home id out rc=0
+  id=atomic-dispatch-kimi-readiness-signal-b5
+  case_dir=$(make_home dispatch-kimi-readiness-signal "$id")
+  home=$(home_of "$case_dir")
+  add_item "$case_dir" "$id"
+  interrupt_kimi_readiness "$case_dir"
+
+  out=$(HOME="$home" FM_KIMI_READY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
+    run_spawn "$case_dir" "$id" "$case_dir/project" --harness kimi \
+      --mode no-mistakes --yolo off) || rc=$?
+  [ "$rc" -ne 0 ] || fail "Kimi readiness interruption was reported as success"
+  assert_absent "$home/state/$id.meta" \
+    "Kimi readiness interruption retained an unconfirmed task record"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "Kimi readiness interruption committed unconfirmed work In flight: $out"
+  pass "Kimi readiness interruptions fail before backlog commit"
 }
 
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight() {
@@ -1043,6 +1084,26 @@ test_recovery_replays_a_close_an_interrupted_cleanup_left_open() {
   assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
     "a replayed close left its record behind"
   pass "session start finishes a close an interrupted cleanup recorded but never landed"
+}
+
+test_recovery_backfills_a_recorded_link_on_an_already_done_item() {
+  local case_dir id marker out
+  id=atomic-heal-done-backfill-b9
+  case_dir=$(make_home heal-done-backfill)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  tasks-axi done "$id" --file "$(backlog_of "$case_dir")" >/dev/null
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-heal-done\narg=--pr\narg=https://github.com/example/repo/pull/13\n' \
+    "$id" "$(home_of "$case_dir")/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = "done" ] \
+    || fail "replaying a completion link changed the closed row: $out"
+  assert_grep 'https://github.com/example/repo/pull/13' "$(backlog_of "$case_dir")" \
+    "recovery discarded the recorded link because the item was already Done"
+  assert_absent "$marker" "recovery retained an applied completion-link marker"
+  pass "recovery backfills recorded links onto already Done items"
 }
 
 test_recovery_preserves_a_close_when_the_backlog_cannot_be_read() {
@@ -1507,6 +1568,7 @@ test_a_persistent_secondmate_is_never_a_backlog_item() {
 }
 
 test_dispatch_moves_the_item_in_flight_in_the_same_run
+test_dispatch_refuses_a_pending_authoritative_close
 test_dispatch_reads_the_row_from_the_backlog_root
 test_recovery_uses_the_parent_of_a_trailing_slash_data_record
 test_completion_targets_a_nested_relative_data_directory
@@ -1523,6 +1585,7 @@ test_dispatch_reports_an_incomplete_record_rollback
 test_dispatch_reports_an_incomplete_busy_rollback
 test_dispatch_rolls_back_before_a_failed_launch_delivery
 test_dispatch_defers_interruption_across_backlog_commit
+test_dispatch_interruption_during_kimi_readiness_fails_before_commit
 test_dispatch_does_not_resurrect_a_row_closed_after_preflight
 test_dispatch_fails_when_its_row_vanishes_after_preflight
 test_completion_closes_a_local_only_ship_before_reporting_success
@@ -1540,6 +1603,7 @@ test_recovery_reports_an_owned_row_read_failure
 test_orca_cleanup_recovery_never_transitions_the_backlog
 test_recovery_marks_an_owned_record_in_flight
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open
+test_recovery_backfills_a_recorded_link_on_an_already_done_item
 test_recovery_preserves_a_close_when_the_backlog_cannot_be_read
 test_recovery_finishes_a_close_for_the_same_meta_incarnation
 test_recovery_preserves_both_records_when_meta_removal_fails

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -1297,6 +1297,29 @@ test_recovery_marks_an_owned_record_in_flight() {
   pass "session start marks an item In flight when this home already owns a worker for it"
 }
 
+test_recovery_rejects_an_internal_worker_record_symlink() {
+  local case_dir home id target_id out rc=0
+  id=atomic-heal-internal-symlink-b8
+  target_id=atomic-heal-internal-target-b8
+  case_dir=$(make_home heal-internal-symlink)
+  home=$(home_of "$case_dir")
+  add_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$target_id" ship no-mistakes "spawn_gen=internal-target"
+  ln -s "$target_id.meta" "$home/state/$id.meta"
+
+  out=$(run_bootstrap "$case_dir") || rc=$?
+  [ "$rc" -ne 0 ] || fail "session start accepted an internal worker-record symlink"
+  assert_contains "$out" "task record resolves through a different final path" \
+    "session start did not report the aliased worker record"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "session start paired the aliased worker record with its backlog row"
+  [ -L "$home/state/$id.meta" ] \
+    || fail "session start replaced or removed the aliased worker record"
+  assert_present "$home/state/$target_id.meta" \
+    "session start removed the internal symlink target"
+  pass "session start rejects internal worker-record symlinks"
+}
+
 test_recovery_ignores_a_symlinked_worker_record() {
   local case_dir home id target out rc=0
   id=atomic-heal-symlink-meta-b8
@@ -2170,6 +2193,7 @@ test_recovery_retries_when_a_close_marker_cannot_be_removed
 test_recovery_reports_an_owned_row_read_failure
 test_orca_cleanup_recovery_never_transitions_the_backlog
 test_recovery_marks_an_owned_record_in_flight
+test_recovery_rejects_an_internal_worker_record_symlink
 test_recovery_ignores_a_symlinked_worker_record
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open
 test_recovery_backfills_a_recorded_link_on_an_already_done_item

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -109,6 +109,17 @@ SH
   chmod +x "$case_dir/fakebin/tasks-axi"
 }
 
+make_tasks_axi_incompatible() {  # <case-dir>
+  local case_dir=$1 real
+  real=$(command -v tasks-axi)
+  cat > "$case_dir/fakebin/tasks-axi" <<SH
+#!/usr/bin/env bash
+[ "\${1:-}" != --version ] || exit 1
+exec "$real" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/tasks-axi"
+}
+
 break_verb() {  # <case-dir> <verb>
   local case_dir=$1 verb=$2 real
   real=$(command -v tasks-axi)
@@ -574,6 +585,41 @@ test_dispatch_refuses_a_symlinked_backlog_without_crossing_homes() {
   assert_absent "$(home_of "$case_dir")/state/$id.meta" \
     "unsafe backlog dispatch published a local task record"
   pass "dispatch refuses symlinked backlogs without crossing homes"
+}
+
+test_automatic_backend_refuses_incompatible_tasks_axi_before_mutation() {
+  local spawn_case teardown_case id out rc=0
+  id=atomic-incompatible-tasks-axi-b2
+  spawn_case=$(make_home incompatible-tasks-axi-spawn "$id")
+  add_item "$spawn_case" "$id"
+  make_tasks_axi_incompatible "$spawn_case"
+
+  out=$(run_ship_spawn "$spawn_case" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "automatic spawn succeeded without compatible tasks-axi"
+  assert_contains "$out" "automatic backlog transitions require tasks-axi" \
+    "automatic spawn did not report its unavailable transition tool"
+  assert_absent "$(home_of "$spawn_case")/state/$id.meta" \
+    "automatic spawn published a record without transition tooling"
+  rm -f "$spawn_case/fakebin/tasks-axi"
+  [ "$(row_state "$spawn_case" "$id")" = queued ] \
+    || fail "automatic spawn changed the row without transition tooling"
+
+  teardown_case=$(make_home incompatible-tasks-axi-teardown)
+  add_item "$teardown_case" "$id"
+  start_item "$teardown_case" "$id"
+  write_task_meta "$teardown_case" "$id" ship local-only "spawn_gen=spawn-incompatible"
+  make_tasks_axi_incompatible "$teardown_case"
+  rc=0
+  out=$(run_teardown "$teardown_case" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "automatic teardown succeeded without compatible tasks-axi"
+  assert_contains "$out" "automatic backlog transitions require tasks-axi" \
+    "automatic teardown did not report its unavailable transition tool"
+  assert_present "$(home_of "$teardown_case")/state/$id.meta" \
+    "automatic teardown removed its record without transition tooling"
+  rm -f "$teardown_case/fakebin/tasks-axi"
+  [ "$(row_state "$teardown_case" "$id")" = in_flight ] \
+    || fail "automatic teardown changed the row without transition tooling"
+  pass "automatic homes refuse lifecycle mutation without compatible tasks-axi"
 }
 
 test_dispatch_refuses_an_unresolvable_data_directory() {
@@ -1711,6 +1757,29 @@ test_recovery_rejects_a_legacy_close_without_an_incarnation() {
   pass "session start rejects an unversioned close marker"
 }
 
+test_bootstrap_refuses_a_symlinked_state_directory_before_reconciliation() {
+  local case_dir foreign_case home foreign_state id out rc=0
+  id=atomic-bootstrap-symlink-state-b11
+  case_dir=$(make_home bootstrap-symlink-state)
+  foreign_case=$(make_home bootstrap-symlink-state-foreign)
+  home=$(home_of "$case_dir")
+  foreign_state="$(home_of "$foreign_case")/state"
+  add_item "$case_dir" "$id"
+  write_task_meta "$foreign_case" "$id" ship no-mistakes "spawn_gen=foreign-worker"
+  rm -rf "$home/state"
+  ln -s "$foreign_state" "$home/state"
+
+  out=$(run_bootstrap "$case_dir") || rc=$?
+  [ "$rc" -ne 0 ] || fail "bootstrap accepted a symlinked state directory"
+  assert_contains "$out" "state directory is not a real directory" \
+    "bootstrap did not report the unsafe state boundary"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "bootstrap reconciled a foreign record into the local backlog"
+  assert_present "$foreign_state/$id.meta" \
+    "bootstrap removed the foreign worker record"
+  pass "bootstrap refuses symlinked state before reconciliation"
+}
+
 test_bootstrap_stops_when_data_disappears_before_reconciliation() {
   local case_dir id saved out rc=0
   id=atomic-bootstrap-data-race-b11
@@ -1801,6 +1870,50 @@ test_no_backlog_teardown_refuses_a_symlinked_task_record_at_entry() {
   pass "no-backlog teardown refuses symlinked records before resource actions"
 }
 
+test_teardown_rechecks_record_parent_after_lock_acquisition() {
+  local case_dir home id foreign_state foreign_worktree real_ln out rc=0
+  id=atomic-state-parent-swap-b12
+  case_dir=$(make_home state-parent-swap)
+  home=$(home_of "$case_dir")
+  rm -f "$(backlog_of "$case_dir")"
+  write_task_meta "$case_dir" "$id" ship local-only
+  foreign_state="$case_dir/foreign-state"
+  foreign_worktree="$case_dir/foreign-worktree"
+  mkdir -p "$foreign_state" "$foreign_worktree"
+  fm_write_meta "$foreign_state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$foreign_worktree" "project=$case_dir/foreign-project" \
+    "harness=claude" "kind=ship" "mode=local-only" "yolo=off"
+  track_teardown_resource_actions "$case_dir"
+  real_ln=$(command -v ln)
+  cat > "$case_dir/fakebin/ln" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *"$home/state/.meta-$id.lock"*)
+    if [ ! -e "$case_dir/state-swapped" ]; then
+      : > "$case_dir/state-swapped"
+      mv "$home/state" "$home/state-original" || exit 1
+      "$real_ln" -s "$foreign_state" "$home/state" || exit 1
+    fi
+    ;;
+esac
+exec "$real_ln" "\$@"
+SH
+  chmod +x "$case_dir/fakebin/ln"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown trusted a record after its parent was swapped"
+  assert_contains "$out" "task record parent directory is not a real directory" \
+    "post-lock record check did not report the swapped parent"
+  assert_present "$foreign_state/$id.meta" "teardown removed the foreign record"
+  assert_present "$foreign_worktree" "teardown removed the foreign local copy"
+  assert_absent "$case_dir/backend-resource-action" \
+    "teardown acted on a foreign endpoint after the parent swap"
+  assert_absent "$case_dir/local-copy-resource-action" \
+    "teardown acted on a foreign local copy after the parent swap"
+  pass "teardown rechecks record parents after locking"
+}
+
 test_teardown_refuses_a_symlinked_state_directory_at_entry() {
   local case_dir home id external_state out rc=0
   id=atomic-symlink-state-b12
@@ -1833,6 +1946,7 @@ test_home_without_a_backlog_dispatches_and_completes() {
   id=atomic-no-backlog-b12
   case_dir=$(make_home no-backlog "$id")
   rm -f "$(backlog_of "$case_dir")"
+  make_tasks_axi_incompatible "$case_dir"
 
   out=$(run_ship_spawn "$case_dir" "$id") || fail "no-backlog spawn failed: $out"
   assert_present "$(home_of "$case_dir")/state/$id.meta" \
@@ -1853,6 +1967,7 @@ test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog()
   data="$case_dir/manual-data"
   mv "$(home_of "$case_dir")/data" "$data"
   data_resolved=$(cd "$data" && pwd -P)
+  make_tasks_axi_incompatible "$case_dir"
   # Deliberately no backlog item: on a manual home the operator owns the file,
   # so neither half of the lifecycle may hard-fail over its contents.
   out=$(FM_DATA_OVERRIDE="$data" run_ship_spawn "$case_dir" "$id") \
@@ -1918,6 +2033,7 @@ test_completion_targets_a_nested_relative_data_directory
 test_immediate_child_absolute_data_dispatches_and_completes
 test_bare_relative_data_dispatches_and_completes
 test_dispatch_refuses_a_symlinked_backlog_without_crossing_homes
+test_automatic_backend_refuses_incompatible_tasks_axi_before_mutation
 test_dispatch_refuses_an_unresolvable_data_directory
 test_completion_refuses_an_unresolvable_data_directory
 test_dispatch_refuses_an_id_this_home_has_no_item_for
@@ -1969,10 +2085,12 @@ test_recovery_rejects_invalid_close_arguments
 test_recovery_rejects_a_symlinked_close_marker
 test_recovery_drops_a_close_for_a_newer_meta_incarnation
 test_recovery_rejects_a_legacy_close_without_an_incarnation
+test_bootstrap_refuses_a_symlinked_state_directory_before_reconciliation
 test_bootstrap_stops_when_data_disappears_before_reconciliation
 test_bootstrap_addressing_exemptions_remain_nonfatal
 test_recovery_leaves_a_captain_held_item_alone
 test_no_backlog_teardown_refuses_a_symlinked_task_record_at_entry
+test_teardown_rechecks_record_parent_after_lock_acquisition
 test_teardown_refuses_a_symlinked_state_directory_at_entry
 test_home_without_a_backlog_dispatches_and_completes
 test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -863,6 +863,28 @@ test_completion_refuses_a_legacy_record_without_an_incarnation() {
   pass "completion leaves legacy records open when no incarnation can be recorded"
 }
 
+test_completion_refuses_ambiguous_incarnation_metadata() {
+  local case_dir id meta marker out rc=0
+  id=atomic-close-ambiguous-incarnation-b7
+  case_dir=$(make_home close-ambiguous-incarnation)
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship local-only \
+    "spawn_gen=spawn-old" "spawn_gen=spawn-current"
+  meta="$(home_of "$case_dir")/state/$id.meta"
+  marker="$(home_of "$case_dir")/state/$id.backlog-close"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown accepted ambiguous incarnation metadata"
+  assert_contains "$out" "has 2 spawn generation fields" \
+    "teardown did not report the ambiguous incarnation"
+  assert_present "$meta" "ambiguous-incarnation refusal removed the task record"
+  assert_absent "$marker" "ambiguous-incarnation refusal published a close"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "ambiguous-incarnation refusal changed the backlog row"
+  pass "completion refuses ambiguous task incarnations"
+}
+
 test_completion_records_a_relative_report_for_relocated_data() {
   local case_dir id relocated backlog out
   id=atomic-close-relocated-scout-b7
@@ -1291,6 +1313,30 @@ test_recovery_finishes_a_close_for_the_same_meta_incarnation() {
   assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
     "session start retained the completed incarnation's close marker"
   pass "session start finishes a close for the matching meta incarnation"
+}
+
+test_recovery_preserves_a_close_for_ambiguous_incarnation_metadata() {
+  local case_dir home id marker out
+  id=atomic-heal-ambiguous-incarnation-b12
+  case_dir=$(make_home heal-ambiguous-incarnation)
+  home=$(home_of "$case_dir")
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes \
+    "spawn_gen=spawn-old" "spawn_gen=spawn-current"
+  marker="$home/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-current\narg=--note\narg=local%%20main\n' \
+    "$id" "$home/data" > "$marker"
+
+  out=$(run_bootstrap "$case_dir")
+  assert_contains "$out" "has 2 spawn generation fields" \
+    "recovery did not report ambiguous incarnation metadata"
+  assert_present "$marker" "ambiguous metadata caused recovery to discard the close"
+  assert_present "$home/state/$id.meta" \
+    "ambiguous metadata caused recovery to remove the task record"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "ambiguous metadata allowed recovery to close the backlog row"
+  pass "recovery preserves closes for ambiguous task incarnations"
 }
 
 test_recovery_preserves_both_records_when_meta_removal_fails() {
@@ -1757,6 +1803,7 @@ test_dispatch_fails_when_its_row_vanishes_after_preflight
 test_completion_closes_a_local_only_ship_before_reporting_success
 test_completion_closes_a_scout_with_its_report
 test_completion_refuses_a_legacy_record_without_an_incarnation
+test_completion_refuses_ambiguous_incarnation_metadata
 test_completion_records_a_relative_report_for_relocated_data
 test_space_containing_scout_report_marker_replays
 test_trailing_newline_data_path_fails_closed
@@ -1775,6 +1822,7 @@ test_recovery_backfills_a_recorded_link_on_an_already_done_item
 test_recovery_preserves_a_close_when_the_backlog_cannot_be_read
 test_recovery_retry_preserves_incomplete_cleanup_warning
 test_recovery_finishes_a_close_for_the_same_meta_incarnation
+test_recovery_preserves_a_close_for_ambiguous_incarnation_metadata
 test_recovery_preserves_both_records_when_meta_removal_fails
 test_recovery_preserves_a_close_beside_symlinked_metadata
 test_recovery_rejects_a_marker_for_another_task_identity

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -1192,6 +1192,34 @@ test_recovery_preserves_a_close_when_the_backlog_cannot_be_read() {
   pass "session start preserves a pending close across a transient backlog read failure"
 }
 
+test_recovery_retry_preserves_incomplete_cleanup_warning() {
+  local case_dir home id marker out
+  id=atomic-heal-retry-warning-b10
+  case_dir=$(make_home heal-retry-warning)
+  home=$(home_of "$case_dir")
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=spawn-warning"
+  marker="$home/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=spawn-warning\narg=--note\narg=local%%20main\n' \
+    "$id" "$home/data" > "$marker"
+  break_verb "$case_dir" show
+
+  out=$(run_bootstrap "$case_dir")
+  assert_absent "$home/state/$id.meta" \
+    "failed replay did not cross the task-record removal boundary"
+  assert_present "$marker" "failed replay discarded its pending close"
+  rm -f "$case_dir/fakebin/tasks-axi"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = done ] \
+    || fail "retried recovery left the item In flight: $out"
+  assert_contains "$out" "endpoint or local copy may remain" \
+    "retry lost the incomplete physical-cleanup warning"
+  assert_absent "$marker" "retried recovery retained its applied marker"
+  pass "recovery retries preserve incomplete-cleanup warnings"
+}
+
 test_recovery_finishes_a_close_for_the_same_meta_incarnation() {
   local case_dir id out
   id=atomic-heal-same-incarnation-b11
@@ -1666,6 +1694,7 @@ test_recovery_marks_an_owned_record_in_flight
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open
 test_recovery_backfills_a_recorded_link_on_an_already_done_item
 test_recovery_preserves_a_close_when_the_backlog_cannot_be_read
+test_recovery_retry_preserves_incomplete_cleanup_warning
 test_recovery_finishes_a_close_for_the_same_meta_incarnation
 test_recovery_preserves_both_records_when_meta_removal_fails
 test_recovery_rejects_a_marker_for_another_task_identity

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -462,13 +462,14 @@ test_recovery_uses_the_parent_of_a_trailing_slash_data_record() {
 }
 
 test_completion_targets_a_nested_relative_data_directory() {
-  local case_dir id relative_data data backlog out
+  local case_dir id relative_data data data_resolved backlog out
   id=atomic-close-relative-data-b2
   case_dir=$(make_home close-relative-data)
   relative_data=relocated/data
   data="$case_dir/$relative_data"
   mkdir -p "$case_dir/relocated"
   mv "$(home_of "$case_dir")/data" "$data"
+  data_resolved=$(cd "$data" && pwd -P)
   backlog="$data/backlog.md"
   tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
   tasks-axi start "$id" --file "$backlog" >/dev/null
@@ -485,15 +486,18 @@ test_completion_targets_a_nested_relative_data_directory() {
     "relative-data teardown retained its task record"
   assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
     "relative-data teardown retained its close marker"
+  assert_contains "$out" "closed in $data_resolved/backlog.md" \
+    "relative-data completion collapsed the configured backlog path"
   pass "completion targets nested relative data from the caller directory"
 }
 
 test_immediate_child_absolute_data_dispatches_and_completes() {
-  local case_dir id data backlog out
+  local case_dir id data data_resolved backlog out
   id=atomic-immediate-child-data-b2
   case_dir=$(make_home immediate-child-data "$id")
   data="$case_dir/fm-records"
   mv "$(home_of "$case_dir")/data" "$data"
+  data_resolved=$(cd "$data" && pwd -P)
   backlog="$data/backlog.md"
   tasks-axi add "$id" "item for $id" --kind ship --file "$backlog" >/dev/null
 
@@ -507,7 +511,7 @@ test_immediate_child_absolute_data_dispatches_and_completes() {
     || fail "immediate-child-data teardown failed: $out"
   [ "$(tasks-axi show "$id" --file "$backlog" 2>/dev/null | sed -n 's/^  state: *//p' | head -1)" = "done" ] \
     || fail "immediate-child absolute completion mutated a different backlog"
-  assert_contains "$out" "fm-records/backlog.md" \
+  assert_contains "$out" "closed in $data_resolved/backlog.md" \
     "relocated completion confirmed the wrong backlog path"
   pass "an immediate-child absolute data path keeps one paired backlog"
 }
@@ -1719,18 +1723,22 @@ test_home_without_a_backlog_dispatches_and_completes() {
 }
 
 test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog() {
-  local case_dir id out
+  local case_dir id data data_resolved out
   id=atomic-manual-b12
   case_dir=$(make_home manual-backend "$id")
   printf '%s\n' manual > "$(home_of "$case_dir")/config/backlog-backend"
+  data="$case_dir/manual-data"
+  mv "$(home_of "$case_dir")/data" "$data"
+  data_resolved=$(cd "$data" && pwd -P)
   # Deliberately no backlog item: on a manual home the operator owns the file,
   # so neither half of the lifecycle may hard-fail over its contents.
-  out=$(run_ship_spawn "$case_dir" "$id") || fail "manual-backend spawn failed: $out"
+  out=$(FM_DATA_OVERRIDE="$data" run_ship_spawn "$case_dir" "$id") \
+    || fail "manual-backend spawn failed: $out"
   assert_contains "$out" "spawned $id" "manual-backend spawn did not report success"
-  mv "$(home_of "$case_dir")/data" "$case_dir/manual-data"
 
-  out=$(run_teardown "$case_dir" "$id") || fail "manual-backend teardown failed: $out"
-  assert_contains "$out" "Update $(home_of "$case_dir")/data/backlog.md" \
+  out=$(FM_DATA_OVERRIDE="$data" run_teardown "$case_dir" "$id") \
+    || fail "manual-backend teardown failed: $out"
+  assert_contains "$out" "Update $data_resolved/backlog.md" \
     "manual-backend teardown did not name its configured backlog path"
   assert_absent "$(home_of "$case_dir")/state/$id.backlog-close" \
     "manual-backend teardown recorded a close it never owed"

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -181,6 +181,21 @@ SH
   chmod +x "$case_dir/fakebin/tmux"
 }
 
+track_teardown_resource_actions() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+: > "$case_dir/backend-resource-action"
+exit 0
+SH
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+: > "$case_dir/local-copy-resource-action"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux" "$case_dir/fakebin/treehouse"
+}
+
 interrupt_teardown_during_treehouse_return() {  # <case-dir>
   local case_dir=$1
   cat > "$case_dir/fakebin/treehouse" <<SH
@@ -1757,6 +1772,62 @@ test_recovery_leaves_a_captain_held_item_alone() {
 
 # --- backend selection and secondmate scope ---------------------------------
 
+test_no_backlog_teardown_refuses_a_symlinked_task_record_at_entry() {
+  local case_dir home id target foreign_worktree out rc=0
+  id=atomic-no-backlog-symlink-meta-b12
+  case_dir=$(make_home no-backlog-symlink-meta)
+  home=$(home_of "$case_dir")
+  rm -f "$(backlog_of "$case_dir")"
+  foreign_worktree="$case_dir/foreign-worktree"
+  mkdir -p "$foreign_worktree"
+  target="$case_dir/foreign-task-record"
+  fm_write_meta "$target" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$foreign_worktree" "project=$case_dir/foreign-project" \
+    "harness=claude" "kind=ship" "mode=local-only" "yolo=off"
+  ln -s "$target" "$home/state/$id.meta"
+  track_teardown_resource_actions "$case_dir"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "no-backlog teardown accepted a symlinked task record"
+  assert_contains "$out" "task record is not a regular non-symlink file" \
+    "teardown did not identify the unsafe task record"
+  [ -L "$home/state/$id.meta" ] || fail "teardown removed the symlinked task record"
+  assert_present "$foreign_worktree" "teardown removed a foreign local copy"
+  assert_absent "$case_dir/backend-resource-action" \
+    "teardown acted on the foreign endpoint"
+  assert_absent "$case_dir/local-copy-resource-action" \
+    "teardown acted on the foreign local copy"
+  pass "no-backlog teardown refuses symlinked records before resource actions"
+}
+
+test_teardown_refuses_a_symlinked_state_directory_at_entry() {
+  local case_dir home id external_state out rc=0
+  id=atomic-symlink-state-b12
+  case_dir=$(make_home symlink-state)
+  home=$(home_of "$case_dir")
+  external_state="$case_dir/external-state"
+  mv "$home/state" "$external_state"
+  fm_write_meta "$external_state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$case_dir/foreign-worktree" "project=$case_dir/foreign-project" \
+    "harness=claude" "kind=ship" "mode=local-only" "yolo=off"
+  ln -s "$external_state" "$home/state"
+  track_teardown_resource_actions "$case_dir"
+
+  out=$(run_teardown "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "teardown accepted a symlinked state directory"
+  assert_contains "$out" "state directory is not a real directory" \
+    "teardown did not identify the unsafe state directory"
+  assert_present "$external_state/$id.meta" \
+    "teardown removed metadata through the symlinked state directory"
+  assert_absent "$case_dir/backend-resource-action" \
+    "teardown acted on an endpoint through symlinked state"
+  assert_absent "$case_dir/local-copy-resource-action" \
+    "teardown acted on a local copy through symlinked state"
+  pass "teardown refuses symlinked state before resource actions"
+}
+
 test_home_without_a_backlog_dispatches_and_completes() {
   local case_dir id out
   id=atomic-no-backlog-b12
@@ -1901,6 +1972,8 @@ test_recovery_rejects_a_legacy_close_without_an_incarnation
 test_bootstrap_stops_when_data_disappears_before_reconciliation
 test_bootstrap_addressing_exemptions_remain_nonfatal
 test_recovery_leaves_a_captain_held_item_alone
+test_no_backlog_teardown_refuses_a_symlinked_task_record_at_entry
+test_teardown_refuses_a_symlinked_state_directory_at_entry
 test_home_without_a_backlog_dispatches_and_completes
 test_manual_backend_home_dispatches_and_completes_without_touching_the_backlog
 test_a_secondmate_home_keeps_its_own_books

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -577,7 +577,7 @@ test_dispatch_refuses_a_symlinked_backlog_without_crossing_homes() {
 
   out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
   [ "$rc" -ne 0 ] || fail "spawn accepted a symlinked backlog"
-  assert_contains "$out" "backlog file is not a regular non-symlink file" \
+  assert_contains "$out" "backlog file resolves outside its authorized directory" \
     "spawn did not identify the unsafe backlog boundary"
   [ -L "$local_backlog" ] || fail "spawn replaced the local backlog symlink"
   [ "$(row_state "$foreign_case" "$id")" = queued ] \
@@ -1184,7 +1184,7 @@ test_completion_refuses_a_close_target_symlinked_to_a_directory() {
 
   out=$(run_teardown "$case_dir" "$id") || rc=$?
   [ "$rc" -ne 0 ] || fail "teardown published through a directory symlink"
-  assert_contains "$out" "pending-close record target is not a regular non-symlink file" \
+  assert_contains "$out" "pending-close record target resolves outside its authorized directory" \
     "teardown did not report the unsafe publication target"
   [ -L "$marker" ] || fail "teardown replaced the unsafe close target"
   [ -z "$(find "$external" -mindepth 1 -maxdepth 1 -print -quit)" ] \
@@ -1797,6 +1797,69 @@ SH
   pass "bootstrap rechecks worker-record containment after locking"
 }
 
+test_lifecycle_refuses_ancestor_symlinks_outside_home_roots() {
+  local backlog_case worker_case close_case home foreign id marker out rc=0
+  id=atomic-ancestor-symlink-b14
+
+  backlog_case=$(make_home ancestor-symlink-backlog "$id")
+  home=$(home_of "$backlog_case")
+  foreign="$backlog_case/foreign-home"
+  mkdir -p "$foreign/data"
+  cp "$(backlog_of "$backlog_case")" "$foreign/data/backlog.md"
+  ln -s "$foreign" "$home/foreign-link"
+  out=$(FM_DATA_OVERRIDE="$home/foreign-link/data" run_ship_spawn "$backlog_case" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "dispatch accepted a backlog through an ancestor symlink"
+  assert_absent "$home/state/$id.meta" "dispatch published through a foreign backlog root"
+
+  worker_case=$(make_home ancestor-symlink-worker)
+  home=$(home_of "$worker_case")
+  foreign="$worker_case/foreign-home"
+  mkdir -p "$foreign/state"
+  add_item "$worker_case" "$id"
+  fm_write_meta "$foreign/state/$id.meta" "kind=ship" "spawn_gen=foreign-worker"
+  ln -s "$foreign" "$home/foreign-link"
+  rc=0
+  out=$(FM_STATE_OVERRIDE="$home/foreign-link/state" run_bootstrap "$worker_case") || rc=$?
+  [ "$rc" -ne 0 ] || fail "bootstrap accepted a worker record through an ancestor symlink"
+  [ "$(row_state "$worker_case" "$id")" = queued ] \
+    || fail "bootstrap paired a foreign worker with the local backlog"
+
+  close_case=$(make_home ancestor-symlink-close)
+  home=$(home_of "$close_case")
+  foreign="$close_case/foreign-home"
+  mkdir -p "$foreign/state"
+  add_item "$close_case" "$id"
+  start_item "$close_case" "$id"
+  marker="$foreign/state/$id.backlog-close"
+  printf 'id=%s\ndata=%s\nspawn_gen=foreign-close\narg=--note\narg=local%%20main\n' \
+    "$id" "$home/data" > "$marker"
+  ln -s "$foreign" "$home/foreign-link"
+  rc=0
+  out=$(FM_STATE_OVERRIDE="$home/foreign-link/state" run_bootstrap "$close_case") || rc=$?
+  [ "$rc" -ne 0 ] || fail "bootstrap accepted a close record through an ancestor symlink"
+  assert_present "$marker" "bootstrap discarded a foreign authoritative close"
+  [ "$(row_state "$close_case" "$id")" = in_flight ] \
+    || fail "bootstrap applied a foreign close to the local backlog"
+  pass "lifecycle files reject ancestor symlinks outside home roots"
+}
+
+test_same_home_state_override_remains_supported() {
+  local case_dir home state id out
+  id=atomic-same-home-state-override-b14
+  case_dir=$(make_home same-home-state-override)
+  home=$(home_of "$case_dir")
+  state="$home/runtime-state"
+  add_item "$case_dir" "$id"
+  write_task_meta "$case_dir" "$id" ship no-mistakes "spawn_gen=same-home-override"
+  mv "$home/state" "$state"
+
+  out=$(FM_STATE_OVERRIDE="$state" run_bootstrap "$case_dir") \
+    || fail "same-home state override was refused: $out"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "same-home state override did not reconcile its worker"
+  pass "same-home state overrides remain supported"
+}
+
 test_bootstrap_refuses_a_symlinked_state_directory_before_reconciliation() {
   local case_dir foreign_case home foreign_state id out rc=0
   id=atomic-bootstrap-symlink-state-b11
@@ -1882,14 +1945,16 @@ test_recovery_leaves_a_captain_held_item_alone() {
 # --- backend selection and secondmate scope ---------------------------------
 
 test_no_backlog_teardown_refuses_a_symlinked_task_record_at_entry() {
-  local case_dir home id target foreign_worktree out rc=0
+  local case_dir home id target target_dir foreign_worktree out rc=0
   id=atomic-no-backlog-symlink-meta-b12
   case_dir=$(make_home no-backlog-symlink-meta)
   home=$(home_of "$case_dir")
   rm -f "$(backlog_of "$case_dir")"
   foreign_worktree="$case_dir/foreign-worktree"
   mkdir -p "$foreign_worktree"
-  target="$case_dir/foreign-task-record"
+  target_dir="$home/state-foreign"
+  target="$target_dir/$id.meta"
+  mkdir -p "$target_dir"
   fm_write_meta "$target" \
     "window=firstmate:fm-$id" "endpoint_task_id=$id" \
     "worktree=$foreign_worktree" "project=$case_dir/foreign-project" \
@@ -1899,7 +1964,7 @@ test_no_backlog_teardown_refuses_a_symlinked_task_record_at_entry() {
 
   out=$(run_teardown "$case_dir" "$id") || rc=$?
   [ "$rc" -ne 0 ] || fail "no-backlog teardown accepted a symlinked task record"
-  assert_contains "$out" "task record is not a regular non-symlink file" \
+  assert_contains "$out" "task record resolves outside its authorized directory" \
     "teardown did not identify the unsafe task record"
   [ -L "$home/state/$id.meta" ] || fail "teardown removed the symlinked task record"
   assert_present "$foreign_worktree" "teardown removed a foreign local copy"
@@ -1943,7 +2008,7 @@ SH
 
   out=$(run_teardown "$case_dir" "$id") || rc=$?
   [ "$rc" -ne 0 ] || fail "teardown trusted a record after its parent was swapped"
-  assert_contains "$out" "task record authorized directory is not a real directory" \
+  assert_contains "$out" "task record authorized directory resolves outside this home" \
     "post-lock record check did not report the swapped parent"
   assert_present "$foreign_state/$id.meta" "teardown removed the foreign record"
   assert_present "$foreign_worktree" "teardown removed the foreign local copy"
@@ -2126,6 +2191,8 @@ test_recovery_rejects_a_symlinked_close_marker
 test_recovery_drops_a_close_for_a_newer_meta_incarnation
 test_recovery_rejects_a_legacy_close_without_an_incarnation
 test_bootstrap_rechecks_worker_record_boundary_after_locking
+test_lifecycle_refuses_ancestor_symlinks_outside_home_roots
+test_same_home_state_override_remains_supported
 test_bootstrap_refuses_a_symlinked_state_directory_before_reconciliation
 test_bootstrap_stops_when_data_disappears_before_reconciliation
 test_bootstrap_addressing_exemptions_remain_nonfatal

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -1126,6 +1126,24 @@ test_recovery_marks_an_owned_record_in_flight() {
   pass "session start marks an item In flight when this home already owns a worker for it"
 }
 
+test_recovery_ignores_a_symlinked_worker_record() {
+  local case_dir home id target out
+  id=atomic-heal-symlink-meta-b8
+  case_dir=$(make_home heal-symlink-meta)
+  home=$(home_of "$case_dir")
+  add_item "$case_dir" "$id"
+  target="$case_dir/symlink-meta-target"
+  printf 'kind=ship\nspawn_gen=unpublished\n' > "$target"
+  ln -s "$target" "$home/state/$id.meta"
+
+  out=$(run_bootstrap "$case_dir")
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "session start treated a symlink as an owned worker record: $out"
+  [ -L "$home/state/$id.meta" ] \
+    || fail "session start replaced or removed the inert symlinked record"
+  pass "session start ignores symlinked worker records"
+}
+
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open() {
   local case_dir id out
   id=atomic-heal-b9
@@ -1691,6 +1709,7 @@ test_recovery_retries_when_a_close_marker_cannot_be_removed
 test_recovery_reports_an_owned_row_read_failure
 test_orca_cleanup_recovery_never_transitions_the_backlog
 test_recovery_marks_an_owned_record_in_flight
+test_recovery_ignores_a_symlinked_worker_record
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open
 test_recovery_backfills_a_recorded_link_on_an_already_done_item
 test_recovery_preserves_a_close_when_the_backlog_cannot_be_read

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -451,6 +451,76 @@ SH
   pass "dispatch refuses held rows before creating resources"
 }
 
+test_dispatch_refuses_a_blocked_row_before_creating_resources() {
+  local case_dir id blocker out rc=0
+  id=atomic-dispatch-blocked-b16
+  blocker=atomic-dispatch-blocker-b16
+  case_dir=$(make_home dispatch-blocked "$id" "$blocker")
+  add_item "$case_dir" "$blocker"
+  tasks-axi add "$id" "item for $id" --kind ship --blocked-by "$blocker" \
+    --file "$(backlog_of "$case_dir")" >/dev/null
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *new-window*) : > "$case_dir/task-endpoint-created" ;;
+  *treehouse\\ get*) : > "$case_dir/local-copy-requested" ;;
+  *"#{pane_current_path}"*) printf '%s\n' "\${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "\${1:-}" in display-message) printf 'firstmate\n'; exit 0 ;; esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn accepted a dependency-blocked backlog row"
+  assert_contains "$out" "state queued no yes" \
+    "blocked-row refusal did not name the actual ineligible state"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "blocked-row refusal published a task record"
+  assert_absent "$case_dir/task-endpoint-created" \
+    "blocked-row refusal created an unowned endpoint"
+  assert_absent "$case_dir/local-copy-requested" \
+    "blocked-row refusal requested an unowned local copy"
+  [ "$(row_state "$case_dir" "$id")" = queued ] \
+    || fail "blocked-row refusal changed the backlog state"
+  pass "dispatch refuses dependency-blocked rows before creating resources"
+}
+
+test_dispatch_refuses_a_held_in_flight_row_before_relaunch() {
+  local case_dir id out rc=0
+  id=atomic-dispatch-held-in-flight-b16
+  case_dir=$(make_home dispatch-held-in-flight "$id")
+  add_item "$case_dir" "$id"
+  start_item "$case_dir" "$id"
+  tasks-axi hold "$id" --reason "captain decision pending" --kind captain \
+    --file "$(backlog_of "$case_dir")" >/dev/null
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *new-window*) : > "$case_dir/task-endpoint-created" ;;
+  *treehouse\\ get*) : > "$case_dir/local-copy-requested" ;;
+  *"#{pane_current_path}"*) printf '%s\n' "\${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "\${1:-}" in display-message) printf 'firstmate\n'; exit 0 ;; esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux"
+
+  out=$(run_ship_spawn "$case_dir" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "spawn accepted a held In-flight backlog row"
+  assert_contains "$out" "state in_flight yes no" \
+    "held In-flight refusal did not name the actual ineligible state"
+  assert_absent "$(home_of "$case_dir")/state/$id.meta" \
+    "held In-flight refusal published a task record"
+  assert_absent "$case_dir/task-endpoint-created" \
+    "held In-flight refusal created a replacement endpoint"
+  assert_absent "$case_dir/local-copy-requested" \
+    "held In-flight refusal requested a replacement local copy"
+  [ "$(row_state "$case_dir" "$id")" = in_flight ] \
+    || fail "held In-flight refusal changed the backlog state"
+  pass "dispatch refuses held In-flight rows before relaunch"
+}
+
 test_dispatch_reads_the_row_from_the_backlog_root() {
   local case_dir id out
   id=atomic-dispatch-root-b2
@@ -2155,6 +2225,8 @@ test_a_persistent_secondmate_is_never_a_backlog_item() {
 test_dispatch_moves_the_item_in_flight_in_the_same_run
 test_dispatch_refuses_a_pending_authoritative_close
 test_dispatch_refuses_a_held_row_before_creating_resources
+test_dispatch_refuses_a_blocked_row_before_creating_resources
+test_dispatch_refuses_a_held_in_flight_row_before_relaunch
 test_dispatch_reads_the_row_from_the_backlog_root
 test_recovery_uses_the_parent_of_a_trailing_slash_data_record
 test_completion_targets_a_nested_relative_data_directory

--- a/tests/fm-captain-hold-lifecycle.test.sh
+++ b/tests/fm-captain-hold-lifecycle.test.sh
@@ -90,7 +90,8 @@ write_origin_meta() {  # <home> <id> [kind]
     "project=$home/projects/sample" \
     "harness=codex" \
     "kind=$kind" \
-    "mode=$kind"
+    "mode=$kind" \
+    "spawn_gen=fixture-$id"
 }
 
 # Reproduces the loss exactly with privacy-safe synthetic names: the investigation

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -1320,6 +1320,33 @@ test_spawn_relaunch_refuses_a_live_agent() {
   pass "fm-spawn --relaunch: refuses to launch a second agent into a live endpoint"
 }
 
+test_spawn_relaunch_refuses_a_symlinked_task_record_before_inspection() {
+  local dir meta target out rc
+  dir=$(new_case symlink-meta rl37)
+  add_ship_task "$dir" rl37 claude
+  meta="$dir/home/state/rl37.meta"
+  target="$dir/foreign-task-record"
+  mv "$meta" "$target"
+  ln -s "$target" "$meta"
+  mv "$dir/fakebin/tmux" "$dir/fakebin/tmux-real"
+  cat > "$dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+: > "$dir/relaunch-endpoint-inspected"
+exec "$dir/fakebin/tmux-real" "\$@"
+SH
+  chmod +x "$dir/fakebin/tmux"
+
+  out=$(run_spawn "$dir" rl37 --relaunch --harness claude); rc=$?
+  expect_code 1 "$rc" "relaunching from symlinked metadata should refuse"
+  assert_contains "$out" "task record is not a regular non-symlink file" \
+    "relaunch did not identify the unsafe task record"
+  [ -L "$meta" ] || fail "relaunch replaced or removed the symlinked record"
+  assert_present "$target" "relaunch removed the foreign record target"
+  assert_absent "$dir/relaunch-endpoint-inspected" \
+    "relaunch inspected or acted on an endpoint from unsafe metadata"
+  pass "fm-spawn --relaunch: symlinked records refuse before inspection"
+}
+
 test_spawn_relaunch_refuses_a_pending_authoritative_close() {
   local dir meta marker out rc
   dir=$(new_case pending-close rl36)
@@ -1463,6 +1490,7 @@ test_concurrent_relaunch_is_refused
 test_direct_spawn_relaunch_participates_in_the_lifecycle_lock
 test_promotion_participates_in_the_lifecycle_lock_before_metadata_resolution
 test_spawn_relaunch_refuses_a_live_agent
+test_spawn_relaunch_refuses_a_symlinked_task_record_before_inspection
 test_spawn_relaunch_refuses_a_pending_authoritative_close
 test_spawn_relaunch_refuses_contradicting_flags
 test_spawn_relaunch_refuses_an_unrecorded_task

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -1338,7 +1338,7 @@ SH
 
   out=$(run_spawn "$dir" rl37 --relaunch --harness claude); rc=$?
   expect_code 1 "$rc" "relaunching from symlinked metadata should refuse"
-  assert_contains "$out" "task record is not a regular non-symlink file" \
+  assert_contains "$out" "task record resolves outside its authorized directory" \
     "relaunch did not identify the unsafe task record"
   [ -L "$meta" ] || fail "relaunch replaced or removed the symlinked record"
   assert_present "$target" "relaunch removed the foreign record target"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -1320,6 +1320,32 @@ test_spawn_relaunch_refuses_a_live_agent() {
   pass "fm-spawn --relaunch: refuses to launch a second agent into a live endpoint"
 }
 
+test_spawn_relaunch_refuses_a_pending_authoritative_close() {
+  local dir meta marker out rc
+  dir=$(new_case pending-close rl36)
+  add_ship_task "$dir" rl36 claude
+  meta="$dir/home/state/rl36.meta"
+  printf 'spawn_gen=spawn-pending\n' >> "$meta"
+  cp "$meta" "$dir/meta.before"
+  mkdir -p "$dir/wt/.claude"
+  printf 'prior wiring\n' > "$dir/wt/.claude/settings.local.json"
+  marker="$dir/home/state/rl36.backlog-close"
+  printf 'id=rl36\ndata=%s\nspawn_gen=spawn-pending\narg=--note\narg=local%%20main\n' \
+    "$dir/home/data" > "$marker"
+  printf 'zsh' > "$dir/fake/command"
+
+  out=$(run_spawn "$dir" rl36 --relaunch --harness claude); rc=$?
+  expect_code 1 "$rc" "relaunching over a pending close should refuse"
+  assert_contains "$out" "pending authoritative backlog close" \
+    "the refusal should identify the close that still owns the task"
+  cmp -s "$dir/meta.before" "$meta" \
+    || fail "pending-close refusal replaced the task incarnation"
+  assert_grep 'prior wiring' "$dir/wt/.claude/settings.local.json" \
+    "pending-close refusal cleared the prior worker wiring"
+  assert_present "$marker" "pending-close refusal discarded the authoritative close"
+  pass "fm-spawn --relaunch: pending closes refuse before replacement begins"
+}
+
 test_spawn_relaunch_refuses_contradicting_flags() {
   local dir out rc
   dir=$(new_case flags rl16)
@@ -1437,6 +1463,7 @@ test_concurrent_relaunch_is_refused
 test_direct_spawn_relaunch_participates_in_the_lifecycle_lock
 test_promotion_participates_in_the_lifecycle_lock_before_metadata_resolution
 test_spawn_relaunch_refuses_a_live_agent
+test_spawn_relaunch_refuses_a_pending_authoritative_close
 test_spawn_relaunch_refuses_contradicting_flags
 test_spawn_relaunch_refuses_an_unrecorded_task
 test_spawn_relaunch_refuses_a_pane_outside_the_worktree

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -86,7 +86,7 @@ case "${1:-}" in
         'export GOTMPDIR='*)
           if [ -n "${FM_FAKE_TRACE_PREPARE:-}" ]; then
             : > "$FM_FAKE_TRACE_PREPARE"
-            while [ ! -e "$FM_FAKE_META_WRITER_READY" ]; do /bin/sleep 0.01; done
+            while [ ! -e "$FM_FAKE_TRACE_RELEASE" ]; do /bin/sleep 0.01; done
           fi
           ;;
         'export TRACEPARENT='*)
@@ -117,6 +117,7 @@ SH
   chmod +x "$fb/tmux"
   cat > "$fb/sleep" <<'SH'
 #!/usr/bin/env bash
+[ -z "${FM_FAKE_LOCK_WAITING:-}" ] || : > "$FM_FAKE_LOCK_WAITING"
 exit 0
 SH
   chmod +x "$fb/sleep"
@@ -169,6 +170,7 @@ run_control() {  # <case-dir> <args...>
     FM_REAL_MV="${FM_REAL_MV:-}" FM_FAKE_COMPLETE_JOURNAL_MV_FAIL="${FM_FAKE_COMPLETE_JOURNAL_MV_FAIL:-}" \
     FM_FAKE_META_PUBLISH_MV_FAIL="${FM_FAKE_META_PUBLISH_MV_FAIL:-}" \
     FM_FAKE_TRACE_PREPARE="${FM_FAKE_TRACE_PREPARE:-}" \
+    FM_FAKE_TRACE_RELEASE="${FM_FAKE_TRACE_RELEASE:-}" \
     FM_FAKE_META_WRITER_READY="${FM_FAKE_META_WRITER_READY:-}" \
     FM_FAKE_TRACE_EXPORTED="${FM_FAKE_TRACE_EXPORTED:-}" \
     "$CONTROL" "$@" 2>&1
@@ -246,6 +248,38 @@ SH
   chmod +x "$1/fakebin/rm"
 }
 
+# Give a case home a real backlog carrying <id>, so the relaunch path's paired
+# backlog transition (bin/fm-backlog-transition-lib.sh) is live rather than
+# skipped for want of a backlog file.
+seed_backlog() {  # <case-dir> <id> <queued|in_flight>
+  local dir=$1 id=$2 want=$3 file="$1/home/data/backlog.md"
+  printf '%s\n' '# Backlog' '' '## In flight' '' '## Queued' '' '## Done' > "$file"
+  tasks-axi add "$id" "relaunch fixture task" --kind ship --file "$file" >/dev/null
+  [ "$want" != in_flight ] || tasks-axi start "$id" --file "$file" >/dev/null
+}
+
+backlog_state() {  # <case-dir> <id>
+  tasks-axi show "$2" --file "$1/home/data/backlog.md" 2>/dev/null |
+    sed -n 's/^  state: *//p' | head -1
+}
+
+# Shadow tasks-axi so every `start` fails and every other verb is real. A
+# relaunch that re-reads the row before acting never calls it; one that assumes
+# it must re-run the transition trips over it.
+break_tasks_axi_start() {  # <case-dir>
+  local dir=$1 real
+  real=$(command -v tasks-axi)
+  cat > "$dir/fakebin/tasks-axi" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = start ]; then
+  echo 'error: "start refused"' >&2
+  exit 1
+fi
+exec "$real" "\$@"
+SH
+  chmod +x "$dir/fakebin/tasks-axi"
+}
+
 # --- 1. same-harness relaunch -----------------------------------------------
 
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint() {
@@ -298,20 +332,20 @@ test_relaunch_preserves_durable_task_metadata() {
 }
 
 test_relaunch_serializes_concurrent_durable_metadata_publication() {
-  local dir control_pid link_pid rc i=0 traceparent prepare ready exported release
+  local dir control_pid link_pid rc i=0 traceparent prepare launch_release waiting ready release
   dir=$(new_case metadata-race rl28)
   add_ship_task "$dir" rl28 claude
   printf '%s\n' "$$" > "$dir/home/state/.lock"
   printf '%s on\n' "$$" > "$dir/home/state/.trace-context-effective"
   make_mv_failure_stub "$dir"
   prepare="$dir/trace-prepare"
+  launch_release="$dir/trace-release"
+  waiting="$dir/meta-writer-waiting"
   ready="$dir/meta-writer-ready"
-  exported="$dir/trace-exported"
   release="$dir/meta-writer-release"
   FM_REAL_MV=$(command -v mv) \
     FM_FAKE_TRACE_PREPARE="$prepare" \
-    FM_FAKE_META_WRITER_READY="$ready" \
-    FM_FAKE_TRACE_EXPORTED="$exported" \
+    FM_FAKE_TRACE_RELEASE="$launch_release" \
     run_control "$dir" rl28 relaunch --note "continue after publication" > "$dir/control.out" &
   control_pid=$!
   while [ ! -e "$prepare" ] && [ "$i" -lt 200 ]; do
@@ -325,6 +359,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
   }
   env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
     FM_REAL_MV="$(command -v mv)" \
+    FM_FAKE_LOCK_WAITING="$waiting" \
     FM_FAKE_META_WRITER_TARGET="$dir/home/state/rl28.meta" \
     FM_FAKE_META_WRITER_READY="$ready" \
     FM_FAKE_META_WRITER_RELEASE="$release" \
@@ -332,22 +367,34 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
       --carry-platform x --carry-max 280 > "$dir/link.out" 2>&1 &
   link_pid=$!
   i=0
-  while { [ ! -e "$ready" ] || [ ! -e "$exported" ]; } && [ "$i" -lt 200 ]; do
+  while [ ! -e "$waiting" ] && [ "$i" -lt 200 ]; do
     /bin/sleep 0.01
     i=$((i + 1))
   done
-  [ -e "$ready" ] && [ -e "$exported" ] || {
+  [ -e "$waiting" ] && [ ! -e "$ready" ] || {
+    : > "$launch_release"
     : > "$release"
+    wait "$link_pid" 2>/dev/null || true
+    wait "$control_pid" 2>/dev/null || true
+    fail "a durable metadata writer was not blocked during relaunch delivery"
+  }
+  : > "$launch_release"
+  i=0
+  while [ ! -e "$ready" ] && [ "$i" -lt 200 ]; do
+    /bin/sleep 0.01
+    i=$((i + 1))
+  done
+  [ -e "$ready" ] || {
     kill "$link_pid" "$control_pid" 2>/dev/null || true
     wait "$link_pid" 2>/dev/null || true
     wait "$control_pid" 2>/dev/null || true
-    fail "trace publication did not overlap the concurrent metadata writer"
+    fail "durable metadata writer did not resume after relaunch delivery committed"
   }
   : > "$release"
   wait "$link_pid"; rc=$?
   expect_code 0 "$rc" "concurrent X metadata publication should serialize"$'\n'"$(cat "$dir/link.out")"
   wait "$control_pid"; rc=$?
-  expect_code 0 "$rc" "relaunch should complete after serialized metadata publication"$'\n'"$(cat "$dir/control.out")"
+  expect_code 0 "$rc" "relaunch should complete before serialized metadata publication"$'\n'"$(cat "$dir/control.out")"
   [ "$(meta_field "$dir" rl28 x_request)" = request-28 ] \
     || fail "relaunch erased metadata published concurrently through the X interface"
   [ "$(meta_field "$dir" rl28 x_followups)" = 1 ] \
@@ -355,7 +402,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
   traceparent=$(meta_field "$dir" rl28 traceparent)
   fm_trace_context_valid "$traceparent" \
     || fail "concurrent metadata publication erased the replacement's trace carrier"
-  pass "fm-control relaunch: trace and concurrent task metadata publications serialize"
+  pass "fm-control relaunch: delivery and concurrent task metadata publication serialize"
 }
 
 test_disabled_relaunch_clears_prior_trace_context() {
@@ -1312,6 +1359,41 @@ test_spawn_relaunch_refuses_a_pane_outside_the_worktree() {
   pass "fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work"
 }
 
+test_relaunch_reverifies_an_already_in_flight_item_instead_of_rewriting_it() {
+  local dir out rc=0
+  command -v tasks-axi >/dev/null 2>&1 || {
+    pass "skipped: tasks-axi is not installed, so the backlog transition is inert"
+    return 0
+  }
+  dir=$(new_case reverify rl40)
+  add_ship_task "$dir" rl40 claude
+  seed_backlog "$dir" rl40 in_flight
+  break_tasks_axi_start "$dir"
+
+  out=$(run_control "$dir" rl40 relaunch --note "picking the work back up") || rc=$?
+  expect_code 0 "$rc" "a relaunch must not re-run a transition the row already reflects"$'\n'"$out"
+  [ "$(backlog_state "$dir" rl40)" = in_flight ] \
+    || fail "a relaunch changed an already In-flight item to $(backlog_state "$dir" rl40)"
+  pass "relaunch re-reads the backlog item instead of blindly re-running the transition"
+}
+
+test_relaunch_moves_a_drifted_item_back_in_flight() {
+  local dir out rc=0
+  command -v tasks-axi >/dev/null 2>&1 || {
+    pass "skipped: tasks-axi is not installed, so the backlog transition is inert"
+    return 0
+  }
+  dir=$(new_case drifted rl41)
+  add_ship_task "$dir" rl41 claude
+  seed_backlog "$dir" rl41 queued
+
+  out=$(run_control "$dir" rl41 relaunch --note "picking the work back up") || rc=$?
+  expect_code 0 "$rc" "a relaunch onto a drifted item should succeed"$'\n'"$out"
+  [ "$(backlog_state "$dir" rl41)" = in_flight ] \
+    || fail "a relaunch left its item at $(backlog_state "$dir" rl41)"
+  pass "relaunch heals an item that drifted out of In flight while the task stayed live"
+}
+
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_serializes_concurrent_durable_metadata_publication
@@ -1358,3 +1440,5 @@ test_spawn_relaunch_refuses_a_live_agent
 test_spawn_relaunch_refuses_contradicting_flags
 test_spawn_relaunch_refuses_an_unrecorded_task
 test_spawn_relaunch_refuses_a_pane_outside_the_worktree
+test_relaunch_reverifies_an_already_in_flight_item_instead_of_rewriting_it
+test_relaunch_moves_a_drifted_item_back_in_flight

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -1347,6 +1347,36 @@ SH
   pass "fm-spawn --relaunch: symlinked records refuse before inspection"
 }
 
+test_spawn_relaunch_keeps_its_early_meta_lock_continuous() {
+  local dir lock out rc
+  dir=$(new_case continuous-meta-lock rl38)
+  add_ship_task "$dir" rl38 claude
+  printf 'zsh' > "$dir/fake/command"
+  lock="$dir/home/state/.meta-rl38.lock"
+  mv "$dir/fakebin/tmux" "$dir/fakebin/tmux-real"
+  cat > "$dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+if [ -d "$lock" ]; then
+  if [ ! -e "$dir/lock-observation-started" ]; then
+    : > "$dir/lock-observation-started"
+    : > "$lock/continuity-sentinel"
+  elif [ ! -e "$lock/continuity-sentinel" ]; then
+    : > "$dir/meta-lock-was-recreated"
+  fi
+fi
+exec "$dir/fakebin/tmux-real" "\$@"
+SH
+  chmod +x "$dir/fakebin/tmux"
+
+  out=$(run_spawn "$dir" rl38 --relaunch --harness claude); rc=$?
+  expect_code 0 "$rc" "relaunch with one continuous meta lock should succeed"$'\n'"$out"
+  assert_present "$dir/lock-observation-started" \
+    "test did not observe the relaunch-held meta lock"
+  assert_absent "$dir/meta-lock-was-recreated" \
+    "relaunch released or recreated its already-held meta lock"
+  pass "fm-spawn --relaunch: keeps its early meta lock continuous"
+}
+
 test_spawn_relaunch_refuses_a_pending_authoritative_close() {
   local dir meta marker out rc
   dir=$(new_case pending-close rl36)
@@ -1491,6 +1521,7 @@ test_direct_spawn_relaunch_participates_in_the_lifecycle_lock
 test_promotion_participates_in_the_lifecycle_lock_before_metadata_resolution
 test_spawn_relaunch_refuses_a_live_agent
 test_spawn_relaunch_refuses_a_symlinked_task_record_before_inspection
+test_spawn_relaunch_keeps_its_early_meta_lock_continuous
 test_spawn_relaunch_refuses_a_pending_authoritative_close
 test_spawn_relaunch_refuses_contradicting_flags
 test_spawn_relaunch_refuses_an_unrecorded_task

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -269,7 +269,7 @@ test_send_refuses_and_admits() {
 make_teardown_case() {
   local name=$1 case_dir fakebin t
   case_dir="$TMP/$name"; fakebin="$case_dir/fakebin"
-  mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin"
+  mkdir -p "$case_dir/state" "$case_dir/config" "$case_dir/data" "$fakebin"
   for t in treehouse tmux; do
     printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/$t"
     chmod +x "$fakebin/$t"
@@ -305,7 +305,7 @@ SH
   fm_write_meta "$case_dir/state/task-x1.meta" \
     "window=firstmate:fm-task-x1" "endpoint_task_id=task-x1" \
     "worktree=$case_dir/wt" "project=$case_dir/project" \
-    "kind=ship" "mode=no-mistakes"
+    "kind=ship" "mode=no-mistakes" "spawn_gen=spawn-gate-refuse-task-x1"
   touch "$case_dir/state/.last-watcher-beat"
   printf '%s\n' "$case_dir"
 }
@@ -315,7 +315,8 @@ run_teardown() {
   local cwd=$1 case_dir=$2; shift 2
   ( cd "$cwd" && env -u NO_MISTAKES_GATE -u FM_GATE_REFUSE_BYPASS \
       "FM_ROOT_OVERRIDE=$ROOT" "FM_STATE_OVERRIDE=$case_dir/state" \
-      "FM_CONFIG_OVERRIDE=$case_dir/config" "PATH=$case_dir/fakebin:$PATH" "$@" \
+      "FM_DATA_OVERRIDE=$case_dir/data" "FM_CONFIG_OVERRIDE=$case_dir/config" \
+      "PATH=$case_dir/fakebin:$PATH" "$@" \
       "$TEARDOWN" task-x1 ) 2>&1
 }
 

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -47,7 +47,7 @@ TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-gotmp-tests.XXXXXX")
 make_fake_root() {
   local id=$1 tasktmp=$2
   local fake="$TMP_ROOT/$id"
-  mkdir -p "$fake/bin/backends" "$fake/state"
+  mkdir -p "$fake/bin/backends" "$fake/state" "$fake/data"
   # Symlink the REAL teardown so the test exercises actual code, not a copy.
   ln -s "$TEARDOWN" "$fake/bin/fm-teardown.sh"
   # fm-backend.sh + its tmux adapter: symlink the REAL files (teardown sources
@@ -148,7 +148,7 @@ test_teardown_skips_gracefully_without_tasktmp() {
   # not error and must not remove anything.
   local id=td-absent-z3
   local fake="$TMP_ROOT/$id-root"
-  mkdir -p "$fake/bin/backends" "$fake/state"
+  mkdir -p "$fake/bin/backends" "$fake/state" "$fake/data"
   ln -s "$TEARDOWN" "$fake/bin/fm-teardown.sh"
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -101,11 +101,15 @@ SH
 exit 0
 SH
   chmod +x "$fake/bin/fm-fleet-sync.sh"
-  # fm-tasks-axi-lib.sh: stub (teardown sources it). Report no backend so
-  # backlog_refresh_reminder takes the plain-message path; no tasks-axi here.
+  # fm-tasks-axi-lib.sh: stub (teardown sources it). Report no backend so the
+  # fused backlog close is skipped and the follow-up echo takes the plain-message
+  # path; there is no tasks-axi and no backlog in this fixture.
   cat > "$fake/bin/fm-tasks-axi-lib.sh" <<'SH'
 fm_tasks_axi_backend_available() { return 1; }
+fm_tasks_axi_compatible() { return 1; }
+fm_backlog_backend_manual() { return 1; }
 SH
+  ln -s "$ROOT/bin/fm-backlog-transition-lib.sh" "$fake/bin/fm-backlog-transition-lib.sh"
   # Meta with a nonexistent worktree so the dirty/treehouse blocks skip.
   cat > "$fake/state/$id.meta" <<META
 window=fakeses:fm-$id
@@ -188,7 +192,10 @@ SH
   chmod +x "$fake/bin/fm-fleet-sync.sh"
   cat > "$fake/bin/fm-tasks-axi-lib.sh" <<'SH'
 fm_tasks_axi_backend_available() { return 1; }
+fm_tasks_axi_compatible() { return 1; }
+fm_backlog_backend_manual() { return 1; }
 SH
+  ln -s "$ROOT/bin/fm-backlog-transition-lib.sh" "$fake/bin/fm-backlog-transition-lib.sh"
   # No tasktmp= line at all.
   cat > "$fake/state/$id.meta" <<META
 window=fakeses:fm-$id

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -624,7 +624,7 @@ test_secondmate_teardown_requires_parent_binding() {
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
     FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
@@ -648,7 +648,7 @@ test_secondmate_teardown_requires_parent_binding() {
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
   assert_absent "$child/.fm-secondmate-parent" \
     "the legacy env-only binding case must not gain a durable parent record"
 
@@ -757,7 +757,7 @@ test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost() {
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   # No FM_PUBLIC_FOLLOWUP_PRIMARY_HOME at all here: a restart of the secondmate
   # agent that drops the launch-time prefix must still find the real parent
@@ -790,7 +790,7 @@ test_secondmate_teardown_durable_record_missing_parent_registration_still_refuse
   assert_local_secondmate_parent_record "$child" "$parent_resolved"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
   # No parent/state/mate.meta at all: the parent never recorded this secondmate's
   # own agent, so its side of the binding is genuinely missing. A durable LOCAL
   # record naming the real parent path must not be enough on its own to bypass
@@ -828,7 +828,7 @@ test_secondmate_teardown_durable_record_with_unknown_field_succeeds() {
   fm_write_meta "$child/state/work-clean.meta" \
     "window=firstmate:fm-work-clean" "endpoint_task_id=work-clean" \
     "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
-    "kind=ship" "mode=local-only"
+    "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   rc=0
   out=$(PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
@@ -860,7 +860,7 @@ test_secondmate_teardown_rejects_conflicting_live_and_durable_parent_bindings() 
   fm_write_meta "$child/state/work-conflict.meta" \
     "window=firstmate:fm-work-conflict" "endpoint_task_id=work-conflict" \
     "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
-    "kind=ship" "mode=local-only"
+    "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
     FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
@@ -887,7 +887,7 @@ test_secondmate_teardown_rejects_unsafe_durable_parent_records() {
     fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
     fm_write_meta "$child/state/work-child.meta" \
       "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-      "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+      "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
     parent_record="$child/.fm-secondmate-parent"
     case "$case_name" in
       symlink)
@@ -954,7 +954,7 @@ test_secondmate_teardown_rejects_nul_bearing_durable_parent_record() {
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
     "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
-    "kind=ship" "mode=local-only"
+    "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
   pre=${parent_resolved%??????}
   suf=${parent_resolved#"$pre"}
   record="$child/.fm-secondmate-parent"
@@ -992,7 +992,7 @@ SH
   fm_write_meta "$home/state/work-disabled.meta" \
     "window=firstmate:fm-work-disabled" "endpoint_task_id=work-disabled" \
     "worktree=$home/projects/worktree" "project=$home/projects/worktree" \
-    "kind=ship" "mode=local-only"
+    "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   rc=0
   out=$(PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
@@ -1028,7 +1028,7 @@ SH
   fm_write_meta "$child/state/work-disabled.meta" \
     "window=firstmate:fm-work-disabled" "endpoint_task_id=work-disabled" \
     "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
-    "kind=ship" "mode=local-only"
+    "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   rc=0
   out=$(PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
@@ -1056,7 +1056,7 @@ test_secondmate_parent_binding_matches_literal_id() {
   fm_write_meta "$parent/state/mate.id.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-literal.meta" \
     "window=firstmate:fm-work-literal" "endpoint_task_id=work-literal" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
     FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
@@ -1141,13 +1141,18 @@ test_cleanup_refuses_while_a_public_reply_is_owed() {
   local home rc
   home=$(make_home cleanup-guard)
   seed_commitment "$home" pf-guard req-guard discord main ship-task
+  tasks_in "$home" add ship-task "ship guarded by its public follow-up" --kind ship >/dev/null \
+    || fail "could not add the guarded ship to its home's backlog"
+  tasks_in "$home" start ship-task >/dev/null \
+    || fail "could not mark the guarded ship In flight"
   fm_write_meta "$home/state/ship-task.meta" \
     "window=firstmate:fm-ship-task" \
     "worktree=$home/projects/gone" \
     "project=$home/projects/sample" \
     "harness=codex" \
     "kind=ship" \
-    "mode=no-mistakes"
+    "mode=no-mistakes" \
+    "spawn_gen=public-followup-guard"
 
   rc=0
   PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
@@ -1392,7 +1397,7 @@ test_dropped_baton_now_surfaces_open_loop() {
 
   fm_write_meta "$child/state/pi-rearm-loop-fix-r1.meta" \
     "window=firstmate:fm-pi-rearm-loop-fix-r1" "endpoint_task_id=pi-rearm-loop-fix-r1" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
 
   PATH="$parent/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$parent" \
     FM_STATE_OVERRIDE="$parent/state" "$PF" guard-work secondmate:mate pi-rearm-loop-fix-r1 \
@@ -1428,7 +1433,7 @@ test_control_registered_followon_is_guarded() {
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/pi-rearm-loop-fix-r1.meta" \
     "window=firstmate:fm-pi-rearm-loop-fix-r1" "endpoint_task_id=pi-rearm-loop-fix-r1" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
   PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
     FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
     expect_failure "registered follow-on must be guarded" "$TEARDOWN" pi-rearm-loop-fix-r1
@@ -1966,13 +1971,18 @@ test_retention_creates_no_false_teardown_refusal() {
   local home home2 rc out registry tmp
   home=$(make_home retain-teardown)
   seed_commitment "$home" pf-retain req-retain discord main ship-retain
+  tasks_in "$home" add ship-retain "ship with a retained delivered registration" --kind ship >/dev/null \
+    || fail "could not add the retained-registration ship to its home's backlog"
+  tasks_in "$home" start ship-retain >/dev/null \
+    || fail "could not mark the retained-registration ship In flight"
   fm_write_meta "$home/state/ship-retain.meta" \
     "window=firstmate:fm-ship-retain" \
     "worktree=$home/projects/gone" \
     "project=$home/projects/sample" \
     "harness=codex" \
     "kind=ship" \
-    "mode=no-mistakes"
+    "mode=no-mistakes" \
+    "spawn_gen=public-followup-retain"
   emit_terminal "$home" "$home" pf-retain main ship-retain >/dev/null || fail "emit failed"
   run_pf "$home" consume >/dev/null || fail "consume failed"
   FAKE_CURL_LOG="$home/curl.log" run_pf "$home" deliver pf-retain >/dev/null || fail "delivery failed"
@@ -2121,12 +2131,17 @@ test_prechange_registration_is_open_and_unrechainable() {
 test_x_request_teardown_warns_when_final_unposted() {
   local home rc
   home=$(make_home xreq-warn)
+  tasks_in "$home" add linked-task "ship with a legacy Relay request link" --kind ship >/dev/null \
+    || fail "could not add the legacy-link ship to its home's backlog"
+  tasks_in "$home" start linked-task >/dev/null \
+    || fail "could not mark the legacy-link ship In flight"
   fm_write_meta "$home/state/linked-task.meta" \
     "window=firstmate:fm-linked-task" \
     "worktree=$home/projects/gone" \
     "project=$home/projects/sample" \
     "kind=ship" \
     "mode=local-only" \
+    "spawn_gen=public-followup-legacy-link" \
     "x_request=req-legacy-final"
   rc=0
   PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \

--- a/tests/fm-remote-secondmate-parent-binding.test.sh
+++ b/tests/fm-remote-secondmate-parent-binding.test.sh
@@ -221,6 +221,10 @@ esac
 # --- a finished child worker inside the remote secondmate home --------------
 CHILD_WT="$REMOTE_HOME/projects/alpha"
 mkdir -p "$REMOTE_HOME/state"
+# This regression exercises remote-parent binding, not backlog mutation. Keep
+# its synthetic child home on the supported hand-edited backend so teardown's
+# fused automatic close is correctly exempt without requiring a tasks-axi mock.
+printf '%s\n' manual > "$REMOTE_HOME/config/backlog-backend"
 write_child_meta() {
   fm_write_meta "$REMOTE_HOME/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \

--- a/tests/fm-remote-secondmate-parent-binding.test.sh
+++ b/tests/fm-remote-secondmate-parent-binding.test.sh
@@ -175,6 +175,16 @@ if [ "$command_name" = fm-remote-doctor.sh ]; then
   printf 'ok: remote second-mate readiness confirmed on this host\n'
   exit 0
 fi
+if [ "$command_name" = fm-remote-secondmate-control.sh ] \
+   && [ "$_command_action" = launch ] \
+   && [ -n "${FM_TEST_PUBLICATION_TARGET:-}" ]; then
+  out=$("$FM_FAKE_REMOTE_ENTRYPOINT" "$@")
+  rc=$?
+  rm -f "$FM_TEST_PUBLICATION_TARGET"
+  ln -s "$FM_TEST_PUBLICATION_FOREIGN" "$FM_TEST_PUBLICATION_TARGET" || exit 94
+  printf '%s\n' "$out"
+  exit "$rc"
+fi
 exec "$FM_FAKE_REMOTE_ENTRYPOINT" "$@"
 SH
 chmod +x "$FAKEBIN/fake-ssh"
@@ -294,5 +304,23 @@ assert_contains "$CHILD_TEARDOWN_OUT" "cannot resolve the primary home" \
 assert_present "$REMOTE_HOME/state/work-child.meta" \
   "a genuine refusal must preserve the child work metadata"
 pass "a remote secondmate's own committed relay token still refuses cleanup"
+
+FOREIGN_META="$TMP_ROOT/foreign-ios.meta"
+LOCAL_META="$PARENT/state/ios.meta"
+printf 'foreign sentinel\n' > "$FOREIGN_META"
+rm -f "$LOCAL_META"
+PUBLICATION_RC=0
+PUBLICATION_OUT=$(FM_TEST_PUBLICATION_TARGET="$LOCAL_META" \
+  FM_TEST_PUBLICATION_FOREIGN="$FOREIGN_META" \
+  remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate 2>&1) || PUBLICATION_RC=$?
+[ "$PUBLICATION_RC" -ne 0 ] \
+  || fail "remote secondmate publication accepted a target resolving outside its home"
+assert_contains "$PUBLICATION_OUT" "task record could not be published" \
+  "remote secondmate publication did not report its record-boundary refusal"
+cmp -s "$FOREIGN_META" <(printf 'foreign sentinel\n') \
+  || fail "remote secondmate publication wrote through the foreign target"
+[ -L "$LOCAL_META" ] \
+  || fail "remote secondmate publication replaced the refused target boundary"
+pass "remote secondmate publication refuses targets outside its home"
 
 echo "ALL TESTS PASSED"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -6,7 +6,7 @@
 # Coverage:
 #   - absent-file markers vs empty-but-present files in the context digest
 #   - the lock-refusal read-only path: banner leads, every mutating step is
-#     skipped (including bootstrap's five mutating sweeps, verified by their
+#     skipped (including bootstrap's seven mutating sweeps, verified by their
 #     ABSENCE), the digest still completes
 #   - output section ordering: the safety preamble leads unchanged, live fleet
 #     state precedes the curated memory a truncated tail may take, and the

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -96,7 +96,7 @@ test_projects_path_scoping() {
     fi
     status=$?
     [ "$status" -ne 0 ] || fail "$label: spawn with missing brief should fail"
-    expected="error: no brief at $home/data/$id/brief.md"
+    expected="error: task $id has no brief at inaccessible data path $home/data/$id/brief.md"
     printf '%s\n' "$out" | grep -F "$expected" >/dev/null \
       || fail "$label: projects/alpha was not resolved through the home before the brief check"
     printf '%s\n' "$out" | grep -F 'cd: projects/alpha' >/dev/null \

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -609,7 +609,7 @@ test_teardown_closes_the_backlog_item_itself() {
 }
 
 test_teardown_manual_backend_leaves_the_backlog_to_the_operator() {
-  local case_dir out
+  local case_dir out backlog_path
   case_dir=$(make_case tasks-axi-manual-optout)
   write_meta "$case_dir" no-mistakes ship
   printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
@@ -619,7 +619,8 @@ test_teardown_manual_backend_leaves_the_backlog_to_the_operator() {
   out=$(run_teardown "$case_dir") || fail "teardown failed with manual backlog backend"
   [ "$(backlog_row_state "$case_dir")" = in_flight ] \
     || fail "manual backlog backend was mutated by teardown anyway"
-  printf '%s\n' "$out" | grep -F 'Update data/backlog.md - move task-x1 to Done' >/dev/null \
+  backlog_path=$(cd "$case_dir/data" && pwd -P)/backlog.md
+  printf '%s\n' "$out" | grep -F "Update $backlog_path - move task-x1 to Done" >/dev/null \
     || fail "teardown did not prompt manual backlog update under opt-out: $out"
   pass "teardown honors config/backlog-backend=manual and still finishes cleanly"
 }

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -76,7 +76,7 @@ make_case() {
   local name=$1 case_dir fakebin
   case_dir="$TMP_ROOT/$name"
   fakebin="$case_dir/fakebin"
-  mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin"
+  mkdir -p "$case_dir/state" "$case_dir/config" "$case_dir/data" "$fakebin"
 
   # Mocks for the post-check teardown steps. Refuse logic exits before these
   # run; the ALLOW cases need them so the script can complete cleanly.
@@ -175,29 +175,6 @@ SH
   printf '%s\n' "$case_dir"
 }
 
-add_compatible_tasks_axi() {
-  local case_dir=$1
-  cat > "$case_dir/fakebin/tasks-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.2.4'
-  exit 0
-fi
-if [ "${1:-}" = update ] && [ "${2:-}" = --help ]; then
-  printf '%s\n' 'usage: tasks-axi update <id> [flags]'
-  printf '%s\n' '  --body-file <path>'
-  printf '%s\n' '  --archive-body'
-  exit 0
-fi
-if [ "${1:-}" = mv ] && [ "${2:-}" = --help ]; then
-  printf '%s\n' 'usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$case_dir/fakebin/tasks-axi"
-}
-
 # Write a meta file for the task. Args: case_dir mode kind
 write_meta() {
   local case_dir=$1 mode=$2 kind=$3
@@ -207,7 +184,8 @@ write_meta() {
     "worktree=$case_dir/wt" \
     "project=$case_dir/project" \
     "kind=$kind" \
-    "mode=$mode"
+    "mode=$mode" \
+    "spawn_gen=teardown-test-task-x1"
 }
 
 # Commit something on the worktree's task branch. Args: case_dir [message]
@@ -273,7 +251,7 @@ SH
 case "\${1:-} \${2:-}" in
   "pr view")
     case " \$* " in
-      *"state,headRefOid"*) printf '%s\t%s\n' 'MERGED' '$head' ; exit 0 ;;
+      *"state,headRefOid,url"*) printf '%s\t%s\t%s\n' 'MERGED' '$head' 'https://github.com/example/repo/pull/7' ; exit 0 ;;
       *"headRefOid"*) printf '%s\n' '$head' ; exit 0 ;;
     esac
     ;;
@@ -542,11 +520,34 @@ SH
 # Run teardown with PATH mocking. Args: case_dir [extra args...]
 run_teardown() {
   local case_dir=$1; shift
+  # FM_DATA_OVERRIDE is pinned to the case dir because teardown closes this
+  # home's backlog item itself; without it $DATA would resolve to the real
+  # repo's own home and a test could mutate live records.
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_DATA_OVERRIDE="$case_dir/data" \
   FM_CONFIG_OVERRIDE="$case_dir/config" \
   PATH="$case_dir/fakebin:${FM_TEARDOWN_TEST_PATH:-$PATH}" \
     "$TEARDOWN" task-x1 "$@"
+}
+
+# Seed a real backlog carrying task-x1 as In flight, so a teardown in this case
+# has a row to close. Uses the real tasks-axi (the fixture's default fakebin has
+# no tasks-axi stub, so PATH resolves the installed one).
+seed_backlog_in_flight() {
+  local case_dir=$1 kind=${2:-ship}
+  mkdir -p "$case_dir/data"
+  printf '%s\n' '# Backlog' '' '## In flight' '' '## Queued' '' '## Done' \
+    > "$case_dir/data/backlog.md"
+  tasks-axi add task-x1 "teardown fixture task" --kind "$kind" \
+    --file "$case_dir/data/backlog.md" >/dev/null
+  tasks-axi start task-x1 --file "$case_dir/data/backlog.md" >/dev/null
+}
+
+backlog_row_state() {
+  local case_dir=$1
+  tasks-axi show task-x1 --file "$case_dir/data/backlog.md" 2>/dev/null |
+    sed -n 's/^  state: *//p' | head -1
 }
 
 # Build the teardown test's executable search path without lsof, regardless of
@@ -584,39 +585,43 @@ test_local_only_fork_remote_allows() {
   pass "local-only worktree with HEAD on a fork remote is torn down and the home summary is refreshed"
 }
 
-test_teardown_prompts_tasks_axi_done_when_compatible() {
+test_teardown_closes_the_backlog_item_itself() {
   local case_dir out
-  case_dir=$(make_case tasks-axi-reminder)
+  case_dir=$(make_case tasks-axi-close)
   write_meta "$case_dir" no-mistakes ship
   printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
-  add_compatible_tasks_axi "$case_dir"
+  seed_backlog_in_flight "$case_dir"
 
-  out=$(run_teardown "$case_dir") || fail "teardown failed with compatible tasks-axi"
-  printf '%s\n' "$out" | grep -F 'tasks-axi done task-x1 --pr https://github.com/example/repo/pull/7' >/dev/null \
-    || fail "teardown did not prompt tasks-axi done: $out"
+  out=$(run_teardown "$case_dir") || fail "teardown failed with a real backlog"
+  [ "$(backlog_row_state "$case_dir")" = "done" ] \
+    || fail "teardown returned success while its backlog item was still open: $(backlog_row_state "$case_dir")"
+  assert_grep 'https://github.com/example/repo/pull/7' "$case_dir/data/backlog.md" \
+    "closed backlog item did not record the task's PR"
+  assert_absent "$case_dir/state/task-x1.backlog-close" \
+    "a landed close left its pending-close record behind"
   printf '%s\n' "$out" | grep -F 'tasks-axi ready' >/dev/null \
-    || fail "teardown did not prompt tasks-axi ready: $out"
+    || fail "teardown dropped the dependency-cleared follow-up: $out"
   printf '%s\n' "$out" | grep -F 'check date gates' >/dev/null \
     || fail "teardown did not preserve date-gate check: $out"
-  printf '%s\n' "$out" | grep -F 'keep Done to the 10 most recent' >/dev/null \
-    && fail "teardown kept manual Done pruning in compatible tasks-axi prompt: $out"
-  pass "teardown prompts tasks-axi backlog refresh when compatible"
+  printf '%s\n' "$out" | grep -F 'Run tasks-axi done' >/dev/null \
+    && fail "teardown still asked a later turn to close the item it already closed: $out"
+  pass "teardown closes its own backlog item before reporting success"
 }
 
-test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present() {
+test_teardown_manual_backend_leaves_the_backlog_to_the_operator() {
   local case_dir out
   case_dir=$(make_case tasks-axi-manual-optout)
   write_meta "$case_dir" no-mistakes ship
   printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
   printf '%s\n' manual > "$case_dir/config/backlog-backend"
-  add_compatible_tasks_axi "$case_dir"
+  seed_backlog_in_flight "$case_dir"
 
   out=$(run_teardown "$case_dir") || fail "teardown failed with manual backlog backend"
+  [ "$(backlog_row_state "$case_dir")" = in_flight ] \
+    || fail "manual backlog backend was mutated by teardown anyway"
   printf '%s\n' "$out" | grep -F 'Update data/backlog.md - move task-x1 to Done' >/dev/null \
     || fail "teardown did not prompt manual backlog update under opt-out: $out"
-  printf '%s\n' "$out" | grep -F 'tasks-axi done' >/dev/null \
-    && fail "teardown prompted tasks-axi despite manual backend opt-out: $out"
-  pass "teardown honors config/backlog-backend=manual even when tasks-axi is compatible"
+  pass "teardown honors config/backlog-backend=manual and still finishes cleanly"
 }
 
 test_local_only_truly_unpushed_refuses() {
@@ -757,6 +762,7 @@ test_no_pr_recorded_discovers_merged_pr_by_branch_allows() {
   pr_head=$(commit_tree_from_wt_head "$case_dir" "$local_head" "no-mistakes auto-fix")
   land_on_origin_main "$case_dir" feature.txt hello
   add_gh_pr_merged_for_head "$case_dir" "$pr_head"
+  seed_backlog_in_flight "$case_dir"
   # No append_pr_meta_* call: state/task-x1.meta has no pr= or pr_head= line.
 
   ! grep -qE '^(pr|pr_head)=' "$case_dir/state/task-x1.meta" \
@@ -769,6 +775,8 @@ test_no_pr_recorded_discovers_merged_pr_by_branch_allows() {
 
   expect_code 0 "$rc" "no-pr-branch-discovery: teardown should succeed by discovering the merged PR from the branch name"
   ! grep -q REFUSED "$case_dir/stderr" || fail "no-pr-branch-discovery: teardown printed a REFUSED line"
+  assert_grep 'https://github.com/example/repo/pull/7' "$case_dir/data/backlog.md" \
+    "no-pr-branch-discovery: resolved PR URL was not recorded on completion"
   pass "teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded"
 }
 
@@ -1563,8 +1571,8 @@ SH
       ;;
   esac
   rc=0
-  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" FM_CONFIG_OVERRIDE="$case_dir/config" \
-    FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" \
+  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" FM_DATA_OVERRIDE="$case_dir/data" \
+    FM_CONFIG_OVERRIDE="$case_dir/config" FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" \
     FM_FAKE_HERDR_SESSION_LIST_GARBAGE="$([ "$mode" = unresolvable-lock ] && printf 1 || printf 0)" \
     PATH="$case_dir/fakebin:$PATH" \
     "$teardown_bin" task-x1 --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
@@ -2597,8 +2605,8 @@ EOF
 }
 
 test_local_only_fork_remote_allows
-test_teardown_prompts_tasks_axi_done_when_compatible
-test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
+test_teardown_closes_the_backlog_item_itself
+test_teardown_manual_backend_leaves_the_backlog_to_the_operator
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
 test_no_mistakes_origin_remote_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -556,7 +556,7 @@ make_path_without_lsof() {  # <case-dir>
   local case_dir=$1 path_dir="$1/path-without-lsof" cmd resolved
   mkdir -p "$path_dir"
   for cmd in awk bash basename cat chmod cp cut date dirname env find git grep head hostname id ln \
-    mkdir mktemp mv od perl ps readlink realpath rm sed sh sleep sort stat tail timeout tr uname wc xargs; do
+    mkdir mktemp mv perl ps readlink realpath rm sed sh sleep sort stat tail timeout tr uname wc xargs; do
     resolved=$(command -v "$cmd" 2>/dev/null) || continue
     case "$resolved" in /*) ln -sf "$resolved" "$path_dir/$cmd" ;; esac
   done

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -556,7 +556,7 @@ make_path_without_lsof() {  # <case-dir>
   local case_dir=$1 path_dir="$1/path-without-lsof" cmd resolved
   mkdir -p "$path_dir"
   for cmd in awk bash basename cat chmod cp cut date dirname env find git grep head hostname id ln \
-    mkdir mktemp mv perl ps readlink realpath rm sed sh sleep sort stat tail timeout tr uname wc xargs; do
+    mkdir mktemp mv od perl ps readlink realpath rm sed sh sleep sort stat tail timeout tr uname wc xargs; do
     resolved=$(command -v "$cmd" 2>/dev/null) || continue
     case "$resolved" in /*) ln -sf "$resolved" "$path_dir/$cmd" ;; esac
   done


### PR DESCRIPTION
## Intent

Make Firstmate backlog and task-record state atomically consistent by construction, so the three record-disagreement classes an earlier investigation catalogued (orphan_in_flight, unowned_current, terminal_in_flight) cannot arise from the ordinary dispatch/completion path, and add durable terminal-close recovery for the class that can still occur across a crash.

INVARIANT: the script performing the mechanical physical-state change (create or remove state/<id>.meta) must be the SOLE owner of the paired backlog transition, executed in the same process under the per-task lock it already holds, BEFORE it reports success - never a second, independently-timed step.

ACCEPTED REQUIREMENTS:
1. Dispatch (bin/fm-spawn.sh): after durably writing the task record and while holding the meta lock, fold the backlog In-flight transition into the spawn as the last step before declaring success; on failure fail loudly and remove the provisional record rather than leaving an orphaned one. Reject every known-ineligible row state at preflight, before any resource is created, so a held row can never launch a worker that the transition then rolls back. Relaunch re-verifies rather than blindly re-running, and must not re-acquire a lock it already holds.
2. Completion (bin/fm-teardown.sh): fold the backlog completion transition (with the right --pr/--report/--note) in under the meta lock before release and before reporting success. Record the AUTHORITATIVE close BEFORE the destructive cleanup sequence begins (process reaping, local-copy return, endpoint closure), so a crash mid-cleanup leaves a recoverable pending close; this deliberately accepts that replay may close the books while physical resources are partially cleaned, so that case must be reported, never silent. A resolved merged PR URL must reach the close. The reminder becomes a truthful confirmation echo naming the ACTUAL configured backlog path. Existing unlanded-work and landed-work refusals are unchanged.
3. Same-home self-heal (bin/fm-bootstrap.sh): reconcile this home own books on restart. Same-home only - never read or write another home; the fleet snapshot classifier and the cross-home nudge remain backstops. A pending close suppresses record reconciliation for that id.
4. Backend exemption, CAPTAIN-DECIDED and narrowed: exempt EXACTLY two cases, a manual-backend home and a home with no backlog. An automatic-backend home that HAS a backlog but whose tasks-axi is missing or incompatible must FAIL LOUDLY BEFORE ANY MUTATION, not silently skip.
5. Close-record integrity: reject the raw record when it carries NUL or other control bytes; require every field well-formed and non-duplicated; require the id to match the record it was found under; restrict close arguments to permitted well-formed values; and apply the idempotent done backfill before deleting an already-closed record so a completion link is never lost. Writer and reader share ONE validator, so anything published stays replayable regardless of process locale, and legitimate paths containing spaces or non-ASCII characters round-trip.
6. Same-home containment, CAPTAIN-DECIDED: at ONE shared file-access boundary covering the backlog, the worker record and the close record, canonicalize the accessed path and the home root and require containment, and additionally require the resolved path to equal its canonical parent plus the original basename so a final-component symlink is refused even when its target is inside the home. Every access point and every post-lock recheck routes through that single boundary.
7. Tool contract: the spawn and teardown lifecycle runs under a curated command set (pinned by make_path_without_lsof in tests/fm-teardown.test.sh). Byte validation uses perl, which is in that set. Do NOT reintroduce a dependency on od, and do NOT widen that fixture allowlist to make a test pass - a validator that cannot run must never wedge dispatch or cleanup.

EXCLUSIONS: no distributed transaction, two-phase commit, durable-retry, receipt, or crash-safe journal subsystem - this is single-writer, single-host, single-filesystem-per-task. Do not unify decision owners. The markerless-remote-mate gap is out of scope. Broader spawn-interrupt safety is DEFERRED to a dedicated follow-up: signal deferral must stay scoped to the backlog-transition window only, and must NOT be extended to cover launch submission, harness readiness or delivery, and no live-worker marking or confirmed-absence rollback machinery.

TESTS: behavioral regressions exercising the real scripts and asserting observable record and backlog state, never source text.

Changed bash must be stock macOS bash 3.2 compatible and shellcheck-clean.

KNOWN PRE-EXISTING, NOT CAUSED BY THIS BRANCH - do NOT attempt to fix: tests/fm-session-start.test.sh hangs at test_codex_unreachable_reset_sources_do_not_claim_instruction_refresh, and tests/fm-public-followup.test.sh fails its missing-parent-binding assertion. Both reproduce identically on unmodified origin/main.

## What Changed
- Fuse dispatch record publication and backlog start under the per-task lock, with eligibility preflight, relaunch re-verification, and provisional-record rollback on failure.
- Record and validate authoritative completion details before teardown cleanup, close the backlog under the same lock, and replay interrupted closes or reconcile owned records during same-home bootstrap.
- Add shared path-containment, symlink, byte, and record-integrity checks, plus behavioral coverage and lifecycle documentation for automatic and exempt backends.

## Risk Assessment

✅ Low: The changes consistently enforce the stated dispatch, completion, recovery, containment, and tooling invariants without a substantiated remaining defect.

## Testing

Exercised real spawn, teardown, bootstrap recovery, restricted-PATH cleanup, backlog/record atomicity, containment, eligibility refusal, exemptions, close replay, and remote-secondmate publication; all targeted behavioral checks passed and the worktree remained clean.

<details>
<summary>Evidence: Backlog atomicity end-to-end transcript</summary>

Source: [Backlog atomicity end-to-end transcript](https://github.com/kunchenguid/firstmate/blob/d8b513999b4046839a2083ea19aa8af313bc1ff6/.no-mistakes/evidence/fm/fm-secondmate-record-atomic-transitions-r3/fm-backlog-atomicity.txt)

```text
ok - dispatch publishes the record and moves the backlog item In flight in one run
ok - dispatch refuses to supersede a pending authoritative close
ok - dispatch refuses held rows before creating resources
ok - dispatch refuses dependency-blocked rows before creating resources
ok - dispatch refuses held In-flight rows before relaunch
ok - dispatch reads backlog rows from the backlog addressing root
ok - recovery uses the parent of a trailing-slash data record
ok - completion targets nested relative data from the caller directory
ok - an immediate-child absolute data path keeps one paired backlog
ok - bare relative data addresses one backlog through dispatch and completion
ok - dispatch refuses symlinked backlogs without crossing homes
ok - automatic homes refuse lifecycle mutation without compatible tasks-axi
ok - dispatch refuses an unresolvable backlog data directory
ok - completion refuses before mutation when backlog data is unresolvable
ok - dispatch refuses, before creating anything, when the home has no item for the id
ok - dispatch distinguishes backlog read failures from missing items
ok - dispatch refuses a closed item instead of silently reopening it
ok - dispatch cannot commit without a verified task-record publication
ok - a failed backlog transition fails the dispatch loudly and leaves no record
ok - dispatch reports when failed-transition rollback cannot remove its record
ok - dispatch verifies both task and busy records during rollback
ok - dispatch commits neither record nor backlog state before launch delivery succeeds
ok - dispatch retries interrupted transitions before honoring termination
ok - Kimi readiness interruptions fail before backlog commit
ok - dispatch does not resurrect a row closed after preflight
ok - dispatch fails when its backlog row vanishes after preflight
ok - completion closes a local-only ship, with its landing note, before reporting success
ok - completion closes a scout item against its report
ok - completion leaves legacy records open when no incarnation can be recorded
ok - completion refuses ambiguous task incarnations
ok - completion records relocated scout reports relative to the backlog root
ok - space-containing scout report paths round-trip through recovery
ok - control-byte data paths fail closed before paired transitions
ok - unreplayable data paths are refused before destructive cleanup
ok - completion preserves recovery state when task-record removal fails
ok - completion refuses to report success while its item is still open, and records what it owes
ok - restart recovers closes recorded before destructive cleanup
ok - completion refuses directory-symlink close targets
ok - completion reports failure until its durable close marker is removed
ok - session start retries a close whose marker could not be removed
ok - session start reports owned backlog rows it cannot read
ok - Orca cleanup recovery is excluded from backlog lifecycle transitions
ok - session start marks an item In flight when this home already owns a worker for it
ok - session start rejects internal worker-record symlinks
ok - session start rejects symlinked worker records
ok - session start finishes a close an interrupted cleanup recorded but never landed
ok - recovery backfills recorded links onto already Done items
ok - session start preserves a pending close across a transient backlog read failure
ok - recovery preserves incomplete-cleanup evidence across a failed replay
ok - session start finishes a close for the matching meta incarnation
ok - recovery preserves closes for ambiguous task incarnations
ok - recovery preserves both records when meta removal fails
ok - recovery preserves closes beside symlinked metadata
ok - recovery binds close-marker identity to its locked filename
ok - recovery rejects close markers targeting another home's data
ok - recovery validates an unterminated final marker field
ok - recovery rejects lexical traversal before resolving marker data
ok - recovery rejects marker control bytes before parsing
ok - recovery rejects malformed PR URL values
ok - a retained pending close is never started by reconciliation
ok - recovery rejects close-marker arguments outside its protocol
ok - recovery reports and rejects dangling symlink close markers
ok - session start drops a close recorded for an older meta incarnation
ok - session start rejects an unversioned close marker
ok - bootstrap rechecks worker-record containment after locking
ok - lifecycle files reject ancestor symlinks outside home roots
ok - same-home state overrides remain supported
ok - bootstrap refuses symlinked state before reconciliation
ok - bootstrap stops when backlog data disappears before reconciliation
ok - bootstrap preserves secondmate, manual, and absent-backlog exemptions
ok - session start leaves a captain-held item where the captain put it
ok - no-backlog teardown refuses symlinked records before resource actions
ok - teardown rechecks record parents after locking
ok - teardown refuses symlinked state before resource actions
ok - a home with no backlog remains exempt from lifecycle transitions
ok - a manual-backlog home dispatches and completes without a hard failure
ok - a secondmate home keeps its own books paired through dispatch and completion
ok - dispatching a persistent secondmate needs no backlog item
```
</details>
<details>
<summary>Evidence: Remote secondmate publication-boundary transcript</summary>

Source: [Remote secondmate publication-boundary transcript](https://github.com/kunchenguid/firstmate/blob/d8b513999b4046839a2083ea19aa8af313bc1ff6/.no-mistakes/evidence/fm/fm-secondmate-record-atomic-transitions-r3/fm-remote-secondmate-parent-binding.txt)

```text
ok - remote provisioning publishes durable parent state before its completion marker
ok - a remote secondmate's finished worker cleans up when the remote code root's own .env looked relay-active
ok - a remote secondmate's finished worker cleans up when only an ambient exported token looked relay-active
ok - a remote secondmate's finished worker cleans up with no relay signal anywhere
ok - a remote secondmate's own committed relay token still refuses cleanup
ok - remote secondmate publication refuses targets outside its home
ALL TESTS PASSED
```
</details>
<details>
<summary>Evidence: Teardown lifecycle and restricted-PATH transcript</summary>

Source: [Teardown lifecycle and restricted-PATH transcript](https://github.com/kunchenguid/firstmate/blob/d8b513999b4046839a2083ea19aa8af313bc1ff6/.no-mistakes/evidence/fm/fm-secondmate-record-atomic-transitions-r3/fm-teardown.txt)

```text
ok - local-only worktree with HEAD on a fork remote is torn down and the home summary is refreshed
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 1s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ~/.no-mistakes/worktrees/52b07e9083e7/01M191W7FFBJTVZTD7S34VPWWN/.pi/extensions/fm-primary-turnend-guard.ts -e ~/.no-mistakes/worktrees/52b07e9083e7/01M191W7FFBJTVZTD7S34VPWWN/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - teardown closes its own backlog item before reporting success
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 0s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ~/.no-mistakes/worktrees/52b07e9083e7/01M191W7FFBJTVZTD7S34VPWWN/.pi/extensions/fm-primary-turnend-guard.ts -e ~/.no-mistakes/worktrees/52b07e9083e7/01M191W7FFBJTVZTD7S34VPWWN/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - teardown honors config/backlog-backend=manual and still finishes cleanly
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly
ok - herdr flat teardown never erases records when pane presence is unparseable
ok - herdr flat teardown preflight refuses before every destructive change
ok - forced secondmate teardown preflights every Herdr child before cleanup mutation
ok - forced secondmate teardown holds every descendant lifecycle and metadata lock
ok - forced secondmate teardown retains Herdr child identity until exact pane disappearance
ok - forced teardown retains a nested secondmate home and its grandchild's Herdr identity when the grandchild close is unconfirmed
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown retains every record when post-close presence is unknown
ok - herdr projection teardown surfaces failed focus restoration without turning confirmed cleanup into a hard failure
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 0s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ~/.no-mistakes/worktrees/52b07e9083e7/01M191W7FFBJTVZTD7S34VPWWN/.pi/extensions/fm-primary-turnend-guard.ts -e ~/.no-mistakes/worktrees/52b07e9083e7/01M191W7FFBJTVZTD7S34VPWWN/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
WARNING: watcher still down (same stale episode; last beat: 1s ago, grace 300s) - full banner already printed this episode.
ok - fm-pr-check does not refresh PR head after HEAD moves
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 0s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ~/.no-mistakes/worktrees/52b07e9083e7/01M191W7FFBJTVZTD7S34VPWWN/.pi/extensions/fm-primary-turnend-guard.ts -e ~/.no-mistakes/worktrees/52b07e9083e7/01M191W7FFBJTVZTD7S34VPWWN/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
ok - a task's own parked no-mistakes run is aborted, not orphaned, before the worker is removed
ok - teardown refuses before reap or removal when a task-owned run remains parked
ok - a different run cannot confirm the targeted abort
ok - empty post-abort status is not accepted as confirmation
ok - the CLI's exact run-not-found signal confirms completion
ok - a parked run on another branch is never aborted by this task's teardown (ownership is precise)
ok - a task-owned autonomous running step is left alone rather than aborted
ok - a leaked descendant process rooted under the task's worktree is reaped by teardown, not left surviving
ok - a leaked descendant process rooted under the task's per-task tasktmp is reaped by teardown too
ok - missing lsof falls back to reaping the tmux pane process group
ok - an erroring lsof scan refuses teardown and preserves the task
ok - a reused pid with a different start time is never force-killed
ok - an exec change preserves birth identity and the process is reaped
ok - a process spawned during grace is reaped on a later pass
ok - persistent leaked processes refuse teardown after bounded retries
ok - a process exiting during identity lookup does not block teardown
ok - the run abort and the leaked-process reap both complete before the destructive worktree return
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2ac9e02399788ac31c6a9e72034d0c8255c18c71","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-backlog-transition-lib.sh:225` - The required preflight must reject every known-ineligible row before creating resources, but the probe records only state and held status, omitting `blocked_by`, while `fm_backlog_row_dispatchable` accepts every `in_flight *` row. Thus a dependency-blocked queued item appears as `queued no` and launches before `tasks-axi start` can refuse, and a held in-flight item can relaunch successfully. Include blocker eligibility and require `held=no` at both preflight and commit. This contradicts accepted requirement 1, so the remedy requires user review.
- 🚨 `bin/fm-spawn.sh:673` - Remote secondmate metadata is published with a direct `mv` rather than the required shared lifecycle file-access boundary. If the state parent is replaced with a symlink during the preceding remote operations, publication can write into another home without the canonical containment or post-publication check used by local task records. Route this publication through `fm_backlog_atomic_transition publish`. This contradicts accepted requirement 6 that every worker-record access and post-lock recheck use the single shared boundary, so user review is required.

🔧 Fix: Enforce dispatch eligibility and atomic remote record publication
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-backlog-atomicity.test.sh`
- `bash tests/fm-remote-secondmate-parent-binding.test.sh`
- `bash tests/fm-teardown.test.sh`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
