### PR TITLE
fix: deduplicate supervision terminal no-op reports

### DIFF
--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -794,6 +794,13 @@ export default function (pi: ExtensionAPI) {
             isError: true,
           };
         }
+        if (!actingAsOwner(toolGeneration)) {
+          return {
+            content: [{ type: "text", text: "report refused: supervision session was replaced or lost lock ownership" }],
+            details: undefined,
+            isError: true,
+          };
+        }
         if (terminalReceipt && existsSync(terminalReceipt.path)) {
           const existingSeq = receiptSeq(terminalReceipt.path);
           if (!existingSeq) {
@@ -810,13 +817,6 @@ export default function (pi: ExtensionAPI) {
         }
         const appendArgs = ["append", "--task", task, "--verdict", verdict, "--summary", summary, "--silent", String(silent)];
         if (wake) appendArgs.push("--wake", wake);
-        if (!actingAsOwner(toolGeneration)) {
-          return {
-            content: [{ type: "text", text: "report refused: supervision session was replaced or lost lock ownership" }],
-            details: undefined,
-            isError: true,
-          };
-        }
         const appended = runOutcomeScript(appendArgs);
         if (!appended.ok) {
           return {

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -717,6 +717,21 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
+  function hasVisibleUnreadThrough(seq: string): boolean {
+    const unread = runOutcomeScript(["unread"]);
+    if (!unread.ok) return true;
+    for (const line of unread.stdout.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      try {
+        const row = JSON.parse(line) as { seq?: unknown; silent?: unknown };
+        if (typeof row.seq === "number" && row.seq <= Number(seq) && row.silent !== true) return true;
+      } catch {
+        return true;
+      }
+    }
+    return false;
+  }
+
   function mergeIntoMain(
     expectedGeneration: number,
     seq: string,
@@ -743,6 +758,7 @@ export default function (pi: ExtensionAPI) {
     }
     if (/^[0-9]+$/.test(seq)) {
       if (!actingAsOwner(expectedGeneration)) return false;
+      if (silent && hasVisibleUnreadThrough(seq)) return true;
       return runOutcomeScript(["mark-read", "--through", seq]).ok;
     }
     return true;
@@ -811,6 +827,12 @@ export default function (pi: ExtensionAPI) {
               content: [{ type: "text", text: "terminal-noop receipt marker is unreadable; refusing to guess whether to merge" }],
               details: undefined,
               isError: true,
+            };
+          }
+          if (hasVisibleUnreadThrough(existingSeq)) {
+            return {
+              content: [{ type: "text", text: `terminal-noop receipt already recorded seq ${existingSeq}; visible unread outcomes remain preserved for replay; no merge needed` }],
+              details: undefined,
             };
           }
           const marked = runOutcomeScript(["mark-read", "--through", existingSeq]);

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -1637,8 +1637,8 @@ ${context.command}
   });
 
   // Pi only calls this renderer for a message with display: true, which
-  // mergeIntoMain sets for every routine note except an explicitly silent
-  // fleet heartbeat; captain-facing notes are never printed or rendered here.
+  // mergeIntoMain sets for every visible routine note; store-only routine
+  // outcomes and captain-facing notes are never printed or rendered here.
   pi.registerMessageRenderer?.("fm-branch-merge", (message, _options, theme) => {
     const note = textOfContent(message.content);
     const hasGlyph = note.startsWith(MERGE_NOTE_BOAT);

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -813,6 +813,14 @@ export default function (pi: ExtensionAPI) {
               isError: true,
             };
           }
+          const marked = runOutcomeScript(["mark-read", "--through", existingSeq]);
+          if (!marked.ok) {
+            return {
+              content: [{ type: "text", text: `terminal-noop receipt already recorded seq ${existingSeq}, but could not be marked read: ${marked.detail}` }],
+              details: undefined,
+              isError: true,
+            };
+          }
           return {
             content: [{ type: "text", text: `terminal-noop receipt already recorded seq ${existingSeq}; no merge needed` }],
             details: undefined,

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -133,6 +133,9 @@ const branchCacheKey = `fm-branch-${createHash("sha256").update(fmHome).digest("
 
 const MIRROR_MESSAGE_CAP = 4000;
 const MERGE_NOTE_BOAT = "⛵";
+const TERMINAL_NOOP_RECEIPT = "terminal-noop";
+const routineReceiptDir = join(state, "branch-routine-receipts");
+type RoutineReceipt = "" | typeof TERMINAL_NOOP_RECEIPT;
 // Carried inside the captain note's own text because that text is the only
 // part of a custom message Pi gives the model (see mergeIntoMain).
 //
@@ -600,9 +603,10 @@ export default function (pi: ExtensionAPI) {
   // (queued as a follow-up while main is busy) - that follow-up turn is
   // itself the captain-visible outcome, so the captain-facing note is
   // delivered silently (display: false) rather than printed or rendered a
-  // second time; routine notes stay rendered except an explicitly silent
-  // no-change heartbeat. The read cursor advances once the note is handed to
-  // Pi; a crash inside Pi's
+  // second time. Ordinary routine notes stay rendered, while explicitly
+  // silent routine receipts are store-only and only advance the read cursor.
+  // The read cursor advances once the note is handed to Pi, or immediately
+  // for a store-only receipt; a crash inside Pi's
   // own delivery window leaves the outcome durable in the store, where
   // main's fm_branch_outcomes tool still reads it on demand.
   //
@@ -631,6 +635,85 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
+  function signalWakeIsSameTaskTerminal(task: string, wake: string): boolean {
+    const match = /^signal:\s+(.+)$/.exec(wake);
+    if (!match) return false;
+    const files = match[1].trim().split(/\s+/).filter(Boolean);
+    if (files.length === 0) return false;
+    let hasTurnEnded = false;
+    for (const file of files) {
+      const slash = Math.max(file.lastIndexOf("/"), file.lastIndexOf("\\"));
+      const base = slash >= 0 ? file.slice(slash + 1) : file;
+      let rowTask = "";
+      if (base.endsWith(".turn-ended")) {
+        rowTask = base.slice(0, -".turn-ended".length);
+        hasTurnEnded = true;
+      } else if (base.endsWith(".status")) {
+        rowTask = base.slice(0, -".status".length);
+      } else {
+        return false;
+      }
+      if (rowTask !== task) return false;
+    }
+    return hasTurnEnded;
+  }
+
+  function metaField(text: string, key: string): string {
+    const prefix = `${key}=`;
+    return text.split(/\r?\n/).find((line) => line.startsWith(prefix))?.slice(prefix.length).trim() ?? "";
+  }
+
+  function taskIncarnation(task: string): string {
+    try {
+      const text = readFileSync(join(state, `${task}.meta`), "utf8");
+      const spawnGen = metaField(text, "spawn_gen");
+      if (/^[A-Za-z0-9._-]+$/.test(spawnGen)) return `spawn:${spawnGen}`;
+      const tasktmp = metaField(text, "tasktmp");
+      const window = metaField(text, "window");
+      const worktree = metaField(text, "worktree");
+      const identity = tasktmp || `${window}|${worktree}`;
+      if (!identity || identity === "|") return "";
+      return `legacy:${createHash("sha256").update(identity).digest("hex")}`;
+    } catch {
+      return "";
+    }
+  }
+
+  function terminalNoopReceipt(task: string, wake: string): { fingerprint: string; path: string; incarnation: string } | null {
+    if (!signalWakeIsSameTaskTerminal(task, wake)) return null;
+    const incarnation = taskIncarnation(task);
+    if (!incarnation) return null;
+    const fingerprint = createHash("sha256")
+      .update(`fm-branch-terminal-noop-v1\0${task}\0${incarnation}`)
+      .digest("hex")
+      .slice(0, 32);
+    return { fingerprint, path: join(routineReceiptDir, `${fingerprint}.receipt`), incarnation };
+  }
+
+  function receiptSeq(path: string): string {
+    try {
+      const text = readFileSync(path, "utf8");
+      return /^seq=([0-9]+)$/m.exec(text)?.[1] ?? "";
+    } catch {
+      return "";
+    }
+  }
+
+  function recordTerminalNoopReceipt(receipt: { fingerprint: string; path: string; incarnation: string }, task: string, seq: string): boolean {
+    try {
+      mkdirSync(routineReceiptDir, { recursive: true });
+      writeFileSync(
+        receipt.path,
+        `schema=fm-branch-routine-receipt.v1\nreceipt=${TERMINAL_NOOP_RECEIPT}\nfingerprint=${receipt.fingerprint}\ntask=${task}\nincarnation=${receipt.incarnation}\nseq=${seq}\n`,
+        { flag: "wx", mode: 0o600 },
+      );
+      return true;
+    } catch (error) {
+      if ((error as { code?: string }).code === "EEXIST") return true;
+      return false;
+    }
+  }
+
   function mergeIntoMain(
     expectedGeneration: number,
     seq: string,
@@ -647,8 +730,8 @@ export default function (pi: ExtensionAPI) {
         display: false,
       };
       pi.sendMessage(message, { triggerTurn: true, deliverAs: "followUp" });
-    } else {
-      const message = { customType: "fm-branch-merge", content: `${MERGE_NOTE_BOAT} ${task}: ${summary}`, display: !(task === "fleet" && silent) };
+    } else if (!silent) {
+      const message = { customType: "fm-branch-merge", content: `${MERGE_NOTE_BOAT} ${task}: ${summary}`, display: true };
       if (mainStreaming) {
         pi.sendMessage(message, { deliverAs: "nextTurn" });
       } else {
@@ -667,7 +750,7 @@ export default function (pi: ExtensionAPI) {
       name: "fm_branch_report",
       label: "Report supervision outcome",
       description:
-        "Record the outcome of one handled fleet event: write it durably to the outcome store, then merge an append-only note into the captain-facing main conversation. verdict captain surfaces it to the captain in one turn; routine notes render unless silent marks a no-change heartbeat.",
+        "Record the outcome of one handled fleet event: write it durably to the outcome store, then merge an append-only note into the captain-facing main conversation unless the routine outcome is store-only. verdict captain surfaces it to the captain in one turn; ordinary routine notes render; guarded routine receipts stay store-only.",
       parameters: Type.Object({
         task: Type.String({ description: "The task id the event belongs to (or 'fleet' for fleet-wide events)" }),
         verdict: Type.Union([Type.Literal("routine"), Type.Literal("captain")], {
@@ -680,7 +763,10 @@ export default function (pi: ExtensionAPI) {
         }),
         wake: Type.Optional(Type.String({ description: "The wake reason line this outcome answers" })),
         silent: Type.Optional(Type.Boolean({
-          description: "True only when a fleet-wide heartbeat review found literally nothing worth reporting; omit or use false whenever any action was taken or any routine result is worth a note",
+          description: "True only for a store-only routine outcome: a fleet-wide no-change heartbeat, or a task-local terminal-noop receipt that has no new captain-visible consequence",
+        })),
+        receipt: Type.Optional(Type.Union([Type.Literal(TERMINAL_NOOP_RECEIPT)], {
+          description: "Use terminal-noop only for a task-local routine signal whose same-task turn-ended row has already been handled and only needs a durable no-action receipt",
         })),
       }),
       execute: async (_toolCallId, params) => {
@@ -688,8 +774,9 @@ export default function (pi: ExtensionAPI) {
         const verdictRaw = String((params as { verdict: unknown }).verdict || "");
         const summary = String((params as { summary: unknown }).summary || "").trim();
         const wake = String((params as { wake?: unknown }).wake ?? "").trim();
-        const silent = (params as { silent?: unknown }).silent === true;
-        if (!task || !summary || (verdictRaw !== "routine" && verdictRaw !== "captain") || (silent && (task !== "fleet" || verdictRaw !== "routine"))) {
+        const receipt = String((params as { receipt?: unknown }).receipt ?? "").trim() as RoutineReceipt;
+        const requestedSilent = (params as { silent?: unknown }).silent === true;
+        if (!task || !summary || (verdictRaw !== "routine" && verdictRaw !== "captain") || (receipt && receipt !== TERMINAL_NOOP_RECEIPT)) {
           return {
             content: [{ type: "text", text: "invalid report: task, verdict (routine|captain), and summary are required" }],
             details: undefined,
@@ -697,6 +784,30 @@ export default function (pi: ExtensionAPI) {
           };
         }
         const verdict = verdictRaw as Verdict;
+        const terminalReceipt = receipt === TERMINAL_NOOP_RECEIPT ? terminalNoopReceipt(task, wake) : null;
+        const receiptValid = receipt !== TERMINAL_NOOP_RECEIPT || (verdict === "routine" && task !== "fleet" && terminalReceipt !== null);
+        const silent = requestedSilent || receipt === TERMINAL_NOOP_RECEIPT;
+        if ((silent && verdict !== "routine") || (silent && task !== "fleet" && receipt !== TERMINAL_NOOP_RECEIPT) || !receiptValid) {
+          return {
+            content: [{ type: "text", text: "invalid report: silent task-local receipts require verdict routine, receipt terminal-noop, and a same-task turn-ended signal wake" }],
+            details: undefined,
+            isError: true,
+          };
+        }
+        if (terminalReceipt && existsSync(terminalReceipt.path)) {
+          const existingSeq = receiptSeq(terminalReceipt.path);
+          if (!existingSeq) {
+            return {
+              content: [{ type: "text", text: "terminal-noop receipt marker is unreadable; refusing to guess whether to merge" }],
+              details: undefined,
+              isError: true,
+            };
+          }
+          return {
+            content: [{ type: "text", text: `terminal-noop receipt already recorded seq ${existingSeq}; no merge needed` }],
+            details: undefined,
+          };
+        }
         const appendArgs = ["append", "--task", task, "--verdict", verdict, "--summary", summary, "--silent", String(silent)];
         if (wake) appendArgs.push("--wake", wake);
         if (!actingAsOwner(toolGeneration)) {
@@ -714,6 +825,13 @@ export default function (pi: ExtensionAPI) {
             isError: true,
           };
         }
+        if (terminalReceipt && !recordTerminalNoopReceipt(terminalReceipt, task, appended.stdout)) {
+          return {
+            content: [{ type: "text", text: `recorded seq ${appended.stdout}, but terminal-noop receipt could not be saved safely` }],
+            details: undefined,
+            isError: true,
+          };
+        }
         if (!mergeIntoMain(toolGeneration, appended.stdout, task, verdict, summary, silent)) {
           return {
             content: [{ type: "text", text: `recorded seq ${appended.stdout}, but merge refused after supervision replacement or lock loss` }],
@@ -722,7 +840,7 @@ export default function (pi: ExtensionAPI) {
           };
         }
         return {
-          content: [{ type: "text", text: `recorded seq ${appended.stdout} and merged [${verdict}] into main` }],
+          content: [{ type: "text", text: silent ? `recorded seq ${appended.stdout} as store-only [${verdict}]` : `recorded seq ${appended.stdout} and merged [${verdict}] into main` }],
           details: undefined,
         };
       },

--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -121,6 +121,9 @@ const wakeGrantScript = join(fmRoot, "bin", "fm-wake-grant.sh");
 const loadedMarker = join(state, ".pi-branch-extension-loaded");
 const modelPinFile = join(config, "supervision-branch-model");
 const effortPinFile = join(config, "supervision-branch-effort");
+const processEnvWithoutActor = { ...process.env };
+delete processEnvWithoutActor.FM_SUPERVISION_ACTOR;
+delete processEnvWithoutActor.FM_LEASE_HOLDER_PID;
 
 // Same tool set in the same order on every request (part of the cached
 // prefix). "bash" resolves to the customTools override below, which injects
@@ -156,7 +159,7 @@ type Verdict = "routine" | "captain";
 type LockOwnership = "owned" | "other" | "missing";
 
 const scriptEnv = {
-  ...process.env,
+  ...processEnvWithoutActor,
   FM_HOME: fmHome,
   FM_ROOT_OVERRIDE: fmRoot,
   FM_STATE_OVERRIDE: state,

--- a/bin/fm-branch-outcome.sh
+++ b/bin/fm-branch-outcome.sh
@@ -10,8 +10,10 @@
 #     Existing lines are never rewritten, reordered, or deleted by any
 #     subcommand; the read state lives
 #     entirely in the cursor sidecar so marking outcomes read cannot disturb
-#     the log. Retention: the log is small (one line per handled fleet event)
-#     and truncation, if ever needed, is a captain-approved manual act.
+#     the log. `silent:true` means store-only: session-start replay skips the
+#     row after recording the read cursor. Retention: the log is small (one
+#     line per handled fleet event) and truncation, if ever needed, is a
+#     captain-approved manual act.
 #   - Cursor: $STATE/.branch-outcomes-cursor holds the highest seq handed to
 #     Pi as an append-only merge note, emitted by the locked session-start
 #     replay, or silently consumed there because `silent` is true. Records

--- a/bin/fm-branch-prompt.sh
+++ b/bin/fm-branch-prompt.sh
@@ -48,14 +48,20 @@ Handle it start to finish in one turn sequence:
    Claim the reserved `backlog` lease around backlog writes (`bin/fm-lease.sh claim backlog`, then `tasks-axi ...`, then release).
    A refused claim means MAIN is acting on that task right now: do not work around it; report the event with what you observed and let the next wake retry.
 3. Handle with real tools: `bin/fm-crew-state.sh <task>` for current state (a status line is a wake event, not current-state truth), `bin/fm-send.sh` for a short steer, `bin/fm-control.sh <task> interrupt|exit|relaunch` for lifecycle, `bin/fm-pr-check.sh <task> <url>` when a PR is reported, `tasks-axi` for backlog moves.
-4. Report: call the fm_branch_report tool exactly once per handled event, with the task id, the verdict, and a one-or-two-sentence summary; set silent true only for a fleet-wide heartbeat review that found literally nothing worth reporting.
-   The report is what durably records your outcome and merges it into MAIN; an event without a report is an event MAIN never learns about, so never skip it, including for events where you took no action.
+4. Report: call the fm_branch_report tool exactly once per handled event, with the task id, the verdict, and a one-or-two-sentence summary.
+   A signal batch containing same-task `.status` and `.turn-ended` rows is one handled event: report once with the highest-consequence outcome, not once per row.
+   Set silent true only for a store-only routine outcome: a fleet-wide heartbeat review that found literally nothing worth reporting, or a task-local terminal no-op using `receipt: "terminal-noop"`.
+   Use `receipt: "terminal-noop"` only when a same-task `.turn-ended` signal has no new captain-visible consequence after you handled it, such as an already stopped/completed worker needing only a durable receipt.
+   Never use that receipt for substantive outcomes, failures, decisions, credentials, destructive/security-sensitive choices, cleanup refusals, or any result that directly answers an explicit captain request.
+   The report is what durably records your outcome and merges it into MAIN when visible; an event without a report is an event MAIN never learns about, so never skip it, including for events where you took no action.
 5. Acknowledge: after the report succeeds, run the exact `--ack-through` command the drain printed as WAKE_ACK_REQUIRED.
 6. Release every lease you claimed: `bin/fm-lease.sh release <task>`.
-A crash after the report but before acknowledgement re-presents the wake, and re-handling may append a second outcome note; that benign over-reporting is deliberately accepted because replay is preferred over loss, and no idempotency machinery exists for it by design.
+A crash after the report but before acknowledgement re-presents the wake, and re-handling may append a second visible outcome note for non-receipt outcomes; that benign over-reporting is deliberately accepted because replay is preferred over loss.
+Task-local terminal-noop receipts are deduplicated per task incarnation, so an equivalent cleanup/no-action replay records once and then stays store-only without another note.
 
 A heartbeat wake asks you to review the whole fleet the way MAIN would on an ordinary heartbeat: reconcile suspicious tasks and PR state from the fleet view, update the backlog, and report verdict routine with a one-line summary when nothing changed.
 Set silent true only when that review changed nothing, took no action, and found nothing worth a routine note; omit it or set it false after any successful automatic recovery, backlog reconciliation, or other real routine action.
+For a completed scout or investigation, verify the report is preserved, run the captain-call completion owner, close the backlog item only when appropriate, and then run guarded cleanup through `bin/fm-teardown.sh`; if cleanup refuses, report one captain-facing blocker rather than looping on routine terminal notifications.
 Never report verdict captain merely to say the fleet is quiet; a no-op heartbeat pass stays silent.
 
 For a stale, looping, confused, or unresponsive worker, follow the recovery playbook included at the end of this prompt.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,7 +46,7 @@ Homes on any other primary harness never load this feature and are entirely unaf
 A captain-facing (verdict `captain`) branch outcome opens exactly one follow-up turn on main, and Pi never separately prints or renders the merge note itself.
 The branch prompt owns the unconditional explicit-request rule and the distinction between captain-facing, unsolicited routine, and unchanged-review outcomes.
 The generated [Pi supervision protocol](supervision-protocols/pi.md) owns main's required captain-visible response, event ownership, and conversational treatment for merged outcomes.
-A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is delivered silently with no rendered note, while every other routine outcome still appends a rendered, sailboat-prefixed note.
+Store-only routine outcomes - no-change fleet heartbeats and validated task-local terminal-noop receipts - do not render a note; [docs/pi-supervision-branch.md](pi-supervision-branch.md#two-stage-noise-filter) owns the detailed merge contract.
 
 ## Pi supervision branch model and effort (config/supervision-branch-model, config/supervision-branch-effort)
 

--- a/docs/pi-supervision-branch-poster.svg
+++ b/docs/pi-supervision-branch-poster.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 860" width="1200" height="860" role="img" aria-labelledby="poster-title poster-desc">
   <title id="poster-title">Multi-brain agent architecture</title>
-  <desc id="poster-desc">One agent. Two branches of attention. Events are commits. A git-graph poster of one fix: silent notes merge with zero turns; only the merge that matters wakes the main brain.</desc>
+  <desc id="poster-desc">One agent. Two branches of attention. Events are commits. A git-graph poster of one fix: routine notes land with zero turns; only the merge that matters wakes the main brain.</desc>
   <defs>
     <pattern id="poster-grid" width="36" height="36" patternUnits="userSpaceOnUse">
       <path d="M 36 0 L 0 0 0 36" fill="none" stroke="#8CAAE6" stroke-opacity="0.06" stroke-width="1"/>
@@ -16,7 +16,7 @@
     <text x="1152" y="56" text-anchor="end" fill="#8CA3C7" fill-opacity="0.7" font-size="14">fig. 1 - firstmate</text>
   </g>
   <g transform="translate(0 100)" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
-<title id="mb-title">Multi-brain agent architecture drawn as a git graph: one fix's lifecycle. The worker finishes and CI runs (silent note), the captain's merge-when-green instruction is cherry-picked down, a flaky test is rerun (silent note), and when CI goes green the supervision brain merges and one note wakes the main brain.</title>
+<title id="mb-title">Multi-brain agent architecture drawn as a git graph: one fix's lifecycle. The worker finishes and CI runs (routine note), the captain's merge-when-green instruction is cherry-picked down, a flaky test is rerun (routine note), and when CI goes green the supervision brain merges and one note wakes the main brain.</title>
         <defs>
           <marker id="ah-cyan" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto-start-reverse">
             <path d="M 0 0 L 10 5 L 0 10 z" fill="#56C8FF"></path>
@@ -53,7 +53,7 @@
 
         <!-- ================= EXAMPLE CHIPS ON THE ARCS ================= -->
         <g id="chip-quiet-1">
-          <title>A silent note: nothing needs the captain yet</title>
+          <title>A routine note: nothing needs the captain yet</title>
           <rect x="385" y="312" width="230" height="36" rx="6" fill="#0D1321" stroke="#56C8FF" stroke-width="1.5" opacity="0.95"></rect>
           <text x="500" y="336" text-anchor="middle" fill="#B9E5FF" font-size="16">&#8220;PR opened, CI running&#8221;</text>
         </g>
@@ -63,7 +63,7 @@
           <text x="660" y="401" text-anchor="middle" fill="#FFD9A0" font-size="16">you: &#8220;merge when CI green&#8221;</text>
         </g>
         <g id="chip-quiet-2">
-          <title>A silent note: the supervision brain already fixed it</title>
+          <title>A routine note: the supervision brain already fixed it</title>
           <rect x="665" y="272" width="270" height="36" rx="6" fill="#0D1321" stroke="#56C8FF" stroke-width="1.5" opacity="0.95"></rect>
           <text x="800" y="296" text-anchor="middle" fill="#B9E5FF" font-size="16">&#8220;flaky test: reran, passed&#8221;</text>
         </g>
@@ -80,14 +80,14 @@
           <circle cx="620" cy="210" r="11" fill="#0D1321" stroke="#FFB454" stroke-width="3.5"></circle>
           <circle cx="1120" cy="210" r="11" fill="#0D1321" stroke="#FFB454" stroke-width="3.5"></circle>
         </g>
-        <!-- silent-note landings -->
-        <g id="silent-landings">
-          <title>Notes merged silently into the conversation: no one is woken</title>
+        <!-- routine-note landings -->
+        <g id="routine-landings">
+          <title>Routine notes merged into the conversation: no turn is opened</title>
           <circle cx="545" cy="210" r="7" fill="#0D1321" stroke="#56C8FF" stroke-width="3" opacity="0.85"></circle>
           <circle cx="830" cy="210" r="7" fill="#0D1321" stroke="#56C8FF" stroke-width="3" opacity="0.85"></circle>
         </g>
-        <text x="545" y="174" text-anchor="middle" fill="#56C8FF" opacity="0.8" font-size="13.5">silent merge. zero turns</text>
-        <text x="830" y="174" text-anchor="middle" fill="#56C8FF" opacity="0.8" font-size="13.5">silent merge. zero turns</text>
+        <text x="545" y="174" text-anchor="middle" fill="#56C8FF" opacity="0.8" font-size="13.5">routine note. zero turns</text>
+        <text x="830" y="174" text-anchor="middle" fill="#56C8FF" opacity="0.8" font-size="13.5">routine note. zero turns</text>
         <!-- the merge commit that wakes the main brain -->
         <g id="merge-commit">
           <title>Merged and surfaced: the main brain is woken exactly once</title>
@@ -120,6 +120,6 @@
         <text x="1128" y="665" fill="#8CA3C7" font-size="15">time</text>
 
         <!-- ================= MORAL ================= -->
-        <text x="560" y="700" text-anchor="middle" fill="#E6EDF3" opacity="0.6" font-size="18">Routine merges back silently. Only what needs you wakes the main brain.</text>
+        <text x="560" y="700" text-anchor="middle" fill="#E6EDF3" opacity="0.6" font-size="18">Routine notes land without a turn. Only what needs you wakes the main brain.</text>
   </g>
 </svg>

--- a/docs/pi-supervision-branch-poster.svg
+++ b/docs/pi-supervision-branch-poster.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 860" width="1200" height="860" role="img" aria-labelledby="poster-title poster-desc">
   <title id="poster-title">Multi-brain agent architecture</title>
-  <desc id="poster-desc">One agent. Two branches of attention. Events are commits. A git-graph poster of one fix: routine notes land with zero turns; only the merge that matters wakes the main brain.</desc>
+  <desc id="poster-desc">One agent. Two branches of attention. Events are commits. A git-graph poster of one fix: silent notes merge with zero turns; only the merge that matters wakes the main brain.</desc>
   <defs>
     <pattern id="poster-grid" width="36" height="36" patternUnits="userSpaceOnUse">
       <path d="M 36 0 L 0 0 0 36" fill="none" stroke="#8CAAE6" stroke-opacity="0.06" stroke-width="1"/>
@@ -16,7 +16,7 @@
     <text x="1152" y="56" text-anchor="end" fill="#8CA3C7" fill-opacity="0.7" font-size="14">fig. 1 - firstmate</text>
   </g>
   <g transform="translate(0 100)" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
-<title id="mb-title">Multi-brain agent architecture drawn as a git graph: one fix's lifecycle. The worker finishes and CI runs (routine note), the captain's merge-when-green instruction is cherry-picked down, a flaky test is rerun (routine note), and when CI goes green the supervision brain merges and one note wakes the main brain.</title>
+<title id="mb-title">Multi-brain agent architecture drawn as a git graph: one fix's lifecycle. The worker finishes and CI runs (silent note), the captain's merge-when-green instruction is cherry-picked down, a flaky test is rerun (silent note), and when CI goes green the supervision brain merges and one note wakes the main brain.</title>
         <defs>
           <marker id="ah-cyan" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto-start-reverse">
             <path d="M 0 0 L 10 5 L 0 10 z" fill="#56C8FF"></path>
@@ -53,7 +53,7 @@
 
         <!-- ================= EXAMPLE CHIPS ON THE ARCS ================= -->
         <g id="chip-quiet-1">
-          <title>A routine note: nothing needs the captain yet</title>
+          <title>A silent note: nothing needs the captain yet</title>
           <rect x="385" y="312" width="230" height="36" rx="6" fill="#0D1321" stroke="#56C8FF" stroke-width="1.5" opacity="0.95"></rect>
           <text x="500" y="336" text-anchor="middle" fill="#B9E5FF" font-size="16">&#8220;PR opened, CI running&#8221;</text>
         </g>
@@ -63,7 +63,7 @@
           <text x="660" y="401" text-anchor="middle" fill="#FFD9A0" font-size="16">you: &#8220;merge when CI green&#8221;</text>
         </g>
         <g id="chip-quiet-2">
-          <title>A routine note: the supervision brain already fixed it</title>
+          <title>A silent note: the supervision brain already fixed it</title>
           <rect x="665" y="272" width="270" height="36" rx="6" fill="#0D1321" stroke="#56C8FF" stroke-width="1.5" opacity="0.95"></rect>
           <text x="800" y="296" text-anchor="middle" fill="#B9E5FF" font-size="16">&#8220;flaky test: reran, passed&#8221;</text>
         </g>
@@ -80,14 +80,14 @@
           <circle cx="620" cy="210" r="11" fill="#0D1321" stroke="#FFB454" stroke-width="3.5"></circle>
           <circle cx="1120" cy="210" r="11" fill="#0D1321" stroke="#FFB454" stroke-width="3.5"></circle>
         </g>
-        <!-- routine-note landings -->
-        <g id="routine-landings">
-          <title>Routine notes merged into the conversation: no turn is opened</title>
+        <!-- silent-note landings -->
+        <g id="silent-landings">
+          <title>Notes merged silently into the conversation: no one is woken</title>
           <circle cx="545" cy="210" r="7" fill="#0D1321" stroke="#56C8FF" stroke-width="3" opacity="0.85"></circle>
           <circle cx="830" cy="210" r="7" fill="#0D1321" stroke="#56C8FF" stroke-width="3" opacity="0.85"></circle>
         </g>
-        <text x="545" y="174" text-anchor="middle" fill="#56C8FF" opacity="0.8" font-size="13.5">routine note. zero turns</text>
-        <text x="830" y="174" text-anchor="middle" fill="#56C8FF" opacity="0.8" font-size="13.5">routine note. zero turns</text>
+        <text x="545" y="174" text-anchor="middle" fill="#56C8FF" opacity="0.8" font-size="13.5">silent merge. zero turns</text>
+        <text x="830" y="174" text-anchor="middle" fill="#56C8FF" opacity="0.8" font-size="13.5">silent merge. zero turns</text>
         <!-- the merge commit that wakes the main brain -->
         <g id="merge-commit">
           <title>Merged and surfaced: the main brain is woken exactly once</title>
@@ -120,6 +120,6 @@
         <text x="1128" y="665" fill="#8CA3C7" font-size="15">time</text>
 
         <!-- ================= MORAL ================= -->
-        <text x="560" y="700" text-anchor="middle" fill="#E6EDF3" opacity="0.6" font-size="18">Routine notes land without a turn. Only what needs you wakes the main brain.</text>
+        <text x="560" y="700" text-anchor="middle" fill="#E6EDF3" opacity="0.6" font-size="18">Routine merges back silently. Only what needs you wakes the main brain.</text>
   </g>
 </svg>

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -6,7 +6,7 @@ The poster is the visual of the idea.
 This document stays the owner and the contract.
 
 Fleet supervision on the Pi primary harness runs on a second, persistent conversation - the supervision branch - inside the same `pi` process as the captain's chat.
-Supervision is default-on: once a Pi primary session owns this home's fleet lock, the branch handles eligible task-local rows from ordinary actionable wakes plus heartbeat scans that the cheap bash-level scan flags as possibly captain-relevant, then merges each outcome back by appending a short note to the captain conversation's tail.
+Supervision is default-on: once a Pi primary session owns this home's fleet lock, the branch handles eligible task-local rows from ordinary actionable wakes plus heartbeat scans that the cheap bash-level scan flags as possibly captain-relevant, then merges each visible outcome back by appending a short note to the captain conversation's tail.
 Ordinary main-only rows remain on main even when eligible task-local rows share their queue.
 An unresolvable row makes the scan unsafe and returns the whole wake to main, and every watcher-failure alarm also stays on main.
 Only captain-relevant branch outcomes open a turn on main; the generated [Pi supervision protocol](supervision-protocols/pi.md) requires MAIN to produce the captain-visible response in that turn, while Pi never separately prints or renders a captain-facing merge note.
@@ -31,6 +31,7 @@ This feature is Pi-only by construction and changes nothing anywhere else:
 - Branch system prompt: `bin/fm-branch-prompt.sh`; its header owns the byte-stable-prefix contract (no timestamps, no fleet snapshot, no per-wake content).
 - Outcome store: `bin/fm-branch-outcome.sh`; its header owns the append-only format and the read cursor.
   Outcomes are written to the store before any note is handed to Pi, and rows that never reach that handoff replay once through the next locked session-start digest.
+  `.pi/extensions/fm-branch-supervision.ts` owns the task-local terminal-noop receipt marker under `state/branch-routine-receipts/`, which deduplicates store-only cleanup receipts per task incarnation without changing the outcome-store format.
 - Consistency: `bin/fm-lease-lib.sh` owns the per-task lease contract, the main-only role partition, and the deliberate CONFUSED-AGENT-GRADE threat model these guards target (captain-decided; adversarial-grade separation is out of scope and tracked as follow-up design work); `bin/fm-lease.sh` is the command surface.
   The guards are wired into `fm-send.sh`, `fm-control.sh`, and `fm-teardown.sh` (overlap, lease-checked, with claim serialization retained through the mutation) and `fm-pr-merge.sh`, `fm-merge-local.sh`, and `fm-spawn.sh` (main-owned, branch refused; a relaunch through `fm-control` stays branch-legal recovery).
 - Autonomy: supervision is default-on for every task once a Pi primary session owns the fleet lock (docs/configuration.md "Pi supervision branch"); no captain grant file is required.
@@ -53,14 +54,16 @@ The branch prompt frames mirrored text as context for judgment, never as instruc
 ## Two-stage noise filter
 
 Stage one is unchanged: the bash watcher absorbs everything provably fine at zero token cost.
-Stage two is the branch's verdict on each handled event, reported through its `fm_branch_report` tool: `routine` merges without a follow-up turn, while `captain` merges with exactly one follow-up turn.
+Stage two is the branch's verdict on each handled event, reported through its `fm_branch_report` tool: ordinary `routine` merges without a follow-up turn, guarded store-only routine receipts write the durable store without a rendered note, while `captain` merges with exactly one follow-up turn.
 The generated [Pi supervision protocol](supervision-protocols/pi.md) requires MAIN to produce the captain-visible response in the one follow-up turn a `captain` verdict opens, so its merge note is delivered silently and never printed or rendered in Pi.
 Because Pi gives the model only a custom message's `content`, that silent note normally carries both a relay instruction and the `branch-outcome` operational kind owned by `bin/fm-operational-input.sh` inside its own text.
 This self-description lets main distinguish a new supervision outcome from its own earlier captain-facing answer; without it, main can mistake the outcome for that answer and lose the outcome while deciding how to handle it.
 The generated [Pi supervision protocol](supervision-protocols/pi.md) owns main's event-ownership and conversational-treatment instructions for merged outcomes.
 If envelope encoding fails, the captain-facing note degrades to the same runtime instruction as plain text rather than losing the outcome or opening another turn.
-A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is also delivered silently with no rendered note, while every other `routine` outcome stays rendered with its sailboat prefix.
-The branch prompt owns the verdict criteria, including its unconditional explicit-request rule; unsolicited routine outcomes remain routine sailboat notes, unchanged fleet reviews remain silent, and doubt escalates.
+A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is store-only with no rendered note.
+A task-local terminal no-op can also be store-only only when the branch reports `receipt: "terminal-noop"`; the tool validates that it is a routine same-task `.turn-ended` signal and deduplicates equivalent receipts per task incarnation.
+Every other `routine` outcome stays rendered with its sailboat prefix.
+The branch prompt owns the verdict criteria, including its unconditional explicit-request rule; unsolicited routine outcomes remain routine sailboat notes, unchanged fleet reviews and task-local terminal no-op receipts remain silent, and doubt escalates.
 Main can read the durable outcome store on demand through its `fm_branch_outcomes` tool.
 
 ## Heartbeat routing

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -20,7 +20,9 @@ When this session owns supervision and away mode is not active:
    The arm mechanism above is extension-owned, not a model tool call, but a manual recovery probe that backgrounds, pipes, or bundles the arm is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`, wired into the turn-end guard extension at `__FM_PI_TURNEND_EXT__`).
 
 The supervision branch is default-on (docs/pi-supervision-branch.md): whenever this session owns the fleet lock and away mode is not active, the watcher extension hands eligible task-local rows from ordinary actionable wakes, plus selected fleet-wide heartbeat reviews, to the persistent in-process supervision branch while main-only rows remain queued for this conversation.
-A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is delivered silently with no rendered note, while every other routine outcome returns as an appended, rendered note that leads with ⛵ then the dim outcome text.
+A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is stored without a rendered note.
+A task-local terminal no-op reported with `receipt: "terminal-noop"` is also stored without a rendered note and deduplicated per task incarnation.
+Every other routine outcome returns as an appended, rendered note that leads with ⛵ then the dim outcome text.
 A captain-facing outcome instead opens exactly one follow-up turn on this conversation - MAIN must produce its captain-visible response in that turn, and no separate note is printed here.
 Before MAIN steers, controls lifecycle, or cleans up a task, claim its lease with `bin/fm-lease.sh claim <task>` and release it afterwards; a refused claim means the branch is acting on that task right now.
 This conversation still receives every other fleet-wide or unresolvable wake, the branch's wakes when it is unavailable or away mode is active, and every watcher-failure alarm regardless, so the arm and repair contract above is unchanged.

--- a/tests/fm-branch-supervision.test.sh
+++ b/tests/fm-branch-supervision.test.sh
@@ -12,6 +12,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-branch-supervision)
+unset FM_HOME FM_STATE_OVERRIDE FM_CONFIG_OVERRIDE FM_ROOT_OVERRIDE FM_SUPERVISION_ACTOR FM_LEASE_HOLDER_PID
 
 # --- byte-stable branch prompt ------------------------------------------------
 

--- a/tests/fm-branch-supervision.test.sh
+++ b/tests/fm-branch-supervision.test.sh
@@ -52,6 +52,10 @@ test_branch_prompt_is_byte_stable_and_above_cache_floor() {
     *"Report verdict captain for any outcome that directly answers an explicit captain request."*"This rule is unconditional"*"Keep an unsolicited routine outcome as verdict routine"*"Keep an unchanged fleet review silent"*) ;;
     *) fail "branch prompt lost the unconditional requested-outcome or routine-silence rules" ;;
   esac
+  case "$out_a" in
+    *"A signal batch containing same-task \`.status\` and \`.turn-ended\` rows is one handled event"*"receipt: \"terminal-noop\""*"deduplicated per task incarnation"*) ;;
+    *) fail "branch prompt lost task-local terminal receipt or same-task signal coalescing rules" ;;
+  esac
   pass "branch prompt is byte-stable across homes, cwd, timezone, and time, above the cache floor"
 }
 
