### PR TITLE
ci: pin Treehouse installer to v2.1.1

### DIFF
--- a/bin/fm-install-treehouse.sh
+++ b/bin/fm-install-treehouse.sh
@@ -9,12 +9,12 @@
 # Usage:
 #   fm-install-treehouse.sh <destination-directory>
 #
-# Pins Treehouse v2.0.1, the version exercised by the local real-Herdr suite.
+# Pins Treehouse v2.1.1, the version exercised by the local real-Herdr suite.
 set -eu
 
-FM_TREEHOUSE_CI_VERSION=2.0.1
+FM_TREEHOUSE_CI_VERSION=2.1.1
 FM_TREEHOUSE_CI_TAG="v${FM_TREEHOUSE_CI_VERSION}"
-# Bounded download ceiling (bytes). Official 2.0.1 archives are under 8 MiB.
+# Bounded download ceiling (bytes). Official 2.1.1 archives are under 8 MiB.
 FM_TREEHOUSE_CI_MAX_BYTES=15000000
 FM_TREEHOUSE_CI_REPO=kunchenguid/treehouse
 
@@ -30,19 +30,19 @@ arch=$(uname -m)
 case "${os}-${arch}" in
   Linux-x86_64)
     ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-linux-amd64.tar.gz
-    SHA256=1d5a32751ab921670103fd201ddb2b91b47338cb13976f45642b827cf8976af2
+    SHA256=2fe3e01220ae51a967c3e5ba6ccf10ec83bdbae8e420368d194285a8d04c9ef8
     ;;
   Linux-aarch64|Linux-arm64)
     ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-linux-arm64.tar.gz
-    SHA256=eaccc9c5b98125df8bd77425598eeecee66cb0371db4eb1cf75f0d813c18fab9
+    SHA256=980367c0233274eb3181a19a2ca8ec69d09b4a588ba27367937d336f9a2c938e
     ;;
   Darwin-arm64)
     ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-darwin-arm64.tar.gz
-    SHA256=7ee5078f3d1f33c01196548797fce65408e459d53530b77d4ba56e074fa1c1a2
+    SHA256=deabeb7153bad14659e98da78de5334afecaeaac7e05988b106a4888646747d3
     ;;
   Darwin-x86_64)
     ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-darwin-amd64.tar.gz
-    SHA256=1cf44580a5837f995e1d3bb74f4fbd3112b642acd20406087d9735a8106112fd
+    SHA256=f6f6bd71fe8279826aa35f201e79f34106c1c4056179e3e8141942027dd992a6
     ;;
   *)
     die "unsupported platform ${os}-${arch}; official Treehouse assets are linux/darwin amd64 and arm64"
@@ -68,7 +68,7 @@ fi
 [ "$ACTUAL_SHA256" = "$SHA256" ] || die "checksum mismatch for $ARCHIVE (expected $SHA256, got $ACTUAL_SHA256)"
 
 tar -xzf "$TMP/$ARCHIVE" -C "$TMP"
-# Archive layout: a single `treehouse` binary at the archive root (verified for v2.0.1).
+# Archive layout: a single `treehouse` binary at the archive root (verified for v2.1.1).
 if [ -f "$TMP/treehouse" ]; then
   BIN="$TMP/treehouse"
 elif [ -f "$TMP/treehouse-v${FM_TREEHOUSE_CI_VERSION}/treehouse" ]; then
@@ -82,7 +82,7 @@ mkdir -p "$DESTINATION"
 install -m 0755 "$BIN" "$DESTINATION/treehouse"
 
 installed_version=$("$DESTINATION/treehouse" --version 2>/dev/null | tr -d '[:space:]')
