### PR TITLE
feat(bin): cap active crew concurrency per home

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,10 @@ Each secondmate reconciles work already in its own home and then idles; recovery
 If away mode is present, load `/afk` and let its daemon own supervision rather than arming another cycle.
 Surface only captain-relevant decisions, review-ready PRs, failures, and credential needs; otherwise resume the emitted supervision protocol silently.
 A restart must be a non-event because durable state and live backend inventory, not conversation memory, are authoritative.
+Keep one coherent objective in the primary session.
+Before switching to unrelated work, invoke `/stow`, report that durable state is current, and recommend a fresh session rather than carrying the old objective's context forward.
+For a continuing objective whose visible context approaches 100,000 tokens, finish the current milestone, invoke `/stow`, and compact only after the durable handoff is current; never interrupt a critical reasoning or validation step merely to meet the threshold.
+When the captain steps away during live work, use `/afk` so its daemon owns no-change waits instead of extending the primary model session.
 
 ## 6. Project and knowledge management
 
@@ -295,8 +299,9 @@ On a `no-mistakes-prod-only` project, classify the task's surface: internal-only
 An unregistered project or absent registry resolves to `no-mistakes` with yolo off, and the registration gap goes to the captain.
 Record the resulting mode, `yolo` merge posture, and the one-line reason for any deviation in the backlog item note.
 
-Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, and dispatch isolated work immediately with no concurrency cap when each change can be independently implemented and validated and the selected delivery path can reconcile ordinary rebases or conflicts.
-Serialize only for a true semantic dependency, shared mutable external state, incompatible concurrent migration, or another concrete condition that makes independent progress or reconciliation unsafe; same-file editing alone is insufficient, and genuine blockers remain durable.
+Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, but keep at most two ship or scout tasks active in one home by default.
+Dispatch independent work until that capacity is full, then keep additional work queued without downgrading its model, effort, evidence, or delivery path; raise the one-shot limit only when the captain explicitly prioritizes wall-clock speed for independently implementable and validatable work.
+Serialize regardless of spare capacity for a true semantic dependency, shared mutable external state, incompatible concurrent migration, or another concrete condition that makes independent progress or reconciliation unsafe; same-file editing alone is insufficient, and genuine blockers remain durable.
 Write the task-specific brief under section 11 before spawning.
 
 ### Dispatch and supervision handoff

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 ## Features
 
 - **One liaison** - you talk only to the first mate; it dispatches, supervises, escalates only real decisions, and reports plain outcomes.
