### PR TITLE
feat(skills): add skills-verifier process-to-skill verification loop

### DIFF
--- a/.agents/skills/skills-verifier/SKILL.md
+++ b/.agents/skills/skills-verifier/SKILL.md
@@ -63,7 +63,7 @@ Record the handoff path in the run log.
 
 Commit the generator's final output before anything is iterated, and record the commit hash as the restore point.
 
-- Run `git add -A` on the draft and its direct references.
+- Run `git add -- <draft> <references>` to stage only the draft and its direct references, so unrelated worktree changes never enter the rollback anchor.
 - Commit with a message naming the version and stage, for example `skills-verifier: generator v1.0.0 draft`.
 - Tag the commit, for example `git tag skills-verifier-anchor-<slug>`.
 - Append a status note naming the tag and commit hash so the restore point survives a restart.
@@ -124,6 +124,7 @@ The decider chooses the winner, applying configured authority when present.
   Then return to the generator (or the lane) for the final accept decision.
 - **Reject** - restore the recorded rollback commit exactly.
   The restore is the anchor from phase 2, not a fresh checkout and not a discard of unlanded work.
+  When firstmate decides under configured authority, discarding unlanded negotiated work beyond the anchored commit still requires explicit captain authorization per hard rule 3.
 
 A rejected run must not leave a half-versioned draft in place.
 Restore the anchor commit and stop the loop unless the decider reopens it.
@@ -134,8 +135,11 @@ pi-peer lets independent pi sessions find and message each other.
 Install it once per machine:
 
 ```bash
-pi install git:github.com/shift-labs-ai/pi-peer
+pi install git:github.com/shift-labs-ai/pi-peer@5e8fcb20c14cc5bc99a704e5b466f22bcf553861
 ```
+
+The pinned ref is the piloted revision (v0.2.0).
+Pinning keeps the install on the verified transport instead of the mutable head.
 
 Nothing else to enable; every session registers itself on startup.
 pi-peer exposes two model-invoked tools: `list_peers` and `message_peer`.

