### PR TITLE
fix(bin): validate composite orca_worktree_id shape instead of atom class

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -383,6 +383,22 @@ fm_backend_endpoint_atom_valid() {  # <value>
   esac
 }
 
+# Orca worktree ids are composite: <repo-uuid>::<absolute worktree path>.
+# The left side is an ordinary endpoint atom; the right side is a filesystem
+# path, so it is validated as one (absolute, no shell metacharacters) rather
+# than with the atom class that would reject every legal '/'.
+fm_backend_orca_worktree_id_valid() {  # <value>
+  local repo=${1%%::*} path=${1#*::}
+  [ "$repo" != "$1" ] || return 1
+  fm_backend_endpoint_atom_valid "$repo" || return 1
+  case "$path" in
+    ''|[!/]*) return 1 ;;
+  esac
+  case "${path// /_}" in
+    *[!A-Za-z0-9._@%+/-]*) return 1 ;;
+  esac
+}
+
 fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
   local meta=$1 id=$2 backend_count backend window worktree project binding_count binding
   local session pane recorded_session workspace tab terminal worktree_id surface
@@ -503,7 +519,7 @@ fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
       }
       if [ "$window" != "fm-$id" ] \
         || ! fm_backend_endpoint_atom_valid "$terminal" \
-        || ! fm_backend_endpoint_atom_valid "$worktree_id"; then
+        || ! fm_backend_orca_worktree_id_valid "$worktree_id"; then
         echo "REFUSED: Orca endpoint metadata for task $id is malformed or inconsistent; preserving task state." >&2
         return 1
       fi

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -385,8 +385,9 @@ fm_backend_endpoint_atom_valid() {  # <value>
 
 # Orca worktree ids are composite: <repo-uuid>::<absolute worktree path>.
 # The left side is an ordinary endpoint atom; the right side is a filesystem
-# path, so it is validated as one (absolute, no shell metacharacters) rather
-# than with the atom class that would reject every legal '/'.
+# path, so it is validated as one (absolute, no control characters or shell
+# metacharacters) rather than with the atom class that would reject every
+# legal path character, e.g. an apostrophe in a username directory.
 fm_backend_orca_worktree_id_valid() {  # <value>
   local repo=${1%%::*} path=${1#*::}
   [ "$repo" != "$1" ] || return 1
@@ -394,8 +395,11 @@ fm_backend_orca_worktree_id_valid() {  # <value>
   case "$path" in
     ''|[!/]*) return 1 ;;
   esac
-  case "${path// /_}" in
-    *[!A-Za-z0-9._@%+/-]*) return 1 ;;
+  case "$path" in
+    *[[:cntrl:]]*) return 1 ;;
+  esac
+  case "$path" in
+    *[\`\$\;\&\|\<\>\"\\]*) return 1 ;;
   esac
 }
 

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -812,7 +812,7 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-teardown" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-teardown" \
+    "backend=orca" "orca_worktree_id=wt-teardown::$wt" \
     "decisions_reviewed=1" "decision_keys="
   orca_case teardown
   printf '{"ok":true,"result":{"worktree":{"id":"wt-teardown","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
@@ -826,7 +826,7 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
   expect_code 0 "$rc" "Orca scout teardown should succeed once report exists"$'\n'"$out"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-teardown'$'\x1f''--json' \
     "teardown did not close the recorded Orca terminal"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-teardown'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:wt-teardown::$wt"$'\x1f''--force'$'\x1f''--json' \
     "teardown did not remove the Orca worktree through orca worktree rm"
   assert_absent "$state/$id.meta" "teardown should remove task metadata"
   pass "fm-teardown.sh backend=orca: scout report gate then helper-backed worktree removal"
@@ -849,7 +849,7 @@ test_scout_teardown_refuses_orca_id_path_mismatch() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-scout-mismatch" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-scout-mismatch" \
+    "backend=orca" "orca_worktree_id=wt-scout-mismatch::$wt" \
     "decisions_reviewed=1" "decision_keys="
   orca_case scout-mismatch
   printf '{"ok":true,"result":{"worktree":{"id":"wt-scout-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
@@ -885,7 +885,7 @@ test_teardown_removes_orca_worktree_when_path_missing() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-missing-path" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-missing-path" \
+    "backend=orca" "orca_worktree_id=wt-missing-path::$wt" \
     "decisions_reviewed=1" "decision_keys="
   orca_case missing-path
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -898,7 +898,7 @@ test_teardown_removes_orca_worktree_when_path_missing() {
   expect_code 0 "$rc" "Orca teardown should release helpers even when the path is absent"$'\n'"$out"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-missing-path'$'\x1f''--json' \
     "teardown did not close the recorded Orca terminal when the path was absent"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-missing-path'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:wt-missing-path::$wt"$'\x1f''--force'$'\x1f''--json' \
     "teardown did not remove the recorded Orca worktree when the path was absent"
   assert_absent "$state/$id.meta" "successful helper cleanup should remove task metadata"
   pass "fm-teardown.sh backend=orca: releases terminal/worktree when path is absent"
@@ -918,7 +918,7 @@ test_teardown_preserves_metadata_when_orca_remove_error_json() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-remove-error" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-remove-error" \
+    "backend=orca" "orca_worktree_id=wt-remove-error::$wt" \
     "decisions_reviewed=1" "decision_keys="
   orca_case remove-error-teardown
   printf '{"ok":true,"result":{}}\n' > "$RESP/1.out"
@@ -949,7 +949,7 @@ test_scout_teardown_refuses_orca_missing_report_when_path_missing() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-missing-report" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-missing-report"
+    "backend=orca" "orca_worktree_id=wt-missing-report::$wt"
   orca_case missing-report
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
@@ -979,7 +979,7 @@ test_ship_teardown_refuses_orca_missing_worktree_path() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-missing-ship" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-missing-ship"
+    "backend=orca" "orca_worktree_id=wt-missing-ship::$wt"
   orca_case missing-ship-path
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
@@ -1010,7 +1010,7 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-match" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-match"
+    "backend=orca" "orca_worktree_id=wt-ship-match::$wt"
   orca_case ship-match
   printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-match","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -1021,11 +1021,11 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
   rc=$?
   set -e
   expect_code 0 "$rc" "Orca ship teardown should succeed when the id path matches the inspected worktree"$'\n'"$out"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-match'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f'"id:wt-ship-match::$wt"$'\x1f''--json' \
     "teardown did not resolve the Orca worktree id before removal"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-ship-match'$'\x1f''--json' \
     "teardown did not close the matched Orca terminal"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-ship-match'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:wt-ship-match::$wt"$'\x1f''--force'$'\x1f''--json' \
     "teardown did not remove the matched Orca worktree"
   assert_absent "$state/$id.meta" "successful matched teardown should remove task metadata"
   pass "fm-teardown.sh backend=orca: ship teardown requires a matching Orca id path"
@@ -1045,7 +1045,7 @@ test_ship_teardown_refuses_orca_unresolvable_worktree_id() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-unresolved" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-unresolved"
+    "backend=orca" "orca_worktree_id=wt-ship-unresolved::$wt"
   orca_case ship-unresolved
   printf '1\n' > "$RESP/1.exit"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -1056,9 +1056,9 @@ test_ship_teardown_refuses_orca_unresolvable_worktree_id() {
   rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "Orca ship teardown should refuse when the worktree id cannot be resolved"
-  assert_contains "$out" "cannot resolve Orca worktree id wt-ship-unresolved" \
+  assert_contains "$out" "cannot resolve Orca worktree id wt-ship-unresolved::$wt" \
     "unresolvable Orca worktree id refusal should explain the fail-closed check"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-unresolved'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f'"id:wt-ship-unresolved::$wt"$'\x1f''--json' \
     "teardown did not attempt to resolve the Orca worktree id"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
     "refused unresolved Orca ship teardown should not close terminals"
@@ -1084,7 +1084,7 @@ test_ship_teardown_refuses_orca_id_path_mismatch() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-mismatch" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-mismatch"
+    "backend=orca" "orca_worktree_id=wt-ship-mismatch::$wt"
   orca_case ship-mismatch
   printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -1097,7 +1097,7 @@ test_ship_teardown_refuses_orca_id_path_mismatch() {
   [ "$rc" -ne 0 ] || fail "Orca ship teardown should refuse when the id path differs from worktree="
   assert_contains "$out" "not inspected worktree" \
     "mismatched Orca worktree path refusal should name the mismatch"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-mismatch'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f'"id:wt-ship-mismatch::$wt"$'\x1f''--json' \
     "teardown did not resolve the mismatched Orca worktree id"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
     "refused mismatched Orca ship teardown should not close terminals"
@@ -1153,7 +1153,7 @@ test_teardown_refuses_orca_worktree_without_terminal_handle() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-no-terminal" \
+    "backend=orca" "orca_worktree_id=wt-no-terminal::$wt" \
     "decisions_reviewed=1" "decision_keys="
   orca_case no-terminal
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -1190,7 +1190,7 @@ test_secondmate_force_teardown_removes_orca_child_via_orca() {
     "window=fm-$child_id" "endpoint_task_id=$child_id" \
     "terminal=term-child-cleanup" "worktree=$childwt" "project=$childproj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-child-cleanup"
+    "backend=orca" "orca_worktree_id=wt-child-cleanup::$childwt"
   orca_case secondmate-child-cleanup
   printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/1.out"
   printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/2.out"
@@ -1206,7 +1206,7 @@ test_secondmate_force_teardown_removes_orca_child_via_orca() {
   expect_code 0 "$rc" "forced secondmate teardown should remove Orca child work through Orca"$'\n'"$out"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-child-cleanup'$'\x1f''--json' \
     "child cleanup did not close the recorded Orca terminal"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-child-cleanup'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:wt-child-cleanup::$childwt"$'\x1f''--force'$'\x1f''--json' \
     "child cleanup did not remove the Orca worktree through orca worktree rm"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f'"fm-$child_id" \
     "child cleanup closed the stable alias instead of the Orca terminal"
@@ -1236,7 +1236,7 @@ test_secondmate_force_teardown_refuses_orca_child_id_path_mismatch() {
     "window=fm-$child_id" "endpoint_task_id=$child_id" \
     "terminal=term-child-mismatch" "worktree=$childwt" "project=$childproj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-child-mismatch"
+    "backend=orca" "orca_worktree_id=wt-child-mismatch::$childwt"
   orca_case secondmate-child-mismatch
   printf '{"ok":true,"result":{"worktree":{"id":"wt-child-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
   add_tmux_fake "$FB"
@@ -1277,7 +1277,7 @@ test_secondmate_force_teardown_refuses_partial_orca_child() {
     "window=fm-$child_id" "endpoint_task_id=$child_id" \
     "worktree=$childwt" "project=$childproj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-partial-child"
+    "backend=orca" "orca_worktree_id=wt-partial-child::$childwt"
   orca_case secondmate-partial-child-cleanup
   add_tmux_fake "$FB"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -392,7 +392,7 @@ test_orca_refuses_an_escape_harness_interrupt() {
   {
     cat "$dir/home/state/t1.meta"
     echo "terminal=term-1"
-    echo "orca_worktree_id=wt-1"
+    echo "orca_worktree_id=wt-1::$dir/worktree"
   } > "$dir/home/state/t1.meta.new"
   sed 's|^window=.*|window=fm-t1|' "$dir/home/state/t1.meta.new" > "$dir/home/state/t1.meta"
   out=$(run_control "$dir" t1 interrupt); rc=$?

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -222,10 +222,11 @@ test_supported_backend_endpoint_records_validate() {
 
   id=orca-task
   fm_write_meta "$dir/home/state/$id.meta" \
-    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
-    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" "orca_worktree_id=worktree-9"
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term_6f0b2c1e-9a4d-4f7e-8b2a-1c3d5e7f9a0b" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=6f0b2c1e-9a4d-4f7e-8b2a-1c3d5e7f9a0b::$dir/worktree"
   fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" || fail "valid Orca endpoint refused"
-  [ "$FM_BACKEND_VALIDATED_TARGET" = term-7 ] || fail "Orca validation did not select its terminal"
+  [ "$FM_BACKEND_VALIDATED_TARGET" = term_6f0b2c1e-9a4d-4f7e-8b2a-1c3d5e7f9a0b ] || fail "Orca validation did not select its terminal"
 
   id=cmux-task
   fm_write_meta "$dir/home/state/$id.meta" \
@@ -241,6 +242,45 @@ test_supported_backend_endpoint_records_validate() {
     [ "$target" -ne 0 ] || fail "$backend generic kill accepted an empty target"
   done
   pass "cleanup identity: valid tmux, Herdr, Zellij, Orca, and cmux records validate while every empty backend target refuses"
+}
+
+test_orca_composite_worktree_id_shapes() {
+  local dir id=orca-shape bad
+  dir=$(make_case orca-composite-shapes)
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-backend.sh"
+
+  write_orca_meta() {  # <worktree-id>
+    fm_write_meta "$dir/home/state/$id.meta" \
+      "window=fm-$id" "endpoint_task_id=$id" "terminal=term_9b1d" \
+      "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+      "orca_worktree_id=$1"
+  }
+
+  write_orca_meta "6f0b2c1e-9a4d-4f7e-8b2a-1c3d5e7f9a0b::$dir/worktree"
+  fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" \
+    || fail "composite Orca worktree id (uuid::absolute-path) refused"
+
+  write_orca_meta "6f0b2c1e-9a4d-4f7e-8b2a-1c3d5e7f9a0b::/path/with spaces/worktree"
+  fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" \
+    || fail "composite Orca worktree id with a spaced path refused"
+
+  # shellcheck disable=SC2016 # The injection shapes must stay unexpanded literals.
+  for bad in \
+    "worktree-9" \
+    "::$dir/worktree" \
+    "6f0b2c1e-9a4d-4f7e-8b2a-1c3d5e7f9a0b::" \
+    "6f0b2c1e-9a4d-4f7e-8b2a-1c3d5e7f9a0b::relative/worktree" \
+    "6f0b2c1e-9a4d-4f7e-8b2a-1c3d5e7f9a0b::/tmp/x;rm -rf /" \
+    '6f0b2c1e-9a4d-4f7e-8b2a-1c3d5e7f9a0b::/tmp/$(evil)' \
+    '6f0b2c1e-9a4d-4f7e-8b2a-1c3d5e7f9a0b::/tmp/`evil`' \
+    "bad:uuid::$dir/worktree"; do
+    write_orca_meta "$bad"
+    if fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" 2>/dev/null; then
+      fail "malformed Orca worktree id accepted: $bad"
+    fi
+  done
+  pass "cleanup identity: Orca composite worktree ids require uuid::absolute-path and refuse injection shapes"
 }
 
 test_tmux_empty_target_refuses_without_invocation() {
@@ -369,6 +409,7 @@ test_invalid_endpoint_records_refuse_before_mutation
 test_control_lock_contention_refuses_before_mutation
 test_metadata_lock_serializes_destructive_cleanup
 test_supported_backend_endpoint_records_validate
+test_orca_composite_worktree_id_shapes
 test_tmux_empty_target_refuses_without_invocation
 test_recorded_process_identity_cleanup_is_exact
 test_isolated_tmux_invalid_and_valid_cleanup

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -265,6 +265,14 @@ test_orca_composite_worktree_id_shapes() {
   fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" \
     || fail "composite Orca worktree id with a spaced path refused"
 
+  write_orca_meta "6f0b2c1e-9a4d-4f7e-8b2a-1c3d5e7f9a0b::/Users/O'Brien/worktree"
+  fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" \
+    || fail "composite Orca worktree id with an apostrophe in the path refused"
+
+  write_orca_meta "6f0b2c1e-9a4d-4f7e-8b2a-1c3d5e7f9a0b::/Users/café/wörktree"
+  fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" \
+    || fail "composite Orca worktree id with a unicode path refused"
+
   # shellcheck disable=SC2016 # The injection shapes must stay unexpanded literals.
   for bad in \
     "worktree-9" \


### PR DESCRIPTION
## Intent

Fix a fleet-blocking validation bug in the firstmate repo: fm_backend_validate_task_endpoint in bin/fm-backend.sh refused every well-formed Orca-backed task. bin/fm-spawn.sh records orca_worktree_id with Orca's native worktree identity, a composite <repo-uuid>::<absolute-path> (confirmed live from orca worktree list; bin/backends/orca.sh passes the composite verbatim to orca worktree rm --worktree id:...). The orca branch of fm_backend_validate_task_endpoint ran fm_backend_endpoint_atom_valid on that whole recorded value, and the atom character class [A-Za-z0-9._@%+-] rejects ':' and '/', so validation always failed and fm-control exit/relaunch and fm-teardown were refused for every Orca task while spawn and supervision worked. Required fix, as specified: make the orca branch validate the composite shape properly - split on the first '::', require an atom-valid left id (the existing atom class is right for it) and a non-empty absolute path right side validated with a path-appropriate check (NOT the atom class) that still rejects shell metacharacters and injection shapes; keep genuinely malformed values (empty parts, no '::', relative path) refused loudly. Audit other consumers of orca_worktree_id for the same mistaken atom check and fix only where the same bug exists (audit result: the atom check on orca_worktree_id existed only at the one site in fm-backend.sh; all other consumers pass the composite through, so no other code change was needed - do not refactor beyond the defect). Add/extend colocated tests under tests/ covering: a valid composite passes; missing '::', empty uuid, empty/relative path, and injection-shaped values are refused; and tmux/herdr task validation behavior is unchanged. Do not change the recorded metadata format itself - existing task records in live homes must keep validating. Deliberate test changes: fabricated plain-atom orca_worktree_id values in existing tests (tests/fm-backend-orca.test.sh, tests/fm-control.test.sh, tests/fm-teardown-endpoint-safety.test.sh) were converted to realistic uuid::absolute-path composites, including the matching stubbed orca-CLI command assertions, because the new shape check deliberately refuses ::-less values; a new test test_orca_composite_worktree_id_shapes was added to tests/fm-teardown-endpoint-safety.test.sh; an SC2016 shellcheck disable comment there is deliberate because the injection-shape test literals must stay unexpanded. Acceptance: fm_backend_validate_task_endpoint accepts a real Orca task meta (window=fm-<id>, terminal=term_<uuid>, orca_worktree_id=<uuid>::<abs path>) and still refuses malformed ones; existing suite passes; bin scripts shellcheck-clean; no behavior change for non-Orca backends. Repo style: one sentence per line in docs, shellcheck-clean bin scripts, colocated tests, no agent co-author on commits.

## What Changed

- Added `fm_backend_orca_worktree_id_valid` in `bin/fm-backend.sh`, which splits `orca_worktree_id` on the first `::`, validates the left side (repo id) with the existing endpoint-atom check, and validates the right side (absolute worktree path) with a path-appropriate check that requires a leading `/` and rejects control characters and shell metacharacters.
- Updated the Orca branch of `fm_backend_validate_task_endpoint` to call the new composite check instead of running the plain atom check against the whole `orca_worktree_id` value, which previously rejected every well-formed `<repo-uuid>::<absolute-path>` id.
- Updated `tests/fm-backend-orca.test.sh`, `tests/fm-control.test.sh`, and `tests/fm-teardown-endpoint-safety.test.sh` to use realistic `uuid::absolute-path` composite ids (and matching stubbed orca-CLI assertions), and added `test_orca_composite_worktree_id_shapes` covering acceptance of valid composites (including spaced/unicode paths) and refusal of missing `::`, empty uuid/path, relative paths, and shell-injection-shaped values.

## Risk Assessment

✅ Low: The change is a small, precisely-scoped fix that exactly implements the previously-authorized shape check (split on first '::', atom-validate the uuid, reject only genuinely dangerous path characters); tracing the new fm_backend_orca_worktree_id_valid logic against real composite ids, apostrophe/unicode/space paths, and each injection-shaped test case confirms correct accept/reject behavior, the audit of other orca_worktree_id consumers found no other atom-check sites to fix, and colocated tests were extended consistently with realistic composite values.

## Testing

All three targeted test files pass end-to-end against the target commit, including the newly added test_orca_composite_worktree_id_shapes which directly proves the fix (accepts realistic uuid::/abs/path Orca metadata with apostrophe/unicode/space paths per the round-1 review decision, refuses malformed/injection-shaped composites), with fm-backend-orca and fm-control suites confirming no regression elsewhere; no findings.

<details>
<summary>Evidence: fm-teardown-endpoint-safety.test.sh (includes new test_orca_composite_worktree_id_shapes)</summary>

```text
ok - cleanup identity: valid tmux, Herdr, Zellij, Orca, and cmux records validate while every empty backend target refuses
ok - cleanup identity: Orca composite worktree ids require uuid::absolute-path and refuse injection shapes
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"69b6fa0bc798514c18412a5b33e37a2328cf7295","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"skipped"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-teardown-endpoint-safety.test.sh`
- `bash tests/fm-backend-orca.test.sh`
- `bash tests/fm-control.test.sh`
- `grep audit confirming fm_backend_endpoint_atom_valid on orca_worktree_id only existed at the one fixed call site in bin/fm-backend.sh`
- `git status --porcelain (clean worktree, no stray artifacts)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
