### PR TITLE
fix(bin): refuse unrecognised fm-lock.sh arguments instead of acquiring the lock

### DIFF
--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -24,10 +24,7 @@ MODE=acquire
 if [ "$#" -gt 0 ]; then
   case "$1" in
     status) MODE=status ;;
-    -h | --help)
-      usage
-      exit 0
-      ;;
+    -h | --help) MODE=help ;;
     *)
       echo "error: unrecognized argument '$1'" >&2
       usage >&2
@@ -38,6 +35,10 @@ if [ "$#" -gt 0 ]; then
     echo "error: unexpected extra argument '$2'" >&2
     usage >&2
     exit 2
+  fi
+  if [ "$MODE" = help ]; then
+    usage
+    exit 0
   fi
 fi
 

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -5,7 +5,7 @@
 # PID of any one tool call, which is dead moments after it is written.
 # Usage: fm-lock.sh           acquire; exit 1 unless ownership is verified
 #        fm-lock.sh status    print holder and liveness; always exits 0
-#        fm-lock.sh --help    print usage; exit 0 without touching the lock
+#        fm-lock.sh -h|--help print usage; exit 0 without touching the lock
 # Any other argument is refused with exit 2 and the lock left untouched, so a
 # probe like `--help` can never claim the home's session lock as a side effect.
 set -u
@@ -14,7 +14,7 @@ usage() {
   cat <<'USAGE'
 Usage: fm-lock.sh           acquire the session lock; exit 1 unless ownership is verified
        fm-lock.sh status    print holder and liveness; always exits 0
-       fm-lock.sh --help    print this usage; exit 0 without touching the lock
+       fm-lock.sh -h|--help print this usage; exit 0 without touching the lock
 USAGE
 }
 

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -5,7 +5,41 @@
 # PID of any one tool call, which is dead moments after it is written.
 # Usage: fm-lock.sh           acquire; exit 1 unless ownership is verified
 #        fm-lock.sh status    print holder and liveness; always exits 0
+#        fm-lock.sh --help    print usage; exit 0 without touching the lock
+# Any other argument is refused with exit 2 and the lock left untouched, so a
+# probe like `--help` can never claim the home's session lock as a side effect.
 set -u