--- a/.agents/skills/skills-verifier/SKILL.md
+++ b/.agents/skills/skills-verifier/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: skills-verifier
+description: >-
+  Agent-only verifier loop for the workflow-conversion path: turning a verified process into an agent skill.
+  Use when a generator has produced a draft agent skill from a verified process, when the captain asks to verify or iterate on a skill draft, or before shipping a skill that was distilled from evidence rather than written against a spec.
+  Runs the anchor-verify-negotiate-blindjudge loop with independent pi session sub-agents, reports a recommendation to the captain, and either lands the accepted commit or restores the rollback commit exactly.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# skills-verifier
+
+Verify an agent skill that was distilled from a verified process, so the shipped skill is checked by an independent agent rather than graded by the agent that wrote it.
+
+This is the loop for the workflow-conversion path: a process that has already been executed and verified becomes an agent skill.
+The generator turns the evidence into a draft.
+This skill runs the rest of the loop: anchor a rollback point, have an independent verifier review it, negotiate with a two-round cap, judge the versions blind, report to the captain, then land or restore.
+
+This skill is the owner of the loop.
+Where the captain or firstmate has configured authority to decide, the loop applies it; otherwise the captain decides.
+See `references/agent-cookbook/` for the companion manual that converts any verified process into an SSF-style custom workflow.
+
+## The loop
+
+Run the phases in order.
+Each phase hands a concrete artifact to the next, and every phase is a separate agent unless this skill is the deciding authority.
+
+1. **Handoff** - the generator delivers its final output, a draft agent skill.
+2. **Rollback anchor** - commit the final output and record the commit hash as the restore point before any iteration.
+3. **Verify** - an independent verifier agent receives the output, reviews it, and records its own commit/note.
+4. **Bounded negotiation** - the verifier sends structured suggestions to the generator; they discuss and converge on an upgraded, versioned artifact.
+5. **Blind judging** - a judge agent receives both versions anonymized plus deterministic facts, and ranks them with a justification.
+6. **Report to the captain** - result, comparison, options, recommendation.
+7. **Accept or Reject** - keep the accepted commit and run `writing-for-agents` to finalize, or restore the recorded rollback commit exactly.
+
+## Roles and independence
+
+The loop has three work roles plus a decider.
+
+- The **generator** owns the draft.
+- The **verifier** reviews the draft and proposes upgrades.
+- The **judge** is the tie-breaker that sees both versions blind.
+- The **decider** is the captain, or firstmate under configured authority.
+
+Each of the three work roles MUST be an independent pi session.
+Never let one agent grade its own work, and never let the generator be the verifier or the judge of its own draft.
+A verifier that rewrites the draft and then judges its own rewrite is the same violation.
+
+The sub-agents speak through pi-peer.
+pi-peer is the verified transport; if it is unavailable after two genuine attempts, fall back to herdr agent prompts plus file inboxes and record the substitution in the PR.
+See the transport section below for the exact message-flow commands.
+
+## Phase 1 - Handoff
+
+The generator delivers its final output and the path to it.
+The output is a single draft file, usually a `SKILL.md`, plus any direct reference files it needs.
+
+A handoff is complete when the draft path is known and the draft is readable.
+Record the handoff path in the run log.
+
+## Phase 2 - Rollback anchor
+
+Commit the generator's final output before anything is iterated, and record the commit hash as the restore point.
+
+- Run `git add -A` on the draft and its direct references.
+- Commit with a message naming the version and stage, for example `skills-verifier: generator v1.0.0 draft`.
+- Tag the commit, for example `git tag skills-verifier-anchor-<slug>`.
+- Append a status note naming the tag and commit hash so the restore point survives a restart.
+
+Do this before any negotiation or revision.
+The anchor is what "Reject" restores, so it must exist before any change.
+
+## Phase 3 - Verify
+
+The verifier agent receives the draft and reviews it against the source evidence and the skill-writing reference.
+The verifier records a commit and a note, and returns a structured review.
+
+The review carries what it observed and what it proposes.
+Separate facts from opinions: a fact is a testable claim about the draft, an opinion is a recommendation about wording or scope.
+
+The verifier also validates the draft's own contract: frontmatter, trigger branches, phase structure, and that every rule traces to an authoritative source rather than a re-derived value.
+
+## Phase 4 - Bounded negotiation
+
+The verifier sends its structured suggestions to the generator, and they converge on an upgraded, versioned artifact.
+Versioning is semver MAJOR.MINOR.PATCH and is truthful:
+
+- **PATCH** - wording, clarity, or documentation, no behavior change.
+- **MINOR** - a new bounded capability that does not change existing behavior.
+- **MAJOR** - a behavior change.
+
+Every bump must match what the artifact actually changed.
+A negotiation is capped at two suggestion rounds.
+After two rounds, the loop lands on a sign-off or escalates.
+Never let the negotiation become unbounded discussion.
+Write a `round` tag on each suggestion set and on the resulting artifact version.
+
+## Phase 5 - Blind judging
+
+The judge agent receives BOTH versions anonymized and ranks them.
+Anonymization is strict:
+
+- Label the versions A and B with the order randomized per round.
+- Strip all metadata that could identify a version, including author, timestamp, and any name that leaks recency.
+- Give the judge the two bodies plus deterministic facts only, never the source of either.
+
+The deterministic facts are the objective inputs: test results, diff statistics, gate outputs, and any executable check on the skill.
+The judge ranks one version over the other and writes a justification tied to those facts.
+
+The judge must not be able to tell which version is newer, which is the generator's, or which the verifier rewrote.
+
+## Phase 6 - Report to the captain
+
+Report in plain terms: the result, the comparison, the options, and a recommendation.
+Include the full URL of any PR when one exists.
+Lead with the outcome and the decision the captain needs to make.
+
+## Phase 7 - Accept or Reject
+
+The decider chooses the winner, applying configured authority when present.
+
+- **Accept** - keep the accepted commit and run the `writing-for-agents` skill to finalize and codify it.
+  Then return to the generator (or the lane) for the final accept decision.
+- **Reject** - restore the recorded rollback commit exactly.
+  The restore is the anchor from phase 2, not a fresh checkout and not a discard of unlanded work.
+
+A rejected run must not leave a half-versioned draft in place.
+Restore the anchor commit and stop the loop unless the decider reopens it.
+
+## Transport: pi-peer
+
+pi-peer lets independent pi sessions find and message each other.
+Install it once per machine:
+
+```bash
+pi install git:github.com/shift-labs-ai/pi-peer
+```
+
+Nothing else to enable; every session registers itself on startup.
+pi-peer exposes two model-invoked tools: `list_peers` and `message_peer`.
+`list_peers` shows the other sessions, their working directory, and whether each is idle, working, unresponsive, or not running.
+`message_peer` sends plain text to one peer by name; the receiving session sees it mid-task, marked as coming from a peer and carrying no authority.
+
+A message is text only, capped at 32 KB.
+Send a summary and a path, never a payload.
+The channel is auditable and useless for smuggling state, which is the point.
+
+The message-flow for a role is:
+
+1. Launch the role as its own pi session in its own working directory, for example `pi -p --name <role>` with the role prompt.
+2. Have the role call `list_peers` to discover the other sessions by name.
+3. Have the role call `message_peer({ to: "<peer-name>", message: "<summary + path>" })` to hand off.
+4. Check the receipt: the sender is told **delivered** if the receiving agent took the letter and **queued** if the letter waited.
+   A queued letter is read when the peer session resumes.
+
+The address of a session is derived from its working directory and pi's session id, so it survives restarts.
+Mail for a session that is not running waits on disk and is read when the session resumes.
+Use a distinct working directory per role so the three roles never share an inbox.
+
+If pi-peer cannot be made to work after two genuine attempts, substitute herdr agent prompts plus file inboxes.
+Each role's inbound and outbound messages become files in a shared directory, and each role is still a separate pi session.
+Record the substitution in the PR so the reader knows the transport was swapped.
+
+## The workflow-conversion path
+
+A process becomes a skill only after it has been executed and verified.
+The conversion path is:
+
+1. Have the verified process's evidence, not a spec.
+2. Have the generator distill the evidence into a draft skill.
+3. Run this verifier loop on the draft.
+4. Land the accepted version, then codify it with `writing-for-agents`.
+
+The companion manual, `references/agent-cookbook/README.md`, walks through converting any verified process into an SSF-style custom workflow.
+It uses the data-analysis process as the worked example.
+See it when the conversion target is a custom workflow rather than a single skill.
+
+## Tests
+
+A colocated test pins the loop's deterministic parts.
+It asserts the labels randomize per round, the negotiation cap holds, and the version bump is truthful.
+It does not grade a model's prose, because a stub cannot prove an agent's judgement.
+Run it with the repo's script runner; see `tests/skills-verifier.test.sh`.
+
+## Files
+
+- `SKILL.md` - this skill, the owner of the loop.
+- `references/agent-cookbook/README.md` - the companion conversion manual, with the data-analysis worked example.

--- a/.agents/skills/skills-verifier/SKILL.md
+++ b/.agents/skills/skills-verifier/SKILL.md
@@ -63,6 +63,7 @@ Record the handoff path in the run log.
 
 Commit the generator's final output before anything is iterated, and record the commit hash as the restore point.
 
+- Require a clean index before staging: `git diff --cached --quiet` must pass; if unrelated entries are already staged, stop and have the operator commit or stash them, so the anchor commit never sweeps in unrelated staged work.
 - Run `git add -- <draft> <references>` to stage only the draft and its direct references, so unrelated worktree changes never enter the rollback anchor.
 - Commit with a message naming the version and stage, for example `skills-verifier: generator v1.0.0 draft`.
 - Tag the commit, for example `git tag skills-verifier-anchor-<slug>`.

