### PR TITLE
fix(bin): make trace-disabled Pi relaunches Fish-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,7 @@ jobs:
             exit 1
           }
 
-          /bin/bash tests/fm-control-relaunch.test.sh
+          FM_TEST_REQUIRE_FISH=1 /bin/bash tests/fm-control-relaunch.test.sh
 
   invariants:
     name: Repo invariants

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,11 +348,13 @@ jobs:
           if-no-files-found: warn
 
   macos-stock-bash:
-    name: Stock macOS Bash snapshot compatibility
+    name: Stock macOS Bash and Fish compatibility
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - name: Install Fish
+        run: brew install fish
       - name: Run snapshot consumers with stock Bash
         shell: /bin/bash {0}
         env:
@@ -389,6 +391,8 @@ jobs:
             echo "::error::expected 42 Bearings tests, got $bearings_count"
             exit 1
           }
+
+          /bin/bash tests/fm-control-relaunch.test.sh
 
   invariants:
     name: Repo invariants

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -782,7 +782,7 @@ record_note() {
 }
 
 do_relaunch() {
-  local exit_result state note_line
+  local exit_result state note_line identity elapsed
   local -a spawn_args
 
   require_state_verified_backend relaunch
@@ -842,6 +842,20 @@ do_relaunch() {
   state=$(wait_agent_state "$LAUNCH_WAIT" alive) || {
     die "the replacement agent for $ID did not come up within ${LAUNCH_WAIT}s (endpoint reads '$state')"
   }
+  # Herdr can keep a shell registered after a rejected Fish command, so the
+  # observed Pi relaunch needs the native agent identity as its final proof.
+  if [ "$BACKEND:$TARGET_HARNESS" = herdr:pi ]; then
+    elapsed=0
+    while :; do
+      identity=$(fm_backend_herdr_composer_identity "$T" 2>/dev/null || true)
+      [ "${identity%%$'\t'*}" = pi ] && break
+      awk -v e="$elapsed" -v t="$LAUNCH_WAIT" 'BEGIN{exit !(e < t)}' || {
+        die "the replacement Pi agent for $ID did not come up within ${LAUNCH_WAIT}s (Herdr reports '${identity%%$'\t'*}')"
+      }
+      sleep "$POLL"
+      elapsed=$(awk -v e="$elapsed" -v p="$POLL" 'BEGIN{printf "%.3f", e + p}')
+    done
+  fi
   RELAUNCH_AGENT_CONFIRMED=1
 
   journal_write complete "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -841,22 +841,25 @@ do_relaunch() {
     die "the replacement agent for $ID could not be launched on $TARGET_HARNESS"
   fi
 
-  state=$(wait_agent_state "$LAUNCH_WAIT" alive) || {
-    die "the replacement agent for $ID did not come up within ${LAUNCH_WAIT}s (endpoint reads '$state')"
-  }
   # Herdr can keep a shell registered after a rejected Fish command, so the
-  # observed Pi relaunch needs the native agent identity as its final proof.
+  # observed Pi relaunch needs one native identity/state snapshot as its proof.
   if [ "$BACKEND:$TARGET_HARNESS" = herdr:pi ]; then
     elapsed=0
     while :; do
       identity=$(fm_backend_herdr_composer_identity "$T" 2>/dev/null || true)
-      [ "${identity%%$'\t'*}" = pi ] && break
+      case "$identity" in
+        pi$'\t'working|pi$'\t'idle|pi$'\t'done|pi$'\t'blocked) break ;;
+      esac
       awk -v e="$elapsed" -v t="$LAUNCH_WAIT" 'BEGIN{exit !(e < t)}' || {
         die "the replacement Pi agent for $ID did not come up within ${LAUNCH_WAIT}s (Herdr reports '${identity%%$'\t'*}')"
       }
       sleep "$POLL"
       elapsed=$(awk -v e="$elapsed" -v p="$POLL" 'BEGIN{printf "%.3f", e + p}')
     done
+  else
+    state=$(wait_agent_state "$LAUNCH_WAIT" alive) || {
+      die "the replacement agent for $ID did not come up within ${LAUNCH_WAIT}s (endpoint reads '$state')"
+    }
   fi
   RELAUNCH_AGENT_CONFIRMED=1
 

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -844,6 +844,7 @@ do_relaunch() {
   # Herdr can keep a shell registered after a rejected Fish command, so the
   # observed Pi relaunch needs one native identity/state snapshot as its proof.
   if [ "$BACKEND:$TARGET_HARNESS" = herdr:pi ]; then
+    fm_backend_source "$BACKEND" || die "the Herdr backend could not be loaded to verify the replacement Pi agent"
     elapsed=0
     while :; do
       identity=$(fm_backend_herdr_composer_identity "$T" 2>/dev/null || true)

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -46,8 +46,10 @@
 #              standing charter is never rewritten.
 #              Records a durable checkpoint and that note, exits the old agent,
 #              then delegates the launch to its single owner,
-#              bin/fm-spawn.sh --relaunch. A failure before publication keeps
-#              the prior durable record in place and reports the concrete
+#              bin/fm-spawn.sh --relaunch. A Herdr relaunch onto Pi additionally
+#              requires Herdr's native agent identity to report Pi, so a
+#              surviving shell is not success. A failure before publication
+#              keeps the prior durable record in place and reports the concrete
 #              state; it never leaves a half-transitioned task claiming to be
 #              running.
 #

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -208,8 +208,9 @@
 # When the home session's frozen trace-context decision is enabled (see
 # docs/configuration.md and bin/fm-trace-context-lib.sh), the meta also records
 # one W3C traceparent= carrier, the same value injected into the pane as
-# TRACEPARENT; the default-off path writes neither, leaving the generated meta
-# and launch environment unchanged.
+# TRACEPARENT. The default-off path writes and exports neither; on relaunch it
+# also clears any prior carrier only from the replacement process environment
+# with `env -u TRACEPARENT`, leaving the long-lived pane shell unchanged.
 #   --traceparent <carrier> delivers a carrier that a REMOTE parent already
 #   resolved and will record, instead of resolving one from this home's frozen
 #   decision. It is accepted only for --secondmate spawns, only as a strictly

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3005,7 +3005,7 @@ if [ "$KIND" = secondmate ]; then
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=$sq_primary_home FM_HOME=$sq_home FM_TRACE_CONTEXT=$SPAWN_TRACE_EFFECTIVE FM_SUPERVISION_MODEL=$supervision_model $LAUNCH"
 fi
 if [ -z "$SPAWN_TRACEPARENT" ] && [ "$RELAUNCH" -eq 1 ]; then
-  LAUNCH="unset TRACEPARENT; $LAUNCH"
+  LAUNCH="env -u TRACEPARENT $LAUNCH"
 fi
 
 spawn_record_traceparent() {
@@ -3044,7 +3044,7 @@ spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 if [ -n "$SPAWN_TRACEPARENT" ]; then
   if spawn_send_text_line "$T" "export TRACEPARENT=$SPAWN_TRACEPARENT"; then
     if ! spawn_record_traceparent; then
-      LAUNCH="unset TRACEPARENT; $LAUNCH"
+      LAUNCH="env -u TRACEPARENT $LAUNCH"
     fi
   else
     TRACE_SEND_STATUS=$?
@@ -3052,7 +3052,7 @@ if [ -n "$SPAWN_TRACEPARENT" ]; then
       echo "error: trace-context input could not be cleared for $W; refusing to append the launch command" >&2
       exit 1
     fi
-    LAUNCH="unset TRACEPARENT; $LAUNCH"
+    LAUNCH="env -u TRACEPARENT $LAUNCH"
   fi
 fi
 sleep 0.3

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3044,7 +3044,11 @@ spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 if [ -n "$SPAWN_TRACEPARENT" ]; then
   if spawn_send_text_line "$T" "export TRACEPARENT=$SPAWN_TRACEPARENT"; then
     if ! spawn_record_traceparent; then
-      LAUNCH="env -u TRACEPARENT $LAUNCH"
+      if [ "$RELAUNCH" -eq 1 ]; then
+        LAUNCH="env -u TRACEPARENT $LAUNCH"
+      else
+        LAUNCH="unset TRACEPARENT; $LAUNCH"
+      fi
     fi
   else
     TRACE_SEND_STATUS=$?
@@ -3052,7 +3056,11 @@ if [ -n "$SPAWN_TRACEPARENT" ]; then
       echo "error: trace-context input could not be cleared for $W; refusing to append the launch command" >&2
       exit 1
     fi
-    LAUNCH="env -u TRACEPARENT $LAUNCH"
+    if [ "$RELAUNCH" -eq 1 ]; then
+      LAUNCH="env -u TRACEPARENT $LAUNCH"
+    else
+      LAUNCH="unset TRACEPARENT; $LAUNCH"
+    fi
   fi
 fi
 sleep 0.3

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -32,7 +32,7 @@ A recorded `harness=` is not always an exact adapter name: a task launched from 
 | --- | --- | --- |
 | `interrupt` | Deliver the harness's verified interrupt sequence while leaving the agent running. | Delivery succeeds while the endpoint still exists and the agent is still alive where the backend can classify that; cancellation is confirmed only from an adapter-owned acknowledgement and otherwise reports `cancel=unconfirmed`. |
 | `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone. Already-stopped is idempotent success. |
-| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, and effort. | The new agent is alive on the recorded endpoint, and the durable record names the harness that is actually running. |
+| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, and effort. | The new agent is alive on the recorded endpoint, and the durable record names the harness that is actually running; a Herdr relaunch onto Pi additionally requires Herdr's native agent identity to report Pi rather than a surviving shell. |
 
 An exit that delivers lifecycle input but cannot prove the agent stopped fails with `exit=unconfirmed`, reports the observed agent state and any interrupt cancellation claim, and never claims that nothing changed.
 Interrupt never rewrites busy state as proof of its own success.
@@ -118,5 +118,5 @@ The empirical basis for each adapter's value is the `harness-adapters` skill's v
 ## Verification
 
 - `tests/fm-control.test.sh` - the adapter contract for every verified harness, the backend capability matrix, exact-id scoping, the closed verb list, the busy, idle, dead, and idempotent lifecycle cases, and marker non-regression, all against a stubbed session provider.
-- `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, the progress note, checkpoint refusals, and rollback after a failed launch.
+- `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, the progress note, checkpoint refusals, trace-disabled Fish launch cleanup, Herdr/Pi agent-identity confirmation, and rollback after a failed launch.
 - `tests/fm-control-herdr-smoke.test.sh` - the second state-verified backend against the real herdr binary, on an isolated throwaway lab session.

--- a/docs/trace-context.md
+++ b/docs/trace-context.md
@@ -50,7 +50,8 @@ The point of these rules is one trace per task: never merge unrelated tasks, and
 
 Because ambient `TRACEPARENT` is never read, the environment a supervisor happens to run under - a Secondmate's launch-time carrier, or an operator shell with a leftover `TRACEPARENT` - cannot leak into new task identities.
 Disabling propagation is an intentional trace boundary: a disabled home injects no carrier into a newly launched or relaunched agent even when the task meta already contains a valid `traceparent=`.
-An actual disabled relaunch regenerates the task meta without `traceparent=`, so a later enabled relaunch roots a new trace instead of resuming the identity from before the boundary; reusing an already-alive remote endpoint is not a relaunch and preserves the carrier that agent already holds.
+An actual disabled relaunch starts the replacement with shell-neutral `env -u TRACEPARENT`, which clears the carrier from that process without mutating the long-lived pane shell.
+It also regenerates the task meta without `traceparent=`, so a later enabled relaunch roots a new trace instead of resuming the identity from before the boundary; reusing an already-alive remote endpoint is not a relaunch and preserves the carrier that agent already holds.
 
 ### Enablement is home-session-scoped
 
@@ -88,7 +89,8 @@ This is a deliberate, source-owned choice:
 ## Safety
 
 - **Default-off.**
-  With no `config/trace-context` and no `FM_TRACE_CONTEXT`, a fresh spawn or actual relaunch injects nothing and writes no `traceparent=` line, so the generated meta and the launch environment are unchanged.
+  With no `config/trace-context` and no `FM_TRACE_CONTEXT`, a fresh spawn injects nothing and writes no `traceparent=` line, so its generated meta and launch environment are unchanged.
+  An actual relaunch writes no `traceparent=` line and excludes any prior carrier from the replacement process as described above.
   Reusing an already-alive remote endpoint records any carrier that endpoint reports without injecting a new one.
   A locked session start makes the one config-file check, and each spawn sources one extra library and reads the frozen effective-state file, so the process is not literally byte-for-byte identical, but nothing an agent, an observer, or the task meta can see differs.
 - **What is and is not exposed.**
@@ -102,7 +104,7 @@ This is a deliberate, source-owned choice:
   Any entropy or self-validation failure that returns omits the carrier for that spawn without aborting source work; a corrupt recorded carrier is re-minted as a fresh root rather than propagated (it is not an omission).
   If the pre-launch carrier export fails, Firstmate omits the `traceparent=` metadata claim and still launches the task.
   If the backend reports that failed trace input could not be cleared, Firstmate refuses to append the launch command rather than risk launching with an unknown partial carrier.
-  If recording the carrier fails after export, Firstmate unsets `TRACEPARENT` in the launch command and still launches the task, so the child never receives an identity absent from its metadata.
+  If recording the carrier fails after export, Firstmate excludes `TRACEPARENT` from the child launch and still launches the task, so the child never receives an identity absent from its metadata.
 - **Metadata-only.**
   The value lives in the ephemeral pane shell and in `state/<id>.meta`; teardown removes state as before, so there is no new durable surface and no schema migration.
 

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -459,18 +459,18 @@ test_disabled_relaunch_clears_prior_trace_context() {
     || fail "disabled relaunch must clear the pane carrier in the replacement process environment"
   ! grep -q '^export TRACEPARENT=' "$dir/fake/literal" \
     || fail "disabled relaunch must not export a replacement trace carrier"
-  if command -v fish >/dev/null 2>&1; then
-    cat > "$dir/fakebin/claude" <<'SH'
+  command -v fish >/dev/null 2>&1 \
+    || fail "Fish is required for the trace-disabled replacement launch regression"
+  cat > "$dir/fakebin/claude" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "${TRACEPARENT-unset}" > "$FM_FAKE_DIR/fish-traceparent"
 SH
-    chmod +x "$dir/fakebin/claude"
-    PATH="$dir/fakebin:$PATH" FM_FAKE_DIR="$dir/fake" TRACEPARENT=stale \
-      fish -c "$launch" >/dev/null 2>&1 \
-      || fail "Fish rejected the trace-disabled replacement launch"
-    [ "$(cat "$dir/fake/fish-traceparent")" = unset ] \
-      || fail "the replacement process inherited TRACEPARENT under Fish"
-  fi
+  chmod +x "$dir/fakebin/claude"
+  PATH="$dir/fakebin:$PATH" FM_FAKE_DIR="$dir/fake" TRACEPARENT=stale \
+    fish -c "$launch" >/dev/null 2>&1 \
+    || fail "Fish rejected the trace-disabled replacement launch"
+  [ "$(cat "$dir/fake/fish-traceparent")" = unset ] \
+    || fail "the replacement process inherited TRACEPARENT under Fish"
   pass "fm-control relaunch: disabling tracing clears metadata and starts through Fish without inheriting pane context"
 }
 

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -123,6 +123,43 @@ SH
   chmod +x "$fb/sleep"
 }
 
+make_herdr_stub() {  # <dir>
+  local fb="$1/fakebin"
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+D=$FM_FAKE_DIR
+case "${1:-} ${2:-}" in
+  "status --json")
+    printf '%s\n' '{"client":{"version":"0.8.2","protocol":19},"server":{"running":true}}'
+    ;;
+  "pane get")
+    printf '{"result":{"pane":{"pane_id":"w1:p1","foreground_cwd":"%s"}}}\n' "$(cat "$D/cwd")"
+    ;;
+  "agent get")
+    if [ -e "$D/launch-entered" ]; then
+      printf '%s\n' '{"result":{"agent":{"agent":"shell","agent_status":"idle"}}}'
+    else
+      printf '%s\n' '{"error":{"code":"agent_not_found"}}'
+    fi
+    ;;
+  "pane send-text")
+    printf '%s\n' "${4:-}" >> "$D/literal"
+    : > "$D/launch-pending"
+    ;;
+  "pane send-keys")
+    [ ! -e "$D/launch-pending" ] || : > "$D/launch-entered"
+    ;;
+esac
+SH
+  chmod +x "$fb/herdr"
+  cat > "$fb/pi" <<'SH'
+#!/usr/bin/env bash
+[ "${1:-}" != --help ] || printf '%s\n' 'Usage: pi'
+SH
+  chmod +x "$fb/pi"
+}
+
 # new_case <name> [id] -> echoes a case dir with a live claude ship task.
 new_case() {
   local id=${2:-t1} dir="$TMP_ROOT/$1-$RANDOM"
@@ -406,7 +443,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
 }
 
 test_disabled_relaunch_clears_prior_trace_context() {
-  local dir out rc
+  local dir out rc launch
   dir=$(new_case trace-off rl33)
   add_ship_task "$dir" rl33 claude
   printf '%s\n' 'traceparent=00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01' \
@@ -418,11 +455,46 @@ test_disabled_relaunch_clears_prior_trace_context() {
   expect_code 0 "$rc" "disabled relaunch should succeed"$'\n'"$out"
   [ -z "$(meta_field "$dir" rl33 traceparent)" ] \
     || fail "disabled relaunch must remove the prior trace carrier from metadata"
-  grep -q '^unset TRACEPARENT; .*claude' "$dir/fake/literal" \
-    || fail "disabled relaunch must clear the pane carrier before replacement launch"
+  launch=$(grep '^env -u TRACEPARENT .*claude' "$dir/fake/literal") \
+    || fail "disabled relaunch must clear the pane carrier in the replacement process environment"
   ! grep -q '^export TRACEPARENT=' "$dir/fake/literal" \
     || fail "disabled relaunch must not export a replacement trace carrier"
-  pass "fm-control relaunch: disabling tracing clears metadata and pane context"
+  if command -v fish >/dev/null 2>&1; then
+    cat > "$dir/fakebin/claude" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${TRACEPARENT-unset}" > "$FM_FAKE_DIR/fish-traceparent"
+SH
+    chmod +x "$dir/fakebin/claude"
+    PATH="$dir/fakebin:$PATH" FM_FAKE_DIR="$dir/fake" TRACEPARENT=stale \
+      fish -c "$launch" >/dev/null 2>&1 \
+      || fail "Fish rejected the trace-disabled replacement launch"
+    [ "$(cat "$dir/fake/fish-traceparent")" = unset ] \
+      || fail "the replacement process inherited TRACEPARENT under Fish"
+  fi
+  pass "fm-control relaunch: disabling tracing clears metadata and starts through Fish without inheriting pane context"
+}
+
+test_herdr_pi_relaunch_rejects_a_surviving_shell() {
+  local dir out rc meta
+  dir=$(new_case herdr-pi-shell rl42)
+  add_ship_task "$dir" rl42 pi
+  make_herdr_stub "$dir"
+  meta="$dir/home/state/rl42.meta"
+  sed -i.bak 's|^window=.*|window=fake:w1:p1|' "$meta"
+  rm -f "$meta.bak"
+  {
+    printf '%s\n' 'backend=herdr'
+    printf '%s\n' 'herdr_session=fake'
+    printf '%s\n' 'herdr_workspace_id=w1'
+    printf '%s\n' 'herdr_tab_id=w1:t1'
+    printf '%s\n' 'herdr_pane_id=w1:p1'
+  } >> "$meta"
+
+  out=$(run_control "$dir" rl42 relaunch --note "retry the Pi worker") || rc=$?
+  expect_code 1 "${rc:-0}" "a surviving Herdr shell must not prove the replacement Pi agent started"$'\n'"$out"
+  assert_contains "$out" "replacement Pi agent" \
+    "the refusal should name the selected agent that never started"
+  pass "fm-control relaunch: Herdr rejects a surviving shell when the selected Pi agent never starts"
 }
 
 test_relaunch_appends_the_progress_note_to_the_instructions() {
@@ -1481,6 +1553,7 @@ test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_serializes_concurrent_durable_metadata_publication
 test_disabled_relaunch_clears_prior_trace_context
+test_herdr_pi_relaunch_rejects_a_surviving_shell
 test_relaunch_appends_the_progress_note_to_the_instructions
 test_relaunch_requires_a_note_for_a_ship_task
 test_harness_switch_moves_the_record_and_clears_prior_wiring

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -496,6 +496,8 @@ test_herdr_pi_relaunch_rejects_a_surviving_shell() {
   expect_code 1 "${rc:-0}" "a surviving Herdr shell must not prove the replacement Pi agent started"$'\n'"$out"
   assert_contains "$out" "replacement Pi agent" \
     "the refusal should name the selected agent that never started"
+  assert_contains "$out" "Herdr reports 'shell'" \
+    "the refusal should identify the surviving shell that failed launch verification"
   pass "fm-control relaunch: Herdr rejects a surviving shell when the selected Pi agent never starts"
 }
 

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -459,19 +459,21 @@ test_disabled_relaunch_clears_prior_trace_context() {
     || fail "disabled relaunch must clear the pane carrier in the replacement process environment"
   ! grep -q '^export TRACEPARENT=' "$dir/fake/literal" \
     || fail "disabled relaunch must not export a replacement trace carrier"
-  command -v fish >/dev/null 2>&1 \
-    || fail "Fish is required for the trace-disabled replacement launch regression"
-  cat > "$dir/fakebin/claude" <<'SH'
+  if command -v fish >/dev/null 2>&1; then
+    cat > "$dir/fakebin/claude" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "${TRACEPARENT-unset}" > "$FM_FAKE_DIR/fish-traceparent"
 SH
-  chmod +x "$dir/fakebin/claude"
-  PATH="$dir/fakebin:$PATH" FM_FAKE_DIR="$dir/fake" TRACEPARENT=stale \
-    fish -c "$launch" >/dev/null 2>&1 \
-    || fail "Fish rejected the trace-disabled replacement launch"
-  [ "$(cat "$dir/fake/fish-traceparent")" = unset ] \
-    || fail "the replacement process inherited TRACEPARENT under Fish"
-  pass "fm-control relaunch: disabling tracing clears metadata and starts through Fish without inheriting pane context"
+    chmod +x "$dir/fakebin/claude"
+    PATH="$dir/fakebin:$PATH" FM_FAKE_DIR="$dir/fake" TRACEPARENT=stale \
+      fish -c "$launch" >/dev/null 2>&1 \
+      || fail "Fish rejected the trace-disabled replacement launch"
+    [ "$(cat "$dir/fake/fish-traceparent")" = unset ] \
+      || fail "the replacement process inherited TRACEPARENT under Fish"
+  elif [ "${FM_TEST_REQUIRE_FISH:-0}" = 1 ]; then
+    fail "Fish is required for the trace-disabled replacement launch regression"
+  fi
+  pass "fm-control relaunch: disabling tracing clears metadata and replacement process context"
 }
 
 test_herdr_pi_relaunch_rejects_a_surviving_shell() {

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -304,7 +304,8 @@ test_failed_delivery_omits_metadata_and_still_launches() {
     || fail "failed traceparent delivery must not leave a traceparent= claim in meta"
   ! grep -q '^export TRACEPARENT=' "$LAUNCH_LOG" \
     || fail "the failed TRACEPARENT export must not be recorded as delivered"
-  grep -q 'claude' "$LAUNCH_LOG" || fail "the source task must still launch"
+  grep -q '^unset TRACEPARENT; .*claude' "$LAUNCH_LOG" \
+    || fail "failed TRACEPARENT delivery must preserve the fresh-spawn launch cleanup"
   pass "failed TRACEPARENT delivery omits metadata while the source task still launches"
 }
 
@@ -342,8 +343,8 @@ test_failed_metadata_append_unsets_carrier_and_still_launches() {
 
   ! grep -q '^traceparent=' "$meta" \
     || fail "failed metadata append must not leave a traceparent= claim in meta"
-  grep -q '^env -u TRACEPARENT .*claude' "$LAUNCH_LOG" \
-    || fail "failed metadata append must clear TRACEPARENT in the launched process environment"
+  grep -q '^unset TRACEPARENT; .*claude' "$LAUNCH_LOG" \
+    || fail "failed metadata append must unset TRACEPARENT in the launch command"
   pass "failed traceparent metadata append removes the carrier from the launched task"
 }
 

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -342,8 +342,8 @@ test_failed_metadata_append_unsets_carrier_and_still_launches() {
 
   ! grep -q '^traceparent=' "$meta" \
     || fail "failed metadata append must not leave a traceparent= claim in meta"
-  grep -q '^unset TRACEPARENT; .*claude' "$LAUNCH_LOG" \
-    || fail "failed metadata append must unset TRACEPARENT in the launch command"
+  grep -q '^env -u TRACEPARENT .*claude' "$LAUNCH_LOG" \
+    || fail "failed metadata append must clear TRACEPARENT in the launched process environment"
   pass "failed traceparent metadata append removes the carrier from the launched task"
 }
 


### PR DESCRIPTION
## Intent

Fix kunchenguid/firstmate issue #3393 with the minimal patch for the real macOS incident where an idle local Second Mate using Fish 4.8.1, the Herdr backend, Pi, and default-disabled trace context was relaunched through bin/fm-control.sh and the generated unset TRACEPARENT command failed in Fish, no replacement Pi agent started, yet lifecycle control reported success because the shell survived. A trace-disabled relaunch must atomically clear TRACEPARENT with shell-neutral process-environment syntax and start from Fish; the observed Herdr + Pi path must reject a surviving shell unless the selected Pi agent actually starts. Add the smallest behavioral regression using existing seams, with a real Fish invocation only where it is the shortest faithful check. Keep fresh-spawn behavior, trace default-off, raw Pi launch, Second Mate extension flags, and zsh/bash behavior unchanged. Do not reuse or repair closed PR #3333, add generalized C-shell support, tmux startup proof, cross-harness executable identity catalogues, Cursor/Codex exceptions, session-lock matching changes, new abstractions, or broad backend/framework machinery. Follow CONTRIBUTING.md from current upstream main through the fork and no-mistakes v1.46.0+ structured final-head attestation. Open a new upstream PR, do not modify PR #3333, do not merge, and use Fixes #3393. The PR body must lead with the machine, Fish shell, Herdr session, Pi agent, trace-disabled setup, exact unset TRACEPARENT command shape, Fish error, absent Pi agent, and false success; distinguish the Fish-specific incompatibility from the generic consequence of trusting a surviving shell; state the minimal fix, focused verification, and explicit non-goals in neutral contributor language. Escalate rather than generalize if review requests scope beyond this field incident.

## What Changed

- On macOS, a trace-disabled Fish 4.8.1 Herdr session generated `unset TRACEPARENT; <Pi launch>`, which Fish rejected; no Pi agent started, but lifecycle control falsely succeeded because the shell survived. Relaunches now use shell-neutral `env -u TRACEPARENT <Pi launch>`.
- Require Herdr’s native agent identity to report Pi before a Herdr/Pi relaunch succeeds, rejecting a surviving shell as launch proof.
- Add focused real-Fish macOS and Herdr/Pi regressions while preserving trace default-off, fresh spawns, raw Pi launches, Second Mate extension flags, and zsh/Bash behavior. Fixes #3393.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped and the current source closes the Fish relaunch false-success path while preserving fresh-spawn behavior and required CI coverage.

## Testing

Baseline diff inspection was clean; the Fish-required relaunch suite and trace-context spawn suite exited successfully, the manual Fish 4.8.1 transcript reproduced the legacy false-success shape and verified the fixed child environment, reviewer evidence was recorded, and the worktree was left clean.

<details>
<summary>Evidence: Fish relaunch verification transcript</summary>

Source: [Fish relaunch verification transcript](https://github.com/sayoriqwq/firstmate/blob/3846b0cbcdf8fdf359d457aaf127a3a5135e6a25/.no-mistakes/evidence/fm/fish-relaunch-minimal/fish-relaunch-transcript.log)

<code>Fish 4.8.1 rejects `unset TRACEPARENT`, while the shell survives with exit 0. The fixed `env -u TRACEPARENT` launch reports the replacement carrier unset. The transcript also records both focused suites passing.</code>

```text
^Dhost-shell: fish, version 4.8.1
legacy-command: unset TRACEPARENT; echo legacy-shell-survived
fish: Unknown command: unset
fish: 
unset TRACEPARENT; echo legacy-shell-survived
^~~~^
legacy-shell-survived
legacy-exit=0
fixed-command: env -u TRACEPARENT <replacement>
replacement-carrier-unset
fixed-exit=0
ok - fm-control relaunch: a same-harness relaunch replaces the agent in the same endpoint and worktree
ok - fm-control relaunch: durable task metadata survives replacement launch publication
ok - fm-control relaunch: delivery and concurrent task metadata publication serialize
ok - fm-control relaunch: disabling tracing clears metadata and replacement process context
ok - fm-control relaunch: Herdr rejects a surviving shell when the selected Pi agent never starts
ok - fm-control relaunch: the progress note lands in the instructions the replacement reads
ok - fm-control relaunch: a ship task refuses without the progress note its replacement needs
ok - fm-control relaunch: switching harness is one ordinary relaunch, and the old wiring goes with the old agent
ok - fm-control relaunch: a harness switch resets model and effort unless they are named too
ok - fm-control relaunch: a prefixed recorded harness can switch adapters transactionally
ok - fm-control relaunch: a prefixed command requires an explicit replacement harness
ok - fm-control relaunch: a same-harness relaunch keeps the profile axes it was running with
ok - fm-control relaunch: explicit model and effort win over the recorded ones
ok - fm-control relaunch: refuses to relaunch onto an adapter with no verified mechanics
ok - fm-control relaunch: the retired incarnation's global turn-end token is revoked
ok - fm-control relaunch: wiring cleanup failure refuses replacement arming
ok - fm-control-lib: one owner resolves each harness's turn-end registry entry, and refuses a malformed token
ok - fm-control relaunch: a secondmate relaunch re-resolves its durable configured harness pin
ok - fm-control relaunch: invalid configured effort is ignored before stop
ok - fm-control relaunch: an adapter unverified for this task kind refuses before the agent is stopped
ok - fm-control relaunch: explicit secondmate harness resets unnamed profile axes
ok - fm-control relaunch: a ship task keeps its recorded harness instead of re-reading crew config
ok - fm-spawn --relaunch: with no explicit harness it reuses the task's recorded one, never the crew default
ok - fm-spawn --relaunch: wiring armed under a prefixed harness name is still retired
ok - fm-spawn --relaunch: switching away from muse retires its session binding
ok - fm-spawn --relaunch: switching away from cursor retires its session binding
ok - fm-control relaunch: an unaccountable local copy refuses before the agent is touched
ok - fm-control relaunch: a worker with nothing to work from is never launched
ok - fm-control relaunch: a refusal before the agent is stopped leaves the durable record untouched
ok - fm-control relaunch: checkpoint inspection failures refuse before stopping
ok - fm-control relaunch: a launch failure after the stop keeps the prior record and reports the real state
ok - fm-control relaunch: unpublished rollback keeps concurrent durable metadata
ok - fm-control relaunch: post-publication failure keeps the new durable record
ok - fm-control relaunch: partial stop reconciles actual agent state
ok - fm-control relaunch: failed journal replacement preserves durable phase
ok - fm-spawn relaunch: prepublication abort removes replacement state
ok - fm-control relaunch: the checkpoint records the exact unlanded work it preserved
ok - fm-control relaunch: a secondmate's child work is accounted for and its charter is left alone
ok - fm-control relaunch: a secondmate home that is not this secondmate's is refused
ok - fm-control relaunch: unreadable and untraversable child state fails checkpoint
ok - fm-control relaunch: two control actions on one task serialize instead of interleaving
ok - fm-spawn relaunch: direct entry participates in lifecycle serialization
ok - fm-promote: promotion participates in lifecycle serialization
ok - fm-spawn --relaunch: refuses to launch a second agent into a live endpoint
ok - fm-spawn --relaunch: symlinked records refuse before inspection
ok - fm-spawn --relaunch: keeps its early meta lock continuous
ok - fm-spawn --relaunch: pending closes refuse before replacement begins
ok - fm-spawn --relaunch: every identity axis comes from the record, and a contradicting flag refuses
ok - fm-spawn --relaunch: an unrecorded task is refused
ok - fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work
ok - relaunch re-reads the backlog item instead of blindly re-running the transition
ok - relaunch heals an item that drifted out of In flight while the task stayed live
ok - enabled: one resolved carrier is recorded in meta and the identical TRACEPARENT is exported before launch
ok - disabled: neither traceparent= in meta nor a TRACEPARENT export is produced
ok - failed TRACEPARENT delivery omits metadata while the source task still launches
ok - uncleared TRACEPARENT input stops before the launch command is appended
ok - failed traceparent metadata append removes the carrier from the launched task
ok - duplicate secondmate preflight leaves trace-context unchanged
ok - relaunch reuses the recorded carrier verbatim for both the meta record and the injected export
ok - session start freezes the env override and later config or environment edits do not alter spawns
ok - two-level: env-on/file-absent keeps the nested worker enabled, rooting its own per-task trace
ok - two-level: env-off/file-present keeps the nested worker disabled even though the config file was copied into the secondmate home
ok - two unrelated routed tasks through one persistent Secondmate root distinct traces, adopt nothing from its environment, and keep per-task identity across relaunch
ok - secondmate carrier and FM_TRACE_CONTEXT snapshot always agree, both derived from one frozen decision (file-decided path)
# all fm-trace-context-spawn tests passed
```
</details>
<details>
<summary>Evidence: Reproducible evidence script</summary>

Source: [Reproducible evidence script](https://github.com/sayoriqwq/firstmate/blob/3846b0cbcdf8fdf359d457aaf127a3a5135e6a25/.no-mistakes/evidence/fm/fish-relaunch-minimal/verify-fish-relaunch.fish)

```text
#!/etc/profiles/per-user/sayori/bin/fish

set -lx TRACEPARENT stale
printf 'host-shell: '
rtk fish --version

set legacy_cmd "unset TRACEPARENT; echo legacy-shell-survived"
printf 'legacy-command: %s\n' "$legacy_cmd"
rtk fish -c "$legacy_cmd"
printf 'legacy-exit=%s\n' "$status"

set fixed_probe "if set -q TRACEPARENT; echo replacement-carrier-present; exit 1; else; echo replacement-carrier-unset; end"
printf 'fixed-command: env -u TRACEPARENT <replacement>\n'
rtk env -u TRACEPARENT fish -c "$fixed_probe"
or exit $status
printf 'fixed-exit=%s\n' "$status"

set -lx FM_TEST_REQUIRE_FISH 1
rtk /bin/bash tests/fm-control-relaunch.test.sh
or exit $status
rtk /bin/bash tests/fm-trace-context-spawn.test.sh
or exit $status
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"14257f1ae8244648fbd1c5858f3a4c2d47ac46d2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `tests/fm-control-relaunch.test.sh:462` - The only executable Fish regression is silently skipped when `fish` is unavailable, yet the test still reports that the Fish launch passed. The required CI jobs neither provision nor require Fish, so this regression can remain untested. Require/provision Fish in the lane running this suite and fail when it is absent.

🔧 Fix: Enforce Fish relaunch regression in macOS CI
2 errors still open:

- 🚨 `bin/fm-spawn.sh:3047` - Intent requires “Keep fresh-spawn behavior ... unchanged,” but this also changes fresh-spawn fallback behavior. After a successful trace export followed by metadata-publication failure, `env -u TRACEPARENT` clears only the child environment and leaves the carrier in the long-lived pane shell; the prior `unset TRACEPARENT;` removed it. Line 3055 has the same scope expansion. Limit the shell-neutral change to relaunches unless this fresh-spawn change is explicitly approved.
- 🚨 `tests/fm-control-relaunch.test.sh:462` - This suite still runs in a required Ubuntu portable-serial lane, but only the macOS invocation provisions Fish. The unconditional `command -v fish || fail` therefore breaks that Ubuntu lane when Fish is absent; the [official runner inventory](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md?plain=1) does not include Fish. Scope the hard requirement to the provisioned macOS invocation without reporting a Fish pass elsewhere.

🔧 Fix: Preserve fresh spawns and scope required Fish coverage
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `rtk git diff --check 4ad8cbaeafc109a17c1af3911867b7fe9e04e801..d2cc74066d202538a4284ef3c0688ba740bc396b`
- <code>`rtk fish --version` → Fish 4.8.1</code>
- `set -lx FM_TEST_REQUIRE_FISH 1; rtk /bin/bash tests/fm-control-relaunch.test.sh`
- `rtk /bin/bash tests/fm-trace-context-spawn.test.sh`
- `rtk script -q /Users/sayori/.no-mistakes/evidence/01M1C91X1262NCHF7HGQK8QEC6/fish-relaunch-transcript.log /Users/sayori/.no-mistakes/evidence/01M1C91X1262NCHF7HGQK8QEC6/verify-fish-relaunch.fish`
- <code>`rtk git status --short` after transient-artifact cleanup</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Verify pinned lint checks pass
1 warning still open:

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
