### PR TITLE
fix: distinguish passive CI monitoring from active work

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -339,12 +339,12 @@ nm_ci_checks_state() {
   log_tail=$(nm_run axi logs --step ci --run "$run_id") || true
   [ -n "$log_tail" ] || { printf 'unknown'; return; }
   marker=$(printf '%s\n' "$log_tail" \
-    | grep -E 'CI checks passed|no CI checks reported - still monitoring|repository declares no CI .*treating as all checks passed.*still monitoring|no CI checks reported yet|checks failed|issues detected|CI checks running|base branch advanced.*re-arming CI monitor timeout' \
+    | grep -E 'CI checks passed|no CI checks reported - still monitoring|repository declares no CI .*treating as all checks passed.*still monitoring|no CI checks reported yet|checks failed|issues detected but checks still pending|manual fix requested|auto-fixing|CI checks running|base branch advanced.*re-arming CI monitor timeout' \
     | tail -1)
   case "$marker" in
     *"checks passed"*|*"no CI checks reported - still monitoring"*) printf 'green' ;;
-    *"issues detected"*) printf 'fixing' ;;
-    *"no CI checks reported yet"*|*"checks failed"*|*"CI checks running"*|*"base branch advanced"*"re-arming CI monitor timeout"*) printf 'not-ready' ;;
+    *"manual fix requested"*|*"auto-fixing"*) printf 'fixing' ;;
+    *"no CI checks reported yet"*|*"checks failed"*|*"issues detected but checks still pending"*|*"CI checks running"*|*"base branch advanced"*"re-arming CI monitor timeout"*) printf 'not-ready' ;;
     *) printf 'unknown' ;;
   esac
 }
@@ -525,7 +525,7 @@ if [ "$HAVE_RUN" = 1 ]; then
     # status_span_first_actionable) regardless of this coarse-vs-full
     # distinction, so a real gate is never silently missed.
     case "$COARSE_STATUS" in
-      running)   RUN_STATE=working; RUN_DETAIL="validating (background run)" ;;
+      running)   RUN_STATE=unknown; RUN_DETAIL="background run active; exact phase unavailable" ;;
       completed) RUN_STATE="done";  RUN_DETAIL="run completed" ;;
       failed)    RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
       cancelled) RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
@@ -601,7 +601,7 @@ if [ "$HAVE_RUN" = 1 ]; then
     fi
   fi
 
-  if { [ "$RUN_STATE" = working ] || { [ "$RUN_STATE" = parked ] && [ "$RUN_IS_GATE_PARKED" != 1 ]; }; } \
+  if { [ "$RUN_SOURCE" = coarse ] || [ "$RUN_STATE" = working ] || { [ "$RUN_STATE" = parked ] && [ "$RUN_IS_GATE_PARKED" != 1 ]; }; } \
     && log_reports_ci_ready; then
     if [ "$RUN_SOURCE" = coarse ]; then
       emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
@@ -624,7 +624,7 @@ if [ "$HAVE_RUN" = 1 ]; then
   # stale: the gate resolved and the run resumed or finished.
   case "$LOG_VERB" in
     needs-decision|blocked)
-      if [ "$RUN_IS_GATE_PARKED" != 1 ]; then
+      if [ "$RUN_SOURCE" != coarse ] && [ "$RUN_IS_GATE_PARKED" != 1 ]; then
         if [ "$RUN_STATE" = working ]; then
           RUN_DETAIL="$RUN_DETAIL${SEP}status-log superseded by active run"
         else

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -34,8 +34,8 @@
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
 #      the active step is ci, `axi status` alone cannot tell "still waiting on
 #      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
-#      a ci-step log-tail check overrides working -> done once checks read
-#      green, so a green PR is never silently read as still-validating.
+#      a ci-step log-tail check distinguishes a passive wait, active remediation,
+#      and checks green, so none is silently reported as generic validation.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log
@@ -516,9 +516,10 @@ if [ "$HAVE_RUN" = 1 ]; then
   RUN_STATUS=""
   RUN_IS_GATE_PARKED=0
   if [ "$RUN_SOURCE" = coarse ]; then
-    # No step/gate detail is available from the plain runs list - only ever
-    # true/working, done, or failed. A crew genuinely parked at a gate still
-    # gets full detail once `axi status` reports its own branch again (e.g.
+    # No step/gate detail is available from the plain runs list, so an active
+    # row is unknown rather than presumed working or parked. A crew genuinely
+    # parked at a gate still gets full detail once `axi status` reports its own
+    # branch again (e.g.
     # once its own step is the most-recently-touched one), and its own
     # needs-decision/blocked status-log append (a captain-relevant VERB) is
     # surfaced by each supervisor's span classification (fm-classify-lib.sh's

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -28,8 +28,9 @@
 #      gone/dead.
 #   2. Attribute an active or terminal no-mistakes run under the branch, head,
 #      pipeline-custody, and newest-first rules owned by bin/fm-nm-run-lib.sh.