--- a/.agents/skills/skills-verifier/references/agent-cookbook/README.md
+++ b/.agents/skills/skills-verifier/references/agent-cookbook/README.md
@@ -1,0 +1,228 @@
+# Agent Cookbook - converting a verified process into an SSF-style custom workflow
+
+This manual converts any process that has already been executed and verified into a custom agent-factory workflow in the shape of the Super Simple Software Factory (SSF).
+It extracts SSF's shape, not its code, and adapts that shape to firstmate's existing machinery.
+Use it when the conversion target is a workflow you will run repeatedly, rather than a single skill.
+
+The companion `../SKILL.md` owns the verifier loop that checks a produced artifact.
+This manual owns the conversion shape.
+The worked example throughout is the verified Whoa Tea July-2026 retail sales analysis, which is already a proven process.
+
+## What to carry over from SSF
+
+Do not copy SSF's code.
+Carry over these five ideas, and adapt each to firstmate's machinery.
+
+1. **Agents propose, code disposes.**
+   An agent owns the work inside one bounded phase.
+   Deterministic code owns sequencing, retries, and acceptance between phases.
+   The agent never decides whether its own work passed.
+
+2. **Observable phases.**
+   A run is a sequence of named phases.
+   Each phase has a kind, an owner, and a completion condition.
+   The trace records what phase ran, who ran it, and whether it passed.
+   The plan/build/test/review/fix loop is the repeated shape.
+
+3. **Per-agent config.**
+   One config entry per agent: name, model, thinking level, prompts, harness, and the boundary of what it may change.
+   Different phases can run different models at different price or speed points.
+
+4. **YAML plus Python only, no invented DSL.**
+   The config is YAML.
+   The deterministic layer is real code in the repo's language.
+   There is no proprietary schema to learn.
+
+5. **Sessions reusable and resumable.**
+   Running an agent and continuing it are the same call.
+   A correction is a message into a live session, never a cold restart.
+
+## Firstmate's machinery is the adaptation target
+
+SSF applies to a repo you own.
+Firstmate applies to a fleet of agent tasks.
+The parts line up one to one.
+
+| SSF idea | Firstmate equivalent |
+| --- | --- |
+| ADW script (`adw_*.py`) | a run recipe built from the role briefs and the backlog |
+| Agent node (`kind="agent"`) | a crewmate launched through `bin/fm-spawn.sh` |
+| Agent prompt (`prompt_engineering/`) | the task brief from `bin/fm-brief.sh` |
+| Per-agent config (`sssf.config.yaml`) | the dispatch profile in `config/crew-dispatch.json` plus the harness and model pins |
+| Deterministic gate (`gates.py`) | a no-mistakes gate, a shellcheck-clean script, a set check |
+| Trace (`sssf.db`, `events`) | the task's status file, metadata, and the durable backlog record |
+| Session resume (`--session-id`) | the crewmate's persistent session through `bin/fm-control.sh` |
+| Run surface (`just demo`, trace UI) | a herdr pane projecting the run |
+
+The point of the adaptation is that firstmate already owns most of the machinery.
+The conversion is mainly a mapping decision: which part of the verified process becomes an agent phase, and which part becomes a deterministic gate.
+
+## The ADW phase shape
+
+Every phase is one of three kinds.
+
+- **engineer** - the human decides something the workflow cannot.
+- **agent** - a bounded agent does the work and returns a typed result.
+- **code** - a deterministic step runs on its own, like a commit or a check.
+
+A phase defaults to not having passed.
+It passes when it could have failed and did not.
+An agent phase also needs its result to parse and its gates to come back green.
+Let `code` own anything whose invocation is already known, such as running a test suite or a formatter, because paying an agent to do arithmetic is wasted leverage.
+
+An agent has exactly two output channels: reference files it leaves in a handoff location, and a final structured result that code validates.
+Context crosses a seam in code, not in conversation.
+
+## The config schema, adapted
+
+A firstmate-flavored config keeps SSF's shape but speaks firstmate's nouns.
+This is illustration, not a shipped format.
+
+```yaml
+defaults:
+  coding_agent: pi
+  model: anthropic/claude-sonnet-4
+  thinking: medium
+  # Anything an agent may not edit, even with bash.
+  protected_files:
+    - bin/
+    - data/
+
+run:
+  breadcrumb: data/skills-verifier-build-i1   # where this run's artifacts land
+  trace:
+    status_file: state/<id>.status
+    meta_file: state/<id>.meta
+
+phases:
+  - name: plan
+    kind: agent
+    owner: planner
+    model: google/gemini-3.6-flash
+    writes: [specs/]
+  - name: build
+    kind: agent
+    owner: builder
+    model: anthropic/claude-sonnet-4
+    writes: []                       # the only phase that may change source
+  - name: test
+    kind: code
+    owner: gates                     # no agent; run the suite
+    command: bin/gate-test.sh
+  - name: review
+    kind: agent
+    owner: reviewer
+    model: openai/gpt-5.6-terra
+    writes: []
+  - name: fix
+    kind: agent
+    owner: builder
+    model: anthropic/claude-sonnet-4
+    writes: []
+```
+
+The per-agent essence is the same four plus one: model, thinking, prompts, tools, and the write boundary.
+The write boundary is what makes a read-only phase genuinely read-only, because a tool list alone cannot stop `bash` from running `git checkout`.
+
+## Deterministic gates, adapted
+
+A gate verifies a claim the agent declared, after the fact.
+It is never a prediction, because nobody knows what an agent will touch before it finishes.
+A gate is a check with the signature `gate(result, run) -> report`, and each check names what it verified.
+
+Firstmate's gates are the no-mistakes steps and the repo's own checks.
+Map the verified process's checks onto those.
+
+| SSF gate | Firstmate gate |
+| --- | --- |
+| `json_parses` | the brief's structured exit contract, parsed |
+| `artifacts_exist` | the expected deliverables exist at the declared paths |
+| `files_non_empty` | the key outputs are non-empty |
+| `diff_matches_claims` | the changed files match the task's declared scope |
+| `tests_pass(...)` | a no-mistakes run step, or the repo's own test runner |
+| `quality` / lint | a shellcheck-clean or lint gate |
+
+The rule to keep is that the gate layer never decides the work is good.
+It decides the work meets its own declared contract.
+The human decides whether the result is what was asked for.
+
+## The worked example: the data-analysis process
+
+The Whoa Tea July-2026 analysis is already a verified process.
+Its evidence is the report, the methods note, the authoritative conventions module, and the 21 executed notebooks in `notebooks/full/`.
+The process has eight phases, and each maps cleanly onto the SSF shape.
+
+| Verified process phase | AS a phase kind | Who owns it | The gate |
+| --- | --- | --- | --- |
+| Setup | code | deterministic script | the conventions module imports read-only |
+| Ingest | code | deterministic loader | the On-Account fix is applied |
+| Per-branch | agent | builder | `bill_product_coverage >= 0.60` for line items |
+| Region | agent | builder | the `REGION` map, none unassigned |
+| Company | code | deterministic roll-up | the 17-branch sum equals the roll-up |
+| Product & category | agent | builder | exclusions applied, Keeta footnote carried |
+| Reconcile | code | deterministic check | exact reconciliation to SAR 1,070,940.27 / 30,857 bills |
+| Report | agent | builder | every line-item metric carries the Keeta footnote |
+
+The insight is that most of this process is deterministic and should be `code`.
+Only the parts that require reading and deciding, like interpreting each region or choosing which product insight to surface, are `agent`.
+The wrong conversion would make every phase an agent and pay for arithmetic that a script already knows.
+
+## Step-by-step conversion procedure
+
+1. **Capture the verified process as named phases.**
+   Write each phase, its input, its output, and the condition that says it is done.
+   Use the evidence, not a spec.
+
+2. **Split each phase into agent versus code.**
+   A phase whose invocation is already known is `code`.
+   A phase that needs reading and deciding is `agent`.
+
+3. **Identify the deterministic gates.**
+   For each agent phase, name the after-the-fact check that verifies its declared contract.
+   Map each to a no-mistakes step, a repo script, or a set check.
+
+4. **Assign an agent per phase.**
+   Give the planner a frontier model and the builder a cheaper, faster one.
+   Give a reviewer no write boundary at all.
+
+5. **Write the config.**
+   YAML only, one entry per agent, with model, thinking, prompts, harness, and the write boundary.
+   Do not invent a DSL.
+
+6. **Wire the gate calls.**
+   Each agent phase ends by handing a structured result to the deterministic layer, which validates and gates it.
+   A violation returns to the same live session as a correction, not a restart.
+
+7. **Run and observe.**
+   Each phase writes to the task's status and meta records as it runs.
+   Read the run from the trace, not from a transcript novel.
+
+8. **Fix and re-run.**
+   A correction is a steering message into the same session.
+   The fix phase reuses the session, so it does not relearn what it just learned.
+
+## Sessions reusable and resumable
+
+A session is keyed by its identity, not by its process, so resuming is the same call as running.
+In SSF that is `--session-id` create-or-continue.
+In firstmate that is the crewmate's persistent session, steered and resumed through `bin/fm-control.sh`.
+A correction must cost one message, never a cold start.
+Never restart a session to throw away what the agent learned; restart only when the task is genuinely stuck.
+
+## Gotchas and honest limits
+
+- Keeping a phase as `code` instead of `agent` is the single biggest leverage decision.
+  Most teams ship agents that do arithmetic.
+- A read-only agent is read-only with respect to the repo, not unable to write its own report.
+- The gate layer verifies contract, not quality.
+  Do not let a green gate stand in for the human's judgement.
+- The configuration and the prompt are both owned by the run, not by a copy inside a skill.
+  Edit them in place, or the run drifts from the description.
+- A verifier loop (see the parent skill) is the path to trust the agent-built artifact.
+  A workflow that gates with code cannot vouch for prose it did not write.
+
+## Open questions the captain should answer
+
+- Should the deterministic layer be `bin/` shell gates, or a dedicated script module?
+- Which phases of the data-analysis process warrant an agent, versus staying as `code`?
+- Should the config be a tracked file or a private dispatch profile?

