### PR TITLE
fix(bin): measure startup-memory symlinks from their resolved regular-file target

### DIFF
--- a/bin/fm-startup-memory-budget-lib.sh
+++ b/bin/fm-startup-memory-budget-lib.sh
@@ -180,7 +180,6 @@ fm_startup_memory_measure_file() {
   bytes=$(LC_ALL=C perl - "$path" <<'PERL'
 use strict;
 use warnings;
-use Cwd qw(realpath);
 use Fcntl qw(:DEFAULT :mode);
 
 my $path = shift @ARGV;
@@ -204,15 +203,17 @@ sub kind_for_mode {
 my @link_stat = lstat($path);
 @link_stat or fail("memory file could not be inspected: $path");
 my $is_symlink = S_ISLNK($link_stat[2]);
-my $resolved = realpath($path);
-if (!defined $resolved) {
-  fail("memory file symlink target could not be resolved, possibly due to a loop: $path") if $is_symlink;
-  fail("memory file could not be resolved: $path");
-}
 
-my @target_stat = stat($resolved);
+# stat() follows the link, so the kernel classifies each failure class and a
+# dangling target is never reported as a loop.
+$! = 0;
+my @target_stat = stat($path);
 if (!@target_stat) {
-  fail("memory file symlink target does not exist: $path") if $is_symlink;
+  if ($is_symlink) {
+    fail("memory file symlink loop: $path") if $!{ELOOP};
+    fail("memory file symlink target does not exist: $path") if $!{ENOENT} || $!{ENOTDIR};
+    fail("memory file symlink target could not be resolved ($!): $path");
+  }
   fail("memory file target could not be inspected: $path");
 }
 if (!S_ISREG($target_stat[2])) {
@@ -222,7 +223,7 @@ if (!S_ISREG($target_stat[2])) {
 # The target can be replaced between the stat above and the open, so open
 # without blocking (a swapped-in FIFO must not hang the measurement), then
 # re-check type and dev/ino on the open descriptor before any byte is read.
-sysopen(my $fh, $resolved, O_RDONLY | O_NONBLOCK)
+sysopen(my $fh, $path, O_RDONLY | O_NONBLOCK)
   or fail("memory file target could not be read: $path");
 my @fh_stat = stat($fh);
 @fh_stat or fail("memory file target could not be inspected after open: $path");

--- a/bin/fm-startup-memory-budget-lib.sh
+++ b/bin/fm-startup-memory-budget-lib.sh
@@ -164,7 +164,10 @@ fm_startup_memory_estimated_tokens_for_bytes() {
 # Prints "<bytes> <estimated-tokens> <present|absent>".  Memory files must
 # resolve to ordinary readable regular files when present, so an intentional
 # symlink is measured from its resolved target while every special target type
-# is rejected before content is read.
+# is rejected before content is read.  Tests may set
+# FM_STARTUP_MEMORY_MEASURE_TEST_SWAP=<path> to rename <path> over the resolved
+# target between inspection and open, exercising the identity re-check without
+# a timing race.
 fm_startup_memory_measure_file() {
   local path=$1 bytes tokens
   FM_STARTUP_MEMORY_MEASURE_BYTES=""
@@ -177,7 +180,7 @@ fm_startup_memory_measure_file() {
     printf '0 0 absent\n'
     return 0
   fi
-  bytes=$(perl - "$path" <<'PERL' 2>&1
+  bytes=$(LC_ALL=C perl - "$path" <<'PERL'
 use strict;
 use warnings;
 use Cwd qw(realpath);
@@ -186,7 +189,7 @@ use Fcntl qw(:DEFAULT :mode);
 my $path = shift @ARGV;
 
 sub fail {
-  print STDERR $_[0], "\n";
+  print $_[0], "\n";
   exit 1;
 }
 
@@ -219,6 +222,12 @@ if (!S_ISREG($target_stat[2])) {
   fail("memory file target is " . kind_for_mode($target_stat[2]) . ", not an ordinary readable regular file: $path");
 }
 
+my $swap = $ENV{FM_STARTUP_MEMORY_MEASURE_TEST_SWAP};
+if (defined $swap && length $swap) {
+  rename($swap, $resolved)
+    or fail("memory file test swap could not replace the target: $path");
+}
+
 sysopen(my $fh, $resolved, O_RDONLY | O_NONBLOCK)
   or fail("memory file target could not be read: $path");
 my @fh_stat = stat($fh);
@@ -244,7 +253,7 @@ while (1) {
 print $bytes, "\n";
 PERL
   ) || {
-    fm_startup_memory_budget_fail "$bytes"
+    fm_startup_memory_budget_fail "${bytes:-memory file could not be measured: $path}"
     return 1
   }
   case "$bytes" in

--- a/bin/fm-startup-memory-budget-lib.sh
+++ b/bin/fm-startup-memory-budget-lib.sh
@@ -161,9 +161,10 @@ fm_startup_memory_estimated_tokens_for_bytes() {
 }
 
 # fm_startup_memory_measure_file <path>
-# Prints "<bytes> <estimated-tokens> <present|absent>".  Memory files must be
-# ordinary files when present so a measurement never follows a symlink or reads
-# a special file.
+# Prints "<bytes> <estimated-tokens> <present|absent>".  Memory files must
+# resolve to ordinary readable regular files when present, so an intentional
+# symlink is measured from its resolved target while every special target type
+# is rejected before content is read.
 fm_startup_memory_measure_file() {
   local path=$1 bytes tokens
   FM_STARTUP_MEMORY_MEASURE_BYTES=""
@@ -176,12 +177,74 @@ fm_startup_memory_measure_file() {
     printf '0 0 absent\n'
     return 0
   fi
-  if [ -L "$path" ] || [ ! -f "$path" ]; then
-    fm_startup_memory_budget_fail "memory file is not an ordinary regular file: $path"
-    return 1
-  fi
-  bytes=$(LC_ALL=C wc -c < "$path" 2>/dev/null | tr -d '[:space:]') || {
-    fm_startup_memory_budget_fail "could not measure memory file: $path"
+  bytes=$(perl - "$path" <<'PERL' 2>&1
+use strict;
+use warnings;
+use Cwd qw(realpath);
+use Fcntl qw(:DEFAULT :mode);
+
+my $path = shift @ARGV;
+
+sub fail {
+  print STDERR $_[0], "\n";
+  exit 1;
+}
+
+sub kind_for_mode {
+  my ($mode) = @_;
+  return 'a directory' if S_ISDIR($mode);
+  return 'a FIFO' if S_ISFIFO($mode);
+  return 'a socket' if S_ISSOCK($mode);
+  return 'a character device' if S_ISCHR($mode);
+  return 'a block device' if S_ISBLK($mode);
+  return 'a symlink' if S_ISLNK($mode);
+  return 'not an ordinary regular file';
+}
+
+my @link_stat = lstat($path);
+@link_stat or fail("memory file could not be inspected: $path");
+my $is_symlink = S_ISLNK($link_stat[2]);
+my $resolved = realpath($path);
+if (!defined $resolved) {
+  fail("memory file symlink target could not be resolved, possibly due to a loop: $path") if $is_symlink;
+  fail("memory file could not be resolved: $path");
+}
+
+my @target_stat = stat($resolved);
+if (!@target_stat) {
+  fail("memory file symlink target does not exist: $path") if $is_symlink;
+  fail("memory file target could not be inspected: $path");
+}
+if (!S_ISREG($target_stat[2])) {
+  fail("memory file target is " . kind_for_mode($target_stat[2]) . ", not an ordinary readable regular file: $path");
+}
+
+sysopen(my $fh, $resolved, O_RDONLY | O_NONBLOCK)
+  or fail("memory file target could not be read: $path");
+my @fh_stat = stat($fh);
+@fh_stat or fail("memory file target could not be inspected after open: $path");
+if (!S_ISREG($fh_stat[2])) {
+  fail("memory file target changed to " . kind_for_mode($fh_stat[2]) . " while being measured: $path");
+}
+if ($target_stat[0] != $fh_stat[0] || $target_stat[1] != $fh_stat[1]) {
+  fail("memory file target changed while being measured: $path");
+}
+
+binmode($fh) or fail("memory file target could not be read: $path");
+my $bytes = 0;
+while (1) {
+  my $n = sysread($fh, my $buffer, 65536);
+  if (!defined $n) {
+    next if $!{EINTR};
+    fail("memory file target could not be measured: $path");
+  }
+  last if $n == 0;
+  $bytes += $n;
+}
+print $bytes, "\n";
+PERL
+  ) || {
+    fm_startup_memory_budget_fail "$bytes"
     return 1
   }
   case "$bytes" in

--- a/bin/fm-startup-memory-budget-lib.sh
+++ b/bin/fm-startup-memory-budget-lib.sh
@@ -164,10 +164,7 @@ fm_startup_memory_estimated_tokens_for_bytes() {
 # Prints "<bytes> <estimated-tokens> <present|absent>".  Memory files must
 # resolve to ordinary readable regular files when present, so an intentional
 # symlink is measured from its resolved target while every special target type
-# is rejected before content is read.  Tests may set
-# FM_STARTUP_MEMORY_MEASURE_TEST_SWAP=<path> to rename <path> over the resolved
-# target between inspection and open, exercising the identity re-check without
-# a timing race.
+# is rejected before content is read.
 fm_startup_memory_measure_file() {
   local path=$1 bytes tokens
   FM_STARTUP_MEMORY_MEASURE_BYTES=""
@@ -220,12 +217,6 @@ if (!@target_stat) {
 }
 if (!S_ISREG($target_stat[2])) {
   fail("memory file target is " . kind_for_mode($target_stat[2]) . ", not an ordinary readable regular file: $path");
-}
-
-my $swap = $ENV{FM_STARTUP_MEMORY_MEASURE_TEST_SWAP};
-if (defined $swap && length $swap) {
-  rename($swap, $resolved)
-    or fail("memory file test swap could not replace the target: $path");
 }
 
 sysopen(my $fh, $resolved, O_RDONLY | O_NONBLOCK)

--- a/bin/fm-startup-memory-budget-lib.sh
+++ b/bin/fm-startup-memory-budget-lib.sh
@@ -219,6 +219,9 @@ if (!S_ISREG($target_stat[2])) {
   fail("memory file target is " . kind_for_mode($target_stat[2]) . ", not an ordinary readable regular file: $path");
 }
 
+# The target can be replaced between the stat above and the open, so open
+# without blocking (a swapped-in FIFO must not hang the measurement), then
+# re-check type and dev/ino on the open descriptor before any byte is read.
 sysopen(my $fh, $resolved, O_RDONLY | O_NONBLOCK)
   or fail("memory file target could not be read: $path");
 my @fh_stat = stat($fh);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,6 +220,7 @@ Malformed, multi-line, symlinked, hardlinked, special, or otherwise unsafe value
 Use `bin/fm-startup-memory-budget.sh read` to validate and print the effective value, or `bin/fm-startup-memory-budget.sh report` to account for the three files.
 Startup-memory files are counted from ordinary readable regular files, and an intentional symlink is measured from its resolved target even when that target lives outside the home.
 Broken links, loops, directories, FIFOs, devices, sockets, and unreadable or otherwise non-regular targets are rejected with a concrete diagnostic instead of being read.
+Each class names its own problem, so a dangling link reports a missing target and only a genuine symlink loop reports a loop.
 The stable local estimate is `ceil(UTF-8 bytes / 3)` per file, a conservative portable approximation rather than a provider-exact tokenizer.
 An inherited `data/captain-shared.md` counts in a secondmate's total but remains primary-owned and read-only there.
 The internal [`/stow` skill](../.agents/skills/stow/SKILL.md) owns curation and its automatic secondmate cascade, which accounts every home against this same per-home allowance separately rather than against a fleet total.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,7 +218,8 @@ A secondmate does not create an independent default and instead receives the pri
 The file must be one positive base-10 integer followed by exactly one newline in a regular, single-linked file beneath a non-symlinked `config/` directory.
 Malformed, multi-line, symlinked, hardlinked, special, or otherwise unsafe values are rejected rather than treated as a default.
 Use `bin/fm-startup-memory-budget.sh read` to validate and print the effective value, or `bin/fm-startup-memory-budget.sh report` to account for the three files.
-Startup-memory files are counted from ordinary readable regular files, including intentional symlinks whose resolved targets are ordinary readable regular files outside the home; broken links, loops, directories, FIFOs, devices, sockets, and unreadable targets are rejected instead of read.
+Startup-memory files are counted from ordinary readable regular files, and an intentional symlink is measured from its resolved target even when that target lives outside the home.
+Broken links, loops, directories, FIFOs, devices, sockets, and unreadable or otherwise non-regular targets are rejected with a concrete diagnostic instead of being read.
 The stable local estimate is `ceil(UTF-8 bytes / 3)` per file, a conservative portable approximation rather than a provider-exact tokenizer.
 An inherited `data/captain-shared.md` counts in a secondmate's total but remains primary-owned and read-only there.
 The internal [`/stow` skill](../.agents/skills/stow/SKILL.md) owns curation and its automatic secondmate cascade, which accounts every home against this same per-home allowance separately rather than against a fleet total.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,7 +218,7 @@ A secondmate does not create an independent default and instead receives the pri
 The file must be one positive base-10 integer followed by exactly one newline in a regular, single-linked file beneath a non-symlinked `config/` directory.
 Malformed, multi-line, symlinked, hardlinked, special, or otherwise unsafe values are rejected rather than treated as a default.
 Use `bin/fm-startup-memory-budget.sh read` to validate and print the effective value, or `bin/fm-startup-memory-budget.sh report` to account for the three files.
-Startup-memory files are counted from ordinary readable regular files, and an intentional symlink is measured from its resolved target even when that target lives outside the home.
+The three accounted memory files are counted from ordinary readable regular files, and an intentional symlink is measured from its resolved target even when that target lives outside the home.
 Broken links, loops, directories, FIFOs, devices, sockets, and unreadable or otherwise non-regular targets are rejected with a concrete diagnostic instead of being read.
 Each class names its own problem, so a dangling link reports a missing target and only a genuine symlink loop reports a loop.
 The stable local estimate is `ceil(UTF-8 bytes / 3)` per file, a conservative portable approximation rather than a provider-exact tokenizer.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,6 +218,7 @@ A secondmate does not create an independent default and instead receives the pri
 The file must be one positive base-10 integer followed by exactly one newline in a regular, single-linked file beneath a non-symlinked `config/` directory.
 Malformed, multi-line, symlinked, hardlinked, special, or otherwise unsafe values are rejected rather than treated as a default.
 Use `bin/fm-startup-memory-budget.sh read` to validate and print the effective value, or `bin/fm-startup-memory-budget.sh report` to account for the three files.
+Startup-memory files are counted from ordinary readable regular files, including intentional symlinks whose resolved targets are ordinary readable regular files outside the home; broken links, loops, directories, FIFOs, devices, sockets, and unreadable targets are rejected instead of read.
 The stable local estimate is `ceil(UTF-8 bytes / 3)` per file, a conservative portable approximation rather than a provider-exact tokenizer.
 An inherited `data/captain-shared.md` counts in a secondmate's total but remains primary-owned and read-only there.
 The internal [`/stow` skill](../.agents/skills/stow/SKILL.md) owns curation and its automatic secondmate cascade, which accounts every home against this same per-home allowance separately rather than against a fleet total.

--- a/tests/fixtures/fm-startup-memory-budget/FmStartupMemoryMeasureRace.pm
+++ b/tests/fixtures/fm-startup-memory-budget/FmStartupMemoryMeasureRace.pm
@@ -8,8 +8,9 @@ package FmStartupMemoryMeasureRace;
 # file that open resolves to, reproducing a target replaced between inspection
 # and open.  Activation is confined to a tests/lib.sh fixture root:
 # <fixture-root> must carry the .fm-test-fixture marker, and the resolved
-# target and <replacement> must both sit beneath it on its device.  Every other call dies before
-# touching the filesystem, so a real home or memory target is never replaced.
+# target and <replacement> must both sit beneath it on its device.  Every
+# other call dies before touching the filesystem, so a real home or memory
+# target is never replaced.
 use strict;
 use warnings;
 use Cwd qw(realpath);

--- a/tests/fixtures/fm-startup-memory-budget/FmStartupMemoryMeasureRace.pm
+++ b/tests/fixtures/fm-startup-memory-budget/FmStartupMemoryMeasureRace.pm
@@ -4,11 +4,11 @@ package FmStartupMemoryMeasureRace;
 # One bin/fm-startup-memory-budget.sh report run loads it through PERL5OPT:
 #   PERL5OPT="-I<repo>/tests/fixtures/fm-startup-memory-budget \
 #             -MFmStartupMemoryMeasureRace=<fixture-root>,<replacement>"
-# The measurement's first sysopen then renames <replacement> over the file it
-# is about to open, reproducing a target replaced between inspection and open.
-# Activation is confined to a tests/lib.sh fixture root: <fixture-root> must
-# carry the .fm-test-fixture marker, and the opened file and <replacement>
-# must both resolve beneath it on its device.  Every other call dies before
+# The measurement's first sysopen then renames <replacement> over the regular
+# file that open resolves to, reproducing a target replaced between inspection
+# and open.  Activation is confined to a tests/lib.sh fixture root:
+# <fixture-root> must carry the .fm-test-fixture marker, and the resolved
+# target and <replacement> must both sit beneath it on its device.  Every other call dies before
 # touching the filesystem, so a real home or memory target is never replaced.
 use strict;
 use warnings;

--- a/tests/fixtures/fm-startup-memory-budget/FmStartupMemoryMeasureRace.pm
+++ b/tests/fixtures/fm-startup-memory-budget/FmStartupMemoryMeasureRace.pm
@@ -1,0 +1,64 @@
+package FmStartupMemoryMeasureRace;
+# Test-only sysopen interposer for tests/fm-startup-memory-budget.test.sh.
+#
+# One bin/fm-startup-memory-budget.sh report run loads it through PERL5OPT:
+#   PERL5OPT="-I<repo>/tests/fixtures/fm-startup-memory-budget \
+#             -MFmStartupMemoryMeasureRace=<fixture-root>,<replacement>"
+# The measurement's first sysopen then renames <replacement> over the file it
+# is about to open, reproducing a target replaced between inspection and open.
+# Activation is confined to a tests/lib.sh fixture root: <fixture-root> must
+# carry the .fm-test-fixture marker, and the opened file and <replacement>
+# must both resolve beneath it on its device.  Every other call dies before
+# touching the filesystem, so a real home or memory target is never replaced.
+use strict;
+use warnings;
+use Cwd qw(realpath);
+use Fcntl qw(:mode);
+
+my ($root, $root_dev, $replacement, $armed);
+
+sub import {
+  my ($class, $fixture_root, $replacement_path) = @_;
+  (defined $fixture_root && defined $replacement_path)
+    or die "$class: usage -M$class=<fixture-root>,<replacement>\n";
+  my $real_root = realpath($fixture_root);
+  (defined $real_root && -d $real_root && -f "$real_root/.fm-test-fixture")
+    or die "$class: $fixture_root is not a tests/lib.sh fixture root\n";
+  ($root, $root_dev, $replacement, $armed) =
+    ($real_root, (stat $real_root)[0], $replacement_path, 1);
+}
+
+sub proven_path {
+  my ($label, $path) = @_;
+  my $real = realpath($path);
+  (defined $real && index($real, "$root/") == 0)
+    or die __PACKAGE__ . ": refused $label outside fixture root $root: $path\n";
+  my @st = lstat $real;
+  (@st && $st[0] == $root_dev)
+    or die __PACKAGE__ . ": refused $label off the fixture device: $path\n";
+  return ($real, @st);
+}
+
+sub replace_target {
+  my ($target) = @_;
+  my ($real_target, @target_st) = proven_path('target', $target);
+  S_ISREG($target_st[2])
+    or die __PACKAGE__ . ": refused target that is not a regular file: $target\n";
+  my ($real_replacement) = proven_path('replacement', $replacement);
+  rename($real_replacement, $real_target)
+    or die __PACKAGE__ . ": could not replace $target: $!\n";
+}
+
+BEGIN {
+  *CORE::GLOBAL::sysopen = sub (*$$;$) {
+    if ($armed) {
+      $armed = 0;
+      replace_target($_[1]);
+    }
+    return @_ > 3
+      ? CORE::sysopen($_[0], $_[1], $_[2], $_[3])
+      : CORE::sysopen($_[0], $_[1], $_[2]);
+  };
+}
+
+1;

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -130,10 +130,11 @@ expect_rejected_read() {
   assert_contains "$out" "$expected" "unsafe budget rejection was not specific"
 }
 
-expect_rejected_report() {  # <home> <expected> [mid-measurement swap path]
-  local home=$1 expected=$2 swap=${3:-} out rc
+expect_rejected_report() {  # <home> <expected> [VAR=value ...]
+  local home=$1 expected=$2 out rc
+  shift 2
   set +e
-  out=$(FM_HOME="$home" FM_STARTUP_MEMORY_MEASURE_TEST_SWAP="$swap" "$BUDGET" report 2>&1)
+  out=$(env "$@" FM_HOME="$home" "$BUDGET" report 2>&1)
   rc=$?
   set -e
   expect_code 2 "$rc" "unsafe memory input should fail the accounting command"
@@ -214,10 +215,11 @@ test_budget_accounting_reports_all_three_files_and_safe_failure() {
 
 make_unix_socket() {
   local path=$1 ready=$2
-  perl -MSocket=PF_UNIX,SOCK_STREAM,sockaddr_un -e '
+  perl -MSocket=PF_UNIX,SOCK_STREAM,sockaddr_un -MFile::Basename=basename,dirname -e '
     my ($path, $ready) = @ARGV;
+    chdir(dirname($path)) or die "chdir: $!";
     socket(my $sock, PF_UNIX, SOCK_STREAM, 0) or die "socket: $!";
-    bind($sock, sockaddr_un($path)) or die "bind: $!";
+    bind($sock, sockaddr_un(basename($path))) or die "bind: $!";
     open(my $fh, ">", $ready) or die "ready: $!";
     close($fh) or die "ready close: $!";
     sleep 30;
@@ -289,28 +291,45 @@ test_budget_accounting_rejects_unsafe_memory_targets() {
 }
 
 test_budget_accounting_rejects_targets_replaced_mid_measurement() {
-  local home outside swap out
+  local home race_root outside replacement interpose out
   home="$TMP_ROOT/accounting-race-home"
   mkdir -p "$home/config" "$home/data"
   printf '10\n' > "$home/config/startup-memory-budget"
-  outside="$TMP_ROOT/accounting-race-outside"
-  swap="$TMP_ROOT/accounting-race-swap"
+  race_root=$(fm_test_tmproot fm-startup-memory-budget-race)
+  outside="$race_root/outside"
+  replacement="$race_root/replacement"
+  interpose="PERL5OPT=-I$ROOT/tests/fixtures/fm-startup-memory-budget -MFmStartupMemoryMeasureRace=$race_root,$replacement"
   printf 'outside\n' > "$outside"
   ln -s "$outside" "$home/data/captain.md"
 
-  printf 'replaced\n' > "$swap"
-  expect_rejected_report "$home" 'memory file target changed while being measured' "$swap"
-  [ "$(<"$outside")" = replaced ] || fail "mid-measurement swap did not replace the resolved target"
+  printf 'replaced\n' > "$replacement"
+  expect_rejected_report "$home" 'memory file target changed while being measured' "$interpose"
+  [ "$(<"$outside")" = replaced ] || fail "mid-measurement replacement did not reach the resolved target"
 
-  mkfifo "$swap"
-  expect_rejected_report "$home" 'memory file target changed to a FIFO while being measured' "$swap"
-  [ -p "$outside" ] || fail "mid-measurement swap did not retype the resolved target"
+  mkfifo "$replacement"
+  expect_rejected_report "$home" 'memory file target changed to a FIFO while being measured' "$interpose"
+  [ -p "$outside" ] || fail "mid-measurement replacement did not retype the resolved target"
 
   rm -f "$outside"
   printf 'outside\n' > "$outside"
   out=$(FM_HOME="$home" "$BUDGET" report)
   assert_contains "$out" 'file=data/captain.md bytes=8 estimated_tokens=3 status=present' \
-    "a stable symlink target was not measured once no swap was requested"
+    "a stable symlink target was not measured once nothing interposed"
+
+  printf 'replaced\n' > "$replacement"
+  printf 'unproven\n' > "$TMP_ROOT/accounting-race-unproven"
+  rm -f "$home/data/captain.md"
+  ln -s "$TMP_ROOT/accounting-race-unproven" "$home/data/captain.md"
+  expect_rejected_report "$home" "memory file could not be measured: $home/data/captain.md" "$interpose"
+  [ "$(<"$TMP_ROOT/accounting-race-unproven")" = unproven ] \
+    || fail "interposer replaced a target outside its proven fixture root"
+  [ -f "$replacement" ] || fail "interposer consumed the replacement while refusing"
+
+  rm -f "$home/data/captain.md"
+  ln -s "$outside" "$home/data/captain.md"
+  expect_rejected_report "$home" "memory file could not be measured: $home/data/captain.md" \
+    "PERL5OPT=-I$ROOT/tests/fixtures/fm-startup-memory-budget -MFmStartupMemoryMeasureRace=$home,$replacement"
+  [ "$(<"$outside")" = outside ] || fail "interposer accepted a root without the test-only fixture marker"
   pass "budget accounting rejects targets replaced or retyped between inspection and read"
 }
 

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -130,6 +130,16 @@ expect_rejected_read() {
   assert_contains "$out" "$expected" "unsafe budget rejection was not specific"
 }
 
+expect_rejected_report() {
+  local home=$1 expected=$2 out rc
+  set +e
+  out=$(FM_HOME="$home" "$BUDGET" report 2>&1)
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "unsafe memory input should fail the accounting command"
+  assert_contains "$out" "$expected" "accounting rejection was not specific"
+}
+
 test_safe_parser_rejects_ambiguous_and_unsafe_values() {
   local home outside
   home="$TMP_ROOT/parser-home"
@@ -166,7 +176,7 @@ test_safe_parser_rejects_ambiguous_and_unsafe_values() {
 }
 
 test_budget_accounting_reports_all_three_files_and_safe_failure() {
-  local home out rc outside
+  local home out outside
   home="$TMP_ROOT/accounting-home"
   mkdir -p "$home/config" "$home/data"
   printf '10\n' > "$home/config/startup-memory-budget"
@@ -191,17 +201,91 @@ test_budget_accounting_reports_all_three_files_and_safe_failure() {
 
   outside="$TMP_ROOT/accounting-outside"
   printf 'outside\n' > "$outside"
-  rm -f "$home/data/captain.md"
+  rm -f "$home/data/captain.md" "$home/data/learnings.md"
   ln -s "$outside" "$home/data/captain.md"
-  set +e
-  out=$(FM_HOME="$home" "$BUDGET" report 2>&1)
-  rc=$?
-  set -e
-  expect_code 2 "$rc" "unsafe memory input should fail the accounting command"
-  assert_contains "$out" 'memory file is not an ordinary regular file' \
-    "accounting failure did not identify the unsafe memory file"
-  [ "$(<"$outside")" = outside ] || fail "accounting failure changed a symlink target"
-  pass "budget accounting sums the three startup files and reports safe failures"
+  out=$(FM_HOME="$home" "$BUDGET" report)
+  assert_contains "$out" 'file=data/captain.md bytes=8 estimated_tokens=3 status=present' \
+    "accounting did not measure the resolved symlink target bytes"
+  assert_contains "$out" 'total_estimated_tokens=6' \
+    "accounting did not include the resolved symlink target in the total"
+  [ "$(<"$outside")" = outside ] || fail "accounting changed a symlink target"
+  pass "budget accounting sums regular files, absent files, and valid external symlink targets"
+}
+
+make_unix_socket() {
+  local path=$1 ready=$2
+  perl -MSocket=PF_UNIX,SOCK_STREAM,sockaddr_un -e '
+    my ($path, $ready) = @ARGV;
+    socket(my $sock, PF_UNIX, SOCK_STREAM, 0) or die "socket: $!";
+    bind($sock, sockaddr_un($path)) or die "bind: $!";
+    open(my $fh, ">", $ready) or die "ready: $!";
+    close($fh) or die "ready close: $!";
+    sleep 30;
+  ' "$path" "$ready" &
+  FM_TEST_SOCKET_PID=$!
+}
+
+wait_for_socket_ready() {
+  local ready=$1 attempts=0
+  while [ "$attempts" -lt 10 ]; do
+    [ -e "$ready" ] && return 0
+    sleep 0.1
+    attempts=$((attempts + 1))
+  done
+  return 1
+}
+
+test_budget_accounting_rejects_unsafe_memory_targets() {
+  local home target ready socket_pid
+  home="$TMP_ROOT/accounting-unsafe-home"
+  mkdir -p "$home/config" "$home/data"
+  printf '10\n' > "$home/config/startup-memory-budget"
+
+  ln -s "$TMP_ROOT/missing-memory-target" "$home/data/captain.md"
+  expect_rejected_report "$home" 'memory file symlink target does not exist'
+
+  rm -f "$home/data/captain.md"
+  ln -s captain.md "$home/data/captain.md"
+  expect_rejected_report "$home" 'memory file symlink target could not be resolved'
+
+  rm -f "$home/data/captain.md"
+  target="$TMP_ROOT/accounting-target-dir"
+  mkdir -p "$target"
+  ln -s "$target" "$home/data/captain.md"
+  expect_rejected_report "$home" 'memory file target is a directory'
+
+  rm -f "$home/data/captain.md"
+  target="$TMP_ROOT/accounting-target-fifo"
+  mkfifo "$target"
+  ln -s "$target" "$home/data/captain.md"
+  expect_rejected_report "$home" 'memory file target is a FIFO'
+
+  rm -f "$home/data/captain.md"
+  ln -s /dev/null "$home/data/captain.md"
+  expect_rejected_report "$home" 'memory file target is a character device'
+
+  rm -f "$home/data/captain.md"
+  target="$TMP_ROOT/accounting-target-socket"
+  ready="$TMP_ROOT/accounting-target-socket.ready"
+  make_unix_socket "$target" "$ready" || fail "could not create unix socket fixture"
+  socket_pid=$FM_TEST_SOCKET_PID
+  wait_for_socket_ready "$ready" || fail "unix socket fixture did not become ready"
+  ln -s "$target" "$home/data/captain.md"
+  expect_rejected_report "$home" 'memory file target is a socket'
+  kill "$socket_pid" 2>/dev/null || true
+  wait "$socket_pid" 2>/dev/null || true
+
+  if [ "$(id -u)" != 0 ]; then
+    rm -f "$home/data/captain.md"
+    target="$TMP_ROOT/accounting-target-unreadable"
+    printf 'secret\n' > "$target"
+    chmod 000 "$target"
+    ln -s "$target" "$home/data/captain.md"
+    expect_rejected_report "$home" 'memory file target could not be read'
+    chmod 600 "$target"
+  fi
+
+  pass "budget accounting rejects broken links, loops, directories, FIFOs, devices, sockets, and unreadable targets"
 }
 
 new_propagation_world() {
@@ -328,6 +412,7 @@ test_primary_budget_converges_with_exact_reread_and_safe_failures() {
 test_primary_bootstrap_materializes_visible_default
 test_safe_parser_rejects_ambiguous_and_unsafe_values
 test_budget_accounting_reports_all_three_files_and_safe_failure
+test_budget_accounting_rejects_unsafe_memory_targets
 test_primary_budget_converges_with_exact_reread_and_safe_failures
 
 echo '# all fm-startup-memory-budget tests passed'

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Behavioral coverage for the visible startup-memory budget, its safe parser,
 # accounting command, primary-to-secondmate convergence, and exact reread bytes.
+# Accounting cases cover valid external symlink targets, each unsafe-target
+# rejection class, and a target replaced between inspection and read, which
+# the proof-gated interposer in tests/fixtures/fm-startup-memory-budget/
+# reproduces deterministically.
 set -u
 
 # shellcheck source=tests/lib.sh

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -229,7 +229,7 @@ make_unix_socket() {
 
 wait_for_socket_ready() {
   local ready=$1 attempts=0
-  while [ "$attempts" -lt 10 ]; do
+  while [ "$attempts" -lt 50 ]; do
     [ -e "$ready" ] && return 0
     sleep 0.1
     attempts=$((attempts + 1))

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -251,8 +251,17 @@ test_budget_accounting_rejects_unsafe_memory_targets() {
   expect_rejected_report "$home" 'memory file symlink target does not exist'
 
   rm -f "$home/data/captain.md"
+  ln -s "$TMP_ROOT/missing-memory-dir/captain.md" "$home/data/captain.md"
+  expect_rejected_report "$home" 'memory file symlink target does not exist'
+
+  rm -f "$home/data/captain.md"
+  printf 'not a directory\n' > "$TMP_ROOT/accounting-target-notdir"
+  ln -s "$TMP_ROOT/accounting-target-notdir/captain.md" "$home/data/captain.md"
+  expect_rejected_report "$home" 'memory file symlink target does not exist'
+
+  rm -f "$home/data/captain.md"
   ln -s captain.md "$home/data/captain.md"
-  expect_rejected_report "$home" 'memory file symlink target could not be resolved'
+  expect_rejected_report "$home" 'memory file symlink loop'
 
   rm -f "$home/data/captain.md"
   target="$TMP_ROOT/accounting-target-dir"
@@ -291,7 +300,7 @@ test_budget_accounting_rejects_unsafe_memory_targets() {
     chmod 600 "$target"
   fi
 
-  pass "budget accounting rejects broken links, loops, directories, FIFOs, devices, sockets, and unreadable targets"
+  pass "budget accounting names dangling links, loops, directories, FIFOs, devices, sockets, and unreadable targets apart"
 }
 
 test_budget_accounting_rejects_targets_replaced_mid_measurement() {

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -130,10 +130,10 @@ expect_rejected_read() {
   assert_contains "$out" "$expected" "unsafe budget rejection was not specific"
 }
 
-expect_rejected_report() {
-  local home=$1 expected=$2 out rc
+expect_rejected_report() {  # <home> <expected> [mid-measurement swap path]
+  local home=$1 expected=$2 swap=${3:-} out rc
   set +e
-  out=$(FM_HOME="$home" "$BUDGET" report 2>&1)
+  out=$(FM_HOME="$home" FM_STARTUP_MEMORY_MEASURE_TEST_SWAP="$swap" "$BUDGET" report 2>&1)
   rc=$?
   set -e
   expect_code 2 "$rc" "unsafe memory input should fail the accounting command"
@@ -288,6 +288,57 @@ test_budget_accounting_rejects_unsafe_memory_targets() {
   pass "budget accounting rejects broken links, loops, directories, FIFOs, devices, sockets, and unreadable targets"
 }
 
+test_budget_accounting_rejects_targets_replaced_mid_measurement() {
+  local home outside swap out
+  home="$TMP_ROOT/accounting-race-home"
+  mkdir -p "$home/config" "$home/data"
+  printf '10\n' > "$home/config/startup-memory-budget"
+  outside="$TMP_ROOT/accounting-race-outside"
+  swap="$TMP_ROOT/accounting-race-swap"
+  printf 'outside\n' > "$outside"
+  ln -s "$outside" "$home/data/captain.md"
+
+  printf 'replaced\n' > "$swap"
+  expect_rejected_report "$home" 'memory file target changed while being measured' "$swap"
+  [ "$(<"$outside")" = replaced ] || fail "mid-measurement swap did not replace the resolved target"
+
+  mkfifo "$swap"
+  expect_rejected_report "$home" 'memory file target changed to a FIFO while being measured' "$swap"
+  [ -p "$outside" ] || fail "mid-measurement swap did not retype the resolved target"
+
+  rm -f "$outside"
+  printf 'outside\n' > "$outside"
+  out=$(FM_HOME="$home" "$BUDGET" report)
+  assert_contains "$out" 'file=data/captain.md bytes=8 estimated_tokens=3 status=present' \
+    "a stable symlink target was not measured once no swap was requested"
+  pass "budget accounting rejects targets replaced or retyped between inspection and read"
+}
+
+test_budget_accounting_separates_diagnostics_from_byte_counts() {
+  local home fakebin out rc
+  home="$TMP_ROOT/accounting-diagnostics-home"
+  mkdir -p "$home/config" "$home/data"
+  printf '10\n' > "$home/config/startup-memory-budget"
+  printf 'abc\n' > "$home/data/captain.md"
+
+  out=$(LC_ALL=xx_XX.UTF-8 FM_HOME="$home" "$BUDGET" report 2>/dev/null) \
+    || fail "an unsupported locale broke measurement of a valid memory file"
+  assert_contains "$out" 'file=data/captain.md bytes=4 estimated_tokens=2 status=present' \
+    "locale diagnostics were mixed into the measured byte count"
+
+  fakebin=$(fm_fakebin "$TMP_ROOT/accounting-diagnostics")
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$fakebin/perl"
+  chmod +x "$fakebin/perl"
+  set +e
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$BUDGET" report 2>&1)
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "a silent measurement tool failure should fail the accounting command"
+  assert_contains "$out" "memory file could not be measured: $home/data/captain.md" \
+    "a silent measurement tool failure did not name the memory file"
+  pass "budget accounting keeps diagnostics out of byte counts and names silent measurement failures"
+}
+
 new_propagation_world() {
   local world=$1 root="$1/root" home="$1/home" sm="$1/sm" head
   mkdir -p "$home/config" "$home/data" "$home/state" "$root/bin"
@@ -413,6 +464,8 @@ test_primary_bootstrap_materializes_visible_default
 test_safe_parser_rejects_ambiguous_and_unsafe_values
 test_budget_accounting_reports_all_three_files_and_safe_failure
 test_budget_accounting_rejects_unsafe_memory_targets
+test_budget_accounting_rejects_targets_replaced_mid_measurement
+test_budget_accounting_separates_diagnostics_from_byte_counts
 test_primary_budget_converges_with_exact_reread_and_safe_failures
 
 echo '# all fm-startup-memory-budget tests passed'


### PR DESCRIPTION
## Intent

Fix Firstmate's startup-memory budget accounting so the intentional data/captain.md symlink into the captain's private volkrav-hq store can be measured without weakening the rejection of unsafe or unsupported filesystem objects.

Original defect: bin/fm-startup-memory-budget.sh report rejected data/captain.md as not an ordinary regular file, because this home has it as an intentional symlink to an ordinary regular file outside the Firstmate home.

Requirements:
- Preserve ordinary regular-file behavior and continue refusing broken links, loops, directories, FIFOs, devices, sockets, or any target that cannot be safely proven to be an ordinary readable regular file.
- A valid symlink must be counted from the resolved target contents, including when that target lives outside the Firstmate home as this shared-store setup requires.
- Do not replace the captain's symlink, modify private operational files, weaken path checks globally, or create a second owner for the filesystem acceptance contract.
- Add executable regression coverage for the valid external regular-file symlink and each materially different rejection class, plus any race or identity boundary the existing implementation makes relevant.
- Update the existing authoritative script help or maintained documentation only if the supported behavior is operator-visible and not already correctly described.
- Regression tests must exercise behavior through the public script interface rather than asserting source text.
- Do not manually modify CHANGELOG.md or generated files.
- This is the Firstmate repository: follow firstmate-coding-guidelines for shared tracked material (one sentence per line, plain dash instead of em dash, no agent co-author, shellcheck-clean bin scripts, colocated tests).

Accepted captain decisions from earlier review gates, now in force:
- Remove the production-capable destructive environment-variable fault-injection seam completely. bin/fm-startup-memory-budget-lib.sh must expose no test hook on the production measurement path.
- Redesign the deterministic mid-measurement identity-change test so activation is structurally impossible for real homes or real memory targets: confine any injection to an isolated synthetic fixture under explicit test-only proof, refuse unless all involved paths and identities satisfy that proof, and never expose a production path that can rename over resolved captain data. Keep the mechanism minimal and specific, not a generic injection framework.
- Keep Perl diagnostics separated from byte counts so stderr text can never be counted as file bytes.
- Keep the Unix-socket test fixture path short enough to be portable on macOS and nested test TMPDIRs, and give its readiness poll a bound matching sibling test conventions.

Acceptance criteria:
- The real shared-store shape is supported without copying or replacing data/captain.md.
- Budget reporting produces valid per-file and total estimates for an allowed symlink target.
- Unsupported or unsafe target types are still rejected with concrete diagnostics.
- Changes remain narrowly owned, documented where appropriate, and committed in verifiable units.

Delivery: push the branch to the authorized fork https://github.com/joaodiniz99/firstmate.git over the existing authenticated HTTPS path and open the PR against kunchenguid/firstmate main. Six commits are already preserved on the branch; keep all of them.

## What Changed

- `bin/fm-startup-memory-budget-lib.sh` replaces the `[ -L ] || [ ! -f ]` rejection in `fm_startup_memory_measure_file` with a Perl measurement that resolves symlinks via `realpath`, stats the target, and counts bytes only from an ordinary regular file (including targets outside the Firstmate home); broken links, loops, directories, FIFOs, sockets, character/block devices, and unreadable targets each fail with a concrete diagnostic, the file is opened `O_NONBLOCK` and its type and dev/ino are re-checked on the open descriptor so a target swapped between stat and open is rejected, and diagnostics are kept separate from the byte count.
- `docs/configuration.md` documents that startup-memory files are counted from resolved regular-file targets, even outside the home, and lists the rejected target classes.
- `tests/fm-startup-memory-budget.test.sh` adds accounting coverage for a valid external symlink target, every rejection class (including a live Unix socket fixture with a bounded readiness poll), diagnostics-vs-count separation and silent `perl` failure, and a deterministic mid-measurement replacement race driven by the new proof-gated `sysopen` interposer `tests/fixtures/fm-startup-memory-budget/FmStartupMemoryMeasureRace.pm`, which only activates for paths beneath a marked `tests/lib.sh` fixture root and leaves the production measurement path free of any test hook.

## Risk Assessment

✅ Low: The change is confined to one measurement function plus test-only fixtures; the perl path was traced for regular, symlinked, empty, unreadable, and every special-type target, the sysopen interposer was probed to confirm single-shot arming, lexical filehandle autovivification, and refusal of non-fixture roots, and all intent constraints and prior accepted decisions (no production seam, proof-gated injection, stderr kept out of counts, portable socket path, 5s poll) are satisfied.

## Testing

Ran the focused startup-memory budget suite directly and through bin/fm-test-run.sh (all passing, 5 runs, no flakiness), reproduced the original symlink rejection on the base commit and showed the target commit measuring the external shared-store symlink with correct byte/token/total figures while leaving captain data untouched, captured concrete-diagnostic rejections for every unsafe target class through the public `report` command, verified the removed env seam and a misdirected or forged-marker interposer cannot clobber a real target, and confirmed the new regression tests fail on base bin scripts; overall result is pass with one pre-existing, out-of-scope help-text truncation noted as info.

<details>
<summary>Evidence: report transcript: shared-store symlink before (base) vs after (target)</summary>

Source: [report transcript: shared-store symlink before (base) vs after (target)](https://github.com/joaodiniz99/firstmate/blob/473c7a9d9e4e9630aa88afa2271b64375978a016/.no-mistakes/evidence/fm/stow-captain-symlink-budget-fix/report-symlink-before-after.txt)

<code>## BEFORE FIX (base 1260adc)&#10;$ FM_HOME=home base-bin/fm-startup-memory-budget.sh report&#10;startup-memory-budget: memory file is not an ordinary regular file: &lt;tmp&gt;/home/data/captain.md&#10;exit=2&#10;&#10;## AFTER FIX (target 710e6cd)&#10;$ FM_HOME=home bin/fm-startup-memory-budget.sh report&#10;file=data/captain.md bytes=73 estimated_tokens=25 status=present&#10;file=data/captain-shared.md bytes=0 estimated_tokens=0 status=absent&#10;file=data/learnings.md bytes=10 estimated_tokens=4 status=present&#10;total_estimated_tokens=29&#10;budget_status=within-budget&#10;exit=0&#10;$ wc -c volkrav-hq/firstmate/captain.md -&gt; 73</code>

```text
## Fixture (mirrors the real shared-store shape)
$ ls -l home/data
total 4
lrwxrwxrwx 1 volkrav volkrav 57 Aug 30 19:06 captain.md -> <tmp>/volkrav-hq/firstmate/captain.md
-rw-rw-r-- 1 volkrav volkrav 10 Aug 30 19:06 learnings.md

## BEFORE FIX (base 1260adce77a49ffd5979d8158743d4b0ac40d15d): bin/fm-startup-memory-budget.sh report
$ FM_HOME=home base-bin/fm-startup-memory-budget.sh report
estimator=ceil(UTF-8 bytes / 3) conservative-local-estimate
role=primary
effective_budget_tokens=7500
startup-memory-budget: memory file is not an ordinary regular file: <tmp>/home/data/captain.md
exit=2

## AFTER FIX (target 710e6cd): bin/fm-startup-memory-budget.sh report
$ FM_HOME=home bin/fm-startup-memory-budget.sh report
estimator=ceil(UTF-8 bytes / 3) conservative-local-estimate
role=primary
effective_budget_tokens=7500
file=data/captain.md bytes=73 estimated_tokens=25 status=present
file=data/captain-shared.md bytes=0 estimated_tokens=0 status=absent
file=data/learnings.md bytes=10 estimated_tokens=4 status=present
total_estimated_tokens=29
budget_status=within-budget
exit=0

$ wc -c volkrav-hq/firstmate/captain.md   (expected bytes for the symlink target)
73

## Symlink and target untouched after report
lrwxrwxrwx 1 volkrav volkrav 57 Aug 30 19:06 <tmp>/home/data/captain.md -> <tmp>/volkrav-hq/firstmate/captain.md
# Captain

Shared-store captain memory lives outside the Firstmate home.
```
</details>
<details>
<summary>Evidence: report transcript: every unsafe-target rejection class</summary>

Source: [report transcript: every unsafe-target rejection class](https://github.com/joaodiniz99/firstmate/blob/473c7a9d9e4e9630aa88afa2271b64375978a016/.no-mistakes/evidence/fm/stow-captain-symlink-budget-fix/report-rejections.txt)

<code>broken link -&gt; memory file symlink target does not exist (exit 2)&#10;self loop -&gt; memory file symlink target could not be resolved, possibly due to a loop (exit 2)&#10;directory -&gt; memory file target is a directory, not an ordinary readable regular file (exit 2)&#10;FIFO -&gt; memory file target is a FIFO, not an ordinary readable regular file (exit 2)&#10;/dev/null -&gt; memory file target is a character device, not an ordinary readable regular file (exit 2)&#10;unix socket -&gt; memory file target is a socket, not an ordinary readable regular file (exit 2)&#10;mode-000 file -&gt; memory file target could not be read (exit 2)&#10;valid ext symlink-&gt; bytes=73 estimated_tokens=25 status=present (exit 0)</code>

```text
## Unsafe-target rejections through bin/fm-startup-memory-budget.sh report (target 710e6cd)

$ broken link
  data/captain.md -> <tmp>/targets/missing (absent)
startup-memory-budget: memory file symlink target does not exist: <tmp>/home/data/captain.md
  exit=2

$ self loop
  data/captain.md -> captain.md (loop)
startup-memory-budget: memory file symlink target could not be resolved, possibly due to a loop: <tmp>/home/data/captain.md
  exit=2

$ directory
  data/captain.md -> <tmp>/targets/dir/
startup-memory-budget: memory file target is a directory, not an ordinary readable regular file: <tmp>/home/data/captain.md
  exit=2

$ FIFO
  data/captain.md -> <tmp>/targets/fifo
startup-memory-budget: memory file target is a FIFO, not an ordinary readable regular file: <tmp>/home/data/captain.md
  exit=2

$ character device
  data/captain.md -> /dev/null
startup-memory-budget: memory file target is a character device, not an ordinary readable regular file: <tmp>/home/data/captain.md
  exit=2

$ unix socket
  data/captain.md -> <tmp>/targets/sock
startup-memory-budget: memory file target is a socket, not an ordinary readable regular file: <tmp>/home/data/captain.md
  exit=2

$ unreadable regular file (mode 000)
  data/captain.md -> <tmp>/targets/unreadable
startup-memory-budget: memory file target could not be read: <tmp>/home/data/captain.md
  exit=2

## Control: valid external regular-file symlink still measured
$ valid external symlink
  data/captain.md -> <tmp>/volkrav-hq/firstmate/captain.md
file=data/captain.md bytes=73 estimated_tokens=25 status=present
file=data/captain-shared.md bytes=0 estimated_tokens=0 status=absent
file=data/learnings.md bytes=10 estimated_tokens=4 status=present
total_estimated_tokens=29
budget_status=within-budget
  exit=0
```
</details>
<details>
<summary>Evidence: safety: removed env seam and misdirected interposer cannot replace captain data</summary>

Source: [safety: removed env seam and misdirected interposer cannot replace captain data](https://github.com/joaodiniz99/firstmate/blob/473c7a9d9e4e9630aa88afa2271b64375978a016/.no-mistakes/evidence/fm/stow-captain-symlink-budget-fix/no-production-seam.txt)

<code>FM_STARTUP_MEMORY_MEASURE_TEST_SWAP=&lt;payload&gt; report -&gt; normal success, exit 0 (seam removed)&#10;PERL5OPT interposer with &lt;home&gt; as root -&gt; &#39;FmStartupMemoryMeasureRace: &lt;tmp&gt;/home is not a tests/lib.sh fixture root&#39;, exit 2&#10;forged .fm-test-fixture in home -&gt; &#39;refused target outside fixture root &lt;tmp&gt;/home: &lt;tmp&gt;/volkrav-hq/firstmate/captain.md&#39;, exit 2&#10;Resolved captain target after all attempts: UNCHANGED (cmp OK); swap payload never renamed</code>

```text
## Safety: no production-path fault-injection seam remains (target 710e6cd)

$ FM_STARTUP_MEMORY_MEASURE_TEST_SWAP=<tmp>/swap-payload FM_HOME=home bin/fm-startup-memory-budget.sh report   # removed env seam
estimator=ceil(UTF-8 bytes / 3) conservative-local-estimate
role=primary
effective_budget_tokens=7500
file=data/captain.md bytes=73 estimated_tokens=25 status=present
file=data/captain-shared.md bytes=0 estimated_tokens=0 status=absent
file=data/learnings.md bytes=10 estimated_tokens=4 status=present
total_estimated_tokens=29
budget_status=within-budget
  exit=0

$ PERL5OPT="-I tests/fixtures/... -MFmStartupMemoryMeasureRace=<home>,<tmp>/swap-payload" FM_HOME=home bin/fm-startup-memory-budget.sh report   # interposer pointed at a non-fixture root
estimator=ceil(UTF-8 bytes / 3) conservative-local-estimate
role=primary
effective_budget_tokens=7500
FmStartupMemoryMeasureRace: <tmp>/home is not a tests/lib.sh fixture root
BEGIN failed--compilation aborted.
startup-memory-budget: memory file could not be measured: <tmp>/home/data/captain.md
  exit=2

$ # forged marker: a .fm-test-fixture file inside the home, but target resolves outside that root
estimator=ceil(UTF-8 bytes / 3) conservative-local-estimate
role=primary
effective_budget_tokens=7500
FmStartupMemoryMeasureRace: refused target outside fixture root <tmp>/home: <tmp>/volkrav-hq/firstmate/captain.md
startup-memory-budget: memory file could not be measured: <tmp>/home/data/captain.md
  exit=2

## Resolved captain target after all three attempts (must be byte-identical to original)
  UNCHANGED: cmp OK
  swap payload still in place (never renamed)
```
</details>
<details>
<summary>Evidence: new regression tests fail against base-commit scripts</summary>

Source: [new regression tests fail against base-commit scripts](https://github.com/joaodiniz99/firstmate/blob/473c7a9d9e4e9630aa88afa2271b64375978a016/.no-mistakes/evidence/fm/stow-captain-symlink-budget-fix/regression-fails-on-base.txt)

<code>ok - primary bootstrap materializes only the visible default and preserves valid captain choices&#10;ok - budget parser accepts one exact positive value and rejects malformed or unsafe inputs&#10;startup-memory-budget: memory file is not an ordinary regular file: .../accounting-home/data/captain.md&#10;exit=2</code>

```text
## New regression tests run against the BASE commit's bin scripts (1260adce77a49ffd5979d8158743d4b0ac40d15d) - expected to fail
$ bash tests/fm-startup-memory-budget.test.sh   # tree = target tests + base bin/
ok - primary bootstrap materializes only the visible default and preserves valid captain choices
ok - budget parser accepts one exact positive value and rejects malformed or unsafe inputs
startup-memory-budget: memory file is not an ordinary regular file: /tmp/fm-startup-memory-budget.sXUssV/accounting-home/data/captain.md
exit=2
```
</details>
- Outcome: ⚠️ 1 info across 1 run (3m23s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"710e6cd79e4801d0fff43b512f9a4405fa5b43e2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `tests/fm-startup-memory-budget.test.sh:305` - The interposer is delivered through PERL5OPT, which perl splits on whitespace with no quoting mechanism, so a repo checkout or TMPDIR whose path contains a space breaks the `-I&lt;dir&gt;` / `-M&lt;module&gt;=&lt;root&gt;,&lt;replacement&gt;` switches and the race test fails with a perl switch error (it fails loudly, never silently passes). This matches existing repo assumptions about space-free paths and the accepted &#39;minimal mechanism&#39; decision, so no change is required; noting it in case a future fixture needs to pass paths through PERL5OPT (an env var read by the module would avoid the split).
</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `bin/fm-startup-memory-budget.sh:26` - Pre-existing, not introduced by this change: `usage()` prints header lines 2-11 but the header comment runs through line 12, so `bin/fm-startup-memory-budget.sh --help` cuts off mid-sentence after &#39;...hardlinked, or otherwise&#39; (the closing &#39;unsafe value is a concrete error rather than an inferred default.&#39; is dropped). Verified identical on the base commit. One-character fix (`2,12`) if the author wants it in this branch; out of scope for the test phase.
- <code>`bash tests/fm-startup-memory-budget.test.sh` (7/7 ok; repeated 4 times total, all pass, ~10s each)</code>
- <code>`bin/fm-test-run.sh tests/fm-startup-memory-budget.test.sh` (pass under the runner&#39;s nested worker TMPDIR, exercising the shortened unix-socket fixture path)</code>
- <code>Manual before/after: extracted base-commit `bin/fm-startup-memory-budget{,-lib}.sh` and ran `FM_HOME=&lt;home&gt; ... report` against a home with `data/captain.md -&gt; &lt;tmp&gt;/volkrav-hq/firstmate/captain.md`; base exits 2 with &#39;not an ordinary regular file&#39;, target reports bytes=73 estimated_tokens=25 total=29 within-budget exit 0; target file and symlink unchanged after run</code>
- <code>Manual rejection transcript via target `report`: broken link, self-loop, directory, FIFO, /dev/null, live unix socket, mode-000 regular file - each exit 2 with class-specific diagnostic; valid external symlink control still measured</code>
- <code>Safety check: `FM_STARTUP_MEMORY_MEASURE_TEST_SWAP=&lt;payload&gt; ... report` succeeds normally (seam gone); `PERL5OPT=-MFmStartupMemoryMeasureRace=&lt;home&gt;,&lt;payload&gt;` refused (&#39;not a tests/lib.sh fixture root&#39;); forged `.fm-test-fixture` in home refused (&#39;refused target outside fixture root&#39;); `cmp` confirms captain target byte-identical and payload never renamed</code>
- `Regression proof: ran the target's tests/ against base bin/ in a scratch tree - fails at the symlink accounting case with the original defect message (exit 2)`
- <code>Reviewed `bin/fm-startup-memory-budget.sh --help` and docs/configuration.md lines 218-223 for operator-visible wording (docs updated, one sentence per line, plain dashes)</code>
- <code>Confirmed `git status --porcelain` clean and all /tmp fixtures removed</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