+
+usage() {
+  cat <<'USAGE'
+Usage: fm-lock.sh           acquire the session lock; exit 1 unless ownership is verified
+       fm-lock.sh status    print holder and liveness; always exits 0
+       fm-lock.sh --help    print this usage; exit 0 without touching the lock
+USAGE
+}
+
+# Parse before any state is touched: an unrecognized argument must leave the
+# lock, and the state directory, exactly as it found them.
+MODE=acquire
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+    status) MODE=status ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unrecognized argument '$1'" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  if [ "$#" -gt 1 ]; then
+    echo "error: unexpected extra argument '$2'" >&2
+    usage >&2
+    exit 2
+  fi
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
@@ -23,7 +57,7 @@ mkdir -p "$STATE" 2>/dev/null || {
 # shellcheck source=bin/fm-session-lock-lib.sh
 . "$SCRIPT_DIR/fm-session-lock-lib.sh"
 
-if [ "${1:-}" = "status" ]; then
+if [ "$MODE" = status ]; then
   if [ ! -f "$LOCK" ]; then echo "lock: free"; exit 0; fi
   old=$(cat "$LOCK" 2>/dev/null) || {
     echo "lock: unreadable"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -248,6 +248,7 @@ family_for_basename() {
       ;;
     fm-backlog-atomicity.test.sh|\
     fm-bootstrap.test.sh|fm-bootstrap-network-parallel.test.sh|fm-fleet-sync.test.sh|fm-gate-refuse.test.sh|fm-gotmp.test.sh|\
+    fm-lock.test.sh|\
     fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-startup-network.test.sh|\
     fm-tangle-guard.test.sh|fm-update.test.sh)
       printf '%s\n' session-bootstrap

--- a/tests/fm-lock.test.sh
+++ b/tests/fm-lock.test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# tests/fm-lock.test.sh - argument handling of the session-lock entry point
+# (bin/fm-lock.sh).
+#
+# The hazard this pins is that fm-lock.sh ACQUIRES the home's session lock when
+# it is run with no argument, and the session lock is what decides which session
+# may mutate the fleet at all. So every argument the script does not recognize -
+# `--help` most of all, since that is what a person types to find out what the
+# script does - must be refused without the lock being taken. The cases below
+# drive the real script end to end and judge it by what is on disk afterwards:
+# whether state/.lock exists and what it holds, never by reading the script's
+# own source.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-lock)
+
+# A home whose ancestry resolves to a harness, so the bare acquire path can
+# actually succeed and is not passing merely because identity failed first. The
+# fake ps reports this suite's own process as a claude session and every other
+# pid as its parent, exactly as the neighbouring session-lock suites do.
+make_home() { # <name> -> echoes the home dir
+  local name=$1 dir fakebin
+  dir="$TMP_ROOT/$name"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  *:comm=) printf '%s\n' claude ;;
+  *:args=) printf '%s\n' claude ;;
+  *:ppid=) printf '%s\n' 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  printf '%s\n' "$dir"
+}
+
+run_lock() { # <home> [args...]
+  local home=$1
+  shift
+  FM_HOME="$home" PATH="$home/fakebin:$PATH" bash "$ROOT/bin/fm-lock.sh" "$@"
+}
+
+test_unrecognized_argument_refuses_and_leaves_the_lock_unclaimed() {
+  local home out rc arg
+  home=$(make_home unrecognized)
+  for arg in --help-me -x status-please --lock; do
+    out=$(run_lock "$home" "$arg" 2>&1)
+    rc=$?
+    [ "$rc" -ne 0 ] || fail "'$arg' was accepted (exit 0) instead of refused"
+    assert_contains "$out" "unrecognized argument" "'$arg' was refused without saying which argument was wrong"
+    assert_contains "$out" "fm-lock.sh status" "'$arg' was refused without printing the usage that names the real forms"
+    assert_absent "$home/state/.lock" "'$arg' claimed the home's session lock while being refused"
+  done
+  # The same must hold for an extra argument trailing a form that IS recognized.
+  out=$(run_lock "$home" status extra 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "a trailing extra argument after 'status' was accepted instead of refused"
+  assert_contains "$out" "unexpected extra argument" "the trailing argument was refused without naming it"
+  assert_absent "$home/state/.lock" "a trailing extra argument claimed the home's session lock"
+  pass "fm-lock: an unrecognized argument is refused nonzero and leaves the session lock unclaimed"
+}
+
+test_help_prints_usage_without_touching_the_lock() {
+  local home out flag
+  home=$(make_home help)
+  for flag in --help -h; do
+    out=$(run_lock "$home" "$flag" 2>&1)
+    expect_code 0 "$?" "'$flag' must be answered with usage, not an error"
+    assert_contains "$out" "fm-lock.sh status" "'$flag' did not print the documented status form"
+    assert_contains "$out" "acquire the session lock" "'$flag' did not print the documented acquire form"
+    assert_absent "$home/state/.lock" "'$flag' claimed the home's session lock"
+  done
+  pass "fm-lock: --help and -h print usage on exit 0 and never claim the lock"
+}
+
+test_status_still_reports_the_holder() {
+  local home out
+  home=$(make_home status)
+  out=$(run_lock "$home" status)
+  expect_code 0 "$?" "status on a free home must still exit 0"
+  assert_contains "$out" "lock: free" "status did not report an unheld lock as free"
+  assert_absent "$home/state/.lock" "status created the lock it was only asked to inspect"
+
+  printf '%s\n' "$$" > "$home/state/.lock"
+  out=$(run_lock "$home" status)
+  expect_code 0 "$?" "status on a held home must still exit 0"
+  assert_contains "$out" "held by live harness pid $$" "status did not report the live holder it found"
+  pass "fm-lock: status still prints the holder and exits 0"
+}
+
+test_bare_invocation_still_acquires() {
+  local home out claimed written
+  home=$(make_home acquire)
+  out=$(run_lock "$home")
+  expect_code 0 "$?" "the bare acquire path must still succeed"
+  assert_contains "$out" "lock acquired: harness pid" "the bare invocation did not report the acquisition"
+  assert_present "$home/state/.lock" "the bare invocation did not write the session lock"
+  claimed=${out##*harness pid }
+  written=$(tr -d '[:space:]' < "$home/state/.lock")
+  [ -n "$written" ] && [ "$written" = "$claimed" ] \
+    || fail "the reported holder and the recorded one disagree: reported '$claimed', recorded '$written'"
+  pass "fm-lock: the bare invocation still acquires the session lock"
+}
+
+test_unrecognized_argument_refuses_and_leaves_the_lock_unclaimed
+test_help_prints_usage_without_touching_the_lock
+test_status_still_reports_the_holder
+test_bare_invocation_still_acquires

--- a/tests/fm-lock.test.sh
+++ b/tests/fm-lock.test.sh
@@ -25,7 +25,6 @@ make_home() { # <name> -> echoes the home dir
   local name=$1 dir fakebin
   dir="$TMP_ROOT/$name"
   fakebin=$(fm_fakebin "$dir")
-  mkdir -p "$dir/state"
   cat > "$fakebin/ps" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -59,18 +58,21 @@ test_unrecognized_argument_refuses_and_leaves_the_lock_unclaimed() {
   for arg in --help-me -x status-please --lock; do
     out=$(run_lock "$home" "$arg" 2>&1)
     rc=$?
-    [ "$rc" -ne 0 ] || fail "'$arg' was accepted (exit 0) instead of refused"
+    expect_code 2 "$rc" "'$arg' must be refused as a usage error, not accepted or confused with a held lock"
     assert_contains "$out" "unrecognized argument" "'$arg' was refused without saying which argument was wrong"
     assert_contains "$out" "fm-lock.sh status" "'$arg' was refused without printing the usage that names the real forms"
-    assert_absent "$home/state/.lock" "'$arg' claimed the home's session lock while being refused"
+    assert_absent "$home/state" "'$arg' created the home's session-lock state directory while being refused"
   done
-  # The same must hold for an extra argument trailing a form that IS recognized.
-  out=$(run_lock "$home" status extra 2>&1)
-  rc=$?
-  [ "$rc" -ne 0 ] || fail "a trailing extra argument after 'status' was accepted instead of refused"
-  assert_contains "$out" "unexpected extra argument" "the trailing argument was refused without naming it"
-  assert_absent "$home/state/.lock" "a trailing extra argument claimed the home's session lock"
-  pass "fm-lock: an unrecognized argument is refused nonzero and leaves the session lock unclaimed"
+  # The same must hold for an extra argument trailing either form that IS
+  # recognized: it is still an argument the script does not recognize.
+  for arg in status --help; do
+    out=$(run_lock "$home" "$arg" extra 2>&1)
+    rc=$?
+    expect_code 2 "$rc" "a trailing extra argument after '$arg' must be refused as a usage error"
+    assert_contains "$out" "unexpected extra argument" "the argument trailing '$arg' was refused without naming it"
+    assert_absent "$home/state" "a trailing extra argument after '$arg' created the session-lock state directory"
+  done
+  pass "fm-lock: an unrecognized argument is refused with exit 2 and leaves the session lock unclaimed"
 }
 
 test_help_prints_usage_without_touching_the_lock() {
@@ -81,7 +83,7 @@ test_help_prints_usage_without_touching_the_lock() {
     expect_code 0 "$?" "'$flag' must be answered with usage, not an error"
     assert_contains "$out" "fm-lock.sh status" "'$flag' did not print the documented status form"
     assert_contains "$out" "acquire the session lock" "'$flag' did not print the documented acquire form"
-    assert_absent "$home/state/.lock" "'$flag' claimed the home's session lock"
+    assert_absent "$home/state" "'$flag' created the home's session-lock state directory"
   done
   pass "fm-lock: --help and -h print usage on exit 0 and never claim the lock"
 }
@@ -94,6 +96,7 @@ test_status_still_reports_the_holder() {
   assert_contains "$out" "lock: free" "status did not report an unheld lock as free"
   assert_absent "$home/state/.lock" "status created the lock it was only asked to inspect"
 
+  mkdir -p "$home/state"
   printf '%s\n' "$$" > "$home/state/.lock"
   out=$(run_lock "$home" status)
   expect_code 0 "$?" "status on a held home must still exit 0"


### PR DESCRIPTION
## Intent

Make bin/fm-lock.sh refuse an argument it does not recognise, instead of silently taking the home's session lock.

The bug: fm-lock.sh documents two forms in its own header - no argument acquires the lock, and 'status' prints the holder. It tested only for the literal string 'status', so every other argument fell straight through to the acquire path. Running 'fm-lock.sh --help' to find out what the script does therefore took ownership of this home's session lock and printed 'lock acquired: harness pid <n>'. This was found the hard way on 2026-09-01 while inspecting a stale lock: the intent was to read usage text and the effect was claiming the lock. It happened to be harmless only because the recorded holder was already dead. A help flag that mutates shared state is the hazard, and the session lock is the specific piece of shared state that decides which session may mutate the fleet at all.

What was asked for: reject an unrecognised argument with a clear usage message and a nonzero exit, leaving the lock untouched. Keep both currently documented forms working exactly as they are - no argument still acquires, 'status' still prints and still exits 0. Treat '--help' and '-h' as a real request for that usage text on exit 0 rather than as an error, since that is what a person typing it actually wants.

Deliberate scope constraints set by the requester, which a reviewer reading only the diff would not know:
- Keep the change small and inside this one script. Do not restructure its argument handling beyond what this needs.
- Do NOT touch any other fm-*.sh script in this branch even though several share the same pattern. Other scripts sharing this bug are deliberately out of scope and are to be named in the report instead of fixed here. A review finding that proposes fixing sibling scripts is out of scope by explicit instruction.

Decisions made while implementing:
- Argument parsing was placed at the very top of the script, before FM_ROOT/FM_HOME resolution and before the 'mkdir -p $STATE' that creates the state directory, so a refused argument leaves both the lock and the state directory exactly as it found them. This is the point of the fix: the refusal must have no side effect at all.
- Exit code 2 was chosen for a refused argument (usage error), distinct from the acquire path's existing exit 1, which means 'ownership could not be verified'. Callers of the acquire path check for nonzero, so this distinction is additive.
- A trailing extra argument after a recognised form ('fm-lock.sh status extra') is also refused, on the same reasoning - it is an argument the script does not recognise. All existing callers in the repo (fm-session-start.sh, fm-claude-stop-autoarm.sh, fm-turnend-guard-cursor.sh, and the test suites) pass either no argument or exactly 'status', so this refuses nothing that is in use.
- MODE is resolved during parsing and the later branch tests "$MODE" = status instead of "${1:-}", which is what closes the fall-through.
- Usage text lives in the script's own --help output and header comment, per this repo's rule that exact mechanics are owned by the script rather than restated in prose docs; no documentation file needed changing.

Tests: there was no existing tests/fm-lock.test.sh, so a new one was colocated following the conventions of its neighbours (tests/fm-session-lock-ancestry.test.sh in particular), sourcing tests/lib.sh and using its reporters and assertions. It covers all three paths through the executable interface - an unrecognised argument exits nonzero and leaves state/.lock absent, '--help'/'-h' print usage on exit 0 without claiming the lock, 'status' still reports free and held holders on exit 0, and the bare invocation still acquires and records the holder it reports. The unrecognised-argument case is the point of the suite: it was verified to fail when the guard is removed. Homes are driven behind a deterministic fake ps, matching how the neighbouring session-lock suites establish harness identity, and every assertion reads observable behaviour - exit codes, output, and what is on disk - never the script's source bytes.

Delivery: branch fm/fm-lock-arg-guard, branched from origin/main. Pushes go to the fork nikolajernst91/firstmate and the PR opens against kunchenguid/firstmate. bin/fm-lint.sh (pinned ShellCheck 0.11.0 and actionlint 1.7.12) passes, as do tests/fm-lock.test.sh, tests/fm-session-lock-ancestry.test.sh, tests/fm-claude-stop-autoarm.test.sh, and tests/fm-secondmate-safety.test.sh. The merge is the upstream maintainer's decision, not ours.

## What Changed

- `bin/fm-lock.sh` now parses its argument at the very top of the script, before `FM_ROOT`/`FM_HOME` resolution and the `mkdir -p "$STATE"`, so a refused invocation leaves both the lock file and the state directory untouched. An unrecognised argument - or an extra argument after a recognised one - prints an error plus usage on stderr and exits 2, distinct from the acquire path's existing exit 1. Previously only the literal `status` was tested, so anything else (including `--help`) fell through to the acquire path and claimed the home's session lock.
- `-h`/`--help` are handled as a real request for usage: they print the usage text to stdout and exit 0 without touching the lock. The two previously documented forms are unchanged - no argument still acquires, `status` still prints the holder and exits 0 - with the status branch now testing the resolved `MODE` rather than `${1:-}`. The header comment and a new `usage()` function carry the usage text.
- Adds `tests/fm-lock.test.sh`, sourcing `tests/lib.sh` and driving homes behind a deterministic fake `ps`, covering the unrecognised-argument refusal (nonzero exit with `state/.lock` absent), `--help`/`-h` on exit 0 without claiming the lock, `status` reporting free and held holders, and the bare invocation still acquiring and recording the holder it reports. `bin/fm-test-run.sh` files the new suite under the `session-bootstrap` family.

## Risk Assessment

✅ Low: A tightly scoped argument guard placed before any state resolution, with all repo call sites passing only no-arg or 'status' so the new exit 2 is unreachable for existing callers, backed by a behavior-driven suite whose state-directory assertion is now genuinely observable; the sole extra file touched is a correct, inert test-family mapping the human explicitly authorized.

## Testing

<code>Exercised the reported hazard directly: drove the real `bin/fm-lock.sh` against throwaway homes under this session&#39;s genuine harness ancestry and captured a before/after CLI transcript showing that `--help` used to print `lock acquired: harness pid &lt;n&gt;` and write `state/.lock`, and now prints usage on exit 0 leaving no `state/` directory, while `status` and the bare acquire path behave exactly as before and an unrecognised or trailing-extra argument exits 2 with no side effect. The new `tests/fm-lock.test.sh` passes on the branch and fails against the pre-fix script, and two mutants confirmed the review-round hardenings are load-bearing rather than decorative. Ran the suites of every direct `fm-lock.sh` caller plus the composing `fm-session-start` suite as targeted regression, all green, and verified by grep that no caller passes an argument the new guard would refuse. Also demonstrated the changed-file lane fix apples-to-apples: with only `bin/fm-lock.sh` edited, the base runner never selected the new suite and this branch&#39;s runner does. No screenshot applies - this is a shell CLI, so the reviewer-visible surface is the terminal transcript itself. Worktree left clean at the target commit with no transient artifacts.</code>

<details>
<summary>Evidence: fm-lock.sh CLI transcript: before/after, real harness ancestry</summary>

Source: [fm-lock.sh CLI transcript: before/after, real harness ancestry](https://github.com/nikolajernst91/firstmate/blob/8c34117e1b3759f5058b62900eca74bc80cd9b21/.no-mistakes/evidence/fm/fm-lock-arg-guard/fm-lock-cli-transcript.txt)

<code>===== BEFORE - base commit a5f3cbe (the reported bug) =====&#10;&#10;$ FM_HOME=&lt;home&gt; fm-lock.sh --help&#10;lock acquired: harness pid 1039683&#10;[exit 0]&#10;&gt;&gt; SESSION LOCK NOW HELD: state/.lock contains pid 1039683&#10;&#10;===== AFTER - branch fm/fm-lock-arg-guard (f3fb80b) =====&#10;&#10;$ FM_HOME=&lt;home&gt; fm-lock.sh --help&#10;Usage: fm-lock.sh acquire the session lock; exit 1 unless ownership is verified&#10;fm-lock.sh status print holder and liveness; always exits 0&#10;fm-lock.sh --help print this usage; exit 0 without touching the lock&#10;[exit 0]&#10;&gt;&gt; untouched: no state/ directory, no lock&#10;&#10;$ FM_HOME=&lt;home&gt; fm-lock.sh -h&#10;Usage: fm-lock.sh acquire the session lock; exit 1 unless ownership is verified&#10;fm-lock.sh status print holder and liveness; always exits 0&#10;fm-lock.sh --help print this usage; exit 0 without touching the lock&#10;[exit 0]&#10;&gt;&gt; untouched: no state/ directory, no lock&#10;&#10;$ FM_HOME=&lt;home&gt; fm-lock.sh --lock&#10;error: unrecognized argument &#39;--lock&#39;&#10;Usage: fm-lock.sh acquire the session lock; exit 1 unless ownership is verified&#10;fm-lock.sh status print holder and liveness; always exits 0&#10;fm-lock.sh --help print this usage; exit 0 without touching the lock&#10;[exit 2]&#10;&gt;&gt; untouched: no state/ directory, no lock&#10;&#10;$ FM_HOME=&lt;home&gt; fm-lock.sh status extra&#10;error: unexpected extra argument &#39;extra&#39;&#10;Usage: fm-lock.sh acquire the session lock; exit 1 unless ownership is verified&#10;fm-lock.sh status print holder and liveness; always exits 0&#10;fm-lock.sh --help print this usage; exit 0 without touching the lock&#10;[exit 2]&#10;&gt;&gt; untouched: no state/ directory, no lock&#10;&#10;$ FM_HOME=&lt;home&gt; fm-lock.sh status&#10;lock: free&#10;[exit 0]&#10;&gt;&gt; lock not taken (state/ directory exists, state/.lock absent)&#10;&#10;$ FM_HOME=&lt;home&gt; fm-lock.sh&#10;lock acquired: harness pid 1039683&#10;[exit 0]&#10;&gt;&gt; SESSION LOCK NOW HELD: state/.lock contains pid 1039683&#10;&#10;$ FM_HOME=&lt;home&gt; fm-lock.sh status&#10;lock: held by live harness pid 1039683&#10;[exit 0]&#10;&gt;&gt; SESSION LOCK NOW HELD: state/.lock contains pid 1039683</code>

```text
fm-lock.sh argument handling - real CLI transcript
Machine: Linux 7.1.9-arch1-2 x86_64; bash 5.3.15(1)-release
Harness ancestry is this session's real Claude process (no fake ps).

===== BEFORE - base commit a5f3cbe (the reported bug) =====

$ FM_HOME=<home> fm-lock.sh --help
  lock acquired: harness pid 1039683
  [exit 0]
  >> SESSION LOCK NOW HELD: state/.lock contains pid 1039683

===== AFTER - branch fm/fm-lock-arg-guard (f3fb80b) =====

$ FM_HOME=<home> fm-lock.sh --help
  Usage: fm-lock.sh           acquire the session lock; exit 1 unless ownership is verified
         fm-lock.sh status    print holder and liveness; always exits 0
         fm-lock.sh --help    print this usage; exit 0 without touching the lock
  [exit 0]
  >> untouched: no state/ directory, no lock

$ FM_HOME=<home> fm-lock.sh -h
  Usage: fm-lock.sh           acquire the session lock; exit 1 unless ownership is verified
         fm-lock.sh status    print holder and liveness; always exits 0
         fm-lock.sh --help    print this usage; exit 0 without touching the lock
  [exit 0]
  >> untouched: no state/ directory, no lock

$ FM_HOME=<home> fm-lock.sh --lock
  error: unrecognized argument '--lock'
  Usage: fm-lock.sh           acquire the session lock; exit 1 unless ownership is verified
         fm-lock.sh status    print holder and liveness; always exits 0
         fm-lock.sh --help    print this usage; exit 0 without touching the lock
  [exit 2]
  >> untouched: no state/ directory, no lock

$ FM_HOME=<home> fm-lock.sh status extra
  error: unexpected extra argument 'extra'
  Usage: fm-lock.sh           acquire the session lock; exit 1 unless ownership is verified
         fm-lock.sh status    print holder and liveness; always exits 0
         fm-lock.sh --help    print this usage; exit 0 without touching the lock
  [exit 2]
  >> untouched: no state/ directory, no lock

$ FM_HOME=<home> fm-lock.sh status
  lock: free
  [exit 0]
  >> lock not taken (state/ directory exists, state/.lock absent)

$ FM_HOME=<home> fm-lock.sh 
  lock acquired: harness pid 1039683
  [exit 0]
  >> SESSION LOCK NOW HELD: state/.lock contains pid 1039683

$ FM_HOME=<home> fm-lock.sh status
  lock: held by live harness pid 1039683
  [exit 0]
  >> SESSION LOCK NOW HELD: state/.lock contains pid 1039683
```
</details>
<details>
<summary>Evidence: Changed-file lane now selects tests/fm-lock.test.sh when bin/fm-lock.sh is edited</summary>

Source: [Changed-file lane now selects tests/fm-lock.test.sh when bin/fm-lock.sh is edited](https://github.com/nikolajernst91/firstmate/blob/8c34117e1b3759f5058b62900eca74bc80cd9b21/.no-mistakes/evidence/fm/fm-lock-arg-guard/fm-test-run-changed-lane.txt)

<code>Scenario in both cases: a single unrelated working-tree edit to bin/fm-lock.sh,&#10;nothing else modified, then ask the runner which suites it would run.&#10;&#10;--- BEFORE: family_for_basename has no fm-lock.test.sh arm (base a5f3cbe) ---&#10;$ git diff --name-only HEAD&#10;bin/fm-lock.sh&#10;$ bin/fm-test-run.sh --list --changed --base HEAD&#10;tests/fm-backlog-atomicity.test.sh&#10;tests/fm-bootstrap-network-parallel.test.sh&#10;tests/fm-bootstrap.test.sh&#10;tests/fm-fleet-sync.test.sh&#10;tests/fm-gate-refuse.test.sh&#10;tests/fm-gotmp.test.sh&#10;tests/fm-session-start.test.sh&#10;tests/fm-sessionstart-nudge.test.sh&#10;tests/fm-startup-network.test.sh&#10;tests/fm-tangle-guard.test.sh&#10;tests/fm-update.test.sh&#10;&#10;--- AFTER: this branch (f3fb80b) ---&#10;$ git diff --name-only HEAD&#10;bin/fm-lock.sh&#10;$ bin/fm-test-run.sh --list --changed --base HEAD&#10;tests/fm-backlog-atomicity.test.sh&#10;tests/fm-bootstrap-network-parallel.test.sh&#10;tests/fm-bootstrap.test.sh&#10;tests/fm-fleet-sync.test.sh&#10;tests/fm-gate-refuse.test.sh&#10;tests/fm-gotmp.test.sh&#10;tests/fm-lock.test.sh&#10;tests/fm-session-start.test.sh&#10;tests/fm-sessionstart-nudge.test.sh&#10;tests/fm-startup-network.test.sh&#10;tests/fm-tangle-guard.test.sh&#10;tests/fm-update.test.sh</code>

```text
Changed-file lane: editing bin/fm-lock.sh must select tests/fm-lock.test.sh

Scenario in both cases: a single unrelated working-tree edit to bin/fm-lock.sh,
nothing else modified, then ask the runner which suites it would run.

--- BEFORE: family_for_basename has no fm-lock.test.sh arm (base a5f3cbe) ---
  $ git diff --name-only HEAD
    bin/fm-lock.sh
  $ bin/fm-test-run.sh --list --changed --base HEAD
    tests/fm-backlog-atomicity.test.sh
    tests/fm-bootstrap-network-parallel.test.sh
    tests/fm-bootstrap.test.sh
    tests/fm-fleet-sync.test.sh
    tests/fm-gate-refuse.test.sh
    tests/fm-gotmp.test.sh
    tests/fm-session-start.test.sh
    tests/fm-sessionstart-nudge.test.sh
    tests/fm-startup-network.test.sh
    tests/fm-tangle-guard.test.sh
    tests/fm-update.test.sh

--- AFTER: this branch (f3fb80b) ---
  $ git diff --name-only HEAD
    bin/fm-lock.sh
  $ bin/fm-test-run.sh --list --changed --base HEAD
    tests/fm-backlog-atomicity.test.sh
    tests/fm-bootstrap-network-parallel.test.sh
    tests/fm-bootstrap.test.sh
    tests/fm-fleet-sync.test.sh
    tests/fm-gate-refuse.test.sh
    tests/fm-gotmp.test.sh
    tests/fm-lock.test.sh
    tests/fm-session-start.test.sh
    tests/fm-sessionstart-nudge.test.sh
    tests/fm-startup-network.test.sh
    tests/fm-tangle-guard.test.sh
    tests/fm-update.test.sh
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4cb4e9b899013de7e926934f21c7017506db4136","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `tests/fm-lock.test.sh:1` - The new suite is invisible to the runner&#39;s changed-file lane for its own subject. bin/fm-test-run.sh:1139 maps `bin/fm-lock*` to the `session-bootstrap` family, but `family_for_basename` (bin/fm-test-run.sh:196-305) has no pattern for `fm-lock.test.sh`, so it falls to `unclassified`. `select_changed` (bin/fm-test-run.sh:1338-1345) resolves a wanted family to scripts by `family_for_basename` equality, so `bin/fm-test-run.sh --changed --base main` after editing only bin/fm-lock.sh selects fm-bootstrap/fm-session-start/etc. and never tests/fm-lock.test.sh. It runs on THIS branch only because the test file itself is in the diff (tests/*.test.sh yields the `__script__:` marker), and full CI still covers it because `list_portable_serial` derives the remainder from `all_repo_tests`. Remedy: add `fm-lock.test.sh` to the session-bootstrap arm of `family_for_basename`, or emit `__script__:fm-lock.test.sh` from the `bin/fm-lock*` arm of `families_for_changed_path`. Flagged ask-user because the remedy - not the defect - requires editing bin/fm-test-run.sh, and the intent explicitly says to keep this branch inside bin/fm-lock.sh and not touch other fm-*.sh scripts.
- ℹ️ `tests/fm-lock.test.sh:62` - The refusal cases assert only `[ &#34;$rc&#34; -ne 0 ]`, so the exit code the change deliberately introduced and now documents in the script header (2 = usage error, distinct from the acquire path&#39;s 1 = ownership could not be verified) is not pinned. A regression that refused with `exit 1` - indistinguishable to a caller from &#39;another live session holds the lock&#39; - would keep this suite green. Mechanical fix: replace the two `-ne 0` checks at lines 62 and 70 with `expect_code 2 &#34;$rc&#34; ...`, which tests/lib.sh already provides and the neighbouring suites already use.
- ℹ️ `tests/fm-lock.test.sh:28` - `make_home` pre-creates `$dir/state` for every fixture, so the invariant the intent calls the point of the fix - that a refused argument leaves the STATE DIRECTORY, not just the lock, exactly as it found it - is untestable by construction. Concretely: move the argument-parsing block from bin/fm-lock.sh:23-42 to just after `mkdir -p &#34;$STATE&#34;` (bin/fm-lock.sh:52) and all four tests still pass, because state/ already exists and only state/.lock is asserted absent. Mechanical fix: drop the `mkdir -p &#34;$dir/state&#34;` from make_home (the acquire path creates it itself, and fm_fakebin already creates $dir) and add `assert_absent &#34;$home/state&#34;` to the refusal case.
- ℹ️ `bin/fm-lock.sh:27` - The `-h | --help` arm exits 0 before the arity check at line 37, so `fm-lock.sh --help extra` prints usage and exits 0 while `fm-lock.sh status extra` exits 2. The intent&#39;s reasoning for refusing a trailing extra (&#39;it is an argument the script does not recognise&#39;) applies equally to both forms, so the two recognised forms now disagree on the same input shape. No hazard either way - both leave the lock and state directory untouched - and exiting 0 on `--help &lt;junk&gt;` is common CLI behaviour, which is why this is raised for your call rather than fixed: hoisting `if [ &#34;$#&#34; -gt 1 ]` above the case would make it consistent but changes the user-visible exit code for `--help extra` from 0 to 2.

🔧 Fix: pin fm-lock refusal exit 2, state-dir invariant, and test family
1 info still open:

- ℹ️ `bin/fm-test-run.sh:251` - Informational reconciliation, no code change needed. The intent states &#34;Keep the change small and inside this one script&#34; and &#34;Do NOT touch any other fm-*.sh script in this branch&#34;, but the diff now also edits bin/fm-test-run.sh (adds `fm-lock.test.sh|` to the session-bootstrap arm of family_for_basename). That edit is the exact remedy the prior review round described for `changed-file-map-misses-new-suite`, whose description said outright that fixing it requires editing bin/fm-test-run.sh, and a human selected it - so this is authorized and I am not re-litigating it. I verified the edit itself is correct and inert: it mirrors the existing `bin/fm-lock*` -&gt; session-bootstrap mapping at bin/fm-test-run.sh:1141; session-bootstrap is absent from list_concurrent_safe_families (bin/fm-test-run.sh:430-435) so nothing gains concurrency; list_portable_serial (bin/fm-test-run.sh:478-492) derives from all_repo_tests minus the proven-isolated set, so CI lane assignment is unchanged; and no test or workflow enumerates that family&#39;s members. The only loose end is narrative: the intent&#39;s scope sentence and any PR body derived from it now understate the touched file set, so the PR description should name bin/fm-test-run.sh and why.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-lock.test.sh` on the branch - all four cases pass</code>
- <code>Same suite against `git show a5f3cbe:bin/fm-lock.sh` in a temp copy - fails with `expected exit 2, got 0`, confirming fail-before/pass-after</code>
- <code>Manual CLI transcript: `FM_HOME=&lt;scratch&gt; bash bin/fm-lock.sh --help | -h | --lock | status extra | status | &lt;no args&gt;` under this session&#39;s real harness ancestry (no fake ps), before and after, checking exit code and whether `state/` and `state/.lock` exist</code>
- <code>Mutation check A: refusal changed to `exit 1` -&gt; suite fails (`expected exit 2, got 1`)</code>
- <code>Mutation check B: argument parsing moved below `mkdir -p &#34;$STATE&#34;` -&gt; suite fails (`created the home&#39;s session-lock state directory while being refused`)</code>
- `bash tests/fm-session-lock-ancestry.test.sh`
- `bash tests/fm-claude-stop-autoarm.test.sh`
- `bash tests/fm-secondmate-safety.test.sh`
- `bash tests/fm-kimi-harness.test.sh`
- `bash tests/fm-grok-harness.test.sh`
- <code>`bash tests/fm-session-start.test.sh` (composes the real fm-lock.sh acquire path)</code>
- <code>`grep -rn &#39;fm-lock\.sh&#39;` over the repo to confirm every caller passes no argument or exactly `status`</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` with only `bin/fm-lock.sh` edited, run against the base-commit runner (via a temp commit, then reset) and the branch runner</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/fm-test-portable-shards.md:80` - Judgment call, left unchanged deliberately. The new tests/fm-lock.test.sh lands in the derived portable-serial remainder, so the per-shard script counts in the &#39;Portable serial CI shards&#39; table (29/28/30/30) are each a script behind reality. I did not refresh them: the doc itself states membership is derived rather than enumerated and that hints only affect balance, the table is dated evidence from CI run 32491999845 rather than a live contract, and repository precedent is that test-adding commits (0866a77, 1260adc, 1fbc7bb) do not touch this page - its last update was #2684. Refreshing one row by hand would also make it disagree with the run it cites. If a maintainer wants these counts current, the right follow-up is regenerating the whole table plus timing hints from a fresh green run, which is out of scope for this change.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
