### PR TITLE
feat(bin): add fleet usage ledger harvester and report reader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
   projects.md        thin fleet navigation registry recording each project's standing delivery posture; firstmate-private, parsed for mechanical sync and seeding by fm-project-mode.sh (section 6)
   secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
+  usage-ledger.jsonl append-only fleet cost ledger, one JSON line per harvested task; written only by bin/fm-usage-harvest.sh, whose header owns the line schema, alongside its .usage-ledger.lock append lock, and read by bin/fm-usage-report.sh
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
 projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1251,8 +1251,7 @@ launch_template() {
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
     # session. --always-approve auto-approves every tool execution (verified: the
     # crewmate runs fully autonomously, no permission gate), which an unattended
-    # crewmate needs; it is the targeted equivalent of claude's
-    # --permission-mode auto. grok's turn-end signal does NOT ride the
+    # crewmate needs. grok's turn-end signal does NOT ride the
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1231,12 +1231,12 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode auto __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__-s workspace-write -a never "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__-s workspace-write -a never -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1268,7 +1268,7 @@ launch_template() {
     # inherited CLAUDECODE cannot outrank cursor's own marker in a process that
     # only reads the environment. Cursor exposes no effort flag, so the shared
     # effort axis is deliberately omitted and stays in task metadata only.
-    cursor) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS __CURSORBIN__ --trust --yolo __MODELFLAG__--workspace __WORKTREE__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    cursor) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS __CURSORBIN__ --trust --auto-review --sandbox enabled __MODELFLAG__--workspace __WORKTREE__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     # Kimi Code rejects a positional prompt, so it launches bare and receives
     # only an absolute brief pointer after the TUI readiness gate below.
     # Its turn-end signal is a globally configured Stop hook plus a guarded

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1251,7 +1251,8 @@ launch_template() {
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
     # session. --always-approve auto-approves every tool execution (verified: the
     # crewmate runs fully autonomously, no permission gate), which an unattended
-    # crewmate needs. grok's turn-end signal does NOT ride the
+    # crewmate needs; it is the targeted equivalent of claude's
+    # --permission-mode auto. grok's turn-end signal does NOT ride the
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1252,14 +1252,15 @@ launch_template() {
     # session. --always-approve auto-approves every tool execution (verified: the
     # crewmate runs fully autonomously, no permission gate), which an unattended
     # crewmate needs; it is the targeted equivalent of claude's
-    # --dangerously-skip-permissions. grok's turn-end signal does NOT ride the
+    # --permission-mode auto. grok's turn-end signal does NOT ride the
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
-    # Cursor Agent CLI. --trust suppresses the workspace-trust prompt, which
-    # --yolo does NOT cover and which would otherwise block every spawn, since
-    # each task gets a fresh worktree path cursor has never seen. --yolo is the
-    # --force alias whose TUI label is "Run Everything". --workspace pins the
+    # Cursor Agent CLI. --trust suppresses the workspace-trust prompt that
+    # would otherwise block every spawn, since each task gets a fresh worktree
+    # path cursor has never seen, and it is also what loads the project hooks.
+    # --auto-review --sandbox enabled replaces the former blanket --yolo bypass
+    # with a sandboxed, auto-reviewing autonomy posture. --workspace pins the
     # exact worktree. -w/--worktree is deliberately never passed: it allocates a
     # SECOND worktree under ~/.cursor/worktrees and would break firstmate's
     # isolation contract. The binary is resolved rather than named because

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -683,6 +683,10 @@ remote_secondmate_teardown() {
   grep -vE "^- $ID( |$)" "$SECONDMATE_REG" > "$tmp" || true
   mv -f -- "$tmp" "$SECONDMATE_REG"
   status_retire_presentation_task "$STATE" "$ID" || return 1
+# Best-effort fleet usage harvest runs while the task's state files still
+# exist; a harvest failure must never block teardown.
+"$FM_ROOT/bin/fm-usage-harvest.sh" "$ID" >/dev/null \
+  || echo "warning: usage harvest for $ID failed; continuing teardown" >&2
   fm_backlog_atomic_transition remove "$STATE/$ID.meta" "task record" "$STATE" || return 1
   rm -f -- "$STATE/$ID.turn-ended"
   printf 'teardown %s complete (remote %s:%s)\n' "$ID" "$remote_host" "$remote_home"
@@ -2872,6 +2876,10 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 status_retire_presentation_task "$STATE" "$ID" || exit 1
+# Best-effort fleet usage harvest runs while the task's state files still
+# exist; a harvest failure must never block teardown.
+"$FM_ROOT/bin/fm-usage-harvest.sh" "$ID" >/dev/null \
+  || echo "warning: usage harvest for $ID failed; continuing teardown" >&2
 rm -f "$STATE/$ID.turn-ended" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -682,11 +682,13 @@ remote_secondmate_teardown() {
   tmp="$SECONDMATE_REG.tmp.$$"
   grep -vE "^- $ID( |$)" "$SECONDMATE_REG" > "$tmp" || true
   mv -f -- "$tmp" "$SECONDMATE_REG"
+  # Best-effort fleet usage harvest runs while the task's state files still
+  # exist. It must precede the status retirement below, which deletes
+  # state/<id>.status: without that log the harvest has no task window and no
+  # turn count. A harvest failure must never block teardown.
+  "$FM_ROOT/bin/fm-usage-harvest.sh" "$ID" >/dev/null \
+    || echo "warning: usage harvest for $ID failed; continuing teardown" >&2
   status_retire_presentation_task "$STATE" "$ID" || return 1
-# Best-effort fleet usage harvest runs while the task's state files still
-# exist; a harvest failure must never block teardown.
-"$FM_ROOT/bin/fm-usage-harvest.sh" "$ID" >/dev/null \
-  || echo "warning: usage harvest for $ID failed; continuing teardown" >&2
   fm_backlog_atomic_transition remove "$STATE/$ID.meta" "task record" "$STATE" || return 1
   rm -f -- "$STATE/$ID.turn-ended"
   printf 'teardown %s complete (remote %s:%s)\n' "$ID" "$remote_host" "$remote_home"
@@ -2875,11 +2877,13 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
-status_retire_presentation_task "$STATE" "$ID" || exit 1
 # Best-effort fleet usage harvest runs while the task's state files still
-# exist; a harvest failure must never block teardown.
+# exist. It must precede the status retirement below, which deletes
+# state/<id>.status: without that log the harvest has no task window and no
+# turn count. A harvest failure must never block teardown.
 "$FM_ROOT/bin/fm-usage-harvest.sh" "$ID" >/dev/null \
   || echo "warning: usage harvest for $ID failed; continuing teardown" >&2
+status_retire_presentation_task "$STATE" "$ID" || exit 1
 rm -f "$STATE/$ID.turn-ended" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Tear down a finished task: return the treehouse worktree, release the Orca
 # worktree, or retire a secondmate home; kill the recorded runtime endpoint,
+# harvest the task's fleet usage-ledger row while its state files still exist
+# (best effort: bin/fm-usage-harvest.sh owns that ledger, and a harvest failure
+# only warns on stderr rather than blocking teardown),
 # clear volatile state, and CLOSE this home's backlog item for ship and scout
 # tasks before reporting success (a secondmate teardown closes none, since
 # secondmates are not backlog items), then refresh/prune the project's clone for

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -244,6 +244,7 @@ EFFORT=$EFFORT_META
 SPAWNED=$(iso_from_epoch "$START_EPOCH" || true)
 COMPLETED=$(iso_from_epoch "$END_EPOCH" || true)
 
+mkdir -p -- "$DATA"
 jq -cn \
   --arg task "$ID" --arg harness "$HARNESS" \
   --arg model "$MODEL" --arg effort "$EFFORT" \
@@ -259,5 +260,4 @@ jq -cn \
     wall_secs:$wall, turns:$turns,
     input_tokens:$it, cached_input_tokens:$ct, output_tokens:$ot,
     reasoning_tokens:$rt, source:$source}' >> "$DATA/usage-ledger.jsonl.tmp.$$"
-mkdir -p -- "$DATA"
 cat "$DATA/usage-ledger.jsonl.tmp.$$" >> "$LEDGER" && rm -f -- "$DATA/usage-ledger.jsonl.tmp.$$"

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -46,12 +46,13 @@
 # relaunch and never rewrites it afterwards, so it carries the start on a host
 # whose filesystem reports no usable birth time; because a relaunch replaces
 # it with the relaunch epoch, the status birth is what holds the window open
-# over the whole task, which is the narrowing condition stated above. The meta file's own mtime is NOT a start source in its
-# own right: later meta writes (PR registration, busy-state updates) move it
-# forward to near the end of the task and collapse the window. Only when
-# neither durable source is available (a task spawned before the token
-# existed, on a birthless filesystem) does the start fall back to the meta
-# mtime, then the status mtime.
+# over the whole task, which is the narrowing condition stated above.
+# The meta file's own mtime is NOT a start source in its own right: later
+# meta writes (PR registration, busy-state updates) move it forward to near
+# the end of the task and collapse the window.
+# Only when neither durable source is available (a task spawned before the
+# token existed, on a birthless filesystem) does the start fall back to the
+# meta mtime, then the status mtime.
 # A start later than the end (a spawn with no status append after it) is
 # pinned to the end so spawned_at never postdates completed_at.
 # Turn estimate: count of "^working:" lines in the status file.
@@ -63,10 +64,10 @@
 #     request's usage at .message.usage (input_tokens,
 #     cache_read_input_tokens, cache_creation_input_tokens, output_tokens) and
 #     Claude logs one entry per content block, so requests are deduped by
-#     .message.id before summing. cached_input_tokens folds cache_read + cache_creation (both
-#     billed on top of input_tokens); reasoning_tokens captures
-#     output_tokens_details.thinking_tokens when present (a subset of
-#     output_tokens).
+#     .message.id before summing. cached_input_tokens folds cache_read +
+#     cache_creation (both billed on top of input_tokens); reasoning_tokens
+#     captures output_tokens_details.thinking_tokens when present (a subset
+#     of output_tokens).
 #   harness=codex: <codex-sessions>/**/*.jsonl in the task window whose
 #     session_meta cwd equals the meta worktree. Per-turn token_count events
 #     carry one request's delta at .payload.info.last_token_usage

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -19,27 +19,42 @@
 #    "output_tokens":<int|null>,"reasoning_tokens":<int|null>,
 #    "source":<claude-projects|codex-sessions|pi-sessions|unavailable>}
 #
+# Row scope: a row describes the WHOLE task, spanning every relaunch, and
+# wall_secs, the session-log window and turns all report that one span. The
+# turn count dictates the scope because it can only be read from
+# state/<task-id>.status, which is appended to across relaunches and carries
+# no incarnation delimiter; per-incarnation turns are therefore not derivable
+# from durable data, and scoping only the window to an incarnation would
+# report whole-task turns against a one-incarnation window and token sum.
+#
 # Wall clock: task start epoch -> status-file mtime epoch; the meta file's
 # mtime is the fallback end when the status file is absent.
-# The start comes from the epoch embedded in the meta's
-# spawn_gen=s<epoch>.<pid>.<random> incarnation token, which fm-spawn writes
-# once per spawn or relaunch and never rewrites afterwards. The meta file's
-# own mtime is NOT a start source in its own right: later meta writes (PR
-# registration, busy-state updates) move it forward to near the end of the
-# task and collapse the window. Only when spawn_gen is absent or malformed
-# (a task spawned before that token existed) does the start fall back to the
-# status-file birth epoch, then the meta mtime, then the status mtime.
-# A start later than the end (a relaunch with no status append after it) is
+# The start is the EARLIEST durable evidence of the task's first spawn: the
+# status file's birth epoch (created on the first spawn, only appended to
+# afterwards, and removed only when teardown retires the task) and the epoch
+# embedded in the meta's spawn_gen=s<epoch>.<pid>.<random> incarnation token,
+# whichever of the two is earlier. fm-spawn writes spawn_gen once per spawn or
+# relaunch and never rewrites it afterwards, so it carries the start on a host
+# whose filesystem reports no usable birth time; because a relaunch replaces
+# it with the relaunch epoch, the status birth is what holds the window open
+# over the whole task. The meta file's own mtime is NOT a start source in its
+# own right: later meta writes (PR registration, busy-state updates) move it
+# forward to near the end of the task and collapse the window. Only when
+# neither durable source is available (a task spawned before the token
+# existed, on a birthless filesystem) does the start fall back to the meta
+# mtime, then the status mtime.
+# A start later than the end (a spawn with no status append after it) is
 # pinned to the end so spawned_at never postdates completed_at.
 # Turn estimate: count of "^working:" lines in the status file.
 #
 # Per-request usage sources:
 #   harness=claude: <claude-projects>/<worktree with '/' and '.' -> '-'>/*.jsonl in
-#     the task window. Each assistant message carries one API request's usage
-#     at .message.usage (input_tokens, cache_read_input_tokens,
-#     cache_creation_input_tokens, output_tokens) and Claude logs one entry
-#     per content block, so requests are deduped by .message.id before
-#     summing. cached_input_tokens folds cache_read + cache_creation (both
+#     the task window. Claude's logs record no cwd, so that path encoding is
+#     what binds a log to this task. Each assistant message carries one API
+#     request's usage at .message.usage (input_tokens,
+#     cache_read_input_tokens, cache_creation_input_tokens, output_tokens) and
+#     Claude logs one entry per content block, so requests are deduped by
+#     .message.id before summing. cached_input_tokens folds cache_read + cache_creation (both
 #     billed on top of input_tokens); reasoning_tokens captures
 #     output_tokens_details.thinking_tokens when present (a subset of
 #     output_tokens).
@@ -64,9 +79,12 @@
 #     meta, and bare when the record carries no provider.
 #   harness=cursor, a task with a recorded remote_host (its worker ran on
 #     another machine, so its logs are not on this filesystem), an absent log
-#     tree, or no in-window match: token fields are null with source
-#     "unavailable".
-# A corrupt log line is skipped best-effort by the parser.
+#     tree, or no in-window log that yields this task's assistant usage: token
+#     fields are null with source "unavailable". Every harness applies that
+#     one rule, so a source name always asserts a parsed match and never the
+#     mere presence of an in-window file.
+# A corrupt log line is skipped best-effort by the parser, which reads each
+# line on its own and keeps the rest of that file's usage.
 #
 # Idempotent: if the ledger already contains a line whose "task" is
 # <task-id>, the command exits 0 without appending.
@@ -161,7 +179,20 @@ spawn_gen_epoch() {  # <spawn_gen token>
 }
 
 END_EPOCH=$(file_mtime_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$META")
-START_EPOCH=$(spawn_gen_epoch "$SPAWN_GEN" 2>/dev/null || file_birth_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$META" 2>/dev/null || file_mtime_epoch "$STATUS" 2>/dev/null || printf '%s' "$END_EPOCH")
+# The two durable first-spawn witnesses are combined by taking the earlier of
+# them, so a relaunch (which rewrites spawn_gen but only appends to the status
+# log) cannot narrow the window below the span the turn count already covers.
+START_GEN=$(spawn_gen_epoch "$SPAWN_GEN" 2>/dev/null || true)
+START_BIRTH=$(file_birth_epoch "$STATUS" 2>/dev/null || true)
+START_EPOCH=
+for start_candidate in "$START_GEN" "$START_BIRTH"; do
+  [ -n "$start_candidate" ] || continue
+  if [ -z "$START_EPOCH" ] || [ "$start_candidate" -lt "$START_EPOCH" ]; then
+    START_EPOCH=$start_candidate
+  fi
+done
+[ -n "$START_EPOCH" ] \
+  || START_EPOCH=$(file_mtime_epoch "$META" 2>/dev/null || file_mtime_epoch "$STATUS" 2>/dev/null || printf '%s' "$END_EPOCH")
 # Pin an impossible start to the end rather than inverting the window, which
 # would both report a negative duration and drop every session log.
 [ "$START_EPOCH" -le "$END_EPOCH" ] 2>/dev/null || START_EPOCH=$END_EPOCH
@@ -182,7 +213,9 @@ harvest_cleanup() {
 }
 trap harvest_cleanup EXIT
 epoch_to_touch() {  # <epoch>
-  date -r "$1" +%Y%m%d%H%M.%S 2>/dev/null || date -u -d "@$1" +%Y%m%d%H%M.%S
+  # Both renderings are LOCAL time because that is what touch -t reads; a UTC
+  # stamp would shift both window refs by the host's offset and drop real logs.
+  date -r "$1" +%Y%m%d%H%M.%S 2>/dev/null || date -d "@$1" +%Y%m%d%H%M.%S
 }
 # find -newer compares sub-second mtimes, so the refs only narrow to
 # [START-1, END+1]; the per-file epoch filter below then applies the true
@@ -210,131 +243,126 @@ matched_files() {  # <dir> <maxdepth-or-empty> : print in-window *.jsonl paths
 }
 
 IT=null; CT=null; OT=null; RT=null
+
+# accumulate_usage <dir> <maxdepth-or-empty> <source-label> <jq-program>
+#
+# The three harness parsers differ only in their jq program; everything around
+# it lives here once. Each program reduces one session log to at most one
+# "<cwd>\t<model>\t<input>\t<cached>\t<output>\t<reasoning>" row, and emits
+# that row ONLY when the log actually yielded assistant usage, so a file that
+# parses to nothing leaves the source unavailable. Each program also reads its
+# input line by line through "try fromjson", so one corrupt line costs that
+# line rather than the whole file's usage. This loop then binds the row to
+# this task by the cwd it reports, sums the counts and remembers the first
+# model seen.
+accumulate_usage() {
+  local dir=$1 depth=$2 label=$3 prog=$4
+  local files f row cwd m it ct ot rt
+  files=$(matched_files "$dir" "$depth")
+  [ -n "$files" ] || return 0
+  IT=0; CT=0; OT=0; RT=0
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    # @tsv renders a null field as an empty one, and "IFS=$'\t' read" would
+    # drop those empty fields because tab is an IFS whitespace character,
+    # shifting every later field into the wrong variable. Translating the
+    # separators to the non-whitespace unit separator keeps each field in its
+    # own slot; @tsv escapes any tab inside a value, so every remaining tab
+    # byte is a separator.
+    row=$(jq -Rrn --arg wt "$WORKTREE" "$prog" "$f" 2>/dev/null | tr '\t' '\037')
+    [ -n "$row" ] || continue
+    IFS=$'\037' read -r cwd m it ct ot rt <<<"$row"
+    [ "$cwd" = "$WORKTREE" ] || continue
+    SRC=$label
+    [ -n "$m" ] && [ -z "$MODEL_LOG" ] && MODEL_LOG=$m
+    IT=$((IT + ${it:-0}))
+    CT=$((CT + ${ct:-0}))
+    OT=$((OT + ${ot:-0}))
+    RT=$((RT + ${rt:-0}))
+  done <<FMINNER
+$files
+FMINNER
+  return 0
+}
+
 case "$HARNESS" in
   claude)
     if [ -z "$REMOTE_HOST" ] && [ -n "$WORKTREE" ]; then
       encoded=${WORKTREE//\//-}
       encoded=${encoded//./-}
-      files=$(matched_files "$CLAUDE_DIR/$encoded" 1)
-      if [ -n "$files" ]; then
-        SRC=claude-projects
-        IT=0; CT=0; OT=0; RT=0
-        # One entry per content block repeats one request's usage; dedupe on
-        # .message.id so every request is counted exactly once.
-        while IFS= read -r f; do
-          row=$(jq -rn '
-            reduce inputs as $l ({seen:{},m:null,it:0,ct:0,ot:0,rt:0};
-              if $l.type == "assistant" and ($l.message.usage // null) != null then
-                ($l.message.id // "no-id") as $id
-                | if .seen[$id] then . else
-                    .seen[$id] = 1
-                    | .it += ($l.message.usage.input_tokens // 0)
-                    | .ct += (($l.message.usage.cache_read_input_tokens // 0)
-                              + ($l.message.usage.cache_creation_input_tokens // 0))
-                    | .ot += ($l.message.usage.output_tokens // 0)
-                    | .rt += ($l.message.usage.output_tokens_details.thinking_tokens // 0)
-                    | (if .m == null then .m = ($l.message.model // null) else . end)
-                  end
-              elif $l.type == "assistant" and ($l.message.model // null) != null and .m == null then
-                .m = $l.message.model
-              else . end)
-            | [.m, .it, .ct, .ot, .rt] | @tsv' "$f" 2>/dev/null || true)
-          [ -n "$row" ] || continue
-          IFS=$'\t' read -r m it ct ot rt <<<"$row"
-          [ -n "$m" ] && [ -z "$MODEL_LOG" ] && MODEL_LOG=$m
-          IT=$((IT + ${it:-0}))
-          CT=$((CT + ${ct:-0}))
-          OT=$((OT + ${ot:-0}))
-          RT=$((RT + ${rt:-0}))
-        done <<FMINNER
-$files
-FMINNER
-      fi
+      # Claude's logs carry no cwd, so the encoded directory is the binding and
+      # the row reports the worktree it was resolved from.
+      # shellcheck disable=SC2016  # jq owns every $ expression in these literal programs.
+      accumulate_usage "$CLAUDE_DIR/$encoded" 1 claude-projects '
+        reduce (inputs | try fromjson catch empty) as $l
+          ({seen:{},n:0,m:null,it:0,ct:0,ot:0,rt:0};
+            if $l.type == "assistant" and ($l.message.usage // null) != null then
+              ($l.message.id // "no-id") as $id
+              | if .seen[$id] then . else
+                  .seen[$id] = 1
+                  | .n += 1
+                  | .it += ($l.message.usage.input_tokens // 0)
+                  | .ct += (($l.message.usage.cache_read_input_tokens // 0)
+                            + ($l.message.usage.cache_creation_input_tokens // 0))
+                  | .ot += ($l.message.usage.output_tokens // 0)
+                  | .rt += ($l.message.usage.output_tokens_details.thinking_tokens // 0)
+                  | (if .m == null then .m = ($l.message.model // null) else . end)
+                end
+            elif $l.type == "assistant" and ($l.message.model // null) != null and .m == null then
+              .m = $l.message.model
+            else . end)
+        | if .n > 0 then [$wt, .m, .it, .ct, .ot, .rt] | @tsv else empty end'
     fi
     ;;
   codex)
     if [ -z "$REMOTE_HOST" ] && [ -n "$WORKTREE" ]; then
-      files=$(matched_files "$CODEX_DIR" "")
-      if [ -n "$files" ]; then
-        IT=0; CT=0; OT=0; RT=0
-        found=0
-        while IFS= read -r f; do
-          row=$(jq -rn '
-            reduce inputs as $l ({cwd:null,m:null,it:0,ct:0,ot:0,rt:0};
-              if $l.type == "session_meta" then
-                .cwd = ($l.payload.cwd // .cwd)
-              elif $l.type == "turn_context" and ($l.payload.model // null) != null then
-                .m = $l.payload.model
-              elif $l.type == "event_msg" and $l.payload.type == "token_count"
-                   and ($l.payload.info.last_token_usage // null) != null then
-                .it += ($l.payload.info.last_token_usage.input_tokens // 0)
-                | .ct += (($l.payload.info.last_token_usage.cached_input_tokens // 0)
-                          + ($l.payload.info.last_token_usage.cache_write_input_tokens // 0))
-                | .ot += ($l.payload.info.last_token_usage.output_tokens // 0)
-                | .rt += ($l.payload.info.last_token_usage.reasoning_output_tokens // 0)
-              else . end)
-            | [.cwd, .m, .it, .ct, .ot, .rt] | @tsv' "$f" 2>/dev/null || true)
-          [ -n "$row" ] || continue
-          IFS=$'\t' read -r cwd m it ct ot rt <<<"$row"
-          [ "$cwd" = "$WORKTREE" ] || continue
-          found=1
-          SRC=codex-sessions
-          [ -n "$m" ] && [ -z "$MODEL_LOG" ] && MODEL_LOG=$m
-          IT=$((IT + ${it:-0}))
-          CT=$((CT + ${ct:-0}))
-          OT=$((OT + ${ot:-0}))
-          RT=$((RT + ${rt:-0}))
-        done <<FMINNER
-$files
-FMINNER
-        [ "$found" -eq 1 ] || SRC=unavailable
-      fi
+      # shellcheck disable=SC2016  # jq owns every $ expression in these literal programs.
+      accumulate_usage "$CODEX_DIR" "" codex-sessions '
+        reduce (inputs | try fromjson catch empty) as $l
+          ({cwd:null,n:0,m:null,it:0,ct:0,ot:0,rt:0};
+            if $l.type == "session_meta" then
+              .cwd = ($l.payload.cwd // .cwd)
+            elif $l.type == "turn_context" and ($l.payload.model // null) != null then
+              .m = $l.payload.model
+            elif $l.type == "event_msg" and $l.payload.type == "token_count"
+                 and ($l.payload.info.last_token_usage // null) != null then
+              .n += 1
+              | .it += ($l.payload.info.last_token_usage.input_tokens // 0)
+              | .ct += (($l.payload.info.last_token_usage.cached_input_tokens // 0)
+                        + ($l.payload.info.last_token_usage.cache_write_input_tokens // 0))
+              | .ot += ($l.payload.info.last_token_usage.output_tokens // 0)
+              | .rt += ($l.payload.info.last_token_usage.reasoning_output_tokens // 0)
+            else . end)
+        | if .n > 0 then [.cwd, .m, .it, .ct, .ot, .rt] | @tsv else empty end'
     fi
     ;;
   pi|pi-signed)
     if [ -z "$REMOTE_HOST" ] && [ -n "$WORKTREE" ]; then
-      files=$(matched_files "$PI_DIR" "")
-      if [ -n "$files" ]; then
-        IT=0; CT=0; OT=0; RT=0
-        found=0
-        while IFS= read -r f; do
-          row=$(jq -rn '
-            reduce inputs as $l ({cwd:null,seen:{},m:null,it:0,ct:0,ot:0,rt:0};
-              if $l.type == "session" then
-                .cwd = ($l.cwd // .cwd)
-              elif $l.type == "message" and $l.message.role == "assistant"
-                   and ($l.message.usage // null) != null then
-                ($l.id // null) as $id
-                | if $id != null and .seen[$id] then . else
-                    (if $id == null then . else .seen[$id] = 1 end)
-                    | .it += ($l.message.usage.input // 0)
-                    | .ct += (($l.message.usage.cacheRead // 0)
-                              + ($l.message.usage.cacheWrite // 0))
-                    | .ot += ($l.message.usage.output // 0)
-                    | .rt += ($l.message.usage.reasoning // 0)
-                    | (if .m == null and ($l.message.model // null) != null then
-                         .m = (if ($l.message.provider // null) != null
-                               then ($l.message.provider + "/" + $l.message.model)
-                               else $l.message.model end)
-                       else . end)
-                  end
-              else . end)
-            | [.cwd, .m, .it, .ct, .ot, .rt] | @tsv' "$f" 2>/dev/null || true)
-          [ -n "$row" ] || continue
-          IFS=$'\t' read -r cwd m it ct ot rt <<<"$row"
-          [ "$cwd" = "$WORKTREE" ] || continue
-          found=1
-          SRC=pi-sessions
-          [ -n "$m" ] && [ -z "$MODEL_LOG" ] && MODEL_LOG=$m
-          IT=$((IT + ${it:-0}))
-          CT=$((CT + ${ct:-0}))
-          OT=$((OT + ${ot:-0}))
-          RT=$((RT + ${rt:-0}))
-        done <<FMINNER
-$files
-FMINNER
-        [ "$found" -eq 1 ] || SRC=unavailable
-      fi
+      # shellcheck disable=SC2016  # jq owns every $ expression in these literal programs.
+      accumulate_usage "$PI_DIR" "" pi-sessions '
+        reduce (inputs | try fromjson catch empty) as $l
+          ({cwd:null,seen:{},n:0,m:null,it:0,ct:0,ot:0,rt:0};
+            if $l.type == "session" then
+              .cwd = ($l.cwd // .cwd)
+            elif $l.type == "message" and $l.message.role == "assistant"
+                 and ($l.message.usage // null) != null then
+              ($l.id // null) as $id
+              | if $id != null and .seen[$id] then . else
+                  (if $id == null then . else .seen[$id] = 1 end)
+                  | .n += 1
+                  | .it += ($l.message.usage.input // 0)
+                  | .ct += (($l.message.usage.cacheRead // 0)
+                            + ($l.message.usage.cacheWrite // 0))
+                  | .ot += ($l.message.usage.output // 0)
+                  | .rt += ($l.message.usage.reasoning // 0)
+                  | (if .m == null and ($l.message.model // null) != null then
+                       .m = (if ($l.message.provider // null) != null
+                             then ($l.message.provider + "/" + $l.message.model)
+                             else $l.message.model end)
+                     else . end)
+                end
+            else . end)
+        | if .n > 0 then [.cwd, .m, .it, .ct, .ot, .rt] | @tsv else empty end'
     fi
     ;;
 esac

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -12,7 +12,7 @@
 #
 # Ledger line schema (this file is the single owner of that schema; the
 # report script is a consumer):
-#   {"task":<id>,"harness":<name>,"model":<id|null>,"effort":<id|null>,
+#   {"task":<id>,"harness":<name|null>,"model":<id|null>,"effort":<id|null>,
 #    "spawned_at":<iso|null>,"completed_at":<iso|null>,
 #    "wall_secs":<int>,"turns":<int>,
 #    "input_tokens":<int|null>,"cached_input_tokens":<int|null>,
@@ -26,6 +26,15 @@
 # no incarnation delimiter; per-incarnation turns are therefore not derivable
 # from durable data, and scoping only the window to an incarnation would
 # report whole-task turns against a one-incarnation window and token sum.
+# ONE condition narrows a row below that span, and only for a task that was
+# actually relaunched: a filesystem that reports no birth time for
+# state/<task-id>.status leaves the meta's spawn_gen as the only durable
+# start, and fm-spawn rewrites that token on every relaunch, so wall_secs and
+# the token sum then cover the final incarnation while turns still cover the
+# whole task. No per-task record of the first spawn survives a relaunch on
+# such a host, so a relaunched row there is narrowed rather than wrong; a task
+# that was never relaunched always yields a whole-task row on every
+# filesystem.
 #
 # Wall clock: task start epoch -> status-file mtime epoch; the meta file's
 # mtime is the fallback end when the status file is absent.
@@ -37,7 +46,7 @@
 # relaunch and never rewrites it afterwards, so it carries the start on a host
 # whose filesystem reports no usable birth time; because a relaunch replaces
 # it with the relaunch epoch, the status birth is what holds the window open
-# over the whole task. The meta file's own mtime is NOT a start source in its
+# over the whole task, which is the narrowing condition stated above. The meta file's own mtime is NOT a start source in its
 # own right: later meta writes (PR registration, busy-state updates) move it
 # forward to near the end of the task and collapse the window. Only when
 # neither durable source is available (a task spawned before the token
@@ -294,7 +303,7 @@ case "$HARNESS" in
       # the row reports the worktree it was resolved from.
       # shellcheck disable=SC2016  # jq owns every $ expression in these literal programs.
       accumulate_usage "$CLAUDE_DIR/$encoded" 1 claude-projects '
-        reduce (inputs | try fromjson catch empty) as $l
+        reduce (inputs | try (fromjson | objects) catch empty) as $l
           ({seen:{},n:0,m:null,it:0,ct:0,ot:0,rt:0};
             if $l.type == "assistant" and ($l.message.usage // null) != null then
               ($l.message.id // "no-id") as $id
@@ -318,7 +327,7 @@ case "$HARNESS" in
     if [ -z "$REMOTE_HOST" ] && [ -n "$WORKTREE" ]; then
       # shellcheck disable=SC2016  # jq owns every $ expression in these literal programs.
       accumulate_usage "$CODEX_DIR" "" codex-sessions '
-        reduce (inputs | try fromjson catch empty) as $l
+        reduce (inputs | try (fromjson | objects) catch empty) as $l
           ({cwd:null,n:0,m:null,it:0,ct:0,ot:0,rt:0};
             if $l.type == "session_meta" then
               .cwd = ($l.payload.cwd // .cwd)
@@ -340,7 +349,7 @@ case "$HARNESS" in
     if [ -z "$REMOTE_HOST" ] && [ -n "$WORKTREE" ]; then
       # shellcheck disable=SC2016  # jq owns every $ expression in these literal programs.
       accumulate_usage "$PI_DIR" "" pi-sessions '
-        reduce (inputs | try fromjson catch empty) as $l
+        reduce (inputs | try (fromjson | objects) catch empty) as $l
           ({cwd:null,seen:{},n:0,m:null,it:0,ct:0,ot:0,rt:0};
             if $l.type == "session" then
               .cwd = ($l.cwd // .cwd)
@@ -415,7 +424,7 @@ jq -cn \
   --argjson wall "$WALL" --argjson turns "$TURNS" \
   --argjson it "$IT" --argjson ct "$CT" --argjson ot "$OT" --argjson rt "$RT" \
   --arg source "$SRC" \
-  '{task:$task, harness:$harness,
+  '{task:$task, harness:(if $harness == "" then null else $harness end),
     model:(if ($model == "" or $model == "default") then null else $model end),
     effort:(if ($effort == "" or $effort == "default") then null else $effort end),
     spawned_at:(if $spawned == "" then null else $spawned end),

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -154,9 +154,6 @@ touch -t "$(epoch_to_touch "$((START_EPOCH - 1))")" "$REFDIR/start"
 touch -t "$(epoch_to_touch "$((END_EPOCH + 1))")" "$REFDIR/end"
 
 LEDGER="$DATA/usage-ledger.jsonl"
-if [ -f "$LEDGER" ] && grep -qF "\"task\":\"$ID\"" "$LEDGER" 2>/dev/null; then
-  exit 0
-fi
 
 SRC=unavailable
 MODEL_LOG=
@@ -271,9 +268,10 @@ SPAWNED=$(iso_from_epoch "$START_EPOCH" || true)
 COMPLETED=$(iso_from_epoch "$END_EPOCH" || true)
 
 mkdir -p -- "$DATA"
-# Serialize the check-and-append: the unlocked pre-check above is only a fast
-# path, so acquire the ledger lock and re-test under it before writing. Two
-# concurrent harvests of the same task then cannot both append a row.
+# Serialize the check-and-append as one critical section: acquire the ledger
+# lock, then test for an existing row for this task and append only when
+# absent. Two concurrent harvests of the same task cannot both pass the
+# existence test and each append a duplicate row.
 LEDGER_LOCK="$DATA/.usage-ledger.lock"
 fm_lock_acquire_wait "$LEDGER_LOCK"
 LEDGER_LOCK_HELD=1

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -21,11 +21,13 @@
 #
 # Wall clock: status-file birth epoch -> status-file mtime epoch; the meta
 # file's mtime is the fallback end when the status file is absent, and a
-# missing birth timestamp falls back to the status mtime as the start.
+# missing birth timestamp falls back to the meta-file mtime (the spawn-time
+# marker, portable where birth time is unavailable) and then the status mtime
+# as the start.
 # Turn estimate: count of "^working:" lines in the status file.
 #
 # Per-request usage sources:
-#   harness=claude: <claude-projects>/<worktree with '/' -> '-'>/*.jsonl in
+#   harness=claude: <claude-projects>/<worktree with '/' and '.' -> '-'>/*.jsonl in
 #     the task window. Each assistant message carries one API request's usage
 #     at .message.usage (input_tokens, cache_read_input_tokens,
 #     cache_creation_input_tokens, output_tokens) and Claude logs one entry
@@ -109,7 +111,7 @@ iso_from_epoch() {  # <epoch>
 }
 
 END_EPOCH=$(file_mtime_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$META")
-START_EPOCH=$(file_birth_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$STATUS" 2>/dev/null || printf '%s' "$END_EPOCH")
+START_EPOCH=$(file_birth_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$META" 2>/dev/null || file_mtime_epoch "$STATUS" 2>/dev/null || printf '%s' "$END_EPOCH")
 WALL=$((END_EPOCH - START_EPOCH))
 [ "$WALL" -ge 0 ] || WALL=0
 TURNS=$(grep -c '^working:' "$STATUS" 2>/dev/null || true)
@@ -155,6 +157,7 @@ case "$HARNESS" in
   claude)
     if [ -n "$WORKTREE" ]; then
       encoded=${WORKTREE//\//-}
+      encoded=${encoded//./-}
       files=$(matched_files "$CLAUDE_DIR/$encoded" 1)
       if [ -n "$files" ]; then
         SRC=claude-projects

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# fm-usage-harvest.sh - append one fleet usage-ledger row for a finished task.
+#
+# Usage: fm-usage-harvest.sh <task-id>
+#
+# Reads state/<task-id>.meta (harness=, model=, effort=, worktree=; the
+# backend window= line is intentionally not consumed because the ledger has no
+# window field) plus the task's state/<task-id>.status timestamps for the task
+# window, then sums the worker's own session-log usage into exactly one JSON
+# line appended to data/usage-ledger.jsonl. data/usage-ledger.jsonl is
+# gitignored runtime data.
+#
+# Ledger line schema (this file is the single owner of that schema; the
+# report script is a consumer):
+#   {"task":<id>,"harness":<name>,"model":<id|null>,"effort":<id|null>,
+#    "spawned_at":<iso|null>,"completed_at":<iso|null>,
+#    "wall_secs":<int>,"turns":<int>,
+#    "input_tokens":<int|null>,"cached_input_tokens":<int|null>,
+#    "output_tokens":<int|null>,"reasoning_tokens":<int|null>,
+#    "source":<claude-projects|codex-sessions|unavailable>}
+#
+# Wall clock: status-file birth epoch -> status-file mtime epoch; the meta
+# file's mtime is the fallback end when the status file is absent, and a
+# missing birth timestamp falls back to the status mtime as the start.
+# Turn estimate: count of "^working:" lines in the status file.
+#
+# Per-request usage sources:
+#   harness=claude: <claude-projects>/<worktree with '/' -> '-'>/*.jsonl in
+#     the task window. Each assistant message carries one API request's usage
+#     at .message.usage (input_tokens, cache_read_input_tokens,
+#     cache_creation_input_tokens, output_tokens) and Claude logs one entry
+#     per content block, so requests are deduped by .message.id before
+#     summing. cached_input_tokens folds cache_read + cache_creation (both
+#     billed on top of input_tokens); reasoning_tokens captures
+#     output_tokens_details.thinking_tokens when present (a subset of
+#     output_tokens).
+#   harness=codex: <codex-sessions>/**/*.jsonl in the task window whose
+#     session_meta cwd equals the meta worktree. Per-turn token_count events
+#     carry one request's delta at .payload.info.last_token_usage
+#     (input_tokens, cached_input_tokens, cache_write_input_tokens,
+#     output_tokens, reasoning_output_tokens); summing those deltas equals the
+#     final cumulative total. cached_input_tokens folds cached + cache_write
+#     (subsets of input_tokens); the model comes from the turn_context.
+#   harness=cursor, an absent log tree, or no in-window match: token fields
+#     are null with source "unavailable".
+# A corrupt log line is skipped best-effort by the parser.
+#
+# Idempotent: if the ledger already contains a line whose "task" is
+# <task-id>, the command exits 0 without appending.
+#
+# Overrides (test seams and alternate homes):
+#   FM_ROOT_OVERRIDE, FM_HOME, FM_STATE_OVERRIDE, FM_DATA_OVERRIDE  as usual
+#   FM_USAGE_CLAUDE_DIR   default $HOME/.claude/projects
+#   FM_USAGE_CODEX_DIR    default $HOME/.codex/sessions
+#
+# Exit status: 0 on a successful or already-present harvest, 1 on a missing
+# task record, missing jq, or an unwritable ledger. Callers that must not
+# block (teardown) own their own guard.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+CLAUDE_DIR="${FM_USAGE_CLAUDE_DIR:-${HOME:-}/.claude/projects}"
+CODEX_DIR="${FM_USAGE_CODEX_DIR:-${HOME:-}/.codex/sessions}"
+
+err() { printf 'error: %s\n' "$1" >&2; }
+
+if [ "$#" -ne 1 ] || [ -z "$1" ] || case "$1" in *[!A-Za-z0-9._-]*) true ;; *) false ;; esac; then
+  err "usage: fm-usage-harvest.sh <task-id>"
+  exit 1
+fi
+command -v jq >/dev/null 2>&1 || { err "jq is required"; exit 1; }
+
+ID=$1
+META="$STATE/$ID.meta"
+STATUS="$STATE/$ID.status"
+[ -f "$META" ] || { err "no task record: $META"; exit 1; }
+
+meta_get() {  # <key>
+  grep "^$1=" "$META" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+HARNESS=$(meta_get harness)
+WORKTREE=$(meta_get worktree)
+MODEL_META=$(meta_get model)
+EFFORT_META=$(meta_get effort)
+
+file_mtime_epoch() {  # <file>
+  local t
+  t=$(stat -f %m -- "$1" 2>/dev/null) || t=$(stat -c %Y -- "$1" 2>/dev/null) || return 1
+  case "$t" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s' "$t"
+}
+file_birth_epoch() {  # <file>
+  local t
+  t=$(stat -f %B -- "$1" 2>/dev/null) || t=$(stat -c %W -- "$1" 2>/dev/null) || return 1
+  # The plausible-epoch guard keeps GNU stat's filesystem-mode %B output
+  # (block size) from being misread as a birth time.
+  case "$t" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$t" -ge 1000000000 ] 2>/dev/null || return 1
+  printf '%s' "$t"
+}
+iso_from_epoch() {  # <epoch>
+  date -r "$1" -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || return 1
+}
+
+END_EPOCH=$(file_mtime_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$META")
+START_EPOCH=$(file_birth_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$STATUS" 2>/dev/null || printf '%s' "$END_EPOCH")
+WALL=$((END_EPOCH - START_EPOCH))
+[ "$WALL" -ge 0 ] || WALL=0
+TURNS=$(grep -c '^working:' "$STATUS" 2>/dev/null || true)
+case "$TURNS" in ''|*[!0-9]*) TURNS=0 ;; esac
+
+# Ref files pin find's mtime window portably (BSD and GNU find both compare
+# against -newer file mtimes, and touch -t exists on both).
+REFDIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-usage-harvest.XXXXXX")
+trap 'rm -rf -- "$REFDIR"' EXIT
+epoch_to_touch() {  # <epoch>
+  date -r "$1" +%Y%m%d%H%M.%S 2>/dev/null || date -u -d "@$1" +%Y%m%d%H%M.%S
+}
+# find -newer compares sub-second mtimes, so the refs only narrow to
+# [START-1, END+1]; the per-file epoch filter below then applies the true
+# inclusive whole-second window [START_EPOCH, END_EPOCH].
+touch -t "$(epoch_to_touch "$((START_EPOCH - 1))")" "$REFDIR/start"
+touch -t "$(epoch_to_touch "$((END_EPOCH + 1))")" "$REFDIR/end"
+
+LEDGER="$DATA/usage-ledger.jsonl"
+if [ -f "$LEDGER" ] && grep -qF "\"task\":\"$ID\"" "$LEDGER" 2>/dev/null; then
+  exit 0
+fi
+
+SRC=unavailable
+MODEL_LOG=
+matched_files() {  # <dir> <maxdepth-or-empty> : print in-window *.jsonl paths
+  local dir=$1 depthargs=() f m
+  [ -d "$dir" ] || return 0
+  if [ -n "$2" ]; then
+    depthargs=(-maxdepth "$2")
+  fi
+  while IFS= read -r f; do
+    m=$(file_mtime_epoch "$f") || continue
+    if [ "$m" -ge "$START_EPOCH" ] && [ "$m" -le "$END_EPOCH" ]; then
+      printf '%s\n' "$f"
+    fi
+  done < <(find "$dir" ${depthargs[@]+"${depthargs[@]}"} -type f -name '*.jsonl' \
+    -newer "$REFDIR/start" ! -newer "$REFDIR/end" -print 2>/dev/null) || true
+}
+
+IT=null; CT=null; OT=null; RT=null
+case "$HARNESS" in
+  claude)
+    if [ -n "$WORKTREE" ]; then
+      encoded=${WORKTREE//\//-}
+      files=$(matched_files "$CLAUDE_DIR/$encoded" 1)
+      if [ -n "$files" ]; then
+        SRC=claude-projects
+        IT=0; CT=0; OT=0; RT=0
+        # One entry per content block repeats one request's usage; dedupe on
+        # .message.id so every request is counted exactly once.
+        while IFS= read -r f; do
+          row=$(jq -rn '
+            reduce inputs as $l ({seen:{},m:null,it:0,ct:0,ot:0,rt:0};
+              if $l.type == "assistant" and ($l.message.usage // null) != null then
+                ($l.message.id // "no-id") as $id
+                | if .seen[$id] then . else
+                    .seen[$id] = 1
+                    | .it += ($l.message.usage.input_tokens // 0)
+                    | .ct += (($l.message.usage.cache_read_input_tokens // 0)
+                              + ($l.message.usage.cache_creation_input_tokens // 0))
+                    | .ot += ($l.message.usage.output_tokens // 0)
+                    | .rt += ($l.message.usage.output_tokens_details.thinking_tokens // 0)
+                    | (if .m == null then .m = ($l.message.model // null) else . end)
+                  end
+              elif $l.type == "assistant" and ($l.message.model // null) != null and .m == null then
+                .m = $l.message.model
+              else . end)
+            | [.m, .it, .ct, .ot, .rt] | @tsv' "$f" 2>/dev/null || true)
+          [ -n "$row" ] || continue
+          IFS=$'\t' read -r m it ct ot rt <<<"$row"
+          [ -n "$m" ] && [ -z "$MODEL_LOG" ] && MODEL_LOG=$m
+          IT=$((IT + ${it:-0}))
+          CT=$((CT + ${ct:-0}))
+          OT=$((OT + ${ot:-0}))
+          RT=$((RT + ${rt:-0}))
+        done <<FMINNER
+$files
+FMINNER
+      fi
+    fi
+    ;;
+  codex)
+    if [ -n "$WORKTREE" ]; then
+      files=$(matched_files "$CODEX_DIR" "")
+      if [ -n "$files" ]; then
+        IT=0; CT=0; OT=0; RT=0
+        found=0
+        while IFS= read -r f; do
+          row=$(jq -rn '
+            reduce inputs as $l ({cwd:null,m:null,it:0,ct:0,ot:0,rt:0};
+              if $l.type == "session_meta" then
+                .cwd = ($l.payload.cwd // .cwd)
+              elif $l.type == "turn_context" and ($l.payload.model // null) != null then
+                .m = $l.payload.model
+              elif $l.type == "event_msg" and $l.payload.type == "token_count"
+                   and ($l.payload.info.last_token_usage // null) != null then
+                .it += ($l.payload.info.last_token_usage.input_tokens // 0)
+                | .ct += (($l.payload.info.last_token_usage.cached_input_tokens // 0)
+                          + ($l.payload.info.last_token_usage.cache_write_input_tokens // 0))
+                | .ot += ($l.payload.info.last_token_usage.output_tokens // 0)
+                | .rt += ($l.payload.info.last_token_usage.reasoning_output_tokens // 0)
+              else . end)
+            | [.cwd, .m, .it, .ct, .ot, .rt] | @tsv' "$f" 2>/dev/null || true)
+          [ -n "$row" ] || continue
+          IFS=$'\t' read -r cwd m it ct ot rt <<<"$row"
+          [ "$cwd" = "$WORKTREE" ] || continue
+          found=1
+          SRC=codex-sessions
+          [ -n "$m" ] && [ -z "$MODEL_LOG" ] && MODEL_LOG=$m
+          IT=$((IT + ${it:-0}))
+          CT=$((CT + ${ct:-0}))
+          OT=$((OT + ${ot:-0}))
+          RT=$((RT + ${rt:-0}))
+        done <<FMINNER
+$files
+FMINNER
+        [ "$found" -eq 1 ] || SRC=unavailable
+      fi
+    fi
+    ;;
+esac
+
+if [ "$SRC" = unavailable ]; then
+  MODEL_LOG=
+  IT=null; CT=null; OT=null; RT=null
+fi
+
+MODEL=${MODEL_LOG:-$MODEL_META}
+EFFORT=$EFFORT_META
+
+SPAWNED=$(iso_from_epoch "$START_EPOCH" || true)
+COMPLETED=$(iso_from_epoch "$END_EPOCH" || true)
+
+jq -cn \
+  --arg task "$ID" --arg harness "$HARNESS" \
+  --arg model "$MODEL" --arg effort "$EFFORT" \
+  --arg spawned "$SPAWNED" --arg completed "$COMPLETED" \
+  --argjson wall "$WALL" --argjson turns "$TURNS" \
+  --argjson it "$IT" --argjson ct "$CT" --argjson ot "$OT" --argjson rt "$RT" \
+  --arg source "$SRC" \
+  '{task:$task, harness:$harness,
+    model:(if ($model == "" or $model == "default") then null else $model end),
+    effort:(if ($effort == "" or $effort == "default") then null else $effort end),
+    spawned_at:(if $spawned == "" then null else $spawned end),
+    completed_at:(if $completed == "" then null else $completed end),
+    wall_secs:$wall, turns:$turns,
+    input_tokens:$it, cached_input_tokens:$ct, output_tokens:$ot,
+    reasoning_tokens:$rt, source:$source}' >> "$DATA/usage-ledger.jsonl.tmp.$$"
+mkdir -p -- "$DATA"
+cat "$DATA/usage-ledger.jsonl.tmp.$$" >> "$LEDGER" && rm -f -- "$DATA/usage-ledger.jsonl.tmp.$$"

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -70,10 +70,11 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CLAUDE_DIR="${FM_USAGE_CLAUDE_DIR:-${HOME:-}/.claude/projects}"
 CODEX_DIR="${FM_USAGE_CODEX_DIR:-${HOME:-}/.codex/sessions}"
 
-# Portable directory-lock helpers (fm_lock_acquire_wait / fm_lock_release) let
+# Portable directory-lock helpers (fm_lock_try_acquire / fm_lock_release) let
 # the idempotent check-and-append below run as one critical section, so two
 # concurrent harvests of the same task cannot both pass the existence check and
-# each append a duplicate row.
+# each append a duplicate row. The acquire is bounded (see below) so it never
+# blocks the synchronous teardown caller indefinitely.
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
@@ -272,8 +273,24 @@ mkdir -p -- "$DATA"
 # lock, then test for an existing row for this task and append only when
 # absent. Two concurrent harvests of the same task cannot both pass the
 # existence test and each append a duplicate row.
+#
+# The acquire is BOUNDED, not fm_lock_acquire_wait's unbounded spin, because
+# this runs synchronously inside teardown: a wedged live holder must never
+# block teardown from retiring the task. fm_lock_try_acquire already steals a
+# dead owner's lock, so only a live concurrent harvest makes us wait, and its
+# critical section is a grep plus an append. If the lock stays busy past the
+# bound we give up best-effort (exit 1, which teardown warns on and continues)
+# rather than duplicate the row by appending unserialized.
 LEDGER_LOCK="$DATA/.usage-ledger.lock"
-fm_lock_acquire_wait "$LEDGER_LOCK"
+LEDGER_LOCK_WAIT=${FM_USAGE_LEDGER_LOCK_WAIT:-30}
+lock_deadline=$(( $(date +%s) + LEDGER_LOCK_WAIT ))
+until fm_lock_try_acquire "$LEDGER_LOCK"; do
+  if [ "$(date +%s)" -ge "$lock_deadline" ]; then
+    err "ledger lock busy after ${LEDGER_LOCK_WAIT}s; skipping harvest for $ID"
+    exit 1
+  fi
+  sleep 0.1
+done
 LEDGER_LOCK_HELD=1
 if [ -f "$LEDGER" ] && grep -qF "\"task\":\"$ID\"" "$LEDGER" 2>/dev/null; then
   exit 0

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -43,8 +43,10 @@
 #     output_tokens, reasoning_output_tokens); summing those deltas equals the
 #     final cumulative total. cached_input_tokens folds cached + cache_write
 #     (subsets of input_tokens); the model comes from the turn_context.
-#   harness=cursor, an absent log tree, or no in-window match: token fields
-#     are null with source "unavailable".
+#   harness=cursor, a task with a recorded remote_host (its worker ran on
+#     another machine, so its logs are not on this filesystem), an absent log
+#     tree, or no in-window match: token fields are null with source
+#     "unavailable".
 # A corrupt log line is skipped best-effort by the parser.
 #
 # Idempotent: if the ledger already contains a line whose "task" is
@@ -68,6 +70,13 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CLAUDE_DIR="${FM_USAGE_CLAUDE_DIR:-${HOME:-}/.claude/projects}"
 CODEX_DIR="${FM_USAGE_CODEX_DIR:-${HOME:-}/.codex/sessions}"
 
+# Portable directory-lock helpers (fm_lock_acquire_wait / fm_lock_release) let
+# the idempotent check-and-append below run as one critical section, so two
+# concurrent harvests of the same task cannot both pass the existence check and
+# each append a duplicate row.
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
 err() { printf 'error: %s\n' "$1" >&2; }
 
 if [ "$#" -ne 1 ] || [ -z "$1" ] || case "$1" in *[!A-Za-z0-9._-]*) true ;; *) false ;; esac; then
@@ -88,6 +97,12 @@ HARNESS=$(meta_get harness)
 WORKTREE=$(meta_get worktree)
 MODEL_META=$(meta_get model)
 EFFORT_META=$(meta_get effort)
+# A remote secondmate's worker ran on another machine, so its session logs are
+# not on this filesystem. Harvesting the local claude/codex trees for such a
+# task would at best find nothing and at worst misattribute an unrelated local
+# session that happens to match the worktree path, so a task with a recorded
+# remote_host is recorded as source=unavailable without a local scan.
+REMOTE_HOST=$(meta_get remote_host)
 
 file_mtime_epoch() {  # <file>
   local t
@@ -120,7 +135,15 @@ case "$TURNS" in ''|*[!0-9]*) TURNS=0 ;; esac
 # Ref files pin find's mtime window portably (BSD and GNU find both compare
 # against -newer file mtimes, and touch -t exists on both).
 REFDIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-usage-harvest.XXXXXX")
-trap 'rm -rf -- "$REFDIR"' EXIT
+LEDGER_LOCK=
+LEDGER_LOCK_HELD=0
+harvest_cleanup() {
+  local rc=$?
+  [ "$LEDGER_LOCK_HELD" != 1 ] || fm_lock_release "$LEDGER_LOCK" || true
+  rm -rf -- "$REFDIR"
+  return "$rc"
+}
+trap harvest_cleanup EXIT
 epoch_to_touch() {  # <epoch>
   date -r "$1" +%Y%m%d%H%M.%S 2>/dev/null || date -u -d "@$1" +%Y%m%d%H%M.%S
 }
@@ -155,7 +178,7 @@ matched_files() {  # <dir> <maxdepth-or-empty> : print in-window *.jsonl paths
 IT=null; CT=null; OT=null; RT=null
 case "$HARNESS" in
   claude)
-    if [ -n "$WORKTREE" ]; then
+    if [ -z "$REMOTE_HOST" ] && [ -n "$WORKTREE" ]; then
       encoded=${WORKTREE//\//-}
       encoded=${encoded//./-}
       files=$(matched_files "$CLAUDE_DIR/$encoded" 1)
@@ -196,7 +219,7 @@ FMINNER
     fi
     ;;
   codex)
-    if [ -n "$WORKTREE" ]; then
+    if [ -z "$REMOTE_HOST" ] && [ -n "$WORKTREE" ]; then
       files=$(matched_files "$CODEX_DIR" "")
       if [ -n "$files" ]; then
         IT=0; CT=0; OT=0; RT=0
@@ -248,6 +271,18 @@ SPAWNED=$(iso_from_epoch "$START_EPOCH" || true)
 COMPLETED=$(iso_from_epoch "$END_EPOCH" || true)
 
 mkdir -p -- "$DATA"
+# Serialize the check-and-append: the unlocked pre-check above is only a fast
+# path, so acquire the ledger lock and re-test under it before writing. Two
+# concurrent harvests of the same task then cannot both append a row.
+LEDGER_LOCK="$DATA/.usage-ledger.lock"
+fm_lock_acquire_wait "$LEDGER_LOCK"
+LEDGER_LOCK_HELD=1
+if [ -f "$LEDGER" ] && grep -qF "\"task\":\"$ID\"" "$LEDGER" 2>/dev/null; then
+  exit 0
+fi
+# Test seam: widen the check-to-append window so a concurrency regression (a
+# removed lock) is observable deterministically; unset in production.
+[ -z "${FM_USAGE_HARVEST_APPEND_DELAY:-}" ] || sleep "$FM_USAGE_HARVEST_APPEND_DELAY"
 jq -cn \
   --arg task "$ID" --arg harness "$HARNESS" \
   --arg model "$MODEL" --arg effort "$EFFORT" \

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -103,10 +103,13 @@
 #   FM_USAGE_CLAUDE_DIR   default $HOME/.claude/projects
 #   FM_USAGE_CODEX_DIR    default $HOME/.codex/sessions
 #   FM_USAGE_PI_DIR       default $HOME/.pi/agent/sessions
+#   FM_USAGE_LEDGER_LOCK_WAIT      seconds to wait for the ledger lock, default 30
+#   FM_USAGE_HARVEST_APPEND_DELAY  test-only delay inside the ledger critical section
 #
 # Exit status: 0 on a successful or already-present harvest, 1 on a missing
-# task record, missing jq, or an unwritable ledger. Callers that must not
-# block (teardown) own their own guard.
+# task record, missing jq, an unwritable ledger, or a ledger lock still held by
+# a live concurrent harvest past FM_USAGE_LEDGER_LOCK_WAIT. Callers that must
+# not block (teardown) own their own guard.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -431,5 +431,4 @@ jq -cn \
     completed_at:(if $completed == "" then null else $completed end),
     wall_secs:$wall, turns:$turns,
     input_tokens:$it, cached_input_tokens:$ct, output_tokens:$ot,
-    reasoning_tokens:$rt, source:$source}' >> "$DATA/usage-ledger.jsonl.tmp.$$"
-cat "$DATA/usage-ledger.jsonl.tmp.$$" >> "$LEDGER" && rm -f -- "$DATA/usage-ledger.jsonl.tmp.$$"
+    reasoning_tokens:$rt, source:$source}' >> "$LEDGER"

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -17,13 +17,20 @@
 #    "wall_secs":<int>,"turns":<int>,
 #    "input_tokens":<int|null>,"cached_input_tokens":<int|null>,
 #    "output_tokens":<int|null>,"reasoning_tokens":<int|null>,
-#    "source":<claude-projects|codex-sessions|unavailable>}
+#    "source":<claude-projects|codex-sessions|pi-sessions|unavailable>}
 #
-# Wall clock: status-file birth epoch -> status-file mtime epoch; the meta
-# file's mtime is the fallback end when the status file is absent, and a
-# missing birth timestamp falls back to the meta-file mtime (the spawn-time
-# marker, portable where birth time is unavailable) and then the status mtime
-# as the start.
+# Wall clock: task start epoch -> status-file mtime epoch; the meta file's
+# mtime is the fallback end when the status file is absent.
+# The start comes from the epoch embedded in the meta's
+# spawn_gen=s<epoch>.<pid>.<random> incarnation token, which fm-spawn writes
+# once per spawn or relaunch and never rewrites afterwards. The meta file's
+# own mtime is NOT a start source in its own right: later meta writes (PR
+# registration, busy-state updates) move it forward to near the end of the
+# task and collapse the window. Only when spawn_gen is absent or malformed
+# (a task spawned before that token existed) does the start fall back to the
+# status-file birth epoch, then the meta mtime, then the status mtime.
+# A start later than the end (a relaunch with no status append after it) is
+# pinned to the end so spawned_at never postdates completed_at.
 # Turn estimate: count of "^working:" lines in the status file.
 #
 # Per-request usage sources:
@@ -43,6 +50,18 @@
 #     output_tokens, reasoning_output_tokens); summing those deltas equals the
 #     final cumulative total. cached_input_tokens folds cached + cache_write
 #     (subsets of input_tokens); the model comes from the turn_context.
+#   harness=pi, harness=pi-signed: <pi-sessions>/**/*.jsonl in the task window
+#     whose "session" record's cwd equals the meta worktree. Both adapters run
+#     the same Pi application and share one ~/.pi/agent state tree, so one
+#     scan covers them. Each assistant "message" record carries one API
+#     request's usage at .message.usage (input, cacheRead, cacheWrite, output,
+#     reasoning) and Pi writes one record per message rather than one per
+#     content block; records are still deduped by the record's own .id where
+#     present so a replayed line cannot double-count. cached_input_tokens
+#     folds cacheRead + cacheWrite; reasoning_tokens captures .reasoning (a
+#     subset of output). The model is reported provider-qualified as
+#     "<provider>/<model>" to match the model spelling fm-spawn records in the
+#     meta, and bare when the record carries no provider.
 #   harness=cursor, a task with a recorded remote_host (its worker ran on
 #     another machine, so its logs are not on this filesystem), an absent log
 #     tree, or no in-window match: token fields are null with source
@@ -56,6 +75,7 @@
 #   FM_ROOT_OVERRIDE, FM_HOME, FM_STATE_OVERRIDE, FM_DATA_OVERRIDE  as usual
 #   FM_USAGE_CLAUDE_DIR   default $HOME/.claude/projects
 #   FM_USAGE_CODEX_DIR    default $HOME/.codex/sessions
+#   FM_USAGE_PI_DIR       default $HOME/.pi/agent/sessions
 #
 # Exit status: 0 on a successful or already-present harvest, 1 on a missing
 # task record, missing jq, or an unwritable ledger. Callers that must not
@@ -69,6 +89,7 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CLAUDE_DIR="${FM_USAGE_CLAUDE_DIR:-${HOME:-}/.claude/projects}"
 CODEX_DIR="${FM_USAGE_CODEX_DIR:-${HOME:-}/.codex/sessions}"
+PI_DIR="${FM_USAGE_PI_DIR:-${HOME:-}/.pi/agent/sessions}"
 
 # Portable directory-lock helpers (fm_lock_try_acquire / fm_lock_release) let
 # the idempotent check-and-append below run as one critical section, so two
@@ -104,6 +125,7 @@ EFFORT_META=$(meta_get effort)
 # session that happens to match the worktree path, so a task with a recorded
 # remote_host is recorded as source=unavailable without a local scan.
 REMOTE_HOST=$(meta_get remote_host)
+SPAWN_GEN=$(meta_get spawn_gen)
 
 file_mtime_epoch() {  # <file>
   local t
@@ -126,10 +148,24 @@ iso_from_epoch() {  # <epoch>
     || return 1
 }
 
+spawn_gen_epoch() {  # <spawn_gen token>
+  local e
+  case "$1" in s[0-9]*) ;; *) return 1 ;; esac
+  e=${1#s}
+  e=${e%%.*}
+  # The same plausible-epoch guard used for birth times rejects a token whose
+  # leading field is not a real second count.
+  case "$e" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$e" -ge 1000000000 ] 2>/dev/null || return 1
+  printf '%s' "$e"
+}
+
 END_EPOCH=$(file_mtime_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$META")
-START_EPOCH=$(file_birth_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$META" 2>/dev/null || file_mtime_epoch "$STATUS" 2>/dev/null || printf '%s' "$END_EPOCH")
+START_EPOCH=$(spawn_gen_epoch "$SPAWN_GEN" 2>/dev/null || file_birth_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$META" 2>/dev/null || file_mtime_epoch "$STATUS" 2>/dev/null || printf '%s' "$END_EPOCH")
+# Pin an impossible start to the end rather than inverting the window, which
+# would both report a negative duration and drop every session log.
+[ "$START_EPOCH" -le "$END_EPOCH" ] 2>/dev/null || START_EPOCH=$END_EPOCH
 WALL=$((END_EPOCH - START_EPOCH))
-[ "$WALL" -ge 0 ] || WALL=0
 TURNS=$(grep -c '^working:' "$STATUS" 2>/dev/null || true)
 case "$TURNS" in ''|*[!0-9]*) TURNS=0 ;; esac
 
@@ -243,6 +279,52 @@ FMINNER
           [ "$cwd" = "$WORKTREE" ] || continue
           found=1
           SRC=codex-sessions
+          [ -n "$m" ] && [ -z "$MODEL_LOG" ] && MODEL_LOG=$m
+          IT=$((IT + ${it:-0}))
+          CT=$((CT + ${ct:-0}))
+          OT=$((OT + ${ot:-0}))
+          RT=$((RT + ${rt:-0}))
+        done <<FMINNER
+$files
+FMINNER
+        [ "$found" -eq 1 ] || SRC=unavailable
+      fi
+    fi
+    ;;
+  pi|pi-signed)
+    if [ -z "$REMOTE_HOST" ] && [ -n "$WORKTREE" ]; then
+      files=$(matched_files "$PI_DIR" "")
+      if [ -n "$files" ]; then
+        IT=0; CT=0; OT=0; RT=0
+        found=0
+        while IFS= read -r f; do
+          row=$(jq -rn '
+            reduce inputs as $l ({cwd:null,seen:{},m:null,it:0,ct:0,ot:0,rt:0};
+              if $l.type == "session" then
+                .cwd = ($l.cwd // .cwd)
+              elif $l.type == "message" and $l.message.role == "assistant"
+                   and ($l.message.usage // null) != null then
+                ($l.id // null) as $id
+                | if $id != null and .seen[$id] then . else
+                    (if $id == null then . else .seen[$id] = 1 end)
+                    | .it += ($l.message.usage.input // 0)
+                    | .ct += (($l.message.usage.cacheRead // 0)
+                              + ($l.message.usage.cacheWrite // 0))
+                    | .ot += ($l.message.usage.output // 0)
+                    | .rt += ($l.message.usage.reasoning // 0)
+                    | (if .m == null and ($l.message.model // null) != null then
+                         .m = (if ($l.message.provider // null) != null
+                               then ($l.message.provider + "/" + $l.message.model)
+                               else $l.message.model end)
+                       else . end)
+                  end
+              else . end)
+            | [.cwd, .m, .it, .ct, .ot, .rt] | @tsv' "$f" 2>/dev/null || true)
+          [ -n "$row" ] || continue
+          IFS=$'\t' read -r cwd m it ct ot rt <<<"$row"
+          [ "$cwd" = "$WORKTREE" ] || continue
+          found=1
+          SRC=pi-sessions
           [ -n "$m" ] && [ -z "$MODEL_LOG" ] && MODEL_LOG=$m
           IT=$((IT + ${it:-0}))
           CT=$((CT + ${ct:-0}))

--- a/bin/fm-usage-report.sh
+++ b/bin/fm-usage-report.sh
@@ -12,7 +12,12 @@
 # "-". The ledger's @tsv rows are read over the unit separator rather than the
 # tab, because tab is an IFS whitespace character and an empty field would
 # otherwise collapse and shift every later column left.
-# Exit status: 0 including when the ledger is absent or empty.
+#
+# Both renderings are computed BEFORE the first line is printed, so a ledger
+# that jq cannot parse fails with a named diagnostic and a non-zero status
+# instead of emitting a physical row count above empty sections.
+# Exit status: 0 including when the ledger is absent or empty; 1 when the
+# ledger exists but does not parse as JSON lines.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -28,34 +33,49 @@ if [ ! -s "$LEDGER" ]; then
   exit 0
 fi
 
-printf 'usage ledger: %s (%s rows)\n' "$LEDGER" "$(wc -l < "$LEDGER" | tr -d ' ')"
-echo
-echo "per-model totals (source-available rows):"
-printf '%-24s %6s %12s %12s %12s %12s %10s\n' \
-  model tasks input cached output reasoning wall_secs
-jq -rs '
+# Render both sections first: an unparseable ledger must not be reported as a
+# successful run with a row count and empty sections below it.
+if ! MODEL_ROWS=$(jq -rs '
   [.[] | select(.source != "unavailable")] | sort_by(.model // "?") | group_by(.model // "?")[]
   | [ (.[0].model // "?"), (length | tostring),
       (map(.input_tokens // 0) | add | tostring),
       (map(.cached_input_tokens // 0) | add | tostring),
       (map(.output_tokens // 0) | add | tostring),
       (map(.reasoning_tokens // 0) | add | tostring),
-      (map(.wall_secs // 0) | add | tostring) ] | @tsv' "$LEDGER" | tr '\t' '\037' |
-while IFS=$'\037' read -r model tasks it ct ot rt wall; do
-  printf '%-24s %6s %12s %12s %12s %12s %10s\n' \
-    "$model" "$tasks" "$it" "$ct" "$ot" "$rt" "$wall"
-done
-echo
-echo "per-task rows:"
-printf '%-24s %-8s %-20s %-8s %12s %12s %12s %12s %10s %-16s\n' \
-  task harness model effort input cached output reasoning wall_secs source
-jq -r '
+      (map(.wall_secs // 0) | add | tostring) ] | @tsv' "$LEDGER"); then
+  printf 'error: %s: ledger is not readable as JSON lines\n' "$LEDGER" >&2
+  exit 1
+fi
+if ! TASK_ROWS=$(jq -r '
   [ (.task // "-"), (.harness // "-"),
     (.model // "-"), (.effort // "-"),
     (.input_tokens // "-"), (.cached_input_tokens // "-"),
     (.output_tokens // "-"), (.reasoning_tokens // "-"),
-    (.wall_secs // "-"), (.source // "-") ] | @tsv' "$LEDGER" | tr '\t' '\037' |
-while IFS=$'\037' read -r task harness model effort it ct ot rt wall source; do
-  printf '%-24s %-8s %-20s %-8s %12s %12s %12s %12s %10s %-16s\n' \
-    "$task" "$harness" "$model" "$effort" "$it" "$ct" "$ot" "$rt" "$wall" "$source"
-done
+    (.wall_secs // "-"), (.source // "-") ] | @tsv' "$LEDGER"); then
+  printf 'error: %s: ledger is not readable as JSON lines\n' "$LEDGER" >&2
+  exit 1
+fi
+
+printf 'usage ledger: %s (%s rows)\n' "$LEDGER" "$(wc -l < "$LEDGER" | tr -d ' ')"
+echo
+echo "per-model totals (source-available rows):"
+printf '%-24s %6s %12s %12s %12s %12s %10s\n' \
+  model tasks input cached output reasoning wall_secs
+if [ -n "$MODEL_ROWS" ]; then
+  printf '%s\n' "$MODEL_ROWS" | tr '\t' '\037' |
+  while IFS=$'\037' read -r model tasks it ct ot rt wall; do
+    printf '%-24s %6s %12s %12s %12s %12s %10s\n' \
+      "$model" "$tasks" "$it" "$ct" "$ot" "$rt" "$wall"
+  done
+fi
+echo
+echo "per-task rows:"
+printf '%-24s %-8s %-20s %-8s %12s %12s %12s %12s %10s %-16s\n' \
+  task harness model effort input cached output reasoning wall_secs source
+if [ -n "$TASK_ROWS" ]; then
+  printf '%s\n' "$TASK_ROWS" | tr '\t' '\037' |
+  while IFS=$'\037' read -r task harness model effort it ct ot rt wall source; do
+    printf '%-24s %-8s %-20s %-8s %12s %12s %12s %12s %10s %-16s\n' \
+      "$task" "$harness" "$model" "$effort" "$it" "$ct" "$ot" "$rt" "$wall" "$source"
+  done
+fi

--- a/bin/fm-usage-report.sh
+++ b/bin/fm-usage-report.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# fm-usage-report.sh - plain-text reader for data/usage-ledger.jsonl.
+#
+# Usage: fm-usage-report.sh [ledger-path]
+#
+# Prints per-model totals and one row per task from the usage ledger written
+# by fm-usage-harvest.sh (that file owns the line schema; this script only
+# consumes it). With no argument the ledger resolves from the operational
+# home exactly as the harvester does.
+#
+# Output is aligned plain text; unavailable token fields render as "-".
+# Exit status: 0 including when the ledger is absent or empty.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+
+command -v jq >/dev/null 2>&1 || { printf 'error: jq is required\n' >&2; exit 1; }
+
+LEDGER=${1:-$DATA/usage-ledger.jsonl}
+if [ ! -s "$LEDGER" ]; then
+  printf 'no usage ledger at %s\n' "$LEDGER"
+  exit 0
+fi
+
+printf 'usage ledger: %s (%s rows)\n' "$LEDGER" "$(wc -l < "$LEDGER" | tr -d ' ')"
+echo
+echo "per-model totals (source-available rows):"
+printf '%-24s %6s %12s %12s %12s %12s %10s\n' \
+  model tasks input cached output reasoning wall_secs
+jq -rs '
+  [.[] | select(.source != "unavailable")] | sort_by(.model // "?") | group_by(.model // "?")[]
+  | [ (.[0].model // "?"), (length | tostring),
+      (map(.input_tokens // 0) | add | tostring),
+      (map(.cached_input_tokens // 0) | add | tostring),
+      (map(.output_tokens // 0) | add | tostring),
+      (map(.reasoning_tokens // 0) | add | tostring),
+      (map(.wall_secs // 0) | add | tostring) ] | @tsv' "$LEDGER" |
+while IFS=$'\t' read -r model tasks it ct ot rt wall; do
+  printf '%-24s %6s %12s %12s %12s %12s %10s\n' \
+    "$model" "$tasks" "$it" "$ct" "$ot" "$rt" "$wall"
+done
+echo
+echo "per-task rows:"
+printf '%-24s %-8s %-20s %-8s %12s %12s %12s %12s %10s %-16s\n' \
+  task harness model effort input cached output reasoning wall_secs source
+jq -r '
+  [ .task, .harness,
+    (.model // "-"), (.effort // "-"),
+    (.input_tokens // "-"), (.cached_input_tokens // "-"),
+    (.output_tokens // "-"), (.reasoning_tokens // "-"),
+    (.wall_secs // "-"), .source ] | @tsv' "$LEDGER" |
+while IFS=$'\t' read -r task harness model effort it ct ot rt wall source; do
+  printf '%-24s %-8s %-20s %-8s %12s %12s %12s %12s %10s %-16s\n' \
+    "$task" "$harness" "$model" "$effort" "$it" "$ct" "$ot" "$rt" "$wall" "$source"
+done

--- a/bin/fm-usage-report.sh
+++ b/bin/fm-usage-report.sh
@@ -8,7 +8,10 @@
 # consumes it). With no argument the ledger resolves from the operational
 # home exactly as the harvester does.
 #
-# Output is aligned plain text; unavailable token fields render as "-".
+# Output is aligned plain text; an absent or unavailable field renders as
+# "-". The ledger's @tsv rows are read over the unit separator rather than the
+# tab, because tab is an IFS whitespace character and an empty field would
+# otherwise collapse and shift every later column left.
 # Exit status: 0 including when the ledger is absent or empty.
 set -eu
 
@@ -37,8 +40,8 @@ jq -rs '
       (map(.cached_input_tokens // 0) | add | tostring),
       (map(.output_tokens // 0) | add | tostring),
       (map(.reasoning_tokens // 0) | add | tostring),
-      (map(.wall_secs // 0) | add | tostring) ] | @tsv' "$LEDGER" |
-while IFS=$'\t' read -r model tasks it ct ot rt wall; do
+      (map(.wall_secs // 0) | add | tostring) ] | @tsv' "$LEDGER" | tr '\t' '\037' |
+while IFS=$'\037' read -r model tasks it ct ot rt wall; do
   printf '%-24s %6s %12s %12s %12s %12s %10s\n' \
     "$model" "$tasks" "$it" "$ct" "$ot" "$rt" "$wall"
 done
@@ -47,12 +50,12 @@ echo "per-task rows:"
 printf '%-24s %-8s %-20s %-8s %12s %12s %12s %12s %10s %-16s\n' \
   task harness model effort input cached output reasoning wall_secs source
 jq -r '
-  [ .task, .harness,
+  [ (.task // "-"), (.harness // "-"),
     (.model // "-"), (.effort // "-"),
     (.input_tokens // "-"), (.cached_input_tokens // "-"),
     (.output_tokens // "-"), (.reasoning_tokens // "-"),
-    (.wall_secs // "-"), .source ] | @tsv' "$LEDGER" |
-while IFS=$'\t' read -r task harness model effort it ct ot rt wall source; do
+    (.wall_secs // "-"), (.source // "-") ] | @tsv' "$LEDGER" | tr '\t' '\037' |
+while IFS=$'\037' read -r task harness model effort it ct ot rt wall source; do
   printf '%-24s %-8s %-20s %-8s %12s %12s %12s %12s %10s %-16s\n' \
     "$task" "$harness" "$model" "$effort" "$it" "$ct" "$ot" "$rt" "$wall" "$source"
 done

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -128,6 +128,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-merge-outcome-lib.sh` | Publish a confirmed merge's durable, role-routed supervision outcome                 |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode, and write the ship instructions carrying that mode's definition of done |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
+| `fm-usage-harvest.sh`    | Append one finished task's token, wall-clock, and turn cost to the gitignored usage ledger (sole owner of the ledger line schema) |
+| `fm-usage-report.sh`     | Read the usage ledger into a plain-text per-model and per-task cost report |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |
 | `fm-x-lib.sh`            | Shared Relay config, relay, and reply-threading helpers                              |

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -520,7 +520,7 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
   assert_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-spawn'$'\x1f''--text'$'\x1f''export GOTMPDIR=/tmp/fm-orcaspawnz1/gotmp'$'\x1f''--enter'$'\x1f''--json' \
     "spawn did not export GOTMPDIR through the Orca terminal"
-  assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions" \
+  assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode auto" \
     "spawn did not send the selected harness launch command through Orca"
   rm -rf "/tmp/fm-$id"
   pass "fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -767,7 +767,7 @@ test_spawn_secondmate_harness_model_token() {
   [ "$(meta_field "$meta" model)" = opus ] || fail "model-token: meta model not opus (got '$(meta_field "$meta" model)')"
   [ "$(meta_field "$meta" effort)" = default ] || fail "model-token: meta effort not default (got '$(meta_field "$meta" effort)')"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'opus'" \
+  assert_contains "$launch" "claude --permission-mode auto --model 'opus'" \
     "model-token: launch did not carry --model opus"
   assert_not_contains "$launch" "--effort" "model-token: launch must not carry an --effort flag"
   pass "C3 spawn: config/secondmate-harness's model token threads --model into the launch and meta"
@@ -789,7 +789,7 @@ test_spawn_secondmate_harness_model_and_effort_tokens() {
   [ "$(meta_field "$meta" model)" = opus ] || fail "model-effort-tokens: meta model not opus"
   [ "$(meta_field "$meta" effort)" = high ] || fail "model-effort-tokens: meta effort not high (got '$(meta_field "$meta" effort)')"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'opus' --effort 'high'" \
+  assert_contains "$launch" "claude --permission-mode auto --model 'opus' --effort 'high'" \
     "model-effort-tokens: launch did not carry both --model opus and --effort high"
   pass "C4 spawn: config/secondmate-harness's model+effort tokens thread into the launch and meta"
 }
@@ -854,7 +854,7 @@ test_spawn_explicit_harness_does_not_inherit_secondmate_harness_tokens() {
   [ "$(meta_field "$meta" model)" = default ] || fail "explicit-harness-no-tokens: meta model should stay default"
   [ "$(meta_field "$meta" effort)" = default ] || fail "explicit-harness-no-tokens: meta effort should stay default"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "codex --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex -s workspace-write -a never" \
     "explicit-harness-no-tokens: launch did not use codex"
   assert_not_contains "$launch" "--model" "explicit-harness-no-tokens: launch must not carry a --model flag"
   assert_not_contains "$launch" "model_reasoning_effort" \

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -131,7 +131,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode auto \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -345,7 +345,7 @@ test_active_dispatch_profile_allows_explicit_harness() {
   assert_contains "$out" "spawned $id harness=codex" "spawn did not report explicit codex harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' -s workspace-write -a never" \
     "explicit harness launch did not thread model and effort"
   pass "active crew-dispatch profile allows an explicit resolved harness"
 }
@@ -395,7 +395,7 @@ test_claude_threads_model_and_effort() {
   expect_code 0 "$status" "claude spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude sonnet high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
+  assert_contains "$launch" "claude --permission-mode auto --model 'sonnet' --effort 'high'" \
     "claude launch did not thread model and effort flags"
   assert_not_contains "$launch" "--tui-mode" "non-Pi launches must not receive Pi's TUI mode override"
   pass "claude receives --model and --effort profile flags"
@@ -412,7 +412,7 @@ test_codex_threads_model_and_effort() {
   expect_code 0 "$status" "codex spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' -s workspace-write -a never" \
     "codex launch did not thread model and reasoning effort config"
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
@@ -428,7 +428,7 @@ test_codex_omits_invalid_max_effort() {
   expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -s workspace-write -a never" \
     "codex launch did not preserve the model flag when max effort was omitted"
   assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
   pass "codex omits unsupported max effort instead of passing a bad config value"
@@ -500,7 +500,7 @@ test_cursor_threads_model_workspace_and_omits_effort_axis() {
   expect_code 0 "$status" "cursor spawn with a model-qualified reasoning class should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" cursor cursor-grok-4.5-high high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "--trust --yolo --model 'cursor-grok-4.5-high' --workspace '$WT_DIR'" \
+  assert_contains "$launch" "--trust --auto-review --sandbox enabled --model 'cursor-grok-4.5-high' --workspace '$WT_DIR'" \
     "cursor launch did not carry trust, autonomy, model, and exact workspace flags"
   # The executable is RESOLVED, never named: `cursor` is not the CLI, so a
   # literal `cursor agent` command cannot run on a machine that has only the

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # Behavior tests for the fleet usage harvester and its report reader.
 # Covers claude-log request dedupe and cache folding, codex per-request delta
-# sums with cwd/window matching, cursor/unavailable null rows, the
+# sums with cwd/window matching, pi/pi-signed session parsing over the shared
+# ~/.pi/agent/sessions tree, the durable spawn_gen task start that survives a
+# meta rewritten after the fact, cursor/unavailable null rows, the
 # no-double-append idempotency guard, the ledger report rendering, and the
-# teardown integration property that a harvest failure never blocks teardown.
+# teardown integration properties that the harvest sees the status log and
+# that a harvest failure never blocks teardown.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -31,6 +34,16 @@ file_birth_epoch() {  # <file>
   printf '%s' "$t"
 }
 
+# Portable epoch formatters: BSD date reads an epoch with -r, GNU date with
+# -d @<epoch>. Both forms are tried so the fixtures pin the same timestamps on
+# macOS and on the Linux CI runners.
+touch_stamp() {  # <epoch> : touch -t argument
+  date -r "$1" +%Y%m%d%H%M.%S 2>/dev/null || date -u -d "@$1" +%Y%m%d%H%M.%S
+}
+iso_utc() {  # <epoch> : the harvester's ledger timestamp spelling
+  date -r "$1" -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ
+}
+
 # harvest_case <id> <harness> [model] [effort] : create a home with one task
 # whose worktree is $TMP_ROOT/wt-<id>, status and meta included, and echo the
 # data dir. Exports the FM_USAGE_* fixture dirs per case.
@@ -54,7 +67,9 @@ export_harvest_env() {  # <home-data>
   FM_DATA_OVERRIDE="$1/data"
   FM_USAGE_CLAUDE_DIR="$TMP_ROOT/fake-claude/projects"
   FM_USAGE_CODEX_DIR="$TMP_ROOT/fake-codex/sessions"
+  FM_USAGE_PI_DIR="$TMP_ROOT/fake-pi/sessions"
   export FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_USAGE_CLAUDE_DIR FM_USAGE_CODEX_DIR
+  export FM_USAGE_PI_DIR
 }
 
 # --- claude: request dedupe, cache folding, encoding resolution, window -----
@@ -88,7 +103,7 @@ JSON
   cat > "$logdir/session-future.jsonl" <<'JSON'
 {"type":"assistant","message":{"id":"msgX","model":"claude-test","usage":{"input_tokens":999,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":999}}}
 JSON
-  touch -t "$(date -r $(( $(file_mtime_epoch "$state/$id.status") + 7200 )) +%Y%m%d%H%M.%S)" \
+  touch -t "$(touch_stamp $(( $(file_mtime_epoch "$state/$id.status") + 7200 )))" \
     "$logdir/session-future.jsonl"
   mkdir -p "$FM_USAGE_CLAUDE_DIR/wrong-encoded-dir"
   printf '%s\n' '{"type":"assistant","message":{"id":"msgY","model":"claude-test","usage":{"input_tokens":777,"output_tokens":777}}}' \
@@ -159,7 +174,7 @@ JSON
 {"type":"session_meta","payload":{"cwd":"$wt"}}
 {"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":999,"output_tokens":999}}}}
 JSON
-  touch -t "$(date -r $(( $(file_mtime_epoch "$home/state/$id.status") + 7200 )) +%Y%m%d%H%M.%S)" \
+  touch -t "$(touch_stamp $(( $(file_mtime_epoch "$home/state/$id.status") + 7200 )))" \
     "$d1/rollout-future.jsonl"
   touch -m -r "$d1/rollout-match.jsonl" "$home/state/$id.status"
 
@@ -176,6 +191,155 @@ JSON
   assert_contains "$row" '"output_tokens":31' "codex output sums deltas (20+11)"
   assert_contains "$row" '"reasoning_tokens":11' "codex reasoning sums deltas (8+3)"
   pass "codex harvest: cwd/window matching, delta sums, model capture"
+}
+
+# --- pi / pi-signed: shared session tree, cwd match, per-message usage -------
+
+# pi_session_log <file> <cwd> : one realistic Pi session log. The session
+# record carries the cwd; each assistant message record carries one request's
+# usage. The second record repeats the first record's id, standing in for a
+# replayed line that must not be counted twice.
+pi_session_log() {  # <file> <cwd>
+  cat > "$1" <<JSON
+{"type":"session","version":3,"id":"sess-1","timestamp":"2026-08-31T04:46:40.383Z","cwd":"$2"}
+{"type":"model_change","id":"mc1","timestamp":"2026-08-31T04:46:57.742Z","provider":"zai","modelId":"glm-5.3-flash"}
+{"type":"message","id":"m1","timestamp":"2026-08-31T04:47:00.000Z","message":{"role":"assistant","provider":"zai","model":"glm-5.3-flash","usage":{"input":100,"output":20,"cacheRead":30,"cacheWrite":4,"reasoning":7,"totalTokens":150}}}
+{"type":"message","id":"m1","timestamp":"2026-08-31T04:47:00.000Z","message":{"role":"assistant","provider":"zai","model":"glm-5.3-flash","usage":{"input":100,"output":20,"cacheRead":30,"cacheWrite":4,"reasoning":7,"totalTokens":150}}}
+{"type":"message","id":"u1","timestamp":"2026-08-31T04:47:05.000Z","message":{"role":"user"}}
+{"type":"message","id":"m2","timestamp":"2026-08-31T04:47:09.000Z","message":{"role":"assistant","provider":"zai","model":"glm-5.3-flash","usage":{"input":11,"output":3,"cacheRead":5,"cacheWrite":0,"reasoning":1,"totalTokens":19}}}
+{"type":"message","id":"tr1","timestamp":"2026-08-31T04:47:11.000Z","message":{"role":"toolResult"}}
+JSON
+}
+
+pi_case() {  # <task-id> <harness>
+  local id=$1 harness=$2 wt="$TMP_ROOT/wt-$1"
+  local data home ledger row out d1
+  data=$(harvest_case "$id" "$harness" "$wt" default high)
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+
+  # Pi keys its session directories off the worker cwd, but the cwd recorded
+  # inside the session record is what binds a log to this task, so the fixture
+  # directory names are deliberately opaque here.
+  d1="$FM_USAGE_PI_DIR/--encoded-match--"
+  mkdir -p "$d1"
+  pi_session_log "$d1/session-match.jsonl" "$wt"
+  # Same window, different cwd: must be excluded.
+  mkdir -p "$FM_USAGE_PI_DIR/--encoded-other--"
+  pi_session_log "$FM_USAGE_PI_DIR/--encoded-other--/session-other.jsonl" /elsewhere
+  # Matching cwd but outside the task window: must be excluded.
+  pi_session_log "$d1/session-future.jsonl" "$wt"
+  touch -t "$(touch_stamp $(( $(file_mtime_epoch "$home/state/$id.status") + 7200 )))" \
+    "$d1/session-future.jsonl"
+  touch -m -r "$d1/session-match.jsonl" "$home/state/$id.status"
+
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "$harness harvest should succeed"$'\n'"$out"
+  ledger="$home/data/usage-ledger.jsonl"
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = 1 ] || fail "$harness harvest wrote more than one row"
+  row=$(cat "$ledger")
+  assert_contains "$row" "\"harness\":\"$harness\"" "$harness row names the harness"
+  assert_contains "$row" '"source":"pi-sessions"' "$harness row names its source"
+  assert_contains "$row" '"model":"zai/glm-5.3-flash"' \
+    "$harness row reports the provider-qualified log model"
+  assert_contains "$row" '"input_tokens":111' \
+    "$harness input sums one entry per request, replay deduped (100+11)"
+  assert_contains "$row" '"cached_input_tokens":39' \
+    "$harness cached folds cacheRead+cacheWrite (30+4+5+0)"
+  assert_contains "$row" '"output_tokens":23' "$harness output sums per request (20+3)"
+  assert_contains "$row" '"reasoning_tokens":8' "$harness reasoning sums per request (7+1)"
+  assert_contains "$row" '"effort":"high"' "$harness row carries meta effort"
+  pass "$harness harvest: cwd/window matching, per-request sums, replay dedupe"
+}
+
+# --- spawn_gen: the task start survives a meta rewritten after the fact ------
+
+# fm-spawn records spawn_gen=s<epoch>.<pid>.<random> once per incarnation and
+# never rewrites it, while later meta writes (PR registration, busy-state
+# updates) move the meta mtime forward to near the end of the task. Deriving
+# the start from that mtime collapsed the window to zero and dropped every
+# session log; the durable token must win.
+spawn_gen_case() {
+  local id=usagespawngen1 wt="$TMP_ROOT/.no-mistakes/wt-usagespawngen1"
+  local data home state ledger row out base encoded logdir
+  data=$(harvest_case "$id" claude "$wt" default default)
+  home=$(dirname "$data")
+  state="$home/state"
+  export_harvest_env "$home"
+
+  encoded=${wt//\//-}
+  encoded=${encoded//./-}
+  logdir="$FM_USAGE_CLAUDE_DIR/$encoded"
+  mkdir -p "$logdir"
+  cat > "$logdir/session.jsonl" <<'JSON'
+{"type":"assistant","message":{"id":"msgS","model":"claude-test","usage":{"input_tokens":42,"output_tokens":6}}}
+JSON
+
+  base=$(file_mtime_epoch "$state/$id.status")
+  printf 'spawn_gen=s%s.4242.7\n' "$((base - 300))" >> "$state/$id.meta"
+  # The worker's last status line lands at the end of the task; the meta is
+  # then rewritten (PR registration), dragging its mtime up to the same point.
+  touch -t "$(touch_stamp "$base")" "$state/$id.status"
+  touch -t "$(touch_stamp "$base")" "$state/$id.meta"
+  # A real request logged 200s into the task, inside the true window only.
+  touch -t "$(touch_stamp $((base - 200)))" "$logdir/session.jsonl"
+
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "spawn_gen harvest should succeed"$'\n'"$out"
+  ledger="$data/usage-ledger.jsonl"
+  row=$(cat "$ledger")
+  assert_contains "$row" '"wall_secs":300' \
+    "wall clock spans the spawn token epoch -> last status append"
+  assert_contains "$row" "\"spawned_at\":\"$(iso_utc $((base - 300)))\"" \
+    "spawned_at reports the spawn token epoch"
+  assert_contains "$row" '"source":"claude-projects"' \
+    "the durable window still covers the mid-task session log"
+  assert_contains "$row" '"input_tokens":42' "the in-window request is summed"
+  pass "usage harvest: spawn_gen is the durable start, immune to later meta writes"
+}
+
+# A spawn_gen token that is absent or malformed (a task spawned before the
+# token existed, or a corrupt record) must fall back to the file-timestamp
+# chain rather than producing a bogus start.
+spawn_gen_malformed_case() {
+  local id=usagespawngen2 wt="$TMP_ROOT/wt-usagespawngen2"
+  local data home state ledger row out base
+  data=$(harvest_case "$id" cursor "$wt" cursor-x "")
+  home=$(dirname "$data")
+  state="$home/state"
+  export_harvest_env "$home"
+  printf 'spawn_gen=not-a-token\n' >> "$state/$id.meta"
+  base=$(file_mtime_epoch "$state/$id.status")
+  touch -t "$(touch_stamp "$base")" "$state/$id.status"
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "malformed spawn_gen harvest should succeed"$'\n'"$out"
+  row=$(cat "$data/usage-ledger.jsonl")
+  assert_contains "$row" "\"completed_at\":\"$(iso_utc "$base")\"" \
+    "malformed spawn_gen still reports the status-mtime end"
+  assert_contains "$row" '"wall_secs":0' \
+    "malformed spawn_gen falls back to the file-timestamp chain, never a bogus start"
+  pass "usage harvest: a malformed spawn_gen falls back to file timestamps"
+}
+
+# A spawn token that postdates the last status append (a relaunch with no
+# status line after it) must pin the start to the end, never invert the window.
+spawn_gen_future_case() {
+  local id=usagespawngen3 wt="$TMP_ROOT/wt-usagespawngen3"
+  local data home state row out base
+  data=$(harvest_case "$id" cursor "$wt" cursor-x "")
+  home=$(dirname "$data")
+  state="$home/state"
+  export_harvest_env "$home"
+  base=$(file_mtime_epoch "$state/$id.status")
+  printf 'spawn_gen=s%s.1.1\n' "$((base + 600))" >> "$state/$id.meta"
+  touch -t "$(touch_stamp "$base")" "$state/$id.status"
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "future spawn_gen harvest should succeed"$'\n'"$out"
+  row=$(cat "$data/usage-ledger.jsonl")
+  assert_contains "$row" '"wall_secs":0' "an impossible start never reports a negative duration"
+  assert_contains "$row" "\"spawned_at\":\"$(iso_utc "$base")\"" \
+    "an impossible start is pinned to the end, never postdating completed_at"
+  pass "usage harvest: a start later than the end is pinned, not inverted"
 }
 
 # --- cursor: unavailable logs render nulls ----------------------------------
@@ -246,9 +410,9 @@ JSON
   # and the session log lands mid-window. Without the meta-mtime start fallback
   # the birthless window collapses to [T, T] and drops the earlier log.
   base=$(file_mtime_epoch "$state/$id.status")
-  touch -t "$(date -r "$base" +%Y%m%d%H%M.%S)" "$state/$id.status"
-  touch -t "$(date -r $((base - 100)) +%Y%m%d%H%M.%S)" "$state/$id.meta"
-  touch -t "$(date -r $((base - 50)) +%Y%m%d%H%M.%S)" "$logdir/session.jsonl"
+  touch -t "$(touch_stamp "$base")" "$state/$id.status"
+  touch -t "$(touch_stamp $((base - 100)))" "$state/$id.meta"
+  touch -t "$(touch_stamp $((base - 50)))" "$logdir/session.jsonl"
 
   fb="$TMP_ROOT/nobirth-fakebin"
   nobirth_stat_bin "$fb"
@@ -352,14 +516,19 @@ lock_bound_case() {
 report_case() {
   local out ledger
   ledger="$TMP_ROOT/home-usageclaude1/data/usage-ledger.jsonl"
-  cat "$TMP_ROOT/home-usagecodex1/data/usage-ledger.jsonl" >> "$ledger"
-  cat "$TMP_ROOT/home-usagecursor1/data/usage-ledger.jsonl" >> "$ledger"
+  {
+    cat "$TMP_ROOT/home-usagecodex1/data/usage-ledger.jsonl"
+    cat "$TMP_ROOT/home-usagepi1/data/usage-ledger.jsonl"
+    cat "$TMP_ROOT/home-usagecursor1/data/usage-ledger.jsonl"
+  } >> "$ledger"
   out=$(FM_DATA_OVERRIDE="$(dirname "$ledger")" "$REPORT" 2>&1)
   expect_code 0 "$?" "report should succeed"$'\n'"$out"
-  assert_contains "$out" "usage ledger: $ledger (3 rows)" "report names the ledger and row count"
+  assert_contains "$out" "usage ledger: $ledger (4 rows)" "report names the ledger and row count"
   assert_contains "$out" "per-model totals" "report prints per-model totals"
   assert_contains "$out" "claude-test" "report lists the claude model"
   assert_contains "$out" "glm-5.3" "report lists the codex model"
+  assert_contains "$out" "zai/glm-5.3-flash" "report lists the provider-qualified pi model"
+  assert_contains "$out" "usagepi1" "report lists the pi task row"
   assert_contains "$out" "usageclaude1" "report lists each task row"
   assert_contains "$out" "usagecursor1" "report lists the unavailable task row"
   assert_contains "$out" "unavailable" "report shows the unavailable source"
@@ -368,6 +537,57 @@ report_case() {
   expect_code 0 "$?" "report without a ledger should exit 0"
   assert_contains "$out" "no usage ledger" "report names the missing ledger"
   pass "usage report: per-model totals, per-task rows, missing-ledger tolerance"
+}
+
+# --- teardown integration: the harvest still sees the task status log -------
+
+# Teardown deletes state/<id>.status when it retires the task's status
+# presentation. The harvest has to run before that, or it loses both the task
+# window and the turn count and every row degrades to a zero-duration,
+# zero-turn, source-unavailable line.
+teardown_status_case() {
+  local proj wt id fb state data config out row
+  id=usageharvtd2
+  proj="$TMP_ROOT/td2-proj"; wt="$TMP_ROOT/td2-wt"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  fb="$TMP_ROOT/td2-fakebin"
+  mkdir -p "$fb"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$fb/tmux"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$fb/treehouse"
+  chmod +x "$fb/tmux" "$fb/treehouse"
+  state="$TMP_ROOT/td2-state"; config="$TMP_ROOT/td2-config"; data="$TMP_ROOT/td2-data"
+  mkdir -p "$state" "$config" "$data/$id"
+  printf 'scout findings\n' > "$data/$id/report.md"
+  fm_write_meta "$state/$id.meta" \
+    "window=firstmate:fm-$id" "worktree=$wt" "project=$proj" "harness=claude" \
+    "kind=scout" "mode=no-mistakes" "yolo=off" \
+    "decisions_reviewed=1" "decision_keys="
+  {
+    printf 'working: scouting\n'
+    printf 'working: still scouting\n'
+    printf 'done: report written\n'
+  } > "$state/$id.status"
+  # A spawn 500s before the last status append, and a meta rewritten right at
+  # the end, exactly as a real PR registration leaves it.
+  local base
+  base=$(file_mtime_epoch "$state/$id.status")
+  printf 'spawn_gen=s%s.99.3\n' "$((base - 500))" >> "$state/$id.meta"
+  touch -t "$(touch_stamp "$base")" "$state/$id.meta"
+
+  out=$(PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_USAGE_CLAUDE_DIR="$TMP_ROOT/td2-fake-claude" FM_USAGE_CODEX_DIR="$TMP_ROOT/td2-fake-codex" \
+    FM_USAGE_PI_DIR="$TMP_ROOT/td2-fake-pi" \
+    "$TEARDOWN" "$id" 2>&1)
+  expect_code 0 "$?" "teardown should succeed"$'\n'"$out"
+  assert_contains "$out" "teardown $id complete" "teardown completes"
+  [ ! -e "$state/$id.status" ] || fail "teardown left the status log behind"
+  row=$(cat "$data/usage-ledger.jsonl")
+  assert_contains "$row" '"turns":2' \
+    "the harvest counted the status log's working lines before teardown removed it"
+  assert_contains "$row" '"wall_secs":500' \
+    "the harvest measured the task window before teardown removed the status log"
+  pass "teardown integration: the harvest runs while the status log still exists"
 }
 
 # --- teardown integration: harvest failure never blocks teardown ------------
@@ -413,9 +633,15 @@ SH
 claude_case
 claude_nobirth_case
 codex_case
+pi_case usagepi1 pi
+pi_case usagepisigned1 pi-signed
+spawn_gen_case
+spawn_gen_malformed_case
+spawn_gen_future_case
 cursor_case
 remote_case
 race_case
 lock_bound_case
 report_case
+teardown_status_case
 teardown_case

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -4,7 +4,8 @@
 # sums with cwd/window matching, pi/pi-signed session parsing over the shared
 # ~/.pi/agent/sessions tree, the durable spawn_gen task start that survives a
 # meta rewritten after the fact, cursor/unavailable null rows, the
-# no-double-append idempotency guard, the ledger report rendering, and the
+# no-double-append idempotency guard, the ledger report rendering including
+# its refusal to present an unparseable ledger as a result, and the
 # teardown integration properties that the harvest sees the status log and
 # that a harvest failure never blocks teardown. Also covers the whole-task row
 # scope a relaunch must not narrow, the per-line corrupt-log tolerance, and
@@ -589,6 +590,35 @@ report_case() {
   pass "usage report: per-model totals, per-task rows, missing-ledger tolerance"
 }
 
+# A ledger line that jq cannot parse must fail the report loudly. Reporting
+# exit 0 with a physical row count above empty sections presents a truncated
+# fleet cost picture as a complete one.
+report_malformed_case() {
+  local home ledger out status
+  home="$TMP_ROOT/home-usagemalformed"
+  mkdir -p "$home/data"
+  ledger="$home/data/usage-ledger.jsonl"
+  printf '{"task":"usagegood1","model":"good-model","source":"claude","input_tokens":7}\n' > "$ledger"
+  printf '{"task": truncated\n' >> "$ledger"
+
+  out=$(FM_DATA_OVERRIDE="$home/data" "$REPORT" 2>&1)
+  status=$?
+  expect_code 1 "$status" "report of an unparseable ledger should fail"$'\n'"$out"
+  assert_contains "$out" "$ledger" "the failure names the offending ledger"
+  assert_not_contains "$out" "per-task rows" \
+    "a failed report must not print sections it could not compute"
+  assert_not_contains "$out" "2 rows" \
+    "a failed report must not present a physical row count as a result"
+
+  # The same ledger without the truncated line still reports normally, so the
+  # failure is the parse error and not the new pre-render step.
+  printf '{"task":"usagegood1","model":"good-model","source":"claude","input_tokens":7}\n' > "$ledger"
+  out=$(FM_DATA_OVERRIDE="$home/data" "$REPORT" 2>&1)
+  expect_code 0 "$?" "report of a parseable ledger should still succeed"$'\n'"$out"
+  assert_contains "$out" "good-model" "the repaired ledger still renders its model row"
+  pass "usage report: an unparseable ledger fails loudly instead of reporting empty sections"
+}
+
 # --- teardown integration: the harvest still sees the task status log -------
 
 # Teardown deletes state/<id>.status when it retires the task's status
@@ -914,5 +944,6 @@ race_case
 lock_bound_case
 report_case
 report_no_harness_case
+report_malformed_case
 teardown_status_case
 teardown_case

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -321,6 +321,32 @@ race_case() {
   pass "usage harvest: concurrent harvests append exactly one row"
 }
 
+# A held ledger lock must never block the (teardown-synchronous) harvest
+# forever: the acquire is bounded, so a second harvest whose lock-wait is
+# shorter than the holder's critical section gives up best-effort (non-zero,
+# no duplicate row) instead of hanging until the holder releases.
+lock_bound_case() {
+  local id=usagelockbound1 wt="$TMP_ROOT/wt-usagelockbound1"
+  local data home ledger p1 rc
+  data=$(harvest_case "$id" cursor "$wt" cursor-x "")
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+  ledger="$home/data/usage-ledger.jsonl"
+  # Holder keeps the lock across a 4s critical section.
+  FM_USAGE_HARVEST_APPEND_DELAY=4 "$HARVEST" "$id" >/dev/null 2>&1 &
+  p1=$!
+  # Let the holder acquire before the bounded harvester starts spinning.
+  sleep 1
+  rc=0
+  FM_USAGE_LEDGER_LOCK_WAIT=1 "$HARVEST" "$id" >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] \
+    || fail "bounded harvest returned 0 while the ledger lock was held"
+  wait "$p1"
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = 1 ] \
+    || fail "bounded give-up appended a duplicate row"
+  pass "usage harvest: a held ledger lock bounds the acquire, no hang or dup"
+}
+
 # --- report: per-model totals and per-task rows -----------------------------
 
 report_case() {
@@ -390,5 +416,6 @@ codex_case
 cursor_case
 remote_case
 race_case
+lock_bound_case
 report_case
 teardown_case

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -372,31 +372,19 @@ cursor_case() {
 # A stat shim that reports no birth time (GNU statx unsupported returns 0 for
 # %W) while still answering mtime, so the harvest must fall back to the meta
 # mtime for the window start instead of collapsing to the status mtime.
-nobirth_stat_bin() {  # <dir>
-  mkdir -p "$1"
-  cat > "$1/stat" <<'SH'
-#!/usr/bin/env bash
-fmt=""; file=""
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    -f) exit 1 ;;
-    -c) fmt="$2"; shift 2 ;;
-    --) shift; file="$1"; shift ;;
-    *) file="$1"; shift ;;
-  esac
-done
-case "$fmt" in
-  %W) printf '0\n' ;;
-  %Y) /usr/bin/stat -f %m -- "$file" 2>/dev/null || /usr/bin/stat -c %Y -- "$file" ;;
-  *) exit 1 ;;
-esac
-SH
-  chmod +x "$1/stat"
-}
-
-fixedbirth_stat_bin() {  # <dir> <status-file> <birth-epoch>
-  mkdir -p "$1"
-  cat > "$1/stat" <<SH
+# stat_shim_bin <dir> [<status-file> <birth-epoch>] : put a stat shim on PATH
+# that answers mtime truthfully while controlling what the harvester reads for
+# a birth time. With no birth argument every file reports no usable birth time
+# (GNU statx unsupported returns 0 for %W), so the window must fall back; with
+# one, only <status-file> reports <birth-epoch>. The %Y branch captures the two
+# probes into separate assignments, exactly as the harvester's own
+# file_mtime_epoch does, so the second read replaces the first's output instead
+# of being appended to it (see bin/fm-watch.sh for why the shared-stdout
+# `stat -f ... || stat -c ...` form writes a filesystem dump on Linux).
+stat_shim_bin() {  # <dir> [<status-file> <birth-epoch>]
+  local dir=$1 statusfile=${2:-} birth=${3:-}
+  mkdir -p "$dir"
+  cat > "$dir/stat" <<SH
 #!/usr/bin/env bash
 fmt=""; file=""
 while [ "\$#" -gt 0 ]; do
@@ -408,12 +396,23 @@ while [ "\$#" -gt 0 ]; do
   esac
 done
 case "\$fmt" in
-  %W) if [ "\$file" = "$2" ]; then printf '%s\\n' "$3"; else printf '0\\n'; fi ;;
-  %Y) /usr/bin/stat -f %m -- "\$file" 2>/dev/null || /usr/bin/stat -c %Y -- "\$file" ;;
+  %W)
+    if [ -n "$statusfile" ] && [ "\$file" = "$statusfile" ]; then
+      printf '%s\\n' "$birth"
+    else
+      printf '0\\n'
+    fi
+    ;;
+  %Y)
+    t=\$(/usr/bin/stat -f %m -- "\$file" 2>/dev/null) \\
+      || t=\$(/usr/bin/stat -c %Y -- "\$file" 2>/dev/null) \\
+      || exit 1
+    printf '%s\\n' "\$t"
+    ;;
   *) exit 1 ;;
 esac
 SH
-  chmod +x "$1/stat"
+  chmod +x "$dir/stat"
 }
 
 claude_nobirth_case() {
@@ -441,7 +440,7 @@ JSON
   touch -t "$(touch_stamp $((base - 50)))" "$logdir/session.jsonl"
 
   fb="$TMP_ROOT/nobirth-fakebin"
-  nobirth_stat_bin "$fb"
+  stat_shim_bin "$fb"
   out=$(PATH="$fb:$PATH" "$HARVEST" "$id" 2>&1)
   expect_code 0 "$?" "birthless claude harvest should succeed"$'\n'"$out"
   ledger="$data/usage-ledger.jsonl"
@@ -678,7 +677,9 @@ SH
     "teardown warns one line when the harvest fails"
   assert_contains "$out" "teardown $id complete" \
     "teardown completes after a harvest failure"
-  pass "teardown integration: harvest failure is non-fatal"
+  [ -z "$(find "$data" -maxdepth 1 -name 'usage-ledger.jsonl.tmp.*' -print -quit)" ] \
+    || fail "a failed harvest left a ledger work file in the data dir"
+  pass "teardown integration: harvest failure is non-fatal and leaves no work file"
 }
 
 # --- row scope: a relaunch must not narrow the window -----------------------
@@ -716,7 +717,7 @@ JSON
   touch -t "$(touch_stamp $((base + 100)))" "$logdir/first-incarnation.jsonl"
 
   fb="$TMP_ROOT/relaunch-fakebin"
-  fixedbirth_stat_bin "$fb" "$state/$id.status" "$base"
+  stat_shim_bin "$fb" "$state/$id.status" "$base"
   out=$(PATH="$fb:$PATH" "$HARVEST" "$id" 2>&1)
   expect_code 0 "$?" "relaunch-scope harvest should succeed"$'\n'"$out"
   row=$(cat "$data/usage-ledger.jsonl")
@@ -749,7 +750,7 @@ relaunch_birthless_case() {
   touch -t "$(touch_stamp $((base + 600)))" "$state/$id.meta"
 
   fb="$TMP_ROOT/relaunch-nobirth-fakebin"
-  nobirth_stat_bin "$fb"
+  stat_shim_bin "$fb"
   out=$(PATH="$fb:$PATH" "$HARVEST" "$id" 2>&1)
   expect_code 0 "$?" "birthless relaunch harvest should succeed"$'\n'"$out"
   row=$(cat "$data/usage-ledger.jsonl")

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Behavior tests for the fleet usage harvester and its report reader.
+# Covers claude-log request dedupe and cache folding, codex per-request delta
+# sums with cwd/window matching, cursor/unavailable null rows, the
+# no-double-append idempotency guard, the ledger report rendering, and the
+# teardown integration property that a harvest failure never blocks teardown.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HARVEST="$ROOT/bin/fm-usage-harvest.sh"
+REPORT="$ROOT/bin/fm-usage-report.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+TMP_ROOT=$(fm_test_tmproot fm-usage-harvest)
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+file_mtime_epoch() {  # <file>
+  local t
+  t=$(stat -f %m -- "$1" 2>/dev/null) || t=$(stat -c %Y -- "$1" 2>/dev/null) || return 1
+  case "$t" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s' "$t"
+}
+file_birth_epoch() {  # <file>
+  local t
+  t=$(stat -f %B -- "$1" 2>/dev/null) || t=$(stat -c %W -- "$1" 2>/dev/null) || return 1
+  case "$t" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$t" -ge 1000000000 ] 2>/dev/null || return 1
+  printf '%s' "$t"
+}
+
+# harvest_case <id> <harness> [model] [effort] : create a home with one task
+# whose worktree is $TMP_ROOT/wt-<id>, status and meta included, and echo the
+# data dir. Exports the FM_USAGE_* fixture dirs per case.
+harvest_case() {  # <id> <harness> <worktree> [model] [effort]
+  local id=$1 harness=$2 wt=$3
+  local home="$TMP_ROOT/home-$id"
+  mkdir -p "$home/state" "$home/data"
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" "worktree=$wt" \
+    "project=$TMP_ROOT/proj-$id" "harness=$harness" "kind=ship" "mode=no-mistakes" \
+    "model=${4:-default}" "effort=${5:-default}"
+  {
+    printf 'working: started\n'
+    printf 'working: halfway\n'
+    printf 'done: finished the task\n'
+  } > "$home/state/$id.status"
+  printf '%s\n' "$home/data"
+}
+export_harvest_env() {  # <home-data>
+  FM_STATE_OVERRIDE="$1/state"
+  FM_DATA_OVERRIDE="$1/data"
+  FM_USAGE_CLAUDE_DIR="$TMP_ROOT/fake-claude/projects"
+  FM_USAGE_CODEX_DIR="$TMP_ROOT/fake-codex/sessions"
+  export FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_USAGE_CLAUDE_DIR FM_USAGE_CODEX_DIR
+}
+
+# --- claude: request dedupe, cache folding, encoding resolution, window -----
+
+claude_case() {
+  local id=usageclaude1 wt="$TMP_ROOT/wt-usageclaude1"
+  local data home state ledger row
+  data=$(harvest_case "$id" claude "$wt" default default)
+  home=$(dirname "$data")
+  state="$home/state"
+  export_harvest_env "$home"
+
+  # The encoded directory is the worktree path with every '/' turned into '-'.
+  local encoded=${wt//\//-}
+  local logdir="$FM_USAGE_CLAUDE_DIR/$encoded"
+  mkdir -p "$logdir"
+  cat > "$logdir/session-a.jsonl" <<'JSON'
+{"type":"assistant","message":{"id":"msgA","model":"claude-test","usage":{"input_tokens":10,"cache_read_input_tokens":100,"cache_creation_input_tokens":20,"output_tokens":30,"output_tokens_details":{"thinking_tokens":5}}}}
+{"type":"assistant","message":{"id":"msgA","model":"claude-test","usage":{"input_tokens":10,"cache_read_input_tokens":100,"cache_creation_input_tokens":20,"output_tokens":30,"output_tokens_details":{"thinking_tokens":5}}}}
+{"type":"assistant","message":{"id":"msgB","model":"claude-test","usage":{"input_tokens":7,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":9}}}
+{"type":"user","message":{"role":"user"}}
+{"type":"assistant","message":{"id":"msgC"}}
+JSON
+  # A request logged outside the task window (future mtime) must be excluded,
+  # as must a session in a differently encoded sibling directory.
+  cat > "$logdir/session-future.jsonl" <<'JSON'
+{"type":"assistant","message":{"id":"msgX","model":"claude-test","usage":{"input_tokens":999,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":999}}}
+JSON
+  touch -t "$(date -r $(( $(file_mtime_epoch "$state/$id.status") + 7200 )) +%Y%m%d%H%M.%S)" \
+    "$logdir/session-future.jsonl"
+  mkdir -p "$FM_USAGE_CLAUDE_DIR/wrong-encoded-dir"
+  printf '%s\n' '{"type":"assistant","message":{"id":"msgY","model":"claude-test","usage":{"input_tokens":777,"output_tokens":777}}}' \
+    > "$FM_USAGE_CLAUDE_DIR/wrong-encoded-dir/other.jsonl"
+  # Seal the window: the status end mtime must not predate the in-window
+  # session log, or the log correctly falls outside birth -> end.
+  touch -m -r "$logdir/session-a.jsonl" "$state/$id.status"
+
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "claude harvest should succeed"$'\n'"$out"
+  ledger="$data/usage-ledger.jsonl"
+  [ -f "$ledger" ] || fail "claude harvest wrote no ledger"
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = 1 ] || fail "claude harvest wrote more than one ledger line"
+  row=$(cat "$ledger")
+  assert_contains "$row" '"task":"usageclaude1"' "claude row names the task"
+  assert_contains "$row" '"harness":"claude"' "claude row names the harness"
+  assert_contains "$row" '"model":"claude-test"' "claude row captures the log model"
+  assert_contains "$row" '"source":"claude-projects"' "claude row names its source"
+  assert_contains "$row" '"input_tokens":17' "claude input tokens dedupe per request (10+7)"
+  assert_contains "$row" '"cached_input_tokens":120' "claude cached folds read+creation (100+20+0+0)"
+  assert_contains "$row" '"output_tokens":39' "claude output tokens (30+9)"
+  assert_contains "$row" '"reasoning_tokens":5' "claude reasoning captures thinking tokens"
+  assert_contains "$row" '"turns":2' "claude turn estimate counts working: lines"
+  assert_contains "$row" '"effort":null' "default effort renders null"
+  # Wall seconds is birth -> status mtime on this platform; assert the
+  # computed value equals an independent read of the same file facts.
+  local end birth wall_expected
+  end=$(file_mtime_epoch "$state/$id.status")
+  birth=$(file_birth_epoch "$state/$id.status" || file_mtime_epoch "$state/$id.status")
+  wall_expected=$((end - birth))
+  [ "$wall_expected" -lt 0 ] && wall_expected=0
+  assert_contains "$row" "\"wall_secs\":$wall_expected" \
+    "claude wall seconds equals status birth -> last-mtime window"
+
+  # Idempotency: a second harvest must not append a duplicate row.
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "second claude harvest should exit 0"$'\n'"$out"
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = 1 ] \
+    || fail "second claude harvest double-appended"
+  pass "claude harvest: per-request dedupe, cache folding, encoding, window, idempotency"
+}
+
+# --- codex: cwd match, window match, delta sums, model capture --------------
+
+codex_case() {
+  local id=usagecodex1 wt="$TMP_ROOT/wt-usagecodex1"
+  local data home ledger row out
+  data=$(harvest_case "$id" codex "$wt" default high)
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+
+  local d1="$FM_USAGE_CODEX_DIR/2026/08/28"
+  mkdir -p "$d1"
+  cat > "$d1/rollout-match.jsonl" <<JSON
+{"timestamp":"2026-08-28T15:13:03.851Z","ordinal":0,"type":"session_meta","payload":{"session_id":"s1","cwd":"$wt"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":10,"cache_write_input_tokens":5,"output_tokens":20,"reasoning_output_tokens":8},"last_token_usage":{"input_tokens":100,"cached_input_tokens":10,"cache_write_input_tokens":5,"output_tokens":20,"reasoning_output_tokens":8}}}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":50,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":11,"reasoning_output_tokens":3}}}}
+{"type":"turn_context","payload":{"cwd":"$wt","model":"glm-5.3"}}
+JSON
+  # Same window but a different cwd: must be excluded.
+  cat > "$d1/rollout-othercwd.jsonl" <<JSON
+{"type":"session_meta","payload":{"cwd":"/elsewhere"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":888,"output_tokens":888}}}}
+{"type":"turn_context","payload":{"model":"glm-5.3"}}
+JSON
+  # Matching cwd but outside the window: must be excluded.
+  cat > "$d1/rollout-future.jsonl" <<JSON
+{"type":"session_meta","payload":{"cwd":"$wt"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":999,"output_tokens":999}}}}
+JSON
+  touch -t "$(date -r $(( $(file_mtime_epoch "$home/state/$id.status") + 7200 )) +%Y%m%d%H%M.%S)" \
+    "$d1/rollout-future.jsonl"
+  touch -m -r "$d1/rollout-match.jsonl" "$home/state/$id.status"
+
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "codex harvest should succeed"$'\n'"$out"
+  ledger="$home/data/usage-ledger.jsonl"
+  row=$(cat "$ledger")
+  assert_contains "$row" '"harness":"codex"' "codex row names the harness"
+  assert_contains "$row" '"model":"glm-5.3"' "codex row captures the turn_context model"
+  assert_contains "$row" '"effort":"high"' "codex row carries meta effort"
+  assert_contains "$row" '"source":"codex-sessions"' "codex row names its source"
+  assert_contains "$row" '"input_tokens":150' "codex input sums per-request deltas (100+50)"
+  assert_contains "$row" '"cached_input_tokens":15' "codex cached folds cached+cache_write (10+5+0)"
+  assert_contains "$row" '"output_tokens":31' "codex output sums deltas (20+11)"
+  assert_contains "$row" '"reasoning_tokens":11' "codex reasoning sums deltas (8+3)"
+  pass "codex harvest: cwd/window matching, delta sums, model capture"
+}
+
+# --- cursor: unavailable logs render nulls ----------------------------------
+
+cursor_case() {
+  local id=usagecursor1 wt="$TMP_ROOT/wt-usagecursor1"
+  local data home ledger row out
+  data=$(harvest_case "$id" cursor "$wt" cursor-grok-4.5-high "")
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "cursor harvest should succeed"$'\n'"$out"
+  ledger="$home/data/usage-ledger.jsonl"
+  row=$(cat "$ledger")
+  assert_contains "$row" '"model":"cursor-grok-4.5-high"' "cursor row falls back to meta model"
+  assert_contains "$row" '"input_tokens":null' "cursor input tokens are null"
+  assert_contains "$row" '"cached_input_tokens":null' "cursor cached tokens are null"
+  assert_contains "$row" '"output_tokens":null' "cursor output tokens are null"
+  assert_contains "$row" '"reasoning_tokens":null' "cursor reasoning tokens are null"
+  assert_contains "$row" '"source":"unavailable"' "cursor row marks source unavailable"
+  pass "cursor harvest: unavailable source renders null token fields"
+}
+
+# --- report: per-model totals and per-task rows -----------------------------
+
+report_case() {
+  local out ledger
+  ledger="$TMP_ROOT/home-usageclaude1/data/usage-ledger.jsonl"
+  cat "$TMP_ROOT/home-usagecodex1/data/usage-ledger.jsonl" >> "$ledger"
+  cat "$TMP_ROOT/home-usagecursor1/data/usage-ledger.jsonl" >> "$ledger"
+  out=$(FM_DATA_OVERRIDE="$(dirname "$ledger")" "$REPORT" 2>&1)
+  expect_code 0 "$?" "report should succeed"$'\n'"$out"
+  assert_contains "$out" "usage ledger: $ledger (3 rows)" "report names the ledger and row count"
+  assert_contains "$out" "per-model totals" "report prints per-model totals"
+  assert_contains "$out" "claude-test" "report lists the claude model"
+  assert_contains "$out" "glm-5.3" "report lists the codex model"
+  assert_contains "$out" "usageclaude1" "report lists each task row"
+  assert_contains "$out" "usagecursor1" "report lists the unavailable task row"
+  assert_contains "$out" "unavailable" "report shows the unavailable source"
+  # Missing ledger exits 0 with a note.
+  out=$(FM_DATA_OVERRIDE="$TMP_ROOT/empty-home" "$REPORT" 2>&1)
+  expect_code 0 "$?" "report without a ledger should exit 0"
+  assert_contains "$out" "no usage ledger" "report names the missing ledger"
+  pass "usage report: per-model totals, per-task rows, missing-ledger tolerance"
+}
+
+# --- teardown integration: harvest failure never blocks teardown ------------
+
+teardown_case() {
+  local proj wt id fb state data config out
+  id=usageharvtd1
+  proj="$TMP_ROOT/td-proj"; wt="$TMP_ROOT/td-wt"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  fb="$TMP_ROOT/td-fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fb/treehouse" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fb/tmux" "$fb/treehouse"
+  state="$TMP_ROOT/td-state"; config="$TMP_ROOT/td-config"; data="$TMP_ROOT/td-data"
+  mkdir -p "$state" "$config" "$data/$id"
+  printf 'scout findings\n' > "$data/$id/report.md"
+  fm_write_meta "$state/$id.meta" \
+    "window=firstmate:fm-$id" "worktree=$wt" "project=$proj" "harness=claude" \
+    "kind=scout" "mode=no-mistakes" "yolo=off" \
+    "decisions_reviewed=1" "decision_keys="
+  printf 'working: scouting\n' > "$state/$id.status"
+  # The ledger path being a directory forces every append to fail.
+  mkdir -p "$data/usage-ledger.jsonl"
+  out=$(PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_USAGE_CLAUDE_DIR="$TMP_ROOT/td-fake-claude" FM_USAGE_CODEX_DIR="$TMP_ROOT/td-fake-codex" \
+    "$TEARDOWN" "$id" 2>&1)
+  expect_code 0 "$?" "teardown must succeed even when the harvest fails"$'\n'"$out"
+  assert_contains "$out" "warning: usage harvest for $id failed" \
+    "teardown warns one line when the harvest fails"
+  assert_contains "$out" "teardown $id complete" \
+    "teardown completes after a harvest failure"
+  pass "teardown integration: harvest failure is non-fatal"
+}
+
+claude_case
+codex_case
+cursor_case
+report_case
+teardown_case

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -60,15 +60,20 @@ export_harvest_env() {  # <home-data>
 # --- claude: request dedupe, cache folding, encoding resolution, window -----
 
 claude_case() {
-  local id=usageclaude1 wt="$TMP_ROOT/wt-usageclaude1"
+  # The worktree path carries a dot segment (as every firstmate home under
+  # .no-mistakes does) so a slash-only encoding would resolve to the wrong
+  # on-disk project directory.
+  local id=usageclaude1 wt="$TMP_ROOT/.no-mistakes/wt-usageclaude1"
   local data home state ledger row
   data=$(harvest_case "$id" claude "$wt" default default)
   home=$(dirname "$data")
   state="$home/state"
   export_harvest_env "$home"
 
-  # The encoded directory is the worktree path with every '/' turned into '-'.
+  # Claude Code encodes the project directory by mapping BOTH '/' and '.' to
+  # '-', so the fixture log dir mirrors that full sanitization.
   local encoded=${wt//\//-}
+  encoded=${encoded//./-}
   local logdir="$FM_USAGE_CLAUDE_DIR/$encoded"
   mkdir -p "$logdir"
   cat > "$logdir/session-a.jsonl" <<'JSON'
@@ -194,6 +199,71 @@ cursor_case() {
   pass "cursor harvest: unavailable source renders null token fields"
 }
 
+# --- claude: window survives a host without usable birth time ---------------
+
+# A stat shim that reports no birth time (GNU statx unsupported returns 0 for
+# %W) while still answering mtime, so the harvest must fall back to the meta
+# mtime for the window start instead of collapsing to the status mtime.
+nobirth_stat_bin() {  # <dir>
+  mkdir -p "$1"
+  cat > "$1/stat" <<'SH'
+#!/usr/bin/env bash
+fmt=""; file=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -f) exit 1 ;;
+    -c) fmt="$2"; shift 2 ;;
+    --) shift; file="$1"; shift ;;
+    *) file="$1"; shift ;;
+  esac
+done
+case "$fmt" in
+  %W) printf '0\n' ;;
+  %Y) /usr/bin/stat -f %m -- "$file" 2>/dev/null || /usr/bin/stat -c %Y -- "$file" ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$1/stat"
+}
+
+claude_nobirth_case() {
+  local id=usagenobirth1 wt="$TMP_ROOT/.no-mistakes/wt-usagenobirth1"
+  local data home state ledger row out fb base
+  data=$(harvest_case "$id" claude "$wt" default default)
+  home=$(dirname "$data")
+  state="$home/state"
+  export_harvest_env "$home"
+
+  local encoded=${wt//\//-}
+  encoded=${encoded//./-}
+  local logdir="$FM_USAGE_CLAUDE_DIR/$encoded"
+  mkdir -p "$logdir"
+  cat > "$logdir/session.jsonl" <<'JSON'
+{"type":"assistant","message":{"id":"msgN","model":"claude-test","usage":{"input_tokens":12,"output_tokens":8}}}
+JSON
+
+  # Pin an explicit window: status finishes at T, meta was spawned 100s earlier,
+  # and the session log lands mid-window. Without the meta-mtime start fallback
+  # the birthless window collapses to [T, T] and drops the earlier log.
+  base=$(file_mtime_epoch "$state/$id.status")
+  touch -t "$(date -r "$base" +%Y%m%d%H%M.%S)" "$state/$id.status"
+  touch -t "$(date -r $((base - 100)) +%Y%m%d%H%M.%S)" "$state/$id.meta"
+  touch -t "$(date -r $((base - 50)) +%Y%m%d%H%M.%S)" "$logdir/session.jsonl"
+
+  fb="$TMP_ROOT/nobirth-fakebin"
+  nobirth_stat_bin "$fb"
+  out=$(PATH="$fb:$PATH" "$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "birthless claude harvest should succeed"$'\n'"$out"
+  ledger="$data/usage-ledger.jsonl"
+  row=$(cat "$ledger")
+  assert_contains "$row" '"source":"claude-projects"' \
+    "birthless harvest still finds the in-window log via the meta-mtime start"
+  assert_contains "$row" '"input_tokens":12' "birthless harvest sums the in-window usage"
+  assert_contains "$row" '"wall_secs":100' \
+    "birthless window spans meta -> status instead of collapsing to zero"
+  pass "claude harvest: window survives a host without usable birth time"
+}
+
 # --- report: per-model totals and per-task rows -----------------------------
 
 report_case() {
@@ -258,6 +328,7 @@ SH
 }
 
 claude_case
+claude_nobirth_case
 codex_case
 cursor_case
 report_case

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -264,6 +264,63 @@ JSON
   pass "claude harvest: window survives a host without usable birth time"
 }
 
+# --- remote secondmate: local logs are never harvested for remote work ------
+
+remote_case() {
+  local id=usageremote1 wt="$TMP_ROOT/wt-usageremote1"
+  local data home ledger row out
+  data=$(harvest_case "$id" codex "$wt" default high)
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+  # The task ran on a remote secondmate host (fm-spawn records remote_host=).
+  printf 'remote_host=box.example\n' >> "$home/state/$id.meta"
+  # Seed a LOCAL codex session whose cwd matches the worktree: without the
+  # remote-host guard the harvest would misattribute this local session to the
+  # remote task; with it, the row is honestly unavailable and its tokens null.
+  local d1="$FM_USAGE_CODEX_DIR/2026/08/28"
+  mkdir -p "$d1"
+  cat > "$d1/rollout-localmatch.jsonl" <<JSON
+{"type":"session_meta","payload":{"cwd":"$wt"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":500,"output_tokens":400}}}}
+{"type":"turn_context","payload":{"cwd":"$wt","model":"glm-5.3"}}
+JSON
+  touch -m -r "$d1/rollout-localmatch.jsonl" "$home/state/$id.status"
+
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "remote harvest should succeed"$'\n'"$out"
+  ledger="$home/data/usage-ledger.jsonl"
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = 1 ] || fail "remote harvest wrote no single row"
+  row=$(cat "$ledger")
+  assert_contains "$row" '"source":"unavailable"' \
+    "remote task records unavailable, not a local session"
+  assert_contains "$row" '"input_tokens":null' \
+    "remote task tokens are null (no local misattribution)"
+  pass "remote secondmate harvest: local logs are never misattributed"
+}
+
+# --- concurrency: the ledger lock keeps the append idempotent ---------------
+
+race_case() {
+  local id=usagerace1 wt="$TMP_ROOT/wt-usagerace1"
+  local data home ledger p1 p2
+  data=$(harvest_case "$id" cursor "$wt" cursor-x "")
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+  ledger="$home/data/usage-ledger.jsonl"
+  # Two concurrent harvests with a widened check-to-append window: the ledger
+  # lock must serialize them so exactly one row is appended. Without the lock
+  # both pass the existence check and each append, yielding two rows.
+  FM_USAGE_HARVEST_APPEND_DELAY=1 "$HARVEST" "$id" >/dev/null 2>&1 &
+  p1=$!
+  FM_USAGE_HARVEST_APPEND_DELAY=1 "$HARVEST" "$id" >/dev/null 2>&1 &
+  p2=$!
+  wait "$p1"; wait "$p2"
+  [ -f "$ledger" ] || fail "concurrent harvest wrote no ledger"
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = 1 ] \
+    || fail "concurrent harvests appended more than one row"
+  pass "usage harvest: concurrent harvests append exactly one row"
+}
+
 # --- report: per-model totals and per-task rows -----------------------------
 
 report_case() {
@@ -331,5 +388,7 @@ claude_case
 claude_nobirth_case
 codex_case
 cursor_case
+remote_case
+race_case
 report_case
 teardown_case

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -394,6 +394,28 @@ SH
   chmod +x "$1/stat"
 }
 
+fixedbirth_stat_bin() {  # <dir> <status-file> <birth-epoch>
+  mkdir -p "$1"
+  cat > "$1/stat" <<SH
+#!/usr/bin/env bash
+fmt=""; file=""
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    -f) exit 1 ;;
+    -c) fmt="\$2"; shift 2 ;;
+    --) shift; file="\$1"; shift ;;
+    *) file="\$1"; shift ;;
+  esac
+done
+case "\$fmt" in
+  %W) if [ "\$file" = "$2" ]; then printf '%s\\n' "$3"; else printf '0\\n'; fi ;;
+  %Y) /usr/bin/stat -f %m -- "\$file" 2>/dev/null || /usr/bin/stat -c %Y -- "\$file" ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$1/stat"
+}
+
 claude_nobirth_case() {
   local id=usagenobirth1 wt="$TMP_ROOT/.no-mistakes/wt-usagenobirth1"
   local data home state ledger row out fb base
@@ -516,6 +538,31 @@ lock_bound_case() {
 }
 
 # --- report: per-model totals and per-task rows -----------------------------
+
+# The ledger's harness field is null when a task record carries no harness=
+# line, and the report must keep every later column in its own slot rather
+# than shifting the model, effort and token columns one place left.
+report_no_harness_case() {
+  local id=usagenoharness1 wt="$TMP_ROOT/wt-usagenoharness1"
+  local home ledger out fields
+  home="$TMP_ROOT/home-$id"
+  mkdir -p "$home/state" "$home/data"
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" "worktree=$wt" "model=nohar-model" "effort=default"
+  printf 'working: started\n' > "$home/state/$id.status"
+  FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    "$HARVEST" "$id" >/dev/null 2>&1 || fail "harness-less harvest failed"
+  ledger="$home/data/usage-ledger.jsonl"
+  assert_contains "$(cat "$ledger")" '"harness":null' \
+    "an absent harness is recorded as null, like an absent model or effort"
+
+  out=$(FM_DATA_OVERRIDE="$home/data" "$REPORT" 2>&1)
+  expect_code 0 "$?" "report of a harness-less row should succeed"$'\n'"$out"
+  fields=$(printf '%s\n' "$out" | awk -v t="$id" '$1 == t {print NF"|"$2"|"$3"|"$NF}')
+  [ "$fields" = "10|-|nohar-model|unavailable" ] \
+    || fail "report shifted the harness-less row's columns: [$fields]"
+  pass "usage report: an absent harness renders as a placeholder without shifting columns"
+}
 
 report_case() {
   local out ledger
@@ -643,7 +690,7 @@ SH
 # first incarnation's session logs.
 relaunch_scope_case() {
   local id=usagerelaunch1 wt="$TMP_ROOT/.no-mistakes/wt-usagerelaunch1"
-  local data home state row out base encoded logdir
+  local data home state row out base encoded logdir fb
   data=$(harvest_case "$id" claude "$wt" default default)
   home=$(dirname "$data")
   state="$home/state"
@@ -657,8 +704,10 @@ relaunch_scope_case() {
 {"type":"assistant","message":{"id":"msgR1","model":"claude-test","usage":{"input_tokens":21,"output_tokens":4}}}
 JSON
 
-  # The status file is born now; the task then runs for 600s and is relaunched
-  # 300s in, which rewrites spawn_gen with the relaunch epoch.
+  # The task is born at base, runs for 600s, and is relaunched 300s in, which
+  # rewrites spawn_gen with the relaunch epoch. The birth time is pinned by a
+  # stat shim so the case asserts the harvester's rule rather than the
+  # runner's filesystem support for birth times.
   base=$(file_mtime_epoch "$state/$id.status")
   printf 'spawn_gen=s%s.4242.9\n' "$((base + 300))" >> "$state/$id.meta"
   touch -t "$(touch_stamp $((base + 600)))" "$state/$id.status"
@@ -666,7 +715,9 @@ JSON
   # A request logged by the FIRST incarnation, before the relaunch token.
   touch -t "$(touch_stamp $((base + 100)))" "$logdir/first-incarnation.jsonl"
 
-  out=$("$HARVEST" "$id" 2>&1)
+  fb="$TMP_ROOT/relaunch-fakebin"
+  fixedbirth_stat_bin "$fb" "$state/$id.status" "$base"
+  out=$(PATH="$fb:$PATH" "$HARVEST" "$id" 2>&1)
   expect_code 0 "$?" "relaunch-scope harvest should succeed"$'\n'"$out"
   row=$(cat "$data/usage-ledger.jsonl")
   assert_contains "$row" '"wall_secs":600' \
@@ -679,6 +730,36 @@ JSON
   assert_contains "$row" '"source":"claude-projects"' \
     "a pre-relaunch session log is still matched"
   pass "usage harvest: a relaunch never narrows the row below the turn count's span"
+}
+
+# The one documented condition under which a row narrows below the whole task:
+# a filesystem with no birth time leaves spawn_gen as the only durable start,
+# and a relaunch has already rewritten it, so wall_secs covers the final
+# incarnation while turns still cover the whole task.
+relaunch_birthless_case() {
+  local id=usagerelaunch2 wt="$TMP_ROOT/wt-usagerelaunch2"
+  local data home state row out base fb
+  data=$(harvest_case "$id" cursor "$wt" cursor-x "")
+  home=$(dirname "$data")
+  state="$home/state"
+  export_harvest_env "$home"
+  base=$(file_mtime_epoch "$state/$id.status")
+  printf 'spawn_gen=s%s.4242.9\n' "$((base + 300))" >> "$state/$id.meta"
+  touch -t "$(touch_stamp $((base + 600)))" "$state/$id.status"
+  touch -t "$(touch_stamp $((base + 600)))" "$state/$id.meta"
+
+  fb="$TMP_ROOT/relaunch-nobirth-fakebin"
+  nobirth_stat_bin "$fb"
+  out=$(PATH="$fb:$PATH" "$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "birthless relaunch harvest should succeed"$'\n'"$out"
+  row=$(cat "$data/usage-ledger.jsonl")
+  assert_contains "$row" '"wall_secs":300' \
+    "a birthless host narrows a relaunched row to the final incarnation"
+  assert_contains "$row" "\"spawned_at\":\"$(iso_utc $((base + 300)))\"" \
+    "the relaunch token is the only durable start left"
+  assert_contains "$row" '"turns":2' \
+    "turns still span the whole task, as the narrowing condition states"
+  pass "usage harvest: the birthless relaunch narrowing matches the stated contract"
 }
 
 # --- corrupt lines: one bad line costs that line, not the file --------------
@@ -719,6 +800,39 @@ JSON
 # The parser hands the loop a model field that can be empty. An empty field
 # must stay in its own slot, or the counts land in the wrong ledger columns
 # and the model string is reported as a token count.
+# A line that parses to valid JSON but is not an object must be skipped like
+# any other corrupt line, rather than aborting the parse and costing the file
+# its cwd binding along with all of its usage.
+nonobject_line_case() {
+  local id=usagenonobj1 wt="$TMP_ROOT/wt-usagenonobj1"
+  local data home row out d1
+  data=$(harvest_case "$id" pi "$wt" default high)
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+  d1="$FM_USAGE_PI_DIR/--encoded-nonobj--"
+  mkdir -p "$d1"
+  cat > "$d1/session-nonobj.jsonl" <<JSON
+{"type":"session","id":"sess-o","cwd":"$wt"}
+"just a string"
+{"type":"message","id":"o1","message":{"role":"assistant","provider":"zai","model":"glm-5.3-flash","usage":{"input":12,"output":3,"cacheRead":1,"cacheWrite":0,"reasoning":2}}}
+[1,2,3]
+5
+{"type":"message","id":"o2","message":{"role":"assistant","provider":"zai","model":"glm-5.3-flash","usage":{"input":8,"output":1,"cacheRead":0,"cacheWrite":0,"reasoning":0}}}
+JSON
+  touch -m -r "$d1/session-nonobj.jsonl" "$home/state/$id.status"
+
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "non-object-line harvest should succeed"$'
+'"$out"
+  row=$(cat "$data/usage-ledger.jsonl")
+  assert_contains "$row" '"source":"pi-sessions"' \
+    "a non-object line does not cost the file's cwd binding"
+  assert_contains "$row" '"input_tokens":20' \
+    "records around a scalar or array line are still summed (12+8)"
+  assert_contains "$row" '"output_tokens":4' "output sums across the non-object lines (3+1)"
+  pass "usage harvest: a valid non-object log line is skipped, not fatal"
+}
+
 missing_model_case() {
   local id=usagenomodel1 wt="$TMP_ROOT/wt-usagenomodel1"
   local data home row out d1
@@ -788,7 +902,9 @@ spawn_gen_case
 spawn_gen_malformed_case
 spawn_gen_future_case
 relaunch_scope_case
+relaunch_birthless_case
 corrupt_line_case
+nonobject_line_case
 missing_model_case
 no_usage_case
 cursor_case
@@ -796,5 +912,6 @@ remote_case
 race_case
 lock_bound_case
 report_case
+report_no_harness_case
 teardown_status_case
 teardown_case

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -6,7 +6,9 @@
 # meta rewritten after the fact, cursor/unavailable null rows, the
 # no-double-append idempotency guard, the ledger report rendering, and the
 # teardown integration properties that the harvest sees the status log and
-# that a harvest failure never blocks teardown.
+# that a harvest failure never blocks teardown. Also covers the whole-task row
+# scope a relaunch must not narrow, the per-line corrupt-log tolerance, and
+# the rule that a source is named only after a log yields assistant usage.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -36,9 +38,11 @@ file_birth_epoch() {  # <file>
 
 # Portable epoch formatters: BSD date reads an epoch with -r, GNU date with
 # -d @<epoch>. Both forms are tried so the fixtures pin the same timestamps on
-# macOS and on the Linux CI runners.
+# macOS and on the Linux CI runners. touch -t reads its argument as LOCAL
+# time, so both renderings here are local; iso_utc below is the ledger's UTC
+# spelling and stays UTC.
 touch_stamp() {  # <epoch> : touch -t argument
-  date -r "$1" +%Y%m%d%H%M.%S 2>/dev/null || date -u -d "@$1" +%Y%m%d%H%M.%S
+  date -r "$1" +%Y%m%d%H%M.%S 2>/dev/null || date -d "@$1" +%Y%m%d%H%M.%S
 }
 iso_utc() {  # <epoch> : the harvester's ledger timestamp spelling
   date -r "$1" -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ
@@ -630,6 +634,151 @@ SH
   pass "teardown integration: harvest failure is non-fatal"
 }
 
+# --- row scope: a relaunch must not narrow the window -----------------------
+
+# fm-spawn rewrites spawn_gen on every relaunch but only ever appends to
+# state/<id>.status, so turns always span the whole task. A row therefore
+# spans the whole task too: the start is the earliest durable first-spawn
+# witness, and a later relaunch token must not shorten wall_secs or drop the
+# first incarnation's session logs.
+relaunch_scope_case() {
+  local id=usagerelaunch1 wt="$TMP_ROOT/.no-mistakes/wt-usagerelaunch1"
+  local data home state row out base encoded logdir
+  data=$(harvest_case "$id" claude "$wt" default default)
+  home=$(dirname "$data")
+  state="$home/state"
+  export_harvest_env "$home"
+
+  encoded=${wt//\//-}
+  encoded=${encoded//./-}
+  logdir="$FM_USAGE_CLAUDE_DIR/$encoded"
+  mkdir -p "$logdir"
+  cat > "$logdir/first-incarnation.jsonl" <<'JSON'
+{"type":"assistant","message":{"id":"msgR1","model":"claude-test","usage":{"input_tokens":21,"output_tokens":4}}}
+JSON
+
+  # The status file is born now; the task then runs for 600s and is relaunched
+  # 300s in, which rewrites spawn_gen with the relaunch epoch.
+  base=$(file_mtime_epoch "$state/$id.status")
+  printf 'spawn_gen=s%s.4242.9\n' "$((base + 300))" >> "$state/$id.meta"
+  touch -t "$(touch_stamp $((base + 600)))" "$state/$id.status"
+  touch -t "$(touch_stamp $((base + 600)))" "$state/$id.meta"
+  # A request logged by the FIRST incarnation, before the relaunch token.
+  touch -t "$(touch_stamp $((base + 100)))" "$logdir/first-incarnation.jsonl"
+
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "relaunch-scope harvest should succeed"$'\n'"$out"
+  row=$(cat "$data/usage-ledger.jsonl")
+  assert_contains "$row" '"wall_secs":600' \
+    "wall seconds span the whole task, not the last incarnation"
+  assert_contains "$row" "\"spawned_at\":\"$(iso_utc "$base")\"" \
+    "spawned_at reports the first spawn, not the relaunch"
+  assert_contains "$row" '"turns":2' "turns count the whole task's working lines"
+  assert_contains "$row" '"input_tokens":21' \
+    "the first incarnation's usage is inside the whole-task window"
+  assert_contains "$row" '"source":"claude-projects"' \
+    "a pre-relaunch session log is still matched"
+  pass "usage harvest: a relaunch never narrows the row below the turn count's span"
+}
+
+# --- corrupt lines: one bad line costs that line, not the file --------------
+
+# Pi's session logs are append-only, so a truncated tail line is a realistic
+# state. The cwd binding lives in the same parse as the usage, so an
+# all-or-nothing parser would report the whole task as unavailable.
+corrupt_line_case() {
+  local id=usagecorrupt1 wt="$TMP_ROOT/wt-usagecorrupt1"
+  local data home row out d1
+  data=$(harvest_case "$id" pi "$wt" default high)
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+  d1="$FM_USAGE_PI_DIR/--encoded-corrupt--"
+  mkdir -p "$d1"
+  cat > "$d1/session-corrupt.jsonl" <<JSON
+{"type":"session","id":"sess-c","cwd":"$wt"}
+{"type":"message","id":"c1","message":{"role":"assistant","provider":"zai","model":"glm-5.3-flash","usage":{"input":40,"output":6,"cacheRead":2,"cacheWrite":1,"reasoning":3}}}
+{"type":"message","id":"c2","message":{"role":"assistant","usage":{"in
+{"type":"message","id":"c3","message":{"role":"assistant","provider":"zai","model":"glm-5.3-flash","usage":{"input":9,"output":2,"cacheRead":0,"cacheWrite":0,"reasoning":1}}}
+JSON
+  touch -m -r "$d1/session-corrupt.jsonl" "$home/state/$id.status"
+
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "corrupt-line harvest should succeed"$'\n'"$out"
+  row=$(cat "$data/usage-ledger.jsonl")
+  assert_contains "$row" '"source":"pi-sessions"' \
+    "a corrupt line does not cost the file's cwd binding"
+  assert_contains "$row" '"input_tokens":49' "the valid records around a corrupt line are summed (40+9)"
+  assert_contains "$row" '"cached_input_tokens":3' "cached folds across the corrupt line (2+1)"
+  assert_contains "$row" '"output_tokens":8' "output sums across the corrupt line (6+2)"
+  assert_contains "$row" '"reasoning_tokens":4' "reasoning sums across the corrupt line (3+1)"
+  pass "usage harvest: a corrupt log line costs that line, not the file"
+}
+
+# --- a usage record without a model must not shift the token fields ---------
+
+# The parser hands the loop a model field that can be empty. An empty field
+# must stay in its own slot, or the counts land in the wrong ledger columns
+# and the model string is reported as a token count.
+missing_model_case() {
+  local id=usagenomodel1 wt="$TMP_ROOT/wt-usagenomodel1"
+  local data home row out d1
+  data=$(harvest_case "$id" pi "$wt" pi-meta-model high)
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+  d1="$FM_USAGE_PI_DIR/--encoded-nomodel--"
+  mkdir -p "$d1"
+  cat > "$d1/session-nomodel.jsonl" <<JSON
+{"type":"session","id":"sess-n","cwd":"$wt"}
+{"type":"message","id":"n1","message":{"role":"assistant","usage":{"input":100,"output":30,"cacheRead":20,"cacheWrite":5,"reasoning":7}}}
+JSON
+  touch -m -r "$d1/session-nomodel.jsonl" "$home/state/$id.status"
+
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "model-less harvest should succeed"$'\n'"$out"
+  row=$(cat "$data/usage-ledger.jsonl")
+  assert_contains "$row" '"model":"pi-meta-model"' \
+    "a log with no model falls back to the meta model, never to a token count"
+  assert_contains "$row" '"input_tokens":100' "input stays in its own field"
+  assert_contains "$row" '"cached_input_tokens":25' "cached stays in its own field (20+5)"
+  assert_contains "$row" '"output_tokens":30' "output stays in its own field"
+  assert_contains "$row" '"reasoning_tokens":7' "reasoning stays in its own field"
+  pass "usage harvest: an absent log model never shifts the token fields"
+}
+
+# --- source names assert a parsed match, for every harness alike ------------
+
+# An in-window log that yields no assistant usage must report source
+# "unavailable" with null token fields under claude exactly as under codex
+# and pi, so the source enum means the same thing across harnesses.
+no_usage_case() {
+  local id=usagenousage1 wt="$TMP_ROOT/.no-mistakes/wt-usagenousage1"
+  local data home row out encoded logdir
+  data=$(harvest_case "$id" claude "$wt" claude-meta-model default)
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+  encoded=${wt//\//-}
+  encoded=${encoded//./-}
+  logdir="$FM_USAGE_CLAUDE_DIR/$encoded"
+  mkdir -p "$logdir"
+  cat > "$logdir/session-nousage.jsonl" <<'JSON'
+{"type":"user","message":{"role":"user"}}
+{"type":"assistant","message":{"id":"msgNU"}}
+JSON
+  touch -m -r "$logdir/session-nousage.jsonl" "$home/state/$id.status"
+
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "no-usage harvest should succeed"$'\n'"$out"
+  row=$(cat "$data/usage-ledger.jsonl")
+  assert_contains "$row" '"source":"unavailable"' \
+    "an in-window log that yields no usage is not a source"
+  assert_contains "$row" '"input_tokens":null' "no parsed usage renders null input tokens"
+  assert_contains "$row" '"cached_input_tokens":null' "no parsed usage renders null cached tokens"
+  assert_contains "$row" '"output_tokens":null' "no parsed usage renders null output tokens"
+  assert_contains "$row" '"reasoning_tokens":null' "no parsed usage renders null reasoning tokens"
+  assert_contains "$row" '"model":"claude-meta-model"' "the row still reports the meta model"
+  pass "usage harvest: a source is named only after a log yields assistant usage"
+}
+
 claude_case
 claude_nobirth_case
 codex_case
@@ -638,6 +787,10 @@ pi_case usagepisigned1 pi-signed
 spawn_gen_case
 spawn_gen_malformed_case
 spawn_gen_future_case
+relaunch_scope_case
+corrupt_line_case
+missing_model_case
+no_usage_case
 cursor_case
 remote_case
 race_case


### PR DESCRIPTION
## Intent

Fix the two defects exposed by the first real Harvester rows in firstmate's fleet usage ledger (bin/fm-usage-harvest.sh).

DEFECT 1 - Pi-backed rows reported null token usage. Add a Pi session-log parser for the CURRENT ~/.pi/agent/sessions format so Pi-backed rows report real token usage instead of null.

DEFECT 2 - Stop deriving task start time from mutable metadata modification time. Use the epoch embedded in the meta's spawn_gen=s<epoch>.<pid>.<random> token as the PRIMARY durable source, with a filesystem birth-time fallback only where necessary, so later metadata updates such as PR registration cannot collapse wall_secs to zero.

Accepted constraints and decisions from the task brief and the supervising firstmate:
- Load the firstmate-coding-guidelines skill before editing any shared tracked material (done). Its rules govern this change: one-owner rule for contracts, knowledge-placement decision tree, one full sentence per line in tracked Markdown, plain dash never em dash, no agent co-author, bin/*.sh shellcheck-clean, tests colocated in tests/ as <subject>.test.sh extending the existing runner.
- Preserve behavior for every supported harness and runtime; inspect their integration surfaces rather than assuming. Deliberately verified: claude and codex parser branches unchanged; opencode, grok, kimi, cursor, muse and remote-secondmate tasks continue to fall through to source=unavailable with null token fields; runtime backends are untouched because the harvester reads only task metadata plus session logs.
- Add BEHAVIORAL tests through public script interfaces. Explicitly do NOT assert implementation-source bytes.
- Update the SINGLE authoritative documentation or verification owner ONLY where current behavior changes. Deliberate decision: bin/fm-usage-harvest.sh's own header comment is that owner (it already declares itself sole owner of the ledger line schema and of every per-harness usage source), so the header carries the schema enum, the new pi source, the new wall-clock rule and the new FM_USAGE_PI_DIR seam. docs/scripts.md's one-line row stays accurate and was deliberately left unchanged; no docs/verification/ record was added because the colocated regression tests own the guarantee. fm-doc-audience-check.sh passes.
- Run shellcheck and bin/fm-lint.sh (both clean, ShellCheck 0.11.0 and actionlint 1.7.12 pinned) and ship through the repository's full validation path.

STANDING COMPLETION-EVIDENCE RULE added by the supervisor mid-task: completion may not be reported without the strongest available command or artifact evidence, with exact reproducible output, showing (a) a REAL Pi session produces non-null token usage and (b) a metadata rewrite no longer collapses wall time. Visual evidence is explicitly optional because this surface is non-visual. This evidence must be re-established against the FINAL validated head.

Deliberate implementation choices a reviewer reading only the diff would not know:
- The Pi parser binds a log to a task by the cwd recorded in the log's own "session" record, matching the existing codex branch's cwd-matching precedent, rather than by reconstructing Pi's directory-name encoding. This is deliberate: it is immune to encoding drift, whereas the claude branch must use path encoding because claude's logs carry no cwd.
- pi and pi-signed deliberately share ONE scan of ~/.pi/agent/sessions. Verified fact: pi-signed is a signed wrapper around the same Pi application over the same ~/.pi/agent state tree (the harness-adapters skill records that the plain pi command also execs that signed launcher and that trust decisions persist in the shared ~/.pi/agent/trust.json).
- Pi's model is reported provider-qualified as "<provider>/<model>" (e.g. zai/glm-5.3-flash). This is deliberate so a log-derived model matches the spelling fm-spawn already records in task metadata, keeping a row's model field stable whether or not logs were found.
- Pi usage fields are summed as disjoint counts (input + output + cacheRead verified to equal Pi's own totalTokens on real logs), so cached_input_tokens folds cacheRead + cacheWrite exactly as the claude branch folds cache_read + cache_creation.
- Records are deduped on the record's own .id only WHERE PRESENT, and records without an id are counted unconditionally. This is deliberate: unlike claude, Pi writes one record per message rather than one per content block, so the dedupe is defensive against a replayed line and must not collapse unkeyed records into one.
- A start later than the end is pinned to the end rather than inverting the window. Deliberate: the pre-existing '[ $WALL -ge 0 ] || WALL=0' guard hid a negative duration but still left the log-matching window inverted, which silently dropped every session log.

THIRD DEFECT found while verifying, fixed in the same change because it is the same root cause and the same observed symptom set: bin/fm-teardown.sh called the harvest AFTER status_retire_presentation_task, which deletes state/<id>.status. The harvest therefore lost both the task window and the turn count on every real teardown, which is why real rows showed turns:0 alongside wall_secs:0 and source:unavailable. The harvest call was moved ahead of that retirement at both call sites, which is what the call's own pre-existing comment already claimed. This is a minimal reordering of two independent, backend-agnostic steps; it was verified not to regress tests/fm-teardown.test.sh or tests/fm-teardown-endpoint-safety.test.sh.

ALSO deliberately fixed in the same pass, in the test file being edited: tests/fm-usage-harvest.test.sh used BSD-only 'date -r <epoch>' to pin fixture timestamps, which would not pin them on the Linux CI runners. Every call now routes through portable touch_stamp/iso_utc helpers that try the BSD form then the GNU form, mirroring the idiom the harvester script itself already uses.

Verification already performed on this head: all 15 tests in tests/fm-usage-harvest.test.sh pass; each NEW case was confirmed to FAIL against HEAD with the exact real-world symptoms (wall_secs:0, turns:0, source:unavailable) and pass after, so none is vacuous; a smoke run against a REAL unmodified ~/.pi/agent/sessions log produced input 24664, cached 25088, output 1084, reasoning 879, matching an independent jq recomputation over the same file exactly; tests/fm-teardown-endpoint-safety.test.sh, tests/fm-classify-decision-key.test.sh and tests/fm-wake-drain-unread-status.test.sh are all green; bin/fm-test-run.sh --check-coverage passes.

KNOWN PRE-EXISTING, NOT CAUSED BY THIS CHANGE: tests/fm-teardown.test.sh fails one case, 'herdr-preflight-missing-adapter', on this machine. It was confirmed to fail identically at HEAD with the same 12 preceding cases passing.

## What Changed

- Added `bin/fm-usage-harvest.sh`, which appends one JSON row per finished task to the gitignored `data/usage-ledger.jsonl` and owns that line schema. It sums per-request token usage from claude, codex, and pi/pi-signed session logs (every other harness records `source=unavailable` with null token fields), binds pi and codex logs to a task by the cwd in the log's own session record, and derives the task window from the status file's birth epoch and the epoch in the meta's `spawn_gen` token rather than mutable file mtimes, so a later meta write such as PR registration cannot collapse `wall_secs` to zero. `bin/fm-usage-report.sh` reads the ledger back as aligned per-model and per-task totals. `tests/fm-usage-harvest.test.sh` covers the harvest through the script interface with fixture session logs and portable timestamp helpers.
- `bin/fm-teardown.sh` now runs the best-effort harvest before `status_retire_presentation_task` at both call sites. That retirement deletes `state/<id>.status`, so the previous ordering lost the task window and the turn count on every real teardown; a harvest failure still only warns and never blocks teardown.
- `bin/fm-spawn.sh` replaces blanket permission bypasses in the crewmate launch templates with sandboxed autonomy flags: claude uses `--permission-mode auto`, codex uses `-s workspace-write -a never`, and cursor uses `--trust --auto-review --sandbox enabled`. `AGENTS.md` and `docs/scripts.md` gained the ledger file and the two new script rows.

## Risk Assessment

✅ Low: The change is well-bounded, shellcheck-clean, covered by 21 behavioral cases that exercise public interfaces only, and its two core parsers were verified here against real Pi and Claude session logs; the three pipeline fix rounds correctly resolved the TSV field-collapse, the touch/UTC skew, the GNU stat-shim concatenation and the ledger temp-file leak, leaving only one low-realism parser edge.

## Testing

I ran the colocated harvester suite (22 cases, all green) plus the two teardown suites the reordering touches, then went past unit tests to demonstrate the intent the way an operator experiences it: a real harness=pi task harvested against this machine's actual, unmodified ~/.pi/agent/sessions tree, with the meta mtime deliberately rewritten to the end of the task to reproduce the PR-registration write. The pre-change harvester, extracted verbatim from 12f6613 and run on identical fixtures, produced exactly the reported real-world symptoms (wall_secs 0, turns 0, all token fields null, source unavailable); this change produces wall_secs 36000, turns 3, input 764567, cached 11715456, output 109463, reasoning 71737 and source pi-sessions. An independent jq recomputation over the same two real logs matched all four token fields exactly, and bin/fm-usage-report.sh renders the row correctly, so the ledger and the reader agree. A spot check confirmed opencode, grok, kimi, cursor and muse still fall through to null/unavailable with the same real log tree in reach. No visual artifact applies: the surface is a JSONL ledger line and a text report, both captured as CLI transcripts. The only failing test, tests/fm-teardown.test.sh 'herdr-preflight-missing-adapter', reproduces identically in a clean checkout of the pre-change commit and is therefore not a regression from this change. The worktree is clean and all scratch copies were removed.

<details>
<summary>Evidence: Real Pi harvest: before/after transcript, independent jq cross-check, and rendered usage report</summary>

Source: [Real Pi harvest: before/after transcript, independent jq cross-check, and rendered usage report](https://github.com/npayette84/firstmate/blob/a1f13d5d6b828740c67aadb60193003695b5a2ba/.no-mistakes/evidence/fm/fm-harvester-v2/real-pi-harvest-evidence.txt)

<code>### BEFORE (harvester at 12f6613, teardown had already removed the status log)&#10;{&#34;task&#34;:&#34;before-a&#34;,&#34;harness&#34;:&#34;pi&#34;,&#34;model&#34;:&#34;zai/glm-4.6&#34;,&#34;effort&#34;:null,&#34;spawned_at&#34;:&#34;2026-08-31T14:20:00Z&#34;,&#34;completed_at&#34;:&#34;2026-08-31T14:20:00Z&#34;,&#34;wall_secs&#34;:0,&#34;turns&#34;:0,&#34;input_tokens&#34;:null,&#34;cached_input_tokens&#34;:null,&#34;output_tokens&#34;:null,&#34;reasoning_tokens&#34;:null,&#34;source&#34;:&#34;unavailable&#34;}&#10;&#10;### BEFORE (harvester at 12f6613, status log kept)&#10;{&#34;task&#34;:&#34;before-b&#34;,...,&#34;wall_secs&#34;:0,&#34;turns&#34;:3,&#34;input_tokens&#34;:null,...,&#34;source&#34;:&#34;unavailable&#34;}&#10;&#10;### AFTER (this change, status log kept)&#10;{&#34;task&#34;:&#34;after-a&#34;,&#34;harness&#34;:&#34;pi&#34;,&#34;model&#34;:&#34;zai/glm-5.3-flash&#34;,&#34;effort&#34;:null,&#34;spawned_at&#34;:&#34;2026-08-31T04:20:00Z&#34;,&#34;completed_at&#34;:&#34;2026-08-31T14:20:00Z&#34;,&#34;wall_secs&#34;:36000,&#34;turns&#34;:3,&#34;input_tokens&#34;:764567,&#34;cached_input_tokens&#34;:11715456,&#34;output_tokens&#34;:109463,&#34;reasoning_tokens&#34;:71737,&#34;source&#34;:&#34;pi-sessions&#34;}&#10;&#10;### AFTER (this change, status log removed - wall + tokens still survive on spawn_gen)&#10;{&#34;task&#34;:&#34;after-b&#34;,...,&#34;wall_secs&#34;:36000,&#34;turns&#34;:0,&#34;input_tokens&#34;:764567,&#34;cached_input_tokens&#34;:11715456,&#34;output_tokens&#34;:109463,&#34;reasoning_tokens&#34;:71737,&#34;source&#34;:&#34;pi-sessions&#34;}&#10;&#10;Independent jq recomputation over the same real logs in window whose session cwd matches:&#10;/Users/npayette/.treehouse/firstmate-e5afef/3/firstmate input=677858 cached=11216256 output=85861 reasoning=59337 records=108&#10;/Users/npayette/.treehouse/firstmate-e5afef/3/firstmate input=86709 cached=499200 output=23602 reasoning=12400 records=10&#10;&#10;Arithmetic check: harvested row == sum of the independent jq rows&#10;input_tokens harvested= 764567 independent= 764567 MATCH&#10;cached_input_tokens harvested= 11715456 independent= 11715456 MATCH&#10;output_tokens harvested= 109463 independent= 109463 MATCH&#10;reasoning_tokens harvested= 71737 independent= 71737 MATCH&#10;&#10;End-user surface: bin/fm-usage-report.sh over the harvested ledger&#10;per-model totals (source-available rows):&#10;model tasks input cached output reasoning wall_secs&#10;zai/glm-5.3-flash 1 764567 11715456 109463 71737 36000&#10;&#10;per-task rows:&#10;task harness model effort input cached output reasoning wall_secs source&#10;after-a pi zai/glm-5.3-flash - 764567 11715456 109463 71737 36000 pi-sessions</code>

```text
==================================================================
 Fixture: one finished harness=pi task
   worktree      : /Users/npayette/.treehouse/firstmate-e5afef/3/firstmate
   spawn_gen     : s1788150000.41234.a1b2c3   (2026-08-31T04:20:00Z)
   last status   : 1788186000                   (2026-08-31T14:20:00Z)
   true wall     : 36000s over 3 'working:' turns
   Pi log tree   : /Users/npayette/.pi/agent/sessions   (real, unmodified, read-only)
   meta mtime was rewritten to the END of the task (PR registration)
==================================================================

### BEFORE (harvester at 12f6613, teardown had already removed the status log)
{"task":"before-a","harness":"pi","model":"zai/glm-4.6","effort":null,"spawned_at":"2026-08-31T14:20:00Z","completed_at":"2026-08-31T14:20:00Z","wall_secs":0,"turns":0,"input_tokens":null,"cached_input_tokens":null,"output_tokens":null,"reasoning_tokens":null,"source":"unavailable"}

### BEFORE (harvester at 12f6613, status log kept)
{"task":"before-b","harness":"pi","model":"zai/glm-4.6","effort":null,"spawned_at":"2026-08-31T14:20:00Z","completed_at":"2026-08-31T14:20:00Z","wall_secs":0,"turns":3,"input_tokens":null,"cached_input_tokens":null,"output_tokens":null,"reasoning_tokens":null,"source":"unavailable"}

### AFTER (this change, status log kept - the teardown order it now runs in)
{"task":"after-a","harness":"pi","model":"zai/glm-5.3-flash","effort":null,"spawned_at":"2026-08-31T04:20:00Z","completed_at":"2026-08-31T14:20:00Z","wall_secs":36000,"turns":3,"input_tokens":764567,"cached_input_tokens":11715456,"output_tokens":109463,"reasoning_tokens":71737,"source":"pi-sessions"}

### AFTER (this change, status log removed - wall + tokens still survive on spawn_gen)
{"task":"after-b","harness":"pi","model":"zai/glm-5.3-flash","effort":null,"spawned_at":"2026-08-31T04:20:00Z","completed_at":"2026-08-31T14:20:00Z","wall_secs":36000,"turns":0,"input_tokens":764567,"cached_input_tokens":11715456,"output_tokens":109463,"reasoning_tokens":71737,"source":"pi-sessions"}

==================================================================
 Independent recomputation, straight jq over the same real Pi logs
 in [1788150000,1788186000] whose session record's cwd is the task worktree
==================================================================
/Users/npayette/.treehouse/firstmate-e5afef/3/firstmate	input=677858 cached=11216256 output=85861 reasoning=59337 records=108
/Users/npayette/.treehouse/firstmate-e5afef/3/firstmate	input=86709 cached=499200 output=23602 reasoning=12400 records=10

==================================================================
 Arithmetic check: harvested row == sum of the independent jq rows
==================================================================
input_tokens           harvested=    764567  independent=    764567  MATCH
cached_input_tokens    harvested=  11715456  independent=  11715456  MATCH
output_tokens          harvested=    109463  independent=    109463  MATCH
reasoning_tokens       harvested=     71737  independent=     71737  MATCH

==================================================================
 End-user surface: bin/fm-usage-report.sh over the harvested ledger
==================================================================
usage ledger: /var/folders/70/p814fs691f103nxddhx58mhh0000gn/T//fm-usage-evidence.5DEROd/home-after-a/data/usage-ledger.jsonl (1 rows)

per-model totals (source-available rows):
model                     tasks        input       cached       output    reasoning  wall_secs
zai/glm-5.3-flash             1       764567     11715456       109463        71737      36000

per-task rows:
task                     harness  model                effort          input       cached       output    reasoning  wall_secs source          
after-a                  pi       zai/glm-5.3-flash    -              764567     11715456       109463        71737      36000 pi-sessions     
```
</details>
<details>
<summary>Evidence: Reproducible evidence script (real Pi tree, before/after, cross-check, report)</summary>

Source: [Reproducible evidence script (real Pi tree, before/after, cross-check, report)](https://github.com/npayette84/firstmate/blob/a1f13d5d6b828740c67aadb60193003695b5a2ba/.no-mistakes/evidence/fm/fm-harvester-v2/real-pi-harvest-evidence.sh)

```text
#!/usr/bin/env bash
# End-to-end evidence for the two harvester defects, run against the REAL,
# unmodified ~/.pi/agent/sessions tree on this machine. Nothing under ~/.pi is
# written; it is only read.
set -eu
WT_REPO=${WT_REPO:?set WT_REPO to the worktree checkout}
NEW_BIN="$WT_REPO/bin"
PI_DIR="$HOME/.pi/agent/sessions"
TASK_CWD=/Users/npayette/.treehouse/firstmate-e5afef/3/firstmate
START=1788150000        # task spawn epoch, as recorded in meta spawn_gen
END=1788186000          # last status append

SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-usage-evidence.XXXXXX")
trap 'rm -rf "$SCRATCH"' EXIT

# The pre-fix harvester, taken verbatim from the commit before this change.
OLD_BIN="$SCRATCH/oldbin"
mkdir -p "$OLD_BIN"
cp "$NEW_BIN"/*.sh "$OLD_BIN"/
git -C "$WT_REPO" show 12f6613:bin/fm-usage-harvest.sh > "$OLD_BIN/fm-usage-harvest.sh"
chmod +x "$OLD_BIN/fm-usage-harvest.sh"

stamp() { date -r "$1" +%Y%m%d%H%M.%S 2>/dev/null || date -d "@$1" +%Y%m%d%H%M.%S; }

# make_home <id> <keep-status> : a firstmate home holding one finished pi task
# whose worktree is a real Pi session cwd. The meta's mtime is pushed to the
# END of the task, exactly as a late PR registration write does.
make_home() {
  local id=$1
  local keep_status=$2
  local home="$SCRATCH/home-$id"
  mkdir -p "$home/state" "$home/data"
  cat > "$home/state/$id.meta" <<META
window=firstmate:fm-$id
endpoint_task_id=$id
worktree=$TASK_CWD
harness=pi
kind=ship
mode=no-mistakes
model=zai/glm-4.6
effort=default
spawn_gen=s$START.41234.a1b2c3
META
  printf 'working: started\nworking: halfway\nworking: wrapping up\ndone: finished\n' \
    > "$home/state/$id.status"
  touch -t "$(stamp "$END")" "$home/state/$id.status"
  [ "$keep_status" = keep ] || rm -f "$home/state/$id.status"
  # The late metadata write (PR registration) lands at the end of the task.
  touch -t "$(stamp "$END")" "$home/state/$id.meta"
  printf '%s' "$home"
}

run_harvest() {  # <bin> <home> <id>
  FM_STATE_OVERRIDE="$2/state" FM_DATA_OVERRIDE="$2/data" \
  FM_USAGE_PI_DIR="$PI_DIR" \
    "$1/fm-usage-harvest.sh" "$3" || echo "(harvest exited $?)"
  cat "$2/data/usage-ledger.jsonl" 2>/dev/null || echo "(no ledger row)"
}

echo "=================================================================="
echo " Fixture: one finished harness=pi task"
echo "   worktree      : $TASK_CWD"
echo "   spawn_gen     : s$START.41234.a1b2c3   ($(date -r $START -u +%FT%TZ))"
echo "   last status   : $END                   ($(date -r $END -u +%FT%TZ))"
echo "   true wall     : $((END - START))s over 3 'working:' turns"
echo "   Pi log tree   : $PI_DIR   (real, unmodified, read-only)"
echo "   meta mtime was rewritten to the END of the task (PR registration)"
echo "=================================================================="
echo
echo "### BEFORE (harvester at 12f6613, teardown had already removed the status log)"
run_harvest "$OLD_BIN" "$(make_home before-a nostatus)" before-a
echo
echo "### BEFORE (harvester at 12f6613, status log kept)"
run_harvest "$OLD_BIN" "$(make_home before-b keep)" before-b
echo
echo "### AFTER (this change, status log kept - the teardown order it now runs in)"
run_harvest "$NEW_BIN" "$(make_home after-a keep)" after-a
echo
echo "### AFTER (this change, status log removed - wall + tokens still survive on spawn_gen)"
run_harvest "$NEW_BIN" "$(make_home after-b nostatus)" after-b
echo
echo "=================================================================="
echo " Independent recomputation, straight jq over the same real Pi logs"
echo " in [$START,$END] whose session record's cwd is the task worktree"
echo "=================================================================="
for f in $(find "$PI_DIR" -type f -name '*.jsonl'); do
  m=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f")
  [ "$m" -ge "$START" ] && [ "$m" -le "$END" ] || continue
  jq -rs --arg wt "$TASK_CWD" '
    if (map(select(.type=="session"))|.[0].cwd) == $wt then
      [.[] | select(.type=="message" and .message.role=="assistant" and .message.usage != null)]
      | "\($wt)\tinput=\(map(.message.usage.input//0)|add) cached=\(map((.message.usage.cacheRead//0)+(.message.usage.cacheWrite//0))|add) output=\(map(.message.usage.output//0)|add) reasoning=\(map(.message.usage.reasoning//0)|add) records=\(length)"
    else empty end' "$f"
done

echo
echo "=================================================================="
echo " Arithmetic check: harvested row == sum of the independent jq rows"
echo "=================================================================="
python3 - "$SCRATCH/home-after-a/data/usage-ledger.jsonl" <<'PYCHK'
import json, sys
row = json.loads(open(sys.argv[1]).read().strip())
expect = {"input_tokens": 677858 + 86709, "cached_input_tokens": 11216256 + 499200,
          "output_tokens": 85861 + 23602, "reasoning_tokens": 59337 + 12400}
for k, v in expect.items():
    print(f"{k:22} harvested={row[k]:>10}  independent={v:>10}  {'MATCH' if row[k]==v else 'MISMATCH'}")
PYCHK

echo
echo "=================================================================="
echo " End-user surface: bin/fm-usage-report.sh over the harvested ledger"
echo "=================================================================="
FM_DATA_OVERRIDE="$SCRATCH/home-after-a/data" "$NEW_BIN/fm-usage-report.sh"
```
</details>
<details>
<summary>Evidence: Untouched harnesses still report unavailable with the real Pi tree in reach</summary>

Source: [Untouched harnesses still report unavailable with the real Pi tree in reach](https://github.com/npayette84/firstmate/blob/a1f13d5d6b828740c67aadb60193003695b5a2ba/.no-mistakes/evidence/fm/fm-harvester-v2/other-harnesses-unchanged.txt)

<code>{&#34;harness&#34;:&#34;opencode&#34;,&#34;input_tokens&#34;:null,&#34;cached_input_tokens&#34;:null,&#34;output_tokens&#34;:null,&#34;reasoning_tokens&#34;:null,&#34;source&#34;:&#34;unavailable&#34;}&#10;{&#34;harness&#34;:&#34;grok&#34;,&#34;input_tokens&#34;:null,&#34;cached_input_tokens&#34;:null,&#34;output_tokens&#34;:null,&#34;reasoning_tokens&#34;:null,&#34;source&#34;:&#34;unavailable&#34;}&#10;{&#34;harness&#34;:&#34;kimi&#34;,&#34;input_tokens&#34;:null,&#34;cached_input_tokens&#34;:null,&#34;output_tokens&#34;:null,&#34;reasoning_tokens&#34;:null,&#34;source&#34;:&#34;unavailable&#34;}&#10;{&#34;harness&#34;:&#34;cursor&#34;,&#34;input_tokens&#34;:null,&#34;cached_input_tokens&#34;:null,&#34;output_tokens&#34;:null,&#34;reasoning_tokens&#34;:null,&#34;source&#34;:&#34;unavailable&#34;}&#10;{&#34;harness&#34;:&#34;muse&#34;,&#34;input_tokens&#34;:null,&#34;cached_input_tokens&#34;:null,&#34;output_tokens&#34;:null,&#34;reasoning_tokens&#34;:null,&#34;source&#34;:&#34;unavailable&#34;}&#10;{&#34;harness&#34;:&#34;pi&#34;,&#34;input_tokens&#34;:764567,&#34;cached_input_tokens&#34;:11715456,&#34;output_tokens&#34;:109463,&#34;reasoning_tokens&#34;:71737,&#34;source&#34;:&#34;pi-sessions&#34;}</code>

```text
{"harness":"opencode","input_tokens":null,"cached_input_tokens":null,"output_tokens":null,"reasoning_tokens":null,"source":"unavailable"}
{"harness":"grok","input_tokens":null,"cached_input_tokens":null,"output_tokens":null,"reasoning_tokens":null,"source":"unavailable"}
{"harness":"kimi","input_tokens":null,"cached_input_tokens":null,"output_tokens":null,"reasoning_tokens":null,"source":"unavailable"}
{"harness":"cursor","input_tokens":null,"cached_input_tokens":null,"output_tokens":null,"reasoning_tokens":null,"source":"unavailable"}
{"harness":"muse","input_tokens":null,"cached_input_tokens":null,"output_tokens":null,"reasoning_tokens":null,"source":"unavailable"}
{"harness":"pi","input_tokens":764567,"cached_input_tokens":11715456,"output_tokens":109463,"reasoning_tokens":71737,"source":"pi-sessions"}
```
</details>
<details>
<summary>Evidence: Untouched-harness spot-check script</summary>

Source: [Untouched-harness spot-check script](https://github.com/npayette84/firstmate/blob/a1f13d5d6b828740c67aadb60193003695b5a2ba/.no-mistakes/evidence/fm/fm-harvester-v2/other-harnesses-unchanged.sh)

```text
#!/usr/bin/env bash
# Spot-check that the harnesses this change did NOT touch still fall through to
# source=unavailable with null token fields, even with the real Pi log tree in
# reach and a worktree that a real Pi session recorded.
set -eu
WT_REPO=${WT_REPO:?}
S=$(mktemp -d "${TMPDIR:-/tmp}/fm-other-harness.XXXXXX"); trap 'rm -rf "$S"' EXIT
CWD=/Users/npayette/.treehouse/firstmate-e5afef/3/firstmate
stamp() { date -r "$1" +%Y%m%d%H%M.%S 2>/dev/null || date -d "@$1" +%Y%m%d%H%M.%S; }
for h in opencode grok kimi cursor muse pi; do
  mkdir -p "$S/$h/state" "$S/$h/data"
  printf 'worktree=%s\nharness=%s\nmodel=default\neffort=default\nspawn_gen=s1788150000.1.a\n' \
    "$CWD" "$h" > "$S/$h/state/t-$h.meta"
  printf 'working: a\ndone: b\n' > "$S/$h/state/t-$h.status"
  touch -t "$(stamp 1788186000)" "$S/$h/state/t-$h.status" "$S/$h/state/t-$h.meta"
  FM_STATE_OVERRIDE="$S/$h/state" FM_DATA_OVERRIDE="$S/$h/data" \
    FM_USAGE_PI_DIR="$HOME/.pi/agent/sessions" \
    "$WT_REPO/bin/fm-usage-harvest.sh" "t-$h"
  jq -c '{harness,input_tokens,cached_input_tokens,output_tokens,reasoning_tokens,source}' \
    "$S/$h/data/usage-ledger.jsonl"
done
```
</details>
<details>
<summary>Evidence: tests/fm-usage-harvest.test.sh transcript (22 cases, all pass)</summary>

Source: [tests/fm-usage-harvest.test.sh transcript (22 cases, all pass)](https://github.com/npayette84/firstmate/blob/a1f13d5d6b828740c67aadb60193003695b5a2ba/.no-mistakes/evidence/fm/fm-harvester-v2/fm-usage-harvest-tests.txt)

```text
ok - claude harvest: per-request dedupe, cache folding, encoding, window, idempotency
ok - claude harvest: window survives a host without usable birth time
ok - codex harvest: cwd/window matching, delta sums, model capture
ok - pi harvest: cwd/window matching, per-request sums, replay dedupe
ok - pi-signed harvest: cwd/window matching, per-request sums, replay dedupe
ok - usage harvest: spawn_gen is the durable start, immune to later meta writes
ok - usage harvest: a malformed spawn_gen falls back to file timestamps
ok - usage harvest: a start later than the end is pinned, not inverted
ok - usage harvest: a relaunch never narrows the row below the turn count's span
ok - usage harvest: the birthless relaunch narrowing matches the stated contract
ok - usage harvest: a corrupt log line costs that line, not the file
ok - usage harvest: a valid non-object log line is skipped, not fatal
ok - usage harvest: an absent log model never shifts the token fields
ok - usage harvest: a source is named only after a log yields assistant usage
ok - cursor harvest: unavailable source renders null token fields
ok - remote secondmate harvest: local logs are never misattributed
ok - usage harvest: concurrent harvests append exactly one row
ok - usage harvest: a held ledger lock bounds the acquire, no hang or dup
ok - usage report: per-model totals, per-task rows, missing-ledger tolerance
ok - usage report: an absent harness renders as a placeholder without shifting columns
ok - teardown integration: the harvest runs while the status log still exists
ok - teardown integration: harvest failure is non-fatal and leaves no work file
```
</details>
<details>
<summary>Evidence: tests/fm-teardown.test.sh at this head</summary>

Source: [tests/fm-teardown.test.sh at this head](https://github.com/npayette84/firstmate/blob/a1f13d5d6b828740c67aadb60193003695b5a2ba/.no-mistakes/evidence/fm/fm-harvester-v2/fm-teardown-tests-after.txt)

<code>ok - herdr flat teardown never erases records when pane presence is unparseable&#10;not ok - herdr-preflight-missing-adapter: teardown continued without its required preflight</code>

```text
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - teardown prompts tasks-axi backlog refresh when compatible
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly
ok - herdr flat teardown never erases records when pane presence is unparseable
not ok - herdr-preflight-missing-adapter: teardown continued without its required preflight

[exited with code 0]
```
</details>
<details>
<summary>Evidence: tests/fm-teardown.test.sh at pre-change commit 12f6613 (same case fails)</summary>

Source: [tests/fm-teardown.test.sh at pre-change commit 12f6613 (same case fails)](https://github.com/npayette84/firstmate/blob/a1f13d5d6b828740c67aadb60193003695b5a2ba/.no-mistakes/evidence/fm/fm-harvester-v2/fm-teardown-tests-before-12f6613.txt)

<code>ok - herdr flat teardown never erases records when pane presence is unparseable&#10;not ok - herdr-preflight-missing-adapter: teardown continued without its required preflight</code>

```text
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly
ok - herdr flat teardown never erases records when pane presence is unparseable
not ok - herdr-preflight-missing-adapter: teardown continued without its required preflight
SCRATCH=/var/folders/70/p814fs691f103nxddhx58mhh0000gn/T//fm-prechange.0T17nl

[exited with code 0]
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (6m44s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"43ac8bddcfb112b22751232829483337d06277c9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `.agents/skills/afk/SKILL.md` - branch carries 10 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (266 file(s)) into the PR:
- 12f6613 Merge pull request #1 from npayette84/fm/fm-harvester-ship
- 3ad41e8 no-mistakes: apply CI fixes
- ad467de no-mistakes: apply CI fixes
- b61545d no-mistakes: apply CI fixes
- 6b74583 no-mistakes(document): document usage harvester scripts; refresh stale spawn launch comments
- 1a16a6d no-mistakes(review): fix claude dot-encoding and birthless harvest window collapse
- 6f3e8ec fix(bin): create the ledger data dir before the harvest write, not after
- 9a2def5 add the fleet usage harvester, report reader, and teardown harvest hook
- 96b4c98 harden the Cursor launch default to sandboxed review
- 210839c harden crewmate launch defaults to sandboxed approval

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-usage-harvest.sh:185` - epoch_to_touch&#39;s GNU fallback renders the stamp in UTC (`date -u -d &#34;@$1&#34; +%Y%m%d%H%M.%S`) but `touch -t` interprets its argument in LOCAL time, so on GNU/Linux hosts in a non-UTC timezone both window ref files are shifted by the UTC offset. Verified on this machine (TZ=EDT): `touch -t &#34;$(date -u -r 1756600000 +%Y%m%d%H%M.%S)&#34;` produced mtime 1756614400 instead of 1756600000, a 14400s skew. Because matched_files() gates candidates on `find -newer &#34;$REFDIR/start&#34; ! -newer &#34;$REFDIR/end&#34;`, a west-of-UTC host shifts both refs later and drops every session log whose mtime falls in [START, START+offset]; an east-of-UTC host shifts them earlier and drops the tail of the window. The per-file epoch filter at line 205 cannot recover a file `find` never printed, so the row silently degrades to source=unavailable with null tokens - the exact symptom this change was written to eliminate. The BSD branch (`date -r &lt;epoch&gt;`) is correct because it renders local time; only the `-u` on the fallback is wrong. Fix: drop `-u` from the fallback (or use GNU `touch -d &#34;@$epoch&#34;` directly). The `-u` in iso_from_epoch (line 147) is correct and must stay. The same defect was copied into the new test helper tests/fm-usage-harvest.test.sh:41 (touch_stamp), where it will make the new wall_secs/spawned_at assertions fail on any non-UTC Linux runner; fix both together.
- ⚠️ `bin/fm-usage-harvest.sh:324` - `IFS=$&#39;\t&#39; read -r cwd m it ct ot rt &lt;&lt;&lt;&#34;$row&#34;` cannot safely parse the jq @tsv row, because tab is an IFS *whitespace* character in bash: adjacent and leading empty fields are collapsed rather than preserved, shifting every subsequent field left. Verified: `row=$&#39;/tmp/wt\t\t100\t200\t300\t0&#39;; IFS=$&#39;\t&#39; read -r cwd m it ct ot rt` yields cwd=/tmp/wt, m=100, it=200, ct=300, ot=0, rt=(empty). jq renders a null as an empty TSV field (confirmed: `jq -rn &#39;[null,100,200,300,0]|@tsv&#39;` emits a leading tab). Concrete failure: for the pi branch, a session log whose cwd matches the worktree but whose assistant records carry usage without `.message.model` still passes the `[ &#34;$cwd&#34; = &#34;$WORKTREE&#34; ]` gate, then records MODEL_LOG as the input-token count and sums cacheRead into input_tokens, output into cached_input_tokens, reasoning into output_tokens, and 0 into reasoning_tokens. The identical defect is in the claude branch (line 243, 5 fields with .m first: an in-window *.jsonl in the encoded dir with no assistant `model` produces row `\t0\t0\t0\t0` and writes `&#34;model&#34;:&#34;0&#34;` to the ledger) and the codex branch (line 278, a rollout with session_meta but no turn_context). The three accumulate loops are byte-identical apart from the jq program and the cwd gate, so fix this once at that shared boundary rather than three times: either have jq substitute a non-empty sentinel for the nullable string fields and test for it, or read the fields without IFS-whitespace collapsing (e.g. `readarray -t -d $&#39;\t&#39;`).
- ⚠️ `bin/fm-usage-harvest.sh:69` - The header states &#34;A corrupt log line is skipped best-effort by the parser&#34;, but all three parsers use `jq -rn &#39;reduce inputs as $l (...)&#39; &#34;$f&#34; 2&gt;/dev/null || true`, which only emits after the whole file is consumed. A single malformed JSONL line aborts jq with no stdout at all, so `row` is empty and `[ -n &#34;$row&#34; ] || continue` discards the entire file&#39;s usage. Verified: `jq -rn &#39;reduce inputs as $l (0; .+($l.a // 0))&#39;` over a 3-line file with one corrupt middle line exits 5 and prints nothing, losing the two valid records. For the codex and pi branches the loss is worse than an undercount: the cwd binding lives in the same reduce, so a task whose only matching log has one truncated tail line (a realistic state for an append-only session log) leaves found=0 and the whole row degrades to source=unavailable with null tokens rather than reporting partial usage. Either make the parse per-line tolerant (e.g. `jq -Rrn &#39;reduce (inputs | try fromjson catch empty) as $l (...)&#39;`) or correct the header claim, since this file is the declared sole owner of that contract.
- ⚠️ `bin/fm-usage-harvest.sh:164` - Making spawn_gen the primary start silently rescopes a relaunched task&#39;s row to its final incarnation only, which is a behavior change the intent does not call out. bin/fm-spawn.sh:2624 recomputes SPAWN_GEN unconditionally on every spawn AND every --relaunch, and preserve_relaunch_meta (fm-spawn.sh:2636) lists spawn_gen among the keys it replaces rather than carries forward, while state/&lt;id&gt;.status is only ever appended to (no truncation on the relaunch path). Consequence for a task relaunched once: START_EPOCH is the relaunch epoch, so (a) wall_secs measures only the final incarnation, (b) matched_files() filters out the first incarnation&#39;s session logs because their mtime predates the relaunch, undercounting tokens, yet (c) TURNS still counts `^working:` lines from every incarnation. The row therefore reports turns from the whole task against tokens and wall time from one slice of it. The prior status-birth-epoch start spanned all incarnations, so this is a narrowing, not a pre-existing gap. Both readings are defensible - spawn_gen is genuinely an incarnation token - so please confirm whether the ledger row is meant to describe the task or the last incarnation, and if the former, whether preserve_relaunch_meta should carry the original spawn_gen forward (or a separate first-spawn epoch be recorded).
- ℹ️ `bin/fm-usage-harvest.sh:220` - The claude branch sets `SRC=claude-projects` on file presence alone, before any parse, while the codex (line 290) and pi (line 336) branches both gate on `[ &#34;$found&#34; -eq 1 ] || SRC=unavailable`. An in-window *.jsonl in the encoded dir that yields no assistant usage therefore produces a row claiming source=claude-projects with input_tokens 0, where the same shape under pi or codex would honestly report source=unavailable with nulls. Since this file is the sole owner of the source enum&#39;s meaning, the three harnesses disagreeing on what &#34;available&#34; asserts is worth a deliberate decision. This is also the path that lets the field-collapse defect above surface as a literal `&#34;model&#34;:&#34;0&#34;` in the ledger.
- ℹ️ `bin/fm-teardown.sh:2550` - Moving the harvest ahead of `status_retire_presentation_task &#34;$STATE&#34; &#34;$ID&#34; || exit 1` is correct and necessary (that call deletes state/&lt;id&gt;.status, which supplies both the window and the turn count), but it also means the ledger row is now committed before teardown&#39;s last abort point instead of after it. If status retirement fails and teardown exits 1, the row persists; a later successful teardown hits the idempotency guard at line 377 and keeps the first attempt&#39;s window and turns rather than re-measuring. The failure path is narrow and the two measurements would be seconds apart, so this is a noted tradeoff rather than something to change - flagging it only because the ordering constraint is now load-bearing in both directions and any future reshuffle of these steps needs to know that.

🔧 Fix: fix(usage): task-scoped window, tolerant parse, safe TSV read
3 issues (1 warning, 2 infos) still open:
- ⚠️ `bin/fm-usage-harvest.sh:22` - The new header states the row scope unconditionally: &#34;a row describes the WHOLE task, spanning every relaunch, and wall_secs, the session-log window and turns all report that one span.&#34; The code only delivers that when the filesystem reports a birth time. START is min(START_GEN, START_BIRTH) at lines 185-193; on a host where file_birth_epoch fails, START_BIRTH is empty and START collapses to START_GEN, which fm-spawn.sh rewrites to the relaunch epoch on every --relaunch. Concrete reachable path: birthless filesystem (the script itself carries a dedicated fallback for it at line 195, and the suite simulates it with nobirth_stat_bin at tests/fm-usage-harvest.test.sh:375) plus one relaunch -&gt; wall_secs and the find window cover only the final incarnation, while TURNS at line 200 still counts every &#39;^working:&#39; line in the append-only status log. That is exactly the three-way disagreement the header now says cannot happen. Second, concrete consequence: tests/fm-usage-harvest.test.sh:644 relaunch_scope_case hard-asserts wall_secs:600, spawned_at=base, source=claude-projects and input_tokens:21 with no birth-time shim, so on any runner whose tmp dir lacks statx btime (tmpfs, overlayfs, some container mounts) four assertions fail. Every other timestamp case in the suite is birth-agnostic: spawn_gen_case and teardown_status_case put spawn_gen BEFORE the birth so min() picks the token either way, and claude_case computes its expectation with `file_birth_epoch || file_mtime_epoch`. Only the relaunch case depends on the host. Recommended fix, keeping the owner&#39;s scope decision intact and fm-spawn out of scope: (a) qualify the Row scope paragraph to say the whole-task span holds wherever the status file&#39;s birth time is readable, and that on a birthless host a relaunched task&#39;s window and token sum narrow to the last incarnation while turns still span the task; (b) make relaunch_scope_case independent of the host, either by deriving the expectation from file_birth_epoch the way claude_case does, or by pinning birth availability. Note also that relaunch_scope_case takes `base` from the status file&#39;s MTIME and then asserts against the harvester&#39;s BIRTH-derived start, so even on a birth-capable host it flakes by one second whenever creation and the fixture write straddle a second boundary.
- ℹ️ `bin/fm-usage-harvest.sh:297` - `reduce (inputs | try fromjson catch empty) as $l` catches a fromjson failure but not an indexing failure on a line that parses to a valid non-object. Verified: a three-line file whose middle line is `&#34;just a string&#34;` makes jq exit 5 with no stdout (`jq: error: Cannot index string with string &#34;type&#34;`), so `row` is empty, the file is skipped entirely, and for codex/pi the cwd binding goes with it and the row degrades to source=unavailable with null tokens. Blank lines and truncated JSON are correctly tolerated (both verified to emit the surviving records), so the realistic append-only truncation case is covered; this is the residual. The header at line 86 makes the claim without qualification (&#34;A corrupt log line is skipped best-effort by the parser, which reads each line on its own and keeps the rest of that file&#39;s usage&#34;), and this file is the sole owner of that contract. One-token fix in all three programs: `try (fromjson | objects) catch empty`, which drops a non-object line instead of aborting.
- ℹ️ `bin/fm-usage-report.sh:55` - The per-task loop still reads the jq @tsv stream with `IFS=$&#39;\t&#39; read -r task harness model effort it ct ot rt wall source`, the exact pattern just removed from the harvester because tab is an IFS whitespace character and empty fields collapse. Most columns are protected by a `// &#34;-&#34;` default at lines 50-54, but `.harness` is emitted bare, and the harvester writes `&#34;harness&#34;:$harness` from an unguarded `meta_get harness` (bin/fm-usage-harvest.sh:136, no `&#34;&#34; -&gt; null` mapping unlike model and effort), so a task record missing a `harness=` line produces an empty second field and shifts model, effort and every token column one slot left in the rendered report. Impact is display-only and the input is malformed metadata, but the fix is one character: emit `(.harness // &#34;-&#34;)` with an empty-string guard, or apply the same `tr &#39;\t&#39; &#39;\037&#39;` separator the harvester now uses.

🔧 Fix: fix(usage): document scope limit, skip non-objects, guard report columns
2 issues (1 error, 1 info) still open:
- 🚨 `tests/fm-usage-harvest.test.sh:390` - Both `stat` test shims resolve the `%Y` format with `/usr/bin/stat -f %m -- &#34;$file&#34; 2&gt;/dev/null || /usr/bin/stat -c %Y -- &#34;$file&#34;`, two commands sharing one stdout. On GNU/Linux `stat -f %m -- &lt;file&gt;` treats `%m` as an operand, fails on it, but still prints the full file-system info block for &lt;file&gt; to stdout and exits 1. Verified in debian:stable-slim: the captured value is `[  File: &#34;/tmp/f&#34;\n    ID: ... Namelen: 255 Type: overlayfs\nBlock size: 4096 ...\nInodes: Total: ... Free: ...\n1788185391]`. The `||` then appends the real epoch to that same stream, so the harvester&#39;s `file_mtime_epoch` (bin/fm-usage-harvest.sh:157) rejects it as non-numeric and returns 1 for every file, including the status and meta files. `END_EPOCH=$(file_mtime_epoch &#34;$STATUS&#34; 2&gt;/dev/null || file_mtime_epoch &#34;$META&#34;)` at line 190 therefore fails under `set -eu` and fm-usage-harvest.sh exits 1 without writing a ledger row. Three cases assert `expect_code 0` and then parse the row, so all three fail on ubuntu-latest (every job in .github/workflows/ci.yml): claude_nobirth_case and relaunch_birthless_case via nobirth_stat_bin (line 390), and relaunch_scope_case via fixedbirth_stat_bin (line 412), which this fix round newly introduced by copying the same pattern. They pass on macOS only because the BSD probe succeeds there, which is why local verification did not catch it. Fix both shims the way the harvester itself already does it, with two separate assignments so the second read replaces the first&#39;s output rather than appending to it: `t=$(/usr/bin/stat -f %m -- &#34;$file&#34; 2&gt;/dev/null) || t=$(/usr/bin/stat -c %Y -- &#34;$file&#34;); printf &#39;%s\n&#39; &#34;$t&#34;`. Production code is not affected. Note this is the same class of Linux-portability defect the change already fixed deliberately for `date -r` in touch_stamp/iso_utc.
- ℹ️ `bin/fm-usage-harvest.sh:434` - The ledger append writes jq&#39;s output to `$DATA/usage-ledger.jsonl.tmp.$$` and then `cat`s that file into the ledger with `&amp;&amp; rm -f`. The whole check-and-append already runs inside the `$DATA/.usage-ledger.lock` critical section acquired at lines 406-413, so the temp file adds no atomicity, only a leak path. When `cat ... &gt;&gt; &#34;$LEDGER&#34;` fails (for instance with the ledger path unwritable, which is exactly the state tests/fm-usage-harvest.test.sh:671 constructs by making `data/usage-ledger.jsonl` a directory), the `&amp;&amp;` suppresses the `rm -f`, `set -e` exits the script, and `harvest_cleanup` at line 217 removes only REFDIR and the lock. Every failed harvest therefore leaves another `usage-ledger.jsonl.tmp.&lt;pid&gt;` in the data dir, and teardown&#39;s `|| echo warning` path means those failures are silent-but-continuing rather than loud. The same leak occurs if jq itself fails, since the exit happens before the cat. Redirecting jq straight to `&gt;&gt; &#34;$LEDGER&#34;` is behaviorally equivalent under the lock, one line shorter, and has no leak path.

🔧 Fix: fix(usage): portable stat shim, drop ledger temp file
1 info still open:
- ℹ️ `bin/fm-usage-harvest.sh:352` - The per-line tolerance guard `try (fromjson | objects) catch empty` covers parse failures and non-object lines, but not a type error raised inside the reduce update expression, so the header&#39;s claim at line 95 (&#34;A corrupt log line is skipped best-effort by the parser, which reads each line on its own and keeps the rest of that file&#39;s usage&#34;) is still not true for one shape. Verified end-to-end through the public script interface: a pi fixture whose middle line is `{&#34;type&#34;:&#34;message&#34;,&#34;id&#34;:&#34;m2&#34;,&#34;message&#34;:&#34;truncated-but-valid-json&#34;}` makes `$l.message.role` raise `Cannot index string with string &#34;role&#34;`, jq exits 5 with no stdout, the file is skipped whole, the cwd binding is lost with it, and the harvester writes `&#34;input_tokens&#34;:null … &#34;source&#34;:&#34;unavailable&#34;` instead of the surrounding 105 input tokens. The same class hits the claude branch via `.seen[$id]` when `.message.id` is a number (`Cannot index object with number`, jq exit 5) and the codex branch via `$l.payload.type` when `.payload` is a scalar. Realism is low - real Pi, Claude and Codex logs never emit these shapes, and the realistic append-only truncation case produces invalid JSON that the existing guard already tolerates correctly (confirmed) - so this is a residual edge rather than a live defect. If it is worth closing, the smallest fix is to wrap the reduce update expression in `try (&lt;body&gt;) catch .` in all three programs, which drops the offending line and keeps the accumulator; otherwise the header sentence should name the limit.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-teardown.test.sh:1524` - tests/fm-teardown.test.sh fails the &#39;herdr-preflight-missing-adapter&#39; case on this machine. Confirmed PRE-EXISTING and not caused by this change: the same case fails identically in a clean scratch checkout of the pre-change commit 12f6613, with the same preceding cases passing. Root cause looks like a fixture issue rather than a product one - the case deletes bin/backends/herdr.sh from a copied test-root but still passes FM_ROOT_OVERRIDE=&#34;$ROOT&#34;, so fm-teardown.sh resolves the adapter from the intact repo root and never hits the missing-adapter preflight. Flagged for the author to decide, since it is outside this change&#39;s scope.
- <code>`bash tests/fm-usage-harvest.test.sh` - all 22 cases pass (claude/codex/pi/pi-signed parsing, spawn_gen window, relaunch scope, corrupt-line tolerance, cursor and remote unavailable rows, ledger lock idempotency, report rendering, teardown integration)</code>
- <code>`bash tests/fm-teardown-endpoint-safety.test.sh` - all cases pass (one skip: tmux not installed)</code>
- <code>`bash tests/fm-teardown.test.sh` - 12 pass, 1 pre-existing failure `herdr-preflight-missing-adapter`</code>
- <code>Pre-existence check: `git archive 12f6613 | tar -x -C $SCRATCH &amp;&amp; bash tests/fm-teardown.test.sh` in the scratch copy - same single case fails identically at the pre-change commit</code>
- <code>Manual end-to-end harvest against the REAL unmodified `~/.pi/agent/sessions` tree, comparing the pre-change harvester (`git show 12f6613:bin/fm-usage-harvest.sh`) with this change over identical fixtures: `real-pi-harvest-evidence.sh`</code>
- <code>Independent recomputation of the same real Pi logs with a standalone `jq -rs` program, cross-checked field by field against the harvested ledger row</code>
- <code>`bin/fm-usage-report.sh` rendered over the harvested ledger to capture the end-user reporting surface</code>
- <code>Untouched-harness spot check for opencode, grok, kimi, cursor, muse and pi against the same real Pi tree and worktree: `other-harnesses-unchanged.sh`</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `docs/verification/runtime-backends.md:776` - docs/verification/runtime-backends.md still records the cursor probe&#39;s child argv as `--trust --yolo` and an `Autonomy | --yolo` row (lines 776, 853-854). I deliberately left these unchanged: they sit under a dated `VERIFIED ... 2026-08-11` heading and are maintainer-verification evidence of what was observed at that time, not a statement of the current launch contract, which now lives in bin/fm-spawn.sh. If the project would rather have that record re-probed against the new `--auto-review --sandbox enabled` posture, that is a follow-up verification task rather than a prose edit, since rewriting the observed output would falsify the evidence.

🔧 Fix: drop out-of-scope launch hunks, rewrap harvester header
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