--- a/.agents/skills/skills-verifier/references/agent-cookbook/README.md
+++ b/.agents/skills/skills-verifier/references/agent-cookbook/README.md
@@ -104,7 +104,7 @@ phases:
     kind: agent
     owner: builder
     model: anthropic/claude-sonnet-4
-    writes: []                       # the only phase that may change source
+    writes: [src/, tests/]           # the only phase that may change source
   - name: test
     kind: code
     owner: gates                     # no agent; run the suite
@@ -118,7 +118,7 @@ phases:
     kind: agent
     owner: builder
     model: anthropic/claude-sonnet-4
-    writes: []
+    writes: [src/, tests/]           # fix touches only what build may touch
 ```
 
 The per-agent essence is the same four plus one: model, thinking, prompts, tools, and the write boundary.

--- a/.agents/skills/skills-verifier/references/agent-cookbook/README.md
+++ b/.agents/skills/skills-verifier/references/agent-cookbook/README.md
@@ -118,7 +118,7 @@ phases:
     kind: agent
     owner: builder
     model: anthropic/claude-sonnet-4
-    writes: [src/, tests/]           # fix touches only what build may touch
+    writes: [src/, tests/]           # fix re-enters source with build's boundary; review is the only read-only phase
 ```
 
 The per-agent essence is the same four plus one: model, thinking, prompts, tools, and the write boundary.
@@ -183,7 +183,7 @@ The wrong conversion would make every phase an agent and pay for arithmetic that
 
 4. **Assign an agent per phase.**
    Give the planner a frontier model and the builder a cheaper, faster one.
-   Give a reviewer no write boundary at all.
+   Give the reviewer no writes at all (writes: []).
 
 5. **Write the config.**
    YAML only, one entry per agent, with model, thinking, prompts, harness, and the write boundary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -552,6 +552,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `skills-verifier` - load before verifying a process-to-agent-skill conversion, before running the generator/verifier/judge loop on a produced skill draft, or when the captain asks to iterate on a skill that was distilled from evidence rather than written against a spec.
 
 ## 14. Relay
 

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -212,7 +212,8 @@ family_for_basename() {
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
     fm-tmux-submit-busy.test.sh|fm-trace-context-lib.test.sh|\
     fm-transition-lib.test.sh|\
-    fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
+    fm-test-run.test.sh|fm-test-isolation-proof.test.sh|\
+    skills-verifier.test.sh)
       printf '%s\n' pure-contract-unit
       ;;
     fm-daemon.test.sh|fm-guard-stale-banner.test.sh|fm-pi-watch-extension.test.sh|\
@@ -1225,7 +1226,7 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' live-harness-optin
       ;;
