### PR TITLE
fix(bin): forward PI_CODING_AGENT_DIR to Pi crewmates

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2985,6 +2985,14 @@ esac
 if [ "$HARNESS" = claude ] && [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
   LAUNCH="CLAUDE_CONFIG_DIR=$(shell_quote "$CLAUDE_CONFIG_DIR") $LAUNCH"
 fi
+# Same daemon-environment gap for Pi: PI_CODING_AGENT_DIR selects the agent
+# profile (settings, packages, extensions, auth). A primary running under an
+# alternate profile would otherwise spawn crewmates on the default ~/.pi/agent,
+# which can carry a different model, packages, and extensions than the primary
+# was launched with. Forward it the same way, only when set.
+if { [ "$HARNESS" = pi ] || [ "$HARNESS" = pi-signed ]; } && [ -n "${PI_CODING_AGENT_DIR:-}" ]; then
+  LAUNCH="PI_CODING_AGENT_DIR=$(shell_quote "$PI_CODING_AGENT_DIR") $LAUNCH"
+fi
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   sq_primary_home=$(shell_quote "$FM_HOME")

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -90,8 +90,10 @@ run_spawn() {
   # CLAUDE_CONFIG_DIR is forwarded onto claude launches by fm-spawn, so pin it
   # explicitly (empty by default) instead of leaking the invoking shell's value,
   # which would make launch assertions depend on the developer's environment.
-  # A test opts in to the set case via FM_TEST_CLAUDE_CONFIG_DIR.
+  # A test opts in to the set case via FM_TEST_CLAUDE_CONFIG_DIR. Same for
+  # PI_CODING_AGENT_DIR on pi launches via FM_TEST_PI_CODING_AGENT_DIR.
   CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
+    PI_CODING_AGENT_DIR="${FM_TEST_PI_CODING_AGENT_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
     FM_FAKE_CURSOR_MODELS="${FM_TEST_CURSOR_MODELS:-}" \
     FM_FAKE_CURSOR_LIST_STATUS="${FM_TEST_CURSOR_LIST_STATUS:-0}" \
@@ -167,7 +169,7 @@ test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
       FM_STATE_OVERRIDE=home/state FM_DATA_OVERRIDE=home/data \
       FM_PROJECTS_OVERRIDE=home/projects FM_CONFIG_OVERRIDE=home/config \
       FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
-      CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
+      CLAUDE_CONFIG_DIR='' PI_CODING_AGENT_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
       GROK_HOME=home/grok-home PATH="$FAKEBIN_DIR:$PATH" \
       "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
   )
@@ -196,7 +198,7 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
       FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' \
       FM_PROJECTS_OVERRIDE=home/projects FM_CONFIG_OVERRIDE=home/config \
       FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
-      CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
+      CLAUDE_CONFIG_DIR='' PI_CODING_AGENT_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
       GROK_HOME=home/grok-home PATH="$FAKEBIN_DIR:$PATH" \
       "$SPAWN" "$relative_id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
   )
@@ -216,7 +218,7 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
       FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' \
       FM_PROJECTS_OVERRIDE="$linked_home/projects" FM_CONFIG_OVERRIDE="$linked_home/config" \
       FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
-      CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
+      CLAUDE_CONFIG_DIR='' PI_CODING_AGENT_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
       GROK_HOME="$linked_home/grok-home" PATH="$FAKEBIN_DIR:$PATH" \
       "$SPAWN" "$absolute_id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
   )
@@ -244,7 +246,7 @@ test_absolute_override_spelling_is_preserved_in_launch_paths() {
       FM_STATE_OVERRIDE="$linked_home/state" FM_DATA_OVERRIDE="$linked_home/data" \
       FM_PROJECTS_OVERRIDE="$linked_home/projects" FM_CONFIG_OVERRIDE="$linked_home/config" \
       FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
-      CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
+      CLAUDE_CONFIG_DIR='' PI_CODING_AGENT_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
       GROK_HOME="$linked_home/grok-home" PATH="$FAKEBIN_DIR:$PATH" \
       "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
   )
@@ -774,6 +776,55 @@ test_non_claude_harness_ignores_config_dir() {
   pass "non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix"
 }
 
