### PR TITLE
feat(delivery): add the direct-push delivery mode (directed tests, push to the default branch, no PR)

### DIFF
--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -40,6 +40,7 @@ Choose that posture when adding or creating the project:
 
 - `no-mistakes` runs the full validation pipeline before a PR.
 - `direct-PR` pushes and opens a PR without the no-mistakes pipeline.
+- `direct-push` runs directed tests and pushes straight to the default branch with no PR; the push is the landing.
 - `local-only` has no required remote or PR and lands only through the approved local fast-forward path.
 - `no-mistakes-prod-only` is a conditional policy rather than one flat mode: genuinely internal-only tooling, automation, contributor or operator process, and release or submission work ships `direct-PR`, while product-facing, mixed, and uncertain work ships `no-mistakes`.
 
@@ -57,7 +58,7 @@ Default it off for every project and every posture, and enable it only on the ca
 Confirm the source URL, local project name, delivery posture, and autonomy posture, stating the resolved default for each rather than asking the captain to invent one.
 Clone into `projects/<name>` and add the registry entry only after the destination is known to be unused.
 A `no-mistakes` or `no-mistakes-prod-only` project must have an `origin` remote and must complete the initialization procedure below, because a conditional policy's product-facing work runs the pipeline while its internal-only work still takes the direct PR.
-A `direct-PR` project needs an `origin` remote but skips no-mistakes initialization.
+A `direct-PR` or `direct-push` project needs an `origin` remote but skips no-mistakes initialization.
 A `local-only` project may have no remote and skips no-mistakes initialization.
 
 ## Create a project

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -150,7 +150,7 @@ Run `bin/fm-home-seed.sh validate` when checking registry integrity; its header 
 Seeding is transactional.
 If validation, cloning, no-mistakes initialization, or registry update fails, generated briefs, new homes, new project clones, and registry edits are rolled back.
 
-Secondmate project lists may include `no-mistakes` and `direct-PR` projects only.
+Secondmate project lists may include `no-mistakes`, `direct-PR`, and `direct-push` projects only.
 `local-only` projects stay with the main firstmate.
 For `no-mistakes` projects, seeding initializes only projects newly cloned into a secondmate home and refuses to mutate a preexisting clone that is not already initialized.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,10 +329,12 @@ The path's worker, automated gates, and captain approval remain authoritative:
 
 - **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
 - **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
+- **direct-push** has the worker run directed tests and push its commits straight to the repo's default branch; there is no PR, the push is the landing, and the next fleet sync reconciles the local copy.
 - **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.
 
 Delivery mode and `yolo` are orthogonal.
 `yolo` governs merge authority only: with it off, the captain approves every PR merge and every local-only landing; with it on, firstmate merges green, in-scope work itself.
+A `direct-push` task has no merge step, so merge authority never gates it: the worker's own tested push to the default branch is the landing.
 Never merge a red PR under either setting; destructive, irreversible, and security-sensitive merges still escalate.
 Without a current explicit captain instruction that states the concrete merge, that default stands, and standing `yolo` cannot authorize a red merge; section 1 owns when such an instruction overrides a Firstmate-written standing rule within its exact scope.
 Load `ask-user-authority` before deciding any ask-user finding; the implementation worker never answers its own finding.
@@ -366,6 +368,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 ### PR ready, landing, and teardown
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
+A `direct-push` task reports `done: pushed to <default>; directed tests green` after its push, which is also its landing.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine merge authority.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,7 +6,7 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|direct-push|local-only> [--herdr-lab]
 #        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
@@ -32,6 +32,8 @@
 # captain's standing posture as context, and this script never reads it:
 #   no-mistakes  implement -> /no-mistakes pipeline -> PR -> configured merge authority
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
+#   direct-push  implement + directed tests -> push commits straight to the default
+#                branch (no PR anywhere; the push is the landing)
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                the configured merge authority approves, firstmate merges to local main
 # no-mistakes-prod-only is a registry policy, not a task mode; resolve it to one of
@@ -145,15 +147,15 @@ done
 # missing or invalid value stops the scaffold rather than silently defaulting.
 if [ "$KIND" = ship ]; then
   [ "$MODE_SET" -eq 1 ] || {
-    echo "error: ship briefs require --mode <no-mistakes|direct-PR|local-only>; resolve it at intake from the captain's instruction and the project's registered posture in data/projects.md" >&2
+    echo "error: ship briefs require --mode <no-mistakes|direct-PR|direct-push|local-only>; resolve it at intake from the captain's instruction and the project's registered posture in data/projects.md" >&2
     exit 1
   }
   case "$MODE" in
-    no-mistakes|direct-PR|local-only) ;;
+    no-mistakes|direct-PR|direct-push|local-only) ;;
     no-mistakes-prod-only)
       echo "error: no-mistakes-prod-only is a registry policy, not a task mode; classify this task's surface and resolve it to no-mistakes or direct-PR at intake" >&2
       exit 1 ;;
