### PR TITLE
feat(bin): add the captain-facing workstream board

### DIFF
--- a/.agents/skills/workstreams/SKILL.md
+++ b/.agents/skills/workstreams/SKILL.md
@@ -32,7 +32,8 @@ The board is a sibling of the bearings board and shares its build mechanics thro
    - Pass the snapshot's workstreams through, including the explicit `unassigned` lane, and keep each lane's `more` count as the payload's `more_tasks`.
    - Distribute the snapshot's flat `tasks[]` into each lane's `tasks` array by each row's `ws` field; a lane's `tasks` holds exactly the rows tagged with that lane's id.
    - Carry each lane's whole-lane state tallies through as its `counts` object with all six keys (`done`, `review`, `active`, `held`, `decision`, `queued`), so the progress bar reports the lane rather than the rows the cap left visible.
-     The builder REFUSES a lane that ships `more_tasks` above zero without `counts`, a partial `counts`, or a `counts` totalling fewer than the rows the lane ships.
+     The six counts must total EXACTLY the lane - the rows the payload ships plus its `more_tasks` - which the snapshot's own `total` already satisfies.
+     The builder REFUSES a lane that ships `more_tasks` above zero without `counts`, a partial or empty `counts`, or any `counts` whose total is not that exact lane total.
    - Pass the snapshot's `edges` and `divergence` rows through; the divergence callout is how the captain learns the backlog and the live fleet disagree.
    - Map each agent's state to a chip tone: `working` for a working agent, `decision` for one waiting on the captain, `paused` otherwise.
      The same tone rule fills the roster's `agents[].tone` and each pinned chip's `tasks[].agent_tone`.

--- a/.agents/skills/workstreams/SKILL.md
+++ b/.agents/skills/workstreams/SKILL.md
@@ -30,6 +30,7 @@ The board is a sibling of the bearings board and shares its build mechanics thro
    - Compose exactly one waiting item per captain-held task id; when one task carries multiple questions, consolidate them into that item (`captain-hold-lifecycle` owns this rule).
    - Set `close: "release"` when the answer should free a captain-gated WORK item to proceed; question-shaped items omit it.
    - Pass the snapshot's workstreams through, including the explicit `unassigned` lane, and keep each lane's `more` count as the payload's `more_tasks`.
+   - Carry each lane's whole-lane state tallies through as its `counts` object (`done`, `review`, `active`, `held`, `decision`, `queued`), so the progress bar reports the lane rather than the rows the cap left visible.
    - Pass the snapshot's `edges` and `divergence` rows through; the divergence callout is how the captain learns the backlog and the live fleet disagree.
    - Map each agent's state to a chip tone: `working` for a working agent, `decision` for one waiting on the captain, `paused` otherwise.
 

--- a/.agents/skills/workstreams/SKILL.md
+++ b/.agents/skills/workstreams/SKILL.md
@@ -30,9 +30,14 @@ The board is a sibling of the bearings board and shares its build mechanics thro
    - Compose exactly one waiting item per captain-held task id; when one task carries multiple questions, consolidate them into that item (`captain-hold-lifecycle` owns this rule).
    - Set `close: "release"` when the answer should free a captain-gated WORK item to proceed; question-shaped items omit it.
    - Pass the snapshot's workstreams through, including the explicit `unassigned` lane, and keep each lane's `more` count as the payload's `more_tasks`.
-   - Carry each lane's whole-lane state tallies through as its `counts` object (`done`, `review`, `active`, `held`, `decision`, `queued`), so the progress bar reports the lane rather than the rows the cap left visible.
+   - Distribute the snapshot's flat `tasks[]` into each lane's `tasks` array by each row's `ws` field; a lane's `tasks` holds exactly the rows tagged with that lane's id.
+   - Carry each lane's whole-lane state tallies through as its `counts` object with all six keys (`done`, `review`, `active`, `held`, `decision`, `queued`), so the progress bar reports the lane rather than the rows the cap left visible.
+     The builder REFUSES a lane that ships `more_tasks` above zero without `counts`, a partial `counts`, or a `counts` totalling fewer than the rows the lane ships.
    - Pass the snapshot's `edges` and `divergence` rows through; the divergence callout is how the captain learns the backlog and the live fleet disagree.
    - Map each agent's state to a chip tone: `working` for a working agent, `decision` for one waiting on the captain, `paused` otherwise.
+     The same tone rule fills the roster's `agents[].tone` and each pinned chip's `tasks[].agent_tone`.
+   - Pin the live agents on the tasks they are working: every snapshot `agents[]` id IS a task id, so set that task row's `tasks[].agent` label and `tasks[].agent_tone` from the matching agent.
+     A task with no live agent record carries neither field, and neither field may name an agent the snapshot does not report.
 
 3. **Run `build` once after composing the payload.**
    Its serve-first sequence publishes the board, establishes or resumes its Lavish session, and only then binds and arms the polling source; use the session URL it prints in the chat reply.

--- a/.agents/skills/workstreams/SKILL.md
+++ b/.agents/skills/workstreams/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: workstreams
+description: >-
+  Build and arm the captain-facing workstream board: backlog tasks grouped into workstreams against intended outcomes, dependency edges drawn, live agents pinned on the tasks they are working, and captain decisions answerable from the board.
+  Use when the captain invokes /workstreams or asks for the workstream board, and also load this skill's board-wake handling when a procevent lavish wake's source id matches the canonical source id of the stable workstream board path.
+  A sibling of /bearings, not an extension of it: bearings is the whole-fleet digest, this board is the grouped per-outcome view of the main home's backlog.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# workstreams
+
+Build the interactive workstream board so the captain sees every task grouped by intended outcome, what each live agent is doing right now, and answers pending decisions directly on the board.
+`bin/fm-workstream-board.sh` owns every board mechanic - the stable board path, fm-workstream-board.v1 payload validation, template injection, Lavish session establishment, the answer binding, and arm-if-absent registration - so the per-invocation work is composing the payload and running its `build`.
+The board is a sibling of the bearings board and shares its build mechanics through `bin/fm-board-lib.sh`; it never replaces the four-section `/bearings` digest.
+
+## What it does
+
+1. **Gather live grouped state with one deterministic command.**
+   Run `snapshot=$(bin/fm-workstream-snapshot.sh --json)` at invocation time and read that compact output.
+   It is the single bounded, deterministic source for this board; do not create a second fleet-state reader, status-tail interpretation, or ad-hoc `gh`/`gh-axi` query.
+   The command's header owns the workstream-derivation convention (umbrella tasks with `kind: program`, id prefixes, blocked-by edges, the unassigned lane), the task-state precedence, the divergence rules, and the bounds with their `omitted[]` disclosure.
+   The projection is always local-only and main-home only.
+
+2. **Compose the fm-workstream-board.v1 payload from that snapshot.**
+   The gather step is deterministic; your judgment is scoped to captain-facing copy - workstream outcome lines, task row wording, agent chip labels, and decision cards.
+   Board rules:
+   - A waiting item's `key` is the captain-held TASK ID from the snapshot's `decisions[]`, so the bound keyed-answer intake closes or releases that task at answer time; never invent a key that names no captain-held task.
+   - Compose exactly one waiting item per captain-held task id; when one task carries multiple questions, consolidate them into that item (`captain-hold-lifecycle` owns this rule).
+   - Set `close: "release"` when the answer should free a captain-gated WORK item to proceed; question-shaped items omit it.
+   - Pass the snapshot's workstreams through, including the explicit `unassigned` lane, and keep each lane's `more` count as the payload's `more_tasks`.
+   - Pass the snapshot's `edges` and `divergence` rows through; the divergence callout is how the captain learns the backlog and the live fleet disagree.
+   - Map each agent's state to a chip tone: `working` for a working agent, `decision` for one waiting on the captain, `paused` otherwise.
+
+3. **Run `build` once after composing the payload.**
+   Its serve-first sequence publishes the board, establishes or resumes its Lavish session, and only then binds and arms the polling source; use the session URL it prints in the chat reply.
+   Never run `lavish-axi poll` for the board yourself: the armed source's supervised runner owns the blocking poll.
+
+4. **Reply in chat with the board URL and a one-line summary** of what needs the captain (decisions waiting, divergence callouts), following `AGENTS.md` section 9.
+
+## Starting or reshaping a workstream
+
+The backlog has no workstream field; the grouping is the umbrella-task convention the snapshot header owns.
+When the captain asks to group work, create one umbrella task per workstream (`tasks-axi add <slug> "<workstream name>" --kind program`) with the intended-outcome line as its body, give member tasks the umbrella's id prefix or a real `blocked-by` edge, and let the next `/workstreams` run pick the grouping up.
+Record real dependencies only; the graph draws what the backlog actually says.
+
+## Handling a board wake
+
+A board answer arrives as an ordinary `procevent lavish <source-id> <sequence>` check wake.
+Identify it by comparing the wake source id with `bin/fm-procevent-lavish.sh source-id "$(bin/fm-workstream-board.sh path)"`, then load `process-event-sources` and follow its contract for the result read, adapter classification, and the handled acknowledgement.
+Decision answers need no routing from you: the runner feeds the board's binding into `bin/fm-captain-hold.sh`'s one keyed-answer intake, which closes or releases each answered captain-held task at answer time.
+Reconcile any `skipped:` key yourself with a direct `answer`, and when the captain's answer is "later", record it as a deferral with `tasks-axi hold <id> ... --until <date>` instead of a closure.
+After handling, rebuild the board from a fresh snapshot so answered items leave the waiting rail, and echo every action taken in chat so the board and chat never diverge silently.
+
+## Supervision discipline
+
+A board build changes no fleet state beyond the board artifact, its answer binding, and its source registration.
+During the invocation, do not tear down a task, merge a PR, dispatch queued work, steer a worker, answer a queued decision, or mutate any other `state/` or `data/` file.
+If the snapshot suggests an action - a divergence to repair, a stale worker - name it in chat and leave it to the normal lifecycle and configured authority.
+On a later board wake, this read-only rule yields to "Handling a board wake" and the normal authority rules.

--- a/.agents/skills/workstreams/assets/board-template.html
+++ b/.agents/skills/workstreams/assets/board-template.html
@@ -360,7 +360,23 @@ __FM_WORKSTREAM_BOARD_DATA__
   document.getElementById("wb-home").textContent = data.home;
   document.getElementById("wb-provenance").textContent = data.schema + " · " + data.generated;
 
