### PR TITLE
fix: secure Herdr relaunch recovery and test isolation

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1947,6 +1947,193 @@ fm_backend_herdr_agent_alive() {  # <target>
   esac
 }
 
+# A missing-endpoint recovery may create exactly one task tab in an existing
+# workspace. It never creates a workspace, allocates a worktree, or infers
+# ownership from labels. Callers must hold the task and named-session locks.
+fm_backend_herdr_session_running() {  # <session>
+  local session=$1 out
+  out=$(fm_backend_herdr_cli "$session" status --json 2>/dev/null) || return 1
+  printf '%s' "$out" | jq -e '.server.running == true' >/dev/null 2>&1
+}
+
+fm_backend_herdr_physical_path() {  # <path>
+  local path=$1 dir base
+  [ -n "$path" ] || return 1
+  if [ -d "$path" ]; then
+    (CDPATH='' cd -- "$path" 2>/dev/null && pwd -P) || return 1
+    return 0
+  fi
+  dir=$(dirname -- "$path")
+  base=$(basename -- "$path")
+  [ -d "$dir" ] || return 1
+  dir=$(CDPATH='' cd -- "$dir" 2>/dev/null && pwd -P) || return 1
+  printf '%s/%s' "$dir" "$base"
+}
+
+# Resolve one existing workspace. A live launcher identity wins; otherwise
+# the home label must resolve uniquely. A recorded workspace id is checked only
+# for readability and is never treated as placement authority by itself.
+fm_backend_herdr_missing_relaunch_parent_workspace() {  # <session> <recorded-workspace>
+  local session=$1 recorded=$2 presence status parent label
+  presence=$(fm_backend_herdr_workspace_presence_state "$session" "$recorded")
+  case "$presence" in
+    present|dead) ;;
+    *)
+      echo "error: recorded herdr workspace '$recorded' is unreadable; refusing missing-endpoint recovery" >&2
+      return 1
+      ;;
+  esac
+  fm_backend_herdr_launcher_identity "$session" && status=0 || status=$?
+  case "$status" in
+    0) parent=$FM_BACKEND_HERDR_LAUNCHER_WORKSPACE_ID ;;
+    2)
+      label=$(fm_backend_herdr_workspace_label)
+      parent=$(fm_backend_herdr_projection_parent_workspace_exact "$session" "$label" 2>/dev/null) || {
+        echo "error: herdr home workspace '$label' is absent or ambiguous; refusing to create a recovery endpoint in a guessed parent" >&2
+        return 1
+      }
+      ;;
+    *) return 1 ;;
+  esac
+  [ -n "$parent" ] || return 1
+  printf '%s' "$parent"
+}
+
+# Read all named-session inventories and refuse any same-worktree or duplicate
+# task candidate. Unknown or malformed responses are ambiguity, never proof of
+# safety. The optional candidate ids are the only response-derived exception.
+fm_backend_herdr_missing_relaunch_inventory_safe() {  # <session> <worktree> <task-label> <old-pane> [<candidate-tab> <candidate-pane>]
+  local session=$1 worktree=$2 task_label=$3 old_pane=$4 candidate_tab=${5:-} candidate_pane=${6:-}
+  local expected panes tabs agents rows pane tab cwd foreground canonical seen_candidate_pane=0 seen_candidate_tab=0
+  expected=$(fm_backend_herdr_physical_path "$worktree") || return 1
+  panes=$(fm_backend_herdr_cli "$session" pane list 2>/dev/null) || return 1
+  tabs=$(fm_backend_herdr_cli "$session" tab list 2>/dev/null) || return 1
+  agents=$(fm_backend_herdr_cli "$session" agent list 2>/dev/null) || return 1
+  printf '%s' "$panes" | jq -e '(.result.panes | type) == "array"' >/dev/null 2>&1 || return 1
+  printf '%s' "$tabs" | jq -e '(.result.tabs | type) == "array"' >/dev/null 2>&1 || return 1
+  printf '%s' "$agents" | jq -e '(.result.agents | type) == "array"' >/dev/null 2>&1 || return 1
+
+  rows=$(printf '%s' "$panes" | jq -r '.result.panes[] | [(.pane_id // ""), (.tab_id // ""), (.cwd // ""), (.foreground_cwd // "")] | @tsv' 2>/dev/null) || return 1
+  while IFS=$'\t' read -r pane tab cwd foreground; do
+    [ -n "$pane$tab$cwd$foreground" ] || continue
+    [ -n "$pane" ] && [ -n "$tab" ] && [ -n "$cwd$foreground" ] || return 1
+    [ "$pane" != "$old_pane" ] || return 1
+    if [ -n "$candidate_pane" ] && [ "$pane" = "$candidate_pane" ]; then
+      [ "$tab" = "$candidate_tab" ] || return 1
+      seen_candidate_pane=$((seen_candidate_pane + 1))
+      continue
+    fi
+    for canonical in "$cwd" "$foreground"; do
+      [ -n "$canonical" ] || continue
+      canonical=$(fm_backend_herdr_physical_path "$canonical") || return 1
+      [ "$canonical" != "$expected" ] || {
+        echo "error: herdr pane '$pane' already uses task worktree '$worktree'; refusing a duplicate recovery endpoint" >&2
+        return 1
+      }
+    done
+  done <<EOF
+$rows
+EOF
+
+  rows=$(printf '%s' "$tabs" | jq -r '.result.tabs[] | [(.tab_id // ""), (.label // "")] | @tsv' 2>/dev/null) || return 1
+  while IFS=$'\t' read -r tab label; do
+    [ -n "$tab$label" ] || continue
+    [ -n "$tab" ] || return 1
+    if [ "$label" = "$task_label" ]; then
+      if [ -n "$candidate_tab" ] && [ "$tab" = "$candidate_tab" ]; then
+        seen_candidate_tab=$((seen_candidate_tab + 1))
+      else
+        echo "error: herdr tab '$tab' already carries task label '$task_label'; refusing duplicate recovery" >&2
+        return 1
+      fi
+    fi
+  done <<EOF
+$rows
+EOF
+
+  rows=$(printf '%s' "$agents" | jq -r '.result.agents[] | [(.pane_id // ""), (.cwd // ""), (.foreground_cwd // "")] | @tsv' 2>/dev/null) || return 1
+  while IFS=$'\t' read -r pane cwd foreground; do
+    [ -n "$pane$cwd$foreground" ] || continue
+    [ -n "$pane" ] && [ -n "$cwd$foreground" ] || return 1
+    [ "$pane" != "$candidate_pane" ] || return 1
+    for canonical in "$cwd" "$foreground"; do
+      [ -n "$canonical" ] || continue
+      canonical=$(fm_backend_herdr_physical_path "$canonical") || return 1
+      [ "$canonical" != "$expected" ] || {
+        echo "error: herdr agent in pane '$pane' already uses task worktree '$worktree'; refusing duplicate recovery" >&2
+        return 1
+      }
+    done
+  done <<EOF
+$rows
+EOF
+  if [ -n "$candidate_pane" ]; then
+    [ "$seen_candidate_pane" -eq 1 ] && [ "$seen_candidate_tab" -eq 1 ] || return 1
+  fi
+}
+
+# Create and fully round-trip one recovery tab/pane. Response-derived ids are
+# exported even on later verification failure so cleanup can remain exact.
+fm_backend_herdr_missing_relaunch_create() {  # <session> <workspace> <task-label> <worktree>
+  local session=$1 workspace=$2 task_label=$3 worktree=$4 out info expected cwd state
+  FM_BACKEND_HERDR_MISSING_RELAUNCH_TAB_ID=
+  FM_BACKEND_HERDR_MISSING_RELAUNCH_PANE_ID=
+  export FM_BACKEND_HERDR_MISSING_RELAUNCH_CLEANUP_SAFE=0
+  out=$(fm_backend_herdr_cli "$session" tab create --workspace "$workspace" --cwd "$worktree" --label "$task_label" --no-focus 2>/dev/null) || return 1
+  FM_BACKEND_HERDR_MISSING_RELAUNCH_TAB_ID=$(printf '%s' "$out" | jq -r '.result.tab.tab_id // empty' 2>/dev/null)
+  FM_BACKEND_HERDR_MISSING_RELAUNCH_PANE_ID=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
+  [ -n "$FM_BACKEND_HERDR_MISSING_RELAUNCH_TAB_ID" ] && [ -n "$FM_BACKEND_HERDR_MISSING_RELAUNCH_PANE_ID" ] || return 1
+  # Response validation is complete only when the created candidate is known
+  # safe to clean up if a later publication step fails.
+  FM_BACKEND_HERDR_MISSING_RELAUNCH_CLEANUP_SAFE=1
+  export FM_BACKEND_HERDR_MISSING_RELAUNCH_CLEANUP_SAFE
+  info=$(fm_backend_herdr_cli "$session" tab get "$FM_BACKEND_HERDR_MISSING_RELAUNCH_TAB_ID" 2>/dev/null) || return 1
+  printf '%s' "$info" | jq -e --arg tab "$FM_BACKEND_HERDR_MISSING_RELAUNCH_TAB_ID" --arg workspace "$workspace" --arg label "$task_label" '
+    .result.tab.tab_id == $tab and .result.tab.workspace_id == $workspace and .result.tab.label == $label
+  ' >/dev/null 2>&1 || return 1
+  info=$(fm_backend_herdr_cli "$session" pane get "$FM_BACKEND_HERDR_MISSING_RELAUNCH_PANE_ID" 2>/dev/null) || return 1
+  printf '%s' "$info" | jq -e --arg pane "$FM_BACKEND_HERDR_MISSING_RELAUNCH_PANE_ID" --arg tab "$FM_BACKEND_HERDR_MISSING_RELAUNCH_TAB_ID" --arg workspace "$workspace" '
+    .result.pane.pane_id == $pane and .result.pane.tab_id == $tab and .result.pane.workspace_id == $workspace
+  ' >/dev/null 2>&1 || return 1
+  expected=$(fm_backend_herdr_physical_path "$worktree") || return 1
+  cwd=$(printf '%s' "$info" | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null)
+  [ -n "$cwd" ] || return 1
+  cwd=$(fm_backend_herdr_physical_path "$cwd") || return 1
+  [ "$cwd" = "$expected" ] || return 1
+  state=$(fm_backend_herdr_pane_agent_state "$session" "$FM_BACKEND_HERDR_MISSING_RELAUNCH_PANE_ID")
+  [ "$state" = no-agent ]
+}
+
+# Close only a response-derived, exact-cwd, no-agent candidate. Any uncertainty
+# leaves it for reconciliation rather than guessing at destructive cleanup.
+fm_backend_herdr_missing_relaunch_cleanup() {  # <session> <workspace> <tab> <pane> <worktree>
+  local session=$1 workspace=$2 tab=$3 pane=$4 worktree=$5 expected cwd state info tabs before active_tab
+  [ -n "$workspace" ] && [ -n "$tab" ] && [ -n "$pane" ] || return 1
+  state=$(fm_backend_herdr_pane_agent_state "$session" "$pane")
+  case "$state" in
+    dead) return 0 ;;
+    no-agent) ;;
+    *) return 1 ;;
+  esac
+  info=$(fm_backend_herdr_cli "$session" pane get "$pane" 2>/dev/null) || return 1
+  printf '%s' "$info" | jq -e --arg pane "$pane" --arg tab "$tab" --arg workspace "$workspace" '
+    .result.pane.pane_id == $pane and .result.pane.tab_id == $tab and .result.pane.workspace_id == $workspace
+  ' >/dev/null 2>&1 || return 1
+  expected=$(fm_backend_herdr_physical_path "$worktree") || return 1
+  cwd=$(printf '%s' "$info" | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null)
+  [ -n "$cwd" ] || return 1
+  cwd=$(fm_backend_herdr_physical_path "$cwd") || return 1
+  [ "$cwd" = "$expected" ] || return 1
+  tabs=$(fm_backend_herdr_cli "$session" tab list --workspace "$workspace" 2>/dev/null) || return 1
+  printf '%s' "$tabs" | jq -e --arg tab "$tab" '(.result.tabs | type) == "array" and (.result.tabs | length) > 1 and ([.result.tabs[] | select(.tab_id == $tab)] | length) == 1' >/dev/null 2>&1 || return 1
+  before=$(fm_backend_herdr_projection_focus_snapshot "$session") || return 1
+  active_tab=${before#*$'\t'}
+  [ "$active_tab" != "$tab" ] || return 1
+  fm_backend_herdr_explicit_close_pane_confirmed "$session" "$pane" || return 1
+  fm_backend_herdr_projection_focus_restore "$session" "$before" "missing-relaunch candidate close" || return 1
+  [ "$(fm_backend_herdr_pane_presence_state "$session" "$pane")" = dead ]
+}
+
 # fm_backend_herdr_create_task: create the task's tab (one pane) in
 # <container> ("session:workspace_id"). Herdr does NOT enforce label
 # uniqueness itself (verified: two tabs can share a label), so the duplicate

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -31,10 +31,13 @@
 #              busy, then submits the harness's exit command. Postcondition:
 #              the backend's recovery-grade classifier reports the agent gone.
 #              Already-stopped is success (idempotent).
