### PR TITLE
fix: guard PR merges against foreign branch content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,6 +337,7 @@ Never merge a red PR under either setting; destructive, irreversible, and securi
 Without a current explicit captain instruction that states the concrete merge, that default stands, and standing `yolo` cannot authorize a red merge; section 1 owns when such an instruction overrides a Firstmate-written standing rule within its exact scope.
 Load `ask-user-authority` before deciding any ask-user finding; the implementation worker never answers its own finding.
 Use `bin/fm-pr-merge.sh` for every task PR merge so merge metadata is recorded and an unproved merge is refused instead of reported as landed, and use `bin/fm-merge-local.sh` for approved local-only landing; never call a lower-level merge command around their guards.
+A refused PR base check means the guard could not prove the PR content came from its base; escalate instead of merging, and never pass `--override-pr-base-check` without the captain's explicit word.
 After an autonomous merge, give the captain a one-line full-URL or local-main outcome.
 
 ### Validate

--- a/bin/fm-pr-base-check.sh
+++ b/bin/fm-pr-base-check.sh
@@ -47,7 +47,7 @@ RAW_URL=$1
 shift
 
 BASE_BRANCH=
-AGAINST_BRANCHES=(main)
+AGAINST_BRANCHES=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --base)
@@ -69,6 +69,10 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+if [ "${#AGAINST_BRANCHES[@]}" -eq 0 ]; then
+  AGAINST_BRANCHES=(main)
+fi
+
 if ! fm_pr_url_parse "$RAW_URL" || [ "$FM_PR_PROVIDER" != github ]; then
   fail_closed "cannot parse a GitHub PR URL"
 fi
@@ -79,8 +83,46 @@ PR_NUMBER=$FM_PR_NUMBER
 
 CLONE=$(git rev-parse --show-toplevel 2>/dev/null) \
   || fail_closed "the current directory is not a Git clone"
-git -C "$CLONE" remote get-url origin >/dev/null 2>&1 \
+ORIGIN_URL=$(git -C "$CLONE" remote get-url origin 2>/dev/null) \
   || fail_closed "the Git clone has no origin remote"
