### PR TITLE
fix: make agent relaunch shell-safe and verifiable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,16 @@ jobs:
           set -eu
           npm install -g tasks-axi
           tasks-axi --version
+      - name: Install Fish for shell regressions
+        run: |
+          set -eu
+          lane="portable-serial-${{ matrix.shard }}of${{ strategy.job-total }}"
+          if bin/fm-test-run.sh --list --lane "$lane" \
+            | grep -Eq 'tests/(fm-control-relaunch|fm-trace-context-spawn)\.test\.sh'; then
+            sudo apt-get update
+            sudo apt-get install -y fish
+            fish --version
+          fi
       - name: Run portable serial shard ${{ matrix.shard }}
         env:
           # job-total rather than a literal, so shrinking or growing the matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,8 +172,9 @@ jobs:
           if bin/fm-test-run.sh --list --lane "$lane" \
             | grep -Eq 'tests/(fm-control-relaunch|fm-trace-context-spawn)\.test\.sh'; then
             sudo apt-get update
-            sudo apt-get install -y fish
+            sudo apt-get install -y fish tcsh
             fish --version
+            csh --version
           fi
       - name: Run portable serial shard ${{ matrix.shard }}
         env:

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -72,6 +72,9 @@ FM_BACKEND_HERDR_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_BACKEND_HERDR_ROOT}}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$FM_BACKEND_HERDR_ROOT/bin/fm-session-lock-lib.sh"
+
 # Shared composer-content classifier (empty|pending|unknown, and the fleet-wide
 # dead-shell-vs-agent-composer rule). Owned by bin/fm-composer-lib.sh, reused by
 # every backend so the decision cannot drift.
@@ -1924,44 +1927,12 @@ fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
 # fm_backend_herdr_agent_started: positive replacement-launch proof. Native
 # registration must name a live agent, and process-info must show that agent in
 # a foreground process group distinct from the endpoint shell.
-fm_backend_herdr_process_matches_agent() {  # <harness> <process>
-  local harness=$1 process=$2 name=${2##*/} family
+fm_backend_herdr_registered_agent_matches_harness() {  # <harness> <agent>
+  local harness=$1 agent=$2
   case "$harness" in
-    pi|pi-signed)
-      case "$name" in
-        pi|pi-signed|pi-launcher|Pi) return 0 ;;
-      esac
-      return 1
-      ;;
-    claude*) family=claude ;;
-    codex*) family=codex ;;
-    opencode*) family=opencode ;;
-    grok*) family=grok ;;
-    kimi*) family=kimi ;;
-    cursor*) family=cursor ;;
-    muse*)
-      case "$name" in
-        muse|muse-bin-*) return 0 ;;
-      esac
-      case "/$process/" in
-        */muse/*) return 0 ;;
-      esac
-      return 1
-      ;;
-    *) return 1 ;;
+    pi|pi-signed) case "$agent" in pi|pi-signed) return 0 ;; *) return 1 ;; esac ;;
+    *) [ "$agent" = "$harness" ] ;;
   esac
-  case "$process" in
-    *"$family"*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-fm_backend_herdr_interpreter_script_matches_agent() {  # <harness> <interpreter> <script>
-  local harness=$1 interpreter=${2##*/} script=$3
-  interpreter=${interpreter#-}
-  [ "$harness" = cursor ] || return 1
-  case "$interpreter" in node|node-*|node[0-9]*) ;; *) return 1 ;; esac
-  case "$script" in */cursor-agent/versions/*/index.js) return 0 ;; *) return 1 ;; esac
 }
 
 fm_backend_herdr_agent_started() {  # <target> <harness>
@@ -1977,7 +1948,7 @@ fm_backend_herdr_agent_started() {  # <target> <harness>
     | .agent
     | select(type == "string" and length > 0)
   ' 2>/dev/null) || return 1
-  fm_backend_herdr_process_matches_agent "$harness" "$agent" || return 1
+  fm_backend_herdr_registered_agent_matches_harness "$harness" "$agent" || return 1
   info=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane process-info --pane "$FM_BACKEND_HERDR_PANE" 2>/dev/null) || return 1
   printf '%s' "$info" | jq -e --arg pane "$FM_BACKEND_HERDR_PANE" '
     .result.type == "pane_process_info"
@@ -1998,11 +1969,9 @@ fm_backend_herdr_agent_started() {  # <target> <harness>
   while IFS= read -r process; do
     name=$(printf '%s' "$process" | jq -r '(.name // empty) | select(type == "string")' 2>/dev/null) || continue
     argv0=$(printf '%s' "$process" | jq -r '(.argv0 // .argv[0] // empty) | select(type == "string")' 2>/dev/null) || continue
-    fm_backend_herdr_process_matches_agent "$harness" "$name" && return 0
-    fm_backend_herdr_process_matches_agent "$harness" "$argv0" && return 0
+    fm_harness_selected_executable_matches "$harness" "$name" "$argv0" && return 0
     script=$(printf '%s' "$process" | jq -r '(.argv[1] // empty) | select(type == "string")' 2>/dev/null) || continue
-    fm_backend_herdr_interpreter_script_matches_agent "$harness" "$name" "$script" && return 0
-    fm_backend_herdr_interpreter_script_matches_agent "$harness" "$argv0" "$script" && return 0
+    fm_harness_selected_interpreter_script_matches "$harness" "$name" "$argv0" "$script" && return 0
   done <<EOF
 $processes
 EOF

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1921,6 +1921,26 @@ fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
   esac
 }
 
+# fm_backend_herdr_agent_started: positive replacement-launch proof. Native
+# registration must name a live agent, and process-info must show a foreground
+# process group distinct from the endpoint shell. This rejects a surviving
+# fish, bash, or zsh prompt even when native agent registration is stale.
+fm_backend_herdr_agent_started() {  # <target>
+  local target=$1 info shell_pid foreground_pgid
+  fm_backend_herdr_parse_target "$target" || return 1
+  [ "$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")" = live ] || return 1
+  info=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane process-info --pane "$FM_BACKEND_HERDR_PANE" 2>/dev/null) || return 1
+  printf '%s' "$info" | jq -e --arg pane "$FM_BACKEND_HERDR_PANE" '
+    .result.type == "pane_process_info"
+    and .result.process_info.pane_id == $pane
+  ' >/dev/null 2>&1 || return 1
+  shell_pid=$(printf '%s' "$info" | jq -er \
+    '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
+  foreground_pgid=$(printf '%s' "$info" | jq -er \
+    '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
+  [ "$foreground_pgid" != "$shell_pid" ]
+}
+
 # fm_backend_herdr_agent_state: recovery-grade state for the same session-start
 # sweep as the tmux classifier. It reuses the husk classifier rather than
 # creating a second Herdr state machine: a structurally gone pane is `missing`,

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1956,8 +1956,17 @@ fm_backend_herdr_process_matches_agent() {  # <harness> <process>
   esac
 }
 
+fm_backend_herdr_interpreter_script_matches_agent() {  # <harness> <interpreter> <script>
+  local harness=$1 interpreter=${2##*/} script=$3
+  interpreter=${interpreter#-}
+  [ "$harness" = cursor ] || return 1
+  case "$interpreter" in node|node-*|node[0-9]*) ;; *) return 1 ;; esac
+  case "$script" in */cursor-agent/versions/*/index.js) return 0 ;; *) return 1 ;; esac
+}
+
 fm_backend_herdr_agent_started() {  # <target> <harness>
   local target=$1 harness=$2 agent_info agent info shell_pid foreground_pgid processes process
+  local name argv0 script
   fm_backend_herdr_parse_target "$target" || return 1
   [ "$(fm_backend_herdr_pane_presence_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")" = present ] || return 1
   agent_info=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" agent get "$FM_BACKEND_HERDR_PANE" 2>/dev/null) || return 1
@@ -1983,11 +1992,17 @@ fm_backend_herdr_agent_started() {  # <target> <harness>
     .result.process_info.foreground_processes
     | select(type == "array" and length > 0)
     | .[]
-    | (.name, .argv0, .argv[]?)
-    | select(type == "string" and length > 0)
+    | select(type == "object")
+    | @json
   ' 2>/dev/null) || return 1
   while IFS= read -r process; do
-    fm_backend_herdr_process_matches_agent "$harness" "$process" && return 0
+    name=$(printf '%s' "$process" | jq -r '(.name // empty) | select(type == "string")' 2>/dev/null) || continue
+    argv0=$(printf '%s' "$process" | jq -r '(.argv0 // .argv[0] // empty) | select(type == "string")' 2>/dev/null) || continue
+    fm_backend_herdr_process_matches_agent "$harness" "$name" && return 0
+    fm_backend_herdr_process_matches_agent "$harness" "$argv0" && return 0
+    script=$(printf '%s' "$process" | jq -r '(.argv[1] // empty) | select(type == "string")' 2>/dev/null) || continue
+    fm_backend_herdr_interpreter_script_matches_agent "$harness" "$name" "$script" && return 0
+    fm_backend_herdr_interpreter_script_matches_agent "$harness" "$argv0" "$script" && return 0
   done <<EOF
 $processes
 EOF

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1922,13 +1922,53 @@ fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
 }
 
 # fm_backend_herdr_agent_started: positive replacement-launch proof. Native
-# registration must name a live agent, and process-info must show a foreground
-# process group distinct from the endpoint shell. This rejects a surviving
-# fish, bash, or zsh prompt even when native agent registration is stale.
-fm_backend_herdr_agent_started() {  # <target>
-  local target=$1 info shell_pid foreground_pgid
+# registration must name a live agent, and process-info must show that agent in
+# a foreground process group distinct from the endpoint shell.
+fm_backend_herdr_process_matches_agent() {  # <harness> <process>
+  local harness=$1 process=$2 name=${2##*/} family
+  case "$harness" in
+    pi|pi-signed)
+      case "$name" in
+        pi|pi-signed|pi-launcher|Pi) return 0 ;;
+      esac
+      return 1
+      ;;
+    claude*) family=claude ;;
+    codex*) family=codex ;;
+    opencode*) family=opencode ;;
+    grok*) family=grok ;;
+    kimi*) family=kimi ;;
+    cursor*) family=cursor ;;
+    muse*)
+      case "$name" in
+        muse|muse-bin-*) return 0 ;;
+      esac
+      case "/$process/" in
+        */muse/*) return 0 ;;
+      esac
+      return 1
+      ;;
+    *) return 1 ;;
+  esac
+  case "$process" in
+    *"$family"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_backend_herdr_agent_started() {  # <target> <harness>
+  local target=$1 harness=$2 agent_info agent info shell_pid foreground_pgid processes process
   fm_backend_herdr_parse_target "$target" || return 1
-  [ "$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")" = live ] || return 1
+  [ "$(fm_backend_herdr_pane_presence_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")" = present ] || return 1
+  agent_info=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" agent get "$FM_BACKEND_HERDR_PANE" 2>/dev/null) || return 1
+  agent=$(printf '%s' "$agent_info" | jq -er '
+    .result.agent
+    | select(.agent_status == "working" or .agent_status == "idle"
+      or .agent_status == "done" or .agent_status == "blocked")
+    | .agent
+    | select(type == "string" and length > 0)
+  ' 2>/dev/null) || return 1
+  fm_backend_herdr_process_matches_agent "$harness" "$agent" || return 1
   info=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane process-info --pane "$FM_BACKEND_HERDR_PANE" 2>/dev/null) || return 1
   printf '%s' "$info" | jq -e --arg pane "$FM_BACKEND_HERDR_PANE" '
     .result.type == "pane_process_info"
@@ -1938,7 +1978,20 @@ fm_backend_herdr_agent_started() {  # <target>
     '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
   foreground_pgid=$(printf '%s' "$info" | jq -er \
     '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
-  [ "$foreground_pgid" != "$shell_pid" ]
+  [ "$foreground_pgid" != "$shell_pid" ] || return 1
+  processes=$(printf '%s' "$info" | jq -er '
+    .result.process_info.foreground_processes
+    | select(type == "array" and length > 0)
+    | .[]
+    | (.name, .argv0, .argv[]?)
+    | select(type == "string" and length > 0)
+  ' 2>/dev/null) || return 1
+  while IFS= read -r process; do
+    fm_backend_herdr_process_matches_agent "$harness" "$process" && return 0
+  done <<EOF
+$processes
+EOF
+  return 1
 }
 
 # fm_backend_herdr_agent_state: recovery-grade state for the same session-start

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -263,8 +263,8 @@ fm_backend_tmux_window_exists() {  # <target>
 # foreground process group only. Unlike recovery state below, it deliberately
 # ignores pane_current_command: that title can remain agent-shaped over a live
 # shell and must not turn a submitted launch line into relaunch success.
-fm_backend_tmux_agent_started() {  # <target>
-  local target=$1 requested=$1 names name
+fm_backend_tmux_agent_started() {  # <target> <harness>
+  local target=$1 harness=$2 requested=$1 names name
   fm_backend_tmux_window_exists "$requested" || return 1
   case "$target" in
     *:*:*|'':*|*:'') return 1 ;;
@@ -274,7 +274,7 @@ fm_backend_tmux_agent_started() {  # <target>
   names=$(fm_backend_tmux_foreground_comms "$target")
   while IFS= read -r name; do
     [ -n "$name" ] || continue
-    [ "$(fm_backend_tmux_classify_process_name "$name")" = agent ] \
+    fm_harness_selected_executable_matches "$harness" "$name" '' \
       && fm_backend_tmux_window_exists "$requested" && return 0
   done <<EOF
 $names
@@ -282,7 +282,7 @@ EOF
   names=$(fm_backend_tmux_foreground_argv0s "$target")
   while IFS= read -r name; do
     [ -n "$name" ] || continue
-    [ "$(fm_backend_tmux_classify_process_name '' "$name")" = agent ] \
+    fm_harness_selected_executable_matches "$harness" '' "$name" \
       && fm_backend_tmux_window_exists "$requested" && return 0
   done <<EOF
 $names

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -246,6 +246,29 @@ fm_backend_tmux_foreground_argv0s() {  # <target>
       done
 }
 
+# fm_backend_tmux_agent_started: positive replacement-launch proof from the
+# foreground process group only. Unlike recovery state below, it deliberately
+# ignores pane_current_command: that title can remain agent-shaped over a live
+# shell and must not turn a submitted launch line into relaunch success.
+fm_backend_tmux_agent_started() {  # <target>
+  local target=$1 names name
+  names=$(fm_backend_tmux_foreground_comms "$target")
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    [ "$(fm_backend_tmux_classify_process_name "$name")" = agent ] && return 0
+  done <<EOF
+$names
+EOF
+  names=$(fm_backend_tmux_foreground_argv0s "$target")
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    [ "$(fm_backend_tmux_classify_process_name '' "$name")" = agent ] && return 0
+  done <<EOF
+$names
+EOF
+  return 1
+}
+
 # fm_backend_tmux_agent_state: recovery-grade harness-agent state for one
 # recorded target. See bin/fm-backend.sh's fm_backend_agent_state for the
 # shared state vocabulary and docs/tmux-backend.md "Agent liveness probe" for

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -271,6 +271,10 @@ fm_backend_tmux_agent_started() {  # <target> <harness>
     *:*) target="=${target%%:*}:=${target#*:}" ;;
     *) return 1 ;;
   esac
+  if [ "$harness" = cursor ] && fm_tmux_pane_is_cursor "$target"; then
+    fm_backend_tmux_window_exists "$requested"
+    return
+  fi
   names=$(fm_backend_tmux_foreground_comms "$target")
   while IFS= read -r name; do
     [ -n "$name" ] || continue

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -246,23 +246,44 @@ fm_backend_tmux_foreground_argv0s() {  # <target>
       done
 }
 
+fm_backend_tmux_window_exists() {  # <target>
+  local target=$1 session window windows
+  case "$target" in
+    *:*:*|'':*|*:'') return 1 ;;
+    *:*) ;;
+    *) return 1 ;;
+  esac
+  session=${target%%:*}
+  window=${target#*:}
+  windows=$(LC_ALL=C tmux list-windows -t "=$session" -F '#{window_name}' 2>/dev/null) || return 1
+  printf '%s\n' "$windows" | grep -Fqx "$window"
+}
+
 # fm_backend_tmux_agent_started: positive replacement-launch proof from the
 # foreground process group only. Unlike recovery state below, it deliberately
 # ignores pane_current_command: that title can remain agent-shaped over a live
 # shell and must not turn a submitted launch line into relaunch success.
 fm_backend_tmux_agent_started() {  # <target>
-  local target=$1 names name
+  local target=$1 requested=$1 names name
+  fm_backend_tmux_window_exists "$requested" || return 1
+  case "$target" in
+    *:*:*|'':*|*:'') return 1 ;;
+    *:*) target="=${target%%:*}:=${target#*:}" ;;
+    *) return 1 ;;
+  esac
   names=$(fm_backend_tmux_foreground_comms "$target")
   while IFS= read -r name; do
     [ -n "$name" ] || continue
-    [ "$(fm_backend_tmux_classify_process_name "$name")" = agent ] && return 0
+    [ "$(fm_backend_tmux_classify_process_name "$name")" = agent ] \
+      && fm_backend_tmux_window_exists "$requested" && return 0
   done <<EOF
 $names
 EOF
   names=$(fm_backend_tmux_foreground_argv0s "$target")
   while IFS= read -r name; do
     [ -n "$name" ] || continue
-    [ "$(fm_backend_tmux_classify_process_name '' "$name")" = agent ] && return 0
+    [ "$(fm_backend_tmux_classify_process_name '' "$name")" = agent ] \
+      && fm_backend_tmux_window_exists "$requested" && return 0
   done <<EOF
 $names
 EOF

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -895,6 +895,21 @@ fm_backend_agent_state() {  # <backend> <target>
   esac
 }
 
+# fm_backend_agent_started: positive proof that a replacement launch produced
+# a harness agent rather than merely leaving its terminal endpoint alive.
+# Recovery state is intentionally conservative against duplicate launches and
+# may accept a stale agent-shaped title; lifecycle success needs this stricter
+# foreground-process proof.
+fm_backend_agent_started() {  # <backend> <target>
+  local backend=$1 target=$2
+  fm_backend_source "$backend" || return 1
+  case "$backend" in
+    tmux) fm_backend_tmux_agent_started "$target" ;;
+    herdr) fm_backend_herdr_agent_started "$target" ;;
+    *) return 1 ;;
+  esac
+}
+
 # Backward-compatible three-state view for existing callers. An
 # authoritatively missing endpoint is confidently not a live agent, while every
 # ambiguous, unreadable, or unverified result stays unknown.

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -904,7 +904,7 @@ fm_backend_agent_started() {  # <backend> <target> <harness>
   local backend=$1 target=$2 harness=$3
   fm_backend_source "$backend" || return 1
   case "$backend" in
-    tmux) fm_backend_tmux_agent_started "$target" ;;
+    tmux) fm_backend_tmux_agent_started "$target" "$harness" ;;
     herdr) fm_backend_herdr_agent_started "$target" "$harness" ;;
     *) return 1 ;;
   esac

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -900,12 +900,12 @@ fm_backend_agent_state() {  # <backend> <target>
 # Recovery state is intentionally conservative against duplicate launches and
 # may accept a stale agent-shaped title; lifecycle success needs this stricter
 # foreground-process proof.
-fm_backend_agent_started() {  # <backend> <target>
-  local backend=$1 target=$2
+fm_backend_agent_started() {  # <backend> <target> <harness>
+  local backend=$1 target=$2 harness=$3
   fm_backend_source "$backend" || return 1
   case "$backend" in
     tmux) fm_backend_tmux_agent_started "$target" ;;
-    herdr) fm_backend_herdr_agent_started "$target" ;;
+    herdr) fm_backend_herdr_agent_started "$target" "$harness" ;;
     *) return 1 ;;
   esac
 }

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -345,7 +345,7 @@ wait_agent_state() {  # <timeout> <wanted>...
 wait_replacement_agent() {  # <timeout>
   local timeout=$1 state elapsed=0 confirmations=0
   while :; do
-    if fm_backend_agent_started "$BACKEND" "$T"; then
+    if fm_backend_agent_started "$BACKEND" "$T" "$TARGET_HARNESS"; then
       confirmations=$((confirmations + 1))
       if [ "$confirmations" -ge 2 ]; then
         printf 'alive'

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -342,6 +342,28 @@ wait_agent_state() {  # <timeout> <wanted>...
   return 1
 }
 
+wait_replacement_agent() {  # <timeout>
+  local timeout=$1 state elapsed=0 confirmations=0
+  while :; do
+    if fm_backend_agent_started "$BACKEND" "$T"; then
+      confirmations=$((confirmations + 1))
+      if [ "$confirmations" -ge 2 ]; then
+        printf 'alive'
+        return 0
+      fi
+    else
+      confirmations=0
+    fi
+    state=$(agent_state)
+    [ "$state" != alive ] || state=unconfirmed
+    awk -v e="$elapsed" -v t="$timeout" 'BEGIN{exit !(e < t)}' || break
+    sleep "$POLL"
+    elapsed=$(awk -v e="$elapsed" -v p="$POLL" 'BEGIN{printf "%.3f", e + p}')
+  done
+  printf '%s' "$state"
+  return 1
+}
+
 require_state_verified_backend() {  # <verb>
   fm_control_backend_state_verified "$BACKEND" && return 0
   die "task $ID runs on the $BACKEND backend, which has no recovery-grade agent-state classifier, so '$1' cannot prove the agent actually stopped; refusing rather than reporting an unproven transition as done"
@@ -839,7 +861,7 @@ do_relaunch() {
     die "the replacement agent for $ID could not be launched on $TARGET_HARNESS"
   fi
 
-  state=$(wait_agent_state "$LAUNCH_WAIT" alive) || {
+  state=$(wait_replacement_agent "$LAUNCH_WAIT") || {
     die "the replacement agent for $ID did not come up within ${LAUNCH_WAIT}s (endpoint reads '$state')"
   }
   RELAUNCH_AGENT_CONFIRMED=1

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -59,6 +59,7 @@ fm_harness_selected_executable_matches() {  # <harness> <comm> [argv0]
     case "$harness" in
       claude|codex|opencode|grok)
         [ "$base" = "$harness" ] && return 0
+        [ "$harness:$base" = codex:codex-aarch64-a ] && return 0
         name=$(fm_harness_path_name "$value" 2>/dev/null) || name=
         [ "$name" = "$harness" ] && return 0
         ;;

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Shared session-lock harness identity.
+# Shared verified-harness executable and session-lock identity.
 #
-# ONE owner of the "which verified-harness process holds this home's session
-# lock, and does the current process descend from that same harness?" decision.
+# ONE owner of selected-harness executable matching and of the "which
+# verified-harness process holds this home's session lock, and does the current
+# process descend from that same harness?" decision.
+# Backend replacement-start probes use the selected-executable matchers;
 # bin/fm-lock.sh uses it to acquire and inspect state/.lock;
 # bin/fm-claude-stop-autoarm.sh uses it to prove a Stop hook fires inside the
 # lock-owning primary session before it may arm or rewake.

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -45,6 +45,56 @@ fm_harness_path_name() {  # <path>
   return 1
 }
 
+fm_harness_selected_executable_matches() {  # <harness> <comm> [argv0]
+  local harness=$1 comm=$2 argv0=${3:-} value base name
+  [ -n "$harness" ] || return 1
+  if [ "$harness" = cursor ]; then
+    fm_cursor_process_matches "$comm" '' "$argv0"
+    return
+  fi
+  for value in "$comm" "$argv0"; do
+    [ -n "$value" ] || continue
+    base=${value##*/}
+    base=${base#-}
+    case "$harness" in
+      claude|codex|opencode|grok)
+        [ "$base" = "$harness" ] && return 0
+        name=$(fm_harness_path_name "$value" 2>/dev/null) || name=
+        [ "$name" = "$harness" ] && return 0
+        ;;
+      kimi)
+        case "$base" in kimi|kimi-code) return 0 ;; esac
+        name=$(fm_harness_path_name "$value" 2>/dev/null) || name=
+        [ "$name" = kimi ] && return 0
+        ;;
+      pi|pi-signed)
+        case "$base" in pi|pi-signed|pi-launcher|Pi) return 0 ;; esac
+        name=$(fm_harness_path_name "$value" 2>/dev/null) || name=
+        case "$name" in pi|pi-signed) return 0 ;; esac
+        ;;
+      muse)
+        case "$base" in muse|muse-bin-*) return 0 ;; esac
+        case "/$value/" in */muse/*) return 0 ;; esac
+        ;;
+      *) return 1 ;;
+    esac
+  done
+  return 1
+}
+
+fm_harness_selected_interpreter_script_matches() {  # <harness> <comm> <argv0> <script>
+  local harness=$1 comm=$2 argv0=$3 script=$4 value base
+  [ "$harness" = cursor ] || return 1
+  for value in "$comm" "$argv0"; do
+    base=${value##*/}
+    base=${base#-}
+    case "$base" in
+      node|node-*|node[0-9]*) fm_cursor_path_is_cursor "$script" && return 0 ;;
+    esac
+  done
+  return 1
+}
+
 # True when the process described by command name $1 and full argument string $2
 # is a verified harness. Sets FM_HARNESS_IS_CLAUDE for the ancestry walk.
 #

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -195,8 +195,9 @@
 # docs/configuration.md and bin/fm-trace-context-lib.sh), the meta also records
 # one W3C traceparent= carrier, the same value injected into the pane as
 # TRACEPARENT. A fresh default-off spawn writes neither and leaves the launch
