### PR TITLE
fix: safely recover stale Herdr done registrations

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1956,14 +1956,16 @@ fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
 # fm_backend_herdr_agent_state: recovery-grade state for the same session-start
 # sweep as the tmux classifier. It reuses the husk classifier rather than
 # creating a second Herdr state machine: a structurally gone pane is `missing`,
-# a confirmed agent-less pane is `dead`, a registered agent is `alive`, and an
-# unexpected or failed API read is `unreadable`.
+# a confirmed agent-less pane is `dead`, a strictly proved stale `done`
+# registration is `stale-done`, a registered agent is `alive`, and an unexpected
+# or failed API read is `unreadable`.
 fm_backend_herdr_agent_state() {  # <target>
   local target=$1
   fm_backend_herdr_parse_target "$target" || { printf 'unreadable'; return 0; }
   case "$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")" in
     dead) printf 'missing' ;;
-    no-agent|stale-done) printf 'dead' ;;
+    no-agent) printf 'dead' ;;
+    stale-done) printf 'stale-done' ;;
     live) printf 'alive' ;;
     *) printf 'unreadable' ;;
   esac
@@ -2349,7 +2351,11 @@ fm_backend_herdr_projection_reclaim_task() {  # <session> <journal> <task-id> <h
   fi
   state=$(fm_backend_herdr_pane_agent_state "$session" "$meta_pane")
   case "$state" in
-    no-agent|stale-done) required_agent_state=$state ;;
+    no-agent) required_agent_state=$state ;;
+    stale-done)
+      echo "error: exact herdr presentation pane for $id has a stale done registration; refusing replacement that could signal its process group" >&2
+      return 1
+      ;;
     dead)
       echo "warning: exact herdr presentation pane for $id is gone; spawning flat" >&2
       return 2
@@ -2507,7 +2513,11 @@ fm_backend_herdr_projection_recovery_allows_flat() {  # <session> <journal> <tas
       [ -n "$pane" ] || continue
       state=$(fm_backend_herdr_pane_agent_state "$session" "$pane")
       case "$state" in
-        dead|no-agent|stale-done) : ;;
+        dead|no-agent) : ;;
+        stale-done)
+          echo "error: quarantined herdr presentation for $id has a stale done registration; refusing flat fallback without a fresh launch-boundary proof" >&2
+          return 1
+          ;;
         live|unknown)
           echo "error: quarantined herdr presentation for $id has a $state pane; refusing duplicate launch" >&2
           return 1

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -138,7 +138,7 @@ FM_BACKEND_HERDR_SECONDMATE_MARKER=".fm-secondmate-home"
 # Version 1 records only the attempted projection's random correlator.
 # Version 2 additionally binds the successful projection's exact home,
 # session, workspace, tab, pane, parent, and presentation labels so a resumed
-# spawn can replace one verified agent-free husk under the session lock.
+# spawn can replace one verified unregistered husk under the session lock.
 # No send, capture, Treehouse, or general task-ownership path reads it.
 FM_BACKEND_HERDR_PRESENTATION_JOURNAL_SUFFIX=".herdr-presentation"
 
@@ -1175,6 +1175,9 @@ fm_backend_herdr_pid_is_bare_shell() {  # <ps-bin> <pid>
   return 1
 }
 
+# fm_backend_herdr_response_is_success: accept exactly one object envelope with no
+# non-null error member, so a contradictory or multi-document response cannot
+# authorize a stale-registration replacement.
 fm_backend_herdr_response_is_success() {
   printf '%s' "$1" | jq -se '
     if length != 1 then false
@@ -1187,6 +1190,8 @@ fm_backend_herdr_response_is_success() {
   ' >/dev/null 2>&1
 }
 
+# fm_backend_herdr_response_error_code: return a code only from exactly one
+# error-only object envelope, never a response that also presents a result.
 fm_backend_herdr_response_error_code() {
   printf '%s' "$1" | jq -sr '
     if length != 1 then empty
@@ -2338,7 +2343,7 @@ fm_backend_herdr_projection_reclaim_rollback() {  # <session> <new-pane>
   [ "$(fm_backend_herdr_pane_agent_state "$session" "$new_pane")" = dead ]
 }
 
-# fm_backend_herdr_projection_reclaim_task: replace one exact agent-free
+# fm_backend_herdr_projection_reclaim_task: replace one exact unregistered
 # restored projection husk inside its original workspace.
 # The caller holds the session presentation lock and has already established
 # that flat fallback is safe across every token match.
@@ -2497,7 +2502,7 @@ fm_backend_herdr_projection_reclaim_task() {  # <session> <journal> <task-id> <h
 # or deleting anything.
 # Missing matches safely degrade to the normal flat workspace.
 # One or more matches allow flat fallback only when every pane is positively
-# dead or agent-free; a live or unknown pane refuses a duplicate launch.
+# dead or unregistered; `stale-done`, live, or unknown panes refuse a duplicate launch.
 fm_backend_herdr_projection_recovery_allows_flat() {  # <session> <journal> <task-id>
   local session=$1 journal=$2 id=$3 token list wsids count wsid panes pane_ids pane state
   token=$(fm_backend_herdr_projection_journal_token "$journal" "$id") || {

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1175,6 +1175,27 @@ fm_backend_herdr_pid_is_bare_shell() {  # <ps-bin> <pid>
   return 1
 }
 
+fm_backend_herdr_response_is_success() {
+  printf '%s' "$1" | jq -e '
+    if type != "object" then false
+    elif (has("error") | not) or .error == null then true
+    else false
+    end
+  ' >/dev/null 2>&1
+}
+
+fm_backend_herdr_response_error_code() {
+  printf '%s' "$1" | jq -r '
+    if type != "object" then empty
+    elif (has("error") | not) or .error == null or has("result") then empty
+    elif (.error | type) != "object" then empty
+    elif (.error.code | type) != "string" then empty
+    elif (.error.code | length) == 0 then empty
+    else .error.code
+    end
+  ' 2>/dev/null
+}
+
 # fm_backend_herdr_pane_idle_shell_pid: print the shell pid of <pane-id> only
 # when the exact pane provably holds one lone idle recognized shell: pane
 # process-info agrees on the pane id, the shell pid is both the foreground
@@ -1209,6 +1230,7 @@ fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
   local session=$1 pane=$2 info shell_pid foreground_pgid count
   local process_pid name argv0 shell_name rows stat ps_bin
   info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null) || return 1
+  fm_backend_herdr_response_is_success "$info" || return 1
   printf '%s' "$info" | jq -e --arg pane "$pane" '
     .result.type == "pane_process_info"
     and .result.process_info.pane_id == $pane
@@ -1830,8 +1852,8 @@ fm_backend_herdr_container_ensure() {  # <cwd-for-a-fresh-workspace> [<launcher-
 fm_backend_herdr_pane_presence_state() {  # <session> <pane_id>
   local session=$1 pane_id=$2 out code pid
   out=$(fm_backend_herdr_cli "$session" pane get "$pane_id" 2>&1)
-  code=$(printf '%s' "$out" | jq -r '.error.code // empty' 2>/dev/null)
-  if [ -n "$code" ]; then
+  if ! fm_backend_herdr_response_is_success "$out"; then
+    code=$(fm_backend_herdr_response_error_code "$out")
     [ "$code" = "pane_not_found" ] && printf 'dead' || printf 'unknown'
     return 0
   fi
@@ -1922,8 +1944,8 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
     return 0
   fi
   out=$(fm_backend_herdr_cli "$session" agent get "$pane_id" 2>&1)
-  code=$(printf '%s' "$out" | jq -r '.error.code // empty' 2>/dev/null)
-  if [ -n "$code" ]; then
+  if ! fm_backend_herdr_response_is_success "$out"; then
+    code=$(fm_backend_herdr_response_error_code "$out")
     [ "$code" = "agent_not_found" ] && printf 'no-agent' || printf 'unknown'
     return 0
   fi
@@ -3037,6 +3059,7 @@ fm_backend_herdr_classify_submit_agent_status() {  # <raw-agent_status>
 fm_backend_herdr_agent_status_raw() {  # <session> <pane_id>
   local session=$1 pane_id=$2 out
   out=$(fm_backend_herdr_cli "$session" agent get "$pane_id" 2>/dev/null) || { printf ''; return 0; }
+  fm_backend_herdr_response_is_success "$out" || { printf ''; return 0; }
   printf '%s' "$out" | jq -r '.result.agent.agent_status // empty' 2>/dev/null
 }
 

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -3176,14 +3176,23 @@ fm_backend_herdr_wait_for_working() {  # <session> <pane_id> <budget-seconds> <p
   fi
 }
 
-# fm_backend_herdr_pane_for_tab: the root pane id for <tab_id> in <workspace_id>
-# of <session>, via one pane list call filtered by tab_id (never assumes a
-# tab-number/pane-number correspondence - herdr numbers them independently).
+# fm_backend_herdr_pane_for_tab: the sole pane id for <tab_id> in
+# <workspace_id> of <session>. A task tab is created with exactly one root
+# pane, so an error, malformed envelope, or multiple candidate panes is
+# ambiguous and must not license a close or replacement.
 fm_backend_herdr_pane_for_tab() {  # <session> <workspace_id> <tab_id>
   local session=$1 wsid=$2 tab_id=$3 panes
   panes=$(fm_backend_herdr_cli "$session" pane list --workspace "$wsid" 2>/dev/null) || return 1
-  printf '%s' "$panes" | jq -r --arg tab "$tab_id" \
-    '.result.panes[]? | select(.tab_id == $tab) | .pane_id' 2>/dev/null | head -1
+  fm_backend_herdr_response_is_success "$panes" || return 1
+  printf '%s' "$panes" | jq -er --arg tab "$tab_id" '
+    (.result.panes | select(type == "array")) as $panes
+    | [$panes[]
+       | select(.tab_id == $tab)
+       | .pane_id
+       | select(type == "string" and length > 0)] as $matches
+    | select($matches | length == 1)
+    | $matches[0]
+  ' 2>/dev/null
 }
 
 # fm_backend_herdr_resolve_bare_selector: the live-tab-listing fallback for an

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1863,8 +1863,9 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 }
 
 # fm_backend_herdr_pane_agent_state: classify <pane_id> in <session> as one of
-# dead|no-agent|live|unknown, purely from the JSON body of two read-only
-# calls - never from process exit status, since a business-logic "not found"
+# dead|no-agent|live|unknown from read-only backend state plus the shared
+# strict process proof for a stale `done` entry - never from process exit status,
+# since a business-logic "not found"
 # response is a normal, expected outcome here, not a call failure (real herdr
 # 0.7.1 exits 1 for it; the canned-response test fakes exit 0; parsing only
 # the JSON keeps this function correct against either).
@@ -1883,16 +1884,33 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 #              stability across a server restart"), and what a future
 #              `resume_agents_on_restore = false` restore would produce too
 #              (a plain shell, never an agent).
-#   live     - `agent get` succeeds and reports a real agent_status (working,
-#              idle, done, or blocked - any registered value). An idle or
-#              blocked agent is still a genuine, still-registered agent, not
-#              a restored husk, so it is never a close-and-replace candidate.
+#              A `done` registration also resolves to no-agent, but only
+#              after a strict bare-idle-shell proof and a second `agent get`
+#              both agree; a done registration alone remains unknown because
+#              it can still describe an agent that owns the pane.
+#   live     - `agent get` succeeds and reports working, idle, or blocked.
+#              Every one remains a genuine registered agent and is never a
+#              close-and-replace candidate.
 #   unknown  - anything else: an unparseable/unexpected response from either
-#              call, or a `pane get` success whose own echoed pane_id does not
-#              round-trip (guards against misreading a herdr response shape
-#              change as "the pane exists"). The caller must fail safe toward
-#              refusal here, never toward closing - this is the conservative
-#              backstop the husk check depends on.
+#              call, a changed `done` registration, or a `pane get` success
+#              whose own echoed pane_id does not round-trip (guards against
+#              misreading a herdr response shape change as "the pane exists").
+#              The caller must fail safe toward refusal here, never toward
+#              closing - this is the conservative backstop the husk check
+#              depends on.
+#
+# fm_backend_herdr_done_registration_is_stale: a `done` registry entry is
+# agent-free only when the pane independently proves it has returned to its
+# one bare, idle shell and a second registry read is still `done`. The shared
+# idle-shell proof rejects foreground commands, children, active jobs, unknown
+# process identities, and unreadable process data. This helper only observes;
+# it never signals or closes the pane.
+fm_backend_herdr_done_registration_is_stale() {  # <session> <pane_id>
+  local session=$1 pane_id=$2
+  fm_backend_herdr_pane_idle_shell_pid "$session" "$pane_id" >/dev/null || return 1
+  [ "$(fm_backend_herdr_agent_status_raw "$session" "$pane_id")" = "done" ]
+}
+
 fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   local session=$1 pane_id=$2 out code presence status
   presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane_id")
@@ -1911,7 +1929,14 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   fi
   status=$(printf '%s' "$out" | jq -r '.result.agent.agent_status // empty' 2>/dev/null)
   case "$status" in
-    working|idle|done|blocked) printf 'live' ;;
+    working|idle|blocked) printf 'live' ;;
+    done)
+      if fm_backend_herdr_done_registration_is_stale "$session" "$pane_id"; then
+        printf 'no-agent'
+      else
+        printf 'unknown'
+      fi
+      ;;
     *) printf 'unknown' ;;
   esac
 }

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2014,24 +2014,14 @@ fm_backend_herdr_agent_alive() {  # <target>
   esac
 }
 
-# fm_backend_herdr_unpublished_replacement_rollback: remove an exact replacement
-# tab that create_task made but cannot publish after its stale-husk boundary
-# recheck. It may only close the exact response-derived tab after it still owns
-# its exact response-derived pane and that pane is positively unregistered.
-# A live, stale-done, dead, or unreadable pane leaves the tab untouched for an
-# operator rather than risking another process.
+# fm_backend_herdr_unpublished_replacement_rollback: remove the exact replacement
+# tab create_task made but cannot publish after its stale-husk boundary recheck.
+# Its response-derived tab id is enough authority: no input has been sent to the
+# new pane, while an extra pane/agent read could transiently fail and strand an
+# unrecorded duplicate. Never derive a label-based target here.
 fm_backend_herdr_unpublished_replacement_rollback() {  # <session> <workspace> <tab> <pane>
-  local session=$1 wsid=$2 tab_id=$3 pane_id=$4 state list
-  [ "$(fm_backend_herdr_pane_for_tab "$session" "$wsid" "$tab_id")" = "$pane_id" ] || return 1
-  state=$(fm_backend_herdr_pane_agent_state "$session" "$pane_id")
-  [ "$state" = no-agent ] || return 1
-  fm_backend_herdr_cli "$session" tab close "$tab_id" >/dev/null 2>&1 || return 1
-  list=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 1
-  fm_backend_herdr_response_is_success "$list" || return 1
-  printf '%s' "$list" | jq -e --arg tab "$tab_id" '
-    (.result.tabs | type) == "array"
-    and ([.result.tabs[]? | select(.tab_id == $tab)] | length) == 0
-  ' >/dev/null 2>&1
+  local session=$1 tab_id=$3
+  fm_backend_herdr_cli "$session" tab close "$tab_id" >/dev/null 2>&1
 }
 
 # fm_backend_herdr_create_task: create the task's tab (one pane) in
@@ -2082,6 +2072,10 @@ fm_backend_herdr_create_task() {  # <container> <label> <cwd> <seeded_default_ta
   session=${container%%:*}
   wsid=${container#*:}
   list=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 1
+  fm_backend_herdr_response_is_success "$list" || {
+    echo "error: could not parse herdr tab list output for workspace $wsid (session $session)" >&2
+    return 1
+  }
   dup_tabs=$(printf '%s' "$list" | jq -r --arg want "$label" 'if (.result.tabs | type) == "array" then .result.tabs[] | select(.label == $want) | .tab_id else error("missing result.tabs") end' 2>/dev/null) || {
     echo "error: could not parse herdr tab list output for workspace $wsid (session $session)" >&2
     return 1
@@ -2105,6 +2099,10 @@ $dup_tabs
 EOF
   fi
   out=$(fm_backend_herdr_cli "$session" tab create --workspace "$wsid" --cwd "$cwd" --label "$label" --no-focus 2>/dev/null) || return 1
+  fm_backend_herdr_response_is_success "$out" || {
+    echo "error: could not parse tab/pane id from herdr tab create output" >&2
+    return 1
+  }
   tab_id=$(printf '%s' "$out" | jq -r '.result.tab.tab_id // empty' 2>/dev/null)
   pane_id=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
   if [ -z "$tab_id" ] || [ -z "$pane_id" ]; then
@@ -2132,7 +2130,8 @@ EOF
       echo "error: could not verify herdr husk removal for tab '$label' in workspace $wsid (session $session)" >&2
       return 1
     }
-    if ! printf '%s' "$list" | jq -e '(.result.tabs | type) == "array"' >/dev/null 2>&1; then
+    if ! fm_backend_herdr_response_is_success "$list" \
+       || ! printf '%s' "$list" | jq -e '(.result.tabs | type) == "array"' >/dev/null 2>&1; then
       echo "error: could not parse herdr tab list output for workspace $wsid (session $session)" >&2
       return 1
     fi

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1214,15 +1214,15 @@ fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
     and .result.process_info.pane_id == $pane
   ' >/dev/null 2>&1 || return 1
   shell_pid=$(printf '%s' "$info" | jq -er \
-    '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
+    '.result.process_info.shell_pid | select(type == "number" and . > 1 and floor == .)' 2>/dev/null) || return 1
   foreground_pgid=$(printf '%s' "$info" | jq -er \
-    '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
+    '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1 and floor == .)' 2>/dev/null) || return 1
   [ "$foreground_pgid" = "$shell_pid" ] || return 1
   count=$(printf '%s' "$info" | jq -er \
     '.result.process_info.foreground_processes | select(type == "array") | length' 2>/dev/null) || return 1
   [ "$count" -eq 1 ] || return 1
   process_pid=$(printf '%s' "$info" | jq -er \
-    '.result.process_info.foreground_processes[0].pid | select(type == "number") | floor' 2>/dev/null) || return 1
+    '.result.process_info.foreground_processes[0].pid | select(type == "number" and . > 1 and floor == .)' 2>/dev/null) || return 1
   [ "$process_pid" = "$shell_pid" ] || return 1
   name=$(printf '%s' "$info" | jq -er \
     '.result.process_info.foreground_processes[0].name | select(type == "string" and length > 0)' 2>/dev/null) || return 1
@@ -1863,7 +1863,7 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 }
 
 # fm_backend_herdr_pane_agent_state: classify <pane_id> in <session> as one of
-# dead|no-agent|live|unknown from read-only backend state plus the shared
+# dead|no-agent|stale-done|live|unknown from read-only backend state plus the shared
 # strict process proof for a stale `done` entry - never from process exit status,
 # since a business-logic "not found"
 # response is a normal, expected outcome here, not a call failure (real herdr
@@ -1884,10 +1884,10 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 #              stability across a server restart"), and what a future
 #              `resume_agents_on_restore = false` restore would produce too
 #              (a plain shell, never an agent).
-#              A `done` registration also resolves to no-agent, but only
-#              after a strict bare-idle-shell proof and a second `agent get`
-#              both agree; a done registration alone remains unknown because
-#              it can still describe an agent that owns the pane.
+#   stale-done - a `done` registration proved agent-free by a strict
+#              bare-idle-shell proof and a second `agent get` that still
+#              reports `done`. Kept distinct from no-agent so a replacement
+#              boundary can require the same proof again.
 #   live     - `agent get` succeeds and reports working, idle, or blocked.
 #              Every one remains a genuine registered agent and is never a
 #              close-and-replace candidate.
@@ -1932,7 +1932,7 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
     working|idle|blocked) printf 'live' ;;
     done)
       if fm_backend_herdr_done_registration_is_stale "$session" "$pane_id"; then