-#      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
-#      awaiting_approval/fix_review -> parked (with gate findings), terminal
+#      The run-step is AUTHORITATIVE: implementation/fix activity -> working,
+#      passive CI/check monitoring -> parked, awaiting_approval/fix_review ->
+#      parked (with gate findings), terminal
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
 #      the active step is ci, `axi status` alone cannot tell "still waiting on
 #      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
@@ -338,11 +339,12 @@ nm_ci_checks_state() {
   log_tail=$(nm_run axi logs --step ci --run "$run_id") || true
   [ -n "$log_tail" ] || { printf 'unknown'; return; }
   marker=$(printf '%s\n' "$log_tail" \
-    | grep -E 'CI checks passed|no CI checks reported - still monitoring|no CI checks reported yet|checks failed|issues detected|CI checks running|base branch advanced.*re-arming CI monitor timeout' \
+    | grep -E 'CI checks passed|no CI checks reported - still monitoring|repository declares no CI .*treating as all checks passed.*still monitoring|no CI checks reported yet|checks failed|issues detected|CI checks running|base branch advanced.*re-arming CI monitor timeout' \
     | tail -1)
   case "$marker" in
     *"checks passed"*|*"no CI checks reported - still monitoring"*) printf 'green' ;;
-    *"no CI checks reported yet"*|*"checks failed"*|*"issues detected"*|*"CI checks running"*|*"base branch advanced"*"re-arming CI monitor timeout"*) printf 'not-ready' ;;
+    *"issues detected"*) printf 'fixing' ;;
+    *"no CI checks reported yet"*|*"checks failed"*|*"CI checks running"*|*"base branch advanced"*"re-arming CI monitor timeout"*) printf 'not-ready' ;;
     *) printf 'unknown' ;;
   esac
 }
@@ -472,6 +474,7 @@ if [ "$HAVE_RUN" = 1 ]; then
   CI_STEP_STATUS=""
   CI_LOG_STATE=""
   RUN_STATUS=""
+  RUN_IS_GATE_PARKED=0
   if [ "$RUN_SOURCE" = coarse ]; then
     # No step/gate detail is available from the plain runs list - only ever
     # true/working, done, or failed. A crew genuinely parked at a gate still
@@ -514,6 +517,7 @@ if [ "$HAVE_RUN" = 1 ]; then
       [ -n "$gate" ] || gate=$status
       [ -n "$gate" ] || gate=gate
       RUN_STATE=parked
+      RUN_IS_GATE_PARKED=1
       RUN_DETAIL="parked at $gate"
       fcount=$(nm_gate_findings_count)
       [ -n "$fcount" ] && RUN_DETAIL="$RUN_DETAIL: $fcount finding(s)"
@@ -538,6 +542,15 @@ if [ "$HAVE_RUN" = 1 ]; then
             if [ "$CI_LOG_STATE" = green ]; then
               RUN_STATE="done"
               RUN_DETAIL="checks green: PR ready for review (still monitoring for merge/close)"
+            elif [ "$CI_LOG_STATE" = fixing ]; then
+              RUN_STATE=working
+              RUN_DETAIL="ci remediation active"
+            elif [ "$CI_LOG_STATE" = not-ready ]; then
+              RUN_STATE=parked
+              RUN_DETAIL="waiting for CI checks"
+            else
+              RUN_STATE=parked
+              RUN_DETAIL="waiting for CI status (monitor log unavailable)"
             fi
             ;;
           fixing)
@@ -548,7 +561,8 @@ if [ "$HAVE_RUN" = 1 ]; then
     fi
   fi
 
-  if [ "$RUN_STATE" = working ] && log_reports_ci_ready; then
+  if { [ "$RUN_STATE" = working ] || { [ "$RUN_STATE" = parked ] && [ "$RUN_IS_GATE_PARKED" != 1 ]; }; } \
+    && log_reports_ci_ready; then
     if [ "$RUN_SOURCE" = coarse ]; then
       emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
     fi
@@ -560,7 +574,7 @@ if [ "$HAVE_RUN" = 1 ]; then
     elif [ "$CI_STEP_STATUS" = fixing ]; then
       CI_LOG_STATE=not-ready
     fi
-    if [ "$CI_LOG_STATE" != not-ready ]; then
+    if [ "$CI_LOG_STATE" != not-ready ] && [ "$CI_LOG_STATE" != fixing ]; then
       emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
     fi
   fi
@@ -570,7 +584,7 @@ if [ "$HAVE_RUN" = 1 ]; then
   # stale: the gate resolved and the run resumed or finished.
   case "$LOG_VERB" in
     needs-decision|blocked)
-      if [ "$RUN_STATE" != parked ]; then
+      if [ "$RUN_IS_GATE_PARKED" != 1 ]; then
         if [ "$RUN_STATE" = working ]; then
           RUN_DETAIL="$RUN_DETAIL${SEP}status-log superseded by active run"
         else

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -348,7 +348,7 @@ nm_ci_checks_state() {
     *) printf 'unknown' ;;
   esac
 }