-# environment unchanged; a default-off relaunch clears any leftover pane value
-# in the same submitted shell program that runs the unchanged raw launch.
+# environment unchanged; a default-off relaunch strips any leftover pane value
+# from the replacement's environment in the same submitted program that runs
+# the unchanged raw launch.
 #   --traceparent <carrier> delivers a carrier that a REMOTE parent already
 #   resolved and will record, instead of resolving one from this home's frozen
 #   decision. It is accepted only for --secondmate spawns, only as a strictly
@@ -2184,34 +2185,24 @@ spawn_send_text_line() {  # <target> <text>
 }
 spawn_bind_tracefree_launch() {
   local probe="$TASK_TMP/pane-shell.$SPAWN_GEN" proof="$TASK_TMP/traceparent-cleared.$SPAWN_GEN"
-  local command pane_shell i=0
+  local command pane_shell pane_shell_name i=0
   SPAWN_TRACEPARENT_PROOF=
   rm -f "$probe" "$proof"
-  command="sh -c 'ps -p \"\$PPID\" -o comm= > \"\$1\"' sh $(shell_quote "$probe")"
+  command="/bin/sh -c 'name=\$(ps -p \"\$PPID\" -o comm= | tr -d \"[:space:]\") || exit; name=\${name##*/}; name=\${name#-}; command -v \"\$name\" > \"\$1\"' sh $(shell_quote "$probe")"
   spawn_send_text_line "$T" "$command" || { rm -f "$probe" "$proof"; return 1; }
   while [ ! -s "$probe" ] && [ "$i" -lt 20 ]; do
     sleep 0.1
     i=$((i + 1))
   done
   [ -s "$probe" ] || { rm -f "$probe" "$proof"; return 1; }
-  pane_shell=$(tr -d '[:space:]' < "$probe")
-  pane_shell=${pane_shell##*/}
-  pane_shell=${pane_shell#-}
-  case "$pane_shell" in
-    fish)
-      LAUNCH="set -e TRACEPARENT; sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof"); and begin; $LAUNCH; end"
-      ;;
-    sh|bash|zsh|dash|ash|ksh|mksh)
-      LAUNCH="unset TRACEPARENT && sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof") && { $LAUNCH; }"
-      ;;
-    csh|tcsh)
-      LAUNCH="unsetenv TRACEPARENT && sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof") && ( $LAUNCH )"
-      ;;
-    *)
-      rm -f "$probe" "$proof"
-      return 1
-      ;;
+  IFS= read -r pane_shell < "$probe" || { rm -f "$probe" "$proof"; return 1; }
+  pane_shell_name=${pane_shell##*/}
+  case "$pane_shell_name" in
+    sh|bash|zsh|dash|ash|ksh|mksh|fish|csh|tcsh) : ;;
+    *) rm -f "$probe" "$proof"; return 1 ;;
   esac
+  [ -x "$pane_shell" ] || { rm -f "$probe" "$proof"; return 1; }
+  LAUNCH="env -u TRACEPARENT /bin/sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\" && exec \"\$2\" -c \"\$3\"' sh $(shell_quote "$proof") $(shell_quote "$pane_shell") $(shell_quote "$LAUNCH")"
   rm -f "$probe"
   SPAWN_TRACEPARENT_PROOF=$proof
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1099,6 +1099,10 @@ shell_quote() {
   printf "'"
 }
 