-        printf 'no-agent'
+        printf 'stale-done'
       else
         printf 'unknown'
       fi
@@ -1941,14 +1941,14 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   esac
 }
 
-# fm_backend_herdr_tab_is_husk: true (0) only for the two conservative husk
-# states (dead, no-agent) fm_backend_herdr_pane_agent_state can positively
+# fm_backend_herdr_tab_is_husk: true (0) only for the conservative husk
+# states (dead, no-agent, stale-done) fm_backend_herdr_pane_agent_state can positively
 # confirm; live and unknown both refuse (1), so an inconclusive read never
 # licenses closing anything. Restored-layout recovery depends on this
 # fail-safe-toward-refusal behavior.
 fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
   case "$(fm_backend_herdr_pane_agent_state "$1" "$2")" in
-    dead|no-agent) return 0 ;;
+    dead|no-agent|stale-done) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -1963,7 +1963,7 @@ fm_backend_herdr_agent_state() {  # <target>
   fm_backend_herdr_parse_target "$target" || { printf 'unreadable'; return 0; }
   case "$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")" in
     dead) printf 'missing' ;;
-    no-agent) printf 'dead' ;;
+    no-agent|stale-done) printf 'dead' ;;
     live) printf 'alive' ;;
     *) printf 'unreadable' ;;
   esac
@@ -1993,7 +1993,7 @@ fm_backend_herdr_agent_alive() {  # <target>
 # be there. Before this fix, every fleet respawn after such a restart needed
 # the operator to manually close each husk pane first before firstmate could
 # spawn into it again. fm_backend_herdr_tab_is_husk classifies the existing
-# tab's pane conservatively (dead or no-agent only; anything live or
+# tab's pane conservatively (dead, no-agent, or strictly proved stale-done only; anything live or
 # ambiguous refuses exactly as before) and, when it is a confirmed husk,
 # this function CLOSES AND REPLACES it instead of refusing.
 #
@@ -2023,7 +2023,7 @@ fm_backend_herdr_agent_alive() {  # <target>
 # 4th arg, so this function never even queries for a prune candidate in that
 # case. Echoes "<tab_id> <pane_id>" on success.
 fm_backend_herdr_create_task() {  # <container> <label> <cwd> <seeded_default_tab_id>
-  local container=$1 label=$2 cwd=$3 seeded_tab_id=${4:-} session wsid list dup_tabs dup dup_pane dup_tab_ids out tab_id pane_id remaining_dup_tabs
+  local container=$1 label=$2 cwd=$3 seeded_tab_id=${4:-} session wsid list dup_tabs dup dup_pane dup_state dup_tab_ids out tab_id pane_id remaining_dup_tabs
   session=${container%%:*}
   wsid=${container#*:}
   list=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 1
@@ -2036,11 +2036,15 @@ fm_backend_herdr_create_task() {  # <container> <label> <cwd> <seeded_default_ta
     while IFS= read -r dup; do
       [ -n "$dup" ] || continue
       dup_pane=$(fm_backend_herdr_pane_for_tab "$session" "$wsid" "$dup")
-      if [ -z "$dup_pane" ] || ! fm_backend_herdr_tab_is_husk "$session" "$dup_pane"; then
-        echo "error: herdr tab '$label' already exists in workspace $wsid (session $session)" >&2
-        return 1
-      fi
-      dup_tab_ids="${dup_tab_ids}${dup}"$'\n'
+      dup_state=$(fm_backend_herdr_pane_agent_state "$session" "$dup_pane")
+      case "$dup_state" in
+        dead|no-agent|stale-done) ;;
+        *)
+          echo "error: herdr tab '$label' already exists in workspace $wsid (session $session)" >&2
+          return 1
+          ;;
+      esac
+      dup_tab_ids="${dup_tab_ids}${dup}"$'\t'"${dup_state}"$'\n'
     done <<EOF
 $dup_tabs
 EOF
@@ -2054,8 +2058,13 @@ EOF
   fi
   [ -z "$seeded_tab_id" ] || fm_backend_herdr_workspace_prune_seeded_default_tab "$session" "$wsid" "$seeded_tab_id"
   if [ -n "$dup_tab_ids" ]; then
-    while IFS= read -r dup; do
+    while IFS=$'\t' read -r dup dup_state; do
       [ -n "$dup" ] || continue
+      dup_pane=$(fm_backend_herdr_pane_for_tab "$session" "$wsid" "$dup")
+      if [ -z "$dup_pane" ] || [ "$(fm_backend_herdr_pane_agent_state "$session" "$dup_pane")" != "$dup_state" ]; then
+        echo "error: herdr tab '$label' changed before its stale pane could be replaced in workspace $wsid (session $session)" >&2
+        return 1
+      fi
       fm_backend_herdr_cli "$session" tab close "$dup" >/dev/null 2>&1 || true
     done <<EOF
 $dup_tab_ids
@@ -2308,7 +2317,7 @@ fm_backend_herdr_projection_reclaim_rollback() {  # <session> <new-pane>
 # post-mutation uncertainty that must refuse the launch.
 fm_backend_herdr_projection_reclaim_task() {  # <session> <journal> <task-id> <home> <meta-workspace> <meta-tab> <meta-pane> <parent-label> <task-label> <cwd>
   local session=$1 journal=$2 id=$3 home=$4 meta_workspace=$5 meta_tab=$6 meta_pane=$7
-  local parent_label=$8 task_label=$9 cwd=${10} canonical_home state focus_before active_tab out new_tab new_pane info close_status
+  local parent_label=$8 task_label=$9 cwd=${10} canonical_home state required_agent_state focus_before active_tab out new_tab new_pane info close_status
   FM_BACKEND_HERDR_PROJECTION_TAB_ID=""
   FM_BACKEND_HERDR_PROJECTION_PANE_ID=""
   fm_backend_herdr_projection_journal_snapshot "$journal" "$id" || return 1
@@ -2340,7 +2349,7 @@ fm_backend_herdr_projection_reclaim_task() {  # <session> <journal> <task-id> <h
   fi
   state=$(fm_backend_herdr_pane_agent_state "$session" "$meta_pane")
   case "$state" in
-    no-agent) ;;
+    no-agent|stale-done) required_agent_state=$state ;;
     dead)
       echo "warning: exact herdr presentation pane for $id is gone; spawning flat" >&2
       return 2
@@ -2392,20 +2401,20 @@ fm_backend_herdr_projection_reclaim_task() {  # <session> <journal> <task-id> <h
     return 2
   fi
   state=$(fm_backend_herdr_pane_agent_state "$session" "$meta_pane")
-  case "$state" in
-    no-agent) ;;
-    live|unknown)
-      fm_backend_herdr_projection_reclaim_rollback "$session" "$new_pane" || return 1
-      echo "error: herdr presentation pane for $id became $state during reclaim; refusing duplicate launch" >&2
-      return 1
-      ;;
-    dead)
-      fm_backend_herdr_projection_reclaim_rollback "$session" "$new_pane" || return 1
-      echo "warning: herdr presentation pane for $id disappeared during reclaim; spawning flat" >&2
-      return 2
-      ;;
-  esac
-  if fm_backend_herdr_projection_close_pane_focus_preserving "$session" "$meta_pane" no-agent; then
+  if [ "$state" != "$required_agent_state" ]; then
+    fm_backend_herdr_projection_reclaim_rollback "$session" "$new_pane" || return 1
+    case "$state" in
+      dead)
+        echo "warning: herdr presentation pane for $id disappeared during reclaim; spawning flat" >&2
+        return 2
+        ;;
+      *)
+        echo "error: herdr presentation pane for $id became $state during reclaim; refusing duplicate launch" >&2
+        return 1
+        ;;
+    esac
+  fi
+  if fm_backend_herdr_projection_close_pane_focus_preserving "$session" "$meta_pane" "$required_agent_state"; then
     close_status=0
   else
     close_status=$?