-# Coarse fallback for cross-branch attribution. `no-mistakes axi status` (bare)
+# Cross-branch attribution. `no-mistakes axi status` (bare)
 # reports the active-or-most-recent run for the CURRENT branch when one
 # exists, else falls back to some other branch's run purely as informational
 # display (verified empirically: querying a worktree with its own active run
@@ -356,18 +356,11 @@ nm_ci_checks_state() {
 # validating crews on the same underlying repo). A crew whose branch genuinely
 # has no run yet therefore sees another branch's answer here.
 #
-# This fallback used to shell out to `no-mistakes axi` (bare, no subcommand)
-# expecting a `runs[N]{id,branch,status,...}:` TOON table and re-query the
-# matched id via `axi status --run <id>`. Verified against the real installed
-# CLI (v1.32.2): the `axi` surface exposes only abort/logs/respond/run/status -
-# there is no runs-listing subcommand under `axi` at all, so that table never
-# appears and the lookup was silently dead code; whenever the bare `axi
-# status` answer was not this crew's own branch, attribution always failed and
-# the caller fell straight through to the pane/log fallback below. (The
-# PRIMARY cause of the 2026-07 herdr false-surface incidents turned out to be
-# a separate bug in bin/fm-watch.sh's stale_is_terminal precedence - see that
-# file's history - but this cross-branch path was independently confirmed
-# dead code and is worth having actually work.)
+# The AXI home view exposes recent runs as structured rows with IDs. Resolve
+# this branch there and re-query the exact run so every attribution path has
+# the same step, gate, and CI-monitor detail. Older no-mistakes versions did
+# not expose that table, so the human-oriented top-level runs list remains a
+# coarse compatibility fallback for terminal state and active-run attribution.
 #
 # The real run-listing command is the top-level `no-mistakes runs` (verified:
 # `no-mistakes --help` lists it separately from `axi`). It is plain, human-
@@ -407,6 +400,40 @@ nm_runs_status_for_branch() {  # <branch>
     fi
   done <<< "$out"
   return 0
+}
+
+nm_axi_run_id_for_branch() {  # <branch>
+  local branch=$1 out in_runs=0 row id rest br st sha
+  out=$(nm_run axi)
+  [ -n "$out" ] || return 0
+  while IFS= read -r row; do
+    case "$row" in
+      runs\[*\]\{id,branch,status,head,pr\}:) in_runs=1; continue ;;
+      [![:space:]]*) in_runs=0 ;;
+    esac
+    [ "$in_runs" = 1 ] || continue
+    row=$(trim "$row")
+    id=${row%%,*}
+    rest=${row#*,}
+    br=${rest%%,*}
+    rest=${rest#*,}
+    st=${rest%%,*}
+    rest=${rest#*,}
+    sha=${rest%%,*}
+    br=$(strip_quotes "$br")
+    sha=$(strip_quotes "$sha")
+    [ "$br" = "$branch" ] || continue
+    case "$(strip_quotes "$st")" in
+      completed|failed|cancelled|running|fixing|awaiting_approval|fix_review|ci) ;;
+      *) return 0 ;;
+    esac
+    if ! nm_coarse_head_matches_worktree "$sha"; then
+      fm_nm_head_resolvable "$WT" "$sha" || return 0
+      continue
+    fi
+    strip_quotes "$id"
+    return 0
+  done <<< "$out"
 }
 
 # CREW_BRANCH is empty at detached HEAD (a just-spawned crew, or a scout's
@@ -454,13 +481,26 @@ if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/n
       # attribution failed (the CLI is alive and answered) - try the coarse
       # fallback.
       # Deliberately nested inside `[ -n "$RUN_OUT" ]`: an empty/timed-out
-      # primary call means the CLI itself did not respond, so retrying it
-      # immediately with a second bounded call would just double the wait
-      # for no better answer.
-      COARSE_STATUS=$(nm_runs_status_for_branch "$CREW_BRANCH")
-      if [ -n "$COARSE_STATUS" ]; then
-        HAVE_RUN=1
-        RUN_SOURCE=coarse
+      # primary call means the CLI itself did not respond, so further bounded
+      # queries would only multiply the wait without improving attribution.
+      run_id=$(nm_axi_run_id_for_branch "$CREW_BRANCH")
+      if [ -n "$run_id" ]; then
+        exact_run=$(nm_run axi status --run "$run_id")
+        exact_branch=$(strip_quotes "$(fm_nm_field "$exact_run" branch)")
+        exact_id=$(strip_quotes "$(fm_nm_field "$exact_run" id)")
+        if [ "$exact_id" = "$run_id" ] && [ "$exact_branch" = "$CREW_BRANCH" ] \
+          && { fm_nm_head_matches_worktree "$WT" "$(strip_quotes "$(fm_nm_field "$exact_run" head)")" \
+            || fm_nm_run_is_pipeline_owned_active "$exact_run"; }; then
+          RUN_OUT=$exact_run
+          HAVE_RUN=1
+        fi
+      fi
+      if [ "$HAVE_RUN" != 1 ]; then
+        COARSE_STATUS=$(nm_runs_status_for_branch "$CREW_BRANCH")
+        if [ -n "$COARSE_STATUS" ]; then
+          HAVE_RUN=1
+          RUN_SOURCE=coarse
+        fi
       fi
     fi
   fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,6 +58,7 @@ A turn-ended-only queue row omits its historical status annotation when that sta
 Any direct or remaining historical annotation prints every status line unread at the presentation cursor instead of replaying only the latest line.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes an active or terminal no-mistakes run under the shared run-attribution contract, then keeps that run-step authoritative even if the pane has closed.
 [`bin/fm-nm-run-lib.sh`](../bin/fm-nm-run-lib.sh)'s header owns the exact branch, head, pipeline-custody, and newest-first attribution rules.