+spawn_clear_launch_traceparent() {
+  LAUNCH="env -u TRACEPARENT \"\$SHELL\" -c $(shell_quote "$LAUNCH")"
+}
+
 resolve_pi_executable() {
   local candidate dir
   candidate=$(type -P -- "$1" 2>/dev/null) || return 1
@@ -2833,7 +2837,7 @@ if [ "$KIND" = secondmate ]; then
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=$sq_primary_home FM_HOME=$sq_home FM_TRACE_CONTEXT=$SPAWN_TRACE_EFFECTIVE FM_SUPERVISION_MODEL=$supervision_model $LAUNCH"
 fi
 if [ -z "$SPAWN_TRACEPARENT" ] && [ "$RELAUNCH" -eq 1 ]; then
-  LAUNCH="env -u TRACEPARENT $LAUNCH"
+  spawn_clear_launch_traceparent
 fi
 
 spawn_record_traceparent() {
@@ -2865,7 +2869,7 @@ spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 if [ -n "$SPAWN_TRACEPARENT" ]; then
   if spawn_send_text_line "$T" "export TRACEPARENT=$SPAWN_TRACEPARENT"; then
     if ! spawn_record_traceparent; then
-      LAUNCH="env -u TRACEPARENT $LAUNCH"
+      spawn_clear_launch_traceparent
     fi
   else
     TRACE_SEND_STATUS=$?
@@ -2873,7 +2877,7 @@ if [ -n "$SPAWN_TRACEPARENT" ]; then
       echo "error: trace-context input could not be cleared for $W; refusing to append the launch command" >&2
       exit 1
     fi
-    LAUNCH="env -u TRACEPARENT $LAUNCH"
+    spawn_clear_launch_traceparent
   fi
 fi
 sleep 0.3

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2833,7 +2833,7 @@ if [ "$KIND" = secondmate ]; then
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=$sq_primary_home FM_HOME=$sq_home FM_TRACE_CONTEXT=$SPAWN_TRACE_EFFECTIVE FM_SUPERVISION_MODEL=$supervision_model $LAUNCH"
 fi
 if [ -z "$SPAWN_TRACEPARENT" ] && [ "$RELAUNCH" -eq 1 ]; then
-  LAUNCH="unset TRACEPARENT; $LAUNCH"
+  LAUNCH="env -u TRACEPARENT $LAUNCH"
 fi
 
 spawn_record_traceparent() {
@@ -2865,7 +2865,7 @@ spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 if [ -n "$SPAWN_TRACEPARENT" ]; then
   if spawn_send_text_line "$T" "export TRACEPARENT=$SPAWN_TRACEPARENT"; then
     if ! spawn_record_traceparent; then
-      LAUNCH="unset TRACEPARENT; $LAUNCH"
+      LAUNCH="env -u TRACEPARENT $LAUNCH"
     fi
   else
     TRACE_SEND_STATUS=$?
@@ -2873,7 +2873,7 @@ if [ -n "$SPAWN_TRACEPARENT" ]; then
       echo "error: trace-context input could not be cleared for $W; refusing to append the launch command" >&2
       exit 1
     fi
-    LAUNCH="unset TRACEPARENT; $LAUNCH"
+    LAUNCH="env -u TRACEPARENT $LAUNCH"
   fi
 fi
 sleep 0.3

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -676,6 +676,7 @@ SPAWN_META_LOCK=
 SPAWN_META_LOCK_HELD=0
 SPAWN_META_PUBLISH_STARTED=0
 SPAWN_TRACEPARENT_PROOF=
+SPAWN_TRACEFREE_SCRIPT=
 SPAWN_TASK_SET_LOCK=
 SPAWN_TASK_SET_LOCK_HELD=0
 RELAUNCH_REPLACEMENT_PENDING=0
@@ -793,6 +794,7 @@ spawn_abort_cleanup() {
   fi
   [ -z "$SPAWN_META_TMP" ] || rm -f "$SPAWN_META_TMP" 2>/dev/null || true
   [ -z "$SPAWN_TRACEPARENT_PROOF" ] || rm -f "$SPAWN_TRACEPARENT_PROOF" 2>/dev/null || true
+  [ -z "$SPAWN_TRACEFREE_SCRIPT" ] || rm -f "$SPAWN_TRACEFREE_SCRIPT" 2>/dev/null || true
   if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
     CONFIG_INHERIT_LOCK_HELD=0
     fm_lock_release "$CONFIG_INHERIT_LOCK" || true
@@ -2185,23 +2187,39 @@ spawn_send_text_line() {  # <target> <text>
 }
 spawn_bind_tracefree_launch() {
   local probe="$TASK_TMP/pane-shell.$SPAWN_GEN" proof="$TASK_TMP/traceparent-cleared.$SPAWN_GEN"
-  local command pane_shell pane_shell_name i=0
+  local command pane_shell pane_shell_name script sq_proof sq_script sq_launch i=0
   SPAWN_TRACEPARENT_PROOF=
+  SPAWN_TRACEFREE_SCRIPT=
   rm -f "$probe" "$proof"
   if [ "$RELAUNCH" -eq 1 ]; then
-    # Relaunches always use a generated POSIX launch template, independent of
-    # the interactive shell that happens to own the reused pane.
-    pane_shell=/bin/sh
-  else
-    command="/bin/sh -c 'name=\$(ps -p \"\$PPID\" -o comm= | tr -d \"[:space:]\") || exit; name=\${name##*/}; name=\${name#-}; command -v \"\$name\" > \"\$1\"' sh $(shell_quote "$probe")"
-    spawn_send_text_line "$T" "$command" || { rm -f "$probe" "$proof"; return 1; }
-    while [ ! -s "$probe" ] && [ "$i" -lt 20 ]; do
-      sleep 0.1
-      i=$((i + 1))
-    done
-    [ -s "$probe" ] || { rm -f "$probe" "$proof"; return 1; }
-    IFS= read -r pane_shell < "$probe" || { rm -f "$probe" "$proof"; return 1; }
+    # The reused pane sees only this argument-safe bootstrap. The generated
+    # POSIX launch stays in a file, so csh, fish, and other interactive shells
+    # never parse its quoting before /bin/sh does.
+    script=$(mktemp "$TASK_TMP/tracefree-launch.$SPAWN_GEN.XXXXXX") || return 1
+    sq_proof=$(shell_quote "$proof")
+    sq_script=$(shell_quote "$script")
+    sq_launch=$(shell_quote "$LAUNCH")
+    {
+      printf '%s\n' '#!/bin/sh'
+      # shellcheck disable=SC2016  # expansion belongs to the generated script
+      printf '%s\n' 'test -z "${TRACEPARENT+x}" || exit 1'
+      printf ': > %s\n' "$sq_proof"
+      printf 'rm -f %s\n' "$sq_script"
+      printf 'exec /bin/sh -c %s\n' "$sq_launch"
+    } > "$script" || { rm -f "$script" "$proof"; return 1; }
+    SPAWN_TRACEFREE_SCRIPT=$script
+    LAUNCH="/usr/bin/env -u TRACEPARENT /bin/sh $script"
+    SPAWN_TRACEPARENT_PROOF=$proof
+    return 0
   fi
+  command="/bin/sh -c 'name=\$(ps -p \"\$PPID\" -o comm= | tr -d \"[:space:]\") || exit; name=\${name##*/}; name=\${name#-}; command -v \"\$name\" > \"\$1\"' sh $(shell_quote "$probe")"
+  spawn_send_text_line "$T" "$command" || { rm -f "$probe" "$proof"; return 1; }
+  while [ ! -s "$probe" ] && [ "$i" -lt 20 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -s "$probe" ] || { rm -f "$probe" "$proof"; return 1; }
+  IFS= read -r pane_shell < "$probe" || { rm -f "$probe" "$proof"; return 1; }
   pane_shell_name=${pane_shell##*/}
   case "$pane_shell_name" in
     sh|bash|zsh|dash|ash|ksh|mksh|fish|csh|tcsh) : ;;
@@ -2220,7 +2238,9 @@ spawn_verify_traceparent_clear() {
   done
   [ -e "$SPAWN_TRACEPARENT_PROOF" ] && status=0
   rm -f "$SPAWN_TRACEPARENT_PROOF"
+  [ -z "$SPAWN_TRACEFREE_SCRIPT" ] || rm -f "$SPAWN_TRACEFREE_SCRIPT"
   SPAWN_TRACEPARENT_PROOF=
+  SPAWN_TRACEFREE_SCRIPT=
   return "$status"
 }
 spawn_current_path() {  # <target>

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -194,8 +194,9 @@
 # When the home session's frozen trace-context decision is enabled (see
 # docs/configuration.md and bin/fm-trace-context-lib.sh), the meta also records
 # one W3C traceparent= carrier, the same value injected into the pane as
-# TRACEPARENT; the default-off path writes neither, leaving the generated meta
-# and launch environment unchanged.
+# TRACEPARENT. A fresh default-off spawn writes neither and leaves the launch
+# environment unchanged; a default-off relaunch clears any leftover pane value
+# in the same submitted shell program that runs the unchanged raw launch.
 #   --traceparent <carrier> delivers a carrier that a REMOTE parent already
 #   resolved and will record, instead of resolving one from this home's frozen
 #   decision. It is accepted only for --secondmate spawns, only as a strictly

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2195,7 +2195,7 @@ spawn_clear_pane_traceparent() {
   pane_shell=${pane_shell#-}
   case "$pane_shell" in
     fish)
-      command="set -e TRACEPARENT; and sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof")"
+      command="set -e TRACEPARENT; sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof")"
       ;;
     sh|bash|zsh|dash|ash|ksh|mksh)
       command="unset TRACEPARENT && sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof")"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2188,14 +2188,20 @@ spawn_bind_tracefree_launch() {
   local command pane_shell pane_shell_name i=0
   SPAWN_TRACEPARENT_PROOF=
   rm -f "$probe" "$proof"
-  command="/bin/sh -c 'name=\$(ps -p \"\$PPID\" -o comm= | tr -d \"[:space:]\") || exit; name=\${name##*/}; name=\${name#-}; command -v \"\$name\" > \"\$1\"' sh $(shell_quote "$probe")"
-  spawn_send_text_line "$T" "$command" || { rm -f "$probe" "$proof"; return 1; }
-  while [ ! -s "$probe" ] && [ "$i" -lt 20 ]; do
-    sleep 0.1
-    i=$((i + 1))
-  done
-  [ -s "$probe" ] || { rm -f "$probe" "$proof"; return 1; }
-  IFS= read -r pane_shell < "$probe" || { rm -f "$probe" "$proof"; return 1; }
+  if [ "$RELAUNCH" -eq 1 ]; then
+    # Relaunches always use a generated POSIX launch template, independent of
+    # the interactive shell that happens to own the reused pane.
+    pane_shell=/bin/sh
+  else
+    command="/bin/sh -c 'name=\$(ps -p \"\$PPID\" -o comm= | tr -d \"[:space:]\") || exit; name=\${name##*/}; name=\${name#-}; command -v \"\$name\" > \"\$1\"' sh $(shell_quote "$probe")"
+    spawn_send_text_line "$T" "$command" || { rm -f "$probe" "$proof"; return 1; }
+    while [ ! -s "$probe" ] && [ "$i" -lt 20 ]; do
+      sleep 0.1
+      i=$((i + 1))
+    done
+    [ -s "$probe" ] || { rm -f "$probe" "$proof"; return 1; }
+    IFS= read -r pane_shell < "$probe" || { rm -f "$probe" "$proof"; return 1; }
+  fi
   pane_shell_name=${pane_shell##*/}
   case "$pane_shell_name" in
     sh|bash|zsh|dash|ash|ksh|mksh|fish|csh|tcsh) : ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -673,6 +673,7 @@ SPAWN_META_TMP=
 SPAWN_META_LOCK=
 SPAWN_META_LOCK_HELD=0
 SPAWN_META_PUBLISH_STARTED=0
+SPAWN_TRACEPARENT_PROOF=
 SPAWN_TASK_SET_LOCK=
 SPAWN_TASK_SET_LOCK_HELD=0
 RELAUNCH_REPLACEMENT_PENDING=0
@@ -789,6 +790,7 @@ spawn_abort_cleanup() {
     fm_lock_release "$SPAWN_CONTROL_LOCK" || true
   fi
   [ -z "$SPAWN_META_TMP" ] || rm -f "$SPAWN_META_TMP" 2>/dev/null || true
+  [ -z "$SPAWN_TRACEPARENT_PROOF" ] || rm -f "$SPAWN_TRACEPARENT_PROOF" 2>/dev/null || true
   if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
     CONFIG_INHERIT_LOCK_HELD=0
     fm_lock_release "$CONFIG_INHERIT_LOCK" || true
@@ -2179,12 +2181,13 @@ spawn_send_text_line() {  # <target> <text>
     cmux) fm_backend_cmux_send_text_line "$1" "$2" "$W" ;;
   esac
 }
-spawn_clear_pane_traceparent() {
+spawn_bind_tracefree_launch() {
   local probe="$TASK_TMP/pane-shell.$SPAWN_GEN" proof="$TASK_TMP/traceparent-cleared.$SPAWN_GEN"
-  local command pane_shell i=0 status=1
+  local command pane_shell i=0
+  SPAWN_TRACEPARENT_PROOF=
   rm -f "$probe" "$proof"
   command="sh -c 'ps -p \"\$PPID\" -o comm= > \"\$1\"' sh $(shell_quote "$probe")"
-  spawn_send_text_line "$T" "$command" || return 1
+  spawn_send_text_line "$T" "$command" || { rm -f "$probe" "$proof"; return 1; }
   while [ ! -s "$probe" ] && [ "$i" -lt 20 ]; do
     sleep 0.1
     i=$((i + 1))
@@ -2195,27 +2198,31 @@ spawn_clear_pane_traceparent() {
   pane_shell=${pane_shell#-}
   case "$pane_shell" in
     fish)
-      command="set -e TRACEPARENT; sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof")"
+      LAUNCH="set -e TRACEPARENT; sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof"); and begin; $LAUNCH; end"
       ;;
     sh|bash|zsh|dash|ash|ksh|mksh)
-      command="unset TRACEPARENT && sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof")"
+      LAUNCH="unset TRACEPARENT && sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof") && { $LAUNCH; }"
       ;;
     csh|tcsh)
-      command="unsetenv TRACEPARENT && sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof")"
+      LAUNCH="unsetenv TRACEPARENT && sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof") && ( $LAUNCH )"
       ;;
     *)
       rm -f "$probe" "$proof"
       return 1
       ;;
   esac
-  spawn_send_text_line "$T" "$command" || { rm -f "$probe" "$proof"; return 1; }
-  i=0
-  while [ ! -e "$proof" ] && [ "$i" -lt 20 ]; do
+  rm -f "$probe"
+  SPAWN_TRACEPARENT_PROOF=$proof
+}
+spawn_verify_traceparent_clear() {
+  local i=0 status=1
+  while [ ! -e "$SPAWN_TRACEPARENT_PROOF" ] && [ "$i" -lt 20 ]; do
     sleep 0.1
     i=$((i + 1))
   done
-  [ -e "$proof" ] && status=0
-  rm -f "$probe" "$proof"
+  [ -e "$SPAWN_TRACEPARENT_PROOF" ] && status=0
+  rm -f "$SPAWN_TRACEPARENT_PROOF"
+  SPAWN_TRACEPARENT_PROOF=
   return "$status"
 }
 spawn_current_path() {  # <target>
@@ -2916,8 +2923,8 @@ if [ -n "$SPAWN_TRACEPARENT" ]; then
     SPAWN_CLEAR_TRACEPARENT=1
   fi
 fi
-if [ "$SPAWN_CLEAR_TRACEPARENT" -eq 1 ] && ! spawn_clear_pane_traceparent; then
-  echo "error: could not verify TRACEPARENT was cleared in $W; refusing to append the launch command" >&2
+if [ "$SPAWN_CLEAR_TRACEPARENT" -eq 1 ] && ! spawn_bind_tracefree_launch; then
+  echo "error: could not prepare verified TRACEPARENT clearing in $W; refusing to append the launch command" >&2
   exit 1
 fi
 sleep 0.3
@@ -2928,6 +2935,10 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   spawn_herdr_presentation_order_lock_release
 fi
 spawn_send_key "$T" Enter
+if [ "$SPAWN_CLEAR_TRACEPARENT" -eq 1 ] && ! spawn_verify_traceparent_clear; then
+  echo "error: could not verify TRACEPARENT was cleared in $W; replacement launch refused" >&2
+  exit 1
+fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1099,10 +1099,6 @@ shell_quote() {
   printf "'"
 }
 
-spawn_clear_launch_traceparent() {
-  LAUNCH="env -u TRACEPARENT \"\$SHELL\" -c $(shell_quote "$LAUNCH")"
-}
-
 resolve_pi_executable() {
   local candidate dir
   candidate=$(type -P -- "$1" 2>/dev/null) || return 1
@@ -2183,6 +2179,45 @@ spawn_send_text_line() {  # <target> <text>
     cmux) fm_backend_cmux_send_text_line "$1" "$2" "$W" ;;
   esac
 }
+spawn_clear_pane_traceparent() {
+  local probe="$TASK_TMP/pane-shell.$SPAWN_GEN" proof="$TASK_TMP/traceparent-cleared.$SPAWN_GEN"
+  local command pane_shell i=0 status=1
+  rm -f "$probe" "$proof"
+  command="sh -c 'ps -p \"\$PPID\" -o comm= > \"\$1\"' sh $(shell_quote "$probe")"
+  spawn_send_text_line "$T" "$command" || return 1
+  while [ ! -s "$probe" ] && [ "$i" -lt 20 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -s "$probe" ] || { rm -f "$probe" "$proof"; return 1; }
+  pane_shell=$(tr -d '[:space:]' < "$probe")
+  pane_shell=${pane_shell##*/}
+  pane_shell=${pane_shell#-}
+  case "$pane_shell" in
+    fish)
+      command="set -e TRACEPARENT; and sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof")"
+      ;;
+    sh|bash|zsh|dash|ash|ksh|mksh)
+      command="unset TRACEPARENT && sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof")"
+      ;;
+    csh|tcsh)
+      command="unsetenv TRACEPARENT && sh -c 'test -z \"\${TRACEPARENT+x}\" && : > \"\$1\"' sh $(shell_quote "$proof")"
+      ;;
+    *)
+      rm -f "$probe" "$proof"
+      return 1
+      ;;
+  esac
+  spawn_send_text_line "$T" "$command" || { rm -f "$probe" "$proof"; return 1; }
+  i=0
+  while [ ! -e "$proof" ] && [ "$i" -lt 20 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$proof" ] && status=0
+  rm -f "$probe" "$proof"
+  return "$status"
+}
 spawn_current_path() {  # <target>
   case "$BACKEND" in
     tmux) fm_backend_tmux_current_path "$1" ;;
@@ -2691,6 +2726,7 @@ else
     SPAWN_TRACEPARENT=
   fi
 fi
+SPAWN_CLEAR_TRACEPARENT=0
 
 META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
@@ -2837,7 +2873,7 @@ if [ "$KIND" = secondmate ]; then
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=$sq_primary_home FM_HOME=$sq_home FM_TRACE_CONTEXT=$SPAWN_TRACE_EFFECTIVE FM_SUPERVISION_MODEL=$supervision_model $LAUNCH"
 fi
 if [ -z "$SPAWN_TRACEPARENT" ] && [ "$RELAUNCH" -eq 1 ]; then
