### PR TITLE
fix(bin): withhold project memory-layout authority from ship briefs by default

### DIFF
--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -180,7 +180,8 @@ Approved project-level destinations are not produced by stow: they ship normally
   Because this destination is local and untracked, it is also the JIT home for private conditional knowledge that no committed surface may hold.
 - An already-existing user-owned local on-demand note with an established trigger, after confirming it is untracked, private, and able to hold the quoted entry.
   The pass may add the entry to that existing owner but never creates a new note, skill, or trigger for this purpose.
-- A project's existing committed `AGENTS.md`, for project-intrinsic knowledge useful to nearly every session of that project, through a normal crewmate ship task using `bin/fm-ensure-agents-md.sh` and the project's registered delivery mode.
+- A project's existing committed `AGENTS.md`, for project-intrinsic knowledge useful to nearly every session of that project, through a normal crewmate ship task on the project's registered delivery mode.
+  The ship brief carries the memory-layout reconciliation step only when firstmate owns that repo's agent-memory convention, so route the knowledge into the memory file the project already keeps.
 - A project-level skill in the project's own repository, for situation-conditional knowledge within one project, through the same ship-task path.
 
 Forbidden destinations: any firstmate-repo-tracked skill per the hard rule; firstmate's own `AGENTS.md`, which is always-loaded for every fleet session; `docs/` alone, which is never agent-loaded on demand, though a skill body may point into docs for depth; and any committed surface for private content.
