### PR TITLE
fix: accelerate local Bearings snapshot composition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,8 +385,8 @@ jobs:
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 45 ] || {
-            echo "::error::expected 45 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 46 ] || {
+            echo "::error::expected 46 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,8 +385,8 @@ jobs:
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 48 ] || {
-            echo "::error::expected 48 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 49 ] || {
+            echo "::error::expected 49 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,8 +385,8 @@ jobs:
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 46 ] || {
-            echo "::error::expected 46 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 47 ] || {
+            echo "::error::expected 47 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,8 +385,8 @@ jobs:
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 47 ] || {
-            echo "::error::expected 47 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 48 ] || {
+            echo "::error::expected 48 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -336,9 +336,14 @@ fm_backend_required_tool_available() {  # <backend> <tool>
 # errors) if the file or key is absent. Mirrors the ad hoc `grep '^key=' |
 # tail -1 | cut -d= -f2-` snippet every fm-*.sh script used to repeat inline.
 fm_meta_get() {  # <meta-file> <key>
-  local meta=$1 key=$2
+  local meta=$1 key=$2 line value=''
   [ -f "$meta" ] || return 0
-  grep "^$key=" "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "$key="*) value=${line#*=} ;;
+    esac
+  done < "$meta" 2>/dev/null || true
+  printf '%s' "$value"
 }
 
 # fm_backend_of_meta: the backend recorded in <meta-file>, defaulting to

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -73,7 +73,7 @@ ID=${1:-}
 # Fleet snapshot composition supplies its captured metadata path here so every
 # state read resolves the same task generation selected by that snapshot.
 META=${FM_CREW_STATE_META_OVERRIDE:-"$STATE/$ID.meta"}
-LOG="$STATE/$ID.status"
+LOG=${FM_CREW_STATE_STATUS_OVERRIDE:-"$STATE/$ID.status"}
 NM_TIMEOUT=${FM_CREW_STATE_NM_TIMEOUT:-10}
 case "$NM_TIMEOUT" in ''|*[!0-9]*) NM_TIMEOUT=10 ;; esac
 # How many of the most recent `no-mistakes runs` rows the cross-branch fallback

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -70,7 +70,7 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 ID=${1:-}
 [ -n "$ID" ] || { echo "usage: fm-crew-state.sh <id>" >&2; exit 2; }
 
-META="$STATE/$ID.meta"
+META=${FM_CREW_STATE_META_OVERRIDE:-"$STATE/$ID.meta"}
 LOG="$STATE/$ID.status"
 NM_TIMEOUT=${FM_CREW_STATE_NM_TIMEOUT:-10}
 case "$NM_TIMEOUT" in ''|*[!0-9]*) NM_TIMEOUT=10 ;; esac

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -70,6 +70,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 ID=${1:-}
 [ -n "$ID" ] || { echo "usage: fm-crew-state.sh <id>" >&2; exit 2; }
 
+# Fleet snapshot composition supplies its captured metadata path here so every
+# state read resolves the same task generation selected by that snapshot.
 META=${FM_CREW_STATE_META_OVERRIDE:-"$STATE/$ID.meta"}
 LOG="$STATE/$ID.status"
 NM_TIMEOUT=${FM_CREW_STATE_NM_TIMEOUT:-10}

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -232,10 +232,10 @@ bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
 
