### PR TITLE
fix: reject foreign clone-family worker allocations

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2239,17 +2239,17 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   proj_real=$PROJ_ABS_REAL
   if ! proj_common=$(resolve_absolute_git_common_dir "$proj_real"); then
     preserve_common_dir_mismatch_allocation
-    echo "error: $source allocated '$wt_real', but the requested project's absolute Git common directory could not be resolved from '$proj_real'; refusing before worker launch. No supported non-cleaning allocation return or quarantine operation is available, so the allocated local copy and endpoint are preserved in place. Inspect $inspect_target and reconcile the pool or provider through its guarded ownership path before retrying" >&2
+    echo "error: $source allocated '$wt_real', but the requested project's absolute Git common directory could not be resolved from '$proj_real'; refusing before worker launch. No supported non-cleaning allocation return or quarantine operation is available, so the allocated local copy and any existing endpoint are preserved in place. Inspect $inspect_target and reconcile the pool or provider through its guarded ownership path before retrying" >&2
     exit 1
   fi
   if ! wt_common=$(resolve_absolute_git_common_dir "$wt_real"); then
     preserve_common_dir_mismatch_allocation
-    echo "error: $source allocated '$wt_real', but its absolute Git common directory could not be resolved; the requested project '$proj_real' uses '$proj_common'. Refusing before worker launch. No supported non-cleaning allocation return or quarantine operation is available, so the allocated local copy and endpoint are preserved in place. Inspect $inspect_target and reconcile the pool or provider through its guarded ownership path before retrying" >&2
+    echo "error: $source allocated '$wt_real', but its absolute Git common directory could not be resolved; the requested project '$proj_real' uses '$proj_common'. Refusing before worker launch. No supported non-cleaning allocation return or quarantine operation is available, so the allocated local copy and any existing endpoint are preserved in place. Inspect $inspect_target and reconcile the pool or provider through its guarded ownership path before retrying" >&2
     exit 1
   fi
   if [ "$wt_common" != "$proj_common" ]; then
     preserve_common_dir_mismatch_allocation
-    echo "error: Git common-directory mismatch after $source: requested project '$proj_real' uses '$proj_common', but allocated worktree '$wt_real' uses '$wt_common'. Refusing before worker launch. No supported non-cleaning allocation return or quarantine operation is available, so the allocated local copy and endpoint are preserved in place. Inspect $inspect_target and reconcile the mixed clone-family pool or provider through its guarded ownership path before retrying; do not force-return, clean, reset, or remove this allocation" >&2
+    echo "error: Git common-directory mismatch after $source: requested project '$proj_real' uses '$proj_common', but allocated worktree '$wt_real' uses '$wt_common'. Refusing before worker launch. No supported non-cleaning allocation return or quarantine operation is available, so the allocated local copy and any existing endpoint are preserved in place. Inspect $inspect_target and reconcile the mixed clone-family pool or provider through its guarded ownership path before retrying; do not force-return, clean, reset, or remove this allocation" >&2
     exit 1
   fi
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -152,9 +152,14 @@
 #   out as a transient rather than adopted and then refused, so a home that is
 #   itself a linked worktree of the project repository still launches. A pane
 #   that never reaches an isolated worktree refuses at the end of that wait,
-#   naming the last path seen and why it was rejected.
-#   Only after this isolation check, a fresh ship or scout's clean task worktree
-#   fetches origin, resolves the current remote default branch, and resets to its tip.
+#   naming the last path seen and why it was rejected. The allocated worktree's
+#   absolute Git common directory must also match the requested project's.
+#   A common-directory mismatch is refused before worker launch and preserved in
+#   place because neither Treehouse nor Orca exposes a supported non-cleaning
+#   quarantine or return operation; the error identifies the project family,
+#   allocated family, local copy, and endpoint for guarded reconciliation.
+#   Only after these checks, a fresh ship or scout's clean task worktree fetches
+#   origin, resolves the current remote default branch, and resets to its tip.
 #   Relaunch reuses the recorded worktree without fetching or resetting its base.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses a fresh spawn rather than risking a PR based on stale history.
@@ -2203,10 +2208,48 @@ spawn_worktree_isolated() {  # <path>
   return 0
 }
 