-# treehouse prints "v2.0.1" (leading v) on --version.
+# treehouse prints "v2.1.1" (leading v) on --version.
 case "$installed_version" in
   "v${FM_TREEHOUSE_CI_VERSION}"|"${FM_TREEHOUSE_CI_VERSION}") ;;
   *)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -203,6 +203,7 @@ family_for_basename() {
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-captain-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
+    fm-install-treehouse.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-lint-workflows.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\

--- a/tests/fm-install-treehouse.test.sh
+++ b/tests/fm-install-treehouse.test.sh
@@ -5,33 +5,46 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 INSTALLER="$ROOT/bin/fm-install-treehouse.sh"
+TREEHOUSE_LINUX_AMD64_SHA=2fe3e01220ae51a967c3e5ba6ccf10ec83bdbae8e420368d194285a8d04c9ef8
 
-test_ci_treehouse_pin_and_checksum() {
-  local tmp fakebin dest url_log out
-  tmp=$(fm_test_tmproot fm-treehouse-installer)
+make_treehouse_fakebin() {
+  local tmp=$1 fakebin
   fakebin=$(fm_fakebin "$tmp")
-  dest="$tmp/bin"
   cat > "$fakebin/uname" <<'SH'
 #!/usr/bin/env bash
-case "$1" in -s) echo Linux;; -m) echo x86_64;; esac
+case "$1" in
+  -s) printf '%s\n' "${FAKE_UNAME_S:?}" ;;
+  -m) printf '%s\n' "${FAKE_UNAME_M:?}" ;;
+esac
 SH
   cat > "$fakebin/curl" <<'SH'
 #!/usr/bin/env bash
 while [ "$#" -gt 0 ]; do
-  case "$1" in -o) out=$2; shift 2;; *) url=$1; shift;; esac
+  case "$1" in
+    -o) out=$2; shift 2 ;;
+    https://*) url=$1; shift ;;
+    *) shift ;;
+  esac
 done
 printf '%s\n' "$url" > "${CURL_URL_LOG:?}"
 : > "$out"
 SH
   cat > "$fakebin/sha256sum" <<'SH'
 #!/usr/bin/env bash
-printf '%s  %s\n' 2fe3e01220ae51a967c3e5ba6ccf10ec83bdbae8e420368d194285a8d04c9ef8 "$1"
+printf 'sha256sum\n' >> "${CHECKSUM_TOOL_LOG:?}"
+printf '%s  %s\n' "${FAKE_TREEHOUSE_SHA:?}" "$1"
+SH
+  cat > "$fakebin/shasum" <<'SH'
+#!/usr/bin/env bash
+printf 'shasum\n' >> "${CHECKSUM_TOOL_LOG:?}"
+while [ "$#" -gt 1 ]; do shift; done
+printf '%s  %s\n' "${FAKE_TREEHOUSE_SHA:?}" "$1"
 SH
   cat > "$fakebin/tar" <<'SH'
 #!/usr/bin/env bash
 while [ "$#" -gt 0 ]; do
   if [ "$1" = -C ]; then
-    printf '#!/usr/bin/env bash\necho v2.1.1\n' > "$2/treehouse"
+    printf '#!/usr/bin/env bash\necho %s\n' "${FAKE_TREEHOUSE_VERSION:?}" > "$2/treehouse"
     chmod +x "$2/treehouse"
     exit 0
   fi
