### PR TITLE
feat(bin): mandate a base-freshness check in generated crewmate briefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -519,6 +519,7 @@ Use its scaffold as the contract, then replace every `{TASK}` placeholder with a
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.
+Every ship and scout brief must equally retain the base-freshness check that precedes any other read or write, and a ship brief keeps it ahead of its branch step.
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -13,10 +13,12 @@
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
 #   repo-name stays a free-form caller-supplied label. It is resolved best-effort
 #   under FM_PROJECTS_OVERRIDE when set, otherwise under $FM_HOME/projects;
-#   projects/<repo-name> and explicit directory paths work too. A repo that
-#   resolves renders its real default branch into the startup base-freshness
-#   check; one that does not still gets the same mandatory check, deferred to the
-#   worker at runtime. An unresolvable label never fails the scaffold.
+#   projects/<repo-name>, explicit directory paths, and a bare name relative to
+#   the caller's cwd work too. Resolution only succeeds when the candidate is
+#   itself a git work-tree ROOT. A repo that resolves renders its real default
+#   branch into the startup base-freshness check; one that does not still gets
+#   the same mandatory check, deferred to the worker at runtime. An unresolvable
+#   label never fails the scaffold.
 #   --secondmate writes a persistent secondmate charter. The project list
 #   is cloned into the secondmate home, while the natural-language scope
 #   tells the main firstmate when to route work there; routine churn stays in its own home;
@@ -88,8 +90,6 @@ esac
 . "$SCRIPT_DIR/fm-classify-lib.sh"
 # shellcheck source=bin/fm-dod-lib.sh
 . "$SCRIPT_DIR/fm-dod-lib.sh"