+resolve_absolute_git_common_dir() {  # <repository>
+  local repository=$1 common
+  common=$(git -C "$repository" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+  case "$common" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  CDPATH='' cd -- "$common" 2>/dev/null && pwd -P
+}
+
+preserve_common_dir_mismatch_allocation() {
+  # Orca's only removal primitive is forced, and Treehouse documents no
+  # non-cleaning quarantine or return operation. Herdr presentation abort and
+  # Orca abort cleanup would otherwise remove the endpoint or allocated local
+  # copy on EXIT, so disable only those cleanup paths for this safety refusal.
+  # The ordinary tmux, flat-Herdr, Zellij, and cmux abort paths already retain
+  # their endpoint and Treehouse allocation in place.
+  HERDR_PROJECTION_ABORT_CLEANUP=0
+  ORCA_ABORT_CLEANUP=0
+}
+
 validate_spawn_worktree() {  # <source> <inspect-target>
-  local source=$1 inspect_target=$2
+  local source=$1 inspect_target=$2 wt_real proj_real proj_common wt_common
   if ! spawn_worktree_isolated "$WT"; then
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${SPAWN_WT_TOP:-none}'; spawning project '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
+    exit 1
+  fi
+  wt_real=$(cd "$WT" 2>/dev/null && pwd -P) || wt_real=
+  proj_real=$PROJ_ABS_REAL
+  if ! proj_common=$(resolve_absolute_git_common_dir "$proj_real"); then
+    preserve_common_dir_mismatch_allocation
+    echo "error: $source allocated '$wt_real', but the requested project's absolute Git common directory could not be resolved from '$proj_real'; refusing before worker launch. No supported non-cleaning allocation return or quarantine operation is available, so the allocated local copy and endpoint are preserved in place. Inspect $inspect_target and reconcile the pool or provider through its guarded ownership path before retrying" >&2
+    exit 1
+  fi
+  if ! wt_common=$(resolve_absolute_git_common_dir "$wt_real"); then
+    preserve_common_dir_mismatch_allocation
+    echo "error: $source allocated '$wt_real', but its absolute Git common directory could not be resolved; the requested project '$proj_real' uses '$proj_common'. Refusing before worker launch. No supported non-cleaning allocation return or quarantine operation is available, so the allocated local copy and endpoint are preserved in place. Inspect $inspect_target and reconcile the pool or provider through its guarded ownership path before retrying" >&2
+    exit 1
+  fi
+  if [ "$wt_common" != "$proj_common" ]; then
+    preserve_common_dir_mismatch_allocation
+    echo "error: Git common-directory mismatch after $source: requested project '$proj_real' uses '$proj_common', but allocated worktree '$wt_real' uses '$wt_common'. Refusing before worker launch. No supported non-cleaning allocation return or quarantine operation is available, so the allocated local copy and endpoint are preserved in place. Inspect $inspect_target and reconcile the mixed clone-family pool or provider through its guarded ownership path before retrying; do not force-return, clean, reset, or remove this allocation" >&2
     exit 1
   fi
 }
@@ -2650,7 +2693,9 @@ EOF
       echo "error: orca did not return a worktree id/path for $W" >&2
       exit 1
     fi
-    validate_spawn_worktree "orca worktree create" "$W"
+    ORCA_INSPECT_TARGET="task '$W', Orca worktree id '$ORCA_WORKTREE_ID'"
+    [ -z "$ORCA_TERMINAL" ] || ORCA_INSPECT_TARGET="$ORCA_INSPECT_TARGET, terminal '$ORCA_TERMINAL'"
+    validate_spawn_worktree "orca worktree create" "$ORCA_INSPECT_TARGET"
     if [ -z "$ORCA_TERMINAL" ]; then
       ORCA_TERMINAL=$(fm_backend_orca_terminal_create "$ORCA_WORKTREE_ID" "$W") || exit 1
     fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -331,7 +331,7 @@ family_for_basename() {
     fm-procevent-quota.test.sh|fm-procevent-when.test.sh|fm-procevent.test.sh|\
     fm-project-origin.test.sh|fm-public-followup.test.sh|fm-quota-choose.test.sh|\
     fm-remote-entrypoint.test.sh|fm-remote-secondmate-parent-binding.test.sh|\
-    fm-send-remote-delivery.test.sh|fm-spawn-pool-base-freshen.test.sh|\
+    fm-send-remote-delivery.test.sh|\
     fm-test-fixture-cleanup.test.sh|fm-test-fixtures.test.sh|\
     fm-voice-relay.test.sh|fm-wake-drain-open-decisions-cursor.test.sh|\
     fm-wake-drain-open-decisions.test.sh|fm-wake-drain-outcome-backstop.test.sh)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -296,7 +296,8 @@ family_for_basename() {
     fm-control.test.sh|fm-control-relaunch.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|\
     fm-send-inbox.test.sh|fm-spawn-batch.test.sh|\
-    fm-spawn-dispatch-profile.test.sh|fm-claude-trust.test.sh|\
+    fm-spawn-common-dir.test.sh|fm-spawn-dispatch-profile.test.sh|fm-claude-trust.test.sh|\
+    fm-spawn-pool-base-freshen.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,8 +200,11 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
-The [`fm-spawn.sh` header](../bin/fm-spawn.sh) owns ship/scout worktree isolation and fresh-base refusal rules, including spawns from linked homes.
-Portable regressions live in [`tests/fm-spawn-pool-base-freshen.test.sh`](../tests/fm-spawn-pool-base-freshen.test.sh) for spawn isolation and base freshness, and [`tests/fm-control-relaunch.test.sh`](../tests/fm-control-relaunch.test.sh) for preserving the recorded copy on relaunch.
+For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root distinct from both the spawning project and its repository's primary checkout, including spawns from linked homes, and belongs to the requested project's absolute Git common directory.
+The common-directory check is the single post-allocation owner shared by Treehouse-backed tmux, Herdr, Zellij, and cmux tasks and by Orca-owned task worktrees.
+A mismatched allocation is refused before worker launch and preserved in place because neither provider exposes a supported non-cleaning quarantine or return operation.
+`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn; relaunch preserves the recorded copy without fetching or resetting it.
+Its header owns the exact refusal mechanics, `tests/fm-spawn-common-dir.test.sh` owns portable mixed-clone preservation coverage, `tests/fm-spawn-pool-base-freshen.test.sh` owns portable isolation and base-freshness coverage, and `tests/fm-control-relaunch.test.sh` owns preserving the recorded copy on relaunch.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -634,6 +634,49 @@ test_spawn_refuses_orca_nonisolated_worktree() {
   pass "fm-spawn.sh --backend orca: refuses non-isolated worktrees and closes implicit terminals"
 }
 
+test_spawn_preserves_orca_common_dir_mismatch() {
+  local proj foreign wt data state config id out status before
+  id="orcamixedfamilyz5"
+  proj="$TMP_ROOT/mixed-orca-project"
+  foreign="$TMP_ROOT/mixed-orca-foreign"
+  wt="$TMP_ROOT/mixed-orca-wt"
+  data="$TMP_ROOT/mixed-orca-data"
+  state="$TMP_ROOT/mixed-orca-state"
+  config="$TMP_ROOT/mixed-orca-config"
+  fm_git_init_commit "$proj"
+  fm_git_worktree "$foreign" "$wt" "fm/$id"
+  mkdir -p "$data/$id" "$state" "$config"
+  printf 'brief\n' > "$data/$id/brief.md"
+  touch "$state/.last-watcher-beat"
+  before=$(git -C "$wt" rev-parse HEAD)
+  orca_case mixed-family-spawn
+  printf '1\n' > "$RESP/1.exit"
+  printf '{"ok":true,"result":{"repo":{"id":"repo-mixed-family"}}}\n' > "$RESP/2.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-mixed-family","path":"%s"},"terminal":{"handle":"term-mixed-family"}}}\n' "$wt" > "$RESP/3.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --mode no-mistakes --yolo off --backend orca 2>&1 )
+  status=$?
+  expect_code 1 "$status" "fm-spawn.sh --backend orca should refuse a foreign clone-family worktree"
+  assert_contains "$out" "Git common-directory mismatch after orca worktree create" \
+    "Orca spawn did not use the shared clone-family guard"
+  assert_contains "$out" "Orca worktree id 'wt-mixed-family', terminal 'term-mixed-family'" \
+    "Orca mismatch refusal did not retain precise allocation identifiers"
+  assert_contains "$out" "preserved in place" \
+    "Orca mismatch refusal did not explain that the allocation was retained"
+  [ "$(git -C "$wt" rev-parse HEAD)" = "$before" ] \
+    || fail "Orca mismatch refusal changed the allocated worktree HEAD"
+  assert_absent "$state/$id.meta" "Orca mismatch refusal must not publish launched-task metadata"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''send' \
+    "Orca mismatch refusal sent a worker launch command"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
+    "Orca mismatch refusal closed the preserved endpoint"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm' \
+    "Orca mismatch refusal used the provider's forced removal path"
+  pass "fm-spawn.sh --backend orca: preserves a foreign clone-family allocation before worker launch"
+}
+
 test_spawn_removes_orca_worktree_when_terminal_create_fails() {
   local proj wt data state config id out status
   id="orcatermfailz8"
@@ -1354,6 +1397,7 @@ test_spawn_writes_orca_metadata_and_launches_harness
 test_spawn_refuses_orca_secondmate_before_home_mutation
 test_spawn_refuses_orca_when_runtime_not_ready
 test_spawn_refuses_orca_nonisolated_worktree
+test_spawn_preserves_orca_common_dir_mismatch
 test_spawn_removes_orca_worktree_when_terminal_create_fails
 test_spawn_preserves_orca_metadata_when_abort_cleanup_fails
 test_spawn_releases_orca_resources_when_metadata_write_fails

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -646,7 +646,7 @@ test_spawn_preserves_orca_common_dir_mismatch() {
   fm_git_init_commit "$proj"
   fm_git_worktree "$foreign" "$wt" "fm/$id"
   mkdir -p "$data/$id" "$state" "$config"
-  printf 'brief\n' > "$data/$id/brief.md"
+  write_spawn_brief "$data" "$id"
   touch "$state/.last-watcher-beat"
   before=$(git -C "$wt" rev-parse HEAD)
   orca_case mixed-family-spawn
@@ -675,6 +675,47 @@ test_spawn_preserves_orca_common_dir_mismatch() {
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm' \
     "Orca mismatch refusal used the provider's forced removal path"
   pass "fm-spawn.sh --backend orca: preserves a foreign clone-family allocation before worker launch"
+}
+
+test_spawn_preserves_terminal_less_orca_common_dir_mismatch() {
+  local proj foreign wt data state config id out status before
+  id="orcamixednotermz6"
+  proj="$TMP_ROOT/mixed-orca-no-terminal-project"
+  foreign="$TMP_ROOT/mixed-orca-no-terminal-foreign"
+  wt="$TMP_ROOT/mixed-orca-no-terminal-wt"
+  data="$TMP_ROOT/mixed-orca-no-terminal-data"
+  state="$TMP_ROOT/mixed-orca-no-terminal-state"
+  config="$TMP_ROOT/mixed-orca-no-terminal-config"
+  fm_git_init_commit "$proj"
+  fm_git_worktree "$foreign" "$wt" "fm/$id"
+  mkdir -p "$data/$id" "$state" "$config"
+  write_spawn_brief "$data" "$id"
+  touch "$state/.last-watcher-beat"
+  before=$(git -C "$wt" rev-parse HEAD)
+  orca_case mixed-family-no-terminal-spawn
+  printf '1\n' > "$RESP/1.exit"
+  printf '{"ok":true,"result":{"repo":{"id":"repo-mixed-no-terminal"}}}\n' > "$RESP/2.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-mixed-no-terminal","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --mode no-mistakes --yolo off --backend orca 2>&1 )
+  status=$?
+  expect_code 1 "$status" "fm-spawn.sh --backend orca should refuse a terminal-less foreign clone-family worktree"
+  assert_contains "$out" "task 'fm-$id', Orca worktree id 'wt-mixed-no-terminal'" \
+    "terminal-less Orca mismatch refusal did not retain available allocation identifiers"
+  assert_contains "$out" "allocated local copy and any existing endpoint are preserved in place" \
+    "terminal-less Orca mismatch refusal claimed a nonexistent endpoint was preserved"
+  assert_not_contains "$out" "terminal '" \
+    "terminal-less Orca mismatch refusal invented a terminal identifier"
+  [ "$(git -C "$wt" rev-parse HEAD)" = "$before" ] \
+    || fail "terminal-less Orca mismatch refusal changed the allocated worktree HEAD"
+  assert_absent "$state/$id.meta" "terminal-less Orca mismatch refusal must not publish launched-task metadata"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal' \
+    "terminal-less Orca mismatch refusal created, launched, or closed a terminal"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm' \
+    "terminal-less Orca mismatch refusal used the provider's forced removal path"
+  pass "fm-spawn.sh --backend orca: preserves a terminal-less foreign allocation before worker launch"
 }
 
 test_spawn_removes_orca_worktree_when_terminal_create_fails() {
@@ -1398,6 +1439,7 @@ test_spawn_refuses_orca_secondmate_before_home_mutation
 test_spawn_refuses_orca_when_runtime_not_ready
 test_spawn_refuses_orca_nonisolated_worktree
 test_spawn_preserves_orca_common_dir_mismatch
+test_spawn_preserves_terminal_less_orca_common_dir_mismatch
 test_spawn_removes_orca_worktree_when_terminal_create_fails
 test_spawn_preserves_orca_metadata_when_abort_cleanup_fails
 test_spawn_releases_orca_resources_when_metadata_write_fails

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -403,7 +403,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
     FM_FAKE_TRACE_RELEASE="$launch_release" \
     run_control "$dir" rl28 relaunch --note "continue after publication" > "$dir/control.out" &
   control_pid=$!
-  while [ ! -e "$prepare" ] && [ "$i" -lt 200 ]; do
+  while [ ! -e "$prepare" ] && [ "$i" -lt 500 ]; do
     /bin/sleep 0.01
     i=$((i + 1))
   done

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -14,16 +14,19 @@ set -u
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-batch)
+mkdir -p "$TMP_ROOT/config"
 export FM_BACKEND=tmux
 
-# Clear ambient firstmate overrides so the behavior test owns its environment.
+# Clear ambient firstmate overrides and use an empty config directory so the
+# behavior test owns its environment even when the invoking worktree has a
+# local crew-dispatch profile.
 run_spawn() {
   FM_ROOT_OVERRIDE='' \
     FM_HOME='' \
     FM_STATE_OVERRIDE='' \
     FM_DATA_OVERRIDE='' \
     FM_PROJECTS_OVERRIDE='' \
-    FM_CONFIG_OVERRIDE='' \
+    FM_CONFIG_OVERRIDE="$TMP_ROOT/config" \
     FM_SPAWN_NO_GUARD=1 \
     "$SPAWN" "$@" 2>&1
 }

--- a/tests/fm-spawn-common-dir.test.sh
+++ b/tests/fm-spawn-common-dir.test.sh
@@ -73,7 +73,7 @@ snapshot_mixed_slot() {  # <slot> <foreign-clone>
     GIT_OPTIONAL_LOCKS=0 git -C "$foreign" worktree list --porcelain
     printf '%s\n' '--- refs ---'
     GIT_OPTIONAL_LOCKS=0 git -C "$foreign" for-each-ref \
-      --format='%(refname)%09%(objectname)' refs/heads refs/remotes refs/stash
+      --format='%(refname)%09%(objectname)%09%(symref)'
     printf '%s\n' '--- worktree git pointer ---'
     cat "$slot/.git"
   }
@@ -104,6 +104,10 @@ EOF
   git clone --quiet --bare "$seed" "$origin"
   git clone --quiet "file://$origin" "$project"
   git clone --quiet "file://$origin" "$foreign"
+  printf 'stashed local evidence\n' >> "$foreign/tracked-staged.txt"
+  git -C "$foreign" stash push --quiet -m preserved-stash -- tracked-staged.txt
+  git -C "$foreign" tag -a preserved-tag -m preserved-tag HEAD
+  git -C "$foreign" update-ref refs/firstmate/preserved-custom HEAD
   git -C "$foreign" worktree add --quiet -b fm/mixed-slot "$slot" HEAD
 
   printf 'staged local change\n' > "$slot/tracked-staged.txt"
@@ -125,6 +129,12 @@ EOF
   before="$case_dir/before.snapshot"
   after="$case_dir/after.snapshot"
   snapshot_mixed_slot "$slot" "$foreign" > "$before"
+  assert_contains "$(cat "$before")" 'refs/stash' \
+    "mixed fixture did not seed a stash ref"
+  assert_contains "$(cat "$before")" 'refs/tags/preserved-tag' \
+    "mixed fixture did not seed a tag ref"
+  assert_contains "$(cat "$before")" 'refs/firstmate/preserved-custom' \
+    "mixed fixture did not seed a custom ref"
 
   out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \

--- a/tests/fm-spawn-common-dir.test.sh
+++ b/tests/fm-spawn-common-dir.test.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Regression coverage for fm-spawn's post-allocation Git common-directory
+# ownership check.
+#
+# A shared Treehouse pool can contain slots from two clones of the same remote.
+# The requested project path therefore cannot identify the clone family of the
+# allocated worktree. This test drives the real spawn path with a deliberately
+# mixed allocation and proves rejection happens before launch without changing
+# any Git or filesystem state in the foreign slot.
+set -u
+
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-common-dir)
+
+make_mixed_fakebin() {  # <dir>
+  local fakebin
+  fakebin=$(fm_fakebin "$1")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ -n "${FM_FAKE_SEND_LOG:-}" ] && [ "${1:-}" = send-keys ]; then
+  {
+    printf 'tmux'
+    for arg in "$@"; do printf '\x1f%s' "$arg"; done
+    printf '\n'
+  } >> "$FM_FAKE_SEND_LOG"
+fi
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|set-window-option|send-keys|kill-window) exit 0 ;;
+  new-window) printf '@mixed\n'; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+snapshot_mixed_slot() {  # <slot> <foreign-clone>
+  local slot=$1 foreign=$2 index
+  index=$(git -C "$slot" rev-parse --git-path index)
+  {
+    printf '%s\n' '--- branch ---'
+    git -C "$slot" symbolic-ref HEAD
+    printf '%s\n' '--- HEAD ---'
+    git -C "$slot" rev-parse HEAD
+    printf '%s\n' '--- semantic index tree ---'
+    git -C "$slot" write-tree
+    printf '%s\n' '--- index bytes ---'
+    git hash-object --no-filters "$index"
+    printf '%s\n' '--- tracked file bytes ---'
+    git hash-object --no-filters \
+      "$slot/tracked-staged.txt" "$slot/tracked-unstaged.txt"
+    printf '%s\n' '--- untracked and ignored file bytes ---'
+    git hash-object --no-filters \
+      "$slot/untracked-preserve.txt" "$slot/ignored-preserve.txt"
+    printf '%s\n' '--- status including ignored paths ---'
+    GIT_OPTIONAL_LOCKS=0 git -C "$slot" -c core.quotePath=false \
+      status --porcelain=v2 --branch --untracked-files=all --ignored=matching
+    printf '%s\n' '--- staged diff ---'
+    GIT_OPTIONAL_LOCKS=0 git -C "$slot" diff --cached --binary
+    printf '%s\n' '--- unstaged diff ---'
+    GIT_OPTIONAL_LOCKS=0 git -C "$slot" diff --binary
+    printf '%s\n' '--- worktree registry ---'
+    GIT_OPTIONAL_LOCKS=0 git -C "$foreign" worktree list --porcelain
+    printf '%s\n' '--- refs ---'
+    GIT_OPTIONAL_LOCKS=0 git -C "$foreign" for-each-ref \
+      --format='%(refname)%09%(objectname)' refs/heads refs/remotes refs/stash
+    printf '%s\n' '--- worktree git pointer ---'
+    cat "$slot/.git"
+  }
+}
+
+test_mixed_clone_family_is_refused_unchanged_before_launch() {
+  local case_dir seed origin project foreign slot home fakebin id send_log
+  local project_common slot_common before after out status
+  case_dir="$TMP_ROOT/mixed-family"
+  seed="$case_dir/seed"
+  origin="$case_dir/origin.git"
+  project="$case_dir/requested-project"
+  foreign="$case_dir/foreign-clone"
+  slot="$case_dir/mixed-slot"
+  home="$case_dir/home"
+  id='mixed-common-dir-z1'
+  send_log="$case_dir/send.log"
+
+  fm_git_identity
+  git init --quiet -b main "$seed"
+  cat > "$seed/.gitignore" <<'EOF'
+ignored-preserve.txt
+EOF
+  printf 'committed staged file\n' > "$seed/tracked-staged.txt"
+  printf 'committed unstaged file\n' > "$seed/tracked-unstaged.txt"
+  git -C "$seed" add .gitignore tracked-staged.txt tracked-unstaged.txt
+  git -C "$seed" commit --quiet -m initial
+  git clone --quiet --bare "$seed" "$origin"
+  git clone --quiet "file://$origin" "$project"
+  git clone --quiet "file://$origin" "$foreign"
+  git -C "$foreign" worktree add --quiet -b fm/mixed-slot "$slot" HEAD
+
+  printf 'staged local change\n' > "$slot/tracked-staged.txt"
+  git -C "$slot" add tracked-staged.txt
+  printf 'unstaged local change\n' > "$slot/tracked-unstaged.txt"
+  printf 'untracked local evidence\n' > "$slot/untracked-preserve.txt"
+  printf 'ignored private evidence\n' > "$slot/ignored-preserve.txt"
+
+  fm_test_spawn_home "$home" codex
+  fm_test_spawn_brief "$home" "$id" 'Delivery contract: mode=no-mistakes'
+  fakebin=$(make_mixed_fakebin "$case_dir/fake")
+  : > "$send_log"
+
+  project_common=$(git -C "$project" rev-parse --path-format=absolute --git-common-dir)
+  slot_common=$(git -C "$slot" rev-parse --path-format=absolute --git-common-dir)
+  [ "$project_common" != "$slot_common" ] \
+    || fail "mixed fixture did not create two distinct Git common directories"
+
+  before="$case_dir/before.snapshot"
+  after="$case_dir/after.snapshot"
+  snapshot_mixed_slot "$slot" "$foreign" > "$before"
+
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX='fake,1,0' FM_FAKE_PANE_PATH="$slot" \
+    FM_FAKE_SEND_LOG="$send_log" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$project" --mode no-mistakes --yolo off 2>&1)
+  status=$?
+
+  [ "$status" -ne 0 ] || fail "spawn accepted a worktree from a foreign clone family"
+  assert_contains "$out" 'Git common-directory mismatch' \
+    "spawn did not identify the clone-family mismatch"
+  assert_contains "$out" "$project_common" \
+    "spawn did not report the requested project's absolute Git common directory"
+  assert_contains "$out" "$slot_common" \
+    "spawn did not report the allocated worktree's absolute Git common directory"
+  assert_contains "$out" 'preserved in place' \
+    "spawn did not explain that the unsafe allocation was retained"
+  assert_contains "$out" 'do not force-return, clean, reset, or remove this allocation' \
+    "spawn did not provide the non-destructive recovery boundary"
+
+  snapshot_mixed_slot "$slot" "$foreign" > "$after"
+  cmp -s "$before" "$after" \
+    || fail "mismatch rejection changed branch, HEAD, index, files, refs, status, or worktree registration"
+  assert_contains "$(cat "$send_log")" 'treehouse get' \
+    "fixture did not exercise the post-Treehouse-allocation path"
+  assert_not_contains "$(cat "$send_log")" 'treehouse return' \
+    "mismatch rejection attempted to return the allocation"
+  assert_not_contains "$(cat "$send_log")" 'codex' \
+    "mismatch rejection handed a worker launch command to the endpoint"
+  assert_absent "$home/state/$id.meta" \
+    "mismatch rejection published task metadata despite refusing before launch"
+
+  pass "fm-spawn rejects a mixed clone-family allocation before launch and preserves all slot state"
+}
+
+test_mixed_clone_family_is_refused_unchanged_before_launch
+
+echo '# all fm-spawn common-directory tests passed'


### PR DESCRIPTION
## Intent

Implement the shared Firstmate safety prerequisite that rejects a project-worker allocation when the allocated worktree's Git common directory does not match the requested project's Git common directory. The approved DTM intake is blocked because shared Treehouse pools contain worktrees from multiple clone families. Use the current spawn, Treehouse allocation, backend, return, and test ownership rather than stale report line numbers, and keep this enforcement in the single shared post-allocation owner for every supported project-worker backend instead of duplicating it per adapter. After allocation and before any worker process starts, resolve the requested project's and allocated worktree's absolute Git common directories and refuse any mismatch. Use only a supported non-cleaning allocation-return or quarantine path; because no such safe path exists, preserve the allocation in place and return a precise actionable failure rather than inventing cleanup. Portable regression coverage must deliberately allocate from a mixed clone family, prove rejection occurs before worker launch, and prove branch, HEAD, index, tracked files, untracked files, ignored files, refs, and worktree state remain unchanged. Preserve every project clone, pool slot, branch, stash, credential, ignored file, untracked file, and existing task. Do not drain, rebuild, clean, reset, prune, move, delete, force-return, or otherwise repair either DTM clone family or pool. Update operator or maintainer documentation only where current ownership requires it, following the one-owner and documentation-audience contracts. Validate relevant spawn, Treehouse, backend, lint, and documentation checks. Deliver a green pull request but never merge it.

## What Changed

- Compare the requested project’s and allocated worktree’s absolute Git common directories in the shared post-allocation spawn guard for Treehouse and Orca.
- Refuse mismatches before worker launch, preserving the allocation and endpoint in place with actionable reconciliation details.
- Add mixed-clone regression coverage for pre-launch rejection and preservation of Git and filesystem state, and document the shared ownership boundary.

## Risk Assessment

✅ Low: The shared post-allocation guard covers all supported project-worker backends, fails before worker launch, and preserves mismatched allocations without destructive cleanup.

## Testing

Starting from a clean target worktree, targeted Treehouse, shared spawn, Orca, and settle-path tests passed; an end-to-end mixed-clone allocation was rejected with actionable CLI output before launch, while branch, HEAD, index, tracked/untracked/ignored files, refs, stash, and worktree registration remained byte-for-byte unchanged, and final status stayed clean.

<details>
<summary>Evidence: Mixed clone-family allocation rejection and preservation transcript</summary>

Source: [Mixed clone-family allocation rejection and preservation transcript](https://github.com/Charliekirk-creator/firstmate/blob/23762965ee4b377badb444b3920bb075d5e1d7ad/.no-mistakes/evidence/fm/firstmate-project-common-dir-allocation-guard/mixed-clone-family-cli-transcript.txt)

```text
FIRSTMATE MIXED-CLONE ALLOCATION — END-USER CLI EVIDENCE
requested_project_common_dir=/private/var/folders/l9/13blqg851n3bj8p1b_3lxxk00000gn/T/fm-common-dir-evidence.ktA9fI/requested-project/.git
allocated_worktree_common_dir=/private/var/folders/l9/13blqg851n3bj8p1b_3lxxk00000gn/T/fm-common-dir-evidence.ktA9fI/foreign-clone/.git
spawn_exit=1
--- fm-spawn response ---
error: Git common-directory mismatch after treehouse get: requested project '/private/var/folders/l9/13blqg851n3bj8p1b_3lxxk00000gn/T/fm-common-dir-evidence.ktA9fI/requested-project' uses '/private/var/folders/l9/13blqg851n3bj8p1b_3lxxk00000gn/T/fm-common-dir-evidence.ktA9fI/requested-project/.git', but allocated worktree '/private/var/folders/l9/13blqg851n3bj8p1b_3lxxk00000gn/T/fm-common-dir-evidence.ktA9fI/allocated-slot' uses '/private/var/folders/l9/13blqg851n3bj8p1b_3lxxk00000gn/T/fm-common-dir-evidence.ktA9fI/foreign-clone/.git'. Refusing before worker launch. No supported non-cleaning allocation return or quarantine operation is available, so the allocated local copy and any existing endpoint are preserved in place. Inspect firstmate:fm-mixed-family-evidence-z1 and reconcile the mixed clone-family pool or provider through its guarded ownership path before retrying; do not force-return, clean, reset, or remove this allocation
--- preserved allocation state ---
branch=fm/evidence
head=4690e0b102a16c17fb864b1072cbcfd65e6cd52d
before_snapshot_hash=ebfeb07c36a45a72c217d9ff230996fad707f08c
after_snapshot_hash=ebfeb07c36a45a72c217d9ff230996fad707f08c
branch_head_index_files_refs_and_worktree_state_unchanged=yes
--- allocated slot status (including untracked and ignored) ---
## fm/evidence
M  tracked-staged.txt
 M tracked-unstaged.txt
?? untracked-preserve.txt
!! ignored-preserve.txt
treehouse_allocation_exercised=yes
treehouse_return_attempted=no
worker_launch_sent=no
task_metadata_published=no
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c2e3ee8aa6da613e9865c5e70746c93f78928568","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `tests/fm-spawn-common-dir.test.sh:75` - Intent requires portable coverage to “prove ... refs ... remain unchanged,” but the snapshot only captures refs/heads, refs/remotes, and refs/stash, excluding tags and custom refs; the fixture also creates no stash, tag, or custom ref. Snapshot all refs and seed representative non-branch refs so preservation is behaviorally demonstrated.
- ⚠️ `bin/fm-spawn.sh:1891` - Intent requires a “precise actionable failure,” but Orca may return a worktree without a terminal; validation runs before terminal creation at line 2338, yet this message claims an endpoint was preserved. Say “any existing endpoint” or condition the message on ORCA_TERMINAL, and cover the terminal-less mismatch path.

🔧 Fix: Expand ref preservation and terminal-less Orca coverage
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-spawn-common-dir.test.sh tests/fm-backend-orca.test.sh`
- `bin/fm-test-run.sh tests/fm-spawn-worktree-settle.test.sh`
- <code>Manual mixed-clone Treehouse allocation through `bin/fm-spawn.sh mixed-family-evidence-z1 &lt;requested-project&gt; --mode no-mistakes --yolo off`; compared complete pre/post Git snapshots and checked allocation, return, launch, and metadata side effects.</code>
- <code>`git status --short` before and after testing to confirm the worktree remained clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