@@ -2498,7 +2507,7 @@ fm_backend_herdr_projection_recovery_allows_flat() {  # <session> <journal> <tas
       [ -n "$pane" ] || continue
       state=$(fm_backend_herdr_pane_agent_state "$session" "$pane")
       case "$state" in
-        dead|no-agent) : ;;
+        dead|no-agent|stale-done) : ;;
         live|unknown)
           echo "error: quarantined herdr presentation for $id has a $state pane; refusing duplicate launch" >&2
           return 1

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2014,6 +2014,26 @@ fm_backend_herdr_agent_alive() {  # <target>
   esac
 }
 
+# fm_backend_herdr_unpublished_replacement_rollback: remove an exact replacement
+# tab that create_task made but cannot publish after its stale-husk boundary
+# recheck. It may only close the exact response-derived tab after it still owns
+# its exact response-derived pane and that pane is positively unregistered.
+# A live, stale-done, dead, or unreadable pane leaves the tab untouched for an
+# operator rather than risking another process.
+fm_backend_herdr_unpublished_replacement_rollback() {  # <session> <workspace> <tab> <pane>
+  local session=$1 wsid=$2 tab_id=$3 pane_id=$4 state list
+  [ "$(fm_backend_herdr_pane_for_tab "$session" "$wsid" "$tab_id")" = "$pane_id" ] || return 1
+  state=$(fm_backend_herdr_pane_agent_state "$session" "$pane_id")
+  [ "$state" = no-agent ] || return 1
+  fm_backend_herdr_cli "$session" tab close "$tab_id" >/dev/null 2>&1 || return 1
+  list=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 1
+  fm_backend_herdr_response_is_success "$list" || return 1
+  printf '%s' "$list" | jq -e --arg tab "$tab_id" '
+    (.result.tabs | type) == "array"
+    and ([.result.tabs[]? | select(.tab_id == $tab)] | length) == 0
+  ' >/dev/null 2>&1
+}
+
 # fm_backend_herdr_create_task: create the task's tab (one pane) in
 # <container> ("session:workspace_id"). Herdr does NOT enforce label
 # uniqueness itself (verified: two tabs can share a label), so the duplicate
@@ -2097,6 +2117,10 @@ EOF
       [ -n "$dup" ] || continue
       dup_pane=$(fm_backend_herdr_pane_for_tab "$session" "$wsid" "$dup")
       if [ -z "$dup_pane" ] || [ "$(fm_backend_herdr_pane_agent_state "$session" "$dup_pane")" != "$dup_state" ]; then
+        if ! fm_backend_herdr_unpublished_replacement_rollback "$session" "$wsid" "$tab_id" "$pane_id"; then
+          echo "error: herdr tab '$label' changed before its stale pane could be replaced and its unpublished replacement could not be removed in workspace $wsid (session $session)" >&2
+          return 1
+        fi
         echo "error: herdr tab '$label' changed before its stale pane could be replaced in workspace $wsid (session $session)" >&2
         return 1
       fi

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1176,22 +1176,28 @@ fm_backend_herdr_pid_is_bare_shell() {  # <ps-bin> <pid>
 }
 
 fm_backend_herdr_response_is_success() {
-  printf '%s' "$1" | jq -e '
-    if type != "object" then false
-    elif (has("error") | not) or .error == null then true
-    else false
+  printf '%s' "$1" | jq -se '
+    if length != 1 then false
+    else .[0] as $response
+    | if ($response | type) != "object" then false
+      elif (($response | has("error")) | not) or $response.error == null then true
+      else false
+      end
     end
   ' >/dev/null 2>&1
 }
 
 fm_backend_herdr_response_error_code() {
-  printf '%s' "$1" | jq -r '
-    if type != "object" then empty
-    elif (has("error") | not) or .error == null or has("result") then empty
-    elif (.error | type) != "object" then empty
-    elif (.error.code | type) != "string" then empty
-    elif (.error.code | length) == 0 then empty
-    else .error.code
+  printf '%s' "$1" | jq -sr '
+    if length != 1 then empty
+    else .[0] as $response
+    | if ($response | type) != "object" then empty
+      elif (($response | has("error")) | not) or $response.error == null or ($response | has("result")) then empty
+      elif ($response.error | type) != "object" then empty
+      elif ($response.error.code | type) != "string" then empty
+      elif ($response.error.code | length) == 0 then empty
+      else $response.error.code
+      end
     end
   ' 2>/dev/null
 }

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -876,10 +876,12 @@ fm_backend_target_exists() {  # <backend> <target> [expected-label]
 #   alive      - a verified harness agent is running.
 #   dead       - the endpoint exists but confidently has no agent.
 #   missing    - the recorded endpoint is authoritatively absent.
+#   stale-done - a Herdr done registration strictly proved detached from its agent.
 #   ambiguous  - the endpoint exists but its process cannot be attributed.
 #   unreadable - a target or inventory read failed or contradicted itself.
 #   unverified - this backend has no recovery classifier.
-# Only `dead` and `missing` license recovery. The tmux adapter requires a
+# Only `dead` and `missing` license generic recovery; `stale-done` requires a
+# dedicated Herdr replacement flow. The tmux adapter requires a
 # successful session inventory and returns `missing` only when it omits the
 # exact window; the Herdr adapter reuses its husk
 # classifier. Zellij remains unverified because its secondmate ghost-tab and

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -449,7 +449,7 @@ do_exit() {
   require_state_verified_backend exit
   state=$(agent_state)
   case "$state" in
-    dead)
+    dead|stale-done)
       printf 'already-stopped'
       return 0
       ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -76,7 +76,7 @@
 #   workspace containing only the ordinary task pane. A successful clean create
 #   upgrades its attempt journal with exact home, session, workspace, tab, pane,
 #   parent, and label bindings. On a same-identity restart, that complete binding
-#   plus authoritative metadata may replace one exact agent-free husk in place.
+#   plus authoritative metadata may replace one exact unregistered husk in place.
 #   The journal, visible token, and labels alone are never endpoint or ownership
 #   authority, and every ambiguous recovery stays on the flat fallback after
 #   duplicate-agent risk is independently absent. Treehouse allocation and task
@@ -1960,7 +1960,7 @@ herdr_projection_meta_field_exact() {  # <meta> <key>
 
 # A stale presentation journal never grants launch authority.
 # Under the session lock, authoritative metadata must identify one positively
-# dead or agent-free endpoint before token inspection may allow flat fallback.
+# dead or unregistered endpoint before token inspection may allow flat fallback.
 # A stale done registration remains reserved for a dedicated replacement flow
 # that revalidates it immediately before the first launch input.
 # Exact Herdr fields are retained for the narrower version 2 reclaim path.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1961,6 +1961,8 @@ herdr_projection_meta_field_exact() {  # <meta> <key>
 # A stale presentation journal never grants launch authority.
 # Under the session lock, authoritative metadata must identify one positively
 # dead or agent-free endpoint before token inspection may allow flat fallback.
+# A stale done registration remains reserved for a dedicated replacement flow
+# that revalidates it immediately before the first launch input.
 # Exact Herdr fields are retained for the narrower version 2 reclaim path.
 herdr_projection_existing_meta_allows_flat() {  # <meta>
   local meta=$1 old_backend old_target old_session old_pane old_state target_session target_pane
@@ -2009,7 +2011,11 @@ herdr_projection_existing_meta_allows_flat() {  # <meta>
     }
     old_state=$(fm_backend_herdr_pane_agent_state "$old_session" "$old_pane")
     case "$old_state" in
-      dead|no-agent|stale-done) return 0 ;;
+      dead|no-agent) return 0 ;;
+      stale-done)
+        echo "error: existing herdr endpoint for $ID has a stale done registration; refusing flat fallback without a fresh launch-boundary proof" >&2
+        return 1
+        ;;
       live|unknown)
         echo "error: existing herdr endpoint for $ID is $old_state; refusing duplicate launch" >&2
         return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1089,6 +1089,7 @@ FIRSTMATE_HOME=
 # validation teardown uses, so a malformed, ambiguous, or foreign record
 # refuses here exactly as it refuses there.
 RELAUNCH_PRIOR_HARNESS=
+RELAUNCH_HERDR_PANE_STATE=
 if [ "$RELAUNCH" -eq 1 ]; then
   [ "${#POS[@]}" -eq 1 ] || {
     echo "error: --relaunch takes the task id only; its project or home comes from the task's own record" >&2
@@ -1122,7 +1123,18 @@ if [ "$RELAUNCH" -eq 1 ]; then
     echo "error: backend '$BACKEND' has no recovery-grade agent-state classifier, so a relaunch cannot prove the previous agent exited; refusing rather than risking two agents in one endpoint" >&2
     exit 1
   }
-  RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
+  if [ "$BACKEND" = herdr ]; then
+    fm_backend_herdr_parse_target "$RELAUNCH_TARGET" || exit 1
+    RELAUNCH_HERDR_PANE_STATE=$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
+    case "$RELAUNCH_HERDR_PANE_STATE" in
+      no-agent|stale-done) RELAUNCH_STATE=dead ;;
+      dead) RELAUNCH_STATE=missing ;;
+      live) RELAUNCH_STATE=alive ;;
+      *) RELAUNCH_STATE=unreadable ;;
+    esac
+  else
+    RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
+  fi
   [ "$RELAUNCH_STATE" = dead ] || {
     echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
     exit 1
@@ -1997,7 +2009,7 @@ herdr_projection_existing_meta_allows_flat() {  # <meta>
     }
     old_state=$(fm_backend_herdr_pane_agent_state "$old_session" "$old_pane")
     case "$old_state" in
-      dead|no-agent) return 0 ;;
+      dead|no-agent|stale-done) return 0 ;;
       live|unknown)
         echo "error: existing herdr endpoint for $ID is $old_state; refusing duplicate launch" >&2
         return 1
