### PR TITLE
feat: adopt constitution layering in worker briefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -512,7 +512,7 @@ Preserve durable structured identifiers, dependencies, and completion artifact l
 
 ## 11. Crewmate briefs
 
-`bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, delivery-mode definitions of done, exact safety mechanics, and the generated ship project-memory rule-file layering contract.
+`bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, delivery-mode definitions of done, and exact safety mechanics; `bin/fm-dod-lib.sh` owns the worker-facing rule-file layering contract rendered into ship briefs and promoted ship instructions alike.
 Use its scaffold as the contract, then replace every `{TASK}` placeholder with a clear task description, acceptance criteria, constraints, and necessary context before dispatch or seeding.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -512,7 +512,7 @@ Preserve durable structured identifiers, dependencies, and completion artifact l
 
 ## 11. Crewmate briefs
 
-`bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, delivery-mode definitions of done, and exact safety mechanics.
+`bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, delivery-mode definitions of done, exact safety mechanics, and the generated ship project-memory rule-file layering contract.
 Use its scaffold as the contract, then replace every `{TASK}` placeholder with a clear task description, acceptance criteria, constraints, and necessary context before dispatch or seeding.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -55,9 +55,10 @@
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
-# over copied detail), owns the worker-facing rule-file layering contract, and
-# has the crewmate add the fm-ensure-agents-md.sh self-governance section when a
-# touched project AGENTS.md lacks it.
+# over copied detail), renders the worker-facing rule-file layering contract
+# from bin/fm-dod-lib.sh (its single owner), and has the crewmate add the
+# fm-ensure-agents-md.sh self-governance section when a touched project AGENTS.md
+# lacks it.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -395,6 +396,7 @@ case "$MODE" in
     ;;
 esac
 DOD=$(fm_dod_block "$MODE" "$ID") || exit 1
+LAYERING=$(fm_layering_line) || exit 1
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -445,7 +447,7 @@ $INBOX_SECTION
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
 Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
-A shared worker-facing rule file is law: never replace it with a same-named project file; put that specialization in a clearly-namespaced \`local-*\` file instead.
+$LAYERING
 If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -55,8 +55,9 @@
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
-# over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
-# self-governance section when a touched project AGENTS.md lacks it.
+# over copied detail), owns the worker-facing rule-file layering contract, and
+# has the crewmate add the fm-ensure-agents-md.sh self-governance section when a
+# touched project AGENTS.md lacks it.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -444,6 +445,7 @@ $INBOX_SECTION
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
 Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
+A shared worker-facing rule file is law: never replace it with a same-named project file; put that specialization in a clearly-namespaced \`local-*\` file instead.
 If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -5,6 +5,10 @@
 # receives. Both paths must hand the worker the same contract: a promoted
 # no-mistakes worker that never received the ask-user escalation rule or the
 # `--yes` ban is the exact delivery hole this single owner exists to close.
+# fm_layering_line prints the worker-facing rule-file layering contract and is
+# that sentence's single owner: bin/fm-brief.sh renders it into a ship brief's
+# project-memory section, and bin/fm-promote.sh into a promoted scout's ship
+# instructions, so both worker classes receive the same rule.
 # fm_dod_block <no-mistakes|direct-PR|local-only> <task-id> prints the block on
 # stdout with no trailing blank line. The caller validates the mode; an unknown
 # mode is refused rather than silently rendered as the pipeline contract.
@@ -64,4 +68,10 @@ EOF
       echo "error: fm_dod_block: unknown delivery mode '$mode'" >&2
       return 1 ;;
   esac
+}
+
+fm_layering_line() {
+  cat <<EOF
+A shared worker-facing rule file is law: never replace it with a same-named project file; put that specialization in a clearly-namespaced \`local-*\` file instead.
+EOF
 }

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -7,9 +7,10 @@
 # delivers them. Those instructions carry the scratch-state inventory, the clean
 # default-branch base, the fm/<task-id> branch, and - rendered from
 # bin/fm-dod-lib.sh, the single owner an ordinary ship brief also uses - the
-# mode-specific Definition of done, so a promoted worker receives exactly the same
-# delivery contract as a briefed one, including the no-mistakes mode's ask-user
-# escalation rule and --yes ban.
+# mode-specific Definition of done and the worker-facing rule-file layering
+# contract, so a promoted worker receives exactly the same delivery contract as
+# a briefed one, including the no-mistakes mode's ask-user escalation rule and
+# --yes ban.
 # A scout records no delivery posture, so promotion is where this task's delivery
 # contract is decided: --mode and --yolo are REQUIRED and written into the meta
 # alongside the kind= flip. Firstmate resolves both at promotion time, having just

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -149,6 +149,8 @@ Your scout task has been promoted to a ship task, mode=$MODE. Your window, workt
 5. If you reproduced a bug, turn that reproduction into a regression test.
 6. These ship instructions supersede the scout delivery rules and report-based Definition of done. Everything else in your original instructions carries over unchanged: the status protocol; the instruction inbox and its acknowledgement; the escalation rules, including ask-user; and every safety rule.
 
+$(fm_layering_line)
+
 EOF
   fm_dod_block "$MODE" "$ID"
 } > "$TMP" || { echo "error: could not render ship instructions for mode=$MODE" >&2; exit 1; }

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -31,7 +31,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-captain-hold.sh`     | Hold tasks for the captain, record the captain's answers, gate investigation completion, and report record divergence between the status log and the backlog |
 | `fm-decision-hold.sh`    | One-release compatibility shim mapping the retired decision commands onto fm-captain-hold.sh |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