+Complete branch-specific structured lookup beyond AXI home's capped recent-run table remains a no-mistakes API responsibility, so a matching coarse active row reports unknown when its exact phase is unavailable.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 A passive CI or check-registration wait is parked rather than underway, an active CI remediation remains working, and a trusted `no_ci: true` or green-check marker reports the deliverable done even while no-mistakes keeps monitoring the PR.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done, a later re-arm or failed-check marker reports parked, and an active issue-remediation marker returns the crew to working.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,7 @@ Any direct or remaining historical annotation prints every status line unread at
 [`bin/fm-nm-run-lib.sh`](../bin/fm-nm-run-lib.sh)'s header owns the exact branch, head, pipeline-custody, and newest-first attribution rules.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 A passive CI or check-registration wait is parked rather than underway, an active CI remediation remains working, and a trusted `no_ci: true` or green-check marker reports the deliverable done even while no-mistakes keeps monitoring the PR.
-The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
+The most recent recognized ci log marker wins, so checks-green monitoring reports done, a later re-arm or failed-check marker reports parked, and an active issue-remediation marker returns the crew to working.
 Only when no matching run exists does it consult semantic busy state; exact busy reports working, exact idle permits fallback to a status-log event whose verb maps to a recognized run-state, and unknown or a dead pane stays unknown instead of trusting a stale log.
 Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,6 +59,7 @@ Any direct or remaining historical annotation prints every status line unread at
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes an active or terminal no-mistakes run under the shared run-attribution contract, then keeps that run-step authoritative even if the pane has closed.
 [`bin/fm-nm-run-lib.sh`](../bin/fm-nm-run-lib.sh)'s header owns the exact branch, head, pipeline-custody, and newest-first attribution rules.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
+A passive CI or check-registration wait is parked rather than underway, an active CI remediation remains working, and a trusted `no_ci: true` or green-check marker reports the deliverable done even while no-mistakes keeps monitoring the PR.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
 Only when no matching run exists does it consult semantic busy state; exact busy reports working, exact idle permits fallback to a status-log event whose verb maps to a recognized run-state, and unknown or a dead pane stays unknown instead of trusting a stale log.
 Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -51,11 +51,9 @@ make_repo_on_branch() {  # <dir> <branch>
 
 # A fakebin with a fake `no-mistakes` (serves the env-driven run output) and a
 # fake `tmux` (serves a busy or idle pane). The fake no-mistakes mirrors the real
-# command surface the helper uses: `axi status`, `axi status --run <id>` (the
-# `axi` surface - no runs-listing subcommand exists under it, verified against
-# the real CLI), and the actual top-level run-listing command, `no-mistakes
-# runs --limit N`, which is plain text - no run id, no quoting - serving
-# FM_FAKE_RUNS_LIST verbatim.
+# command surface the helper uses: the bare `axi` home view, `axi status`,
+# `axi status --run <id>`, and the top-level `no-mistakes runs --limit N`
+# listing, which is plain text with no run ID or quoting.
 make_fakebin() {  # <dir> -> echoes fakebin path
   local dir=$1 fb="$1/fakebin"
   mkdir -p "$fb"
@@ -721,16 +719,10 @@ test_terminal_failed() {
   pass "terminal failed run is authoritative"
 }
 
-# (e) cross-branch attribution: `axi status` returns ANOTHER branch's run (the
-# routine case once more than one crew validates the same underlying repo
-# concurrently - they share ONE no-mistakes repo registration), so the helper
-# falls back to the real top-level `no-mistakes runs` listing to learn whether
-# THIS branch has an active run of its own. Regression coverage for the
-# 2026-07-02 herdr incident: the old fallback shelled out to `no-mistakes axi`
-# (bare) expecting a `runs[N]{...}:` TOON table that the real CLI never emits
-# (verified against the installed v1.32.2 - the `axi` surface has no
-# runs-listing subcommand at all), so attribution silently failed every time
-# the repo-wide answer was not this crew's own branch.
+# (e) Cross-branch attribution first resolves this branch's run ID from AXI
+# home's capped structured table. If that table omits the branch, the top-level
+# `no-mistakes runs` fallback can prove a run exists but cannot identify its
+# exact phase, so a coarse active row reports unknown.
 test_cross_branch_coarse_running_phase_is_unknown() {
   reset_fakes
   local d short; d=$(new_case crossbranch)

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -66,6 +66,8 @@ case "${1:-}" in
   axi)
     shift
     case "${1:-}" in
+      '')
+        printf '%s\n' "${FM_FAKE_AXI_HOME:-}" ;;
       status)
         shift
         if [ "${1:-}" = --run ]; then printf '%s\n' "${FM_FAKE_AXI_STATUS_RUN:-}"