-  spawn_clear_launch_traceparent
+  SPAWN_CLEAR_TRACEPARENT=1
 fi
 
 spawn_record_traceparent() {
@@ -2869,7 +2905,7 @@ spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 if [ -n "$SPAWN_TRACEPARENT" ]; then
   if spawn_send_text_line "$T" "export TRACEPARENT=$SPAWN_TRACEPARENT"; then
     if ! spawn_record_traceparent; then
-      spawn_clear_launch_traceparent
+      SPAWN_CLEAR_TRACEPARENT=1
     fi
   else
     TRACE_SEND_STATUS=$?
@@ -2877,8 +2913,12 @@ if [ -n "$SPAWN_TRACEPARENT" ]; then
       echo "error: trace-context input could not be cleared for $W; refusing to append the launch command" >&2
       exit 1
     fi
-    spawn_clear_launch_traceparent
+    SPAWN_CLEAR_TRACEPARENT=1
   fi
+fi
+if [ "$SPAWN_CLEAR_TRACEPARENT" -eq 1 ] && ! spawn_clear_pane_traceparent; then
+  echo "error: could not verify TRACEPARENT was cleared in $W; refusing to append the launch command" >&2
+  exit 1
 fi
 sleep 0.3
 spawn_send_literal "$T" "$LAUNCH"

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -32,7 +32,7 @@ A recorded `harness=` is not always an exact adapter name: a task launched from 
 | --- | --- | --- |
 | `interrupt` | Deliver the harness's verified interrupt sequence while leaving the agent running. | Delivery succeeds while the endpoint still exists and the agent is still alive where the backend can classify that; cancellation is confirmed only from an adapter-owned acknowledgement and otherwise reports `cancel=unconfirmed`. |
 | `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone. Already-stopped is idempotent success. |
-| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, and effort. | The new agent is alive on the recorded endpoint, and the durable record names the harness that is actually running. |
+| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, and effort. | The selected replacement agent satisfies the fail-closed positive-start proof, and the durable record names the harness that is actually running. |
 
 An exit that delivers lifecycle input but cannot prove the agent stopped fails with `exit=unconfirmed`, reports the observed agent state and any interrupt cancellation claim, and never claims that nothing changed.
 Interrupt never rewrites busy state as proof of its own success.
@@ -69,7 +69,8 @@ It is not deterministic across the verified adapters: codex and grok resume only
    A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation; the note is appended to the instructions it reads.
    A secondmate relaunch does not require one and never rewrites its standing charter.
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
-5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+5. **Launch and confirm the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+   The control plane then enforces the relaunch postcondition above before reporting success.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
 
@@ -77,7 +78,7 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
 
 - A refusal **before** the agent is stopped leaves the durable record and the instructions byte-identical.
 - A launch failure **after** the agent is stopped restores the prior durable record, keeps the progress note so a later recovery still has it, marks the journal `failed:launching`, and reports plainly that no agent is running and where the work is preserved.
-- If the launch owner already published the new record but no running agent can be confirmed, the new record is kept: the task is recorded on the new harness with no agent confirmed, which is exactly what recovery reconciles.
+- If the launch owner already published the new record but the selected replacement agent cannot be confirmed, the new record is kept: the task is recorded on the new harness with no agent confirmed, which is exactly what recovery reconciles.
   Rewriting it back to the old harness would be a second, worse inaccuracy.
 
 ## Fail-closed boundaries
@@ -96,6 +97,8 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
   Orca's terminal API exposes only an interrupt and an Enter, so it can deliver neither Escape nor Ctrl+U.
 - `exit` and `relaunch` require a backend with a recovery-grade agent-state classifier - tmux and herdr - because without one the "the agent stopped" postcondition cannot be proven.
   zellij, orca, and cmux are refused rather than reported as successful blind.
+- Relaunch success uses a stricter positive proof than recovery liveness: exact target membership and the selected harness's foreground executable identity must be observed on two consecutive polls.
+  A surviving shell, stale agent-shaped title, background harness process, wrong harness, or unrelated argument text cannot satisfy it.
 - An ambiguous or unreadable endpoint state refuses.
   Only a positively classified state acts.
 - `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
@@ -118,5 +121,5 @@ The empirical basis for each adapter's value is the `harness-adapters` skill's v
 ## Verification
 
 - `tests/fm-control.test.sh` - the adapter contract for every verified harness, the backend capability matrix, exact-id scoping, the closed verb list, the busy, idle, dead, and idempotent lifecycle cases, and marker non-regression, all against a stubbed session provider.
-- `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, the progress note, checkpoint refusals, and rollback after a failed launch.
+- `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, the progress note, checkpoint refusals, selected-harness foreground proof, Fish-safe trace clearing, and rollback after a failed launch.
 - `tests/fm-control-herdr-smoke.test.sh` - the second state-verified backend against the real herdr binary, on an isolated throwaway lab session.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -41,7 +41,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` `@AGENTS.md` pointer, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
-| `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
+| `fm-session-lock-lib.sh` | Shared verified-harness executable identity for session locks and replacement-start proof |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |

--- a/docs/trace-context.md
+++ b/docs/trace-context.md
@@ -100,9 +100,9 @@ This is a deliberate, source-owned choice:
   There is no configured provider command, no network, and no watchdog.
   The normal cost is small, but `od`/`tr` are external processes, so there is no hard latency guarantee - this is not a guaranteed-negligible bound.
   Any entropy or self-validation failure that returns omits the carrier for that spawn without aborting source work; a corrupt recorded carrier is re-minted as a fresh root rather than propagated (it is not an omission).
-  If the pre-launch carrier export fails, or recording the carrier fails after export, Firstmate clears `TRACEPARENT` in the detected existing pane interpreter and requires positive proof that it is absent before appending the unchanged launch program.
-  This preserves that pane interpreter's parsing of raw launch programs, including builtins and compound commands, instead of converting them into environment-command arguments.
-  A failed shell detection, clear, or proof refuses the launch; a proven clear omits the `traceparent=` metadata claim and still launches the task, so the child never receives an identity absent from its metadata.
+  If the pre-launch carrier export fails, or recording the carrier fails after export, Firstmate binds the `TRACEPARENT` clear, absence proof, and unchanged raw launch into one program for the detected existing pane interpreter.
+  The launch runs only after that in-program proof, so an interactive prompt hook cannot restore the carrier between proof and launch, and builtins or compound commands keep the pane interpreter's parsing context.
+  A failed shell detection, submission, clear, or proof refuses the launch; a proven clear omits the `traceparent=` metadata claim and still launches the task, so the child never receives an identity absent from its metadata.
 - **Metadata-only.**
   The value lives in the ephemeral pane shell and in `state/<id>.meta`; teardown removes state as before, so there is no new durable surface and no schema migration.
 

--- a/docs/trace-context.md
+++ b/docs/trace-context.md
@@ -88,9 +88,9 @@ This is a deliberate, source-owned choice:
 ## Safety
 
 - **Default-off.**
-  With no `config/trace-context` and no `FM_TRACE_CONTEXT`, a fresh spawn injects nothing, while an actual relaunch removes any leftover `TRACEPARENT` from its reused pane before launch; neither path writes a `traceparent=` line.
+  With no `config/trace-context` and no `FM_TRACE_CONTEXT`, a fresh spawn injects nothing, while an actual relaunch removes any leftover `TRACEPARENT` from the replacement's launch environment; neither path writes a `traceparent=` line.
   Reusing an already-alive remote endpoint records any carrier that endpoint reports without injecting a new one.
-  A locked session start makes the one config-file check, and each spawn sources one extra library and reads the frozen effective-state file; for a fresh trace-off spawn, nothing an agent, an observer, or the task meta can see differs, while a relaunch has only the deliberate removal of stale pane context.
+  A locked session start makes the one config-file check, and each spawn sources one extra library and reads the frozen effective-state file; for a fresh trace-off spawn, nothing an agent, an observer, or the task meta can see differs, while a relaunch has only the deliberate removal of stale launch context.
 - **What is and is not exposed.**
   A Firstmate-*minted* root uses a random id and reads no prompt, path, task prose, credential, or arbitrary environment key, so Firstmate never *originates* sensitive data in the carrier.
   Every carrier Firstmate injects is either such a mint or the same task's previously recorded carrier reused verbatim; ambient `TRACEPARENT` is never read, so no caller-controlled bytes enter a new carrier.
@@ -101,7 +101,7 @@ This is a deliberate, source-owned choice:
   The normal cost is small, but `od`/`tr` are external processes, so there is no hard latency guarantee - this is not a guaranteed-negligible bound.
   Any entropy or self-validation failure that returns omits the carrier for that spawn without aborting source work; a corrupt recorded carrier is re-minted as a fresh root rather than propagated (it is not an omission).
   If the pre-launch carrier export fails, or recording the carrier fails after export, Firstmate binds the `TRACEPARENT` clear, absence proof, and unchanged raw launch into one program for the detected existing pane interpreter.
-  The launch runs only after that in-program proof, so an interactive prompt hook cannot restore the carrier between proof and launch, and builtins or compound commands keep the pane interpreter's parsing context.
+  The launch runs only after that in-program proof, so an interactive prompt hook cannot restore the carrier between proof and launch, and builtins or compound commands are still parsed by the detected pane interpreter.
   A failed shell detection, submission, clear, or proof refuses the launch; a proven clear omits the `traceparent=` metadata claim and still launches the task, so the child never receives an identity absent from its metadata.
 - **Metadata-only.**
   The value lives in the ephemeral pane shell and in `state/<id>.meta`; teardown removes state as before, so there is no new durable surface and no schema migration.

--- a/docs/trace-context.md
+++ b/docs/trace-context.md
@@ -88,9 +88,9 @@ This is a deliberate, source-owned choice:
 ## Safety
 
 - **Default-off.**
-  With no `config/trace-context` and no `FM_TRACE_CONTEXT`, a fresh spawn or actual relaunch injects nothing and writes no `traceparent=` line, so the generated meta and the launch environment are unchanged.
+  With no `config/trace-context` and no `FM_TRACE_CONTEXT`, a fresh spawn injects nothing, while an actual relaunch removes any leftover `TRACEPARENT` from its reused pane before launch; neither path writes a `traceparent=` line.
   Reusing an already-alive remote endpoint records any carrier that endpoint reports without injecting a new one.
-  A locked session start makes the one config-file check, and each spawn sources one extra library and reads the frozen effective-state file, so the process is not literally byte-for-byte identical, but nothing an agent, an observer, or the task meta can see differs.
+  A locked session start makes the one config-file check, and each spawn sources one extra library and reads the frozen effective-state file; for a fresh trace-off spawn, nothing an agent, an observer, or the task meta can see differs, while a relaunch has only the deliberate removal of stale pane context.
 - **What is and is not exposed.**
   A Firstmate-*minted* root uses a random id and reads no prompt, path, task prose, credential, or arbitrary environment key, so Firstmate never *originates* sensitive data in the carrier.
   Every carrier Firstmate injects is either such a mint or the same task's previously recorded carrier reused verbatim; ambient `TRACEPARENT` is never read, so no caller-controlled bytes enter a new carrier.
@@ -100,9 +100,9 @@ This is a deliberate, source-owned choice:
   There is no configured provider command, no network, and no watchdog.
   The normal cost is small, but `od`/`tr` are external processes, so there is no hard latency guarantee - this is not a guaranteed-negligible bound.
   Any entropy or self-validation failure that returns omits the carrier for that spawn without aborting source work; a corrupt recorded carrier is re-minted as a fresh root rather than propagated (it is not an omission).
-  If the pre-launch carrier export fails, Firstmate omits the `traceparent=` metadata claim and still launches the task.
-  If the backend reports that failed trace input could not be cleared, Firstmate refuses to append the launch command rather than risk launching with an unknown partial carrier.
-  If recording the carrier fails after export, Firstmate unsets `TRACEPARENT` in the launch command and still launches the task, so the child never receives an identity absent from its metadata.
+  If the pre-launch carrier export fails, or recording the carrier fails after export, Firstmate clears `TRACEPARENT` in the detected existing pane interpreter and requires positive proof that it is absent before appending the unchanged launch program.
+  This preserves that pane interpreter's parsing of raw launch programs, including builtins and compound commands, instead of converting them into environment-command arguments.
+  A failed shell detection, clear, or proof refuses the launch; a proven clear omits the `traceparent=` metadata claim and still launches the task, so the child never receives an identity absent from its metadata.
 - **Metadata-only.**
   The value lives in the ephemeral pane shell and in `state/<id>.meta`; teardown removes state as before, so there is no new durable surface and no schema migration.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -95,6 +95,15 @@ ok - harness liveness: claude 2.1.220 (Claude Code) classifies alive
 # checked 7 installed harness(es)
 ```
 
+The stricter foreground-process replacement-start proof was reverified on 2026-08-29 with the same command against every installed harness on the machine.
+
+```text
+ok - harness liveness: claude 2.1.220 (Claude Code) classifies alive
+ok - harness liveness: codex codex-cli 0.146.0 classifies alive
+ok - harness liveness: pi 0.84.4 classifies alive
+# checked 3 installed harness(es)
+```
+
 Installed-wrapper checks:
 
 ```sh

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -178,7 +178,7 @@ Both recorded runtime identities now classify the exact `pi-launcher` foreground
 
 Backend applicability was reviewed across every spawn adapter.
 Tmux needs the exact `pi-launcher`, `pi-signed`, `pi`, and `Pi` process identities for recovery-grade liveness.
-Herdr uses native registered-agent state and needs no process-name branch.
+Herdr corroborates native registered-agent state with matching foreground process identity.
 Zellij has no verified recovery-grade agent process probe, while Orca and cmux do not support secondmate spawns, so those three retain their existing generic ordinary-launch semantics without a new liveness matcher.
 
 The current classifier matrix and its refresh guard are recorded in [Composer classification matrix](#composer-classification-matrix), with portable shape coverage in `tests/fm-composer-lib.test.sh` and `tests/fm-composer-ghost.test.sh`.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -95,7 +95,7 @@ ok - harness liveness: claude 2.1.220 (Claude Code) classifies alive
 # checked 7 installed harness(es)
 ```
 
-The stricter foreground-process replacement-start proof was reverified on 2026-08-29 with the same command against every installed harness on the machine.
+The stricter tmux foreground-process replacement-start proof was reverified on 2026-08-29 with the same command against every installed harness on the machine.
 
 ```text
 ok - harness liveness: claude 2.1.220 (Claude Code) classifies alive
@@ -178,7 +178,7 @@ Both recorded runtime identities now classify the exact `pi-launcher` foreground
 
 Backend applicability was reviewed across every spawn adapter.
 Tmux needs the exact `pi-launcher`, `pi-signed`, `pi`, and `Pi` process identities for recovery-grade liveness.
-Herdr corroborates native registered-agent state with matching foreground process identity.
+Herdr's replacement-start proof corroborates native registered-agent state with matching foreground process identity.
 Zellij has no verified recovery-grade agent process probe, while Orca and cmux do not support secondmate spawns, so those three retain their existing generic ordinary-launch semantics without a new liveness matcher.
 
 The current classifier matrix and its refresh guard are recorded in [Composer classification matrix](#composer-classification-matrix), with portable shape coverage in `tests/fm-composer-lib.test.sh` and `tests/fm-composer-ghost.test.sh`.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2939,27 +2939,47 @@ test_current_path_reads_cwd() {
   pass "fm_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd"
 }
 
-test_agent_started_rejects_a_registered_shell_and_accepts_a_foreground_agent() {
+test_agent_started_rejects_unrelated_foreground_processes_and_accepts_the_registered_agent() {
   local dir log resp fb
   dir="$TMP_ROOT/agent-started-shell"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out"
-  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":42}}}\n' > "$resp/3.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":42,"foreground_processes":[{"name":"zsh","argv0":"zsh"}]}}}\n' > "$resp/3.out"
   fb=$(make_herdr_fakebin "$dir")
   if PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_started default:w1:p2' "$ROOT"; then
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_started default:w1:p2 pi' "$ROOT"; then
     fail "a registered Herdr agent over the endpoint shell must not prove replacement start"
+  fi
+
+  dir="$TMP_ROOT/agent-started-unrelated"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":43,"foreground_processes":[{"name":"sleep","argv0":"sleep"}]}}}\n' > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+  if PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_started default:w1:p2 pi' "$ROOT"; then
+    fail "a stale pi registration over a foreground sleep process must not prove replacement start"
+  fi
+
+  dir="$TMP_ROOT/agent-started-wrong-harness"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":43,"foreground_processes":[{"name":"pi","argv0":"/usr/local/bin/pi"}]}}}\n' > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+  if PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_started default:w1:p2 claude' "$ROOT"; then
+    fail "a foreground pi process must not prove a selected claude replacement start"
   fi
 
   dir="$TMP_ROOT/agent-started-live"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out"
-  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":43}}}\n' > "$resp/3.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":43,"foreground_processes":[{"name":"pi","argv0":"/usr/local/bin/pi"}]}}}\n' > "$resp/3.out"
   fb=$(make_herdr_fakebin "$dir")
   PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_started default:w1:p2' "$ROOT" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_started default:w1:p2 pi' "$ROOT" \
     || fail "a registered Herdr agent in its own foreground process group should prove replacement start"
-  pass "fm_backend_herdr_agent_started: a live shell is not a replacement agent, while a genuine foreground agent is"
+  pass "fm_backend_herdr_agent_started: only the registered foreground agent proves replacement start"
 }
 
 # --- busy_state (semantic agent state) ---------------------------------------
@@ -4556,7 +4576,7 @@ test_capture_preserves_pane_read_failure
 test_send_key_normalizes_and_targets_pane
 test_kill_is_best_effort
 test_current_path_reads_cwd
-test_agent_started_rejects_a_registered_shell_and_accepts_a_foreground_agent
+test_agent_started_rejects_unrelated_foreground_processes_and_accepts_the_registered_agent
 test_busy_state_working_maps_to_busy
 test_busy_state_done_and_blocked_map_to_idle
 test_busy_state_unknown_on_no_agent

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2939,6 +2939,29 @@ test_current_path_reads_cwd() {
   pass "fm_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd"
 }
 
+test_agent_started_rejects_a_registered_shell_and_accepts_a_foreground_agent() {
+  local dir log resp fb
+  dir="$TMP_ROOT/agent-started-shell"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":42}}}\n' > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+  if PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_started default:w1:p2' "$ROOT"; then
+    fail "a registered Herdr agent over the endpoint shell must not prove replacement start"
+  fi
+
+  dir="$TMP_ROOT/agent-started-live"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":43}}}\n' > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_started default:w1:p2' "$ROOT" \
+    || fail "a registered Herdr agent in its own foreground process group should prove replacement start"
+  pass "fm_backend_herdr_agent_started: a live shell is not a replacement agent, while a genuine foreground agent is"
+}
+
 # --- busy_state (semantic agent state) ---------------------------------------
 
 test_busy_state_working_maps_to_busy() {
@@ -4533,6 +4556,7 @@ test_capture_preserves_pane_read_failure
 test_send_key_normalizes_and_targets_pane
 test_kill_is_best_effort
 test_current_path_reads_cwd
+test_agent_started_rejects_a_registered_shell_and_accepts_a_foreground_agent
 test_busy_state_working_maps_to_busy
 test_busy_state_done_and_blocked_map_to_idle
 test_busy_state_unknown_on_no_agent

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2961,6 +2961,16 @@ test_agent_started_rejects_unrelated_foreground_processes_and_accepts_the_regist
     fail "a stale pi registration over a foreground sleep process must not prove replacement start"
   fi
 
+  dir="$TMP_ROOT/agent-started-substring"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"claude","agent_status":"idle"}}}\n' > "$resp/2.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":43,"foreground_processes":[{"name":"claude-bootstrap","argv0":"/tmp/claude-bootstrap"}]}}}\n' > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+  if PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_started default:w1:p2 claude' "$ROOT"; then
+    fail "a stale claude registration over /tmp/claude-bootstrap must not prove replacement start"
+  fi
+
   dir="$TMP_ROOT/agent-started-wrong-harness"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out"

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2954,7 +2954,7 @@ test_agent_started_rejects_unrelated_foreground_processes_and_accepts_the_regist
   dir="$TMP_ROOT/agent-started-unrelated"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out"
-  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":43,"foreground_processes":[{"name":"sleep","argv0":"sleep"}]}}}\n' > "$resp/3.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":43,"foreground_processes":[{"name":"sleep","argv0":"sleep","argv":["sleep","pi"]}]}}}\n' > "$resp/3.out"
   fb=$(make_herdr_fakebin "$dir")
   if PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_started default:w1:p2 pi' "$ROOT"; then
@@ -2964,7 +2964,7 @@ test_agent_started_rejects_unrelated_foreground_processes_and_accepts_the_regist
   dir="$TMP_ROOT/agent-started-wrong-harness"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out"
-  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":43,"foreground_processes":[{"name":"pi","argv0":"/usr/local/bin/pi"}]}}}\n' > "$resp/3.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":43,"foreground_processes":[{"name":"node","argv0":"/Applications/Pi Launcher.app/Contents/Resources/pi/pi-launcher","argv":["pi-launcher","pi"]}]}}}\n' > "$resp/3.out"
   fb=$(make_herdr_fakebin "$dir")
   if PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_started default:w1:p2 claude' "$ROOT"; then
@@ -2979,6 +2979,15 @@ test_agent_started_rejects_unrelated_foreground_processes_and_accepts_the_regist
   PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_started default:w1:p2 pi' "$ROOT" \
     || fail "a registered Herdr agent in its own foreground process group should prove replacement start"
+
+  dir="$TMP_ROOT/agent-started-interpreter"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"cursor","agent_status":"blocked"}}}\n' > "$resp/2.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_process_group_id":43,"foreground_processes":[{"name":"node","argv0":"node","argv":["node","/Users/example/.local/share/cursor-agent/versions/2026.08.11-e8db854/index.js"]}]}}}\n' > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_started default:w1:p2 cursor' "$ROOT" \
+    || fail "a verified Cursor interpreter script should prove replacement start"
   pass "fm_backend_herdr_agent_started: only the registered foreground agent proves replacement start"
 }
 

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -91,7 +91,7 @@ for _ in $(seq 1 100); do
 done
 [ "$SHELL_READY" = true ] || fail "the tmux task shell did not become ready"
 
-tmux send-keys -t "$TARGET" "cd /tmp && PS1='smoke\$ ' && clear && printf 'setup-%s\\n' ready" Enter
+tmux send-keys -t "$TARGET" "cd /tmp && clear && printf 'setup-%s\\n' ready" Enter
 wait_for_capture_text "$TARGET" "setup-ready" || fail "the tmux task shell did not complete setup"
 
 fm_backend_tmux_send_text_line "$TARGET" "printf 'captain-on-deck-%s\\n' line" \
@@ -126,7 +126,7 @@ pass "real tmux: fm_backend_tmux_send_literal + fm_backend_tmux_send_key Enter s
 # earliest lines scroll out of a small window) while a large one reaches back
 # far enough to still see the earliest line - the same -S -N bounding fm-peek.sh
 # and fm-watch.sh rely on for a bounded, cheap pane read.
-fm_backend_tmux_send_text_line "$TARGET" "for i in \$(seq 1 80); do echo tag-line-\$i; done"
+fm_backend_tmux_send_text_line "$TARGET" "seq -f 'tag-line-%g' 1 80"
 wait_for_capture_text "$TARGET" "tag-line-80" \
   || fail "the numbered output did not complete before capture"
 small=$(fm_backend_tmux_capture "$TARGET" 3) || fail "fm_backend_tmux_capture (small window) failed"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -74,6 +74,9 @@ case "${1:-}" in
     if [ "$literal" = 1 ]; then
       printf '%s\n' "$payload" >> "$D/literal"
       case "$payload" in