+
+lowercase() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+# Every branch and the PR head come from origin, so origin must be the same
+# repository the PR URL names. A local clone path carries no forge identity to
+# compare and is left to the branch and PR head fetches to reject.
+verify_origin_repo() {
+  local url=$1 host path
+  case "$url" in
+    file://*|/*|./*|../*|~*) return 0 ;;
+    *://*)
+      path=${url#*://}
+      host=${path%%/*}
+      case "$path" in
+        */*) path=${path#*/} ;;
+        *) path= ;;
+      esac
+      ;;
+    *:*)
+      host=${url%%:*}
+      path=${url#*:}
+      ;;
+    *) return 0 ;;
+  esac
+  host=${host#*@}
+  host=${host%%:*}
+  path=${path#/}
+  path=${path%/}
+  path=${path%.git}
+  [ "$(lowercase "$host")" = github.com ] \
+    || fail_closed "origin is not the PR repository: $url"
+  [ "$(lowercase "$path")" = "$(lowercase "$PR_OWNER/$PR_REPO")" ] \
+    || fail_closed "origin is not the PR repository: $url"
+}
+
+verify_origin_repo "$ORIGIN_URL"
 
 valid_branch() {
   local branch=$1
@@ -134,6 +176,19 @@ for branch in "${AGAINST_BRANCHES[@]}"; do
 done
 
 PR_HEAD_REF="refs/fm-pr-base-check/pull/$PR_NUMBER/head"
+PR_HEAD_REF_WRITTEN=false
+FILE_LIST_TMP=
+cleanup() {
+  local rc=$?
+  [ -z "$FILE_LIST_TMP" ] || rm -f -- "$FILE_LIST_TMP" || true
+  if [ "$PR_HEAD_REF_WRITTEN" = true ]; then
+    git -C "$CLONE" update-ref -d "$PR_HEAD_REF" >/dev/null 2>&1 || true
+  fi
+  return "$rc"
+}
+trap cleanup EXIT
+
+PR_HEAD_REF_WRITTEN=true
 git -C "$CLONE" fetch --quiet origin \
   "+refs/pull/$PR_NUMBER/head:$PR_HEAD_REF" >/dev/null 2>&1 \
   || fail_closed "cannot fetch PR head: $URL"
@@ -174,10 +229,6 @@ done <<<"$COMMIT_LINES"
 
 FILE_LIST_TMP=$(mktemp "${TMPDIR:-/tmp}/fm-pr-base-check.XXXXXX") \
   || fail_closed "cannot create a temporary file list"
-cleanup() {
-  rm -f -- "$FILE_LIST_TMP"
-}
-trap cleanup EXIT
 git -C "$CLONE" diff --name-only -z "$BASE_REF...$PR_HEAD_REF" >"$FILE_LIST_TMP" \
   || fail_closed "cannot list changed PR files"
 
@@ -196,6 +247,9 @@ blob_id() {
 while IFS= read -r -d '' path; do
   pr_blob=$(blob_id "$PR_HEAD_REF" "$path") \
     || fail_closed "cannot determine the PR blob for file: $path"
+  # A path the PR deletes has no blob to attribute to an against branch, and
+  # the MISSING sentinel must never compare equal to another absent path.
+  [ "$pr_blob" != MISSING ] || continue
   base_blob=$(blob_id "$BASE_REF" "$path") \
     || fail_closed "cannot determine the base blob for file: $path"
   for index in "${!UNIQUE_AGAINST_BRANCHES[@]}"; do

--- a/bin/fm-pr-base-check.sh
+++ b/bin/fm-pr-base-check.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Refuse a PR whose changed content came wholesale from a suspect branch.
+#
+# The script runs against the Git clone at the caller's current directory. It
+# fetches the PR head and named branches into private remote-tracking or review
+# refs, then performs an ancestry check, a foreign-commit check, and a
+# foreign-content check. It never checks out a branch or changes the caller's
+# working tree.
+#
+# Usage: fm-pr-base-check.sh <pr-url> [--base <branch>] [--against <branch>]
+#   --base <branch>       PR base branch; otherwise read it from GitHub.
+#   --against <branch>    branch whose content must not be used; repeatable;
+#                         defaults to main.
+#
+# A failed ancestry check alone is reported but does not fail. A commit that is
+# reachable from an against branch, or a changed file whose PR blob equals an
+# against blob and differs from the base blob, fails the check.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: fm-pr-base-check.sh <pr-url> [--base <branch>] [--against <branch>]
+
+Checks that a PR did not take commits or changed file content from a foreign
+branch. The --against flag can be repeated and defaults to main. The script
+uses the Git clone at the current directory and does not change its checkout.
+EOF
+}
+
+fail_closed() {
+  echo "PR base check: ERROR: $1" >&2
+  exit 1
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+[ "$#" -ge 1 ] || { usage; exit 2; }
+RAW_URL=$1
+shift
+
+BASE_BRANCH=
+AGAINST_BRANCHES=(main)
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base)
+      [ "$#" -ge 2 ] || { echo "error: --base requires a branch" >&2; exit 2; }
+      [ -z "$BASE_BRANCH" ] || { echo "error: --base may be used only once" >&2; exit 2; }
+      BASE_BRANCH=$2
+      shift 2
+      ;;
+    --against)
+      [ "$#" -ge 2 ] || { echo "error: --against requires a branch" >&2; exit 2; }
+      AGAINST_BRANCHES+=("$2")
+      shift 2
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if ! fm_pr_url_parse "$RAW_URL" || [ "$FM_PR_PROVIDER" != github ]; then
+  fail_closed "cannot parse a GitHub PR URL"
+fi
+URL=$FM_PR_URL
+PR_OWNER=$FM_PR_OWNER
+PR_REPO=$FM_PR_REPO
+PR_NUMBER=$FM_PR_NUMBER
+
+CLONE=$(git rev-parse --show-toplevel 2>/dev/null) \
+  || fail_closed "the current directory is not a Git clone"
+git -C "$CLONE" remote get-url origin >/dev/null 2>&1 \
+  || fail_closed "the Git clone has no origin remote"
+
+valid_branch() {
+  local branch=$1
+  [ -n "$branch" ] || return 1
+  case "$branch" in
+    origin/*|-*) return 1 ;;
+  esac
+  git -C "$CLONE" check-ref-format --branch "$branch" >/dev/null 2>&1
+}
+
+fetch_branch() {
+  local branch=$1
+  valid_branch "$branch" || fail_closed "invalid branch name: $branch"
+  git -C "$CLONE" fetch --quiet origin \
+    "+refs/heads/$branch:refs/remotes/origin/$branch" >/dev/null 2>&1 \
+    || fail_closed "cannot fetch branch: $branch"
+  git -C "$CLONE" rev-parse --verify --quiet \
+    "refs/remotes/origin/$branch^{commit}" >/dev/null \
+    || fail_closed "branch does not resolve after fetch: $branch"
+}
+
+if [ -z "$BASE_BRANCH" ]; then
+  API_OUTPUT=$(gh-axi api "repos/$PR_OWNER/$PR_REPO/pulls/$PR_NUMBER" \
+    --template '{{.base.ref}}' 2>/dev/null) \
+    || fail_closed "cannot determine the PR base branch from GitHub"
+  BASE_BRANCH=$(printf '%s\n' "$API_OUTPUT" | sed -n 's/^  body: //p')
+  if [ -z "$BASE_BRANCH" ]; then
+    [ "$(printf '%s\n' "$API_OUTPUT" | wc -l | tr -d ' ')" = 1 ] \
+      || fail_closed "GitHub returned an unreadable PR base branch"
+    BASE_BRANCH=$API_OUTPUT
+  fi
+  case "$BASE_BRANCH" in
+    \"*\") BASE_BRANCH=${BASE_BRANCH#\"}; BASE_BRANCH=${BASE_BRANCH%\"} ;;
+  esac
+fi
+
+valid_branch "$BASE_BRANCH" || fail_closed "invalid PR base branch: $BASE_BRANCH"
+fetch_branch "$BASE_BRANCH"
+
+UNIQUE_AGAINST_BRANCHES=()
+for branch in "${AGAINST_BRANCHES[@]}"; do
+  valid_branch "$branch" || fail_closed "invalid against branch: $branch"
+  duplicate=false
+  for existing in "${UNIQUE_AGAINST_BRANCHES[@]:-}"; do
+    [ "$existing" = "$branch" ] && duplicate=true
+  done
+  if [ "$duplicate" = false ]; then
+    UNIQUE_AGAINST_BRANCHES+=("$branch")
+    fetch_branch "$branch"
+  fi
+done
+
+PR_HEAD_REF="refs/fm-pr-base-check/pull/$PR_NUMBER/head"
+git -C "$CLONE" fetch --quiet origin \
+  "+refs/pull/$PR_NUMBER/head:$PR_HEAD_REF" >/dev/null 2>&1 \
+  || fail_closed "cannot fetch PR head: $URL"
+git -C "$CLONE" rev-parse --verify --quiet "$PR_HEAD_REF^{commit}" >/dev/null \
+  || fail_closed "fetched PR head does not resolve: $URL"
+
+BASE_REF="refs/remotes/origin/$BASE_BRANCH"
+PR_HEAD=$(git -C "$CLONE" rev-parse --verify "$PR_HEAD_REF^{commit}") \
+  || fail_closed "cannot resolve the fetched PR head"
+
+if git -C "$CLONE" merge-base --is-ancestor "$BASE_REF" "$PR_HEAD_REF" >/dev/null 2>&1; then
+  ANCESTRY="base is an ancestor of PR head"
+else
+  ancestry_rc=$?
+  [ "$ancestry_rc" -eq 1 ] \
+    || fail_closed "cannot determine whether the base is an ancestor of the PR head"
+  ANCESTRY="base is not an ancestor of PR head"
+fi
+
+COMMIT_LINES=$(git -C "$CLONE" log --format='%H%x09%s' "$BASE_REF..$PR_HEAD_REF" 2>/dev/null) \
+  || fail_closed "cannot list PR commits"
+FOREIGN_COMMITS=()
+while IFS=$'\t' read -r commit subject; do
+  [ -n "${commit:-}" ] || continue
+  for index in "${!UNIQUE_AGAINST_BRANCHES[@]}"; do
+    against_branch=${UNIQUE_AGAINST_BRANCHES[$index]}
+    against_ref="refs/remotes/origin/$against_branch"
+    if git -C "$CLONE" merge-base --is-ancestor "$commit" "$against_ref" >/dev/null 2>&1; then
+      FOREIGN_COMMITS+=("$commit"$'\t'"$subject"$'\t'"$against_branch")
+      break
+    else
+      against_rc=$?
+      [ "$against_rc" -eq 1 ] \
+        || fail_closed "cannot compare commit $commit with branch $against_branch"
+    fi
+  done
+done <<<"$COMMIT_LINES"
+
+FILE_LIST_TMP=$(mktemp "${TMPDIR:-/tmp}/fm-pr-base-check.XXXXXX") \
+  || fail_closed "cannot create a temporary file list"
+cleanup() {
+  rm -f -- "$FILE_LIST_TMP"
+}
+trap cleanup EXIT
+git -C "$CLONE" diff --name-only -z "$BASE_REF...$PR_HEAD_REF" >"$FILE_LIST_TMP" \
+  || fail_closed "cannot list changed PR files"
+
+FOREIGN_CONTENT=()
+blob_id() {
+  local ref=$1 path=$2 blob
+  if ! git -C "$CLONE" cat-file -e "$ref:$path" 2>/dev/null; then
+    printf '%s\n' MISSING
+    return 0
+  fi
+  blob=$(git -C "$CLONE" rev-parse --verify "$ref:$path" 2>/dev/null) || return 1
+  [ "$(git -C "$CLONE" cat-file -t "$blob" 2>/dev/null)" = blob ] || return 1
+  printf '%s\n' "$blob"
+}
+
+while IFS= read -r -d '' path; do
+  pr_blob=$(blob_id "$PR_HEAD_REF" "$path") \
+    || fail_closed "cannot determine the PR blob for file: $path"
+  base_blob=$(blob_id "$BASE_REF" "$path") \
+    || fail_closed "cannot determine the base blob for file: $path"
+  for index in "${!UNIQUE_AGAINST_BRANCHES[@]}"; do
+    against_branch=${UNIQUE_AGAINST_BRANCHES[$index]}
+    against_ref="refs/remotes/origin/$against_branch"
+    against_blob=$(blob_id "$against_ref" "$path") \
+      || fail_closed "cannot determine the $against_branch blob for file: $path"
+    if [ "$pr_blob" = "$against_blob" ] && [ "$pr_blob" != "$base_blob" ]; then
+      FOREIGN_CONTENT+=("$path"$'\t'"$against_branch"$'\t'"$pr_blob"$'\t'"$base_blob")
+      break
+    fi
+  done
+done <"$FILE_LIST_TMP"
+
+if [ "${#FOREIGN_COMMITS[@]}" -gt 0 ] || [ "${#FOREIGN_CONTENT[@]}" -gt 0 ]; then
+  printf 'PR base check: FAIL (base=%s, pr-head=%s)\n' "$BASE_BRANCH" "$PR_HEAD"
+  printf 'ancestry: %s\n' "$ANCESTRY"
+  for evidence in "${FOREIGN_COMMITS[@]:-}"; do
+    [ -n "$evidence" ] || continue
+    IFS=$'\t' read -r commit subject against_branch <<<"$evidence"
+    printf 'foreign commit: %s %s (reachable from %s)\n' \
+      "$commit" "$subject" "$against_branch"
+  done
+  for evidence in "${FOREIGN_CONTENT[@]:-}"; do
+    [ -n "$evidence" ] || continue
+    IFS=$'\t' read -r path against_branch pr_blob base_blob <<<"$evidence"
+    printf 'foreign content: %s appears taken from %s (PR blob %s equals %s and differs from base blob %s)\n' \
+      "$path" "$against_branch" "$pr_blob" "$against_branch" "$base_blob"
+  done
+  exit 1
+fi
+
+printf 'PR base check: PASS (base=%s, pr-head=%s)\n' "$BASE_BRANCH" "$PR_HEAD"
+printf 'ancestry: %s\n' "$ANCESTRY"

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -63,7 +63,12 @@
 # destination, normal-case deduplication, and at-least-once recovery.
 # A landed merge whose outcome cannot be written is reported loudly rather than
 # misreported as a failed merge.
+# Before merging, bin/fm-pr-base-check.sh must pass against the task's project
+# clone. Pass --override-pr-base-check after the optional -- separator only for
+# a deliberate, visible override; the flag is not passed to the forge CLI.
+# GitLab merge requests skip this GitHub-specific check.
 # Usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra forge merge args>]
+#   --override-pr-base-check  merge after a failed base-content guard.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -102,6 +107,21 @@ PR_NUMBER=$FM_PR_NUMBER
 PROJECT_URL="https://$FM_PR_HOST/$FM_PR_PATH"
 shift 2
 [ "${1:-}" = "--" ] && shift
+
+OVERRIDE_BASE_CHECK=false
+merge_extra_args=()
+for arg in "$@"; do
+  if [ "$arg" = "--override-pr-base-check" ]; then
+    OVERRIDE_BASE_CHECK=true
+  else
+    merge_extra_args+=("$arg")
+  fi
+done
+if [ "${#merge_extra_args[@]}" -gt 0 ]; then
+  set -- "${merge_extra_args[@]}"
+else
+  set --
+fi
 
 caller_has_merge_method() {
   local arg
@@ -627,6 +647,24 @@ gitlab_confirm_merged() {
 # landed outcome, so even a provider read failure after a real merge cannot
 # leave teardown without the PR identity it needs to verify the result.
 record_pr_metadata || exit 1
+
+if [ "$PROVIDER" = github ]; then
+  PROJECT=$(grep '^project=' "$META" | tail -1 | cut -d= -f2- || true)
+  if [ -z "$PROJECT" ] || [ ! -d "$PROJECT" ]; then
+    echo "error: PR base check project clone is unavailable" >&2
+    exit 1
+  fi
+  if (cd "$PROJECT" && "$SCRIPT_DIR/fm-pr-base-check.sh" "$URL"); then
+    :
+  else
+    base_check_rc=$?
+    if [ "$OVERRIDE_BASE_CHECK" = false ]; then
+      echo "error: PR base check failed; refusing merge" >&2
+      exit "$base_check_rc"
+    fi
+    echo "warning: PR base check failed; proceeding with --override-pr-base-check" >&2
+  fi
+fi
 
 case "$PROVIDER" in
   github)

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -76,6 +76,21 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
+usage() {
+  cat >&2 <<'EOF'
+usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra forge merge args>]
+
+Records PR metadata, checks GitHub PR base content, runs the forge merge, and
+verifies the outcome. Pass --override-pr-base-check after -- only to continue
+after a failed GitHub PR base check. The override flag never reaches the forge.
+EOF
+}
+
+if [ "$#" -eq 1 ] && { [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; }; then
+  usage
+  exit 0
+fi
+
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-merge-outcome-lib.sh

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -296,6 +296,10 @@ On GitHub an outcome that is neither merged nor queued is refused loudly and non
 When the forge already accepted exactly those flags and the pull request still has not entered the queue, that refusal points at the queue state to re-check instead of echoing back the flags the caller just ran.
 An auto-merge request is held to the same standard: `--auto` that leaves the pull request neither merged nor queued is refused rather than reported as success.
 Every GitHub refusal states what it could not observe as plainly as what it did, so an unreadable branch-rule response, an unrecognised queue method, and a merge queue no available read can see are each named rather than left to look like a base branch with no queue at all.
+Before a GitHub merge, the helper runs [`bin/fm-pr-base-check.sh`](../bin/fm-pr-base-check.sh) inside the task's recorded `project=` clone, so no GitHub merge path can skip that guard.
+The guard fetches the PR head and compared branches without a checkout change, and it refuses foreign commits or changed-file blobs taken from a foreign branch.
+It fails closed on an unavailable project clone, a missing branch, unreachable forge data, or an unparseable URL, and only `--override-pr-base-check` permits a merge after failure.
+The guard script's header owns its flags, default `--against main` comparison set, and exact output shape.
 A confirmed merge leaves a durable role-routed outcome instead of living only in the merging agent's memory, and [`bin/fm-merge-outcome-lib.sh`](../bin/fm-merge-outcome-lib.sh)'s header owns its destination, shape, identity, normal-case deduplication, and at-least-once recovery.
 The same emitter handles a merge firstmate performed and one its poll detected, while the watcher immediately delivers the emitter's local actionable poll row.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -124,7 +124,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-lib.sh`           | Own canonical task and PR validation plus private atomic PR-poll publication, merge-notification identity, and retirement |
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
-| `fm-pr-merge.sh`         | Record PR metadata, merge a task's canonical full GitHub or GitLab URL, then refuse an outcome it cannot prove landed or queued |
+| `fm-pr-base-check.sh`    | Refuse a PR whose commits or changed file content came from a foreign branch         |
+| `fm-pr-merge.sh`         | Record PR metadata, guard GitHub base content, merge a canonical GitHub or GitLab URL, then verify the outcome |
 | `fm-merge-outcome-lib.sh` | Publish a confirmed merge's durable, role-routed supervision outcome                 |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode, and write the ship instructions carrying that mode's definition of done |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -154,9 +154,13 @@ case " $* " in
     ;;
 esac
 SH
-  cat > "$fakebin/gh-axi" <<'SH'
+cat > "$fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$FM_TEST_GH_AXI_LOG"
+if [ "${1:-}" = api ]; then
+  printf '%s\n' "${FM_TEST_PR_BASE:-main}"
+  exit "${FM_TEST_GH_AXI_RC:-0}"
+fi
 case "${1:-} ${2:-}" in
   "pr view")
     [ "$#" -eq 5 ] && [ "${4:-}" = --repo ] || exit 2
@@ -180,6 +184,23 @@ SH
   : > "$dir/glab.log"
   : > "$dir/guard.log"
   printf '%s\n' "$dir"
+}
+
+# Build the project clone that bin/fm-pr-base-check.sh inspects at merge time.
+# Each PR head equals the base tip, so the guard finds no foreign content.
+write_project_clone() {
+  local dir=$1 seed remote number head
+  shift
+  seed="$dir/project-seed"
+  remote="$dir/project-origin.git"
+  fm_git_init_commit "$seed"
+  git -C "$seed" branch -M main
+  git clone -q --bare "$seed" "$remote"
+  head=$(git -C "$seed" rev-parse HEAD)
+  for number in "$@"; do
+    git -C "$remote" update-ref "refs/pull/$number/head" "$head"
+  done
+  git clone -q "file://$remote" "$dir/project"
 }
 
 write_task_meta() {
@@ -486,6 +507,7 @@ test_valid_recording_and_merge_derivation() {
   local dir expected sidecar count rc
   dir=$(make_case valid-recording)
   write_task_meta "$dir"
+  write_project_clone "$dir" 37
   expected=0123456789abcdef0123456789abcdef01234567
   FM_TEST_GH_HEAD=$expected run_check_entry "$dir" task-a https://github.com/my-org/repo_name.with-dots/pull/37 \
     > "$dir/stdout" 2> "$dir/stderr" || fail "valid direct check failed"
@@ -552,6 +574,7 @@ test_valid_recording_and_merge_derivation() {
 
   dir=$(make_case lifecycle-compatible-id)
   write_task_meta "$dir" Task_A.1
+  write_project_clone "$dir" 3
   run_merge_entry "$dir" Task_A.1 https://github.com/o/r/pull/3 \
     > "$dir/stdout" 2> "$dir/stderr" \
     || fail "safe lifecycle-compatible task ID could not use the PR merge flow"
@@ -579,6 +602,12 @@ SH
       "project=$dir/project" \
       'kind=ship' \
       'mode=local-only'
+    write_project_clone "$dir" 4
+    mkdir -p "$dir/home/state/.pr-check-quarantine"
+    chmod 0700 "$dir/home/state/.pr-check-quarantine"
+    printf 'reserved migration evidence\n' \
+      > "$dir/home/state/.pr-check-quarantine/!noncanonical.check.evidence"
+    chmod 0600 "$dir/home/state/.pr-check-quarantine/!noncanonical.check.evidence"
     cat > "$dir/fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 exit 0
@@ -614,10 +643,15 @@ SH
   pass "valid direct and merge flows record exact metadata and reject multiline head metadata"
 }
 
+# The bound only stops a wedged watcher from hanging the suite.
+# A healthy watcher exits before this generous limit.
+FM_TEST_WATCH_BOUND=${FM_TEST_WATCH_BOUND:-120}
+
 run_watcher_bounded() {
   local home=$1 fakebin=$2 check_interval=${FM_TEST_CHECK_INTERVAL:-0} watch_root=${FM_TEST_WATCH_ROOT:-$ROOT}
   shift 2
-  perl -e 'my $pid=fork; die unless defined $pid; if (!$pid) { exec @ARGV } local $SIG{ALRM}=sub { kill "TERM", $pid; waitpid $pid, 0; exit 124 }; alarm 10; waitpid $pid, 0; alarm 0; exit($? >> 8)' \
+  perl -e 'my $bound = shift; my $pid=fork; die unless defined $pid; if (!$pid) { exec @ARGV } local $SIG{ALRM}=sub { kill "TERM", $pid; waitpid $pid, 0; exit 124 }; alarm $bound; waitpid $pid, 0; alarm 0; exit($? >> 8)' \
+    "$FM_TEST_WATCH_BOUND" \
     env FM_HOME="$home" FM_ROOT_OVERRIDE="$watch_root" FM_CHECK_INTERVAL="$check_interval" FM_CHECK_TIMEOUT=1 \
       FM_POLL=0.02 FM_HEARTBEAT=999999 FM_SIGNAL_GRACE=0 PATH="$fakebin:$BASE_PATH" "$WATCH" "$@"
 }
@@ -1591,6 +1625,7 @@ test_self_merge_and_poll_publish_one_outcome() {
   dir=$(make_case merge-outcome-committed)
   state="$dir/home/state"
   replies="$state/parent-replies.status"
+  write_project_clone "$dir" 1
   seed_secondmate_home "$dir"
   write_task_meta "$dir" task-a
   run_check_entry "$dir" task-a "$url" >/dev/null 2>"$dir/seed.err" \
@@ -1616,6 +1651,7 @@ test_self_merge_and_poll_publish_one_outcome() {
   # than treating the interrupted attempt as complete and going silent.
   dir=$(make_case merge-outcome-uncommitted)
   state="$dir/home/state"
+  write_project_clone "$dir" 1
   write_task_meta "$dir" task-a
   run_check_entry "$dir" task-a "$url" >/dev/null 2>"$dir/seed.err" \
     || fail "merge-outcome-uncommitted: could not arm merge poll"

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -75,6 +75,7 @@
 #   (bb) --against replaces the main default
 #   (bc) a foreign origin fails closed
 #   (bd) the PR base guard removes its fetched PR head ref on exit
+#   (be) --help documents the explicit base-check override
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -1504,6 +1505,22 @@ test_parses_pr_url_for_gh_axi() {
   pass "fm-pr-merge parses a GitHub PR URL into gh-axi number and --repo arguments"
 }
 
+test_help_documents_base_check_override() {
+  local out rc
+  set +e
+  out=$("$PR_MERGE" --help 2>&1)
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "merge-help: --help should succeed"
+  assert_contains "$out" \
+    'usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra forge merge args>]' \
+    "merge-help: usage is missing"
+  assert_contains "$out" '--override-pr-base-check' \
+    "merge-help: override flag is missing"
+  pass "fm-pr-merge help documents the explicit base-check override"
+}
+
 test_gitlab_url_resolves_and_merges() {
   local case_dir rc merge_line
   case_dir=$(make_gitlab_case gitlab-merges)
@@ -2360,6 +2377,7 @@ test_bundled_repo_override_args_refuse_before_recording
 test_explicit_merge_method_not_overridden
 test_method_equals_merge_method_not_overridden
 test_parses_pr_url_for_gh_axi
+test_help_documents_base_check_override
 test_github_still_forwards_sha_arg
 test_gitlab_url_resolves_and_merges
 test_gitlab_host_comes_from_the_url

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -71,6 +71,10 @@
 #   (ax) the PR base guard catches foreign commits and foreign file content
 #   (ay) the PR base guard allows clean content and an agreed base/main blob
 #   (az) the merge path refuses the guard failure unless explicitly overridden
+#   (ba) the PR base guard allows deleting a file the against branch never had
+#   (bb) --against replaces the main default
+#   (bc) a foreign origin fails closed
+#   (bd) the PR base guard removes its fetched PR head ref on exit
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -108,7 +112,7 @@ REAL_MV=$(command -v mv) || fail "these tests need mv to simulate a failed poll 
 # Build a fresh sandbox for one test case: a state dir with a task meta and a
 # fakebin with a gh-axi mock that records how it was invoked. Echoes the case dir.
 make_case() {
-  local name=$1 case_dir fakebin project remote seed number
+  local name=$1 case_dir fakebin project remote seed number pr_head
   case_dir="$TMP_ROOT/$name"
   fakebin="$case_dir/fakebin"
   mkdir -p "$case_dir/state" "$fakebin"
@@ -122,9 +126,11 @@ make_case() {
   printf 'pull request content\n' > "$seed/pr.txt"
   git -C "$seed" add pr.txt
   git -C "$seed" commit -qm 'test pull request content'
+  pr_head=$(git -C "$seed" rev-parse HEAD)
+  git -C "$seed" push -q "file://$remote" HEAD:refs/pull/template/head
   for number in 5 6 7 8 9 13 15 21 22 23 44 51 52 53 54 55 56 57 58 59 \
     60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 126; do
-    git -C "$seed" push -q "file://$remote" HEAD:"refs/pull/$number/head"
+    git -C "$remote" update-ref "refs/pull/$number/head" "$pr_head"
   done
   git clone -q "file://$remote" "$project"
   fm_write_meta "$case_dir/state/task-x1.meta" \
@@ -2101,6 +2107,7 @@ test_secondmate_without_parent_binding_is_loud() {
     "unbound-secondmate: a secondmate home fell back to the main-home record"
   pass "a secondmate home that cannot report upward says so instead of merging in silence"
 }
+GUARD_COMPONENT=apps/sdlc-ui/UI/src/app/components/workflow-preview/run-activity/run-activity.component.ts
 
 build_guard_project() {
   local case_dir=$1 mode=$2 seed remote project root_commit
@@ -2110,26 +2117,28 @@ build_guard_project() {
   fm_git_init_commit "$seed"
   root_commit=$(git -C "$seed" rev-parse HEAD)
   git -C "$seed" branch -M main
-  printf 'main component\n' > "$seed/component.ts"
+  mkdir -p "$seed/$(dirname "$GUARD_COMPONENT")"
+  printf 'main component\n' > "$seed/$GUARD_COMPONENT"
   printf 'agreed content\n' > "$seed/same.txt"
-  git -C "$seed" add component.ts same.txt
+  git -C "$seed" add "$GUARD_COMPONENT" same.txt
   git -C "$seed" commit -qm 'main component change'
   git -C "$seed" checkout -q -b feature/base "$root_commit"
-  printf 'base component\n' > "$seed/component.ts"
+  mkdir -p "$seed/$(dirname "$GUARD_COMPONENT")"
+  printf 'base component\n' > "$seed/$GUARD_COMPONENT"
   printf 'agreed content\n' > "$seed/same.txt"
-  git -C "$seed" add component.ts same.txt
+  git -C "$seed" add "$GUARD_COMPONENT" same.txt
   git -C "$seed" commit -qm 'feature base component change'
   git -C "$seed" checkout -q -b pr
   case "$mode" in
     content)
-      printf 'main component\n' > "$seed/component.ts"
-      git -C "$seed" add component.ts
+      printf 'main component\n' > "$seed/$GUARD_COMPONENT"
+      git -C "$seed" add "$GUARD_COMPONENT"
       git -C "$seed" commit -qm 'copy main component wholesale'
       ;;
     foreign-commit)
       git -C "$seed" merge --no-ff main -m 'merge main into PR' >/dev/null 2>&1 || {
-        git -C "$seed" checkout -q --ours component.ts
-        git -C "$seed" add component.ts
+        git -C "$seed" checkout -q --ours "$GUARD_COMPONENT"
+        git -C "$seed" add "$GUARD_COMPONENT"
         git -C "$seed" commit -qm 'merge main into PR'
       }
       ;;
@@ -2142,6 +2151,16 @@ build_guard_project() {
       printf 'only PR content\n' > "$seed/pr-only.txt"
       git -C "$seed" add pr-only.txt
       git -C "$seed" commit -qm 'clean PR content'
+      ;;
+    deleted)
+      git -C "$seed" checkout -q feature/base
+      printf 'base only scaffold\n' > "$seed/scaffold.txt"
+      git -C "$seed" add scaffold.txt
+      git -C "$seed" commit -qm 'base scaffold that main never had'
+      git -C "$seed" branch -qf pr
+      git -C "$seed" checkout -q pr
+      git -C "$seed" rm -q scaffold.txt
+      git -C "$seed" commit -qm 'delete the base scaffold'
       ;;
     *) fail "unknown guard fixture mode: $mode" ;;
   esac
@@ -2192,7 +2211,7 @@ test_base_guard_foreign_content_fails_with_file() {
   out=$(run_base_check "$case_dir" content)
   rc=$(printf '%s\n' "$out" | head -1)
   expect_code 1 "$rc" "base-foreign-content: foreign content should fail"
-  assert_contains "$out" 'foreign content: component.ts appears taken from main' \
+  assert_contains "$out" "foreign content: $GUARD_COMPONENT appears taken from main" \
     "base-foreign-content: file evidence is missing"
   pass "PR base guard catches wrong-branch file content"
 }
@@ -2206,6 +2225,64 @@ test_base_guard_agreed_blob_does_not_fail() {
   expect_code 0 "$rc" "base-agreed: agreed blob should pass"
   assert_contains "$out" 'PR base check: PASS' "base-agreed: pass summary is missing"
   pass "PR base guard allows content that base and main already share"
+}
+
+test_base_guard_deleted_base_file_does_not_fail() {
+  local case_dir out rc
+  case_dir="$TMP_ROOT/base-deleted"
+  mkdir -p "$case_dir"
+  out=$(run_base_check "$case_dir" deleted)
+  rc=$(printf '%s\n' "$out" | head -1)
+  expect_code 0 "$rc" "base-deleted: deleting a base-only file should pass"
+  assert_contains "$out" 'PR base check: PASS' "base-deleted: pass summary is missing"
+  pass "PR base guard allows a PR that deletes a file the against branch never had"
+}
+
+test_base_guard_uses_supplied_against_branches_only() {
+  local case_dir project out rc
+  case_dir="$TMP_ROOT/base-against-only"
+  mkdir -p "$case_dir"
+  project=$(build_guard_project "$case_dir" content)
+  git -C "$project" push -q origin --delete main
+  set +e
+  out=$( (cd "$project" && "$PR_BASE_CHECK" \
+    https://github.com/example/repo/pull/1 --base feature/base \
+    --against feature/base) 2>&1 )
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "base-against-only: supplied --against should replace the main default"
+  assert_contains "$out" 'PR base check: PASS' "base-against-only: pass summary is missing"
+  pass "PR base guard uses only the supplied --against branches"
+}
+
+test_base_guard_refuses_a_foreign_origin() {
+  local case_dir project out rc
+  case_dir="$TMP_ROOT/base-foreign-origin"
+  mkdir -p "$case_dir"
+  project=$(build_guard_project "$case_dir" clean)
+  git -C "$project" remote set-url origin https://github.com/other/repo.git
+  set +e
+  out=$( (cd "$project" && "$PR_BASE_CHECK" \
+    https://github.com/example/repo/pull/1 --base feature/base) 2>&1 )
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "base-foreign-origin: a mismatched origin should fail closed"
+  assert_contains "$out" 'origin is not the PR repository' \
+    "base-foreign-origin: refusal did not name the origin mismatch"
+  pass "PR base guard refuses an origin that is not the PR repository"
+}
+
+test_base_guard_removes_the_fetched_pr_ref() {
+  local case_dir project refs
+  case_dir="$TMP_ROOT/base-ref-cleanup"
+  mkdir -p "$case_dir"
+  project=$(build_guard_project "$case_dir" clean)
+  (cd "$project" && "$PR_BASE_CHECK" \
+    https://github.com/example/repo/pull/1 --base feature/base --against main) \
+    > "$case_dir/stdout" 2>&1 || fail "base-ref-cleanup: clean PR should pass"
+  refs=$(git -C "$project" for-each-ref --format='%(refname)' 'refs/fm-pr-base-check/**')
+  [ -z "$refs" ] || fail "base-ref-cleanup: guard left review refs behind: $refs"
+  pass "PR base guard removes the fetched PR head ref on exit"
 }
 
 test_merge_guard_refuses_and_override_proceeds() {
@@ -2229,7 +2306,7 @@ test_merge_guard_refuses_and_override_proceeds() {
   rc=$?
   set -e
   expect_code 1 "$rc" "merge-base-guard: failed guard should refuse merge"
-  assert_grep 'foreign content: component.ts appears taken from main' "$case_dir/stdout" \
+  assert_grep "foreign content: $GUARD_COMPONENT appears taken from main" "$case_dir/stdout" \
     "merge-base-guard: refusal omitted guard evidence"
   assert_no_grep 'pr merge' "$case_dir/gh-axi.log" \
     "merge-base-guard: merge was invoked after guard failure"
@@ -2311,4 +2388,8 @@ test_base_guard_clean_pr_passes
 test_base_guard_foreign_commit_fails_with_subject
 test_base_guard_foreign_content_fails_with_file
 test_base_guard_agreed_blob_does_not_fail
+test_base_guard_deleted_base_file_does_not_fail
+test_base_guard_uses_supplied_against_branches_only
+test_base_guard_refuses_a_foreign_origin
+test_base_guard_removes_the_fetched_pr_ref
 test_merge_guard_refuses_and_override_proceeds

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -68,6 +68,9 @@
 #   (av) a base branch with no queue rule says nothing about a merge queue
 #   (aw) a refusal built on the gh-axi view says the merge queue could not be
 #       observed, and judges that view's state like the queue-aware one
+#   (ax) the PR base guard catches foreign commits and foreign file content
+#   (ay) the PR base guard allows clean content and an agreed base/main blob
+#   (az) the merge path refuses the guard failure unless explicitly overridden
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -75,8 +78,20 @@ set -u
 fm_git_identity fmtest fmtest@example.invalid
 
 PR_MERGE="$ROOT/bin/fm-pr-merge.sh"
+PR_BASE_CHECK="$ROOT/bin/fm-pr-base-check.sh"
 TMP_ROOT=$(fm_test_tmproot fm-pr-merge-tests)
 BASE_PATH=$PATH
+BASE_CHECK_FAKEBIN="$TMP_ROOT/base-check-fakebin"
+mkdir -p "$BASE_CHECK_FAKEBIN"
+cat > "$BASE_CHECK_FAKEBIN/gh-axi" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = api ]; then
+  printf 'api_response:\n  body: %s\n  truncated: false\n' "${FM_TEST_PR_BASE:-main}"
+  exit 0
+fi
+exec "$FM_TEST_FORGE_FAKEBIN/gh-axi" "$@"
+SH
+chmod +x "$BASE_CHECK_FAKEBIN/gh-axi"
 
 # The GitLab fixture. A placeholder host that resolves nowhere, and a namespace
 # deeper than one group, because a GitLab project has no owner/repository pair.
@@ -93,14 +108,29 @@ REAL_MV=$(command -v mv) || fail "these tests need mv to simulate a failed poll 
 # Build a fresh sandbox for one test case: a state dir with a task meta and a
 # fakebin with a gh-axi mock that records how it was invoked. Echoes the case dir.
 make_case() {
-  local name=$1 case_dir fakebin
+  local name=$1 case_dir fakebin project remote seed number
   case_dir="$TMP_ROOT/$name"
   fakebin="$case_dir/fakebin"
   mkdir -p "$case_dir/state" "$fakebin"
+  project="$case_dir/project"
+  remote="$case_dir/origin.git"
+  seed="$case_dir/seed"
+  fm_git_init_commit "$seed"
+  git -C "$seed" branch -M main
+  git clone -q --bare "$seed" "$remote"
+  git -C "$seed" checkout -q -b pr
+  printf 'pull request content\n' > "$seed/pr.txt"
+  git -C "$seed" add pr.txt
+  git -C "$seed" commit -qm 'test pull request content'
+  for number in 5 6 7 8 9 13 15 21 22 23 44 51 52 53 54 55 56 57 58 59 \
+    60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 126; do
+    git -C "$seed" push -q "file://$remote" HEAD:"refs/pull/$number/head"
+  done
+  git clone -q "file://$remote" "$project"
   fm_write_meta "$case_dir/state/task-x1.meta" \
     "window=fm-task-x1" \
     "worktree=$case_dir/wt" \
-    "project=$case_dir/project" \
+    "project=$project" \
     "kind=ship" \
     "mode=no-mistakes"
   printf '%s\n' \
@@ -164,8 +194,8 @@ add_gh_mocks_merge_fails() {
 printf '%s\n' "$*" >> "$FM_TEST_GH_AXI_LOG"
 case "${1:-} ${2:-}" in
   "pr merge") echo "error: pr merge failed" >&2 ; exit 1 ;;
-  esac
-  exit 0
+esac
+exit 0
 SH
   cat > "$case_dir/fakebin/gh" <<'SH'
 #!/usr/bin/env bash
@@ -357,6 +387,7 @@ run_pr_merge() {
   FM_HOME="${FM_TEST_HOME:-$ROOT}" \
   FM_STATE_OVERRIDE="$case_dir/state" \
   FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
+  FM_TEST_FORGE_FAKEBIN="$case_dir/fakebin" \
   FM_TEST_GH_LOG="$case_dir/gh.log" \
   FM_TEST_GH_OUTCOME="$case_dir/github-outcome" \
   FM_TEST_GH_RULES="$case_dir/github-rules" \
@@ -364,7 +395,7 @@ run_pr_merge() {
   FM_TEST_REAL_MV="$REAL_MV" \
   FM_TEST_GLAB_LOG="$case_dir/glab.log" \
   FM_TEST_GLAB_JSON="$case_dir/mr.json" \
-  PATH="$case_dir/fakebin:$PATH" \
+  PATH="$BASE_CHECK_FAKEBIN:$case_dir/fakebin:$PATH" \
     "$PR_MERGE" "$@"
   rc=$?
   if [ "${case_dir##*/}" = unsafe-url-segment ] && [ "$rc" -eq 2 ]; then
@@ -395,7 +426,6 @@ test_verified_merge_records_pr_and_head() {
     > "$case_dir/stdout" 2> "$case_dir/stderr"
   rc=$?
   set -e
-
   expect_code 0 "$rc" "records-before-merge: fm-pr-merge should succeed"
   assert_grep 'pr=https://github.com/example/repo/pull/9' "$case_dir/state/task-x1.meta" \
     "records-before-merge: pr= was not recorded"
@@ -2072,6 +2102,150 @@ test_secondmate_without_parent_binding_is_loud() {
   pass "a secondmate home that cannot report upward says so instead of merging in silence"
 }
 
+build_guard_project() {
+  local case_dir=$1 mode=$2 seed remote project root_commit
+  seed="$case_dir/guard-seed"
+  remote="$case_dir/guard-origin.git"
+  project="$case_dir/guard-project"
+  fm_git_init_commit "$seed"
+  root_commit=$(git -C "$seed" rev-parse HEAD)
+  git -C "$seed" branch -M main
+  printf 'main component\n' > "$seed/component.ts"
+  printf 'agreed content\n' > "$seed/same.txt"
+  git -C "$seed" add component.ts same.txt
+  git -C "$seed" commit -qm 'main component change'
+  git -C "$seed" checkout -q -b feature/base "$root_commit"
+  printf 'base component\n' > "$seed/component.ts"
+  printf 'agreed content\n' > "$seed/same.txt"
+  git -C "$seed" add component.ts same.txt
+  git -C "$seed" commit -qm 'feature base component change'
+  git -C "$seed" checkout -q -b pr
+  case "$mode" in
+    content)
+      printf 'main component\n' > "$seed/component.ts"
+      git -C "$seed" add component.ts
+      git -C "$seed" commit -qm 'copy main component wholesale'
+      ;;
+    foreign-commit)
+      git -C "$seed" merge --no-ff main -m 'merge main into PR' >/dev/null 2>&1 || {
+        git -C "$seed" checkout -q --ours component.ts
+        git -C "$seed" add component.ts
+        git -C "$seed" commit -qm 'merge main into PR'
+      }
+      ;;
+    agreed)
+      chmod +x "$seed/same.txt"
+      git -C "$seed" add same.txt
+      git -C "$seed" commit -qm 'change mode on agreed file'
+      ;;
+    clean)
+      printf 'only PR content\n' > "$seed/pr-only.txt"
+      git -C "$seed" add pr-only.txt
+      git -C "$seed" commit -qm 'clean PR content'
+      ;;
+    *) fail "unknown guard fixture mode: $mode" ;;
+  esac
+  git clone -q --bare "$seed" "$remote"
+  git -C "$seed" push -q "file://$remote" HEAD:refs/pull/1/head
+  git clone -q "file://$remote" "$project"
+  printf '%s\n' "$project"
+}
+
+run_base_check() {
+  local project=$1 mode=$2 out rc
+  project=$(build_guard_project "$project" "$mode")
+  set +e
+  out=$(cd "$project" && "$PR_BASE_CHECK" \
+    https://github.com/example/repo/pull/1 --base feature/base --against main 2>&1)
+  rc=$?
+  set -e
+  printf '%s\n%s\n' "$rc" "$out"
+}
+
+test_base_guard_clean_pr_passes() {
+  local case_dir out rc
+  case_dir="$TMP_ROOT/base-clean"
+  mkdir -p "$case_dir"
+  out=$(run_base_check "$case_dir" clean)
+  rc=$(printf '%s\n' "$out" | head -1)
+  expect_code 0 "$rc" "base-clean: clean PR should pass"
+  assert_contains "$out" 'PR base check: PASS' "base-clean: pass summary is missing"
+  pass "PR base guard passes a clean PR"
+}
+
+test_base_guard_foreign_commit_fails_with_subject() {
+  local case_dir out rc
+  case_dir="$TMP_ROOT/base-foreign-commit"
+  mkdir -p "$case_dir"
+  out=$(run_base_check "$case_dir" foreign-commit)
+  rc=$(printf '%s\n' "$out" | head -1)
+  expect_code 1 "$rc" "base-foreign-commit: foreign commit should fail"
+  assert_contains "$out" 'foreign commit:' "base-foreign-commit: evidence is missing"
+  assert_contains "$out" 'main component change' "base-foreign-commit: commit subject is missing"
+  pass "PR base guard names a foreign reachable commit"
+}
+
+test_base_guard_foreign_content_fails_with_file() {
+  local case_dir out rc
+  case_dir="$TMP_ROOT/base-foreign-content"
+  mkdir -p "$case_dir"
+  out=$(run_base_check "$case_dir" content)
+  rc=$(printf '%s\n' "$out" | head -1)
+  expect_code 1 "$rc" "base-foreign-content: foreign content should fail"
+  assert_contains "$out" 'foreign content: component.ts appears taken from main' \
+    "base-foreign-content: file evidence is missing"
+  pass "PR base guard catches wrong-branch file content"
+}
+
+test_base_guard_agreed_blob_does_not_fail() {
+  local case_dir out rc
+  case_dir="$TMP_ROOT/base-agreed"
+  mkdir -p "$case_dir"
+  out=$(run_base_check "$case_dir" agreed)
+  rc=$(printf '%s\n' "$out" | head -1)
+  expect_code 0 "$rc" "base-agreed: agreed blob should pass"
+  assert_contains "$out" 'PR base check: PASS' "base-agreed: pass summary is missing"
+  pass "PR base guard allows content that base and main already share"
+}
+
+test_merge_guard_refuses_and_override_proceeds() {
+  local case_dir project rc
+  case_dir="$TMP_ROOT/merge-base-guard"
+  mkdir -p "$case_dir/state" "$case_dir/fakebin"
+  project=$(build_guard_project "$case_dir" content)
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=fm-task-x1" \
+    "worktree=$case_dir/wt" \
+    "project=$project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks "$case_dir" 1111111111111111111111111111111111111111
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  FM_TEST_PR_BASE=feature/base run_pr_merge "$case_dir" task-x1 \
+    https://github.com/example/repo/pull/1 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "merge-base-guard: failed guard should refuse merge"
+  assert_grep 'foreign content: component.ts appears taken from main' "$case_dir/stdout" \
+    "merge-base-guard: refusal omitted guard evidence"
+  assert_no_grep 'pr merge' "$case_dir/gh-axi.log" \
+    "merge-base-guard: merge was invoked after guard failure"
+
+  : > "$case_dir/gh-axi.log"
+  FM_TEST_PR_BASE=feature/base run_pr_merge "$case_dir" task-x1 \
+    https://github.com/example/repo/pull/1 -- --override-pr-base-check \
+    > "$case_dir/stdout-override" 2> "$case_dir/stderr-override" \
+    || fail "merge-base-guard: override should proceed"
+  grep -qxF 'pr merge 1 --repo example/repo --squash' "$case_dir/gh-axi.log" \
+    || fail "merge-base-guard: override did not invoke the default squash merge"
+  assert_no_grep '--override-pr-base-check' "$case_dir/gh-axi.log" \
+    "merge-base-guard: override flag reached gh-axi"
+  pass "fm-pr-merge refuses a failed guard and requires the explicit override"
+}
+
 test_github_zero_exit_queue_required_refuses_with_exact_retry
 test_github_closed_unqueued_outcome_omits_retry_flags
 test_github_agreeing_queue_rules_keep_retry_guidance
@@ -2133,3 +2307,8 @@ test_queued_github_merge_leaves_the_poll_armed
 test_distinct_merged_prs_keep_distinct_wakes
 test_uncommitted_marker_retry_is_never_silent
 test_secondmate_without_parent_binding_is_loud
+test_base_guard_clean_pr_passes
+test_base_guard_foreign_commit_fails_with_subject
+test_base_guard_foreign_content_fails_with_file
+test_base_guard_agreed_blob_does_not_fail
+test_merge_guard_refuses_and_override_proceeds


### PR DESCRIPTION
## Summary

Add a merge-time guard that refuses PR content taken wholesale from a foreign branch.
Wire the guard into `fm-pr-merge.sh` with an explicit `--override-pr-base-check` escape hatch.

The guard checks ancestry, foreign commits, and changed-file blob identity.
It fails closed when it cannot resolve the forge, branch, or PR URL.

## Verification

The live PR 462 proof became unavailable because PR 462 was corrected and merged before proof collection.
I reconstructed the historical case locally from `integration/lifecycle-forge-v2` with the affected file replaced by the `main` version.
The following outputs are the exact guard outputs.

### Reconstructed historical PR 462 failure

```text
PR base check: FAIL (base=integration/lifecycle-forge-v2, pr-head=58a4189d0961c72719ce42be31917640538fbe4d)
ancestry: base is an ancestor of PR head
foreign content: apps/sdlc-ui/UI/src/app/components/workflow-preview/run-activity/run-activity.component.ts appears taken from main (PR blob ccfc1f2a430c295cac9974b19e4d7f6ff5b44aea equals main and differs from base blob 2eb657cccfcc0d0e0ae0fb2b5167e65ab614cc22)
```

### Equal-content control

```text
PR base check: PASS (base=integration/lifecycle-forge-v2, pr-head=7edb30ed9b75a822968241c56423dfce68836652)
ancestry: base is an ancestor of PR head
```

### Live PR 463

```text
PR base check: PASS (base=integration/lifecycle-forge-v2, pr-head=7b67ae870464a6642edf74967693ed65a27826e8)
ancestry: base is not an ancestor of PR head
```

The test suite covers clean PRs, foreign commits, the exact run-activity component regression, equal content, merge refusal, override behavior, and mutation of the content comparison.
