### PR TITLE
feat(pi): make watcher supervision demand-driven

### DIFF
--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -471,6 +471,16 @@ export default function (pi: ExtensionAPI) {
     return forceRetireArm(armChild);
   }
 
+  async function awaitArmReadiness(owner: SessionGeneration, armChild: ChildProcess): Promise<boolean> {
+    const ready = await waitForReadiness(armChild);
+    if (ready) return owner.child === armChild;
+    if (generationIsLive(owner) && owner.child === armChild) {
+      unreadyArms.add(armChild);
+      await retireUnreadyArm(armChild);
+    }
+    return false;
+  }
+
   async function restoreAfterActionableClose(owner: SessionGeneration, predecessorArmPid: string): Promise<{
     failure: string;
     recovery?: { generation: string; watcherPid: string };
@@ -544,14 +554,16 @@ export default function (pi: ExtensionAPI) {
         finishRetry(false);
         return;
       }
-      void waitForReadiness(retryChild).then(finishRetry);
+      void (async () => {
+        const ready = await awaitArmReadiness(owner, retryChild);
+        finishRetry(ready);
+      })();
     }, retryDelay(owner.retryFailures));
     timer.unref();
     owner.retryTimer = timer;
   }
 
-  function startArm(owner: SessionGeneration, predecessorArmPid = ""): ArmResult {
-    if (!generationIsLive(owner)) return { ok: false, message: shuttingDownMessage };
+  function lockFailure(): ArmResult | null {
     const ownership = lockOwnership();
     if (ownership === "other") return { ok: false, message: "watcher: read-only - session lock is held by another firstmate session" };
     if (ownership === "missing") {
@@ -560,6 +572,13 @@ export default function (pi: ExtensionAPI) {
         message: "watcher: not armed - no live session holds the lock; run bin/fm-session-start.sh to reclaim it, then call fm_watch_arm_pi to re-arm",
       };
     }
+    return null;
+  }
+
+  function startArm(owner: SessionGeneration, predecessorArmPid = ""): ArmResult {
+    if (!generationIsLive(owner)) return { ok: false, message: shuttingDownMessage };
+    const lockResult = lockFailure();
+    if (lockResult) return lockResult;
     markLoaded();
     if (owner.child && intentionalIdleRetirements.has(owner.child)) {
       return {
@@ -723,11 +742,8 @@ export default function (pi: ExtensionAPI) {
       if (!result.ok) return;
       const armChild = owner.child;
       if (armChild) {
-        const ready = await waitForReadiness(armChild);
-        if (!ready && generationIsLive(owner) && owner.child === armChild) {
-          unreadyArms.add(armChild);
-          await retireUnreadyArm(armChild);
-        }
+        const ready = await awaitArmReadiness(owner, armChild);
+        if (!ready || owner.child !== armChild) await waitForPendingRetry(owner);
       } else {
         await waitForPendingRetry(owner);
       }
@@ -810,6 +826,61 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
+  async function repairArm(owner: SessionGeneration): Promise<ArmResult> {
+    const observedDemand = await readSupervisionDemand();
+    if (!generationIsLive(owner)) return { ok: false, message: shuttingDownMessage };
+    if (observedDemand !== "idle") {
+      const lockResult = lockFailure();
+      if (lockResult) return lockResult;
+    }
+    if (observedDemand !== "idle" && owner.retryTimer) {
+      return {
+        ok: true,
+        message: `watcher: unchanged - Pi extension already owns a scheduled continuity retry; no manual re-arm needed; ${repairOnlyHint}`,
+      };
+    }
+    const sequenceBefore = owner.seq;
+    await queueDemandReconciliation(owner);
+    if (!generationIsLive(owner)) return { ok: false, message: shuttingDownMessage };
+    if (owner.child && intentionalIdleRetirements.has(owner.child)) {
+      return {
+        ok: false,
+        message: "watcher: not armed - the prior idle retirement is still exiting; demand reconciliation will retry after it closes",
+      };
+    }
+    if (owner.child && unreadyArms.has(owner.child)) {
+      return {
+        ok: false,
+        message: "watcher: not armed - the previous arm failed readiness and is still exiting; demand reconciliation will retry after it closes",
+      };
+    }
+    if (owner.child) {
+      if (owner.seq > sequenceBefore) {
+        return {
+          ok: true,
+          message: `watcher: started Pi extension arm child ${owner.seq}; future ordinary re-arms are automatic; ${repairOnlyHint}`,
+        };
+      }
+      return {
+        ok: true,
+        message: `watcher: unchanged - Pi extension already owns an arm child; no manual re-arm needed; ${repairOnlyHint}`,
+      };
+    }
+    if (owner.retryTimer) {
+      return {
+        ok: true,
+        message: `watcher: unchanged - Pi extension already owns a scheduled continuity retry; no manual re-arm needed; ${repairOnlyHint}`,
+      };
+    }
+    if (observedDemand === "idle") {
+      return { ok: true, message: "watcher: unchanged - no supervision demand; Pi monitoring remains idle" };
+    }
+    return {
+      ok: false,
+      message: "watcher: FAILED - demand reconciliation did not establish a ready watcher arm",
+    };
+  }
+
   pi.on?.("session_start", async () => {
     if (generation.stopping) generation = createGeneration();
     activateGeneration(generation);
@@ -832,7 +903,7 @@ export default function (pi: ExtensionAPI) {
   pi.registerCommand?.("fm-watch-arm-pi", {
     description: "Explicitly repair firstmate watcher supervision through the Pi extension.",
     handler: async (_args, ctx) => {
-      const result = startArm(generation);
+      const result = await repairArm(generation);
       ctx.ui.notify(result.message, result.ok ? "info" : "warning");
     },
   });
@@ -869,7 +940,7 @@ export default function (pi: ExtensionAPI) {
       return new Container();
     },
     execute: async () => {
-      const result = startArm(generation);
+      const result = await repairArm(generation);
       return {
         content: [{ type: "text", text: result.message }],
         details: result,

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -122,6 +122,7 @@ const armReadiness = new WeakMap<ChildProcess, Promise<boolean>>();
 const armClose = new WeakMap<ChildProcess, Promise<void>>();
 const armRecovery = new WeakMap<ChildProcess, { generation: string; watcherPid: string }>();
 const intentionalIdleRetirements = new WeakSet<ChildProcess>();
+const unreadyArms = new WeakSet<ChildProcess>();
 
 function positiveInteger(name: string, fallback: number): number {
   const value = Number(process.env[name]);
@@ -440,11 +441,9 @@ export default function (pi: ExtensionAPI) {
     });
   }
 
-  async function retireArm(armChild: ChildProcess | null): Promise<boolean> {
-    if (!armChild) return true;
-    armChild.kill("SIGTERM");
+  function waitForArmClose(armChild: ChildProcess): Promise<boolean> {
     const closed = armClose.get(armChild);
-    if (!closed) return false;
+    if (!closed) return Promise.resolve(false);
     return new Promise((resolveRetired) => {
       const timer = setTimeout(() => resolveRetired(false), armRetireTimeoutMs);
       timer.unref();
@@ -453,6 +452,23 @@ export default function (pi: ExtensionAPI) {
         resolveRetired(true);
       });
     });
+  }
+
+  async function retireArm(armChild: ChildProcess | null): Promise<boolean> {
+    if (!armChild) return true;
+    armChild.kill("SIGTERM");
+    return waitForArmClose(armChild);
+  }
+
+  async function forceRetireArm(armChild: ChildProcess | null): Promise<boolean> {
+    if (!armChild) return true;
+    armChild.kill("SIGKILL");
+    return waitForArmClose(armChild);
+  }
+
+  async function retireUnreadyArm(armChild: ChildProcess): Promise<boolean> {
+    if (await retireArm(armChild)) return true;
+    return forceRetireArm(armChild);
   }
 
   async function restoreAfterActionableClose(owner: SessionGeneration, predecessorArmPid: string): Promise<{
@@ -545,6 +561,18 @@ export default function (pi: ExtensionAPI) {
       };
     }
     markLoaded();
+    if (owner.child && intentionalIdleRetirements.has(owner.child)) {
+      return {
+        ok: false,
+        message: "watcher: not armed - the prior idle retirement is still exiting; demand reconciliation will retry after it closes",
+      };
+    }
+    if (owner.child && unreadyArms.has(owner.child)) {
+      return {
+        ok: false,
+        message: "watcher: not armed - the previous arm failed readiness and is still exiting; demand reconciliation will retry after it closes",
+      };
+    }
     if (owner.child) {
       return {
         ok: true,
@@ -616,6 +644,7 @@ export default function (pi: ExtensionAPI) {
       resolveClosed();
       settleReadiness(false);
       releaseChild();
+      unreadyArms.delete(armChild);
       if (!generationIsLive(owner)) return;
       const classification = classifyClose(stdout, stderr, code, signal);
       const intentionalRetirement = intentionalIdleRetirements.has(armChild);
@@ -654,6 +683,7 @@ export default function (pi: ExtensionAPI) {
       resolveClosed();
       settleReadiness(false);
       releaseChild();
+      unreadyArms.delete(armChild);
       if (!generationIsLive(owner)) return;
       if (intentionalIdleRetirements.has(armChild)) {
         intentionalIdleRetirements.delete(armChild);
@@ -685,11 +715,22 @@ export default function (pi: ExtensionAPI) {
     if (!generationIsLive(owner)) return;
     const demand = owner.demandHintsReliable ? observedDemand : "uncertain";
     if (demand !== "idle") {
+      const retiringChild = owner.child;
+      if (retiringChild && intentionalIdleRetirements.has(retiringChild)) {
+        if (!(await forceRetireArm(retiringChild))) return;
+      }
       const result = startArm(owner);
       if (!result.ok) return;
       const armChild = owner.child;
-      if (armChild) await waitForReadiness(armChild);
-      else await waitForPendingRetry(owner);
+      if (armChild) {
+        const ready = await waitForReadiness(armChild);
+        if (!ready && generationIsLive(owner) && owner.child === armChild) {
+          unreadyArms.add(armChild);
+          await retireUnreadyArm(armChild);
+        }
+      } else {
+        await waitForPendingRetry(owner);
+      }
       return;
     }
     cancelRetry(owner);

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -60,6 +60,8 @@ type SessionGeneration = {
   stopping: boolean;
   child: ChildProcess | null;
   retryTimer: ReturnType<typeof setTimeout> | null;
+  retryReady: Promise<boolean> | null;
+  retryReadyResolve: ((ready: boolean) => void) | null;
   retryFailures: number;
   restoring: boolean;
   reconcileTail: Promise<void>;
@@ -250,6 +252,8 @@ function createGeneration(): SessionGeneration {
     stopping: false,
     child: null,
     retryTimer: null,
+    retryReady: null,
+    retryReadyResolve: null,
     retryFailures: 0,
     restoring: false,
     reconcileTail: Promise.resolve(),
@@ -271,6 +275,9 @@ function generationIsLive(generation: SessionGeneration): boolean {
 function cancelRetry(generation: SessionGeneration): void {
   if (generation.retryTimer) clearTimeout(generation.retryTimer);
   generation.retryTimer = null;
+  generation.retryReadyResolve?.(false);
+  generation.retryReadyResolve = null;
+  generation.retryReady = null;
 }
 
 function stopGeneration(generation: SessionGeneration): void {
@@ -491,13 +498,37 @@ export default function (pi: ExtensionAPI) {
       surfaceFailure(owner, `watcher: FAILED - Pi extension could not restore watcher continuity after ${retryLimit} retries\n${message}`);
       return;
     }
+    let resolveRetryReady: (ready: boolean) => void = () => {};
+    const retryReady = new Promise<boolean>((resolveReady) => {
+      resolveRetryReady = resolveReady;
+    });
+    owner.retryReady = retryReady;
+    owner.retryReadyResolve = resolveRetryReady;
+    const finishRetry = (ready: boolean): void => {
+      if (owner.retryReady === retryReady) {
+        owner.retryReady = null;
+        owner.retryReadyResolve = null;
+      }
+      resolveRetryReady(ready);
+    };
     const timer = setTimeout(() => {
       if (owner.retryTimer === timer) owner.retryTimer = null;
-      if (!generationIsLive(owner)) return;
+      if (!generationIsLive(owner)) {
+        finishRetry(false);
+        return;
+      }
       const result = startArm(owner, predecessorArmPid);
       if (!result.ok) {
         surfaceFailure(owner, `watcher: FAILED - Pi extension could not launch a continuity retry\n${result.message}`);
+        finishRetry(false);
+        return;
       }
+      const retryChild = owner.child;
+      if (!retryChild) {
+        finishRetry(false);
+        return;
+      }
+      void waitForReadiness(retryChild).then(finishRetry);
     }, retryDelay(owner.retryFailures));
     timer.unref();
     owner.retryTimer = timer;
@@ -638,6 +669,16 @@ export default function (pi: ExtensionAPI) {
     };
   }
 
+  async function waitForPendingRetry(owner: SessionGeneration): Promise<void> {
+    while (generationIsLive(owner)) {
+      const retryReady = owner.retryReady;
+      if (!retryReady) return;
+      await retryReady;
+      if (!generationIsLive(owner)) return;
+      if (!owner.retryReady && !owner.retryTimer && !owner.child) return;
+    }
+  }
+
   async function reconcileDemand(owner: SessionGeneration): Promise<void> {
     if (!generationIsLive(owner)) return;
     const observedDemand = await readSupervisionDemand();
@@ -648,6 +689,7 @@ export default function (pi: ExtensionAPI) {
       if (!result.ok) return;
       const armChild = owner.child;
       if (armChild) await waitForReadiness(armChild);
+      else await waitForPendingRetry(owner);
       return;
     }
     cancelRetry(owner);

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -268,10 +268,14 @@ function generationIsLive(generation: SessionGeneration): boolean {
   return activeGeneration === generation && !generation.stopping;
 }
 
-function stopGeneration(generation: SessionGeneration): void {
-  generation.stopping = true;
+function cancelRetry(generation: SessionGeneration): void {
   if (generation.retryTimer) clearTimeout(generation.retryTimer);
   generation.retryTimer = null;
+}
+
+function stopGeneration(generation: SessionGeneration): void {
+  generation.stopping = true;
+  cancelRetry(generation);
   if (generation.demandHintTimer) clearTimeout(generation.demandHintTimer);
   generation.demandHintTimer = null;
   for (const watcher of generation.demandWatchers.splice(0)) watcher.close();
@@ -583,11 +587,13 @@ export default function (pi: ExtensionAPI) {
       releaseChild();
       if (!generationIsLive(owner)) return;
       const classification = classifyClose(stdout, stderr, code, signal);
-      if (intentionalIdleRetirements.has(armChild) && classification.kind === "failure") {
+      const intentionalRetirement = intentionalIdleRetirements.has(armChild);
+      if (intentionalRetirement && classification.kind === "failure") {
         intentionalIdleRetirements.delete(armChild);
         void queueDemandReconciliation(owner);
         return;
       }
+      if (intentionalRetirement) intentionalIdleRetirements.delete(armChild);
       const predecessor = String(armChild.pid ?? "");
       if (classification.kind === "actionable") {
         if (owner.restoring) return;
@@ -638,14 +644,18 @@ export default function (pi: ExtensionAPI) {
     if (!generationIsLive(owner)) return;
     const demand = owner.demandHintsReliable ? observedDemand : "uncertain";
     if (demand !== "idle") {
-      startArm(owner);
+      const result = startArm(owner);
+      if (!result.ok) return;
+      const armChild = owner.child;
+      if (armChild) await waitForReadiness(armChild);
       return;
     }
+    cancelRetry(owner);
+    owner.retryFailures = 0;
     const armChild = owner.child;
     if (!armChild) return;
     intentionalIdleRetirements.add(armChild);
-    const retired = await retireArm(armChild);
-    if (!retired) intentionalIdleRetirements.delete(armChild);
+    await retireArm(armChild);
     if (!generationIsLive(owner)) return;
     const observedAfterRetirement = await readSupervisionDemand();
     if (!generationIsLive(owner)) return;
@@ -707,7 +717,7 @@ export default function (pi: ExtensionAPI) {
     owner.demandHintsReliable = true;
     watchDemandDirectory(owner, state, (filename) => {
       if (filename === null) return true;
-      if (filename === ".wake-queue" || filename === "x-watch.check.sh" || filename === "procevent") return true;
+      if (filename === ".wake-queue" || filename === "x-watch.check.sh" || filename === "procevent" || filename === ".lock") return true;
       return !filename.startsWith(".") && filename.endsWith(".meta");
     });
     const procevent = `${state}/procevent`;

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -10,7 +10,7 @@
 // callbacks from a prior generation are no-ops against the active replacement.
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, watch, writeFileSync, type FSWatcher } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
@@ -27,6 +27,10 @@ import {
   FIRSTMATE_CALM_PRESENTATION_EVENT,
 } from "./lib/fm-calm-visibility.ts";
 import { encodeFirstmateOperationalInput } from "./lib/fm-operational-input.ts";
+import {
+  FM_PI_WATCH_RECONCILE_EVENT,
+  type PiWatchReconcileRequest,
+} from "./lib/fm-pi-watch-coordination.ts";
 
 type ArmResult = {
   ok: boolean;
@@ -58,6 +62,10 @@ type SessionGeneration = {
   retryTimer: ReturnType<typeof setTimeout> | null;
   retryFailures: number;
   restoring: boolean;
+  reconcileTail: Promise<void>;
+  demandWatchers: FSWatcher[];
+  demandHintTimer: ReturnType<typeof setTimeout> | null;
+  demandHintsReliable: boolean;
   seq: number;
 };
 
@@ -88,6 +96,7 @@ const fmRoot = process.env.FM_ROOT_OVERRIDE || root;
 const state = process.env.FM_STATE_OVERRIDE || `${fmHome}/state`;
 const config = process.env.FM_CONFIG_OVERRIDE || `${fmHome}/config`;
 const armScript = `${fmRoot}/bin/fm-watch-arm.sh`;
+const supervisionLib = `${fmRoot}/bin/fm-supervision-lib.sh`;
 const marker = `${state}/.pi-watch-extension-loaded`;
 const extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
 const retryBaseMs = positiveInteger("FM_WATCH_REARM_RETRY_BASE_MS", 250);
@@ -101,6 +110,7 @@ const armReadyTimeoutMs = positiveInteger(
   process.platform === "win32" ? 35000 : 12000,
 );
 const armRetireTimeoutMs = positiveInteger("FM_WATCH_ARM_RETIRE_TIMEOUT_MS", 1000);
+const demandDebounceMs = positiveInteger("FM_PI_DEMAND_DEBOUNCE_MS", 50);
 const repairOnlyHint = "call fm_watch_arm_pi again only after a later notification says the cycle is missing, failed, or unhealthy";
 const shuttingDownMessage = "watcher: not armed - Pi session is shutting down";
 
@@ -109,6 +119,7 @@ let activeGeneration: SessionGeneration | null = null;
 const armReadiness = new WeakMap<ChildProcess, Promise<boolean>>();
 const armClose = new WeakMap<ChildProcess, Promise<void>>();
 const armRecovery = new WeakMap<ChildProcess, { generation: string; watcherPid: string }>();
+const intentionalIdleRetirements = new WeakSet<ChildProcess>();
 
 function positiveInteger(name: string, fallback: number): number {
   const value = Number(process.env[name]);
@@ -190,6 +201,49 @@ function classifyClose(stdout: string, stderr: string, code: number | null, sign
   };
 }
 
+function readSupervisionDemand(): Promise<"needed" | "idle" | "uncertain"> {
+  return new Promise((resolveDemand) => {
+    let output = "";
+    let settled = false;
+    const settle = (demand: "needed" | "idle" | "uncertain"): void => {
+      if (settled) return;
+      settled = true;
+      resolveDemand(demand);
+    };
+    let child: ChildProcess;
+    try {
+      child = spawn(
+        "bash",
+        [
+          "-c",
+          '. "$1" || exit 1; fm_supervision_status "$2"; printf "needed=%s certain=%s\\n" "$FM_SUP_NEEDED" "$FM_SUP_CERTAIN"',
+          "fm-pi-supervision-demand",
+          supervisionLib,
+          state,
+        ],
+        { stdio: ["ignore", "pipe", "ignore"] },
+      );
+    } catch {
+      settle("uncertain");
+      return;
+    }
+    child.stdout?.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+    child.on("error", () => settle("uncertain"));
+    child.on("close", (code) => {
+      if (code !== 0) {
+        settle("uncertain");
+        return;
+      }
+      const result = output.trim();
+      if (result === "needed=true certain=true") settle("needed");
+      else if (result === "needed=false certain=true") settle("idle");
+      else settle("uncertain");
+    });
+  });
+}
+
 function createGeneration(): SessionGeneration {
   return {
     id: ++nextGenerationId,
@@ -198,6 +252,10 @@ function createGeneration(): SessionGeneration {
     retryTimer: null,
     retryFailures: 0,
     restoring: false,
+    reconcileTail: Promise.resolve(),
+    demandWatchers: [],
+    demandHintTimer: null,
+    demandHintsReliable: true,
     seq: 0,
   };
 }
@@ -214,6 +272,9 @@ function stopGeneration(generation: SessionGeneration): void {
   generation.stopping = true;
   if (generation.retryTimer) clearTimeout(generation.retryTimer);
   generation.retryTimer = null;
+  if (generation.demandHintTimer) clearTimeout(generation.demandHintTimer);
+  generation.demandHintTimer = null;
+  for (const watcher of generation.demandWatchers.splice(0)) watcher.close();
   if (generation.child) generation.child.kill("SIGTERM");
   generation.child = null;
 }
@@ -522,6 +583,11 @@ export default function (pi: ExtensionAPI) {
       releaseChild();
       if (!generationIsLive(owner)) return;
       const classification = classifyClose(stdout, stderr, code, signal);
+      if (intentionalIdleRetirements.has(armChild) && classification.kind === "failure") {
+        intentionalIdleRetirements.delete(armChild);
+        void queueDemandReconciliation(owner);
+        return;
+      }
       const predecessor = String(armChild.pid ?? "");
       if (classification.kind === "actionable") {
         if (owner.restoring) return;
@@ -552,6 +618,11 @@ export default function (pi: ExtensionAPI) {
       settleReadiness(false);
       releaseChild();
       if (!generationIsLive(owner)) return;
+      if (intentionalIdleRetirements.has(armChild)) {
+        intentionalIdleRetirements.delete(armChild);
+        void queueDemandReconciliation(owner);
+        return;
+      }
       if (owner.restoring) return;
       scheduleRetry(owner, `watcher: FAILED - Pi extension arm child ${id} failed: ${error.message}`, String(armChild.pid ?? ""));
     });
@@ -561,17 +632,112 @@ export default function (pi: ExtensionAPI) {
     };
   }
 
-  pi.on?.("session_start", () => {
+  async function reconcileDemand(owner: SessionGeneration): Promise<void> {
+    if (!generationIsLive(owner)) return;
+    const observedDemand = await readSupervisionDemand();
+    if (!generationIsLive(owner)) return;
+    const demand = owner.demandHintsReliable ? observedDemand : "uncertain";
+    if (demand !== "idle") {
+      startArm(owner);
+      return;
+    }
+    const armChild = owner.child;
+    if (!armChild) return;
+    intentionalIdleRetirements.add(armChild);
+    const retired = await retireArm(armChild);
+    if (!retired) intentionalIdleRetirements.delete(armChild);
+    if (!generationIsLive(owner)) return;
+    const observedAfterRetirement = await readSupervisionDemand();
+    if (!generationIsLive(owner)) return;
+    const demandAfterRetirement = owner.demandHintsReliable ? observedAfterRetirement : "uncertain";
+    if (demandAfterRetirement === "idle") return;
+    startArm(owner);
+  }
+
+  function queueDemandReconciliation(owner: SessionGeneration): Promise<void> {
+    const run = owner.reconcileTail.then(
+      () => reconcileDemand(owner),
+      () => reconcileDemand(owner),
+    );
+    owner.reconcileTail = run.catch(() => {
+      // An uncertain reconciliation is retried by the next lifecycle or state hint.
+    });
+    return run;
+  }
+
+  function scheduleDemandHint(owner: SessionGeneration): void {
+    if (!generationIsLive(owner)) return;
+    if (owner.demandHintTimer) clearTimeout(owner.demandHintTimer);
+    const timer = setTimeout(() => {
+      if (owner.demandHintTimer === timer) owner.demandHintTimer = null;
+      if (generationIsLive(owner)) void queueDemandReconciliation(owner);
+    }, demandDebounceMs);
+    timer.unref();
+    owner.demandHintTimer = timer;
+  }
+
+  function watchDemandDirectory(
+    owner: SessionGeneration,
+    directory: string,
+    relevant: (filename: string | null) => boolean,
+  ): void {
+    try {
+      const watcher = watch(directory, (eventType, filename) => {
+        const name = filename === null ? null : String(filename);
+        if (eventType === "rename" && directory === state && name === "procevent") {
+          installDemandWatchers(owner);
+        }
+        if (relevant(name)) scheduleDemandHint(owner);
+      });
+      watcher.on("error", () => {
+        owner.demandHintsReliable = false;
+        scheduleDemandHint(owner);
+      });
+      watcher.unref();
+      owner.demandWatchers.push(watcher);
+    } catch {
+      owner.demandHintsReliable = false;
+      scheduleDemandHint(owner);
+    }
+  }
+
+  function installDemandWatchers(owner: SessionGeneration): void {
+    if (!generationIsLive(owner)) return;
+    for (const watcher of owner.demandWatchers.splice(0)) watcher.close();
+    owner.demandHintsReliable = true;
+    watchDemandDirectory(owner, state, (filename) => {
+      if (filename === null) return true;
+      if (filename === ".wake-queue" || filename === "x-watch.check.sh" || filename === "procevent") return true;
+      return !filename.startsWith(".") && filename.endsWith(".meta");
+    });
+    const procevent = `${state}/procevent`;
+    if (existsSync(procevent)) {
+      watchDemandDirectory(owner, procevent, (filename) =>
+        filename === null || filename.endsWith(".source"));
+    }
+  }
+
+  pi.on?.("session_start", async () => {
     if (generation.stopping) generation = createGeneration();
     activateGeneration(generation);
     markLoaded();
+    installDemandWatchers(generation);
+    await queueDemandReconciliation(generation);
+  });
+  pi.events?.on?.(FM_PI_WATCH_RECONCILE_EVENT, (value) => {
+    const request = value as Partial<PiWatchReconcileRequest>;
+    if (typeof request.waitUntil !== "function") return;
+    request.waitUntil(queueDemandReconciliation(generation));
+  });
+  pi.on?.("agent_settled", async () => {
+    await queueDemandReconciliation(generation);
   });
   pi.on?.("session_shutdown", () => {
     stopGeneration(generation);
   });
 
   pi.registerCommand?.("fm-watch-arm-pi", {
-    description: "Arm firstmate watcher supervision through the Pi extension instead of foreground bash.",
+    description: "Explicitly repair firstmate watcher supervision through the Pi extension.",
     handler: async (_args, ctx) => {
       const result = startArm(generation);
       ctx.ui.notify(result.message, result.ok ? "info" : "warning");
@@ -581,11 +747,7 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool?.({
     name: "fm_watch_arm_pi",
     label: "Arm firstmate watcher",
-    description: "Start the first required Pi watcher cycle, or repair one only after a notification says the cycle is missing, failed, or unhealthy. Do not call after ordinary work or ordinary notifications; the Pi extension re-arms automatically. Never run bin/fm-watch-arm.sh through bash.",
-    promptSnippet: "Start the first required Pi watcher cycle or repair a cycle reported missing, failed, or unhealthy; ordinary re-arming is automatic.",
-    promptGuidelines: [
-      "Call fm_watch_arm_pi only for the first required cycle or after a notification says the cycle is missing, failed, or unhealthy. Do not call it after ordinary work, turn completion, or ordinary signal, stale, check, or heartbeat handling because the Pi extension owns re-arming. Never run bin/fm-watch-arm.sh through bash.",
-    ],
+    description: "Rare explicit repair for a Pi watcher cycle reported missing, failed, or unhealthy. Normal demand-based start, stop, and continuation are automatic. Never run bin/fm-watch-arm.sh through bash.",
     parameters: Type.Object({}),
     renderShell: "self",
     renderCall: (_args, theme, context) => {

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -8,6 +8,10 @@ import {
   classifyFirstmateCurrentOperationalText,
   encodeFirstmateOperationalInput,
 } from "./lib/fm-operational-input.ts";
+import {
+  FM_PI_WATCH_RECONCILE_EVENT,
+  type PiWatchReconcileRequest,
+} from "./lib/fm-pi-watch-coordination.ts";
 
 let guardFollowupActive = false;
 
@@ -438,6 +442,17 @@ async function claimSessionstartMessage(
   return sessionstartMessage(generation, result);
 }
 
+async function waitForWatchDemandReconciliation(pi: ExtensionAPI): Promise<void> {
+  const waits: Promise<unknown>[] = [];
+  const request: PiWatchReconcileRequest = {
+    waitUntil(promise) {
+      waits.push(Promise.resolve(promise));
+    },
+  };
+  pi.events?.emit?.(FM_PI_WATCH_RECONCILE_EVENT, request);
+  await Promise.all(waits.map((wait) => wait.catch(() => undefined)));
+}
+
 function runGuard(): Promise<{ code: number; stderr: string }> {
   return new Promise((resolveResult) => {
     const child = spawn(`${root}/bin/fm-turnend-guard.sh`, {
@@ -580,6 +595,7 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
+    await waitForWatchDemandReconciliation(pi);
     const result = await runGuard();
     if (result.code !== 2) return;
 

--- a/.pi/extensions/lib/fm-pi-watch-coordination.ts
+++ b/.pi/extensions/lib/fm-pi-watch-coordination.ts
@@ -1,0 +1,8 @@
+// Synchronous event-bus handshake between the Pi watcher and turn-end guard.
+// The guard collects the local reconciliation promise before it evaluates
+// whether a repair follow-up is needed.
+export const FM_PI_WATCH_RECONCILE_EVENT = "fm-primary-pi-watch:reconcile-demand";
+
+export type PiWatchReconcileRequest = {
+  waitUntil(promise: Promise<unknown>): void;
+};

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -150,7 +150,8 @@ fi
 
 # Compute supervision need and watcher-beacon freshness via the shared
 # grace-based predicate (bin/fm-supervision-lib.sh). Act when work, an event
-# source, or an X-mode relay poll needs supervision.
+# source, an X-mode relay poll, a pending durable wake, or uncertain state needs
+# supervision.
 fm_supervision_status "$STATE" "$GRACE"
 in_flight=$FM_SUP_IN_FLIGHT
 sources=$FM_SUP_SOURCES
@@ -207,8 +208,12 @@ if [ "$watcher_healthy" = false ]; then
         printf '●  %s task(s) in flight, but %s.\n' "$in_flight" "$watcher_cause"
       elif [ "$sources" -gt 0 ]; then
         printf '●  %s process-event source(s) registered, but %s.\n' "$sources" "$watcher_cause"
-      else
+      elif "$queue_pending"; then
+        printf '●  A pending durable wake needs supervision until drain, but %s.\n' "$watcher_cause"
+      elif [ -f "$STATE/x-watch.check.sh" ]; then
         printf '●  X-mode relay polling needs supervision, but %s.\n' "$watcher_cause"
+      else
+        printf '●  Supervision demand state is uncertain, but %s.\n' "$watcher_cause"
       fi
       if [ "$READ_ONLY" -eq 1 ]; then
         printf '●  This read-only session should report the lapse, not repair it.\n'

--- a/bin/fm-supervision-lib.sh
+++ b/bin/fm-supervision-lib.sh
@@ -25,34 +25,86 @@ fm_sup_stat_mtime() {
 # Populates, for the state dir at $1:
 #   FM_SUP_IN_FLIGHT      count of state/*.meta (in-flight tasks)
 #   FM_SUP_SOURCES        count of registered process-to-event sources
-#   FM_SUP_NEEDED         true/false - in-flight work, an X-mode relay poll, or a
-#                         registered event source (a source is a wait on an
-#                         external process, not a task, so it has no metadata)
+#   FM_SUP_NEEDED         true/false - in-flight work, an X-mode relay poll, a
+#                         registered event source, or a pending durable wake
+#                         (a source is a wait on an external process, not a task,
+#                         so it has no metadata)
 #   FM_SUP_WATCHER_FRESH  true/false - a watcher beacon within the grace window
 #   FM_SUP_BEACON_DESC    human-readable beacon age, for banners ("never" if absent)
 #   FM_SUP_QUEUE_PENDING  true/false - state/.wake-queue has unread records
+#   FM_SUP_CERTAIN        true/false - every demand-bearing state path was safely
+#                         classifiable; uncertainty keeps FM_SUP_NEEDED true
 # grace-seconds defaults to $FM_GUARD_GRACE, then 300, matching fm-guard.sh.
 # Always returns 0; callers read the vars, or use fm_supervision_unhealthy below.
 fm_supervision_status() {
-  local state=$1 grace=${2:-${FM_GUARD_GRACE:-300}} meta source beat m age
+  local state=$1 grace=${2:-${FM_GUARD_GRACE:-300}} meta source path beat m age
   FM_SUP_IN_FLIGHT=0
   FM_SUP_NEEDED=false
   FM_SUP_WATCHER_FRESH=false
   FM_SUP_BEACON_DESC=never
   FM_SUP_QUEUE_PENDING=false
-
-  for meta in "$state"/*.meta; do
-    [ -e "$meta" ] || continue
-    FM_SUP_IN_FLIGHT=$((FM_SUP_IN_FLIGHT + 1))
-  done
+  FM_SUP_CERTAIN=true
   FM_SUP_SOURCES=0
-  for source in "$state"/procevent/*.source; do
-    [ -e "$source" ] || continue
-    FM_SUP_SOURCES=$((FM_SUP_SOURCES + 1))
-  done
+
+  if [ -e "$state" ] || [ -L "$state" ]; then
+    if [ ! -d "$state" ] || [ -L "$state" ] || [ ! -r "$state" ] || [ ! -x "$state" ]; then
+      FM_SUP_CERTAIN=false
+    else
+      # Published task records use the non-hidden state/<id>.meta name. Spawn and
+      # relaunch stage dot-prefixed .<id>.meta.* files before atomic publication,
+      # so the glob deliberately excludes them. Record contents and endpoint
+      # liveness do not affect demand: dead, stalled, and malformed published
+      # tasks still need supervision.
+      for meta in "$state"/*.meta; do
+        [ -e "$meta" ] || [ -L "$meta" ] || continue
+        if [ -f "$meta" ] && [ ! -L "$meta" ] && [ -r "$meta" ]; then
+          FM_SUP_IN_FLIGHT=$((FM_SUP_IN_FLIGHT + 1))
+        else
+          FM_SUP_CERTAIN=false
+        fi
+      done
+
+      path="$state/procevent"
+      if [ -e "$path" ] || [ -L "$path" ]; then
+        if [ ! -d "$path" ] || [ -L "$path" ] || [ ! -r "$path" ] || [ ! -x "$path" ]; then
+          FM_SUP_CERTAIN=false
+        else
+          for source in "$path"/*.source; do
+            [ -e "$source" ] || [ -L "$source" ] || continue
+            if [ -f "$source" ] && [ ! -L "$source" ] && [ -r "$source" ]; then
+              FM_SUP_SOURCES=$((FM_SUP_SOURCES + 1))
+            else
+              FM_SUP_CERTAIN=false
+            fi
+          done
+        fi
+      fi
+
+      path="$state/.wake-queue"
+      if [ -e "$path" ] || [ -L "$path" ]; then
+        if [ -f "$path" ] && [ ! -L "$path" ] && [ -r "$path" ]; then
+          # shellcheck disable=SC2034 # Read by callers (fm-guard.sh) after sourcing.
+          [ -s "$path" ] && FM_SUP_QUEUE_PENDING=true
+        else
+          FM_SUP_CERTAIN=false
+        fi
+      fi
+
+      path="$state/x-watch.check.sh"
+      if [ -e "$path" ] || [ -L "$path" ]; then
+        if [ -f "$path" ] && [ ! -L "$path" ] && [ -r "$path" ]; then
+          FM_SUP_NEEDED=true
+        else
+          FM_SUP_CERTAIN=false
+        fi
+      fi
+    fi
+  fi
+
   if [ "$FM_SUP_IN_FLIGHT" -gt 0 ] \
-    || [ -f "$state/x-watch.check.sh" ] \
-    || [ "$FM_SUP_SOURCES" -gt 0 ]; then
+    || [ "$FM_SUP_SOURCES" -gt 0 ] \
+    || [ "$FM_SUP_QUEUE_PENDING" = true ] \
+    || [ "$FM_SUP_CERTAIN" = false ]; then
     FM_SUP_NEEDED=true
   fi
 
@@ -69,8 +121,6 @@ fm_supervision_status() {
     fi
   fi
 
-  # shellcheck disable=SC2034 # Read by callers (fm-guard.sh) after sourcing.
-  [ -s "$state/.wake-queue" ] && FM_SUP_QUEUE_PENDING=true
   return 0
 }
 

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -187,8 +187,12 @@ block_stop() {
       printf '●  %s task(s) in flight, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_IN_FLIGHT" "$FM_SUP_BEACON_DESC"
     elif [ "$FM_SUP_SOURCES" -gt 0 ]; then
       printf '●  %s process-event source(s) registered, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_SOURCES" "$FM_SUP_BEACON_DESC"
-    else
+    elif [ "$FM_SUP_QUEUE_PENDING" = true ]; then
+      printf '●  A pending durable wake needs supervision until drain, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_BEACON_DESC"
+    elif [ -f "$STATE/x-watch.check.sh" ]; then
       printf '●  X-mode relay polling needs supervision, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_BEACON_DESC"
+    else
+      printf '●  Supervision demand state is uncertain, and no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_BEACON_DESC"
     fi
     if [ "$CLAUDE_MODE" -eq 1 ]; then
       printf '●  The Stop-owned auto-arm did not claim this home either, so recovery is NOT already under way.\n'
@@ -422,8 +426,12 @@ if [ "$terminal_status" -eq 0 ]; then
     NEED_DESC="$FM_SUP_IN_FLIGHT task(s) in flight"
   elif [ "$FM_SUP_SOURCES" -gt 0 ]; then
     NEED_DESC="$FM_SUP_SOURCES process-event source(s) registered"
-  else
+  elif [ "$FM_SUP_QUEUE_PENDING" = true ]; then
+    NEED_DESC="a durable wake still pending drain"
+  elif [ -f "$STATE/x-watch.check.sh" ]; then
     NEED_DESC="X-mode relay polling active"
+  else
+    NEED_DESC="supervision demand state uncertain"
   fi
   printf '{"systemMessage":"FIRSTMATE SUPERVISION IS GENUINELY DOWN: %s, the Stop-owned auto-arm exhausted its bounded retries and one failure notice, no watcher or automatic continuation exists, and the block budget is exhausted. Keep this session attended and diagnose the automatic Stop-hook and watcher startup before relying on unattended supervision."}\n' "$NEED_DESC"
   exit 0

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -4,19 +4,20 @@ When this session owns supervision and away mode is not active:
 1. Drain first with `bin/fm-wake-drain.sh`.
    After handling all emitted wakes and reconciling open decisions and unread status lines, run the exact `--ack-through` command printed as `WAKE_ACK_REQUIRED`; until then the work remains durable for idempotent re-handling after interruption.
 2. Confirm the Pi primary auto-loaded both project extensions (plain `pi` or `pi-signed`, after approving project trust once per clone); if not, restart the selected executable with `-e __FM_PI_TURNEND_EXT__ -e __FM_PI_EXT__` as a trust-free fallback.
-3. First cycle only: make the one required `fm_watch_arm_pi` call.
-   Use `/fm-watch-arm-pi` only as a human-entered fallback.
-   Never run `bin/fm-watch-arm.sh` through Pi's bash tool because that foreground arm can wedge the agent and bypasses extension-owned cleanup.
-4. If the extension says no live session holds the lock, run `bin/fm-session-start.sh` to reclaim the session lock, then call `fm_watch_arm_pi` again.
-5. The extension starts `bin/fm-watch-arm.sh --restart`, keeps the child attached to the live Pi process, and owns every later successor launch.
-6. Ordinary same-process session replacement (`/new`, `/resume`, `/fork`, reload) retires only the prior generation; call `fm_watch_arm_pi` once for the first cycle of the replacement session without restarting Pi.
+3. The extension starts monitoring automatically when supervision demand appears and retires monitoring automatically when that demand clears.
+4. Demand includes published task records, Relay polling, registered process-event sources, and a pending durable wake until drain acknowledgement removes it.
+   Dead, stalled, malformed, or unreadable published task state keeps monitoring active, while dot-prefixed spawn and relaunch staging records do not count.
+5. Session start, each settled main run, and filtered debounced demand-state hints trigger serialized reconciliation without a model turn.
+   Idle retirement re-reads demand after the child exits so a concurrent publication restarts monitoring immediately.
+6. The extension starts `bin/fm-watch-arm.sh --restart`, keeps the child attached to the live Pi process, and owns later successor launch or intentional idle retirement.
+7. Ordinary same-process session replacement (`/new`, `/resume`, `/fork`, reload) retires only the prior generation and reconciles the replacement automatically.
    The generation-owner contract lives in `.pi/extensions/fm-primary-pi-watch.ts`.
-7. After an actionable child close, the extension rechecks session-lock ownership and verifies one successor before it delivers the follow-up wake; its bounded fallback is defined in `docs/watcher-continuity.md`.
-8. Ordinary work, turn completion, and ordinary signal, stale, check, heartbeat, or other wake handling: do not call `fm_watch_arm_pi` again because continuity is extension-owned rather than model-memory-owned.
-9. An unexpected child close enters bounded exponential retry, and an exhausted retry or lost session lock is surfaced as a watcher failure instead of disappearing.
-10. Missing, failed, or unhealthy cycle only: if a later notification explicitly reports one of those repair conditions, drain queued wakes, inspect the failure text, call `fm_watch_arm_pi`, and restart the selected Pi-family executable with both extensions loaded if needed.
-   A redundant call while the extension owns an arm child or scheduled retry is an ownership-based `watcher: unchanged` no-op, not an independent health claim.
-11. Never use shell `&` for watcher supervision.
+8. After an actionable child close, the extension rechecks session-lock ownership and verifies one demanded successor before it delivers the follow-up wake; its bounded fallback is defined in `docs/watcher-continuity.md`.
+9. Ordinary work, turn completion, and ordinary signal, stale, check, heartbeat, or other wake handling: do not call `fm_watch_arm_pi` because demand reconciliation and continuity are extension-owned.
+10. Missing, failed, or unhealthy cycle only: drain queued wakes, inspect the failure text, call the rare explicit repair tool `fm_watch_arm_pi`, and restart the selected Pi-family executable with both extensions loaded if needed.
+   Use `/fm-watch-arm-pi` only as a human-entered fallback.
+   A redundant repair while the extension owns an arm child or scheduled retry is an ownership-based `watcher: unchanged` no-op, not an independent health claim.
+11. Never run `bin/fm-watch-arm.sh` through Pi's bash tool and never use shell `&` for watcher supervision.
    The arm mechanism above is extension-owned, not a model tool call, but a manual recovery probe that backgrounds, pipes, or bundles the arm is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`, wired into the turn-end guard extension at `__FM_PI_TURNEND_EXT__`).
 
 The supervision branch is default-on (docs/pi-supervision-branch.md): whenever this session owns the fleet lock and away mode is not active, the watcher extension hands eligible task-local rows from ordinary actionable wakes, plus selected fleet-wide heartbeat reviews, to the persistent in-process supervision branch while main-only rows remain queued for this conversation.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -13,7 +13,7 @@ Do not infer this guard's scope, loop safety, or compatibility tradeoffs for tho
 
 `bin/fm-guard.sh` is a pull-based warning that runs only when another supervision command invokes it.
 The turn-end guard closes the remaining gap at the primary's own turn boundary.
-When work, a process-event source, or Relay polling needs supervision at that boundary and no identity-matched watcher has a fresh beacon, the harness integration must either block the turn end or force one bounded follow-up that uses the recovery instruction from the emitted session-start protocol.
+When work, a process-event source, Relay polling, or a pending durable wake needs supervision at that boundary and no identity-matched watcher has a fresh beacon, the harness integration must either block the turn end or force one bounded follow-up that uses the recovery instruction from the emitted session-start protocol.
 The mid-turn pull warning uses the model-aware supervision verdict described below, while the turn-end guard keeps the PID-strict watcher predicate.
 The guard remains a backstop; [`watcher-continuity.md`](watcher-continuity.md) owns normal continuity.
 
@@ -26,10 +26,13 @@ An unmarked checkout or invalid marker falls through to the git-dir check.
 That check keeps crewmate and scout linked worktrees inert because their git dir differs from their git common dir.
 It also requires `AGENTS.md`, `bin/`, and the effective state directory.
 
-For an in-scope primary, the guard counts in-flight work from `state/*.meta`.
-Registered `state/procevent/*.source` records also require supervision even though they have no task metadata.
-The default cross-harness mode exits silently with no supervision need.
+For an in-scope primary, the guard gets the complete supervision-demand verdict from `bin/fm-supervision-lib.sh`.
+Published non-hidden `state/*.meta` task records count even when their worker is dead or stalled, while dot-prefixed spawn and relaunch staging records do not count.
+Registered `state/procevent/*.source` records require supervision even though they have no task metadata.
 Every mode treats `state/x-watch.check.sh` as supervision need, so Relay polling remains guarded without an in-flight task.
+A non-empty `state/.wake-queue` keeps supervision required until its durable rows are acknowledged and removed.
+Unreadable, malformed, or uncertain demand-bearing state keeps supervision required rather than producing an idle verdict.
+The default cross-harness mode exits silently only when that shared verdict reports no supervision need.
 Otherwise it calls `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] [home]` from `bin/fm-wake-lib.sh`, the same PID-strict identity-matched lock and fresh-beacon check used by `bin/fm-watch-arm.sh`: a stale beacon blocks even when a watcher pid is live, and a fresh leftover beacon blocks when the lock is missing, dead, or identity-mismatched.
 The turn-end guard needs that strict check because it fires at the turn boundary, where the auto-arm is bringing a fresh watcher up for the upcoming idle period, and it cooperates with that arm rather than trusting a beacon left by the cycle that just ended.
 `bin/fm-guard.sh`, the pull warning, instead uses the model-aware `fm_watcher_supervision_verdict` from the same library, because it fires mid-turn when the auto-arm model runs no watcher at all.
@@ -52,7 +55,7 @@ If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot s
 - Claude registers two `Stop` hooks in `.claude/settings.json`, both anchored through `CLAUDE_PROJECT_DIR`: `bin/fm-turnend-guard.sh --claude`, and `bin/fm-claude-stop-autoarm.sh` with `asyncRewake: true` and `timeout: 28800`.
 - Codex registers a `Stop` hook in `.codex/hooks.json`, anchors the executable to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and passes the original payload to the shared guard.
 - OpenCode listens for `session.idle` in `.opencode/plugins/fm-primary-turnend-guard.js`, lets the watcher coordinator act first, and calls `client.session.promptAsync` once when the guard returns 2.
-- Pi listens for `agent_settled` in `.pi/extensions/fm-primary-turnend-guard.ts`, runs once per logical agent run, and calls `pi.sendUserMessage(..., { deliverAs: "followUp" })` once when the guard returns 2.
+- Pi listens for `agent_settled` in `.pi/extensions/fm-primary-turnend-guard.ts`, waits for the watcher extension's serialized local demand reconciliation, runs once per logical agent run, and calls `pi.sendUserMessage(..., { deliverAs: "followUp" })` once when the guard still returns 2.
 - Cursor registers a `stop` hook in `.cursor/hooks.json` and delegates the whole turn boundary to `bin/fm-turnend-guard-cursor.sh`, the park described below.
   Cursor also loads `<project>/.claude/settings.json`, so every tracked Claude-shaped entrypoint whose event Cursor covers stands down on a Cursor-delivered payload through `bin/fm-hook-host-lib.sh`.
   That predicate reads the delivered payload's own `cursor_version`, never the environment: Cursor exports `CURSOR_INVOKED_AS`, `CURSOR_PROJECT_DIR`, and `CURSOR_VERSION` into every child process, so an environment guard would also disable the hooks of a Claude session started by hand from a Cursor pane, which is the hazard the `GROK_SESSION_ID` exclusion below records.
@@ -159,7 +162,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 
 ## Regression coverage
 
-`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, the cooperative `--claude` open-generation claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, generation and legacy claim cases that must block or clear instead of allowing a blind stop, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
+`tests/fm-turnend-guard.test.sh` covers published-versus-staged task demand, uncertain-state monitoring, pending-wake demand, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, the cooperative `--claude` open-generation claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, generation and legacy claim cases that must block or clear instead of allowing a blind stop, Pi reconciliation ordering and logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
 `tests/fm-guard-stale-banner.test.sh` covers the pull-guard predicate, including the persistent-model fresh-leftover-beacon negative control, the auto-arm model's healthy fresh-beacon-without-a-watcher case and stale-beacon alarm, and the extension model's live-watcher path, ownership-qualified fresh hand-off, held-lock failures, independently broken ownership signals, stale-beacon alarm, queued-wake warning, and Pi and pi-signed harness routing.
 It also covers true-reason banner wording and reason-keyed episode dedup surviving a beacon mtime change.
 `tests/fm-cursor-primary.test.sh` covers the Cursor park end to end over real processes with no harness installed: each tracked Claude-shaped entrypoint standing down on a Cursor payload, both follow-up sources, the bounded repair nag and its reset, the nested loop bounds, supersession, away-mode and lock-ownership inertness, Pi-host stand-down without Cursor identity and continued parking when `PI_CODING_AGENT` leaks alongside `CURSOR_AGENT` or `CURSOR_INVOKED_AS`, child-worktree exclusion, and that the adapter never exits 2.

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -5,10 +5,15 @@ Must-work continuity now lives above that process boundary instead of depending 
 
 ## Ownership
 
-Pi's `.pi/extensions/fm-primary-pi-watch.ts` and OpenCode's `.opencode/plugins/fm-primary-watch-arm.js` own continuous re-arm after an actionable child close.
-Each adapter starts the next arm before delivering the wake prompt, checks current session-lock ownership at launch, preserves one child or scheduled retry at a time, and applies bounded exponential retry after an unexpected or failed close.
+Pi's `.pi/extensions/fm-primary-pi-watch.ts` owns demand-driven monitoring, while OpenCode's `.opencode/plugins/fm-primary-watch-arm.js` owns continuous re-arm after an actionable child close.
+Pi reconciles demand at session start, after each settled main run, and after filtered debounced state hints without opening a model turn.
+`bin/fm-supervision-lib.sh` is the demand authority: published task records, Relay polling, registered process-event sources, and a pending durable wake require monitoring.
+Dead, stalled, malformed, unreadable, or otherwise uncertain published state keeps monitoring active, while dot-prefixed task-record staging does not count.
+Pi starts the existing arm child directly when demand appears and intentionally retires it without retry or notification when demand clears.
+Idle retirement is serialized with every other reconciliation and re-reads demand after the child exits so a publication racing retirement restarts immediately.
+Each active adapter starts the next arm before delivering the wake prompt, checks current session-lock ownership at launch, preserves one child or scheduled retry at a time, and applies bounded exponential retry after an unexpected or failed close.
 A failed follow-up never cancels continuity restoration.
-Pi same-process session replacement follows the generation-owner contract in `.pi/extensions/fm-primary-pi-watch.ts`.
+Pi same-process session replacement follows the generation-owner contract in `.pi/extensions/fm-primary-pi-watch.ts` and reconciles the replacement automatically.
 Cursor's `.cursor/hooks.json` `stop` hook (`bin/fm-turnend-guard-cursor.sh`) owns routine tokenless re-arm for a Cursor primary by parking that awaited hook on `bin/fm-watch-arm.sh` and returning an actionable close as one follow-up; [`turnend-guard.md`](turnend-guard.md#harness-integrations) owns its Pi-host stand-down, loop bounds, and supersession baton.
 Claude's `.claude/settings.json` Stop `asyncRewake` hook (`bin/fm-claude-stop-autoarm.sh`) owns routine tokenless re-arm.
 The hook fires on every Stop, and an eligible primary with supervision need admits one home-scoped owner that foregrounds `bin/fm-watch-arm.sh` inside the hook-owned process tree.
@@ -23,6 +28,7 @@ While supervision is still needed and away mode remains inactive, an actionable 
 ## Actionable wake ordering
 
 After an actionable Pi or OpenCode child close, the adapter starts and verifies one singleton successor before it delivers the original wake.
+For Pi, the durable queued wake itself keeps demand active until the drain acknowledgement removes it.
 It confirms the handling handoff against that successor before scheduling the follow-up, retries once against the current generation and successor, and treats a failed confirmation as a restoration failure: it classifies the error, retires a successor that is no longer alive, and surfaces exactly one typed message.
 A failed confirmation is never swallowed.
 It waits at most one readiness timeout per attempt, then sends TERM and waits a bounded retirement confirmation before the next lock-verified exponential retry.
@@ -98,8 +104,9 @@ Only the watcher process touches `state/.last-watcher-beat`; no helper process c
 
 ## Regression coverage
 
-`tests/fm-pi-watch-extension.test.sh` checks Pi's first-cycle-or-explicit-repair tool metadata and ownership-based redundant-call no-ops, then simulates actionable and empty child closes against the actual Pi and OpenCode close handlers, blocks prompt delivery to prove the successor launches first, verifies single-flight behavior, changes the session lock before close to prove ownership is rechecked, and hangs each successor arm to prove bounded fallback delivery includes the typed restoration failure.
-The same suite covers ordinary same-process session replacement for `/new`, `/resume`, and `/fork`, same-instance shutdown-plus-start, stale prior-generation callbacks, repeated transitions with exactly one live cycle, disappearance of the shutting-down refusal after a valid replacement activates, and terminal quit still refusing late rearm.
+`tests/fm-pi-watch-extension.test.sh` checks zero-turn automatic start for every demand source, idle silence, intentional retirement, retirement-race restart, filtered external state hints, rare explicit-repair metadata, and ownership-based redundant-call no-ops.
+It also simulates actionable and empty child closes against the actual Pi and OpenCode close handlers, blocks prompt delivery to prove the successor launches first, verifies single-flight behavior, changes the session lock before close to prove ownership is rechecked, and hangs each successor arm to prove bounded fallback delivery includes the typed restoration failure.
+The same suite covers ordinary same-process session replacement for `/new`, `/resume`, and `/fork`, same-instance shutdown-plus-start, stale prior-generation callbacks, repeated transitions with exactly one demanded live cycle, disappearance of the shutting-down refusal after a valid replacement activates, and terminal quit still refusing late rearm.
 `tests/fm-watch-arm.test.sh` covers durable queue replay, real remote parent-replies ingestion into the authoritative status log, decision-only OPEN DECISIONS recovery, interrupted handling replay, generation-bound acknowledgement, a persistent live successor after recovery, a watcher close inside the handling window that must leave the printed acknowledgement valid, and the self-healing moved-generation acknowledgement that consumes its handled rows and names its remedy.
 `tests/fm-watch-recovery-loop.test.sh` covers the once-per-generation announcement bound with the real Pi extension against a refused handling handshake, and a handling successor that must surface a real crew event instead of going blind.
 `tests/fm-watcher-lock.test.sh` covers verified-successor attach, recovery publication before stale-lock removal, the typed self-eviction failure, bounded and successor-linked lifecycle rows, and a SIGSTOP counterfactual that distinguishes a live PID from a stale beacon before classifying termination.

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -678,6 +678,7 @@ test_rendering_and_session_lifecycle() {
   cp "$WORKING_SHIP" "$fixture/lib/fm-calm-working-ship.ts"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$fixture/lib/fm-operational-input.ts"
   cp "$ROOT/.pi/extensions/lib/fm-branch-dispatch.ts" "$fixture/lib/fm-branch-dispatch.ts"
+  cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$fixture/lib/fm-pi-watch-coordination.ts"
   cp "$WATCH_EXT" "$fixture/fm-primary-pi-watch.ts"
   ln -s "$PI_PACKAGE_DIR" "$fixture/node_modules/@earendil-works/pi-coding-agent"
   ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/node_modules/@earendil-works/pi-tui"
@@ -3126,6 +3127,7 @@ test_interactive_terminal_e2e() {
   cp "$WORKING_SHIP" "$project/.pi/extensions/lib/fm-calm-working-ship.ts"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$project/.pi/extensions/lib/fm-operational-input.ts"
   cp "$ROOT/.pi/extensions/lib/fm-branch-dispatch.ts" "$project/.pi/extensions/lib/fm-branch-dispatch.ts"
+  cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$project/.pi/extensions/lib/fm-pi-watch-coordination.ts"
   cp "$WATCH_EXT" "$project/.pi/extensions/fm-primary-pi-watch.ts"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$project/.pi/extensions/fm-primary-turnend-guard.ts"
   cp \

--- a/tests/fm-pi-primary-live-e2e.test.sh
+++ b/tests/fm-pi-primary-live-e2e.test.sh
@@ -257,9 +257,11 @@ cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$PROJECT/.pi/extensions/lib
 cp "$ROOT/.pi/extensions/lib/fm-calm-working-ship.ts" "$PROJECT/.pi/extensions/lib/fm-calm-working-ship.ts"
 cp "$ROOT/.pi/extensions/lib/fm-branch-dispatch.ts" "$PROJECT/.pi/extensions/lib/fm-branch-dispatch.ts"
 cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$PROJECT/.pi/extensions/lib/fm-operational-input.ts"
+cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$PROJECT/.pi/extensions/lib/fm-pi-watch-coordination.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$PROJECT/.pi/extensions/fm-primary-turnend-guard.ts"
 cp "$ROOT/bin/fm-watch-arm.sh" "$PROJECT/bin/fm-watch-arm.sh"
 cp "$ROOT/bin/fm-operational-input.sh" "$PROJECT/bin/fm-operational-input.sh"
+cp "$ROOT/bin/fm-supervision-lib.sh" "$PROJECT/bin/fm-supervision-lib.sh"
 cp "$ROOT/bin/fm-supervision-instructions.sh" "$PROJECT/bin/fm-supervision-instructions.sh"
 chmod +x "$PROJECT/bin/fm-operational-input.sh"
 mkdir -p "$HOME_DIR/state" "$HOME_DIR/config"
@@ -304,9 +306,16 @@ printf '%s\n' "$pane" | grep -Fq "calm transcript" \
 send_prompt "/calm"
 sleep 0.2
 
+send_prompt "Reply exactly READY_FOR_WATCH. After the next watcher wake, run bin/fm-wake-drain.sh and reply exactly HANDLED without calling fm_watch_arm_pi."
+wait_for_exact_line "READY_FOR_WATCH" 120 || fail "Pi did not settle the demand-driven watcher setup turn"
 : > "$HOME_DIR/state/pi-e2e.meta"
-send_prompt "Start supervision with fm_watch_arm_pi and never use bash to arm supervision. After the watcher wake arrives, run bin/fm-wake-drain.sh and reply exactly HANDLED."
-wait_for_text "watcher: started Pi extension arm child 1" || fail "Pi did not render the initial watcher tool result"
+i=0
+while [ "$i" -lt 240 ]; do
+  [ -s "$HOME_DIR/state/.watch.lock/pid" ] && break
+  sleep 0.25
+  i=$((i + 1))
+done
+[ -s "$HOME_DIR/state/.watch.lock/pid" ] || fail "Pi did not start watcher monitoring when task demand appeared"
 
 printf 'done: pi live e2e watcher fire\n' > "$HOME_DIR/state/pi-e2e.status"
 i=0
@@ -327,7 +336,7 @@ if printf '%s\n' "$pane" | grep -Fq "$foreground_arm"; then
   fail "Pi used a foreground bash watcher arm"
 fi
 arm_tool_result_count=$(printf '%s\n' "$pane" | grep -Ec 'watcher: (started|unchanged|not armed|read-only)' || true)
-[ "$arm_tool_result_count" -eq 1 ] || fail "Pi model re-armed from memory instead of the extension (tool-result count $arm_tool_result_count)"
+[ "$arm_tool_result_count" -eq 0 ] || fail "Pi spent a model tool call on demand-driven monitoring (tool-result count $arm_tool_result_count)"
 
 pid_file=$(find "$HOME_DIR/state" -maxdepth 3 -type f -name pid | head -1)
 [ -n "$pid_file" ] || fail "re-armed watcher pid was not recorded"

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -38,6 +38,7 @@ cp "$ROOT/.pi/extensions/lib/fm-calm-operational-user-layout.ts" "$TMP_ROOT/lib/
 cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$TMP_ROOT/lib/fm-calm-visibility.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-working-ship.ts" "$TMP_ROOT/lib/fm-calm-working-ship.ts"
 cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$TMP_ROOT/lib/fm-operational-input.ts"
+cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$TMP_ROOT/lib/fm-pi-watch-coordination.ts"
 ln -s "$PI_PACKAGE_DIR" "$TMP_ROOT/node_modules/@earendil-works/pi-coding-agent"
 ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$TMP_ROOT/node_modules/@earendil-works/pi-tui"
 ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-ai" "$TMP_ROOT/node_modules/@earendil-works/pi-ai"

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -173,7 +173,7 @@ trap 'exit 0' TERM INT
 while :; do :; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_READY_FILE="$ready" FM_PI_ARM_READY_TIMEOUT_MS=500 node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_READY_FILE="$ready" FM_PI_ARM_READY_TIMEOUT_MS=2000 node --input-type=module 2>&1 <<'EOF'
 import { existsSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -334,6 +334,147 @@ EOF
   expect_code 0 "$status" "pending retry demand reconciliation must wait for a ready arm: $out"
   [ -z "$out" ] || fail "Pi pending-retry reconciliation test printed output: $out"
   pass "Pi pending retry reconciliation waits for watcher readiness"
+}
+
+test_pi_retirement_timeout_restarts_returning_demand() {
+  local repo home plugin log first_pid returning overlap out status
+  repo="$TMP_ROOT/pi-demand-retirement-race-root"
+  home="$TMP_ROOT/pi-demand-retirement-race-home"
+  log="$TMP_ROOT/pi-demand-retirement-race.log"
+  first_pid="$TMP_ROOT/pi-demand-retirement-race.pid"
+  returning="$home/state/returning.meta"
+  overlap="$TMP_ROOT/pi-demand-retirement-race.overlap"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+count=$(wc -l < "$FM_ARM_LOG" | tr -d '[:space:]')
+if [ "$count" -eq 1 ]; then
+  printf '%s\n' "$$" > "${FM_FIRST_PID:?}"
+  printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+  trap 'printf "returning\n" > "${FM_RETURNING_DEMAND:?}"' TERM INT
+  while :; do sleep 0.02; done
+fi
+if kill -0 "$(cat "${FM_FIRST_PID:?}")" 2>/dev/null; then
+  printf 'overlap\n' > "${FM_OVERLAP:?}"
+fi
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while :; do :; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_FIRST_PID="$first_pid" FM_RETURNING_DEMAND="$returning" FM_OVERLAP="$overlap" FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=10 FM_WATCH_REARM_RETRY_MAX_MS=10 node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let modelTurns = 0;
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand() {},
+  registerTool() {},
+  sendUserMessage: async () => {
+    modelTurns += 1;
+  },
+};
+const rows = () => existsSync(process.env.FM_ARM_LOG)
+  ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n").filter(Boolean)
+  : [];
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_HOME}/state/task.meta`, "published task\n");
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+rmSync(`${process.env.FM_HOME}/state/task.meta`);
+await handlers.get("agent_settled")?.({ type: "agent_settled" }, {});
+for (let i = 0; i < 300 && rows().length < 2; i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (!existsSync(process.env.FM_RETURNING_DEMAND)) throw new Error("retirement did not observe returning demand");
+if (rows().length !== 2) throw new Error(`returning demand did not restart monitoring: ${rows().length} arm cycles`);
+if (existsSync(process.env.FM_OVERLAP)) throw new Error("replacement arm overlapped the unretired child");
+if (modelTurns !== 0) throw new Error(`retirement demand race used ${modelTurns} model turns`);
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "returning demand must restart after a timed-out idle retirement: $out"
+  [ -z "$out" ] || fail "Pi retirement-demand race test printed output: $out"
+  pass "Pi timed-out idle retirement restarts returning demand without overlap"
+}
+
+test_pi_readiness_timeout_retires_hung_arm() {
+  local repo home plugin log first_marker ready out status
+  repo="$TMP_ROOT/pi-demand-readiness-timeout-root"
+  home="$TMP_ROOT/pi-demand-readiness-timeout-home"
+  log="$TMP_ROOT/pi-demand-readiness-timeout.log"
+  first_marker="$TMP_ROOT/pi-demand-readiness-timeout.first"
+  ready="$TMP_ROOT/pi-demand-readiness-timeout.ready"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+if [ ! -e "${FM_FIRST_MARKER:?}" ]; then
+  : > "$FM_FIRST_MARKER"
+  trap 'exit 0' TERM INT
+  while :; do sleep 0.01; done
+fi
+printf 'ready\n' > "${FM_READY_FILE:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while :; do :; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_FIRST_MARKER="$first_marker" FM_READY_FILE="$ready" FM_PI_ARM_READY_TIMEOUT_MS="$ARM_READY_TIMEOUT_MS" FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=10 FM_WATCH_REARM_RETRY_MAX_MS=10 node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let modelTurns = 0;
+let tool = null;
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand() {},
+  registerTool(candidate) {
+    if (candidate.name === "fm_watch_arm_pi") tool = candidate;
+  },
+  sendUserMessage: async () => {
+    modelTurns += 1;
+  },
+};
+const rows = () => existsSync(process.env.FM_ARM_LOG)
+  ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n").filter(Boolean)
+  : [];
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_HOME}/state/task.meta`, "published task\n");
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+for (let i = 0; i < 300 && rows().length < 2; i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (rows().length !== 2) throw new Error(`hung readiness arm did not make a retry: ${rows().length} arm cycles`);
+if (!existsSync(process.env.FM_READY_FILE)) throw new Error("retry arm did not establish readiness");
+const repair = await tool.execute("repair-after-timeout", {}, undefined, undefined, {});
+if (repair.details?.ok !== true || !repair.content[0]?.text.includes("already owns an arm child")) {
+  throw new Error(`repair arm remained trapped by the hung child: ${JSON.stringify(repair.details)}`);
+}
+if (modelTurns !== 0) throw new Error(`readiness timeout recovery used ${modelTurns} model turns`);
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "readiness timeout must retire a hung arm and retry demanded monitoring: $out"
+  [ -z "$out" ] || fail "Pi readiness-timeout test printed output: $out"
+  pass "Pi readiness timeout retires hung arms and restores demanded monitoring"
 }
 
 test_pi_idle_retirement_timeout_suppresses_late_failure() {
@@ -3346,6 +3487,8 @@ test_pi_session_start_arms_only_with_supervision_demand
 test_pi_session_start_waits_for_arm_readiness
 test_pi_idle_demand_cancels_pending_retry
 test_pi_pending_retry_reconciliation_waits_for_ready_arm
+test_pi_retirement_timeout_restarts_returning_demand
+test_pi_readiness_timeout_retires_hung_arm
 test_pi_idle_retirement_timeout_suppresses_late_failure
 test_pi_lock_handoff_reconciles_existing_demand
 test_pi_settled_run_retires_idle_monitoring_without_model_turn

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -336,6 +336,173 @@ EOF
   pass "Pi pending retry reconciliation waits for watcher readiness"
 }
 
+test_pi_explicit_repair_respects_idle_demand() {
+  local repo home plugin log out status
+  repo="$TMP_ROOT/pi-explicit-repair-idle-root"
+  home="$TMP_ROOT/pi-explicit-repair-idle-home"
+  log="$TMP_ROOT/pi-explicit-repair-idle.log"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+let tool = null;
+let modelTurns = 0;
+const pi = {
+  on() {},
+  registerCommand() {},
+  registerTool(candidate) {
+    if (candidate.name === "fm_watch_arm_pi") tool = candidate;
+  },
+  sendUserMessage: async () => {
+    modelTurns += 1;
+  },
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+const result = await tool.execute("idle-repair", {}, undefined, undefined, {});
+if (result.details?.ok !== true) throw new Error(`idle repair was not a no-op: ${JSON.stringify(result.details)}`);
+if (!result.content[0]?.text.includes("no supervision demand")) throw new Error(`idle repair omitted its demand guard: ${result.content[0]?.text}`);
+await new Promise((resolve) => setTimeout(resolve, 120));
+if (existsSync(process.env.FM_ARM_LOG)) throw new Error("idle explicit repair started a watcher arm");
+if (modelTurns !== 0) throw new Error(`idle explicit repair used ${modelTurns} model turns`);
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "explicit Pi repair must remain idle without supervision demand: $out"
+  [ -z "$out" ] || fail "Pi idle explicit-repair test printed output: $out"
+  pass "Pi explicit repair respects idle supervision demand"
+}
+
+test_pi_retry_readiness_failure_rearms() {
+  local repo home plugin log ready out status
+  repo="$TMP_ROOT/pi-retry-readiness-root"
+  home="$TMP_ROOT/pi-retry-readiness-home"
+  log="$TMP_ROOT/pi-retry-readiness.log"
+  ready="$TMP_ROOT/pi-retry-readiness.ready"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+count=$(wc -l < "$FM_ARM_LOG" | tr -d '[:space:]')
+if [ "$count" -eq 1 ]; then
+  exit 0
+fi
+if [ "$count" -eq 2 ]; then
+  trap 'exit 0' TERM INT
+  while :; do sleep 0.01; done
+fi
+printf 'ready\n' > "${FM_READY_FILE:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while :; do sleep 0.01; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_READY_FILE="$ready" FM_PI_ARM_READY_TIMEOUT_MS=2000 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=200 FM_WATCH_REARM_RETRY_BASE_MS=10 FM_WATCH_REARM_RETRY_MAX_MS=10 node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let modelTurns = 0;
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand() {},
+  registerTool() {},
+  sendUserMessage: async () => {
+    modelTurns += 1;
+  },
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_HOME}/state/task.meta`, "published task\n");
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+const keepalive = setInterval(() => {}, 10);
+await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+clearInterval(keepalive);
+const rows = existsSync(process.env.FM_ARM_LOG)
+  ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n").filter(Boolean)
+  : [];
+if (rows.length !== 3) throw new Error(`readiness failure did not rearm: ${rows.length} arm cycles`);
+if (!existsSync(process.env.FM_READY_FILE)) throw new Error("rearmed retry never established readiness");
+if (modelTurns !== 0) throw new Error(`retry readiness recovery used ${modelTurns} model turns`);
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "a retry readiness timeout must retire and rearm the demanded watcher: $out"
+  [ -z "$out" ] || fail "Pi retry-readiness test printed output: $out"
+  pass "Pi retry readiness timeout re-arms demanded monitoring"
+}
+
+test_pi_close_before_readiness_waits_for_retry() {
+  local repo home plugin log ready out status
+  repo="$TMP_ROOT/pi-close-before-readiness-root"
+  home="$TMP_ROOT/pi-close-before-readiness-home"
+  log="$TMP_ROOT/pi-close-before-readiness.log"
+  ready="$TMP_ROOT/pi-close-before-readiness.ready"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+count=$(wc -l < "$FM_ARM_LOG" | tr -d '[:space:]')
+if [ "$count" -eq 1 ]; then exit 0; fi
+printf 'ready\n' > "${FM_READY_FILE:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while :; do sleep 0.01; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_READY_FILE="$ready" FM_PI_ARM_READY_TIMEOUT_MS=500 FM_WATCH_REARM_RETRY_BASE_MS=10 FM_WATCH_REARM_RETRY_MAX_MS=10 node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let modelTurns = 0;
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand() {},
+  registerTool() {},
+  sendUserMessage: async () => {
+    modelTurns += 1;
+  },
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_HOME}/state/task.meta`, "published task\n");
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+const keepalive = setInterval(() => {}, 10);
+await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+clearInterval(keepalive);
+if (!existsSync(process.env.FM_READY_FILE)) throw new Error("session_start returned before its retry became ready");
+const rows = readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n").filter(Boolean);
+if (rows.length !== 2) throw new Error(`close-before-readiness launched ${rows.length} arm cycles`);
+if (modelTurns !== 0) throw new Error(`close-before-readiness used ${modelTurns} model turns`);
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "close before readiness must be reconciled through the pending retry: $out"
+  [ -z "$out" ] || fail "Pi close-before-readiness test printed output: $out"
+  pass "Pi close-before-readiness waits for its retry"
+}
+
 test_pi_retirement_timeout_restarts_returning_demand() {
   local repo home plugin log first_pid returning overlap out status
   repo="$TMP_ROOT/pi-demand-retirement-race-root"
@@ -457,7 +624,9 @@ writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 writeFileSync(`${process.env.FM_HOME}/state/task.meta`, "published task\n");
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 mod.default(pi);
+const keepalive = setInterval(() => {}, 10);
 await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+clearInterval(keepalive);
 for (let i = 0; i < 300 && rows().length < 2; i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
@@ -774,9 +943,11 @@ test_pi_extension_reports_external_healthy_watcher() {
   home="$TMP_ROOT/pi-external-healthy-home"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
@@ -852,10 +1023,13 @@ test_pi_tool_returns_agent_tool_result() {
   home="$TMP_ROOT/pi-tool-result-home"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
-exit 0
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while :; do sleep 0.02; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
   out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
@@ -863,8 +1037,11 @@ import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 let tool = null;
+const handlers = new Map();
 const pi = {
-  on() {},
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
   registerCommand() {},
   registerTool(candidate) {
     if (candidate.name === "fm_watch_arm_pi") tool = candidate;
@@ -897,6 +1074,7 @@ if (!result.content[0].text.includes("only after a later notification says the c
 if (result.details?.ok !== true || result.details?.message !== result.content[0].text) {
   throw new Error(`invalid tool details: ${JSON.stringify(result.details)}`);
 }
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
 EOF
 )
   status=$?
@@ -913,6 +1091,7 @@ test_pi_redundant_tool_call_is_owned_noop() {
   stop="$TMP_ROOT/pi-redundant-tool.stop"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -975,10 +1154,12 @@ test_pi_scheduled_retry_call_is_owned_noop() {
   log="$TMP_ROOT/pi-scheduled-retry.log"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
 printf 'arm\n' >> "${FM_ARM_LOG:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
 exit 0
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
@@ -998,6 +1179,7 @@ const pi = {
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 mod.default(pi);
+const keepalive = setInterval(() => {}, 10);
 await tool.execute("tool-call-first", {}, undefined, undefined, {});
 let redundant = null;
 for (let i = 0; i < 100; i += 1) {
@@ -1017,6 +1199,7 @@ if (!redundant.content[0]?.text.includes("only after a later notification says t
 await new Promise((resolve) => setTimeout(resolve, 100));
 const rows = readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n");
 if (rows.length !== 1) throw new Error(`scheduled retry call spawned ${rows.length} arm children`);
+clearInterval(keepalive);
 EOF
 )
   status=$?
@@ -1033,6 +1216,7 @@ test_pi_actionable_close_starts_single_successor_before_delivery() {
   stop="$TMP_ROOT/pi-continuous-rearm.stop"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1124,6 +1308,7 @@ test_pi_branch_offer_owns_actionable_wake() {
   stop="$TMP_ROOT/pi-branch-offer.stop"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1236,6 +1421,7 @@ test_pi_branch_offer_flags_heartbeat() {
   stop="$TMP_ROOT/pi-branch-heartbeat.stop"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1321,6 +1507,7 @@ test_pi_heartbeat_is_not_ridden_into_main_by_a_co_present_check() {
   stop="$TMP_ROOT/pi-heartbeat-mixed-queue.stop"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1413,6 +1600,7 @@ test_pi_main_only_check_classes_stay_on_main() {
   home="$TMP_ROOT/pi-main-only-check-home"
   mkdir -p "$repo/bin" "$home/state" "$home/config" "$home/projects/approved"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   printf 'project=%s/projects/approved\nwindow=fm-window\n' "$home" > "$home/state/task-a.meta"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
@@ -1509,6 +1697,7 @@ test_pi_heartbeat_restoration_failure_stays_on_main() {
   log="$TMP_ROOT/pi-heartbeat-restoration-failure.log"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1585,9 +1774,11 @@ test_pi_watcher_failure_never_offered_to_branch() {
   home="$TMP_ROOT/pi-watcher-failure-home"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
@@ -1657,6 +1848,7 @@ test_pi_handling_delivery_failure_is_typed_once() {
   stop="$TMP_ROOT/pi-handling-fail.stop"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1729,6 +1921,7 @@ test_pi_hung_successor_falls_back_to_typed_wake() {
   log="$TMP_ROOT/pi-hung-successor.log"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1798,6 +1991,7 @@ test_pi_unretired_successor_falls_back_without_retry() {
   release="$TMP_ROOT/pi-unretired-successor.release"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1873,6 +2067,7 @@ test_pi_late_unretired_close_resumes_supervision() {
     stop="$TMP_ROOT/pi-late-$kind.stop"
     mkdir -p "$repo/bin" "$home/state" "$home/config"
     install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
     plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
     cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1966,6 +2161,7 @@ test_pi_empty_close_retries_instead_of_disappearing() {
   stop="$TMP_ROOT/pi-empty-close.stop"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1996,6 +2192,7 @@ const pi = {
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 mod.default(pi);
+const keepalive = setInterval(() => {}, 10);
 await tool.execute("tool-call-empty", {}, undefined, undefined, {});
 for (let i = 0; i < 250; i += 1) {
   const rows = existsSync(process.env.FM_ARM_LOG)
@@ -2024,6 +2221,7 @@ test_pi_established_empty_close_honors_retry_limit() {
   log="$TMP_ROOT/pi-established-empty-close.log"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -2076,10 +2274,12 @@ test_pi_actionable_close_rechecks_session_lock() {
   release="$TMP_ROOT/pi-close-lock.release"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
 printf 'arm=%s\n' "$$" >> "${FM_ARM_LOG:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
 while [ ! -e "$FM_RELEASE_FILE" ]; do sleep 0.02; done
 printf 'signal: lock handoff\n'
 SH
@@ -2134,10 +2334,12 @@ test_pi_arm_distinguishes_session_lock_ownership() {
   log="$TMP_ROOT/pi-lock-ownership.log"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
 printf 'arm\n' >> "${FM_ARM_LOG:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
   out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" node --input-type=module 2>&1 <<'EOF'
@@ -2218,6 +2420,7 @@ test_pi_session_transition_generation_owner() {
   arm_log="$TMP_ROOT/pi-session-transition-arm.log"
   mkdir -p "$repo/bin" "$home/state" "$home/config" "$marker_root"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -2446,9 +2649,11 @@ test_pi_process_exit_cleanup_stops_arm_child() {
   pid_file="$TMP_ROOT/pi-process-exit-child.pid"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
+  printf 'published tool demand\n' > "$home/state/task.meta"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
 trap 'printf "%s\n" "$$" >> "$FM_CLEANUP_LOG"; exit 0' TERM
 printf '%s\n' "$$" > "$FM_CHILD_PID_FILE"
 while :; do sleep 1; done
@@ -3487,6 +3692,9 @@ test_pi_session_start_arms_only_with_supervision_demand
 test_pi_session_start_waits_for_arm_readiness
 test_pi_idle_demand_cancels_pending_retry
 test_pi_pending_retry_reconciliation_waits_for_ready_arm
+test_pi_explicit_repair_respects_idle_demand
+test_pi_retry_readiness_failure_rearms
+test_pi_close_before_readiness_waits_for_retry
 test_pi_retirement_timeout_restarts_returning_demand
 test_pi_readiness_timeout_retires_hung_arm
 test_pi_idle_retirement_timeout_suppresses_late_failure

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -154,6 +154,227 @@ EOF
   pass "Pi session start arms only with supervision demand and uses zero model turns"
 }
 
+test_pi_session_start_waits_for_arm_readiness() {
+  local repo home plugin log ready out status
+  repo="$TMP_ROOT/pi-demand-readiness-root"
+  home="$TMP_ROOT/pi-demand-readiness-home"
+  log="$TMP_ROOT/pi-demand-readiness.log"
+  ready="$TMP_ROOT/pi-demand-readiness.ready"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+sleep 0.12
+printf 'ready\n' > "${FM_READY_FILE:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while :; do :; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_READY_FILE="$ready" FM_PI_ARM_READY_TIMEOUT_MS=500 node --input-type=module 2>&1 <<'EOF'
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let modelTurns = 0;
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand() {},
+  registerTool() {},
+  sendUserMessage: async () => {
+    modelTurns += 1;
+  },
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_HOME}/state/task.meta`, "published task\n");
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+if (!existsSync(process.env.FM_READY_FILE)) throw new Error("session_start returned before watcher readiness");
+if (modelTurns !== 0) throw new Error(`readiness wait used ${modelTurns} model turns`);
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi session start must wait for a ready watcher arm: $out"
+  [ -z "$out" ] || fail "Pi readiness test printed output: $out"
+  pass "Pi session start waits for watcher readiness without a model turn"
+}
+
+test_pi_idle_demand_cancels_pending_retry() {
+  local repo home plugin log out status
+  repo="$TMP_ROOT/pi-demand-cancel-retry-root"
+  home="$TMP_ROOT/pi-demand-cancel-retry-home"
+  log="$TMP_ROOT/pi-demand-cancel-retry.log"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+if [ "$(wc -l < "$FM_ARM_LOG" | tr -d '[:space:]')" -eq 1 ]; then
+  printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+  exit 0
+fi
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while :; do :; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_WATCH_REARM_RETRY_BASE_MS=200 FM_WATCH_REARM_RETRY_MAX_MS=200 node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let modelTurns = 0;
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand() {},
+  registerTool() {},
+  sendUserMessage: async () => {
+    modelTurns += 1;
+  },
+};
+const rows = () => existsSync(process.env.FM_ARM_LOG)
+  ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n").filter(Boolean)
+  : [];
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_HOME}/state/task.meta`, "published task\n");
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+for (let i = 0; i < 100 && rows().length < 1; i += 1) await new Promise((resolve) => setTimeout(resolve, 10));
+await new Promise((resolve) => setTimeout(resolve, 80));
+rmSync(`${process.env.FM_HOME}/state/task.meta`);
+await handlers.get("agent_settled")?.({ type: "agent_settled" }, {});
+await new Promise((resolve) => setTimeout(resolve, 320));
+if (rows().length !== 1) throw new Error(`idle demand allowed a pending retry to launch ${rows().length} arm cycles`);
+if (modelTurns !== 0) throw new Error(`idle retry cancellation used ${modelTurns} model turns`);
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "idle demand must cancel a pending watcher retry: $out"
+  [ -z "$out" ] || fail "Pi idle retry-cancellation test printed output: $out"
+  pass "Pi idle demand cancels pending watcher retries"
+}
+
+test_pi_idle_retirement_timeout_suppresses_late_failure() {
+  local repo home plugin log release out status
+  repo="$TMP_ROOT/pi-demand-late-retirement-root"
+  home="$TMP_ROOT/pi-demand-late-retirement-home"
+  log="$TMP_ROOT/pi-demand-late-retirement.log"
+  release="$TMP_ROOT/pi-demand-late-retirement.release"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap '' TERM INT
+while [ ! -e "$FM_RELEASE_FILE" ]; do sleep 0.02; done
+exit 0
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_RELEASE_FILE="$release" FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=10 FM_WATCH_REARM_RETRY_MAX_MS=10 node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+const prompts = [];
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand() {},
+  registerTool() {},
+  sendUserMessage: async (message) => {
+    prompts.push(message);
+  },
+};
+const rows = () => existsSync(process.env.FM_ARM_LOG)
+  ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n").filter(Boolean)
+  : [];
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_HOME}/state/task.meta`, "published task\n");
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+rmSync(`${process.env.FM_HOME}/state/task.meta`);
+await handlers.get("agent_settled")?.({ type: "agent_settled" }, {});
+await new Promise((resolve) => setTimeout(resolve, 80));
+if (rows().length !== 1 || prompts.length !== 0) throw new Error(`idle retirement retried or notified before late close: rows=${rows().length} prompts=${prompts.length}`);
+writeFileSync(process.env.FM_RELEASE_FILE, "release\n");
+await new Promise((resolve) => setTimeout(resolve, 160));
+if (rows().length !== 1) throw new Error(`late intentional retirement failure launched ${rows().length} arm cycles`);
+if (prompts.length !== 0) throw new Error(`late intentional retirement failure notified ${prompts.length} times`);
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "late idle retirement failure must stay suppressed: $out"
+  [ -z "$out" ] || fail "Pi late retirement test printed output: $out"
+  pass "Pi late idle retirement failure stays silent and does not retry"
+}
+
+test_pi_lock_handoff_reconciles_existing_demand() {
+  local repo home plugin log out status
+  repo="$TMP_ROOT/pi-demand-lock-handoff-root"
+  home="$TMP_ROOT/pi-demand-lock-handoff-home"
+  log="$TMP_ROOT/pi-demand-lock-handoff.log"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while :; do :; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let modelTurns = 0;
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand() {},
+  registerTool() {},
+  sendUserMessage: async () => {
+    modelTurns += 1;
+  },
+};
+writeFileSync(`${process.env.FM_HOME}/state/task.meta`, "published before lock handoff\n");
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+for (let i = 0; i < 300 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (!existsSync(process.env.FM_ARM_LOG)) throw new Error("lock handoff did not recheck existing supervision demand");
+if (modelTurns !== 0) throw new Error(`lock handoff used ${modelTurns} model turns`);
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "lock publication must trigger demand reconciliation: $out"
+  [ -z "$out" ] || fail "Pi lock-handoff test printed output: $out"
+  pass "Pi lock handoff reconciles pre-existing supervision demand"
+}
+
 test_pi_settled_run_retires_idle_monitoring_without_model_turn() {
   local repo home plugin log retired out status
   repo="$TMP_ROOT/pi-demand-retire-root"
@@ -3051,6 +3272,10 @@ EOF
 }
 
 test_pi_session_start_arms_only_with_supervision_demand
+test_pi_session_start_waits_for_arm_readiness
+test_pi_idle_demand_cancels_pending_retry
+test_pi_idle_retirement_timeout_suppresses_late_failure
+test_pi_lock_handoff_reconciles_existing_demand
 test_pi_settled_run_retires_idle_monitoring_without_model_turn
 test_pi_idle_retirement_race_restarts_monitoring
 test_pi_state_hint_starts_new_external_demand

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -265,6 +265,77 @@ EOF
   pass "Pi idle demand cancels pending watcher retries"
 }
 
+test_pi_pending_retry_reconciliation_waits_for_ready_arm() {
+  local repo home plugin log ready out status
+  repo="$TMP_ROOT/pi-demand-pending-retry-root"
+  home="$TMP_ROOT/pi-demand-pending-retry-home"
+  log="$TMP_ROOT/pi-demand-pending-retry.log"
+  ready="$TMP_ROOT/pi-demand-pending-retry.ready"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+if [ "$(wc -l < "$FM_ARM_LOG" | tr -d '[:space:]')" -eq 1 ]; then
+  printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+  exit 0
+fi
+sleep 0.12
+printf 'ready\n' > "${FM_READY_FILE:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while :; do :; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_READY_FILE="$ready" FM_WATCH_REARM_RETRY_BASE_MS=120 FM_WATCH_REARM_RETRY_MAX_MS=120 FM_PI_ARM_READY_TIMEOUT_MS=500 node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let modelTurns = 0;
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand() {},
+  registerTool() {},
+  sendUserMessage: async () => {
+    modelTurns += 1;
+  },
+};
+const rows = () => existsSync(process.env.FM_ARM_LOG)
+  ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n").filter(Boolean)
+  : [];
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_HOME}/state/task.meta`, "published task\n");
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+await new Promise((resolve) => setTimeout(resolve, 60));
+const settled = handlers.get("agent_settled")?.({ type: "agent_settled" }, {});
+const keepalive = setInterval(() => {}, 10);
+let settledFinished = false;
+void settled?.then(() => {
+  settledFinished = true;
+});
+await new Promise((resolve) => setTimeout(resolve, 30));
+if (settledFinished) throw new Error("demand reconciliation returned before its pending retry ran");
+if (rows().length !== 1) throw new Error(`pending retry launched unexpectedly early: ${rows().length} arm cycles`);
+await settled;
+clearInterval(keepalive);
+if (!existsSync(process.env.FM_READY_FILE)) throw new Error("pending retry reconciliation returned before arm readiness");
+if (rows().length !== 2) throw new Error(`pending retry reconciliation launched ${rows().length} arm cycles`);
+if (modelTurns !== 0) throw new Error(`pending retry reconciliation used ${modelTurns} model turns`);
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "pending retry demand reconciliation must wait for a ready arm: $out"
+  [ -z "$out" ] || fail "Pi pending-retry reconciliation test printed output: $out"
+  pass "Pi pending retry reconciliation waits for watcher readiness"
+}
+
 test_pi_idle_retirement_timeout_suppresses_late_failure() {
   local repo home plugin log release out status
   repo="$TMP_ROOT/pi-demand-late-retirement-root"
@@ -3274,6 +3345,7 @@ EOF
 test_pi_session_start_arms_only_with_supervision_demand
 test_pi_session_start_waits_for_arm_readiness
 test_pi_idle_demand_cancels_pending_retry
+test_pi_pending_retry_reconciliation_waits_for_ready_arm
 test_pi_idle_retirement_timeout_suppresses_late_failure
 test_pi_lock_handoff_reconciles_existing_demand
 test_pi_settled_run_retires_idle_monitoring_without_model_turn

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -35,9 +35,11 @@ install_pi_watch_extension_fixture() {
   cp "$ROOT/.pi/extensions/lib/fm-branch-dispatch.ts" "$repo/.pi/extensions/lib/fm-branch-dispatch.ts"
   cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$repo/.pi/extensions/lib/fm-calm-visibility.ts"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$repo/.pi/extensions/lib/fm-operational-input.ts"
+  cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$repo/.pi/extensions/lib/fm-pi-watch-coordination.ts"
   mkdir -p "$repo/bin"
   cp "$ROOT/bin/fm-operational-input.sh" "$repo/bin/fm-operational-input.sh"
-  chmod +x "$repo/bin/fm-operational-input.sh"
+  cp "$ROOT/bin/fm-supervision-lib.sh" "$repo/bin/fm-supervision-lib.sh"
+  chmod +x "$repo/bin/fm-operational-input.sh" "$repo/bin/fm-supervision-lib.sh"
   cat > "$repo/node_modules/@earendil-works/pi-coding-agent/package.json" <<'JSON'
 {"name":"@earendil-works/pi-coding-agent","type":"module","exports":"./index.js"}
 JSON
@@ -70,6 +72,267 @@ export const Type = {
   },
 };
 JS
+}
+
+test_pi_session_start_arms_only_with_supervision_demand() {
+  local repo home plugin log out status
+  repo="$TMP_ROOT/pi-demand-start-root"
+  home="$TMP_ROOT/pi-demand-start-home"
+  log="$TMP_ROOT/pi-demand-start.log"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while :; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+async function runScenario(name, expectedDemand) {
+  rmSync(process.env.FM_ARM_LOG, { force: true });
+  const state = `${process.env.FM_HOME}/state`;
+  rmSync(`${state}/task.meta`, { force: true });
+  rmSync(`${state}/.task.meta.spawn.123`, { force: true });
+  rmSync(`${state}/x-watch.check.sh`, { force: true });
+  rmSync(`${state}/.wake-queue`, { force: true });
+  rmSync(`${state}/procevent`, { force: true, recursive: true });
+  if (name === "task") writeFileSync(`${state}/task.meta`, "published task\n");
+  if (name === "staged") writeFileSync(`${state}/.task.meta.spawn.123`, "staged task\n");
+  if (name === "relay") writeFileSync(`${state}/x-watch.check.sh`, "relay\n");
+  if (name === "queue") writeFileSync(`${state}/.wake-queue`, "pending wake\n");
+  if (name === "source") {
+    mkdirSync(`${state}/procevent`);
+    writeFileSync(`${state}/procevent/source.source`, "registered source\n");
+  }
+  if (name === "uncertain") symlinkSync("missing", `${state}/task.meta`);
+  writeFileSync(`${state}/.lock`, `${process.pid}\n`);
+  const handlers = new Map();
+  let modelTurns = 0;
+  const pi = {
+    on(event, handler) {
+      handlers.set(event, handler);
+    },
+    registerCommand() {},
+    registerTool() {},
+    sendUserMessage: async () => {
+      modelTurns += 1;
+    },
+  };
+  const mod = await import(`${pathToFileURL(process.env.PLUGIN).href}?scenario=${name}`);
+  mod.default(pi);
+  await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+  for (let i = 0; i < 200 && expectedDemand && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  await new Promise((resolve) => setTimeout(resolve, 80));
+  const armed = existsSync(process.env.FM_ARM_LOG);
+  await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+  return { armed, modelTurns };
+}
+
+for (const name of ["idle", "staged"]) {
+  const result = await runScenario(name, false);
+  if (result.armed) throw new Error(`${name} session started watcher monitoring`);
+  if (result.modelTurns !== 0) throw new Error(`${name} session started ${result.modelTurns} model turns`);
+}
+for (const name of ["task", "relay", "source", "queue", "uncertain"]) {
+  const result = await runScenario(name, true);
+  if (!result.armed) throw new Error(`${name} supervision demand did not start watcher monitoring`);
+  if (result.modelTurns !== 0) throw new Error(`${name} automatic watcher start used ${result.modelTurns} model turns`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi session start must arm only when supervision demand exists: $out"
+  [ -z "$out" ] || fail "Pi demand-driven session-start test printed output: $out"
+  pass "Pi session start arms only with supervision demand and uses zero model turns"
+}
+
+test_pi_settled_run_retires_idle_monitoring_without_model_turn() {
+  local repo home plugin log retired out status
+  repo="$TMP_ROOT/pi-demand-retire-root"
+  home="$TMP_ROOT/pi-demand-retire-home"
+  log="$TMP_ROOT/pi-demand-retire.log"
+  retired="$TMP_ROOT/pi-demand-retire.done"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'printf "retired\n" > "${FM_RETIRED_FILE:?}"; exit 0' TERM INT
+while :; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_RETIRED_FILE="$retired" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let modelTurns = 0;
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand() {},
+  registerTool() {},
+  sendUserMessage: async () => {
+    modelTurns += 1;
+  },
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_HOME}/state/task.meta`, "published task\n");
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+for (let i = 0; i < 200 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (!existsSync(process.env.FM_ARM_LOG)) throw new Error("watcher did not start for published work");
+rmSync(`${process.env.FM_HOME}/state/task.meta`);
+await handlers.get("agent_settled")?.({ type: "agent_settled" }, { isIdle: () => true });
+for (let i = 0; i < 200 && !existsSync(process.env.FM_RETIRED_FILE); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (!existsSync(process.env.FM_RETIRED_FILE)) throw new Error("idle watcher was not intentionally retired");
+if (modelTurns !== 0) throw new Error(`idle retirement used ${modelTurns} model turns`);
+await new Promise((resolve) => setTimeout(resolve, 100));
+if (modelTurns !== 0) throw new Error("intentional idle retirement was reported as a watcher failure");
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi settled run must retire idle monitoring without a model turn: $out"
+  [ -z "$out" ] || fail "Pi demand-driven idle-retirement test printed output: $out"
+  pass "Pi settled run retires idle monitoring silently with zero model turns"
+}
+
+test_pi_idle_retirement_race_restarts_monitoring() {
+  local repo home plugin log stop out status
+  repo="$TMP_ROOT/pi-demand-retire-race-root"
+  home="$TMP_ROOT/pi-demand-retire-race-home"
+  log="$TMP_ROOT/pi-demand-retire-race.log"
+  stop="$TMP_ROOT/pi-demand-retire-race.stop"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+count=$(wc -l < "$FM_ARM_LOG" | tr -d '[:space:]')
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+if [ "$count" -eq 1 ]; then
+  trap 'printf "replacement demand\n" > "${FM_HOME:?}/state/replacement.meta"; exit 0' TERM INT
+else
+  trap 'exit 0' TERM INT
+fi
+while [ ! -e "$FM_STOP_FILE" ]; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_STOP_FILE="$stop" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let modelTurns = 0;
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand() {},
+  registerTool() {},
+  sendUserMessage: async () => {
+    modelTurns += 1;
+  },
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_HOME}/state/task.meta`, "initial demand\n");
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+for (let i = 0; i < 200 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+rmSync(`${process.env.FM_HOME}/state/task.meta`);
+await handlers.get("agent_settled")?.({ type: "agent_settled" }, { isIdle: () => true });
+for (let i = 0; i < 300; i += 1) {
+  const rows = existsSync(process.env.FM_ARM_LOG)
+    ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n")
+    : [];
+  if (rows.length >= 2) break;
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+const rows = readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n");
+if (rows.length !== 2) throw new Error(`retirement race started ${rows.length} watcher cycles`);
+if (!existsSync(`${process.env.FM_HOME}/state/replacement.meta`)) throw new Error("retirement race fixture did not publish replacement demand");
+if (modelTurns !== 0) throw new Error(`retirement race used ${modelTurns} model turns`);
+writeFileSync(process.env.FM_STOP_FILE, "stop\n");
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi must re-read demand and restart immediately after idle retirement: $out"
+  [ -z "$out" ] || fail "Pi demand retirement-race test printed output: $out"
+  pass "Pi idle retirement re-reads demand and restarts monitoring without a model turn"
+}
+
+test_pi_state_hint_starts_new_external_demand() {
+  local repo home plugin log out status
+  repo="$TMP_ROOT/pi-demand-state-hint-root"
+  home="$TMP_ROOT/pi-demand-state-hint-home"
+  log="$TMP_ROOT/pi-demand-state-hint.log"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while :; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_PI_DEMAND_DEBOUNCE_MS=10 node --input-type=module 2>&1 <<'EOF'
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let modelTurns = 0;
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand() {},
+  registerTool() {},
+  sendUserMessage: async () => {
+    modelTurns += 1;
+  },
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+if (existsSync(process.env.FM_ARM_LOG)) throw new Error("idle session started monitoring before external demand");
+writeFileSync(`${process.env.FM_HOME}/state/external.meta`, "external published demand\n");
+for (let i = 0; i < 300 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (!existsSync(process.env.FM_ARM_LOG)) throw new Error("state change hint did not start monitoring");
+if (modelTurns !== 0) throw new Error(`state change hint used ${modelTurns} model turns`);
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi state hint must start monitoring when external demand appears: $out"
+  [ -z "$out" ] || fail "Pi demand state-hint test printed output: $out"
+  pass "Pi filtered state hint starts external supervision demand with zero model turns"
 }
 
 test_pi_extension_reports_external_healthy_watcher() {
@@ -181,13 +444,10 @@ mod.default(pi);
 if (!tool) throw new Error("Pi watch tool was not registered");
 if (tool.label !== "Arm firstmate watcher") throw new Error(`unexpected label: ${tool.label}`);
 if (tool.parameters?.type !== "object") throw new Error("tool parameters are not a TypeBox object schema");
-const metadata = [tool.description, tool.promptSnippet, ...(tool.promptGuidelines ?? [])].join("\n");
-if (metadata.includes("Always use this tool")) throw new Error(`broad tool-selection metadata remained visible: ${metadata}`);
-if (!tool.description.includes("first required Pi watcher cycle")) throw new Error(`tool description omitted the first-cycle condition: ${tool.description}`);
-if (!tool.promptSnippet.includes("ordinary re-arming is automatic")) throw new Error(`tool snippet omitted automatic continuation: ${tool.promptSnippet}`);
-if (!tool.promptGuidelines.some((guideline) => guideline.includes("ordinary signal, stale, check, or heartbeat handling"))) {
-  throw new Error(`tool guidelines omitted ordinary-notification prevention: ${tool.promptGuidelines}`);
-}
+if (tool.promptSnippet !== undefined) throw new Error(`repair tool added normal-session prompt snippet overhead: ${tool.promptSnippet}`);
+if (tool.promptGuidelines !== undefined) throw new Error(`repair tool added normal-session prompt guideline overhead: ${tool.promptGuidelines}`);
+if (!tool.description.includes("Rare explicit repair")) throw new Error(`tool description omitted the repair-only boundary: ${tool.description}`);
+if (tool.description.includes("first required Pi watcher cycle")) throw new Error(`tool description still asks the model to start normal monitoring: ${tool.description}`);
 const result = await tool.execute("tool-call-1", {}, undefined, undefined, {});
 if (!Array.isArray(result.content) || result.content[0]?.type !== "text") {
   throw new Error(`invalid tool content: ${JSON.stringify(result)}`);
@@ -1604,15 +1864,12 @@ function liveArmPids() {
 }
 
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_HOME}/state/session-transition.meta`, "published task\n");
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 
 const startup = makePi();
 mod.default(startup.pi);
 await startup.handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
-const first = await startup.getTool().execute("startup", {}, undefined, undefined, {});
-if (!first.details?.ok || !String(first.details.message).includes("started Pi extension arm child")) {
-  throw new Error(`startup arm failed: ${JSON.stringify(first.details)}`);
-}
 await waitFor(() => {
   const arm = currentArm();
   return arm.pid && arm.marker && existsSync(arm.marker) && pidAlive(arm.pid);
@@ -1634,13 +1891,6 @@ async function replaceSession(previous, reason) {
     reason,
     previousSessionFile: `/tmp/previous-${reason}.jsonl`,
   }, {});
-  const armed = await next.getTool().execute(`arm-${reason}`, {}, undefined, undefined, {});
-  if (!armed.details?.ok) {
-    throw new Error(`${reason} replacement arm failed: ${JSON.stringify(armed.details)}`);
-  }
-  if (String(armed.details.message).includes("shutting down")) {
-    throw new Error(`${reason} replacement still refused with shutting-down latch`);
-  }
   await waitFor(() => {
     const arm = currentArm();
     return arm.pid && arm.marker && arm.marker !== previousArm.marker && existsSync(arm.marker) && pidAlive(arm.pid) && liveArmPids().includes(arm.pid);
@@ -1660,11 +1910,7 @@ current = await replaceSession(current, "fork");
 const sameInstanceArm = currentArm();
 await current.handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "new" }, {});
 await current.handlers.get("session_start")?.({ type: "session_start", reason: "new" }, {});
-const sameInstanceResult = await current.getTool().execute("same-instance", {}, undefined, undefined, {});
-if (!sameInstanceResult.details?.ok || String(sameInstanceResult.details.message).includes("shutting down")) {
-  throw new Error(`same-instance replacement arm failed: ${JSON.stringify(sameInstanceResult.details)}`);
-  }
-  await waitFor(() => {
+await waitFor(() => {
     const arm = currentArm();
     return arm.pid && arm.marker && arm.marker !== sameInstanceArm.marker && existsSync(arm.marker) && pidAlive(arm.pid) && liveArmPids().includes(arm.pid);
   }, "same-instance replacement child and arm record");
@@ -2804,6 +3050,10 @@ EOF
   pass "OpenCode healthy arm output does not suppress the turn-end guard"
 }
 
+test_pi_session_start_arms_only_with_supervision_demand
+test_pi_settled_run_retires_idle_monitoring_without_model_turn
+test_pi_idle_retirement_race_restarts_monitoring
+test_pi_state_hint_starts_new_external_demand
 test_pi_extension_reports_external_healthy_watcher
 test_pi_tool_returns_agent_tool_result
 test_pi_redundant_tool_call_is_owned_noop

--- a/tests/fm-sessionstart-hook-live-e2e.test.sh
+++ b/tests/fm-sessionstart-hook-live-e2e.test.sh
@@ -176,6 +176,7 @@ SH
     pi)
       mkdir -p "$lab/.pi/extensions/lib"
       cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$lab/.pi/extensions/"
+      cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$lab/.pi/extensions/lib/"
       cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" \
         "$ROOT/.pi/extensions/lib/fm-sessionstart-supervisor.mjs" "$lab/.pi/extensions/lib/"
       cp "$ROOT/bin/fm-operational-input.sh" "$lab/bin/"
@@ -352,6 +353,7 @@ probe_pi_sessionstart_prerequisite() {
   git -C "$project" config user.name fmtest
   printf '# Offline Pi startup-prerequisite lab\n' > "$project/AGENTS.md"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$project/.pi/extensions/"
+  cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$project/.pi/extensions/lib/"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" \
     "$ROOT/.pi/extensions/lib/fm-sessionstart-supervisor.mjs" "$project/.pi/extensions/lib/"
   cp "$ROOT/bin/fm-operational-input.sh" "$project/bin/"

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -330,6 +330,7 @@ test_pi_startup_classifies_cli_continuations() {
   fixture="$TMP_ROOT/pi-continuation-source"
   mkdir -p "$fixture/.pi/extensions/lib" "$fixture/bin" "$fixture/state"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$fixture/.pi/extensions/"
+  cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$fixture/.pi/extensions/lib/"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" \
     "$ROOT/.pi/extensions/lib/fm-sessionstart-supervisor.mjs" "$fixture/.pi/extensions/lib/"
   cat > "$fixture/bin/fm-sessionstart-run.sh" <<'SH'
@@ -428,6 +429,7 @@ test_pi_sessionstart_generation_prerequisite() {
   fixture="$TMP_ROOT/pi-sessionstart-generation"
   mkdir -p "$fixture/.pi/extensions/lib" "$fixture/bin" "$fixture/state"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$fixture/.pi/extensions/"
+  cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$fixture/.pi/extensions/lib/"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" \
     "$ROOT/.pi/extensions/lib/fm-sessionstart-supervisor.mjs" "$fixture/.pi/extensions/lib/"
   cp "$ROOT/bin/fm-operational-input.sh" "$fixture/bin/"
@@ -754,6 +756,7 @@ test_pi_reload_releases_sessionstart_exit_listener() {
   fixture="$TMP_ROOT/pi-reload-exit-listener"
   mkdir -p "$fixture/.pi/extensions/lib" "$fixture/bin" "$fixture/state"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$fixture/.pi/extensions/"
+  cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$fixture/.pi/extensions/lib/"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" \
     "$ROOT/.pi/extensions/lib/fm-sessionstart-supervisor.mjs" "$fixture/.pi/extensions/lib/"
   cp "$ROOT/bin/fm-operational-input.sh" "$fixture/bin/"
@@ -888,6 +891,7 @@ test_pi_large_sessionstart_digest_is_delivered_loudly() {
   git -C "$fixture" commit -q --allow-empty -m init
   : > "$fixture/AGENTS.md"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$fixture/.pi/extensions/"
+  cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$fixture/.pi/extensions/lib/"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" \
     "$ROOT/.pi/extensions/lib/fm-sessionstart-supervisor.mjs" "$fixture/.pi/extensions/lib/"
   cp "$ROOT/bin/fm-sessionstart-run.sh" "$ROOT/bin/fm-sessionstart-nudge.sh" \

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -76,6 +76,9 @@ test_cross_harness_ordinary_continuation_and_repair_matrix() {
 
   out=$("$RENDER" --harness pi)
   ordinary=$(printf '%s\n' "$out" | grep -F -- '- Ordinary wake:')
+  assert_contains "$out" "starts monitoring automatically when supervision demand appears" "pi protocol does not describe demand-driven automatic start"
+  assert_contains "$out" "retires monitoring automatically when that demand clears" "pi protocol does not describe demand-driven idle retirement"
+  assert_not_contains "$out" "First cycle only" "pi protocol still spends a normal model turn on initial watcher start"
   assert_contains "$ordinary" "Pi extension already owns watcher continuity" "pi ordinary-wake line does not leave continuity to the extension"
   assert_not_contains "$ordinary" "fm_watch_arm_pi" "pi ordinary-wake line incorrectly calls the recovery tool"
   out=$("$RENDER" --harness pi --repair-line)

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -33,6 +33,31 @@ test_predicate_healthy_no_inflight() {
   pass "fm_supervision_unhealthy: false with no state/*.meta at all"
 }
 
+test_predicate_counts_only_published_task_records() {
+  local state="$TMP_ROOT/pred-published/state"
+  mkdir -p "$state"
+  : > "$state/.task1.meta.spawn.123"
+  fm_supervision_status "$state" 300
+  [ "$FM_SUP_IN_FLIGHT" -eq 0 ] || fail "staged task record counted as published work"
+  [ "$FM_SUP_NEEDED" = false ] || fail "staged task record started supervision"
+  : > "$state/task1.meta"
+  printf 'malformed but published\n' > "$state/task2.meta"
+  fm_supervision_status "$state" 300
+  [ "$FM_SUP_IN_FLIGHT" -eq 2 ] || fail "dead or malformed published task records did not count"
+  [ "$FM_SUP_NEEDED" = true ] || fail "published task records did not start supervision"
+  pass "fm_supervision_status: published task records count while staged records do not"
+}
+
+test_predicate_uncertain_published_state_keeps_supervision() {
+  local state="$TMP_ROOT/pred-uncertain/state"
+  mkdir -p "$state"
+  ln -s missing-target "$state/task1.meta"
+  fm_supervision_status "$state" 300
+  [ "$FM_SUP_CERTAIN" = false ] || fail "a symlinked published task record was treated as certain idle state"
+  [ "$FM_SUP_NEEDED" = true ] || fail "uncertain published task state silenced supervision"
+  pass "fm_supervision_status: uncertain published state keeps supervision active"
+}
+
 test_predicate_unhealthy_no_beacon() {
   local state="$TMP_ROOT/pred-nobeat/state"
   mkdir -p "$state"
@@ -74,7 +99,9 @@ test_predicate_queue_pending_flag() {
   printf 'record\n' > "$state/.wake-queue"
   fm_supervision_status "$state" 300
   [ "$FM_SUP_QUEUE_PENDING" = true ] || fail "a non-empty wake queue must read as pending"
-  pass "fm_supervision_status: FM_SUP_QUEUE_PENDING tracks state/.wake-queue"
+  [ "$FM_SUP_NEEDED" = true ] || fail "a pending durable wake must keep supervision needed"
+  fm_supervision_needed "$state" 300 || fail "a pending durable wake must keep the watcher active until drain"
+  pass "fm_supervision_status: a pending durable wake keeps supervision needed until drain"
 }
 
 test_predicate_x_mode_needs_supervision() {
@@ -386,6 +413,17 @@ test_hook_x_mode_reason_sources_cadence() {
   expect_code 2 "$status" "hook must block when in-flight X-mode work has no live watcher"
   assert_contains "$out" "source '$home/config/x-mode.env' first" "block reason must source the effective X-mode cadence"
   pass "fm-turnend-guard: X-mode repair reason sources the cadence config"
+}
+
+test_hook_pending_wake_only_blocks_in_default_mode() {
+  local dir out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-pending-wake-only")
+  printf 'pending wake\n' > "$dir/state/.wake-queue"
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 2 "$status" "default hook mode must block while a durable wake remains pending"
+  assert_contains "$out" "pending durable wake needs supervision" "pending-wake-only blind stop must identify its supervision need"
+  assert_not_contains "$out" "X-mode relay polling needs supervision" "pending wake was misreported as Relay demand"
+  pass "fm-turnend-guard: pending durable wake remains guarded until drain"
 }
 
 test_hook_x_mode_only_blocks_in_default_mode() {
@@ -977,6 +1015,7 @@ test_pi_extension_injects_once_per_logical_agent_run() {
   mkdir -p "$repo/.pi/extensions/lib" "$repo/bin" "$home/state"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$ext"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$repo/.pi/extensions/lib/fm-operational-input.ts"
+  cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$repo/.pi/extensions/lib/fm-pi-watch-coordination.ts"
   cp "$ROOT/bin/fm-operational-input.sh" "$repo/bin/fm-operational-input.sh"
   cat > "$repo/bin/fm-turnend-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1035,6 +1074,77 @@ EOF
   pass ".pi primary extension: no-tool and multi-tool runs each inject exactly one guard follow-up"
 }
 
+test_pi_guard_waits_for_watcher_demand_reconciliation() {
+  local repo home ext log out status
+  repo="$TMP_ROOT/pi-guard-reconcile-root"
+  home="$TMP_ROOT/pi-guard-reconcile-home"
+  ext="$repo/.pi/extensions/fm-primary-turnend-guard.ts"
+  log="$TMP_ROOT/pi-guard-reconcile.log"
+  mkdir -p "$repo/.pi/extensions/lib" "$repo/bin" "$home/state"
+  cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$ext"
+  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$repo/.pi/extensions/lib/fm-operational-input.ts"
+  cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$repo/.pi/extensions/lib/fm-pi-watch-coordination.ts"
+  cp "$ROOT/bin/fm-operational-input.sh" "$repo/bin/fm-operational-input.sh"
+  cat > "$repo/bin/fm-turnend-guard.sh" <<'SH'
+#!/usr/bin/env bash
+cat >/dev/null
+printf 'guard\n' >> "${FM_GUARD_LOG:?}"
+exit 0
+SH
+  cat > "$repo/bin/fm-arm-pretool-check.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$repo/bin/fm-cd-pretool-check.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$repo/bin/fm-turnend-guard.sh" "$repo/bin/fm-arm-pretool-check.sh" "$repo/bin/fm-cd-pretool-check.sh"
+  out=$(PLUGIN="$ext" FM_HOME="$home" FM_GUARD_LOG="$log" node --input-type=module 2>&1 <<'EOF'
+import { existsSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+const listeners = new Map();
+let release = () => {};
+const reconciliation = new Promise((resolve) => {
+  release = resolve;
+});
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  events: {
+    on(event, handler) {
+      listeners.set(event, handler);
+    },
+    emit(event, payload) {
+      listeners.get(event)?.(payload);
+    },
+  },
+  sendUserMessage: async () => {},
+};
+pi.events.on("fm-primary-pi-watch:reconcile-demand", (request) => {
+  request.waitUntil(reconciliation);
+});
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+const settledRun = handlers.get("agent_settled")?.({ type: "agent_settled" }, {});
+for (let i = 0; i < 100 && !existsSync(process.env.FM_GUARD_LOG); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (existsSync(process.env.FM_GUARD_LOG)) throw new Error("guard ran before watcher demand reconciliation settled");
+release();
+await settledRun;
+if (!existsSync(process.env.FM_GUARD_LOG)) throw new Error("guard did not run after watcher demand reconciliation settled");
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi turn-end guard must wait for watcher demand reconciliation: $out"
+  [ -z "$out" ] || fail "Pi guard reconciliation test printed output: $out"
+  pass ".pi primary guard waits for local watcher demand reconciliation before repair"
+}
+
 test_pi_extension_retries_after_followup_delivery_failure() {
   local repo home ext out status
   repo="$TMP_ROOT/pi-delivery-failure-root"
@@ -1043,6 +1153,7 @@ test_pi_extension_retries_after_followup_delivery_failure() {
   mkdir -p "$repo/.pi/extensions/lib" "$repo/bin" "$home/state"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$ext"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$repo/.pi/extensions/lib/fm-operational-input.ts"
+  cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$repo/.pi/extensions/lib/fm-pi-watch-coordination.ts"
   cp "$ROOT/bin/fm-operational-input.sh" "$repo/bin/fm-operational-input.sh"
   cat > "$repo/bin/fm-turnend-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1751,6 +1862,8 @@ test_hook_claude_mode_secondmate_reblocks_like_primary() {
 }
 
 test_predicate_healthy_no_inflight
+test_predicate_counts_only_published_task_records
+test_predicate_uncertain_published_state_keeps_supervision
 test_predicate_unhealthy_no_beacon
 test_predicate_unhealthy_stale_beacon
 test_predicate_healthy_fresh_beacon
@@ -1767,6 +1880,7 @@ test_hook_blocks_with_live_lock_and_stale_beacon
 test_hook_blocks_when_unhealthy_in_primary
 test_hook_blocks_from_fm_home_state
 test_hook_x_mode_reason_sources_cadence
+test_hook_pending_wake_only_blocks_in_default_mode
 test_hook_x_mode_only_blocks_in_default_mode
 test_hook_ignores_repo_state_when_fm_home_set
 test_hook_uses_state_override
@@ -1795,6 +1909,7 @@ test_codex_hook_uses_process_pwd_when_payload_cwd_is_outside_root
 test_codex_hook_ignores_nested_git_root_guard
 test_opencode_plugin_anchors_guard_to_worktree
 test_pi_extension_injects_once_per_logical_agent_run
+test_pi_guard_waits_for_watcher_demand_reconciliation
 test_pi_extension_retries_after_followup_delivery_failure
 test_hook_claude_mode_reblocks_stop_hook_active_when_unhealthy
 test_hook_claude_mode_reblocks_x_mode_without_tasks

--- a/tests/fm-watch-recovery-loop.test.sh
+++ b/tests/fm-watch-recovery-loop.test.sh
@@ -22,8 +22,10 @@ install_pi_watch_extension_fixture() {
   cp "$ROOT/.pi/extensions/lib/fm-branch-dispatch.ts" "$repo/.pi/extensions/lib/fm-branch-dispatch.ts"
   cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$repo/.pi/extensions/lib/fm-calm-visibility.ts"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$repo/.pi/extensions/lib/fm-operational-input.ts"
+  cp "$ROOT/.pi/extensions/lib/fm-pi-watch-coordination.ts" "$repo/.pi/extensions/lib/fm-pi-watch-coordination.ts"
   cp "$ROOT/bin/fm-operational-input.sh" "$repo/bin/fm-operational-input.sh"
-  chmod +x "$repo/bin/fm-operational-input.sh"
+  cp "$ROOT/bin/fm-supervision-lib.sh" "$repo/bin/fm-supervision-lib.sh"
+  chmod +x "$repo/bin/fm-operational-input.sh" "$repo/bin/fm-supervision-lib.sh"
   cat > "$repo/node_modules/@earendil-works/pi-coding-agent/package.json" <<'JSON'
 {"name":"@earendil-works/pi-coding-agent","type":"module","exports":"./index.js"}
 JSON


### PR DESCRIPTION
## Intent

Make Pi primary watcher monitoring demand-driven without spending model turns on routine start or stop checks.

## What changed

- Reconciles supervision demand at Pi session start, after settled main runs, and from filtered debounced state hints.
- Starts the existing arm child only when published tasks, Relay, process-event sources, pending wakes, or uncertain state require supervision.
- Retires idle monitoring silently and rechecks demand across retirement races.
- Keeps pending wakes supervised until drain and excludes dot-prefixed task staging records.
- Makes the Pi turn-end guard await local watcher reconciliation before considering repair.
- Keeps `fm_watch_arm_pi` as a rare demand-gated repair tool without normal prompt snippets or guidelines.
- Preserves generation ownership, actionable wake delivery, Relay-only and process-event-only demand, and fail-toward-monitoring uncertainty.

## Pipeline fixes

Automated review found and fixed idle retry cancellation, late-retirement suppression, lock-handoff detection, readiness and retry ordering, demand-gated explicit repair, complete fixture wiring, bounded hung-arm recovery, and actionable-close coordination races.

## Tests

- `bash tests/fm-pi-watch-extension.test.sh`
- `bash tests/fm-turnend-guard.test.sh`
- `bash tests/fm-supervision-instructions.test.sh`
- `bash tests/fm-watch-recovery-loop.test.sh`
- `bash tests/fm-watch-arm.test.sh`
- `bash tests/fm-guard-stale-banner.test.sh`
- `bash tests/fm-calm-pi-extension.test.sh`
- `bash tests/fm-session-start.test.sh`
- `npm exec --yes --package=typescript -- bash tests/fm-pi-primary-types.test.sh`
- `PATH=/tmp/fm-lint-tools-demand-watcher:$PATH bin/fm-lint.sh`
- `bin/fm-doc-audience-check.sh`

The full no-mistakes run was cancelled at the captain's request after targeted behavioral, type, documentation, and lint checks passed.

## Risk

High: this changes watcher lifecycle and turn-end coordination, with behavioral coverage for demand sources, idle retirement, readiness, retry, lock handoff, process-tree cleanup, session replacement, and real wake delivery.