-#   relaunch   Transactionally replace the running agent with a new one, in the
-#              SAME endpoint and SAME worktree, on the same or a newly chosen
-#              harness/model/effort - so switching harness is one ordinary use
-#              of this verb. With no explicit axis, a secondmate re-resolves its
+#   relaunch   Transactionally replace the running agent with a new one in the
+#              SAME worktree, on the same or a newly chosen harness/model/
+#              effort - so switching harness is one ordinary use of this verb.
+#              The endpoint is also reused except for one narrow recovery: an
+#              authoritatively missing Herdr ship/scout endpoint is recreated
+#              inside the existing worktree by the owning control transaction.
+#              With no explicit axis, a secondmate re-resolves its
 #              durable config/secondmate-harness pin (harness plus its optional
 #              model and effort tokens) exactly as any other respawn does, while
 #              a ship or scout keeps the exact adapter already recorded for it.
@@ -301,12 +304,26 @@ KIND=$(fm_meta_get "$META" kind)
 WT=$(fm_meta_get "$META" worktree)
 [ -n "$KIND" ] || KIND=ship
 
-HARNESS=$(fm_control_harness_family "$RECORDED_HARNESS") \
-  || die "task $ID records harness '${RECORDED_HARNESS:-none}', which has no verified control mechanics; fm-control refuses to guess an interrupt key or exit command"
-fm_control_harness_supported "$HARNESS" \
-  || die "task $ID records harness '${RECORDED_HARNESS:-none}', which has no verified control mechanics; fm-control refuses to guess an interrupt key or exit command"
-
 fm_backend_validate "$BACKEND" || exit 1
+
+# A missing local Herdr endpoint has no old agent to control. For that one
+# recovery shape, an explicit verified replacement harness is sufficient even
+# when the retired record names an adapter whose control mechanics are no
+# longer supported. Every other verb and endpoint state still requires the
+# recorded harness to be controllable.
+if [ "$VERB" = relaunch ] && [ "$HARNESS_SET" = 1 ] \
+   && [ "$BACKEND" = herdr ] \
+   && { [ "$KIND" = ship ] || [ "$KIND" = scout ]; } \
+   && [ "$(fm_backend_agent_state "$BACKEND" "$T")" = missing ] \
+   && fm_control_harness_supported "$NEW_HARNESS" \
+   && fm_control_harness_supports_kind "$NEW_HARNESS" "$KIND"; then
+  HARNESS=$NEW_HARNESS
+else
+  HARNESS=$(fm_control_harness_family "$RECORDED_HARNESS") \
+    || die "task $ID records harness '${RECORDED_HARNESS:-none}', which has no verified control mechanics; fm-control refuses to guess an interrupt key or exit command"
+  fm_control_harness_supported "$HARNESS" \
+    || die "task $ID records harness '${RECORDED_HARNESS:-none}', which has no verified control mechanics; fm-control refuses to guess an interrupt key or exit command"
+fi
 
 # --- shared helpers ---------------------------------------------------------
 
@@ -508,6 +525,10 @@ RELAUNCH_META_PUBLISHED=0
 RELAUNCH_AGENT_CONFIRMED=0
 RELAUNCH_TX=
 RELAUNCH_BRIEF=
+RELAUNCH_ENDPOINT_STATE=
+RELAUNCH_FROM_ENDPOINT=$T
+RELAUNCH_TO_ENDPOINT=$T
+RELAUNCH_ENDPOINT_RECREATED=0
 PRIOR_HARNESS=$HARNESS
 PRIOR_RECORDED_HARNESS=$RECORDED_HARNESS
 CONFIG_HARNESS=
@@ -809,21 +830,56 @@ do_relaunch() {
     note_line="note=none"
   fi
   safe_checkpoint
+  RELAUNCH_ENDPOINT_STATE=$(agent_state)
+  case "$RELAUNCH_ENDPOINT_STATE" in
+    alive|dead) ;;
+    missing)
+      if [ "$BACKEND" != herdr ] \
+         || { [ "$KIND" != ship ] && [ "$KIND" != scout ]; }; then
+        die "task $ID's recorded endpoint is missing, but endpoint recreation is defined only for a local Herdr ship or scout"
+      fi
+      RELAUNCH_ENDPOINT_RECREATED=1
+      ;;
+    *)
+      die "task $ID's endpoint reads '$RELAUNCH_ENDPOINT_STATE' rather than a positively classified state; refusing relaunch"
+      ;;
+  esac
   cp -p "$META" "$META_PRIOR" || die "could not preserve task $ID's durable record before relaunching"
   RELAUNCH_ACTIVE=1
-  journal_write checkpoint "${CHECKPOINT_LINES[@]}" "$note_line"
+  journal_write checkpoint "${CHECKPOINT_LINES[@]}" "$note_line" \
+    "from_endpoint=$RELAUNCH_FROM_ENDPOINT" "endpoint_state=$RELAUNCH_ENDPOINT_STATE"
 
   record_note
-  journal_write noted "${CHECKPOINT_LINES[@]}" "$note_line"
+  journal_write noted "${CHECKPOINT_LINES[@]}" "$note_line" \
+    "from_endpoint=$RELAUNCH_FROM_ENDPOINT" "endpoint_state=$RELAUNCH_ENDPOINT_STATE"
 
-  journal_write stopping "${CHECKPOINT_LINES[@]}" "$note_line"
-  exit_result=$(do_exit)
-  journal_write exited "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"
+  # Re-check the endpoint immediately before any control key is sent. A
+  # missing snapshot may only authorize recreation; it must never authorize
+  # sending the newly selected harness's keys to a resurrected agent.
+  if [ "$RELAUNCH_ENDPOINT_STATE" = missing ]; then
+    state=$(agent_state)
+    [ "$state" = missing ] || {
+      die "task $ID's endpoint changed from missing to '$state' before relaunch control; refusing to send the replacement harness's lifecycle keys"
+    }
+  fi
+  if [ "$RELAUNCH_ENDPOINT_RECREATED" = 1 ]; then
+    exit_result=already-missing
+    journal_write exited "${CHECKPOINT_LINES[@]}" "$note_line" \
+      "from_endpoint=$RELAUNCH_FROM_ENDPOINT" "endpoint_state=missing" "exit_result=$exit_result"
+  else
+    journal_write stopping "${CHECKPOINT_LINES[@]}" "$note_line" \
+      "from_endpoint=$RELAUNCH_FROM_ENDPOINT" "endpoint_state=$RELAUNCH_ENDPOINT_STATE"
+    exit_result=$(do_exit)
+    journal_write exited "${CHECKPOINT_LINES[@]}" "$note_line" \
+      "from_endpoint=$RELAUNCH_FROM_ENDPOINT" "endpoint_state=$RELAUNCH_ENDPOINT_STATE" "exit_result=$exit_result"
+  fi
 
   # The launch owner (fm-spawn --relaunch) clears the previous incarnation's
   # per-task harness wiring before arming the new one, so nothing to do here.
   RELAUNCH_TX="${BASHPID:-$$}.$(date -u +%Y%m%dT%H%M%SZ).$RANDOM"
-  journal_write launching "${CHECKPOINT_LINES[@]}" "$note_line" "relaunch_tx=$RELAUNCH_TX"
+  journal_write launching "${CHECKPOINT_LINES[@]}" "$note_line" \
+    "from_endpoint=$RELAUNCH_FROM_ENDPOINT" "endpoint_state=$RELAUNCH_ENDPOINT_STATE" \
+    "relaunch_tx=$RELAUNCH_TX"
   spawn_args=("$ID" --relaunch --harness "$TARGET_HARNESS")
   [ "$TARGET_MODEL" = default ] || spawn_args+=(--model "$TARGET_MODEL")
   [ "$TARGET_EFFORT" = default ] || spawn_args+=(--effort "$TARGET_EFFORT")
