### PR TITLE
fix(bin): render the accepted default decision key in OPEN DECISIONS

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,6 +49,10 @@
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
+# Every scaffold's status protocol also states where a decision key may appear:
+# "[key=<slug>]" counts before the line's colon or at the very head of the note,
+# and a later occurrence stays prose that keys nothing.
+# bin/fm-classify-lib.sh owns that grammar; these scaffolds only restate it.
 # Every scaffold also carries the steering-inbox receive-and-ack section:
 # process state/<id>.inbox/*.msg in order and acknowledge each by moving it to
 # handled/ (record, doorbell, and ladder owned by bin/fm-task-inbox-lib.sh).

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -197,6 +197,11 @@ The move IS the acknowledgement: without it firstmate rings again and eventually
 EOF
 INBOX_SECTION=${INBOX_SECTION%$'\n'}
 
+# One deliberate reinforcement of fm-classify-lib.sh's decision-key grammar at
+# every scaffold's status-writing point. Keep the grammar itself owned there.
+# shellcheck disable=SC2016 # Backticks are literal generated Markdown, not shell expressions.
+STATUS_KEY_POSITION_SENTENCE='When you use `[key=<slug>]`, place it before the colon (`needs-decision [key=<slug>]: ...`) or at the very head of the note (`needs-decision: [key=<slug>] ...`); a token later in the summary is prose and does not key the record.'
+
 if [ "$KIND" = secondmate ]; then
 SECONDMATE_PROJECTS=""
 idx=1