@@ -221,7 +222,7 @@ A local skill exists only in this home, so offloading an entry out of `data/capt
    - In a primary home, curate shared captain preferences only under the existing primary-authoritative shared-preference contract.
      In a secondmate home, route a newly discovered shared preference to the main firstmate through marked status or a document pointer instead of editing the inherited file.
    - Project-intrinsic knowledge never goes directly into a project's `AGENTS.md`.
-     Route it through a normal ship task so a crewmate records it with `bin/fm-ensure-agents-md.sh` and the project's delivery path.
+     Route it through a normal ship task so a crewmate records it through the project's delivery path, into the memory file that project already keeps.
    - Knowledge general to every Firstmate user belongs in this repo's shared tracked material through the normal branch, no-mistakes, PR, and captain-merge path.
    - For task-scoped notes, inspect the item with `tasks-axi show <id> --full`, classify the change as new, duplicate, superseding, or obsolete, then use a considered replacement body through `tasks-axi update <id> --body-file <path>`.
      Use `--archive-body` when recoverability matters.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,8 @@ Route durable knowledge to its most specific owner:
 - Knowledge general to every firstmate user belongs in this repo's shared tracked surface.
 
 Firstmate never writes a project's `AGENTS.md` directly.
-A crewmate creates or updates it lazily through the project's selected delivery path, using `bin/fm-ensure-agents-md.sh` and preferring pointers to authoritative sources over copied detail.
+A crewmate creates or updates it lazily through the project's selected delivery path, preferring pointers to authoritative sources over copied detail.
+Reconciling a project's memory-file layout with `bin/fm-ensure-agents-md.sh` is separate authority that ship briefs withhold by default: scaffold with `--ensure-agents-md` only for a repo whose agent-memory convention firstmate owns, never to restructure a `CLAUDE.md` another team maintains.
 Keep fleet delivery posture and captain-private strategy out of project memory.
 When the captain invokes `/stow`, load the `stow` skill for its memory curation, knowledge routing, and persistence of the open work records this session is holding; it files and corrects only the open work that session is holding, and never reconciles the backlog against repository or PR reality.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,7 @@ Route durable knowledge to its most specific owner:
 - Knowledge general to every firstmate user belongs in this repo's shared tracked surface.
 
 Firstmate never writes a project's `AGENTS.md` directly.
-A crewmate creates or updates it lazily through the project's selected delivery path, preferring pointers to authoritative sources over copied detail.
+A crewmate records durable knowledge lazily through the project's selected delivery path, into the memory file that project already keeps and preserving that file's existing name and structure, preferring pointers to authoritative sources over copied detail.
 Reconciling a project's memory-file layout with `bin/fm-ensure-agents-md.sh` is separate authority that ship briefs withhold by default: scaffold with `--ensure-agents-md` only for a repo whose agent-memory convention firstmate owns, never to restructure a `CLAUDE.md` another team maintains.
 Keep fleet delivery posture and captain-private strategy out of project memory.
 When the captain invokes `/stow`, load the `stow` skill for its memory curation, knowledge routing, and persistence of the open work records this session is holding; it files and corrects only the open work that session is holding, and never reconciles the backlog against repository or PR reality.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -61,6 +61,10 @@
 # running fm-ensure-agents-md.sh and forbids creating, renaming, converting, or
 # replacing AGENTS.md and CLAUDE.md, and directs durable knowledge into the
 # memory file the project already has, as it already is.
+# When that project keeps no memory file at all, the default section routes the
+# knowledge to firstmate as a single note: line on the task's status file; the
+# ship scaffold's status protocol permits that one line for that one purpose,
+# adding no state and relaxing nothing else about status appends.
 # --ensure-agents-md opts a ship brief back into the reconciling form: it runs
 # fm-ensure-agents-md.sh and adds that script's self-governance section when a
 # touched project AGENTS.md lacks it. Pass it only for a repo whose agent-memory

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -441,7 +441,7 @@ Do NOT run `fm-ensure-agents-md.sh` here, and do NOT create, rename, convert, re
 An existing `CLAUDE.md` stays exactly the file it is. It belongs to this project's own maintainers, and turning it into an `@AGENTS.md` pointer is a change they never asked for.
 If this task produced durable project-intrinsic knowledge and the project already keeps a memory file, add the knowledge as ordinary content to that existing file, preserving its name, structure, and conventions.
 Record only knowledge useful to almost every future session, and prefer a pointer to the authoritative file, command, or doc over copying the detail.
-If the project keeps no memory file, do not create one: report the knowledge to firstmate instead.
+If the project keeps no memory file, do not create one: append a single `note:` line carrying that knowledge to the status file rule 4 names, so it reaches firstmate instead.
 If firstmate does own this repo's memory-file convention, the brief must be regenerated with `--ensure-agents-md`; do not add that step to this brief by hand.
 EOF
 fi
@@ -475,6 +475,9 @@ $RULE1
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
    needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
    firstmate reads your pane for that.
+   A single \`note:\` line is permitted for exactly one purpose - carrying durable project
+   knowledge to firstmate when the Project memory section sends you here because the project
+   keeps no memory file - and it authorises no other use of \`note:\`.
    A mid-task \`working:\` line (including setup complete) is nonterminal: do not end the
    turn after it; continue the same stage until a defined \`done:\` gate under Definition of done.
    Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,7 +6,7 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab] [--ensure-agents-md]
 #        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
@@ -52,11 +52,24 @@
 # Every scaffold also carries the steering-inbox receive-and-ack section:
 # process state/<id>.inbox/*.msg in order and acknowledge each by moving it to
 # handled/ (record, doorbell, and ladder owned by bin/fm-task-inbox-lib.sh).
-# Ship tasks include a project-memory section so durable project-intrinsic
-# learnings can be committed to AGENTS.md through the project's delivery path;
-# it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
-# over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
-# self-governance section when a touched project AGENTS.md lacks it.
+# Ship tasks include a project-memory section carrying the AGENTS.md authoring
+# bar: widely useful knowledge only, pointers over copied detail.
+# Reconciling a project's memory-FILE LAYOUT is a separate authority and is off
+# by default, because a repo firstmate does not own may keep a CLAUDE.md its own
+# maintainers wrote, and converting it into an @AGENTS.md pointer is a change
+# they never asked for. Without --ensure-agents-md the section instead forbids
+# running fm-ensure-agents-md.sh and forbids creating, renaming, converting, or
+# replacing AGENTS.md and CLAUDE.md, and directs durable knowledge into the
+# memory file the project already has, as it already is.
+# --ensure-agents-md opts a ship brief back into the reconciling form: it runs
+# fm-ensure-agents-md.sh and adds that script's self-governance section when a
+# touched project AGENTS.md lacks it. Pass it only for a repo whose agent-memory
+# convention firstmate owns. Like --herdr-lab it must be explicit, because {TASK}
+# is filled after scaffolding and the caller-supplied repo string cannot reliably
+# identify whose repo this is; the default brief names the flag loudly so an
+# omitted opt-in is never silent.
+# It is refused on scout and secondmate scaffolds, which carry no project-memory
+# section, so a misplaced flag fails rather than being silently dropped.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -108,6 +121,7 @@ else
 fi
 KIND=ship
 HERDR_LAB=0
+ENSURE_AGENTS_MD=0
 NO_PROJECTS=0
 MODE=
 MODE_SET=0
@@ -129,6 +143,7 @@ for a in "$@"; do
     --scout) KIND=scout ;;
     --secondmate) KIND=secondmate ;;
     --herdr-lab) HERDR_LAB=1 ;;
+    --ensure-agents-md) ENSURE_AGENTS_MD=1 ;;
     --no-projects) NO_PROJECTS=1 ;;
     --mode) want_value=mode ;;
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
@@ -163,6 +178,14 @@ ID=${POS[0]}
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
   echo "error: --herdr-lab applies only to crewmate ship or scout briefs" >&2
+  exit 1
+fi
+
+# Only ship briefs carry a project-memory section, so the opt-in is refused
+# rather than dropped anywhere else: a silently ignored --ensure-agents-md would
+# read as authority the generated brief does not actually grant.
+if [ "$KIND" != ship ] && [ "$ENSURE_AGENTS_MD" -eq 1 ]; then
+  echo "error: --ensure-agents-md applies only to ship briefs; a scout writes a report and a secondmate charter carries no project-memory section" >&2
   exit 1
 fi
 
@@ -395,6 +418,35 @@ case "$MODE" in
 esac
 DOD=$(fm_dod_block "$MODE" "$ID") || exit 1
 
+# Project-memory authority. Recording knowledge in the file a project already
+# keeps is always in scope; reconciling that project's memory-FILE LAYOUT is not,
+# and is granted only by an explicit --ensure-agents-md. The default section
+# states the prohibition and names the flag, so a worker reading carefully is
+# steered away from the conversion rather than towards it.
+if [ "$ENSURE_AGENTS_MD" -eq 1 ]; then
+IFS= read -r -d '' MEMORY_SECTION <<EOF || true
+# Project memory
+This brief was explicitly scaffolded with \`--ensure-agents-md\`: firstmate owns this repo's agent-memory convention, so reconciling its memory-file layout is in scope for this task.
+If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
+Record only project knowledge useful to almost every future session.
+For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
+If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
+Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
+EOF
+else
+IFS= read -r -d '' MEMORY_SECTION <<'EOF' || true
+# Project memory - memory-file layout NOT firstmate-owned
+**HARD SAFETY GATE:** this brief grants no authority over this project's agent-memory file layout.
+Do NOT run `fm-ensure-agents-md.sh` here, and do NOT create, rename, convert, replace, or delete `AGENTS.md` or `CLAUDE.md`.
+An existing `CLAUDE.md` stays exactly the file it is. It belongs to this project's own maintainers, and turning it into an `@AGENTS.md` pointer is a change they never asked for.
+If this task produced durable project-intrinsic knowledge and the project already keeps a memory file, add the knowledge as ordinary content to that existing file, preserving its name, structure, and conventions.
+Record only knowledge useful to almost every future session, and prefer a pointer to the authoritative file, command, or doc over copying the detail.
+If the project keeps no memory file, do not create one: report the knowledge to firstmate instead.
+If firstmate does own this repo's memory-file convention, the brief must be regenerated with `--ensure-agents-md`; do not add that step to this brief by hand.
+EOF
+fi
+MEMORY_SECTION=${MEMORY_SECTION%$'\n'}
+
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
@@ -440,12 +492,7 @@ $RULE1
 
 $INBOX_SECTION
 
-# Project memory
-If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
-Record only project knowledge useful to almost every future session.
-For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
-If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
-Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
+$MEMORY_SECTION
 
 $DOD
 EOF

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -345,7 +345,8 @@ The [Relay configuration reference](configuration.md#promised-public-replies-sta
 ## Project memory belongs to projects
 
 Durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a real `@AGENTS.md` import pointer.
-Ship briefs prompt crewmates to create or update those files through the normal delivery path; `data/projects.md` stays a thin private registry.
+Ship briefs prompt crewmates to record that knowledge through the normal delivery path; `data/projects.md` stays a thin private registry.
+Changing a project's memory-file layout is separate authority a ship brief withholds unless it was scaffolded with `--ensure-agents-md`, because a repo firstmate does not own may keep a `CLAUDE.md` its own maintainers wrote, and converting that file into a pointer is a change they never asked for.
 Each project `AGENTS.md` carries a short `## Maintaining this file` self-governance section; `bin/fm-ensure-agents-md.sh` owns the canonical wording and injects it idempotently when creating the skeleton, promoting an existing `CLAUDE.md`, or reconciling an existing `AGENTS.md` that still lacks it.
 It refuses a case-variant real memory file such as a lowercase `agents.md`, so the pointer's `@AGENTS.md` import resolves to a real `AGENTS.md` on a case-sensitive filesystem, and surfaces the mismatch for manual reconciliation.
 The full ownership rule - what is project-intrinsic versus fleet-private, and how firstmate keeps the two apart without writing into project clones - is owned by [`AGENTS.md`](../AGENTS.md) (project and knowledge management).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -344,7 +344,7 @@ The [Relay configuration reference](configuration.md#promised-public-replies-sta
 
 ## Project memory belongs to projects
 
-Durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a real `@AGENTS.md` import pointer.
+Durable project-intrinsic agent knowledge lives in the memory file each project commits, canonically a real `AGENTS.md` with `CLAUDE.md` as an `@AGENTS.md` import pointer.
 Ship briefs prompt crewmates to record that knowledge through the normal delivery path; `data/projects.md` stays a thin private registry.
 Changing a project's memory-file layout is separate authority a ship brief withholds unless it was scaffolded with `--ensure-agents-md`, because a repo firstmate does not own may keep a `CLAUDE.md` its own maintainers wrote, and converting that file into a pointer is a change they never asked for.
 Each project `AGENTS.md` carries a short `## Maintaining this file` self-governance section; `bin/fm-ensure-agents-md.sh` owns the canonical wording and injects it idempotently when creating the skeleton, promoting an existing `CLAUDE.md`, or reconciling an existing `AGENTS.md` that still lacks it.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -286,8 +286,10 @@ yolo on a ship brief|brief-refused-b1 some-proj --mode direct-PR --yolo on|--yol
 yolo=value form on a ship brief|brief-refused-b2 some-proj --mode direct-PR --yolo=off|--yolo is not a brief input
 mode on a scout brief|brief-refused-b3 some-proj --scout --mode direct-PR|--mode applies only to ship briefs
 mode on a secondmate charter|brief-refused-b4 --secondmate --no-projects --mode no-mistakes|--mode applies only to ship briefs
+ensure-agents-md on a scout brief|brief-refused-b5 some-proj --scout --ensure-agents-md|--ensure-agents-md applies only to ship briefs
+ensure-agents-md on a secondmate charter|brief-refused-b6 --secondmate --no-projects --ensure-agents-md|--ensure-agents-md applies only to ship briefs
 ROWS
-  pass "fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped"
+  pass "fm-brief.sh: --yolo, scout/secondmate --mode, and misplaced --ensure-agents-md are refused, never silently dropped"
 }
 
 test_faster_paths_use_configured_authority_without_stacked_review() {
@@ -365,14 +367,20 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose and bans --yes outright"
 }
 