@@ -162,6 +164,7 @@ arm_idle_record() {  # <state-dir> <id>
 reset_fakes() {
   FM_FAKE_AXI_STATUS=""
   FM_FAKE_AXI_STATUS_RUN=""
+  FM_FAKE_AXI_HOME=""
   FM_FAKE_RUNS_LIST=""
   FM_FAKE_BUSY=0
   FM_FAKE_BUSY_TEXT=
@@ -170,7 +173,7 @@ reset_fakes() {
   FM_FAKE_HERDR_MISSING=0
   FM_FAKE_HERDR_AGENT_STATUS=""
   FM_FAKE_CI_LOGS=""
-  export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
+  export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_AXI_HOME FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
   export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS
 }
 
@@ -733,6 +736,52 @@ EOF
   assert_contains "$out" "state: working" "this branch's own run attributed via the runs list"
   assert_contains "$out" "source: run-step" "runs-list-resolved run -> run-step source"
   pass "cross-branch run is attributed via the real runs list"
+}
+
+test_cross_branch_passive_ci_monitor_parks() {
+  reset_fakes
+  local d short; d=$(new_case crossbranch-ci-wait)
+  make_repo_on_branch "$d/wt" fm/feat-cross-ci-wait
+  short=$(git -C "$d/wt" rev-parse --short=7 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cross-ci-wait.meta" "window=fm:fm-feat-cross-ci-wait" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_AXI_HOME="$(cat <<EOF
+runs[2]{id,branch,status,head,pr}:
+  01OTHER,fm/other-crew,running,aaaaaaa,
+  01TARGET,fm/feat-cross-ci-wait,running,${short},https://github.com/o/r/pull/2
+EOF
+)"
+  FM_FAKE_AXI_STATUS_RUN="$(run_ci_monitoring fm/feat-cross-ci-wait | sed 's/01RUN/01TARGET/')"
+  FM_FAKE_CI_LOGS="CI checks running, waiting for results..."
+  local out; out=$(run_crew_state "$d" feat-cross-ci-wait)
+  assert_contains "$out" "state: parked" "cross-branch passive CI monitor -> parked"
+  assert_contains "$out" "waiting for CI checks" "cross-branch passive CI monitor names the wait"
+  assert_not_contains "$out" "state: working" "cross-branch passive CI monitor must not appear active"
+  pass "cross-branch passive CI monitor parks from exact run status"
+}
+
+test_cross_branch_ci_remediation_stays_working() {
+  reset_fakes
+  local d short; d=$(new_case crossbranch-ci-fixing)
+  make_repo_on_branch "$d/wt" fm/feat-cross-ci-fixing
+  short=$(git -C "$d/wt" rev-parse --short=7 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cross-ci-fixing.meta" "window=fm:fm-feat-cross-ci-fixing" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_AXI_HOME="$(cat <<EOF
+runs[2]{id,branch,status,head,pr}:
+  01OTHER,fm/other-crew,running,aaaaaaa,
+  01TARGET,fm/feat-cross-ci-fixing,running,${short},https://github.com/o/r/pull/2
+EOF
+)"
+  FM_FAKE_AXI_STATUS_RUN="$(run_ci_monitoring fm/feat-cross-ci-fixing | sed 's/01RUN/01TARGET/')"
+  FM_FAKE_CI_LOGS="issues detected: ci failure - auto-fix enabled"
+  local out; out=$(run_crew_state "$d" feat-cross-ci-fixing)
+  assert_contains "$out" "state: working" "cross-branch CI remediation -> working"
+  assert_contains "$out" "ci remediation active" "cross-branch CI remediation names active work"
+  assert_not_contains "$out" "state: parked" "cross-branch CI remediation must not appear passive"
+  pass "cross-branch CI remediation stays working from exact run status"
 }
 
 # The runs list is newest-first; a branch with an OLDER completed run must not
@@ -1589,6 +1638,8 @@ test_top_level_fixing_done_log_stays_working
 test_terminal_passed
 test_terminal_failed
 test_cross_branch_attribution_via_runs_list
+test_cross_branch_passive_ci_monitor_parks
+test_cross_branch_ci_remediation_stays_working
 test_cross_branch_attribution_picks_most_recent_row
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status
 test_other_branch_run_ignored

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -513,7 +513,22 @@ test_ci_monitoring_no_checks_terminal_surfaces_done() {
   pass "terminal no-checks ci-monitor marker surfaces done"
 }
 
-test_ci_monitoring_green_then_rearm_stays_working() {
+test_ci_monitoring_trusted_no_ci_surfaces_done() {
+  reset_fakes
+  local d; d=$(new_case ci-trusted-no-ci)
+  make_repo_on_branch "$d/wt" fm/feat-citrustednoci
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-citrustednoci.meta" "window=fm:fm-feat-citrustednoci" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-citrustednoci)"
+  FM_FAKE_CI_LOGS="repository declares no CI (no_ci: true) - treating as all checks passed - still monitoring until merged or closed"
+  local out; out=$(run_crew_state "$d" feat-citrustednoci)
+  assert_contains "$out" "state: done" "trusted no-ci monitor run -> done"
+  assert_contains "$out" "checks green" "trusted no-ci detail reports readiness"
+  assert_not_contains "$out" "state: working" "trusted no-ci monitor must not read as active work"
+  pass "trusted no-ci monitor marker surfaces done"
+}
+
+test_ci_monitoring_green_then_rearm_parks() {
   reset_fakes
   local d; d=$(new_case ci-green-then-rearm)
   make_repo_on_branch "$d/wt" fm/feat-cirearm
@@ -526,13 +541,14 @@ base branch advanced (aaaaaaa..bbbbbbb), re-arming CI monitor timeout
 EOF
 )
   local out; out=$(run_crew_state "$d" feat-cirearm)
-  assert_contains "$out" "state: working" "base-advance rearm marker -> working"
+  assert_contains "$out" "state: parked" "base-advance rearm marker -> parked"
+  assert_contains "$out" "waiting for CI checks" "base-advance rearm names the external wait"
   assert_not_contains "$out" "state: done" "base-advance rearm marker must not read as done"
   assert_not_contains "$out" "checks green" "base-advance rearm marker must not read as checks green"
-  pass "base-advance rearm after green stays working"
+  pass "base-advance rearm after green parks while waiting"
 }
 
-test_ci_monitoring_no_checks_yet_stays_working() {
+test_ci_monitoring_no_checks_yet_parks() {
   reset_fakes
   local d; d=$(new_case ci-nochecks-yet)
   make_repo_on_branch "$d/wt" fm/feat-cinochecksyet
@@ -546,13 +562,14 @@ no CI checks reported yet, waiting for checks to register...
 EOF
 )
   local out; out=$(run_crew_state "$d" feat-cinochecksyet)
-  assert_contains "$out" "state: working" "pending no-checks marker -> working"
+  assert_contains "$out" "state: parked" "pending no-checks marker -> parked"
+  assert_contains "$out" "waiting for CI checks" "pending no-checks names the external wait"
   assert_not_contains "$out" "state: done" "pending no-checks marker must not read as done"
   assert_not_contains "$out" "checks green" "pending no-checks marker must not read as checks green"
-  pass "pending no-checks ci-monitor marker stays working"
+  pass "pending no-checks ci-monitor marker parks"
 }
 
-test_ci_monitoring_still_waiting_stays_working() {
+test_ci_monitoring_still_waiting_parks() {
   reset_fakes
   local d; d=$(new_case ci-waiting)
   make_repo_on_branch "$d/wt" fm/feat-ciwait
@@ -561,9 +578,10 @@ test_ci_monitoring_still_waiting_stays_working() {
   FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-ciwait)"
   FM_FAKE_CI_LOGS="CI checks running, waiting for results..."
   local out; out=$(run_crew_state "$d" feat-ciwait)
-  assert_contains "$out" "state: working" "ci step still red -> working"
+  assert_contains "$out" "state: parked" "ci step waiting on results -> parked"
+  assert_contains "$out" "waiting for CI checks" "ci wait names the external dependency"
   assert_not_contains "$out" "checks green" "no green marker present -> no checks-green detail"
-  pass "ci-monitoring run with checks not yet green stays working"
+  pass "ci-monitoring run with checks not yet green parks"
 }
 
 # A later merge-conflict auto-fix round after an earlier green reading must
@@ -587,7 +605,7 @@ EOF
   pass "a fresh issue after an earlier green reading is not masked"
 }
 
-test_ci_ready_done_log_relapse_stays_working() {
+test_ci_ready_done_log_relapse_parks() {
   reset_fakes
   local d; d=$(new_case ci-ready-then-relapse)
   make_repo_on_branch "$d/wt" fm/feat-cireadyrelapse
@@ -602,10 +620,11 @@ CI checks running, waiting for results...
 EOF
 )
   local out; out=$(run_crew_state "$d" feat-cireadyrelapse)
-  assert_contains "$out" "state: working" "a stale ready status must not mask a later CI relapse"
+  assert_contains "$out" "state: parked" "a stale ready status must not mask a later CI relapse"
+  assert_contains "$out" "waiting for CI checks" "the later CI wait remains visible"
   assert_contains "$out" "source: run-step" "relapsed ci run remains run-step sourced"
   assert_not_contains "$out" "state: done" "relapsed ci run with stale done log must not read as done"
-  pass "stale checks-green status log does not mask CI relapse"
+  pass "stale checks-green status log does not mask a later CI wait"
 }
 
 test_ci_fixing_after_green_stays_working() {
@@ -1558,11 +1577,12 @@ test_ci_ready_done_log_beats_monitoring_run
 test_ci_monitoring_checks_green_surfaces_done
 test_top_level_ci_checks_green_surfaces_done
 test_ci_monitoring_no_checks_terminal_surfaces_done
-test_ci_monitoring_green_then_rearm_stays_working
-test_ci_monitoring_no_checks_yet_stays_working
-test_ci_monitoring_still_waiting_stays_working
+test_ci_monitoring_trusted_no_ci_surfaces_done
+test_ci_monitoring_green_then_rearm_parks
+test_ci_monitoring_no_checks_yet_parks
+test_ci_monitoring_still_waiting_parks
 test_ci_monitoring_green_then_new_issue_stays_working
-test_ci_ready_done_log_relapse_stays_working
+test_ci_ready_done_log_relapse_parks
 test_ci_fixing_after_green_stays_working
 test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -587,6 +587,21 @@ test_ci_monitoring_still_waiting_parks() {
   pass "ci-monitoring run with checks not yet green parks"
 }
 
+test_ci_monitoring_pending_issues_parks() {
+  reset_fakes
+  local d; d=$(new_case ci-pending-issues)
+  make_repo_on_branch "$d/wt" fm/feat-cipendingissues
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cipendingissues.meta" "window=fm:fm-feat-cipendingissues" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-cipendingissues)"
+  FM_FAKE_CI_LOGS="issues detected but checks still pending, waiting for all checks to complete..."
+  local out; out=$(run_crew_state "$d" feat-cipendingissues)
+  assert_contains "$out" "state: parked" "pending-check issues marker -> parked"
+  assert_contains "$out" "waiting for CI checks" "pending-check issues marker names the wait"
+  assert_not_contains "$out" "state: working" "pending-check issues must not appear as remediation"
+  pass "pending-check issues marker parks"
+}
+
 # A later merge-conflict auto-fix round after an earlier green reading must
 # not be masked: the MOST RECENT marker in the log tail wins.
 test_ci_monitoring_green_then_new_issue_stays_working() {
@@ -716,7 +731,7 @@ test_terminal_failed() {
 # (verified against the installed v1.32.2 - the `axi` surface has no
 # runs-listing subcommand at all), so attribution silently failed every time
 # the repo-wide answer was not this crew's own branch.
-test_cross_branch_attribution_via_runs_list() {
+test_cross_branch_coarse_running_phase_is_unknown() {
   reset_fakes
   local d short; d=$(new_case crossbranch)
   make_repo_on_branch "$d/wt" fm/feat-f
@@ -725,6 +740,20 @@ test_cross_branch_attribution_via_runs_list() {
   fm_write_meta "$d/state/feat-f.meta" "window=fm:fm-feat-f" "worktree=$d/wt" "kind=ship"
   # The repo-wide active/most-recent run belongs to a different crew's branch.
   FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_AXI_HOME="$(cat <<'EOF'
+runs[10]{id,branch,status,head,pr}:
+  01OTHER01,fm/newer-01,running,aaaaaaa,
+  01OTHER02,fm/newer-02,running,aaaaaaa,
+  01OTHER03,fm/newer-03,running,aaaaaaa,
+  01OTHER04,fm/newer-04,running,aaaaaaa,
+  01OTHER05,fm/newer-05,running,aaaaaaa,
+  01OTHER06,fm/newer-06,running,aaaaaaa,
+  01OTHER07,fm/newer-07,running,aaaaaaa,
+  01OTHER08,fm/newer-08,running,aaaaaaa,
+  01OTHER09,fm/newer-09,running,aaaaaaa,
+  01OTHER10,fm/newer-10,running,aaaaaaa,
+EOF
+)"
   # Real `no-mistakes runs` shape: plain text, newest-first, no run id, no
   # quoting - "<status> <branch> <short-sha> <date> [<pr-url>]".
   FM_FAKE_RUNS_LIST="$(cat <<EOF
@@ -733,9 +762,12 @@ test_cross_branch_attribution_via_runs_list() {
 EOF
 )"
   local out; out=$(run_crew_state "$d" feat-f)
-  assert_contains "$out" "state: working" "this branch's own run attributed via the runs list"
-  assert_contains "$out" "source: run-step" "runs-list-resolved run -> run-step source"
-  pass "cross-branch run is attributed via the real runs list"
+  assert_contains "$out" "state: unknown" "coarse running row without exact phase -> unknown"
+  assert_contains "$out" "source: run-step" "coarse running row remains run-step sourced"
+  assert_contains "$out" "exact phase unavailable" "coarse running detail names the missing phase"
+  assert_not_contains "$out" "state: working" "displaced passive monitor must not appear active"
+  assert_not_contains "$out" "state: parked" "unknown coarse phase must not be guessed passive"
+  pass "cross-branch run beyond AXI home cap reports unknown phase"
 }
 
 test_cross_branch_passive_ci_monitor_parks() {
@@ -776,7 +808,7 @@ runs[2]{id,branch,status,head,pr}:
 EOF
 )"
   FM_FAKE_AXI_STATUS_RUN="$(run_ci_monitoring fm/feat-cross-ci-fixing | sed 's/01RUN/01TARGET/')"
-  FM_FAKE_CI_LOGS="issues detected: ci failure - auto-fix enabled"
+  FM_FAKE_CI_LOGS="issues detected: ci failure - auto-fixing (attempt 1/3)..."
   local out; out=$(run_crew_state "$d" feat-cross-ci-fixing)
   assert_contains "$out" "state: working" "cross-branch CI remediation -> working"
   assert_contains "$out" "ci remediation active" "cross-branch CI remediation names active work"
@@ -801,7 +833,7 @@ test_cross_branch_attribution_picks_most_recent_row() {
 EOF
 )"
   local out; out=$(run_crew_state "$d" feat-fq)
-  assert_contains "$out" "state: working" "most recent (running) row wins over an older completed row"
+  assert_contains "$out" "state: unknown" "most recent running row has unknown exact phase"
   assert_contains "$out" "source: run-step" "most-recent-row resolution -> run-step source"
   pass "cross-branch attribution picks the branch's most recent row"
 }
@@ -1332,11 +1364,10 @@ test_missing_meta() {
 # (k) crew_is_provably_working end-to-end over the REAL fm-crew-state.sh (not a
 # canned fake verdict, unlike tests/fm-watch-triage.test.sh's classifier
 # coverage). This is the direct regression pair for the 2026-07-02 herdr
-# incident: a validating crew whose bare `axi status` answer belongs to
-# another branch must still be absorbed by the watcher via the runs-list
-# fallback (working), while a crew with genuinely no run anywhere and an idle
-# pane must still surface (the safety property the fix must never widen away).
-test_provably_working_via_runs_list_fallback() {
+# incident: a validating crew whose exact phase is unavailable must not be
+# absorbed as provably working, and a crew with genuinely no run anywhere and
+# an idle pane must still surface.
+test_coarse_running_is_not_provably_working() {
   reset_fakes
   local d short; d=$(new_case provably-working-crossbranch)
   make_repo_on_branch "$d/wt" fm/feat-provable
@@ -1349,9 +1380,10 @@ test_provably_working_via_runs_list_fallback() {
   running    fm/feat-provable ${short}  2026-07-02 22:05
 EOF
 )"
-  PATH="$d/fakebin:$PATH" FM_STATE_OVERRIDE="$d/state" crew_is_provably_working feat-provable \
-    || fail "cross-branch attribution via the runs list was not treated as provably working"
-  pass "crew_is_provably_working absorbs a validating crew found only via the runs-list fallback"
+  if PATH="$d/fakebin:$PATH" FM_STATE_OVERRIDE="$d/state" crew_is_provably_working feat-provable; then
+    fail "a coarse running row with unknown phase was treated as provably working"
+  fi
+  pass "crew_is_provably_working rejects a coarse run with unknown phase"
 }
 
 test_not_provably_working_when_stopped() {
@@ -1630,6 +1662,7 @@ test_ci_monitoring_trusted_no_ci_surfaces_done
 test_ci_monitoring_green_then_rearm_parks
 test_ci_monitoring_no_checks_yet_parks
 test_ci_monitoring_still_waiting_parks
+test_ci_monitoring_pending_issues_parks
 test_ci_monitoring_green_then_new_issue_stays_working
 test_ci_ready_done_log_relapse_parks
 test_ci_fixing_after_green_stays_working
@@ -1637,7 +1670,7 @@ test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
 test_terminal_passed
 test_terminal_failed
-test_cross_branch_attribution_via_runs_list
+test_cross_branch_coarse_running_phase_is_unknown
 test_cross_branch_passive_ci_monitor_parks
 test_cross_branch_ci_remediation_stays_working
 test_cross_branch_attribution_picks_most_recent_row
@@ -1665,7 +1698,7 @@ test_remote_alive_idle_is_healthy_not_gone
 test_remote_unreachable_is_unknown_remote_not_dead
 test_remote_dead_reports_remote_verdict
 test_missing_meta
-test_provably_working_via_runs_list_fallback
+test_coarse_running_is_not_provably_working
 test_not_provably_working_when_stopped
 test_usage_error
 test_historical_same_branch_rewritten_head_not_current


### PR DESCRIPTION
## Summary

Firstmate could report a no-mistakes run as active work when it was only waiting for external CI checks. That made fleet status look productive even when no implementation or validation was running.

## Fix

- Report passive CI waits as parked.
- Report active remediation as working.
- Report trusted no-CI or green-check completion as done.
- Report coarse cross-branch runs as unknown when their exact phase cannot be proven.
- Recognize pending-check messages separately from active auto-fix messages.
- Document the state contract and add regression coverage.

## Validation

- No-mistakes review completed with no open findings.
- No-mistakes test gate completed.
- No-mistakes documentation gate completed.
- No-mistakes lint gate completed with ShellCheck 0.11.0 and actionlint 1.7.12.
- Changed-file regression selection: 32 suites, 0 failures, 2 expected optional-tool skips.
- Focused fm-crew-state suite passed.