-    .agents/skills/*/SKILL.md)
+    .agents/skills/*/SKILL.md|.agents/skills/*/references/*)
       printf '%s\n' pure-contract-unit
       ;;
     .github/workflows/ci.yml|.no-mistakes.yaml)

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -225,6 +225,14 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/skills-verifier/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/skills-verifier/references/agent-cookbook/README.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/stow/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/tests/skills-verifier.test.sh
+++ b/tests/skills-verifier.test.sh
@@ -165,6 +165,7 @@ EOF
 
 test_blind_label_strips_every_declared_marker() {
   local draft labeled marker
+  [ -n "$(strip_markers)" ] || fail "SKILL.md no longer declares any strip markers, so the stripping contract cannot be tested"
   draft="author: ver-agent
 timestamp: 2026-08-30T23:25:00Z
 body-only-content"

--- a/tests/skills-verifier.test.sh
+++ b/tests/skills-verifier.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Behavioral regressions for the skills-verifier loop's deterministic guarantees.
+#
+# The loop that this skill owns is orchestrated by independent pi agents, so a
+# model's prose cannot be pinned by a test. What CAN be pinned is the two rules
+# the loop treats as code, because they decide which version wins and whether a
+# judge can tell the versions apart:
+#
+#   1. the semver bump is truthful (a change class maps to exactly one bump);
+#   2. the blind-judging label assignment randomizes per round, so the A/B
+#      labels never leak which version is newer or which the verifier rewrote.
+#
+# These are encoded here as pure functions and asserted through their return
+# values, not through the prose of SKILL.md.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# classify_bump <change-description> -> the truthful semver class.
+# Mirrors the skill's rule: PATCH for wording/clarity, MINOR for a new bounded
+# capability, MAJOR for a behavior change, and a loud refusal otherwise.
+classify_bump() {
+  case "$1" in
+    wording | clarity | docs) echo patch ;;
+    "new capability") echo minor ;;
+    "behavior change") echo major ;;
+    *) return 1 ;;
+  esac
+}
+
+# anonymize <body-a> <body-b> -> prints two lines, "<label>:<body>".
+# Labels A and B randomly per call, and strips identity/recency markers from
+# each body so the judge never sees which version is newer or who wrote it.
+anonymize() {
+  local a b flip
+  a=$(printf '%s' "$1" | sed -E 's/^(version|author|timestamp|date):.*/<redacted>/')
+  b=$(printf '%s' "$2" | sed -E 's/^(version|author|timestamp|date):.*/<redacted>/')
+  flip=$(( RANDOM % 2 ))
+  if [ "$flip" = "0" ]; then
+    printf 'A:%s\nB:%s\n' "$a" "$b"
+  else
+    printf 'A:%s\nB:%s\n' "$b" "$a"
+  fi
+}
+
+# label_of <label> -> the body line out of an anonymize() pair.
+label_of() { grep "^$1:" | sed "s/^$1://"; }
+
+test_version_bump_is_truthful_and_total() {
+  local got
+  got=$(classify_bump wording) || fail "wording must classify"
+  expect_code patch "$got" "wording/clarity bumps PATCH"
+  got=$(classify_bump "new capability") || fail "new capability must classify"
+  expect_code minor "$got" "a new bounded capability bumps MINOR"
+  got=$(classify_bump "behavior change") || fail "behavior change must classify"
+  expect_code major "$got" "a behavior change bumps MAJOR"
+  if classify_bump "completely different" >/dev/null 2>&1; then
+    fail "an unsupported change class must be refused, not guessed"
+  fi
+  pass "version bump classification is truthful and does not guess"
+}
+
+test_blind_label_randomizes_per_round() {
+  local out_a i seen_ab=0 seen_ba=0
+  for i in $(seq 1 30); do
+    out_a=$(anonymize "body-alpha" "body-beta" | label_of A)
+    case "$out_a" in
+      "body-alpha") seen_ab=$(( seen_ab + 1 )) ;;
+      "body-beta") seen_ba=$(( seen_ba + 1 )) ;;
+    esac
+  done
+  [ "$seen_ab" -gt 0 ] && [ "$seen_ba" -gt 0 ] || fail "A/B labels did not randomize across rounds"
+  pass "blind-judging A/B labels randomize so the newer version is not inferable from labeling"
+}
+
+test_blind_label_strips_identity_markers() {
+  local draft="version: 2.0.0
+author: ver-agent
+timestamp: 2026-08-30T23:25:00Z
+body-only-content"
+  local labeled
+  labeled=$(anonymize "$draft" "$draft")
+  assert_not_contains "$labeled" "version: 2.0.0" "the blind label leaks a version marker"
+  assert_not_contains "$labeled" "author: ver-agent" "the blind label leaks an author marker"
+  assert_not_contains "$labeled" "timestamp: 2026-08-30T23:25:00Z" "the blind label leaks a timestamp marker"
+  assert_contains "$labeled" "body-only-content" "the blind label kept the real body content"
+  pass "blind judging strips identity and recency markers from a version"
+}
+
+test_version_bump_is_truthful_and_total
+test_blind_label_randomizes_per_round
+test_blind_label_strips_identity_markers

--- a/tests/skills-verifier.test.sh
+++ b/tests/skills-verifier.test.sh
@@ -49,14 +49,16 @@ blind_labels() {
   sed -nE 's/^- Label the versions ([A-Z]) and ([A-Z]).*/\1 \2/p' "$SKILL_MD"
 }
 
-# strip_markers -> the metadata keys Phase 5 orders stripped ("Strip all
-# metadata ... including author, timestamp, ...").
+# strip_markers -> every metadata key Phase 5 orders stripped ("Strip all
+# metadata ... including author, timestamp, ..."). Commas and "and" both
+# separate markers; no token the contract sentence declares may be filtered
+# out, so a reworded contract cannot grow a marker this suite stops testing.
 strip_markers() {
   sed -nE 's/^- Strip all metadata.* including ([^.]+)\..*/\1/p' "$SKILL_MD" |
-    sed -E 's/ and .*//' |
+    sed -E 's/[[:space:]]+and[[:space:]]+/,/g' |
     tr ',' '\n' |
-    sed -E 's/^ +| +$//g' |
-    grep -E '^[a-z]+$'
+    sed -E 's/^[[:space:]]+|[[:space:]]+$//g' |
+    grep -v '^$'
 }
 
 # --- gates executed against the derived contract -----------------------------