+        *'/traceparent-cleared.'*) printf '%s' "$payload" > "$D/pending-launch" ;;
+      esac
+      case "$payload" in
         /exit|/quit)
           printf 'zsh' > "$D/command"
           printf 'zsh' > "$D/foreground"
@@ -105,6 +108,12 @@ case "${1:-}" in
       case "$payload" in
         *'/pane-shell.'*|*'/traceparent-cleared.'*)
           TRACEPARENT=stale fish -c "$payload" >/dev/null 2>&1 || true
+          ;;
+        Enter)
+          if [ -f "$D/pending-launch" ]; then
+            TRACEPARENT=stale fish -c "$(cat "$D/pending-launch")" >/dev/null 2>&1 || true
+            rm -f "$D/pending-launch"
+          fi
           ;;
       esac
     fi
@@ -149,6 +158,7 @@ SH
 exit 0
 SH
   chmod +x "$fb/sleep"
+  fm_fake_exit0 "$fb" claude codex grok
 }
 
 # new_case <name> [id] -> echoes a case dir with a live claude ship task.
@@ -390,7 +400,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
 }
 
 test_disabled_relaunch_clears_prior_trace_context() {
-  local dir out rc clear launch
+  local dir out rc launch
   dir=$(new_case trace-off rl33)
   add_ship_task "$dir" rl33 claude
   printf '%s\n' 'traceparent=00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01' \
@@ -402,8 +412,6 @@ test_disabled_relaunch_clears_prior_trace_context() {
   expect_code 0 "$rc" "disabled relaunch should succeed"$'\n'"$out"
   [ -z "$(meta_field "$dir" rl33 traceparent)" ] \
     || fail "disabled relaunch must remove the prior trace carrier from metadata"
-  clear=$(grep 'traceparent-cleared' "$dir/fake/keys" | tail -1)
-  [ -n "$clear" ] || fail "disabled relaunch did not emit a verified pane-shell clear"
   launch=$(tail -1 "$dir/fake/literal")
   ! grep -q '^export TRACEPARENT=' "$dir/fake/literal" \
     || fail "disabled relaunch must not export a replacement trace carrier"
@@ -413,7 +421,7 @@ printf '%s' "${TRACEPARENT-unset}" > "$FM_FAKE_DIR/fish-traceparent"
 SH
   chmod +x "$dir/fakebin/claude"
   TRACEPARENT=stale PATH="$dir/fakebin:$PATH" FM_FAKE_DIR="$dir/fake" \
-    "$FISH_BIN" -c "$clear"$'\n'"$launch" >/dev/null 2>&1
+    "$FISH_BIN" -c "$launch" >/dev/null 2>&1
   [ "$(cat "$dir/fake/fish-traceparent")" = unset ] \
     || fail "the real fish launch retained stale TRACEPARENT"
   pass "fm-control relaunch: disabling tracing clears metadata and the existing fish pane context"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -19,6 +19,7 @@
 #      agent exited.
 #   7. Relaunch success requires a foreground agent, not a surviving shell with
 #      a stale agent-shaped terminal title.
+#   8. A generated replacement launch is not reparsed by a C shell.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -107,11 +108,11 @@ case "${1:-}" in
       esac
       case "$payload" in
         *'/pane-shell.'*|*'/traceparent-cleared.'*)
-          TRACEPARENT=stale fish -c "$payload" >/dev/null 2>&1 || true
+          TRACEPARENT=stale "${FM_FAKE_PANE_SHELL_EXEC:-fish}" -c "$payload" >/dev/null 2>&1 || true
           ;;
         Enter)
           if [ -f "$D/pending-launch" ]; then
-            TRACEPARENT=stale fish -c "$(cat "$D/pending-launch")" >/dev/null 2>&1 || true
+            TRACEPARENT=stale "${FM_FAKE_PANE_SHELL_EXEC:-fish}" -c "$(cat "$D/pending-launch")" >/dev/null 2>&1 || true
             rm -f "$D/pending-launch"
           fi
           ;;
@@ -148,6 +149,10 @@ fi
 if [ "${1:-}" = -p ] && [ "${2:-}" = 4242 ] && [ "${3:-}" = -o ] && [ "${4:-}" = args= ]; then
   cat "$FM_FAKE_DIR/foreground"
   printf '\n'
+  exit 0
+fi
+if [ -n "${FM_FAKE_PANE_SHELL:-}" ] && [ "${1:-}" = -p ] && [ "${3:-}" = -o ] && [ "${4:-}" = comm= ]; then
+  printf '%s\n' "$FM_FAKE_PANE_SHELL"
   exit 0
 fi
 exec /bin/ps "$@"
@@ -212,6 +217,8 @@ run_control() {  # <case-dir> <args...>
     FM_FAKE_META_WRITER_READY="${FM_FAKE_META_WRITER_READY:-}" \
     FM_FAKE_TRACE_EXPORTED="${FM_FAKE_TRACE_EXPORTED:-}" \
     FM_FAKE_STALE_LAUNCH_TITLE="${FM_FAKE_STALE_LAUNCH_TITLE:-}" \
+    FM_FAKE_PANE_SHELL="${FM_FAKE_PANE_SHELL:-}" \
+    FM_FAKE_PANE_SHELL_EXEC="${FM_FAKE_PANE_SHELL_EXEC:-}" \
     "$CONTROL" "$@" 2>&1
 }
 
@@ -425,6 +432,43 @@ SH
   [ "$(cat "$dir/fake/fish-traceparent")" = unset ] \
     || fail "the real fish launch retained stale TRACEPARENT"
   pass "fm-control relaunch: disabling tracing clears metadata and the replacement environment in fish"
+}
+
+test_generated_relaunch_is_not_reparsed_by_a_c_shell() {
+  local dir out rc result
+  dir=$(new_case c-shell rl37)
+  add_ship_task "$dir" rl37 claude
+  result="$dir/fake/c-shell-launch"
+  cat > "$dir/fakebin/csh" <<'SH'
+#!/usr/bin/env bash
+[ "${1:-}" = -c ] || exit 64
+command=${2:-}
+printf '%s\n' "$command" >> "$FM_FAKE_DIR/c-shell-commands"
+case "$command" in
+  /bin/sh\ -c\ *|env\ -u\ TRACEPARENT\ /bin/sh\ -c\ *) exec /bin/sh -c "$command" ;;
+  *) : > "$FM_FAKE_DIR/c-shell-reparsed-launch"; exit 64 ;;
+esac
+SH
+  chmod +x "$dir/fakebin/csh"
+  cat > "$dir/fakebin/claude" <<'SH'
+#!/usr/bin/env bash
+printf '%s|%s' "${TRACEPARENT-unset}" "$*" > "$FM_FAKE_DIR/c-shell-launch"
+SH
+  chmod +x "$dir/fakebin/claude"
+
+  out=$(FM_FAKE_PANE_SHELL=csh FM_FAKE_PANE_SHELL_EXEC="$dir/fakebin/csh" \
+    run_control "$dir" rl37 relaunch --model model-csh --effort high --note "cross-shell replacement"); rc=$?
+  expect_code 0 "$rc" "a generated relaunch from a C-shell pane should succeed"$'\n'"$out"
+  [ -s "$dir/fake/c-shell-commands" ] \
+    || fail "the C-shell fixture did not parse the submitted launch"
+  [ ! -e "$dir/fake/c-shell-reparsed-launch" ] \
+    || fail "the generated replacement command was reparsed by the C shell"
+  [ -s "$result" ] || fail "the replacement agent never started"
+  assert_contains "$(cat "$result")" "unset|" \
+    "the C-shell relaunch must clear TRACEPARENT from the replacement environment"
+  assert_contains "$(cat "$result")" "--model model-csh --effort high" \
+    "the shell-neutral relaunch must preserve model and effort flags"
+  pass "fm-control relaunch: a generated launch crosses a C-shell pane without C-shell reparsing"
 }
 
 test_relaunch_appends_the_progress_note_to_the_instructions() {
@@ -1389,6 +1433,7 @@ test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_serializes_concurrent_durable_metadata_publication
 test_disabled_relaunch_clears_prior_trace_context
+test_generated_relaunch_is_not_reparsed_by_a_c_shell
 test_relaunch_appends_the_progress_note_to_the_instructions
 test_relaunch_requires_a_note_for_a_ship_task
 test_harness_switch_moves_the_record_and_clears_prior_wiring

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -34,6 +34,7 @@ SPAWN="$ROOT/bin/fm-spawn.sh"
 PROMOTE="$ROOT/bin/fm-promote.sh"
 X_LINK="$ROOT/bin/fm-x-link.sh"
 FISH_BIN=$(command -v fish) || fail "fish is required for relaunch regressions"
+CSH_BIN=$(command -v csh) || fail "csh is required for relaunch regressions"
 # fm_test_tmproot's own cleanup trap fires when its command substitution exits,
 # so recreate the root before resolving it and clean it up from this file's trap.
 TMP_ROOT=$(fm_test_tmproot fm-control-relaunch)
@@ -75,7 +76,7 @@ case "${1:-}" in
     if [ "$literal" = 1 ]; then
       printf '%s\n' "$payload" >> "$D/literal"
       case "$payload" in
-        *'/traceparent-cleared.'*) printf '%s' "$payload" > "$D/pending-launch" ;;
+        *'/traceparent-cleared.'*|*'/tracefree-launch.'*) printf '%s' "$payload" > "$D/pending-launch" ;;
       esac
       case "$payload" in
         /exit|/quit)
@@ -83,7 +84,7 @@ case "${1:-}" in
           printf 'zsh' > "$D/foreground"
           [ -z "${FM_FAKE_EXIT_TRANSPORT_FAIL_AFTER_STOP:-}" ] || exit 1
           ;;
-        *'encode launch-brief'*)
+        *'encode launch-brief'*|*'/tracefree-launch.'*)
           cat "$D/becomes" > "$D/command"
           if [ -n "${FM_FAKE_STALE_LAUNCH_TITLE:-}" ]; then
             printf 'zsh' > "$D/foreground"
@@ -218,7 +219,7 @@ run_control() {  # <case-dir> <args...>
     FM_FAKE_TRACE_EXPORTED="${FM_FAKE_TRACE_EXPORTED:-}" \
     FM_FAKE_STALE_LAUNCH_TITLE="${FM_FAKE_STALE_LAUNCH_TITLE:-}" \
     FM_FAKE_PANE_SHELL="${FM_FAKE_PANE_SHELL:-}" \
-    FM_FAKE_PANE_SHELL_EXEC="${FM_FAKE_PANE_SHELL_EXEC:-}" \
+    FM_FAKE_PANE_SHELL_EXEC="${FM_FAKE_PANE_SHELL_EXEC:-$FISH_BIN}" \
     "$CONTROL" "$@" 2>&1
 }
 
@@ -317,7 +318,8 @@ test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint() {
   [ "$(journal_field "$dir" rl1 phase)" = complete ] \
     || fail "the transaction journal should end complete"
   assert_grep "/exit" "$dir/fake/literal" "the previous agent should have been exited"
-  assert_grep "encode launch-brief" "$dir/fake/literal" "the replacement should have been launched"
+  [ "$(cat "$dir/fake/foreground")" = claude ] \
+    || fail "the replacement agent should be running"
   pass "fm-control relaunch: a same-harness relaunch replaces the agent in the same endpoint and worktree"
 }
 
@@ -407,7 +409,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
 }
 
 test_disabled_relaunch_clears_prior_trace_context() {
-  local dir out rc launch
+  local dir out rc
   dir=$(new_case trace-off rl33)
   add_ship_task "$dir" rl33 claude
   printf '%s\n' 'traceparent=00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01' \
@@ -415,20 +417,18 @@ test_disabled_relaunch_clears_prior_trace_context() {
   printf '%s\n' "$$" > "$dir/home/state/.lock"
   printf '%s off\n' "$$" > "$dir/home/state/.trace-context-effective"
 
-  out=$(run_control "$dir" rl33 relaunch --note "crossing trace boundary"); rc=$?
-  expect_code 0 "$rc" "disabled relaunch should succeed"$'\n'"$out"
-  [ -z "$(meta_field "$dir" rl33 traceparent)" ] \
-    || fail "disabled relaunch must remove the prior trace carrier from metadata"
-  launch=$(tail -1 "$dir/fake/literal")
-  ! grep -q '^export TRACEPARENT=' "$dir/fake/literal" \
-    || fail "disabled relaunch must not export a replacement trace carrier"
   cat > "$dir/fakebin/claude" <<'SH'
 #!/usr/bin/env bash
 printf '%s' "${TRACEPARENT-unset}" > "$FM_FAKE_DIR/fish-traceparent"
 SH
   chmod +x "$dir/fakebin/claude"
-  TRACEPARENT=stale PATH="$dir/fakebin:$PATH" FM_FAKE_DIR="$dir/fake" \
-    "$FISH_BIN" -c "$launch" >/dev/null 2>&1
+
+  out=$(run_control "$dir" rl33 relaunch --note "crossing trace boundary"); rc=$?
+  expect_code 0 "$rc" "disabled relaunch should succeed"$'\n'"$out"
+  [ -z "$(meta_field "$dir" rl33 traceparent)" ] \
+    || fail "disabled relaunch must remove the prior trace carrier from metadata"
+  ! grep -q '^export TRACEPARENT=' "$dir/fake/literal" \
+    || fail "disabled relaunch must not export a replacement trace carrier"
   [ "$(cat "$dir/fake/fish-traceparent")" = unset ] \
     || fail "the real fish launch retained stale TRACEPARENT"
   pass "fm-control relaunch: disabling tracing clears metadata and the replacement environment in fish"
@@ -439,34 +439,19 @@ test_generated_relaunch_is_not_reparsed_by_a_c_shell() {
   dir=$(new_case c-shell rl37)
   add_ship_task "$dir" rl37 claude
   result="$dir/fake/c-shell-launch"
-  cat > "$dir/fakebin/csh" <<'SH'
-#!/usr/bin/env bash
-[ "${1:-}" = -c ] || exit 64
-command=${2:-}
-printf '%s\n' "$command" >> "$FM_FAKE_DIR/c-shell-commands"
-case "$command" in
-  /bin/sh\ -c\ *|env\ -u\ TRACEPARENT\ /bin/sh\ -c\ *) exec /bin/sh -c "$command" ;;
-  *) : > "$FM_FAKE_DIR/c-shell-reparsed-launch"; exit 64 ;;
-esac
-SH
-  chmod +x "$dir/fakebin/csh"
   cat > "$dir/fakebin/claude" <<'SH'
 #!/usr/bin/env bash
 printf '%s|%s' "${TRACEPARENT-unset}" "$*" > "$FM_FAKE_DIR/c-shell-launch"
 SH
   chmod +x "$dir/fakebin/claude"
 
-  out=$(FM_FAKE_PANE_SHELL=csh FM_FAKE_PANE_SHELL_EXEC="$dir/fakebin/csh" \
-    run_control "$dir" rl37 relaunch --model model-csh --effort high --note "cross-shell replacement"); rc=$?
+  out=$(FM_FAKE_PANE_SHELL_EXEC="$CSH_BIN" \
+    run_control "$dir" rl37 relaunch --model "model'csh" --effort high --note "cross-shell replacement"); rc=$?
   expect_code 0 "$rc" "a generated relaunch from a C-shell pane should succeed"$'\n'"$out"
-  [ -s "$dir/fake/c-shell-commands" ] \
-    || fail "the C-shell fixture did not parse the submitted launch"
-  [ ! -e "$dir/fake/c-shell-reparsed-launch" ] \
-    || fail "the generated replacement command was reparsed by the C shell"
   [ -s "$result" ] || fail "the replacement agent never started"
   assert_contains "$(cat "$result")" "unset|" \
     "the C-shell relaunch must clear TRACEPARENT from the replacement environment"
-  assert_contains "$(cat "$result")" "--model model-csh --effort high" \
+  assert_contains "$(cat "$result")" "--model model'csh --effort high" \
     "the shell-neutral relaunch must preserve model and effort flags"
   pass "fm-control relaunch: a generated launch crosses a C-shell pane without C-shell reparsing"
 }
@@ -517,7 +502,8 @@ test_harness_switch_moves_the_record_and_clears_prior_wiring() {
   [ "$(meta_field "$dir" rl4 harness)" = codex ] || fail "the record should follow the switch"
   [ ! -e "$dir/wt/.claude/settings.local.json" ] \
     || fail "the previous harness's per-task wiring must be cleared on a switch"
-  assert_grep "codex" "$dir/fake/literal" "the replacement launch should be the new harness"
+  [ "$(cat "$dir/fake/foreground")" = codex ] \
+    || fail "the selected replacement agent should be running"
   [ "$(journal_field "$dir" rl4 from_harness)" = claude ] || fail "the journal should record the origin harness"
   [ "$(journal_field "$dir" rl4 to_harness)" = codex ] || fail "the journal should record the target harness"
   pass "fm-control relaunch: switching harness is one ordinary relaunch, and the old wiring goes with the old agent"
@@ -668,8 +654,8 @@ test_wiring_removal_failure_refuses_before_replacement_arm() {
   assert_contains "$out" "could not retire claude wiring" \
     "the failure should identify prior wiring cleanup"
   [ -e "$hook" ] || fail "the fixture should retain the undeletable prior hook"
-  assert_no_grep "encode launch-brief" "$dir/fake/literal" \
-    "replacement launch must not be armed after wiring cleanup fails"
+  [ "$(wc -l < "$dir/fake/literal" | tr -d ' ')" = 1 ] \
+    || fail "replacement launch must not be armed after wiring cleanup fails"
   [ "$(journal_field "$dir" rl29 phase)" = failed:launching ] \
     || fail "the transaction should record the partial launch failure"
   [ "$(journal_field "$dir" rl29 rollback)" = prior-record-kept ] \

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -32,6 +32,7 @@ CONTROL="$ROOT/bin/fm-control.sh"
 SPAWN="$ROOT/bin/fm-spawn.sh"
 PROMOTE="$ROOT/bin/fm-promote.sh"
 X_LINK="$ROOT/bin/fm-x-link.sh"
+FISH_BIN=$(command -v fish) || fail "fish is required for relaunch regressions"
 # fm_test_tmproot's own cleanup trap fires when its command substitution exits,
 # so recreate the root before resolving it and clean it up from this file's trap.
 TMP_ROOT=$(fm_test_tmproot fm-control-relaunch)
@@ -99,6 +100,11 @@ case "${1:-}" in
           ;;
         'export TRACEPARENT='*)
           [ -z "${FM_FAKE_TRACE_EXPORTED:-}" ] || : > "$FM_FAKE_TRACE_EXPORTED"
+          ;;
+      esac
+      case "$payload" in
+        *'/pane-shell.'*|*'/traceparent-cleared.'*)
+          TRACEPARENT=stale fish -c "$payload" >/dev/null 2>&1 || true
           ;;
       esac
     fi
