### PR TITLE
fix(orca): accept composite worktree ids

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -383,6 +383,33 @@ fm_backend_endpoint_atom_valid() {  # <value>
   esac
 }
 
+# Orca historically returned single-atom worktree ids and currently returns
+# <repo-uuid>::<absolute-worktree-path>. The composite form is accepted only
+# when its embedded absolute path exactly matches the separately recorded
+# worktree path; teardown still resolves that id through Orca before removal.
+fm_backend_orca_worktree_id_valid() {  # <value> <recorded-worktree>
+  local value=$1 recorded=$2 repository_id path
+  fm_backend_endpoint_atom_valid "$value" && return 0
+  [[ "$value" =~ [[:cntrl:]] ]] && return 1
+  case "$value" in
+    *::*) ;;
+    *) return 1 ;;
+  esac
+  repository_id=${value%%::*}
+  path=${value#*::}
+  [[ "$repository_id" =~ ^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$ ]] \
+    || return 1
+  case "$path" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  [ "$path" = "$recorded" ] || return 1
+  case "$path" in
+    /|*/|*/./*|*/../*|*/.|*/..|*::*) return 1 ;;
+  esac
+  return 0
+}
+
 fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
   local meta=$1 id=$2 backend_count backend window worktree project binding_count binding
   local session pane recorded_session workspace tab terminal worktree_id surface
@@ -503,7 +530,7 @@ fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
       }
       if [ "$window" != "fm-$id" ] \
         || ! fm_backend_endpoint_atom_valid "$terminal" \
-        || ! fm_backend_endpoint_atom_valid "$worktree_id"; then
+        || ! fm_backend_orca_worktree_id_valid "$worktree_id" "$worktree"; then
         echo "REFUSED: Orca endpoint metadata for task $id is malformed or inconsistent; preserving task state." >&2
         return 1
       fi

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -42,6 +42,10 @@ worktree=<absolute Orca worktree path>
 
 `window=` remains the caller-facing Firstmate alias.
 `terminal=` and `orca_worktree_id=` are the backend authority used by operation and cleanup paths.
+Orca 1.4.192 issues worktree ids in the form `<repo UUID>::<absolute worktree path>`.
+Firstmate also accepts the earlier single-atom worktree ids.
+A composite id is valid only when it has one UUID-shaped repository prefix, one `::` separator, and an unambiguous absolute path that exactly matches the separately recorded `worktree=` value.
+Terminal handles remain single atoms and do not inherit the composite worktree-id syntax.
 
 ## Current lifecycle and safety
 
@@ -59,8 +63,9 @@ Grok alone retains its isolated rendered-tail fallback.
 Cleanup keeps all shared Firstmate safety checks.
 A scout still requires its report and completed decision inventory.
 A ship still refuses dirty or unlanded work.
-Before release, cleanup resolves the recorded Orca worktree id and verifies its path matches the recorded worktree path.
-A missing, unreadable, or mismatched identity preserves metadata and stops rather than deleting anything.
+Before release, cleanup passes the exact recorded Orca worktree id to `orca worktree show` and verifies the resolved path matches the recorded worktree path.
+That live id-to-path check remains independent of the metadata-only composite-id consistency check.
+A missing, unreadable, malformed, ambiguous, duplicated, or mismatched identity preserves metadata and stops rather than deleting anything.
 After those checks, Firstmate closes the exact terminal and releases the exact worktree with Orca's worktree command.
 It never raw-deletes an Orca worktree.
 
@@ -77,6 +82,8 @@ It never raw-deletes an Orca worktree.
 
 ```sh
 tests/fm-backend-orca.test.sh
+tests/fm-teardown-endpoint-safety.test.sh
+tests/fm-control.test.sh
 tests/fm-backend.test.sh
 tests/fm-bootstrap.test.sh
 ```

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -75,7 +75,7 @@ It never raw-deletes an Orca worktree.
 - The app must be running and report ready.
 - Secondmate spawns are unsupported.
 - Escape is unsupported.
