### PR TITLE
ci: rebalance portable serial test shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,15 +129,15 @@ jobs:
   tests-portable-serial:
     name: Behavior portable serial ${{ matrix.shard }}
     runs-on: ubuntu-latest
-    # Measured whole remainder is ~42 min of serial work; the balanced shards
-    # are ~10.6 min each. Cap is a hang tripwire with roughly 2x margin, not the
-    # expected healthy end of the lane.
+    # Measured whole remainder is ~63 min of serial work; the balanced shards
+    # are ~12.7 min each. Cap is a hang tripwire with roughly 1.6x margin, not
+    # the expected healthy end of the lane.
     timeout-minutes: 20
     strategy:
       # Every shard reports so one failure never hides another shard's result.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -153,12 +153,20 @@ CHANGED_DEFAULT_TIMEOUT_SECS=900
 
 # How many separate-runner shards the portable serial remainder splits into.
 # One owner: CI lane names carry this count and are refused when they disagree.
-PORTABLE_SERIAL_SHARDS=4
+PORTABLE_SERIAL_SHARDS=5
 
 # Balance hint for a portable-serial script with no measured duration, close to
 # the measured per-script mean so a newly added test neither starves nor
 # overloads the shard it lands in.
-PORTABLE_SERIAL_DEFAULT_WEIGHT_MS=20000
+PORTABLE_SERIAL_DEFAULT_WEIGHT_MS=27000
+
+# Largest share of the serial lane allowed to run on the default weight above.
+# Hints are what keep the shards balanced, so once too much of the lane is
+# unmeasured the balance is guesswork and one shard can reach its CI job cap
+# while another sits idle. The coverage guard refuses past this share, which
+# leaves room for newly added tests while making a stale hint table fail loudly
+# instead of silently. docs/fm-test-portable-shards.md owns the refresh.
+PORTABLE_SERIAL_MAX_UNHINTED_PERCENT=15
 
 usage() {
   awk '
@@ -491,135 +499,165 @@ list_portable_serial() {
 }
 
 # Measured portable-serial script durations in milliseconds, from the CI timing
-# artifact recorded in docs/fm-test-portable-shards.md. These are balance hints
-# only: the shard partition stays complete and disjoint whatever they say, so a
-# stale hint costs balance rather than coverage. That doc owns the refresh
-# procedure.
+# artifacts recorded in docs/fm-test-portable-shards.md. Each value is the
+# slowest of several green runs, so the balance holds on a slow runner rather
+# than only on the fastest one measured. These are balance hints only: the shard
+# partition stays complete and disjoint whatever they say, so a stale hint costs
+# balance rather than coverage. That doc owns the refresh procedure.
 portable_serial_weight_hints() {
   cat <<'EOF'
-tests/fm-afk-inject-e2e.test.sh 35900
-tests/fm-afk-pi-herdr-return-e2e.test.sh 66
-tests/fm-afk-return.test.sh 3974
-tests/fm-ask-user-authority.test.sh 83
-tests/fm-backend-cmux-smoke.test.sh 30
-tests/fm-backend-cmux.test.sh 3351
-tests/fm-backend-herdr-focus-flash-e2e.test.sh 21
-tests/fm-backend-orca.test.sh 14681
-tests/fm-backend-tmux-smoke.test.sh 361
-tests/fm-backend-zellij-smoke.test.sh 22
-tests/fm-backend-zellij.test.sh 8297
-tests/fm-backend.test.sh 17169
-tests/fm-backlog-handoff.test.sh 4157
-tests/fm-bearings-board.test.sh 3385
-tests/fm-bearings-snapshot.test.sh 68659
-tests/fm-bootstrap-network-parallel.test.sh 8000
-tests/fm-bootstrap.test.sh 38417
-tests/fm-busy-adapter-wiring.test.sh 14880
-tests/fm-busy-state.test.sh 714
-tests/fm-calm-pi-extension.test.sh 464
-tests/fm-classify-decision-key.test.sh 928
-tests/fm-claude-stop-autoarm-live-e2e.test.sh 30
-tests/fm-claude-stop-autoarm.test.sh 60633
-tests/fm-cmux-claude-composer-live-e2e.test.sh 20
-tests/fm-codex-continuity-live-e2e.test.sh 19
-tests/fm-composer-matrix-live-e2e.test.sh 21
-tests/fm-control-relaunch.test.sh 31881
-tests/fm-control.test.sh 36712
-tests/fm-cursor-harness.test.sh 30071
-tests/fm-cursor-primary-live-e2e.test.sh 20
-tests/fm-cursor-primary.test.sh 52324
-tests/fm-daemon.test.sh 25834
-tests/fm-documentation-audiences.test.sh 642
-tests/fm-fleet-snapshot-view.test.sh 6995
-tests/fm-fleet-sync.test.sh 20194
-tests/fm-extension-binding.test.sh 35000
-tests/fm-gate-refuse.test.sh 4071
-tests/fm-gitignore-config.test.sh 63
-tests/fm-gotmp.test.sh 762
-tests/fm-grok-continuity-live-e2e.test.sh 19
+tests/fm-afk-inject-e2e.test.sh 35792
+tests/fm-afk-pi-herdr-return-e2e.test.sh 100
+tests/fm-afk-return.test.sh 1837
+tests/fm-ask-user-authority.test.sh 128
+tests/fm-backend-cmux-smoke.test.sh 33
+tests/fm-backend-cmux.test.sh 3657
+tests/fm-backend-herdr-focus-flash-e2e.test.sh 22
+tests/fm-backend-orca.test.sh 19253
+tests/fm-backend-tmux-smoke.test.sh 393
+tests/fm-backend-zellij-smoke.test.sh 23
+tests/fm-backend-zellij.test.sh 9418
+tests/fm-backend.test.sh 20061
+tests/fm-backlog-atomicity.test.sh 122256
+tests/fm-backlog-handoff.test.sh 52291
+tests/fm-bearings-board-render.test.sh 1528
+tests/fm-bearings-board.test.sh 4195
+tests/fm-bearings-snapshot.test.sh 79954
+tests/fm-bootstrap-network-parallel.test.sh 8214
+tests/fm-bootstrap.test.sh 25208
+tests/fm-branch-supervision.test.sh 5729
+tests/fm-busy-adapter-wiring.test.sh 17873
+tests/fm-busy-state.test.sh 2926
+tests/fm-calm-pi-extension.test.sh 256
+tests/fm-check-unregister.test.sh 481
+tests/fm-classify-corr-token.test.sh 38742
+tests/fm-classify-decision-key.test.sh 1167
+tests/fm-claude-stop-autoarm-live-e2e.test.sh 21
+tests/fm-claude-stop-autoarm.test.sh 60709
+tests/fm-cmux-claude-composer-live-e2e.test.sh 23
+tests/fm-codex-continuity-live-e2e.test.sh 21
+tests/fm-composer-matrix-live-e2e.test.sh 23
+tests/fm-control-relaunch.test.sh 48210
+tests/fm-control.test.sh 37798
+tests/fm-cursor-harness.test.sh 30103
+tests/fm-cursor-primary-live-e2e.test.sh 21
+tests/fm-cursor-primary.test.sh 54947
+tests/fm-daemon.test.sh 26870
+tests/fm-documentation-audiences.test.sh 732
+tests/fm-extension-binding.test.sh 7398
+tests/fm-fleet-snapshot-view.test.sh 8547
+tests/fm-fleet-sync.test.sh 37749
+tests/fm-gate-refuse.test.sh 4977
+tests/fm-gitignore-config.test.sh 62
+tests/fm-gotmp.test.sh 1310
+tests/fm-grok-continuity-live-e2e.test.sh 20
 tests/fm-grok-stop-live-e2e.test.sh 21
+tests/fm-guard-stale-banner.test.sh 11218
 tests/fm-harness-adapter-instructions-live-e2e.test.sh 20
-tests/fm-harness-adapter-references.test.sh 2
-tests/fm-guard-stale-banner.test.sh 11280
-tests/fm-harness-liveness-drift-live-e2e.test.sh 19
-tests/fm-herdr-session-cleanup.test.sh 14120
-tests/fm-herdr-submit-confirm-live-e2e.test.sh 20
-tests/fm-herdr-version-floor-live-e2e.test.sh 20
-tests/fm-inactive-reconcile.test.sh 41671
-tests/fm-kimi-harness.test.sh 15092
-tests/fm-lint-workflows.test.sh 744
-tests/fm-muse-harness.test.sh 27414
-tests/fm-muse-signals-live-e2e.test.sh 21
-tests/fm-on.test.sh 8602
-tests/fm-opencode-primary-live-e2e.test.sh 22
-tests/fm-operational-input.test.sh 246
-tests/fm-peek-remote.test.sh 848
-tests/fm-pending-reply.test.sh 19488
-tests/fm-pi-primary-live-e2e.test.sh 41
-tests/fm-pi-watch-extension.test.sh 17979
-tests/fm-pr-check-security.test.sh 250417
-tests/fm-procevent-when.test.sh 15249
-tests/fm-procevent.test.sh 53142
-tests/fm-project-origin.test.sh 105
-tests/fm-public-followup.test.sh 36301
-tests/fm-quota-array-dispatch-live-e2e.test.sh 18
-tests/fm-remote-backlog-handoff.test.sh 20389
-tests/fm-remote-doctor.test.sh 4705
-tests/fm-remote-entrypoint.test.sh 98
-tests/fm-remote-job-orphan-reap.test.sh 2903
-tests/fm-remote-job.test.sh 48068
-tests/fm-remote-reply.test.sh 40906
-tests/fm-remote-secondmate-lifecycle-e2e.test.sh 170240
-tests/fm-remote-secondmate-parent-binding.test.sh 13064
-tests/fm-remote-secondmate-trace-context.test.sh 39927
-tests/fm-secondmate-harness.test.sh 123471
-tests/fm-secondmate-lifecycle-e2e.test.sh 6539
-tests/fm-secondmate-liveness.test.sh 16365
-tests/fm-secondmate-safety.test.sh 49011
-tests/fm-secondmate-sync.test.sh 29236
-tests/fm-send-remote-delivery.test.sh 4892
-tests/fm-send-resolve-key.test.sh 13450
-tests/fm-send-secondmate-marker-herdr-e2e.test.sh 45
-tests/fm-send-secondmate-marker.test.sh 4439
-tests/fm-session-lock-ancestry.test.sh 1205
-tests/fm-session-start.test.sh 144836
-tests/fm-sessionstart-hook-live-e2e.test.sh 21
-tests/fm-sessionstart-instruction-refresh-live-e2e.test.sh 21
-tests/fm-sessionstart-nudge.test.sh 26684
-tests/fm-shared-captain-inheritance.test.sh 10672
-tests/fm-spawn-dispatch-profile.test.sh 57765
-tests/fm-spawn-pool-base-freshen.test.sh 13257
-tests/fm-spawn-worktree-settle.test.sh 4828
-tests/fm-startup-memory-budget.test.sh 6550
-tests/fm-startup-network.test.sh 48888
-tests/fm-stow-cascade.test.sh 2986
-tests/fm-subagent-pretool-check.test.sh 1066
-tests/fm-supervision-events.test.sh 1431
-tests/fm-tangle-guard.test.sh 8364
-tests/fm-task-delivery.test.sh 2414
-tests/fm-teardown-endpoint-safety.test.sh 7295
-tests/fm-teardown.test.sh 87400
-tests/fm-test-fixture-cleanup.test.sh 532
-tests/fm-test-fixtures.test.sh 1045
-tests/fm-test-isolation-proof.test.sh 451
-tests/fm-tmux-agent-liveness.test.sh 4065
-tests/fm-tool-update-check.test.sh 12846
-tests/fm-trace-context-lib.test.sh 194
-tests/fm-trace-context-spawn.test.sh 35325
-tests/fm-turnend-guard.test.sh 34915
-tests/fm-update.test.sh 5280
-tests/fm-vendor-auth-probe.test.sh 43243
-tests/fm-wake-daemon-lifecycle-e2e.test.sh 6219
-tests/fm-wake-drain-open-decisions-cursor.test.sh 17357
-tests/fm-wake-drain-open-decisions.test.sh 11300
-tests/fm-wake-drain-unread-status.test.sh 25214
-tests/fm-wake-queue.test.sh 30887
-tests/fm-watch-arm.test.sh 53598
-tests/fm-watch-checkpoint.test.sh 5293
-tests/fm-watch-recovery-loop.test.sh 58721
-tests/fm-watch-triage.test.sh 142409
-tests/fm-watcher-lock.test.sh 54364
+tests/fm-harness-adapter-references.test.sh 55
+tests/fm-harness-liveness-drift-live-e2e.test.sh 21
+tests/fm-herdr-session-cleanup.test.sh 6704
+tests/fm-herdr-submit-confirm-live-e2e.test.sh 23
+tests/fm-herdr-version-floor-live-e2e.test.sh 23
+tests/fm-home-summary-refresh.test.sh 34793
+tests/fm-inactive-reconcile.test.sh 41826
+tests/fm-kimi-harness.test.sh 18015
+tests/fm-lint-workflows.test.sh 855
+tests/fm-muse-harness.test.sh 55572
+tests/fm-muse-signals-live-e2e.test.sh 23
+tests/fm-no-mistakes-required.test.sh 370
+tests/fm-on.test.sh 11692
+tests/fm-opencode-primary-live-e2e.test.sh 21
+tests/fm-operational-input.test.sh 231
+tests/fm-peek-remote.test.sh 1018
+tests/fm-pending-reply.test.sh 24679
+tests/fm-pi-branch-extension.test.sh 22239
+tests/fm-pi-branch-live-e2e.test.sh 56
+tests/fm-pi-primary-live-e2e.test.sh 20
+tests/fm-pi-watch-extension.test.sh 42970
+tests/fm-pr-check-security.test.sh 160475
+tests/fm-procevent-quota.test.sh 1949
+tests/fm-procevent-when.test.sh 17392
+tests/fm-procevent.test.sh 69715
+tests/fm-project-origin.test.sh 137
+tests/fm-public-followup.test.sh 196745
+tests/fm-quota-array-dispatch-live-e2e.test.sh 21
+tests/fm-quota-choose.test.sh 1461
+tests/fm-remote-backlog-handoff.test.sh 41432
+tests/fm-remote-doctor.test.sh 5198
+tests/fm-remote-entrypoint.test.sh 132
+tests/fm-remote-job-orphan-reap.test.sh 2972
+tests/fm-remote-job.test.sh 59603
+tests/fm-remote-reply.test.sh 101690
+tests/fm-remote-secondmate-lifecycle-e2e.test.sh 209631
+tests/fm-remote-secondmate-parent-binding.test.sh 29562
+tests/fm-remote-secondmate-trace-context.test.sh 67096
+tests/fm-remote-transport-lanes.test.sh 63140
+tests/fm-secondmate-harness.test.sh 151589
+tests/fm-secondmate-lifecycle-e2e.test.sh 8793
+tests/fm-secondmate-liveness.test.sh 18146
+tests/fm-secondmate-reconcile.test.sh 62726
+tests/fm-secondmate-safety.test.sh 57689
+tests/fm-secondmate-sync.test.sh 17183
+tests/fm-send-inbox-doorbell-live-e2e.test.sh 22
+tests/fm-send-inbox.test.sh 38956
+tests/fm-send-remote-delivery.test.sh 27686
+tests/fm-send-resolve-key.test.sh 19619
+tests/fm-send-secondmate-marker-herdr-e2e.test.sh 51
+tests/fm-send-secondmate-marker.test.sh 6252
+tests/fm-session-lock-ancestry.test.sh 1414
+tests/fm-session-start.test.sh 156952
+tests/fm-sessionstart-hook-live-e2e.test.sh 20
+tests/fm-sessionstart-instruction-refresh-live-e2e.test.sh 22
+tests/fm-sessionstart-nudge.test.sh 66194
+tests/fm-shared-captain-inheritance.test.sh 6108
+tests/fm-spawn-dispatch-profile.test.sh 63996
+tests/fm-spawn-pool-base-freshen.test.sh 34920
+tests/fm-spawn-worktree-settle.test.sh 5687
+tests/fm-startup-memory-budget.test.sh 6964
+tests/fm-startup-network.test.sh 54700
+tests/fm-stow-cascade.test.sh 3101
+tests/fm-subagent-pretool-check.test.sh 1030
+tests/fm-supervision-events.test.sh 719
+tests/fm-tangle-guard.test.sh 9662
+tests/fm-task-delivery.test.sh 5952
+tests/fm-task-inbox.test.sh 25369
+tests/fm-teardown-endpoint-safety.test.sh 4620
+tests/fm-teardown.test.sh 97603
+tests/fm-test-fixture-cleanup.test.sh 915
+tests/fm-test-fixtures.test.sh 151
+tests/fm-test-isolation-proof.test.sh 2567
+tests/fm-tmux-agent-liveness.test.sh 1516
+tests/fm-tool-update-check.test.sh 14176
+tests/fm-trace-context-lib.test.sh 209
+tests/fm-trace-context-spawn.test.sh 44702
+tests/fm-turnend-guard.test.sh 42565
+tests/fm-update.test.sh 5212
+tests/fm-vendor-auth-probe.test.sh 43316
+tests/fm-voice-relay.test.sh 28699
+tests/fm-wake-daemon-lifecycle-e2e.test.sh 7381
+tests/fm-wake-drain-open-decisions-cursor.test.sh 20629
+tests/fm-wake-drain-open-decisions.test.sh 6240
+tests/fm-wake-drain-unread-status.test.sh 35078
+tests/fm-wake-queue.test.sh 56674
+tests/fm-watch-arm.test.sh 58528
+tests/fm-watch-checkpoint.test.sh 5779
+tests/fm-watch-recovery-loop.test.sh 58731
+tests/fm-watch-triage.test.sh 262626
+tests/fm-watcher-lock.test.sh 88554
 EOF
+}
+
+# The portable-serial scripts with no measured hint, one per line. These fall
+# back to PORTABLE_SERIAL_DEFAULT_WEIGHT_MS, so they are balanced on a guess
+# rather than on evidence; the coverage guard bounds how many there may be.
+portable_serial_unhinted() {
+  local tmp
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-unhinted.XXXXXX") || return 1
+  portable_serial_weight_hints | awk 'NF { print $1 }' | LC_ALL=C sort -u >"$tmp/hinted"
+  list_portable_serial | LC_ALL=C sort -u >"$tmp/serial"
+  comm -23 "$tmp/serial" "$tmp/hinted"
+  rm -rf "$tmp"
 }
 
 portable_serial_weight_for() {
@@ -749,7 +787,7 @@ select_lane() {
 }
 
 run_coverage_guard() {
-  local tmp missing extra a b shard
+  local tmp missing extra a b shard unhinted serial_total
   local -a saved_scripts=()
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-coverage.XXXXXX")
 
@@ -852,6 +890,23 @@ run_coverage_guard() {
     return 1
   fi
 
+  # Hint drift is what makes a balanced-looking partition run unbalanced: the
+  # shards are packed from hints, so every unmeasured script is balanced on a
+  # guess and enough of them let one shard reach its CI job cap while another
+  # runner sits idle. Bound the unmeasured share here rather than waiting for a
+  # shard to time out.
+  portable_serial_unhinted >"$tmp/unhinted"
+  unhinted=$(wc -l <"$tmp/unhinted" | tr -d ' ')
+  serial_total=$(wc -l <"$tmp/serial" | tr -d ' ')
+  if [ "$serial_total" -gt 0 ] &&
+    [ "$((unhinted * 100))" -gt "$((serial_total * PORTABLE_SERIAL_MAX_UNHINTED_PERCENT))" ]; then
+    log "coverage guard: $unhinted of $serial_total portable serial scripts have no measured duration hint (max ${PORTABLE_SERIAL_MAX_UNHINTED_PERCENT}%)"
+    log "refresh the hints from a green run's timing artifacts: docs/fm-test-portable-shards.md"
+    cat "$tmp/unhinted" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+
   if [ -x "$ROOT/bin/fm-test-isolation-proof.sh" ]; then
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
@@ -862,11 +917,12 @@ run_coverage_guard() {
     fi
   fi
 
-  printf 'FM_TEST_COVERAGE ok total=%s parallel=%s serial=%s serial_shards=%s herdr=%s\n' \
+  printf 'FM_TEST_COVERAGE ok total=%s parallel=%s serial=%s serial_shards=%s serial_unhinted=%s herdr=%s\n' \
     "$(wc -l <"$tmp/all" | tr -d ' ')" \
     "$(wc -l <"$tmp/shards_union" | tr -d ' ')" \
     "$(wc -l <"$tmp/serial" | tr -d ' ')" \
     "$PORTABLE_SERIAL_SHARDS" \
+    "$unhinted" \
     "$(wc -l <"$tmp/herdr" | tr -d ' ')"
   rm -rf "$tmp"
   return 0

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -64,7 +64,8 @@ Each shard is still strictly serial in itself, and separate runners mean no two 
 `.github/workflows/ci.yml` derives the same `n` from `strategy.job-total` rather than a literal, so changing the shard count in either file without the other fails the lane loudly instead of leaving part of the required suite unrun.
 
 Assignment is longest-processing-time bin packing over per-script duration hints embedded in `bin/fm-test-run.sh`.
-The hints are the slowest measurement of each script across the `fm-test-timing-portable-serial-*` artifacts of three green CI runs on 2026-09-01, [33558082172](https://github.com/kunchenguid/firstmate/actions/runs/33558082172), [33523597838](https://github.com/kunchenguid/firstmate/actions/runs/33523597838), and [33463326167](https://github.com/kunchenguid/firstmate/actions/runs/33463326167), where the lane ran 139 scripts in 3809887 ms of serial work.
+The hints are the slowest measurement of each of the lane's 139 scripts across the `fm-test-timing-portable-serial-*` artifacts of three green CI runs on 2026-09-01, [33558082172](https://github.com/kunchenguid/firstmate/actions/runs/33558082172), [33523597838](https://github.com/kunchenguid/firstmate/actions/runs/33523597838), and [33463326167](https://github.com/kunchenguid/firstmate/actions/runs/33463326167).
+Those per-script maxima total 3809887 ms of conservative balance weight.
 Taking the slowest of several runs rather than a single run keeps the balance honest on a slow runner: individual scripts varied by up to 20% between those three runs.
 A script with no hint gets the conservative `PORTABLE_SERIAL_DEFAULT_WEIGHT_MS` default.
 Hints only affect balance: the coverage guard keeps the partition complete and disjoint whatever they say, so a stale hint costs a slower shard rather than lost coverage.

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -64,36 +64,48 @@ Each shard is still strictly serial in itself, and separate runners mean no two 
 `.github/workflows/ci.yml` derives the same `n` from `strategy.job-total` rather than a literal, so changing the shard count in either file without the other fails the lane loudly instead of leaving part of the required suite unrun.
 
 Assignment is longest-processing-time bin packing over per-script duration hints embedded in `bin/fm-test-run.sh`.
-The hints came from the `fm-test-timing-portable-serial-*` artifacts of green CI run [32491999845](https://github.com/kunchenguid/firstmate/actions/runs/32491999845) on 2026-08-21, where the lane ran 116 scripts in 2541548 ms of serial work.
-`tests/fm-tool-update-check.test.sh` did not exist on that run, so its 12846 ms hint comes from the shard 3 artifact of run [32461816719](https://github.com/kunchenguid/firstmate/actions/runs/32461816719), which is the first run that measured it.
+The hints are the slowest measurement of each script across the `fm-test-timing-portable-serial-*` artifacts of three green CI runs on 2026-09-01, [33558082172](https://github.com/kunchenguid/firstmate/actions/runs/33558082172), [33523597838](https://github.com/kunchenguid/firstmate/actions/runs/33523597838), and [33463326167](https://github.com/kunchenguid/firstmate/actions/runs/33463326167), where the lane ran 139 scripts in 3809887 ms of serial work.
+Taking the slowest of several runs rather than a single run keeps the balance honest on a slow runner: individual scripts varied by up to 20% between those three runs.
 A script with no hint gets the conservative `PORTABLE_SERIAL_DEFAULT_WEIGHT_MS` default.
 Hints only affect balance: the coverage guard keeps the partition complete and disjoint whatever they say, so a stale hint costs a slower shard rather than lost coverage.
 Balance is still worth keeping current, because enough unmeasured scripts let one shard carry more than twice another shard's real work and reach the job cap while another runner sits idle.
-Refresh the hints whenever the serial lane gains scripts, rather than waiting for a shard to time out.
+That is not hypothetical: by 2026-09-01 the lane had grown from 116 to 139 scripts and from ~42 to ~63 minutes, 17 scripts were still unmeasured, and several hints were low by 2-5x, so shard 3 of 4 ran 17-20 minutes against its 20-minute cap while shard 1 ran 11.5 minutes and run [33574154856](https://github.com/kunchenguid/firstmate/actions/runs/33574154856) timed out seconds after a passing test.
+`bin/fm-test-run.sh --check-coverage` now reports the unmeasured share as `serial_unhinted=` and refuses past `PORTABLE_SERIAL_MAX_UNHINTED_PERCENT`, so hint drift fails the coverage guard instead of silently pushing one shard into its job cap.
+Refresh the hints whenever the serial lane gains scripts, rather than waiting for that bound to trip.
 
 | Lane | Script count | Estimated duration |
 |---|---:|---:|
-| `portable-serial-1of4` | 29 | 638602 ms (~638.6 s) |
-| `portable-serial-2of4` | 28 | 638594 ms (~638.6 s) |
-| `portable-serial-3of4` | 30 | 638607 ms (~638.6 s) |
-| `portable-serial-4of4` | 30 | 638591 ms (~638.6 s) |
+| `portable-serial-1of5` | 27 | 761980 ms (~12.70 min) |
+| `portable-serial-2of5` | 27 | 761972 ms (~12.70 min) |
+| `portable-serial-3of5` | 28 | 761968 ms (~12.70 min) |
+| `portable-serial-4of5` | 28 | 761984 ms (~12.70 min) |
+| `portable-serial-5of5` | 29 | 761983 ms (~12.70 min) |
 | imbalance | | 16 ms |
 
-The single longest script, `tests/fm-pr-check-security.test.sh` at 250417 ms, is the floor for any shard count.
+Replaying that partition against each of the three source runs' real per-script durations puts the worst shard at 12.54 min, 63% of the 20-minute job cap.
 
-Refresh the hints by downloading the per-shard timing artifacts from a green CI run, replacing the `portable_serial_weight_hints` table in `bin/fm-test-run.sh` with the measured `path`/`duration_ms` pairs, and updating the table above:
+The single longest script, `tests/fm-watch-triage.test.sh` at 262626 ms, is the floor for any shard count.
+
+Refresh the hints by downloading the per-shard timing artifacts from several green CI runs, replacing the `portable_serial_weight_hints` table in `bin/fm-test-run.sh` with the slowest measured `duration_ms` per `path`, and updating the table above:
 
 ```sh
-gh run download <run-id> -R kunchenguid/firstmate --pattern 'fm-test-timing-portable-serial-*' -D /tmp/fm-serial
-jq -r '.scripts[] | [.path, .duration_ms] | @tsv' /tmp/fm-serial/*.json | LC_ALL=C sort
+for run in <run-id> <run-id> <run-id>; do
+  gh run download "$run" -R kunchenguid/firstmate --pattern 'fm-test-timing-portable-serial-*' -D "/tmp/fm-serial/$run"
+done
+jq -r '.scripts[] | [.path, .duration_ms] | @tsv' /tmp/fm-serial/*/*.json \
+  | awk -F'\t' '$2 > m[$1] { m[$1] = $2 } END { for (p in m) print p, m[p] }' \
+  | LC_ALL=C sort
 bin/fm-test-run.sh --check-coverage
 ```
+
+A timed-out shard uploads no artifact, so pick runs where every serial shard is green or the lane's slowest scripts go unmeasured in exactly the shard that needs them most.
 
 ## Coverage guard
 
 `bin/fm-test-run.sh --check-coverage` verifies that both parallel lanes partition the proven-isolated set.
 It also verifies that the parallel lanes, portable serial lane, and real-Herdr family are disjoint and cover every `tests/*.test.sh` script.
 It separately verifies that the portable serial CI shards are non-empty, disjoint, and together equal the portable serial lane.
+It reports the unmeasured serial share as `serial_unhinted=` and refuses when that share exceeds `PORTABLE_SERIAL_MAX_UNHINTED_PERCENT`, so the shards stay balanced on evidence rather than on the default weight.
 
 ## Timing artifacts
 
@@ -111,7 +123,7 @@ Portable shards, each portable serial shard, and the Herdr lane upload runner-ge
 | Lane | Bound | Rationale |
 |---|---|---|
 | portable parallel 1/2 | job `timeout-minutes: 10` | The measured shard sums are about three minutes and the timeout is a hang tripwire. |
-| portable serial 1-4 | job `timeout-minutes: 20` | Each balanced shard is about eleven minutes of measured script time, leaving roughly 2x hang-tripwire margin for job setup and runner-speed spread. |
+| portable serial 1-5 | job `timeout-minutes: 20` | Each balanced shard is about 12.7 minutes of measured script time, leaving roughly 1.6x hang-tripwire margin for job setup and runner-speed spread. |
 | Herdr | family-run step `timeout-minutes: 20`; job `timeout-minutes: 75` backstop | Healthy runs finish around 7 minutes, so the step bound is the hang tripwire (cleanup and timing artifacts still upload) while the job cap stays a last-resort backstop. |
 
 Timeouts are hang tripwires rather than expected healthy durations.

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -712,6 +712,31 @@ test_portable_serial_shards_partition_the_serial_lane() {
   pass "portable serial shards are a deterministic disjoint cover of the serial lane"
 }
 
+test_portable_serial_hint_coverage_is_reported_and_bounded() {
+  local out serial unhinted
+  # Shards are packed from measured duration hints, so an unmeasured script is
+  # placed on a guess. Enough of them and the partition still looks balanced by
+  # script count while one shard carries far more real work than another and
+  # reaches its CI job cap. The coverage guard therefore reports the unmeasured
+  # share and refuses past its bound; assert that contract is live rather than
+  # trusting the hint table to stay fresh on its own.
+  out=$("$RUNNER" --check-coverage)
+  assert_contains "$out" "serial_unhinted=" "coverage guard must report the unmeasured serial share"
+  serial=$(printf '%s\n' "$out" | sed -n 's/.*[^_]serial=\([0-9][0-9]*\).*/\1/p')
+  unhinted=$(printf '%s\n' "$out" | sed -n 's/.*serial_unhinted=\([0-9][0-9]*\).*/\1/p')
+  [ -n "$serial" ] && [ -n "$unhinted" ] \
+    || fail "coverage summary must carry numeric serial counts: $out"
+  [ "$serial" -gt 0 ] || fail "portable serial lane must be non-empty, got $serial"
+  [ "$unhinted" -le "$serial" ] \
+    || fail "unmeasured count $unhinted exceeds the serial lane size $serial"
+  # 15% is the guard's own bound; staying well inside it is what keeps the
+  # balance evidence-based. Refresh from a green run's timing artifacts when
+  # this trips (docs/fm-test-portable-shards.md).
+  [ "$((unhinted * 100))" -le "$((serial * 15))" ] \
+    || fail "$unhinted of $serial portable serial scripts lack a measured hint; refresh them"
+  pass "coverage guard reports and bounds the unmeasured portable serial share"
+}
+
 test_portable_serial_shard_lane_refusals() {
   local tmp count rc other
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-shard-lane.XXXXXX")
@@ -1185,6 +1210,7 @@ test_fail_on_gate_skip_token
 test_exclude_family
 test_portable_shard_union_and_coverage_guard
 test_portable_serial_shards_partition_the_serial_lane
+test_portable_serial_hint_coverage_is_reported_and_bounded
 test_portable_serial_shard_lane_refusals
 test_jobs_requires_proven_isolated
 test_jobs_admits_a_concurrent_safe_family


### PR DESCRIPTION
## Intent

Fix the over-budget CI serial-3 shard AT ITS CAUSE, with measured evidence; a blind timeout bump was explicitly ruled out as unacceptable.

Problem: the 'Behavior portable serial 3' CI shard ran ~20m12s against its timeout-minutes: 20 budget and timed out 1-3s after a passing test, on branches and on main alike (run 33574154856). Not a hang, not a cancellation - simply over its allowance, intermittently blocking every PR's path to clean-green.

Required approach, followed in order: (1) MEASURE first - determine exactly which behavior tests the serial-3 shard runs, their individual runtimes, and the shard total, and do the same for serial shards 1, 2 and 4 to expose the imbalance. (2) THEN fix the cause, choosing the cleaner of rebalancing the shards so no shard sits near its budget, or raising shard 3's timeout-minutes ONLY with the measured runtime and explicit headroom recorded in the PR body. Rebalancing was preferred because the imbalance was the real cause.

Measurement performed: per-shard test-step wall times were read from the CI job timings and the uploaded fm-test-timing-portable-serial-* artifacts of three green runs (33558082172, 33523597838, 33463326167). Shard 1 ran 11.3-11.7 min, shard 2 12.5-14.5 min, shard 3 17.3-19.7 min, shard 4 15.2-17.1 min. Shard 3's timed-out step in run 33574154856 ran 20m06s with only ~6s of setup.

Diagnosed cause: shards are packed longest-processing-time from per-script duration hints embedded in bin/fm-test-run.sh. Those hints were last measured on 2026-08-21 at 116 scripts; the lane has since grown to 139 scripts and from ~42 to ~63 minutes. 17 scripts had no hint at all and fell back to the 20s PORTABLE_SERIAL_DEFAULT_WEIGHT_MS default, and several existing hints were low by 2-5x (fm-watch-triage hinted 142409 ms vs 262626 ms measured; fm-public-followup 36301 ms vs 196745 ms). So the partition looked perfectly balanced in hint space at 734.6s per shard while really running 11.5/13.6/18.8/16.5 minutes. The existing tests asserted script-COUNT balance, which stayed normal (35 of 139 scripts on shard 3) and hid the duration skew.

Deliberate decisions a reviewer should not re-litigate:
- timeout-minutes stays 20. It was deliberately NOT raised; the fix is the rebalance.
- Hints were refreshed from THREE green runs taking the SLOWEST measurement per script, not a single run, because individual scripts varied up to 20% between runs and the balance must hold on a slow runner. The documented refresh procedure in docs/fm-test-portable-shards.md was updated to match and was verified to reproduce the committed table exactly.
- The shard count was deliberately raised from 4 to 5. At 4 shards the refreshed partition still puts the worst shard at 15.7 min (78% of cap) on a lane that is actively growing, which does not satisfy the requirement that no shard sit near its budget. At 5 shards, replaying the partition against the three runs' real per-script durations puts the worst shard at 12.54 min = 63% of the 20-minute cap with 60% headroom, and the serial lane's wall-clock critical path drops from ~20 to ~12.5 min. The shard count is a single constant plus the ci.yml matrix, which already cross-validate via strategy.job-total, so this is a parameter change and not new machinery.
- PORTABLE_SERIAL_DEFAULT_WEIGHT_MS was moved 20000 -> 27000 to track the new measured per-script mean (27409 ms), per its own comment.
- A drift bound was added deliberately: --check-coverage now reports serial_unhinted= and refuses past PORTABLE_SERIAL_MAX_UNHINTED_PERCENT (15%). This recurrence has now happened twice (docs record the same timeout at PR 1495), and the repo's own coding guidelines prefer deterministic enforcement over relying on agent memory for critical infrastructure. The refusal path was verified by dropping 25 hints: exit 1 naming the count, the bound, the refresh doc, and the offending scripts. It currently reports serial_unhinted=0.

Constraints that were required and honored: do not change what any test asserts or which tests run - only how they are partitioned across shards and/or the shard timeout budget. This edits firstmate SHARED, TRACKED material (.github/workflows/ and bin/), so .agents/skills/firstmate-coding-guidelines/SKILL.md was read and followed. Keep any shell bash-3.2-safe, and bin/fm-timeout-lib.sh stays the single owner of bounded execution. Every commit is authored with NO co-author / Co-Authored-By trailer.

Acceptance the PR must meet: the PR body records the measured per-shard runtimes (all four serial shards), which approach was taken (rebalance vs raise) and why, and the resulting headroom so no shard sits at its budget; and the serial shards complete within budget with headroom on a CI run on this branch.

Verification already run locally: bin/fm-lint.sh clean, bin/fm-doc-audience-check.sh clean, tests/fm-test-run.test.sh 26/26 pass, --check-coverage reports total=175 parallel=24 serial=139 serial_shards=5 serial_unhinted=0 herdr=12.

## What Changed

- Refresh serial-test duration hints from the slowest per-script measurements across three green runs; the former four shards measured 11.3–11.7, 12.5–14.5, 17.3–19.7, and 15.2–17.1 minutes.
- Rebalance the lane from four to five shards while retaining the 20-minute timeout. Replay against measured runtimes puts the worst shard at 12.54 minutes—63% of the cap, leaving 7.46 minutes of headroom—rather than raising the timeout around the imbalance.
- Raise the default unmeasured-script weight to 27 seconds and make coverage checks report and enforce a 15% maximum unhinted share, with tests and refresh documentation for the new guard.

## Risk Assessment

✅ Low: The change is well-bounded, preserves complete test coverage, aligns the five-shard workflow and runner configuration, and produces evenly balanced measured weights with substantial timeout headroom.

## Testing

The initial bounded runner-test attempt timed out after the shard-focused cases had passed, and a longer targeted rerun completed successfully; coverage reports 139 serial tests across five disjoint shards with zero unhinted scripts, the drift refusal works end-to-end, and replaying three green CI timing sets puts the worst new shard at 12.54 minutes with 59.5% runtime headroom. Reviewer-visible replay, refusal, and normalized workflow artifacts were captured; no branch CI run existed yet, so actual branch-run confirmation remains for the outer mandatory CI phase.

<details>
<summary>Evidence: Measured three-run serial shard replay and headroom</summary>

Source: [Measured three-run serial shard replay and headroom](https://github.com/kunchenguid/firstmate/blob/8baeaf8c0be3c4073d8b3b9b3e3267f81ad779c8/.no-mistakes/evidence/fm/fm-ci-serial-shard-budget-rebalance-r1/serial-shard-replay.txt)

```text
Portable serial shard replay against three green CI timing-artifact runs
Current executable interface: bin/fm-test-run.sh --list --lane portable-serial-<k>of5
Unchanged CI timeout: 20.00 min (1,200,000 ms)

run 33558082172: original 4-shard script totals = 11.63m, 13.68m, 19.28m, 17.11m
run 33558082172: replayed 5-shard totals        = 12.25m, 11.99m, 12.54m, 12.34m, 12.45m
run 33558082172: worst replay shard             = 12.54m (62.7% of cap; 59.5% runtime headroom)

run 33523597838: original 4-shard script totals = 11.68m, 12.46m, 19.67m, 15.18m
run 33523597838: replayed 5-shard totals        = 11.84m, 11.30m, 12.07m, 11.74m, 11.93m
run 33523597838: worst replay shard             = 12.07m (60.3% of cap; 65.7% runtime headroom)

run 33463326167: original 4-shard script totals = 11.33m, 14.52m, 17.33m, 17.09m
run 33463326167: replayed 5-shard totals        = 11.96m, 12.22m, 11.54m, 12.49m, 11.92m
run 33463326167: worst replay shard             = 12.49m (62.5% of cap; 60.1% runtime headroom)

Worst across all replayed runs: run 33558082172, shard 3, 12.54m, 62.7% of cap, 59.5% runtime headroom.
Coverage check: every current shard script had a real timing in every source run.
```
</details>
<details>
<summary>Evidence: Unhinted-duration drift refusal</summary>

Source: [Unhinted-duration drift refusal](https://github.com/kunchenguid/firstmate/blob/8baeaf8c0be3c4073d8b3b9b3e3267f81ad779c8/.no-mistakes/evidence/fm/fm-ci-serial-shard-budget-rebalance-r1/unhinted-drift-refusal.txt)

```text
fm-test-run: coverage guard: 25 of 164 portable serial scripts have no measured duration hint (max 15%)
fm-test-run: refresh the hints from a green run's timing artifacts: docs/fm-test-portable-shards.md
tests/fm-unhinted-drift-evidence-01.test.sh
tests/fm-unhinted-drift-evidence-02.test.sh
tests/fm-unhinted-drift-evidence-03.test.sh
tests/fm-unhinted-drift-evidence-04.test.sh
tests/fm-unhinted-drift-evidence-05.test.sh
tests/fm-unhinted-drift-evidence-06.test.sh
tests/fm-unhinted-drift-evidence-07.test.sh
tests/fm-unhinted-drift-evidence-08.test.sh
tests/fm-unhinted-drift-evidence-09.test.sh
tests/fm-unhinted-drift-evidence-10.test.sh
tests/fm-unhinted-drift-evidence-11.test.sh
tests/fm-unhinted-drift-evidence-12.test.sh
tests/fm-unhinted-drift-evidence-13.test.sh
tests/fm-unhinted-drift-evidence-14.test.sh
tests/fm-unhinted-drift-evidence-15.test.sh
tests/fm-unhinted-drift-evidence-16.test.sh
tests/fm-unhinted-drift-evidence-17.test.sh
tests/fm-unhinted-drift-evidence-18.test.sh
tests/fm-unhinted-drift-evidence-19.test.sh
tests/fm-unhinted-drift-evidence-20.test.sh
tests/fm-unhinted-drift-evidence-21.test.sh
tests/fm-unhinted-drift-evidence-22.test.sh
tests/fm-unhinted-drift-evidence-23.test.sh
tests/fm-unhinted-drift-evidence-24.test.sh
tests/fm-unhinted-drift-evidence-25.test.sh

exit_code=1
```
</details>
<details>
<summary>Evidence: Normalized CI serial matrix configuration</summary>

Source: [Normalized CI serial matrix configuration](https://github.com/kunchenguid/firstmate/blob/8baeaf8c0be3c4073d8b3b9b3e3267f81ad779c8/.no-mistakes/evidence/fm/fm-ci-serial-shard-budget-rebalance-r1/ci-serial-matrix.json)

```text
{
  "job_name": "Behavior portable serial ${{ matrix.shard }}",
  "timeout_minutes": 20,
  "matrix_shards": [
    1,
    2,
    3,
    4,
    5
  ],
  "fail_fast": false,
  "lane_env": "portable-serial-${{ matrix.shard }}of${{ strategy.job-total }}"
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f8dc72fa35a3346b8ec6cf99081c884722d4bed0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`tests/fm-test-run.test.sh` with a 180-second bound (timed out during later unrelated cases after all shard-focused cases passed), then rerun with a 600-second bound to completion</code>
- <code>`bin/fm-test-run.sh --check-coverage` and `bin/fm-test-run.sh --list-lanes`</code>
- <code>`bin/fm-test-run.sh --list --lane portable-serial-{1,2,3,4,5}of5` to verify shard counts and memberships</code>
- <code>Downloaded all portable-serial timing artifacts from green CI runs 33558082172, 33523597838, and 33463326167 with `npx -y gh-axi run download`, then replayed their measured script durations through the current executable shard memberships</code>
- <code>Added 25 temporary unhinted test executables, ran `bin/fm-test-run.sh --check-coverage`, verified exit 1 with the count, 15% bound, refresh documentation, and offending paths, then removed all temporary files</code>
- <code>Parsed `.github/workflows/ci.yml` with Ruby YAML and verified the serial matrix is `[1,2,3,4,5]`, `timeout-minutes` remains 20, and lane names derive their total from `strategy.job-total`</code>
- <code>`npx -y gh-axi run list --workflow ci.yml --branch fm/fm-ci-serial-shard-budget-rebalance-r1 --limit 5 --fields headSha,number,updatedAt,url` (no branch CI run existed yet; the outer CI phase remains required)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