@@ -3037,6 +3049,17 @@ spawn_record_traceparent() {
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.
+if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
+  fm_backend_herdr_parse_target "$T" || {
+    echo "error: task $ID's Herdr endpoint became malformed before replacement input; refusing relaunch" >&2
+    exit 1
+  }
+  RELAUNCH_STATE=$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
+  if [ "$RELAUNCH_STATE" != "$RELAUNCH_HERDR_PANE_STATE" ]; then
+    echo "error: task $ID's Herdr endpoint changed from '$RELAUNCH_HERDR_PANE_STATE' to '$RELAUNCH_STATE' before replacement input; refusing relaunch" >&2
+    exit 1
+  fi
+fi
 spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 # Send through the exact channel that already ships GOTMPDIR, so every backend
 # and harness - ship, scout, and secondmate - gets it before launch. Skipped

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -382,7 +382,7 @@ The mechanics are owned by the `/updatefirstmate` skill and firstmate's operatin
 ## Restart-proof
 
 Fleet state lives in each task's session-provider backend (tmux by hard default, herdr or cmux when selected or auto-detected, zellij/orca when explicitly selected), no-mistakes run records, status event logs, local markdown under `data/` including `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, and persistent secondmate homes.
-For herdr, respawning after a server-restored layout closes and replaces confirmed no-agent or dead task-tab husks instead of requiring manual tab cleanup.
+For Herdr, designated task replacement flows close and replace only confirmed safe task-tab husks; [Restart and liveness behavior](herdr-backend.md#restart-and-liveness-behavior) owns the classifications and proof boundary.
 At session start, confirmed-dead secondmate agent endpoints are closed and relaunched through the same secondmate spawn path, while ambiguous liveness reads are left untouched to avoid duplicate supervisors.
 Use `/stow` before an intentional reset when the conversation may hold durable knowledge that has not yet been written to disk; after that, the next firstmate session can reconcile and carry on.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -271,6 +271,7 @@ This prevents closing the workspace's last tab before a replacement exists.
 The generic Herdr agent-liveness probe reuses the same classifier.
 A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, and registered `working`, `idle`, and `blocked` agents remain `alive`.
 A registered `done` entry becomes `dead` only after the exact pane independently proves it holds one bare idle shell with no child process or foreground command, then a second registry read still reports `done`.
+Every replacement boundary repeats that exact stale-done classification and refuses if it changed before an old-tab close or relaunch input.
 A `done` entry with any changed, unreadable, or non-idle process evidence becomes `unreadable` and refuses recovery.
 Unlike tmux process-name inspection, this combines native registration with a structural shell proof rather than guessing from a generic interpreter name.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -131,12 +131,12 @@ If lock, snapshot, pane identity, or restoration is ambiguous, cleanup warns and
 Recovery is deliberately conservative and presentation-only.
 An existing journal suppresses another projected create.
 Before any recovery mutation, Firstmate holds both the task spawn lock and the named-session presentation lock.
-A same-identity version 2 binding may replace one exact agent-free restart husk in place only when the physical home, session, metadata endpoint, unique token match, workspace shape and labels, parent identity and placement, and non-target focus snapshot all agree.
+A same-identity version 2 binding may replace one exact unregistered restart husk in place only when the physical home, session, metadata endpoint, unique token match, workspace shape and labels, parent identity and placement, and non-target focus snapshot all agree.
 The replacement tab and pane are created and verified before the old pane is rechecked and closed, then the journal advances atomically to the replacement endpoint before metadata publication.
 The reclaim path never moves, closes, deletes, or renames a workspace and never touches a parent, sibling, captain, or foreign pane.
 A failed replacement rolls back only the exact response-derived new pane when focus-safe verification permits it.
 Version 1 journals, dead or missing panes, duplicate or absent tokens, renamed or detached spaces, cross-home mismatches, inconsistent endpoint bindings, active target tabs, and ambiguous identity or focus fall back flat without mutating the old projection when duplicate-agent risk is positively absent.
-A live or unknown recorded or token-matched endpoint refuses duplicate launch.
+A `stale-done`, live, or unknown recorded or token-matched endpoint refuses duplicate launch; [Restart and liveness behavior](#restart-and-liveness-behavior) owns the classification boundary.
 
 Locked session start has one narrower cleanup for a restored projected child that is no longer current task state.
 It runs only when the current home has at least one ordinary presentation journal and considers only that home; a primary never recursively sweeps a secondmate home.
@@ -264,15 +264,16 @@ No Herdr-specific copy of that protocol exists.
 ## Restart and liveness behavior
 
 Stopping and restarting a named Herdr server preserves workspace, tab, pane, and label ids, but the underlying harness processes and live agent registrations do not survive.
-A restored same-labeled tab with a missing pane or no registered agent is a husk.
-Create replaces only a confidently dead or no-agent husk, creates the replacement before closing the old tab, and refuses live or unknown states.
+A same-labeled tab with a missing pane, no registered agent, or a strictly proved stale `done` registration is a husk.
+Create replaces only a confidently dead, no-agent, or `stale-done` husk, creates the replacement before closing the old tab, and refuses live or unknown states.
 This prevents closing the workspace's last tab before a replacement exists.
 
 The generic Herdr agent-liveness probe reuses the same classifier.
 A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, and registered `working`, `idle`, and `blocked` agents remain `alive`.
 A registered `done` entry becomes `stale-done` only after the exact pane independently proves it holds one bare idle shell with no child process or foreground command, then a second registry read still reports `done`.
+The classification performs only registry and process reads.
 Generic lifecycle and projected-layout recovery treat `stale-done` as protected; only dedicated replacement flows may consume it, and each repeats the exact classification immediately before an old-tab close or relaunch input.
-A projected stale registration never falls back to a flat launch without that fresh launch-boundary proof.
+A stale registration in a quarantined projection refuses a flat fallback.
 A `done` entry with any changed, unreadable, or non-idle process evidence becomes `unreadable` and refuses recovery.
 Unlike tmux process-name inspection, this combines native registration with a structural shell proof rather than guessing from a generic interpreter name.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -269,8 +269,10 @@ Create replaces only a confidently dead or no-agent husk, creates the replacemen
 This prevents closing the workspace's last tab before a replacement exists.
 
 The generic Herdr agent-liveness probe reuses the same classifier.
-A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
-Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
+A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, and registered `working`, `idle`, and `blocked` agents remain `alive`.
+A registered `done` entry becomes `dead` only after the exact pane independently proves it holds one bare idle shell with no child process or foreground command, then a second registry read still reports `done`.
+A `done` entry with any changed, unreadable, or non-idle process evidence becomes `unreadable` and refuses recovery.
+Unlike tmux process-name inspection, this combines native registration with a structural shell proof rather than guessing from a generic interpreter name.
 
 The session-start sweep uses this probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -270,8 +270,9 @@ This prevents closing the workspace's last tab before a replacement exists.
 
 The generic Herdr agent-liveness probe reuses the same classifier.
 A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, and registered `working`, `idle`, and `blocked` agents remain `alive`.
-A registered `done` entry becomes `dead` only after the exact pane independently proves it holds one bare idle shell with no child process or foreground command, then a second registry read still reports `done`.
-Every replacement boundary repeats that exact stale-done classification and refuses if it changed before an old-tab close or relaunch input.
+A registered `done` entry becomes `stale-done` only after the exact pane independently proves it holds one bare idle shell with no child process or foreground command, then a second registry read still reports `done`.
+Generic lifecycle and projected-layout recovery treat `stale-done` as protected; only dedicated replacement flows may consume it, and each repeats the exact classification immediately before an old-tab close or relaunch input.
+A projected stale registration never falls back to a flat launch without that fresh launch-boundary proof.
 A `done` entry with any changed, unreadable, or non-idle process evidence becomes `unreadable` and refuses recovery.
 Unlike tmux process-name inspection, this combines native registration with a structural shell proof rather than guessing from a generic interpreter name.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -654,6 +654,11 @@ ok - real herdr: an agent that does not stop fails closed instead of being repor
 The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
 That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
+A stale `done` registration cannot be fabricated with that API.
+On 2026-08-31, Herdr 0.8.2 protocol 20 rejected the guarded-lab probe `pane report-agent <pane> --source fm-stale-done-probe --agent pi --state done` with `invalid pane agent state: done (expected idle, working, blocked, or unknown)`.
+A clean isolated Pi `/quit` removed its pane instead of leaving `done`, so the executable regression uses a stateful Herdr fixture for the stale-registry edge while retaining the real lab coverage above.
+`tests/fm-backend-herdr.test.sh` requires two `done` reads around the shared strict bare-idle-shell proof, keeps `working`, `idle`, and `blocked` live, rejects foreground Pi evidence, and drives `fm-control.sh ... relaunch` through a replacement without sending `/exit` to the returned shell.
+
 ### Away-mode transport
 
 The Pi/Herdr return and injection path was reverified on Herdr 0.7.3 and Pi 0.80.7:

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1655,6 +1655,31 @@ test_agent_state_refuses_fractional_process_identities() {
   pass "fm_backend_herdr_agent_state: fractional process identities do not prove a stale done registration"
 }
 
+test_agent_state_refuses_contradictory_done_envelopes() {
+  local kind dir log resp fb out status pid=4242
+  for kind in agent process; do
+    dir="$TMP_ROOT/done-agent-contradictory-$kind"; mkdir -p "$dir/responses"
+    log="$dir/log"; resp="$dir/responses"; : > "$log"
+    printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
+    printf '%s\n' '{"result":{"agent":{"agent_status":"done"}}}' > "$resp/2.out"
+    if [ "$kind" = agent ]; then
+      death_process_info_fixture w2:p2 "$pid" > "$resp/3.out"
+      printf '%s\n' '{"error":{"code":"internal_error"},"result":{"agent":{"agent_status":"done"}}}' > "$resp/4.out"
+    else
+      printf '{"error":{"code":"internal_error"},"result":{"type":"pane_process_info","process_info":{"pane_id":"w2:p2","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"zsh","argv0":"zsh"}]}}}\n' "$pid" "$pid" "$pid" > "$resp/3.out"
+    fi
+    make_death_lab "$dir" "$pid"
+    fb=$(make_herdr_fakebin "$dir")
+    out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+      FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state fmtest:w2:p2' "$ROOT" 2>&1)
+    status=$?
+    [ "$status" -eq 0 ] && [ "$out" = unreadable ] \
+      || fail "a contradictory $kind response must remain unreadable, got '$out'"
+  done
+  pass "fm_backend_herdr_agent_state: contradictory done and process responses refuse stale recovery"
+}
+
 test_create_task_refuses_when_stale_done_changes_before_close() {
   local dir log resp fb out status pid=4242
   dir="$TMP_ROOT/stale-done-close-boundary"; mkdir -p "$dir/responses"
@@ -4807,6 +4832,7 @@ test_create_task_refuses_when_agent_state_ambiguous
 test_agent_state_accepts_only_a_stale_done_registration
 test_agent_state_refuses_done_without_a_bare_shell
 test_agent_state_refuses_fractional_process_identities
+test_agent_state_refuses_contradictory_done_envelopes
 test_create_task_refuses_when_stale_done_changes_before_close
 test_spawn_relaunch_refuses_when_stale_done_changes_before_input
 test_agent_state_keeps_active_registered_statuses_live

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -845,6 +845,32 @@ test_create_task_refuses_when_agent_state_ambiguous() {
   pass "fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently"
 }
 
+test_create_task_refuses_an_ambiguous_duplicate_pane_list() {
+  # A recovered task tab has one root pane. If Herdr returns two candidates for
+  # the same tab, do not select whichever happens to sort first and create a
+  # replacement alongside a potentially live endpoint.
+  local dir log resp fb out status
+  dir="$TMP_ROOT/husk-ambiguous-pane-list"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-ambig-pane","workspace_id":"w1"}]}}\n' > "$resp/1.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p9","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
+  # These responses would authorize a replacement if the adapter selected the
+  # first candidate rather than refusing the ambiguous public CLI result.
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/4.out"
+  printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/5.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-ambig-pane /tmp/proj' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "create_task must refuse an ambiguous pane list"
+  assert_contains "$out" "already exists" "create_task did not report the ambiguous duplicate tab"
+  assert_not_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''create' \
+    "create_task created a replacement after an ambiguous pane list"
+  assert_not_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''close' \
+    "create_task closed a tab after an ambiguous pane list"
+  pass "fm_backend_herdr_create_task: refuses an ambiguous pane list without creating or closing tabs"
+}
+
 test_create_task_husk_replacement_creates_before_closing() {
   # Safety-critical ordering: the replacement tab must be created BEFORE the
   # husk tab is closed, never the reverse - closing a workspace's LAST
@@ -4848,6 +4874,7 @@ test_create_task_closes_and_replaces_no_agent_husk
 test_create_task_closes_all_duplicate_husks_after_replacement
 test_create_task_refuses_when_preexisting_husk_tab_remains
 test_create_task_refuses_when_agent_state_ambiguous
+test_create_task_refuses_an_ambiguous_duplicate_pane_list
 test_agent_state_accepts_only_a_stale_done_registration
 test_agent_state_refuses_done_without_a_bare_shell
 test_agent_state_refuses_fractional_process_identities

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -117,7 +117,7 @@ SH
 make_herdr_statefake() {  # <dir> -> echoes fakebin dir; seeds an empty state file
   local dir=$1 fb="$1/fakebin"
   mkdir -p "$fb"
-  printf '{"next":1,"workspaces":[],"tabs":[],"agent_status":{}}\n' > "$dir/state.json"
+  printf '{"next":1,"workspaces":[],"tabs":[],"agent_status":{},"agent_gets":{},"launch_pending":{}}\n' > "$dir/state.json"
   cat > "$fb/herdr" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -195,11 +195,17 @@ case "$cmd $sub" in
     ;;
   "pane send-keys")
     pane=${3:-}; key=${4:-}
-    if [ "$key" = enter ] && [ "$(jq_state -r --arg p "$pane" '.agent_status[$p] // empty')" = done ]; then
-      jq_state --arg p "$pane" '.agent_status[$p] = "idle"' | save
+    if [ "$key" = enter ] \
+      && [ "$(jq_state -r --arg p "$pane" '.agent_status[$p] // empty')" = done ] \
+      && [ "$(jq_state -r --arg p "$pane" '.launch_pending[$p] // false')" = true ]; then
+      jq_state --arg p "$pane" '.agent_status[$p] = "idle" | del(.launch_pending[$p])' | save
     fi
     ;;
-  "pane send-text"|"pane run") : ;;
+  "pane send-text")
+    pane=${3:-}
+    jq_state --arg p "$pane" '.launch_pending[$p] = true' | save
+    ;;
+  "pane run") : ;;
   "pane close")
     pane=${3:-}
     jq_state --arg p "$pane" '.tabs |= [.[]|select(.pane_id != $p)]' | save
@@ -210,6 +216,11 @@ case "$cmd $sub" in
     ;;
   "agent get")
     pane=${3:-}