-- Orca exposes no stable CLI version or protocol marker, so readiness is the compatibility gate rather than a version floor.
+- Firstmate reads no version or protocol floor from Orca: `orca status --json` reports `result.runtime.appVersion`, but readiness alone is the compatibility gate.
 - Only the verified terminal-handle and worktree result fields are accepted; speculative response shapes are rejected.
 
 ## Regression entry points

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -178,7 +178,8 @@ Herdr's Claude idle-native submit confirmation is pinned by `tests/fm-backend-he
 
 ### Cleanup endpoint identity
 
-The cleanup identity boundary was refreshed on 2026-08-30 with metadata fixtures for every supported backend and the current composite Orca worktree-id shape.
+The cleanup identity boundary was validated on 2026-07-28 with tmux 3.6a, and its metadata-fixture cells were refreshed on 2026-08-30 for every supported backend, including the current composite Orca worktree-id shape.
+The dedicated tmux cell below is skipped when tmux is absent, so its recorded result stays attributed to the tmux 3.6a run.
 
 ```sh
 tests/fm-teardown-endpoint-safety.test.sh
@@ -712,6 +713,7 @@ Observed fields:
 ```text
 result.runtime.reachable=true
 result.runtime.state=ready
+result.runtime.appVersion=1.4.192
 ```
 
 `orca terminal create --json` returned `result.terminal.handle`.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -489,7 +489,7 @@ HERDR_LAB_HELPER=bin/fm-herdr-lab.sh \
 Observed output on Herdr 0.7.5:
 
 ```text
-ok - old path: the explicit last-pane close of a non-focused workspace stole focus (w3<TAB>w3:t1 -> w2<TAB>w2:t1)
+ok - old path: the explicit last-pane close of a non-focused workspace stole focus (w3	w3:t1 -> w2	w2:t1)
 ok - mitigation: every in-operation sample preserved exact focus while the doomed workspace was removed
 ok - mitigation: no explicit close and no corrective focus were needed on the defective release
 ok - fallback: a doomed pane holding a persistent child exhausts the proof and takes the plain explicit close

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -178,7 +178,7 @@ Herdr's Claude idle-native submit confirmation is pinned by `tests/fm-backend-he
 
 ### Cleanup endpoint identity
 
-The cleanup identity boundary was validated on 2026-07-28 with tmux 3.6a and metadata fixtures for every supported backend.
+The cleanup identity boundary was refreshed on 2026-08-30 with metadata fixtures for every supported backend and the current composite Orca worktree-id shape.
 
 ```sh
 tests/fm-teardown-endpoint-safety.test.sh
@@ -193,7 +193,8 @@ Bounded output from the incident regression:
 
 ```text
 ok - fm-teardown: missing, empty, malformed, ambiguous, and task-mismatched endpoints refuse before every mutation or runtime call
-ok - cleanup identity: valid tmux, Herdr, Zellij, Orca, and cmux records validate while every empty backend target refuses
+ok - fm-teardown: malformed, ambiguous, duplicated, control-bearing, and inconsistent Orca composite ids refuse before runtime calls
+ok - cleanup identity: valid tmux, Herdr, Zellij, composite/simple Orca, and cmux records validate while every empty backend target refuses
 ok - tmux backend: direct empty target returns nonzero without invoking tmux
 ok - process cleanup: creation-time PID identity removes only the exact child and preserves the control child
 ok - fm-teardown: dedicated-socket invalid cleanup preserves target/control and valid cleanup removes only the exact target
@@ -202,6 +203,7 @@ ok - fm-teardown: dedicated-socket invalid cleanup preserves target/control and 
 The dedicated tmux cell removed ambient tmux variables, required a socket-bound wrapper, kept one target and one independent control window, and proved the wrapper was not called for invalid metadata or a direct empty target.
 Valid cleanup removed only the exact task-bound target and left the control window live.
 The metadata-only validation covers tmux, Herdr, Zellij, Orca, and cmux before backend dispatch.
+Only Orca worktree ids use the composite contract; tmux endpoint parsing and the generic single-atom checks for Herdr, Zellij, cmux, and Orca terminal handles remain unchanged.
 Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, Cursor, and Muse share that backend cleanup boundary; their harness-specific hook files, tokens, transcript bindings, and session-log sidecars are cleaned only after it, so no harness needs a separate endpoint parser.
 
 ## Composer classification matrix
