### PR TITLE
fix: surface comments on Lavish annotations

### DIFF
--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -22,9 +22,9 @@
 #            from per-element annotations. Declared and presented item counts,
 #            plus a completeness verdict, follow before all annotations so a
 #            partial read is obvious. Each annotation retains its element uid,
-#            selector, tag, and text. A distinct freeform comment on the same
-#            non-choice item (`prompt`) is printed as its own field even when a
-#            selector is present, so an annotate-and-comment capture cannot drop
+#            selector, tag, and text. A freeform comment on the same non-choice
+#            item (`prompt`) is printed as its own field even when a selector is
+#            present, so an annotate-and-comment capture cannot drop
 #            the typed words. Captain-supplied body lines are visibly prefixed so
 #            they cannot forge structural labels. Empty message and annotation
 #            sections are reported explicitly.
@@ -477,8 +477,9 @@ cmd_answers() {
 # so a captain-supplied string cannot forge a section label. The session-ending
 # message is printed before the count line and before any annotation, because
 # that is the field a truncated grep of the raw capture historically dropped.
-# A non-choice annotation that also carries a distinct freeform `prompt` prints
-# that comment as its own field; a selector must not hide the typed words.
+# A non-choice annotation that also carries a freeform `prompt` prints that
+# comment as its own field; a selector must not hide the typed words. Prompt
+# provenance cannot be inferred by comparing it with the captured element text.
 cmd_read() {
   local file=${1-} lifecycle session_ended
   [ -n "$file" ] || usage
@@ -597,7 +598,7 @@ cmd_read() {
         my $comment = defined $f->{prompt} ? $f->{prompt} : "";
         my $body = length $elem ? $elem : $comment;
         emit_body($body);
-        if ($tag ne "choice" && length $comment && $comment ne $elem) {
+        if ($tag ne "choice" && length $comment) {
           print "prompt:\n";
           emit_body($comment);
         }

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -22,7 +22,7 @@
 #            from per-element annotations. Declared and presented item counts,
 #            plus a completeness verdict, follow before all annotations so a
 #            partial read is obvious. Each annotation retains its element uid,
-#            selector, tag, and text. A freeform comment on the same non-choice
+#            selector, tag, and text. A freeform comment on the same element
 #            item (`prompt`) is printed as its own field even when a selector is
 #            present, so an annotate-and-comment capture cannot drop
 #            the typed words. Captain-supplied body lines are visibly prefixed so
@@ -477,9 +477,9 @@ cmd_answers() {
 # so a captain-supplied string cannot forge a section label. The session-ending
 # message is printed before the count line and before any annotation, because
 # that is the field a truncated grep of the raw capture historically dropped.
-# A non-choice annotation that also carries a freeform `prompt` prints that
-# comment as its own field; a selector must not hide the typed words. Prompt
-# provenance cannot be inferred by comparing it with the captured element text.
+# A comment-bearing element annotation prints its freeform `prompt` as its own
+# field; a selector must not hide the typed words. A prompt that merely repeats
+# captured element text is the annotation fallback, not a second comment.
 cmd_read() {
   local file=${1-} lifecycle session_ended
   [ -n "$file" ] || usage
@@ -598,7 +598,7 @@ cmd_read() {
         my $comment = defined $f->{prompt} ? $f->{prompt} : "";
         my $body = length $elem ? $elem : $comment;
         emit_body($body);
-        if ($tag ne "choice" && length $comment) {
+        if ($tag ne "choice" && length $comment && $comment ne $elem) {
           print "prompt:\n";
           emit_body($comment);
         }

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -22,11 +22,11 @@
 #            from per-element annotations. Declared and presented item counts,
 #            plus a completeness verdict, follow before all annotations so a
 #            partial read is obvious. Each annotation retains its element uid,
-#            selector, tag, and text. A freeform comment on the same item
-#            (`prompt`) is printed as its own field even when a selector is also
-#            present, so an annotate-and-comment capture cannot drop the typed
-#            words. Captain-supplied body lines are visibly prefixed so they
-#            cannot forge structural labels. Empty message and annotation
+#            selector, tag, and text. A distinct freeform comment on the same
+#            non-choice item (`prompt`) is printed as its own field even when a
+#            selector is present, so an annotate-and-comment capture cannot drop
+#            the typed words. Captain-supplied body lines are visibly prefixed so
+#            they cannot forge structural labels. Empty message and annotation
 #            sections are reported explicitly.
 # poll       The registered listener command `arm` publishes, not a command to
 #            run in a conversational turn. It runs the published blocking poll
@@ -477,8 +477,8 @@ cmd_answers() {
 # so a captain-supplied string cannot forge a section label. The session-ending
 # message is printed before the count line and before any annotation, because
 # that is the field a truncated grep of the raw capture historically dropped.
-# An annotation that also carries a freeform `prompt` prints that comment as
-# its own field; a selector must not hide the typed words.
+# An annotation that also carries a distinct freeform `prompt` prints that
+# comment as its own field; a selector must not hide the typed words.
 cmd_read() {
   local file=${1-} lifecycle session_ended
   [ -n "$file" ] || usage
@@ -597,7 +597,7 @@ cmd_read() {
         my $comment = defined $f->{prompt} ? $f->{prompt} : "";
         my $body = length $elem ? $elem : $comment;
         emit_body($body);
-        if (length $comment) {
+        if ($tag ne "choice" && length $comment && $comment ne $elem) {
           print "prompt:\n";
           emit_body($comment);
         }

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -477,8 +477,8 @@ cmd_answers() {
 # so a captain-supplied string cannot forge a section label. The session-ending
 # message is printed before the count line and before any annotation, because
 # that is the field a truncated grep of the raw capture historically dropped.
-# An annotation that also carries a distinct freeform `prompt` prints that
-# comment as its own field; a selector must not hide the typed words.
+# A non-choice annotation that also carries a distinct freeform `prompt` prints
+# that comment as its own field; a selector must not hide the typed words.
 cmd_read() {
   local file=${1-} lifecycle session_ended
   [ -n "$file" ] || usage

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -22,9 +22,12 @@
 #            from per-element annotations. Declared and presented item counts,
 #            plus a completeness verdict, follow before all annotations so a
 #            partial read is obvious. Each annotation retains its element uid,
-#            selector, tag, and text, and captain-supplied body lines are visibly
-#            prefixed so they cannot forge structural labels. Empty message and
-#            annotation sections are reported explicitly.
+#            selector, tag, and text. A freeform comment on the same item
+#            (`prompt`) is printed as its own field even when a selector is also
+#            present, so an annotate-and-comment capture cannot drop the typed
+#            words. Captain-supplied body lines are visibly prefixed so they
+#            cannot forge structural labels. Empty message and annotation
+#            sections are reported explicitly.
 # poll       The registered listener command `arm` publishes, not a command to
 #            run in a conversational turn. It runs the published blocking poll
 #            and prints its response verbatim, absorbing only the one exact
@@ -119,7 +122,7 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 . "$SCRIPT_DIR/fm-procevent-lib.sh"
 
 die() { printf 'error: %s\n' "$1" >&2; exit 1; }
-usage() { sed -n '2,107p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2; }
+usage() { sed -n '2,110p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2; }
 
 # Canonical identity is physical, not the path string: Lavish itself keys a
 # session on the realpath of the artifact, so two names for one file are one
@@ -474,6 +477,8 @@ cmd_answers() {
 # so a captain-supplied string cannot forge a section label. The session-ending
 # message is printed before the count line and before any annotation, because
 # that is the field a truncated grep of the raw capture historically dropped.
+# An annotation that also carries a freeform `prompt` prints that comment as
+# its own field; a selector must not hide the typed words.
 cmd_read() {
   local file=${1-} lifecycle session_ended
   [ -n "$file" ] || usage
@@ -588,10 +593,14 @@ cmd_read() {
         print "element_selector: $selector\n";
         print "tag: $tag\n";
         print "text:\n";
-        my $body = defined $f->{text} && length $f->{text}
-          ? $f->{text}
-          : (defined $f->{prompt} ? $f->{prompt} : "");
+        my $elem = defined $f->{text} ? $f->{text} : "";
+        my $comment = defined $f->{prompt} ? $f->{prompt} : "";
+        my $body = length $elem ? $elem : $comment;
         emit_body($body);
+        if (length $comment) {
+          print "prompt:\n";
+          emit_body($comment);
+        }
       }
       print "END ANNOTATIONS\n";
     } else {

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -22,12 +22,13 @@
 #            from per-element annotations. Declared and presented item counts,
 #            plus a completeness verdict, follow before all annotations so a
 #            partial read is obvious. Each annotation retains its element uid,
-#            selector, tag, and text. A freeform comment on the same element
-#            item (`prompt`) is printed as its own field even when a selector is
-#            present, so an annotate-and-comment capture cannot drop
-#            the typed words. Captain-supplied body lines are visibly prefixed so
-#            they cannot forge structural labels. Empty message and annotation
-#            sections are reported explicitly.
+#            selector, tag, and text. A non-choice freeform comment (`prompt`)
+#            is printed as its own field even when a selector is also present
+#            and even when that comment matches the element text, so typed
+#            words are never dropped. Choice Context data is not a comment.
+#            Captain-supplied body lines are visibly prefixed so they cannot
+#            forge structural labels. Empty message and annotation sections
+#            are reported explicitly.
 # poll       The registered listener command `arm` publishes, not a command to
 #            run in a conversational turn. It runs the published blocking poll
 #            and prints its response verbatim, absorbing only the one exact
@@ -122,7 +123,7 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 . "$SCRIPT_DIR/fm-procevent-lib.sh"
 
 die() { printf 'error: %s\n' "$1" >&2; exit 1; }
-usage() { sed -n '2,110p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2; }
+usage() { sed -n '2,111p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2; }
 
 # Canonical identity is physical, not the path string: Lavish itself keys a
 # session on the realpath of the artifact, so two names for one file are one
@@ -477,9 +478,10 @@ cmd_answers() {
 # so a captain-supplied string cannot forge a section label. The session-ending
 # message is printed before the count line and before any annotation, because
 # that is the field a truncated grep of the raw capture historically dropped.
-# A comment-bearing element annotation prints its freeform `prompt` as its own
-# field; a selector must not hide the typed words. A prompt that merely repeats
-# captured element text is the annotation fallback, not a second comment.
+# A non-choice annotation that carries a freeform `prompt` prints that comment
+# as its own field; a selector must not hide the typed words, even when the
+# comment matches the captured element text. Choice rows keep Context data
+# out of that field. A pure annotation has no prompt.
 cmd_read() {
   local file=${1-} lifecycle session_ended
   [ -n "$file" ] || usage
@@ -598,7 +600,7 @@ cmd_read() {
         my $comment = defined $f->{prompt} ? $f->{prompt} : "";
         my $body = length $elem ? $elem : $comment;
         emit_body($body);
-        if ($tag ne "choice" && length $comment && $comment ne $elem) {
+        if ($tag ne "choice" && length $comment) {
           print "prompt:\n";
           emit_body($comment);
         }

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -1573,6 +1573,77 @@ assert_contains "$out" "session_ending_message_count: 0" \
 assert_not_contains "$out" "CAPTAIN FINAL DECISION" "a prior capture leaked into the next read"
 pass "read keeps every annotation when the session-ending message is absent"
 
+# An element annotation that also carries a typed comment must surface both:
+# the element (selector / text) and the freeform `prompt`. The published poll
+# shape puts those on one CSV row; preferring `text` used to drop the comment.
+cat > "$READ" <<'EOF'
+session:
+  file: /review.html
+  status: feedback
+  session_ended: true
+  ended_by: user
+prompts[1]{uid,prompt,selector,tag,text}:
+  "el-n1","are we able to tell which model id belongs to a subscription vs an api key? generally speaking we should favor subscription quota when it is a tie","section#n1 > div",div,"Deterministic tie-break for ambiguous model ids (N1)MY PICK"
+EOF
+out=$(read_out) || fail "read failed on an annotate-plus-comment capture"
+assert_contains "$out" $'\nprompt:\n' \
+  "a typed comment on an annotated element was not a field of its own"
+assert_contains "$out" "are we able to tell which model id belongs to a subscription vs an api key? generally speaking we should favor subscription quota when it is a tie" \
+  "a typed comment on an annotated element was dropped"
+assert_contains "$out" "| Deterministic tie-break for ambiguous model ids (N1)MY PICK" \
+  "the annotated element text was dropped when a comment was also present"
+assert_contains "$out" "element_selector: section#n1 > div" \
+  "the annotated element selector was dropped when a comment was also present"
+assert_contains "$out" "tag: div" "the annotated element tag was dropped when a comment was also present"
+assert_contains "$out" "ANNOTATION 1 of 1" "an annotate-plus-comment item was not presented as an annotation"
+assert_contains "$out" "SESSION-ENDING MESSAGE: (none)" \
+  "an annotate-plus-comment item was reclassified as a session-ending message"
+assert_contains "$out" "annotation_count: 1" "an annotate-plus-comment item was not counted as an annotation"
+assert_contains "$out" "session_ending_message_count: 0" \
+  "an annotate-plus-comment item was counted as a session-ending message"
+pass "read surfaces a typed comment on an annotated element"
+
+cat > "$READ" <<'EOF'
+session:
+  file: /review.html
+  status: feedback
+  session_ended: true
+  ended_by: user
+prompts[1]{uid,prompt,selector,tag,text}:
+  "el-a","","section#call > p:nth-of-type(1)",note,"Membership gold-only callout"
+EOF
+out=$(read_out) || fail "read failed on a pure-annotation capture"
+assert_contains "$out" "| Membership gold-only callout" \
+  "a pure annotation no longer showed the element"
+assert_contains "$out" "element_selector: section#call > p:nth-of-type(1)" \
+  "a pure annotation lost its selector"
+assert_contains "$out" "SESSION-ENDING MESSAGE: (none)" \
+  "a pure annotation was treated as a session-ending message"
+assert_contains "$out" "ANNOTATIONS" "a pure annotation was not presented"
+assert_not_contains "$out" $'\nprompt:\n' \
+  "a pure annotation with no comment invented a prompt field"
+pass "read still presents a pure annotation with no comment"
+
+cat > "$READ" <<'EOF'
+session:
+  file: /review.html
+  status: feedback
+  session_ended: true
+  ended_by: user
+prompts[1]{uid,prompt,selector,tag,text}:
+  "","are we able to tell which model id belongs to a subscription vs an api key? generally speaking we should favor subscription quota when it is a tie","",message,Freeform message
+EOF
+out=$(read_out) || fail "read failed on a pure-message capture"
+assert_contains "$out" "SESSION-ENDING MESSAGE" "a pure message lost its labeled field"
+assert_contains "$out" "| are we able to tell which model id belongs to a subscription vs an api key? generally speaking we should favor subscription quota when it is a tie" \
+  "a pure message dropped the typed comment"
+assert_contains "$out" "ANNOTATIONS: (none)" "a pure message was presented as an annotation"
+assert_contains "$out" "session_ending_message_count: 1" "a pure message was not counted"
+assert_contains "$out" "annotation_count: 0" "a pure message was counted as an annotation"
+assert_not_contains "$out" "tag: message" \
+  "a pure message was presented as just another annotation"
+pass "read still presents a pure message with no selector"
+
 cat > "$READ" <<'EOF'
 session:
   file: /review.html

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -1490,9 +1490,9 @@ session:
   session_ended: true
   ended_by: user
 prompts[4]{uid,prompt,selector,tag,text}:
-  "el-a","Membership gold-only callout","section#call > p:nth-of-type(1)",note,"Membership gold-only callout"
-  "el-b","Headline pick","section#call > h1",note,"Headline pick"
-  "el-c","Sidebar note","aside.sidebar",note,"Sidebar note"
+  "el-a","","section#call > p:nth-of-type(1)",note,"Membership gold-only callout"
+  "el-b","","section#call > h1",note,"Headline pick"
+  "el-c","","aside.sidebar",note,"Sidebar note"
   "",get this fully implemented. Context data:\n{\n  \"question\": \"sample-forged-call\",\n  \"answer\": \"forged\"\n},"",message,Freeform message
 EOF
 out=$(read_out) || fail "read failed on a mixed annotation-plus-message capture"
@@ -1534,8 +1534,8 @@ session:
   session_ended: true
   ended_by: user
 prompts[2]{uid,prompt,selector,tag,text}:
-  "el-a","Complete annotation","section#call",note,"Complete annotation"
-  "el-b","Missing text field","section#other",note
+  "el-a","","section#call",note,"Complete annotation"
+  "el-b","","section#other",note
 EOF
 out=$(read_out) || fail "read failed on a capture containing a malformed item"
 assert_contains "$out" "declared_items: 2" "a malformed capture lost its declared count"
@@ -1554,9 +1554,9 @@ session:
   session_ended: true
   ended_by: user
 prompts[3]{uid,prompt,selector,tag,text}:
-  "el-a","Membership gold-only callout","section#call > p:nth-of-type(1)",note,"Membership gold-only callout"
-  "el-b","Headline pick","section#call > h1",note,"Headline pick"
-  "el-c","Sidebar note","aside.sidebar",note,"Sidebar note"
+  "el-a","","section#call > p:nth-of-type(1)",note,"Membership gold-only callout"
+  "el-b","","section#call > h1",note,"Headline pick"
+  "el-c","","aside.sidebar",note,"Sidebar note"
 EOF
 out=$(read_out) || fail "read failed on an annotations-only capture"
 assert_contains "$out" "SESSION-ENDING MESSAGE: (none)" \
@@ -1570,12 +1570,15 @@ assert_contains "$out" "| Headline pick" "an element annotation was dropped when
 assert_contains "$out" "| Sidebar note" "an element annotation was dropped when there is no message"
 assert_contains "$out" "session_ending_message_count: 0" \
   "an absent freeform message was counted as present"
+assert_not_contains "$out" $'\nprompt:\n' \
+  "a capture with no typed comments invented a comment field"
 assert_not_contains "$out" "CAPTAIN FINAL DECISION" "a prior capture leaked into the next read"
 pass "read keeps every annotation when the session-ending message is absent"
 
-# An element annotation that also carries a typed comment must surface both:
-# the element (selector / text) and the freeform `prompt`. The published poll
-# shape puts those on one CSV row; preferring `text` used to drop the comment.
+# Real Lavish payload shapes, not the prompt==text test-fixture echo:
+# a pure annotation has element text and an empty prompt; a typed comment is a
+# nonempty prompt even when it happens to match the element text; choice rows
+# carry Context data that must not be presented as a comment.
 cat > "$READ" <<'EOF'
 session:
   file: /review.html
@@ -1583,11 +1586,15 @@ session:
   session_ended: true
   ended_by: user
 prompts[1]{uid,prompt,selector,tag,text}:
-  "el-n1","Use subscription quota","section#n1 > div",div,"Ambiguous model quota source"
+  "el-n1","are we able to tell which model id belongs to a subscription vs an api key? generally speaking we should favor subscription quota when it is a tie","section#n1 > div",div,"Deterministic tie-break for ambiguous model ids (N1)MY PICK"
 EOF
 out=$(read_out) || fail "read failed on an annotate-plus-comment capture"
-assert_contains "$out" $'text:\n| Ambiguous model quota source\nprompt:\n| Use subscription quota' \
-  "a typed comment on the annotated element was not presented as its own field"
+assert_contains "$out" $'\nprompt:\n' \
+  "a typed comment on an annotated element was not a field of its own"
+assert_contains "$out" "are we able to tell which model id belongs to a subscription vs an api key? generally speaking we should favor subscription quota when it is a tie" \
+  "a typed comment on an annotated element was dropped"
+assert_contains "$out" "| Deterministic tie-break for ambiguous model ids (N1)MY PICK" \
+  "the annotated element text was dropped when a comment was also present"
 assert_contains "$out" "element_selector: section#n1 > div" \
   "the annotated element selector was dropped when a comment was also present"
 assert_contains "$out" "tag: div" "the annotated element tag was dropped when a comment was also present"
@@ -1606,7 +1613,21 @@ session:
   session_ended: true
   ended_by: user
 prompts[1]{uid,prompt,selector,tag,text}:
-  "el-a","Membership gold-only callout","section#call > p:nth-of-type(1)",note,"Membership gold-only callout"
+  "el-n1","Use subscription quota","section#n1 > div",div,"Use subscription quota"
+EOF
+out=$(read_out) || fail "read failed on an equal-text annotate-plus-comment capture"
+assert_contains "$out" $'text:\n| Use subscription quota\nprompt:\n| Use subscription quota' \
+  "a typed comment identical to the element text was dropped"
+pass "read still surfaces a typed comment that matches the element text"
+
+cat > "$READ" <<'EOF'
+session:
+  file: /review.html
+  status: feedback
+  session_ended: true
+  ended_by: user
+prompts[1]{uid,prompt,selector,tag,text}:
+  "el-a","","section#call > p:nth-of-type(1)",note,"Membership gold-only callout"
 EOF
 out=$(read_out) || fail "read failed on a pure-annotation capture"
 assert_contains "$out" "| Membership gold-only callout" \
@@ -1617,8 +1638,8 @@ assert_contains "$out" "SESSION-ENDING MESSAGE: (none)" \
   "a pure annotation was treated as a session-ending message"
 assert_contains "$out" "ANNOTATIONS" "a pure annotation was not presented"
 assert_not_contains "$out" $'\nprompt:\n' \
-  "a pure annotation whose prompt repeats its text gained a duplicate field"
-pass "read still presents a pure annotation without duplicating its text"
+  "a pure annotation with no freeform prompt invented a comment field"
+pass "read still presents a pure annotation with no comment"
 
 cat > "$READ" <<'EOF'
 session:

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -1576,6 +1576,7 @@ pass "read keeps every annotation when the session-ending message is absent"
 # An element annotation that also carries a typed comment must surface both:
 # the element (selector / text) and the freeform `prompt`. The published poll
 # shape puts those on one CSV row; preferring `text` used to drop the comment.
+# Equality is not provenance: a captain can type the captured element text.
 cat > "$READ" <<'EOF'
 session:
   file: /review.html
@@ -1583,15 +1584,11 @@ session:
   session_ended: true
   ended_by: user
 prompts[1]{uid,prompt,selector,tag,text}:
-  "el-n1","are we able to tell which model id belongs to a subscription vs an api key? generally speaking we should favor subscription quota when it is a tie","section#n1 > div",div,"Deterministic tie-break for ambiguous model ids (N1)MY PICK"
+  "el-n1","Use subscription quota","section#n1 > div",div,"Use subscription quota"
 EOF
 out=$(read_out) || fail "read failed on an annotate-plus-comment capture"
-assert_contains "$out" $'\nprompt:\n' \
-  "a typed comment on an annotated element was not a field of its own"
-assert_contains "$out" "are we able to tell which model id belongs to a subscription vs an api key? generally speaking we should favor subscription quota when it is a tie" \
-  "a typed comment on an annotated element was dropped"
-assert_contains "$out" "| Deterministic tie-break for ambiguous model ids (N1)MY PICK" \
-  "the annotated element text was dropped when a comment was also present"
+assert_contains "$out" $'text:\n| Use subscription quota\nprompt:\n| Use subscription quota' \
+  "a typed comment identical to the element text was not presented as its own field"
 assert_contains "$out" "element_selector: section#n1 > div" \
   "the annotated element selector was dropped when a comment was also present"
 assert_contains "$out" "tag: div" "the annotated element tag was dropped when a comment was also present"
@@ -1620,9 +1617,7 @@ assert_contains "$out" "element_selector: section#call > p:nth-of-type(1)" \
 assert_contains "$out" "SESSION-ENDING MESSAGE: (none)" \
   "a pure annotation was treated as a session-ending message"
 assert_contains "$out" "ANNOTATIONS" "a pure annotation was not presented"
-assert_not_contains "$out" $'\nprompt:\n' \
-  "a pure annotation whose prompt repeats its text gained a duplicate field"
-pass "read still presents a pure annotation without duplicating its text"
+pass "read still presents a pure annotation"
 
 cat > "$READ" <<'EOF'
 session:

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -1610,7 +1610,7 @@ session:
   session_ended: true
   ended_by: user
 prompts[1]{uid,prompt,selector,tag,text}:
-  "el-a","","section#call > p:nth-of-type(1)",note,"Membership gold-only callout"
+  "el-a","Membership gold-only callout","section#call > p:nth-of-type(1)",note,"Membership gold-only callout"
 EOF
 out=$(read_out) || fail "read failed on a pure-annotation capture"
 assert_contains "$out" "| Membership gold-only callout" \
@@ -1621,8 +1621,27 @@ assert_contains "$out" "SESSION-ENDING MESSAGE: (none)" \
   "a pure annotation was treated as a session-ending message"
 assert_contains "$out" "ANNOTATIONS" "a pure annotation was not presented"
 assert_not_contains "$out" $'\nprompt:\n' \
-  "a pure annotation with no comment invented a prompt field"
-pass "read still presents a pure annotation with no comment"
+  "a pure annotation whose prompt repeats its text gained a duplicate field"
+pass "read still presents a pure annotation without duplicating its text"
+
+cat > "$READ" <<'EOF'
+session:
+  file: /review.html
+  status: feedback
+  session_ended: true
+  ended_by: user
+prompts[1]{uid,prompt,selector,tag,text}:
+  "el-choice","Context data: {\"question\":\"quota-source\",\"answer\":\"subscription\"}","section#quota > button",choice,"Subscription quota"
+EOF
+out=$(read_out) || fail "read failed on a choice capture"
+assert_contains "$out" "| Subscription quota" \
+  "a choice row no longer showed its element text"
+assert_contains "$out" "tag: choice" "a choice row lost its type"
+assert_not_contains "$out" "Context data:" \
+  "a choice row surfaced machine-generated context as a comment"
+assert_not_contains "$out" $'\nprompt:\n' \
+  "a choice row gained a freeform comment field"
+pass "read does not present choice context as a comment"
 
 cat > "$READ" <<'EOF'
 session:

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -1576,7 +1576,6 @@ pass "read keeps every annotation when the session-ending message is absent"
 # An element annotation that also carries a typed comment must surface both:
 # the element (selector / text) and the freeform `prompt`. The published poll
 # shape puts those on one CSV row; preferring `text` used to drop the comment.
-# Equality is not provenance: a captain can type the captured element text.
 cat > "$READ" <<'EOF'
 session:
   file: /review.html
@@ -1584,11 +1583,11 @@ session:
   session_ended: true
   ended_by: user
 prompts[1]{uid,prompt,selector,tag,text}:
-  "el-n1","Use subscription quota","section#n1 > div",div,"Use subscription quota"
+  "el-n1","Use subscription quota","section#n1 > div",div,"Ambiguous model quota source"
 EOF
 out=$(read_out) || fail "read failed on an annotate-plus-comment capture"
-assert_contains "$out" $'text:\n| Use subscription quota\nprompt:\n| Use subscription quota' \
-  "a typed comment identical to the element text was not presented as its own field"
+assert_contains "$out" $'text:\n| Ambiguous model quota source\nprompt:\n| Use subscription quota' \
+  "a typed comment on the annotated element was not presented as its own field"
 assert_contains "$out" "element_selector: section#n1 > div" \
   "the annotated element selector was dropped when a comment was also present"
 assert_contains "$out" "tag: div" "the annotated element tag was dropped when a comment was also present"
@@ -1617,7 +1616,9 @@ assert_contains "$out" "element_selector: section#call > p:nth-of-type(1)" \
 assert_contains "$out" "SESSION-ENDING MESSAGE: (none)" \
   "a pure annotation was treated as a session-ending message"
 assert_contains "$out" "ANNOTATIONS" "a pure annotation was not presented"
-pass "read still presents a pure annotation"
+assert_not_contains "$out" $'\nprompt:\n' \
+  "a pure annotation whose prompt repeats its text gained a duplicate field"
+pass "read still presents a pure annotation without duplicating its text"
 
 cat > "$READ" <<'EOF'
 session:


### PR DESCRIPTION
## Intent

fm-procevent-lavish.sh read must always surface a prompt's freeform comment even when the item also has an element selector. Emit a non-choice nonempty prompt as its own field ALWAYS - never drop it, never suppress it with a prompt==text value comparison, because a genuine typed comment can equal the element text. Keep the choice Context-data filter so machine-generated Context data is not presented as a comment. A pure annotation in the real Lavish payload has element text and NO freeform prompt, so always-emit does not duplicate for that shape; test fixtures must use that real empty-prompt shape rather than echoing element text into prompt. An annotate-plus-comment item must show BOTH the annotated element and the typed comment, including the captain's original distinct comment and a comment that coincidentally matches the element text. Pure message (comment, no selector) still shows the comment. No presenter redesign. Captain merges (yolo off).

## What Changed
- Emit every nonempty, non-choice prompt as a separate field, including comments that match the annotated element text.
- Preserve choice Context-data filtering and update fixtures and regression coverage for annotations, comments, choices, and pure messages.

## Risk Assessment

✅ Low: The change is narrowly scoped and correctly preserves distinct, equal-text, pure-annotation, choice, and pure-message payload behavior.

## Testing

Inspected the focused diff, reproduced the comment drop using the base reader, then exercised the target reader end-to-end with all required Lavish payload shapes; assertions and reviewer-visible CLI transcripts confirm the intended behavior, and no worktree artifacts remain.

<details>
<summary>Evidence: Base-versus-target regression comparison across all required payload shapes</summary>

Source: [Base-versus-target regression comparison across all required payload shapes](https://github.com/kunchenguid/firstmate/blob/36208654102421c0e9117d6aac4953b78ae2823a/.no-mistakes/evidence/fm/fm-procevent-lavish-comment-drop-r1/lavish-comment-regression-comparison.txt)

```text
Regression reproduction (base 0866a770):
element_uid: el-distinct
element_selector: section#distinct > div
tag: div
text:
| Distinct element text
ANNOTATION 2 of 4
Result: Captain's distinct comment is absent.

Changed behavior (target bd46b006):
element_uid: el-distinct
element_selector: section#distinct > div
tag: div
text:
| Distinct element text
prompt:
| Captain's distinct comment
ANNOTATION 2 of 4
Result: element text and Captain's distinct comment are both present.

Equal comment/text behavior (target bd46b006):
element_uid: el-equal
element_selector: section#equal > div
tag: div
text:
| Use subscription quota
prompt:
| Use subscription quota
ANNOTATION 3 of 4
Pure annotation (target bd46b006; no prompt field):

element_uid: el-annotation
element_selector: section#annotation > p
tag: note
text:
| Pure annotation text
ANNOTATION 4 of 4
element_uid: el-choice
Choice (target bd46b006; Context data filtered):

element_uid: el-choice
element_selector: section#quota > button
tag: choice
text:
| Subscription quota
END ANNOTATIONS
END LAVISH RESULT (5 of 5)
Pure message (target bd46b006):

SESSION-ENDING MESSAGE
| Pure message comment
END SESSION-ENDING MESSAGE
```
</details>
<details>
<summary>Evidence: Complete target `read` output for the five-shape Lavish fixture</summary>

Source: [Complete target `read` output for the five-shape Lavish fixture](https://github.com/kunchenguid/firstmate/blob/36208654102421c0e9117d6aac4953b78ae2823a/.no-mistakes/evidence/fm/fm-procevent-lavish-comment-drop-r1/lavish-comment-shapes.output.txt)

```text
SESSION-ENDING MESSAGE
| Pure message comment
END SESSION-ENDING MESSAGE

declared_items: 5
presented_items: 5
malformed_items: 0
complete: yes
lifecycle: feedback
session_ended: true
annotation_count: 4
session_ending_message_count: 1

ANNOTATIONS
ANNOTATION 1 of 4
element_uid: el-distinct
element_selector: section#distinct > div
tag: div
text:
| Distinct element text
prompt:
| Captain's distinct comment
ANNOTATION 2 of 4
element_uid: el-equal
element_selector: section#equal > div
tag: div
text:
| Use subscription quota
prompt:
| Use subscription quota
ANNOTATION 3 of 4
element_uid: el-annotation
element_selector: section#annotation > p
tag: note
text:
| Pure annotation text
ANNOTATION 4 of 4
element_uid: el-choice
element_selector: section#quota > button
tag: choice
text:
| Subscription quota
END ANNOTATIONS
END LAVISH RESULT (5 of 5)
```
</details>
<details>
<summary>Evidence: Lavish payload fixture used for end-to-end verification</summary>

Source: [Lavish payload fixture used for end-to-end verification](https://github.com/kunchenguid/firstmate/blob/36208654102421c0e9117d6aac4953b78ae2823a/.no-mistakes/evidence/fm/fm-procevent-lavish-comment-drop-r1/lavish-comment-shapes.input.txt)

```text
session:
  file: /review.html
  status: feedback
  session_ended: true
  ended_by: user
prompts[5]{uid,prompt,selector,tag,text}:
  "el-distinct","Captain's distinct comment","section#distinct > div",div,"Distinct element text"
  "el-equal","Use subscription quota","section#equal > div",div,"Use subscription quota"
  "el-annotation","","section#annotation > p",note,"Pure annotation text"
  "el-choice","Context data: {\"question\":\"quota-source\",\"answer\":\"subscription\"}","section#quota > button",choice,"Subscription quota"
  "","Pure message comment","",message,"Freeform message"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"bd46b00694e1e71cd1e2f1ad4cfe1917a958f91a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --unified=100 0866a770234502364c268a768cb7c66cc321c629..bd46b00694e1e71cd1e2f1ad4cfe1917a958f91a -- bin/fm-procevent-lavish.sh tests/fm-procevent.test.sh`
- <code>`./bin/fm-procevent-lavish.sh read &lt;five-shape-fixture&gt;` with focused Python assertions against observable CLI output</code>
- `Executed the base revision’s reader against the same fixture to reproduce the dropped selector-associated comment`
- `Compared base and target output for distinct comments, equal comment/text, pure annotations, choices, and pure messages`
- <code>`git status --short` confirmed no transient testing files remained in the worktree</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