+    jq_state --arg p "$pane" --arg transition "${FM_FAKE_HERDR_AGENT_WORKING_ON_GET:-}" '
+      ((.agent_gets[$p] // 0) + 1) as $count
+      | .agent_gets[$p] = $count
+      | if $transition == ($p + ":" + ($count | tostring)) then .agent_status[$p] = "working" else . end
+    ' | save
     status=$(jq_state -r --arg p "$pane" '.agent_status[$p] // empty')
     if [ -n "$status" ]; then
       printf '{"result":{"agent":{"agent_status":"%s"}}}\n' "$status"
@@ -698,7 +709,9 @@ test_create_task_closes_and_replaces_dead_pane_husk() {
   printf '{"error":{"code":"pane_not_found","message":"pane w1:p2 not found"}}\n' > "$resp/3.out"
   # 4: tab create -> the replacement tab (created BEFORE the husk is closed)
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/4.out"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk1","workspace_id":"w1"}]}}\n' > "$resp/6.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/5.out"
+  printf '{"error":{"code":"pane_not_found","message":"pane w1:p2 not found"}}\n' > "$resp/6.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk1","workspace_id":"w1"}]}}\n' > "$resp/8.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-husk1 /tmp/proj' "$ROOT" ) \
@@ -726,7 +739,10 @@ test_create_task_closes_and_replaces_no_agent_husk() {
   printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/4.out"
   # 5: tab create -> the replacement tab (created BEFORE the husk is closed)
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/5.out"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk2","workspace_id":"w1"}]}}\n' > "$resp/7.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/6.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/7.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/8.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk2","workspace_id":"w1"}]}}\n' > "$resp/10.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-husk2 /tmp/proj' "$ROOT" ) \
@@ -754,7 +770,13 @@ test_create_task_closes_all_duplicate_husks_after_replacement() {
   printf '{"result":{"pane":{"pane_id":"w1:p3"}}}\n' > "$resp/6.out"
   printf '{"error":{"code":"agent_not_found","message":"agent target w1:p3 not found"}}\n' > "$resp/7.out"
   printf '{"result":{"tab":{"tab_id":"w1:t4"},"root_pane":{"pane_id":"w1:p4"}}}\n' > "$resp/8.out"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t4","label":"fm-husk-many","workspace_id":"w1"}]}}\n' > "$resp/11.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}\n' > "$resp/9.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/10.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/11.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}\n' > "$resp/13.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p3"}}}\n' > "$resp/14.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p3 not found"}}\n' > "$resp/15.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t4","label":"fm-husk-many","workspace_id":"w1"}]}}\n' > "$resp/17.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-husk-many /tmp/proj' "$ROOT" ) \
@@ -785,8 +807,11 @@ test_create_task_refuses_when_preexisting_husk_tab_remains() {
   printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
   printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/4.out"
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/5.out"
-  printf '1\n' > "$resp/6.exit"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-stale-husk","workspace_id":"w1"},{"tab_id":"w1:t3","label":"fm-stale-husk","workspace_id":"w1"}]}}\n' > "$resp/7.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/6.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/7.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/8.out"
+  printf '1\n' > "$resp/9.exit"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-stale-husk","workspace_id":"w1"},{"tab_id":"w1:t3","label":"fm-stale-husk","workspace_id":"w1"}]}}\n' > "$resp/10.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-stale-husk /tmp/proj' "$ROOT" 2>&1 )
@@ -834,7 +859,9 @@ test_create_task_husk_replacement_creates_before_closing() {
   printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
   printf '{"error":{"code":"pane_not_found","message":"pane w1:p2 not found"}}\n' > "$resp/3.out"
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/4.out"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-order1","workspace_id":"w1"}]}}\n' > "$resp/6.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/5.out"
+  printf '{"error":{"code":"pane_not_found","message":"pane w1:p2 not found"}}\n' > "$resp/6.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-order1","workspace_id":"w1"}]}}\n' > "$resp/8.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-order1 /tmp/proj' "$ROOT" ) \
@@ -1606,6 +1633,104 @@ test_agent_state_refuses_done_without_a_bare_shell() {
   [ "$(grep -c $'agent\x1fget\x1fw2:p2' "$log")" -eq 1 ] \
     || fail "an unsafe done registration should not be reclassified after its shell proof failed"
   pass "fm_backend_herdr_agent_state: done with an active foreground process remains unverified"
+}
+
+test_agent_state_refuses_fractional_process_identities() {
+  local dir log resp fb out status pid=4242
+  dir="$TMP_ROOT/done-agent-fractional-process"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"done"}}}' > "$resp/2.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w2:p2","shell_pid":4242.5,"foreground_process_group_id":4242.5,"foreground_processes":[{"pid":4242.5,"name":"zsh","argv0":"zsh"}]}}}\n' > "$resp/3.out"
+  make_death_lab "$dir" "$pid"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state fmtest:w2:p2' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] && [ "$out" = unreadable ] \
+    || fail "a done registration with fractional process identities must remain unreadable, got '$out'"
+  [ "$(grep -c $'agent\x1fget\x1fw2:p2' "$log")" -eq 1 ] \
+    || fail "a fractional process identity reached the done-registration recheck"
+  pass "fm_backend_herdr_agent_state: fractional process identities do not prove a stale done registration"
+}
+
+test_create_task_refuses_when_stale_done_changes_before_close() {
+  local dir log resp fb out status pid=4242
+  dir="$TMP_ROOT/stale-done-close-boundary"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-boundary","workspace_id":"w1"}]}}' > "$resp/1.out"
+  printf '%s\n' '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}' > "$resp/2.out"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w1:p2"}}}' > "$resp/3.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"done"}}}' > "$resp/4.out"
+  death_process_info_fixture w1:p2 "$pid" > "$resp/5.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"done"}}}' > "$resp/6.out"
+  printf '%s\n' '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}' > "$resp/7.out"
+  printf '%s\n' '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}' > "$resp/8.out"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w1:p2"}}}' > "$resp/9.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"working"}}}' > "$resp/10.out"
+  make_death_lab "$dir" "$pid"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-boundary /tmp/proj' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "create_task must refuse when stale done becomes working before close"
+  assert_contains "$out" "changed before its stale pane could be replaced" \
+    "create_task did not report the changed stale registration"
+  assert_not_contains "$(cat "$log")" $'tab\x1fclose\x1fw1:t2' \
+    "create_task closed a pane that became working after stale-done proof"
+  pass "fm_backend_herdr_create_task: rechecks stale done immediately before closing its old tab"
+}
+
+test_spawn_relaunch_refuses_when_stale_done_changes_before_input() {
+  local dir home proj wt log state fb out status
+  dir="$TMP_ROOT/stale-done-input-boundary"; home="$dir/home"; proj="$dir/proj"; wt="$dir/wt"
+  mkdir -p "$home/state" "$home/data/hdoneinput" "$home/config"
+  printf '# replacement brief\n' > "$home/data/hdoneinput/brief.md"
+  fm_git_worktree "$proj" "$wt" "task-hdoneinput"
+  log="$dir/log"; : > "$log"
+  fb=$(make_herdr_statefake "$dir")
+  state="$dir/state.json"
+  jq -n --arg cwd "$wt" '{
+    next:2,
+    workspaces:[{workspace_id:"w1",label:"firstmate"}],
+    tabs:[{tab_id:"w1:t1",label:"fm-hdoneinput",workspace_id:"w1",pane_id:"w1:p1",foreground_cwd:$cwd}],
+    agent_status:{"w1:p1":"done"}
+  }' > "$state"
+  make_death_lab "$dir" 4242
+  {
+    echo 'window=fmtest:w1:p1'
+    echo 'endpoint_task_id=hdoneinput'
+    echo "worktree=$wt"
+    echo "project=$proj"
+    echo 'harness=claude'
+    echo 'kind=ship'
+    echo 'mode=no-mistakes'
+    echo 'yolo=off'
+    echo 'model=default'
+    echo 'effort=default'
+    echo 'backend=herdr'
+    echo 'herdr_session=fmtest'
+    echo 'herdr_workspace_id=w1'
+    echo 'herdr_tab_id=w1:t1'
+    echo 'herdr_pane_id=w1:p1'
+  } > "$home/state/hdoneinput.meta"
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" FM_HERDR_LOG="$log" FM_FAKE_HERDR_STATE="$state" \
+    HERDR_SESSION=fmtest FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    FM_FAKE_HERDR_AGENT_WORKING_ON_GET=w1:p1:3 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" hdoneinput --relaunch --harness claude 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "relaunch must refuse when stale done becomes working before input"
+  assert_contains "$out" "changed from 'stale-done' to 'live'" \
+    "relaunch did not report the changed stale registration before input"
+  assert_not_contains "$(cat "$log")" $'pane\x1frun\x1f' \
+    "relaunch sent a command after the stale registration became working"
+  assert_not_contains "$(cat "$log")" $'pane\x1fsend-text\x1f' \
+    "relaunch typed a replacement launch after the stale registration became working"
+  assert_not_contains "$(cat "$log")" $'pane\x1fsend-keys\x1f' \
+    "relaunch submitted input after the stale registration became working"
+  pass "fm-spawn relaunch: a stale done registration changing to working receives no replacement input"
 }
 
 test_agent_state_keeps_active_registered_statuses_live() {
@@ -4664,6 +4789,9 @@ test_create_task_refuses_when_preexisting_husk_tab_remains
 test_create_task_refuses_when_agent_state_ambiguous
 test_agent_state_accepts_only_a_stale_done_registration
 test_agent_state_refuses_done_without_a_bare_shell
+test_agent_state_refuses_fractional_process_identities
+test_create_task_refuses_when_stale_done_changes_before_close
+test_spawn_relaunch_refuses_when_stale_done_changes_before_input
 test_agent_state_keeps_active_registered_statuses_live
 test_control_relaunch_replaces_a_stale_done_registration
 test_create_task_husk_replacement_creates_before_closing

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1705,6 +1705,12 @@ test_create_task_refuses_when_stale_done_changes_before_close() {
   printf '%s\n' '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}' > "$resp/8.out"
   printf '%s\n' '{"result":{"pane":{"pane_id":"w1:p2"}}}' > "$resp/9.out"
   printf '%s\n' '{"result":{"agent":{"agent_status":"working"}}}' > "$resp/10.out"
+  # The unpublished replacement is still its exact, agent-free pane, so the
+  # refusal must retire it rather than leave a duplicate unrecorded tab.
+  printf '%s\n' '{"result":{"panes":[{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}' > "$resp/11.out"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w1:p3"}}}' > "$resp/12.out"
+  printf '%s\n' '{"error":{"code":"agent_not_found","message":"agent target w1:p3 not found"}}' > "$resp/13.out"
+  printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-boundary","workspace_id":"w1"}]}}' > "$resp/15.out"
   make_death_lab "$dir" "$pid"
   fb=$(make_herdr_fakebin "$dir")
   out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
@@ -1716,7 +1722,9 @@ test_create_task_refuses_when_stale_done_changes_before_close() {
     "create_task did not report the changed stale registration"
   assert_not_contains "$(cat "$log")" $'tab\x1fclose\x1fw1:t2' \
     "create_task closed a pane that became working after stale-done proof"
-  pass "fm_backend_herdr_create_task: rechecks stale done immediately before closing its old tab"
+  assert_contains "$(cat "$log")" $'tab\x1fclose\x1fw1:t3' \
+    "create_task left its unpublished replacement tab behind after stale-done proof changed"
+  pass "fm_backend_herdr_create_task: rechecks stale done before closing its old tab and retires its unpublished replacement"
 }
 
 test_spawn_relaunch_refuses_when_stale_done_changes_before_input() {

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1657,17 +1657,28 @@ test_agent_state_refuses_fractional_process_identities() {
 
 test_agent_state_refuses_contradictory_done_envelopes() {
   local kind dir log resp fb out status pid=4242
-  for kind in agent process; do
+  for kind in agent process agent-stream process-stream; do
     dir="$TMP_ROOT/done-agent-contradictory-$kind"; mkdir -p "$dir/responses"
     log="$dir/log"; resp="$dir/responses"; : > "$log"
     printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
     printf '%s\n' '{"result":{"agent":{"agent_status":"done"}}}' > "$resp/2.out"
-    if [ "$kind" = agent ]; then
-      death_process_info_fixture w2:p2 "$pid" > "$resp/3.out"
-      printf '%s\n' '{"error":{"code":"internal_error"},"result":{"agent":{"agent_status":"done"}}}' > "$resp/4.out"
-    else
-      printf '{"error":{"code":"internal_error"},"result":{"type":"pane_process_info","process_info":{"pane_id":"w2:p2","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"zsh","argv0":"zsh"}]}}}\n' "$pid" "$pid" "$pid" > "$resp/3.out"
-    fi
+    case "$kind" in
+      agent)
+        death_process_info_fixture w2:p2 "$pid" > "$resp/3.out"
+        printf '%s\n' '{"error":{"code":"internal_error"},"result":{"agent":{"agent_status":"done"}}}' > "$resp/4.out"
+        ;;
+      process)
+        printf '{"error":{"code":"internal_error"},"result":{"type":"pane_process_info","process_info":{"pane_id":"w2:p2","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"zsh","argv0":"zsh"}]}}}\n' "$pid" "$pid" "$pid" > "$resp/3.out"
+        ;;
+      agent-stream)
+        death_process_info_fixture w2:p2 "$pid" > "$resp/3.out"
+        printf '%s\n' '{"error":{"code":"temporary"}}' '{"result":{"agent":{"agent_status":"done"}}}' > "$resp/4.out"
+        ;;
+      process-stream)
+        printf '%s\n' '{"error":{"code":"temporary"}}' > "$resp/3.out"
+        death_process_info_fixture w2:p2 "$pid" >> "$resp/3.out"
+        ;;
+    esac
     make_death_lab "$dir" "$pid"
     fb=$(make_herdr_fakebin "$dir")
     out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
@@ -1677,7 +1688,7 @@ test_agent_state_refuses_contradictory_done_envelopes() {
     [ "$status" -eq 0 ] && [ "$out" = unreadable ] \
       || fail "a contradictory $kind response must remain unreadable, got '$out'"
   done
-  pass "fm_backend_herdr_agent_state: contradictory done and process responses refuse stale recovery"
+  pass "fm_backend_herdr_agent_state: contradictory done and process response streams refuse stale recovery"
 }
 
 test_create_task_refuses_when_stale_done_changes_before_close() {

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1606,13 +1606,13 @@ test_agent_state_accepts_only_a_stale_done_registration() {
     FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state fmtest:w2:p2' "$ROOT" 2>&1)
   status=$?
-  [ "$status" -eq 0 ] && [ "$out" = dead ] \
-    || fail "a stale done registration over a proved bare shell should classify dead, got '$out'"
+  [ "$status" -eq 0 ] && [ "$out" = stale-done ] \
+    || fail "a stale done registration over a proved bare shell should classify stale-done, got '$out'"
   [ "$(grep -c $'agent\x1fget\x1fw2:p2' "$log")" -eq 2 ] \
     || fail "stale done recovery did not re-read the agent registration after proving the shell"
   assert_contains "$(cat "$log")" $'pane\x1fprocess-info\x1f--pane\x1fw2:p2' \
     "stale done recovery did not prove the pane had returned to its bare shell"
-  pass "fm_backend_herdr_agent_state: a stale done registration over a proved bare shell is agent-free"
+  pass "fm_backend_herdr_agent_state: a stale done registration remains distinct from generic dead state"
 }
 
 test_agent_state_refuses_done_without_a_bare_shell() {
@@ -2958,6 +2958,7 @@ test_projection_reclaim_refusal_matrix_is_non_mutating() {
           case "$mode" in
             live) printf live ;;
             unknown) printf unknown ;;
+            stale-done) printf stale-done ;;
             *) printf no-agent ;;
           esac
         }