@@ -697,10 +699,12 @@ The real lifecycle smoke proved spawn, metadata, nested-subshell worktree discov
 
 ## Orca
 
-Real readiness was verified against `/usr/local/bin/orca` with `/Applications/Orca.app` bundle version 1.4.116.
+Real compatibility evidence was refreshed on 2026-08-30 against the Orca app/runtime version 1.4.192.
 
 ```sh
 orca status --json
+recorded_id=$(sed -n 's/^orca_worktree_id=//p' state/<id>.meta)
+orca worktree show --worktree "id:$recorded_id" --json
 ```
 
 Observed fields:
@@ -712,15 +716,20 @@ result.runtime.state=ready
 
 `orca terminal create --json` returned `result.terminal.handle`.
 `orca worktree create` returned `result.worktree.id` and `result.worktree.path`.
-Speculative bare ids and nested terminal fields were deliberately rejected.
+The current `result.worktree.id` shape was `<repo UUID>::<absolute worktree path>`, and the matching live `orca worktree show` returned that exact recorded path.
+The live terminal record reported the same worktree id and path.
+The earlier single-atom worktree id remains covered as a compatibility form.
+Speculative terminal-id fields remain rejected.
 
 ```sh
 tests/fm-backend-orca.test.sh
+tests/fm-teardown-endpoint-safety.test.sh
+tests/fm-control.test.sh
 tests/fm-backend.test.sh
 tests/fm-bootstrap.test.sh
 ```
 
-The fake-Orca suite covers readiness, registration, create response parsing, metadata routing, popup-safe submit, and path-matched release refusal.
+The fake-Orca and endpoint-safety suites cover readiness, registration, composite and simple create response parsing, exact composite-id helper arguments, metadata routing, popup-safe submit, strict composite metadata refusal, and path-matched release refusal.
 
 ## cmux
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -295,7 +295,7 @@ The CLI matrix was checked directly:
 | --- | --- | --- |
 | Explicit session routing | `herdr <verb> ... --session <name>` | Reached the named session even while another server was running. |
 | Literal send | `herdr pane send-text <pane> <text> --session <name>` | Left text unsubmitted until Enter. |
-| Keys | `herdr pane send-keys <pane> enter|escape|ctrl+c --session <name>` | Enter and Escape worked; Ctrl-C interrupted foreground work. |
+| Keys | `herdr pane send-keys <pane> enter\|escape\|ctrl+c --session <name>` | Enter and Escape worked; Ctrl-C interrupted foreground work. |
 | Capture | `herdr pane read <pane> --source recent --lines N` | Small N could return empty below viewport height; a 200-line request plus local trim was stable. |
 | Native state | `herdr agent get <pane>` | Working and done transitions were visible on some harnesses; live Claude Code 2.1.236 on Herdr 0.8.0 kept `agent_status=idle` for an entire landed turn, including a multi-second tool call, so submit confirmation falls through to the shared composer verdict. Native `busy` remains positive activity evidence, while native `idle` cannot close a turn and the adapter's semantic lifecycle decides worker state. |
 | Restart | guarded named-session stop then start | Workspace, tab, pane, and labels persisted; the agent process and registration did not. |
