### PR TITLE
fix(herdr): make presentation-lock namespace per-user

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -658,18 +658,17 @@ fm_backend_herdr_projection_workspace_label() {  # <task-id> <projection-id>
 # fm_backend_herdr_presentation_lock_namespace: per-user namespace, never a
 # fixed shared path. On a multi-user host a fixed /tmp path is created and
 # owned by whichever user gets there first, permanently locking every other
-# user out (mode 700, foreign uid). Prefers $XDG_RUNTIME_DIR (already
-# per-user, mode 700 by the XDG Base Directory spec) when it is set and
-# usable, else falls back to a uid-suffixed /tmp path. A foreign-owned legacy
-# /tmp/firstmate-herdr-presentation (no uid suffix) is never read, chowned,
-# chmodded, or migrated - it is simply not this function's return value
-# anymore, and the locks themselves are ephemeral.
+# user out (mode 700, foreign uid). Always resolves the deterministic
+# uid-suffixed /tmp path - never $XDG_RUNTIME_DIR, whose presence and value
+# can differ between two processes of the SAME user (a systemd user session
+# vs. a cron/sudo/detached invocation, or two different session ids), which
+# would split one user's own lock identity across two different directories
+# and silently defeat the mutual exclusion the lock exists for. A
+# foreign-owned legacy /tmp/firstmate-herdr-presentation (no uid suffix) is
+# never read, chowned, chmodded, or migrated - it is simply not this
+# function's return value anymore, and the locks themselves are ephemeral.
 fm_backend_herdr_presentation_lock_namespace() {
   local uid
-  if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -d "${XDG_RUNTIME_DIR:-}" ] && [ -w "${XDG_RUNTIME_DIR:-}" ]; then
-    printf '%s/firstmate-herdr-presentation' "$XDG_RUNTIME_DIR"
-    return 0
-  fi
   uid=$(id -u 2>/dev/null) || return 1
   [ -n "$uid" ] || return 1
   printf '/tmp/firstmate-herdr-presentation-%s' "$uid"

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -655,8 +655,24 @@ fm_backend_herdr_projection_workspace_label() {  # <task-id> <projection-id>
 # The path is never under any one home's state/ and secondmates never write the
 # primary home. Returns non-zero when the named session's socket cannot be
 # resolved unambiguously.
+# fm_backend_herdr_presentation_lock_namespace: per-user namespace, never a
+# fixed shared path. On a multi-user host a fixed /tmp path is created and
+# owned by whichever user gets there first, permanently locking every other
+# user out (mode 700, foreign uid). Prefers $XDG_RUNTIME_DIR (already
+# per-user, mode 700 by the XDG Base Directory spec) when it is set and
+# usable, else falls back to a uid-suffixed /tmp path. A foreign-owned legacy
+# /tmp/firstmate-herdr-presentation (no uid suffix) is never read, chowned,
+# chmodded, or migrated - it is simply not this function's return value
+# anymore, and the locks themselves are ephemeral.
 fm_backend_herdr_presentation_lock_namespace() {
-  printf '%s' '/tmp/firstmate-herdr-presentation'
+  local uid
+  if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -d "${XDG_RUNTIME_DIR:-}" ] && [ -w "${XDG_RUNTIME_DIR:-}" ]; then
+    printf '%s/firstmate-herdr-presentation' "$XDG_RUNTIME_DIR"
+    return 0
+  fi
+  uid=$(id -u 2>/dev/null) || return 1
+  [ -n "$uid" ] || return 1
+  printf '/tmp/firstmate-herdr-presentation-%s' "$uid"
 }
 
 fm_backend_herdr_presentation_lock_namespace_mode() {

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2508,30 +2508,35 @@ SH
 }
 
 test_presentation_session_lock_path_is_shared_across_homes() {
-  local dir log resp fb path_a path_b path_other path_tmp path_private
+  local dir log resp fb path_a path_b path_other path_tmp path_private uid
   dir="$TMP_ROOT/presentation-session-lock"; mkdir -p "$dir/responses" "$dir/sockdir"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
+  uid=$(id -u) || fail "could not resolve current uid"
   : > "$dir/sockdir/fmtest.sock"
   printf '%s\n' "{\"sessions\":[{\"name\":\"fmtest\",\"running\":true,\"socket_path\":\"$dir/sockdir/fmtest.sock\"}]}" > "$resp/1.out"
   printf '%s\n' "{\"sessions\":[{\"name\":\"fmtest\",\"running\":true,\"socket_path\":\"$dir/sockdir/fmtest.sock\"}]}" > "$resp/2.out"
   printf '%s\n' "{\"sessions\":[{\"name\":\"other\",\"running\":true,\"socket_path\":\"$dir/sockdir/other.sock\"}]}" > "$resp/3.out"
   : > "$dir/sockdir/other.sock"
   fb=$(make_herdr_fakebin "$dir")
-  path_a=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+  # XDG_RUNTIME_DIR="" forces the deterministic per-uid /tmp fallback for this
+  # assertion regardless of the ambient test environment (fixture-set state
+  # persists per session/socket either way; see the XDG_RUNTIME_DIR-preferring
+  # and fallback tests below for the namespace choice itself).
+  path_a=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT") \
     || fail "session lock path resolution failed for home A"
-  path_b=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+  path_b=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT") \
     || fail "session lock path resolution failed for home B"
   [ "$path_a" = "$path_b" ] || fail "same session/socket must resolve one shared lock path"
   case "$path_a" in
-    /tmp/firstmate-herdr-presentation/order-*.lock) ;;
-    *) fail "session lock path must use the shared machine namespace: $path_a" ;;
+    /tmp/firstmate-herdr-presentation-"$uid"/order-*.lock) ;;
+    *) fail "session lock path must use the per-user machine namespace: $path_a" ;;
   esac
   case "$path_a" in
     */state/*) fail "session lock path must not live under a home state directory: $path_a" ;;
   esac
-  path_other=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+  path_other=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path other' "$ROOT") \
     || fail "session lock path resolution failed for a different session"
   [ "$path_other" != "$path_a" ] || fail "different sessions must not share one lock path"
@@ -2540,10 +2545,10 @@ test_presentation_session_lock_path_is_shared_across_homes() {
     : > /tmp/fm-herdr-lock-canon-$$.sock
     printf '%s\n' '{"sessions":[{"name":"canon","running":true,"socket_path":"/tmp/fm-herdr-lock-canon-'"$$"'.sock"}]}' > "$resp/4.out"
     printf '%s\n' "{\"sessions\":[{\"name\":\"canon\",\"running\":true,\"socket_path\":\"$(cd /tmp && pwd -P)/fm-herdr-lock-canon-$$.sock\"}]}" > "$resp/5.out"
-    path_tmp=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    path_tmp=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
       bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path canon' "$ROOT") \
       || fail "lock path with /tmp socket failed"
-    path_private=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    path_private=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
       bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path canon' "$ROOT") \
       || fail "lock path with canonical socket failed"
     rm -f /tmp/fm-herdr-lock-canon-$$.sock
@@ -2551,6 +2556,88 @@ test_presentation_session_lock_path_is_shared_across_homes() {
       || fail "symlink parent socket paths must resolve one lock: $path_tmp vs $path_private"
   fi
   pass "herdr presentation lock: one path per session/socket across homes"
+}
+
+test_presentation_lock_namespace_prefers_xdg_runtime_dir() {
+  local runtime_dir dir expected
+  runtime_dir="$TMP_ROOT/xdg-runtime"; mkdir -p "$runtime_dir"
+  expected="$runtime_dir/firstmate-herdr-presentation"
+  dir=$(XDG_RUNTIME_DIR="$runtime_dir" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
+    || fail "namespace resolution failed with a usable XDG_RUNTIME_DIR"
+  [ "$dir" = "$expected" ] || fail "expected $expected, got $dir"
+  pass "herdr presentation lock namespace: prefers a usable XDG_RUNTIME_DIR"
+}
+
+test_presentation_lock_namespace_falls_back_without_xdg_runtime_dir() {
+  local dir uid expected
+  uid=$(id -u) || fail "could not resolve current uid"
+  expected="/tmp/firstmate-herdr-presentation-$uid"
+  dir=$(XDG_RUNTIME_DIR="" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
+    || fail "namespace resolution failed with no XDG_RUNTIME_DIR"
+  [ "$dir" = "$expected" ] || fail "expected $expected, got $dir"
+  pass "herdr presentation lock namespace: falls back to a uid-suffixed /tmp path"
+}
+
+test_presentation_lock_namespace_falls_back_on_unusable_xdg_runtime_dir() {
+  local dir uid expected missing
+  uid=$(id -u) || fail "could not resolve current uid"
+  expected="/tmp/firstmate-herdr-presentation-$uid"
+  missing="$TMP_ROOT/xdg-runtime-does-not-exist"
+  dir=$(XDG_RUNTIME_DIR="$missing" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
+    || fail "namespace resolution failed with a nonexistent XDG_RUNTIME_DIR"
+  [ "$dir" = "$expected" ] || fail "expected $expected, got $dir"
+  pass "herdr presentation lock namespace: falls back when XDG_RUNTIME_DIR is not usable"
+}
+
+test_presentation_lock_namespace_ignores_foreign_legacy_path() {
+  local legacy="/tmp/firstmate-herdr-presentation" created=0 dir uid
+  uid=$(id -u) || fail "could not resolve current uid"
+  if [ ! -e "$legacy" ]; then
+    mkdir -m 755 "$legacy" 2>/dev/null && created=1
+  fi
+  # A foreign-owned (or, here, merely wrong-mode) legacy path must never be
+  # read, chowned, chmodded, or migrated; only assert the resolver's return
+  # value ignores it, and never mutate a pre-existing entry this test did not
+  # create itself.
+  dir=$(XDG_RUNTIME_DIR="" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT")
+  if [ "$created" -eq 1 ]; then rmdir "$legacy" 2>/dev/null || true; fi
+  [ "$dir" = "/tmp/firstmate-herdr-presentation-$uid" ] \
+    || fail "resolver must ignore the legacy shared path: $dir"
+  pass "herdr presentation lock namespace: ignores a foreign-owned legacy shared path"
+}
+
+test_presentation_lock_namespace_valid_rejects_symlink() {
+  local dir target link
+  dir="$TMP_ROOT/namespace-valid-symlink"; mkdir -p "$dir"
+  target="$dir/target"; mkdir -m 700 "$target"
+  link="$dir/link"; ln -s "$target" "$link"
+  if bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace_valid "$1"' "$ROOT" "$link"; then
+    fail "a symlinked namespace must not validate"
+  fi
+  pass "herdr presentation lock namespace: validation refuses a symlink"
+}
+
+test_presentation_lock_namespace_valid_rejects_wrong_mode() {
+  local dir target
+  dir="$TMP_ROOT/namespace-valid-wrong-mode"; mkdir -p "$dir"
+  target="$dir/target"; mkdir -m 755 "$target"
+  if bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace_valid "$1"' "$ROOT" "$target"; then
+    fail "a mode-755 namespace must not validate"
+  fi
+  pass "herdr presentation lock namespace: validation refuses a wrong-mode directory"
+}
+
+test_presentation_lock_namespace_valid_accepts_own_700() {
+  local dir target
+  dir="$TMP_ROOT/namespace-valid-ok"; mkdir -p "$dir"
+  target="$dir/target"; mkdir -m 700 "$target"
+  bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace_valid "$1"' "$ROOT" "$target" \
+    || fail "an own-uid mode-700 directory must validate"
+  pass "herdr presentation lock namespace: validation accepts an own-uid mode-700 directory"
 }
 
 test_presentation_session_lock_path_rejects_malformed_socket() {
@@ -4518,6 +4605,13 @@ test_projection_order_anchors_the_parent_by_exact_id
 test_projection_order_foreign_new_child_before_parent_is_read_only
 test_projection_order_missing_parent_is_read_only
 test_presentation_session_lock_path_is_shared_across_homes
+test_presentation_lock_namespace_prefers_xdg_runtime_dir
+test_presentation_lock_namespace_falls_back_without_xdg_runtime_dir
+test_presentation_lock_namespace_falls_back_on_unusable_xdg_runtime_dir
+test_presentation_lock_namespace_ignores_foreign_legacy_path
+test_presentation_lock_namespace_valid_rejects_symlink
+test_presentation_lock_namespace_valid_rejects_wrong_mode
+test_presentation_lock_namespace_valid_accepts_own_700
 test_presentation_session_lock_path_rejects_malformed_socket
 test_projection_order_rejects_malformed_socket
 test_projection_reclaim_refusal_matrix_is_non_mutating

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2518,14 +2518,10 @@ test_presentation_session_lock_path_is_shared_across_homes() {
   printf '%s\n' "{\"sessions\":[{\"name\":\"other\",\"running\":true,\"socket_path\":\"$dir/sockdir/other.sock\"}]}" > "$resp/3.out"
   : > "$dir/sockdir/other.sock"
   fb=$(make_herdr_fakebin "$dir")
-  # XDG_RUNTIME_DIR="" forces the deterministic per-uid /tmp fallback for this
-  # assertion regardless of the ambient test environment (fixture-set state
-  # persists per session/socket either way; see the XDG_RUNTIME_DIR-preferring
-  # and fallback tests below for the namespace choice itself).
-  path_a=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
+  path_a=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT") \
     || fail "session lock path resolution failed for home A"
-  path_b=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
+  path_b=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT") \
     || fail "session lock path resolution failed for home B"
   [ "$path_a" = "$path_b" ] || fail "same session/socket must resolve one shared lock path"
@@ -2536,7 +2532,7 @@ test_presentation_session_lock_path_is_shared_across_homes() {
   case "$path_a" in
     */state/*) fail "session lock path must not live under a home state directory: $path_a" ;;
   esac
-  path_other=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
+  path_other=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path other' "$ROOT") \
     || fail "session lock path resolution failed for a different session"
   [ "$path_other" != "$path_a" ] || fail "different sessions must not share one lock path"
@@ -2545,10 +2541,10 @@ test_presentation_session_lock_path_is_shared_across_homes() {
     : > /tmp/fm-herdr-lock-canon-$$.sock
     printf '%s\n' '{"sessions":[{"name":"canon","running":true,"socket_path":"/tmp/fm-herdr-lock-canon-'"$$"'.sock"}]}' > "$resp/4.out"
     printf '%s\n' "{\"sessions\":[{\"name\":\"canon\",\"running\":true,\"socket_path\":\"$(cd /tmp && pwd -P)/fm-herdr-lock-canon-$$.sock\"}]}" > "$resp/5.out"
-    path_tmp=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
+    path_tmp=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
       bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path canon' "$ROOT") \
       || fail "lock path with /tmp socket failed"
-    path_private=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
+    path_private=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
       bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path canon' "$ROOT") \
       || fail "lock path with canonical socket failed"
     rm -f /tmp/fm-herdr-lock-canon-$$.sock
@@ -2558,38 +2554,36 @@ test_presentation_session_lock_path_is_shared_across_homes() {
   pass "herdr presentation lock: one path per session/socket across homes"
 }
 
-test_presentation_lock_namespace_prefers_xdg_runtime_dir() {
-  local runtime_dir dir expected
-  runtime_dir="$TMP_ROOT/xdg-runtime"; mkdir -p "$runtime_dir"
-  expected="$runtime_dir/firstmate-herdr-presentation"
-  dir=$(XDG_RUNTIME_DIR="$runtime_dir" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
-    || fail "namespace resolution failed with a usable XDG_RUNTIME_DIR"
-  [ "$dir" = "$expected" ] || fail "expected $expected, got $dir"
-  pass "herdr presentation lock namespace: prefers a usable XDG_RUNTIME_DIR"
-}
-
-test_presentation_lock_namespace_falls_back_without_xdg_runtime_dir() {
+test_presentation_lock_namespace_is_deterministic_per_uid() {
   local dir uid expected
   uid=$(id -u) || fail "could not resolve current uid"
   expected="/tmp/firstmate-herdr-presentation-$uid"
-  dir=$(XDG_RUNTIME_DIR="" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
-    || fail "namespace resolution failed with no XDG_RUNTIME_DIR"
+  dir=$(bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
+    || fail "namespace resolution failed"
   [ "$dir" = "$expected" ] || fail "expected $expected, got $dir"
-  pass "herdr presentation lock namespace: falls back to a uid-suffixed /tmp path"
+  pass "herdr presentation lock namespace: resolves the deterministic uid-suffixed /tmp path"
 }
 
-test_presentation_lock_namespace_falls_back_on_unusable_xdg_runtime_dir() {
-  local dir uid expected missing
+test_presentation_lock_namespace_ignores_ambient_xdg_runtime_dir() {
+  local uid runtime_dir with_xdg without_xdg expected
   uid=$(id -u) || fail "could not resolve current uid"
   expected="/tmp/firstmate-herdr-presentation-$uid"
-  missing="$TMP_ROOT/xdg-runtime-does-not-exist"
-  dir=$(XDG_RUNTIME_DIR="$missing" \
+  runtime_dir="$TMP_ROOT/xdg-runtime-ambient"; mkdir -p "$runtime_dir"
+  # Two processes of the SAME user must resolve the identical namespace
+  # regardless of whether XDG_RUNTIME_DIR happens to be set in one of them
+  # (a systemd user session vs. a cron/sudo/detached invocation, say) -
+  # otherwise the two would split one user's own lock identity across two
+  # different directories and silently defeat the mutual exclusion the lock
+  # exists for.
+  with_xdg=$(XDG_RUNTIME_DIR="$runtime_dir" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
-    || fail "namespace resolution failed with a nonexistent XDG_RUNTIME_DIR"
-  [ "$dir" = "$expected" ] || fail "expected $expected, got $dir"
-  pass "herdr presentation lock namespace: falls back when XDG_RUNTIME_DIR is not usable"
+    || fail "namespace resolution failed with XDG_RUNTIME_DIR set"
+  without_xdg=$(bash -c 'unset XDG_RUNTIME_DIR; . "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
+    || fail "namespace resolution failed with XDG_RUNTIME_DIR unset"
+  [ "$with_xdg" = "$without_xdg" ] \
+    || fail "XDG_RUNTIME_DIR must not split one user's lock identity: $with_xdg vs $without_xdg"
+  [ "$with_xdg" = "$expected" ] || fail "expected $expected, got $with_xdg"
+  pass "herdr presentation lock namespace: ignores ambient XDG_RUNTIME_DIR, same uid always resolves the same path"
 }
 
 test_presentation_lock_namespace_ignores_foreign_legacy_path() {
@@ -2602,8 +2596,7 @@ test_presentation_lock_namespace_ignores_foreign_legacy_path() {
   # read, chowned, chmodded, or migrated; only assert the resolver's return
   # value ignores it, and never mutate a pre-existing entry this test did not
   # create itself.
-  dir=$(XDG_RUNTIME_DIR="" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT")
+  dir=$(bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT")
   if [ "$created" -eq 1 ]; then rmdir "$legacy" 2>/dev/null || true; fi
   [ "$dir" = "/tmp/firstmate-herdr-presentation-$uid" ] \
     || fail "resolver must ignore the legacy shared path: $dir"
@@ -4605,9 +4598,8 @@ test_projection_order_anchors_the_parent_by_exact_id
 test_projection_order_foreign_new_child_before_parent_is_read_only
 test_projection_order_missing_parent_is_read_only
 test_presentation_session_lock_path_is_shared_across_homes
-test_presentation_lock_namespace_prefers_xdg_runtime_dir
-test_presentation_lock_namespace_falls_back_without_xdg_runtime_dir
-test_presentation_lock_namespace_falls_back_on_unusable_xdg_runtime_dir
+test_presentation_lock_namespace_is_deterministic_per_uid
+test_presentation_lock_namespace_ignores_ambient_xdg_runtime_dir
 test_presentation_lock_namespace_ignores_foreign_legacy_path
 test_presentation_lock_namespace_valid_rejects_symlink
 test_presentation_lock_namespace_valid_rejects_wrong_mode


### PR DESCRIPTION
## Problem

`fm_backend_herdr_presentation_lock_namespace()` returns the fixed path `/tmp/firstmate-herdr-presentation`.
On a multi-user host, the first user's firstmate creates it at mode 700 and owns it; every other user's firstmate then fails `fm_backend_herdr_presentation_lock_namespace_valid` (owner != current uid) and cannot create it either.
The result is that every herdr task teardown (and every spawn with presentation spaces enabled) fails with `herdr session presentation lock could not be resolved`, with no recovery available to the locked-out user.

Observed live on a shared host with two firstmate homes under different Unix users.

## Fix

Resolve the lock namespace to a deterministic per-user path: `/tmp/firstmate-herdr-presentation-<uid>`, preserving every existing validation guarantee (mode 700, owned by the current uid, not a symlink).

An earlier revision preferred `$XDG_RUNTIME_DIR`; review correctly flagged that two processes of the same user can see different `XDG_RUNTIME_DIR` states and would then resolve different lock namespaces, splitting the lock identity. The environment preference is dropped: every process of a user resolves the same path unconditionally.

A foreign-owned directory at the legacy shared path is simply ignored - never chowned, chmodded, deleted, or migrated.
The locks are ephemeral, so no migration is needed.

## Tests

Extended `tests/fm-backend-herdr.test.sh`:

- deterministic per-user path resolution, identical across environments of the same user,
- a foreign-owned/wrong-mode directory at the legacy path is ignored and resolution succeeds at the per-user path,
- validation still refuses symlinked and wrong-mode namespaces.

`bin/fm-lint.sh` and shellcheck pass on the changed script; the backend test file passes end to end.
