### PR TITLE
fix(bin): contain promote and Relay metadata publishing

### DIFF
--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -234,13 +234,6 @@ fm_backlog_row_probe() {  # <data-dir> <id>
   return 0
 }
 
-# Echo "<state> <held> <blocked>" for one row, e.g. "queued no no".
-# Returns 1 when the row does not exist or cannot be read.
-fm_backlog_row_state() {  # <data-dir> <id>
-  fm_backlog_row_probe "$1" "$2" || return 1
-  printf '%s\n' "$FM_BACKLOG_ROW_STATE"
-}
-
 # Run one tasks-axi mutation against <home>'s backlog, capturing its first
 # output line in FM_BACKLOG_TRANSITION_ERROR on failure.
 fm_backlog_mutate() {  # <data-dir> <verb> <id> [flag...]
@@ -463,7 +456,6 @@ fm_backlog_atomic_transition() {
   shift
   case "$operation" in
     publish) fm_backlog_record_publish "$@" ;;
-    verify-published) fm_backlog_record_present "$@" ;;
     remove) fm_backlog_record_remove "$@" ;;
     dispatch) fm_backlog_dispatch_transition "$@" ;;
     rollback) fm_backlog_dispatch_rollback "$@" ;;

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -122,7 +122,10 @@ META="$STATE/$ID.meta"
 META_LOCK=$(fm_meta_lock_path "$META") || exit 1
 fm_lock_acquire_wait "$META_LOCK"
 META_LOCK_HELD=1
-[ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+if ! fm_backlog_record_present "$META" "task record" "$STATE"; then
+  echo "error: task record for $ID is unsafe or missing ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+  exit 1
+fi
 grep -qx 'kind=scout' "$META" || { echo "error: task $ID is not a scout task (kind=scout not in meta)" >&2; exit 1; }
 
 # The promoted worker must receive the same delivery contract an ordinary ship

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -31,6 +31,10 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-tasks-axi-lib.sh
+. "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-backlog-transition-lib.sh
+. "$SCRIPT_DIR/fm-backlog-transition-lib.sh"
 # shellcheck source=bin/fm-public-followup-lib.sh
 . "$SCRIPT_DIR/fm-public-followup-lib.sh"
 # shellcheck source=bin/fm-secondmate-parent-lib.sh
@@ -156,7 +160,12 @@ grep -v -e '^kind=' -e '^mode=' -e '^yolo=' "$META" > "$TMP"
   echo "mode=$MODE"
   echo "yolo=$YOLO"
 } >> "$TMP"
-mv "$TMP" "$META"
+if ! fm_backlog_atomic_transition publish "$TMP" "$META" "task record" "$STATE"; then
+  rm -f -- "$TMP"
+  TMP=
+  echo "error: task record for $ID could not be published ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+  exit 1
+fi
 TMP=
 fm_lock_release "$META_LOCK"
 META_LOCK_HELD=0

--- a/bin/fm-x-followup.sh
+++ b/bin/fm-x-followup.sh
@@ -157,6 +157,10 @@ case "$ID" in
 esac
 
 META="$STATE/$ID.meta"
+if [ -e "$META" ] || [ -L "$META" ]; then
+  fm_backlog_record_present "$META" "task record" "$STATE" \
+    || { echo "fm-x-followup: unsafe task record in state/$ID.meta" >&2; exit 1; }
+fi
 if [ "$MODE" = clear ]; then
   fmx_meta_link_clear "$META" \
     || { echo "fm-x-followup: could not clear the link in state/$ID.meta" >&2; exit 1; }