@@ -489,7 +489,7 @@ HERDR_LAB_HELPER=bin/fm-herdr-lab.sh \
 Observed output on Herdr 0.7.5:
 
 ```text
-ok - old path: the explicit last-pane close of a non-focused workspace stole focus (w3	w3:t1 -> w2	w2:t1)
+ok - old path: the explicit last-pane close of a non-focused workspace stole focus (w3<TAB>w3:t1 -> w2<TAB>w2:t1)
 ok - mitigation: every in-operation sample preserved exact focus while the doomed workspace was removed
 ok - mitigation: no explicit close and no corrective focus were needed on the defective release
 ok - fallback: a doomed pane holding a persistent child exhausts the proof and takes the plain explicit close
@@ -521,7 +521,7 @@ Default-on presentation projection is floored at Herdr 0.8.0.
 The floor's structural signal is the selected running server's protocol number, falling back to the client protocol only when that selected session positively reports no running server, and the release mapping was measured on 2026-08-05 by running each pinned upstream macOS aarch64 release asset's own `status --json` through the guarded lab helper:
 
 | Release | Reported version | Protocol | Carries both upstream focus fixes | Floor verdict |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | v0.7.3 | 0.7.3 | 16 | no | below |
 | v0.7.4 | 0.7.4 | 16 | no | below |
 | v0.7.5 | 0.7.5 | 17 | no | below |
@@ -767,7 +767,7 @@ Current active CLI findings:
 | Fresh readiness | `list-panes --workspace <id> --json --id-format uuids` | Found a brand-new surface before content existed. |
 | Fresh read counterexample | `read-screen` before any write | Returned `internal_error: Failed to read terminal text`. |
 | Literal send | `send --workspace <id> --surface <id> -- <text>` | Left text unsubmitted. |
-| Keys | `send-key ... enter|escape|ctrl-c` | All shared key operations worked. |
+| Keys | `send-key ... enter\|escape\|ctrl-c` | All shared key operations worked. |
 | Nested cwd | `current_directory` plus foreground subshell | Structured cwd froze; the marker-delimited `pwd` probe found the live cwd. |
 | Last surface | `close-surface` on the only surface | Refused with `invalid_state: Cannot close the last surface`. |
 | Last workspace | `close-workspace` on the only workspace in a window | Printed success but left the workspace present. |

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -368,16 +368,25 @@ test_remove_worktree_rejects_orca_error_json() {
   pass "fm_backend_orca_remove_worktree: fails closed on ok:false JSON"
 }
 
-test_worktree_path_resolves_id() {
-  local out
-  orca_case path-resolve
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-123","path":"/tmp/orca-wt"}}}\n' > "$RESP/1.out"
+test_worktree_helpers_preserve_composite_id() {
+  local out worktree_id
+  worktree_id=123e4567-e89b-12d3-a456-426614174000::/tmp/orca-wt
+  orca_case composite-id-helpers
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"/tmp/orca-wt"}}}\n' \
+    "$worktree_id" > "$RESP/1.out"
+  printf '{"ok":true,"result":{}}\n' > "$RESP/2.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
-    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_path wt-123' "$ROOT" )
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_path "$1"' "$ROOT" "$worktree_id" )
   [ "$out" = /tmp/orca-wt ] || fail "worktree path helper should print the resolved path, got '$out'"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-123'$'\x1f''--json' \
-    "worktree path helper did not call orca worktree show"
-  pass "fm_backend_orca_worktree_path: resolves an Orca worktree id to its path"
+  PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_remove_worktree "$1"' "$ROOT" "$worktree_id"
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:'"$worktree_id"$'\x1f''--json' \
+    "worktree path helper did not pass the exact composite id to orca worktree show"
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:'"$worktree_id"$'\x1f''--force'$'\x1f''--json' \
+    "worktree removal helper did not pass the exact composite id to orca worktree rm"
+  pass "Orca worktree helpers: preserve the exact composite id for path resolution and removal"
 }
 
 test_json_get_ignores_undocumented_terminal_id_shapes() {
@@ -488,7 +497,7 @@ test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails() {
 }
 
 test_spawn_writes_orca_metadata_and_launches_harness() {
-  local proj wt data state config id out log
+  local proj wt data state config id out log worktree_id
   id="orcaspawnz1"
   proj="$TMP_ROOT/spawn-project"
   wt="$TMP_ROOT/spawn-wt"
@@ -501,9 +510,11 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   touch "$state/.last-watcher-beat"
   orca_case spawn
   log="$LOG"
+  worktree_id="123e4567-e89b-12d3-a456-426614174000::$wt"
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-spawn"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-spawn","path":"%s"},"terminal":{"handle":"term-spawn"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"},"terminal":{"handle":"term-spawn"}}}\n' \
+    "$worktree_id" "$wt" > "$RESP/3.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
@@ -514,7 +525,8 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   assert_grep "backend=orca" "$state/$id.meta" "meta missing backend=orca"
   assert_grep "window=fm-$id" "$state/$id.meta" "meta missing stable Orca window alias"
   assert_grep "terminal=term-spawn" "$state/$id.meta" "meta missing terminal handle"
-  assert_grep "orca_worktree_id=wt-spawn" "$state/$id.meta" "meta missing Orca worktree id"
+  assert_grep "orca_worktree_id=$worktree_id" "$state/$id.meta" \
+    "spawn did not preserve the composite Orca worktree id"
   assert_grep "worktree=$wt" "$state/$id.meta" "meta missing Orca worktree path"
   assert_not_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''create' \
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
@@ -996,7 +1008,7 @@ test_ship_teardown_refuses_orca_missing_worktree_path() {
 }
 
 test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
-  local proj wt data state config id out rc neutral
+  local proj wt data state config id out rc neutral worktree_id
   id="orcashipmatchz2"
   proj="$TMP_ROOT/ship-match-project"
   wt="$TMP_ROOT/ship-match-wt"
@@ -1006,12 +1018,14 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
   fm_git_worktree "$proj" "$wt" "fm/$id"
   mkdir -p "$data/$id" "$state" "$config"
   touch "$state/.last-watcher-beat"
+  worktree_id="123e4567-e89b-12d3-a456-426614174000::$wt"
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-match" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-match"
+    "backend=orca" "orca_worktree_id=$worktree_id"
   orca_case ship-match
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-match","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' \
+    "$worktree_id" "$wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -1020,12 +1034,14 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
   rc=$?
   set -e
   expect_code 0 "$rc" "Orca ship teardown should succeed when the id path matches the inspected worktree"$'\n'"$out"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-match'$'\x1f''--json' \
-    "teardown did not resolve the Orca worktree id before removal"
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:'"$worktree_id"$'\x1f''--json' \
+    "teardown did not resolve the exact composite Orca worktree id before removal"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-ship-match'$'\x1f''--json' \
     "teardown did not close the matched Orca terminal"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-ship-match'$'\x1f''--force'$'\x1f''--json' \
-    "teardown did not remove the matched Orca worktree"
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:'"$worktree_id"$'\x1f''--force'$'\x1f''--json' \
+    "teardown did not remove the matched composite Orca worktree"
   assert_absent "$state/$id.meta" "successful matched teardown should remove task metadata"
   pass "fm-teardown.sh backend=orca: ship teardown requires a matching Orca id path"
 }
@@ -1068,7 +1084,7 @@ test_ship_teardown_refuses_orca_unresolvable_worktree_id() {
 }
 
 test_ship_teardown_refuses_orca_id_path_mismatch() {
-  local proj wt other_wt data state config id out rc neutral
+  local proj wt other_wt data state config id out rc neutral worktree_id
   id="orcashipmismatchz9"
   proj="$TMP_ROOT/ship-mismatch-project"
   wt="$TMP_ROOT/ship-mismatch-wt"
@@ -1080,12 +1096,14 @@ test_ship_teardown_refuses_orca_id_path_mismatch() {
   git -C "$proj" worktree add --quiet -b "fm/$id-other" "$other_wt"
   mkdir -p "$data/$id" "$state" "$config"
   touch "$state/.last-watcher-beat"
+  worktree_id="123e4567-e89b-12d3-a456-426614174000::$wt"
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-mismatch" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-mismatch"
+    "backend=orca" "orca_worktree_id=$worktree_id"
   orca_case ship-mismatch
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' \
+    "$worktree_id" "$other_wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -1096,8 +1114,9 @@ test_ship_teardown_refuses_orca_id_path_mismatch() {
   [ "$rc" -ne 0 ] || fail "Orca ship teardown should refuse when the id path differs from worktree="
   assert_contains "$out" "not inspected worktree" \
     "mismatched Orca worktree path refusal should name the mismatch"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-mismatch'$'\x1f''--json' \
-    "teardown did not resolve the mismatched Orca worktree id"
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:'"$worktree_id"$'\x1f''--json' \
+    "teardown did not resolve the exact composite Orca worktree id before detecting the live path mismatch"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
     "refused mismatched Orca ship teardown should not close terminals"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm' \
@@ -1324,7 +1343,7 @@ test_send_key_refuses_escape_until_supported
 test_kill_is_best_effort_close
 test_remove_worktree_refuses_empty_id
 test_remove_worktree_rejects_orca_error_json
-test_worktree_path_resolves_id
+test_worktree_helpers_preserve_composite_id
 test_dispatcher_sources_orca_and_routes_primitives
 test_json_get_ignores_undocumented_terminal_id_shapes
 test_worktree_and_terminal_helpers_parse_json

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -385,20 +385,23 @@ test_harness_kind_capability() {
 }
 
 test_orca_refuses_an_escape_harness_interrupt() {
-  local dir out rc
+  local dir out rc worktree_id
   dir=$(new_case orca-escape)
   add_task "$dir" t1 claude ship orca "term-1"
+  worktree_id="123e4567-e89b-12d3-a456-426614174000::$dir/wt-t1"
   # Orca records its endpoint as terminal=, which endpoint validation requires.
   {
     cat "$dir/home/state/t1.meta"
     echo "terminal=term-1"
-    echo "orca_worktree_id=wt-1"
+    echo "orca_worktree_id=$worktree_id"
   } > "$dir/home/state/t1.meta.new"
   sed 's|^window=.*|window=fm-t1|' "$dir/home/state/t1.meta.new" > "$dir/home/state/t1.meta"
   out=$(run_control "$dir" t1 interrupt); rc=$?
   expect_code 1 "$rc" "an Escape harness on orca should refuse"
-  assert_contains "$out" "cannot deliver" "refusal should name the undeliverable key"
-  pass "fm-control interrupt: a backend that cannot deliver the harness's key refuses instead of sending another"
+  assert_contains "$out" "cannot deliver" "a valid composite Orca id should reach the backend key-capability refusal"
+  assert_not_contains "$out" "malformed or inconsistent" \
+    "a current composite Orca id should pass control endpoint validation"
+  pass "fm-control interrupt: composite Orca ids validate before unsupported Escape refuses"
 }
 
 test_unverified_state_backends_refuse_stop_verbs() {

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -30,7 +30,15 @@ printf ' <%s>' "$@" >> "${FM_RUNTIME_LOG:?}"
 printf '\n' >> "${FM_RUNTIME_LOG:?}"
 exit 0
 SH
-  chmod +x "$TMP_ROOT/$dir/fakebin/tmux" "$TMP_ROOT/$dir/fakebin/treehouse"
+  cat > "$TMP_ROOT/$dir/fakebin/orca" <<'SH'
+#!/usr/bin/env bash
+printf 'orca' >> "${FM_RUNTIME_LOG:?}"
+printf ' <%s>' "$@" >> "${FM_RUNTIME_LOG:?}"
+printf '\n' >> "${FM_RUNTIME_LOG:?}"
+exit 0
+SH
+  chmod +x "$TMP_ROOT/$dir/fakebin/tmux" "$TMP_ROOT/$dir/fakebin/treehouse" \
+    "$TMP_ROOT/$dir/fakebin/orca"
   printf '%s\n' "$TMP_ROOT/$dir"
 }
 
@@ -190,8 +198,65 @@ test_metadata_lock_serializes_destructive_cleanup() {
   pass "fm-teardown: destructive cleanup serializes with metadata writers"
 }
 
+test_orca_composite_endpoint_refusals_precede_runtime_calls() {
+  local dir id=orca-composite-invalid uuid
+  uuid=123e4567-e89b-12d3-a456-426614174000
+
+  dir=$(make_case orca-bad-uuid)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=not-a-uuid::$dir/worktree"
+  assert_refused_without_mutation "$dir" "$id" "Orca composite id with malformed repository UUID"
+
+  dir=$(make_case orca-relative-path)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=$uuid::relative/worktree"
+  assert_refused_without_mutation "$dir" "$id" "Orca composite id with relative path"
+
+  dir=$(make_case orca-ambiguous-id)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=$uuid::$dir/worktree::duplicate"
+  assert_refused_without_mutation "$dir" "$id" "Orca composite id with ambiguous delimiter"
+
+  dir=$(make_case orca-path-mismatch)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=$uuid::$dir/other-worktree"
+  assert_refused_without_mutation "$dir" "$id" "Orca composite id with inconsistent recorded path"
+
+  dir=$(make_case orca-control-character)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=$uuid::$dir/worktree"$'\033'
+  assert_refused_without_mutation "$dir" "$id" "Orca composite id with control character"
+
+  dir=$(make_case orca-duplicate-id)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=$uuid::$dir/worktree" \
+    "orca_worktree_id=$uuid::$dir/worktree"
+  assert_refused_without_mutation "$dir" "$id" "duplicated Orca composite id"
+
+  dir=$(make_case orca-invalid-terminal)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term/7" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=$uuid::$dir/worktree"
+  assert_refused_without_mutation "$dir" "$id" "Orca composite id with malformed terminal handle"
+
+  pass "fm-teardown: malformed, ambiguous, duplicated, control-bearing, and inconsistent Orca composite ids refuse before runtime calls"
+}
+
 test_supported_backend_endpoint_records_validate() {
-  local dir id backend target
+  local dir id backend target composite_id
   dir=$(make_case valid-backends)
   # shellcheck source=/dev/null
   . "$ROOT/bin/fm-backend.sh"
@@ -221,11 +286,18 @@ test_supported_backend_endpoint_records_validate() {
   fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" || fail "valid Zellij endpoint refused"
 
   id=orca-task
+  composite_id="123e4567-e89b-12d3-a456-426614174000::$dir/worktree"
   fm_write_meta "$dir/home/state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
-    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" "orca_worktree_id=worktree-9"
-  fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" || fail "valid Orca endpoint refused"
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" "orca_worktree_id=$composite_id"
+  fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" || fail "valid composite Orca endpoint refused"
   [ "$FM_BACKEND_VALIDATED_TARGET" = term-7 ] || fail "Orca validation did not select its terminal"
+
+  id=orca-simple-task
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-8" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" "orca_worktree_id=worktree-9"
+  fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" || fail "valid simple Orca endpoint refused"
 
   id=cmux-task
   fm_write_meta "$dir/home/state/$id.meta" \
@@ -240,7 +312,7 @@ test_supported_backend_endpoint_records_validate() {
     set -e
     [ "$target" -ne 0 ] || fail "$backend generic kill accepted an empty target"
   done
-  pass "cleanup identity: valid tmux, Herdr, Zellij, Orca, and cmux records validate while every empty backend target refuses"
+  pass "cleanup identity: valid tmux, Herdr, Zellij, composite/simple Orca, and cmux records validate while every empty backend target refuses"
 }
 
 test_tmux_empty_target_refuses_without_invocation() {
@@ -366,6 +438,7 @@ SH
 }
 
 test_invalid_endpoint_records_refuse_before_mutation
+test_orca_composite_endpoint_refusals_precede_runtime_calls
 test_control_lock_contention_refuses_before_mutation
 test_metadata_lock_serializes_destructive_cleanup
 test_supported_backend_endpoint_records_validate

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -233,7 +233,7 @@ test_orca_composite_endpoint_refusals_precede_runtime_calls() {
   dir=$(make_case orca-control-character)
   fm_write_meta "$dir/home/state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
-    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "worktree=$dir/worktree"$'\033' "project=$dir/project" "backend=orca" \
     "orca_worktree_id=$uuid::$dir/worktree"$'\033'
   assert_refused_without_mutation "$dir" "$id" "Orca composite id with control character"
 


### PR DESCRIPTION
## Summary

- accept Orca 1.4.192 composite worktree IDs only in the strict `<repo UUID>::<absolute worktree path>` form while preserving legacy single-atom IDs
- bind the embedded path to recorded worktree metadata and retain the independent live ID-to-path check before terminal closure or worktree removal
- add control, spawn, malformed-metadata, exact-helper-argument, cleanup-safety, path-mismatch, control-character, and legacy-ID regressions
- update the authoritative Orca guide and active runtime verification evidence

## Validation

- no-mistakes source review, focused tests, and documentation checks passed on validated head `bdd201ad`
- focused Orca control and cleanup regressions passed
- non-Orca backend suites remained green
- pinned ShellCheck/actionlint validation passed before the no-mistakes run; the isolated lint step could not find ShellCheck in its PATH

## Known pre-existing failure

`tests/fm-backend-orca.test.sh` retains the unrelated existing failure in `test_spawn_releases_orca_resources_when_metadata_write_fails`: `fm-spawn.sh` prints a metadata-write error when the target metadata path is a directory but still exits successfully. The same failure was reproduced at base `debe4bf` and branch tip `7f5b1ae`; this PR does not touch that metadata-publication path.
