### PR TITLE
feat: add compact fleet review mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,8 +377,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 22 ] || {
-            echo "::error::expected 22 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 24 ] || {
+            echo "::error::expected 24 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,8 +377,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 21 ] || {
-            echo "::error::expected 21 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 22 ] || {
+            echo "::error::expected 22 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,8 +377,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 21 ] || {
+            echo "::error::expected 21 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,7 +413,7 @@ Handle actionable wakes as follows:
 1. For `signal:`, read the listed event lines first, then reconcile current state only where action depends on it.
 2. For `stale:`, inspect the recorded endpoint and load `stuck-crewmate-recovery` for a stopped, looping, confused, or unresponsive worker; a deep-inspection reason also requires current-state and validation-log inspection.
 3. For `check:`, act on the named poll result, including merges, Relay events, process-to-event source results, and captain inbox notes; a handled inbox note is also acknowledged with `bin/fm-inbox.sh drain --ack <id>`, or it stays counted as still waiting for firstmate.
-4. For `heartbeat:`, review the whole fleet from the structured fleet view, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
+4. For `heartbeat:`, review the whole fleet with `bin/fm-fleet-view.sh --compact`, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
 
 When any wake reports a merged PR for a project cloned in this home, refresh that clone through the guarded fleet-sync path.
 When Relay-linked work reaches a milestone or terminal state, load `fmx-respond`; before terminal teardown, use its promised-final reconciliation when a typed public commitment exists, otherwise post the final completion follow-up so the link clears even if earlier follow-ups were spent.

--- a/bin/fm-branch-prompt.sh
+++ b/bin/fm-branch-prompt.sh
@@ -54,7 +54,7 @@ Handle it start to finish in one turn sequence:
 6. Release every lease you claimed: `bin/fm-lease.sh release <task>`.
 A crash after the report but before acknowledgement re-presents the wake, and re-handling may append a second outcome note; that benign over-reporting is deliberately accepted because replay is preferred over loss, and no idempotency machinery exists for it by design.
 
-A heartbeat wake asks you to review the whole fleet the way MAIN would on an ordinary heartbeat: reconcile suspicious tasks and PR state from the fleet view, update the backlog, and report verdict routine with a one-line summary when nothing changed.
+A heartbeat wake asks you to review the whole fleet the way MAIN would on an ordinary heartbeat: run `bin/fm-fleet-view.sh --compact`, reconcile suspicious tasks and PR state, update the backlog, and report verdict routine with a one-line summary when nothing changed.
 Set silent true only when that review changed nothing, took no action, and found nothing worth a routine note; omit it or set it false after any successful automatic recovery, backlog reconciliation, or other real routine action.
 Never report verdict captain merely to say the fleet is quiet; a no-op heartbeat pass stays silent.
 

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -830,6 +830,7 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
         omitted:[
           (if ($active_all | length) > $child_n then {surface:"active_children",count:(($active_all | length) - $child_n)} else empty end),
           (if ($decisions_all | length) > $decisions_n then {surface:"decisions_open",count:(($decisions_all | length) - $decisions_n)} else empty end),
+          (if ($holds_all | length) > $queued_n then {surface:"holds",count:(($holds_all | length) - $queued_n)} else empty end),
           (if ($queued_all | length) > $queued_n then {surface:"queued",count:(($queued_all | length) - $queued_n)} else empty end),
           (if ($tasks | length) > $child_n then {surface:"endpoints",count:(($tasks | length) - $child_n)} else empty end),
           (if $landed_n > 0 and ($landed_all | length) > $landed_n then {surface:"landed",count:(($landed_all | length) - $landed_n)} else empty end)
@@ -1361,7 +1362,8 @@ secondmate_current_json() {  # <parent-tasks-json>
          reconcile_inventory:(if $summary_sampled then $summary.invalidity else null end),
          provenance:{selected:$provenance,structured_home:($home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
          freshness:{status:$freshness,observed_at:$observed,age_seconds:$event_age},
-         active_children:[],decisions_open:[],holds:[],queued:[],landed:[],endpoints:[],counts:{active_children:0,decisions_open:0,holds:0,queued:0,landed:0,endpoints:0},omitted:[],
+         active_children:[],decisions_open:[],holds:[],queued:[],landed:[],endpoints:[],counts:{active_children:0,decisions_open:0,holds:0,queued:0,landed:0,endpoints:0},
+         omitted:(if $summary_sampled then $summary.omitted else [] end),
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi

--- a/bin/fm-fleet-view.sh
+++ b/bin/fm-fleet-view.sh
@@ -51,7 +51,11 @@ if [ "$MODE" = compact ]; then
   COMPACT_ESCAPE_HOME=$(printf '%s\n' "$SNAPSHOT" | jq -r '.fm_home')
   COMPACT_ESCAPE_HOME=$(cd "$COMPACT_ESCAPE_HOME" && pwd -P) || exit $?
   COMPACT_ESCAPE_DIR=$(pwd -P) || exit $?
-  printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" --arg escape_home "$COMPACT_ESCAPE_HOME" --arg escape_dir "$COMPACT_ESCAPE_DIR" '
+  case "${FM_HOME:-}" in
+    ""|/*) COMPACT_ESCAPE_NEEDS_DIRECTORY=false ;;
+    *) COMPACT_ESCAPE_NEEDS_DIRECTORY=true ;;
+  esac
+  printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" --arg escape_home "$COMPACT_ESCAPE_HOME" --arg escape_dir "$COMPACT_ESCAPE_DIR" --argjson escape_needs_directory "$COMPACT_ESCAPE_NEEDS_DIRECTORY" '
     def dash($v): if $v == null or $v == "" then "-" else $v end;
     def endpoint_exists($t):
       if $t.endpoint.exists == null then "unknown"
@@ -140,15 +144,15 @@ if [ "$MODE" = compact ]; then
       "Rows shown/total: under-way=\($under_way)/\($under_way); queued=\($queued)/\($queued); done=0/\($done).",
       "Raw-view omissions: done detail rows=\($done); task path cells=\($paths_omitted).",
       "Compact renderer truncation: none.",
-      (if $home == $escape_home then
-         "Full human detail: FM_HOME=\($escape_home | @sh) \($view_script | @sh) --raw"
-       else
+      (if $escape_needs_directory then
          "Full human detail: cd \($escape_dir | @sh) && FM_HOME=\($home | @sh) \($view_script | @sh) --raw"
-       end),
-      (if $home == $escape_home then
-         "Complete raw snapshot: FM_HOME=\($escape_home | @sh) \($view_script | @sh) --json"
        else
+         "Full human detail: FM_HOME=\($home | @sh) \($view_script | @sh) --raw"
+       end),
+      (if $escape_needs_directory then
          "Complete raw snapshot: cd \($escape_dir | @sh) && FM_HOME=\($home | @sh) \($view_script | @sh) --json"
+       else
+         "Complete raw snapshot: FM_HOME=\($home | @sh) \($view_script | @sh) --json"
        end),
       "Full queued hold detail: tasks-axi show <id> --full, or \(($escape_home + "/data/backlog.md") | @sh).",
       "Actions: peek = bin/fm-peek.sh fm-<row-id>; return = bin/fm-send.sh fm-<row-id> \u0027<request>\u0027, then read status/doc and do not routinely peek a secondmate.",

--- a/bin/fm-fleet-view.sh
+++ b/bin/fm-fleet-view.sh
@@ -4,29 +4,184 @@
 # This command intentionally does not parse fleet state itself.
 # It shells out to fm-fleet-snapshot.sh --json and renders that stable
 # structured contract for humans.
+#
+# The default and --raw views are the complete historical human rendering.
+# --compact is an explicit model-facing projection for recurring fleet reviews:
+# every under-way and queued row remains in snapshot order, every state and
+# endpoint error remains visible, and open decisions and hold reasons remain
+# explicit.
+# The renderer never truncates output, and it explicitly discloses bounded or
+# incomplete secondmate evidence inherited from the snapshot.
+# Done-row detail and populated task-path cells are the only deliberate
+# omissions from the historical human view; each class has an exact count and
+# a complete-detail command or path in the output.
+# Repeated per-task action commands collapse into exact row-id templates rather
+# than disappearing.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   cat <<'EOF'
-usage: fm-fleet-view.sh [--json]
+usage: fm-fleet-view.sh [--raw|--compact|--json]
 
 Render a human fleet view from fm-fleet-snapshot.sh.
-Use --json to print the underlying snapshot.
+The default and --raw print the complete historical human view.
+--compact keeps every under-way and queued row, counts every omission from
+raw mode, applies no renderer truncation, discloses incomplete snapshot
+evidence, and prints exact full-detail commands.
+--json prints the complete underlying snapshot.
 EOF
 }
 
+MODE=raw
 case "${1:-}" in
   -h|--help) usage; exit 0 ;;
+  --raw|"") ;;
+  --compact) MODE=compact ;;
   --json) "$SCRIPT_DIR/fm-fleet-snapshot.sh" --json; exit $? ;;
-  "") ;;
   *) usage >&2; exit 2 ;;
 esac
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-view: jq not found" >&2; exit 1; }
 
 SNAPSHOT=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" --json) || exit $?
+
+if [ "$MODE" = compact ]; then
+  printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" '
+    def dash($v): if $v == null or $v == "" then "-" else $v end;
+    def endpoint_exists($t):
+      if $t.endpoint.exists == null then "unknown"
+      elif $t.endpoint.exists then "present"
+      else "absent" end;
+    def endpoint_of($t):
+      if $t.kind == "secondmate" then "\(endpoint_exists($t))/\($t.endpoint.agent_alive)"
+      else endpoint_exists($t) end;
+    def artifact($t):
+      if $t.pr.url != null then $t.pr.url
+      elif $t.paths.report.present then $t.paths.report.path
+      else null end;
+    def path_of($t):
+      if $t.paths.home.present then $t.paths.home.path
+      elif $t.paths.home.path != null then $t.paths.home.path + " (absent)"
+      elif $t.paths.worktree.present then $t.paths.worktree.path
+      elif $t.paths.worktree.path != null then $t.paths.worktree.path + " (absent)"
+      else "-" end;
+    def home_path($v; $home):
+      if $v == null or $v == "-" then dash($v)
+      elif $v == $home then "$FM_HOME"
+      elif ($v | startswith($home + "/")) then "$FM_HOME/" + ($v | ltrimstr($home + "/"))
+      else $v end;
+    def attention($t):
+      ($t.current_state.state != "working")
+      or ($t.endpoint.exists != true)
+      or ($t.kind == "secondmate" and $t.endpoint.agent_alive != "alive")
+      or ((($t.hints.open_decisions // []) | length) > 0);
+    def task_action($t): if $t.kind == "secondmate" then "return" else "peek" end;
+    def hold_detail($r):
+      if ($r.hold_reason // "") == "" then null
+      else "\(dash($r.hold_kind)): \($r.hold_reason)"
+        + (if ($r.hold_until // "") == "" then "" else " until \($r.hold_until)" end)
+      end;
+    def task_row($t; $home):
+      (if attention($t) then "! " else "- " end)
+      + "\($t.id): \($t.current_state.state)/\($t.current_state.source)"
+      + "; \($t.kind) \(dash($t.backlog.repo // $t.project))"
+      + "; \($t.backend) \(endpoint_of($t))"
+      + (if $t.current_state.state != "working" and (($t.current_state.detail // "") != "")
+         then "; detail=\($t.current_state.detail)" else "" end)
+      + (if hold_detail($t.backlog) == null then "" else "; hold=\(hold_detail($t.backlog))" end)
+      + (if artifact($t) == null then "" else "; artifact=\(home_path(artifact($t); $home))" end)
+      + "; action=\(task_action($t))";
+    def decision_row($t; $d):
+      "  ! decision \($t.id)[key=\($d.key)]: \($d.verb): \($d.summary)";
+    def blocker($r):
+      if ($r.blocked_by // "") == "" then "-"
+      elif ($r.blocked_reason // "") == "" then $r.blocked_by
+      else "\($r.blocked_by) - \($r.blocked_reason)" end;
+    def backlog_artifact($r): $r.pr_url // $r.report_path // $r.local_note;
+    def backlog_row($r; $home):
+      (if (($r.captain_actionable // false) or ($r.structured == false)) then "! " else "- " end)
+      + (if $r.structured then
+          "\($r.id): \($r.title); \(dash($r.repo)) \(dash($r.kind))"
+          + (if blocker($r) == "-" then "" else "; blocked=\(blocker($r))" end)
+          + (if hold_detail($r) == null then "" else "; hold=\(hold_detail($r))" end)
+          + (if backlog_artifact($r) == null then "" else "; artifact=\(home_path(backlog_artifact($r); $home))" end)
+        else "unstructured: \($r.raw)" end);
+    def secondmate_evidence_issue($r; $home):
+      if $r.current.state == "unknown" then
+        "! secondmate evidence \($r.id): unavailable; home=\(home_path($r.home; $home)); reason=\(dash($r.current.reason))"
+      else empty end,
+      if $r.provenance.trust == "partial-structured" then
+        "! secondmate evidence \($r.id): partial; home=\(home_path($r.home; $home)); reason=\(dash($r.current.reason))"
+      else empty end,
+      if ($r.contradiction // false) then
+        "! secondmate evidence \($r.id): contradictory; home=\(home_path($r.home; $home))"
+      else empty end;
+    def secondmate_omission($r):
+      $r.omitted[]?
+      | "! secondmate evidence \($r.id): bounded \(.surface) omitted=\(.count)";
+
+    .fm_home as $home
+    | ([.tasks[].id]) as $task_ids
+    | ([.backlog.records[]?
+        | select(.state == "in_flight")
+        | select((.structured | not) or (.id as $id | $task_ids | index($id) | not))]) as $unmatched_in_flight
+    | ((.tasks | length) + ($unmatched_in_flight | length)) as $under_way
+    | ([.backlog.records[]? | select(.state == "queued")] | length) as $queued
+    | ([.backlog.records[]? | select(.state == "done")] | length) as $done
+    | ([.tasks[] | select(path_of(.) != "-")] | length) as $paths_omitted
+    | "# Fleet View (compact)",
+      "",
+      "Home: \($home)",
+      "Rows shown/total: under-way=\($under_way)/\($under_way); queued=\($queued)/\($queued); done=0/\($done).",
+      "Raw-view omissions: done detail rows=\($done); task path cells=\($paths_omitted).",
+      "Compact renderer truncation: none.",
+      "Full human detail: FM_HOME=\($home | @sh) \($view_script | @sh) --raw",
+      "Complete raw snapshot: FM_HOME=\($home | @sh) \($view_script | @sh) --json",
+      "Full queued hold detail: tasks-axi show <id> --full, or \(($home + "/data/backlog.md") | @sh).",
+      "Actions: peek = bin/fm-peek.sh fm-<row-id>; return = bin/fm-send.sh fm-<row-id> \u0027<request>\u0027, then read status/doc and do not routinely peek a secondmate.",
+      "Attention marker: ! means a non-working task, endpoint problem, open decision, captain-actionable row, unstructured row, or inventory error.",
+      (if .backlog.present != true then
+         "! inventory error: backlog missing: \(.backlog.path)"
+       elif .main_inventory.valid then empty
+       else "! inventory error: \(.main_inventory.reason); orphan in-flight=\(.main_inventory.orphan_in_flight | join(",")); unstructured current=\(.main_inventory.unstructured_current_count)"
+       end),
+      "",
+      "## Under Way",
+      (if $under_way == 0 then "None."
+       else (.tasks[] | . as $task
+         | task_row($task; $home),
+           ($task.hints.open_decisions[]? | decision_row($task; .))),
+         ($unmatched_in_flight[]
+          | if .structured then backlog_row(.; $home)
+            else "! inventory item: unstructured in-flight: \(.raw)" end)
+       end),
+      "",
+      "## Queued",
+      (if $queued == 0 then "None."
+       else (.backlog.records[] | select(.state == "queued") | backlog_row(.; $home))
+       end),
+      "",
+      "## Done",
+      "\($done) detail row(s) omitted; use the full-human-detail command above.",
+      "",
+      "## Secondmates",
+      .secondmate_guidance.note,
+      (if .secondmate_current.registry.available != true then
+         "! secondmate registry unavailable: \(dash(.secondmate_current.registry.reason))"
+       elif .secondmate_current.registry.complete != true then
+         "! secondmate registry incomplete: \((.secondmate_current.registry.reasons // []) | join(","))"
+       else empty end),
+      (if .secondmate_current.truncated > 0 then
+         "! secondmate evidence: bounded records omitted=\(.secondmate_current.truncated); shown=\(.secondmate_current.shown)/\(.secondmate_current.total)"
+       else empty end),
+      (.secondmate_current.records[]? as $record
+       | secondmate_evidence_issue($record; $home),
+         secondmate_omission($record))
+  '
+  exit $?
+fi
 
 printf '%s\n' "$SNAPSHOT" | jq -r '
   def dash($v): if $v == null or $v == "" then "-" else $v end;

--- a/bin/fm-fleet-view.sh
+++ b/bin/fm-fleet-view.sh
@@ -49,7 +49,13 @@ SNAPSHOT=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" --json) || exit $?
 
 if [ "$MODE" = compact ]; then
   COMPACT_ESCAPE_HOME=$(printf '%s\n' "$SNAPSHOT" | jq -r '.fm_home')
-  case "${FM_HOME:-}" in
+  COMPACT_ESCAPE_VARIABLE=FM_HOME
+  COMPACT_ESCAPE_VALUE=${FM_HOME:-}
+  if [ -z "$COMPACT_ESCAPE_VALUE" ] && [ -n "${FM_ROOT_OVERRIDE:-}" ]; then
+    COMPACT_ESCAPE_VARIABLE=FM_ROOT_OVERRIDE
+    COMPACT_ESCAPE_VALUE=$FM_ROOT_OVERRIDE
+  fi
+  case "$COMPACT_ESCAPE_VALUE" in
     ""|/*)
       COMPACT_ESCAPE_DIR=
       COMPACT_ESCAPE_NEEDS_DIRECTORY=false
@@ -60,7 +66,7 @@ if [ "$MODE" = compact ]; then
       COMPACT_ESCAPE_NEEDS_DIRECTORY=true
       ;;
   esac
-  printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" --arg escape_home "$COMPACT_ESCAPE_HOME" --arg escape_dir "$COMPACT_ESCAPE_DIR" --argjson escape_needs_directory "$COMPACT_ESCAPE_NEEDS_DIRECTORY" '
+  printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" --arg escape_home "$COMPACT_ESCAPE_HOME" --arg escape_variable "$COMPACT_ESCAPE_VARIABLE" --arg escape_dir "$COMPACT_ESCAPE_DIR" --argjson escape_needs_directory "$COMPACT_ESCAPE_NEEDS_DIRECTORY" '
     def dash($v): if $v == null or $v == "" then "-" else $v end;
     def endpoint_exists($t):
       if $t.endpoint.exists == null then "unknown"
@@ -150,14 +156,14 @@ if [ "$MODE" = compact ]; then
       "Raw-view omissions: done detail rows=\($done); task path cells=\($paths_omitted).",
       "Compact renderer truncation: none.",
       (if $escape_needs_directory then
-         "Full human detail: cd \($escape_dir | @sh) && FM_HOME=\($home | @sh) \($view_script | @sh) --raw"
+         "Full human detail: cd \($escape_dir | @sh) && \($escape_variable)=\($home | @sh) \($view_script | @sh) --raw"
        else
-         "Full human detail: FM_HOME=\($home | @sh) \($view_script | @sh) --raw"
+         "Full human detail: \($escape_variable)=\($home | @sh) \($view_script | @sh) --raw"
        end),
       (if $escape_needs_directory then
-         "Complete raw snapshot: cd \($escape_dir | @sh) && FM_HOME=\($home | @sh) \($view_script | @sh) --json"
+         "Complete raw snapshot: cd \($escape_dir | @sh) && \($escape_variable)=\($home | @sh) \($view_script | @sh) --json"
        else
-         "Complete raw snapshot: FM_HOME=\($home | @sh) \($view_script | @sh) --json"
+         "Complete raw snapshot: \($escape_variable)=\($home | @sh) \($view_script | @sh) --json"
        end),
       "Full queued hold detail: tasks-axi show <id> --full, or \(($escape_home + "/data/backlog.md") | @sh).",
       "Actions: peek = bin/fm-peek.sh fm-<row-id>; return = bin/fm-send.sh fm-<row-id> \u0027<request>\u0027, then read status/doc and do not routinely peek a secondmate.",

--- a/bin/fm-fleet-view.sh
+++ b/bin/fm-fleet-view.sh
@@ -96,7 +96,17 @@ if [ "$MODE" = compact ]; then
       ;;
   esac
   fi
-  printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" --arg escape_home "$COMPACT_ESCAPE_HOME" --arg escape_home_env "$COMPACT_ESCAPE_HOME_ENV" --arg escape_root_env "$COMPACT_ESCAPE_ROOT_ENV" --arg escape_dir "$COMPACT_ESCAPE_DIR" --argjson escape_has_home "$COMPACT_ESCAPE_HAS_HOME" --argjson escape_has_root "$COMPACT_ESCAPE_HAS_ROOT" --argjson escape_needs_directory "$COMPACT_ESCAPE_NEEDS_DIRECTORY" '
+  COMPACT_ESCAPE_BACKLOG="$COMPACT_ESCAPE_HOME/data/backlog.md"
+  if [ -z "${FM_HOME:-}" ] && [ "$COMPACT_ESCAPE_HAS_ROOT" = true ]; then
+    case "$FM_ROOT_OVERRIDE" in
+      /*) : ;;
+      *)
+        COMPACT_ESCAPE_BACKLOG_HOME=$(cd "$COMPACT_ESCAPE_HOME" && pwd -P) || exit $?
+        COMPACT_ESCAPE_BACKLOG="$COMPACT_ESCAPE_BACKLOG_HOME/data/backlog.md"
+        ;;
+    esac
+  fi
+  printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" --arg escape_home "$COMPACT_ESCAPE_HOME" --arg escape_home_env "$COMPACT_ESCAPE_HOME_ENV" --arg escape_root_env "$COMPACT_ESCAPE_ROOT_ENV" --arg escape_dir "$COMPACT_ESCAPE_DIR" --arg escape_backlog "$COMPACT_ESCAPE_BACKLOG" --argjson escape_has_home "$COMPACT_ESCAPE_HAS_HOME" --argjson escape_has_root "$COMPACT_ESCAPE_HAS_ROOT" --argjson escape_needs_directory "$COMPACT_ESCAPE_NEEDS_DIRECTORY" '
     def dash($v): if $v == null or $v == "" then "-" else $v end;
     def endpoint_exists($t):
       if $t.endpoint.exists == null then "unknown"
@@ -199,7 +209,7 @@ if [ "$MODE" = compact ]; then
        else
          "Complete raw snapshot: \(escape_environment) \($view_script | @sh) --json"
        end),
-      "Full queued hold detail: tasks-axi show <id> --full, or \(($escape_home + "/data/backlog.md") | @sh).",
+      "Full queued hold detail: tasks-axi show <id> --full, or \($escape_backlog | @sh).",
       "Actions: peek = bin/fm-peek.sh fm-<row-id>; return = bin/fm-send.sh fm-<row-id> \u0027<request>\u0027, then read status/doc and do not routinely peek a secondmate.",
       "Attention marker: ! means a non-working task, endpoint problem, open decision, captain-actionable row, unstructured row, or inventory error.",
       (if .backlog.present != true then

--- a/bin/fm-fleet-view.sh
+++ b/bin/fm-fleet-view.sh
@@ -49,11 +49,16 @@ SNAPSHOT=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" --json) || exit $?
 
 if [ "$MODE" = compact ]; then
   COMPACT_ESCAPE_HOME=$(printf '%s\n' "$SNAPSHOT" | jq -r '.fm_home')
-  COMPACT_ESCAPE_HOME=$(cd "$COMPACT_ESCAPE_HOME" && pwd -P) || exit $?
-  COMPACT_ESCAPE_DIR=$(pwd -P) || exit $?
   case "${FM_HOME:-}" in
-    ""|/*) COMPACT_ESCAPE_NEEDS_DIRECTORY=false ;;
-    *) COMPACT_ESCAPE_NEEDS_DIRECTORY=true ;;
+    ""|/*)
+      COMPACT_ESCAPE_DIR=
+      COMPACT_ESCAPE_NEEDS_DIRECTORY=false
+      ;;
+    *)
+      COMPACT_ESCAPE_HOME=$(cd "$COMPACT_ESCAPE_HOME" && pwd -P) || exit $?
+      COMPACT_ESCAPE_DIR=$(pwd -P) || exit $?
+      COMPACT_ESCAPE_NEEDS_DIRECTORY=true
+      ;;
   esac
   printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" --arg escape_home "$COMPACT_ESCAPE_HOME" --arg escape_dir "$COMPACT_ESCAPE_DIR" --argjson escape_needs_directory "$COMPACT_ESCAPE_NEEDS_DIRECTORY" '
     def dash($v): if $v == null or $v == "" then "-" else $v end;

--- a/bin/fm-fleet-view.sh
+++ b/bin/fm-fleet-view.sh
@@ -50,7 +50,8 @@ SNAPSHOT=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" --json) || exit $?
 if [ "$MODE" = compact ]; then
   COMPACT_ESCAPE_HOME=$(printf '%s\n' "$SNAPSHOT" | jq -r '.fm_home')
   COMPACT_ESCAPE_HOME=$(cd "$COMPACT_ESCAPE_HOME" && pwd -P) || exit $?
-  printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" --arg escape_home "$COMPACT_ESCAPE_HOME" '
+  COMPACT_ESCAPE_DIR=$(pwd -P) || exit $?
+  printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" --arg escape_home "$COMPACT_ESCAPE_HOME" --arg escape_dir "$COMPACT_ESCAPE_DIR" '
     def dash($v): if $v == null or $v == "" then "-" else $v end;
     def endpoint_exists($t):
       if $t.endpoint.exists == null then "unknown"
@@ -139,8 +140,16 @@ if [ "$MODE" = compact ]; then
       "Rows shown/total: under-way=\($under_way)/\($under_way); queued=\($queued)/\($queued); done=0/\($done).",
       "Raw-view omissions: done detail rows=\($done); task path cells=\($paths_omitted).",
       "Compact renderer truncation: none.",
-      "Full human detail: FM_HOME=\($escape_home | @sh) \($view_script | @sh) --raw",
-      "Complete raw snapshot: FM_HOME=\($escape_home | @sh) \($view_script | @sh) --json",
+      (if $home == $escape_home then
+         "Full human detail: FM_HOME=\($escape_home | @sh) \($view_script | @sh) --raw"
+       else
+         "Full human detail: cd \($escape_dir | @sh) && FM_HOME=\($home | @sh) \($view_script | @sh) --raw"
+       end),
+      (if $home == $escape_home then
+         "Complete raw snapshot: FM_HOME=\($escape_home | @sh) \($view_script | @sh) --json"
+       else
+         "Complete raw snapshot: cd \($escape_dir | @sh) && FM_HOME=\($home | @sh) \($view_script | @sh) --json"
+       end),
       "Full queued hold detail: tasks-axi show <id> --full, or \(($escape_home + "/data/backlog.md") | @sh).",
       "Actions: peek = bin/fm-peek.sh fm-<row-id>; return = bin/fm-send.sh fm-<row-id> \u0027<request>\u0027, then read status/doc and do not routinely peek a secondmate.",
       "Attention marker: ! means a non-working task, endpoint problem, open decision, captain-actionable row, unstructured row, or inventory error.",

--- a/bin/fm-fleet-view.sh
+++ b/bin/fm-fleet-view.sh
@@ -49,24 +49,54 @@ SNAPSHOT=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" --json) || exit $?
 
 if [ "$MODE" = compact ]; then
   COMPACT_ESCAPE_HOME=$(printf '%s\n' "$SNAPSHOT" | jq -r '.fm_home')
-  COMPACT_ESCAPE_VARIABLE=FM_HOME
-  COMPACT_ESCAPE_VALUE=${FM_HOME:-}
-  if [ -z "$COMPACT_ESCAPE_VALUE" ] && [ -n "${FM_ROOT_OVERRIDE:-}" ]; then
-    COMPACT_ESCAPE_VARIABLE=FM_ROOT_OVERRIDE
-    COMPACT_ESCAPE_VALUE=$FM_ROOT_OVERRIDE
+  COMPACT_ESCAPE_ROOT=$(printf '%s\n' "$SNAPSHOT" | jq -r '.roots.fm_root')
+  COMPACT_ESCAPE_HOME_ENV=$COMPACT_ESCAPE_HOME
+  COMPACT_ESCAPE_ROOT_ENV=$COMPACT_ESCAPE_ROOT
+  COMPACT_ESCAPE_HAS_HOME=true
+  COMPACT_ESCAPE_HAS_ROOT=false
+  if [ -n "${FM_ROOT_OVERRIDE:-}" ]; then
+    COMPACT_ESCAPE_HAS_ROOT=true
   fi
-  case "$COMPACT_ESCAPE_VALUE" in
-    ""|/*)
-      COMPACT_ESCAPE_DIR=
-      COMPACT_ESCAPE_NEEDS_DIRECTORY=false
-      ;;
-    *)
+  if [ -z "${FM_HOME:-}" ] && [ "$COMPACT_ESCAPE_HAS_ROOT" = true ]; then
+    COMPACT_ESCAPE_HAS_HOME=false
+  fi
+  COMPACT_ESCAPE_DIR=
+  COMPACT_ESCAPE_NEEDS_DIRECTORY=false
+  if [ "$COMPACT_ESCAPE_HAS_HOME" = true ] && [ -n "${FM_HOME:-}" ]; then
+    case "$FM_HOME" in
+      /*)
+        COMPACT_ESCAPE_HOME=$FM_HOME
+        COMPACT_ESCAPE_HOME_ENV=$FM_HOME
+        ;;
+      *)
+        COMPACT_ESCAPE_HOME=$(cd "$COMPACT_ESCAPE_HOME" && pwd -P) || exit $?
+        COMPACT_ESCAPE_HOME_ENV=$FM_HOME
+        COMPACT_ESCAPE_DIR=$(pwd -P) || exit $?
+        COMPACT_ESCAPE_NEEDS_DIRECTORY=true
+        ;;
+    esac
+  fi
+  if [ "$COMPACT_ESCAPE_HAS_ROOT" = true ]; then
+    COMPACT_ESCAPE_ROOT_ENV=$FM_ROOT_OVERRIDE
+    case "$FM_ROOT_OVERRIDE" in
+      /*) COMPACT_ESCAPE_ROOT=$FM_ROOT_OVERRIDE ;;
+      *)
+        COMPACT_ESCAPE_DIR=$(pwd -P) || exit $?
+        COMPACT_ESCAPE_NEEDS_DIRECTORY=true
+        ;;
+    esac
+  fi
+  if [ "$COMPACT_ESCAPE_HAS_HOME" = true ] && [ -z "${FM_HOME:-}" ]; then
+    case "$COMPACT_ESCAPE_HOME" in
+      /*) : ;;
+      *)
       COMPACT_ESCAPE_HOME=$(cd "$COMPACT_ESCAPE_HOME" && pwd -P) || exit $?
       COMPACT_ESCAPE_DIR=$(pwd -P) || exit $?
       COMPACT_ESCAPE_NEEDS_DIRECTORY=true
       ;;
   esac
-  printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" --arg escape_home "$COMPACT_ESCAPE_HOME" --arg escape_variable "$COMPACT_ESCAPE_VARIABLE" --arg escape_dir "$COMPACT_ESCAPE_DIR" --argjson escape_needs_directory "$COMPACT_ESCAPE_NEEDS_DIRECTORY" '
+  fi
+  printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" --arg escape_home "$COMPACT_ESCAPE_HOME" --arg escape_home_env "$COMPACT_ESCAPE_HOME_ENV" --arg escape_root_env "$COMPACT_ESCAPE_ROOT_ENV" --arg escape_dir "$COMPACT_ESCAPE_DIR" --argjson escape_has_home "$COMPACT_ESCAPE_HAS_HOME" --argjson escape_has_root "$COMPACT_ESCAPE_HAS_ROOT" --argjson escape_needs_directory "$COMPACT_ESCAPE_NEEDS_DIRECTORY" '
     def dash($v): if $v == null or $v == "" then "-" else $v end;
     def endpoint_exists($t):
       if $t.endpoint.exists == null then "unknown"
@@ -101,6 +131,10 @@ if [ "$MODE" = compact ]; then
       else "\(dash($r.hold_kind)): \($r.hold_reason)"
         + (if ($r.hold_until // "") == "" then "" else " until \($r.hold_until)" end)
       end;
+    def escape_environment:
+      (if $escape_has_home then "FM_HOME=\($escape_home_env | @sh)" else "" end)
+      + (if $escape_has_home and $escape_has_root then " " else "" end)
+      + (if $escape_has_root then "FM_ROOT_OVERRIDE=\($escape_root_env | @sh)" else "" end);
     def task_row($t; $home):
       (if attention($t) then "! " else "- " end)
       + "\($t.id): \($t.current_state.state)/\($t.current_state.source)"
@@ -156,14 +190,14 @@ if [ "$MODE" = compact ]; then
       "Raw-view omissions: done detail rows=\($done); task path cells=\($paths_omitted).",
       "Compact renderer truncation: none.",
       (if $escape_needs_directory then
-         "Full human detail: cd \($escape_dir | @sh) && \($escape_variable)=\($home | @sh) \($view_script | @sh) --raw"
+         "Full human detail: cd \($escape_dir | @sh) && \(escape_environment) \($view_script | @sh) --raw"
        else
-         "Full human detail: \($escape_variable)=\($home | @sh) \($view_script | @sh) --raw"
+         "Full human detail: \(escape_environment) \($view_script | @sh) --raw"
        end),
       (if $escape_needs_directory then
-         "Complete raw snapshot: cd \($escape_dir | @sh) && \($escape_variable)=\($home | @sh) \($view_script | @sh) --json"
+         "Complete raw snapshot: cd \($escape_dir | @sh) && \(escape_environment) \($view_script | @sh) --json"
        else
-         "Complete raw snapshot: \($escape_variable)=\($home | @sh) \($view_script | @sh) --json"
+         "Complete raw snapshot: \(escape_environment) \($view_script | @sh) --json"
        end),
       "Full queued hold detail: tasks-axi show <id> --full, or \(($escape_home + "/data/backlog.md") | @sh).",
       "Actions: peek = bin/fm-peek.sh fm-<row-id>; return = bin/fm-send.sh fm-<row-id> \u0027<request>\u0027, then read status/doc and do not routinely peek a secondmate.",

--- a/bin/fm-fleet-view.sh
+++ b/bin/fm-fleet-view.sh
@@ -48,7 +48,9 @@ command -v jq >/dev/null 2>&1 || { echo "fm-fleet-view: jq not found" >&2; exit 
 SNAPSHOT=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" --json) || exit $?
 
 if [ "$MODE" = compact ]; then
-  printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" '
+  COMPACT_ESCAPE_HOME=$(printf '%s\n' "$SNAPSHOT" | jq -r '.fm_home')
+  COMPACT_ESCAPE_HOME=$(cd "$COMPACT_ESCAPE_HOME" && pwd -P) || exit $?
+  printf '%s\n' "$SNAPSHOT" | jq -r --arg view_script "$SCRIPT_DIR/fm-fleet-view.sh" --arg escape_home "$COMPACT_ESCAPE_HOME" '
     def dash($v): if $v == null or $v == "" then "-" else $v end;
     def endpoint_exists($t):
       if $t.endpoint.exists == null then "unknown"
@@ -137,9 +139,9 @@ if [ "$MODE" = compact ]; then
       "Rows shown/total: under-way=\($under_way)/\($under_way); queued=\($queued)/\($queued); done=0/\($done).",
       "Raw-view omissions: done detail rows=\($done); task path cells=\($paths_omitted).",
       "Compact renderer truncation: none.",
-      "Full human detail: FM_HOME=\($home | @sh) \($view_script | @sh) --raw",
-      "Complete raw snapshot: FM_HOME=\($home | @sh) \($view_script | @sh) --json",
-      "Full queued hold detail: tasks-axi show <id> --full, or \(($home + "/data/backlog.md") | @sh).",
+      "Full human detail: FM_HOME=\($escape_home | @sh) \($view_script | @sh) --raw",
+      "Complete raw snapshot: FM_HOME=\($escape_home | @sh) \($view_script | @sh) --json",
+      "Full queued hold detail: tasks-axi show <id> --full, or \(($escape_home + "/data/backlog.md") | @sh).",
       "Actions: peek = bin/fm-peek.sh fm-<row-id>; return = bin/fm-send.sh fm-<row-id> \u0027<request>\u0027, then read status/doc and do not routinely peek a secondmate.",
       "Attention marker: ! means a non-working task, endpoint problem, open decision, captain-actionable row, unstructured row, or inventory error.",
       (if .backlog.present != true then

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ The semantic branch reports working only on an exact busy verdict and names the 
 For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, bounded current summaries from registered secondmate homes, and secondmate return-channel guidance.
 Each home also atomically publishes that same bounded home summary with freshness epoch metadata at `state/home-summary.json` after a locked session start, a watcher-observed status change, task spawn, task teardown, and on a recurring live-watcher cadence; `bin/fm-home-summary-refresh.sh` owns the publication mechanics.
 The fleet snapshot and Bearings paths do not consume this additive publication yet, so mixed-version homes without it retain the established on-demand summary behavior.
-`bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so both views consume one structured contract instead of reparsing raw fleet files.
+`bin/fm-fleet-view.sh` renders that snapshot as complete Markdown by default or as an explicit omission-accounted `--compact` recurring-review view, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so all views consume one structured contract instead of reparsing raw fleet files.
 The script header owns the exact JSON schema.
 
 On a Pi primary, supervision is default-on: the watcher extension can hand eligible task-local rows from an ordinary actionable wake, plus selected fleet-wide heartbeat reviews, to a persistent in-process supervision conversation while main-only rows remain on the captain-facing path.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -16,7 +16,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-home-summary-refresh.sh` | Atomically publish this home's structured summary ledger                         |
-| `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
+| `fm-fleet-view.sh`       | Render the fleet snapshot as complete or explicit compact human Markdown             |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-bearings-board.sh`   | Build and arm the stable interactive `/bearings lavish` fleet board                  |
 | `fm-secondmate-reconcile.sh` | Ask each secondmate to reconcile an inventory mismatch through its durable inbox, limited by a per-home cooldown |

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -230,6 +230,46 @@ tests/fm-busy-adapter-wiring.test.sh
 tests/fm-crew-state.test.sh
 ```
 
+## Compact fleet review
+
+The explicit compact fleet view was measured on 2026-08-30 at public-main commit `d71f4b9cf1e6a8c647867d9a92c67ab0a6bb460f` through the public `bin/fm-fleet-view.sh` interface.
+The representative fixture carries 12 live rows, 24 queued rows, 8 retained Done rows, long stable identities, project paths, endpoint state, and repeated action guidance.
+The default and explicit raw invocations were byte-identical, while compact output retained every live and queued row, every state and endpoint error, deterministic ordering, exact omission counts, explicit no-truncation disclosure, and raw-detail escape commands.
+
+```sh
+bin/fm-test-run.sh tests/fm-fleet-snapshot-view.test.sh
+```
+
+Observed output:
+
+```text
+ok - fleet view compact mode preserves raw output, rows, errors, ordering, omission counts, and escape hatches
+ok - compact fleet view representative fixture: 9875 -> 6270 bytes (~2469 -> ~1568 tokens at four bytes/token)
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0
+```
+
+The measured reduction is 3,605 bytes, or 36.5%, and approximately 901 tokens per representative recurring fleet review under the stated four-bytes-per-token estimate.
+The compact renderer has no harness or model-provider branch.
+Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, and Cursor primaries, plus Muse workers, all consume the same normalized snapshot fields, so no vendor or model call is applicable to this view.
+Tmux, Herdr, Zellij, Orca, and cmux remain normalized by `bin/fm-fleet-snapshot.sh`; their adapter-specific endpoint behavior stays owned by the runtime-backend verification and portable backend suites.
+
+```sh
+bin/fm-test-run.sh \
+  tests/fm-backend.test.sh \
+  tests/fm-backend-herdr.test.sh \
+  tests/fm-backend-zellij.test.sh \
+  tests/fm-backend-orca.test.sh
+```
+
+Observed backend-suite summary:
+
+```text
+FM_TEST_SUMMARY total=4 failed=0 skipped_gate=0 duration_ms=530342
+FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=2 duration_ms=421294 failed=0
+FM_TEST_SUMMARY_FAMILY family=orca count=1 duration_ms=69970 failed=0
+FM_TEST_SUMMARY_FAMILY family=zellij count=1 duration_ms=38657 failed=0
+```
+
 ## Turn-end guard
 
 The blocking and bounded-follow-up mechanisms were validated across six harnesses on 2026-07-08 through 2026-08-13, with Claude's replacement Stop-owned path revalidated on 2026-07-24 and Cursor's stop-hook park validated on 2026-08-13.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -232,7 +232,7 @@ tests/fm-crew-state.test.sh
 
 ## Compact fleet review
 
-The explicit compact fleet view was measured on 2026-08-30 at public-main commit `d71f4b9cf1e6a8c647867d9a92c67ab0a6bb460f` through the public `bin/fm-fleet-view.sh` interface.
+The explicit compact fleet view was measured on 2026-08-31 at commit `166323975d44f84c6e8b7f1f855b336af7713445` through the public `bin/fm-fleet-view.sh` interface.
 The representative fixture carries 12 live rows, 24 queued rows, 8 retained Done rows, long stable identities, project paths, endpoint state, and repeated action guidance.
 The default and explicit raw invocations were byte-identical, while compact output retained every live and queued row, every state and endpoint error, deterministic ordering, exact omission counts, explicit no-truncation disclosure, and raw-detail escape commands.
 

--- a/tests/fm-branch-supervision.test.sh
+++ b/tests/fm-branch-supervision.test.sh
@@ -52,6 +52,8 @@ test_branch_prompt_is_byte_stable_and_above_cache_floor() {
     *"Report verdict captain for any outcome that directly answers an explicit captain request."*"This rule is unconditional"*"Keep an unsolicited routine outcome as verdict routine"*"Keep an unchanged fleet review silent"*) ;;
     *) fail "branch prompt lost the unconditional requested-outcome or routine-silence rules" ;;
   esac
+  assert_contains "$out_a" "run \`bin/fm-fleet-view.sh --compact\`" \
+    "branch heartbeat prompt lost the compact fleet-view command"
   pass "branch prompt is byte-stable across homes, cwd, timezone, and time, above the cache floor"
 }
 

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -939,10 +939,11 @@ test_compact_view_relative_home_escape_hatches() {
 }
 
 test_compact_view_relative_root_override_escape_hatches() {
-  local home relative_root fakebin compact raw snapshot raw_command json_command escaped_raw escaped_json
+  local home relative_root canonical_home fakebin compact raw snapshot raw_command json_command queued_hold_path escaped_raw escaped_json escaped_backlog
   home="$TMP_ROOT/relative-root-override-home"
   relative_root="relative-root-override-home"
   mkdir -p "$home/state" "$home/data" "$home/projects" "$home/config" "$TMP_ROOT/elsewhere"
+  canonical_home=$(cd "$home" && pwd -P)
   write_fixture "$home"
   fakebin=$(make_fakebin "$home")
 
@@ -954,15 +955,19 @@ test_compact_view_relative_root_override_escape_hatches() {
     FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 "$VIEW" --compact)
   raw_command=$(printf '%s\n' "$compact" | sed -n 's/^Full human detail: //p')
   json_command=$(printf '%s\n' "$compact" | sed -n 's/^Complete raw snapshot: //p')
+  queued_hold_path=$(printf '%s\n' "$compact" | sed -n "s|^Full queued hold detail: tasks-axi show <id> --full, or '\(.*\)'\.$|\1|p")
 
   escaped_raw=$(cd "$TMP_ROOT/elsewhere" && PATH="$fakebin:$PATH" \
     FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 sh -c "$raw_command")
   escaped_json=$(cd "$TMP_ROOT/elsewhere" && PATH="$fakebin:$PATH" \
     FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 sh -c "$json_command")
+  escaped_backlog=$(cd "$TMP_ROOT/elsewhere" && sed -n '1p' "$queued_hold_path")
   [ "$escaped_raw" = "$raw" ] \
     || fail "relative FM_ROOT_OVERRIDE raw escape command did not recover the original complete fleet view"
   [ "$escaped_json" = "$snapshot" ] \
     || fail "relative FM_ROOT_OVERRIDE JSON escape command did not recover the original complete snapshot"
+  [ "$queued_hold_path" = "$canonical_home/data/backlog.md" ] && [ "$escaped_backlog" = "## In flight" ] \
+    || fail "relative FM_ROOT_OVERRIDE queued-hold escape path did not resolve to the fixture backlog from another directory"
   pass "compact view preserves relative FM_ROOT_OVERRIDE escape hatches"
 }
 

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -966,6 +966,27 @@ test_compact_view_relative_root_override_escape_hatches() {
   pass "compact view preserves relative FM_ROOT_OVERRIDE escape hatches"
 }
 
+test_compact_view_combined_override_escape_hatches() {
+  local home root fakebin compact snapshot json_command escaped_json
+  home=$(make_home compact-combined-override-home)
+  root="$TMP_ROOT/compact-combined-override-root"
+  mkdir -p "$root" "$TMP_ROOT/elsewhere"
+  write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+
+  snapshot=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$root" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 "$SNAPSHOT" --json)
+  compact=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$root" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 "$VIEW" --compact)
+  json_command=$(printf '%s\n' "$compact" | sed -n 's/^Complete raw snapshot: //p')
+  escaped_json=$(cd "$TMP_ROOT/elsewhere" && PATH="$fakebin:$PATH" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 sh -c "$json_command")
+
+  [ "$escaped_json" = "$snapshot" ] \
+    || fail "combined FM_HOME and FM_ROOT_OVERRIDE JSON escape command did not recover the original complete snapshot"
+  pass "compact view preserves combined FM_HOME and FM_ROOT_OVERRIDE escape hatches"
+}
+
 assert_compact_view_absolute_home_escape_hatches() {
   local home alias_home fakebin compact
   home=$(make_home compact-absolute-escape)
@@ -1259,6 +1280,7 @@ test_view_renders_dead_secondmate_agent_status
 test_compact_view_contract
 test_compact_view_relative_home_escape_hatches
 test_compact_view_relative_root_override_escape_hatches
+test_compact_view_combined_override_escape_hatches
 test_compact_view_unmatched_in_flight_records
 test_compact_view_missing_backlog_error
 test_compact_view_discloses_incomplete_secondmate_evidence

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -799,6 +799,369 @@ test_parked_scout_decision_stays_pending() {
   pass "a scout still parked at a decision stays pending (terminal clear does not over-fire)"
 }
 
+test_compact_view_contract() {
+  local home fakebin help raw explicit_raw snapshot_json view_json compact repeated raw_error compact_error raw_rc compact_rc
+  local cmux_line decision_line scout_line secondmate_line ship_line recovery_line queued_line unstructured_line captain_line
+  home=$(make_home compact-contract)
+  write_fixture "$home"
+  mkdir -p "$home/projects/decision-worktree"
+  fm_write_meta "$home/state/decision-task.meta" \
+    "window=firstmate:fm-decision-task" \
+    "worktree=$home/projects/decision-worktree" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=scout" \
+    "mode=scout"
+  record_claude_idle "$home/state" decision-task
+  printf 'needs-decision [key=route]: choose the release route\n' > "$home/state/decision-task.status"
+  awk '
+    /^## In flight/ {
+      print
+      print "unstructured in-flight recovery note"
+      next
+    }
+    /^## Done/ {
+      print "- [ ] captain-choice - Choose rollout (repo: alpha) (kind: captain) (hold: select blue or green) (hold-kind: captain)"
+      print ""
+    }
+    { print }
+  ' "$home/data/backlog.md" > "$home/data/backlog.next"
+  mv "$home/data/backlog.next" "$home/data/backlog.md"
+  fakebin=$(make_fakebin "$home")
+
+  help=$("$VIEW" --help)
+  assert_contains "$help" "usage: fm-fleet-view.sh [--raw|--compact|--json]" \
+    "fleet view help did not publish the compact and full-detail modes"
+  raw=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$VIEW")
+  explicit_raw=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$VIEW" --raw)
+  [ "$raw" = "$explicit_raw" ] || fail "explicit --raw changed the default fleet view"
+  snapshot_json=$(PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 \
+    "$SNAPSHOT" --json)
+  view_json=$(PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 \
+    "$VIEW" --json)
+  [ "$snapshot_json" = "$view_json" ] || fail "fleet view --json changed the complete snapshot escape hatch"
+
+  compact=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$VIEW" --compact)
+  repeated=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$VIEW" --compact)
+  [ "$compact" = "$repeated" ] || fail "compact fleet view was not deterministic across identical reads"
+
+  assert_contains "$compact" "Rows shown/total: under-way=6/6; queued=3/3; done=0/1." \
+    "compact view did not retain every live and queued row or account for Done"
+  assert_contains "$compact" "Raw-view omissions: done detail rows=1; task path cells=5." \
+    "compact view did not count every detail row and path cell omitted from raw mode"
+  assert_contains "$compact" "Compact renderer truncation: none." "compact view did not make its no-truncation guarantee explicit"
+  assert_contains "$compact" "Full human detail: FM_HOME='$home' '$VIEW' --raw" \
+    "compact view omitted its exact raw-detail escape command"
+  assert_contains "$compact" "Complete raw snapshot: FM_HOME='$home' '$VIEW' --json" \
+    "compact view omitted its complete structured-detail escape command"
+  assert_contains "$compact" "Full queued hold detail: tasks-axi show <id> --full, or '$home/data/backlog.md'." \
+    "compact view omitted the full hold-detail escape hatch"
+  assert_contains "$compact" "! inventory error:" "compact view did not preserve the unstructured-row inventory error"
+  assert_contains "$compact" "! inventory item: unstructured in-flight: unstructured in-flight recovery note" \
+    "compact view did not retain an unstructured in-flight inventory item"
+  [ "$(printf '%s\n' "$compact" | grep -Fc '! inventory item: unstructured in-flight: unstructured in-flight recovery note')" -eq 1 ] \
+    || fail "compact view duplicated an unstructured in-flight inventory item"
+  assert_contains "$compact" "! cmux-task: unknown/none; ship alpha; cmux absent; detail=worktree gone (torn down?)" \
+    "compact view did not retain a task error and its detail"
+  assert_contains "$compact" "! decision decision-task[key=route]: needs-decision: choose the release route" \
+    "compact view did not retain an actionable keyed decision"
+  assert_contains "$compact" "! captain-choice: Choose rollout; alpha captain; hold=captain: select blue or green" \
+    "compact view did not retain the reason for a captain-actionable queued row"
+  assert_contains "$compact" "! unstructured: handoff note without canonical syntax" \
+    "compact view did not retain an unstructured queued row"
+  assert_not_contains "$compact" "done-task" "compact view leaked a Done detail row it says it omits"
+  assert_contains "$compact" "peek = bin/fm-peek.sh fm-<row-id>" \
+    "compact view dropped the exact ordinary-task action template"
+  assert_contains "$compact" "return = bin/fm-send.sh fm-<row-id> '<request>'" \
+    "compact view dropped the exact secondmate return action template"
+
+  cmux_line=$(printf '%s\n' "$compact" | grep -n '^! cmux-task:' | cut -d: -f1)
+  decision_line=$(printf '%s\n' "$compact" | grep -n '^! decision-task:' | cut -d: -f1)
+  scout_line=$(printf '%s\n' "$compact" | grep -n '^! scout-task:' | cut -d: -f1)
+  secondmate_line=$(printf '%s\n' "$compact" | grep -n '^- secondmate-task:' | cut -d: -f1)
+  ship_line=$(printf '%s\n' "$compact" | grep -n '^- ship-task:' | cut -d: -f1)
+  recovery_line=$(printf '%s\n' "$compact" | grep -n '^! inventory item: unstructured in-flight:' | cut -d: -f1)
+  [ "$cmux_line" -lt "$decision_line" ] && [ "$decision_line" -lt "$scout_line" ] \
+    && [ "$scout_line" -lt "$secondmate_line" ] && [ "$secondmate_line" -lt "$ship_line" ] \
+    && [ "$ship_line" -lt "$recovery_line" ] \
+    || fail "compact task rows did not preserve deterministic snapshot order"
+  queued_line=$(printf '%s\n' "$compact" | grep -n '^- queued-task:' | cut -d: -f1)
+  unstructured_line=$(printf '%s\n' "$compact" | grep -n '^! unstructured:' | cut -d: -f1)
+  captain_line=$(printf '%s\n' "$compact" | grep -n '^! captain-choice:' | cut -d: -f1)
+  [ "$queued_line" -lt "$unstructured_line" ] && [ "$unstructured_line" -lt "$captain_line" ] \
+    || fail "compact queued rows did not preserve backlog order"
+
+  raw_error=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_CREW_STATE_TIMEOUT=0 "$VIEW" --raw 2>&1)
+  raw_rc=$?
+  compact_error=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_CREW_STATE_TIMEOUT=0 "$VIEW" --compact 2>&1)
+  compact_rc=$?
+  [ "$raw_rc" -eq 2 ] && [ "$compact_rc" -eq "$raw_rc" ] \
+    || fail "compact mode changed a snapshot validation error exit status"
+  [ "$compact_error" = "$raw_error" ] \
+    || fail "compact mode changed or suppressed a snapshot validation error: $compact_error"
+  assert_contains "$compact_error" "FM_SNAPSHOT_CREW_STATE_TIMEOUT must be a positive integer" \
+    "compact mode did not preserve the underlying snapshot error"
+  pass "fleet view compact mode preserves raw output, rows, errors, ordering, omission counts, and escape hatches"
+}
+
+test_compact_view_unmatched_in_flight_records() {
+  local home fakebin compact observation_line observation_rows worker_rows unstructured_rows busy_gen
+  home=$(make_home compact-unmatched-in-flight)
+  mkdir -p "$home/projects/observation" "$home/projects/worker"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] program - Aggregate program (repo: alpha) (kind: program)
+- [ ] observation - Watch production (repo: alpha) (kind: scout) (hold: wait for metrics) (hold-kind: external) (hold-until: 2026-09-01)
+- [ ] worker - Active worker (repo: alpha) (kind: ship)
+recovery note without canonical syntax
+
+## Queued
+
+## Done
+EOF
+  fm_write_meta "$home/state/observation.meta" \
+    "window=firstmate:fm-observation" \
+    "worktree=$home/projects/observation" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=scout" \
+    "mode=scout"
+  printf 'working: watching metrics\n' > "$home/state/observation.status"
+  busy_gen=$("$ROOT/bin/fm-busy-event.sh" arm "$home/state" observation)
+  "$ROOT/bin/fm-busy-event.sh" apply "$home/state" observation busy --gen "$busy_gen" \
+    --source codex-hook --event user-prompt-submit
+  fm_write_meta "$home/state/worker.meta" \
+    "window=firstmate:fm-worker" \
+    "worktree=$home/projects/worker" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship"
+  printf 'working: active\n' > "$home/state/worker.status"
+  fakebin=$(make_fakebin "$home")
+
+  compact=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$VIEW" --compact)
+  assert_contains "$compact" "Rows shown/total: under-way=4/4; queued=0/0; done=0/0." \
+    "compact view did not count every unmatched in-flight record"
+  assert_contains "$compact" "- program: Aggregate program; alpha program" \
+    "compact view omitted an unmatched program record"
+  observation_line=$(printf '%s\n' "$compact" | grep -E '^[-!] observation:')
+  assert_contains "$observation_line" "; hold=external: wait for metrics until 2026-09-01; action=peek" \
+    "compact view omitted a matched held record's identifying hold detail"
+  observation_rows=$(printf '%s\n' "$compact" | grep -Ec '^[-!] observation:')
+  [ "$observation_rows" -eq 1 ] || fail "compact view duplicated a task-backed held record"
+  worker_rows=$(printf '%s\n' "$compact" | grep -Ec '^[-!] worker:')
+  [ "$worker_rows" -eq 1 ] || fail "compact view duplicated a task-backed in-flight record"
+  assert_contains "$compact" "! inventory item: unstructured in-flight: recovery note without canonical syntax" \
+    "compact view omitted an unmatched unstructured in-flight record"
+  unstructured_rows=$(printf '%s\n' "$compact" | grep -Fc '! inventory item: unstructured in-flight: recovery note without canonical syntax')
+  [ "$unstructured_rows" -eq 1 ] || fail "compact view duplicated an unmatched unstructured in-flight record"
+  pass "compact view retains every unmatched in-flight record without duplicates"
+}
+
+test_compact_view_missing_backlog_error() {
+  local home compact
+  home=$(make_home compact-missing-backlog)
+
+  compact=$(FM_HOME="$home" "$VIEW" --compact)
+  assert_contains "$compact" "! inventory error: backlog missing: $home/data/backlog.md" \
+    "compact view did not surface a missing backlog inventory error"
+  pass "compact view surfaces a missing backlog inventory error"
+}
+
+test_compact_view_discloses_incomplete_secondmate_evidence() {
+  local home partial unavailable omitted fakebin compact
+  home=$(make_home compact-secondmate-evidence)
+  partial="$TMP_ROOT/compact-partial-home"
+  unavailable="$TMP_ROOT/compact-unavailable-home"
+  omitted="$TMP_ROOT/compact-omitted-home"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+
+## Queued
+
+## Done
+EOF
+  mkdir -p "$partial/state" "$partial/data" "$partial/config" "$partial/projects" "$partial/bin"
+  printf '# Firstmate fixture\n' > "$partial/AGENTS.md"
+  printf 'a-partial\n' > "$partial/.fm-secondmate-home"
+  cat > "$partial/data/backlog.md" <<'EOF'
+## In flight
+- [ ] orphan-child - Missing child metadata (repo: alpha) (kind: ship)
+
+## Queued
+
+## Done
+EOF
+  mkdir -p "$omitted/state" "$omitted/data" "$omitted/config" "$omitted/projects" "$omitted/bin"
+  printf '# Firstmate fixture\n' > "$omitted/AGENTS.md"
+  printf 'c-omitted\n' > "$omitted/.fm-secondmate-home"
+  cat > "$omitted/data/backlog.md" <<'EOF'
+## In flight
+
+## Queued
+
+## Done
+EOF
+  cat > "$home/data/secondmates.md" <<EOF
+- a-partial - fixture (home: $partial; scope: fixture; projects: alpha; added 2026-08-30)
+- b-unavailable - fixture (home: $unavailable; scope: fixture; projects: alpha; added 2026-08-30)
+- c-omitted - fixture (home: $omitted; scope: fixture; projects: alpha; added 2026-08-30)
+EOF
+  fakebin=$(make_fakebin "$home")
+
+  compact=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_SECONDMATES=2 "$VIEW" --compact)
+  assert_contains "$compact" "Compact renderer truncation: none." \
+    "compact view did not distinguish renderer completeness from snapshot bounds"
+  assert_contains "$compact" "! secondmate evidence: bounded records omitted=1; shown=2/3" \
+    "compact view hid a bounded secondmate record"
+  assert_contains "$compact" '! secondmate evidence a-partial: partial; home=' \
+    "compact view hid partial structured secondmate evidence"
+  assert_contains "$compact" 'reason=structured home state invalid: in-flight backlog item has no child metadata: orphan-child' \
+    "compact view hid the partial secondmate reason"
+  assert_contains "$compact" "! secondmate evidence b-unavailable: unavailable; home=$unavailable; reason=invalid home: not a directory" \
+    "compact view hid unavailable secondmate evidence"
+  pass "compact view discloses bounded, unavailable, and partial secondmate evidence"
+}
+
+test_compact_view_discloses_bounded_secondmate_holds() {
+  local home secondmate fakebin snapshot compact
+  home=$(make_home compact-bounded-secondmate-holds)
+  secondmate="$TMP_ROOT/compact-bounded-holds-home"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+
+## Queued
+
+## Done
+EOF
+  mkdir -p "$secondmate/state" "$secondmate/data" "$secondmate/config" "$secondmate/projects" "$secondmate/bin"
+  printf '# Firstmate fixture\n' > "$secondmate/AGENTS.md"
+  printf 'bounded-holds\n' > "$secondmate/.fm-secondmate-home"
+  cat > "$secondmate/data/backlog.md" <<'EOF'
+## In flight
+- [ ] orphan-child - Missing child metadata (repo: gamma) (kind: ship)
+
+## Queued
+- [ ] first-hold - Wait for first dependency (repo: alpha) (kind: ship) (hold: first external dependency) (hold-kind: external)
+- [ ] second-hold - Wait for second dependency (repo: beta) (kind: scout) (hold: second external dependency) (hold-kind: external)
+
+## Done
+EOF
+  cat > "$home/data/secondmates.md" <<EOF
+- bounded-holds - fixture (home: $secondmate; scope: fixture; projects: alpha; added 2026-08-30)
+EOF
+  fm_write_meta "$home/state/bounded-holds.meta" \
+    "window=firstmate:fm-bounded-holds" \
+    "worktree=$secondmate" \
+    "project=$secondmate" \
+    "harness=codex" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "home=$secondmate" \
+    "projects=alpha"
+  printf 'needs-decision [key=stale]: old parent question\n' > "$home/state/bounded-holds.status"
+  fakebin=$(make_fakebin "$home")
+
+  snapshot=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_SECONDMATE_QUEUED=1 "$SNAPSHOT" --json)
+  printf '%s' "$snapshot" | jq -e '
+    .secondmate_current.records[] | select(.id == "bounded-holds")
+    | .provenance.trust == "partial-structured"
+      and .contradiction == true
+      and .counts.holds == 2
+      and (.holds | length) == 1
+      and any(.omitted[]; .surface == "holds" and .count == 1)
+  ' >/dev/null || fail "snapshot did not disclose contradictory evidence and the exact bounded hold count: $snapshot"
+
+  compact=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_SECONDMATE_QUEUED=1 "$VIEW" --compact)
+  assert_contains "$compact" "! secondmate evidence bounded-holds: partial; home=" \
+    "compact view hid partial structured secondmate evidence"
+  assert_contains "$compact" "! secondmate evidence bounded-holds: contradictory; home=" \
+    "compact view hid contradictory parent evidence alongside partial structured evidence"
+  assert_contains "$compact" "! secondmate evidence bounded-holds: bounded holds omitted=1" \
+    "compact view hid a bounded secondmate hold"
+  assert_contains "$compact" "! secondmate evidence bounded-holds: bounded queued omitted=1" \
+    "compact view hid the corresponding bounded queued row"
+
+  awk '
+    /^## Done/ { print "unstructured queued recovery note"; print "" }
+    { print }
+  ' "$secondmate/data/backlog.md" > "$secondmate/data/backlog.next"
+  mv "$secondmate/data/backlog.next" "$secondmate/data/backlog.md"
+
+  snapshot=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_SECONDMATE_QUEUED=1 "$SNAPSHOT" --json)
+  printf '%s' "$snapshot" | jq -e '
+    .secondmate_current.records[] | select(.id == "bounded-holds")
+    | .provenance.selected == "parent-event-fallback"
+      and .current.state == "unknown"
+      and any(.omitted[]; .surface == "holds" and .count == 1)
+      and any(.omitted[]; .surface == "queued" and .count == 1)
+  ' >/dev/null || fail "snapshot fallback did not preserve exact bounded hold and queued counts: $snapshot"
+
+  compact=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_SECONDMATE_QUEUED=1 "$VIEW" --compact)
+  assert_contains "$compact" "! secondmate evidence bounded-holds: unavailable; home=" \
+    "compact view hid unavailable fallback secondmate evidence"
+  assert_contains "$compact" "! secondmate evidence bounded-holds: bounded holds omitted=1" \
+    "compact fallback hid a bounded secondmate hold"
+  assert_contains "$compact" "! secondmate evidence bounded-holds: bounded queued omitted=1" \
+    "compact fallback hid the corresponding bounded queued row"
+  pass "compact view discloses bounded secondmate rows through structured and fallback records"
+}
+
+test_compact_view_representative_reduction() {
+  local home fakebin raw compact raw_bytes compact_bytes raw_tokens compact_tokens i id busy_gen
+  home=$(make_home compact-measurement)
+  mkdir -p "$home/projects"
+  {
+    printf '## In flight\n'
+    i=1
+    while [ "$i" -le 12 ]; do
+      id=$(printf 'representative-worker-%02d-with-stable-identity' "$i")
+      mkdir -p "$home/projects/$id"
+      fm_write_meta "$home/state/$id.meta" \
+        "window=firstmate:fm-$id" \
+        "worktree=$home/projects/$id" \
+        "project=representative-project" \
+        "harness=claude" \
+        "kind=scout" \
+        "mode=scout"
+      printf 'working: representative supervision activity %02d\n' "$i" > "$home/state/$id.status"
+      busy_gen=$("$ROOT/bin/fm-busy-event.sh" arm "$home/state" "$id")
+      "$ROOT/bin/fm-busy-event.sh" apply "$home/state" "$id" busy --gen "$busy_gen" \
+        --source claude-hook --event user-prompt-submit
+      printf -- '- [ ] %s - Representative active task %02d (repo: representative-project) (kind: scout)\n' "$id" "$i"
+      i=$((i + 1))
+    done
+    printf '\n## Queued\n'
+    i=1
+    while [ "$i" -le 24 ]; do
+      id=$(printf 'representative-queued-%02d-with-stable-identity' "$i")
+      printf -- '- [ ] %s - Representative queued task %02d with bounded acceptance criteria (repo: representative-project) (kind: ship)\n' "$id" "$i"
+      i=$((i + 1))
+    done
+    printf '\n## Done\n'
+    i=1
+    while [ "$i" -le 8 ]; do
+      id=$(printf 'representative-done-%02d-with-stable-identity' "$i")
+      printf -- '- [x] %s - Representative completed task %02d https://github.com/kunchenguid/firstmate/pull/%d (repo: representative-project) (kind: ship) (merged 2026-08-30)\n' "$id" "$i" "$i"
+      i=$((i + 1))
+    done
+  } > "$home/data/backlog.md"
+  fakebin=$(make_fakebin "$home")
+
+  raw=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$VIEW" --raw)
+  compact=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$VIEW" --compact)
+  raw_bytes=$(printf '%s' "$raw" | LC_ALL=C wc -c | tr -d ' ')
+  compact_bytes=$(printf '%s' "$compact" | LC_ALL=C wc -c | tr -d ' ')
+  [ $((compact_bytes * 100)) -le $((raw_bytes * 75)) ] \
+    || fail "representative compact view saved less than 25%: raw=$raw_bytes compact=$compact_bytes"
+  raw_tokens=$(((raw_bytes + 3) / 4))
+  compact_tokens=$(((compact_bytes + 3) / 4))
+  pass "compact fleet view representative fixture: $raw_bytes -> $compact_bytes bytes (~$raw_tokens -> ~$compact_tokens tokens at four bytes/token)"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
@@ -814,3 +1177,9 @@ test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot
 test_view_renders_dead_secondmate_agent_status
+test_compact_view_contract
+test_compact_view_unmatched_in_flight_records
+test_compact_view_missing_backlog_error
+test_compact_view_discloses_incomplete_secondmate_evidence
+test_compact_view_discloses_bounded_secondmate_holds
+test_compact_view_representative_reduction

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -907,10 +907,11 @@ test_compact_view_contract() {
 }
 
 test_compact_view_relative_home_escape_hatches() {
-  local home relative_home fakebin compact raw snapshot raw_command json_command escaped_raw escaped_json
+  local home relative_home canonical_home fakebin compact raw snapshot raw_command json_command escaped_raw escaped_json
   home="$TMP_ROOT/relative-escape-home"
   relative_home="relative-escape-home"
   mkdir -p "$home/state" "$home/data" "$home/projects" "$home/config" "$TMP_ROOT/elsewhere"
+  canonical_home=$(cd "$home" && pwd -P)
   write_fixture "$home"
   fakebin=$(make_fakebin "$home")
 
@@ -931,9 +932,29 @@ test_compact_view_relative_home_escape_hatches() {
     || fail "relative FM_HOME raw escape command did not recover the original complete fleet view"
   [ "$escaped_json" = "$snapshot" ] \
     || fail "relative FM_HOME JSON escape command did not recover the original complete snapshot"
-  assert_contains "$compact" "or '$home/data/backlog.md'." \
+  assert_contains "$compact" "or '$canonical_home/data/backlog.md'." \
     "relative FM_HOME queued-hold escape hatch was not canonicalized"
-  pass "compact view canonicalizes relative FM_HOME escape hatches"
+  assert_compact_view_absolute_home_escape_hatches
+  pass "compact view preserves relative and absolute FM_HOME escape hatches"
+}
+
+assert_compact_view_absolute_home_escape_hatches() {
+  local home alias_home fakebin compact
+  home=$(make_home compact-absolute-escape)
+  alias_home="$TMP_ROOT/compact-absolute-escape-alias"
+  write_fixture "$home"
+  ln -s "$home" "$alias_home"
+  fakebin=$(make_fakebin "$home")
+
+  compact=$(PATH="$fakebin:$PATH" FM_HOME="$alias_home" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 "$VIEW" --compact)
+
+  assert_contains "$compact" "Full human detail: FM_HOME='$alias_home' '$VIEW' --raw" \
+    "absolute FM_HOME raw escape command did not retain its supplied path"
+  assert_contains "$compact" "Complete raw snapshot: FM_HOME='$alias_home' '$VIEW' --json" \
+    "absolute FM_HOME JSON escape command did not retain its supplied path"
+  assert_contains "$compact" "or '$alias_home/data/backlog.md'." \
+    "absolute FM_HOME queued-hold escape path did not retain its supplied path"
 }
 
 test_compact_view_unmatched_in_flight_records() {

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -906,6 +906,36 @@ test_compact_view_contract() {
   pass "fleet view compact mode preserves raw output, rows, errors, ordering, omission counts, and escape hatches"
 }
 
+test_compact_view_relative_home_escape_hatches() {
+  local home relative_home fakebin compact raw snapshot raw_command json_command escaped_raw escaped_json
+  home="$TMP_ROOT/relative-escape-home"
+  relative_home="relative-escape-home"
+  mkdir -p "$home/state" "$home/data" "$home/projects" "$home/config" "$TMP_ROOT/elsewhere"
+  write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+
+  raw=$(cd "$TMP_ROOT" && PATH="$fakebin:$PATH" FM_HOME="$relative_home" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 "$VIEW" --raw)
+  snapshot=$(cd "$TMP_ROOT" && PATH="$fakebin:$PATH" FM_HOME="$relative_home" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 "$SNAPSHOT" --json)
+  compact=$(cd "$TMP_ROOT" && PATH="$fakebin:$PATH" FM_HOME="$relative_home" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 "$VIEW" --compact)
+  raw_command=$(printf '%s\n' "$compact" | sed -n 's/^Full human detail: //p')
+  json_command=$(printf '%s\n' "$compact" | sed -n 's/^Complete raw snapshot: //p')
+
+  escaped_raw=$(cd "$TMP_ROOT/elsewhere" && PATH="$fakebin:$PATH" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 sh -c "$raw_command")
+  escaped_json=$(cd "$TMP_ROOT/elsewhere" && PATH="$fakebin:$PATH" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 sh -c "$json_command")
+  [ "$escaped_raw" = "$raw" ] \
+    || fail "relative FM_HOME raw escape command did not recover the original complete fleet view"
+  [ "$escaped_json" = "$snapshot" ] \
+    || fail "relative FM_HOME JSON escape command did not recover the original complete snapshot"
+  assert_contains "$compact" "or '$home/data/backlog.md'." \
+    "relative FM_HOME queued-hold escape hatch was not canonicalized"
+  pass "compact view canonicalizes relative FM_HOME escape hatches"
+}
+
 test_compact_view_unmatched_in_flight_records() {
   local home fakebin compact observation_line observation_rows worker_rows unstructured_rows busy_gen
   home=$(make_home compact-unmatched-in-flight)
@@ -1178,6 +1208,7 @@ test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot
 test_view_renders_dead_secondmate_agent_status
 test_compact_view_contract
+test_compact_view_relative_home_escape_hatches
 test_compact_view_unmatched_in_flight_records
 test_compact_view_missing_backlog_error
 test_compact_view_discloses_incomplete_secondmate_evidence

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -938,6 +938,34 @@ test_compact_view_relative_home_escape_hatches() {
   pass "compact view preserves relative and absolute FM_HOME escape hatches"
 }
 
+test_compact_view_relative_root_override_escape_hatches() {
+  local home relative_root fakebin compact raw snapshot raw_command json_command escaped_raw escaped_json
+  home="$TMP_ROOT/relative-root-override-home"
+  relative_root="relative-root-override-home"
+  mkdir -p "$home/state" "$home/data" "$home/projects" "$home/config" "$TMP_ROOT/elsewhere"
+  write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+
+  raw=$(cd "$TMP_ROOT" && PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$relative_root" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 "$VIEW" --raw)
+  snapshot=$(cd "$TMP_ROOT" && PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$relative_root" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 "$SNAPSHOT" --json)
+  compact=$(cd "$TMP_ROOT" && PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$relative_root" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 "$VIEW" --compact)
+  raw_command=$(printf '%s\n' "$compact" | sed -n 's/^Full human detail: //p')
+  json_command=$(printf '%s\n' "$compact" | sed -n 's/^Complete raw snapshot: //p')
+
+  escaped_raw=$(cd "$TMP_ROOT/elsewhere" && PATH="$fakebin:$PATH" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 sh -c "$raw_command")
+  escaped_json=$(cd "$TMP_ROOT/elsewhere" && PATH="$fakebin:$PATH" \
+    FM_SNAPSHOT_NOW=2026-08-30T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788091200 sh -c "$json_command")
+  [ "$escaped_raw" = "$raw" ] \
+    || fail "relative FM_ROOT_OVERRIDE raw escape command did not recover the original complete fleet view"
+  [ "$escaped_json" = "$snapshot" ] \
+    || fail "relative FM_ROOT_OVERRIDE JSON escape command did not recover the original complete snapshot"
+  pass "compact view preserves relative FM_ROOT_OVERRIDE escape hatches"
+}
+
 assert_compact_view_absolute_home_escape_hatches() {
   local home alias_home fakebin compact
   home=$(make_home compact-absolute-escape)
@@ -1230,6 +1258,7 @@ test_view_renders_snapshot
 test_view_renders_dead_secondmate_agent_status
 test_compact_view_contract
 test_compact_view_relative_home_escape_hatches
+test_compact_view_relative_root_override_escape_hatches
 test_compact_view_unmatched_in_flight_records
 test_compact_view_missing_backlog_error
 test_compact_view_discloses_incomplete_secondmate_evidence


### PR DESCRIPTION
## Intent

Build and publish a conservative, measurement-driven public Firstmate improvement as a new pull request whose canonical base repository is exactly github.com/kunchenguid/firstmate. Captain approval is required for merge; do not merge. Validate final committed head 166323975d44f84c6e8b7f1f855b336af7713445 on fresh replacement branch fm/firstmate-compact-command-modes-v1-c4-clean-1663239; its parent is the independently fetched current public-main commit 4ad8cbaeafc109a17c1af3911867b7fe9e04e801. Leave https://github.com/kunchenguid/firstmate/pull/3362 and its branch entirely open and unchanged as evidence: do not close, force-push, rewrite, merge, or reuse that divergent identity. Preserve the old clean local e7496a8, rebuilt clean local 1663239, and unsafe remote 7a4b2f6 as evidence; do not carry private or MITRE-only history or behavior.

Measure representative current-public behavior from existing commands used in recurring recovery and supervision, identify the largest repeated context contributors, and ship only the smallest coherent bounded improvement with material, testable benefit. Extend the existing bin/fm-fleet-view.sh owner with explicit opt-in --compact and explicit --raw modes while keeping the historical default output and existing --json output unchanged and authoritative. Compact output must retain every under-way and queued item, actionable decision, hold reason, inventory or endpoint error, and required identifying context; preserve deterministic ordering; state exact shown/total and omission counts; make renderer and upstream evidence bounds explicit; apply no truncation; and print exact commands or paths for complete raw human, JSON, and queued-hold detail. Collapse repeated per-row actions only into exact row-id templates.

Preserve the captain-accepted completeness corrections: retain and count unmatched structured and unstructured in-flight records without duplicates while preserving inventory-error markers; surface a missing backlog; retain matched backlog hold metadata at the deduplicated task-row boundary; disclose bounded, unavailable, partial, contradictory, and fallback secondmate evidence with exact omission counts; and assert through the emitted public Pi branch prompt that heartbeat instructions invoke bin/fm-fleet-view.sh --compact. Keep recurring main and Pi heartbeat adoption narrowly scoped and do not broadly reorganize AGENTS.md.

Add behavioral tests only through executable or public interfaces for help, default and --raw compatibility, unchanged --json passthrough, complete live and queued rows, actionable decisions and hold reasons, inventory and endpoint errors, exact omission accounting, deterministic output, underlying errors and exit status, no truncation, full-detail escape hatches, Pi prompt output, and a material representative reduction. Preserve the maintainer measurement for the 12-live, 24-queued, 8-Done fixture: 9,875 raw bytes versus 6,270 compact bytes, approximately 2,469 versus 1,568 tokens at four bytes per token, a 36.5 percent or roughly 901-token reduction. Review all supported primary harnesses and execution providers; the renderer remains harness-, model-provider-, and runtime-independent, and portable CI must make no provider or LLM calls.

Require focused compact and Pi prompt tests, every affected supported-runtime suite other than the accepted cmux baseline, lint, documentation checks, and diff checks to pass. Keep the twice-reproduced unchanged public-main cmux absent-target defect out of scope: send_text_submit returned unknown instead of send-failed, and no cmux source or test may change. Keep the separately reproduced public-main Muse process detection, composer structural edge case, captain-hold exit-status, and Bearings Lavish source-claim failures documented and out of scope.

Do not add typed Pi tools or any Pi extension; do not redesign recovery into an indexed packet; do not change compaction file-list behavior; do not broadly reduce or reorganize AGENTS.md; do not modify the running Firstmate home, install the branch, or update shared tools; do not add provider or LLM calls to portable CI; and do not broaden into unrelated cleanup, Rust caching, GitLab routing, or skill-catalog work. Exclude the prior out-of-scope bin/fm-remote-job-worker.sh change, the attestation-only documentation sentence, and any source-only change manufactured to create an attestation head. Use the v1.60.2 pipeline-supported final-head PR attestation path and do not create another source commit after attesting.

This is the single fresh validation of the clean replacement branch under no-mistakes v1.60.2. Own each gate through a green new PR or a genuinely new captain decision. Publish the replacement PR only when its base is exactly github.com/kunchenguid/firstmate. Report its full URL when green, and never merge either PR.

## What Changed

- Adds an opt-in `--compact` fleet view while preserving the historical default and `--raw` output, with `--json` continuing to pass through the authoritative snapshot.
- Keeps all under-way and queued records, decisions, hold reasons, and inventory or endpoint errors visible in compact output while reporting exact omissions and raw-detail escape commands.
- Carries secondmate evidence omission metadata into the snapshot, adopts compact mode for heartbeat guidance and the Pi supervision prompt, and adds behavioral coverage and CI expectations.

## Risk Assessment

✅ Low: The compact renderer is opt-in, preserves the default and JSON paths, and the changed snapshot disclosures are bounded and surfaced without introducing a source-verifiable regression.

## Testing

An isolated fleet fixture demonstrates byte-identical default/--raw output, complete compact under-way and queued rows with hold and inventory-error disclosure, exact omission counts and raw/JSON escape hatches, JSON snapshot output, invalid-option exit 2, and the Pi heartbeat command `bin/fm-fleet-view.sh --compact`; the reviewer-visible transcript is attached.

<details>
<summary>Evidence: Fleet-view CLI transcript</summary>

Source: [Fleet-view CLI transcript](https://github.com/M00NLIG7/firstmate/blob/aac81686440677b4a7e5c1d78eff410bc1531e49/.no-mistakes/evidence/fm/firstmate-compact-command-modes-v1-c4-clean-1663239/fleet-view-cli-transcript.txt)

```text
Fleet view executable-interface transcript

=== help ===
usage: fm-fleet-view.sh [--raw|--compact|--json]

Render a human fleet view from fm-fleet-snapshot.sh.
The default and --raw print the complete historical human view.
--compact keeps every under-way and queued row, counts every omission from
raw mode, applies no renderer truncation, discloses incomplete snapshot
evidence, and prints exact full-detail commands.
--json prints the complete underlying snapshot.

=== default equals --raw ===
yes (byte-for-byte cmp)

=== --compact ===
# Fleet View (compact)

Home: ~/.no-mistakes/evidence/01M1C7DXH49H4RCMKRAQHCBZBD/fleet-view-cli-fixture
Rows shown/total: under-way=2/2; queued=2/2; done=0/1.
Raw-view omissions: done detail rows=1; task path cells=0.
Compact renderer truncation: none.
Full human detail: FM_HOME='~/.no-mistakes/evidence/01M1C7DXH49H4RCMKRAQHCBZBD/fleet-view-cli-fixture' '~/.no-mistakes/worktrees/48ce38e9c45c/01M1C7DXH49H4RCMKRAQHCBZBD/bin/fm-fleet-view.sh' --raw
Complete raw snapshot: FM_HOME='~/.no-mistakes/evidence/01M1C7DXH49H4RCMKRAQHCBZBD/fleet-view-cli-fixture' '~/.no-mistakes/worktrees/48ce38e9c45c/01M1C7DXH49H4RCMKRAQHCBZBD/bin/fm-fleet-view.sh' --json
Full queued hold detail: tasks-axi show <id> --full, or '~/.no-mistakes/evidence/01M1C7DXH49H4RCMKRAQHCBZBD/fleet-view-cli-fixture/data/backlog.md'.
Actions: peek = bin/fm-peek.sh fm-<row-id>; return = bin/fm-send.sh fm-<row-id> '<request>', then read status/doc and do not routinely peek a secondmate.
Attention marker: ! means a non-working task, endpoint problem, open decision, captain-actionable row, unstructured row, or inventory error.
! inventory error: unstructured current backlog row; orphan in-flight=; unstructured current=2

## Under Way
! inventory item: unstructured in-flight: unstructured recovery item requiring reconciliation
- orphan-ship: Structured live row without task metadata; alpha ship; hold=captain: awaiting captain decision

## Queued
! captain-route: Choose release route; alpha captain; hold=captain: select one option
! unstructured: unstructured queued recovery note

## Done
1 detail row(s) omitted; use the full-human-detail command above.

## Secondmates
For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority.

=== --json contract summary ===
{"schema":"fm-fleet-snapshot.v1","backlog":{"present":true,"records":[{"id":null,"state":"in_flight","structured":false,"hold_reason":null,"hold_kind":null},{"id":"orphan-ship","state":"in_flight","structured":true,"hold_reason":"awaiting captain decision","hold_kind":"captain"},{"id":"captain-route","state":"queued","structured":true,"hold_reason":"select one option","hold_kind":"captain"},{"id":null,"state":"queued","structured":false,"hold_reason":null,"hold_kind":null},{"id":"previous-ship","state":"done","structured":true,"hold_reason":null,"hold_kind":null}]},"main_inventory":{"valid":false,"reason":"unstructured current backlog row","orphan_in_flight":[],"unstructured_current_count":2}}

=== emitted Pi heartbeat instruction ===
A heartbeat wake asks you to review the whole fleet the way MAIN would on an ordinary heartbeat: run `bin/fm-fleet-view.sh --compact`, reconcile suspicious tasks and PR state, update the backlog, and report verdict routine with a one-line summary when nothing changed.
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (4m21s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"527d336d8ee977f294a32f9767b3597e0fd746ba","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-fleet-snapshot-view.test.sh` - The broader snapshot and branch-supervision test launchers exited their enclosing shell during unrelated later checks, before a final suite status could be reported. The targeted CLI behavior was instead verified directly with an isolated executable fixture and captured as evidence.
- <code>`bash tests/fm-fleet-snapshot-view.test.sh` (early relevant checks ran; launcher ended before final status)</code>
- <code>`bash tests/fm-branch-supervision.test.sh` (Pi prompt contract ran; launcher ended before final status)</code>
- <code>`FM_HOME=&lt;isolated fixture&gt; bin/fm-fleet-view.sh`, `--raw`, `--compact`, `--json`, `--help`, and invalid-option exit behavior</code>
- `FM_HOME=<isolated fixture> bin/fm-branch-prompt.sh`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
