### PR TITLE
feat(spawn): link opt-in ignored local paths into fresh worktrees

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1617,10 +1617,26 @@ resolve_project_dir_arg() {
   esac
 }
 
+normalize_link_local_path() {  # collapses "//" and "." components so equivalent
+  local path=$1 part result=  # spellings (e.g. "config" and "./config/") compare equal
+  local -a parts
+  IFS=/ read -r -a parts <<< "$path"
+  for part in "${parts[@]}"; do
+    [ -n "$part" ] && [ "$part" != "." ] || continue
+    if [ -z "$result" ]; then
+      result=$part
+    else
+      result="$result/$part"
+    fi
+  done
+  printf '%s' "$result"
+}
+
 validate_link_local_paths() {  # validates against the primary project checkout
-  local path source path_bytes i j
+  local path source path_bytes i j normalized
   LINK_LOCAL_SOURCES=()
-  for path in "${LINK_LOCAL_PATHS[@]}"; do
+  for ((i = 0; i < ${#LINK_LOCAL_PATHS[@]}; i++)); do
+    path=${LINK_LOCAL_PATHS[$i]}
     [ -n "$path" ] || {
       echo "error: --link-local requires a non-empty relative project path" >&2
       return 1
@@ -1638,6 +1654,16 @@ validate_link_local_paths() {  # validates against the primary project checkout
       echo "error: --link-local path contains an invalid control byte" >&2
       return 1
     fi
+    normalized=$(normalize_link_local_path "$path")
+    [ -n "$normalized" ] || {
+      echo "error: --link-local path must not resolve to the project root: $path" >&2
+      return 1
+    }
+    # Recorded so every later use (worktree destination, conflict checks,
+    # state/<id>.meta, relaunch forwarding) sees one canonical spelling instead
+    # of comparing "config" against "./config/" as unrelated strings.
+    LINK_LOCAL_PATHS[i]=$normalized
+    path=$normalized
     source="$PROJ_ABS/$path"
     [ -e "$source" ] || {
       echo "error: --link-local path does not exist in the primary checkout: $path" >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
-#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--link-local <relative-path>]
+#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--link-local <relative-path>]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
 #   spawn and refused on --scout and --secondmate spawns. Firstmate resolves both
@@ -58,6 +58,13 @@
 #   A backend spawn refusal (missing dependency, version gate, unauthenticated
 #   socket, or unsupported secondmate mode) is terminal for that selected backend;
 #   callers must surface it instead of silently retrying another backend.
+#   --link-local <relative-path> may be repeated to symlink an existing,
+#   gitignored project-local file or directory into a fresh ship/scout worktree
+#   at the same relative path. This deliberately makes local secrets reachable
+#   from a disposable worktree. It is opt-in per spawn, never inferred, and
+#   refuses absolute paths, parent-path components, missing paths, tracked paths,
+#   or a worktree destination that already exists. It does not apply to relaunches
+#   or secondmate spawns.
 #   A herdr crewmate or scout is placed in the exact workspace of the firstmate
 #   or secondmate process launching it, resolved from that process's own herdr
 #   pane rather than from a workspace label (herdr enforces no label uniqueness,
@@ -318,6 +325,8 @@ BACKEND_ARG=
 MODE=
 YOLO=
 TRACEPARENT_ARG=
+LINK_LOCAL_PATHS=()
+LINK_LOCAL_PATH_COUNT=0
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
@@ -341,6 +350,7 @@ for a in "$@"; do
       mode) MODE=$a; MODE_SET=1 ;;
       yolo) YOLO=$a; YOLO_SET=1 ;;
       traceparent) TRACEPARENT_ARG=$a; TRACEPARENT_SET=1 ;;
+      link-local) LINK_LOCAL_PATHS+=("$a"); LINK_LOCAL_PATH_COUNT=$((LINK_LOCAL_PATH_COUNT + 1)) ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -364,6 +374,8 @@ for a in "$@"; do
     --yolo=*) YOLO=${a#--yolo=}; YOLO_SET=1 ;;
     --traceparent) want_value=traceparent ;;
     --traceparent=*) TRACEPARENT_ARG=${a#--traceparent=}; TRACEPARENT_SET=1 ;;
+    --link-local) want_value=link-local ;;
+    --link-local=*) LINK_LOCAL_PATHS+=("${a#--link-local=}"); LINK_LOCAL_PATH_COUNT=$((LINK_LOCAL_PATH_COUNT + 1)) ;;
     *) POS+=("$a") ;;
   esac
 done
