### PR TITLE
fix(bin): bound wake drain presentation lock waits

### DIFF
--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -7,7 +7,7 @@
 # Keep sequence-bound row consumption independent from generation-bound episode
 # retirement; docs/watcher-continuity.md owns the recovery contract.
 # FM_STATUS_PRESENTATION_LOCK_TIMEOUT sets the positive whole-second wait for
-# the presentation-only lock (default 10); queue mutation locks remain blocking.
+# presentation-path locks (default 10); queue mutation locks remain blocking.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -34,6 +34,8 @@ ACK_THROUGH=
 ACK_GENERATION=
 ACK_FINGERPRINTS=
 ACK_NOTICE_FINGERPRINTS=
+PRESENTATION_LOCK_TIMEOUT=${FM_STATUS_PRESENTATION_LOCK_TIMEOUT:-10}
+case "$PRESENTATION_LOCK_TIMEOUT" in ''|*[!0-9]*|0) PRESENTATION_LOCK_TIMEOUT=10 ;; esac
 
 # --- per-actor consume (docs/watcher-continuity.md "Per-actor acknowledgement") --
 # main (FM_SUPERVISION_ACTOR unset or "main", via fm-lease-lib.sh's fm_lease_actor
@@ -364,17 +366,15 @@ print_status_sections() {
 
 print_status_presentation() {  # [<deduped-raw-rows>]
   local rows=${1:-} lock="$STATE/.status-presentation-lock" snapshot annotation_manifest fully_presented='' rc=0
-  local lock_timeout lock_rc holder_pid
-  lock_timeout=${FM_STATUS_PRESENTATION_LOCK_TIMEOUT:-10}
-  case "$lock_timeout" in ''|*[!0-9]*|0) lock_timeout=10 ;; esac
-  if fm_lock_acquire_wait_bounded "$lock" "$lock_timeout"; then
+  local lock_rc holder_pid
+  if fm_lock_acquire_wait_bounded "$lock" "$PRESENTATION_LOCK_TIMEOUT"; then
     :
   else
     lock_rc=$?
     if [ "$lock_rc" -eq 124 ]; then
       holder_pid=${FM_LOCK_HELD_PID:-unknown}
       printf 'STATUS PRESENTATION SKIPPED: lock remains held by live pid %s after %ss; retry on the next drain.\n' \
-        "$holder_pid" "$lock_timeout"
+        "$holder_pid" "$PRESENTATION_LOCK_TIMEOUT"
     else
       printf 'wake drain: status presentation lock could not be acquired safely\n' >&2
     fi
@@ -411,7 +411,20 @@ trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
+if [ -n "$ACK_THROUGH" ]; then
+  fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
+elif fm_lock_acquire_wait_bounded "$FM_WAKE_QUEUE_LOCK" "$PRESENTATION_LOCK_TIMEOUT"; then
+  :
+else
+  lock_rc=$?
+  if [ "$lock_rc" -eq 124 ]; then
+    printf 'WAKE DRAIN SKIPPED: queue lock remains held by live pid %s after %ss; retry on the next drain.\n' \
+      "${FM_LOCK_HELD_PID:-unknown}" "$PRESENTATION_LOCK_TIMEOUT"
+    exit 0
+  fi
+  printf 'wake drain: queue lock could not be acquired safely\n' >&2
+  exit 1
+fi
 DRAIN_LOCK_HELD=true
 reclaim_stale_branch_grant_locked || exit 1
 [ "$ACTOR" != branch ] || require_branch_eligible_rows || exit 1

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -6,6 +6,8 @@
 #
 # Keep sequence-bound row consumption independent from generation-bound episode
 # retirement; docs/watcher-continuity.md owns the recovery contract.
+# FM_STATUS_PRESENTATION_LOCK_TIMEOUT sets the positive whole-second wait for
+# the presentation-only lock (default 10); queue mutation locks remain blocking.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -362,7 +364,20 @@ print_status_sections() {
 
 print_status_presentation() {  # [<deduped-raw-rows>]
   local rows=${1:-} lock="$STATE/.status-presentation-lock" snapshot annotation_manifest fully_presented='' rc=0
-  fm_lock_acquire_wait "$lock" || return 1
+  local lock_timeout lock_rc holder_pid
+  lock_timeout=${FM_STATUS_PRESENTATION_LOCK_TIMEOUT:-10}
+  case "$lock_timeout" in ''|*[!0-9]*|0) lock_timeout=10 ;; esac
+  if fm_lock_acquire_wait_bounded "$lock" "$lock_timeout"; then
+    :
+  else
+    lock_rc=$?
+    if [ "$lock_rc" -eq 124 ]; then
+      holder_pid=${FM_LOCK_HELD_PID:-unknown}
+      printf 'STATUS PRESENTATION SKIPPED: lock remains held by live pid %s after %ss; retry on the next drain.\n' \
+        "$holder_pid" "$lock_timeout"
+    fi
+    return 1
+  fi
   snapshot=$(status_presentation_snapshot "$STATE") || {
     printf 'STATUS PRESENTATION INCOMPLETE: status snapshot could not be read.\n'
     rc=1

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -375,6 +375,8 @@ print_status_presentation() {  # [<deduped-raw-rows>]
       holder_pid=${FM_LOCK_HELD_PID:-unknown}
       printf 'STATUS PRESENTATION SKIPPED: lock remains held by live pid %s after %ss; retry on the next drain.\n' \
         "$holder_pid" "$lock_timeout"
+    else
+      printf 'wake drain: status presentation lock could not be acquired safely\n' >&2
     fi
     return 1
   fi

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -957,7 +957,8 @@ fm_lock_acquire_wait_bounded() {
     "FM_ROOT_OVERRIDE=$FM_ROOT" \
     "FM_LOCK_STALE_AFTER=$FM_LOCK_STALE_AFTER" \
     bash -c '. "$1"; _fm_lock_acquire_wait_handoff "$2" "$3"' \
-      _ "$FM_WAKE_LIB_DIR/fm-wake-lib.sh" "$lockdir" "$caller_pid"; then
+      _ "$FM_WAKE_LIB_DIR/fm-wake-lib.sh" "$lockdir" "$caller_pid" \
+      </dev/null >/dev/null 2>&1; then
     rc=0
   else
     rc=$?

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -974,7 +974,20 @@ fm_lock_acquire_wait_bounded() {
   if fm_lock_try_acquire "$lockdir"; then
     return 0
   fi
-  [ "$rc" -eq 124 ] && return 124
+  if [ "$rc" -eq 124 ]; then
+    owner_pid=$(cat "$lockdir/pid" 2>/dev/null || true)
+    case "$owner_pid" in
+      ''|*[!0-9]*|0) ;;
+      *)
+        if [ "$owner_pid" -gt 0 ] 2>/dev/null && fm_pid_alive "$owner_pid"; then
+          FM_LOCK_HELD_PID=$owner_pid
+          return 124
+        fi
+        ;;
+    esac
+    FM_LOCK_HELD_PID=
+    return 1
+  fi
   return "$rc"
 }
 

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -986,6 +986,7 @@ fm_lock_acquire_wait_bounded() {
         fi
         ;;
     esac
+    # shellcheck disable=SC2034 # Output read by callers after bounded acquisition.
     FM_LOCK_HELD_PID=
     return 1
   fi

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -24,6 +24,14 @@ _fm_wake_require_classify() {
   . "$FM_WAKE_LIB_DIR/fm-classify-lib.sh"
 }
 
+# Load the bounded-execution owner only for callers that use the presentation
+# lock deadline. Most wake-library consumers need no timeout machinery.
+_fm_wake_require_timeout() {
+  command -v fm_run_timed >/dev/null 2>&1 && return 0
+  # shellcheck source=bin/fm-timeout-lib.sh
+  . "$FM_WAKE_LIB_DIR/fm-timeout-lib.sh"
+}
+
 fm_current_pid() {
   printf '%s\n' "${BASHPID:-$$}"
 }
@@ -897,6 +905,77 @@ fm_lock_acquire_wait() {
   while ! fm_lock_try_acquire "$lockdir"; do
     sleep 0.1
   done
+}
+
+# Acquire in the timed helper process, then transfer the lock record to the
+# waiting caller before exiting. The lock's ordinary stale-owner recovery makes
+# every interruption safe: before transfer the helper is the owner; after
+# transfer the still-live caller is the owner.
+_fm_lock_acquire_wait_handoff() {  # <lockdir> <caller-pid>
+  local lockdir=$1 caller_pid=$2 ownerdir current back
+  case "$caller_pid" in ''|*[!0-9]*) return 1 ;; esac
+  fm_pid_alive "$caller_pid" || return 1
+  trap 'fm_lock_release "$lockdir"; exit 143' TERM INT
+  fm_lock_acquire_wait "$lockdir" || return 1
+  if [ -L "$lockdir" ]; then
+    ownerdir=$(fm_lock_link_owner "$lockdir" 2>/dev/null) || {
+      fm_lock_release "$lockdir"
+      return 1
+    }
+  else
+    ownerdir=$lockdir
+  fi
+  current=${BASHPID:-$$}
+  back=$(cat "$ownerdir/pid" 2>/dev/null || true)
+  if [ "$back" != "$current" ] \
+    || ! printf '%s\n' "$caller_pid" > "$ownerdir/pid" 2>/dev/null \
+    || [ "$(cat "$ownerdir/pid" 2>/dev/null || true)" != "$caller_pid" ]; then
+    fm_lock_release "$lockdir"
+    return 1
+  fi
+  trap - TERM INT
+}
+
+# fm_lock_acquire_wait_bounded <lockdir> <positive-seconds>
+#
+# Presentation-only acquire variant. It preserves the ordinary wait/reclaim
+# behavior until fm-timeout-lib.sh's hard deadline, returns 124 when a live
+# holder still owns the lock, and leaves FM_LOCK_HELD_PID naming that holder.
+# Mutation-critical callers continue to use fm_lock_acquire_wait.
+fm_lock_acquire_wait_bounded() {
+  local lockdir=$1 seconds=$2 caller_pid rc owner_pid
+  case "$seconds" in ''|*[!0-9]*|0) return 2 ;; esac
+  _fm_wake_require_timeout || return 1
+  if fm_lock_try_acquire "$lockdir"; then
+    return 0
+  fi
+
+  caller_pid=${BASHPID:-$$}
+  # shellcheck disable=SC2016 # Positional parameters expand in the child shell.
+  if fm_run_timed "$seconds" env \
+    "FM_STATE_OVERRIDE=$STATE" \
+    "FM_ROOT_OVERRIDE=$FM_ROOT" \
+    "FM_LOCK_STALE_AFTER=$FM_LOCK_STALE_AFTER" \
+    bash -c '. "$1"; _fm_lock_acquire_wait_handoff "$2" "$3"' \
+      _ "$FM_WAKE_LIB_DIR/fm-wake-lib.sh" "$lockdir" "$caller_pid"; then
+    rc=0
+  else
+    rc=$?
+  fi
+
+  owner_pid=$(cat "$lockdir/pid" 2>/dev/null || true)
+  if [ "$owner_pid" = "$caller_pid" ]; then
+    return 0
+  fi
+  [ "$rc" -ne 0 ] || rc=1
+  # A deadline can kill the helper just after it acquired and before handoff.
+  # Give ordinary stale-owner recovery one final non-blocking chance so that
+  # helper cleanup cannot manufacture a false contention advisory.
+  if fm_lock_try_acquire "$lockdir"; then
+    return 0
+  fi
+  [ "$rc" -eq 124 ] && return 124
+  return "$rc"
 }
 
 fm_lock_release() {

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -63,6 +63,9 @@ An acknowledged episode does not freeze the generation, because the next downtim
 
 `bin/fm-wake-drain.sh` consumes the queue per actor, not per whole-queue cutoff, using `bin/fm-lease-lib.sh`'s existing `fm_lease_actor` identity (`FM_SUPERVISION_ACTOR`, unset or `main` for every non-Pi harness and Pi's own main session; `branch` only inside the Pi supervision branch's own bash tool calls, injected deterministically by the extension - never agent memory).
 Every presented row is claimed to exactly one actor under the durable queue lock.
+An ordinary presentation drain bounds both its initial queue-lock acquire and its later status-presentation-lock acquire at the deadline owned by the script header.
+A live initial queue-lock holder produces one PID-naming advisory and skips the whole drain before any claim or mutation, while a live status-presentation-lock holder produces one such advisory after raw wake presentation and leaves status annotations, sections, and cursors retriable on the next drain.
+Acknowledgement invocations and every other mutation-critical queue-lock acquire retain blocking semantics, so acknowledgement atomicity is unchanged.
 Main records its presented set in `state/.main-eligible-rows`.
 A branch grant is published through `bin/fm-wake-grant.sh` under that same lock in `state/.branch-eligible-rows`, bound to the live branch process and extension generation recorded in `state/.branch-eligible-owner`, and publication is refused if main already claimed any requested row.
 A main drain validates that owner evidence under the queue lock and reclaims the grant when its process is gone or its identity no longer matches.
@@ -75,7 +78,7 @@ A check-kind row is main-owned in every mode, including a heartbeat review, so i
 `fm-wake-drain.sh` never reclassifies a row itself: it filters the queue to the current actor's opaque claim before same-key deduplication, then presents and acknowledges only that actor-local view.
 A missing or empty branch snapshot is refused loudly rather than read as "nothing eligible", because reaching the drain without the non-empty handoff promised by the extension is a wiring bug.
 Because branch claims contain no check-kind rows, a branch acknowledgement skips check-specific receipt scans.
-`tests/fm-wake-queue.test.sh`'s mixed-queue actor tests drive both directions against the real scripts: branch acknowledgement cannot swallow a main row, and a concurrent main turn cannot present or acknowledge an active branch grant.
+`tests/fm-wake-queue.test.sh`'s mixed-queue actor and presentation-deadline tests drive the real scripts: branch acknowledgement cannot swallow a main row, a concurrent main turn cannot present or acknowledge an active branch grant, live-holder presentation contention stays bounded and retriable, and acknowledgement locking remains blocking.
 `tests/fm-pi-branch-extension.test.sh` pins extension-side classification, claim publication and release, and the pre-drain recheck.
 
 ## Arm-layer cycle contract

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -1244,6 +1244,31 @@ test_live_presentation_holder_is_deadlined_without_weakening_ack() {
   pass "presentation lock waits are bounded and retriable without weakening acknowledgement atomicity"
 }
 
+test_malformed_presentation_lock_reports_acquire_failure() {
+  local dir state status out err
+  dir=$(make_case malformed-presentation-lock)
+  state="$dir/state"
+  status="$state/task.status"
+  out="$dir/drain.out"
+  err="$dir/drain.err"
+
+  printf 'needs-decision [key=fixture]: malformed lock remains retriable\n' > "$status"
+  append_wake "$state" signal task.status "signal: $status" \
+    || fail "could not seed the malformed-lock wake"
+  : > "$state/.status-presentation-lock"
+
+  FM_STATE_OVERRIDE="$state" FM_STATUS_PRESENTATION_LOCK_TIMEOUT=1 \
+    "$DRAIN" > "$out" 2> "$err" || fail "malformed-lock drain failed"
+  grep -F 'wake drain: status presentation lock could not be acquired safely' "$err" >/dev/null \
+    || fail "malformed presentation lock did not report an acquire failure"
+  if grep -F 'STATUS PRESENTATION SKIPPED: lock remains held by live pid' "$out" >/dev/null; then
+    fail "malformed presentation lock was reported as live-holder contention"
+  fi
+  grep "$(printf '\tsignal\t')" "$out" >/dev/null \
+    || fail "malformed presentation lock dropped the durable wake row"
+  pass "malformed presentation locks report acquire failure instead of contention"
+}
+
 # Drain-time historical annotation staleness: a turn-ended-only wake row must
 # not present an already-announced status line as a new update, while a status
 # file with unannounced bytes keeps its annotation and a direct status row is
@@ -1295,6 +1320,7 @@ test_historical_annotation_skips_announced_status() {
 
 test_self_held_lock_reclaims_instead_of_deadlocking
 test_live_presentation_holder_is_deadlined_without_weakening_ack
+test_malformed_presentation_lock_reports_acquire_failure
 test_secondmate_foreign_queue_stall_is_one_shot_and_read_only
 test_secondmate_stall_marker_rejects_symlink
 test_acknowledged_stall_publication_survives_pre_marker_crash

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -1144,6 +1144,79 @@ test_self_held_lock_reclaims_instead_of_deadlocking() {
   pass "an abandoned same-process lock hold is reclaimed; a parent's live hold is not"
 }
 
+# A bounded waiter acquires in a helper process, but the caller must own the
+# lock once contention clears so it can safely hold and release the critical
+# section itself.
+test_bounded_lock_handoff_after_contention() {
+  local dir state lock holder_pid waiter_pid i recorded_pid real_sleep sleep_log
+  dir=$(make_case bounded-lock-handoff)
+  state="$dir/state"
+  lock="$state/.fixture.lock"
+  sleep_log="$dir/waiter-sleeps"
+  real_sleep=$(command -v sleep) || fail "sleep is unavailable for the handoff fixture"
+  cat > "$dir/fakebin/sleep" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$1" >> "$FM_HANDOFF_SLEEP_LOG"
+exec "$FM_HANDOFF_REAL_SLEEP" "$@"
+SH
+  chmod +x "$dir/fakebin/sleep"
+
+  FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_lock_acquire_wait "$2" || exit 10
+    printf "ready\n" > "$3"
+    while [ ! -e "$4" ]; do sleep 0.05; done
+    fm_lock_release "$2"
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$lock" "$dir/holder.ready" "$dir/release-holder" &
+  holder_pid=$!
+  i=0
+  while [ "$i" -lt 100 ] && [ ! -s "$dir/holder.ready" ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ -s "$dir/holder.ready" ] \
+    || { kill "$holder_pid" 2>/dev/null || true; fail "handoff fixture holder never acquired its lock"; }
+
+  PATH="$dir/fakebin:$PATH" FM_HANDOFF_SLEEP_LOG="$sleep_log" FM_HANDOFF_REAL_SLEEP="$real_sleep" \
+    FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_lock_acquire_wait_bounded "$2" 5 || exit 11
+    current=${BASHPID:-$$}
+    printf "%s\n" "$current" > "$3"
+    while [ ! -e "$4" ]; do sleep 0.05; done
+    [ "$(cat "$2/pid" 2>/dev/null || true)" = "$current" ] || exit 12
+    fm_lock_release "$2"
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$lock" "$dir/waiter.ready" "$dir/release-waiter" &
+  waiter_pid=$!
+  i=0
+  while [ "$i" -lt 100 ] && ! grep -Fx '0.1' "$sleep_log" >/dev/null 2>&1; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  grep -Fx '0.1' "$sleep_log" >/dev/null 2>&1 \
+    || { kill "$holder_pid" "$waiter_pid" 2>/dev/null || true; fail "bounded helper never entered its contended wait"; }
+  [ ! -e "$dir/waiter.ready" ] \
+    || { kill "$holder_pid" "$waiter_pid" 2>/dev/null || true; fail "bounded waiter bypassed a live holder"; }
+
+  : > "$dir/release-holder"
+  wait "$holder_pid" || { kill "$waiter_pid" 2>/dev/null || true; fail "fixture holder did not release cleanly"; }
+  i=0
+  while [ "$i" -lt 100 ] && [ ! -s "$dir/waiter.ready" ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ -s "$dir/waiter.ready" ] \
+    || { kill "$waiter_pid" 2>/dev/null || true; fail "bounded waiter did not acquire after contention cleared"; }
+  recorded_pid=$(cat "$dir/waiter.ready")
+  [ "$recorded_pid" = "$waiter_pid" ] && [ "$(cat "$lock/pid" 2>/dev/null || true)" = "$waiter_pid" ] \
+    || { kill "$waiter_pid" 2>/dev/null || true; fail "bounded acquire did not hand lock ownership to its caller"; }
+
+  : > "$dir/release-waiter"
+  wait "$waiter_pid" || fail "caller could not release its handed-off lock"
+  [ ! -e "$lock" ] && [ ! -L "$lock" ] || fail "handed-off lock remained after caller release"
+  pass "bounded acquire hands ownership to the waiting caller after contention"
+}
+
 # A live-but-stuck presentation lock must not strand the executable drain. The
 # presentation remains retriable on the next pass, while the separate queue
 # mutation lock keeps its blocking all-or-nothing acknowledgement contract.
@@ -1365,6 +1438,7 @@ test_historical_annotation_skips_announced_status() {
 }
 
 test_self_held_lock_reclaims_instead_of_deadlocking
+test_bounded_lock_handoff_after_contention
 test_live_presentation_holder_is_deadlined_without_weakening_ack
 test_malformed_presentation_lock_reports_acquire_failure
 test_secondmate_foreign_queue_stall_is_one_shot_and_read_only

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # tests/fm-wake-queue.test.sh - wake-queue losslessness (the queue safety matrix):
-# concurrent append/drain, bounded structural enrichment, interruption safety,
-# signal catch-up while no watcher runs, stale/check enqueue-before-suppressor
+# concurrent append/drain, bounded structural enrichment and presentation-lock
+# waits, interruption safety, signal catch-up while no watcher runs, stale/check enqueue-before-suppressor
 # ordering, atomic double-drain, duplicate collapse, and liveness assertion.
 # Nothing is lost and nothing is double-consumed. General watcher/lock liveness
 # lives in fm-watcher-lock.test.sh; daemon classification/injection in
@@ -1144,6 +1144,106 @@ test_self_held_lock_reclaims_instead_of_deadlocking() {
   pass "an abandoned same-process lock hold is reclaimed; a parent's live hold is not"
 }
 
+# A live-but-stuck status presenter must not strand the executable drain. The
+# presentation remains retriable on the next pass, while the separate queue
+# mutation lock keeps its blocking all-or-nothing acknowledgement contract.
+test_live_presentation_holder_is_deadlined_without_weakening_ack() {
+  local dir state status first_out first_err second_out second_err replay_out replay_err
+  local presentation_holder ack_holder i start elapsed rc advisory_count
+  dir=$(make_case presentation-lock-deadline)
+  state="$dir/state"
+  status="$state/task.status"
+  first_out="$dir/first.out"
+  first_err="$dir/first.err"
+  second_out="$dir/second.out"
+  second_err="$dir/second.err"
+  replay_out="$dir/replay.out"
+  replay_err="$dir/replay.err"
+
+  printf 'needs-decision [key=fixture]: presentation remains retriable\n' > "$status"
+  append_wake "$state" signal task.status "signal: $status" \
+    || fail "could not seed the presentation-deadline wake"
+
+  FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_lock_acquire_wait "$2"
+    printf "ready\n" > "$3"
+    exec sleep 30
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$state/.status-presentation-lock" "$dir/presentation.ready" &
+  presentation_holder=$!
+  i=0
+  while [ "$i" -lt 100 ] && [ ! -s "$dir/presentation.ready" ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ -s "$dir/presentation.ready" ] \
+    || { kill "$presentation_holder" 2>/dev/null || true; fail "presentation holder never acquired its lock"; }
+
+  start=$(date +%s)
+  FM_STATE_OVERRIDE="$state" FM_STATUS_PRESENTATION_LOCK_TIMEOUT=1 \
+    "$DRAIN" > "$first_out" 2> "$first_err" \
+    || { kill "$presentation_holder" 2>/dev/null || true; fail "bounded presentation drain failed"; }
+  elapsed=$(( $(date +%s) - start ))
+  [ "$elapsed" -le 2 ] \
+    || { kill "$presentation_holder" 2>/dev/null || true; fail "presentation lock delayed the drain for ${elapsed}s"; }
+  advisory_count=$(grep -Fc \
+    "STATUS PRESENTATION SKIPPED: lock remains held by live pid $presentation_holder" \
+    "$first_out" || true)
+  [ "$advisory_count" -eq 1 ] \
+    || { kill "$presentation_holder" 2>/dev/null || true; fail "presentation deadline did not emit exactly one holder advisory"; }
+  grep "$(printf '\tsignal\t')" "$first_out" >/dev/null \
+    || { kill "$presentation_holder" 2>/dev/null || true; fail "bounded presentation dropped the durable wake row"; }
+  if grep -F 'task.status: needs-decision [key=fixture]' "$first_out" >/dev/null; then
+    kill "$presentation_holder" 2>/dev/null || true
+    fail "contended presentation emitted status content without its cursor lock"
+  fi
+
+  kill "$presentation_holder" 2>/dev/null || true
+  wait "$presentation_holder" 2>/dev/null || true
+  FM_STATE_OVERRIDE="$state" FM_STATUS_PRESENTATION_LOCK_TIMEOUT=1 \
+    "$DRAIN" > "$second_out" 2> "$second_err" || fail "presentation retry failed"
+  grep -F 'task.status: needs-decision [key=fixture]: presentation remains retriable' "$second_out" >/dev/null \
+    || fail "the next presentation pass did not surface the skipped status"
+
+  FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_lock_acquire_wait "$2"
+    printf "ready\n" > "$3"
+    exec sleep 30
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$state/.wake-queue.lock" "$dir/ack.ready" &
+  ack_holder=$!
+  i=0
+  while [ "$i" -lt 100 ] && [ ! -s "$dir/ack.ready" ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ -s "$dir/ack.ready" ] \
+    || { kill "$ack_holder" 2>/dev/null || true; fail "acknowledgement holder never acquired the queue lock"; }
+
+  rc=0
+  FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    shift
+    fm_run_timed 1 "$@"
+  ' _ "$ROOT/bin/fm-timeout-lib.sh" "$DRAIN" \
+    --ack-through "$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through \([0-9][0-9]*\) --recovery-generation [A-Za-z0-9._-][A-Za-z0-9._-]*$/\1/p' "$second_err")" \
+    --recovery-generation "$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through [0-9][0-9]* --recovery-generation \([A-Za-z0-9._-][A-Za-z0-9._-]*\)$/\1/p' "$second_err")" \
+    > "$dir/ack-held.out" 2> "$dir/ack-held.err" || rc=$?
+  [ "$rc" -eq 124 ] \
+    || { kill "$ack_holder" 2>/dev/null || true; fail "held acknowledgement lock did not retain blocking semantics (rc=$rc)"; }
+
+  kill "$ack_holder" 2>/dev/null || true
+  wait "$ack_holder" 2>/dev/null || true
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$replay_out" 2> "$replay_err" \
+    || fail "drain after the interrupted acknowledgement failed"
+  grep "$(printf '\tsignal\t')" "$replay_out" >/dev/null \
+    || fail "the held acknowledgement lock allowed a partial consume"
+  ack_drain_err "$state" "$replay_err" \
+    || fail "the intact wake could not be acknowledged after contention cleared"
+  [ ! -s "$state/.wake-queue" ] || fail "acknowledged presentation fixture remained queued"
+  pass "presentation lock waits are bounded and retriable without weakening acknowledgement atomicity"
+}
+
 # Drain-time historical annotation staleness: a turn-ended-only wake row must
 # not present an already-announced status line as a new update, while a status
 # file with unannounced bytes keeps its annotation and a direct status row is
@@ -1194,6 +1294,7 @@ test_historical_annotation_skips_announced_status() {
 }
 
 test_self_held_lock_reclaims_instead_of_deadlocking
+test_live_presentation_holder_is_deadlined_without_weakening_ack
 test_secondmate_foreign_queue_stall_is_one_shot_and_read_only
 test_secondmate_stall_marker_rejects_symlink
 test_acknowledged_stall_publication_survives_pre_marker_crash

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -1193,6 +1193,8 @@ test_live_presentation_holder_is_deadlined_without_weakening_ack() {
     "$queue_out" || true)
   [ "$advisory_count" -eq 1 ] \
     || { kill "$queue_holder" 2>/dev/null || true; fail "queue deadline did not emit exactly one holder advisory"; }
+  [ ! -s "$queue_err" ] \
+    || { kill "$queue_holder" 2>/dev/null || true; fail "queue deadline leaked helper-process diagnostics"; }
   if grep "$(printf '\tsignal\t')" "$queue_out" >/dev/null \
     || grep -F 'WAKE_ACK_REQUIRED:' "$queue_err" >/dev/null; then
     kill "$queue_holder" 2>/dev/null || true
@@ -1231,6 +1233,10 @@ test_live_presentation_holder_is_deadlined_without_weakening_ack() {
     "$first_out" || true)
   [ "$advisory_count" -eq 1 ] \
     || { kill "$presentation_holder" 2>/dev/null || true; fail "presentation deadline did not emit exactly one holder advisory"; }
+  if grep -v '^WAKE_ACK_REQUIRED:' "$first_err" | grep . >/dev/null; then
+    kill "$presentation_holder" 2>/dev/null || true
+    fail "presentation deadline leaked helper-process diagnostics"
+  fi
   grep "$(printf '\tsignal\t')" "$first_out" >/dev/null \
     || { kill "$presentation_holder" 2>/dev/null || true; fail "bounded presentation dropped the durable wake row"; }
   if grep -F 'task.status: needs-decision [key=fixture]' "$first_out" >/dev/null; then

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -1144,15 +1144,17 @@ test_self_held_lock_reclaims_instead_of_deadlocking() {
   pass "an abandoned same-process lock hold is reclaimed; a parent's live hold is not"
 }
 
-# A live-but-stuck status presenter must not strand the executable drain. The
+# A live-but-stuck presentation lock must not strand the executable drain. The
 # presentation remains retriable on the next pass, while the separate queue
 # mutation lock keeps its blocking all-or-nothing acknowledgement contract.
 test_live_presentation_holder_is_deadlined_without_weakening_ack() {
-  local dir state status first_out first_err second_out second_err replay_out replay_err
-  local presentation_holder ack_holder i start elapsed rc advisory_count
+  local dir state status queue_out queue_err first_out first_err second_out second_err replay_out replay_err
+  local queue_holder presentation_holder ack_holder i start elapsed rc advisory_count
   dir=$(make_case presentation-lock-deadline)
   state="$dir/state"
   status="$state/task.status"
+  queue_out="$dir/queue.out"
+  queue_err="$dir/queue.err"
   first_out="$dir/first.out"
   first_err="$dir/first.err"
   second_out="$dir/second.out"
@@ -1163,6 +1165,44 @@ test_live_presentation_holder_is_deadlined_without_weakening_ack() {
   printf 'needs-decision [key=fixture]: presentation remains retriable\n' > "$status"
   append_wake "$state" signal task.status "signal: $status" \
     || fail "could not seed the presentation-deadline wake"
+
+  FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_lock_acquire_wait "$2"
+    printf "ready\n" > "$3"
+    exec sleep 30
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$state/.wake-queue.lock" "$dir/queue.ready" &
+  queue_holder=$!
+  i=0
+  while [ "$i" -lt 100 ] && [ ! -s "$dir/queue.ready" ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ -s "$dir/queue.ready" ] \
+    || { kill "$queue_holder" 2>/dev/null || true; fail "queue holder never acquired its lock"; }
+
+  start=$(date +%s)
+  FM_STATE_OVERRIDE="$state" FM_STATUS_PRESENTATION_LOCK_TIMEOUT=1 \
+    "$DRAIN" > "$queue_out" 2> "$queue_err" \
+    || { kill "$queue_holder" 2>/dev/null || true; fail "bounded queue presentation drain failed"; }
+  elapsed=$(( $(date +%s) - start ))
+  [ "$elapsed" -le 4 ] \
+    || { kill "$queue_holder" 2>/dev/null || true; fail "queue lock delayed the drain for ${elapsed}s"; }
+  advisory_count=$(grep -Fc \
+    "WAKE DRAIN SKIPPED: queue lock remains held by live pid $queue_holder" \
+    "$queue_out" || true)
+  [ "$advisory_count" -eq 1 ] \
+    || { kill "$queue_holder" 2>/dev/null || true; fail "queue deadline did not emit exactly one holder advisory"; }
+  if grep "$(printf '\tsignal\t')" "$queue_out" >/dev/null \
+    || grep -F 'WAKE_ACK_REQUIRED:' "$queue_err" >/dev/null; then
+    kill "$queue_holder" 2>/dev/null || true
+    fail "contended queue lock allowed a partial drain"
+  fi
+  grep "$(printf '\tsignal\t')" "$state/.wake-queue" >/dev/null \
+    || { kill "$queue_holder" 2>/dev/null || true; fail "contended queue lock changed the durable wake"; }
+
+  kill "$queue_holder" 2>/dev/null || true
+  wait "$queue_holder" 2>/dev/null || true
 
   FM_STATE_OVERRIDE="$state" bash -c '
     . "$1"
@@ -1184,7 +1224,7 @@ test_live_presentation_holder_is_deadlined_without_weakening_ack() {
     "$DRAIN" > "$first_out" 2> "$first_err" \
     || { kill "$presentation_holder" 2>/dev/null || true; fail "bounded presentation drain failed"; }
   elapsed=$(( $(date +%s) - start ))
-  [ "$elapsed" -le 2 ] \
+  [ "$elapsed" -le 4 ] \
     || { kill "$presentation_holder" 2>/dev/null || true; fail "presentation lock delayed the drain for ${elapsed}s"; }
   advisory_count=$(grep -Fc \
     "STATUS PRESENTATION SKIPPED: lock remains held by live pid $presentation_holder" \


### PR DESCRIPTION
## Intent

Startup fix B: bounded acquire for presentation-path locks (drain, status-presentation) that skips a pass with an advisory line on a live holder, mutation-critical locks keep blocking semantics, ack unchanged

## What Changed

- Add bounded lock acquisition with safe ownership handoff for presentation-only wake drain paths.
- Skip contended queue or status presentation passes with live-holder PID advisories while keeping acknowledgement locks blocking and atomic.
- Document the deadline behavior and add regression coverage for bounded, retriable contention and malformed locks.

## Risk Assessment

✅ Low: The change is bounded to presentation-path acquisition, preserves blocking acknowledgement paths, and handles live, stale, and malformed lock states consistently.

## Testing

Targeted executable tests and a manual end-to-end CLI run confirmed both presentation locks time out cleanly with holder-specific advisories, skipped wakes remain retriable, malformed locks fail safely, and acknowledgement locking remains blocking and lossless.

<details>
<summary>Evidence: Bounded presentation-lock end-to-end CLI transcript</summary>

Source: [Bounded presentation-lock end-to-end CLI transcript](https://github.com/kunchenguid/firstmate/blob/022f9485d6df5567758c10f9119458f29c323861/.no-mistakes/evidence/fm/fm-startup-fix-b-presentation-lock-deadline-r1/presentation-lock-end-to-end.txt)

```text
FirstMate wake drain: bounded presentation-lock end-to-end transcript

$ FM_STATUS_PRESENTATION_LOCK_TIMEOUT=1 bin/fm-wake-drain.sh  # queue lock held by pid 37800
WAKE DRAIN SKIPPED: queue lock remains held by live pid 37800 after 1s; retry on the next drain.
Durable queue rows after skipped pass: 1

$ FM_STATUS_PRESENTATION_LOCK_TIMEOUT=1 bin/fm-wake-drain.sh  # status lock held by pid 41895
1788301350	1	signal	task.status	signal: ~/.no-mistakes/worktrees/52b07e9083e7/01M1FGAHY8FABW1NYTQAAXWY5X/.manual-presentation-lock.dCLmeZ/state/task.status
STATUS PRESENTATION SKIPPED: lock remains held by live pid 41895 after 1s; retry on the next drain.
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 1 --recovery-generation 37666.1788301350.kyFfzj
Durable queue rows after skipped status presentation: 1

$ FM_STATUS_PRESENTATION_LOCK_TIMEOUT=1 bin/fm-wake-drain.sh  # holder released; next pass
1788301350	1	signal	task.status	signal: ~/.no-mistakes/worktrees/52b07e9083e7/01M1FGAHY8FABW1NYTQAAXWY5X/.manual-presentation-lock.dCLmeZ/state/task.status
wake annotation: latest wake-EVENT observed at drain, not current state: task.status: needs-decision [key=fixture]: retried presentation is visible
OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):
task [key=fixture] needs-decision: retried presentation is visible
OPEN DECISIONS: close one by answering it: bin/fm-send.sh <task> --resolve-key <key> '<answer>'
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 1 --recovery-generation 37666.1788301350.kyFfzj

$ bin/fm-wake-drain.sh --ack-through 1 --recovery-generation 37666.1788301350.kyFfzj
Durable queue rows after acknowledgement: 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b7140f122fa0e6db313f7d0b700e5778d4d6bcb8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-wake-drain.sh:412` - Intent requires bounded acquisition for both presentation paths: “(drain, status-presentation)”. The initial drain still unconditionally calls `fm_lock_acquire_wait` before distinguishing acknowledgement mode. If a live process holds `.wake-queue.lock`, a normal no-ack startup drain blocks forever and emits no advisory. Use bounded acquisition for the no-ack presentation path while retaining blocking acquisition when `ACK_THROUGH` is set.
- ⚠️ `bin/fm-wake-lib.sh:977` - A timeout is always returned as live-holder contention, even when the lock is malformed or otherwise unrecoverable. For example, a regular file at `.status-presentation-lock` makes every acquire fail without a holder; after the deadline this returns 124 and the caller reports a fictitious live PID, while status presentation remains skipped indefinitely. Return 124 only after validating a numeric, currently live holder; report other acquisition failures as lock errors.

🔧 Fix: Distinguish malformed presentation locks from live contention
1 error still open:

- 🚨 `bin/fm-wake-drain.sh:414` - Intent requires “bounded acquire for presentation-path locks (drain, status-presentation)” while keeping mutation-critical and acknowledgement locking blocking. A normal no-ack drain still enters unconditional `fm_lock_acquire_wait &#34;$FM_WAKE_QUEUE_LOCK&#34;`; with a live holder it blocks forever before reaching the bounded status-presentation acquire, so no pass is skipped and no advisory is emitted. At this initial boundary, use bounded acquisition for no-ack presentation drains while retaining blocking acquisition when `ACK_THROUGH` is set.

🔧 Fix: Bound no-ack drain queue lock acquisition
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Focused execution of `test_live_presentation_holder_is_deadlined_without_weakening_ack` from `tests/fm-wake-queue.test.sh`</code>
- <code>Focused execution of `test_malformed_presentation_lock_reports_acquire_failure` from `tests/fm-wake-queue.test.sh`</code>
- `Manual CLI verification with live queue and status lock holders: confirmed bounded skip advisories, intact durable queue, next-pass presentation, and successful acknowledgement`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Annotate bounded lock output global
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