@@ -126,16 +130,20 @@ test_outcome_startup_replay_preserves_silence() {
     --task fleet --verdict routine --summary 'fleet reviewed, nothing changed' --silent true >/dev/null \
     || fail "silent outcome append failed"
   FM_HOME="$home" "$ROOT/bin/fm-branch-outcome.sh" append \
+    --task task-terminal --verdict routine --summary 'terminal no-op stored only' --silent true >/dev/null \
+    || fail "task-local silent outcome append failed"
+  FM_HOME="$home" "$ROOT/bin/fm-branch-outcome.sh" append \
     --task task-1 --verdict routine --summary 'worker recovered automatically' >/dev/null \
     || fail "visible outcome append failed"
 
   replay=$(FM_HOME="$home" "$ROOT/bin/fm-branch-outcome.sh" startup-replay) || fail "mixed startup replay failed"
   assert_not_contains "$replay" "fleet reviewed, nothing changed" "startup replay printed a silent outcome"
+  assert_not_contains "$replay" "terminal no-op stored only" "startup replay printed a task-local silent outcome"
   assert_contains "$replay" "worker recovered automatically" "startup replay lost a visible routine outcome"
   [ -z "$(FM_HOME="$home" "$ROOT/bin/fm-branch-outcome.sh" unread)" ] \
     || fail "startup replay did not mark the silent and visible rows read"
 
-  printf '%s\n' '{"seq":3,"epoch":1,"task":"task-legacy","wake":"","verdict":"routine","summary":"legacy visible outcome"}' \
+  printf '%s\n' '{"seq":4,"epoch":1,"task":"task-legacy","wake":"","verdict":"routine","summary":"legacy visible outcome"}' \
     >> "$home/state/branch-outcomes.jsonl"
   replay=$(FM_HOME="$home" "$ROOT/bin/fm-branch-outcome.sh" startup-replay) || fail "legacy startup replay failed"
   assert_contains "$replay" "legacy visible outcome" "startup replay hid a legacy row with no silent field"

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -621,9 +621,11 @@ console.log(`CACHE_KEY=${rewriteA.prompt_cache_key}`);
 
 // 4. Two-stage filter, stage 2: routine while main is idle appends with no
 // turn; routine while main is busy defers to after the captain's next prompt;
-// captain-relevant appends and triggers exactly one turn. Store rows are
-// written BEFORE the merge note and marked read after it.
+// guarded terminal no-op receipts stay store-only and deduplicate per task
+// incarnation; captain-relevant appends and triggers exactly one turn. Store
+// rows are written BEFORE the visible merge note and marked read after it.
 const report = session.options.customTools.find((tool) => tool.name === "fm_branch_report");
+writeFileSync(`${home}/state/task-9.meta`, `project=${home}/projects/approved\nwindow=fm-task-9\nspawn_gen=spawn-nine\n`);
 const r1 = await report.execute("call-1", { task: "task-9", verdict: "routine", summary: "worker healthy, no action needed", wake: "signal: working" }, undefined, undefined, {});
 if (r1.isError) throw new Error(`routine report failed: ${JSON.stringify(r1)}`);
 if (sentToMain.length !== 1) throw new Error("routine report did not merge exactly one note");
@@ -640,6 +642,35 @@ await report.execute("call-3", { task: "task-9", verdict: "captain", summary: "P
 if (sentToMain[2].options.triggerTurn !== true || sentToMain[2].options.deliverAs !== "followUp") {
   throw new Error(`captain merge must trigger exactly one follow-up turn: ${JSON.stringify(sentToMain[2].options)}`);
 }
+const terminalWake = `signal: ${home}/state/task-9.status ${home}/state/task-9.turn-ended`;
+const r4 = await report.execute(
+  "call-4",
+  { task: "task-9", verdict: "routine", summary: "the completed worker is already stopped; no action is needed", wake: terminalWake, receipt: "terminal-noop" },
+  undefined,
+  undefined,
+  {},
+);
+if (r4.isError) throw new Error(`terminal-noop receipt failed: ${JSON.stringify(r4)}`);
+if (sentToMain.length !== 3) throw new Error("store-only terminal receipt rendered a merge note");
+const r5 = await report.execute(
+  "call-5",
+  { task: "task-9", verdict: "routine", summary: "the completed worker is still stopped; no action is needed", wake: terminalWake, receipt: "terminal-noop" },
+  undefined,
+  undefined,
+  {},
+);
+if (r5.isError || !String(r5.content[0].text).includes("already recorded")) {
+  throw new Error(`duplicate terminal-noop receipt did not deduplicate: ${JSON.stringify(r5)}`);
+}
+if (sentToMain.length !== 3) throw new Error("duplicate terminal receipt rendered a merge note");
+const invalidReceipt = await report.execute(
+  "call-bad-receipt",
+  { task: "task-9", verdict: "captain", summary: "captain-facing work must not be hidden", wake: terminalWake, receipt: "terminal-noop" },
+  undefined,
+  undefined,
+  {},
+);
+if (!invalidReceipt.isError) throw new Error("captain-facing terminal receipt was accepted as store-only");
 if (typeof sentToMain[0].message.content !== "string" || !sentToMain[0].message.content.startsWith("⛵ ")) {
   throw new Error(`routine note missing sailboat prefix: ${sentToMain[0].message.content}`);
 }
@@ -679,13 +710,15 @@ if (sentToMain.filter((sent) => sent.options.triggerTurn).length !== 1) {
   throw new Error("one captain outcome must open exactly one turn on main");
 }
 
-// The store (the owned durable contract) holds all three outcomes in order,
-// and each merged note advanced the read cursor.
+// The store (the owned durable contract) holds the visible outcomes plus the
+// first store-only terminal receipt. The duplicate terminal receipt is a
+// per-incarnation no-op and must not append a fifth row.
 const rows = readFileSync(`${home}/state/branch-outcomes.jsonl`, "utf8").trim().split("\n").map((line) => JSON.parse(line));
-if (rows.length !== 3) throw new Error(`expected 3 store rows, got ${rows.length}`);
-if (rows[0].verdict !== "routine" || rows[2].verdict !== "captain") throw new Error("store verdicts out of order");
+if (rows.length !== 4) throw new Error(`expected 4 store rows, got ${rows.length}`);
+if (rows[0].verdict !== "routine" || rows[2].verdict !== "captain" || rows[3].verdict !== "routine") throw new Error("store verdicts out of order");
 if (rows[0].wake !== "signal: working") throw new Error("store lost the wake reason");
-if (outcomeScript(["unread"]) !== "") throw new Error("merged outcomes were not marked read");
+if (rows[3].silent !== true || rows[3].wake !== terminalWake) throw new Error(`terminal receipt was not stored silently: ${JSON.stringify(rows[3])}`);
+if (outcomeScript(["unread"]) !== "") throw new Error("merged outcomes and store-only receipts were not marked read");
 
 // 5. Main-side surfaces: the on-demand store reader tool and the merge-note
 // renderer.
@@ -1169,6 +1202,7 @@ await settle(() => (globalThis.__fmPrompts ?? []).length === 2, "heartbeat wake 
 // escalate a captain-worthy finding into one main turn.
 const heartbeatSession = globalThis.__fmSessions[globalThis.__fmSessions.length - 1];
 const heartbeatReport = heartbeatSession.options.customTools.find((tool) => tool.name === "fm_branch_report");
+const beforeNoopMessages = sentToMain.length;
 await heartbeatReport.execute(
   "heartbeat-noop",
   { task: "fleet", verdict: "routine", summary: "fleet reviewed, nothing changed", silent: true },
@@ -1176,9 +1210,7 @@ await heartbeatReport.execute(
   undefined,
   {},
 );
-const noopMerge = sentToMain[sentToMain.length - 1];
-if (noopMerge.options.triggerTurn) throw new Error("a no-op heartbeat pass must not open a main turn");
-if (noopMerge.message.display !== false) throw new Error("a no-op heartbeat pass must not render a merge note");
+if (sentToMain.length !== beforeNoopMessages) throw new Error("a no-op heartbeat pass rendered or delivered a merge note");
 const storedNoop = readFileSync(`${home}/state/branch-outcomes.jsonl`, "utf8")
   .trim()
   .split("\n")

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -663,6 +663,18 @@ if (r5.isError || !String(r5.content[0].text).includes("already recorded")) {
   throw new Error(`duplicate terminal-noop receipt did not deduplicate: ${JSON.stringify(r5)}`);
 }
 if (sentToMain.length !== 3) throw new Error("duplicate terminal receipt rendered a merge note");
+writeFileSync(`${home}/state/.lock`, `1\n`);
+const r5LostOwner = await report.execute(
+  "call-5-lost-owner",
+  { task: "task-9", verdict: "routine", summary: "the completed worker is still stopped; no action is needed", wake: terminalWake, receipt: "terminal-noop" },
+  undefined,
+  undefined,
+  {},
+);
+if (!r5LostOwner.isError || !String(r5LostOwner.content[0].text).includes("lost lock ownership")) {
+  throw new Error(`duplicate terminal-noop receipt bypassed ownership: ${JSON.stringify(r5LostOwner)}`);
+}
+writeFileSync(`${home}/state/.lock`, `${process.ppid}\n`);
 const invalidReceipt = await report.execute(
   "call-bad-receipt",
   { task: "task-9", verdict: "captain", summary: "captain-facing work must not be hidden", wake: terminalWake, receipt: "terminal-noop" },

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -1448,7 +1448,7 @@ if (existsSync(`${home}/state/.branch-eligible-rows`)) {
 }
 const drain = spawnSync("bash", [`${realRoot}/bin/fm-wake-drain.sh`], {
   encoding: "utf8",
-  env: { ...process.env, FM_HOME: home, FM_STATE_OVERRIDE: `${home}/state`, FM_ROOT_OVERRIDE: realRoot },
+  env: { ...process.env, FM_HOME: home, FM_STATE_OVERRIDE: `${home}/state`, FM_ROOT_OVERRIDE: realRoot, FM_SUPERVISION_ACTOR: "main" },
 });
 if (drain.status !== 0) throw new Error(`main drain failed after grant release: ${drain.stderr}`);
 if (!drain.stdout.includes("\tsignal\tbranch-driver.status\t")) {

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -360,6 +360,8 @@ const { pathToFileURL } = await import("node:url");
 
 const home = process.env.FM_HOME;
 const realRoot = process.env.FM_ROOT_OVERRIDE;
+process.env.FM_STATE_OVERRIDE = `${home}/state`;
+process.env.FM_CONFIG_OVERRIDE = `${home}/config`;
 const approvedProject = `${home}/projects/approved`;
 mkdirSync(`${home}/state`, { recursive: true });
 mkdirSync(`${home}/config`, { recursive: true });

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -739,6 +739,38 @@ if (rows[0].wake !== "signal: working") throw new Error("store lost the wake rea
 if (rows[3].silent !== true || rows[3].wake !== terminalWake) throw new Error(`terminal receipt was not stored silently: ${JSON.stringify(rows[3])}`);
 if (outcomeScript(["unread"]) !== "") throw new Error("merged outcomes and store-only receipts were not marked read");
 
+// Crash replay safety: a later store-only terminal receipt must not advance
+// the cursor past an earlier visible outcome that has not reached main yet.
+const crashVisibleSeq = outcomeScript(["append", "--task", "task-visible", "--verdict", "captain", "--summary", "visible outcome preserved after crash"]);
+if (crashVisibleSeq !== "5") throw new Error(`unexpected crash-visible seq ${crashVisibleSeq}`);
+writeFileSync(`${home}/state/task-10.meta`, `project=${home}/projects/approved\nwindow=fm-task-10\nspawn_gen=spawn-ten\n`);
+const terminalWakeAfterCrash = `signal: ${home}/state/task-10.status ${home}/state/task-10.turn-ended`;
+const crashReceipt = await report.execute(
+  "call-crash-receipt",
+  { task: "task-10", verdict: "routine", summary: "completed worker needs no action", wake: terminalWakeAfterCrash, receipt: "terminal-noop" },
+  undefined,
+  undefined,
+  {},
+);
+if (crashReceipt.isError) throw new Error(`terminal receipt after visible crash failed: ${JSON.stringify(crashReceipt)}`);
+if (sentToMain.length !== 3) throw new Error("terminal receipt after visible crash rendered a merge note");
+let crashUnread = outcomeScript(["unread"]).trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+if (crashUnread.length !== 2 || crashUnread[0].seq !== 5 || crashUnread[0].silent === true || crashUnread[1].seq !== 6 || crashUnread[1].silent !== true) {
+  throw new Error(`store-only receipt advanced past visible unread outcome: ${JSON.stringify(crashUnread)}`);
+}
+const crashDuplicate = await report.execute(
+  "call-crash-duplicate",
+  { task: "task-10", verdict: "routine", summary: "completed worker still needs no action", wake: terminalWakeAfterCrash, receipt: "terminal-noop" },
+  undefined,
+  undefined,
+  {},
+);
+if (crashDuplicate.isError) throw new Error(`duplicate terminal receipt after visible crash failed: ${JSON.stringify(crashDuplicate)}`);
+crashUnread = outcomeScript(["unread"]).trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+if (crashUnread.length !== 2 || crashUnread[0].seq !== 5 || crashUnread[1].seq !== 6) {
+  throw new Error(`duplicate terminal receipt disturbed visible crash replay state: ${JSON.stringify(crashUnread)}`);
+}
+
 // 5. Main-side surfaces: the on-demand store reader tool and the merge-note
 // renderer.
 const outcomesTool = mainTools.find((tool) => tool.name === "fm_branch_outcomes");
@@ -801,9 +833,9 @@ try {
 if (!exportCallFellBack || !exportResultFellBack) {
   throw new Error("fm_branch_outcomes replaced Pi stock export rendering");
 }
-const listed = await outcomesTool.execute("call-4", { recent: 2 }, undefined, undefined, {});
+const listed = await outcomesTool.execute("call-4", { recent: 6 }, undefined, undefined, {});
 const listedText = listed.content[0].text;
-if (listedText.split("\n").length !== 2 || !listedText.includes("checks green")) {
+if (listedText.split("\n").length !== 6 || !listedText.includes("checks green") || !listedText.includes("visible outcome preserved after crash")) {
   throw new Error(`fm_branch_outcomes did not read the store: ${listedText}`);
 }
 if (!renderers.has("fm-branch-merge")) throw new Error("merge-note renderer missing");

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -654,6 +654,10 @@ const r4 = await report.execute(
 );
 if (r4.isError) throw new Error(`terminal-noop receipt failed: ${JSON.stringify(r4)}`);
 if (sentToMain.length !== 3) throw new Error("store-only terminal receipt rendered a merge note");
+// Reproduce a crash after store+receipt but before cursor advancement: the
+// repeated completion notification must coalesce to the existing receipt and
+// silently reconcile the cursor instead of leaving an unread no-op row behind.
+writeFileSync(`${home}/state/.branch-outcomes-cursor`, "3\n");
 const r5 = await report.execute(
   "call-5",
   { task: "task-9", verdict: "routine", summary: "the completed worker is still stopped; no action is needed", wake: terminalWake, receipt: "terminal-noop" },
@@ -665,6 +669,7 @@ if (r5.isError || !String(r5.content[0].text).includes("already recorded")) {
   throw new Error(`duplicate terminal-noop receipt did not deduplicate: ${JSON.stringify(r5)}`);
 }
 if (sentToMain.length !== 3) throw new Error("duplicate terminal receipt rendered a merge note");
+if (outcomeScript(["unread"]) !== "") throw new Error("duplicate terminal receipt did not reconcile the unread store-only row");
 writeFileSync(`${home}/state/.lock`, `1\n`);
 const r5LostOwner = await report.execute(
   "call-5-lost-owner",

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -6,6 +6,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-supervision-instructions)
+unset FM_HOME FM_STATE_OVERRIDE FM_CONFIG_OVERRIDE FM_ROOT_OVERRIDE FM_SUPERVISION_ACTOR FM_LEASE_HOLDER_PID
 RENDER="$ROOT/bin/fm-supervision-instructions.sh"
 
 test_selected_harness_block_only() {


### PR DESCRIPTION
## Intent

Investigate and fix the Pi supervision reporting defect where the supervision branch produced one substantive outcome for a completed scout followed by repeated visible routine terminal/cleanup notes. Implement the smallest coherent Firstmate fix through existing owners: task-local store-only routine terminal receipts, same-task signal coalescing, per-incarnation terminal-event deduplication, and explicit successful scout cleanup/reconciliation guidance. Preserve durable outcome store-first ordering, crash replay, and visible captain turns for substantive outcomes, failures, decisions, credentials, destructive/security-sensitive choices, and cleanup refusals. Do not use live fleet state as test data; add fake-home regression coverage for repeated completion notifications and healthy/no-action task notes; update authoritative docs only.

## What Changed

- Adds validated task-local `terminal-noop` receipts that store routine terminal outcomes without rendering merge notes and deduplicate them per task incarnation.
- Updates branch reporting behavior and prompts to keep same-task terminal/status signal batches to one handled event while preserving visible captain turns for substantive outcomes.
- Documents the store-only receipt contract and extends fake-home regression coverage for silent replay, repeated completion notifications, and healthy no-action notes.

## Risk Assessment

⚠️ Medium: The change is narrowly scoped and preserves the key store-first paths, but it touches supervision durability/deduplication behavior with some reliance on model-followed reporting conventions.

## Testing

Exercised the focused branch supervision store/prompt tests and Pi branch extension regression coverage in isolated fake-home environments, then captured a fake-home durable-store transcript showing a routine terminal receipt is stored silently while a substantive captain outcome replays visibly; all targeted checks passed.

<details>
<summary>Evidence: Targeted supervision test transcript</summary>

Source: [Targeted supervision test transcript](https://github.com/Yolo923-cmd/firstmate/blob/9f5a18a99f1823afecdbe041db4e747cae1a0647/.no-mistakes/evidence/fm/supervision-terminal-outcome-v1/targeted-supervision-tests.log)

```text
$ env -u FM_HOME -u FM_ROOT_OVERRIDE -u FM_STATE_OVERRIDE -u FM_CONFIG_OVERRIDE -u FM_LEASE_HOLDER_PID -u FM_SUPERVISION_ACTOR bash tests/fm-branch-supervision.test.sh
ok - branch prompt is byte-stable across homes, cwd, timezone, and time, above the cache floor
ok - outcome store is append-only and refuses sequence reuse after a torn tail
ok - startup replay skips silent outcomes and preserves visible and legacy rows
ok - lease exclusivity, same-actor refresh, release, staleness, and sweep hold
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'firstmate@firstmate-lab.(none)')
ok - fm-control and fm-teardown refuse the other actor's live lease and pass through otherwise
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'firstmate@firstmate-lab.(none)')
ok - PR merge, local landing, and new-task spawn refuse the branch actor and spare main
ok - a non-Pi home ignores stale Pi leases even when the recycled pid owns its lock
ok - lease liveness requires an exact valid session-lock pid
ok - concurrent stale-lease claims serialize so exactly one actor succeeds
ok - guard stale cleanup cannot race with or delete a newer lease claim
ok - lease guard excludes a concurrent actor for the complete mutation
ok - a claim naming the other actor fails loudly instead of silently impersonating it
ok - release commands authorize the caller and bulk release drops only that actor's leases
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'firstmate@firstmate-lab.(none)')
ok - the branch cannot force a teardown or bypass fm-control for a relaunch

$ env -u FM_HOME -u FM_ROOT_OVERRIDE -u FM_STATE_OVERRIDE -u FM_CONFIG_OVERRIDE -u FM_LEASE_HOLDER_PID -u FM_SUPERVISION_ACTOR bash tests/fm-pi-branch-extension.test.sh
skip: installed @earendil-works/pi-coding-agent package not found
skip: installed @earendil-works/pi-coding-agent package not found
ok - branch owns accepted wakes with a stable prefix contract and verdict-driven merge delivery
ok - a captain outcome reaches main's model as typed, self-describing input while routine notes stay plain
ok - requested and unsolicited healthy outcomes keep distinct delivery and event ownership
ok - a broken operational encoder still delivers one invisible instructed captain outcome as a follow-up
ok - scopeForUnreadWake excludes every main-only class without vetoing eligible task-local rows, and writes the eligible snapshot
ok - branch prompt_cache_key is stable per home across sessions and distinct between homes
ok - branch default-on eligibility (task-scoped, heartbeat, afk) binds and a broken branch falls back to main
ok - a heartbeat review survives a check row arriving before its drain
ok - pre-drain eligibility re-check excludes a newly main-owned row without deferring eligible work
ok - a settled branch turn releases an unacknowledged grant for main replay
ok - a stale main claim cannot silently suppress later wake delivery
ok - pre-drain eligibility re-check no-ops an already-drained wake
ok - dialog mirror filters tool and operational traffic, lands before wakes, and keeps a durable cursor
ok - branch session persists across process restarts through the recorded pointer
ok - the current pin state binds every branch create and reopen, and clearing it returns the branch to main's model
ok - unpinned branches follow main model changes live while pinned branches stay fixed
ok - supervision-model command persists the captain's pick and rebinds the live branch
ok - supervision-model opens a bounded searchable list, follow main first, and pins the branch alone
ok - branch model picker keeps follow main first and filters the eligible catalog
ok - the effort pin binds every branch create and reopen, and clearing it returns the branch to main's effort
ok - unpinned branches follow main effort changes live while pinned branches stay fixed
ok - supervision-model runs an effort picker after the model picker and persists both independently
ok - an unusable model pin falls back to main and an unparseable one is treated as no pin
ok - replacement activation cleans old branch leases and retries failed cleanup
ok - branch activates on a cold start once the lock is acquired, never before
ok - queued wakes and mirrors stop mutating branch state after lock ownership is lost
ok - stale reports, shells, mirrors, cursors, leases, and prompts perform no side effects
ok - a Pi session that does not own the lock accepts nothing and mutates no branch state
ok - an extension rebind re-mirrors undelivered dialog instead of dropping it
```
</details>
<details>
<summary>Evidence: Fake-home terminal receipt durable-store/replay transcript</summary>

Source: [Fake-home terminal receipt durable-store/replay transcript](https://github.com/Yolo923-cmd/firstmate/blob/9f5a18a99f1823afecdbe041db4e747cae1a0647/.no-mistakes/evidence/fm/supervision-terminal-outcome-v1/fake-home-terminal-receipt-demo.log)

```text
# Fake-home durable outcome/replay transcript
$ env -u FM_STATE_OVERRIDE -u FM_CONFIG_OVERRIDE FM_HOME=$DEMO/home bin/fm-branch-outcome.sh append --task task-9 --verdict routine --summary terminal-noop-stored-only --wake signal:task-9.status,task-9.turn-ended --silent true
1
$ env -u FM_STATE_OVERRIDE -u FM_CONFIG_OVERRIDE FM_HOME=$DEMO/home bin/fm-branch-outcome.sh append --task task-9 --verdict captain --summary substantive-outcome-visible --wake signal:task-9.status
2
$ cat $DEMO/home/state/branch-outcomes.jsonl
{"seq":1,"epoch":1788232474,"task":"task-9","wake":"signal:task-9.status,task-9.turn-ended","verdict":"routine","summary":"terminal-noop-stored-only","silent":true}
{"seq":2,"epoch":1788232474,"task":"task-9","wake":"signal:task-9.status","verdict":"captain","summary":"substantive-outcome-visible","silent":false}
$ env -u FM_STATE_OVERRIDE -u FM_CONFIG_OVERRIDE FM_HOME=$DEMO/home bin/fm-branch-outcome.sh startup-replay
BRANCH OUTCOMES (handled by the supervision branch, not yet seen by this session):
{"seq":2,"epoch":1788232474,"task":"task-9","wake":"signal:task-9.status","verdict":"captain","summary":"substantive-outcome-visible","silent":false}
$ env -u FM_STATE_OVERRIDE -u FM_CONFIG_OVERRIDE FM_HOME=$DEMO/home bin/fm-branch-outcome.sh unread
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (11m44s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a82eb98955679422a380ddaac42994536338e161","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `.pi/extensions/fm-branch-supervision.ts:797` - The duplicate terminal-noop fast path returns success before re-checking `actingAsOwner`, so a replaced or lock-losing branch can report success for a re-presented wake outside the existing ownership boundary. Move the ownership check before the receipt-exists return path so duplicate store-only receipts preserve the same side-effect/ack ownership invariant as normal reports.

🔧 Fix: Guard duplicate terminal receipts by ownership
✅ Re-checked - no issues remain.
</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.pi/extensions/fm-branch-supervision.ts:1134` - Targeted Pi extension regressions show eligible task-scoped supervision wakes are refused before branch handling: both the two-stage filter test and the default-on heartbeat/AFK routing test fail because dispatch(...).accepted remains false. This prevents the new terminal receipt/coalescing behavior from being exercised end-to-end and would fall back to main-visible wake handling instead of branch-owned supervision.
- <code>`bash tests/.tmp-targeted-pi-branch-extension.sh` running `test_branch_dispatch_two_stage_filter_and_prefix_contract` from `tests/fm-pi-branch-extension.test.sh`</code>
- <code>`bash tests/.tmp-targeted-pi-branch-extension.sh` running `test_branch_default_on_heartbeat_afk_and_fallback` from `tests/fm-pi-branch-extension.test.sh`</code>
- <code>`bash tests/.tmp-targeted-branch-supervision.sh` running `test_branch_prompt_is_byte_stable_and_above_cache_floor` and `test_outcome_startup_replay_preserves_silence` from `tests/fm-branch-supervision.test.sh`</code>
- <code>Manual CLI transcript exercising `bin/fm-branch-outcome.sh startup-replay` with silent routine rows and a legacy visible row</code>

🔧 Fix: Isolate branch extension test state
✅ Re-checked - no issues remain.
- <code>`bash tests/fm-branch-supervision.test.sh` (initial setup run exposed inherited FM_STATE_OVERRIDE/FM_HOME contamination)</code>
- `env -u FM_HOME -u FM_ROOT_OVERRIDE -u FM_STATE_OVERRIDE -u FM_CONFIG_OVERRIDE -u FM_LEASE_HOLDER_PID -u FM_SUPERVISION_ACTOR bash tests/fm-branch-supervision.test.sh`
- `env -u FM_HOME -u FM_ROOT_OVERRIDE -u FM_STATE_OVERRIDE -u FM_CONFIG_OVERRIDE -u FM_LEASE_HOLDER_PID -u FM_SUPERVISION_ACTOR bash tests/fm-pi-branch-extension.test.sh`
- <code>Fake-home CLI transcript using `bin/fm-branch-outcome.sh append --silent true`, visible captain append, `startup-replay`, and `unread`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
