### PR TITLE
fix(bin): pass unbounded snapshot documents to jq through files, not argv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,8 +377,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 18 ] || {
-            echo "::error::expected 18 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 19 ] || {
+            echo "::error::expected 19 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,16 +377,16 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 18 ] || {
+            echo "::error::expected 18 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 42 ] || {
-            echo "::error::expected 42 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 43 ] || {
+            echo "::error::expected 43 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -262,11 +262,13 @@ EOF
       # Candidate PR rows grow with the fleet's open PRs, so the accumulator
       # and the projection below hand jq slurped files instead of argv entries:
       # a SINGLE argv entry is capped at MAX_ARG_STRLEN (128 KiB) independently
-      # of the far larger ARG_MAX, and exec fails with E2BIG past it. An empty
-      # document is refused rather than folded away, matching --argjson.
+      # of the far larger ARG_MAX, and exec fails with E2BIG past it. Exactly
+      # one document is required, so an empty or multi-value stream is refused
+      # rather than folded away, matching --argjson.
       rows=$(jq -n --slurpfile a <(printf '%s' "$rows") --slurpfile b <(printf '%s' "$repo_rows") \
         'if (($a | length) == 1) and (($b | length) == 1) then $a[0] + $b[0]
-         else error("fm-bearings-snapshot: empty candidate PR row document") end')
+         else error("fm-bearings-snapshot: expected exactly one JSON document for each candidate PR row set, got "
+                    + ($a | length | tostring) + " and " + ($b | length | tostring)) end')
     done
     PR_REPOS_SHOWN=$nrepos
     PR_ROWS_CAPPED=$ncapped
@@ -328,7 +330,8 @@ MODEL=$(printf '%s' "$SNAP" | jq \
        | select(length > $i)
        | .[$i]][:$n];
   ($candidate_prs | if length == 1 then .[0]
-   else error("fm-bearings-snapshot: empty candidate PR document") end) as $candidate_prs
+   else error("fm-bearings-snapshot: expected exactly one JSON document for $candidate_prs, got "
+              + (length | tostring)) end) as $candidate_prs
   | ($fields | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != ""))) as $fl
   | (($fl | index("bodies")) != null) as $f_bodies
   | (($fl | index("paths")) != null) as $f_paths

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -99,6 +99,18 @@ validate_bound FM_BEARINGS_UNHEALTHY "$FM_BEARINGS_UNHEALTHY"
 validate_bound FM_BEARINGS_PR_REPOS "$FM_BEARINGS_PR_REPOS"
 validate_bound FM_BEARINGS_PR_LIMIT "$FM_BEARINGS_PR_LIMIT"
 
+# Candidate PR rows grow with the fleet's open PRs, so every value that can grow
+# without limit reaches jq through a file rather than an argv entry: a SINGLE
+# argv entry is capped at MAX_ARG_STRLEN (128 KiB) independently of the far
+# larger ARG_MAX, and exec fails with E2BIG past it.
+# Filters unwrap a slurped document with `doc($x; "x")`, which accepts exactly
+# one document the way --argjson accepts exactly one JSON value: a producer that
+# returned nothing, or that emitted a concatenated multi-value stream, fails
+# closed instead of binding null or silently binding the first value and
+# discarding the rest.
+# shellcheck disable=SC2016 # jq filter text: $d and $name are jq variables.
+JQ_DOC='def doc($d; $name): if ($d | length) != 1 then error("fm-bearings-snapshot: expected exactly one JSON document for $" + $name + ", got " + ($d | length | tostring)) else $d[0] end;'
+
 usage() {
   cat <<'EOF'
 usage: fm-bearings-snapshot.sh [--json] [--include-prs] [--fields <list>]
@@ -259,16 +271,8 @@ EOF
       cnt=$(printf '%s' "$repo_rows" | jq 'length')
       [ "$returned" -gt "$FM_BEARINGS_PR_LIMIT" ] && ncapped=$((ncapped + 1))
       npr=$((npr + cnt))
-      # Candidate PR rows grow with the fleet's open PRs, so the accumulator
-      # and the projection below hand jq slurped files instead of argv entries:
-      # a SINGLE argv entry is capped at MAX_ARG_STRLEN (128 KiB) independently
-      # of the far larger ARG_MAX, and exec fails with E2BIG past it. Exactly
-      # one document is required, so an empty or multi-value stream is refused
-      # rather than folded away, matching --argjson.
       rows=$(jq -n --slurpfile a <(printf '%s' "$rows") --slurpfile b <(printf '%s' "$repo_rows") \
-        'if (($a | length) == 1) and (($b | length) == 1) then $a[0] + $b[0]
-         else error("fm-bearings-snapshot: expected exactly one JSON document for each candidate PR row set, got "
-                    + ($a | length | tostring) + " and " + ($b | length | tostring)) end')
+        "$JQ_DOC"'doc($a; "a") + doc($b; "b")')
     done
     PR_REPOS_SHOWN=$nrepos
     PR_ROWS_CAPPED=$ncapped
@@ -320,7 +324,8 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson pr_repos_shown "$PR_REPOS_SHOWN" \
   --argjson pr_rows_capped "$PR_ROWS_CAPPED" \
   --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" \
-  --slurpfile candidate_prs <(printf '%s' "$CANDIDATE_PRS") '
+  --slurpfile candidate_prs <(printf '%s' "$CANDIDATE_PRS") \
+  "$JQ_DOC"'
   def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
   def round_robin_landed($n):
@@ -329,9 +334,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
        | $groups[]
        | select(length > $i)
        | .[$i]][:$n];
-  ($candidate_prs | if length == 1 then .[0]
-   else error("fm-bearings-snapshot: expected exactly one JSON document for $candidate_prs, got "
-              + (length | tostring)) end) as $candidate_prs
+  doc($candidate_prs; "candidate_prs") as $candidate_prs
   | ($fields | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != ""))) as $fl
   | (($fl | index("bodies")) != null) as $f_bodies
   | (($fl | index("paths")) != null) as $f_paths

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -259,7 +259,14 @@ EOF
       cnt=$(printf '%s' "$repo_rows" | jq 'length')
       [ "$returned" -gt "$FM_BEARINGS_PR_LIMIT" ] && ncapped=$((ncapped + 1))
       npr=$((npr + cnt))
-      rows=$(jq -n --argjson a "$rows" --argjson b "$repo_rows" '$a + $b')
+      # Candidate PR rows grow with the fleet's open PRs, so the accumulator
+      # and the projection below hand jq slurped files instead of argv entries:
+      # a SINGLE argv entry is capped at MAX_ARG_STRLEN (128 KiB) independently
+      # of the far larger ARG_MAX, and exec fails with E2BIG past it. An empty
+      # document is refused rather than folded away, matching --argjson.
+      rows=$(jq -n --slurpfile a <(printf '%s' "$rows") --slurpfile b <(printf '%s' "$repo_rows") \
+        'if (($a | length) == 1) and (($b | length) == 1) then $a[0] + $b[0]
+         else error("fm-bearings-snapshot: empty candidate PR row document") end')
     done
     PR_REPOS_SHOWN=$nrepos
     PR_ROWS_CAPPED=$ncapped
@@ -311,7 +318,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson pr_repos_shown "$PR_REPOS_SHOWN" \
   --argjson pr_rows_capped "$PR_ROWS_CAPPED" \
   --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" \
-  --argjson candidate_prs "$CANDIDATE_PRS" '
+  --slurpfile candidate_prs <(printf '%s' "$CANDIDATE_PRS") '
   def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
   def round_robin_landed($n):
@@ -320,7 +327,9 @@ MODEL=$(printf '%s' "$SNAP" | jq \
        | $groups[]
        | select(length > $i)
        | .[$i]][:$n];
-  ($fields | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != ""))) as $fl
+  ($candidate_prs | if length == 1 then .[0]
+   else error("fm-bearings-snapshot: empty candidate PR document") end) as $candidate_prs
+  | ($fields | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != ""))) as $fl
   | (($fl | index("bodies")) != null) as $f_bodies
   | (($fl | index("paths")) != null) as $f_paths
   | (($fl | index("actions")) != null) as $f_actions

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -103,11 +103,8 @@ validate_bound FM_BEARINGS_PR_LIMIT "$FM_BEARINGS_PR_LIMIT"
 # without limit reaches jq through a file rather than an argv entry: a SINGLE
 # argv entry is capped at MAX_ARG_STRLEN (128 KiB) independently of the far
 # larger ARG_MAX, and exec fails with E2BIG past it.
-# Filters unwrap a slurped document with `doc($x; "x")`, which accepts exactly
-# one document the way --argjson accepts exactly one JSON value: a producer that
-# returned nothing, or that emitted a concatenated multi-value stream, fails
-# closed instead of binding null or silently binding the first value and
-# discarding the rest.
+# bin/fm-fleet-snapshot.sh's JQ_DOC comment owns the boundedness rule and the
+# fail-closed single-document contract that `doc($x; "x")` enforces here too.
 # shellcheck disable=SC2016 # jq filter text: $d and $name are jq variables.
 JQ_DOC='def doc($d; $name): if ($d | length) != 1 then error("fm-bearings-snapshot: expected exactly one JSON document for $" + $name + ", got " + ($d | length | tostring)) else $d[0] end;'
 

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -211,6 +211,19 @@ bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
 
