### PR TITLE
fix(bin): absorb orphaned status, turn-end, and check markers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ bin/fm-test-isolation-proof.sh --pool watcher-wake-lock --jobs 4   # re-run an a
 @AGENTS.md
 EOF
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
-tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVERRIDE="$tmp" FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then an actionable signal)
+tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && printf 'window=fake\n' > "$tmp/smoke.meta" && FM_STATE_OVERRIDE="$tmp" FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then an actionable signal); the .meta file is required, else the orphan guard absorbs the status as a torn-down task's leftover
 ```
 
 `bin/fm-test-run.sh` is the single owner of behavior-suite selection, portable CI lane composition, bounded concurrency admission, per-script timing markers, family totals, the coverage guard, and the optional JSON timing artifact.

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1142,6 +1142,13 @@ housekeeping() {  # <state>
     for f in "$state"/*.status; do
       [ -e "$f" ] || [ -L "$f" ] || continue
       task=$(basename "$f"); task="${task%.status}"
+      # Same orphan guard as bin/fm-watch.sh's scan_signals: a .status
+      # surviving with no matching state/<id>.meta belongs to a torn-down (or
+      # never-recorded) task and has no owner for firstmate to act on, so it
+      # must never wake firstmate via this catch-all either. Skipped here, not
+      # removed - the watcher's own per-poll scan already best-effort removes
+      # the file, so this stays a pure read.
+      [ -e "$state/$task.meta" ] || continue
       record=$(status_span_first_actionable_record "$f" \
         "$(status_seen_offset "$state" "$task")")
       rc=$?

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -15,7 +15,12 @@
 # on every wake. Printed reason lines:
 #   signal: <file>...      status/turn-end signals, surfaced when a listed status
 #                          span has a captain-relevant event OR a no-verb signal lacks
-#                          positive execution evidence, unless afk is active
+#                          positive execution evidence, unless afk is active. A
+#                          .status/.turn-ended with no matching state/<id>.meta is
+#                          an orphan from a torn-down task (or a leaked writer
+#                          still touching its old path) and is always absorbed
+#                          and removed, even under afk - never classified, never
+#                          actionable, no matter how many times it is recreated.
 #   stale: <window>        a provably-working stale is ALWAYS absorbed (with a wedge
 #                          timer) regardless of what the status log says - an active
 #                          run-step or busy pane outranks even a captain-relevant log
@@ -70,7 +75,11 @@
 #                          captured generation, never again while that record
 #                          stays queued and never once it is acknowledged
 #   check: rejected unauthenticated state checks: <paths>
-#                          unsafe state checks were refused without execution
+#                          unsafe state checks were refused without execution.
+#                          A check.sh with no matching state/<id>.meta is instead
+#                          an orphan (unless its fixed name is an exempt shim like
+#                          x-watch.check.sh or tool-updates.check.sh) and is
+#                          absorbed and removed here rather than reported
 #   check: rejected unauthenticated PR poll retirement receipts: <paths>
 #                          invalid pending retirements were preserved without
 #                          running a check or removing poll artifacts
@@ -1007,11 +1016,34 @@ age_of() {  # seconds since file mtime; "due immediately" if missing
 # Pure read: prints one "<seen-file>\t<sig>\t<file>" line per changed file.
 # The caller records reported state only after surfacing or intentional absorption,
 # and commits a status classification position only after a successful span read.
+#
+# Orphan guard: a live task always has a matching state/<id>.meta (fm-spawn.sh
+# writes it before the agent can produce a first status or turn-end, and
+# teardown removes markers before it removes .meta - see fm-teardown.sh). A
+# .status/.turn-ended surviving with no matching .meta belongs to no task
+# firstmate can act on, most commonly a harness turn-end hook whose command
+# line baked in this absolute path before teardown ran and which keeps firing
+# if its process outlives teardown's best-effort backend kill (Stop hooks,
+# opencode's plugin, pi's extension, grok's global hook). Such a file must
+# never wake firstmate no matter how many times it is recreated: skip it here,
+# before it ever reaches a signature or classification, and best-effort remove
+# it so a leaked writer cannot leave a permanently "fresh" file in state/.
 scan_signals() {
-  local f sig sf
+  local f sig sf base task
   for f in "$STATE"/*.status "$STATE"/*.turn-ended; do
     if [ ! -e "$f" ]; then
       case "$f" in *.status) [ -L "$f" ] || continue ;; *) continue ;; esac
+    fi
+    base=$(basename "$f")
+    case "$base" in
+      *.status) task=${base%.status} ;;
+      *.turn-ended) task=${base%.turn-ended} ;;
+      *) continue ;;
+    esac
+    if [ ! -e "$STATE/$task.meta" ]; then
+      triage_log "absorbed orphan signal (no state/$task.meta): $f"
+      rm -f "$f" 2>/dev/null || true
+      continue
     fi
     sig=$(fm_wake_signal_sig "$f") || continue
     [ -n "$sig" ] || continue
@@ -1230,6 +1262,12 @@ heartbeat_scan_finds_actionable() {
   for f in "$STATE"/*.status; do
     [ -e "$f" ] || [ -L "$f" ] || continue
     task=$(basename "$f"); task="${task%.status}"
+    # Same orphan guard as scan_signals: a .status surviving with no matching
+    # state/<id>.meta belongs to a torn-down (or never-recorded) task and must
+    # never wake firstmate via this backstop either. Skipped here, not
+    # removed - scan_signals' own per-poll pass already best-effort removes
+    # the file, so this stays a pure read.
+    [ -e "$STATE/$task.meta" ] || continue
     record=$(status_span_first_actionable_record "$f" "$(hb_surfaced_offset "$task")")
     rc=$?
     [ "$rc" -eq 1 ] && [ -z "$record" ] && continue
@@ -1545,6 +1583,7 @@ while :; do
     rejected_checks=
     for c in "$STATE"/*.check.sh; do
       [ -e "$c" ] || continue
+      id=$(basename "$c" .check.sh)
       is_pr_poll=0
       if [ "$(basename "$c")" = x-watch.check.sh ]; then
         if fmx_poll_shim_valid "$c" "$FM_HOME" "$FM_ROOT" \
@@ -1556,7 +1595,6 @@ while :; do
           continue
         fi
       else
-        id=$(basename "$c" .check.sh)
         if fm_pr_poll_snapshot_capture "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh"; then
           is_pr_poll=1
           provider=$FM_PR_POLL_SNAPSHOT_PROVIDER
@@ -1574,7 +1612,27 @@ while :; do
           fm_custom_check_snapshot_cleanup
         else
           fm_custom_check_snapshot_cleanup
-          rejected_checks="$rejected_checks $c"
+          # Orphan guard: a per-task custom check is always registered
+          # (state/<id>.check-trust) against a live task with a matching
+          # state/<id>.meta - fm-teardown.sh's remove_pr_poll_artifacts
+          # removes .check.sh and .check-trust together with .meta, so a
+          # registered live task never reaches this branch at all. A survivor
+          # here has failed BOTH pr-poll and custom-check registration, so it
+          # is either a live task whose registration is genuinely broken
+          # (still worth reporting) or a torn-down task's leftover with no
+          # owner (must never wake firstmate, no matter how many
+          # CHECK_INTERVAL sweeps pass). state/<id>.meta is what tells the two
+          # apart. tool-updates is the sole exception: fm-tool-update-check.sh's
+          # fixed-name poll shim, keyed by a constant id rather than a spawned
+          # task id, so it never has a matching .meta by design - a broken
+          # tool-updates registration must keep surfacing, exactly like
+          # x-watch's own name-based carve-out above.
+          if [ "$id" = tool-updates ] || [ -e "$STATE/$id.meta" ]; then
+            rejected_checks="$rejected_checks $c"
+          else
+            triage_log "absorbed orphan check (no matching state/$id.meta): $c"
+            rm -f "$c" "$STATE/$id.check-trust" 2>/dev/null || true
+          fi
           continue
         fi
       fi

--- a/tests/fm-afk-inject-e2e.test.sh
+++ b/tests/fm-afk-inject-e2e.test.sh
@@ -161,6 +161,11 @@ chmod +x "$TMUX_SHIM_DIR/tmux"
 # Create a fake crewmate window (the watcher lists fm-* windows for stale
 # detection). The pane is an inert shell - it just needs to exist.
 "$REAL_TMUX" -L "$SOCKET" new-window -d -n fm-fake-c1 -t supervisor
+# A live task always has a matching state/<id>.meta (fm-spawn.sh writes it
+# before ever launching the window); without one the watcher's orphan guard
+# absorbs fake-c1.status as belonging to no task, before this suite's own
+# assertions ever get to run.
+printf 'window=supervisor:fm-fake-c1\n' > "$STATE_DIR/fake-c1.meta"
 
 start_daemon() {
   PATH="$TMUX_SHIM_DIR:$PATH" \

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -296,6 +296,7 @@ test_status_read_failure_surfaces_without_advancing_seen() {
 test_catchall_advances_routine_then_surfaces_append() {
   local dir state out
   dir=$(make_supercase catchall-routine); state="$dir/state"
+  fm_write_meta "$state/routine-r6.meta" "window=sess:fm-routine-r6"
   printf 'working: routine history\nworking: still routine\n' > "$state/routine-r6.status"
   rm -f "$state/.subsuper-last-scan"
   FM_STATE_OVERRIDE="$state" housekeeping "$state"
@@ -349,6 +350,7 @@ test_catchall_buffer_failure_preserves_position() {
   local dir state buffer out
   dir=$(make_supercase catchall-write-failure); state="$dir/state"
   buffer="$state/.subsuper-escalations"
+  fm_write_meta "$state/catch-write-r2.meta" "window=sess:fm-catch-write-r2"
   printf 'failed: release verification broke\nworking: collecting logs\n' > "$state/catch-write-r2.status"
   mkdir "$buffer"
   rm -f "$state/.subsuper-last-scan"
@@ -450,6 +452,7 @@ test_permission_recovery_reclassifies_catchall_status() {
   local dir state status before_ident after_ident out
   dir=$(make_supercase catchall-permission-recovery); state="$dir/state"
   status="$state/permission-r8.status"
+  fm_write_meta "$state/permission-r8.meta" "window=sess:fm-permission-r8"
   printf 'blocked: release approval required\nworking: preserving context\n' > "$status"
   before_ident=$(_fm_open_decisions_file_ident "$status")
   chmod 000 "$status"
@@ -551,6 +554,7 @@ test_catchall_scan_surfaces_a_masked_event() {
   local dir state
   dir=$(make_supercase catchall-masked)
   state="$dir/state"
+  fm_write_meta "$state/catch-m1.meta" "window=sess:fm-catch-m1"
   printf 'working: setup\nneeds-decision [key=release]: pick A or B\nfailed: release build broke\nworking: tidying the branch\n' \
     > "$state/catch-m1.status"
   rm -f "$state/.subsuper-last-scan"
@@ -1407,6 +1411,7 @@ test_heartbeat_scan_dedup() {
   local dir state
   dir=$(make_supercase scan-dedup)
   state="$dir/state"
+  fm_write_meta "$state/dup-t6.meta" "window=sess:fm-dup-t6"
   printf 'done: ready\n' > "$state/dup-t6.status"
   rm -f "$state/.subsuper-last-scan"
   FM_STATE_OVERRIDE="$state" housekeeping "$state"
@@ -1416,6 +1421,22 @@ test_heartbeat_scan_dedup() {
   FM_STATE_OVERRIDE="$state" housekeeping "$state"
   [ -s "$state/.subsuper-escalations" ] && fail "catch-all scan re-escalated the same terminal (dedup failed)"
   pass "catch-all scan escalates a missed terminal once, not twice"
+}
+
+# Regression for the orphan-marker guard: a .status surviving with no matching
+# state/<id>.meta belongs to a torn-down (or never-recorded) task and must
+# never be escalated by this catch-all, mirroring bin/fm-watch.sh's own
+# scan_signals orphan guard - even under afk, where this catch-all is the ONLY
+# scanner running.
+test_heartbeat_scan_orphan_status_not_escalated() {
+  local dir state
+  dir=$(make_supercase scan-orphan)
+  state="$dir/state"
+  printf 'done: orphan PR\n' > "$state/ghost.status"
+  rm -f "$state/.subsuper-last-scan"
+  FM_STATE_OVERRIDE="$state" housekeeping "$state"
+  [ -s "$state/.subsuper-escalations" ] && fail "catch-all scan escalated an orphan .status with no matching .meta"
+  pass "catch-all scan never escalates a no-meta orphan .status (housekeeping stays quiet, even under afk)"
 }
 
 test_handle_wake_routes_self_and_escalate() {
@@ -2653,6 +2674,7 @@ test_housekeeping_orca_persistent_stale_resolves_terminal
 test_escalate_batches_into_one_digest
 test_escalate_batch_age_uses_first_append
 test_heartbeat_scan_dedup
+test_heartbeat_scan_orphan_status_not_escalated
 test_handle_wake_routes_self_and_escalate
 test_inject_skip_forces_self
 test_is_wake_reason_distinguishes_status_stdout

--- a/tests/fm-wake-daemon-lifecycle-e2e.test.sh
+++ b/tests/fm-wake-daemon-lifecycle-e2e.test.sh
@@ -67,6 +67,7 @@ test_routine_then_terminal_after_restart() {
   drain_out="$dir/drain.out"
   drain_err="$dir/drain.err"
   status_file="$state/task-w1.status"
+  fm_write_meta "$state/task-w1.meta" "window=sess:fm-task-w1"
 
   # A routine status fires a signal; the watcher queues it and exits.
   printf 'working: building\n' > "$status_file"

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -62,6 +62,7 @@ test_signal_catchup_without_running_watcher() {
   drain_out="$dir/drain.out"
   drain_err="$dir/drain.err"
   status_file="$state/task.status"
+  fm_write_meta "$state/task.meta" "window=sess:fm-task"
   # The durable-queue catch-up contract applies to ACTIONABLE wakes (the always-on
   # watcher can absorb no-verb working: notes when the crew is provably working).
   # Use a captain-relevant verb so the wake is surfaced and the catch-up path is

--- a/tests/fm-watch-arm.test.sh
+++ b/tests/fm-watch-arm.test.sh
@@ -169,6 +169,7 @@ test_attached_arm_reports_the_delivered_wake() {
 
   # A real captain-relevant status change: the watcher records it in the durable
   # queue, prints its one reason line to its own stdout, and exits.
+  fm_write_meta "$state/demo.meta" "window=sess:fm-demo"
   printf 'done: fixture finished\n' > "$state/demo.status"
   wait_for_exit "$SEED_PID" 120
   grep -q '^signal:' "$out" || fail "seed watcher did not surface the signal wake: $(cat "$out")"
@@ -199,6 +200,7 @@ test_attached_arm_reports_the_delivered_wake_after_drain() {
   # handling turn drains, which is the ordering this case exists to cover.
   start_attached_arm "$state" "$fakebin" "$armout" 5
 
+  fm_write_meta "$state/demo.meta" "window=sess:fm-demo"
   printf 'done: fixture finished\n' > "$state/demo.status"
   wait_for_exit "$SEED_PID" 120
   # The handling turn consumes the records before the attached arm closes: the
@@ -253,6 +255,11 @@ test_rearm_resurfaces_durable_queue_and_remote_open_decision() {
   armout="$dir/arm.out"
   drainout="$dir/drain.out"
   mkdir -p "$home/data"
+
+  # A registered secondmate always has a matching state/<id>.meta in the
+  # parent home (kind=secondmate), same as any live task; without one the
+  # watcher's orphan guard would absorb ios.status as belonging to no task.
+  fm_write_meta "$state/ios.meta" "kind=secondmate" "home=$dir/ios-home"
 
   # This is the real remote parent-reply ingest boundary. It writes the remote
   # secondmate's decision onto the parent status surface the shared fold owns.
@@ -408,6 +415,7 @@ test_delivery_gap_wake_is_recovered_once() {
   fakebin="$dir/fakebin"
   mkdir -p "$home/data"
 
+  fm_write_meta "$state/first.meta" "window=sess:fm-first"
   start_rearm_arm "$home" "$state" "$fakebin" "$dir/first-arm.out"
   first_arm=$ARM_PID
   is_live_non_zombie "$first_arm" || fail "delivery-gap fixture watcher did not stay live"
@@ -447,6 +455,7 @@ test_interrupted_handling_is_redrained_on_rearm() {
   fakebin="$dir/fakebin"
   mkdir -p "$home/data"
 
+  fm_write_meta "$state/interrupted.meta" "window=sess:fm-interrupted"
   start_rearm_arm "$home" "$state" "$fakebin" "$dir/first-arm.out"
   first_arm=$ARM_PID
   is_live_non_zombie "$first_arm" || fail "interrupted-handling fixture watcher did not stay live"
@@ -649,6 +658,9 @@ test_handling_window_close_keeps_the_acknowledgement_valid() {
   fakebin="$dir/fakebin"
   mkdir -p "$home/data"
 
+  fm_write_meta "$state/handled.meta" "window=sess:fm-handled"
+  fm_write_meta "$state/during-handling.meta" "window=sess:fm-during-handling"
+  fm_write_meta "$state/later.meta" "window=sess:fm-later"
   start_rearm_arm "$home" "$state" "$fakebin" "$dir/first-arm.out"
   is_live_non_zombie "$ARM_PID" || fail "handling-window fixture watcher did not stay live"
   printf 'done: wake handled while a watcher cycle closes\n' > "$state/handled.status"
@@ -717,6 +729,8 @@ test_moved_generation_acknowledgement_is_self_healing() {
   fakebin="$dir/fakebin"
   mkdir -p "$home/data"
 
+  fm_write_meta "$state/first.meta" "window=sess:fm-first"
+  fm_write_meta "$state/second.meta" "window=sess:fm-second"
   start_rearm_arm "$home" "$state" "$fakebin" "$dir/first-arm.out"
   is_live_non_zombie "$ARM_PID" || fail "moved-generation fixture watcher did not stay live"
   printf 'done: first handled wake\n' > "$state/first.status"

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1694,6 +1694,29 @@ SH
   pass "tool-updates.check.sh survives the orphan guard and keeps running with no state/tool-updates.meta"
 }
 
+# tool-updates is exempt from the orphan guard's .meta requirement even when
+# its registration is broken (unlike x-watch's fixed-name bypass, tool-updates
+# is authorized through the ordinary custom-check trust path, so a missing or
+# invalid registration must still fall through to the rejected-checks branch
+# and keep surfacing rather than being silently absorbed for lacking a .meta).
+test_tool_updates_check_sh_unregistered_still_surfaces() {
+  local dir state fakebin out pid
+  dir=$(make_case tool-updates-unregistered-check-sh); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  # No state/tool-updates.meta and no check-trust registration at all.
+  cat > "$state/tool-updates.check.sh" <<'SH'
+#!/usr/bin/env bash
+echo "should never run either, but must be reported"
+SH
+  chmod 700 "$state/tool-updates.check.sh"
+  watch_bg "$state" "$fakebin" "$out" FM_CHECK_INTERVAL=1
+  pid=$!
+  wait_for_exit "$pid" 100 || fail "watcher did not exit for an unregistered tool-updates.check.sh"
+  grep -F "check: rejected unauthenticated state checks:" "$out" | grep -F "tool-updates.check.sh" >/dev/null \
+    || fail "an unregistered tool-updates.check.sh was not reported: $(cat "$out")"
+  [ -e "$state/tool-updates.check.sh" ] || fail "tool-updates.check.sh was wrongly removed by the orphan guard"
+  pass "an unregistered tool-updates.check.sh keeps surfacing as a rejected check despite no state/tool-updates.meta"
+}
+
 # --- actionable wakes are surfaced (queue + exit) ---------------------------
 
 test_actionable_signal_surfaced() {
@@ -4067,6 +4090,7 @@ test_orphan_check_sh_never_runs
 test_live_task_unregistered_check_sh_still_surfaces
 test_x_watch_check_sh_survives_orphan_guard_and_runs
 test_tool_updates_check_sh_survives_orphan_guard_and_runs
+test_tool_updates_check_sh_unregistered_still_surfaces
 test_actionable_signal_surfaced
 test_actionable_signal_survives_a_later_routine_append
 test_release_completion_survives_a_later_routine_append

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -47,7 +47,11 @@ ack_stopped_cycle() {  # <state>
 watch_bg() {  # <state> <fakebin> <out> [extra env assignments...]
   local state=$1 fakebin=$2 out=$3
   shift 3
-  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+  # A trailing "NAME=value" caller override must go through env: bash only
+  # recognizes a literal parse-time "NAME=value" token as an assignment
+  # prefix, never one produced by "$@" expansion, so passing it directly
+  # ahead of "$WATCH" would run it as a (nonexistent) command instead.
+  PATH="$fakebin:$PATH" env FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
     FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$@" "$WATCH" > "$out" &
 }
 
@@ -691,6 +695,7 @@ test_secondmate_status_signal_never_absorbed_classifier() {
 test_provably_working_signal_absorbed() {
   local dir state fakebin out status_file pid
   dir=$(make_case provably-working-signal); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  fm_write_meta "$state/task.meta" "window=sess:fm-task"
   status_file="$state/task.status"
   printf 'working: compiling step 2\n' > "$status_file"
   # The crew's pipeline is in an actively-running step: positive evidence it is
@@ -713,6 +718,7 @@ test_provably_working_signal_absorbed() {
 test_turn_ended_provably_working_absorbed() {
   local dir state fakebin out pid
   dir=$(make_case turn-ended-working); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  fm_write_meta "$state/task.meta" "window=sess:fm-task"
   : > "$state/task.turn-ended"
   # A busy pane is the second form of positive evidence (covers a queued
   # continuation right after the turn-end).
@@ -737,6 +743,7 @@ test_turn_ended_not_working_surfaced() {
   local dir state fakebin out drain_out pid
   dir=$(make_case turn-ended-stopped); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; drain_out="$dir/drain.out"
+  fm_write_meta "$state/task.meta" "window=sess:fm-task"
   : > "$state/task.turn-ended"
   # No running pipeline, no busy pane: the crew has stopped (e.g. it finished via
   # an interactive menu and wrote no done: status). Default unknown verdict.
@@ -1437,6 +1444,7 @@ test_working_note_not_working_surfaced() {
   local dir state fakebin out drain_out status_file pid
   dir=$(make_case working-note-stopped); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; drain_out="$dir/drain.out"
+  fm_write_meta "$state/task.meta" "window=sess:fm-task"
   status_file="$state/task.status"
   printf 'working: compiling step 2\n' > "$status_file"
   # A non-no-mistakes crew (no run) whose pane went idle: fm-crew-state falls back
@@ -1476,6 +1484,7 @@ test_secondmate_status_note_surfaced_despite_busy_agent() {
 test_self_announced_close_does_not_rewake_but_next_note_does() {
   local dir state fakebin out status_file pid rc
   dir=$(make_case self-close-quiet); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  fm_write_meta "$state/task.meta" "window=sess:fm-task"
   status_file="$state/task.status"
   printf 'needs-decision [key=k1]: pick one\n' > "$status_file"
   prime_status_seen "$state" "$status_file" || fail "could not prime the announced baseline"
@@ -1504,12 +1513,194 @@ test_self_announced_close_does_not_rewake_but_next_note_does() {
   pass "a self-announced close never wakes its own home, and the next real note still does"
 }
 
+# --- an orphan marker with no matching state/<id>.meta NEVER surfaces --------
+# A live task always has a matching state/<id>.meta: fm-spawn.sh writes it
+# before the agent can produce a first status or turn-end, and fm-teardown.sh
+# removes .status/.turn-ended/.check.sh before it removes .meta (see
+# status_retire_presentation_task and remove_pr_poll_artifacts, both called
+# ahead of the backlog transition that drops .meta). A marker that survives
+# with no .meta belongs to no task firstmate can act on - most plausibly a
+# harness turn-end hook (e.g. a Claude Stop hook) whose command line baked in
+# the absolute state path before teardown ran, still firing if its owning
+# process outlives teardown's best-effort backend kill. Regression for the
+# orphan-signal-forever bug: such a marker must never wake firstmate, no
+# matter how many times it reappears with a fresh mtime, and the watcher
+# should clean it up rather than leave it sitting in state/ forever.
+
+test_orphan_turn_ended_never_surfaces() {
+  local dir state fakebin out pid
+  dir=$(make_case orphan-turn-ended); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  # Deliberately NO state/orphan.meta: this id was torn down (or never spawned).
+  : > "$state/orphan.turn-ended"
+  # Even a verdict that would normally be surfaced (crew "not provably
+  # working") must not matter here - the orphan guard runs before any
+  # provably-working read.
+  export FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'
+  watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "watcher exited for an orphan turn-end with no matching .meta (should absorb): $(cat "$out")"
+  fi
+  [ ! -s "$out" ] || fail "orphan turn-end printed a wake reason: $(cat "$out")"
+  [ ! -s "$state/.wake-queue" ] || fail "orphan turn-end enqueued a durable wake record"
+  [ ! -e "$state/orphan.turn-ended" ] || fail "orphan turn-end was not cleaned up"
+  reap "$pid"
+  pass "a turn-end marker with no matching state/<id>.meta never surfaces and is removed"
+}
+
+test_orphan_turn_ended_recreated_every_poll_never_surfaces() {
+  local dir state fakebin out pid i
+  dir=$(make_case orphan-turn-ended-recreated); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  export FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'
+  watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  # Simulate a leaked writer that keeps re-touching the orphan marker with a
+  # fresh mtime every poll (the exact reported symptom: recreated even when
+  # manually deleted between cycles). Across several poll cycles this must
+  # never once become an actionable wake.
+  i=0
+  while [ "$i" -lt 5 ]; do
+    : > "$state/ghost.turn-ended"
+    sleep 0.3
+    i=$((i + 1))
+  done
+  if ! wait_live "$pid" 10; then
+    reap "$pid"; fail "watcher exited while an orphan turn-end was repeatedly recreated (should never surface): $(cat "$out")"
+  fi
+  [ ! -s "$out" ] || fail "repeatedly recreated orphan turn-end printed a wake reason: $(cat "$out")"
+  [ ! -s "$state/.wake-queue" ] || fail "repeatedly recreated orphan turn-end enqueued a durable wake record"
+  reap "$pid"
+  pass "an orphan turn-end recreated with a fresh mtime every poll never becomes actionable"
+}
+
+test_orphan_status_with_captain_relevant_verb_never_surfaces() {
+  local dir state fakebin out pid
+  dir=$(make_case orphan-status-verb); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  # No state/orphan.meta. Even a captain-relevant verb (which would normally
+  # be immediately actionable via signal_reason_is_actionable) must not
+  # surface for an unowned file - the orphan check runs before classification.
+  printf 'needs-decision: pick A or B\n' > "$state/orphan.status"
+  watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "watcher exited for an orphan captain-relevant status with no matching .meta (should absorb): $(cat "$out")"
+  fi
+  [ ! -s "$out" ] || fail "orphan captain-relevant status printed a wake reason: $(cat "$out")"
+  [ ! -s "$state/.wake-queue" ] || fail "orphan captain-relevant status enqueued a durable wake record"
+  [ ! -e "$state/orphan.status" ] || fail "orphan captain-relevant status was not cleaned up"
+  reap "$pid"
+  pass "a captain-relevant status with no matching state/<id>.meta never surfaces and is removed"
+}
+
+# --- an orphan check.sh with no matching state/<id>.meta never runs ----------
+# Custom and PR-poll checks are authorized by registration (state/<id>.check-
+# trust or a PR-poll snapshot), not by .meta - but a per-task check.sh still
+# always belongs to a live task with a matching .meta (fm-teardown.sh's
+# remove_pr_poll_artifacts removes .check.sh and .check-trust together with
+# .meta). A survivor with no .meta and no fixed-name exemption must never run
+# or wake firstmate, and the sweep must fold it into the same orphan-absorb
+# path as .status/.turn-ended rather than reporting it as a routine rejected-
+# unauthenticated check every CHECK_INTERVAL forever.
+test_orphan_check_sh_never_runs() {
+  local dir state fakebin out pid
+  dir=$(make_case orphan-check-sh); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  # No state/orphan.meta. A .check.sh that would otherwise print an actionable
+  # line must never even run once its owning task is torn down.
+  cat > "$state/orphan.check.sh" <<'SH'
+#!/usr/bin/env bash
+echo "should never run"
+SH
+  chmod 700 "$state/orphan.check.sh"
+  watch_bg "$state" "$fakebin" "$out" FM_CHECK_INTERVAL=1
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "watcher exited for an orphan check.sh with no matching .meta (should absorb): $(cat "$out")"
+  fi
+  [ ! -s "$out" ] || fail "orphan check.sh printed a wake reason: $(cat "$out")"
+  [ ! -s "$state/.wake-queue" ] || fail "orphan check.sh enqueued a durable wake record"
+  [ ! -e "$state/orphan.check.sh" ] || fail "orphan check.sh was not cleaned up"
+  reap "$pid"
+  pass "a check.sh with no matching state/<id>.meta never runs and is removed"
+}
+
+# A live task's own check.sh must keep surfacing exactly as before when its
+# registration is broken or missing - the orphan guard is keyed on .meta
+# presence alone and must never swallow a real, actionable rejection.
+test_live_task_unregistered_check_sh_still_surfaces() {
+  local dir state fakebin out pid
+  dir=$(make_case live-unregistered-check-sh); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  fm_write_meta "$state/mytask.meta" "window=fm-mytask"
+  cat > "$state/mytask.check.sh" <<'SH'
+#!/usr/bin/env bash
+echo "should never run either, but must be reported"
+SH
+  chmod 700 "$state/mytask.check.sh"
+  watch_bg "$state" "$fakebin" "$out" FM_CHECK_INTERVAL=1
+  pid=$!
+  wait_for_exit "$pid" 100 || fail "watcher did not exit for a live task's unregistered check.sh"
+  grep -F "check: rejected unauthenticated state checks:" "$out" | grep -F "mytask.check.sh" >/dev/null \
+    || fail "a live task's unregistered check.sh was not reported: $(cat "$out")"
+  [ -e "$state/mytask.check.sh" ] || fail "a live task's check.sh was wrongly removed by the orphan guard"
+  pass "a live task's unregistered check.sh keeps surfacing as a rejected check, not silently absorbed"
+}
+
+# --- the fixed-name poll shims (no task id, so no .meta by design) are exempt -
+# x-watch.check.sh (Relay's poll shim) and tool-updates.check.sh (the watched-
+# tool update poll shim) are both keyed by a constant name rather than a
+# spawned task id, so neither ever has a matching state/<id>.meta. The orphan
+# guard must not treat either as an orphan: both must keep running and must
+# not be deleted.
+test_x_watch_check_sh_survives_orphan_guard_and_runs() {
+  local dir state fakebin out pid
+  dir=$(make_case x-watch-check-sh); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  # No state/x-watch.meta - by design, this shim is never task-keyed.
+  cat > "$state/x-watch.check.sh" <<'SH'
+#!/usr/bin/env bash
+echo "check: x-mention deadbeef"
+SH
+  chmod +x "$state/x-watch.check.sh"
+  watch_bg "$state" "$fakebin" "$out" FM_CHECK_INTERVAL=1
+  pid=$!
+  if wait_live "$pid" 30; then
+    reap "$pid"; fail "watcher never fired for x-watch.check.sh's actionable output (should surface): $(cat "$out")"
+  fi
+  [ -s "$out" ] || fail "x-watch.check.sh's actionable output did not produce a wake reason"
+  [ -e "$state/x-watch.check.sh" ] || fail "x-watch.check.sh was wrongly deleted as an orphan"
+  pass "x-watch.check.sh survives the orphan guard and keeps running with no state/x-watch.meta"
+}
+
+test_tool_updates_check_sh_survives_orphan_guard_and_runs() {
+  local dir state fakebin out pid
+  dir=$(make_case tool-updates-check-sh); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  # No state/tool-updates.meta - by design, this shim is never task-keyed.
+  # Unlike x-watch.check.sh it is authorized through the ordinary custom-check
+  # trust registration rather than a fixed-name bypass, so register it for
+  # real through the production entrypoint.
+  cat > "$state/tool-updates.check.sh" <<'SH'
+#!/usr/bin/env bash
+echo "check: a watched tool has an update"
+SH
+  chmod 700 "$state/tool-updates.check.sh"
+  FM_STATE_OVERRIDE="$state" "$ROOT/bin/fm-check-register.sh" tool-updates \
+    || fail "could not register tool-updates.check.sh for the exemption test"
+  watch_bg "$state" "$fakebin" "$out" FM_CHECK_INTERVAL=1
+  pid=$!
+  if wait_live "$pid" 30; then
+    reap "$pid"; fail "watcher never fired for tool-updates.check.sh's actionable output (should surface): $(cat "$out")"
+  fi
+  [ -s "$out" ] || fail "tool-updates.check.sh's actionable output did not produce a wake reason"
+  [ -e "$state/tool-updates.check.sh" ] || fail "tool-updates.check.sh was wrongly deleted as an orphan"
+  [ -e "$state/tool-updates.check-trust" ] || fail "tool-updates.check-trust was wrongly deleted as an orphan"
+  pass "tool-updates.check.sh survives the orphan guard and keeps running with no state/tool-updates.meta"
+}
+
 # --- actionable wakes are surfaced (queue + exit) ---------------------------
 
 test_actionable_signal_surfaced() {
   local dir state fakebin out drain_out status_file pid
   dir=$(make_case actionable-signal); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; drain_out="$dir/drain.out"
+  fm_write_meta "$state/task.meta" "window=sess:fm-task"
   status_file="$state/task.status"
   printf 'working: setup\nneeds-decision: pick A or B\n' > "$status_file"
   watch_bg "$state" "$fakebin" "$out"
@@ -1533,6 +1724,7 @@ test_actionable_signal_survives_a_later_routine_append() {
   local dir state fakebin out drain_out status_file sig pid
   dir=$(make_case actionable-masked); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; drain_out="$dir/drain.out"
+  fm_write_meta "$state/task.meta" "window=sess:fm-task"
   status_file="$state/task.status"
   # Everything through "working: setup" was already classified, so this asserts
   # the newly appended span, not merely a whole-file re-read.
@@ -1559,6 +1751,7 @@ test_release_completion_survives_a_later_routine_append() {
   local dir state fakebin out drain_out status_file sig pid
   dir=$(make_case release-masked); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; drain_out="$dir/drain.out"
+  fm_write_meta "$state/task.meta" "window=sess:fm-task"
   status_file="$state/task.status"
   printf 'working: publishing\n' > "$status_file"
   sig=$(seen_sig "$status_file"); printf '%s' "$sig" > "$state/.seen-task_status"
@@ -1602,6 +1795,7 @@ test_unreadable_status_reports_once_per_file_state() {
   local dir state fakebin out status_file target marker sig pid
   dir=$(make_case unreadable-status); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; status_file="$state/task.status"; target="$dir/missing-status-target"
+  fm_write_meta "$state/task.meta" "window=sess:fm-task"
   ln -s "$target" "$status_file"
   marker="$state/.seen-task_status"
 
@@ -1648,6 +1842,7 @@ test_permission_recovery_surfaces_preserved_status() {
   local dir state fakebin out status_file marker before_ident after_ident pid
   dir=$(make_case permission-recovery); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; status_file="$state/task.status"; marker="$state/.seen-task_status"
+  fm_write_meta "$state/task.meta" "window=sess:fm-task"
   printf 'blocked: release approval required\nworking: preserving context\n' > "$status_file"
   before_ident=$(_fm_open_decisions_file_ident "$status_file")
   chmod 000 "$status_file"
@@ -3615,6 +3810,7 @@ test_procevent_marker_failure_exits_and_replays() {
 test_heartbeat_no_change_absorbed() {
   local dir state fakebin out pid i sig
   dir=$(make_case heartbeat-absorb); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  fm_write_meta "$state/routine.meta" "window=sess:fm-routine"
   printf 'working: routine heartbeat history\n' > "$state/routine.status"
   sig=$(seen_sig "$state/routine.status"); printf '%s' "$sig" > "$state/.seen-routine_status"
   # A quiet fleet with a fast heartbeat cadence.
@@ -3648,6 +3844,7 @@ test_heartbeat_backstop_surfaces_a_masked_status() {
   local dir state fakebin out sig pid
   dir=$(make_case heartbeat-masked); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"
+  fm_write_meta "$state/miss.meta" "window=sess:fm-miss"
   # Same miss as below, but the captain-relevant event is followed by a routine
   # append, so its last line reads benign. The backstop must still catch it.
   printf 'working: setup\nneeds-decision: pick A or B\nworking: tidying the branch\n' \
@@ -3669,6 +3866,7 @@ test_heartbeat_backstop_surfaces_unsurfaced_status() {
   local dir state fakebin out drain_out sig pid
   dir=$(make_case heartbeat-backstop); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; drain_out="$dir/drain.out"
+  fm_write_meta "$state/miss.meta" "window=sess:fm-miss"
   # A captain-relevant status whose .seen-* signature ALREADY matches (so the
   # per-poll signal scan stays quiet) but which was never surfaced (no
   # .hb-surfaced-* marker). This stands in for a per-wake-path miss; the heartbeat
@@ -3686,6 +3884,29 @@ test_heartbeat_backstop_surfaces_unsurfaced_status() {
   FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the backstop heartbeat failed"
   grep "$(printf '\theartbeat\t')" "$drain_out" >/dev/null || fail "backstop heartbeat was not queued"
   pass "heartbeat backstop fail-safe surfaces a captain-relevant status the per-wake path missed"
+}
+
+# heartbeat_scan_finds_actionable is "the always-on twin of the daemon's
+# catch-all" (its own doc comment) and walks *.status independently of
+# scan_signals, so it needs the identical orphan guard: a captain-relevant
+# status with no matching state/<id>.meta must never trip the heartbeat wake.
+test_heartbeat_backstop_never_surfaces_an_orphan_status() {
+  local dir state fakebin out pid
+  dir=$(make_case heartbeat-orphan); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  # No state/ghost.meta. Even a captain-relevant verb must not reach the
+  # heartbeat backstop for an unowned file.
+  printf 'needs-decision: pick A or B\n' > "$state/ghost.status"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=1 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "heartbeat backstop surfaced an orphan status with no matching .meta: $(cat "$out")"
+  fi
+  [ ! -s "$out" ] || fail "heartbeat backstop printed a wake reason for an orphan status: $(cat "$out")"
+  [ ! -s "$state/.wake-queue" ] || fail "heartbeat backstop enqueued a durable wake record for an orphan status"
+  reap "$pid"
+  pass "the heartbeat backstop never surfaces a captain-relevant orphan status with no matching .meta"
 }
 
 # --- beacon stays fresh while absorbing -------------------------------------
@@ -3727,6 +3948,7 @@ test_afk_signal_records_heartbeat_endpoint() {
   local dir state fakebin out status_file pid
   dir=$(make_case afk-heartbeat-endpoint); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; status_file="$state/task.status"
+  fm_write_meta "$state/task.meta" "window=sess:fm-task"
   printf 'needs-decision: choose release target\nworking: preparing both targets\n' > "$status_file"
   date '+%s' > "$state/.afk"
   export FM_FAKE_CREW_STATE='state: working · source: run-step · validating (running)'
@@ -3745,6 +3967,7 @@ test_afk_present_reverts_watcher_to_one_shot() {
   dir=$(make_case afk-coherence); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; drain_out="$dir/drain.out"
   status_file="$state/task.status"
+  fm_write_meta "$state/task.meta" "window=sess:fm-task"
   printf 'working: routine note\n' > "$status_file"
   date '+%s' > "$state/.afk"   # away mode: the supervise-daemon owns triage
   # Set a PROVABLY-WORKING verdict: if afk failed to bypass the provably-working
@@ -3837,6 +4060,13 @@ test_turn_ended_surfaced_batch_opens_no_partial_deadline
 test_working_note_not_working_surfaced
 test_secondmate_status_note_surfaced_despite_busy_agent
 test_self_announced_close_does_not_rewake_but_next_note_does
+test_orphan_turn_ended_never_surfaces
+test_orphan_turn_ended_recreated_every_poll_never_surfaces
+test_orphan_status_with_captain_relevant_verb_never_surfaces
+test_orphan_check_sh_never_runs
+test_live_task_unregistered_check_sh_still_surfaces
+test_x_watch_check_sh_survives_orphan_guard_and_runs
+test_tool_updates_check_sh_survives_orphan_guard_and_runs
 test_actionable_signal_surfaced
 test_actionable_signal_survives_a_later_routine_append
 test_release_completion_survives_a_later_routine_append
@@ -3883,6 +4113,7 @@ test_procevent_marker_failure_exits_and_replays
 test_heartbeat_no_change_absorbed
 test_heartbeat_backstop_surfaces_unsurfaced_status
 test_heartbeat_backstop_surfaces_a_masked_status
+test_heartbeat_backstop_never_surfaces_an_orphan_status
 test_beacon_stays_fresh_while_absorbing
 test_afk_signal_records_heartbeat_endpoint
 test_afk_present_reverts_watcher_to_one_shot


### PR DESCRIPTION
## Intent

Determine whether firstmate's watcher still has the 'orphaned marker' problem against CURRENT code (the watcher, the shared classifier library, and the supervise-daemon) - a marker file (a task's status log, its turn-end ping, or its custom check script) that survives with no matching task-metadata record getting surfaced as a wake instead of being absorbed - and if it does, re-implement the guard against current code. A July 2026 local fix for this (commits 8b9222e, 62bf0f4, f43a968, 5bf45c6) was dropped during a 2026-08-30 upstream reconciliation that substantially rewrote the watcher, and it was unknown whether upstream's rewrite (a presentation-cursor dedup, a generation-bound wake acknowledgement mechanism, a watcher-downtime marker) already covered the same ground.

Diagnosis phase (scout, no code changes) reproduced the problem in an isolated scratch home and confirmed it still occurs, in two forms: (1) a repeatedly-touched orphan status/turn-end log (the classic leaked-hook-still-firing-after-cleanup case) still re-surfaces forever, though a one-time static leftover now self-heals thanks to upstream's cursor dedup; (2) an orphan custom check produces an undeduped "rejected unauthenticated state checks" wake every check interval with no self-healing at all, which is a new, worse-than-July failure mode introduced by upstream's registration-based check authorization model. Findings and the disconfirming-evidence check are recorded in data/fm-orphan-guard-x2/report.md.

Implementation phase (this branch) was then explicitly authorized to re-implement the guard exactly as the report recommended, with these accepted constraints: do not cherry-pick the four old commits as-is, since their target functions were renamed and restructured; re-implement equivalent logic at current call sites; the two generated fixed-name poll shims must stay exempt, since both are keyed by a constant id rather than a spawned task id and so neither ever has a matching metadata record by design, and a genuine authorization failure for either must keep surfacing rather than vanish silently; anything belonging to a live task (a metadata record present) must behave identically before and after, since this is the fleet's supervision path and a mistake here silently breaks monitoring for every project; reinstate the July orphan tests retargeted at current function names, especially the repeated-touch regression test, the highest-value one since it is the case the static-dedup mechanism alone does not cover; load the coding-guidelines skill before touching this shared tracked material; never touch the default branch or the backup refs.

During implementation, verification against the real test suite surfaced one more genuine call site beyond the report's original three: the watcher's own always-on twin of the daemon's catch-all backstop, documented in its own header comment that way, previously uncounted. It got the identical guard. Verification also caught a real design bug in the first custom-check implementation: an upfront metadata-presence gate would have wrongly deleted a validly-registered custom check that has no task-shaped id, confirmed via an existing security test's own control-check fixture, and by extension any future non-task custom check registered through the operator registration entrypoint. The corrected design applies the metadata check only within the "neither poll nor trust registration validated" rejection path, so a check with valid trust registration is never affected regardless of whether it has a task id.

Fixing the guard required adding metadata fixtures to several pre-existing tests across five test files that never needed one before this guard existed, including a genuine architectural case: a remote secondmate's parent-side status file also needs a metadata record recording it as a secondmate, matching how a real registered secondmate is recorded, which one affected test fixture was missing. The full watcher/daemon-dependent test surface (13 files) was run to completion; two failures were confirmed via a from-scratch pristine-checkout comparison (identical failure with zero of this branch's changes applied) to be pre-existing environment issues unrelated to this change, and are not regressions from this work.

## What Changed

- `bin/fm-watch.sh`: `scan_signals` and `heartbeat_scan_finds_actionable` now skip any `.status`/`.turn-ended` file that has no matching `state/<id>.meta`, treating it as an orphan from a torn-down (or never-recorded) task rather than a wake candidate; `scan_signals` also best-effort removes the orphaned file so a leaked writer can't leave it permanently "fresh". The custom-check rejection path applies the same `.meta` check before adding a check to `rejected_checks`, deleting the orphaned `.check.sh`/`.check-trust` pair instead of reporting it — except for the `tool-updates` fixed-name poll shim (alongside the existing `x-watch.check.sh` carve-out), which is exempt because it is keyed by a constant id and never has a matching `.meta` by design, so a genuine authorization failure there still surfaces.
- `bin/fm-supervise-daemon.sh`: `housekeeping`'s catch-all `.status` scan applies the identical `state/<id>.meta` guard (read-only skip; the watcher's own scan owns removal).
- `CONTRIBUTING.md`: updates the watcher re-arm smoke test snippet to also create a matching `.meta` fixture alongside the `.status` fixture, since the new guard would otherwise absorb it as an orphan.
- Test suite: reinstates orphan-guard coverage across `tests/fm-watch-triage.test.sh` (including a repeated-touch regression case and unregistered tool-updates bypass coverage), `tests/fm-daemon.test.sh`, `tests/fm-watch-arm.test.sh`, `tests/fm-afk-inject-e2e.test.sh`, and `tests/fm-wake-daemon-lifecycle-e2e.test.sh`/`tests/fm-wake-queue.test.sh`, and adds `.meta` fixtures to several pre-existing tests (including a remote secondmate's parent-side status file) that previously didn't need one.

## Risk Assessment

✅ Low: All four call sites (fm-watch.sh's scan_signals, heartbeat_scan_finds_actionable, the check-loop rejected-checks path, and fm-supervise-daemon.sh's housekeeping catch-all) correctly gate on state/<id>.meta presence before absorbing a marker, the tool-updates/x-watch fixed-name exemptions are scoped precisely to the rejection branch (never bypassing a valid trust registration), and both prior review-round fixes (CONTRIBUTING.md .meta pairing, the missing negative test for the tool-updates exemption) verify correct against current code with no regressions; tracing concrete orphan/live/exempt/broken-registration scenarios through the code produced no wrong-result case, and the change conforms to every constraint in the stated intent.

## Testing

All targeted watcher/daemon orphan-guard tests pass (fm-watch-triage.test.sh's 8 new orphan-guard cases plus the heartbeat-backstop case, fm-daemon.test.sh's catch-all orphan case, fm-watch-arm.test.sh's secondmate-metadata fixture case, and the untouched-but-dependent afk/wake-queue/lifecycle e2e suites), and manual CLI verification of the CONTRIBUTING.md smoke-test fix shows the documented command now correctly surfaces the actionable signal with the required .meta fixture while reproducing the exact silent-absorption false negative when that fixture is omitted. The one observed failure (a process-event fixture timeout in fm-watch-triage.test.sh) was verified via a pristine base-commit worktree to be a pre-existing environment issue unrelated to this change, matching what the author's intent already documented.

<details>
<summary>Evidence: CONTRIBUTING.md watcher re-arm smoke test — with the fixed .meta fixture (post-fix behavior)</summary>

```text
$ tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && printf 'window=fake\n' > "$tmp/smoke.meta" && FM_STATE_OVERRIDE="$tmp" FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 bin/fm-watch-arm.sh
watcher: started pid=738440 (beacon fresh)
signal: /tmp/tmp.jLjqROffdz/smoke.status
EXIT=0
```
</details>
<details>
<summary>Evidence: Same smoke test WITHOUT .meta — reproduces the pre-fix false negative (orphan guard silently absorbs and deletes smoke.status)</summary>

```text
$ tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVERRIDE="$tmp" FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 timeout 10 bin/fm-watch-arm.sh
watcher: started pid=740019 (beacon fresh)
EXIT=124 # timed out, no 'signal:' line printed, smoke.status deleted out from under the caller
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d4a94c8b2e5a6b3b56d31b6eaeeb15c25769ce15","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"skipped"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `CONTRIBUTING.md:99` - CONTRIBUTING.md&#39;s documented watcher re-arm smoke test creates only a `.status` file (`$tmp/smoke.status`) with no matching `.meta`. After this change, scan_signals()&#39;s new orphan guard in bin/fm-watch.sh will silently absorb and delete that file instead of surfacing &#39;an actionable signal&#39; as the comment promises, so a contributor who copy-pastes this exact command to smoke-test a watcher change gets a false negative (silence instead of a signal, and the fixture file is deleted out from under them). The July 2026 predecessor fix (commit 5d0e962) hit the identical problem on this same line and fixed it by adding a matching `$tmp/smoke.meta` write; that doc update was not carried over in this re-implementation.
- ℹ️ `docs/architecture.md:49` - The July 2026 fix documented the &#39;a .status/.turn-ended/.check.sh with no matching state/&lt;id&gt;.meta is absorbed, even under afk (except state/x-watch.check.sh)&#39; behavior contract in AGENTS.md, docs/architecture.md, and docs/scripts.md. All three doc updates were dropped along with the code during the 2026-08-30 upstream rewrite, and this re-implementation (correctly) restores the code and tests but does not restore the doc prose describing the now-real contract again, so the documented behavior contract and the actual code are back in sync only by coincidence, not by explicit documentation.

