### PR TITLE
fix(bin): safely unregister custom checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,6 +370,7 @@ Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_he
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine merge authority.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
+Retire a custom check only through `bin/fm-check-unregister.sh <id>` (or `bin/fm-teardown.sh` for a spawned task); never hand-compose an `rm` with `$STATE`/`$ID`.
 
 Tear down a ship task only after landing is confirmed.
 A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.

--- a/bin/fm-check-register.sh
+++ b/bin/fm-check-register.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Bind an intentional custom watcher check to its current bytes.
 # Usage: fm-check-register.sh <id>
+# Retire with fm-check-unregister.sh <id>; do not hand-compose an rm.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-check-unregister.sh
+++ b/bin/fm-check-unregister.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Retire an intentional custom watcher check and its trust binding.
 # Usage: fm-check-unregister.sh <id>
-# Pass only the id; this script resolves the home's state directory itself.
+# Pass only the id. An unset FM_STATE_OVERRIDE selects FM_HOME/state; an
+# explicitly empty override, an invalid id, or a resolved state path that is
+# not an existing non-symlink directory is refused before removal.
+# Each existing named artifact must be an ordinary single-link file on the
+# state directory's device; only <id>.check.sh and <id>.check-trust are removed.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-check-unregister.sh
+++ b/bin/fm-check-unregister.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Retire an intentional custom watcher check and its trust binding.
+# Usage: fm-check-unregister.sh <id>
+# Pass only the id; this script resolves the home's state directory itself.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+
+if [ "$#" -ne 1 ] || ! fm_pr_task_id_valid "$1"; then
+  echo "error: invalid custom check unregistration" >&2
+  exit 2
+fi
+
+ID=$1
+
+if [ -z "${STATE-}" ] || [ ! -d "${STATE-}" ] || [ -L "${STATE-}" ]; then
+  echo "error: state directory is unavailable" >&2
+  exit 1
+fi
+
+CHECK="$STATE/$ID.check.sh"
+TRUST="$STATE/$ID.check-trust"
+STATE_DEVICE=$(fm_pr_file_device "$STATE") || {
+  echo "error: state directory is unavailable" >&2
+  exit 1
+}
+
+for artifact in "$CHECK" "$TRUST"; do
+  [ -e "$artifact" ] || [ -L "$artifact" ] || continue
+  if [ ! -f "$artifact" ] || [ -L "$artifact" ] \
+    || [ "$(fm_pr_file_device "$artifact")" != "$STATE_DEVICE" ] \
+    || [ "$(fm_pr_file_link_count "$artifact")" != 1 ]; then
+    echo "error: custom check is unsafe to remove" >&2
+    exit 1
+  fi
+done
+
+rm -f -- "$CHECK" "$TRUST" || {
+  echo "error: custom check could not be removed" >&2
+  exit 1
+}
+printf 'unregistered: state/%s.check.sh\n' "$ID"

--- a/bin/fm-check-unregister.sh
+++ b/bin/fm-check-unregister.sh
@@ -7,7 +7,7 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
-STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+STATE="${FM_STATE_OVERRIDE-$FM_HOME/state}"
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -279,8 +279,8 @@ family_for_basename() {
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;
-    fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
-    fm-teardown.test.sh|fm-x-mode.test.sh)
+    fm-check-unregister.test.sh|fm-pr-check-security.test.sh|fm-pr-merge.test.sh|\
+    fm-review-diff.test.sh|fm-teardown.test.sh|fm-x-mode.test.sh)
       printf '%s\n' pr-forge
       ;;
     fm-afk-inject-e2e.test.sh|fm-afk-return.test.sh)

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -116,6 +116,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for composer capture, verified submit, and the submit-time busy check |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate endpoint                                          |
 | `fm-check-register.sh`   | Bind an intentional custom watcher check to its current bytes                       |
+| `fm-check-unregister.sh` | Retire a custom watcher check and its trust binding by validated task id            |
 | `fm-check-lib.sh`        | Validate custom-check registrations and prepare private execution snapshots          |
 | `fm-tool-update-check.sh` | Report watched tooling with an update available, and updates installed but left inert by PATH order |
 | `fm-pr-lib.sh`           | Own canonical task and PR validation plus private atomic PR-poll publication, merge-notification identity, and retirement |

