### PR TITLE
feat: prefer Herdr for crew dispatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,7 @@ The generic effort fallback and its precedence are owned by `harness-adapters`: 
 Do not add model-specific versions of that policy.
 
 `secondmate-provisioning` owns secondmate harness pins and inherited local material, while `harness-adapters` owns the harness consequences.
+For crewmate and scout work, prefer Herdr unless the captain explicitly selects another backend or Herdr cannot launch safely.
 Dispatch only on a backend that `fm-spawn` validates as spawn-capable; pass an explicit per-spawn `--backend` only under that exact task's own authority, never as later-task precedent (selection contract: [`docs/configuration.md`](docs/configuration.md) "Runtime backend").
 A missing dependency, authentication failure, unsupported backend, or version refusal is a blocker; never silently retry on another backend.
 


### PR DESCRIPTION
## Intent

Update this repository’s tracked AGENTS.md with the captain’s global preference to use the Herdr backend for future crewmate and scout work unless the captain explicitly selects another backend or Herdr cannot launch safely. Make the smallest durable instruction change at the backend-dispatch decision point. Preserve all existing per-task authority, backend validation and refusal, recovery, and isolation rules. Do not alter any current worker backend, write local config/backend, or change scripts.

## What Changed

- Prefer Herdr for crewmate and scout dispatch unless the captain selects another backend or Herdr cannot launch safely.
- Preserve existing per-task backend authority, spawn validation, and refusal behavior.

## Risk Assessment

✅ Low: Captain, the single instruction is narrowly placed at the backend-dispatch decision point, matches the required Herdr preference and exceptions, and preserves existing validation, refusal, recovery, isolation, and per-task authority rules.

## Testing

Validated the policy-only commit scope, absence of local backend mutation, and the focused end-to-end backend path covering Herdr detection, explicit captain-style override precedence, spawn-capability validation, and loud refusal of unsupported backends; all checks passed, evidence was captured, and no screenshot was applicable because this change affects a tracked instruction contract rather than a rendered UI.

<details>
<summary>Evidence: Backend selection, override, validation, and refusal transcript</summary>

Source: [Backend selection, override, validation, and refusal transcript](https://github.com/indrasantosa/firstmate/blob/81487d543d641aae166e19ba7e3a35a7f81fa2eb/.no-mistakes/evidence/fm/firstmate-herdr-default-preference/herdr-backend-policy-validation.log)

```text
ok - fm_backend_name: FM_BACKEND env > config/backend > default tmux
ok - fm_backend_detect: no markers -> undetected, HERDR_ENV=1 -> herdr, $TMUX -> tmux, CMUX_WORKSPACE_ID -> cmux, nested combinations resolve innermost-first
ok - fm_backend_detect: falls back to __CFBundleIdentifier=com.cmuxterm.app when CMUX_WORKSPACE_ID is absent (signal bundle-id; foreign bundle ids rejected)
ok - fm_backend_detect: the cmux fallback signals are macOS-only (inert on a non-Darwin uname)
ok - fm_backend_detect: an inherited cmux bundle id never outranks $TMUX or HERDR_ENV (tmux/herdr-inside-cmux false positive absorbed)
ok - fm_backend_detect: ancestry fallback matches the lsappinfo-resolved (bundle-id) cmux app pid in the parent chain
ok - fm_backend_detect: ancestry fallback matches a bundle-shaped cmux comm path at any install location when lsappinfo cannot resolve a pid
ok - fm_backend_detect: ancestry fallback stops undetected at launchd (a reparented tmux server never reaches cmux)
ok - fm_backend_name: a fallback-detected cmux prints a NOTICE naming the fallback signal; the primary-marker notice is unchanged
ok - fm_backend_name: auto-detect selects herdr or cmux (loud notice) or tmux (silent, including nested tmux-in-herdr/tmux-in-cmux)
ok - fm_backend_name: an explicit FM_BACKEND or config/backend setting always wins over runtime auto-detection, including an ambient cmux marker
ok - fm_backend_validate: implemented adapters accepted, unknown and blocked codex-app backends refused loudly
ok - zsh: fm_backend_source recognizes known backends and rejects unknown ones
ok - bash: fm_backend_source recognizes known backends and rejects unknown ones
ok - fm_backend_validate_spawn: all implemented lifecycle backends are spawn-supported
ok - fm_meta_get / fm_backend_of_meta: read key=value, default backend to tmux
ok - fm_backend_resolve_selector: session:window literal, exact task id first, legacy fm-<id> label fallback, ad hoc bare name via tmux list-windows
ok - fm_backend_of_selector: exact task ids, legacy fm-<id> labels, and matching explicit targets inherit metadata backend
ok - fm-send.sh: explicit tmux targets are verified; text types once and submits with Enter
ok - fm-peek.sh: capture-pane invocation and output are byte-identical old vs new
ok - fm-spawn.sh: a project reached through a symlinked prefix (e.g. macOS /tmp -> /private/tmp) does not trip the isolation guard's false refusal
ok - fm-teardown.sh: treehouse return remains compatible while tmux cleanup uses exact selectors
ok - fm-spawn.sh --backend bogus is refused loudly
ok - fm-spawn.sh --backend codex-app is refused
ok - fm-spawn.sh honors FM_BACKEND and refuses an unimplemented value loudly
ok - fm-spawn.sh: an explicit --backend tmux resolves silently and writes no backend= (missing means tmux)
ok - fm-spawn.sh: explicit --backend tmux wins over an ambient HERDR_ENV=1 auto-detect marker
ok - fm-spawn.sh: auto-detect resolves nested tmux-in-herdr to tmux and stays silent end to end
```
</details>
<details>
<summary>Evidence: Exact tracked AGENTS.md preference change</summary>

Source: [Exact tracked AGENTS.md preference change](https://github.com/indrasantosa/firstmate/blob/81487d543d641aae166e19ba7e3a35a7f81fa2eb/.no-mistakes/evidence/fm/firstmate-herdr-default-preference/agents-herdr-preference.patch)

```text
diff --git a/AGENTS.md b/AGENTS.md
index 6622697..103192d 100644
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,7 @@ The generic effort fallback and its precedence are owned by `harness-adapters`:
 Do not add model-specific versions of that policy.
 
 `secondmate-provisioning` owns secondmate harness pins and inherited local material, while `harness-adapters` owns the harness consequences.
+For crewmate and scout work, prefer Herdr unless the captain explicitly selects another backend or Herdr cannot launch safely.
 Dispatch only on a backend that `fm-spawn` validates as spawn-capable; pass an explicit per-spawn `--backend` only under that exact task's own authority, never as later-task precedent (selection contract: [`docs/configuration.md`](docs/configuration.md) "Runtime backend").
 A missing dependency, authentication failure, unsupported backend, or version refusal is a blocker; never silently retry on another backend.
 
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"208ef951ded5f664cee511ab4a403c9c61c5b648","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --name-status 1260adce77a49ffd5979d8158743d4b0ac40d15d..208ef951ded5f664cee511ab4a403c9c61c5b648`
- <code>Confirmed `config/backend` remains absent and no local backend configuration was written</code>
- <code>Inspected `.agents/skills/harness-adapters/SKILL.md` and `references/common/dispatch.md` to verify natural-language selection and executable validation ownership</code>
- `tests/fm-backend.test.sh`
- <code>Captured `git diff --no-ext-diff --unified=3 1260adce77a49ffd5979d8158743d4b0ac40d15d..208ef951ded5f664cee511ab4a403c9c61c5b648 -- AGENTS.md` as reviewer evidence</code>
- <code>`git status --short` and transient-artifact directory check</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