@@ -2978,15 +2979,16 @@ test_projection_reclaim_refusal_matrix_is_non_mutating() {
       run_case ambiguous "$JOURNAL" "$HOME_A"
       run_case live "$JOURNAL" "$HOME_A"
       run_case unknown "$JOURNAL" "$HOME_A"
+      run_case stale-done "$JOURNAL" "$HOME_A"
       run_case focus-unknown "$JOURNAL" "$HOME_A"
     ')
-  [ "$out" = $'legacy:2\ncross-home:2\nambiguous:2\nlive:1\nunknown:1\nfocus-unknown:2' ] \
+  [ "$out" = $'legacy:2\ncross-home:2\nambiguous:2\nlive:1\nunknown:1\nstale-done:1\nfocus-unknown:2' ] \
     || fail "reclaim refusal matrix returned wrong decisions: $out"
   [ ! -s "$mutation_log" ] \
-    || fail "legacy, cross-home, ambiguous, live/unknown, or focus-unknown refusal mutated Herdr: $(cat "$mutation_log")"
+    || fail "legacy, cross-home, ambiguous, live/unknown, stale-done, or focus-unknown refusal mutated Herdr: $(cat "$mutation_log")"
   [ "$(sed -n 's/^workspace_label=//p' "$journal")" = "$label" ] \
     || fail "reclaim refusal matrix rewrote the bound workspace label"
-  pass "herdr presentation reclaim: legacy, cross-home, ambiguous, live/unknown, and focus-unknown cases refuse without mutation"
+  pass "herdr presentation reclaim: stale-done and every ambiguous case refuse without mutation"
 }
 
 test_projection_reclaim_replaces_only_exact_husk_and_advances_binding() {
@@ -3102,7 +3104,22 @@ test_projection_recovery_is_read_only_and_refuses_live_duplicate_risk() {
   [ "$status" -ne 0 ] || fail "a token match with a live registered agent must refuse duplicate launch"
   assert_contains "$out" "has a live pane" "live duplicate refusal did not explain the risk"
   assert_not_contains "$(cat "$log")" $'pane\x1fclose' "live duplicate refusal closed a pane"
-  pass "herdr presentation recovery: duplicate-token inspection is read-only and live-agent risk refuses fallback"
+
+  : > "$log"; rm -f "$resp"/*.out "$resp"/*.exit "$resp/.count"
+  printf '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate/task-p3 · p:%s"}]}}\n' "$token" > "$resp/1.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p1","tab_id":"w1:t1"}]}}\n' > "$resp/2.out"
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '
+      . "$0/bin/backends/herdr.sh"
+      fm_backend_herdr_pane_agent_state() { printf stale-done; }
+      fm_backend_herdr_projection_recovery_allows_flat fmtest "$1" task-p3
+    ' "$ROOT" "$journal" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a stale done token match must refuse flat fallback without a launch-boundary proof"
+  assert_contains "$out" "stale done registration" "stale done fallback refusal did not explain the proof boundary"
+  assert_not_contains "$(cat "$log")" $'tab\x1fcreate' "stale done fallback created a tab"
+  assert_not_contains "$(cat "$log")" $'pane\x1fclose' "stale done fallback closed a pane"
+  pass "herdr presentation recovery: duplicate-token inspection is read-only and live or stale-done risk refuses fallback"
 }
 
 # --- workspace_find: scoped to THIS home's own label, not just any match ----

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -133,12 +133,13 @@ jq_state() { jq "$@" "$STATE"; }
 save() { local tmp="$STATE.tmp.$$"; cat > "$tmp" && mv "$tmp" "$STATE"; }
 
 cmd=${1:-}; sub=${2:-}
-ws=""; label=""
+ws=""; label=""; cwd=""
 args=("$@")
 for ((i=0; i<${#args[@]}; i++)); do
   case "${args[$i]}" in
     --workspace) ws=${args[$((i+1))]:-} ;;
     --label) label=${args[$((i+1))]:-} ;;
+    --cwd) cwd=${args[$((i+1))]:-} ;;
   esac
 done
 
@@ -164,14 +165,41 @@ case "$cmd $sub" in
     ;;
   "tab create")
     n=$(jq_state -r '.next'); tabid="$ws:t$n"; paneid="$ws:p$n"
-    jq_state --arg w "$ws" --arg wlabel "$label" --arg tabid "$tabid" --arg paneid "$paneid" \
-      '.tabs += [{tab_id:$tabid, label:$wlabel, workspace_id:$w, pane_id:$paneid}]
+    jq_state --arg w "$ws" --arg wlabel "$label" --arg tabid "$tabid" --arg paneid "$paneid" --arg cwd "$cwd" \
+      '.tabs += [{tab_id:$tabid, label:$wlabel, workspace_id:$w, pane_id:$paneid, foreground_cwd:$cwd}]
        | .next = (.next + 1)' | save
     printf '{"result":{"tab":{"tab_id":"%s"},"root_pane":{"pane_id":"%s"}}}\n' "$tabid" "$paneid"
     ;;
   "pane list")
     jq_state --arg w "$ws" '{result:{panes:[.tabs[]|select(.workspace_id==$w)|{pane_id:.pane_id, tab_id:.tab_id}]}}'
     ;;
+  "pane get")
+    pane=${3:-}
+    jq_state --arg p "$pane" '
+      [.tabs[] | select(.pane_id == $p)] as $matches
+      | if ($matches | length) == 1 then
+          {result:{pane:($matches[0] | {pane_id,tab_id,workspace_id,foreground_cwd:(.foreground_cwd // "")})}}
+        else
+          {error:{code:"pane_not_found",message:"pane not found"}}
+        end'
+    ;;
+  "pane process-info")
+    pane=${4:-}
+    jq_state --arg p "$pane" '
+      [.tabs[] | select(.pane_id == $p)] as $matches
+      | if ($matches | length) == 1 then
+          {result:{type:"pane_process_info",process_info:{pane_id:$p,shell_pid:4242,foreground_process_group_id:4242,foreground_processes:[{pid:4242,name:"zsh",argv0:"zsh"}]}}}
+        else
+          {error:{code:"pane_not_found",message:"pane not found"}}
+        end'
+    ;;
+  "pane send-keys")
+    pane=${3:-}; key=${4:-}
+    if [ "$key" = enter ] && [ "$(jq_state -r --arg p "$pane" '.agent_status[$p] // empty')" = done ]; then
+      jq_state --arg p "$pane" '.agent_status[$p] = "idle"' | save
+    fi
+    ;;
+  "pane send-text"|"pane run") : ;;
   "pane close")
     pane=${3:-}
     jq_state --arg p "$pane" '.tabs |= [.[]|select(.pane_id != $p)]' | save
@@ -1532,6 +1560,124 @@ SH
 
 death_process_info_fixture() {  # <pane> <pid>
   printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"%s","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"zsh","argv0":"zsh"}]}}}\n' "$1" "$2" "$2" "$2"
+}
+
+# A done registration alone is not enough to replace a worker: it has to stay
+# done across a strict proof that the pane has only its idle shell. This models
+# the stale registry left after a Pi process exits back to its shell.
+test_agent_state_accepts_only_a_stale_done_registration() {
+  local dir log resp fb out status pid=4242
+  dir="$TMP_ROOT/stale-done-agent-state"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"done"}}}' > "$resp/2.out"
+  death_process_info_fixture w2:p2 "$pid" > "$resp/3.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"done"}}}' > "$resp/4.out"
+  make_death_lab "$dir" "$pid"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state fmtest:w2:p2' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] && [ "$out" = dead ] \
+    || fail "a stale done registration over a proved bare shell should classify dead, got '$out'"
+  [ "$(grep -c $'agent\x1fget\x1fw2:p2' "$log")" -eq 2 ] \
+    || fail "stale done recovery did not re-read the agent registration after proving the shell"
+  assert_contains "$(cat "$log")" $'pane\x1fprocess-info\x1f--pane\x1fw2:p2' \
+    "stale done recovery did not prove the pane had returned to its bare shell"
+  pass "fm_backend_herdr_agent_state: a stale done registration over a proved bare shell is agent-free"
+}
+
+test_agent_state_refuses_done_without_a_bare_shell() {
+  local dir log resp fb out status pid=4242
+  dir="$TMP_ROOT/done-agent-active-process"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"done"}}}' > "$resp/2.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w2:p2","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"zsh","argv0":"zsh"},{"pid":4243,"name":"pi","argv0":"pi"}]}}}\n' "$pid" "$pid" "$pid" > "$resp/3.out"
+  make_death_lab "$dir" "$pid"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state fmtest:w2:p2' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] && [ "$out" = unreadable ] \
+    || fail "a done registration with a foreground Pi process must refuse recovery, got '$out'"
+  [ "$(grep -c $'agent\x1fget\x1fw2:p2' "$log")" -eq 1 ] \
+    || fail "an unsafe done registration should not be reclassified after its shell proof failed"
+  pass "fm_backend_herdr_agent_state: done with an active foreground process remains unverified"
+}
+
+test_agent_state_keeps_active_registered_statuses_live() {
+  local candidate dir log resp fb out status
+  for candidate in working idle blocked; do
+    dir="$TMP_ROOT/agent-state-$candidate"; mkdir -p "$dir/responses"
+    log="$dir/log"; resp="$dir/responses"; : > "$log"
+    printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
+    printf '{"result":{"agent":{"agent_status":"%s"}}}\n' "$candidate" > "$resp/2.out"
+    fb=$(make_herdr_fakebin "$dir")
+    out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state fmtest:w2:p2' "$ROOT" 2>&1)
+    status=$?
+    [ "$status" -eq 0 ] && [ "$out" = alive ] \
+      || fail "registered agent_status=$candidate must remain live, got '$out'"
+    assert_not_contains "$(cat "$log")" $'pane\x1fprocess-info' \
+      "registered agent_status=$candidate should not enter stale-done recovery"
+  done
+  pass "fm_backend_herdr_agent_state: working, idle, and blocked registrations remain live"
+}
+
+# Drive fm-control's complete relaunch transaction against the stale-done
+# classifier. The stateful Herdr double accepts a replacement only when its
+# launch Enter lands, so the test proves the transaction did not type an exit
+# command into the returned shell before it launched the replacement.
+test_control_relaunch_replaces_a_stale_done_registration() {
+  local dir home proj wt log state fb out status
+  dir="$TMP_ROOT/control-stale-done"; home="$dir/home"; proj="$dir/proj"; wt="$dir/wt"
+  mkdir -p "$home/state" "$home/data/hdone" "$home/config"
+  printf '# replacement brief\n' > "$home/data/hdone/brief.md"
+  fm_git_worktree "$proj" "$wt" "task-hdone"
+  log="$dir/log"; : > "$log"
+  fb=$(make_herdr_statefake "$dir")
+  state="$dir/state.json"
+  jq -n --arg cwd "$wt" '{
+    next:2,
+    workspaces:[{workspace_id:"w1",label:"firstmate"}],
+    tabs:[{tab_id:"w1:t1",label:"fm-hdone",workspace_id:"w1",pane_id:"w1:p1",foreground_cwd:$cwd}],
+    agent_status:{"w1:p1":"done"}
+  }' > "$state"
+  make_death_lab "$dir" 4242
+  {
+    echo 'window=fmtest:w1:p1'
+    echo 'endpoint_task_id=hdone'
+    echo "worktree=$wt"
+    echo "project=$proj"
+    echo 'harness=claude'
+    echo 'kind=ship'
+    echo 'mode=no-mistakes'
+    echo 'yolo=off'
+    echo 'model=default'
+    echo 'effort=default'
+    echo 'backend=herdr'
+    echo 'herdr_session=fmtest'
+    echo 'herdr_workspace_id=w1'
+    echo 'herdr_tab_id=w1:t1'
+    echo 'herdr_pane_id=w1:p1'
+  } > "$home/state/hdone.meta"
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" FM_HERDR_LOG="$log" FM_FAKE_HERDR_STATE="$state" \
+    HERDR_SESSION=fmtest FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    FM_SPAWN_NO_GUARD=1 FM_CONTROL_POLL=0.01 FM_CONTROL_LAUNCH_WAIT=0.2 \
+    "$ROOT/bin/fm-control.sh" hdone relaunch --note 'continue from the preserved local copy' 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] \
+    || fail "stale done recovery should complete the relaunch transaction: $out"
+  assert_contains "$out" 'relaunched hdone harness=claude' \
+    "stale done recovery did not report a replacement agent"
+  [ "$(jq -r '.agent_status["w1:p1"]' "$state")" = idle ] \
+    || fail "replacement launch did not replace the stale done registration with a live agent"
+  assert_not_contains "$(cat "$log")" $'\x1f/exit' \
+    "stale done recovery typed an exit command into the proved returned shell"
+  pass "fm-control relaunch: a proved stale done registration is replaced without sending a lifecycle command to the shell"
 }
 
 test_projection_close_emptying_after_focus_uses_pane_death_without_move() {
@@ -4516,6 +4662,10 @@ test_create_task_closes_and_replaces_no_agent_husk
 test_create_task_closes_all_duplicate_husks_after_replacement
 test_create_task_refuses_when_preexisting_husk_tab_remains
 test_create_task_refuses_when_agent_state_ambiguous
+test_agent_state_accepts_only_a_stale_done_registration
+test_agent_state_refuses_done_without_a_bare_shell
+test_agent_state_keeps_active_registered_statuses_live
+test_control_relaunch_replaces_a_stale_done_registration
 test_create_task_husk_replacement_creates_before_closing
 test_create_task_creates_and_parses_ids
 test_create_task_creates_with_no_focus_flag

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -845,6 +845,23 @@ test_create_task_refuses_when_agent_state_ambiguous() {
   pass "fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently"
 }
 
+test_create_task_refuses_an_error_tab_list_envelope() {
+  local dir log resp fb out status
+  dir="$TMP_ROOT/husk-error-tab-list"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # A result alongside an error must not authorize a tab create.
+  printf '%s\n' '{"error":{"code":"temporary"},"result":{"tabs":[]}}' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-error-list /tmp/proj' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "create_task must refuse an error tab-list envelope"
+  assert_contains "$out" "could not parse herdr tab list" \
+    "create_task did not report its unreadable tab list"
+  assert_not_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''create' \
+    "create_task created a tab from an error tab-list envelope"
+  pass "fm_backend_herdr_create_task: refuses an error tab-list envelope without creating a tab"
+}
+
 test_create_task_refuses_an_ambiguous_duplicate_pane_list() {
   # A recovered task tab has one root pane. If Herdr returns two candidates for
   # the same tab, do not select whichever happens to sort first and create a
@@ -1731,12 +1748,9 @@ test_create_task_refuses_when_stale_done_changes_before_close() {
   printf '%s\n' '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}' > "$resp/8.out"
   printf '%s\n' '{"result":{"pane":{"pane_id":"w1:p2"}}}' > "$resp/9.out"
   printf '%s\n' '{"result":{"agent":{"agent_status":"working"}}}' > "$resp/10.out"
-  # The unpublished replacement is still its exact, agent-free pane, so the
-  # refusal must retire it rather than leave a duplicate unrecorded tab.
-  printf '%s\n' '{"result":{"panes":[{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}' > "$resp/11.out"
-  printf '%s\n' '{"result":{"pane":{"pane_id":"w1:p3"}}}' > "$resp/12.out"
-  printf '%s\n' '{"error":{"code":"agent_not_found","message":"agent target w1:p3 not found"}}' > "$resp/13.out"
-  printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-boundary","workspace_id":"w1"}]}}' > "$resp/15.out"
+  # Deliberately leave response 11 absent. The old rollback consumed this as
+  # an unreadable pane-list response and stranded the replacement; the exact
+  # tab returned from create is unpublished, so it must be closed directly.
   make_death_lab "$dir" "$pid"
   fb=$(make_herdr_fakebin "$dir")
   out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
@@ -1750,7 +1764,7 @@ test_create_task_refuses_when_stale_done_changes_before_close() {
     "create_task closed a pane that became working after stale-done proof"
   assert_contains "$(cat "$log")" $'tab\x1fclose\x1fw1:t3' \
     "create_task left its unpublished replacement tab behind after stale-done proof changed"
-  pass "fm_backend_herdr_create_task: rechecks stale done before closing its old tab and retires its unpublished replacement"
+  pass "fm_backend_herdr_create_task: rechecks stale done before closing its old tab and retires its unpublished replacement despite unreadable cleanup reads"
 }
 
 test_spawn_relaunch_refuses_when_stale_done_changes_before_input() {
@@ -4874,6 +4888,7 @@ test_create_task_closes_and_replaces_no_agent_husk
 test_create_task_closes_all_duplicate_husks_after_replacement
 test_create_task_refuses_when_preexisting_husk_tab_remains
 test_create_task_refuses_when_agent_state_ambiguous
+test_create_task_refuses_an_error_tab_list_envelope
 test_create_task_refuses_an_ambiguous_duplicate_pane_list
 test_agent_state_accepts_only_a_stale_done_registration
 test_agent_state_refuses_done_without_a_bare_shell


### PR DESCRIPTION
## Intent

Publish the completed Firstmate stale Herdr-registration recovery repair from the preserved local branch fm/fm-herdr-recovery-publish-s7 at expected head 4ab6006c. The repair is reviewed F001-F007, rebased onto origin/main at 355f46f, and must remain limited to generic Firstmate code, documentation, and tests. Do not recreate, reset, rebase, broaden, force-push, add private local material, send credentials, publish before validation passes, or merge. Initialize no-mistakes with fork https://github.com/rockinet/firstmate.git while retaining origin at kunchenguid/firstmate, validate through the complete supported no-mistakes pipeline, and open a PR from rockinet/firstmate to kunchenguid/firstmate main only after validation passes.

## What Changed
- Classify Herdr `done` registrations as stale only after strict idle-shell proof and a repeated registry read.
- Permit dedicated relaunch and task replacement flows to recover proven stale registrations with launch-boundary revalidation, while keeping generic and projected recovery blocked.
- Add stale-registration regression coverage and document the liveness and recovery boundaries.

## Risk Assessment

✅ Low: The stale-done classification is conservatively revalidated at each authorized replacement boundary, and changed sibling recovery paths refuse rather than duplicate or close an uncertain endpoint.

## Testing

Exercised the Herdr adapter’s executable fake-backend recovery flows, including multi-document/contradictory response refusal, stale-done launch-boundary protection, and end-to-end control-plane replacement; the targeted run completed successfully with no worktree artifacts left behind.

<details>
<summary>Evidence: Focused Herdr recovery test transcript</summary>

Source: [Focused Herdr recovery test transcript](https://github.com/rockinet/firstmate/blob/044ac70642be960fd014694ad5f408a4f8d920ab/.no-mistakes/evidence/fm/fm-herdr-recovery-publish-s7/fm-backend-herdr-test.log)

```text
FM_TEST_BEGIN 2026-09-01T19:07:14Z tests/fm-backend-herdr.test.sh family=backend-dispatch expected_gate_skip=none
ok - fm_backend_herdr_version_check: accepts the current protocol (14)
ok - fm_backend_herdr_version_check: refuses an old protocol loudly
ok - fm_backend_herdr_version_check: refuses loudly when herdr is not installed
ok - fm_backend_herdr_workspace_label: a primary home (no marker) resolves to 'firstmate'
ok - fm_backend_herdr_workspace_label: a secondmate home (.fm-secondmate-home) resolves to '2ndmate-<id>'
ok - fm_backend_herdr_workspace_label: trims whitespace around the marker's secondmate id
ok - fm_backend_herdr_workspace_label: an empty marker file falls back to the primary label 'firstmate'
ok - fm_backend_herdr_workspace_label: two different secondmate homes get two different, non-colliding labels
ok - fm_backend_herdr_cli: sets HERDR_SESSION AND appends a trailing --session flag on every call
ok - fm_backend_herdr_launcher_identity: a firstmate not running inside herdr has no launcher workspace to inherit
ok - fm_backend_herdr_launcher_identity: HERDR_ENV=1 without a pane id selects the backend but binds no parent
ok - fm_backend_herdr_launcher_identity: resolves the launcher's exact workspace even when a same-labeled workspace sorts first
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane that names a different herdr session
ok - fm_backend_herdr_launcher_identity: refuses a claimed pane without exact server identity
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane whose injected socket belongs to another herdr server
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's own pane no longer resolves
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's pane and tab disagree about their workspace
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's workspace is gone from its own session
ok - fm_backend_herdr_workspace_ensure: places a worker in the launcher's exact workspace, not the first same-labeled one
ok - fm_backend_herdr_workspace_ensure: refuses to guess between two same-labeled home workspaces
ok - fm_backend_herdr_workspace_ensure: a --secondmate container resolves that home's own workspace, not the launcher's
ok - fm_backend_herdr_container_ensure: surfaces the exact ambiguous-placement refusal instead of a generic failure
ok - fm_backend_herdr_container_ensure: version-gates, starts the server, ensures the firstmate workspace, echoes session:workspace_id + the seeded default tab id
ok - fm_backend_herdr_server_ensure: scrubs home and harness identity without disturbing unrelated environment or session routing
ok - fm_backend_herdr_container_ensure: reuses an existing firstmate workspace without recreating it, and reports no seeded default tab (adopted, not created)
ok - fm_backend_herdr_container_ensure: workspace create passes --no-focus
ok - fm_backend_herdr_container_ensure: creates the workspace under the SECONDMATE home's own label, not 'firstmate'
ok - fm_backend_herdr_create_task: prunes exactly the seeded default tab container_ensure identified, once the first real task tab exists
ok - herdr repeated spawn/teardown: one persistent firstmate workspace reused, zero orphans, default tab pruned, create ran once
ok - fm_backend_herdr_create_task: an ADOPTED workspace's pre-existing tab is never pruned (the created-vs-adopted gate)
ok - fm_backend_herdr_create_task: the label-collision startup-workspace scenario (2026-07-02 incident) leaves the captain's live tab untouched
ok - fm_backend_herdr_workspace_prune_seeded_default_tab: refuses to close the seeded default tab when its pane reports a working agent (defense in depth)
ok - fm_backend_herdr_create_task: refuses a duplicate tab label (herdr's own tab create has no uniqueness check)
ok - fm_backend_herdr_create_task: a same-labeled tab with a live (even idle) registered agent still refuses exactly as before
ok - fm_backend_herdr_create_task: scans every same-labeled tab and refuses if any duplicate is live
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is dead (pane_not_found)
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is alive but hosts no registered agent (a restored plain shell)
ok - fm_backend_herdr_create_task: closes every confirmed same-labeled husk only after creating the replacement
ok - fm_backend_herdr_create_task: refuses success when a preexisting husk tab remains after replacement
ok - fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently
ok - fm_backend_herdr_agent_state: a stale done registration remains distinct from generic dead state
ok - fm_backend_herdr_agent_state: done with an active foreground process remains unverified
ok - fm_backend_herdr_agent_state: fractional process identities do not prove a stale done registration
ok - fm_backend_herdr_agent_state: contradictory done and process response streams refuse stale recovery
ok - fm_backend_herdr_create_task: rechecks stale done immediately before closing its old tab
ok - fm-spawn relaunch: a stale done registration changing to working receives no replacement input
ok - fm_backend_herdr_agent_state: working, idle, and blocked registrations remain live
ok - fm-control relaunch: a proved stale done registration is replaced without sending a lifecycle command to the shell
ok - fm_backend_herdr_create_task: creates the replacement tab BEFORE closing the husk tab, never the reverse
ok - fm_backend_herdr_create_task: creates a tab and parses tab_id/pane_id from the JSON response, prunes nothing when no seeded tab id is given
ok - fm_backend_herdr_create_task: tab create passes --no-focus
ok - herdr presentation: a home that set nothing gets the projection by default at or above the floor
ok - herdr presentation: an unconfigured home below the floor falls back flat with one naming warning
ok - herdr presentation: an unreadable client release falls back flat instead of guessing
ok - herdr presentation: a deliberate opt-in is never silently downgraded below the floor
ok - herdr presentation: an explicit off opts the home out
ok - herdr presentation: an unrecognized value warns and follows the default instead of failing a spawn
ok - herdr presentation: the below-floor warning is one per home per release, not one per spawn
ok - herdr presentation: warning marker publication is atomic, symlink-safe, and fails visible
ok - herdr presentation: client and selected server floors compose conservatively without overriding explicit opt-in
ok - herdr presentation floor: every measured release, and each signal alone, classifies correctly
ok - herdr presentation floor: either signal alone can carry an above verdict, and each divergence is real
ok - herdr presentation: config parsing separates a deliberate choice from an unconfigured default
ok - herdr presentation journal: atomically publishes one non-authoritative 128-bit correlator and refuses overwrite
ok - herdr presentation journal: version 2 binds exact home/endpoint/parent identities and advances atomically
ok - herdr presentation create: exact response IDs yield one normal task pane with no workspace-close authority
ok - herdr presentation create: concurrent same-label tabs are never prune targets
ok - herdr presentation focus: snapshot requires one exact active workspace and tab
ok - herdr presentation focus: exact pane close restores the exact prior workspace and tab
ok - herdr presentation focus: cleanup refuses rather than close the captain's active tab
ok - herdr presentation focus: pane close fails when exact focus restoration fails
ok - herdr presentation reclaim: live agent state at the close boundary refuses mutation
ok - herdr presentation cleanup: emptying close behind focus ends the exact shell without a move or focus change
ok - herdr presentation cleanup: emptying close before focus moves the doomed workspace to the end and ends its exact shell
ok - herdr presentation cleanup: emptying close with the focused workspace last skips the move
ok - herdr presentation cleanup: emptying close of

... [5026 bytes truncated] ...

ok - fm_backend_herdr_composer_state: bright placeholder-like text stays pending rather than being mistaken for an idle ghost
ok - fm_backend_herdr_composer_state: real composer text reads pending
ok - fm_backend_herdr_composer_state: a slash-command popup's argument-hint placeholder still reads pending (the incident fix)
ok - fm_backend_herdr_composer_state: reports unknown when the pane cannot be captured
ok - fm_backend_herdr_composer_state: reports unknown for bare shell prompts with no composer row
ok - fm_backend_herdr_composer_state: a blocked pi pane parked on a prompt is not an empty composer
ok - fm_backend_herdr_composer_state: a native idle Pi separator composer reads empty
ok - fm_backend_herdr_composer_state: real Pi composer text remains pending
ok - fm_backend_herdr_composer_state: an incomplete lower Pi separator cannot inherit a stale empty row
ok - fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯' prompt row (no border box in view) reads empty
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯ <text>' prompt row reads pending
ok - fm_backend_herdr_composer_state: a live unbordered prompt row below a stale bordered decorative box still wins (not misread as the box's own row)
ok - fm_backend_herdr_composer_state: claude's dim prompt-suggestion ghost (the overnight wedge shape) reads empty
ok - fm_backend_herdr_composer_state: real typed text on the same claude prompt row still reads pending
ok - fm_backend_herdr_composer_state: grok's dark-truecolor placeholder (the TRUECOLOR gap) reads empty
ok - fm_backend_herdr_composer_state: grok's real bright typed input still reads pending
ok - fm_backend_herdr_composer_state: a real-codex unbordered '›' prompt row reads empty
ok - fm_backend_herdr_composer_state: a faint real-codex ghost suggestion reads empty
ok - fm_backend_herdr_composer_state: non-faint codex prompt text still reads pending
ok - fm_backend_herdr_wait_for_working: reports 'busy' immediately on the first poll, without spending the rest of the budget
ok - fm_backend_herdr_wait_for_working: a slow transition landing on a later sample within one window is still caught (robust against the 'slow transition' failure direction)
ok - fm_backend_herdr_wait_for_working: spreads six samples across the full budget endpoint without a final trailing sleep
ok - fm_backend_herdr_send_text_submit: applies the herdr minimum confirmation budget before polling agent-state
ok - fm_backend_herdr_wait_for_working: reports 'idle' (readable, genuinely not yet working) when 'busy' never appears
ok - fm_backend_herdr_wait_for_working: reports 'unknown' (a hard read failure, not a timing race) only when EVERY poll in the window fails
ok - fm_backend_herdr_wait_for_working: treats blocked as submit-active for confirmation without changing watcher busy-state semantics
ok - fm_backend_herdr_send_text_submit: reports 'empty' once agent_status reports working after one Enter, without ever reading the composer
ok - fm_backend_herdr_send_text_submit: reports 'pending' when agent_status stays idle and the composer still holds unsent text after retried Enters (swallowed)
ok - fm_backend_herdr_send_text_submit: a slash-command popup's placeholder fill on Enter #1 never flips agent_status to working, so it does not short-circuit as submitted; Enter #2 is retried and lands it
ok - fm_backend_herdr_send_text_submit: a post-Enter blocked state confirms delivery without retrying into the prompt
ok - fm_backend_herdr_send_text_submit: native working + proven pending after retries reports empty (queued Enter)
ok - fm_backend_herdr_send_text_submit: a failed Enter cannot borrow preexisting working state as queued-delivery proof
ok - fm_backend_herdr_send_text_submit: a failed Enter cannot borrow a later native transition as delivery proof
ok - fm_backend_herdr_send_text_submit: idle native agent-state plus empty composer reports empty (landed Claude turn)
ok - fm_backend_herdr_send_text_submit: idle native baseline uses a rendered busy footer to confirm a queued Enter
ok - fm_backend_herdr_composer_state: cursor's mid-turn placeholder-plus-busy-token row reads pending (why delivery needs a separate signal)
ok - fm_backend_herdr_rendered_busy_state: busy/idle/unknown from the rendered footer, with an unreadable pane never reading idle
ok - fm_backend_herdr_send_text_submit: a rendered-footer idle-to-busy transition confirms delivery when native agent-state never reports idle
ok - fm_backend_herdr_send_text_submit: an already-busy footer baseline is never accepted as proof that this Enter landed
ok - fm_backend_herdr_send_text_submit: confirms submission via native agent-state alone, immune to a codex-style dynamic idle-tip composer that would have misread as 'pending' under the old composer-based confirmation
ok - fm_backend_herdr_composer_state: a faint real-codex dynamic idle-tip composer row reads empty
ok - fm_backend_composer_state (herdr): the pre-injection empty-box guard still refuses a genuinely non-empty composer, unaffected by the submit-confirmation change
ok - fm_backend_herdr_send_text_submit: a slow transition landing on a later sample within one Enter's budget is confirmed WITHOUT sending a needless extra Enter
ok - fm_backend_herdr_send_text_submit: reports 'send-failed' when the literal send-text call itself errors
ok - fm_backend_herdr_send_text_submit: reports 'unknown' when the post-Enter agent-get read fails (never retries past an unreadable target)
ok - fm_backend_herdr_send_text_submit: an unreadable composer stops Enter retries after native status stays idle
ok - fm_backend_validate: herdr is a known backend (P2)
ok - fm_backend_busy_state: tmux (no native primitive) always reports unknown, preserving the P1 regex-only path
error: unknown backend 'bogus' (known: tmux herdr zellij orca cmux)
ok - fm_backend_composer_state dispatches every backend to its named thin classifier, unknown for unrecognized backends
ok - fm-peek/fm-send: explicit stale targets matching metadata use the recorded backend
ok - fm_backend_herdr_normalize_event routes through the shared record with an empty from_status
ok - fm_backend_herdr_escalation_marker keys the dedupe marker exactly like the watcher's .stale-<key>
ok - fm_backend_herdr_apply_transition: blocked dedupe starts only after explicit commit
ok - fm_backend_herdr_apply_transition: a working edge clears the marker so the next ->blocked re-escalates
ok - fm_backend_herdr_clear_transition removes task-owned dedupe state
ok - fm_backend_herdr_apply_transition: idle/done (defer) and unknown/empty (fallback) take no fast action
ok - fm_backend_herdr_wait_transition: a home with no herdr panes falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: below-capability protocol/schema falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: reconnect level-reconcile returns an uncommitted blocked pane
ok - fm_backend_herdr_wait_transition: subscribes before reconnect level-reconcile
ok - fm_backend_herdr_wait_transition: a still-blocked, already-escalated pane is not re-delivered on reconnect
ok - fm_backend_herdr_wait_transition: a streamed ->blocked edge returns the record sub-poll
ok - fm_backend_herdr_wait_transition: streamed working clears the marker, idle/done are deferred (clean timeout)
ok - fm_backend_herdr_wait_transition: a reader/subscribe failure falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: Bash 3.2-safe bad-ack path closes fd 9 and removes its FIFO
ok - fm_backend_herdr_wait_transition: stock macOS Bash clean timeout closes fd 9 and returns 1
FM_TEST_END 2026-09-01T19:12:44Z tests/fm-backend-herdr.test.sh exit=0 duration_ms=329333 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=329414
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=329333 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-backend-herdr.test.sh duration_ms=329333
fm-test-run: wrote timing artifact: /Users/avohar/.no-mistakes/evidence/01M1F5EY31H1PZ47Y79RE5DPZV/fm-backend-herdr-timing.json
```
</details>
<details>
<summary>Evidence: Focused test timing/result artifact</summary>

Source: [Focused test timing/result artifact](https://github.com/rockinet/firstmate/blob/044ac70642be960fd014694ad5f408a4f8d920ab/.no-mistakes/evidence/fm/fm-herdr-recovery-publish-s7/fm-backend-herdr-timing.json)

```text
{
  "families": [
    {
      "count": 1,
      "duration_ms": 329333,
      "failed": 0,
      "name": "backend-dispatch"
    }
  ],
  "finished_at": "2026-09-01T19:12:44Z",
  "run_id": "fm-test-run-1788289634699-58690",
  "scripts": [
    {
      "duration_ms": 329333,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "backend-dispatch",
      "gate_skip": false,
      "path": "tests/fm-backend-herdr.test.sh"
    }
  ],
  "selection": "scripts",
  "started_at": "2026-09-01T19:07:14Z",
  "summary": {
    "duration_ms": 329414,
    "failed": 0,
    "skipped_gate": 0,
    "total": 1
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4ab6006c697c9b9d848103edec98bed4e4b6ae80","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/backends/herdr.sh:1182` - `jq -s` exits 0 even when this filter emits `false`, so error-only, contradictory, and multi-document JSON responses are accepted. `agent_not_found` is consequently misclassified as `unknown`, while a contradictory response containing `agent_status=done` can still become `stale-done` and authorize replacement. Use `jq -se` (or equivalent true-only exit behavior) at this shared boundary.

🔧 Fix: Confirmed strict Herdr response validation
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-backend-herdr.test.sh --json /Users/avohar/.no-mistakes/evidence/01M1F5EY31H1PZ47Y79RE5DPZV/fm-backend-herdr-timing.json`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