--- a/tests/fm-check-unregister.test.sh
+++ b/tests/fm-check-unregister.test.sh
@@ -115,6 +115,20 @@ test_empty_id_and_empty_state_refuse_without_stray_rm() {
   assert_present "$canary_sibling" "bad state override deleted a sibling"
   assert_rm_not_invoked "$log"
 
+  write_registered_check "$home" override-empty
+  status=0
+  : > "$log"
+  PATH="$home/fakebin:$PATH" FM_HOME="$home" FM_STATE_OVERRIDE='' \
+    "$UNREGISTER" override-empty >"$out" 2>"$err" || status=$?
+  expect_code 1 "$status" "unregister with explicitly empty state override"
+  assert_contains "$(cat "$err")" "state directory is unavailable" \
+    "empty state override refusal used the wrong stderr"
+  assert_present "$home/state/override-empty.check.sh" \
+    "empty state override deleted the home state check"
+  assert_present "$home/state/override-empty.check-trust" \
+    "empty state override deleted the home state trust binding"
+  assert_rm_not_invoked "$log"
+
   pass "empty id or missing state dir refuses loudly and never rms a stray path"
 }
 

--- a/tests/fm-check-unregister.test.sh
+++ b/tests/fm-check-unregister.test.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-check-unregister.sh: refuse empty-variable retirement,
+# and remove only the two named custom-check files on the happy path.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+UNREGISTER="$ROOT/bin/fm-check-unregister.sh"
+REGISTER="$ROOT/bin/fm-check-register.sh"
+TMP_ROOT=$(fm_test_tmproot fm-check-unregister)
+REAL_RM=$(command -v rm)
+
+make_home() {
+  local name=$1 home
+  home="$TMP_ROOT/$name"
+  mkdir -p "$home/state" "$home/data" "$home/config"
+  printf '%s\n' "$home"
+}
+
+write_registered_check() {
+  local home=$1 id=$2
+  cat > "$home/state/$id.check.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'custom-ready\n'
+SH
+  chmod 0700 "$home/state/$id.check.sh"
+  FM_HOME="$home" "$REGISTER" "$id" >/dev/null \
+    || fail "could not register custom check $id"
+}
+
+install_rm_logger() {
+  local home=$1 fakebin log
+  fakebin=$(fm_fakebin "$home")
+  log="$home/rm.log"
+  : > "$log"
+  cat > "$fakebin/rm" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$log"
+exec "$REAL_RM" "\$@"
+SH
+  chmod +x "$fakebin/rm"
+  printf '%s\n' "$log"
+}
+
+assert_rm_not_invoked() {
+  local log=$1
+  [ -s "$log" ] && fail "retire path invoked rm while refusing"$'\n'"--- rm log ---"$'\n'"$(cat "$log")"
+}
+
+test_empty_id_and_empty_state_refuse_without_stray_rm() {
+  local home out err status log canary_empty_id canary_sibling decoy
+  home=$(make_home empty-var)
+  out="$home/out.txt"
+  err="$home/err.txt"
+  log=$(install_rm_logger "$home")
+  canary_empty_id="$home/state/.check.sh"
+  canary_sibling="$home/state/keep.check.sh"
+  decoy="$home/decoy.check.sh"
+  printf 'canary-empty-id\n' > "$canary_empty_id"
+  printf 'sibling\n' > "$canary_sibling"
+  printf 'decoy\n' > "$decoy"
+  chmod 0700 "$canary_empty_id" "$canary_sibling"
+
+  status=0
+  PATH="$home/fakebin:$PATH" STATE='' ID='' FM_HOME="$home" \
+    "$UNREGISTER" >"$out" 2>"$err" || status=$?
+  expect_code 2 "$status" "unregister with no id"
+  assert_contains "$(cat "$err")" "error:" "missing-id refusal had no stderr"
+  assert_present "$canary_empty_id" "empty-id expansion deleted state/.check.sh"
+  assert_present "$canary_sibling" "missing-id call deleted a sibling check file"
+  assert_present "$decoy" "missing-id call deleted a decoy outside state/"
+  assert_rm_not_invoked "$log"
+
+  status=0
+  : > "$log"
+  PATH="$home/fakebin:$PATH" STATE='' ID='' FM_HOME="$home" \
+    "$UNREGISTER" "" >"$out" 2>"$err" || status=$?
+  expect_code 2 "$status" "unregister with empty id"
+  assert_contains "$(cat "$err")" "error:" "empty-id refusal had no stderr"
+  assert_present "$canary_empty_id" "empty-string id deleted state/.check.sh"
+  assert_rm_not_invoked "$log"
+
+  status=0
+  : > "$log"
+  PATH="$home/fakebin:$PATH" STATE='' ID='' FM_HOME="$home" \
+    "$UNREGISTER" "../escape" >"$out" 2>"$err" || status=$?
+  expect_code 2 "$status" "unregister with unsafe id"
+  assert_present "$canary_empty_id" "unsafe id deleted state/.check.sh"
+  assert_rm_not_invoked "$log"
+
+  mkdir -p "$home/nostate-home"
+  printf 'pre-state-canary\n' > "$home/nostate-home/.check.sh"
+  status=0
+  : > "$log"
+  PATH="$home/fakebin:$PATH" STATE='' ID='' FM_HOME="$home/nostate-home" \
+    "$UNREGISTER" demo-check >"$out" 2>"$err" || status=$?
+  expect_code 1 "$status" "unregister with missing state dir"
+  assert_contains "$(cat "$err")" "state directory is unavailable" \
+    "missing state dir refusal used the wrong stderr"
+  assert_present "$home/nostate-home/.check.sh" \
+    "missing-state-dir call deleted a stray path in the home"
+  assert_present "$canary_empty_id" "missing-state-dir call reached another home's files"
+  assert_rm_not_invoked "$log"
+
+  status=0
+  : > "$log"
+  PATH="$home/fakebin:$PATH" STATE='' ID='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/missing-state" \
+    "$UNREGISTER" demo-check >"$out" 2>"$err" || status=$?
+  expect_code 1 "$status" "unregister with empty-equivalent state override"
+  assert_contains "$(cat "$err")" "state directory is unavailable" \
+    "non-directory state override refusal used the wrong stderr"
+  assert_present "$canary_empty_id" "bad state override deleted state/.check.sh"
+  assert_present "$canary_sibling" "bad state override deleted a sibling"
+  assert_rm_not_invoked "$log"
+
+  pass "empty id or missing state dir refuses loudly and never rms a stray path"
+}
+
+test_happy_path_removes_only_check_and_trust() {
+  local home out err status sibling meta
+  home=$(make_home happy)
+  out="$home/out.txt"
+  err="$home/err.txt"
+  sibling="$home/state/other.check.sh"
+  meta="$home/state/demo-check.meta"
+  write_registered_check "$home" demo-check
+  printf '#!/usr/bin/env bash\nprintf other\n' > "$sibling"
+  chmod 0700 "$sibling"
+  printf 'keep-meta\n' > "$meta"
+  assert_present "$home/state/demo-check.check.sh" "fixture check.sh missing before unregister"
+  assert_present "$home/state/demo-check.check-trust" "fixture check-trust missing before unregister"
+
+  status=0
+  STATE='' ID='' FM_HOME="$home" "$UNREGISTER" demo-check >"$out" 2>"$err" || status=$?
+  expect_code 0 "$status" "happy-path unregister"
+  assert_contains "$(cat "$out")" "unregistered: state/demo-check.check.sh" \
+    "happy path did not report unregistration"
+  assert_absent "$home/state/demo-check.check.sh" "happy path left check.sh behind"
+  assert_absent "$home/state/demo-check.check-trust" "happy path left check-trust behind"
+  assert_present "$sibling" "happy path deleted a sibling check.sh"
+  assert_present "$meta" "happy path deleted an unrelated state file"
+
+  pass "happy path removes only the named check.sh and check-trust"
+}
+
+test_unsafe_hardlink_or_symlink_is_refused() {
+  local home out err status alias
+  home=$(make_home unsafe)
+  out="$home/out.txt"
+  err="$home/err.txt"
+  write_registered_check "$home" custom
+  alias="$home/custom-check.alias"
+  ln "$home/state/custom.check.sh" "$alias"
+
+  status=0
+  FM_HOME="$home" "$UNREGISTER" custom >"$out" 2>"$err" || status=$?
+  expect_code 1 "$status" "unregister hard-linked check.sh"
+  assert_contains "$(cat "$err")" "unsafe to remove" "hard-link refusal used the wrong stderr"
+  assert_present "$home/state/custom.check.sh" "hard-link refusal deleted check.sh"
+  assert_present "$home/state/custom.check-trust" "hard-link refusal deleted check-trust"
+  assert_present "$alias" "hard-link refusal deleted the external alias"
+
+  rm -f "$alias"
+  rm -f "$home/state/custom.check.sh"
+  printf '#!/usr/bin/env bash\nprintf target\n' > "$home/outside.check.sh"
+  chmod 0700 "$home/outside.check.sh"
+  ln -s "$home/outside.check.sh" "$home/state/custom.check.sh"
+
+  status=0
+  FM_HOME="$home" "$UNREGISTER" custom >"$out" 2>"$err" || status=$?
+  expect_code 1 "$status" "unregister symlink check.sh"
+  assert_contains "$(cat "$err")" "unsafe to remove" "symlink refusal used the wrong stderr"
+  assert_present "$home/state/custom.check.sh" "symlink refusal removed the state symlink"
+  assert_present "$home/outside.check.sh" "symlink refusal deleted the external target"
+  assert_present "$home/state/custom.check-trust" "symlink refusal deleted check-trust"
+
+  pass "hard-linked or symlinked artifacts are refused and left in place"
+}
+
+test_empty_id_and_empty_state_refuse_without_stray_rm
+test_happy_path_removes_only_check_and_trust
+test_unsafe_hardlink_or_symlink_is_refused