+# The opted-in form is the one that may reconcile a project's memory-file
+# layout, so its authoring bar is asserted against a brief scaffolded WITH
+# --ensure-agents-md. The default form is covered by
+# test_project_memory_layout_authority_is_opt_in.
 test_ship_project_memory_wording() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
   mkdir -p "$home/data"
   id="brief-memory-c1"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes --ensure-agents-md >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
+  assert_grep "bin/fm-ensure-agents-md.sh .\` in the worktree" "$brief" \
+    "opted-in project-memory contract lost the fm-ensure-agents-md.sh run step"
   assert_grep "Record only project knowledge useful to almost every future session." "$brief" \
     "project-memory contract lost the durable-knowledge bar"
   assert_grep "prefer a pointer to the authoritative file, command, or doc over copying the detail" "$brief" \
@@ -380,6 +388,54 @@ test_ship_project_memory_wording() {
   assert_grep "lacks \`## Maintaining this file\`, add that short self-governance section" "$brief" \
     "project-memory contract lost the self-governance add-in-same-pass rule"
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
+}
+
+# Reconciling a project's agent-memory FILE LAYOUT is authority firstmate only
+# has over repos whose convention it owns. A repo belonging to another team can
+# keep a CLAUDE.md its own maintainers wrote, and converting that file into an
+# @AGENTS.md pointer is a change they never asked for. The generated brief is
+# where that has to be settled: a worker who reads the brief carefully and obeys
+# it must not end up making the change, so the default brief hands over no
+# fm-ensure-agents-md.sh path at all and states the prohibition instead.
+test_project_memory_layout_authority_is_opt_in() {
+  local home id brief mode
+  home="$TMP_ROOT/memory-authority-home"
+  mkdir -p "$home/data"
+
+  # Every ship mode defaults to the no-authority form, including the exact
+  # command shape that produced the incident: a third-party repo, local-only.
+  for id_mode in "brief-memory-off-nm:no-mistakes" "brief-memory-off-dp:direct-PR" "brief-memory-off-lo:local-only"; do
+    id=${id_mode%%:*}
+    mode=${id_mode##*:}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" merlin --mode "$mode" >/dev/null 2>&1 \
+      || fail "$id: default ship brief should scaffold"
+    brief="$home/data/$id/brief.md"
+    assert_no_grep "bin/fm-ensure-agents-md.sh" "$brief" \
+      "$id: default brief still hands the worker a runnable fm-ensure-agents-md.sh path"
+    assert_grep "memory-file layout NOT firstmate-owned" "$brief" \
+      "$id: default brief did not declare that it grants no memory-layout authority"
+    assert_grep "do NOT create, rename, convert, replace, or delete" "$brief" \
+      "$id: default brief did not forbid restructuring the project memory files"
+    assert_grep "An existing \`CLAUDE.md\` stays exactly the file it is" "$brief" \
+      "$id: default brief did not protect an existing CLAUDE.md by name"
+    assert_grep "must be regenerated with \`--ensure-agents-md\`" "$brief" \
+      "$id: default brief did not name the flag that grants the authority"
+    assert_grep "do not add that step to this brief by hand" "$brief" \
+      "$id: default brief did not forbid hand-adding the step it withholds"
+  done
+
+  # The opt-in restores the reconciling form for a repo firstmate does own.
+  id="brief-memory-on-lo"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode local-only --ensure-agents-md >/dev/null 2>&1 \
+    || fail "$id: opted-in ship brief should scaffold"
+  brief="$home/data/$id/brief.md"
+  assert_grep "scaffolded with \`--ensure-agents-md\`" "$brief" \
+    "$id: opted-in brief did not record which flag granted the authority"
+  assert_grep "bin/fm-ensure-agents-md.sh .\` in the worktree" "$brief" \
+    "$id: opted-in brief lost the fm-ensure-agents-md.sh run step"
+  assert_no_grep "memory-file layout NOT firstmate-owned" "$brief" \
+    "$id: opted-in brief still carries the no-authority declaration"
+  pass "fm-brief.sh: project memory-layout authority is off by default and opt-in per task"
 }
 
 test_herdr_lab_contract_is_explicit_and_complete() {
@@ -772,6 +828,7 @@ test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_project_memory_layout_authority_is_opt_in
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -428,6 +428,14 @@ test_project_memory_layout_authority_is_opt_in() {
       "$id: default brief lost the durable-knowledge bar"
     assert_grep "prefer a pointer to the authoritative file, command, or doc over copying the detail" "$brief" \
       "$id: default brief lost pointer-over-copy guidance"
+    assert_grep "append a single \`note:\` line carrying that knowledge to the status file rule 4 names" "$brief" \
+      "$id: default brief left the no-memory-file report directive without a channel"
+    assert_grep "A single \`note:\` line is permitted for exactly one purpose" "$brief" \
+      "$id: status protocol did not permit the note: line the project-memory section requires"
+    assert_grep "No step-by-step FYI progress lines" "$brief" \
+      "$id: the note: permission weakened the ban on FYI progress lines"
+    assert_grep "States: working, needs-decision, blocked, paused, done, failed." "$brief" \
+      "$id: note: leaked into the enumerated status states instead of staying one permitted line"
   done
 
   # The opt-in restores the reconciling form for a repo firstmate does own.
@@ -813,6 +821,8 @@ test_scout_and_secondmate_scaffold() {
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
   assert_grep "you may host the Lavish review loop yourself" "$brief" \
     "scout brief must mention the option to host a Lavish review loop"
+  assert_no_grep "A single \`note:\` line is permitted" "$brief" \
+    "scout scaffold carries a note: permission whose only purpose is a project-memory section it does not have"
 
   FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
     FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-sm-q6 --secondmate alpha >/dev/null 2>&1 \
@@ -821,6 +831,8 @@ test_scout_and_secondmate_scaffold() {
   assert_present "$brief" "secondmate charter was not scaffolded"
   assert_grep "persistent second mate" "$brief" \
     "secondmate charter must declare its role"
+  assert_no_grep "A single \`note:\` line is permitted" "$brief" \
+    "secondmate charter carries a note: permission whose only purpose is a project-memory section it does not have"
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -422,6 +422,12 @@ test_project_memory_layout_authority_is_opt_in() {
       "$id: default brief did not name the flag that grants the authority"
     assert_grep "do not add that step to this brief by hand" "$brief" \
       "$id: default brief did not forbid hand-adding the step it withholds"
+    assert_grep "add the knowledge as ordinary content to that existing file, preserving its name, structure, and conventions" "$brief" \
+      "$id: default brief lost the instruction to record knowledge in the memory file the project already keeps"
+    assert_grep "Record only knowledge useful to almost every future session" "$brief" \
+      "$id: default brief lost the durable-knowledge bar"
+    assert_grep "prefer a pointer to the authoritative file, command, or doc over copying the detail" "$brief" \
+      "$id: default brief lost pointer-over-copy guidance"
   done
 
   # The opt-in restores the reconciling form for a repo firstmate does own.


### PR DESCRIPTION
## Intent

The generated ship brief told every crewmate to run bin/fm-ensure-agents-md.sh whenever a project already had an AGENTS.md or CLAUDE.md. On a repo firstmate does not own, that is a directive to restructure another team's committed memory files: it promotes their CLAUDE.md into AGENTS.md and leaves a two-line @AGENTS.md pointer behind, so a worker that obeys its brief ships an unrequested rename inside an unrelated change. Recording durable project-intrinsic knowledge in the memory file a project already keeps must stay in every ship brief. Reconciling that project's memory-FILE LAYOUT becomes separate authority, off by default and granted per task by an explicit --ensure-agents-md flag. Without the flag the brief hands over no runnable fm-ensure-agents-md.sh path at all and states the prohibition instead: do not run it, do not create, rename, convert, replace, or delete AGENTS.md or CLAUDE.md, and record knowledge in the existing file as it already is. The flag is explicit rather than inferred for the same reason --herdr-lab already is: {TASK} is filled in after scaffolding and the caller-supplied repo string carries no reliable signal of whose repo it names, so guessing would fail in the dangerous direction. It is refused on scout and secondmate scaffolds, which carry no project-memory section, so a misplaced flag fails instead of being silently dropped. AGENTS.md section 6, docs/architecture.md, and the stow skill carry the same boundary as one-line cross-references to the single owner rather than restating it.

## What Changed

- `bin/fm-brief.sh` now emits two project-memory sections for ship briefs. The default form hands the worker no runnable `fm-ensure-agents-md.sh` path at all and instead forbids running it and forbids creating, renaming, converting, replacing, or deleting `AGENTS.md` or `CLAUDE.md`, while still directing durable project-intrinsic knowledge into the memory file the project already keeps, as it already is; when the project keeps no memory file, it routes that knowledge to firstmate as a single `note:` status line, which the ship scaffold's status protocol now permits for that one purpose.
- A new explicit `--ensure-agents-md` flag opts a ship brief back into the reconciling form that runs `bin/fm-ensure-agents-md.sh` and adds its self-governance section. The flag is refused with an error on scout and secondmate scaffolds, which carry no project-memory section, so a misplaced flag fails instead of being silently dropped.
- `AGENTS.md` section 6, `docs/architecture.md`, and the `stow` skill drop the unconditional `fm-ensure-agents-md.sh` instruction and carry the same boundary as one-line cross-references; `tests/fm-brief.test.sh` adds `test_project_memory_layout_authority_is_opt_in` covering all three ship modes plus the opted-in form, asserts the flag-refusal rows, and asserts the `note:` permission does not leak into scout or secondmate scaffolds.

## Risk Assessment

✅ Low: The change is well-bounded - one new opt-in flag with a fail-closed refusal, two variants of a generated prompt section, and one-line cross-references in three docs - it fails in the safe direction by default, introduces no new state or control flow, and every required intent constraint is source-verifiable and satisfied.

## Testing

Exercised the change through its real end-user surface - the generated ship brief a crewmate reads - rather than only through unit assertions: rendered both brief forms, confirmed the default one grants no memory-layout authority and hands over no runnable fm-ensure-agents-md.sh path while still requiring durable knowledge to be recorded in the project's existing memory file, confirmed --ensure-agents-md restores the reconciling form, captured the CLI refusal transcript for misplaced flags, reproduced the third-party CLAUDE.md promotion the default now prevents, and proved the new `note:` directive actually reaches firstmate through a live wake drain. The targeted suite `tests/fm-brief.test.sh` passes 23/23. This change has no rendered UI, HTML, or visual surface - the product surface is generated Markdown and CLI output - so the evidence is the rendered brief files and command transcripts instead of screenshots.

<details>
<summary>Evidence: Default ship brief for a repo firstmate does not own (rendered, full file)</summary>

Source: [Default ship brief for a repo firstmate does not own (rendered, full file)](https://github.com/jonathankv/firstmate/blob/0728a21b10f334bd7b5bceec6e58c7ee8b00fd56/.no-mistakes/evidence/fm/fm-agents-md-kho-doi-khac/brief-default-no-layout-authority.md)

<code># Project memory - memory-file layout NOT firstmate-owned&#10;**HARD SAFETY GATE:** this brief grants no authority over this project&#39;s agent-memory file layout.&#10;Do NOT run `fm-ensure-agents-md.sh` here, and do NOT create, rename, convert, replace, or delete `AGENTS.md` or `CLAUDE.md`.&#10;An existing `CLAUDE.md` stays exactly the file it is. It belongs to this project&#39;s own maintainers, and turning it into an `@AGENTS.md` pointer is a change they never asked for.&#10;If this task produced durable project-intrinsic knowledge and the project already keeps a memory file, add the knowledge as ordinary content to that existing file, preserving its name, structure, and conventions.&#10;Record only knowledge useful to almost every future session, and prefer a pointer to the authoritative file, command, or doc over copying the detail.&#10;If the project keeps no memory file, do not create one: append a single `note:` line carrying that knowledge to the status file rule 4 names, so it reaches firstmate instead.&#10;If firstmate does own this repo&#39;s memory-file convention, the brief must be regenerated with `--ensure-agents-md`; do not add that step to this brief by hand.</code>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of acme-api, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/t9`

# Rules
1. Never push to the default branch (push only your `fm/t9` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/x7/lxvbttwd77qcm_wx2qhy9j3r0000gn/T//fm-brief-evidence.Zdrlex/state/t9.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A single `note:` line is permitted for exactly one purpose - carrying durable project
   knowledge to firstmate when the Project memory section sends you here because the project
   keeps no memory file - and it authorises no other use of `note:`.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/var/folders/x7/lxvbttwd77qcm_wx2qhy9j3r0000gn/T//fm-brief-evidence.Zdrlex/state/t9.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/var/folders/x7/lxvbttwd77qcm_wx2qhy9j3r0000gn/T//fm-brief-evidence.Zdrlex/state/t9.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/var/folders/x7/lxvbttwd77qcm_wx2qhy9j3r0000gn/T//fm-brief-evidence.Zdrlex/state/t9.inbox'/NNN.msg '/var/folders/x7/lxvbttwd77qcm_wx2qhy9j3r0000gn/T//fm-brief-evidence.Zdrlex/state/t9.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory - memory-file layout NOT firstmate-owned
**HARD SAFETY GATE:** this brief grants no authority over this project's agent-memory file layout.
Do NOT run `fm-ensure-agents-md.sh` here, and do NOT create, rename, convert, replace, or delete `AGENTS.md` or `CLAUDE.md`.
An existing `CLAUDE.md` stays exactly the file it is. It belongs to this project's own maintainers, and turning it into an `@AGENTS.md` pointer is a change they never asked for.
If this task produced durable project-intrinsic knowledge and the project already keeps a memory file, add the knowledge as ordinary content to that existing file, preserving its name, structure, and conventions.
Record only knowledge useful to almost every future session, and prefer a pointer to the authoritative file, command, or doc over copying the detail.
If the project keeps no memory file, do not create one: append a single `note:` line carrying that knowledge to the status file rule 4 names, so it reaches firstmate instead.
If firstmate does own this repo's memory-file convention, the brief must be regenerated with `--ensure-agents-md`; do not add that step to this brief by hand.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Opted-in ship brief (--ensure-agents-md) restores the reconciling form</summary>

Source: [Opted-in ship brief (--ensure-agents-md) restores the reconciling form](https://github.com/jonathankv/firstmate/blob/0728a21b10f334bd7b5bceec6e58c7ee8b00fd56/.no-mistakes/evidence/fm/fm-agents-md-kho-doi-khac/brief-opt-in-ensure-agents-md.md)

<code># Project memory&#10;This brief was explicitly scaffolded with `--ensure-agents-md`: firstmate owns this repo&#39;s agent-memory convention, so reconciling its memory-file layout is in scope for this task.&#10;If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `&lt;FM_ROOT&gt;/bin/fm-ensure-agents-md.sh .` in the worktree.&#10;Record only project knowledge useful to almost every future session.&#10;For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.&#10;If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `&lt;FM_ROOT&gt;/bin/fm-ensure-agents-md.sh` in the same pass.&#10;Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.</code>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/t7`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/x7/lxvbttwd77qcm_wx2qhy9j3r0000gn/T//fm-brief-evidence.Zdrlex/state/t7.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A single `note:` line is permitted for exactly one purpose - carrying durable project
   knowledge to firstmate when the Project memory section sends you here because the project
   keeps no memory file - and it authorises no other use of `note:`.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/var/folders/x7/lxvbttwd77qcm_wx2qhy9j3r0000gn/T//fm-brief-evidence.Zdrlex/state/t7.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/var/folders/x7/lxvbttwd77qcm_wx2qhy9j3r0000gn/T//fm-brief-evidence.Zdrlex/state/t7.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/var/folders/x7/lxvbttwd77qcm_wx2qhy9j3r0000gn/T//fm-brief-evidence.Zdrlex/state/t7.inbox'/NNN.msg '/var/folders/x7/lxvbttwd77qcm_wx2qhy9j3r0000gn/T//fm-brief-evidence.Zdrlex/state/t7.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
This brief was explicitly scaffolded with `--ensure-agents-md`: firstmate owns this repo's agent-memory convention, so reconciling its memory-file layout is in scope for this task.
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `~/.no-mistakes/worktrees/38c446864270/01M1C7WEEVXSKQEYC0CFBTD0Q6/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `~/.no-mistakes/worktrees/38c446864270/01M1C7WEEVXSKQEYC0CFBTD0Q6/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Incident the default brief now prevents: third-party CLAUDE.md restructured</summary>

Source: [Incident the default brief now prevents: third-party CLAUDE.md restructured](https://github.com/jonathankv/firstmate/blob/0728a21b10f334bd7b5bceec6e58c7ee8b00fd56/.no-mistakes/evidence/fm/fm-agents-md-kho-doi-khac/incident-old-brief-restructured-third-party-claude-md.txt)

<code># Third-party repo before (CLAUDE.md written by its own maintainers):&#10;CLAUDE.md&#10;&#10;$ bin/fm-ensure-agents-md.sh . # the command the old brief handed to every ship crewmate&#10;promoted: moved CLAUDE.md to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer&#10;&#10;# Repo after:&#10;AGENTS.md&#10;CLAUDE.md&#10;&#10;$ cat CLAUDE.md # the maintainers&#39; file, replaced by a pointer&#10;&lt;!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. --&gt;&#10;@AGENTS.md&#10;&#10;# With this change, the default ship brief hands over no such command:&#10;$ grep -n &#39;fm-ensure-agents-md&#39; brief-default-no-layout-authority.md&#10;56:Do NOT run `fm-ensure-agents-md.sh` here, and do NOT create, rename, convert, replace, or delete `AGENTS.md` or `CLAUDE.md`.</code>

```text
# What the OLD brief directed on a repo firstmate does not own
# Third-party repo state before (CLAUDE.md written by its own maintainers):
CLAUDE.md

$ bin/fm-ensure-agents-md.sh .   # the command the old brief handed to every ship crewmate
promoted: moved CLAUDE.md to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in /private/var/folders/x7/lxvbttwd77qcm_wx2qhy9j3r0000gn/T/acme-api.DsH476
exit=0

# Repo state after:
AGENTS.md
CLAUDE.md

$ cat CLAUDE.md   # the maintainers' file, replaced by a pointer
<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
@AGENTS.md

# With this change, the default ship brief hands over no such command:
$ grep -n 'fm-ensure-agents-md' brief-default-no-layout-authority.md
56:Do NOT run `fm-ensure-agents-md.sh` here, and do NOT create, rename, convert, replace, or delete `AGENTS.md` or `CLAUDE.md`.
```
</details>
<details>
<summary>Evidence: The note: channel the default brief names actually reaches firstmate</summary>

Source: [The note: channel the default brief names actually reaches firstmate](https://github.com/jonathankv/firstmate/blob/0728a21b10f334bd7b5bceec6e58c7ee8b00fd56/.no-mistakes/evidence/fm/fm-agents-md-kho-doi-khac/note-channel-end-to-end.txt)

<code>$ sed -n &#39;/If the project keeps no memory file/p&#39; brief-default-no-layout-authority.md&#10;If the project keeps no memory file, do not create one: append a single `note:` line carrying that knowledge to the status file rule 4 names, so it reaches firstmate instead.&#10;&#10;$ echo &#34;note: acme-api pins Node 20 in .nvmrc; CI matrix must match&#34; &gt;&gt; $FM_HOME/state/t9.status&#10;&#10;$ bin/fm-wake-drain.sh&#10;UNREAD STATUS (new since last drain, not re-printed after this presentation):&#10;t9 note: acme-api pins Node 20 in .nvmrc; CI matrix must match</code>

```text
# End-to-end: the default brief's no-memory-file directive, followed literally

$ sed -n '/If the project keeps no memory file/p' brief-default-no-layout-authority.md
If the project keeps no memory file, do not create one: append a single `note:` line carrying that knowledge to the status file rule 4 names, so it reaches firstmate instead.

# Worker follows rule 4's exact append command from the same brief, with the one permitted note: line.
$ echo "note: acme-api pins Node 20 in .nvmrc; CI matrix must match" >> $FM_HOME/state/t9.status

# Firstmate's next wake drain, which is what section 3 runs at session start:
$ bin/fm-wake-drain.sh
UNREAD STATUS (new since last drain, not re-printed after this presentation):
t9 note: acme-api pins Node 20 in .nvmrc; CI matrix must match
```
</details>
<details>
<summary>Evidence: Misplaced --ensure-agents-md is refused on scout and secondmate scaffolds</summary>

Source: [Misplaced --ensure-agents-md is refused on scout and secondmate scaffolds](https://github.com/jonathankv/firstmate/blob/0728a21b10f334bd7b5bceec6e58c7ee8b00fd56/.no-mistakes/evidence/fm/fm-agents-md-kho-doi-khac/cli-refusal-misplaced-flag.txt)

<code>$ fm-brief.sh t1 acme-api --scout --ensure-agents-md&#10;error: --ensure-agents-md applies only to ship briefs; a scout writes a report and a secondmate charter carries no project-memory section&#10;exit=1&#10;&#10;$ fm-brief.sh t2 --secondmate --no-projects --ensure-agents-md&#10;error: --ensure-agents-md applies only to ship briefs; a scout writes a report and a secondmate charter carries no project-memory section&#10;exit=1&#10;&#10;$ ls $FM_HOME/data # no brief was written by either refused call&#10;&#10;$ bin/fm-brief.sh --help&#10;Usage: fm-brief.sh &lt;task-id&gt; &lt;repo-name&gt; --mode &lt;no-mistakes|direct-PR|local-only&gt; [--herdr-lab] [--ensure-agents-md]</code>

```text
$ fm-brief.sh t1 acme-api --scout --ensure-agents-md
error: --ensure-agents-md applies only to ship briefs; a scout writes a report and a secondmate charter carries no project-memory section
exit=1

$ fm-brief.sh t2 --secondmate --no-projects --ensure-agents-md
error: --ensure-agents-md applies only to ship briefs; a scout writes a report and a secondmate charter carries no project-memory section
exit=1

$ ls $FM_HOME/data   # no brief was written by either refused call
$ bin/fm-brief.sh --help   # usage lines only
Scaffold a crewmate brief or persistent secondmate charter at
data/<task-id>/brief.md under the active firstmate home.
For ordinary tasks, the standard Setup/Rules/Definition-of-done contract is
filled in. Firstmate then replaces the {TASK} placeholder with the task
description, acceptance criteria, and context, and may adjust other sections
when the task genuinely deviates (e.g. working an existing external PR instead
of shipping a new one).
Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab] [--ensure-agents-md]
       fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
       fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
  --scout writes the scout contract instead: the deliverable is a report at
  data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"53d7e749cc3d23521df97d34b4cb068e1bb6b201","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `AGENTS.md:261` - AGENTS.md section 6 still tells firstmate &#34;A crewmate creates or updates it lazily through the project&#39;s selected delivery path&#34;, but the default generated brief now says the opposite: &#34;If the project keeps no memory file, do not create one: report the knowledge to firstmate instead.&#34; (bin/fm-brief.sh:444). The intent explicitly requires the no-flag brief to forbid creation (&#34;do not run it, do not create, rename, convert, replace, or delete AGENTS.md or CLAUDE.md&#34;), so the brief is right and the always-loaded contract sentence is stale. Concrete failure: a ship task on a project with no memory file, scaffolded without --ensure-agents-md; firstmate, reading section 6, expects the crewmate to create the file, the crewmate correctly refuses per its brief, and the durable knowledge lands nowhere. The new line 262 states the layout gate but does not retract &#34;creates&#34; on line 261. Remedy is a wording decision on the authoritative operating contract, so it needs the author, not an auto-fix.
- ⚠️ `bin/fm-brief.sh:440` - The default project-memory section is unconditional: &#34;**HARD SAFETY GATE:** ... Do NOT run `fm-ensure-agents-md.sh` here, and do NOT create, rename, convert, replace, or delete `AGENTS.md` or `CLAUDE.md`.&#34; It is emitted into every ship brief regardless of what {TASK} turns out to be, and {TASK} is filled in after scaffolding. Concrete trace: `fm-brief.sh t1 firstmate --mode no-mistakes` (no flag, which section 6 permits since the flag is &#34;only for&#34; owned repos, not mandatory for them) for a task whose assigned work is rewriting a section of the firstmate repo&#39;s own AGENTS.md - exactly the shape of this very commit. The worker reads a hard gate forbidding it to replace AGENTS.md, and an obedient worker appends `blocked:` rather than doing its assigned change. Same shape for a captain-requested &#34;set up agent memory for project X&#34; ship task. The escape hatch in the section (&#34;the brief must be regenerated with `--ensure-agents-md`&#34;) makes this recoverable but costs a stall and grants layout authority the task did not need. A carve-out for work the task text itself assigns is a wording/product decision on emitted worker instructions, so it belongs to the author.
- ⚠️ `tests/fm-brief.test.sh:379` - Coverage that previously guarded the default ship brief was moved onto the opt-in brief and not replaced. test_ship_project_memory_wording now scaffolds with --ensure-agents-md, so its &#34;Record only project knowledge useful to almost every future session.&#34; and &#34;prefer a pointer to the authoritative file, command, or doc over copying the detail&#34; assertions no longer touch the default path. test_project_memory_layout_authority_is_opt_in (lines 411-424) asserts only the prohibitions. Result: the intent&#39;s REQUIRED behavior - &#34;Recording durable project-intrinsic knowledge in the memory file a project already keeps must stay in every ship brief&#34; - has no test on the default form. Deleting bin/fm-brief.sh lines 442-443 (&#34;add the knowledge as ordinary content to that existing file, preserving its name, structure, and conventions&#34; and the durable-knowledge/pointer bar) leaves the whole suite green. Add those positive assertions inside the existing default-form loop; the fix is mechanical and stays inside the test the change already added.

🔧 Fix: align AGENTS.md memory wording, cover default brief recording
1 warning still open:

- ⚠️ `bin/fm-brief.sh:444` - The default project-memory section ends with &#34;If the project keeps no memory file, do not create one: report the knowledge to firstmate instead.&#34; but the brief names no channel for that report. Rule 4 of the same generated brief enumerates the complete status protocol as &#34;States: working, needs-decision, blocked, paused, done, failed&#34; (verified in a rendered brief at line 26), and explicitly tells the worker &#34;No step-by-step FYI progress lines&#34;. The informational `note:` kind that bin/fm-classify-lib.sh recognizes and that the wake drain surfaces as UNREAD STATUS (AGENTS.md section 3) is never taught to crewmates in any scaffold. Concrete trace: `fm-brief.sh t9 acme-api --mode direct-PR` (no flag, correct for a repo firstmate does not own) on a project with neither AGENTS.md nor CLAUDE.md; the task produces a durable project fact. The worker is forbidden to create a memory file, is told to report to firstmate, and finds no state that fits. It either appends `needs-decision:` and stops - stalling the task on a non-decision that firstmate must then close with --resolve-key - or buries the fact in the PR body, where firstmate&#39;s knowledge routing never sees it. This directive is new in this change: previously the worker ran fm-ensure-agents-md.sh and the knowledge landed in a file. The smallest honest remedy is to name the concrete channel in that same sentence, which is a wording change to instructions a crewmate executes, so it needs the author rather than an auto-fix. Note this is distinct from the accepted brief-prohibition-overrides-assigned-task decision: that one was about the prohibition overriding assigned work, this is about a directive with no destination.

🔧 Fix: name the note: channel for unrecordable project knowledge
2 infos still open:

- ℹ️ `bin/fm-brief.sh:146` - `--ensure-agents-md` is matched only in its bare form, so a `=value` spelling falls through to the `*)` catch-all and becomes a positional argument. The intent stresses that a misplaced flag must fail rather than be silently dropped, and this file already implements that for the dangerous-direction flag via `--yolo|--yolo=*` at line 152. Concretely: `fm-brief.sh t1 acme-api --mode direct-PR --ensure-agents-md=1` scaffolds the prohibiting default form with ENSURE_AGENTS_MD still 0, and `fm-brief.sh t1 --ensure-agents-md=1 acme-api --mode direct-PR` additionally renders `REPO=${POS[1]}` as the literal string `--ensure-agents-md=1` into the brief&#39;s Setup section. Both directions are safe-failing (authority is withheld, and the brief loudly declares `memory-file layout NOT firstmate-owned`), and `--herdr-lab` has the same pre-existing shape, so this is hardening rather than a defect. Adding `--ensure-agents-md=*` to the refusal would mirror the existing `--yolo=*` guard.
- ℹ️ `bin/fm-brief.sh:478` - The rule 4 `note:` permission is emitted into every ship brief, including the `--ensure-agents-md` form, but its stated trigger (&#34;when the Project memory section sends you here because the project keeps no memory file&#34;) can only occur in the default form. In an opted-in brief the Project memory section instead directs the worker to run `fm-ensure-agents-md.sh`, which creates the memory file, so the permission&#39;s condition is unreachable there. Rendering both forms confirms the clause is byte-identical in each. No behavioral risk: the clause is explicitly conditional and closes with &#34;it authorises no other use of `note:`&#34;. Noting it only as an inconsistency in the emitted agent interface; gating the clause on ENSURE_AGENTS_MD=0 would be a change to worker-facing instruction wording, which is the author&#39;s call, not a mechanical cleanup.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` - full targeted suite for the changed script, 23/23 pass</code>
- <code>`tests/fm-brief.test.sh::test_project_memory_layout_authority_is_opt_in` - default form across no-mistakes/direct-PR/local-only plus the opt-in form</code>
- <code>`tests/fm-brief.test.sh::test_ship_project_memory_wording` - opted-in authoring bar and run step</code>
- <code>`tests/fm-brief.test.sh::test_delivery_flags_are_refused_where_they_do_not_apply` - misplaced --ensure-agents-md refusal</code>
- <code>`tests/fm-brief.test.sh::test_scout_and_secondmate_scaffold` - scout/secondmate scaffolds carry no note: permission</code>
- <code>Manual render: `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh t9 acme-api --mode direct-PR` and `... t7 firstmate --mode no-mistakes --ensure-agents-md`, then read both rendered briefs</code>
- <code>Manual contrast: `grep -n &#39;fm-ensure-agents-md&#39; &lt;default brief&gt;` shows only the prohibition, no runnable path</code>
- <code>Manual CLI transcript: `bin/fm-brief.sh t1 acme-api --scout --ensure-agents-md` and `bin/fm-brief.sh t2 --secondmate --no-projects --ensure-agents-md` both exit 1 and write no brief; `bin/fm-brief.sh --help` shows the new usage line</code>
- <code>Manual incident reproduction: `bin/fm-ensure-agents-md.sh .` in a temp repo holding a maintainer-written CLAUDE.md, showing the promotion and pointer the default brief now forbids</code>
- <code>Manual end-to-end channel check: appended the permitted `note:` line to `state/t9.status` via rule 4&#39;s own command, then `bin/fm-wake-drain.sh` surfaced it under UNREAD STATUS</code>
- <code>Manual doc check: `sed -n 259,263p AGENTS.md`, `grep -rn &#39;fm-ensure-agents-md&#39; --include=&#39;*.md&#39;` across tracked docs, and an em-dash scan of all four changed files</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