-# shellcheck source=bin/fm-tangle-lib.sh
-. "$SCRIPT_DIR/fm-tangle-lib.sh"
 PAUSED_VERB=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
 
 resolve_directory_input() {
@@ -208,23 +208,37 @@ resolve_brief_repo() {  # <repo-name-or-directory>
       ;;
   esac
   [ -d "$candidate" ] || return 1
-  git -C "$candidate" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
   resolved=$(CDPATH='' cd -- "$candidate" 2>/dev/null && pwd -P) || return 1
+  # Must BE a work tree root, not merely sit inside one: `projects/` is a
+  # gitignored subdirectory of the firstmate checkout, so an inside-a-work-tree
+  # test resolves any `projects/<name>` that is not itself a clone to the
+  # firstmate repo and renders ITS default branch as that project's base.
+  [ "$(git -C "$resolved" rev-parse --show-toplevel 2>/dev/null)" = "$resolved" ] || return 1
   printf '%s\n' "$resolved"
+}
+
+origin_default_branch_name() {  # <repo-dir>
+  local repo=$1 ref
+  ref=$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null) || return 1
+  case "$ref" in
+    origin/*) printf '%s\n' "${ref#origin/}" ;;
+    *) return 1 ;;
+  esac
 }
 
 # origin/HEAD only supplies the NAME; the comparison must still target the
 # clone's local branch, which may legitimately be ahead of origin. Resolution
 # never reads HEAD: a primary stranded on a feature branch (the worktree tangle
 # bin/fm-tangle-lib.sh exists to detect) would otherwise have that feature branch
-# rendered into the brief as its own base. fm_default_branch encodes the same
-# origin/HEAD-then-local-main/master order the rest of the fleet uses; the loop
-# below covers the residual case where origin names a branch this clone has no
-# local ref for.
+# rendered into the brief as its own base. When origin names a default this clone
+# has no local ref for, resolution FAILS rather than substituting main/master:
+# origin/HEAD is the authority, and presenting some other branch as "your local
+# default branch" would be the same confidently-wrong base this check exists to
+# catch. The main/master guess applies only where no authority exists at all.
 resolve_local_default_branch() {  # <repo-dir>
   local repo=$1 branch
-  if branch=$(fm_default_branch "$repo" 2>/dev/null) \
-    && git -C "$repo" rev-parse --verify --quiet "refs/heads/$branch^{commit}" >/dev/null 2>&1; then
+  if branch=$(origin_default_branch_name "$repo"); then
+    git -C "$repo" rev-parse --verify --quiet "refs/heads/$branch^{commit}" >/dev/null 2>&1 || return 1
     printf '%s\n' "$branch"
     return 0
   fi
@@ -238,12 +252,8 @@ resolve_local_default_branch() {  # <repo-dir>
 }
 
 resolve_origin_default_branch() {  # <repo-dir>
-  local repo=$1 ref branch
-  ref=$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null) || return 1
-  case "$ref" in
-    origin/*) branch=${ref#origin/} ;;
-    *) return 1 ;;
-  esac
+  local repo=$1 branch
+  branch=$(origin_default_branch_name "$repo") || return 1
   git -C "$repo" rev-parse --verify --quiet "refs/remotes/origin/$branch^{commit}" >/dev/null 2>&1 || return 1
   printf '%s\n' "$branch"
 }
@@ -373,42 +383,43 @@ REPO=${POS[1]}
 BASE_REF=
 BASE_DESCRIPTION=
 BASE_NEEDS_FETCH=0
+BASE_NO_FETCH_REASON=
 BASE_UNRESOLVED_REASON=
 case "$KIND:$MODE" in
   ship:local-only) BASE_FALLBACK_KIND=local ;;
   *) BASE_FALLBACK_KIND=origin ;;
 esac
 
+set_origin_base() {  # <repo-dir>
+  local branch
+  branch=$(resolve_origin_default_branch "$1") || return 1
+  BASE_REF="origin/$branch"
+  BASE_DESCRIPTION="the freshly fetched default branch \`$BASE_REF\`"
+  BASE_NEEDS_FETCH=1
+}
+
+set_local_base() {  # <repo-dir> <why-no-fetch>
+  local branch
+  branch=$(resolve_local_default_branch "$1") || return 1
+  BASE_REF=$branch
+  BASE_DESCRIPTION="your local default branch \`$branch\`"
+  BASE_NO_FETCH_REASON=$2
+}
+
 if REPO_DIR=$(resolve_brief_repo "$REPO"); then
   case "$KIND:$MODE" in
     ship:local-only)
-      if DEFAULT_BRANCH=$(resolve_local_default_branch "$REPO_DIR"); then
-        BASE_REF=$DEFAULT_BRANCH
-        BASE_DESCRIPTION="your local default branch \`$DEFAULT_BRANCH\`"
-      else
-        BASE_UNRESOLVED_REASON="This brief could not determine the local default branch of \`$REPO\`"
-      fi
+      set_local_base "$REPO_DIR" "This task lands locally, so do not fetch" \
+        || BASE_UNRESOLVED_REASON="This brief could not determine the local default branch of \`$REPO\`"
       ;;
     ship:*)
-      if DEFAULT_BRANCH=$(resolve_origin_default_branch "$REPO_DIR"); then
-        BASE_REF="origin/$DEFAULT_BRANCH"
-        BASE_DESCRIPTION="the freshly fetched default branch \`$BASE_REF\`"
-        BASE_NEEDS_FETCH=1
-      else
-        BASE_UNRESOLVED_REASON="This brief could not determine origin's default branch for \`$REPO\`"
-      fi
+      set_origin_base "$REPO_DIR" \
+        || BASE_UNRESOLVED_REASON="This brief could not determine origin's default branch for \`$REPO\`"
       ;;
     scout:*)
-      if DEFAULT_BRANCH=$(resolve_origin_default_branch "$REPO_DIR"); then
-        BASE_REF="origin/$DEFAULT_BRANCH"
-        BASE_DESCRIPTION="the freshly fetched default branch \`$BASE_REF\`"
-        BASE_NEEDS_FETCH=1
-      elif DEFAULT_BRANCH=$(resolve_local_default_branch "$REPO_DIR"); then
-        BASE_REF=$DEFAULT_BRANCH
-        BASE_DESCRIPTION="your local default branch \`$DEFAULT_BRANCH\`"
-      else
-        BASE_UNRESOLVED_REASON="This brief could not determine a default branch for \`$REPO\`"
-      fi
+      set_origin_base "$REPO_DIR" \
+        || set_local_base "$REPO_DIR" "Origin's default branch could not be resolved, so do not fetch" \
+        || BASE_UNRESOLVED_REASON="This brief could not determine a default branch for \`$REPO\`"
       ;;
   esac
 else
@@ -449,7 +460,7 @@ $step. **Check your base before starting work.** Refresh the remote exactly once
 EOF
   else
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
-$step. **Check your base before starting work.** This task lands locally, so do not fetch; measure against the local branch:
+$step. **Check your base before starting work.** $BASE_NO_FETCH_REASON; measure against the local branch:
    \`git rev-list --count \$(git merge-base HEAD $BASE_REF)..$BASE_REF\`
    Only \`0\` passes against $BASE_DESCRIPTION.
    If the count is not \`0\`, rebase onto \`$BASE_REF\` before reading or writing anything.
@@ -559,7 +570,11 @@ case "$MODE" in
     ;;
   local-only)
     SETUP2=""
-    RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
+    if [ -n "$BASE_REF" ]; then
+      RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`$BASE_REF\`."
+    else
+      RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into the local default branch you resolved in Setup."
+    fi
     ;;
   *)  # no-mistakes
     SETUP2="

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -445,7 +445,7 @@ fi
 # The one rule for naming a LOCAL default branch at runtime, shared by every
 # fallback that has to fall back to one so their wording cannot drift apart.
 IFS= read -r -d '' LOCAL_DEFAULT_RULE <<EOF || true
-   Read \`git symbolic-ref --quiet --short refs/remotes/origin/HEAD\`. If it names a branch, that name with the leading \`origin/\` dropped IS \`<default>\`: confirm the local branch exists with \`git rev-parse --verify <default>\`, and if it does not, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
+   Read \`git symbolic-ref --quiet refs/remotes/origin/HEAD\`. If it names a ref, that ref with the leading \`refs/remotes/origin/\` dropped IS \`<default>\`: confirm the local branch exists with \`git rev-parse --verify refs/heads/<default>\`, and if it does not, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
    Only when that ref is absent entirely may \`<default>\` be the local \`main\` or \`master\`, confirmed the same way. Never substitute \`main\`, \`master\`, or whatever branch happens to be checked out for a default branch this clone is missing, and append the same \`blocked:\` line and stop if none of these resolves.
 EOF
 LOCAL_DEFAULT_RULE=${LOCAL_DEFAULT_RULE%$'\n'}
@@ -456,7 +456,7 @@ build_base_freshness_section() {  # <step-number>
   if [ -n "$BASE_UNRESOLVED_REASON" ] && [ "$BASE_POLICY" = 'origin-then-local' ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
-   Try origin first: run \`git remote set-head origin --auto\`, then read \`git symbolic-ref --quiet --short refs/remotes/origin/HEAD\` and drop the leading \`origin/\` to get \`<default>\`.
+   Try origin first: run \`git remote set-head origin --auto\`, then read \`git symbolic-ref --quiet refs/remotes/origin/HEAD\` and drop the leading \`refs/remotes/origin/\` to get \`<default>\`.
    If that names a branch, refresh the remote exactly once BEFORE verifying or comparing its tracking ref - the fetch is what creates a pruned or never-fetched \`origin/<default>\`:
    \`git fetch origin --quiet\`
    If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
@@ -472,7 +472,7 @@ EOF
   elif [ -n "$BASE_UNRESOLVED_REASON" ] && [ "$BASE_POLICY" = origin ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
-   Determine \`<default>\` with \`git remote set-head origin --auto\` then \`git symbolic-ref --quiet --short refs/remotes/origin/HEAD\`, dropping the leading \`origin/\`. Never substitute whatever branch happens to be checked out.
+   Determine \`<default>\` with \`git remote set-head origin --auto\` then \`git symbolic-ref --quiet refs/remotes/origin/HEAD\`, dropping the leading \`refs/remotes/origin/\`. Never substitute whatever branch happens to be checked out.
    If you cannot determine it, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
    Then refresh the remote exactly once and measure:
    \`git fetch origin --quiet\`

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -381,6 +381,7 @@ REPO=${POS[1]}
 # mandate a single `git fetch origin --quiet` first. Scouts have no delivery
 # mode: prefer the remote path, and otherwise use their local base.
 BASE_REF=
+BASE_SHELL_REF=
 BASE_DESCRIPTION=
 BASE_NEEDS_FETCH=0
 BASE_NO_FETCH_REASON=
@@ -395,6 +396,7 @@ set_origin_base() {  # <repo-dir>
   local branch
   branch=$(resolve_origin_default_branch "$1") || return 1
   BASE_REF="origin/$branch"
+  BASE_SHELL_REF=$(shell_quote "$BASE_REF")
   BASE_DESCRIPTION="the freshly fetched default branch \`$BASE_REF\`"
   BASE_NEEDS_FETCH=1
 }
@@ -403,6 +405,7 @@ set_local_base() {  # <repo-dir> <why-no-fetch>
   local branch
   branch=$(resolve_local_default_branch "$1") || return 1
   BASE_REF=$branch
+  BASE_SHELL_REF=$(shell_quote "$BASE_REF")
   BASE_DESCRIPTION="your local default branch \`$branch\`"
   BASE_NO_FETCH_REASON=$2
 }
@@ -477,17 +480,17 @@ EOF
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** Refresh the remote exactly once, then measure:
    \`git fetch origin --quiet\`
-   \`git rev-list --count \$(git merge-base HEAD $BASE_REF)..$BASE_REF\`
+   \`git rev-list --count \$(git merge-base HEAD $BASE_SHELL_REF)..$BASE_SHELL_REF\`
    Only \`0\` passes against $BASE_DESCRIPTION.
    If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
-   If the count is not \`0\`, rebase onto \`$BASE_REF\` before reading or writing anything.
+   If the count is not \`0\`, rebase onto \`$BASE_SHELL_REF\` before reading or writing anything.
 EOF
   else
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_NO_FETCH_REASON; measure against the local branch:
-   \`git rev-list --count \$(git merge-base HEAD $BASE_REF)..$BASE_REF\`
+   \`git rev-list --count \$(git merge-base HEAD $BASE_SHELL_REF)..$BASE_SHELL_REF\`
    Only \`0\` passes against $BASE_DESCRIPTION.
-   If the count is not \`0\`, rebase onto \`$BASE_REF\` before reading or writing anything.
+   If the count is not \`0\`, rebase onto \`$BASE_SHELL_REF\` before reading or writing anything.
 EOF
   fi
   BASE_FRESHNESS_SECTION=${BASE_FRESHNESS_SECTION%$'\n'}

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -404,6 +404,13 @@ case "$KIND:$MODE" in
   *) BASE_POLICY=origin ;;
 esac
 
+# BASE_REF and BASE_SHELL_REF are two spellings of the same base and are
+# deliberately not interchangeable: BASE_REF is the short readable name used in
+# prose, while BASE_SHELL_REF is what the worker EXECUTES, so it is fully
+# qualified and shell-quoted. git's refname precedence puts `refs/tags/<name>`
+# above both heads and remotes, so an unqualified `release` or `origin/release`
+# lets a same-named TAG decide the pass/fail count this check exists to trust,
+# and the quoting keeps a shell-significant branch name one shell word.
 set_origin_base() {  # <repo-dir>
   local branch
   branch=$(resolve_origin_default_branch "$1") || return 1
@@ -444,6 +451,11 @@ fi
 
 # The one rule for naming a LOCAL default branch at runtime, shared by every
 # fallback that has to fall back to one so their wording cannot drift apart.
+# It has the worker read the FULL `origin/HEAD` ref for the same reason
+# origin_default_branch_name does, and confirm `refs/heads/<default>` rather than
+# a bare `<default>`: git resolves `remotes/origin/<default>` to the tracking
+# ref, which would satisfy a check meant to prove a LOCAL branch exists and leave
+# the worker measuring against origin while its local default is ahead.
 IFS= read -r -d '' LOCAL_DEFAULT_RULE <<EOF || true
    Read \`git symbolic-ref --quiet refs/remotes/origin/HEAD\`. If it names a ref, that ref with the leading \`refs/remotes/origin/\` dropped IS \`<default>\`: confirm the local branch exists with \`git rev-parse --verify refs/heads/<default>\`, and if it does not, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
    Only when that ref is absent entirely may \`<default>\` be the local \`main\` or \`master\`, confirmed the same way. Never substitute \`main\`, \`master\`, or whatever branch happens to be checked out for a default branch this clone is missing, and append the same \`blocked:\` line and stop if none of these resolves.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -427,22 +427,32 @@ else
   BASE_UNRESOLVED_REASON="This brief could not resolve \`$REPO\` to a local checkout"
 fi
 
+# The one rule for naming a LOCAL default branch at runtime, shared by every
+# fallback that has to fall back to one so their wording cannot drift apart.
+IFS= read -r -d '' LOCAL_DEFAULT_RULE <<EOF || true
+   Read \`git symbolic-ref --quiet --short refs/remotes/origin/HEAD\`. If it names a branch, that name with the leading \`origin/\` dropped IS \`<default>\`: confirm the local branch exists with \`git rev-parse --verify <default>\`, and if it does not, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
+   Only when that ref is absent entirely may \`<default>\` be the local \`main\` or \`master\`, confirmed the same way. Never substitute \`main\`, \`master\`, or whatever branch happens to be checked out for a default branch this clone is missing, and append the same \`blocked:\` line and stop if none of these resolves.
+EOF
+LOCAL_DEFAULT_RULE=${LOCAL_DEFAULT_RULE%$'\n'}
+
 # Sets BASE_FRESHNESS_SECTION as the numbered startup step <step-number>.
 build_base_freshness_section() {  # <step-number>
   local step=$1
   if [ -n "$BASE_UNRESOLVED_REASON" ] && [ "$BASE_POLICY" = 'origin-then-local' ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
-   Try origin first: run \`git remote set-head origin --auto\`, then read \`git symbolic-ref --quiet --short refs/remotes/origin/HEAD\` and drop the leading \`origin/\` to get \`<default>\`. If that names a branch, confirm it with \`git rev-parse --verify origin/<default>\`; if the name resolves but the ref does not, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop instead of guessing another branch.
-   With a verified origin default, refresh the remote exactly once and measure:
+   Try origin first: run \`git remote set-head origin --auto\`, then read \`git symbolic-ref --quiet --short refs/remotes/origin/HEAD\` and drop the leading \`origin/\` to get \`<default>\`.
+   If that names a branch, refresh the remote exactly once BEFORE verifying or comparing its tracking ref - the fetch is what creates a pruned or never-fetched \`origin/<default>\`:
    \`git fetch origin --quiet\`
+   If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
+   Then confirm the tracking ref with \`git rev-parse --verify origin/<default>\` and measure:
    \`git rev-list --count \$(git merge-base HEAD origin/<default>)..origin/<default>\`
-   Only \`0\` passes. If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
-   If the count is not \`0\`, rebase onto \`origin/<default>\` before reading or writing anything.
-   Only when this clone has no origin default at all - no \`origin\` remote, or its HEAD cannot be set - use the local default branch, \`main\` or \`master\`, confirmed with \`git rev-parse --verify <default>\`. Do not fetch in that case; measure:
+   Only \`0\` passes. If the count is not \`0\`, rebase onto \`origin/<default>\` before reading or writing anything.
+   If no usable origin default remains after that single fetch - no \`origin\` remote, no \`origin/HEAD\`, or its tracking ref still missing - fall back to a local default branch with NO further network refresh, named by exactly this rule:
+$LOCAL_DEFAULT_RULE
+   Then measure against that local branch:
    \`git rev-list --count \$(git merge-base HEAD <default>)..<default>\`
    Only \`0\` passes, and if the count is not \`0\`, rebase onto \`<default>\` before reading or writing anything.
-   Never substitute whatever branch happens to be checked out. If neither an origin default nor a local default can be determined and verified, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
 EOF
   elif [ -n "$BASE_UNRESOLVED_REASON" ] && [ "$BASE_POLICY" = origin ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
@@ -458,8 +468,7 @@ EOF
   elif [ -n "$BASE_UNRESOLVED_REASON" ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
-   Read \`git symbolic-ref --quiet --short refs/remotes/origin/HEAD\`. If it names a branch, that name with the leading \`origin/\` dropped IS \`<default>\`: confirm the local branch exists with \`git rev-parse --verify <default>\`, and if it does not, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
-   Only when that ref is absent entirely may \`<default>\` be the local \`main\` or \`master\`, confirmed the same way. Never substitute \`main\`, \`master\`, or whatever branch happens to be checked out for a default branch this clone is missing, and append the same \`blocked:\` line and stop if none of these resolves.
+$LOCAL_DEFAULT_RULE
    This task lands locally, so do not fetch; measure against the local branch:
    \`git rev-list --count \$(git merge-base HEAD <default>)..<default>\`
    Only \`0\` passes. If the count is not \`0\`, rebase onto \`<default>\` before reading or writing anything.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -51,6 +51,12 @@
 # Ship briefs open with an explicitly numbered safety contract: 1 worktree
 # isolation, 2 base freshness, 3 branch creation. Nothing is read or written
 # until steps 1 and 2 pass.
+# Which base that check names depends on the delivery path: PR-based modes
+# (no-mistakes, direct-PR) compare against `origin/<default>` after exactly one
+# fetch, local-only compares against the clone's LOCAL default branch with no
+# network refresh, and a scout has no delivery mode so it prefers origin and
+# degrades to the local default. The default branch is always resolved from the
+# repository, never hard-coded to main.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns merge decisions, so yolo is
@@ -217,11 +223,17 @@ resolve_brief_repo() {  # <repo-name-or-directory>
   printf '%s\n' "$resolved"
 }
 
+# Reads the FULL ref, never the `--short` abbreviation: `--short` output is
+# ambiguity-dependent, so a clone that also holds a ref literally named
+# `origin/<default>` (a local branch or a tag) gets `remotes/origin/<default>`
+# back instead. An unparseable answer here is indistinguishable from an absent
+# `origin/HEAD`, which is the one case allowed to fall through to the
+# main/master guess, so this parse must never fail on a resolvable default.
 origin_default_branch_name() {  # <repo-dir>
   local repo=$1 ref
-  ref=$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null) || return 1
+  ref=$(git -C "$repo" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null) || return 1
   case "$ref" in
-    origin/*) printf '%s\n' "${ref#origin/}" ;;
+    refs/remotes/origin/*) printf '%s\n' "${ref#refs/remotes/origin/}" ;;
     *) return 1 ;;
   esac
 }
@@ -483,14 +495,14 @@ $step. **Check your base before starting work.** Refresh the remote exactly once
    \`git rev-list --count \$(git merge-base HEAD $BASE_SHELL_REF)..$BASE_SHELL_REF\`
    Only \`0\` passes against $BASE_DESCRIPTION.
    If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
-   If the count is not \`0\`, rebase onto \`$BASE_SHELL_REF\` before reading or writing anything.
+   If the count is not \`0\`, rebase onto \`$BASE_REF\` before reading or writing anything.
 EOF
   else
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_NO_FETCH_REASON; measure against the local branch:
    \`git rev-list --count \$(git merge-base HEAD $BASE_SHELL_REF)..$BASE_SHELL_REF\`
    Only \`0\` passes against $BASE_DESCRIPTION.
-   If the count is not \`0\`, rebase onto \`$BASE_SHELL_REF\` before reading or writing anything.
+   If the count is not \`0\`, rebase onto \`$BASE_REF\` before reading or writing anything.
 EOF
   fi
   BASE_FRESHNESS_SECTION=${BASE_FRESHNESS_SECTION%$'\n'}

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -57,6 +57,9 @@
 # network refresh, and a scout has no delivery mode so it prefers origin and
 # degrades to the local default. The default branch is always resolved from the
 # repository, never hard-coded to main.
+# Every base ref the brief emits reaches the worker as one shell word: a
+# scaffold-resolved ref is shell-quoted here, and a worker-resolved `<default>`
+# is rendered inside quotes with its substitution rule spelled out.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns merge decisions, so yolo is
@@ -457,10 +460,23 @@ fi
 # ref, which would satisfy a check meant to prove a LOCAL branch exists and leave
 # the worker measuring against origin while its local default is ahead.
 IFS= read -r -d '' LOCAL_DEFAULT_RULE <<EOF || true
-   Read \`git symbolic-ref --quiet refs/remotes/origin/HEAD\`. If it names a ref, that ref with the leading \`refs/remotes/origin/\` dropped IS \`<default>\`: confirm the local branch exists with \`git rev-parse --verify refs/heads/<default>\`, and if it does not, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
+   Read \`git symbolic-ref --quiet refs/remotes/origin/HEAD\`. If it names a ref, that ref with the leading \`refs/remotes/origin/\` dropped IS \`<default>\`: confirm the local branch exists with \`git rev-parse --verify 'refs/heads/<default>'\`, and if it does not, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
    Only when that ref is absent entirely may \`<default>\` be the local \`main\` or \`master\`, confirmed the same way. Never substitute \`main\`, \`master\`, or whatever branch happens to be checked out for a default branch this clone is missing, and append the same \`blocked:\` line and stop if none of these resolves.
 EOF
 LOCAL_DEFAULT_RULE=${LOCAL_DEFAULT_RULE%$'\n'}
+
+# The runtime twin of BASE_SHELL_REF's shell_quote, and the reason every
+# `<default>` below is already wrapped in single quotes: a fallback names a base
+# the WORKER resolves, and git permits refnames holding `$`, backticks and `;`,
+# so a name spliced raw into these commands can split the ref or run as a second
+# command in the worker's shell. Stated once here so the three fallbacks cannot
+# drift apart, exactly like LOCAL_DEFAULT_RULE.
+IFS= read -r -d '' RUNTIME_REF_QUOTING_RULE <<'EOF' || true
+   These commands name the base as `<default>`, a name you resolve at runtime and then substitute yourself.
+   Substitute it inside the single quotes already shown - as in `'refs/heads/<default>'` - so the whole ref stays one shell word, and never paste the resolved name into an unquoted argument.
+   If the resolved name itself contains a single quote, close the quoted run, escape that quote, and reopen it (`'a'\''b'`).
+EOF
+RUNTIME_REF_QUOTING_RULE=${RUNTIME_REF_QUOTING_RULE%$'\n'}
 
 # Sets BASE_FRESHNESS_SECTION as the numbered startup step <step-number>.
 build_base_freshness_section() {  # <step-number>
@@ -468,37 +484,40 @@ build_base_freshness_section() {  # <step-number>
   if [ -n "$BASE_UNRESOLVED_REASON" ] && [ "$BASE_POLICY" = 'origin-then-local' ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
+$RUNTIME_REF_QUOTING_RULE
    Try origin first: run \`git remote set-head origin --auto\`, then read \`git symbolic-ref --quiet refs/remotes/origin/HEAD\` and drop the leading \`refs/remotes/origin/\` to get \`<default>\`.
    If that names a branch, refresh the remote exactly once BEFORE verifying or comparing its tracking ref - the fetch is what creates a pruned or never-fetched \`origin/<default>\`:
    \`git fetch origin --quiet\`
    If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
-   Then confirm the tracking ref with \`git rev-parse --verify refs/remotes/origin/<default>\` and measure:
-   \`git rev-list --count \$(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>\`
-   Only \`0\` passes. If the count is not \`0\`, rebase onto \`refs/remotes/origin/<default>\` before reading or writing anything.
+   Then confirm the tracking ref with \`git rev-parse --verify 'refs/remotes/origin/<default>'\` and measure:
+   \`git rev-list --count \$(git merge-base HEAD 'refs/remotes/origin/<default>')..'refs/remotes/origin/<default>'\`
+   Only \`0\` passes. If the count is not \`0\`, rebase onto \`'refs/remotes/origin/<default>'\` before reading or writing anything.
    If no usable origin default remains after that single fetch - no \`origin\` remote, no \`origin/HEAD\`, or its tracking ref still missing - fall back to a local default branch with NO further network refresh, named by exactly this rule:
 $LOCAL_DEFAULT_RULE
    Then measure against that local branch:
-   \`git rev-list --count \$(git merge-base HEAD refs/heads/<default>)..refs/heads/<default>\`
-   Only \`0\` passes, and if the count is not \`0\`, rebase onto \`refs/heads/<default>\` before reading or writing anything.
+   \`git rev-list --count \$(git merge-base HEAD 'refs/heads/<default>')..'refs/heads/<default>'\`
+   Only \`0\` passes, and if the count is not \`0\`, rebase onto \`'refs/heads/<default>'\` before reading or writing anything.
 EOF
   elif [ -n "$BASE_UNRESOLVED_REASON" ] && [ "$BASE_POLICY" = origin ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
+$RUNTIME_REF_QUOTING_RULE
    Determine \`<default>\` with \`git remote set-head origin --auto\` then \`git symbolic-ref --quiet refs/remotes/origin/HEAD\`, dropping the leading \`refs/remotes/origin/\`. Never substitute whatever branch happens to be checked out.
    If you cannot determine it, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
    Then refresh the remote exactly once and measure:
    \`git fetch origin --quiet\`
-   \`git rev-list --count \$(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>\`
+   \`git rev-list --count \$(git merge-base HEAD 'refs/remotes/origin/<default>')..'refs/remotes/origin/<default>'\`
    Only \`0\` passes. If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
-   If the count is not \`0\`, rebase onto \`refs/remotes/origin/<default>\` before reading or writing anything.
+   If the count is not \`0\`, rebase onto \`'refs/remotes/origin/<default>'\` before reading or writing anything.
 EOF
   elif [ -n "$BASE_UNRESOLVED_REASON" ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
+$RUNTIME_REF_QUOTING_RULE
 $LOCAL_DEFAULT_RULE
    This task lands locally, so do not fetch; measure against the local branch:
-   \`git rev-list --count \$(git merge-base HEAD refs/heads/<default>)..refs/heads/<default>\`
-   Only \`0\` passes. If the count is not \`0\`, rebase onto \`refs/heads/<default>\` before reading or writing anything.
+   \`git rev-list --count \$(git merge-base HEAD 'refs/heads/<default>')..'refs/heads/<default>'\`
+   Only \`0\` passes. If the count is not \`0\`, rebase onto \`'refs/heads/<default>'\` before reading or writing anything.
 EOF
   elif [ "$BASE_NEEDS_FETCH" -eq 1 ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -386,8 +386,9 @@ BASE_NEEDS_FETCH=0
 BASE_NO_FETCH_REASON=
 BASE_UNRESOLVED_REASON=
 case "$KIND:$MODE" in
-  ship:local-only) BASE_FALLBACK_KIND=local ;;
-  *) BASE_FALLBACK_KIND=origin ;;
+  ship:local-only) BASE_POLICY=local ;;
+  scout:*) BASE_POLICY='origin-then-local' ;;
+  *) BASE_POLICY=origin ;;
 esac
 
 set_origin_base() {  # <repo-dir>
@@ -407,16 +408,16 @@ set_local_base() {  # <repo-dir> <why-no-fetch>
 }
 
 if REPO_DIR=$(resolve_brief_repo "$REPO"); then
-  case "$KIND:$MODE" in
-    ship:local-only)
+  case "$BASE_POLICY" in
+    local)
       set_local_base "$REPO_DIR" "This task lands locally, so do not fetch" \
         || BASE_UNRESOLVED_REASON="This brief could not determine the local default branch of \`$REPO\`"
       ;;
-    ship:*)
+    origin)
       set_origin_base "$REPO_DIR" \
         || BASE_UNRESOLVED_REASON="This brief could not determine origin's default branch for \`$REPO\`"
       ;;
-    scout:*)
+    origin-then-local)
       set_origin_base "$REPO_DIR" \
         || set_local_base "$REPO_DIR" "Origin's default branch could not be resolved, so do not fetch" \
         || BASE_UNRESOLVED_REASON="This brief could not determine a default branch for \`$REPO\`"
@@ -429,7 +430,21 @@ fi
 # Sets BASE_FRESHNESS_SECTION as the numbered startup step <step-number>.
 build_base_freshness_section() {  # <step-number>
   local step=$1
-  if [ -n "$BASE_UNRESOLVED_REASON" ] && [ "$BASE_FALLBACK_KIND" = origin ]; then
+  if [ -n "$BASE_UNRESOLVED_REASON" ] && [ "$BASE_POLICY" = 'origin-then-local' ]; then
+    IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
+$step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
+   Try origin first: run \`git remote set-head origin --auto\`, then read \`git symbolic-ref --quiet --short refs/remotes/origin/HEAD\` and drop the leading \`origin/\` to get \`<default>\`. If that names a branch, confirm it with \`git rev-parse --verify origin/<default>\`; if the name resolves but the ref does not, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop instead of guessing another branch.
+   With a verified origin default, refresh the remote exactly once and measure:
+   \`git fetch origin --quiet\`
+   \`git rev-list --count \$(git merge-base HEAD origin/<default>)..origin/<default>\`
+   Only \`0\` passes. If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
+   If the count is not \`0\`, rebase onto \`origin/<default>\` before reading or writing anything.
+   Only when this clone has no origin default at all - no \`origin\` remote, or its HEAD cannot be set - use the local default branch, \`main\` or \`master\`, confirmed with \`git rev-parse --verify <default>\`. Do not fetch in that case; measure:
+   \`git rev-list --count \$(git merge-base HEAD <default>)..<default>\`
+   Only \`0\` passes, and if the count is not \`0\`, rebase onto \`<default>\` before reading or writing anything.
+   Never substitute whatever branch happens to be checked out. If neither an origin default nor a local default can be determined and verified, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
+EOF
+  elif [ -n "$BASE_UNRESOLVED_REASON" ] && [ "$BASE_POLICY" = origin ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
    Determine \`<default>\` with \`git remote set-head origin --auto\` then \`git symbolic-ref --quiet --short refs/remotes/origin/HEAD\`, dropping the leading \`origin/\`. Never substitute whatever branch happens to be checked out.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -60,6 +60,9 @@
 # Every base ref the brief emits reaches the worker as one shell word: a
 # scaffold-resolved ref is shell-quoted here, and a worker-resolved `<default>`
 # is rendered inside quotes with its substitution rule spelled out.
+# A refname may itself hold a backtick, so a scaffold-resolved ref also reaches
+# the worker as one complete markdown code span through md_code_span, which is
+# what delimits the command it must run.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns merge decisions, so yolo is
@@ -199,6 +202,29 @@ shell_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
   printf "'"
+}
+
+# Renders <text> as the markdown code span the worker reads as a command boundary.
+# git permits a backtick in a refname, so a fixed one-backtick fence around a
+# resolved ref ends at that character and hands the worker a truncated command
+# instead of the freshness check: shell_quote keeps the ref one shell WORD, and
+# this keeps the whole command one readable SPAN. The fence is one backtick longer
+# than the longest run in the content, because a span closes only on a run of the
+# same length, and content carrying a backtick is padded so the span can neither
+# open nor close on one; both extras render away.
+md_code_span() {  # <text>
+  local text=$1 run='`' fence=
+  while :; do
+    case $text in
+      *"$run"*) fence=$run; run="$run\`" ;;
+      *) break ;;
+    esac
+  done
+  fence="$fence\`"
+  case $text in
+    *'`'*) printf '%s %s %s\n' "$fence" "$text" "$fence" ;;
+    *) printf '%s%s%s\n' "$fence" "$text" "$fence" ;;
+  esac
 }
 
 resolve_brief_repo() {  # <repo-name-or-directory>
@@ -396,6 +422,7 @@ REPO=${POS[1]}
 # mandate a single `git fetch origin --quiet` first. Scouts have no delivery
 # mode: prefer the remote path, and otherwise use their local base.
 BASE_REF=
+BASE_REF_CODE=
 BASE_SHELL_REF=
 BASE_DESCRIPTION=
 BASE_NEEDS_FETCH=0
@@ -418,8 +445,9 @@ set_origin_base() {  # <repo-dir>
   local branch
   branch=$(resolve_origin_default_branch "$1") || return 1
   BASE_REF="origin/$branch"
+  BASE_REF_CODE=$(md_code_span "$BASE_REF")
   BASE_SHELL_REF=$(shell_quote "refs/remotes/origin/$branch")
-  BASE_DESCRIPTION="the freshly fetched default branch \`$BASE_REF\`"
+  BASE_DESCRIPTION="the freshly fetched default branch $BASE_REF_CODE"
   BASE_NEEDS_FETCH=1
 }
 
@@ -427,8 +455,9 @@ set_local_base() {  # <repo-dir> <why-no-fetch>
   local branch
   branch=$(resolve_local_default_branch "$1") || return 1
   BASE_REF=$branch
+  BASE_REF_CODE=$(md_code_span "$BASE_REF")
   BASE_SHELL_REF=$(shell_quote "refs/heads/$branch")
-  BASE_DESCRIPTION="your local default branch \`$branch\`"
+  BASE_DESCRIPTION="your local default branch $BASE_REF_CODE"
   BASE_NO_FETCH_REASON=$2
 }
 
@@ -480,7 +509,10 @@ RUNTIME_REF_QUOTING_RULE=${RUNTIME_REF_QUOTING_RULE%$'\n'}
 
 # Sets BASE_FRESHNESS_SECTION as the numbered startup step <step-number>.
 build_base_freshness_section() {  # <step-number>
-  local step=$1
+  local step=$1 count_command rebase_target
+  # Both spans carry the resolved ref, so both take their fence from its content.
+  count_command=$(md_code_span "git rev-list --count \$(git merge-base HEAD $BASE_SHELL_REF)..$BASE_SHELL_REF")
+  rebase_target=$(md_code_span "$BASE_SHELL_REF")
   if [ -n "$BASE_UNRESOLVED_REASON" ] && [ "$BASE_POLICY" = 'origin-then-local' ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
@@ -523,17 +555,17 @@ EOF
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** Refresh the remote exactly once, then measure:
    \`git fetch origin --quiet\`
-   \`git rev-list --count \$(git merge-base HEAD $BASE_SHELL_REF)..$BASE_SHELL_REF\`
+   $count_command
    Only \`0\` passes against $BASE_DESCRIPTION.
    If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
-   If the count is not \`0\`, rebase onto \`$BASE_SHELL_REF\` before reading or writing anything.
+   If the count is not \`0\`, rebase onto $rebase_target before reading or writing anything.
 EOF
   else
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_NO_FETCH_REASON; measure against the local branch:
-   \`git rev-list --count \$(git merge-base HEAD $BASE_SHELL_REF)..$BASE_SHELL_REF\`
+   $count_command
    Only \`0\` passes against $BASE_DESCRIPTION.
-   If the count is not \`0\`, rebase onto \`$BASE_SHELL_REF\` before reading or writing anything.
+   If the count is not \`0\`, rebase onto $rebase_target before reading or writing anything.
 EOF
   fi
   BASE_FRESHNESS_SECTION=${BASE_FRESHNESS_SECTION%$'\n'}
@@ -641,7 +673,7 @@ case "$MODE" in
   local-only)
     SETUP2=""
     if [ -n "$BASE_REF" ]; then
-      RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`$BASE_REF\`."
+      RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local $BASE_REF_CODE."
     else
       RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into the local default branch you resolved in Setup."
     fi

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -443,8 +443,8 @@ EOF
   elif [ -n "$BASE_UNRESOLVED_REASON" ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
-   Determine \`<default>\` from \`git symbolic-ref --quiet --short refs/remotes/origin/HEAD\` with the leading \`origin/\` dropped, else the local \`main\` or \`master\` branch. Never substitute whatever branch happens to be checked out; verify the branch exists with \`git rev-parse --verify <default>\`.
-   If you cannot determine it, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
+   Read \`git symbolic-ref --quiet --short refs/remotes/origin/HEAD\`. If it names a branch, that name with the leading \`origin/\` dropped IS \`<default>\`: confirm the local branch exists with \`git rev-parse --verify <default>\`, and if it does not, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
+   Only when that ref is absent entirely may \`<default>\` be the local \`main\` or \`master\`, confirmed the same way. Never substitute \`main\`, \`master\`, or whatever branch happens to be checked out for a default branch this clone is missing, and append the same \`blocked:\` line and stop if none of these resolves.
    This task lands locally, so do not fetch; measure against the local branch:
    \`git rev-list --count \$(git merge-base HEAD <default>)..<default>\`
    Only \`0\` passes. If the count is not \`0\`, rebase onto \`<default>\` before reading or writing anything.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -408,7 +408,7 @@ set_origin_base() {  # <repo-dir>
   local branch
   branch=$(resolve_origin_default_branch "$1") || return 1
   BASE_REF="origin/$branch"
-  BASE_SHELL_REF=$(shell_quote "$BASE_REF")
+  BASE_SHELL_REF=$(shell_quote "refs/remotes/origin/$branch")
   BASE_DESCRIPTION="the freshly fetched default branch \`$BASE_REF\`"
   BASE_NEEDS_FETCH=1
 }
@@ -417,7 +417,7 @@ set_local_base() {  # <repo-dir> <why-no-fetch>
   local branch
   branch=$(resolve_local_default_branch "$1") || return 1
   BASE_REF=$branch
-  BASE_SHELL_REF=$(shell_quote "$BASE_REF")
+  BASE_SHELL_REF=$(shell_quote "refs/heads/$branch")
   BASE_DESCRIPTION="your local default branch \`$branch\`"
   BASE_NO_FETCH_REASON=$2
 }
@@ -460,14 +460,14 @@ $step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so res
    If that names a branch, refresh the remote exactly once BEFORE verifying or comparing its tracking ref - the fetch is what creates a pruned or never-fetched \`origin/<default>\`:
    \`git fetch origin --quiet\`
    If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
-   Then confirm the tracking ref with \`git rev-parse --verify origin/<default>\` and measure:
-   \`git rev-list --count \$(git merge-base HEAD origin/<default>)..origin/<default>\`
-   Only \`0\` passes. If the count is not \`0\`, rebase onto \`origin/<default>\` before reading or writing anything.
+   Then confirm the tracking ref with \`git rev-parse --verify refs/remotes/origin/<default>\` and measure:
+   \`git rev-list --count \$(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>\`
+   Only \`0\` passes. If the count is not \`0\`, rebase onto \`refs/remotes/origin/<default>\` before reading or writing anything.
    If no usable origin default remains after that single fetch - no \`origin\` remote, no \`origin/HEAD\`, or its tracking ref still missing - fall back to a local default branch with NO further network refresh, named by exactly this rule:
 $LOCAL_DEFAULT_RULE
    Then measure against that local branch:
-   \`git rev-list --count \$(git merge-base HEAD <default>)..<default>\`
-   Only \`0\` passes, and if the count is not \`0\`, rebase onto \`<default>\` before reading or writing anything.
+   \`git rev-list --count \$(git merge-base HEAD refs/heads/<default>)..refs/heads/<default>\`
+   Only \`0\` passes, and if the count is not \`0\`, rebase onto \`refs/heads/<default>\` before reading or writing anything.
 EOF
   elif [ -n "$BASE_UNRESOLVED_REASON" ] && [ "$BASE_POLICY" = origin ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
@@ -476,17 +476,17 @@ $step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so res
    If you cannot determine it, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
    Then refresh the remote exactly once and measure:
    \`git fetch origin --quiet\`
-   \`git rev-list --count \$(git merge-base HEAD origin/<default>)..origin/<default>\`
+   \`git rev-list --count \$(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>\`
    Only \`0\` passes. If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
-   If the count is not \`0\`, rebase onto \`origin/<default>\` before reading or writing anything.
+   If the count is not \`0\`, rebase onto \`refs/remotes/origin/<default>\` before reading or writing anything.
 EOF
   elif [ -n "$BASE_UNRESOLVED_REASON" ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
 $LOCAL_DEFAULT_RULE
    This task lands locally, so do not fetch; measure against the local branch:
-   \`git rev-list --count \$(git merge-base HEAD <default>)..<default>\`
-   Only \`0\` passes. If the count is not \`0\`, rebase onto \`<default>\` before reading or writing anything.
+   \`git rev-list --count \$(git merge-base HEAD refs/heads/<default>)..refs/heads/<default>\`
+   Only \`0\` passes. If the count is not \`0\`, rebase onto \`refs/heads/<default>\` before reading or writing anything.
 EOF
   elif [ "$BASE_NEEDS_FETCH" -eq 1 ]; then
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
@@ -495,14 +495,14 @@ $step. **Check your base before starting work.** Refresh the remote exactly once
    \`git rev-list --count \$(git merge-base HEAD $BASE_SHELL_REF)..$BASE_SHELL_REF\`
    Only \`0\` passes against $BASE_DESCRIPTION.
    If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
-   If the count is not \`0\`, rebase onto \`$BASE_REF\` before reading or writing anything.
+   If the count is not \`0\`, rebase onto \`$BASE_SHELL_REF\` before reading or writing anything.
 EOF
   else
     IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
 $step. **Check your base before starting work.** $BASE_NO_FETCH_REASON; measure against the local branch:
    \`git rev-list --count \$(git merge-base HEAD $BASE_SHELL_REF)..$BASE_SHELL_REF\`
    Only \`0\` passes against $BASE_DESCRIPTION.
-   If the count is not \`0\`, rebase onto \`$BASE_REF\` before reading or writing anything.
+   If the count is not \`0\`, rebase onto \`$BASE_SHELL_REF\` before reading or writing anything.
 EOF
   fi
   BASE_FRESHNESS_SECTION=${BASE_FRESHNESS_SECTION%$'\n'}

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -11,8 +11,12 @@
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
-#   repo-name resolves under FM_PROJECTS_OVERRIDE when set, otherwise under
-#   $FM_HOME/projects; projects/<repo-name> and explicit directory paths work too.
+#   repo-name stays a free-form caller-supplied label. It is resolved best-effort
+#   under FM_PROJECTS_OVERRIDE when set, otherwise under $FM_HOME/projects;
+#   projects/<repo-name> and explicit directory paths work too. A repo that
+#   resolves renders its real default branch into the startup base-freshness
+#   check; one that does not still gets the same mandatory check, deferred to the
+#   worker at runtime. An unresolvable label never fails the scaffold.
 #   --secondmate writes a persistent secondmate charter. The project list
 #   is cloned into the secondmate home, while the natural-language scope
 #   tells the main firstmate when to route work there; routine churn stays in its own home;
@@ -42,7 +46,9 @@
 # "Delivery contract: mode=<mode>" line. bin/fm-spawn.sh reads that line and refuses
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
-# Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Ship briefs open with an explicitly numbered safety contract: 1 worktree
+# isolation, 2 base freshness, 3 branch creation. Nothing is read or written
+# until steps 1 and 2 pass.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns merge decisions, so yolo is
@@ -82,6 +88,8 @@ esac
 . "$SCRIPT_DIR/fm-classify-lib.sh"
 # shellcheck source=bin/fm-dod-lib.sh
 . "$SCRIPT_DIR/fm-dod-lib.sh"
+# shellcheck source=bin/fm-tangle-lib.sh
+. "$SCRIPT_DIR/fm-tangle-lib.sh"
 PAUSED_VERB=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
 
 resolve_directory_input() {
@@ -199,30 +207,34 @@ resolve_brief_repo() {  # <repo-name-or-directory>
       fi
       ;;
   esac
-  [ -d "$candidate" ] || {
-    echo "error: repo for brief does not exist or is not a directory: $candidate" >&2
-    return 1
-  }
-  git -C "$candidate" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
-    echo "error: repo for brief is not a git worktree: $candidate" >&2
-    return 1
-  }
-  resolved=$(cd "$candidate" && pwd -P) || return 1
+  [ -d "$candidate" ] || return 1
+  git -C "$candidate" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+  resolved=$(CDPATH='' cd -- "$candidate" 2>/dev/null && pwd -P) || return 1
   printf '%s\n' "$resolved"
 }
 
+# origin/HEAD only supplies the NAME; the comparison must still target the
+# clone's local branch, which may legitimately be ahead of origin. Resolution
+# never reads HEAD: a primary stranded on a feature branch (the worktree tangle
+# bin/fm-tangle-lib.sh exists to detect) would otherwise have that feature branch
+# rendered into the brief as its own base. fm_default_branch encodes the same
+# origin/HEAD-then-local-main/master order the rest of the fleet uses; the loop
+# below covers the residual case where origin names a branch this clone has no
+# local ref for.
 resolve_local_default_branch() {  # <repo-dir>
   local repo=$1 branch
-  # origin/HEAD can identify the name while the comparison must still target
-  # the clone's local branch, which may be ahead of origin.
-  if branch=$(resolve_origin_default_branch "$repo" 2>/dev/null) \
+  if branch=$(fm_default_branch "$repo" 2>/dev/null) \
     && git -C "$repo" rev-parse --verify --quiet "refs/heads/$branch^{commit}" >/dev/null 2>&1; then
     printf '%s\n' "$branch"
     return 0
   fi
-  branch=$(git -C "$repo" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
-  git -C "$repo" rev-parse --verify --quiet "refs/heads/$branch^{commit}" >/dev/null 2>&1 || return 1
-  printf '%s\n' "$branch"
+  for branch in main master; do
+    if git -C "$repo" rev-parse --verify --quiet "refs/heads/$branch^{commit}" >/dev/null 2>&1; then
+      printf '%s\n' "$branch"
+      return 0
+    fi
+  done
+  return 1
 }
 
 resolve_origin_default_branch() {  # <repo-dir>
@@ -343,51 +355,108 @@ exit 0
 fi
 
 REPO=${POS[1]}
-REPO_DIR=$(resolve_brief_repo "$REPO") || exit 1
 
+# The repo positional is a free-form caller-supplied label rendered into the
+# brief text, so firstmate can legitimately name a repo this scaffold has no
+# local view of. Resolution is therefore best-effort and never fails the
+# scaffold. A resolved repo renders its real base ref; an unresolved one carries
+# the identical mandatory check with the base determined by the worker at
+# runtime. The check is never softened or omitted either way.
+#
 # A local-only task lands into the clone's local default branch, which can be
-# ahead of its origin tracking ref. PR-based tasks instead need the fetched
-# remote default branch that their PR will merge into. Scouts have no delivery
-# mode, so use the remote path when available and otherwise their local base.
+# ahead of its origin tracking ref, so it uses that branch with no network
+# refresh. PR-based tasks instead need the remote default branch their PR will
+# merge into, and the tracking ref only answers truthfully after a fetch (a
+# `fm-spawn.sh --relaunch` worktree is reused without one), so those paths
+# mandate a single `git fetch origin --quiet` first. Scouts have no delivery
+# mode: prefer the remote path, and otherwise use their local base.
+BASE_REF=
+BASE_DESCRIPTION=
+BASE_NEEDS_FETCH=0
+BASE_UNRESOLVED_REASON=
 case "$KIND:$MODE" in
-  ship:local-only)
-    DEFAULT_BRANCH=$(resolve_local_default_branch "$REPO_DIR") || {
-      echo "error: could not determine the checked-out local default branch for local-only brief repo $REPO_DIR" >&2
-      exit 1
-    }
-    BASE_REF=$DEFAULT_BRANCH
-    BASE_DESCRIPTION="your local default branch \`$DEFAULT_BRANCH\`"
-    ;;
-  ship:*)
-    DEFAULT_BRANCH=$(resolve_origin_default_branch "$REPO_DIR") || {
-      echo "error: could not determine origin's default branch for PR-based brief repo $REPO_DIR" >&2
-      exit 1
-    }
-    BASE_REF="origin/$DEFAULT_BRANCH"
-    BASE_DESCRIPTION="the fetched default branch \`$BASE_REF\`"
-    ;;
-  scout:*)
-    if DEFAULT_BRANCH=$(resolve_origin_default_branch "$REPO_DIR"); then
-      BASE_REF="origin/$DEFAULT_BRANCH"
-      BASE_DESCRIPTION="the fetched default branch \`$BASE_REF\`"
-    else
-      DEFAULT_BRANCH=$(resolve_local_default_branch "$REPO_DIR") || {
-        echo "error: could not determine a default branch for scout brief repo $REPO_DIR" >&2
-        exit 1
-      }
-      BASE_REF=$DEFAULT_BRANCH
-      BASE_DESCRIPTION="your local default branch \`$DEFAULT_BRANCH\`"
-    fi
-    ;;
+  ship:local-only) BASE_FALLBACK_KIND=local ;;
+  *) BASE_FALLBACK_KIND=origin ;;
 esac
 
-IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
-1. **First startup step - check your base before starting work.** Run:
+if REPO_DIR=$(resolve_brief_repo "$REPO"); then
+  case "$KIND:$MODE" in
+    ship:local-only)
+      if DEFAULT_BRANCH=$(resolve_local_default_branch "$REPO_DIR"); then
+        BASE_REF=$DEFAULT_BRANCH
+        BASE_DESCRIPTION="your local default branch \`$DEFAULT_BRANCH\`"
+      else
+        BASE_UNRESOLVED_REASON="This brief could not determine the local default branch of \`$REPO\`"
+      fi
+      ;;
+    ship:*)
+      if DEFAULT_BRANCH=$(resolve_origin_default_branch "$REPO_DIR"); then
+        BASE_REF="origin/$DEFAULT_BRANCH"
+        BASE_DESCRIPTION="the freshly fetched default branch \`$BASE_REF\`"
+        BASE_NEEDS_FETCH=1
+      else
+        BASE_UNRESOLVED_REASON="This brief could not determine origin's default branch for \`$REPO\`"
+      fi
+      ;;
+    scout:*)
+      if DEFAULT_BRANCH=$(resolve_origin_default_branch "$REPO_DIR"); then
+        BASE_REF="origin/$DEFAULT_BRANCH"
+        BASE_DESCRIPTION="the freshly fetched default branch \`$BASE_REF\`"
+        BASE_NEEDS_FETCH=1
+      elif DEFAULT_BRANCH=$(resolve_local_default_branch "$REPO_DIR"); then
+        BASE_REF=$DEFAULT_BRANCH
+        BASE_DESCRIPTION="your local default branch \`$DEFAULT_BRANCH\`"
+      else
+        BASE_UNRESOLVED_REASON="This brief could not determine a default branch for \`$REPO\`"
+      fi
+      ;;
+  esac
+else
+  BASE_UNRESOLVED_REASON="This brief could not resolve \`$REPO\` to a local checkout"
+fi
+
+# Sets BASE_FRESHNESS_SECTION as the numbered startup step <step-number>.
+build_base_freshness_section() {  # <step-number>
+  local step=$1
+  if [ -n "$BASE_UNRESOLVED_REASON" ] && [ "$BASE_FALLBACK_KIND" = origin ]; then
+    IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
+$step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
+   Determine \`<default>\` with \`git remote set-head origin --auto\` then \`git symbolic-ref --quiet --short refs/remotes/origin/HEAD\`, dropping the leading \`origin/\`. Never substitute whatever branch happens to be checked out.
+   If you cannot determine it, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
+   Then refresh the remote exactly once and measure:
+   \`git fetch origin --quiet\`
+   \`git rev-list --count \$(git merge-base HEAD origin/<default>)..origin/<default>\`
+   Only \`0\` passes. If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
+   If the count is not \`0\`, rebase onto \`origin/<default>\` before reading or writing anything.
+EOF
+  elif [ -n "$BASE_UNRESOLVED_REASON" ]; then
+    IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
+$step. **Check your base before starting work.** $BASE_UNRESOLVED_REASON, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
+   Determine \`<default>\` from \`git symbolic-ref --quiet --short refs/remotes/origin/HEAD\` with the leading \`origin/\` dropped, else the local \`main\` or \`master\` branch. Never substitute whatever branch happens to be checked out; verify the branch exists with \`git rev-parse --verify <default>\`.
+   If you cannot determine it, append \`blocked: cannot determine the default branch to verify base freshness\` to the status file and stop.
+   This task lands locally, so do not fetch; measure against the local branch:
+   \`git rev-list --count \$(git merge-base HEAD <default>)..<default>\`
+   Only \`0\` passes. If the count is not \`0\`, rebase onto \`<default>\` before reading or writing anything.
+EOF
+  elif [ "$BASE_NEEDS_FETCH" -eq 1 ]; then
+    IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
+$step. **Check your base before starting work.** Refresh the remote exactly once, then measure:
+   \`git fetch origin --quiet\`
    \`git rev-list --count \$(git merge-base HEAD $BASE_REF)..$BASE_REF\`
    Only \`0\` passes against $BASE_DESCRIPTION.
-   If the result is not \`0\`, rebase onto \`$BASE_REF\` before reading or writing anything.
+   If the fetch fails, append \`blocked: cannot fetch origin to verify base freshness\` to the status file and stop - one fetch, no retry loop.
+   If the count is not \`0\`, rebase onto \`$BASE_REF\` before reading or writing anything.
 EOF
-BASE_FRESHNESS_SECTION=${BASE_FRESHNESS_SECTION%$'\n'}
+  else
+    IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
+$step. **Check your base before starting work.** This task lands locally, so do not fetch; measure against the local branch:
+   \`git rev-list --count \$(git merge-base HEAD $BASE_REF)..$BASE_REF\`
+   Only \`0\` passes against $BASE_DESCRIPTION.
+   If the count is not \`0\`, rebase onto \`$BASE_REF\` before reading or writing anything.
+EOF
+  fi
+  BASE_FRESHNESS_SECTION=${BASE_FRESHNESS_SECTION%$'\n'}
+}
 
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
@@ -422,6 +491,7 @@ HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
 if [ "$KIND" = scout ]; then
+build_base_freshness_section 1
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
@@ -475,6 +545,8 @@ echo "scaffolded: $BRIEF (scout; replace {TASK})"
 exit 0
 fi
 
+build_base_freshness_section 2
+
 # Ship task: shape Setup / Rule 1 by this task's explicit delivery mode, validated
 # above, and render the Definition of done from its single owner, bin/fm-dod-lib.sh,
 # which bin/fm-promote.sh renders too so a promoted scout receives the same contract.
@@ -491,7 +563,7 @@ case "$MODE" in
     ;;
   *)  # no-mistakes
     SETUP2="
-3. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
+4. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
     ;;
 esac
@@ -508,13 +580,13 @@ $HERDR_SECTION
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD supplied by the worktree pool.
 
-**Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
-The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
-If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
+1. **Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
+   The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
+   If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
 $BASE_FRESHNESS_SECTION
 
-2. Create your branch: \`git checkout -b fm/$ID\`$SETUP2
+3. Create your branch: \`git checkout -b fm/$ID\`$SETUP2
 
 # Rules
 $RULE1

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -11,6 +11,8 @@
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
+#   repo-name resolves under FM_PROJECTS_OVERRIDE when set, otherwise under
+#   $FM_HOME/projects; projects/<repo-name> and explicit directory paths work too.
 #   --secondmate writes a persistent secondmate charter. The project list
 #   is cloned into the secondmate home, while the natural-language scope
 #   tells the main firstmate when to route work there; routine churn stays in its own home;
@@ -106,6 +108,7 @@ if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
 else
   STATE="$FM_HOME/state"
 fi
+PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 KIND=ship
 HERDR_LAB=0
 NO_PROJECTS=0
@@ -179,6 +182,58 @@ shell_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
   printf "'"
+}
+
+resolve_brief_repo() {  # <repo-name-or-directory>
+  local repo=$1 candidate resolved
+  case "$repo" in
+    projects/*) candidate="$PROJECTS/${repo#projects/}" ;;
+    /*|./*|../*) candidate=$repo ;;
+    *)
+      if [ -d "$PROJECTS/$repo" ]; then
+        candidate="$PROJECTS/$repo"
+      elif [ "$repo" = "$(basename "$FM_ROOT")" ]; then
+        candidate="$FM_ROOT"
+      else
+        candidate=$repo
+      fi
+      ;;
+  esac
+  [ -d "$candidate" ] || {
+    echo "error: repo for brief does not exist or is not a directory: $candidate" >&2
+    return 1
+  }
+  git -C "$candidate" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+    echo "error: repo for brief is not a git worktree: $candidate" >&2
+    return 1
+  }
+  resolved=$(cd "$candidate" && pwd -P) || return 1
+  printf '%s\n' "$resolved"
+}
+
+resolve_local_default_branch() {  # <repo-dir>
+  local repo=$1 branch
+  # origin/HEAD can identify the name while the comparison must still target
+  # the clone's local branch, which may be ahead of origin.
+  if branch=$(resolve_origin_default_branch "$repo" 2>/dev/null) \
+    && git -C "$repo" rev-parse --verify --quiet "refs/heads/$branch^{commit}" >/dev/null 2>&1; then
+    printf '%s\n' "$branch"
+    return 0
+  fi
+  branch=$(git -C "$repo" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
+  git -C "$repo" rev-parse --verify --quiet "refs/heads/$branch^{commit}" >/dev/null 2>&1 || return 1
+  printf '%s\n' "$branch"
+}
+
+resolve_origin_default_branch() {  # <repo-dir>
+  local repo=$1 ref branch
+  ref=$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null) || return 1
+  case "$ref" in
+    origin/*) branch=${ref#origin/} ;;
+    *) return 1 ;;
+  esac
+  git -C "$repo" rev-parse --verify --quiet "refs/remotes/origin/$branch^{commit}" >/dev/null 2>&1 || return 1
+  printf '%s\n' "$branch"
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
@@ -288,6 +343,51 @@ exit 0
 fi
 
 REPO=${POS[1]}
+REPO_DIR=$(resolve_brief_repo "$REPO") || exit 1
+
+# A local-only task lands into the clone's local default branch, which can be
+# ahead of its origin tracking ref. PR-based tasks instead need the fetched
+# remote default branch that their PR will merge into. Scouts have no delivery
+# mode, so use the remote path when available and otherwise their local base.
+case "$KIND:$MODE" in
+  ship:local-only)
+    DEFAULT_BRANCH=$(resolve_local_default_branch "$REPO_DIR") || {
+      echo "error: could not determine the checked-out local default branch for local-only brief repo $REPO_DIR" >&2
+      exit 1
+    }
+    BASE_REF=$DEFAULT_BRANCH
+    BASE_DESCRIPTION="your local default branch \`$DEFAULT_BRANCH\`"
+    ;;
+  ship:*)
+    DEFAULT_BRANCH=$(resolve_origin_default_branch "$REPO_DIR") || {
+      echo "error: could not determine origin's default branch for PR-based brief repo $REPO_DIR" >&2
+      exit 1
+    }
+    BASE_REF="origin/$DEFAULT_BRANCH"
+    BASE_DESCRIPTION="the fetched default branch \`$BASE_REF\`"
+    ;;
+  scout:*)
+    if DEFAULT_BRANCH=$(resolve_origin_default_branch "$REPO_DIR"); then
+      BASE_REF="origin/$DEFAULT_BRANCH"
+      BASE_DESCRIPTION="the fetched default branch \`$BASE_REF\`"
+    else
+      DEFAULT_BRANCH=$(resolve_local_default_branch "$REPO_DIR") || {
+        echo "error: could not determine a default branch for scout brief repo $REPO_DIR" >&2
+        exit 1
+      }
+      BASE_REF=$DEFAULT_BRANCH
+      BASE_DESCRIPTION="your local default branch \`$DEFAULT_BRANCH\`"
+    fi
+    ;;
+esac
+
+IFS= read -r -d '' BASE_FRESHNESS_SECTION <<EOF || true
+1. **First startup step - check your base before starting work.** Run:
+   \`git rev-list --count \$(git merge-base HEAD $BASE_REF)..$BASE_REF\`
+   Only \`0\` passes against $BASE_DESCRIPTION.
+   If the result is not \`0\`, rebase onto \`$BASE_REF\` before reading or writing anything.
+EOF
+BASE_FRESHNESS_SECTION=${BASE_FRESHNESS_SECTION%$'\n'}
 
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
@@ -331,7 +431,9 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 $HERDR_SECTION
 
 # Setup
-You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
+You are in a disposable git worktree of $REPO, at a detached HEAD supplied by the worktree pool.
+$BASE_FRESHNESS_SECTION
+
 This is a SCOUT task: the deliverable is a written report, not a PR.
 The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
 The report is the only thing that survives, so anything worth keeping must be in it.
@@ -389,7 +491,7 @@ case "$MODE" in
     ;;
   *)  # no-mistakes
     SETUP2="
-2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
+3. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
     ;;
 esac
@@ -404,13 +506,15 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 $HERDR_SECTION
 
 # Setup
-You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
+You are in a disposable git worktree of $REPO, at a detached HEAD supplied by the worktree pool.
 
 **Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+$BASE_FRESHNESS_SECTION
+
+2. Create your branch: \`git checkout -b fm/$ID\`$SETUP2
 
 # Rules
 $RULE1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,8 +196,10 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
-`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
+`fm-spawn.sh` also owns the spawn-time base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
+Generated ship and scout briefs carry the complementary runtime layer, which also covers a base that spawn never freshened, such as the worktree a `relaunch` reuses: before reading or writing anything the crewmate measures its base against the resolved default branch, treats only a zero count as a pass, and rebases when it is behind.
+`bin/fm-brief.sh`'s header owns which base each path resolves - `origin/<default>` for PR-based delivery, the clone's local default branch for `local-only`, origin then local for a scout - and how an unresolvable repo label defers the same mandatory check to the worker, while `tests/fm-brief.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -502,6 +502,46 @@ test_scout_local_fallback_uses_kind_neutral_wording() {
   pass "fm-brief.sh: a scout local fallback explains itself without claiming it lands locally"
 }
 
+# A scout's runtime fallback must mirror the policy the same scaffold applies
+# when the label DOES resolve: prefer a verified origin default, degrade to a
+# verified local default with no network refresh, and block only if neither can
+# be established. An origin-only fallback would strand a scout in a remote-less
+# clone before it does any research.
+# shellcheck disable=SC2016 # Literal brief text: the backticks and $(...) must stay unexpanded.
+test_unresolved_scout_fallback_degrades_to_a_local_default() {
+  local home scout_setup ship_setup
+  home="$TMP_ROOT/unresolved-scout-fallback-home"
+  mkdir -p "$home/data"
+
+  [ ! -d "$BRIEF_PROJECTS/comms" ] || fail "fixture leak: comms must not resolve"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" fallback-scout comms --scout >/dev/null 2>&1 \
+    || fail "an unresolvable scout label must not fail the scaffold"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" fallback-ship comms --mode direct-PR >/dev/null 2>&1 \
+    || fail "an unresolvable PR-path label must not fail the scaffold"
+  scout_setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/fallback-scout/brief.md")
+  ship_setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/fallback-ship/brief.md")
+
+  assert_contains "$scout_setup" 'git fetch origin --quiet' \
+    "the scout fallback dropped the single fetch that precedes its origin comparison"
+  assert_contains "$scout_setup" 'git rev-list --count $(git merge-base HEAD origin/<default>)..origin/<default>' \
+    "the scout fallback lost its origin-first zero-count command"
+  assert_contains "$scout_setup" 'git rev-list --count $(git merge-base HEAD <default>)..<default>' \
+    "the scout fallback never degrades to a local default when origin cannot be established"
+  assert_contains "$scout_setup" 'Only when this clone has no origin default at all' \
+    "the scout fallback did not gate its local degradation on origin being unavailable"
+  assert_contains "$scout_setup" 'Do not fetch in that case' \
+    "the scout local degradation did not forbid the network refresh"
+  assert_contains "$scout_setup" 'blocked: cannot determine the default branch to verify base freshness' \
+    "the scout fallback dropped its block-and-stop requirement"
+  assert_not_contains "$scout_setup" 'This task lands locally' \
+    "the scout fallback claimed the task lands locally"
+
+  assert_not_contains "$ship_setup" 'git rev-list --count $(git merge-base HEAD <default>)..<default>' \
+    "a PR-path fallback degraded to a local base instead of requiring origin"
+  pass "fm-brief.sh: an unresolved scout fallback degrades to a local default before blocking"
+}
+
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
 # unusable value must stop the scaffold instead of silently defaulting. The
 # no-mistakes-prod-only row is the conditional registry policy: it is never a task
@@ -1058,6 +1098,7 @@ test_non_root_directory_never_resolves_to_its_enclosing_repo
 test_absent_local_ref_for_origin_default_never_substitutes_another_branch
 test_local_only_rule_names_the_resolved_default_branch
 test_scout_local_fallback_uses_kind_neutral_wording
+test_unresolved_scout_fallback_degrades_to_a_local_default
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -486,6 +486,49 @@ test_absent_local_ref_for_origin_default_never_substitutes_another_branch() {
   pass "fm-brief.sh: an absent local ref for origin's default never substitutes another branch"
 }
 
+# `git symbolic-ref --short` abbreviates only while the result is unambiguous: a
+# clone that also holds a ref literally named `origin/<default>` gets
+# `remotes/origin/<default>` back instead. Reading the default branch through
+# that abbreviation turned a resolvable default into "no authority exists at
+# all" and silently substituted the local `main` - the exact wrong-base failure
+# this check exists to catch.
+# shellcheck disable=SC2016 # Literal brief text: the backticks and $(...) must stay unexpanded.
+test_ambiguous_origin_head_still_resolves_the_real_default_branch() {
+  local home ambiguous setup rules
+  home="$TMP_ROOT/ambiguous-origin-head-home"
+  ambiguous="$BRIEF_PROJECTS/ambiguous-origin-head"
+  mkdir -p "$home/data"
+
+  fm_git_init_commit "$ambiguous"
+  git -C "$ambiguous" branch -M develop
+  fm_git_add_origin "$ambiguous" "$ambiguous.origin.git"
+  git -C "$ambiguous" fetch --quiet origin
+  git -C "$ambiguous" remote set-head origin --auto >/dev/null
+  git -C "$ambiguous" branch main
+  git -C "$ambiguous" tag origin/develop
+  [ "$(git -C "$ambiguous" symbolic-ref --quiet --short refs/remotes/origin/HEAD)" = 'remotes/origin/develop' ] \
+    || fail "fixture did not make the --short abbreviation of origin/HEAD ambiguous"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" ambiguous-head ambiguous-origin-head --mode local-only >/dev/null 2>&1 \
+    || fail "an ambiguous origin/HEAD abbreviation must not fail the scaffold"
+  setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/ambiguous-head/brief.md")
+  rules=$(sed -n '/^# Rules$/,/^# Firstmate instruction inbox$/p' "$home/data/ambiguous-head/brief.md")
+
+  assert_contains "$setup" "git rev-list --count \$(git merge-base HEAD 'develop')..'develop'" \
+    "an ambiguous origin/HEAD abbreviation stopped the brief measuring against the real default branch"
+  assert_contains "$setup" 'Only `0` passes against your local default branch `develop`.' \
+    "the brief did not name the real default branch in its zero-only criterion"
+  assert_not_contains "$setup" 'your local default branch `main`' \
+    "an ambiguous origin/HEAD abbreviation substituted main for the real default branch"
+  assert_not_contains "$setup" 'git rev-list --count $(git merge-base HEAD <default>)..<default>' \
+    "a resolvable default branch was deferred to the runtime fallback"
+  assert_contains "$rules" 'firstmate handles the merge into local `develop`' \
+    "Rule 1 named a branch other than the real default"
+  assert_not_contains "$rules" 'merge into local `main`' \
+    "Rule 1 substituted main for the real default branch"
+  pass "fm-brief.sh: an ambiguous origin/HEAD abbreviation still resolves the real default branch"
+}
+
 # The generated brief must not contradict itself: a local-only task whose Setup
 # rebases onto `release` cannot tell the worker firstmate merges into `main`.
 # shellcheck disable=SC2016 # Literal brief text: the backticks and $(...) must stay unexpanded.
@@ -499,8 +542,10 @@ test_local_only_rule_names_the_resolved_default_branch() {
   setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/rule-local/brief.md")
   rules=$(sed -n '/^# Rules$/,/^# Firstmate instruction inbox$/p' "$home/data/rule-local/brief.md")
 
-  assert_contains "$setup" "rebase onto \`'release'\`" \
+  assert_contains "$setup" "rebase onto \`release\`" \
     "the local-only fixture no longer resolves its non-main default branch"
+  assert_not_contains "$setup" "rebase onto \`'release'\`" \
+    "the prose rebase instruction leaked the shell quoting that only the executed command needs"
   assert_contains "$rules" 'firstmate handles the merge into local `release`' \
     "Rule 1 named a branch other than the resolved local default"
   assert_not_contains "$rules" 'merge into local `main`' \
@@ -1181,6 +1226,7 @@ test_unresolvable_repo_label_still_mandates_the_base_check
 test_missing_origin_head_never_relabels_the_current_branch
 test_non_root_directory_never_resolves_to_its_enclosing_repo
 test_absent_local_ref_for_origin_default_never_substitutes_another_branch
+test_ambiguous_origin_head_still_resolves_the_real_default_branch
 test_local_only_rule_names_the_resolved_default_branch
 test_scout_local_fallback_uses_kind_neutral_wording
 test_unresolved_scout_fallback_degrades_to_a_local_default

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -345,6 +345,50 @@ test_resolved_default_branch_is_shell_quoted_in_the_freshness_command() {
   pass "fm-brief.sh: resolved default branches are shell-quoted in freshness commands"
 }
 
+# The runtime twin of the test above. An unresolvable repo label leaves the base
+# to be named by the WORKER at runtime, so the emitted command carries a
+# `<default>` placeholder instead of a scaffold-quoted ref. git permits refnames
+# holding `$`, backticks and `;`, so that placeholder must already sit inside
+# single quotes: a worker substituting a shell-significant default branch into an
+# unquoted argument would split the ref or run a second command instead of
+# measuring its base.
+# shellcheck disable=SC2016 # The fixture branch must contain the literal $IFS expansion attempt.
+test_runtime_fallback_ref_stays_one_shell_word() {
+  local home unsafe worktree marker marker_name setup count_cmd unsafe_branch count
+  home="$TMP_ROOT/runtime-quoted-default-home"
+  unsafe="$TMP_ROOT/runtime-shell-significant-default"
+  worktree="$TMP_ROOT/runtime-shell-significant-worktree"
+  marker_name='runtime-branch-name-command-ran'
+  marker="$worktree/$marker_name"
+  mkdir -p "$home/data"
+
+  [ ! -d "$BRIEF_PROJECTS/no-such-unsafe-repo" ] || fail "fixture leak: no-such-unsafe-repo must not resolve"
+
+  unsafe_branch="release;touch\$IFS\$9$marker_name"
+  fm_git_init_commit "$unsafe"
+  git -C "$unsafe" branch -M "$unsafe_branch"
+  git -C "$unsafe" worktree add --quiet --detach "$worktree" HEAD
+  printf '%s\n' 'the default branch advances' >> "$unsafe/README.md"
+  git -C "$unsafe" add README.md
+  git -C "$unsafe" commit -qm 'default branch advances'
+  printf '%s\n' 'the default branch advances again' >> "$unsafe/README.md"
+  git -C "$unsafe" add README.md
+  git -C "$unsafe" commit -qm 'default branch advances again'
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" runtime-quoted no-such-unsafe-repo --mode local-only >/dev/null 2>&1 \
+    || fail "an unresolvable local-only label must not fail the scaffold"
+  setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/runtime-quoted/brief.md")
+  count_cmd=$(printf '%s\n' "$setup" | sed -n 's/^   `\(git rev-list --count .*\)`$/\1/p' | head -1)
+  [ -n "$count_cmd" ] || fail "the runtime fallback did not render a zero-count command"
+
+  count=$(cd "$worktree" && bash -c "${count_cmd//<default>/$unsafe_branch}" 2>/dev/null) \
+    || fail "the emitted runtime command did not execute against a shell-significant default branch"
+  assert_absent "$marker" "the substituted default branch executed a shell command"
+  [ "$count" = 2 ] \
+    || fail "the emitted runtime command measured '$count' instead of 2 commits behind the default branch"
+  pass "fm-brief.sh: runtime fallback refs stay one shell word when substituted"
+}
+
 # git's rev-parse precedence ranks `refs/tags/<name>` ABOVE `refs/heads/<name>`
 # and `refs/remotes/<name>`, so a tag that merely shares the base branch's name
 # wins the emitted command's ref lookup. The brief is generated worker-facing
@@ -446,13 +490,13 @@ test_unresolvable_repo_label_still_mandates_the_base_check() {
 
   assert_contains "$ship_setup" "2. **Check your base before starting work.**" \
     "the runtime fallback lost its numbered place in the ship safety contract"
-  assert_contains "$ship_setup" 'git rev-list --count $(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>' \
+  assert_contains "$ship_setup" "git rev-list --count \$(git merge-base HEAD 'refs/remotes/origin/<default>')..'refs/remotes/origin/<default>'" \
     "the runtime fallback omitted the mandatory zero-count command"
   assert_contains "$ship_setup" 'blocked: cannot determine the default branch to verify base freshness' \
     "the runtime fallback did not require reporting blocked on an undeterminable base"
   assert_contains "$ship_setup" 'never skip, soften, or postpone it' \
     "the runtime fallback softened the mandatory check"
-  assert_contains "$scout_setup" 'git rev-list --count $(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>' \
+  assert_contains "$scout_setup" "git rev-list --count \$(git merge-base HEAD 'refs/remotes/origin/<default>')..'refs/remotes/origin/<default>'" \
     "the scout runtime fallback omitted the mandatory zero-count command"
   pass "fm-brief.sh: an unresolvable repo label still mandates the base check at runtime"
 }
@@ -513,7 +557,7 @@ test_non_root_directory_never_resolves_to_its_enclosing_repo() {
 
   assert_not_contains "$setup" 'origin/trunk' \
     "a plain directory inside a work tree rendered the enclosing repo's default branch as its base"
-  assert_contains "$setup" 'git rev-list --count $(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>' \
+  assert_contains "$setup" "git rev-list --count \$(git merge-base HEAD 'refs/remotes/origin/<default>')..'refs/remotes/origin/<default>'" \
     "a non-root project directory did not fall back to the runtime base check"
   pass "fm-brief.sh: a directory inside a work tree never resolves as that project's repo"
 }
@@ -550,7 +594,7 @@ test_absent_local_ref_for_origin_default_never_substitutes_another_branch() {
 
   assert_not_contains "$setup" 'your local default branch `main`' \
     "a substitute branch was presented as the repository's local default branch"
-  assert_contains "$setup" 'git rev-list --count $(git merge-base HEAD refs/heads/<default>)..refs/heads/<default>' \
+  assert_contains "$setup" "git rev-list --count \$(git merge-base HEAD 'refs/heads/<default>')..'refs/heads/<default>'" \
     "an absent local ref for origin's default did not fall back to the runtime base check"
   assert_contains "$setup" 'blocked: cannot determine the default branch to verify base freshness' \
     "the runtime fallback dropped its blocked-and-stop requirement"
@@ -595,7 +639,7 @@ test_ambiguous_origin_head_still_resolves_the_real_default_branch() {
     "the brief did not name the real default branch in its zero-only criterion"
   assert_not_contains "$setup" 'your local default branch `main`' \
     "an ambiguous origin/HEAD abbreviation substituted main for the real default branch"
-  assert_not_contains "$setup" 'git rev-list --count $(git merge-base HEAD refs/heads/<default>)..refs/heads/<default>' \
+  assert_not_contains "$setup" "git rev-list --count \$(git merge-base HEAD 'refs/heads/<default>')..'refs/heads/<default>'" \
     "a resolvable default branch was deferred to the runtime fallback"
   assert_contains "$rules" 'firstmate handles the merge into local `develop`' \
     "Rule 1 named a branch other than the real default"
@@ -743,9 +787,9 @@ test_unresolved_scout_fallback_degrades_to_a_local_default() {
 
   assert_contains "$scout_setup" 'git fetch origin --quiet' \
     "the scout fallback dropped the single fetch that precedes its origin comparison"
-  assert_contains "$scout_setup" 'git rev-list --count $(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>' \
+  assert_contains "$scout_setup" "git rev-list --count \$(git merge-base HEAD 'refs/remotes/origin/<default>')..'refs/remotes/origin/<default>'" \
     "the scout fallback lost its origin-first zero-count command"
-  assert_contains "$scout_setup" 'git rev-list --count $(git merge-base HEAD refs/heads/<default>)..refs/heads/<default>' \
+  assert_contains "$scout_setup" "git rev-list --count \$(git merge-base HEAD 'refs/heads/<default>')..'refs/heads/<default>'" \
     "the scout fallback never degrades to a local default when origin cannot be established"
   assert_contains "$scout_setup" 'If no usable origin default remains after that single fetch' \
     "the scout fallback did not gate its local degradation on origin being unusable after the fetch"
@@ -756,7 +800,7 @@ test_unresolved_scout_fallback_degrades_to_a_local_default() {
   assert_not_contains "$scout_setup" 'This task lands locally' \
     "the scout fallback claimed the task lands locally"
 
-  assert_not_contains "$ship_setup" 'git rev-list --count $(git merge-base HEAD refs/heads/<default>)..refs/heads/<default>' \
+  assert_not_contains "$ship_setup" "git rev-list --count \$(git merge-base HEAD 'refs/heads/<default>')..'refs/heads/<default>'" \
     "a PR-path fallback degraded to a local base instead of requiring origin"
   pass "fm-brief.sh: an unresolved scout fallback degrades to a local default before blocking"
 }
@@ -797,7 +841,7 @@ test_scout_fallback_fetches_before_verifying_and_degrades_like_the_resolved_path
     "the resolved scout path stopped degrading to the local default branch"
 
   fetch_line=$(printf '%s\n' "$unresolved_setup" | grep -n -F -m1 'git fetch origin --quiet' | cut -d: -f1)
-  verify_line=$(printf '%s\n' "$unresolved_setup" | grep -n -F -m1 'git rev-parse --verify refs/remotes/origin/<default>' | cut -d: -f1)
+  verify_line=$(printf '%s\n' "$unresolved_setup" | grep -n -F -m1 "git rev-parse --verify 'refs/remotes/origin/<default>'" | cut -d: -f1)
   [ -n "$fetch_line" ] || fail "the scout fallback dropped its single fetch"
   [ -n "$verify_line" ] || fail "the scout fallback dropped its origin tracking-ref verification"
   [ "$fetch_line" -lt "$verify_line" ] \
@@ -1363,6 +1407,7 @@ test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_base_freshness_check_is_resolved_and_mode_aware
 test_resolved_default_branch_is_shell_quoted_in_the_freshness_command
+test_runtime_fallback_ref_stays_one_shell_word
 test_emitted_base_command_survives_a_same_named_tag
 test_unresolvable_repo_label_still_mandates_the_base_check
 test_missing_origin_head_never_relabels_the_current_branch

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -528,10 +528,10 @@ test_unresolved_scout_fallback_degrades_to_a_local_default() {
     "the scout fallback lost its origin-first zero-count command"
   assert_contains "$scout_setup" 'git rev-list --count $(git merge-base HEAD <default>)..<default>' \
     "the scout fallback never degrades to a local default when origin cannot be established"
-  assert_contains "$scout_setup" 'Only when this clone has no origin default at all' \
-    "the scout fallback did not gate its local degradation on origin being unavailable"
-  assert_contains "$scout_setup" 'Do not fetch in that case' \
-    "the scout local degradation did not forbid the network refresh"
+  assert_contains "$scout_setup" 'If no usable origin default remains after that single fetch' \
+    "the scout fallback did not gate its local degradation on origin being unusable after the fetch"
+  assert_contains "$scout_setup" 'NO further network refresh' \
+    "the scout local degradation did not forbid an additional network refresh"
   assert_contains "$scout_setup" 'blocked: cannot determine the default branch to verify base freshness' \
     "the scout fallback dropped its block-and-stop requirement"
   assert_not_contains "$scout_setup" 'This task lands locally' \
@@ -540,6 +540,57 @@ test_unresolved_scout_fallback_degrades_to_a_local_default() {
   assert_not_contains "$ship_setup" 'git rev-list --count $(git merge-base HEAD <default>)..<default>' \
     "a PR-path fallback degraded to a local base instead of requiring origin"
   pass "fm-brief.sh: an unresolved scout fallback degrades to a local default before blocking"
+}
+
+# The scout runtime fallback must not block where the same scaffold's resolved
+# path degrades. A clone whose origin/HEAD names a branch with a pruned or
+# never-fetched tracking ref is the case: the single permitted fetch is what
+# restores that ref, so verification must follow it, and the local degradation
+# must name the branch origin/HEAD points at rather than only main/master.
+# shellcheck disable=SC2016 # Literal brief text: the backticks and $(...) must stay unexpanded.
+test_scout_fallback_fetches_before_verifying_and_degrades_like_the_resolved_path() {
+  local home pruned resolved_setup unresolved_setup fetch_line verify_line
+  home="$TMP_ROOT/scout-pruned-home"
+  pruned="$BRIEF_PROJECTS/pruned"
+  mkdir -p "$home/data"
+
+  fm_git_init_commit "$pruned"
+  git -C "$pruned" branch -M develop
+  fm_git_add_origin "$pruned" "$pruned.origin.git"
+  git -C "$pruned" fetch --quiet origin
+  git -C "$pruned" remote set-head origin --auto >/dev/null
+  git -C "$pruned" update-ref -d refs/remotes/origin/develop
+  [ "$(git -C "$pruned" symbolic-ref --short refs/remotes/origin/HEAD)" = "origin/develop" ] \
+    || fail "fixture origin/HEAD does not name develop"
+  git -C "$pruned" rev-parse --verify --quiet refs/heads/develop >/dev/null \
+    || fail "fixture lost its local develop branch"
+  git -C "$pruned" rev-parse --verify --quiet refs/remotes/origin/develop >/dev/null 2>&1 \
+    && fail "fixture still has the origin/develop tracking ref"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" pruned-resolved pruned --scout >/dev/null 2>&1 \
+    || fail "a resolvable scout label must scaffold against a pruned tracking ref"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" pruned-unresolved comms --scout >/dev/null 2>&1 \
+    || fail "an unresolvable scout label must scaffold against the same state"
+  resolved_setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/pruned-resolved/brief.md")
+  unresolved_setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/pruned-unresolved/brief.md")
+
+  assert_contains "$resolved_setup" 'git rev-list --count $(git merge-base HEAD develop)..develop' \
+    "the resolved scout path stopped degrading to the local default branch"
+
+  fetch_line=$(printf '%s\n' "$unresolved_setup" | grep -n -F -m1 'git fetch origin --quiet' | cut -d: -f1)
+  verify_line=$(printf '%s\n' "$unresolved_setup" | grep -n -F -m1 'git rev-parse --verify origin/<default>' | cut -d: -f1)
+  [ -n "$fetch_line" ] || fail "the scout fallback dropped its single fetch"
+  [ -n "$verify_line" ] || fail "the scout fallback dropped its origin tracking-ref verification"
+  [ "$fetch_line" -lt "$verify_line" ] \
+    || fail "the scout fallback verifies origin/<default> before the fetch that would create it"
+
+  assert_contains "$unresolved_setup" 'that name with the leading `origin/` dropped IS `<default>`' \
+    "the scout local degradation does not name the branch origin/HEAD points at"
+  assert_contains "$unresolved_setup" 'Only when that ref is absent entirely may `<default>` be the local `main` or `master`' \
+    "the scout local degradation offered main/master without gating on an absent origin/HEAD"
+  assert_not_contains "$unresolved_setup" 'This task lands locally' \
+    "the scout fallback claimed the task lands locally"
+  pass "fm-brief.sh: the scout fallback fetches before verifying and degrades like its resolved path"
 }
 
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
@@ -1099,6 +1150,7 @@ test_absent_local_ref_for_origin_default_never_substitutes_another_branch
 test_local_only_rule_names_the_resolved_default_branch
 test_scout_local_fallback_uses_kind_neutral_wording
 test_unresolved_scout_fallback_degrades_to_a_local_default
+test_scout_fallback_fetches_before_verifying_and_degrades_like_the_resolved_path
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -529,6 +529,72 @@ test_ambiguous_origin_head_still_resolves_the_real_default_branch() {
   pass "fm-brief.sh: an ambiguous origin/HEAD abbreviation still resolves the real default branch"
 }
 
+# The runtime local-default rule is generated worker-facing output that a
+# crewmate executes verbatim, so it is held to the same standard as the
+# scaffold-side resolution. Reading origin/HEAD through the ambiguity-dependent
+# `--short` form and then confirming a bare `<default>` let the remote-tracking
+# ref satisfy a guard meant to prove a LOCAL branch exists, so a local-only
+# worker measured zero against origin while its local default was ahead.
+# shellcheck disable=SC2016 # Literal brief text: the backticks and $(...) must stay unexpanded.
+test_runtime_local_default_rule_resolves_a_local_branch_not_a_tracking_ref() {
+  local home stale worktree setup symbolic_cmd strip_prefix verify_cmd count_cmd
+  local head_ref resolved_default count tracking_ref
+  tracking_ref='remotes/origin/develop'
+  home="$TMP_ROOT/runtime-local-rule-home"
+  stale="$BRIEF_PROJECTS/stale-local-default"
+  worktree="$TMP_ROOT/stale-local-default-worktree"
+  mkdir -p "$home/data"
+
+  [ ! -d "$BRIEF_PROJECTS/unresolvable-stale" ] || fail "fixture leak: unresolvable-stale must not resolve"
+
+  fm_git_init_commit "$stale"
+  git -C "$stale" branch -M develop
+  fm_git_add_origin "$stale" "$stale.origin.git"
+  git -C "$stale" fetch --quiet origin
+  git -C "$stale" remote set-head origin --auto >/dev/null
+  git -C "$stale" tag origin/develop
+  printf '%s\n' 'the local default advances' >> "$stale/README.md"
+  git -C "$stale" add README.md
+  git -C "$stale" commit -qm 'local develop advances'
+  printf '%s\n' 'the local default advances again' >> "$stale/README.md"
+  git -C "$stale" add README.md
+  git -C "$stale" commit -qm 'local develop advances again'
+  git -C "$stale" worktree add --quiet --detach "$worktree" refs/remotes/origin/develop
+  [ "$(git -C "$stale" symbolic-ref --quiet --short refs/remotes/origin/HEAD)" = 'remotes/origin/develop' ] \
+    || fail "fixture did not make the --short abbreviation of origin/HEAD ambiguous"
+  [ "$(git -C "$worktree" rev-list --count "$(git -C "$worktree" merge-base HEAD develop)..develop")" -eq 2 ] \
+    || fail "fixture worktree is not two commits behind its local default branch"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" runtime-local unresolvable-stale --mode local-only >/dev/null 2>&1 \
+    || fail "an unresolvable local-only label must not fail the scaffold"
+  setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/runtime-local/brief.md")
+
+  symbolic_cmd=$(printf '%s\n' "$setup" | sed -n 's/^.*Read `\(git symbolic-ref [^`]*\)`.*$/\1/p' | head -1)
+  strip_prefix=$(printf '%s\n' "$setup" | sed -n 's/^.*with the leading `\([^`]*\)` dropped.*$/\1/p' | head -1)
+  verify_cmd=$(printf '%s\n' "$setup" | sed -n 's/^.*exists with `\(git rev-parse --verify [^`]*\)`.*$/\1/p' | head -1)
+  count_cmd=$(printf '%s\n' "$setup" | sed -n 's/^   `\(git rev-list --count .*\)`$/\1/p' | head -1)
+  [ -n "$symbolic_cmd" ] || fail "the runtime rule stopped telling the worker how to read origin/HEAD"
+  [ -n "$strip_prefix" ] || fail "the runtime rule stopped naming the prefix to strip from origin/HEAD"
+  [ -n "$verify_cmd" ] || fail "the runtime rule stopped telling the worker how to confirm the local branch"
+  [ -n "$count_cmd" ] || fail "the runtime rule stopped emitting its zero-count command"
+
+  head_ref=$(cd "$worktree" && eval "$symbolic_cmd") \
+    || fail "the emitted origin/HEAD read failed against the fixture"
+  resolved_default=${head_ref#"$strip_prefix"}
+  [ "$resolved_default" = develop ] \
+    || fail "the emitted rule resolved \`$resolved_default\` instead of the real default branch develop"
+  (cd "$worktree" && eval "${verify_cmd//<default>/$resolved_default}" >/dev/null 2>&1) \
+    || fail "the emitted confirmation rejected the real local default branch"
+  (cd "$worktree" && eval "${verify_cmd//<default>/$tracking_ref}" >/dev/null 2>&1) \
+    && fail "the emitted confirmation accepted a remote-tracking ref as the local default branch"
+
+  count=$(cd "$worktree" && eval "${count_cmd//<default>/$resolved_default}") \
+    || fail "the emitted zero-count command failed against the fixture"
+  [ "$count" -eq 2 ] \
+    || fail "the emitted check measured $count against the local default branch instead of 2"
+  pass "fm-brief.sh: the runtime local-default rule resolves a local branch, never a tracking ref"
+}
+
 # The generated brief must not contradict itself: a local-only task whose Setup
 # rebases onto `release` cannot tell the worker firstmate merges into `main`.
 # shellcheck disable=SC2016 # Literal brief text: the backticks and $(...) must stay unexpanded.
@@ -662,7 +728,7 @@ test_scout_fallback_fetches_before_verifying_and_degrades_like_the_resolved_path
   [ "$fetch_line" -lt "$verify_line" ] \
     || fail "the scout fallback verifies origin/<default> before the fetch that would create it"
 
-  assert_contains "$unresolved_setup" 'that name with the leading `origin/` dropped IS `<default>`' \
+  assert_contains "$unresolved_setup" 'that ref with the leading `refs/remotes/origin/` dropped IS `<default>`' \
     "the scout local degradation does not name the branch origin/HEAD points at"
   assert_contains "$unresolved_setup" 'Only when that ref is absent entirely may `<default>` be the local `main` or `master`' \
     "the scout local degradation offered main/master without gating on an absent origin/HEAD"
@@ -1227,6 +1293,7 @@ test_missing_origin_head_never_relabels_the_current_branch
 test_non_root_directory_never_resolves_to_its_enclosing_repo
 test_absent_local_ref_for_origin_default_never_substitutes_another_branch
 test_ambiguous_origin_head_still_resolves_the_real_default_branch
+test_runtime_local_default_rule_resolves_a_local_branch_not_a_tracking_ref
 test_local_only_rule_names_the_resolved_default_branch
 test_scout_local_fallback_uses_kind_neutral_wording
 test_unresolved_scout_fallback_degrades_to_a_local_default

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -345,6 +345,78 @@ test_resolved_default_branch_is_shell_quoted_in_the_freshness_command() {
   pass "fm-brief.sh: resolved default branches are shell-quoted in freshness commands"
 }
 
+# Reads the first command the brief DELIMITS on a line of its own, the way the
+# reading worker does: a markdown code span opens on a backtick run and closes on
+# the first later run of the same length, and one padding space on each side is
+# dropped. The tests below must not assume a one-backtick fence, or they would
+# read past a broken span and pass on output no worker could run.
+brief_delimited_command() {  # <setup-text> <command-prefix>
+  perl - "$2" "$1" <<'PERL'
+use strict;
+use warnings;
+
+my ($prefix, $text) = @ARGV;
+for my $line (split /\n/, $text) {
+  next unless $line =~ /^\s*(`+)(.*)$/;
+  my ($fence, $rest) = ($1, $2);
+  my $content;
+  while ($rest =~ /(`+)/g) {
+    next unless length($1) == length($fence);
+    $content = substr($rest, 0, $-[1]);
+    last;
+  }
+  next unless defined $content;
+  $content = $1 if $content =~ /^ (.*) $/;
+  next unless index($content, $prefix) == 0;
+  print "$content\n";
+  exit 0;
+}
+exit 1;
+PERL
+}
+
+# git permits a backtick in a refname, and the brief is generated worker-facing
+# output whose markdown code span is what tells the worker where the mandatory
+# command ends. A fixed one-backtick fence closes on the ref's own backtick, so
+# the worker is handed a truncated, unrunnable fragment of the freshness check
+# while the scaffold still reports success - the check silently stops existing
+# for that repo. Drive such a branch through the scaffold and run exactly what
+# the brief delimits.
+test_resolved_default_branch_survives_a_backtick_in_its_name() {
+  local home backtick worktree setup freshness_command count branch
+  home="$TMP_ROOT/backtick-default-home"
+  backtick="$BRIEF_PROJECTS/backtick-default"
+  worktree="$TMP_ROOT/backtick-default-worktree"
+  branch='rel`ease'
+  mkdir -p "$home/data"
+
+  fm_git_init_commit "$backtick"
+  git -C "$backtick" branch -M "$branch"
+  fm_git_add_origin "$backtick" "$backtick.origin.git"
+  git -C "$backtick" worktree add --quiet --detach "$worktree" HEAD
+  printf '%s\n' 'the default branch advances' >> "$backtick/README.md"
+  git -C "$backtick" add README.md
+  git -C "$backtick" commit -qm 'default branch advances'
+  printf '%s\n' 'the default branch advances again' >> "$backtick/README.md"
+  git -C "$backtick" add README.md
+  git -C "$backtick" commit -qm 'default branch advances again'
+  git -C "$backtick" push --quiet origin "$branch"
+  git -C "$backtick" fetch --quiet origin
+  git -C "$backtick" remote set-head origin --auto >/dev/null
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" backtick-base backtick-default --mode direct-PR >/dev/null 2>&1 \
+    || fail "a backtick in the default branch name must not fail the scaffold"
+  setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/backtick-base/brief.md")
+  freshness_command=$(brief_delimited_command "$setup" 'git rev-list --count ') \
+    || fail "the brief delimited no complete freshness command for a backtick default branch"
+
+  count=$(cd "$worktree" && eval "$freshness_command") \
+    || fail "the delimited freshness command did not run against a backtick default branch"
+  [ "$count" -eq 2 ] \
+    || fail "the delimited command measured '$count' instead of 2 commits behind the default branch"
+  pass "fm-brief.sh: a backtick in the default branch name still delimits a runnable command"
+}
+
 # The runtime twin of the test above. An unresolvable repo label leaves the base
 # to be named by the WORKER at runtime, so the emitted command carries a
 # `<default>` placeholder instead of a scaffold-quoted ref. git permits refnames
@@ -1407,6 +1479,7 @@ test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_base_freshness_check_is_resolved_and_mode_aware
 test_resolved_default_branch_is_shell_quoted_in_the_freshness_command
+test_resolved_default_branch_survives_a_backtick_in_its_name
 test_runtime_fallback_ref_stays_one_shell_word
 test_emitted_base_command_survives_a_same_named_tag
 test_unresolvable_repo_label_still_mandates_the_base_check

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -18,6 +18,7 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+fm_git_identity
 TMP_ROOT=$(fm_test_tmproot fm-brief)
 BRIEF_HOME="$TMP_ROOT/home"
 mkdir -p "$BRIEF_HOME/data"
@@ -315,6 +316,7 @@ test_base_freshness_check_is_resolved_and_mode_aware() {
 # names repos this scaffold has no local view of, so an unresolvable label must
 # still produce a brief - and that brief must still carry the mandatory check
 # with the base determined by the worker at runtime.
+# shellcheck disable=SC2016 # Literal brief text: the backticks and $(...) must stay unexpanded.
 test_unresolvable_repo_label_still_mandates_the_base_check() {
   local home ship scout ship_setup scout_setup
   home="$TMP_ROOT/unresolvable-repo-home"
@@ -350,6 +352,7 @@ test_unresolvable_repo_label_still_mandates_the_base_check() {
 # A clone with no origin/HEAD that is stranded on a feature branch (the worktree
 # tangle bin/fm-tangle-lib.sh detects) must never have that feature branch
 # rendered as its own base - the brief would then certify a wrong base as fresh.
+# shellcheck disable=SC2016 # Literal brief text: the backticks and $(...) must stay unexpanded.
 test_missing_origin_head_never_relabels_the_current_branch() {
   local home stranded setup
   home="$TMP_ROOT/stranded-head-home"
@@ -379,6 +382,7 @@ test_missing_origin_head_never_relabels_the_current_branch() {
 # directory that is merely INSIDE a work tree must never resolve: it would render
 # the enclosing repo's default branch as an unrelated project's base - a
 # confidently-wrong base with no error, the exact class this check exists to stop.
+# shellcheck disable=SC2016 # Literal brief text: the backticks and $(...) must stay unexpanded.
 test_non_root_directory_never_resolves_to_its_enclosing_repo() {
   local home enclosing setup
   home="$TMP_ROOT/non-root-home"
@@ -409,6 +413,7 @@ test_non_root_directory_never_resolves_to_its_enclosing_repo() {
 # origin/HEAD is the authority on the default branch NAME. When the clone has no
 # local ref for it, no other branch may be presented as "your local default
 # branch"; the strict runtime fallback must take over instead.
+# shellcheck disable=SC2016 # Literal brief text: the backticks and $(...) must stay unexpanded.
 test_absent_local_ref_for_origin_default_never_substitutes_another_branch() {
   local home diverged setup
   home="$TMP_ROOT/absent-local-ref-home"
@@ -441,11 +446,16 @@ test_absent_local_ref_for_origin_default_never_substitutes_another_branch() {
     "an absent local ref for origin's default did not fall back to the runtime base check"
   assert_contains "$setup" 'blocked: cannot determine the default branch to verify base freshness' \
     "the runtime fallback dropped its blocked-and-stop requirement"
+  assert_contains "$setup" 'Only when that ref is absent entirely' \
+    "the runtime fallback did not gate the main/master guess on origin/HEAD being absent"
+  assert_contains "$setup" 'Never substitute `main`, `master`, or whatever branch happens to be checked out' \
+    "the runtime fallback did not forbid substituting a branch for a missing default"
   pass "fm-brief.sh: an absent local ref for origin's default never substitutes another branch"
 }
 
 # The generated brief must not contradict itself: a local-only task whose Setup
 # rebases onto `release` cannot tell the worker firstmate merges into `main`.
+# shellcheck disable=SC2016 # Literal brief text: the backticks and $(...) must stay unexpanded.
 test_local_only_rule_names_the_resolved_default_branch() {
   local home rules setup
   home="$TMP_ROOT/local-rule-home"
@@ -468,6 +478,7 @@ test_local_only_rule_names_the_resolved_default_branch() {
 # A scout lands nowhere - its deliverable is a report and it may never push. When
 # it falls back to a local comparison it must be told WHY (origin's default could
 # not be resolved), never that its task "lands locally".
+# shellcheck disable=SC2016 # Literal brief text: the backticks and $(...) must stay unexpanded.
 test_scout_local_fallback_uses_kind_neutral_wording() {
   local home remoteless setup
   home="$TMP_ROOT/scout-neutral-home"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -21,6 +21,25 @@ set -u
 TMP_ROOT=$(fm_test_tmproot fm-brief)
 BRIEF_HOME="$TMP_ROOT/home"
 mkdir -p "$BRIEF_HOME/data"
+BRIEF_PROJECTS="$TMP_ROOT/projects"
+
+# Brief generation now resolves its named repo from the configured project root.
+# These local-only fixtures carry a non-main default branch and a local origin
+# so the generated command is tested against the actual delivery-path ref.
+init_brief_project() {
+  local name=$1 repo
+  repo="$BRIEF_PROJECTS/$name"
+  fm_git_init_commit "$repo"
+  git -C "$repo" branch -M release
+  fm_git_add_origin "$repo" "$repo.origin.git"
+  git -C "$repo" fetch --quiet origin
+  git -C "$repo" remote set-head origin --auto >/dev/null
+}
+
+for brief_project in some-proj direct-proj local-proj never-registered firstmate foreign sample alpha; do
+  init_brief_project "$brief_project"
+done
+export FM_PROJECTS_OVERRIDE="$BRIEF_PROJECTS"
 
 # The script itself must always parse under the ambient bash. That is Bash 5 in
 # CI and locally, where the issue #958/#1069 parser bug does not fire, so this
@@ -215,6 +234,71 @@ test_ship_modes_generate_clean_briefs() {
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
+}
+
+test_base_freshness_check_is_resolved_and_mode_aware() {
+  local home ship local_brief scout ship_setup local_setup scout_setup ship_dod local_dod scout_dod local_ahead
+  home="$TMP_ROOT/base-freshness-home"
+  mkdir -p "$home/data"
+
+  printf '%s\n' 'local-only default moves ahead of origin' >> "$BRIEF_PROJECTS/local-proj/README.md"
+  git -C "$BRIEF_PROJECTS/local-proj" add README.md
+  git -C "$BRIEF_PROJECTS/local-proj" commit -qm 'local default advances'
+  local_ahead=$(git -C "$BRIEF_PROJECTS/local-proj" rev-list --count origin/release..release)
+  [ "$local_ahead" -gt 0 ] || fail "local-only fixture did not move its local default branch ahead of origin"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" base-pr direct-proj --mode direct-PR >/dev/null 2>&1 \
+    || fail "PR brief should scaffold with a resolved default branch"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" base-local local-proj --mode local-only >/dev/null 2>&1 \
+    || fail "local-only brief should scaffold with a resolved local default branch"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" base-scout sample --scout >/dev/null 2>&1 \
+    || fail "scout brief should scaffold with a resolved default branch"
+
+  ship="$home/data/base-pr/brief.md"
+  local_brief="$home/data/base-local/brief.md"
+  scout="$home/data/base-scout/brief.md"
+  ship_setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$ship")
+  local_setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$local_brief")
+  scout_setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$scout")
+  ship_dod=$(sed -n '/^# Definition of done$/,$p' "$ship")
+  local_dod=$(sed -n '/^# Definition of done$/,$p' "$local_brief")
+  scout_dod=$(sed -n '/^# Definition of done$/,$p' "$scout")
+
+  assert_contains "$ship_setup" "1. **First startup step - check your base before starting work.**" \
+    "ship brief did not make the base check its first startup step"
+  assert_contains "$ship_setup" "git rev-list --count \$(git merge-base HEAD origin/release)..origin/release" \
+    "PR brief did not check the resolved remote default branch"
+  assert_contains "$ship_setup" "Only \`0\` passes against the fetched default branch \`origin/release\`." \
+    "PR brief did not state the zero-only pass criterion"
+  assert_contains "$ship_setup" "2. Create your branch: \`git checkout -b fm/base-pr\`" \
+    "ship brief did not put branch creation after its freshness check"
+  assert_not_contains "$ship_setup" 'on a clean default branch' \
+    "ship brief retained an unchecked clean-base assertion"
+  assert_not_contains "$ship_setup" 'origin/main' \
+    "PR brief hard-coded main instead of the resolved default branch"
+  assert_not_contains "$ship_dod" 'git rev-list --count' \
+    "PR brief put the freshness check in Definition of done instead of Setup"
+
+  assert_contains "$local_setup" "git rev-list --count \$(git merge-base HEAD release)..release" \
+    "local-only brief did not check its local default branch"
+  assert_contains "$local_setup" "Only \`0\` passes against your local default branch \`release\`." \
+    "local-only brief did not explain its local zero-only criterion"
+  assert_not_contains "$local_setup" 'origin/release' \
+    "local-only brief used the stale origin tracking ref instead of its local default branch"
+  assert_not_contains "$local_dod" 'git rev-list --count' \
+    "local-only brief put the freshness check in Definition of done instead of Setup"
+
+  assert_contains "$scout_setup" "1. **First startup step - check your base before starting work.**" \
+    "scout brief did not make the base check its first startup step"
+  assert_contains "$scout_setup" "git rev-list --count \$(git merge-base HEAD origin/release)..origin/release" \
+    "scout brief did not check the resolved default branch"
+  assert_contains "$scout_setup" "Only \`0\` passes against the fetched default branch \`origin/release\`." \
+    "scout brief did not state the zero-only pass criterion"
+  assert_not_contains "$scout_setup" 'on a clean default branch' \
+    "scout brief retained an unchecked clean-base assertion"
+  assert_not_contains "$scout_dod" 'git rev-list --count' \
+    "scout brief put the freshness check in Definition of done instead of Setup"
+  pass "fm-brief.sh: startup base freshness is resolved, zero-only, and mode-aware"
 }
 
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
@@ -766,6 +850,7 @@ test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_base_freshness_check_is_resolved_and_mode_aware
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -269,7 +269,7 @@ test_base_freshness_check_is_resolved_and_mode_aware() {
     "ship brief did not number worktree isolation as the first safety step"
   assert_contains "$ship_setup" "2. **Check your base before starting work.**" \
     "ship brief did not number the base check as the second safety step"
-  assert_contains "$ship_setup" "git rev-list --count \$(git merge-base HEAD origin/release)..origin/release" \
+  assert_contains "$ship_setup" "git rev-list --count \$(git merge-base HEAD 'origin/release')..'origin/release'" \
     "PR brief did not check the resolved remote default branch"
   assert_contains "$ship_setup" "Only \`0\` passes against the freshly fetched default branch \`origin/release\`." \
     "PR brief did not state the zero-only pass criterion"
@@ -286,7 +286,7 @@ test_base_freshness_check_is_resolved_and_mode_aware() {
   assert_not_contains "$ship_dod" 'git rev-list --count' \
     "PR brief put the freshness check in Definition of done instead of Setup"
 
-  assert_contains "$local_setup" "git rev-list --count \$(git merge-base HEAD release)..release" \
+  assert_contains "$local_setup" "git rev-list --count \$(git merge-base HEAD 'release')..'release'" \
     "local-only brief did not check its local default branch"
   assert_contains "$local_setup" "Only \`0\` passes against your local default branch \`release\`." \
     "local-only brief did not explain its local zero-only criterion"
@@ -299,7 +299,7 @@ test_base_freshness_check_is_resolved_and_mode_aware() {
 
   assert_contains "$scout_setup" "1. **Check your base before starting work.**" \
     "scout brief did not make the base check its first numbered startup step"
-  assert_contains "$scout_setup" "git rev-list --count \$(git merge-base HEAD origin/release)..origin/release" \
+  assert_contains "$scout_setup" "git rev-list --count \$(git merge-base HEAD 'origin/release')..'origin/release'" \
     "scout brief did not check the resolved default branch"
   assert_contains "$scout_setup" "Only \`0\` passes against the freshly fetched default branch \`origin/release\`." \
     "scout brief did not state the zero-only pass criterion"
@@ -310,6 +310,39 @@ test_base_freshness_check_is_resolved_and_mode_aware() {
   assert_not_contains "$scout_dod" 'git rev-list --count' \
     "scout brief put the freshness check in Definition of done instead of Setup"
   pass "fm-brief.sh: startup base freshness is resolved, zero-only, and mode-aware"
+}
+
+# The default branch is data from a repository, but resolved briefs embed it in
+# commands that workers execute. A shell-significant ref must therefore render
+# as one shell word, not become a second command in the worker's shell.
+# shellcheck disable=SC2016 # The fixture branch must contain the literal $IFS expansion attempt.
+test_resolved_default_branch_is_shell_quoted_in_the_freshness_command() {
+  local home unsafe marker marker_name setup freshness_command unsafe_branch
+  home="$TMP_ROOT/shell-quoted-default-home"
+  unsafe="$BRIEF_PROJECTS/shell-quoted-default"
+  marker_name='branch-name-command-ran'
+  marker="$unsafe/$marker_name"
+  mkdir -p "$home/data"
+
+  unsafe_branch="release;touch\$IFS\$9$marker_name"
+  fm_git_init_commit "$unsafe"
+  git -C "$unsafe" branch -M "$unsafe_branch"
+  fm_git_add_origin "$unsafe" "$unsafe.origin.git"
+  git -C "$unsafe" fetch --quiet origin
+  git -C "$unsafe" remote set-head origin --auto >/dev/null
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" shell-quoted shell-quoted-default --mode direct-PR >/dev/null 2>&1 \
+    || fail "a shell-significant default branch should scaffold successfully"
+  setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/shell-quoted/brief.md")
+  freshness_command=$(printf '%s\n' "$setup" | sed -n 's/^   `\(git rev-list --count .*\)`$/\1/p')
+
+  assert_contains "$freshness_command" "git rev-list --count \$(git merge-base HEAD 'origin/$unsafe_branch')..'origin/$unsafe_branch'" \
+    "the resolved default branch was not shell-quoted in the freshness command"
+  [ -n "$freshness_command" ] || fail "the resolved brief did not render a freshness command"
+  (cd "$unsafe" && bash -c "$freshness_command") >/dev/null 2>&1 \
+    || fail "the shell-quoted freshness command did not execute against its default branch"
+  assert_absent "$marker" "the rendered default branch executed a shell command"
+  pass "fm-brief.sh: resolved default branches are shell-quoted in freshness commands"
 }
 
 # The repo positional is a caller-supplied label, not a path contract: firstmate
@@ -373,7 +406,7 @@ test_missing_origin_head_never_relabels_the_current_branch() {
 
   assert_not_contains "$setup" 'fm/old-task' \
     "the checked-out feature branch was rendered as the local default branch"
-  assert_contains "$setup" 'git rev-list --count $(git merge-base HEAD main)..main' \
+  assert_contains "$setup" "git rev-list --count \$(git merge-base HEAD 'main')..'main'" \
     "the stranded clone did not fall back to its local default-branch ref"
   pass "fm-brief.sh: a missing origin/HEAD never relabels the current feature branch"
 }
@@ -466,7 +499,7 @@ test_local_only_rule_names_the_resolved_default_branch() {
   setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/rule-local/brief.md")
   rules=$(sed -n '/^# Rules$/,/^# Firstmate instruction inbox$/p' "$home/data/rule-local/brief.md")
 
-  assert_contains "$setup" 'rebase onto `release`' \
+  assert_contains "$setup" "rebase onto \`'release'\`" \
     "the local-only fixture no longer resolves its non-main default branch"
   assert_contains "$rules" 'firstmate handles the merge into local `release`' \
     "Rule 1 named a branch other than the resolved local default"
@@ -493,7 +526,7 @@ test_scout_local_fallback_uses_kind_neutral_wording() {
     || fail "scout brief should scaffold against a remoteless clone"
   setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/neutral-scout/brief.md")
 
-  assert_contains "$setup" 'git rev-list --count $(git merge-base HEAD main)..main' \
+  assert_contains "$setup" "git rev-list --count \$(git merge-base HEAD 'main')..'main'" \
     "the scout local fallback did not measure against the local default branch"
   assert_not_contains "$setup" 'This task lands locally' \
     "the scout brief claimed its task lands locally"
@@ -574,7 +607,7 @@ test_scout_fallback_fetches_before_verifying_and_degrades_like_the_resolved_path
   resolved_setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/pruned-resolved/brief.md")
   unresolved_setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/pruned-unresolved/brief.md")
 
-  assert_contains "$resolved_setup" 'git rev-list --count $(git merge-base HEAD develop)..develop' \
+  assert_contains "$resolved_setup" "git rev-list --count \$(git merge-base HEAD 'develop')..'develop'" \
     "the resolved scout path stopped degrading to the local default branch"
 
   fetch_line=$(printf '%s\n' "$unresolved_setup" | grep -n -F -m1 'git fetch origin --quiet' | cut -d: -f1)
@@ -1143,6 +1176,7 @@ test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_base_freshness_check_is_resolved_and_mode_aware
+test_resolved_default_branch_is_shell_quoted_in_the_freshness_command
 test_unresolvable_repo_label_still_mandates_the_base_check
 test_missing_origin_head_never_relabels_the_current_branch
 test_non_root_directory_never_resolves_to_its_enclosing_repo

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -375,6 +375,122 @@ test_missing_origin_head_never_relabels_the_current_branch() {
   pass "fm-brief.sh: a missing origin/HEAD never relabels the current feature branch"
 }
 
+# `projects/` is a gitignored subdirectory of the firstmate checkout itself, so a
+# directory that is merely INSIDE a work tree must never resolve: it would render
+# the enclosing repo's default branch as an unrelated project's base - a
+# confidently-wrong base with no error, the exact class this check exists to stop.
+test_non_root_directory_never_resolves_to_its_enclosing_repo() {
+  local home enclosing setup
+  home="$TMP_ROOT/non-root-home"
+  enclosing="$TMP_ROOT/enclosing-checkout"
+  mkdir -p "$home/data"
+
+  fm_git_init_commit "$enclosing"
+  git -C "$enclosing" branch -M trunk
+  fm_git_add_origin "$enclosing" "$enclosing.origin.git"
+  git -C "$enclosing" fetch --quiet origin
+  git -C "$enclosing" remote set-head origin --auto >/dev/null
+  mkdir -p "$enclosing/projects/webapp"
+  [ "$(git -C "$enclosing/projects/webapp" rev-parse --show-toplevel)" = "$(cd "$enclosing" && pwd -P)" ] \
+    || fail "fixture is not a plain directory inside the enclosing work tree"
+
+  FM_PROJECTS_OVERRIDE="$enclosing/projects" FM_HOME="$home" \
+    "$ROOT/bin/fm-brief.sh" non-root webapp --mode direct-PR >/dev/null 2>&1 \
+    || fail "a non-root project directory must not fail the scaffold"
+  setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/non-root/brief.md")
+
+  assert_not_contains "$setup" 'origin/trunk' \
+    "a plain directory inside a work tree rendered the enclosing repo's default branch as its base"
+  assert_contains "$setup" 'git rev-list --count $(git merge-base HEAD origin/<default>)..origin/<default>' \
+    "a non-root project directory did not fall back to the runtime base check"
+  pass "fm-brief.sh: a directory inside a work tree never resolves as that project's repo"
+}
+
+# origin/HEAD is the authority on the default branch NAME. When the clone has no
+# local ref for it, no other branch may be presented as "your local default
+# branch"; the strict runtime fallback must take over instead.
+test_absent_local_ref_for_origin_default_never_substitutes_another_branch() {
+  local home diverged setup
+  home="$TMP_ROOT/absent-local-ref-home"
+  diverged="$BRIEF_PROJECTS/diverged"
+  mkdir -p "$home/data"
+
+  fm_git_init_commit "$diverged"
+  git -C "$diverged" branch -M develop
+  fm_git_add_origin "$diverged" "$diverged.origin.git"
+  git -C "$diverged" fetch --quiet origin
+  git -C "$diverged" remote set-head origin --auto >/dev/null
+  git -C "$diverged" checkout -q -b main
+  printf '%s\n' 'diverged' >> "$diverged/README.md"
+  git -C "$diverged" add README.md
+  git -C "$diverged" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm 'local main diverges from the default branch'
+  git -C "$diverged" branch -D develop >/dev/null
+  [ "$(git -C "$diverged" symbolic-ref --short refs/remotes/origin/HEAD)" = "origin/develop" ] \
+    || fail "fixture origin/HEAD does not name develop"
+  git -C "$diverged" rev-parse --verify --quiet refs/heads/develop >/dev/null 2>&1 \
+    && fail "fixture still has a local develop ref"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" absent-ref diverged --mode local-only >/dev/null 2>&1 \
+    || fail "an absent local ref for origin's default must not fail the scaffold"
+  setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/absent-ref/brief.md")
+
+  assert_not_contains "$setup" 'your local default branch `main`' \
+    "a substitute branch was presented as the repository's local default branch"
+  assert_contains "$setup" 'git rev-list --count $(git merge-base HEAD <default>)..<default>' \
+    "an absent local ref for origin's default did not fall back to the runtime base check"
+  assert_contains "$setup" 'blocked: cannot determine the default branch to verify base freshness' \
+    "the runtime fallback dropped its blocked-and-stop requirement"
+  pass "fm-brief.sh: an absent local ref for origin's default never substitutes another branch"
+}
+
+# The generated brief must not contradict itself: a local-only task whose Setup
+# rebases onto `release` cannot tell the worker firstmate merges into `main`.
+test_local_only_rule_names_the_resolved_default_branch() {
+  local home rules setup
+  home="$TMP_ROOT/local-rule-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" rule-local local-proj --mode local-only >/dev/null 2>&1 \
+    || fail "local-only brief should scaffold against the release-default fixture"
+  setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/rule-local/brief.md")
+  rules=$(sed -n '/^# Rules$/,/^# Firstmate instruction inbox$/p' "$home/data/rule-local/brief.md")
+
+  assert_contains "$setup" 'rebase onto `release`' \
+    "the local-only fixture no longer resolves its non-main default branch"
+  assert_contains "$rules" 'firstmate handles the merge into local `release`' \
+    "Rule 1 named a branch other than the resolved local default"
+  assert_not_contains "$rules" 'merge into local `main`' \
+    "Rule 1 kept the hard-coded main that contradicts the resolved Setup base"
+  pass "fm-brief.sh: local-only Rule 1 names the resolved local default branch"
+}
+
+# A scout lands nowhere - its deliverable is a report and it may never push. When
+# it falls back to a local comparison it must be told WHY (origin's default could
+# not be resolved), never that its task "lands locally".
+test_scout_local_fallback_uses_kind_neutral_wording() {
+  local home remoteless setup
+  home="$TMP_ROOT/scout-neutral-home"
+  remoteless="$BRIEF_PROJECTS/remoteless"
+  mkdir -p "$home/data"
+
+  fm_git_init_commit "$remoteless"
+  git -C "$remoteless" branch -M main
+  [ -z "$(git -C "$remoteless" remote)" ] || fail "remoteless fixture unexpectedly has a remote"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" neutral-scout remoteless --scout >/dev/null 2>&1 \
+    || fail "scout brief should scaffold against a remoteless clone"
+  setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/neutral-scout/brief.md")
+
+  assert_contains "$setup" 'git rev-list --count $(git merge-base HEAD main)..main' \
+    "the scout local fallback did not measure against the local default branch"
+  assert_not_contains "$setup" 'This task lands locally' \
+    "the scout brief claimed its task lands locally"
+  assert_contains "$setup" "Origin's default branch could not be resolved, so do not fetch" \
+    "the scout local fallback did not explain why it skips the network refresh"
+  pass "fm-brief.sh: a scout local fallback explains itself without claiming it lands locally"
+}
+
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
 # unusable value must stop the scaffold instead of silently defaulting. The
 # no-mistakes-prod-only row is the conditional registry policy: it is never a task
@@ -927,6 +1043,10 @@ test_ship_modes_generate_clean_briefs
 test_base_freshness_check_is_resolved_and_mode_aware
 test_unresolvable_repo_label_still_mandates_the_base_check
 test_missing_origin_head_never_relabels_the_current_branch
+test_non_root_directory_never_resolves_to_its_enclosing_repo
+test_absent_local_ref_for_origin_default_never_substitutes_another_branch
+test_local_only_rule_names_the_resolved_default_branch
+test_scout_local_fallback_uses_kind_neutral_wording
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -269,7 +269,7 @@ test_base_freshness_check_is_resolved_and_mode_aware() {
     "ship brief did not number worktree isolation as the first safety step"
   assert_contains "$ship_setup" "2. **Check your base before starting work.**" \
     "ship brief did not number the base check as the second safety step"
-  assert_contains "$ship_setup" "git rev-list --count \$(git merge-base HEAD 'origin/release')..'origin/release'" \
+  assert_contains "$ship_setup" "git rev-list --count \$(git merge-base HEAD 'refs/remotes/origin/release')..'refs/remotes/origin/release'" \
     "PR brief did not check the resolved remote default branch"
   assert_contains "$ship_setup" "Only \`0\` passes against the freshly fetched default branch \`origin/release\`." \
     "PR brief did not state the zero-only pass criterion"
@@ -286,7 +286,7 @@ test_base_freshness_check_is_resolved_and_mode_aware() {
   assert_not_contains "$ship_dod" 'git rev-list --count' \
     "PR brief put the freshness check in Definition of done instead of Setup"
 
-  assert_contains "$local_setup" "git rev-list --count \$(git merge-base HEAD 'release')..'release'" \
+  assert_contains "$local_setup" "git rev-list --count \$(git merge-base HEAD 'refs/heads/release')..'refs/heads/release'" \
     "local-only brief did not check its local default branch"
   assert_contains "$local_setup" "Only \`0\` passes against your local default branch \`release\`." \
     "local-only brief did not explain its local zero-only criterion"
@@ -299,7 +299,7 @@ test_base_freshness_check_is_resolved_and_mode_aware() {
 
   assert_contains "$scout_setup" "1. **Check your base before starting work.**" \
     "scout brief did not make the base check its first numbered startup step"
-  assert_contains "$scout_setup" "git rev-list --count \$(git merge-base HEAD 'origin/release')..'origin/release'" \
+  assert_contains "$scout_setup" "git rev-list --count \$(git merge-base HEAD 'refs/remotes/origin/release')..'refs/remotes/origin/release'" \
     "scout brief did not check the resolved default branch"
   assert_contains "$scout_setup" "Only \`0\` passes against the freshly fetched default branch \`origin/release\`." \
     "scout brief did not state the zero-only pass criterion"
@@ -336,13 +336,88 @@ test_resolved_default_branch_is_shell_quoted_in_the_freshness_command() {
   setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/shell-quoted/brief.md")
   freshness_command=$(printf '%s\n' "$setup" | sed -n 's/^   `\(git rev-list --count .*\)`$/\1/p')
 
-  assert_contains "$freshness_command" "git rev-list --count \$(git merge-base HEAD 'origin/$unsafe_branch')..'origin/$unsafe_branch'" \
+  assert_contains "$freshness_command" "git rev-list --count \$(git merge-base HEAD 'refs/remotes/origin/$unsafe_branch')..'refs/remotes/origin/$unsafe_branch'" \
     "the resolved default branch was not shell-quoted in the freshness command"
   [ -n "$freshness_command" ] || fail "the resolved brief did not render a freshness command"
   (cd "$unsafe" && bash -c "$freshness_command") >/dev/null 2>&1 \
     || fail "the shell-quoted freshness command did not execute against its default branch"
   assert_absent "$marker" "the rendered default branch executed a shell command"
   pass "fm-brief.sh: resolved default branches are shell-quoted in freshness commands"
+}
+
+# git's rev-parse precedence ranks `refs/tags/<name>` ABOVE `refs/heads/<name>`
+# and `refs/remotes/<name>`, so a tag that merely shares the base branch's name
+# wins the emitted command's ref lookup. The brief is generated worker-facing
+# output and states `0` as its sole pass criterion, so an unqualified base ref
+# lets a same-named tag certify a stale base as fresh - the exact failure this
+# check exists to catch.
+# shellcheck disable=SC2016 # The sed pattern must match the literal backticks the brief emits.
+test_emitted_base_command_survives_a_same_named_tag() {
+  local home local_repo local_worktree pr_repo pr_worktree setup freshness_command count shadowed
+  home="$TMP_ROOT/tag-shadowed-home"
+  local_repo="$BRIEF_PROJECTS/tag-shadowed-local"
+  local_worktree="$TMP_ROOT/tag-shadowed-local-worktree"
+  pr_repo="$BRIEF_PROJECTS/tag-shadowed-origin"
+  pr_worktree="$TMP_ROOT/tag-shadowed-origin-worktree"
+  mkdir -p "$home/data"
+
+  fm_git_init_commit "$local_repo"
+  git -C "$local_repo" branch -M release
+  fm_git_add_origin "$local_repo" "$local_repo.origin.git"
+  git -C "$local_repo" fetch --quiet origin
+  git -C "$local_repo" remote set-head origin --auto >/dev/null
+  git -C "$local_repo" tag stale-base
+  git -C "$local_repo" tag release
+  printf '%s\n' 'first' >> "$local_repo/README.md"
+  git -C "$local_repo" add README.md
+  git -C "$local_repo" commit -qm 'local default advances once'
+  printf '%s\n' 'second' >> "$local_repo/README.md"
+  git -C "$local_repo" add README.md
+  git -C "$local_repo" commit -qm 'local default advances twice'
+  git -C "$local_repo" worktree add --quiet --detach "$local_worktree" refs/tags/stale-base
+
+  fm_git_init_commit "$pr_repo"
+  git -C "$pr_repo" branch -M release
+  fm_git_add_origin "$pr_repo" "$pr_repo.origin.git"
+  git -C "$pr_repo" fetch --quiet origin
+  git -C "$pr_repo" remote set-head origin --auto >/dev/null
+  git -C "$pr_repo" tag stale-base
+  git -C "$pr_repo" tag origin/release
+  printf '%s\n' 'first' >> "$pr_repo/README.md"
+  git -C "$pr_repo" add README.md
+  git -C "$pr_repo" commit -qm 'remote default advances once'
+  printf '%s\n' 'second' >> "$pr_repo/README.md"
+  git -C "$pr_repo" add README.md
+  git -C "$pr_repo" commit -qm 'remote default advances twice'
+  git -C "$pr_repo" push --quiet origin release
+  git -C "$pr_repo" fetch --quiet origin
+  git -C "$pr_repo" worktree add --quiet --detach "$pr_worktree" refs/tags/stale-base
+
+  shadowed=$(cd "$local_worktree" && git rev-list --count "$(git merge-base HEAD release)..release" 2>/dev/null)
+  [ "$shadowed" -eq 0 ] || fail "the local fixture does not shadow its default branch with a same-named tag"
+  shadowed=$(cd "$pr_worktree" && git rev-list --count "$(git merge-base HEAD origin/release)..origin/release" 2>/dev/null)
+  [ "$shadowed" -eq 0 ] || fail "the PR fixture does not shadow its tracking ref with a same-named tag"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" tag-local tag-shadowed-local --mode local-only >/dev/null 2>&1 \
+    || fail "a tag-shadowed local default must not fail the scaffold"
+  setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/tag-local/brief.md")
+  freshness_command=$(printf '%s\n' "$setup" | sed -n 's/^   `\(git rev-list --count .*\)`$/\1/p' | head -1)
+  [ -n "$freshness_command" ] || fail "the local-only brief emitted no base-freshness command"
+  count=$(cd "$local_worktree" && eval "$freshness_command" 2>/dev/null) \
+    || fail "the emitted local-only command failed against the tag-shadowed fixture"
+  [ "$count" -eq 2 ] \
+    || fail "the emitted local-only command reported $count against a same-named tag instead of 2 against the branch"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" tag-pr tag-shadowed-origin --mode direct-PR >/dev/null 2>&1 \
+    || fail "a tag-shadowed tracking ref must not fail the scaffold"
+  setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/tag-pr/brief.md")
+  freshness_command=$(printf '%s\n' "$setup" | sed -n 's/^   `\(git rev-list --count .*\)`$/\1/p' | head -1)
+  [ -n "$freshness_command" ] || fail "the PR-path brief emitted no base-freshness command"
+  count=$(cd "$pr_worktree" && eval "$freshness_command" 2>/dev/null) \
+    || fail "the emitted PR-path command failed against the tag-shadowed fixture"
+  [ "$count" -eq 2 ] \
+    || fail "the emitted PR-path command reported $count against a same-named tag instead of 2 against the tracking ref"
+  pass "fm-brief.sh: the emitted base command measures the real ref through a same-named tag"
 }
 
 # The repo positional is a caller-supplied label, not a path contract: firstmate
@@ -371,13 +446,13 @@ test_unresolvable_repo_label_still_mandates_the_base_check() {
 
   assert_contains "$ship_setup" "2. **Check your base before starting work.**" \
     "the runtime fallback lost its numbered place in the ship safety contract"
-  assert_contains "$ship_setup" 'git rev-list --count $(git merge-base HEAD origin/<default>)..origin/<default>' \
+  assert_contains "$ship_setup" 'git rev-list --count $(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>' \
     "the runtime fallback omitted the mandatory zero-count command"
   assert_contains "$ship_setup" 'blocked: cannot determine the default branch to verify base freshness' \
     "the runtime fallback did not require reporting blocked on an undeterminable base"
   assert_contains "$ship_setup" 'never skip, soften, or postpone it' \
     "the runtime fallback softened the mandatory check"
-  assert_contains "$scout_setup" 'git rev-list --count $(git merge-base HEAD origin/<default>)..origin/<default>' \
+  assert_contains "$scout_setup" 'git rev-list --count $(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>' \
     "the scout runtime fallback omitted the mandatory zero-count command"
   pass "fm-brief.sh: an unresolvable repo label still mandates the base check at runtime"
 }
@@ -406,7 +481,7 @@ test_missing_origin_head_never_relabels_the_current_branch() {
 
   assert_not_contains "$setup" 'fm/old-task' \
     "the checked-out feature branch was rendered as the local default branch"
-  assert_contains "$setup" "git rev-list --count \$(git merge-base HEAD 'main')..'main'" \
+  assert_contains "$setup" "git rev-list --count \$(git merge-base HEAD 'refs/heads/main')..'refs/heads/main'" \
     "the stranded clone did not fall back to its local default-branch ref"
   pass "fm-brief.sh: a missing origin/HEAD never relabels the current feature branch"
 }
@@ -438,7 +513,7 @@ test_non_root_directory_never_resolves_to_its_enclosing_repo() {
 
   assert_not_contains "$setup" 'origin/trunk' \
     "a plain directory inside a work tree rendered the enclosing repo's default branch as its base"
-  assert_contains "$setup" 'git rev-list --count $(git merge-base HEAD origin/<default>)..origin/<default>' \
+  assert_contains "$setup" 'git rev-list --count $(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>' \
     "a non-root project directory did not fall back to the runtime base check"
   pass "fm-brief.sh: a directory inside a work tree never resolves as that project's repo"
 }
@@ -475,7 +550,7 @@ test_absent_local_ref_for_origin_default_never_substitutes_another_branch() {
 
   assert_not_contains "$setup" 'your local default branch `main`' \
     "a substitute branch was presented as the repository's local default branch"
-  assert_contains "$setup" 'git rev-list --count $(git merge-base HEAD <default>)..<default>' \
+  assert_contains "$setup" 'git rev-list --count $(git merge-base HEAD refs/heads/<default>)..refs/heads/<default>' \
     "an absent local ref for origin's default did not fall back to the runtime base check"
   assert_contains "$setup" 'blocked: cannot determine the default branch to verify base freshness' \
     "the runtime fallback dropped its blocked-and-stop requirement"
@@ -514,13 +589,13 @@ test_ambiguous_origin_head_still_resolves_the_real_default_branch() {
   setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/ambiguous-head/brief.md")
   rules=$(sed -n '/^# Rules$/,/^# Firstmate instruction inbox$/p' "$home/data/ambiguous-head/brief.md")
 
-  assert_contains "$setup" "git rev-list --count \$(git merge-base HEAD 'develop')..'develop'" \
+  assert_contains "$setup" "git rev-list --count \$(git merge-base HEAD 'refs/heads/develop')..'refs/heads/develop'" \
     "an ambiguous origin/HEAD abbreviation stopped the brief measuring against the real default branch"
   assert_contains "$setup" 'Only `0` passes against your local default branch `develop`.' \
     "the brief did not name the real default branch in its zero-only criterion"
   assert_not_contains "$setup" 'your local default branch `main`' \
     "an ambiguous origin/HEAD abbreviation substituted main for the real default branch"
-  assert_not_contains "$setup" 'git rev-list --count $(git merge-base HEAD <default>)..<default>' \
+  assert_not_contains "$setup" 'git rev-list --count $(git merge-base HEAD refs/heads/<default>)..refs/heads/<default>' \
     "a resolvable default branch was deferred to the runtime fallback"
   assert_contains "$rules" 'firstmate handles the merge into local `develop`' \
     "Rule 1 named a branch other than the real default"
@@ -608,10 +683,10 @@ test_local_only_rule_names_the_resolved_default_branch() {
   setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/rule-local/brief.md")
   rules=$(sed -n '/^# Rules$/,/^# Firstmate instruction inbox$/p' "$home/data/rule-local/brief.md")
 
-  assert_contains "$setup" "rebase onto \`release\`" \
-    "the local-only fixture no longer resolves its non-main default branch"
-  assert_not_contains "$setup" "rebase onto \`'release'\`" \
-    "the prose rebase instruction leaked the shell quoting that only the executed command needs"
+  assert_contains "$setup" "rebase onto \`'refs/heads/release'\`" \
+    "the rebase target the worker executes is not the fully-qualified, shell-quoted local default ref"
+  assert_contains "$setup" 'Only `0` passes against your local default branch `release`.' \
+    "the descriptive line stopped naming the default branch by its short readable name"
   assert_contains "$rules" 'firstmate handles the merge into local `release`' \
     "Rule 1 named a branch other than the resolved local default"
   assert_not_contains "$rules" 'merge into local `main`' \
@@ -637,7 +712,7 @@ test_scout_local_fallback_uses_kind_neutral_wording() {
     || fail "scout brief should scaffold against a remoteless clone"
   setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/neutral-scout/brief.md")
 
-  assert_contains "$setup" "git rev-list --count \$(git merge-base HEAD 'main')..'main'" \
+  assert_contains "$setup" "git rev-list --count \$(git merge-base HEAD 'refs/heads/main')..'refs/heads/main'" \
     "the scout local fallback did not measure against the local default branch"
   assert_not_contains "$setup" 'This task lands locally' \
     "the scout brief claimed its task lands locally"
@@ -668,9 +743,9 @@ test_unresolved_scout_fallback_degrades_to_a_local_default() {
 
   assert_contains "$scout_setup" 'git fetch origin --quiet' \
     "the scout fallback dropped the single fetch that precedes its origin comparison"
-  assert_contains "$scout_setup" 'git rev-list --count $(git merge-base HEAD origin/<default>)..origin/<default>' \
+  assert_contains "$scout_setup" 'git rev-list --count $(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>' \
     "the scout fallback lost its origin-first zero-count command"
-  assert_contains "$scout_setup" 'git rev-list --count $(git merge-base HEAD <default>)..<default>' \
+  assert_contains "$scout_setup" 'git rev-list --count $(git merge-base HEAD refs/heads/<default>)..refs/heads/<default>' \
     "the scout fallback never degrades to a local default when origin cannot be established"
   assert_contains "$scout_setup" 'If no usable origin default remains after that single fetch' \
     "the scout fallback did not gate its local degradation on origin being unusable after the fetch"
@@ -681,7 +756,7 @@ test_unresolved_scout_fallback_degrades_to_a_local_default() {
   assert_not_contains "$scout_setup" 'This task lands locally' \
     "the scout fallback claimed the task lands locally"
 
-  assert_not_contains "$ship_setup" 'git rev-list --count $(git merge-base HEAD <default>)..<default>' \
+  assert_not_contains "$ship_setup" 'git rev-list --count $(git merge-base HEAD refs/heads/<default>)..refs/heads/<default>' \
     "a PR-path fallback degraded to a local base instead of requiring origin"
   pass "fm-brief.sh: an unresolved scout fallback degrades to a local default before blocking"
 }
@@ -718,11 +793,11 @@ test_scout_fallback_fetches_before_verifying_and_degrades_like_the_resolved_path
   resolved_setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/pruned-resolved/brief.md")
   unresolved_setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/pruned-unresolved/brief.md")
 
-  assert_contains "$resolved_setup" "git rev-list --count \$(git merge-base HEAD 'develop')..'develop'" \
+  assert_contains "$resolved_setup" "git rev-list --count \$(git merge-base HEAD 'refs/heads/develop')..'refs/heads/develop'" \
     "the resolved scout path stopped degrading to the local default branch"
 
   fetch_line=$(printf '%s\n' "$unresolved_setup" | grep -n -F -m1 'git fetch origin --quiet' | cut -d: -f1)
-  verify_line=$(printf '%s\n' "$unresolved_setup" | grep -n -F -m1 'git rev-parse --verify origin/<default>' | cut -d: -f1)
+  verify_line=$(printf '%s\n' "$unresolved_setup" | grep -n -F -m1 'git rev-parse --verify refs/remotes/origin/<default>' | cut -d: -f1)
   [ -n "$fetch_line" ] || fail "the scout fallback dropped its single fetch"
   [ -n "$verify_line" ] || fail "the scout fallback dropped its origin tracking-ref verification"
   [ "$fetch_line" -lt "$verify_line" ] \
@@ -1288,6 +1363,7 @@ test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_base_freshness_check_is_resolved_and_mode_aware
 test_resolved_default_branch_is_shell_quoted_in_the_freshness_command
+test_emitted_base_command_survives_a_same_named_tag
 test_unresolvable_repo_label_still_mandates_the_base_check
 test_missing_origin_head_never_relabels_the_current_branch
 test_non_root_directory_never_resolves_to_its_enclosing_repo

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -264,14 +264,20 @@ test_base_freshness_check_is_resolved_and_mode_aware() {
   local_dod=$(sed -n '/^# Definition of done$/,$p' "$local_brief")
   scout_dod=$(sed -n '/^# Definition of done$/,$p' "$scout")
 
-  assert_contains "$ship_setup" "1. **First startup step - check your base before starting work.**" \
-    "ship brief did not make the base check its first startup step"
+  assert_contains "$ship_setup" "1. **Verify isolation before anything else.**" \
+    "ship brief did not number worktree isolation as the first safety step"
+  assert_contains "$ship_setup" "2. **Check your base before starting work.**" \
+    "ship brief did not number the base check as the second safety step"
   assert_contains "$ship_setup" "git rev-list --count \$(git merge-base HEAD origin/release)..origin/release" \
     "PR brief did not check the resolved remote default branch"
-  assert_contains "$ship_setup" "Only \`0\` passes against the fetched default branch \`origin/release\`." \
+  assert_contains "$ship_setup" "Only \`0\` passes against the freshly fetched default branch \`origin/release\`." \
     "PR brief did not state the zero-only pass criterion"
-  assert_contains "$ship_setup" "2. Create your branch: \`git checkout -b fm/base-pr\`" \
-    "ship brief did not put branch creation after its freshness check"
+  assert_contains "$ship_setup" 'git fetch origin --quiet' \
+    "PR brief compared against the tracking ref without refreshing it first"
+  assert_contains "$ship_setup" 'blocked: cannot fetch origin to verify base freshness' \
+    "PR brief did not tell the worker to report blocked when the single fetch fails"
+  assert_contains "$ship_setup" "3. Create your branch: \`git checkout -b fm/base-pr\`" \
+    "ship brief did not number branch creation as the third safety step"
   assert_not_contains "$ship_setup" 'on a clean default branch' \
     "ship brief retained an unchecked clean-base assertion"
   assert_not_contains "$ship_setup" 'origin/main' \
@@ -285,20 +291,88 @@ test_base_freshness_check_is_resolved_and_mode_aware() {
     "local-only brief did not explain its local zero-only criterion"
   assert_not_contains "$local_setup" 'origin/release' \
     "local-only brief used the stale origin tracking ref instead of its local default branch"
+  assert_not_contains "$local_setup" 'git fetch' \
+    "local-only brief refreshed the network even though it lands in the local branch"
   assert_not_contains "$local_dod" 'git rev-list --count' \
     "local-only brief put the freshness check in Definition of done instead of Setup"
 
-  assert_contains "$scout_setup" "1. **First startup step - check your base before starting work.**" \
-    "scout brief did not make the base check its first startup step"
+  assert_contains "$scout_setup" "1. **Check your base before starting work.**" \
+    "scout brief did not make the base check its first numbered startup step"
   assert_contains "$scout_setup" "git rev-list --count \$(git merge-base HEAD origin/release)..origin/release" \
     "scout brief did not check the resolved default branch"
-  assert_contains "$scout_setup" "Only \`0\` passes against the fetched default branch \`origin/release\`." \
+  assert_contains "$scout_setup" "Only \`0\` passes against the freshly fetched default branch \`origin/release\`." \
     "scout brief did not state the zero-only pass criterion"
+  assert_contains "$scout_setup" 'git fetch origin --quiet' \
+    "scout brief compared against the tracking ref without refreshing it first"
   assert_not_contains "$scout_setup" 'on a clean default branch' \
     "scout brief retained an unchecked clean-base assertion"
   assert_not_contains "$scout_dod" 'git rev-list --count' \
     "scout brief put the freshness check in Definition of done instead of Setup"
   pass "fm-brief.sh: startup base freshness is resolved, zero-only, and mode-aware"
+}
+
+# The repo positional is a caller-supplied label, not a path contract: firstmate
+# names repos this scaffold has no local view of, so an unresolvable label must
+# still produce a brief - and that brief must still carry the mandatory check
+# with the base determined by the worker at runtime.
+test_unresolvable_repo_label_still_mandates_the_base_check() {
+  local home ship scout ship_setup scout_setup
+  home="$TMP_ROOT/unresolvable-repo-home"
+  mkdir -p "$home/data"
+
+  [ ! -d "$BRIEF_PROJECTS/no-such-repo" ] || fail "fixture leak: no-such-repo must not resolve"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" label-ship no-such-repo --mode no-mistakes >/dev/null 2>&1 \
+    || fail "an unresolvable repo label must not fail the ship scaffold"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" label-scout no-such-repo --scout >/dev/null 2>&1 \
+    || fail "an unresolvable repo label must not fail the scout scaffold"
+
+  ship="$home/data/label-ship/brief.md"
+  scout="$home/data/label-scout/brief.md"
+  [ -f "$ship" ] || fail "no ship brief was written for an unresolvable repo label"
+  [ -f "$scout" ] || fail "no scout brief was written for an unresolvable repo label"
+  ship_setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$ship")
+  scout_setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$scout")
+
+  assert_contains "$ship_setup" "2. **Check your base before starting work.**" \
+    "the runtime fallback lost its numbered place in the ship safety contract"
+  assert_contains "$ship_setup" 'git rev-list --count $(git merge-base HEAD origin/<default>)..origin/<default>' \
+    "the runtime fallback omitted the mandatory zero-count command"
+  assert_contains "$ship_setup" 'blocked: cannot determine the default branch to verify base freshness' \
+    "the runtime fallback did not require reporting blocked on an undeterminable base"
+  assert_contains "$ship_setup" 'never skip, soften, or postpone it' \
+    "the runtime fallback softened the mandatory check"
+  assert_contains "$scout_setup" 'git rev-list --count $(git merge-base HEAD origin/<default>)..origin/<default>' \
+    "the scout runtime fallback omitted the mandatory zero-count command"
+  pass "fm-brief.sh: an unresolvable repo label still mandates the base check at runtime"
+}
+
+# A clone with no origin/HEAD that is stranded on a feature branch (the worktree
+# tangle bin/fm-tangle-lib.sh detects) must never have that feature branch
+# rendered as its own base - the brief would then certify a wrong base as fresh.
+test_missing_origin_head_never_relabels_the_current_branch() {
+  local home stranded setup
+  home="$TMP_ROOT/stranded-head-home"
+  stranded="$BRIEF_PROJECTS/stranded"
+  mkdir -p "$home/data"
+
+  fm_git_init_commit "$stranded"
+  git -C "$stranded" branch -M main
+  git -C "$stranded" checkout -q -b fm/old-task
+  [ "$(git -C "$stranded" symbolic-ref --short HEAD)" = "fm/old-task" ] \
+    || fail "stranded fixture is not checked out on its feature branch"
+  git -C "$stranded" symbolic-ref -q refs/remotes/origin/HEAD >/dev/null 2>&1 \
+    && fail "stranded fixture unexpectedly has an origin/HEAD"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" stranded-local stranded --mode local-only >/dev/null 2>&1 \
+    || fail "local-only brief should scaffold against a stranded clone"
+  setup=$(sed -n '/^# Setup$/,/^# Rules$/p' "$home/data/stranded-local/brief.md")
+
+  assert_not_contains "$setup" 'fm/old-task' \
+    "the checked-out feature branch was rendered as the local default branch"
+  assert_contains "$setup" 'git rev-list --count $(git merge-base HEAD main)..main' \
+    "the stranded clone did not fall back to its local default-branch ref"
+  pass "fm-brief.sh: a missing origin/HEAD never relabels the current feature branch"
 }
 
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
@@ -851,6 +925,8 @@ test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_base_freshness_check_is_resolved_and_mode_aware
+test_unresolvable_repo_label_still_mandates_the_base_check
+test_missing_origin_head_never_relabels_the_current_branch
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply


### PR DESCRIPTION
## Intent

Goal: make the generated crewmate brief demand a base-freshness check as its first startup step, with the exact command and an explicit pass criterion, replacing a soft advisory line that depended on firstmate remembering it.

Why: the treehouse worktree pool recycles slots without refreshing them, so a worker can silently start hundreds of commits behind the default branch. Measured 2026-08-28: one slot 947 commits behind, several at 635, others between 26 and 288. That caused seven wasted lanes in a single day, one caught only by the captain from a stale screenshot. The corrective rule already existed in the fleet's notes and still failed, because it depended on being remembered while hand-writing each brief. The fix is to move the check into the generated scaffold where it is emitted every time.

Scope accepted at intake: change the scaffold in bin/fm-brief.sh and its colocated tests only. bin/fm-spawn.sh and the worktree pool itself are explicitly out of scope (a sibling ticket owns the pool). Do not rewrite the definition-of-done block beyond what this needs, and do not silently delete the soft line in bin/fm-dod-lib.sh - report on it instead.

Required properties of the emitted check, all non-negotiable: it runs before starting any other read or write, it spells out the exact command, and zero is the only acceptable answer. Both the ship scaffold and the scout scaffold carry it, because a scout working on a stale base produces a report later work is built on.

Deliberate decisions made along the way, each one accepted by firstmate before implementation, so they are chosen behavior rather than oversights:

1. Step order (decision brief-step-order): worktree isolation stays the explicit first numbered step, base freshness is second, branch creation third. The existing isolation-before-anything safety wording wins over making the base check literally first.

2. Remote freshness (decision brief-remote-freshness): PR-based paths mandate exactly one `git fetch origin --quiet` before comparing, because the origin tracking ref only answers truthfully after a fetch and a relaunched worktree is reused without one. One fetch, no retry loop; a failed fetch makes the worker append a blocked: line and stop. Local-only paths do no network refresh at all.

3. Base selection per delivery mode: a local-only task compares against the clone's LOCAL default branch, because origin can be far behind in those projects and comparing against origin would make the new check confidently wrong. PR-based ship modes compare against origin/<default>. A scout has no delivery mode, so it prefers the remote base and degrades to the local one.

4. Default branch is resolved from the repository, never hard-coded to main. origin/HEAD supplies only the NAME; when it names a default this clone has no local ref for, resolution deliberately FAILS rather than substituting main, master, or whatever branch happens to be checked out - presenting some other branch as "your local default branch" would be the same confidently-wrong base this ticket exists to catch. The main/master guess applies only where no authority exists at all. Resolution also requires the candidate to be a git work-tree ROOT, because projects/ is a gitignored subdirectory of the firstmate checkout and an inside-a-work-tree test would otherwise render firstmate's own default branch as some project's base.

5. Repo label compatibility (decision brief-repo-resolution): the repo positional stays a free-form caller-supplied label. Resolution is best-effort and never fails the scaffold. A repo that resolves renders its real base ref; one that does not still carries the identical mandatory check, with the base resolved by the worker at runtime under an explicit rule. The check is never softened or omitted either way. Making an existing local repo path a hard precondition was considered and rejected as an unwanted compatibility break.

6. Stale origin/HEAD (decision stale-origin-default): preserve the scaffold-time local resolution. Fresh remote default-branch resolution was explicitly rejected, so a remote default-branch rename can leave a cached origin/HEAD; that residual risk is accepted rather than adding a new network dependency to scaffolding.

7. Shell quoting of the resolved ref: the default branch name is data read from a repository but is embedded in a command the worker executes, so it is rendered through the script's existing shell_quote helper and appears as one shell word. Quoting was chosen over restricting accepted branch names because it touches the least surface and preserves every legitimate ref name. A test drives a deliberately shell-significant branch name through the scaffold and executes the emitted command to prove it stays one word.

Tests: colocated in tests/fm-brief.test.sh, covering that the check is present in both scaffolds, that it renders in the Setup section rather than the definition of done, that a non-main default branch is substituted correctly, that the local-only wording differs from the PR-path wording, that an unresolvable repo label still mandates the check, that a missing origin/HEAD never relabels the current feature branch, and that the resolved ref is shell-quoted.

Repo style constraints: one sentence per line, plain dash, shellcheck clean on touched bin scripts, and never add an agent as a commit co-author.

## What Changed

- `bin/fm-brief.sh` now emits a numbered base-freshness step in both the ship and scout scaffolds, before any other read or write: ship briefs run worktree isolation as step 1, the base check as step 2, and branch creation as step 3 (the `no-mistakes` setup line renumbers to 4 accordingly), while scout briefs carry the check as step 1. The step spells out an exact `git rev-list --count $(git merge-base HEAD <base>)..<base>` command, treats only `0` as a pass, and directs a rebase onto the base otherwise.
- Base selection is resolved from the repository rather than hard-coded: PR-based ship modes compare against `origin/<default>` after exactly one `git fetch origin --quiet` (a failed fetch makes the worker append a `blocked:` line and stop, with no retry loop), `local-only` compares against the clone's local default branch with no network refresh, and scouts prefer the origin base and degrade to the local one. New `resolve_brief_repo`, `origin_default_branch_name`, `resolve_local_default_branch`, and `resolve_origin_default_branch` helpers require the candidate to be a git work-tree root, read `origin/HEAD` as a full `refs/remotes/origin/*` ref, and fail rather than substituting `main`/`master` when the named local ref is missing; emitted refs are fully qualified (`refs/heads/…`, `refs/remotes/origin/…`) and passed through the existing `shell_quote` helper. A repo label that does not resolve still renders the identical mandatory check with runtime resolution rules instead of failing the scaffold.
- `tests/fm-brief.test.sh` adds 13 tests plus an `init_brief_project` fixture helper covering presence in both scaffolds, Setup-section placement, mode-aware wording, a non-`main` default branch, shell-quoting of a deliberately shell-significant branch name, a same-named tag not hijacking the emitted command, an unresolvable repo label, and a missing `origin/HEAD` never relabeling the current branch. `bin/fm-brief.sh`'s header, `docs/architecture.md`, and `AGENTS.md` document the new runtime layer and its per-path base resolution alongside the existing spawn-time boundary.

## Risk Assessment

✅ Low: The change is confined to one scaffold script plus its colocated tests and docs, every path I rendered and executed produces the correct ref and fails closed (block-and-stop) when a base cannot be determined, and the only findings are pre-existing follow-ups the user has explicitly scoped out or deferred.

## Testing

I ran the colocated tests/fm-brief.test.sh suite and the seven non-live sibling suites that invoke bin/fm-brief.sh, all green, then proved the intent end-to-end the way a crewmate experiences it: I rebuilt the incident from the ticket (a treehouse pool slot recycled without refreshing, 30 commits behind a non-main `release` default), scaffolded real briefs for the no-mistakes, direct-PR, local-only and scout paths, and executed the commands those briefs emit verbatim in the stale slots. The check caught the stale base (30, not 0), passed only after the instructed rebase, correctly used the local default with no network for local-only, resisted a same-named tag, kept a shell-significant branch name as one shell word, and still rendered as mandatory for a repo label the scaffold cannot resolve; scaffolding the same brief from the base commit shows the prior wording had no check at all. This is a CLI/generated-markdown surface with no rendered UI, so the artifacts are the generated brief files and CLI transcripts rather than screenshots.

<details>
<summary>Evidence: End-to-end transcript: stale recycled pool slot caught by the emitted check (incl. before/after vs base commit)</summary>

Source: [End-to-end transcript: stale recycled pool slot caught by the emitted check (incl. before/after vs base commit)](https://github.com/mikeastwoody/firstmate/blob/aa02e53dfabf44a36c141fa7a630b2491840576f/.no-mistakes/evidence/fm/fm-brief-comprobacion-base/stale-base-caught-transcript.txt)

```text

==============================================================
0. The situation firstmate hands the worker
==============================================================
project hazlo default branch (from the repo, not hard-coded): refs/remotes/origin/release
recycled pool slot HEAD:            ace3682
slot's cached origin/release:       ace3682   <- stale, never fetched
true remote default branch tip:     b26a78f
the slot is 30 commits behind the default branch

local-only project tobydoro: local release is 12 commits AHEAD of its origin
its recycled slot HEAD:      73510c3

==============================================================
1. Scaffold the briefs firstmate would hand out
==============================================================
$ /Users/mike/.no-mistakes/worktrees/8544444aa3b7/01M1HS83HZF1Z76F10VX3X9YX3/bin/fm-brief.sh ev-nomistakes hazlo --mode no-mistakes
scaffolded: /tmp/fm-brief-e2e.hNRMcP/home/data/ev-nomistakes/brief.md (ship, mode=no-mistakes; replace {TASK})
$ /Users/mike/.no-mistakes/worktrees/8544444aa3b7/01M1HS83HZF1Z76F10VX3X9YX3/bin/fm-brief.sh ev-localonly tobydoro --mode local-only
scaffolded: /tmp/fm-brief-e2e.hNRMcP/home/data/ev-localonly/brief.md (ship, mode=local-only; replace {TASK})
$ /Users/mike/.no-mistakes/worktrees/8544444aa3b7/01M1HS83HZF1Z76F10VX3X9YX3/bin/fm-brief.sh ev-scout hazlo --scout
scaffolded: /tmp/fm-brief-e2e.hNRMcP/home/data/ev-scout/brief.md (scout; replace {TASK})

==============================================================
2. What the worker actually reads (Setup section of the generated brief)
==============================================================
--- no-mistakes ship brief (PR path) ---
# Setup
You are in a disposable git worktree of hazlo, at a detached HEAD supplied by the worktree pool.

1. **Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
   The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
   If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

2. **Check your base before starting work.** Refresh the remote exactly once, then measure:
   `git fetch origin --quiet`
   `git rev-list --count $(git merge-base HEAD 'refs/remotes/origin/release')..'refs/remotes/origin/release'`
   Only `0` passes against the freshly fetched default branch `origin/release`.
   If the fetch fails, append `blocked: cannot fetch origin to verify base freshness` to the status file and stop - one fetch, no retry loop.
   If the count is not `0`, rebase onto `'refs/remotes/origin/release'` before reading or writing anything.

3. Create your branch: `git checkout -b fm/ev-nomistakes`
4. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

--- local-only ship brief ---
# Setup
You are in a disposable git worktree of tobydoro, at a detached HEAD supplied by the worktree pool.

1. **Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
   The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
   If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

2. **Check your base before starting work.** This task lands locally, so do not fetch; measure against the local branch:
   `git rev-list --count $(git merge-base HEAD 'refs/heads/release')..'refs/heads/release'`
   Only `0` passes against your local default branch `release`.
   If the count is not `0`, rebase onto `'refs/heads/release'` before reading or writing anything.

3. Create your branch: `git checkout -b fm/ev-localonly`

--- scout brief ---
# Setup
You are in a disposable git worktree of hazlo, at a detached HEAD supplied by the worktree pool.
1. **Check your base before starting work.** Refresh the remote exactly once, then measure:
   `git fetch origin --quiet`
   `git rev-list --count $(git merge-base HEAD 'refs/remotes/origin/release')..'refs/remotes/origin/release'`
   Only `0` passes against the freshly fetched default branch `origin/release`.
   If the fetch fails, append `blocked: cannot fetch origin to verify base freshness` to the status file and stop - one fetch, no retry loop.
   If the count is not `0`, rebase onto `'refs/remotes/origin/release'` before reading or writing anything.

This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.


==============================================================
3. The worker runs the brief's commands verbatim in the recycled slot
==============================================================
[control] the same count WITHOUT the brief's mandated fetch, i.e. what a
          relaunched worktree answers on its stale tracking ref:
$ git rev-list --count $(git merge-base HEAD 'refs/remotes/origin/release')..'refs/remotes/origin/release'
0
          ^ 0 would have silently certified a 30-commits-behind base as fresh.

[brief, step 2 as written]
$ git fetch origin --quiet
$ git rev-list --count $(git merge-base HEAD 'refs/remotes/origin/release')..'refs/remotes/origin/release'
30
          ^ not 0 -> the brief says: rebase onto 'refs/remotes/origin/release'
            before reading or writing anything. The stale base is caught.

[worker does what the brief says, then re-checks]
$ git rebase --quiet refs/remotes/origin/release
$ git rev-list --count $(git merge-base HEAD 'refs/remotes/origin/release')..'refs/remotes/origin/release'
0
          ^ 0 -> passes, and only now does the worker create its branch.
$ git checkout -q -b fm/ev-nomistakes
b26a78f upstream change 30

==============================================================
4. local-only uses the LOCAL default branch, and does not touch the network
==============================================================
the local-only brief emits no git fetch at all (checked above)
$ git rev-list --count $(git merge-base HEAD 'refs/heads/release')..'refs/heads/release'
12
          ^ measured against local refs/heads/release. Against the stale
            origin tracking ref the same slot answers:
$ git rev-list --count $(git merge-base HEAD refs/remotes/origin/release)..refs/remotes/origin/release
0
          ^ 0, i.e. comparing a local-only task against origin would be confidently wrong.

==============================================================
5. A same-named tag cannot certify a stale base (fully-qualified emitted refs)
==============================================================
this clone also holds a TAG literally named origin/release, at the old tip.
$ git rev-list --count $(git merge-base HEAD 'refs/remotes/origin/release')..'refs/remotes/origin/release'
30   <- emitted (qualified) ref: still catches the stale base
$ git rev-list --count $(git merge-base HEAD 'origin/release')..'origin/release'
0   <- an unqualified name would resolve to the tag and report a false pass

==============================================================
6. Before / after: the same brief scaffolded from the base commit
==============================================================
--- BEFORE (base commit d22318e) Setup section ---
# Setup
You are in a disposable git worktree of hazlo, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/ev-nomistakes`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

--- AFTER (this branch) Setup section ---
# Setup
You are in a disposable git worktree of hazlo, at a detached HEAD supplied by the worktree pool.

1. **Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
   The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
   If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

2. **Check your base before starting work.** Refresh the remote exactly once, then measure:
   `git fetch origin --quiet`
   `git rev-list --count $(git merge-base HEAD 'refs/remotes/origin/release')..'refs/remotes/origin/release'`
   Only `0` passes against the freshly fetched default branch `origin/release`.
   If the fetch fails, append `blocked: cannot fetch origin to verify base freshness` to the status file and stop - one fetch, no retry loop.
   If the count is not `0`, rebase onto `'refs/remotes/origin/release'` before reading or writing anything.

3. Create your branch: `git checkout -b fm/ev-nomistakes`
4. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.


==============================================================
artifacts written
==============================================================
brief-local-only.md
brief-no-mistakes-BEFORE.md
brief-no-mistakes.md
brief-scout.md
stale-base-caught-transcript.txt
```
</details>
<details>
<summary>Evidence: Transcript: unresolvable repo label still mandates the check, and shell-significant branch name stays one word</summary>

Source: [Transcript: unresolvable repo label still mandates the check, and shell-significant branch name stays one word](https://github.com/mikeastwoody/firstmate/blob/aa02e53dfabf44a36c141fa7a630b2491840576f/.no-mistakes/evidence/fm/fm-brief-comprobacion-base/unresolvable-label-and-quoting-transcript.txt)

```text

==============================================================
A. A repo label this scaffold cannot resolve still carries the SAME mandatory check
==============================================================
$ bin/fm-brief.sh ev-unresolvable a-repo-firstmate-has-no-local-view-of --mode direct-PR
scaffolded: /tmp/fm-brief-e2e2.daLioB/home/data/ev-unresolvable/brief.md (ship, mode=direct-PR; replace {TASK})
# Setup
You are in a disposable git worktree of a-repo-firstmate-has-no-local-view-of, at a detached HEAD supplied by the worktree pool.

1. **Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
   The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
   If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

2. **Check your base before starting work.** This brief could not resolve `a-repo-firstmate-has-no-local-view-of` to a local checkout, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
   Determine `<default>` with `git remote set-head origin --auto` then `git symbolic-ref --quiet refs/remotes/origin/HEAD`, dropping the leading `refs/remotes/origin/`. Never substitute whatever branch happens to be checked out.
   If you cannot determine it, append `blocked: cannot determine the default branch to verify base freshness` to the status file and stop.
   Then refresh the remote exactly once and measure:
   `git fetch origin --quiet`
   `git rev-list --count $(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>`
   Only `0` passes. If the fetch fails, append `blocked: cannot fetch origin to verify base freshness` to the status file and stop - one fetch, no retry loop.
   If the count is not `0`, rebase onto `refs/remotes/origin/<default>` before reading or writing anything.

3. Create your branch: `git checkout -b fm/ev-unresolvable`


==============================================================
B. Same unresolvable label on a SCOUT: degrades to a local default, blocks only if neither resolves
==============================================================
$ bin/fm-brief.sh ev-unresolvable-scout a-repo-firstmate-has-no-local-view-of --scout
scaffolded: /tmp/fm-brief-e2e2.daLioB/home/data/ev-unresolvable-scout/brief.md (scout; replace {TASK})
# Setup
You are in a disposable git worktree of a-repo-firstmate-has-no-local-view-of, at a detached HEAD supplied by the worktree pool.
1. **Check your base before starting work.** This brief could not resolve `a-repo-firstmate-has-no-local-view-of` to a local checkout, so resolve the base yourself first. This check is mandatory: never skip, soften, or postpone it.
   Try origin first: run `git remote set-head origin --auto`, then read `git symbolic-ref --quiet refs/remotes/origin/HEAD` and drop the leading `refs/remotes/origin/` to get `<default>`.
   If that names a branch, refresh the remote exactly once BEFORE verifying or comparing its tracking ref - the fetch is what creates a pruned or never-fetched `origin/<default>`:
   `git fetch origin --quiet`
   If the fetch fails, append `blocked: cannot fetch origin to verify base freshness` to the status file and stop - one fetch, no retry loop.
   Then confirm the tracking ref with `git rev-parse --verify refs/remotes/origin/<default>` and measure:
   `git rev-list --count $(git merge-base HEAD refs/remotes/origin/<default>)..refs/remotes/origin/<default>`
   Only `0` passes. If the count is not `0`, rebase onto `refs/remotes/origin/<default>` before reading or writing anything.
   If no usable origin default remains after that single fetch - no `origin` remote, no `origin/HEAD`, or its tracking ref still missing - fall back to a local default branch with NO further network refresh, named by exactly this rule:
   Read `git symbolic-ref --quiet refs/remotes/origin/HEAD`. If it names a ref, that ref with the leading `refs/remotes/origin/` dropped IS `<default>`: confirm the local branch exists with `git rev-parse --verify refs/heads/<default>`, and if it does not, append `blocked: cannot determine the default branch to verify base freshness` to the status file and stop.
   Only when that ref is absent entirely may `<default>` be the local `main` or `master`, confirmed the same way. Never substitute `main`, `master`, or whatever branch happens to be checked out for a default branch this clone is missing, and append the same `blocked:` line and stop if none of these resolves.
   Then measure against that local branch:
   `git rev-list --count $(git merge-base HEAD refs/heads/<default>)..refs/heads/<default>`
   Only `0` passes, and if the count is not `0`, rebase onto `refs/heads/<default>` before reading or writing anything.

This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.


==============================================================
C. A shell-significant default branch name stays ONE shell word in the emitted command
==============================================================
the project default branch is literally: release;touch$IFS$9fm-brief-injection-marker
scaffolded: /tmp/fm-brief-e2e2.daLioB/home/data/ev-quoting/brief.md (ship, mode=local-only; replace {TASK})
2. **Check your base before starting work.** This task lands locally, so do not fetch; measure against the local branch:
   `git rev-list --count $(git merge-base HEAD 'refs/heads/release;touch$IFS$9fm-brief-injection-marker')..'refs/heads/release;touch$IFS$9fm-brief-injection-marker'`
   Only `0` passes against your local default branch `release;touch$IFS$9fm-brief-injection-marker`.
   If the count is not `0`, rebase onto `'refs/heads/release;touch$IFS$9fm-brief-injection-marker'` before reading or writing anything.

a worker pastes that command into its shell, in a fresh pool slot:
$ git rev-list --count $(git merge-base HEAD 'refs/heads/release;touch$IFS$9fm-brief-injection-marker')..'refs/heads/release;touch$IFS$9fm-brief-injection-marker'
0
0 -> base is fresh. And nothing was executed out of the branch name:
$ ls fm-brief-injection-marker
ls: fm-brief-injection-marker: No such file or directory
the branch name stayed one shell word of data.
```
</details>
<details>
<summary>Evidence: Generated brief a crewmate reads (no-mistakes ship, resolved origin/release base)</summary>

Source: [Generated brief a crewmate reads (no-mistakes ship, resolved origin/release base)](https://github.com/mikeastwoody/firstmate/blob/aa02e53dfabf44a36c141fa7a630b2491840576f/.no-mistakes/evidence/fm/fm-brief-comprobacion-base/brief-no-mistakes.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of hazlo, at a detached HEAD supplied by the worktree pool.

1. **Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
   The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
   If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

2. **Check your base before starting work.** Refresh the remote exactly once, then measure:
   `git fetch origin --quiet`
   `git rev-list --count $(git merge-base HEAD 'refs/remotes/origin/release')..'refs/remotes/origin/release'`
   Only `0` passes against the freshly fetched default branch `origin/release`.
   If the fetch fails, append `blocked: cannot fetch origin to verify base freshness` to the status file and stop - one fetch, no retry loop.
   If the count is not `0`, rebase onto `'refs/remotes/origin/release'` before reading or writing anything.

3. Create your branch: `git checkout -b fm/ev-nomistakes`
4. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-brief-e2e.hNRMcP/home/state/ev-nomistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/tmp/fm-brief-e2e.hNRMcP/home/state/ev-nomistakes.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/tmp/fm-brief-e2e.hNRMcP/home/state/ev-nomistakes.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/tmp/fm-brief-e2e.hNRMcP/home/state/ev-nomistakes.inbox'/NNN.msg '/tmp/fm-brief-e2e.hNRMcP/home/state/ev-nomistakes.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/mike/.no-mistakes/worktrees/8544444aa3b7/01M1HS83HZF1Z76F10VX3X9YX3/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/mike/.no-mistakes/worktrees/8544444aa3b7/01M1HS83HZF1Z76F10VX3X9YX3/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated brief (local-only ship, local refs/heads/release base, no fetch)</summary>

Source: [Generated brief (local-only ship, local refs/heads/release base, no fetch)](https://github.com/mikeastwoody/firstmate/blob/aa02e53dfabf44a36c141fa7a630b2491840576f/.no-mistakes/evidence/fm/fm-brief-comprobacion-base/brief-local-only.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of tobydoro, at a detached HEAD supplied by the worktree pool.

1. **Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
   The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
   If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

2. **Check your base before starting work.** This task lands locally, so do not fetch; measure against the local branch:
   `git rev-list --count $(git merge-base HEAD 'refs/heads/release')..'refs/heads/release'`
   Only `0` passes against your local default branch `release`.
   If the count is not `0`, rebase onto `'refs/heads/release'` before reading or writing anything.

3. Create your branch: `git checkout -b fm/ev-localonly`

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/ev-localonly` branch; firstmate handles the merge into local `release`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-brief-e2e.hNRMcP/home/state/ev-localonly.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/tmp/fm-brief-e2e.hNRMcP/home/state/ev-localonly.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/tmp/fm-brief-e2e.hNRMcP/home/state/ev-localonly.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/tmp/fm-brief-e2e.hNRMcP/home/state/ev-localonly.inbox'/NNN.msg '/tmp/fm-brief-e2e.hNRMcP/home/state/ev-localonly.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/mike/.no-mistakes/worktrees/8544444aa3b7/01M1HS83HZF1Z76F10VX3X9YX3/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/mike/.no-mistakes/worktrees/8544444aa3b7/01M1HS83HZF1Z76F10VX3X9YX3/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/ev-localonly`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/ev-localonly` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>

- Evidence: [Generated brief (scout, base check as step 1)](https://github.com/mikeastwoody/firstmate/blob/aa02e53dfabf44a36c141fa7a630b2491840576f/.no-mistakes/evidence/fm/fm-brief-comprobacion-base/brief-scout.md)
- Evidence: [Same brief scaffolded from base commit d22318e (BEFORE: no base check)](https://github.com/mikeastwoody/firstmate/blob/aa02e53dfabf44a36c141fa7a630b2491840576f/.no-mistakes/evidence/fm/fm-brief-comprobacion-base/brief-no-mistakes-BEFORE.md)

<details>
<summary>Evidence: Key excerpt: the worker running the brief&#39;s own commands in a 30-commit-stale pool slot</summary>

```text
[control] the same count WITHOUT the brief's mandated fetch, i.e. what a
relaunched worktree answers on its stale tracking ref:
$ git rev-list --count $(git merge-base HEAD 'refs/remotes/origin/release')..'refs/remotes/origin/release'
0
^ 0 would have silently certified a 30-commits-behind base as fresh.

[brief, step 2 as written]
$ git fetch origin --quiet
$ git rev-list --count $(git merge-base HEAD 'refs/remotes/origin/release')..'refs/remotes/origin/release'
30
^ not 0 -> the brief says: rebase onto 'refs/remotes/origin/release'
before reading or writing anything. The stale base is caught.

[worker does what the brief says, then re-checks]
$ git rebase --quiet refs/remotes/origin/release
$ git rev-list --count $(git merge-base HEAD 'refs/remotes/origin/release')..'refs/remotes/origin/release'
0
^ 0 -> passes, and only now does the worker create its branch.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"62932db4da35ccd9dfa8d945b265426d337e0f21","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `bin/fm-brief.sh:222` - `origin_default_branch_name` reads the default-branch name with `git symbolic-ref --quiet --short refs/remotes/origin/HEAD` and accepts only output matching `origin/*`. `--short` output is ambiguity-dependent: when the clone holds any ref literally named `origin/&lt;default&gt;` (a local branch OR a tag), git can no longer abbreviate to `origin/&lt;default&gt;` and returns `remotes/origin/&lt;default&gt;` instead, so the `case` guard at bin/fm-brief.sh:225 falls to `*) return 1`. `resolve_local_default_branch` (bin/fm-brief.sh:238) treats that as &#34;no authority exists at all&#34; and drops into the `for branch in main master` guess at bin/fm-brief.sh:245 — even though origin/HEAD authoritatively names the default and the local ref for it exists. Reproduced end to end: a clone with `origin/HEAD -&gt; origin/develop`, a local `develop`, a tag named `origin/develop`, and a local `main`, scaffolded with `--mode local-only`, emits step 2 &#34;Only `0` passes against your local default branch `main`&#34; and &#34;rebase onto `&#39;main&#39;`&#34;, plus Rule 1 &#34;firstmate handles the merge into local `main`&#34; — silently substituting `main` for the real default `develop`. That is exactly the substitution the change&#39;s own comment (bin/fm-brief.sh:232-237) and the accepted decision 4 forbid: &#34;The main/master guess applies only where no authority exists at all.&#34; No error is raised; the worker measures and rebases onto the wrong branch. Fix at the same helper: read the unambiguous full ref instead — `ref=$(git -C &#34;$repo&#34; symbolic-ref --quiet refs/remotes/origin/HEAD 2&gt;/dev/null) || return 1` with `case &#34;$ref&#34; in refs/remotes/origin/*) printf &#39;%s\n&#39; &#34;${ref#refs/remotes/origin/}&#34; ;; *) return 1 ;; esac`. Verified `git symbolic-ref --quiet refs/remotes/origin/HEAD` returns `refs/remotes/origin/develop` in the same fixture where `--short` returns `remotes/origin/develop`. (The `--short` idiom is pre-existing elsewhere — fm-ff-lib.sh:39, fm-tangle-lib.sh:24, fm-fleet-sync.sh:120 — but only this helper routes a parse failure into a silent branch substitution, so the fix belongs here and does not need a repo-wide refactor.)
- ⚠️ `bin/fm-dod-lib.sh:35` - Intent-required report on the preserved soft line, plus a new inconsistency it now creates. The local-only Definition of done still hardcodes `main` twice — &#34;if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward&#34; (bin/fm-dod-lib.sh:35) and &#34;firstmate merges it into local `main`&#34; (bin/fm-dod-lib.sh:37). Before this change Rule 1 also said `main`, so the brief was at least self-consistent. Now, for a project whose default branch is not `main`, the same generated brief says in Setup step 2 &#34;rebase onto `&#39;release&#39;`&#34; and in Rule 1 &#34;firstmate handles the merge into local `release`&#34;, while the Definition of done still points the worker at `main`. I rendered this: a local-only brief for a fixture whose local default is `release` contains all three lines. A worker that follows the DoD would rebase onto a branch that is not the repository&#39;s default — the confidently-wrong base this ticket exists to catch. No action taken: the user intent explicitly scopes this out (&#34;do not silently delete the soft line in bin/fm-dod-lib.sh - report on it instead&#34;) and a prior round recorded fm-dod-lib as a deferred follow-up. Recorded so the follow-up survives with its new contradiction noted.
- ℹ️ `docs/architecture.md:202` - The new sentence asserts &#34;`bin/fm-brief.sh`&#39;s header owns which base each path resolves - `origin/&lt;default&gt;` for PR-based delivery, the clone&#39;s local default branch for `local-only`, origin then local for a scout&#34;. The header does not carry that. I ran `./bin/fm-brief.sh --help` (which `usage()` renders verbatim from the leading comment block) and its only base-related lines are &#34;...renders its real default branch into the startup base-freshness check; one that does not still gets the same mandatory check, deferred to the worker at runtime&#34; and the numbered 1/2/3 safety-contract line. The per-mode base selection lives only in a non-header inline comment at bin/fm-brief.sh:376-382, which `--help` never prints. AGENTS.md section 11 treats &#34;`bin/fm-brief.sh` and its help own ... exact safety mechanics&#34; as a load-bearing ownership contract, so the second clause of the same doc sentence (unresolvable-label deferral) is accurate while the first sends a reader to a place that does not state it. Fix either by adding the one-line per-mode summary to the header block, or by rewording the pointer to name the inline comment instead.
- ℹ️ `bin/fm-brief.sh:486` - `BASE_SHELL_REF` is correctly used inside the executable `git rev-list` line, but it is also substituted into the prose sentence &#34;If the count is not `0`, rebase onto `$BASE_SHELL_REF` before reading or writing anything&#34; (bin/fm-brief.sh:486 for the fetch path and bin/fm-brief.sh:493 for the local path). Rendered, that reads &#34;rebase onto `&#39;origin/release&#39;`&#34; two lines below &#34;Only `0` passes against the freshly fetched default branch `origin/release`&#34; — the same branch presented under two different names in adjacent lines of the same numbered step. It is not a shell-injection risk either way (a worker running `git rebase &#34;&#39;origin/release&#39;&#34;` fails loudly rather than silently rebasing onto something else), and the intent&#39;s decision 7 only requires the ref to be one shell word in the command the worker executes. Using `$BASE_REF` in the prose line and keeping `$BASE_SHELL_REF` in the command would restore consistency; tests/fm-brief.test.sh:499 currently pins the quoted prose form, so that assertion moves with it. Generated worker-facing text, so the wording is the author&#39;s call.

🔧 Fix: resolve default branch from unambiguous origin/HEAD ref
1 warning still open:

- ⚠️ `bin/fm-brief.sh:448` - The scaffold-side parser was fixed in 5b9902d to stop reading `origin/HEAD` through the ambiguity-dependent `git symbolic-ref --short`, but the *emitted runtime* rule still instructs the worker to use it, and its confirmation step accepts a remote-tracking ref. LOCAL_DEFAULT_RULE (bin/fm-brief.sh:448) says: &#34;Read `git symbolic-ref --quiet --short refs/remotes/origin/HEAD`. If it names a branch, that name with the leading `origin/` dropped IS `&lt;default&gt;`: confirm the local branch exists with `git rev-parse --verify &lt;default&gt;`&#34;. Reproduced end to end with a real fixture: a clone whose origin/HEAD -&gt; origin/develop, whose local `develop` is 2 commits ahead of origin, that also holds a ref literally named `origin/develop` (a tag suffices), and a recycled worktree detached at the old pushed base. `--short` returns `remotes/origin/develop`; stripping a leading `origin/` leaves it unchanged; `git rev-parse --verify remotes/origin/develop` PASSES because git resolves `remotes/&lt;x&gt;` to `refs/remotes/&lt;x&gt;` — so the &#34;confirm the local branch exists&#34; guard is satisfied by the remote-tracking ref, not a local branch. The worker then runs `git rev-list --count $(git merge-base HEAD remotes/origin/develop)..remotes/origin/develop` -&gt; 0 and treats the base as fresh, while the correct count against local `develop` is 2. Silent wrong pass, in local-only mode, where the accepted intent states comparing against origin &#34;would make the new check confidently wrong&#34;. Reachable whenever the free-form repo label does not resolve (or origin/HEAD names a branch with no local ref), which is exactly when this rule is emitted. Lines 459 and 475 carry the same `--short` read on the origin-first arms; those fail loudly (`origin/remotes/origin/&lt;x&gt;` does not resolve) rather than silently, but should move with it. Earliest shared fix is the single LOCAL_DEFAULT_RULE plus the two origin arms: read `git symbolic-ref --quiet refs/remotes/origin/HEAD` and strip `refs/remotes/origin/`, and confirm with `git rev-parse --verify refs/heads/&lt;default&gt;` so only a local branch satisfies the local arm. tests/fm-brief.test.sh:665-668 currently pins the `--short` wording, so those assertions move with the text. Generated worker-facing prose and a deliberate wording choice, so it needs the author&#39;s call.

🔧 Fix: read origin/HEAD as full ref in emitted base rule
2 issues (1 warning, 1 info) still open:

- ⚠️ `bin/fm-brief.sh:495` - The scaffold resolves the default branch through fully-qualified refs (`refs/heads/$branch^{commit}` at bin/fm-brief.sh:253 and :258, `refs/remotes/origin/$branch^{commit}` at :269) and the runtime rule confirms with `git rev-parse --verify refs/heads/&lt;default&gt;` (:448) — but every emitted MEASUREMENT and REBASE command uses the unqualified name, so the one command that decides pass/fail is resolved by git&#39;s ambiguous-refname precedence. `BASE_SHELL_REF` is `shell_quote &#34;$BASE_REF&#34;`, i.e. `&#39;origin/release&#39;` or `&#39;release&#39;`, never `refs/remotes/origin/release` / `refs/heads/release` (:411, :420, used at :495 and :503; the fallback arms have the same shape at :464, :469, :479, :488).

git&#39;s rev-parse precedence puts `refs/tags/&lt;name&gt;` ABOVE `refs/heads/&lt;name&gt;` and above `refs/remotes/&lt;name&gt;`, so a ref that merely shares the name wins. Reproduced end to end on git 2.48.1, both paths:

(a) local-only. Repo with local default `release` two commits ahead of a detached worker HEAD, plus a tag `release` at the old tip. The emitted command `git rev-list --count $(git merge-base HEAD &#39;release&#39;)..&#39;release&#39;` returns `0` — the brief&#39;s declared pass — while `refs/heads/release` returns `2`.

(b) PR path. Clone with `refs/remotes/origin/release` two commits ahead of a detached worker HEAD, plus a tag literally named `origin/release` at the old tip. The emitted `git rev-list --count $(git merge-base HEAD &#39;origin/release&#39;)..&#39;origin/release&#39;` returns `0`; `refs/remotes/origin/release` returns `2`.

That is a stale base certified fresh with a `0`, the exact failure this branch exists to prevent, and it defeats the runtime rule&#39;s own hardening: the worker verifies `refs/heads/develop` exists and then measures against a tag named `develop`. git does print `warning: refname &#39;X&#39; is ambiguous.` on stderr, but the brief never mentions it and states `0` as the sole criterion, so a worker following the instructions passes. The `origin/&lt;name&gt;` tag shape is not hypothetical here — this change&#39;s own fixtures create `git tag origin/develop` (tests/fm-brief.test.sh:494, :557) to demonstrate that exact ambiguity class matters.

Earliest shared fix is the ref that goes INTO the executed command: have `set_origin_base`/`set_local_base` shell-quote the fully-qualified ref (`refs/remotes/origin/&lt;b&gt;` / `refs/heads/&lt;b&gt;`) for `BASE_SHELL_REF` while `BASE_REF` keeps the short name for the prose and Rule 1, and qualify `&lt;default&gt;` the same way in the four fallback commands. This needs the author&#39;s call because it changes generated worker-facing text and interacts with the round-1 decision that deliberately split the quoted command form from the bare prose form (tests/fm-brief.test.sh asserts both).
- ℹ️ `bin/fm-brief.sh:44` - Preserved follow-up, recorded so it survives with the new contradiction noted. The header block — which `usage()` renders verbatim into `--help` (bin/fm-brief.sh:80-86) and which this change edits directly two lines below (:48-57) — still describes local-only as &#34;the configured merge authority approves, firstmate merges to local main&#34;. The generated brief no longer agrees: for the `release`-default fixture I rendered, Setup step 2 says &#34;rebase onto `release`&#34;, Rule 1 says &#34;firstmate handles the merge into local `release`&#34;, and only the help text and bin/fm-dod-lib.sh:37 still say `main`. This is the same hardcoded-`main` family as the fm-dod-lib line the user already chose to defer (&#34;do not silently delete the soft line in bin/fm-dod-lib.sh - report on it instead&#34;), so no action taken; whoever lands that follow-up should update this help line in the same pass.

🔧 Fix: qualify emitted base refs against same-named tags
2 infos still open:

- ℹ️ `bin/fm-dod-lib.sh:35` - Preserved follow-up, reported (not fixed) exactly as user intent requires: &#34;do not silently delete the soft line in bin/fm-dod-lib.sh - report on it instead&#34;. Now that Setup and Rule 1 render the resolved default branch, the same generated brief contradicts itself. For a local-only brief against a `release`-default clone I rendered end to end: Setup step 2 says &#34;Only `0` passes against your local default branch `release`&#34; and &#34;rebase onto `&#39;refs/heads/release&#39;`&#34;, Rule 1 says &#34;firstmate handles the merge into local `release`&#34;, but the Definition of done (bin/fm-dod-lib.sh:35 and :37) still says &#34;if `main` has advanced, rebase onto it&#34; and &#34;firstmate merges it into local `main`&#34;. A worker that follows the DoD line would rebase onto a branch that is not this repo&#39;s default. `fm-brief.sh` and `fm-promote.sh` both render this block, so the fix belongs in fm_dod_block (thread the resolved base ref through, or drop the branch name) rather than in either caller. Explicitly deferred by the user in an earlier round; recorded only so the follow-up survives.
- ℹ️ `bin/fm-spawn.sh:1909` - Sibling of the ref-ambiguity class this change just closed, confirmed still present and correctly untouched because user intent scopes it out (&#34;bin/fm-spawn.sh and the worktree pool itself are explicitly out of scope (a sibling ticket owns the pool)&#34;). `freshen_spawn_worktree_base` builds `target=&#34;origin/$default&#34;` (bin/fm-spawn.sh:1909) and then uses that unqualified name for `git rev-parse --verify --quiet &#34;$target^{commit}&#34;` (:1914) and `git reset --hard &#34;$target&#34;` (:1929). git&#39;s rev-parse precedence ranks `refs/tags/&lt;name&gt;` above `refs/remotes/&lt;name&gt;`, so a tag literally named `origin/&lt;default&gt;` resolves ahead of the tracking ref; `expected` and `actual` would then both be the tag&#39;s commit, the post-reset equality check at :1934 passes, and a fresh spawn is silently seeded from the tag instead of the fetched default tip - no error. The line-1910 refspec fetch keeps `refs/remotes/origin/&lt;default&gt;` current but does not change which ref the bare name resolves to. The emitted brief now uses `refs/remotes/origin/&lt;default&gt;` for exactly this reason (bin/fm-brief.sh:411), so the spawn-time and runtime layers currently disagree on ref qualification. Contrived trigger and out of scope here; recorded so the pool ticket can qualify these two refs in the same pass.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash bin/fm-test-run.sh tests/fm-brief.test.sh` - 34 assertions, all pass (base-freshness mode awareness, zero-only criterion, Setup-vs-DOD placement, shell quoting, same-named-tag ref qualification, unresolvable label, missing origin/HEAD, scout fallback)</code>
- <code>`bash bin/fm-test-run.sh tests/fm-task-delivery.test.sh tests/fm-tangle-guard.test.sh tests/fm-secondmate-safety.test.sh tests/fm-ask-user-authority.test.sh tests/fm-classify-corr-token.test.sh tests/fm-voice-relay.test.sh tests/fm-subagent-pretool-check.test.sh` - the 7 non-live sibling suites that invoke bin/fm-brief.sh, all pass</code>
- <code>Manual E2E: built a `release`-default project + bare origin, leased a detached treehouse pool slot, advanced the remote 30 commits, scaffolded `bin/fm-brief.sh ev-nomistakes hazlo --mode no-mistakes`, extracted the emitted `git fetch origin --quiet` and `git rev-list --count $(git merge-base HEAD &#39;refs/remotes/origin/release&#39;)..&#39;refs/remotes/origin/release&#39;` from the rendered Setup section and executed them verbatim in the stale slot (0 without the fetch, 30 with it, 0 after the instructed rebase)</code>
- <code>Manual E2E: `bin/fm-brief.sh ev-localonly tobydoro --mode local-only` against a project whose local default is 12 commits ahead of origin - emitted command reports 12 against `refs/heads/release`, emits no `git fetch`, while the same slot reports 0 against the stale origin tracking ref</code>
- <code>Manual E2E: `bin/fm-brief.sh ev-scout hazlo --scout` - base check renders as scout step 1 with the origin path</code>
- <code>Manual E2E: tag literally named `origin/release` at the old tip - emitted qualified ref reports 30, an unqualified `origin/release` reports 0 (false pass)</code>
- <code>Manual E2E: `bin/fm-brief.sh ev-unresolvable a-repo-firstmate-has-no-local-view-of --mode direct-PR` and the same label with `--scout` - both still render the mandatory check with runtime base resolution and blocked: escalation</code>
- <code>Manual E2E: project whose real default branch is `release;touch$IFS$9fm-brief-injection-marker` - executed the emitted rev-list command in a worktree; it returned 0 and created no marker file</code>
- <code>Before/after: scaffolded the same no-mistakes brief from base commit d22318e (`git show d22318e:bin/fm-brief.sh`) to show the prior Setup section had no base check at all</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-brief.sh:46` - The header block that usage() renders into --help still says local-only is &#34;the configured merge authority approves, firstmate merges to local main&#34;, while the brief this change now emits says &#34;firstmate handles the merge into local `&lt;default&gt;`&#34; (verified: a release-default fixture renders &#34;merge into local `release`&#34;). Left untouched deliberately: review round 3 of this run recorded this exact line as a declined no-op, and the user intent defers the sibling hardcoded-`main` line in bin/fm-dod-lib.sh (&#34;do not silently delete the soft line ... report on it instead&#34;). Reported so the header line is updated in the same pass as that fm-dod-lib follow-up; no Markdown doc restates this fact, so those two script surfaces are the only copies.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
