### PR TITLE
feat(bin): accept cloud kicks without waiting for captain chat

### DIFF
--- a/bin/fm-cloud-annahme.sh
+++ b/bin/fm-cloud-annahme.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Accept a new cloud kick: compare state/cloud-kick.md to state/cloud-kick.done and
+# queue one check wake when the kick changed.
+#
+# Usage:
+#   fm-cloud-annahme.sh
+#
+# Silent success when the bridge is not configured or the kick is unchanged.
+# Supervisor checkpoints (empty wake queue, turn-end) call this directly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-cloud-lib.sh
+. "$SCRIPT_DIR/fm-cloud-lib.sh"
+
+fm_cloud_annahme_try

--- a/bin/fm-cloud-holen.sh
+++ b/bin/fm-cloud-holen.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Poll the ntfy kick topic and write the latest message to state/cloud-kick.md.
+#
+# Usage:
+#   fm-cloud-holen.sh once     one blocking poll; print kick ok when a message lands
+#   fm-cloud-holen.sh run      loop forever (default)
+#
+# Requires state/bruecke.env with BRUECKE_KICK. Announces a new kick through
+# bin/fm-cloud-annahme.sh so firstmate sees it without waiting for captain chat.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-cloud-lib.sh
+. "$SCRIPT_DIR/fm-cloud-lib.sh"
+
+die() { printf 'fm-cloud-holen: %s\n' "$*" >&2; exit 1; }
+
+poll_once() {
+  local dest="$CLOUD_KICK_FILE" wrote=0
+  fm_cloud_bruecke_configured || die "missing $CLOUD_BRUECKE_ENV"
+  fm_cloud_load_bruecke
+  [ -n "${BRUECKE_KICK:-}" ] || die 'BRUECKE_KICK is unset'
+  export DEST="$dest"
+  if curl -sS "https://ntfy.sh/${BRUECKE_KICK}/json?poll=1&since=all" | python3 -c 'import json,os,sys,tempfile
+dest=os.environ["DEST"]
+body=None
+for line in sys.stdin:
+    line=line.strip()
+    if not line:
+        continue
+    try:
+        o=json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if o.get("event")=="message" and o.get("message"):
+        body=o["message"]
+if not body:
+    sys.exit(1)
+text=body if body.endswith("\n") else body+"\n"
+fd,tmp=tempfile.mkstemp(dir=os.path.dirname(dest) or ".", prefix=".cloud-kick.", suffix=".tmp")
+os.close(fd)
+with open(tmp,"w",encoding="utf-8") as f:
+    f.write(text)
+os.replace(tmp, dest)
+print("kick ok")'; then
+    wrote=1
+    FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_ROOT_OVERRIDE="$FM_ROOT" \
+      "$SCRIPT_DIR/fm-cloud-annahme.sh" >/dev/null || true
+  fi
+  return $((1 - wrote))
+}
+
+cmd=${1:-run}
+case "$cmd" in
+  once)
+    poll_once
+    ;;
+  run)
+    while true; do
+      poll_once || true
+      sleep 5
+    done
+    ;;
+  --help|-h)
+    sed -n '2,10p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    ;;
+  *)
+    die "usage: $(basename "$0") [once|run]"
+    ;;
+esac

--- a/bin/fm-cloud-lib.sh
+++ b/bin/fm-cloud-lib.sh
@@ -11,6 +11,7 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 CLOUD_KICK_FILE="$STATE/cloud-kick.md"
 CLOUD_DONE_FILE="$STATE/cloud-kick.done"
+# shellcheck disable=SC2034 # Consumed by fm-cloud-senden.sh after sourcing this library.
 CLOUD_BERICHT_FILE="$STATE/cloud-bericht.md"
 CLOUD_BRUECKE_ENV="$STATE/bruecke.env"
 