--- a/tests/skills-verifier.test.sh
+++ b/tests/skills-verifier.test.sh
@@ -54,7 +54,7 @@ blind_labels() {
 # separate markers; no token the contract sentence declares may be filtered
 # out, so a reworded contract cannot grow a marker this suite stops testing.
 strip_markers() {
-  sed -nE 's/^- Strip all metadata.* including ([^.]+)\..*/\1/p' "$SKILL_MD" |
+  sed -nE 's/^- Strip all metadata.* including (.*)\..*/\1/p' "$SKILL_MD" |
     sed -E 's/[[:space:]]+and[[:space:]]+/,/g' |
     tr ',' '\n' |
     sed -E 's/^[[:space:]]+|[[:space:]]+$//g' |

--- a/tests/skills-verifier.test.sh
+++ b/tests/skills-verifier.test.sh
@@ -1,93 +1,183 @@
 #!/usr/bin/env bash
 # Behavioral regressions for the skills-verifier loop's deterministic guarantees.
 #
-# The loop that this skill owns is orchestrated by independent pi agents, so a
-# model's prose cannot be pinned by a test. What CAN be pinned is the two rules
-# the loop treats as code, because they decide which version wins and whether a
-# judge can tell the versions apart:
-#
-#   1. the semver bump is truthful (a change class maps to exactly one bump);
-#   2. the blind-judging label assignment randomizes per round, so the A/B
-#      labels never leak which version is newer or which the verifier rewrote.
-#
-# These are encoded here as pure functions and asserted through their return
-# values, not through the prose of SKILL.md.
+# The loop this skill owns is orchestrated by independent pi agents, so a
+# model's prose cannot be pinned by a test. What CAN be pinned is the rules the
+# loop treats as code, because they decide which version wins, when negotiation
+# must stop, and whether a judge can tell the versions apart. Those rules are
+# declared in SKILL.md's contract (Phase 4's bump bullets and negotiation cap,
+# Phase 5's labeling and stripping orders); this test DERIVES its inputs from
+# that contract and executes gates keyed on the derived values, so the shipped
+# skill and this suite cannot drift apart with the suite green.
 set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-# classify_bump <change-description> -> the truthful semver class.
-# Mirrors the skill's rule: PATCH for wording/clarity, MINOR for a new bounded
-# capability, MAJOR for a behavior change, and a loud refusal otherwise.
-classify_bump() {
-  case "$1" in
-    wording | clarity | docs) echo patch ;;
-    "new capability") echo minor ;;
-    "behavior change") echo major ;;
+SKILL_MD="$ROOT/.agents/skills/skills-verifier/SKILL.md"
+assert_present "$SKILL_MD" "the shipped skill must exist for its contract to be tested"
+
+# --- inputs derived from SKILL.md's contract --------------------------------
+
+# bump_classes -> the version-bump classes Phase 4 declares, in contract order.
+bump_classes() {
+  sed -nE 's/^- \*\*(PATCH|MINOR|MAJOR)\*\* -.*/\1/p' "$SKILL_MD" | tr '[:upper:]' '[:lower:]'
+}
+
+# bump_rule_line <class> -> Phase 4's own description of that bump class.
+bump_rule_line() {
+  sed -nE "s/^- \*\*$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')\*\* - (.*)/\1/p" "$SKILL_MD"
+}
+
+# negotiation_cap -> the round cap Phase 4 declares ("capped at N suggestion
+# rounds"), as a number. Fails loudly when the contract stops declaring one.
+negotiation_cap() {
+  local word
+  word=$(sed -nE 's/.*capped at ([a-z]+) suggestion rounds.*/\1/p' "$SKILL_MD" | head -n 1)
+  case "$word" in
+    one) echo 1 ;;
+    two) echo 2 ;;
+    three) echo 3 ;;
+    four) echo 4 ;;
+    five) echo 5 ;;
     *) return 1 ;;
   esac
 }
 
-# anonymize <body-a> <body-b> -> prints two lines, "<label>:<body>".
-# Labels A and B randomly per call, and strips identity/recency markers from
-# each body so the judge never sees which version is newer or who wrote it.
+# blind_labels -> the two labels Phase 5 assigns, in contract order.
+blind_labels() {
+  sed -nE 's/^- Label the versions ([A-Z]) and ([A-Z]).*/\1 \2/p' "$SKILL_MD"
+}
+
+# strip_markers -> the metadata keys Phase 5 orders stripped ("Strip all
+# metadata ... including author, timestamp, ...").
+strip_markers() {
+  sed -nE 's/^- Strip all metadata.* including ([^.]+)\..*/\1/p' "$SKILL_MD" |
+    sed -E 's/ and .*//' |
+    tr ',' '\n' |
+    sed -E 's/^ +| +$//g' |
+    grep -E '^[a-z]+$'
+}
+
+# --- gates executed against the derived contract -----------------------------
+
+# classify_bump <change-description> -> the bump class whose own Phase 4 rule
+# line names the change; refuses change classes no declared rule covers.
+classify_bump() {
+  local class
+  while IFS= read -r class; do
+    case "$(bump_rule_line "$class")" in
+      *"$1"*) printf '%s\n' "$class"; return 0 ;;
+    esac
+  done < <(bump_classes)
+  return 1
+}
+
+# negotiation_open <round> -> whether the declared cap still admits this round.
+negotiation_open() {
+  local cap
+  cap=$(negotiation_cap) || return 1
+  [ "$1" -le "$cap" ]
+}
+
+# anonymize <body-a> <body-b> -> "<label>:<body>" lines using the derived
+# labels, assigned at random, with every derived marker stripped from each body.
 anonymize() {
-  local a b flip
-  a=$(printf '%s' "$1" | sed -E 's/^(version|author|timestamp|date):.*/<redacted>/')
-  b=$(printf '%s' "$2" | sed -E 's/^(version|author|timestamp|date):.*/<redacted>/')
+  local la lb a b flip marker strip_re
+  read -r la lb <<EOF
+$(blind_labels)
+EOF
+  strip_re="^($(
+    local first=1 marker
+    while IFS= read -r marker; do
+      [ "$first" = 1 ] || printf '|'
+      printf '%s' "$marker"
+      first=0
+    done < <(strip_markers)
+  )):"
+  a=$(printf '%s' "$1" | sed -E "s/$strip_re.*/<redacted>/")
+  b=$(printf '%s' "$2" | sed -E "s/$strip_re.*/<redacted>/")
   flip=$(( RANDOM % 2 ))
   if [ "$flip" = "0" ]; then
-    printf 'A:%s\nB:%s\n' "$a" "$b"
+    printf '%s:%s\n%s:%s\n' "$la" "$a" "$lb" "$b"
   else
-    printf 'A:%s\nB:%s\n' "$b" "$a"
+    printf '%s:%s\n%s:%s\n' "$la" "$b" "$lb" "$a"
   fi
 }
 
 # label_of <label> -> the body line out of an anonymize() pair.
 label_of() { grep "^$1:" | sed "s/^$1://"; }
 
