### PR TITLE
Verify omp as a Firstmate harness adapter (crewmate/scout on Herdr)

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -3,7 +3,7 @@ name: harness-adapters
 description: >-
   Agent-only reference for firstmate harness operations.
   Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
-  Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, and muse.
+  Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, muse, and omp.
 user-invocable: false
 metadata:
   internal: true
@@ -35,7 +35,7 @@ For recovery and control, use the exact `harness=` in `state/<id>.meta`; never i
 Deliver lifecycle actions only through `../../../bin/fm-control.sh <task-id> interrupt|exit|relaunch`.
 Never type an interrupt key or exit command through `fm-send`, where routing-marked lifecycle text becomes chat.
 Trust handling is complete only when inspection proves the target started processing its instructions; delivery success alone is not proof.
-Muse is verified only for crewmate and scout work, never a secondmate or primary.
+Muse and OMP are verified only for crewmate and scout work, never a secondmate or primary.
 
 ## Detection
 
@@ -89,7 +89,8 @@ A new tool remains undispatchable until the `verify` plan, its harness entry, ev
     "grok": "references/harness/grok.md",
     "kimi": "references/harness/kimi.md",
     "cursor": "references/harness/cursor.md",
-    "muse": "references/harness/muse.md"
+    "muse": "references/harness/muse.md",
+    "omp": "references/harness/omp.md"
   }
 }
 ```

--- a/.agents/skills/harness-adapters/references/harness/omp.md
+++ b/.agents/skills/harness-adapters/references/harness/omp.md
@@ -29,6 +29,7 @@ Use deterministic `relaunch` from the durable brief instead.
 
 OMP is verified for crewmate and scout workers on Herdr.
 The tmux process-name branch has portable coverage but no supervised OMP tmux launch in this audit, so tmux remains unverified for OMP worker dispatch.
-On Herdr, OMP's installed lifecycle registration persists as idle after `/exit`, so Firstmate proves the exact pane has returned to one lone idle shell rather than treating that idle registration itself as exit proof.
+On Herdr, OMP's installed lifecycle registration persists as idle after `/exit`, so Firstmate proves the pane holds one recognized idle foreground shell with no `omp` process left beneath it rather than treating that idle registration itself as exit proof.
+The same pane-process proof licenses a deterministic `relaunch` into the stopped endpoint; without it the stale registration would read as a live agent forever.
 `../../../bin/fm-spawn.sh` refuses OMP secondmates before endpoint creation because no primary supervision protocol was verified.
 OMP primary integration is unsupported for the same reason, so `fm-session-lock-lib.sh`, `fm-wake-lib.sh`, and the primary-hook surface have no OMP branch.

--- a/.agents/skills/harness-adapters/references/harness/omp.md
+++ b/.agents/skills/harness-adapters/references/harness/omp.md
@@ -1,0 +1,34 @@
+# OMP
+
+Verified on 2026-08-30 with `omp/18.0.11`.
+OMP is a 186 MB compiled binary, distinct from the Node-bundled Pi executable.
+Its help advertises `PI_SMOL_MODEL`, `PI_SLOW_MODEL`, and `PI_PLAN_MODEL`, and its installed Herdr integration uses the Pi-shaped extension API, so the shared lifecycle lineage is evidenced without treating the programs as identical.
+
+## Operating facts
+
+| Fact | Value |
+| --- | --- |
+| Launch | One positional launch brief, `--auto-approve`, and a per-task `-e` extension outside the worktree. |
+| Busy state | The per-task extension marks `agent_start` busy and normally debounces `agent_end` to idle. Retryable provider-error ends remain busy for OMP's observed retry grace and then become unknown if no retry starts. Unlike Pi, OMP exposes `agent_end`, not `agent_settled`. Herdr's installed OMP integration independently reports native pane state. |
+| Turn end | OMP's `turn_end` event touches `state/<id>.turn-ended`; this is a watcher notification, not current-state truth. |
+| Exit | `/exit`, one Enter; observed output was `Closing session…` and `Resume this session with omp --resume <id>`. |
+| Interrupt | Single Escape; an active Bash tool call visibly changed to `Command aborted` and returned to the `❯` composer. No interrupt acknowledgement is credited, so control reports `cancel=unconfirmed`. |
+| Model | `--model=<model>`; discover configured models with `omp models --json`. The observed default store listed `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp`, and `deepseek-v4-pro`. |
+| Effort | `--thinking=<low\|medium\|high\|xhigh\|max>`. OMP also advertises `off`, `minimal`, and `auto`, which are outside Firstmate's shared effort axis. `max` is passed only for an explicit choice and is never selected by the fallback. |
+| Trust | A normal configured-profile launch in a clean worktree showed no project trust dialog. A blank isolated profile instead opened provider onboarding despite `--auto-approve`, so a fresh unauthenticated profile cannot carry a worker. |
+| Detection | `FM_OMP_HARNESS=omp` wins before the shared `PI_CODING_AGENT` marker; otherwise exact `omp` ancestry identifies the binary. |
+| Composer | The observed busy footer was a braille spinner followed by elapsed time, for example `⠹ 3s`; this is delivery-only confirmation, never a worker-state source. |
+
+OMP accepts `--approval-mode=always-ask|write|yolo`, `--cwd`, `--add-dir`, `--profile`, `--skills` or `--no-skills`, `--max-time`, and `--mode=text|json|rpc|rpc-ui` in its help.
+Firstmate uses only `--auto-approve` for unattended worker autonomy.
+
+## Resume and task kinds
+
+OMP's native `--resume <id>` form was observed at exit, but there is no verified Firstmate pane-resume contract.
+Use deterministic `relaunch` from the durable brief instead.
+
+OMP is verified for crewmate and scout workers on Herdr.
+The tmux process-name branch has portable coverage but no supervised OMP tmux launch in this audit, so tmux remains unverified for OMP worker dispatch.
+On Herdr, OMP's installed lifecycle registration persists as idle after `/exit`, so Firstmate proves the exact pane has returned to one lone idle shell rather than treating that idle registration itself as exit proof.
+`../../../bin/fm-spawn.sh` refuses OMP secondmates before endpoint creation because no primary supervision protocol was verified.
+OMP primary integration is unsupported for the same reason, so `fm-session-lock-lib.sh`, `fm-wake-lib.sh`, and the primary-hook surface have no OMP branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ projects/            cloned repos; gitignored; read-only except under hard rule 
 state/               runtime records and signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
+  <id>.omp-ext.ts    Firstmate-owned OMP semantic busy-state, Herdr registration, and turn-end extension; removed by teardown
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
   <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
   <id>.muse-session  muse busy-source binding (sessions root plus task worktree) written by fm-spawn; removed by teardown
@@ -194,7 +195,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `cursor`, plus `muse` for crewmates and scouts only; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `cursor`, plus `muse` and `omp` for crewmates and scouts only; never dispatch on an unverified adapter.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1250,6 +1250,100 @@ fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
   printf '%s\n' "$shell_pid"
 }
 
+# fm_backend_herdr_pane_omp_exit_proof: print the foreground shell pid of
+# <pane-id> only when the exact pane's SOLE foreground process is one
+# recognized idle shell and no omp process remains anywhere beneath the pane
+# shell. This is the OMP-on-Herdr exit postcondition.
+#
+# OMP's installed Herdr integration keeps an idle agent registration after
+# `/exit`, so the agent-state classifier stays live and exit must prove the
+# process truth instead. The pane shell's own pid is deliberately NOT required
+# to be the foreground process: the spawn owner always places the worker
+# inside a `treehouse get` subshell, so the worktree shell - a second
+# recognized shell under the treehouse CLI - is the real foreground, and the
+# strict lone-pane-shell proof can never hold in that launch shape.
+#
+# The descendant scan over the pane shell's process tree is what keeps a
+# lingering background omp from passing: while OMP holds the TTY its own
+# process is a pane-shell descendant, so the scan refuses; after `/exit` the
+# foreground is the worktree shell and the scan finds no omp row.
+# Retries strict single samples for a bounded settle window like the shared
+# idle-shell proof, for the same prompt-redraw transient.
+fm_backend_herdr_pane_omp_exit_proof() {  # <session> <pane-id>
+  local attempt=0 max_attempts=${FM_BACKEND_HERDR_OMP_EXIT_PROOF_POLLS:-10}
+  while :; do
+    if fm_backend_herdr_pane_omp_exit_sample "$1" "$2"; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    [ "$attempt" -lt "$max_attempts" ] || return 1
+    sleep 0.1
+  done
+}
+
+# fm_backend_herdr_pane_omp_exit_sample: one strict instantaneous observation
+# for fm_backend_herdr_pane_omp_exit_proof, which owns the proof contract.
+fm_backend_herdr_pane_omp_exit_sample() {  # <session> <pane-id>
+  local session=$1 pane=$2 info shell_pid foreground_pgid count pid name argv0
+  local shell_name rows ps_bin stat
+  info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null) || return 1
+  printf '%s' "$info" | jq -e --arg pane "$pane" '
+    .result.type == "pane_process_info"
+    and .result.process_info.pane_id == $pane
+  ' >/dev/null 2>&1 || return 1
+  shell_pid=$(printf '%s' "$info" | jq -er \
+    '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
+  foreground_pgid=$(printf '%s' "$info" | jq -er \
+    '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
+  count=$(printf '%s' "$info" | jq -er \
+    '.result.process_info.foreground_processes | select(type == "array") | length' 2>/dev/null) || return 1
+  [ "$count" -eq 1 ] || return 1
+  pid=$(printf '%s' "$info" | jq -er \
+    '.result.process_info.foreground_processes[0].pid | select(type == "number") | floor' 2>/dev/null) || return 1
+  [ "$pid" = "$foreground_pgid" ] || return 1
+  name=$(printf '%s' "$info" | jq -er \
+    '.result.process_info.foreground_processes[0].name | select(type == "string" and length > 0)' 2>/dev/null) || return 1
+  argv0=$(printf '%s' "$info" | jq -er '
+    .result.process_info.foreground_processes[0] as $process
+    | ($process.argv0 // $process.argv[0])
+    | select(type == "string" and length > 0)
+  ' 2>/dev/null) || return 1
+  shell_name=${name##*/}
+  argv0=${argv0#-}
+  argv0=${argv0##*/}
+  [ "$argv0" = "$shell_name" ] || return 1
+  case "$shell_name" in sh|bash|zsh|dash|ksh|fish) ;; *) return 1 ;; esac
+
+  ps_bin=${FM_HERDR_PS_BIN:-ps}
+  command -v "$ps_bin" >/dev/null 2>&1 || return 1
+  rows=$("$ps_bin" -axo pid=,ppid=,comm= 2>/dev/null) || return 1
+  printf '%s\n' "$rows" | awk -v shell="$shell_pid" '
+    function basename(s) { n = s; sub(/^.*\//, "", n); return n }
+    BEGIN { stack[shell] = 1 }
+    { pids[$1] = basename($3); parents[$1] = $2 }
+    END {
+      changed = 1
+      while (changed) {
+        changed = 0
+        for (p in pids) {
+          if ((parents[p] in stack) && !(p in stack)) { stack[p] = 1; changed = 1 }
+        }
+      }
+      for (p in stack) {
+        if (pids[p] ~ /^omp(-|$)/) { exit 1 }
+      }
+      exit 0
+    }
+  ' || return 1
+  printf '%s\n' "$rows" | awk -v shell="$pid" '
+    $1 == shell { found++ }
+    END { exit(found == 1 ? 0 : 1) }
+  ' || return 1
+  stat=$("$ps_bin" -p "$pid" -o stat= 2>/dev/null | tr -d '[:space:]') || return 1
+  case "$stat" in S*|I*) ;; *) return 1 ;; esac
+  printf '%s\n' "$pid"
+}
+
 # fm_backend_herdr_projection_order_best_effort: place the exact workspace id
 # returned by THIS projected create immediately after its owning parent's
 # contiguous child block and before the next parent.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -170,7 +170,7 @@ fm_backend_tmux_classify_process_name() {  # <path> [argv0] -> agent|shell|other
     # cannot carry it either: ~/.local/bin/muse-bin-<version> has no `muse` path
     # COMPONENT, so the fm_harness_path_name fallback below never fires for it.
     muse|muse-bin-*) printf 'agent' ;;
-    *claude*|*codex*|*opencode*|*grok*|*kimi*|pi|pi-signed|pi-launcher|Pi) printf 'agent' ;;
+    *claude*|*codex*|*opencode*|*grok*|*kimi*|omp|pi|pi-signed|pi-launcher|Pi) printf 'agent' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'shell' ;;
     *)
       if fm_harness_path_name "$path" >/dev/null || fm_harness_path_name "$argv0" >/dev/null; then

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -786,7 +786,7 @@ secondmate_liveness_one() {  # <meta> <id>
   [ -n "$target" ] || target="$window"
   agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null) || agent_state=unreadable
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi|omp) ;;
     *)
       case "$agent_state" in dead|missing) agent_state=unverified-harness ;; esac
       ;;
@@ -1098,14 +1098,14 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","cursor","muse"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","cursor","muse","omp"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
-      elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "pi" or $h == "pi-signed" or $h == "omp" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" or $h == "kimi" or $h == "cursor" then false
       else true

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -192,6 +192,7 @@ fm_busy_sources_for_harness() {  # <harness>
       ;;
     opencode*) adapter=opencode-plugin ;;
     pi|pi-signed) adapter=pi-ext ;;
+    omp) adapter=omp-ext ;;
     kimi*)
       fm_busy_kimi_verified || { printf ''; return 0; }
       adapter='kimi-wire kimi-hook'

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -316,6 +316,7 @@ FM_DELIVERY_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[
 FM_DELIVERY_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_DELIVERY_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_DELIVERY_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
+FM_DELIVERY_OMP_BUSY_REGEX_DEFAULT='[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][[:space:]]+[0-9]+[smh]'
 FM_DELIVERY_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
 # cursor-agent's busy footer. The TOKEN is matched, not the spinner verb: the
 # same version rendered both `Working` and `Running` beside its braille spinner
@@ -338,6 +339,7 @@ fm_busy_lines_match() {  # [harness]
       codex) regex=$FM_DELIVERY_CODEX_BUSY_REGEX_DEFAULT ;;
       opencode) regex=$FM_DELIVERY_OPENCODE_BUSY_REGEX_DEFAULT ;;
       pi|pi-signed) regex=$FM_DELIVERY_PI_BUSY_REGEX_DEFAULT ;;
+      omp) regex=$FM_DELIVERY_OMP_BUSY_REGEX_DEFAULT ;;
       grok) regex=$FM_DELIVERY_GROK_BUSY_REGEX_DEFAULT ;;
       kimi) regex=$FM_DELIVERY_KIMI_BUSY_REGEX_DEFAULT ;;
       cursor) regex=$FM_DELIVERY_CURSOR_BUSY_REGEX_DEFAULT ;;

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -167,10 +167,10 @@ fm_control_exit_command() {  # <harness>
 }
 
 # Whether an adapter retains a stale Herdr agent registration after its process
-# exits, requiring the backend's strict lone-idle-shell proof as the exit
-# postcondition. This is deliberately a closed empirical table, never a
-# fallback for an unknown or merely idle registered agent.
-fm_control_exit_uses_herdr_idle_shell_proof() {  # <harness> <backend>
+# exits, requiring the backend's pane-process exit proof as the postcondition.
+# This is deliberately a closed empirical table, never a fallback for an
+# unknown or merely idle registered agent.
+fm_control_exit_uses_herdr_pane_exit_proof() {  # <harness> <backend>
   [ "${1-}" = omp ] && [ "${2-}" = herdr ]
 }
 

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -63,7 +63,7 @@ fm_control_verb_allowed() {  # <verb>
 # than guessed at, exactly as a spawn on it would be.
 fm_control_harness_supported() {  # <harness>
   case "${1-}" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse) return 0 ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse|omp) return 0 ;;
   esac
   return 1
 }
@@ -80,6 +80,7 @@ fm_control_harness_family() {  # <recorded-harness>
   case "${1-}" in
     pi) printf 'pi' ;;
     pi-signed) printf 'pi-signed' ;;
+    omp) printf 'omp' ;;
     claude*) printf 'claude' ;;
     codex*) printf 'codex' ;;
     opencode*) printf 'opencode' ;;
@@ -101,7 +102,7 @@ fm_control_harness_supports_kind() {  # <harness> <kind>
   local harness=${1-} kind=${2-}
   fm_control_harness_supported "$harness" || return 1
   case "$harness" in
-    muse) [ "$kind" != secondmate ] || return 1 ;;
+    muse|omp) [ "$kind" != secondmate ] || return 1 ;;
   esac
   return 0
 }
@@ -110,7 +111,7 @@ fm_control_harness_supports_kind() {  # <harness> <kind>
 # whose Esc only moves focus to the scrollback; grok cancels on Ctrl+C.
 fm_control_interrupt_key() {  # <harness>
   case "${1-}" in
-    claude|codex|opencode|pi|pi-signed|kimi|cursor|muse) printf 'Escape' ;;
+    claude|codex|opencode|pi|pi-signed|kimi|cursor|muse|omp) printf 'Escape' ;;
     grok) printf 'C-c' ;;
     *) return 1 ;;
   esac
@@ -121,7 +122,7 @@ fm_control_interrupt_key() {  # <harness>
 fm_control_interrupt_repeat() {  # <harness>
   case "${1-}" in
     opencode) printf '2' ;;
-    claude|codex|pi|pi-signed|grok|kimi|cursor|muse) printf '1' ;;
+    claude|codex|pi|pi-signed|grok|kimi|cursor|muse|omp) printf '1' ;;
     *) return 1 ;;
   esac
 }
@@ -139,7 +140,7 @@ fm_control_interrupt_repeat() {  # <harness>
 fm_control_interrupt_clear_key() {  # <harness>
   case "${1-}" in
     muse) printf 'C-u' ;;
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor) ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|omp) ;;
     *) return 1 ;;
   esac
 }
@@ -151,7 +152,7 @@ fm_control_interrupt_ack_source() {  # <harness>
     # after an interrupt was measured as variable - sometimes seconds, sometimes
     # not within 20 - so a cancellation claim built on it would be unreliable.
     # Normal turn completion is prompt, which is what the busy fold depends on.
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor) printf 'none' ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|omp) printf 'none' ;;
     *) return 1 ;;
   esac
 }
@@ -159,10 +160,18 @@ fm_control_interrupt_ack_source() {  # <harness>
 # The command that exits the agent from its own composer.
 fm_control_exit_command() {  # <harness>
   case "${1-}" in
-    claude|opencode|grok|kimi|cursor|muse) printf '/exit' ;;
+    claude|opencode|grok|kimi|cursor|muse|omp) printf '/exit' ;;
     codex|pi|pi-signed) printf '/quit' ;;
     *) return 1 ;;
   esac
+}
+
+# Whether an adapter retains a stale Herdr agent registration after its process
+# exits, requiring the backend's strict lone-idle-shell proof as the exit
+# postcondition. This is deliberately a closed empirical table, never a
+# fallback for an unknown or merely idle registered agent.
+fm_control_exit_uses_herdr_idle_shell_proof() {  # <harness> <backend>
+  [ "${1-}" = omp ] && [ "${2-}" = herdr ]
 }
 
 # Which named keys a backend adapter can deliver. Every session provider
@@ -207,6 +216,7 @@ fm_control_harness_wiring_paths() {  # <harness> <worktree> <state-dir> <id>
     claude) printf '%s\n' "$wt/.claude/settings.local.json" ;;
     opencode) printf '%s\n' "$wt/.opencode/plugins/fm-busy-state.js" ;;
     pi|pi-signed) printf '%s\n' "$state/$id.pi-ext.ts" ;;
+    omp) printf '%s\n' "$state/$id.omp-ext.ts" ;;
     grok)
       printf '%s\n' "$wt/.fm-grok-turnend"
       printf '%s\n' "$state/$id.grok-turnend-token"

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -30,6 +30,8 @@
 #              every uncommitted change. Interrupts first when the task reads
 #              busy, then submits the harness's exit command. Postcondition:
 #              the backend's recovery-grade classifier reports the agent gone.
+#              OMP on Herdr instead proves the exact pane returned to one lone
+#              idle shell because its installed Herdr registration persists.
 #              Already-stopped is success (idempotent).
 #   relaunch   Transactionally replace the running agent with a new one, in the
 #              SAME endpoint and SAME worktree, on the same or a newly chosen
@@ -342,6 +344,34 @@ wait_agent_state() {  # <timeout> <wanted>...
   return 1
 }
 
+# wait_exit_postcondition: accept only the normal dead-agent transition, plus
+# OMP's verified Herdr exception. OMP's installed Herdr integration leaves an
+# idle registration after `/exit`, so the exact pane must instead prove one lone
+# idle shell. This cannot generalize from harness=omp or backend=herdr alone:
+# fm-control-lib.sh owns the closed empirical pair.
+wait_exit_postcondition() {  # <timeout> -> dead|shell (success), final state (failure)
+  local timeout=$1 state elapsed=0
+  while :; do
+    state=$(agent_state)
+    if [ "$state" = dead ]; then
+      printf 'dead'
+      return 0
+    fi
+    if fm_control_exit_uses_herdr_idle_shell_proof "$HARNESS" "$BACKEND"; then
+      if fm_backend_herdr_parse_target "$T" \
+        && fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE" >/dev/null; then
+        printf 'shell'
+        return 0
+      fi
+    fi
+    awk -v e="$elapsed" -v t="$timeout" 'BEGIN{exit !(e < t)}' || break
+    sleep "$POLL"
+    elapsed=$(awk -v e="$elapsed" -v p="$POLL" 'BEGIN{printf "%.3f", e + p}')
+  done
+  printf '%s' "$state"
+  return 1
+}
+
 require_state_verified_backend() {  # <verb>
   fm_control_backend_state_verified "$BACKEND" && return 0
   die "task $ID runs on the $BACKEND backend, which has no recovery-grade agent-state classifier, so '$1' cannot prove the agent actually stopped; refusing rather than reporting an unproven transition as done"
@@ -485,7 +515,7 @@ do_exit() {
     || die "the exit command could not be sent to task $ID on $BACKEND"
   [ "$verdict" != send-failed ] \
     || die "the exit command could not be sent to task $ID on $BACKEND"
-  state=$(wait_agent_state "$EXIT_WAIT" dead) || {
+  state=$(wait_exit_postcondition "$EXIT_WAIT") || {
     die "exit-delivered $ID interrupt=$interrupt_result exit-command=delivered agent-state=$state exit=unconfirmed; the agent did not stop within ${EXIT_WAIT}s"
   }
   # The incarnation is over: retire its busy wiring so no stale record or

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -30,8 +30,9 @@
 #              every uncommitted change. Interrupts first when the task reads
 #              busy, then submits the harness's exit command. Postcondition:
 #              the backend's recovery-grade classifier reports the agent gone.
-#              OMP on Herdr instead proves the exact pane returned to one lone
-#              idle shell because its installed Herdr registration persists.
+#              OMP on Herdr instead proves the pane holds one recognized idle
+#              foreground shell with no omp process beneath it, because its
+#              installed Herdr registration persists.
 #              Already-stopped is success (idempotent).
 #   relaunch   Transactionally replace the running agent with a new one, in the
 #              SAME endpoint and SAME worktree, on the same or a newly chosen
@@ -346,8 +347,9 @@ wait_agent_state() {  # <timeout> <wanted>...
 
 # wait_exit_postcondition: accept only the normal dead-agent transition, plus
 # OMP's verified Herdr exception. OMP's installed Herdr integration leaves an
-# idle registration after `/exit`, so the exact pane must instead prove one lone
-# idle shell. This cannot generalize from harness=omp or backend=herdr alone:
+# idle registration after `/exit`, so the exact pane must instead prove one
+# recognized idle foreground shell with no omp process left beneath it. This
+# cannot generalize from harness=omp or backend=herdr alone:
 # fm-control-lib.sh owns the closed empirical pair.
 wait_exit_postcondition() {  # <timeout> -> dead|shell (success), final state (failure)
   local timeout=$1 state elapsed=0
@@ -357,9 +359,13 @@ wait_exit_postcondition() {  # <timeout> -> dead|shell (success), final state (f
       printf 'dead'
       return 0
     fi
-    if fm_control_exit_uses_herdr_idle_shell_proof "$HARNESS" "$BACKEND"; then
+    if fm_control_exit_uses_herdr_pane_exit_proof "$HARNESS" "$BACKEND"; then
+      # agent_state and the send-verdict run in command-substitution subshells,
+      # so the backend file was sourced only in those children; source it here
+      # in the current shell before calling its helpers directly.
+      fm_backend_source "$BACKEND" || return 1
       if fm_backend_herdr_parse_target "$T" \
-        && fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE" >/dev/null; then
+        && fm_backend_herdr_pane_omp_exit_proof "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE" >/dev/null; then
         printf 'shell'
         return 0
       fi

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse|omp|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -50,6 +50,9 @@ detect_own() {
   # CURSOR_AGENT=1 is set for the child/tool processes this script runs as.
   [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
   [ "${CURSOR_INVOKED_AS:-}" = "cursor-agent" ] && { echo cursor; return; }
+  # OMP shares Pi environment names, so its launch marker must win before the
+  # PI_CODING_AGENT branch below can classify it as Pi.
+  [ "${FM_OMP_HARNESS:-}" = "omp" ] && { echo omp; return; }
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   if [ "${PI_CODING_AGENT:-}" = "true" ]; then
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
@@ -87,6 +90,7 @@ detect_own() {
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
       kimi) echo kimi; return ;;
+      omp) echo omp; return ;;
       # muse's installed launcher ~/.local/bin/muse execs ~/.local/bin/muse-bin-<version>
       # (verified in the published launcher, muse 0.1.0-R708.1), so the live process
       # name carries the version and CHANGES on every auto-update. Match the stable

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -104,10 +104,10 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse|omp)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
-#   new adapters. For pi and pi-signed, fm-spawn resolves the selected executable
+#   new adapters. For pi, pi-signed, and omp, fm-spawn resolves the selected executable
 #   name from PATH once, probes that concrete path with --help, and launches the
 #   same path. It adds --tui-mode regular only when that help advertises the flag;
 #   a failed or inconclusive probe omits it so older Pi versions remain launchable.
@@ -161,6 +161,8 @@
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
 #     __PIBIN__    quoted concrete Pi-family executable path resolved from PATH
 #     __PITUIMODE__ optional --tui-mode regular when that executable advertises it
+#     __OMPBIN__   quoted concrete OMP executable path resolved from PATH
+#     __OMPEXT__   absolute path to state/<task-id>.omp-ext.ts (OMP worker extension)
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
 #                  turn-end signal rides the launch command, e.g. codex -c notify=[...])
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
@@ -483,6 +485,12 @@ spawn_remote_secondmate() {
   fi
   case "$harness" in
     claude|codex|opencode|pi|pi-signed|grok|kimi|cursor) ;;
+    omp)
+      fm_lock_release "$registry_lock" || true
+      fm_lock_release "$SPAWN_TASK_LOCK" || true
+      echo "error: omp is a verified crewmate/scout adapter only and cannot run a secondmate; it has no primary supervision protocol. Select a harness verified for secondmates." >&2
+      return 1
+      ;;
     *)
       fm_lock_release "$registry_lock" || true
       fm_lock_release "$SPAWN_TASK_LOCK" || true
@@ -1166,7 +1174,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   }
 elif [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse)
+    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse|omp)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -1205,6 +1213,10 @@ resolve_pi_executable() {
       printf '%s/%s\n' "$dir" "$(basename "$candidate")"
       ;;
   esac
+}
+
+resolve_omp_executable() {
+  resolve_pi_executable omp
 }
 
 # Pi's CLI surface is version-dependent, so probe the resolved executable's help
@@ -1248,6 +1260,7 @@ launch_template() {
         printf '%s' ' __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
+    omp) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS FM_OMP_HARNESS=omp __OMPBIN__ --auto-approve __MODELFLAG____EFFORTFLAG__-e __OMPEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
     # session. --always-approve auto-approves every tool execution (verified: the
     # crewmate runs fully autonomously, no permission gate), which an unattended
@@ -1336,15 +1349,17 @@ case "$ARG3" in
     ;;
 esac
 
-# muse is verified as a CREWMATE/SCOUT adapter only. A secondmate is a firstmate
-# instance, so it needs a primary supervision protocol; muse has none, and its
-# Claude-compatible hook dialect explicitly rejects the model-reawakening and
-# asyncRewake handlers that firstmate's primary turn-end supervision is built on
-# (muse 0.1.0-R708.1). Refusing here keeps that gap loud instead of standing up a
-# secondmate whose supervision cycle could never be armed.
-if [ "$KIND" = secondmate ] && [ "$HARNESS" = muse ]; then
-  echo "error: muse is a verified crewmate/scout adapter only and cannot run a secondmate; it has no primary supervision protocol. Select a harness verified for secondmates." >&2
-  exit 1
+# muse and omp are verified as CREWMATE/SCOUT adapters only. A secondmate is a
+# firstmate instance, so it needs a primary supervision protocol. Refusing here
+# keeps that gap loud instead of standing up a secondmate whose supervision cycle
+# could never be armed.
+if [ "$KIND" = secondmate ]; then
+  case "$HARNESS" in
+    muse|omp)
+      echo "error: $HARNESS is a verified crewmate/scout adapter only and cannot run a secondmate; it has no primary supervision protocol. Select a harness verified for secondmates." >&2
+      exit 1
+      ;;
+  esac
 fi
 
 case "$HARNESS" in
@@ -1359,6 +1374,12 @@ case "$HARNESS" in
     fi
     LAUNCH=${LAUNCH//__PITUIMODE__/$PI_TUI_MODE}
     LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH"
+    ;;
+  omp)
+    OMP_BIN=$(resolve_omp_executable) || {
+      echo "error: omp executable not found on PATH; install it or select a different verified harness" >&2
+      exit 1
+    }
     ;;
   cursor)
     # `cursor` is not the CLI name, and the legacy alias `agent` is far too
@@ -1484,6 +1505,9 @@ model_flag_for_harness() {
     claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
+    omp)
+      printf -- '--model=%s ' "$(shell_quote "$model")"
+      ;;
   esac
 }
 
@@ -1514,10 +1538,17 @@ effort_flag_for_harness() {
       esac
       ;;
     pi|pi-signed)
-      # Pi 0.80.6 accepts the full shared effort vocabulary, including max, through
-      # its --thinking flag.
+      # Pi accepts the full shared effort vocabulary, including max, through its
+      # --thinking flag. The fallback policy never selects max.
       case "$effort" in
         low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
+      esac
+      ;;
+    omp)
+      # OMP advertises --thinking=<value> and accepts the full shared effort
+      # vocabulary, including max. The fallback policy never selects max.
+      case "$effort" in
+        low|medium|high|xhigh|max) printf -- '--thinking=%s ' "$(shell_quote "$effort")" ;;
       esac
       ;;
     muse)
@@ -2528,7 +2559,7 @@ if [ "$KIND" != secondmate ]; then
       ;;
   esac
   case "$HARNESS" in
-    claude*|opencode*|pi|pi-signed)
+    claude*|opencode*|pi|pi-signed|omp)
       BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
         echo "error: failed to arm the busy-state contract for $ID" >&2
         exit 1
@@ -2650,6 +2681,87 @@ export default function (pi: any) {
   pi.on("agent_settled", (_event: any, ctx: any) => {
     if (ctx && typeof ctx.isIdle === "function" && !ctx.isIdle()) return;
     return busyEvent("idle", "agent-settled");
+  });
+  pi.on("turn_end", () => execFile("touch", ["$TURNEND"]));
+}
+EOF
+      ;;
+    omp)
+      # OMP's extension lifecycle matches Pi's shape but not its settled event:
+      # OMP emits agent_start and agent_end. The per-task extension lives outside
+      # the worktree so no project-trust decision is needed. Its semantic state
+      # goes through the Firstmate busy contract. Herdr's installed OMP
+      # integration separately owns native pane registration and status.
+      cat > "$STATE/$ID.omp-ext.ts" <<EOF
+// Firstmate semantic busy-state events + turn-end notification; written by
+// fm-spawn under the contract owned by bin/fm-busy-lib.sh.
+// OMP emits "agent_start" when a low-level run begins and "agent_end" when it
+// ends. A short debounce lets a following agent_start retain busy. Retryable
+// end events stay busy through OMP's retry grace and become unknown if no retry
+// starts, rather than falsely claiming idle. Herdr's installed OMP integration
+// owns its independent native pane registration.
+import { execFile } from "node:child_process";
+const busyEvent = (state: string, event: string) =>
+  new Promise<void>((resolve) => {
+    execFile("$FM_ROOT/bin/fm-busy-event.sh", [
+      "apply", "$STATE_REAL", "$ID", state,
+      "--gen", "$BUSY_GEN", "--source", "omp-ext", "--event", event,
+    ], () => resolve());
+  });
+const idleDebounceMs = Number.parseInt(process.env.FM_OMP_IDLE_DEBOUNCE_MS || "250", 10);
+const retryGraceMs = Number.parseInt(process.env.FM_OMP_RETRY_GRACE_MS || "2500", 10);
+const retryableErrorPattern =
+  /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
+const retryableError = (event: any) => {
+  const messages = Array.isArray(event?.messages) ? event.messages : [];
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "assistant") continue;
+    return message.stopReason === "error"
+      && retryableErrorPattern.test(String(message.errorMessage ?? ""));
+  }
+  return false;
+};
+export default function (pi: any) {
+  let rootSession = false;
+  let agentActive = false;
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+  const clearTimers = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    if (retryTimer) clearTimeout(retryTimer);
+    idleTimer = undefined;
+    retryTimer = undefined;
+  };
+  const rootUI = (ctx: any) => {
+    if (ctx && ctx.hasUI === true) rootSession = true;
+    return rootSession;
+  };
+  pi.on("session_start", (_event: any, ctx: any) => { rootUI(ctx); });
+  pi.on("agent_start", (_event: any, ctx: any) => {
+    if (!rootUI(ctx)) return;
+    clearTimers();
+    agentActive = true;
+    return busyEvent("busy", "agent-start");
+  });
+  pi.on("agent_end", (event: any) => {
+    if (!rootSession || !agentActive) return;
+    agentActive = false;
+    if (retryableError(event)) {
+      clearTimers();
+      retryTimer = setTimeout(() => {
+        retryTimer = undefined;
+        if (!agentActive) void busyEvent("unknown", "agent-end-retry-grace-expired");
+      }, Number.isFinite(retryGraceMs) && retryGraceMs >= 0 ? retryGraceMs : 2500);
+      retryTimer.unref?.();
+      return;
+    }
+    idleTimer = setTimeout(() => {
+      idleTimer = undefined;
+      if (agentActive) return;
+      void busyEvent("idle", "agent-end");
+    }, Number.isFinite(idleDebounceMs) && idleDebounceMs >= 0 ? idleDebounceMs : 250);
+    idleTimer.unref?.();
   });
   pi.on("turn_end", () => execFile("touch", ["$TURNEND"]));
 }
@@ -2951,6 +3063,7 @@ fi
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
+sq_ompext=$(shell_quote "$STATE/$ID.omp-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
@@ -2962,16 +3075,18 @@ LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
+LAUNCH=${LAUNCH//__OMPEXT__/$sq_ompext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 case "$HARNESS" in
   pi|pi-signed) LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"} ;;
+  omp) LAUNCH=${LAUNCH//__OMPBIN__/"$(shell_quote "$OMP_BIN")"} ;;
   cursor) LAUNCH=${LAUNCH//__CURSORBIN__/"$(shell_quote "$CURSOR_BIN")"} ;;
 esac
 LAUNCH=${LAUNCH//__WORKTREE__/$sq_worktree}
 case "$HARNESS" in
-  claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
+  claude|codex|opencode|pi|pi-signed|grok|kimi|muse|omp)
     LAUNCH="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS $LAUNCH"
     ;;
 esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1130,12 +1130,25 @@ if [ "$RELAUNCH" -eq 1 ]; then
     echo "error: backend '$BACKEND' has no recovery-grade agent-state classifier, so a relaunch cannot prove the previous agent exited; refusing rather than risking two agents in one endpoint" >&2
     exit 1
   }
+  RELAUNCH_PRIOR_HARNESS=$(fm_meta_get "$RELAUNCH_META" harness)
   RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
-  [ "$RELAUNCH_STATE" = dead ] || {
+  RELAUNCH_AGENT_FREE=0
+  if [ "$RELAUNCH_STATE" = dead ]; then
+    RELAUNCH_AGENT_FREE=1
+  elif fm_control_exit_uses_herdr_pane_exit_proof "$RELAUNCH_PRIOR_HARNESS" "$BACKEND"; then
+    # OMP's installed Herdr integration keeps an idle agent registration after
+    # /exit, so agent_state stays live forever; the same pane-process exit
+    # proof fm-control.sh accepts must license the relaunch here, or the
+    # recommended deterministic-relaunch path could never launch a replacement.
+    if fm_backend_herdr_parse_target "$RELAUNCH_TARGET" \
+      && fm_backend_herdr_pane_omp_exit_proof "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE" >/dev/null; then
+      RELAUNCH_AGENT_FREE=1
+    fi
+  fi
+  [ "$RELAUNCH_AGENT_FREE" -eq 1 ] || {
     echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
     exit 1
   }
-  RELAUNCH_PRIOR_HARNESS=$(fm_meta_get "$RELAUNCH_META" harness)
   KIND=$(fm_meta_get "$RELAUNCH_META" kind)
   [ -n "$KIND" ] || KIND=ship
   MODE=$(fm_meta_get "$RELAUNCH_META" mode)

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -31,7 +31,7 @@ A recorded `harness=` is not always an exact adapter name: a task launched from 
 | Verb | Effect | Postcondition |
 | --- | --- | --- |
 | `interrupt` | Deliver the harness's verified interrupt sequence while leaving the agent running. | Delivery succeeds while the endpoint still exists and the agent is still alive where the backend can classify that; cancellation is confirmed only from an adapter-owned acknowledgement and otherwise reports `cancel=unconfirmed`. |
-| `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone, except OMP on Herdr proves the exact pane returned to one lone idle shell because its installed registration persists. Already-stopped is idempotent success. |
+| `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone, except OMP on Herdr proves the pane holds one recognized idle foreground shell with no omp process left beneath it because its installed registration persists. Already-stopped is idempotent success. |
 | `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, and effort. | The new agent is alive on the recorded endpoint, and the durable record names the harness that is actually running. |
 
 An exit that delivers lifecycle input but cannot prove the agent stopped fails with `exit=unconfirmed`, reports the observed agent state and any interrupt cancellation claim, and never claims that nothing changed.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -31,7 +31,7 @@ A recorded `harness=` is not always an exact adapter name: a task launched from 
 | Verb | Effect | Postcondition |
 | --- | --- | --- |
 | `interrupt` | Deliver the harness's verified interrupt sequence while leaving the agent running. | Delivery succeeds while the endpoint still exists and the agent is still alive where the backend can classify that; cancellation is confirmed only from an adapter-owned acknowledgement and otherwise reports `cancel=unconfirmed`. |