@@ -266,6 +271,7 @@ This is also how you return the answer to a marked from-firstmate request above.
 A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
 Never append \`working:\` merely to acknowledge receipt or announce that a marked request has started.
 When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
+$STATUS_KEY_POSITION_SENTENCE
 If its first reportable event is \`working [key=<work-slug>]: {material phase}\`, use the same key on its later \`$PAUSED_VERB\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event so the earlier working phase is superseded.
 When a keyed phase ends without another reportable state, append \`resolved [key=<work-slug>]: {why it is no longer active}\`.
 \`resolved\` separately closes an escalated decision or blocker, and only a \`resolved\` line carrying that decision's exact key closes it: a later \`done\` or \`working\` event never does, even when the answer is what started that work.
@@ -353,6 +359,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+   $STATUS_KEY_POSITION_SENTENCE
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
@@ -432,6 +439,7 @@ $RULE1
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+   $STATUS_KEY_POSITION_SENTENCE
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -450,7 +450,10 @@ _fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb
 
 # Fold the WHOLE status stream into the set of decisions still open. Prints one
 # TAB-separated "<key>\t<verb>\t<summary>" line per still-open decision, in
-# most-recently-opened-last order; prints nothing when none are open. Pure read of
+# most-recently-opened-last order; prints nothing when none are open. The key
+# column is also the display authority: a consumer that offers a key-based close
+# command must render it even when its value is "default", so a prose key token
+# in the summary cannot be mistaken for the record's accepted key. Pure read of
 # the file, no globals beyond the optional FM_CLASSIFY_RESOLVE_VERB override. This
 # is the durable open-set the fleet snapshot and any point-in-time consumer must use
 # instead of trusting the last status line.

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -255,9 +255,10 @@ print_open_decisions_section() {
 
   while IFS=$(printf '\t') read -r task key verb note; do
     [ -n "$task" ] || continue
-    line="$task"
-    [ "$key" = default ] || line="$line [key=$key]"
-    line="$line $verb: $note"
+    # Always render the fold's accepted key, including "default". A note may
+    # legitimately mention a deeper [key=...] token as prose; hiding the default
+    # key would make that prose look like the argument accepted by --resolve-key.
+    line="$task [key=$key] $verb: $note"
     # The shared cut counts the item's own characters; the trailing newline this
     # section's global budget also pays for is this caller's, so the per-item
     # allowance passed down is one short of the cap.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -762,6 +762,31 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+test_status_key_position_is_taught_in_every_scaffold() {
+  local home expected brief
+  home="$TMP_ROOT/status-key-position-home"
+  mkdir -p "$home/data"
+  # shellcheck disable=SC2016 # Backticks are literal expected Markdown, not shell expressions.
+  expected='When you use `[key=<slug>]`, place it before the colon (`needs-decision [key=<slug>]: ...`) or at the very head of the note (`needs-decision: [key=<slug>] ...`); a token later in the summary is prose and does not key the record.'
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" key-position-ship repo --mode no-mistakes >/dev/null 2>&1 \
+    || fail "ship brief with the decision-key instruction did not scaffold"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" key-position-scout repo --scout >/dev/null 2>&1 \
+    || fail "scout brief with the decision-key instruction did not scaffold"
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='Route fixture work.' \
+    "$ROOT/bin/fm-brief.sh" key-position-secondmate --secondmate --no-projects >/dev/null 2>&1 \
+    || fail "secondmate brief with the decision-key instruction did not scaffold"
+
+  for brief in \
+    "$home/data/key-position-ship/brief.md" \
+    "$home/data/key-position-scout/brief.md" \
+    "$home/data/key-position-secondmate/brief.md"; do
+    assert_grep "$expected" "$brief" \
+      "$brief did not teach both accepted key positions or distinguish later prose tokens"
+  done
+  pass "fm-brief.sh: every scaffold teaches the accepted decision-key positions"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -781,5 +806,6 @@ test_secondmate_no_projects_charter
 test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
+test_status_key_position_is_taught_in_every_scaffold
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold

--- a/tests/fm-classify-corr-token.test.sh
+++ b/tests/fm-classify-corr-token.test.sh
@@ -106,10 +106,10 @@ test_token_is_read_through_in_every_position_it_is_written_in() {
   view=$(drain_open "$state" "$out")
   case "$view" in *'t1'*'[key=before]'*) ;; *) fail "token before the key did not open: $view" ;; esac
   case "$view" in *'t2'*'[key=after]'*) ;; *) fail "token after the key did not open: $view" ;; esac
-  # The drain prints the default key as a bare verb, with no [key=...] segment.
-  case "$view" in *'t3 blocked:'*) ;; *) fail "token with no key did not open the default key: $view" ;; esac
+  # The drain renders the fold's accepted default key explicitly.
+  case "$view" in *'t3 [key=default] blocked:'*) ;; *) fail "token with no key did not open the default key: $view" ;; esac
   case "$view" in *'t4'*'[key=twice]'*) ;; *) fail "two tokens on one line did not open: $view" ;; esac
-  case "$view" in *'t5 needs-decision:'*) ;; *) fail "the bracketed helper token did not open: $view" ;; esac
+  case "$view" in *'t5 [key=default] needs-decision:'*) ;; *) fail "the bracketed helper token did not open: $view" ;; esac
 
   # ...and each closes from the same position.
   printf 'resolved corr=%s [key=before]: closed\n' "$CORR" >> "$state/t1.status"
@@ -136,7 +136,7 @@ test_untokened_pair_is_unchanged() {
   printf 'blocked: no key at all\n' > "$state/bare.status"
   view=$(drain_open "$state" "$out")
   case "$view" in *'keyed'*'[key=api-shape]'*) ;; *) fail "an untokened keyed opener regressed: $view" ;; esac
-  case "$view" in *'bare blocked:'*) ;; *) fail "an untokened bare opener regressed: $view" ;; esac
+  case "$view" in *'bare [key=default] blocked:'*) ;; *) fail "an untokened bare opener regressed: $view" ;; esac
 
   printf 'resolved [key=api-shape]: went with REST\n' >> "$state/keyed.status"
   printf 'resolved: cleared on its own\n' >> "$state/bare.status"

--- a/tests/fm-wake-drain-open-decisions.test.sh
+++ b/tests/fm-wake-drain-open-decisions.test.sh
@@ -37,6 +37,28 @@ test_buried_decision_still_surfaces() {
   pass "a needs-decision buried under later routine/other-key lines still reports as open"
 }
 
+test_default_key_is_rendered_explicitly_when_note_mentions_a_key() {
+  local dir state out expected
+  dir=$(make_case explicit-default-key)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # The trailing token is deliberately prose under the fold grammar. The
+  # rendering must lead with the actual default key so the adjacent
+  # --resolve-key hint cannot make the prose token look accepted.
+  printf 'needs-decision: choose the lint response [key=lint-1]\n' > "$state/task-default.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
+    || fail "drain failed on a default-key decision with a prose key token"
+
+  expected='task-default [key=default] needs-decision: choose the lint response [key=lint-1]'
+  grep -Fx "$expected" "$out" >/dev/null \
+    || fail "the open decision did not render its accepted default key: $(cat "$out")"
+  if grep -Fx 'task-default needs-decision: choose the lint response [key=lint-1]' "$out" >/dev/null; then
+    fail "the ambiguous keyless rendering remained visible: $(cat "$out")"
+  fi
+  pass "a default-key open decision renders the key accepted by --resolve-key"
+}
+
 test_explicit_resolution_closes_it() {
   local dir state out
   dir=$(make_case resolved)
@@ -216,6 +238,7 @@ test_over_long_decision_note_is_capped_with_a_marker() {
 }
 
 test_buried_decision_still_surfaces
+test_default_key_is_rendered_explicitly_when_note_mentions_a_key
 test_over_long_decision_note_is_capped_with_a_marker
 test_explicit_resolution_closes_it
 test_later_unrelated_terminal_line_does_not_close_it


### PR DESCRIPTION
## Intent

Correct the OPEN DECISIONS display defect without changing decision-key parser semantics. A [key=<slug>] token is a stated key only before the line's first colon or at the very head of the note; a deeper token remains prose and must never open or close that key. When a keyless needs-decision or blocked record therefore folds under the default key, render the accepted key explicitly so a trailing prose token cannot be mistaken for the argument accepted by bin/fm-send.sh --resolve-key. Teach generated crewmate, scout, and secondmate instructions that [key=<slug>] must appear before the colon or at the note head and that later occurrences are prose. Add executable regression coverage for the misleading trailing-token display and generated guidance. Keep the existing parser protection intact. Do not edit bin/fm-spawn.sh, bin/fm-teardown.sh, or bin/fm-control.sh because concurrent work owns those files. Follow Firstmate shared-material style: one sentence per tracked Markdown line, plain dashes, shellcheck-clean scripts, colocated behavior tests, and no agent co-author.

## What Changed

- `bin/fm-wake-drain.sh` now always prints the fold's accepted key in the OPEN DECISIONS section, including `default`, instead of omitting the `[key=...]` segment for keyless records — so a trailing prose `[key=...]` token in a note can no longer be mistaken for the argument `bin/fm-send.sh --resolve-key` accepts. `bin/fm-classify-lib.sh` gains a header note naming the key column as the display authority for that rule; the parser grammar is unchanged.
- `bin/fm-brief.sh` adds a shared `STATUS_KEY_POSITION_SENTENCE` woven into the crewmate, scout, and secondmate scaffolds, stating that `[key=<slug>]` counts only before the line's colon or at the very head of the note and that a later occurrence is prose; the file header documents where that grammar is owned and restated.
- Tests: a new `tests/fm-wake-drain-open-decisions.test.sh` case asserts the explicit `[key=default]` rendering and the absence of the old ambiguous line, a new `tests/fm-brief.test.sh` case asserts all three scaffolds carry the position sentence, and `tests/fm-classify-corr-token.test.sh` expectations were updated to the explicit default-key output.

## Risk Assessment

✅ Low: A tightly scoped, single-commit display fix that leaves the decision-key parser untouched, aligns OPEN DECISIONS with the unconditional key rendering already used by RECORD DIVERGENCE and fm-afk-return's blocker listing, renders a key that bin/fm-send.sh genuinely accepts via --resolve-key, updates every stale test expectation, and adds behavioral regression coverage for both the display defect and the generated guidance.

## Testing

Ran the targeted tests covering the changed rendering, the decision-key parser contract, the generated briefs, and every other test that consumes the OPEN DECISIONS listing; all pass except one pre-existing failure unrelated to this change. Beyond the suite I drove the actual supervisor surface end-to-end at both base and target — seeding a keyless needs-decision whose note carries a trailing prose [key=lint-1] token, running the real drain, then the real bin/fm-send.sh --resolve-key — which shows the defect concretely: fm-send refuses the prose token and accepts only `default` in both revisions, so before the fix the listing's sole visible key was the one that does not work, and after the fix the listing leads with `[key=default]`. I also verified the new brief guidance is accurate rather than merely present by driving all three taught key positions through the real parser and send path, and confirmed the regression tests are genuinely red against the un-fixed scripts. No screenshot applies: this is a terminal CLI surface, so the captured command transcripts are the end-user-visible rendering. Overall result: the user intent is satisfied, parser semantics are untouched, and the worktree was left clean.

The captured results showed the old display exposing a non-resolvable prose key, the fixed display exposing and resolving `default`, generated guidance matching parser behavior, and regression tests failing before and passing after the fix.
- Outcome: ⚠️ 1 info across 1 run (13m2s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"afa629ae2179eac0442ac312c0f5336457b0c766","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-wake-drain.sh:261` - Unconditionally rendering `[key=default]` adds 14 bytes to every keyless OPEN DECISIONS item, which both shrinks the per-item note allowance (item_bytes=220, cut at 219) and consumes the 4000-byte section budget faster. A keyless decision whose note previously fit whole can now be cut with `[truncated]`, and a dense fleet can push one more item into the `N more omitted (byte cap)` tail. This is the deliberate tradeoff the intent requires, the key survives truncation because it leads the line, and omissions are still explicitly announced, so no action is needed - noting it only so the budget effect is a recorded consequence rather than a surprise.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-captain-hold-lifecycle.test.sh:712` - tests/fm-captain-hold-lifecycle.test.sh fails in this environment, but reproduces identically at the base commit 355f46f, so it is pre-existing and not caused by this change. The script dies at `bin/fm-procevent.sh start fixture-src` (a perl fork/setpgrp daemonization path) after 10 of 17 cases pass; the 7 unreached cases assert only on the RECORD DIVERGENCE section and a task-name substring, none of which depend on the OPEN DECISIONS key rendering this change modified. Left as out of scope for this fix.
- <code>`bin/fm-test-run.sh tests/fm-wake-drain-open-decisions.test.sh tests/fm-classify-corr-token.test.sh` - the changed OPEN DECISIONS rendering and its correlation-token consumers, all pass</code>
- <code>`bin/fm-test-run.sh tests/fm-brief.test.sh tests/fm-classify-decision-key.test.sh` - new generated-guidance case plus the full decision-key parser contract, all pass</code>
- <code>`bin/fm-test-run.sh tests/fm-send-resolve-key.test.sh` - the real --resolve-key answerer-closes path over stubbed transports, all 14 cases pass</code>
- <code>`bin/fm-test-run.sh tests/fm-wake-drain-open-decisions-cursor.test.sh tests/fm-wake-drain-unread-status.test.sh tests/fm-send-remote-delivery.test.sh` - remaining consumers of the modified listing format, all pass</code>
- <code>Manual end-to-end at the target commit: seeded `needs-decision: adopt the strict lint profile or keep the current one [key=lint-1]`, ran the real `bin/fm-wake-drain.sh`, then the real `bin/fm-send.sh &lt;task&gt; --resolve-key lint-1` (refused, exit 1, nothing sent) and `--resolve-key default` (exit 0, appended `resolved [key=default]`, decision no longer listed)</code>
- <code>Manual end-to-end at the base commit over an unpacked base tree: same fixture, same fm-send behavior, but the listing shows no key at all so the prose `[key=lint-1]` token is the only visible candidate</code>
- <code>Grammar conformance check: drove `needs-decision [key=X]: note`, `needs-decision: [key=X] note`, and `needs-decision: note [key=X]` through the real drain and real `fm-send --resolve-key`, confirming the positions the new brief sentence teaches are exactly the positions the parser honors</code>
- <code>Generated the real ship, scout, and secondmate `brief.md` via `bin/fm-brief.sh` and captured the new key-position sentence in surrounding context in each</code>
- <code>Red/green: reverted only `bin/fm-wake-drain.sh` and `bin/fm-brief.sh` to base in an unpacked target tree and re-ran `tests/fm-wake-drain-open-decisions.test.sh`, `tests/fm-brief.test.sh`, `tests/fm-classify-corr-token.test.sh` - each fails there and passes at target</code>
- <code>`git diff 355f46f 30d5b79 -- bin/fm-classify-lib.sh` filtered to non-comment lines - empty, confirming no parser code was touched</code>
- <code>`git diff --name-only 355f46f 30d5b79` checked against fm-spawn.sh / fm-teardown.sh / fm-control.sh - none present</code>
- <code>`bash tests/fm-captain-hold-lifecycle.test.sh` run twice at target and once against an unpacked base tree - identical exit 1 both places, confirming the failure is pre-existing</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `.agents/skills/firstmate-codexapp/SKILL.md:64` - Out-of-scope follow-up: the Codex Desktop status-return-channel template is a second, hand-written place that dictates worker status-line vocabulary outside bin/fm-brief.sh, and it teaches only the bare verb prefixes with no decision-key grammar. This change deliberately scoped the key-position teaching to the generated crewmate, scout, and secondmate briefs, so nothing there became false, but a future consolidation should decide whether that template should point at the fm-brief.sh status protocol instead of restating a narrower prefix list.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