@@ -836,14 +892,30 @@ do_relaunch() {
     die "the replacement agent for $ID could not be launched on $TARGET_HARNESS"
   fi
 
+  fm_backend_validate_task_endpoint "$META" "$ID" || \
+    die "the replacement publication for $ID did not preserve a valid task endpoint"
+  [ "$FM_BACKEND_VALIDATED_BACKEND" = "$BACKEND" ] || \
+    die "the replacement publication for $ID changed backend identity"
+  T=$FM_BACKEND_VALIDATED_TARGET
+  RELAUNCH_TO_ENDPOINT=$T
   state=$(wait_agent_state "$LAUNCH_WAIT" alive) || {
-    die "the replacement agent for $ID did not come up within ${LAUNCH_WAIT}s (endpoint reads '$state')"
+    die "the replacement agent for $ID did not come up within ${LAUNCH_WAIT}s (published endpoint reads '$state')"
   }
   RELAUNCH_AGENT_CONFIRMED=1
 
-  journal_write complete "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"
+  journal_write complete "${CHECKPOINT_LINES[@]}" "$note_line" \
+    "from_endpoint=$RELAUNCH_FROM_ENDPOINT" "to_endpoint=$RELAUNCH_TO_ENDPOINT" \
+    "endpoint_state=$RELAUNCH_ENDPOINT_STATE" "exit_result=$exit_result"
+  if [ "$RELAUNCH_ENDPOINT_RECREATED" = 1 ]; then
+    rm -f -- "$JOURNAL.candidate" || \
+      die "the replacement is running, but its completed Herdr recovery record could not be retired"
+  fi
   RELAUNCH_ACTIVE=0
-  echo "relaunched $ID harness=$TARGET_HARNESS from=$PRIOR_RECORDED_HARNESS model=$TARGET_MODEL effort=$TARGET_EFFORT backend=$BACKEND endpoint=$T worktree=$WT"
+  if [ "$RELAUNCH_ENDPOINT_RECREATED" = 1 ]; then
+    echo "relaunched $ID harness=$TARGET_HARNESS from=$PRIOR_RECORDED_HARNESS model=$TARGET_MODEL effort=$TARGET_EFFORT backend=$BACKEND endpoint-recreated=$RELAUNCH_FROM_ENDPOINT->$T worktree=$WT"
+  else
+    echo "relaunched $ID harness=$TARGET_HARNESS from=$PRIOR_RECORDED_HARNESS model=$TARGET_MODEL effort=$TARGET_EFFORT backend=$BACKEND endpoint=$T worktree=$WT"
+  fi
 }
 
 # --- verbs ------------------------------------------------------------------

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -664,6 +664,18 @@ HERDR_PROJECTION_ABORT_TASK_PANE=
 HERDR_PROJECTION_ABORT_SEEDED_PANE=
 HERDR_PRESENTATION_ORDER_LOCK=
 HERDR_PRESENTATION_ORDER_LOCK_HELD=0
+HERDR_MISSING_RELAUNCH=0
+HERDR_MISSING_RELAUNCH_PUBLISHED=0
+HERDR_MISSING_RELAUNCH_CANDIDATE=
+HERDR_MISSING_RELAUNCH_CANDIDATE_SAFE=0
+HERDR_MISSING_RELAUNCH_SIDECAR=
+# Preserve the invoking process's Herdr ancestry before relaunch metadata
+# reuses the task endpoint variables below.
+SPAWN_CALLER_HERDR_PANE_ID=${HERDR_PANE_ID:-}
+SPAWN_CALLER_HERDR_TAB_ID=${HERDR_TAB_ID:-}
+SPAWN_CALLER_HERDR_WORKSPACE_ID=${HERDR_WORKSPACE_ID:-}
+SPAWN_CALLER_HERDR_SESSION=${HERDR_SESSION:-}
+SPAWN_CALLER_HERDR_SOCKET_PATH=${HERDR_SOCKET_PATH:-}
 SPAWN_TASK_LOCK=
 SPAWN_TASK_LOCK_HELD=0
 SPAWN_CONTROL_LOCK=
@@ -701,7 +713,31 @@ parse_orca_worktree_result() {
 }
 
 spawn_abort_cleanup() {
-  local status=$?
+  local status=$? published_meta=
+  [ -z "${ID:-}" ] || published_meta="$STATE/$ID.meta"
+  if [ "$HERDR_MISSING_RELAUNCH" = 1 ] \
+     && [ -n "$published_meta" ] \
+     && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ] \
+     && [ "$(fm_meta_get "$published_meta" control_relaunch_tx)" = "$FM_CONTROL_RELAUNCH_TX" ]; then
+    HERDR_MISSING_RELAUNCH_PUBLISHED=1
+  fi
+  if [ "$HERDR_MISSING_RELAUNCH" = 1 ] \
+     && [ "$HERDR_MISSING_RELAUNCH_PUBLISHED" != 1 ]; then
+    if [ -n "$HERDR_MISSING_RELAUNCH_CANDIDATE" ]; then
+      if [ "$HERDR_MISSING_RELAUNCH_CANDIDATE_SAFE" = 1 ] \
+         && fm_backend_herdr_missing_relaunch_cleanup \
+           "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$HERDR_TAB_ID" \
+           "$HERDR_MISSING_RELAUNCH_CANDIDATE" "$RELAUNCH_WT"; then
+        rm -f -- "$HERDR_MISSING_RELAUNCH_SIDECAR" 2>/dev/null || true
+      else
+        echo "warning: response-derived Herdr recovery candidate '$HERDR_MISSING_RELAUNCH_CANDIDATE' is quarantined for task $ID; inspect $HERDR_MISSING_RELAUNCH_SIDECAR before retrying" >&2
+      fi
+      HERDR_MISSING_RELAUNCH_CANDIDATE=
+    elif [ -n "$HERDR_MISSING_RELAUNCH_SIDECAR" ] \
+       && { [ -e "$HERDR_MISSING_RELAUNCH_SIDECAR" ] || [ -L "$HERDR_MISSING_RELAUNCH_SIDECAR" ]; }; then
+      echo "warning: Herdr recovery create did not return a complete candidate for task $ID; $HERDR_MISSING_RELAUNCH_SIDECAR is quarantined" >&2
+    fi
+  fi
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
      && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
      && [ -n "$SPAWN_META_TMP" ] \
@@ -1005,6 +1041,43 @@ FIRSTMATE_HOME=
 # validation teardown uses, so a malformed, ambiguous, or foreign record
 # refuses here exactly as it refuses there.
 RELAUNCH_PRIOR_HARNESS=
