### PR TITLE
feat(bin): add fm-dogfood-verify for immutable dogfood pinning and live truth verification

### DIFF
--- a/bin/fm-dogfood-verify.sh
+++ b/bin/fm-dogfood-verify.sh
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+# fm-dogfood-verify.sh - immutable pinning and on-demand truth verification for
+# local installed-app "dogfood" activations.
+#
+# The failure this guards against: a dogfood activation points a live symlink
+# (e.g. ~/Library/Application Support/<App>/ui) at a path INSIDE a shared task
+# worktree that other, unrelated tasks keep committing to. The installed app
+# then silently starts serving a different commit than the one that was
+# activated, with no notification, so a "still active"/overnight-status claim
+# becomes false without anyone touching the activation.
+#
+# This script is project-agnostic. Any local dogfood-activation flow can use it.
+#
+# Two subcommands:
+#
+#   pin      Pin an EXACT commit into a dedicated, activation-owned worktree
+#            copy that no other task writes to, point the live symlink at that
+#            copy (never at a shared worktree), and record a content-hash
+#            manifest plus invariants alongside it. Idempotent and reusable: a
+#            second pin of the same commit into the same --pin-dir reuses it.
+#
+#   verify   Revalidate a recorded activation LIVE, right now, and report a
+#            clear PASS or a specific named drift. Read-only: it never deletes
+#            or mutates anything. Checks the symlink target, the exact HEAD at
+#            the pinned copy, content hashes of the served files against the
+#            recorded manifest, any recorded invariant files, and (when
+#            recorded) that the serving process/port is actually up.
+#
+# Usage:
+#   fm-dogfood-verify.sh pin \
+#     --source <repo-or-worktree> --sha <commit-ish> \
+#     --pin-dir <dedicated-copy-path> --record <activation-record-dir> \
+#     [--serve-subdir <relpath>] [--link <live-symlink-path>] \
+#     [--file <served-relpath>]... \
+#     [--port <n>] [--process-pattern <pgrep -f pattern>] \
+#     [--invariant <label>=<abs-path>]...
+#
+#   fm-dogfood-verify.sh verify [--skip-serve] <activation-record-dir | pin.env-path>
+#
+#   fm-dogfood-verify.sh --help
+#
+# pin writes into <activation-record-dir>: pin.env (metadata), manifest.tsv
+# (<sha256><TAB><served-relpath> per line), and invariants.tsv
+# (<label><TAB><sha256><TAB><abs-path> per line). verify reads exactly those.
+#
+# Exit codes: 0 PASS/success, 1 verify drift, 2 usage or precondition error.
+set -eu
+
+PROG=fm-dogfood-verify
+
+fail() {
+  printf '%s: %s\n' "$PROG" "$*" >&2
+  exit 2
+}
+
+usage() {
+  awk 'NR==1{next} /^#/{sub(/^# ?/,"");print;next} {exit}' "$0"
+}
+
+reject_ctrl() {  # <value> <label>
+  case "$1" in
+    *$'\n'*) fail "$2 must not contain a newline" ;;
+    *$'\t'*) fail "$2 must not contain a tab" ;;
+  esac
+}
+
+sha256_file() {  # <path>
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -- "$1" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -- "$1" | awk '{print $1}'
+  else
+    fail "shasum or sha256sum is required"
+  fi
+}
+
+abspath() {  # <path>  (parent directory must already exist)
+  # Physical (pwd -P) so the containment check below matches git's physical
+  # --show-toplevel even when /tmp or a home dir is itself a symlink.
+  local p=$1 dir base
+  dir=$(cd "$(dirname "$p")" 2>/dev/null && pwd -P) || fail "cannot resolve parent directory of: $p"
+  base=$(basename "$p")
+  case "$base" in
+    .|/) printf '%s\n' "$dir" ;;
+    *) printf '%s/%s\n' "$dir" "$base" ;;
+  esac
+}
+
+read_pin_env() {  # <record-path>  -> sets PE_* globals
+  local rp=$1 envf line k v
+  if [ -d "$rp" ]; then envf=$rp/pin.env; else envf=$rp; fi
+  [ -f "$envf" ] || fail "verify: no pin.env at: $rp"
+  PE_RECORD_DIR=$(cd "$(dirname "$envf")" && pwd)
+  PE_VERSION=''; PE_SHA=''; PE_PIN_DIR=''; PE_SERVED_ROOT=''
+  PE_LINK=''; PE_PORT=''; PE_PROC=''
+  while IFS= read -r line; do
+    case "$line" in ''|'#'*) continue ;; esac
+    k=${line%%=*}; v=${line#*=}
+    case "$k" in
+      fm_dogfood_pin_version) PE_VERSION=$v ;;
+      sha) PE_SHA=$v ;;
+      pin_dir) PE_PIN_DIR=$v ;;
+      served_root) PE_SERVED_ROOT=$v ;;
+      link) PE_LINK=$v ;;
+      serve_port) PE_PORT=$v ;;
+      serve_process_pattern) PE_PROC=$v ;;
+    esac
+  done < "$envf"
+  [ "$PE_VERSION" = 1 ] || fail "verify: unsupported pin.env version: '$PE_VERSION'"
+  [ -n "$PE_SHA" ] || fail "verify: pin.env missing sha"
+  [ -n "$PE_SERVED_ROOT" ] || fail "verify: pin.env missing served_root"
+}
+
+# do_verify <record-path> [skip_serve]  -> 0 PASS, 1 drift. Never mutates.
+do_verify() {
+  local rp=$1 skip_serve=${2:-0}
+  read_pin_env "$rp"
+  local fails=0 warns=0
+
+  if [ -n "$PE_LINK" ]; then
+    if [ ! -L "$PE_LINK" ]; then
+      printf 'FAIL symlink-drift: %s is not a symlink\n' "$PE_LINK"; fails=$((fails+1))
+    else
+      local actual; actual=$(readlink "$PE_LINK")
+      if [ "$actual" != "$PE_SERVED_ROOT" ]; then
+        printf 'FAIL symlink-drift: %s -> %s (expected %s)\n' "$PE_LINK" "$actual" "$PE_SERVED_ROOT"
+        fails=$((fails+1))
+      fi
+    fi
+  fi
+
+  if [ -n "$PE_PIN_DIR" ]; then
+    local head; head=$(git -C "$PE_PIN_DIR" rev-parse HEAD 2>/dev/null) || head=''
+    if [ -z "$head" ]; then
+      printf 'FAIL head-unreadable: cannot read git HEAD at %s\n' "$PE_PIN_DIR"; fails=$((fails+1))
+    elif [ "$head" != "$PE_SHA" ]; then
+      printf 'FAIL head-drift: %s at %s (expected %s)\n' "$head" "$PE_PIN_DIR" "$PE_SHA"; fails=$((fails+1))
+    fi
+  fi
+
+  local manifest=$PE_RECORD_DIR/manifest.tsv exp rel cur
+  if [ ! -f "$manifest" ]; then
+    printf 'FAIL manifest-missing: %s\n' "$manifest"; fails=$((fails+1))
+  else
+    while IFS=$'\t' read -r exp rel; do
+      [ -n "$exp" ] || continue
+      if [ ! -f "$PE_SERVED_ROOT/$rel" ]; then
+        printf 'FAIL content-missing: %s\n' "$rel"; fails=$((fails+1)); continue
+      fi
+      cur=$(sha256_file "$PE_SERVED_ROOT/$rel")
+      if [ "$cur" != "$exp" ]; then
+        printf 'FAIL content-drift: %s\n' "$rel"; fails=$((fails+1))
+      fi
+    done < "$manifest"
+  fi
+
+  local invfile=$PE_RECORD_DIR/invariants.tsv label iexp ipath icur
+  if [ -f "$invfile" ]; then
+    while IFS=$'\t' read -r label iexp ipath; do
+      [ -n "$label" ] || continue
+      if [ ! -f "$ipath" ]; then
+        printf 'FAIL invariant-missing: %s (%s)\n' "$label" "$ipath"; fails=$((fails+1)); continue
+      fi
+      icur=$(sha256_file "$ipath")
+      if [ "$icur" != "$iexp" ]; then
+        printf 'FAIL invariant-drift: %s (%s)\n' "$label" "$ipath"; fails=$((fails+1))
+      fi
+    done < "$invfile"
+  fi
+
+  if [ "$skip_serve" != 1 ]; then
+    if [ -n "$PE_PORT" ]; then
+      if command -v lsof >/dev/null 2>&1; then
+        if ! lsof -nP -iTCP:"$PE_PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
+          printf 'FAIL serve-port-down: nothing listening on port %s\n' "$PE_PORT"; fails=$((fails+1))
+        fi
+      else
+        printf 'WARN serve-port-uncheckable: lsof not available\n'; warns=$((warns+1))
+      fi
+    fi
+    if [ -n "$PE_PROC" ]; then
+      if command -v pgrep >/dev/null 2>&1; then
+        if ! pgrep -f -- "$PE_PROC" >/dev/null 2>&1; then
+          printf 'FAIL serve-process-down: no process matches %s\n' "$PE_PROC"; fails=$((fails+1))
+        fi
+      else
+        printf 'WARN serve-process-uncheckable: pgrep not available\n'; warns=$((warns+1))
+      fi
+    fi
+  fi
+
+  if [ "$fails" -eq 0 ]; then
+    if [ "$warns" -gt 0 ]; then
+      printf 'PASS %s sha=%s (with %s warning(s))\n' "$PE_RECORD_DIR" "$PE_SHA" "$warns"
+    else
+      printf 'PASS %s sha=%s\n' "$PE_RECORD_DIR" "$PE_SHA"
+    fi
+    return 0
+  fi
+  printf 'FAILED %s (%s check(s) failed)\n' "$PE_RECORD_DIR" "$fails"
+  return 1
+}
+
+cmd_pin() {
+  local source='' sha='' pin_dir='' record='' serve_subdir='.' link='' port='' proc_pat=''
+  local -a files=() invariants=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --source) source=${2:-}; shift 2 ;;
+      --sha) sha=${2:-}; shift 2 ;;
+      --pin-dir) pin_dir=${2:-}; shift 2 ;;
+      --record) record=${2:-}; shift 2 ;;
+      --serve-subdir) serve_subdir=${2:-}; shift 2 ;;
+      --link) link=${2:-}; shift 2 ;;
+      --file) files+=("${2:-}"); shift 2 ;;
+      --port) port=${2:-}; shift 2 ;;
+      --process-pattern) proc_pat=${2:-}; shift 2 ;;
+      --invariant) invariants+=("${2:-}"); shift 2 ;;
+      -h|--help) usage; exit 0 ;;
+      *) fail "pin: unknown argument: $1" ;;
+    esac
+  done
+
+  [ -n "$source" ] || fail "pin: --source is required"
+  [ -n "$sha" ] || fail "pin: --sha is required"
+  [ -n "$pin_dir" ] || fail "pin: --pin-dir is required"
+  [ -n "$record" ] || fail "pin: --record is required"
+  command -v git >/dev/null 2>&1 || fail "git is required"
+
+  reject_ctrl "$pin_dir" "--pin-dir"
+  reject_ctrl "$serve_subdir" "--serve-subdir"
+  reject_ctrl "$link" "--link"
+  reject_ctrl "$port" "--port"
+  reject_ctrl "$proc_pat" "--process-pattern"
+
+  local src_top resolved
+  src_top=$(git -C "$source" rev-parse --show-toplevel 2>/dev/null) \
+    || fail "pin: --source is not a git repository: $source"
+  resolved=$(git -C "$source" rev-parse --verify --quiet "${sha}^{commit}" 2>/dev/null) \
+    || fail "pin: cannot resolve commit '$sha' in $source"
+
+  # A dedicated pin copy must live OUTSIDE the shared source worktree, or it is
+  # not actually isolated from the tasks that keep committing there.
+  mkdir -p "$(dirname "$pin_dir")" || fail "pin: cannot create parent of --pin-dir"
+  pin_dir=$(abspath "$pin_dir")
+  case "$pin_dir" in
+    "$src_top"|"$src_top"/*) fail "pin: --pin-dir is inside the source worktree ($src_top); choose a dedicated path outside it" ;;
+  esac
+
+  if [ -e "$pin_dir" ]; then
+    local existing
+    existing=$(git -C "$pin_dir" rev-parse HEAD 2>/dev/null) \
+      || fail "pin: --pin-dir exists but is not a git worktree: $pin_dir"
+    [ "$existing" = "$resolved" ] \
+      || fail "pin: --pin-dir already pinned at $existing, not $resolved; refusing to clobber"
+  else
+    git -C "$source" worktree add --detach --quiet "$pin_dir" "$resolved" \
+      || fail "pin: git worktree add failed for $resolved -> $pin_dir"
+  fi
+
+  local pinned_head
+  pinned_head=$(git -C "$pin_dir" rev-parse HEAD 2>/dev/null) || fail "pin: cannot read pinned HEAD"
+  [ "$pinned_head" = "$resolved" ] || fail "pin: pinned HEAD $pinned_head != $resolved"
+
+  local served_root
+  case "$serve_subdir" in
+    .|'') served_root=$pin_dir ;;
+    /*) fail "pin: --serve-subdir must be relative" ;;
+    *) served_root=$pin_dir/$serve_subdir ;;
+  esac
+  [ -d "$served_root" ] || fail "pin: served directory does not exist: $served_root"
+
+  mkdir -p "$record" || fail "pin: cannot create --record dir: $record"
+  record=$(abspath "$record")
+
+  local -a served_files=()
+  if [ "${#files[@]}" -gt 0 ]; then
+    local f
+    for f in "${files[@]}"; do
+      reject_ctrl "$f" "--file"
+      [ -f "$served_root/$f" ] || fail "pin: --file not found under served root: $f"
+      served_files+=("$f")
+    done
+  else
+    local rel
+    while IFS= read -r rel; do
+      rel=${rel#./}
+      reject_ctrl "$rel" "served file path"
+      served_files+=("$rel")
+    done < <(cd "$served_root" && find . -name .git -prune -o -type f -print | LC_ALL=C sort)
+  fi
+  [ "${#served_files[@]}" -gt 0 ] || fail "pin: no served files found under $served_root"
+
+  local manifest=$record/manifest.tsv h
+  : > "$manifest"
+  local rel2
+  for rel2 in "${served_files[@]}"; do
+    h=$(sha256_file "$served_root/$rel2")
+    printf '%s\t%s\n' "$h" "$rel2" >> "$manifest"
+  done
+
+  local invfile=$record/invariants.tsv
+  : > "$invfile"
+  if [ "${#invariants[@]}" -gt 0 ]; then
+    local spec label path
+    for spec in "${invariants[@]}"; do
+      case "$spec" in
+        *=*) label=${spec%%=*}; path=${spec#*=} ;;
+        *) fail "pin: --invariant must be <label>=<path>: $spec" ;;
+      esac
+      reject_ctrl "$label" "invariant label"
+      reject_ctrl "$path" "invariant path"
+      [ -f "$path" ] || fail "pin: invariant file not found: $path"
+      h=$(sha256_file "$path")
+      printf '%s\t%s\t%s\n' "$label" "$h" "$path" >> "$invfile"
+    done
+  fi
+
+  # Point the live symlink at the dedicated copy with an atomic replace. We
+  # never clobber a real file/dir, and we record the previous target so the
+  # change is reversible.
+  local previous='(none)'
+  if [ -n "$link" ]; then
+    link=$(abspath "$link")
+    if [ -L "$link" ]; then
+      previous=$(readlink "$link")
+    elif [ -e "$link" ]; then
+      fail "pin: refusing to replace a non-symlink at --link: $link"
+    fi
+    local tmp=$link.fmpin.$$
+    rm -f "$tmp"
+    ln -s "$served_root" "$tmp" || fail "pin: cannot stage symlink at $tmp"
+    mv -f "$tmp" "$link" || { rm -f "$tmp"; fail "pin: cannot install symlink at $link"; }
+  fi
+
+  {
+    printf 'fm_dogfood_pin_version=1\n'
+    printf 'state=active\n'
+    printf 'created_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'source_worktree=%s\n' "$src_top"
+    printf 'sha=%s\n' "$resolved"
+    printf 'pin_dir=%s\n' "$pin_dir"
+    printf 'serve_subdir=%s\n' "$serve_subdir"
+    printf 'served_root=%s\n' "$served_root"
+    printf 'link=%s\n' "$link"
+    printf 'previous_link_target=%s\n' "$previous"
+    printf 'serve_port=%s\n' "$port"
+    printf 'serve_process_pattern=%s\n' "$proc_pat"
+  } > "$record/pin.env"
+
+  # Postflight self-check: prove the pin took, structurally. The app is not
+  # necessarily launched yet, so skip the serve checks here.
+  local vout vrc
+  vout=$(do_verify "$record" 1 2>&1) && vrc=0 || vrc=$?
+  if [ "$vrc" -ne 0 ]; then
+    printf '%s\n' "$vout" >&2
+    fail "pin: postflight verification failed"
+  fi
+
+  printf 'PINNED %s sha=%s files=%s pin_dir=%s\n' "$record" "$resolved" "${#served_files[@]}" "$pin_dir"
+  if [ -n "$link" ]; then
+    printf 'LINK %s -> %s (was: %s)\n' "$link" "$served_root" "$previous"
+  fi
+}
+
+cmd_verify() {
+  local skip_serve=0 target=''
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --skip-serve) skip_serve=1; shift ;;
+      -h|--help) usage; exit 0 ;;
+      --) shift; target=${1:-}; [ $# -gt 0 ] && shift ;;
+      -*) fail "verify: unknown option: $1" ;;
+      *) target=$1; shift ;;
+    esac
+  done
+  [ -n "$target" ] || fail "verify: activation-record path is required"
+  if do_verify "$target" "$skip_serve"; then exit 0; else exit 1; fi
+}
+
+case "${1:-}" in
+  pin) shift; cmd_pin "$@" ;;
+  verify) shift; cmd_verify "$@" ;;
+  -h|--help) usage; exit 0 ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/bin/fm-dogfood-verify.sh
+++ b/bin/fm-dogfood-verify.sh
@@ -86,6 +86,31 @@ abspath() {  # <path>  (parent directory must already exist)
   esac
 }
 
+# canonicalize <path>: print the fully physical path of an EXISTING path,
+# following every symlink (including the final component). Portable stand-in for
+# `readlink -f` (absent on macOS). Fails on a symlink cycle. Used to contain
+# served files under the pinned worktree even when a component or the file
+# itself is a symlink pointing elsewhere.
+canonicalize() {
+  local p=$1 dir base target i=0
+  while [ "$i" -lt 64 ]; do
+    dir=$(cd "$(dirname "$p")" 2>/dev/null && pwd -P) || return 1
+    base=$(basename "$p")
+    case "$base" in
+      /|.) printf '%s\n' "$dir"; return 0 ;;
+    esac
+    p=$dir/$base
+    [ -L "$p" ] || { printf '%s\n' "$p"; return 0; }
+    target=$(readlink "$p")
+    case "$target" in
+      /*) p=$target ;;
+      *) p=$dir/$target ;;
+    esac
+    i=$((i+1))
+  done
+  return 1
+}
+
 read_pin_env() {  # <record-path>  -> sets PE_* globals
   local rp=$1 envf line k v
   if [ -d "$rp" ]; then envf=$rp/pin.env; else envf=$rp; fi
@@ -283,10 +308,24 @@ cmd_pin() {
 
   local -a served_files=()
   if [ "${#files[@]}" -gt 0 ]; then
-    local f
+    local f phys
     for f in "${files[@]}"; do
       reject_ctrl "$f" "--file"
-      [ -f "$served_root/$f" ] || fail "pin: --file not found under served root: $f"
+      case "$f" in
+        /*) fail "pin: --file must be relative to the served root: $f" ;;
+      esac
+      [ -e "$served_root/$f" ] || fail "pin: --file not found under served root: $f"
+      # Contain it PHYSICALLY: a --file with parent components (../x) or a file
+      # that is a symlink to content outside the pinned worktree must not let the
+      # activation record/serve mutable external data while claiming the pin is
+      # intact. verify follows the same relative path, so both must stay inside.
+      phys=$(canonicalize "$served_root/$f") \
+        || fail "pin: cannot resolve --file: $f"
+      case "$phys" in
+        "$pin_dir"|"$pin_dir"/*) : ;;
+        *) fail "pin: --file escapes the pinned worktree: $f" ;;
+      esac
+      [ -f "$phys" ] || fail "pin: --file is not a regular file: $f"
       served_files+=("$f")
     done
   else

--- a/bin/fm-dogfood-verify.sh
+++ b/bin/fm-dogfood-verify.sh
@@ -367,12 +367,26 @@ cmd_pin() {
       served_files+=("$f")
     done
   else
-    local rel
+    local rel phys
+    # Enumerate regular files AND symlinks. A plain `-type f` sweep silently omits
+    # symlink entries, so a served path that is (or traverses) a symlink pointing
+    # at mutable content OUTSIDE the pinned worktree would never reach the manifest
+    # - and pin/verify would both report success while the app serves un-pinned,
+    # mutable bytes. Contain every entry PHYSICALLY, exactly like the --file branch:
+    # an in-pin regular file (or in-pin symlink to one) is covered, an escape is
+    # rejected by name rather than dropped.
     while IFS= read -r rel; do
       rel=${rel#./}
       reject_ctrl "$rel" "served file path"
+      phys=$(canonicalize "$served_root/$rel") \
+        || fail "pin: cannot resolve served file: $rel"
+      case "$phys" in
+        "$pin_dir"|"$pin_dir"/*) : ;;
+        *) fail "pin: served file escapes the pinned worktree: $rel" ;;
+      esac
+      [ -f "$phys" ] || fail "pin: served entry is not a regular file: $rel"
       served_files+=("$rel")
-    done < <(cd "$served_root" && find . -name .git -prune -o -type f -print | LC_ALL=C sort)
+    done < <(cd "$served_root" && find . -name .git -prune -o \( -type f -o -type l \) -print | LC_ALL=C sort)
   fi
   [ "${#served_files[@]}" -gt 0 ] || fail "pin: no served files found under $served_root"
 

--- a/bin/fm-dogfood-verify.sh
+++ b/bin/fm-dogfood-verify.sh
@@ -269,6 +269,14 @@ cmd_pin() {
     *) served_root=$pin_dir/$serve_subdir ;;
   esac
   [ -d "$served_root" ] || fail "pin: served directory does not exist: $served_root"
+  # Resolve physically and require containment: a --serve-subdir with parent
+  # components (e.g. ../other) must not let the served root escape the pinned
+  # worktree, or the app would serve content outside the pinned commit.
+  served_root=$(cd "$served_root" && pwd -P) || fail "pin: cannot resolve served directory: $served_root"
+  case "$served_root" in
+    "$pin_dir"|"$pin_dir"/*) : ;;
+    *) fail "pin: --serve-subdir escapes the pinned worktree: $serve_subdir" ;;
+  esac
 
   mkdir -p "$record" || fail "pin: cannot create --record dir: $record"
   record=$(abspath "$record")

--- a/bin/fm-dogfood-verify.sh
+++ b/bin/fm-dogfood-verify.sh
@@ -329,8 +329,11 @@ cmd_pin() {
     fi
     local tmp=$link.fmpin.$$
     rm -f "$tmp"
-    ln -s "$served_root" "$tmp" || fail "pin: cannot stage symlink at $tmp"
-    mv -f "$tmp" "$link" || { rm -f "$tmp"; fail "pin: cannot install symlink at $link"; }
+    ln -s "$served_root" "$tmp" || { rm -f "$tmp"; fail "pin: cannot stage symlink at $tmp"; }
+    if [ -L "$link" ]; then
+      rm -f "$link" || { rm -f "$tmp"; fail "pin: cannot remove existing symlink at $link"; }
+    fi
+    mv "$tmp" "$link" || { rm -f "$tmp"; fail "pin: cannot install symlink at $link"; }
   fi
 
   {

--- a/bin/fm-dogfood-verify.sh
+++ b/bin/fm-dogfood-verify.sh
@@ -163,7 +163,31 @@ do_verify() {
     fi
   fi
 
-  local manifest=$PE_RECORD_DIR/manifest.tsv exp rel cur
+  # Live containment re-check. pin proved the served root and every served file
+  # resolve PHYSICALLY inside the immutable pinned worktree, but only at
+  # activation time. Between then and now a directory component or a served file
+  # could have been replaced by a symlink pointing at mutable content OUTSIDE the
+  # pin. If verify merely followed the recorded served_root and hashed whatever it
+  # landed on, an escape whose current bytes still match the manifest would report
+  # PASS while the app serves content that is no longer the pinned commit -
+  # exactly the drift this tool exists to catch. So we re-resolve live and name
+  # the escape instead of silently trusting the recorded path.
+  local pin_real='' served_real=''
+  if [ -n "$PE_PIN_DIR" ]; then
+    pin_real=$(canonicalize "$PE_PIN_DIR" 2>/dev/null) || pin_real=''
+  fi
+  if [ -n "$pin_real" ]; then
+    served_real=$(canonicalize "$PE_SERVED_ROOT" 2>/dev/null) || served_real=''
+    if [ -n "$served_real" ]; then
+      case "$served_real" in
+        "$pin_real"|"$pin_real"/*) : ;;
+        *) printf 'FAIL serve-root-escape: %s now resolves to %s, outside the pin %s\n' \
+             "$PE_SERVED_ROOT" "$served_real" "$pin_real"; fails=$((fails+1)) ;;
+      esac
+    fi
+  fi
+
+  local manifest=$PE_RECORD_DIR/manifest.tsv exp rel cur fphys
   if [ ! -f "$manifest" ]; then
     printf 'FAIL manifest-missing: %s\n' "$manifest"; fails=$((fails+1))
   else
@@ -171,6 +195,20 @@ do_verify() {
       [ -n "$exp" ] || continue
       if [ ! -f "$PE_SERVED_ROOT/$rel" ]; then
         printf 'FAIL content-missing: %s\n' "$rel"; fails=$((fails+1)); continue
+      fi
+      # Same containment invariant, per served file: a served path that now
+      # resolves outside the pin is an escape, not valid content, even if its
+      # bytes match. Skip hashing it and name the escape.
+      if [ -n "$pin_real" ]; then
+        fphys=$(canonicalize "$PE_SERVED_ROOT/$rel" 2>/dev/null) || fphys=''
+        if [ -z "$fphys" ]; then
+          printf 'FAIL content-missing: %s\n' "$rel"; fails=$((fails+1)); continue
+        fi
+        case "$fphys" in
+          "$pin_real"|"$pin_real"/*) : ;;
+          *) printf 'FAIL content-escape: %s now resolves to %s, outside the pin\n' \
+               "$rel" "$fphys"; fails=$((fails+1)); continue ;;
+        esac
       fi
       cur=$(sha256_file "$PE_SERVED_ROOT/$rel")
       if [ "$cur" != "$exp" ]; then

--- a/tests/fm-dogfood-verify.test.sh
+++ b/tests/fm-dogfood-verify.test.sh
@@ -326,6 +326,27 @@ test_repin_over_existing_symlink() {
   pass "pin: re-pinning a different commit onto an existing symlink-to-dir repoints the link"
 }
 
+test_serve_subdir_escape_is_refused() {
+  local case_dir src pin rec sha out
+  case_dir="$TMP_ROOT/escape"
+  src="$case_dir/src"; pin="$case_dir/pin"; rec="$case_dir/rec"
+  build_src "$src" esc
+  sha=$(git -C "$src" rev-parse HEAD)
+
+  # A --serve-subdir with parent components would otherwise resolve the served
+  # root OUTSIDE the pinned worktree, making the app serve content that is not
+  # part of the pinned commit. Give it a real existing sibling dir to escape to.
+  mkdir -p "$case_dir/outside"
+  printf 'not-in-the-pin\n' > "$case_dir/outside/index.html"
+
+  out=$("$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$pin" \
+    --record "$rec" --serve-subdir '../outside' 2>&1); RC=$?
+  [ "$RC" -eq 2 ] || fail "a --serve-subdir that escapes the pin should be refused (exit 2), got $RC"
+  assert_contains "$out" "escapes the pinned worktree" "escape refusal was not named"
+  assert_absent "$rec/pin.env" "a pin record was written for an escaping served root"
+  pass "pin: refuses a --serve-subdir that escapes the pinned worktree"
+}
+
 test_usage_errors() {
   local out
   out=$("$SCRIPT" bogus 2>&1); RC=$?
@@ -347,4 +368,5 @@ test_verify_is_read_only
 test_serve_process_up_and_down
 test_pin_safety_and_reuse
 test_repin_over_existing_symlink
+test_serve_subdir_escape_is_refused
 test_usage_errors

--- a/tests/fm-dogfood-verify.test.sh
+++ b/tests/fm-dogfood-verify.test.sh
@@ -383,6 +383,38 @@ test_explicit_file_escape_is_refused() {
   pass "pin: refuses an explicit --file (parent path or escaping symlink) outside the pinned worktree"
 }
 
+test_default_enumeration_rejects_escaping_symlink() {
+  local case_dir src pin rec sha out secret
+  case_dir="$TMP_ROOT/autoescape"
+  src="$case_dir/src"; pin="$case_dir/pin"; rec="$case_dir/rec"
+  build_src "$src" autoesc
+  sha=$(git -C "$src" rev-parse HEAD)
+
+  # Mutable external content that lives OUTSIDE the pinned worktree.
+  mkdir -p "$case_dir/outside"
+  secret="$case_dir/outside/secret.txt"
+  printf 'external-and-mutable\n' > "$secret"
+
+  # A clean default-enumeration pin (no --file) succeeds and materializes the
+  # dedicated worktree copy.
+  "$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$pin" --record "$rec" \
+    --serve-subdir ui >/dev/null || fail "clean default-enumeration pin failed"
+
+  # Now a served entry becomes a SYMLINK to that external mutable content. A plain
+  # `find -type f` sweep would omit it, so pin/verify would report success while
+  # the app serves un-pinned bytes. Default enumeration must instead NAME the
+  # escape and refuse, exactly like the explicit --file branch.
+  ln -s "$secret" "$pin/ui/leak.html"
+  out=$("$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$pin" \
+    --record "$case_dir/rec2" --serve-subdir ui 2>&1); RC=$?
+  rm -f "$pin/ui/leak.html"
+  [ "$RC" -eq 2 ] || fail "default enumeration must refuse an escaping served symlink (exit 2), got $RC"
+  assert_contains "$out" "escapes the pinned worktree" "the escaping served symlink was not named"
+  assert_absent "$case_dir/rec2/manifest.tsv" "a manifest was written despite an escaping served symlink"
+  [ "$(cat "$secret")" = 'external-and-mutable' ] || fail "the external file was disturbed"
+  pass "pin: default enumeration refuses (does not omit) a served symlink that escapes the pin"
+}
+
 test_verify_names_live_containment_escape() {
   local case_dir src pin rec sha served outside
   case_dir="$TMP_ROOT/liveescape"
@@ -443,5 +475,6 @@ test_pin_safety_and_reuse
 test_repin_over_existing_symlink
 test_serve_subdir_escape_is_refused
 test_explicit_file_escape_is_refused
+test_default_enumeration_rejects_escaping_symlink
 test_verify_names_live_containment_escape
 test_usage_errors

--- a/tests/fm-dogfood-verify.test.sh
+++ b/tests/fm-dogfood-verify.test.sh
@@ -279,6 +279,53 @@ test_pin_safety_and_reuse() {
   pass "pin: refuses pin-dir inside source, refuses non-symlink clobber, reuses an identical pin"
 }
 
+test_repin_over_existing_symlink() {
+  local case_dir src pin1 pin2 rec1 rec2 link sha1 sha2 target stray
+  case_dir="$TMP_ROOT/repin"
+  src="$case_dir/src"; pin1="$case_dir/pin1"; pin2="$case_dir/pin2"
+  rec1="$case_dir/rec1"; rec2="$case_dir/rec2"
+  mkdir -p "$case_dir/live"
+  link="$case_dir/live/ui"
+  build_src "$src" first
+  sha1=$(git -C "$src" rev-parse HEAD)
+
+  # First activation creates the live symlink (link did not exist before).
+  "$SCRIPT" pin --source "$src" --sha "$sha1" --pin-dir "$pin1" --record "$rec1" \
+    --serve-subdir ui --link "$link" >/dev/null || fail "first pin failed"
+  [ -L "$link" ] || fail "first pin did not create the live symlink"
+
+  # A second commit, activated at the SAME live link into a DIFFERENT pin dir.
+  # This is the normal re-activation case: the link already exists as a
+  # symlink-to-directory and must be repointed, not dereferenced.
+  printf 'CHANGED\n' > "$src/ui/index.html"
+  git -C "$src" add -A
+  git -C "$src" commit -qm second
+  sha2=$(git -C "$src" rev-parse HEAD)
+  [ "$sha1" != "$sha2" ] || fail "fixture did not advance the source"
+
+  "$SCRIPT" pin --source "$src" --sha "$sha2" --pin-dir "$pin2" --record "$rec2" \
+    --serve-subdir ui --link "$link" >/dev/null \
+    || fail "re-pin onto an existing symlink-to-dir failed"
+
+  [ -L "$link" ] || fail "re-pin left the live path as a non-symlink"
+  target=$(readlink "$link")
+  case "$target" in
+    */pin2/ui) : ;;
+    *) fail "live symlink still resolves to $target, not the NEW pin copy" ;;
+  esac
+
+  # The old served directory must not have a stray staged symlink deposited in
+  # it (the dereference symptom).
+  stray=$(cd "$pin1/ui" && find . -maxdepth 1 -name 'ui.fmpin.*' -print 2>/dev/null)
+  [ -z "$stray" ] || fail "re-pin deposited a stray staged symlink inside the old copy: $stray"
+
+  # verify agrees the recorded activation is live and correct.
+  vout --skip-serve "$rec2"
+  [ "$RC" -eq 0 ] || fail "verify should PASS on the re-pinned activation: $OUT"
+  assert_contains "$OUT" "PASS" "re-pinned activation did not verify PASS"
+  pass "pin: re-pinning a different commit onto an existing symlink-to-dir repoints the link"
+}
+
 test_usage_errors() {
   local out
   out=$("$SCRIPT" bogus 2>&1); RC=$?
@@ -299,4 +346,5 @@ test_verify_pass_and_named_drifts
 test_verify_is_read_only
 test_serve_process_up_and_down
 test_pin_safety_and_reuse
+test_repin_over_existing_symlink
 test_usage_errors

--- a/tests/fm-dogfood-verify.test.sh
+++ b/tests/fm-dogfood-verify.test.sh
@@ -383,6 +383,43 @@ test_explicit_file_escape_is_refused() {
   pass "pin: refuses an explicit --file (parent path or escaping symlink) outside the pinned worktree"
 }
 
+test_verify_names_live_containment_escape() {
+  local case_dir src pin rec sha served outside
+  case_dir="$TMP_ROOT/liveescape"
+  src="$case_dir/src"; pin="$case_dir/pin"; rec="$case_dir/rec"
+  build_src "$src" esc2
+  sha=$(git -C "$src" rev-parse HEAD)
+  "$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$pin" --record "$rec" \
+    --serve-subdir ui >/dev/null || fail "pin failed"
+  served=$(sed -n 's/^served_root=//p' "$rec/pin.env")
+
+  # Baseline: the untouched pin PASSes.
+  vout --skip-serve "$rec"
+  [ "$RC" -eq 0 ] || fail "verify should PASS on the untouched pin: $OUT"
+
+  # pin enforced containment at activation time. AFTER activation, a served file
+  # is replaced by a symlink to mutable content OUTSIDE the pin whose bytes match
+  # the recorded hash. Content hashing alone still matches, so only a live
+  # containment re-check catches that the app no longer serves the pinned copy.
+  outside="$case_dir/outside"
+  mkdir -p "$outside"
+  cp "$served/index.html" "$outside/index.html"   # byte-identical to the manifest
+  rm -f "$served/index.html"
+  ln -s "$outside/index.html" "$served/index.html"
+
+  vout --skip-serve "$rec"
+  [ "$RC" -eq 1 ] || fail "verify should FAIL when a served path escapes the pin after activation, got $RC: $OUT"
+  assert_contains "$OUT" "content-escape" "the live containment escape was not named"
+
+  # Restore the real file inside the pin -> PASS again (verify itself changed
+  # nothing; the escape, not verify, was the mutation).
+  rm -f "$served/index.html"
+  cp "$outside/index.html" "$served/index.html"
+  vout --skip-serve "$rec"
+  [ "$RC" -eq 0 ] || fail "verify should PASS after the escaped file is restored: $OUT"
+  pass "verify: names a live containment escape when a served path leaves the pin after activation"
+}
+
 test_usage_errors() {
   local out
   out=$("$SCRIPT" bogus 2>&1); RC=$?
@@ -406,4 +443,5 @@ test_pin_safety_and_reuse
 test_repin_over_existing_symlink
 test_serve_subdir_escape_is_refused
 test_explicit_file_escape_is_refused
+test_verify_names_live_containment_escape
 test_usage_errors

--- a/tests/fm-dogfood-verify.test.sh
+++ b/tests/fm-dogfood-verify.test.sh
@@ -347,6 +347,42 @@ test_serve_subdir_escape_is_refused() {
   pass "pin: refuses a --serve-subdir that escapes the pinned worktree"
 }
 
+test_explicit_file_escape_is_refused() {
+  local case_dir src pin rec sha out secret
+  case_dir="$TMP_ROOT/fileescape"
+  src="$case_dir/src"; pin="$case_dir/pin"; rec="$case_dir/rec"
+  build_src "$src" fesc
+  sha=$(git -C "$src" rev-parse HEAD)
+
+  # Mutable external content the activation must NOT be able to record/serve.
+  mkdir -p "$case_dir/outside"
+  secret="$case_dir/outside/secret.txt"
+  printf 'external-and-mutable\n' > "$secret"
+
+  # (1) A --file with parent components resolving outside the pinned worktree.
+  out=$("$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$pin" \
+    --record "$rec" --serve-subdir ui --file '../../outside/secret.txt' 2>&1); RC=$?
+  [ "$RC" -eq 2 ] || fail "a --file escaping the pin should be refused (exit 2), got $RC"
+  assert_contains "$out" "escapes the pinned worktree" "file-escape refusal was not named"
+  assert_absent "$rec/pin.env" "a pin record was written for an escaping --file"
+  assert_absent "$rec/manifest.tsv" "a manifest was written for an escaping --file"
+
+  # (2) A served file that is a SYMLINK pointing outside the pinned worktree.
+  # It lives at a valid relative path inside served_root, but its target is the
+  # mutable external file, which must be refused just the same.
+  ln -s "$secret" "$pin/ui/leak.html"
+  out=$("$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$pin" \
+    --record "$case_dir/rec2" --serve-subdir ui --file leak.html 2>&1); RC=$?
+  rm -f "$pin/ui/leak.html"
+  [ "$RC" -eq 2 ] || fail "a --file symlink escaping the pin should be refused (exit 2), got $RC"
+  assert_contains "$out" "escapes the pinned worktree" "symlink file-escape refusal was not named"
+  assert_absent "$case_dir/rec2/manifest.tsv" "a manifest was written for an escaping symlink --file"
+
+  # The external file was never touched by the refused pins.
+  [ "$(cat "$secret")" = 'external-and-mutable' ] || fail "the external file was disturbed"
+  pass "pin: refuses an explicit --file (parent path or escaping symlink) outside the pinned worktree"
+}
+
 test_usage_errors() {
   local out
   out=$("$SCRIPT" bogus 2>&1); RC=$?
@@ -369,4 +405,5 @@ test_serve_process_up_and_down
 test_pin_safety_and_reuse
 test_repin_over_existing_symlink
 test_serve_subdir_escape_is_refused
+test_explicit_file_escape_is_refused
 test_usage_errors

--- a/tests/fm-dogfood-verify.test.sh
+++ b/tests/fm-dogfood-verify.test.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-dogfood-verify.sh.
+#
+# These exercise the two primitives through the real CLI: pin (immutable copy of
+# an exact commit + recorded manifest) and verify (live PASS or a specific named
+# drift). No project code and no live installed app are involved.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SCRIPT="$ROOT/bin/fm-dogfood-verify.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-dogfood-verify)
+fm_git_identity
+
+# Extra teardown: reap any serve process a test left running, then run the
+# registered temp-dir cleanup from tests/lib.sh.
+SERVE_PID=''
+dogfood_cleanup() {
+  if [ -n "$SERVE_PID" ]; then
+    kill "$SERVE_PID" 2>/dev/null || true
+    wait "$SERVE_PID" 2>/dev/null || true
+  fi
+  fm_test_cleanup
+}
+trap dogfood_cleanup EXIT
+trap 'dogfood_cleanup; exit 130' INT
+trap 'dogfood_cleanup; exit 143' TERM
+
+# build_src <dir> <content>: a repo with ui/index.html + ui/main.js, one commit.
+build_src() {
+  local d=$1 content=$2
+  mkdir -p "$d/ui"
+  printf '%s\n' "$content" > "$d/ui/index.html"
+  printf 'js-%s\n' "$content" > "$d/ui/main.js"
+  git -C "$d" init -q
+  git -C "$d" add -A
+  git -C "$d" commit -qm "ui $content"
+}
+
+# vout <args...>: run verify, capture combined output in OUT and status in RC.
+# Uses global writes (not command substitution) so RC survives to the caller.
+OUT=''
+RC=0
+vout() {
+  OUT=$("$SCRIPT" verify "$@" 2>&1)
+  RC=$?
+}
+
+test_pin_copies_exact_commit_not_shared_worktree() {
+  local case_dir src pin rec link sha head target src_phys
+  case_dir="$TMP_ROOT/copies"
+  src="$case_dir/src"; pin="$case_dir/pin"; rec="$case_dir/rec"
+  mkdir -p "$case_dir/live"
+  link="$case_dir/live/ui"
+  build_src "$src" v1
+  sha=$(git -C "$src" rev-parse HEAD)
+
+  "$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$pin" --record "$rec" \
+    --serve-subdir ui --link "$link" >/dev/null \
+    || fail "pin failed for a clean activation"
+
+  head=$(git -C "$pin" rev-parse HEAD)
+  [ "$head" = "$sha" ] || fail "pinned copy HEAD ($head) is not the activated commit ($sha)"
+  assert_grep "sha=$sha" "$rec/pin.env" "pin.env did not record the exact sha"
+  assert_present "$rec/manifest.tsv" "no manifest was written"
+  [ -s "$rec/manifest.tsv" ] || fail "manifest is empty"
+
+  # The live symlink must point at the dedicated pin copy, never inside the
+  # shared source worktree that other tasks keep committing to.
+  [ -L "$link" ] || fail "live symlink was not created"
+  target=$(readlink "$link")
+  case "$target" in
+    */pin/ui) : ;;
+    *) fail "live symlink points at $target, not the dedicated pin copy" ;;
+  esac
+  src_phys=$(cd "$src" && pwd -P)
+  case "$target" in
+    "$src_phys"|"$src_phys"/*) fail "live symlink points INSIDE the shared source worktree: $target" ;;
+  esac
+  pass "pin: copies the exact commit into a dedicated pin, symlink not in the shared worktree"
+}
+
+test_later_source_commit_does_not_change_pin() {
+  local case_dir src pin rec sha1 sha2
+  case_dir="$TMP_ROOT/isolation"
+  src="$case_dir/src"; pin="$case_dir/pin"; rec="$case_dir/rec"
+  build_src "$src" orig
+  sha1=$(git -C "$src" rev-parse HEAD)
+  "$SCRIPT" pin --source "$src" --sha "$sha1" --pin-dir "$pin" --record "$rec" \
+    --serve-subdir ui >/dev/null || fail "pin failed"
+
+  # A later, unrelated commit on the ORIGINAL source worktree/branch.
+  printf 'CHANGED-BY-LATER-TASK\n' > "$src/ui/index.html"
+  git -C "$src" add -A
+  git -C "$src" commit -qm later
+  sha2=$(git -C "$src" rev-parse HEAD)
+  [ "$sha1" != "$sha2" ] || fail "fixture did not advance the source"
+
+  [ "$(git -C "$pin" rev-parse HEAD)" = "$sha1" ] \
+    || fail "the pinned copy moved when the source advanced"
+  [ "$(cat "$pin/ui/index.html")" = orig ] \
+    || fail "the pinned copy now serves the later commit's content"
+
+  vout --skip-serve "$rec"
+  [ "$RC" -eq 0 ] || fail "verify should PASS on an untouched pin after the source advanced: $OUT"
+  assert_contains "$OUT" "PASS" "verify did not report PASS after the source advanced"
+  pass "pin: a later commit on the source does not change what the pinned copy serves"
+}
+
+test_verify_pass_and_named_drifts() {
+  local case_dir src pin rec link reg sha other served
+  case_dir="$TMP_ROOT/drift"
+  src="$case_dir/src"; pin="$case_dir/pin"; rec="$case_dir/rec"
+  mkdir -p "$case_dir/live"
+  link="$case_dir/live/ui"
+  reg="$case_dir/registry.json"
+  build_src "$src" base
+  sha=$(git -C "$src" rev-parse HEAD)
+  printf 'reg-v1\n' > "$reg"
+  "$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$pin" --record "$rec" \
+    --serve-subdir ui --link "$link" --invariant registry="$reg" >/dev/null \
+    || fail "pin failed"
+  # The authoritative served target pin recorded (physical path); restore to it.
+  served=$(sed -n 's/^served_root=//p' "$rec/pin.env")
+
+  # A second commit exists so we can push the pinned worktree off its pin.
+  printf 'v2\n' > "$src/ui/index.html"
+  git -C "$src" add -A
+  git -C "$src" commit -qm v2
+  other=$(git -C "$src" rev-parse HEAD)
+
+  vout --skip-serve "$rec"
+  [ "$RC" -eq 0 ] || fail "verify should PASS on the untouched pin: $OUT"
+  assert_contains "$OUT" "PASS" "untouched pin did not PASS"
+
+  # (1) symlink drift
+  ln -sfn "$case_dir" "$link"
+  vout --skip-serve "$rec"
+  [ "$RC" -eq 1 ] || fail "symlink drift should exit 1, got $RC"
+  assert_contains "$OUT" "symlink-drift" "symlink drift was not named"
+  ln -sfn "$served" "$link"
+
+  # (2) HEAD drift: advance the pinned worktree itself
+  git -C "$pin" checkout -q "$other"
+  vout --skip-serve "$rec"
+  [ "$RC" -eq 1 ] || fail "head drift should exit 1, got $RC"
+  assert_contains "$OUT" "head-drift" "head drift was not named"
+  git -C "$pin" checkout -q "$sha"
+
+  # (3) content drift: tamper a served file without moving HEAD
+  printf 'tampered\n' > "$pin/ui/index.html"
+  vout --skip-serve "$rec"
+  [ "$RC" -eq 1 ] || fail "content drift should exit 1, got $RC"
+  assert_contains "$OUT" "content-drift" "content drift was not named"
+  assert_not_contains "$OUT" "head-drift" "content-only drift wrongly reported head drift"
+  git -C "$pin" checkout -q -- ui/index.html
+
+  # (4) invariant drift
+  printf 'reg-v2\n' > "$reg"
+  vout --skip-serve "$rec"
+  [ "$RC" -eq 1 ] || fail "invariant drift should exit 1, got $RC"
+  assert_contains "$OUT" "invariant-drift" "invariant drift was not named"
+  printf 'reg-v1\n' > "$reg"
+
+  # Restored -> PASS again
+  vout --skip-serve "$rec"
+  [ "$RC" -eq 0 ] || fail "verify should PASS again after restore: $OUT"
+  assert_contains "$OUT" "PASS" "restored pin did not PASS"
+  pass "verify: PASS on an untouched pin, specific named FAIL for symlink/HEAD/content/invariant drift"
+}
+
+test_verify_is_read_only() {
+  local case_dir src pin rec link sha before after sentinel s_before list_before list_after
+  case_dir="$TMP_ROOT/readonly"
+  src="$case_dir/src"; pin="$case_dir/pin"; rec="$case_dir/rec"
+  mkdir -p "$case_dir/live"
+  link="$case_dir/live/ui"
+  build_src "$src" ro
+  sha=$(git -C "$src" rev-parse HEAD)
+  "$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$pin" --record "$rec" \
+    --serve-subdir ui --link "$link" >/dev/null || fail "pin failed"
+  local served
+  served=$(sed -n 's/^served_root=//p' "$rec/pin.env")
+
+  sentinel="$case_dir/sentinel"
+  printf 'do-not-touch\n' > "$sentinel"
+  s_before=$(cat "$sentinel")
+  before=$(cat "$rec/pin.env" "$rec/manifest.tsv" "$rec/invariants.tsv" | sha256_of_stdin)
+  list_before=$(cd "$rec" && find . -maxdepth 1 | LC_ALL=C sort)
+
+  # A passing verify.
+  vout --skip-serve "$rec"
+  # A failing verify (drifted symlink) must also mutate nothing.
+  ln -sfn "$case_dir" "$link"
+  vout --skip-serve "$rec"
+  ln -sfn "$served" "$link"
+
+  after=$(cat "$rec/pin.env" "$rec/manifest.tsv" "$rec/invariants.tsv" | sha256_of_stdin)
+  list_after=$(cd "$rec" && find . -maxdepth 1 | LC_ALL=C sort)
+  [ "$before" = "$after" ] || fail "verify mutated the recorded activation files"
+  [ "$list_before" = "$list_after" ] || fail "verify added or removed files in the record dir"
+  assert_present "$sentinel" "verify deleted an unrelated file"
+  [ "$(cat "$sentinel")" = "$s_before" ] || fail "verify modified an unrelated file"
+  pass "verify: never deletes or mutates unrelated data (PASS or FAIL)"
+}
+
+# sha256_of_stdin: portable stdin hash used only by the read-only test.
+sha256_of_stdin() {
+  if command -v shasum >/dev/null 2>&1; then shasum -a 256 | awk '{print $1}';
+  else sha256sum | awk '{print $1}'; fi
+}
+
+test_serve_process_up_and_down() {
+  local case_dir src pin rec sha marker out
+  if ! command -v pgrep >/dev/null 2>&1; then
+    pass "verify: serve-process check (skipped: pgrep not available)"
+    return 0
+  fi
+  case_dir="$TMP_ROOT/serve"
+  src="$case_dir/src"; pin="$case_dir/pin"; rec="$case_dir/rec"
+  build_src "$src" serve
+  sha=$(git -C "$src" rev-parse HEAD)
+  marker="$case_dir/fmdogfood-serve-marker-$$"
+  mkdir -p "$case_dir"
+
+  # A real process whose argv[0] is the unique marker, so pgrep -f matches it.
+  ( exec -a "$marker" sleep 120 ) &
+  SERVE_PID=$!
+  sleep 0.2
+
+  "$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$pin" --record "$rec" \
+    --serve-subdir ui --process-pattern "$marker" >/dev/null || fail "pin failed"
+
+  out=$("$SCRIPT" verify "$rec" 2>&1); RC=$?
+  [ "$RC" -eq 0 ] || fail "verify should PASS while the serve process is up: $out"
+  assert_contains "$out" "PASS" "serve-up verify did not PASS"
+
+  kill "$SERVE_PID" 2>/dev/null || true
+  wait "$SERVE_PID" 2>/dev/null || true
+  SERVE_PID=''
+
+  out=$("$SCRIPT" verify "$rec" 2>&1); RC=$?
+  [ "$RC" -eq 1 ] || fail "verify should FAIL once the serve process is gone, got $RC"
+  assert_contains "$out" "serve-process-down" "process-down drift was not named"
+  pass "verify: reports serve-process-down when the recorded process is gone"
+}
+
+test_pin_safety_and_reuse() {
+  local case_dir src pin rec sha out realdir
+  case_dir="$TMP_ROOT/safety"
+  src="$case_dir/src"; pin="$case_dir/pin"; rec="$case_dir/rec"
+  build_src "$src" safe
+  sha=$(git -C "$src" rev-parse HEAD)
+
+  # pin-dir inside the source worktree is refused.
+  out=$("$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$src/inside" \
+    --record "$case_dir/rec-inside" --serve-subdir ui 2>&1); RC=$?
+  [ "$RC" -eq 2 ] || fail "pin-dir inside source should be refused (exit 2), got $RC"
+  assert_contains "$out" "inside the source worktree" "refusal did not explain the reason"
+  assert_absent "$src/inside" "a pin copy was created inside the source worktree"
+
+  # A clean pin, then a byte-identical reuse of the same commit + pin-dir.
+  "$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$pin" --record "$rec" \
+    --serve-subdir ui >/dev/null || fail "first pin failed"
+  "$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$pin" --record "$case_dir/rec2" \
+    --serve-subdir ui >/dev/null || fail "idempotent reuse of the same pin failed"
+
+  # Refuse to clobber a real (non-symlink) path at --link.
+  realdir="$case_dir/realdir"
+  mkdir -p "$realdir"
+  out=$("$SCRIPT" pin --source "$src" --sha "$sha" --pin-dir "$pin" --record "$case_dir/rec3" \
+    --serve-subdir ui --link "$realdir" 2>&1); RC=$?
+  [ "$RC" -eq 2 ] || fail "clobbering a non-symlink --link should be refused, got $RC"
+  assert_contains "$out" "non-symlink" "clobber refusal did not name the hazard"
+  assert_present "$realdir" "the real directory at --link was disturbed"
+  [ ! -L "$realdir" ] || fail "the real directory at --link was replaced by a symlink"
+  pass "pin: refuses pin-dir inside source, refuses non-symlink clobber, reuses an identical pin"
+}
+
+test_usage_errors() {
+  local out
+  out=$("$SCRIPT" bogus 2>&1); RC=$?
+  [ "$RC" -eq 2 ] || fail "an unknown subcommand should exit 2, got $RC"
+
+  out=$("$SCRIPT" verify 2>&1); RC=$?
+  [ "$RC" -eq 2 ] || fail "verify with no record path should exit 2, got $RC"
+  assert_contains "$out" "required" "missing-arg verify did not explain the requirement"
+
+  out=$("$SCRIPT" pin --source "$TMP_ROOT" 2>&1); RC=$?
+  [ "$RC" -eq 2 ] || fail "pin without required args should exit 2, got $RC"
+  pass "usage: unknown subcommand and missing required arguments exit 2"
+}
+
+test_pin_copies_exact_commit_not_shared_worktree
+test_later_source_commit_does_not_change_pin
+test_verify_pass_and_named_drifts
+test_verify_is_read_only
+test_serve_process_up_and_down
+test_pin_safety_and_reuse
+test_usage_errors


### PR DESCRIPTION
## Intent

Build a small, general-purpose, reusable bin/ script (bin/fm-dogfood-verify.sh) that any project's local installed-app 'dogfood' activation flow can use, fixing a concrete reproducible failure: an activation pointed the live ~/Library/Application Support/<App>/ui symlink at a path INSIDE a shared, mutable task worktree that unrelated later tasks kept committing to, so the installed app silently began serving a different commit than the one activated, making 'still active'/overnight-status claims false with no notification.

The script owns two responsibilities. (1) Immutable pinning at activation time: the 'pin' subcommand copies the EXACT commit into a dedicated, activation-owned git worktree (git worktree add --detach) that no other task ever writes to, points the live symlink at that dedicated copy instead of at a shared task worktree, and records the exact SHA plus a content-hash manifest of the served files and other invariants alongside it. It is idempotent/reusable: re-pinning the same commit into the same pin-dir reuses it. (2) On-demand truth verification: the 'verify' subcommand revalidates a recorded activation LIVE, right now, and reports a clear PASS or a specific named drift/failure - it re-checks the symlink target, the exact HEAD at the pinned copy, content hashes of served files vs the recorded manifest, any recorded invariant files (e.g. registry/history hashes), and that the serving process/port is actually up. It never silently assumes the recorded active.json is still true. verify is strictly read-only: it never deletes or mutates anything.

These are reusable, project-agnostic primitives, not a TodoFlow-only fix; TodoFlow's existing activation record is only today's proof, and the same shape must work for any future local-dogfood activation.

Explicitly out of scope: no changes to TodoFlow or Faber product code or their repos; no live mutation of the currently-installed app or its symlink; do not decide Faber's real daily surface; do not touch currently-running crew task worktrees.

Acceptance: tests prove (a) activation copies/pins an exact commit rather than pointing at a live shared worktree; (b) a later commit on the ORIGINAL source worktree/branch does not change what the pinned copy serves; (c) verify correctly reports PASS on an untouched pin and a specific named FAIL when the symlink target, HEAD, or file hashes have drifted; (d) verify never deletes or mutates unrelated data. Both commands are documented in the script's own --help. The change is minimal and reversible reliability tooling, not a redesign of the dogfood concept. Delivered as bin/fm-dogfood-verify.sh plus tests/fm-dogfood-verify.test.sh.

## What Changed

- Add `bin/fm-dogfood-verify.sh`, a project-agnostic tool with two subcommands: `pin` copies an exact commit into a dedicated `git worktree add --detach` copy outside the shared source worktree, atomically repoints the live symlink at that copy, and records a `pin.env` metadata file plus a `manifest.tsv` content-hash of served files and an `invariants.tsv`; it is idempotent (re-pinning the same commit reuses the copy), refuses a pin-dir inside the source worktree, refuses to clobber a non-symlink `--link`, and runs a structural postflight self-check.
- Add `verify`, a strictly read-only revalidation that re-checks the symlink target, the pinned copy's live HEAD, served-file hashes vs the manifest, recorded invariant files, and (unless `--skip-serve`) the recorded port/process, reporting `PASS` or a specific named drift (`symlink-drift`, `head-drift`, `content-drift`, `invariant-drift`, `serve-port-down`, `serve-process-down`) with exit codes 0/1/2.
- Add `tests/fm-dogfood-verify.test.sh` covering exact-commit pinning, isolation from later source commits, PASS plus each named drift, read-only guarantees, serve-process up/down, pin safety/reuse, re-pinning over an existing symlink, and usage errors.

## Risk Assessment

✅ Low: The fix-round change is a small, well-bounded, correct resolution of the previously-reported symlink-dereference bug, covered by a genuine behavior-level regression test, with only a negligible non-atomicity nit that has no portable better alternative.

## Testing

Ran the smallest relevant automated suite (`tests/fm-dogfood-verify.test.sh`, 8/8 pass) which exercises the real pin/verify CLI and observable exit codes/drift names rather than source text, plus a hand-built end-to-end CLI transcript that reproduces the exact reported failure (installed app silently serving a different commit) and shows immutable pinning + live truth verification with PASS/named-FAIL exit codes. This is a bash CLI tool with no rendered UI surface, so a CLI transcript (not a screenshot) is the reviewer-visible end-user artifact. All acceptance criteria (a)-(d) demonstrated; no failures or environment issues.

<details>
<summary>Evidence: End-to-end reproduction transcript (pin/verify vs the reported drift bug)</summary>

Source: [End-to-end reproduction transcript (pin/verify vs the reported drift bug)](https://github.com/AbdullahPesteli/firstmate/blob/fe715efa78261a4a38b6efc0863d83b8cf49a319/.no-mistakes/evidence/fm/ship-firstmate-dogfood-truth-guard/e2e-transcript.txt)

```text
############################################################
# fm-dogfood-verify end-to-end: reproduce the reported bug  #
#   'installed app silently serves a DIFFERENT commit'      #
############################################################

>> Activated commit (build A): 414650beba5f55f21fc4487dc347f8e3d2cbe3eb
>> Served content at activation:
     <h1>TodoFlow build A (ACTIVATED)</h1>

>> [pin] activate build A into a dedicated, activation-owned copy
PINNED /private/var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T/fmdogfood-demo.j9iPgy/records/todoflow sha=414650beba5f55f21fc4487dc347f8e3d2cbe3eb files=1 pin_dir=/private/var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T/fmdogfood-demo.j9iPgy/pins/todoflow-A
LINK /private/var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T/fmdogfood-demo.j9iPgy/Application Support/TodoFlow/ui -> /private/var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T/fmdogfood-demo.j9iPgy/pins/todoflow-A/ui (was: (none))

>> Live symlink now points at (dedicated pin, NOT the shared worktree):
     /var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T//fmdogfood-demo.j9iPgy/Application Support/TodoFlow/ui -> /private/var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T/fmdogfood-demo.j9iPgy/pins/todoflow-A/ui

>> [verify] right after activation (read-only):
PASS /var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T/fmdogfood-demo.j9iPgy/records/todoflow sha=414650beba5f55f21fc4487dc347f8e3d2cbe3eb
   exit=0

------------------------------------------------------------
>> An UNRELATED later task commits to the SAME shared worktree...
>> Shared worktree HEAD moved to build B: 826783156a30a444ae20d279542bc742674e66dc
>> Shared worktree now serves:
     <h1>UNRELATED build B (never activated)</h1>

>> But what the INSTALLED APP serves (via the live symlink) is:
     <h1>TodoFlow build A (ACTIVATED)</h1>
   ^^ still build A. The later commit did NOT change what is served.

>> [verify] still truthful after the shared worktree advanced:
PASS /var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T/fmdogfood-demo.j9iPgy/records/todoflow sha=414650beba5f55f21fc4487dc347f8e3d2cbe3eb
   exit=0

------------------------------------------------------------
>> DRIFT DETECTION (verify never lies).
>> (a) live symlink repointed at the shared worktree (the old bug):
FAIL symlink-drift: /private/var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T/fmdogfood-demo.j9iPgy/Application Support/TodoFlow/ui -> /var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T//fmdogfood-demo.j9iPgy/shared-task-worktree/ui (expected /private/var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T/fmdogfood-demo.j9iPgy/pins/todoflow-A/ui)
FAILED /var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T/fmdogfood-demo.j9iPgy/records/todoflow (1 check(s) failed)
   exit=1

>> (b) a served file tampered inside the pinned copy:
FAIL content-drift: index.html
FAILED /var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T/fmdogfood-demo.j9iPgy/records/todoflow (1 check(s) failed)
   exit=1

>> (c) restored -> PASS again:
PASS /var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T/fmdogfood-demo.j9iPgy/records/todoflow sha=414650beba5f55f21fc4487dc347f8e3d2cbe3eb
   exit=0

############################  DONE  ############################
```
</details>
<details>
<summary>Evidence: Targeted test suite result</summary>

```text
ok - pin: copies the exact commit into a dedicated pin, symlink not in the shared worktree
ok - pin: a later commit on the source does not change what the pinned copy serves
ok - verify: PASS on an untouched pin, specific named FAIL for symlink/HEAD/content/invariant drift
ok - verify: never deletes or mutates unrelated data (PASS or FAIL)
ok - verify: reports serve-process-down when the recorded process is gone
ok - pin: refuses pin-dir inside source, refuses non-symlink clobber, reuses an identical pin
ok - pin: re-pinning a different commit onto an existing symlink-to-dir repoints the link
ok - usage: unknown subcommand and missing required arguments exit 2
EXIT=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"53e9a807fbb19b0f42a4e00925d450ff0c27fc2a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `bin/fm-dogfood-verify.sh:333` - pin installs the live symlink with `mv -f &#34;$tmp&#34; &#34;$link&#34;` (bin/fm-dogfood-verify.sh:333). When --link already exists as a symlink to a directory — the normal re-activation case for a live `~/Library/Application Support/&lt;App&gt;/ui` link — `mv` on darwin/BSD (and GNU) dereferences the destination symlink and moves the staged symlink INTO the old served directory instead of atomically replacing the link. Reproduced end-to-end on darwin: re-activating a different commit at the same live link leaves the link still pointing at the OLD pin copy, deposits a stray `ui.fmpin.NNN` symlink inside the previous worktree, and aborts with `pin: postflight verification failed` (exit 2). Only the first pin (where the link does not yet exist) works; every subsequent re-activation onto the live symlink is broken — the exact &#39;repoint the live symlink&#39; guarantee the tool exists to provide. Fix: install the symlink without dereferencing the destination, e.g. `ln -sfn &#34;$served_root&#34; &#34;$link&#34;` (the pattern the tests already use to restore), or `rm -f &#34;$link&#34;` before creating it. No test covers re-pinning onto an existing symlink-to-dir, which is why it slipped through.

🔧 Fix: fix(bin): repoint live symlink without dereferencing on re-pin
1 info still open:
- ℹ️ `bin/fm-dogfood-verify.sh:333` - The re-pin fix swaps the live symlink via `rm -f &#34;$link&#34;` then `mv &#34;$tmp&#34; &#34;$link&#34;` (lines 333-336). This correctly avoids mv&#39;s dereference-into-directory bug, but it is not truly atomic: there is a brief window where $link does not exist, and if the subsequent `mv` were to fail (e.g. concurrent permission change / ENOSPC on inode) the previous live symlink would already be gone, leaving no live symlink at all — whereas the original `mv -f` preserved the old target on failure. In practice `mv` of a symlink onto a same-directory non-existent destination is a rename(2) that essentially cannot fail, and no portable fully-atomic symlink-to-dir replacement exists (GNU `mv -T` / BSD have no common flag), so the rm+mv approach is the pragmatic and reasonable choice. Noted for awareness; no action needed.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-dogfood-verify.test.sh` — all 8 behavior tests pass (pin copies exact commit vs shared worktree; source-advance isolation; verify PASS + named symlink/HEAD/content/invariant drift; read-only; serve-process up/down; pin safety+reuse; re-pin symlink repoint; usage errors)</code>
- <code>`bash bin/fm-dogfood-verify.sh --help` — confirms both `pin` and `verify` documented</code>
- `End-to-end reproduction transcript: pinned build A, advanced shared worktree to build B, confirmed installed app still serves A; verify PASS (exit 0) untouched, FAIL symlink-drift + content-drift (exit 1), PASS again after restore`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