### PR DESCRIPTION
## Intent

Add bin/fm-check-unregister.sh as the owner that refuses an unset/empty/non-directory state dir and an invalid id before removing only the named custom check.sh and check-trust files, using the same single-link/same-device safety as teardown. Add one AGENTS.md sentence next to the custom-check write rule directing firstmate to retire only through that owner or fm-teardown.sh for a spawned task, never a hand-composed rm with $STATE/$ID. Include a behavioral regression test that invokes the retire path with the state dir/id effectively empty and asserts loud refusal (nonzero, no rm on an empty-var path) plus a happy path that removes a real registered pair. Do not modify the harness confirmation guard, do not add ${STATE:?} only inside teardown or register, do not change how custom checks are written or registered, the watcher, teardown poll-artifact removal, or Relay/monitor architecture. Delivery is no-mistakes with yolo off: bring the PR to green; the captain merges; never pass --yes.

## What Changed
- Add a dedicated unregister command that validates state directories and task IDs before removing only the named check and trust files.
- Enforce single-link, same-device artifact safety and refuse symlinks, hard links, and unsafe state paths.
- Document the retirement workflow and add behavioral regression coverage for refusal and successful removal paths.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves teardown-equivalent file safety, correctly rejects explicitly empty state overrides, and behaviorally covers refusal and successful retirement paths.