-| `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone. Already-stopped is idempotent success. |
+| `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone, except OMP on Herdr proves the exact pane returned to one lone idle shell because its installed registration persists. Already-stopped is idempotent success. |
 | `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, and effort. | The new agent is alive on the recorded endpoint, and the durable record names the harness that is actually running. |
 
 An exit that delivers lifecycle input but cannot prove the agent stopped fails with `exit=unconfirmed`, reports the observed agent state and any interrupt cancellation claim, and never claims that nothing changed.
@@ -48,7 +48,7 @@ The clear is refused before anything is sent when the recorded backend cannot de
 Removing a worktree, closing an endpoint, or discarding work stays with [`bin/fm-teardown.sh`](../bin/fm-teardown.sh), which owns the landed-work test.
 
 **`resume` is not a verb.**
-It is not deterministic across the verified adapters: codex and grok resume only from a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, and kimi have no verified pane-resume contract.
+It is not deterministic across the verified adapters: codex, grok, and OMP resume only from a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, and kimi have no verified pane-resume contract.
 `relaunch` covers the same need on every adapter, because the brief on disk - not a harness-private session - is the durable instruction.
 
 ## Transactional relaunch
@@ -91,7 +91,7 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
 - An unverified harness is refused rather than guessed at.
 - An implicit relaunch from a prefixed raw-command basename is refused before the agent or durable state is touched because its original launch command cannot be reconstructed.
 - An adapter that is not verified for this task's kind is refused **before** the running agent is stopped, not after.
-  Muse is a crewmate and scout adapter only, so relaunching a secondmate onto it refuses while its agent is still up rather than leaving that secondmate with no agent when the launch owner refuses.
+  Muse and OMP are crewmate and scout adapters only, so relaunching a secondmate onto either refuses while its agent is still up rather than leaving that secondmate with no agent when the launch owner refuses.
 - A backend that cannot deliver the harness's interrupt key, or the composer clear that key needs, is refused rather than sent a different key.
   Orca's terminal API exposes only an interrupt and an Enter, so it can deliver neither Escape nor Ctrl+U.
 - `exit` and `relaunch` require a backend with a recovery-grade agent-state classifier - tmux and herdr - because without one the "the agent stopped" postcondition cannot be proven.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -220,7 +220,7 @@ The session-start bootstrap step keeps valid dispatch configuration silent unles
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, and muse while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, opencode, omp, pi, pi-signed, grok, kimi, cursor, and muse while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -201,6 +201,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/harness-adapters/references/harness/omp.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/harness-adapters/references/harness/opencode.md",
       "audience": "agent-runtime"
     },

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -48,7 +48,7 @@ Verify setup by spawning a small task and confirming its `fm-<id>` window appear
 
 A target-existence check proves only that the pane exists.
 The deeper tmux agent-liveness probe first verifies exact window membership, then reads process names to distinguish a running harness from a bare idle shell.
-It classifies recognized Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, Cursor, and Muse process identities as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
+It classifies recognized Claude, Codex, OpenCode, OMP, Pi, pi-signed, Grok, Kimi, Cursor, and Muse process identities as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
 Only `dead` and `missing` authorize recovery because a false dead result could launch a duplicate agent.
 
 For positive attribution, the probe combines two independent name sources rather than making either one load-bearing.

--- a/docs/trace-context.md
+++ b/docs/trace-context.md
@@ -23,7 +23,7 @@ When enabled, for each spawn Firstmate resolves one W3C `traceparent` carrier fo
 This feature parents no SDK span by itself.
 
 Because the injected carrier and the recorded carrier are the same string, an observer that reads the metadata reconstructs exactly the identity the child received.
-The injection sits at the unconditional pre-launch export site, so it covers ship and scout spawns across `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, `cursor`, and `muse`, plus Secondmate spawns across that same set except the deliberately crewmate-only `muse` adapter.
+The injection sits at the unconditional pre-launch export site, so it covers ship and scout spawns across `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, `cursor`, `muse`, and `omp`, plus Secondmate spawns across that same set except the deliberately crewmate-only `muse` and `omp` adapters.
 This is the same coverage `GOTMPDIR` already has and requires no trace-specific `launch_template()` behavior.
 Ship and scout spawns reach that site on every spawn backend (`tmux`, `herdr`, `zellij`, `orca`, `cmux`); a Secondmate reaches it on every backend that accepts a Secondmate spawn (`tmux`, `herdr`, `zellij`), because `bin/fm-spawn.sh` rejects a Secondmate on `orca` and `cmux`.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -302,6 +302,17 @@ The CLI matrix was checked directly:
 All destructive verification used `bin/fm-herdr-lab.sh` with a non-default `fm-lab-` name and a byte-identical default-session tripwire.
 No ambient `herdr server stop` command is a supported test operation.
 
+### OMP worker adapter
+
+OMP `18.0.11` was verified on 2026-08-30 through a real `fm-spawn.sh` crewmate launch in a guarded non-default Herdr 0.7.3 lab.
+The spawned worker read and completed its one-command brief, printed `OMP_CODE_LIVE_THREE_READY`, and touched the generated `turn_end` marker.
+The generated extension moved Firstmate busy state from `busy omp-ext` to `idle omp-ext` after the normal turn.
+Single Escape during a `sleep 30` Bash tool call produced `Command aborted` and left the OMP composer available; `fm-control.sh` reported `interrupt-delivered ... verified=agent-alive cancel=unconfirmed`.
+`/exit` printed `Closing session…` plus `Resume this session with omp --resume <id>` and returned the pane to its lone shell.
+OMP's installed Herdr integration retained an idle agent registration after exit, so the control plane accepts only that exact lone-idle-shell proof for OMP on Herdr; no other adapter or backend inherits it.
+The direct worker proof covers crewmate and scout dispatch only.
+OMP secondmates and primary integration remain unsupported because no primary supervision or primary-hook protocol was verified.
+
 ### Submit confirmation
 
 Measured 2026-08-19 against Herdr 0.8.0 and Claude Code 2.1.236 in an isolated `fm-lab-` session.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -305,11 +305,16 @@ No ambient `herdr server stop` command is a supported test operation.
 ### OMP worker adapter
 
 OMP `18.0.11` was verified on 2026-08-30 through a real `fm-spawn.sh` crewmate launch in a guarded non-default Herdr 0.7.3 lab.
-The spawned worker read and completed its one-command brief, printed `OMP_CODE_LIVE_THREE_READY`, and touched the generated `turn_end` marker.
+The spawned worker read and completed its one-command brief, printed `OMP_LIVE_READY`, and touched the generated `turn_end` marker.
 The generated extension moved Firstmate busy state from `busy omp-ext` to `idle omp-ext` after the normal turn.
-Single Escape during a `sleep 30` Bash tool call produced `Command aborted` and left the OMP composer available; `fm-control.sh` reported `interrupt-delivered ... verified=agent-alive cancel=unconfirmed`.
-`/exit` printed `Closing session…` plus `Resume this session with omp --resume <id>` and returned the pane to its lone shell.
-OMP's installed Herdr integration retained an idle agent registration after exit, so the control plane accepts only that exact lone-idle-shell proof for OMP on Herdr; no other adapter or backend inherits it.
+Single Escape during a `sleep 45` Bash tool call produced `Command aborted` and left the OMP composer available; `fm-control.sh` reported `interrupt-delivered ... verified=agent-alive cancel=unconfirmed`.
+`/exit` returned the pane to its worktree shell and `fm-control.sh` printed `stopped omp-live-1 harness=omp backend=herdr endpoint=<lab>:w1:p2 worktree=<treehouse worktree>`; a deterministic `relaunch` then printed `relaunched omp-live-1 harness=omp from=omp ... backend=herdr endpoint=<same pane>`.
+
+Two defects surfaced only under this live launch and were fixed in the same pass.
+First, the exit wait loop called herdr helpers directly after `agent_state` and the send-verdict ran in command-substitution subshells, so the backend file was sourced only in those children; `fm-control.sh` now sources the backend in its own shell before the direct calls.
+Second, OMP's installed Herdr integration keeps an idle agent registration after `/exit`, so `agent_state` stays `live` and the original lone-pane-shell exit proof can never hold in the real launch shape: the spawn owner always places the worker inside a `treehouse get` subshell, so the pane's foreground after exit is the worktree shell, never its own pane shell.
+The OMP-on-Herdr exit and relaunch postconditions therefore use a pane-process proof (`fm_backend_herdr_pane_omp_exit_proof`): the pane's sole foreground process is one recognized idle shell and no `omp` process remains anywhere beneath the pane shell.
+The proof refused while the worker ran (foreground `omp`) and passed after `/exit` (foreground `bash`, worktree shell pid).
 The direct worker proof covers crewmate and scout dispatch only.
 OMP secondmates and primary integration remain unsupported because no primary supervision or primary-hook protocol was verified.
 

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -23,7 +23,7 @@ make_spawn_case() {  # <name> <harness> <id>
   home="$case_dir/home"
   proj="$case_dir/project"
   wt="$case_dir/wt"
-  fakebin=$(make_spawn_fakebin "$case_dir/fake" pi opencode claude codex)
+  fakebin=$(make_spawn_fakebin "$case_dir/fake" pi omp opencode claude codex)
   fm_test_spawn_home "$home" "$harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
   fm_test_spawn_brief "$home" "$id"
@@ -145,6 +145,83 @@ test_pi_extension_stale_incarnation_rejected() {
   out=$(classify pi "$id" "$state")
   [ "$out" = "busy fm-spawn" ] || fail "a stale extension event must not change state, got '$out'"
   pass "pi extension events from a superseded incarnation are rejected as stale"
+}
+
+# drive_omp_ext <ext-path> <mode>: OMP's extension API shares Pi's registration
+# shape but emits agent_end rather than agent_settled.
+drive_omp_ext() {
+  EXT_PATH="$1" MODE="$2" FM_OMP_IDLE_DEBOUNCE_MS=10 FM_OMP_RETRY_GRACE_MS=20 \
+    node --input-type=module 2>&1 <<'EOF'
+import { pathToFileURL } from "node:url";
+const mod = await import(pathToFileURL(process.env.EXT_PATH).href);
+const handlers = {};
+mod.default({ on: (name, fn) => { handlers[name] = fn; } });
+const ctx = { hasUI: true };
+await handlers["session_start"]({}, ctx);
+switch (process.env.MODE) {
+  case "agent-start": await handlers["agent_start"]({}, ctx); break;
+  case "agent-end-idle":
+    await handlers["agent_start"]({}, ctx);
+    await handlers["agent_end"]({}, ctx);
+    break;
+  case "end-then-start":
+    await handlers["agent_start"]({}, ctx);
+    await handlers["agent_end"]({}, ctx);
+    await handlers["agent_start"]({}, ctx);
+    break;
+  case "retry-expired":
+    await handlers["agent_start"]({}, ctx);
+    await handlers["agent_end"]({ messages: [{ role: "assistant", stopReason: "error", errorMessage: "HTTP 429 retry delay" }] }, ctx);
+    break;
+  case "turn-end": await handlers["turn_end"]({}, ctx); break;
+  default: throw new Error("unknown mode " + process.env.MODE);
+}
+if (process.env.MODE === "turn-end" || process.env.MODE === "agent-end-idle" || process.env.MODE === "retry-expired") {
+  await new Promise((resolve) => setTimeout(resolve, 200));
+}
+EOF
+}
+
+test_omp_extension_semantic_lifecycle() {
+  local rec id=busy-omp-1 out state ext
+  rec=$(make_spawn_case omp-lifecycle omp "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
+  expect_code 0 $? "omp spawn should succeed: $out"
+  state="$HOME_DIR/state"
+  ext="$state/$id.omp-ext.ts"
+  assert_present "$ext" "omp spawn did not write the per-task extension"
+
+  out=$(classify omp "$id" "$state")
+  [ "$out" = "busy fm-spawn" ] || fail "seed after spawn must be 'busy fm-spawn', got '$out'"
+
+  rm -f "$state/$id.turn-ended"
+  out=$(drive_omp_ext "$ext" turn-end) || fail "turn_end drive failed: $out"
+  [ -f "$state/$id.turn-ended" ] || fail "OMP turn_end no longer touches the notification marker"
+  out=$(classify omp "$id" "$state")
+  [ "$out" = "busy fm-spawn" ] || fail "OMP turn_end must stay a notification, got '$out'"
+
+  out=$(drive_omp_ext "$ext" agent-start) || fail "initial agent_start drive failed: $out"
+  out=$(classify omp "$id" "$state")
+  [ "$out" = "busy omp-ext" ] || fail "agent_start must classify 'busy omp-ext', got '$out'"
+
+  out=$(drive_omp_ext "$ext" agent-end-idle) || fail "agent_end idle drive failed: $out"
+  out=$(classify omp "$id" "$state")
+  [ "$out" = "idle omp-ext" ] || fail "a settled agent_end must classify 'idle omp-ext', got '$out'"
+
+  out=$(drive_omp_ext "$ext" agent-start) || fail "agent_start drive failed: $out"
+  out=$(classify omp "$id" "$state")
+  [ "$out" = "busy omp-ext" ] || fail "agent_start must classify 'busy omp-ext', got '$out'"
+
+  out=$(drive_omp_ext "$ext" end-then-start) || fail "following agent_start drive failed: $out"
+  out=$(classify omp "$id" "$state")
+  [ "$out" = "busy omp-ext" ] || fail "an agent_start inside OMP's idle debounce must stay busy, got '$out'"
+
+  out=$(drive_omp_ext "$ext" retry-expired) || fail "retry expiration drive failed: $out"
+  out=$(classify omp "$id" "$state")
+  [ "$out" = "unknown omp-ext" ] || fail "an expired OMP retry must be unknown, not idle, got '$out'"
+
+  pass "omp extension reports agent_start/agent_end state, preserves retry safety, and keeps turn_end a notification"
 }
 
 # drive_oc_plugin <plugin-path> <events-json-lines...>: load the generated
@@ -315,6 +392,7 @@ test_kimi_and_grok_install_no_unverified_wiring() {
 test_pi_extension_semantic_lifecycle
 test_pi_extension_serializes_settle_before_next_start
 test_pi_extension_stale_incarnation_rejected
+test_omp_extension_semantic_lifecycle
 test_kimi_and_grok_install_no_unverified_wiring
 test_opencode_plugin_semantic_lifecycle
 test_claude_hooks_semantic_lifecycle

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -218,7 +218,7 @@ test_stale_gen_record_unknown() {
 test_missing_record_unknown_not_idle() {
   local state out h
   state=$(new_state_dir missing)
-  for h in claude opencode pi pi-signed; do
+  for h in claude opencode pi pi-signed omp; do
     out=$(fm_busy_classify tmux w1 "$h" t1 "$state")
     [ "$out" = "unknown missing" ] || fail "$h with no record must be 'unknown missing', got '$out'"
   done
@@ -268,6 +268,11 @@ test_source_mismatch_cross_adapter() {
   [ "$out" = "unknown source-mismatch" ] || fail "pi-ext record on a claude task must be untrusted, got '$out'"
   out=$(fm_busy_classify tmux w1 pi t1 "$state")
   [ "$out" = "busy pi-ext" ] || fail "pi-ext record on a pi task must classify, got '$out'"
+  out=$(fm_busy_classify tmux w1 omp t1 "$state")
+  [ "$out" = "unknown source-mismatch" ] || fail "pi-ext record on an OMP task must be untrusted, got '$out'"
+  "$EV" apply "$state" t1 busy --gen "$gen" --source omp-ext --event agent-start
+  out=$(fm_busy_classify tmux w1 omp t1 "$state")
+  [ "$out" = "busy omp-ext" ] || fail "omp-ext record on an OMP task must classify, got '$out'"
   out=$(fm_busy_classify tmux w1 grok t1 "$state")
   [ "$out" = "unknown source-mismatch" ] || fail "grok trusts no semantic source, got '$out'"
   pass "a record is trusted only by the adapter whose source wrote it"
@@ -280,7 +285,7 @@ test_converted_adapters_ignore_footer_text() {
    ■■■■⬝⬝⬝⬝  esc interrupt
 Working...
 Ctrl+c:cancel'
-  for h in claude opencode pi pi-signed; do
+  for h in claude opencode pi pi-signed omp; do
     out=$(fm_busy_classify tmux w1 "$h" t1 "$state" "$tail")
     [ "$out" = "unknown missing" ] || fail "$h must never classify from footer text, got '$out'"
   done

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -661,6 +661,20 @@ test_queued_enter_verdict_does_not_convert_other_states() {
   pass "fm_composer_queued_enter_verdict: only proven pending is converted"
 }
 
+test_omp_busy_footer_is_adapter_scoped() {
+  local busy='⠹ 3s  · 󰪟 DeepSeek V4 Flash' idle='❯'
+  printf '%s' "$busy" | fm_busy_lines_match omp \
+    || fail "the observed OMP braille elapsed footer must acknowledge an OMP delivery"
+  if printf '%s' "$idle" | fm_busy_lines_match omp; then
+    fail "an idle OMP composer must not match OMP's busy footer"
+  fi
+  if printf '%s' "$busy" | fm_busy_lines_match pi; then
+    fail "OMP's busy footer must not be borrowed by Pi's delivery guard"
+  fi
+  pass "fm_busy_lines_match: OMP's observed elapsed footer is busy only for OMP"
+}
+
 test_queued_enter_verdict_busy_pending_is_empty
 test_queued_enter_verdict_idle_pending_stays_pending
 test_queued_enter_verdict_does_not_convert_other_states
+test_omp_busy_footer_is_adapter_scoped

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -446,18 +446,18 @@ test_state_verified_backends_are_exactly_tmux_and_herdr() {
   pass "fm-control-lib: stop-proving verbs are gated on the backends that really classify agent state"
 }
 
-test_omp_herdr_exit_uses_only_its_verified_idle_shell_proof() {
+test_omp_herdr_exit_uses_only_its_verified_pane_exit_proof() {
   local pair harness backend
-  fm_control_exit_uses_herdr_idle_shell_proof omp herdr \
-    || fail "OMP's stale Herdr registration needs the measured idle-shell exit proof"
+  fm_control_exit_uses_herdr_pane_exit_proof omp herdr \
+    || fail "OMP's stale Herdr registration needs the measured pane-process exit proof"
   for pair in omp:tmux pi:herdr muse:herdr someagent:herdr; do
     harness=${pair%%:*}
     backend=${pair#*:}
-    if fm_control_exit_uses_herdr_idle_shell_proof "$harness" "$backend"; then
+    if fm_control_exit_uses_herdr_pane_exit_proof "$harness" "$backend"; then
       fail "$harness on $backend must not borrow OMP's Herdr exit proof"
     fi
   done
-  pass "fm-control-lib: only OMP on Herdr uses the measured idle-shell exit proof"
+  pass "fm-control-lib: only OMP on Herdr uses the measured pane-process exit proof"
 }
 
 # --- 3. exact-id scoping ----------------------------------------------------
@@ -901,7 +901,7 @@ test_harness_kind_capability
 test_orca_refuses_an_escape_harness_interrupt
 test_unverified_state_backends_refuse_stop_verbs
 test_state_verified_backends_are_exactly_tmux_and_herdr
-test_omp_herdr_exit_uses_only_its_verified_idle_shell_proof
+test_omp_herdr_exit_uses_only_its_verified_pane_exit_proof
 test_window_label_is_refused_with_the_exact_id
 test_explicit_endpoint_is_refused
 test_unknown_task_is_refused

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -35,7 +35,7 @@ mkdir -p "$TMP_ROOT"
 TMP_ROOT=$(cd "$TMP_ROOT" && pwd)
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
-VERIFIED_HARNESSES="claude codex opencode pi pi-signed grok kimi cursor muse"
+VERIFIED_HARNESSES="claude codex opencode pi pi-signed grok kimi cursor muse omp"
 
 # The expectation table, written out independently of the implementation so a
 # silent change to either side shows up here. The fourth field is the composer
@@ -52,6 +52,7 @@ verified_adapter_contract() {  # <harness> -> exit command, interrupt key, repea
     kimi) printf '/exit\tEscape\t1\t\n' ;;
     cursor) printf '/exit\tEscape\t1\t\n' ;;
     muse) printf '/exit\tEscape\t1\tC-u\n' ;;
+    omp) printf '/exit\tEscape\t1\t\n' ;;
     *) return 1 ;;
   esac
 }
@@ -266,7 +267,7 @@ test_harness_family_resolution() {
   local pair recorded want got
   for pair in claude:claude claude-latest:claude codex:codex codex-cli:codex \
       opencode:opencode grok:grok grok-2:grok kimi:kimi cursor:cursor \
-      cursor-agent:cursor muse:muse muse-bin-0.1.0:muse pi:pi \
+      cursor-agent:cursor muse:muse muse-bin-0.1.0:muse omp:omp pi:pi \
       pi-signed:pi-signed; do
     recorded=${pair%%:*}
     want=${pair#*:}
@@ -361,8 +362,8 @@ test_backend_key_capability_matrix() {
 }
 
 # A verified adapter is not automatically verified for every task kind, and the
-# check has to sit on the pre-stop side of a relaunch: muse has no primary
-# supervision protocol, so bin/fm-spawn.sh refuses it for a secondmate, and
+# check has to sit on the pre-stop side of a relaunch: muse and omp have no
+# primary supervision protocol, so bin/fm-spawn.sh refuses either for a secondmate, and
 # discovering that only after the running agent was stopped would strand the
 # secondmate with no agent at all.
 test_harness_kind_capability() {
@@ -375,6 +376,8 @@ test_harness_kind_capability() {
   done
   fm_control_harness_supports_kind muse secondmate \
     && fail "muse has no primary supervision protocol and must not claim a secondmate"
+  fm_control_harness_supports_kind omp secondmate \
+    && fail "omp has no primary supervision protocol and must not claim a secondmate"
   for harness in claude codex opencode pi pi-signed grok kimi; do
     fm_control_harness_supports_kind "$harness" secondmate \
       || fail "$harness should be able to run a secondmate"
@@ -441,6 +444,20 @@ test_state_verified_backends_are_exactly_tmux_and_herdr() {
       && fail "$backend has no recovery-grade classifier and must not claim one"
   done
   pass "fm-control-lib: stop-proving verbs are gated on the backends that really classify agent state"
+}
+
+test_omp_herdr_exit_uses_only_its_verified_idle_shell_proof() {
+  local pair harness backend
+  fm_control_exit_uses_herdr_idle_shell_proof omp herdr \
+    || fail "OMP's stale Herdr registration needs the measured idle-shell exit proof"
+  for pair in omp:tmux pi:herdr muse:herdr someagent:herdr; do
+    harness=${pair%%:*}
+    backend=${pair#*:}
+    if fm_control_exit_uses_herdr_idle_shell_proof "$harness" "$backend"; then
+      fail "$harness on $backend must not borrow OMP's Herdr exit proof"
+    fi
+  done
+  pass "fm-control-lib: only OMP on Herdr uses the measured idle-shell exit proof"
 }
 
 # --- 3. exact-id scoping ----------------------------------------------------
@@ -884,6 +901,7 @@ test_harness_kind_capability
 test_orca_refuses_an_escape_harness_interrupt
 test_unverified_state_backends_refuse_stop_verbs
 test_state_verified_backends_are_exactly_tmux_and_herdr
+test_omp_herdr_exit_uses_only_its_verified_idle_shell_proof
 test_window_label_is_refused_with_the_exact_id
 test_explicit_endpoint_is_refused
 test_unknown_task_is_refused

--- a/tests/fm-harness-adapter-instructions-live-e2e.test.sh
+++ b/tests/fm-harness-adapter-instructions-live-e2e.test.sh
@@ -97,7 +97,7 @@ if ! diff -u \
   <(jq -S . "$TMP_ROOT/normalized-response.json") > "$TMP_ROOT/diff"; then
   fail "local model $MODEL did not follow the routing instructions: $(tr '\n' ' ' < "$TMP_ROOT/diff")"
 fi
-pass "local model $MODEL selected every operation scenario and all nine harness identities"
+pass "local model $MODEL selected every operation scenario and all ten harness identities"
 
 CHECKED=0
 MISSING=
@@ -120,7 +120,7 @@ resolve_native_binary() {
   return 1
 }
 
-for harness in claude codex opencode pi pi-signed grok kimi cursor muse; do
+for harness in claude codex opencode pi pi-signed grok kimi cursor muse omp; do
   if binary=$(resolve_native_binary "$harness"); then
     version=$("$binary" --version 2>/dev/null | head -1 | tr -d '\r') || version=unknown
     printf '# native loader not claimed: %s %s is installed, but this harness-neutral evaluation does not exercise its provider transport\n' "$harness" "$version"

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Portable OMP harness identity regression for bin/fm-harness.sh.
+#
+# OMP advertises Pi environment variables but is a distinct binary, so its
+# Firstmate launch marker must beat PI_CODING_AGENT and its own exact command
+# name must identify a hand-launched OMP process through ancestry.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HARNESS="$ROOT/bin/fm-harness.sh"
+TMP_ROOT=$(fm_test_tmproot fm-omp-harness)
+
+test_omp_marker_beats_shared_pi_marker() {
+  local out
+  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u CLAUDECODE -u GROK_AGENT \
+    FM_OMP_HARNESS=omp PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed \
+    "$HARNESS")
+  [ "$out" = omp ] || fail "the OMP marker must beat PI_CODING_AGENT, got '$out'"
+  pass "fm-harness: OMP's launch marker wins over the shared Pi marker"
+}
+
+test_omp_exact_command_ancestry() {
+  local dir bin out
+  dir="$TMP_ROOT/ancestry"
+  mkdir -p "$dir"
+  for bin in omp ompx my-omp; do
+    cp "$(command -v bash)" "$dir/$bin"
+    out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u CLAUDECODE \
+      -u PI_CODING_AGENT -u FM_PI_HARNESS -u FM_OMP_HARNESS -u GROK_AGENT \
+      "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
+    if [ "$bin" = omp ]; then
+      [ "$out" = omp ] || fail "an OMP process ancestor resolved '$out', expected omp"
+    else
+      [ "$out" != omp ] || fail "unrelated process '$bin' was misidentified as OMP"
+    fi
+  done
+  pass "fm-harness: OMP is detected by its exact process name, never a substring"
+}
+
+test_omp_marker_beats_shared_pi_marker
+test_omp_exact_command_ancestry
+
+echo "all fm-omp-harness tests passed"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -30,6 +30,16 @@ SH
   chmod +x "$fakebin/$tool"
 }
 
+make_spawn_omp_probe() {
+  local fakebin=$1
+  cat > "$fakebin/omp" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then printf '%s\n' 'omp/18.0.11'; fi
+exit 0
+SH
+  chmod +x "$fakebin/omp"
+}
+
 make_spawn_fakebin() {
   local dir=$1 fakebin
   fakebin=$(fm_test_make_spawn_fakebin "$dir")
@@ -49,6 +59,7 @@ SH
   chmod +x "$fakebin/timeout" "$fakebin/cursor-agent"
   make_spawn_pi_probe "$fakebin" pi
   make_spawn_pi_probe "$fakebin" pi-signed
+  make_spawn_omp_probe "$fakebin"
   printf '%s\n' "$fakebin"
 }
 
@@ -631,6 +642,69 @@ test_pi_signed_threads_shared_pi_profile_and_preserves_identity() {
   pass "pi-signed shares Pi launch semantics while preserving its configured and recorded identity"
 }
 
+test_omp_threads_model_effort_autonomy_and_worker_extension() {
+  local rec id out status launch ext gen
+  id=profile-omp-z8c
+  rec=$(make_spawn_case profile-omp omp "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model deepseek-v4-pro --effort max)
+  status=$?
+  expect_code 0 "$status" "OMP spawn with model and max effort should succeed"
+  assert_contains "$out" "spawned $id harness=omp" "OMP spawn did not preserve its visible identity"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" omp deepseek-v4-pro max
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "FM_OMP_HARNESS=omp '$FAKEBIN_DIR/omp' --auto-approve --model='deepseek-v4-pro' --thinking='max' -e '$HOME_DIR/state/$id.omp-ext.ts'" \
+    "OMP launch did not thread autonomy, model, effort, and its worker extension"
+  assert_not_contains "$launch" "FM_PI_HARNESS=pi" \
+    "OMP launch must not identify itself as Pi"
+  assert_not_contains "$launch" "--tui-mode" \
+    "OMP launch must not borrow Pi's version-sensitive TUI flag"
+  ext="$HOME_DIR/state/$id.omp-ext.ts"
+  assert_present "$ext" "OMP launch did not install its turn and semantic-state extension"
+  assert_present "$HOME_DIR/state/$id.busy-gen" "OMP spawn did not arm the busy-state contract"
+  assert_contains "$(cat "$HOME_DIR/state/$id.busy-state")" "state=busy source=fm-spawn" \
+    "OMP spawn did not seed the busy-state record from the launch brief"
+  gen=$(cat "$HOME_DIR/state/$id.busy-gen")
+  assert_contains "$(cat "$ext")" 'pi.on("agent_start"' \
+    "OMP extension lost the semantic agent_start busy edge"
+  assert_contains "$(cat "$ext")" 'pi.on("agent_end"' \
+    "OMP extension lost the semantic agent_end idle edge"
+  assert_contains "$(cat "$ext")" '"--source", "omp-ext"' \
+    "OMP extension does not attribute its semantic source"
+  assert_contains "$(cat "$ext")" "\"--gen\", \"$gen\"" \
+    "OMP extension does not carry the armed incarnation gen"
+  assert_not_contains "$(cat "$ext")" 'pane.report_agent' \
+    "OMP worker state wiring must not compete with Herdr's installed OMP integration"
+  assert_contains "$(cat "$ext")" 'pi.on("turn_end"' \
+    "OMP extension lost the turn-end notification touch"
+  pass "OMP receives model and max thinking, auto-approves tools, and installs state wiring"
+}
+
+test_omp_missing_binary_refuses_before_endpoint_or_metadata() {
+  local rec id out status
+  id=profile-omp-missing-z8d
+  rec=$(make_spawn_case profile-omp-missing omp "$id")
+  read_case_record "$rec"
+  rm -f "$FAKEBIN_DIR/omp"
+  : > "$LAUNCH_LOG"
+
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+    FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" PATH="$FAKEBIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1)
+  status=$?
+  expect_code 1 "$status" "a missing OMP executable should refuse the spawn"
+  assert_contains "$out" "omp executable not found on PATH" \
+    "missing OMP refusal did not name the actionable requirement"
+  assert_absent "$HOME_DIR/state/$id.meta" "missing OMP refusal wrote task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "missing OMP refusal typed a launch command"
+  pass "OMP refuses safely and actionably when its executable is unavailable"
+}
+
 test_pi_tui_mode_probe_is_safe_for_old_and_new_pi() {
   local harness version rec id out status launch
   for harness in pi pi-signed; do
@@ -704,6 +778,25 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
   assert_contains "$launch" "FM_PI_HARNESS=pi-signed '$FAKEBIN_DIR/pi-signed' --tui-mode regular -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
     "pi-signed secondmate did not force the regular TUI with Pi's primary extension launch shape"
   pass "pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics"
+}
+
+test_omp_secondmate_refuses_before_endpoint_or_metadata() {
+  local rec id sm out status
+  id=profile-omp-secondmate-z8e
+  rec=$(make_spawn_case profile-omp-secondmate claude "$id")
+  read_case_record "$rec"
+  printf '%s\n' omp > "$HOME_DIR/config/secondmate-harness"
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$id"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$sm" --secondmate)
+  status=$?
+  expect_code 1 "$status" "OMP secondmate spawn should refuse"
+  assert_contains "$out" "omp is a verified crewmate/scout adapter only" \
+    "OMP secondmate refusal did not name the unsupported primary boundary"
+  assert_absent "$HOME_DIR/state/$id.meta" "OMP secondmate refusal wrote task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "OMP secondmate refusal typed a launch command"
+  pass "OMP's unverified primary protocol refuses secondmate dispatch before endpoint creation"
 }
 
 test_batch_forwards_shared_profile_flags() {
@@ -816,8 +909,11 @@ test_opencode_threads_model_and_ignores_effort_axis
 test_pi_threads_model_and_max_effort
 test_pi_tui_mode_probe_is_safe_for_old_and_new_pi
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
+test_omp_threads_model_effort_autonomy_and_worker_extension
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata
+test_omp_missing_binary_refuses_before_endpoint_or_metadata
 test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity
+test_omp_secondmate_refuses_before_endpoint_or_metadata
 test_batch_forwards_shared_profile_flags
 test_claude_forwards_firstmate_config_dir_when_set
 test_claude_omits_config_dir_prefix_when_unset

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -52,6 +52,7 @@ export PATH
 # and is killed on macOS arm64. The symlink name is what the kernel records as
 # the executable identity, which is exactly the signal under test.
 ln -s "$SLEEP_BIN" "$LAB/bin/claude-link"
+ln -s "$SLEEP_BIN" "$LAB/bin/omp"
 ln -s "$SLEEP_BIN" "$LAB/bin/pi"
 ln -s "$SLEEP_BIN" "$LAB/bin/notaharness"
 # muse's installed binary is muse-bin-<version>: the launcher execs it, so the
@@ -154,6 +155,13 @@ new_window agent "$LAB/bin/claude-link" 900
 wait_for_state "$SESSION:agent" alive \
   || fail "a running harness-named foreground process must classify alive"
 pass "tmux liveness: a harness-named foreground process classifies alive"
+
+# OMP is a distinct compiled binary even though its extension event surface
+# resembles Pi's, so its exact process name needs its own liveness proof.
+new_window omp "$LAB/bin/omp" 900
+wait_for_state "$SESSION:omp" alive \
+  || fail "a running OMP foreground process must classify alive"
+pass "tmux liveness: an OMP foreground process classifies alive"
 
 # --- muse's version-suffixed binary name ------------------------------------
 # A muse crewmate pane misclassified here reads as a dead endpoint, so a healthy


### PR DESCRIPTION
## What

Verify `omp` (omp/18.0.11, a compiled binary) as a Firstmate harness adapter for crewmate and scout workers on Herdr, and wire it through every owner the verify plan names.

OMP is a distinct program from Pi (`@earendil-works/pi-coding-agent` v0.84.4, Node bundle) even though its help advertises `PI_SMOL_MODEL`/`PI_SLOW_MODEL`/`PI_PLAN_MODEL` and its installed Herdr integration uses the Pi-shaped extension API. The shared lineage is evidenced from behavior, not assumed: OMP emits `agent_end` rather than Pi's `agent_settled`, its launch flags use `--model=`/`--thinking=` equals forms, and its installed Herdr registration persists as idle after exit.

## Verified (live, real worker through the normal spawn path)

Launch, turn lifecycle, interrupt, exit, and relaunch were demonstrated against a real `omp` worker spawned by `bin/fm-spawn.sh` in a guarded non-default Herdr lab session (`fm-lab-` name, default-session tripwire):

- **Launch** — `spawned omp-live-1 harness=omp kind=scout window=<lab session>:w1:p2 worktree=<treehouse worktree>`
- **Turn** — worker ran `printf 'OMP_LIVE_READY\n'` via its Bash tool and replied `OMP_LIVE_READY`; the generated extension moved busy state `busy omp-ext` -> `idle omp-ext` (agent_start -> debounced agent_end) and touched `state/<id>.turn-ended`.
- **Interrupt** — steered into `sleep 45`, then `bin/fm-control.sh omp-live-1 interrupt` printed `interrupt-delivered omp-live-1 harness=omp backend=herdr verified=agent-alive cancel=unconfirmed`; the session transcript shows the tool result `Command aborted` and assistant `stopReason: "aborted"` with `errorMessage: "Interrupted by user"`.
- **Exit** — `bin/fm-control.sh omp-live-1 exit` printed `stopped omp-live-1 harness=omp backend=herdr endpoint=<lab session>:w1:p2 worktree=<treehouse worktree>`.
- **Relaunch** — `bin/fm-control.sh omp-live-1 relaunch --note ...` printed `relaunched omp-live-1 harness=omp from=omp model=default effort=default backend=herdr endpoint=<same pane>`.

Live verification caught two defects the portable suites could not, both fixed in this PR:

1. `wait_exit_postcondition` called herdr helpers directly after `agent_state` and the send-verdict ran in command-substitution subshells, so `herdr.sh` was sourced only in those children (`fm_backend_herdr_parse_target: command not found`). `fm-control.sh` now sources the backend into its own shell before the direct calls.
2. OMP's installed Herdr integration keeps an idle agent registration after `/exit`, so `agent_state` stays `live` forever, and the original lone-pane-shell exit proof can never hold in the real launch shape: the spawn owner always places the worker inside a `treehouse get` subshell, so the pane's foreground after exit is the worktree shell, never its own pane shell.

The OMP-on-Herdr exit and relaunch postconditions therefore use a new pane-process proof, `fm_backend_herdr_pane_omp_exit_proof`: the pane's sole foreground process is one recognized idle shell and no `omp` process remains anywhere beneath the pane shell. The proof refused while the worker ran (foreground `omp`) and passed after `/exit` (foreground `bash`).

## Owners landed

- `bin/fm-harness.sh` — `FM_OMP_HARNESS=omp` detection marker (wins before the shared `PI_CODING_AGENT` branch) plus exact `omp` process-ancestry detection.
- `bin/fm-spawn.sh` — launch template (`--auto-approve`, `--model=`, `--thinking=`, per-task `-e` extension, encoded positional brief), executable resolution with a missing-binary refusal before endpoint creation, busy-contract arming, and the secondmate refusal before endpoint creation.
- `bin/fm-busy-lib.sh` / `bin/fm-composer-lib.sh` — `omp-ext` semantic busy source and the observed braille-elapsed busy footer.
- `bin/fm-control-lib.sh` / `bin/fm-control.sh` — interrupt (single Escape), exit (`/exit`), the closed `omp`+`herdr` pane-process exit-proof pair, and the same proof licensing relaunch.
- `bin/backends/tmux.sh` — OMP process-name classification (portable coverage).
- `.agents/skills/harness-adapters/references/harness/omp.md` — the tool record, registered in the SKILL.md routing object and the documentation-audiences inventory.
- Portable regressions: `tests/fm-omp-harness.test.sh` (new) plus extended `fm-busy-adapter-wiring`, `fm-busy-state`, `fm-composer-lib`, `fm-control`, `fm-spawn-dispatch-profile`, `fm-tmux-agent-liveness`, and the harness-adapter-instructions e2e. All directly-touched suites pass (`bin/fm-test-run.sh`); the real-herdr smoke suite passes; `bin/fm-lint.sh` shellcheck is clean (the only lint failure is the pre-existing missing actionlint, and no workflows changed). `bin/fm-doc-audience-check.sh` passes.

## Recorded as unsupported (explicit boundaries)

- **Secondmate and primary integration**: no primary supervision protocol was verified, so `fm-spawn.sh` refuses OMP secondmates before endpoint creation and the primary-hook surface has no OMP branch (`kimi`-style boundary).
- **tmux worker dispatch**: the process-name branch has portable coverage but no supervised OMP tmux launch in this audit; tmux remains unverified for OMP workers.
- **Resume**: OMP's native `--resume <id>` exists but has no verified Firstmate pane-resume contract; deterministic `relaunch` from the durable brief is the supported path.
- **Fresh unauthenticated profile**: a blank isolated profile opens provider onboarding despite `--auto-approve`; the configured default profile carries the worker.

## Note on the fork

The branch is pushed to the fork `marianvnc/firstmate` and the PR targets `kunchenguid/firstmate:main`. The PR merge poll and `fm-pr-merge.sh` address the PR by number on the base repo, so the merge flow is unaffected on the captain's side.