--- a/bin/fm-x-lib.sh
+++ b/bin/fm-x-lib.sh
@@ -982,9 +982,11 @@ fmx_meta_followups_set() {
 # missing.
 fmx_meta_link_clear() {
   local meta=$1 tmp lock
+  [ ! -L "$meta" ] || return 1
   [ -f "$meta" ] || return 0
   lock=$(fm_meta_lock_path "$meta") || return 1
   fm_lock_acquire_wait "$lock"
+  [ ! -L "$meta" ] || { fm_lock_release "$lock"; return 1; }
   [ -f "$meta" ] || { fm_lock_release "$lock"; return 0; }
   tmp=$(fmx_meta_tmp "$meta") || { fm_lock_release "$lock"; return 1; }
   if ! { grep -vE '^x_request=|^x_request_ts=|^x_followups=|^x_platform=|^x_reply_max_chars=' "$meta" || true; } > "$tmp"; then

--- a/bin/fm-x-lib.sh
+++ b/bin/fm-x-lib.sh
@@ -48,6 +48,14 @@
 #   fmx_meta_link_clear <meta> - remove the X-request link entirely
 # Callers must have FM_HOME set before calling fmx_load_config.
 
+_FM_X_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if ! command -v fm_backlog_atomic_transition >/dev/null 2>&1; then
+  # shellcheck source=bin/fm-tasks-axi-lib.sh
+  . "$_FM_X_LIB_DIR/fm-tasks-axi-lib.sh"
+  # shellcheck source=bin/fm-backlog-transition-lib.sh
+  . "$_FM_X_LIB_DIR/fm-backlog-transition-lib.sh"
+fi
+
 # Read the value of KEY from a .env-style file: last assignment wins; tolerates a
 # leading "export ", surrounding whitespace, and one layer of matching single or
 # double quotes. Prints nothing (and succeeds) when the file or key is absent, so
@@ -939,7 +947,11 @@ fmx_meta_link_set() {
     ''|*[!0-9]*) ;;
     *) printf 'x_reply_max_chars=%s\n' "$reply_max" >> "$tmp" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; } ;;
   esac
-  mv -f "$tmp" "$meta" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
+  # STATE is the caller's authorized state directory, never dirname of $meta.
+  # shellcheck disable=SC2153
+  if ! fm_backlog_atomic_transition publish "$tmp" "$meta" "task record" "$STATE"; then
+    rm -f "$tmp"; fm_lock_release "$lock"; return 1
+  fi
   fm_lock_release "$lock"
 }
 
@@ -957,7 +969,10 @@ fmx_meta_followups_set() {
     rm -f "$tmp"; fm_lock_release "$lock"; return 1
   fi
   printf 'x_followups=%s\n' "$n" >> "$tmp" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
-  mv -f "$tmp" "$meta" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
+  # shellcheck disable=SC2153
+  if ! fm_backlog_atomic_transition publish "$tmp" "$meta" "task record" "$STATE"; then
+    rm -f "$tmp"; fm_lock_release "$lock"; return 1
+  fi
   fm_lock_release "$lock"
 }
 
@@ -975,6 +990,9 @@ fmx_meta_link_clear() {
   if ! { grep -vE '^x_request=|^x_request_ts=|^x_followups=|^x_platform=|^x_reply_max_chars=' "$meta" || true; } > "$tmp"; then
     rm -f "$tmp"; fm_lock_release "$lock"; return 1
   fi
-  mv -f "$tmp" "$meta" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
+  # shellcheck disable=SC2153
+  if ! fm_backlog_atomic_transition publish "$tmp" "$meta" "task record" "$STATE"; then
+    rm -f "$tmp"; fm_lock_release "$lock"; return 1
+  fi
   fm_lock_release "$lock"
 }

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -262,6 +262,32 @@ test_promote_requires_and_records_the_delivery_contract() {
   pass "fm-promote: promotion requires the delivery contract and records it exactly once"
 }
 
+# A symlink at state/<id>.meta is the containment hazard the shared publisher
+# refuses: promotion must not rewrite the symlink target in place.
+test_promote_refuses_a_symlinked_task_record() {
+  local home meta target original out status leftover
+  home="$TMP_ROOT/promote-symlink/home"
+  mkdir -p "$home/state"
+  meta="$home/state/promote-sym.meta"
+  target="$TMP_ROOT/promote-symlink/foreign-task-record"
+  original="$TMP_ROOT/promote-symlink/foreign-task-record.expected"
+  printf '%s\n' 'window=fm-promote-sym' 'kind=scout' 'worktree=/tmp/wt' > "$target"
+  cp "$target" "$original"
+  ln -s "$target" "$meta"
+
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$PROMOTE" promote-sym --mode direct-PR --yolo on 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "promotion through a symlink record should refuse"
+  assert_contains "$out" "task record" "promotion did not identify the unpublished task record"
+  [ -L "$meta" ] || fail "promotion replaced or removed the symlink record"
+  cmp -s "$target" "$original" \
+    || fail "promotion rewrote the symlink target in place"
+  leftover=$(find "$home/state" -maxdepth 1 -name '.*.meta.promote.*' -print 2>/dev/null || true)
+  [ -z "$leftover" ] || fail "promotion left a staging file after a refused publish: $leftover"
+  pass "fm-promote: a symlinked task record is refused and its target is left untouched"
+}
+
 # The delivery contract only protects a worker that actually receives it. A promoted
 # scout used to get a free-form hint instead of the mode-specific Definition of done,
 # so it never saw the ask-user escalation rule or the --yes ban that every briefed