+RELAUNCH_IDENTITY=
+RELAUNCH_HERDR_WORKSPACE_ID=
+relaunch_identity_snapshot() {  # <meta>
+  local meta=$1 key
+  for key in window endpoint_task_id worktree project harness kind mode yolo \
+    model effort backend herdr_session herdr_workspace_id herdr_tab_id \
+    herdr_pane_id home projects; do
+    printf '%s=%s\n' "$key" "$(fm_meta_get "$meta" "$key")"
+  done
+}
+
+relaunch_same_worktree_task_absent() {  # <worktree>
+  local expected candidate other id
+  expected=$(real_path_or_raw "$1")
+  for candidate in "$STATE"/*.meta; do
+    [ -e "$candidate" ] || continue
+    [ -f "$candidate" ] && [ ! -L "$candidate" ] || {
+      echo "error: task metadata '$candidate' is unreadable while checking recovery worktree ownership" >&2
+      return 1
+    }
+    [ "$candidate" != "$RELAUNCH_META" ] || continue
+    other=$(fm_meta_get "$candidate" worktree)
+    [ -z "$other" ] || [ ! -d "$other" ] || {
+      if [ "$(real_path_or_raw "$other")" = "$expected" ]; then
+        id=${candidate##*/}
+        id=${id%.meta}
+        echo "error: task $id already records recovery worktree '$1'; refusing a second endpoint for the same copy" >&2
+        return 1
+      fi
+    }
+  done
+}
+
+relaunch_identity_still_matches() {
+  [ "$(relaunch_identity_snapshot "$RELAUNCH_META")" = "$RELAUNCH_IDENTITY" ]
+}
+
 if [ "$RELAUNCH" -eq 1 ]; then
   [ "${#POS[@]}" -eq 1 ] || {
     echo "error: --relaunch takes the task id only; its project or home comes from the task's own record" >&2
@@ -1020,24 +1093,47 @@ if [ "$RELAUNCH" -eq 1 ]; then
   RELAUNCH_TARGET=$FM_BACKEND_VALIDATED_TARGET
   fm_backend_validate_spawn "$BACKEND" || exit 1
   fm_backend_source "$BACKEND" || exit 1
-  # A relaunch must PROVE the previous agent is gone before it launches another
-  # one into the same endpoint, and only tmux and herdr have a recovery-grade
-  # classifier that can (bin/fm-control-lib.sh owns that capability table).
-  fm_control_backend_state_verified "$BACKEND" || {
-    echo "error: backend '$BACKEND' has no recovery-grade agent-state classifier, so a relaunch cannot prove the previous agent exited; refusing rather than risking two agents in one endpoint" >&2
-    exit 1
-  }
+  # A relaunch ordinarily needs a positively dead endpoint. The only exception
+  # is the authenticated child of fm-control for a local Herdr ship/scout whose
+  # old endpoint is authoritatively missing.
   RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
-  [ "$RELAUNCH_STATE" = dead ] || {
-    echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
-    exit 1
-  }
   RELAUNCH_PRIOR_HARNESS=$(fm_meta_get "$RELAUNCH_META" harness)
   KIND=$(fm_meta_get "$RELAUNCH_META" kind)
   [ -n "$KIND" ] || KIND=ship
   MODE=$(fm_meta_get "$RELAUNCH_META" mode)
   YOLO=$(fm_meta_get "$RELAUNCH_META" yolo)
   RELAUNCH_WT=$(fm_meta_get "$RELAUNCH_META" worktree)
+  RELAUNCH_IDENTITY=$(relaunch_identity_snapshot "$RELAUNCH_META")
+  case "$RELAUNCH_STATE" in
+    dead) ;;
+    missing)
+      if [ "$SPAWN_CONTROL_PARENT" = 1 ] \
+         && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ] \
+         && [ "$BACKEND" = herdr ] \
+         && { [ "$KIND" = ship ] || [ "$KIND" = scout ]; } \
+         && [ -f "$STATE/$ID.control-relaunch" ] \
+         && [ ! -L "$STATE/$ID.control-relaunch" ] \
+         && [ -f "$STATE/$ID.control-relaunch.meta-prior" ] \
+         && [ ! -L "$STATE/$ID.control-relaunch.meta-prior" ] \
+         && [ "$(relaunch_identity_snapshot "$STATE/$ID.control-relaunch.meta-prior")" = "$RELAUNCH_IDENTITY" ] \
+         && [ "$(fm_meta_get "$STATE/$ID.control-relaunch" task)" = "$ID" ] \
+         && [ "$(fm_meta_get "$STATE/$ID.control-relaunch" phase)" = launching ] \
+         && [ "$(fm_meta_get "$STATE/$ID.control-relaunch" backend)" = herdr ] \
+         && [ "$(fm_meta_get "$STATE/$ID.control-relaunch" endpoint_state)" = missing ] \
+         && [ "$(fm_meta_get "$STATE/$ID.control-relaunch" endpoint)" = "$RELAUNCH_TARGET" ] \
+         && [ "$(fm_meta_get "$STATE/$ID.control-relaunch" worktree)" = "$RELAUNCH_WT" ] \
+         && [ "$(fm_meta_get "$STATE/$ID.control-relaunch" relaunch_tx)" = "$FM_CONTROL_RELAUNCH_TX" ]; then
+        HERDR_MISSING_RELAUNCH=1
+      else
+        echo "error: task $ID's endpoint reads 'missing'; only the owning fm-control relaunch transaction may recreate a missing Herdr ship/scout endpoint" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
+      exit 1
+      ;;
+  esac
   [ -n "$RELAUNCH_WT" ] && [ -d "$RELAUNCH_WT" ] || {
     echo "error: task $ID's recorded worktree '${RELAUNCH_WT:-none}' is missing; refusing to relaunch without the local copy its work lives in" >&2
     exit 1
@@ -1054,7 +1150,8 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   if [ "$BACKEND" = herdr ]; then
     HERDR_SES=$(fm_meta_get "$RELAUNCH_META" herdr_session)
-    HERDR_WORKSPACE_ID=$(fm_meta_get "$RELAUNCH_META" herdr_workspace_id)
+    RELAUNCH_HERDR_WORKSPACE_ID=$(fm_meta_get "$RELAUNCH_META" herdr_workspace_id)
+    HERDR_WORKSPACE_ID=$RELAUNCH_HERDR_WORKSPACE_ID
     HERDR_TAB_ID=$(fm_meta_get "$RELAUNCH_META" herdr_tab_id)
     HERDR_PANE_ID=$(fm_meta_get "$RELAUNCH_META" herdr_pane_id)
   fi
@@ -1917,16 +2014,108 @@ herdr_projection_existing_meta_allows_flat() {  # <meta>
 
 W="fm-$ID"
 if [ "$RELAUNCH" -eq 1 ]; then
-  # Adopt the recorded endpoint instead of creating one. This is what keeps a
-  # relaunch a REPLACEMENT rather than a second copy of the task: no new
-  # terminal, no second worktree, and every uncommitted change left exactly
-  # where the previous agent left it.
-  T=$RELAUNCH_TARGET
   # A secondmate's home already resolved WT above through the same validation a
   # fresh secondmate spawn uses; every other kind takes the recorded worktree.
   [ "$KIND" = secondmate ] || WT=$RELAUNCH_WT
-  WT_TARGET=$T
-  SES=${T%%:*}
+  # Adopt the recorded endpoint instead of creating one. Missing Herdr recovery
+  # replaces this target below with its response-derived endpoint.
+  T=$RELAUNCH_TARGET
+  if [ "$HERDR_MISSING_RELAUNCH" = 1 ]; then
+    # Recreate only inside the existing named session/workspace. Hold the
+    # canonical session lock from absence proof through launch submission.
+    fm_backend_herdr_session_running "$HERDR_SES" || {
+      echo "error: missing-endpoint recovery requires named Herdr session '$HERDR_SES' to be running and readable" >&2
+      exit 1
+    }
+    spawn_herdr_presentation_order_lock_acquire "$HERDR_SES" || {
+      echo "error: missing-endpoint recovery could not acquire the named Herdr session lock" >&2
+      exit 1
+    }
+    HERDR_MISSING_RELAUNCH_SIDECAR="$STATE/$ID.control-relaunch.candidate"
+    if [ -e "$HERDR_MISSING_RELAUNCH_SIDECAR" ] || [ -L "$HERDR_MISSING_RELAUNCH_SIDECAR" ]; then
+      echo "error: task $ID has an unreconciled Herdr recovery candidate; refusing another create" >&2
+      exit 1
+    fi
+    {
+      echo "v1"
+      echo "task=$ID"
+      echo "relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
+      echo "phase=intent"
+      echo "session=$HERDR_SES"
+      echo "old_endpoint=$RELAUNCH_TARGET"
+      echo "worktree=$RELAUNCH_WT"
+    } > "$HERDR_MISSING_RELAUNCH_SIDECAR.tmp" \
+      && mv -f "$HERDR_MISSING_RELAUNCH_SIDECAR.tmp" "$HERDR_MISSING_RELAUNCH_SIDECAR" || exit 1
+    SPAWN_META_LOCK=$(fm_meta_lock_path "$RELAUNCH_META") || exit 1
+    fm_lock_acquire_wait "$SPAWN_META_LOCK"
+    SPAWN_META_LOCK_HELD=1
+    relaunch_identity_still_matches || {
+      echo "error: task $ID identity changed before missing-endpoint creation; refusing publication" >&2
+      exit 1
+    }
+    [ "$(fm_backend_agent_state herdr "$RELAUNCH_TARGET")" = missing ] || {
+      echo "error: task $ID's old Herdr endpoint is no longer authoritatively missing; refusing recovery create" >&2
+      exit 1
+    }
+    relaunch_same_worktree_task_absent "$RELAUNCH_WT" || exit 1
+    HERDR_PARENT_WORKSPACE_ID=$( \
+      FM_HOME="$FM_HOME" \
+      HERDR_PANE_ID="$SPAWN_CALLER_HERDR_PANE_ID" \
+      HERDR_TAB_ID="$SPAWN_CALLER_HERDR_TAB_ID" \
+      HERDR_WORKSPACE_ID="$SPAWN_CALLER_HERDR_WORKSPACE_ID" \
+      HERDR_SESSION="$SPAWN_CALLER_HERDR_SESSION" \
+      HERDR_SOCKET_PATH="$SPAWN_CALLER_HERDR_SOCKET_PATH" \
+      fm_backend_herdr_missing_relaunch_parent_workspace \
+        "$HERDR_SES" "$RELAUNCH_HERDR_WORKSPACE_ID" \
+    ) || exit 1
+    fm_backend_herdr_missing_relaunch_inventory_safe \
+      "$HERDR_SES" "$RELAUNCH_WT" "$W" "${RELAUNCH_TARGET#*:}" || {
+      echo "error: named Herdr session inventory could not prove duplicate recovery risk absent" >&2
+      exit 1
+    }
+    if ! fm_backend_herdr_missing_relaunch_create \
+      "$HERDR_SES" "$HERDR_PARENT_WORKSPACE_ID" "$W" "$RELAUNCH_WT"; then
+      HERDR_WORKSPACE_ID=$HERDR_PARENT_WORKSPACE_ID
+      HERDR_TAB_ID=$FM_BACKEND_HERDR_MISSING_RELAUNCH_TAB_ID
+      HERDR_MISSING_RELAUNCH_CANDIDATE=$FM_BACKEND_HERDR_MISSING_RELAUNCH_PANE_ID
+      HERDR_MISSING_RELAUNCH_CANDIDATE_SAFE=$FM_BACKEND_HERDR_MISSING_RELAUNCH_CLEANUP_SAFE
+      if [ -n "$HERDR_MISSING_RELAUNCH_CANDIDATE" ]; then
+        {
+          echo "v1"
+          echo "task=$ID"
+          echo "relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
+          echo "phase=response-unverified"
+          echo "session=$HERDR_SES"
+          echo "workspace=$HERDR_WORKSPACE_ID"
+          echo "tab=$HERDR_TAB_ID"
+          echo "pane=$HERDR_MISSING_RELAUNCH_CANDIDATE"
+          echo "worktree=$RELAUNCH_WT"
+        } > "$HERDR_MISSING_RELAUNCH_SIDECAR.tmp" \
+          && mv -f "$HERDR_MISSING_RELAUNCH_SIDECAR.tmp" "$HERDR_MISSING_RELAUNCH_SIDECAR" || true
+      fi
+      echo "error: Herdr recovery endpoint creation or response validation failed" >&2
+      exit 1
+    fi
+    HERDR_TAB_ID=$FM_BACKEND_HERDR_MISSING_RELAUNCH_TAB_ID
+    HERDR_PANE_ID=$FM_BACKEND_HERDR_MISSING_RELAUNCH_PANE_ID
+    HERDR_WORKSPACE_ID=$HERDR_PARENT_WORKSPACE_ID
+    HERDR_MISSING_RELAUNCH_CANDIDATE=$HERDR_PANE_ID
+    HERDR_MISSING_RELAUNCH_CANDIDATE_SAFE=1
+    fm_backend_herdr_missing_relaunch_inventory_safe \
+      "$HERDR_SES" "$RELAUNCH_WT" "$W" "${RELAUNCH_TARGET#*:}" \
+      "$HERDR_TAB_ID" "$HERDR_PANE_ID" || {
+      echo "error: Herdr recovery duplicate-risk proof changed after candidate creation" >&2
+      exit 1
+    }
+    T="$HERDR_SES:$HERDR_PANE_ID"
+    WT_TARGET=$T
+    SES=$HERDR_SES
+  else
+    # Ordinary relaunch adopts the exact recorded endpoint.
+    T=$RELAUNCH_TARGET
+    WT_TARGET=$T
+    SES=${T%%:*}
+  fi
 else
 case "$BACKEND" in
   tmux)
@@ -1964,7 +2153,7 @@ case "$BACKEND" in
     HERDR_LAUNCHER_RELATIONSHIP=launcher-home
     if [ "$KIND" = secondmate ]; then
       HERDR_LABEL_HOME=$PROJ_ABS
-      HERDR_LAUNCHER_RELATIONSHIP=other-home
+      HERDR_LAUNCHER_RELATIONSHIP='other-home'
     fi
     HERDR_PRESENTATION_JOURNAL=$(fm_backend_herdr_projection_journal_path "$STATE" "$ID")
     HERDR_PROJECTED=0
@@ -2693,9 +2882,26 @@ META_WINDOW=$T
 SPAWN_GEN="s$(date +%s).${BASHPID:-$$}.$RANDOM"
 SPAWN_META_PATH="$STATE/$ID.meta"
 if [ "$RELAUNCH" -eq 1 ]; then
-  SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
-  fm_lock_acquire_wait "$SPAWN_META_LOCK"
-  SPAWN_META_LOCK_HELD=1
+  if [ "$SPAWN_META_LOCK_HELD" != 1 ]; then
+    SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
+    fm_lock_acquire_wait "$SPAWN_META_LOCK"
+    SPAWN_META_LOCK_HELD=1
+  fi
+  if [ "$HERDR_MISSING_RELAUNCH" = 1 ]; then
+    HERDR_MISSING_RELAUNCH_SIDECAR="$STATE/$ID.control-relaunch.candidate"
+    {
+      echo "v1"
+      echo "task=$ID"
+      echo "relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
+      echo "phase=validated"
+      echo "session=$HERDR_SES"
+      echo "workspace=$HERDR_WORKSPACE_ID"
+      echo "tab=$HERDR_TAB_ID"
+      echo "pane=$HERDR_PANE_ID"
+      echo "worktree=$RELAUNCH_WT"
+    } > "$HERDR_MISSING_RELAUNCH_SIDECAR.tmp" \
+      && mv -f "$HERDR_MISSING_RELAUNCH_SIDECAR.tmp" "$HERDR_MISSING_RELAUNCH_SIDECAR" || exit 1
+  fi
   SPAWN_META_TMP="$STATE/.$ID.meta.relaunch.${BASHPID:-$$}"
   SPAWN_META_PATH=$SPAWN_META_TMP
 fi
@@ -2751,6 +2957,21 @@ preserve_relaunch_meta() {
     echo "projects=$SECONDMATE_PROJECTS"
   fi
   if [ "$RELAUNCH" -eq 1 ]; then
+    if [ "$HERDR_MISSING_RELAUNCH" = 1 ]; then
+      if [ "$SPAWN_META_LOCK_HELD" != 1 ]; then
+        SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
+        fm_lock_acquire_wait "$SPAWN_META_LOCK"
+        SPAWN_META_LOCK_HELD=1
+      fi
+      relaunch_identity_still_matches || {
+        echo "error: task $ID identity changed before missing-endpoint publication; refusing publication" >&2
+        exit 1
+      }
+      [ "$(fm_backend_agent_state herdr "$RELAUNCH_TARGET")" = missing ] || {
+        echo "error: task $ID's old Herdr endpoint is no longer authoritatively missing; refusing publication" >&2
+        exit 1
+      }
+    fi
     preserve_relaunch_meta
   fi
   if [ "$SPAWN_CONTROL_PARENT" = 1 ] && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ]; then
@@ -2760,6 +2981,21 @@ preserve_relaunch_meta() {
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_PUBLISH_STARTED=1
   mv -f "$SPAWN_META_TMP" "$STATE/$ID.meta"
+  if [ "$HERDR_MISSING_RELAUNCH" = 1 ]; then
+    HERDR_MISSING_RELAUNCH_PUBLISHED=1
+    {
+      echo "v1"
+      echo "task=$ID"
+      echo "relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
+      echo "phase=published"
+      echo "session=$HERDR_SES"
+      echo "workspace=$HERDR_WORKSPACE_ID"
+      echo "tab=$HERDR_TAB_ID"
+      echo "pane=$HERDR_PANE_ID"
+      echo "worktree=$RELAUNCH_WT"
+    } > "$HERDR_MISSING_RELAUNCH_SIDECAR.tmp" \
+      && mv -f "$HERDR_MISSING_RELAUNCH_SIDECAR.tmp" "$HERDR_MISSING_RELAUNCH_SIDECAR" || exit 1
+  fi
   RELAUNCH_REPLACEMENT_PENDING=0
   SPAWN_META_PUBLISH_STARTED=0
   SPAWN_META_TMP=
@@ -2884,6 +3120,9 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   spawn_herdr_presentation_order_lock_release
 fi
 spawn_send_key "$T" Enter
+if [ "$HERDR_MISSING_RELAUNCH" = 1 ]; then
+  spawn_herdr_presentation_order_lock_release
+fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -17,21 +17,26 @@
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
-#   --relaunch launches a replacement agent for an EXISTING task into that
-#   task's own recorded endpoint and worktree instead of creating either. It is
-#   the launch half of the control plane (bin/fm-control.sh relaunch), which
-#   owns the checkpoint, the progress note, stopping the previous agent, and the
-#   transaction; call fm-control rather than this flag directly unless you are
-#   deliberately re-launching an already-stopped task. Every identity axis -
+#   --relaunch launches a replacement agent for an EXISTING task. An ordinary
+#   relaunch adopts that task's own recorded endpoint and worktree instead of
+#   creating either; the only exception is an authenticated child of the owning
+#   fm-control transaction recreating an authoritatively missing local Herdr
+#   ship/scout endpoint in an existing named session/workspace and the recorded
+#   worktree. It is the launch half of the control plane (bin/fm-control.sh
+#   relaunch), which owns the checkpoint, the progress note, stopping the
+#   previous agent, and the transaction; direct invocation cannot bypass missing
+#   endpoint authorization, so call fm-control rather than this flag unless you
+#   are deliberately re-launching an already-stopped task. Every identity axis -
 #   backend, kind, project or home, worktree, endpoint - comes from the task's
 #   validated state/<id>.meta, so --backend, --scout, --secondmate, a project
 #   positional, and batch pairs are all refused alongside it; only harness,
 #   model, and effort may change, which is what makes a harness switch one
-#   ordinary relaunch. It refuses unless the recorded endpoint is positively
-#   agent-free on a backend with a recovery-grade agent-state classifier (tmux
-#   or herdr), refuses unless the endpoint's shell is sitting in the recorded
-#   worktree, and clears the previous harness's per-task wiring before arming
-#   the new incarnation.
+#   ordinary relaunch. For an ordinary relaunch it refuses unless the recorded
+#   endpoint is positively agent-free on a backend with a recovery-grade agent-
+#   state classifier (tmux or herdr), and refuses unless the endpoint's shell is
+#   sitting in the recorded worktree. A missing endpoint is accepted only for
+#   the authenticated Herdr ship/scout exception above. It clears the previous
+#   harness's per-task wiring before arming the new incarnation.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -32,7 +32,7 @@ A recorded `harness=` is not always an exact adapter name: a task launched from 
 | --- | --- | --- |
 | `interrupt` | Deliver the harness's verified interrupt sequence while leaving the agent running. | Delivery succeeds while the endpoint still exists and the agent is still alive where the backend can classify that; cancellation is confirmed only from an adapter-owned acknowledgement and otherwise reports `cancel=unconfirmed`. |
 | `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone. Already-stopped is idempotent success. |
-| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, and effort. | The new agent is alive on the recorded endpoint, and the durable record names the harness that is actually running. |
+| `relaunch` | Replace a running agent with a new one in the same worktree, normally reusing the recorded endpoint, on the exact recorded adapter or an explicitly chosen harness, model, and effort, while an authenticated control transaction may recreate an authoritatively missing local Herdr ship or scout endpoint. | The new agent is alive on the reused or narrowly recreated endpoint, and the durable record names the harness that is actually running. |
 
 An exit that delivers lifecycle input but cannot prove the agent stopped fails with `exit=unconfirmed`, reports the observed agent state and any interrupt cancellation claim, and never claims that nothing changed.
 Interrupt never rewrites busy state as proof of its own success.
@@ -60,6 +60,7 @@ It is not deterministic across the verified adapters: codex and grok resume only
    Otherwise a `kind=secondmate` task re-resolves its durable `config/secondmate-harness` pin, including that file's optional model and effort tokens, exactly as every other respawn does - so setting the pin and relaunching is the ordinary way to move a secondmate's runtime.
    A ship or scout keeps the harness already recorded for it, because that harness comes from firstmate's dispatch-profile judgment at intake and must not be silently re-read from configuration.
    A recorded raw-command basename that differs from its resolved adapter cannot reproduce the command actually running, so relaunch refuses before the checkpoint unless the caller passes an explicit `--harness` to choose the replacement runtime deliberately.
+   For an authoritatively missing local Herdr ship or scout endpoint, an explicit verified `--harness` may replace a recorded harness whose old control mechanics are unavailable, because there is no old agent to control; the replacement harness must still be verified for that task kind.
    A harness change resets model and effort unless they are named too, because a model chosen for one adapter does not transfer to another.
 2. **Safe checkpoint.**
    The recorded worktree must exist and be a worktree root; its head and dirty state are recorded.
@@ -68,15 +69,15 @@ It is not deterministic across the verified adapters: codex and grok resume only
 3. **Record the note.**
    A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation; the note is appended to the instructions it reads.
    A secondmate relaunch does not require one and never rewrites its standing charter.
-4. **Stop the old agent** through the `exit` verb, with its postcondition.
-5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+4. **Stop the old agent** through the `exit` verb, with its postcondition, unless the recorded endpoint is already authoritatively missing, in which case the transaction records that no lifecycle command was sent.
+5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which normally adopts the recorded endpoint and worktree instead of creating either, but may recreate one authoritatively missing local Herdr ship or scout endpoint under the authenticated control transaction; it then clears the previous harness's per-task wiring and arms a fresh busy generation.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
 
 ### Failure and rollback
 
 - A refusal **before** the agent is stopped leaves the durable record and the instructions byte-identical.
-- A launch failure **after** the agent is stopped restores the prior durable record, keeps the progress note so a later recovery still has it, marks the journal `failed:launching`, and reports plainly that no agent is running and where the work is preserved.
+- A launch failure **after the old agent is stopped, or after a missing endpoint is accepted for authenticated recovery,** keeps the prior durable record, keeps the progress note so a later recovery still has it, marks the journal `failed:launching`, and reports plainly that no replacement agent is confirmed and where the work is preserved.
 - If the launch owner already published the new record but no running agent can be confirmed, the new record is kept: the task is recorded on the new harness with no agent confirmed, which is exactly what recovery reconciles.
   Rewriting it back to the old harness would be a second, worse inaccuracy.
 
@@ -88,7 +89,7 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
 - A remotely placed secondmate is refused by name.
   Its agent runs on another host, so none of the postconditions this plane verifies could be read for it here; local endpoint validation would refuse the record regardless, because `window=remote:<id>` can never match a local backend's required shape.
   Drive that lifecycle on its own host and reconcile it through the secondmate recovery path.
-- An unverified harness is refused rather than guessed at.
+- An unverified replacement harness is refused rather than guessed at.
 - An implicit relaunch from a prefixed raw-command basename is refused before the agent or durable state is touched because its original launch command cannot be reconstructed.
 - An adapter that is not verified for this task's kind is refused **before** the running agent is stopped, not after.
   Muse is a crewmate and scout adapter only, so relaunching a secondmate onto it refuses while its agent is still up rather than leaving that secondmate with no agent when the launch owner refuses.
@@ -98,7 +99,9 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
   zellij, orca, and cmux are refused rather than reported as successful blind.
 - An ambiguous or unreadable endpoint state refuses.
   Only a positively classified state acts.
-- `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
+- `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree for an ordinary relaunch, so a replacement can never join a live agent or start outside the copy holding the work.
+  The sole exception is an authoritatively missing local Herdr ship or scout endpoint when the process is the authenticated child of its owning `fm-control` relaunch transaction with matching journal, prior metadata, endpoint, worktree, and transaction identity; it may then create one response-verified replacement in an existing named Herdr workspace and session.
+  A direct `fm-spawn --relaunch`, or any live, remote, malformed, ambiguous, unsupported, or otherwise non-authoritatively-missing endpoint, is refused.
 
 ## Capability matrix
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -261,7 +261,8 @@ No Herdr-specific copy of that protocol exists.
 
 Stopping and restarting a named Herdr server preserves workspace, tab, pane, and label ids, but the underlying harness processes and live agent registrations do not survive.
 A restored same-labeled tab with a missing pane or no registered agent is a husk.
-Create replaces only a confidently dead or no-agent husk, creates the replacement before closing the old tab, and refuses live or unknown states.
+Ordinary create replaces only a confidently dead or no-agent husk, creates the replacement before closing the old tab, and refuses live or unknown states.
+A structurally missing task endpoint is not repaired by ordinary create or session-start recovery; authenticated control-plane recovery for a local ship or scout is defined in [agent-control.md](agent-control.md#transactional-relaunch), while direct spawn relaunch remains refused.
 This prevents closing the workspace's last tab before a replacement exists.
 
 The generic Herdr agent-liveness probe reuses the same classifier.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -604,7 +604,7 @@ Polling remained active and is covered as the fallback for capability, connect, 
 
 ### Agent lifecycle control
 
-Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; the output below was reverified 2026-08-08 on Herdr 0.8.0, and first measured 2026-08-02 on Herdr 0.7.5 with identical results.
+Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; the output below was reverified 2026-08-30 on Herdr 0.8.2, after the original five-line lifecycle result was first measured 2026-08-02 on Herdr 0.7.5 and reverified 2026-08-08 on Herdr 0.8.0.
 
 ```sh
 HERDR_LAB_HELPER=bin/fm-herdr-lab.sh tests/fm-control-herdr-smoke.test.sh
@@ -618,11 +618,11 @@ ok - real herdr: interrupt refuses when herdr's own agent registry reports no ag
 ok - real herdr: interrupt delivers the harness's key and proves the agent survived it
 ok - real herdr: no control verb removed the endpoint or the task's local copy
 ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
+ok - real herdr: authenticated relaunch recreates a missing task endpoint in the recorded workspace
+ok - real herdr: direct fm-spawn relaunch cannot bypass authenticated missing-endpoint recovery
 ```
 
 The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
-The current smoke also exercises authenticated recovery of a missing local Herdr ship/scout endpoint and refusal of a direct `fm-spawn --relaunch` bypass.
-Those cases were added after the dated run above, so their observed output is not recorded here until the guarded command is rerun.
 That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
 ### Away-mode transport

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -604,10 +604,10 @@ Polling remained active and is covered as the fallback for capability, connect, 
 
 ### Agent lifecycle control
 
-Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-08-08 on Herdr 0.8.0, and first measured 2026-08-02 on Herdr 0.7.5 with identical results:
+Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; the output below was reverified 2026-08-08 on Herdr 0.8.0, and first measured 2026-08-02 on Herdr 0.7.5 with identical results.
 
 ```sh
-tests/fm-control-herdr-smoke.test.sh
+HERDR_LAB_HELPER=bin/fm-herdr-lab.sh tests/fm-control-herdr-smoke.test.sh
 ```
 
 Observed output:
@@ -621,6 +621,8 @@ ok - real herdr: an agent that does not stop fails closed instead of being repor
 ```
 
 The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
+The current smoke also exercises authenticated recovery of a missing local Herdr ship/scout endpoint and refusal of a direct `fm-spawn --relaunch` bypass.
+Those cases were added after the dated run above, so their observed output is not recorded here until the guarded command is rerun.
 That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
 ### Away-mode transport

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -19,26 +19,39 @@
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 
 fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
 
 command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
+[ -x "$HERDR_LAB_HELPER" ] || { echo "skip: Herdr lab helper not executable at $HERDR_LAB_HELPER"; exit 0; }
 
 # shellcheck source=tests/herdr-test-safety.sh
 . "$ROOT/tests/herdr-test-safety.sh"
 herdr_forget_inherited_pane
 
-SESSION="fm-lab-control-smoke-$$"
-export HERDR_SESSION="$SESSION"
+SESSION=$(PATH="$PATH" "$HERDR_LAB_HELPER" name fm-control-smoke)
+INITIAL_SESSION=$SESSION
+export HERDR_LAB_HELPER HERDR_LAB_SESSION="$SESSION" HERDR_SESSION="$SESSION"
 SCRATCH=
 cleanup_all() {
+  local status=0
   [ -n "$SCRATCH" ] && rm -rf "$SCRATCH"
-  herdr_safe_stop_and_delete "$SESSION"
+  for lab_session in "${INITIAL_SESSION:-}" "${RECOVERY_SESSION:-}"; do
+    [ -n "$lab_session" ] || continue
+    [ -f "$(fm_herdr_lab_tripwire_path "$lab_session")" ] || continue
+    PATH="$ORIGINAL_PATH" "$HERDR_LAB_HELPER" teardown "$lab_session" || status=1
+  done
+  return "$status"
 }
 trap cleanup_all EXIT
-fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+PATH="$PATH" "$HERDR_LAB_HELPER" provision "$SESSION" || fail "could not prepare isolated Herdr lab session"
+
+lab() {
+  PATH="$ORIGINAL_PATH" "$HERDR_LAB_HELPER" run "$SESSION" "$@"
+}
 
 SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-control-herdr.XXXXXX")
 SCRATCH=$(cd "$SCRATCH" && pwd)
@@ -46,7 +59,31 @@ HOME_DIR="$SCRATCH/home"
 mkdir -p "$HOME_DIR/state" "$HOME_DIR/data/hsmoke"
 printf '# brief\n' > "$HOME_DIR/data/hsmoke/brief.md"
 
-# A real git worktree so the control plane's checkpoint has a real local copy.
+REAL_HERDR=$(command -v herdr)
+ORIGINAL_PATH=$PATH
+FAKEBIN="$SCRATCH/fakebin"
+mkdir -p "$FAKEBIN"
+cat > "$FAKEBIN/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = --version ]; then
+  exec env PATH="$HERDR_ORIGINAL_PATH" "$REAL_HERDR" "$@"
+fi
+args=("$@")
+last=$((${#args[@]} - 1))
+if [ "${#args[@]}" -ge 2 ] && [ "${args[$last-1]}" = --session ] \
+   && [ "${args[$last]}" = "$HERDR_LAB_SESSION" ]; then
+  unset 'args[last]' 'args[last-1]'
+fi
+for arg in "${args[@]}"; do
+  case "$arg" in
+    --session|--session=*) exit 2 ;;
+  esac
+done
+exec env PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" "${args[@]}"
+SH
+chmod +x "$FAKEBIN/herdr"
+export HERDR_ORIGINAL_PATH="$ORIGINAL_PATH" REAL_HERDR PATH="$FAKEBIN:$ORIGINAL_PATH"
 PROJ="$SCRATCH/proj"
 WT="$SCRATCH/wt"
 mkdir -p "$PROJ"
@@ -95,7 +132,12 @@ run_control() {
     "$ROOT/bin/fm-control.sh" "$@" 2>&1
 }
 
-# --- no registered agent: the endpoint exists but hosts no agent ------------
+run_spawn_missing() {
+  env PATH="$PATH" FM_HOME="$HOME_DIR" HERDR_SESSION="$SESSION" \
+    FM_SPAWN_NO_GUARD=1 GROK_HOME="$SCRATCH/grokhome" \
+    "$ROOT/bin/fm-spawn.sh" "$@" 2>&1
+}
+
 
 OUT=$(run_control hsmoke exit) || fail "exit against an agent-free herdr pane should be idempotent success: $OUT"
 case "$OUT" in
@@ -115,9 +157,10 @@ pass "real herdr: interrupt refuses when herdr's own agent registry reports no a
 
 # --- a registered agent: classification flips, and the verbs follow ---------
 
-herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-smoke-agent \
-  --state idle --session "$SESSION" >/dev/null 2>&1 \
-  || fail "could not register a live agent on the task pane"
+if ! lab pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-smoke-agent \
+  --state idle >/dev/null 2>&1; then
+  fail "could not register a live agent on the task pane"
+fi
 
 STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
 [ "$STATE" = alive ] || fail "herdr should classify a registered agent as alive, got '$STATE'"
@@ -129,7 +172,7 @@ case "$OUT" in
 esac
 pass "real herdr: interrupt delivers the harness's key and proves the agent survived it"
 
-herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
+  lab pane get "$PANE_ID" >/dev/null 2>&1 \
   || fail "the control plane must never remove the endpoint it was operating on"
 [ -d "$WT" ] || fail "the control plane must never remove the task's local copy"
 pass "real herdr: no control verb removed the endpoint or the task's local copy"
@@ -145,5 +188,100 @@ case "$OUT" in
   *) fail "the exit failure should say the agent did not stop, got: $OUT" ;;
 esac
 pass "real herdr: an agent that does not stop fails closed instead of being reported as stopped"
+
+# --- authenticated missing-endpoint recovery -------------------------------
+# Use a fresh named lab after the stop-failure smoke. The old scenario is
+# intentionally terminal: its failed exit may leave the prior workspace in a
+# state that is unsuitable for a second independent assertion.
+PATH="$ORIGINAL_PATH" "$HERDR_LAB_HELPER" teardown "$INITIAL_SESSION" \
+  || fail "could not retire the first isolated Herdr smoke session"
+INITIAL_SESSION=
+RECOVERY_SESSION=$(PATH="$ORIGINAL_PATH" "$HERDR_LAB_HELPER" name fm-control-recovery)
+SESSION=$RECOVERY_SESSION
+export HERDR_LAB_SESSION="$SESSION" HERDR_SESSION="$SESSION"
+PATH="$ORIGINAL_PATH" "$HERDR_LAB_HELPER" provision "$SESSION" \
+  || fail "could not provision the recovery Herdr lab session"
+CONTAINER_RAW=$(fm_backend_herdr_container_ensure "$WT") \
+  || fail "recovery container_ensure failed"
+CONTAINER=${CONTAINER_RAW%%$'\t'*}
+SEEDED_TAB_ID=${CONTAINER_RAW#*$'\t'}
+WORKSPACE_ID=${CONTAINER#*:}
+TASK_IDS=$(fm_backend_herdr_create_task "$CONTAINER" "fm-hsmoke" "$WT" "$SEEDED_TAB_ID") \
+  || fail "recovery create_task failed"
+read -r TAB_ID PANE_ID <<EOF
+$TASK_IDS
+EOF
+{
+  echo "window=$SESSION:$PANE_ID"
+  echo "endpoint_task_id=hsmoke"
+  echo "worktree=$WT"
+  echo "project=$PROJ"
+  echo "harness=historical-unsupported"
+  echo "kind=ship"
+  echo "mode=no-mistakes"
+  echo "yolo=off"
+  echo "model=default"
+  echo "effort=default"
+  echo "backend=herdr"
+  echo "herdr_session=$SESSION"
+  echo "herdr_workspace_id=$WORKSPACE_ID"
+  echo "herdr_tab_id=$TAB_ID"
+  echo "herdr_pane_id=$PANE_ID"
+} > "$HOME_DIR/state/hsmoke.meta"
+# The fresh task pane is agent-free by construction. Closing it below creates
+# the authoritative missing endpoint without invoking lifecycle control on the
+# deliberately unsupported historical harness.
+# Keep an anchor tab so closing the retired task tab cannot remove the named
+# workspace. Its cwd is deliberately not the task worktree, so the duplicate
+# worktree inventory remains a meaningful guard.
+lab tab create --workspace "$WORKSPACE_ID" --cwd "$ROOT" --label fm-control-anchor --no-focus \
+  >/dev/null || fail "could not create the non-task workspace anchor"
+cat > "$FAKEBIN/claude" <<'SH'
+#!/usr/bin/env bash
+set -u
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane report-agent "$HERDR_PANE_ID" \
+  --source fm-control-relaunch-smoke --agent fm-control-relaunch-agent --state idle >/dev/null
+while :; do sleep 1; done
+SH
+chmod +x "$FAKEBIN/claude"
+lab pane close "$PANE_ID" >/dev/null || fail "could not remove the retired task pane"
+awk -F= 'BEGIN { OFS="=" } $1 == "harness" { $2="historical-unsupported" } { print }' \
+  "$HOME_DIR/state/hsmoke.meta" > "$HOME_DIR/state/hsmoke.meta.tmp"
+mv "$HOME_DIR/state/hsmoke.meta.tmp" "$HOME_DIR/state/hsmoke.meta"
+OUT=$(run_control hsmoke relaunch --harness claude --note "recover the missing Herdr endpoint") \
+  || fail "authenticated missing Herdr recovery should succeed: $OUT"
+case "$OUT" in
+  *"endpoint-recreated="*) : ;;
+  *) fail "recovery outcome should identify the recreated endpoint, got: $OUT" ;;
+esac
+NEW_PANE=$(grep '^herdr_pane_id=' "$HOME_DIR/state/hsmoke.meta" | cut -d= -f2-)
+NEW_TAB=$(grep '^herdr_tab_id=' "$HOME_DIR/state/hsmoke.meta" | cut -d= -f2-)
+NEW_WORKSPACE=$(grep '^herdr_workspace_id=' "$HOME_DIR/state/hsmoke.meta" | cut -d= -f2-)
+[ "$NEW_WORKSPACE" = "$WORKSPACE_ID" ] || fail "recovery must preserve the recorded workspace"
+[ "$NEW_PANE" != "$PANE_ID" ] || fail "recovery must publish the new response-derived pane"
+[ "$NEW_TAB" != "$TAB_ID" ] || fail "recovery must publish the new response-derived tab"
+[ "$(fm_backend_agent_state herdr "$SESSION:$NEW_PANE")" = alive ] \
+  || fail "the replacement agent must be alive on the recreated pane"
+[ "$(cat "$HOME_DIR/state/hsmoke.control-relaunch.candidate" 2>/dev/null || true)" = "" ] \
+  || fail "a completed recovery must retire its candidate sidecar"
+[ "$(grep '^harness=' "$HOME_DIR/state/hsmoke.meta")" = harness=claude ] \
+  || fail "recovery must publish the explicit verified replacement harness"
+pass "real herdr: authenticated relaunch recreates a missing task endpoint in the recorded workspace"
+
+# Direct fm-spawn relaunch is not an authorization path. Remove the replacement
+# pane, leave its metadata intact, and prove a direct missing-endpoint attempt
+# refuses without creating another tab.
+lab pane close "$NEW_PANE" >/dev/null || fail "could not remove the recovered pane for bypass testing"
+DIRECT_BEFORE_TABS=$(lab tab list --workspace "$WORKSPACE_ID")
+if DIRECT_OUT=$(run_spawn_missing hsmoke --relaunch --harness claude 2>&1); then
+  fail "direct fm-spawn relaunch must refuse a missing Herdr endpoint: $DIRECT_OUT"
+fi
+case "$DIRECT_OUT" in
+  *"only the owning fm-control relaunch transaction"*) : ;;
+  *) fail "direct missing-endpoint refusal should name fm-control ownership: $DIRECT_OUT" ;;
+esac
+AFTER_TABS=$(lab tab list --workspace "$WORKSPACE_ID")
+[ "$AFTER_TABS" = "$DIRECT_BEFORE_TABS" ] || fail "direct missing-endpoint refusal must not create a Herdr tab"
+pass "real herdr: direct fm-spawn relaunch cannot bypass authenticated missing-endpoint recovery"
 
 fm_backend_herdr_kill "$SESSION:$PANE_ID" 2>/dev/null || true

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -30,19 +30,31 @@ CONTROL="$ROOT/bin/fm-control.sh"
 SPAWN="$ROOT/bin/fm-spawn.sh"
 PROMOTE="$ROOT/bin/fm-promote.sh"
 X_LINK="$ROOT/bin/fm-x-link.sh"
-# fm_test_tmproot's own cleanup trap fires when its command substitution exits,
-# so recreate the root before resolving it and clean it up from this file's trap.
-TMP_ROOT=$(fm_test_tmproot fm-control-relaunch)
-mkdir -p "$TMP_ROOT"
-TMP_ROOT=$(cd "$TMP_ROOT" && pwd)
-TASK_TMPS=()
+relaunch_fixture_root() {
+  local root
+  root=$(mktemp -d "${TMPDIR:-/tmp}/fm-control-relaunch.XXXXXX") || return 1
+  if ! printf '%s\n' "fm-control-relaunch-fixture.v1:$root" > "$root/.fm-test-fixture"; then
+    rm -rf -- "$root"
+    return 1
+  fi
+  printf '%s\n' "$root"
+}
+
+RELAUNCH_FIXTURE_ROOT=$(cd "$(relaunch_fixture_root)" && pwd -P)
+TMP_ROOT=$RELAUNCH_FIXTURE_ROOT
+
+relaunch_cleanup_root() {  # <fixture-root>
+  local root=$1 marker
+  [ -n "$root" ] || return 0
+  [ -d "$root" ] && [ ! -L "$root" ] || return 0
+  marker="$root/.fm-test-fixture"
+  [ -f "$marker" ] && [ ! -L "$marker" ] || return 0
+  [ "$(cat "$marker" 2>/dev/null)" = "fm-control-relaunch-fixture.v1:$root" ] || return 0
+  rm -rf -- "$root"
+}
 
 relaunch_cleanup() {
-  local d
-  for d in "${TASK_TMPS[@]:-}"; do
-    [ -n "$d" ] && rm -rf "$d"
-  done
-  rm -rf "$TMP_ROOT"
+  relaunch_cleanup_root "${RELAUNCH_FIXTURE_ROOT:-}"
 }
 trap relaunch_cleanup EXIT
 
@@ -151,13 +163,13 @@ add_ship_task() {
     echo "kind=ship"
     echo "mode=no-mistakes"
     echo "yolo=off"
-    echo "tasktmp=/tmp/fm-$id"
+    echo "tasktmp=$dir/tasktmp/$id"
     echo "model=default"
     echo "effort=default"
   } > "$home/state/$id.meta"
   printf '%s\n' "fm-$id" > "$dir/fake/windows"
   printf '%s' "$wt" > "$dir/fake/cwd"
-  TASK_TMPS+=("/tmp/fm-$id")
+  mkdir -p "$dir/tasktmp/$id"
 }
 
 run_control() {  # <case-dir> <args...>
@@ -188,6 +200,77 @@ meta_field() {  # <case-dir> <id> <key>
 journal_field() {  # <case-dir> <id> <key>
   grep "^$3=" "$1/home/state/$2.control-relaunch" | tail -1 | cut -d= -f2-
 }
+
+run_cleanup_probe() {  # <success|assertion|early|single|truncated>
+  local mode=$1 external result fixture_path rc expected
+  external=$(mktemp -d "${TMPDIR:-/tmp}/fm-control-relaunch-real-task.XXXXXX") \
+    || fail "could not create external cleanup probe root"
+  mkdir -p "$external/repository/tasktmp"
+  printf 'external live-copy sentinel\n' > "$external/repository/tasktmp/sentinel"
+  result="$external/probe-result"
+  fixture_path="$external/fixture-path"
+  case "$mode" in
+    success|single) expected=0 ;;
+    assertion|early|truncated) expected=nonzero ;;
+    *) rm -rf -- "$external"; fail "unknown cleanup probe mode '$mode'" ;;
+  esac
+  export -f relaunch_cleanup_root
+  PROBE_MODE="$mode" PROBE_EXTERNAL="$external" PROBE_RESULT="$result" PROBE_FIXTURE_PATH="$fixture_path" \
+    bash -c '
+      set -eu
+      make_fixture_root() {
+        local root
+        root=$(mktemp -d "${TMPDIR:-/tmp}/fm-control-relaunch-fixture.XXXXXX")
+        printf "fm-control-relaunch-fixture.v1:%s\\n" "$root" > "$root/.fm-test-fixture"
+        printf "%s\\n" "$root"
+      }
+      FIXTURE_ROOT=$(make_fixture_root)
+      printf "%s\\n" "$FIXTURE_ROOT" > "$PROBE_FIXTURE_PATH"
+      TASK_TMPS="$PROBE_EXTERNAL/repository/tasktmp"
+      cleanup() {
+        relaunch_cleanup_root "$FIXTURE_ROOT"
+        [ ! -e "$FIXTURE_ROOT" ] && printf "cleaned\\n" > "$PROBE_RESULT"
+      }
+      trap cleanup EXIT
+      one_case() {
+        [ -f "$TASK_TMPS/sentinel" ]
+      }
+      case "$PROBE_MODE" in
+        success) exit 0 ;;
+        assertion) false ;;
+        early) exit 73 ;;
+        single) one_case; exit 0 ;;
+        truncated) kill -KILL $$ ;;
+      esac
+    '
+  rc=$?
+  if [ "$expected" = 0 ]; then
+    [ "$rc" -eq 0 ] || { rm -rf -- "$external"; fail "$mode cleanup probe returned $rc"; }
+  else
+    [ "$rc" -ne 0 ] || { rm -rf -- "$external"; fail "$mode cleanup probe unexpectedly succeeded"; }
+  fi
+  if [ "$mode" = truncated ]; then
+    fixture=$(cat "$fixture_path" 2>/dev/null || true)
+    [ -d "$fixture" ] || { rm -rf -- "$external"; fail "truncated cleanup probe unexpectedly ran its trap"; }
+    rm -rf -- "$fixture"
+  else
+    [ "$(cat "$result" 2>/dev/null || true)" = cleaned ] \
+      || { rm -rf -- "$external"; fail "$mode cleanup did not remove only its exact disposable fixture root"; }
+  fi
+  [ -f "$external/repository/tasktmp/sentinel" ] \
+    || { rm -rf -- "$external"; fail "$mode cleanup removed an external live-copy sentinel"; }
+  rm -rf -- "$external"
+  pass "relaunch cleanup: external sentinel survives $mode subprocess execution"
+}
+
+test_relaunch_cleanup_isolated_from_external_task_roots() {
+  run_cleanup_probe success
+  run_cleanup_probe assertion
+  run_cleanup_probe early
+  run_cleanup_probe single
+  run_cleanup_probe truncated
+}
+
 
 make_git_failure_stub() {  # <case-dir>
   cat > "$1/fakebin/git" <<'SH'
@@ -298,7 +381,7 @@ test_relaunch_preserves_durable_task_metadata() {
 }
 
 test_relaunch_serializes_concurrent_durable_metadata_publication() {
-  local dir control_pid link_pid rc i=0 traceparent prepare ready exported release
+  local dir control_pid link_pid rc i=0 traceparent prepare ready exported release wait_attempts=1000
   dir=$(new_case metadata-race rl28)
   add_ship_task "$dir" rl28 claude
   printf '%s\n' "$$" > "$dir/home/state/.lock"
@@ -314,7 +397,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
     FM_FAKE_TRACE_EXPORTED="$exported" \
     run_control "$dir" rl28 relaunch --note "continue after publication" > "$dir/control.out" &
   control_pid=$!
-  while [ ! -e "$prepare" ] && [ "$i" -lt 200 ]; do
+  while [ ! -e "$prepare" ] && [ "$i" -lt "$wait_attempts" ]; do
     /bin/sleep 0.01
     i=$((i + 1))
   done
@@ -332,7 +415,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
       --carry-platform x --carry-max 280 > "$dir/link.out" 2>&1 &
   link_pid=$!
   i=0
-  while { [ ! -e "$ready" ] || [ ! -e "$exported" ]; } && [ "$i" -lt 200 ]; do
+  while { [ ! -e "$ready" ] || [ ! -e "$exported" ]; } && [ "$i" -lt "$wait_attempts" ]; do
     /bin/sleep 0.01
     i=$((i + 1))
   done
@@ -1312,6 +1395,7 @@ test_spawn_relaunch_refuses_a_pane_outside_the_worktree() {
   pass "fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work"
 }
 
+test_relaunch_cleanup_isolated_from_external_task_roots
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_serializes_concurrent_durable_metadata_publication


### PR DESCRIPTION
## Intent

Implement two defects in the firstmate project: allow fm-control.sh <task> relaunch --harness <verified> to recover a locally missing Herdr ship/scout endpoint with strict authenticated control-transaction authorization, preserving task identity, worktree, brief, metadata, uncommitted changes, and recorded workspace, while refusing live, remote, malformed, ambiguous, unsupported, or non-authoritatively-missing endpoints and refusing any direct fm-spawn --relaunch bypass; and harden tests/fm-control-relaunch.test.sh cleanup so it can remove only its own newly-created exact-marked fixture root, with subprocess regressions proving external task/repository sentinels survive success, assertion failure, early exit, single-case, and truncated execution. Use only the guarded named Herdr lab helper for lifecycle operations, do not run raw or destructive Herdr commands, preserve existing delivery evidence, do not merge, and drive the validated change to a green PR.

## What Changed
- Added authenticated recovery for authoritatively missing local Herdr ship/scout endpoints through `fm-control.sh`, with transaction, identity, workspace, worktree, and response-validation checks while preserving task metadata; direct `fm-spawn --relaunch` bypasses remain refused.
- Updated Herdr lifecycle documentation and smoke coverage to use the guarded lab helper and verify missing-endpoint recovery plus direct-bypass refusal.
- Hardened `fm-control-relaunch.test.sh` cleanup around an exact-marked fixture root, with subprocess regressions proving external task and repository sentinels survive success, assertion failure, early exit, single-case, and truncated execution.

## Risk Assessment

✅ Low: Static review of b52377c against its parent found no substantiated blocker, high, or medium severity defect. Missing-endpoint recovery is narrowly authenticated through fm-control, direct fm-spawn bypasses are refused, identity/worktree/metadata/workspace checks are preserved, and Herdr candidate cleanup fails closed. Residual risk is limited to dependence on Herdr response schemas; malformed or unsupported responses are refused.

## Testing

Ran only the two targeted validation scripts. The hermetic suite covered the requested cleanup and relaunch regressions, while the real Herdr smoke test demonstrated end-user recovery behavior and authenticated control authorization. No linters, formatters, static analysis, or full repository suite were run.

<details>
<summary>Evidence: Focused relaunch regression transcript</summary>

Source: [Focused relaunch regression transcript](https://github.com/chsong1/firstmate/blob/8e60a2c7a64dce78055db3b4297bf2c7b8938a1b/.no-mistakes/evidence/fm/firstmate-legacy-harness-test-isolation-r2/fm-control-relaunch.test.log)

```text
$ tests/fm-control-relaunch.test.sh
ok - relaunch cleanup: external sentinel survives success subprocess execution
ok - relaunch cleanup: external sentinel survives assertion subprocess execution
ok - relaunch cleanup: external sentinel survives early subprocess execution
ok - relaunch cleanup: external sentinel survives single subprocess execution
./tests/fm-control-relaunch.test.sh: line 204: 48106 Killed: 9               PROBE_MODE="$mode" PROBE_EXTERNAL="$external" PROBE_RESULT="$result" PROBE_FIXTURE_PATH="$fixture_path" bash -c '
      set -eu
      make_fixture_root() {
        local root
        root=$(mktemp -d "${TMPDIR:-/tmp}/fm-control-relaunch-fixture.XXXXXX")
        printf "fm-control-relaunch-fixture.v1:%s\\n" "$root" > "$root/.fm-test-fixture"
        printf "%s\\n" "$root"
      }
      FIXTURE_ROOT=$(make_fixture_root)
      printf "%s\\n" "$FIXTURE_ROOT" > "$PROBE_FIXTURE_PATH"
      TASK_TMPS="$PROBE_EXTERNAL/repository/tasktmp"
      cleanup() {
        relaunch_cleanup_root "$FIXTURE_ROOT"
        [ ! -e "$FIXTURE_ROOT" ] && printf "cleaned\\n" > "$PROBE_RESULT"
      }
      trap cleanup EXIT
      one_case() {
        [ -f "$TASK_TMPS/sentinel" ]
      }
      case "$PROBE_MODE" in
        success) exit 0 ;;
        assertion) false ;;
        early) exit 73 ;;
        single) one_case; exit 0 ;;
        truncated) kill -KILL $$ ;;
      esac
    '
ok - relaunch cleanup: external sentinel survives truncated subprocess execution
ok - fm-control relaunch: a same-harness relaunch replaces the agent in the same endpoint and worktree
ok - fm-control relaunch: durable task metadata survives replacement launch publication
ok - fm-control relaunch: trace and concurrent task metadata publications serialize
ok - fm-control relaunch: disabling tracing clears metadata and pane context
ok - fm-control relaunch: the progress note lands in the instructions the replacement reads
ok - fm-control relaunch: a ship task refuses without the progress note its replacement needs
ok - fm-control relaunch: switching harness is one ordinary relaunch, and the old wiring goes with the old agent
ok - fm-control relaunch: a harness switch resets model and effort unless they are named too
ok - fm-control relaunch: a prefixed recorded harness can switch adapters transactionally
ok - fm-control relaunch: a prefixed command requires an explicit replacement harness
ok - fm-control relaunch: a same-harness relaunch keeps the profile axes it was running with
ok - fm-control relaunch: explicit model and effort win over the recorded ones
ok - fm-control relaunch: refuses to relaunch onto an adapter with no verified mechanics
ok - fm-control relaunch: the retired incarnation's global turn-end token is revoked
ok - fm-control relaunch: wiring cleanup failure refuses replacement arming
ok - fm-control-lib: one owner resolves each harness's turn-end registry entry, and refuses a malformed token
ok - fm-control relaunch: a secondmate relaunch re-resolves its durable configured harness pin
ok - fm-control relaunch: invalid configured effort is ignored before stop
ok - fm-control relaunch: an adapter unverified for this task kind refuses before the agent is stopped
ok - fm-control relaunch: explicit secondmate harness resets unnamed profile axes
ok - fm-control relaunch: a ship task keeps its recorded harness instead of re-reading crew config
ok - fm-spawn --relaunch: with no explicit harness it reuses the task's recorded one, never the crew default
ok - fm-spawn --relaunch: wiring armed under a prefixed harness name is still retired
ok - fm-spawn --relaunch: switching away from muse retires its session binding
ok - fm-spawn --relaunch: switching away from cursor retires its session binding
ok - fm-control relaunch: an unaccountable local copy refuses before the agent is touched
ok - fm-control relaunch: a worker with nothing to work from is never launched
ok - fm-control relaunch: a refusal before the agent is stopped leaves the durable record untouched
ok - fm-control relaunch: checkpoint inspection failures refuse before stopping
ok - fm-control relaunch: a launch failure after the stop keeps the prior record and reports the real state
ok - fm-control relaunch: unpublished rollback keeps concurrent durable metadata
ok - fm-control relaunch: post-publication failure keeps the new durable record
ok - fm-control relaunch: partial stop reconciles actual agent state
ok - fm-control relaunch: failed journal replacement preserves durable phase
ok - fm-spawn relaunch: prepublication abort removes replacement state
ok - fm-control relaunch: the checkpoint records the exact unlanded work it preserved
ok - fm-control relaunch: a secondmate's child work is accounted for and its charter is left alone
ok - fm-control relaunch: a secondmate home that is not this secondmate's is refused
ok - fm-control relaunch: unreadable and untraversable child state fails checkpoint
ok - fm-control relaunch: two control actions on one task serialize instead of interleaving
ok - fm-spawn relaunch: direct entry participates in lifecycle serialization
ok - fm-promote: promotion participates in lifecycle serialization
ok - fm-spawn --relaunch: refuses to launch a second agent into a live endpoint
ok - fm-spawn --relaunch: every identity axis comes from the record, and a contradicting flag refuses
ok - fm-spawn --relaunch: an unrecorded task is refused
ok - fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work
```
</details>
<details>
<summary>Evidence: Real Herdr recovery transcript</summary>

Source: [Real Herdr recovery transcript](https://github.com/chsong1/firstmate/blob/8e60a2c7a64dce78055db3b4297bf2c7b8938a1b/.no-mistakes/evidence/fm/firstmate-legacy-harness-test-isolation-r2/fm-control-herdr-smoke.test.log)

```text
$ tests/fm-control-herdr-smoke.test.sh
ok - real herdr: exit on a pane with no registered agent is idempotent success
ok - real herdr: interrupt refuses when herdr's own agent registry reports no agent
ok - real herdr: interrupt delivers the harness's key and proves the agent survived it
ok - real herdr: no control verb removed the endpoint or the task's local copy
ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
ok - real herdr: authenticated relaunch recreates a missing task endpoint in the recorded workspace
ok - real herdr: direct fm-spawn relaunch cannot bypass authenticated missing-endpoint recovery
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a8278d104ab10cd5d3c4b5ce861b3aee4a491a16","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`./tests/fm-control-relaunch.test.sh` — exercised relaunch identity, metadata, worktree preservation, refusal paths, direct `fm-spawn --relaunch` safeguards, and cleanup across success, assertion failure, early exit, single-case, and truncated subprocesses.</code>
- <code>`./tests/fm-control-herdr-smoke.test.sh` — exercised the real guarded Herdr lab recovery flow, workspace and endpoint preservation, live replacement verification, candidate cleanup, and direct-spawn bypass refusal.</code>
- `Captured the targeted test transcripts as reviewer-visible CLI evidence in the dedicated evidence directory.`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `docs/verification/runtime-backends.md:625` - The newly added authenticated missing-endpoint recovery and direct fm-spawn bypass cases lack dated observed output in the maintainer-verification record; rerun the guarded Herdr smoke and append its exact results.

🔧 Fix: Recorded Herdr relaunch recovery evidence
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Pass ShellCheck and pinned actionlint lint gates
1 warning still open:
- ⚠️ linter found issues (exit code 1)

🔧 Fix: Passed ShellCheck and actionlint lint gates
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