+# Unbounded JSON documents reach jq through --slurpfile and process
+# substitution, never --argjson. Linux caps a SINGLE argv entry at
+# MAX_ARG_STRLEN (128 KiB) independently of the far larger ARG_MAX, so exec
+# fails with E2BIG ("Argument list too long") once one document crosses it,
+# and this home's backlog, task list, and cross-home roll-ups all grow with
+# the fleet. Filters unwrap a slurped document with `doc($x; "x")`, which also
+# refuses an empty document the way --argjson refuses an empty argument, so a
+# producer that returned nothing still fails closed instead of binding null.
+# Small fixed-size values - counts, booleans, timestamps, single paths, single
+# status lines - stay on argv as ordinary --arg or --argjson.
+# shellcheck disable=SC2016 # jq filter text: $d and $name are jq variables.
+JQ_DOC='def doc($d; $name): if ($d | length) == 0 then error("fm-fleet-snapshot: empty JSON document for $" + $name) else $d[0] end;'
+
 path_present_json() {  # <path>
   local present=0
   [ -e "$1" ] && present=1
@@ -599,11 +612,13 @@ task_json_lines() {
       --argjson worktree_path "$worktree_json" \
       --argjson home_path "$home_json" \
       --argjson endpoint_exists "$endpoint_exists" \
-      --argjson open_decisions "$open_decisions_json" \
+      --slurpfile open_decisions <(printf '%s' "$open_decisions_json") \
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
       --argjson report_present "$(bool_json "$report_present")" \
-      '{
+      "$JQ_DOC"'
+      doc($open_decisions; "open_decisions") as $open_decisions
+      | {
         id:$id,
         kind:$kind,
         harness:($harness // ""),
@@ -655,9 +670,12 @@ task_json_lines() {
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
   jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    ([ $backlog.records[]?
+    --slurpfile backlog <(printf '%s' "$1") \
+    --slurpfile tasks <(printf '%s' "$2") \
+    "$JQ_DOC"'
+    doc($backlog; "backlog") as $backlog
+    | doc($tasks; "tasks") as $tasks
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
          | select(.state == "in_flight" and .structured and .requires_child_metadata) ]) as $owned_in_flight
@@ -690,12 +708,15 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+    --slurpfile backlog <(printf '%s' "$1") \
+    --slurpfile tasks <(printf '%s' "$2") \
+    "$JQ_DOC"'
     def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
-    ([ $backlog.records[]?
+    doc($backlog; "backlog") as $backlog
+    | doc($tasks; "tasks") as $tasks
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]? | select(.state == "in_flight" and .structured) ]) as $owned_in_flight
     | ([ $backlog.records[]?
@@ -1107,7 +1128,11 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
+  jq -n \
+    --slurpfile summary <(printf '%s' "$1") \
+    --slurpfile activities <(printf '%s' "$2") \
+    --slurpfile decisions <(printf '%s' "$3") \
+    "$JQ_DOC"'
     def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
@@ -1118,7 +1143,10 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
         compared_to:$surface,
         matched:(if ($e.key | keyed) then ($matches[0] // null) else null end)
       };
-    ([ $activities[] as $e
+    doc($summary; "summary") as $summary
+    | doc($activities; "activities") as $activities
+    | doc($decisions; "decisions") as $decisions
+    | ([ $activities[] as $e
        | if $e.verb == "working" then
            ([ $summary.active_children[]
               | select(if ($e.key | keyed) then .id == $e.key else true end)
@@ -1172,8 +1200,13 @@ secondmate_current_json() {  # <parent-tasks-json>
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
-    ($registry.records // []) as $registered
+  union=$(jq -n \
+    --slurpfile registry <(printf '%s' "$registry") \
+    --slurpfile tasks <(printf '%s' "$tasks") \
+    "$JQ_DOC"'
+    doc($registry; "registry") as $registry
+    | doc($tasks; "tasks") as $tasks
+    | ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
          | $r + {parent_task:([$tasks[] | select(.id == $r.id)][0] // null)} ]
@@ -1319,11 +1352,21 @@ secondmate_current_json() {  # <parent-tasks-json>
       record=$(jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
-        --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
-        --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
-        {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        --argjson registered "$registered" --argjson summary_valid "$summary_valid" \
+        --slurpfile summary <(printf '%s' "$summary") \
+        --slurpfile decisions <(printf '%s' "$decisions") \
+        --slurpfile activities <(printf '%s' "$activities") \
+        --slurpfile activity_scan <(printf '%s' "$activity_scan") \
+        --slurpfile reconciliation <(printf '%s' "$reconciliation") \
+        --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
+        --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" \
+        "$JQ_DOC"'
+        doc($summary; "summary") as $summary
+        | doc($decisions; "decisions") as $decisions
+        | doc($activities; "activities") as $activities
+        | doc($activity_scan; "activity_scan") as $activity_scan
+        | doc($reconciliation; "reconciliation") as $reconciliation
+        | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
          reconcile_inventory:$summary.invalidity,
@@ -1353,9 +1396,18 @@ secondmate_current_json() {  # <parent-tasks-json>
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
         --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
-        --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" --argjson summary "$summary" --argjson summary_sampled "$summary_sampled" '
-        {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        --argjson registered "$registered" --argjson event_age "$event_age" \
+        --slurpfile activities <(printf '%s' "$activities") \
+        --slurpfile activity_scan <(printf '%s' "$activity_scan") \
+        --slurpfile decisions <(printf '%s' "$decisions") \
+        --slurpfile summary <(printf '%s' "$summary") \
+        --argjson terminal "$terminal" --argjson summary_sampled "$summary_sampled" \
+        "$JQ_DOC"'
+        doc($activities; "activities") as $activities
+        | doc($activity_scan; "activity_scan") as $activity_scan
+        | doc($decisions; "decisions") as $decisions
+        | doc($summary; "summary") as $summary
+        | {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:"unknown",reason:$reason},invalidity:null,
          reconcile_inventory:(if $summary_sampled then $summary.invalidity else null end),
@@ -1365,23 +1417,31 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    records=$(jq -n \
+      --slurpfile records <(printf '%s' "$records") \
+      --slurpfile record <(printf '%s' "$record") \
+      "$JQ_DOC"'doc($records; "records") + [doc($record; "record")]')
   done <<EOF
 $rows
 EOF
   jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+    --slurpfile registry <(printf '%s' "$union" | jq '.registry') \
+    --slurpfile records <(printf '%s' "$records") \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
     --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    "$JQ_DOC"'
+    doc($registry; "registry") as $registry
+    | doc($records; "records") as $records
+    | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
-    {records:[ $current.records[]
+  jq -n --slurpfile current <(printf '%s' "$1") \
+    "$JQ_DOC"'
+    doc($current; "current") as $current
+    | {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
       | . + {home:$mate.home,home_id:$mate.id}],
@@ -1437,13 +1497,19 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  --slurpfile backlog <(printf '%s' "$BACKLOG_JSON") \
+  --slurpfile tasks <(printf '%s' "$TASKS_JSON") \
+  --slurpfile main_inventory <(printf '%s' "$MAIN_INVENTORY_JSON") \
+  --slurpfile scout_reports <(printf '%s' "$SCOUT_REPORTS_JSON") \
+  --slurpfile secondmate_current <(printf '%s' "$SECONDMATE_CURRENT_JSON") \
+  --slurpfile secondmate_landed <(printf '%s' "$SECONDMATE_LANDED_JSON") \
+  "$JQ_DOC"'doc($backlog; "backlog") as $backlog
+   | doc($tasks; "tasks") as $tasks
+   | doc($main_inventory; "main_inventory") as $main_inventory
+   | doc($scout_reports; "scout_reports") as $scout_reports
+   | doc($secondmate_current; "secondmate_current") as $secondmate_current
+   | doc($secondmate_landed; "secondmate_landed") as $secondmate_landed
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -211,18 +211,25 @@ bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
 
-# Unbounded JSON documents reach jq through --slurpfile and process
-# substitution, never --argjson. Linux caps a SINGLE argv entry at
-# MAX_ARG_STRLEN (128 KiB) independently of the far larger ARG_MAX, so exec
-# fails with E2BIG ("Argument list too long") once one document crosses it,
-# and this home's backlog, task list, and cross-home roll-ups all grow with
-# the fleet. Filters unwrap a slurped document with `doc($x; "x")`, which
-# accepts exactly one document the way --argjson accepts exactly one JSON
-# value: a producer that returned nothing, or that emitted a concatenated
-# multi-value stream, fails closed instead of binding null or silently
-# binding the first value and discarding the rest.
-# Small fixed-size values - counts, booleans, timestamps, single paths, single
-# status lines - stay on argv as ordinary --arg or --argjson.
+# The rule here is BOUNDEDNESS, not JSON shape and not which flag carries the
+# value. Linux caps a SINGLE argv entry at MAX_ARG_STRLEN (128 KiB)
+# independently of the far larger ARG_MAX, so exec fails with E2BIG ("Argument
+# list too long") once any one value crosses it - --arg hits that wall exactly
+# as --argjson does, and a cap written inside the jq program cannot protect an
+# exec that never happens.
+# A value stays on argv only when its PRODUCER bounds its length: ids, kinds,
+# backends, modes, timestamps, counts, booleans, single filesystem paths, and
+# the fixed state/source words fm-crew-state.sh emits.
+# Everything a caller, a status log, or another home can grow without limit
+# reaches jq through a file instead - --slurpfile for a JSON document, --rawfile
+# for a raw string - even when it is a single line of text. A status log line
+# has no producer bound at all, and this home's backlog, task list, and
+# cross-home roll-ups all grow with the fleet.
+# Filters unwrap a slurped document with `doc($x; "x")`, which accepts exactly
+# one document the way --argjson accepts exactly one JSON value: a producer that
+# returned nothing, or that emitted a concatenated multi-value stream, fails
+# closed instead of binding null or silently binding the first value and
+# discarding the rest.
 # shellcheck disable=SC2016 # jq filter text: $d and $name are jq variables.
 JQ_DOC='def doc($d; $name): if ($d | length) != 1 then error("fm-fleet-snapshot: expected exactly one JSON document for $" + $name + ", got " + ($d | length | tostring)) else $d[0] end;'
 
@@ -277,7 +284,8 @@ crew_state_json() {  # <id>
       esac
       ;;
   esac
-  jq -n --arg raw "$raw" --arg state "$state" --arg source "$source" --arg detail "$detail" \
+  jq -n --rawfile raw <(printf '%s' "$raw") --arg state "$state" --arg source "$source" \
+    --rawfile detail <(printf '%s' "$detail") \
     '{state:$state,source:$source,detail:$detail,raw:$raw}'
 }
 
@@ -291,9 +299,9 @@ status_event_json() {  # <status-log>
   fi
   jq -n \
     --arg path "$log" \
-    --arg raw "$raw" \
-    --arg verb "$verb" \
-    --arg note "$note" \
+    --rawfile raw <(printf '%s' "$raw") \
+    --rawfile verb <(printf '%s' "$verb") \
+    --rawfile note <(printf '%s' "$note") \
     --argjson present "$(bool_json "$present")" \
     '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw}}'
 }
@@ -606,10 +614,10 @@ task_json_lines() {
       --arg pr_source "$pr_source" \
       --arg agent_alive "$agent_alive" \
       --arg observed_at "$SNAPSHOT_NOW" \
-      --arg last_event_raw "$last_event_raw" \
-      --argjson current_state "$current_json" \
+      --rawfile last_event_raw <(printf '%s' "$last_event_raw") \
+      --slurpfile current_state <(printf '%s' "$current_json") \
       --argjson meta_path "$meta_json" \
-      --argjson status_log "$status_json" \
+      --slurpfile status_log <(printf '%s' "$status_json") \
       --argjson report "$report_json" \
       --argjson worktree_path "$worktree_json" \
       --argjson home_path "$home_json" \
@@ -620,6 +628,8 @@ task_json_lines() {
       --argjson report_present "$(bool_json "$report_present")" \
       "$JQ_DOC"'
       doc($open_decisions; "open_decisions") as $open_decisions
+      | doc($current_state; "current_state") as $current_state
+      | doc($status_log; "status_log") as $status_log
       | {
         id:$id,
         kind:$kind,
@@ -1354,7 +1364,8 @@ secondmate_current_json() {  # <parent-tasks-json>
       fi
       reconciliation=$(parent_evidence_reconciliation_json "$summary" "$activities" "$decisions")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
-      terminal_contradiction=$(printf '%s' "$reconciliation" | jq -r --arg note "$event_note" '
+      terminal_contradiction=$(printf '%s' "$reconciliation" \
+        | jq -r --rawfile note <(printf '%s' "$event_note") '
         any(.activities[]; .verdict == "contradicts" and .summary == $note)')
       if [ "$terminal_contradiction" = true ]; then
         terminal=$(terminal_evidence_json "$task" "$event_note" true)
@@ -1364,7 +1375,8 @@ secondmate_current_json() {  # <parent-tasks-json>
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
       record=$(jq -n \
-        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
+        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg observed "$SNAPSHOT_NOW" \
+        --rawfile current_reason <(printf '%s' "$current_reason") \
         --arg spawn_gen "$sampled_spawn_gen" \
         --argjson registered "$registered" --argjson summary_valid "$summary_valid" \
         --slurpfile summary <(printf '%s' "$summary") \
@@ -1373,7 +1385,8 @@ secondmate_current_json() {  # <parent-tasks-json>
         --slurpfile activity_scan <(printf '%s' "$activity_scan") \
         --slurpfile reconciliation <(printf '%s' "$reconciliation") \
         --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
-        --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" \
+        --rawfile event_raw <(printf '%s' "$event_raw") \
+        --rawfile event_note <(printf '%s' "$event_note") --argjson event_age "$event_age" \
         "$JQ_DOC"'
         doc($summary; "summary") as $summary
         | doc($decisions; "decisions") as $decisions
@@ -1407,9 +1420,12 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       record=$(jq -n \
-        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
+        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg observed "$SNAPSHOT_NOW" \
+        --rawfile reason <(printf '%s' "$reason") \
         --arg spawn_gen "$sampled_spawn_gen" \
-        --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
+        --arg provenance "$provenance" --arg freshness "$freshness" \
+        --rawfile event_raw <(printf '%s' "$event_raw") \
+        --rawfile event_note <(printf '%s' "$event_note") \
         --argjson registered "$registered" --argjson event_age "$event_age" \
         --slurpfile activities <(printf '%s' "$activities") \
         --slurpfile activity_scan <(printf '%s' "$activity_scan") \

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1301,6 +1301,15 @@ secondmate_current_json() {  # <parent-tasks-json>
           "$SCRIPT_DIR/fm-fleet-snapshot.sh" --secondmate-home-summary 2>/dev/null)
         summary_rc=$?
       fi
+      # Every branch that gives up on a sample resets summary to '{}' before
+      # setting its reason. An unusable sample must never reach the fallback
+      # record assembly's --slurpfile below: jq fails there, and that failure
+      # cascades through the empty record, the accumulator's doc() guard, and
+      # the final assembly into a whole-snapshot exit 1. One unreadable home
+      # has to degrade to its own unknown-state record instead of breaking
+      # every fleet read in this home. The schema check below is -s with
+      # length == 1 for the same reason: two concatenated documents are just
+      # as unusable, and a bare jq -e would report only the last one's status.
       if [ "$summary_rc" -ne 0 ]; then
         summary='{}'
         [ "$summary_rc" -eq 124 ] && reason="structured home snapshot timed out" || reason="structured home snapshot failed"

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -610,10 +610,10 @@ task_json_lines() {
       --arg target "$target" \
       --arg remote_host "$remote_host" \
       --arg remote_root "$remote_root" \
-      --arg pr "$pr" \
       --arg pr_source "$pr_source" \
       --arg agent_alive "$agent_alive" \
       --arg observed_at "$SNAPSHOT_NOW" \
+      --rawfile pr <(printf '%s' "$pr") \
       --rawfile last_event_raw <(printf '%s' "$last_event_raw") \
       --slurpfile current_state <(printf '%s' "$current_json") \
       --argjson meta_path "$meta_json" \

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1307,17 +1307,20 @@ secondmate_current_json() {  # <parent-tasks-json>
       else
         summary_bytes=$(printf '%s' "$summary" | LC_ALL=C wc -c | tr -d ' ')
         if [ "$summary_bytes" -gt "$FM_SNAPSHOT_SECONDMATE_MAX_BYTES" ]; then
+          summary='{}'
           reason="structured home snapshot exceeded byte limit"
-        elif ! printf '%s' "$summary" | jq -e --arg home "$home" --arg generated "$SNAPSHOT_NOW" --argjson remote "$remote" '
-          .schema == "fm-secondmate-home-summary.v1" and .home == $home
+        elif ! printf '%s' "$summary" | jq -e -s --arg home "$home" --arg generated "$SNAPSHOT_NOW" --argjson remote "$remote" '
+          length == 1 and (.[0]
+          | .schema == "fm-secondmate-home-summary.v1" and .home == $home
           and (($remote == true) or .generated == $generated)
           and (.valid | type) == "boolean" and (.state | type) == "string"
           and (.invalidity | type) == "object" and (.invalidity.ids | type) == "array"
           and (.active_children | type) == "array" and (.decisions_open | type) == "array"
           and (.holds | type) == "array" and (.queued | type) == "array"
           and (.landed | type) == "array" and (.endpoints | type) == "array"
-          and (.counts | type) == "object" and (.omitted | type) == "array"
+          and (.counts | type) == "object" and (.omitted | type) == "array")
         ' >/dev/null 2>&1; then
+          summary='{}'
           reason="structured home snapshot was malformed or stale"
         else
           summary_sampled=true

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -216,13 +216,15 @@ bool_json() {
 # MAX_ARG_STRLEN (128 KiB) independently of the far larger ARG_MAX, so exec
 # fails with E2BIG ("Argument list too long") once one document crosses it,
 # and this home's backlog, task list, and cross-home roll-ups all grow with
-# the fleet. Filters unwrap a slurped document with `doc($x; "x")`, which also
-# refuses an empty document the way --argjson refuses an empty argument, so a
-# producer that returned nothing still fails closed instead of binding null.
+# the fleet. Filters unwrap a slurped document with `doc($x; "x")`, which
+# accepts exactly one document the way --argjson accepts exactly one JSON
+# value: a producer that returned nothing, or that emitted a concatenated
+# multi-value stream, fails closed instead of binding null or silently
+# binding the first value and discarding the rest.
 # Small fixed-size values - counts, booleans, timestamps, single paths, single
 # status lines - stay on argv as ordinary --arg or --argjson.
 # shellcheck disable=SC2016 # jq filter text: $d and $name are jq variables.
-JQ_DOC='def doc($d; $name): if ($d | length) == 0 then error("fm-fleet-snapshot: empty JSON document for $" + $name) else $d[0] end;'
+JQ_DOC='def doc($d; $name): if ($d | length) != 1 then error("fm-fleet-snapshot: expected exactly one JSON document for $" + $name + ", got " + ($d | length | tostring)) else $d[0] end;'
 
 path_present_json() {  # <path>
   local present=0

--- a/bin/fm-public-followup-emit.sh
+++ b/bin/fm-public-followup-emit.sh
@@ -203,7 +203,11 @@ esac
 [ -n "$OUTCOME_TEXT" ] || die "outcome text is empty once whitespace and control characters are removed"
 
 # Canonical deliverables object: sorted keys, compact, so the same deliverables
-# always hash to the same identity regardless of flag order.
+# always hash to the same identity regardless of flag order. --deliverable is
+# repeatable with no cap on how many arrive, so the composed object reaches jq
+# through a file for the same argv reason as the outcome text below; the length
+# guard there keeps --argjson's fail-closed refusal of a missing or multi-value
+# document.
 DELIVERABLES_JSON=$(
   {
     i=0
@@ -225,7 +229,12 @@ esac
 [ "${#EVENT_ID}" -eq 64 ] || die "could not derive a usable event id" 1
 
 # jq bounds the outcome text by codepoint, so a long or non-ASCII sentence is
-# capped without ever splitting a multi-byte character.
+# capped without ever splitting a multi-byte character. That cap runs INSIDE the
+# jq program, so it cannot keep an unbounded sentence off argv: --outcome-text-file
+# reads a file or stdin, Linux caps a single argv entry at MAX_ARG_STRLEN
+# (128 KiB) whatever flag carries it, and the exec would fail with E2BIG before
+# jq ever ran. The text therefore reaches jq through a file as a raw string,
+# which keeps the codepoint-exact truncation semantics unchanged.
 EVENT_JSON=$(jq -Sc -n \
   --argjson schema_version "$FM_PF_EVENT_SCHEMA_VERSION" \
   --arg event_id "$EVENT_ID" \
@@ -235,14 +244,16 @@ EVENT_JSON=$(jq -Sc -n \
   --argjson generation "$GENERATION" \
   --arg source_home_id "$SOURCE_HOME" \
   --arg outcome_type "$OUTCOME" \
-  --argjson deliverables "$DELIVERABLES_JSON" \
-  --arg public_safe_outcome "$OUTCOME_TEXT" \
+  --slurpfile deliverables_doc <(printf '%s' "$DELIVERABLES_JSON") \
+  --rawfile public_safe_outcome <(printf '%s' "$OUTCOME_TEXT") \
   --argjson outcome_max "$FM_PF_OUTCOME_TEXT_MAX" \
   --arg occurred_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   '{schema_version:$schema_version, event_id:$event_id, obligation_id:$obligation_id,
     relation_id:$relation_id, work_id:$work_id, generation:$generation,
     source_home_id:$source_home_id, outcome_type:$outcome_type,
-    deliverables:$deliverables,
+    deliverables:(if ($deliverables_doc | length) != 1
+                  then error("fm-public-followup-emit: expected exactly one deliverables document")
+                  else $deliverables_doc[0] end),
     public_safe_outcome:($public_safe_outcome[0:$outcome_max]),
     occurred_at:$occurred_at, successor:null}') \
   || die "could not build the typed terminal event" 1

--- a/docs/verification/public-followup.md
+++ b/docs/verification/public-followup.md
@@ -2,12 +2,13 @@
 
 Audience: maintainer verification.
 
-This record supports four active guarantees for promised public replies made through the myfirstmate relay:
+This record supports five active guarantees for promised public replies made through the myfirstmate relay:
 
 1. A promised final reply survives compaction and restart, reconciles from disk alone, and lands in the original thread exactly once.
 2. A home that never opted into the relay pays nothing for any of it.
 3. Delivering a final does not close the public loop: the registration is retained as `state=delivered` until `retire --reason`, session start surfaces an `open-loop` line, and `rechain` can bind follow-on work to the same thread.
 4. A first registration with no registry lock already held succeeds under stock macOS Bash 3.2 with `set -u`.
+5. An outcome sentence too large to travel as one command-line argument still publishes its typed terminal event.
 
 [`docs/configuration.md`](../configuration.md#promised-public-replies-statepublic-followup) owns the operator-facing contract, [`docs/architecture.md`](../architecture.md#optional-relay) owns the mechanism boundary, and `tasks-axi public-followup --help` owns the typed obligation schema.
 Task chronology and delivery evidence stay outside this record.
@@ -93,6 +94,7 @@ It delivers a `report-ready` promised-final, asserts the registration is retaine
 The concurrency and interrupted-bind cases verify that one delivered source cannot fork and that retry converges on the same destination obligation.
 A pre-change on-disk record (no `state=`, no `request_context_b64`) is an open loop and un-rechainable rather than a crash.
 The stock macOS Bash lane in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) sets `FM_TEST_ONLY=test_first_register_succeeds_with_empty_lock_list_under_bash32` and runs `tests/fm-public-followup.test.sh` through real `/bin/bash` 3.2, proving the first `register` path is safe when its registry lock list starts empty.
+The oversized-outcome case is the proof of guarantee 5: a report body past the 131072-byte single-argument cap reaches the emitter from a file and from stdin, and both publish the same typed event with the sentence still bounded by codepoint and its multi-byte characters intact.
 
 The existing Relay mention suite (`tests/fm-x-mode.test.sh`) is unchanged by this work.
 

--- a/docs/verification/public-followup.md
+++ b/docs/verification/public-followup.md
@@ -16,6 +16,8 @@ Task chronology and delivery evidence stay outside this record.
 
 Recorded 2026-08-21 on Darwin 25.5.0 (arm64) with GNU bash 5.3.9, tasks-axi 0.2.5, jq 1.8.1, and ShellCheck 0.11.0 (the version `bin/fm-lint.sh` pins).
 The stock macOS compatibility lane additionally runs the focused first-registration regression with `/bin/bash` 3.2.57 and a real `tasks-axi` installation.
+The suite transcript below was re-run 2026-08-31 on Linux 7.0.12-linuxkit (aarch64) with GNU bash 5.2.21, tasks-axi 0.2.5, jq 1.7, and the same pinned ShellCheck, and reproduced every earlier line unchanged plus the oversized-outcome-text case.
+The measurement later in this record is still from the recorded environment above.
 The relay is a fakebin `curl` in every case, so no public post is ever made; `tasks-axi` and `jq` are the real tools, because stubbing the obligation state machine would verify nothing.
 
 ## Restart end-to-end and regressions
@@ -26,6 +28,7 @@ bash tests/fm-public-followup.test.sh
 
 ```
 ok - outcome text is collapsed to one line, bounded by codepoint, and never corrupts characters
+ok - an outcome text past the single-argument size cap still publishes its terminal event
 ok - restart end-to-end: typed result reconciles from disk and delivers one reply to the original thread
 ok - duplicate terminal results, restart replay, and repeated delivery are all no-ops
 ok - wrong source, wrong work id, stale generation, malformed, unsupported deliverable, and forged identity are all refused

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -49,6 +49,17 @@ SH
 echo "gh $*" >> "$NET_LOG"
 if [ "${FAKE_GH_FAIL:-0}" = 1 ]; then exit 1; fi
 if [ "${FAKE_GH_SLEEP:-0}" = 1 ]; then sleep 30; fi
+if [ "${FAKE_GH_BULK:-0}" != 0 ]; then
+  awk -v n="$FAKE_GH_BULK" 'BEGIN {
+    printf "["
+    for (i = 1; i <= n; i++) {
+      if (i > 1) printf ","
+      printf "{\"number\":%d,\"title\":\"Bulk %d\",\"url\":\"https://github.com/acme/bulk/pull/%d\",\"headRefName\":\"fm/bulk-%d\",\"reviewDecision\":\"APPROVED\",\"mergeable\":\"MERGEABLE\",\"statusCheckRollup\":[{\"conclusion\":\"SUCCESS\",\"status\":\"COMPLETED\"}]}", i, i, i, i
+    }
+    printf "]\n"
+  }'
+  exit 0
+fi
 if [ "${FAKE_GH_MANY:-0}" = 1 ]; then
   cat <<'JSON'
 [{"number":1,"title":"One","url":"https://github.com/acme/repo/pull/1","headRefName":"fm/one","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]},{"number":2,"title":"Two","url":"https://github.com/acme/repo/pull/2","headRefName":"fm/two","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]},{"number":3,"title":"Three","url":"https://github.com/acme/repo/pull/3","headRefName":"fm/three","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]}]
@@ -1159,6 +1170,25 @@ test_per_repository_pr_cap_is_disclosed() {
   pass "per-repository open-PR caps are disclosed with an expansion knob"
 }
 
+# Regression: the accumulated candidate PR rows used to reach jq as one
+# --argjson argument, so a fleet with enough open PRs made the projection exec
+# fail with E2BIG ("Argument list too long") and bearings exit non-zero with no
+# output. The rows grow with the fleet, so they must travel as a document.
+test_oversized_candidate_pr_set_still_projects() {
+  local home fakebin json rows_bytes
+  home=$(make_home bulk-prs); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  json=$(FAKE_GH_BULK=900 FM_BEARINGS_PR_LIMIT=1000 run "$home" "$fakebin" --include-prs --json) \
+    || fail "bearings must survive a candidate PR set larger than one argv entry"
+  printf '%s' "$json" | jq -e '.schema == "fm-bearings.v1" and (.candidate_prs | length) == 900' \
+    >/dev/null || fail "oversized candidate PR set was dropped or truncated: got $(printf '%s' "$json" | jq -r '(.candidate_prs | length) // "none"') rows"
+  # Prove the fixture actually crosses the cap this test exists for.
+  rows_bytes=$(printf '%s' "$json" | jq -c '.candidate_prs' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$rows_bytes" -gt 131072 ] \
+    || fail "candidate PR rows render to only $rows_bytes bytes; they must exceed the 131072-byte argv cap"
+  pass "a candidate PR set past the single-argument size cap still projects"
+}
+
 install_failing_jq() {  # <fakebin> <model|toon>
   local fakebin=$1 phase=$2 real
   real=$(command -v jq)
@@ -1987,4 +2017,5 @@ test_section_caps_and_expansion_flags
 test_collapsed_captain_call_deferral_and_landed
 test_pr_repository_cap_and_expansion
 test_per_repository_pr_cap_is_disclosed
+test_oversized_candidate_pr_set_still_projects
 test_projection_and_toon_fail_closed

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -869,6 +869,77 @@ test_oversized_backlog_still_reads() {
   pass "a backlog past the single-argument size cap still reads through snapshot, home summary, and bearings"
 }
 
+# A single status-log line long enough to cross MAX_ARG_STRLEN on its own. It is
+# ordinary status-log text - one verb, one colon, one very long note - because
+# nothing bounds how much a worker writes on one line.
+write_oversized_status_line() {  # <status-file>
+  {
+    printf 'working: '
+    awk 'BEGIN { while (i++ < 4000) printf "a very long progress note that keeps on growing " }'
+    printf '\n'
+  } > "$1"
+}
+
+# Regression, and a worse failure than the oversized backlog above: the task's
+# own jq exec died with E2BIG while the snapshot still exited 0, so the task
+# disappeared from .tasks entirely and main_inventory then reported its backlog
+# row as an orphan, "in-flight backlog item has no child metadata". A supervisor
+# reading that would be told a live worker does not exist. The note also has to
+# survive whole, since renderers read it as the last event text.
+test_oversized_status_line_keeps_the_task() {
+  local home fakebin out line_bytes raw_len note_len
+  home=$(make_home oversized-status-line)
+  mkdir -p "$home/projects/big-worktree"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] big-line-task - Big Line Task (repo: alpha) (kind: ship) (since 2026-08-01)
+
+## Queued
+
+## Done
+EOF
+  fm_write_meta "$home/state/big-line-task.meta" \
+    "window=firstmate:fm-big-line-task" \
+    "worktree=$home/projects/big-worktree" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=ship"
+  write_oversized_status_line "$home/state/big-line-task.status"
+  fakebin=$(make_fakebin "$home")
+
+  # Prove the fixture actually crosses the cap this test exists for; a smaller
+  # line would make the whole case vacuous. Measured on disk, so the guard holds
+  # whether or not the snapshot manages to read the line at all.
+  line_bytes=$(LC_ALL=C wc -c < "$home/state/big-line-task.status" | tr -d ' ')
+  [ "$line_bytes" -gt 131072 ] \
+    || fail "fixture status line is only $line_bytes bytes; it must exceed the 131072-byte argv cap"
+
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "snapshot must survive a status line larger than one argv entry"
+  printf '%s' "$out" | jq -e . >/dev/null \
+    || fail "snapshot output must be valid JSON for an oversized status line"
+
+  printf '%s' "$out" | jq -e '
+    (.tasks | length) == 1
+      and .tasks[0].id == "big-line-task"
+      and .main_inventory.valid == true
+      and (.main_inventory.orphan_in_flight | length) == 0
+  ' >/dev/null || fail "an oversized status line must not drop the task or invent an orphan"
+
+  raw_len=$(printf '%s' "$out" | jq -r '.tasks[0].paths.status_log.last_event.raw | length')
+  [ "$raw_len" -eq $((line_bytes - 1)) ] \
+    || fail "the recorded event must keep the whole line, got $raw_len of $((line_bytes - 1)) characters"
+  note_len=$(printf '%s' "$out" | jq -r '.tasks[0].paths.status_log.last_event.note | length')
+  [ "$note_len" -eq $((raw_len - 9)) ] \
+    || fail "the parsed note must keep the whole line, got $note_len of $raw_len characters"
+  printf '%s' "$out" | jq -e '
+    .tasks[0].paths.status_log.last_event.state == "working"
+      and .tasks[0].hints.last_event_text == .tasks[0].paths.status_log.last_event.raw
+  ' >/dev/null || fail "an oversized status line must still parse into verb and raw event text"
+  pass "a status line past the single-argument size cap keeps its task instead of dropping it"
+}
+
 # Regression: one registered secondmate whose home summary command exits 0 but
 # returns something unusable used to fail the whole snapshot for the entire
 # home. The unusable sample was carried into the record assembly, which could
@@ -921,6 +992,7 @@ test_open_decision_clears_on_keyed_resolution
 test_completed_scout_report_is_pointer_not_pending
 test_parked_scout_decision_stays_pending
 test_oversized_backlog_still_reads
+test_oversized_status_line_keeps_the_task
 test_unusable_secondmate_summary_degrades_to_unknown_record
 test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -940,6 +940,74 @@ EOF
   pass "a status line past the single-argument size cap keeps its task instead of dropping it"
 }
 
+# A status log carrying one PR-URL-shaped token long enough to cross
+# MAX_ARG_STRLEN on its own. first_pr_url_in_file greps
+# 'https?://[^[:space:])"]+/pull/[0-9]+', and POSIX ERE takes the longest
+# leftmost match, so an unbroken run of non-space, non-')', non-'"' bytes
+# between the scheme and /pull/N is returned whole however long it is.
+write_oversized_status_pr_url() {  # <status-file>
+  {
+    printf 'shipped: opened https://example.invalid/'
+    awk 'BEGIN { while (i++ < 4000) printf "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }'
+    printf '/pull/1\n'
+  } > "$1"
+}
+
+# Regression, the same E2BIG drop as the oversized status line above reached
+# through a sibling field: the PR URL is the one task-level value the script
+# derives from status-log text, which nothing bounds, so handing it to jq as a
+# single argv entry killed the per-task jq, dropped the task from .tasks while
+# the snapshot still exited 0, and made main_inventory report the live backlog
+# row as an orphan.
+test_oversized_status_pr_url_keeps_the_task() {
+  local home fakebin out url_bytes pr_len
+  home=$(make_home oversized-status-pr-url)
+  mkdir -p "$home/projects/big-pr-worktree"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] big-pr-task - Big Pr Task (repo: alpha) (kind: ship) (since 2026-08-01)
+
+## Queued
+
+## Done
+EOF
+  fm_write_meta "$home/state/big-pr-task.meta" \
+    "window=firstmate:fm-big-pr-task" \
+    "worktree=$home/projects/big-pr-worktree" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=ship"
+  write_oversized_status_pr_url "$home/state/big-pr-task.status"
+  fakebin=$(make_fakebin "$home")
+
+  # Prove the URL token itself - not merely the line - crosses the cap, since
+  # the line's other fields already reach jq through files.
+  url_bytes=$(grep -Eo 'https?://[^[:space:])"]+/pull/[0-9]+' "$home/state/big-pr-task.status" \
+    | head -1 | LC_ALL=C wc -c | tr -d ' ')
+  [ "$url_bytes" -gt 131072 ] \
+    || fail "fixture PR URL is only $url_bytes bytes; it must exceed the 131072-byte argv cap"
+
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "snapshot must survive a PR URL larger than one argv entry"
+  printf '%s' "$out" | jq -e . >/dev/null \
+    || fail "snapshot output must be valid JSON for an oversized status PR URL"
+
+  printf '%s' "$out" | jq -e '
+    (.tasks | length) == 1
+      and .tasks[0].id == "big-pr-task"
+      and .main_inventory.valid == true
+      and (.main_inventory.orphan_in_flight | length) == 0
+  ' >/dev/null || fail "an oversized status PR URL must not drop the task or invent an orphan"
+
+  pr_len=$(printf '%s' "$out" | jq -r '.tasks[0].pr.url | length')
+  [ "$pr_len" -eq $((url_bytes - 1)) ] \
+    || fail "the recorded PR URL must survive whole, got $pr_len of $((url_bytes - 1)) characters"
+  printf '%s' "$out" | jq -e '.tasks[0].pr.source == "status_event"' >/dev/null \
+    || fail "a PR URL recovered from the status log must be attributed to the status event"
+  pass "a status-log PR URL past the single-argument size cap keeps its task instead of dropping it"
+}
+
 # Regression: one registered secondmate whose home summary command exits 0 but
 # returns something unusable used to fail the whole snapshot for the entire
 # home. The unusable sample was carried into the record assembly, which could
@@ -993,6 +1061,7 @@ test_completed_scout_report_is_pointer_not_pending
 test_parked_scout_decision_stays_pending
 test_oversized_backlog_still_reads
 test_oversized_status_line_keeps_the_task
+test_oversized_status_pr_url_keeps_the_task
 test_unusable_secondmate_summary_degrades_to_unknown_record
 test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -8,6 +8,7 @@ set -u
 
 SNAPSHOT="$ROOT/bin/fm-fleet-snapshot.sh"
 VIEW="$ROOT/bin/fm-fleet-view.sh"
+BEARINGS="$ROOT/bin/fm-bearings-snapshot.sh"
 TMP_ROOT=$(fm_test_tmproot fm-fleet-snapshot)
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
@@ -799,6 +800,75 @@ test_parked_scout_decision_stays_pending() {
   pass "a scout still parked at a decision stays pending (terminal clear does not over-fire)"
 }
 
+# A backlog large enough that its rendered JSON crosses a single argv entry's
+# MAX_ARG_STRLEN cap (128 KiB on Linux, independent of the far larger ARG_MAX).
+# Every command that reads this home has to keep working: a document that big
+# can only reach jq through a file, never as one command-line argument.
+write_oversized_backlog() {  # <home>
+  local home=$1 pad i
+  pad=""
+  for i in $(seq 1 12); do
+    pad="$pad padding body text that makes each backlog row expensive to render"
+  done
+  {
+    printf '## In flight\n'
+    for i in $(seq 1 40); do
+      printf -- '- [ ] big-ship-%03d - Big Ship %d (repo: alpha) (kind: ship) (since 2026-08-01)\n' "$i" "$i"
+      printf '  %s\n' "$pad"
+    done
+    printf '\n## Queued\n'
+    for i in $(seq 1 40); do
+      printf -- '- [ ] big-queued-%03d - Big Queued %d (repo: alpha) (kind: ship) (since 2026-08-01)\n' "$i" "$i"
+      printf '  %s\n' "$pad"
+    done
+    printf '\n## Done\n'
+    for i in $(seq 1 40); do
+      printf -- '- [x] big-done-%03d - Big Done %d https://github.com/kunchenguid/firstmate/pull/%d (repo: alpha) (kind: ship) (merged 2026-08-02)\n' "$i" "$i" "$i"
+      printf '  %s\n' "$pad"
+    done
+  } > "$home/data/backlog.md"
+}
+
+# Regression: a large backlog used to break every fleet read in the home. The
+# rendered backlog document was handed to jq as a single --argjson argument, so
+# exec failed with E2BIG ("Argument list too long") and the snapshot, the
+# secondmate home summary, and bearings all exited non-zero with no output.
+test_oversized_backlog_still_reads() {
+  local home fakebin out summary bearings backlog_bytes
+  home=$(make_home oversized-backlog)
+  write_oversized_backlog "$home"
+  fakebin=$(make_fakebin "$home")
+
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "snapshot must survive a backlog larger than one argv entry"
+  printf '%s' "$out" | jq -e . >/dev/null \
+    || fail "snapshot output must be valid JSON for an oversized backlog"
+
+  # Prove the fixture actually crosses the cap this test exists for; a smaller
+  # document would make the whole case vacuous.
+  backlog_bytes=$(printf '%s' "$out" | jq -c '.backlog' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$backlog_bytes" -gt 131072 ] \
+    || fail "fixture backlog renders to only $backlog_bytes bytes; it must exceed the 131072-byte argv cap"
+  printf '%s' "$out" | jq -e '
+    (.backlog.records | length) == 120
+      and .main_inventory.valid == false
+      and .main_inventory.unstructured_current_count == 0
+      and ((.main_inventory.orphan_in_flight | length) == 40)
+  ' >/dev/null || fail "oversized backlog must still project a complete main inventory: $backlog_bytes bytes"
+
+  summary=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary) \
+    || fail "secondmate home summary must survive a backlog larger than one argv entry"
+  printf '%s' "$summary" | jq -e '.schema == "fm-secondmate-home-summary.v1"' >/dev/null \
+    || fail "secondmate home summary must stay valid JSON for an oversized backlog"
+
+  bearings=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$BEARINGS" --json) \
+    || fail "bearings must survive a backlog larger than one argv entry"
+  printf '%s' "$bearings" | jq -e '.schema == "fm-bearings.v1"' >/dev/null \
+    || fail "bearings output must stay valid JSON for an oversized backlog"
+
+  pass "a backlog past the single-argument size cap still reads through snapshot, home summary, and bearings"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
@@ -810,6 +880,7 @@ test_open_decision_transfers_to_captain_hold
 test_open_decision_clears_on_keyed_resolution
 test_completed_scout_report_is_pointer_not_pending
 test_parked_scout_decision_stays_pending
+test_oversized_backlog_still_reads
 test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -869,6 +869,46 @@ test_oversized_backlog_still_reads() {
   pass "a backlog past the single-argument size cap still reads through snapshot, home summary, and bearings"
 }
 
+# Regression: one registered secondmate whose home summary command exits 0 but
+# returns something unusable used to fail the whole snapshot for the entire
+# home. The unusable sample was carried into the record assembly, which could
+# not parse it, and the failure cascaded out through the accumulator to
+# "registered secondmate aggregation failed" with no output at all. An
+# unsamplable route has to degrade to the unknown-state record this function
+# already builds for every other unreachable mate.
+test_unusable_secondmate_summary_degrades_to_unknown_record() {
+  local home stub out rc
+  home=$(make_home unusable-secondmate-summary)
+  cat > "$home/data/secondmates.md" <<'EOF'
+- badjson - remote mate (host: remote-mac; root: /remote/root; home: /remote/home; scope: remote testing; projects: alpha; added 2026-08-02)
+EOF
+  stub=$home/stubbin
+  mkdir -p "$stub"
+  cat > "$stub/fake-ssh" <<'SH'
+#!/usr/bin/env bash
+printf 'Welcome to remote-mac\n'
+exit 0
+SH
+  chmod +x "$stub/fake-ssh"
+
+  out=$(FM_HOME="$home" FM_SSH_BIN="$stub/fake-ssh" "$SNAPSHOT" --json 2>"$home/summary-err"); rc=$?
+  expect_code 0 "$rc" \
+    "one unusable secondmate home summary must not fail the whole snapshot: $(cat "$home/summary-err")"
+  printf '%s' "$out" | jq -e . >/dev/null \
+    || fail "snapshot must stay valid JSON when a secondmate home summary is unusable"
+  printf '%s' "$out" | jq -e '
+    .secondmate_current.records
+    | length == 1
+      and (.[0].id == "badjson")
+      and (.[0].registered == true)
+      and (.[0].remote == true)
+      and (.[0].current.state == "unknown")
+      and (.[0].current.reason == "structured home snapshot was malformed or stale")
+      and (.[0].reconcile_inventory == null)
+  ' >/dev/null || fail "an unusable home summary must degrade to an unknown-state record: $out"
+  pass "an unusable secondmate home summary degrades to an unknown record instead of failing the snapshot"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
@@ -881,6 +921,7 @@ test_open_decision_clears_on_keyed_resolution
 test_completed_scout_report_is_pointer_not_pending
 test_parked_scout_decision_stays_pending
 test_oversized_backlog_still_reads
+test_unusable_secondmate_summary_degrades_to_unknown_record
 test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -271,6 +271,56 @@ test_outcome_text_is_bounded_without_corrupting_characters() {
   pass "outcome text is collapsed to one line, bounded by codepoint, and never corrupts characters"
 }
 
+# Regression: --outcome-text-file reads a file or stdin, so the outcome sentence
+# has no producer bound at all. It used to ride to jq as a single --arg entry,
+# and Linux caps one argv entry at MAX_ARG_STRLEN (128 KiB), so a long report
+# body failed the exec with "Argument list too long" and the terminal event was
+# never published - the promised public reply simply never happened. The
+# 600-codepoint cap lives inside the jq program and could not help: it only runs
+# once jq is already running.
+test_oversized_outcome_text_file_still_emits() {
+  local home event text bytes
+  home=$(make_home outcome-text-oversized)
+  seed_commitment "$home" pf-big req-big discord main work-big
+
+  {
+    printf 'Shipped the caf\xc3\xa9 fix, and here is the rest of the report: '
+    awk 'BEGIN { while (i++ < 4000) printf "a very long report body that keeps on going " }'
+  } > "$home/outcome.txt"
+  bytes=$(LC_ALL=C wc -c < "$home/outcome.txt" | tr -d ' ')
+  [ "$bytes" -gt 131072 ] \
+    || fail "fixture outcome text is only $bytes bytes; it must exceed the 131072-byte argv cap"
+
+  "$EMIT" --home "$home" --obligation pf-big --relation rel-code \
+    --source-home main --work-id work-big --generation 1 --outcome pr-merged \
+    --deliverable pr_url=https://github.com/example/repo/pull/5 \
+    --outcome-text-file "$home/outcome.txt" >/dev/null \
+    || fail "emit must survive an outcome text larger than one argv entry ($bytes bytes)"
+  event=$(find "$home/state/public-followup/events" -name '*.json' | head -1)
+  [ -n "$event" ] || fail "an oversized outcome text must still publish a terminal event"
+  text=$(jq -r '.public_safe_outcome' "$event") \
+    || fail "the typed event must remain valid JSON for an oversized outcome text"
+  [ "${#text}" -eq 600 ] \
+    || fail "the oversized outcome must still be capped at 600 codepoints, got ${#text}"
+  case "$text" in
+    *café*) ;;
+    *) fail "codepoint bounding corrupted a multi-byte character: $text" ;;
+  esac
+
+  # The same text arriving on stdin takes the identical path and must agree
+  # byte for byte, so the bound cannot depend on how the text was supplied.
+  rm -f "$event"
+  "$EMIT" --home "$home" --obligation pf-big --relation rel-code \
+    --source-home main --work-id work-big --generation 1 --outcome pr-merged \
+    --deliverable pr_url=https://github.com/example/repo/pull/5 \
+    --outcome-text-file - < "$home/outcome.txt" >/dev/null \
+    || fail "emit must survive an oversized outcome text on stdin"
+  event=$(find "$home/state/public-followup/events" -name '*.json' | head -1)
+  [ "$(jq -r '.public_safe_outcome' "$event")" = "$text" ] \
+    || fail "stdin and file outcome text must produce the same bounded sentence"
+  pass "an outcome text past the single-argument size cap still publishes its terminal event"
+}
+
 # --- 1. the restart end-to-end -------------------------------------------------
 
 # The whole reported failure, start to finish, with no conversation memory
@@ -2280,6 +2330,7 @@ if [ -n "${FM_TEST_ONLY:-}" ]; then
 fi
 
 test_outcome_text_is_bounded_without_corrupting_characters
+test_oversized_outcome_text_file_still_emits
 test_restart_e2e_delivers_exactly_once
 test_duplicate_event_and_replay_are_noops
 test_invalid_events_are_refused_and_quarantined


### PR DESCRIPTION
## Intent

Get the existing upstream pull request https://github.com/kunchenguid/firstmate/pull/3418 green on every check. This is not a fresh implementation: six commits already exist and the PR is already open, and the work must be continued rather than restarted, rewritten, or squashed, because those commits carry the evidence the PR body cites.

The underlying change: bin/fm-fleet-snapshot.sh and neighbours built JSON by handing whole unbounded documents to jq as single command-line arguments (--argjson backlog "$1" and similar). Linux caps a single argv entry at MAX_ARG_STRLEN = 128 KiB, independent of ARG_MAX, so once one document crosses it exec fails with E2BIG and jq never runs. Those values now reach jq through files (--slurpfile/--rawfile via process substitution) instead. It also fixes a neighbouring script (bin/fm-bearings-snapshot.sh) that a first audit wrongly reported clean, moves unbounded status-line and outcome-text values in bin/fm-public-followup-emit.sh off jq argv, and adds a guard refusing multi-document slurps in the fleet snapshot JQ_DOC path.

Two checks were failing and this run must clear both.

Failure 1, "Stock macOS Bash snapshot compatibility" (job macos-stock-bash in .github/workflows/ci.yml). Diagnosed from the real failing job log, not assumed: the job runs on stock Bash 3.2.57, parses every file from bin/fm-lint.sh --list-files with /bin/bash -n, then runs the snapshot and Bearings suites and asserts an EXACT count of "ok - " lines. The log shows the parse sweep clean and all tests passing under real Bash 3.2.57, failing only on "expected 15 snapshot/fleet-view tests, got 18". The regressions this change added moved the totals, so the hardcoded literals were stale: the snapshot suite gained three cases (oversized backlog, oversized status line, unusable secondmate home summary) so 15 becomes 18, and the Bearings suite gained one case (oversized candidate PR set) so 42 becomes 43. The Bearings literal was a latent second failure that the job never reached. Only the two stale literals were changed; the job's real assertions are untouched, and it still requires every listed file to parse under /bin/bash 3.2.57 and every test in both suites to pass there. Do not weaken, skip or disable this gate.

Failure 2, "PR must be raised via no-mistakes". PR 3418 was opened by hand with gh because at the time the pipeline had no write access anywhere and the fork did not exist. The captain authorised the fork https://github.com/rrecheve/firstmate on 2026-08-31 and it now has write access, so the gate must be satisfied the legitimate way: by having this pipeline push the branch to that fork and raise or re-raise the PR against kunchenguid/firstmate, producing a genuine attestation bound to the current head SHA. The gate is deliberately not forgery-proof, but hand-writing the signature or attestation into the PR body is explicitly out of scope and must not be done. The pipeline push target was configured with no-mistakes init --fork-url for exactly this reason. Prefer bringing the existing PR 3418 into compliance over closing and re-raising it.

Rebase context: upstream main moved to a5f3cbe "fix: support first public-followup registration on Bash 3.2 (#3420)", which touches the same file family and the same Bash 3.2 theme. Their fix is a different bug in a different file (empty array under set -u in bin/fm-public-followup.sh) from ours (argv size limits in bin/fm-public-followup-emit.sh), so the two are complementary and neither supersedes the other. The branch has been rebased onto their main; the one conflict, in docs/verification/public-followup.md, was purely additive and both sides were kept, theirs first. Their bin/fm-public-followup.sh and tests/fm-pr-check-security.test.sh changes are untouched by us. Never resolve a conflict by discarding their work; we are guests in their repository and if their approach supersedes ours we adopt theirs.

Constraints: bin/*.sh must pass shellcheck and bin/fm-lint.sh must be clean (both verified green locally, including actionlint on the edited workflow). Tracked Markdown uses one sentence per line and a plain dash, never an em dash. Never add an agent name as a commit co-author. This is somebody else's repository and their gates are not ours to lower: if a check cannot be made to pass for a reason outside our control, stop and report it with evidence rather than disabling, skipping or weakening the check.

## What Changed

- `bin/fm-fleet-snapshot.sh`, `bin/fm-bearings-snapshot.sh`, and `bin/fm-public-followup-emit.sh` now hand every value whose length has no producer bound (backlog and task documents, secondmate home summaries and reconciliations, status-log lines and PR URLs, candidate PR rows, composed deliverables, and outcome text) to `jq` through `--slurpfile`/`--rawfile` process substitution instead of `--argjson`/`--arg`. Previously a single document past Linux's 128 KiB `MAX_ARG_STRLEN` made the `exec` fail with `E2BIG` so `jq` never ran. Bounded values (ids, kinds, counts, timestamps, single paths, fixed state words) stay on argv.
- A shared `JQ_DOC` `doc($d; $name)` helper unwraps each slurped document and errors unless exactly one arrived, so a producer that emits nothing or concatenates multiple documents fails closed rather than binding `null` or silently keeping the first value; `fm-public-followup-emit.sh` applies the same length guard inline for deliverables.
- An unusable secondmate home summary (failed, timed out, oversized, malformed, or stale) now resets to `{}` and degrades to its own unknown-state record instead of cascading into a whole-snapshot exit 1, and its schema check runs under `jq -s` with `length == 1` so concatenated documents are rejected too.
- Added regressions for oversized backlogs, status lines, status-log PR URLs, unusable home summaries, oversized candidate PR sets, and oversized outcome text (file and stdin); updated the stock macOS Bash lane's exact `ok -` counts to 19 snapshot/fleet-view and 43 Bearings tests, and recorded the new argv-size guarantee in `docs/verification/public-followup.md`.

## Risk Assessment

✅ Low: The change is a mechanical, hunk-by-hunk semantics-preserving move of unbounded values from jq argv onto --slurpfile/--rawfile with a shared one-document guard, backed by real fail-before/pass-after regressions and CI count literals I independently recounted as correct (19 and 43); the single warning is a pre-existing fail-open pipeline boundary with no realistically reachable trigger left after this change.

## Testing

Ran the three suites that own the changed scripts (19 snapshot, 43 Bearings, 54 public-followup ok lines, no failures) plus two consumer suites, then went past pass/fail for product evidence: with only the three fixed scripts reverted to base, an operator running fm-fleet-view.sh, fm-bearings-snapshot.sh and fm-public-followup-emit.sh on oversized-but-ordinary inputs gets \"Argument list too long\" and no output at all, while the target commit renders the fleet view, the Bearings board and the published terminal event with the long values intact; a two-document remote summary likewise degrades to one unknown-state record instead of killing the whole snapshot. For the failing CI check I extracted the macos-stock-bash job script and ran it verbatim (exit 0, no ::error::, correct 19/43/1 counts) and reproduced the original failure by running the base version of that script against the current suites. Stock Bash 3.2.57 is unavailable on this Linux runner, so the job's parse sweep ran under 5.2.21 and the 3.2-specific half is left to the macOS lane in remote CI; the \"PR must be raised via no-mistakes\" check is a pipeline action outside this phase. One consumer suite, fm-bearings-board.test.sh, fails identically on base and target from a sandbox-level process-event source claim, so it is environmental rather than a regression. Evidence transcripts are in /tmp/no-mistakes-evidence/01M1E9Z2JZ2H9T9ABV54TBPXST.

<details>
<summary>Evidence: Operator CLI transcript: oversized backlog and status line, before vs after</summary>

```text
FM_HOME                  : /tmp/fm-argv-demo.HJkh6N
backlog.md size          : 107159 bytes
ship-task.status line    : 180010 bytes
MAX_ARG_STRLEN (one argv): 131072 bytes

==================================================================
BEFORE  (/tmp/fm-argv-baseline)
==================================================================
$ FM_HOME=$HOME_DIR bin/fm-fleet-view.sh 
/tmp/fm-argv-baseline/bin/fm-fleet-snapshot.sh: line 277: /usr/bin/jq: Argument list too long
jq: invalid JSON text passed to --argjson
Use jq --help for help with command-line options,
or see the jq manpage, or online docs  at https://jqlang.github.io/jq
/tmp/fm-argv-baseline/bin/fm-fleet-snapshot.sh: line 657: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed
-> exit 1

$ FM_HOME=$HOME_DIR bin/fm-bearings-snapshot.sh 
/tmp/fm-argv-baseline/bin/fm-fleet-snapshot.sh: line 277: /usr/bin/jq: Argument list too long
jq: invalid JSON text passed to --argjson
Use jq --help for help with command-line options,
or see the jq manpage, or online docs  at https://jqlang.github.io/jq
/tmp/fm-argv-baseline/bin/fm-fleet-snapshot.sh: line 657: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed
-> exit 1

$ FM_HOME=$HOME_DIR bin/fm-fleet-snapshot.sh --json | jq '.tasks[0] | ...'

==================================================================
AFTER  (/home/vscode/.no-mistakes/worktrees/c52ddf65534b/01M1E9Z2JZ2H9T9ABV54TBPXST)
==================================================================
$ FM_HOME=$HOME_DIR bin/fm-fleet-view.sh 
# Fleet View

Schema: fm-fleet-snapshot.v1
Home: /tmp/fm-argv-demo.HJkh6N

## Under Way
| ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| ship-task | unknown / none | ship | alpha | tmux | absent | - | /tmp/fm-argv-demo.HJkh6N/projects/alpha-worktree | bin/fm-peek.sh fm-ship-task |

## Queued
| ID | Title | Repo | Kind | Blocked By | Artifact |
| --- | --- | --- | --- | --- | --- |
| big-queued-001 | Big Queued 1 | alpha | ship | - | - |
| big-queued-002 | Big Queued 2 | alpha | ship | - | - |
| big-queued-003 | Big Queued 3 | alpha | ship | - | - |
| big-queued-004 | Big Queued 4 | alpha | ship | - | - |
| big-queued-005 | Big Queued 5 | alpha | ship | - | - |
| big-queued-006 | Big Queued 6 | alpha | ship | - | - |
| big-queued-007 | Big Queued 7 | alpha | ship | - | - |
| big-queued-008 | Big Queued 8 | alpha | ship | - | - |
| big-queued-009 | Big Queued 9 | alpha | ship | - | - |
  ... (100 lines total)
-> exit 0

$ FM_HOME=$HOME_DIR bin/fm-bearings-snapshot.sh 
schema: fm-bearings.v1
home: tmp/fm-argv-demo.HJkh6N
generated: "2026-09-01T11:41:24Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight[1]{id,kind,state,doing}:
  ship-task,ship,unknown,"backend target gone: firstmate:fm-ship-task"
secondmates: []
secondmate_reconcile: []
decisions_open: []
landed[6]{id,what,artifact,owner}:
  big-done-040,Big Done 40,"https://github.com/kunchenguid/firstmate/pull/40",(main)
  big-done-039,Big Done 39,"https://github.com/kunchenguid/firstmate/pull/39",(main)
  ... (52 lines total)
-> exit 0

$ FM_HOME=$HOME_DIR bin/fm-fleet-snapshot.sh --json | jq '.tasks[0] | ...'
{
  "task": "ship-task",
  "state": "working",
  "note_chars": 180000,
  "note_head": "rebasing onto main and re-running the suite; rebasing onto m",
  "backlog_records": 121,
  "main_inventory_orphans": 40
}
```
</details>
<details>
<summary>Evidence: Public-followup emit with a 176 KB outcome text, before vs after</summary>

<code>=== BEFORE (base a5f3cbe) ===&#10;outcome text file: 176059 bytes (one argv entry is capped at 131072)&#10;$ bin/fm-public-followup-emit.sh --home $HOME --obligation pf-demo --outcome pr-merged --outcome-text-file outcome.txt&#10;fm-public-followup-emit.sh: line 247: /usr/bin/jq: Argument list too long&#10;fm-public-followup-emit: could not build the typed terminal event&#10;-&gt; exit 1&#10;no terminal event was published - the promised public reply never happens&#10;&#10;=== AFTER (target 7a9c65a) ===&#10;-&gt; exit 0&#10;published terminal event: 51221036412dfdcc11284f409b66ce772e8238a5dfca3a2733e09f5765562206.json&#10;{&#10;&#34;schema_version&#34;: 1,&#10;&#34;obligation_id&#34;: &#34;pf-demo&#34;,&#10;&#34;outcome_type&#34;: &#34;pr-merged&#34;,&#10;&#34;deliverables&#34;: { &#34;pr_url&#34;: &#34;https://github.com/example/repo/pull/5&#34; },&#10;&#34;public_safe_outcome_chars&#34;: 600,&#10;&#34;public_safe_outcome_head&#34;: &#34;Shipped the café fix, and here is the rest of the report: a very long &#34;&#10;}</code>

```text
=== BEFORE (bin/fm-public-followup-emit.sh at base a5f3cbe) ===
outcome text file: 176059 bytes (one argv entry is capped at 131072)
$ bin/fm-public-followup-emit.sh --home $HOME --obligation pf-demo --outcome pr-merged --outcome-text-file outcome.txt
/tmp/fm-argv-baseline/bin/fm-public-followup-emit.sh: line 247: /usr/bin/jq: Argument list too long
fm-public-followup-emit: could not build the typed terminal event
-> exit 1
no terminal event was published - the promised public reply never happens

=== AFTER (bin/fm-public-followup-emit.sh at target 7a9c65a) ===
outcome text file: 176059 bytes (one argv entry is capped at 131072)
$ bin/fm-public-followup-emit.sh --home $HOME --obligation pf-demo --outcome pr-merged --outcome-text-file outcome.txt
51221036412dfdcc11284f409b66ce772e8238a5dfca3a2733e09f5765562206
-> exit 0
published terminal event: 51221036412dfdcc11284f409b66ce772e8238a5dfca3a2733e09f5765562206.json
{
  "schema_version": 1,
  "obligation_id": "pf-demo",
  "outcome_type": "pr-merged",
  "deliverables": {
    "pr_url": "https://github.com/example/repo/pull/5"
  },
  "public_safe_outcome_chars": 600,
  "public_safe_outcome_head": "Shipped the café fix, and here is the rest of the report: a very long "
}
```
</details>
<details>
<summary>Evidence: Multi-document slurp guard: whole-snapshot failure becomes one degraded record</summary>

<code>=== BEFORE (base a5f3cbe) ===&#10;remote home summary emits: 2 JSON documents&#10;$ FM_HOME=$HOME_DIR bin/fm-fleet-snapshot.sh --json&#10;-&gt; exit 1&#10;stderr:&#10;jq: invalid JSON text passed to --argjson&#10;(no snapshot output at all - every fleet read in this home is dead)&#10;&#10;=== AFTER (target 7a9c65a) ===&#10;remote home summary emits: 2 JSON documents&#10;-&gt; exit 0&#10;{&#10;&#34;secondmate_records&#34;: 1,&#10;&#34;id&#34;: &#34;twodocs&#34;,&#10;&#34;state&#34;: &#34;unknown&#34;,&#10;&#34;reason&#34;: &#34;structured home snapshot was malformed or stale&#34;,&#10;&#34;reconcile_inventory&#34;: null&#10;}</code>

```text
=== BEFORE (bin/fm-fleet-snapshot.sh at base a5f3cbe) ===
remote home summary emits: 2 JSON documents
$ FM_HOME=$HOME_DIR bin/fm-fleet-snapshot.sh --json
-> exit 1
stderr:
jq: invalid JSON text passed to --argjson
Use jq --help for help with command-line options,
or see the jq manpage, or online docs  at https://jqlang.github.io/jq
jq: invalid JSON text passed to --argjson
(no snapshot output at all - every fleet read in this home is dead)

=== AFTER (bin/fm-fleet-snapshot.sh at target 7a9c65a) ===
remote home summary emits: 2 JSON documents
$ FM_HOME=$HOME_DIR bin/fm-fleet-snapshot.sh --json
-> exit 0
{
  "secondmate_records": 1,
  "id": "twodocs",
  "state": "unknown",
  "reason": "structured home snapshot was malformed or stale",
  "reconcile_inventory": null
}
```
</details>
<details>
<summary>Evidence: macos-stock-bash job script run verbatim on the target: exit 0, no ::error::</summary>

```text
LOCAL EMULATION: stock macOS Bash 3.2.57 is unavailable on this Linux runner; running the rest of the job verbatim under 5.2.21(1)-release
GNU bash, version 5.2.21(1)-release (aarch64-unknown-linux-gnu)
ok - empty fleet snapshot and view use explicit absence markers
ok - fixture snapshot covers task rows, backlog rows, pointers, and stable ordering
ok - main_inventory discloses orphan/unstructured and clears when inventory is consistent
ok - backlog normalization preserves strict roles and resolves every blocker compatibly
ok - snapshot event hints follow reconciled current state
ok - durable fold keeps an open decision past a later unrelated event
ok - a live secondmate endpoint preserves unrelated open decisions
ok - durable captain-held transfer closes the duplicate live status decision
ok - durable fold clears a decision only on a keyed resolution
ok - a completed scout's stale decision surfaces as a report pointer, not pending
ok - a scout still parked at a decision stays pending (terminal clear does not over-fire)
ok - a backlog past the single-argument size cap still reads through snapshot, home summary, and bearings
ok - a status line past the single-argument size cap keeps its task instead of dropping it
ok - a status-log PR URL past the single-argument size cap keeps its task instead of dropping it
ok - an unusable secondmate home summary degrades to an unknown record instead of failing the snapshot
ok - snapshot includes durable scout reports after teardown
ok - snapshot parses tasks-axi rows and respects operational overrides
ok - fleet view renders the snapshot without secondmate peek guidance
ok - fleet view renders secondmate agent liveness
ok - Domain Alpha structured state overrides a stale parent Phase 7 event
ok - GNU stat file reads select -c without BSD filesystem-report pollution
ok - parent activity evidence is bounded and disclosed
ok - Bearings excludes a status-only child decision
ok - a structured child captain hold reaches Captain's Call
ok - missing, invalid, unreadable, malformed, and timed-out homes stay explicit unknowns
ok - an oversized secondmate summary retains the strict empty unknown fallback
ok - secondmate and per-home child counts are bounded, disclosed, and explicitly expandable
ok - parent decisions remain untrusted contradiction evidence
ok - parent evidence reconciliation distinguishes matching holds, blocks, and decisions
ok - nonprogressing child states are explicit and inconsistent terminal rows invalidate
ok - registry unavailability and bounded truncation remain explicit
ok - repeated snapshots keep the same current landed baseline and ignore prior reports
ok - default output is bounded, local-only, and marks omitted surfaces
ok - TOON and JSON are parity representations of the same model
ok - landed includes secondmate-managed merges alongside main-home merges
ok - default landed selection balances one dominant home with sparse homes
ok - landed selection refills capacity after sparse homes exhaust
ok - landed selection uses deterministic home order when homes exceed the cap
ok - landed selection preserves deterministic home and internal tie ordering
ok - landed selection handles no landed items
ok - --all-landed keeps the complete global landed output
ok - landed stays bounded with per-home + overall caps and omitted[] disclosure
ok - Bearings keeps a live blocker in structured live state and never converts it to Charted Next queue work
ok - action-free items (working/done/queued/landed) do not leak into Captain's Call
ok - main orphan in-flight stays out of Underway and is disclosed in omitted/gates
ok - main unstructured current is disclosed while structured siblings still project
ok - counterfactual meta clears main inventory warning and projects the live task
ok - mixed secondmate roles, partial state, and captain readiness project independently
ok - main and secondmate captain actionability use the same blocker readiness
ok - a completed scout with decision-like report prose is a pointer, not pending
ok - an authoritative captain hold surfaces end-to-end
ok - current report pointers surface
ok - superseded queued items are dropped by default and restored with --all-queued
ok - --include-prs is the only path that fetches, and it enriches correctly
ok - a partial GitHub failure degrades gracefully
ok - Perl fallback bounds stalled GitHub calls without coreutils timeout
ok - all fleet-sized sections are capped with counted opt-in expansion
ok - captain-held tasks of any kind reach Captain's Call, deferral is honored, and landed excludes answered calls
ok - live PR enrichment caps repositories with counted expansion
ok - per-repository open-PR caps are disclosed with an expansion knob
ok - a candidate PR set past the single-argument size cap still projects
ok - projection and TOON rendering failures exit nonzero with diagnostics
LOCAL EMULATION: skipping global npm install; tasks-axi 0.2.5 is already present
ok - first register succeeds with an empty lock list under /bin/bash
```
</details>
<details>
<summary>Evidence: Reported CI failure reproduced with the pre-fix literals</summary>

<code>=== the base a5f3cbe job script against the current suites ===&#10;ok - fleet view renders secondmate agent liveness&#10;::error::expected 15 snapshot/fleet-view tests, got 19&#10;job exit=1&#10;&#10;=== the same script at target 7a9c65a ===&#10;job exit=0 (19 snapshot + 43 Bearings + 1 public-followup ok lines, no ::error::)</code>

```text
LOCAL EMULATION: stock macOS Bash 3.2.57 unavailable; running the rest verbatim under 5.2.21(1)-release
GNU bash, version 5.2.21(1)-release (aarch64-unknown-linux-gnu)
ok - empty fleet snapshot and view use explicit absence markers
ok - fixture snapshot covers task rows, backlog rows, pointers, and stable ordering
ok - main_inventory discloses orphan/unstructured and clears when inventory is consistent
ok - backlog normalization preserves strict roles and resolves every blocker compatibly
ok - snapshot event hints follow reconciled current state
ok - durable fold keeps an open decision past a later unrelated event
ok - a live secondmate endpoint preserves unrelated open decisions
ok - durable captain-held transfer closes the duplicate live status decision
ok - durable fold clears a decision only on a keyed resolution
ok - a completed scout's stale decision surfaces as a report pointer, not pending
ok - a scout still parked at a decision stays pending (terminal clear does not over-fire)
ok - a backlog past the single-argument size cap still reads through snapshot, home summary, and bearings
ok - a status line past the single-argument size cap keeps its task instead of dropping it
ok - a status-log PR URL past the single-argument size cap keeps its task instead of dropping it
ok - an unusable secondmate home summary degrades to an unknown record instead of failing the snapshot
ok - snapshot includes durable scout reports after teardown
ok - snapshot parses tasks-axi rows and respects operational overrides
ok - fleet view renders the snapshot without secondmate peek guidance
ok - fleet view renders secondmate agent liveness
::error::expected 15 snapshot/fleet-view tests, got 19
job exit=1
```
</details>
<details>
<summary>Evidence: All six new regressions failing against the pre-fix scripts</summary>

```text
### BASELINE: post-fix regression tests against pre-fix bin/*.sh (base a5f3cbe) ###
### baseline tree is a real git checkout so fm-on.sh route resolution matches ###
--- test_oversized_backlog_still_reads ---
not ok - snapshot must survive a backlog larger than one argv entry
    /tmp/fm-argv-baseline/bin/fm-fleet-snapshot.sh: line 657: /usr/bin/jq: Argument list too long
  exit=1
--- test_oversized_status_line_keeps_the_task ---
not ok - an oversized status line must not drop the task or invent an orphan
    /tmp/fm-argv-baseline/bin/fm-fleet-snapshot.sh: line 277: /usr/bin/jq: Argument list too long
    jq: invalid JSON text passed to --argjson
  exit=1
--- test_oversized_status_pr_url_keeps_the_task ---
not ok - an oversized status PR URL must not drop the task or invent an orphan
    /tmp/fm-argv-baseline/bin/fm-fleet-snapshot.sh: line 277: /usr/bin/jq: Argument list too long
    /tmp/fm-argv-baseline/bin/fm-fleet-snapshot.sh: line 575: /usr/bin/jq: Argument list too long
  exit=1
--- test_unusable_secondmate_summary_degrades_to_unknown_record ---
not ok - one unusable secondmate home summary must not fail the whole snapshot: jq: invalid JSON text passed to --argjson
    not ok - one unusable secondmate home summary must not fail the whole snapshot: jq: invalid JSON text passed to --argjson
    jq: invalid JSON text passed to --argjson
    jq: invalid JSON text passed to --argjson
  exit=1
--- bearings: test_oversized_candidate_pr_set_still_projects ---
not ok - bearings must survive a candidate PR set larger than one argv entry
    /tmp/fm-argv-baseline/bin/fm-bearings-snapshot.sh: line 262: /usr/bin/jq: Argument list too long
    fm-bearings-snapshot: projection failed
  exit=1
--- public-followup: test_oversized_outcome_text_file_still_emits ---
not ok - emit must survive an outcome text larger than one argv entry (176059 bytes)
    /tmp/fm-argv-baseline/bin/fm-public-followup-emit.sh: line 247: /usr/bin/jq: Argument list too long
    fm-public-followup-emit: could not build the typed terminal event
  exit=1
```
</details>
<details>
<summary>Evidence: Suite runs on the target: snapshot (19), Bearings (43), public-followup (54)</summary>

```text
ok - empty fleet snapshot and view use explicit absence markers
ok - fixture snapshot covers task rows, backlog rows, pointers, and stable ordering
ok - main_inventory discloses orphan/unstructured and clears when inventory is consistent
ok - backlog normalization preserves strict roles and resolves every blocker compatibly
ok - snapshot event hints follow reconciled current state
ok - durable fold keeps an open decision past a later unrelated event
ok - a live secondmate endpoint preserves unrelated open decisions
ok - durable captain-held transfer closes the duplicate live status decision
ok - durable fold clears a decision only on a keyed resolution
ok - a completed scout's stale decision surfaces as a report pointer, not pending
ok - a scout still parked at a decision stays pending (terminal clear does not over-fire)
ok - a backlog past the single-argument size cap still reads through snapshot, home summary, and bearings
ok - a status line past the single-argument size cap keeps its task instead of dropping it
ok - a status-log PR URL past the single-argument size cap keeps its task instead of dropping it
ok - an unusable secondmate home summary degrades to an unknown record instead of failing the snapshot
ok - snapshot includes durable scout reports after teardown
ok - snapshot parses tasks-axi rows and respects operational overrides
ok - fleet view renders the snapshot without secondmate peek guidance
ok - fleet view renders secondmate agent liveness
```
</details>
<details>
<summary>Evidence: docs/verification/public-followup.md transcript matches the live suite output</summary>

<code>doc lines: 54 run lines: 54&#10;IDENTICAL: docs/verification/public-followup.md transcript matches this run line for line</code>

```text
doc lines: 54  run lines: 54
IDENTICAL: docs/verification/public-followup.md transcript matches this run line for line
```
</details>
<details>
<summary>Evidence: Evidence index with baseline-tree reconstruction steps</summary>

```text
# Evidence: argv-size (E2BIG) fix on fm/fm-fleet-reader-argv-limite

base a5f3cbe -> target 7a9c65a

The baseline tree used for every BEFORE column is a checkout of the target tree with only
bin/fm-fleet-snapshot.sh, bin/fm-bearings-snapshot.sh and bin/fm-public-followup-emit.sh
reverted to base a5f3cbe, so the sole difference is the fix itself.
Recreate it with:

    mkdir /tmp/fm-argv-baseline && git archive 7a9c65a | tar -x -C /tmp/fm-argv-baseline
    for f in bin/fm-fleet-snapshot.sh bin/fm-bearings-snapshot.sh bin/fm-public-followup-emit.sh; do
      git show a5f3cbe:"$f" > /tmp/fm-argv-baseline/$f; chmod +x /tmp/fm-argv-baseline/$f
    done
    cd /tmp/fm-argv-baseline && git init -q && git add -A && git commit -qm baseline   # fm-on.sh needs a tracked checkout

| file | what it shows |
| --- | --- |
| cli-transcript-before-after.txt | An operator runs `fm-fleet-view.sh` and `fm-bearings-snapshot.sh` on a home with a 107 KB backlog and a 180 KB status line. Before: both die with "Argument list too long", exit 1, no fleet read at all. After: the view and the Bearings board render, and the 180 000-character status note survives whole. |
| cli-transcript-public-followup-emit.txt | `fm-public-followup-emit.sh --outcome-text-file` with a 176 KB report body. Before: exit 1, no terminal event, the promised public reply never happens. After: the typed event is published and the outcome is still bounded at 600 codepoints without splitting the multi-byte "café". |
| cli-transcript-multidoc-guard.txt | A remote secondmate whose home-summary command emits two concatenated JSON documents. Before: the whole snapshot exits 1 with no output. After: that one mate degrades to an unknown-state record ("structured home snapshot was malformed or stale") and the rest of the fleet still reads. |
| macos-stock-bash-job-local-run.txt | The `macos-stock-bash` job script extracted from .github/workflows/ci.yml and executed verbatim (minus the Bash 3.2.57 gate, unavailable on this Linux runner, and the global npm install). Exit 0, no `::error::`, 19 + 43 + 1 ok lines. |
| macos-stock-bash-job-prefix-literals.txt | The same job script taken from base a5f3cbe, i.e. the stale literals, run against the current suites: `::error::expected 15 snapshot/fleet-view tests, got 19`, exit 1. This is the reported failing check reproduced. |
| baseline-regressions.txt | All six new regression tests run against the pre-fix scripts. Every one fails with the exact reported symptom (E2BIG / "invalid JSON text passed to --argjson"). They all pass on the target tree. |
| snapshot-suite.txt, bearings-suite.txt, public-followup-suite.txt | Full runs of the three owning suites on the target tree: 19, 43 and 54 ok lines, no failures. |
| doc-transcript-match.txt | The transcript recorded in docs/verification/public-followup.md matches the live suite output line for line, all 54 lines. |
| fm-home-summary-refresh.txt, fm-bearings-board-render.txt | Consumer suites of the changed scripts, both clean. |
| demo-oversized-fleet.sh, demo-multidoc-guard.sh | The manual reproductions used above, re-runnable as `<script> <fixed-tree> <baseline-tree>`. |
| fm-bearings-board.txt | Pre-existing environment failure, not caused by this change: `fm-procevent.sh` cannot claim a `lavish-*` process-event source in this sandbox. It fails identically on the base commit. |
```
</details>
- Outcome: ⚠️ 1 info across 1 run (12m36s)

## Note for maintainers: a pre-existing issue this change deliberately leaves alone

While working in `bin/fm-fleet-snapshot.sh` I noticed that a per-task read failure can discard a live worker silently instead of surfacing an error.
`task_json_lines` (line 469) ends its loop with `done | jq -s 'sort_by(.id)'` at line 676, and the script sets `set -u` at line 73 without `pipefail`, so the function's exit status is the one from `jq -s` and never from the per-task `jq`.
The caller's guard at line 1506 therefore does not see that failure: the affected task emits no line, the loop continues, the snapshot exits 0, the task disappears from `.tasks`, and its still-live in-flight backlog row is then reported under `orphan_in_flight`.
The earliest place the invariant could be enforced is the loop itself, around line 676, either with a per-task status check or a local `set -o pipefail`.

This predates this branch, and the change here does not touch that construct, so I have left it exactly as it is rather than widening a pull request that is about the single-argument size limit.
Whether a lost task should fail the read or degrade to a disclosed record looks like a design call for this repository's maintainers, and the same trade-off appears in this branch's own handling of an unusable secondmate home summary, so I am reporting it here instead of choosing on your behalf.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2fe8ac90364fc55b3cc64b12fad6a4db1532423e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `bin/fm-fleet-snapshot.sh:613` - `--arg pr &#34;$pr&#34;` is the one remaining task-level argv value the script itself derives from status-log text, which the change&#39;s own rule at lines 221-226 declares unbounded (&#34;A status log line has no producer bound at all&#34;). At lines 505-507 `pr` falls back to `first_pr_url_in_file &#34;$status_log&#34;`, i.e. `grep -Eo &#39;https?://[^[:space:])&#34;]+/pull/[0-9]+&#39;`; POSIX ERE takes the longest leftmost match, so a status line of the form `https://x/` + &gt;128 KiB of non-space, non-`)`, non-`&#34;` bytes + `/pull/1` yields a single argv entry past MAX_ARG_STRLEN. That per-task `jq -n` then fails with E2BIG, `task_json_lines`&#39;s `done | jq -s` silently drops the task&#39;s line while still exiting 0, and `main_inventory` reports the still-live backlog row as `orphan_in_flight` - the exact &#34;a supervisor would be told a live worker does not exist&#34; failure `test_oversized_status_line_keeps_the_task` was added to close, reachable through a sibling field in the same jq invocation that was just fixed. Every neighbouring status-derived value (`raw`, `note`, `verb`, `detail`, `last_event_raw`) was moved to `--rawfile`; `pr` was not. Fix at the same boundary: `--rawfile pr &lt;(printf &#39;%s&#39; &#34;$pr&#34;)`. Reachability is low (it needs a pathological unbroken URL-shaped token in a status log), which is why this is a follow-up rather than a merge blocker.
- ℹ️ `bin/fm-bearings-snapshot.sh:268` - The &#34;exactly one slurped document&#34; invariant is open-coded twice in this file with two independently written implementations and two divergent error strings - the accumulator at line 268 (`if (($a | length) == 1) and (($b | length) == 1) ... error(&#34;...for each candidate PR row set...&#34;)`) and the projection at line 332 (`if length == 1 then .[0] else error(&#34;...for $candidate_prs...&#34;)`). The sibling script factored the identical invariant into the reusable `JQ_DOC` helper (bin/fm-fleet-snapshot.sh:234), which yields one uniform, self-naming message. Defining the same one-line `def doc($d; $name)` constant here and calling `doc($a; &#34;a&#34;) + doc($b; &#34;b&#34;)` and `doc($candidate_prs; &#34;candidate_prs&#34;)` removes both hand-rolled copies with no behavior change. Non-functional cleanup only.

🔧 Fix: move PR URL off jq argv and share bearings doc guard
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-fleet-snapshot.sh:676` - The guards this change adds inside the per-task jq fail OPEN, not closed. `task_json_lines` ends `done | jq -s &#39;sort_by(.id)&#39;` with no `pipefail` (the script sets only `set -u` at line 73), so the function&#39;s exit status is `jq -s`&#39;s, never the per-task jq&#39;s. The caller&#39;s guard at line 1506, `TASKS_JSON=$(task_json_lines) || { echo &#34;task snapshot failed&#34;; exit 1; }`, is therefore dead for the dominant failure mode: a per-task jq that dies emits no line, the loop continues, the snapshot exits 0, the task vanishes from `.tasks`, and `main_inventory_json` (line 685) reports its still-live in-flight backlog row under `orphan_in_flight` with reason &#34;in-flight backlog item has no child metadata&#34;. That is verbatim the failure `test_oversized_status_line_keeps_the_task` was added to close (&#34;A supervisor reading that would be told a live worker does not exist&#34;). This change adds three NEW `error()` sites into exactly that jq - `doc($open_decisions)`, `doc($current_state)`, `doc($status_log)` at lines 630-632 - each of which, when it fires, silently deletes a live worker and manufactures a false orphan instead of failing the read. The two named triggers are now closed, and the one residual argv path I can name is contrived (`path_present_json` at line 239 still uses `--arg path`, so a hand-edited `worktree=` value past MAX_ARG_STRLEN would E2BIG, yield an empty `worktree_json`, and break `--argjson worktree_path`; real writers set `WT` to a created git worktree, so PATH_MAX bounds it in practice). The defect is the boundary itself, not a specific trigger: the earliest place the invariant can be made to hold is line 676, by giving the loop a per-task status check (or a local `set -o pipefail`) so a lost task surfaces instead of degrading into a false orphan. Which remedy is right is a product call - commit 5494ad4 chose &#34;degrade to a disclosed unknown record&#34; for an unusable secondmate home rather than hard-failing, and the same choice applies here - so this needs the author&#39;s decision rather than a mechanical fix.
- ℹ️ `tests/fm-fleet-snapshot-view.test.sh:850` - All five new regressions gate their fixtures on a hardcoded `131072` (here and at lines 915 and 988, plus tests/fm-bearings-snapshot.test.sh:1187 and tests/fm-public-followup.test.sh:291), but that number is not a constant: Linux computes MAX_ARG_STRLEN as PAGE_SIZE * 32, so it is 131072 only on 4 KiB-page hosts (verified 4096 here, so these tests genuinely fail-before/pass-after in this environment), 524288 on a 16 KiB-page aarch64 kernel, and 2 MiB on a 64 KiB-page one. Darwin has no per-argument cap at all - only the ~1 MiB total ARG_MAX - so on the `macos-stock-bash` lane, which is the very job this change exists to green and which runs both of these suites in full, a ~136 KiB single argv entry execs fine and every one of these cases passes with the `--arg`/`--argjson` bug fully restored. The fixture guards cannot detect this: `-gt 131072` still succeeds while the fixture sits below the host&#39;s real cap, so the case degrades from a regression proof into a plain happy-path assertion without any signal. The assertions themselves are correct behavior checks on every platform, and the x86-64 Linux lane still provides the fail-before proof, so nothing here is wrong or flaky - noting it so the durability limit is on the record rather than proposing a change.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-bearings-board.test.sh` - tests/fm-bearings-board.test.sh fails in this sandbox at &#34;the order-proof board build failed&#34; because bin/fm-procevent.sh cannot claim a lavish-* process-event source here. It is not caused by this change: the identical failure reproduces on the base commit a5f3cbe with the pre-fix scripts. Recorded only so the failing line in the evidence directory is not mistaken for a regression; remote CI owns this lane.
- <code>`/bin/bash tests/fm-fleet-snapshot-view.test.sh` - 19 ok lines, matches the CI literal</code>
- <code>`/bin/bash tests/fm-bearings-snapshot.test.sh` - 43 ok lines, matches the CI literal</code>
- <code>`/bin/bash tests/fm-public-followup.test.sh` - full owner suite of the changed emit script, 54 ok lines</code>
- <code>`FM_TEST_ONLY=test_first_register_succeeds_with_empty_lock_list_under_bash32 /bin/bash tests/fm-public-followup.test.sh` - the third count the CI job asserts</code>
- <code>Extracted the `macos-stock-bash` job&#39;s run script from .github/workflows/ci.yml and executed it verbatim (Bash 3.2.57 gate and global npm install substituted): exit 0, no `::error::`, 63 ok lines</code>
- <code>Ran the same job script taken from base a5f3cbe against the current suites to reproduce the reported failure: `::error::expected 15 snapshot/fleet-view tests, got 19`, exit 1</code>
- <code>Ran all six new regressions against a tree with only the three fixed scripts reverted to a5f3cbe: every one fails with E2BIG / `invalid JSON text passed to --argjson`</code>
- <code>Manual before/after: `FM_HOME=&lt;big-home&gt; bin/fm-fleet-view.sh` and `bin/fm-bearings-snapshot.sh` with a 107 KB backlog and a 180 KB status line</code>
- <code>Manual before/after: `bin/fm-public-followup-emit.sh --outcome-text-file` with a 176 KB outcome body, checking the published event JSON</code>
- `Manual before/after: remote secondmate whose home-summary command emits two concatenated JSON documents, checking the multi-document slurp guard`
- <code>`/bin/bash tests/fm-home-summary-refresh.test.sh` and `/bin/bash tests/fm-bearings-board-render.test.sh` - consumer suites of the changed scripts, clean</code>
- `Compared the recorded transcript in docs/verification/public-followup.md against the live suite output - identical, all 54 lines`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-bearings-snapshot.sh:109` - The `JQ_DOC` single-document guard is defined three times in executable code - `bin/fm-fleet-snapshot.sh:234`, `bin/fm-bearings-snapshot.sh:109`, and a hand-inlined variant inside the event builder in `bin/fm-public-followup-emit.sh` - differing only in the error prefix. I reduced the duplicated prose to a pointer, but the definition itself is code, so consolidating it (both scripts already source shared libs such as `bin/fm-timeout-lib.sh`, so a lib-owned helper is feasible) would change executable behavior and is outside this documentation phase. Proposed as a follow-up, not needed for this change.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