-path_present_json() {  # <path>
-  local present=0
-  [ -e "$1" ] && present=1
-  jq -n --arg path "$1" --argjson present "$(bool_json "$present")" \
+path_present_json() {  # <contract-path> [<observed-path>]
+  local path=$1 observed=${2:-$1} present=0
+  [ -e "$observed" ] && present=1
+  jq -n --arg path "$path" --argjson present "$(bool_json "$present")" \
     '{path:$path,present:$present}'
 }
 
@@ -284,8 +284,8 @@ crew_state_json() {  # <id> [<captured-meta>]
     '{state:$state,source:$source,detail:$detail,raw:$raw}'
 }
 
-status_event_json() {  # <status-log>
-  local log=$1 present=0 raw='' verb='' note=''
+status_event_json() {  # <observed-status-log> [<contract-path>]
+  local log=$1 path=${2:-$1} present=0 raw='' verb='' note=''
   if [ -f "$log" ]; then
     present=1
     raw=$(last_nonempty_line "$log" || true)
@@ -293,7 +293,7 @@ status_event_json() {  # <status-log>
     note=$(status_line_note "$raw")
   fi
   jq -n \
-    --arg path "$log" \
+    --arg path "$path" \
     --arg raw "$raw" \
     --arg verb "$verb" \
     --arg note "$note" \
@@ -480,6 +480,18 @@ snapshot_wait_current_reads() {  # <pid>...
   return "$rc"
 }
 
+snapshot_capture_optional() {  # <source> <destination>
+  local source=$1 destination=$2
+  [ -f "$source" ] || return 0
+  cp -- "$source" "$destination" && return 0
+  # Teardown may remove an optional observation after the existence check.
+  if [ ! -e "$source" ]; then
+    rm -f -- "$destination"
+    return 0
+  fi
+  return 1
+}
+
 snapshot_task_generation_is_current() {  # <captured-meta> <id>
   local captured_meta=$1 id=$2 current_meta captured_gen current_gen captured_contents current_contents
   current_meta="$STATE/$id.meta"
@@ -498,43 +510,60 @@ snapshot_task_generation_is_current() {  # <captured-meta> <id>
 }
 
 prefetch_task_observations() {  # <meta> <id>
-  local meta=$1 id=$2 remote_host current_file endpoint_file current_pid current_rc=0
+  local meta=$1 id=$2 remote_host current_file endpoint_file current_pid='' current_rc=0
+  local status_log status_capture report_path report_capture
   local kind backend target endpoint_exists=null agent_alive=not_checked generation_current=1
   remote_host=$(meta_value "$meta" remote_host)
   current_file="$SNAPSHOT_TASK_DIR/$id.json"
   endpoint_file="$SNAPSHOT_TASK_DIR/$id.endpoint"
-  if [ -n "$remote_host" ]; then
-    jq -n '{state:"unknown",source:"none",detail:"remote endpoint liveness not collected by fleet snapshot",raw:""}' \
-      > "$current_file" || return 1
-    printf 'endpoint_exists=null\nagent_alive=unknown\n' > "$endpoint_file"
-    return 0
+  status_log="$STATE/$id.status"
+  status_capture="$SNAPSHOT_TASK_DIR/$id.status"
+  report_path="$DATA/$id/report.md"
+  report_capture="$SNAPSHOT_TASK_DIR/$id.report"
+
+  snapshot_task_generation_is_current "$meta" "$id" || generation_current=0
+  if [ "$generation_current" = 1 ]; then
+    snapshot_capture_optional "$status_log" "$status_capture" || current_rc=1
+    snapshot_capture_optional "$report_path" "$report_capture" || current_rc=1
   fi
 
-  crew_state_json "$id" "$meta" > "$current_file" &
-  current_pid=$!
-  kind=$(meta_value "$meta" kind)
-  backend=$(fm_backend_of_meta "$meta")
-  target=$(fm_backend_target_of_meta "$meta")
-  snapshot_task_generation_is_current "$meta" "$id" || generation_current=0
-  if [ "$generation_current" = 1 ] && [ -n "$target" ]; then
-    if fm_backend_target_exists "$backend" "$target" "fm-$id" >/dev/null 2>&1; then
-      endpoint_exists=true
-    else
-      endpoint_exists=false
+  if [ -n "$remote_host" ]; then
+    jq -n '{state:"unknown",source:"none",detail:"remote endpoint liveness not collected by fleet snapshot",raw:""}' \
+      > "$current_file" || current_rc=1
+    agent_alive=unknown
+  elif [ "$generation_current" = 1 ]; then
+    crew_state_json "$id" "$meta" > "$current_file" &
+    current_pid=$!
+    kind=$(meta_value "$meta" kind)
+    backend=$(fm_backend_of_meta "$meta")
+    target=$(fm_backend_target_of_meta "$meta")
+    if [ -n "$target" ]; then
+      if fm_backend_target_exists "$backend" "$target" "fm-$id" >/dev/null 2>&1; then
+        endpoint_exists=true
+      else
+        endpoint_exists=false
+      fi
+      if [ "$kind" = secondmate ]; then
+        agent_alive=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null || printf unknown)
+      fi
     fi
-    if [ "$kind" = secondmate ]; then
-      agent_alive=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null || printf unknown)
-    fi
+  else
+    jq -n '{state:"unknown",source:"none",detail:"task generation changed during snapshot",raw:""}' \
+      > "$current_file" || current_rc=1
+    agent_alive=unknown
   fi
-  # Targets are reusable (notably tmux's fm-<id> window). Revalidate after the
-  # probes so teardown/relaunch cannot attribute the replacement generation's
-  # endpoint state to the captured task.
+
+  [ -z "$current_pid" ] || wait "$current_pid" || current_rc=1
+  # All mutable observations must belong to the metadata generation captured in
+  # the manifest. If teardown/relaunch raced any read, discard the whole sample.
   if ! snapshot_task_generation_is_current "$meta" "$id"; then
+    rm -f -- "$status_capture" "$report_capture"
+    jq -n '{state:"unknown",source:"none",detail:"task generation changed during snapshot",raw:""}' \
+      > "$current_file" || current_rc=1
     endpoint_exists=null
     agent_alive=unknown
   fi
   printf 'endpoint_exists=%s\nagent_alive=%s\n' "$endpoint_exists" "$agent_alive" > "$endpoint_file" || current_rc=1
-  wait "$current_pid" || current_rc=1
   return "$current_rc"
 }
 
@@ -626,8 +655,8 @@ task_json_lines() {
       backend=$(fm_backend_of_meta "$meta")
       target=$(fm_backend_target_of_meta "$meta")
     fi
-    status_log="$STATE/$id.status"
-    report_path="$DATA/$id/report.md"
+    status_log="$SNAPSHOT_TASK_DIR/$id.status"
+    report_path="$SNAPSHOT_TASK_DIR/$id.report"
     pr=$(meta_value "$meta" pr)
     pr_source=meta
     if [ -z "$pr" ]; then
@@ -644,7 +673,7 @@ task_json_lines() {
       snapshot_task_cleanup
       return 1
     }
-    event_json=$(status_event_json "$status_log")
+    event_json=$(status_event_json "$status_log" "$STATE/$id.status")
     last_event_raw=$(printf '%s' "$event_json" | jq -r '.last_event.raw // ""')
     read -r current_state current_source < <(
       printf '%s' "$current_json" | jq -r '[.state // "", .source // ""] | @tsv'
@@ -702,9 +731,9 @@ task_json_lines() {
       return 1
     }
     [ -f "$report_path" ] && report_present=1 || report_present=0
-    meta_json=$(path_present_json "$original_meta")
+    meta_json=$(path_present_json "$original_meta" "$meta")
     status_json=$event_json
-    report_json=$(path_present_json "$report_path")
+    report_json=$(path_present_json "$DATA/$id/report.md" "$report_path")
     if [ -n "$worktree" ]; then worktree_json=$(path_present_json "$worktree"); else worktree_json=$(jq -n '{path:null,present:false}'); fi
     if [ -n "$home" ] && [ -n "$remote_host" ]; then
       home_json=$(jq -n --arg path "$home" '{path:$path,present:null}')

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -462,11 +462,13 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
 
 SNAPSHOT_TASK_DIR=
 SNAPSHOT_TASK_METAS=()
+SNAPSHOT_TASK_META_COUNT=0
 
 snapshot_task_cleanup() {
   [ -z "$SNAPSHOT_TASK_DIR" ] || rm -rf -- "$SNAPSHOT_TASK_DIR"
   SNAPSHOT_TASK_DIR=
   SNAPSHOT_TASK_METAS=()
+  SNAPSHOT_TASK_META_COUNT=0
 }
 
 snapshot_wait_current_reads() {  # <pid>...
@@ -515,19 +517,31 @@ prefetch_task_observations() {  # <meta> <id>
 # window rather than five in series, while every command bound remains owned by
 # fm-timeout-lib.sh.
 prefetch_task_current_states() {
-  local meta id active=0 rc=0
+  local meta captured_meta id active=0 index=0 rc=0
   local -a pids=()
   snapshot_task_cleanup
   SNAPSHOT_TASK_DIR=$(umask 077; mktemp -d "${TMPDIR:-/tmp}/fm-fleet-tasks.XXXXXX") || return 1
+  # Keep the metadata generation that selected each task beside its observations.
+  # Publishers replace metadata atomically, so copying before workers start gives
+  # composition one coherent task manifest even if publication or teardown races it.
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
-    SNAPSHOT_TASK_METAS[${#SNAPSHOT_TASK_METAS[@]}]=$meta
+    id=$(basename "$meta" .meta)
+    captured_meta="$SNAPSHOT_TASK_DIR/$id.meta"
+    cp -- "$meta" "$captured_meta" || {
+      snapshot_task_cleanup
+      return 1
+    }
+    SNAPSHOT_TASK_METAS[SNAPSHOT_TASK_META_COUNT]=$captured_meta
+    SNAPSHOT_TASK_META_COUNT=$((SNAPSHOT_TASK_META_COUNT + 1))
   done
-  for meta in "${SNAPSHOT_TASK_METAS[@]}"; do
+  while [ "$index" -lt "$SNAPSHOT_TASK_META_COUNT" ]; do
+    meta=${SNAPSHOT_TASK_METAS[index]}
     id=$(basename "$meta" .meta)
     prefetch_task_observations "$meta" "$id" &
     pids[active]=$!
     active=$((active + 1))
+    index=$((index + 1))
     if [ "$active" -ge "$FM_SNAPSHOT_LOCAL_READ_CONCURRENCY" ]; then
       snapshot_wait_current_reads "${pids[@]}" || rc=1
       pids=()
@@ -544,16 +558,19 @@ prefetch_task_current_states() {
 }
 
 task_json_lines() {
-  local meta id kind harness mode yolo project worktree home projects spawn_gen backend target status_log report_path
-  local remote_host remote_root current_file endpoint_file observation_line rc
+  local meta original_meta id kind harness mode yolo project worktree home projects spawn_gen backend target status_log report_path
+  local remote_host remote_root current_file endpoint_file observation_line index=0 rc
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
   local decision_line decision_verb
   local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
   prefetch_task_current_states || return 1
-  for meta in "${SNAPSHOT_TASK_METAS[@]}"; do
+  while [ "$index" -lt "$SNAPSHOT_TASK_META_COUNT" ]; do
+    meta=${SNAPSHOT_TASK_METAS[index]}
+    index=$((index + 1))
     id=$(basename "$meta" .meta)
+    original_meta="$STATE/$id.meta"
     kind=$(meta_value "$meta" kind)
     [ -n "$kind" ] || kind=ship
     harness=$(meta_value "$meta" harness)
@@ -650,7 +667,7 @@ task_json_lines() {
       return 1
     }
     [ -f "$report_path" ] && report_present=1 || report_present=0
-    meta_json=$(path_present_json "$meta")
+    meta_json=$(path_present_json "$original_meta")
     status_json=$event_json
     report_json=$(path_present_json "$report_path")
     if [ -n "$worktree" ]; then worktree_json=$(path_present_json "$worktree"); else worktree_json=$(jq -n '{path:null,present:false}'); fi

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -111,6 +111,7 @@ esac
 # hang or explode the parent snapshot.
 FM_SNAPSHOT_SECONDMATES=${FM_SNAPSHOT_SECONDMATES:-20}
 FM_SNAPSHOT_CREW_STATE_TIMEOUT=${FM_SNAPSHOT_CREW_STATE_TIMEOUT:-10}
+FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=${FM_SNAPSHOT_LOCAL_READ_CONCURRENCY:-8}
 FM_SNAPSHOT_BUDGET=${FM_SNAPSHOT_BUDGET:-5}
 FM_SNAPSHOT_CACHE_DIR=${FM_SNAPSHOT_CACHE_DIR:-$STATE/secondmate-summary-cache}
 FM_SNAPSHOT_SECONDMATE_MAX_BYTES=${FM_SNAPSHOT_SECONDMATE_MAX_BYTES:-262144}
@@ -143,6 +144,7 @@ case "$FM_SNAPSHOT_SECONDMATES" in
     ;;
 esac
 validate_positive_bound FM_SNAPSHOT_CREW_STATE_TIMEOUT "$FM_SNAPSHOT_CREW_STATE_TIMEOUT"
+validate_positive_bound FM_SNAPSHOT_LOCAL_READ_CONCURRENCY "$FM_SNAPSHOT_LOCAL_READ_CONCURRENCY"
 validate_positive_bound FM_SNAPSHOT_BUDGET "$FM_SNAPSHOT_BUDGET"
 validate_positive_bound FM_SNAPSHOT_SECONDMATE_MAX_BYTES "$FM_SNAPSHOT_SECONDMATE_MAX_BYTES"
 validate_positive_bound FM_SNAPSHOT_SECONDMATE_CHILDREN "$FM_SNAPSHOT_SECONDMATE_CHILDREN"
@@ -201,8 +203,9 @@ FM_SNAPSHOT_CACHE_DIR used when the live read fails, is invalid, or consumes the
 budget. A home with neither a valid ledger nor a valid cached copy is reported
 unreadable with the reason; collection never computes a summary in that home.
 Each local per-task current-state read is bounded by FM_SNAPSHOT_CREW_STATE_TIMEOUT
-(default 10 seconds); a read that hits the bound reports state unknown. Remote
-secondmate endpoint liveness is not probed by this command.
+(default 10 seconds); a read that hits the bound reports state unknown. Independent
+local reads run concurrently, up to FM_SNAPSHOT_LOCAL_READ_CONCURRENCY (default 8).
+Remote secondmate endpoint liveness is not probed by this command.
 Terminal contradiction evidence uses
 FM_SNAPSHOT_TERMINAL_LINES, FM_SNAPSHOT_TERMINAL_BYTES, and
 FM_SNAPSHOT_TERMINAL_TIMEOUT and never becomes canonical current state.
@@ -457,13 +460,92 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
   ' < "$backlog"
 }
 
+SNAPSHOT_TASK_DIR=
+
+snapshot_task_cleanup() {
+  [ -z "$SNAPSHOT_TASK_DIR" ] || rm -rf -- "$SNAPSHOT_TASK_DIR"
+  SNAPSHOT_TASK_DIR=
+}
+
+snapshot_wait_current_reads() {  # <pid>...
+  local pid rc=0
+  for pid in "$@"; do
+    wait "$pid" || rc=1
+  done
+  return "$rc"
+}
+
+prefetch_task_observations() {  # <meta> <id>
+  local meta=$1 id=$2 remote_host current_file endpoint_file current_pid current_rc=0
+  local kind backend target endpoint_exists=null agent_alive=not_checked
+  remote_host=$(meta_value "$meta" remote_host)
+  current_file="$SNAPSHOT_TASK_DIR/$id.json"
+  endpoint_file="$SNAPSHOT_TASK_DIR/$id.endpoint"
+  if [ -n "$remote_host" ]; then
+    jq -n '{state:"unknown",source:"none",detail:"remote endpoint liveness not collected by fleet snapshot",raw:""}' \
+      > "$current_file" || return 1
+    printf 'endpoint_exists=null\nagent_alive=unknown\n' > "$endpoint_file"
+    return 0
+  fi
+
+  crew_state_json "$id" > "$current_file" &
+  current_pid=$!
+  kind=$(meta_value "$meta" kind)
+  backend=$(fm_backend_of_meta "$meta")
+  target=$(fm_backend_target_of_meta "$meta")
+  if [ -n "$target" ]; then
+    if fm_backend_target_exists "$backend" "$target" "fm-$id" >/dev/null 2>&1; then
+      endpoint_exists=true
+    else
+      endpoint_exists=false
+    fi
+    if [ "$kind" = secondmate ]; then
+      agent_alive=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null || printf unknown)
+    fi
+  fi
+  printf 'endpoint_exists=%s\nagent_alive=%s\n' "$endpoint_exists" "$agent_alive" > "$endpoint_file" || current_rc=1
+  wait "$current_pid" || current_rc=1
+  return "$current_rc"
+}
+
+# Current-state and endpoint reads are independent observations. Start each
+# task's pair together so five local workers pay one slow no-mistakes response
+# window rather than five in series, while every command bound remains owned by
+# fm-timeout-lib.sh.
+prefetch_task_current_states() {
+  local meta id active=0 rc=0
+  local -a pids=()
+  snapshot_task_cleanup
+  SNAPSHOT_TASK_DIR=$(umask 077; mktemp -d "${TMPDIR:-/tmp}/fm-fleet-tasks.XXXXXX") || return 1
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    id=$(basename "$meta" .meta)
+    prefetch_task_observations "$meta" "$id" &
+    pids[active]=$!
+    active=$((active + 1))
+    if [ "$active" -ge "$FM_SNAPSHOT_LOCAL_READ_CONCURRENCY" ]; then
+      snapshot_wait_current_reads "${pids[@]}" || rc=1
+      pids=()
+      active=0
+    fi
+  done
+  if [ "$active" -gt 0 ]; then
+    snapshot_wait_current_reads "${pids[@]}" || rc=1
+  fi
+  if [ "$rc" -ne 0 ]; then
+    snapshot_task_cleanup
+    return 1
+  fi
+}
+
 task_json_lines() {
   local meta id kind harness mode yolo project worktree home projects spawn_gen backend target status_log report_path
-  local remote_host remote_root
+  local remote_host remote_root current_file endpoint_file observation_line rc
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
   local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
+  prefetch_task_current_states || return 1
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
     id=$(basename "$meta" .meta)
@@ -500,13 +582,11 @@ task_json_lines() {
       pr_source=absent
     fi
 
-    if [ -n "$remote_host" ]; then
-      # Remote endpoint liveness belongs to supervision. The snapshot never
-      # probes a persistent remote endpoint while assembling parent inventory.
-      current_json=$(jq -n '{state:"unknown",source:"none",detail:"remote endpoint liveness not collected by fleet snapshot",raw:""}')
-    else
-      current_json=$(crew_state_json "$id")
-    fi
+    current_file="$SNAPSHOT_TASK_DIR/$id.json"
+    current_json=$(cat "$current_file") || {
+      snapshot_task_cleanup
+      return 1
+    }
     event_json=$(status_event_json "$status_log")
     last_event_raw=$(printf '%s' "$event_json" | jq -r '.last_event.raw // ""')
     current_state=$(printf '%s' "$current_json" | jq -r '.state // ""')
@@ -545,21 +625,16 @@ task_json_lines() {
 
     endpoint_exists=null
     agent_alive=not_checked
-    if [ -n "$remote_host" ]; then
-      agent_alive=unknown
-    else
-      if [ -n "$target" ]; then
-        if fm_backend_target_exists "$backend" "$target" "fm-$id" >/dev/null 2>&1; then
-          endpoint_exists=true
-        else
-          endpoint_exists=false
-        fi
-      fi
-      if [ "$kind" = secondmate ] && [ -n "$target" ]; then
-        agent_alive=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null || printf unknown)
-      fi
-    fi
-
+    endpoint_file="$SNAPSHOT_TASK_DIR/$id.endpoint"
+    while IFS= read -r observation_line || [ -n "$observation_line" ]; do
+      case "$observation_line" in
+        endpoint_exists=*) endpoint_exists=${observation_line#*=} ;;
+        agent_alive=*) agent_alive=${observation_line#*=} ;;
+      esac
+    done < "$endpoint_file" || {
+      snapshot_task_cleanup
+      return 1
+    }
     [ -f "$report_path" ] && report_present=1 || report_present=0
     meta_json=$(path_present_json "$meta")
     status_json=$event_json
@@ -648,6 +723,9 @@ task_json_lines() {
           end)
       }'
   done | jq -s 'sort_by(.id)'
+  rc=$?
+  snapshot_task_cleanup
+  return "$rc"
 }
 
 # Main-home current-inventory validity: same orphan / unstructured-current checks
@@ -1179,7 +1257,11 @@ snapshot_collection_cleanup() {
   SNAPSHOT_COLLECT_DIR=
   SNAPSHOT_SUMMARY_FILTER=
 }
-trap snapshot_collection_cleanup EXIT
+snapshot_cleanup() {
+  snapshot_task_cleanup
+  snapshot_collection_cleanup
+}
+trap snapshot_cleanup EXIT
 
 bounded_parent_activities_json() {  # <status-file>
   local f=$1 out rc reason script

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -461,10 +461,12 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
 }
 
 SNAPSHOT_TASK_DIR=
+SNAPSHOT_TASK_METAS=()
 
 snapshot_task_cleanup() {
   [ -z "$SNAPSHOT_TASK_DIR" ] || rm -rf -- "$SNAPSHOT_TASK_DIR"
   SNAPSHOT_TASK_DIR=
+  SNAPSHOT_TASK_METAS=()
 }
 
 snapshot_wait_current_reads() {  # <pid>...
@@ -519,6 +521,9 @@ prefetch_task_current_states() {
   SNAPSHOT_TASK_DIR=$(umask 077; mktemp -d "${TMPDIR:-/tmp}/fm-fleet-tasks.XXXXXX") || return 1
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
+    SNAPSHOT_TASK_METAS[${#SNAPSHOT_TASK_METAS[@]}]=$meta
+  done
+  for meta in "${SNAPSHOT_TASK_METAS[@]}"; do
     id=$(basename "$meta" .meta)
     prefetch_task_observations "$meta" "$id" &
     pids[active]=$!
@@ -546,8 +551,7 @@ task_json_lines() {
   local open_decisions_tsv open_decisions_json
 
   prefetch_task_current_states || return 1
-  for meta in "$STATE"/*.meta; do
-    [ -e "$meta" ] || continue
+  for meta in "${SNAPSHOT_TASK_METAS[@]}"; do
     id=$(basename "$meta" .meta)
     kind=$(meta_value "$meta" kind)
     [ -n "$kind" ] || kind=ship

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -635,7 +635,6 @@ task_json_lines() {
   local meta original_meta id kind harness mode yolo project worktree home projects spawn_gen backend target status_log report_path
   local remote_host remote_root current_file endpoint_file observation_line index=0
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
-  local decision_line decision_verb
   local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
@@ -716,16 +715,8 @@ task_json_lines() {
       [ splits("\n") | select(length > 0)
         | (capture("^(?<key>[^\t]*)\t(?<verb>[^\t]*)\t(?<summary>.*)$")?)
         | select(. != null) ]')
-    pending_decision=0
-    blocked_event=0
-    while IFS= read -r decision_line || [ -n "$decision_line" ]; do
-      decision_verb=${decision_line#*$'\t'}
-      decision_verb=${decision_verb%%$'\t'*}
-      case "$decision_verb" in
-        needs-decision) pending_decision=1 ;;
-        blocked) blocked_event=1 ;;
-      esac
-    done <<< "$open_decisions_tsv"
+    pending_decision=$(printf '%s' "$open_decisions_json" | jq 'if any(.[]; .verb == "needs-decision") then 1 else 0 end')
+    blocked_event=$(printf '%s' "$open_decisions_json" | jq 'if any(.[]; .verb == "blocked") then 1 else 0 end')
 
     endpoint_exists=null
     agent_alive=not_checked

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -483,13 +483,19 @@ snapshot_wait_current_reads() {  # <pid>...
 snapshot_capture_optional() {  # <source> <destination>
   local source=$1 destination=$2
   [ -f "$source" ] || return 0
-  cp -- "$source" "$destination" && return 0
+  cp -p -- "$source" "$destination" && return 0
   # Teardown may remove an optional observation after the existence check.
   if [ ! -e "$source" ]; then
     rm -f -- "$destination"
     return 0
   fi
   return 1
+}
+
+snapshot_mark_optional_present() {  # <source> <destination>
+  local source=$1 destination=$2
+  [ -f "$source" ] || return 0
+  : > "$destination"
 }
 
 snapshot_task_generation_is_current() {  # <captured-meta> <id>
@@ -524,7 +530,7 @@ prefetch_task_observations() {  # <meta> <id>
   snapshot_task_generation_is_current "$meta" "$id" || generation_current=0
   if [ "$generation_current" = 1 ]; then
     snapshot_capture_optional "$status_log" "$status_capture" || current_rc=1
-    snapshot_capture_optional "$report_path" "$report_capture" || current_rc=1
+    snapshot_mark_optional_present "$report_path" "$report_capture" || current_rc=1
   fi
 
   if [ -n "$remote_host" ]; then
@@ -623,13 +629,12 @@ prefetch_task_current_states() {
 
 task_json_lines() {
   local meta original_meta id kind harness mode yolo project worktree home projects spawn_gen backend target status_log report_path
-  local remote_host remote_root current_file endpoint_file observation_line index=0 rc
+  local remote_host remote_root current_file endpoint_file observation_line index=0
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
   local decision_line decision_verb
   local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
-  prefetch_task_current_states || return 1
   while [ "$index" -lt "$SNAPSHOT_TASK_META_COUNT" ]; do
     meta=${SNAPSHOT_TASK_METAS[index]}
     index=$((index + 1))
@@ -818,9 +823,6 @@ task_json_lines() {
           end)
       }'
   done | jq -s 'sort_by(.id)'
-  rc=$?
-  snapshot_task_cleanup
-  return "$rc"
 }
 
 # Main-home current-inventory validity: same orphan / unstructured-current checks
@@ -1448,21 +1450,28 @@ BASH
 }
 
 terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradicts>
-  local task=$1 note=$2 evidence_contradicts=$3 backend target exists expected out rc clean bytes lines seen=false contradiction=false reason='' remote_host
+  local task=$1 note=$2 evidence_contradicts=$3 backend target exists expected out rc clean bytes lines seen=false contradiction=false reason='' remote_host id captured_meta
   backend=$(printf '%s' "$task" | jq -r '.backend // ""')
   target=$(printf '%s' "$task" | jq -r '.endpoint.target // ""')
   exists=$(printf '%s' "$task" | jq -r '.endpoint.exists // "unknown"')
   remote_host=$(printf '%s' "$task" | jq -r '.remote.host // ""')
+  id=$(printf '%s' "$task" | jq -r '.id // ""')
   if [ -n "$remote_host" ]; then
     jq -n --arg observed "$SNAPSHOT_NOW" --arg reason "remote terminal evidence is not collected by the primary" \
       '{provenance:"remote-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:$reason,lines:0,bytes:0,event_note_seen:false,contradiction:false}'
     return 0
   fi
-  expected=$(printf '%s' "$task" | jq -r '"fm-" + (.id // "")')
+  expected="fm-$id"
   if [ -z "$target" ] || [ "$exists" = false ]; then
     [ "$exists" = false ] && reason="recorded endpoint is absent" || reason="no recorded endpoint"
     jq -n --arg observed "$SNAPSHOT_NOW" --arg reason "$reason" \
       '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"unknown",reason:$reason,lines:0,bytes:0,event_note_seen:false,contradiction:false}'
+    return 0
+  fi
+  captured_meta="$SNAPSHOT_TASK_DIR/$id.meta"
+  if [ ! -f "$captured_meta" ] || ! snapshot_task_generation_is_current "$captured_meta" "$id"; then
+    jq -n --arg observed "$SNAPSHOT_NOW" \
+      '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"unknown",reason:"task generation changed during snapshot",lines:0,bytes:0,event_note_seen:false,contradiction:false}'
     return 0
   fi
   # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
@@ -1474,6 +1483,11 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
     [ "$rc" -eq 124 ] && reason="terminal capture timed out" || reason="terminal capture unavailable"
     jq -n --arg observed "$SNAPSHOT_NOW" --arg reason "$reason" \
       '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"unknown",reason:$reason,lines:0,bytes:0,event_note_seen:false,contradiction:false}'
+    return 0
+  fi
+  if ! snapshot_task_generation_is_current "$captured_meta" "$id"; then
+    jq -n --arg observed "$SNAPSHOT_NOW" \
+      '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"unknown",reason:"task generation changed during snapshot",lines:0,bytes:0,event_note_seen:false,contradiction:false}'
     return 0
   fi
   clean=$(printf '%s' "$out" | tail -n "$FM_SNAPSHOT_TERMINAL_LINES" | LC_ALL=C head -c "$FM_SNAPSHOT_TERMINAL_BYTES")
@@ -1563,7 +1577,7 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
 
 secondmate_current_json() {  # <parent-tasks-json>
   local tasks=$1 registry union rows total_registered total shown truncated
-  local row id home host remote registered registry_error task sampled_spawn_gen status_file event_raw event_note event_epoch event_age
+  local row id home host remote registered registry_error task sampled_spawn_gen status_file status_observation_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot
   local records='[]' seen_homes=''
@@ -1605,12 +1619,14 @@ secondmate_current_json() {  # <parent-tasks-json>
     task=$(printf '%s' "$row" | jq -c '.parent_task // {}')
     sampled_spawn_gen=$(printf '%s' "$task" | jq -r '.spawn_gen // ""')
     status_file=$(printf '%s' "$task" | jq -r '.paths.status_log.path // ""')
+    status_observation_file=
+    if [ -n "$status_file" ]; then status_observation_file="$SNAPSHOT_TASK_DIR/$id.status"; fi
     event_raw=$(printf '%s' "$task" | jq -r '.paths.status_log.last_event.raw // ""')
     event_note=$(printf '%s' "$task" | jq -r '.paths.status_log.last_event.note // ""')
-    activity_scan=$(bounded_parent_activities_json "$status_file")
+    activity_scan=$(bounded_parent_activities_json "$status_observation_file")
     activities=$(printf '%s' "$activity_scan" | jq -c '.records')
     decisions=$(printf '%s' "$task" | jq -c '.hints.open_decisions // []')
-    event_epoch=$(file_mtime_epoch "$status_file")
+    event_epoch=$(file_mtime_epoch "$status_observation_file")
     event_age=null
     if [ -n "$event_epoch" ]; then
       event_age=$((SNAPSHOT_EPOCH - event_epoch))
@@ -1812,6 +1828,7 @@ scout_report_lines() {
 }
 
 BACKLOG_JSON=$(backlog_json) || { echo "fm-fleet-snapshot: backlog read failed" >&2; exit 1; }
+prefetch_task_current_states || { echo "fm-fleet-snapshot: task observation failed" >&2; exit 1; }
 TASKS_JSON=$(task_json_lines) || { echo "fm-fleet-snapshot: task snapshot failed" >&2; exit 1; }
 
 if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -255,14 +255,15 @@ last_nonempty_line() {  # <file>
 # A local crew-state read is bounded so one slow child cannot extend this
 # snapshot without limit. Remote secondmate endpoint liveness is never read here.
 # A local read that hits the bound folds to state unknown.
-crew_state_json() {  # <id> [<captured-meta>]
-  local id=$1 captured_meta=${2:-} raw rest state source detail sep
+crew_state_json() {  # <id> [<captured-meta>] [<captured-status>]
+  local id=$1 captured_meta=${2:-} captured_status=${3:-} raw rest state source detail sep
   raw=$(
     fm_run_timed "$FM_SNAPSHOT_CREW_STATE_TIMEOUT" \
       env FM_ROOT_OVERRIDE="$FM_ROOT" \
       FM_HOME="$FM_HOME" \
       FM_STATE_OVERRIDE="$STATE" \
       FM_CREW_STATE_META_OVERRIDE="$captured_meta" \
+      FM_CREW_STATE_STATUS_OVERRIDE="$captured_status" \
       FM_DATA_OVERRIDE="$DATA" \
       FM_PROJECTS_OVERRIDE="$PROJECTS" \
       FM_CONFIG_OVERRIDE="$CONFIG" \
@@ -542,7 +543,7 @@ prefetch_task_observations() {  # <meta> <id>
       > "$current_file" || current_rc=1
     agent_alive=unknown
   elif [ "$generation_current" = 1 ]; then
-    crew_state_json "$id" "$meta" > "$current_file" &
+    crew_state_json "$id" "$meta" "$status_capture" > "$current_file" &
     current_pid=$!
     kind=$(meta_value "$meta" kind)
     backend=$(fm_backend_of_meta "$meta")

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -764,10 +764,13 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
-  jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    ([ $backlog.records[]?
+  # Feed potentially large inventories through stdin. Linux limits each exec
+  # argument to 128 KiB even when ARG_MAX is larger, so --argjson can reject a
+  # valid large backlog before jq starts.
+  printf '%s\n%s\n' "$1" "$2" | jq -s '
+    .[0] as $backlog
+    | .[1] as $tasks
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
          | select(.state == "in_flight" and .structured and .requires_child_metadata) ]) as $owned_in_flight
@@ -792,17 +795,17 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
-  jq -n \
+  printf '%s\n%s\n' "$1" "$2" | jq -s \
     --arg generated "$SNAPSHOT_NOW" \
     --argjson generated_epoch "$SNAPSHOT_EPOCH" \
     --arg home "$FM_HOME" \
     --argjson child_n "$FM_SNAPSHOT_SECONDMATE_CHILDREN" \
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
-    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    def trunc($n):
+    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '
+    .[0] as $backlog
+    | .[1] as $tasks
+    | def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
     ([ $backlog.records[]?

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -33,7 +33,11 @@
 #     body carries an explicit SUPERSEDED / NOT REQUIRED / DEFERRED marker.
 #     It never changes captain_actionable; renderers may use it to keep
 #     prose-deferred rows out of default views.
-#   tasks[]: one row per state/<id>.meta, sorted by id.
+#   tasks[]: one row per task metadata record captured at snapshot start, sorted
+#     by id. A record removed before capture is omitted. If a captured task's
+#     generation changes while observations run, its selected metadata remains
+#     but mutable current-state, status, report, and endpoint evidence is discarded
+#     rather than attributed to the replacement generation.
 #     Local current_state is parsed from bin/fm-crew-state.sh <id> and preserves
 #     state, source, detail, and raw line separately. Remote secondmate rows use
 #     an explicit unknown value because their endpoint liveness belongs to

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -528,10 +528,19 @@ prefetch_task_current_states() {
     [ -e "$meta" ] || continue
     id=$(basename "$meta" .meta)
     captured_meta="$SNAPSHOT_TASK_DIR/$id.meta"
-    cp -- "$meta" "$captured_meta" || {
+    if ! cp -- "$meta" "$captured_meta" 2>"$captured_meta.copy-error"; then
+      # Teardown may unlink a task after the glob selected it but before cp opens
+      # it. That task is no longer in the inventory; other copy failures remain
+      # fatal rather than silently producing a partial snapshot.
+      if [ ! -e "$meta" ]; then
+        rm -f -- "$captured_meta" "$captured_meta.copy-error"
+        continue
+      fi
+      cat "$captured_meta.copy-error" >&2
       snapshot_task_cleanup
       return 1
-    }
+    fi
+    rm -f -- "$captured_meta.copy-error"
     SNAPSHOT_TASK_METAS[SNAPSHOT_TASK_META_COUNT]=$captured_meta
     SNAPSHOT_TASK_META_COUNT=$((SNAPSHOT_TASK_META_COUNT + 1))
   done

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -203,8 +203,8 @@ FM_SNAPSHOT_CACHE_DIR used when the live read fails, is invalid, or consumes the
 budget. A home with neither a valid ledger nor a valid cached copy is reported
 unreadable with the reason; collection never computes a summary in that home.
 Each local per-task current-state read is bounded by FM_SNAPSHOT_CREW_STATE_TIMEOUT
-(default 10 seconds); a read that hits the bound reports state unknown. Independent
-local reads run concurrently, up to FM_SNAPSHOT_LOCAL_READ_CONCURRENCY (default 8).
+(default 10 seconds); a read that hits the bound reports state unknown. Local task
+observations run concurrently, up to FM_SNAPSHOT_LOCAL_READ_CONCURRENCY (default 8).
 Remote secondmate endpoint liveness is not probed by this command.
 Terminal contradiction evidence uses
 FM_SNAPSHOT_TERMINAL_LINES, FM_SNAPSHOT_TERMINAL_BYTES, and
@@ -547,6 +547,7 @@ task_json_lines() {
   local meta id kind harness mode yolo project worktree home projects spawn_gen backend target status_log report_path
   local remote_host remote_root current_file endpoint_file observation_line rc
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
+  local decision_line decision_verb
   local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
@@ -587,14 +588,15 @@ task_json_lines() {
     fi
 
     current_file="$SNAPSHOT_TASK_DIR/$id.json"
-    current_json=$(cat "$current_file") || {
+    current_json=$(<"$current_file") || {
       snapshot_task_cleanup
       return 1
     }
     event_json=$(status_event_json "$status_log")
     last_event_raw=$(printf '%s' "$event_json" | jq -r '.last_event.raw // ""')
-    current_state=$(printf '%s' "$current_json" | jq -r '.state // ""')
-    current_source=$(printf '%s' "$current_json" | jq -r '.source // ""')
+    read -r current_state current_source < <(
+      printf '%s' "$current_json" | jq -r '[.state // "", .source // ""] | @tsv'
+    )
 
     # Durable keyed open-decision set: fold the WHOLE status stream
     # (fm-classify-lib.sh's status_open_decisions) so a later unrelated event can
@@ -624,8 +626,16 @@ task_json_lines() {
       [ splits("\n") | select(length > 0)
         | (capture("^(?<key>[^\t]*)\t(?<verb>[^\t]*)\t(?<summary>.*)$")?)
         | select(. != null) ]')
-    pending_decision=$(printf '%s' "$open_decisions_json" | jq 'if any(.[]; .verb == "needs-decision") then 1 else 0 end')
-    blocked_event=$(printf '%s' "$open_decisions_json" | jq 'if any(.[]; .verb == "blocked") then 1 else 0 end')
+    pending_decision=0
+    blocked_event=0
+    while IFS= read -r decision_line || [ -n "$decision_line" ]; do
+      decision_verb=${decision_line#*$'\t'}
+      decision_verb=${decision_verb%%$'\t'*}
+      case "$decision_verb" in
+        needs-decision) pending_decision=1 ;;
+        blocked) blocked_event=1 ;;
+      esac
+    done <<< "$open_decisions_tsv"
 
     endpoint_exists=null
     agent_alive=not_checked

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -480,9 +480,26 @@ snapshot_wait_current_reads() {  # <pid>...
   return "$rc"
 }
 
+snapshot_task_generation_is_current() {  # <captured-meta> <id>
+  local captured_meta=$1 id=$2 current_meta captured_gen current_gen captured_contents current_contents
+  current_meta="$STATE/$id.meta"
+  [ -f "$current_meta" ] || return 1
+  captured_gen=$(meta_value "$captured_meta" spawn_gen)
+  if [ -n "$captured_gen" ]; then
+    current_gen=$(meta_value "$current_meta" spawn_gen)
+    [ "$current_gen" = "$captured_gen" ]
+  else
+    # Legacy metadata has no generation token. Exact equality is the strongest
+    # available identity check and still detects ordinary teardown/relaunches.
+    captured_contents=$(<"$captured_meta") || return 1
+    current_contents=$(<"$current_meta") || return 1
+    [ "$current_contents" = "$captured_contents" ]
+  fi
+}
+
 prefetch_task_observations() {  # <meta> <id>
   local meta=$1 id=$2 remote_host current_file endpoint_file current_pid current_rc=0
-  local kind backend target endpoint_exists=null agent_alive=not_checked
+  local kind backend target endpoint_exists=null agent_alive=not_checked generation_current=1
   remote_host=$(meta_value "$meta" remote_host)
   current_file="$SNAPSHOT_TASK_DIR/$id.json"
   endpoint_file="$SNAPSHOT_TASK_DIR/$id.endpoint"
@@ -498,7 +515,8 @@ prefetch_task_observations() {  # <meta> <id>
   kind=$(meta_value "$meta" kind)
   backend=$(fm_backend_of_meta "$meta")
   target=$(fm_backend_target_of_meta "$meta")
-  if [ -n "$target" ]; then
+  snapshot_task_generation_is_current "$meta" "$id" || generation_current=0
+  if [ "$generation_current" = 1 ] && [ -n "$target" ]; then
     if fm_backend_target_exists "$backend" "$target" "fm-$id" >/dev/null 2>&1; then
       endpoint_exists=true
     else
@@ -507,6 +525,13 @@ prefetch_task_observations() {  # <meta> <id>
     if [ "$kind" = secondmate ]; then
       agent_alive=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null || printf unknown)
     fi
+  fi
+  # Targets are reusable (notably tmux's fm-<id> window). Revalidate after the
+  # probes so teardown/relaunch cannot attribute the replacement generation's
+  # endpoint state to the captured task.
+  if ! snapshot_task_generation_is_current "$meta" "$id"; then
+    endpoint_exists=null
+    agent_alive=unknown
   fi
   printf 'endpoint_exists=%s\nagent_alive=%s\n' "$endpoint_exists" "$agent_alive" > "$endpoint_file" || current_rc=1
   wait "$current_pid" || current_rc=1

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -251,13 +251,14 @@ last_nonempty_line() {  # <file>
 # A local crew-state read is bounded so one slow child cannot extend this
 # snapshot without limit. Remote secondmate endpoint liveness is never read here.
 # A local read that hits the bound folds to state unknown.
-crew_state_json() {  # <id>
-  local id=$1 raw rest state source detail sep
+crew_state_json() {  # <id> [<captured-meta>]
+  local id=$1 captured_meta=${2:-} raw rest state source detail sep
   raw=$(
     fm_run_timed "$FM_SNAPSHOT_CREW_STATE_TIMEOUT" \
       env FM_ROOT_OVERRIDE="$FM_ROOT" \
       FM_HOME="$FM_HOME" \
       FM_STATE_OVERRIDE="$STATE" \
+      FM_CREW_STATE_META_OVERRIDE="$captured_meta" \
       FM_DATA_OVERRIDE="$DATA" \
       FM_PROJECTS_OVERRIDE="$PROJECTS" \
       FM_CONFIG_OVERRIDE="$CONFIG" \
@@ -492,7 +493,7 @@ prefetch_task_observations() {  # <meta> <id>
     return 0
   fi
 
-  crew_state_json "$id" > "$current_file" &
+  crew_state_json "$id" "$meta" > "$current_file" &
   current_pid=$!
   kind=$(meta_value "$meta" kind)
   backend=$(fm_backend_of_meta "$meta")
@@ -1513,8 +1514,10 @@ secondmate_current_json() {  # <parent-tasks-json>
   local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
-    ($registry.records // []) as $registered
+  union=$(printf '%s\n%s\n' "$registry" "$tasks" | jq -s '
+    .[0] as $registry
+    | .[1] as $tasks
+    | ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
          | $r + {parent_task:([$tasks[] | select(.id == $r.id)][0] // null)} ]
@@ -1771,7 +1774,12 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
-jq -n \
+# Stream fleet-sized JSON values through stdin rather than argv: Linux applies
+# a much smaller per-argument limit than ARG_MAX, including to --argjson.
+printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
+  "$BACKLOG_JSON" "$TASKS_JSON" "$MAIN_INVENTORY_JSON" "$SCOUT_REPORTS_JSON" \
+  "$SECONDMATE_CURRENT_JSON" "$SECONDMATE_LANDED_JSON" \
+| jq -s \
   --arg generated "$SNAPSHOT_NOW" \
   --arg fm_home "$FM_HOME" \
   --arg fm_root "$FM_ROOT" \
@@ -1779,13 +1787,13 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  '.[0] as $backlog
+   | .[1] as $tasks
+   | .[2] as $main_inventory
+   | .[3] as $scout_reports
+   | .[4] as $secondmate_current
+   | .[5] as $secondmate_landed
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -817,6 +817,7 @@ FM_HOME_SUMMARY_TIMEOUT=60     # seconds bounding the complete best-effort home-
 FM_HOME_SUMMARY_ERROR_LOG_MAX_BYTES=65536   # approximate size cap for state/.home-summary-refresh.log before it is trimmed to the newest 200 lines; invalid or zero values use 65536
 FM_HOME_SUMMARY_FAILURE_REPORT=2   # recorded publication failures since the ledger's own last publication before session start reports a HOME_SUMMARY line; invalid or zero values use 2
 FM_SNAPSHOT_CREW_STATE_TIMEOUT=10   # seconds bounding each local per-task current-state read inside bin/fm-fleet-snapshot.sh; remote endpoint liveness is not probed on the snapshot path
+FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=8   # maximum local tasks whose current-state and endpoint observations are collected concurrently during snapshot composition
 FM_SNAPSHOT_BUDGET=5                # one total seconds budget for all concurrent remote home-ledger reads
 FM_SNAPSHOT_CACHE_DIR=$FM_HOME/state/secondmate-summary-cache   # private parent-side cache of successfully fetched remote home ledgers
 FM_RECONCILE_REQUEST_MAX_BYTES=1048576   # maximum captured Bearings or fleet snapshot accepted for durable reconcile-notify request publication

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -531,7 +531,7 @@ test_backend_validate_spawn_accepts_orca() {
 }
 
 test_meta_get_and_backend_of_meta() {
-  local meta=$TMP_ROOT/meta-get.meta
+  local meta=$TMP_ROOT/meta-get.meta edge=$TMP_ROOT/meta-get-edge.meta
   fm_write_meta "$meta" "window=firstmate:fm-x1" "harness=claude"
   [ "$(fm_meta_get "$meta" window)" = "firstmate:fm-x1" ] || fail "fm_meta_get did not read window="
   [ "$(fm_meta_get "$meta" missing)" = "" ] || fail "fm_meta_get should print nothing for an absent key"
@@ -540,7 +540,11 @@ test_meta_get_and_backend_of_meta() {
   printf 'backend=tmux\n' >> "$meta"
   [ "$(fm_backend_of_meta "$meta")" = tmux ] || fail "fm_backend_of_meta should read an explicit backend=tmux"
 
-  pass "fm_meta_get / fm_backend_of_meta: read key=value, default backend to tmux"
+  printf 'token=first\ntoken=last=value' > "$edge"
+  [ "$(fm_meta_get "$edge" token)" = "last=value" ] \
+    || fail "fm_meta_get did not preserve last-value or no-final-newline semantics"
+
+  pass "fm_meta_get / fm_backend_of_meta: read last key=value and default backend to tmux"
 }
 
 test_resolve_selector_three_forms() {

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -2164,7 +2164,7 @@ EOF
 }
 
 test_large_local_snapshot_composes_under_five_seconds_without_projection_drift() {
-  local home fakebin worktree serial parallel started elapsed i
+  local home fakebin worktree serial parallel parallel_file snapshot_pid started elapsed i
   home=$(make_home large-local-snapshot)
   worktree="$home/projects/shared-worktree"
   fm_git_init_commit "$worktree"
@@ -2172,7 +2172,10 @@ test_large_local_snapshot_composes_under_five_seconds_without_projection_drift()
   fakebin=$(make_fakebin "$home")
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
-if [ "$*" = "axi status" ] && [ "${FAKE_NM_DELAY:-0}" = 1 ]; then sleep 1; fi
+if [ "$*" = "axi status" ] && [ "${FAKE_NM_DELAY:-0}" = 1 ]; then
+  [ -z "${FAKE_NM_SIGNAL:-}" ] || : > "$FAKE_NM_SIGNAL"
+  sleep 1
+fi
 exit 0
 SH
   chmod +x "$fakebin/no-mistakes"
@@ -2202,7 +2205,28 @@ SH
 
   serial=$(FAKE_NM_DELAY=0 FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=1 run "$home" "$fakebin" --json)
   started=$(date +%s)
-  parallel=$(FAKE_NM_DELAY=1 FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=8 run "$home" "$fakebin" --json)
+  parallel_file="$home/parallel-snapshot.json"
+  FAKE_NM_DELAY=1 FAKE_NM_SIGNAL="$home/nm-started" FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=8 \
+    run "$home" "$fakebin" --json > "$parallel_file" &
+  snapshot_pid=$!
+  i=0
+  while [ ! -e "$home/nm-started" ] && [ "$i" -lt 100 ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  if [ ! -e "$home/nm-started" ]; then
+    kill "$snapshot_pid" 2>/dev/null || true
+    wait "$snapshot_pid" 2>/dev/null || true
+    fail "concurrent local snapshot never began a current-state read"
+  fi
+  # Replace mutable publication metadata while current-state reads are in flight.
+  # The composed row must retain the metadata generation paired with its prefetched
+  # observation rather than becoming a ship observation attributed to a scout.
+  fm_write_meta "$home/state/local-1.meta" \
+    "window=fixture:local-1" "worktree=$worktree" "project=firstmate" \
+    "harness=claude" "kind=scout" "mode=scout"
+  wait "$snapshot_pid" || fail "concurrent local snapshot failed"
+  parallel=$(<"$parallel_file")
   elapsed=$(( $(date +%s) - started ))
   [ "$elapsed" -lt 5 ] \
     || fail "five local current-state reads exceeded the local composition target (${elapsed}s)"
@@ -2212,6 +2236,7 @@ SH
     .schema == "fm-bearings.v1"
       and (.in_flight | length) == 5
       and ([.in_flight[].id] | sort) == ["local-1","local-2","local-3","local-4","local-5"]
+      and ([.in_flight[] | select(.id == "local-1" and .kind == "ship")] | length) == 1
   ' >/dev/null || fail "large local snapshot lost a worker row: $parallel"
   pass "large local snapshot stays under five seconds with byte-identical serial and concurrent projections"
 }

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -2163,6 +2163,59 @@ EOF
   pass "main and secondmate captain actionability use the same blocker readiness"
 }
 
+test_large_local_snapshot_composes_under_five_seconds_without_projection_drift() {
+  local home fakebin worktree serial parallel started elapsed i
+  home=$(make_home large-local-snapshot)
+  worktree="$home/projects/shared-worktree"
+  fm_git_init_commit "$worktree"
+  git -C "$worktree" checkout -qb fm/synthetic-large-local
+  fakebin=$(make_fakebin "$home")
+  cat > "$fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+if [ "$*" = "axi status" ] && [ "${FAKE_NM_DELAY:-0}" = 1 ]; then sleep 1; fi
+exit 0
+SH
+  chmod +x "$fakebin/no-mistakes"
+
+  {
+    printf '## In flight\n'
+    i=1
+    while [ "$i" -le 5 ]; do
+      printf -- '- [ ] local-%s - Synthetic local worker %s (repo: firstmate) (kind: ship)\n' "$i" "$i"
+      i=$((i + 1))
+    done
+    printf '\n## Queued\n\n## Done\n'
+    i=1
+    while [ "$i" -le 300 ]; do
+      printf -- '- [x] history-%s - Historical completed item %s https://github.com/acme/firstmate/pull/%s (repo: firstmate) (kind: ship) (done 2026-01-01)\n' "$i" "$i" "$i"
+      i=$((i + 1))
+    done
+  } > "$home/data/backlog.md"
+  i=1
+  while [ "$i" -le 5 ]; do
+    fm_write_meta "$home/state/local-$i.meta" \
+      "window=fixture:local-$i" "worktree=$worktree" "project=firstmate" \
+      "harness=claude" "kind=ship" "mode=no-mistakes"
+    printf 'working: synthetic fixture\n' > "$home/state/local-$i.status"
+    i=$((i + 1))
+  done
+
+  serial=$(FAKE_NM_DELAY=0 FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=1 run "$home" "$fakebin" --json)
+  started=$(date +%s)
+  parallel=$(FAKE_NM_DELAY=1 FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=8 run "$home" "$fakebin" --json)
+  elapsed=$(( $(date +%s) - started ))
+  [ "$elapsed" -lt 5 ] \
+    || fail "five local current-state reads exceeded the local composition target (${elapsed}s)"
+  [ "$parallel" = "$serial" ] \
+    || fail "concurrent local observation changed the fm-bearings.v1 projection"
+  printf '%s' "$parallel" | jq -e '
+    .schema == "fm-bearings.v1"
+      and (.in_flight | length) == 5
+      and ([.in_flight[].id] | sort) == ["local-1","local-2","local-3","local-4","local-5"]
+  ' >/dev/null || fail "large local snapshot lost a worker row: $parallel"
+  pass "large local snapshot stays under five seconds with byte-identical serial and concurrent projections"
+}
+
 test_remote_ledgers_share_one_concurrent_budget_and_fall_back_to_cache() {
   local parent fakebin json started elapsed i remote_home pid collector_pid sleeper_pid duplicate_base
   parent=$(make_home concurrent-remote-ledgers)
@@ -2283,6 +2336,7 @@ test_a_remote_home_without_any_ledger_is_explicitly_unreadable_without_remote_co
   pass "a missing remote ledger stays explicitly unreadable without remote summary computation"
 }
 
+test_large_local_snapshot_composes_under_five_seconds_without_projection_drift
 test_remote_ledgers_share_one_concurrent_budget_and_fall_back_to_cache
 test_a_remote_home_without_any_ledger_is_explicitly_unreadable_without_remote_compute
 test_domain_alpha_stale_parent_event_does_not_become_current_work

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -2221,7 +2221,7 @@ SH
 }
 
 test_large_local_snapshot_composes_under_five_seconds_without_projection_drift() {
-  local home fakebin worktree serial parallel parallel_file snapshot_pid started elapsed i
+  local home fakebin worktree real_cp serial parallel parallel_file snapshot_pid started elapsed i
   home=$(make_home large-local-snapshot)
   worktree="$home/projects/shared-worktree"
   fm_git_init_commit "$worktree"
@@ -2235,7 +2235,27 @@ if [ "$*" = "axi status" ] && [ "${FAKE_NM_DELAY:-0}" = 1 ]; then
 fi
 exit 0
 SH
-  chmod +x "$fakebin/no-mistakes"
+  real_cp=$(command -v cp)
+  cat > "$fakebin/cp" <<'SH'
+#!/usr/bin/env bash
+"$REAL_CP" "$@" || exit
+if [ "${FAKE_REPLACE_AFTER_COPY:-0}" = 1 ]; then
+  for arg in "$@"; do
+    if [ "$arg" = "$FAKE_REPLACE_META" ]; then
+      cat > "$FAKE_REPLACE_META" <<EOF
+window=fixture:local-1
+worktree=$FAKE_REPLACEMENT_WORKTREE
+project=firstmate
+harness=claude
+kind=scout
+mode=scout
+EOF
+      break
+    fi
+  done
+fi
+SH
+  chmod +x "$fakebin/no-mistakes" "$fakebin/cp"
 
   {
     printf '## In flight\n'
@@ -2260,10 +2280,13 @@ SH
     i=$((i + 1))
   done
 
-  serial=$(FAKE_NM_DELAY=0 FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=1 run "$home" "$fakebin" --json)
+  serial=$(REAL_CP="$real_cp" FAKE_NM_DELAY=0 FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=1 run "$home" "$fakebin" --json)
   started=$(date +%s)
   parallel_file="$home/parallel-snapshot.json"
-  FAKE_NM_DELAY=1 FAKE_NM_SIGNAL="$home/nm-started" FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=8 \
+  REAL_CP="$real_cp" FAKE_REPLACE_AFTER_COPY=1 \
+    FAKE_REPLACE_META="$home/state/local-1.meta" \
+    FAKE_REPLACEMENT_WORKTREE="$home/projects/replacement-not-created" \
+    FAKE_NM_DELAY=1 FAKE_NM_SIGNAL="$home/nm-started" FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=8 \
     run "$home" "$fakebin" --json > "$parallel_file" &
   snapshot_pid=$!
   i=0
@@ -2276,12 +2299,9 @@ SH
     wait "$snapshot_pid" 2>/dev/null || true
     fail "concurrent local snapshot never began a current-state read"
   fi
-  # Replace mutable publication metadata while current-state reads are in flight.
-  # The composed row must retain the metadata generation paired with its prefetched
-  # observation rather than becoming a ship observation attributed to a scout.
-  fm_write_meta "$home/state/local-1.meta" \
-    "window=fixture:local-1" "worktree=$worktree" "project=firstmate" \
-    "harness=claude" "kind=scout" "mode=scout"
+  # The cp fixture replaces local-1 immediately after its captured generation is
+  # copied, before observation workers start. Current state must use that captured
+  # metadata too, rather than crossing into the replacement task generation.
   wait "$snapshot_pid" || fail "concurrent local snapshot failed"
   parallel=$(<"$parallel_file")
   elapsed=$(( $(date +%s) - started ))

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -2163,6 +2163,63 @@ EOF
   pass "main and secondmate captain actionability use the same blocker readiness"
 }
 
+test_task_teardown_during_metadata_capture_does_not_abort_snapshot() {
+  local home fakebin real_cp output snapshot_pid i
+  home=$(make_home metadata-teardown-race)
+  fakebin=$(make_fakebin "$home")
+  real_cp=$(command -v cp)
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] a-hold - Stable local worker (repo: firstmate) (kind: ship)
+
+## Queued
+
+## Done
+EOF
+  fm_write_meta "$home/state/a-hold.meta" \
+    "window=fixture:a-hold" "project=firstmate" "harness=claude" "kind=ship" "mode=no-mistakes"
+  fm_write_meta "$home/state/z-gone.meta" \
+    "window=fixture:z-gone" "project=firstmate" "harness=claude" "kind=ship" "mode=no-mistakes"
+  printf 'working: stable fixture\n' > "$home/state/a-hold.status"
+  cat > "$fakebin/cp" <<'SH'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    */a-hold.meta)
+      : > "$FAKE_CP_STARTED"
+      while [ ! -e "$FAKE_CP_RELEASE" ]; do sleep 0.01; done
+      break
+      ;;
+  esac
+done
+exec "$REAL_CP" "$@"
+SH
+  chmod +x "$fakebin/cp"
+
+  REAL_CP="$real_cp" FAKE_CP_STARTED="$home/cp-started" FAKE_CP_RELEASE="$home/cp-release" \
+    run "$home" "$fakebin" --json > "$home/snapshot.json" &
+  snapshot_pid=$!
+  i=0
+  while [ ! -e "$home/cp-started" ] && [ "$i" -lt 500 ]; do
+    sleep 0.01
+    i=$((i + 1))
+  done
+  if [ ! -e "$home/cp-started" ]; then
+    kill "$snapshot_pid" 2>/dev/null || true
+    wait "$snapshot_pid" 2>/dev/null || true
+    fail "snapshot never entered metadata capture"
+  fi
+  rm -f "$home/state/z-gone.meta"
+  : > "$home/cp-release"
+  wait "$snapshot_pid" || fail "task teardown aborted the public Bearings snapshot"
+  output=$(<"$home/snapshot.json")
+  printf '%s' "$output" | jq -e '
+    .schema == "fm-bearings.v1"
+      and ([.in_flight[].id] | sort) == ["a-hold"]
+  ' >/dev/null || fail "snapshot after concurrent teardown was not usable: $output"
+  pass "task teardown during metadata capture is omitted without aborting the snapshot"
+}
+
 test_large_local_snapshot_composes_under_five_seconds_without_projection_drift() {
   local home fakebin worktree serial parallel parallel_file snapshot_pid started elapsed i
   home=$(make_home large-local-snapshot)
@@ -2361,6 +2418,7 @@ test_a_remote_home_without_any_ledger_is_explicitly_unreadable_without_remote_co
   pass "a missing remote ledger stays explicitly unreadable without remote summary computation"
 }
 
+test_task_teardown_during_metadata_capture_does_not_abort_snapshot
 test_large_local_snapshot_composes_under_five_seconds_without_projection_drift
 test_remote_ledgers_share_one_concurrent_budget_and_fall_back_to_cache
 test_a_remote_home_without_any_ledger_is_explicitly_unreadable_without_remote_compute

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -2220,6 +2220,61 @@ SH
   pass "task teardown during metadata capture is omitted without aborting the snapshot"
 }
 
+test_relaunched_task_does_not_inherit_reused_endpoint_state() {
+  local home fakebin worktree json
+  home=$(make_home endpoint-generation-race)
+  worktree="$home/projects/generation-race-not-created"
+  fakebin=$(make_fakebin "$home")
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] generation-race - Generation identity fixture (repo: firstmate) (kind: ship)
+
+## Queued
+
+## Done
+EOF
+  fm_write_meta "$home/state/generation-race.meta" \
+    "window=fixture:fm-generation-race" "worktree=$worktree" "project=firstmate" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "spawn_gen=old-generation"
+  printf 'working: old generation\n' > "$home/state/generation-race.status"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = display-message ]; then
+  if mkdir "$RACE_ONCE" 2>/dev/null; then
+    tmp="$RACE_META.tmp.$$"
+    cat > "$tmp" <<EOF
+window=fixture:fm-generation-race
+worktree=$RACE_WORKTREE
+project=firstmate
+harness=claude
+kind=ship
+mode=no-mistakes
+spawn_gen=new-generation
+EOF
+    mv "$tmp" "$RACE_META"
+  fi
+  # The old endpoint disappeared while a replacement reused the same target.
+  exit 1
+fi
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+
+  json=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z \
+    FM_SNAPSHOT_NOW_EPOCH=1783792800 NET_LOG="$home/net.log" \
+    RACE_ONCE="$home/relaunch-once" RACE_META="$home/state/generation-race.meta" \
+    RACE_WORKTREE="$worktree" "$ROOT/bin/fm-fleet-snapshot.sh" --json) \
+    || fail "fleet snapshot failed during endpoint generation race"
+  printf '%s' "$json" | jq -e '
+    .tasks[] | select(.id == "generation-race")
+    | .spawn_gen == "old-generation"
+      and .endpoint.exists == null
+      and .endpoint.agent_alive == "unknown"
+      and .endpoint.status == "unknown"
+  ' >/dev/null || fail "replacement endpoint state crossed task generations: $json"
+  pass "reused endpoint state is discarded when task generation changes"
+}
+
 test_large_local_snapshot_composes_under_five_seconds_without_projection_drift() {
   local home fakebin worktree real_cp serial parallel parallel_file snapshot_pid started elapsed i
   home=$(make_home large-local-snapshot)
@@ -2439,6 +2494,7 @@ test_a_remote_home_without_any_ledger_is_explicitly_unreadable_without_remote_co
 }
 
 test_task_teardown_during_metadata_capture_does_not_abort_snapshot
+test_relaunched_task_does_not_inherit_reused_endpoint_state
 test_large_local_snapshot_composes_under_five_seconds_without_projection_drift
 test_remote_ledgers_share_one_concurrent_budget_and_fall_back_to_cache
 test_a_remote_home_without_any_ledger_is_explicitly_unreadable_without_remote_compute

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -2220,6 +2220,57 @@ SH
   pass "task teardown during metadata capture is omitted without aborting the snapshot"
 }
 
+test_current_state_uses_captured_status_observation() {
+  local home fakebin real_cp worktree json
+  home=$(make_home captured-status-race)
+  fakebin=$(make_fakebin "$home")
+  real_cp=$(command -v cp)
+  worktree="$home/projects/captured-status"
+  mkdir -p "$worktree"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] captured-status - Captured status fixture (repo: firstmate) (kind: ship)
+
+## Queued
+
+## Done
+EOF
+  fm_write_meta "$home/state/captured-status.meta" \
+    "window=fixture:captured-status" "worktree=$worktree" "project=firstmate" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "spawn_gen=stable-generation"
+  printf 'working: captured state\n' > "$home/state/captured-status.status"
+  record_claude_state "$home/state" captured-status idle
+  cat > "$fakebin/cp" <<'SH'
+#!/usr/bin/env bash
+"$REAL_CP" "$@" || exit
+for arg in "$@"; do
+  if [ "$arg" = "$RACE_STATUS" ] && mkdir "$RACE_ONCE" 2>/dev/null; then
+    printf 'needs-decision[new]: appended after capture\n' >> "$RACE_STATUS"
+    break
+  fi
+done
+SH
+  chmod +x "$fakebin/cp"
+
+  json=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z \
+    FM_SNAPSHOT_NOW_EPOCH=1783792800 NET_LOG="$home/net.log" REAL_CP="$real_cp" \
+    RACE_ONCE="$home/status-race-once" RACE_STATUS="$home/state/captured-status.status" \
+    "$ROOT/bin/fm-fleet-snapshot.sh" --json) \
+    || fail "fleet snapshot failed during captured status race"
+  printf '%s' "$json" | jq -e '
+    .tasks[] | select(.id == "captured-status")
+    | .current_state.state == "working"
+      and .current_state.source == "status-log"
+      and .paths.status_log.last_event.raw == "working: captured state"
+      and .hints.pending_decision == false
+      and .hints.open_decisions == []
+  ' >/dev/null || fail "current state escaped the captured status observation: $json"
+  [ "$(tail -n 1 "$home/state/captured-status.status")" = \
+      "needs-decision[new]: appended after capture" ] \
+    || fail "captured status race fixture did not append the live decision"
+  pass "current state and decision hints share one captured status observation"
+}
+
 test_relaunched_task_does_not_inherit_reused_endpoint_state() {
   local home fakebin worktree json
   home=$(make_home endpoint-generation-race)
@@ -2499,6 +2550,7 @@ test_a_remote_home_without_any_ledger_is_explicitly_unreadable_without_remote_co
 }
 
 test_task_teardown_during_metadata_capture_does_not_abort_snapshot
+test_current_state_uses_captured_status_observation
 test_relaunched_task_does_not_inherit_reused_endpoint_state
 test_large_local_snapshot_overlaps_local_reads_without_projection_drift
 test_remote_ledgers_share_one_concurrent_budget_and_fall_back_to_cache

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -2288,8 +2288,9 @@ SH
   pass "reused live state is discarded when task generation changes"
 }
 
-test_large_local_snapshot_composes_under_five_seconds_without_projection_drift() {
-  local home fakebin worktree serial parallel parallel_file snapshot_pid started elapsed i
+test_large_local_snapshot_overlaps_local_reads_without_projection_drift() {
+  local home fakebin worktree serial parallel parallel_file snapshot_pid i
+  local serial_started serial_elapsed parallel_started parallel_elapsed saved
   home=$(make_home large-local-snapshot)
   worktree="$home/projects/shared-worktree"
   fm_git_init_commit "$worktree"
@@ -2329,7 +2330,19 @@ SH
   done
 
   serial=$(FAKE_NM_DELAY=0 FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=1 run "$home" "$fakebin" --json)
-  started=$(date +%s)
+
+  # Serialized reads pay every worker's delay end to end while concurrent reads
+  # overlap them. Time both runs and compare, because the two pay the same
+  # composition overhead: the difference isolates the overlap this change
+  # delivers, where an absolute wall-clock budget would instead measure how
+  # loaded the host happens to be and flake on a busy runner.
+  serial_started=$(date +%s)
+  FAKE_NM_DELAY=1 FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=1 \
+    run "$home" "$fakebin" --json >/dev/null \
+    || fail "serialized local snapshot failed"
+  serial_elapsed=$(( $(date +%s) - serial_started ))
+
+  parallel_started=$(date +%s)
   parallel_file="$home/parallel-snapshot.json"
   FAKE_NM_DELAY=1 FAKE_NM_SIGNAL="$home/nm-started" \
     FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=8 \
@@ -2347,9 +2360,13 @@ SH
   fi
   wait "$snapshot_pid" || fail "concurrent local snapshot failed"
   parallel=$(<"$parallel_file")
-  elapsed=$(( $(date +%s) - started ))
-  [ "$elapsed" -lt 5 ] \
-    || fail "five local current-state reads exceeded the local composition target (${elapsed}s)"
+  parallel_elapsed=$(( $(date +%s) - parallel_started ))
+  # Five one-second reads serialize into five seconds and overlap into about
+  # one, so at least two of those four seconds must show up as real savings.
+  # Serializing the reads again collapses that difference to roughly zero.
+  saved=$(( serial_elapsed - parallel_elapsed ))
+  [ "$saved" -ge 2 ] \
+    || fail "concurrent local reads saved no measurable time (serial ${serial_elapsed}s vs concurrent ${parallel_elapsed}s)"
   [ "$parallel" = "$serial" ] \
     || fail "concurrent local observation changed the fm-bearings.v1 projection"
   printf '%s' "$parallel" | jq -e '
@@ -2358,7 +2375,7 @@ SH
       and ([.in_flight[].id] | sort) == ["local-1","local-2","local-3","local-4","local-5"]
       and ([.in_flight[] | select(.id == "local-1" and .kind == "ship")] | length) == 1
   ' >/dev/null || fail "large local snapshot lost a worker row: $parallel"
-  pass "large local snapshot stays under five seconds with byte-identical serial and concurrent projections"
+  pass "large local snapshot overlaps local reads with byte-identical serial and concurrent projections"
 }
 
 test_remote_ledgers_share_one_concurrent_budget_and_fall_back_to_cache() {
@@ -2483,7 +2500,7 @@ test_a_remote_home_without_any_ledger_is_explicitly_unreadable_without_remote_co
 
 test_task_teardown_during_metadata_capture_does_not_abort_snapshot
 test_relaunched_task_does_not_inherit_reused_endpoint_state
-test_large_local_snapshot_composes_under_five_seconds_without_projection_drift
+test_large_local_snapshot_overlaps_local_reads_without_projection_drift
 test_remote_ledgers_share_one_concurrent_budget_and_fall_back_to_cache
 test_a_remote_home_without_any_ledger_is_explicitly_unreadable_without_remote_compute
 test_domain_alpha_stale_parent_event_does_not_become_current_work

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -2252,6 +2252,9 @@ mode=no-mistakes
 spawn_gen=new-generation
 EOF
     mv "$tmp" "$RACE_META"
+    printf 'needs-decision[replacement]: replacement-only decision https://github.com/acme/firstmate/pull/999\n' > "$RACE_STATUS"
+    mkdir -p "$(dirname "$RACE_REPORT")"
+    printf 'replacement-only report\n' > "$RACE_REPORT"
   fi
   # The old endpoint disappeared while a replacement reused the same target.
   exit 1
@@ -2263,20 +2266,30 @@ SH
   json=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z \
     FM_SNAPSHOT_NOW_EPOCH=1783792800 NET_LOG="$home/net.log" \
     RACE_ONCE="$home/relaunch-once" RACE_META="$home/state/generation-race.meta" \
-    RACE_WORKTREE="$worktree" "$ROOT/bin/fm-fleet-snapshot.sh" --json) \
+    RACE_STATUS="$home/state/generation-race.status" \
+    RACE_REPORT="$home/data/generation-race/report.md" RACE_WORKTREE="$worktree" \
+    "$ROOT/bin/fm-fleet-snapshot.sh" --json) \
     || fail "fleet snapshot failed during endpoint generation race"
   printf '%s' "$json" | jq -e '
     .tasks[] | select(.id == "generation-race")
     | .spawn_gen == "old-generation"
+      and .current_state.state == "unknown"
       and .endpoint.exists == null
       and .endpoint.agent_alive == "unknown"
       and .endpoint.status == "unknown"
-  ' >/dev/null || fail "replacement endpoint state crossed task generations: $json"
-  pass "reused endpoint state is discarded when task generation changes"
+      and .pr.url == null
+      and .paths.status_log.present == false
+      and .paths.report.present == false
+      and .hints.pending_decision == false
+      and .hints.open_decisions == []
+      and .hints.scout_report_present == false
+      and .hints.last_event_text == ""
+  ' >/dev/null || fail "replacement live state crossed task generations: $json"
+  pass "reused live state is discarded when task generation changes"
 }
 
 test_large_local_snapshot_composes_under_five_seconds_without_projection_drift() {
-  local home fakebin worktree real_cp serial parallel parallel_file snapshot_pid started elapsed i
+  local home fakebin worktree serial parallel parallel_file snapshot_pid started elapsed i
   home=$(make_home large-local-snapshot)
   worktree="$home/projects/shared-worktree"
   fm_git_init_commit "$worktree"
@@ -2290,27 +2303,7 @@ if [ "$*" = "axi status" ] && [ "${FAKE_NM_DELAY:-0}" = 1 ]; then
 fi
 exit 0
 SH
-  real_cp=$(command -v cp)
-  cat > "$fakebin/cp" <<'SH'
-#!/usr/bin/env bash
-"$REAL_CP" "$@" || exit
-if [ "${FAKE_REPLACE_AFTER_COPY:-0}" = 1 ]; then
-  for arg in "$@"; do
-    if [ "$arg" = "$FAKE_REPLACE_META" ]; then
-      cat > "$FAKE_REPLACE_META" <<EOF
-window=fixture:local-1
-worktree=$FAKE_REPLACEMENT_WORKTREE
-project=firstmate
-harness=claude
-kind=scout
-mode=scout
-EOF
-      break
-    fi
-  done
-fi
-SH
-  chmod +x "$fakebin/no-mistakes" "$fakebin/cp"
+  chmod +x "$fakebin/no-mistakes"
 
   {
     printf '## In flight\n'
@@ -2335,13 +2328,11 @@ SH
     i=$((i + 1))
   done
 
-  serial=$(REAL_CP="$real_cp" FAKE_NM_DELAY=0 FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=1 run "$home" "$fakebin" --json)
+  serial=$(FAKE_NM_DELAY=0 FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=1 run "$home" "$fakebin" --json)
   started=$(date +%s)
   parallel_file="$home/parallel-snapshot.json"
-  REAL_CP="$real_cp" FAKE_REPLACE_AFTER_COPY=1 \
-    FAKE_REPLACE_META="$home/state/local-1.meta" \
-    FAKE_REPLACEMENT_WORKTREE="$home/projects/replacement-not-created" \
-    FAKE_NM_DELAY=1 FAKE_NM_SIGNAL="$home/nm-started" FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=8 \
+  FAKE_NM_DELAY=1 FAKE_NM_SIGNAL="$home/nm-started" \
+    FM_SNAPSHOT_LOCAL_READ_CONCURRENCY=8 \
     run "$home" "$fakebin" --json > "$parallel_file" &
   snapshot_pid=$!
   i=0
@@ -2354,9 +2345,6 @@ SH
     wait "$snapshot_pid" 2>/dev/null || true
     fail "concurrent local snapshot never began a current-state read"
   fi
-  # The cp fixture replaces local-1 immediately after its captured generation is
-  # copied, before observation workers start. Current state must use that captured
-  # metadata too, rather than crossing into the replacement task generation.
   wait "$snapshot_pid" || fail "concurrent local snapshot failed"
   parallel=$(<"$parallel_file")
   elapsed=$(( $(date +%s) - started ))


### PR DESCRIPTION
## Intent

Cut the cost of composing the LOCAL Bearings fleet snapshot so that on a large home a same-home run is fast in both the cold and the warm case, targeting under 5 seconds. Before this change local composition took roughly 13-16 seconds on a large home. This is specifically the LOCAL composition path and is a separate concern from the remote ledger collector, which already returns in about 2 seconds and is not what this work is about.

The hard acceptance criterion is that the fm-bearings.v1 projection output must stay IDENTICAL apart from timestamps. This is a pure cost fix: no field may change value, appear, or disappear, and no row may be reordered or dropped. Speed must not be bought with any behavior or output change.

Accepted scope decision, deliberately narrow. Only the real hot paths are addressed:
1. The per-task local observations. For each task the snapshot needs a current-state read and an endpoint-existence probe, and for secondmates an agent-liveness read. These are independent observations, and the previous code performed them strictly in series across every task, so a home with N local workers paid N slow reads back to back. They are now prefetched per task, with each task's current-state read and endpoint probe started together, across a bounded worker pool. The pool size is the new FM_SNAPSHOT_LOCAL_READ_CONCURRENCY knob, default 8, validated by the same positive-bound validator as the other snapshot knobs.
2. fm_meta_get in bin/fm-backend.sh, which is called many times per task and per snapshot and previously spawned a grep | tail | cut subprocess chain on every single call. It is now a pure-shell read loop. Its existing semantics are preserved exactly: last value wins for a repeated key, and a file with no trailing newline still yields its final value.

Broader ideas that were considered and deliberately NOT pursued in this change: rewriting the large-backlog parse, changing the scout-report scan, and a general reduction of the many small jq invocations. Those were dropped in favour of this narrower, lower-risk fix against the paths that actually dominate the measured cost. Reviewers should not treat their absence as an oversight.

Constraints held throughout:
- bin/fm-timeout-lib.sh remains the single owner of bounded execution. This change introduces no new timeout, deadline, or kill mechanism; every command bound, including the existing FM_SNAPSHOT_CREW_STATE_TIMEOUT per-task bound, is still owned there. The concurrency added here only decides how many bounded reads may be in flight at once.
- Everything stays bash 3.2 safe, since that is the system bash on macOS.
- Temporary per-task observation files are created under a mktemp -d directory with umask 077, and are cleaned up both on the normal path and through the EXIT trap, which now chains the task cleanup alongside the pre-existing collection cleanup.
- Tests are behavioral: they drive the real command and assert observable output and timing, never implementation source text.

Test coverage added:
- A behavioral regression that builds a synthetic large home (five local workers plus a 300-entry Done backlog), runs the real snapshot twice, and asserts three things: composition stays under the five second target, the serial and concurrent projections are byte-identical so concurrency introduces no drift, and every worker row survives.
- An extension of the existing fm_meta_get test covering the last-value-wins and missing-final-newline edge cases that the pure-shell rewrite has to preserve.

Context for this particular run: the change was already implemented, committed, and opened as a pull request, but that pull request then fell behind and conflicted with the default branch, and its earlier validation run was aborted for a tooling upgrade. The branch has now been rebased onto the current default branch. The one conflict was in bin/fm-fleet-snapshot.sh, where the default branch had meanwhile removed the remote_home_present variable entirely as part of removing legacy remote snapshot reads. The resolution keeps the default branch's removal of that variable while preserving the concurrent prefetch, and carries the default branch's updated rationale comment about not probing remote endpoints into the prefetch function, which is where that decision now lives. A full fresh validation is wanted on the rebased head.

End-to-end verification already performed on a copy of a real large home (8 local workers, 887-line backlog, real worktrees and real backends), measured with the pre-change and post-change code interleaved so that host load affects both equally: the snapshot went from roughly 18-26 seconds to roughly 6-10 seconds, and the bearings projection from roughly 14-20 seconds to roughly 6-9 seconds, a consistent 2.5-3x reduction. Absolute numbers were inflated because the host was heavily oversubscribed at the time (load average 16-26 on 14 CPUs) by unrelated concurrent work; the eight per-task reads alone accounted for 4.6-6.0 seconds of that on their own, and a single external per-task status call cost 1.0-1.4 seconds under the same load, so the snapshot's own composition is now a small remainder on top of that external term. Output identity was confirmed on the same real home: the fm-bearings.v1 projection compared 218 leaves with 217 byte-identical and the single difference being the generated timestamp, and the underlying fm-fleet-snapshot.v1 projection compared 5153 leaves with 5135 byte-identical, the differences being only observed_at timestamps.

Do not merge the pull request; merge authority is not granted for this work.

Two corrections were made on top of the recovered pull-request head before this run. First, the large-local-snapshot regression originally asserted that a whole snapshot composed in under five seconds; that bound measures host load rather than whether the per-task reads actually overlap, and it failed roughly one run in six on a contended machine, landing exactly on the five second boundary. It now times a serialized run and a concurrent run of the same workload and requires the concurrent one to save at least two seconds, so the two runs' shared composition overhead cancels and the assertion still fails loudly when the concurrency regresses, which was confirmed by forcing the concurrent run back to serial. Second, the pinned Bearings test count in CI moved from 47 to 48 because rebasing onto the current default branch picked up its captain-hold test.

## What Changed
- Prefetch local task state, endpoint, and secondmate-liveness observations through a bounded, configurable worker pool while keeping captured observations generation-coherent.
- Replace `fm_meta_get` subprocess chains with a semantics-preserving shell loop and stream large snapshot JSON values through stdin.
- Add behavioral coverage for concurrent-read projection identity, metadata and status races, generation changes, teardown, and metadata edge cases.

## Risk Assessment

✅ Low: The concurrent observation path is bounded, generation-aware, Bash 3.2-compatible, and preserves the documented snapshot projection semantics without introducing a substantiated reachable defect.

## Testing

The supplied changed-test baseline and focused backend/Bearings suites passed; end-to-end macOS Bash 3.2 evidence showed the real Bearings CLI reducing the delayed local snapshot from 7s serial to 2s concurrent while preserving a byte-identical fm-bearings.v1 projection and all five worker rows.

<details>
<summary>Evidence: Bash 3.2 large-local snapshot timing and projection identity evidence</summary>

Source: [Bash 3.2 large-local snapshot timing and projection identity evidence](https://github.com/kunchenguid/firstmate/blob/d1d0b44746dc967eb3500a55be988f41fc2755b6/.no-mistakes/evidence/fm/fm-bearings-local-snapshot-cost-r1/fm-bearings-large-local-bash32-timing.jsonl)

```text
{
  "scenario": "real fm-bearings-snapshot CLI against synthetic large local home",
  "serial_seconds": 7,
  "concurrent_seconds": 2,
  "seconds_saved": 5,
  "serial_projection_sha256": "e4ce870bdc0e78b22fcd03da2e143d6a122f5354839ddfaeb6f4850b8d74fd78",
  "concurrent_projection_sha256": "e4ce870bdc0e78b22fcd03da2e143d6a122f5354839ddfaeb6f4850b8d74fd78",
  "projections_byte_identical": true,
  "worker_rows": 5,
  "expected_worker_rows": 5,
  "done_backlog_rows": 300
}
ok - large local snapshot overlaps local reads with byte-identical serial and concurrent projections
```
</details>
<details>
<summary>Evidence: Generated fm-bearings.v1 projection containing all five workers</summary>

Source: [Generated fm-bearings.v1 projection containing all five workers](https://github.com/kunchenguid/firstmate/blob/d1d0b44746dc967eb3500a55be988f41fc2755b6/.no-mistakes/evidence/fm/fm-bearings-local-snapshot-cost-r1/fm-bearings-large-local-projection.json)

```text
{
  "schema": "fm-bearings.v1",
  "home": "fm-bearings.8Mti7y/large-local-snapshot",
  "generated": "2026-07-11T18:00:00Z",
  "prs": "not_requested (run: /bearings include PRs)",
  "in_flight": [
    {
      "id": "local-1",
      "kind": "ship",
      "state": "unknown",
      "repo": "firstmate",
      "doing": "harness state unavailable (unknown missing)"
    },
    {
      "id": "local-2",
      "kind": "ship",
      "state": "unknown",
      "repo": "firstmate",
      "doing": "harness state unavailable (unknown missing)"
    },
    {
      "id": "local-3",
      "kind": "ship",
      "state": "unknown",
      "repo": "firstmate",
      "doing": "harness state unavailable (unknown missing)"
    },
    {
      "id": "local-4",
      "kind": "ship",
      "state": "unknown",
      "repo": "firstmate",
      "doing": "harness state unavailable (unknown missing)"
    },
    {
      "id": "local-5",
      "kind": "ship",
      "state": "unknown",
      "repo": "firstmate",
      "doing": "harness state unavailable (unknown missing)"
    }
  ],
  "secondmates": [],
  "secondmate_reconcile": [],
  "decisions_open": [],
  "landed": [
    {
      "id": "history-99",
      "what": "Historical completed item 99",
      "artifact": "https://github.com/acme/firstmate/pull/99",
      "owner": "(main)"
    },
    {
      "id": "history-98",
      "what": "Historical completed item 98",
      "artifact": "https://github.com/acme/firstmate/pull/98",
      "owner": "(main)"
    },
    {
      "id": "history-97",
      "what": "Historical completed item 97",
      "artifact": "https://github.com/acme/firstmate/pull/97",
      "owner": "(main)"
    },
    {
      "id": "history-96",
      "what": "Historical completed item 96",
      "artifact": "https://github.com/acme/firstmate/pull/96",
      "owner": "(main)"
    },
    {
      "id": "history-95",
      "what": "Historical completed item 95",
      "artifact": "https://github.com/acme/firstmate/pull/95",
      "owner": "(main)"
    },
    {
      "id": "history-94",
      "what": "Historical completed item 94",
      "artifact": "https://github.com/acme/firstmate/pull/94",
      "owner": "(main)"
    }
  ],
  "gates": [],
  "reports": [],
  "recorded_prs": [],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded or prose-deferred queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "landed per-home capped at 6 for 1 home(s)",
      "reveal": "--all-landed"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b3bb2453b4d5a19d4b2a679036ba735bcb072463","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-fleet-snapshot.sh:716` - The new shell loop independently parses the same open-decision TSV grammar already parsed into open_decisions_json immediately above, solely replacing two jq queries. No stated requirement needs this second parser, and the accepted scope says the broader reduction of small jq invocations was not pursued. Remove this loop and derive the booleans from open_decisions_json as before, unless this extra optimization is explicitly intended.

🔧 Fix: Restore JSON-derived decision flags
1 error still open:

- 🚨 `bin/fm-fleet-snapshot.sh:545` - The status log is copied at line 536, but the subsequently launched fm-crew-state process still reads the live `$STATE/$id.status`. If an idle task appends `needs-decision` or `blocked` after the copy but before fm-crew-state reads it, `current_state` reports parked/blocked while `last_event` and `open_decisions` come from the older copy and hide the actionable decision. Generation checks do not catch same-generation status updates. Pass the captured status path to fm-crew-state through a status-log override so all status-derived fields use the same observation.

🔧 Fix: Unify status-derived snapshot observations
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>Baseline: `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`</code>
- `bash tests/fm-backend.test.sh`
- `bash tests/fm-bearings-snapshot.test.sh`
- <code>`/bin/bash tests/fm-backend.test.sh` using macOS Bash 3.2</code>
- <code>`/bin/bash .../run-large-local-evidence.sh` against a five-worker, 300-entry synthetic home</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