-    *) echo "error: --mode must be one of no-mistakes, direct-PR, local-only (got '$MODE')" >&2; exit 1 ;;
+    *) echo "error: --mode must be one of no-mistakes, direct-PR, direct-push, local-only (got '$MODE')" >&2; exit 1 ;;
   esac
 elif [ "$MODE_SET" -eq 1 ]; then
   echo "error: --mode applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract" >&2
@@ -382,6 +384,10 @@ case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
+    ;;
+  direct-push)
+    SETUP2=""
+    RULE1="1. Never open a PR and never merge. Deliver by pushing your commits from your \`fm/$ID\` branch straight to the default branch (\`git push origin HEAD:<default>\`); no other push is allowed."
     ;;
   local-only)
     SETUP2=""

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -5,7 +5,7 @@
 # receives. Both paths must hand the worker the same contract: a promoted
 # no-mistakes worker that never received the ask-user escalation rule or the
 # `--yes` ban is the exact delivery hole this single owner exists to close.
-# fm_dod_block <no-mistakes|direct-PR|local-only> <task-id> prints the block on
+# fm_dod_block <no-mistakes|direct-PR|direct-push|local-only> <task-id> prints the block on
 # stdout with no trailing blank line. The caller validates the mode; an unknown
 # mode is refused rather than silently rendered as the pipeline contract.
 # The block opens with the fixed machine-readable "Delivery contract: mode=<mode>"