## Testing

Repository inspection, the focused behavioral regression test, and an end-user CLI lifecycle check all succeeded; refusal, safety, and selective removal behavior matched the required intent.

<details>
<summary>Evidence: End-user custom-check retirement transcript</summary>

Source: [End-user custom-check retirement transcript](https://github.com/kunchenguid/firstmate/blob/33ddf125acb07ae6664a604701b7ad48484f527a/.no-mistakes/evidence/fm/fm-check-unregister-owner-r1/fm-check-unregister-cli-transcript.txt)

```text
END-USER CHECK RETIREMENT TRANSCRIPT

1. Registered files before retirement:
demo.check-trust
demo.check.sh
sibling.note

2. Attempt retirement with explicitly empty FM_STATE_OVERRIDE:
exit=1
error: state directory is unavailable
files still present after refusal:
demo.check-trust
demo.check.sh
sibling.note

3. Retire normally using FM_HOME/state:
exit=0
unregistered: state/demo.check.sh
files remaining after successful retirement:
sibling.note

4. Observable checks:
PASS empty override refused loudly
PASS normal retirement succeeded
PASS named check removed
PASS named trust binding removed
PASS unrelated sibling preserved
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f18de26153a3dcc102eb72ee108b3e319aed98d7","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-check-unregister.sh:10` - Contradicts the required criterion that the owner “refuses an unset/empty/non-directory state dir.” `STATE=&#34;${FM_STATE_OVERRIDE:-$FM_HOME/state}&#34;` treats an explicitly empty override as unset and silently targets `$FM_HOME/state`; with a valid ID and registered pair, `FM_STATE_OVERRIDE=&#39;&#39;` removes that pair instead of refusing. The test labels a non-directory path as “empty-equivalent” but never exercises an actually empty override. Preserve an explicitly empty override so the line 22 guard rejects it, and cover that concrete invocation behaviorally.

🔧 Fix: Refuse explicitly empty custom-check state overrides
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target diff against `a56a78ac431833381a265d28cbc9c5ab6094117d`.</code>
- `./tests/fm-check-unregister.test.sh`
- `./bin/fm-test-run.sh tests/fm-check-unregister.test.sh`
- <code>Manual CLI lifecycle: registered a check, verified `FM_STATE_OVERRIDE=&#39;&#39;` refused without deletion, then unregistered normally and confirmed only the named check/trust pair was removed while an unrelated sibling remained.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