+- **Quality-preserving capacity** - each home runs at most two ship or scout tasks by default and keeps excess work queued; a captain-approved one-shot override can spend more concurrency without silently changing model, effort, evidence, or delivery rigor.
 - **A visible crew** - every crewmate works in its own tmux window, experimental herdr/zellij tab, cmux workspace, or Orca terminal you can watch or type into; the first mate reconciles.
 - **Disposable worktrees** - each task runs in a clean [treehouse](https://github.com/kunchenguid/treehouse) git worktree, or an Orca-managed worktree when `backend=orca`, so parallel work on one repo never collides.
 - **Two task shapes** - ship tasks deliver authorized changes; scout tasks leave standalone investigation reports when the intake contract warrants separate research.
@@ -177,6 +178,9 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, persist the open work records this session knows are unfiled or now wrong, curate tiered startup memory with decay and cold archival, enforce each home's budget or surface the required decision, cascade to registered second mates, and report what is safe to reset |
+
+For the best quality-to-cost tradeoff, keep one coherent objective in the primary session, use `/stow` before starting an unrelated objective, and then start a fresh session.
+For continuing work, compact after a major milestone once `/stow` has made the handoff durable, especially as visible context approaches 100,000 tokens; use `/afk` for unattended waits.
 
 Bearings invocation examples:
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 
 For the best quality-to-cost tradeoff, keep one coherent objective in the primary session, use `/stow` before starting an unrelated objective, and then start a fresh session.
 For continuing work, compact after a major milestone once `/stow` has made the handoff durable, especially as visible context approaches 100,000 tokens; use `/afk` for unattended waits.
+When the captain explicitly approves a temporary higher limit, scope it to the single spawn command, such as `FM_CREW_CONCURRENCY_LIMIT=3 bin/fm-spawn.sh ...`, rather than exporting it for later dispatches.
 Activation does not require restarting the Mac.
 After this change is merged and Firstmate is updated, invoke `/stow` and start a fresh primary agent session so it loads the new policy.
 Existing secondmates do not need to be killed, and new ship and scout dispatches use the enforced capacity automatically.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 
 For the best quality-to-cost tradeoff, keep one coherent objective in the primary session, use `/stow` before starting an unrelated objective, and then start a fresh session.
 For continuing work, compact after a major milestone once `/stow` has made the handoff durable, especially as visible context approaches 100,000 tokens; use `/afk` for unattended waits.
+Activation does not require restarting the Mac.
+After this change is merged and Firstmate is updated, invoke `/stow` and start a fresh primary agent session so it loads the new policy.
+Existing secondmates do not need to be killed, and new ship and scout dispatches use the enforced capacity automatically.
 
 Bearings invocation examples:
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -98,6 +98,10 @@
 #   even when they select different backends. A fresh spawn first takes the
 #   per-home task-set lock and refuses rather than waits when forced teardown owns
 #   it; relaunch is exempt because the existing task's control lock covers it.
+#   Fresh crewmate and scout spawns also share a per-home admission limit under
+#   that task-set lock. FM_CREW_CONCURRENCY_LIMIT is a positive one-shot override;
+#   its default is 2. A full home refuses before endpoint or worktree creation so
+#   the caller can leave the task queued until teardown frees capacity.
 #   With no harness arg, a crewmate/scout spawn resolves the CREW harness only when
 #   config/crew-dispatch.json is absent. When that file exists, crewmate/scout
 #   spawns require an explicit harness so firstmate cannot silently skip dispatch
@@ -953,6 +957,28 @@ if [ "$RELAUNCH" -eq 0 ]; then
     exit 1
   fi
   SPAWN_TASK_SET_LOCK_HELD=1
+fi
+if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
+  CREW_CONCURRENCY_LIMIT=${FM_CREW_CONCURRENCY_LIMIT:-2}
+  case "$CREW_CONCURRENCY_LIMIT" in
+    ''|*[!0-9]*|0)
+      echo "error: FM_CREW_CONCURRENCY_LIMIT must be a positive integer" >&2
+      exit 2
+      ;;
+  esac
+  ACTIVE_CREW=0
+  for ACTIVE_META in "$STATE"/*.meta; do
+    [ -e "$ACTIVE_META" ] || continue
+    ACTIVE_KIND=$(sed -n 's/^kind=//p' "$ACTIVE_META" 2>/dev/null | head -n 1 || true)
+    case "$ACTIVE_KIND" in
+      secondmate) ;;
+      *) ACTIVE_CREW=$((ACTIVE_CREW + 1)) ;;
+    esac
+  done
+  if [ "$ACTIVE_CREW" -ge "$CREW_CONCURRENCY_LIMIT" ]; then
+    echo "error: crew capacity is full ($ACTIVE_CREW/$CREW_CONCURRENCY_LIMIT active ship/scout tasks); leave task $ID queued and retry after teardown, or use a captain-approved one-shot FM_CREW_CONCURRENCY_LIMIT override" >&2
+    exit 1
+  fi
 fi
 if [ "$KIND" = secondmate ]; then
   if spawn_remote_secondmate "$ID"; then

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -782,14 +782,55 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
   enable_dispatch_profile "$HOME_DIR"
   sm="$CASE_DIR/secondmate-home"
   make_seeded_secondmate_home "$sm" "$id"
+  printf '%s\n' 'kind=ship' > "$HOME_DIR/state/active-ship.meta"
+  printf '%s\n' 'kind=scout' > "$HOME_DIR/state/active-scout.meta"
 
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$sm" --secondmate)
   status=$?
-  expect_code 0 "$status" "secondmate spawn should be exempt from the dispatch-profile explicit harness requirement"
+  expect_code 0 "$status" "secondmate spawn should be exempt from crew dispatch profile and capacity requirements"
   assert_contains "$out" "spawned $id harness=codex kind=secondmate" "secondmate launch did not use secondmate harness resolution"
   assert_grep "kind=secondmate" "$HOME_DIR/state/$id.meta" "secondmate meta missing kind=secondmate"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex default default
-  pass "active crew-dispatch profile does not block secondmate launches"
+  pass "active crew-dispatch profile and full crew capacity do not block secondmate launches"
+}
+
+test_default_crew_capacity_refuses_third_task_before_launch() {
+  local rec id out status
+  id=profile-capacity-default-z20
+  rec=$(make_spawn_case profile-capacity-default codex "$id")
+  read_case_record "$rec"
+  printf '%s\n' 'kind=ship' > "$HOME_DIR/state/active-ship.meta"
+  printf '%s\n' 'kind=scout' > "$HOME_DIR/state/active-scout.meta"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" 2>&1)
+  status=$?
+  expect_code 1 "$status" "a third active crew task should stay queued by default"
+  assert_contains "$out" "crew capacity is full (2/2 active ship/scout tasks)" \
+    "default capacity refusal did not report the measured occupancy"
+  assert_contains "$out" "leave task $id queued" \
+    "default capacity refusal did not preserve the queued-work next action"
+  assert_absent "$HOME_DIR/state/$id.meta" "capacity refusal published task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "capacity refusal launched a harness"
+  pass "default crew capacity keeps a third task queued before launch"
+}
+
+test_captain_approved_crew_capacity_override_allows_third_task() {
+  local rec id out status
+  id=profile-capacity-override-z21
+  rec=$(make_spawn_case profile-capacity-override codex "$id")
+  read_case_record "$rec"
+  printf '%s\n' 'kind=ship' > "$HOME_DIR/state/active-ship.meta"
+  printf '%s\n' 'kind=scout' > "$HOME_DIR/state/active-scout.meta"
+
+  out=$(FM_CREW_CONCURRENCY_LIMIT=3 \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "an explicit capacity of three should admit the third task"
+  assert_contains "$out" "spawned $id harness=codex" \
+    "capacity override did not reach the ordinary spawn path"
+  assert_grep 'kind=ship' "$HOME_DIR/state/$id.meta" \
+    "capacity override did not publish ordinary ship metadata"
+  pass "one-shot crew capacity override admits explicitly authorized parallel work"
 }
 
 test_no_profile_keeps_claude_profile_defaults
@@ -823,5 +864,7 @@ test_claude_forwards_firstmate_config_dir_when_set
 test_claude_omits_config_dir_prefix_when_unset
 test_non_claude_harness_ignores_config_dir
 test_active_dispatch_profile_does_not_block_secondmate_launch
+test_default_crew_capacity_refuses_third_task_before_launch
+test_captain_approved_crew_capacity_override_allows_third_task
 
 echo "# all fm-spawn-dispatch-profile tests passed"


### PR DESCRIPTION
## Intent

Implement Firstmate controls that reduce expensive long-context, high-concurrency, and long-running agent usage without reducing output quality. The priority is a Pareto-efficient solution: keep one coherent objective per primary session; persist durable state before a fresh session or milestone compaction; use event-driven away-mode for unattended waits; cap each Firstmate home at two active ship/scout tasks by default; queue excess work rather than downgrading models, effort, evidence, validation, or delivery rigor; exempt persistent secondmates; and allow a higher one-shot concurrency limit only with explicit captain approval. Tell the captain how to help enforce the controls and whether the Mac or agent must be restarted, and include that activation and restart guidance in the README. Keep the implementation small by extending Firstmate's existing spawn lock, /stow, and /afk paths rather than adding a scheduler, token estimator, dashboard, or background loop. The identical Git tree already passed targeted tests, documentation validation, and canonical lint in no-mistakes run 01M18MH4ES19N3RE5DKQV2AK2K; this run records the required same-run review approval and publishes through the newly configured fork.

## What Changed

- Enforce a default two-task admission limit for fresh ship/scout spawns, refusing excess work before endpoint or worktree creation while exempting persistent secondmates.
- Support a captain-approved one-shot `FM_CREW_CONCURRENCY_LIMIT` override, with coverage for default refusal, override admission, and secondmate exemption.
- Document `/stow`, fresh-session, milestone compaction, and `/afk` guidance, including that activation requires a fresh agent session after updating Firstmate but no Mac restart.

## Risk Assessment

✅ Low: The change is narrowly scoped and the existing per-home task-set lock serializes capacity checks and metadata publication, preserving the two-task limit while exempting secondmates and satisfying the documented session-management intent.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3bb82a716d4884beee40bedf5c24dbb23d006c4b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"skipped"},{"step":"document","status":"skipped"},{"step":"lint","status":"skipped"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.
</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.
</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