-  var allTasks = data.workstreams.reduce(function (acc, ws) { return acc.concat(ws.tasks); }, []);
+  var STATES = ["done", "review", "active", "held", "decision", "queued"];
+  /* One owner for a lane's tallies: the composer's validated counts, which are
+     guaranteed to total the rows the lane ships plus the rows it omitted, and
+     the shipped rows only when a lane omits nothing and sent no counts. Row
+     capping is a display bound and never moves these numbers. */
+  function laneTally(ws) {
+    var visible = { done: 0, review: 0, active: 0, held: 0, decision: 0, queued: 0 };
+    ws.tasks.forEach(function (t) { visible[t.state] += 1; });
+    var declared = (ws.counts && typeof ws.counts === "object") ? ws.counts : null;
+    var counts = {};
+    STATES.forEach(function (k) {
+      counts[k] = declared ? (typeof declared[k] === "number" ? declared[k] : 0) : visible[k];
+    });
+    return { counts: counts, total: STATES.reduce(function (acc, k) { return acc + counts[k]; }, 0) };
+  }
+
+  var boardTasks = data.workstreams.reduce(function (acc, ws) { return acc + laneTally(ws).total; }, 0);
   var taskIndex = {};
   data.workstreams.forEach(function (ws) {
     ws.tasks.forEach(function (t) {
@@ -372,7 +388,7 @@ __FM_WORKSTREAM_BOARD_DATA__
   /* stat strip: clickable anchors into the board */
   var stats = [
     { n: data.workstreams.length, l: "workstreams", href: "#wb-streams" },
-    { n: allTasks.length, l: "tasks on the board", href: "#wb-streams" },
+    { n: boardTasks, l: "tasks on the board", href: "#wb-streams" },
     { n: liveAgents, l: "agents live", href: "#wb-agents" },
     { n: data.waiting.length, l: "waiting on you", href: "#wb-waiting", attn: data.waiting.length > 0 }
   ];
@@ -535,17 +551,8 @@ __FM_WORKSTREAM_BOARD_DATA__
     var head = el("div", "ws-head");
     var top = el("div", "ws-head-top");
     top.appendChild(el("h2", null, ws.name));
-    /* Row capping is a display bound: the bar, key, and badges report the
-       lane's declared totals, falling back to the visible rows only when the
-       composer sent no counts. */
-    var STATES = ["done", "review", "active", "held", "decision", "queued"];
-    var visible = { done: 0, review: 0, active: 0, held: 0, decision: 0, queued: 0 };
-    ws.tasks.forEach(function (t) { visible[t.state] += 1; });
-    var declared = (ws.counts && typeof ws.counts === "object") ? ws.counts : null;
-    var counts = {};
-    STATES.forEach(function (k) {
-      counts[k] = declared ? (typeof declared[k] === "number" ? declared[k] : 0) : visible[k];
-    });
+    var tally = laneTally(ws);
+    var counts = tally.counts;
     var held = counts.held;
     var decisions = counts.decision;
     var review = counts.review;
@@ -555,7 +562,7 @@ __FM_WORKSTREAM_BOARD_DATA__
     head.appendChild(top);
     if (ws.outcome) head.appendChild(el("p", "ws-outcome", ws.outcome));
 
-    var total = STATES.reduce(function (acc, k) { return acc + counts[k]; }, 0);
+    var total = tally.total;
     if (total > 0) {
       var bar = el("div", "ws-progress");
       /* held rides the active (gold) segment; decision gets its own rust pop */
@@ -661,7 +668,7 @@ __FM_WORKSTREAM_BOARD_DATA__
       body.appendChild(el("h3", null, "Done"));
       doneRows.forEach(function (t) { body.appendChild(taskRow(t)); });
     }
-    if (!ws.tasks.length) body.appendChild(el("p", "wb-empty", "No tasks are grouped here yet."));
+    if (!total) body.appendChild(el("p", "wb-empty", "No tasks are grouped here yet."));
     if (ws.more_tasks) body.appendChild(el("span", "wb-morechip", "+" + ws.more_tasks + " more - ask firstmate for the full list"));
     card.appendChild(body);
     streamsCol.appendChild(card);

--- a/.agents/skills/workstreams/assets/board-template.html
+++ b/.agents/skills/workstreams/assets/board-template.html
@@ -359,6 +359,12 @@ __FM_WORKSTREAM_BOARD_DATA__
   document.getElementById("wb-provenance").textContent = data.schema + " · " + data.generated;
 
   var allTasks = data.workstreams.reduce(function (acc, ws) { return acc.concat(ws.tasks); }, []);
+  var taskIndex = {};
+  data.workstreams.forEach(function (ws) {
+    ws.tasks.forEach(function (t) {
+      if (!taskIndex[t.id]) taskIndex[t.id] = { task: t, wsName: ws.name };
+    });
+  });
   var liveAgents = data.agents.length;
 
   /* stat strip: clickable anchors into the board */
@@ -417,18 +423,28 @@ __FM_WORKSTREAM_BOARD_DATA__
     decision: { fill: "#fbece3", stroke: "#a93a1f", text: "#8f2f17", dash: "" },
     queued:   { fill: "#fbf4e2", stroke: "#9c8a6c", text: "#3f3224", dash: "4 3" }
   };
-  function depGraph(tasks, edges, markerId) {
+  function depGraph(tasks, edges, markerId, index) {
     var ids = {};
     tasks.forEach(function (t) { ids[t.id] = t; });
-    var local = edges.filter(function (e) { return ids[e.from] && ids[e.to]; });
+    /* An edge is drawn when at least one endpoint sits in this card and the
+       other is a task the board knows, so a dependency that crosses two
+       workstreams stays visible from both of them. */
+    var local = edges.filter(function (e) {
+      return index[e.from] && index[e.to] && (ids[e.from] || ids[e.to]);
+    });
     if (!local.length) return null;
+    var nodes = [];
+    var seen = {};
+    function addNode(id) { if (!seen[id]) { seen[id] = true; nodes.push(index[id]); } }
+    tasks.forEach(function (t) { addNode(t.id); });
+    local.forEach(function (e) { addNode(e.from); addNode(e.to); });
     /* longest-path layering, bounded by node count so a cycle cannot spin */
     var layer = {};
-    tasks.forEach(function (t) { layer[t.id] = 0; });
-    for (var pass = 0; pass < tasks.length; pass++) {
+    nodes.forEach(function (n) { layer[n.task.id] = 0; });
+    for (var pass = 0; pass < nodes.length; pass++) {
       var changed = false;
       local.forEach(function (e) {
-        var want = Math.min(layer[e.from] + 1, tasks.length);
+        var want = Math.min(layer[e.from] + 1, nodes.length);
         if (layer[e.to] < want) { layer[e.to] = want; changed = true; }
       });
       if (!changed) break;
@@ -438,11 +454,11 @@ __FM_WORKSTREAM_BOARD_DATA__
     local.forEach(function (e) { touched[e.from] = true; touched[e.to] = true; });
     var cols = {};
     var maxLayer = 0;
-    tasks.forEach(function (t) {
-      if (!touched[t.id]) return;
-      var L = layer[t.id];
+    nodes.forEach(function (n) {
+      if (!touched[n.task.id]) return;
+      var L = layer[n.task.id];
       maxLayer = Math.max(maxLayer, L);
-      (cols[L] = cols[L] || []).push(t.id);
+      (cols[L] = cols[L] || []).push(n.task.id);
     });
     var W = 170, H = 26, GX = 70, GY = 10, PAD = 14;
     var pos = {};
@@ -471,10 +487,17 @@ __FM_WORKSTREAM_BOARD_DATA__
     });
     Object.keys(pos).forEach(function (id) {
       var p = pos[id];
-      var style = NODE_FILL[ids[id].state] || NODE_FILL.queued;
+      var node = index[id];
+      var style = NODE_FILL[node.task.state] || NODE_FILL.queued;
       var attrs = { x: p.x, y: p.y, width: W, height: H, rx: 7, fill: style.fill, stroke: style.stroke, "stroke-width": "1.5" };
       if (style.dash) attrs["stroke-dasharray"] = style.dash;
-      svg.appendChild(svgEl("rect", attrs));
+      var rect = svgEl("rect", attrs);
+      var rectTitle = svgEl("title", {});
+      rectTitle.textContent = ids[id]
+        ? id + " · " + node.task.state
+        : id + " · " + node.task.state + " · in " + node.wsName;
+      rect.appendChild(rectTitle);
+      svg.appendChild(rect);
       var label = id.length > 22 ? id.slice(0, 21) + "…" : id;
       var text = svgEl("text", {
         x: p.x + W / 2, y: p.y + H / 2 + 4, "text-anchor": "middle",
@@ -501,18 +524,27 @@ __FM_WORKSTREAM_BOARD_DATA__
     var head = el("div", "ws-head");
     var top = el("div", "ws-head-top");
     top.appendChild(el("h2", null, ws.name));
-    var held = ws.tasks.filter(function (t) { return t.state === "held"; }).length;
-    var decisions = ws.tasks.filter(function (t) { return t.state === "decision"; }).length;
-    var review = ws.tasks.filter(function (t) { return t.state === "review"; }).length;
+    /* Row capping is a display bound: the bar, key, and badges report the
+       lane's declared totals, falling back to the visible rows only when the
+       composer sent no counts. */
+    var STATES = ["done", "review", "active", "held", "decision", "queued"];
+    var visible = { done: 0, review: 0, active: 0, held: 0, decision: 0, queued: 0 };
+    ws.tasks.forEach(function (t) { visible[t.state] += 1; });
+    var declared = (ws.counts && typeof ws.counts === "object") ? ws.counts : null;
+    var counts = {};
+    STATES.forEach(function (k) {
+      counts[k] = declared ? (typeof declared[k] === "number" ? declared[k] : 0) : visible[k];
+    });
+    var held = counts.held;
+    var decisions = counts.decision;
+    var review = counts.review;
     if (decisions) top.appendChild(badge("danger", decisions + " need" + (decisions === 1 ? "s" : "") + " your decision"));
     if (held) top.appendChild(badge("warn", held + " held"));
     if (review) top.appendChild(badge("info", review + " in review"));
     head.appendChild(top);
     if (ws.outcome) head.appendChild(el("p", "ws-outcome", ws.outcome));
 
-    var counts = { done: 0, review: 0, active: 0, held: 0, decision: 0, queued: 0 };
-    ws.tasks.forEach(function (t) { counts[t.state] += 1; });
-    var total = ws.tasks.length + (ws.more_tasks || 0);
+    var total = STATES.reduce(function (acc, k) { return acc + counts[k]; }, 0);
     if (total > 0) {
       var bar = el("div", "ws-progress");
       /* held rides the active (gold) segment; decision gets its own rust pop */
@@ -542,7 +574,7 @@ __FM_WORKSTREAM_BOARD_DATA__
     card.appendChild(head);
 
     var body = el("div", "ws-body");
-    var graph = depGraph(ws.tasks, data.edges, "wb-arr-" + ws.id);
+    var graph = depGraph(ws.tasks, data.edges, "wb-arr-" + ws.id, taskIndex);
     if (graph) {
       body.appendChild(el("h3", null, "Dependency graph"));
       var fig = el("div", "ws-fig");
@@ -560,7 +592,9 @@ __FM_WORKSTREAM_BOARD_DATA__
         "wb-trow" + (t.state === "held" ? " wb-trow--held" : "") + (t.state === "decision" ? " wb-trow--decision" : ""));
       var sum = el(expandable ? "summary" : "div", "wb-trow__sum");
       sum.appendChild(el("span", "wb-trow__id", t.id));
-      sum.appendChild(el("span", "wb-trow__t", t.title));
+      var titleSpan = el("span", "wb-trow__t", t.title);
+      titleSpan.setAttribute("title", t.title);
+      sum.appendChild(titleSpan);
       if (t.agent) sum.appendChild(agentChip(t.agent, t.agent_tone || "paused"));
       row.appendChild(sum);
       if (expandable) {

--- a/.agents/skills/workstreams/assets/board-template.html
+++ b/.agents/skills/workstreams/assets/board-template.html
@@ -164,6 +164,8 @@ a { color: inherit; text-decoration: none; }
 .ws-key { display: flex; gap: 14px; flex-wrap: wrap; font-size: var(--fs-2xs); color: var(--text-muted); margin-top: 6px; font-weight: 600; }
 .ws-key i { display: inline-block; width: 10px; height: 10px; border-radius: 3px; border: 1px solid var(--ink-900); margin-right: 5px; vertical-align: -1px; }
 .ws-key i.ws-seg--queued { background: var(--paper-200); }
+.ws-key i.ws-seg--cross { background: var(--paper-200); opacity: 0.5; }
+.ws-key--cross { margin-top: 8px; }
 .ws-body { padding: 16px 20px 20px; }
 .ws-body h3 { font-size: var(--fs-2xs); font-weight: 800; text-transform: uppercase; letter-spacing: var(--ls-caps); color: var(--text-faint); margin: 18px 0 8px; }
 .ws-body h3:first-child { margin-top: 0; }
@@ -471,8 +473,14 @@ __FM_WORKSTREAM_BOARD_DATA__
     });
     var width = PAD * 2 + (maxLayer + 1) * W + maxLayer * GX;
     var height = PAD * 2 + maxRows * H + (maxRows - 1) * GY;
+    var foreign = Object.keys(pos)
+      .filter(function (id) { return !ids[id]; })
+      .map(function (id) { return { id: id, wsName: index[id].wsName }; });
     var svg = svgEl("svg", { viewBox: "0 0 " + width + " " + height, role: "img" });
-    svg.setAttribute("aria-label", "Dependency graph");
+    svg.setAttribute("aria-label", foreign.length
+      ? "Dependency graph, including " + foreign.length + " task" + (foreign.length === 1 ? "" : "s")
+        + " from other workstreams: " + foreign.map(function (f) { return f.id + " in " + f.wsName; }).join(", ")
+      : "Dependency graph");
     var defs = svgEl("defs", {});
     var marker = svgEl("marker", { id: markerId, viewBox: "0 0 8 8", refX: "7", refY: "4", markerWidth: "7", markerHeight: "7", orient: "auto" });
     marker.appendChild(svgEl("path", { d: "M0,0 L8,4 L0,8 z", fill: "#9c8a6c" }));
@@ -491,6 +499,7 @@ __FM_WORKSTREAM_BOARD_DATA__
       var style = NODE_FILL[node.task.state] || NODE_FILL.queued;
       var attrs = { x: p.x, y: p.y, width: W, height: H, rx: 7, fill: style.fill, stroke: style.stroke, "stroke-width": "1.5" };
       if (style.dash) attrs["stroke-dasharray"] = style.dash;
+      if (!ids[id]) attrs.opacity = "0.5";
       var rect = svgEl("rect", attrs);
       var rectTitle = svgEl("title", {});
       rectTitle.textContent = ids[id]
@@ -499,14 +508,16 @@ __FM_WORKSTREAM_BOARD_DATA__
       rect.appendChild(rectTitle);
       svg.appendChild(rect);
       var label = id.length > 22 ? id.slice(0, 21) + "…" : id;
-      var text = svgEl("text", {
+      var textAttrs = {
         x: p.x + W / 2, y: p.y + H / 2 + 4, "text-anchor": "middle",
         "font-family": "JetBrains Mono,monospace", "font-size": "11", fill: style.text
-      });
+      };
+      if (!ids[id]) textAttrs.opacity = "0.5";
+      var text = svgEl("text", textAttrs);
       text.textContent = label;
       svg.appendChild(text);
     });
-    return svg;
+    return { svg: svg, foreign: foreign };
   }
 
   /* ---- workstream cards ---- */
@@ -578,8 +589,18 @@ __FM_WORKSTREAM_BOARD_DATA__
     if (graph) {
       body.appendChild(el("h3", null, "Dependency graph"));
       var fig = el("div", "ws-fig");
-      fig.appendChild(graph);
+      fig.appendChild(graph.svg);
       body.appendChild(fig);
+      if (graph.foreign.length) {
+        var crossKey = el("div", "ws-key ws-key--cross");
+        graph.foreign.forEach(function (f) {
+          var item = el("span");
+          item.appendChild(el("i", "ws-seg--cross"));
+          item.appendChild(document.createTextNode(f.id + " - in " + f.wsName));
+          crossKey.appendChild(item);
+        });
+        body.appendChild(crossKey);
+      }
     }
 
     var moving = ws.tasks.filter(function (t) { return t.state !== "queued" && t.state !== "done"; });

--- a/.agents/skills/workstreams/assets/board-template.html
+++ b/.agents/skills/workstreams/assets/board-template.html
@@ -1,0 +1,721 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Workstreams - captain's board</title>
+<style>
+/* ============================================================
+   Workstream board - Firstmate Design System, inlined for portability.
+   Tokens copied verbatim from myfirstmate priv/static/assets/app.css
+   (the compiled adoption of .agents/skills/firstmate-design), matching the
+   bearings board template and the captain-approved mockup.
+   ============================================================ */
+@import url("https://fonts.googleapis.com/css2?family=Chango&family=Jost:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap");
+
+:root {
+  --rust-700: #8f2f17; --rust-600: #a93a1f; --rust-500: #c0452a;
+  --rust-400: #d35f3f; --rust-300: #e08365; --rust-100: #f4d8c9; --rust-050: #fbece3;
+  --navy-700: #1a2238; --navy-600: #222c49; --navy-500: #2a3656;
+  --navy-300: #6c7796; --navy-100: #d9deea;
+  --gold-600: #b5791c; --gold-500: #e0a52e; --gold-300: #f0d38c; --gold-100: #f8ecc9;
+  --ocean-600: #2f6688; --ocean-500: #3c7ea6; --ocean-200: #b6d4e2; --ocean-050: #e8f1f5;
+  --sea-700: #234e3a; --sea-500: #2f6b4f; --sea-200: #b9d4c5; --sea-050: #e9f2ec;
+  --paper-000: #fbf4e2; --paper-100: #f6ecd3; --paper-200: #f0e3c4; --paper-300: #e7d6ae;
+  --cream-line: #ddc89c;
+  --ink-900: #241c14; --ink-700: #3f3224; --ink-500: #6f5e46; --ink-300: #9c8a6c;
+  --white: #fffdf7;
+  --bg-page: var(--paper-100);
+  --surface-card: var(--white);
+  --surface-card-warm: var(--paper-000);
+  --text-strong: var(--ink-900); --text-body: var(--ink-700);
+  --text-muted: var(--ink-500); --text-faint: var(--ink-300);
+  --border-default: var(--cream-line); --border-soft: var(--paper-300);
+  --status-online: var(--sea-500); --status-online-soft: var(--sea-050);
+  --status-warn: var(--gold-600); --status-warn-soft: var(--gold-100);
+  --status-danger: var(--rust-600); --status-danger-soft: var(--rust-050);
+  --status-info: var(--ocean-500); --status-info-soft: var(--ocean-050);
+  --font-display: "Chango", "Cooper Black", Rockwell, Georgia, serif;
+  --font-sans: "Jost", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --fs-h3: 1.4rem; --fs-h4: 1.15rem; --fs-base: 1rem; --fs-sm: 0.9375rem;
+  --fs-xs: 0.8125rem; --fs-2xs: 0.6875rem;
+  --ls-caps: 0.16em;
+  --radius-xs: 6px; --radius-sm: 9px; --radius-md: 12px; --radius-banner: 7px;
+  --radius-lg: 18px; --radius-pill: 999px;
+  --shadow-sm: 0 1px 2px rgba(36, 28, 20, 0.06), 0 4px 10px rgba(36, 28, 20, 0.06);
+  --shadow-hard: 4px 4px 0 var(--ink-900);
+  --shadow-hard-sm: 3px 3px 0 var(--ink-900);
+  --texture-paper: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.045'/%3E%3C/svg%3E");
+  --focus-ring: 0 0 0 3px var(--gold-300);
+  --container-app: 1180px;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--font-sans);
+  color: var(--text-body);
+  background: var(--bg-page);
+  background-image: var(--texture-paper);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: inherit; text-decoration: none; }
+
+/* ---- fm primitives (verbatim contracts) ---- */
+.fm-badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: var(--fs-2xs); font-weight: 800; line-height: 1;
+  padding: 5px 9px 4px; text-transform: uppercase; letter-spacing: 0.07em;
+  border-radius: var(--radius-xs); border: 1.5px solid var(--ink-900);
+  box-shadow: 2px 2px 0 var(--ink-900); white-space: nowrap;
+}
+.fm-badge--online  { background: var(--sea-500);  color: var(--paper-000); }
+.fm-badge--warn    { background: var(--gold-500); color: var(--navy-700); }
+.fm-badge--danger  { background: var(--rust-600); color: var(--paper-000); }
+.fm-badge--info    { background: var(--ocean-500); color: var(--paper-000); }
+.fm-badge--neutral { background: var(--paper-000); color: var(--ink-900); }
+
+.fm-btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  font-family: var(--font-sans); font-weight: 800; line-height: 1; white-space: nowrap;
+  border: 2px solid transparent; border-radius: var(--radius-banner); cursor: pointer;
+  text-decoration: none; transition: background 120ms, border-color 120ms, transform 120ms, box-shadow 120ms;
+}
+.fm-btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+.fm-btn:active { transform: translateY(1px); }
+.fm-btn--sm { font-size: var(--fs-xs); padding: 8px 16px; }
+.fm-btn--gold { background: var(--gold-500); color: var(--navy-700); border-color: var(--ink-900); box-shadow: var(--shadow-hard-sm); }
+.fm-btn--gold:hover { background: var(--gold-600); color: var(--white); }
+.fm-btn[disabled] { opacity: 0.5; cursor: not-allowed; }
+
+.fm-card {
+  background: var(--surface-card); border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); overflow: hidden;
+  min-width: 0;
+}
+
+/* ---- page chrome (wb-*) ---- */
+.wb-nav {
+  position: sticky; top: 0; z-index: 20;
+  background: color-mix(in srgb, var(--paper-100) 86%, transparent);
+  backdrop-filter: saturate(150%) blur(10px);
+  border-bottom: 1px solid var(--border-default);
+}
+.wb-nav__inner {
+  max-width: var(--container-app); margin: 0 auto; padding: 0 28px; height: 64px;
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+}
+.wb-brand { display: inline-flex; align-items: center; gap: 12px; }
+.wb-brand__disc {
+  display: grid; place-items: center; width: 34px; height: 34px; flex: none;
+  border-radius: 999px; background: var(--rust-500); color: var(--paper-000);
+  border: 2px solid var(--ink-900); box-shadow: var(--shadow-hard-sm);
+}
+.wb-brand__disc svg { width: 60%; height: 60%; }
+.wb-brand__wm { font-family: var(--font-display); font-size: 23px; color: var(--text-strong); line-height: 1; }
+.wb-meta-mono { font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--text-faint); white-space: nowrap; }
+
+.wb-main {
+  max-width: var(--container-app); margin: 0 auto;
+  padding: 26px 28px 72px; display: flex; flex-direction: column; gap: 22px;
+}
+
+/* stat strip: clickable anchor tiles */
+.wb-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; }
+.wb-stat {
+  display: flex; flex-direction: column; gap: 4px; padding: 14px 16px; min-width: 0;
+  background: var(--surface-card-warm); border: 1px solid var(--border-soft); border-radius: var(--radius-md);
+  cursor: pointer; transition: transform 120ms, box-shadow 120ms;
+}
+.wb-stat:hover { transform: translateY(-2px); box-shadow: var(--shadow-hard-sm); }
+.wb-stat--attn { background: var(--rust-050); border: 2px solid var(--rust-500); }
+.wb-stat--warn { background: var(--status-warn-soft); border: 2px solid var(--gold-500); }
+.wb-stat__num { font-family: var(--font-mono); font-size: var(--fs-h3); font-weight: 600; line-height: 1; color: var(--text-strong); }
+.wb-stat--attn .wb-stat__num { color: var(--rust-600); }
+.wb-stat__label { font-family: var(--font-mono); font-size: var(--fs-2xs); letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-muted); }
+
+/* board ≠ reality callout */
+.wb-callout {
+  background: var(--status-danger-soft); border: 1.5px solid var(--rust-300);
+  border-radius: var(--radius-md); padding: 12px 16px; font-size: var(--fs-sm);
+}
+.wb-callout b { color: var(--rust-600); }
+.wb-callout__row { margin: 4px 0 0; }
+.wb-callout__id { font-family: var(--font-mono); font-size: var(--fs-2xs); color: var(--text-muted); margin-right: 6px; }
+
+/* two-column layout */
+.wb-cols { display: grid; grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr); gap: 22px; align-items: start; }
+@media (max-width: 900px) { .wb-cols { grid-template-columns: minmax(0, 1fr); } }
+.wb-col { display: flex; flex-direction: column; gap: 22px; min-width: 0; }
+
+/* workstream card */
+.ws-head { padding: 16px 20px 12px; border-bottom: 1px solid var(--border-soft); background: var(--surface-card-warm); }
+.ws-head-top { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.ws-head h2 { font-family: var(--font-display); font-size: var(--fs-h4); color: var(--text-strong); margin: 0; }
+.ws-outcome { font-size: var(--fs-sm); color: var(--text-muted); margin: 4px 0 10px; }
+.ws-progress { display: flex; height: 14px; border-radius: var(--radius-pill); overflow: hidden; border: 1.5px solid var(--ink-900); background: var(--paper-200); }
+.ws-progress span { display: block; height: 100%; }
+.ws-seg--done { background: var(--sea-500); }
+.ws-seg--review { background: var(--ocean-500); }
+.ws-seg--active { background: var(--gold-500); }
+.ws-seg--decision { background: var(--rust-500); }
+.ws-key { display: flex; gap: 14px; flex-wrap: wrap; font-size: var(--fs-2xs); color: var(--text-muted); margin-top: 6px; font-weight: 600; }
+.ws-key i { display: inline-block; width: 10px; height: 10px; border-radius: 3px; border: 1px solid var(--ink-900); margin-right: 5px; vertical-align: -1px; }
+.ws-key i.ws-seg--queued { background: var(--paper-200); }
+.ws-body { padding: 16px 20px 20px; }
+.ws-body h3 { font-size: var(--fs-2xs); font-weight: 800; text-transform: uppercase; letter-spacing: var(--ls-caps); color: var(--text-faint); margin: 18px 0 8px; }
+.ws-body h3:first-child { margin-top: 0; }
+
+/* dependency graph */
+.ws-fig { width: 100%; overflow-x: auto; }
+.ws-fig svg { display: block; height: auto; min-width: 480px; max-width: 100%; }
+
+/* task rows */
+.wb-trow { display: block; border: 1px solid var(--border-soft); border-radius: var(--radius-sm); margin-bottom: 6px; background: var(--surface-card); min-width: 0; }
+.wb-trow__sum { display: flex; align-items: center; gap: 10px; padding: 8px 10px; min-width: 0; list-style: none; }
+details.wb-trow > summary { cursor: pointer; }
+details.wb-trow > summary::-webkit-details-marker { display: none; }
+details.wb-trow > summary::after { content: "▸"; color: var(--text-faint); flex: none; font-size: var(--fs-xs); }
+details.wb-trow[open] > summary::after { content: "▾"; }
+.wb-trow__id { font-family: var(--font-mono); font-size: var(--fs-2xs); color: var(--text-muted); flex: none; }
+.wb-trow__t { font-size: var(--fs-sm); color: var(--text-body); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1 1 auto; }
+.wb-trow--held { background: var(--status-warn-soft); border-color: var(--gold-300); }
+.wb-trow--decision { background: var(--status-danger-soft); border-color: var(--rust-300); }
+.wb-trow__detail { padding: 2px 14px 12px; border-top: 1px dashed var(--border-soft); font-size: var(--fs-xs); }
+.wb-fld { margin-top: 8px; }
+.wb-fld b { display: block; font-size: var(--fs-2xs); font-weight: 800; text-transform: uppercase; letter-spacing: var(--ls-caps); color: var(--text-faint); }
+.wb-fld span, .wb-fld a { color: var(--text-body); overflow-wrap: anywhere; }
+.wb-fld a { color: var(--ocean-600); font-family: var(--font-mono); font-size: var(--fs-2xs); }
+.wb-fld a:hover { text-decoration: underline; }
+.wb-morechip {
+  display: inline-flex; align-items: center; gap: 6px; margin-top: 4px;
+  font-size: var(--fs-xs); font-weight: 800; color: var(--text-muted);
+  border: 1.5px dashed var(--ink-300); border-radius: var(--radius-pill); padding: 5px 12px; width: fit-content;
+}
+.wb-empty { font-size: var(--fs-sm); color: var(--text-muted); }
+
+/* agent chip */
+.wb-agent {
+  display: inline-flex; align-items: center; gap: 6px; flex: none;
+  font-family: var(--font-mono); font-size: var(--fs-2xs); font-weight: 700;
+  border: 1.5px solid var(--ink-900); border-radius: var(--radius-pill);
+  padding: 3px 9px 3px 5px; background: var(--white); box-shadow: 2px 2px 0 var(--ink-900);
+  max-width: 100%; min-width: 0;
+}
+.wb-agent__label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wb-dot { width: 8px; height: 8px; border-radius: 50%; border: 1px solid var(--ink-900); flex: none; }
+.wb-dot--working { background: var(--sea-500); animation: wb-pulse 1.6s infinite; }
+.wb-dot--paused { background: var(--gold-500); }
+.wb-dot--decision { background: var(--rust-600); animation: wb-pulse 1.6s infinite; }
+@keyframes wb-pulse { 50% { opacity: 0.35; } }
+
+/* right rail */
+.wb-rail-item { padding: 12px 16px; border-bottom: 1px solid var(--border-soft); font-size: var(--fs-sm); }
+.wb-rail-item:last-child { border-bottom: none; }
+.wb-rail-item .wb-k { font-family: var(--font-mono); font-size: var(--fs-2xs); color: var(--text-muted); }
+.wb-rail-item p { margin: 4px 0 0; color: var(--text-body); }
+
+/* waiting-on-you answer forms */
+.wb-qform { margin-top: 8px; }
+.wb-qform label { display: flex; gap: 8px; align-items: flex-start; font-size: var(--fs-xs); margin: 4px 0; color: var(--text-body); cursor: pointer; }
+.wb-qform input[type="radio"] { accent-color: var(--rust-500); margin-top: 2px; flex: none; }
+.wb-opt__hint { display: block; color: var(--text-muted); }
+.wb-opt__rec { font-weight: 800; color: var(--gold-600); }
+.wb-freeform { width: 100%; font-family: var(--font-sans); font-size: var(--fs-xs); color: var(--text-strong);
+  background: var(--surface-card); border: 1.5px solid var(--border-default); border-radius: var(--radius-sm); padding: 7px 10px; margin-top: 4px; }
+.wb-freeform:focus { outline: none; border-color: var(--rust-400); box-shadow: var(--focus-ring); }
+.wb-qfoot { display: flex; align-items: center; gap: 8px; margin-top: 6px; flex-wrap: wrap; }
+.wb-queued {
+  display: none; align-items: center; gap: 6px;
+  font-size: var(--fs-2xs); font-weight: 800; text-transform: uppercase; letter-spacing: 0.07em;
+  color: var(--sea-700); background: var(--sea-050); border: 1.5px solid var(--sea-200);
+  border-radius: var(--radius-xs); padding: 5px 9px 4px;
+}
+.is-queued .wb-queued { display: inline-flex; }
+.wb-limit { display: none; font-size: var(--fs-xs); font-weight: 700; color: var(--status-danger); }
+.wb-limit.is-visible { display: inline; }
+.wb-rail-note { font-size: var(--fs-2xs); color: var(--text-muted); }
+
+.wb-foot { display: flex; justify-content: flex-end; border-top: 1px solid var(--border-default); padding-top: 14px; }
+</style>
+</head>
+<body>
+
+<header class="wb-nav">
+  <div class="wb-nav__inner">
+    <span class="wb-brand">
+      <span class="wb-brand__disc">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M3 12h4l3-8 4 16 3-8h4"/>
+        </svg>
+      </span>
+      <span class="wb-brand__wm">workstreams</span>
+    </span>
+    <span class="wb-meta-mono" id="wb-home">-</span>
+  </div>
+</header>
+
+<main class="wb-main">
+
+  <div class="wb-stats" id="wb-stats"></div>
+
+  <div class="wb-callout" id="wb-divergence" hidden></div>
+
+  <div class="wb-cols">
+    <div class="wb-col" id="wb-streams"></div>
+    <div class="wb-col">
+      <section class="fm-card" id="wb-waiting">
+        <div class="ws-head"><div class="ws-head-top"><h2>Waiting on you</h2><span class="fm-badge fm-badge--danger" id="wb-waiting-count">0</span></div></div>
+        <div id="wb-waiting-items"></div>
+      </section>
+      <section class="fm-card" id="wb-agents">
+        <div class="ws-head"><div class="ws-head-top"><h2>Agents right now</h2><span class="fm-badge fm-badge--online" id="wb-agents-count">0</span></div></div>
+        <div id="wb-agents-items"></div>
+      </section>
+    </div>
+  </div>
+
+  <footer class="wb-foot">
+    <span class="wb-meta-mono" id="wb-provenance">-</span>
+  </footer>
+
+</main>
+
+<!-- ONE SLOT. bin/fm-workstream-board.sh build injects the fresh
+     fm-workstream-board.v1 payload in place of the placeholder below;
+     everything above and below is the shipped template and is never
+     regenerated per run. -->
+<script id="workstream-data" type="application/json">
+__FM_WORKSTREAM_BOARD_DATA__
+</script>
+
+<script>
+(function () {
+  "use strict";
+
+  /* Fail closed: a board with unreadable or wrong-schema data says so plainly
+     instead of rendering an empty page that looks like an empty fleet. */
+  function renderBoardError(msg) {
+    var main = document.querySelector(".wb-main");
+    main.innerHTML = "";
+    var card = document.createElement("div");
+    card.className = "fm-card";
+    var pad = document.createElement("div");
+    pad.className = "ws-head";
+    var h = document.createElement("h2");
+    h.textContent = "This board could not load";
+    var d = document.createElement("p");
+    d.className = "ws-outcome";
+    d.textContent = msg + " - ask firstmate to rebuild the board.";
+    pad.appendChild(h);
+    pad.appendChild(d);
+    card.appendChild(pad);
+    main.appendChild(card);
+  }
+
+  var data;
+  try {
+    data = JSON.parse(document.getElementById("workstream-data").textContent);
+  } catch (e) {
+    renderBoardError("The board data is not valid JSON");
+    return;
+  }
+  if (!data || data.schema !== "fm-workstream-board.v1") {
+    renderBoardError("Unsupported board data schema: " + (data && data.schema ? data.schema : "(none)"));
+    return;
+  }
+  var lists = [data.workstreams, data.edges, data.waiting, data.agents, data.divergence];
+  var streamsValid = Array.isArray(data.workstreams) && data.workstreams.every(function (ws) {
+    return ws && typeof ws === "object" &&
+      typeof ws.id === "string" && ws.id.length > 0 &&
+      typeof ws.name === "string" && ws.name.length > 0 &&
+      Array.isArray(ws.tasks);
+  });
+  var waitingValid = Array.isArray(data.waiting) && data.waiting.every(function (item) {
+    return item && typeof item === "object" &&
+      typeof item.key === "string" && item.key.length > 0 &&
+      typeof item.title === "string" && item.title.length > 0 &&
+      Array.isArray(item.options);
+  });
+  if (!lists.every(Array.isArray) || !streamsValid || !waitingValid) {
+    renderBoardError("The board data does not have the required structure");
+    return;
+  }
+
+  try {
+  function el(tag, cls, text) {
+    var n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (text != null) n.textContent = text;
+    return n;
+  }
+  function badge(tone, text) { return el("span", "fm-badge fm-badge--" + tone, text); }
+  function utf8ByteLength(text) { return new TextEncoder().encode(text).length; }
+  var CHECK_SVG = '<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>';
+
+  document.getElementById("wb-home").textContent = data.home;
+  document.getElementById("wb-provenance").textContent = data.schema + " · " + data.generated;
+
+  var allTasks = data.workstreams.reduce(function (acc, ws) { return acc.concat(ws.tasks); }, []);
+  var liveAgents = data.agents.length;
+
+  /* stat strip: clickable anchors into the board */
+  var stats = [
+    { n: data.workstreams.length, l: "workstreams", href: "#wb-streams" },
+    { n: allTasks.length, l: "tasks on the board", href: "#wb-streams" },
+    { n: liveAgents, l: "agents live", href: "#wb-agents" },
+    { n: data.waiting.length, l: "waiting on you", href: "#wb-waiting", attn: data.waiting.length > 0 }
+  ];
+  if (data.divergence.length) {
+    stats.push({ n: data.divergence.length, l: "board ≠ reality", href: "#wb-divergence", warn: true });
+  }
+  var strip = document.getElementById("wb-stats");
+  stats.forEach(function (s) {
+    var t = el("a", "wb-stat" + (s.attn ? " wb-stat--attn" : "") + (s.warn ? " wb-stat--warn" : ""));
+    t.setAttribute("href", s.href);
+    t.appendChild(el("span", "wb-stat__num", String(s.n)));
+    t.appendChild(el("span", "wb-stat__label", s.l));
+    strip.appendChild(t);
+  });
+
+  /* board ≠ reality callout */
+  var dv = document.getElementById("wb-divergence");
+  dv.hidden = !data.divergence.length;
+  if (data.divergence.length) {
+    dv.appendChild(el("b", null, "Board ≠ reality: "));
+    dv.appendChild(el("span", null, "the backlog and the live fleet disagree on " + data.divergence.length + " task" + (data.divergence.length === 1 ? "" : "s") + "."));
+    data.divergence.forEach(function (d) {
+      var row = el("div", "wb-callout__row");
+      row.appendChild(el("span", "wb-callout__id", d.id));
+      row.appendChild(el("span", null, d.note));
+      dv.appendChild(row);
+    });
+  }
+
+  /* agent chip: dot tone from the composer-declared tone */
+  function agentChip(label, tone) {
+    var chip = el("span", "wb-agent");
+    chip.appendChild(el("span", "wb-dot wb-dot--" + tone));
+    chip.appendChild(el("span", "wb-agent__label", label));
+    return chip;
+  }
+
+  /* ---- dependency graph: layered inline SVG from blocked-by edges ---- */
+  var SVG_NS = "http://www.w3.org/2000/svg";
+  function svgEl(tag, attrs) {
+    var n = document.createElementNS(SVG_NS, tag);
+    Object.keys(attrs || {}).forEach(function (k) { n.setAttribute(k, attrs[k]); });
+    return n;
+  }
+  var NODE_FILL = {
+    done:     { fill: "#e9f2ec", stroke: "#2f6b4f", text: "#234e3a", dash: "" },
+    review:   { fill: "#e8f1f5", stroke: "#3c7ea6", text: "#2f6688", dash: "" },
+    active:   { fill: "#f8ecc9", stroke: "#b5791c", text: "#3f3224", dash: "" },
+    held:     { fill: "#f8ecc9", stroke: "#b5791c", text: "#3f3224", dash: "4 3" },
+    decision: { fill: "#fbece3", stroke: "#a93a1f", text: "#8f2f17", dash: "" },
+    queued:   { fill: "#fbf4e2", stroke: "#9c8a6c", text: "#3f3224", dash: "4 3" }
+  };
+  function depGraph(tasks, edges, markerId) {
+    var ids = {};
+    tasks.forEach(function (t) { ids[t.id] = t; });
+    var local = edges.filter(function (e) { return ids[e.from] && ids[e.to]; });
+    if (!local.length) return null;
+    /* longest-path layering, bounded by node count so a cycle cannot spin */
+    var layer = {};
+    tasks.forEach(function (t) { layer[t.id] = 0; });
+    for (var pass = 0; pass < tasks.length; pass++) {
+      var changed = false;
+      local.forEach(function (e) {
+        var want = Math.min(layer[e.from] + 1, tasks.length);
+        if (layer[e.to] < want) { layer[e.to] = want; changed = true; }
+      });
+      if (!changed) break;
+    }
+    /* only nodes that touch an edge are drawn; isolated rows stay list-only */
+    var touched = {};
+    local.forEach(function (e) { touched[e.from] = true; touched[e.to] = true; });
+    var cols = {};
+    var maxLayer = 0;
+    tasks.forEach(function (t) {
+      if (!touched[t.id]) return;
+      var L = layer[t.id];
+      maxLayer = Math.max(maxLayer, L);
+      (cols[L] = cols[L] || []).push(t.id);
+    });
+    var W = 170, H = 26, GX = 70, GY = 10, PAD = 14;
+    var pos = {};
+    var maxRows = 0;
+    Object.keys(cols).forEach(function (L) {
+      cols[L].forEach(function (id, i) {
+        pos[id] = { x: PAD + L * (W + GX), y: PAD + i * (H + GY) };
+      });
+      maxRows = Math.max(maxRows, cols[L].length);
+    });
+    var width = PAD * 2 + (maxLayer + 1) * W + maxLayer * GX;
+    var height = PAD * 2 + maxRows * H + (maxRows - 1) * GY;
+    var svg = svgEl("svg", { viewBox: "0 0 " + width + " " + height, role: "img" });
+    svg.setAttribute("aria-label", "Dependency graph");
+    var defs = svgEl("defs", {});
+    var marker = svgEl("marker", { id: markerId, viewBox: "0 0 8 8", refX: "7", refY: "4", markerWidth: "7", markerHeight: "7", orient: "auto" });
+    marker.appendChild(svgEl("path", { d: "M0,0 L8,4 L0,8 z", fill: "#9c8a6c" }));
+    defs.appendChild(marker);
+    svg.appendChild(defs);
+    local.forEach(function (e) {
+      var a = pos[e.from], b = pos[e.to];
+      svg.appendChild(svgEl("line", {
+        x1: a.x + W, y1: a.y + H / 2, x2: b.x - 4, y2: b.y + H / 2,
+        stroke: "#9c8a6c", "stroke-width": "1.5", "marker-end": "url(#" + markerId + ")"
+      }));
+    });
+    Object.keys(pos).forEach(function (id) {
+      var p = pos[id];
+      var style = NODE_FILL[ids[id].state] || NODE_FILL.queued;
+      var attrs = { x: p.x, y: p.y, width: W, height: H, rx: 7, fill: style.fill, stroke: style.stroke, "stroke-width": "1.5" };
+      if (style.dash) attrs["stroke-dasharray"] = style.dash;
+      svg.appendChild(svgEl("rect", attrs));
+      var label = id.length > 22 ? id.slice(0, 21) + "…" : id;
+      var text = svgEl("text", {
+        x: p.x + W / 2, y: p.y + H / 2 + 4, "text-anchor": "middle",
+        "font-family": "JetBrains Mono,monospace", "font-size": "11", fill: style.text
+      });
+      text.textContent = label;
+      svg.appendChild(text);
+    });
+    return svg;
+  }
+
+  /* ---- workstream cards ---- */
+  var streamsCol = document.getElementById("wb-streams");
+  if (!data.workstreams.length) {
+    var emptyCard = el("section", "fm-card");
+    var emptyPad = el("div", "ws-head");
+    emptyPad.appendChild(el("p", "wb-empty", "No workstreams are on the board, captain - nothing is grouped yet."));
+    emptyCard.appendChild(emptyPad);
+    streamsCol.appendChild(emptyCard);
+  }
+  data.workstreams.forEach(function (ws) {
+    var card = el("section", "fm-card");
+    card.id = "ws-" + ws.id;
+    var head = el("div", "ws-head");
+    var top = el("div", "ws-head-top");
+    top.appendChild(el("h2", null, ws.name));
+    var held = ws.tasks.filter(function (t) { return t.state === "held"; }).length;
+    var decisions = ws.tasks.filter(function (t) { return t.state === "decision"; }).length;
+    var review = ws.tasks.filter(function (t) { return t.state === "review"; }).length;
+    if (decisions) top.appendChild(badge("danger", decisions + " need" + (decisions === 1 ? "s" : "") + " your decision"));
+    if (held) top.appendChild(badge("warn", held + " held"));
+    if (review) top.appendChild(badge("info", review + " in review"));
+    head.appendChild(top);
+    if (ws.outcome) head.appendChild(el("p", "ws-outcome", ws.outcome));
+
+    var counts = { done: 0, review: 0, active: 0, held: 0, decision: 0, queued: 0 };
+    ws.tasks.forEach(function (t) { counts[t.state] += 1; });
+    var total = ws.tasks.length + (ws.more_tasks || 0);
+    if (total > 0) {
+      var bar = el("div", "ws-progress");
+      /* held rides the active (gold) segment; decision gets its own rust pop */
+      var segCounts = { done: counts.done, review: counts.review,
+                        active: counts.active + counts.held, decision: counts.decision };
+      [["done", "ws-seg--done"], ["review", "ws-seg--review"],
+       ["active", "ws-seg--active"], ["decision", "ws-seg--decision"]].forEach(function (seg) {
+        var n = segCounts[seg[0]];
+        if (!n) return;
+        var span = el("span", seg[1]);
+        span.style.width = (n * 100 / total) + "%";
+        bar.appendChild(span);
+      });
+      head.appendChild(bar);
+      var key = el("div", "ws-key");
+      [["done", "ws-seg--done"], ["review", "ws-seg--review"], ["active", "ws-seg--active"],
+       ["held", "ws-seg--active"], ["decision", "ws-seg--decision"], ["queued", "ws-seg--queued"]].forEach(function (seg) {
+        var n = counts[seg[0]];
+        if (!n) return;
+        var item = el("span");
+        item.appendChild(el("i", seg[1]));
+        item.appendChild(document.createTextNode(n + " " + seg[0]));
+        key.appendChild(item);
+      });
+      head.appendChild(key);
+    }
+    card.appendChild(head);
+
+    var body = el("div", "ws-body");
+    var graph = depGraph(ws.tasks, data.edges, "wb-arr-" + ws.id);
+    if (graph) {
+      body.appendChild(el("h3", null, "Dependency graph"));
+      var fig = el("div", "ws-fig");
+      fig.appendChild(graph);
+      body.appendChild(fig);
+    }
+
+    var moving = ws.tasks.filter(function (t) { return t.state !== "queued" && t.state !== "done"; });
+    var queued = ws.tasks.filter(function (t) { return t.state === "queued"; });
+    var doneRows = ws.tasks.filter(function (t) { return t.state === "done"; });
+
+    function taskRow(t) {
+      var expandable = !!(t.doing || t.contract || t.pr_url);
+      var row = el(expandable ? "details" : "div",
+        "wb-trow" + (t.state === "held" ? " wb-trow--held" : "") + (t.state === "decision" ? " wb-trow--decision" : ""));
+      var sum = el(expandable ? "summary" : "div", "wb-trow__sum");
+      sum.appendChild(el("span", "wb-trow__id", t.id));
+      sum.appendChild(el("span", "wb-trow__t", t.title));
+      if (t.agent) sum.appendChild(agentChip(t.agent, t.agent_tone || "paused"));
+      row.appendChild(sum);
+      if (expandable) {
+        var detail = el("div", "wb-trow__detail");
+        var f = el("div", "wb-fld");
+        f.appendChild(el("b", null, "Full title"));
+        f.appendChild(el("span", null, t.title));
+        detail.appendChild(f);
+        if (t.contract) {
+          var c = el("div", "wb-fld");
+          c.appendChild(el("b", null, "Contract"));
+          c.appendChild(el("span", null, t.contract));
+          detail.appendChild(c);
+        }
+        if (t.doing) {
+          var g = el("div", "wb-fld");
+          g.appendChild(el("b", null, "Doing right now"));
+          g.appendChild(el("span", null, t.doing));
+          detail.appendChild(g);
+        }
+        if (t.pr_url) {
+          var pfld = el("div", "wb-fld");
+          pfld.appendChild(el("b", null, "PR"));
+          var a = el("a", null, t.pr_url);
+          a.href = t.pr_url; a.target = "_blank"; a.rel = "noopener";
+          pfld.appendChild(a);
+          detail.appendChild(pfld);
+        }
+        row.appendChild(detail);
+      }
+      return row;
+    }
+
+    if (moving.length) {
+      body.appendChild(el("h3", null, "In flight - agents pinned"));
+      moving.forEach(function (t) { body.appendChild(taskRow(t)); });
+    }
+    if (queued.length) {
+      body.appendChild(el("h3", null, "Queued in this workstream"));
+      queued.forEach(function (t) { body.appendChild(taskRow(t)); });
+    }
+    if (doneRows.length) {
+      body.appendChild(el("h3", null, "Done"));
+      doneRows.forEach(function (t) { body.appendChild(taskRow(t)); });
+    }
+    if (!ws.tasks.length) body.appendChild(el("p", "wb-empty", "No tasks are grouped here yet."));
+    if (ws.more_tasks) body.appendChild(el("span", "wb-morechip", "+" + ws.more_tasks + " more - ask firstmate for the full list"));
+    card.appendChild(body);
+    streamsCol.appendChild(card);
+  });
+
+  /* ---- waiting on you: queue-answer forms ---- */
+  var waitingItems = document.getElementById("wb-waiting-items");
+  document.getElementById("wb-waiting-count").textContent = String(data.waiting.length);
+  if (!data.waiting.length) {
+    var none = el("div", "wb-rail-item");
+    none.appendChild(el("p", null, "Nothing needs your action right now, captain."));
+    waitingItems.appendChild(none);
+  }
+  data.waiting.forEach(function (item) {
+    var wrap = el("div", "wb-rail-item");
+    wrap.appendChild(el("span", "wb-k", item.key));
+    wrap.appendChild(el("p", null, item.title));
+    if (item.question) wrap.appendChild(el("p", "wb-rail-note", item.question));
+
+    var form = document.createElement("form");
+    form.className = "wb-qform";
+    form.setAttribute("data-lavish-question", item.key);
+    item.options.forEach(function (o) {
+      var lab = el("label");
+      var input = document.createElement("input");
+      input.type = "radio"; input.name = "answer"; input.value = o.value;
+      lab.appendChild(input);
+      var body = el("span");
+      body.appendChild(document.createTextNode(o.label));
+      if (item.recommend_value && o.value === item.recommend_value) {
+        body.appendChild(document.createTextNode(" "));
+        body.appendChild(el("span", "wb-opt__rec", "(recommended)"));
+      }
+      if (o.hint) body.appendChild(el("span", "wb-opt__hint", o.hint));
+      lab.appendChild(body);
+      form.appendChild(lab);
+    });
+    if (item.allow_freeform) {
+      var ff = document.createElement("input");
+      ff.type = "text"; ff.name = "note"; ff.className = "wb-freeform";
+      ff.placeholder = item.freeform_hint || "or answer in your own words…";
+      form.appendChild(ff);
+    }
+    var foot = el("div", "wb-qfoot");
+    var btn = el("button", "fm-btn fm-btn--sm fm-btn--gold", "Queue answer");
+    btn.type = "submit";
+    foot.appendChild(btn);
+    var q = el("span", "wb-queued");
+    q.innerHTML = CHECK_SVG + " queued";
+    foot.appendChild(q);
+    var answerLimit = el("span", "wb-limit");
+    answerLimit.setAttribute("role", "alert");
+    foot.appendChild(answerLimit);
+    form.appendChild(foot);
+
+    form.addEventListener("submit", function (ev) {
+      ev.preventDefault();
+      answerLimit.classList.remove("is-visible");
+      var fd = new FormData(form);
+      var value = fd.get("answer");
+      var note = (fd.get("note") || "").trim();
+      /* picked option, optionally annotated; a bare note is itself the answer */
+      var answer = value ? (note ? value + " - " + note : value) : note;
+      if (!answer) return;
+      if (utf8ByteLength(answer) > 512) {
+        answerLimit.textContent = "Answer is too long to queue (512 bytes maximum).";
+        answerLimit.classList.add("is-visible");
+        return;
+      }
+      if (window.lavish && window.lavish.queuePrompt) {
+        /* close carries the composer-declared close mode: "release" frees a
+           captain-gated work item instead of completing a question task */
+        var ctxData = { question: item.key, answer: answer };
+        if (item.close) ctxData.close = item.close;
+        window.lavish.queuePrompt(
+          "Workstream answer - " + item.title + ": " + answer,
+          { tag: "choice", text: item.title + " -> " + answer, element: form,
+            data: ctxData }
+        );
+      }
+      wrap.classList.add("is-queued");
+    });
+    wrap.appendChild(form);
+    waitingItems.appendChild(wrap);
+  });
+  if (data.waiting.length) {
+    var hint = el("div", "wb-rail-item");
+    hint.appendChild(el("p", "wb-rail-note", "Pick an option, queue it, then press Send to Agent - nothing happens until you send."));
+    waitingItems.appendChild(hint);
+  }
+
+  /* ---- agent roster ---- */
+  var agentsItems = document.getElementById("wb-agents-items");
+  document.getElementById("wb-agents-count").textContent = data.agents.length + " live";
+  if (!data.agents.length) {
+    var idle = el("div", "wb-rail-item");
+    idle.appendChild(el("p", null, "No agents are live."));
+    agentsItems.appendChild(idle);
+  }
+  data.agents.forEach(function (a) {
+    var row = el("div", "wb-rail-item");
+    row.appendChild(agentChip(a.id, a.tone || "paused"));
+    if (a.doing) row.appendChild(el("p", null, a.doing));
+    agentsItems.appendChild(row);
+  });
+  } catch (e) {
+    renderBoardError("The board data could not be rendered");
+  }
+})();
+</script>
+</body>
+</html>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -534,7 +534,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 ## 13. Agent-only reference skills
 
-These skills are not captain-invocable; load them only at their precise triggers.
+Load these skills only at their precise triggers; except where an entry says otherwise, they are not captain-invocable.
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `HOME_SUMMARY:`, `BACKLOG_RECONCILE:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`), or when `BOOTSTRAP_INFO:` says an interrupted backlog cleanup may have left an endpoint or local copy; silence and other `BOOTSTRAP_INFO:` facts need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
@@ -551,6 +551,7 @@ These skills are not captain-invocable; load them only at their precise triggers
   Never run a registered source's blocking command yourself in a conversational turn.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
