### PR TITLE
feat(bin): add fm-grant, the captain-authorized grant vault

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,7 @@ When that section reports its checks still in progress it names exactly what is 
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.
 Use `gh-axi` for GitHub, `chrome-devtools-axi` for browser work, and `lavish-axi` for structured decisions or reports; consult current help rather than memorizing flags.
+For a command that needs a stored secret, run it through `bin/fm-grant.sh exec KEY... -- <cmd>`, which never prints the value and falls back loudly to one av approval dialog when no grant is active; grant a promptless window only on an explicit captain instruction quoted in `--reason`, heed its grant-shape warnings, and never `av bless` fm-grant.sh itself (`docs/fm-grant.md`).
 A silent bootstrap section needs no action; for any printed actionable diagnostic line, load `bootstrap-diagnostics` and follow its owner procedure.
 `BOOTSTRAP_INFO:` lines are completed no-action facts and do not require loading a skill.
 `secondmate-provisioning` owns startup secondmate sync, liveness, and inherited local-material convergence.

--- a/bin/fm-grant.sh
+++ b/bin/fm-grant.sh
@@ -1,0 +1,568 @@
+#!/usr/bin/env bash
+# fm-grant.sh - captain-authorized grant vault: a bounded convenience window of
+# promptless secret access for firstmate's own fleet, with receipts.
+#
+# HONESTY FIRST: this is NOT a security control. Once `grant` imports a secret
+# into the macOS Keychain (service firstmate-grant), ANY same-user process can
+# read it silently with `security find-generic-password -w` until `forget`
+# removes the item. Grant counts and expiry are cooperative bookkeeping and an
+# audit trail bounding firstmate's own polite usage - they are not an OS
+# boundary. `forget` is the only real revocation; expiry and `revoke` close the
+# bookkeeping window but leave the item readable.
+#
+# NEVER `av bless` this script. The single remaining human checkpoint is the
+# one av approval on first import; blessing fm-grant.sh would delete that
+# checkpoint and make every future import promptless and unbounded.
+#
+# The public surface never prints a secret: `exec` injects resolved values into
+# the child command's environment only, because a value printed to stdout lands
+# in agent transcripts, panes, and reports. There is deliberately no public
+# `get`. Without an active grant, `exec` execs `av inject +KEY... -- cmd`
+# directly - the value never transits this script on that path - after one loud
+# stderr line, so a headless lane does not wedge silently on the hidden av
+# dialog. Import runs `av inject +KEY -- fm-grant.sh _store KEY`: the value
+# travels env -> child -> `security` with no `sh -c`, no pipe, and no plaintext
+# on any file descriptor, and the av dialog legibly names `_store KEY`.
+#
+# State: per-secret shell-parseable files under <state>/grants/<KEY> plus one
+# append-only <state>/grants.log, where <state> is
+# ${FM_GRANT_STATE_DIR:-${FM_STATE_OVERRIDE:-$FM_HOME/state}} so secondmate
+# homes never share grants. Dir 0700, files 0600, umask 077, atomic tmp+mv
+# writes, and an mkdir spinlock around every read-decrement-write because
+# parallel lanes race the counter. Grant bounds combine and whichever limit
+# comes first wins; a "use" is one key retrieval; expiry is applied lazily on
+# every exec and status. Trailing newlines are stripped on import and
+# retrieval (fine for tokens). macOS-only: needs `security` and `av`.
+#
+# Usage:
+#   fm-grant.sh grant KEY (--uses N | --until <N><s|m|h|d> | --permanent)... \
+#     --reason "<captain's literal words>"
+#   fm-grant.sh exec KEY [KEY...] -- <cmd> [args...]
+#   fm-grant.sh status
+#   fm-grant.sh revoke KEY|--all     close the grant, KEEP the Keychain item
+#   fm-grant.sh forget KEY|--all     wipe the Keychain item and the record
+#
+# `grant` requires --reason (the captain's words, logged and shown in status)
+# and at least one explicit bound. It warns - never blocks - on risky grant
+# shapes: --permanent, uses over 100, until over 30 days, and names on the
+# small consequence list (PAYMENT|TEBEX|STRIPE|PROD|DEPLOY|SIGNING). The
+# hidden `_store` subcommand exists only as the av inject target above;
+# agents never call it directly.
+{ set +x; } 2>/dev/null # a secret must never reach an inherited xtrace
+set -u
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SELF="$SCRIPT_DIR/fm-grant.sh"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+GRANT_STATE="${FM_GRANT_STATE_DIR:-$STATE}"
+GRANTS_DIR="$GRANT_STATE/grants"
+GRANT_LOG="$GRANT_STATE/grants.log"
+SERVICE=firstmate-grant
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$SELF"
+}
+
+fail() {
+  printf 'fm-grant: %s\n' "$*" >&2
+  exit 1
+}
+
+# Spelled-out classes: a [A-Z] case range is locale-collation-dependent and can
+# match lowercase, so the injection-critical name check never uses ranges.
+readonly KEY_ALPHA=ABCDEFGHIJKLMNOPQRSTUVWXYZ
+validate_key() {
+  case "$1" in
+    ["$KEY_ALPHA"]*) : ;;
+    *) fail "invalid secret name '$1' (must match ^[A-Z][A-Z0-9_]*\$)" ;;
+  esac
+  case "$1" in
+    *[!"$KEY_ALPHA"0123456789_]*) fail "invalid secret name '$1' (must match ^[A-Z][A-Z0-9_]*\$)" ;;
+  esac
+}
+
+is_uint() {
+  case "$1" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  return 0
+}
+
+ensure_grant_dirs() {
+  mkdir -p "$GRANTS_DIR" || fail "cannot create $GRANTS_DIR"
+  chmod 700 "$GRANTS_DIR" 2>/dev/null || :
+}
+
+log_event() {
+  mkdir -p "$GRANT_STATE" || fail "cannot create $GRANT_STATE"
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$GRANT_LOG" \
+    || fail "cannot append to $GRANT_LOG"
+}
+
+# mkdir spinlock around every read-decrement-write: macOS has no flock and
+# firstmate's parallel lanes race the counter otherwise. Bounded retries with a
+# stale-by-mtime steal so a killed holder cannot wedge the key forever.
+lock_key() {
+  local dir="$GRANTS_DIR/.$1.lock" tries=0 mtime now
+  ensure_grant_dirs
+  while ! mkdir "$dir" 2>/dev/null; do
+    tries=$((tries + 1))
+    [ "$tries" -lt 200 ] || fail "timed out waiting for the $1 grant lock ($dir)"
+    mtime=$(stat -c %Y "$dir" 2>/dev/null || stat -f %m "$dir" 2>/dev/null) || mtime=
+    case "$mtime" in '' | *[!0-9]*) mtime= ;; esac
+    now=$(date +%s)
+    if [ -n "$mtime" ] && [ $((now - mtime)) -gt 30 ]; then
+      rmdir "$dir" 2>/dev/null || :
+      continue
+    fi
+    sleep 0.05
+  done
+}
+
+unlock_key() {
+  rmdir "$GRANTS_DIR/.$1.lock" 2>/dev/null || :
+}
+
+grant_field() { # <KEY> <field> - first value, empty when absent
+  sed -n "s/^$2=//p" "$GRANTS_DIR/$1" 2>/dev/null | sed -n 1p
+}
+
+# Atomic install of the full six-field grant record (house tmp+mv idiom).
+write_grant_file() { # <KEY> <uses> <deadline> <permanent> <created> <reason>
+  local key=$1 uses=$2 deadline=$3 permanent=$4 created=$5 reason=$6 tmp
+  ensure_grant_dirs
+  tmp=$(mktemp "$GRANTS_DIR/.$key.tmp.XXXXXX") || fail "cannot stage grant state for $key"
+  {
+    printf 'uses_left=%s\n' "$uses"
+    printf 'deadline_epoch=%s\n' "$deadline"
+    printf 'permanent=%s\n' "$permanent"
+    printf 'created_at=%s\n' "$created"
+    printf 'reason=%s\n' "$reason"
+    printf 'imported_from=av\n'
+  } > "$tmp" || { rm -f "$tmp"; fail "cannot write grant state for $key"; }
+  chmod 0600 "$tmp" 2>/dev/null || :
+  mv -f "$tmp" "$GRANTS_DIR/$key" || { rm -f "$tmp"; fail "cannot install grant state for $key"; }
+}
+
+grant_active() { # <KEY> - 0 while the bookkeeping window is open
+  local uses deadline permanent now
+  [ -f "$GRANTS_DIR/$1" ] || return 1
+  uses=$(grant_field "$1" uses_left)
+  deadline=$(grant_field "$1" deadline_epoch)
+  permanent=$(grant_field "$1" permanent)
+  if [ -n "$uses" ]; then
+    is_uint "$uses" || return 1
+    [ "$uses" -gt 0 ] || return 1
+  fi
+  if [ -n "$deadline" ]; then
+    is_uint "$deadline" || return 1
+    now=$(date +%s)
+    [ "$now" -le "$deadline" ] || return 1
+  fi
+  if [ "$permanent" = 1 ]; then
+    return 0
+  fi
+  [ -n "$uses" ] || [ -n "$deadline" ] || return 1
+  return 0
+}
+
+# Lazy expiry (caller holds the key lock): normalize a tripped grant to the
+# terminal closed form exactly once, logging which limit came first. The
+# Keychain item deliberately stays - only `forget` removes it.
+expire_norm() { # <KEY>
+  local uses deadline created reason limit
+  [ -f "$GRANTS_DIR/$1" ] || return 0
+  if grant_active "$1"; then
+    return 0
+  fi
+  uses=$(grant_field "$1" uses_left)
+  deadline=$(grant_field "$1" deadline_epoch)
+  if [ "$uses" = 0 ] && [ -z "$deadline" ]; then
+    return 0 # already in the terminal closed form
+  fi
+  limit=deadline
+  if [ -n "$uses" ] && is_uint "$uses" && [ "$uses" -le 0 ]; then
+    limit=uses
+  fi
+  created=$(grant_field "$1" created_at)
+  reason=$(grant_field "$1" reason)
+  write_grant_file "$1" 0 '' 0 "$created" "$reason"
+  log_event "expire $1 limit=$limit"
+}
+
+# One retrieval consumes one use (caller holds the key lock; grant is active).
+# Time-only and permanent grants are not decremented but still leave a receipt.
+consume_use() { # <KEY>
+  local uses deadline permanent created reason
+  uses=$(grant_field "$1" uses_left)
+  if [ -z "$uses" ]; then
+    log_event "use $1 uses_left=-"
+    return 0
+  fi
+  uses=$((uses - 1))
+  created=$(grant_field "$1" created_at)
+  reason=$(grant_field "$1" reason)
+  if [ "$uses" -le 0 ]; then
+    write_grant_file "$1" 0 '' 0 "$created" "$reason"
+    log_event "use $1 uses_left=0"
+    log_event "expire $1 limit=uses"
+    return 0
+  fi
+  deadline=$(grant_field "$1" deadline_epoch)
+  permanent=$(grant_field "$1" permanent)
+  write_grant_file "$1" "$uses" "$deadline" "$permanent" "$created" "$reason"
+  log_event "use $1 uses_left=$uses"
+}
+
+keychain_has() {
+  security find-generic-password -s "$SERVICE" -a "$1" >/dev/null 2>&1
+}
+
+keychain_read() {
+  security find-generic-password -w -s "$SERVICE" -a "$1" 2>/dev/null
+}
+
+parse_duration() { # <N><s|m|h|d> -> seconds on stdout
+  local n unit
+  case "$1" in
+    '' | [!0-9]* | *[!0-9smhd]*) return 1 ;;
+  esac
+  unit=${1##*[0-9]}
+  n=${1%"$unit"}
+  is_uint "$n" || return 1
+  [ "$n" -ge 1 ] || return 1
+  case "$unit" in
+    s) printf '%s\n' "$n" ;;
+    m) printf '%s\n' $((n * 60)) ;;
+    h) printf '%s\n' $((n * 3600)) ;;
+    d) printf '%s\n' $((n * 86400)) ;;
+    *) return 1 ;;
+  esac
+}
+
+fmt_epoch() { # best-effort human timestamp for status output
+  date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -r "$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || printf 'epoch %s\n' "$1"
+}
+
+describe_bounds() { # <uses> <deadline> <permanent>
+  local out=''
+  if [ "$3" = 1 ]; then
+    out='permanent'
+  fi
+  if [ -n "$1" ]; then
+    out="${out:+$out, }uses left: $1"
+  fi
+  if [ -n "$2" ]; then
+    out="${out:+$out, }until $(fmt_epoch "$2")"
+  fi
+  printf '%s\n' "${out:-closed}"
+}
+
+warn_shape() { # <KEY> <why> - the risk axis is the grant SHAPE, never a name heuristic
+  printf 'fm-grant: grant-shape warning: %s - %s.\n' "$1" "$2" >&2
+}
+
+# One av approval permanently moves KEY under promptless custody; say so
+# loudly BEFORE the hidden dialog fires so nobody approves it half-informed.
+import_key() { # <KEY>
+  printf 'fm-grant: importing %s: after this ONE av approval, %s moves permanently under weaker promptless custody - ANY same-user process can read it silently until "fm-grant.sh forget %s".\n' "$1" "$1" "$1" >&2
+  printf 'fm-grant: an av approval dialog may now be waiting; it reads "fm-grant.sh _store %s".\n' "$1" >&2
+  av inject "+$1" -- "$SELF" _store "$1" \
+    || fail "import of $1 was not approved or av failed - no grant recorded"
+  keychain_has "$1" || fail "import of $1 did not land in the Keychain - no grant recorded"
+  log_event "import $1 via=av"
+}
+
+cmd_grant() {
+  local key uses='' dur='' permanent=0 reason='' deadline='' seconds=0 created
+  [ $# -ge 1 ] || fail 'usage: fm-grant.sh grant KEY [--uses N] [--until <N><s|m|h|d>] [--permanent] --reason "..."'
+  key=$1
+  shift
+  validate_key "$key"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --uses)
+        [ $# -ge 2 ] || fail '--uses needs a count'
+        uses=$2
+        shift 2
+        ;;
+      --until)
+        [ $# -ge 2 ] || fail '--until needs a duration like 12h or 7d'
+        dur=$2
+        shift 2
+        ;;
+      --permanent)
+        permanent=1
+        shift
+        ;;
+      --reason)
+        [ $# -ge 2 ] || fail "--reason needs the captain's words"
+        reason=$2
+        shift 2
+        ;;
+      *) fail "unknown grant option: $1" ;;
+    esac
+  done
+  [ -n "$reason" ] || fail "--reason is required: quote the captain's explicit instruction"
+  case "$reason" in
+    *$'\n'* | *$'\r'*) fail '--reason must be one line' ;;
+  esac
+  if [ -n "$uses" ]; then
+    if ! is_uint "$uses" || [ "$uses" -lt 1 ]; then
+      fail '--uses must be a positive integer'
+    fi
+  fi
+  if [ -n "$dur" ]; then
+    seconds=$(parse_duration "$dur") || fail '--until must be <N><s|m|h|d>, e.g. 12h or 7d'
+    deadline=$(($(date +%s) + seconds))
+  fi
+  if [ -z "$uses" ] && [ -z "$dur" ] && [ "$permanent" != 1 ]; then
+    fail 'state an explicit bound: --uses N, --until <dur>, or --permanent'
+  fi
+  if [ "$permanent" = 1 ]; then
+    warn_shape "$key" '--permanent never expires; only revoke or forget ends it'
+  fi
+  if [ -n "$uses" ] && [ "$uses" -gt 100 ]; then
+    warn_shape "$key" "--uses $uses is an unusually wide window"
+  fi
+  if [ -n "$dur" ] && [ "$seconds" -gt $((30 * 86400)) ]; then
+    warn_shape "$key" "--until $dur is longer than 30 days"
+  fi
+  case "$key" in
+    *PAYMENT* | *TEBEX* | *STRIPE* | *PROD* | *DEPLOY* | *SIGNING*)
+      warn_shape "$key" 'this name suggests money, production, or release authority'
+      ;;
+  esac
+  if ! keychain_has "$key"; then
+    import_key "$key"
+  fi
+  created=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  lock_key "$key"
+  write_grant_file "$key" "$uses" "$deadline" "$permanent" "$created" "$reason"
+  unlock_key "$key"
+  log_event "grant $key uses=${uses:--} until=${dur:--} permanent=$permanent reason=$reason"
+  printf 'fm-grant: granted %s (%s).\n' "$key" "$(describe_bounds "$uses" "$deadline" "$permanent")"
+  printf 'fm-grant: bookkeeping only - %s stays silently readable by ANY same-user process until "fm-grant.sh forget %s".\n' "$key" "$key"
+}
+
+# Hidden import plumbing target for `av inject +KEY -- fm-grant.sh _store KEY`:
+# the value arrives in this process's own environment and goes straight to
+# `security`, so it never touches stdout, a pipe, or a shell command line here.
+cmd_store() {
+  [ $# -eq 1 ] || fail '_store expects exactly one KEY'
+  validate_key "$1"
+  local name=$1 value
+  value=${!name-}
+  [ -n "$value" ] || fail "_store expected $name in the environment (it arrives via av inject)"
+  value=${value%$'\n'} # tokens never need a trailing newline; documented
+  security add-generic-password -U -s "$SERVICE" -a "$name" -w "$value" >/dev/null 2>&1 \
+    || fail "Keychain write for $name failed"
+}
+
+grant_usable() { # <KEY> - active window AND a readable Keychain item
+  [ -f "$GRANTS_DIR/$1" ] || return 1
+  keychain_has "$1" || return 1
+  local usable=1
+  lock_key "$1"
+  expire_norm "$1"
+  if grant_active "$1"; then
+    usable=0
+  fi
+  unlock_key "$1"
+  return "$usable"
+}
+
+# No-grant path: one loud line so a headless lane does not wedge silently, then
+# exec av directly - the value never transits fm-grant here, and nothing is
+# consumed from any grant.
+exec_av_fallback() { # <ungranted-list> <KEY>... -- <cmd>...
+  local ungranted=$1 avargs=()
+  shift
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --)
+        shift
+        break
+        ;;
+      *)
+        avargs+=("+$1")
+        shift
+        ;;
+    esac
+  done
+  printf 'fm-grant: no active grant for%s - handing to av; a macOS av approval dialog may now be waiting for a click.\n' "$ungranted" >&2
+  log_event "fallback ungranted=${ungranted# }"
+  exec av inject ${avargs[@]+"${avargs[@]}"} -- "$@"
+}
+
+cmd_exec() {
+  local keys=() k ungranted='' v pairs=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --)
+        shift
+        break
+        ;;
+      *)
+        keys+=("$1")
+        shift
+        ;;
+    esac
+  done
+  [ "${#keys[@]}" -ge 1 ] || fail 'usage: fm-grant.sh exec KEY [KEY...] -- <cmd> [args...]'
+  [ $# -ge 1 ] || fail 'missing command after --'
+  for k in "${keys[@]}"; do
+    validate_key "$k"
+  done
+  for k in "${keys[@]}"; do
+    if ! grant_usable "$k"; then
+      ungranted="$ungranted $k"
+    fi
+  done
+  if [ -n "$ungranted" ]; then
+    exec_av_fallback "$ungranted" "${keys[@]}" -- "$@"
+  fi
+  for k in "${keys[@]}"; do
+    lock_key "$k"
+    expire_norm "$k"
+    if ! grant_active "$k"; then
+      # Raced to exhaustion since the check above. Earlier keys already left a
+      # use receipt each - acceptable for cooperative bookkeeping, and visible
+      # in the log next to this fallback line.
+      unlock_key "$k"
+      exec_av_fallback " $k" "${keys[@]}" -- "$@"
+    fi
+    consume_use "$k"
+    unlock_key "$k"
+  done
+  for k in "${keys[@]}"; do
+    if ! v=$(keychain_read "$k") || [ -z "$v" ]; then
+      exec_av_fallback " $k" "${keys[@]}" -- "$@"
+    fi
+    pairs+=("$k=$v")
+  done
+  # env(1) carries the values straight into the child's environment; they are
+  # never printed, logged, or exported into an intermediate shell.
+  exec env ${pairs[@]+"${pairs[@]}"} "$@"
+}
+
+cmd_status() {
+  [ $# -eq 0 ] || fail 'status takes no arguments'
+  printf 'fm-grant status - a convenience window with receipts, NOT a security control.\n'
+  printf 'Every imported key below is silently readable by ANY same-user process until "fm-grant.sh forget KEY"; grant limits bound firstmate'\''s own bookkeeping, not the OS.\n'
+  local f key uses deadline permanent created reason shown=0
+  if [ -d "$GRANTS_DIR" ]; then
+    for f in "$GRANTS_DIR"/*; do
+      [ -f "$f" ] || continue
+      key=$(basename "$f")
+      lock_key "$key"
+      expire_norm "$key"
+      uses=$(grant_field "$key" uses_left)
+      deadline=$(grant_field "$key" deadline_epoch)
+      permanent=$(grant_field "$key" permanent)
+      created=$(grant_field "$key" created_at)
+      reason=$(grant_field "$key" reason)
+      if grant_active "$key"; then
+        printf '%s: ACTIVE (%s)\n' "$key" "$(describe_bounds "$uses" "$deadline" "$permanent")"
+      else
+        printf '%s: imported, NO active grant - still promptless-readable; forget removes it\n' "$key"
+      fi
+      unlock_key "$key"
+      printf '  reason: %s (granted %s)\n' "${reason:-?}" "${created:-?}"
+      shown=1
+    done
+  fi
+  if [ "$shown" = 0 ]; then
+    printf 'No keys imported.\n'
+  fi
+  if [ -f "$GRANT_LOG" ]; then
+    printf 'Audit log: %s\n' "$GRANT_LOG"
+  fi
+  return 0
+}
+
+TARGETS=()
+resolve_targets() { # <subcommand> <KEY|--all>
+  local sub=$1 f
+  shift
+  TARGETS=()
+  if [ "${1-}" = --all ]; then
+    [ $# -eq 1 ] || fail "$sub --all takes no other arguments"
+    if [ -d "$GRANTS_DIR" ]; then
+      for f in "$GRANTS_DIR"/*; do
+        [ -f "$f" ] || continue
+        TARGETS+=("$(basename "$f")")
+      done
+    fi
+    [ "${#TARGETS[@]}" -ge 1 ] || fail "nothing imported - no keys to $sub"
+    return 0
+  fi
+  [ $# -eq 1 ] || fail "usage: fm-grant.sh $sub KEY|--all"
+  validate_key "$1"
+  TARGETS=("$1")
+}
+
+cmd_revoke() {
+  resolve_targets revoke "$@"
+  local k created reason
+  for k in "${TARGETS[@]}"; do
+    if [ ! -f "$GRANTS_DIR/$k" ]; then
+      printf 'fm-grant: no grant record for %s.\n' "$k"
+      continue
+    fi
+    lock_key "$k"
+    created=$(grant_field "$k" created_at)
+    reason=$(grant_field "$k" reason)
+    write_grant_file "$k" 0 '' 0 "$created" "$reason"
+    unlock_key "$k"
+    log_event "revoke $k"
+    printf 'fm-grant: revoked %s - the window is closed, but the Keychain item REMAINS silently readable; "fm-grant.sh forget %s" removes it.\n' "$k" "$k"
+  done
+}
+
+cmd_forget() {
+  resolve_targets forget "$@"
+  local k note
+  for k in "${TARGETS[@]}"; do
+    if security delete-generic-password -s "$SERVICE" -a "$k" >/dev/null 2>&1; then
+      note=removed
+    else
+      note=absent
+    fi
+    lock_key "$k"
+    rm -f "$GRANTS_DIR/$k"
+    unlock_key "$k"
+    log_event "forget $k keychain=$note"
+    printf 'fm-grant: forgot %s (Keychain item %s) - promptless access ended.\n' "$k" "$note"
+  done
+}
+
+SUB=${1-}
+if [ $# -gt 0 ]; then
+  shift
+fi
+case "$SUB" in
+  grant) cmd_grant "$@" ;;
+  exec) cmd_exec "$@" ;;
+  status) cmd_status "$@" ;;
+  revoke) cmd_revoke "$@" ;;
+  forget) cmd_forget "$@" ;;
+  _store) cmd_store "$@" ;;
+  -h | --help | help)
+    usage
+    ;;
+  '')
+    usage >&2
+    exit 2
+    ;;
+  *) fail "unknown subcommand '$SUB' (there is deliberately no public get - values are never printed)" ;;
+esac

--- a/bin/fm-grant.sh
+++ b/bin/fm-grant.sh
@@ -441,13 +441,16 @@ cmd_exec() {
       unlock_key "$k"
       exec_av_fallback " $k" "${keys[@]}" -- "$@"
     fi
-    consume_use "$k"
-    unlock_key "$k"
-  done
-  for k in "${keys[@]}"; do
+    # Read the secret BEFORE consuming a use: if the value is gone (a "forget"
+    # raced this window) a failed or empty read must not burn a use. Same-key
+    # lock still held, so no other exec can consume between the read and the
+    # consume here.
     if ! v=$(keychain_read "$k") || [ -z "$v" ]; then
+      unlock_key "$k"
       exec_av_fallback " $k" "${keys[@]}" -- "$@"
     fi
+    consume_use "$k"
+    unlock_key "$k"
     pairs+=("$k=$v")
   done
   # env(1) carries the values straight into the child's environment; they are

--- a/bin/fm-grant.sh
+++ b/bin/fm-grant.sh
@@ -17,10 +17,13 @@
 # The public surface never prints a secret: `exec` injects resolved values into
 # the child command's environment only, because a value printed to stdout lands
 # in agent transcripts, panes, and reports. There is deliberately no public
-# `get`. Without an active grant, `exec` execs `av inject +KEY... -- cmd`
-# directly - the value never transits this script on that path - after one loud
-# stderr line, so a headless lane does not wedge silently on the hidden av
-# dialog. Import runs `av inject +KEY -- fm-grant.sh _store KEY`: the value
+# `get`. `exec` is all-or-nothing: it locks every requested key, buffers every
+# value, and consumes uses only after each key proves active AND readable; if
+# ANY key is not usable it execs `av inject +KEY... -- cmd` for the FULL key
+# set - the value never transits this script on that path and NO use is
+# consumed for any key - after one loud stderr line, so a headless lane does
+# not wedge silently on the hidden av dialog.
+# Import runs `av inject +KEY -- fm-grant.sh _store KEY`: the value
 # travels env -> child -> `security` with no `sh -c`, no pipe, and no plaintext
 # on any file descriptor, and the av dialog legibly names `_store KEY`.
 #
@@ -42,6 +45,9 @@
 #   fm-grant.sh revoke KEY|--all     close the grant, KEEP the Keychain item
 #   fm-grant.sh forget KEY|--all     wipe the Keychain item and the record
 #
+# A `forget` whose Keychain delete really fails (anything but the benign
+# item-not-found exit 44) keeps the grant record, reports the item still
+# readable, and exits nonzero, so a failed revocation never looks completed.
 # `grant` requires --reason (the captain's words, logged and shown in status)
 # and at least one explicit bound. It warns - never blocks - on risky grant
 # shapes: --permanent, uses over 100, until over 30 days, and names on the
@@ -368,19 +374,6 @@ cmd_store() {
     || fail "Keychain write for $name failed"
 }
 
-grant_usable() { # <KEY> - active window AND a readable Keychain item
-  [ -f "$GRANTS_DIR/$1" ] || return 1
-  keychain_has "$1" || return 1
-  local usable=1
-  lock_key "$1"
-  expire_norm "$1"
-  if grant_active "$1"; then
-    usable=0
-  fi
-  unlock_key "$1"
-  return "$usable"
-}
-
 # No-grant path: one loud line so a headless lane does not wedge silently, then
 # exec av directly - the value never transits fm-grant here, and nothing is
 # consumed from any grant.
@@ -405,7 +398,7 @@ exec_av_fallback() { # <ungranted-list> <KEY>... -- <cmd>...
 }
 
 cmd_exec() {
-  local keys=() k ungranted='' v pairs=()
+  local keys=() uniq_keys=() vals=() pairs=() k v i unusable=''
   while [ $# -gt 0 ]; do
     case "$1" in
       --)
@@ -423,35 +416,48 @@ cmd_exec() {
   for k in "${keys[@]}"; do
     validate_key "$k"
   done
-  for k in "${keys[@]}"; do
-    if ! grant_usable "$k"; then
-      ungranted="$ungranted $k"
-    fi
-  done
-  if [ -n "$ungranted" ]; then
-    exec_av_fallback "$ungranted" "${keys[@]}" -- "$@"
-  fi
-  for k in "${keys[@]}"; do
+  # Names are ^[A-Z][A-Z0-9_]*$, so newline-splitting them is safe. The sorted
+  # dedup gives one lock/read/consume per key and one global lock order, so two
+  # overlapping execs cannot spin each other out on ABBA lock waits and the
+  # all-keys lock below never takes the same key's lock twice.
+  while IFS= read -r k; do
+    uniq_keys+=("$k")
+  done < <(printf '%s\n' "${keys[@]}" | LC_ALL=C sort -u)
+  # All-or-nothing: hold every key's lock across the whole read-and-decide so
+  # no other exec can consume in between, buffer each value, and consume uses
+  # only once every key has proven BOTH active and readable. Any unusable key
+  # - an inactive grant, or a vanished/empty value from a "forget" racing this
+  # window - sends the WHOLE exec through the av fallback for the full key
+  # set, consuming no use for any key.
+  for k in "${uniq_keys[@]}"; do
     lock_key "$k"
+  done
+  i=0
+  for k in "${uniq_keys[@]}"; do
     expire_norm "$k"
     if ! grant_active "$k"; then
-      # Raced to exhaustion since the check above. Earlier keys already left a
-      # use receipt each - acceptable for cooperative bookkeeping, and visible
-      # in the log next to this fallback line.
-      unlock_key "$k"
-      exec_av_fallback " $k" "${keys[@]}" -- "$@"
+      unusable="$unusable $k"
+    elif ! v=$(keychain_read "$k") || [ -z "$v" ]; then
+      unusable="$unusable $k"
+    else
+      vals[i]=$v
     fi
-    # Read the secret BEFORE consuming a use: if the value is gone (a "forget"
-    # raced this window) a failed or empty read must not burn a use. Same-key
-    # lock still held, so no other exec can consume between the read and the
-    # consume here.
-    if ! v=$(keychain_read "$k") || [ -z "$v" ]; then
+    i=$((i + 1))
+  done
+  if [ -n "$unusable" ]; then
+    for k in "${uniq_keys[@]}"; do
       unlock_key "$k"
-      exec_av_fallback " $k" "${keys[@]}" -- "$@"
-    fi
+    done
+    exec_av_fallback "$unusable" "${keys[@]}" -- "$@"
+  fi
+  i=0
+  for k in "${uniq_keys[@]}"; do
     consume_use "$k"
+    pairs+=("$k=${vals[i]}")
+    i=$((i + 1))
+  done
+  for k in "${uniq_keys[@]}"; do
     unlock_key "$k"
-    pairs+=("$k=$v")
   done
   # env(1) carries the values straight into the child's environment; they are
   # never printed, logged, or exported into an intermediate shell.
@@ -534,19 +540,30 @@ cmd_revoke() {
 
 cmd_forget() {
   resolve_targets forget "$@"
-  local k note
+  local k note rc failed=0
   for k in "${TARGETS[@]}"; do
-    if security delete-generic-password -s "$SERVICE" -a "$k" >/dev/null 2>&1; then
-      note=removed
-    else
-      note=absent
-    fi
+    security delete-generic-password -s "$SERVICE" -a "$k" >/dev/null 2>&1
+    rc=$?
+    case "$rc" in
+      0) note=removed ;;
+      44) note=absent ;; # errSecItemNotFound: nothing left in the Keychain
+      *)
+        # A real delete failure (locked keychain, permissions): the item is
+        # still readable, so the grant record must survive to keep saying so,
+        # and this forget must not look like a completed revocation.
+        failed=1
+        log_event "forget $k keychain=error status=$rc"
+        printf 'fm-grant: ERROR: Keychain delete for %s failed (security exit %s) - the secret REMAINS silently readable and the grant record is kept; fix the Keychain and re-run "fm-grant.sh forget %s".\n' "$k" "$rc" "$k" >&2
+        continue
+        ;;
+    esac
     lock_key "$k"
     rm -f "$GRANTS_DIR/$k"
     unlock_key "$k"
     log_event "forget $k keychain=$note"
     printf 'fm-grant: forgot %s (Keychain item %s) - promptless access ended.\n' "$k" "$note"
   done
+  [ "$failed" = 0 ] || exit 1
 }
 
 SUB=${1-}

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -249,6 +249,10 @@
       "audience": "operator-example"
     },
     {
+      "path": "docs/fm-grant.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/fm-test-isolation-proof.md",
       "audience": "maintainer-verification"
     },

--- a/docs/fm-grant.md
+++ b/docs/fm-grant.md
@@ -1,0 +1,37 @@
+# fm-grant - the captain-authorized grant vault
+
+`bin/fm-grant.sh` gives firstmate a bounded, captain-authorized window of promptless access to a secret, so the fleet stops hitting av's approval dialog on every use.
+Exact flags, subcommands, state fields, and concurrency mechanics are owned by the script's own header comment and `bin/fm-grant.sh --help`; this page owns what the tool is, what it is not, and how to operate it safely.
+
+## What this is, honestly
+
+fm-grant is a convenience window with receipts, NOT a security control.
+Once `grant` imports a secret into the macOS Keychain (service `firstmate-grant`), ANY same-user process can read it silently with `security find-generic-password -w -s firstmate-grant -a KEY` - no grant, no expiry, and no fm-grant involved - until `forget` removes the item.
+The grant count and expiry are cooperative bookkeeping plus an audit trail for firstmate's own well-behaved callers: they bound firstmate's polite usage, not the machine.
+`forget` is the only real revocation; `revoke` and expiry close the bookkeeping window but leave the item readable.
+Importing a key is therefore a permanent runtime-gate downgrade for that key: its at-rest storage is Keychain-grade either way, but the per-use human approval is gone for every same-user process, not just for firstmate.
+This trade is acceptable because the threat being solved is prompt fatigue from firstmate's own fleet, not malware: a hostile same-user process could equally wrap `av` or read agent memory, so that game is already lost before fm-grant enters it.
+
+## Operating it
+
+Grant only on the captain's explicit instruction, quoting their words in the required `--reason`, which is logged and shown in `status`.
+Any secret is eligible; the captain's instruction is the scope.
+The first grant for a key runs one av approval shaped as `av inject +KEY -- fm-grant.sh _store KEY`, and fm-grant announces loudly before the dialog fires that approving it permanently moves the key under the weaker promptless custody described above.
+Run secret-needing commands as `bin/fm-grant.sh exec KEY [KEY...] -- <cmd> [args...]`, which resolves each key and injects the values into the child command's environment only.
+No fm-grant output ever contains a value, and there is deliberately no public `get`, because a value printed to stdout lands in agent transcripts, panes, and reports.
+Without an active grant for every requested key, `exec` prints one loud stderr line and then execs `av inject +KEY... -- <cmd>` directly, so behavior degrades to the ordinary prompting path, no grant is consumed, and the value never transits fm-grant.
+Grant bounds (`--uses N`, `--until <N><s|m|h|d>`, `--permanent`) combine, and whichever limit comes first wins; a use is one key retrieval, and expiry is applied lazily on every exec and status.
+Risky grant shapes warn on stderr but never block: `--permanent`, uses over 100, deadlines past 30 days, and names on the small consequence list (PAYMENT, TEBEX, STRIPE, PROD, DEPLOY, SIGNING).
+
+## Never bless fm-grant.sh
+
+Never `av bless` fm-grant.sh itself.
+The one human checkpoint left in this design is the av approval on first import; blessing the script would delete that checkpoint and make every future import promptless and unbounded.
+
+## State, audit, and limits
+
+Grant records are per-secret shell-parseable files under `<state>/grants/<KEY>` plus one append-only `<state>/grants.log`, resolved per home so secondmate homes never share grants.
+`status` lists every imported key - including expired and revoked ones that remain silently readable - with its bounds, reason, and the audit log path, and restates the exposure above.
+Trailing newlines are stripped on import and retrieval, which is fine for tokens.
+The tool is macOS-only: it needs `security` and `av`.
+`tests/fm-grant.test.sh` pins this contract against fake `security` and `av` shims and never touches the real login Keychain or a real av dialog.

--- a/docs/fm-grant.md
+++ b/docs/fm-grant.md
@@ -22,6 +22,7 @@ No fm-grant output ever contains a value, and there is deliberately no public `g
 Without an active grant for every requested key, `exec` prints one loud stderr line and then execs `av inject +KEY... -- <cmd>` directly, so behavior degrades to the ordinary prompting path, no grant is consumed, and the value never transits fm-grant.
 Grant bounds (`--uses N`, `--until <N><s|m|h|d>`, `--permanent`) combine, and whichever limit comes first wins; a use is one key retrieval, and expiry is applied lazily on every exec and status.
 Risky grant shapes warn on stderr but never block: `--permanent`, uses over 100, deadlines past 30 days, and names on the small consequence list (PAYMENT, TEBEX, STRIPE, PROD, DEPLOY, SIGNING).
+When the Keychain refuses a real `forget` deletion (anything but an already-absent item), fm-grant keeps that grant record, reports that the secret remains readable, and exits nonzero, so a failed revocation is never mistaken for a completed one.
 
 ## Never bless fm-grant.sh
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -61,6 +61,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-config-push.sh`      | Push declared inherited local material to live local or remote secondmates and send the placement-specific config reread when changed |
 | `fm-project-mode.sh`     | Resolve a project's registered delivery posture from `data/projects.md` for fleet sync and home seeding |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
+| `fm-grant.sh`            | Captain-authorized bounded promptless secret access with receipts: Keychain-backed env-inject `exec`, one av import approval, honest status (docs/fm-grant.md) |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and keyed escalation lifecycle |

--- a/tests/fm-grant.test.sh
+++ b/tests/fm-grant.test.sh
@@ -17,7 +17,12 @@
 #   - the no-grant fallback execs `av inject +KEY... -- cmd` directly, prints
 #     one loud stderr line, consumes nothing, and the value never transits
 #     fm-grant.
+#   - a multi-key exec is all-or-nothing: any unusable key sends the whole
+#     exec through the av fallback with no use consumed for any key.
 #   - revoke ends the window but keeps the item; forget wipes both.
+#   - a forget whose Keychain delete really fails (non-44) keeps the record,
+#     reports the item still readable, and exits nonzero; already-absent (44)
+#     stays a clean removal.
 #   - concurrent execs decrement exactly once each (the mkdir-spinlock proof).
 #   - grant-shape warnings (--permanent, uses>100, until>30d, consequence-
 #     listed names) warn without blocking, and a plain API key stays quiet.
@@ -36,14 +41,17 @@ SECRET='s3cr3t-value-du2ok9-never-in-output'
 # --- shared fakebin shims ----------------------------------------------------
 #
 # Both shims are pure functions of per-case env (FAKE_KEYCHAIN, FAKE_AV_SECRETS,
-# AV_LOG), so one shared fakebin dir serves every case.
+# AV_LOG, FAKE_SECURITY_DELETE_FAIL), so one shared fakebin dir serves every
+# case.
 
 FAKEBIN="$TMP_ROOT/fakebin"
 mkdir -p "$FAKEBIN"
 
 # Fake macOS `security` backed by $FAKE_KEYCHAIN/<account> files holding the
 # exact stored bytes. find -w prints the value plus the real tool's trailing
-# newline; a missing item exits 44 like errSecItemNotFound.
+# newline; a missing item exits 44 like errSecItemNotFound; setting
+# FAKE_SECURITY_DELETE_FAIL=<account>:<code> makes that account's delete fail
+# with <code>, emulating a real-world stuck delete (locked keychain, denied).
 cat > "$FAKEBIN/security" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -86,6 +94,9 @@ case "$cmd" in
     printf '%s' "$add_value" > "$item"
     ;;
   delete-generic-password)
+    case "${FAKE_SECURITY_DELETE_FAIL:-}" in
+      "$account":*) exit "${FAKE_SECURITY_DELETE_FAIL#*:}" ;;
+    esac
     [ -f "$item" ] || exit 44
     rm -f "$item"
     ;;
@@ -303,6 +314,50 @@ assert_grep 'inject +RACE_KEY -- /bin/sh' "$d/av.log" 'fallback execs av inject 
 assert_no_value_leak "$d" "$SECRET" 'read-race case'
 pass 'a failed or empty Keychain read falls back to av and consumes no use'
 
+# --- multi-key exec is all-or-nothing: a bad later key consumes nothing ------
+# Regression: exec used to consume each key's use as it walked the key list, so
+# a later key failing its read still left the earlier keys' uses spent even
+# though the whole exec then fell back through av. The buffered
+# read-everything-then-consume ordering under all the key locks means any
+# unusable key falls the WHOLE exec back with no use consumed for any key.
+
+d=$(new_case)
+printf '%s' "$SECRET" > "$d/avsecrets/AAA_KEY"
+printf '%s' 'zzz-value-plain' > "$d/avsecrets/ZZZ_BAD"
+fmg "$d" grant AAA_KEY --uses 3 --reason 'captain: pair one'
+expect_code 0 "$RC" 'setup first grant for the all-or-nothing case'
+fmg "$d" grant ZZZ_BAD --uses 2 --reason 'captain: pair two'
+expect_code 0 "$RC" 'setup second grant for the all-or-nothing case'
+
+# The later key's stored value becomes empty - an item that still exists (so
+# any upfront existence check passes) but whose read is unusable, discovered
+# only after the earlier key was already read.
+: > "$d/keychain/ZZZ_BAD"
+
+# shellcheck disable=SC2016 # the child shell, not this test, expands the env var
+fmg "$d" exec AAA_KEY ZZZ_BAD -- /bin/sh -c 'printf "%s:%s" "$AAA_KEY" "$ZZZ_BAD" > "$1"' _ "$d/child-out"
+expect_code 0 "$RC" 'exec with one unreadable key still completes through av'
+printf '%s:%s' "$SECRET" 'zzz-value-plain' > "$d/expected-bytes"
+cmp -s "$d/child-out" "$d/expected-bytes" || fail 'fallback child got every value from av'
+[ "$(grant_field "$d" AAA_KEY uses_left)" = 3 ] || fail 'the readable earlier key consumed no use'
+[ "$(grant_field "$d" ZZZ_BAD uses_left)" = 2 ] || fail 'the unreadable later key consumed no use'
+assert_no_grep 'use AAA_KEY' "$d/state/grants.log" 'no use receipt for the earlier key'
+assert_no_grep 'use ZZZ_BAD' "$d/state/grants.log" 'no use receipt for the later key'
+assert_grep 'no active grant for ZZZ_BAD' "$d/err" 'the unusable key is named loudly'
+assert_grep 'inject +AAA_KEY +ZZZ_BAD -- /bin/sh' "$d/av.log" 'fallback hands av the FULL key set'
+assert_grep 'fallback ungranted=ZZZ_BAD' "$d/state/grants.log" 'fallback logged'
+
+# Same all-or-nothing rule when the later key is merely inactive (revoked).
+printf '%s' 'zzz-value-plain' > "$d/keychain/ZZZ_BAD"
+fmg "$d" revoke ZZZ_BAD
+expect_code 0 "$RC" 'revoke the later key'
+fmg "$d" exec AAA_KEY ZZZ_BAD -- /usr/bin/true
+expect_code 0 "$RC" 'exec with one revoked key still completes through av'
+[ "$(grant_field "$d" AAA_KEY uses_left)" = 3 ] || fail 'a revoked later key consumes nothing for the earlier key'
+assert_no_grep 'use AAA_KEY' "$d/state/grants.log" 'still no use receipt after the revoked-key fallback'
+assert_no_value_leak "$d" "$SECRET" 'all-or-nothing case'
+pass 'a multi-key exec with any unusable key falls back whole and consumes no use'
+
 # --- combined uses+deadline: whichever limit comes first wins ----------------
 
 d=$(new_case)
@@ -390,6 +445,61 @@ assert_absent "$d/state/grants/ROT_KEY" 'forget removes the grant record'
 assert_grep 'forget ROT_KEY keychain=removed' "$d/state/grants.log" 'forget logged'
 assert_no_value_leak "$d" "$SECRET" 'revoke/forget case'
 pass 'revoke keeps the Keychain item while forget wipes it and the record'
+
+# --- forget: a real Keychain delete failure must not report revocation -------
+# Regression: every nonzero delete was lumped into "absent", so a locked
+# keychain or permission failure still removed the grant record and reported
+# access ended while the secret stayed silently readable. Only exit 44 (item
+# not found) is benign; any other failure keeps the record, says the item
+# REMAINS readable, and exits nonzero.
+
+d=$(new_case)
+printf '%s' "$SECRET" > "$d/avsecrets/AAA_STUCK"
+printf '%s' "$SECRET" > "$d/avsecrets/ZZZ_OK"
+fmg "$d" grant AAA_STUCK --uses 3 --reason 'captain: stuck'
+expect_code 0 "$RC" 'setup first grant for the forget-failure case'
+fmg "$d" grant ZZZ_OK --uses 3 --reason 'captain: fine'
+expect_code 0 "$RC" 'setup second grant for the forget-failure case'
+
+export FAKE_SECURITY_DELETE_FAIL='AAA_STUCK:36'
+fmg "$d" forget AAA_STUCK
+expect_code 1 "$RC" 'forget exits nonzero on a real Keychain delete failure'
+assert_present "$d/keychain/AAA_STUCK" 'the failed delete leaves the Keychain item'
+assert_present "$d/state/grants/AAA_STUCK" 'the failed delete keeps the grant record'
+assert_grep 'REMAINS silently readable' "$d/err" 'the failure says the secret is still readable'
+assert_no_grep 'promptless access ended' "$d/out" 'a failed forget never reports access ended'
+assert_no_grep 'promptless access ended' "$d/err" 'a failed forget never reports access ended on stderr'
+assert_grep 'forget AAA_STUCK keychain=error status=36' "$d/state/grants.log" 'the failure is logged with the real status'
+
+# --all reports the stuck key, still forgets the healthy one, and exits
+# nonzero - one real failure must not silently skip the rest.
+fmg "$d" forget --all
+expect_code 1 "$RC" 'forget --all exits nonzero when any key really fails'
+assert_present "$d/state/grants/AAA_STUCK" '--all keeps the stuck record'
+assert_grep 'REMAINS silently readable' "$d/err" '--all reports the stuck key'
+assert_absent "$d/state/grants/ZZZ_OK" '--all still removes the healthy record'
+assert_absent "$d/keychain/ZZZ_OK" '--all still wipes the healthy item'
+assert_grep 'forget ZZZ_OK keychain=removed' "$d/state/grants.log" 'the healthy removal is logged'
+
+# Once the Keychain cooperates again, the same forget completes cleanly.
+unset FAKE_SECURITY_DELETE_FAIL
+fmg "$d" forget AAA_STUCK
+expect_code 0 "$RC" 'forget succeeds once the delete works'
+assert_absent "$d/keychain/AAA_STUCK" 'the retried forget wipes the item'
+assert_absent "$d/state/grants/AAA_STUCK" 'the retried forget removes the record'
+
+# Exit 44 (item already absent) stays a benign, record-removing forget.
+printf '%s' "$SECRET" > "$d/avsecrets/GONE_KEY"
+fmg "$d" grant GONE_KEY --uses 2 --reason 'captain: gone'
+expect_code 0 "$RC" 'setup grant for the absent-item forget'
+rm -f "$d/keychain/GONE_KEY"
+fmg "$d" forget GONE_KEY
+expect_code 0 "$RC" 'forget of an already-absent item stays clean'
+assert_absent "$d/state/grants/GONE_KEY" 'the absent-item forget removes the record'
+assert_grep 'forget GONE_KEY keychain=absent' "$d/state/grants.log" 'the absent item is logged as absent'
+assert_grep 'promptless access ended' "$d/out" 'the absent-item forget reports access ended'
+assert_no_value_leak "$d" "$SECRET" 'forget-failure case'
+pass 'forget treats only exit 44 as benign and never reports a failed revocation as done'
 
 # --- concurrent execs decrement exactly once each (spinlock proof) -----------
 

--- a/tests/fm-grant.test.sh
+++ b/tests/fm-grant.test.sh
@@ -275,6 +275,34 @@ assert_grep 'fallback ungranted=API_TOKEN' "$d/state/grants.log" 'fallback logge
 assert_no_value_leak "$d" "$SECRET" 'exec case'
 pass 'exec injects into the child env, decrements one use per retrieval, and exhausts to av'
 
+# --- a failed/empty read must NOT consume a use ------------------------------
+# Regression: exec used to consume a use in one loop and read the secret in a
+# separate later loop, so a "forget" racing that window burned a use without
+# ever delivering the value. The read now precedes the consume under the same
+# per-key lock, so a vanished value falls back to av while the grant is intact.
+
+d=$(new_case)
+printf '%s' "$SECRET" > "$d/avsecrets/RACE_KEY"
+printf '%s' "$SECRET" > "$d/expected-bytes"
+fmg "$d" grant RACE_KEY --uses 2 --reason 'captain: race window'
+expect_code 0 "$RC" 'setup grant for read-race case'
+[ "$(grant_field "$d" RACE_KEY uses_left)" = 2 ] || fail 'read-race grant starts with two uses'
+
+# The value disappears from the Keychain after the active grant still exists -
+# exactly the forget-vs-read race the bug burned a use on.
+rm -f "$d/keychain/RACE_KEY"
+
+# shellcheck disable=SC2016 # the child shell, not this test, expands the env var
+fmg "$d" exec RACE_KEY -- /bin/sh -c 'printf %s "$RACE_KEY" > "$1"' _ "$d/child-out"
+expect_code 0 "$RC" 'exec with a vanished value still completes through av'
+cmp -s "$d/child-out" "$d/expected-bytes" || fail 'fallback child got the value from av'
+[ "$(grant_field "$d" RACE_KEY uses_left)" = 2 ] || fail 'a failed/empty read consumes no use'
+assert_no_grep 'use RACE_KEY' "$d/state/grants.log" 'no use receipt logged for the vanished read'
+assert_grep 'no active grant for RACE_KEY' "$d/err" 'vanished-value exec falls back loudly'
+assert_grep 'inject +RACE_KEY -- /bin/sh' "$d/av.log" 'fallback execs av inject with the command directly'
+assert_no_value_leak "$d" "$SECRET" 'read-race case'
+pass 'a failed or empty Keychain read falls back to av and consumes no use'
+
 # --- combined uses+deadline: whichever limit comes first wins ----------------
 
 d=$(new_case)

--- a/tests/fm-grant.test.sh
+++ b/tests/fm-grant.test.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-grant.sh - the captain-authorized grant vault.
+#
+# Every case runs against fakebin `security` and `av` shims plus an isolated
+# FM_GRANT_STATE_DIR, so no test ever touches the real login Keychain or fires
+# a real av approval dialog. The suite pins the public contract:
+#   - names failing ^[A-Z][A-Z0-9_]*$ are hard-rejected by every subcommand,
+#     --reason is required, a grant needs one explicit bound, and there is no
+#     public get.
+#   - grant imports through the hidden `_store` shape
+#     (`av inject +KEY -- fm-grant.sh _store KEY`), announces the permanent
+#     custody downgrade, stores the exact bytes minus one trailing newline,
+#     and lands state 0600 inside a 0700 grants dir.
+#   - exec injects the Keychain value into the child env only, decrements one
+#     use per retrieval, and combined uses+deadline grants trip on whichever
+#     limit comes first while the Keychain item stays.
+#   - the no-grant fallback execs `av inject +KEY... -- cmd` directly, prints
+#     one loud stderr line, consumes nothing, and the value never transits
+#     fm-grant.
+#   - revoke ends the window but keeps the item; forget wipes both.
+#   - concurrent execs decrement exactly once each (the mkdir-spinlock proof).
+#   - grant-shape warnings (--permanent, uses>100, until>30d, consequence-
+#     listed names) warn without blocking, and a plain API key stays quiet.
+#   - no secret value ever appears in fm-grant stdout/stderr, grant state, the
+#     grant log, or recorded av argv.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+FM_GRANT="$ROOT/bin/fm-grant.sh"
+TMP_ROOT=$(fm_test_tmproot fm-grant-tests)
+
+SECRET='s3cr3t-value-du2ok9-never-in-output'
+
+# --- shared fakebin shims ----------------------------------------------------
+#
+# Both shims are pure functions of per-case env (FAKE_KEYCHAIN, FAKE_AV_SECRETS,
+# AV_LOG), so one shared fakebin dir serves every case.
+
+FAKEBIN="$TMP_ROOT/fakebin"
+mkdir -p "$FAKEBIN"
+
+# Fake macOS `security` backed by $FAKE_KEYCHAIN/<account> files holding the
+# exact stored bytes. find -w prints the value plus the real tool's trailing
+# newline; a missing item exits 44 like errSecItemNotFound.
+cat > "$FAKEBIN/security" <<'SH'
+#!/usr/bin/env bash
+set -u
+cmd=${1-}
+[ $# -eq 0 ] || shift
+service= account= find_w=0 add_value= have_add_value=0
+case "$cmd" in
+  find-generic-password|add-generic-password|delete-generic-password) : ;;
+  *) echo "fake security: unsupported command $cmd" >&2; exit 64 ;;
+esac
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -s) service=$2; shift 2 ;;
+    -a) account=$2; shift 2 ;;
+    -U) shift ;;
+    -w)
+      if [ "$cmd" = add-generic-password ]; then
+        add_value=$2; have_add_value=1; shift 2
+      else
+        find_w=1; shift
+      fi
+      ;;
+    *) shift ;;
+  esac
+done
+[ "$service" = firstmate-grant ] || { echo "fake security: unexpected service '$service'" >&2; exit 64; }
+[ -n "$account" ] || { echo "fake security: missing account" >&2; exit 64; }
+item="$FAKE_KEYCHAIN/$account"
+case "$cmd" in
+  find-generic-password)
+    [ -f "$item" ] || exit 44
+    if [ "$find_w" = 1 ]; then
+      cat "$item"
+      printf '\n'
+    fi
+    ;;
+  add-generic-password)
+    [ "$have_add_value" = 1 ] || { echo "fake security: add without -w value" >&2; exit 64; }
+    mkdir -p "$FAKE_KEYCHAIN"
+    printf '%s' "$add_value" > "$item"
+    ;;
+  delete-generic-password)
+    [ -f "$item" ] || exit 44
+    rm -f "$item"
+    ;;
+esac
+exit 0
+SH
+
+# Fake `av`: records its argv to $AV_LOG, then emulates `inject +KEY... -- cmd`
+# by injecting $FAKE_AV_SECRETS/<KEY> bytes (trailing newline preserved) into
+# the child env and exec'ing the command.
+cat > "$FAKEBIN/av" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "$AV_LOG"
+[ "${1-}" = inject ] || { echo "fake av: unsupported command ${1-}" >&2; exit 64; }
+shift
+pairs=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    +*)
+      k=${1#+}
+      f="$FAKE_AV_SECRETS/$k"
+      [ -f "$f" ] || { echo "fake av: no fixture secret for $k" >&2; exit 65; }
+      v=$(cat "$f"; printf x)
+      v=${v%x}
+      pairs+=("$k=$v")
+      shift
+      ;;
+    --) shift; break ;;
+    *) echo "fake av: unexpected arg $1" >&2; exit 64 ;;
+  esac
+done
+[ $# -gt 0 ] || { echo "fake av: missing command" >&2; exit 64; }
+exec env ${pairs[@]+"${pairs[@]}"} "$@"
+SH
+
+chmod +x "$FAKEBIN/security" "$FAKEBIN/av"
+
+# --- case fixtures and helpers -----------------------------------------------
+
+CASE_N=0
+new_case() {
+  CASE_N=$((CASE_N + 1))
+  local d="$TMP_ROOT/case-$CASE_N"
+  mkdir -p "$d/state" "$d/keychain" "$d/avsecrets"
+  printf '%s\n' "$d"
+}
+
+# fmg <case-dir> <arg>... - run fm-grant against the case's shims and isolated
+# state; stdout lands in <case>/out, stderr in <case>/err, exit code in RC.
+RC=0
+fmg() {
+  local d=$1
+  shift
+  PATH="$FAKEBIN:$PATH" \
+    FAKE_KEYCHAIN="$d/keychain" \
+    FAKE_AV_SECRETS="$d/avsecrets" \
+    AV_LOG="$d/av.log" \
+    FM_HOME="$d" \
+    FM_GRANT_STATE_DIR="$d/state" \
+    "$FM_GRANT" "$@" > "$d/out" 2> "$d/err"
+  RC=$?
+}
+
+grant_field() {  # <case> <KEY> <field>
+  sed -n "s/^$3=//p" "$1/state/grants/$2" 2>/dev/null | sed -n 1p
+}
+
+file_mode() {
+  stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null
+}
+
+av_lines() {  # <case> - how many av invocations were recorded
+  if [ -f "$1/av.log" ]; then
+    wc -l < "$1/av.log"
+  else
+    printf '0\n'
+  fi
+}
+
+assert_no_value_leak() {  # <case> <value> <label>
+  local d=$1 v=$2 label=$3 f
+  for f in "$d/out" "$d/err" "$d/state/grants.log" "$d/av.log"; do
+    [ -f "$f" ] || continue
+    assert_no_grep "$v" "$f" "$label: value leaked into ${f#"$d"/}"
+  done
+  if [ -d "$d/state/grants" ] && grep -rF -- "$v" "$d/state/grants" >/dev/null 2>&1; then
+    fail "$label: value leaked into grant state"
+  fi
+}
+
+# --- name validation, required flags, no public get -------------------------
+
+d=$(new_case)
+printf '%s' "$SECRET" > "$d/avsecrets/GOOD_KEY"
+
+fmg "$d" grant lower_key --uses 1 --reason ok
+expect_code 1 "$RC" 'lowercase name rejected'
+assert_grep 'invalid secret name' "$d/err" 'grant names the validation failure'
+fmg "$d" grant 'BAD-DASH' --uses 1 --reason ok
+expect_code 1 "$RC" 'dashed name rejected'
+fmg "$d" grant '1LEADING' --uses 1 --reason ok
+expect_code 1 "$RC" 'digit-led name rejected'
+fmg "$d" exec 'BAD;INJ' -- /usr/bin/true
+expect_code 1 "$RC" 'exec rejects a shell-metacharacter name'
+fmg "$d" revoke 'bad name'
+expect_code 1 "$RC" 'revoke rejects an invalid name'
+fmg "$d" forget 'x/y'
+expect_code 1 "$RC" 'forget rejects an invalid name'
+fmg "$d" _store 'bad name'
+expect_code 1 "$RC" '_store rejects an invalid name'
+fmg "$d" _store GOOD_KEY
+expect_code 1 "$RC" '_store without the env value fails'
+fmg "$d" grant GOOD_KEY --uses 1
+expect_code 1 "$RC" 'grant without --reason rejected'
+assert_grep '--reason' "$d/err" 'grant names the missing --reason'
+fmg "$d" grant GOOD_KEY --reason ok
+expect_code 1 "$RC" 'grant without any explicit bound rejected'
+fmg "$d" get GOOD_KEY
+expect_code 1 "$RC" 'no public get subcommand'
+assert_absent "$d/state/grants/GOOD_KEY" 'rejected grants write no state'
+assert_absent "$d/av.log" 'rejected grants never reach av'
+fmg "$d" status
+expect_code 0 "$RC" 'status works with nothing imported'
+assert_grep 'NOT a security control' "$d/out" 'status states the honest identity'
+assert_grep 'No keys imported' "$d/out" 'empty status says so'
+pass 'validation hard-rejects bad names, missing --reason, missing bounds, and public get'
+
+# --- import via the hidden _store shape --------------------------------------
+
+d=$(new_case)
+# The fixture value carries a trailing newline that import must strip.
+printf '%s\n' "$SECRET" > "$d/avsecrets/API_TOKEN"
+printf '%s' "$SECRET" > "$d/expected-bytes"
+
+fmg "$d" grant API_TOKEN --uses 3 --reason 'captain: stop prompting for linear'
+expect_code 0 "$RC" 'grant with first-time import succeeds'
+assert_grep "inject +API_TOKEN -- $FM_GRANT _store API_TOKEN" "$d/av.log" 'import goes through the av _store shape'
+assert_present "$d/keychain/API_TOKEN" 'import lands the Keychain item'
+cmp -s "$d/keychain/API_TOKEN" "$d/expected-bytes" || fail 'stored bytes are the exact value minus one trailing newline'
+assert_grep 'ANY same-user process' "$d/err" 'grant announces the custody downgrade'
+assert_grep 'av approval dialog' "$d/err" 'grant says a dialog may be waiting'
+[ "$(file_mode "$d/state/grants/API_TOKEN")" = 600 ] || fail 'grant state file is 0600'
+[ "$(file_mode "$d/state/grants")" = 700 ] || fail 'grants dir is 0700'
+[ "$(grant_field "$d" API_TOKEN uses_left)" = 3 ] || fail 'uses_left recorded'
+[ "$(grant_field "$d" API_TOKEN imported_from)" = av ] || fail 'imported_from recorded'
+assert_grep 'captain: stop prompting for linear' "$d/state/grants/API_TOKEN" 'reason recorded in state'
+assert_grep 'grant API_TOKEN uses=3' "$d/state/grants.log" 'grant logged'
+assert_grep 'import API_TOKEN via=av' "$d/state/grants.log" 'import logged'
+assert_no_value_leak "$d" "$SECRET" 'import case'
+
+av_before=$(av_lines "$d")
+fmg "$d" grant API_TOKEN --uses 5 --reason 'captain: widen it'
+expect_code 0 "$RC" 're-grant succeeds'
+[ "$(av_lines "$d")" -eq "$av_before" ] || fail 're-grant of an imported key skips av'
+[ "$(grant_field "$d" API_TOKEN uses_left)" = 5 ] || fail 're-grant replaces the bounds'
+pass 'grant imports via the _store shape, stores exact bytes, and lands 0600/0700 state'
+
+# --- exec decrements, injects, and exhaustion falls back ---------------------
+
+d=$(new_case)
+printf '%s' "$SECRET" > "$d/avsecrets/API_TOKEN"
+printf '%s' "$SECRET" > "$d/expected-bytes"
+fmg "$d" grant API_TOKEN --uses 2 --reason 'captain: two uses'
+expect_code 0 "$RC" 'setup grant for exec case'
+
+# shellcheck disable=SC2016 # the child shell, not this test, expands the env var
+fmg "$d" exec API_TOKEN -- /bin/sh -c 'printf %s "$API_TOKEN" > "$1"' _ "$d/child-out"
+expect_code 0 "$RC" 'exec with an active grant succeeds'
+cmp -s "$d/child-out" "$d/expected-bytes" || fail 'child received the value via its env'
+[ "$(grant_field "$d" API_TOKEN uses_left)" = 1 ] || fail 'one use consumed'
+[ "$(av_lines "$d")" -eq 1 ] || fail 'granted exec never calls av'
+assert_grep 'use API_TOKEN uses_left=1' "$d/state/grants.log" 'use receipt logged'
+
+fmg "$d" exec API_TOKEN -- /usr/bin/true
+expect_code 0 "$RC" 'second exec consumes the last use'
+[ "$(grant_field "$d" API_TOKEN uses_left)" = 0 ] || fail 'last use consumed'
+assert_grep 'expire API_TOKEN limit=uses' "$d/state/grants.log" 'exhaustion logged as expiry'
+
+# shellcheck disable=SC2016 # the child shell, not this test, expands the env var
+fmg "$d" exec API_TOKEN -- /bin/sh -c 'printf %s "$API_TOKEN" > "$1"' _ "$d/child-out-fb"
+expect_code 0 "$RC" 'exhausted exec still completes through av'
+cmp -s "$d/child-out-fb" "$d/expected-bytes" || fail 'fallback child got the value from av'
+assert_grep 'no active grant' "$d/err" 'fallback is announced loudly on stderr'
+assert_grep 'inject +API_TOKEN -- /bin/sh' "$d/av.log" 'fallback execs av inject with the command directly'
+assert_grep 'fallback ungranted=API_TOKEN' "$d/state/grants.log" 'fallback logged'
+assert_no_value_leak "$d" "$SECRET" 'exec case'
+pass 'exec injects into the child env, decrements one use per retrieval, and exhausts to av'
+
+# --- combined uses+deadline: whichever limit comes first wins ----------------
+
+d=$(new_case)
+printf '%s' "$SECRET" > "$d/avsecrets/COMBO_USES"
+printf '%s' "$SECRET" > "$d/avsecrets/COMBO_TIME"
+
+fmg "$d" grant COMBO_USES --uses 1 --until 12h --reason 'captain: combo uses-first'
+expect_code 0 "$RC" 'combined grant accepted'
+fmg "$d" exec COMBO_USES -- /usr/bin/true
+expect_code 0 "$RC" 'first combined exec consumes the single use'
+assert_grep 'expire COMBO_USES limit=uses' "$d/state/grants.log" 'uses limit trips first'
+fmg "$d" exec COMBO_USES -- /usr/bin/true
+expect_code 0 "$RC" 'post-exhaustion exec completes via av'
+assert_grep 'no active grant' "$d/err" 'uses-exhausted combined grant falls back'
+
+fmg "$d" grant COMBO_TIME --uses 5 --until 12h --reason 'captain: combo deadline-first'
+expect_code 0 "$RC" 'second combined grant accepted'
+sed 's/^deadline_epoch=.*/deadline_epoch=100/' "$d/state/grants/COMBO_TIME" > "$d/tmpstate"
+mv "$d/tmpstate" "$d/state/grants/COMBO_TIME"
+fmg "$d" exec COMBO_TIME -- /usr/bin/true
+expect_code 0 "$RC" 'deadline-tripped exec still completes via av'
+assert_grep 'no active grant for COMBO_TIME' "$d/err" 'deadline expiry falls back loudly'
+assert_grep 'expire COMBO_TIME limit=deadline' "$d/state/grants.log" 'deadline limit trips despite remaining uses'
+[ "$(grant_field "$d" COMBO_TIME uses_left)" = 0 ] || fail 'expired grant normalized'
+assert_no_grep 'use COMBO_TIME' "$d/state/grants.log" 'no use consumed after the deadline'
+assert_present "$d/keychain/COMBO_TIME" 'expiry keeps the Keychain item'
+
+fmg "$d" status
+expect_code 0 "$RC" 'status succeeds'
+assert_grep 'NOT a security control' "$d/out" 'status leads with the honest identity'
+assert_grep 'ANY same-user process' "$d/out" 'status states the real exposure'
+assert_grep 'COMBO_TIME' "$d/out" 'status lists the expired key'
+assert_grep 'NO active grant' "$d/out" 'status shows imported-but-inactive honestly'
+assert_grep 'captain: combo uses-first' "$d/out" 'status shows the recorded reason'
+assert_no_value_leak "$d" "$SECRET" 'combined-limits case'
+pass 'combined uses+deadline grants expire on the first limit and status stays honest'
+
+# --- no-grant fallback consumes nothing and never captures the value ---------
+
+d=$(new_case)
+FALLBACK_VALUE='fallback-value-zz9-never-in-output'
+printf '%s' "$FALLBACK_VALUE" > "$d/avsecrets/FRESH_KEY"
+printf '%s' "$FALLBACK_VALUE" > "$d/expected-bytes"
+
+# shellcheck disable=SC2016 # the child shell, not this test, expands the env var
+fmg "$d" exec FRESH_KEY -- /bin/sh -c 'printf %s "$FRESH_KEY" > "$1"' _ "$d/child-out"
+expect_code 0 "$RC" 'ungranted exec completes through av'
+cmp -s "$d/child-out" "$d/expected-bytes" || fail 'fallback child got the value from av'
+assert_grep 'no active grant for FRESH_KEY' "$d/err" 'fallback prints the loud stderr line'
+assert_grep 'inject +FRESH_KEY -- /bin/sh' "$d/av.log" 'fallback is a direct av inject exec'
+assert_absent "$d/state/grants/FRESH_KEY" 'fallback creates no grant state'
+assert_no_grep 'use FRESH_KEY' "$d/state/grants.log" 'fallback consumes nothing'
+assert_grep 'fallback ungranted=FRESH_KEY' "$d/state/grants.log" 'fallback leaves an audit line'
+assert_no_value_leak "$d" "$FALLBACK_VALUE" 'fallback case'
+pass 'no-grant fallback execs av directly, consumes nothing, and never captures the value'
+
+# --- revoke keeps the key, forget removes it ---------------------------------
+
+d=$(new_case)
+printf '%s' "$SECRET" > "$d/avsecrets/ROT_KEY"
+fmg "$d" grant ROT_KEY --uses 5 --reason 'captain: rotate later'
+expect_code 0 "$RC" 'setup grant for revoke case'
+
+fmg "$d" revoke ROT_KEY
+expect_code 0 "$RC" 'revoke succeeds'
+assert_present "$d/keychain/ROT_KEY" 'revoke keeps the Keychain item'
+assert_grep 'Keychain item' "$d/out" 'revoke says the item survives'
+assert_grep 'revoke ROT_KEY' "$d/state/grants.log" 'revoke logged'
+fmg "$d" exec ROT_KEY -- /usr/bin/true
+expect_code 0 "$RC" 'revoked exec completes via av'
+assert_grep 'no active grant' "$d/err" 'revoked grant falls back'
+
+av_before=$(av_lines "$d")
+fmg "$d" grant ROT_KEY --uses 2 --reason 'captain: again'
+expect_code 0 "$RC" 're-grant after revoke succeeds'
+[ "$(av_lines "$d")" -eq "$av_before" ] || fail 're-grant after revoke skips av (item still stored)'
+fmg "$d" exec ROT_KEY -- /usr/bin/true
+expect_code 0 "$RC" 're-granted exec succeeds'
+[ "$(grant_field "$d" ROT_KEY uses_left)" = 1 ] || fail 're-granted key consumes again'
+
+fmg "$d" forget ROT_KEY
+expect_code 0 "$RC" 'forget succeeds'
+assert_absent "$d/keychain/ROT_KEY" 'forget wipes the Keychain item'
+assert_absent "$d/state/grants/ROT_KEY" 'forget removes the grant record'
+assert_grep 'forget ROT_KEY keychain=removed' "$d/state/grants.log" 'forget logged'
+assert_no_value_leak "$d" "$SECRET" 'revoke/forget case'
+pass 'revoke keeps the Keychain item while forget wipes it and the record'
+
+# --- concurrent execs decrement exactly once each (spinlock proof) -----------
+
+d=$(new_case)
+printf '%s' "$SECRET" > "$d/avsecrets/CONC_KEY"
+fmg "$d" grant CONC_KEY --uses 20 --reason 'captain: parallel lanes'
+expect_code 0 "$RC" 'setup grant for concurrency case'
+
+pids=
+i=0
+while [ "$i" -lt 4 ]; do
+  PATH="$FAKEBIN:$PATH" \
+    FAKE_KEYCHAIN="$d/keychain" \
+    FAKE_AV_SECRETS="$d/avsecrets" \
+    AV_LOG="$d/av.log" \
+    FM_HOME="$d" \
+    FM_GRANT_STATE_DIR="$d/state" \
+    "$FM_GRANT" exec CONC_KEY -- /usr/bin/true > "$d/out.$i" 2> "$d/err.$i" &
+  pids="$pids $!"
+  i=$((i + 1))
+done
+for p in $pids; do
+  wait "$p" || fail 'concurrent exec exited nonzero'
+done
+[ "$(grant_field "$d" CONC_KEY uses_left)" = 16 ] \
+  || fail "4 concurrent execs must decrement exactly 4 (uses_left=$(grant_field "$d" CONC_KEY uses_left))"
+[ "$(grep -c ' use CONC_KEY ' "$d/state/grants.log")" -eq 4 ] || fail 'exactly four use receipts logged'
+pass 'concurrent execs decrement exactly once each - the mkdir spinlock holds'
+
+# --- grant-shape warnings warn without blocking ------------------------------
+
+d=$(new_case)
+for k in PERM_KEY WIDE_KEY LONG_KEY STRIPE_LIVE_KEY; do
+  printf '%s' "$SECRET" > "$d/avsecrets/$k"
+done
+printf '%s' 'linear-value-abc' > "$d/avsecrets/LINEAR_API_KEY"
+
+fmg "$d" grant PERM_KEY --permanent --reason 'captain: forever'
+expect_code 0 "$RC" '--permanent grant succeeds despite the warning'
+assert_grep 'grant-shape warning' "$d/err" '--permanent warns'
+fmg "$d" grant WIDE_KEY --uses 500 --reason 'captain: wide'
+expect_code 0 "$RC" 'wide uses grant succeeds despite the warning'
+assert_grep 'grant-shape warning' "$d/err" 'uses>100 warns'
+fmg "$d" grant LONG_KEY --until 90d --reason 'captain: long'
+expect_code 0 "$RC" 'long deadline grant succeeds despite the warning'
+assert_grep 'grant-shape warning' "$d/err" 'until>30d warns'
+fmg "$d" grant STRIPE_LIVE_KEY --uses 5 --reason 'captain: stripe'
+expect_code 0 "$RC" 'consequence-listed grant succeeds despite the warning'
+assert_grep 'grant-shape warning' "$d/err" 'consequence-listed name warns'
+fmg "$d" grant LINEAR_API_KEY --uses 20 --reason 'captain: linear'
+expect_code 0 "$RC" 'plain API key grant succeeds'
+assert_no_grep 'grant-shape warning' "$d/err" 'a bounded plain API key never warns (no name heuristic)'
+
+# shellcheck disable=SC2016 # the child shell, not this test, expands the env var
+fmg "$d" exec PERM_KEY LINEAR_API_KEY -- /bin/sh -c 'printf "%s:%s" "$PERM_KEY" "$LINEAR_API_KEY" > "$1"' _ "$d/child-out"
+expect_code 0 "$RC" 'multi-key exec succeeds'
+printf '%s:%s' "$SECRET" 'linear-value-abc' > "$d/expected-bytes"
+cmp -s "$d/child-out" "$d/expected-bytes" || fail 'multi-key exec injects each key correctly'
+[ -z "$(grant_field "$d" PERM_KEY uses_left)" ] || fail 'permanent grant is not decremented'
+[ "$(grant_field "$d" LINEAR_API_KEY uses_left)" = 19 ] || fail 'uses-bounded key decremented alongside permanent'
+assert_grep 'use PERM_KEY uses_left=-' "$d/state/grants.log" 'permanent retrieval still leaves a receipt'
+assert_no_value_leak "$d" "$SECRET" 'shape-warning case'
+pass 'shape warnings warn without blocking, and permanent grants exec without decrement'


### PR DESCRIPTION
## What

Adds `bin/fm-grant.sh`, the captain-authorized grant vault for bounded, promptless access to stored secrets:

```
fm-grant.sh exec KEY... -- <cmd>
```

It runs a command that needs a stored secret without ever printing the value, and falls back loudly to a single approval dialog when no grant is active. A promptless window is only ever opened on an explicit captain instruction quoted in `--reason`.

Ships with:
- `bin/fm-grant.sh` — the vault (568 lines).
- `docs/fm-grant.md` — usage and safety contract.
- `tests/fm-grant.test.sh` — behavior coverage (427 lines).
- Wiring: reference in `AGENTS.md`, `docs/scripts.md`, and `docs/documentation-audiences.json`.

## Why

Commands that need a stored secret currently have no single audited path. This gives them one that keeps the secret out of logs and terminal output, and fails safe to an explicit approval prompt rather than proceeding without authorization.

## Scope and safety

- Pure additions; verified to merge cleanly onto current `main` with no conflicts.
- This is the vault on its own, extracted from an older bundled change whose other pieces already landed separately.
- Passes `bin/fm-lint.sh` and the documentation-audience check; `tests/fm-grant.test.sh` covers the behavior.