@@ -51,10 +52,10 @@ fm_cloud_done_hash() {
 }
 
 fm_cloud_kick_is_new() {
-  local kick done
+  local kick prev_hash
   kick=$(fm_cloud_kick_hash) || return 1
-  done=$(fm_cloud_done_hash) || return 0
-  [ "$kick" != "$done" ]
+  prev_hash=$(fm_cloud_done_hash) || return 0
+  [ "$kick" != "$prev_hash" ]
 }
 
 fm_cloud_mark_done() {

--- a/bin/fm-cloud-lib.sh
+++ b/bin/fm-cloud-lib.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# fm-cloud-lib.sh - shared cloud-kick bridge paths, hashing, and acceptance.
+#
+# Source this library; it is not a CLI entrypoint.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+CLOUD_KICK_FILE="$STATE/cloud-kick.md"
+CLOUD_DONE_FILE="$STATE/cloud-kick.done"
+CLOUD_BERICHT_FILE="$STATE/cloud-bericht.md"
+CLOUD_BRUECKE_ENV="$STATE/bruecke.env"
+
+fm_cloud_sha256() {
+  local file=$1
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" 2>/dev/null | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" 2>/dev/null | awk '{print $1}'
+  else
+    return 1
+  fi
+}
+
+fm_cloud_bruecke_configured() {
+  [ -r "$CLOUD_BRUECKE_ENV" ]
+}
+
+fm_cloud_load_bruecke() {
+  # shellcheck disable=SC1090
+  . "$CLOUD_BRUECKE_ENV"
+}
+
+fm_cloud_kick_hash() {
+  local hash
+  [ -s "$CLOUD_KICK_FILE" ] || return 1
+  hash=$(fm_cloud_sha256 "$CLOUD_KICK_FILE") || return 1
+  [[ "$hash" =~ ^[0-9a-f]{64}$ ]] || return 1
+  printf '%s\n' "$hash"
+}
+
+fm_cloud_done_hash() {
+  local hash
+  [ -r "$CLOUD_DONE_FILE" ] || return 1
+  hash=$(tr -d '[:space:]' < "$CLOUD_DONE_FILE")
+  [[ "$hash" =~ ^[0-9a-f]{64}$ ]] || return 1
+  printf '%s\n' "$hash"
+}
+
+fm_cloud_kick_is_new() {
+  local kick done
+  kick=$(fm_cloud_kick_hash) || return 1
+  done=$(fm_cloud_done_hash) || return 0
+  [ "$kick" != "$done" ]
+}
+
+fm_cloud_mark_done() {
+  local hash
+  hash=$(fm_cloud_kick_hash) || return 1
+  printf '%s\n' "$hash" > "$CLOUD_DONE_FILE"
+}
+
+fm_cloud_annahme_try() {
+  local hash summary lib="$FM_ROOT/bin/fm-wake-lib.sh"
+  fm_cloud_bruecke_configured || return 0
+  fm_cloud_kick_is_new || return 0
+  hash=$(fm_cloud_kick_hash) || return 1
+  summary=$(head -n 1 "$CLOUD_KICK_FILE" | tr '\n\t' '  ' | cut -c1-80)
+  [ -n "${summary//[[:space:]]/}" ] || summary='neuer Cloud-Kick'
+  [ -r "$lib" ] || {
+    printf 'fm-cloud: kick gespeichert aber Wake fehlgeschlagen (fehlendes %s)\n' "$lib" >&2
+    return 1
+  }
+  # shellcheck source=/dev/null
+  FM_ROOT_OVERRIDE="$FM_ROOT" FM_HOME="$FM_HOME" STATE="$STATE" . "$lib"
+  fm_wake_append check cloud-kick "check: cloud-kick neu - $summary" || return 1
+  fm_cloud_mark_done || return 1
+  printf 'cloud-kick angenommen\n'
+}

--- a/bin/fm-cloud-senden.sh
+++ b/bin/fm-cloud-senden.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Send state/cloud-bericht.md (or a given file) to the ntfy report topic.
+#
+# Usage:
+#   fm-cloud-senden.sh [path-to-body]
+#
+# Requires state/bruecke.env with BRUECKE_BERICHT. Normalizes the on-disk bericht
+# file to end with a single newline before posting.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-cloud-lib.sh
+. "$SCRIPT_DIR/fm-cloud-lib.sh"
+
+die() { printf 'fm-cloud-senden: %s\n' "$*" >&2; exit 1; }
+
+fm_cloud_bruecke_configured || die "missing $CLOUD_BRUECKE_ENV"
+fm_cloud_load_bruecke
+[ -n "${BRUECKE_BERICHT:-}" ] || die 'BRUECKE_BERICHT is unset'
+
+src=${1:-$CLOUD_BERICHT_FILE}
+[ -r "$src" ] || die "cannot read report body: $src"
+BODY=$(cat "$src")
+[ -n "${BODY//[[:space:]]/}" ] || die 'refusing to send an empty report'
+
+printf '%s\n' "$BODY" > "$CLOUD_BERICHT_FILE"
+curl -fsS -H "Title: bericht" -d "$BODY" "https://ntfy.sh/${BRUECKE_BERICHT}"
+printf '\nbericht gesendet\n'

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -219,7 +219,7 @@ family_for_basename() {
     fm-session-lock-ancestry.test.sh|fm-cursor-primary.test.sh|\
     fm-supervision-events.test.sh|fm-turnend-guard.test.sh|fm-wake-daemon-lifecycle-e2e.test.sh|\
     fm-wake-drain-unread-status.test.sh|\
-    fm-tool-update-check.test.sh|\
+    fm-tool-update-check.test.sh|fm-cloud.test.sh|\
     fm-wake-queue.test.sh|fm-watch-arm.test.sh|fm-watch-checkpoint.test.sh|fm-watch-recovery-loop.test.sh|\
     fm-watch-triage.test.sh|fm-task-inbox.test.sh|\
     fm-watcher-lock.test.sh|fm-inactive-reconcile.test.sh)
@@ -603,6 +603,7 @@ tests/fm-test-fixtures.test.sh 1045
 tests/fm-test-isolation-proof.test.sh 451
 tests/fm-tmux-agent-liveness.test.sh 4065
 tests/fm-tool-update-check.test.sh 12846
+tests/fm-cloud.test.sh 2500
 tests/fm-trace-context-lib.test.sh 194
 tests/fm-trace-context-spawn.test.sh 35325
 tests/fm-turnend-guard.test.sh 34915

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -163,9 +163,11 @@ budget_reset() {
 fm_supervision_status "$STATE" "$GRACE"
 if [ "$FM_SUP_NEEDED" = false ]; then
   [ -e "$FAILURE_NOTICE" ] || budget_reset
+  "$SCRIPT_DIR/fm-cloud-annahme.sh" >/dev/null 2>&1 || true
   exit 0
 fi
 if fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME"; then
+  "$SCRIPT_DIR/fm-cloud-annahme.sh" >/dev/null 2>&1 || true
   [ "$CLAUDE_MODE" -eq 1 ] || exit 0
   fm_failure_episode_reset "$STATE" && exit 0
   exit 2

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -513,6 +513,7 @@ if [ ! -s "$FM_WAKE_QUEUE" ]; then
   if [ "$RECOVERY_ACK_REQUIRED" = true ]; then
     printf 'WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 0 --recovery-generation %s\n' "${RECOVERY_MARKER_TOKEN##*:}" >&2
   fi
+  "$SCRIPT_DIR/fm-cloud-annahme.sh" >/dev/null 2>&1 || true
   assert_watcher_liveness
   exit 0
 fi
@@ -526,6 +527,7 @@ if [ "$ACTOR" = main ]; then
     fm_lock_release "$FM_WAKE_QUEUE_LOCK"
     DRAIN_LOCK_HELD=false
     (print_status_presentation) || true
+    "$SCRIPT_DIR/fm-cloud-annahme.sh" >/dev/null 2>&1 || true
     assert_watcher_liveness
     exit 0
   fi

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -116,6 +116,10 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-peek.sh`             | Print a bounded tail of a crewmate endpoint                                          |
 | `fm-check-register.sh`   | Bind an intentional custom watcher check to its current bytes                       |
 | `fm-check-lib.sh`        | Validate custom-check registrations and prepare private execution snapshots          |
+| `fm-cloud-annahme.sh`    | Accept a new cloud kick by comparing state/cloud-kick.md to cloud-kick.done and queue one check wake |
+| `fm-cloud-holen.sh`      | Poll the ntfy kick topic into state/cloud-kick.md and announce through annahme       |
+| `fm-cloud-lib.sh`        | Shared cloud-kick paths, hashing, and acceptance helpers                             |
+| `fm-cloud-senden.sh`     | Post state/cloud-bericht.md to the ntfy report topic                               |
 | `fm-tool-update-check.sh` | Report watched tooling with an update available, and updates installed but left inert by PATH order |
 | `fm-pr-lib.sh`           | Own canonical task and PR validation plus private atomic PR-poll publication, merge-notification identity, and retirement |
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |

--- a/tests/fm-cloud.test.sh
+++ b/tests/fm-cloud.test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Behavior tests for the cloud-kick bridge (holen, annahme, senden).
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ANNAHME="$ROOT/bin/fm-cloud-annahme.sh"
+HOLEN="$ROOT/bin/fm-cloud-holen.sh"
+SENDEN="$ROOT/bin/fm-cloud-senden.sh"
+TMP_ROOT=$(fm_test_tmproot fm-cloud)
+
+make_home() {
+  local name=$1 home
+  home="$TMP_ROOT/$name"
+  mkdir -p "$home/state"
+  printf '%s\n' "$home"
+}
+
+write_bruecke() {
+  local home=$1
+  cat > "$home/state/bruecke.env" <<'ENV'
+BRUECKE_KICK=test-kick-topic
+BRUECKE_BERICHT=test-bericht-topic
+ENV
+}
+
+write_kick() {
+  printf '%s\n' "$2" > "$1/state/cloud-kick.md"
+}
+
+kick_hash() {
+  FM_HOME="$1" FM_STATE_OVERRIDE="$1/state" "$ROOT/bin/fm-cloud-lib.sh" >/dev/null 2>&1 || true
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1/state/cloud-kick.md" | awk '{print $1}'
+  else
+    sha256sum "$1/state/cloud-kick.md" | awk '{print $1}'
+  fi
+}
+
+wake_payloads() {
+  awk -F '\t' '{print $5}' "$1/state/.wake-queue" 2>/dev/null
+}
+
+test_annahme_silent_without_bridge() {
+  local home
+  home=$(make_home no-bridge)
+  write_kick "$home" 'Neuer Auftrag'
+  FM_HOME="$home" "$ANNAHME" >/dev/null
+  [ ! -f "$home/state/.wake-queue" ] \
+    || fail 'annahme without bruecke.env must not enqueue a wake'
+  pass 'cloud: annahme stays silent when the bridge is not configured'
+}
+
+test_annahme_silent_when_kick_unchanged() {
+  local home hash
+  home=$(make_home unchanged)
+  write_bruecke "$home"
+  write_kick "$home" 'Gleicher Kick'
+  hash=$(kick_hash "$home")
+  printf '%s\n' "$hash" > "$home/state/cloud-kick.done"
+  FM_HOME="$home" "$ANNAHME" >/dev/null
+  [ ! -f "$home/state/.wake-queue" ] \
+    || fail 'unchanged kick must not enqueue a wake'
+  pass 'cloud: annahme ignores an already accepted kick'
+}
+
+test_annahme_queues_wake_for_new_kick() {
+  local home out hash
+  home=$(make_home fresh)
+  write_bruecke "$home"
+  write_kick "$home" 'Frischer Cloud-Kick'
+  out=$(FM_HOME="$home" "$ANNAHME")
+  assert_contains "$out" 'cloud-kick angenommen' 'annahme should confirm acceptance'
+  assert_present "$home/state/.wake-queue" 'new kick must enqueue a wake'
+  assert_contains "$(wake_payloads "$home")" 'check: cloud-kick neu' \
+    'wake payload must name the cloud kick'
+  hash=$(kick_hash "$home")
+  assert_grep "$hash" "$home/state/cloud-kick.done" \
+    'done marker must record the accepted hash'
+  pass 'cloud: annahme queues one check wake for a new kick'
+}
+
+test_annahme_idempotent_after_done() {
+  local home
+  home=$(make_home idempotent)
+  write_bruecke "$home"
+  write_kick "$home" 'Einmaliger Kick'
+  FM_HOME="$home" "$ANNAHME" >/dev/null
+  FM_HOME="$home" "$ANNAHME" >/dev/null
+  count=$(wc -l < "$home/state/.wake-queue" | tr -d ' ')
+  [ "$count" = 1 ] || fail "expected one wake row, got $count"
+  pass 'cloud: annahme does not re-announce an already accepted kick'
+}
+
+test_holen_writes_kick_and_announces() {
+  local home fakebin curl_log
+  home=$(make_home holen)
+  write_bruecke "$home"
+  fakebin="$TMP_ROOT/fakebin"
+  mkdir -p "$fakebin"
+  curl_log="$TMP_ROOT/holen-curl.log"
+  cat > "$fakebin/curl" <<SH
+#!/usr/bin/env bash
+printf '%s\n' '{"event":"message","message":"Kick aus der Wolke"}' | tee -a '$curl_log'
+exit 0
+SH
+  chmod +x "$fakebin/curl"
+  PATH="$fakebin:$PATH" FM_HOME="$home" "$HOLEN" once >/dev/null
+  assert_grep 'Kick aus der Wolke' "$home/state/cloud-kick.md" \
+    'holen must write the polled message'
+  assert_contains "$(wake_payloads "$home")" 'check: cloud-kick neu' \
+    'holen must announce through annahme'
+  pass 'cloud: holen writes a kick and accepts it immediately'
+}
+
+test_senden_posts_bericht() {
+  local home fakebin body_log
+  home=$(make_home senden)
+  write_bruecke "$home"
+  printf '%s\n' 'Erster Satz.' > "$home/state/cloud-bericht.md"
+  printf '%s\n' 'Zweiter Satz.' >> "$home/state/cloud-bericht.md"
+  fakebin="$TMP_ROOT/sendbin"
+  mkdir -p "$fakebin"
+  body_log="$TMP_ROOT/senden-body.log"
+  cat > "$fakebin/curl" <<SH
+#!/usr/bin/env bash
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    -d) printf '%s' "\$2" > '$body_log'; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf 'ok\n'
+exit 0
+SH
+  chmod +x "$fakebin/curl"
+  BODY_LOG="$body_log" PATH="$fakebin:$PATH" FM_HOME="$home" "$SENDEN" >/dev/null
+  assert_grep 'Erster Satz.' "$body_log" 'senden must post the bericht body'
+  assert_grep 'Zweiter Satz.' "$body_log" 'senden must post the full bericht'
+  pass 'cloud: senden posts cloud-bericht.md to ntfy'
+}
+
+test_senden_refuses_empty_body() {
+  local home status=0
+  home=$(make_home empty-send)
+  write_bruecke "$home"
+  : > "$home/state/cloud-bericht.md"
+  FM_HOME="$home" "$SENDEN" >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail 'empty bericht must be refused'
+  pass 'cloud: senden refuses an empty report'
+}
+
+test_annahme_silent_without_bridge
+test_annahme_silent_when_kick_unchanged
+test_annahme_queues_wake_for_new_kick
+test_annahme_idempotent_after_done
+test_holen_writes_kick_and_announces
+test_senden_posts_bericht
+test_senden_refuses_empty_body


### PR DESCRIPTION
## Summary
- Add `fm-cloud-annahme.sh` to detect new `state/cloud-kick.md` content (vs `cloud-kick.done`) and queue one `check: cloud-kick neu` wake.
- Harden `fm-cloud-holen.sh` / `fm-cloud-senden.sh` with `FM_HOME`, atomic kick writes, and immediate annahme after holen.
- Hook empty wake-queue drain and turn-end guard so kicks are accepted at queue-0 and turn-end without waiting for captain chat.

## Test plan
- [x] `./bin/fm-test-run.sh tests/fm-cloud.test.sh` (7 tests)