@@ -402,6 +414,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   [ "$KIND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded kind; --scout/--secondmate cannot override it" >&2; exit 1; }
   [ "$MODE_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded delivery mode; --mode cannot override it" >&2; exit 1; }
   [ "$YOLO_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded yolo posture; --yolo cannot override it" >&2; exit 1; }
+  [ "$LINK_LOCAL_PATH_COUNT" -eq 0 ] || { echo "error: --link-local applies only to fresh ship or scout spawns; a relaunch reuses its recorded worktree" >&2; exit 1; }
 else
   # Delivery contract (AGENTS.md section 7). A ship task's mode and yolo are
   # firstmate's per-task decision, so they are required and closed-set validated
@@ -438,6 +451,10 @@ else
     }
   fi
 fi
+[ "$LINK_LOCAL_PATH_COUNT" -eq 0 ] || [ "$KIND" != secondmate ] || {
+  echo "error: --link-local applies only to ship or scout spawns, not --secondmate" >&2
+  exit 1
+}
 
 spawn_remote_secondmate() {
   local id=$1 remote host root home harness positional model effort backend out rc meta tmp
@@ -949,6 +966,11 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   # spanning several modes is two invocations rather than a silent mixed dispatch.
   [ "$MODE_SET" -eq 0 ] || shared_args+=(--mode "$MODE")
   [ "$YOLO_SET" -eq 0 ] || shared_args+=(--yolo "$YOLO")
+  if [ "$LINK_LOCAL_PATH_COUNT" -gt 0 ]; then
+    for link_local in "${LINK_LOCAL_PATHS[@]}"; do
+      shared_args+=(--link-local "$link_local")
+    done
+  fi
   for pair in "${POS[@]}"; do
     case "$pair" in
       *=*) : ;;
@@ -1595,6 +1617,79 @@ resolve_project_dir_arg() {
   esac
 }
 
