### PR TITLE
fix(bin): keep relaunch rewrites from breaking the armed PR merge poll

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3023,8 +3023,15 @@ spawn_record_traceparent() {
   fi
   SPAWN_META_TMP="$STATE/.$ID.meta.trace.${BASHPID:-$$}"
   if [ ! -f "$meta" ] || [ ! -w "$meta" ] \
-     || ! awk -F= '$1 != "traceparent"' "$meta" > "$SPAWN_META_TMP" \
-     || ! printf 'traceparent=%s\n' "$SPAWN_TRACEPARENT" >> "$SPAWN_META_TMP" \
+     || ! awk -F= -v carrier="$SPAWN_TRACEPARENT" '
+          $1 == "traceparent" { next }
+          $1 == "pr" && !recorded {
+            printf "traceparent=%s\n", carrier
+            recorded = 1
+          }
+          { print }
+          END { if (!recorded) printf "traceparent=%s\n", carrier }
+        ' "$meta" > "$SPAWN_META_TMP" \
      || ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$meta" "task record" "$STATE"; then
     status=1
     rm -f "$SPAWN_META_TMP" 2>/dev/null || true

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3022,6 +3022,9 @@ spawn_record_traceparent() {
     acquired=1
   fi
   SPAWN_META_TMP="$STATE/.$ID.meta.trace.${BASHPID:-$$}"
+  # Inserted before the first pr= line so the armed poll's identity lines stay
+  # terminal (fm_pr_metadata_identity_parse rejects unknown fields after pr=,
+  # so a carrier appended at the end would break the PR merge poll).
   if [ ! -f "$meta" ] || [ ! -w "$meta" ] \
      || ! awk -F= -v carrier="$SPAWN_TRACEPARENT" '
           $1 == "traceparent" { next }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2894,11 +2894,14 @@ preserve_relaunch_meta() {
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
   fi
+  if [ "$SPAWN_CONTROL_PARENT" = 1 ] && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ]; then
+    # Written before the preserved lines so a task's pr= identity line stays
+    # terminal in the rewritten record (fm_pr_metadata_identity_parse rejects
+    # unknown fields after pr=, which would break the armed PR merge poll).
+    echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
+  fi
   if [ "$RELAUNCH" -eq 1 ]; then
     preserve_relaunch_meta
-  fi
-  if [ "$SPAWN_CONTROL_PARENT" = 1 ] && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ]; then
-    echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
   fi
 } > "$SPAWN_META_PATH" || {
   echo "error: task record for $ID could not be prepared at $SPAWN_META_PATH" >&2

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -362,6 +362,45 @@ test_relaunch_keeps_the_pr_identity_line_terminal() {
   pass "fm-control relaunch: the replacement record keeps the armed poll's pr identity terminal"
 }
 
+test_trace_enabled_relaunch_keeps_the_pr_identity_line_terminal() {
+  local dir out rc url head carrier traceparent
+  dir=$(new_case trace-poll-identity rl42)
+  add_ship_task "$dir" rl42 claude
+  url=https://github.com/example/repo/pull/22
+  head=0123456789abcdef0123456789abcdef01234567
+  carrier=00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01
+  # The armed shape a trace-context home leaves behind: the task's recorded
+  # carrier sits before the pr= and pr_head= identity lines that fm-pr-check.sh
+  # appends terminally. A relaunch under the same frozen on decision re-records
+  # the carrier into the replacement, and that re-record must not land after the
+  # identity lines, or the merge poll is rejected every cycle.
+  {
+    printf '%s\n' "traceparent=$carrier"
+    printf '%s\n' "pr=$url"
+    printf '%s\n' "pr_head=$head"
+  } >> "$dir/home/state/rl42.meta"
+  printf '%s\n' "$$" > "$dir/home/state/.lock"
+  printf '%s on\n' "$$" > "$dir/home/state/.trace-context-effective"
+
+  out=$(run_control "$dir" rl42 relaunch --note "continue under tracing"); rc=$?
+  expect_code 0 "$rc" "a traced relaunch of a PR-armed task should succeed"$'\n'"$out"
+  fm_pr_metadata_identity_parse "$dir/home/state/rl42.meta" \
+    || fail "the traced relaunch recorded the carrier after the pr identity, so the armed merge poll is rejected every cycle"
+  [ "$FM_PR_META_URL" = "$url" ] \
+    || fail "the traced relaunch lost the armed poll's PR identity URL"
+  [ "$FM_PR_META_PROVIDER" = github ] \
+    && [ "$FM_PR_META_HOST" = github.com ] \
+    && [ "$FM_PR_META_PATH" = example/repo ] \
+    && [ "$FM_PR_META_NUMBER" = 22 ] \
+    || fail "the traced relaunch reports the wrong PR identity fields"
+  traceparent=$(meta_field "$dir" rl42 traceparent)
+  fm_trace_context_valid "$traceparent" \
+    || fail "the traced relaunch lost the task's trace carrier"
+  [ "$traceparent" = "$carrier" ] \
+    || fail "a traced relaunch must reuse the task's recorded carrier verbatim"
+  pass "fm-control relaunch: a traced relaunch keeps the armed poll's pr identity terminal"
+}
+
 test_relaunch_serializes_concurrent_durable_metadata_publication() {
   local dir control_pid link_pid rc i=0 traceparent prepare launch_release waiting ready release
   dir=$(new_case metadata-race rl28)
@@ -1511,6 +1550,7 @@ test_relaunch_moves_a_drifted_item_back_in_flight() {
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_keeps_the_pr_identity_line_terminal
+test_trace_enabled_relaunch_keeps_the_pr_identity_line_terminal
 test_relaunch_serializes_concurrent_durable_metadata_publication
 test_disabled_relaunch_clears_prior_trace_context
 test_relaunch_appends_the_progress_note_to_the_instructions

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -24,6 +24,8 @@ set -u
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-control-lib.sh"
 # shellcheck source=/dev/null
+. "$ROOT/bin/fm-pr-lib.sh"
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-trace-context-lib.sh"
 
 CONTROL="$ROOT/bin/fm-control.sh"
@@ -329,6 +331,35 @@ test_relaunch_preserves_durable_task_metadata() {
   [ "$(meta_field "$dir" rl19 decisions_reviewed)" = 1 ] \
     || fail "the task decision state must survive relaunch"
   pass "fm-control relaunch: durable task metadata survives replacement launch publication"
+}
+
+test_relaunch_keeps_the_pr_identity_line_terminal() {
+  local dir out rc url head
+  dir=$(new_case poll-identity rl20)
+  add_ship_task "$dir" rl20 claude
+  url=https://github.com/example/repo/pull/20
+  head=0123456789abcdef0123456789abcdef01234567
+  # The exact shape fm-pr-check.sh leaves behind: the armed poll's pr= and
+  # pr_head= identity lines terminate the record, and the watcher's merge
+  # poll validates that identity every cycle. A relaunch rewrite that lets
+  # any non-identity field land after them breaks that validation.
+  {
+    printf '%s\n' "pr=$url"
+    printf '%s\n' "pr_head=$head"
+  } >> "$dir/home/state/rl20.meta"
+
+  out=$(run_control "$dir" rl20 relaunch --note "mid-review relaunch"); rc=$?
+  expect_code 0 "$rc" "a relaunch of a PR-armed task should succeed"$'\n'"$out"
+  fm_pr_metadata_identity_parse "$dir/home/state/rl20.meta" \
+    || fail "the relaunched task record no longer parses as a PR identity, so the armed merge poll is rejected every cycle"
+  [ "$FM_PR_META_URL" = "$url" ] \
+    || fail "the relaunched task record reports the wrong PR identity URL"
+  [ "$FM_PR_META_PROVIDER" = github ] \
+    && [ "$FM_PR_META_HOST" = github.com ] \
+    && [ "$FM_PR_META_PATH" = example/repo ] \
+    && [ "$FM_PR_META_NUMBER" = 20 ] \
+    || fail "the relaunched task record reports the wrong PR identity fields"
+  pass "fm-control relaunch: the replacement record keeps the armed poll's pr identity terminal"
 }
 
 test_relaunch_serializes_concurrent_durable_metadata_publication() {
@@ -1479,6 +1510,7 @@ test_relaunch_moves_a_drifted_item_back_in_flight() {
 
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
+test_relaunch_keeps_the_pr_identity_line_terminal
 test_relaunch_serializes_concurrent_durable_metadata_publication
 test_disabled_relaunch_clears_prior_trace_context
 test_relaunch_appends_the_progress_note_to_the_instructions

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -416,6 +416,39 @@ test_meta_identity_orders_relaunch_fields_before_pr() {
   pass "the PR identity parse accepts relaunch fields before pr= and rejects them after"
 }
 
+test_meta_identity_orders_trace_carrier_before_pr() {
+  local dir state url head carrier
+  dir=$(make_case trace-identity-order)
+  state="$dir/home/state"
+  url=https://github.com/example/repo/pull/22
+  head=0123456789abcdef0123456789abcdef01234567
+  carrier=00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01
+  # A trace-context relaunch re-records the task's carrier before the preserved
+  # identity lines, so the armed poll's terminal pr= shape survives and the
+  # merge poll keeps validating the record every cycle. The same carrier
+  # landing after pr= is the rejected pollution shape, because anything other
+  # than pr_head= and the x-mode fields after pr= could be a field an
+  # unrelated writer appended to a validated identity.
+  fm_write_meta "$state/task-a.meta" \
+    'window=fm-task-a' \
+    "traceparent=$carrier" \
+    "pr=$url" \
+    "pr_head=$head"
+  fm_pr_metadata_identity_parse "$state/task-a.meta" \
+    || fail "a trace carrier before pr= broke the PR identity parse"
+  [ "$FM_PR_META_URL" = "$url" ] \
+    || fail "the pre-pr trace carrier changed the parsed PR identity"
+
+  fm_write_meta "$state/task-a.meta" \
+    'window=fm-task-a' \
+    "pr=$url" \
+    "pr_head=$head" \
+    "traceparent=$carrier"
+  fm_pr_metadata_identity_parse "$state/task-a.meta" \
+    && fail "a trace carrier after pr= was accepted into the PR identity"
+  pass "the PR identity parse accepts the trace carrier before pr= and rejects it after"
+}
+
 test_invalid_entrypoints_have_zero_side_effects() {
   local dir before after value rc
   dir=$(make_case invalid-entrypoints)
@@ -2145,6 +2178,7 @@ test_gitlab_merged_poll_retires() {
 
 test_parser_matrix
 test_meta_identity_orders_relaunch_fields_before_pr
+test_meta_identity_orders_trace_carrier_before_pr
 test_gitlab_merge_watch
 test_merged_poll_retires_once
 test_merged_poll_reregistration_after_notification_is_absorbed

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -384,6 +384,38 @@ EOF
   pass "raw-byte parser accepts canonical URLs and rejects the complete adversarial matrix"
 }
 
+test_meta_identity_orders_relaunch_fields_before_pr() {
+  local dir state url head
+  dir=$(make_case relaunch-identity-order)
+  state="$dir/home/state"
+  url=https://github.com/example/repo/pull/21
+  head=0123456789abcdef0123456789abcdef01234567
+  # A relaunch rewrite records its transaction marker before the preserved
+  # identity lines, so the armed poll's terminal pr= shape survives and the
+  # merge poll keeps validating the record every cycle. The same marker
+  # landing after pr= is the rejected pollution shape, because anything
+  # other than pr_head= and the x-mode fields after pr= could be a field an
+  # unrelated writer appended to a validated identity.
+  fm_write_meta "$state/task-a.meta" \
+    'window=fm-task-a' \
+    'control_relaunch_tx=3181152.20260831T104354Z.25096' \
+    "pr=$url" \
+    "pr_head=$head"
+  fm_pr_metadata_identity_parse "$state/task-a.meta" \
+    || fail "a relaunch transaction marker before pr= broke the PR identity parse"
+  [ "$FM_PR_META_URL" = "$url" ] \
+    || fail "the pre-pr transaction marker changed the parsed PR identity"
+
+  fm_write_meta "$state/task-a.meta" \
+    'window=fm-task-a' \
+    "pr=$url" \
+    "pr_head=$head" \
+    'control_relaunch_tx=3181152.20260831T104354Z.25096'
+  fm_pr_metadata_identity_parse "$state/task-a.meta" \
+    && fail "a relaunch transaction marker after pr= was accepted into the PR identity"
+  pass "the PR identity parse accepts relaunch fields before pr= and rejects them after"
+}
+
 test_invalid_entrypoints_have_zero_side_effects() {
   local dir before after value rc
   dir=$(make_case invalid-entrypoints)
@@ -2112,6 +2144,7 @@ test_gitlab_merged_poll_retires() {
 }
 
 test_parser_matrix
+test_meta_identity_orders_relaunch_fields_before_pr
 test_gitlab_merge_watch
 test_merged_poll_retires_once
 test_merged_poll_reregistration_after_notification_is_absorbed


### PR DESCRIPTION
## Intent

Fix a relaunch bug in bin/fm-spawn.sh that breaks an armed PR merge poll's identity validation, and cover it with a regression test. Bug (reproduced live on this home): when bin/fm-control.sh <task-id> relaunch rewrites a task's state/<task-id>.meta, the meta writer appends the preserved unowned lines (including the pr= identity line that bin/fm-pr-check.sh records) and then writes control_relaunch_tx= after them; fm_pr_metadata_identity_parse in bin/fm-pr-lib.sh only tolerates unknown fields BEFORE the pr= line, and after it only pr=, pr_head=, and the x-mode fields are allowed, so the parse fails, fm_pr_poll_artifacts_valid fails, and the watcher rejects the task's armed PR merge poll every cycle with 'check: rejected unauthenticated state checks'. Fix: in the fm-spawn.sh meta writer block that calls preserve_relaunch_meta and conditionally echoes control_relaunch_tx=, write control_relaunch_tx= BEFORE preserve_relaunch_meta runs so preserved lines, and the pr= identity line, remain terminal in the rewritten meta; keep the change minimal, no restructuring of the writer beyond the ordering fix. Test: colocated regression tests following this repo's existing test conventions (extend tests/fm-control-relaunch.test.sh and tests/fm-pr-check-security.test.sh, no new runner) that fail before the fix and pass after: a relaunch-shaped meta rewrite keeps the pr= line terminal (verified through the real fm-control.sh relaunch path and fm_pr_metadata_identity_parse), and a meta with control_relaunch_tx= before pr= parses as a valid identity while the post-pr= pollution shape fails. Constraints: this task touches firstmate's shared tracked material, so follow firstmate-coding-guidelines: one sentence per line in tracked Markdown, plain dash never em dash, no agent name as commit co-author, bin scripts shellcheck-clean per bin/fm-lint.sh, tests must exercise behavior through an executable or public interface and never assert implementation-source bytes. Verification context from the developer's session, so re-derivation is unnecessary: both touched suites pass in full with the fix (tests/fm-control-relaunch.test.sh about 75 seconds, tests/fm-pr-check-security.test.sh about 200 seconds); stashing only the bin/fm-spawn.sh fix makes the new relaunch regression test fail with the reported symptom and restoring it passes; bin/fm-lint.sh is clean when the pinned shellcheck 0.11.0 and actionlint 1.7.12 binaries are installed to a directory and put on PATH (they are not on the default PATH; bin/fm-install-shellcheck.sh and bin/fm-install-actionlint.sh each take a destination directory); the prior pipeline run's review step completed at low risk with only an informational out-of-scope note about fm-captain-hold.sh. The prior pipeline run's test step had validated this change completely before its 30-minute agent wall clock expired: both new tests fail pre-fix and pass post-fix, and a full end-to-end demo through the real executables (arm the poll via real fm-pr-check.sh with a stubbed gh, relaunch via real fm-control.sh, real fm-watch.sh cycles) reproduced the exact 'check: rejected unauthenticated state checks' rejection pre-fix and passed with the fix. Note: 'fallback-timeout watcher did not stop' in test_returned_custom_check_descendants_are_drained (tests/fm-pr-check-security.test.sh) is a pre-existing timing-sensitive watcher-shutdown failure mode unrelated to the meta-writer change; a suite invocation that passes is adequate evidence of that, and characterizing it further is not part of this brief. Later authorized extension to the same brief: spawn_record_traceparent must write traceparent= BEFORE the preserved pr=/pr_head= identity lines so pr= stays terminal, mirroring the committed control_relaunch_tx fix, with a colocated regression test covering a PR-armed relaunch with trace-context enabled (armed poll identity must survive both control_relaunch_tx and traceparent= appends); fm-captain-hold.sh is out of scope under a separate queued task.

## What Changed

- In the `bin/fm-spawn.sh` task-record writer, `control_relaunch_tx=` is now emitted before `preserve_relaunch_meta` appends the preserved lines, so a relaunch rewrite keeps the `pr=` and `pr_head=` identity lines terminal and the armed PR merge poll's identity validation no longer rejects the task every cycle.
- `spawn_record_traceparent` now inserts `traceparent=` before the first `pr=` line instead of appending it at the end, so a traced relaunch that re-records the carrier preserves the same terminal-identity shape.
- Regression tests in `tests/fm-control-relaunch.test.sh` and `tests/fm-pr-check-security.test.sh` cover both writer paths through the real `fm-control.sh` relaunch flow and `fm_pr_metadata_identity_parse`, asserting the pre-`pr=` placement parses as a valid PR identity while the post-`pr=` pollution shape is rejected.

## Risk Assessment

✅ Low: The change is a minimal, mechanically verified ordering fix in two meta writers plus colocated behavior-level regression tests through the real executables and public parser; the only remaining reachable sibling path (fm-captain-hold.sh) is explicitly authorized out of scope under a separate queued task.

## Testing

Exercised the change through the real executables: the four new regression tests pass with the fix, both relaunch-path tests fail with the reported symptom when only the bin/fm-spawn.sh fix is reverted, a real fm-pr-check.sh arm plus real fm-control.sh relaunch plus real fm-watch.sh cycles demo reproduced the exact 'check: rejected unauthenticated state checks' rejection every cycle pre-fix and a validated merged notification with clean poll retirement post-fix (transcripts captured), and both touched suites pass in full through the repo's runner; the worktree was left clean and byte-identical to the target commit with all transient artifacts removed. No UI surface exists for this CLI change, so CLI transcripts are the reviewer-visible evidence rather than screenshots.

<details>
<summary>Evidence: Pre-fix end-to-end transcript: relaunch breaks the armed PR merge poll (real fm-pr-check.sh, fm-control.sh, fm-watch.sh)</summary>

Source: [Pre-fix end-to-end transcript: relaunch breaks the armed PR merge poll (real fm-pr-check.sh, fm-control.sh, fm-watch.sh)](https://github.com/ardydedase/firstmate/blob/4853a0dc179147939031fa218e052c6bb2175a5e/.no-mistakes/evidence/ardy/firstmate-relaunch-poll-meta-order/pre-fix-e2e-transcript.txt)

<code>$ fm-control.sh demo relaunch --note &#34;mid-review relaunch&#34;&#10;relaunched demo harness=claude from=claude model=default effort=default backend=tmux endpoint=fmses:fm-demo worktree=...&#10;14 pr=https://github.com/example/repo/pull/21&#10;15 pr_head=0123456789abcdef0123456789abcdef01234567&#10;16 control_relaunch_tx=1874406.20260831T132318Z.15134&#10;meta shape: control_relaunch_tx= was written AFTER the pr= identity line&#10;&#10;$ FM_TEST_GH_STATE=MERGED fm-watch.sh&#10;watcher stdout:&#10;check: rejected unauthenticated state checks: .../state/demo.check.sh&#10;(second cycle: identical rejection; poll never consulted the forge and never retired)</code>

```text

========== setup: hermetic home with a live claude ship task ==========
worktree: ~/.no-mistakes/worktrees/86574f01ec14/01M1BZ4PFVBXMX15CKVNNVM15B
head:     8701c51f529cab3afc85ca4a62cc93a6ed063e31
writer:   bin/fm-spawn.sh differs from HEAD (base writer reverted for this run)
mode:     reject-expected
--- /tmp/fm-e2e-reject-expected.siGUP0/case/home/state/demo.meta ---
   1  window=fmses:fm-demo
   2  endpoint_task_id=demo
   3  worktree=/tmp/fm-e2e-reject-expected.siGUP0/case/wt
   4  project=/tmp/fm-e2e-reject-expected.siGUP0/case/proj
   5  harness=claude
   6  kind=ship
   7  mode=no-mistakes
   8  yolo=off
   9  tasktmp=/tmp/fm-e2e-reject-expected.siGUP0/case/tasktmp
  10  model=default
  11  effort=default

========== arm the PR merge poll via the real fm-pr-check.sh (stubbed gh CLI) ==========
$ fm-pr-check.sh demo https://github.com/example/repo/pull/21
armed: state/demo.check.sh
--- /tmp/fm-e2e-reject-expected.siGUP0/case/home/state/demo.meta ---
   1  window=fmses:fm-demo
   2  endpoint_task_id=demo
   3  worktree=/tmp/fm-e2e-reject-expected.siGUP0/case/wt
   4  project=/tmp/fm-e2e-reject-expected.siGUP0/case/proj
   5  harness=claude
   6  kind=ship
   7  mode=no-mistakes
   8  yolo=off
   9  tasktmp=/tmp/fm-e2e-reject-expected.siGUP0/case/tasktmp
  10  model=default
  11  effort=default
  12  pr=https://github.com/example/repo/pull/21
  13  pr_head=0123456789abcdef0123456789abcdef01234567
poll artifacts: case/home/state/demo.check.sh case/home/state/demo.pr-poll case/home/state/demo.pr-poll-registration 

========== relaunch the task via the real fm-control.sh (the reported live command) ==========
$ fm-control.sh demo relaunch --note "mid-review relaunch"
warning: /tmp/fm-e2e-reject-expected.siGUP0/case/home/data/demo/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
relaunched demo harness=claude from=claude model=default effort=default backend=tmux endpoint=fmses:fm-demo worktree=/tmp/fm-e2e-reject-expected.siGUP0/case/wt
relaunch exit status: 0
--- /tmp/fm-e2e-reject-expected.siGUP0/case/home/state/demo.meta ---
   1  window=fmses:fm-demo
   2  endpoint_task_id=demo
   3  worktree=/tmp/fm-e2e-reject-expected.siGUP0/case/wt
   4  project=/tmp/fm-e2e-reject-expected.siGUP0/case/proj
   5  harness=claude
   6  kind=ship
   7  mode=no-mistakes
   8  yolo=off
   9  tasktmp=/tmp/fm-demo
  10  model=default
  11  effort=default
  12  busy_gen=g1788182599.1875111.29260
  13  spawn_gen=s1788182599.1874908.7630
  14  pr=https://github.com/example/repo/pull/21
  15  pr_head=0123456789abcdef0123456789abcdef01234567
  16  control_relaunch_tx=1874406.20260831T132318Z.15134
meta shape: control_relaunch_tx= was written AFTER the pr= identity line

========== watcher cycle 1 via the real fm-watch.sh (gh reports the PR MERGED) ==========
$ FM_TEST_GH_STATE=MERGED fm-watch.sh
watcher exit status: 0
watcher stdout:
  check: rejected unauthenticated state checks: /tmp/fm-e2e-reject-expected.siGUP0/case/home/state/demo.check.sh

========== watcher cycle 2 via the real fm-watch.sh (poll rejected every cycle) ==========
$ FM_TEST_GH_STATE=MERGED fm-watch.sh
watcher exit status: 0
watcher stdout:
  check: rejected unauthenticated state checks: /tmp/fm-e2e-reject-expected.siGUP0/case/home/state/demo.check.sh

========== poll state after the watcher cycles ==========
forge calls the poll made (gh.log):
  $ gh pr view https://github.com/example/repo/pull/21 --json headRefOid -q .headRefOid
armed poll still present (never retired): /tmp/fm-e2e-reject-expected.siGUP0/case/home/state/demo.check.sh
--- /tmp/fm-e2e-reject-expected.siGUP0/case/home/state/demo.meta ---
   1  window=fmses:fm-demo
   2  endpoint_task_id=demo
   3  worktree=/tmp/fm-e2e-reject-expected.siGUP0/case/wt
   4  project=/tmp/fm-e2e-reject-expected.siGUP0/case/proj
   5  harness=claude
   6  kind=ship
   7  mode=no-mistakes
   8  yolo=off
   9  tasktmp=/tmp/fm-demo
  10  model=default
  11  effort=default
  12  busy_gen=g1788182599.1875111.29260
  13  spawn_gen=s1788182599.1874908.7630
  14  pr=https://github.com/example/repo/pull/21
  15  pr_head=0123456789abcdef0123456789abcdef01234567
  16  control_relaunch_tx=1874406.20260831T132318Z.15134

========== verdict (reject-expected) ==========
RESULT: the armed PR merge poll was rejected every cycle, as the unfixed writer causes
```
</details>
<details>
<summary>Evidence: Post-fix end-to-end transcript: armed poll survives relaunch, is validated, observes the merge, and retires</summary>

Source: [Post-fix end-to-end transcript: armed poll survives relaunch, is validated, observes the merge, and retires](https://github.com/ardydedase/firstmate/blob/4853a0dc179147939031fa218e052c6bb2175a5e/.no-mistakes/evidence/ardy/firstmate-relaunch-poll-meta-order/post-fix-e2e-transcript.txt)

<code>$ fm-control.sh demo relaunch --note &#34;mid-review relaunch&#34;&#10;relaunched demo harness=claude from=claude model=default effort=default backend=tmux endpoint=fmses:fm-demo worktree=...&#10;14 control_relaunch_tx=1877729.20260831T132330Z.30183&#10;15 pr=https://github.com/example/repo/pull/21&#10;16 pr_head=0123456789abcdef0123456789abcdef01234567&#10;meta shape: control_relaunch_tx= was written BEFORE the pr= identity line&#10;&#10;$ FM_TEST_GH_STATE=MERGED fm-watch.sh&#10;watcher stdout:&#10;check: .../state/demo.check.sh: merged&#10;armed poll retired by the watcher: state/demo.check.sh is gone&#10;(second cycle reached an ordinary custom check with no rejection)</code>

```text

========== setup: hermetic home with a live claude ship task ==========
worktree: ~/.no-mistakes/worktrees/86574f01ec14/01M1BZ4PFVBXMX15CKVNNVM15B
head:     8701c51f529cab3afc85ca4a62cc93a6ed063e31
writer:   bin/fm-spawn.sh matches HEAD (fixed writer)
mode:     accept-expected
--- /tmp/fm-e2e-accept-expected.C3kBbk/case/home/state/demo.meta ---
   1  window=fmses:fm-demo
   2  endpoint_task_id=demo
   3  worktree=/tmp/fm-e2e-accept-expected.C3kBbk/case/wt
   4  project=/tmp/fm-e2e-accept-expected.C3kBbk/case/proj
   5  harness=claude
   6  kind=ship
   7  mode=no-mistakes
   8  yolo=off
   9  tasktmp=/tmp/fm-e2e-accept-expected.C3kBbk/case/tasktmp
  10  model=default
  11  effort=default

========== arm the PR merge poll via the real fm-pr-check.sh (stubbed gh CLI) ==========
$ fm-pr-check.sh demo https://github.com/example/repo/pull/21
armed: state/demo.check.sh
--- /tmp/fm-e2e-accept-expected.C3kBbk/case/home/state/demo.meta ---
   1  window=fmses:fm-demo
   2  endpoint_task_id=demo
   3  worktree=/tmp/fm-e2e-accept-expected.C3kBbk/case/wt
   4  project=/tmp/fm-e2e-accept-expected.C3kBbk/case/proj
   5  harness=claude
   6  kind=ship
   7  mode=no-mistakes
   8  yolo=off
   9  tasktmp=/tmp/fm-e2e-accept-expected.C3kBbk/case/tasktmp
  10  model=default
  11  effort=default
  12  pr=https://github.com/example/repo/pull/21
  13  pr_head=0123456789abcdef0123456789abcdef01234567
poll artifacts: case/home/state/demo.check.sh case/home/state/demo.pr-poll case/home/state/demo.pr-poll-registration 

========== relaunch the task via the real fm-control.sh (the reported live command) ==========
$ fm-control.sh demo relaunch --note "mid-review relaunch"
warning: /tmp/fm-e2e-accept-expected.C3kBbk/case/home/data/demo/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
relaunched demo harness=claude from=claude model=default effort=default backend=tmux endpoint=fmses:fm-demo worktree=/tmp/fm-e2e-accept-expected.C3kBbk/case/wt
relaunch exit status: 0
--- /tmp/fm-e2e-accept-expected.C3kBbk/case/home/state/demo.meta ---
   1  window=fmses:fm-demo
   2  endpoint_task_id=demo
   3  worktree=/tmp/fm-e2e-accept-expected.C3kBbk/case/wt
   4  project=/tmp/fm-e2e-accept-expected.C3kBbk/case/proj
   5  harness=claude
   6  kind=ship
   7  mode=no-mistakes
   8  yolo=off
   9  tasktmp=/tmp/fm-demo
  10  model=default
  11  effort=default
  12  busy_gen=g1788182610.1878202.12982
  13  spawn_gen=s1788182610.1877998.12533
  14  control_relaunch_tx=1877729.20260831T132330Z.30183
  15  pr=https://github.com/example/repo/pull/21
  16  pr_head=0123456789abcdef0123456789abcdef01234567
meta shape: control_relaunch_tx= was written BEFORE the pr= identity line

========== watcher cycle 1 via the real fm-watch.sh (gh reports the PR MERGED) ==========
$ FM_TEST_GH_STATE=MERGED fm-watch.sh
watcher exit status: 0
watcher stdout:
  check: /tmp/fm-e2e-accept-expected.C3kBbk/case/home/state/demo.check.sh: merged

========== watcher cycle 2 via the real fm-watch.sh (ordinary check, no rejection) ==========
$ FM_TEST_GH_STATE=MERGED fm-watch.sh
watcher exit status: 0
watcher stdout:
  check: /tmp/fm-e2e-accept-expected.C3kBbk/case/home/state/z-stop.check.sh: stop-cycle

========== poll state after the watcher cycles ==========
forge calls the poll made (gh.log):
  $ gh pr view https://github.com/example/repo/pull/21 --json headRefOid -q .headRefOid
  $ gh pr view https://github.com/example/repo/pull/21 --json state -q .state
armed poll retired by the watcher: state/demo.check.sh is gone
--- /tmp/fm-e2e-accept-expected.C3kBbk/case/home/state/demo.meta ---
   1  window=fmses:fm-demo
   2  endpoint_task_id=demo
   3  worktree=/tmp/fm-e2e-accept-expected.C3kBbk/case/wt
   4  project=/tmp/fm-e2e-accept-expected.C3kBbk/case/proj
   5  harness=claude
   6  kind=ship
   7  mode=no-mistakes
   8  yolo=off
   9  tasktmp=/tmp/fm-demo
  10  model=default
  11  effort=default
  12  busy_gen=g1788182610.1878202.12982
  13  spawn_gen=s1788182610.1877998.12533
  14  control_relaunch_tx=1877729.20260831T132330Z.30183
  15  pr=https://github.com/example/repo/pull/21
  16  pr_head=0123456789abcdef0123456789abcdef01234567

========== verdict (accept-expected) ==========
RESULT: the armed PR merge poll survived the relaunch, was validated, observed the merge, and retired
```
</details>
<details>
<summary>Evidence: End-to-end evidence harness script driving the real fm-pr-check.sh, fm-control.sh, and fm-watch.sh executables (reuses the suite&#39;s hermetic stubs verbatim)</summary>

Source: [End-to-end evidence harness script driving the real fm-pr-check.sh, fm-control.sh, and fm-watch.sh executables (reuses the suite&#39;s hermetic stubs verbatim)](https://github.com/ardydedase/firstmate/blob/4853a0dc179147939031fa218e052c6bb2175a5e/.no-mistakes/evidence/ardy/firstmate-relaunch-poll-meta-order/e2e-relaunch-poll-demo.sh)

```text
#!/usr/bin/env bash
# End-to-end evidence harness for the relaunch meta-order fix
# (branch ardy/firstmate-relaunch-poll-meta-order).
#
# It reproduces the reported live failure through the real executables only:
#   1. a live claude ship task in a hermetic home (stubbed tmux session
#      provider, real git worktree, real state records),
#   2. the PR merge poll armed by the real bin/fm-pr-check.sh with a stubbed
#      gh CLI that reports the PR head sha and the PR state,
#   3. the task relaunched by the real bin/fm-control.sh <id> relaunch,
#   4. real bin/fm-watch.sh cycles that must validate and run the armed poll.
#
# Usage: e2e-relaunch-poll-demo.sh <worktree-root> <mode>
#   mode: reject-expected - the unfixed writer; the watcher must reject the
#         armed poll with 'check: rejected unauthenticated state checks' every
#         cycle, and the poll never retires.
#   mode: accept-expected - the fixed writer; the watcher must validate the
#         poll, observe the merge, and retire the poll.
#
# Not part of the repository test suite; it lives in the run's evidence
# directory and reuses the suite's hermetic stubs verbatim.
set -u

WORKTREE=${1:?usage: e2e-relaunch-poll-demo.sh <worktree-root> <mode>}
MODE=${2:?usage: e2e-relaunch-poll-demo.sh <worktree-root> <mode>}
case "$MODE" in
  reject-expected|accept-expected) ;;
  *) printf 'error: unknown mode %s\n' "$MODE" >&2; exit 2 ;;
esac

# shellcheck source=/dev/null
. "$WORKTREE/tests/lib.sh"
if [ "$ROOT" != "$WORKTREE" ]; then
  printf 'error: ROOT %s does not match the given worktree %s\n' "$ROOT" "$WORKTREE" >&2
  exit 2
fi

CONTROL="$ROOT/bin/fm-control.sh"
PR_CHECK="$ROOT/bin/fm-pr-check.sh"
WATCH="$ROOT/bin/fm-watch.sh"
REGISTER="$ROOT/bin/fm-check-register.sh"
BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
ID=demo
URL=https://github.com/example/repo/pull/21
HEAD_SHA=0123456789abcdef0123456789abcdef01234567

# The same lifecycle-modelling tmux stub as tests/fm-control-relaunch.test.sh.
make_tmux_stub() {  # <dir>
  local fb="$1/fakebin"
  mkdir -p "$fb"
  cat > "$fb/tmux" <<'SH'
#!/usr/bin/env bash
set -u
D=$FM_FAKE_DIR
case "${1:-}" in
  send-keys)
    shift
    literal=0
    while [ $# -gt 0 ]; do
      case "$1" in
        -t) shift 2 ;;
        -l) literal=1; shift ;;
        *) break ;;
      esac
    done
    payload=${1:-}
    if [ "$literal" = 1 ]; then
      printf '%s\n' "$payload" >> "$D/literal"
      case "$payload" in
        /exit|/quit)
          printf 'zsh' > "$D/command"
          [ -z "${FM_FAKE_EXIT_TRANSPORT_FAIL_AFTER_STOP:-}" ] || exit 1
          ;;
        *'encode launch-brief'*)
          cat "$D/becomes" > "$D/command"
          [ -z "${FM_FAKE_LAUNCH_TRANSPORT_FAIL_AFTER_START:-}" ] || exit 1
          ;;
      esac
    else
      printf '%s\n' "$payload" >> "$D/keys"
    fi
    exit 0 ;;
  display-message)
    for a in "$@"; do
      case "$a" in
        *cursor_y*) printf '1\n'; exit 0 ;;
        *pane_current_command*) cat "$D/command"; printf '\n'; exit 0 ;;
        *pane_current_path*) cat "$D/cwd"; printf '\n'; exit 0 ;;
      esac
    done
    printf 'fakepane\n'; exit 0 ;;
  capture-pane) printf '\xe2\x95\xad\xe2\x94\x80\xe2\x94\x80\xe2\x95\xae\n'; exit 0 ;;
  list-windows) [ -f "$D/windows" ] && cat "$D/windows"; exit 0 ;;
esac
exit 0
SH
  chmod +x "$fb/tmux"
  cat > "$fb/sleep" <<'SH'
#!/usr/bin/env bash
exit 0
SH
  chmod +x "$fb/sleep"
}

# The same forge-CLI stubs as tests/fm-pr-check-security.test.sh: gh answers
# the head sha and the PR state, glab and gh-axi answer their own contracts.
make_forge_stubs() {  # <dir>
  local fb="$1/fakebin"
  cat > "$fb/gh" <<'SH'
#!/usr/bin/env bash
printf '%s\n' "$*" >> "$FM_TEST_GH_LOG"
case " $* " in
  *" headRefOid "*) printf '%s\n' "${FM_TEST_GH_HEAD:-0123456789abcdef0123456789abcdef01234567}" ;;
  *" state "*)
    [ "${FM_TEST_GH_FAIL:-0}" = 0 ] || exit 1
    printf '%s\n' "${FM_TEST_GH_STATE:-OPEN}"
    ;;
esac
exit 0
SH
  cat > "$fb/gh-axi" <<'SH'
#!/usr/bin/env bash
printf '%s\n' "$*" >> "$FM_TEST_GH_AXI_LOG"
case "${1:-} ${2:-}" in
  "pr view")
    [ "$#" -eq 5 ] && [ "${4:-}" = --repo ] || exit 2
    printf 'pull_request:\n  number: %s\n  state: %s\n' "$3" "${FM_TEST_GH_MERGE_STATE:-merged}"
    ;;
esac
exit "${FM_TEST_GH_AXI_RC:-0}"
SH
  cat > "$fb/glab" <<'SH'
#!/usr/bin/env bash
printf '%s\n' "$*" >> "$FM_TEST_GLAB_LOG"
[ "${FM_TEST_GLAB_FAIL:-0}" = 0 ] || exit 1
printf 'title:\tfixture merge request\nstate:\t%s\nauthor:\tsomeone\n' "${FM_TEST_GLAB_STATE:-opened}"
SH
  chmod +x "$fb/gh" "$fb/gh-axi" "$fb/glab"
}

# The same bounded single-cycle watcher driver as tests/fm-pr-check-security.test.sh.
run_watcher_bounded() {
  local home=$1 fakebin=$2 check_interval=${FM_TEST_CHECK_INTERVAL:-0} watch_root=${FM_TEST_WATCH_ROOT:-$ROOT}
  shift 2
  perl -e 'my $pid=fork; die unless defined $pid; if (!$pid) { exec @ARGV } local $SIG{ALRM}=sub { kill "TERM", $pid; waitpid $pid, 0; exit 124 }; alarm 10; waitpid $pid, 0; alarm 0; exit($? >> 8)' \
    env FM_HOME="$home" FM_ROOT_OVERRIDE="$watch_root" FM_CHECK_INTERVAL="$check_interval" FM_CHECK_TIMEOUT=1 \
      FM_POLL=0.02 FM_HEARTBEAT=999999 FM_SIGNAL_GRACE=0 PATH="$fakebin:$BASE_PATH" "$WATCH" "$@"
}

ack_watcher_cycle() {  # <state>
  local state=$1 err sequence generation
  err="$state/.test-wake-drain.err"
  FM_STATE_OVERRIDE="$state" "$ROOT/bin/fm-wake-drain.sh" >/dev/null 2> "$err" || return 1
  sequence=$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through \([0-9][0-9]*\) --recovery-generation [A-Za-z0-9._-][A-Za-z0-9._-]*$/\1/p' "$err")
  generation=$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through [0-9][0-9]* --recovery-generation \([A-Za-z0-9._-][A-Za-z0-9._-]*\)$/\1/p' "$err")
  rm -f "$err"
  [ -n "$sequence" ] && [ -n "$generation" ] || return 1
  FM_STATE_OVERRIDE="$state" "$ROOT/bin/fm-wake-drain.sh" --ack-through "$sequence" \
    --recovery-generation "$generation"
}

banner() { printf '\n========== %s ==========\n' "$1"; }
show_meta() {  # <meta>
  printf -- '--- %s ---\n' "$1"
  awk '{ printf "  %2d  %s\n", NR, $0 }' "$1"
}

TMP_ROOT=$(fm_test_tmproot "fm-e2e-$MODE")
mkdir -p "$TMP_ROOT"
TMP_ROOT=$(cd "$TMP_ROOT" && pwd)
demo_cleanup() {
  rm -rf "$TMP_ROOT" "/tmp/fm-$ID"
  fm_test_cleanup
}
trap demo_cleanup EXIT HUP INT TERM

# ---------------------------------------------------------------- setup ----
banner "setup: hermetic home with a live claude ship task"
printf 'worktree: %s\n' "$WORKTREE"
printf 'head:     %s\n' "$(git -C "$WORKTREE" rev-parse HEAD)"
printf 'writer:   bin/fm-spawn.sh '
if git -C "$WORKTREE" diff --quiet HEAD -- bin/fm-spawn.sh; then
  printf 'matches HEAD (fixed writer)\n'
else
  printf 'differs from HEAD (base writer reverted for this run)\n'
fi
printf 'mode:     %s\n' "$MODE"

dir="$TMP_ROOT/case"
home="$dir/home"
state="$home/state"
mkdir -p "$home/state" "$home/data/$ID" "$dir/fake" "$dir/root/bin"
: > "$dir/fake/literal"
: > "$dir/fake/keys"
printf 'claude' > "$dir/fake/command"
printf 'claude' > "$dir/fake/becomes"
printf '%s\n' "fm-$ID" > "$dir/fake/windows"
make_tmux_stub "$dir"
make_forge_stubs "$dir"
: > "$dir/gh.log"
: > "$dir/gh-axi.log"
: > "$dir/glab.log"
# A no-op guard root for the arming entry point, as in the security suite.
printf '#!/usr/bin/env bash\nexit 0\n' > "$dir/root/bin/fm-guard.sh"
chmod +x "$dir/root/bin/fm-guard.sh"

fm_git_worktree "$dir/proj" "$dir/wt" "task-$ID"
printf '# brief for %s\n\nDo the thing.\n' "$ID" > "$home/data/$ID/brief.md"
{
  echo "window=fmses:fm-$ID"
  echo "endpoint_task_id=$ID"
  echo "worktree=$dir/wt"
  echo "project=$dir/proj"
  echo "harness=claude"
  echo "kind=ship"
  echo "mode=no-mistakes"
  echo "yolo=off"
  echo "tasktmp=$dir/tasktmp"
  echo "model=default"
  echo "effort=default"
} > "$state/$ID.meta"
printf '%s' "$dir/wt" > "$dir/fake/cwd"
show_meta "$state/$ID.meta"

# ----------------------------------------------------------------- arm ----
banner "arm the PR merge poll via the real fm-pr-check.sh (stubbed gh CLI)"
printf '$ fm-pr-check.sh %s %s\n' "$ID" "$URL"
set +e
env PATH="$dir/fakebin:$BASE_PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$dir/root" \
  FM_TEST_GH_LOG="$dir/gh.log" FM_TEST_GH_AXI_LOG="$dir/gh-axi.log" \
  FM_TEST_GLAB_LOG="$dir/glab.log" FM_TEST_GH_STATE=OPEN FM_TEST_GH_HEAD="$HEAD_SHA" \
  "$PR_CHECK" "$ID" "$URL"
arm_rc=$?
set -e
[ "$arm_rc" -eq 0 ] || { printf 'error: arming failed (rc=%s)\n' "$arm_rc" >&2; exit 1; }
show_meta "$state/$ID.meta"
printf 'poll artifacts: '
ls "$state/$ID.check.sh" "$state/$ID.pr-poll" "$state/$ID.pr-poll-registration" \
  | sed "s|^$TMP_ROOT/||" | tr '\n' ' '
printf '\n'

# ------------------------------------------------------------ relaunch ----
banner "relaunch the task via the real fm-control.sh (the reported live command)"
printf '$ fm-control.sh %s relaunch --note "mid-review relaunch"\n' "$ID"
set +e
env PATH="$dir/fakebin:$PATH" FM_HOME="$home" FM_FAKE_DIR="$dir/fake" \
  FM_SPAWN_NO_GUARD=1 GROK_HOME="$dir/grokhome" \
  FM_CONTROL_POLL=0.01 FM_CONTROL_EXIT_WAIT=0.05 FM_CONTROL_LAUNCH_WAIT=0.05 \
  "$CONTROL" "$ID" relaunch --note "mid-review relaunch"
relaunch_rc=$?
set -e
printf 'relaunch exit status: %s\n' "$relaunch_rc"
[ "$relaunch_rc" -eq 0 ] || { printf 'error: relaunch failed\n' >&2; exit 1; }
show_meta "$state/$ID.meta"
if awk '/^pr=/{p=1} p && /^control_relaunch_tx=/{found=1} END {exit !found}' \
     "$state/$ID.meta"; then
  printf 'meta shape: control_relaunch_tx= was written AFTER the pr= identity line\n'
else
  printf 'meta shape: control_relaunch_tx= was written BEFORE the pr= identity line\n'
fi

# ------------------------------------------------------------- watcher ----
banner "watcher cycle 1 via the real fm-watch.sh (gh reports the PR MERGED)"
rm -f "$state/.last-check"
printf '$ FM_TEST_GH_STATE=MERGED fm-watch.sh\n'
set +e
FM_TEST_GH_STATE=MERGED FM_TEST_GH_LOG="$dir/gh.log" FM_TEST_GH_AXI_LOG="$dir/gh-axi.log" \
  FM_TEST_GLAB_LOG="$dir/glab.log" \
  run_watcher_bounded "$home" "$dir/fakebin" > "$dir/watch-1.out" 2> "$dir/watch-1.err"
watch1_rc=$?
set -e
printf 'watcher exit status: %s\n' "$watch1_rc"
printf 'watcher stdout:\n'
sed 's/^/  /' "$dir/watch-1.out"
[ -s "$dir/watch-1.err" ] && { printf 'watcher stderr:\n'; sed 's/^/  /' "$dir/watch-1.err"; }

if [ "$MODE" = reject-expected ]; then
  # The reported symptom: the poll is rejected every cycle.
  ack_watcher_cycle "$state" || { printf 'error: could not ack cycle 1\n' >&2; exit 1; }
  banner "watcher cycle 2 via the real fm-watch.sh (poll rejected every cycle)"
  rm -f "$state/.last-check"
  printf '$ FM_TEST_GH_STATE=MERGED fm-watch.sh\n'
  set +e
  FM_TEST_GH_STATE=MERGED FM_TEST_GH_LOG="$dir/gh.log" FM_TEST_GH_AXI_LOG="$dir/gh-axi.log" \
    FM_TEST_GLAB_LOG="$dir/glab.log" \
    run_watcher_bounded "$home" "$dir/fakebin" > "$dir/watch-2.out" 2> "$dir/watch-2.err"
  watch2_rc=$?
  set -e
  printf 'watcher exit status: %s\n' "$watch2_rc"
  printf 'watcher stdout:\n'
  sed 's/^/  /' "$dir/watch-2.out"
  [ -s "$dir/watch-2.err" ] && { printf 'watcher stderr:\n'; sed 's/^/  /' "$dir/watch-2.err"; }
  ack_watcher_cycle "$state" || { printf 'error: could not ack cycle 2\n' >&2; exit 1; }
else
  # With the fix, the merged poll is validated, observed, and retired, and the
  # next cycle reaches an ordinary custom check with no rejection at all.
  ack_watcher_cycle "$state" || { printf 'error: could not ack cycle 1\n' >&2; exit 1; }
  printf '#!/usr/bin/env bash\nprintf "stop-cycle\\n"\n' > "$state/z-stop.check.sh"
  chmod 0700 "$state/z-stop.check.sh"
  env FM_HOME="$home" "$REGISTER" z-stop >/dev/null
  banner "watcher cycle 2 via the real fm-watch.sh (ordinary check, no rejection)"
  rm -f "$state/.last-check"
  printf '$ FM_TEST_GH_STATE=MERGED fm-watch.sh\n'
  set +e
  FM_TEST_GH_STATE=MERGED FM_TEST_GH_LOG="$dir/gh.log" FM_TEST_GH_AXI_LOG="$dir/gh-axi.log" \
    FM_TEST_GLAB_LOG="$dir/glab.log" \
    run_watcher_bounded "$home" "$dir/fakebin" > "$dir/watch-2.out" 2> "$dir/watch-2.err"
  watch2_rc=$?
  set -e
  printf 'watcher exit status: %s\n' "$watch2_rc"
  printf 'watcher stdout:\n'
  sed 's/^/  /' "$dir/watch-2.out"
  [ -s "$dir/watch-2.err" ] && { printf 'watcher stderr:\n'; sed 's/^/  /' "$dir/watch-2.err"; }
  ack_watcher_cycle "$state" || { printf 'error: could not ack cycle 2\n' >&2; exit 1; }
fi

# -------------------------------------------------------------- evidence ----
banner "poll state after the watcher cycles"
printf 'forge calls the poll made (gh.log):\n'
sed 's/^/  $ gh /' "$dir/gh.log"
if [ -e "$state/$ID.check.sh" ]; then
  printf 'armed poll still present (never retired): %s\n' "$state/$ID.check.sh"
else
  printf 'armed poll retired by the watcher: state/%s.check.sh is gone\n' "$ID"
fi
show_meta "$state/$ID.meta"

# -------------------------------------------------------------- verdict ----
banner "verdict ($MODE)"
rejection='check: rejected unauthenticated state checks'
if [ "$MODE" = reject-expected ]; then
  grep -qF "$rejection" "$dir/watch-1.out" && grep -qF "$rejection" "$dir/watch-2.out" \
    && [ -e "$state/$ID.check.sh" ] \
    && { printf 'RESULT: the armed PR merge poll was rejected every cycle, as the unfixed writer causes\n'; exit 0; }
  printf 'RESULT: UNEXPECTED - the unfixed writer did not reproduce the rejection\n' >&2
  exit 1
fi
grep -qF "$rejection" "$dir/watch-1.out" && { printf 'RESULT: UNEXPECTED - the fixed writer still produced a rejection\n' >&2; exit 1; }
grep -qF "$ID.check.sh: merged" "$dir/watch-1.out" \
  && [ ! -e "$state/$ID.check.sh" ] \
  && { printf 'RESULT: the armed PR merge poll survived the relaunch, was validated, observed the merge, and retired\n'; exit 0; }
printf 'RESULT: UNEXPECTED - the fixed writer did not complete the merged-poll lifecycle\n' >&2
exit 1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8701c51f529cab3afc85ca4a62cc93a6ed063e31","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-captain-hold.sh:816` - The same post-pr= pollution failure mode remains reachable through a sibling writer: fm-captain-hold.sh appends decisions_reviewed= and decision_keys= to state/&lt;origin&gt;.meta, which lands after a terminal pr= identity line and would make fm_pr_metadata_identity_parse reject an armed poll&#39;s record. The user intent explicitly marks fm-captain-hold.sh out of scope under a separate queued task, so this is recorded only to document the verified boundary of this fix, not as a blocker.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/.tmp-driver-relaunch-identity.test.sh (trimmed copy of tests/fm-control-relaunch.test.sh running only test_relaunch_keeps_the_pr_identity_line_terminal and test_trace_enabled_relaunch_keeps_the_pr_identity_line_terminal) - pass with fix, both fail with the reported symptom after 'git checkout 0866a770 -- bin/fm-spawn.sh', pass again after restore`
- `bash tests/.tmp-driver-pr-identity.test.sh (trimmed copy of tests/fm-pr-check-security.test.sh running only test_meta_identity_orders_relaunch_fields_before_pr and test_meta_identity_orders_trace_carrier_before_pr) - pass with fix and unchanged when the writer is reverted, as these pin the parser's ordering contract`
- `./e2e-relaunch-poll-demo.sh <worktree> accept-expected - end-to-end through real bin/fm-pr-check.sh (armed: state/demo.check.sh), real bin/fm-control.sh demo relaunch, and real bin/fm-watch.sh cycles; watcher reported 'check: .../demo.check.sh: merged', retired the poll, and a second cycle reached an ordinary check with no rejection`
- `./e2e-relaunch-poll-demo.sh <worktree> reject-expected - same end-to-end flow with bin/fm-spawn.sh reverted to the base commit; both watcher cycles emitted 'check: rejected unauthenticated state checks: .../demo.check.sh', the poll never consulted the forge and never retired, and the meta showed control_relaunch_tx= after pr_head=`
- `bin/fm-test-run.sh tests/fm-control-relaunch.test.sh - full suite passes (exit=0, 66s)`
- `bin/fm-test-run.sh tests/fm-pr-check-security.test.sh - full suite passes (exit=0, 146s), including the timing-sensitive test_returned_custom_check_descendants_are_drained`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
