### PR TITLE
test(brief): guard every brief renderer against Bash 3.2 heredoc parsing

### DIFF
--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -125,6 +125,7 @@ Firstmate PR #3644 demonstrated the cost: pinning a 75-162-script walk took 32.7
 - Plain dash `-`, never an em dash.
 - Never add an agent name as a commit co-author.
 - `bin/*.sh` and `bin/backends/*.sh` must pass `shellcheck`.
+- Every `bin/` and `tests/` script must also parse under stock macOS `/bin/bash` 3.2, so never nest a heredoc inside `$(...)`; `CONTRIBUTING.md`'s helper-script conventions own the rule, the safe shapes, and the sweep command.
 - Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition that CI and the no-mistakes pre-push gate both invoke, its own header owns what that definition covers, and it refuses to run under any other version of either linter.
 - When a task names a specific tool, implement the work with that tool, or explicitly flag the substitution and its new dependency footprint for review before shipping.
 - Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,8 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 - Helper scripts in `bin/` are plain bash.
   Each starts with a usage header comment; keep it accurate when you change behavior.
   Test scripts and helpers in `tests/` are plain bash too.
+  Every one of them must also parse under stock macOS `/bin/bash` 3.2, whose lexer tracks quote state through a heredoc body nested in `$(...)`, so never build a variable with `VAR=$(cat <<EOF ... EOF)`; use a plain heredoc into `cat`, `IFS= read -r -d '' VAR <<EOF || true`, or a function that prints the block instead.
+  The `macos-stock-bash` CI job runs the `/bin/bash -n` sweep below on real 3.2 for every pull request, and `tests/fm-brief.test.sh` guards the brief renderers' shape locally.
   `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, pinned shellcheck version, pinned actionlint workflow lint, and the backend-purity check rejecting direct Beads CLI calls in core `bin/` scripts), and both CI and the no-mistakes pre-push gate invoke it with no arguments.
   Its header and `--help` output own the exact local lint modes, file-set selection, and analysis flags.
   A malformed `.github/workflows/*.yml`, including a self-broken `ci.yml`, fails that local lint path before merge because a broken workflow cannot report its own breakage.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -7,10 +7,13 @@
 # the command substitution textually and tracks quote state through the heredoc
 # body, so a single apostrophe, unbalanced quote, or unbalanced paren anywhere
 # in that body breaks parsing of the *entire rest of the script* - `bash -n`
-# fails, not just the generated brief. The DOD and Herdr-section builders now
-# use `IFS= read -r -d '' VAR <<EOF || true` instead, which removes the `$(...)`
-# wrapper and eliminates the whole defect class regardless of future prose.
-# test_no_heredoc_in_command_substitution guards that structure directly.
+# fails, not just the generated brief. The Herdr and inbox section builders use
+# `IFS= read -r -d '' VAR <<EOF || true` instead, and the Definition of done
+# heredocs live in bin/fm-dod-lib.sh as plain `cat <<EOF` blocks that
+# bin/fm-brief.sh and bin/fm-promote.sh render through fm_dod_block; both shapes
+# remove the `$(...)` wrapper and eliminate the whole defect class regardless of
+# future prose. test_no_heredoc_in_command_substitution guards that structure
+# directly in every file that renders a brief.
 # Ambient `bash -n` here is Bash 5 and cannot see the bug, so the real
 # cross-version enforcement lives in the macos-stock-bash CI job.
 set -u
@@ -41,7 +44,7 @@ test_script_parses() {
 # guards the *shape* directly against the whole file, so any future DOD or
 # section builder that reintroduces the class fails here regardless of prose.
 test_no_heredoc_in_command_substitution() {
-  local unsafe safe
+  local unsafe safe script
   unsafe="$TMP_ROOT/heredoc-in-substitution.sh"
   safe="$TMP_ROOT/plain-heredoc.sh"
   # shellcheck disable=SC2016 # Literal shell fixtures must remain unexpanded.
@@ -53,9 +56,14 @@ test_no_heredoc_in_command_substitution() {
   fi
   no_heredoc_in_command_substitution "$safe" \
     || fail "structural guard treated heredoc body prose as shell structure"
-  no_heredoc_in_command_substitution "$ROOT/bin/fm-brief.sh" \
-    || fail "fm-brief.sh wraps a heredoc in a command substitution (breaks Bash 3.2 parsing)"
-  pass "fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)"
+  # The Definition of done heredocs live in bin/fm-dod-lib.sh, sourced by both
+  # bin/fm-brief.sh and bin/fm-promote.sh, so the guard follows every file that
+  # renders a brief rather than only the scaffold entry point.
+  for script in fm-brief.sh fm-dod-lib.sh fm-promote.sh; do
+    no_heredoc_in_command_substitution "$ROOT/bin/$script" \
+      || fail "$script wraps a heredoc in a command substitution (breaks Bash 3.2 parsing)"
+  done
+  pass "fm-brief.sh, fm-dod-lib.sh, fm-promote.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)"
 }
 
 no_heredoc_in_command_substitution() {


### PR DESCRIPTION
## Intent

Fix bin/fm-brief.sh so its ship-brief path parses and runs on stock macOS /bin/bash 3.2.57, where bash 3.2's lexer mishandles a heredoc nested inside $(...) command substitution when the heredoc body contains an apostrophe (bash -n failed with 'unexpected EOF while looking for matching quote'). Investigation established the structural fix already landed on main in PR #3269: the Definition-of-done heredocs moved out of fm-brief.sh into bin/fm-dod-lib.sh as plain cat <<EOF blocks (outside any command substitution), sourced by both fm-brief.sh and fm-promote.sh, and the macos-stock-bash CI job already sweeps every shell file in the fm-lint inventory with /bin/bash -n on real 3.2.57 on every PR. Verified empirically on this machine's /bin/bash 3.2.57: bash -n passes on all 344 inventory files; ship briefs for no-mistakes, direct-PR, and local-only plus --scout and --secondmate scaffold correctly with byte-identical DoD blocks; and appending a nested heredoc containing one apostrophe to fm-dod-lib.sh reproduces the exact reported error. The remaining gap this change closes: the fast Bash-5 structural guard test_no_heredoc_in_command_substitution in tests/fm-brief.test.sh still checked only bin/fm-brief.sh, so a regression reintroduced in fm-dod-lib.sh or fm-promote.sh would pass the local test and surface only in the macOS CI job. Deliberate decisions: (1) extend the existing structural guard (an established, documented exception to the no-source-byte-assertion style rule, because Bash 5 cannot observe this bug) to loop over fm-brief.sh, fm-dod-lib.sh, and fm-promote.sh rather than adding a new test runner; (2) refresh the test header comment to describe the current layout (Herdr/inbox builders use IFS= read -r -d '', DoD lives in fm-dod-lib.sh via fm_dod_block); (3) state the Bash 3.2 rule and safe shapes exactly once under CONTRIBUTING.md's helper-script conventions, next to the existing /bin/bash -n sweep command, with only a one-line cross-reference in .agents/skills/firstmate-coding-guidelines/SKILL.md per the repo's one-owner rule; (4) do not touch bin/fm-brief.sh, fm-dod-lib.sh, or the CI workflow, since they are already correct and generated brief text must remain unchanged; (5) no new CI job because real-3.2 coverage already exists. Style constraints: one sentence per line in Markdown, plain dashes, no agent co-author. Environment note: the local lint exits 1 solely because actionlint is not installed on this machine; shellcheck is clean and the pipeline's own lint fix agent confirmed the full lint exits 0 once actionlint 1.7.12 is present, so that is not a code finding.

## What Changed

- Extended the `test_no_heredoc_in_command_substitution` structural guard in `tests/fm-brief.test.sh` to loop over `bin/fm-brief.sh`, `bin/fm-dod-lib.sh`, and `bin/fm-promote.sh`, so a heredoc-in-command-substitution regression reintroduced in any of the three renderers is caught locally instead of only surfacing in the macOS stock-Bash CI job.
- Refreshed the test's header comment to describe the current layout (Herdr/inbox builders using `IFS= read -r -d ''`, Definition-of-done text living in `fm-dod-lib.sh` via `fm_dod_block`).
- Documented the Bash 3.2 heredoc rule and safe shapes once in `CONTRIBUTING.md` beside the existing `/bin/bash -n` sweep, with a one-line cross-reference added to `.agents/skills/firstmate-coding-guidelines/SKILL.md`.

The Test stage confirms all 21 checks pass on `/bin/bash` 3.2.57 and that an injected regression trips the extended guard. The single Lint warning is only the absence of the `actionlint` tool on the runner, not a code finding.

## Risk Assessment

✅ Low: The change only extends an existing structural test guard to cover two additional already-present files and adds documentation; no runtime code or generated brief output changes, and the referenced files and helper function are verified present and correctly shaped.

## Testing

Baseline `./tests/fm-brief.test.sh` passes cleanly (exit 0, 21 checks) on the machine's stock /bin/bash 3.2.57, which is the very interpreter this change targets. To prove the guard actually protects against the regression it was extended for — not just that the current tree is clean — I injected the reported bug (a heredoc-in-command-substitution with an apostrophe) into bin/fm-dod-lib.sh and confirmed the extended guard fails with `not ok - fm-dod-lib.sh wraps a heredoc in a command substitution`, whereas the pre-change guard checked only fm-brief.sh and would have missed it; the file was then restored. I also reproduced the original `unexpected EOF` parse error under `bash -n`, confirmed all three renderers parse safely on 3.2, and rendered the DoD blocks for all three delivery modes (including the apostrophe-bearing no-mistakes prose) as product artifacts. The CI/docs edits are documentation-only and require no code test. Working tree left clean; overall result: pass.

<details>
<summary>Evidence: Extended guard catches a regression reintroduced in fm-dod-lib.sh (the gap the change closes)</summary>

```text
### Extended guard vs a regression reintroduced in bin/fm-dod-lib.sh
(This is the exact gap the change closes: pre-change the guard only checked fm-brief.sh.)

$ ./tests/fm-brief.test.sh  # only the structural guard shown
/var/folders/ld/8gwv1fy138x2j9c27z7z5mqw0000gn/T//fm-brief.Ul6eo0/heredoc-in-substitution.sh:2
not ok - fm-dod-lib.sh wraps a heredoc in a command substitution (breaks Bash 3.2 parsing)

test suite exit =  (non-zero = regression caught)
```
</details>
<details>
<summary>Evidence: Stock bash 3.2 parse evidence: three renderers pass, reported bug reproduces</summary>

```text
### Stock bash version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

### 1. bash -n on the real (fixed) three renderers — all parse-safe on 3.2
PASS  bin/fm-brief.sh
PASS  bin/fm-dod-lib.sh
PASS  bin/fm-promote.sh

### 2. Reproduce reported bug: nested heredoc + apostrophe appended to fm-dod-lib.sh copy
$ /bin/bash -n <copy-with-regression>
exit=2
stderr: /var/folders/ld/8gwv1fy138x2j9c27z7z5mqw0000gn/T/tmp.0XGH7gtC59/fm-dod-lib.sh: line 71: unexpected EOF while looking for matching `''
/var/folders/ld/8gwv1fy138x2j9c27z7z5mqw0000gn/T/tmp.0XGH7gtC59/fm-dod-lib.sh: line 75: syntax error: unexpected end of file
```
</details>
<details>
<summary>Evidence: DoD blocks rendered by fm_dod_block on bash 3.2 (all three modes, apostrophe prose intact)</summary>

```text
# Definition-of-done blocks rendered by fm_dod_block on stock /bin/bash 3.2.57
# (bin/fm-dod-lib.sh — the plain cat <<EOF blocks moved out of $(...))

======================= mode=no-mistakes =======================
# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.

======================= mode=direct-PR =======================
# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.

======================= mode=local-only =======================
# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/TASK-123`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/TASK-123` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`./tests/fm-brief.test.sh` on /bin/bash 3.2.57 — all 21 checks pass (exit 0), including the extended `test_no_heredoc_in_command_substitution` naming all three renderers</code>
- <code>Injected a `VAR=$(cat &lt;&lt;EOF ... &#39;apostrophe ... EOF)` regression into bin/fm-dod-lib.sh and re-ran the suite: the extended guard reports `not ok - fm-dod-lib.sh wraps a heredoc in a command substitution` (the exact gap the change closes; pre-change it only checked fm-brief.sh), then restored the file clean</code>
- <code>`/bin/bash -n` on bin/fm-brief.sh, bin/fm-dod-lib.sh, bin/fm-promote.sh — all parse-safe on 3.2</code>
- <code>Reproduced the reported bug: appending a nested heredoc with one apostrophe yields `unexpected EOF while looking for matching &#34;&#39;&#39;&#34;` under bash 3.2 -n</code>
- <code>Rendered `fm_dod_block` for no-mistakes/direct-PR/local-only on bash 3.2 — DoD blocks emit cleanly, including the apostrophe-containing no-mistakes prose that triggered the original failure</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: no code lint issues; failure was missing actionlint tool
1 warning still open:
- ⚠️ linter found issues (exit code 1)

🔧 Fix: no code lint issues; failure was missing actionlint tool
1 warning still open:
- ⚠️ linter found issues (exit code 1)

🔧 Fix: no code lint issues; failure was missing actionlint tool
1 warning still open:
- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