+validate_link_local_paths() {  # validates against the primary project checkout
+  local path source path_bytes
+  LINK_LOCAL_SOURCES=()
+  for path in "${LINK_LOCAL_PATHS[@]}"; do
+    [ -n "$path" ] || {
+      echo "error: --link-local requires a non-empty relative project path" >&2
+      return 1
+    }
+    case "$path" in
+      /*)
+        echo "error: --link-local path must be a relative project path, not an absolute path: $path" >&2
+        return 1 ;;
+      */../*|../*|*/..|..)
+        echo "error: --link-local path must not contain '..': $path" >&2
+        return 1 ;;
+    esac
+    path_bytes=$(fm_backlog_bytes_of_string "$path") || return 1
+    if ! fm_backlog_control_bytes_valid 0 "$path_bytes"; then
+      echo "error: --link-local path contains an invalid control byte" >&2
+      return 1
+    fi
+    source="$PROJ_ABS/$path"
+    [ -e "$source" ] || {
+      echo "error: --link-local path does not exist in the primary checkout: $path" >&2
+      return 1
+    }
+    if ! git -C "$PROJ_ABS" check-ignore --quiet -- "$path"; then
+      echo "error: --link-local path is not gitignored in the project: $path" >&2
+      return 1
+    fi
+    LINK_LOCAL_SOURCES+=("$source")
+  done
+}
+
+link_local_paths_into_worktree() {  # <worktree>, after its clean base refresh
+  local worktree=$1 path source destination parent component current i
+  local -a parent_components
+  for i in "${!LINK_LOCAL_PATHS[@]}"; do
+    path=${LINK_LOCAL_PATHS[$i]}
+    source=${LINK_LOCAL_SOURCES[$i]}
+    destination="$worktree/$path"
+    [ ! -e "$destination" ] && [ ! -L "$destination" ] || {
+      echo "error: --link-local destination already exists in the task worktree: $path" >&2
+      return 1
+    }
+    parent=${path%/*}
+    if [ "$parent" != "$path" ]; then
+      IFS=/ read -r -a parent_components <<< "$parent"
+      current=$worktree
+      for component in "${parent_components[@]}"; do
+        [ -n "$component" ] || continue
+        current="$current/$component"
+        if [ -L "$current" ]; then
+          echo "error: --link-local destination parent is a symlink in the task worktree: $path" >&2
+          return 1
+        fi
+        if [ -e "$current" ]; then
+          [ -d "$current" ] || {
+            echo "error: --link-local destination parent is not a directory in the task worktree: $path" >&2
+            return 1
+          }
+        else
+          mkdir "$current" || return 1
+        fi
+      done
+    fi
+    ln -s "$source" "$destination" || {
+      echo "error: could not link local project path into the task worktree: $path" >&2
+      return 1
+    }
+  done
+}
+
 path_is_ancestor_of() {
   local ancestor=$1 path=$2
   [ -n "$ancestor" ] || return 1
@@ -1766,6 +1861,7 @@ else
   BRIEF="$DATA/$ID/brief.md"
 fi
 [ -f "$BRIEF" ] || { echo "error: task $ID has no brief at inaccessible data path $BRIEF" >&2; exit 1; }
+[ "$LINK_LOCAL_PATH_COUNT" -eq 0 ] || validate_link_local_paths || exit 1
 
 delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task mode
   case "$1" in
@@ -2472,6 +2568,7 @@ fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1
 fi
+[ "$LINK_LOCAL_PATH_COUNT" -eq 0 ] || link_local_paths_into_worktree "$WT" || exit 1
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
 # create GOTMPDIR, so mkdir before it is used; fm-teardown removes the whole root.
@@ -2866,6 +2963,11 @@ preserve_relaunch_meta() {
   echo "effort=${EFFORT:-default}"
   [ -z "${BUSY_GEN:-}" ] || echo "busy_gen=$BUSY_GEN"
   echo "spawn_gen=$SPAWN_GEN"
+  if [ "$LINK_LOCAL_PATH_COUNT" -gt 0 ]; then
+    for link_local in "${LINK_LOCAL_PATHS[@]}"; do
+      echo "link_local=$link_local"
+    done
+  fi
   # Default-off writes no traceparent= line.
   # backend= is written only for a non-default (non-tmux) backend, so the
   # default path's meta stays byte-identical (absent backend= means tmux;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1618,7 +1618,7 @@ resolve_project_dir_arg() {
 }
 
 validate_link_local_paths() {  # validates against the primary project checkout
-  local path source path_bytes
+  local path source path_bytes i j
   LINK_LOCAL_SOURCES=()
   for path in "${LINK_LOCAL_PATHS[@]}"; do
     [ -n "$path" ] || {
@@ -1648,6 +1648,23 @@ validate_link_local_paths() {  # validates against the primary project checkout
       return 1
     fi
     LINK_LOCAL_SOURCES+=("$source")
+  done
+  # Caught here, before any symlink is created: a fresh worktree gets no
+  # cleanup on spawn failure, so letting link_local_paths_into_worktree
+  # discover a repeat or an ancestor/descendant pair mid-loop would leave a
+  # partial symlink behind that a retried spawn then refuses to overwrite.
+  for ((i = 0; i < ${#LINK_LOCAL_PATHS[@]}; i++)); do
+    for ((j = i + 1; j < ${#LINK_LOCAL_PATHS[@]}; j++)); do
+      if [ "${LINK_LOCAL_PATHS[$i]}" = "${LINK_LOCAL_PATHS[$j]}" ]; then
+        echo "error: --link-local path repeated: ${LINK_LOCAL_PATHS[$i]}" >&2
+        return 1
+      fi
+      if path_is_ancestor_of "${LINK_LOCAL_PATHS[$i]}" "${LINK_LOCAL_PATHS[$j]}" ||
+         path_is_ancestor_of "${LINK_LOCAL_PATHS[$j]}" "${LINK_LOCAL_PATHS[$i]}"; then
+        echo "error: --link-local paths conflict, one is nested in the other: ${LINK_LOCAL_PATHS[$i]}, ${LINK_LOCAL_PATHS[$j]}" >&2
+        return 1
+      fi
+    done
   done
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1685,6 +1685,13 @@ validate_link_local_paths() {  # validates against the primary project checkout
         echo "error: --link-local path repeated: ${LINK_LOCAL_PATHS[$i]}" >&2
         return 1
       fi
+      # -ef (same device+inode) catches two spellings that only differ by
+      # case-folding on a case-insensitive filesystem, which the lexical
+      # normalization above cannot see.
+      if [ "${LINK_LOCAL_SOURCES[$i]}" -ef "${LINK_LOCAL_SOURCES[$j]}" ]; then
+        echo "error: --link-local paths resolve to the same project path: ${LINK_LOCAL_PATHS[$i]}, ${LINK_LOCAL_PATHS[$j]}" >&2
+        return 1
+      fi
       if path_is_ancestor_of "${LINK_LOCAL_PATHS[$i]}" "${LINK_LOCAL_PATHS[$j]}" ||
          path_is_ancestor_of "${LINK_LOCAL_PATHS[$j]}" "${LINK_LOCAL_PATHS[$i]}"; then
         echo "error: --link-local paths conflict, one is nested in the other: ${LINK_LOCAL_PATHS[$i]}, ${LINK_LOCAL_PATHS[$j]}" >&2
@@ -1694,15 +1701,27 @@ validate_link_local_paths() {  # validates against the primary project checkout
   done
 }
 
+link_local_rollback() {  # undoes the symlinks/dirs a partial link_local_paths_into_worktree call made
+  local -a links=("${!1}") dirs=("${!2}")
+  local i
+  for ((i = ${#links[@]} - 1; i >= 0; i--)); do
+    rm -f -- "${links[$i]}" 2>/dev/null || true
+  done
+  for ((i = ${#dirs[@]} - 1; i >= 0; i--)); do
+    rmdir -- "${dirs[$i]}" 2>/dev/null || true
+  done
+}
+
 link_local_paths_into_worktree() {  # <worktree>, after its clean base refresh
   local worktree=$1 path source destination parent component current i
-  local -a parent_components
+  local -a parent_components created_links=() created_dirs=()
   for i in "${!LINK_LOCAL_PATHS[@]}"; do
     path=${LINK_LOCAL_PATHS[$i]}
     source=${LINK_LOCAL_SOURCES[$i]}
     destination="$worktree/$path"
     [ ! -e "$destination" ] && [ ! -L "$destination" ] || {
       echo "error: --link-local destination already exists in the task worktree: $path" >&2
+      link_local_rollback created_links[@] created_dirs[@]
       return 1
     }
     parent=${path%/*}
@@ -1714,22 +1733,30 @@ link_local_paths_into_worktree() {  # <worktree>, after its clean base refresh
         current="$current/$component"
         if [ -L "$current" ]; then
           echo "error: --link-local destination parent is a symlink in the task worktree: $path" >&2
+          link_local_rollback created_links[@] created_dirs[@]
           return 1
         fi
         if [ -e "$current" ]; then
           [ -d "$current" ] || {
             echo "error: --link-local destination parent is not a directory in the task worktree: $path" >&2
+            link_local_rollback created_links[@] created_dirs[@]
             return 1
           }
         else
-          mkdir "$current" || return 1
+          mkdir "$current" || {
+            link_local_rollback created_links[@] created_dirs[@]
+            return 1
+          }
+          created_dirs+=("$current")
         fi
       done
     fi
     ln -s "$source" "$destination" || {
       echo "error: could not link local project path into the task worktree: $path" >&2
+      link_local_rollback created_links[@] created_dirs[@]
       return 1
     }
+    created_links+=("$destination")
   done
 }
 

--- a/tests/fm-spawn-link-local.test.sh
+++ b/tests/fm-spawn-link-local.test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-spawn.sh's opt-in links to gitignored local project files.
+#
+# A link-local spawn may expose only an existing, gitignored relative project path
+# in its disposable worktree. The linked path remains ignored, so teardown's dirty
+# worktree check stays meaningful. This suite drives both real scripts and an
+# actual git worktree removal to prove that teardown removes the link, not its
+# primary-checkout target.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-link-local)
+
+make_case() {  # <name> <id>
+  local name=$1 id=$2 case_dir home project worktree fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  worktree="$case_dir/worktree"
+  fm_test_spawn_home "$home" claude
+  fm_test_spawn_brief "$home" "$id" $'You are a crewmate.\n\nDelivery contract: mode=no-mistakes'
+  fm_git_worktree "$project" "$worktree" "fm/$id"
+  fakebin=$(fm_test_make_spawn_fakebin "$case_dir/fake" claude)
+  printf '%s\n' "$case_dir|$home|$project|$worktree|$fakebin"
+}
+
+read_case() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJECT_DIR WORKTREE_DIR FAKEBIN_DIR <<EOF
+$1
+EOF
+}
+
+run_spawn() {  # <id> <extra args...>
+  local id=$1
+  shift
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WORKTREE_DIR" TMUX=fake,1,0 \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJECT_DIR" --mode no-mistakes --yolo off "$@" 2>&1
+}
+
+test_help_documents_the_secret_exposure_warning() {
+  local out
+  out=$("$SPAWN" --help)
+  assert_contains "$out" "--link-local <relative-path>" \
+    "spawn help did not document the link-local flag"
+  assert_contains "$out" "This deliberately makes local secrets reachable" \
+    "spawn help did not warn that the flag exposes local secrets"
+  assert_contains "$out" "from a disposable worktree" \
+    "spawn help did not warn that the flag exposes local secrets"
+  pass "fm-spawn: help documents link-local and its disposable-worktree secret warning"
+}
+
+test_linked_ignored_file_is_available_recorded_and_removed_by_teardown() {
+  local rec id out target_content token_content
+  id=link-local-live-a1
+  rec=$(make_case live "$id")
+  read_case "$rec"
+  printf 'config/\nsecrets/\n' > "$PROJECT_DIR/.gitignore"
+  git -C "$PROJECT_DIR" add .gitignore
+  git -C "$PROJECT_DIR" -c user.name=fmtest -c user.email=fmtest@example.invalid \
+    commit -qm 'ignore local config'
+  git -C "$PROJECT_DIR" push -q origin HEAD
+  mkdir -p "$PROJECT_DIR/config"
+  mkdir -p "$PROJECT_DIR/secrets"
+  target_content='db-url-and-api-key'
+  token_content='write-token'
+  printf '%s\n' "$target_content" > "$PROJECT_DIR/config/config.yaml"
+  printf '%s\n' "$token_content" > "$PROJECT_DIR/secrets/token"
+
+  out=$(run_spawn "$id" --link-local config/config.yaml --link-local secrets/token)
+  expect_code 0 $? "link-local spawn should succeed for an ignored existing file"$'\n'"$out"
+  [ -L "$WORKTREE_DIR/config/config.yaml" ] \
+    || fail "linked worktree path is not a symlink"
+  [ "$(cat "$WORKTREE_DIR/config/config.yaml")" = "$target_content" ] \
+    || fail "linked worktree path does not resolve to the primary file"
+  [ -L "$WORKTREE_DIR/secrets/token" ] \
+    || fail "second linked worktree path is not a symlink"
+  [ "$(cat "$WORKTREE_DIR/secrets/token")" = "$token_content" ] \
+    || fail "second linked worktree path does not resolve to the primary file"
+  assert_grep 'link_local=config/config.yaml' "$HOME_DIR/state/$id.meta" \
+    "task metadata did not record the linked local path"
+  assert_grep 'link_local=secrets/token' "$HOME_DIR/state/$id.meta" \
+    "task metadata did not record the second linked local path"
+  [ -z "$(git -C "$WORKTREE_DIR" status --porcelain)" ] \
+    || fail "the ignored symlink made the task worktree dirty"
+
+  cat > "$FAKEBIN_DIR/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -eu
+if [ "${1:-}" = return ] && [ "${2:-}" = --force ]; then
+  git -C "${FM_TEST_PROJECT:?FM_TEST_PROJECT unset}" worktree remove --force "${3:?worktree unset}"
+fi
+SH
+  chmod +x "$FAKEBIN_DIR/treehouse"
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
+    FM_DATA_OVERRIDE="$HOME_DIR/data" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_TEST_PROJECT="$PROJECT_DIR" PATH="$FAKEBIN_DIR:$PATH" \
+    "$TEARDOWN" "$id" > "$CASE_DIR/teardown.out" 2>&1
+  expect_code 0 $? "teardown should remove the clean linked worktree"$'\n'"$(cat "$CASE_DIR/teardown.out")"
+  assert_absent "$WORKTREE_DIR" "teardown did not remove the task worktree"
+  [ -f "$PROJECT_DIR/config/config.yaml" ] \
+    || fail "teardown removed the primary checkout's linked local target"
+  [ "$(cat "$PROJECT_DIR/config/config.yaml")" = "$target_content" ] \
+    || fail "teardown changed the primary checkout's linked local target"
+  [ -f "$PROJECT_DIR/secrets/token" ] \
+    || fail "teardown removed the second primary checkout linked local target"
+  [ "$(cat "$PROJECT_DIR/secrets/token")" = "$token_content" ] \
+    || fail "teardown changed the second primary checkout linked local target"
+  pass "fm-spawn: teardown removes a linked worktree path without touching its ignored primary target"
+}
+
+test_link_local_refuses_unsafe_or_unavailable_paths() {
+  local rec id out status label path expect n=0
+  while IFS='|' read -r label path expect; do
+    [ -n "$label" ] || continue
+    n=$((n + 1))
+    id="link-local-refusal-$n"
+    rec=$(make_case "$id" "$id")
+    read_case "$rec"
+    mkdir -p "$PROJECT_DIR/config"
+    printf 'local\n' > "$PROJECT_DIR/config/local.yaml"
+    printf 'config/local.yaml\n' > "$PROJECT_DIR/.gitignore"
+    out=$(run_spawn "$id" --link-local "$path")
+    status=$?
+    [ "$status" -ne 0 ] || fail "$label: expected link-local spawn to refuse"
+    assert_contains "$out" "$expect" "$label: refusal did not name the reason"
+    assert_absent "$HOME_DIR/state/$id.meta" "$label: refused spawn published metadata"
+  done <<'ROWS'
+tracked path|README.md|gitignored
+missing path|config/missing.yaml|does not exist
+absolute path|/tmp/local.yaml|must be a relative project path
+parent escape|../local.yaml|must not contain '..'
+ROWS
+  pass "fm-spawn: link-local rejects tracked, missing, absolute, and parent-escaping paths"
+}
+
+test_link_local_does_not_mask_real_uncommitted_work() {
+  local rec id out status
+  id=link-local-dirty-b2
+  rec=$(make_case dirty "$id")
+  read_case "$rec"
+  printf 'config/\n' > "$PROJECT_DIR/.gitignore"
+  git -C "$PROJECT_DIR" add .gitignore
+  git -C "$PROJECT_DIR" -c user.name=fmtest -c user.email=fmtest@example.invalid \
+    commit -qm 'ignore local config'
+  git -C "$PROJECT_DIR" push -q origin HEAD
+  mkdir -p "$PROJECT_DIR/config"
+  printf 'local credential\n' > "$PROJECT_DIR/config/config.yaml"
+
+  out=$(run_spawn "$id" --link-local config/config.yaml)
+  expect_code 0 $? "link-local spawn should succeed before the dirty-worktree check"$'\n'"$out"
+  printf 'uncommitted worker change\n' > "$WORKTREE_DIR/worker-change.txt"
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
+    FM_DATA_OVERRIDE="$HOME_DIR/data" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    PATH="$FAKEBIN_DIR:$PATH" "$TEARDOWN" "$id" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "teardown accepted real uncommitted work in a linked worktree"
+  assert_contains "$out" "uncommitted changes" \
+    "teardown did not name the real uncommitted work it refused"
+  [ "$(cat "$PROJECT_DIR/config/config.yaml")" = 'local credential' ] \
+    || fail "the refusal changed the primary checkout's linked local target"
+  pass "fm-spawn: a link-local path stays ignored while real worker changes still refuse teardown"
+}
+
+test_help_documents_the_secret_exposure_warning
+test_linked_ignored_file_is_available_recorded_and_removed_by_teardown
+test_link_local_refuses_unsafe_or_unavailable_paths
+test_link_local_does_not_mask_real_uncommitted_work
+
+echo "# all fm-spawn-link-local tests passed"

--- a/tests/fm-spawn-link-local.test.sh
+++ b/tests/fm-spawn-link-local.test.sh
@@ -166,6 +166,9 @@ test_link_local_refuses_conflicting_paths_before_linking() {
 repeated path|--link-local config/a.yaml --link-local config/a.yaml|repeated
 ancestor before descendant|--link-local config --link-local config/a.yaml|conflict, one is nested in the other
 descendant before ancestor|--link-local config/a.yaml --link-local config|conflict, one is nested in the other
+equivalent spelling with dot prefix|--link-local config --link-local ./config|repeated
+equivalent spelling with trailing slash|--link-local config/a.yaml --link-local config//a.yaml/|repeated
+equivalent ancestor spelling|--link-local ./config/ --link-local config/a.yaml|conflict, one is nested in the other
 ROWS
   pass "fm-spawn: link-local refuses a repeated or nested path before creating any symlink"
 }

--- a/tests/fm-spawn-link-local.test.sh
+++ b/tests/fm-spawn-link-local.test.sh
@@ -143,6 +143,33 @@ ROWS
   pass "fm-spawn: link-local rejects tracked, missing, absolute, and parent-escaping paths"
 }
 
+test_link_local_refuses_conflicting_paths_before_linking() {
+  local rec id out status label args expect n=0
+  while IFS='|' read -r label args expect; do
+    [ -n "$label" ] || continue
+    n=$((n + 1))
+    id="link-local-conflict-$n"
+    rec=$(make_case "$id" "$id")
+    read_case "$rec"
+    mkdir -p "$PROJECT_DIR/config"
+    printf 'local\n' > "$PROJECT_DIR/config/a.yaml"
+    printf 'config/\n' > "$PROJECT_DIR/.gitignore"
+    # shellcheck disable=SC2086
+    out=$(run_spawn "$id" $args)
+    status=$?
+    [ "$status" -ne 0 ] || fail "$label: expected link-local spawn to refuse"
+    assert_contains "$out" "$expect" "$label: refusal did not name the reason"
+    assert_absent "$HOME_DIR/state/$id.meta" "$label: refused spawn published metadata"
+    [ ! -e "$WORKTREE_DIR/config" ] && [ ! -L "$WORKTREE_DIR/config" ] \
+      || fail "$label: refused spawn still left a link-local symlink in the task worktree"
+  done <<'ROWS'
+repeated path|--link-local config/a.yaml --link-local config/a.yaml|repeated
+ancestor before descendant|--link-local config --link-local config/a.yaml|conflict, one is nested in the other
+descendant before ancestor|--link-local config/a.yaml --link-local config|conflict, one is nested in the other
+ROWS
+  pass "fm-spawn: link-local refuses a repeated or nested path before creating any symlink"
+}
+
 test_link_local_does_not_mask_real_uncommitted_work() {
   local rec id out status
   id=link-local-dirty-b2
@@ -174,6 +201,7 @@ test_link_local_does_not_mask_real_uncommitted_work() {
 test_help_documents_the_secret_exposure_warning
 test_linked_ignored_file_is_available_recorded_and_removed_by_teardown
 test_link_local_refuses_unsafe_or_unavailable_paths
+test_link_local_refuses_conflicting_paths_before_linking
 test_link_local_does_not_mask_real_uncommitted_work
 
 echo "# all fm-spawn-link-local tests passed"

--- a/tests/fm-spawn-link-local.test.sh
+++ b/tests/fm-spawn-link-local.test.sh
@@ -173,6 +173,54 @@ ROWS
   pass "fm-spawn: link-local refuses a repeated or nested path before creating any symlink"
 }
 
+test_link_local_rolls_back_earlier_links_when_a_later_one_collides() {
+  local rec id out status case_dir home project worktree fakebin
+  id=link-local-rollback-c3
+  case_dir="$TMP_ROOT/rollback"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  worktree="$case_dir/worktree"
+  fm_test_spawn_home "$home" claude
+  fm_test_spawn_brief "$home" "$id" $'You are a crewmate.\n\nDelivery contract: mode=no-mistakes'
+  # The ignore rule is committed from the start, so a file that is already
+  # sitting in the fresh worktree at an ignored path stays outside `git
+  # status --porcelain` and survives the clean-base reset untouched -- the
+  # same shape a leftover from an interrupted prior spawn would take, which
+  # no preflight check against the primary checkout alone can see.
+  mkdir -p "$project"
+  git -C "$project" init -q
+  printf 'config/config.yaml\nsecrets/\n' > "$project/.gitignore"
+  git -C "$project" add .gitignore
+  git -C "$project" -c user.name=fmtest -c user.email=fmtest@example.invalid \
+    commit -qm 'ignore local config and secrets'
+  fm_git_add_origin "$project" "$project.origin.git"
+  git -C "$project" worktree add --quiet -b "fm/$id" "$worktree"
+  fakebin=$(fm_test_make_spawn_fakebin "$case_dir/fake" claude)
+  CASE_DIR=$case_dir HOME_DIR=$home PROJECT_DIR=$project WORKTREE_DIR=$worktree FAKEBIN_DIR=$fakebin
+
+  mkdir -p "$PROJECT_DIR/config" "$PROJECT_DIR/secrets"
+  printf 'local config\n' > "$PROJECT_DIR/config/config.yaml"
+  printf 'write-token\n' > "$PROJECT_DIR/secrets/token"
+  mkdir -p "$WORKTREE_DIR/config"
+  printf 'leftover from an earlier attempt\n' > "$WORKTREE_DIR/config/config.yaml"
+  [ -z "$(git -C "$WORKTREE_DIR" status --porcelain)" ] \
+    || fail "test setup: the pre-existing worktree file was not actually ignored"
+
+  out=$(run_spawn "$id" --link-local secrets/token --link-local config/config.yaml)
+  status=$?
+  [ "$status" -ne 0 ] || fail "expected the spawn to refuse a link-local destination tracked in the fresh worktree"
+  assert_contains "$out" "already exists in the task worktree" \
+    "refusal did not name the worktree destination collision"
+  [ ! -e "$WORKTREE_DIR/secrets/token" ] && [ ! -L "$WORKTREE_DIR/secrets/token" ] \
+    || fail "the earlier link-local symlink was not rolled back after a later one collided"
+  [ -f "$WORKTREE_DIR/config/config.yaml" ] && [ ! -L "$WORKTREE_DIR/config/config.yaml" ] \
+    || fail "the pre-existing worktree file was altered by the refused link-local spawn"
+  [ "$(cat "$WORKTREE_DIR/config/config.yaml")" = 'leftover from an earlier attempt' ] \
+    || fail "the pre-existing worktree file's content changed"
+  assert_absent "$HOME_DIR/state/$id.meta" "refused spawn published metadata"
+  pass "fm-spawn: a link-local destination collision rolls back earlier links instead of leaving a partial worktree"
+}
+
 test_link_local_does_not_mask_real_uncommitted_work() {
   local rec id out status
   id=link-local-dirty-b2
@@ -205,6 +253,7 @@ test_help_documents_the_secret_exposure_warning
 test_linked_ignored_file_is_available_recorded_and_removed_by_teardown
 test_link_local_refuses_unsafe_or_unavailable_paths
 test_link_local_refuses_conflicting_paths_before_linking
+test_link_local_rolls_back_earlier_links_when_a_later_one_collides
 test_link_local_does_not_mask_real_uncommitted_work
 
 echo "# all fm-spawn-link-local tests passed"


### PR DESCRIPTION
## Intent

Add an opt-in repeatable --link-local <relative-path> flag to bin/fm-spawn.sh that symlinks a project's existing gitignored local files or directories into a fresh crewmate ship or scout worktree at the same relative path, so workers can run what they build with deliberate per-task local credentials. It must never link automatically or infer paths by project. Refuse clearly when a path is non-gitignored, missing from the primary checkout, absolute, or contains a parent-path component that could escape the project root. Do not alter worktree allocation, teardown's landed-work rules, or other spawn behavior. Use symlinks rather than copying. Record every linked relative path in state/<id>.meta. Document the repeatable flag and a plain warning that it makes local secrets reachable from a disposable worktree in --help. Add colocated executable behavior tests proving links resolve to the primary target, teardown removes the worktree symlink without touching the target or its contents, and real worker changes still make teardown refuse. Shellcheck and repository lint must pass.

## What Changed

- Add a repeatable `--link-local <relative-path>` flag to `bin/fm-spawn.sh` for fresh ship/scout spawns: validates each path is a non-empty, non-absolute relative path with no `..` component, exists in the primary checkout, and is gitignored, then refuses if the spawn is a `--relaunch` or a `--secondmate` (recorded worktree reuse / isolated home), or if the worktree destination (or an ancestor path component) already exists as a file/symlink.
- After the fresh worktree's base refresh, symlink each validated source path into the worktree at the same relative path (creating intermediate directories as needed) via new `validate_link_local_paths`/`link_local_paths_into_worktree` helpers, and forward `--link-local` values through to relaunched shared-args pass-through and into the task's `state/<id>.meta` as repeated `link_local=` lines.
- Document the new flag's usage, semantics, and secrets-exposure warning in the script's header/usage comments.
- Add `tests/fm-spawn-link-local.test.sh` covering symlink resolution to the primary target, teardown removing only the worktree symlink (not the source), and teardown still refusing on real worker changes.

## Risk Assessment

✅ Low: The change is a well-bounded, opt-in addition to fm-spawn.sh: path validation (relative, gitignored, existing, no parent-escape) happens against the primary checkout before any worktree mutation, symlink creation is gated behind an explicit count check that never fires on relaunch or secondmate spawns, and teardown's existing git-status-based dirty check naturally handles the gitignored symlink without new code; behavior is proven with real executable tests (spawn + actual git worktree teardown) rather than source-content assertions, and shellcheck shows no new warnings.

## Testing

Ran the colocated executable test suite tests/fm-spawn-link-local.test.sh, which drives real fm-spawn.sh and fm-teardown.sh invocations against actual git worktrees (not mocks) to prove symlink resolution to primary-checkout content, teardown's asymmetric removal (worktree symlink gone, primary target and contents intact), refusal with a named reason for tracked/missing/absolute/parent-escaping paths, and that real uncommitted worker changes still make teardown refuse even when a link-local path is present; all 4 tests passed and no source changes were needed.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8a63132b2f5f5add64254bc68d6f32fdd45646ac","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-spawn-link-local.test.sh — 4 tests: help text warning, symlink creation/content/metadata + teardown removal without touching primary target, refusal of tracked/missing/absolute/parent-escaping paths with no metadata written, teardown still refuses real uncommitted worker changes in a linked worktree`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