+# --- tests -------------------------------------------------------------------
+
+test_bump_contract_declares_exactly_three_classes() {
+  local classes
+  classes=$(bump_classes | tr '\n' ' ' | sed 's/ $//')
+  expect_code "patch minor major" "$classes" "Phase 4 declares exactly PATCH, MINOR, MAJOR in order"
+  pass "the version-bump contract declares exactly three ordered classes"
+}
+
 test_version_bump_is_truthful_and_total() {
   local got
-  got=$(classify_bump wording) || fail "wording must classify"
+  got=$(classify_bump "wording") || fail "wording must classify"
   expect_code patch "$got" "wording/clarity bumps PATCH"
-  got=$(classify_bump "new capability") || fail "new capability must classify"
+  got=$(classify_bump "bounded capability") || fail "a bounded capability must classify"
   expect_code minor "$got" "a new bounded capability bumps MINOR"
-  got=$(classify_bump "behavior change") || fail "behavior change must classify"
+  got=$(classify_bump "a behavior change") || fail "a behavior change must classify"
   expect_code major "$got" "a behavior change bumps MAJOR"
   if classify_bump "completely different" >/dev/null 2>&1; then
     fail "an unsupported change class must be refused, not guessed"
   fi
-  pass "version bump classification is truthful and does not guess"
+  pass "version bump classification follows the contract and does not guess"
+}
+
+test_negotiation_cap_holds() {
+  local cap round
+  cap=$(negotiation_cap) || fail "the contract must declare a suggestion-round cap"
+  [ "$cap" -ge 1 ] || fail "the negotiation cap must admit at least one round"
+  round=1
+  while [ "$round" -le "$cap" ]; do
+    negotiation_open "$round" || fail "round $round must be admitted under a cap of $cap"
+    round=$((round + 1))
+  done
+  if negotiation_open "$round"; then
+    fail "round $round exceeds the declared cap of $cap and must be refused"
+  fi
+  pass "the negotiation admits exactly the declared rounds and refuses the next"
 }
 
 test_blind_label_randomizes_per_round() {
-  local out_a seen_ab=0 seen_ba=0
+  local la lb out_a seen_ab=0 seen_ba=0
+  read -r la lb <<EOF
+$(blind_labels)
+EOF
+  [ -n "$la" ] && [ -n "$lb" ] || fail "Phase 5 must declare two blind labels"
   for _ in $(seq 1 30); do
-    out_a=$(anonymize "body-alpha" "body-beta" | label_of A)
+    out_a=$(anonymize "body-alpha" "body-beta" | label_of "$la")
     case "$out_a" in
       "body-alpha") seen_ab=$(( seen_ab + 1 )) ;;
       "body-beta") seen_ba=$(( seen_ba + 1 )) ;;
     esac
   done
-  [ "$seen_ab" -gt 0 ] && [ "$seen_ba" -gt 0 ] || fail "A/B labels did not randomize across rounds"
-  pass "blind-judging A/B labels randomize so the newer version is not inferable from labeling"
+  [ "$seen_ab" -gt 0 ] && [ "$seen_ba" -gt 0 ] || fail "the blind labels did not randomize across rounds"
+  pass "blind-judging labels randomize so the newer version is not inferable from labeling"
 }
 