@@ -384,7 +390,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
 }
 
 test_disabled_relaunch_clears_prior_trace_context() {
-  local dir out rc launch
+  local dir out rc clear launch
   dir=$(new_case trace-off rl33)
   add_ship_task "$dir" rl33 claude
   printf '%s\n' 'traceparent=00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01' \
@@ -396,25 +402,21 @@ test_disabled_relaunch_clears_prior_trace_context() {
   expect_code 0 "$rc" "disabled relaunch should succeed"$'\n'"$out"
   [ -z "$(meta_field "$dir" rl33 traceparent)" ] \
     || fail "disabled relaunch must remove the prior trace carrier from metadata"
+  clear=$(grep 'traceparent-cleared' "$dir/fake/keys" | tail -1)
+  [ -n "$clear" ] || fail "disabled relaunch did not emit a verified pane-shell clear"
   launch=$(tail -1 "$dir/fake/literal")
-  case "$launch" in
-    'env -u TRACEPARENT "$SHELL" -c '*) ;;
-    *) fail "disabled relaunch must clear the pane carrier around the shell program: $launch" ;;
-  esac
   ! grep -q '^export TRACEPARENT=' "$dir/fake/literal" \
     || fail "disabled relaunch must not export a replacement trace carrier"
-  if command -v fish >/dev/null 2>&1; then
-    cat > "$dir/fakebin/claude" <<'SH'
+  cat > "$dir/fakebin/claude" <<'SH'
 #!/usr/bin/env bash
 printf '%s' "${TRACEPARENT-unset}" > "$FM_FAKE_DIR/fish-traceparent"
 SH
-    chmod +x "$dir/fakebin/claude"
-    TRACEPARENT=stale PATH="$dir/fakebin:$PATH" FM_FAKE_DIR="$dir/fake" \
-      SHELL="$(command -v fish)" fish -c "$launch" >/dev/null 2>&1
-    [ "$(cat "$dir/fake/fish-traceparent")" = unset ] \
-      || fail "the real fish launch retained stale TRACEPARENT"
-  fi
-  pass "fm-control relaunch: disabling tracing clears metadata and pane context in fish and POSIX shells"
+  chmod +x "$dir/fakebin/claude"
+  TRACEPARENT=stale PATH="$dir/fakebin:$PATH" FM_FAKE_DIR="$dir/fake" \
+    "$FISH_BIN" -c "$clear"$'\n'"$launch" >/dev/null 2>&1
+  [ "$(cat "$dir/fake/fish-traceparent")" = unset ] \
+    || fail "the real fish launch retained stale TRACEPARENT"
+  pass "fm-control relaunch: disabling tracing clears metadata and the existing fish pane context"
 }
 
 test_relaunch_appends_the_progress_note_to_the_instructions() {

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -398,8 +398,8 @@ test_disabled_relaunch_clears_prior_trace_context() {
     || fail "disabled relaunch must remove the prior trace carrier from metadata"
   launch=$(tail -1 "$dir/fake/literal")
   case "$launch" in
-    'env -u TRACEPARENT '*) ;;
-    *) fail "disabled relaunch must clear the pane carrier with shell-agnostic env -u: $launch" ;;
+    'env -u TRACEPARENT "$SHELL" -c '*) ;;
+    *) fail "disabled relaunch must clear the pane carrier around the shell program: $launch" ;;
   esac
   ! grep -q '^export TRACEPARENT=' "$dir/fake/literal" \
     || fail "disabled relaunch must not export a replacement trace carrier"
@@ -409,7 +409,8 @@ test_disabled_relaunch_clears_prior_trace_context() {
 printf '%s' "${TRACEPARENT-unset}" > "$FM_FAKE_DIR/fish-traceparent"
 SH
     chmod +x "$dir/fakebin/claude"
-    TRACEPARENT=stale PATH="$dir/fakebin:$PATH" FM_FAKE_DIR="$dir/fake" fish -c "$launch" >/dev/null 2>&1
+    TRACEPARENT=stale PATH="$dir/fakebin:$PATH" FM_FAKE_DIR="$dir/fake" \
+      SHELL="$(command -v fish)" fish -c "$launch" >/dev/null 2>&1
     [ "$(cat "$dir/fake/fish-traceparent")" = unset ] \
       || fail "the real fish launch retained stale TRACEPARENT"
   fi

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -17,6 +17,8 @@
 #   6. fm-spawn --relaunch refuses on its own: a live agent, a contradicting
 #      flag, an extra positional, or a backend that cannot prove the previous
 #      agent exited.
+#   7. Relaunch success requires a foreground agent, not a surviving shell with
+#      a stale agent-shaped terminal title.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -73,10 +75,16 @@ case "${1:-}" in
       case "$payload" in
         /exit|/quit)
           printf 'zsh' > "$D/command"
+          printf 'zsh' > "$D/foreground"
           [ -z "${FM_FAKE_EXIT_TRANSPORT_FAIL_AFTER_STOP:-}" ] || exit 1
           ;;
         *'encode launch-brief'*)
           cat "$D/becomes" > "$D/command"
+          if [ -n "${FM_FAKE_STALE_LAUNCH_TITLE:-}" ]; then
+            printf 'zsh' > "$D/foreground"
+          else
+            cat "$D/becomes" > "$D/foreground"
+          fi
           [ -z "${FM_FAKE_LAUNCH_TRANSPORT_FAIL_AFTER_START:-}" ] || exit 1
           ;;
       esac
@@ -100,6 +108,7 @@ case "${1:-}" in
       case "$a" in
         *cursor_y*) printf '1\n'; exit 0 ;;
         *pane_current_command*) cat "$D/command"; printf '\n'; exit 0 ;;
+        *pane_tty*) printf '/dev/fm-fake\n'; exit 0 ;;
         *pane_current_path*)
           if [ -n "${FM_FAKE_CWD_RACE_READY:-}" ]; then
             : > "$FM_FAKE_CWD_RACE_READY"
@@ -115,6 +124,20 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
+  cat > "$fb/ps" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = -t ] && [ "${2:-}" = fm-fake ]; then
+  printf '4242 4242 4242 %s\n' "$(cat "$FM_FAKE_DIR/foreground")"
+  exit 0
+fi
+if [ "${1:-}" = -p ] && [ "${2:-}" = 4242 ] && [ "${3:-}" = -o ] && [ "${4:-}" = args= ]; then
+  cat "$FM_FAKE_DIR/foreground"
+  printf '\n'
+  exit 0
+fi
+exec /bin/ps "$@"
+SH
+  chmod +x "$fb/ps"
   cat > "$fb/sleep" <<'SH'
 #!/usr/bin/env bash
 exit 0
@@ -129,6 +152,7 @@ new_case() {
   : > "$dir/fake/literal"
   : > "$dir/fake/keys"
   printf 'claude' > "$dir/fake/command"
+  printf 'claude' > "$dir/fake/foreground"
   printf 'claude' > "$dir/fake/becomes"
   printf '%s\n' "fm-$id" > "$dir/fake/windows"
   make_tmux_stub "$dir"
@@ -171,6 +195,7 @@ run_control() {  # <case-dir> <args...>
     FM_FAKE_TRACE_PREPARE="${FM_FAKE_TRACE_PREPARE:-}" \
     FM_FAKE_META_WRITER_READY="${FM_FAKE_META_WRITER_READY:-}" \
     FM_FAKE_TRACE_EXPORTED="${FM_FAKE_TRACE_EXPORTED:-}" \
+    FM_FAKE_STALE_LAUNCH_TITLE="${FM_FAKE_STALE_LAUNCH_TITLE:-}" \
     "$CONTROL" "$@" 2>&1
 }
 
@@ -314,14 +339,14 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
     FM_FAKE_TRACE_EXPORTED="$exported" \
     run_control "$dir" rl28 relaunch --note "continue after publication" > "$dir/control.out" &
   control_pid=$!
-  while [ ! -e "$prepare" ] && [ "$i" -lt 200 ]; do
+  while [ ! -e "$prepare" ] && [ "$i" -lt 500 ]; do
     /bin/sleep 0.01
     i=$((i + 1))
   done
   [ -e "$prepare" ] || {
     kill "$control_pid" 2>/dev/null || true
     wait "$control_pid" 2>/dev/null || true
-    fail "relaunch did not reach trace delivery"
+    fail "relaunch did not reach trace delivery: $(cat "$dir/control.out")"
   }
   env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
     FM_REAL_MV="$(command -v mv)" \
@@ -332,7 +357,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
       --carry-platform x --carry-max 280 > "$dir/link.out" 2>&1 &
   link_pid=$!
   i=0
-  while { [ ! -e "$ready" ] || [ ! -e "$exported" ]; } && [ "$i" -lt 200 ]; do
+  while { [ ! -e "$ready" ] || [ ! -e "$exported" ]; } && [ "$i" -lt 500 ]; do
     /bin/sleep 0.01
     i=$((i + 1))
   done
@@ -359,7 +384,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
 }
 
 test_disabled_relaunch_clears_prior_trace_context() {
-  local dir out rc
+  local dir out rc launch
   dir=$(new_case trace-off rl33)
   add_ship_task "$dir" rl33 claude
   printf '%s\n' 'traceparent=00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01' \
@@ -371,11 +396,24 @@ test_disabled_relaunch_clears_prior_trace_context() {
   expect_code 0 "$rc" "disabled relaunch should succeed"$'\n'"$out"
   [ -z "$(meta_field "$dir" rl33 traceparent)" ] \
     || fail "disabled relaunch must remove the prior trace carrier from metadata"
-  grep -q '^unset TRACEPARENT; .*claude' "$dir/fake/literal" \
-    || fail "disabled relaunch must clear the pane carrier before replacement launch"
+  launch=$(tail -1 "$dir/fake/literal")
+  case "$launch" in
+    'env -u TRACEPARENT '*) ;;
+    *) fail "disabled relaunch must clear the pane carrier with shell-agnostic env -u: $launch" ;;
+  esac
   ! grep -q '^export TRACEPARENT=' "$dir/fake/literal" \
     || fail "disabled relaunch must not export a replacement trace carrier"
