### PR TITLE
fix(bin): trust exact-branch active crew runs regardless of head

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -26,8 +26,11 @@
 #      to the routed status log; dead/missing report the remote verdict; an
 #      unreachable or unreadable remote reports unknown-remote, never a false
 #      gone/dead.
-#   2. Attribute an active or terminal no-mistakes run under the branch, head,
-#      pipeline-custody, and newest-first rules owned by bin/fm-nm-run-lib.sh.
+#   2. Attribute an active or terminal no-mistakes run under the branch, active-
+#      run precedence, head, and newest-first rules owned by
+#      bin/fm-nm-run-lib.sh. An exact-branch active run is current regardless of
+#      head match because pipeline fix commits advance in the gate clone, not
+#      this worktree. Terminal runs still require matching code identity.
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
@@ -372,10 +375,12 @@ nm_ci_checks_state() {
 # oriented text - no run id, no JSON/TOON, newest-first, columns
 # "<status> <branch> <short-sha> <date> [<pr-url>]" separated by runs of
 # spaces (verified: no quoting, so splitting on the first two whitespace runs
-# is exact) - but branch + coarse status is exactly what this predicate needs:
-# is a run for THIS branch active right now. Echoes the first (most recent)
-# matching row's status word (running/completed/cancelled/failed), or empty
-# when the branch has no run within FM_CREW_STATE_RUNS_LIMIT rows.
+# is exact) - but branch + coarse status is exactly what this predicate needs.
+# An active row for this branch wins regardless of head because its head may
+# exist only in the gate clone. A terminal row still requires matching code
+# identity. Echoes the first attributable matching row's status word
+# (running/completed/cancelled/failed), or empty when the branch has no run
+# within FM_CREW_STATE_RUNS_LIMIT rows.
 nm_runs_status_for_branch() {  # <branch>
   local branch=$1 out row st rest br sha
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
@@ -391,8 +396,13 @@ nm_runs_status_for_branch() {  # <branch>
     rest=$(trim "$rest")
     sha=${rest%% *}
     if [ "$br" = "$branch" ]; then
+      if [ "$st" = running ]; then
+        printf '%s' "$st"
+        return 0
+      fi
       # Same code-identity rule as axi status: skip a same-branch row whose
-      # short-sha does not match this worktree (rewritten or advanced tip).
+      # terminal short-sha does not match this worktree (rewritten or
+      # advanced tip).
       if ! nm_coarse_head_matches_worktree "$sha"; then
         # An UNRESOLVABLE head is unknown attribution, not a proven
         # mismatch. Stop instead of surfacing an older, superseded row;
@@ -440,12 +450,12 @@ if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/n
   RUN_OUT=$(nm_run axi status)
   if [ -n "$RUN_OUT" ]; then
     run_branch=$(strip_quotes "$(nm_field branch)")
-    # Head equality, or the pipeline-owned-active exemption: while the
-    # pipeline owns this branch, the daemon's own branch attribution is
-    # authoritative and the lane head need not be a git object here
-    # (fm_nm_run_is_pipeline_owned_active in bin/fm-nm-run-lib.sh).
+    # An exact-branch active run is authoritative regardless of head match:
+    # pipeline-owned fix commits advance in the gate clone and routinely do
+    # not exist in this worktree. Terminal runs retain strict head identity so
+    # a historical run on a reused branch cannot bind by name alone.
     if [ -n "$run_branch" ] && [ "$run_branch" = "$CREW_BRANCH" ] \
-      && { nm_run_head_matches_worktree || fm_nm_run_is_pipeline_owned_active "$RUN_OUT"; }; then
+      && { fm_nm_run_is_active "$RUN_OUT" || nm_run_head_matches_worktree; }; then
       HAVE_RUN=1
     else
       # The active-or-most-recent run is for another branch, or its same-branch

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -4,10 +4,11 @@
 # ONE owner for the no-mistakes run-attribution primitives used by
 # fm-crew-state.sh (read-only current-state reporting) and fm-teardown.sh
 # (pre-teardown run abort, see its "Fix 1" header comment). Teardown uses only
-# strict branch-and-head identity; crew-state additionally permits the active
-# pipeline-owned exemption defined below. Getting this wrong in either
-# direction is unsafe: a false negative hides a genuinely parked run, and a
-# false positive lets teardown act on a run it does not own.
+# strict branch-and-head identity; crew-state additionally gives an exact-
+# branch active run precedence over head identity because pipeline fix commits
+# advance in the gate clone. Getting this wrong in either direction is unsafe:
+# a false negative hides a genuinely active run, and a false positive lets
+# teardown act on a run it does not own.
 #
 # Bounded call to `no-mistakes "$@"` in dir $1, timeout $2 seconds. The bounded
 # form preserves stdout, stderr, and exit status; the checked form discards
@@ -64,8 +65,9 @@ fm_nm_field() {  # <toon-output> <key>
 #     the same history advanced the run tip past local HEAD)
 #   - run head is a strict ancestor of worktree HEAD, or diverged: no match
 #     (local work advanced outside the run, or the branch tip was rewritten)
-# fm_nm_run_is_pipeline_owned_active below carries the one exemption: a live
-# run whose pipeline currently owns the branch binds without head equality.
+# fm-crew-state carries the active exact-branch exemption at its attribution
+# decision point; this shared primitive remains the strict head check used by
+# teardown and terminal crew-state attribution.
 fm_nm_head_matches_worktree() {  # <worktree> <run_head>
   local wt=$1 run_head=$2 local_full run_full
   [ -n "$run_head" ] || return 1
@@ -86,19 +88,6 @@ fm_nm_head_resolvable() {  # <worktree> <head>
   git -C "$1" rev-parse --verify --quiet "$2^{commit}" >/dev/null 2>&1
 }
 
-# branch_sync.state from captured `axi status` TOON $1: the scalar directly
-# under the top-level `branch_sync:` block. The first `state:` inside the
-# block is the direct child (the nested local/pipeline/target/remote
-# sub-blocks carry no `state:` key). Empty when the block is absent: no run
-# on the current branch, another branch's run, or a CLI without branch sync.
-fm_nm_branch_sync_state() {  # <toon-output>
-  local s
-  s=$(printf '%s\n' "$1" \
-    | sed -n '/^[[:space:]]*branch_sync:[[:space:]]*$/,/^[^[:space:]][^:]*:/s/^[[:space:]]\{1,\}state:[[:space:]]*\(.*\)/\1/p' \
-    | head -1)
-  fm_nm_strip_quotes "$s"
-}
-
 # 0 if the run in captured `axi status` TOON $1 is still in flight: no
 # terminal outcome and no terminal status.
 fm_nm_run_is_active() {  # <toon-output>
@@ -107,18 +96,4 @@ fm_nm_run_is_active() {  # <toon-output>
   outcome=$(fm_nm_strip_quotes "$(fm_nm_field "$1" outcome)")
   [ -z "$outcome" ] || return 1
   case "$status" in completed|failed|cancelled) return 1 ;; esac
-}
-
-# The one exemption to the head rule above: while the pipeline OWNS the branch
-# (branch_sync.state=pipeline_owned), the daemon's own branch attribution IS
-# the attribution for an ACTIVE run, and
-# head equality must not be required - the pipeline's lane head is routinely
-# not a git object in the task worktree (rebase and fix commits that were
-# never pushed back), so the head rule rejects exactly the run that is most
-# current. The exemption never applies to a terminal run: a terminal run has
-# released the branch, and binding one by branch name alone is the historical
-# reused-branch misattribution the head rule exists to prevent.
-fm_nm_run_is_pipeline_owned_active() {  # <toon-output>
-  [ "$(fm_nm_branch_sync_state "$1")" = pipeline_owned ] || return 1
-  fm_nm_run_is_active "$1"
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,7 +57,7 @@ This home's answerer close, pending-reply escalation close, and captain-held tra
 A turn-ended-only queue row omits its historical status annotation when that status file exactly matches the same seen marker.
 Any direct or remaining historical annotation prints every status line unread at the presentation cursor instead of replaying only the latest line.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes an active or terminal no-mistakes run under the shared run-attribution contract, then keeps that run-step authoritative even if the pane has closed.
-[`bin/fm-nm-run-lib.sh`](../bin/fm-nm-run-lib.sh)'s header owns the exact branch, head, pipeline-custody, and newest-first attribution rules.
+[`bin/fm-nm-run-lib.sh`](../bin/fm-nm-run-lib.sh)'s header owns the exact branch, active-run precedence, head, and newest-first attribution rules: an exact-branch active run is current regardless of head because pipeline fix commits advance only in the gate clone, while terminal runs keep strict head identity.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
 Only when no matching run exists does it consult semantic busy state; exact busy reports working, exact idle permits fallback to a status-log event whose verb maps to a recognized run-state, and unknown or a dead pane stays unknown instead of trusting a stale log.

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1316,8 +1316,9 @@ test_usage_error() {
 }
 
 # Head-binding: same branch name with a rewritten/diverged worktree tip must not
-# attribute a historical no-mistakes run (multi-stage branch reuse incident).
-test_historical_same_branch_rewritten_head_not_current() {
+# attribute a historical TERMINAL no-mistakes run (multi-stage branch reuse
+# incident). Active exact-branch runs have stronger precedence below.
+test_historical_terminal_same_branch_rewritten_head_not_current() {
   reset_fakes
   local d old_head new_head out
   d=$(new_case rewritten-head)
@@ -1334,12 +1335,12 @@ test_historical_same_branch_rewritten_head_not_current() {
   printf 'working: stage 2 setup complete rebased onto merged #76\n' > "$d/state/wishlist.status"
   # Historical run still reports the pre-rewrite head on the reused branch.
   FM_FAKE_RUN_HEAD="$old_head"
-  FM_FAKE_AXI_STATUS="$(run_parked fm/todo-flag)"
+  FM_FAKE_AXI_STATUS="$(run_passed fm/todo-flag)"
   FM_FAKE_BUSY=0
   arm_idle_record "$d/state" wishlist
   out=$(run_crew_state "$d" wishlist)
   assert_not_contains "$out" "source: run-step" "historical rewritten head must not use run-step"
-  assert_not_contains "$out" "parked at" "historical parked run must not mask current state"
+  assert_not_contains "$out" "state: done" "historical passed run must not mask current state"
   assert_contains "$out" "source: status-log" "falls back to status-log after head mismatch"
   assert_contains "$out" "state: working" "status-log working: remains current"
   pass "historical same-branch rewritten head is not attributed as current"
@@ -1367,8 +1368,9 @@ test_active_run_descendant_fix_head_remains_current() {
   pass "active run with valid descendant fix head remains current"
 }
 
-# Head-binding: local work that advanced past the run head invalidates the run.
-test_local_advanced_past_run_head_invalidates() {
+# Head-binding: local work that advanced past a terminal run head invalidates
+# that historical run. Active exact-branch runs remain authoritative.
+test_local_advanced_past_terminal_run_head_invalidates() {
   reset_fakes
   local d run_head out
   d=$(new_case local-advanced)
@@ -1379,22 +1381,21 @@ test_local_advanced_past_run_head_invalidates() {
   fm_write_meta "$d/state/adv.meta" "window=fm:fm-adv" "worktree=$d/wt" "kind=ship" "harness=claude"
   printf 'working: stage 2 implementation in progress\n' > "$d/state/adv.status"
   FM_FAKE_RUN_HEAD="$run_head"
-  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-adv)"
+  FM_FAKE_AXI_STATUS="$(run_failed fm/feat-adv)"
   FM_FAKE_BUSY=0
   arm_idle_record "$d/state" adv
   out=$(run_crew_state "$d" adv)
-  assert_not_contains "$out" "source: run-step" "local-advanced tip must not use historical run"
+  assert_not_contains "$out" "source: run-step" "local-advanced tip must not use historical terminal run"
   assert_contains "$out" "source: status-log" "falls back after local advanced past run"
   assert_contains "$out" "state: working" "status-log working: is current"
   pass "local work advanced past run head invalidates attribution"
 }
 
-# --- Run-attribution precedence for pipeline-owned lane heads ----------------
-# A live run whose pipeline OWNS the branch (branch_sync.state=pipeline_owned)
-# can report a lane head that is not a git object in the task worktree.
-# Every fixture head is deliberately unresolvable so only the top-level
-# branch_sync exemption - never an accidental nested-field match - attributes
-# the run.
+# --- Exact-branch active run precedence --------------------------------------
+# A live run can report a lane head that is not a git object in the task
+# worktree because pipeline fixes commit in the gate clone. Every fixture head
+# here is deliberately unresolvable so only active exact-branch precedence,
+# never an accidental head match, attributes the run.
 run_running_pipeline_owned() {  # <branch> <head> [<sync-state>]
   cat <<EOF
 run:
@@ -1442,6 +1443,41 @@ EOF
   pass "pipeline-owned active run binds without head equality and beats the failed row"
 }
 
+# A pipeline fix commit lives only in the gate clone, so its head is genuinely
+# ahead of the crew worktree but not resolvable from that worktree. The exact-
+# branch active run is still current and must outrank both the older failed run
+# row and the stale failed status event.
+test_active_fix_run_with_gate_clone_head_beats_older_failure() {
+  reset_fakes
+  local d worktree_short fix_head out
+  d=$(new_case active-gate-clone-head)
+  make_repo_on_branch "$d/wt" fm/feat-gate-fix
+  worktree_short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  git clone -q "$d/wt" "$d/gate-clone"
+  git -C "$d/gate-clone" commit -q --allow-empty -m 'pipeline fix commit'
+  fix_head=$(git -C "$d/gate-clone" rev-parse HEAD)
+  if git -C "$d/wt" rev-parse --verify --quiet "${fix_head}^{commit}" >/dev/null; then
+    fail "gate-clone fix head unexpectedly resolves in the crew worktree"
+  fi
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/gate-fix.meta" "window=fm:fm-gate-fix" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'failed: previous validation run failed\n' > "$d/state/gate-fix.status"
+  FM_FAKE_RUN_HEAD="$fix_head"
+  FM_FAKE_AXI_STATUS="$(run_fixing fm/feat-gate-fix)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/feat-gate-fix ${fix_head:0:8}  2026-08-27 13:53
+  failed     fm/feat-gate-fix ${worktree_short}  2026-08-27 12:09
+EOF
+)"
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" gate-fix
+  out=$(run_crew_state "$d" gate-fix)
+  assert_contains "$out" "state: working" "exact-branch active fix run -> working"
+  assert_contains "$out" "source: run-step" "exact-branch active fix run -> run-step source"
+  assert_not_contains "$out" "state: failed" "older failure must not surface over the active fix run"
+  pass "exact-branch active fix run outranks an older failure despite its gate-clone-only head"
+}
+
 # T1 direction 2: a genuinely-failed run with NO later run on the branch still
 # surfaces as failed - hiding real failures is equally wrong.
 test_failed_run_with_no_later_run_still_surfaces() {
@@ -1459,11 +1495,10 @@ test_failed_run_with_no_later_run_still_surfaces() {
   pass "a genuinely failed run with no later run is not hidden"
 }
 
-# The coarse runs-list scan: an ACTIVE row for this branch at an unresolvable
-# head is unknown attribution and must STOP the scan, never fall through onto
-# the older failed row (axi status answers another branch here, so attribution
-# can only go through the coarse list).
-test_coarse_unresolvable_active_row_never_falls_to_older_row() {
+# The coarse runs-list scan must attribute an ACTIVE exact-branch row regardless
+# of its head, never fall through onto the older failed row. `axi status`
+# answers another branch here, so attribution can only use the coarse list.
+test_coarse_active_row_beats_older_failed_row_despite_unresolvable_head() {
   reset_fakes
   local d short; d=$(new_case f10-coarse-guard)
   make_repo_on_branch "$d/wt" fm/feat-f10c
@@ -1482,30 +1517,30 @@ EOF
   "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-f10c busy --gen "$gen" \
     --source claude-hook --event user-prompt-submit
   local out; out=$(run_crew_state "$d" feat-f10c)
-  assert_not_contains "$out" "state: failed" "an unresolvable active row must not fall to the older failed row"
-  assert_not_contains "$out" "source: run-step" "unknown attribution must not bind a run"
-  assert_contains "$out" "state: working" "the busy crew still reads working through the pane fallback"
-  assert_contains "$out" "source: pane" "unknown attribution falls to the pane, not an older row"
-  pass "coarse scan stops on an unresolvable active row instead of binding an older one"
+  assert_contains "$out" "state: working" "coarse active row remains working"
+  assert_contains "$out" "source: run-step" "coarse active row binds regardless of head"
+  assert_not_contains "$out" "state: failed" "active row must not fall to the older failed row"
+  pass "coarse active exact-branch row beats an older failure regardless of head"
 }
 
-# Negative control: the exemption is gated on pipeline_owned specifically - any
-# other branch_sync state keeps the strict head rule.
-test_non_pipeline_owned_unresolvable_head_not_attributed() {
+# Active attribution depends on the exact branch and active status already
+# exposed by the CLI, not on an optional branch_sync state.
+test_active_run_does_not_require_pipeline_owned_branch_sync() {
   reset_fakes
   local d; d=$(new_case f10-not-owned)
   make_repo_on_branch "$d/wt" fm/feat-f10d
   make_fakebin "$d" >/dev/null
   fm_write_meta "$d/state/feat-f10d.meta" "window=fm:fm-feat-f10d" "worktree=$d/wt" "kind=ship" "harness=claude"
-  printf 'working: implementing\n' > "$d/state/feat-f10d.status"
+  printf 'failed: older validation failed\n' > "$d/state/feat-f10d.status"
   FM_FAKE_AXI_STATUS="$(run_running_pipeline_owned fm/feat-f10d f0f0f0f0 synced)"
   FM_FAKE_RUNS_LIST=""
   FM_FAKE_BUSY=0
   arm_idle_record "$d/state" feat-f10d
   local out; out=$(run_crew_state "$d" feat-f10d)
-  assert_not_contains "$out" "source: run-step" "a non-pipeline-owned unresolvable head must not bind"
-  assert_contains "$out" "source: status-log" "falls back to the status log without the exemption"
-  pass "the exemption requires branch_sync.state=pipeline_owned"
+  assert_contains "$out" "state: working" "exact-branch active run remains working without pipeline_owned"
+  assert_contains "$out" "source: run-step" "exact-branch active run binds without pipeline_owned"
+  assert_not_contains "$out" "state: failed" "stale failure does not override the active run"
+  pass "active exact-branch attribution does not depend on branch_sync state"
 }
 
 # Negative control: the exemption also requires an ACTIVE run - a terminal run
@@ -1529,7 +1564,7 @@ outcome: failed"
   pass "the exemption never applies to a terminal run"
 }
 
-test_missing_run_head_falls_back_to_current_state() {
+test_active_run_with_missing_head_remains_current() {
   reset_fakes
   local d out
   d=$(new_case missing-run-head)
@@ -1542,10 +1577,9 @@ test_missing_run_head_falls_back_to_current_state() {
   FM_FAKE_BUSY=0
   arm_idle_record "$d/state" no-head
   out=$(run_crew_state "$d" no-head)
-  assert_not_contains "$out" "source: run-step" "missing run head must not permit branch-only attribution"
-  assert_contains "$out" "source: status-log" "missing run head falls back to current state sources"
-  assert_contains "$out" "state: working" "status-log remains current after missing run head"
-  pass "missing run head falls back instead of matching by branch"
+  assert_contains "$out" "source: run-step" "active exact-branch run binds despite a missing head"
+  assert_contains "$out" "state: parked" "active parked run remains current despite a missing head"
+  pass "active exact-branch run does not require a head field"
 }
 
 test_active_run_is_authoritative
@@ -1597,14 +1631,15 @@ test_missing_meta
 test_provably_working_via_runs_list_fallback
 test_not_provably_working_when_stopped
 test_usage_error
-test_historical_same_branch_rewritten_head_not_current
+test_historical_terminal_same_branch_rewritten_head_not_current
 test_active_run_descendant_fix_head_remains_current
-test_local_advanced_past_run_head_invalidates
+test_local_advanced_past_terminal_run_head_invalidates
 test_pipeline_owned_active_run_beats_superseded_failed_row
+test_active_fix_run_with_gate_clone_head_beats_older_failure
 test_failed_run_with_no_later_run_still_surfaces
-test_coarse_unresolvable_active_row_never_falls_to_older_row
-test_non_pipeline_owned_unresolvable_head_not_attributed
+test_coarse_active_row_beats_older_failed_row_despite_unresolvable_head
+test_active_run_does_not_require_pipeline_owned_branch_sync
 test_pipeline_owned_terminal_run_not_exempt
-test_missing_run_head_falls_back_to_current_state
+test_active_run_with_missing_head_remains_current
 
 echo "all fm-crew-state tests passed"


### PR DESCRIPTION
## Intent

Fix bin/fm-crew-state.sh reporting a crew as failed while an exact-branch no-mistakes validation run is actively fixing and its pipeline-owned fix head has advanced only in the gate clone beyond the crew worktree. Verify the causal path rather than assuming it. An ACTIVE run reported by the CLI for the exact branch must be authoritative regardless of head match; do not widen head-match tolerance, and reserve coarse terminal attribution for cases with no active run for the branch. Add a hermetic failing-before regression with an active gate-clone-only head and an older failed run, plus tests proving a genuinely failed run with no active successor still reports failed and a passed run still reports passed. Do not add dependencies or scrape pipeline internals beyond existing CLI output, and ensure fixtures never touch live no-mistakes or Firstmate state. Investigate kunchenguid/firstmate issue 3306, but leave it unchanged if it is a separate decision point rather than expanding into a general crew-state rewrite. Follow Firstmate shared tracked code conventions and preserve strict terminal head identity.

## What Changed
- `bin/fm-crew-state.sh` now treats an active no-mistakes run reported by the CLI for the exact branch as authoritative regardless of head match, because pipeline fix commits advance only in the gate clone beyond the crew worktree; terminal runs still require strict head identity, and both the `axi status` attribution path and the coarse runs-list scan (which now returns the first active branch row without a head check) follow this rule.
- `bin/fm-nm-run-lib.sh` drops the `branch_sync.state=pipeline_owned` exemption (`fm_nm_run_is_pipeline_owned_active` and `fm_nm_branch_sync_state` are removed), leaving only the strict branch-and-head identity primitives shared with teardown, and `docs/architecture.md` updates the attribution-rule description to active-run precedence.
- `tests/fm-crew-state.test.sh` adds a hermetic regression where an actively fixing run's head exists only in a gate clone and an older failed run exists on the branch, and updates existing cases so historical rewritten-head and locally-advanced scenarios use terminal passed/failed runs while preserving coverage that genuinely failed runs with no active successor still report failed.

## Risk Assessment

✅ Low: The change narrowly reorders attribution precedence exactly as the stated intent requires, preserves strict terminal head identity, removes only unused helpers, and is covered by behavioral hermetic tests including a failing-before regression.

## Testing

Ran the targeted crew-state suite (passes at target, and the new gate-clone-head regression demonstrably fails at the base commit with the exact reported 'failed while actively fixing' symptom), confirmed the changed run-lib does not regress teardown or gotmp consumers beyond a known pre-existing lsof-environment failure, and captured a before/after CLI transcript plus terminal failed/passed run checks showing the end-user-visible crew-state output is now correct.

<details>
<summary>Evidence: fm-crew-state.sh before/after CLI transcript (active gate-clone fix head vs older failed run, plus terminal failed and passed runs)</summary>

Source: [fm-crew-state.sh before/after CLI transcript (active gate-clone fix head vs older failed run, plus terminal failed and passed runs)](https://github.com/hajekt2/firstmate/blob/851cca64595736fa30bce04c671e41b72ebc0be3/.no-mistakes/evidence/fm/fm-crewstate-active-run-misread/fm-crew-state-before-after-transcript.txt)

<code>=== BEFORE (base bin/fm-crew-state.sh @ debe4bf) ===&#10;state: failed · source: status-log · previous validation run failed&#10;=== AFTER (target bin/fm-crew-state.sh @ b307d60) ===&#10;state: working · source: run-step · validating (running)&#10;=== genuinely failed run, no active successor ===&#10;state: failed · source: run-step · run failed&#10;=== passed run, same head binding ===&#10;state: done · source: run-step · run passed: PR merged/closed</code>

```text
crew worktree head:   430b1c95
active run head:      33d6e271ce34e4397b0fb98ae63fff840cc7b955 (exists ONLY in the gate clone)

=== BEFORE (base bin/fm-crew-state.sh @ debe4bf) ===
state: failed · source: status-log · previous validation run failed

=== AFTER (target bin/fm-crew-state.sh @ b307d60) ===
state: working · source: run-step · validating (running)
=== genuinely failed run, no active successor ===
state: failed · source: run-step · run failed
=== passed run, same head binding ===
state: done · source: run-step · run passed: PR merged/closed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b307d600b674709b63c046d1599c78279d9e188f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-crew-state.test.sh` at the target commit — all pass, including the new `test_active_fix_run_with_gate_clone_head_beats_older_failure` and the rewritten terminal-head, coarse-scan, branch-sync-independence, missing-head, failed-run-still-surfaces, and terminal-exemption cases</code>
- <code>Failing-before check: copied the worktree to a temp checkout of base `bin/fm-crew-state.sh` + `bin/fm-nm-run-lib.sh` (debe4bf) with the target test file — `test_active_fix_run_with_gate_clone_head_beats_older_failure` fails with `state: failed · source: status-log · previous validation run failed`, reproducing the reported misread</code>
- <code>`bash tests/fm-teardown.test.sh` — only the pre-existing `lsof`-unavailable `test_leaked_worktree_process_is_reaped` failure (recorded declined decision) remains; strict head-identity teardown attribution is unaffected</code>
- <code>`bash tests/fm-gotmp.test.sh` — passes with the reworked `bin/fm-nm-run-lib.sh`</code>
- <code>`grep` for `fm_nm_run_is_pipeline_owned_active` / `fm_nm_branch_sync_state` — no remaining callers of the removed helpers</code>
- <code>Manual end-to-end CLI transcript driving the real `bin/fm-crew-state.sh` over a real git worktree plus a gate clone holding an unresolvable-in-worktree fix head: base binary reports `state: failed · source: status-log`, target binary reports `state: working · source: run-step · validating (running)`; the same CLI reports `state: failed` for a genuinely failed run with no active successor and `state: done` for a passed run</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