+test_pi_forwards_firstmate_coding_agent_dir_when_set() {
+  local rec id out status launch
+  id=profile-pi-agentdir-z20
+  rec=$(make_spawn_case profile-pi-agentdir pi "$id")
+  read_case_record "$rec"
+
+  out=$(FM_TEST_PI_CODING_AGENT_DIR="/opt/test/pi-work" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "pi spawn with PI_CODING_AGENT_DIR set should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "PI_CODING_AGENT_DIR='/opt/test/pi-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS FM_PI_HARNESS=pi '$FAKEBIN_DIR/pi' --tui-mode regular" \
+    "pi launch did not forward firstmate's PI_CODING_AGENT_DIR to the crewmate pane"
+  pass "pi forwards firstmate's PI_CODING_AGENT_DIR so the crewmate uses the same agent profile"
+}
+
+test_pi_omits_coding_agent_dir_prefix_when_unset() {
+  local rec id out status launch
+  id=profile-pi-noagentdir-z21
+  rec=$(make_spawn_case profile-pi-noagentdir pi "$id")
+  read_case_record "$rec"
+
+  # run_spawn pins PI_CODING_AGENT_DIR empty by default, exercising the default
+  # ~/.pi/agent path where fm-spawn adds no prefix.
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "pi spawn without PI_CODING_AGENT_DIR should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "PI_CODING_AGENT_DIR=" \
+    "pi launch must not add a profile prefix when firstmate has no PI_CODING_AGENT_DIR set"
+  pass "pi omits the profile prefix when firstmate runs with the default agent directory"
+}
+
+test_non_pi_harness_ignores_coding_agent_dir() {
+  local rec id out status launch
+  id=profile-claude-noagentdir-z22
+  rec=$(make_spawn_case profile-claude-noagentdir claude "$id")
+  read_case_record "$rec"
+
+  out=$(FM_TEST_PI_CODING_AGENT_DIR="/opt/test/pi-work" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "claude spawn with PI_CODING_AGENT_DIR set should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "PI_CODING_AGENT_DIR=" \
+    "non-pi harness launch must not receive the pi-specific profile prefix"
+  pass "non-pi harnesses do not receive the PI_CODING_AGENT_DIR prefix"
+}
+
 test_active_dispatch_profile_does_not_block_secondmate_launch() {
   local rec id sm out status
   id=profile-secondmate-z16
@@ -822,6 +873,9 @@ test_batch_forwards_shared_profile_flags
 test_claude_forwards_firstmate_config_dir_when_set
 test_claude_omits_config_dir_prefix_when_unset
 test_non_claude_harness_ignores_config_dir
+test_pi_forwards_firstmate_coding_agent_dir_when_set
+test_pi_omits_coding_agent_dir_prefix_when_unset
+test_non_pi_harness_ignores_coding_agent_dir
 test_active_dispatch_profile_does_not_block_secondmate_launch
 
 echo "# all fm-spawn-dispatch-profile tests passed"


### PR DESCRIPTION
## Intent

Forward PI_CODING_AGENT_DIR onto pi and pi-signed crewmate launches in bin/fm-spawn.sh, only when it is set, exactly mirroring how PR #1195 forwards CLAUDE_CONFIG_DIR for claude crewmates. Motivation: crewmate panes come from the long-lived tmux/herdr daemon and do not inherit the primary's environment, so a firstmate primary started under an alternate Pi profile (PI_CODING_AGENT_DIR pointing at a profile with different settings, packages, extensions, auth) spawned crewmates on the default ~/.pi/agent profile. Verified by reading fm-spawn.sh and backends/tmux.sh (send-keys into a new window of the firstmate session) and by launching a pi worker in a fresh tmux shell. Deliberate decisions: keep the change minimal (no new profile concept, no pinning, unlike the stale PRs #877/#966); apply to both pi and pi-signed since both share the Pi launch template; place the block directly after the CLAUDE_CONFIG_DIR block with a matching comment; never prefix when the variable is unset so the default single-profile path is byte-identical to before. Tests: in tests/fm-spawn-dispatch-profile.test.sh pin PI_CODING_AGENT_DIR empty in run_spawn (opt-in via FM_TEST_PI_CODING_AGENT_DIR) and in the four ad-hoc spawn invocations that already pin CLAUDE_CONFIG_DIR, so assertions never depend on the developer's shell; add three cases mirroring the claude ones: pi forwards when set, pi omits the prefix when unset, a non-pi harness (claude) ignores it. No docs changed, matching PR #1195's file set. Commit follows Conventional Commits with no AI attribution.

## What Changed

- Pin `PI_CODING_AGENT_DIR` in spawn fixtures and cover forwarding, omission, and non-Pi behavior.
- Forward a set `PI_CODING_AGENT_DIR` to `pi` and `pi-signed` crewmates while leaving other launches unchanged.

## Risk Assessment

✅ Low: The change is narrowly scoped, matches the CLAUDE_CONFIG_DIR precedent, safely quotes the value, covers both Pi harnesses, preserves the unset path, and adds behavior-level spawn tests.

## Testing

After repository bootstrap, the targeted suite and focused cases passed. The base source failed the new forwarding test as expected, while the end-to-end CLI transcript showed the profile prefix on `pi` and `pi-signed` launches and nowhere else. The worktree remained clean.

<details>
<summary>Evidence: End-to-end Pi spawn transcript</summary>

Source: [End-to-end Pi spawn transcript](https://github.com/pperanich/firstmate/blob/20a2f188800fdae30b54701693b118f40e7528f6/.no-mistakes/evidence/fix/spawn-forward-pi-coding-agent-dir/pi-agent-dir-end-to-end.txt)

```text
CASE pi with alternate profile
spawned evidence-pi-set-z1 harness=pi kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-pi-set-z1 worktree=/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.5kdLNh/evidence-pi-set/wt
TMUX_PAYLOAD=PI_CODING_AGENT_DIR='/opt/profiles/alternate-pi' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS FM_PI_HARNESS=pi '/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.5kdLNh/evidence-pi-set/fake/fakebin/pi' --tui-mode regular -e '/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.5kdLNh/evidence-pi-set/home/state/evidence-pi-set-z1.pi-ext.ts' "$('~/.no-mistakes/worktrees/74c906478ac0/01M1G1SDSM8C5Q0TKAE006FE9F/bin/fm-operational-input.sh' encode launch-brief < '/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.5kdLNh/evidence-pi-set/home/data/evidence-pi-set-z1/brief.md')"

CASE pi-signed with alternate profile
spawned evidence-pi-signed-set-z2 harness=pi-signed kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-pi-signed-set-z2 worktree=/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.5kdLNh/evidence-pi-signed-set/wt
TMUX_PAYLOAD=PI_CODING_AGENT_DIR='/opt/profiles/alternate-pi' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS FM_PI_HARNESS=pi-signed '/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.5kdLNh/evidence-pi-signed-set/fake/fakebin/pi-signed' --tui-mode regular -e '/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.5kdLNh/evidence-pi-signed-set/home/state/evidence-pi-signed-set-z2.pi-ext.ts' "$('~/.no-mistakes/worktrees/74c906478ac0/01M1G1SDSM8C5Q0TKAE006FE9F/bin/fm-operational-input.sh' encode launch-brief < '/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.5kdLNh/evidence-pi-signed-set/home/data/evidence-pi-signed-set-z2/brief.md')"

CASE pi with PI_CODING_AGENT_DIR unset
spawned evidence-pi-unset-z3 harness=pi kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-pi-unset-z3 worktree=/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.5kdLNh/evidence-pi-unset/wt
PROFILE_PREFIX=absent

CASE claude while PI_CODING_AGENT_DIR is set
spawned evidence-claude-pi-set-z4 harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-claude-pi-set-z4 worktree=/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.5kdLNh/evidence-claude-pi-set/wt
PI_PROFILE_PREFIX=absent
```
</details>
<details>
<summary>Evidence: Baseline regression reproduction</summary>

Source: [Baseline regression reproduction](https://github.com/pperanich/firstmate/blob/20a2f188800fdae30b54701693b118f40e7528f6/.no-mistakes/evidence/fix/spawn-forward-pi-coding-agent-dir/pi-agent-dir-baseline-regression.txt)

```text
Baseline regression check: target behavioral test against base fm-spawn.sh
not ok - pi launch did not forward firstmate's PI_CODING_AGENT_DIR to the crewmate pane (missing: 'PI_CODING_AGENT_DIR='/opt/test/pi-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS FM_PI_HARNESS=pi '/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.lSoIfP/profile-pi-agentdir/fake/fakebin/pi' --tui-mode regular')
--- output ---
env -u CURSOR_AGENT -u CURSOR_INVOKED_AS FM_PI_HARNESS=pi '/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.lSoIfP/profile-pi-agentdir/fake/fakebin/pi' --tui-mode regular -e '/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.lSoIfP/profile-pi-agentdir/home/state/profile-pi-agentdir-z20.pi-ext.ts' "$('/private/tmp/fm-pi-agentdir-baseline.XvlGVv/bin/fm-operational-input.sh' encode launch-brief < '/private/var/folders/1c/sz9p1x8j1msd9cmf3f8rfgrw0000gn/T/fm-spawn-dispatch-profile.lSoIfP/profile-pi-agentdir/home/data/profile-pi-agentdir-z20/brief.md')"
baseline_exit=1 (expected nonzero)
```
</details>
<details>
<summary>Evidence: Dispatch-profile test log</summary>

Source: [Dispatch-profile test log](https://github.com/pperanich/firstmate/blob/20a2f188800fdae30b54701693b118f40e7528f6/.no-mistakes/evidence/fix/spawn-forward-pi-coding-agent-dir/fm-spawn-dispatch-profile-tests.txt)

```text
ok - no --model/--effort records defaults and types the claude launch instructions
ok - non-cursor launches clear inherited Cursor identity markers
ok - relative home overrides ignore CDPATH and become absolute before spawn launch construction
ok - FM_HOME defaults resolve relative paths and preserve absolute spellings
ok - absolute override spellings are preserved in spawn launch paths
ok - unresolvable relative spawn overrides fail with named diagnostics
ok - active crew-dispatch profile requires an explicit harness for ship spawns
ok - active crew-dispatch profile requires an explicit harness for scout spawns
ok - active crew-dispatch profile allows an explicit resolved harness
ok - active crew-dispatch profile allows the legacy positional harness form
ok - active crew-dispatch profile allows the raw launch-command escape hatch
ok - claude receives --model and --effort profile flags
ok - codex receives --model and model_reasoning_effort profile flags
ok - codex omits unsupported max effort instead of passing a bad config value
ok - grok receives --model and --reasoning-effort profile flags
ok - grok omits unsupported max reasoning effort
ok - grok omits unsupported xhigh reasoning effort
ok - cursor receives its model-qualified reasoning class and exact task workspace
ok - cursor refuses model ids absent from its resolved binary's live catalog
ok - cursor preserves the requested model when its live catalog is unreachable
ok - opencode receives --model and omits the unsupported effort axis
ok - pi receives --model and --thinking max profile flags
ok - Pi launch probing omits --tui-mode on older Pi and preserves it on supporting Pi
ok - pi-signed shares Pi launch semantics while preserving its configured and recorded identity
ok - pi-signed refuses safely and actionably when the selected executable is unavailable
ok - pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics
ok - batch dispatch forwards shared --harness, --model, and --effort to every pair
ok - claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store
ok - claude omits the config-dir prefix when firstmate runs with the single-store default
ok - non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix
ok - pi forwards firstmate's PI_CODING_AGENT_DIR so the crewmate uses the same agent profile
ok - pi omits the profile prefix when firstmate runs with the default agent directory
ok - non-pi harnesses do not receive the PI_CODING_AGENT_DIR prefix
ok - active crew-dispatch profile does not block secondmate launches
# all fm-spawn-dispatch-profile tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8635fcb9a28e446c9d6a3b0f447ddc7dae65157e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Repository bootstrap: `bin/fm-session-start.sh`</code>
- <code>Automated behavior suite: `bash tests/fm-spawn-dispatch-profile.test.sh`</code>
- <code>Focused selectors: `test_pi_forwards_firstmate_coding_agent_dir_when_set`, `test_pi_omits_coding_agent_dir_prefix_when_unset`, and `test_non_pi_harness_ignores_coding_agent_dir`</code>
- <code>Focused `pi-signed` spawn assertion through the shared Pi launch path</code>
- <code>Regression reproduction: target `test_pi_forwards_firstmate_coding_agent_dir_when_set` executed against `54663948647a41e21b289d9992159b1bdc3bb6ca:bin/fm-spawn.sh`</code>
- <code>Evidence-producing executable check through `fm-spawn.sh` and captured tmux payloads for set Pi, set Pi Signed, unset Pi, and Claude</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