-  pass "fm-control relaunch: disabling tracing clears metadata and pane context"
+  if command -v fish >/dev/null 2>&1; then
+    cat > "$dir/fakebin/claude" <<'SH'
+#!/usr/bin/env bash
+printf '%s' "${TRACEPARENT-unset}" > "$FM_FAKE_DIR/fish-traceparent"
+SH
+    chmod +x "$dir/fakebin/claude"
+    TRACEPARENT=stale PATH="$dir/fakebin:$PATH" FM_FAKE_DIR="$dir/fake" fish -c "$launch" >/dev/null 2>&1
+    [ "$(cat "$dir/fake/fish-traceparent")" = unset ] \
+      || fail "the real fish launch retained stale TRACEPARENT"
+  fi
+  pass "fm-control relaunch: disabling tracing clears metadata and pane context in fish and POSIX shells"
 }
 
 test_relaunch_appends_the_progress_note_to_the_instructions() {
@@ -452,6 +490,7 @@ test_harness_switch_resolves_a_prefixed_recorded_harness() {
   dir=$(new_case prefixcontrol rl32)
   add_ship_task "$dir" rl32 grok-2
   printf 'grok-2' > "$dir/fake/command"
+  printf 'grok-2' > "$dir/fake/foreground"
   mkdir -p "$dir/grokhome/hooks/fm-turn-end.d"
   printf 'fm.abcdefabcdef\n' > "$dir/home/state/rl32.grok-turnend-token"
   auth="$dir/grokhome/hooks/fm-turn-end.d/fm.abcdefabcdef"
@@ -479,6 +518,7 @@ test_prefixed_recorded_harness_requires_explicit_replacement() {
   dir=$(new_case prefixrefuse rl34)
   add_ship_task "$dir" rl34 grok-2
   printf 'grok-2' > "$dir/fake/command"
+  printf 'grok-2' > "$dir/fake/foreground"
   meta="$dir/home/state/rl34.meta"
   brief="$dir/home/data/rl34/brief.md"
   cp "$meta" "$dir/meta.before"
@@ -550,6 +590,7 @@ test_prior_harness_turnend_registry_entry_is_cleared() {
   auth="$dir/grokhome/hooks/fm-turn-end.d/fm.abcdefabcdef"
   printf '%s\n' "$dir/home/state/rl9.turn-ended" > "$auth"
   printf 'grok' > "$dir/fake/command"
+  printf 'grok' > "$dir/fake/foreground"
   printf 'grok' > "$dir/fake/becomes"
   run_control "$dir" rl9 relaunch --note "restart on the same runtime" >/dev/null
   [ ! -e "$auth" ] \
@@ -778,6 +819,7 @@ test_spawn_relaunch_without_a_harness_reuses_the_recorded_one() {
   mkdir -p "$dir/home/config"
   printf 'codex\n' > "$dir/home/config/crew-harness"
   printf 'zsh' > "$dir/fake/command"
+  printf 'zsh' > "$dir/fake/foreground"
   out=$(run_spawn "$dir" rl21 --relaunch)
   [ "$(meta_field "$dir" rl21 harness)" = claude ] \
     || fail "fm-spawn --relaunch without --harness must reuse the recorded harness, got '$(meta_field "$dir" rl21 harness)'"
@@ -800,6 +842,7 @@ test_prefixed_prior_harness_wiring_is_still_retired() {
   printf '%s\n' "$dir/home/state/rl30.turn-ended" > "$auth"
   printf 'token=fm.abcdefabcdef\n' > "$dir/wt/.fm-grok-turnend"
   printf 'zsh' > "$dir/fake/command"
+  printf 'zsh' > "$dir/fake/foreground"
   run_spawn "$dir" rl30 --relaunch --harness claude >/dev/null
   [ ! -e "$auth" ] \
     || fail "a prefixed prior harness must still have its turn-end registry entry revoked"
@@ -822,6 +865,7 @@ test_muse_session_binding_is_retired_on_a_harness_switch() {
     > "$dir/home/state/rl31.muse-session"
   printf '/nonexistent/session.jsonl\n' > "$dir/home/state/rl31.muse-session-current"
   printf 'zsh' > "$dir/fake/command"
+  printf 'zsh' > "$dir/fake/foreground"
   run_spawn "$dir" rl31 --relaunch --harness claude >/dev/null
   [ ! -e "$dir/home/state/rl31.muse-session" ] \
     || fail "the retired muse incarnation's session binding must not outlive it"
@@ -837,6 +881,7 @@ test_cursor_session_binding_is_retired_on_a_harness_switch() {
   printf 'workspace=%s\nprior_conversation=old-conversation\n' "$dir/wt" \
     > "$dir/home/state/rl35.cursor-session"
   printf 'zsh' > "$dir/fake/command"
+  printf 'zsh' > "$dir/fake/foreground"
   run_spawn "$dir" rl35 --relaunch --harness claude >/dev/null
   [ ! -e "$dir/home/state/rl35.cursor-session" ] \
     || fail "the retired cursor incarnation's session binding must not outlive it"
@@ -929,6 +974,20 @@ test_launch_failure_keeps_the_prior_record_and_reports_it() {
   assert_grep "carry this forward" "$dir/home/data/rl13/brief.md" \
     "the progress note must survive so a later recovery still has it"
   pass "fm-control relaunch: a launch failure after the stop keeps the prior record and reports the real state"
+}
+
+test_relaunch_refuses_a_stale_agent_title_over_a_live_shell() {
+  local dir out rc
+  dir=$(new_case false-success rl36)
+  add_ship_task "$dir" rl36 claude
+  out=$(FM_FAKE_STALE_LAUNCH_TITLE=1 \
+    run_control "$dir" rl36 relaunch --note "retry safely"); rc=$?
+  expect_code 1 "$rc" "a shell-only replacement must not count as a successful relaunch"$'\n'"$out"
+  assert_contains "$out" "no running agent could be confirmed" \
+    "the failure must distinguish the live shell from a started replacement agent"
+  [ "$(cat "$dir/fake/foreground")" = zsh ] \
+    || fail "the false-success fixture must leave only the endpoint shell"
+  pass "fm-control relaunch: a stale agent title cannot turn a live shell into launch success"
 }
 
 test_prepublication_failure_keeps_concurrent_durable_metadata() {
@@ -1210,6 +1269,7 @@ test_direct_spawn_relaunch_participates_in_the_lifecycle_lock() {
   dir=$(new_case spawnlock rl26)
   add_ship_task "$dir" rl26 claude
   printf 'zsh' > "$dir/fake/command"
+  printf 'zsh' > "$dir/fake/foreground"
   lock="$dir/home/state/.control-rl26.lock"
   (
     . "$ROOT/bin/fm-wake-lib.sh"
@@ -1278,6 +1338,7 @@ test_spawn_relaunch_refuses_contradicting_flags() {
   dir=$(new_case flags rl16)
   add_ship_task "$dir" rl16 claude
   printf 'zsh' > "$dir/fake/command"
+  printf 'zsh' > "$dir/fake/foreground"
   out=$(run_spawn "$dir" rl16 --relaunch --backend herdr); rc=$?
   expect_code 1 "$rc" "--backend should be refused alongside --relaunch"
   assert_contains "$out" "recorded backend" "the refusal should name the recorded backend rule"
@@ -1305,6 +1366,7 @@ test_spawn_relaunch_refuses_a_pane_outside_the_worktree() {
   dir=$(new_case wrongcwd rl18)
   add_ship_task "$dir" rl18 claude
   printf 'zsh' > "$dir/fake/command"
+  printf 'zsh' > "$dir/fake/foreground"
   printf '%s' "$dir/proj" > "$dir/fake/cwd"
   out=$(run_spawn "$dir" rl18 --relaunch --harness claude); rc=$?
   expect_code 1 "$rc" "a pane outside the worktree should refuse"
@@ -1342,6 +1404,7 @@ test_missing_instructions_refuse_before_stopping_anything
 test_checkpoint_refusal_leaves_the_record_byte_identical
 test_checkpoint_refuses_uninspectable_head_and_status
 test_launch_failure_keeps_the_prior_record_and_reports_it
+test_relaunch_refuses_a_stale_agent_title_over_a_live_shell
 test_prepublication_failure_keeps_concurrent_durable_metadata
 test_post_publication_launch_failure_keeps_the_new_record
 test_stop_transport_failure_reconciles_a_dead_agent

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -424,7 +424,7 @@ SH
     "$FISH_BIN" -c "$launch" >/dev/null 2>&1
   [ "$(cat "$dir/fake/fish-traceparent")" = unset ] \
     || fail "the real fish launch retained stale TRACEPARENT"
-  pass "fm-control relaunch: disabling tracing clears metadata and the existing fish pane context"
+  pass "fm-control relaunch: disabling tracing clears metadata and the replacement environment in fish"
 }
 
 test_relaunch_appends_the_progress_note_to_the_instructions() {

--- a/tests/fm-harness-liveness-drift-live-e2e.test.sh
+++ b/tests/fm-harness-liveness-drift-live-e2e.test.sh
@@ -124,7 +124,7 @@ for harness in claude codex opencode pi pi-signed grok kimi cursor muse; do
   started=0
   for _ in $(seq 1 300); do
     state=$(fm_backend_agent_state tmux "$target")
-    if [ "$state" = alive ] && fm_backend_agent_started tmux "$target" claude; then
+    if [ "$state" = alive ] && fm_backend_agent_started tmux "$target" "$harness"; then
       started=1
       break
     fi

--- a/tests/fm-harness-liveness-drift-live-e2e.test.sh
+++ b/tests/fm-harness-liveness-drift-live-e2e.test.sh
@@ -121,17 +121,21 @@ for harness in claude codex opencode pi pi-signed grok kimi cursor muse; do
     || fail "$harness ($version): could not launch a window for the liveness probe"
 
   state=
+  started=0
   for _ in $(seq 1 300); do
     state=$(fm_backend_agent_state tmux "$target")
-    [ "$state" = alive ] && break
+    if [ "$state" = alive ] && fm_backend_agent_started tmux "$target"; then
+      started=1
+      break
+    fi
     sleep 0.2
   done
 
   title=$(fm_backend_tmux_current_command "$target")
   comms=$(fm_backend_tmux_foreground_comms "$target" | tr '\n' ' ')
 
-  [ "$state" = alive ] || fail \
-    "LIVENESS DRIFT: $harness $version is running but classifies '$state', not 'alive'. Supervision and lifecycle control treat this endpoint as unattributable. Observed process title '$title'; observed foreground process names [$comms]. Teach bin/backends/tmux.sh's fm_backend_tmux_classify_process_name the identity this release actually reports."
+  [ "$state" = alive ] && [ "$started" = 1 ] || fail \
+    "LIVENESS DRIFT: $harness $version is running but recovery state is '$state' and replacement-start proof is '$started'. Supervision and lifecycle control treat this endpoint as unattributable. Observed process title '$title'; observed foreground process names [$comms]. Teach bin/backends/tmux.sh's fm_backend_tmux_classify_process_name the identity this release actually reports."
 
   note "$harness $version: title='$title' foreground=[$comms]"
 

--- a/tests/fm-harness-liveness-drift-live-e2e.test.sh
+++ b/tests/fm-harness-liveness-drift-live-e2e.test.sh
@@ -124,7 +124,7 @@ for harness in claude codex opencode pi pi-signed grok kimi cursor muse; do
   started=0
   for _ in $(seq 1 300); do
     state=$(fm_backend_agent_state tmux "$target")
-    if [ "$state" = alive ] && fm_backend_agent_started tmux "$target"; then
+    if [ "$state" = alive ] && fm_backend_agent_started tmux "$target" claude; then
       started=1
       break
     fi

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -53,6 +53,7 @@ export PATH
 # the executable identity, which is exactly the signal under test.
 ln -s "$SLEEP_BIN" "$LAB/bin/claude/claude"
 ln -s "$SLEEP_BIN" "$LAB/bin/codex"
+ln -s "$SLEEP_BIN" "$LAB/bin/codex-aarch64-a"
 ln -s "$SLEEP_BIN" "$LAB/bin/pi"
 ln -s "$SLEEP_BIN" "$LAB/bin/notaharness"
 # muse's installed binary is muse-bin-<version>: the launcher execs it, so the
@@ -167,6 +168,32 @@ if fm_backend_agent_started tmux "$SESSION:wrong-harness" claude; then
   fail "a foreground codex executable must not prove a selected claude replacement start"
 fi
 pass "tmux liveness: replacement proof requires the selected foreground harness"
+
+new_window codex-artifact "$LAB/bin/codex-aarch64-a" 900
+wait_for_state "$SESSION:codex-artifact" alive \
+  || fail "the verified codex-aarch64-a artifact must classify alive"
+fm_backend_agent_started tmux "$SESSION:codex-artifact" codex \
+  || fail "the verified codex-aarch64-a artifact must prove a selected codex replacement start"
+pass "tmux liveness: the verified codex-aarch64-a artifact proves selected Codex startup"
+
+(
+  tmux() {
+    case "$1" in
+      list-windows) printf '%s\n' paired ;;
+      display-message) printf '%s\n' /dev/fm-cursor-pair ;;
+      *) return 1 ;;
+    esac
+  }
+  ps() {
+    case "$1" in
+      -t) printf '%s\n' '101 77 77 node' ;;
+      -p) printf '%s\n' '/opt/cursor-agent --model gpt' ;;
+      *) return 1 ;;
+    esac
+  }
+  fm_backend_agent_started tmux cursor-fixture:paired cursor
+) || fail "paired comm=node and argv0=/opt/cursor-agent must prove a selected Cursor replacement start"
+pass "tmux liveness: paired node and cursor-agent identity proves selected Cursor startup"
 
 # --- muse's version-suffixed binary name ------------------------------------
 # A muse crewmate pane misclassified here reads as a dead endpoint, so a healthy

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -177,6 +177,7 @@ fm_backend_agent_started tmux "$SESSION:codex-artifact" codex \
 pass "tmux liveness: the verified codex-aarch64-a artifact proves selected Codex startup"
 
 (
+  # shellcheck disable=SC2329 # Mock invoked indirectly by the sourced backend.
   tmux() {
     case "$1" in
       list-windows) printf '%s\n' paired ;;
@@ -184,6 +185,7 @@ pass "tmux liveness: the verified codex-aarch64-a artifact proves selected Codex
       *) return 1 ;;
     esac
   }
+  # shellcheck disable=SC2329 # Mock invoked indirectly by the sourced backend.
   ps() {
     case "$1" in
       -t) printf '%s\n' '101 77 77 node' ;;

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -153,7 +153,7 @@ assert_sources_disagree() {  # <target> <label>
 new_window agent "$LAB/bin/claude-link" 900
 wait_for_state "$SESSION:agent" alive \
   || fail "a running harness-named foreground process must classify alive"
-fm_backend_agent_started tmux "$SESSION:agent" \
+fm_backend_agent_started tmux "$SESSION:agent" claude \
   || fail "a running harness-named foreground process must prove replacement start"
 pass "tmux liveness: a harness-named foreground process classifies alive and proves replacement start"
 
@@ -241,7 +241,7 @@ kill -0 "$bg_pid" 2>/dev/null \
   || fail "the background harness-named process is not running, so this case would prove nothing"
 wait_for_state "$SESSION:background" dead \
   || fail "a pane whose only harness-named process is backgrounded must classify dead"
-if fm_backend_agent_started tmux "$SESSION:background"; then
+if fm_backend_agent_started tmux "$SESSION:background" claude; then
   fail "a background harness process over a live shell must not prove replacement start"
 fi
 kill -0 "$bg_pid" 2>/dev/null \
@@ -257,7 +257,7 @@ pass "tmux liveness: a harness-named background process in an idle pane still cl
 fm_backend_tmux_foreground_comms "$SESSION:no-such-window" >/dev/null \
   || fail "the foreground-comms read must stay best-effort for an absent window"
 "$REAL_TMUX" -L "$SOCKET" select-window -t "$SESSION:agent"
-if fm_backend_agent_started tmux "$SESSION:no-such-window"; then
+if fm_backend_agent_started tmux "$SESSION:no-such-window" claude; then
   fail "an absent target must not inherit positive replacement proof from the active agent window"
 fi
 [ "$(fm_backend_agent_state tmux "$SESSION:no-such-window")" = missing ] \

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -153,7 +153,9 @@ assert_sources_disagree() {  # <target> <label>
 new_window agent "$LAB/bin/claude-link" 900
 wait_for_state "$SESSION:agent" alive \
   || fail "a running harness-named foreground process must classify alive"
-pass "tmux liveness: a harness-named foreground process classifies alive"
+fm_backend_agent_started tmux "$SESSION:agent" \
+  || fail "a running harness-named foreground process must prove replacement start"
+pass "tmux liveness: a harness-named foreground process classifies alive and proves replacement start"
 
 # --- muse's version-suffixed binary name ------------------------------------
 # A muse crewmate pane misclassified here reads as a dead endpoint, so a healthy
@@ -239,6 +241,9 @@ kill -0 "$bg_pid" 2>/dev/null \
   || fail "the background harness-named process is not running, so this case would prove nothing"
 wait_for_state "$SESSION:background" dead \
   || fail "a pane whose only harness-named process is backgrounded must classify dead"
+if fm_backend_agent_started tmux "$SESSION:background"; then
+  fail "a background harness process over a live shell must not prove replacement start"
+fi
 kill -0 "$bg_pid" 2>/dev/null \
   || fail "the background harness-named process died during the check, so this case proves nothing"
 pass "tmux liveness: a harness-named background process in an idle pane still classifies dead"

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -256,9 +256,13 @@ pass "tmux liveness: a harness-named background process in an idle pane still cl
 
 fm_backend_tmux_foreground_comms "$SESSION:no-such-window" >/dev/null \
   || fail "the foreground-comms read must stay best-effort for an absent window"
+"$REAL_TMUX" -L "$SOCKET" select-window -t "$SESSION:agent"
+if fm_backend_agent_started tmux "$SESSION:no-such-window"; then
+  fail "an absent target must not inherit positive replacement proof from the active agent window"
+fi
 [ "$(fm_backend_agent_state tmux "$SESSION:no-such-window")" = missing ] \
   || fail "an absent window in a readable session must classify missing, not whatever the fallback pane runs"
-pass "tmux liveness: an absent window classifies missing rather than inheriting tmux's active-window fallback"
+pass "tmux liveness: an absent window cannot inherit state or startup proof from tmux's active-window fallback"
 
 # --- Cursor's composer: the terminal cursor is NOT a composer locator --------
 # Cursor Agent CLI parks its terminal cursor below its footer with cursor_flag 0,

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -51,7 +51,8 @@ export PATH
 # binary, never copies: a copied platform binary fails code-signing validation
 # and is killed on macOS arm64. The symlink name is what the kernel records as
 # the executable identity, which is exactly the signal under test.
-ln -s "$SLEEP_BIN" "$LAB/bin/claude-link"
+ln -s "$SLEEP_BIN" "$LAB/bin/claude/claude"
+ln -s "$SLEEP_BIN" "$LAB/bin/codex"
 ln -s "$SLEEP_BIN" "$LAB/bin/pi"
 ln -s "$SLEEP_BIN" "$LAB/bin/notaharness"
 # muse's installed binary is muse-bin-<version>: the launcher execs it, so the
@@ -150,12 +151,22 @@ assert_sources_disagree() {  # <target> <label>
 # tmux and ps, while Linux can expose the symlink name through both, so the
 # version-string case below owns the cross-platform divergence assertion.
 
-new_window agent "$LAB/bin/claude-link" 900
+new_window agent "$LAB/bin/claude/claude" 900
 wait_for_state "$SESSION:agent" alive \
   || fail "a running harness-named foreground process must classify alive"
 fm_backend_agent_started tmux "$SESSION:agent" claude \
   || fail "a running harness-named foreground process must prove replacement start"
 pass "tmux liveness: a harness-named foreground process classifies alive and proves replacement start"
+
+new_window wrong-harness "$LAB/bin/codex" 900
+wait_for_state "$SESSION:wrong-harness" alive \
+  || fail "a running codex executable must classify alive"
+fm_backend_agent_started tmux "$SESSION:wrong-harness" codex \
+  || fail "a running codex executable must prove a selected codex replacement start"
+if fm_backend_agent_started tmux "$SESSION:wrong-harness" claude; then
+  fail "a foreground codex executable must not prove a selected claude replacement start"
+fi
+pass "tmux liveness: replacement proof requires the selected foreground harness"
 
 # --- muse's version-suffixed binary name ------------------------------------
 # A muse crewmate pane misclassified here reads as a dead endpoint, so a healthy
@@ -165,6 +176,8 @@ pass "tmux liveness: a harness-named foreground process classifies alive and pro
 new_window muse "$LAB/bin/muse-bin-0.1.0-R708.1" 900
 wait_for_state "$SESSION:muse" alive \
   || fail "muse's version-suffixed binary name must classify alive"
+fm_backend_agent_started tmux "$SESSION:muse" muse \
+  || fail "muse's version-suffixed binary must prove selected muse replacement start"
 pass "tmux liveness: muse's version-suffixed muse-bin-<version> classifies alive"
 
 for decoy in musescore amuse muse-binary muse-bind; do
@@ -189,6 +202,8 @@ if [ -n "$CC_BIN" ] &&
   new_window titled "$LAB/bin/claude/2.1.220"
   wait_for_state "$SESSION:titled" alive \
     || fail "a version-named executable under a harness install path must classify alive"
+  fm_backend_agent_started tmux "$SESSION:titled" claude \
+    || fail "a version-named executable under the claude install path must prove replacement start"
   assert_sources_disagree "$SESSION:titled" "version-string process name"
   pass "tmux liveness: a version-named executable under a harness install path classifies alive"
 
@@ -214,6 +229,8 @@ pass "tmux liveness: a process neither name source attributes stays ambiguous ra
 new_window launcher "$LAB/bin/agent-launcher"
 wait_for_state "$SESSION:launcher" alive \
   || fail "a launcher running a harness child must classify alive, never dead"
+fm_backend_agent_started tmux "$SESSION:launcher" pi \
+  || fail "a launcher running a foreground pi child must prove selected pi replacement start"
 comms_classify_agent "$SESSION:launcher" \
   || fail "the launcher's harness child must be visible in the foreground process group"
 pass "tmux liveness: a launcher whose own identity reads as a bare shell classifies alive from its harness child"
@@ -230,7 +247,7 @@ pass "tmux liveness: an idle shell pane classifies dead"
 # `set -m` gives the background job its own process group, which is what an
 # interactive shell does for a job an exited agent left behind.
 
-new_window background bash -c "set -m; '$LAB/bin/claude-link' 900 & printf '%s\n' \"\$!\" > '$LAB/bg.pid'; exec /bin/sh"
+new_window background bash -c "set -m; '$LAB/bin/claude/claude' 900 & printf '%s\n' \"\$!\" > '$LAB/bg.pid'; exec /bin/sh"
 bg_pid=
 for _ in $(seq 1 100); do
   [ -s "$LAB/bg.pid" ] && bg_pid=$(cat "$LAB/bg.pid") && break

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -75,7 +75,11 @@ case "${1:-}" in
       done
       case "$payload" in
         *'/pane-shell.'*|*'/traceparent-cleared.'*)
-          TRACEPARENT=stale fish -c "$payload" >/dev/null 2>&1 || true
+          if [ "${FM_FAKE_TRACEPARENT_SEND_FAIL:-0}" = 1 ]; then
+            env -u TRACEPARENT fish -c "$payload" >/dev/null 2>&1 || true
+          else
+            TRACEPARENT=stale fish -c "$payload" >/dev/null 2>&1 || true
+          fi
           ;;
       esac
     fi

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -10,6 +10,7 @@ set -u
 . "$ROOT/bin/fm-trace-context-lib.sh"
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
+FISH_BIN=$(command -v fish) || fail "fish is required for trace-context spawn regressions"
 TMP_ROOT=$(fm_test_tmproot fm-trace-context-spawn)
 
 # Fake tmux: answers the pane-path query and logs every literal `send-keys -l`
@@ -62,15 +63,21 @@ case "${1:-}" in
     if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
       shift
       skip_next=
+      payload=
       for a in "$@"; do
         if [ -n "$skip_next" ]; then skip_next=; continue; fi
         case "$a" in
           -t) skip_next=1; continue ;;
           -l) continue ;;
           Enter|C-m) continue ;;
-          *) printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG" ;;
+          *) payload=$a; printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG" ;;
         esac
       done
+      case "$payload" in
+        *'/pane-shell.'*|*'/traceparent-cleared.'*)
+          TRACEPARENT=stale fish -c "$payload" >/dev/null 2>&1 || true
+          ;;
+      esac
     fi
     exit 0
     ;;
@@ -287,7 +294,7 @@ test_disabled_writes_and_injects_neither() {
 }
 
 test_failed_delivery_omits_metadata_and_still_launches() {
-  local rec out status meta launch raw result
+  local rec out status meta program raw result
   rec=$(make_spawn_case tc-send-failure)
   read_case_record "$rec"
   : > "$HOME_DIR/config/trace-context"
@@ -315,13 +322,11 @@ SH
     || fail "failed traceparent delivery must not leave a traceparent= claim in meta"
   ! grep -q '^export TRACEPARENT=' "$LAUNCH_LOG" \
     || fail "the failed TRACEPARENT export must not be recorded as delivered"
-  launch=$(tail -1 "$LAUNCH_LOG")
-  if command -v fish >/dev/null 2>&1; then
-    TRACEPARENT=stale FM_RAW_RESULT="$result" PATH="$FAKEBIN_DIR:$PATH" \
-      SHELL="$(command -v fish)" fish -c "$launch" >/dev/null 2>&1
-    [ "$(cat "$result")" = 'unset|ready' ] \
-      || fail "failed trace delivery must clear TRACEPARENT without bypassing fish parsing"
-  fi
+  program=$(cat "$LAUNCH_LOG")
+  TRACEPARENT=stale FM_RAW_RESULT="$result" PATH="$FAKEBIN_DIR:$PATH" \
+    "$FISH_BIN" -c "$program" >/dev/null 2>&1
+  [ "$(cat "$result")" = 'unset|ready' ] \
+    || fail "failed trace delivery must clear TRACEPARENT without bypassing fish parsing"
   pass "failed TRACEPARENT delivery omits metadata and preserves raw fish shell programs"
 }
 
@@ -344,7 +349,7 @@ test_unsafe_delivery_refuses_to_append_launch() {
 }
 
 test_failed_metadata_append_unsets_carrier_and_still_launches() {
-  local rec out status meta
+  local rec out status meta program result
   rec=$(make_spawn_case tc-metadata-failure)
   read_case_record "$rec"
   : > "$HOME_DIR/config/trace-context"
@@ -359,8 +364,17 @@ test_failed_metadata_append_unsets_carrier_and_still_launches() {
 
   ! grep -q '^traceparent=' "$meta" \
     || fail "failed metadata append must not leave a traceparent= claim in meta"
-  grep -q '^env -u TRACEPARENT "\$SHELL" -c .*claude' "$LAUNCH_LOG" \
-    || fail "failed metadata append must clear TRACEPARENT portably in the launch command"
+  cat > "$FAKEBIN_DIR/claude" <<'SH'
+#!/usr/bin/env bash
+printf '%s' "${TRACEPARENT-unset}" > "$FM_RAW_RESULT"
+SH
+  chmod +x "$FAKEBIN_DIR/claude"
+  result="$HOME_DIR/metadata-result"
+  program=$(cat "$LAUNCH_LOG")
+  TRACEPARENT=stale FM_RAW_RESULT="$result" PATH="$FAKEBIN_DIR:$PATH" \
+    "$FISH_BIN" -c "$program" >/dev/null 2>&1
+  [ "$(cat "$result")" = unset ] \
+    || fail "failed metadata append must clear TRACEPARENT in the existing fish pane"
   pass "failed traceparent metadata append removes the carrier from the launched task"
 }
 

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -90,6 +90,7 @@ exit 0
 SH
   chmod +x "$fakebin/tmux"
   fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_exit0 "$fakebin" claude
   printf '%s\n' "$fakebin"
 }
 
@@ -298,7 +299,7 @@ test_disabled_writes_and_injects_neither() {
 }
 
 test_failed_delivery_omits_metadata_and_still_launches() {
-  local rec out status meta program raw result
+  local rec out status meta program raw result trace setup prompts real_tmux socket
   rec=$(make_spawn_case tc-send-failure)
   read_case_record "$rec"
   : > "$HOME_DIR/config/trace-context"
@@ -307,9 +308,9 @@ test_failed_delivery_omits_metadata_and_still_launches() {
   cat > "$HOME_DIR/setup.fish" <<'FISH'
 set -gx FM_RAW_SETUP ready
 FISH
-  cat > "$FAKEBIN_DIR/custom-agent" <<'SH'
+cat > "$FAKEBIN_DIR/custom-agent" <<'SH'
 #!/usr/bin/env bash
-printf '%s|%s' "${TRACEPARENT-unset}" "${FM_RAW_SETUP-unset}" > "$FM_RAW_RESULT"
+printf '%s|%s|%s' "${TRACEPARENT-unset}" "${FM_RAW_SETUP-unset}" "${FM_PROMPT_COUNT:-0}" > "$FM_RAW_RESULT"
 SH
   chmod +x "$FAKEBIN_DIR/custom-agent"
   raw="source $HOME_DIR/setup.fish; exec custom-agent"
@@ -327,11 +328,40 @@ SH
   ! grep -q '^export TRACEPARENT=' "$LAUNCH_LOG" \
     || fail "the failed TRACEPARENT export must not be recorded as delivered"
   program=$(cat "$LAUNCH_LOG")
-  TRACEPARENT=stale FM_RAW_RESULT="$result" PATH="$FAKEBIN_DIR:$PATH" \
-    "$FISH_BIN" -c "$program" >/dev/null 2>&1
-  [ "$(cat "$result")" = 'unset|ready' ] \
+  real_tmux=$(command -v tmux) || fail "tmux is required for the interactive fish regression"
+  socket="fm-trace-prompt-$$-$RANDOM"
+  (
+    pane=
+    trap '"$real_tmux" -L "$socket" kill-server >/dev/null 2>&1 || true' EXIT
+    pane=$("$real_tmux" -L "$socket" new-session -dP -F '#{pane_id}' \
+      -s fish-prompt -x 120 -y 40 \
+      -e TRACEPARENT=stale -e FM_RAW_RESULT="$result" \
+      -e PATH="$FAKEBIN_DIR:$PATH" "$FISH_BIN --no-config --interactive") || exit 1
+    "$real_tmux" -L "$socket" send-keys -t "$pane" -l \
+      "set -gx PATH '$FAKEBIN_DIR' \$PATH; function fish_prompt; if set -q FM_PROMPT_COUNT; set -gx FM_PROMPT_COUNT (math \$FM_PROMPT_COUNT + 1); else; set -gx FM_PROMPT_COUNT 1; end; set -gx TRACEPARENT prompt-restored; end"
+    "$real_tmux" -L "$socket" send-keys -t "$pane" Enter
+    sleep 0.2
+    while IFS= read -r line; do
+      "$real_tmux" -L "$socket" send-keys -t "$pane" -l "$line" || exit 1
+      "$real_tmux" -L "$socket" send-keys -t "$pane" Enter || exit 1
+      sleep 0.1
+    done <<< "$program"
+    i=0
+    while [ ! -s "$result" ] && [ "$i" -lt 20 ]; do
+      sleep 0.1
+      i=$((i + 1))
+    done
+    [ -s "$result" ] || {
+      "$real_tmux" -L "$socket" capture-pane -p -t "$pane" -S -100 >&2 || true
+      exit 1
+    }
+  ) || fail "the real interactive fish pane did not complete the generated launch program"
+  IFS='|' read -r trace setup prompts < "$result"
+  [ "$trace" = unset ] && [ "$setup" = ready ] \
     || fail "failed trace delivery must clear TRACEPARENT without bypassing fish parsing"
-  pass "failed TRACEPARENT delivery omits metadata and preserves raw fish shell programs"
+  [ "$prompts" -ge 2 ] \
+    || fail "the interactive fish regression did not redraw enough prompts to exercise the hook race"
+  pass "failed TRACEPARENT delivery stays cleared across interactive fish prompt redraws"
 }
 
 test_unsafe_delivery_refuses_to_append_launch() {

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -287,14 +287,25 @@ test_disabled_writes_and_injects_neither() {
 }
 
 test_failed_delivery_omits_metadata_and_still_launches() {
-  local rec out status meta
+  local rec out status meta launch raw result
   rec=$(make_spawn_case tc-send-failure)
   read_case_record "$rec"
   : > "$HOME_DIR/config/trace-context"
   start_trace_session "$HOME_DIR"
 
+  cat > "$HOME_DIR/setup.fish" <<'FISH'
+set -gx FM_RAW_SETUP ready
+FISH
+  cat > "$FAKEBIN_DIR/custom-agent" <<'SH'
+#!/usr/bin/env bash
+printf '%s|%s' "${TRACEPARENT-unset}" "${FM_RAW_SETUP-unset}" > "$FM_RAW_RESULT"
+SH
+  chmod +x "$FAKEBIN_DIR/custom-agent"
+  raw="source $HOME_DIR/setup.fish; exec custom-agent"
+  result="$HOME_DIR/raw-result"
+
   out=$(FM_FAKE_TRACEPARENT_SEND_FAIL=1 \
-    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$CASE_ID" "$PROJ_DIR")
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$CASE_ID" "$PROJ_DIR" "$raw")
   status=$?
   expect_code 0 "$status" "failed traceparent delivery must not abort spawn"
   assert_contains "$out" "spawned $CASE_ID" "spawn should report success after failed traceparent delivery"
@@ -304,9 +315,14 @@ test_failed_delivery_omits_metadata_and_still_launches() {
     || fail "failed traceparent delivery must not leave a traceparent= claim in meta"
   ! grep -q '^export TRACEPARENT=' "$LAUNCH_LOG" \
     || fail "the failed TRACEPARENT export must not be recorded as delivered"
-  grep -q '^env -u TRACEPARENT .*claude' "$LAUNCH_LOG" \
-    || fail "failed trace delivery must clear TRACEPARENT portably before launch"
-  pass "failed TRACEPARENT delivery omits metadata while the source task still launches"
+  launch=$(tail -1 "$LAUNCH_LOG")
+  if command -v fish >/dev/null 2>&1; then
+    TRACEPARENT=stale FM_RAW_RESULT="$result" PATH="$FAKEBIN_DIR:$PATH" \
+      SHELL="$(command -v fish)" fish -c "$launch" >/dev/null 2>&1
+    [ "$(cat "$result")" = 'unset|ready' ] \
+      || fail "failed trace delivery must clear TRACEPARENT without bypassing fish parsing"
+  fi
+  pass "failed TRACEPARENT delivery omits metadata and preserves raw fish shell programs"
 }
 
 test_unsafe_delivery_refuses_to_append_launch() {
@@ -343,7 +359,7 @@ test_failed_metadata_append_unsets_carrier_and_still_launches() {
 
   ! grep -q '^traceparent=' "$meta" \
     || fail "failed metadata append must not leave a traceparent= claim in meta"
-  grep -q '^env -u TRACEPARENT .*claude' "$LAUNCH_LOG" \
+  grep -q '^env -u TRACEPARENT "\$SHELL" -c .*claude' "$LAUNCH_LOG" \
     || fail "failed metadata append must clear TRACEPARENT portably in the launch command"
   pass "failed traceparent metadata append removes the carrier from the launched task"
 }

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -304,7 +304,8 @@ test_failed_delivery_omits_metadata_and_still_launches() {
     || fail "failed traceparent delivery must not leave a traceparent= claim in meta"
   ! grep -q '^export TRACEPARENT=' "$LAUNCH_LOG" \
     || fail "the failed TRACEPARENT export must not be recorded as delivered"
-  grep -q 'claude' "$LAUNCH_LOG" || fail "the source task must still launch"
+  grep -q '^env -u TRACEPARENT .*claude' "$LAUNCH_LOG" \
+    || fail "failed trace delivery must clear TRACEPARENT portably before launch"
   pass "failed TRACEPARENT delivery omits metadata while the source task still launches"
 }
 
@@ -342,8 +343,8 @@ test_failed_metadata_append_unsets_carrier_and_still_launches() {
 
   ! grep -q '^traceparent=' "$meta" \
     || fail "failed metadata append must not leave a traceparent= claim in meta"
-  grep -q '^unset TRACEPARENT; .*claude' "$LAUNCH_LOG" \
-    || fail "failed metadata append must unset TRACEPARENT in the launch command"
+  grep -q '^env -u TRACEPARENT .*claude' "$LAUNCH_LOG" \
+    || fail "failed metadata append must clear TRACEPARENT portably in the launch command"
   pass "failed traceparent metadata append removes the carrier from the launched task"
 }
 

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -408,7 +408,7 @@ SH
   TRACEPARENT=stale FM_RAW_RESULT="$result" PATH="$FAKEBIN_DIR:$PATH" \
     "$FISH_BIN" -c "$program" >/dev/null 2>&1
   [ "$(cat "$result")" = unset ] \
-    || fail "failed metadata append must clear TRACEPARENT in the existing fish pane"
+    || fail "failed metadata append must clear TRACEPARENT from the replacement launched through fish"
   pass "failed traceparent metadata append removes the carrier from the launched task"
 }
 


### PR DESCRIPTION
## Intent

Fix Firstmate's agent relaunch path so it is shell-agnostic and cannot report success when the replacement agent never starts. Diagnose the relaunch flow end to end through fm-control.sh, fm-control-lib.sh, fm-spawn.sh, and the selected backend, including every emitted TRACEPARENT clear and caller; compare fresh spawn behavior and history, test the causal counterfactual in real fish, and determine independently whether lifecycle verification can accept a live shell without the selected agent. Relaunch command construction must clear TRACEPARENT without interactive-shell syntax in every affected fallback while keeping tracing default-off and preserving launch environment isolation, secondmate extension flags, model and effort handling, and backend behavior. Lifecycle control must report success only after positive proof that the replacement agent itself is alive, never from a surviving terminal shell. Add minimal behavioral regressions for fish, false relaunch success, and genuine agent start using existing seams. Do not restart Knowledge Mate, mutate its home, close its tab, or add an operational workaround. Validate targeted relaunch, spawn, and backend tests, shellcheck/lint, the relevant full test family, and the documentation audience check. Deliver a green PR but do not merge.

## What Changed

- Detect the reused pane’s shell and atomically clear and verify `TRACEPARENT` with Fish-, POSIX-, or C-shell-safe syntax before relaunching, while leaving fresh trace-disabled spawns unchanged.
- Require two consecutive backend-specific proofs that the selected harness is the foreground agent on the exact tmux or Herdr endpoint, preventing surviving shells, stale titles, background processes, and mismatched harnesses from reporting relaunch success.
- Add Fish-enabled CI and regression coverage for relaunch, trace context, backend startup proof, and live harness liveness; update lifecycle and tracing documentation accordingly.

## Risk Assessment

✅ Low: Captain, the change is well-bounded and the reviewed source preserves raw launch parsing while requiring exact selected-agent startup evidence before relaunch success.

## Testing

At target 4269fac, baseline inspection was clean; focused relaunch, Fish trace clearing, tmux identity, Herdr, and backend smoke tests passed, and after correcting an evidence-only echoed-marker collision, the manual transcript proved atomic trace removal plus selected-agent-only startup confirmation; lint, documentation, push, PR, and CI remain outer-phase responsibilities.

<details>
<summary>Evidence: Real Fish and tmux relaunch transcript</summary>

Source: [Real Fish and tmux relaunch transcript](https://github.com/sayoriqwq/firstmate/blob/e233a610e188ad48522d46af3c10e67de09fc5c0/.no-mistakes/evidence/fm/fish-safe-relaunch/relaunch-runtime-transcript.txt)

<code>PROMPT_HOOK_OBS traceparent=prompt-restored prompts=1&#10;AGENT_STARTED traceparent=unset raw_setup=ready prompts=2&#10;Selected Claude: genuine foreground accepted twice; shell, wrong harness, and absent target rejected.</code>

```text
Firstmate relaunch runtime evidence
HEAD=4269fac892b483f0bb2f39556bcd8e6b20f8d423
fish=fish, version 4.8.1
tmux=tmux 3.7b
PROMPT_HOOK_OBS traceparent=prompt-restored prompts=1
AGENT_STARTED traceparent=unset raw_setup=ready prompts=2
selected=claude target=relaunch-evidence:agent confirmation_1=started confirmation_2=started foreground=[/var/folders/w8/b0vdr9ld3dsg1dyb06ctbr6c0000gn/T//fm-relaunch-evidence.F7r4eP/bin/claude/claude ]
selected=claude target=relaunch-evidence:fish verdict=rejected foreground=[/bin/sh sleep ]
selected=claude target=relaunch-evidence:wrong verdict=rejected foreground=[/var/folders/w8/b0vdr9ld3dsg1dyb06ctbr6c0000gn/T//fm-relaunch-evidence.F7r4eP/bin/codex ]
selected=claude target=relaunch-evidence:absent verdict=rejected
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cb38b61aeeeababaf1c93563af23d1626a6d6841","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-spawn.sh:2919` - Required: “Relaunch command construction must clear TRACEPARENT … while keeping tracing default-off.” This invokes a standalone clear/proof command; after it finishes, interactive Fish runs prompt/direnv hooks before the launch is submitted at line 2924. A hook that exports TRACEPARENT restores the stale value in that gap, so the replacement inherits an unrecorded carrier and relaunch can still report success. Bind clear, proof, and the unchanged raw launch into one submitted program in the detected interpreter, with an interactive Fish regression that re-exports TRACEPARENT during prompt redraw.

🔧 Fix: Bind TRACEPARENT clearing atomically to relaunch
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Baseline: `rtk git status --short --branch`, `rtk git rev-parse HEAD`, and commit-range diff inspection</code>
- `rtk bash tests/fm-control-relaunch.test.sh`
- `rtk bash tests/fm-trace-context-spawn.test.sh`
- `rtk bash tests/fm-tmux-agent-liveness.test.sh`
- `rtk bash tests/fm-backend-herdr.test.sh`
- `rtk bash tests/fm-backend-tmux-smoke.test.sh`
- <code>Manual evidence: `rtk bash .../manual-relaunch-evidence.sh | rtk tee .../relaunch-runtime-transcript.txt` using private real Fish/tmux sessions</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
