### PR TITLE
fix(herdr): make presentation-lock namespace per-user

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -658,18 +658,17 @@ fm_backend_herdr_projection_workspace_label() {  # <task-id> <projection-id>
 # fm_backend_herdr_presentation_lock_namespace: per-user namespace, never a
 # fixed shared path. On a multi-user host a fixed /tmp path is created and
 # owned by whichever user gets there first, permanently locking every other
-# user out (mode 700, foreign uid). Prefers $XDG_RUNTIME_DIR (already
-# per-user, mode 700 by the XDG Base Directory spec) when it is set and
-# usable, else falls back to a uid-suffixed /tmp path. A foreign-owned legacy
-# /tmp/firstmate-herdr-presentation (no uid suffix) is never read, chowned,
-# chmodded, or migrated - it is simply not this function's return value
-# anymore, and the locks themselves are ephemeral.
+# user out (mode 700, foreign uid). Always resolves the deterministic
+# uid-suffixed /tmp path - never $XDG_RUNTIME_DIR, whose presence and value
+# can differ between two processes of the SAME user (a systemd user session
+# vs. a cron/sudo/detached invocation, or two different session ids), which
+# would split one user's own lock identity across two different directories
+# and silently defeat the mutual exclusion the lock exists for. A
+# foreign-owned legacy /tmp/firstmate-herdr-presentation (no uid suffix) is
+# never read, chowned, chmodded, or migrated - it is simply not this
+# function's return value anymore, and the locks themselves are ephemeral.
 fm_backend_herdr_presentation_lock_namespace() {
   local uid
-  if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -d "${XDG_RUNTIME_DIR:-}" ] && [ -w "${XDG_RUNTIME_DIR:-}" ]; then
-    printf '%s/firstmate-herdr-presentation' "$XDG_RUNTIME_DIR"
-    return 0
-  fi
   uid=$(id -u 2>/dev/null) || return 1
   [ -n "$uid" ] || return 1
   printf '/tmp/firstmate-herdr-presentation-%s' "$uid"

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -655,8 +655,24 @@ fm_backend_herdr_projection_workspace_label() {  # <task-id> <projection-id>
 # The path is never under any one home's state/ and secondmates never write the
 # primary home. Returns non-zero when the named session's socket cannot be
 # resolved unambiguously.
+# fm_backend_herdr_presentation_lock_namespace: per-user namespace, never a
+# fixed shared path. On a multi-user host a fixed /tmp path is created and
+# owned by whichever user gets there first, permanently locking every other
+# user out (mode 700, foreign uid). Prefers $XDG_RUNTIME_DIR (already
+# per-user, mode 700 by the XDG Base Directory spec) when it is set and
+# usable, else falls back to a uid-suffixed /tmp path. A foreign-owned legacy
+# /tmp/firstmate-herdr-presentation (no uid suffix) is never read, chowned,
+# chmodded, or migrated - it is simply not this function's return value
+# anymore, and the locks themselves are ephemeral.
 fm_backend_herdr_presentation_lock_namespace() {
-  printf '%s' '/tmp/firstmate-herdr-presentation'
+  local uid
+  if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -d "${XDG_RUNTIME_DIR:-}" ] && [ -w "${XDG_RUNTIME_DIR:-}" ]; then
+    printf '%s/firstmate-herdr-presentation' "$XDG_RUNTIME_DIR"
+    return 0
+  fi
+  uid=$(id -u 2>/dev/null) || return 1
+  [ -n "$uid" ] || return 1
+  printf '/tmp/firstmate-herdr-presentation-%s' "$uid"
 }
 
 fm_backend_herdr_presentation_lock_namespace_mode() {

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -105,7 +105,7 @@ An ambiguous response grants no mutation or cleanup authority.
 
 Protocol 16 exposes `workspace.move` over the named session socket but no CLI subcommand.
 `bin/backends/herdr-workspace-move.py` sends only that whitelisted method and verifies the complete returned workspace order.
-Projected children are placed in one contiguous block immediately after their owning home when the session layout, protocol, socket, `python3`, and machine-private per-session lock are all verifiable.
+Projected children are placed in one contiguous block immediately after their owning home when the session layout, protocol, socket, `python3`, and per-user machine-private per-session lock are all verifiable.
 Existing legacy child labels may extend an already adjacent block read-only but are never renamed or migrated.
 A foreign, ambiguous, detached, or manually interleaved child makes ordering skip with a warning rather than rewriting the layout.
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2508,30 +2508,35 @@ SH
 }
 
 test_presentation_session_lock_path_is_shared_across_homes() {
-  local dir log resp fb path_a path_b path_other path_tmp path_private
+  local dir log resp fb path_a path_b path_other path_tmp path_private uid
   dir="$TMP_ROOT/presentation-session-lock"; mkdir -p "$dir/responses" "$dir/sockdir"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
+  uid=$(id -u) || fail "could not resolve current uid"
   : > "$dir/sockdir/fmtest.sock"
   printf '%s\n' "{\"sessions\":[{\"name\":\"fmtest\",\"running\":true,\"socket_path\":\"$dir/sockdir/fmtest.sock\"}]}" > "$resp/1.out"
   printf '%s\n' "{\"sessions\":[{\"name\":\"fmtest\",\"running\":true,\"socket_path\":\"$dir/sockdir/fmtest.sock\"}]}" > "$resp/2.out"
   printf '%s\n' "{\"sessions\":[{\"name\":\"other\",\"running\":true,\"socket_path\":\"$dir/sockdir/other.sock\"}]}" > "$resp/3.out"
   : > "$dir/sockdir/other.sock"
   fb=$(make_herdr_fakebin "$dir")
-  path_a=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+  # XDG_RUNTIME_DIR="" forces the deterministic per-uid /tmp fallback for this
+  # assertion regardless of the ambient test environment (fixture-set state
+  # persists per session/socket either way; see the XDG_RUNTIME_DIR-preferring
+  # and fallback tests below for the namespace choice itself).
+  path_a=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT") \
     || fail "session lock path resolution failed for home A"
-  path_b=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+  path_b=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT") \
     || fail "session lock path resolution failed for home B"
   [ "$path_a" = "$path_b" ] || fail "same session/socket must resolve one shared lock path"
   case "$path_a" in
-    /tmp/firstmate-herdr-presentation/order-*.lock) ;;
-    *) fail "session lock path must use the shared machine namespace: $path_a" ;;
+    /tmp/firstmate-herdr-presentation-"$uid"/order-*.lock) ;;
+    *) fail "session lock path must use the per-user machine namespace: $path_a" ;;
   esac
   case "$path_a" in
     */state/*) fail "session lock path must not live under a home state directory: $path_a" ;;
   esac
-  path_other=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+  path_other=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path other' "$ROOT") \
     || fail "session lock path resolution failed for a different session"
   [ "$path_other" != "$path_a" ] || fail "different sessions must not share one lock path"
@@ -2540,10 +2545,10 @@ test_presentation_session_lock_path_is_shared_across_homes() {
     : > /tmp/fm-herdr-lock-canon-$$.sock
     printf '%s\n' '{"sessions":[{"name":"canon","running":true,"socket_path":"/tmp/fm-herdr-lock-canon-'"$$"'.sock"}]}' > "$resp/4.out"
     printf '%s\n' "{\"sessions\":[{\"name\":\"canon\",\"running\":true,\"socket_path\":\"$(cd /tmp && pwd -P)/fm-herdr-lock-canon-$$.sock\"}]}" > "$resp/5.out"
-    path_tmp=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    path_tmp=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
       bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path canon' "$ROOT") \
       || fail "lock path with /tmp socket failed"
-    path_private=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    path_private=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
       bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path canon' "$ROOT") \
       || fail "lock path with canonical socket failed"
     rm -f /tmp/fm-herdr-lock-canon-$$.sock
@@ -2551,6 +2556,88 @@ test_presentation_session_lock_path_is_shared_across_homes() {
       || fail "symlink parent socket paths must resolve one lock: $path_tmp vs $path_private"
   fi
   pass "herdr presentation lock: one path per session/socket across homes"
+}
+
+test_presentation_lock_namespace_prefers_xdg_runtime_dir() {
+  local runtime_dir dir expected
+  runtime_dir="$TMP_ROOT/xdg-runtime"; mkdir -p "$runtime_dir"
+  expected="$runtime_dir/firstmate-herdr-presentation"
+  dir=$(XDG_RUNTIME_DIR="$runtime_dir" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
+    || fail "namespace resolution failed with a usable XDG_RUNTIME_DIR"
+  [ "$dir" = "$expected" ] || fail "expected $expected, got $dir"
+  pass "herdr presentation lock namespace: prefers a usable XDG_RUNTIME_DIR"
+}
+
+test_presentation_lock_namespace_falls_back_without_xdg_runtime_dir() {
+  local dir uid expected
+  uid=$(id -u) || fail "could not resolve current uid"
+  expected="/tmp/firstmate-herdr-presentation-$uid"
+  dir=$(XDG_RUNTIME_DIR="" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
+    || fail "namespace resolution failed with no XDG_RUNTIME_DIR"
+  [ "$dir" = "$expected" ] || fail "expected $expected, got $dir"
+  pass "herdr presentation lock namespace: falls back to a uid-suffixed /tmp path"
+}
+
+test_presentation_lock_namespace_falls_back_on_unusable_xdg_runtime_dir() {
+  local dir uid expected missing
+  uid=$(id -u) || fail "could not resolve current uid"
+  expected="/tmp/firstmate-herdr-presentation-$uid"
+  missing="$TMP_ROOT/xdg-runtime-does-not-exist"
+  dir=$(XDG_RUNTIME_DIR="$missing" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
+    || fail "namespace resolution failed with a nonexistent XDG_RUNTIME_DIR"
+  [ "$dir" = "$expected" ] || fail "expected $expected, got $dir"
+  pass "herdr presentation lock namespace: falls back when XDG_RUNTIME_DIR is not usable"
+}
+
+test_presentation_lock_namespace_ignores_foreign_legacy_path() {
+  local legacy="/tmp/firstmate-herdr-presentation" created=0 dir uid
+  uid=$(id -u) || fail "could not resolve current uid"
+  if [ ! -e "$legacy" ]; then
+    mkdir -m 755 "$legacy" 2>/dev/null && created=1
+  fi
+  # A foreign-owned (or, here, merely wrong-mode) legacy path must never be
+  # read, chowned, chmodded, or migrated; only assert the resolver's return
+  # value ignores it, and never mutate a pre-existing entry this test did not
+  # create itself.
+  dir=$(XDG_RUNTIME_DIR="" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT")
+  if [ "$created" -eq 1 ]; then rmdir "$legacy" 2>/dev/null || true; fi
+  [ "$dir" = "/tmp/firstmate-herdr-presentation-$uid" ] \
+    || fail "resolver must ignore the legacy shared path: $dir"
+  pass "herdr presentation lock namespace: ignores a foreign-owned legacy shared path"
+}
+
+test_presentation_lock_namespace_valid_rejects_symlink() {
+  local dir target link
+  dir="$TMP_ROOT/namespace-valid-symlink"; mkdir -p "$dir"
+  target="$dir/target"; mkdir -m 700 "$target"
+  link="$dir/link"; ln -s "$target" "$link"
+  if bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace_valid "$1"' "$ROOT" "$link"; then
+    fail "a symlinked namespace must not validate"
+  fi
+  pass "herdr presentation lock namespace: validation refuses a symlink"
+}
+
+test_presentation_lock_namespace_valid_rejects_wrong_mode() {
+  local dir target
+  dir="$TMP_ROOT/namespace-valid-wrong-mode"; mkdir -p "$dir"
+  target="$dir/target"; mkdir -m 755 "$target"
+  if bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace_valid "$1"' "$ROOT" "$target"; then
+    fail "a mode-755 namespace must not validate"
+  fi
+  pass "herdr presentation lock namespace: validation refuses a wrong-mode directory"
+}
+
+test_presentation_lock_namespace_valid_accepts_own_700() {
+  local dir target
+  dir="$TMP_ROOT/namespace-valid-ok"; mkdir -p "$dir"
+  target="$dir/target"; mkdir -m 700 "$target"
+  bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace_valid "$1"' "$ROOT" "$target" \
+    || fail "an own-uid mode-700 directory must validate"
+  pass "herdr presentation lock namespace: validation accepts an own-uid mode-700 directory"
 }
 
 test_presentation_session_lock_path_rejects_malformed_socket() {
@@ -4518,6 +4605,13 @@ test_projection_order_anchors_the_parent_by_exact_id
 test_projection_order_foreign_new_child_before_parent_is_read_only
 test_projection_order_missing_parent_is_read_only
 test_presentation_session_lock_path_is_shared_across_homes
+test_presentation_lock_namespace_prefers_xdg_runtime_dir
+test_presentation_lock_namespace_falls_back_without_xdg_runtime_dir
+test_presentation_lock_namespace_falls_back_on_unusable_xdg_runtime_dir
+test_presentation_lock_namespace_ignores_foreign_legacy_path
+test_presentation_lock_namespace_valid_rejects_symlink
+test_presentation_lock_namespace_valid_rejects_wrong_mode
+test_presentation_lock_namespace_valid_accepts_own_700
 test_presentation_session_lock_path_rejects_malformed_socket
 test_projection_order_rejects_malformed_socket
 test_projection_reclaim_refusal_matrix_is_non_mutating

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2518,14 +2518,10 @@ test_presentation_session_lock_path_is_shared_across_homes() {
   printf '%s\n' "{\"sessions\":[{\"name\":\"other\",\"running\":true,\"socket_path\":\"$dir/sockdir/other.sock\"}]}" > "$resp/3.out"
   : > "$dir/sockdir/other.sock"
   fb=$(make_herdr_fakebin "$dir")
-  # XDG_RUNTIME_DIR="" forces the deterministic per-uid /tmp fallback for this
-  # assertion regardless of the ambient test environment (fixture-set state
-  # persists per session/socket either way; see the XDG_RUNTIME_DIR-preferring
-  # and fallback tests below for the namespace choice itself).
-  path_a=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
+  path_a=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT") \
     || fail "session lock path resolution failed for home A"
-  path_b=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
+  path_b=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT") \
     || fail "session lock path resolution failed for home B"
   [ "$path_a" = "$path_b" ] || fail "same session/socket must resolve one shared lock path"
@@ -2536,7 +2532,7 @@ test_presentation_session_lock_path_is_shared_across_homes() {
   case "$path_a" in
     */state/*) fail "session lock path must not live under a home state directory: $path_a" ;;
   esac
-  path_other=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
+  path_other=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path other' "$ROOT") \
     || fail "session lock path resolution failed for a different session"
   [ "$path_other" != "$path_a" ] || fail "different sessions must not share one lock path"
@@ -2545,10 +2541,10 @@ test_presentation_session_lock_path_is_shared_across_homes() {
     : > /tmp/fm-herdr-lock-canon-$$.sock
     printf '%s\n' '{"sessions":[{"name":"canon","running":true,"socket_path":"/tmp/fm-herdr-lock-canon-'"$$"'.sock"}]}' > "$resp/4.out"
     printf '%s\n' "{\"sessions\":[{\"name\":\"canon\",\"running\":true,\"socket_path\":\"$(cd /tmp && pwd -P)/fm-herdr-lock-canon-$$.sock\"}]}" > "$resp/5.out"
-    path_tmp=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
+    path_tmp=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
       bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path canon' "$ROOT") \
       || fail "lock path with /tmp socket failed"
-    path_private=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" XDG_RUNTIME_DIR="" \
+    path_private=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
       bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path canon' "$ROOT") \
       || fail "lock path with canonical socket failed"
     rm -f /tmp/fm-herdr-lock-canon-$$.sock
@@ -2558,38 +2554,36 @@ test_presentation_session_lock_path_is_shared_across_homes() {
   pass "herdr presentation lock: one path per session/socket across homes"
 }
 
-test_presentation_lock_namespace_prefers_xdg_runtime_dir() {
-  local runtime_dir dir expected
-  runtime_dir="$TMP_ROOT/xdg-runtime"; mkdir -p "$runtime_dir"
-  expected="$runtime_dir/firstmate-herdr-presentation"
-  dir=$(XDG_RUNTIME_DIR="$runtime_dir" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
-    || fail "namespace resolution failed with a usable XDG_RUNTIME_DIR"
-  [ "$dir" = "$expected" ] || fail "expected $expected, got $dir"
-  pass "herdr presentation lock namespace: prefers a usable XDG_RUNTIME_DIR"
-}
-
-test_presentation_lock_namespace_falls_back_without_xdg_runtime_dir() {
+test_presentation_lock_namespace_is_deterministic_per_uid() {
   local dir uid expected
   uid=$(id -u) || fail "could not resolve current uid"
   expected="/tmp/firstmate-herdr-presentation-$uid"
-  dir=$(XDG_RUNTIME_DIR="" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
-    || fail "namespace resolution failed with no XDG_RUNTIME_DIR"
+  dir=$(bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
+    || fail "namespace resolution failed"
   [ "$dir" = "$expected" ] || fail "expected $expected, got $dir"
-  pass "herdr presentation lock namespace: falls back to a uid-suffixed /tmp path"
+  pass "herdr presentation lock namespace: resolves the deterministic uid-suffixed /tmp path"
 }
 
-test_presentation_lock_namespace_falls_back_on_unusable_xdg_runtime_dir() {
-  local dir uid expected missing
+test_presentation_lock_namespace_ignores_ambient_xdg_runtime_dir() {
+  local uid runtime_dir with_xdg without_xdg expected
   uid=$(id -u) || fail "could not resolve current uid"
   expected="/tmp/firstmate-herdr-presentation-$uid"
-  missing="$TMP_ROOT/xdg-runtime-does-not-exist"
-  dir=$(XDG_RUNTIME_DIR="$missing" \
+  runtime_dir="$TMP_ROOT/xdg-runtime-ambient"; mkdir -p "$runtime_dir"
+  # Two processes of the SAME user must resolve the identical namespace
+  # regardless of whether XDG_RUNTIME_DIR happens to be set in one of them
+  # (a systemd user session vs. a cron/sudo/detached invocation, say) -
+  # otherwise the two would split one user's own lock identity across two
+  # different directories and silently defeat the mutual exclusion the lock
+  # exists for.
+  with_xdg=$(XDG_RUNTIME_DIR="$runtime_dir" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
-    || fail "namespace resolution failed with a nonexistent XDG_RUNTIME_DIR"
-  [ "$dir" = "$expected" ] || fail "expected $expected, got $dir"
-  pass "herdr presentation lock namespace: falls back when XDG_RUNTIME_DIR is not usable"
+    || fail "namespace resolution failed with XDG_RUNTIME_DIR set"
+  without_xdg=$(bash -c 'unset XDG_RUNTIME_DIR; . "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
+    || fail "namespace resolution failed with XDG_RUNTIME_DIR unset"
+  [ "$with_xdg" = "$without_xdg" ] \
+    || fail "XDG_RUNTIME_DIR must not split one user's lock identity: $with_xdg vs $without_xdg"
+  [ "$with_xdg" = "$expected" ] || fail "expected $expected, got $with_xdg"
+  pass "herdr presentation lock namespace: ignores ambient XDG_RUNTIME_DIR, same uid always resolves the same path"
 }
 
 test_presentation_lock_namespace_ignores_foreign_legacy_path() {
@@ -2602,8 +2596,7 @@ test_presentation_lock_namespace_ignores_foreign_legacy_path() {
   # read, chowned, chmodded, or migrated; only assert the resolver's return
   # value ignores it, and never mutate a pre-existing entry this test did not
   # create itself.
-  dir=$(XDG_RUNTIME_DIR="" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT")
+  dir=$(bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT")
   if [ "$created" -eq 1 ]; then rmdir "$legacy" 2>/dev/null || true; fi
   [ "$dir" = "/tmp/firstmate-herdr-presentation-$uid" ] \
     || fail "resolver must ignore the legacy shared path: $dir"
@@ -4605,9 +4598,8 @@ test_projection_order_anchors_the_parent_by_exact_id
 test_projection_order_foreign_new_child_before_parent_is_read_only
 test_projection_order_missing_parent_is_read_only
 test_presentation_session_lock_path_is_shared_across_homes
-test_presentation_lock_namespace_prefers_xdg_runtime_dir
-test_presentation_lock_namespace_falls_back_without_xdg_runtime_dir
-test_presentation_lock_namespace_falls_back_on_unusable_xdg_runtime_dir
+test_presentation_lock_namespace_is_deterministic_per_uid
+test_presentation_lock_namespace_ignores_ambient_xdg_runtime_dir
 test_presentation_lock_namespace_ignores_foreign_legacy_path
 test_presentation_lock_namespace_valid_rejects_symlink
 test_presentation_lock_namespace_valid_rejects_wrong_mode


### PR DESCRIPTION
## Intent

Fix a multi-user collision in firstmate's herdr backend: fm_backend_herdr_presentation_lock_namespace() returned a fixed /tmp/firstmate-herdr-presentation path, so on a shared host whichever user's firstmate created it first owned it at mode 700 and every other user's fm_backend_herdr_presentation_lock_namespace_valid check then failed (owner != current uid), breaking herdr spawn/teardown for them - reproduced live on this box (dir owned by a different real user). Fix makes the namespace per-user: it always resolves the deterministic /tmp/firstmate-herdr-presentation-<uid> path. An earlier version of this fix preferred $XDG_RUNTIME_DIR when set and usable, falling back to the uid-suffixed /tmp path; upstream PR review (kunchenguid/firstmate#3404) found a real defect in that approach - two processes of the SAME user can see different XDG_RUNTIME_DIR values (a systemd user session vs. a cron/sudo/detached invocation, or two different session ids), which would split one user's own lock identity across two different directories and silently defeat the mutual exclusion the lock exists for. Per that review, the XDG_RUNTIME_DIR preference was dropped entirely - the namespace now always uses only the uid-suffixed /tmp path, with no other change to validation (directory mode 700, owned by the current uid, not a symlink) or to the single caller (fm_backend_herdr_presentation_session_lock_path). A foreign-owned legacy /tmp/firstmate-herdr-presentation (no uid suffix) is intentionally never read, chowned, chmodded, or migrated - it is simply no longer this function's return value. Tests extend the existing tests/fm-backend-herdr.test.sh (colocated, no new runner): coverage includes deterministic per-uid resolution, a same-uid two-environments consistency assertion proving XDG_RUNTIME_DIR cannot split identity, a simulated foreign-owned/wrong-mode legacy path being ignored, and validation still refusing a symlinked or wrong-mode namespace. This run exists to satisfy the repo's required no-mistakes-pipeline-attestation:v1 check on PR 3404 after the branch was originally pushed directly to the fork bypassing the gate; the code itself is already maintainer-approved on substance - do not change it unless a pipeline gate demands it.

## What Changed

- `fm_backend_herdr_presentation_lock_namespace()` now always resolves the deterministic uid-suffixed path `/tmp/firstmate-herdr-presentation-<uid>` (failing if the uid cannot be resolved) instead of the fixed shared `/tmp/firstmate-herdr-presentation`, which on a multi-user host was created mode-700 by whichever user got there first and made every other user's namespace-ownership validation fail, breaking their herdr spawn/teardown. `$XDG_RUNTIME_DIR` is deliberately not consulted — two processes of the same user can see different values (systemd user session vs. cron/sudo/detached invocation), which would split one user's lock identity across two directories and defeat the mutual exclusion. A foreign-owned legacy `/tmp/firstmate-herdr-presentation` is never read, chowned, chmodded, or migrated; validation (mode 700, owned by current uid, not a symlink) and the single caller are unchanged.
- Added six tests to `tests/fm-backend-herdr.test.sh` covering deterministic per-uid resolution, same-uid consistency with and without ambient `XDG_RUNTIME_DIR`, ignoring a wrong-mode legacy shared path, and validation rejecting symlinked or wrong-mode directories while accepting an own-uid mode-700 one; the existing session-lock-path test now asserts the per-user namespace.
- Updated `docs/herdr-backend.md` to describe the projection-ordering lock as per-user machine-private.

## Risk Assessment

✅ Low: Small, tightly-scoped fix that exactly matches the maintainer-approved intent: a pure string-construction change to one resolver with unchanged validation and caller, fail-closed behavior on every adversarial path traced (squat, symlink, concurrent mkdir), and behavioral (non-source-grep) test coverage for each required scenario.

## Testing

Ran the full colocated herdr adapter test file (187 ok, exit 0, all 6 new namespace tests green), proved the new per-uid assertion fails against the base-commit function (real regression coverage), and captured a live-host before/after transcript demonstrating the actual reported collision — foreign-owned legacy /tmp dir breaks lock-path resolution under base code, while target code deterministically resolves the uid-suffixed namespace regardless of XDG_RUNTIME_DIR and succeeds end-to-end without touching the foreign-owned legacy dir. No visual evidence applicable: the change is a shell library function with no rendered surface; CLI transcripts are the end-user-facing artifact.

<details>
<summary>Evidence: Live-host before/after demo transcript (collision reproduced, fix demonstrated end-to-end)</summary>

Source: [Live-host before/after demo transcript (collision reproduced, fix demonstrated end-to-end)](https://github.com/jknair/firstmate/blob/66d3f86ef9abbe44dec8de9c423c4a2a41407def/.no-mistakes/evidence/fm/fm-nsfix-02/live-host-before-after-demo.txt)

<code>=== 1. Live host state (the reported multi-user collision, reproduced) ===&#10;/tmp/firstmate-herdr-presentation owner=jknair-np(uid 1002) mode=700&#10;current user: jknair (uid 1001)&#10;&#10;=== 2. BASE commit (4ad8cba) behavior for uid 1001 ===&#10;namespace resolves to: /tmp/firstmate-herdr-presentation &lt;- fixed shared path, no uid suffix&#10;regression proof: new per-uid test assertion FAILS on base code (as it must)&#10;namespace_valid: REFUSED (owner uid 1002 != current uid 1001)&#10;session_lock_path: FAILED (rc=1) -&gt; herdr spawn/teardown BROKEN for this user&#10;&#10;=== 3. TARGET commit (c71a178) behavior for uid 1001 ===&#10;namespace resolves to: /tmp/firstmate-herdr-presentation-1001 &lt;- per-user, deterministic&#10;with XDG_RUNTIME_DIR set: /tmp/firstmate-herdr-presentation-1001 &lt;- identical, cannot split one user&#39;s lock identity&#10;session_lock_path: SUCCEEDED: /tmp/firstmate-herdr-presentation-1001/order-a2cd389e75cc52e48a055104c0831a7c.lock&#10;&#10;=== 4. Foreign-owned legacy dir untouched (never read/chown/chmod/migrated) ===&#10;/tmp/firstmate-herdr-presentation owner=jknair-np(uid 1002) mode=700 mtime=2026-08-31 15:50:20.680636566 +0000</code>

```text
=== 1. Live host state (the reported multi-user collision, reproduced) ===
/tmp/firstmate-herdr-presentation  owner=jknair-np(uid 1002)  mode=700
current user: jknair (uid 1001)

=== 2. BASE commit (4ad8cba) behavior for uid 1001 ===
namespace resolves to: /tmp/firstmate-herdr-presentation   <- fixed shared path, no uid suffix
regression proof: new per-uid test assertion FAILS on base code (as it must)
namespace_valid: REFUSED (owner uid 1002 != current uid 1001)
session_lock_path: FAILED (rc=1) -> herdr spawn/teardown BROKEN for this user

=== 3. TARGET commit (c71a178) behavior for uid 1001 ===
namespace resolves to: /tmp/firstmate-herdr-presentation-1001   <- per-user, deterministic
with XDG_RUNTIME_DIR set: /tmp/firstmate-herdr-presentation-1001   <- identical, cannot split one user's lock identity
session_lock_path: SUCCEEDED: /tmp/firstmate-herdr-presentation-1001/order-a2cd389e75cc52e48a055104c0831a7c.lock

=== 4. Foreign-owned legacy dir untouched (never read/chown/chmod/migrated) ===
/tmp/firstmate-herdr-presentation  owner=jknair-np(uid 1002)  mode=700  mtime=2026-08-31 15:50:20.680636566 +0000
```
</details>
<details>
<summary>Evidence: Full adapter test run log (187 ok, includes 6 new namespace tests)</summary>

Source: [Full adapter test run log (187 ok, includes 6 new namespace tests)](https://github.com/jknair/firstmate/blob/66d3f86ef9abbe44dec8de9c423c4a2a41407def/.no-mistakes/evidence/fm/fm-nsfix-02/fm-backend-herdr-test-run.txt)

```text
ok - fm_backend_herdr_version_check: accepts the current protocol (14)
ok - fm_backend_herdr_version_check: refuses an old protocol loudly
ok - fm_backend_herdr_version_check: refuses loudly when herdr is not installed
ok - fm_backend_herdr_workspace_label: a primary home (no marker) resolves to 'firstmate'
ok - fm_backend_herdr_workspace_label: a secondmate home (.fm-secondmate-home) resolves to '2ndmate-<id>'
ok - fm_backend_herdr_workspace_label: trims whitespace around the marker's secondmate id
ok - fm_backend_herdr_workspace_label: an empty marker file falls back to the primary label 'firstmate'
ok - fm_backend_herdr_workspace_label: two different secondmate homes get two different, non-colliding labels
ok - fm_backend_herdr_cli: sets HERDR_SESSION AND appends a trailing --session flag on every call
ok - fm_backend_herdr_launcher_identity: a firstmate not running inside herdr has no launcher workspace to inherit
ok - fm_backend_herdr_launcher_identity: HERDR_ENV=1 without a pane id selects the backend but binds no parent
ok - fm_backend_herdr_launcher_identity: resolves the launcher's exact workspace even when a same-labeled workspace sorts first
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane that names a different herdr session
ok - fm_backend_herdr_launcher_identity: refuses a claimed pane without exact server identity
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane whose injected socket belongs to another herdr server
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's own pane no longer resolves
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's pane and tab disagree about their workspace
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's workspace is gone from its own session
ok - fm_backend_herdr_workspace_ensure: places a worker in the launcher's exact workspace, not the first same-labeled one
ok - fm_backend_herdr_workspace_ensure: refuses to guess between two same-labeled home workspaces
ok - fm_backend_herdr_workspace_ensure: a --secondmate container resolves that home's own workspace, not the launcher's
ok - fm_backend_herdr_container_ensure: surfaces the exact ambiguous-placement refusal instead of a generic failure
ok - fm_backend_herdr_container_ensure: version-gates, starts the server, ensures the firstmate workspace, echoes session:workspace_id + the seeded default tab id
ok - fm_backend_herdr_container_ensure: reuses an existing firstmate workspace without recreating it, and reports no seeded default tab (adopted, not created)
ok - fm_backend_herdr_container_ensure: workspace create passes --no-focus
ok - fm_backend_herdr_container_ensure: creates the workspace under the SECONDMATE home's own label, not 'firstmate'
ok - fm_backend_herdr_create_task: prunes exactly the seeded default tab container_ensure identified, once the first real task tab exists
ok - herdr repeated spawn/teardown: one persistent firstmate workspace reused, zero orphans, default tab pruned, create ran once
ok - fm_backend_herdr_create_task: an ADOPTED workspace's pre-existing tab is never pruned (the created-vs-adopted gate)
ok - fm_backend_herdr_create_task: the label-collision startup-workspace scenario (2026-07-02 incident) leaves the captain's live tab untouched
ok - fm_backend_herdr_workspace_prune_seeded_default_tab: refuses to close the seeded default tab when its pane reports a working agent (defense in depth)
ok - fm_backend_herdr_create_task: refuses a duplicate tab label (herdr's own tab create has no uniqueness check)
ok - fm_backend_herdr_create_task: a same-labeled tab with a live (even idle) registered agent still refuses exactly as before
ok - fm_backend_herdr_create_task: scans every same-labeled tab and refuses if any duplicate is live
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is dead (pane_not_found)
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is alive but hosts no registered agent (a restored plain shell)
ok - fm_backend_herdr_create_task: closes every confirmed same-labeled husk only after creating the replacement
ok - fm_backend_herdr_create_task: refuses success when a preexisting husk tab remains after replacement
ok - fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently
ok - fm_backend_herdr_create_task: creates the replacement tab BEFORE closing the husk tab, never the reverse
ok - fm_backend_herdr_create_task: creates a tab and parses tab_id/pane_id from the JSON response, prunes nothing when no seeded tab id is given
ok - fm_backend_herdr_create_task: tab create passes --no-focus
ok - herdr presentation: a home that set nothing gets the projection by default at or above the floor
ok - herdr presentation: an unconfigured home below the floor falls back flat with one naming warning
ok - herdr presentation: an unreadable client release falls back flat instead of guessing
ok - herdr presentation: a deliberate opt-in is never silently downgraded below the floor
ok - herdr presentation: an explicit off opts the home out
ok - herdr presentation: an unrecognized value warns and follows the default instead of failing a spawn
ok - herdr presentation: the below-floor warning is one per home per release, not one per spawn
ok - herdr presentation: warning marker publication is atomic, symlink-safe, and fails visible
ok - herdr presentation: client and selected server floors compose conservatively without overriding explicit opt-in
ok - herdr presentation floor: every measured release, and each signal alone, classifies correctly
ok - herdr presentation floor: either signal alone can carry an above verdict, and each divergence is real
ok - herdr presentation: config parsing separates a deliberate choice from an unconfigured default
ok - herdr presentation journal: atomically publishes one non-authoritative 128-bit correlator and refuses overwrite
ok - herdr presentation journal: version 2 binds exact home/endpoint/parent identities and advances atomically
ok - herdr presentation create: exact response IDs yield one normal task pane with no workspace-close authority
ok - herdr presentation create: concurrent same-label tabs are never prune targets
ok - herdr presentation focus: snapshot requires one exact active workspace and tab
ok - herdr presentation focus: exact pane close restores the exact prior workspace and tab
ok - herdr presentation focus: cleanup refuses rather than close the captain's active tab
ok - herdr presentation focus: pane close fails when exact focus restoration fails
ok - herdr presentation reclaim: live agent state at the close boundary refuses mutation
ok - herdr presentation cleanup: emptying close behind focus ends the exact shell without a move or focus change
ok - herdr presentation cleanup: emptying close before focus moves the doomed workspace to the end and ends its exact shell
ok - herdr presentation cleanup: emptying close with the focused workspace last skips the move
ok - herdr presentation cleanup: emptying close of the last workspace skips the move
ok - herdr presentation cleanup: a non-emptying close stays plain with no proof, move, or signal
ok - herdr presentation cleanup: no-move plain close requires structured pane removal
ok - herdr presentation cleanup: an ambiguous workspace layout falls back to the plain close
ok - herdr presentation cleanup: a failed repositioning move falls back to the plain close with a warning
ok - herdr presentation cleanup: a pane with a live foreground process falls back to the plain close
ok - herdr presentation cleanup: a transient prompt helper settles into the pane-death path instead of the plain close
tests/fm-backend-herdr.test.sh: line 1838: 1645068 Killed                  bash -c 'trap "" HUP; sleep 300'
ok - herdr presentation cleanup: a SIGHUP-surviving shell is escalated to SIGKILL before giving up
tests/fm-backend-herdr.test.sh: line 1876: 1645548 Killed                  bash -c 'trap "" HUP; sleep 300'
ok - herdr presentation cleanup: a failed pane-death close falls back to the plain close
tests/fm-

... [4282 bytes truncated] ...

_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd
ok - fm_backend_herdr_busy_state: working -> busy
ok - fm_backend_herdr_busy_state: done -> idle, blocked -> idle (surfaced like a stale pane, not suppressed as busy)
ok - fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown, the regex-fallback cue
ok - fm_backend_herdr_composer_state: a bare '❯' composer row reads empty
ok - fm_backend_herdr_composer_state: bright placeholder-like text stays pending rather than being mistaken for an idle ghost
ok - fm_backend_herdr_composer_state: real composer text reads pending
ok - fm_backend_herdr_composer_state: a slash-command popup's argument-hint placeholder still reads pending (the incident fix)
ok - fm_backend_herdr_composer_state: reports unknown when the pane cannot be captured
ok - fm_backend_herdr_composer_state: reports unknown for bare shell prompts with no composer row
ok - fm_backend_herdr_composer_state: a blocked pi pane parked on a prompt is not an empty composer
ok - fm_backend_herdr_composer_state: a native idle Pi separator composer reads empty
ok - fm_backend_herdr_composer_state: real Pi composer text remains pending
ok - fm_backend_herdr_composer_state: an incomplete lower Pi separator cannot inherit a stale empty row
ok - fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯' prompt row (no border box in view) reads empty
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯ <text>' prompt row reads pending
ok - fm_backend_herdr_composer_state: a live unbordered prompt row below a stale bordered decorative box still wins (not misread as the box's own row)
ok - fm_backend_herdr_composer_state: claude's dim prompt-suggestion ghost (the overnight wedge shape) reads empty
ok - fm_backend_herdr_composer_state: real typed text on the same claude prompt row still reads pending
ok - fm_backend_herdr_composer_state: grok's dark-truecolor placeholder (the TRUECOLOR gap) reads empty
ok - fm_backend_herdr_composer_state: grok's real bright typed input still reads pending
ok - fm_backend_herdr_composer_state: a real-codex unbordered '›' prompt row reads empty
ok - fm_backend_herdr_composer_state: a faint real-codex ghost suggestion reads empty
ok - fm_backend_herdr_composer_state: non-faint codex prompt text still reads pending
ok - fm_backend_herdr_wait_for_working: reports 'busy' immediately on the first poll, without spending the rest of the budget
ok - fm_backend_herdr_wait_for_working: a slow transition landing on a later sample within one window is still caught (robust against the 'slow transition' failure direction)
ok - fm_backend_herdr_wait_for_working: spreads six samples across the full budget endpoint without a final trailing sleep
ok - fm_backend_herdr_send_text_submit: applies the herdr minimum confirmation budget before polling agent-state
ok - fm_backend_herdr_wait_for_working: reports 'idle' (readable, genuinely not yet working) when 'busy' never appears
ok - fm_backend_herdr_wait_for_working: reports 'unknown' (a hard read failure, not a timing race) only when EVERY poll in the window fails
ok - fm_backend_herdr_wait_for_working: treats blocked as submit-active for confirmation without changing watcher busy-state semantics
ok - fm_backend_herdr_send_text_submit: reports 'empty' once agent_status reports working after one Enter, without ever reading the composer
ok - fm_backend_herdr_send_text_submit: reports 'pending' when agent_status stays idle and the composer still holds unsent text after retried Enters (swallowed)
ok - fm_backend_herdr_send_text_submit: a slash-command popup's placeholder fill on Enter #1 never flips agent_status to working, so it does not short-circuit as submitted; Enter #2 is retried and lands it
ok - fm_backend_herdr_send_text_submit: a post-Enter blocked state confirms delivery without retrying into the prompt
ok - fm_backend_herdr_send_text_submit: native working + proven pending after retries reports empty (queued Enter)
ok - fm_backend_herdr_send_text_submit: a failed Enter cannot borrow preexisting working state as queued-delivery proof
ok - fm_backend_herdr_send_text_submit: a failed Enter cannot borrow a later native transition as delivery proof
ok - fm_backend_herdr_send_text_submit: idle native agent-state plus empty composer reports empty (landed Claude turn)
ok - fm_backend_herdr_send_text_submit: idle native baseline uses a rendered busy footer to confirm a queued Enter
ok - fm_backend_herdr_composer_state: cursor's mid-turn placeholder-plus-busy-token row reads pending (why delivery needs a separate signal)
ok - fm_backend_herdr_rendered_busy_state: busy/idle/unknown from the rendered footer, with an unreadable pane never reading idle
ok - fm_backend_herdr_send_text_submit: a rendered-footer idle-to-busy transition confirms delivery when native agent-state never reports idle
ok - fm_backend_herdr_send_text_submit: an already-busy footer baseline is never accepted as proof that this Enter landed
ok - fm_backend_herdr_send_text_submit: confirms submission via native agent-state alone, immune to a codex-style dynamic idle-tip composer that would have misread as 'pending' under the old composer-based confirmation
ok - fm_backend_herdr_composer_state: a faint real-codex dynamic idle-tip composer row reads empty
ok - fm_backend_composer_state (herdr): the pre-injection empty-box guard still refuses a genuinely non-empty composer, unaffected by the submit-confirmation change
ok - fm_backend_herdr_send_text_submit: a slow transition landing on a later sample within one Enter's budget is confirmed WITHOUT sending a needless extra Enter
ok - fm_backend_herdr_send_text_submit: reports 'send-failed' when the literal send-text call itself errors
ok - fm_backend_herdr_send_text_submit: reports 'unknown' when the post-Enter agent-get read fails (never retries past an unreadable target)
ok - fm_backend_herdr_send_text_submit: an unreadable composer stops Enter retries after native status stays idle
ok - fm_backend_validate: herdr is a known backend (P2)
ok - fm_backend_busy_state: tmux (no native primitive) always reports unknown, preserving the P1 regex-only path
error: unknown backend 'bogus' (known: tmux herdr zellij orca cmux)
ok - fm_backend_composer_state dispatches every backend to its named thin classifier, unknown for unrecognized backends
ok - fm-peek/fm-send: explicit stale targets matching metadata use the recorded backend
ok - fm_backend_herdr_normalize_event routes through the shared record with an empty from_status
ok - fm_backend_herdr_escalation_marker keys the dedupe marker exactly like the watcher's .stale-<key>
ok - fm_backend_herdr_apply_transition: blocked dedupe starts only after explicit commit
ok - fm_backend_herdr_apply_transition: a working edge clears the marker so the next ->blocked re-escalates
ok - fm_backend_herdr_clear_transition removes task-owned dedupe state
ok - fm_backend_herdr_apply_transition: idle/done (defer) and unknown/empty (fallback) take no fast action
ok - fm_backend_herdr_wait_transition: a home with no herdr panes falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: below-capability protocol/schema falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: reconnect level-reconcile returns an uncommitted blocked pane
ok - fm_backend_herdr_wait_transition: subscribes before reconnect level-reconcile
ok - fm_backend_herdr_wait_transition: a still-blocked, already-escalated pane is not re-delivered on reconnect
ok - fm_backend_herdr_wait_transition: a streamed ->blocked edge returns the record sub-poll
ok - fm_backend_herdr_wait_transition: streamed working clears the marker, idle/done are deferred (clean timeout)
ok - fm_backend_herdr_wait_transition: a reader/subscribe failure falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: Bash 3.2-safe bad-ack path closes fd 9 and removes its FIFO
ok - fm_backend_herdr_wait_transition: stock macOS Bash clean timeout closes fd 9 and returns 1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"556ba33fbce0426166ae7debed5a9bdda3e22028","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/backends/herdr.sh:674` - Residual deliberate-DoS remains by design: another local user can pre-create /tmp/firstmate-herdr-presentation-&lt;victim-uid&gt; in world-writable /tmp, making the victim&#39;s mkdir fail and fm_backend_herdr_presentation_lock_namespace_valid reject (owner != uid). The code fails closed — fm_backend_herdr_kill (line 2950) refuses an unlocked pane close rather than using the foreign dir — and the only structural alternative (XDG_RUNTIME_DIR) was explicitly rejected in upstream PR review for splitting same-user lock identity. Accidental collision (the reported bug) is fixed; only intentional squatting remains, and it degrades safely. No action needed; noting the accepted tradeoff.
- ℹ️ `tests/fm-backend-herdr.test.sh:2588` - test_presentation_lock_namespace_ignores_foreign_legacy_path conditionally touches the real /tmp/firstmate-herdr-presentation, and test_presentation_session_lock_path_is_shared_across_homes (via the production lock-path function) creates the real per-uid namespace dir in live /tmp outside TMP_ROOT. Both are safe as written: the legacy test creates only if absent, removes via rmdir only what it created, and never mutates a pre-existing entry; the namespace-dir side effect is the production dir at correct mode/owner and is a pre-existing test pattern (the old fixed path had the same behavior), not introduced by this change. Unavoidable given the hardcoded absolute path is the behavior under test.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-backend-herdr.test.sh` — full colocated adapter test file: 187 ok, 0 failures, exit 0; includes all 6 new namespace tests (deterministic per-uid resolution, same-uid XDG_RUNTIME_DIR consistency, foreign/wrong-mode legacy path ignored, symlink refused, wrong-mode refused, own-uid 700 accepted) and the updated `test_presentation_session_lock_path_is_shared_across_homes` asserting the per-uid path</code>
- <code>Regression proof: extracted base-commit (4ad8cba) `bin/backends/herdr.sh` plus its sourced sibling libs into a temp tree and ran the new per-uid assertion against it — fails on base (returns fixed `/tmp/firstmate-herdr-presentation`), passes on target</code>
- <code>Live-host end-to-end demo (read-only against live /tmp state): confirmed legacy `/tmp/firstmate-herdr-presentation` is genuinely owned by foreign user jknair-np (uid 1002) mode 700; base `fm_backend_herdr_presentation_session_lock_path` fails (rc=1, namespace_valid refuses foreign owner — the reported spawn/teardown breakage); target code resolves `/tmp/firstmate-herdr-presentation-1001`, returns identical namespace with and without XDG_RUNTIME_DIR set, and succeeds end-to-end returning a usable per-uid lock path</code>
- <code>Verified foreign-owned legacy dir never mutated: mtime byte-identical before and after all testing; `git status --porcelain` clean; demo temp tree removed</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: lint clean with pinned ShellCheck 0.11.0 and actionlint 1.7.12
1 warning still open:

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