+- `workstreams` - captain-invocable as `/workstreams`; load it when the captain invokes that or asks for the workstream board, and on any `procevent lavish` check wake whose source id matches the canonical source id of the stable workstream board path (`bin/fm-workstream-board.sh path`).
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
 
 ## 14. Relay

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/ahoy`            | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, then guide the captain through any open decisions one at a time in agent-judged impact order; fall back to Bearings when invoked as the session's first real captain message |
 | `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
+| `/workstreams`     | Build and arm the captain-facing workstream board: backlog tasks grouped into workstreams against their intended outcomes, dependency edges drawn, live agents pinned on the tasks they are working, and captain decisions answerable on the board itself |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, persist the open work records this session knows are unfiled or now wrong, curate tiered startup memory with decay and cold archival, enforce each home's budget or surface the required decision, cascade to registered second mates, and report what is safe to reset |
 
 Bearings invocation examples:

--- a/bin/fm-bearings-board.sh
+++ b/bin/fm-bearings-board.sh
@@ -53,6 +53,14 @@ TEMPLATE="${FM_BEARINGS_BOARD_TEMPLATE:-$SCRIPT_DIR/../.agents/skills/bearings/a
 PLACEHOLDER='__FM_BEARINGS_BOARD_DATA__'
 BOARD_SCHEMA=fm-bearings-board.v1
 
