### PR TITLE
fix(crew-state): stop reporting passed runs as PR merged/closed

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -499,7 +499,7 @@ if [ "$HAVE_RUN" = 1 ]; then
 
     if [ -n "$outcome" ]; then
       case "$outcome" in
-        passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR merged/closed" ;;
+        passed)        RUN_STATE="done"; RUN_DETAIL="run passed" ;;
         checks-passed) RUN_STATE="done"; RUN_DETAIL="checks green: PR ready for review" ;;
         failed)        RUN_STATE=failed; RUN_DETAIL="run failed" ;;
         cancelled)     RUN_STATE=failed; RUN_DETAIL="run cancelled" ;;

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -668,6 +668,10 @@ test_terminal_passed() {
   local out; out=$(run_crew_state "$d" feat-d)
   assert_contains "$out" "state: done" "passed run -> done"
   assert_contains "$out" "source: run-step" "passed -> run-step source"
+  assert_contains "$out" "state: done · source: run-step · run passed" \
+    "passed run reports its result"
+  assert_not_contains "$out" "merged" "passed run does not claim the PR merged"
+  assert_not_contains "$out" "closed" "passed run does not claim the PR closed"
   pass "terminal passed run is authoritative"
 }
 


### PR DESCRIPTION
## Intent

Stop bin/fm-crew-state.sh from claiming a pull request merged when nothing landed. In the passed outcome mapping, run completion must not be presented as PR merged or closed: passed establishes only that the validation run completed successfully, not the pull request's forge merge or closure state. Report the known run result. Keep the checks-passed arm unchanged and prefer the small wording-only change; do not add a live forge read because it must be cheap and reliable at every call site, and wrong-but-quiet reporting is the defect. Add a colocated behavioral regression test through the executable/public interface that pins the passed-outcome wording and verifies a completed run with an open, unmerged PR is never described as merged or closed. Keep the diff tight and do not refactor the state reader. Do not include, depend on, or work around PR 3328's separate active-run trust changes. Do not push commits trying to turn action_required CI or Require no-mistakes gates green, and do not merge. Shellcheck must be clean on touched shell scripts.

## What Changed
- Changed the `passed` outcome mapping in `bin/fm-crew-state.sh` so `RUN_DETAIL` reports `run passed` instead of claiming "PR merged/closed"; the `checks-passed` arm is unchanged.
- Added assertions to `tests/fm-crew-state.test.sh` pinning the passed-outcome wording and verifying a completed run with an unmerged PR is never described as merged or closed.

## Risk Assessment

✅ Low: A minimal wording-only change plus a colocated behavioral regression test that fails pre-fix, with lint clean and no reachable path left claiming merge/closure for a passed run.

## Testing

Exercised the change through bin/fm-crew-state.sh's public CLI: the focused fm-crew-state suite passes with the new passed-outcome wording assertions, the new test was proven to fail against the pre-fix script (true regression coverage), shellcheck is clean on both touched scripts under the project's lint config, and a manual CLI transcript captured the actual user-visible output "state: done · source: run-step · run passed" for a completed run with an open unmerged PR — no merge or closure claim.

<details>
<summary>Evidence: fm-crew-state.sh CLI transcript for a completed passed run with an open, unmerged PR</summary>

Source: [fm-crew-state.sh CLI transcript for a completed passed run with an open, unmerged PR](https://github.com/hajekt2/firstmate/blob/e13c4d3e86c4cf9f15e86fade85fb2e460b0a39c/.no-mistakes/evidence/fm/fm-crewstate-passed-claims-merged/fm-crew-state-passed-open-pr-transcript.txt)

<code>$ bin/fm-crew-state.sh feat-openpr # completed passed run, PR #1 still open&#10;state: done · source: run-step · run passed&#10;&#10;$ bin/fm-crew-state.sh feat-openpr | grep -iE &#34;merged|closed&#34; || echo &#34;no merged/closed claim in output&#34;&#10;no merged/closed claim in output</code>

```text
$ bin/fm-crew-state.sh feat-openpr   # completed passed run, PR #1 still open
state: done · source: run-step · run passed

$ bin/fm-crew-state.sh feat-openpr | grep -iE "merged|closed" || echo "no merged/closed claim in output"
no merged/closed claim in output
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f2a023414a8573598f317ff4b1484c92416d7f7e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-crew-state.test.sh` — full focused crew-state behavior suite passes, including `test_terminal_passed` with the new assertions (asserts &#34;state: done · source: run-step · run passed&#34; and absence of &#34;merged&#34;/&#34;closed&#34;) against the real bin/fm-crew-state.sh executable via the harness fake no-mistakes/tmux/herdr drivers</code>
- `Regression proof: temporarily checked out the base-commit bin/fm-crew-state.sh (0866a77) and re-ran the suite — the new assertion fails with "not ok - passed run does not claim the PR merged (unexpected: 'merged')", then restored the fixed script and confirmed byte-identical restoration`
- <code>`shellcheck --norc --external-sources bin/fm-crew-state.sh tests/fm-crew-state.test.sh` — clean under the project&#39;s pinned shellcheck 0.11.0 and fm-lint.sh&#39;s exact invocation flags, satisfying the shellcheck requirement on touched scripts</code>
- <code>Manual end-to-end CLI check mirroring the end-user surface: invoked bin/fm-crew-state.sh directly against the harness fixture (completed run, outcome passed, PR open and unmerged) and captured the transcript showing `state: done · source: run-step · run passed` with grep confirming no merged/closed claim</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-crew-state.sh:318` - The nm_ci_checks_state rationale comment still states that for captain-merge repos no-mistakes &#39;only reaches outcome=passed once the PR is actually merged&#39;. This is pre-existing historical incident evidence for the ci-log check and was not made stale by this change (which altered only the passed-outcome presentation wording), so it was left untouched per scope discipline. It does carry a residual implication (passed implies merged) that contrasts with this change&#39;s premise that passed establishes only run completion; a future maintainer reconciling that comment with the new conservative wording may want to soften it, but verifying current no-mistakes outcome semantics was out of scope for this documentation pass.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