@@ -40,14 +53,95 @@ done
 exit 2
 SH
   chmod +x "$fakebin"/*
-  url_log="$tmp/url"
-  out=$(CURL_URL_LOG="$url_log" PATH="$fakebin:$PATH" "$INSTALLER" "$dest" 2>&1) \
-    || fail "pinned Treehouse installer failed: $out"
-  assert_contains "$(cat "$url_log")" \
-    "https://github.com/kunchenguid/treehouse/releases/download/v2.1.1/treehouse-v2.1.1-linux-amd64.tar.gz" \
-    "CI installer did not consume the exact v2.1.1 Linux asset"
-  assert_contains "$out" "v2.1.1" "installer did not verify the exact installed version"
-  pass "Treehouse CI installer pins v2.1.1 and its published Linux checksum"
+  printf '%s\n' "$fakebin"
 }
 
-test_ci_treehouse_pin_and_checksum
+run_fake_treehouse_installer() {
+  local fakebin=$1 dest=$2 url_log=$3 tool_log=$4 os=$5 arch=$6 sha=$7 version=$8
+  shift 8
+  CURL_URL_LOG="$url_log" CHECKSUM_TOOL_LOG="$tool_log" \
+    FAKE_UNAME_S="$os" FAKE_UNAME_M="$arch" \
+    FAKE_TREEHOUSE_SHA="$sha" FAKE_TREEHOUSE_VERSION="$version" \
+    PATH="$fakebin:$PATH" "$@" "$INSTALLER" "$dest" 2>&1
+}
+
+test_ci_treehouse_platform_pins() {
+  local os arch asset sha tmp fakebin dest url_log tool_log out expected_url
+  while read -r os arch asset sha; do
+    tmp=$(fm_test_tmproot "fm-treehouse-${os}-${arch}")
+    fakebin=$(make_treehouse_fakebin "$tmp")
+    dest="$tmp/bin"
+    url_log="$tmp/url"
+    tool_log="$tmp/checksum-tool"
+    out=$(run_fake_treehouse_installer "$fakebin" "$dest" "$url_log" "$tool_log" \
+      "$os" "$arch" "$sha" v2.1.1) \
+      || fail "pinned Treehouse installer failed for ${os}-${arch}: $out"
+    expected_url="https://github.com/kunchenguid/treehouse/releases/download/v2.1.1/$asset"
+    [ "$(cat "$url_log")" = "$expected_url" ] \
+      || fail "CI installer did not consume the exact v2.1.1 ${os}-${arch} asset"
+    [ "$(cat "$tool_log")" = sha256sum ] \
+      || fail "CI installer did not verify ${os}-${arch} with sha256sum"
+    assert_contains "$out" "installed treehouse v2.1.1" \
+      "installer did not verify the exact installed version for ${os}-${arch}"
+  done <<'CASES'
+Linux x86_64 treehouse-v2.1.1-linux-amd64.tar.gz 2fe3e01220ae51a967c3e5ba6ccf10ec83bdbae8e420368d194285a8d04c9ef8
+Linux aarch64 treehouse-v2.1.1-linux-arm64.tar.gz 980367c0233274eb3181a19a2ca8ec69d09b4a588ba27367937d336f9a2c938e
+Darwin arm64 treehouse-v2.1.1-darwin-arm64.tar.gz deabeb7153bad14659e98da78de5334afecaeaac7e05988b106a4888646747d3
+Darwin x86_64 treehouse-v2.1.1-darwin-amd64.tar.gz f6f6bd71fe8279826aa35f201e79f34106c1c4056179e3e8141942027dd992a6
+CASES
+  pass "Treehouse CI installer pins every Linux/macOS asset and checksum to v2.1.1"
+}
+
+test_ci_treehouse_rejects_checksum_drift() {
+  local tmp fakebin out code
+  tmp=$(fm_test_tmproot fm-treehouse-checksum-drift)
+  fakebin=$(make_treehouse_fakebin "$tmp")
+  out=$(run_fake_treehouse_installer "$fakebin" "$tmp/bin" "$tmp/url" "$tmp/tool" \
+    Linux x86_64 0000000000000000000000000000000000000000000000000000000000000000 v2.1.1)
+  code=$?
+  expect_code 1 "$code" "Treehouse checksum drift"
+  assert_contains "$out" "checksum mismatch for treehouse-v2.1.1-linux-amd64.tar.gz" \
+    "installer did not reject checksum drift"
+  pass "Treehouse CI installer rejects checksum drift"
+}
+
+test_ci_treehouse_rejects_version_drift() {
+  local tmp fakebin out code
+  tmp=$(fm_test_tmproot fm-treehouse-version-drift)
+  fakebin=$(make_treehouse_fakebin "$tmp")
+  out=$(run_fake_treehouse_installer "$fakebin" "$tmp/bin" "$tmp/url" "$tmp/tool" \
+    Linux x86_64 "$TREEHOUSE_LINUX_AMD64_SHA" v2.1.0)
+  code=$?
+  expect_code 1 "$code" "Treehouse installed-version drift"
+  assert_contains "$out" "installed treehouse version is 'v2.1.0', expected exact pin v2.1.1" \
+    "installer did not reject installed-version drift"
+  pass "Treehouse CI installer rejects installed-version drift"
+}
+
+test_ci_treehouse_preserves_shasum_fallback() {
+  local tmp fakebin bash_env out
+  tmp=$(fm_test_tmproot fm-treehouse-shasum-fallback)
+  fakebin=$(make_treehouse_fakebin "$tmp")
+  bash_env="$tmp/bash-env"
+  cat > "$bash_env" <<'SH'
+command() {
+  if [ "$#" -eq 2 ] && [ "$1" = -v ] && [ "$2" = sha256sum ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+SH
+  out=$(run_fake_treehouse_installer "$fakebin" "$tmp/bin" "$tmp/url" "$tmp/tool" \
+    Darwin arm64 deabeb7153bad14659e98da78de5334afecaeaac7e05988b106a4888646747d3 \
+    v2.1.1 env BASH_ENV="$bash_env") \
+    || fail "Treehouse shasum fallback failed: $out"
+  [ "$(cat "$tmp/tool")" = shasum ] || fail "installer did not use the shasum fallback"
+  assert_contains "$out" "installed treehouse v2.1.1" \
+    "shasum fallback did not install the exact pinned version"
+  pass "Treehouse CI installer preserves the shasum fallback"
+}
+
+test_ci_treehouse_platform_pins
+test_ci_treehouse_rejects_checksum_drift
+test_ci_treehouse_rejects_version_drift
+test_ci_treehouse_preserves_shasum_fallback

--- a/tests/fm-install-treehouse.test.sh
+++ b/tests/fm-install-treehouse.test.sh
@@ -86,6 +86,7 @@ test_ci_treehouse_platform_pins() {
   done <<'CASES'
 Linux x86_64 treehouse-v2.1.1-linux-amd64.tar.gz 2fe3e01220ae51a967c3e5ba6ccf10ec83bdbae8e420368d194285a8d04c9ef8
 Linux aarch64 treehouse-v2.1.1-linux-arm64.tar.gz 980367c0233274eb3181a19a2ca8ec69d09b4a588ba27367937d336f9a2c938e
+Linux arm64 treehouse-v2.1.1-linux-arm64.tar.gz 980367c0233274eb3181a19a2ca8ec69d09b4a588ba27367937d336f9a2c938e
 Darwin arm64 treehouse-v2.1.1-darwin-arm64.tar.gz deabeb7153bad14659e98da78de5334afecaeaac7e05988b106a4888646747d3
 Darwin x86_64 treehouse-v2.1.1-darwin-amd64.tar.gz f6f6bd71fe8279826aa35f201e79f34106c1c4056179e3e8141942027dd992a6
 CASES

--- a/tests/fm-install-treehouse.test.sh
+++ b/tests/fm-install-treehouse.test.sh
@@ -31,6 +31,7 @@ printf '%s\n' "$url" > "${CURL_URL_LOG:?}"
 SH
   cat > "$fakebin/sha256sum" <<'SH'
 #!/usr/bin/env bash
+[ "$#" -eq 1 ] || exit 2
 printf 'sha256sum\n' >> "${CHECKSUM_TOOL_LOG:?}"
 printf '%s  %s\n' "${FAKE_TREEHOUSE_SHA:?}" "$1"
 SH

--- a/tests/fm-install-treehouse.test.sh
+++ b/tests/fm-install-treehouse.test.sh
@@ -36,9 +36,9 @@ printf '%s  %s\n' "${FAKE_TREEHOUSE_SHA:?}" "$1"
 SH
   cat > "$fakebin/shasum" <<'SH'
 #!/usr/bin/env bash
-printf 'shasum\n' >> "${CHECKSUM_TOOL_LOG:?}"
-while [ "$#" -gt 1 ]; do shift; done
-printf '%s  %s\n' "${FAKE_TREEHOUSE_SHA:?}" "$1"
+[ "$#" -eq 3 ] && [ "$1" = -a ] && [ "$2" = 256 ] || exit 2
+printf 'shasum -a 256\n' >> "${CHECKSUM_TOOL_LOG:?}"
+printf '%s  %s\n' "${FAKE_TREEHOUSE_SHA:?}" "$3"
 SH
   cat > "$fakebin/tar" <<'SH'
 #!/usr/bin/env bash
@@ -136,7 +136,8 @@ SH
     Darwin arm64 deabeb7153bad14659e98da78de5334afecaeaac7e05988b106a4888646747d3 \
     v2.1.1 env BASH_ENV="$bash_env") \
     || fail "Treehouse shasum fallback failed: $out"
-  [ "$(cat "$tmp/tool")" = shasum ] || fail "installer did not use the shasum fallback"
+  [ "$(cat "$tmp/tool")" = "shasum -a 256" ] \
+    || fail "installer did not use the SHA-256 shasum fallback"
   assert_contains "$out" "installed treehouse v2.1.1" \
     "shasum fallback did not install the exact pinned version"
   pass "Treehouse CI installer preserves the shasum fallback"

--- a/tests/fm-install-treehouse.test.sh
+++ b/tests/fm-install-treehouse.test.sh
@@ -93,6 +93,44 @@ CASES
   pass "Treehouse CI installer pins every Linux/macOS asset and checksum to v2.1.1"
 }
 
+test_required_ci_job_consumes_treehouse_pin() {
+  local tmp fakebin step out
+  tmp=$(fm_test_tmproot fm-treehouse-ci-job)
+  fakebin=$(make_treehouse_fakebin "$tmp")
+  step="$tmp/install-treehouse-step.sh"
+
+  # The workflow is machine-consumed configuration, so normalize it as YAML and
+  # execute the selected job step instead of treating source text as evidence.
+  ruby - "$ROOT/.github/workflows/ci.yml" "$step" <<'RUBY'
+require "yaml"
+
+workflow = YAML.load_file(ARGV.fetch(0))
+steps = workflow.fetch("jobs").fetch("tests-herdr").fetch("steps")
+matches = steps.select { |candidate| candidate["name"] == "Install pinned Treehouse" }
+abort "expected exactly one tests-herdr Treehouse install step" unless matches.length == 1
+File.write(ARGV.fetch(1), matches.fetch(0).fetch("run"))
+RUBY
+
+  : > "$tmp/github-path"
+  out=$(CURL_URL_LOG="$tmp/url" CHECKSUM_TOOL_LOG="$tmp/checksum-tool" \
+    FAKE_UNAME_S=Linux FAKE_UNAME_M=x86_64 \
+    FAKE_TREEHOUSE_SHA="$TREEHOUSE_LINUX_AMD64_SHA" FAKE_TREEHOUSE_VERSION=v2.1.1 \
+    RUNNER_TEMP="$tmp" GITHUB_PATH="$tmp/github-path" PATH="$fakebin:$PATH" \
+    bash "$step" 2>&1) \
+    || fail "required CI Treehouse install step failed: $out"
+
+  [ "$(cat "$tmp/url")" = \
+    "https://github.com/kunchenguid/treehouse/releases/download/v2.1.1/treehouse-v2.1.1-linux-amd64.tar.gz" ] \
+    || fail "required CI job did not consume the exact v2.1.1 installer asset"
+  [ "$(cat "$tmp/github-path")" = "$tmp/bin" ] \
+    || fail "required CI job did not publish the Treehouse installation directory"
+  [ "$("$tmp/bin/treehouse" --version)" = v2.1.1 ] \
+    || fail "required CI job did not install the exact Treehouse v2.1.1 pin"
+  assert_contains "$out" "installed treehouse v2.1.1" \
+    "required CI job did not execute the pinned installer"
+  pass "required CI Herdr job consumes the exact Treehouse v2.1.1 installer pin"
+}
+
 test_ci_treehouse_rejects_checksum_drift() {
   local tmp fakebin out code
   tmp=$(fm_test_tmproot fm-treehouse-checksum-drift)
@@ -144,6 +182,7 @@ SH
 }
 
 test_ci_treehouse_platform_pins
+test_required_ci_job_consumes_treehouse_pin
 test_ci_treehouse_rejects_checksum_drift
 test_ci_treehouse_rejects_version_drift
 test_ci_treehouse_preserves_shasum_fallback

--- a/tests/fm-install-treehouse.test.sh
+++ b/tests/fm-install-treehouse.test.sh
@@ -150,10 +150,10 @@ test_ci_treehouse_rejects_version_drift() {
   tmp=$(fm_test_tmproot fm-treehouse-version-drift)
   fakebin=$(make_treehouse_fakebin "$tmp")
   out=$(run_fake_treehouse_installer "$fakebin" "$tmp/bin" "$tmp/url" "$tmp/tool" \
-    Linux x86_64 "$TREEHOUSE_LINUX_AMD64_SHA" v2.1.0)
+    Linux x86_64 "$TREEHOUSE_LINUX_AMD64_SHA" v2.0.1)
   code=$?
   expect_code 1 "$code" "Treehouse installed-version drift"
-  assert_contains "$out" "installed treehouse version is 'v2.1.0', expected exact pin v2.1.1" \
+  assert_contains "$out" "installed treehouse version is 'v2.0.1', expected exact pin v2.1.1" \
     "installer did not reject installed-version drift"
   pass "Treehouse CI installer rejects installed-version drift"
 }

--- a/tests/fm-install-treehouse.test.sh
+++ b/tests/fm-install-treehouse.test.sh
@@ -158,6 +158,30 @@ test_ci_treehouse_rejects_version_drift() {
   pass "Treehouse CI installer rejects installed-version drift"
 }
 
+test_ci_treehouse_ignores_ambient_bash_env() {
+  local tmp fakebin bash_env out
+  tmp=$(fm_test_tmproot fm-treehouse-ambient-bash-env)
+  fakebin=$(make_treehouse_fakebin "$tmp")
+  bash_env="$tmp/ambient-bash-env"
+  cat > "$bash_env" <<'SH'
+command() {
+  if [ "$#" -eq 2 ] && [ "$1" = -v ] && [ "$2" = sha256sum ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+SH
+  out=$(BASH_ENV="$bash_env" run_fake_treehouse_installer \
+    "$fakebin" "$tmp/bin" "$tmp/url" "$tmp/tool" \
+    Linux x86_64 "$TREEHOUSE_LINUX_AMD64_SHA" v2.1.1) \
+    || fail "ambient BASH_ENV isolation failed: $out"
+  [ "$(cat "$tmp/tool")" = sha256sum ] \
+    || fail "ambient BASH_ENV changed the installer's checksum path"
+  assert_contains "$out" "installed treehouse v2.1.1" \
+    "ambient BASH_ENV prevented the exact pin from installing"
+  pass "Treehouse CI installer fixture ignores ambient BASH_ENV"
+}
+
 test_ci_treehouse_preserves_shasum_fallback() {
   local tmp fakebin bash_env out
   tmp=$(fm_test_tmproot fm-treehouse-shasum-fallback)
@@ -186,4 +210,5 @@ test_ci_treehouse_platform_pins
 test_required_ci_job_consumes_treehouse_pin
 test_ci_treehouse_rejects_checksum_drift
 test_ci_treehouse_rejects_version_drift
+test_ci_treehouse_ignores_ambient_bash_env
 test_ci_treehouse_preserves_shasum_fallback

--- a/tests/fm-install-treehouse.test.sh
+++ b/tests/fm-install-treehouse.test.sh
@@ -60,7 +60,7 @@ SH
 run_fake_treehouse_installer() {
   local fakebin=$1 dest=$2 url_log=$3 tool_log=$4 os=$5 arch=$6 sha=$7 version=$8
   shift 8
-  CURL_URL_LOG="$url_log" CHECKSUM_TOOL_LOG="$tool_log" \
+  BASH_ENV='' CURL_URL_LOG="$url_log" CHECKSUM_TOOL_LOG="$tool_log" \
     FAKE_UNAME_S="$os" FAKE_UNAME_M="$arch" \
     FAKE_TREEHOUSE_SHA="$sha" FAKE_TREEHOUSE_VERSION="$version" \
     PATH="$fakebin:$PATH" "$@" "$INSTALLER" "$dest" 2>&1

--- a/tests/fm-install-treehouse.test.sh
+++ b/tests/fm-install-treehouse.test.sh
@@ -172,7 +172,7 @@ command() {
 SH
   out=$(run_fake_treehouse_installer "$fakebin" "$tmp/bin" "$tmp/url" "$tmp/tool" \
     Darwin arm64 deabeb7153bad14659e98da78de5334afecaeaac7e05988b106a4888646747d3 \
-    v2.1.1 env BASH_ENV="$bash_env") \
+    v2.1.1 env BASH_ENV="$bash_env" bash) \
     || fail "Treehouse shasum fallback failed: $out"
   [ "$(cat "$tmp/tool")" = "shasum -a 256" ] \
     || fail "installer did not use the SHA-256 shasum fallback"

--- a/tests/fm-install-treehouse.test.sh
+++ b/tests/fm-install-treehouse.test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Deterministic coverage for the exact CI Treehouse release pin.
+set -u
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+INSTALLER="$ROOT/bin/fm-install-treehouse.sh"
+
+test_ci_treehouse_pin_and_checksum() {
+  local tmp fakebin dest url_log out
+  tmp=$(fm_test_tmproot fm-treehouse-installer)
+  fakebin=$(fm_fakebin "$tmp")
+  dest="$tmp/bin"
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+case "$1" in -s) echo Linux;; -m) echo x86_64;; esac
+SH
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+while [ "$#" -gt 0 ]; do
+  case "$1" in -o) out=$2; shift 2;; *) url=$1; shift;; esac
+done
+printf '%s\n' "$url" > "${CURL_URL_LOG:?}"
+: > "$out"
+SH
+  cat > "$fakebin/sha256sum" <<'SH'
+#!/usr/bin/env bash
+printf '%s  %s\n' 2fe3e01220ae51a967c3e5ba6ccf10ec83bdbae8e420368d194285a8d04c9ef8 "$1"
+SH
+  cat > "$fakebin/tar" <<'SH'
+#!/usr/bin/env bash
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -C ]; then
+    printf '#!/usr/bin/env bash\necho v2.1.1\n' > "$2/treehouse"
+    chmod +x "$2/treehouse"
+    exit 0
+  fi
+  shift
+done
+exit 2
+SH
+  chmod +x "$fakebin"/*
+  url_log="$tmp/url"
+  out=$(CURL_URL_LOG="$url_log" PATH="$fakebin:$PATH" "$INSTALLER" "$dest" 2>&1) \
+    || fail "pinned Treehouse installer failed: $out"
+  assert_contains "$(cat "$url_log")" \
+    "https://github.com/kunchenguid/treehouse/releases/download/v2.1.1/treehouse-v2.1.1-linux-amd64.tar.gz" \
+    "CI installer did not consume the exact v2.1.1 Linux asset"
+  assert_contains "$out" "v2.1.1" "installer did not verify the exact installed version"
+  pass "Treehouse CI installer pins v2.1.1 and its published Linux checksum"
+}
+
+test_ci_treehouse_pin_and_checksum

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -103,6 +103,7 @@ init_changed_fixture_repo() {
     fm-daemon.test.sh \
     fm-harness-adapter-instructions-live-e2e.test.sh \
     fm-harness-adapter-references.test.sh \
+    fm-install-treehouse.test.sh \
     fm-backend-herdr-smoke.test.sh \
     fm-secondmate-safety.test.sh \
     fm-session-start.test.sh \
@@ -129,6 +130,7 @@ init_changed_fixture_repo() {
   : >"$repo/bin/fm-procevent-quota.sh"
   : >"$repo/bin/fm-quota-axi-lib.sh"
   : >"$repo/bin/fm-quota-choose.sh"
+  : >"$repo/bin/fm-install-treehouse.sh"
   : >"$repo/bin/unmapped-source.sh"
   # A shared helper with no curated family of its own, named by exactly ONE
   # script of the expensive real-Herdr family and consumed by one curated
@@ -295,6 +297,15 @@ test_changed_dependency_selection_and_unmapped_failure() {
     "timeout library selects quota polling coverage"
   git -C "$repo" add bin/fm-timeout-lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm timeout-lib-change
+
+  printf '\n' >>"$repo/bin/fm-install-treehouse.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-install-treehouse.test.sh" \
+    "Treehouse installer changes select focused pin coverage"
+  assert_contains "$listed" "tests/fm-backend-herdr-smoke.test.sh" \
+    "Treehouse installer changes retain real-Herdr coverage"
+  git -C "$repo" add bin/fm-install-treehouse.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm treehouse-installer-change
 
   printf '\n' >>"$repo/src/unmapped.ts"
   set +e


### PR DESCRIPTION
## Intent

Align Firstmate's exact CI Treehouse installer pin and checksum from 2.0.1 to the already rehearsed and verified 2.1.1 release, now that the candidate dependency recorded in the backlog is complete. Locate every authoritative CI installer/version/checksum owner and update only the exact 2.0.1-to-2.1.1 pin required by the accepted task. Do not redesign installation, broaden supported versions, change runtime selection, or update unrelated dependencies. Verify the 2.1.1 release identity and checksum from an authoritative source; never copy a moving/latest URL or infer a checksum. Add focused deterministic installer evidence that fails on version/checksum drift and proves the intended CI path consumes 2.1.1. Preserve macOS/Linux and existing fallback behavior exactly. Keep shared contracts with one owner, update docs only where the pin is user-visible, and keep shell changes shellcheck-clean. Run focused tests plus required maintainer verification, then ship through the no-mistakes path. Do not modify private fleet configuration, install Treehouse globally, merge the PR, or make unrelated Firstmate changes.

## What Changed

- Pin the CI Treehouse installer to v2.1.1 with exact Linux and macOS amd64/arm64 release checksums.
- Add deterministic coverage for platform assets, the required Herdr CI path, checksum and version drift rejection, and the existing `shasum` fallback.
- Register the installer test with the pure-contract unit family and changed-file selection while retaining real-Herdr coverage.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped, preserves existing platform and fallback behavior, and its four hashes match the official [Treehouse v2.1.1 release](https://github.com/kunchenguid/treehouse/releases/tag/v2.1.1).

## Testing

After confirming the narrow four-file diff, focused installer and runner-selection tests passed; authoritative GitHub release metadata matched every pinned Linux/macOS checksum, and the actual extracted CI workflow step downloaded, verified, and ran Treehouse v2.1.1. The live transcript was saved as evidence and the worktree remained clean.

<details>
<summary>Evidence: Treehouse v2.1.1 authoritative release metadata and live CI installation transcript</summary>

Source: [Treehouse v2.1.1 authoritative release metadata and live CI installation transcript](https://github.com/cdonovan-abtex/firstmate/blob/67a503a113ed24278c67830f0b0f33ee10c832a6/.no-mistakes/evidence/fm/firstmate-treehouse-ci-pin-211-v1/treehouse-v2.1.1-ci-path.txt)

```text
Authoritative GitHub release metadata (kunchenguid/treehouse v2.1.1)
tag=v2.1.1 draft=false prerelease=false published_at=2026-07-31T05:20:26Z
checksums.txt size=612 sha256:22635f887d3d5b9d17f88c13302021802c45e8f8488dd3a569c46bfc0557b638
treehouse-v2.1.1-darwin-amd64.tar.gz size=7322981 sha256:f6f6bd71fe8279826aa35f201e79f34106c1c4056179e3e8141942027dd992a6
treehouse-v2.1.1-darwin-arm64.tar.gz size=6886014 sha256:deabeb7153bad14659e98da78de5334afecaeaac7e05988b106a4888646747d3
treehouse-v2.1.1-linux-amd64.tar.gz size=7160979 sha256:2fe3e01220ae51a967c3e5ba6ccf10ec83bdbae8e420368d194285a8d04c9ef8
treehouse-v2.1.1-linux-arm64.tar.gz size=6532152 sha256:980367c0233274eb3181a19a2ca8ec69d09b4a588ba27367937d336f9a2c938e

Normalized tests-herdr workflow step
set -eu
# Several real-herdr-gated E2E scripts require treehouse for spawn
# worktree acquisition (presentation, workspace-per-home, autodetect).
bin/fm-install-treehouse.sh "$RUNNER_TEMP/bin"
echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"

Live execution of the workflow step
fm-install-treehouse.sh: downloading treehouse-v2.1.1-darwin-arm64.tar.gz from https://github.com/kunchenguid/treehouse/releases/download/v2.1.1/treehouse-v2.1.1-darwin-arm64.tar.gz
fm-install-treehouse.sh: installed treehouse v2.1.1 to /var/folders/l8/htqy6t0j6hd9y084y1jqmqbr0000gn/T//fm-treehouse-live.4WklRa/bin/treehouse
v2.1.1
GITHUB_PATH entry: /var/folders/l8/htqy6t0j6hd9y084y1jqmqbr0000gn/T//fm-treehouse-live.4WklRa/bin
Installed binary version: v2.1.1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2c498fa2170115a9ebe3545243f5925e8edda47d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `tests/fm-install-treehouse.test.sh` - merge conflict rebasing onto origin/main
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 6c1d2db194cb20e08232ba2fa2c414592f724b44..2c498fa2170115a9ebe3545243f5925e8edda47d`</code>
- <code>Ran `tests/fm-install-treehouse.test.sh`</code>
- <code>Ran `tests/fm-test-run.test.sh`</code>
- <code>Ran `gh-axi release view v2.1.1 --repo kunchenguid/treehouse --full`</code>
- <code>Queried `https://api.github.com/repos/kunchenguid/treehouse/releases/tags/v2.1.1` and verified all four Linux/macOS asset digests</code>
- <code>Parsed `.github/workflows/ci.yml` with Ruby YAML, extracted the `tests-herdr` `Install pinned Treehouse` step, and executed it against the real GitHub release</code>
- <code>Ran `git status --short` to confirm testing left the worktree clean</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
