### PR TITLE
feat(bin): automate cswap account selection at claude dispatch

### DIFF
--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -26,6 +26,10 @@ As defense in depth, `fm_composer_strip_ghost` in `../../../bin/fm-composer-lib.
 `../../../docs/herdr-backend.md` under "Composer and injection safety" owns dark-TRUECOLOR tradeoffs and `../../../docs/verification/runtime-backends.md` owns captures.
 Styled capture stays internal to the boolean detector; `fm-peek` and model-facing captures remain plain, without escapes.
 
+## Account selection (cswap)
+
+When the captain's cswap-managed accounts are present, `../../../bin/fm-cswap-lib.sh` runs at every claude-harness spawn/relaunch boundary and may fire `cswap switch <exact-account>` before the launch command is sent, ranking accounts by remaining headroom plus cswap's own weekly burn-rate-vs-reset projection. It is best-effort and inert when cswap or jq is absent. See that script's header for the full safety contract (busy-task guard, no-op-on-already-active, post-switch verification) and `state/<id>.cswap-select` for per-dispatch evidence.
+
 ## Primary integration
 
 Primary behavior was verified 2026-07-04 on 2.1.201, preserved 2026-07-08 on 2.1.204, and Stop auto-arm revalidated 2026-07-24 on 2.1.219.

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -28,7 +28,7 @@ Styled capture stays internal to the boolean detector; `fm-peek` and model-facin
 
 ## Account selection (cswap)
 
-When the captain's cswap-managed accounts are present, `../../../bin/fm-cswap-lib.sh` runs at every claude-harness spawn/relaunch boundary and may fire `cswap switch <exact-account>` before the launch command is sent, ranking accounts by remaining headroom plus cswap's own weekly burn-rate-vs-reset projection. It is best-effort and inert when cswap or jq is absent. See that script's header for the full safety contract (busy-task guard, no-op-on-already-active, post-switch verification) and `state/<id>.cswap-select` for per-dispatch evidence.
+When the captain opts in with `FM_CSWAP_AUTOSELECT=1`, `../../../bin/fm-cswap-lib.sh` runs at every claude-harness spawn/relaunch boundary and may fire `cswap switch <exact-account>` before the launch command is sent, ranking accounts by remaining headroom plus cswap's own weekly burn-rate-vs-reset projection. The gate is the captain's explicit grant to mutate the shared active credential: unset (the default) leaves the active account untouched and runs no cswap command. It is best-effort and inert when cswap or jq is absent. See that script's header for the full safety contract (busy-task guard, no-op-on-already-active, post-switch verification) and `state/<id>.cswap-select` for per-dispatch evidence.
 
 ## Primary integration
 

--- a/bin/fm-cswap-lib.sh
+++ b/bin/fm-cswap-lib.sh
@@ -17,6 +17,13 @@
 # quota-axi's own spendPriority for any other provider.
 #
 # SAFETY CONTRACT.
+#   - AUTHORIZATION. Selection is scoped to the captain's own cswap-managed
+#     accounts, and only the non-disabled ones: a `disabled` account is the
+#     captain's explicit "hold this out of rotation" signal and is never a
+#     candidate (fm-cswap-select.jq is_eligible). Firing at every claude
+#     dispatch boundary is intentional (AGENTS.md section 4 - this is the one
+#     place cswap economics are decided), bounded by that authorization set
+#     and by the mid-task guards below.
 #   - `cswap switch <exact-number>` only - never a bare rotate, never
 #     `--strategy`, so the target is always the one this library's own
 #     ranking chose and can name in evidence.
@@ -35,7 +42,11 @@
 #     re-confirms the live active number under a per-state-dir lock
 #     (state/.cswap-switch.lock) immediately before calling `cswap switch`,
 #     so two racing spawns can never both fire onto the same freshly-chosen
-#     target.
+#     target. If that re-confirmation shows the live active account has moved
+#     to some OTHER account since the list was read (a concurrent spawn
+#     already switched), the decision was ranked against stale state, so the
+#     switch is skipped (keep-current) rather than executing an obsolete
+#     target over a fresher selection.
 #   - After a switch, re-reads `cswap status --json` and records whether the
 #     active account actually became the intended one; a mismatch is
 #     recorded as verified=false and never reported as a successful switch.
@@ -47,9 +58,21 @@
 # no-op, so the decision remains inspectable after the fact:
 #   {ranAt, decision, chosen, reason, active, switched, verified,
 #    switchExitCode, skippedReason, candidates: [...]}
-# candidates carries every account's read inputs (pct5h/7d, resets, cswap's
-# own expectedPct/aheadOfPace/projectedExhaustionAt/willLastToReset for the
-# 7d window) plus this library's computed headroom/margin/reserve fields.
+# candidates carries every account's read inputs (plan, pct5h/7d, resets,
+# cswap's own expectedPct/aheadOfPace/projectedExhaustionAt/willLastToReset
+# for the 7d window) plus this library's computed headroom/margin/reserve
+# fields.
+#
+# PLAN SIZE. Selection ranks by plan size among the other inputs, but cswap's
+# current `list --json` schema exposes no explicit plan/planSize field (the
+# per-account keys are number/email/organization*/isOrganization/active/
+# usageStatus/usage/usageFetchedAt/usageAgeSeconds only), so `plan` reads
+# null today. That is not a gap: plan size is already folded into cswap's own
+# weekly pace math - a larger plan produces a lower expectedPct pace and a
+# longer projectedExhaustionAt runway, which is exactly the burn-runway-vs-
+# reset figure this library ranks on. `plan` is still extracted and ranked so
+# it is captured verbatim in evidence and takes effect the moment a future
+# cswap build begins reporting it, without a second owner of plan economics.
 #
 # Usage: . bin/fm-cswap-lib.sh
 #   fm_cswap_dispatch_switch <task-id> <state-dir>
@@ -154,6 +177,7 @@ fm_cswap_candidates() {
       disabled: (.disabled // false),
       usageStatus,
       usageAgeSeconds: (.usageAgeSeconds // null),
+      plan: (.plan // .planSize // .planMultiplier // null),
       pct5h: (.usage.fiveHour.pct // null),
       resets5h: (.usage.fiveHour.resetsAt // null),
       pct7d: (.usage.sevenDay.pct // null),
@@ -281,6 +305,13 @@ fm_cswap_dispatch_switch() {
 
   if [ "$now_active" = "$chosen" ]; then
     skipped_reason="already active (confirmed under lock, race with another selection)"
+  elif [ -n "$active" ] && [ -n "$now_active" ] && [ "$now_active" != "$active" ]; then
+    # The live active account moved between the `cswap list` read (active=$active)
+    # this decision was ranked against and this under-lock re-confirmation, so a
+    # concurrent spawn already switched. `chosen` was ranked against now-stale
+    # state; fire-and-forget onto it could clobber a fresher selection, so
+    # fail closed to keep-current rather than execute an obsolete target.
+    skipped_reason="active account changed to $now_active since selection (concurrent switch); decision is stale, keeping current"
   elif fm_cswap_any_other_claude_busy "$state" "$id"; then
     skipped_reason="another claude-harness task is currently busy; switching the shared credential could affect it mid-turn"
   fi

--- a/bin/fm-cswap-lib.sh
+++ b/bin/fm-cswap-lib.sh
@@ -183,7 +183,21 @@ fm_cswap_candidates() {
     [.accounts[] | {
       number, email,
       alias: (.alias // ""),
-      disabled: (.disabled // false),
+      # cswap emits `disabled` ONLY for a slot held out of rotation
+      # (claude_swap/json_output.py: `row["disabled"] = True`); the key is
+      # omitted for an in-rotation account and is never serialized as false or
+      # null. Honor that confirmed contract - an ABSENT key is a positively
+      # in-rotation account (enabled) - but fail CLOSED on any present-but-
+      # ambiguous value: a bare null or a non-false scalar from a partial or
+      # garbled read is treated as disabled, never silently enabled onto the
+      # credential switch. (`.disabled // false` would have read such a null as
+      # enabled.)
+      disabled: (
+        if (has("disabled") | not) then false
+        elif (.disabled == false) then false
+        else true
+        end
+      ),
       usageStatus,
       usageAgeSeconds: (.usageAgeSeconds // null),
       plan: (.plan // .planSize // .planMultiplier // null),

--- a/bin/fm-cswap-lib.sh
+++ b/bin/fm-cswap-lib.sh
@@ -17,13 +17,18 @@
 # quota-axi's own spendPriority for any other provider.
 #
 # SAFETY CONTRACT.
-#   - AUTHORIZATION. Selection is scoped to the captain's own cswap-managed
-#     accounts, and only the non-disabled ones: a `disabled` account is the
-#     captain's explicit "hold this out of rotation" signal and is never a
-#     candidate (fm-cswap-select.jq is_eligible). Firing at every claude
-#     dispatch boundary is intentional (AGENTS.md section 4 - this is the one
-#     place cswap economics are decided), bounded by that authorization set
-#     and by the mid-task guards below.
+#   - AUTHORIZATION. The whole mechanism is opt-in: fm-spawn.sh only calls this
+#     library when the captain has set FM_CSWAP_AUTOSELECT=1, the deliberate
+#     grant that opts a fleet into automated selection. Mutating the shared
+#     active Claude credential is never assumed just because a `cswap` CLI is
+#     installed; with the gate unset no cswap command runs at all. Within that
+#     grant, selection is scoped to the captain's own cswap-managed accounts,
+#     and only the non-disabled ones: a `disabled` account is the captain's
+#     explicit "hold this out of rotation" signal and is never a candidate
+#     (fm-cswap-select.jq is_eligible). Firing at every claude dispatch boundary
+#     is intentional (AGENTS.md section 4 - this is the one place cswap
+#     economics are decided), bounded by that authorization set and by the
+#     mid-task guards below.
 #   - `cswap switch <exact-number>` only - never a bare rotate, never
 #     `--strategy`, so the target is always the one this library's own
 #     ranking chose and can name in evidence.
@@ -46,7 +51,11 @@
 #     to some OTHER account since the list was read (a concurrent spawn
 #     already switched), the decision was ranked against stale state, so the
 #     switch is skipped (keep-current) rather than executing an obsolete
-#     target over a fresher selection.
+#     target over a fresher selection. If the re-confirmation itself fails
+#     (`cswap status --json` cannot report the live active account under the
+#     lock), the switch is likewise skipped fail-closed - an unconfirmable
+#     active account is never assumed to still be the one the decision ranked
+#     against, so a stale target can never be fired on a failed status read.
 #   - After a switch, re-reads `cswap status --json` and records whether the
 #     active account actually became the intended one; a mismatch is
 #     recorded as verified=false and never reported as a successful switch.
@@ -301,16 +310,24 @@ fm_cswap_dispatch_switch() {
 
   status_json=$(fm_cswap_status_json)
   now_active=$(printf '%s' "$status_json" | jq -r '.active.number // empty' 2>/dev/null)
-  [ -n "$now_active" ] || now_active=$active
 
-  if [ "$now_active" = "$chosen" ]; then
+  if [ -z "$now_active" ]; then
+    # `cswap status --json` failed to confirm the live active account under the
+    # lock. The decision was ranked against the pre-lock `cswap list` read; with
+    # no fresh confirmation we cannot rule out that a concurrent spawn moved the
+    # active account since, so firing `chosen` could clobber a fresher
+    # selection. Fail closed to keep-current rather than substitute the stale
+    # pre-lock value (which would silently bypass the changed-account guard).
+    skipped_reason="active account could not be confirmed under lock; decision may be stale, keeping current"
+  elif [ "$now_active" = "$chosen" ]; then
     skipped_reason="already active (confirmed under lock, race with another selection)"
-  elif [ -n "$active" ] && [ -n "$now_active" ] && [ "$now_active" != "$active" ]; then
-    # The live active account moved between the `cswap list` read (active=$active)
-    # this decision was ranked against and this under-lock re-confirmation, so a
-    # concurrent spawn already switched. `chosen` was ranked against now-stale
-    # state; fire-and-forget onto it could clobber a fresher selection, so
-    # fail closed to keep-current rather than execute an obsolete target.
+  elif [ "$now_active" != "$active" ]; then
+    # The live active account differs from the one the `cswap list` read
+    # (active=$active) ranked this decision against - a concurrent spawn already
+    # switched, or the active account was unknown at list time and is now some
+    # other account. Either way `chosen` was ranked against now-stale state;
+    # fire-and-forget onto it could clobber a fresher selection, so fail closed
+    # to keep-current rather than execute an obsolete target.
     skipped_reason="active account changed to $now_active since selection (concurrent switch); decision is stale, keeping current"
   elif fm_cswap_any_other_claude_busy "$state" "$id"; then
     skipped_reason="another claude-harness task is currently busy; switching the shared credential could affect it mid-turn"

--- a/bin/fm-cswap-lib.sh
+++ b/bin/fm-cswap-lib.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# fm-cswap-lib.sh - automated cswap (claude-swap) account selection at a
+# Claude-provider crew/secondmate dispatch boundary.
+#
+# WHY. The captain used to have firstmate manually prefer a fixed cswap slot
+# on every dispatch. This library replaces that fixed-slot habit with a
+# per-dispatch decision over the captain's own cswap-managed accounts,
+# ranked by remaining 5h/7d headroom AND cswap's own weekly burn-rate-vs-
+# reset projection (bin/fm-cswap-select.jq owns the ranking; this file owns
+# I/O, safety guards, and evidence).
+#
+# ONE OWNER. quota-axi's spendPriority does not cover this: it models only
+# the single currently-active OS-level Claude credential (see
+# data/learnings.md), never a list of cswap-managed accounts, so it cannot
+# rank candidates it has no visibility into. This library is therefore the
+# one place that computes cswap account economics; it does not reimplement
+# quota-axi's own spendPriority for any other provider.
+#
+# SAFETY CONTRACT.
+#   - `cswap switch <exact-number>` only - never a bare rotate, never
+#     `--strategy`, so the target is always the one this library's own
+#     ranking chose and can name in evidence.
+#   - Fires only once, at the moment a NEW claude-harness agent is about to
+#     be launched (bin/fm-spawn.sh, right before the launch command is sent
+#     into the pane), never on a timer and never mid-task.
+#   - Skips the switch entirely (fail-closed to "keep current", never a
+#     silent guess) when: cswap or jq is unavailable, `cswap list --json`
+#     fails or does not parse, any candidate's usage is stale past
+#     FM_CSWAP_MAX_USAGE_AGE_S, or another claude-harness task recorded in
+#     the same state directory is currently classified busy (mid-turn) -
+#     switching the shared global credential out from under a live worker
+#     is exactly what this guard exists to prevent.
+#   - Never fires a switch onto the account already active: the decision
+#     function itself treats that as "keep-current", and the caller
+#     re-confirms the live active number under a per-state-dir lock
+#     (state/.cswap-switch.lock) immediately before calling `cswap switch`,
+#     so two racing spawns can never both fire onto the same freshly-chosen
+#     target.
+#   - After a switch, re-reads `cswap status --json` and records whether the
+#     active account actually became the intended one; a mismatch is
+#     recorded as verified=false and never reported as a successful switch.
+#   - Never aborts or blocks the spawn: every failure mode above is
+#     recorded to the evidence sidecar and the caller proceeds with
+#     whatever account is currently active.
+#
+# EVIDENCE. Every run writes state/<task-id>.cswap-select (JSON), even a
+# no-op, so the decision remains inspectable after the fact:
+#   {ranAt, decision, chosen, reason, active, switched, verified,
+#    switchExitCode, skippedReason, candidates: [...]}
+# candidates carries every account's read inputs (pct5h/7d, resets, cswap's
+# own expectedPct/aheadOfPace/projectedExhaustionAt/willLastToReset for the
+# 7d window) plus this library's computed headroom/margin/reserve fields.
+#
+# Usage: . bin/fm-cswap-lib.sh
+#   fm_cswap_dispatch_switch <task-id> <state-dir>
+set -u
+
+FM_CSWAP_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-timeout-lib.sh disable=SC1091
+. "$FM_CSWAP_LIB_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-backend.sh disable=SC1091
+. "$FM_CSWAP_LIB_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-busy-lib.sh disable=SC1091
+. "$FM_CSWAP_LIB_DIR/fm-busy-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh disable=SC1091
+. "$FM_CSWAP_LIB_DIR/fm-wake-lib.sh"
+
+# Accounts refresh on their own poll cadence (cswap's README: "a couple of
+# minutes"); 30 minutes is well past any healthy poll interval, so evidence
+# older than this is treated as unmeasurable rather than trusted.
+FM_CSWAP_MAX_USAGE_AGE_S=${FM_CSWAP_MAX_USAGE_AGE_S:-1800}
+FM_CSWAP_CMD_TIMEOUT_S=${FM_CSWAP_CMD_TIMEOUT_S:-10}
+
+fm_cswap_available() {
+  command -v cswap >/dev/null 2>&1
+}
+
+fm_cswap_jq_available() {
+  command -v jq >/dev/null 2>&1
+}
+
+# fm_cswap_iso_to_epoch <iso8601>: epoch seconds, or return 1 on failure.
+# cswap emits both "…SS.ffffff+00:00" (resetsAt) and "…SSZ" (projected*At)
+# shapes (data/learnings.md); BSD `date -j -f` needs an exact format, so
+# fractional seconds are stripped and a numeric +00:00 offset is normalized
+# to Z before that attempt, while the GNU `date -d` fallback parses the
+# original string directly (it accepts both shapes natively).
+fm_cswap_iso_to_epoch() {
+  local ts=$1 stripped
+  [ -n "$ts" ] || return 1
+  stripped=$(printf '%s' "$ts" | sed -E 's/\.[0-9]+//; s/\+00:00$/Z/')
+  date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$stripped" +%s 2>/dev/null \
+    || date -u -d "$ts" +%s 2>/dev/null \
+    || return 1
+}
+
+fm_cswap_now_epoch() {
+  date -u +%s
+}
+
+# fm_cswap_list_json: bounded `cswap list --json` on stdout; empty stdout
+# means the call failed or timed out (a successful call always emits at
+# least schemaVersion), which is what the caller checks.
+fm_cswap_list_json() {
+  fm_run_timed "$FM_CSWAP_CMD_TIMEOUT_S" cswap list --json 2>/dev/null
+}
+
+# fm_cswap_status_json: bounded `cswap status --json` on stdout.
+fm_cswap_status_json() {
+  fm_run_timed "$FM_CSWAP_CMD_TIMEOUT_S" cswap status --json 2>/dev/null
+}
+
+# fm_cswap_augment_epochs: reads normalized account rows (as produced by the
+# jq extraction in fm_cswap_candidates) on stdin, adds *Epoch fields for
+# every ISO timestamp via fm_cswap_iso_to_epoch (never jq's fromdateiso8601 -
+# see fm_cswap_iso_to_epoch), and prints the augmented array. A timestamp
+# that fails to parse becomes null rather than aborting the whole read, so
+# one account's malformed evidence cannot hide every other account's.
+fm_cswap_augment_epochs() {
+  local rows count i row resets5h resets7d proj7d \
+    resets5h_epoch resets7d_epoch proj7d_epoch out
+  rows=$(cat)
+  count=$(printf '%s' "$rows" | jq 'length') || return 1
+  out='[]'
+  i=0
+  while [ "$i" -lt "$count" ]; do
+    row=$(printf '%s' "$rows" | jq -c ".[$i]")
+    resets5h=$(printf '%s' "$row" | jq -r '.resets5h // empty')
+    resets7d=$(printf '%s' "$row" | jq -r '.resets7d // empty')
+    proj7d=$(printf '%s' "$row" | jq -r '.projectedExhaustionAt7d // empty')
+    resets5h_epoch=$(fm_cswap_iso_to_epoch "$resets5h" || true)
+    resets7d_epoch=$(fm_cswap_iso_to_epoch "$resets7d" || true)
+    proj7d_epoch=$(fm_cswap_iso_to_epoch "$proj7d" || true)
+    row=$(printf '%s' "$row" | jq -c \
+      --argjson r5 "${resets5h_epoch:-null}" \
+      --argjson r7 "${resets7d_epoch:-null}" \
+      --argjson p7 "${proj7d_epoch:-null}" \
+      '. + {resets5hEpoch: $r5, resets7dEpoch: $r7, projectedExhaustionAt7dEpoch: $p7}')
+    out=$(printf '%s' "$out" | jq -c --argjson row "$row" '. + [$row]')
+    i=$((i + 1))
+  done
+  printf '%s\n' "$out"
+}
+
+# fm_cswap_candidates: normalizes raw `cswap list --json` into the row shape
+# fm_cswap_augment_epochs and fm-cswap-select.jq expect. Returns 1 on
+# unparseable input.
+fm_cswap_candidates() {
+  local raw=$1
+  printf '%s' "$raw" | jq -c '
+    [.accounts[] | {
+      number, email,
+      alias: (.alias // ""),
+      disabled: (.disabled // false),
+      usageStatus,
+      usageAgeSeconds: (.usageAgeSeconds // null),
+      pct5h: (.usage.fiveHour.pct // null),
+      resets5h: (.usage.fiveHour.resetsAt // null),
+      pct7d: (.usage.sevenDay.pct // null),
+      resets7d: (.usage.sevenDay.resetsAt // null),
+      expectedPct7d: (.usage.sevenDay.expectedPct // null),
+      aheadOfPace7d: (.usage.sevenDay.aheadOfPace // null),
+      projectedExhaustionAt7d: (.usage.sevenDay.projectedExhaustionAt // null),
+      willLastToReset7d: (.usage.sevenDay.willLastToReset // null)
+    }]
+  ' 2>/dev/null
+}
+
+# fm_cswap_decide <candidates-json> <active-number-or-null>: runs the pure
+# selection function and prints its decision JSON.
+fm_cswap_decide() {
+  local candidates=$1 active=$2 now
+  now=$(fm_cswap_now_epoch)
+  printf '%s' "$candidates" | jq -c \
+    --argjson now "$now" \
+    --argjson active "${active:-null}" \
+    --argjson maxAgeS "$FM_CSWAP_MAX_USAGE_AGE_S" \
+    -f "$FM_CSWAP_LIB_DIR/fm-cswap-select.jq" 2>/dev/null
+}
+
+# fm_cswap_any_other_claude_busy <state-dir> <exclude-id>: 0 (true) iff a
+# task other than <exclude-id> whose recorded harness matches claude* is
+# currently classified busy. Requires fm-backend.sh and fm-busy-lib.sh
+# (sourced above). Never treats a read failure as "not busy" for a task
+# whose meta genuinely exists and names a claude harness - an unclassifiable
+# record is unknown, not idle, per fm-busy-lib.sh, so it does not trip this
+# guard, matching that library's own "never fabricate idle" contract.
+fm_cswap_any_other_claude_busy() {
+  local state=$1 exclude=$2 meta id harness verdict
+  [ -d "$state" ] || return 1
+  for meta in "$state"/*.meta; do
+    [ -f "$meta" ] || continue
+    id=$(basename "$meta" .meta)
+    [ "$id" = "$exclude" ] && continue
+    harness=$(fm_meta_get "$meta" harness)
+    case "$harness" in claude*) ;; *) continue ;; esac
+    verdict=$(fm_busy_classify_meta "$meta" "$id" "$state" 2>/dev/null) || continue
+    if [ "${verdict%% *}" = busy ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# fm_cswap_write_evidence <path> <json>: atomic temp+rename write. Best
+# effort - a write failure is not fatal to the caller, it just means this
+# run's evidence is unavailable for later inspection.
+fm_cswap_write_evidence() {
+  local path=$1 json=$2 tmp
+  tmp="$path.tmp.$$"
+  if printf '%s\n' "$json" > "$tmp" 2>/dev/null; then
+    mv -f "$tmp" "$path" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+  fi
+}
+
+# fm_cswap_dispatch_switch <task-id> <state-dir>: the one entry point.
+# Always returns 0; every outcome (including every guard skip and every
+# failure) is recorded to state/<task-id>.cswap-select rather than raised to
+# the caller, so a flaky or absent cswap can never block a crew dispatch.
+fm_cswap_dispatch_switch() {
+  local id=$1 state=$2
+  local evidence="$state/$id.cswap-select"
+  local switch_lock="$state/.cswap-switch.lock"
+  local lock_held=0 raw candidates active decision chosen
+  local switched=false verified=false switch_rc="" skipped_reason=""
+  local status_json now_active
+
+  if ! fm_cswap_available; then
+    return 0
+  fi
+  if ! fm_cswap_jq_available; then
+    fm_cswap_write_evidence "$evidence" \
+      '{"decision":"keep-current","chosen":null,"reason":"jq unavailable; cswap evidence cannot be parsed","switched":false,"verified":false}'
+    return 0
+  fi
+
+  raw=$(fm_cswap_list_json)
+  if [ -z "$raw" ]; then
+    fm_cswap_write_evidence "$evidence" \
+      '{"decision":"keep-current","chosen":null,"reason":"cswap list --json failed or timed out","switched":false,"verified":false}'
+    return 0
+  fi
+  active=$(printf '%s' "$raw" | jq -r '.activeAccountNumber // empty' 2>/dev/null)
+  candidates=$(fm_cswap_candidates "$raw") || candidates=""
+  if [ -z "$candidates" ]; then
+    fm_cswap_write_evidence "$evidence" \
+      '{"decision":"keep-current","chosen":null,"reason":"cswap list --json did not parse","switched":false,"verified":false}'
+    return 0
+  fi
+  candidates=$(printf '%s' "$candidates" | fm_cswap_augment_epochs) || {
+    fm_cswap_write_evidence "$evidence" \
+      '{"decision":"keep-current","chosen":null,"reason":"cswap account timestamps could not be parsed","switched":false,"verified":false}'
+    return 0
+  }
+
+  decision=$(fm_cswap_decide "$candidates" "$active")
+  if [ -z "$decision" ]; then
+    fm_cswap_write_evidence "$evidence" \
+      '{"decision":"keep-current","chosen":null,"reason":"selection could not be evaluated","switched":false,"verified":false}'
+    return 0
+  fi
+  chosen=$(printf '%s' "$decision" | jq -r '.chosen // empty')
+
+  if [ "$(printf '%s' "$decision" | jq -r '.decision')" != switch ] || [ -z "$chosen" ]; then
+    fm_cswap_write_evidence "$evidence" "$(printf '%s' "$decision" | jq -c \
+      --argjson active "${active:-null}" \
+      '. + {ranAt: (now | floor), active: $active, switched: false, verified: false}')"
+    return 0
+  fi
+
+  # Serialize the read-decide-switch-verify sequence so two racing spawns can
+  # never both fire onto the same freshly-chosen target (the burst/thrash
+  # guard: a switch is only ever fired while holding this lock, and only
+  # after re-confirming the live active account under it).
+  fm_lock_acquire_wait "$switch_lock"
+  lock_held=1
+
+  status_json=$(fm_cswap_status_json)
+  now_active=$(printf '%s' "$status_json" | jq -r '.active.number // empty' 2>/dev/null)
+  [ -n "$now_active" ] || now_active=$active
+
+  if [ "$now_active" = "$chosen" ]; then
+    skipped_reason="already active (confirmed under lock, race with another selection)"
+  elif fm_cswap_any_other_claude_busy "$state" "$id"; then
+    skipped_reason="another claude-harness task is currently busy; switching the shared credential could affect it mid-turn"
+  fi
+
+  if [ -z "$skipped_reason" ]; then
+    fm_run_timed "$FM_CSWAP_CMD_TIMEOUT_S" cswap switch "$chosen" >/dev/null 2>&1
+    switch_rc=$?
+    status_json=$(fm_cswap_status_json)
+    now_active=$(printf '%s' "$status_json" | jq -r '.active.number // empty' 2>/dev/null)
+    switched=true
+    [ "$now_active" = "$chosen" ] && verified=true
+  fi
+
+  [ "$lock_held" -eq 0 ] || fm_lock_release "$switch_lock" 2>/dev/null || true
+
+  fm_cswap_write_evidence "$evidence" "$(printf '%s' "$decision" | jq -c \
+    --argjson active "${active:-null}" \
+    --arg skipped "$skipped_reason" \
+    --argjson switched "$switched" \
+    --argjson verified "$verified" \
+    --arg switchRc "${switch_rc:-}" \
+    --arg confirmedActive "${now_active:-}" \
+    '. + {
+       ranAt: (now | floor),
+       active: $active,
+       switched: $switched,
+       verified: $verified,
+       switchExitCode: ($switchRc | if . == "" then null else tonumber end),
+       confirmedActiveAfter: (if $confirmedActive == "" then null else $confirmedActive end),
+       skippedReason: (if $skipped == "" then null else $skipped end)
+     }')"
+  return 0
+}

--- a/bin/fm-cswap-select.jq
+++ b/bin/fm-cswap-select.jq
@@ -1,0 +1,126 @@
+# fm-cswap-select.jq - the pure cswap account-selection decision function.
+#
+# Sourced by bin/fm-cswap-lib.sh via `jq -f`, never invoked standalone in
+# production, but stable enough to unit-test directly with fixture JSON
+# (tests/fm-cswap-select.test.sh).
+#
+# Input (stdin): a JSON array of per-account rows, one per cswap-managed
+# account, already epoch-normalized by fm_cswap_augment_epochs (raw ISO8601
+# strings cannot reach here - jq's fromdateiso8601 does not accept cswap's
+# fractional-second/offset timestamps). Each row:
+#   {number, email, alias, disabled, usageStatus, usageAgeSeconds,
+#    pct5h, resets5hEpoch, pct7d, resets7dEpoch,
+#    expectedPct7d, aheadOfPace7d, willLastToReset7d, projectedExhaustionAt7dEpoch}
+# Numeric/boolean fields are null when cswap did not report them.
+#
+# --argjson now        current epoch seconds
+# --argjson active     the currently active account number, or null
+# --argjson maxAgeS     usage freshness floor in seconds; an older
+#                       usageAgeSeconds makes that candidate ineligible
+#                       (fail-closed on stale evidence, never a fabricated
+#                       guess)
+#
+# Output: one JSON object -
+#   {decision: "switch"|"keep-current", chosen: <number-or-null>,
+#    reason: "<human-readable>", candidates: [<row + computed fields>]}
+#
+# Decision method:
+#  1. A candidate is eligible only when enabled, usageStatus is "ok", both
+#     the 5h and 7d windows report a numeric pct under 100, and the usage
+#     measurement is not older than $maxAgeS. A missing resets timestamp on
+#     a window is NOT disqualifying by itself - cswap omits resetsAt for a
+#     window nothing has consumed yet (a genuinely untouched account has no
+#     open window to report), and neither reset epoch is read anywhere but
+#     the 7d margin computation below, which already treats a missing
+#     projection as the safest case. Any other case (disabled, error status,
+#     absent or out-of-range pct, or stale usage) is disclosed uncertainty,
+#     not a guess, so the row is excluded rather than ranked.
+#  2. margin7d is cswap's own weekly burn-rate-vs-reset projection
+#     (projectedExhaustionAt7dEpoch - resets7dEpoch): positive means the
+#     account is projected to exhaust AFTER its own reset (safe, and larger
+#     is a bigger buffer); negative means it will run dry BEFORE reset (the
+#     exact "burn runway vs reset time" figure this selection exists for).
+#     null means cswap projected no burn at all (idle/flat account - treated
+#     as the safest tier, never a fabricated infinite number).
+#  3. Eligible accounts split into "safe" (willLastToReset7d true, or no
+#     projection at all) and the rest; safe accounts are preferred as a
+#     group over at-risk ones whenever at least one safe account exists.
+#  4. Within a tier, rank by margin7d (bigger buffer wins), then remaining
+#     7d headroom, then remaining 5h headroom, then - the deliberate
+#     tie-break - the currently active account, then account number for a
+#     fully deterministic order. Ranking the active account ahead of an
+#     otherwise-tied peer is what keeps a genuine tie on the current
+#     account rather than churning to an arbitrary equally-good one.
+#  5. No eligible candidate at all keeps the current account (fail-closed);
+#     this function never chooses a switch on absent or stale evidence.
+
+def is_eligible:
+  (.disabled | not)
+  and (.usageStatus == "ok")
+  and (.pct5h != null) and (.pct7d != null)
+  and (.pct5h < 100) and (.pct7d < 100)
+  and ((.usageAgeSeconds == null) or (.usageAgeSeconds <= $maxAgeS));
+
+def margin7d_of:
+  if .projectedExhaustionAt7dEpoch == null then null
+  else .projectedExhaustionAt7dEpoch - .resets7dEpoch
+  end;
+
+def reserve7d_of:
+  if .expectedPct7d == null then null else (.expectedPct7d - .pct7d) end;
+
+def is_safe7d:
+  (.willLastToReset7d == true) or (.projectedExhaustionAt7dEpoch == null);
+
+def fmt_days($seconds):
+  if $seconds == null then "unknown"
+  else (($seconds / 86400) * 100 | round | . / 100 | tostring) + "d"
+  end;
+
+map(
+  . + {
+    eligible: is_eligible,
+    headroom5h: (if .pct5h == null then null else (100 - .pct5h) end),
+    headroom7d: (if .pct7d == null then null else (100 - .pct7d) end),
+    margin7dSeconds: margin7d_of,
+    reserve7dPct: reserve7d_of,
+    safe7d: is_safe7d
+  }
+) as $rows
+| ($rows | map(select(.eligible))) as $eligible
+| if ($eligible | length) == 0 then
+    {
+      decision: "keep-current",
+      chosen: null,
+      reason: "no eligible cswap account (all disabled, errored, unmeasurable, or usage older than \($maxAgeS)s)",
+      candidates: $rows
+    }
+  else
+    ($eligible | map(select(.safe7d))) as $safeRows
+    | (if ($safeRows | length) > 0 then $safeRows else $eligible end) as $pool
+    | (
+        $pool | sort_by([
+          -(.margin7dSeconds // 999999999999),
+          -(.headroom7d // 0),
+          -(.headroom5h // 0),
+          (if .number == $active then 0 else 1 end),
+          .number
+        ])
+      ) as $ranked
+    | ($ranked[0]) as $best
+    | if $best.number == $active then
+        {
+          decision: "keep-current",
+          chosen: $active,
+          reason: "active account \($active) is already the best eligible candidate (margin7d=\(fmt_days($best.margin7dSeconds)), headroom7d=\($best.headroom7d)%)",
+          candidates: $rows
+        }
+      else
+        {
+          decision: "switch",
+          chosen: $best.number,
+          reason: "account \($best.number) has margin7d=\(fmt_days($best.margin7dSeconds)) headroom7d=\($best.headroom7d)% headroom5h=\($best.headroom5h)% vs active account \(($active // "none"))",
+          candidates: $rows
+        }
+      end
+  end

--- a/bin/fm-cswap-select.jq
+++ b/bin/fm-cswap-select.jq
@@ -8,10 +8,17 @@
 # account, already epoch-normalized by fm_cswap_augment_epochs (raw ISO8601
 # strings cannot reach here - jq's fromdateiso8601 does not accept cswap's
 # fractional-second/offset timestamps). Each row:
-#   {number, email, alias, disabled, usageStatus, usageAgeSeconds,
+#   {number, email, alias, disabled, usageStatus, usageAgeSeconds, plan,
 #    pct5h, resets5hEpoch, pct7d, resets7dEpoch,
 #    expectedPct7d, aheadOfPace7d, willLastToReset7d, projectedExhaustionAt7dEpoch}
-# Numeric/boolean fields are null when cswap did not report them.
+# Numeric/boolean fields are null when cswap did not report them. `plan` is
+# the account's plan-size multiplier when cswap exposes one; cswap's current
+# `list --json` schema carries no explicit plan field (it is null in
+# practice), because plan size is already folded into cswap's own weekly
+# pace math (expectedPct7d / projectedExhaustionAt7d / willLastToReset7d) -
+# a bigger plan yields a lower expected-pace and a longer projected runway.
+# It is still read and ranked so the figure is captured verbatim in evidence
+# and takes effect immediately if a future cswap build reports it.
 #
 # --argjson now        current epoch seconds
 # --argjson active     the currently active account number, or null
@@ -45,10 +52,12 @@
 #  3. Eligible accounts split into "safe" (willLastToReset7d true, or no
 #     projection at all) and the rest; safe accounts are preferred as a
 #     group over at-risk ones whenever at least one safe account exists.
-#  4. Within a tier, rank by margin7d (bigger buffer wins), then remaining
-#     7d headroom, then remaining 5h headroom, then - the deliberate
-#     tie-break - the currently active account, then account number for a
-#     fully deterministic order. Ranking the active account ahead of an
+#  4. Within a tier, rank by margin7d (bigger buffer wins), then plan size
+#     (a larger plan has more absolute capacity; null plans compare equal so
+#     the current cswap schema is unaffected), then remaining 7d headroom,
+#     then remaining 5h headroom, then - the deliberate tie-break - the
+#     currently active account, then account number for a fully
+#     deterministic order. Ranking the active account ahead of an
 #     otherwise-tied peer is what keeps a genuine tie on the current
 #     account rather than churning to an arbitrary equally-good one.
 #  5. No eligible candidate at all keeps the current account (fail-closed);
@@ -103,6 +112,7 @@ map(
     | (
         $pool | sort_by([
           -(.margin7dSeconds // 999999999999),
+          -(.plan // 0),
           -(.headroom7d // 0),
           -(.headroom5h // 0),
           (if .number == $active then 0 else 1 end),

--- a/bin/fm-cswap-select.jq
+++ b/bin/fm-cswap-select.jq
@@ -64,7 +64,14 @@
 #     this function never chooses a switch on absent or stale evidence.
 
 def is_eligible:
-  (.disabled | not)
+  # Fail CLOSED on authorization: a candidate is eligible only when its
+  # disabled state is EXPLICITLY the boolean false (positively in-rotation).
+  # fm_cswap_augment_epochs/fm_cswap_candidates already normalize cswap's
+  # omit-when-enabled contract to a concrete boolean, so `== false` here means
+  # a null or otherwise-unconfirmed disabled state can never slip through as
+  # enabled and reach `cswap switch` (`.disabled | not` would have let a null
+  # pass as eligible).
+  (.disabled == false)
   and (.usageStatus == "ok")
   and (.pct5h != null) and (.pct7d != null)
   and (.pct5h < 100) and (.pct7d < 100)

--- a/bin/fm-cswap-select.jq
+++ b/bin/fm-cswap-select.jq
@@ -62,12 +62,14 @@ def is_eligible:
   and ((.usageAgeSeconds == null) or (.usageAgeSeconds <= $maxAgeS));
 
 def margin7d_of:
-  if .projectedExhaustionAt7dEpoch == null then null
+  if (.projectedExhaustionAt7dEpoch == null) or (.resets7dEpoch == null) then null
   else .projectedExhaustionAt7dEpoch - .resets7dEpoch
   end;
 
 def reserve7d_of:
-  if .expectedPct7d == null then null else (.expectedPct7d - .pct7d) end;
+  if (.expectedPct7d == null) or (.pct7d == null) then null
+  else (.expectedPct7d - .pct7d)
+  end;
 
 def is_safe7d:
   (.willLastToReset7d == true) or (.projectedExhaustionAt7dEpoch == null);

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -295,6 +295,8 @@ fm_backlog_directory_present "$STATE" "state directory" || {
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 # shellcheck source=bin/fm-busy-lib.sh
 . "$SCRIPT_DIR/fm-busy-lib.sh"
+# shellcheck source=bin/fm-cswap-lib.sh
+. "$SCRIPT_DIR/fm-cswap-lib.sh"
 # shellcheck source=bin/fm-cursor-lib.sh
 . "$SCRIPT_DIR/fm-cursor-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
@@ -2984,6 +2986,14 @@ esac
 # an unset value is the single-store default and needs no prefix.
 if [ "$HARNESS" = claude ] && [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
   LAUNCH="CLAUDE_CONFIG_DIR=$(shell_quote "$CLAUDE_CONFIG_DIR") $LAUNCH"
+fi
+# Automated cswap account selection (AGENTS.md section 4 dispatch boundary):
+# a genuinely safe task boundary, right before this new claude-harness agent's
+# launch command is sent, never mid-task. Best effort only - see
+# bin/fm-cswap-lib.sh for the full safety contract; a flaky or absent cswap
+# never blocks this spawn.
+if [ "$HARNESS" = claude ]; then
+  fm_cswap_dispatch_switch "$ID" "$STATE" || true
 fi
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2992,7 +2992,15 @@ fi
 # launch command is sent, never mid-task. Best effort only - see
 # bin/fm-cswap-lib.sh for the full safety contract; a flaky or absent cswap
 # never blocks this spawn.
-if [ "$HARNESS" = claude ]; then
+#
+# Gated behind an explicit captain enablement (FM_CSWAP_AUTOSELECT=1). Mutating
+# the shared active Claude credential is autonomy the captain grants
+# deliberately, not something firstmate assumes just because a `cswap` CLI
+# happens to be installed on the host: with the gate unset (the default) the
+# active account is left exactly as the captain last set it, and no cswap
+# command is ever run. Setting FM_CSWAP_AUTOSELECT=1 is the recorded grant that
+# opts this fleet's dispatch boundary into automated per-account selection.
+if [ "$HARNESS" = claude ] && [ "${FM_CSWAP_AUTOSELECT:-0}" = 1 ]; then
   fm_cswap_dispatch_switch "$ID" "$STATE" || true
 fi
 if [ "$KIND" = secondmate ]; then

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -244,14 +244,22 @@ fm_test_spawn_brief() {
 }
 
 # fm_test_make_spawn_fakebin <dir> [extra-exit0-tool...]
-# Creates <dir>/fakebin with the spawn tmux stub, a no-op treehouse, and any
-# extra exit-0 tools. Echoes the fakebin path.
+# Creates <dir>/fakebin with the spawn tmux stub, a no-op treehouse, a no-op
+# cswap, and any extra exit-0 tools. Echoes the fakebin path.
+#
+# cswap is stubbed exit-0-with-no-output here (never a real invocation)
+# because fm_test_run_spawn's PATH keeps the real PATH after the fakebin
+# (PATH="$fakebin:$PATH"), so a developer machine with the real cswap CLI
+# installed would otherwise let a claude-harness spawn test reach it for
+# real - bin/fm-cswap-lib.sh's own no-op-on-empty-output handling then makes
+# every spawn test exercise the same absent/unavailable-cswap path
+# deterministically, never a live account's real state.
 fm_test_make_spawn_fakebin() {
   local dir=$1 fakebin
   shift
   fakebin=$(fm_fakebin "$dir")
   fm_test_fake_tmux_spawn "$fakebin"
-  fm_fake_exit0 "$fakebin" treehouse "$@"
+  fm_fake_exit0 "$fakebin" treehouse cswap "$@"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-cswap-lib.test.sh
+++ b/tests/fm-cswap-lib.test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-cswap-lib.sh's dispatch-time cswap account
+# selection: the busy-worker guard, the no-op-on-already-active guard, post-
+# switch verification, evidence recording, and the fail-open-on-absent-tool
+# path. Hermetic - a fake `cswap` stub on PATH stands in for the real CLI; no
+# real account is ever touched.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-cswap-lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-cswap-lib)
+
+# fm_fake_cswap <fakebin> <active-marker> <switch-log>: a stub that serves
+# `list --json` / `status --json` from a two-account fixture (5x-account 1 at
+# risk, 20x-account 2 safe - the same shape as the captain's scenario) whose
+# CURRENT active number lives in <active-marker>, and logs every `switch`
+# invocation to <switch-log>. FAKE_CSWAP_BLOCK_SWITCH=1 makes `switch`
+# report success without actually moving the active marker, simulating a
+# switch that did not take effect (verification must then read verified=false).
+fm_fake_cswap() {
+  local fakebin=$1 marker=$2 log=$3
+  cat > "$fakebin/cswap" <<SH
+#!/usr/bin/env bash
+set -eu
+MARKER='$marker'
+LOG='$log'
+active=\$(cat "\$MARKER")
+accounts_json() {
+  cat <<JSON
+[
+  {"number":1,"email":"5x@example.com","disabled":false,"usageStatus":"ok","usageAgeSeconds":30,
+   "usage":{"fiveHour":{"pct":10,"resetsAt":"2035-01-01T04:00:00Z"},
+            "sevenDay":{"pct":36,"resetsAt":"2035-01-05T20:00:00Z","expectedPct":30.95,"aheadOfPace":false,
+                        "projectedExhaustionAt":"2035-01-04T19:00:00Z","willLastToReset":false}}},
+  {"number":2,"email":"20x@example.com","disabled":false,"usageStatus":"ok","usageAgeSeconds":30,
+   "usage":{"fiveHour":{"pct":5,"resetsAt":"2035-01-01T04:00:00Z"},
+            "sevenDay":{"pct":6,"resetsAt":"2035-01-05T04:00:00Z","expectedPct":40.4,"aheadOfPace":false,
+                        "projectedExhaustionAt":"2035-02-14T04:00:00Z","willLastToReset":true}}}
+]
+JSON
+}
+case "\${1:-}" in
+  list)
+    printf '{"activeAccountNumber":%s,"accounts":' "\$active"
+    accounts_json
+    printf '}'
+    ;;
+  status)
+    printf '{"active":{"number":%s}}' "\$active"
+    ;;
+  switch)
+    printf 'switch %s\n' "\$2" >> "\$LOG"
+    if [ "\${FAKE_CSWAP_BLOCK_SWITCH:-0}" != 1 ]; then
+      printf '%s' "\$2" > "\$MARKER"
+    fi
+    ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$fakebin/cswap"
+}
+
+new_case() {  # <name> -> prints "<fakebin> <state> <marker> <log>"
+  local d="$TMP_ROOT/$1" fakebin state marker log
+  mkdir -p "$d"
+  fakebin=$(fm_fakebin "$d")
+  state="$d/state"
+  mkdir -p "$state"
+  marker="$d/active"
+  printf '1' > "$marker"
+  log="$d/switch.log"
+  : > "$log"
+  fm_fake_cswap "$fakebin" "$marker" "$log"
+  printf '%s %s %s %s' "$fakebin" "$state" "$marker" "$log"
+}
+
+test_switches_and_verifies_when_target_differs() {
+  local fakebin state marker log
+  read -r fakebin state marker log <<< "$(new_case switch-verify)"
+  PATH="$fakebin:$PATH" fm_cswap_dispatch_switch t1 "$state"
+  [ "$(cat "$marker")" = 2 ] || fail "the active account should have moved to the chosen candidate (2)"
+  [ "$(cat "$log")" = "switch 2" ] || fail "expected exactly one 'switch 2' call, got: $(cat "$log")"
+  [ -f "$state/t1.cswap-select" ] || fail "evidence sidecar was not written"
+  [ "$(jq -r .decision < "$state/t1.cswap-select")" = switch ] || fail "evidence must record decision=switch"
+  [ "$(jq -r .chosen < "$state/t1.cswap-select")" = 2 ] || fail "evidence must record chosen=2"
+  [ "$(jq -r .switched < "$state/t1.cswap-select")" = true ] || fail "evidence must record switched=true"
+  [ "$(jq -r .verified < "$state/t1.cswap-select")" = true ] || fail "evidence must record verified=true after a confirmed switch"
+  [ "$(jq -r '.candidates | length' < "$state/t1.cswap-select")" = 2 ] || fail "evidence must retain the full per-account input candidates"
+  pass "a genuinely better account is switched to and the post-switch identity is verified"
+}
+
+test_switch_verification_failure_is_recorded_not_hidden() {
+  local fakebin state marker log
+  read -r fakebin state marker log <<< "$(new_case verify-fail)"
+  FAKE_CSWAP_BLOCK_SWITCH=1 PATH="$fakebin:$PATH" fm_cswap_dispatch_switch t1 "$state"
+  [ "$(cat "$marker")" = 1 ] || fail "the fake active marker should be unchanged since the switch was blocked"
+  [ "$(cat "$log")" = "switch 2" ] || fail "the switch command must still have been attempted"
+  [ "$(jq -r .switched < "$state/t1.cswap-select")" = true ] || fail "evidence must record that a switch was attempted"
+  [ "$(jq -r .verified < "$state/t1.cswap-select")" = false ] || fail "an unconfirmed switch must never be reported as verified"
+  pass "a switch that does not take effect is recorded as switched but NOT verified, never silently claimed successful"
+}
+
+test_noop_when_target_already_active() {
+  local fakebin state marker log
+  read -r fakebin state marker log <<< "$(new_case noop)"
+  printf '2' > "$marker"
+  PATH="$fakebin:$PATH" fm_cswap_dispatch_switch t1 "$state"
+  [ -s "$log" ] && fail "no switch call should fire when the decision already resolves to keep-current"
+  [ "$(jq -r .decision < "$state/t1.cswap-select")" = keep-current ] || fail "already-best active account must record keep-current"
+  [ "$(jq -r .switched < "$state/t1.cswap-select")" = false ] || fail "keep-current must record switched=false"
+  pass "no switch is attempted when the best candidate is already the active account"
+}
+
+test_skips_switch_when_another_claude_task_is_busy() {
+  local fakebin state marker log
+  read -r fakebin state marker log <<< "$(new_case busy-guard)"
+  fm_write_meta "$state/other.meta" "window=firstmate:fm-other" "harness=claude" "endpoint_task_id=other"
+  "$ROOT/bin/fm-busy-event.sh" arm "$state" other >/dev/null
+  PATH="$fakebin:$PATH" fm_cswap_dispatch_switch t1 "$state"
+  [ -s "$log" ] && fail "switch must not fire while another claude-harness task is busy, log: $(cat "$log")"
+  [ "$(cat "$marker")" = 1 ] || fail "active account must be unchanged while the guard is skipping the switch"
+  [ "$(jq -r .switched < "$state/t1.cswap-select")" = false ] || fail "evidence must record switched=false under the busy guard"
+  case "$(jq -r .skippedReason < "$state/t1.cswap-select")" in
+    *busy*) : ;;
+    *) fail "skippedReason should explain the busy-guard skip, got: $(jq -r .skippedReason < "$state/t1.cswap-select")" ;;
+  esac
+  pass "a currently-busy claude-harness task blocks the switch instead of interrupting it"
+}
+
+test_switches_when_other_claude_task_is_idle() {
+  local fakebin state marker log
+  read -r fakebin state marker log <<< "$(new_case idle-other)"
+  fm_write_meta "$state/other.meta" "window=firstmate:fm-other" "harness=claude" "endpoint_task_id=other"
+  "$ROOT/bin/fm-busy-event.sh" arm "$state" other >/dev/null
+  "$ROOT/bin/fm-busy-event.sh" apply "$state" other idle --current-gen --source fm-interrupt --event interrupt >/dev/null
+  PATH="$fakebin:$PATH" fm_cswap_dispatch_switch t1 "$state"
+  [ "$(cat "$log")" = "switch 2" ] || fail "an idle other claude task must not block a genuinely better switch"
+  pass "an idle (not busy) other claude-harness task does not block the switch"
+}
+
+test_no_evidence_when_cswap_absent() {
+  local d fakebin state
+  d="$TMP_ROOT/absent"
+  mkdir -p "$d"
+  fakebin=$(fm_fakebin "$d")
+  state="$d/state"
+  mkdir -p "$state"
+  # A minimal, real-cswap-free PATH: the fakebin (empty - no cswap stub here)
+  # plus only the standard system directories, so a real cswap installed
+  # elsewhere on this host (e.g. ~/.local/bin) cannot leak into the test.
+  PATH="$fakebin:/usr/bin:/bin" fm_cswap_dispatch_switch t1 "$state" \
+    || fail "dispatch must never fail even when cswap is absent"
+  [ ! -e "$state/t1.cswap-select" ] || fail "no evidence should be written when cswap is not installed at all"
+  pass "cswap being absent is an inert no-op: no evidence, no failure"
+}
+
+test_switches_and_verifies_when_target_differs
+test_switch_verification_failure_is_recorded_not_hidden
+test_noop_when_target_already_active
+test_skips_switch_when_another_claude_task_is_busy
+test_switches_when_other_claude_task_is_idle
+test_no_evidence_when_cswap_absent
+
+echo "all fm-cswap-lib tests passed"

--- a/tests/fm-cswap-lib.test.sh
+++ b/tests/fm-cswap-lib.test.sh
@@ -192,6 +192,26 @@ test_switches_when_other_claude_task_is_idle() {
   pass "an idle (not busy) other claude-harness task does not block the switch"
 }
 
+test_candidate_disabled_normalization_matches_cswap_contract() {
+  # cswap's `list --json` omits `disabled` for an in-rotation account and emits
+  # it as `true` only when the slot is held out of rotation
+  # (claude_swap/json_output.py). fm_cswap_candidates must therefore normalize
+  # an absent key to enabled (false) and a present `true` to disabled (true),
+  # and must fail CLOSED on a present-but-null value (a partial/garbled read)
+  # by normalizing it to disabled (true) rather than silently enabling it.
+  local raw normalized
+  raw='{"activeAccountNumber":1,"accounts":[
+    {"number":1,"email":"enabled@example.com","usageStatus":"ok","usage":{"fiveHour":{"pct":1},"sevenDay":{"pct":1}}},
+    {"number":2,"email":"held@example.com","disabled":true,"usageStatus":"ok","usage":{"fiveHour":{"pct":1},"sevenDay":{"pct":1}}},
+    {"number":3,"email":"garbled@example.com","disabled":null,"usageStatus":"ok","usage":{"fiveHour":{"pct":1},"sevenDay":{"pct":1}}}
+  ]}'
+  normalized=$(fm_cswap_candidates "$raw") || fail "candidates must parse a real-shaped cswap payload"
+  [ "$(printf '%s' "$normalized" | jq -r '.[0].disabled')" = false ] || fail "an account omitting disabled must normalize to enabled (false), got: $normalized"
+  [ "$(printf '%s' "$normalized" | jq -r '.[1].disabled')" = true ] || fail "an account with disabled:true must normalize to disabled (true), got: $normalized"
+  [ "$(printf '%s' "$normalized" | jq -r '.[2].disabled')" = true ] || fail "an account with a null (unconfirmed) disabled must fail closed to disabled (true), got: $normalized"
+  pass "disabled normalization honors cswap's omit-when-enabled contract and fails closed on an unconfirmed value"
+}
+
 test_no_evidence_when_cswap_absent() {
   local d fakebin state
   d="$TMP_ROOT/absent"
@@ -215,6 +235,7 @@ test_skips_switch_when_active_moved_under_lock
 test_skips_switch_when_active_cannot_be_confirmed_under_lock
 test_skips_switch_when_another_claude_task_is_busy
 test_switches_when_other_claude_task_is_idle
+test_candidate_disabled_normalization_matches_cswap_contract
 test_no_evidence_when_cswap_absent
 
 echo "all fm-cswap-lib tests passed"

--- a/tests/fm-cswap-lib.test.sh
+++ b/tests/fm-cswap-lib.test.sh
@@ -50,7 +50,10 @@ case "\${1:-}" in
     printf '}'
     ;;
   status)
-    printf '{"active":{"number":%s}}' "\$active"
+    # FAKE_CSWAP_STATUS_ACTIVE overrides the number reported by \`status\`
+    # (but not \`list\`), simulating the live active account having moved out
+    # from under a decision that was ranked against the \`list\` read.
+    printf '{"active":{"number":%s}}' "\${FAKE_CSWAP_STATUS_ACTIVE:-\$active}"
     ;;
   switch)
     printf 'switch %s\n' "\$2" >> "\$LOG"
@@ -115,6 +118,26 @@ test_noop_when_target_already_active() {
   pass "no switch is attempted when the best candidate is already the active account"
 }
 
+test_skips_switch_when_active_moved_under_lock() {
+  # The `list` read ranks a decision against active=1, but by the time the
+  # switch lock is held the live active has moved to 3 (a concurrent spawn
+  # switched). The chosen target (2) is now ranked against stale state, so
+  # the switch must be skipped (fail-closed), never fired onto an obsolete
+  # target.
+  local fakebin state marker log
+  read -r fakebin state marker log <<< "$(new_case stale-active)"
+  FAKE_CSWAP_STATUS_ACTIVE=3 PATH="$fakebin:$PATH" fm_cswap_dispatch_switch t1 "$state"
+  [ -s "$log" ] && fail "no switch may fire when the live active account moved under the lock, log: $(cat "$log")"
+  [ "$(cat "$marker")" = 1 ] || fail "active marker must be unchanged when the switch is skipped as stale"
+  [ "$(jq -r .switched < "$state/t1.cswap-select")" = false ] || fail "a stale-decision skip must record switched=false"
+  [ "$(jq -r .verified < "$state/t1.cswap-select")" = false ] || fail "a skipped switch is never verified"
+  case "$(jq -r .skippedReason < "$state/t1.cswap-select")" in
+    *stale*|*changed*|*concurrent*) : ;;
+    *) fail "skippedReason should explain the stale/concurrent-switch skip, got: $(jq -r .skippedReason < "$state/t1.cswap-select")" ;;
+  esac
+  pass "a decision ranked against a since-changed active account fails closed instead of executing an obsolete target"
+}
+
 test_skips_switch_when_another_claude_task_is_busy() {
   local fakebin state marker log
   read -r fakebin state marker log <<< "$(new_case busy-guard)"
@@ -161,6 +184,7 @@ test_no_evidence_when_cswap_absent() {
 test_switches_and_verifies_when_target_differs
 test_switch_verification_failure_is_recorded_not_hidden
 test_noop_when_target_already_active
+test_skips_switch_when_active_moved_under_lock
 test_skips_switch_when_another_claude_task_is_busy
 test_switches_when_other_claude_task_is_idle
 test_no_evidence_when_cswap_absent

--- a/tests/fm-cswap-lib.test.sh
+++ b/tests/fm-cswap-lib.test.sh
@@ -50,6 +50,12 @@ case "\${1:-}" in
     printf '}'
     ;;
   status)
+    # FAKE_CSWAP_STATUS_FAIL=1 makes \`status\` fail with no output, simulating
+    # the live active account being unconfirmable under the lock (a stale
+    # decision must then fail closed, never fire the pre-lock target).
+    if [ "\${FAKE_CSWAP_STATUS_FAIL:-0}" = 1 ]; then
+      exit 1
+    fi
     # FAKE_CSWAP_STATUS_ACTIVE overrides the number reported by \`status\`
     # (but not \`list\`), simulating the live active account having moved out
     # from under a decision that was ranked against the \`list\` read.
@@ -138,6 +144,27 @@ test_skips_switch_when_active_moved_under_lock() {
   pass "a decision ranked against a since-changed active account fails closed instead of executing an obsolete target"
 }
 
+test_skips_switch_when_active_cannot_be_confirmed_under_lock() {
+  # `cswap status --json` fails to report the live active account while the
+  # switch lock is held. The decision was ranked against the pre-lock `list`
+  # read; without a fresh confirmation a concurrent switch cannot be ruled out,
+  # so the switch must fail closed (keep-current) rather than fire the pre-lock
+  # target - never substituting the stale list-time active as if it were still
+  # the confirmed live one.
+  local fakebin state marker log
+  read -r fakebin state marker log <<< "$(new_case unconfirmed-active)"
+  FAKE_CSWAP_STATUS_FAIL=1 PATH="$fakebin:$PATH" fm_cswap_dispatch_switch t1 "$state"
+  [ -s "$log" ] && fail "no switch may fire when the live active account cannot be confirmed under the lock, log: $(cat "$log")"
+  [ "$(cat "$marker")" = 1 ] || fail "active marker must be unchanged when the switch is skipped as unconfirmable"
+  [ "$(jq -r .switched < "$state/t1.cswap-select")" = false ] || fail "an unconfirmable-active skip must record switched=false"
+  [ "$(jq -r .verified < "$state/t1.cswap-select")" = false ] || fail "a skipped switch is never verified"
+  case "$(jq -r .skippedReason < "$state/t1.cswap-select")" in
+    *confirm*|*stale*) : ;;
+    *) fail "skippedReason should explain the unconfirmable-active skip, got: $(jq -r .skippedReason < "$state/t1.cswap-select")" ;;
+  esac
+  pass "a switch whose live active account cannot be confirmed under the lock fails closed instead of firing a possibly-stale target"
+}
+
 test_skips_switch_when_another_claude_task_is_busy() {
   local fakebin state marker log
   read -r fakebin state marker log <<< "$(new_case busy-guard)"
@@ -185,6 +212,7 @@ test_switches_and_verifies_when_target_differs
 test_switch_verification_failure_is_recorded_not_hidden
 test_noop_when_target_already_active
 test_skips_switch_when_active_moved_under_lock
+test_skips_switch_when_active_cannot_be_confirmed_under_lock
 test_skips_switch_when_another_claude_task_is_busy
 test_switches_when_other_claude_task_is_idle
 test_no_evidence_when_cswap_absent

--- a/tests/fm-cswap-select.test.sh
+++ b/tests/fm-cswap-select.test.sh
@@ -55,6 +55,36 @@ JSON
   pass "5x at-risk of exhausting before reset vs 20x comfortably safe: the 20x account is chosen"
 }
 
+test_plan_size_breaks_a_tie_and_is_carried_in_evidence() {
+  # Two accounts identical on every other ranking key (same tier, same
+  # margin7d, same headroom) but different plan size: the larger plan must be
+  # chosen, and each account's plan must appear verbatim in the candidates
+  # evidence. Proves selection ranks BY plan size, not just headroom/runway.
+  local now=1735689600 r7 e7 cands out
+  r7=$((now + 400000))
+  e7=$((now + 900000))
+  cands=$(cat <<JSON
+[
+  {"number":1,"email":"5x@example.com","alias":"","disabled":false,"usageStatus":"ok","usageAgeSeconds":30,
+   "plan":5,"pct5h":10,"resets5hEpoch":$((now + 3600)),
+   "pct7d":20,"resets7dEpoch":$r7,"expectedPct7d":20,"aheadOfPace7d":false,
+   "willLastToReset7d":true,"projectedExhaustionAt7dEpoch":$e7},
+  {"number":2,"email":"20x@example.com","alias":"","disabled":false,"usageStatus":"ok","usageAgeSeconds":30,
+   "plan":20,"pct5h":10,"resets5hEpoch":$((now + 3600)),
+   "pct7d":20,"resets7dEpoch":$r7,"expectedPct7d":20,"aheadOfPace7d":false,
+   "willLastToReset7d":true,"projectedExhaustionAt7dEpoch":$e7}
+]
+JSON
+  )
+  out=$(printf '%s' "$cands" | jq -c --argjson now "$now" --argjson active 1 --argjson maxAgeS 1800 \
+    -f "$ROOT/bin/fm-cswap-select.jq")
+  [ "$(field "$out" .decision)" = switch ] || fail "the larger-plan account must win an otherwise-exact tie, got: $out"
+  [ "$(field "$out" .chosen)" = 2 ] || fail "expected the 20x-plan account (2) to be chosen over the tied 5x active one, got: $out"
+  [ "$(field "$out" '.candidates[0].plan')" = 5 ] || fail "account 1's plan size must be carried into evidence, got: $out"
+  [ "$(field "$out" '.candidates[1].plan')" = 20 ] || fail "account 2's plan size must be carried into evidence, got: $out"
+  pass "plan size breaks an otherwise-exact tie (larger plan chosen) and is recorded per account in evidence"
+}
+
 test_tie_stays_on_active_account() {
   local now=1735689600 cands out
   cands=$(cat <<JSON
@@ -149,6 +179,7 @@ JSON
 
 test_captain_scenario_5x_at_risk_vs_20x_safe_picks_20x
 test_untouched_account_with_no_5h_reset_timestamp_is_eligible
+test_plan_size_breaks_a_tie_and_is_carried_in_evidence
 test_tie_stays_on_active_account
 test_stale_usage_fails_closed_to_keep_current
 test_disabled_account_excluded_even_with_best_headroom

--- a/tests/fm-cswap-select.test.sh
+++ b/tests/fm-cswap-select.test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Behavior tests for the pure cswap account-selection decision function
+# (bin/fm-cswap-select.jq, invoked through bin/fm-cswap-lib.sh's
+# fm_cswap_decide). Hermetic - feeds literal fixture JSON, no real cswap call.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-cswap-lib.sh"
+
+decide() {  # <candidates-json> <active>
+  fm_cswap_decide "$1" "$2"
+}
+
+field() {  # <json> <jq-filter>
+  printf '%s' "$1" | jq -r "$2"
+}
+
+# --- the captain's exact scenario -------------------------------------------
+#
+# A 5x-plan account at 36% weekly usage, resetting in 4d20h, projected by
+# cswap's own pace math to exhaust in 3d19h (BEFORE its reset - it will run
+# dry with about a day of margin to spare), against a 20x-plan account at 6%
+# weekly usage, resetting in 4d4h, running 34 points under its expected pace
+# (cswap's own reservePct, i.e. expectedPct - actualPct). A new task must
+# pick the 20x account.
+test_captain_scenario_5x_at_risk_vs_20x_safe_picks_20x() {
+  local now=1735689600 r5x e5x r20x e20x cands out
+  r5x=$((now + 417600))    # +4d20h
+  e5x=$((now + 327600))    # +3d19h - BEFORE r5x: will exhaust before reset
+  r20x=$((now + 360000))   # +4d4h
+  e20x=$((now + 3840000))  # ~+44.4d - far past r20x: comfortably safe
+  cands=$(cat <<JSON
+[
+  {"number":1,"email":"5x@example.com","alias":"","disabled":false,"usageStatus":"ok","usageAgeSeconds":60,
+   "pct5h":10,"resets5hEpoch":$((now + 3600)),
+   "pct7d":36,"resets7dEpoch":$r5x,"expectedPct7d":30.95,"aheadOfPace7d":false,
+   "willLastToReset7d":false,"projectedExhaustionAt7dEpoch":$e5x},
+  {"number":2,"email":"20x@example.com","alias":"","disabled":false,"usageStatus":"ok","usageAgeSeconds":60,
+   "pct5h":5,"resets5hEpoch":$((now + 3600)),
+   "pct7d":6,"resets7dEpoch":$r20x,"expectedPct7d":40.4,"aheadOfPace7d":false,
+   "willLastToReset7d":true,"projectedExhaustionAt7dEpoch":$e20x}
+]
+JSON
+  )
+  out=$(printf '%s' "$cands" | jq -c --argjson now "$now" --argjson active 1 --argjson maxAgeS 1800 \
+    -f "$ROOT/bin/fm-cswap-select.jq")
+  [ "$(field "$out" .decision)" = switch ] || fail "expected a switch decision, got: $out"
+  [ "$(field "$out" .chosen)" = 2 ] || fail "expected the 20x account (2) to be chosen, got: $out"
+  [ "$(field "$out" '.candidates[0].margin7dSeconds')" -lt 0 ] || fail "5x account must show a negative (will-exhaust-early) margin"
+  [ "$(field "$out" '.candidates[1].margin7dSeconds')" -gt 0 ] || fail "20x account must show a positive (safe) margin"
+  [ "$(field "$out" '.candidates[1].reserve7dPct')" = "34.4" ] || fail "20x reserve7dPct should read 34.4 (expectedPct 40.4 - actual 6), got: $out"
+  pass "5x at-risk of exhausting before reset vs 20x comfortably safe: the 20x account is chosen"
+}
+
+test_tie_stays_on_active_account() {
+  local now=1735689600 cands out
+  cands=$(cat <<JSON
+[
+  {"number":1,"email":"a@example.com","alias":"","disabled":false,"usageStatus":"ok","usageAgeSeconds":30,
+   "pct5h":10,"resets5hEpoch":$((now + 3600)),
+   "pct7d":20,"resets7dEpoch":$((now + 400000)),"expectedPct7d":20,"aheadOfPace7d":false,
+   "willLastToReset7d":true,"projectedExhaustionAt7dEpoch":$((now + 900000))},
+  {"number":2,"email":"b@example.com","alias":"","disabled":false,"usageStatus":"ok","usageAgeSeconds":30,
+   "pct5h":10,"resets5hEpoch":$((now + 3600)),
+   "pct7d":20,"resets7dEpoch":$((now + 400000)),"expectedPct7d":20,"aheadOfPace7d":false,
+   "willLastToReset7d":true,"projectedExhaustionAt7dEpoch":$((now + 900000))}
+]
+JSON
+  )
+  out=$(printf '%s' "$cands" | jq -c --argjson now "$now" --argjson active 2 --argjson maxAgeS 1800 \
+    -f "$ROOT/bin/fm-cswap-select.jq")
+  [ "$(field "$out" .decision)" = keep-current ] || fail "an exact tie must keep the currently active account, got: $out"
+  [ "$(field "$out" .chosen)" = 2 ] || fail "keep-current must report the active account as chosen, got: $out"
+  pass "an exact tie between two equally-good accounts stays on the currently active one"
+}
+
+test_stale_usage_fails_closed_to_keep_current() {
+  local now=1735689600 cands out
+  cands=$(cat <<JSON
+[
+  {"number":1,"email":"a@example.com","alias":"","disabled":false,"usageStatus":"ok","usageAgeSeconds":9000,
+   "pct5h":10,"resets5hEpoch":$((now + 3600)),
+   "pct7d":10,"resets7dEpoch":$((now + 400000)),"expectedPct7d":20,"aheadOfPace7d":false,
+   "willLastToReset7d":true,"projectedExhaustionAt7dEpoch":$((now + 900000))}
+]
+JSON
+  )
+  out=$(printf '%s' "$cands" | jq -c --argjson now "$now" --argjson active 1 --argjson maxAgeS 1800 \
+    -f "$ROOT/bin/fm-cswap-select.jq")
+  [ "$(field "$out" .decision)" = keep-current ] || fail "a lone account with stale (9000s > 1800s max) usage must never be picked, got: $out"
+  [ "$(field "$out" .chosen)" = null ] || fail "keep-current on stale-only evidence must not name a chosen account, got: $out"
+  case "$(field "$out" .reason)" in
+    *"no eligible"*) : ;;
+    *) fail "reason should explain no eligible candidate, got: $out" ;;
+  esac
+  pass "the only candidate's usage being older than the freshness floor fails closed instead of guessing"
+}
+
+test_disabled_account_excluded_even_with_best_headroom() {
+  local now=1735689600 cands out
+  cands=$(cat <<JSON
+[
+  {"number":1,"email":"disabled@example.com","alias":"","disabled":true,"usageStatus":"ok","usageAgeSeconds":30,
+   "pct5h":0,"resets5hEpoch":$((now + 3600)),
+   "pct7d":0,"resets7dEpoch":$((now + 400000)),"expectedPct7d":20,"aheadOfPace7d":false,
+   "willLastToReset7d":true,"projectedExhaustionAt7dEpoch":null},
+  {"number":2,"email":"b@example.com","alias":"","disabled":false,"usageStatus":"ok","usageAgeSeconds":30,
+   "pct5h":50,"resets5hEpoch":$((now + 3600)),
+   "pct7d":50,"resets7dEpoch":$((now + 400000)),"expectedPct7d":50,"aheadOfPace7d":false,
+   "willLastToReset7d":true,"projectedExhaustionAt7dEpoch":$((now + 900000))}
+]
+JSON
+  )
+  out=$(printf '%s' "$cands" | jq -c --argjson now "$now" --argjson active 2 --argjson maxAgeS 1800 \
+    -f "$ROOT/bin/fm-cswap-select.jq")
+  [ "$(field "$out" .decision)" = keep-current ] || fail "the only non-disabled account is already active, so this must keep-current, got: $out"
+  [ "$(field "$out" .chosen)" = 2 ] || fail "expected account 2 (the non-disabled one), got: $out"
+  pass "a disabled account (held out of rotation) is never a selection candidate even with perfect headroom"
+}
+
+test_untouched_account_with_no_5h_reset_timestamp_is_eligible() {
+  # Verified live against the captain's real cswap accounts: a window with
+  # 0% usage carries no resetsAt at all (nothing has opened it yet), so
+  # eligibility must not require a 5h reset timestamp to exist.
+  local now=1735689600 cands out
+  cands=$(cat <<JSON
+[
+  {"number":1,"email":"fresh@example.com","alias":"","disabled":false,"usageStatus":"ok","usageAgeSeconds":250,
+   "pct5h":0,"resets5hEpoch":null,
+   "pct7d":6,"resets7dEpoch":$((now + 400000)),"expectedPct7d":40.8,"aheadOfPace7d":null,
+   "willLastToReset7d":true,"projectedExhaustionAt7dEpoch":$((now + 3500000))},
+  {"number":2,"email":"active@example.com","alias":"","disabled":false,"usageStatus":"ok","usageAgeSeconds":20,
+   "pct5h":96,"resets5hEpoch":$((now + 6600)),
+   "pct7d":41,"resets7dEpoch":$((now + 406800)),"expectedPct7d":31.3,"aheadOfPace7d":null,
+   "willLastToReset7d":null,"projectedExhaustionAt7dEpoch":$((now + 259200))}
+]
+JSON
+  )
+  out=$(printf '%s' "$cands" | jq -c --argjson now "$now" --argjson active 2 --argjson maxAgeS 1800 \
+    -f "$ROOT/bin/fm-cswap-select.jq")
+  [ "$(field "$out" '.candidates[0].eligible')" = true ] || fail "an untouched account with no 5h resetsAt must still be eligible, got: $out"
+  [ "$(field "$out" .decision)" = switch ] || fail "expected a switch away from the near-limit active account, got: $out"
+  [ "$(field "$out" .chosen)" = 1 ] || fail "expected the fresh account to be chosen, got: $out"
+  pass "an account whose 5h window has never been opened (no resetsAt) is still a valid selection candidate"
+}
+
+test_captain_scenario_5x_at_risk_vs_20x_safe_picks_20x
+test_untouched_account_with_no_5h_reset_timestamp_is_eligible
+test_tie_stays_on_active_account
+test_stale_usage_fails_closed_to_keep_current
+test_disabled_account_excluded_even_with_best_headroom
+
+echo "all fm-cswap-select tests passed"

--- a/tests/fm-cswap-select.test.sh
+++ b/tests/fm-cswap-select.test.sh
@@ -151,6 +151,37 @@ JSON
   pass "a disabled account (held out of rotation) is never a selection candidate even with perfect headroom"
 }
 
+test_null_disabled_fails_closed_and_is_never_selected() {
+  # cswap's real `list --json` omits `disabled` for an in-rotation account and
+  # emits it as `true` only when a slot is held out of rotation
+  # (claude_swap/json_output.py); it never emits a bare `null`. A null disabled
+  # therefore signals a partial/garbled read whose authorization is UNCONFIRMED,
+  # and must fail CLOSED (excluded) rather than be silently treated as enabled
+  # and reach `cswap switch`. Account 1 here has otherwise-perfect headroom and
+  # a safe (null-projection) tier, so a fail-OPEN reading would wrongly switch
+  # to it; the fix must instead keep the explicitly-enabled active account.
+  local now=1735689600 cands out
+  cands=$(cat <<JSON
+[
+  {"number":1,"email":"unconfirmed@example.com","alias":"","disabled":null,"usageStatus":"ok","usageAgeSeconds":30,
+   "pct5h":0,"resets5hEpoch":$((now + 3600)),
+   "pct7d":0,"resets7dEpoch":$((now + 400000)),"expectedPct7d":20,"aheadOfPace7d":false,
+   "willLastToReset7d":true,"projectedExhaustionAt7dEpoch":null},
+  {"number":2,"email":"b@example.com","alias":"","disabled":false,"usageStatus":"ok","usageAgeSeconds":30,
+   "pct5h":50,"resets5hEpoch":$((now + 3600)),
+   "pct7d":50,"resets7dEpoch":$((now + 400000)),"expectedPct7d":50,"aheadOfPace7d":false,
+   "willLastToReset7d":true,"projectedExhaustionAt7dEpoch":$((now + 900000))}
+]
+JSON
+  )
+  out=$(printf '%s' "$cands" | jq -c --argjson now "$now" --argjson active 2 --argjson maxAgeS 1800 \
+    -f "$ROOT/bin/fm-cswap-select.jq")
+  [ "$(field "$out" '.candidates[0].eligible')" = false ] || fail "an account whose disabled state is null (unconfirmed) must be ineligible, got: $out"
+  [ "$(field "$out" .decision)" = keep-current ] || fail "a null-disabled account with perfect headroom must not trigger a switch, got: $out"
+  [ "$(field "$out" .chosen)" = 2 ] || fail "only the explicitly-enabled (disabled==false) account may be chosen, got: $out"
+  pass "an unconfirmed (null) disabled state fails closed and can never reach a credential switch"
+}
+
 test_untouched_account_with_no_5h_reset_timestamp_is_eligible() {
   # Verified live against the captain's real cswap accounts: a window with
   # 0% usage carries no resetsAt at all (nothing has opened it yet), so
@@ -178,6 +209,7 @@ JSON
 }
 
 test_captain_scenario_5x_at_risk_vs_20x_safe_picks_20x
+test_null_disabled_fails_closed_and_is_never_selected
 test_untouched_account_with_no_5h_reset_timestamp_is_eligible
 test_plan_size_breaks_a_tie_and_is_carried_in_evidence
 test_tie_stays_on_active_account


### PR DESCRIPTION
## Intent

Firstmate currently has no automated logic for choosing which registered Claude account (via the external cswap CLI) a new Claude-provider crew task uses; the captain previously had firstmate manually prefer a fixed cswap slot at every dispatch, and that fixed preference was removed in favor of dynamic per-boundary selection. Build the automated selection mechanism that replaces the old fixed-slot habit:
1. At every new Claude-provider task dispatch boundary (bin/fm-spawn.sh, where HARNESS=claude, right before the launch command is sent), select among the captain-authorized (non-disabled) cswap accounts by plan size, remaining 5-hour percentage, remaining 7-day percentage, reset time for each window, and a computed burn-runway-vs-reset-time figure (does the account's current consumption rate exhaust it before its own reset, and by how much margin) - not just raw remaining percentage. Investigated whether quota-axi's spendPriority already covers this: it does not - quota-axi models only the single currently-active OS-level Claude credential, never a list of cswap-managed accounts, so this stays the one place computing cswap account economics (one-owner rule respected, not duplicated).
2. The actual account switch is narrowly scoped to 'cswap switch <exact-account>' - an exact target, never a bare rotate - and only fires at a genuinely safe task boundary (a new task about to start, not mid-task). It must never interrupt or abort work already running on an account: it is skipped entirely when another claude-harness task recorded in the same state directory is currently classified busy (mid-turn). It must never fire a second switch onto the same account in immediate succession: a per-state-dir lock re-confirms the live active account immediately before firing, and the decision function itself treats an already-active target as a no-op.
3. Every run writes the selection evidence onto the task's own durable record (state/<id>.cswap-select): the per-account inputs read (plan/pct5h/pct7d/resets/expectedPct/aheadOfPace/projectedExhaustionAt/willLastToReset), the computed headroom/margin/reserve, which account was chosen, and why - inspectable after the fact, not just logged transiently.
4. Wired into the existing claude-harness launch boundary in bin/fm-spawn.sh rather than a new standalone entry point, following AGENTS.md section 4 and harness-adapters conventions; a one-line pointer was added to the harness-adapters claude reference.
5. Durable, reusable operational facts learned about cswap's actual JSON schema and behavior (exact fields in 'cswap list --json' including that a fresh/untouched window omits resetsAt entirely, exact semantics of 'cswap switch', 'cswap status --json', and '--strategy best') are documented in the new script's own header/comments for data/learnings.md routing (data/ is gitignored and private to the primary firstmate home, unreachable from this isolated worktree, so the facts are captured in the shippable code comments and surfaced in the task's completion report for firstmate to transcribe).

Captain-added concrete acceptance criteria (verified before considering this done):
(1) An exact fixture test reproduces: a 5x-plan account at 36% weekly usage, resetting in 4d20h, projected by cswap's own pace math to exhaust in 3d19h (before its own reset) versus a 20x-plan account at 6% weekly usage, resetting in 4d4h, running 34 points under its expected pace (reservePct) - the 20x account must be chosen for a new task. This exact scenario is a standalone jq-level fixture test.
(2) No switch fires while another claude-harness task is currently busy (no interruption of live work) - covered by a dedicated fixture test with a real busy-state record.
(3) No switch is attempted onto the account that is already active (no-op) - covered by a dedicated fixture test.
(4) Stale or unknown usage data fails closed (never silently picks a default) - covered by a dedicated fixture test.
(5) After firing the exact 'cswap switch <account>' command, the active identity is re-read and verified before the switch is ever reported as successful; an unconfirmed or mismatched switch is recorded as verified=false, never silently claimed successful - covered by a dedicated fixture test with a fake cswap that simulates a switch not taking effect.
(6) All selection evidence (inputs, computed runway, chosen account, reason) is written to the task's durable record - covered by evidence-content assertions in the fixture tests.
Additionally performed and to be preserved as delivery evidence: a safe, non-destructive real canary read against the captain's actual live cswap accounts (real 'cswap list'/'status --json', decision computed for real, but no real switch executed), and a full regression run of the pre-existing fm-spawn-dispatch-profile test suite confirming no behavior change for non-claude harnesses and no real cswap side effects (the shared spawn test fakebin was given a no-op cswap stub for this reason, since the developer host running these tests has the real cswap CLI installed). Acceptance requires the fixture tests, this independent pipeline review, and that real non-destructive canary evidence - not unit-test-green alone.

## What Changed

- Added `bin/fm-cswap-lib.sh` and `bin/fm-cswap-select.jq`: a per-dispatch decision that ranks the captain's non-disabled cswap-managed accounts by remaining 5h/7d headroom plus cswap's own weekly burn-rate-vs-reset projection (margin/reserve), fires a narrowly-scoped `cswap switch <exact-number>` only at a safe boundary, fails closed to keep-current on stale/unparseable usage, skips while another claude-harness task in the same state dir is busy, re-confirms the live active account under a per-state-dir lock, and re-reads `cswap status --json` to record `verified` after switching.
- Wired `fm_cswap_dispatch_switch` into `bin/fm-spawn.sh` right before the launch command is sent for `HARNESS=claude`, best-effort so an absent or flaky cswap never blocks the spawn; every run writes selection evidence (inputs, computed runway, chosen account, reason) to `state/<id>.cswap-select`.
- Added fixture tests (`tests/fm-cswap-lib.test.sh`, `tests/fm-cswap-select.test.sh`) covering plan-size/burn-runway ranking, no-switch-while-busy, already-active no-op, fail-closed on stale data, and switch verification; updated `tests/fixtures.sh` with a no-op cswap stub so the existing spawn suite runs with no real cswap side effects.

## Risk Assessment

✅ Low: The pipeline fix minimally and correctly guards both null subtractions (verified complete, no other unguarded arithmetic remains), all helper dependencies resolve, the change is fail-closed throughout, and the main decision/dispatch paths are covered by genuine behavioral tests.

## Testing

Ran the two focused cswap fixture suites and the fm-spawn-dispatch-profile regression suite (all green). Produced product-level evidence for this CLI/backend library: a durable state cswap-select record from the real dispatch entry point on the captain at-risk-vs-safe scenario (switch to account 2, verified true) and a non-destructive read-only canary against real live cswap accounts that resolved to keep-current with the active account unchanged. No UI surface exists so JSON records and CLI transcripts are the reviewer-visible artifacts; worktree left clean.

<details>
<summary>Evidence: Durable cswap-select record (captain scenario)</summary>

Source: [Durable cswap-select record (captain scenario)](https://github.com/AbdullahPesteli/firstmate/blob/1055b3f2d18c58ef9b86e941320b0c1deb0dc289/.no-mistakes/evidence/fm/ship-firstmate-cswap-quota-select/cswap-select-record.captain-scenario.json)

```text
{
  "decision": "switch",
  "chosen": 2,
  "reason": "account 2 has margin7d=40d headroom7d=94% headroom5h=95% vs active account 1",
  "candidates": [
    {
      "number": 1,
      "email": "5x-plan@example.com",
      "alias": "",
      "disabled": false,
      "usageStatus": "ok",
      "usageAgeSeconds": 60,
      "pct5h": 10,
      "resets5h": "2035-01-01T04:00:00Z",
      "pct7d": 36,
      "resets7d": "2035-01-05T20:00:00.123456+00:00",
      "expectedPct7d": 30.95,
      "aheadOfPace7d": null,
      "projectedExhaustionAt7d": "2035-01-04T19:00:00Z",
      "willLastToReset7d": null,
      "resets5hEpoch": 2051236800,
      "resets7dEpoch": 2051640000,
      "projectedExhaustionAt7dEpoch": 2051550000,
      "eligible": true,
      "headroom5h": 90,
      "headroom7d": 64,
      "margin7dSeconds": -90000,
      "reserve7dPct": -5.050000000000001,
      "safe7d": false
    },
    {
      "number": 2,
      "email": "20x-plan@example.com",
      "alias": "",
      "disabled": false,
      "usageStatus": "ok",
      "usageAgeSeconds": 60,
      "pct5h": 5,
      "resets5h": "2035-01-01T04:00:00Z",
      "pct7d": 6,
      "resets7d": "2035-01-05T04:00:00.000000+00:00",
      "expectedPct7d": 40.4,
      "aheadOfPace7d": null,
      "projectedExhaustionAt7d": "2035-02-14T04:00:00Z",
      "willLastToReset7d": true,
      "resets5hEpoch": 2051236800,
      "resets7dEpoch": 2051582400,
      "projectedExhaustionAt7dEpoch": 2055038400,
      "eligible": true,
      "headroom5h": 95,
      "headroom7d": 94,
      "margin7dSeconds": 3456000,
      "reserve7dPct": 34.4,
      "safe7d": true
    }
  ],
  "ranAt": 1788116710,
  "active": 1,
  "switched": true,
  "verified": true,
  "switchExitCode": 0,
  "confirmedActiveAfter": "2",
  "skippedReason": null
}
```
</details>
<details>
<summary>Evidence: Read-only canary against real cswap accounts</summary>

Source: [Read-only canary against real cswap accounts](https://github.com/AbdullahPesteli/firstmate/blob/1055b3f2d18c58ef9b86e941320b0c1deb0dc289/.no-mistakes/evidence/fm/ship-firstmate-cswap-quota-select/cswap-canary.real-accounts.redacted.json)

```text
{
  "generated": "read-only canary; NO switch fired",
  "liveActiveAccountNumber": 1,
  "decision": "keep-current",
  "chosen": 1,
  "reason": "active account 1 is already the best eligible candidate (margin7d=34.1d, headroom7d=93%)",
  "candidates": [
    {
      "number": 1,
      "disabled": false,
      "usageStatus": "ok",
      "usageAgeSeconds": 136.0,
      "pct5h": 7.0,
      "pct7d": 7.0,
      "expectedPct7d": 41.1,
      "aheadOfPace7d": null,
      "willLastToReset7d": true,
      "eligible": true,
      "headroom5h": 93,
      "headroom7d": 93,
      "margin7dSeconds": 2946657,
      "reserve7dPct": 34.1,
      "safe7d": true
    },
    {
      "number": 2,
      "disabled": false,
      "usageStatus": "ok",
      "usageAgeSeconds": 194.2,
      "pct5h": 98.0,
      "pct7d": 41.0,
      "expectedPct7d": 31.6,
      "aheadOfPace7d": null,
      "willLastToReset7d": null,
      "eligible": true,
      "headroom5h": 2,
      "headroom7d": 59,
      "margin7dSeconds": -139083,
      "reserve7dPct": -9.399999999999999,
      "safe7d": false
    }
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cb204c27c45fd1982d5890ce40f755a2e41f98d2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-cswap-select.jq:66` - fm-cswap-select.jq margin7d_of computes `.projectedExhaustionAt7dEpoch - .resets7dEpoch` guarding only on the projection being null. When projectedExhaustionAt7dEpoch is a number but resets7dEpoch is null, jq raises `number and null cannot be subtracted` and the ENTIRE selection function aborts (empty output → caller records &#39;selection could not be evaluated&#39; → keep-current for ALL accounts). This is directly reachable via fm_cswap_augment_epochs, which by design sets resets7dEpoch=null when fm_cswap_iso_to_epoch fails to parse a present timestamp — the augment layer&#39;s stated invariant (&#39;one account&#39;s malformed evidence cannot hide every other account&#39;s&#39;) is undone here, silently disabling selection globally on one bad 7d reset timestamp. Verified by feeding the fixture through the real jq (exit 5). Fail-closed so no unsafe switch, but the feature goes dark undetectably. Fix: guard the subtraction, e.g. `if .projectedExhaustionAt7dEpoch == null or .resets7dEpoch == null then null else ... end`.
- ⚠️ `bin/fm-cswap-select.jq:70` - fm-cswap-select.jq reserve7d_of computes `.expectedPct7d - .pct7d` guarding only on expectedPct7d being null. It runs inside the top-level `map(...)` over the UNFILTERED $rows (before the eligibility filter), so any account — including a disabled or errored one that is never a candidate — with expectedPct7d set but pct7d null makes jq raise `number and null cannot be subtracted`, aborting the whole selection function and forcing keep-current for every account. Confirmed against the real jq (exit 5). cswap can report a sevenDay block with expectedPct but a missing/null pct on partially-populated (e.g. disabled/errored) accounts. Fix: also guard pct7d, e.g. `if .expectedPct7d == null or .pct7d == null then null else (.expectedPct7d - .pct7d) end`.
- ⚠️ `bin/fm-cswap-lib.sh:152` - User intent item 1 lists &#39;plan size&#39; as a required selection factor and item 3 explicitly lists `plan` as a per-account input to write onto the durable record (&#34;the per-account inputs read (plan/pct5h/pct7d/resets/...)&#34;). fm_cswap_candidates extracts no plan/planSize field from `cswap list --json` at all (grep for &#39;plan&#39; in both new files returns nothing), so the ranking never considers plan size and state/&lt;id&gt;.cswap-select candidates never carry a plan field. The captain&#39;s exact 20x-over-5x outcome still passes because it is driven by the safe/at-risk (willLastToReset) tiering rather than plan size, but the listed `plan` evidence input is absent. Confirm whether omitting plan (relying on cswap&#39;s burn projection to encode plan economics) is acceptable, or whether the plan field must be read and recorded per item 3.

🔧 Fix: guard jq null subtraction in cswap margin7d/reserve7d
1 info still open:
- ℹ️ `bin/fm-cswap-select.jq:65` - The fix commit cb204c2 correctly guards the two null-subtraction crashes in margin7d_of and reserve7d_of, but the fix rounds added no regression test that reproduces the original failure: no fixture feeds resets7dEpoch=null alongside a non-null projectedExhaustionAt7dEpoch, nor pct7d=null alongside a non-null expectedPct7d. Every existing fixture uses the fully-populated (non-null) branch, so the new guard clauses are never exercised and a future edit could silently re-introduce the whole-selection-abort. A single fixture with one such partially-populated row asserting a clean keep-current decision (rather than empty jq output) would lock the guard in. Not a blocker — the guarded failure is fail-closed and I verified the fix is correct by reasoning through the jq.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-cswap-select.test.sh`
- `bash tests/fm-cswap-lib.test.sh`
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `real fm_cswap_dispatch_switch driven via fake cswap on captain scenario`
- `read-only canary against real cswap accounts, no switch fired`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: lint clean; exit 1 only from missing actionlint binary
1 warning still open:
- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
