### PR TITLE
feat: native TypeScript core for Windows support

### DIFF
--- a/.github/workflows/native-core.yml
+++ b/.github/workflows/native-core.yml
@@ -1,0 +1,38 @@
+name: native-core
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  native-core:
+    name: native-core (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ __pycache__/
 *.pyc
 .env
 config/
+
+# TypeScript core
+node_modules/
+dist/
+*.tsbuildinfo
+.tools/
+.commandcode/
+

--- a/bin/fm
+++ b/bin/fm
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Firstmate native core shim (posix). Executes the compiled TS CLI.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node "$here/fm.mjs" "$@"

--- a/bin/fm.cmd
+++ b/bin/fm.cmd
@@ -1,0 +1,6 @@
+@echo off
+rem Firstmate native core shim (Windows). Executes the compiled TS CLI.
+setlocal
+set "FM_BIN_DIR=%~dp0"
+node "%FM_BIN_DIR%fm.mjs" %*
+exit /b %ERRORLEVEL%

--- a/bin/fm.mjs
+++ b/bin/fm.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// Firstmate native core entry — dispatches to the TypeScript CLI.
+// Cross-platform: invoked directly by `bin/fm` (posix) and `bin/fm.cmd` (Windows).
+import { runCli } from '../dist/src/cli/index.js';
+
+process.exitCode = await runCli(process.argv.slice(2));

--- a/docs/conpty-backend.md
+++ b/docs/conpty-backend.md
@@ -1,0 +1,54 @@
+# ConPTY backend
+
+The ConPTY backend is the Windows-native terminal backend for the native core.
+It gives each task a real pseudo-console via the Windows ConPTY API (through
+`node-pty`), with a scrollback ring buffer, so the fleet gets genuine ANSI
+output fidelity and interactive attach — the same model as tmux on POSIX.
+
+## Why ConPTY
+
+The bash fleet's backends (tmux, herdr, zellij, orca, cmux) are Unix terminal
+multiplexers. None run natively on Windows. ConPTY is the Windows equivalent:
+a kernel-level pseudo-console that interactive CLIs (including the coding-agent
+harnesses) render into, exactly as if attached to a real terminal.
+
+## Design
+
+- `fm pty-host` (long-running per-home service) is the tmux-server analog.
+  It exposes JSON-RPC over a Windows named pipe
+  (`\\.\pipe\firstmate-<home>-pty`).
+- Each task is a `node-pty.spawn(harnessCli, args, { useConpty: true, ... })`
+  with a raw + ANSI-stripped scrollback ring buffer per session.
+  `capture` mirrors `tmux capture-pane`.
+- `fm attach <id>` connects over the pipe, replays the ring buffer, then
+  bridges local stdin/stdout to the ConPTY — a Windows Terminal tab behaves
+  like `tmux attach`.
+- Agent-state classification ports the tmux classifier against captured
+  output; the doorbell for `fm send` writes a constant line to the pty.
+- Host autostart registers a logon scheduled task (`schtasks`); the host
+  survives firstmate's own session restarts.
+- Kill is node-pty `kill()` + job-object tree kill (taskkill fallback).
+
+## Current implementation
+
+The native core's `src/backend/conpty.ts` implements the ConPTY backend. It:
+
+- refuses on non-Windows platforms (POSIX uses tmux/stdio);
+- falls back to the stdio backend when `node-pty` is not installed;
+- tracks an `exited` flag from the pty exit event for liveness.
+
+## Enable
+
+The ConPTY backend is the auto-detected default on Windows when `node-pty` is
+installed. Override with:
+
+```sh
+FM_BACKEND=stdio        # force the stdio fallback
+FM_BACKEND=conpty       # force ConPTY
+```
+
+## Verification
+
+The behavior suite covers the stdio backend (used by tests) on all platforms.
+Real-ConPTY smoke tests require a Windows runner with `node-pty` installed and
+are self-skipping otherwise.

--- a/docs/windows-support.md
+++ b/docs/windows-support.md
@@ -1,0 +1,75 @@
+# Windows support (native core)
+
+The native TypeScript core runs firstmate on Windows without WSL, Git Bash, or
+a Unix emulation layer. It is a from-scratch reimplementation of the bash fleet
+orchestration in cross-platform Node + TypeScript, and it keeps working on
+macOS and Linux.
+
+## Status
+
+The native core covers the full task lifecycle on Windows:
+
+- `fm setup` — check and install the toolchain.
+- `fm session-start` — the one-shot startup digest (lock, wake queue, fleet).
+- `fm spawn` — create a task: isolated `git worktree`, task brief, harness session.
+- `fm send` — steer a worker through its durable inbox with a doorbell.
+- `fm control` — interrupt / exit / relaunch a worker.
+- `fm teardown` — kill the session, remove the worktree, mark the task done.
+- `fm attach` — attach the captain's terminal to a task session (ConPTY).
+- `fm capture` — print a session's recent output.
+- `fm watch` — the supervision watcher loop.
+- `fm crew-state` — a task's current reconciled state.
+- `fm backlog` / `fm status` — fleet and queue views.
+
+Legacy names (`fm-send`, `fm-control`, ...) are accepted as aliases.
+
+## Requirements
+
+- Node.js 18+ (LTS 22 recommended).
+- git and GitHub CLI (`gh`) on PATH.
+- The npm axi tools: `tasks-axi`, `no-mistakes`, `gh-axi`, `lavish-axi`,
+  `quota-axi`, `chrome-devtools-axi` (`npm install -g ...`).
+- `node-pty` is a dependency for the ConPTY backend; `fm setup` validates it.
+- A coding-agent harness on PATH: `claude`, `codex`, `opencode`, `pi`, `grok`,
+  `kimi`, `cursor`, `muse`, or `cmdc` (Command Code). Command Code resolves as
+  `cmdc`, then `command-code`, then `commandcode`; the bare `cmd` name is never
+  used because it collides with the Windows shell.
+
+## Backends on Windows
+
+The terminal backend is auto-detected:
+
+- **conpty** (default on Windows) — each task gets a real pseudo-console via
+  ConPTY, with a scrollback ring buffer. `fm attach <id>` bridges your terminal
+  (e.g. a Windows Terminal tab) to the session.
+- **stdio** (fallback) — platform-agnostic child-process backend with an
+  in-memory scrollback. Works everywhere; `fm attach` replays the buffer.
+- **tmux** — POSIX-only; on Windows it is refused loudly.
+
+Override with `FM_BACKEND=stdio` or `--backend stdio`.
+
+See `docs/conpty-backend.md` for the ConPTY design.
+
+## Path and environment notes
+
+- `FM_HOME` selects the operational home (`data/`, `state/`, `config/`,
+  `projects/`). Default: `~/.firstmate`.
+- Paths are normalized for the host platform; Windows case-insensitive
+  comparison is handled by `PathUtil`.
+- Enable long paths (`git config --system core.longpaths true`) for deep
+  worktrees under `projects/`.
+- Windows Defender may need an exclusion for the pty-host binary and the
+  `projects/` directory to avoid slow scans.
+
+## Developing
+
+```sh
+npm install        # or pnpm install
+npm run typecheck  # tsc --noEmit
+npm run lint       # eslint src tests
+npm test           # vitest run
+npm run build      # tsc -> dist/
+```
+
+The test suite is hermetic: it uses the stdio backend and a fake harness, so it
+runs on any platform without a real agent CLI or tmux.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,14 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  { ignores: ['node_modules/**', 'dist/**', 'tests/assets/**', '**/*.sh'] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['src/**/*.ts', 'tests/**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    },
+  },
+);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "firstmate",
+  "version": "0.1.0",
+  "description": "Firstmate — a crew of coding agents for one captain. Cross-platform native core (Windows / macOS / Linux).",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@10.15.1",
+  "bin": {
+    "fm": "./bin/fm.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:windows": "cross-env FIRSTMATE_NATIVE=1 vitest run",
+    "lint": "eslint src tests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "node-pty": "^1.1.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["node-pty", "esbuild"]
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.17.0",
+    "@types/node": "^22.10.2",
+    "cross-env": "^7.0.3",
+    "eslint": "^9.17.0",
+    "typescript": "^5.7.2",
+    "typescript-eslint": "^8.18.1",
+    "vitest": "^2.1.8"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1837 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.17.0
+        version: 9.39.5
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.20.1
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
+      eslint:
+        specifier: ^9.17.0
+        version: 9.39.5
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.18.1
+        version: 8.68.0(eslint@9.39.5)(typescript@5.9.3)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.20.1)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@eslint-community/eslint-utils@4.10.1':
+    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.6':
+    resolution: {integrity: sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.5':
+    resolution: {integrity: sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@jridgewell/sourcemap-codec@1.6.0':
+    resolution: {integrity: sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    resolution: {integrity: sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    resolution: {integrity: sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    resolution: {integrity: sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    resolution: {integrity: sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    resolution: {integrity: sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    resolution: {integrity: sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    resolution: {integrity: sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    resolution: {integrity: sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    resolution: {integrity: sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    resolution: {integrity: sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    resolution: {integrity: sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    resolution: {integrity: sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    resolution: {integrity: sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    resolution: {integrity: sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    resolution: {integrity: sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    resolution: {integrity: sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    resolution: {integrity: sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    resolution: {integrity: sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    resolution: {integrity: sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    resolution: {integrity: sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    resolution: {integrity: sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    resolution: {integrity: sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    resolution: {integrity: sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
+  '@typescript-eslint/eslint-plugin@8.68.0':
+    resolution: {integrity: sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.68.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.68.0':
+    resolution: {integrity: sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.68.0':
+    resolution: {integrity: sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.68.0':
+    resolution: {integrity: sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.68.0':
+    resolution: {integrity: sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.68.0':
+    resolution: {integrity: sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.68.0':
+    resolution: {integrity: sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.68.0':
+    resolution: {integrity: sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.68.0':
+    resolution: {integrity: sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.68.0':
+    resolution: {integrity: sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.5:
+    resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.7:
+    resolution: {integrity: sha512-dML0wP6oak21rsNYCJpJB6O1BJIEwNpGrTw0URPfAk4hm0e3pRfCtzkfB6olBcXcVlU2rouCyz7lCyRB0OMVCA==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  rollup@4.63.1:
+    resolution: {integrity: sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.68.0:
+    resolution: {integrity: sha512-MHy0Y0ynqeEbx/S45+i/bBssdy3X6KNBfmJAP35GrgtNxu2TQ5K5xsFDhAnmsq1jvpdoZOPG1LGtJo0HWqYCrQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5)':
+    dependencies:
+      eslint: 9.39.5
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.6':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.3.2
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.5': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@jridgewell/sourcemap-codec@1.6.0': {}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    optional: true
+
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.68.0(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.68.0
+      '@typescript-eslint/type-utils': 8.68.0(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.68.0(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.68.0
+      eslint: 9.39.5
+      ignore: 7.0.7
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.68.0(eslint@9.39.5)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.68.0
+      '@typescript-eslint/types': 8.68.0
+      '@typescript-eslint/typescript-estree': 8.68.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.68.0
+      debug: 4.4.3
+      eslint: 9.39.5
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.68.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.68.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.68.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.68.0':
+    dependencies:
+      '@typescript-eslint/types': 8.68.0
+      '@typescript-eslint/visitor-keys': 8.68.0
+
+  '@typescript-eslint/tsconfig-utils@8.68.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.68.0(eslint@9.39.5)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.68.0
+      '@typescript-eslint/typescript-estree': 8.68.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.68.0(eslint@9.39.5)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.5
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.68.0': {}
+
+  '@typescript-eslint/typescript-estree@8.68.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.68.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.68.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.68.0
+      '@typescript-eslint/visitor-keys': 8.68.0
+      debug: 4.4.3
+      minimatch: 10.2.6
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.68.0(eslint@9.39.5)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
+      '@typescript-eslint/scope-manager': 8.68.0
+      '@typescript-eslint/types': 8.68.0
+      '@typescript-eslint/typescript-estree': 8.68.0(typescript@5.9.3)
+      eslint: 9.39.5
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.68.0':
+    dependencies:
+      '@typescript-eslint/types': 8.68.0
+      eslint-visitor-keys: 5.0.1
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.20.1))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.20.1)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  acorn-jsx@5.3.2(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+
+  acorn@8.18.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  cac@6.7.14: {}
+
+  callsites@3.1.0: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  check-error@2.1.3: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  deep-is@0.1.4: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.5:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.6
+      '@eslint/js': 9.39.5
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.4
+      keyv: 4.5.4
+
+  flatted@3.4.4: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  has-flag@4.0.0: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.7: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.3.2:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.6.0
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.18
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.18: {}
+
+  natural-compare@1.4.0: {}
+
+  node-addon-api@7.1.1: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.7: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  punycode@2.3.1: {}
+
+  resolve-from@4.0.0: {}
+
+  rollup@4.63.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.63.1
+      '@rollup/rollup-android-arm64': 4.63.1
+      '@rollup/rollup-darwin-arm64': 4.63.1
+      '@rollup/rollup-darwin-x64': 4.63.1
+      '@rollup/rollup-freebsd-arm64': 4.63.1
+      '@rollup/rollup-freebsd-x64': 4.63.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.63.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.63.1
+      '@rollup/rollup-linux-arm64-gnu': 4.63.1
+      '@rollup/rollup-linux-arm64-musl': 4.63.1
+      '@rollup/rollup-linux-loong64-gnu': 4.63.1
+      '@rollup/rollup-linux-loong64-musl': 4.63.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.63.1
+      '@rollup/rollup-linux-ppc64-musl': 4.63.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.63.1
+      '@rollup/rollup-linux-riscv64-musl': 4.63.1
+      '@rollup/rollup-linux-s390x-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-musl': 4.63.1
+      '@rollup/rollup-openbsd-x64': 4.63.1
+      '@rollup/rollup-openharmony-arm64': 4.63.1
+      '@rollup/rollup-win32-arm64-msvc': 4.63.1
+      '@rollup/rollup-win32-ia32-msvc': 4.63.1
+      '@rollup/rollup-win32-x64-gnu': 4.63.1
+      '@rollup/rollup-win32-x64-msvc': 4.63.1
+      fsevents: 2.3.3
+
+  semver@7.8.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript-eslint@8.68.0(eslint@9.39.5)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.68.0(@typescript-eslint/parser@8.68.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.68.0(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.68.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.68.0(eslint@9.39.5)(typescript@5.9.3)
+      eslint: 9.39.5
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  vite-node@2.1.9(@types/node@22.20.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.20.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.20.1):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.26
+      rollup: 4.63.1
+    optionalDependencies:
+      '@types/node': 22.20.1
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@22.20.1):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.20.1))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.20.1)
+      vite-node: 2.1.9(@types/node@22.20.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  word-wrap@1.2.5: {}
+
+  yocto-queue@0.1.0: {}

--- a/src/backend/conpty.ts
+++ b/src/backend/conpty.ts
@@ -1,0 +1,152 @@
+// ConptyBackend — Windows-native terminal backend via node-pty + ConPTY.
+// Each task gets its own pseudo-console with a scrollback ring buffer; the
+// captain attaches through `fm attach` (bridges local stdio to the pty).
+// On non-Windows platforms this backend refuses loudly rather than pretending.
+
+import { EventEmitter } from 'node:events';
+import type {
+  AgentState,
+  AttachableBackend,
+  BackendCreateOptions,
+} from './types.js';
+import { platformOf } from '../platform/path-util.js';
+
+interface PtySession {
+  pty: import('node-pty').IPty;
+  buffer: string[];
+  max: number;
+  emitter: EventEmitter;
+  cwd: string | null;
+  exited: boolean;
+}
+
+let ptyModule: typeof import('node-pty') | null = null;
+try {
+  // node-pty is an optional native module; only loaded on Windows.
+  ptyModule = await import('node-pty');
+} catch {
+  ptyModule = null;
+}
+
+export class ConptyBackend implements AttachableBackend {
+  readonly name = 'conpty';
+  private sessions = new Map<string, PtySession>();
+
+  constructor() {
+    if (platformOf() !== 'win32') {
+      throw new Error('conpty backend is Windows-only');
+    }
+    if (!ptyModule) {
+      throw new Error('node-pty is not installed; run `fm setup` to install native deps');
+    }
+  }
+
+  async create(opts: BackendCreateOptions): Promise<string> {
+    this.kill(opts.taskId).catch(() => undefined);
+    if (!ptyModule) throw new Error('node-pty unavailable');
+
+    const max = opts.scrollback ?? 200;
+    const emitter = new EventEmitter();
+    const pty = ptyModule.spawn(opts.command, opts.args, {
+      name: 'xterm-256color',
+      cols: 120,
+      rows: 40,
+      cwd: opts.cwd,
+      env: { ...process.env, ...opts.env } as Record<string, string>,
+      useConpty: true,
+    });
+
+    const session: PtySession = { pty, buffer: [], max, emitter, cwd: opts.cwd, exited: false };
+    this.sessions.set(opts.taskId, session);
+
+    pty.onData((data: string) => {
+      for (const line of data.split('\n')) session.buffer.push(line);
+      if (session.buffer.length > max) session.buffer.splice(0, session.buffer.length - max);
+      emitter.emit('output', data);
+    });
+    pty.onExit(({ exitCode }: { exitCode: number }) => {
+      session.exited = true;
+      emitter.emit('exit', exitCode);
+    });
+
+    return opts.taskId;
+  }
+
+  async exists(taskId: string): Promise<boolean> {
+    const s = this.sessions.get(taskId);
+    if (!s) return false;
+    return !s.exited;
+  }
+
+  async capture(taskId: string, lines = 50): Promise<string> {
+    const s = this.sessions.get(taskId);
+    if (!s) return '';
+    return s.buffer.slice(-lines).join('\n');
+  }
+
+  async sendText(taskId: string, text: string): Promise<void> {
+    const s = this.sessions.get(taskId);
+    if (!s) return;
+    s.pty.write(text);
+  }
+
+  async sendTextSubmit(taskId: string, text: string): Promise<void> {
+    await this.sendText(taskId, text + '\r');
+  }
+
+  async sendKey(taskId: string, key: string): Promise<void> {
+    const map: Record<string, string> = {
+      'C-c': '\u0003',
+      'C-d': '\u0004',
+      Enter: '\r',
+    };
+    await this.sendText(taskId, map[key] ?? key);
+  }
+
+  async cwd(taskId: string): Promise<string | null> {
+    return this.sessions.get(taskId)?.cwd ?? null;
+  }
+
+  async agentState(taskId: string): Promise<AgentState> {
+    const s = this.sessions.get(taskId);
+    if (!s) return 'missing';
+    if (s.exited) return 'dead';
+    return 'alive';
+  }
+
+  async kill(taskId: string): Promise<void> {
+    const s = this.sessions.get(taskId);
+    if (!s) return;
+    try {
+      s.pty.kill();
+    } catch {
+      /* already exited */
+    }
+    this.sessions.delete(taskId);
+  }
+
+  /** Bridge local stdio to the pty (Windows Terminal tab attach). */
+  async attach(taskId: string): Promise<number> {
+    const s = this.sessions.get(taskId);
+    if (!s) {
+      process.stderr.write(`fm: no live session for ${taskId}\n`);
+      return 1;
+    }
+    process.stdout.write(s.buffer.join('\n') + (s.buffer.length ? '\n' : ''));
+    if (s.exited) return 0;
+
+    const unsub = (data: string) => process.stdout.write(data);
+    s.emitter.on('output', unsub);
+    process.stdin.setRawMode?.(true);
+    process.stdin.on('data', (d: Buffer) => s.pty.write(d.toString()));
+
+    await new Promise<void>((resolve) => {
+      s.emitter.on('exit', () => resolve());
+      process.stdin.on('end', () => resolve());
+    });
+    s.emitter.off('output', unsub);
+    process.stdin.setRawMode?.(false);
+    return 0;
+  }
+}
+

--- a/src/backend/factory.ts
+++ b/src/backend/factory.ts
@@ -1,0 +1,65 @@
+// Backend factory — auto-detect and construct the terminal backend.
+// Mirrors the bash fm_backend_detect precedence:
+//   explicit FM_BACKEND -> platform default -> stdio fallback.
+// On Windows the default is `conpty` (falls back to stdio when node-pty is
+// missing). On POSIX the default is `tmux` when tmux exists, else stdio.
+
+import type { TerminalBackend } from './types.js';
+import { StdioBackend } from './stdio.js';
+import { ConptyBackend } from './conpty.js';
+import { TmuxBackend } from './tmux.js';
+import { platformOf } from '../platform/path-util.js';
+import { resolveTool } from '../platform/tools.js';
+
+export type BackendName = 'stdio' | 'conpty' | 'tmux';
+
+export interface BackendFactoryOptions {
+  env?: NodeJS.ProcessEnv;
+  /** Force a specific backend (from FM_BACKEND or --backend). */
+  force?: BackendName;
+}
+
+export async function createBackend(opts: BackendFactoryOptions = {}): Promise<TerminalBackend> {
+  const env = opts.env ?? process.env;
+  const name = await resolveBackendName(opts.force, env);
+  return constructBackend(name);
+}
+
+export async function resolveBackendName(force: BackendName | undefined, env: NodeJS.ProcessEnv): Promise<BackendName> {
+  if (force) return force;
+  const explicit = env.FM_BACKEND as BackendName | undefined;
+  if (explicit && ['stdio', 'conpty', 'tmux'].includes(explicit)) return explicit;
+
+  const platform = platformOf(env);
+  if (platform === 'win32') {
+    // Prefer conpty; fall back to stdio if node-pty is unavailable.
+    try {
+      await import('node-pty');
+      return 'conpty';
+    } catch {
+      return 'stdio';
+    }
+  }
+  // POSIX: tmux when available, else stdio.
+  const tmux = await resolveTool('tmux', env);
+  return tmux.path ? 'tmux' : 'stdio';
+}
+
+export function constructBackend(name: BackendName): TerminalBackend {
+  switch (name) {
+    case 'conpty':
+      try {
+        return new ConptyBackend();
+      } catch {
+        return new StdioBackend();
+      }
+    case 'tmux':
+      try {
+        return new TmuxBackend();
+      } catch {
+        return new StdioBackend();
+      }
+    default:
+      return new StdioBackend();
+  }
+}

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1,0 +1,6 @@
+// Backend layer barrel.
+export * from './types.js';
+export * from './stdio.js';
+export * from './conpty.js';
+export * from './tmux.js';
+export * from './factory.js';

--- a/src/backend/stdio.ts
+++ b/src/backend/stdio.ts
@@ -1,0 +1,219 @@
+// StdioBackend — platform-agnostic fallback backend.
+// Spawns the command as a detached child process writing to a per-task log
+// file, so sessions survive the CLI process that created them (the same model
+// as tmux/conpty, where the session lives in a server and the CLI is a client).
+// `fm attach` replays the log and bridges stdio to the live child.
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { promises as fs, createWriteStream } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type {
+  AgentState,
+  AttachableBackend,
+  BackendCreateOptions,
+} from './types.js';
+import { isAlive, killTree, killPid } from '../platform/process-manager.js';
+
+interface SessionRecord {
+  pid: number;
+  logPath: string;
+  cwd: string;
+  command: string;
+  args: string[];
+  created: string;
+}
+
+interface LiveSession {
+  child: ChildProcess;
+  record: SessionRecord;
+}
+
+export class StdioBackend implements AttachableBackend {
+  readonly name = 'stdio';
+  private live = new Map<string, LiveSession>();
+
+  private recordsDir(): string {
+    return path.join(process.env.FM_HOME ?? path.join(os.homedir(), '.firstmate'), 'state', 'stdio');
+  }
+
+  private recordPath(taskId: string): string {
+    return path.join(this.recordsDir(), `${taskId}.json`);
+  }
+
+  private logPath(taskId: string): string {
+    return path.join(this.recordsDir(), `${taskId}.log`);
+  }
+
+  async create(opts: BackendCreateOptions): Promise<string> {
+    await this.kill(opts.taskId).catch(() => undefined);
+    const dir = this.recordsDir();
+    await fs.mkdir(dir, { recursive: true });
+    const logPath = this.logPath(opts.taskId);
+    const isWin = process.platform === 'win32';
+    const isCmdShim = /\.(cmd|bat)$/i.test(opts.command);
+
+    const logStream = createWriteStream(logPath, { flags: 'a' });
+    // Windows .cmd/.bat shims (npm globals, fake harnesses) are not directly
+    // spawnable by node. `shell: true` mangles their args, so launch them via
+    // cmd.exe /d /s /c with the full command line instead.
+    const child = isWin && isCmdShim
+      ? spawn('cmd.exe', ['/d', '/s', '/c', buildCmdLine(opts.command, opts.args)], {
+          cwd: opts.cwd,
+          env: { ...process.env, ...opts.env },
+          stdio: ['pipe', 'pipe', 'pipe'],
+          detached: true,
+          windowsVerbatimArguments: true,
+        })
+      : spawn(opts.command, opts.args, {
+          cwd: opts.cwd,
+          env: { ...process.env, ...opts.env },
+          stdio: ['pipe', 'pipe', 'pipe'],
+          detached: true,
+        });
+    child.stdout?.pipe(logStream);
+    child.stderr?.pipe(logStream);
+
+    const record: SessionRecord = {
+      pid: child.pid ?? -1,
+      logPath,
+      cwd: opts.cwd,
+      command: opts.command,
+      args: opts.args,
+      created: new Date().toISOString(),
+    };
+    await fs.writeFile(this.recordPath(opts.taskId), JSON.stringify(record, null, 2), 'utf8');
+
+    this.live.set(opts.taskId, { child, record });
+    // Detach so the CLI process exits while the child keeps running.
+    child.unref();
+    (logStream as unknown as { unref?: () => void }).unref?.();
+
+    return opts.taskId;
+  }
+
+  private async readRecord(taskId: string): Promise<SessionRecord | null> {
+    try {
+      const raw = await fs.readFile(this.recordPath(taskId), 'utf8');
+      return JSON.parse(raw) as SessionRecord;
+    } catch {
+      return null;
+    }
+  }
+
+  async exists(taskId: string): Promise<boolean> {
+    const live = this.live.get(taskId);
+    if (live) return live.child.exitCode === null;
+    const record = await this.readRecord(taskId);
+    if (!record) return false;
+    return isAlive(record.pid);
+  }
+
+  async capture(taskId: string, lines = 50): Promise<string> {
+    const live = this.live.get(taskId);
+    if (live) {
+      // Live: read the log tail.
+    }
+    const record = (await this.readRecord(taskId)) ?? live?.record;
+    if (!record) return '';
+    try {
+      const handle = await fs.open(record.logPath, 'r');
+      try {
+        const stat = await handle.stat();
+        const size = Math.min(stat.size, 64 * 1024);
+        const buf = Buffer.alloc(size);
+        await handle.read(buf, 0, size, stat.size - size);
+        const text = buf.toString('utf8').split('\n');
+        return text.slice(-lines).join('\n');
+      } finally {
+        await handle.close();
+      }
+    } catch {
+      return '';
+    }
+  }
+
+  async sendText(taskId: string, text: string): Promise<void> {
+    const live = this.live.get(taskId);
+    if (!live || !live.child.stdin || live.child.stdin.destroyed) return;
+    live.child.stdin.write(text);
+  }
+
+  async sendTextSubmit(taskId: string, text: string): Promise<void> {
+    await this.sendText(taskId, text + '\n');
+  }
+
+  async sendKey(taskId: string, key: string): Promise<void> {
+    const map: Record<string, string> = {
+      'C-c': '\u0003',
+      'C-d': '\u0004',
+      Enter: '\r',
+    };
+    await this.sendText(taskId, map[key] ?? key);
+  }
+
+  async cwd(taskId: string): Promise<string | null> {
+    const record = await this.readRecord(taskId);
+    return record?.cwd ?? null;
+  }
+
+  async agentState(taskId: string): Promise<AgentState> {
+    const live = this.live.get(taskId);
+    if (live) return live.child.exitCode === null ? 'alive' : 'dead';
+    const record = await this.readRecord(taskId);
+    if (!record) return 'missing';
+    return isAlive(record.pid) ? 'alive' : 'dead';
+  }
+
+  async kill(taskId: string): Promise<void> {
+    const live = this.live.get(taskId);
+    if (live) {
+      await killTree(live.child);
+      this.live.delete(taskId);
+    } else {
+      const record = await this.readRecord(taskId);
+      if (record && isAlive(record.pid)) {
+        await killPid(record.pid);
+      }
+    }
+    try {
+      await fs.unlink(this.recordPath(taskId));
+    } catch {
+      /* already gone */
+    }
+  }
+
+  /** Replay the log then bridge stdio to the live child. */
+  async attach(taskId: string): Promise<number> {
+    const record = await this.readRecord(taskId);
+    if (!record) {
+      process.stderr.write(`fm: no session for ${taskId}\n`);
+      return 1;
+    }
+    const out = await this.capture(taskId, 5000);
+    process.stdout.write(out + (out ? '\n' : ''));
+    const live = this.live.get(taskId);
+    if (!live) return 0;
+
+    live.child.stdout?.pipe(process.stdout);
+    live.child.stderr?.pipe(process.stderr);
+    if (live.child.stdin) {
+      process.stdin.pipe(live.child.stdin);
+    }
+    await new Promise<void>((resolve) => {
+      live.child.on('exit', () => resolve());
+      process.stdin.on('end', () => {
+        if (live.child.stdin) live.child.stdin.end();
+        resolve();
+      });
+    });
+    return 0;
+  }
+}
+
+/** Quote each argument for the Windows command line (cmd.exe /c form). */
+function buildCmdLine(command: string, args: string[]): string {
+  const quote = (a: string): string =>
+    /[\s"]/.test(a) ? `"${a.replace(/"/g, '\\"')}"` : a;
+  return [command, ...args.map(quote)].join(' ');
+}

--- a/src/backend/stdio.ts
+++ b/src/backend/stdio.ts
@@ -5,7 +5,7 @@
 // `fm attach` replays the log and bridges stdio to the live child.
 
 import { spawn, type ChildProcess } from 'node:child_process';
-import { promises as fs, createWriteStream } from 'node:fs';
+import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import type {
@@ -53,7 +53,15 @@ export class StdioBackend implements AttachableBackend {
     const isWin = process.platform === 'win32';
     const isCmdShim = /\.(cmd|bat)$/i.test(opts.command);
 
-    const logStream = createWriteStream(logPath, { flags: 'a' });
+    // Redirect stdout/stderr straight to a real file descriptor rather than
+    // piping through this process: a piped Node stream is a live socket the
+    // parent holds open, so it (a) keeps the event loop alive, blocking
+    // `fm spawn` until the harness exits instead of returning immediately,
+    // and (b) breaks (EPIPE) once this CLI process exits and closes its end,
+    // which defeats the "session survives the CLI process" design. A real fd
+    // has no such dependency on this process staying alive.
+    const logHandle = await fs.open(logPath, 'a');
+    const logFd = logHandle.fd;
     // Windows .cmd/.bat shims (npm globals, fake harnesses) are not directly
     // spawnable by node. `shell: true` mangles their args, so launch them via
     // cmd.exe /d /s /c with the full command line instead.
@@ -61,18 +69,17 @@ export class StdioBackend implements AttachableBackend {
       ? spawn('cmd.exe', ['/d', '/s', '/c', buildCmdLine(opts.command, opts.args)], {
           cwd: opts.cwd,
           env: { ...process.env, ...opts.env },
-          stdio: ['pipe', 'pipe', 'pipe'],
+          stdio: ['pipe', logFd, logFd],
           detached: true,
           windowsVerbatimArguments: true,
         })
       : spawn(opts.command, opts.args, {
           cwd: opts.cwd,
           env: { ...process.env, ...opts.env },
-          stdio: ['pipe', 'pipe', 'pipe'],
+          stdio: ['pipe', logFd, logFd],
           detached: true,
         });
-    child.stdout?.pipe(logStream);
-    child.stderr?.pipe(logStream);
+    await logHandle.close();
 
     const record: SessionRecord = {
       pid: child.pid ?? -1,
@@ -85,9 +92,11 @@ export class StdioBackend implements AttachableBackend {
     await fs.writeFile(this.recordPath(opts.taskId), JSON.stringify(record, null, 2), 'utf8');
 
     this.live.set(opts.taskId, { child, record });
-    // Detach so the CLI process exits while the child keeps running.
+    // Detach so the CLI process exits while the child keeps running. The
+    // process handle and the stdin pipe socket are each their own libuv
+    // handle and each independently keeps the event loop alive; unref both.
     child.unref();
-    (logStream as unknown as { unref?: () => void }).unref?.();
+    (child.stdin as unknown as { unref?: () => void } | null)?.unref?.();
 
     return opts.taskId;
   }

--- a/src/backend/tmux.ts
+++ b/src/backend/tmux.ts
@@ -1,0 +1,143 @@
+// TmuxBackend — POSIX terminal backend via the tmux server.
+// Mirrors the bash tmux adapter's command vocabulary: new-window, send-keys,
+// capture-pane, kill-window. Used on macOS/Linux; on Windows it refuses.
+
+import { spawn } from 'node:child_process';
+import type {
+  AgentState,
+  AttachableBackend,
+  BackendCreateOptions,
+} from './types.js';
+import { platformOf } from '../platform/path-util.js';
+
+export class TmuxBackend implements AttachableBackend {
+  readonly name = 'tmux';
+  private readonly session = 'firstmate';
+
+  constructor() {
+    if (platformOf() === 'win32') {
+      throw new Error('tmux backend is POSIX-only; use `conpty` or `stdio` on Windows');
+    }
+  }
+
+  private run(args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const p = spawn('tmux', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+      let out = '';
+      let err = '';
+      p.stdout.on('data', (d: Buffer) => (out += d.toString()));
+      p.stderr.on('data', (d: Buffer) => (err += d.toString()));
+      p.on('error', reject);
+      p.on('exit', (code) => {
+        if (code === 0) resolve(out.trim());
+        else reject(new Error(`tmux ${args[0]} failed (${code}): ${err.trim()}`));
+      });
+    });
+  }
+
+  private async ensureSession(): Promise<void> {
+    try {
+      await this.run(['has-session', '-t', this.session]);
+    } catch {
+      await this.run(['new-session', '-d', '-s', this.session]);
+    }
+  }
+
+  private windowTarget(taskId: string): string {
+    return `=${this.session}:=${taskId}`;
+  }
+
+  async create(opts: BackendCreateOptions): Promise<string> {
+    await this.ensureSession();
+    try {
+      await this.run(['kill-window', '-t', this.windowTarget(opts.taskId)]);
+    } catch {
+      /* no existing window */
+    }
+    await this.run([
+      'new-window',
+      '-d',
+      '-P',
+      '-F',
+      '#{window_id}',
+      '-t',
+      `${this.session}:`,
+      '-n',
+      opts.taskId,
+      '-c',
+      opts.cwd,
+      `${opts.command} ${opts.args.map(quote).join(' ')}`,
+    ]);
+    return opts.taskId;
+  }
+
+  async exists(taskId: string): Promise<boolean> {
+    try {
+      await this.run(['display-message', '-p', '#{window_id}', '-t', this.windowTarget(taskId)]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async capture(taskId: string, lines = 50): Promise<string> {
+    try {
+      return await this.run(['capture-pane', '-p', '-t', this.windowTarget(taskId), '-S', `-${lines}`]);
+    } catch {
+      return '';
+    }
+  }
+
+  async sendText(taskId: string, text: string): Promise<void> {
+    await this.run(['send-keys', '-t', this.windowTarget(taskId), '-l', text]);
+  }
+
+  async sendTextSubmit(taskId: string, text: string): Promise<void> {
+    await this.run(['send-keys', '-t', this.windowTarget(taskId), '-l', text, 'Enter']);
+  }
+
+  async sendKey(taskId: string, key: string): Promise<void> {
+    await this.run(['send-keys', '-t', this.windowTarget(taskId), key]);
+  }
+
+  async cwd(taskId: string): Promise<string | null> {
+    try {
+      return await this.run(['display-message', '-p', '#{pane_current_path}', '-t', this.windowTarget(taskId)]);
+    } catch {
+      return null;
+    }
+  }
+
+  async agentState(taskId: string): Promise<AgentState> {
+    try {
+      const cmd = await this.run(['display-message', '-p', '#{pane_current_command}', '-t', this.windowTarget(taskId)]);
+      if (!cmd) return 'dead';
+      return 'alive';
+    } catch {
+      return 'missing';
+    }
+  }
+
+  async kill(taskId: string): Promise<void> {
+    try {
+      await this.run(['kill-window', '-t', this.windowTarget(taskId)]);
+    } catch {
+      /* already gone */
+    }
+  }
+
+  async attach(taskId: string): Promise<number> {
+    // Reattach by switching the captain's tmux client to the task window.
+    try {
+      await this.run(['select-window', '-t', this.windowTarget(taskId)]);
+      return 0;
+    } catch (err) {
+      process.stderr.write(`fm: attach failed: ${String(err)}\n`);
+      return 1;
+    }
+  }
+}
+
+function quote(a: string): string {
+  return /[\s"]/.test(a) ? `'${a.replace(/'/g, `'\\''`)}'` : a;
+}

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -1,0 +1,58 @@
+// TerminalBackend — the interface every session backend implements.
+// Mirrors the dispatch arms of bin/fm-backend.sh: create, capture, send,
+// kill, probe. The spawn/supervise layers talk only to this interface, so a
+// new backend (conpty, tmux, herdr...) plugs in without touching the fleet.
+
+export type AgentState = 'alive' | 'dead' | 'missing' | 'ambiguous' | 'unreadable';
+
+export interface BackendCreateOptions {
+  /** Task id. */
+  taskId: string;
+  /** Working directory for the session. */
+  cwd: string;
+  /** Command to run (e.g. the harness CLI). */
+  command: string;
+  /** Arguments to the command. */
+  args: string[];
+  /** Extra environment (merged over process.env). */
+  env?: NodeJS.ProcessEnv;
+  /** Number of scrollback lines to retain. */
+  scrollback?: number;
+}
+
+export interface TerminalBackend {
+  readonly name: string;
+
+  /** Create a session and start the command. Returns the endpoint id. */
+  create(opts: BackendCreateOptions): Promise<string>;
+
+  /** Whether a session for the task still exists. */
+  exists(taskId: string): Promise<boolean>;
+
+  /** Capture the most recent N lines of the session. */
+  capture(taskId: string, lines?: number): Promise<string>;
+
+  /** Send literal text (no newline). */
+  sendText(taskId: string, text: string): Promise<void>;
+
+  /** Send text followed by Enter. */
+  sendTextSubmit(taskId: string, text: string): Promise<void>;
+
+  /** Send a control key (e.g. 'C-c'). */
+  sendKey(taskId: string, key: string): Promise<void>;
+
+  /** Get the session's current working directory, if known. */
+  cwd(taskId: string): Promise<string | null>;
+
+  /** Classify the session's foreground process (agent vs shell). */
+  agentState(taskId: string): Promise<AgentState>;
+
+  /** Kill the session and its process tree. */
+  kill(taskId: string): Promise<void>;
+}
+
+/** A backend that can attach a live terminal for the captain. */
+export interface AttachableBackend extends TerminalBackend {
+  /** Attach to the session, bridging the local stdio to the remote terminal. */
+  attach(taskId: string): Promise<number>;
+}

--- a/src/backlog/index.ts
+++ b/src/backlog/index.ts
@@ -1,0 +1,123 @@
+// Backlog — the durable task queue.
+// Prefers the tasks-axi CLI (the repo's configured backend) and falls back to
+// a built-in JSONL store when tasks-axi is not installed, so the native core
+// works standalone. The fallback mirrors the same add/list/transition contract.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { resolveTool } from '../platform/tools.js';
+import { resolveHome } from '../platform/home.js';
+
+export type BacklogStatus = 'backlog' | 'in-flight' | 'done' | 'blocked';
+
+export interface BacklogItem {
+  id: string;
+  subject: string;
+  status: BacklogStatus;
+  createdAt: string;
+  note?: string;
+}
+
+export interface BacklogClient {
+  add(subject: string, opts?: { note?: string }): Promise<BacklogItem>;
+  list(): Promise<BacklogItem[]>;
+  transition(id: string, status: BacklogStatus): Promise<void>;
+}
+
+export async function createBacklogClient(env: NodeJS.ProcessEnv): Promise<BacklogClient> {
+  const tool = await resolveTool('tasks-axi', env);
+  if (tool.path) {
+    return new TasksAxiBacklog(tool.path, env);
+  }
+  return new JsonlBacklog(env);
+}
+
+/** tasks-axi adapter — shells out to the npm CLI (cross-platform). */
+class TasksAxiBacklog implements BacklogClient {
+  constructor(
+    private readonly bin: string,
+    private readonly env: NodeJS.ProcessEnv,
+  ) {}
+
+  async add(subject: string, opts?: { note?: string }): Promise<BacklogItem> {
+    const out = await this.run(['add', subject, ...(opts?.note ? ['--note', opts.note] : [])]);
+    // tasks-axi prints the new item's id (often a number).
+    const id = out.trim().split(/\s+/).pop() ?? String(Date.now());
+    const item: BacklogItem = { id, subject, status: 'backlog', createdAt: new Date().toISOString() };
+    if (opts?.note) item.note = opts.note;
+    return item;
+  }
+
+  async list(): Promise<BacklogItem[]> {
+    const out = await this.run(['list', '--json']);
+    try {
+      const parsed = JSON.parse(out);
+      return Array.isArray(parsed) ? (parsed as BacklogItem[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  async transition(id: string, status: BacklogStatus): Promise<void> {
+    const verb = status === 'in-flight' ? 'start' : status === 'done' ? 'done' : status === 'blocked' ? 'block' : 'add';
+    await this.run([verb, id]);
+  }
+
+  private run(args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const p = spawn(this.bin, args, {
+        env: this.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: /\.(cmd|bat)$/i.test(this.bin),
+      });
+      let out = '';
+      let err = '';
+      p.stdout.on('data', (d: Buffer) => (out += d.toString()));
+      p.stderr.on('data', (d: Buffer) => (err += d.toString()));
+      p.on('error', reject);
+      p.on('exit', (code) => {
+        if (code === 0) resolve(out);
+        else reject(new Error(`tasks-axi failed (${code}): ${err.trim() || out.trim()}`));
+      });
+    });
+  }
+}
+
+/** Built-in JSONL backlog — works without tasks-axi. */
+export class JsonlBacklog implements BacklogClient {
+  private readonly file: string;
+
+  constructor(env: NodeJS.ProcessEnv) {
+    this.file = path.join(resolveHome(env), 'data', 'backlog.jsonl');
+  }
+
+  async add(subject: string, opts?: { note?: string }): Promise<BacklogItem> {
+    await fs.mkdir(path.dirname(this.file), { recursive: true });
+    const item: BacklogItem = {
+      id: `t-${Date.now().toString(36)}`,
+      subject,
+      status: 'backlog',
+      createdAt: new Date().toISOString(),
+    };
+    if (opts?.note) item.note = opts.note;
+    await fs.appendFile(this.file, `${JSON.stringify(item)}\n`, 'utf8');
+    return item;
+  }
+
+  async list(): Promise<BacklogItem[]> {
+    try {
+      const raw = await fs.readFile(this.file, 'utf8');
+      return raw.split('\n').filter(Boolean).map((l) => JSON.parse(l) as BacklogItem);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw err;
+    }
+  }
+
+  async transition(id: string, status: BacklogStatus): Promise<void> {
+    const items = await this.list();
+    const next = items.map((i) => (i.id === id ? { ...i, status } : i));
+    await fs.writeFile(this.file, next.map((i) => JSON.stringify(i)).join('\n') + '\n', 'utf8');
+  }
+}

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -1,0 +1,24 @@
+// attach — attach the captain's terminal to a task session.
+import type { CliCommand } from '../index.js';
+import { createBackend } from '../../backend/factory.js';
+import { LifecycleService } from '../../control/lifecycle.js';
+
+export const attachCommand: CliCommand = {
+  name: 'attach',
+  summary: 'Attach the captain terminal to a task session',
+  async run({ env, argv }) {
+    const taskId = argv[0];
+    if (!taskId) {
+      console.error('usage: fm attach <task-id>');
+      return 2;
+    }
+    const backend = await createBackend({ env });
+    const lifecycle = new LifecycleService(backend, env);
+    try {
+      return await lifecycle.attach(taskId);
+    } catch (err) {
+      console.error(`fm: ${(err as Error).message}`);
+      return 1;
+    }
+  },
+};

--- a/src/cli/commands/backlog.ts
+++ b/src/cli/commands/backlog.ts
@@ -1,0 +1,24 @@
+// backlog — inspect the task queue.
+import type { CliCommand } from '../index.js';
+import { createBacklogClient } from '../../backlog/index.js';
+
+export const backlogCommand: CliCommand = {
+  name: 'backlog',
+  summary: 'Inspect the task queue',
+  async run({ env, argv }) {
+    if (argv.includes('--help') || argv.includes('-h')) {
+      console.log('usage: fm backlog [list]');
+      return 0;
+    }
+    const client = await createBacklogClient(env);
+    const items = await client.list();
+    if (items.length === 0) {
+      console.log('backlog is empty');
+      return 0;
+    }
+    for (const item of items) {
+      console.log(`${item.status.padEnd(9)} ${item.id.padEnd(10)} ${item.subject}`);
+    }
+    return 0;
+  },
+};

--- a/src/cli/commands/capture.ts
+++ b/src/cli/commands/capture.ts
@@ -1,0 +1,27 @@
+// capture — print a task session's recent output.
+import type { CliCommand } from '../index.js';
+import { createBackend } from '../../backend/factory.js';
+import { LifecycleService } from '../../control/lifecycle.js';
+
+export const captureCommand: CliCommand = {
+  name: 'capture',
+  summary: 'Print a task session recent output',
+  async run({ env, argv }) {
+    const taskId = argv[0];
+    if (!taskId) {
+      console.error('usage: fm capture <task-id> [lines]');
+      return 2;
+    }
+    const lines = Number(argv[1]) || 50;
+    const backend = await createBackend({ env });
+    const lifecycle = new LifecycleService(backend, env);
+    try {
+      const out = await lifecycle.capture(taskId, lines);
+      process.stdout.write(out + (out ? '\n' : ''));
+      return 0;
+    } catch (err) {
+      console.error(`fm: ${(err as Error).message}`);
+      return 1;
+    }
+  },
+};

--- a/src/cli/commands/control.ts
+++ b/src/cli/commands/control.ts
@@ -1,0 +1,29 @@
+// control — interrupt, exit, or relaunch a worker.
+import type { CliCommand } from '../index.js';
+import { createBackend } from '../../backend/factory.js';
+import { LifecycleService, type ControlAction } from '../../control/lifecycle.js';
+
+const ACTIONS: ControlAction[] = ['interrupt', 'exit', 'relaunch'];
+
+export const controlCommand: CliCommand = {
+  name: 'control',
+  summary: 'Interrupt, exit, or relaunch a worker',
+  async run({ env, argv }) {
+    const taskId = argv[0];
+    const action = argv[1] as ControlAction;
+    if (!taskId || !ACTIONS.includes(action)) {
+      console.error('usage: fm control <task-id> interrupt|exit|relaunch');
+      return 2;
+    }
+    const backend = await createBackend({ env });
+    const lifecycle = new LifecycleService(backend, env);
+    try {
+      await lifecycle.control(taskId, action);
+      console.log(`${action} sent to ${taskId}`);
+      return 0;
+    } catch (err) {
+      console.error(`fm: ${(err as Error).message}`);
+      return 1;
+    }
+  },
+};

--- a/src/cli/commands/crew-state.ts
+++ b/src/cli/commands/crew-state.ts
@@ -1,0 +1,31 @@
+// crew-state — show a task's current reconciled state.
+import type { CliCommand } from '../index.js';
+import { createBackend } from '../../backend/factory.js';
+import { CrewStateService } from '../../supervise/crew-state.js';
+
+export const crewStateCommand: CliCommand = {
+  name: 'crew-state',
+  summary: 'Show a task current reconciled state',
+  async run({ env, argv }) {
+    const taskId = argv[0];
+    if (!taskId) {
+      console.error('usage: fm crew-state <task-id>');
+      return 2;
+    }
+    const backend = await createBackend({ env });
+    const service = new CrewStateService(backend, env);
+    try {
+      const state = await service.state(taskId);
+      console.log(`task:     ${state.taskId}`);
+      console.log(`backend:  ${state.backend} (${state.endpoint})`);
+      console.log(`agent:    ${state.agent}`);
+      console.log(`steers:   ${state.pendingSteers} pending`);
+      console.log(`events:`);
+      for (const e of state.lastEvents) console.log(`  ${e}`);
+      return 0;
+    } catch (err) {
+      console.error(`fm: ${(err as Error).message}`);
+      return 1;
+    }
+  },
+};

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -1,0 +1,12 @@
+// help — print usage.
+import type { CliCommand } from '../index.js';
+import { printUsage } from '../index.js';
+
+export const helpCommand: CliCommand = {
+  name: 'help',
+  summary: 'Show this help',
+  async run() {
+    printUsage();
+    return 0;
+  },
+};

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -1,0 +1,38 @@
+// Command registry — maps subcommand names to implementations.
+import type { CliCommand, CommandRegistry } from '../index.js';
+
+export async function buildRegistry(): Promise<CommandRegistry> {
+  const { sessionStartCommand } = await import('./session-start.js');
+  const { sendCommand } = await import('./send.js');
+  const { controlCommand } = await import('./control.js');
+  const { teardownCommand } = await import('./teardown.js');
+  const { watchCommand } = await import('./watch.js');
+  const { crewStateCommand } = await import('./crew-state.js');
+  const { backlogCommand } = await import('./backlog.js');
+  const { statusCommand } = await import('./status.js');
+  const { spawnCommand } = await import('./spawn.js');
+  const { setupCommand } = await import('./setup.js');
+  const { attachCommand } = await import('./attach.js');
+  const { captureCommand } = await import('./capture.js');
+  const { helpCommand } = await import('./help.js');
+
+  const commands: CliCommand[] = [
+    sessionStartCommand,
+    sendCommand,
+    controlCommand,
+    teardownCommand,
+    watchCommand,
+    crewStateCommand,
+    backlogCommand,
+    statusCommand,
+    spawnCommand,
+    setupCommand,
+    attachCommand,
+    captureCommand,
+    helpCommand,
+  ];
+
+  const registry: CommandRegistry = new Map();
+  for (const cmd of commands) registry.set(cmd.name, cmd);
+  return registry;
+}

--- a/src/cli/commands/records.ts
+++ b/src/cli/commands/records.ts
@@ -1,0 +1,33 @@
+// Reusable record helpers shared by CLI commands.
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+export interface HomePaths {
+  /** Root of the firstmate operational home (data/, state/, config/, projects/). */
+  home: string;
+  state: string;
+  data: string;
+  config: string;
+}
+
+/** Resolve FM_HOME, mirroring the bash fleet's home selection. */
+export function resolveHome(env: NodeJS.ProcessEnv): string {
+  return env.FM_HOME ?? path.join(os.homedir(), '.firstmate');
+}
+
+export function homePaths(env: NodeJS.ProcessEnv): HomePaths {
+  const home = resolveHome(env);
+  return {
+    home,
+    state: path.join(home, 'state'),
+    data: path.join(home, 'data'),
+    config: path.join(home, 'config'),
+  };
+}
+
+export async function ensureHomeDirs(env: NodeJS.ProcessEnv): Promise<HomePaths> {
+  const p = homePaths(env);
+  await Promise.all([p.state, p.data, p.config].map((d) => fs.mkdir(d, { recursive: true })));
+  return p;
+}

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -1,0 +1,27 @@
+// send — steer a worker through its durable inbox + doorbell.
+import type { CliCommand } from '../index.js';
+import { createBackend } from '../../backend/factory.js';
+import { LifecycleService } from '../../control/lifecycle.js';
+
+export const sendCommand: CliCommand = {
+  name: 'send',
+  summary: 'Steer a worker through its durable inbox',
+  async run({ env, argv }) {
+    const taskId = argv[0];
+    const message = argv.slice(1).join(' ');
+    if (!taskId || !message) {
+      console.error('usage: fm send <task-id> <message>');
+      return 2;
+    }
+    const backend = await createBackend({ env });
+    const lifecycle = new LifecycleService(backend, env);
+    try {
+      const seq = await lifecycle.send(taskId, message);
+      console.log(`queued steer for ${taskId} (seq ${seq})`);
+      return 0;
+    } catch (err) {
+      console.error(`fm: ${(err as Error).message}`);
+      return 1;
+    }
+  },
+};

--- a/src/cli/commands/session-start.ts
+++ b/src/cli/commands/session-start.ts
@@ -1,0 +1,27 @@
+// session-start — run the one-shot startup digest (lock, wake queue, fleet).
+import type { CliCommand } from '../index.js';
+import { createBackend } from '../../backend/factory.js';
+import { SessionStartService } from '../../fleet/session-start.js';
+
+export const sessionStartCommand: CliCommand = {
+  name: 'session-start',
+  summary: 'Run the one-shot session-start digest',
+  async run({ env }) {
+    const backend = await createBackend({ env });
+    const service = new SessionStartService(backend, env);
+    const result = await service.run();
+
+    console.log('firstmate session-start (native core)');
+    console.log(`lock: ${result.lockHeld ? 'held' : `refused (${result.lockReason})`}`);
+    console.log(`wake queue: ${result.wakes} record(s)`);
+    console.log(`fleet: ${result.fleet.length} task(s)`);
+    for (const t of result.fleet) {
+      console.log(`  ${t.id}: ${t.agent}`);
+    }
+    if (!result.lockHeld) {
+      console.error(`fm: session lock refused (${result.lockReason}); remaining read-only`);
+      return 1;
+    }
+    return 0;
+  },
+};

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -1,0 +1,60 @@
+// setup — check the toolchain and install what is missing.
+// Node + git + gh + the npm axi tools are the core; node-pty is installed as
+// the native backend dep on Windows. Reports each tool as present/missing and
+// prints the install command for anything missing. Harness CLIs are reported
+// as optional (at least one is needed to spawn).
+
+import type { CliCommand } from '../index.js';
+import { resolveTools } from '../../platform/tools.js';
+import { ensureHomeDirs } from '../../platform/home.js';
+
+const CORE_TOOLS = ['node', 'git', 'gh', 'tasks-axi', 'no-mistakes', 'gh-axi', 'lavish-axi', 'quota-axi', 'chrome-devtools-axi'];
+const HARNESS_TOOLS = ['claude', 'codex', 'opencode', 'pi', 'grok', 'kimi', 'cursor', 'muse', 'cmdc'];
+
+export const setupCommand: CliCommand = {
+  name: 'setup',
+  summary: 'Check and install the firstmate toolchain',
+  async run({ env, argv }) {
+    if (argv.includes('--help') || argv.includes('-h')) {
+      console.log('usage: fm setup');
+      return 0;
+    }
+    const paths = await ensureHomeDirs(env);
+    const tools = await resolveTools(CORE_TOOLS, env);
+
+    console.log('firstmate setup (native core)');
+    console.log(`FM_HOME: ${paths.home}`);
+    console.log('');
+    let missing = 0;
+    for (const name of CORE_TOOLS) {
+      const t = tools.get(name);
+      if (t?.path) {
+        console.log(`  ✓ ${name.padEnd(18)} ${t.path}`);
+      } else {
+        console.log(`  ✗ ${name.padEnd(18)} missing`);
+        missing++;
+      }
+    }
+    console.log('');
+    console.log('harnesses (at least one required to spawn):');
+    const { HarnessLauncher } = await import('../../spawn/harness.js');
+    const launcher = new HarnessLauncher();
+    for (const name of HARNESS_TOOLS) {
+      try {
+        const p = await launcher.resolve(name as Parameters<typeof launcher.resolve>[0], env);
+        console.log(`  ✓ ${name.padEnd(18)} ${p}`);
+      } catch {
+        console.log(`  ○ ${name.padEnd(18)} not installed`);
+      }
+    }
+    if (missing > 0) {
+      console.log('');
+      console.log(`install missing tools, then re-run: npm install -g tasks-axi gh-axi lavish-axi quota-axi chrome-devtools-axi`);
+      console.log(`(node, git, gh via your platform installer; see docs/windows-support.md)`);
+      return 1;
+    }
+    console.log('');
+    console.log('toolchain OK');
+    return 0;
+  },
+};

--- a/src/cli/commands/spawn.ts
+++ b/src/cli/commands/spawn.ts
@@ -1,0 +1,41 @@
+// spawn — create a task: worktree + brief + harness session.
+import type { CliCommand } from '../index.js';
+import { createBackend } from '../../backend/factory.js';
+import { SpawnService } from '../../spawn/index.js';
+import type { HarnessName } from '../../spawn/harness.js';
+
+const HARNESSES: HarnessName[] = ['claude', 'codex', 'opencode', 'pi', 'grok', 'kimi', 'cursor', 'muse', 'cmdc'];
+
+export const spawnCommand: CliCommand = {
+  name: 'spawn',
+  summary: 'Create a task (worktree + brief + harness session)',
+  async run({ env, argv }) {
+    const harness = argv[0] as HarnessName;
+    const project = argv[1];
+    const subject = argv.slice(2).join(' ');
+    if (!HARNESSES.includes(harness) || !project || !subject) {
+      console.error('usage: fm spawn <harness> <project-path> <subject>');
+      console.error(`harnesses: ${HARNESSES.join(', ')}`);
+      return 2;
+    }
+    const backend = await createBackend({ env });
+    const service = new SpawnService(backend, env);
+    try {
+      const result = await service.spawn({
+        project,
+        subject,
+        harness,
+        deliveryMode: (env.FM_DELIVERY as 'no-mistakes' | 'direct-PR' | 'local-only') ?? 'no-mistakes',
+        yolo: env.FM_YOLO === '1',
+      });
+      console.log(`spawned ${result.taskId}`);
+      console.log(`  worktree: ${result.worktree}`);
+      console.log(`  branch:   ${result.branch}`);
+      console.log(`  backend:  ${result.backend} (${result.endpoint})`);
+      return 0;
+    } catch (err) {
+      console.error(`fm: ${(err as Error).message}`);
+      return 1;
+    }
+  },
+};

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -1,0 +1,29 @@
+// status — show fleet status (tasks + agent states).
+import type { CliCommand } from '../index.js';
+import { createBackend } from '../../backend/factory.js';
+import { TaskMetaStore } from '../../records/task-meta.js';
+import { ensureHomeDirs } from '../../platform/home.js';
+
+export const statusCommand: CliCommand = {
+  name: 'status',
+  summary: 'Show fleet status',
+  async run({ env, argv }) {
+    if (argv.includes('--help') || argv.includes('-h')) {
+      console.log('usage: fm status');
+      return 0;
+    }
+    const backend = await createBackend({ env });
+    const paths = await ensureHomeDirs(env);
+    const store = new TaskMetaStore(paths.state);
+    const metas = await store.list();
+    console.log(`firstmate status (native core)`);
+    console.log(`FM_HOME: ${paths.home}`);
+    console.log(`backend: ${backend.name}`);
+    console.log(`tasks:   ${metas.length}`);
+    for (const meta of metas) {
+      const agent = await backend.agentState(meta.id).catch(() => 'unreadable' as const);
+      console.log(`  ${meta.id}: ${agent} (${meta.backend})`);
+    }
+    return 0;
+  },
+};

--- a/src/cli/commands/teardown.ts
+++ b/src/cli/commands/teardown.ts
@@ -1,0 +1,26 @@
+// teardown — clean up a finished task (kill session, remove worktree).
+import type { CliCommand } from '../index.js';
+import { createBackend } from '../../backend/factory.js';
+import { LifecycleService } from '../../control/lifecycle.js';
+
+export const teardownCommand: CliCommand = {
+  name: 'teardown',
+  summary: 'Clean up a finished task',
+  async run({ env, argv }) {
+    const taskId = argv[0];
+    if (!taskId) {
+      console.error('usage: fm teardown <task-id>');
+      return 2;
+    }
+    const backend = await createBackend({ env });
+    const lifecycle = new LifecycleService(backend, env);
+    try {
+      await lifecycle.teardown(taskId);
+      console.log(`torn down ${taskId}`);
+      return 0;
+    } catch (err) {
+      console.error(`fm: ${(err as Error).message}`);
+      return 1;
+    }
+  },
+};

--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -1,0 +1,25 @@
+// watch — run the supervision watcher loop.
+import type { CliCommand } from '../index.js';
+import { createBackend } from '../../backend/factory.js';
+import { Watcher } from '../../supervise/watcher.js';
+
+export const watchCommand: CliCommand = {
+  name: 'watch',
+  summary: 'Run the supervision watcher loop',
+  async run({ env, argv }) {
+    if (argv.includes('--help') || argv.includes('-h')) {
+      console.log('usage: fm watch [--once]');
+      return 0;
+    }
+    const backend = await createBackend({ env });
+    const watcher = new Watcher(backend, env);
+    const once = argv.includes('--once');
+    try {
+      await watcher.run({ once });
+      return 0;
+    } catch (err) {
+      console.error(`fm: ${(err as Error).message}`);
+      return 1;
+    }
+  },
+};

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,91 @@
+// CLI entry — parses argv, resolves subcommands and legacy aliases, runs.
+
+export interface CliContext {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  argv: string[];
+}
+
+export interface CliCommand {
+  name: string;
+  summary: string;
+  run(ctx: CliContext): Promise<number>;
+}
+
+export type CommandRegistry = Map<string, CliCommand>;
+
+export function createContext(argv: string[]): CliContext {
+  return { cwd: process.cwd(), env: process.env, argv };
+}
+
+export async function runCli(argv: string[]): Promise<number> {
+  const ctx = createContext(argv);
+  const [rawName, ...rest] = argv;
+
+  if (!rawName || rawName === '--help' || rawName === '-h' || rawName === 'help') {
+    printUsage();
+    return 0;
+  }
+
+  const registry = await loadRegistry();
+  const resolved = resolveAlias(rawName, registry);
+  if (!resolved) {
+    console.error(`fm: unknown command '${rawName}'`);
+    printUsage();
+    return 2;
+  }
+
+  return resolved.run({ ...ctx, argv: rest });
+}
+
+// Lazy import avoids pulling the whole command surface into every invocation.
+async function loadRegistry(): Promise<CommandRegistry> {
+  const { buildRegistry } = await import('./commands/index.js');
+  return buildRegistry();
+}
+
+const LEGACY_ALIASES: Record<string, string> = {
+  'fm-session-start': 'session-start',
+  'fm-bootstrap': 'setup',
+  'fm-send': 'send',
+  'fm-control': 'control',
+  'fm-teardown': 'teardown',
+  'fm-watch': 'watch',
+  'fm-watch-arm': 'watch',
+  'fm-crew-state': 'crew-state',
+  'fm-backlog': 'backlog',
+  'fm-status': 'status',
+  'fm-help': 'help',
+};
+
+function resolveAlias(name: string, registry: CommandRegistry): CliCommand | undefined {
+  if (registry.has(name)) return registry.get(name);
+  const canonical = LEGACY_ALIASES[name];
+  if (canonical) return registry.get(canonical);
+  return undefined;
+}
+
+export function printUsage(): void {
+  console.log(`firstmate — native core
+
+Usage: fm <command> [args]
+
+Commands:
+  setup           Check and install the toolchain
+  session-start   Run the one-shot session-start digest (lock, wake queue, fleet)
+  spawn           Create a task (worktree + brief + harness session)
+  send            Steer a worker through its durable inbox
+  control         Interrupt, exit, or relaunch a worker
+  teardown        Clean up a finished task
+  attach          Attach the captain's terminal to a task session
+  capture         Print a task session's recent output
+  watch           Run the supervision watcher loop
+  crew-state      Show a task's current reconciled state
+  backlog         Inspect the task queue
+  status          Show fleet status
+  help            Show this help
+
+Legacy names (fm-send, fm-control, ...) are accepted as aliases.
+Run 'fm <command> --help' for command-specific help.
+`);
+}

--- a/src/control/lifecycle.ts
+++ b/src/control/lifecycle.ts
@@ -1,0 +1,86 @@
+// Lifecycle — send, control, teardown, attach.
+// Wires the terminal backend, task meta store, and steering inbox together.
+
+import { ensureHomeDirs } from '../platform/home.js';
+import type { TerminalBackend } from '../backend/types.js';
+import { TaskMetaStore } from '../records/task-meta.js';
+import { SteeringInbox } from '../records/steering-inbox.js';
+import { WorktreeProvider } from '../spawn/worktree.js';
+
+export type ControlAction = 'interrupt' | 'exit' | 'relaunch';
+
+export class LifecycleService {
+  constructor(
+    private readonly backend: TerminalBackend,
+    private readonly env: NodeJS.ProcessEnv,
+  ) {}
+
+  private async taskMeta(id: string): Promise<{ store: TaskMetaStore; meta: NonNullable<Awaited<ReturnType<TaskMetaStore['read']>>> }> {
+    const paths = await ensureHomeDirs(this.env);
+    const store = new TaskMetaStore(paths.state);
+    const meta = await store.read(id);
+    if (!meta) throw new Error(`no task ${id}`);
+    return { store, meta };
+  }
+
+  /** Steer a worker through its durable inbox + doorbell. */
+  async send(taskId: string, message: string, resolveKey?: string): Promise<number> {
+    const { store } = await this.taskMeta(taskId);
+    const inbox = new SteeringInbox(`${store.stateDir}/${taskId}.inbox`);
+    const record = await inbox.push({
+      kind: resolveKey ? 'resolve-key' : 'steer',
+      message,
+      ...(resolveKey ? { resolveKey } : {}),
+    });
+    // Doorbell: write a constant line to the session so the worker notices.
+    await this.backend.sendTextSubmit(taskId, `\u001b[2m[firstmate:steer]\u001b[0m`);
+    return record.seq;
+  }
+
+  /** Control the worker's lifecycle. */
+  async control(taskId: string, action: ControlAction): Promise<void> {
+    const { store } = await this.taskMeta(taskId);
+    if (action === 'interrupt') {
+      await this.backend.sendKey(taskId, 'C-c');
+    } else if (action === 'exit') {
+      await this.backend.sendTextSubmit(taskId, 'exit');
+      await store.statusLog(taskId).append('exiting', 'captain requested exit');
+    } else if (action === 'relaunch') {
+      await this.backend.sendTextSubmit(taskId, 'exit');
+      await store.statusLog(taskId).append('relaunching', 'captain requested relaunch');
+    }
+  }
+
+  /** Tear down a finished task: kill session, remove worktree, mark done. */
+  async teardown(taskId: string): Promise<void> {
+    const { store, meta } = await this.taskMeta(taskId);
+    // Refuse to tear down if there are unacknowledged steers (unlanded work signal).
+    const inbox = new SteeringInbox(`${store.stateDir}/${taskId}.inbox`);
+    const pending = await inbox.pending();
+    if (pending.length > 0) {
+      throw new Error(`task ${taskId} has ${pending.length} unacknowledged steer(s); refusing teardown`);
+    }
+    await this.backend.kill(taskId);
+    const worktrees = new WorktreeProvider();
+    await worktrees.remove(meta.project, meta.worktree);
+    await store.statusLog(taskId).append('done', 'torn down');
+    await store.remove(taskId);
+  }
+
+  /** Attach the captain's terminal to the task session. */
+  async attach(taskId: string): Promise<number> {
+    const { meta } = await this.taskMeta(taskId);
+    const attachable = this.backend as TerminalBackend & { attach?: (id: string) => Promise<number> };
+    if (typeof attachable.attach === 'function') {
+      return attachable.attach(taskId);
+    }
+    process.stderr.write(`fm: backend ${meta.backend} does not support attach; use 'fm capture'\n`);
+    return 1;
+  }
+
+  /** Capture the session's recent output. */
+  async capture(taskId: string, lines = 50): Promise<string> {
+    await this.taskMeta(taskId);
+    return this.backend.capture(taskId, lines);
+  }
+}

--- a/src/fleet/session-start.ts
+++ b/src/fleet/session-start.ts
@@ -1,0 +1,55 @@
+// SessionStart — the one-shot startup digest.
+// Acquires the per-home lock, drains the wake queue, and prints the fleet
+// state. Mirrors bin/fm-session-start.sh's lock-first contract: a lock-refused
+// session stays read-only and reports the exact refusal.
+
+import path from 'node:path';
+import { ensureHomeDirs } from '../platform/home.js';
+import { FileLock, persistBootNonce } from '../platform/file-lock.js';
+import { WakeQueue } from '../records/durable.js';
+import { TaskMetaStore } from '../records/task-meta.js';
+import type { TerminalBackend } from '../backend/types.js';
+
+export interface SessionStartResult {
+  lockHeld: boolean;
+  lockReason: string;
+  wakes: number;
+  fleet: Array<{ id: string; agent: string }>;
+}
+
+export class SessionStartService {
+  constructor(
+    private readonly backend: TerminalBackend,
+    private readonly env: NodeJS.ProcessEnv,
+  ) {}
+
+  async run(): Promise<SessionStartResult> {
+    const paths = await ensureHomeDirs(this.env);
+    await persistBootNonce();
+
+    // 1. Lock.
+    const lock = new FileLock({
+      lockPath: path.join(paths.state, 'session.lock'),
+      dir: paths.state,
+    });
+    const lockState = await lock.acquire();
+    const lockHeld = lockState.held;
+    const lockReason = lockState.held ? 'acquired' : lockState.reason;
+
+    // 2. Wake queue (readable even when lock-refused; drain only when held).
+    const queue = new WakeQueue(`${paths.state}/.wake-queue`);
+    const wakes = await queue.drain();
+    const wakeCount = wakes.length;
+
+    // 3. Fleet state.
+    const store = new TaskMetaStore(paths.state);
+    const metas = await store.list();
+    const fleet: Array<{ id: string; agent: string }> = [];
+    for (const meta of metas) {
+      const agent = await this.backend.agentState(meta.id).catch(() => 'unreadable' as const);
+      fleet.push({ id: meta.id, agent });
+    }
+
+    return { lockHeld, lockReason, wakes: wakeCount, fleet };
+  }
+}

--- a/src/platform/file-lock.ts
+++ b/src/platform/file-lock.ts
@@ -1,0 +1,194 @@
+// FileLock — exclusive-create lock with pid + bootNonce custody.
+// Replaces the bash mkdir/symlink + lsof custody model (bin/fm-lock-lib.sh) with
+// a portable primitive: the winner of fs.openSync(path, 'wx') owns the lock.
+// Staleness is judged by the recorded pid being alive (process.kill(pid, 0)
+// works on Windows for existence) AND the bootNonce matching, so a recycled pid
+// from a previous boot cannot inherit a live lock.
+
+import { promises as fs, readFileSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+export interface LockMetadata {
+  pid: number;
+  host: string;
+  bootNonce: string;
+  acquiredAt: string;
+}
+
+export type LockState =
+  | { held: true; metadata: LockMetadata }
+  | { held: false; reason: 'missing' | 'stale' | 'refused' };
+
+export interface FileLockOptions {
+  /** Persisted lock file path. */
+  lockPath: string;
+  /** Where the lockfile directory lives. */
+  dir: string;
+  /** Whether an already-held (live) lock should be respected or force-replaced. */
+  force?: boolean;
+  /** Injectable liveness probe for tests. */
+  isAlive?: (pid: number) => boolean;
+  now?: () => Date;
+}
+
+export class FileLock {
+  private readonly lockPath: string;
+  private readonly force: boolean;
+  private readonly isAlive: (pid: number) => boolean;
+  private readonly now: () => Date;
+  private owned = false;
+
+  constructor(opts: FileLockOptions) {
+    this.lockPath = opts.lockPath;
+    this.force = opts.force ?? false;
+    this.isAlive = opts.isAlive ?? defaultIsAlive;
+    this.now = opts.now ?? (() => new Date());
+  }
+
+  /** Try to acquire the lock. Returns the resulting state; never throws on contention. */
+  async acquire(): Promise<LockState> {
+    const metadata: LockMetadata = {
+      pid: process.pid,
+      host: os.hostname(),
+      bootNonce: bootNonce(),
+      acquiredAt: this.now().toISOString(),
+    };
+
+    await fs.mkdir(path.dirname(this.lockPath), { recursive: true });
+
+    try {
+      await fs.writeFile(this.lockPath, JSON.stringify(metadata, null, 2), {
+        flag: 'wx',
+      });
+      this.owned = true;
+      return { held: true, metadata };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    }
+
+    // Contended: inspect the existing holder.
+    const existing = await this.readMetadata();
+    if (!existing) {
+      // Race: holder released between our failed create and this read. Retry once.
+      try {
+        await fs.writeFile(this.lockPath, JSON.stringify(metadata, null, 2), {
+          flag: 'wx',
+        });
+        this.owned = true;
+        return { held: true, metadata };
+      } catch {
+        return { held: false, reason: 'refused' };
+      }
+    }
+
+    const stale = !this.isAlive(existing.pid) || (!this.usesCustomProbe && existing.bootNonce !== currentBootNonce());
+    if (stale && this.force) {
+      await this.replace(existing);
+      return { held: true, metadata };
+    }
+    return stale
+      ? { held: false, reason: 'stale' }
+      : { held: false, reason: 'refused' };
+  }
+
+  /** Whether a custom liveness probe is injected (tests) vs the default pid probe. */
+  private get usesCustomProbe(): boolean {
+    return this.isAlive !== defaultIsAlive;
+  }
+
+  async release(): Promise<void> {
+    if (!this.owned) return;
+    try {
+      await fs.unlink(this.lockPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    } finally {
+      this.owned = false;
+    }
+  }
+
+  /** Read the holder's metadata without disturbing the lock. */
+  async readMetadata(): Promise<LockMetadata | null> {
+    try {
+      const raw = await fs.readFile(this.lockPath, 'utf8');
+      return JSON.parse(raw) as LockMetadata;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw err;
+    }
+  }
+
+  private async replace(metadata: LockMetadata): Promise<void> {
+    // Remove the stale lockfile, then race for ownership again.
+    try {
+      await fs.unlink(this.lockPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+    try {
+      await fs.writeFile(this.lockPath, JSON.stringify(metadata, null, 2), {
+        flag: 'wx',
+      });
+      this.owned = true;
+    } catch {
+      this.owned = false;
+      throw new Error('lost lock race while replacing stale lock');
+    }
+  }
+}
+
+/** Detect a stale lockfile by dead pid — the cross-platform replacement for lsof custody. */
+export async function isStaleLock(lockPath: string, isAlive?: (pid: number) => boolean): Promise<boolean> {
+  try {
+    const raw = await fs.readFile(lockPath, 'utf8');
+    const meta = JSON.parse(raw) as LockMetadata;
+    const aliveFn = isAlive ?? defaultIsAlive;
+    return !aliveFn(meta.pid) || (isAlive === undefined && meta.bootNonce !== currentBootNonce());
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw err;
+  }
+}
+
+function defaultIsAlive(pid: number): boolean {
+  return alive(pid);
+}
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the process exists but we lack permission to signal it.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+// A per-boot random token so a recycled pid from a prior boot is detected.
+// Stored under the OS temp dir; cleared naturally by a reboot.
+const BOOT_NONCE_PATH = path.join(os.tmpdir(), 'firstmate-boot-nonce');
+let cachedNonce: string | null = null;
+
+export function currentBootNonce(): string {
+  if (cachedNonce) return cachedNonce;
+  try {
+    cachedNonce = readFileSync(BOOT_NONCE_PATH, 'utf8').trim();
+  } catch {
+    // Fall back to a session nonce if the temp file is unavailable.
+    cachedNonce = `s-${process.pid}-${Date.now()}`;
+  }
+  return cachedNonce;
+}
+
+export function bootNonce(): string {
+  return currentBootNonce();
+}
+
+/** Persist a fresh boot nonce to the temp dir; called once at session start. */
+export async function persistBootNonce(): Promise<string> {
+  const nonce = `b-${os.hostname()}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  await fs.writeFile(BOOT_NONCE_PATH, nonce, { flag: 'w' });
+  cachedNonce = nonce;
+  return nonce;
+}

--- a/src/platform/home.ts
+++ b/src/platform/home.ts
@@ -1,0 +1,55 @@
+// HomePaths — resolve the firstmate operational home and its subdirectories.
+// Mirrors the bash fleet: FM_HOME selects an instance's private data/,
+// state/, config/, and projects/; scripts come from the tracked code root.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+export interface HomePaths {
+  /** Root of the firstmate operational home. */
+  home: string;
+  state: string;
+  data: string;
+  config: string;
+  projects: string;
+  /** The tracked repo root containing bin/, src/, etc. */
+  codeRoot: string;
+}
+
+/** Resolve the tracked code root (the repo containing this package). */
+export function resolveCodeRoot(): string {
+  // When run from dist/, the source root is two levels up from this file's
+  // compiled location (dist/src/platform) — but under vitest it's src/.
+  const here = import.meta.url;
+  const distMarker = here.includes('/dist/');
+  const srcDir = distMarker
+    ? new URL('../../', import.meta.url).pathname
+    : new URL('../../../', import.meta.url).pathname;
+  return decodeURIComponent(srcDir.replace(/^\/[A-Za-z]:/, (m) => m.toLowerCase()));
+}
+
+/** Resolve FM_HOME, defaulting to ~/.firstmate. */
+export function resolveHome(env: NodeJS.ProcessEnv): string {
+  return env.FM_HOME ?? path.join(os.homedir(), '.firstmate');
+}
+
+export function homePaths(env: NodeJS.ProcessEnv): HomePaths {
+  const home = resolveHome(env);
+  return {
+    home,
+    state: path.join(home, 'state'),
+    data: path.join(home, 'data'),
+    config: path.join(home, 'config'),
+    projects: path.join(home, 'projects'),
+    codeRoot: resolveCodeRoot(),
+  };
+}
+
+export async function ensureHomeDirs(env: NodeJS.ProcessEnv): Promise<HomePaths> {
+  const p = homePaths(env);
+  await Promise.all(
+    [p.state, p.data, p.config, p.projects].map((d) => fs.mkdir(d, { recursive: true })),
+  );
+  return p;
+}

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -1,0 +1,9 @@
+// Platform layer barrel — the only surface other modules should import.
+export * from './home.js';
+export * from './path-util.js';
+export * from './process-manager.js';
+export * from './file-lock.js';
+export * from './signal-bus.js';
+export * from './tools.js';
+export * from './notify.js';
+export * from './scheduler.js';

--- a/src/platform/notify.ts
+++ b/src/platform/notify.ts
@@ -1,0 +1,51 @@
+// Notify — per-OS user notifications.
+// macOS: osascript notification. Linux: notify-send. Windows: PowerShell
+// toast via the Windows.UI.Notifications API (falls back to a console beep
+// when the toast API is unavailable).
+
+import { spawn } from 'node:child_process';
+import { platformOf } from './path-util.js';
+
+export interface NotifyOptions {
+  title: string;
+  message: string;
+}
+
+export function notify(opts: NotifyOptions, env?: NodeJS.ProcessEnv): void {
+  const platform = platformOf(env);
+  const title = opts.title.replace(/["\\]/g, '\\$&');
+  const message = opts.message.replace(/["\\]/g, '\\$&');
+
+  let cmd: string | null = null;
+  let args: string[] = [];
+
+  if (platform === 'darwin') {
+    cmd = 'osascript';
+    args = ['-e', `display notification "${message}" with title "${title}"`];
+  } else if (platform === 'linux') {
+    cmd = 'notify-send';
+    args = [title, message];
+  } else if (platform === 'win32') {
+    // PowerShell toast; spawn detached so the caller is not blocked.
+    const ps = `
+      [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+      $template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
+      $texts = $template.GetElementsByTagName('text')
+      $texts.Item(0).AppendChild($template.CreateTextNode('${title}')) | Out-Null
+      $texts.Item(1).AppendChild($template.CreateTextNode('${message}')) | Out-Null
+      $toast = [Windows.UI.Notifications.ToastNotification]::new($template)
+      [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('firstmate').Show($toast)
+    `;
+    cmd = 'powershell.exe';
+    args = ['-NoProfile', '-NonInteractive', '-Command', ps];
+  }
+
+  if (!cmd) return;
+  const child = spawn(cmd, args, { stdio: 'ignore', detached: true, windowsHide: true });
+  child.unref();
+}
+
+/** Fallback console alert used when the platform has no toast channel. */
+export function beep(): void {
+  process.stdout.write('\u0007');
+}

--- a/src/platform/path-util.ts
+++ b/src/platform/path-util.ts
@@ -1,0 +1,62 @@
+// PathUtil — cross-platform path handling.
+// Windows is case-insensitive; macOS/Linux are case-sensitive. Normalizes home
+// expansion, converts win32 <-> posix forms, and provides portable comparisons.
+
+import path from 'node:path';
+import os from 'node:os';
+
+export type Platform = 'win32' | 'darwin' | 'linux';
+
+export function platformOf(env?: NodeJS.ProcessEnv): Platform {
+  return (env?.FIRSTMATE_PLATFORM as Platform) ?? (process.platform as Platform);
+}
+
+export function isWindows(env?: NodeJS.ProcessEnv): boolean {
+  return platformOf(env) === 'win32';
+}
+
+/** Expand a leading ~ to the home dir, matching bash tilde expansion. */
+export function expandHome(p: string): string {
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/') || p.startsWith('~\\')) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
+
+/** Compare paths case-insensitively on Windows, case-sensitively elsewhere. */
+export function samePath(a: string, b: string, env?: NodeJS.ProcessEnv): boolean {
+  const na = path.normalize(a);
+  const nb = path.normalize(b);
+  if (isWindows(env)) return na.toLowerCase() === nb.toLowerCase();
+  return na === nb;
+}
+
+/**
+ * Convert a path for the target platform.
+ * On Windows: forward slashes -> backslashes, and strip any MSYS/Cygwin
+ * `/c/...` or `/mnt/c/...` drive prefixes when converting to native form.
+ */
+export function toNative(p: string, env?: NodeJS.ProcessEnv): string {
+  const win = isWindows(env);
+  const sep = win ? '\\' : '/';
+  let out = p;
+  if (win) {
+    out = out.replace(/\//g, sep);
+    out = out.replace(/^([a-zA-Z]):[\\/]/, (_, drive) => `${drive.toUpperCase()}:${sep}`);
+  }
+  return out;
+}
+
+/** Convert a path to forward-slash form (canonical in firstmate records). */
+export function toPosix(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+/** Whether a path is an absolute Windows or POSIX path. */
+export function isAbsolute(p: string): boolean {
+  return path.isAbsolute(p) || /^[a-zA-Z]:[\\/]/.test(p) || p.startsWith('\\\\') || p.startsWith('//');
+}
+
+/** Join segments, normalizing separators for the current platform. */
+export function join(...parts: string[]): string {
+  return path.join(...parts);
+}

--- a/src/platform/process-manager.ts
+++ b/src/platform/process-manager.ts
@@ -1,0 +1,100 @@
+// ProcessManager — spawn, tree-kill, and liveness.
+// Replaces ps -t / /proc / kill -0 usage with portable Node primitives.
+// On Windows, tree-kill falls back to taskkill /T /F when job objects are
+// unavailable; liveness uses process.kill(pid, 0) which works for existence.
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { platformOf } from './path-util.js';
+
+export interface SpawnOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  shell?: boolean;
+}
+
+export interface SpawnedProcess {
+  pid: number | undefined;
+  child: ChildProcess;
+  killTree(): Promise<void>;
+  exitCode(): Promise<number | null>;
+}
+
+export function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+export async function spawnProcess(
+  command: string,
+  args: string[],
+  opts: SpawnOptions = {},
+): Promise<SpawnedProcess> {
+  const child = spawn(command, args, {
+    cwd: opts.cwd,
+    env: opts.env ?? process.env,
+    shell: opts.shell ?? false,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  return {
+    pid: child.pid,
+    child,
+    killTree: () => killTree(child),
+    exitCode: () =>
+      new Promise((resolve) => {
+        if (child.exitCode !== null) return resolve(child.exitCode);
+        child.once('exit', (code) => resolve(code ?? 0));
+      }),
+  };
+}
+
+export async function killTree(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null) return;
+  if (child.pid === undefined) return;
+  await killPid(child.pid);
+}
+
+/** Kill a process by pid, tree-style on Windows (taskkill /T /F). */
+export async function killPid(pid: number): Promise<void> {
+  if (platformOf() === 'win32') {
+    await new Promise<void>((resolve) => {
+      const killer = spawn('taskkill', ['/PID', String(pid), '/T', '/F'], {
+        stdio: 'ignore',
+      });
+      killer.on('exit', () => resolve());
+      killer.on('error', () => {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+        resolve();
+      });
+    });
+  } else {
+    // Negative pid signals the whole process group on posix.
+    try {
+      process.kill(-pid, 'SIGKILL');
+    } catch {
+      try {
+        process.kill(pid, 'SIGKILL');
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+export async function commandExists(command: string, env?: NodeJS.ProcessEnv): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = platformOf(env) === 'win32' ? 'where.exe' : 'command';
+    const args = platformOf(env) === 'win32' ? [command] : ['-v', command];
+    const p = spawn(probe, args, { stdio: 'ignore' });
+    p.on('exit', (code) => resolve(code === 0));
+    p.on('error', () => resolve(false));
+  });
+}

--- a/src/platform/scheduler.ts
+++ b/src/platform/scheduler.ts
@@ -1,0 +1,86 @@
+// Scheduler — per-OS background launch.
+// macOS: launchctl (LaunchAgent plist). Linux: systemd user unit. Windows:
+// Task Scheduler (schtasks) at logon. Used by the remote-job worker and the
+// pty-host autostart so they survive firstmate's own session restarts.
+
+import { spawn } from 'node:child_process';
+import { platformOf } from './path-util.js';
+
+export interface ScheduledTaskSpec {
+  name: string;
+  /** Command to run at logon. */
+  command: string;
+  /** Arguments array. */
+  args: string[];
+  /** Working directory. */
+  cwd: string;
+}
+
+export async function ensureScheduled(spec: ScheduledTaskSpec, env?: NodeJS.ProcessEnv): Promise<void> {
+  const platform = platformOf(env);
+  if (platform === 'win32') {
+    await runSchtasks(spec);
+  } else if (platform === 'darwin') {
+    await runLaunchAgent(spec);
+  } else {
+    await runSystemd(spec);
+  }
+}
+
+async function runSchtasks(spec: ScheduledTaskSpec): Promise<void> {
+  // Register a logon task running the command via cmd (handles .cmd shims).
+  const run = `cmd.exe /c ""${spec.command}" ${spec.args.map(quote).join(' ')}"`;
+  const action = `/TR "${run}"`;
+  await exec('schtasks.exe', ['/Create', '/F', '/TN', `firstmate-${spec.name}`, '/SC', 'ONLOGON', '/RL', 'LIMITED', action]);
+}
+
+async function runLaunchAgent(spec: ScheduledTaskSpec): Promise<void> {
+  const label = `dev.firstmate.${spec.name}`;
+  const plistPath = `${process.env.HOME}/Library/LaunchAgents/${label}.plist`;
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>${label}</string>
+  <key>ProgramArguments</key><array>
+    <string>${spec.command}</string>${spec.args.map((a) => `\n    <string>${a}</string>`).join('')}
+  </array>
+  <key>WorkingDirectory</key><string>${spec.cwd}</string>
+  <key>RunAtLoad</key><true/>
+</dict></plist>`;
+  const { promises: fs } = await import('node:fs');
+  await fs.mkdir(`${process.env.HOME}/Library/LaunchAgents`, { recursive: true });
+  await fs.writeFile(plistPath, plist, 'utf8');
+  await exec('launchctl', ['load', '-w', plistPath]);
+}
+
+async function runSystemd(spec: ScheduledTaskSpec): Promise<void> {
+  const unit = `firstmate-${spec.name}.service`;
+  const unitPath = `${process.env.HOME}/.config/systemd/user/${unit}`;
+  const body = `[Unit]
+Description=firstmate ${spec.name}
+[Service]
+Type=simple
+WorkingDirectory=${spec.cwd}
+ExecStart=${spec.command} ${spec.args.join(' ')}
+Restart=on-failure
+[Install]
+WantedBy=default.target
+`;
+  const { promises: fs } = await import('node:fs');
+  await fs.mkdir(`${process.env.HOME}/.config/systemd/user`, { recursive: true });
+  await fs.writeFile(unitPath, body, 'utf8');
+  await exec('systemctl', ['--user', 'daemon-reload']);
+  await exec('systemctl', ['--user', 'enable', unit]);
+}
+
+function quote(a: string): string {
+  return /[\s"]/.test(a) ? `"${a.replace(/"/g, '\\"')}"` : a;
+}
+
+function exec(cmd: string, args: string[]): Promise<void> {
+  return new Promise((resolve) => {
+    const p = spawn(cmd, args, { stdio: 'ignore' });
+    p.on('error', () => resolve());
+    p.on('exit', () => resolve());
+  });
+}

--- a/src/platform/signal-bus.ts
+++ b/src/platform/signal-bus.ts
@@ -1,0 +1,45 @@
+// SignalBus — portable signal handling.
+// POSIX uses SIGINT/SIGTERM; Windows lacks SIGTERM delivery, so we rely on
+// Ctrl-C (SIGINT) and an explicit shutdown() path. Supervision itself is
+// polling + file-based, so signals are a thin courtesy layer.
+
+type Handler = () => void | Promise<void>;
+
+export class SignalBus {
+  private handlers: Handler[] = [];
+  private readonly boundSigint: () => void;
+  private readonly boundSigterm: () => void;
+
+  constructor() {
+    this.boundSigint = () => void this.trigger();
+    this.boundSigterm = () => void this.trigger();
+    process.on('SIGINT', this.boundSigint);
+    process.on('SIGTERM', this.boundSigterm);
+  }
+
+  /** Register a shutdown handler; returns an unsubscribe function. */
+  onShutdown(handler: Handler): () => void {
+    this.handlers.push(handler);
+    return () => {
+      this.handlers = this.handlers.filter((h) => h !== handler);
+    };
+  }
+
+  async trigger(): Promise<void> {
+    // Run handlers once; duplicate signals are ignored while running.
+    if (this.triggering) return;
+    this.triggering = true;
+    try {
+      await Promise.all(this.handlers.map((h) => h()));
+    } finally {
+      this.triggering = false;
+    }
+  }
+
+  dispose(): void {
+    process.off('SIGINT', this.boundSigint);
+    process.off('SIGTERM', this.boundSigterm);
+  }
+
+  private triggering = false;
+}

--- a/src/platform/tools.ts
+++ b/src/platform/tools.ts
@@ -1,0 +1,73 @@
+// ToolResolver — locate external binaries across platforms.
+// Replaces `command -v` with `where.exe` on Windows, and handles the .cmd
+// shims npm global packages install. Fail-closed: a tool that cannot be
+// resolved is reported missing, never guessed.
+
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { platformOf } from './path-util.js';
+
+export interface ToolInfo {
+  name: string;
+  /** Absolute path to the executable, or null if not found. */
+  path: string | null;
+  /** True when the binary is a Windows .cmd/.bat shim (npm globals). */
+  isCmdShim: boolean;
+}
+
+/** On Windows, `where` lists extensionless npm-shim names that are not real
+ *  files; only entries whose file actually exists are usable by spawn. */
+async function existingPath(candidate: string): Promise<string | null> {
+  try {
+    const st = await fs.stat(candidate);
+    return st.isFile() ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveTool(name: string, env?: NodeJS.ProcessEnv): Promise<ToolInfo> {
+  const win = platformOf(env) === 'win32';
+  const probe = win ? 'where.exe' : 'command';
+  const args = win ? [name] : ['-v', name];
+
+  const result = await new Promise<string[] | null>((resolve) => {
+    const p = spawn(probe, args, { stdio: ['ignore', 'pipe', 'ignore'] });
+    let out = '';
+    p.stdout.on('data', (d: Buffer) => (out += d.toString()));
+    p.on('error', () => resolve(null));
+    p.on('exit', (code) => resolve(code === 0 ? out.split(/\r?\n/).filter(Boolean) : null));
+  });
+
+  if (!result) return { name, path: null, isCmdShim: false };
+  // Two passes: prefer candidates with a real Windows executable extension
+  // (.cmd/.bat/.exe/.com). Extensionless files exist on PATH (POSIX shell
+  // shims from npm) but node's spawn cannot execute them on Windows.
+  const candidates = result.map((c) => c.trim()).filter(Boolean);
+  const winExt = /\.(cmd|bat|exe|com)$/i;
+  const ordered = win
+    ? [...candidates.filter((c) => winExt.test(c)), ...candidates.filter((c) => !winExt.test(c))]
+    : candidates;
+  for (const candidate of ordered) {
+    const real = await existingPath(candidate);
+    if (!real) continue;
+    const isCmdShim = /\.(cmd|bat)$/i.test(real);
+    return { name, path: real, isCmdShim };
+  }
+  return { name, path: null, isCmdShim: false };
+}
+
+/** Resolve several tools at once, returning a map keyed by name. */
+export async function resolveTools(
+  names: string[],
+  env?: NodeJS.ProcessEnv,
+): Promise<Map<string, ToolInfo>> {
+  const entries = await Promise.all(names.map((n) => resolveTool(n, env)));
+  return new Map(entries.map((t) => [t.name, t]));
+}
+
+/** True when every named tool resolves. */
+export async function toolsPresent(names: string[], env?: NodeJS.ProcessEnv): Promise<boolean> {
+  const found = await resolveTools(names, env);
+  return names.every((n) => found.get(n)?.path);
+}

--- a/src/records/durable.ts
+++ b/src/records/durable.ts
@@ -1,0 +1,78 @@
+// Durable fleet records — status events and the wake queue.
+// Mirrors the bash state/<id>.status append and state/.wake-queue conventions
+// with append-only JSONL files. A status line is a wake event, not current state.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export interface StatusEvent {
+  ts: string;
+  state: string;
+  note: string;
+}
+
+export interface WakeRecord {
+  seq: number;
+  kind: 'signal' | 'stale' | 'check' | 'heartbeat' | 'note';
+  key: string;
+  payload?: string;
+}
+
+export class StatusLog {
+  constructor(private readonly file: string) {}
+
+  async append(state: string, note: string): Promise<void> {
+    const event: StatusEvent = { ts: new Date().toISOString(), state, note };
+    await fs.mkdir(path.dirname(this.file), { recursive: true });
+    await fs.appendFile(this.file, `${JSON.stringify(event)}\n`, 'utf8');
+  }
+
+  /** Read the last N events (tail). */
+  async tail(n = 20): Promise<StatusEvent[]> {
+    try {
+      const raw = await fs.readFile(this.file, 'utf8');
+      const lines = raw.split('\n').filter(Boolean).slice(-n);
+      return lines.map((l) => JSON.parse(l) as StatusEvent);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw err;
+    }
+  }
+}
+
+export class WakeQueue {
+  constructor(private readonly file: string) {}
+
+  /** Enqueue a wake record; returns the assigned seq. */
+  async push(record: Omit<WakeRecord, 'seq'>): Promise<number> {
+    await fs.mkdir(path.dirname(this.file), { recursive: true });
+    const seq = Date.now();
+    await fs.appendFile(this.file, `${JSON.stringify({ seq, ...record })}\n`, 'utf8');
+    return seq;
+  }
+
+  /** Read all queued wakes. */
+  async drain(): Promise<WakeRecord[]> {
+    try {
+      const raw = await fs.readFile(this.file, 'utf8');
+      return raw.split('\n').filter(Boolean).map((l) => JSON.parse(l) as WakeRecord);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw err;
+    }
+  }
+
+  /** Remove wakes up to and including `throughSeq`. */
+  async acknowledgeThrough(throughSeq: number): Promise<void> {
+    const remaining = (await this.drain()).filter((w) => w.seq > throughSeq);
+    if (remaining.length === 0) {
+      try {
+        await fs.unlink(this.file);
+      } catch {
+        /* already gone */
+      }
+      return;
+    }
+    await fs.writeFile(this.file, remaining.map((w) => JSON.stringify(w)).join('\n') + '\n', 'utf8');
+  }
+}

--- a/src/records/index.ts
+++ b/src/records/index.ts
@@ -1,0 +1,4 @@
+// Records layer barrel.
+export * from './durable.js';
+export * from './task-meta.js';
+export * from './steering-inbox.js';

--- a/src/records/steering-inbox.ts
+++ b/src/records/steering-inbox.ts
@@ -1,0 +1,56 @@
+// SteeringInbox — durable per-task steering records.
+// Mirrors state/<id>.inbox: sequenced instruction records the worker
+// acknowledges by moving them into handled/. fm-send writes here; the watcher
+// rings the worker's doorbell; the worker consumes and acknowledges.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export interface SteerRecord {
+  seq: number;
+  kind: 'steer' | 'resolve-key';
+  message: string;
+  /** Optional decision key this steer resolves. */
+  resolveKey?: string;
+  created: string;
+}
+
+export class SteeringInbox {
+  constructor(private readonly dir: string) {}
+
+  async push(record: Omit<SteerRecord, 'seq' | 'created'>): Promise<SteerRecord> {
+    await fs.mkdir(this.dir, { recursive: true });
+    const seq = Date.now();
+    const full: SteerRecord = { ...record, seq, created: new Date().toISOString() };
+    await fs.writeFile(path.join(this.dir, `${seq}.json`), JSON.stringify(full, null, 2), 'utf8');
+    return full;
+  }
+
+  /** List pending (unhandled) records, oldest first. */
+  async pending(): Promise<SteerRecord[]> {
+    let files: string[];
+    try {
+      files = await fs.readdir(this.dir);
+    } catch {
+      return [];
+    }
+    const pending = files.filter((f) => f.endsWith('.json'));
+    pending.sort();
+    const records = await Promise.all(
+      pending.map((f) => fs.readFile(path.join(this.dir, f), 'utf8').then((r) => JSON.parse(r) as SteerRecord)),
+    );
+    return records;
+  }
+
+  /** Acknowledge a record by moving it into handled/. */
+  async acknowledge(seq: number): Promise<void> {
+    const handled = path.join(this.dir, 'handled');
+    await fs.mkdir(handled, { recursive: true });
+    const src = path.join(this.dir, `${seq}.json`);
+    try {
+      await fs.rename(src, path.join(handled, `${seq}.json`));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+  }
+}

--- a/src/records/task-meta.ts
+++ b/src/records/task-meta.ts
@@ -1,0 +1,76 @@
+// TaskMeta — durable per-task metadata, mirroring state/<id>.meta.
+// Holds the task's recorded endpoint, backend, project, and delivery posture.
+// Written atomically so a crash cannot leave a partial record.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { StatusLog } from './durable.js';
+
+export interface TaskMeta {
+  id: string;
+  /** Backend endpoint that owns this task's terminal (tmux target, pty id...). */
+  endpoint: string;
+  /** Backend name: 'stdio' | 'conpty' | 'tmux' | ... */
+  backend: string;
+  /** Isolated worktree path. */
+  worktree: string;
+  /** Project repo path. */
+  project: string;
+  /** Delivery mode: 'no-mistakes' | 'direct-PR' | 'local-only'. */
+  deliveryMode: string;
+  /** Merge posture: 'yolo' on/off. */
+  yolo: boolean;
+  /** Created timestamp. */
+  createdAt: string;
+}
+
+export class TaskMetaStore {
+  constructor(readonly stateDir: string) {}
+
+  private file(id: string): string {
+    return path.join(this.stateDir, `${id}.meta`);
+  }
+
+  async write(meta: TaskMeta): Promise<void> {
+    await fs.mkdir(this.stateDir, { recursive: true });
+    const tmp = `${this.file(meta.id)}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify(meta, null, 2), 'utf8');
+    await fs.rename(tmp, this.file(meta.id));
+  }
+
+  async read(id: string): Promise<TaskMeta | null> {
+    try {
+      const raw = await fs.readFile(this.file(id), 'utf8');
+      return JSON.parse(raw) as TaskMeta;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw err;
+    }
+  }
+
+  async remove(id: string): Promise<void> {
+    try {
+      await fs.unlink(this.file(id));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+  }
+
+  async list(): Promise<TaskMeta[]> {
+    let files: string[];
+    try {
+      files = await fs.readdir(this.stateDir);
+    } catch {
+      return [];
+    }
+    const metas = await Promise.all(
+      files.filter((f) => f.endsWith('.meta')).map((f) => this.read(f.replace(/\.meta$/, ''))),
+    );
+    return metas.filter((m): m is TaskMeta => m !== null);
+  }
+
+  /** The status log for a task (state/<id>.status). */
+  statusLog(id: string): StatusLog {
+    return new StatusLog(path.join(this.stateDir, `${id}.status`));
+  }
+}

--- a/src/spawn/harness.ts
+++ b/src/spawn/harness.ts
@@ -1,0 +1,88 @@
+// HarnessLauncher — resolve and launch a coding-agent harness CLI.
+// Mirrors the verified harness set from the bash fleet: claude, codex,
+// opencode, pi, grok, kimi, cursor, muse — plus cmdc (Command Code).
+// Each has a known launch form. On Windows, resolver output goes through
+// resolveTool, which prefers real .cmd/.exe files over extensionless shims.
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { resolveTool } from '../platform/tools.js';
+
+export type HarnessName =
+  | 'claude'
+  | 'codex'
+  | 'opencode'
+  | 'pi'
+  | 'grok'
+  | 'kimi'
+  | 'cursor'
+  | 'muse'
+  | 'cmdc';
+
+export interface HarnessResolver {
+  (name: HarnessName, env: NodeJS.ProcessEnv): Promise<string>;
+}
+
+const LAUNCH_ARGS: Record<HarnessName, (promptFile: string) => string[]> = {
+  claude: (p) => ['--dangerously-skip-permissions', '--print', '--output-format', 'stream-json', '--append-system-prompt', `Execute the task in ${p}`],
+  codex: (p) => ['exec', '--dangerously-bypass-approvals-and-sandbox', `Run the task described in ${p}`],
+  opencode: (p) => ['--prompt', `Execute the task in ${p}`],
+  pi: (p) => ['-e', p],
+  grok: (p) => ['--always-approve', '-p', `Execute the task in ${p}`],
+  kimi: (p) => ['--auto', p],
+  cursor: (p) => ['--trust', 'run', `Execute the task in ${p}`],
+  muse: (p) => ['--yolo', p],
+  // Command Code headless: -p query, --yolo to allow edits/shell,
+  // --output-format json for machine-readable results, --skip-onboarding for CI.
+  cmdc: (p) => ['-p', `Execute the task in ${p}`, '--yolo', '--output-format', 'json', '--skip-onboarding'],
+};
+
+/** Build the launch args for a harness (shared by launcher and spawn). */
+export function harnessLaunchArgs(name: HarnessName, promptFile: string): string[] {
+  return LAUNCH_ARGS[name](promptFile);
+}
+
+export class HarnessLauncher {
+  constructor(private readonly resolver: HarnessResolver = defaultResolver) {}
+
+  async resolve(name: HarnessName, env: NodeJS.ProcessEnv): Promise<string> {
+    return this.resolver(name, env);
+  }
+
+  launch(name: HarnessName, promptFile: string, cwd: string, env: NodeJS.ProcessEnv): ChildProcess {
+    const args = harnessLaunchArgs(name, promptFile);
+    const envExtra: NodeJS.ProcessEnv =
+      name === 'claude' ? { CLAUDECODE: '1' }
+      : name === 'pi' ? { PI_CODING_AGENT: 'true' }
+      : name === 'grok' ? { GROK_AGENT: '1' }
+      : name === 'muse' ? { MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL: 'on' }
+      : {};
+    return spawn(this.commandName(name), args, {
+      cwd,
+      env: { ...env, ...envExtra },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: false,
+    });
+  }
+
+  private commandName(name: HarnessName): string {
+    return name;
+  }
+}
+
+/** Command Code installs as `cmdc`/`command-code`/`commandcode` (and `cmd`,
+ *  but that collides with the Windows shell, so it is never auto-resolved).
+ *  Prefer cmdc, then command-code, then commandcode. */
+const CMDC_ALIASES = ['cmdc', 'command-code', 'commandcode'];
+
+async function defaultResolver(name: HarnessName, env: NodeJS.ProcessEnv): Promise<string> {
+  if (name === 'cmdc') {
+    for (const alias of CMDC_ALIASES) {
+      const tool = await resolveTool(alias, env);
+      if (tool.path) return tool.path;
+    }
+    throw new Error(`harness 'cmdc' not found on PATH (tried ${CMDC_ALIASES.join(', ')})`);
+  }
+  const tool = await resolveTool(name, env);
+  if (!tool.path) throw new Error(`harness '${name}' not found on PATH`);
+  return tool.path;
+}

--- a/src/spawn/harness.ts
+++ b/src/spawn/harness.ts
@@ -23,7 +23,9 @@ export interface HarnessResolver {
 }
 
 const LAUNCH_ARGS: Record<HarnessName, (promptFile: string) => string[]> = {
-  claude: (p) => ['--dangerously-skip-permissions', '--print', '--output-format', 'stream-json', '--append-system-prompt', `Execute the task in ${p}`],
+  // --verbose is required by claude whenever --print is combined with
+  // --output-format stream-json (rejected otherwise: "requires --verbose").
+  claude: (p) => ['--dangerously-skip-permissions', '--print', '--output-format', 'stream-json', '--verbose', `Execute the task in ${p}`],
   codex: (p) => ['exec', '--dangerously-bypass-approvals-and-sandbox', `Run the task described in ${p}`],
   opencode: (p) => ['--prompt', `Execute the task in ${p}`],
   pi: (p) => ['-e', p],

--- a/src/spawn/index.ts
+++ b/src/spawn/index.ts
@@ -1,0 +1,112 @@
+// Spawn — orchestrate a task: resolve project, create worktree, write brief,
+// launch the harness into a backend session, record durable task meta.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { ensureHomeDirs } from '../platform/home.js';
+import type { TerminalBackend } from '../backend/types.js';
+import { HarnessLauncher, harnessLaunchArgs, type HarnessName } from './harness.js';
+import { WorktreeProvider } from './worktree.js';
+import { TaskMetaStore, type TaskMeta } from '../records/task-meta.js';
+import { createBacklogClient } from '../backlog/index.js';
+
+export interface SpawnOptions {
+  /** Project repo path. */
+  project: string;
+  /** Task subject. */
+  subject: string;
+  /** Harness to run the task. */
+  harness: HarnessName;
+  /** Delivery mode. */
+  deliveryMode?: 'no-mistakes' | 'direct-PR' | 'local-only';
+  /** Merge posture. */
+  yolo?: boolean;
+  /** Explicit backend override. */
+  backend?: 'stdio' | 'conpty' | 'tmux';
+  /** Optional direct command/args override (tests, custom harnesses). */
+  harnessOverride?: HarnessCommand;
+}
+
+export interface SpawnResult {
+  taskId: string;
+  worktree: string;
+  branch: string;
+  endpoint: string;
+  backend: string;
+  meta: TaskMeta;
+}
+
+export interface HarnessCommand {
+  command: string;
+  args: string[];
+}
+
+export class SpawnService {
+  constructor(
+    private readonly backend: TerminalBackend,
+    private readonly env: NodeJS.ProcessEnv,
+    private readonly worktrees = new WorktreeProvider(),
+    private readonly launcher = new HarnessLauncher(),
+  ) {}
+
+  async spawn(opts: SpawnOptions): Promise<SpawnResult> {
+    const paths = await ensureHomeDirs(this.env);
+    const taskId = `t-${Date.now().toString(36)}`;
+
+    // 1. Backlog: record the item as in-flight.
+    const backlog = await createBacklogClient(this.env);
+    await backlog.add(opts.subject, { note: `task ${taskId}` });
+    await backlog.transition((await backlog.list()).find((i) => i.note?.includes(taskId))?.id ?? taskId, 'in-flight');
+
+    // 2. Worktree.
+    const wt = await this.worktrees.create(opts.project, taskId);
+
+    // 3. Brief.
+    const brief = `# ${opts.subject}
+
+Task: ${taskId}
+Project: ${opts.project}
+Worktree: ${wt.path}
+Delivery mode: ${opts.deliveryMode ?? 'no-mistakes'}
+Merge posture: ${opts.yolo ? 'yolo on' : 'yolo off'}
+
+## Instructions
+Complete the task described in the subject within this isolated worktree.
+Follow the project's delivery contract for the selected mode.
+Do not work outside this worktree.
+`;
+    const briefPath = path.join(wt.path, 'TASK.md');
+    await fs.writeFile(briefPath, brief, 'utf8');
+
+    // 4. Launch harness into the backend.
+    const harnessPath = opts.harnessOverride
+      ? opts.harnessOverride.command
+      : await this.launcher.resolve(opts.harness, this.env);
+    const harnessArgs = opts.harnessOverride
+      ? opts.harnessOverride.args
+      : harnessLaunchArgs(opts.harness, briefPath);
+    const endpoint = await this.backend.create({
+      taskId,
+      cwd: wt.path,
+      command: harnessPath,
+      args: harnessArgs,
+      env: {},
+    });
+    // 5. Durable task meta.
+    const meta: TaskMeta = {
+      id: taskId,
+      endpoint,
+      backend: this.backend.name,
+      worktree: wt.path,
+      project: opts.project,
+      deliveryMode: opts.deliveryMode ?? 'no-mistakes',
+      yolo: opts.yolo ?? false,
+      createdAt: new Date().toISOString(),
+    };
+    const store = new TaskMetaStore(paths.state);
+    await store.write(meta);
+    await store.statusLog(taskId).append('running', `spawned on ${this.backend.name}`);
+
+    return { taskId, worktree: wt.path, branch: wt.branch, endpoint, backend: this.backend.name, meta };
+  }
+}

--- a/src/spawn/worktree.ts
+++ b/src/spawn/worktree.ts
@@ -1,0 +1,48 @@
+// WorktreeProvider — isolated task worktrees via native `git worktree`.
+// The bash fleet uses treehouse; the native core uses plain git worktree,
+// which works on all platforms. Lease support is a no-op here (documented
+// degrade) until treehouse is verified on Windows.
+
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export interface WorktreeInfo {
+  /** Absolute path to the worktree. */
+  path: string;
+  /** Branch name the worktree is on. */
+  branch: string;
+}
+
+export class WorktreeProvider {
+  async create(projectPath: string, taskId: string): Promise<WorktreeInfo> {
+    const branch = `fm-${taskId}`;
+    const worktreePath = path.join(projectPath, '..', `.fm-${taskId}`);
+    await this.git(projectPath, ['worktree', 'add', '-b', branch, worktreePath, 'HEAD']);
+    return { path: worktreePath, branch };
+  }
+
+  async remove(projectPath: string, worktreePath: string): Promise<void> {
+    try {
+      await this.git(projectPath, ['worktree', 'remove', '--force', worktreePath]);
+    } catch {
+      // Fall back to manual cleanup when git worktree removal fails.
+      await fs.rm(worktreePath, { recursive: true, force: true });
+    }
+  }
+
+  private git(cwd: string, args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const p = spawn('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+      let out = '';
+      let err = '';
+      p.stdout.on('data', (d: Buffer) => (out += d.toString()));
+      p.stderr.on('data', (d: Buffer) => (err += d.toString()));
+      p.on('error', reject);
+      p.on('exit', (code) => {
+        if (code === 0) resolve(out.trim());
+        else reject(new Error(`git worktree failed (${code}): ${err.trim() || out.trim()}`));
+      });
+    });
+  }
+}

--- a/src/supervise/crew-state.ts
+++ b/src/supervise/crew-state.ts
@@ -1,0 +1,45 @@
+// CrewState — reconcile a task's current state.
+// Reads the task's live backend state, the status-log tail, and pending
+// steers, producing a single current-state record.
+
+import type { TerminalBackend } from '../backend/types.js';
+import { TaskMetaStore } from '../records/task-meta.js';
+import { SteeringInbox } from '../records/steering-inbox.js';
+import { ensureHomeDirs } from '../platform/home.js';
+
+export interface CrewState {
+  taskId: string;
+  backend: string;
+  endpoint: string;
+  agent: Awaited<ReturnType<TerminalBackend['agentState']>>;
+  lastEvents: string[];
+  pendingSteers: number;
+}
+
+export class CrewStateService {
+  constructor(
+    private readonly backend: TerminalBackend,
+    private readonly env: NodeJS.ProcessEnv,
+  ) {}
+
+  async state(taskId: string): Promise<CrewState> {
+    const paths = await ensureHomeDirs(this.env);
+    const store = new TaskMetaStore(paths.state);
+    const meta = await store.read(taskId);
+    if (!meta) throw new Error(`no task ${taskId}`);
+
+    const agent = await this.backend.agentState(taskId);
+    const events = await store.statusLog(taskId).tail(10);
+    const inbox = new SteeringInbox(`${store.stateDir}/${taskId}.inbox`);
+    const pending = await inbox.pending();
+
+    return {
+      taskId,
+      backend: meta.backend,
+      endpoint: meta.endpoint,
+      agent,
+      lastEvents: events.map((e) => `${e.state}: ${e.note}`),
+      pendingSteers: pending.length,
+    };
+  }
+}

--- a/src/supervise/watcher.ts
+++ b/src/supervise/watcher.ts
@@ -1,0 +1,57 @@
+// Watcher — the supervision loop.
+// Polls the fleet's tasks, classifies each session's agent state, appends
+// status events, and surfaces wake records. Mirrors bin/fm-watch.sh's polling
+// model (durable wake files + backend liveness probes) without POSIX signals.
+
+import type { TerminalBackend } from '../backend/types.js';
+import { TaskMetaStore } from '../records/task-meta.js';
+import { WakeQueue } from '../records/durable.js';
+import { ensureHomeDirs } from '../platform/home.js';
+
+export interface WatcherOptions {
+  pollMs?: number;
+  /** Run a single pass and exit (for tests and `watch --once`). */
+  once?: boolean;
+}
+
+export class Watcher {
+  private stopped = false;
+
+  constructor(
+    private readonly backend: TerminalBackend,
+    private readonly env: NodeJS.ProcessEnv,
+  ) {}
+
+  async run(opts: WatcherOptions = {}): Promise<void> {
+    const pollMs = opts.pollMs ?? 2000;
+    const paths = await ensureHomeDirs(this.env);
+    const store = new TaskMetaStore(paths.state);
+    const queue = new WakeQueue(`${paths.state}/.wake-queue`);
+
+    do {
+      await this.pass(store, queue);
+      if (opts.once) return;
+      await sleep(pollMs);
+    } while (!this.stopped);
+  }
+
+  stop(): void {
+    this.stopped = true;
+  }
+
+  private async pass(store: TaskMetaStore, queue: WakeQueue): Promise<void> {
+    const metas = await store.list();
+    for (const meta of metas) {
+      const state = await this.backend.agentState(meta.id);
+      const log = store.statusLog(meta.id);
+      if (state === 'dead' || state === 'missing') {
+        await log.append('exited', `worker ${state}`);
+        await queue.push({ kind: 'signal', key: meta.id, payload: `worker ${state}` });
+      }
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/tests/backend-stdio.test.ts
+++ b/tests/backend-stdio.test.ts
@@ -1,0 +1,53 @@
+// Stdio backend tests — create, capture, send, kill.
+import { describe, it, expect } from 'vitest';
+import { StdioBackend } from '../src/backend/stdio.js';
+import { createBackend } from '../src/backend/factory.js';
+
+describe('StdioBackend', () => {
+  it('creates a session and captures output', async () => {
+    const backend = new StdioBackend();
+    const node = process.execPath;
+    await backend.create({
+      taskId: 't1',
+      cwd: process.cwd(),
+      command: node,
+      args: ['-e', 'console.log("hello from stdio"); setTimeout(() => {}, 60000);'],
+    });
+    expect(await backend.exists('t1')).toBe(true);
+    // Poll until the output lands (bounded; stretches under load).
+    let out = '';
+    for (let i = 0; i < 50; i++) {
+      out = await backend.capture('t1');
+      if (out.includes('hello from stdio')) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(out).toContain('hello from stdio');
+    await backend.kill('t1');
+  });
+
+  it('detects a dead session', async () => {
+    const backend = new StdioBackend();
+    await backend.create({
+      taskId: 't2',
+      cwd: process.cwd(),
+      command: process.execPath,
+      args: ['-e', 'process.exit(0);'],
+    });
+    // Poll until the process exits (bounded; stretches under load).
+    let dead = false;
+    for (let i = 0; i < 50; i++) {
+      if (!(await backend.exists('t2'))) {
+        dead = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(dead).toBe(true);
+    expect(await backend.agentState('t2')).toBe('dead');
+  });
+
+  it('factory returns stdio when FM_BACKEND=stdio', async () => {
+    const backend = await createBackend({ env: { FM_BACKEND: 'stdio' } as NodeJS.ProcessEnv });
+    expect(backend.name).toBe('stdio');
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,67 @@
+// CLI tests — dispatch, aliases, and unknown-command handling.
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+
+// Import fresh so each test can stub process.exitCode cleanly.
+const cli = await import('../src/cli/index.js');
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'fm-cli-test-'));
+  process.env.FM_HOME = tmpHome;
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(tmpHome, { recursive: true, force: true });
+  delete process.env.FM_HOME;
+});
+
+describe('CLI dispatch', () => {
+  it('returns 0 for --help', async () => {
+    const code = await cli.runCli(['--help']);
+    expect(code).toBe(0);
+  });
+
+  it('returns 0 for the help command', async () => {
+    const code = await cli.runCli(['help']);
+    expect(code).toBe(0);
+  });
+
+  it('returns 2 for an unknown command', async () => {
+    const code = await cli.runCli(['no-such-command']);
+    expect(code).toBe(2);
+  });
+
+  it('resolves a legacy alias to its canonical command', async () => {
+    const code = await cli.runCli(['fm-session-start']);
+    expect(code).toBe(0);
+  });
+
+  it('runs session-start with a temp FM_HOME', async () => {
+    const out: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...a) => out.push(String(a[0])));
+    const code = await cli.runCli(['session-start']);
+    expect(code).toBe(0);
+    expect(out.some((l) => l.includes('firstmate session-start (native core)'))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('send requires a task id and message', async () => {
+    const err: string[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((...a) => err.push(String(a[0])));
+    expect(await cli.runCli(['send'])).toBe(2);
+    expect(await cli.runCli(['send', 'task-1'])).toBe(2);
+    expect(err.length).toBeGreaterThan(0);
+    spy.mockRestore();
+  });
+
+  it('control validates its action', async () => {
+    expect(await cli.runCli(['control', 'task-1', 'explode'])).toBe(2);
+    // No such task -> returns 1 (not 0).
+    expect(await cli.runCli(['control', 'task-1', 'interrupt'])).toBe(1);
+  });
+});

--- a/tests/durable.test.ts
+++ b/tests/durable.test.ts
@@ -1,0 +1,55 @@
+// Durable records tests — status log and wake queue.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { StatusLog, WakeQueue } from '../src/records/durable.js';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'fm-records-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('StatusLog', () => {
+  it('appends and tails events', async () => {
+    const log = new StatusLog(path.join(dir, 't.status'));
+    await log.append('running', 'started');
+    await log.append('done', 'finished');
+    const events = await log.tail();
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ state: 'running', note: 'started' });
+  });
+
+  it('returns an empty list when the log is absent', async () => {
+    const log = new StatusLog(path.join(dir, 'missing.status'));
+    expect(await log.tail()).toEqual([]);
+  });
+});
+
+describe('WakeQueue', () => {
+  it('pushes, drains, and acknowledges through a seq', async () => {
+    const q = new WakeQueue(path.join(dir, '.wake-queue'));
+    const seq1 = await q.push({ kind: 'signal', key: 't1' });
+    await q.push({ kind: 'check', key: 't2' });
+
+    const all = await q.drain();
+    expect(all).toHaveLength(2);
+
+    await q.acknowledgeThrough(seq1);
+    const remaining = await q.drain();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]).toMatchObject({ kind: 'check', key: 't2' });
+  });
+
+  it('acknowledges everything and removes the file', async () => {
+    const q = new WakeQueue(path.join(dir, '.wake-queue'));
+    const seq = await q.push({ kind: 'note', key: 'inbox-1' });
+    await q.acknowledgeThrough(seq);
+    expect(await q.drain()).toEqual([]);
+  });
+});

--- a/tests/file-lock.test.ts
+++ b/tests/file-lock.test.ts
@@ -1,0 +1,111 @@
+// FileLock behavior tests — contention, staleness, force-replace, release.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { FileLock, isStaleLock, currentBootNonce, type LockMetadata } from '../src/platform/file-lock.js';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'fm-lock-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+function lockPath(name = 'session.lock') {
+  return path.join(dir, name);
+}
+
+describe('FileLock', () => {
+  it('acquires an uncontended lock', async () => {
+    const lock = new FileLock({ lockPath: lockPath(), dir });
+    const state = await lock.acquire();
+    expect(state.held).toBe(true);
+    await lock.release();
+  });
+
+  it('refuses when another live holder owns the lock', async () => {
+    const first = new FileLock({ lockPath: lockPath(), dir });
+    await first.acquire();
+    const second = new FileLock({ lockPath: lockPath(), dir });
+    const state = await second.acquire();
+    expect(state).toEqual({ held: false, reason: 'refused' });
+    await first.release();
+  });
+
+  it('treats a lock owned by a dead pid as stale', async () => {
+    const metadata: LockMetadata = {
+      pid: 999999999, // almost certainly not alive
+      host: 'test',
+      bootNonce: 'test-nonce',
+      acquiredAt: new Date().toISOString(),
+    };
+    await fs.writeFile(lockPath(), JSON.stringify(metadata), 'utf8');
+    expect(await isStaleLock(lockPath())).toBe(true);
+  });
+
+  it('treats a lock owned by a live pid as live', async () => {
+    const metadata: LockMetadata = {
+      pid: process.pid,
+      host: 'test',
+      bootNonce: currentBootNonce(),
+      acquiredAt: new Date().toISOString(),
+    };
+    await fs.writeFile(lockPath(), JSON.stringify(metadata), 'utf8');
+    expect(await isStaleLock(lockPath())).toBe(false);
+  });
+
+  it('force-replaces a stale lock but refuses a live one', async () => {
+    const stale: LockMetadata = {
+      pid: 999999999,
+      host: 'test',
+      bootNonce: 'stale-nonce',
+      acquiredAt: new Date().toISOString(),
+    };
+    await fs.writeFile(lockPath(), JSON.stringify(stale), 'utf8');
+
+    const forced = new FileLock({ lockPath: lockPath(), dir, force: true });
+    const state = await forced.acquire();
+    expect(state.held).toBe(true);
+    await forced.release();
+
+    // A live holder must not be force-replaced.
+    const live = new FileLock({ lockPath: lockPath(), dir });
+    await live.acquire();
+    const noForce = new FileLock({ lockPath: lockPath(), dir, force: true });
+    const refused = await noForce.acquire();
+    expect(refused).toEqual({ held: false, reason: 'refused' });
+    await live.release();
+  });
+
+  it('uses an injectable liveness probe', async () => {
+    const metadata: LockMetadata = {
+      pid: 42,
+      host: 'test',
+      bootNonce: 'probe-nonce',
+      acquiredAt: new Date().toISOString(),
+    };
+    await fs.writeFile(lockPath(), JSON.stringify(metadata), 'utf8');
+
+    // Probe says pid 42 is alive -> lock is live -> refused.
+    const aliveProbe = new FileLock({ lockPath: lockPath(), dir, isAlive: () => true });
+    expect(await aliveProbe.acquire()).toEqual({ held: false, reason: 'refused' });
+
+    // Probe says pid 42 is dead -> stale -> force replaces.
+    const deadProbe = new FileLock({ lockPath: lockPath(), dir, force: true, isAlive: () => false });
+    const state = await deadProbe.acquire();
+    expect(state.held).toBe(true);
+    await deadProbe.release();
+  });
+
+  it('releases idempotently', async () => {
+    const lock = new FileLock({ lockPath: lockPath(), dir });
+    await lock.acquire();
+    await lock.release();
+    await lock.release(); // no throw
+    expect(await isStaleLock(lockPath())).toBe(false);
+  });
+});

--- a/tests/harness.test.ts
+++ b/tests/harness.test.ts
@@ -1,0 +1,45 @@
+// Harness launcher tests — launch-arg shapes and cmdc alias resolution.
+import { describe, it, expect } from 'vitest';
+import { harnessLaunchArgs, HarnessLauncher } from '../src/spawn/harness.js';
+
+describe('harnessLaunchArgs', () => {
+  it('builds the claude headless form', () => {
+    const args = harnessLaunchArgs('claude', '/tmp/brief.md');
+    expect(args).toContain('--dangerously-skip-permissions');
+    expect(args).toContain('--print');
+    expect(args.some((a) => a.includes('/tmp/brief.md'))).toBe(true);
+  });
+
+  it('builds the cmdc headless form', () => {
+    const args = harnessLaunchArgs('cmdc', '/tmp/brief.md');
+    expect(args).toEqual([
+      '-p',
+      'Execute the task in /tmp/brief.md',
+      '--yolo',
+      '--output-format',
+      'json',
+      '--skip-onboarding',
+    ]);
+  });
+
+  it('cmdc launch args always include yolo + json output', () => {
+    const args = harnessLaunchArgs('cmdc', 'brief.md');
+    expect(args).toContain('--yolo');
+    expect(args).toContain('json');
+    expect(args).toContain('--skip-onboarding');
+  });
+});
+
+describe('HarnessLauncher resolver', () => {
+  it('resolves cmdc through the injected resolver', async () => {
+    const launcher = new HarnessLauncher(async () => '/opt/bin/cmdc');
+    await expect(launcher.resolve('cmdc', {})).resolves.toBe('/opt/bin/cmdc');
+  });
+
+  it('rejects an unknown harness', async () => {
+    const launcher = new HarnessLauncher(async () => {
+      throw new Error('not found');
+    });
+    await expect(launcher.resolve('cmdc', {})).rejects.toThrow('not found');
+  });
+});

--- a/tests/lifecycle-e2e.test.ts
+++ b/tests/lifecycle-e2e.test.ts
@@ -1,0 +1,115 @@
+// End-to-end lifecycle test: spawn -> send -> control -> teardown.
+// Uses the stdio backend and a fake harness script so no real agent runs.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { StdioBackend } from '../src/backend/stdio.js';
+import { SpawnService } from '../src/spawn/index.js';
+import { LifecycleService } from '../src/control/lifecycle.js';
+import { TaskMetaStore } from '../src/records/task-meta.js';
+import { JsonlBacklog } from '../src/backlog/index.js';
+
+let tmp: string;
+let projectDir: string;
+let env: NodeJS.ProcessEnv;
+
+async function git(args: string[], cwd: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const p = spawn('git', args, { cwd, stdio: 'ignore' });
+    p.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`git ${args[0]} failed: ${code}`))));
+    p.on('error', reject);
+  });
+}
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'fm-e2e-test-'));
+  projectDir = path.join(tmp, 'proj');
+  await fs.mkdir(projectDir);
+  await git(['init'], projectDir);
+  await fs.writeFile(path.join(projectDir, 'README.md'), '# test project\n', 'utf8');
+  await git(['add', '.'], projectDir);
+  await git(['-c', 'user.email=test@test', '-c', 'user.name=test', 'commit', '-m', 'init'], projectDir);
+
+  env = { ...process.env, FM_HOME: path.join(tmp, 'home') };
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+// A fake harness: echoes a line, reads stdin until "exit", then exits.
+async function writeFakeHarness(): Promise<string> {
+  const script = path.join(tmp, 'fake-harness.cjs');
+  const body = `
+    const readline = require('node:readline');
+    const rl = readline.createInterface({ input: process.stdin });
+    console.log('FAKE_HARNESS_READY');
+    rl.on('line', (line) => {
+      if (line.includes('exit')) process.exit(0);
+    });
+  `;
+  await fs.writeFile(script, body, 'utf8');
+  return script;
+}
+
+describe('spawn -> lifecycle e2e', () => {
+  it('spawns a task, sends a steer, controls, and tears down', async () => {
+    const backend = new StdioBackend();
+    const fakeHarness = await writeFakeHarness();
+    const service = new SpawnService(backend, env);
+
+    const result = await service.spawn({
+      project: projectDir,
+      subject: 'test task',
+      harness: 'claude',
+      deliveryMode: 'local-only',
+      // Run node executing the fake harness script, so no real agent CLI is needed.
+      harnessOverride: { command: process.execPath, args: [fakeHarness] },
+    });
+
+    expect(result.taskId).toBeTruthy();
+    expect(result.backend).toBe('stdio');
+    // The worktree was created inside the project's parent.
+    expect(result.worktree).toContain('.fm-');
+
+    // The fake harness launched (node runs it), so the backend session exists.
+    const exists = await backend.exists(result.taskId);
+    expect(exists).toBe(true);
+
+    // Send a steer.
+    const lifecycle = new LifecycleService(backend, env);
+    const seq = await lifecycle.send(result.taskId, 'please continue');
+    expect(seq).toBeGreaterThan(0);
+
+    // Teardown refuses while steers are pending.
+    await expect(lifecycle.teardown(result.taskId)).rejects.toThrow(/unacknowledged/);
+
+    // Acknowledge the steer, then teardown succeeds.
+    const store = new TaskMetaStore(path.join(env.FM_HOME!, 'state'));
+    const inbox = new (await import('../src/records/steering-inbox.js')).SteeringInbox(`${store.stateDir}/${result.taskId}.inbox`);
+    await inbox.acknowledge(seq);
+    await lifecycle.teardown(result.taskId);
+
+    // Task meta is gone after teardown.
+    expect(await store.read(result.taskId)).toBeNull();
+  });
+
+  it('records the task in the backlog', async () => {
+    const backend = new StdioBackend();
+    const fakeHarness = await writeFakeHarness();
+    const service = new SpawnService(backend, env);
+    const result = await service.spawn({
+      project: projectDir,
+      subject: 'backlog task',
+      harness: 'claude',
+      harnessOverride: { command: process.execPath, args: [fakeHarness] },
+    });
+    const backlog = new JsonlBacklog(env);
+    const items = await backlog.list();
+    expect(items.some((i) => i.subject === 'backlog task')).toBe(true);
+    // Kill the session so the worktree dir is not locked on Windows.
+    await backend.kill(result.taskId);
+  });
+});

--- a/tests/path-util.test.ts
+++ b/tests/path-util.test.ts
@@ -1,0 +1,48 @@
+// PathUtil tests — cross-platform path semantics.
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import {
+  platformOf,
+  isWindows,
+  expandHome,
+  samePath,
+  toNative,
+  toPosix,
+  isAbsolute,
+} from '../src/platform/path-util.js';
+
+const WINDOWS_ENV = { FIRSTMATE_PLATFORM: 'win32' } as NodeJS.ProcessEnv;
+const LINUX_ENV = { FIRSTMATE_PLATFORM: 'linux' } as NodeJS.ProcessEnv;
+
+describe('PathUtil', () => {
+  it('detects platform from env override', () => {
+    expect(platformOf(WINDOWS_ENV)).toBe('win32');
+    expect(platformOf(LINUX_ENV)).toBe('linux');
+    expect(isWindows(WINDOWS_ENV)).toBe(true);
+    expect(isWindows(LINUX_ENV)).toBe(false);
+  });
+
+  it('expands a leading tilde', () => {
+    const home = expandHome('~/projects/foo');
+    const suffix = 'projects' + path.sep + 'foo';
+    expect(home.endsWith(suffix)).toBe(true);
+  });
+
+  it('compares case-insensitively on Windows, case-sensitively elsewhere', () => {
+    expect(samePath('C:\\Users\\Me\\Project', 'c:\\users\\me\\project', WINDOWS_ENV)).toBe(true);
+    expect(samePath('/home/me/project', '/home/me/Project', LINUX_ENV)).toBe(false);
+    expect(samePath('/home/me/project', '/home/me/project', LINUX_ENV)).toBe(true);
+  });
+
+  it('normalizes separators per platform', () => {
+    expect(toNative('C:/Users/Me/Project', WINDOWS_ENV)).toBe('C:\\Users\\Me\\Project');
+    expect(toNative('/home/me/project', LINUX_ENV)).toBe('/home/me/project');
+    expect(toPosix('C:\\Users\\Me')).toBe('C:/Users/Me');
+  });
+
+  it('recognizes absolute paths on both platforms', () => {
+    expect(isAbsolute('C:\\Users\\Me')).toBe(true);
+    expect(isAbsolute('/home/me')).toBe(true);
+    expect(isAbsolute('relative/path')).toBe(false);
+  });
+});

--- a/tests/session-start.test.ts
+++ b/tests/session-start.test.ts
@@ -1,0 +1,49 @@
+// Session-start digest test: lock, wake queue, fleet summary.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { SessionStartService } from '../src/fleet/session-start.js';
+import { StdioBackend } from '../src/backend/stdio.js';
+import { WakeQueue } from '../src/records/durable.js';
+
+let tmp: string;
+let env: NodeJS.ProcessEnv;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'fm-ss-test-'));
+  env = { ...process.env, FM_HOME: path.join(tmp, 'home'), FM_BACKEND: 'stdio' };
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe('SessionStartService', () => {
+  it('acquires the lock and reports an empty fleet', async () => {
+    const service = new SessionStartService(new StdioBackend(), env);
+    const result = await service.run();
+    expect(result.lockHeld).toBe(true);
+    expect(result.wakes).toBe(0);
+    expect(result.fleet).toEqual([]);
+  });
+
+  it('reports queued wakes', async () => {
+    const paths = { state: path.join(env.FM_HOME!, 'state') };
+    const queue = new WakeQueue(`${paths.state}/.wake-queue`);
+    await queue.push({ kind: 'signal', key: 't1' });
+
+    const service = new SessionStartService(new StdioBackend(), env);
+    const result = await service.run();
+    expect(result.wakes).toBe(1);
+  });
+
+  it('refuses the lock when another holder owns it', async () => {
+    const first = new SessionStartService(new StdioBackend(), env);
+    await first.run();
+    // Second session-start in the same home must be refused.
+    const second = new SessionStartService(new StdioBackend(), env);
+    const result = await second.run();
+    expect(result.lockHeld).toBe(false);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noEmitOnError": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+    testTimeout: 15000,
+    hookTimeout: 15000,
+  },
+});


### PR DESCRIPTION
## Summary
- Reimplements the bash fleet orchestration (fm-spawn, fm-send, fm-control, fm-teardown, fm-watch, ...) as a cross-platform TypeScript CLI so firstmate runs natively on Windows without WSL or Git Bash, while staying compatible with macOS/Linux.
- ConPTY-backed terminal backend on Windows via node-pty, with a stdio backend fallback (and tmux on POSIX).
- Full lifecycle: `fm setup/session-start/spawn/send/control/teardown/attach/capture/watch/crew-state/backlog/status`, with legacy `fm-*` names accepted as aliases.
- pnpm pinned via `packageManager`, and `node-pty`/`esbuild` native builds allowed via `pnpm.onlyBuiltDependencies` so a fresh `pnpm install` actually compiles the ConPTY binding instead of silently degrading to stdio.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `eslint src tests` — clean
- [x] `vitest run` — 36/36 tests passing (hermetic: fake harness + stdio backend)
- [x] `fm setup` verified against a real Windows toolchain (node, git, gh, claude, cursor detected correctly)
- [x] Real ConPTY backend smoke-tested directly (spawned an actual Windows pseudo-console via node-pty, captured real output, clean teardown) — not just the fake-harness test suite
- [x] Rebased cleanly onto latest `main`