@@ -24,6 +24,20 @@ This task ships **direct-PR**: you raise the PR yourself, without the no-mistake
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+EOF
+      ;;
+    direct-push)
+      cat <<EOF
+# Definition of done
+Delivery contract: mode=direct-push
+This task ships **direct-push**: no PR anywhere - you push your commits straight to the repo's default branch.
+The task is complete only when committed on your branch.
+Implement the change, then write and pass DIRECTED tests - tests aimed at the delivered change (run the full suite too when it is cheap).
+There is no review gate, so the directed tests are the gate: they must actually pass before you push.
+Then push your branch's commits to the repo's default branch from this worktree: \`git push origin HEAD:<default>\` (replace \`<default>\` with the repo's actual default branch, e.g. \`main\`).
+That push is the delivery moment; firstmate's fleet sync reconciles the local copy afterwards.
+Do NOT open a PR and do NOT run /no-mistakes.
+When the push has landed, append \`done: pushed to <default>; directed tests green\` to the status file and stop.
 EOF
       ;;
     local-only)

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -466,7 +466,7 @@ clone_project() {
 $(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" "$FM_ROOT/bin/fm-project-mode.sh" "$project")
 EOF
   if [ "$mode" = local-only ]; then
-    echo "error: project $project is local-only; secondmate routes support only no-mistakes and direct-PR projects" >&2
+    echo "error: project $project is local-only; secondmate routes support only no-mistakes, direct-PR, and direct-push projects" >&2
     return 1
   fi
   if [ -e "$dst" ]; then
@@ -493,7 +493,7 @@ validate_seed_project() {
 $(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" "$FM_ROOT/bin/fm-project-mode.sh" "$project")
 EOF
   if [ "$mode" = local-only ]; then
-    echo "error: project $project is local-only; secondmate routes support only no-mistakes and direct-PR projects" >&2
+    echo "error: project $project is local-only; secondmate routes support only no-mistakes, direct-PR, and direct-push projects" >&2
     return 1
   fi
   url=$(git -C "$src" remote get-url origin 2>/dev/null || true)

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Resolve a project's REGISTERED delivery posture from the data/projects.md registry.
 # Prints two words to stdout: "<mode> <yolo>" where mode is one of
-# no-mistakes|direct-PR|local-only and yolo is on|off.
+# no-mistakes|direct-PR|direct-push|local-only and yolo is on|off.
 #
 # MECHANICAL CONSUMERS ONLY. This answers "what posture did the captain register
 # for this project", never "how does this task ship". A task's delivery mode and
@@ -19,6 +19,8 @@
 # Registered modes:
 #   no-mistakes            full pipeline -> PR -> configured merge authority (default)
 #   direct-PR              push + PR via gh-axi, no pipeline
+#   direct-push            directed tests, then push straight to the default
+#                          branch (no PR; the push is the landing)
 #   local-only             local branch, no remote/PR, guarded local merge
 #   no-mistakes-prod-only  a conditional policy, not a task mode: firstmate
 #                          classifies each task's surface at intake (the
@@ -80,7 +82,7 @@ fi
 mode=${parsed%% *}
 yolo=${parsed##* }
 case "$mode" in
-  no-mistakes|direct-PR|local-only|no-mistakes-prod-only) ;;
+  no-mistakes|direct-PR|direct-push|local-only|no-mistakes-prod-only) ;;
   *) echo "warn: unknown mode \"$mode\" for $NAME; defaulting to no-mistakes off" >&2; mode=no-mistakes; yolo=off ;;
 esac
 case "$yolo" in on|off) ;; *) yolo=off ;; esac

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -16,7 +16,7 @@
 # read the scout's report (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never looks it up.
 # no-mistakes-prod-only is a registry policy rather than a task mode and is refused.
-# Usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off>
+# Usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|direct-push|local-only> --yolo <on|off>
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -69,9 +69,9 @@ for a in "$@"; do
   esac
 done
 [ -z "$want_value" ] || { echo "error: --$want_value requires a value" >&2; exit 1; }
-[ "${#POS[@]}" -ge 1 ] || { echo "usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off>" >&2; exit 1; }
+[ "${#POS[@]}" -ge 1 ] || { echo "usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|direct-push|local-only> --yolo <on|off>" >&2; exit 1; }
 [ "$MODE_SET" -eq 1 ] || {
-  echo "error: promotion requires --mode <no-mistakes|direct-PR|local-only>; decide it now from the scout's findings and the project's registered posture in data/projects.md" >&2
+  echo "error: promotion requires --mode <no-mistakes|direct-PR|direct-push|local-only>; decide it now from the scout's findings and the project's registered posture in data/projects.md" >&2
   exit 1
 }
 [ "$YOLO_SET" -eq 1 ] || {
@@ -79,11 +79,11 @@ done
   exit 1
 }
 case "$MODE" in
-  no-mistakes|direct-PR|local-only) ;;
+  no-mistakes|direct-PR|direct-push|local-only) ;;
   no-mistakes-prod-only)
     echo "error: no-mistakes-prod-only is a registry policy, not a task mode; classify this task's surface and resolve it to no-mistakes or direct-PR" >&2
     exit 1 ;;
-  *) echo "error: --mode must be one of no-mistakes, direct-PR, local-only (got '$MODE')" >&2; exit 1 ;;
+  *) echo "error: --mode must be one of no-mistakes, direct-PR, direct-push, local-only (got '$MODE')" >&2; exit 1 ;;
 esac
 case "$YOLO" in
   on|off) ;;

--- a/bin/fm-remote-home-provision.sh
+++ b/bin/fm-remote-home-provision.sh
@@ -219,7 +219,7 @@ EOF
   safe_id "$NAME" || die "project name is unsafe: $NAME"
   [ -n "$ORIGIN" ] || die "project $NAME has no origin"
   fm_project_origin_safe "$ORIGIN" || die "project $NAME origin is not an accepted clone URL: $ORIGIN"
-  case "$MODE" in no-mistakes|direct-PR) ;; *) die "project $NAME has unsupported remote mode: $MODE" ;; esac
+  case "$MODE" in no-mistakes|direct-PR|direct-push) ;; *) die "project $NAME has unsupported remote mode: $MODE" ;; esac
   case "$REGISTRY_LINE" in "- $NAME "*) ;; *) die "project $NAME registry line is malformed" ;; esac
   DEST="$FM_HOME/projects/$NAME"
   if [ -e "$DEST" ] || [ -L "$DEST" ]; then

--- a/bin/fm-remote-home-seed.sh
+++ b/bin/fm-remote-home-seed.sh
@@ -165,7 +165,7 @@ for project in "${PROJECT_NAMES[@]}"; do
 $MODE_LINE
 EOF
   case "$MODE" in
-    no-mistakes|direct-PR) ;;
+    no-mistakes|direct-PR|direct-push) ;;
     local-only) die "project $project is local-only and cannot be provisioned remotely" ;;
     *) die "project $project has unsupported delivery mode: $MODE" ;;
   esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|direct-push|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
 #        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
@@ -409,7 +409,7 @@ else
   # and record no delivery posture; secondmate spawns hardcode theirs.
   if [ "$KIND" = ship ]; then
     [ "$MODE_SET" -eq 1 ] || {
-      echo "error: ship spawns require --mode <no-mistakes|direct-PR|local-only>; resolve it at intake from the captain's instruction and the project's registered posture in data/projects.md" >&2
+      echo "error: ship spawns require --mode <no-mistakes|direct-PR|direct-push|local-only>; resolve it at intake from the captain's instruction and the project's registered posture in data/projects.md" >&2
       exit 1
     }
     [ "$YOLO_SET" -eq 1 ] || {
@@ -417,11 +417,11 @@ else
       exit 1
     }
     case "$MODE" in
-      no-mistakes|direct-PR|local-only) ;;
+      no-mistakes|direct-PR|direct-push|local-only) ;;
       no-mistakes-prod-only)
         echo "error: no-mistakes-prod-only is a registry policy, not a task mode; classify this task's surface and resolve it to no-mistakes or direct-PR at intake" >&2
         exit 1 ;;
-      *) echo "error: --mode must be one of no-mistakes, direct-PR, local-only (got '$MODE')" >&2; exit 1 ;;
+      *) echo "error: --mode must be one of no-mistakes, direct-PR, direct-push, local-only (got '$MODE')" >&2; exit 1 ;;
     esac
     case "$YOLO" in
       on|off) ;;
@@ -1767,11 +1767,14 @@ else
 fi
 [ -f "$BRIEF" ] || { echo "error: task $ID has no brief at inaccessible data path $BRIEF" >&2; exit 1; }
 
-delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task mode
+delivery_rigor_rank() {  # <mode> -> 4 (most rigor) .. 1 (least); 0 = not a task mode
+  # direct-push ranks last: its landing is the worker's own push to the shared
+  # default branch, with no PR review and no merge-authority touchpoint at all.
   case "$1" in
-    no-mistakes) echo 3 ;;
-    direct-PR) echo 2 ;;
-    local-only) echo 1 ;;
+    no-mistakes) echo 4 ;;
+    direct-PR) echo 3 ;;
+    local-only) echo 2 ;;
+    direct-push) echo 1 ;;
     *) echo 0 ;;
   esac
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,7 +216,7 @@ The helper's header owns the exact signal detection, relocated-home limitation, 
 
 ## Two task shapes
 
-Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks leave standalone investigation reports at `data/<id>/report.md` and never push.
+Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, `direct-push`, or `local-only`); scout tasks leave standalone investigation reports at `data/<id>/report.md` and never push.
 The intake and authority contract in `AGENTS.md` owns when separate scout research is warranted.
 
 ## Dispatch profiles
@@ -275,7 +275,7 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 
 ## Delivery modes are explicit per task
 
-`no-mistakes` tasks run the full validation pipeline, `direct-PR` tasks open PRs without that pipeline, and `local-only` tasks stay local until firstmate performs an approved fast-forward merge.
+`no-mistakes` tasks run the full validation pipeline, `direct-PR` tasks open PRs without that pipeline, `direct-push` tasks push directed-test-green commits straight to the default branch with no PR, and `local-only` tasks stay local until firstmate performs an approved fast-forward merge.
 Each task's mode and `yolo` merge posture are firstmate's decision at intake.
 The mode is passed explicitly to `bin/fm-brief.sh`, and both values are passed explicitly to `bin/fm-spawn.sh` and `bin/fm-promote.sh`; each command refuses to guess the values it consumes.
 A ship brief records its mode as a fixed machine-readable line and the spawn refuses to launch on a different one, so the worker's instructions and the recorded task delivery cannot diverge.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -260,7 +260,7 @@ A project-less seed requires no existing project clones or `data/projects.md` en
 A preexisting project-bearing charter is also refused until it is re-scaffolded with `--no-projects` or removed.
 The lease is held under the secondmate id until explicit retirement or seed rollback returns it, so normal restarts do not free or recycle the home.
 Teardown of a leased home fails closed if `treehouse return` cannot release the lease; plain-clone homes with no treehouse pool slot are removed directly.
-Secondmate routes cover `no-mistakes` and `direct-PR` projects; `local-only` projects remain main-firstmate work.
+Secondmate routes cover `no-mistakes`, `direct-PR`, and `direct-push` projects; `local-only` projects remain main-firstmate work.
 For `no-mistakes` projects, seeding initializes only projects newly cloned into a secondmate home and refuses to mutate a preexisting clone that is not already initialized.
 After creating a secondmate, move existing main-backlog queued items that you have judged in-scope with `fm-backlog-handoff.sh <secondmate-id> <item-key>...`; it refuses In flight, Done, or non-secondmate homes, and a new move succeeds only after waking the recorded receiver.
 If the wake is known to have failed, the moved item remains durable and rerunning the same handoff retries it idempotently; an unresolved delivery is reported and never blindly resent.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -199,7 +199,7 @@ test_ship_modes_generate_clean_briefs() {
   home="$TMP_ROOT/ship-home"
   write_registry "$home"
 
-  for id_mode in "brief-nomistakes-a1:no-mistakes" "brief-directpr-a2:direct-PR" "brief-localonly-a3:local-only"; do
+  for id_mode in "brief-nomistakes-a1:no-mistakes" "brief-directpr-a2:direct-PR" "brief-localonly-a3:local-only" "brief-directpush-a4:direct-push"; do
     id=${id_mode%%:*}
     mode=${id_mode##*:}
     FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1; status=$?
@@ -215,6 +215,42 @@ test_ship_modes_generate_clean_briefs() {
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
+}
+
+# direct-push's contract inverts direct-PR's rule 1: the default-branch push IS the
+# delivery, so the brief must ban PRs and merges, name the exact push mechanic,
+# and keep the directed-tests gate and the machine-readable done line.
+test_direct_push_dod_wording() {
+  local home id brief
+  home="$TMP_ROOT/direct-push-home"
+  mkdir -p "$home/data"
+  id="brief-directpush-wording-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-push >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+  grep -qx "Delivery contract: mode=direct-push" "$brief" \
+    || fail "direct-push brief did not record its machine-readable delivery contract"
+  assert_grep "no PR anywhere - you push your commits straight to the repo's default branch" "$brief" \
+    "direct-push DoD lost its no-PR delivery statement"
+  assert_grep "git push origin HEAD:<default>" "$brief" \
+    "direct-push DoD lost the exact default-branch push mechanic"
+  assert_grep "write and pass DIRECTED tests - tests aimed at the delivered change" "$brief" \
+    "direct-push DoD lost the directed-tests gate"
+  assert_grep "the directed tests are the gate: they must actually pass before you push" "$brief" \
+    "direct-push DoD lost the tests-before-push ordering rule"
+  assert_grep "done: pushed to <default>; directed tests green" "$brief" \
+    "direct-push DoD lost its machine-readable done line"
+  assert_grep "Never open a PR and never merge. Deliver by pushing your commits from your \`fm/$id\` branch straight to the default branch" "$brief" \
+    "direct-push rule 1 lost the no-PR/no-merge ban and push mechanic"
+  assert_no_grep "Never push to the default branch" "$brief" \
+    "direct-push brief retained direct-PR's never-push rule 1"
+  assert_no_grep "Do NOT push, do NOT open a PR" "$brief" \
+    "direct-push brief retained local-only's never-push contract"
+  assert_no_grep "no-mistakes axi respond" "$brief" \
+    "direct-push brief received the pipeline gate contract"
+  assert_no_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+    "direct-push brief received the no-mistakes pipeline handoff"
+  pass "fm-brief.sh: direct-push DoD bans PRs, names the push mechanic, and gates on directed tests"
 }
 
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
@@ -238,7 +274,7 @@ test_ship_mode_is_required_and_closed_set() {
   done <<'ROWS'
 missing --mode||ship briefs require --mode
 empty --mode value|--mode|requires a value
-unknown mode value|--mode nope|must be one of no-mistakes, direct-PR, local-only
+unknown mode value|--mode nope|must be one of no-mistakes, direct-PR, direct-push, local-only
 conditional policy is not a task mode|--mode no-mistakes-prod-only|classify this task's surface
 ROWS
   pass "fm-brief.sh: ship --mode is required and closed-set validated"
@@ -766,6 +802,7 @@ test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_direct_push_dod_wording
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -876,10 +876,37 @@ test_home_seed_refuses_local_only_project() {
   if FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" design "$subhome" alpha >/dev/null 2>"$err"; then
     fail "seed allowed a local-only project into a secondmate home"
   fi
-  grep -F 'project alpha is local-only; secondmate routes support only no-mistakes and direct-PR projects' "$err" >/dev/null \
+  grep -F 'project alpha is local-only; secondmate routes support only no-mistakes, direct-PR, and direct-push projects' "$err" >/dev/null \
     || fail "seed did not explain local-only project rejection"
   [ ! -e "$subhome" ] || fail "seed created a subhome before rejecting a local-only project"
   pass "home seeding refuses local-only projects"
+}
+
+# direct-push is a remote-backed mode, so seeding a secondmate home treats it
+# like direct-PR: origin required, clone seeded, and no no-mistakes init step.
+test_home_seed_accepts_direct_push_project_without_no_mistakes_init() {
+  local home subhome err out seeded_origin
+  home="$TMP_ROOT/direct-push-seed-home"
+  subhome="$TMP_ROOT/direct-push-seed-subhome"
+  err="$TMP_ROOT/direct-push-seed.err"
+  mkdir -p "$home/projects" "$home/data" "$home/state"
+  fm_git_init_commit "$home/projects/alpha"
+  fm_git_add_origin "$home/projects/alpha" "$TMP_ROOT/remotes/direct-push-alpha.git"
+  printf '%s\n' '- alpha [direct-push +yolo] - alpha project (added 2026-06-22)' > "$home/data/projects.md"
+  scaffold_secondmate_charter "$home" design 'design domain' alpha || fail "charter scaffold failed for direct-push seed test"
+
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" design "$subhome" alpha 2>"$err") || {
+    cat "$err" >&2
+    fail "seed refused a direct-push project"
+  }
+  seeded_origin=$(git -C "$subhome/projects/alpha" remote get-url origin 2>/dev/null) \
+    || fail "direct-push seed did not clone the project into the subhome"
+  [ "$(git -C "$home/projects/alpha" remote get-url origin)" = "$seeded_origin" ] \
+    || fail "direct-push seed did not preserve the source origin"
+  if git -C "$subhome/projects/alpha" remote get-url no-mistakes >/dev/null 2>&1; then
+    fail "direct-push seed ran a no-mistakes init on the seeded clone"
+  fi
+  pass "home seeding treats direct-push as remote-backed without no-mistakes init"
 }
 
 test_home_seed_refuses_registry_delimiter_home() {
@@ -2922,6 +2949,7 @@ test_home_seed_refuses_projectless_home_with_non_directory_projects
 test_home_seed_refuses_projectless_home_with_uninspectable_registry
 test_home_seed_refuses_missing_projects_without_signal
 test_home_seed_refuses_local_only_project
+test_home_seed_accepts_direct_push_project_without_no_mistakes_init
 test_home_seed_refuses_registry_delimiter_home
 test_home_seed_refuses_active_home_and_root
 test_home_seed_refuses_home_marked_for_another_id

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -82,7 +82,7 @@ EOF
 missing both flags||ship spawns require --mode
 missing --yolo|--mode no-mistakes|ship spawns require --yolo
 missing --mode|--yolo off|ship spawns require --mode
-unknown mode|--mode nope --yolo off|must be one of no-mistakes, direct-PR, local-only
+unknown mode|--mode nope --yolo off|must be one of no-mistakes, direct-PR, direct-push, local-only
 unknown yolo|--mode no-mistakes --yolo maybe|--yolo must be on or off
 conditional policy as a task mode|--mode no-mistakes-prod-only --yolo off|classify this task's surface
 ROWS
@@ -139,6 +139,16 @@ EOF
   out=$(run_spawn "$home" "$fakebin" delivery-agree-b2 "$proj" claude --mode direct-PR --yolo off)
   assert_not_contains "$out" "delivery mismatch" "an agreeing mode was reported as a mismatch"
 
+  # The direct-push contract agrees and mismatches on the same terms as the
+  # other task modes, since the brief/spawn contract line is mode-agnostic.
+  write_brief "$home" delivery-agree-b4 direct-push
+  out=$(run_spawn "$home" "$fakebin" delivery-agree-b4 "$proj" claude --mode direct-push --yolo on)
+  assert_not_contains "$out" "delivery mismatch" "an agreeing direct-push mode was reported as a mismatch"
+  write_brief "$home" delivery-mismatch-b5 direct-push
+  out=$(run_spawn "$home" "$fakebin" delivery-mismatch-b5 "$proj" claude --mode direct-PR --yolo off)
+  assert_contains "$out" "the brief says mode=direct-push but this spawn passed --mode direct-PR" \
+    "a direct-push brief mismatched against a direct-PR spawn was not shown both sides"
+
   # A brief scaffolded before the contract line existed warns once and continues.
   write_brief "$home" delivery-legacy-b3
   out=$(run_spawn "$home" "$fakebin" delivery-legacy-b3 "$proj" claude --mode local-only --yolo off)
@@ -176,8 +186,13 @@ EOF
   done <<'ROWS'
 no-mistakes project shipped direct-PR|- proj [no-mistakes] - fixture (added 2026-01-01)|direct-PR|notice|no-mistakes
 no-mistakes project shipped local-only|- proj [no-mistakes] - fixture (added 2026-01-01)|local-only|notice|no-mistakes
+no-mistakes project shipped direct-push|- proj [no-mistakes] - fixture (added 2026-01-01)|direct-push|notice|no-mistakes
 no-mistakes project shipped no-mistakes|- proj [no-mistakes] - fixture (added 2026-01-01)|no-mistakes|quiet|no-mistakes
+direct-PR project shipped direct-push|- proj [direct-PR] - fixture (added 2026-01-01)|direct-push|notice|direct-PR
+direct-push project shipped direct-PR|- proj [direct-push] - fixture (added 2026-01-01)|direct-PR|quiet|direct-push
+direct-push project shipped direct-push|- proj [direct-push] - fixture (added 2026-01-01)|direct-push|quiet|direct-push
 local-only project shipped no-mistakes|- proj [local-only] - fixture (added 2026-01-01)|no-mistakes|quiet|local-only
+local-only project shipped direct-push|- proj [local-only] - fixture (added 2026-01-01)|direct-push|notice|local-only
 conditional policy shipped direct-PR|- proj [no-mistakes-prod-only] - fixture (added 2026-01-01)|direct-PR|quiet|no-mistakes-prod-only
 unregistered project resolves to the no-mistakes standing default|- other [no-mistakes] - fixture (added 2026-01-01)|direct-PR|notice|no-mistakes
 ROWS
@@ -259,6 +274,17 @@ test_promote_requires_and_records_the_delivery_contract() {
   assert_grep 'yolo=on' "$meta" "promotion did not record the decided merge posture"
   assert_contains "$out" "ship instructions for mode=direct-PR" "promotion hint did not carry the decided mode"
   [ "$(grep -c '^mode=' "$meta")" = 1 ] || fail "promotion left more than one mode= line in the task record"
+
+  # The fourth registered task mode promotes and records on the same terms.
+  meta="$home/state/promote-push-d2.meta"
+  printf 'window=fm-promote-push-d2\nkind=scout\nworktree=/tmp/wt\n' > "$meta"
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" "$PROMOTE" promote-push-d2 --mode direct-push --yolo on 2>&1)
+  status=$?
+  expect_code 0 "$status" "a direct-push promotion carrying both flags should succeed"
+  assert_grep 'kind=ship' "$meta" "direct-push promotion did not restore ship teardown protection"
+  assert_grep 'mode=direct-push' "$meta" "direct-push promotion did not record the decided delivery mode"
+  assert_grep 'yolo=on' "$meta" "direct-push promotion did not record the decided merge posture"
+  assert_contains "$out" "ship instructions for mode=direct-push" "promotion hint did not carry the direct-push mode"
   pass "fm-promote: promotion requires the delivery contract and records it exactly once"
 }
 
@@ -308,7 +334,7 @@ printf '%s' "$2" > "$FM_TEST_CAPTURE"
 STUB
   chmod +x "$sendroot/bin/fm-send.sh"
 
-  for mode in no-mistakes direct-PR local-only; do
+  for mode in no-mistakes direct-PR direct-push local-only; do
     id="promote-dod-$(printf '%s' "$mode" | tr '[:upper:]' '[:lower:]')"
     meta="$home/state/$id.meta"
     printf 'window=fm-%s\nkind=scout\nworktree=/tmp/wt\n' "$id" > "$meta"
@@ -371,6 +397,19 @@ STUB
     "promoted local-only worker lost its no-remote contract"
   assert_no_grep "no-mistakes axi respond" "$TMP_ROOT/promote-dod/payload-promote-dod-direct-pr" \
     "promoted direct-PR worker received the pipeline gate contract"
+
+  # direct-push carries the push mechanic and its own done line, never a PR.
+  payload="$TMP_ROOT/promote-dod/payload-promote-dod-direct-push"
+  assert_grep "git push origin HEAD:<default>" "$payload" \
+    "promoted direct-push worker lost the default-branch push mechanic"
+  assert_grep "done: pushed to <default>; directed tests green" "$payload" \
+    "promoted direct-push worker lost its machine-readable done line"
+  assert_grep "Do NOT open a PR" "$payload" \
+    "promoted direct-push worker lost its no-PR contract"
+  assert_no_grep "no-mistakes axi respond" "$payload" \
+    "promoted direct-push worker received the pipeline gate contract"
+  assert_no_grep "open a PR with" "$payload" \
+    "promoted direct-push worker received the direct-PR open-a-PR instruction"
   pass "fm-promote: a promoted worker receives the same mode-specific delivery contract a briefed one does"
 }
 
@@ -385,6 +424,9 @@ test_project_mode_maps_the_conditional_policy() {
 - prodproj [no-mistakes-prod-only] - fixture (added 2026-01-01)
 - yoloproj [no-mistakes-prod-only +yolo] - fixture (added 2026-01-01)
 - flatproj [direct-PR] - fixture (added 2026-01-01)
+- pushproj [direct-push] - fixture (added 2026-01-01)
+- pushyoloproj [direct-push +yolo] - fixture (added 2026-01-01)
+- pushtypo [direct-pus] - fixture (added 2026-01-01)
 - typoproj [no-mistakez] - fixture (added 2026-01-01)
 EOF
   out=$(FM_HOME="$home" "$PROJECT_MODE" prodproj 2>/dev/null)
@@ -400,6 +442,22 @@ EOF
 
   out=$(FM_HOME="$home" "$PROJECT_MODE" --raw flatproj 2>/dev/null)
   [ "$out" = "direct-PR off" ] || fail "--raw altered a flat registered mode (got '$out')"
+
+  out=$(FM_HOME="$home" "$PROJECT_MODE" pushproj 2>/dev/null)
+  [ "$out" = "direct-push off" ] || fail "direct-push registry mode was not parsed (got '$out')"
+  err=$(FM_HOME="$home" "$PROJECT_MODE" pushproj 2>&1 >/dev/null)
+  [ -z "$err" ] || fail "a registered direct-push mode still warned as unknown: $err"
+
+  out=$(FM_HOME="$home" "$PROJECT_MODE" pushyoloproj 2>/dev/null)
+  [ "$out" = "direct-push on" ] || fail "direct-push dropped its +yolo posture (got '$out')"
+
+  out=$(FM_HOME="$home" "$PROJECT_MODE" --raw pushproj 2>/dev/null)
+  [ "$out" = "direct-push off" ] || fail "--raw altered the direct-push mode (got '$out')"
+
+  out=$(FM_HOME="$home" "$PROJECT_MODE" pushtypo 2>/dev/null)
+  [ "$out" = "no-mistakes off" ] || fail "a direct-push typo no longer falls back to the most rigorous default"
+  err=$(FM_HOME="$home" "$PROJECT_MODE" pushtypo 2>&1 >/dev/null)
+  assert_contains "$err" "unknown mode" "a direct-push typo stopped warning"
 
   out=$(FM_HOME="$home" "$PROJECT_MODE" typoproj 2>/dev/null)
   [ "$out" = "no-mistakes off" ] || fail "a typo'd mode no longer falls back to the most rigorous default"


### PR DESCRIPTION
## What

Adds a fourth registered task delivery mode, `direct-push`: implement, pass directed tests, push the commits straight to the repo's default branch - no PR anywhere; the push is the landing. This is the captain's standing default for product work (2026-08-31, recorded in the captain's preferences); the tooling now supports it.

## Design decisions

- Mode token: `direct-push` (the design contract's token).
- Single owner of the mode's Definition of done stays `bin/fm-dod-lib.sh`, so briefed and promoted workers receive the identical contract. Directed tests are the gate ("they must actually pass before you push"); the mechanic is `git push origin HEAD:<default>` from the isolated worktree; the machine-readable done line is `pushed to <default>; directed tests green`.
- Rigor rank places `direct-push` last (no PR review, no merge-authority touchpoint). The spawn's registry-deviation notice therefore fires when a stricter standing posture is dropped below, including `no-mistakes -> direct-push`, `direct-PR -> direct-push`, and `local-only -> direct-push`; shipping a stricter mode over a `direct-push` standing posture stays quiet. Existing relative ordering is unchanged.
- Mechanical consumers treat it as a remote-backed mode like `direct-PR`: fleet-sync syncs such clones (only `local-only` is skipped), home and remote seeding require an `origin` and skip no-mistakes init, and secondmate routes accept it. The stale "routes support only no-mistakes and direct-PR" refusal message was updated everywhere it appeared.
- Teardown needs no change: after the delivery push the commits are reachable from a remote-tracking ref, so the unlanded-work guard passes; an unpushed "done" still refuses.
- `no-mistakes`, `direct-PR`, and `local-only` keep their exact behavior; no-mistakes itself is untouched. No `data/projects.md` entries flip in this task (the captain directs per-project flips separately).

## Surfaces

- `bin/fm-project-mode.sh`: parse `- <name> [direct-push +yolo]`; header documents the mode.
- `bin/fm-dod-lib.sh`: direct-push DoD block.
- `bin/fm-brief.sh`: `--mode direct-push` accepted; mode-shaped Rule 1 (no PR, no merge, one allowed push).
- `bin/fm-spawn.sh`: `--mode direct-push` accepted (spawn validation, brief contract-line match, rigor rank).
- `bin/fm-promote.sh`: `--mode direct-push` accepted and recorded.
- `bin/fm-home-seed.sh`, `bin/fm-remote-home-seed.sh`, `bin/fm-remote-home-provision.sh`: direct-push treated as remote-backed.
- Docs/instructions: `AGENTS.md` section 7 (mode list, merge-authority note, ready signal), `docs/architecture.md`, `docs/configuration.md`, `project-management` and `secondmate-provisioning` skills.

## Validation evidence

- `bin/fm-lint.sh` clean (pinned ShellCheck 0.11.0, full extended analysis; `actionlint` is absent in this environment - pre-existing, no workflow files changed).
- New/extended colocated behavior tests, all green:
  - `tests/fm-task-delivery.test.sh`: registry parse (`[direct-push]`, `[direct-push +yolo]`, typo fallback with warning, `--raw` passthrough); spawn accepts direct-push and enforces the brief/spawn contract-line match both ways; five new rigor-notice rows; promotion records `mode=direct-push`; promoted-worker DoD parity includes direct-push with new no-PR/push-mechanic assertions.
  - `tests/fm-brief.test.sh`: direct-push brief generates cleanly in the four-mode loop; new wording test pins the no-PR rule, push mechanic, directed-tests gate, and done line, and asserts the direct-PR/local-only never-push contracts are absent.
  - `tests/fm-secondmate-safety.test.sh`: new end-to-end seed test - a `[direct-push +yolo]` project seeds into a secondmate home preserving origin with no `no-mistakes` remote on the seeded clone; local-only refusal message expectation updated.
- Green suites touching the changed scripts: `fm-task-delivery`, `fm-brief`, `fm-secondmate-safety`, `fm-secondmate-lifecycle-e2e`, `fm-spawn-batch`, `fm-control-relaunch`, `fm-backend`, `fm-spawn-worktree-settle`, `fm-doc-audience-check.sh` (89 surfaces, 299 local links).
- `bin/fm-test-run.sh --changed` (68 scripts): 58 pass; the 10 failures reproduce identically on clean `origin/main` in this environment (verified via a stashed baseline run) - missing `ruby`, missing `actionlint`, a node ESM load failure, a platform-specific process-tree fixture, and timing-sensitive process-event claims. None are touched by this branch's diff.

## Delivery

Shipped as direct-PR per the task contract (no-mistakes unavailable by the captain's new default). Note: `taimurrabuske` has no push access to `kunchenguid/firstmate`, so this PR comes from the newly created fork `taimurrabuske/firstmate`.