-test_blind_label_strips_identity_markers() {
-  local draft="version: 2.0.0
-author: ver-agent
+test_blind_label_strips_every_declared_marker() {
+  local draft labeled marker
+  draft="author: ver-agent
 timestamp: 2026-08-30T23:25:00Z
 body-only-content"
-  local labeled
   labeled=$(anonymize "$draft" "$draft")
-  assert_not_contains "$labeled" "version: 2.0.0" "the blind label leaks a version marker"
-  assert_not_contains "$labeled" "author: ver-agent" "the blind label leaks an author marker"
-  assert_not_contains "$labeled" "timestamp: 2026-08-30T23:25:00Z" "the blind label leaks a timestamp marker"
+  while IFS= read -r marker; do
+    assert_not_contains "$labeled" "$marker: " "the blind label leaks a declared $marker marker"
+  done < <(strip_markers)
   assert_contains "$labeled" "body-only-content" "the blind label kept the real body content"
-  pass "blind judging strips identity and recency markers from a version"
+  pass "blind judging strips every metadata marker the contract declares"
 }
 
+test_bump_contract_declares_exactly_three_classes
 test_version_bump_is_truthful_and_total
+test_negotiation_cap_holds
 test_blind_label_randomizes_per_round
-test_blind_label_strips_identity_markers
+test_blind_label_strips_every_declared_marker

--- a/tests/skills-verifier.test.sh
+++ b/tests/skills-verifier.test.sh
@@ -62,8 +62,8 @@ test_version_bump_is_truthful_and_total() {
 }
 
 test_blind_label_randomizes_per_round() {
-  local out_a i seen_ab=0 seen_ba=0
-  for i in $(seq 1 30); do
+  local out_a seen_ab=0 seen_ba=0
+  for _ in $(seq 1 30); do
     out_a=$(anonymize "body-alpha" "body-beta" | label_of A)
     case "$out_a" in
       "body-alpha") seen_ab=$(( seen_ab + 1 )) ;;


### PR DESCRIPTION
## Intent

Build the captain's Agent Skills Verifier loop as a firstmate skill on branch fm/skills-verifier-build-i1 with PR #1 (https://github.com/ameen-saeed/firstmate/pull/1). The change ships: (1) .agents/skills/skills-verifier/SKILL.md implementing the handoff -> rollback-anchor -> verify -> bounded two-round negotiation -> blind A/B judging -> captain report -> accept/reject-restore protocol, with pi-peer as the inter-agent transport (pinned commit) and the documented herdr+file-inbox fallback; (2) an agent-cookbook reference manual inside the skill's references converting verified processes into SSF-style agent-factory workflows (deterministic gates, observable phases, per-agent config, YAML+Python, adapted to fm-spawn/no-mistakes/herdr), with the data-analysis process as worked example; (3) a contract test wired into bin/fm-test-run.sh changed-file selection (pure-contract-unit family) and .agents/skills/*/references/* mapped to a family. Captain decisions already applied and to be preserved: all 3 review findings decided at fix-level (contract test derives inputs from SKILL.md's contract rather than re-implementing rules; Tests section cap claim corrected or assertion added; rollback-anchor staging scoped via pathspec commit with clean-index precondition) and the runner wiring gap decided FIX. The pilot ran with three independent pi sessions (generator/verifier/judge) through pi-peer; blind judge ranked verifier v2 (v1.1.0); captain accepted the pilot and chose fast-path. Pilot artifacts stay uncommitted under data/. Delivery: committed on fm/skills-verifier-build-i1, PR #1 driven to green CI, never merged by the agent.

Recovery note: a prior run on this branch failed mid-review-fix when its agent hit a quota limit. Its preserved review-fix commit (runner wiring + contract-derived tests) was recovered onto the branch, and the pending review findings were applied as follow-up commits: clean-index precondition in SKILL.md Phase 2 (git diff --cached --quiet before pathspec staging), cookbook write-boundary example corrected (build writes [src/, tests/], review/fix read-only), and a strip_markers non-emptiness guard in the contract test. These decisions are applied and must be preserved.

## What Changed

- Add the `skills-verifier` agent skill (`.agents/skills/skills-verifier/SKILL.md`): a handoff → rollback-anchor → verify → bounded two-round negotiation → blind A/B judging → captain report protocol for verifying process-to-agent-skill conversions, using pinned pi-peer sessions as the inter-agent transport with a herdr+file-inbox fallback, plus a clean-index precondition before pathspec-staged anchor commits; register it in AGENTS.md and `docs/documentation-audiences.json`.
- Add the agent-cookbook reference manual converting verified processes into SSF-style agent-factory workflows (deterministic gates, observable phases, per-agent YAML+Python configs) adapted to fm-spawn/no-mistakes/herdr, with the data-analysis process as a worked example and explicit build-writes vs reviewer read-only boundaries.
- Add `tests/skills-verifier.test.sh` as a pure-contract-unit contract test deriving its inputs from SKILL.md rather than re-implementing rules, and wire it into `bin/fm-test-run.sh` changed-file selection (test file and `.agents/skills/*/references/*` mapped to the pure-contract-unit family).

## Risk Assessment

✅ Low: The fix rounds made minimal, instruction-exact changes; every recorded acceptance decision is verifiably applied, and no reachable defect remains in the changed code.

## Testing

Exercised the skills-verifier deliverable end-to-end at its executable surfaces: the contract test suite passes against the shipped SKILL.md, the round's strip_markers hardening was proven to fix the silent token-loss failure mode by running the shipped derivation on a period-bearing contract rewording (old code dropped tokens, new code keeps all four), the real anonymize() consumer strips the new marker correctly, and the fm-test-run.sh changed-file wiring resolves the test and references paths to the pure-contract-unit family. Result: intent satisfied, no failures.

<details>
<summary>Evidence: Strip_markers hardening verification transcript (suite output, old-vs-new regression proof, anonymize end-to-end, runner wiring)</summary>

Source: [Strip_markers hardening verification transcript (suite output, old-vs-new regression proof, anonymize end-to-end, runner wiring)](https://github.com/ameen-saeed/firstmate/blob/b63f92a09e0aa8df939349265c51c36363f6b0cf/.no-mistakes/evidence/fm/skills-verifier-build-i1/skills-verifier-strip-markers-hardening-verification.txt)

```text
skills-verifier strip_markers hardening (target 1f16d8f) - verification transcript

1) Targeted suite, current SKILL.md wording:
$ bash tests/skills-verifier.test.sh
ok - the version-bump contract declares exactly three ordered classes
ok - version bump classification follows the contract and does not guess
ok - the negotiation admits exactly the declared rounds and refuses the next
ok - blind-judging labels randomize so the newer version is not inferable from labeling
ok - blind judging strips every metadata marker the contract declares
exit=0

2) Regression proof: Phase 5 strip bullet reworded to contain a period-bearing
   token ("including author, model v1.2 id, and timestamp, and any name that
   leaks recency."), then the shipped strip_markers() (extracted verbatim from
   tests/skills-verifier.test.sh, not re-implemented) run against it:

   shipped greedy capture (.*)\.:
   author
   model v1.2 id
   timestamp
   any name that leaks recency

   old capture ([^.]+)\. (pre-fix):
   author
   model v1
   -> old code silently dropped "2 id", "timestamp", and
      "any name that leaks recency"; shipped code keeps every declared token.

3) End-to-end through the real anonymize() consumer with the reworded contract:
   anonymize 'model v1.2 id: agent-2\nauthor: ver-agent\nbody-only-content' ...
   -> A:<redacted> / <redacted> / body-only-content
      B:<redacted> / body-only-content
   The period-bearing marker line is stripped, body content preserved.

4) Runner wiring (changed-file selection):
   skills-verifier.test.sh -> pure-contract-unit
   .agents/skills/skills-verifier/references/agent-cookbook/README.md -> pure-contract-unit (no __unmapped__)
   .agents/skills/skills-verifier/SKILL.md -> pure-contract-unit
```
</details>
<details>
<summary>Evidence: Shipped strip_markers output against a period-bearing contract rewording</summary>

Source: [Shipped strip_markers output against a period-bearing contract rewording](https://github.com/ameen-saeed/firstmate/blob/b63f92a09e0aa8df939349265c51c36363f6b0cf/.no-mistakes/evidence/fm/skills-verifier-build-i1/strip-markers-reworded-contract-output.txt)

<code>author&#10;model v1.2 id&#10;timestamp&#10;any name that leaks recency</code>

```text
author
model v1.2 id
timestamp
any name that leaks recency
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1f16d8f07ae3e7915b5fea8f13920dd6dab8b8d9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/skills-verifier.test.sh:57` - The recorded r3-strip-marker-silent-loss decision requires that every token the Phase 5 strip sentence declares appears in strip_markers output or the suite fails. The shipped derivation fixes the two known loss paths (the &#39;[a-z]+&#39; filter is gone and &#39; and &#39; is now split), but the capture &#39;([^.]+)\.&#39; still truncates at the FIRST interior period. If the contract bullet is ever reworded to include a period-bearing token (e.g. &#39;including author, model v1.2 id, and timestamp.&#39;), the capture yields &#39;author, model v1&#39; and silently drops &#39;2 id&#39; with the suite green - exactly the silent-loss class the decision forbids. Mechanical completion of the recorded decision, not new scope: add a guard that the captured include-list contains no interior period (e.g. capture greedily &#39;(.*)\.&#39; and fail if the captured text itself contains a &#39;.&#39;), so any period-bearing token fails loudly instead of being swallowed.

🔧 Fix: Harden strip_markers capture to the sentence-ending period
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/skills-verifier.test.sh` — all 5 contract-derived tests pass with current SKILL.md wording</code>
- <code>Regression proof: reworded the Phase 5 strip bullet to `including author, model v1.2 id, and timestamp, and any name that leaks recency.` in a temp copy, then ran the shipped `strip_markers()` (extracted verbatim from `tests/skills-verifier.test.sh`) against it — yields all 4 tokens including `model v1.2 id`; the pre-fix `([^.]+)\.` capture on the same input truncates to `author`/`model v1`, silently dropping `timestamp` and `any name that leaks recency`</code>
- <code>End-to-end: ran the real `anonymize()` consumer against the reworded contract — the period-bearing marker line `model v1.2 id: agent-2` is redacted and body content is preserved</code>
- <code>`family_for_basename skills-verifier.test.sh` → `pure-contract-unit`; `families_for_changed_path .agents/skills/skills-verifier/references/agent-cookbook/README.md` and `.../SKILL.md` → `pure-contract-unit`, no `__unmapped__`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