@@ -386,6 +412,7 @@ test_spawn_refuses_a_brief_mode_mismatch
 test_spawn_notices_a_rigor_downgrade_against_the_registry
 test_scout_records_no_delivery_posture
 test_promote_requires_and_records_the_delivery_contract
+test_promote_refuses_a_symlinked_task_record
 test_promotion_delivers_the_real_definition_of_done
 test_project_mode_maps_the_conditional_policy
 echo "# all fm-task-delivery tests passed"

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -283,6 +283,8 @@ test_promote_refuses_a_symlinked_task_record() {
   [ -L "$meta" ] || fail "promotion replaced or removed the symlink record"
   cmp -s "$target" "$original" \
     || fail "promotion rewrote the symlink target in place"
+  assert_absent "$home/data/promote-sym/ship-instructions.md" \
+    "refused promotion published ship instructions"
   leftover=$(find "$home/state" -maxdepth 1 -name '.*.meta.promote.*' -print 2>/dev/null || true)
   [ -z "$leftover" ] || fail "promotion left a staging file after a refused publish: $leftover"
   pass "fm-promote: a symlinked task record is refused and its target is left untouched"

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -2526,9 +2526,11 @@ test_meta_helpers_refuse_a_symlinked_task_record() {
   printf 'FMX_PAIRING_TOKEN=tok-sym\n' > "$home/.env"
   FM_HOME="$home" FMX_DRY_RUN=1 FMX_NOW_OVERRIDE=1700003600 PATH="$fakebin:$BASE_PATH" \
     "$ROOT/bin/fm-x-followup.sh" sym-task - <<<"milestone update" >/dev/null 2>&1; rc=$?
-  [ "$rc" -ne 0 ] || fail "a follow-up post must not rewrite a symlink record after posting"
-  assert_grep "x_followups=0" "$target" "a follow-up post incremented the counter through the symlink"
-  assert_symlink_untouched "follow-up post"
+  [ "$rc" -ne 0 ] || fail "a follow-up through a symlink record should refuse"
+  assert_absent "$home/state/x-outbox/req-sym.json" \
+    "a refused symlink record still published a follow-up"
+  assert_grep "x_followups=0" "$target" "a refused follow-up incremented the counter through the symlink"
+  assert_symlink_untouched "follow-up"
   pass "x-lib meta helpers refuse a symlinked task record and leave its target untouched"
 }
 

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -2509,6 +2509,19 @@ test_meta_helpers_refuse_a_symlinked_task_record() {
   assert_grep "x_request=req-sym" "$target" "clear removed the X request through the symlink"
   assert_symlink_untouched "clear"
 
+  rm -f "$meta" "$target"
+  ln -s "$target" "$meta"
+  FM_HOME="$home" "$ROOT/bin/fm-x-followup.sh" --clear sym-task >/dev/null 2>&1; rc=$?
+  [ "$rc" -ne 0 ] || fail "clear through a dangling symlink record should refuse"
+  [ -L "$meta" ] || fail "clear replaced or removed the dangling symlink record"
+  [ ! -e "$target" ] || fail "clear created the dangling symlink target"
+  leftover=$(find "$home/state" -maxdepth 1 -name '.*.fm-x.*' -print 2>/dev/null || true)
+  [ -z "$leftover" ] || fail "clear left a staging file after refusing a dangling symlink: $leftover"
+
+  printf '%s\n' 'window=w' 'kind=ship' 'mode=no-mistakes' 'yolo=off' \
+    'x_request=req-sym' 'x_request_ts=1700000000' 'x_followups=0' \
+    'x_platform=x' 'x_reply_max_chars=280' > "$target"
+  cp "$target" "$original"
   fakebin=$(make_fake_curl "$home")
   printf 'FMX_PAIRING_TOKEN=tok-sym\n' > "$home/.env"
   FM_HOME="$home" FMX_DRY_RUN=1 FMX_NOW_OVERRIDE=1700003600 PATH="$fakebin:$BASE_PATH" \

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -2467,6 +2467,58 @@ test_meta_rewrites_do_not_depend_on_tmpdir() {
   pass "meta rewrites are independent of TMPDIR"
 }
 
+# The shared publisher must refuse a symlink at state/<id>.meta so Relay field
+# rewrites cannot follow it and overwrite the target. Each helper is a real
+# rewrite path: link, follow-up counter, and clear.
+test_meta_helpers_refuse_a_symlinked_task_record() {
+  local home meta target original rc leftover fakebin
+
+  assert_symlink_untouched() {
+    local why=$1
+    [ -L "$meta" ] || fail "$why replaced or removed the symlink record"
+    cmp -s "$target" "$original" \
+      || fail "$why rewrote the symlink target in place"
+    leftover=$(find "$home/state" -maxdepth 1 -name '.*.fm-x.*' -print 2>/dev/null || true)
+    [ -z "$leftover" ] || fail "$why left a staging file after a refused publish: $leftover"
+  }
+
+  home="$TMP_ROOT/meta-symlink"
+  mkdir -p "$home/state"
+  meta="$home/state/sym-task.meta"
+  target="$TMP_ROOT/meta-symlink-foreign.meta"
+  original="$TMP_ROOT/meta-symlink-foreign.expected"
+
+  printf '%s\n' 'window=w' 'kind=ship' 'mode=no-mistakes' 'yolo=off' > "$target"
+  cp "$target" "$original"
+  ln -s "$target" "$meta"
+  FM_HOME="$home" FMX_NOW_OVERRIDE=1700000000 \
+    "$ROOT/bin/fm-x-link.sh" sym-task req-sym >/dev/null 2>&1; rc=$?
+  [ "$rc" -ne 0 ] || fail "link through a symlink record should refuse"
+  assert_no_grep "x_request=" "$target" "link wrote an X request through the symlink"
+  assert_symlink_untouched "link"
+
+  printf '%s\n' 'window=w' 'kind=ship' 'mode=no-mistakes' 'yolo=off' \
+    'x_request=req-sym' 'x_request_ts=1700000000' 'x_followups=0' \
+    'x_platform=x' 'x_reply_max_chars=280' > "$target"
+  cp "$target" "$original"
+  rm -f "$meta"
+  ln -s "$target" "$meta"
+
+  FM_HOME="$home" "$ROOT/bin/fm-x-followup.sh" --clear sym-task >/dev/null 2>&1; rc=$?
+  [ "$rc" -ne 0 ] || fail "clear through a symlink record should refuse"
+  assert_grep "x_request=req-sym" "$target" "clear removed the X request through the symlink"
+  assert_symlink_untouched "clear"
+
+  fakebin=$(make_fake_curl "$home")
+  printf 'FMX_PAIRING_TOKEN=tok-sym\n' > "$home/.env"
+  FM_HOME="$home" FMX_DRY_RUN=1 FMX_NOW_OVERRIDE=1700003600 PATH="$fakebin:$BASE_PATH" \
+    "$ROOT/bin/fm-x-followup.sh" sym-task - <<<"milestone update" >/dev/null 2>&1; rc=$?
+  [ "$rc" -ne 0 ] || fail "a follow-up post must not rewrite a symlink record after posting"
+  assert_grep "x_followups=0" "$target" "a follow-up post incremented the counter through the symlink"
+  assert_symlink_untouched "follow-up post"
+  pass "x-lib meta helpers refuse a symlinked task record and leave its target untouched"
+}
+
 test_link_rejects_unsafe_and_missing() {
   local home rc
   home="$TMP_ROOT/link-bad"; mkdir -p "$home/state"
@@ -2941,6 +2993,7 @@ test_link_carry_count_and_ts_preserve_followup_binding
 test_link_recovery_relink_carries_discord_context_after_inbox_drain
 test_link_carry_count_validation
 test_meta_rewrites_do_not_depend_on_tmpdir
+test_meta_helpers_refuse_a_symlinked_task_record
 test_link_rejects_unsafe_and_missing
 test_link_missing_task_without_secondmates_stays_plain
 test_link_refuses_secondmate_routed_task_with_promised_final_pointer

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -2511,12 +2511,16 @@ test_meta_helpers_refuse_a_symlinked_task_record() {
 
   rm -f "$meta" "$target"
   ln -s "$target" "$meta"
-  FM_HOME="$home" "$ROOT/bin/fm-x-followup.sh" --clear sym-task >/dev/null 2>&1; rc=$?
-  [ "$rc" -ne 0 ] || fail "clear through a dangling symlink record should refuse"
-  [ -L "$meta" ] || fail "clear replaced or removed the dangling symlink record"
-  [ ! -e "$target" ] || fail "clear created the dangling symlink target"
+  FM_HOME="$home" STATE="$home/state" ROOT="$ROOT" META="$meta" bash -c '
+    . "$ROOT/bin/fm-x-lib.sh"
+    . "$ROOT/bin/fm-wake-lib.sh"
+    fmx_meta_link_clear "$META"
+  ' >/dev/null 2>&1; rc=$?
+  [ "$rc" -ne 0 ] || fail "the clear helper should refuse a dangling symlink record"
+  [ -L "$meta" ] || fail "the clear helper replaced or removed the dangling symlink record"
+  [ ! -e "$target" ] || fail "the clear helper created the dangling symlink target"
   leftover=$(find "$home/state" -maxdepth 1 -name '.*.fm-x.*' -print 2>/dev/null || true)
-  [ -z "$leftover" ] || fail "clear left a staging file after refusing a dangling symlink: $leftover"
+  [ -z "$leftover" ] || fail "the clear helper left a staging file after refusing a dangling symlink: $leftover"
 
   printf '%s\n' 'window=w' 'kind=ship' 'mode=no-mistakes' 'yolo=off' \
     'x_request=req-sym' 'x_request_ts=1700000000' 'x_followups=0' \


### PR DESCRIPTION
## Intent

Route fm-promote and the fm-x-lib meta helpers' live task-record rewrites through the containment-aware publish helper, and prune two unused fm-backlog-transition-lib aliases; a symlinked meta record must be refused through both paths.

This is a field-only containment migration, not a backlog transition-logic change. After rewriting the temp meta, publish with fm_backlog_atomic_transition publish using STATE as the authorized root (never dirname of an unsanitized meta path). Keep the existing meta lock. Do not call dispatch, start, close, or transition_applies: promote rewrites fields on an already-in-flight record, and x-lib also rewrites Relay link fields on secondmate metas which are not backlog items.

Do not touch: fm-pr-check.sh's device/nlink/mode meta publisher, fm-captain-hold.sh's tasks-axi done/unhold, cross-home tasks-axi mv in backlog handoff/receive, teardown worktree/home rm -rf containment helpers, or fm-control.sh's meta-prior journal copy. Keep those correctly separate.

Acceptance: both paths publish live meta through the helper never a bare mv; behavioral tests prove a symlinked state/<id>.meta is refused and the symlink target is not overwritten, through both the promote path and the x-lib meta helpers; temp files are cleaned up on publish failure; the unused aliases fm_backlog_row_state and verify-published are gone; existing atomicity and Relay-followup behavior is unchanged for the non-symlink happy path.

Delivery is no-mistakes with yolo off: the captain merges. Do not self-merge.

## What Changed
- Route promote and Relay metadata rewrites through the containment-aware atomic publisher rooted at `STATE`, while preserving existing metadata locks.
- Refuse symlinked task records before promotion or follow-up side effects, clean staging files on failure, and add coverage for each rewrite path.
- Remove the unused `fm_backlog_row_state` and `verify-published` transition aliases.

## Risk Assessment

✅ Low: The containment migration is narrowly scoped, uses the authorized STATE root, preserves locking and atomic publication, refuses symlinked metadata before side effects, and includes behavioral regression coverage.

## Testing

No baseline commands were supplied; targeted delivery and X-mode behavior tests succeeded, and end-to-end CLI checks demonstrated that promote and X helpers refuse symlinked records without touching targets or leaving staging files while normal promotion and Relay follow-up behavior remains functional.

<details>
<summary>Evidence: CLI containment refusal and happy-path transcript</summary>

Source: [CLI containment refusal and happy-path transcript](https://github.com/kunchenguid/firstmate/blob/27be04e606a10ce803f30f125fd4dd47d48159cb/.no-mistakes/evidence/fm/fm-promote-xlib-publish-migration-r1/containment-cli-transcript.txt)

```text
# End-user CLI containment verification

## fm-promote refuses a symlinked live task record
command exit: 1
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ~/.no-mistakes/worktrees/52b07e9083e7/01M19R0VN808EYTMXTEPJQAH2G/.pi/extensions/fm-primary-turnend-guard.ts -e ~/.no-mistakes/worktrees/52b07e9083e7/01M19R0VN808EYTMXTEPJQAH2G/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
error: task record for demo-promote is unsafe or missing (task record resolves outside its authorized directory at /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-containment-evidence.o1WzIJ/promote-refuse/home/state/demo-promote.meta)
symlink preserved: yes; foreign target untouched: yes; instructions absent: yes; staging files: 0

## fm-promote normal record happy path
command exit: 0
persisted fields:
kind=ship
mode=direct-PR
yolo=off
ship instructions published: yes

## fm-x-link refuses symlink publication and cleans its staged rewrite
command exit: 1
fm-x-link: failed to record the link in state/demo-x.meta
symlink preserved: yes; foreign target untouched: yes; staging files: 0

## fm-x-followup --clear refuses a dangling symlink
command exit: 1
fm-x-followup: unsafe task record in state/demo-x.meta
dangling symlink preserved: yes; target still absent: yes

## Relay link/follow-up normal-record happy path
link exit: 0; output: linked demo-relay to X request req-happy
follow-up exit: 0; output: fm-x-reply: DRY RUN - would POST to https://myfirstmate.io/connector/followup (recorded: state/x-outbox/req-happy.json): milestone update
req-happy
persisted Relay fields:
x_request=req-happy
x_request_ts=1700000000
x_platform=x
x_reply_max_chars=280
x_followups=1
dry-run follow-up artifact published: yes
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ba2df9702cd384b5804449229a9a15319c513cc7","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-x-lib.sh:985` - This contradicts the required criterion “a symlinked meta record must be refused through both paths.” A dangling symlink (or symlink to a non-regular target) makes `[ -f &#34;$meta&#34; ]` false, so `fmx_meta_link_clear` returns success without reaching the containment-aware publisher; `fm-x-followup.sh --clear &lt;id&gt;` consequently reports success and leaves the symlink intact. Distinguish true absence from `[ -L &#34;$meta&#34; ]` at both pre-lock checks and behavior-test the dangling-symlink case.

🔧 Fix: Refuse dangling symlinks during X metadata clear
2 issues (1 error, 1 warning) still open:

- 🚨 `bin/fm-x-lib.sh:973` - The containment refusal occurs only after the external follow-up is posted. `fm-x-followup.sh` reads the symlink target, posts at lines 231–235, then this publisher rejects the symlink and leaves `x_followups=0`; repeating the command can therefore publish duplicate follow-ups. The new test at tests/fm-x-mode.test.sh:2527 exercises this sequence but only checks the eventual failure. Refuse a symlinked meta before posting and assert that no dry-run outbox record is created.
- ⚠️ `bin/fm-promote.sh:163` - A symlink whose target contains `kind=scout` passes the earlier checks, and promotion publishes `data/&lt;id&gt;/ship-instructions.md` before this containment-aware publish refuses the meta. The failed command thus leaves a partial promotion artifact. Validate/refuse the meta through the containment boundary before rendering or publishing ship instructions, and cover the absence of that artifact on refusal.

🔧 Fix: Refuse unsafe metadata before follow-up and promotion side effects
1 warning still open:

- ⚠️ `tests/fm-x-mode.test.sh:2514` - The dangling-symlink regression invokes fm-x-followup.sh, whose new preflight rejects at bin/fm-x-followup.sh:160 before fmx_meta_link_clear runs. Removing both new [ -L &#34;$meta&#34; ] checks from fmx_meta_link_clear would therefore still pass this test, contrary to the requested behavioral coverage of that helper. Invoke fmx_meta_link_clear directly in a subprocess with STATE set and assert refusal plus unchanged symlink/target.

🔧 Fix: Exercise dangling symlink refusal through clear helper
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-task-delivery.test.sh`
- `bash tests/fm-x-mode.test.sh`
- <code>Manual CLI verification: invoked `bin/fm-promote.sh` against symlinked and regular task records, checking exit behavior, persisted fields, foreign-target integrity, instruction side effects, and staging cleanup.</code>
- <code>Manual CLI verification: invoked `bin/fm-x-link.sh` against symlinked and regular records, then exercised `bin/fm-x-followup.sh --clear` on a dangling symlink and a dry-run follow-up on a regular record; checked persisted metadata, outbox output, target integrity, and staging cleanup.</code>
- <code>Captured the manual CLI session and resulting persisted state in `containment-cli-transcript.txt`.</code>
- <code>`git status --short` confirmed testing left the worktree clean.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