+# Shared board-build mechanics (injection, round-trip, serve-then-bind-then-arm)
+# have one owner in fm-board-lib.sh; this script keeps the bearings-specific
+# schema validation, template asset, and stable path.
+FM_BOARD_FAIL_PREFIX=fm-bearings-board
+# shellcheck source=bin/fm-board-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-board-lib.sh"
+
 usage() {
   awk '
     NR == 1 { next }
@@ -61,10 +69,7 @@ usage() {
   ' "$0"
 }
 
-fail() {
-  printf 'fm-bearings-board: %s\n' "$*" >&2
-  exit 1
-}
+fail() { fm_board_fail "$@"; }
 
 board_path() { printf '%s/.lavish/bearings-board.html\n' "$FM_HOME"; }
 
@@ -137,63 +142,16 @@ validate_payload() {  # <data.json>
 }
 
 command_build() {
-  local data=${1-} board json tmp sid extracted
+  local data=${1-} board
   [ "$#" -eq 1 ] || { usage >&2; exit 2; }
   command -v jq >/dev/null 2>&1 || fail "jq is required"
   [ -f "$data" ] || fail "board data does not exist: $data"
   jq empty "$data" 2>/dev/null || fail "board data is not valid JSON: $data"
   validate_payload "$data" || fail "board data does not satisfy $BOARD_SCHEMA: $data"
-  [ -f "$TEMPLATE" ] && [ ! -L "$TEMPLATE" ] || fail "board template is missing: $TEMPLATE"
-  [ "$(grep -cxF "$PLACEHOLDER" "$TEMPLATE")" -eq 1 ] \
-    || fail "board template does not carry exactly one data slot: $TEMPLATE"
-
-  json=$(jq -c . "$data") || fail "cannot compact the board data"
-  # `<` never appears in JSON syntax outside strings, so escaping every
-  # occurrence keeps the payload valid JSON while making </script> inert.
-  json=${json//</\\u003c}
 
   board=$(board_path)
-  (umask 077; mkdir -p "${board%/*}") || fail "cannot create ${board%/*}"
-  tmp=$(umask 077; mktemp "${board%/*}/.board.XXXXXX") || fail "cannot stage the board"
-  if ! BOARD_JSON="$json" perl -pe "s/^\\Q$PLACEHOLDER\\E\$/\$ENV{BOARD_JSON}/" "$TEMPLATE" > "$tmp"; then
-    rm -f -- "$tmp"
-    fail "cannot inject the board data"
-  fi
-  if grep -qxF "$PLACEHOLDER" "$tmp"; then
-    rm -f -- "$tmp"
-    fail "the board data slot survived injection"
-  fi
-  # Round-trip the injected payload back out of the built page, so a board that
-  # would fail to parse in the browser fails here instead.
-  extracted=$(sed -n '/<script id="bearings-data" type="application\/json">/,/<\/script>/p' "$tmp" \
-    | sed '1d;$d')
-  if ! printf '%s\n' "$extracted" | jq -e --arg schema "$BOARD_SCHEMA" '.schema == $schema' >/dev/null 2>&1; then
-    rm -f -- "$tmp"
-    fail "the built board does not carry a readable $BOARD_SCHEMA payload"
-  fi
-  if ! { chmod 0600 "$tmp" && mv -f -- "$tmp" "$board"; }; then
-    rm -f -- "$tmp"
-    fail "cannot publish the board"
-  fi
-  printf 'board: %s\n' "$board"
-
-  command -v lavish-axi >/dev/null 2>&1 || fail "lavish-axi is not installed"
-  lavish-axi "$board" || fail "cannot establish the board Lavish session"
-  printf 'served: %s\n' "$board"
-
-  sid=$("$SCRIPT_DIR/fm-procevent-lavish.sh" source-id "$board") \
-    || fail "cannot derive the board source id"
-  "$SCRIPT_DIR/fm-captain-hold.sh" bind "$sid" >/dev/null \
-    || fail "cannot bind the board source to the keyed-answer intake"
-  printf 'bound: %s\n' "$sid"
-
-  if "$SCRIPT_DIR/fm-procevent.sh" list | awk 'NR > 1 { print $1 }' | grep -Fxq "$sid"; then
-    printf 'already-armed: %s\n' "$sid"
-  else
-    "$SCRIPT_DIR/fm-procevent-lavish.sh" arm "$board" >/dev/null \
-      || fail "cannot arm the board as a process-event source"
-    printf 'armed: %s\n' "$sid"
-  fi
+  fm_board_publish "$data" "$TEMPLATE" "$PLACEHOLDER" "$BOARD_SCHEMA" "$board" "bearings-data"
+  fm_board_serve_bind_arm "$board"
 }
 
 case "${1-}" in

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -69,6 +69,9 @@ FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
 # shellcheck source=bin/fm-timeout-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-toon-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-toon-lib.sh"
 
 # Bounds (overridable for tests / large fleets).
 FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
@@ -510,37 +513,7 @@ if [ "$FORMAT" = json ]; then
 fi
 
 # --- TOON renderer (output boundary; parity with the JSON model) ------------
-# The model is a flat object of scalar fields plus arrays of uniform scalar
-# objects, so the encoder only needs object scalars, the tabular array form
-# (key[N]{fields}: + comma rows at +2 indent), and the empty-array form (key: []),
-# per the TOON spec. Quoting follows the spec exactly.
-TOON=$(printf '%s\n' "$MODEL" | jq -r '
-  def q:
-    tostring
-    | if (. == "")
-        or test("^\\s|\\s$")
-        or (. == "true" or . == "false" or . == "null")
-        or test("^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$")
-        or test("[:\"\\\\\\[\\]{},]")
-        or test("[[:cntrl:]]")
-        or test("^-")
-      then "\"" + (gsub("\\\\"; "\\\\") | gsub("\""; "\\\"") | gsub("\n"; "\\n") | gsub("\r"; "\\r") | gsub("\t"; "\\t")) + "\""
-      else . end;
-  def scal:
-    if . == null then "null"
-    elif type == "boolean" then (if . then "true" else "false" end)
-    elif type == "number" then tostring
-    else q end;
-  def emit($k; $v):
-    if ($v | type) == "array" then
-      if ($v | length) == 0 then "\($k): []"
-      else
-        ($v[0] | keys_unsorted) as $ks
-        | ( "\($k)[\($v | length)]{\($ks | map(q) | join(","))}:",
-            ($v[] as $row | "  " + ([ $ks[] as $kk | ($row[$kk] | scal) ] | join(","))) )
-      end
-    else "\($k): " + ($v | scal)
-    end;
-  [ to_entries[] | emit(.key; .value) ] | join("\n")
-') || { echo "fm-bearings-snapshot: TOON rendering failed" >&2; exit 1; }
+# bin/fm-toon-lib.sh owns the shared encoder for flat snapshot projections.
+TOON=$(printf '%s\n' "$MODEL" | fm_toon_render) \
+  || { echo "fm-bearings-snapshot: TOON rendering failed" >&2; exit 1; }
 printf '%s\n' "$TOON"

--- a/bin/fm-board-lib.sh
+++ b/bin/fm-board-lib.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# fm-board-lib.sh - shared mechanics for captain-facing Lavish board builders.
+#
+# One owner for the build sequence every board script shares, so a second board
+# never re-implements injection or the bind-before-arm ordering rule:
+#   1. inject a validated JSON payload into a fresh copy of a shipped template
+#      at a stable board path (fm_board_publish),
+#   2. establish or resume the board's Lavish session, then bind its answer
+#      source to the keyed-answer intake ALWAYS before arming the polling
+#      source (fm_board_serve_bind_arm), enforcing captain-hold-lifecycle's
+#      ordering rule structurally rather than leaving it to agent memory.
+#
+# Each board script keeps ownership of what is board-specific: its payload
+# schema and fail-closed validation, its template asset and stable path, and
+# its CLI. This library owns only the shared mechanics.
+#
+# Contract:
+#   FM_BOARD_FAIL_PREFIX  set by the sourcing script before any call; names it
+#                         in every error line (e.g. "fm-bearings-board").
+#   fm_board_fail <msg>   print "<prefix>: <msg>" to stderr and exit 1.
+#   fm_board_publish <data.json> <template> <placeholder> <schema> <board> <script-id>
+#                         validate JSON syntax was already checked by the
+#                         caller; this performs the template checks, compacts
+#                         the payload, escapes every "<" as < so a string
+#                         containing "</script>" cannot terminate the data
+#                         block, injects into a fresh template copy, round-trips
+#                         the payload back out of the built page, publishes at
+#                         <board>, and prints "board: <board>".
+#   fm_board_serve_bind_arm <board>
+#                         establish/resume the Lavish session, bind the board's
+#                         canonical source id to bin/fm-captain-hold.sh intake,
+#                         then arm the source only if not already registered.
+#                         Prints served:/bound:/armed:/already-armed: lines.
+#
+# Sibling scripts (fm-procevent-lavish.sh, fm-captain-hold.sh, fm-procevent.sh)
+# are resolved from this library's own directory.
+
+FM_BOARD_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+fm_board_fail() {
+  printf '%s: %s\n' "${FM_BOARD_FAIL_PREFIX:-fm-board}" "$*" >&2
+  exit 1
+}
+
+fm_board_publish() {  # <data.json> <template> <placeholder> <schema> <board> <script-id>
+  local data=$1 template=$2 placeholder=$3 schema=$4 board=$5 script_id=$6
+  local json tmp extracted
+  [ -f "$template" ] && [ ! -L "$template" ] || fm_board_fail "board template is missing: $template"
+  [ "$(grep -cxF "$placeholder" "$template")" -eq 1 ] \
+    || fm_board_fail "board template does not carry exactly one data slot: $template"
+
+  json=$(jq -c . "$data") || fm_board_fail "cannot compact the board data"
+  # `<` never appears in JSON syntax outside strings, so escaping every
+  # occurrence keeps the payload valid JSON while making </script> inert.
+  json=${json//</\\u003c}
+
+  (umask 077; mkdir -p "${board%/*}") || fm_board_fail "cannot create ${board%/*}"
+  tmp=$(umask 077; mktemp "${board%/*}/.board.XXXXXX") || fm_board_fail "cannot stage the board"
+  if ! BOARD_JSON="$json" perl -pe "s/^\\Q$placeholder\\E\$/\$ENV{BOARD_JSON}/" "$template" > "$tmp"; then
+    rm -f -- "$tmp"
+    fm_board_fail "cannot inject the board data"
+  fi
+  if grep -qxF "$placeholder" "$tmp"; then
+    rm -f -- "$tmp"
+    fm_board_fail "the board data slot survived injection"
+  fi
+  # Round-trip the injected payload back out of the built page, so a board that
+  # would fail to parse in the browser fails here instead.
+  extracted=$(sed -n '/<script id="'"$script_id"'" type="application\/json">/,/<\/script>/p' "$tmp" \
+    | sed '1d;$d')
+  if ! printf '%s\n' "$extracted" | jq -e --arg schema "$schema" '.schema == $schema' >/dev/null 2>&1; then
+    rm -f -- "$tmp"
+    fm_board_fail "the built board does not carry a readable $schema payload"
+  fi
+  if ! { chmod 0600 "$tmp" && mv -f -- "$tmp" "$board"; }; then
+    rm -f -- "$tmp"
+    fm_board_fail "cannot publish the board"
+  fi
+  printf 'board: %s\n' "$board"
+}
+
+fm_board_serve_bind_arm() {  # <board>
+  local board=$1 sid
+  command -v lavish-axi >/dev/null 2>&1 || fm_board_fail "lavish-axi is not installed"
+  lavish-axi "$board" || fm_board_fail "cannot establish the board Lavish session"
+  printf 'served: %s\n' "$board"
+
+  sid=$("$FM_BOARD_LIB_DIR/fm-procevent-lavish.sh" source-id "$board") \
+    || fm_board_fail "cannot derive the board source id"
+  "$FM_BOARD_LIB_DIR/fm-captain-hold.sh" bind "$sid" >/dev/null \
+    || fm_board_fail "cannot bind the board source to the keyed-answer intake"
+  printf 'bound: %s\n' "$sid"
+
+  if "$FM_BOARD_LIB_DIR/fm-procevent.sh" list | awk 'NR > 1 { print $1 }' | grep -Fxq "$sid"; then
+    printf 'already-armed: %s\n' "$sid"
+  else
+    "$FM_BOARD_LIB_DIR/fm-procevent-lavish.sh" arm "$board" >/dev/null \
+      || fm_board_fail "cannot arm the board as a process-event source"
+    printf 'armed: %s\n' "$sid"
+  fi
+}

--- a/bin/fm-toon-lib.sh
+++ b/bin/fm-toon-lib.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# fm-toon-lib.sh - shared TOON renderer for flat snapshot projections.
+#
+# One owner for the TOON output boundary the agent-facing snapshot wrappers
+# share (fm-bearings-snapshot.sh, fm-workstream-snapshot.sh), so the encoder
+# cannot drift between them. The model each wrapper feeds it is a flat object
+# of scalar fields plus arrays of uniform scalar objects, so the encoder only
+# needs object scalars, the tabular array form (key[N]{fields}: + comma rows at
+# +2 indent), and the empty-array form (key: []), per the TOON spec. Quoting
+# follows the spec exactly.
+#
+# fm_toon_render reads the JSON model on stdin and prints TOON on stdout;
+# non-zero exit means the model could not be rendered, and the caller owns the
+# user-facing error message.
+
+fm_toon_render() {
+  jq -r '
+  def q:
+    tostring
+    | if (. == "")
+        or test("^\\s|\\s$")
+        or (. == "true" or . == "false" or . == "null")
+        or test("^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$")
+        or test("[:\"\\\\\\[\\]{},]")
+        or test("[[:cntrl:]]")
+        or test("^-")
+      then "\"" + (gsub("\\\\"; "\\\\") | gsub("\""; "\\\"") | gsub("\n"; "\\n") | gsub("\r"; "\\r") | gsub("\t"; "\\t")) + "\""
+      else . end;
+  def scal:
+    if . == null then "null"
+    elif type == "boolean" then (if . then "true" else "false" end)
+    elif type == "number" then tostring
+    else q end;
+  def emit($k; $v):
+    if ($v | type) == "array" then
+      if ($v | length) == 0 then "\($k): []"
+      else
+        ($v[0] | keys_unsorted) as $ks
+        | ( "\($k)[\($v | length)]{\($ks | map(q) | join(","))}:",
+            ($v[] as $row | "  " + ([ $ks[] as $kk | ($row[$kk] | scal) ] | join(","))) )
+      end
+    else "\($k): " + ($v | scal)
+    end;
+  [ to_entries[] | emit(.key; .value) ] | join("\n")
+'
+}

--- a/bin/fm-workstream-board.sh
+++ b/bin/fm-workstream-board.sh
@@ -31,10 +31,12 @@
 # schema=fm-workstream-board.v1 and every renderer-consumed field must satisfy
 # the types and item invariants below. Every waiting item's key is a
 # captain-held TASK ID, so the bound keyed-answer intake can close or release
-# that task at answer time. A workstream's optional `counts` object carries
-# that lane's whole-lane state tallies, so the progress bar reports the lane
-# and not whatever subset of rows the row cap left visible. Anything else
-# refuses before the existing board is touched.
+# that task at answer time. A workstream's `counts` object carries that lane's
+# whole-lane state tallies, so the progress bar reports the lane and not
+# whatever subset of rows the row cap left visible; it is REQUIRED whenever
+# `more_tasks` is above zero, must carry all six state keys, and must total at
+# least the rows it ships. Anything else refuses before the existing board is
+# touched.
 #
 # The board path is stable - $FM_HOME/.lavish/workstreams.html - so a
 # re-invocation rebuilds the same file in place, keeping the same Lavish
@@ -83,12 +85,11 @@ validate_payload() {  # <data.json>
           and test("^https://[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?(?::[0-9]{1,5})?(?:[/?#][^[:space:]]*)?$"));
     def tone: . == "working" or . == "paused" or . == "decision";
     def whole_number: type == "number" and . >= 0 and (floor == .);
-    def lane_counts:
+    def lane_counts($rows):
       type == "object"
-      and ([to_entries[]
-        | (.key | . == "done" or . == "review" or . == "active"
-                  or . == "held" or . == "decision" or . == "queued")
-          and (.value | whole_number)] | all);
+      and ((keys - ["active", "decision", "done", "held", "queued", "review"]) | length) == 0
+      and ([.done, .review, .active, .held, .decision, .queued] | all(whole_number))
+      and (([.done, .review, .active, .held, .decision, .queued] | add) >= $rows);
     def task_item:
       type == "object"
       and (.id | slug(128))
@@ -108,7 +109,9 @@ validate_payload() {  # <data.json>
       and (.tasks | type == "array")
       and ([.tasks[] | task_item] | all)
       and ((has("more_tasks") | not) or (.more_tasks | whole_number))
-      and ((has("counts") | not) or (.counts | lane_counts));
+      and ((.tasks | length) as $rows
+        | if has("counts") then (.counts | lane_counts($rows))
+          else (.more_tasks // 0) == 0 end);
     def edge_item:
       type == "object" and (.from | slug(128)) and (.to | slug(128));
     def wait_item:

--- a/bin/fm-workstream-board.sh
+++ b/bin/fm-workstream-board.sh
@@ -31,12 +31,14 @@
 # schema=fm-workstream-board.v1 and every renderer-consumed field must satisfy
 # the types and item invariants below. Every waiting item's key is a
 # captain-held TASK ID, so the bound keyed-answer intake can close or release
-# that task at answer time. A workstream's `counts` object carries that lane's
-# whole-lane state tallies, so the progress bar reports the lane and not
-# whatever subset of rows the row cap left visible; it is REQUIRED whenever
-# `more_tasks` is above zero, must carry all six state keys, and must total
-# EXACTLY the lane - the rows it ships plus `more_tasks`. Anything else refuses
-# before the existing board is touched.
+# that task at answer time. An optional field carrying an explicit null reads
+# as absent, so a composer can pass a snapshot row through unedited; the
+# renderer already draws the two the same way. A workstream's `counts` object
+# carries that lane's whole-lane state tallies, so the progress bar reports
+# the lane and not whatever subset of rows the row cap left visible; it is
+# REQUIRED whenever `more_tasks` is above zero, must carry all six state keys,
+# and must total EXACTLY the lane - the rows it ships plus `more_tasks`.
+# Anything else refuses before the existing board is touched.
 #
 # The board path is stable - $FM_HOME/.lavish/workstreams.html - so a
 # re-invocation rebuilds the same file in place, keeping the same Lavish
@@ -77,9 +79,11 @@ validate_payload() {  # <data.json>
   jq -e --arg schema "$BOARD_SCHEMA" '
     def nonempty_string: type == "string" and length > 0;
     def slug($max): type == "string" and test("^[A-Za-z0-9._-]{1," + ($max | tostring) + "}$");
-    def optional_string($name): (has($name) | not) or (.[$name] | type == "string");
+    def optional_string($name):
+      (has($name) | not) or (.[$name] == null) or (.[$name] | type == "string");
     def optional_https_url($name):
       (has($name) | not)
+      or (.[$name] == null)
       or (.[$name]
         | type == "string"
           and test("^https://[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?(?::[0-9]{1,5})?(?:[/?#][^[:space:]]*)?$"));

--- a/bin/fm-workstream-board.sh
+++ b/bin/fm-workstream-board.sh
@@ -31,8 +31,10 @@
 # schema=fm-workstream-board.v1 and every renderer-consumed field must satisfy
 # the types and item invariants below. Every waiting item's key is a
 # captain-held TASK ID, so the bound keyed-answer intake can close or release
-# that task at answer time. Anything else refuses before the existing board is
-# touched.
+# that task at answer time. A workstream's optional `counts` object carries
+# that lane's whole-lane state tallies, so the progress bar reports the lane
+# and not whatever subset of rows the row cap left visible. Anything else
+# refuses before the existing board is touched.
 #
 # The board path is stable - $FM_HOME/.lavish/workstreams.html - so a
 # re-invocation rebuilds the same file in place, keeping the same Lavish
@@ -80,6 +82,13 @@ validate_payload() {  # <data.json>
         | type == "string"
           and test("^https://[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?(?::[0-9]{1,5})?(?:[/?#][^[:space:]]*)?$"));
     def tone: . == "working" or . == "paused" or . == "decision";
+    def whole_number: type == "number" and . >= 0 and (floor == .);
+    def lane_counts:
+      type == "object"
+      and ([to_entries[]
+        | (.key | . == "done" or . == "review" or . == "active"
+                  or . == "held" or . == "decision" or . == "queued")
+          and (.value | whole_number)] | all);
     def task_item:
       type == "object"
       and (.id | slug(128))
@@ -98,8 +107,8 @@ validate_payload() {  # <data.json>
       and optional_string("outcome")
       and (.tasks | type == "array")
       and ([.tasks[] | task_item] | all)
-      and ((has("more_tasks") | not)
-        or ((.more_tasks | type == "number") and (.more_tasks >= 0) and (.more_tasks | floor == .)));
+      and ((has("more_tasks") | not) or (.more_tasks | whole_number))
+      and ((has("counts") | not) or (.counts | lane_counts));
     def edge_item:
       type == "object" and (.from | slug(128)) and (.to | slug(128));
     def wait_item:

--- a/bin/fm-workstream-board.sh
+++ b/bin/fm-workstream-board.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# fm-workstream-board.sh - build and arm the /workstreams lavish board.
+#
+# The board is the captain-facing interactive surface of /workstreams: the
+# shipped template (.agents/skills/workstreams/assets/board-template.html) plus
+# one injected fm-workstream-board.v1 JSON payload. This script owns the
+# mechanics so the invoking agent's per-run work stays "compose the JSON, run
+# build" - the agent never authors board UI at invocation time. It is a
+# SIBLING of bin/fm-bearings-board.sh: both delegate the shared build sequence
+# (injection, round-trip check, serve-then-bind-then-arm) to
+# bin/fm-board-lib.sh, and each owns only its schema, template, and path.
+#
+# Usage:
+#   fm-workstream-board.sh build <data.json>
+#   fm-workstream-board.sh path
+#
+# build      Validate the payload and inject it into a fresh copy of the shipped
+#            template at the stable board path. Establish or resume the Lavish
+#            session on that board BEFORE binding and arming its answer source.
+#            Bind to the keyed-answer intake (bin/fm-captain-hold.sh) ALWAYS
+#            precedes arm (captain-hold-lifecycle's ordering rule, enforced by
+#            the shared lib). Output starts with `board: <path>`, then includes
+#            lavish-axi's session output and the remaining status:
+#              served: <path>
+#              bound: <source-id>
+#              armed: <source-id>            (first registration)
+#              already-armed: <source-id>    (registration already present)
+# path       Print the stable board path for this home.
+#
+# Validation is fail-closed: the payload must be valid JSON with
+# schema=fm-workstream-board.v1 and every renderer-consumed field must satisfy
+# the types and item invariants below. Every waiting item's key is a
+# captain-held TASK ID, so the bound keyed-answer intake can close or release
+# that task at answer time. Anything else refuses before the existing board is
+# touched.
+#
+# The board path is stable - $FM_HOME/.lavish/workstreams.html - so a
+# re-invocation rebuilds the same file in place, keeping the same Lavish
+# session URL and the same canonical process-event source id. The path is
+# deliberately NOT .lavish/workstream-board.html: that name is the captain's
+# hand-reviewed mockup (data/workstream-board/mockup.html) and its own Lavish
+# session, which this board must never clobber.
+#
+# FM_WORKSTREAM_BOARD_TEMPLATE overrides the shipped template path (tests only).
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-$FM_ROOT}"
+
+TEMPLATE="${FM_WORKSTREAM_BOARD_TEMPLATE:-$SCRIPT_DIR/../.agents/skills/workstreams/assets/board-template.html}"
+PLACEHOLDER='__FM_WORKSTREAM_BOARD_DATA__'
+BOARD_SCHEMA=fm-workstream-board.v1
+
+FM_BOARD_FAIL_PREFIX=fm-workstream-board
+# shellcheck source=bin/fm-board-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-board-lib.sh"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+fail() { fm_board_fail "$@"; }
+
+board_path() { printf '%s/.lavish/workstreams.html\n' "$FM_HOME"; }
+
+validate_payload() {  # <data.json>
+  jq -e --arg schema "$BOARD_SCHEMA" '
+    def nonempty_string: type == "string" and length > 0;
+    def slug($max): type == "string" and test("^[A-Za-z0-9._-]{1," + ($max | tostring) + "}$");
+    def optional_string($name): (has($name) | not) or (.[$name] | type == "string");
+    def optional_https_url($name):
+      (has($name) | not)
+      or (.[$name]
+        | type == "string"
+          and test("^https://[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?(?::[0-9]{1,5})?(?:[/?#][^[:space:]]*)?$"));
+    def tone: . == "working" or . == "paused" or . == "decision";
+    def task_item:
+      type == "object"
+      and (.id | slug(128))
+      and (.title | nonempty_string)
+      and (.state == "done" or .state == "review" or .state == "active"
+           or .state == "held" or .state == "decision" or .state == "queued")
+      and optional_string("doing")
+      and optional_string("contract")
+      and ((has("agent") | not) or ((.agent | nonempty_string) and (.agent_tone | tone)))
+      and ((has("agent_tone") | not) or (.agent_tone | tone))
+      and optional_https_url("pr_url");
+    def ws_item:
+      type == "object"
+      and (.id | slug(128))
+      and (.name | nonempty_string)
+      and optional_string("outcome")
+      and (.tasks | type == "array")
+      and ([.tasks[] | task_item] | all)
+      and ((has("more_tasks") | not)
+        or ((.more_tasks | type == "number") and (.more_tasks >= 0) and (.more_tasks | floor == .)));
+    def edge_item:
+      type == "object" and (.from | slug(128)) and (.to | slug(128));
+    def wait_item:
+      type == "object"
+      and (.key | slug(128))
+      and (.title | nonempty_string)
+      and optional_string("question")
+      and (.options | type == "array")
+      and ((.options | length) > 0 or .allow_freeform == true)
+      and ([.options[]
+        | type == "object"
+          and (.value | slug(128))
+          and (.label | nonempty_string)
+          and optional_string("hint")] | all)
+      and ((has("allow_freeform") | not) or (.allow_freeform | type == "boolean"))
+      and optional_string("freeform_hint")
+      and ((has("recommend_value") | not)
+        or ((.recommend_value | slug(128))
+          and (.recommend_value as $recommend | [.options[].value] | index($recommend) != null)))
+      and ((has("close") | not) or (.close == "done" or .close == "release"));
+    def agent_item:
+      type == "object" and (.id | nonempty_string)
+      and (.tone | tone) and optional_string("doing");
+    def divergence_item:
+      type == "object" and (.id | nonempty_string) and (.note | nonempty_string);
+    type == "object"
+    and (.schema == $schema)
+    and (.home | nonempty_string)
+    and (.generated | nonempty_string)
+    and (.workstreams | type == "array")
+    and (.edges | type == "array")
+    and (.waiting | type == "array")
+    and (.agents | type == "array")
+    and (.divergence | type == "array")
+    and ([.workstreams[] | ws_item] | all)
+    and ([.edges[] | edge_item] | all)
+    and ([.waiting[] | wait_item] | all)
+    and ([.agents[] | agent_item] | all)
+    and ([.divergence[] | divergence_item] | all)
+  ' "$1" >/dev/null
+}
+
+command_build() {
+  local data=${1-} board
+  [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+  command -v jq >/dev/null 2>&1 || fail "jq is required"
+  [ -f "$data" ] || fail "board data does not exist: $data"
+  jq empty "$data" 2>/dev/null || fail "board data is not valid JSON: $data"
+  validate_payload "$data" || fail "board data does not satisfy $BOARD_SCHEMA: $data"
+
+  board=$(board_path)
+  fm_board_publish "$data" "$TEMPLATE" "$PLACEHOLDER" "$BOARD_SCHEMA" "$board" "workstream-data"
+  fm_board_serve_bind_arm "$board"
+}
+
+case "${1-}" in
+  build) shift; command_build "$@" ;;
+  path) board_path ;;
+  -h|--help|help) usage ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/bin/fm-workstream-board.sh
+++ b/bin/fm-workstream-board.sh
@@ -34,9 +34,9 @@
 # that task at answer time. A workstream's `counts` object carries that lane's
 # whole-lane state tallies, so the progress bar reports the lane and not
 # whatever subset of rows the row cap left visible; it is REQUIRED whenever
-# `more_tasks` is above zero, must carry all six state keys, and must total at
-# least the rows it ships. Anything else refuses before the existing board is
-# touched.
+# `more_tasks` is above zero, must carry all six state keys, and must total
+# EXACTLY the lane - the rows it ships plus `more_tasks`. Anything else refuses
+# before the existing board is touched.
 #
 # The board path is stable - $FM_HOME/.lavish/workstreams.html - so a
 # re-invocation rebuilds the same file in place, keeping the same Lavish
@@ -85,11 +85,11 @@ validate_payload() {  # <data.json>
           and test("^https://[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?(?::[0-9]{1,5})?(?:[/?#][^[:space:]]*)?$"));
     def tone: . == "working" or . == "paused" or . == "decision";
     def whole_number: type == "number" and . >= 0 and (floor == .);
-    def lane_counts($rows):
+    def lane_counts($total):
       type == "object"
       and ((keys - ["active", "decision", "done", "held", "queued", "review"]) | length) == 0
       and ([.done, .review, .active, .held, .decision, .queued] | all(whole_number))
-      and (([.done, .review, .active, .held, .decision, .queued] | add) >= $rows);
+      and (([.done, .review, .active, .held, .decision, .queued] | add) == $total);
     def task_item:
       type == "object"
       and (.id | slug(128))
@@ -109,8 +109,8 @@ validate_payload() {  # <data.json>
       and (.tasks | type == "array")
       and ([.tasks[] | task_item] | all)
       and ((has("more_tasks") | not) or (.more_tasks | whole_number))
-      and ((.tasks | length) as $rows
-        | if has("counts") then (.counts | lane_counts($rows))
+      and (((.tasks | length) + (.more_tasks // 0)) as $total
+        | if has("counts") then (.counts | lane_counts($total))
           else (.more_tasks // 0) == 0 end);
     def edge_item:
       type == "object" and (.from | slug(128)) and (.to | slug(128));

--- a/bin/fm-workstream-snapshot.sh
+++ b/bin/fm-workstream-snapshot.sh
@@ -200,6 +200,12 @@ MODEL=$(printf '%s' "$SNAP" | jq \
          agent_state: ($l.current_state.state // ""),
          pr_url: ($l.pr.url // $r.pr_url // null)};
     def state_rank: {decision:0, held:1, active:2, review:3, queued:4, done:5}[.] // 6;
+    def state_counts: {done: (map(select(.state == "done")) | length),
+                       review: (map(select(.state == "review")) | length),
+                       active: (map(select(.state == "active")) | length),
+                       held: (map(select(.state == "held")) | length),
+                       decision: (map(select(.state == "decision")) | length),
+                       queued: (map(select(.state == "queued")) | length)};
   ($umbrellas
    | map(. as $u
      | [ $recs[] | select($assign[.id] == $u.id) ] as $members
@@ -209,23 +215,13 @@ MODEL=$(printf '%s' "$SNAP" | jq \
         name: (($u.title // $u.id) | trunc(90)),
         outcome: (($u.body_excerpt // $u.title // "") | trunc(240)),
         actionable: ($u.captain_actionable == true),
-        counts: ($rows | {done: (map(select(.state == "done")) | length),
-                          review: (map(select(.state == "review")) | length),
-                          active: (map(select(.state == "active")) | length),
-                          held: (map(select(.state == "held")) | length),
-                          decision: (map(select(.state == "decision")) | length),
-                          queued: (map(select(.state == "queued")) | length)}),
+        counts: ($rows | state_counts),
         rows: (if $all_tasks == 1 then $sorted else $sorted[:$tasks_n] end),
         more: (if $all_tasks == 1 then 0 else (($rows | length) - ($sorted[:$tasks_n] | length)) end)})) as $streams_all
   | ([ $recs[]
        | select(.kind != "program" and ($uidx[.id] == null) and ($assign[.id] // null) == null and .state != "done") ]) as $unassigned_recs
   | ($unassigned_recs | map(task_row(.; "unassigned")) | sort_by([(.state | state_rank)])) as $unassigned_rows_all
-  | ($unassigned_rows_all | {done: (map(select(.state == "done")) | length),
-                             review: (map(select(.state == "review")) | length),
-                             active: (map(select(.state == "active")) | length),
-                             held: (map(select(.state == "held")) | length),
-                             decision: (map(select(.state == "decision")) | length),
-                             queued: (map(select(.state == "queued")) | length)}) as $un_counts
+  | ($unassigned_rows_all | state_counts) as $un_counts
   | ([ $recs[] | select(.kind != "program" and ($uidx[.id] == null) and ($assign[.id] // null) == null and .state == "done") ] | length) as $dropped_done
   | (if $all_tasks == 1 then $unassigned_rows_all else $unassigned_rows_all[:$unassigned_n] end) as $unassigned_rows
   | (if ($streams_all | length) > $streams_n then $streams_all[:$streams_n] else $streams_all end) as $streams

--- a/bin/fm-workstream-snapshot.sh
+++ b/bin/fm-workstream-snapshot.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# fm-workstream-snapshot.sh - compact, bounded, TOON-by-default workstream projection.
+#
+# A thin wrapper OVER the canonical bin/fm-fleet-snapshot.sh, sibling to
+# bin/fm-bearings-snapshot.sh. It does not parse fleet state itself: it shells
+# out to `fm-fleet-snapshot.sh --json`, projects that complete structured
+# contract into workstream groupings, and renders TOON at the output boundary
+# (bin/fm-toon-lib.sh owns the shared encoder). The internal data model stays
+# JSON (`--json` prints it verbatim); TOON and JSON are parity representations
+# of the same projected model.
+#
+# LOCAL-ONLY, ALWAYS: every invocation makes ZERO GitHub/network/auth calls,
+# and the projection is main-home only (secondmate homes are not sampled; the
+# omission is disclosed). Task current-state truth stays with the canonical
+# snapshot's bin/fm-crew-state.sh read; this wrapper never re-reads state files.
+#
+# WORKSTREAM DERIVATION (the backlog has no workstream field; the convention is
+# umbrella tasks plus edges, and this header is its one owner):
+#   - An umbrella task is a structured, not-done backlog row with kind=program.
+#     Its id is the workstream id, its title the workstream name, and its body
+#     (first indented lines under the row) the intended-outcome line.
+#   - Members are claimed in three deterministic passes, first claim wins, with
+#     umbrellas considered in backlog order:
+#       1. id prefix: a task whose id starts with "<umbrella-id>-".
+#       2. direct edge: a task whose blocked-by list names the umbrella id.
+#       3. fixpoint expansion: a task connected by any blocked-by edge (either
+#          direction) to an already-claimed task joins that task's workstream;
+#          when neighbors disagree, the workstream whose umbrella comes first
+#          in the backlog wins.
+#   - Tasks claimed by no workstream land in the explicit "unassigned" lane
+#     (done tasks outside every workstream are dropped, with disclosure).
+#
+# TASK STATE (one value per board task, first match wins):
+#   done      backlog Done.
+#   decision  captain_actionable (waiting on the captain now).
+#   held      in-flight and held (current_role=held).
+#   review    a live worker record exists and a PR is recorded for it.
+#   active    a live worker record exists, or backlog In flight.
+#   queued    everything else.
+#
+# BOARD-VS-REALITY DIVERGENCE (`divergence[]`): a backlog row still Queued
+# while a live worker record exists (queued-but-live), a backlog In-flight row
+# with no worker record (in-flight-no-worker, from the canonical
+# main_inventory), and a live worker record with no structured backlog row
+# (worker-not-on-board).
+#
+# Flags:
+#   (default)        compact projection, TOON, local-only
+#   --json           the same projected model as JSON (machine/debug; parity form)
+#   --all-tasks      lift the per-workstream and unassigned task-row caps
+#   --all-edges      include every dependency edge
+#   --all-decisions  include prose-deferred captain holds
+#   -h,--help        usage
+#
+# Bounds (positive integers, overridable for tests / large fleets):
+#   FM_WS_STREAMS (12), FM_WS_TASKS (30 per workstream), FM_WS_UNASSIGNED (20),
+#   FM_WS_EDGES (80), FM_WS_DECISIONS (20), FM_WS_AGENTS (20),
+#   FM_WS_DIVERGENCE (20).
+#
+# Output contract: `fm-workstream.v1`. Read-only; no locks, no mutation.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
+# shellcheck source=bin/fm-toon-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-toon-lib.sh"
+
+FM_WS_STREAMS=${FM_WS_STREAMS:-12}
+FM_WS_TASKS=${FM_WS_TASKS:-30}
+FM_WS_UNASSIGNED=${FM_WS_UNASSIGNED:-20}
+FM_WS_EDGES=${FM_WS_EDGES:-80}
+FM_WS_DECISIONS=${FM_WS_DECISIONS:-20}
+FM_WS_AGENTS=${FM_WS_AGENTS:-20}
+FM_WS_DIVERGENCE=${FM_WS_DIVERGENCE:-20}
+validate_bound() {  # <name> <value>
+  case "$2" in ''|*[!0-9]*|0) echo "fm-workstream-snapshot: $1 must be a positive integer" >&2; exit 2 ;; esac
+}
+validate_bound FM_WS_STREAMS "$FM_WS_STREAMS"
+validate_bound FM_WS_TASKS "$FM_WS_TASKS"
+validate_bound FM_WS_UNASSIGNED "$FM_WS_UNASSIGNED"
+validate_bound FM_WS_EDGES "$FM_WS_EDGES"
+validate_bound FM_WS_DECISIONS "$FM_WS_DECISIONS"
+validate_bound FM_WS_AGENTS "$FM_WS_AGENTS"
+validate_bound FM_WS_DIVERGENCE "$FM_WS_DIVERGENCE"
+
+usage() {
+  cat <<'EOF'
+usage: fm-workstream-snapshot.sh [--json] [--all-tasks] [--all-edges]
+                                 [--all-decisions]
+
+Compact workstream projection over fm-fleet-snapshot.sh. TOON by default.
+Always LOCAL-ONLY (no network) and main-home only.
+Workstreams come from umbrella tasks (kind=program) plus id prefixes and
+blocked-by edges; unclaimed tasks land in the explicit "unassigned" lane.
+The script header owns the exact derivation, state, and divergence rules.
+EOF
+}
+
+FORMAT=toon
+ALL_TASKS=0
+ALL_EDGES=0
+ALL_DECISIONS=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --json) FORMAT=json ;;
+    --all-tasks) ALL_TASKS=1 ;;
+    --all-edges) ALL_EDGES=1 ;;
+    --all-decisions) ALL_DECISIONS=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+command -v jq >/dev/null 2>&1 || { echo "fm-workstream-snapshot: jq not found" >&2; exit 1; }
+
+# The deterministic return-catch-up owner must clear before this or any other
+# ordinary captain request proceeds.
+"$SCRIPT_DIR/fm-afk-return.sh" guard || exit $?
+
+NOW=${FM_WS_NOW:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}
+SNAP=$(FM_SNAPSHOT_NOW="$NOW" FM_SNAPSHOT_SECONDMATES=0 "$FLEET" --json) || exit $?
+HOME_LABEL=$(printf '%s' "$SNAP" | jq -er '.fm_home | strings | split("/") | (.[-2:] | join("/"))') \
+  || { echo "fm-workstream-snapshot: invalid canonical snapshot" >&2; exit 1; }
+
+MODEL=$(printf '%s' "$SNAP" | jq \
+  --arg home "$HOME_LABEL" \
+  --arg now "$NOW" \
+  --argjson streams_n "$FM_WS_STREAMS" \
+  --argjson tasks_n "$FM_WS_TASKS" \
+  --argjson unassigned_n "$FM_WS_UNASSIGNED" \
+  --argjson edges_n "$FM_WS_EDGES" \
+  --argjson decisions_n "$FM_WS_DECISIONS" \
+  --argjson agents_n "$FM_WS_AGENTS" \
+  --argjson divergence_n "$FM_WS_DIVERGENCE" \
+  --argjson all_tasks "$ALL_TASKS" \
+  --argjson all_edges "$ALL_EDGES" \
+  --argjson all_decisions "$ALL_DECISIONS" '
+  def trunc($n): if . == null then null else
+    (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
+
+  ([.backlog.records[]? | select(.structured)]) as $recs
+  | ([.tasks[]? | select(.kind != "secondmate")]) as $live
+  | ($live | map({key:.id, value:.}) | from_entries) as $live_map
+  | ($recs | map({key:.id, value:.}) | from_entries) as $by_id
+  | ([$recs[] | select(.kind == "program" and .state != "done")]) as $umbrellas
+  | ($umbrellas | to_entries | map({key:.value.id, value:.key}) | from_entries) as $uidx
+  # Grouping candidates: every structured non-umbrella row, in backlog order.
+  | ([$recs[] | select(.kind != "program" and ($uidx[.id] == null)) | .id]) as $cands
+  # Undirected blocked-by neighbor map over structured rows.
+  | (reduce $recs[] as $r ({};
+       reduce ($r.blocked_by_ids[]?) as $b (.;
+         .[$r.id] = ((.[$r.id] // []) + [$b])
+         | .[$b] = ((.[$b] // []) + [$r.id])))) as $nbr
+  # Pass 1: id-prefix claims, umbrella order.
+  | (reduce $umbrellas[] as $u ({};
+       . as $acc
+       | reduce ($cands[] | select(startswith($u.id + "-"))) as $tid ($acc;
+           if (.[$tid] // null) != null then . else .[$tid] = $u.id end))) as $a1
+  # Pass 2: direct blocked-by edge to the umbrella itself.
+  | (reduce $umbrellas[] as $u ($a1;
+       . as $acc
+       | reduce ($cands[] | select((($by_id[.].blocked_by_ids // []) | index($u.id)) != null)) as $tid ($acc;
+           if (.[$tid] // null) != null then . else .[$tid] = $u.id end))) as $a2
+  # Pass 3: fixpoint expansion along blocked-by edges; ties go to the
+  # workstream whose umbrella comes first in the backlog.
+  | (
+      def expand:
+        . as $a
+        | reduce $cands[] as $tid ($a;
+            if (.[$tid] // null) != null then .
+            else ([ ($nbr[$tid] // [])[] as $n | ($a[$n] // empty) ]
+                  | unique | sort_by($uidx[.])) as $ws
+            | if ($ws | length) > 0 then .[$tid] = $ws[0] else . end end);
+      def fix: . as $prev | expand | if . == $prev then . else fix end;
+      $a2 | fix
+    ) as $assign
+  # One board-task row; the script header owns the state precedence.
+  | def task_state($r):
+      if $r.state == "done" then "done"
+      elif $r.captain_actionable == true then "decision"
+      elif $r.current_role == "held" then "held"
+      elif $live_map[$r.id] != null then
+        (if ($live_map[$r.id].pr.url // null) != null then "review" else "active" end)
+      elif $r.state == "in_flight" then "active"
+      else "queued" end;
+    def task_row($r; $ws):
+      ($live_map[$r.id]) as $l
+      | {id: $r.id, ws: $ws, state: task_state($r),
+         title: (($r.title // $r.id) | trunc(160)),
+         doing: ((($l.current_state.detail // "") as $d
+                  | if $d != "" then $d else ($l.hints.last_event_text // "") end)
+                 | trunc(120)),
+         contract: (($r.body_excerpt // "") | trunc(240)),
+         agent_state: ($l.current_state.state // ""),
+         pr_url: ($l.pr.url // $r.pr_url // null)};
+    def state_rank: {decision:0, held:1, active:2, review:3, queued:4, done:5}[.] // 6;
+  ($umbrellas
+   | map(. as $u
+     | [ $recs[] | select($assign[.id] == $u.id) ] as $members
+     | ($members | map(task_row(.; $u.id))) as $rows
+     | ($rows | sort_by([(.state | state_rank)])) as $sorted
+     | {id: $u.id,
+        name: (($u.title // $u.id) | trunc(90)),
+        outcome: (($u.body_excerpt // $u.title // "") | trunc(240)),
+        actionable: ($u.captain_actionable == true),
+        counts: ($rows | {done: (map(select(.state == "done")) | length),
+                          review: (map(select(.state == "review")) | length),
+                          active: (map(select(.state == "active")) | length),
+                          held: (map(select(.state == "held")) | length),
+                          decision: (map(select(.state == "decision")) | length),
+                          queued: (map(select(.state == "queued")) | length)}),
+        rows: (if $all_tasks == 1 then $sorted else $sorted[:$tasks_n] end),
+        more: (if $all_tasks == 1 then 0 else (($rows | length) - ($sorted[:$tasks_n] | length)) end)})) as $streams_all
+  | ([ $recs[]
+       | select(.kind != "program" and ($uidx[.id] == null) and ($assign[.id] // null) == null and .state != "done") ]) as $unassigned_recs
+  | ($unassigned_recs | map(task_row(.; "unassigned")) | sort_by([(.state | state_rank)])) as $unassigned_rows_all
+  | ([ $recs[] | select(.kind != "program" and ($uidx[.id] == null) and ($assign[.id] // null) == null and .state == "done") ] | length) as $dropped_done
+  | (if $all_tasks == 1 then $unassigned_rows_all else $unassigned_rows_all[:$unassigned_n] end) as $unassigned_rows
+  | (if ($streams_all | length) > $streams_n then $streams_all[:$streams_n] else $streams_all end) as $streams
+  | ($streams | map(.rows[]) + $unassigned_rows) as $rows_included
+  | ($rows_included | map({key:.id, value:true}) | from_entries) as $included
+  | ([ $rows_included[] as $r
+       | ($by_id[$r.id].blocked_by_ids // [])[] as $b
+       | select($included[$b] == true)
+       | {from: $b, to: $r.id,
+          ws: ((($assign[$b] // "unassigned") == ($assign[$r.id] // "unassigned"))
+               as $same | if $same then ($assign[$r.id] // "unassigned") else "cross" end)} ]
+     | unique_by([.from, .to])) as $edges_all
+  | ([ $recs[]
+       | select(.captain_actionable == true)
+       | select(($all_decisions == 1) or (.deferred_marker != true))
+       | {id, ws: (if $uidx[.id] != null then .id else ($assign[.id] // "unassigned") end),
+          summary: (((.title // .id) + ": " + (.hold_reason // "")) | trunc(120))} ]) as $decisions_all
+  | ([ $recs[] | select(.captain_actionable == true and .deferred_marker == true) ] | length) as $decisions_deferred
+  | ([ $live[]
+       | {id, ws: ($assign[.id] // (if $uidx[.id] != null then .id else "unassigned" end)),
+          state: (.current_state.state // "unknown"),
+          doing: (((.current_state.detail // "") as $d
+                   | if $d != "" then $d else (.hints.last_event_text // "") end)
+                  | trunc(90))} ]) as $agents_all
+  | ([ $recs[] | select(.state == "queued" and $live_map[.id] != null)
+       | {id, kind: "queued-but-live",
+          note: "the backlog still has this queued, but a live worker record exists"} ]
+     + [ (.main_inventory.orphan_in_flight // [])[]
+         | (if type == "object" then .id else . end) as $oid
+         | {id: $oid, kind: "in-flight-no-worker",
+            note: "the backlog has this in flight, but no worker record exists"} ]
+     + [ $live[] | select($by_id[.id] == null)
+         | {id, kind: "worker-not-on-board",
+            note: "a live worker record exists with no structured backlog row"} ]) as $divergence_all
+  | {
+      schema: "fm-workstream.v1",
+      home: $home,
+      generated: $now,
+      workstreams: ($streams | map({id, name, outcome, actionable,
+        total: (.counts | add), done: .counts.done, review: .counts.review,
+        active: .counts.active, held: .counts.held, decision: .counts.decision,
+        queued: .counts.queued, more: .more})),
+      tasks: $rows_included,
+      edges: (if $all_edges == 1 then $edges_all else $edges_all[:$edges_n] end),
+      decisions: ($decisions_all[:$decisions_n]),
+      agents: ($agents_all[:$agents_n]),
+      divergence: ($divergence_all[:$divergence_n])
+    }
+  | . + {omitted: (
+      [ {surface:"secondmate homes not sampled; this board is main-home only", reveal:"/bearings covers the fleet"},
+        (if ($streams_all | length) > ($streams | length) then {surface:("workstreams showing \($streams | length) of \($streams_all | length)"), reveal:"raise FM_WS_STREAMS"} else empty end),
+        (([$streams[] | select(.more > 0)] | length) as $capped
+         | if $capped > 0 then {surface:("task rows capped in \($capped) workstream(s)"), reveal:"--all-tasks"} else empty end),
+        (if ($unassigned_rows_all | length) > ($unassigned_rows | length) then {surface:("unassigned tasks showing \($unassigned_rows | length) of \($unassigned_rows_all | length)"), reveal:"--all-tasks"} else empty end),
+        (if $dropped_done > 0 then {surface:("done tasks outside every workstream dropped: \($dropped_done)"), reveal:"tasks-axi list --state done"} else empty end),
+        (if $all_edges == 0 and ($edges_all | length) > $edges_n then {surface:("edges showing \($edges_n) of \($edges_all | length)"), reveal:"--all-edges"} else empty end),
+        (if ($decisions_all | length) > $decisions_n then {surface:("decisions showing \($decisions_n) of \($decisions_all | length)"), reveal:"raise FM_WS_DECISIONS"} else empty end),
+        (if $all_decisions == 0 and $decisions_deferred > 0 then {surface:("captain holds marked deferred or superseded: \($decisions_deferred)"), reveal:"--all-decisions"} else empty end),
+        (if ($agents_all | length) > $agents_n then {surface:("agents showing \($agents_n) of \($agents_all | length)"), reveal:"raise FM_WS_AGENTS"} else empty end),
+        (if ($divergence_all | length) > $divergence_n then {surface:("divergence showing \($divergence_n) of \($divergence_all | length)"), reveal:"raise FM_WS_DIVERGENCE"} else empty end) ]) }
+') || { echo "fm-workstream-snapshot: projection failed" >&2; exit 1; }
+
+if [ "$FORMAT" = json ]; then
+  printf '%s\n' "$MODEL"
+  exit 0
+fi
+
+# The tasks table is the one nested surface; flatten nothing - every model
+# array already holds uniform scalar objects, so the shared encoder applies.
+TOON=$(printf '%s\n' "$MODEL" | fm_toon_render) \
+  || { echo "fm-workstream-snapshot: TOON rendering failed" >&2; exit 1; }
+printf '%s\n' "$TOON"

--- a/bin/fm-workstream-snapshot.sh
+++ b/bin/fm-workstream-snapshot.sh
@@ -16,7 +16,9 @@
 #
 # WORKSTREAM DERIVATION (the backlog has no workstream field; the convention is
 # umbrella tasks plus edges, and this header is its one owner):
-#   - An umbrella task is a structured, not-done backlog row with kind=program.
+#   - An umbrella task is a structured backlog row with kind=program, done or
+#     not: a finished umbrella keeps its workstream, so its members stay
+#     anchored to it instead of scattering into the unassigned lane.
 #     Its id is the workstream id, its title the workstream name, and its body
 #     (first indented lines under the row) the intended-outcome line.
 #   - Members are claimed in three deterministic passes, first claim wins, with
@@ -27,8 +29,10 @@
 #          direction) to an already-claimed task joins that task's workstream;
 #          when neighbors disagree, the workstream whose umbrella comes first
 #          in the backlog wins.
-#   - Tasks claimed by no workstream land in the explicit "unassigned" lane
-#     (done tasks outside every workstream are dropped, with disclosure).
+#   - Tasks claimed by no workstream land in the explicit "unassigned" lane,
+#     which is a real workstreams[] entry with its own counts and `more` and is
+#     never subject to the FM_WS_STREAMS cap (done tasks outside every
+#     workstream are dropped, with disclosure).
 #
 # TASK STATE (one value per board task, first match wins):
 #   done      backlog Done.
@@ -144,7 +148,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   | ([.tasks[]? | select(.kind != "secondmate")]) as $live
   | ($live | map({key:.id, value:.}) | from_entries) as $live_map
   | ($recs | map({key:.id, value:.}) | from_entries) as $by_id
-  | ([$recs[] | select(.kind == "program" and .state != "done")]) as $umbrellas
+  | ([$recs[] | select(.kind == "program")]) as $umbrellas
   | ($umbrellas | to_entries | map({key:.value.id, value:.key}) | from_entries) as $uidx
   # Grouping candidates: every structured non-umbrella row, in backlog order.
   | ([$recs[] | select(.kind != "program" and ($uidx[.id] == null)) | .id]) as $cands
@@ -216,6 +220,12 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   | ([ $recs[]
        | select(.kind != "program" and ($uidx[.id] == null) and ($assign[.id] // null) == null and .state != "done") ]) as $unassigned_recs
   | ($unassigned_recs | map(task_row(.; "unassigned")) | sort_by([(.state | state_rank)])) as $unassigned_rows_all
+  | ($unassigned_rows_all | {done: (map(select(.state == "done")) | length),
+                             review: (map(select(.state == "review")) | length),
+                             active: (map(select(.state == "active")) | length),
+                             held: (map(select(.state == "held")) | length),
+                             decision: (map(select(.state == "decision")) | length),
+                             queued: (map(select(.state == "queued")) | length)}) as $un_counts
   | ([ $recs[] | select(.kind != "program" and ($uidx[.id] == null) and ($assign[.id] // null) == null and .state == "done") ] | length) as $dropped_done
   | (if $all_tasks == 1 then $unassigned_rows_all else $unassigned_rows_all[:$unassigned_n] end) as $unassigned_rows
   | (if ($streams_all | length) > $streams_n then $streams_all[:$streams_n] else $streams_all end) as $streams
@@ -254,10 +264,20 @@ MODEL=$(printf '%s' "$SNAP" | jq \
       schema: "fm-workstream.v1",
       home: $home,
       generated: $now,
-      workstreams: ($streams | map({id, name, outcome, actionable,
+      workstreams: (($streams | map({id, name, outcome, actionable,
         total: (.counts | add), done: .counts.done, review: .counts.review,
         active: .counts.active, held: .counts.held, decision: .counts.decision,
-        queued: .counts.queued, more: .more})),
+        queued: .counts.queued, more: .more}))
+        + (if ($unassigned_rows_all | length) > 0 then
+             [{id: "unassigned", name: "Unassigned",
+               outcome: "Tasks claimed by no workstream.",
+               actionable: false,
+               total: ($un_counts | add), done: $un_counts.done,
+               review: $un_counts.review, active: $un_counts.active,
+               held: $un_counts.held, decision: $un_counts.decision,
+               queued: $un_counts.queued,
+               more: (($unassigned_rows_all | length) - ($unassigned_rows | length))}]
+           else [] end)),
       tasks: $rows_included,
       edges: (if $all_edges == 1 then $edges_all else $edges_all[:$edges_n] end),
       decisions: ($decisions_all[:$decisions_n]),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ The semantic branch reports working only on an exact busy verdict and names the 
 For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, bounded current summaries from registered secondmate homes, and secondmate return-channel guidance.
 Each home also atomically publishes that same bounded home summary with freshness epoch metadata at `state/home-summary.json` after a locked session start, a watcher-observed status change, task spawn, task teardown, and on a recurring live-watcher cadence; `bin/fm-home-summary-refresh.sh` owns the publication mechanics.
 The fleet snapshot and Bearings paths do not consume this additive publication yet, so mixed-version homes without it retain the established on-demand summary behavior.
-`bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so both views consume one structured contract instead of reparsing raw fleet files.
+`bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection and `bin/fm-workstream-snapshot.sh` the bounded workstream-lane projection, so every view consumes one structured contract instead of reparsing raw fleet files.
 The script header owns the exact JSON schema.
 
 On a Pi primary, supervision is default-on: the watcher extension can hand eligible task-local rows from an ordinary actionable wake, plus selected fleet-wide heartbeat reviews, to a persistent in-process supervision conversation while main-only rows remain on the captain-facing path.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -237,6 +237,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/workstreams/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".greptile/rules.md",
       "audience": "maintainer-architecture"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -19,6 +19,10 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-bearings-board.sh`   | Build and arm the stable interactive `/bearings lavish` fleet board                  |
+| `fm-workstream-snapshot.sh` | Project the fleet snapshot into bounded workstream lanes, edges, and divergence rows; always local-only |
+| `fm-workstream-board.sh` | Build and arm the stable interactive `/workstreams` lavish board                     |
+| `fm-board-lib.sh`        | Shared lavish board build sequence for the bearings and workstream builders: inject, round-trip check, serve then bind then arm |
+| `fm-toon-lib.sh`         | Shared TOON encoder for the snapshot wrappers' output boundary                       |
 | `fm-secondmate-reconcile.sh` | Ask each secondmate to reconcile an inventory mismatch through its durable inbox, limited by a per-home cooldown |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and local or remote secondmate homes       |
 | `fm-on.sh`               | Execute one tracked Firstmate command in a configured remote secondmate home, using its job worker except for the doctor bootstrap |

--- a/tests/assets/workstream-render-harness.mjs
+++ b/tests/assets/workstream-render-harness.mjs
@@ -118,6 +118,7 @@ const streams = streamsCol.children.map((card) => {
     return {
       id: sum ? firstClass(sum, "wb-trow__id")?.textContent : "",
       title: sum ? firstClass(sum, "wb-trow__t")?.textContent : "",
+      titleAttr: sum ? (firstClass(sum, "wb-trow__t")?.attributes.title ?? "") : "",
       held: row.className.includes("wb-trow--held"),
       decision: row.className.includes("wb-trow--decision"),
       expandable: row.tagName === "details",
@@ -129,6 +130,11 @@ const streams = streamsCol.children.map((card) => {
     ? {
         nodes: svg[0].children.filter((c) => c.tagName === "rect").length,
         edges: svg[0].children.filter((c) => c.tagName === "line").length,
+        labels: svg[0].children.filter((c) => c.tagName === "text").map((t) => t.textContent).sort(),
+        nodeTitles: svg[0].children
+          .filter((c) => c.tagName === "rect")
+          .map((r) => r.children.find((c) => c.tagName === "title")?.textContent ?? "")
+          .sort(),
       }
     : null;
   return {
@@ -136,7 +142,11 @@ const streams = streamsCol.children.map((card) => {
     title: head ? firstClass(head, "ws-head-top")?.children.find((c) => c.tagName === "h2")?.textContent : "",
     badges: head ? deep(head, "fm-badge").map((b) => b.textContent) : [],
     outcome: head ? (firstClass(head, "ws-outcome")?.textContent ?? "") : "",
-    segments: head ? deep(head, "ws-progress").flatMap((p) => p.children.map((s) => s.className)) : [],
+    segments: head
+      ? deep(head, "ws-progress").flatMap((p) =>
+          p.children.map((s) => ({ cls: s.className, width: s.style.width })))
+      : [],
+    key: head ? deep(head, "ws-key").flatMap((k) => k.children.map((i) => i.textContent)) : [],
     rows,
     more: deep(card, "wb-morechip").map((c) => c.textContent),
     graph,

--- a/tests/assets/workstream-render-harness.mjs
+++ b/tests/assets/workstream-render-harness.mjs
@@ -155,6 +155,7 @@ const streams = streamsCol.children.map((card) => {
     crossKey: deep(card, "ws-key--cross").flatMap((k) => k.children.map((i) => i.textContent)),
     rows,
     more: deep(card, "wb-morechip").map((c) => c.textContent),
+    empty: deep(card, "wb-empty").length > 0,
     graph,
   };
 });

--- a/tests/assets/workstream-render-harness.mjs
+++ b/tests/assets/workstream-render-harness.mjs
@@ -135,6 +135,11 @@ const streams = streamsCol.children.map((card) => {
           .filter((c) => c.tagName === "rect")
           .map((r) => r.children.find((c) => c.tagName === "title")?.textContent ?? "")
           .sort(),
+        mutedNodes: svg[0].children
+          .filter((c) => c.tagName === "rect" && c.attributes.opacity)
+          .map((r) => r.children.find((c) => c.tagName === "title")?.textContent ?? "")
+          .sort(),
+        ariaLabel: svg[0].attributes["aria-label"] ?? "",
       }
     : null;
   return {
@@ -147,6 +152,7 @@ const streams = streamsCol.children.map((card) => {
           p.children.map((s) => ({ cls: s.className, width: s.style.width })))
       : [],
     key: head ? deep(head, "ws-key").flatMap((k) => k.children.map((i) => i.textContent)) : [],
+    crossKey: deep(card, "ws-key--cross").flatMap((k) => k.children.map((i) => i.textContent)),
     rows,
     more: deep(card, "wb-morechip").map((c) => c.textContent),
     graph,

--- a/tests/assets/workstream-render-harness.mjs
+++ b/tests/assets/workstream-render-harness.mjs
@@ -1,0 +1,182 @@
+// Render a built workstream board's shipped inline script under a minimal DOM
+// shim and print what the renderer actually produced, so board behavior is
+// asserted through the real template rather than by reading its source.
+//
+// Usage: node workstream-render-harness.mjs <built-board.html>
+// Prints one JSON document:
+//   { stats:[{n,label,href}], streams:[{id,name,badges,rows,graph}],
+//     waiting:[{key,title,options}], agents:[{id,doing}],
+//     divergence:[{id,note}], error }
+import { readFileSync } from "node:fs";
+
+const html = readFileSync(process.argv[2], "utf8");
+
+class Node {
+  constructor(tag) {
+    this.tagName = tag;
+    this.className = "";
+    this.children = [];
+    this.attributes = {};
+    this._text = "";
+    this.hidden = false;
+    this.disabled = false;
+    this.innerHTML = "";
+    this.parentNode = null;
+    this.type = "";
+    this.value = "";
+    this.checked = false;
+    this.id = "";
+    this.style = {};
+    this.classList = {
+      add: (c) => { this.className = (this.className + " " + c).trim(); },
+      remove: (c) => {
+        this.className = this.className.split(/\s+/).filter((x) => x !== c).join(" ");
+      },
+      contains: (c) => this.className.split(/\s+/).includes(c),
+    };
+  }
+  get textContent() {
+    return this.children.length
+      ? this.children.map((c) => c.textContent).join("")
+      : this._text;
+  }
+  set textContent(v) { this._text = String(v); this.children = []; }
+  appendChild(n) { n.parentNode = this; this.children.push(n); return n; }
+  setAttribute(k, v) { this.attributes[k] = String(v); if (k === "id") this.id = String(v); }
+  addEventListener() {}
+  querySelectorAll(sel) {
+    const want = sel.replace(/^\./, "").replace(/:checked$/, "");
+    const checkedOnly = sel.endsWith(":checked");
+    const out = [];
+    const walk = (n) => {
+      for (const c of n.children) {
+        if (c.className.split(/\s+/).includes(want) && (!checkedOnly || c.checked)) out.push(c);
+        walk(c);
+      }
+    };
+    walk(this);
+    return out;
+  }
+}
+
+class TextNode {
+  constructor(text) { this._text = String(text); this.children = []; this.className = ""; this.tagName = "#text"; }
+  get textContent() { return this._text; }
+}
+
+const byId = new Map();
+const dataNode = new Node("script");
+dataNode.textContent = html
+  .split('<script id="workstream-data" type="application/json">')[1]
+  .split("</script>")[0];
+byId.set("workstream-data", dataNode);
+
+globalThis.document = {
+  createElement: (tag) => new Node(tag),
+  createElementNS: (_ns, tag) => new Node(tag),
+  createTextNode: (text) => new TextNode(text),
+  // Lazily mint any element the page asks for: the shim tracks whatever ids
+  // the shipped template actually uses instead of pinning a fixed list.
+  getElementById: (id) => {
+    if (!byId.has(id)) {
+      const n = new Node("div");
+      new Node("div").appendChild(n);
+      byId.set(id, n);
+    }
+    return byId.get(id);
+  },
+  querySelector: (sel) => {
+    const id = "sel:" + sel;
+    if (!byId.has(id)) byId.set(id, new Node("div"));
+    return byId.get(id);
+  },
+};
+globalThis.window = {};
+globalThis.TextEncoder = TextEncoder;
+
+const script = html.slice(html.indexOf("<script>") + "<script>".length, html.lastIndexOf("</script>"));
+new Function(script)();
+
+const byClass = (n, cls) => n.children.filter((c) => c.className.split(/\s+/).includes(cls));
+const firstClass = (n, cls) => byClass(n, cls)[0];
+const deep = (n, cls) => n.querySelectorAll("." + cls);
+
+const strip = byId.get("wb-stats") || new Node("div");
+const stats = strip.children.map((t) => ({
+  n: Number(firstClass(t, "wb-stat__num")?.textContent),
+  label: firstClass(t, "wb-stat__label")?.textContent,
+  href: t.attributes.href ?? "",
+  attn: t.className.includes("wb-stat--attn"),
+  warn: t.className.includes("wb-stat--warn"),
+}));
+
+const streamsCol = byId.get("wb-streams") || new Node("div");
+const streams = streamsCol.children.map((card) => {
+  const head = firstClass(card, "ws-head");
+  const rows = deep(card, "wb-trow").map((row) => {
+    const sum = firstClass(row, "wb-trow__sum");
+    return {
+      id: sum ? firstClass(sum, "wb-trow__id")?.textContent : "",
+      title: sum ? firstClass(sum, "wb-trow__t")?.textContent : "",
+      held: row.className.includes("wb-trow--held"),
+      decision: row.className.includes("wb-trow--decision"),
+      expandable: row.tagName === "details",
+      agent: sum ? (firstClass(sum, "wb-agent")?.textContent ?? "") : "",
+    };
+  });
+  const svg = deep(card, "ws-fig").flatMap((f) => f.children.filter((c) => c.tagName === "svg"));
+  const graph = svg.length
+    ? {
+        nodes: svg[0].children.filter((c) => c.tagName === "rect").length,
+        edges: svg[0].children.filter((c) => c.tagName === "line").length,
+      }
+    : null;
+  return {
+    id: card.id,
+    title: head ? firstClass(head, "ws-head-top")?.children.find((c) => c.tagName === "h2")?.textContent : "",
+    badges: head ? deep(head, "fm-badge").map((b) => b.textContent) : [],
+    outcome: head ? (firstClass(head, "ws-outcome")?.textContent ?? "") : "",
+    segments: head ? deep(head, "ws-progress").flatMap((p) => p.children.map((s) => s.className)) : [],
+    rows,
+    more: deep(card, "wb-morechip").map((c) => c.textContent),
+    graph,
+  };
+});
+
+const waitingItems = byId.get("wb-waiting-items") || new Node("div");
+const waiting = waitingItems.children
+  .filter((item) => deep(item, "wb-qform").length)
+  .map((item) => {
+    const form = deep(item, "wb-qform")[0];
+    return {
+      key: firstClass(item, "wb-k")?.textContent ?? "",
+      question: form.attributes["data-lavish-question"] ?? "",
+      options: form.children
+        .filter((c) => c.tagName === "label")
+        .map((lab) => lab.children.find((c) => c.type === "radio")?.value ?? ""),
+      freeform: form.children.some((c) => c.className.includes("wb-freeform")),
+    };
+  });
+
+const agentsItems = byId.get("wb-agents-items") || new Node("div");
+const agents = agentsItems.children
+  .map((row) => ({ chip: firstClass(row, "wb-agent")?.textContent ?? "" }))
+  .filter((a) => a.chip);
+
+const dv = byId.get("wb-divergence") || new Node("div");
+const divergence = {
+  hidden: dv.hidden,
+  rows: deep(dv, "wb-callout__row").map((r) => ({
+    id: firstClass(r, "wb-callout__id")?.textContent ?? "",
+    note: r.children[1]?.textContent ?? "",
+  })),
+};
+
+// A fail-closed render replaces the page body instead of the board sections,
+// so surface it rather than reporting an empty board as a successful render.
+const errorText = [...byId.entries()]
+  .filter(([k]) => k.startsWith("sel:"))
+  .flatMap(([, n]) => n.children.map((c) => c.textContent))
+  .join(" ");
+
+process.stdout.write(JSON.stringify({ stats, streams, waiting, agents, divergence, error: errorText }) + "\n");

--- a/tests/fm-workstream-board-render.test.sh
+++ b/tests/fm-workstream-board-render.test.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Behavior tests for the shipped workstream board renderer
+# (.agents/skills/workstreams/assets/board-template.html), exercised through a
+# real `fm-workstream-board.sh build` and then executed under the minimal DOM
+# shim in tests/assets/workstream-render-harness.mjs. The assertions are on what
+# the page renders - stat tiles, workstream cards, the dependency graph, the
+# waiting rail, the divergence callout - never on the template's source text.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BOARD="$ROOT/bin/fm-workstream-board.sh"
+HARNESS="$ROOT/tests/assets/workstream-render-harness.mjs"
+TEMPLATE="$ROOT/.agents/skills/workstreams/assets/board-template.html"
+TMP_ROOT=$(fm_test_tmproot fm-workstream-board-render)
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+command -v node >/dev/null 2>&1 || { echo "skip: node not found"; exit 0; }
+
+make_home() {  # <name>
+  local home="$TMP_ROOT/$1" fakebin
+  mkdir -p "$home/state" "$home/data"
+  fakebin=$(fm_fakebin "$home")
+  fm_fake_exit0 "$fakebin" lavish-axi
+  printf '%s\n' "$home"
+}
+
+# Build the board from a full payload document and return what the renderer produced.
+render() {  # <home> <payload-json>
+  local home=$1 payload=$2 data="$1/payload.json"
+  printf '%s\n' "$payload" > "$data"
+  PATH="$home/fakebin:$PATH" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
+    "$BOARD" build "$data" >/dev/null || fail "the board did not build"
+  node "$HARNESS" "$home/.lavish/workstreams.html" \
+    || fail "the built board could not be rendered"
+}
+
+base_payload() {
+  cat <<'EOF'
+{
+  "schema": "fm-workstream-board.v1",
+  "home": "render-home",
+  "generated": "2026-09-01T00:00Z",
+  "workstreams": [
+    { "id": "quote-flow", "name": "Quote Flow",
+      "outcome": "Never silently drop a part.",
+      "tasks": [
+        { "id": "quote-flow-fixes", "title": "G9 loud failure", "state": "held",
+          "doing": "fix round 16", "agent": "claude · working", "agent_tone": "working" },
+        { "id": "spend-call", "title": "Eval spend decision", "state": "decision" },
+        { "id": "g6-define", "title": "Define G6", "state": "done" },
+        { "id": "build-g6", "title": "Build G6", "state": "queued" },
+        { "id": "island", "title": "No edges touch this row", "state": "queued" }
+      ],
+      "more_tasks": 3 }
+  ],
+  "edges": [
+    { "from": "g6-define", "to": "build-g6" },
+    { "from": "elsewhere", "to": "build-g6" }
+  ],
+  "waiting": [
+    { "key": "spend-call", "title": "Eval baseline spend",
+      "options": [
+        { "value": "full", "label": "Full baseline" },
+        { "value": "returns-only", "label": "Returns only" }
+      ],
+      "recommend_value": "returns-only", "allow_freeform": true, "close": "release" }
+  ],
+  "agents": [ { "id": "quote-flow-fixes", "tone": "working", "doing": "fix round 16" } ],
+  "divergence": [ { "id": "analytics-triage", "note": "backlog queued, live PR open" } ]
+}
+EOF
+}
+
+test_the_full_board_renders_every_section() {
+  local home out
+  home=$(make_home full)
+  out=$(render "$home" "$(base_payload)")
+  printf '%s' "$out" | jq -e '.error == ""' >/dev/null \
+    || fail "the board rendered its fail-closed error instead of the fleet: $out"
+  printf '%s' "$out" | jq -e '
+    ([.stats[] | {key:.label, value:.n}] | from_entries) as $s
+    | $s["workstreams"] == 1 and $s["tasks on the board"] == 5
+      and $s["agents live"] == 1 and $s["waiting on you"] == 1
+      and $s["board ≠ reality"] == 1
+  ' >/dev/null || fail "the stat tiles do not carry the board tallies: $out"
+  printf '%s' "$out" | jq -e '
+    (.stats[] | select(.label == "waiting on you") | .attn) == true
+      and (.stats[] | select(.label == "board ≠ reality") | .warn) == true
+      and ([.stats[].href] | index("#wb-waiting") != null)
+  ' >/dev/null || fail "the attention tiles do not read as anchors: $out"
+  printf '%s' "$out" | jq -e '
+    (.streams | length) == 1 and (.streams[0].id == "ws-quote-flow")
+      and (.streams[0].title == "Quote Flow")
+      and (.streams[0].badges | any(test("1 needs your decision")))
+      and (.streams[0].badges | any(test("1 held")))
+  ' >/dev/null || fail "the workstream card head is not rendered: $out"
+  printf '%s' "$out" | jq -e '
+    (.streams[0].rows | length) == 5
+      and (.streams[0].rows[] | select(.id == "quote-flow-fixes") | .held and .expandable and (.agent | test("working")))
+      and (.streams[0].rows[] | select(.id == "spend-call") | .decision)
+      and (.streams[0].more == ["+3 more - ask firstmate for the full list"])
+  ' >/dev/null || fail "the task rows do not render their states: $out"
+  printf '%s' "$out" | jq -e '
+    (.waiting | length) == 1 and .waiting[0].question == "spend-call"
+      and (.waiting[0].options == ["full", "returns-only"]) and .waiting[0].freeform
+  ' >/dev/null || fail "the waiting rail form is not rendered: $out"
+  printf '%s' "$out" | jq -e '
+    .divergence.hidden == false
+      and (.divergence.rows == [{"id":"analytics-triage","note":"backlog queued, live PR open"}])
+  ' >/dev/null || fail "the board-vs-reality callout is not rendered: $out"
+  pass "the full board renders stats, cards, rows, forms, and the callout"
+}
+
+test_the_dependency_graph_draws_only_edge_touched_local_nodes() {
+  local home out
+  home=$(make_home graph)
+  out=$(render "$home" "$(base_payload)")
+  # One local edge (g6-define -> build-g6); the edge to a task outside the
+  # workstream is dropped, and the untouched rows stay out of the drawing.
+  printf '%s' "$out" | jq -e '
+    .streams[0].graph == {"nodes": 2, "edges": 1}
+  ' >/dev/null || fail "the dependency graph did not draw the local edge set: $out"
+  pass "the dependency graph draws exactly the edge-touched local nodes"
+}
+
+test_a_board_without_edges_or_divergence_stays_quiet() {
+  local home out payload
+  home=$(make_home quiet)
+  payload=$(base_payload | jq '.edges = [] | .divergence = [] | .waiting = [] | .agents = []')
+  out=$(render "$home" "$payload")
+  printf '%s' "$out" | jq -e '
+    (.streams[0].graph == null)
+      and .divergence.hidden == true
+      and ([.stats[].label] | index("board ≠ reality") == null)
+      and (.waiting | length) == 0
+  ' >/dev/null || fail "an edge-free, divergence-free board still drew those sections: $out"
+  pass "a board without edges, divergence, or waiting items stays quiet"
+}
+
+test_unreadable_data_fails_closed() {
+  local home board out
+  home=$(make_home failclosed)
+  board="$home/.lavish/workstreams.html"
+  mkdir -p "$home/.lavish"
+  # Corrupt the data block directly: the builder would refuse this payload, so
+  # the template's own fail-closed path is exercised without it.
+  perl -pe 's/^__FM_WORKSTREAM_BOARD_DATA__$/{"schema": "fm-workstream-board.v1", "broken": /' \
+    "$TEMPLATE" > "$board"
+  out=$(node "$HARNESS" "$board") || fail "the corrupted board crashed the harness"
+  printf '%s' "$out" | jq -e '
+    (.error | test("could not load")) and (.stats | length) == 0
+  ' >/dev/null || fail "unreadable board data did not fail closed: $out"
+  pass "unreadable board data renders the fail-closed notice, not an empty fleet"
+}
+
+test_the_full_board_renders_every_section
+test_the_dependency_graph_draws_only_edge_touched_local_nodes
+test_a_board_without_edges_or_divergence_stays_quiet
+test_unreadable_data_fails_closed

--- a/tests/fm-workstream-board-render.test.sh
+++ b/tests/fm-workstream-board-render.test.sh
@@ -200,7 +200,8 @@ test_every_task_row_exposes_its_full_title() {
   home=$(make_home titles)
   payload=$(base_payload | jq '
     .workstreams[0].tasks += [{ id: "long-queued", state: "queued",
-      title: "A queued backlog row whose title is far too long to fit on one line of the board" }]')
+      title: "A queued backlog row whose title is far too long to fit on one line of the board" }]
+    | .workstreams[0].counts.queued += 1')
   out=$(render "$home" "$payload")
   # The plain row has no disclosure control, so its full title has to be
   # reachable from the summary itself.

--- a/tests/fm-workstream-board-render.test.sh
+++ b/tests/fm-workstream-board-render.test.sh
@@ -56,6 +56,7 @@ base_payload() {
         { "id": "build-g6", "title": "Build G6", "state": "queued" },
         { "id": "island", "title": "No edges touch this row", "state": "queued" }
       ],
+      "counts": { "done": 3, "review": 0, "active": 0, "held": 1, "decision": 1, "queued": 3 },
       "more_tasks": 3 }
   ],
   "edges": [
@@ -98,6 +99,7 @@ test_the_full_board_renders_every_section() {
       and (.streams[0].title == "Quote Flow")
       and (.streams[0].badges | any(test("1 needs your decision")))
       and (.streams[0].badges | any(test("1 held")))
+      and (.streams[0].key | any(test("^3 done$")))
   ' >/dev/null || fail "the workstream card head is not rendered: $out"
   printf '%s' "$out" | jq -e '
     (.streams[0].rows | length) == 5
@@ -145,25 +147,47 @@ test_a_cross_workstream_edge_is_drawn_on_both_cards() {
       and (.streams[0].graph.nodeTitles | any(test("ontology-rows.*Chat Ontology")))
       and (.streams[1].graph.nodeTitles | any(test("g6-define.*Quote Flow")))
   ' >/dev/null || fail "the cross-workstream edge was not drawn: $out"
+  # The foreign node is muted and named in plain text under the drawing and in
+  # the graph's accessible label, so it never reads as a task of this lane.
+  printf '%s' "$out" | jq -e '
+    (.streams[0].graph.mutedNodes | length) == 1
+      and (.streams[0].graph.mutedNodes[0] | test("ontology-rows"))
+      and (.streams[0].crossKey == ["ontology-rows - in Chat Ontology"])
+      and (.streams[0].graph.ariaLabel | test("ontology-rows in Chat Ontology"))
+      and (.streams[1].crossKey == ["g6-define - in Quote Flow"])
+  ' >/dev/null || fail "the foreign graph node is indistinguishable from a local one: $out"
   pass "a cross-workstream dependency edge is drawn on both workstream cards"
+}
+
+test_a_same_lane_graph_marks_no_foreign_node() {
+  local home out
+  home=$(make_home localgraph)
+  out=$(render "$home" "$(base_payload)")
+  printf '%s' "$out" | jq -e '
+    (.streams[0].graph.mutedNodes == []) and (.streams[0].crossKey == [])
+      and (.streams[0].graph.ariaLabel == "Dependency graph")
+  ' >/dev/null || fail "an all-local graph claimed a foreign node: $out"
+  pass "an all-local dependency graph marks nothing as foreign"
 }
 
 test_the_progress_bar_reports_the_whole_lane() {
   local home out payload
   home=$(make_home progress)
-  # 30 rows visible out of 60; the tail the cap dropped is all done work.
+  # 5 rows visible out of 60; the tail the cap dropped is all done work.
   payload=$(base_payload | jq '
-    .workstreams[0].more_tasks = 30
+    .workstreams[0].more_tasks = 55
     | .workstreams[0].counts = { done: 55, review: 0, active: 5, held: 0, decision: 0, queued: 0 }')
   out=$(render "$home" "$payload")
   printf '%s' "$out" | jq -e '
     (.streams[0].segments | map(select(.cls == "ws-seg--done")) | first | .width)
       == ((55 * 100 / 60 | tostring) + "%")
       and (.streams[0].key | any(test("^55 done$")))
+      and (.streams[0].rows | length) == 5
   ' >/dev/null || fail "the progress bar did not report the lane totals: $out"
 
-  # Without declared counts the bar stays consistent with the rows it drew.
-  out=$(render "$home" "$(base_payload)")
+  # An uncapped lane may omit counts; the bar then matches the rows it drew.
+  payload=$(base_payload | jq 'del(.workstreams[0].counts, .workstreams[0].more_tasks)')
+  out=$(render "$home" "$payload")
   printf '%s' "$out" | jq -e '
     (.streams[0].segments | map(select(.cls == "ws-seg--done")) | first | .width)
       == ((1 * 100 / 5 | tostring) + "%")
@@ -224,6 +248,7 @@ test_unreadable_data_fails_closed() {
 test_the_full_board_renders_every_section
 test_the_dependency_graph_draws_only_edge_touched_local_nodes
 test_a_cross_workstream_edge_is_drawn_on_both_cards
+test_a_same_lane_graph_marks_no_foreign_node
 test_the_progress_bar_reports_the_whole_lane
 test_every_task_row_exposes_its_full_title
 test_a_board_without_edges_or_divergence_stays_quiet

--- a/tests/fm-workstream-board-render.test.sh
+++ b/tests/fm-workstream-board-render.test.sh
@@ -120,12 +120,75 @@ test_the_dependency_graph_draws_only_edge_touched_local_nodes() {
   local home out
   home=$(make_home graph)
   out=$(render "$home" "$(base_payload)")
-  # One local edge (g6-define -> build-g6); the edge to a task outside the
-  # workstream is dropped, and the untouched rows stay out of the drawing.
+  # One local edge (g6-define -> build-g6); the edge whose other endpoint is on
+  # no card is dropped, and the untouched rows stay out of the drawing.
   printf '%s' "$out" | jq -e '
-    .streams[0].graph == {"nodes": 2, "edges": 1}
+    .streams[0].graph.nodes == 2 and .streams[0].graph.edges == 1
+      and (.streams[0].graph.labels == ["build-g6", "g6-define"])
   ' >/dev/null || fail "the dependency graph did not draw the local edge set: $out"
   pass "the dependency graph draws exactly the edge-touched local nodes"
+}
+
+test_a_cross_workstream_edge_is_drawn_on_both_cards() {
+  local home out payload
+  home=$(make_home crossedge)
+  payload=$(base_payload | jq '
+    .workstreams += [{ id: "ontology", name: "Chat Ontology",
+      tasks: [{ id: "ontology-rows", title: "Ontology rows", state: "queued" }] }]
+    | .edges = [{ from: "g6-define", to: "ontology-rows" }]')
+  out=$(render "$home" "$payload")
+  # The one edge crosses two workstreams, so both cards draw it with the
+  # foreign endpoint named, and the foreign node says which lane it lives in.
+  printf '%s' "$out" | jq -e '
+    ([.streams[] | .graph.edges] == [1, 1])
+      and ([.streams[] | .graph.labels] == [["g6-define", "ontology-rows"], ["g6-define", "ontology-rows"]])
+      and (.streams[0].graph.nodeTitles | any(test("ontology-rows.*Chat Ontology")))
+      and (.streams[1].graph.nodeTitles | any(test("g6-define.*Quote Flow")))
+  ' >/dev/null || fail "the cross-workstream edge was not drawn: $out"
+  pass "a cross-workstream dependency edge is drawn on both workstream cards"
+}
+
+test_the_progress_bar_reports_the_whole_lane() {
+  local home out payload
+  home=$(make_home progress)
+  # 30 rows visible out of 60; the tail the cap dropped is all done work.
+  payload=$(base_payload | jq '
+    .workstreams[0].more_tasks = 30
+    | .workstreams[0].counts = { done: 55, review: 0, active: 5, held: 0, decision: 0, queued: 0 }')
+  out=$(render "$home" "$payload")
+  printf '%s' "$out" | jq -e '
+    (.streams[0].segments | map(select(.cls == "ws-seg--done")) | first | .width)
+      == ((55 * 100 / 60 | tostring) + "%")
+      and (.streams[0].key | any(test("^55 done$")))
+  ' >/dev/null || fail "the progress bar did not report the lane totals: $out"
+
+  # Without declared counts the bar stays consistent with the rows it drew.
+  out=$(render "$home" "$(base_payload)")
+  printf '%s' "$out" | jq -e '
+    (.streams[0].segments | map(select(.cls == "ws-seg--done")) | first | .width)
+      == ((1 * 100 / 5 | tostring) + "%")
+  ' >/dev/null || fail "an uncounted lane did not fall back to its visible rows: $out"
+  pass "the progress bar reports the lane totals, not the capped row subset"
+}
+
+test_every_task_row_exposes_its_full_title() {
+  local home out payload
+  home=$(make_home titles)
+  payload=$(base_payload | jq '
+    .workstreams[0].tasks += [{ id: "long-queued", state: "queued",
+      title: "A queued backlog row whose title is far too long to fit on one line of the board" }]')
+  out=$(render "$home" "$payload")
+  # The plain row has no disclosure control, so its full title has to be
+  # reachable from the summary itself.
+  printf '%s' "$out" | jq -e '
+    (.streams[0].rows[] | select(.id == "long-queued"))
+    | .expandable == false
+      and .titleAttr == "A queued backlog row whose title is far too long to fit on one line of the board"
+  ' >/dev/null || fail "a plain task row hides its full title: $out"
+  printf '%s' "$out" | jq -e '
+    [.streams[0].rows[] | select(.titleAttr == "" or .titleAttr != .title)] == []
+  ' >/dev/null || fail "some task row does not carry its full title: $out"
+  pass "every task row exposes its full title, expandable or not"
 }
 
 test_a_board_without_edges_or_divergence_stays_quiet() {
@@ -160,5 +223,8 @@ test_unreadable_data_fails_closed() {
 
 test_the_full_board_renders_every_section
 test_the_dependency_graph_draws_only_edge_touched_local_nodes
+test_a_cross_workstream_edge_is_drawn_on_both_cards
+test_the_progress_bar_reports_the_whole_lane
+test_every_task_row_exposes_its_full_title
 test_a_board_without_edges_or_divergence_stays_quiet
 test_unreadable_data_fails_closed

--- a/tests/fm-workstream-board-render.test.sh
+++ b/tests/fm-workstream-board-render.test.sh
@@ -85,7 +85,7 @@ test_the_full_board_renders_every_section() {
     || fail "the board rendered its fail-closed error instead of the fleet: $out"
   printf '%s' "$out" | jq -e '
     ([.stats[] | {key:.label, value:.n}] | from_entries) as $s
-    | $s["workstreams"] == 1 and $s["tasks on the board"] == 5
+    | $s["workstreams"] == 1 and $s["tasks on the board"] == 8
       and $s["agents live"] == 1 and $s["waiting on you"] == 1
       and $s["board ≠ reality"] == 1
   ' >/dev/null || fail "the stat tiles do not carry the board tallies: $out"
@@ -216,6 +216,47 @@ test_every_task_row_exposes_its_full_title() {
   pass "every task row exposes its full title, expandable or not"
 }
 
+test_the_board_total_counts_whole_lanes_not_visible_rows() {
+  local home out payload expected visible
+  home=$(make_home boardtotal)
+  # A second capped lane, so the tile has more than one lane total to sum.
+  payload=$(base_payload | jq '
+    .workstreams += [{ id: "ontology", name: "Chat Ontology",
+      tasks: [{ id: "ontology-rows", title: "Ontology rows", state: "queued" }],
+      counts: { done: 4, review: 0, active: 0, held: 0, decision: 0, queued: 3 },
+      more_tasks: 6 }]')
+  expected=$(printf '%s' "$payload" | jq '[.workstreams[] | (.tasks | length) + (.more_tasks // 0)] | add')
+  out=$(render "$home" "$payload")
+  # The relationship, not a fixed number: the tile is the sum of the lane
+  # totals, which validation pins to rows plus more_tasks for every lane.
+  printf '%s' "$out" | jq -e --argjson want "$expected" '
+    (.stats[] | select(.label == "tasks on the board") | .n) == $want
+  ' >/dev/null || fail "the board total is not the sum of the lane totals ($expected): $out"
+  # And the fixture is genuinely capped, so the relationship is not a
+  # coincidence of the tile still counting visible rows.
+  visible=$(printf '%s' "$out" | jq '[.streams[].rows | length] | add')
+  [ "$expected" -gt "$visible" ] \
+    || fail "the fixture is not capped ($expected vs $visible rows), so it proves nothing"
+  pass "the board total counts whole lanes, not the rows the cap left visible"
+}
+
+test_a_lane_reports_empty_only_when_its_whole_lane_is_empty() {
+  local home out payload
+  home=$(make_home emptylane)
+  # A lane that ships no rows but omits some still has work in it.
+  payload=$(base_payload | jq '
+    .workstreams += [{ id: "ontology", name: "Chat Ontology", tasks: [],
+      counts: { done: 0, review: 0, active: 0, held: 0, decision: 0, queued: 4 },
+      more_tasks: 4 },
+    { id: "fallow", name: "Fallow", tasks: [] }]')
+  out=$(render "$home" "$payload")
+  printf '%s' "$out" | jq -e '
+    ((.streams[] | select(.id == "ws-ontology") | .empty) == false)
+      and ((.streams[] | select(.id == "ws-fallow") | .empty) == true)
+  ' >/dev/null || fail "a capped lane was reported as having no work in it: $out"
+  pass "a lane reads as empty only when its whole lane is empty"
+}
+
 test_a_board_without_edges_or_divergence_stays_quiet() {
   local home out payload
   home=$(make_home quiet)
@@ -251,6 +292,8 @@ test_the_dependency_graph_draws_only_edge_touched_local_nodes
 test_a_cross_workstream_edge_is_drawn_on_both_cards
 test_a_same_lane_graph_marks_no_foreign_node
 test_the_progress_bar_reports_the_whole_lane
+test_the_board_total_counts_whole_lanes_not_visible_rows
+test_a_lane_reports_empty_only_when_its_whole_lane_is_empty
 test_every_task_row_exposes_its_full_title
 test_a_board_without_edges_or_divergence_stays_quiet
 test_unreadable_data_fails_closed

--- a/tests/fm-workstream-board.test.sh
+++ b/tests/fm-workstream-board.test.sh
@@ -155,6 +155,17 @@ test_build_refuses_malformed_payloads_before_touching_the_board() {
   [ "$rc" -ne 0 ] || fail "a negative omitted-task count was accepted"
 
   write_valid_payload "$data"
+  jq '.workstreams[0].counts = { done: 1, review: 0, active: -2, held: 0, decision: 0, queued: 0 }' \
+    "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "a negative lane count was accepted"
+
+  write_valid_payload "$data"
+  jq '.workstreams[0].counts = { done: 1, sailing: 2 }' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "a lane count keyed by an unknown state was accepted"
+
+  write_valid_payload "$data"
   jq '.waiting[0].key = (reduce range(129) as $i (""; . + "x"))' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
   set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
   [ "$rc" -ne 0 ] || fail "a 129-char waiting key was accepted"

--- a/tests/fm-workstream-board.test.sh
+++ b/tests/fm-workstream-board.test.sh
@@ -126,6 +126,46 @@ test_an_uncapped_lane_may_omit_its_counts() {
   pass "a lane that ships all of its rows may omit its lane counts"
 }
 
+# The board's one lane-total invariant: the six counts sum to EXACTLY the rows
+# the lane ships plus its more_tasks. Sweep both sides of that equation rather
+# than pinning one example payload, so a later hole cannot open unnoticed.
+test_lane_counts_must_total_the_whole_lane_exactly() {
+  local home data delta rc out
+  home=$(make_home lanetotal)
+  data="$home/payload.json"
+
+  # write_valid_payload ships 3 rows, more_tasks 2, and counts totalling 5.
+  for delta in -3 -2 -1 1 2 3; do
+    write_valid_payload "$data"
+    jq --argjson d "$delta" '.workstreams[0].counts.queued += $d' \
+      "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+    set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+    [ "$rc" -ne 0 ] \
+      || fail "lane counts off the lane total by $delta were accepted: $out"
+  done
+
+  # Same equation from the other side: move the lane total, keep counts fixed.
+  for delta in -2 -1 1 2 3; do
+    write_valid_payload "$data"
+    jq --argjson d "$delta" '.workstreams[0].more_tasks += $d' \
+      "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+    set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+    [ "$rc" -ne 0 ] \
+      || fail "a lane total moved $delta away from its counts was accepted: $out"
+  done
+
+  [ ! -e "$home/.lavish/workstreams.html" ] \
+    || fail "a refused lane-total payload still produced a board"
+
+  # The balanced payload the sweep perturbs must itself build, so the sweep is
+  # proving the invariant rather than refusing everything.
+  write_valid_payload "$data"
+  run_board "$home" build "$data" >/dev/null 2>&1 \
+    || fail "the balanced lane-total payload was refused"
+  [ -f "$home/.lavish/workstreams.html" ] || fail "the balanced payload produced no board"
+  pass "lane counts are refused unless they total the shipped rows plus more_tasks"
+}
+
 test_build_refuses_malformed_payloads_before_touching_the_board() {
   local home data board rc out
   home=$(make_home refusal)
@@ -199,6 +239,11 @@ test_build_refuses_malformed_payloads_before_touching_the_board() {
     "$data" > "$data.tmp" && mv "$data.tmp" "$data"
   set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
   [ "$rc" -ne 0 ] || fail "lane counts totalling fewer than the lane's own rows were accepted"
+
+  write_valid_payload "$data"
+  jq 'del(.workstreams[0].more_tasks)' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "lane counts describing rows the lane no longer omits were accepted"
 
   write_valid_payload "$data"
   jq '.waiting[0].key = (reduce range(129) as $i (""; . + "x"))' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
@@ -338,6 +383,7 @@ test_build_refuses_a_template_without_exactly_one_slot() {
 test_path_is_stable_home_scoped_and_mockup_safe
 test_build_refuses_malformed_payloads_before_touching_the_board
 test_an_uncapped_lane_may_omit_its_counts
+test_lane_counts_must_total_the_whole_lane_exactly
 test_build_injects_binds_then_arms
 test_build_does_not_bind_or_arm_when_session_start_fails
 test_rebuild_is_idempotent_and_does_not_double_arm

--- a/tests/fm-workstream-board.test.sh
+++ b/tests/fm-workstream-board.test.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-workstream-board.sh: fail-closed payload validation,
+# slot-injection round-trip through the built page, bind-before-arm through the
+# shared board lib, and idempotent re-arm of the stable board source.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BOARD="$ROOT/bin/fm-workstream-board.sh"
+TMP_ROOT=$(fm_test_tmproot fm-workstream-board)
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+make_home() {  # <name>
+  local home="$TMP_ROOT/$1" fakebin
+  mkdir -p "$home/state" "$home/data"
+  fakebin=$(fm_fakebin "$home")
+  fm_fake_exit0 "$fakebin" lavish-axi
+  printf '%s\n' "$home"
+}
+
+run_board() {  # <home> <args...>
+  local home=$1
+  shift
+  PATH="$home/fakebin:$PATH" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
+    "$BOARD" "$@"
+}
+
+run_procevent() {  # <home> <command args...>
+  local home=$1
+  shift
+  PATH="$home/fakebin:$PATH" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
+    "$ROOT/bin/fm-procevent.sh" "$@"
+}
+
+run_decisions() {  # <home> <command args...>
+  local home=$1
+  shift
+  PATH="$home/fakebin:$PATH" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    "$ROOT/bin/fm-decision-hold.sh" "$@"
+}
+
+run_lavish_source_id() {  # <home> <artifact>
+  local home=$1
+  PATH="$home/fakebin:$PATH" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
+    "$ROOT/bin/fm-procevent-lavish.sh" source-id "$2"
+}
+
+# A realistic payload: a held task with an agent chip, a done->queued edge, a
+# waiting item keyed by a captain-held task id with a release close mode, a
+# divergence row, and a string that tries to terminate the data block early.
+write_valid_payload() {  # <path>
+  cat > "$1" <<'EOF'
+{
+  "schema": "fm-workstream-board.v1",
+  "home": "test-home",
+  "generated": "2026-09-01T00:00Z",
+  "workstreams": [
+    {
+      "id": "quote-flow",
+      "name": "Quote Flow",
+      "outcome": "A quote flow that never silently drops a part: </script><b>x</b>",
+      "tasks": [
+        { "id": "quote-flow-fixes", "title": "G9 loud failure and friends", "state": "held",
+          "doing": "Finishing fix round 16", "contract": "no-mistakes, yolo off",
+          "agent": "claude · working (held)", "agent_tone": "working" },
+        { "id": "g6-define", "title": "Define G6 empty promises", "state": "done" },
+        { "id": "build-g6", "title": "Build the G6 fix", "state": "queued",
+          "pr_url": "https://github.com/example/repo/pull/1" }
+      ],
+      "more_tasks": 2
+    }
+  ],
+  "edges": [ { "from": "g6-define", "to": "build-g6" } ],
+  "waiting": [
+    { "key": "wave5-ontology", "title": "Eval baseline spend for Wave 5",
+      "question": "Full baseline or returns-only?",
+      "options": [
+        { "value": "full", "label": "Full 3-run baseline" },
+        { "value": "returns-only", "label": "Returns group only", "hint": "agent recommends" }
+      ],
+      "recommend_value": "returns-only", "allow_freeform": true, "close": "release" }
+  ],
+  "agents": [ { "id": "quote-flow-fixes", "tone": "working", "doing": "fix round 16" } ],
+  "divergence": [ { "id": "analytics-triage", "note": "backlog queued, live PR open" } ]
+}
+EOF
+}
+
+# Extract the injected payload back out of a built board page.
+extract_payload() {  # <board-path>
+  sed -n '/<script id="workstream-data" type="application\/json">/,/<\/script>/p' "$1" \
+    | sed '1d;$d'
+}
+
+test_path_is_stable_home_scoped_and_mockup_safe() {
+  local home
+  home=$(make_home path)
+  [ "$(run_board "$home" path)" = "$home/.lavish/workstreams.html" ] \
+    || fail "the board path is not the stable home-scoped location"
+  case "$(run_board "$home" path)" in
+    */workstream-board.html) fail "the board path collides with the mockup artifact name" ;;
+  esac
+  pass "path prints the stable home-scoped board location clear of the mockup"
+}
+
+test_build_refuses_malformed_payloads_before_touching_the_board() {
+  local home data board rc out
+  home=$(make_home refusal)
+  board="$home/.lavish/workstreams.html"
+  data="$home/payload.json"
+
+  printf 'not json\n' > "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "a non-JSON payload was accepted"
+  assert_contains "$out" "not valid JSON" "the non-JSON refusal did not say why: $out"
+
+  printf '{"schema":"fm-workstream-board.v2"}\n' > "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "a wrong-schema payload was accepted"
+  assert_contains "$out" "fm-workstream-board.v1" "the schema refusal did not name the contract: $out"
+
+  write_valid_payload "$data"
+  jq '.workstreams[0].tasks[0].state = "sailing"' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "an unknown task state was accepted"
+
+  write_valid_payload "$data"
+  jq '.workstreams[0].tasks[0].agent_tone = "loud"' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "an unknown agent tone was accepted"
+
+  write_valid_payload "$data"
+  jq 'del(.workstreams[0].tasks[0].agent_tone)' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "an agent chip without a declared tone was accepted"
+
+  write_valid_payload "$data"
+  jq '.workstreams[0].tasks[2].pr_url = "javascript:alert(1)"' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "a non-HTTPS task PR URL was accepted"
+
+  write_valid_payload "$data"
+  jq '.workstreams[0].more_tasks = -1' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "a negative omitted-task count was accepted"
+
+  write_valid_payload "$data"
+  jq '.waiting[0].key = (reduce range(129) as $i (""; . + "x"))' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "a 129-char waiting key was accepted"
+
+  write_valid_payload "$data"
+  jq '.waiting[0].options = [] | .waiting[0].allow_freeform = false' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "an unanswerable waiting item was accepted"
+
+  write_valid_payload "$data"
+  jq '.waiting[0].options[0].label = ""' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "a waiting option with an empty label was accepted"
+
+  write_valid_payload "$data"
+  jq '.waiting[0].recommend_value = "absent"' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "a recommendation outside the options was accepted"
+
+  write_valid_payload "$data"
+  jq '.waiting[0].close = "discard"' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "an unknown close mode was accepted"
+
+  write_valid_payload "$data"
+  jq '.divergence[0].note = ""' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "a divergence row without a note was accepted"
+
+  write_valid_payload "$data"
+  jq 'del(.agents[0].tone)' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "a roster agent without a tone was accepted"
+
+  assert_absent "$board" "a refused payload still produced a board"
+  pass "build refuses malformed payloads before touching the board"
+}
+
+test_build_injects_binds_then_arms() {
+  local home data board out sid
+  home=$(make_home build)
+  data="$home/payload.json"
+  board="$home/.lavish/workstreams.html"
+  write_valid_payload "$data"
+
+  out=$(run_board "$home" build "$data") || fail "a valid payload did not build"
+  assert_contains "$out" "board: $board" "build did not report the board path: $out"
+  assert_contains "$out" "served: $board" "build did not establish the Lavish session: $out"
+  assert_contains "$out" "bound: " "build did not report the answer binding: $out"
+  assert_contains "$out" "armed: " "the first build did not arm the board source: $out"
+  assert_present "$board" "build reported success without a board"
+  printf '%s' "$out" | awk '/^bound: /{b=NR} /^armed: /{a=NR} END{exit !(b && a && b < a)}' \
+    || fail "the answer binding did not precede arming: $out"
+
+  # Round-trip: the payload extracted from the built page is byte-for-byte the
+  # same JSON document, and the escaped </script> string can no longer
+  # terminate the data block.
+  extract_payload "$board" | jq -S . > "$home/extracted.json" \
+    || fail "the built board does not carry parseable payload JSON"
+  jq -S . "$data" > "$home/expected.json"
+  diff -u "$home/expected.json" "$home/extracted.json" >/dev/null \
+    || fail "the injected payload does not round-trip to the input document"
+  grep -qF '</script><b>' "$board" \
+    && fail "a payload string embedded a live closing script tag in the page"
+  grep -qxF '__FM_WORKSTREAM_BOARD_DATA__' "$board" \
+    && fail "the data slot survived injection"
+
+  sid=$(run_lavish_source_id "$home" "$board")
+  assert_contains "$out" "bound: $sid" "the binding does not name the board source: $out"
+  [ "$(run_decisions "$home" binding "$sid")" = "(any)" ] \
+    || fail "the board source is not bound any-origin"
+  run_procevent "$home" list | awk 'NR > 1 { print $1 }' | grep -Fxq "$sid" \
+    || fail "the board source is not registered after build"
+  pass "build injects the payload, binds any-origin, then arms the source"
+}
+
+test_build_does_not_bind_or_arm_when_session_start_fails() {
+  local home data rc sid
+  home=$(make_home serve-failure)
+  data="$home/payload.json"
+  write_valid_payload "$data"
+  cat > "$home/fakebin/lavish-axi" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$home/fakebin/lavish-axi"
+
+  set +e
+  run_board "$home" build "$data" >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "build continued after Lavish session establishment failed"
+  sid=$(run_lavish_source_id "$home" "$home/.lavish/workstreams.html")
+  ! run_decisions "$home" binding "$sid" >/dev/null 2>&1 \
+    || fail "build bound the board before its Lavish session existed"
+  ! run_procevent "$home" list | awk 'NR > 1 { print $1 }' | grep -Fxq "$sid" \
+    || fail "build armed the board before its Lavish session existed"
+  pass "build establishes the Lavish session before binding and arming"
+}
+
+test_rebuild_is_idempotent_and_does_not_double_arm() {
+  local home data board out records
+  home=$(make_home rearm)
+  data="$home/payload.json"
+  board="$home/.lavish/workstreams.html"
+  write_valid_payload "$data"
+  run_board "$home" build "$data" >/dev/null || fail "the first build failed"
+
+  jq '.generated = "2026-09-01T01:00Z"' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  out=$(run_board "$home" build "$data") || fail "the rebuild failed"
+  assert_contains "$out" "already-armed: " "the rebuild re-armed an already registered source: $out"
+  extract_payload "$board" | jq -e '.generated == "2026-09-01T01:00Z"' >/dev/null \
+    || fail "the rebuild did not refresh the board payload in place"
+  records=$(find "$home/state/procevent" -name '*.source' | wc -l | tr -d ' ')
+  [ "$records" = 1 ] || fail "rebuilding left $records source registrations instead of 1"
+  pass "rebuild refreshes the board in place without double-arming"
+}
+
+test_build_refuses_a_template_without_exactly_one_slot() {
+  local home data rc out
+  home=$(make_home badslot)
+  data="$home/payload.json"
+  write_valid_payload "$data"
+  printf '<html><body>no slot</body></html>\n' > "$home/broken-template.html"
+  set +e
+  out=$(FM_WORKSTREAM_BOARD_TEMPLATE="$home/broken-template.html" run_board "$home" build "$data" 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "a template with no data slot was accepted"
+  assert_contains "$out" "data slot" "the slot refusal did not say why: $out"
+  assert_absent "$home/.lavish/workstreams.html" "a refused template still produced a board"
+  pass "build refuses a template without exactly one data slot"
+}
+
+test_path_is_stable_home_scoped_and_mockup_safe
+test_build_refuses_malformed_payloads_before_touching_the_board
+test_build_injects_binds_then_arms
+test_build_does_not_bind_or_arm_when_session_start_fails
+test_rebuild_is_idempotent_and_does_not_double_arm
+test_build_refuses_a_template_without_exactly_one_slot

--- a/tests/fm-workstream-board.test.sh
+++ b/tests/fm-workstream-board.test.sh
@@ -77,6 +77,7 @@ write_valid_payload() {  # <path>
         { "id": "build-g6", "title": "Build the G6 fix", "state": "queued",
           "pr_url": "https://github.com/example/repo/pull/1" }
       ],
+      "counts": { "done": 1, "review": 0, "active": 0, "held": 1, "decision": 0, "queued": 3 },
       "more_tasks": 2
     }
   ],
@@ -111,6 +112,18 @@ test_path_is_stable_home_scoped_and_mockup_safe() {
     */workstream-board.html) fail "the board path collides with the mockup artifact name" ;;
   esac
   pass "path prints the stable home-scoped board location clear of the mockup"
+}
+
+test_an_uncapped_lane_may_omit_its_counts() {
+  local home data
+  home=$(make_home uncapped)
+  data="$home/payload.json"
+  write_valid_payload "$data"
+  jq 'del(.workstreams[0].counts, .workstreams[0].more_tasks)' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  run_board "$home" build "$data" >/dev/null 2>&1 \
+    || fail "an uncapped lane without lane counts was refused"
+  [ -f "$home/.lavish/workstreams.html" ] || fail "the accepted payload produced no board"
+  pass "a lane that ships all of its rows may omit its lane counts"
 }
 
 test_build_refuses_malformed_payloads_before_touching_the_board() {
@@ -155,15 +168,37 @@ test_build_refuses_malformed_payloads_before_touching_the_board() {
   [ "$rc" -ne 0 ] || fail "a negative omitted-task count was accepted"
 
   write_valid_payload "$data"
-  jq '.workstreams[0].counts = { done: 1, review: 0, active: -2, held: 0, decision: 0, queued: 0 }' \
-    "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  jq '.workstreams[0].counts.active = -2' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
   set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
   [ "$rc" -ne 0 ] || fail "a negative lane count was accepted"
 
   write_valid_payload "$data"
-  jq '.workstreams[0].counts = { done: 1, sailing: 2 }' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  jq '.workstreams[0].counts.sailing = 2' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
   set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
   [ "$rc" -ne 0 ] || fail "a lane count keyed by an unknown state was accepted"
+
+  # The progress bar reads counts, so a capped lane cannot ship without them,
+  # and the object it does ship cannot be partial or smaller than its own rows.
+  write_valid_payload "$data"
+  jq 'del(.workstreams[0].counts)' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "a capped lane without lane counts was accepted"
+
+  write_valid_payload "$data"
+  jq '.workstreams[0].counts = {}' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "an empty lane-counts object was accepted"
+
+  write_valid_payload "$data"
+  jq 'del(.workstreams[0].counts.held)' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "a partial lane-counts object was accepted"
+
+  write_valid_payload "$data"
+  jq '.workstreams[0].counts = { done: 1, review: 0, active: 0, held: 1, decision: 0, queued: 0 }' \
+    "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+  set +e; out=$(run_board "$home" build "$data" 2>&1); rc=$?; set -e
+  [ "$rc" -ne 0 ] || fail "lane counts totalling fewer than the lane's own rows were accepted"
 
   write_valid_payload "$data"
   jq '.waiting[0].key = (reduce range(129) as $i (""; . + "x"))' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
@@ -302,6 +337,7 @@ test_build_refuses_a_template_without_exactly_one_slot() {
 
 test_path_is_stable_home_scoped_and_mockup_safe
 test_build_refuses_malformed_payloads_before_touching_the_board
+test_an_uncapped_lane_may_omit_its_counts
 test_build_injects_binds_then_arms
 test_build_does_not_bind_or_arm_when_session_start_fails
 test_rebuild_is_idempotent_and_does_not_double_arm

--- a/tests/fm-workstream-board.test.sh
+++ b/tests/fm-workstream-board.test.sh
@@ -9,6 +9,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 BOARD="$ROOT/bin/fm-workstream-board.sh"
+SNAPSHOT="$ROOT/bin/fm-workstream-snapshot.sh"
 TMP_ROOT=$(fm_test_tmproot fm-workstream-board)
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
@@ -164,6 +165,94 @@ test_lane_counts_must_total_the_whole_lane_exactly() {
     || fail "the balanced lane-total payload was refused"
   [ -f "$home/.lavish/workstreams.html" ] || fail "the balanced payload produced no board"
   pass "lane counts are refused unless they total the shipped rows plus more_tasks"
+}
+
+# The documented compose path end to end: run the real composer, apply only the
+# mechanical joins SKILL.md step 2 names, and hand the result to the real
+# builder. The composer emits `pr_url: null` on every task with no PR, so the
+# shapes it actually produces have to validate.
+compose_from_snapshot() {  # <home> <fakebin> <out.json>
+  local home=$1 fb=$2 out=$3 snapshot
+  snapshot=$(NET_LOG="$home/net.log" PATH="$fb:$PATH" FM_HOME="$home" \
+    FM_ROOT_OVERRIDE="$TMP_ROOT/fixture-root" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    "$SNAPSHOT" --json) || return 1
+  printf '%s' "$snapshot" | jq '
+    . as $root
+    | {
+        schema: "fm-workstream-board.v1",
+        home: $root.home,
+        generated: $root.generated,
+        workstreams: [ $root.workstreams[] as $w
+          | { id: $w.id, name: $w.name, outcome: $w.outcome,
+              tasks: [ $root.tasks[] | select(.ws == $w.id) ],
+              counts: { done: $w.done, review: $w.review, active: $w.active,
+                        held: $w.held, decision: $w.decision, queued: $w.queued },
+              more_tasks: $w.more } ],
+        edges: [ $root.edges[] | {from, to} ],
+        waiting: [ $root.decisions[]
+          | { key: .id, title: .summary, allow_freeform: true, options: [],
+              close: "release" } ],
+        agents: [ $root.agents[]
+          | { id: .id, doing: .doing,
+              tone: (if .state == "working" then "working"
+                     elif .state == "decision" then "decision"
+                     else "paused" end) } ],
+        divergence: [ $root.divergence[] | {id, note} ]
+      }' > "$out"
+}
+
+test_the_composers_own_output_shape_builds() {
+  local home fb data
+  home=$(make_home composed)
+  mkdir -p "$home/projects" "$home/config" "$TMP_ROOT/fixture-root"
+  fb="$home/fakebin"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  display-message) printf '%%1\n' ;;
+  capture-pane) printf 'all quiet\n> \n' ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/tmux"
+  # A PR-less task, a task with a PR, a captain hold, and an ungrouped row, so
+  # both the null and the populated pr_url branches ship in one payload.
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+
+- [ ] quote - Quote Flow (kind: program)
+  Intended outcome: a quote flow that never silently drops a part.
+- [ ] quote-fixes - G9 loud failure and friends
+
+## Queued
+
+- [ ] quote-review - Analytics triage weekly study
+- [ ] spend-call - Eval spend decision (hold: full baseline or returns-only?, hold-kind: captain)
+- [ ] loner - Completely ungrouped work with no PR anywhere
+
+## Done
+EOF
+  fm_write_meta "$home/state/quote-fixes.meta" "backend=tmux" "window=fm:1" \
+    "kind=ship" "project=$home/projects/sample"
+  printf 'working: fixing G20\n' > "$home/state/quote-fixes.status"
+  fm_write_meta "$home/state/quote-review.meta" "backend=tmux" "window=fm:2" \
+    "kind=ship" "project=$home/projects/sample" "pr=https://github.com/acme/repo/pull/197"
+
+  data="$home/payload.json"
+  compose_from_snapshot "$home" "$fb" "$data" || fail "the composer did not run"
+
+  # The payload really does carry the shape under test, in both branches.
+  jq -e '
+    ([.workstreams[].tasks[] | select(.pr_url == null)] | length) > 0
+      and ([.workstreams[].tasks[] | select(.pr_url != null)] | length) > 0
+  ' "$data" >/dev/null || fail "the composed payload has no null pr_url to prove: $(cat "$data")"
+
+  run_board "$home" build "$data" >/dev/null 2>&1 \
+    || fail "the composer's own output was refused by the builder: $(cat "$data")"
+  [ -f "$home/.lavish/workstreams.html" ] || fail "the composed payload produced no board"
+  pass "the composer's own output shape builds through the real builder"
 }
 
 test_build_refuses_malformed_payloads_before_touching_the_board() {
@@ -383,6 +472,7 @@ test_build_refuses_a_template_without_exactly_one_slot() {
 test_path_is_stable_home_scoped_and_mockup_safe
 test_build_refuses_malformed_payloads_before_touching_the_board
 test_an_uncapped_lane_may_omit_its_counts
+test_the_composers_own_output_shape_builds
 test_lane_counts_must_total_the_whole_lane_exactly
 test_build_injects_binds_then_arms
 test_build_does_not_bind_or_arm_when_session_start_fails

--- a/tests/fm-workstream-snapshot.test.sh
+++ b/tests/fm-workstream-snapshot.test.sh
@@ -105,7 +105,7 @@ test_grouping_states_edges_and_divergence() {
 
   # Umbrellas become workstreams; prefix and blocked-by members are claimed.
   printf '%s' "$model" | jq -e '
-    ([.workstreams[].id] == ["quote", "ontology"])
+    ([.workstreams[].id] == ["quote", "ontology", "unassigned"])
       and ([.tasks[] | select(.ws == "quote") | .id] | sort == ["quote-define", "quote-fixes"])
   ' >/dev/null || fail "prefix members did not reach their umbrella workstream: $model"
 
@@ -119,6 +119,14 @@ test_grouping_states_edges_and_divergence() {
   printf '%s' "$model" | jq -e '
     [.tasks[] | select(.ws == "unassigned") | .id] | sort == ["census", "loner", "review-me", "spend-call"]
   ' >/dev/null || fail "unclaimed tasks did not land in the unassigned lane: $model"
+
+  # The unassigned lane is a real workstreams[] entry carrying its own totals,
+  # so a composer that reads workstreams[] can never hide ungrouped work.
+  printf '%s' "$model" | jq -e '
+    (.workstreams[] | select(.id == "unassigned"))
+    | .total == 4 and .more == 0 and .held == 1 and .review == 1
+      and .decision == 1 and .queued == 1 and (.name | length) > 0
+  ' >/dev/null || fail "the unassigned lane is not a real workstream entry: $model"
 
   # Task-state classification, one of each.
   printf '%s' "$model" | jq -e '
@@ -185,11 +193,21 @@ test_bounds_are_disclosed_and_liftable() {
   fb=$(make_fakebin "$home")
   write_fixture "$home"
 
+  # The umbrella cap drops umbrella lanes and discloses it; the unassigned lane
+  # is the catch-all and is never dropped by that cap.
   model=$(FM_WS_STREAMS=1 run_ws "$home" "$fb" --json) || fail "the bounded projection did not run"
   printf '%s' "$model" | jq -e '
-    (.workstreams | length) == 1
+    ([.workstreams[].id] == ["quote", "unassigned"])
       and ([.omitted[].surface] | any(test("workstreams showing 1 of 2")))
   ' >/dev/null || fail "the workstream cap is not disclosed: $model"
+
+  model=$(FM_WS_UNASSIGNED=1 run_ws "$home" "$fb" --json) || fail "the unassigned-capped run failed"
+  printf '%s' "$model" | jq -e '
+    (.workstreams[] | select(.id == "unassigned")) as $u
+    | $u.more == 3 and $u.total == 4
+      and ([.tasks[] | select(.ws == "unassigned")] | length) == 1
+      and ([.omitted[].surface] | any(test("unassigned tasks showing 1 of 4")))
+  ' >/dev/null || fail "the unassigned lane does not carry a machine-readable more: $model"
 
   model=$(FM_WS_TASKS=1 run_ws "$home" "$fb" --json) || fail "the task-capped projection did not run"
   printf '%s' "$model" | jq -e '
@@ -208,6 +226,32 @@ test_bounds_are_disclosed_and_liftable() {
   pass "caps are disclosed in omitted[] and lifted by --all-tasks"
 }
 
+test_a_done_umbrella_keeps_its_workstream() {
+  local home fb model
+  home=$(make_home doneumbrella)
+  fb=$(make_fakebin "$home")
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+
+- [ ] quote-fixes - G9 loud failure and friends
+
+## Queued
+
+- [ ] loner - Completely ungrouped work
+
+## Done
+
+- [x] quote - Quote Flow (kind: program) (done: 2026-08-30)
+EOF
+  model=$(run_ws "$home" "$fb" --json) || fail "the projection did not run"
+  printf '%s' "$model" | jq -e '
+    ([.workstreams[].id] == ["quote", "unassigned"])
+      and ([.tasks[] | select(.ws == "quote") | .id] == ["quote-fixes"])
+      and ([.tasks[] | select(.ws == "unassigned") | .id] == ["loner"])
+  ' >/dev/null || fail "a finished umbrella lost its workstream and scattered its members: $model"
+  pass "a finished umbrella keeps its workstream with its members anchored"
+}
+
 test_toon_and_json_are_parity_forms() {
   local home fb toon
   home=$(make_home parity)
@@ -217,7 +261,7 @@ test_toon_and_json_are_parity_forms() {
   toon=$(run_ws "$home" "$fb") || fail "the TOON projection did not run"
   printf '%s' "$toon" | grep -q '^schema: fm-workstream.v1$' \
     || fail "TOON output does not open with the schema line: $toon"
-  printf '%s' "$toon" | grep -q '^workstreams\[2\]{' \
+  printf '%s' "$toon" | grep -q '^workstreams\[3\]{' \
     || fail "TOON output does not carry the workstreams table: $toon"
   printf '%s' "$toon" | grep -q '^tasks\[' \
     || fail "TOON output does not carry the tasks table: $toon"
@@ -229,4 +273,5 @@ test_toon_and_json_are_parity_forms() {
 test_grouping_states_edges_and_divergence
 test_in_flight_without_worker_is_divergence
 test_bounds_are_disclosed_and_liftable
+test_a_done_umbrella_keeps_its_workstream
 test_toon_and_json_are_parity_forms

--- a/tests/fm-workstream-snapshot.test.sh
+++ b/tests/fm-workstream-snapshot.test.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Behavior tests for the workstream projection wrapper over fm-fleet-snapshot.sh.
+# Covers workstream derivation (umbrella kind=program, id-prefix claims, direct
+# blocked-by claims, fixpoint expansion, first-claim-wins), the unassigned lane,
+# task-state classification, board-vs-reality divergence, dependency edges,
+# bounded output with omitted[] disclosure, TOON/JSON parity, and the zero-network
+# guarantee of the only path.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+WS="$ROOT/bin/fm-workstream-snapshot.sh"
+TMP_ROOT=$(fm_test_tmproot fm-workstream-snapshot)
+# Keep disposable homes outside the snapshot's fixture repo boundary even when
+# TMPDIR is inside an isolated source worktree.
+FM_ROOT_OVERRIDE="$TMP_ROOT/fixture-root"
+mkdir -p "$FM_ROOT_OVERRIDE"
+export FM_ROOT_OVERRIDE
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+# A fakebin that stubs the local tools the canonical snapshot may reach for,
+# plus gh/gh-axi/curl recorders that prove the projection makes no network call.
+make_fakebin() {  # <dir>
+  local fb
+  fb=$(fm_fakebin "$1")
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  display-message) printf '%%1\n' ;;
+  capture-pane) printf 'all quiet\n> \n' ;;
+esac
+exit 0
+SH
+  cat > "$fb/gh" <<'SH'
+#!/usr/bin/env bash
+echo "gh $*" >> "$NET_LOG"
+exit 1
+SH
+  sed 's/^echo "gh /echo "gh-axi /' "$fb/gh" > "$fb/gh-axi"
+  sed 's/^echo "gh /echo "curl /' "$fb/gh" > "$fb/curl"
+  chmod +x "$fb/tmux" "$fb/gh" "$fb/gh-axi" "$fb/curl"
+  printf '%s\n' "$fb"
+}
+
+make_home() {  # <name>
+  local home=$TMP_ROOT/$1
+  mkdir -p "$home/state" "$home/data" "$home/projects" "$home/config"
+  printf '%s\n' "$home"
+}
+
+run_ws() {  # <home> <fakebin> <args...>
+  local home=$1 fb=$2
+  shift 2
+  NET_LOG="$home/net.log" PATH="$fb:$PATH" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    "$WS" "$@"
+}
+
+# One shared fixture: two umbrellas, all three claim passes, an unassigned lane,
+# every task state, and all three divergence kinds.
+write_fixture() {  # <home>
+  local home=$1
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+
+- [ ] quote - Quote Flow (kind: program)
+  Intended outcome: a quote flow that never silently drops a part.
+- [ ] quote-fixes - G9 loud failure and friends
+- [ ] census - Census held mid-flight (hold: waiting on eval window, hold-kind: captain)
+
+## Queued
+
+- [ ] ontology - Chat Ontology (kind: program)
+- [ ] rows-live - Ontology rows blocked-by: ontology
+- [ ] rows-followup - Follow-up on the rows blocked-by: rows-live
+- [ ] spend-call - Eval spend decision (hold: full baseline or returns-only?, hold-kind: captain)
+- [ ] review-me - Analytics triage weekly study
+- [ ] loner - Completely ungrouped work
+
+## Done
+
+- [x] quote-define - Define the quote gates (done: 2026-08-30)
+- [x] old-win - Landed long ago, no workstream (done: 2026-08-01)
+EOF
+  fm_write_meta "$home/state/quote-fixes.meta" "backend=tmux" "window=fm:1" "kind=ship" "project=$home/projects/sample"
+  printf 'working: fixing G20\n' > "$home/state/quote-fixes.status"
+  fm_write_meta "$home/state/review-me.meta" "backend=tmux" "window=fm:2" "kind=ship" "project=$home/projects/sample" "pr=https://github.com/acme/repo/pull/197"
+  printf 'done: PR https://github.com/acme/repo/pull/197 checks green\n' > "$home/state/review-me.status"
+  fm_write_meta "$home/state/ghost-worker.meta" "backend=tmux" "window=fm:3" "kind=ship" "project=$home/projects/sample"
+}
+
+test_grouping_states_edges_and_divergence() {
+  local home fb model
+  home=$(make_home grouping)
+  fb=$(make_fakebin "$home")
+  write_fixture "$home"
+
+  model=$(run_ws "$home" "$fb" --json) || fail "the projection did not run"
+  printf '%s' "$model" | jq -e '.schema == "fm-workstream.v1"' >/dev/null \
+    || fail "the projection does not carry its schema"
+
+  # Umbrellas become workstreams; prefix and blocked-by members are claimed.
+  printf '%s' "$model" | jq -e '
+    ([.workstreams[].id] == ["quote", "ontology"])
+      and ([.tasks[] | select(.ws == "quote") | .id] | sort == ["quote-define", "quote-fixes"])
+  ' >/dev/null || fail "prefix members did not reach their umbrella workstream: $model"
+
+  # Fixpoint: rows-followup joins ontology through its edge to rows-live.
+  printf '%s' "$model" | jq -e '
+    [.tasks[] | select(.ws == "ontology") | .id] | sort == ["rows-followup", "rows-live"]
+  ' >/dev/null || fail "fixpoint expansion did not follow the blocked-by edge: $model"
+
+  # Unclaimed non-done tasks land in the explicit unassigned lane; a worker
+  # with no backlog row has no task row (it surfaces under divergence instead).
+  printf '%s' "$model" | jq -e '
+    [.tasks[] | select(.ws == "unassigned") | .id] | sort == ["census", "loner", "review-me", "spend-call"]
+  ' >/dev/null || fail "unclaimed tasks did not land in the unassigned lane: $model"
+
+  # Task-state classification, one of each.
+  printf '%s' "$model" | jq -e '
+    ([.tasks[] | {key:.id, value:.state}] | from_entries) as $s
+    | $s["quote-define"] == "done"
+      and $s["spend-call"] == "decision"
+      and $s["census"] == "held"
+      and $s["review-me"] == "review"
+      and $s["quote-fixes"] == "active"
+      and $s["loner"] == "queued"
+  ' >/dev/null || fail "task states did not classify by the documented precedence: $model"
+
+  # Edges connect included tasks and stay workstream-tagged.
+  printf '%s' "$model" | jq -e '
+    (.edges | map(select(.from == "rows-live" and .to == "rows-followup" and .ws == "ontology")) | length) == 1
+  ' >/dev/null || fail "the in-stream dependency edge is missing: $model"
+
+  # All three divergence kinds surface.
+  printf '%s' "$model" | jq -e '
+    ([.divergence[] | {key:.id, value:.kind}] | from_entries) as $d
+    | $d["review-me"] == "queued-but-live" and $d["ghost-worker"] == "worker-not-on-board"
+  ' >/dev/null || fail "board-vs-reality divergence rows are missing: $model"
+
+  # The captain-actionable hold reaches decisions[] with its reason.
+  printf '%s' "$model" | jq -e '
+    (.decisions | length) == 1 and .decisions[0].id == "spend-call"
+      and (.decisions[0].summary | test("returns-only"))
+  ' >/dev/null || fail "the captain-held task did not reach decisions: $model"
+
+  # Done work outside every workstream is dropped with disclosure, and the
+  # secondmate scope limit is always disclosed.
+  printf '%s' "$model" | jq -e '
+    ([.omitted[].surface] | any(test("done tasks outside every workstream dropped: 1")))
+      and ([.omitted[].surface] | any(test("secondmate homes not sampled")))
+  ' >/dev/null || fail "omitted[] does not disclose the dropped surfaces: $model"
+
+  [ ! -s "$home/net.log" ] || fail "the projection touched the network: $(cat "$home/net.log")"
+  pass "grouping, states, edges, divergence, and disclosure all project correctly"
+}
+
+test_in_flight_without_worker_is_divergence() {
+  local home fb model
+  home=$(make_home orphan)
+  fb=$(make_fakebin "$home")
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+
+- [ ] adrift - In flight with no worker record
+
+## Queued
+
+## Done
+EOF
+  model=$(run_ws "$home" "$fb" --json) || fail "the projection did not run"
+  printf '%s' "$model" | jq -e '
+    (.divergence | map(select(.id == "adrift" and .kind == "in-flight-no-worker")) | length) == 1
+  ' >/dev/null || fail "an in-flight row without a worker record was not flagged: $model"
+  pass "an in-flight backlog row without a worker record surfaces as divergence"
+}
+
+test_bounds_are_disclosed_and_liftable() {
+  local home fb model
+  home=$(make_home bounds)
+  fb=$(make_fakebin "$home")
+  write_fixture "$home"
+
+  model=$(FM_WS_STREAMS=1 run_ws "$home" "$fb" --json) || fail "the bounded projection did not run"
+  printf '%s' "$model" | jq -e '
+    (.workstreams | length) == 1
+      and ([.omitted[].surface] | any(test("workstreams showing 1 of 2")))
+  ' >/dev/null || fail "the workstream cap is not disclosed: $model"
+
+  model=$(FM_WS_TASKS=1 run_ws "$home" "$fb" --json) || fail "the task-capped projection did not run"
+  printf '%s' "$model" | jq -e '
+    ([.workstreams[] | select(.id == "quote") | .more] | first) == 1
+      and ([.omitted[].surface] | any(test("task rows capped in")))
+  ' >/dev/null || fail "the per-workstream task cap is not disclosed: $model"
+
+  model=$(FM_WS_TASKS=1 run_ws "$home" "$fb" --json --all-tasks) || fail "--all-tasks did not run"
+  printf '%s' "$model" | jq -e '
+    ([.workstreams[].more] | add) == 0
+  ' >/dev/null || fail "--all-tasks did not lift the task cap: $model"
+
+  ( run_ws "$home" "$fb" --json >/dev/null 2>&1 ) || fail "a default run failed"
+  FM_WS_STREAMS=0 run_ws "$home" "$fb" --json >/dev/null 2>&1 \
+    && fail "a zero bound was accepted"
+  pass "caps are disclosed in omitted[] and lifted by --all-tasks"
+}
+
+test_toon_and_json_are_parity_forms() {
+  local home fb toon
+  home=$(make_home parity)
+  fb=$(make_fakebin "$home")
+  write_fixture "$home"
+
+  toon=$(run_ws "$home" "$fb") || fail "the TOON projection did not run"
+  printf '%s' "$toon" | grep -q '^schema: fm-workstream.v1$' \
+    || fail "TOON output does not open with the schema line: $toon"
+  printf '%s' "$toon" | grep -q '^workstreams\[2\]{' \
+    || fail "TOON output does not carry the workstreams table: $toon"
+  printf '%s' "$toon" | grep -q '^tasks\[' \
+    || fail "TOON output does not carry the tasks table: $toon"
+  printf '%s' "$toon" | grep -Eq '^  quote-define,quote,done,' \
+    || fail "TOON task rows do not carry the projected fields: $toon"
+  pass "TOON is the default rendering of the same projected model"
+}
+
+test_grouping_states_edges_and_divergence
+test_in_flight_without_worker_is_divergence
+test_bounds_are_disclosed_and_liftable
+test_toon_and_json_are_parity_forms


### PR DESCRIPTION
## What this adds

A captain-facing workstream board, a SIBLING of the bearings board: backlog tasks grouped into workstreams against intended outcomes, dependency edges drawn as an inline-SVG graph, live agents pinned on the tasks they are working, and captain decisions answerable directly from the board.

- `bin/fm-workstream-snapshot.sh` - bounded, TOON-by-default, local-only projection over `fm-fleet-snapshot.sh`. Workstreams derive from umbrella tasks (`kind: program`) plus id prefixes and blocked-by edges (fixpoint, first-claim-wins in backlog order); ungrouped tasks land in an explicit `unassigned` lane; backlog-vs-live divergence (queued-but-live, in-flight-no-worker, worker-not-on-board) surfaces as board-ne-reality rows. Caps disclosed in `omitted[]`; zero network.
- `bin/fm-workstream-board.sh` - fail-closed `fm-workstream-board.v1` validation, then the shared build sequence. Stable path `.lavish/workstreams.html`, deliberately clear of the captain's mockup artifact name. Lane `counts` are validated to sum EXACTLY to visible rows plus `more_tasks`, so capped boards cannot understate progress anywhere (bar, badges, key, or stat tile).
- `bin/fm-board-lib.sh`, `bin/fm-toon-lib.sh` - the build mechanics (inject, round-trip check, serve-then-bind-then-arm) and the TOON encoder factored out of the bearings scripts under the one-owner rule.
- `.agents/skills/workstreams/` - the captain-invocable `/workstreams` skill plus the shipped Firstmate Design System template per the approved mockup; trigger declared in `AGENTS.md` section 13; `/workstreams` row added to the README table and the skill registered in `docs/documentation-audiences.json`.
- Colocated tests: grouping/state/divergence/bounds for the composer, payload refusals and bind-before-arm for the builder, and DOM-shim render tests asserting rendered behavior, never template source text.

## Hard requirement: bearings behavior unchanged

The bearings refactor onto the shared libs is behavior-preserving. Evidence: the pipeline reviewer traced it line by line across two rounds ("Same order of checks, same error strings, same output lines"; "the TOON encoder is byte-identical"), no bearings test file was modified, and `tests/fm-bearings-board.test.sh`, `tests/fm-bearings-board-render.test.sh`, and `tests/fm-bearings-snapshot.test.sh` pass unchanged on this branch.

## Design choice recorded for review (cross-workstream edges)

Cross-lane dependency edges are drawn on BOTH cards: the foreign endpoint renders as a visually muted node (static cue, not hover-only), each foreign node carries an accessible text equivalent naming its home lane, and a plain-text key under the drawing lists foreign nodes ("<id> - in <lane>"). Smallest honest rendering inside the approved mockup vocabulary - no new panel or visual language.

## Validation

Validated by no-mistakes run `01M1EP2T0BH6H2K23XC4J7FD59`: review (5 fix rounds, findings below), test, document, and lint all completed. The push step could not run from the gate (no write access to this repo), so this PR is opened from the fork at the exact validated head `dd0d0a9d`. Lint verified at that head with pinned ShellCheck 0.11.0 and actionlint 1.7.12 (`bin/fm-lint.sh` clean).

Pipeline-applied fixes beyond the original submission: done umbrellas keep their lane (with disclosure), the unassigned lane is a real `workstreams[]` entry, whole-lane totals drive the bar/badges/key/stat tile with the exact-sum counts invariant enforced fail-closed, cross-lane edges are rendered with the muted-node treatment, every row exposes its full title, agent-pinning compose rules are stated in SKILL.md, explicit `null` optional fields are accepted (composer-shaped payloads validate end to end), the skill is registered in the doc-audience inventory, and the new scripts are listed in `docs/scripts.md`.

Two review suggestions were deliberately approved-not-fixed as hardening/polish beyond scope, recorded here for reviewers: per-state cross-checking of `counts` against visible rows (the sum invariant is enforced; per-state distribution of an adversarial payload is not), and one over-broad header sentence in `bin/fm-workstream-board.sh` describing null tolerance as if it covered every optional field (it covers `optional_string` and `optional_https_url`).

Known pre-existing test failure, not from this branch: `tests/fm-bearings-board.test.sh` case "the order-proof board build failed" fails identically at the base commit `a5f3cbe` on the development machine (verified via `git archive` extract; same `cannot claim source: lavish-...` error) - an environmental fm-procevent claim-acquisition failure, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WU4djRiRnArvvmKwkuRm4e