🔧 Fix: docs: pair CONTRIBUTING.md smoke test .status with .meta
1 warning still open:

- ⚠️ `tests/fm-watch-triage.test.sh:1672` - test_tool_updates_check_sh_survives_orphan_guard_and_runs registers tool-updates.check.sh through the real fm-check-register.sh entrypoint, giving it valid check-trust. With valid trust, fm_custom_check_snapshot_prepare() (bin/fm-check-lib.sh:48) succeeds and the check runs via the `elif` branch in bin/fm-watch.sh&#39;s check loop, never reaching the `else` fallback where the new `[ &#34;$id&#34; = tool-updates ] || [ -e &#34;$STATE/$id.meta&#34; ]` bypass at bin/fm-watch.sh:1630 lives. This test would pass identically with or without that bypass condition, so it provides no coverage for the specific behavior the intent calls out: &#39;a broken tool-updates registration must keep surfacing, exactly like x-watch&#39;s own name-based carve-out.&#39; A negative case (tool-updates.check.sh present but unregistered/broken, no state/tool-updates.meta) analogous to test_live_task_unregistered_check_sh_still_surfaces is needed to actually exercise that line.

🔧 Fix: test: cover unregistered tool-updates orphan-guard bypass
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-watch-triage.test.sh (core orphan-guard regressions: test_orphan_turn_ended_never_surfaces, test_orphan_turn_ended_recreated_every_poll_never_surfaces, test_orphan_status_with_captain_relevant_verb_never_surfaces, test_orphan_check_sh_never_runs, test_live_task_unregistered_check_sh_still_surfaces, test_x_watch_check_sh_survives_orphan_guard_and_runs, test_tool_updates_check_sh_survives_orphan_guard_and_runs, test_tool_updates_check_sh_unregistered_still_surfaces, test_heartbeat_backstop_never_surfaces_an_orphan_status — all ok)`
- `bin/fm-test-run.sh tests/fm-daemon.test.sh (covers housekeeping()'s catch-all orphan guard incl. test_heartbeat_scan_orphan_status_not_escalated — all ok)`
- `bin/fm-test-run.sh tests/fm-watch-arm.test.sh (covers the remote secondmate .meta fixture in test_rearm_resurfaces_durable_queue_and_remote_open_decision — all ok)`
- `bin/fm-test-run.sh tests/fm-afk-inject-e2e.test.sh tests/fm-wake-daemon-lifecycle-e2e.test.sh tests/fm-wake-queue.test.sh (all ok)`
- `Manual comparison: re-ran tests/fm-watch-triage.test.sh against a disposable git worktree checked out at the pristine base commit a56a78a with none of this branch's changes applied — the single failing case (test_procevent_captured_result_surfaces_proactively / 'the fixture captured no process-event result') reproduced identically, confirming it is a pre-existing environment issue, not a regression`
- `Manual CLI verification of the CONTRIBUTING.md smoke test: ran the documented command with the new smoke.meta fixture (signal correctly surfaces, exit 0) and re-ran it without smoke.meta to reproduce the pre-fix false negative (orphan guard silently absorbs and deletes smoke.status, watcher times out with no signal line)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Install pinned ShellCheck 0.11.0 and actionlint 1.7.12 in lint environment
1 warning still open:

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