-| `fm-dod-lib.sh`          | One owner of the ship task's mode-specific definition of done, rendered by both the brief scaffold and a scout promotion |
+| `fm-dod-lib.sh`          | One owner of the mode-specific definition of done and the worker rule-file layering line, rendered by both the brief scaffold and a scout promotion |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -377,6 +377,8 @@ test_ship_project_memory_wording() {
     "project-memory contract lost the durable-knowledge bar"
   assert_grep "prefer a pointer to the authoritative file, command, or doc over copying the detail" "$brief" \
     "project-memory contract lost pointer-over-copy guidance"
+  assert_grep "A shared worker-facing rule file is law: never replace it with a same-named project file; put that specialization in a clearly-namespaced \`local-*\` file instead." "$brief" \
+    "project-memory contract lost the rule-file layering line"
   assert_grep "lacks \`## Maintaining this file\`, add that short self-governance section" "$brief" \
     "project-memory contract lost the self-governance add-in-same-pass rule"
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -336,6 +336,8 @@ STUB
       "$mode: promoted worker was not told to stop for any wrong worktree"
     assert_grep "git checkout -b fm/$id" "$payload" \
       "$mode: promoted worker was not told to leave the scratch base for its ship branch"
+    assert_grep "A shared worker-facing rule file is law: never replace it with a same-named project file; put that specialization in a clearly-namespaced \`local-*\` file instead." "$payload" \
+      "$mode: promoted worker did not receive the rule-file layering contract"
 
     # Compare the public outputs of both real generation paths. The promoted
     # payload ends at its Definition of done, as does an ordinary generated


### PR DESCRIPTION
## Intent

Adopt the constitution-layering discipline into firstmate's worker-facing rule-file contract, per the captain's ruling of 2026-09-01 ("1 = adopt", harbor #107).

The discipline: shared worker-facing rule files are law and are never same-name overridden by a project; project specialization lives in separate, clearly-namespaced local-* style files. This keeps shared rules drift-free across every project a worker touches. It matches the captain's own standing config practice (global config is law, local files specialize under distinct names).

Requirements:
1. Codify the discipline in the right owning location(s) of firstmate's shared tracked surface - AGENTS.md's worker-brief/crewmate contract area and/or the brief scaffold's generated contract - using pointer-style concision, never duplicating the same rule in two places (one-owner rule).
2. Check docs/configuration.md and bin/fm-brief.sh first: the contract text workers actually read is the scaffold's generated sections, so the discipline must reach the worker-facing surface, not just an internal doc.
3. Keep AGENTS.md size discipline: prefer one tight sentence over a paragraph; prune or merge rather than append.
4. Colocated test or verification if the scaffold text changes (e.g. a scaffold test asserting the layering line exists).

Constraints:
- This task edits firstmate shared tracked material and must follow firstmate-coding-guidelines: one sentence per line, one-owner rule, shellcheck-clean, colocated tests, no agent co-author.
- Another PR (reviewer input sanitizer) may land on this repo concurrently; expect an ordinary rebase, do not build on its branch.
- Do not broaden scope beyond the layering contract and the smallest downstream change needed to keep that contract reaching every ship-facing worker.

Accepted later requirement (firstmate decision key promoted-scouts-layering): promoted scouts must receive the layering contract. fm-promote.sh already renders the delivery DoD contracts for promoted workers, so extend that same rendering to include the layering/project-memory contract sections. Add or extend the colocated scaffold test to pin that promoted briefs carry the layering line. Keep everything else as-is.

Implementation choices already made (not mistakes):
- The generated ship project-memory section in bin/fm-brief.sh is the single owner of the worker-facing layering sentence.
- AGENTS.md section 11 only names that generated section as owner and does not restate the rule.
- docs/configuration.md does not own this contract and was not changed.
- Scout and secondmate scaffolds stay without a duplicate restatement; promoted scouts receive the contract via the promote path's shared owner, matching the accepted later requirement.

## What Changed

Final changed paths and statuses:

```text
M	AGENTS.md
M	bin/fm-brief.sh
M	bin/fm-dod-lib.sh
M	bin/fm-promote.sh
M	docs/scripts.md
M	tests/fm-brief.test.sh
M	tests/fm-task-delivery.test.sh
```

## Risk Assessment

✅ Low: The change is a tightly bounded contract addition: one sentence with a single shared owner rendered into two already-existing delivery surfaces, pinned by colocated behavioral tests that execute the real generation paths, with no reachable path producing a wrong or missing contract.

## Testing

Ran the two colocated test files covering the change (all passing), reproduced both real generation paths end-to-end with the actual CLIs to confirm the layering sentence reaches the worker-facing ship brief and the promoted scout's delivered message, confirmed scout/secondmate scaffolds and AGENTS.md carry no duplicate restatement, and verified at the base commit that both new assertions fail, establishing them as genuine regression tests. No failures; worktree left clean.

<details>
<summary>Evidence: Generated ship brief (worker-facing surface) with layering line in Project memory section</summary>

Source: [Generated ship brief (worker-facing surface) with layering line in Project memory section](https://github.com/derickdsouza/firstmate/blob/0eb21bbba7f900801dbb09c4817ae157b20fdfd3/.no-mistakes/evidence/fm/adopt-constitution-layering/ship-brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of fixture-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/layering-demo-ship`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-layering-demo/home/state/layering-demo-ship.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/tmp/fm-layering-demo/home/state/layering-demo-ship.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/tmp/fm-layering-demo/home/state/layering-demo-ship.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/tmp/fm-layering-demo/home/state/layering-demo-ship.inbox'/NNN.msg '/tmp/fm-layering-demo/home/state/layering-demo-ship.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `~/.no-mistakes/worktrees/7f0ec18181b6/01M1ESQWZ7A1FSEJ7A8JR3E4W7/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
A shared worker-facing rule file is law: never replace it with a same-named project file; put that specialization in a clearly-namespaced `local-*` file instead.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `~/.no-mistakes/worktrees/7f0ec18181b6/01M1ESQWZ7A1FSEJ7A8JR3E4W7/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Promoted scout&#39;s ship-instructions.md carrying the layering contract</summary>

Source: [Promoted scout&#39;s ship-instructions.md carrying the layering contract](https://github.com/derickdsouza/firstmate/blob/0eb21bbba7f900801dbb09c4817ae157b20fdfd3/.no-mistakes/evidence/fm/adopt-constitution-layering/promoted-scout-ship-instructions.md)

```text
Your scout task has been promoted to a ship task, mode=no-mistakes. Your window, worktree, and context stay as they are; only the contract below changes.

# Ship instructions
1. **Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from. If either does not resolve to the worktree you were launched in, stop and escalate to firstmate.
2. Inventory this worktree's scratch state with `git status` and `git log` before changing anything.
3. Return to a clean default-branch base, then create your branch: `git checkout -b fm/layering-demo-scout`.
4. Carry over only the intended fix changes. Leave scratch commits, debug edits, and experiment files behind.
5. If you reproduced a bug, turn that reproduction into a regression test.
6. These ship instructions supersede the scout delivery rules and report-based Definition of done. Everything else in your original instructions carries over unchanged: the status protocol; the instruction inbox and its acknowledgement; the escalation rules, including ask-user; and every safety rule.

A shared worker-facing rule file is law: never replace it with a same-named project file; put that specialization in a clearly-namespaced `local-*` file instead.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Message actually delivered to the promoted worker (captured via the fm-send.sh delivery command promotion printed), layering line at line 11 directly above the Definition of done</summary>

Source: [Message actually delivered to the promoted worker (captured via the fm-send.sh delivery command promotion printed), layering line at line 11 directly above the Definition of done](https://github.com/derickdsouza/firstmate/blob/0eb21bbba7f900801dbb09c4817ae157b20fdfd3/.no-mistakes/evidence/fm/adopt-constitution-layering/promoted-scout-delivered-payload.txt)

```text
Your scout task has been promoted to a ship task, mode=no-mistakes. Your window, worktree, and context stay as they are; only the contract below changes.

# Ship instructions
1. **Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from. If either does not resolve to the worktree you were launched in, stop and escalate to firstmate.
2. Inventory this worktree's scratch state with `git status` and `git log` before changing anything.
3. Return to a clean default-branch base, then create your branch: `git checkout -b fm/layering-demo-scout`.
4. Carry over only the intended fix changes. Leave scratch commits, debug edits, and experiment files behind.
5. If you reproduced a bug, turn that reproduction into a regression test.
6. These ship instructions supersede the scout delivery rules and report-based Definition of done. Everything else in your original instructions carries over unchanged: the status protocol; the instruction inbox and its acknowledgement; the escalation rules, including ask-user; and every safety rule.

A shared worker-facing rule file is law: never replace it with a same-named project file; put that specialization in a clearly-namespaced `local-*` file instead.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: fm-promote.sh transcript: kind=scout→ship flip, mode/yolo recorded, ship instructions written, delivery command printed</summary>

Source: [fm-promote.sh transcript: kind=scout→ship flip, mode/yolo recorded, ship instructions written, delivery command printed](https://github.com/derickdsouza/firstmate/blob/0eb21bbba7f900801dbb09c4817ae157b20fdfd3/.no-mistakes/evidence/fm/adopt-constitution-layering/promote-transcript.txt)

```text
promoted layering-demo-scout to ship mode=no-mistakes yolo=off (teardown protection restored)
wrote ship instructions for mode=no-mistakes: /tmp/fm-layering-demo/home/data/layering-demo-scout/ship-instructions.md
next: FM_HOME=/tmp/fm-layering-demo/home bin/fm-send.sh fm-layering-demo-scout "$(cat /tmp/fm-layering-demo/home/data/layering-demo-scout/ship-instructions.md)"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7ba0d372eee9e8a6d055498fe77841e438525b43","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh (all pass, incl. test_ship_project_memory_wording pinning the layering line in the generated ship brief)`
- `bash tests/fm-task-delivery.test.sh (all pass, incl. test_promotion_delivers_the_real_definition_of_done asserting the delivered payload carries the layering contract for no-mistakes/direct-PR/local-only)`
- <code>manual e2e: `FM_HOME=$DEMO ./bin/fm-brief.sh layering-demo-ship fixture-project --mode no-mistakes` then inspected generated brief.md Project memory section</code>
- <code>manual e2e: `./bin/fm-promote.sh layering-demo-scout --mode no-mistakes --yolo off` with kind=scout task record, then executed the printed fm-send.sh delivery command via a capturing stub and asserted the delivered payload contains the layering line</code>
- <code>one-owner check: `grep -rn &#34;A shared worker-facing rule file is law&#34; --include=&#39;*.sh&#39; --include=&#39;*.md&#39; .` shows the sentence only in bin/fm-dod-lib.sh plus the two pinning tests; scout and secondmate generated briefs confirmed free of it</code>
- `base-commit regression check: ran fm-brief.sh and fm-promote.sh extracted from 355f46f against temp FM_HOME; layering line absent in both generated outputs, proving the new assertions fail before the fix`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
