### PR TITLE
fix(bin): collect follow-up results from remote work homes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ state/               runtime records and signals; gitignored
   x-inbox/           generated Relay pending mention payloads; fmx-respond drains it (section 14)
   x-context/         generated Relay durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)
   x-outbox/          generated Relay dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
-  public-followup/   generated private transport for promised public replies: retained open-loop registrations, typed terminal-result inbox, accepted/rejected ledgers, and retirement receipts (section 14; bin/fm-public-followup.sh)
+  public-followup/   generated private transport for promised public replies: retained open-loop registrations, typed terminal-result inbox, results staged for an owning home on another machine, accepted/rejected ledgers, and retirement receipts (section 14; bin/fm-public-followup.sh)
   x-poll.error x-poll.claim-error  generated Relay and offer-claim diagnostic dedupe markers
   .startup-network.*  status, report, per-step elapsed timings, inline-print claim, and lock for the deferred startup stage that runs network checks and the inactive-outcome scan off the digest's blocking path; bin/fm-startup-network.sh
   .wake-queue        durable queued wakes retained until post-handling acknowledgement: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload

--- a/bin/fm-public-followup-collect.sh
+++ b/bin/fm-public-followup-collect.sh
@@ -36,7 +36,7 @@
 # including an empty outbox and an outbox holding a file too large or too broken
 # to hand over - that one is named on stderr and left in place rather than
 # blocking every other staged result. Exit 2 on a usage or validation error, and
-# 1 when a retirement was asked for and could not be completed.
+# 1 when the outbox cannot be safely read or a retirement cannot be completed.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -76,7 +76,11 @@ cmd_drain() {
   command -v jq >/dev/null 2>&1 || die "jq is required to read a staged terminal event" 1
 
   dir=$(fm_pf_outbox_dir "$STATE")
-  [ -d "$dir" ] && [ ! -L "$dir" ] || return 0
+  if [ ! -e "$dir" ] && [ ! -L "$dir" ]; then
+    return 0
+  fi
+  [ -d "$dir" ] && [ ! -L "$dir" ] && [ -r "$dir" ] && [ -x "$dir" ] \
+    || die "staged-event outbox is not a safely readable directory: $dir" 1
   for file in "$dir"/*.json; do
     [ -f "$file" ] && [ ! -L "$file" ] || continue
     event_id=$(basename "$file" .json)

--- a/bin/fm-public-followup-collect.sh
+++ b/bin/fm-public-followup-collect.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# fm-public-followup-collect.sh - read and retire the typed terminal events a
+# worker in THIS home staged for an owning home on another machine.
+#
+# WHY THIS EXISTS: a public promise is kept by the home that owns the relay
+# consent and the thread binding. When the bound work lives in a REMOTE
+# secondmate home, that worker has no local path to the owning home's inbox, so
+# `fm-public-followup-emit.sh --stage-in` leaves the typed event in this home's
+# public-followup outbox instead. The owning home runs THIS command over the
+# route's own transport (bin/fm-on.sh) to collect what is waiting. The transport
+# only runs main -> secondmate, so collection is a pull; nothing here ever
+# reaches back out.
+#
+# WHAT IT DOES NOT DO: it never builds, edits, posts, or judges an event. The
+# staged bytes are handed over verbatim, and the collecting home re-validates
+# every field against its own registration and tasks-axi before accepting one.
+#
+# Usage:
+#   fm-public-followup-collect.sh drain <obligation-id>
+#       Print every staged event for <obligation-id>, one compact JSON document
+#       per line, newest-first order not guaranteed. NON-DESTRUCTIVE: a dropped
+#       connection must never be able to lose a terminal result, so the staged
+#       copy is retained until the collecting home has it durably and retires it
+#       with `drop`. Prints nothing and exits 0 when nothing is staged.
+#
+#   fm-public-followup-collect.sh drop <obligation-id> <event-id>
+#       Retire one staged event once the collecting home holds it durably.
+#       Idempotent: an already-absent event is a success, so a repeated or
+#       replayed retirement is safe.
+#
+# FM_HOME selects the home to read, exactly as every other command the remote
+# entrypoint runs. Events are matched on their own obligation_id field, never on
+# a filename, so a hand-placed file cannot be collected under another loop's id.
+#
+# Output: drain prints event JSON on stdout, one per line. Exit 0 on success,
+# including an empty outbox and an outbox holding a file too large or too broken
+# to hand over - that one is named on stderr and left in place rather than
+# blocking every other staged result. Exit 2 on a usage or validation error, and
+# 1 when a retirement was asked for and could not be completed.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-public-followup-lib.sh
+. "$SCRIPT_DIR/fm-public-followup-lib.sh"
+
+FM_HOME="${FM_HOME:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: fm-public-followup-collect.sh drain <obligation-id>
+       fm-public-followup-collect.sh drop <obligation-id> <event-id>
+EOF
+}
+
+# The header comment IS the help text, so the two can never drift apart.
+help() { sed -n '2,/^set -u$/p' "$0" | sed '$d; s/^# \{0,1\}//'; }
+
+die() { printf 'fm-public-followup-collect: %s\n' "$1" >&2; exit "${2:-2}"; }
+
+# staged_file <event-id>: the one non-symlink regular file that may hold that
+# event, or nothing.
+staged_file() {
+  local file
+  file="$(fm_pf_outbox_dir "$STATE")/$1.json"
+  [ -f "$file" ] && [ ! -L "$file" ] || return 1
+  printf '%s\n' "$file"
+}
+
+# One unusable staged file must never hold back a good one: it is reported on
+# stderr and left exactly where it is, and the readable results still travel.
+cmd_drain() {
+  local obligation=${1:-} dir file event_id payload
+  [ -n "$obligation" ] || { usage; exit 2; }
+  fm_pf_slug_valid "$obligation" || die "unsafe obligation id: $obligation"
+  command -v jq >/dev/null 2>&1 || die "jq is required to read a staged terminal event" 1
+
+  dir=$(fm_pf_outbox_dir "$STATE")
+  [ -d "$dir" ] && [ ! -L "$dir" ] || return 0
+  for file in "$dir"/*.json; do
+    [ -f "$file" ] && [ ! -L "$file" ] || continue
+    event_id=$(basename "$file" .json)
+    fm_pf_slug_valid "$event_id" || continue
+    if [ "$(wc -c < "$file" 2>/dev/null || echo 0)" -gt "$FM_PF_EVENT_BYTES_MAX" ]; then
+      printf 'fm-public-followup-collect: staged event %s exceeds %s bytes and was left in place\n' \
+        "$event_id" "$FM_PF_EVENT_BYTES_MAX" >&2
+      continue
+    fi
+    payload=$(jq -ce . "$file" 2>/dev/null) || {
+      printf 'fm-public-followup-collect: staged event %s is not readable JSON and was left in place\n' \
+        "$event_id" >&2
+      continue
+    }
+    [ "$(printf '%s' "$payload" | jq -r '.obligation_id // empty' 2>/dev/null)" = "$obligation" ] \
+      || continue
+    printf '%s\n' "$payload"
+  done
+}
+
+cmd_drop() {
+  local obligation=${1:-} event_id=${2:-} file
+  [ -n "$obligation" ] && [ -n "$event_id" ] || { usage; exit 2; }
+  fm_pf_slug_valid "$obligation" || die "unsafe obligation id: $obligation"
+  fm_pf_slug_valid "$event_id" || die "unsafe event id: $event_id"
+  command -v jq >/dev/null 2>&1 || die "jq is required to retire a staged terminal event" 1
+
+  file=$(staged_file "$event_id") || return 0
+  # The obligation must match the event's own record, so one loop's collection
+  # can never retire another loop's staged result.
+  [ "$(jq -r '.obligation_id // empty' "$file" 2>/dev/null)" = "$obligation" ] \
+    || die "staged event '$event_id' does not belong to obligation '$obligation'" 1
+  rm -f -- "$file" 2>/dev/null || die "could not retire staged event '$event_id'" 1
+}
+
+case "${1:-}" in
+  --help|-h|help) help; exit 0 ;;
+  drain) shift; cmd_drain "$@" ;;
+  drop)  shift; cmd_drop "$@" ;;
+  '') usage; exit 2 ;;
+  *) die "unknown subcommand '$1'" ;;
+esac

--- a/bin/fm-public-followup-emit.sh
+++ b/bin/fm-public-followup-emit.sh
@@ -13,7 +13,7 @@
 # home (bin/fm-public-followup.sh deliver).
 #
 # Usage:
-#   fm-public-followup-emit.sh --home <owning-home> \
+#   fm-public-followup-emit.sh (--home <owning-home> | --stage-in <work-home>) \
 #     --obligation <obligation-id> --relation <relation-id> \
 #     --source-home <main|secondmate:<id>> --work-id <task-id> \
 #     --generation <n> --outcome <outcome-type> \
@@ -24,7 +24,17 @@
 #   --home <path>          The home that owns the public commitment (the primary
 #                          that took the mention). Must already have a
 #                          registration for --obligation; see
-#                          `fm-public-followup.sh register`.
+#                          `fm-public-followup.sh register`. Use this whenever
+#                          the owning home is on THIS machine.
+#   --stage-in <path>      The home THIS worker runs in, when the owning home is
+#                          on another machine and no local path reaches it. The
+#                          typed event is staged in this home's public-followup
+#                          outbox with the identical identity, shape, and bounds,
+#                          and the owning home collects it over the route's own
+#                          transport (bin/fm-public-followup-collect.sh). Exactly
+#                          one of --home and --stage-in is required;
+#                          `fm-public-followup.sh brief` prints whichever the
+#                          bound work home actually needs.
 #   --obligation <id>      tasks-axi public-followup obligation id.
 #   --relation <id>        The relation_id this work fulfills or contributes to.
 #   --source-home <id>     This worker's stable home identity, exactly as bound:
@@ -53,9 +63,14 @@
 #
 # SAFETY: the event is published through the shared private-artifact primitive -
 # atomic rename into place, single link, mode 0600 (never executable), inside a
-# 0700 directory this script refuses to create. The owning home must already have
-# registered the obligation, so a home that never opted into the relay can never
-# be given public-followup artifacts by a child.
+# 0700 directory. The owning home must already have registered the obligation, so
+# a home that never opted into the relay can never be given public-followup
+# artifacts by a child. --stage-in writes into the CALLER'S OWN home instead, so
+# that gate does not apply and does not run: the registration and the relay
+# consent both live on the other machine, and the collecting home re-validates
+# every field against its own registration and tasks-axi before accepting the
+# event. A staged event is never posted, never read as a public reply, and never
+# consumed by the staging home's own reconciliation.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -64,7 +79,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   cat >&2 <<'EOF'
-usage: fm-public-followup-emit.sh --home <owning-home> --obligation <id> --relation <id>
+usage: fm-public-followup-emit.sh (--home <owning-home> | --stage-in <work-home>)
+         --obligation <id> --relation <id>
          --source-home <main|secondmate:<id>> --work-id <id> --generation <n>
          --outcome <type> [--deliverable <key>=<value>]...
          (--outcome-text <text> | --outcome-text-file <path> | --outcome-text -)
@@ -78,7 +94,21 @@ help() {
 
 die() { printf 'fm-public-followup-emit: %s\n' "$1" >&2; exit "${2:-2}"; }
 
+# set_home_target <owning|staging> <path>: record which home this event is being
+# written into, and which of the two destinations that means. The two modes
+# answer different questions - is the owning home reachable from here, or not -
+# so mixing them in one invocation is always a mistake and is refused rather
+# than silently resolved by argument order.
+set_home_target() {
+  if [ -n "$HOME_MODE" ] && [ "$HOME_MODE" != "$1" ]; then
+    die "--home and --stage-in are mutually exclusive; pass exactly one"
+  fi
+  HOME_MODE=$1
+  HOME_DIR=$2
+}
+
 HOME_DIR=
+HOME_MODE=
 OBLIGATION=
 RELATION=
 SOURCE_HOME=
@@ -97,7 +127,8 @@ esac
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --home)            shift; HOME_DIR=${1:-} ;;
+    --home)            shift; set_home_target owning "${1:-}" ;;
+    --stage-in)        shift; set_home_target staging "${1:-}" ;;
     --obligation)      shift; OBLIGATION=${1:-} ;;
     --relation)        shift; RELATION=${1:-} ;;
     --source-home)     shift; SOURCE_HOME=${1:-} ;;
@@ -158,36 +189,53 @@ done
 # Resolve the owning home to a real absolute directory before composing any path
 # under it, so a relative or symlinked argument cannot make the destination
 # ambiguous in a later message or write.
+HOME_FLAG=--home
+[ "$HOME_MODE" != staging ] || HOME_FLAG=--stage-in
 case "$HOME_DIR" in
   /*) ;;
-  *) HOME_DIR=$(CDPATH='' cd -- "$HOME_DIR" 2>/dev/null && pwd -P) \
-       || die "--home is not a reachable directory: $1" ;;
+  *)
+    HOME_RESOLVED=$(CDPATH='' cd -- "$HOME_DIR" 2>/dev/null && pwd -P) \
+      || die "$HOME_FLAG is not a reachable directory: $HOME_DIR"
+    HOME_DIR=$HOME_RESOLVED
+    ;;
 esac
 [ -d "$HOME_DIR" ] && [ ! -L "$HOME_DIR" ] \
-  || die "--home must name an existing directory, got '$HOME_DIR'"
-
-fm_pf_relay_active "$HOME_DIR" || exit 0
-command -v jq >/dev/null 2>&1 || die "jq is required to build a typed terminal event" 1
+  || die "$HOME_FLAG must name an existing directory, got '$HOME_DIR'"
+# A staged event is only ever found again by the collecting home reading this
+# home's state tree, so a path that is not a firstmate home would swallow the
+# result silently. Refuse it here instead.
+[ "$HOME_MODE" != staging ] || { [ -d "$HOME_DIR/state" ] && [ ! -L "$HOME_DIR/state" ]; } \
+  || die "--stage-in must name a firstmate home, and '$HOME_DIR' has no state directory"
 
 STATE="$HOME_DIR/state"
-REGISTRY="$(fm_pf_registry_dir "$STATE")/$OBLIGATION"
-if [ ! -f "$REGISTRY" ] || [ -L "$REGISTRY" ]; then
-  die "home '$HOME_DIR' has no public-followup registration for '$OBLIGATION'; the owning home registers a commitment before its work can report one" 1
-fi
+if [ "$HOME_MODE" = owning ]; then
+  fm_pf_relay_active "$HOME_DIR" || exit 0
+  command -v jq >/dev/null 2>&1 || die "jq is required to build a typed terminal event" 1
 
-# The registration is the owning home's own record of what it bound, so checking
-# the identity tuple against it catches a mis-briefed worker at the edge with a
-# clear message. tasks-axi still re-validates everything at consume time and
-# remains the authority; this is a cheap early refusal, not a second gatekeeper.
-reg_mismatch() {
-  local field=$1 expected=$2 got=$3
-  [ -z "$expected" ] || [ "$expected" = "$got" ] \
-    || die "event $field '$got' does not match this home's registration ('$expected')"
-}
-reg_mismatch relation   "$(fm_pf_registry_get "$STATE" "$OBLIGATION" relation_id)" "$RELATION"
-reg_mismatch source-home "$(fm_pf_registry_get "$STATE" "$OBLIGATION" work_home)"  "$SOURCE_HOME"
-reg_mismatch work-id    "$(fm_pf_registry_get "$STATE" "$OBLIGATION" work_id)"     "$WORK_ID"
-reg_mismatch generation "$(fm_pf_registry_get "$STATE" "$OBLIGATION" generation)"  "$GENERATION"
+  REGISTRY="$(fm_pf_registry_dir "$STATE")/$OBLIGATION"
+  if [ ! -f "$REGISTRY" ] || [ -L "$REGISTRY" ]; then
+    die "home '$HOME_DIR' has no public-followup registration for '$OBLIGATION'; the owning home registers a commitment before its work can report one" 1
+  fi
+
+  # The registration is the owning home's own record of what it bound, so checking
+  # the identity tuple against it catches a mis-briefed worker at the edge with a
+  # clear message. tasks-axi still re-validates everything at consume time and
+  # remains the authority; this is a cheap early refusal, not a second gatekeeper.
+  reg_mismatch() {
+    local field=$1 expected=$2 got=$3
+    [ -z "$expected" ] || [ "$expected" = "$got" ] \
+      || die "event $field '$got' does not match this home's registration ('$expected')"
+  }
+  reg_mismatch relation   "$(fm_pf_registry_get "$STATE" "$OBLIGATION" relation_id)" "$RELATION"
+  reg_mismatch source-home "$(fm_pf_registry_get "$STATE" "$OBLIGATION" work_home)"  "$SOURCE_HOME"
+  reg_mismatch work-id    "$(fm_pf_registry_get "$STATE" "$OBLIGATION" work_id)"     "$WORK_ID"
+  reg_mismatch generation "$(fm_pf_registry_get "$STATE" "$OBLIGATION" generation)"  "$GENERATION"
+else
+  # Staging home: the registration and the relay consent live on the other
+  # machine, so neither gate can run here and neither is skipped as a shortcut.
+  # The collecting home applies both, plus tasks-axi, before it accepts anything.
+  command -v jq >/dev/null 2>&1 || die "jq is required to build a typed terminal event" 1
+fi
 
 case "$TEXT_MODE" in
   inline) OUTCOME_TEXT=$(printf '%s' "$TEXT_SOURCE" | fm_pf_clean_outcome_text) ;;
@@ -252,8 +300,13 @@ EVENT_BYTES=$(printf '%s\n' "$EVENT_JSON" | LC_ALL=C wc -c | tr -d ' ') \
 [ "$EVENT_BYTES" -le "$FM_PF_EVENT_BYTES_MAX" ] \
   || die "typed terminal event exceeds $FM_PF_EVENT_BYTES_MAX bytes" 2
 
+if [ "$HOME_MODE" = owning ]; then
+  DESTINATION=$(fm_pf_events_dir "$STATE")
+else
+  DESTINATION=$(fm_pf_outbox_dir "$STATE")
+fi
 printf '%s\n' "$EVENT_JSON" \
-  | fmx_private_artifact_publish_stdin_once "$(fm_pf_events_dir "$STATE")" "$EVENT_ID.json" 600
+  | fmx_private_artifact_publish_stdin_once "$DESTINATION" "$EVENT_ID.json" 600
 case $? in
   0|1) printf '%s\n' "$EVENT_ID" ;;
   *) die "could not publish the terminal event into $HOME_DIR" 1 ;;

--- a/bin/fm-public-followup-emit.sh
+++ b/bin/fm-public-followup-emit.sh
@@ -204,8 +204,18 @@ esac
 # A staged event is only ever found again by the collecting home reading this
 # home's state tree, so a path that is not a firstmate home would swallow the
 # result silently. Refuse it here instead.
-[ "$HOME_MODE" != staging ] || { [ -d "$HOME_DIR/state" ] && [ ! -L "$HOME_DIR/state" ]; } \
-  || die "--stage-in must name a firstmate home, and '$HOME_DIR' has no state directory"
+if [ "$HOME_MODE" = staging ]; then
+  case "$SOURCE_HOME" in
+    secondmate:*) STAGING_HOME_ID=${SOURCE_HOME#secondmate:} ;;
+    *) die "--stage-in must name the secondmate firstmate home identified by --source-home" ;;
+  esac
+  [ -d "$HOME_DIR/state" ] && [ ! -L "$HOME_DIR/state" ] \
+    && [ -f "$HOME_DIR/.fm-secondmate-home" ] && [ ! -L "$HOME_DIR/.fm-secondmate-home" ] \
+    || die "--stage-in must name the secondmate firstmate home identified by --source-home"
+  STAGING_HOME_MARKER=$(sed -n '1p' "$HOME_DIR/.fm-secondmate-home" 2>/dev/null) || STAGING_HOME_MARKER=
+  [ "$STAGING_HOME_MARKER" = "$STAGING_HOME_ID" ] \
+    || die "--stage-in must name the secondmate firstmate home identified by --source-home"
+fi
 
 STATE="$HOME_DIR/state"
 if [ "$HOME_MODE" = owning ]; then

--- a/bin/fm-public-followup-lib.sh
+++ b/bin/fm-public-followup-lib.sh
@@ -44,6 +44,14 @@
 #                              tasks-axi truth.
 #   events/<event-id>.json     inbound typed terminal events awaiting
 #                              reconciliation, one file per event id.
+#   outbox/<event-id>.json     OUTBOUND typed terminal events a worker in THIS
+#                              home produced for an owning home on another
+#                              machine, which no local path can reach. Same file
+#                              shape as events/, staged here until that owning
+#                              home collects them over the route's transport
+#                              (bin/fm-public-followup-emit.sh --stage-in,
+#                              bin/fm-public-followup-collect.sh). A home whose
+#                              work is only ever local never has this directory.
 #   consumed/<event-id>        idempotency ledger: an accepted event id is never
 #                              replayed, so duplicate emits and restart replay
 #                              are no-ops.
@@ -103,6 +111,7 @@ fm_pf_relay_active() {
 fm_pf_root()       { printf '%s\n' "$1/$FM_PF_DIRNAME"; }
 fm_pf_registry_dir() { printf '%s\n' "$1/$FM_PF_DIRNAME/registry"; }
 fm_pf_events_dir()   { printf '%s\n' "$1/$FM_PF_DIRNAME/events"; }
+fm_pf_outbox_dir()   { printf '%s\n' "$1/$FM_PF_DIRNAME/outbox"; }
 fm_pf_consumed_dir() { printf '%s\n' "$1/$FM_PF_DIRNAME/consumed"; }
 fm_pf_rejected_dir() { printf '%s\n' "$1/$FM_PF_DIRNAME/rejected"; }
 fm_pf_retired_dir()  { printf '%s\n' "$1/$FM_PF_DIRNAME/retired"; }

--- a/bin/fm-public-followup.sh
+++ b/bin/fm-public-followup.sh
@@ -507,9 +507,13 @@ collect_remote_staged_events() {
   dir=$(fm_pf_registry_dir "$STATE")
   [ -d "$dir" ] && [ ! -L "$dir" ] || return 0
   for file in "$dir"/*; do
-    [ -f "$file" ] && [ ! -L "$file" ] || continue
     id=$(basename "$file")
     fm_pf_slug_valid "$id" || continue
+    if [ ! -f "$file" ] || [ -L "$file" ]; then
+      printf 'unreached %s: registration is not a safe regular record, so its terminal result stays retained for reconciliation\n' "$id"
+      rc=1
+      continue
+    fi
     if ! public_followup_registration_valid "$id"; then
       work_home=$(fm_pf_registry_get "$STATE" "$id" work_home)
       printf 'unreached %s: registration cannot resolve its work home route %s, so its terminal result stays retained for reconciliation\n' \

--- a/bin/fm-public-followup.sh
+++ b/bin/fm-public-followup.sh
@@ -499,11 +499,10 @@ reject_event() {
 # so this is a pull; a worker on the other machine has no path back here.
 #
 # The current registry record is the route drained. A reassignment between
-# staging and collection is surfaced as unreached when that route is empty; the
-# staged result stays on the original host for reconciliation.
+# staging and collection is not detected; the staged result stays on the
+# original host and must be re-emitted after the reassignment.
 collect_remote_staged_events() {
   local dir file id work_home work_home_path sid route_kind rc=0 collect_rc payload line event_id dropped
-  local obligation_payload delivery events_dir local_file local_obligation inbox_has_event
   dir=$(fm_pf_registry_dir "$STATE")
   [ -d "$dir" ] && [ ! -L "$dir" ] || return 0
   for file in "$dir"/*; do
@@ -552,29 +551,6 @@ collect_remote_staged_events() {
       rc=1
       continue
     fi
-    if [ -z "$payload" ]; then
-      obligation_payload=$(obligation_json "$id" 2>/dev/null) || obligation_payload=
-      delivery=$(pf_field "$obligation_payload" '.public_followup.delivery.state')
-      inbox_has_event=0
-      events_dir=$(fm_pf_events_dir "$STATE")
-      if [ -d "$events_dir" ] && [ ! -L "$events_dir" ]; then
-        for local_file in "$events_dir"/*.json; do
-          [ -f "$local_file" ] && [ ! -L "$local_file" ] || continue
-          local_obligation=$(jq -r '.obligation_id // empty' "$local_file" 2>/dev/null) || local_obligation=
-          if [ "$local_obligation" = "$id" ]; then
-            inbox_has_event=1
-            break
-          fi
-        done
-      fi
-      if [ "$delivery" = pending-work ] && [ "$inbox_has_event" -eq 0 ]; then
-        printf 'unreached %s: the current work home %s returned no staged terminal result; after a route reassignment its terminal result stays retained there for reconciliation\n' \
-          "$id" "$sid"
-        rc=1
-      fi
-      continue
-    fi
-
     while IFS= read -r line; do
       [ -n "$line" ] || continue
       event_id=$(printf '%s' "$line" | jq -r '.event_id // empty' 2>/dev/null)

--- a/bin/fm-public-followup.sh
+++ b/bin/fm-public-followup.sh
@@ -14,6 +14,8 @@
 #   bin/fm-public-followup-lib.sh  the activation gate and private transport.
 #   bin/fm-on.sh                the SSH route to a REMOTE secondmate home, whose
 #                               state no local path can reach.
+#   bin/fm-public-followup-collect.sh  reading and retiring the typed terminal
+#                               results staged in a remote work home.
 # This script composes them; it never restates their contracts or schemas.
 #
 # ZERO OVERHEAD FOR HOMES THAT DO NOT USE THE RELAY: every subcommand gates
@@ -46,7 +48,10 @@
 #       Print the exact fm-public-followup-emit.sh command line the bound worker
 #       must run when its work reaches the promised terminal outcome, so the
 #       binding is copied into a brief instead of hand-assembled. The
-#       --deliverable flags name the obligation's actual required keys.
+#       --deliverable flags name the obligation's actual required keys. For work
+#       bound to a REMOTE secondmate home, the command names that route's own
+#       code root and home with --stage-in, because neither this checkout's path
+#       nor this home's path exists on the machine that worker runs on.
 #
 #   fm-public-followup.sh consume
 #       Drain every pending typed terminal event: validate its derived identity,
@@ -56,6 +61,12 @@
 #       became delivery-ready, and one "rejected <event-id>: <reason>" line per
 #       refusal. Silent when there is nothing to do. Duplicate events and restart
 #       replay are no-ops.
+#       A loop bound to a REMOTE secondmate home is collected first: the staged
+#       results are pulled over that route into this home's own inbox and then
+#       reconciled identically. The staged copy is retired only after this home
+#       holds the result, so a dropped connection cannot lose one. A route that
+#       could not be reached prints one "unreached <obligation-id>: ..." line and
+#       exits non-zero rather than reporting an empty inbox.
 #
 #   fm-public-followup.sh pending
 #       One bounded public-safe line per open public loop, for the session
@@ -337,8 +348,34 @@ cmd_register() {
 
 # --- subcommand: brief ------------------------------------------------------
 
+# brief_emit_target <work-home>: two lines on stdout - the absolute path of the
+# emit script the bound worker must run, and the home flag plus value it must
+# pass. They differ for a REMOTE work home, because both this checkout's path and
+# this home's path exist only on THIS machine: naming either one in instructions
+# for another machine is how a promised public reply silently never arrives.
+brief_emit_target() {
+  local work_home=$1 sid root home
+  case "$work_home" in
+    secondmate:*) sid=${work_home#secondmate:} ;;
+    *) printf '%s\n--home %s\n' "$FM_ROOT/bin/fm-public-followup-emit.sh" "$FM_HOME"; return 0 ;;
+  esac
+  if ! public_followup_route_is_remote "$sid"; then
+    printf '%s\n--home %s\n' "$FM_ROOT/bin/fm-public-followup-emit.sh" "$FM_HOME"
+    return 0
+  fi
+  root=$(secondmate_registry_field "$DATA/secondmates.md" "$sid" root 2>/dev/null) || root=
+  home=$(secondmate_registry_field "$DATA/secondmates.md" "$sid" home 2>/dev/null) || home=
+  case "$root" in /*) ;; *) return 1 ;; esac
+  case "$home" in /*) ;; *) return 1 ;; esac
+  # These two values are printed into a command line the worker runs verbatim, so
+  # keep them to a conservative path charset rather than trusting the record.
+  case "$root$home" in *[!A-Za-z0-9/._+@:-]*) return 1 ;; esac
+  printf '%s\n--stage-in %s\n' "$root/bin/fm-public-followup-emit.sh" "$home"
+}
+
 cmd_brief() {
   local id=${1:-} relation work_home work_id generation payload outcome keys key deliverable_flags
+  local emit_target emit_script emit_home_flag closing_note
   [ -n "$id" ] || { usage; exit 2; }
   fm_pf_slug_valid "$id" || die "unsafe obligation id: $id"
   fm_pf_relay_active "$FM_HOME" || die "the relay is not active for this home" 1
@@ -349,6 +386,26 @@ cmd_brief() {
   work_home=$(fm_pf_registry_get "$STATE" "$id" work_home)
   work_id=$(fm_pf_registry_get "$STATE" "$id" work_id)
   generation=$(fm_pf_registry_get "$STATE" "$id" generation)
+
+  emit_target=$(brief_emit_target "$work_home") \
+    || die "the work home for '$id' is a remote route with no usable code root and home in data/secondmates.md; fix that record before briefing the bound worker" 1
+  emit_script=$(printf '%s\n' "$emit_target" | sed -n '1p')
+  emit_home_flag=$(printf '%s\n' "$emit_target" | sed -n '2p')
+  # The closing paragraph has to match the destination the command above names,
+  # because "the home above" is the owning home only when the work runs on this
+  # machine. A remote worker is told where its result waits instead.
+  case "$emit_home_flag" in
+    --stage-in*)
+      closing_note='Do not post anything publicly yourself and do not look for the public thread:
+the home that owes that reply is on another machine and owns it. Leave the
+result exactly where the command above puts it; that home collects it over the
+same route it reaches you on, and nothing here needs a path back to it.'
+      ;;
+    *)
+      closing_note='Do not post anything publicly yourself and do not look for the public thread:
+the home above owns the reply.'
+      ;;
+  esac
 
   require_tools
   payload=$(obligation_json "$id") \
@@ -377,8 +434,8 @@ EOF
 When this work reaches its promised terminal outcome, report it as typed data
 (never as a sentence for someone to parse) by running exactly:
 
-  $FM_ROOT/bin/fm-public-followup-emit.sh \\
-    --home $FM_HOME \\
+  $emit_script \\
+    $emit_home_flag \\
     --obligation $id \\
     --relation $relation \\
     --source-home $work_home \\
@@ -387,8 +444,7 @@ When this work reaches its promised terminal outcome, report it as typed data
     --outcome $outcome \\
 ${deliverable_flags}    --outcome-text '<one bounded public-safe sentence>'
 
-Do not post anything publicly yourself and do not look for the public thread:
-the home above owns the reply.
+$closing_note
 EOF
 }
 
@@ -422,12 +478,97 @@ reject_event() {
   printf 'rejected %s: %s\n' "$event_id" "$reason"
 }
 
+# collect_remote_staged_events: pull every typed terminal result a REMOTE work
+# home has staged for this home into this home's own inbox, so the ordinary
+# reconciliation below sees it. The route transport only runs main -> secondmate,
+# so this is a pull; a worker on the other machine has no path back here.
+#
+# Returns 0 when every remote-bound loop was reached (including when nothing was
+# staged), and 1 when at least one was not. A route that could not be reached is
+# reported by name and never passed off as an empty inbox: the promise is still
+# owed, and the staged result is still on that host.
+collect_remote_staged_events() {
+  local dir file id work_home sid rc=0 collect_rc payload line event_id dropped
+  dir=$(fm_pf_registry_dir "$STATE")
+  [ -d "$dir" ] && [ ! -L "$dir" ] || return 0
+  for file in "$dir"/*; do
+    [ -f "$file" ] && [ ! -L "$file" ] || continue
+    id=$(basename "$file")
+    fm_pf_slug_valid "$id" || continue
+    work_home=$(fm_pf_registry_get "$STATE" "$id" work_home)
+    case "$work_home" in secondmate:*) sid=${work_home#secondmate:} ;; *) continue ;; esac
+    public_followup_route_is_remote "$sid" || continue
+    command -v jq >/dev/null 2>&1 \
+      || die "jq is required to collect a terminal result from a remote work home" 1
+
+    collect_rc=0
+    payload=$("$FM_ROOT/bin/fm-on.sh" "$sid" fm-public-followup-collect.sh drain "$id") \
+      || collect_rc=$?
+    # fm-on.sh returns ssh's status unchanged, so 255 is the established
+    # "delivered but completion unknown" status this codebase reconciles rather
+    # than reads as done or refused.
+    if [ "$collect_rc" -eq 255 ]; then
+      printf 'unreached %s: the work home %s never answered, so its terminal result stays retained there\n' \
+        "$id" "$sid"
+      rc=1
+      continue
+    fi
+    if [ "$collect_rc" -ne 0 ]; then
+      printf 'unreached %s: the work home %s refused the collection (exit %s), so its terminal result stays retained there\n' \
+        "$id" "$sid" "$collect_rc"
+      rc=1
+      continue
+    fi
+
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      event_id=$(printf '%s' "$line" | jq -r '.event_id // empty' 2>/dev/null)
+      if [ "${#line}" -gt "$FM_PF_EVENT_BYTES_MAX" ] \
+        || [ -z "$event_id" ] || ! fm_pf_slug_valid "$event_id"; then
+        printf 'unreached %s: the work home %s returned an unusable terminal result, which stays retained there\n' \
+          "$id" "$sid"
+        rc=1
+        continue
+      fi
+      printf '%s\n' "$line" \
+        | fmx_private_artifact_publish_stdin_once "$(fm_pf_events_dir "$STATE")" "$event_id.json" 600
+      case $? in
+        0|1) ;;
+        *)
+          printf 'unreached %s: a collected terminal result could not be stored here, so it stays retained on %s\n' \
+            "$id" "$sid"
+          rc=1
+          continue
+          ;;
+      esac
+      # Retiring the staged copy is best effort by design: this home now holds
+      # the event durably, and a retained copy is only ever collected again and
+      # dropped as a duplicate.
+      dropped=0
+      "$FM_ROOT/bin/fm-on.sh" "$sid" fm-public-followup-collect.sh drop "$id" "$event_id" \
+        >/dev/null 2>&1 || dropped=$?
+      [ "$dropped" -eq 0 ] \
+        || printf 'collected %s: the copy staged on %s could not be retired and will be collected again\n' \
+             "$event_id" "$sid"
+    done <<EOF
+$payload
+EOF
+  done
+  return "$rc"
+}
+
 cmd_consume() {
   gate_or_exit
-  fm_pf_has_events "$STATE" || exit 0
+  local collect_rc=0
+  collect_remote_staged_events || collect_rc=1
+  if ! fm_pf_has_events "$STATE"; then
+    [ "$collect_rc" -eq 0 ] || exit 1
+    exit 0
+  fi
   require_tools
 
-  local events_dir consumed_dir stderr_file file event_id payload derived out rc reason consume_rc=0
+  local events_dir consumed_dir stderr_file file event_id payload derived out rc reason
+  local consume_rc=$collect_rc
   local obligation delivery request platform
   events_dir=$(fm_pf_events_dir "$STATE")
   consumed_dir=$(fm_pf_consumed_dir "$STATE")
@@ -710,7 +851,7 @@ public_followup_secondmate_home() {
 # here for the same reason fm-on.sh and fm-send.sh treat it as one: a remote home
 # has no local path, so nothing on this disk can answer the question. Resolving
 # it live also means a registration written before this check (they all record an
-# empty work_home_path for a remote route) still retires.
+# empty work_home_path for a remote route) still resolves.
 public_followup_route_is_remote() {
   local id=$1 remote
   fm_pf_home_id_valid "secondmate:$id" || return 1

--- a/bin/fm-public-followup.sh
+++ b/bin/fm-public-followup.sh
@@ -510,6 +510,13 @@ collect_remote_staged_events() {
     [ -f "$file" ] && [ ! -L "$file" ] || continue
     id=$(basename "$file")
     fm_pf_slug_valid "$id" || continue
+    if ! public_followup_registration_valid "$id"; then
+      work_home=$(fm_pf_registry_get "$STATE" "$id" work_home)
+      printf 'unreached %s: registration cannot resolve its work home route %s, so its terminal result stays retained for reconciliation\n' \
+        "$id" "${work_home:-unknown}"
+      rc=1
+      continue
+    fi
     work_home=$(fm_pf_registry_get "$STATE" "$id" work_home)
     case "$work_home" in secondmate:*) sid=${work_home#secondmate:} ;; *) continue ;; esac
     work_home_path=$(fm_pf_registry_get "$STATE" "$id" work_home_path)

--- a/bin/fm-public-followup.sh
+++ b/bin/fm-public-followup.sh
@@ -513,6 +513,8 @@ collect_remote_staged_events() {
       rc=1
       continue
     fi
+    loop_state=$(fm_pf_registry_loop_state "$STATE" "$id")
+    [ "$loop_state" = open ] || continue
     if ! public_followup_registration_valid "$id"; then
       work_home=$(fm_pf_registry_get "$STATE" "$id" work_home)
       printf 'unreached %s: registration cannot resolve its work home route %s, so its terminal result stays retained for reconciliation\n' \
@@ -520,8 +522,6 @@ collect_remote_staged_events() {
       rc=1
       continue
     fi
-    loop_state=$(fm_pf_registry_loop_state "$STATE" "$id")
-    [ "$loop_state" = open ] || continue
     work_home=$(fm_pf_registry_get "$STATE" "$id" work_home)
     case "$work_home" in secondmate:*) sid=${work_home#secondmate:} ;; *) continue ;; esac
     work_home_path=$(fm_pf_registry_get "$STATE" "$id" work_home_path)

--- a/bin/fm-public-followup.sh
+++ b/bin/fm-public-followup.sh
@@ -498,12 +498,12 @@ reject_event() {
 # reconciliation below sees it. The route transport only runs main -> secondmate,
 # so this is a pull; a worker on the other machine has no path back here.
 #
-# Returns 0 when every remote-bound loop was reached (including when nothing was
-# staged), and 1 when at least one was not. A route that could not be reached is
-# reported by name and never passed off as an empty inbox: the promise is still
-# owed, and the staged result is still on that host.
+# The current registry record is the route drained. A reassignment between
+# staging and collection is surfaced as unreached when that route is empty; the
+# staged result stays on the original host for reconciliation.
 collect_remote_staged_events() {
   local dir file id work_home work_home_path sid route_kind rc=0 collect_rc payload line event_id dropped
+  local obligation_payload delivery events_dir local_file local_obligation inbox_has_event
   dir=$(fm_pf_registry_dir "$STATE")
   [ -d "$dir" ] && [ ! -L "$dir" ] || return 0
   for file in "$dir"/*; do
@@ -539,6 +539,28 @@ collect_remote_staged_events() {
       printf 'unreached %s: the work home %s refused the collection (exit %s), so its terminal result stays retained there for reconciliation\n' \
         "$id" "$sid" "$collect_rc"
       rc=1
+      continue
+    fi
+    if [ -z "$payload" ]; then
+      obligation_payload=$(obligation_json "$id" 2>/dev/null) || obligation_payload=
+      delivery=$(pf_field "$obligation_payload" '.public_followup.delivery.state')
+      inbox_has_event=0
+      events_dir=$(fm_pf_events_dir "$STATE")
+      if [ -d "$events_dir" ] && [ ! -L "$events_dir" ]; then
+        for local_file in "$events_dir"/*.json; do
+          [ -f "$local_file" ] && [ ! -L "$local_file" ] || continue
+          local_obligation=$(jq -r '.obligation_id // empty' "$local_file" 2>/dev/null) || local_obligation=
+          if [ "$local_obligation" = "$id" ]; then
+            inbox_has_event=1
+            break
+          fi
+        done
+      fi
+      if [ "$delivery" = pending-work ] && [ "$inbox_has_event" -eq 0 ]; then
+        printf 'unreached %s: the current work home %s returned no staged terminal result; after a route reassignment its terminal result stays retained there for reconciliation\n' \
+          "$id" "$sid"
+        rc=1
+      fi
       continue
     fi
 

--- a/bin/fm-public-followup.sh
+++ b/bin/fm-public-followup.sh
@@ -502,7 +502,7 @@ reject_event() {
 # staging and collection is not detected; the staged result stays on the
 # original host and must be re-emitted after the reassignment.
 collect_remote_staged_events() {
-  local dir file id work_home work_home_path sid route_kind rc=0 collect_rc payload line event_id dropped
+  local dir file id loop_state work_home work_home_path sid route_kind rc=0 collect_rc payload line event_id dropped
   dir=$(fm_pf_registry_dir "$STATE")
   [ -d "$dir" ] && [ ! -L "$dir" ] || return 0
   for file in "$dir"/*; do
@@ -520,6 +520,8 @@ collect_remote_staged_events() {
       rc=1
       continue
     fi
+    loop_state=$(fm_pf_registry_loop_state "$STATE" "$id")
+    [ "$loop_state" = open ] || continue
     work_home=$(fm_pf_registry_get "$STATE" "$id" work_home)
     case "$work_home" in secondmate:*) sid=${work_home#secondmate:} ;; *) continue ;; esac
     work_home_path=$(fm_pf_registry_get "$STATE" "$id" work_home_path)

--- a/bin/fm-public-followup.sh
+++ b/bin/fm-public-followup.sh
@@ -61,8 +61,8 @@
 #       became delivery-ready, and one "rejected <event-id>: <reason>" line per
 #       refusal. Silent when there is nothing to do. Duplicate events and restart
 #       replay are no-ops.
-#       A loop bound to a REMOTE secondmate home is collected first: the staged
-#       results are pulled over that route into this home's own inbox and then
+#       An open loop bound to a REMOTE secondmate home is collected first: its
+#       staged results are pulled over that route into this home's own inbox and
 #       reconciled identically. The staged copy is retired only after this home
 #       holds the result, so a dropped connection cannot lose one. A route that
 #       could not be reached prints one "unreached <obligation-id>: ..." line and

--- a/bin/fm-public-followup.sh
+++ b/bin/fm-public-followup.sh
@@ -348,18 +348,30 @@ cmd_register() {
 
 # --- subcommand: brief ------------------------------------------------------
 
-# brief_emit_target <work-home>: two lines on stdout - the absolute path of the
-# emit script the bound worker must run, and the home flag plus value it must
-# pass. They differ for a REMOTE work home, because both this checkout's path and
-# this home's path exist only on THIS machine: naming either one in instructions
-# for another machine is how a promised public reply silently never arrives.
+# public_followup_route_kind <secondmate-id> <recorded-local-home>: print remote
+# or local only when the current route still proves which transport owns it.
+public_followup_route_kind() {
+  local id=$1 recorded_home=$2 resolved
+  if public_followup_route_is_remote "$id"; then
+    printf 'remote\n'
+    return 0
+  fi
+  [ -n "$recorded_home" ] || return 1
+  resolved=$(public_followup_secondmate_home "$id" 2>/dev/null) || return 1
+  [ "$resolved" = "$recorded_home" ] || return 1
+  printf 'local\n'
+}
+
+# brief_emit_target <work-home> <recorded-local-home>: two lines on stdout - the
+# absolute path of the emit script the bound worker must run, and its home flag.
 brief_emit_target() {
-  local work_home=$1 sid root home
+  local work_home=$1 recorded_home=${2:-} sid kind root home configured_path
   case "$work_home" in
     secondmate:*) sid=${work_home#secondmate:} ;;
     *) printf '%s\n--home %s\n' "$FM_ROOT/bin/fm-public-followup-emit.sh" "$FM_HOME"; return 0 ;;
   esac
-  if ! public_followup_route_is_remote "$sid"; then
+  kind=$(public_followup_route_kind "$sid" "$recorded_home") || return 1
+  if [ "$kind" = local ]; then
     printf '%s\n--home %s\n' "$FM_ROOT/bin/fm-public-followup-emit.sh" "$FM_HOME"
     return 0
   fi
@@ -367,14 +379,16 @@ brief_emit_target() {
   home=$(secondmate_registry_field "$DATA/secondmates.md" "$sid" home 2>/dev/null) || home=
   case "$root" in /*) ;; *) return 1 ;; esac
   case "$home" in /*) ;; *) return 1 ;; esac
-  # These two values are printed into a command line the worker runs verbatim, so
-  # keep them to a conservative path charset rather than trusting the record.
   case "$root$home" in *[!A-Za-z0-9/._+@:-]*) return 1 ;; esac
+  for configured_path in "$root" "$home"; do
+    case "/$configured_path/" in */../*|*/./*) return 1 ;; esac
+    case "$configured_path" in *'//'*) return 1 ;; esac
+  done
   printf '%s\n--stage-in %s\n' "$root/bin/fm-public-followup-emit.sh" "$home"
 }
 
 cmd_brief() {
-  local id=${1:-} relation work_home work_id generation payload outcome keys key deliverable_flags
+  local id=${1:-} relation work_home work_home_path work_id generation payload outcome keys key deliverable_flags
   local emit_target emit_script emit_home_flag closing_note
   [ -n "$id" ] || { usage; exit 2; }
   fm_pf_slug_valid "$id" || die "unsafe obligation id: $id"
@@ -384,10 +398,11 @@ cmd_brief() {
 
   relation=$(fm_pf_registry_get "$STATE" "$id" relation_id)
   work_home=$(fm_pf_registry_get "$STATE" "$id" work_home)
+  work_home_path=$(fm_pf_registry_get "$STATE" "$id" work_home_path)
   work_id=$(fm_pf_registry_get "$STATE" "$id" work_id)
   generation=$(fm_pf_registry_get "$STATE" "$id" generation)
 
-  emit_target=$(brief_emit_target "$work_home") \
+  emit_target=$(brief_emit_target "$work_home" "$work_home_path") \
     || die "the work home for '$id' is a remote route with no usable code root and home in data/secondmates.md; fix that record before briefing the bound worker" 1
   emit_script=$(printf '%s\n' "$emit_target" | sed -n '1p')
   emit_home_flag=$(printf '%s\n' "$emit_target" | sed -n '2p')
@@ -488,7 +503,7 @@ reject_event() {
 # reported by name and never passed off as an empty inbox: the promise is still
 # owed, and the staged result is still on that host.
 collect_remote_staged_events() {
-  local dir file id work_home sid rc=0 collect_rc payload line event_id dropped
+  local dir file id work_home work_home_path sid route_kind rc=0 collect_rc payload line event_id dropped
   dir=$(fm_pf_registry_dir "$STATE")
   [ -d "$dir" ] && [ ! -L "$dir" ] || return 0
   for file in "$dir"/*; do
@@ -497,7 +512,14 @@ collect_remote_staged_events() {
     fm_pf_slug_valid "$id" || continue
     work_home=$(fm_pf_registry_get "$STATE" "$id" work_home)
     case "$work_home" in secondmate:*) sid=${work_home#secondmate:} ;; *) continue ;; esac
-    public_followup_route_is_remote "$sid" || continue
+    work_home_path=$(fm_pf_registry_get "$STATE" "$id" work_home_path)
+    route_kind=$(public_followup_route_kind "$sid" "$work_home_path") || {
+      printf 'unreached %s: the work home route %s cannot be resolved; its terminal result stays retained for reconciliation; fix data/secondmates.md\n' \
+        "$id" "$sid"
+      rc=1
+      continue
+    }
+    [ "$route_kind" = remote ] || continue
     command -v jq >/dev/null 2>&1 \
       || die "jq is required to collect a terminal result from a remote work home" 1
 
@@ -508,13 +530,13 @@ collect_remote_staged_events() {
     # "delivered but completion unknown" status this codebase reconciles rather
     # than reads as done or refused.
     if [ "$collect_rc" -eq 255 ]; then
-      printf 'unreached %s: the work home %s never answered, so its terminal result stays retained there\n' \
+      printf 'unreached %s: the work home %s never answered, so its terminal result stays retained there for reconciliation\n' \
         "$id" "$sid"
       rc=1
       continue
     fi
     if [ "$collect_rc" -ne 0 ]; then
-      printf 'unreached %s: the work home %s refused the collection (exit %s), so its terminal result stays retained there\n' \
+      printf 'unreached %s: the work home %s refused the collection (exit %s), so its terminal result stays retained there for reconciliation\n' \
         "$id" "$sid" "$collect_rc"
       rc=1
       continue

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -340,6 +340,7 @@ The mechanism boundary is deliberately narrow.
 `bin/fm-x-reply.sh` remains the only thing that posts.
 `bin/fm-public-followup.sh` composes those three and adds the activation gate, a private terminal-event inbox, the idempotent delivery sequence, and retained-loop disposition: delivery stamps the registration delivered, `rechain` hands its thread binding to one follow-on obligation, and `retire` is the only close.
 Work routed to another home reports a *typed* terminal result through `bin/fm-public-followup-emit.sh`; firstmate never recovers the source home, work id, outcome, or deliverables by parsing a free-form `done:` sentence, and the child never learns the thread.
+When that home is a remote secondmate, no local path reaches the owning home, so the result is staged where the work runs and the owning home pulls it over the same SSH route with `bin/fm-public-followup-collect.sh`.
 Because a terminal event's id is derived from its identity tuple rather than generated, duplicate reports and restart replay converge without coordination.
 Reconciliation rides the existing relay poll and the session-start digest instead of a new watcher, daemon, or timer, and both are gated on the same `.env` activation contract so a home that never opted into the relay executes none of it.
 The [Relay configuration reference](configuration.md#promised-public-replies-statepublic-followup) owns the operator-facing contract, and the `fmx-respond` skill owns the procedure.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -578,11 +578,19 @@ Firstmate's bounded registration retains the obligation's public-safe request bi
 Run `bin/fm-public-followup.sh --help` for the exact subcommands and flags.
 
 Registration is what creates this home's private transport under `state/public-followup/` (mode 0700): `registry/` for the bounded private binding of each open public loop (the record survives delivery, stamped `state=delivered`, and is removed only by `retire`), `events/` for typed terminal results awaiting reconciliation, `consumed/` for the accepted-event ledger, `rejected/` for refusals kept with a one-line reason, `retired/` for the mode-0600 reason-and-time receipt written before removal, and `surfaced` for the poll's last-surfaced signature.
+A work home that reports across a machine boundary also gets `outbox/`, described below.
 The home that owns the commitment also owns the outward post, because only it holds the relay consent, the request context, and the opaque thread binding.
 Work routed elsewhere reports a typed terminal result with `bin/fm-public-followup-emit.sh` and never looks for the thread; that emitter refuses to write into a home with no registration for the named obligation.
 When that work lives in a REMOTE secondmate home, delivery clears its bound legacy link after validating the public receipt, while retirement clears the link before closing the loop, and both clears run over that route's SSH transport.
 Readable remote state that proves no link exists succeeds without a write, while a present link is cleared only when its Relay request identity matches the registration and the state is writable; an identity mismatch, unreadable or unsafe state, an unavailable write or lock, an older remote copy, or a host that never confirms the clear leaves the loop retained for reconciliation.
 A terminal event's id is derived from its identity tuple, so a duplicate report, a retry, or a replay after restart resolves to the same event and changes nothing.
+
+Work bound to a REMOTE secondmate home reports across a machine boundary, where no local path reaches the owning home.
+`bin/fm-public-followup.sh brief` therefore prints that worker the route's own code root and home with `--stage-in`, so the typed result is staged in `outbox/` in the home where the work actually runs rather than written to a path that only exists on the owning machine.
+The owning home collects those staged results over the same SSH route it reaches that secondmate on, because that transport only runs in the outbound direction: `consume` pulls them into its own `events/` and then reconciles them exactly as it reconciles a local report.
+Collection is non-destructive until the result is durably held, and the staged copy is retired only afterwards, so a dropped connection can never lose a terminal result.
+A work home that cannot be reached is named in `consume`'s output and keeps the promise open; it is never reported as an empty inbox.
+Run `bin/fm-public-followup-collect.sh --help` for the staged-result commands the owning home runs over that route.
 
 Activation is the same `.env` `FMX_PAIRING_TOKEN` contract as the rest of Relay, with no second flag.
 A home without that token runs one file test and stops: no `tasks-axi` call, no backlog or request-context scan, and no `state/public-followup/` directory.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -580,16 +580,17 @@ Run `bin/fm-public-followup.sh --help` for the exact subcommands and flags.
 Registration is what creates this home's private transport under `state/public-followup/` (mode 0700): `registry/` for the bounded private binding of each open public loop (the record survives delivery, stamped `state=delivered`, and is removed only by `retire`), `events/` for typed terminal results awaiting reconciliation, `consumed/` for the accepted-event ledger, `rejected/` for refusals kept with a one-line reason, `retired/` for the mode-0600 reason-and-time receipt written before removal, and `surfaced` for the poll's last-surfaced signature.
 A work home that reports across a machine boundary also gets `outbox/`, described below.
 The home that owns the commitment also owns the outward post, because only it holds the relay consent, the request context, and the opaque thread binding.
-Work routed elsewhere reports a typed terminal result with `bin/fm-public-followup-emit.sh` and never looks for the thread; that emitter refuses to write into a home with no registration for the named obligation.
+Work routed elsewhere reports a typed terminal result with `bin/fm-public-followup-emit.sh` and never looks for the thread; when writing directly into the owning home, that emitter refuses a home with no registration for the named obligation.
 When that work lives in a REMOTE secondmate home, delivery clears its bound legacy link after validating the public receipt, while retirement clears the link before closing the loop, and both clears run over that route's SSH transport.
 Readable remote state that proves no link exists succeeds without a write, while a present link is cleared only when its Relay request identity matches the registration and the state is writable; an identity mismatch, unreadable or unsafe state, an unavailable write or lock, an older remote copy, or a host that never confirms the clear leaves the loop retained for reconciliation.
 A terminal event's id is derived from its identity tuple, so a duplicate report, a retry, or a replay after restart resolves to the same event and changes nothing.
 
 Work bound to a REMOTE secondmate home reports across a machine boundary, where no local path reaches the owning home.
 `bin/fm-public-followup.sh brief` therefore prints that worker the route's own code root and home with `--stage-in`, so the typed result is staged in `outbox/` in the home where the work actually runs rather than written to a path that only exists on the owning machine.
-The owning home collects those staged results over the same SSH route it reaches that secondmate on, because that transport only runs in the outbound direction: `consume` pulls them into its own `events/` and then reconciles them exactly as it reconciles a local report.
+The owning home collects staged results for open registrations over the same SSH route it reaches that secondmate on, because that transport only runs in the outbound direction: `consume` pulls them into its own `events/` and then reconciles them exactly as it reconciles a local report.
+Non-open registrations owe no result, so `consume` skips them without contacting their routes; an open registration whose reachable route has nothing staged remains pending without an error.
 Collection is non-destructive until the result is durably held, and the staged copy is retired only afterwards, so a dropped connection can never lose a terminal result.
-A work home that cannot be reached is named in `consume`'s output and keeps the promise open; it is never reported as an empty inbox.
+For an open registration, a work home that cannot be reached is named in `consume`'s output and keeps the promise open; it is never reported as an empty inbox.
 Run `bin/fm-public-followup-collect.sh --help` for the staged-result commands the owning home runs over that route.
 
 Activation is the same `.env` `FMX_PAIRING_TOKEN` contract as the rest of Relay, with no second flag.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -138,7 +138,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-x-followup.sh`       | Detect, post, and cap completion follow-ups for a Relay-linked task                  |
 | `fm-public-followup-lib.sh` | Shared Relay gate, open-loop registry state, expiry classification, locking, and private transport paths |
 | `fm-public-followup.sh`  | Reconcile and deliver typed public commitments, then rechain or explicitly retire their retained loops |
-| `fm-public-followup-emit.sh` | Report one typed terminal work result into the home that owes the public reply    |
+| `fm-public-followup-emit.sh` | Report one typed terminal work result into the home that owes the public reply, or stage it when that home is on another machine |
+| `fm-public-followup-collect.sh` | Read and retire the typed terminal results a remote work home staged for the home that owes the public reply |
 | `fm-inbox.sh`            | The captain's out-of-band capture surface: queue a note, dictate one, read status, ask a side question |
 | `fm-voice-relay.py`      | Hold the spoken conversation on this host, answer from the records, and hand real work to `fm-inbox.sh` ([voice-relay.md](voice-relay.md)) |
 | `fm-voice-client.py`     | The laptop end of the spoken interface: capture, playback, and turn timing over SSH; audio devices unverified |

--- a/docs/verification/public-followup.md
+++ b/docs/verification/public-followup.md
@@ -2,13 +2,14 @@
 
 Audience: maintainer verification.
 
-This record supports five active guarantees for promised public replies made through the myfirstmate relay:
+This record supports six active guarantees for promised public replies made through the myfirstmate relay:
 
 1. A promised final reply survives compaction and restart, reconciles from disk alone, and lands in the original thread exactly once.
 2. A home that never opted into the relay pays nothing for any of it.
 3. Delivering a final does not close the public loop: the registration is retained as `state=delivered` until `retire --reason`, session start surfaces an `open-loop` line, and `rechain` can bind follow-on work to the same thread.
 4. A first registration with no registry lock already held succeeds under stock macOS Bash 3.2 with `set -u`.
 5. A public loop whose work lives in a REMOTE secondmate home retires when readable remote state proves no link exists, or after readable and writable remote state clears the matching bound legacy Relay link; unreadable state, a non-writable matching link, an identity mismatch, a metadata lock it cannot acquire within its bound, or unconfirmed completion retains the loop instead of hanging, and `--force` still covers only the unresolved obligation.
+6. Work bound to a REMOTE secondmate home can report its typed terminal result: the instructions name paths that exist on the worker's own machine, the owning home collects the result over that route, and a route it cannot reach is reported rather than read as an empty inbox.
 
 [`docs/configuration.md`](../configuration.md#promised-public-replies-statepublic-followup) owns the operator-facing contract, [`docs/architecture.md`](../architecture.md#optional-relay) owns the mechanism boundary, and `tasks-axi public-followup --help` owns the typed obligation schema.
 Task chronology and delivery evidence stay outside this record.
@@ -18,7 +19,7 @@ Task chronology and delivery evidence stay outside this record.
 Recorded 2026-09-01 on Darwin 25.5.0 (arm64) with GNU bash 5.3.9, tasks-axi 0.2.5, jq 1.8.1, and ShellCheck 0.11.0 (the version `bin/fm-lint.sh` pins).
 The stock macOS compatibility lane additionally runs the focused first-registration regression with `/bin/bash` 3.2.57 and a real `tasks-axi` installation.
 The relay is a fakebin `curl` in every case, so no public post is ever made; `tasks-axi` and `jq` are the real tools, because stubbing the obligation state machine would verify nothing.
-The remote-route cases fake only the SSH binary at the `FM_SSH_BIN` process seam and then run the real tracked `fm-remote-entrypoint.sh` against a local checkout standing in for the remote one, so the clear that has to reach the remote home actually runs there; no host and no network are involved.
+The remote-route cases fake only the SSH binary at the `FM_SSH_BIN` process seam and then run the real tracked `fm-remote-entrypoint.sh` against a local checkout standing in for the remote one, so the work that has to reach the remote home actually runs there; no host and no network are involved.
 
 ## Restart end-to-end and regressions
 
@@ -88,6 +89,11 @@ ok - retire fails closed when remote state is non-writable
 ok - retire accepts link absence in non-writable remote state
 ok - the guarded remote clear refuses a lock it cannot acquire instead of hanging
 ok - an unconfirmed remote clear is unknown completion, never a silent close
+ok - a typed terminal result emitted in a remote work home reaches the owning home
+ok - an unreachable remote work home fails loudly instead of reporting an empty inbox
+ok - a local work home's emit path is unchanged
+ok - a duplicate report from a remote work home stays a no-op
+ok - staging refuses an ambiguous destination and a path that is not a firstmate home
 ```
 
 The restart case is the end-to-end proof of guarantee 1.
@@ -114,6 +120,19 @@ The writability precondition narrows the wedge window but cannot close it, becau
 The case asserts the refusal, the retained registration, the absent receipt, the untouched remote link, and that the call returns at all, which is the observable difference from a wait that never ends.
 The final case makes the transport unreachable and asserts the close is refused with the registration retained, the remote link untouched, and unknown completion named rather than reported as a definite failure.
 A remote home running an older Firstmate copy does not recognize the guarded clear flag and therefore fails closed through the same retained-for-reconciliation message; operators must update that home before retrying, and there is deliberately no unguarded fallback.
+
+## Reporting a terminal result from a remote work home
+
+The five emit-leg cases are the proof of guarantee 6.
+They share the same faked-transport fixture as the retire cases above, so the collection that has to happen actually happens with no live host and no network.
+
+The first case pins the trap condition before asserting anything else: the instructions a remote-bound worker receives must not name the owning home's own path, which exists only on the owning machine.
+It then runs exactly the printed command, so what is verified is the instruction the worker actually gets rather than a hand-written approximation, and asserts the typed result reaches the owning home's inbox, that `consume` reports the loop ready, and that the staged copy is retired from the work home afterwards.
+The duplicate case replays both halves - the worker re-reports and the owning home re-collects - and asserts no second ready announcement and no change to the promise, so a retained staged copy after a failed retirement cannot produce a second public reply.
+The unreachable case drives the same route with a transport that never answers and asserts `consume` fails naming the route, says the result stays retained, and leaves the public loop untouched.
+The local case asserts the unchanged path in the same terms: a main-home work binding is still told to emit straight into this home with this checkout's script, that command still runs as printed, and it still publishes into `events/` with nothing staged.
+
+Outward delivery for a remote-home loop is the separate legacy-link clear proven above, not part of this collection path.
 
 ## Relay-disabled zero overhead
 

--- a/docs/verification/public-followup.md
+++ b/docs/verification/public-followup.md
@@ -9,7 +9,7 @@ This record supports six active guarantees for promised public replies made thro
 3. Delivering a final does not close the public loop: the registration is retained as `state=delivered` until `retire --reason`, session start surfaces an `open-loop` line, and `rechain` can bind follow-on work to the same thread.
 4. A first registration with no registry lock already held succeeds under stock macOS Bash 3.2 with `set -u`.
 5. A public loop whose work lives in a REMOTE secondmate home retires when readable remote state proves no link exists, or after readable and writable remote state clears the matching bound legacy Relay link; unreadable state, a non-writable matching link, an identity mismatch, a metadata lock it cannot acquire within its bound, or unconfirmed completion retains the loop instead of hanging, and `--force` still covers only the unresolved obligation.
-6. Work bound to a REMOTE secondmate home can report its typed terminal result: the instructions name paths that exist on the worker's own machine, the owning home collects the result over that route, and a route it cannot reach is reported rather than read as an empty inbox.
+6. Work bound to a REMOTE secondmate home can report its typed terminal result: the instructions name paths that exist on the worker's own machine, the owning home collects results for open registrations over that route, an unreachable route fails loudly, an empty reachable route is a healthy no-op, and a non-open registration is skipped without contact.
 
 [`docs/configuration.md`](../configuration.md#promised-public-replies-statepublic-followup) owns the operator-facing contract, [`docs/architecture.md`](../architecture.md#optional-relay) owns the mechanism boundary, and `tasks-axi public-followup --help` owns the typed obligation schema.
 Task chronology and delivery evidence stay outside this record.
@@ -82,6 +82,7 @@ ok - pre-change registrations are open loops and un-rechainable, never a crash
 ok - teardown reports an unreconciled legacy Relay link
 ok - secondmate promotion matches teardown parent resolution
 ok - a public loop bound to a remote secondmate home delivers and retires
+ok - delivered remote registrations skip offline collection routes
 ok - --force still covers only the unresolved obligation, not the link clear
 ok - retire fails closed when a remote route is reassigned
 ok - retire fails closed when remote state is unreadable
@@ -91,9 +92,15 @@ ok - the guarded remote clear refuses a lock it cannot acquire instead of hangin
 ok - an unconfirmed remote clear is unknown completion, never a silent close
 ok - a typed terminal result emitted in a remote work home reaches the owning home
 ok - an unreachable remote work home fails loudly instead of reporting an empty inbox
+ok - an unreadable remote outbox fails collection without losing its result
+ok - invalid registration fails collection without dropping the staged result
+ok - unsafe registration entries fail collection without dropping staged results
+ok - route loss fails brief and consume without dropping the staged result
+ok - empty reachable remote collection remains a healthy no-op
+ok - remote brief rejects traversal and empty route path components
 ok - a local work home's emit path is unchanged
 ok - a duplicate report from a remote work home stays a no-op
-ok - staging refuses an ambiguous destination and a path that is not a firstmate home
+ok - staging requires the matching secondmate firstmate home
 ```
 
 The restart case is the end-to-end proof of guarantee 1.
@@ -123,13 +130,15 @@ A remote home running an older Firstmate copy does not recognize the guarded cle
 
 ## Reporting a terminal result from a remote work home
 
-The five emit-leg cases are the proof of guarantee 6.
+The twelve collection and emit cases are the proof of guarantee 6.
 They share the same faked-transport fixture as the retire cases above, so the collection that has to happen actually happens with no live host and no network.
 
-The first case pins the trap condition before asserting anything else: the instructions a remote-bound worker receives must not name the owning home's own path, which exists only on the owning machine.
+The first emit case pins the trap condition before asserting anything else: the instructions a remote-bound worker receives must not name the owning home's own path, which exists only on the owning machine.
 It then runs exactly the printed command, so what is verified is the instruction the worker actually gets rather than a hand-written approximation, and asserts the typed result reaches the owning home's inbox, that `consume` reports the loop ready, and that the staged copy is retired from the work home afterwards.
 The duplicate case replays both halves - the worker re-reports and the owning home re-collects - and asserts no second ready announcement and no change to the promise, so a retained staged copy after a failed retirement cannot produce a second public reply.
-The unreachable case drives the same route with a transport that never answers and asserts `consume` fails naming the route, says the result stays retained, and leaves the public loop untouched.
+The route and record refusal cases assert that unreachable transport, an unreadable outbox, invalid or unsafe registration state, and route loss all fail loudly without dropping the staged result.
+The empty-route case proves that a reachable route with nothing staged is an ordinary silent no-op, while the delivered-registration case proves a settled loop never contacts an offline route.
+The route-path and staging-destination cases prove that the printed remote command cannot target an unsafe or mismatched home.
 The local case asserts the unchanged path in the same terms: a main-home work binding is still told to emit straight into this home with this checkout's script, that command still runs as printed, and it still publishes into `events/` with nothing staged.
 
 Outward delivery for a remote-home loop is the separate legacy-link clear proven above, not part of this collection path.

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -405,7 +405,7 @@ test_duplicate_event_and_replay_are_noops() {
 test_invalid_events_are_refused_and_quarantined() {
   local home out events rejected
   home=$(make_home refusals)
-  seed_commitment "$home" pf-refuse req-refuse discord secondmate:fmdev work-real
+  seed_commitment "$home" pf-refuse req-refuse discord main work-real
 
   # Wrong source home and wrong work id are caught at the edge by the emitter,
   # because the owning home's own registration disagrees.
@@ -419,12 +419,12 @@ test_invalid_events_are_refused_and_quarantined() {
 
   expect_failure "a wrong work id must be refused" \
     "$EMIT" --home "$home" --obligation pf-refuse --relation rel-code \
-    --source-home secondmate:fmdev --work-id work-other --generation 1 \
+    --source-home main --work-id work-other --generation 1 \
     --outcome pr-merged --deliverable pr_url=https://example.invalid/1 \
     --outcome-text 'x'
   expect_failure "a stale generation must be refused" \
     "$EMIT" --home "$home" --obligation pf-refuse --relation rel-code \
-    --source-home secondmate:fmdev --work-id work-real --generation 0 \
+    --source-home main --work-id work-real --generation 0 \
     --outcome pr-merged --deliverable pr_url=https://example.invalid/1 \
     --outcome-text 'x'
 
@@ -441,7 +441,7 @@ test_invalid_events_are_refused_and_quarantined() {
   # A deliverable the expected-final type does not permit. The emitter accepts the
   # shape; tasks-axi is the authority that refuses the semantics.
   "$EMIT" --home "$home" --obligation pf-refuse --relation rel-code \
-    --source-home secondmate:fmdev --work-id work-real --generation 1 \
+    --source-home main --work-id work-real --generation 1 \
     --outcome pr-merged --deliverable report_path=data/x/report.md \
     --outcome-text 'wrong deliverable for a merged PR' >/dev/null \
     || fail "the emitter should publish a shape-valid event"
@@ -453,7 +453,7 @@ test_invalid_events_are_refused_and_quarantined() {
   # A hand-edited event whose id no longer matches its own identity fields.
   jq -n '{schema_version:1, event_id:"forged", obligation_id:"pf-refuse",
           relation_id:"rel-code", work_id:"work-real", generation:1,
-          source_home_id:"secondmate:fmdev", outcome_type:"pr-merged",
+          source_home_id:"main", outcome_type:"pr-merged",
           deliverables:{pr_url:"https://example.invalid/9"},
           public_safe_outcome:"forged", occurred_at:"2026-07-30T12:00:00Z",
           successor:null}' > "$events/forged.json"
@@ -1112,10 +1112,10 @@ test_traversal_registration_is_refused_before_delivery() {
   seed_commitment "$home" pf-traversal req-traversal x main work-traversal
   emit_terminal "$home" "$home" pf-traversal main work-traversal >/dev/null \
     || fail "emit failed for traversal registration"
+  run_pf "$home" consume >/dev/null || fail "consume failed before traversal registration damage"
   sed -i.bak 's/^work_home=.*/work_home=secondmate:..\/..\/x/' \
     "$home/state/public-followup/registry/pf-traversal"
   rm -f "$home/state/public-followup/registry/pf-traversal.bak"
-  run_pf "$home" consume >/dev/null || fail "consume failed for traversal registration"
 
   out=$(FAKE_CURL_LOG="$log" run_pf "$home" deliver pf-traversal 2>&1) && \
     fail "a traversal-shaped registration must not be deliverable"

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -2974,42 +2974,18 @@ test_remote_route_loss_fails_brief_and_collection() {
   pass "route loss fails brief and consume without dropping the staged result"
 }
 
-test_remote_route_reassignment_fails_collection_loudly() {
-  local home original replacement out command
+test_empty_remote_collection_is_healthy() {
+  local home remote out
   remote_fixture_prepare
-  home=$(make_home remote-route-reassigned-emit)
-  original=$(make_remote_route "$home" mini-default)
-  seed_repro_commitment "$home" pf-route-reassigned req-route-reassigned secondmate:mini-default work-reassigned
+  home=$(make_home remote-empty-collection)
+  remote=$(make_remote_route "$home" mini-default)
+  seed_repro_commitment "$home" pf-empty-collection req-empty-collection secondmate:mini-default work-pending
 
-  out=$(run_pf "$home" brief pf-route-reassigned) || fail "brief failed: $out"
-  command=$(brief_emit_command "$out")
-  command=${command//<value>/data/work-reassigned/report.md}
-  command=${command//<one bounded public-safe sentence>/The original remote route finished its work.}
-  printf 'mini-default\n' > "$original/.fm-secondmate-home"
-  bash -c "$command" >/dev/null || fail "the original route must stage its terminal result"
-
-  replacement="$TMP_ROOT/remote-route-reassigned-replacement"
-  mkdir -p "$replacement/state" "$replacement/data"
-  replacement=$(cd "$replacement" && pwd -P)
-  cat > "$home/data/secondmates.md" <<EOF
-- mini-default - replacement lane (host: remote-mac; root: $REMOTE_FIXTURE_ROOT; home: $replacement; scope: relay work; projects: firstmate; added 2026-08-03)
-EOF
-  fm_write_meta "$home/state/mini-default.meta" "kind=secondmate" "home=$replacement" \
-    "remote_host=remote-mac" "remote_root=$REMOTE_FIXTURE_ROOT"
-
-  expect_failure "consume must refuse an empty reassigned route" \
-    run_pf_remote "$home" consume
-  assert_contains "$EXPECT_OUT" "unreached pf-route-reassigned" \
-    "consume must name the stranded obligation as unreached"
-  assert_contains "$EXPECT_OUT" "mini-default" \
-    "consume must name the reassigned route"
-  assert_contains "$EXPECT_OUT" "stays retained there" \
-    "consume must report that the original staged result remains reconcilable"
-  [ -n "$(ls -A "$original/state/public-followup/outbox" 2>/dev/null)" ] \
-    || fail "the original route must retain its staged terminal result"
-  [ "$(delivery_state "$home" pf-route-reassigned)" = pending-work ] \
-    || fail "route reassignment must leave the promise open"
-  pass "route reassignment fails collection without losing the staged result"
+  out=$(run_pf_remote "$home" consume) || fail "an empty reachable route must collect cleanly: $out"
+  [ -z "$out" ] || fail "an empty reachable route must remain silent, got: $out"
+  [ "$(delivery_state "$home" pf-empty-collection)" = pending-work ] \
+    || fail "empty collection must leave unfinished remote work pending"
+  pass "empty reachable remote collection remains a healthy no-op"
 }
 
 test_remote_brief_rejects_traversal_route_paths() {
@@ -3139,7 +3115,7 @@ test_remote_collection_refuses_unreadable_outbox
 test_invalid_registration_fails_remote_collection
 test_unsafe_registration_entry_fails_remote_collection
 test_remote_route_loss_fails_brief_and_collection
-test_remote_route_reassignment_fails_collection_loudly
+test_empty_remote_collection_is_healthy
 test_remote_brief_rejects_traversal_route_paths
 test_local_work_home_emit_path_is_unchanged
 test_remote_collection_is_idempotent

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -2735,6 +2735,7 @@ test_remote_work_home_emit_reaches_owning_home() {
   # literally executable there.
   command=${command//<value>/data/work-remote/report.md}
   command=${command//<one bounded public-safe sentence>/The remote lane finished its investigation.}
+  printf 'mini-default\n' > "$remote/.fm-secondmate-home"
   bash -c "$command" >/dev/null || fail "the worker's own instructions must run in its home"
 
   staged=$(run_pf_remote "$home" consume) || fail "consume failed: $staged"
@@ -2765,6 +2766,7 @@ test_remote_collection_is_idempotent() {
   command=$(brief_emit_command "$out")
   command=${command//<value>/data/work-twice/report.md}
   command=${command//<one bounded public-safe sentence>/The remote lane finished its investigation.}
+  printf 'mini-default\n' > "$remote/.fm-secondmate-home"
   bash -c "$command" >/dev/null || fail "the worker's own instructions must run in its home"
   staged=$(run_pf_remote "$home" consume) || fail "consume failed: $staged"
   assert_contains "$staged" "ready pf-remote-twice" "the first collection must report the loop ready"
@@ -2785,7 +2787,7 @@ test_remote_collection_is_idempotent() {
 # than resolved by argument order, and a staging path that is not a firstmate
 # home is refused rather than swallowing the result.
 test_stage_in_refuses_ambiguous_or_unusable_homes() {
-  local home
+  local home unrelated
   home=$(make_home stage-in-refusals)
   seed_repro_commitment "$home" pf-stage-refuse req-stage-refuse main work-stage
 
@@ -2797,17 +2799,27 @@ test_stage_in_refuses_ambiguous_or_unusable_homes() {
   assert_contains "$EXPECT_OUT" "mutually exclusive" \
     "the refusal must say the two home flags cannot be combined"
 
-  mkdir -p "$home/not-a-home"
-  expect_failure "a staging path that is not a firstmate home must be refused" \
-    "$EMIT" --stage-in "$home/not-a-home" --obligation pf-stage-refuse \
-    --relation rel-code --source-home main --work-id work-stage --generation 1 \
+  unrelated="$home/not-a-home"
+  mkdir -p "$unrelated/state"
+  expect_failure "an ordinary directory with state must not pass as a staging home" \
+    "$EMIT" --stage-in "$unrelated" --obligation pf-stage-refuse \
+    --relation rel-code --source-home secondmate:mate --work-id work-stage --generation 1 \
     --outcome report-ready --deliverable report_path=data/work-stage/report.md \
     --outcome-text 'Nowhere to be collected from.'
   assert_contains "$EXPECT_OUT" "firstmate home" \
     "the refusal must name what --stage-in has to point at"
-  assert_absent "$home/not-a-home/state" \
-    "a refused staging path must gain nothing"
-  pass "staging refuses an ambiguous destination and a path that is not a firstmate home"
+  assert_absent "$unrelated/state/public-followup" \
+    "a refused staging path must gain no outbox"
+
+  printf 'someone-else\n' > "$unrelated/.fm-secondmate-home"
+  expect_failure "a staging home's identity must match --source-home" \
+    "$EMIT" --stage-in "$unrelated" --obligation pf-stage-refuse \
+    --relation rel-code --source-home secondmate:mate --work-id work-stage --generation 1 \
+    --outcome report-ready --deliverable report_path=data/work-stage/report.md \
+    --outcome-text 'Wrong home.'
+  assert_absent "$unrelated/state/public-followup" \
+    "an identity mismatch must gain no outbox"
+  pass "staging requires the matching secondmate firstmate home"
 }
 
 # The owning home must never quietly report "nothing waiting" when it simply
@@ -2830,6 +2842,62 @@ test_remote_collection_transport_failure_is_loud() {
   [ "$(delivery_state "$home" pf-remote-down)" != posted ] \
     || fail "an unreachable work home must never advance the public loop"
   pass "an unreachable remote work home fails loudly instead of reporting an empty inbox"
+}
+
+test_remote_route_loss_fails_brief_and_collection() {
+  local home remote out command
+  remote_fixture_prepare
+  home=$(make_home remote-route-lost)
+  remote=$(make_remote_route "$home" mini-default)
+  seed_repro_commitment "$home" pf-route-lost req-route-lost secondmate:mini-default work-lost
+
+  out=$(run_pf "$home" brief pf-route-lost) || fail "brief failed before route loss: $out"
+  command=$(brief_emit_command "$out")
+  command=${command//<value>/data/work-lost/report.md}
+  command=${command//<one bounded public-safe sentence>/The remote lane finished before its route record was lost.}
+  printf 'mini-default\n' > "$remote/.fm-secondmate-home"
+  bash -c "$command" >/dev/null || fail "the staged result must exist before route loss"
+  rm -f "$home/data/secondmates.md"
+
+  expect_failure "brief must refuse an unresolved remote registration" \
+    run_pf "$home" brief pf-route-lost
+  assert_contains "$EXPECT_OUT" "data/secondmates.md" \
+    "brief must point at the route record that needs repair"
+
+  expect_failure "consume must refuse an unresolved remote registration" \
+    run_pf_remote "$home" consume
+  assert_contains "$EXPECT_OUT" "pf-route-lost" \
+    "consume must name the obligation whose route was lost"
+  assert_contains "$EXPECT_OUT" "mini-default" \
+    "consume must name the unresolved route"
+  assert_contains "$EXPECT_OUT" "retained for reconciliation" \
+    "consume must say the staged result remains reconcilable"
+  [ -n "$(ls -A "$remote/state/public-followup/outbox" 2>/dev/null)" ] \
+    || fail "route loss must leave the staged result in its remote outbox"
+  pass "route loss fails brief and consume without dropping the staged result"
+}
+
+test_remote_brief_rejects_traversal_route_paths() {
+  local home remote
+  remote_fixture_prepare
+  home=$(make_home remote-route-paths)
+  remote=$(make_remote_route "$home" mini-default)
+  seed_repro_commitment "$home" pf-route-paths req-route-paths secondmate:mini-default work-paths
+
+  cat > "$home/data/secondmates.md" <<EOF
+- mini-default - remote lane (host: remote-mac; root: $REMOTE_FIXTURE_ROOT/../remote-root; home: $remote; scope: relay work; projects: firstmate; added 2026-08-02)
+EOF
+  expect_failure "brief must reject a traversal component in the remote root" \
+    run_pf "$home" brief pf-route-paths
+  assert_contains "$EXPECT_OUT" "no usable code root and home" \
+    "a traversal route must use the route-record refusal"
+
+  cat > "$home/data/secondmates.md" <<EOF
+- mini-default - remote lane (host: remote-mac; root: $REMOTE_FIXTURE_ROOT; home: //$remote; scope: relay work; projects: firstmate; added 2026-08-02)
+EOF
+  expect_failure "brief must reject an empty component in the remote home" \
+    run_pf "$home" brief pf-route-paths
+  pass "remote brief rejects traversal and empty route path components"
 }
 
 # A local work home is on this machine, so nothing about its instructions or its
@@ -2932,6 +3000,8 @@ test_remote_retire_refuses_unacquirable_lock_without_hanging
 test_remote_unconfirmed_clear_is_unknown_completion
 test_remote_work_home_emit_reaches_owning_home
 test_remote_collection_transport_failure_is_loud
+test_remote_route_loss_fails_brief_and_collection
+test_remote_brief_rejects_traversal_route_paths
 test_local_work_home_emit_path_is_unchanged
 test_remote_collection_is_idempotent
 test_stage_in_refuses_ambiguous_or_unusable_homes

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -2297,13 +2297,15 @@ test_secondmate_promotion_uses_teardown_parent_resolution() {
 
 # --- remote secondmate work homes ---------------------------------------------
 #
-# A REMOTE secondmate route records no local path for its home, because the home
-# only exists on the other machine. Registration therefore stores an empty
-# work_home_path, and every close that must first clear the bound legacy X link
-# has to reach that home over the route's SSH transport instead.
+# A REMOTE secondmate route's home exists only on the other machine. Registration
+# therefore stores an empty work_home_path, so every close that must first clear
+# the bound legacy X link has to reach that home over the route's SSH transport,
+# and a worker there cannot write into the owning home's typed terminal-result
+# inbox either: the instructions it receives must name paths that exist WHERE IT
+# RUNS, and the owning home must collect the staged result over that same route.
 #
 # The transport is faked at the FM_SSH_BIN process seam and then runs the REAL
-# tracked remote entrypoint against a local "remote" checkout, so the clear that
+# tracked remote entrypoint against a local "remote" checkout, so the work that
 # has to happen actually happens: no live host, no network, and no assumption
 # baked into a stub about what the far side would have done.
 
@@ -2432,7 +2434,7 @@ test_remote_secondmate_loop_delivers_and_retires() {
     --outcome report-ready --deliverable report_path=data/work-remote/report.md \
     --outcome-text 'The remote lane finished its investigation.' >/dev/null \
     || fail "emit failed"
-  run_pf "$home" consume >/dev/null || fail "consume failed"
+  run_pf_remote "$home" consume >/dev/null || fail "consume failed"
 
   FAKE_CURL_LOG="$log" run_pf_remote "$home" deliver pf-remote-close >/dev/null \
     || fail "delivery must not strand a remote-home loop after the public reply lands"
@@ -2496,7 +2498,7 @@ test_remote_retire_refuses_reassigned_route() {
     --source-home secondmate:mate --work-id work-reused --generation 1 \
     --outcome report-ready --deliverable report_path=data/work-reused/report.md \
     --outcome-text 'The original remote route finished its work.' >/dev/null || fail "emit failed"
-  run_pf "$home" consume >/dev/null || fail "consume failed"
+  run_pf_remote "$home" consume >/dev/null || fail "consume failed"
   FAKE_CURL_LOG="$log" run_pf_remote "$home" deliver pf-remote-reassigned >/dev/null \
     || fail "delivery through the original remote route must succeed"
 
@@ -2684,6 +2686,182 @@ test_remote_unconfirmed_clear_is_unknown_completion() {
   pass "an unconfirmed remote clear is unknown completion, never a silent close"
 }
 
+# brief_emit_command <brief-output>: the exact runnable command block the brief
+# tells the bound worker to run, with its placeholders filled in.
+brief_emit_command() {  # <brief-output>
+  printf '%s\n' "$1" | awk '
+    index($0, "/bin/fm-public-followup-emit.sh") { capture=1 }
+    capture { if ($0 == "") exit; print }
+  '
+}
+
+# The reported failure: a public loop whose work lives in a REMOTE secondmate
+# home never received its typed terminal result. The instructions named the
+# owning home's own absolute path, which does not exist on the worker's machine,
+# so the worker's emit could not land anything the owning home would ever read -
+# and consume kept finding nothing while the promise stayed open.
+test_remote_work_home_emit_reaches_owning_home() {
+  local home remote out command staged
+  remote_fixture_prepare
+  home=$(make_home remote-emit)
+  remote=$(make_remote_route "$home" mini-default)
+  seed_repro_commitment "$home" pf-remote-emit req-remote-emit secondmate:mini-default work-remote
+
+  out=$(run_pf "$home" brief pf-remote-emit) || fail "brief failed: $out"
+  command=$(brief_emit_command "$out")
+  [ -n "$command" ] || fail "the brief must print a runnable emit command"
+
+  # The trap condition, pinned so this case can never go vacuous: instructions for
+  # a worker on another machine must name that machine's own paths, never the
+  # owning home and never this checkout - both exist only here.
+  assert_contains "$command" "--stage-in $remote" \
+    "instructions for a remote work home must name that home's own path"
+  case "$command" in
+    *" --home "*) fail "instructions for a remote work home must not point at a home on this machine" ;;
+  esac
+  case "$command" in
+    *"$ROOT/bin/fm-public-followup-emit.sh"*)
+      fail "instructions for a remote work home must not name this checkout's own script path" ;;
+  esac
+  assert_contains "$out" "is on another machine" \
+    "a remote worker must be told where its result waits"
+  case "$out" in
+    *"the home above owns the reply"*)
+      fail "a remote worker must not be told the home named above owns the public reply" ;;
+  esac
+
+  # Run exactly what the worker on the far machine was told to run. The fixture
+  # checkout really exists at the route's remote root, so the printed command is
+  # literally executable there.
+  command=${command//<value>/data/work-remote/report.md}
+  command=${command//<one bounded public-safe sentence>/The remote lane finished its investigation.}
+  bash -c "$command" >/dev/null || fail "the worker's own instructions must run in its home"
+
+  staged=$(run_pf_remote "$home" consume) || fail "consume failed: $staged"
+  assert_contains "$staged" "ready pf-remote-emit" \
+    "the owning home must collect a remote worker's typed result and report the loop ready"
+  [ "$(delivery_state "$home" pf-remote-emit)" = ready ] \
+    || fail "the collected result must move the promise off waiting-on-its-bound-work"
+
+  # Outward delivery from here is the retire/clear side of the same remote-home
+  # gap and is fixed separately; what this case owns is that the typed result
+  # crossed the machine boundary at all.
+  [ -z "$(ls -A "$remote/state/public-followup/outbox" 2>/dev/null)" ] \
+    || fail "a collected result must be retired from the work home's staging outbox"
+  pass "a typed terminal result emitted in a remote work home reaches the owning home"
+}
+
+# A duplicate report from the other machine must stay a no-op: the staged copy is
+# collected again after a failed retirement, and a replayed emit derives the same
+# event id, so neither can produce a second public reply.
+test_remote_collection_is_idempotent() {
+  local home remote out command staged
+  remote_fixture_prepare
+  home=$(make_home remote-emit-twice)
+  remote=$(make_remote_route "$home" mini-default)
+  seed_repro_commitment "$home" pf-remote-twice req-remote-twice secondmate:mini-default work-twice
+
+  out=$(run_pf "$home" brief pf-remote-twice) || fail "brief failed: $out"
+  command=$(brief_emit_command "$out")
+  command=${command//<value>/data/work-twice/report.md}
+  command=${command//<one bounded public-safe sentence>/The remote lane finished its investigation.}
+  bash -c "$command" >/dev/null || fail "the worker's own instructions must run in its home"
+  staged=$(run_pf_remote "$home" consume) || fail "consume failed: $staged"
+  assert_contains "$staged" "ready pf-remote-twice" "the first collection must report the loop ready"
+
+  # The worker reports the same terminal result again, and the owning home
+  # collects again: both must settle to nothing new.
+  bash -c "$command" >/dev/null || fail "a duplicate report must not fail on the worker"
+  staged=$(run_pf_remote "$home" consume) || fail "second consume failed: $staged"
+  case "$staged" in
+    *"ready pf-remote-twice"*) fail "a duplicate remote report must not re-announce the loop as newly ready" ;;
+  esac
+  [ "$(delivery_state "$home" pf-remote-twice)" = ready ] \
+    || fail "a duplicate remote report must leave the promise exactly where it was"
+  pass "a duplicate report from a remote work home stays a no-op"
+}
+
+# The two home flags answer different questions, so mixing them is refused rather
+# than resolved by argument order, and a staging path that is not a firstmate
+# home is refused rather than swallowing the result.
+test_stage_in_refuses_ambiguous_or_unusable_homes() {
+  local home
+  home=$(make_home stage-in-refusals)
+  seed_repro_commitment "$home" pf-stage-refuse req-stage-refuse main work-stage
+
+  expect_failure "the two home flags must not be combined" \
+    "$EMIT" --home "$home" --stage-in "$home" --obligation pf-stage-refuse \
+    --relation rel-code --source-home main --work-id work-stage --generation 1 \
+    --outcome report-ready --deliverable report_path=data/work-stage/report.md \
+    --outcome-text 'Ambiguous destination.'
+  assert_contains "$EXPECT_OUT" "mutually exclusive" \
+    "the refusal must say the two home flags cannot be combined"
+
+  mkdir -p "$home/not-a-home"
+  expect_failure "a staging path that is not a firstmate home must be refused" \
+    "$EMIT" --stage-in "$home/not-a-home" --obligation pf-stage-refuse \
+    --relation rel-code --source-home main --work-id work-stage --generation 1 \
+    --outcome report-ready --deliverable report_path=data/work-stage/report.md \
+    --outcome-text 'Nowhere to be collected from.'
+  assert_contains "$EXPECT_OUT" "firstmate home" \
+    "the refusal must name what --stage-in has to point at"
+  assert_absent "$home/not-a-home/state" \
+    "a refused staging path must gain nothing"
+  pass "staging refuses an ambiguous destination and a path that is not a firstmate home"
+}
+
+# The owning home must never quietly report "nothing waiting" when it simply
+# could not reach the work home: the promise stays open and the operator is told
+# which route failed.
+test_remote_collection_transport_failure_is_loud() {
+  local home remote
+  remote_fixture_prepare
+  home=$(make_home remote-emit-down)
+  remote=$(make_remote_route "$home" mini-default)
+  seed_repro_commitment "$home" pf-remote-down req-remote-down secondmate:mini-default work-down
+
+  FM_FAKE_SSH_MODE=unreachable expect_failure \
+    "an unreachable work home must not pass as an empty inbox" \
+    run_pf_remote "$home" consume
+  assert_contains "$EXPECT_OUT" "mini-default" \
+    "the refusal must name the route that could not be reached"
+  assert_contains "$EXPECT_OUT" "retained" \
+    "the refusal must say the result is retained for reconciliation"
+  [ "$(delivery_state "$home" pf-remote-down)" != posted ] \
+    || fail "an unreachable work home must never advance the public loop"
+  pass "an unreachable remote work home fails loudly instead of reporting an empty inbox"
+}
+
+# A local work home is on this machine, so nothing about its instructions or its
+# emit changes: the command still names this home and the event still lands
+# directly in this home's typed terminal-result inbox.
+test_local_work_home_emit_path_is_unchanged() {
+  local home out command
+  home=$(make_home local-emit-unchanged)
+  seed_repro_commitment "$home" pf-local-emit req-local-emit main work-local
+
+  out=$(run_pf "$home" brief pf-local-emit) || fail "brief failed: $out"
+  command=$(brief_emit_command "$out")
+  assert_contains "$command" "--home $home" \
+    "a local work home must still be told to emit straight into this home"
+  assert_contains "$command" "$ROOT/bin/fm-public-followup-emit.sh" \
+    "a local work home must still run this checkout's emit script"
+  assert_contains "$out" "the home above owns the reply" \
+    "a local work home's instructions must still close on the home named above"
+
+  command=${command//<value>/data/work-local/report.md}
+  command=${command//<one bounded public-safe sentence>/The local lane finished its investigation.}
+  bash -c "$command" >/dev/null || fail "the local emit command must run as printed"
+  [ -n "$(ls -A "$home/state/public-followup/events" 2>/dev/null)" ] \
+    || fail "a local emit must still publish into this home's typed terminal-result inbox"
+  [ -z "$(ls -A "$home/state/public-followup/outbox" 2>/dev/null)" ] \
+    || fail "a local emit must never stage anything for collection"
+  out=$(run_pf "$home" consume) || fail "consume failed: $out"
+  assert_contains "$out" "ready pf-local-emit" \
+    "a local emit must still reconcile the loop to ready"
+  pass "a local work home's emit path is unchanged"
+}
+
 # CI's stock macOS Bash lane sets FM_TEST_ONLY to run just the bash-3.2 empty-lock
 # register regression. The rest of this file is not a 3.2 snapshot suite.
 if [ -n "${FM_TEST_ONLY:-}" ]; then
@@ -2752,3 +2930,8 @@ test_remote_retire_refuses_nonwritable_state
 test_remote_retire_accepts_nonwritable_absence
 test_remote_retire_refuses_unacquirable_lock_without_hanging
 test_remote_unconfirmed_clear_is_unknown_completion
+test_remote_work_home_emit_reaches_owning_home
+test_remote_collection_transport_failure_is_loud
+test_local_work_home_emit_path_is_unchanged
+test_remote_collection_is_idempotent
+test_stage_in_refuses_ambiguous_or_unusable_homes

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -2844,6 +2844,35 @@ test_remote_collection_transport_failure_is_loud() {
   pass "an unreachable remote work home fails loudly instead of reporting an empty inbox"
 }
 
+test_remote_collection_refuses_unreadable_outbox() {
+  local home remote out command rc=0
+  remote_fixture_prepare
+  home=$(make_home remote-outbox-unreadable)
+  remote=$(make_remote_route "$home" mini-default)
+  seed_repro_commitment "$home" pf-outbox-unreadable req-outbox-unreadable secondmate:mini-default work-unreadable
+
+  out=$(run_pf "$home" brief pf-outbox-unreadable) || fail "brief failed: $out"
+  command=$(brief_emit_command "$out")
+  command=${command//<value>/data/work-unreadable/report.md}
+  command=${command//<one bounded public-safe sentence>/The result remains staged while its outbox is unreadable.}
+  printf 'mini-default\n' > "$remote/.fm-secondmate-home"
+  bash -c "$command" >/dev/null || fail "the worker must stage its terminal result"
+
+  chmod 000 "$remote/state/public-followup/outbox"
+  out=$(run_pf_remote "$home" consume 2>&1) || rc=$?
+  chmod 700 "$remote/state/public-followup/outbox"
+  [ "$rc" -ne 0 ] || fail "an unreadable remote outbox must make consume fail"
+  assert_contains "$out" "pf-outbox-unreadable" \
+    "consume must name the obligation whose outbox is unreadable"
+  assert_contains "$out" "mini-default" \
+    "consume must name the route whose outbox is unreadable"
+  assert_contains "$out" "retained" \
+    "consume must report the staged result as retained"
+  [ -n "$(ls -A "$remote/state/public-followup/outbox")" ] \
+    || fail "an unreadable outbox failure must retain the staged result"
+  pass "an unreadable remote outbox fails collection without losing its result"
+}
+
 test_remote_route_loss_fails_brief_and_collection() {
   local home remote out command
   remote_fixture_prepare
@@ -3000,6 +3029,7 @@ test_remote_retire_refuses_unacquirable_lock_without_hanging
 test_remote_unconfirmed_clear_is_unknown_completion
 test_remote_work_home_emit_reaches_owning_home
 test_remote_collection_transport_failure_is_loud
+test_remote_collection_refuses_unreadable_outbox
 test_remote_route_loss_fails_brief_and_collection
 test_remote_brief_rejects_traversal_route_paths
 test_local_work_home_emit_path_is_unchanged

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -2873,6 +2873,40 @@ test_remote_collection_refuses_unreadable_outbox() {
   pass "an unreadable remote outbox fails collection without losing its result"
 }
 
+test_invalid_registration_fails_remote_collection() {
+  local home remote out command registry
+  remote_fixture_prepare
+  home=$(make_home remote-invalid-registration)
+  remote=$(make_remote_route "$home" mini-default)
+  seed_repro_commitment "$home" pf-invalid-registration req-invalid-registration secondmate:mini-default work-invalid
+
+  out=$(run_pf "$home" brief pf-invalid-registration) || fail "brief failed: $out"
+  command=$(brief_emit_command "$out")
+  command=${command//<value>/data/work-invalid/report.md}
+  command=${command//<one bounded public-safe sentence>/The remote lane finished before registration damage.}
+  printf 'mini-default\n' > "$remote/.fm-secondmate-home"
+  bash -c "$command" >/dev/null || fail "the remote route must stage its terminal result"
+
+  registry="$home/state/public-followup/registry/pf-invalid-registration"
+  grep -v '^work_home=' "$registry" > "$registry.tmp"
+  mv "$registry.tmp" "$registry"
+  chmod 600 "$registry"
+
+  expect_failure "consume must refuse an invalid route-bearing registration" \
+    run_pf_remote "$home" consume
+  assert_contains "$EXPECT_OUT" "unreached pf-invalid-registration" \
+    "consume must name the obligation with invalid registration state"
+  assert_contains "$EXPECT_OUT" "work home route unknown" \
+    "consume must identify the unresolved route field"
+  assert_contains "$EXPECT_OUT" "stays retained for reconciliation" \
+    "consume must report the remote result as retained"
+  [ -n "$(ls -A "$remote/state/public-followup/outbox" 2>/dev/null)" ] \
+    || fail "invalid registration state must not remove the staged result"
+  [ "$(delivery_state "$home" pf-invalid-registration)" = pending-work ] \
+    || fail "invalid registration state must leave the promise open"
+  pass "invalid registration fails collection without dropping the staged result"
+}
+
 test_remote_route_loss_fails_brief_and_collection() {
   local home remote out command
   remote_fixture_prepare
@@ -3068,6 +3102,7 @@ test_remote_unconfirmed_clear_is_unknown_completion
 test_remote_work_home_emit_reaches_owning_home
 test_remote_collection_transport_failure_is_loud
 test_remote_collection_refuses_unreadable_outbox
+test_invalid_registration_fails_remote_collection
 test_remote_route_loss_fails_brief_and_collection
 test_remote_route_reassignment_fails_collection_loudly
 test_remote_brief_rejects_traversal_route_paths

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -2453,7 +2453,7 @@ test_remote_secondmate_loop_delivers_and_retires() {
 }
 
 test_delivered_remote_registration_skips_offline_route() {
-  local home remote log out
+  local home remote log out registry
   remote_fixture_prepare
   home=$(make_home remote-delivered-skip)
   remote=$(make_remote_route "$home" mini-default)
@@ -2470,8 +2470,12 @@ test_delivered_remote_registration_skips_offline_route() {
   run_pf_remote "$home" consume >/dev/null || fail "consume failed"
   FAKE_CURL_LOG="$log" run_pf_remote "$home" deliver pf-remote-delivered >/dev/null \
     || fail "delivery failed"
-  assert_grep 'state=delivered' "$home/state/public-followup/registry/pf-remote-delivered" \
+  registry="$home/state/public-followup/registry/pf-remote-delivered"
+  assert_grep 'state=delivered' "$registry" \
     "delivery must retain a delivered registration"
+  grep -v '^relation_id=' "$registry" > "$registry.tmp"
+  mv "$registry.tmp" "$registry"
+  chmod 600 "$registry"
 
   out=$(FM_FAKE_SSH_MODE=unreachable run_pf_remote "$home" consume) \
     || fail "a delivered registration must not require its remote route: $out"

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -2906,6 +2906,44 @@ test_remote_route_loss_fails_brief_and_collection() {
   pass "route loss fails brief and consume without dropping the staged result"
 }
 
+test_remote_route_reassignment_fails_collection_loudly() {
+  local home original replacement out command
+  remote_fixture_prepare
+  home=$(make_home remote-route-reassigned-emit)
+  original=$(make_remote_route "$home" mini-default)
+  seed_repro_commitment "$home" pf-route-reassigned req-route-reassigned secondmate:mini-default work-reassigned
+
+  out=$(run_pf "$home" brief pf-route-reassigned) || fail "brief failed: $out"
+  command=$(brief_emit_command "$out")
+  command=${command//<value>/data/work-reassigned/report.md}
+  command=${command//<one bounded public-safe sentence>/The original remote route finished its work.}
+  printf 'mini-default\n' > "$original/.fm-secondmate-home"
+  bash -c "$command" >/dev/null || fail "the original route must stage its terminal result"
+
+  replacement="$TMP_ROOT/remote-route-reassigned-replacement"
+  mkdir -p "$replacement/state" "$replacement/data"
+  replacement=$(cd "$replacement" && pwd -P)
+  cat > "$home/data/secondmates.md" <<EOF
+- mini-default - replacement lane (host: remote-mac; root: $REMOTE_FIXTURE_ROOT; home: $replacement; scope: relay work; projects: firstmate; added 2026-08-03)
+EOF
+  fm_write_meta "$home/state/mini-default.meta" "kind=secondmate" "home=$replacement" \
+    "remote_host=remote-mac" "remote_root=$REMOTE_FIXTURE_ROOT"
+
+  expect_failure "consume must refuse an empty reassigned route" \
+    run_pf_remote "$home" consume
+  assert_contains "$EXPECT_OUT" "unreached pf-route-reassigned" \
+    "consume must name the stranded obligation as unreached"
+  assert_contains "$EXPECT_OUT" "mini-default" \
+    "consume must name the reassigned route"
+  assert_contains "$EXPECT_OUT" "stays retained there" \
+    "consume must report that the original staged result remains reconcilable"
+  [ -n "$(ls -A "$original/state/public-followup/outbox" 2>/dev/null)" ] \
+    || fail "the original route must retain its staged terminal result"
+  [ "$(delivery_state "$home" pf-route-reassigned)" = pending-work ] \
+    || fail "route reassignment must leave the promise open"
+  pass "route reassignment fails collection without losing the staged result"
+}
+
 test_remote_brief_rejects_traversal_route_paths() {
   local home remote
   remote_fixture_prepare
@@ -3031,6 +3069,7 @@ test_remote_work_home_emit_reaches_owning_home
 test_remote_collection_transport_failure_is_loud
 test_remote_collection_refuses_unreadable_outbox
 test_remote_route_loss_fails_brief_and_collection
+test_remote_route_reassignment_fails_collection_loudly
 test_remote_brief_rejects_traversal_route_paths
 test_local_work_home_emit_path_is_unchanged
 test_remote_collection_is_idempotent

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -2907,6 +2907,40 @@ test_invalid_registration_fails_remote_collection() {
   pass "invalid registration fails collection without dropping the staged result"
 }
 
+test_unsafe_registration_entry_fails_remote_collection() {
+  local home remote out command registry backup
+  remote_fixture_prepare
+  home=$(make_home remote-unsafe-registration)
+  remote=$(make_remote_route "$home" mini-default)
+  seed_repro_commitment "$home" pf-unsafe-registration req-unsafe-registration secondmate:mini-default work-unsafe
+
+  out=$(run_pf "$home" brief pf-unsafe-registration) || fail "brief failed: $out"
+  command=$(brief_emit_command "$out")
+  command=${command//<value>/data/work-unsafe/report.md}
+  command=${command//<one bounded public-safe sentence>/The remote lane finished before registration replacement.}
+  printf 'mini-default\n' > "$remote/.fm-secondmate-home"
+  bash -c "$command" >/dev/null || fail "the remote route must stage its terminal result"
+
+  registry="$home/state/public-followup/registry/pf-unsafe-registration"
+  backup="$home/state/pf-unsafe-registration.backup"
+  mv "$registry" "$backup"
+  ln -s "$backup" "$registry"
+
+  expect_failure "consume must refuse a symlinked route-bearing registration" \
+    run_pf_remote "$home" consume
+  assert_contains "$EXPECT_OUT" "unreached pf-unsafe-registration" \
+    "consume must name the obligation with an unsafe registration entry"
+  assert_contains "$EXPECT_OUT" "safe regular record" \
+    "consume must identify the unsafe registration entry"
+  assert_contains "$EXPECT_OUT" "stays retained for reconciliation" \
+    "consume must report the remote result as retained"
+  [ -n "$(ls -A "$remote/state/public-followup/outbox" 2>/dev/null)" ] \
+    || fail "an unsafe registration entry must not remove the staged result"
+  [ "$(delivery_state "$home" pf-unsafe-registration)" = pending-work ] \
+    || fail "an unsafe registration entry must leave the promise open"
+  pass "unsafe registration entries fail collection without dropping staged results"
+}
+
 test_remote_route_loss_fails_brief_and_collection() {
   local home remote out command
   remote_fixture_prepare
@@ -3103,6 +3137,7 @@ test_remote_work_home_emit_reaches_owning_home
 test_remote_collection_transport_failure_is_loud
 test_remote_collection_refuses_unreadable_outbox
 test_invalid_registration_fails_remote_collection
+test_unsafe_registration_entry_fails_remote_collection
 test_remote_route_loss_fails_brief_and_collection
 test_remote_route_reassignment_fails_collection_loudly
 test_remote_brief_rejects_traversal_route_paths

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -2452,6 +2452,33 @@ test_remote_secondmate_loop_delivers_and_retires() {
   pass "a public loop bound to a remote secondmate home delivers and retires"
 }
 
+test_delivered_remote_registration_skips_offline_route() {
+  local home remote log out
+  remote_fixture_prepare
+  home=$(make_home remote-delivered-skip)
+  remote=$(make_remote_route "$home" mini-default)
+  log="$home/curl.log"; : > "$log"
+  seed_repro_commitment "$home" pf-remote-delivered req-remote-delivered secondmate:mini-default work-delivered
+  fm_write_meta "$remote/state/work-delivered.meta" \
+    "x_request=req-remote-delivered" "x_request_ts=1700000000" "x_followups=1"
+
+  "$EMIT" --home "$home" --obligation pf-remote-delivered --relation rel-code \
+    --source-home secondmate:mini-default --work-id work-delivered --generation 1 \
+    --outcome report-ready --deliverable report_path=data/work-delivered/report.md \
+    --outcome-text 'The remote lane completed its work.' >/dev/null \
+    || fail "emit failed"
+  run_pf_remote "$home" consume >/dev/null || fail "consume failed"
+  FAKE_CURL_LOG="$log" run_pf_remote "$home" deliver pf-remote-delivered >/dev/null \
+    || fail "delivery failed"
+  assert_grep 'state=delivered' "$home/state/public-followup/registry/pf-remote-delivered" \
+    "delivery must retain a delivered registration"
+
+  out=$(FM_FAKE_SSH_MODE=unreachable run_pf_remote "$home" consume) \
+    || fail "a delivered registration must not require its remote route: $out"
+  [ -z "$out" ] || fail "a delivered registration must not report an unreached result: $out"
+  pass "delivered remote registrations skip offline collection routes"
+}
+
 # --force governs the unresolved-obligation refusal and nothing else. It never
 # covered the legacy-link clear before this fix and must not start to now: a link
 # still verifiably in place keeps the loop open on either setting.
@@ -3102,6 +3129,7 @@ test_prechange_registration_is_open_and_unrechainable
 test_x_request_teardown_warns_when_final_unposted
 test_secondmate_promotion_uses_teardown_parent_resolution
 test_remote_secondmate_loop_delivers_and_retires
+test_delivered_remote_registration_skips_offline_route
 test_remote_retire_force_semantics_unchanged
 test_remote_retire_refuses_reassigned_route
 test_remote_retire_refuses_unreadable_state


### PR DESCRIPTION
## Intent

Fix a fundamental gap in firstmate's public-followup EMIT path: a worker in a REMOTE secondmate home could not deliver its typed terminal-result event to the MAIN (owning) home, so a promised public follow-up sat unresolved until firstmate hand-emitted it.

SYMPTOM (reproduced twice, 2026-09-01): fmdev-f1's actionable-update fix (#3268, merged 2026-08-29) never produced a consumable event in the main home; and sshhip-h7 ran the exact fm-public-followup-emit.sh command from its brief for pf-sshhip-purchase-screentime-hint-r1 after merging sshhip #396, yet the main home's 'consume' found nothing and 'deliver' still said the loop was waiting on its bound work.

ROOT CAUSE: 'fm-public-followup.sh brief' printed an emit command carrying '--home <MAIN home absolute path>' plus this checkout's own script path. When the bound work lives in a REMOTE secondmate home on ANOTHER HOST, neither path exists there (the mini's firstmate root is ~/fm-homes/firstmate, not the main home's path), so the typed event was written nowhere the main home reads, and the promise stayed open.

WHAT WAS BUILT (accepted requirements, all of which must hold):
1. The remote-home typed event must reach the MAIN home's typed terminal-result inbox through the EXISTING remote transport - the same fm-on.sh route that already carries work to that secondmate - OR the brief must print a ROUTE-AWARE emit command for a remote work home. Chosen approach: both halves. 'brief' is now route-aware and, for a remote work home, prints that route's OWN code root and home with a new '--stage-in' flag; the worker stages the typed event in its own home's public-followup outbox. The owning home then COLLECTS staged results over the same SSH route via a new bin/fm-public-followup-collect.sh, because the fm-on.sh transport only runs outbound (main -> secondmate), so collection must be a pull; a worker on the other machine has no path back. 'consume' collects first, then reconciles a collected event identically to a local one.
2. The LOCAL-home path stays BYTE-IDENTICAL: a local work home's brief still prints '--home <this home>' and this checkout's emit script, its closing paragraph still says the home above owns the reply, and the event still lands directly in this home's typed terminal-result inbox. This is asserted behaviorally.
3. FAIL LOUDLY when the transport cannot deliver - never silently write to a nonexistent path and never drop the event. An unreachable or refusing route is named by obligation id and route id in consume's output with retained-for-reconciliation wording, and consume exits non-zero rather than reporting an empty inbox. Collection is NON-DESTRUCTIVE until the result is durably held by the owning home, so a dropped connection cannot lose a terminal result; retiring the staged copy is best effort by design, and a retained copy is only ever collected again and dropped as a duplicate. '--stage-in' also refuses a path that is not a firstmate home rather than swallowing the result, and refuses being combined with '--home' rather than resolving the ambiguity by argument order.
4. HERMETIC BEHAVIORAL REGRESSION stubbing the remote transport at its seam, matching how the existing remote cases already fake fm-on.sh/ssh - no live remote home, nothing blocking. Added cases: a typed terminal result emitted in a remote work home reaches the owning home and consume prints the loop ready; an unreachable remote work home fails loudly instead of reporting an empty inbox; a duplicate report from a remote work home stays a no-op (no second public reply, promise unchanged); a local work home's emit path is unchanged; and staging refuses an ambiguous destination and a path that is not a firstmate home.
5. ALIGNED with the retire-side fix #3479 (fm-public-followup-retire-remote-home-r1, merged as ee58e39b), which fixed the RETIRE/CLEAR side of the SAME root-cause family. This change REUSES the remote-route resolution helpers that landed with it (public_followup_route_is_remote, secondmate_registry_field) rather than introducing a second remote-home-transport abstraction, and is rebased onto current main. Scope is deliberately kept to the EMIT/brief path; the retire/clear side is NOT folded in, and one existing remote case notes that outward delivery from the work home is the retire side's concern.

DELIBERATE DECISIONS a reviewer reading only the diff would not know:
- Staging + pull was chosen over having the remote worker push to the main home because the established route transport only runs main -> secondmate; a push would have required inventing a reverse path.
- On the staging side the relay-consent and registration gates deliberately do NOT run, because the registration and the relay consent both live on the other machine; the COLLECTING home re-validates every field against its own registration and tasks-axi before accepting an event, so the authority stays where it always was. A staged event is never posted, never read as a public reply, and never consumed by the staging home's own reconciliation.
- fm-on.sh returns ssh's status unchanged, so exit 255 is treated as the established 'delivered but completion unknown' status this codebase already reconciles, distinct from a route that refused.
- Route root/home values are printed into a command line the worker runs verbatim, so they are constrained to a conservative path charset rather than trusted from the record; a remote route with no usable root/home in data/secondmates.md makes 'brief' refuse with a pointer at that record instead of emitting an unusable command.
- One unusable staged file (oversized or unreadable JSON) is reported on stderr and left in place rather than blocking every other staged result.

CONSTRAINTS the user set: this edits firstmate SHARED, TRACKED material (bin/), so firstmate-coding-guidelines applies and bin/fm-timeout-lib.sh stays the single owner of bounded execution. Bash must stay bash-3.2-safe (macOS default). Tests must be behavioral and must never assert on implementation source text. Every commit carries NO co-author trailer.

## What Changed

- Generate route-aware worker briefs that stage typed terminal results in remote secondmate homes while preserving direct local-home emission.
- Add non-destructive remote outbox collection before reconciliation, with durable handoff, duplicate safety, route validation, and loud failures for unreachable or unsafe routes.
- Document the remote collection flow and add hermetic behavioral coverage for remote delivery, failure, replay, staging validation, and unchanged local behavior.

## Risk Assessment

✅ Low: The change is well-bounded, preserves the local path, fails loudly on genuine remote collection failures, and the follow-up fixes align collection with open registrations only.

## Testing

Inspected the change, ran the focused public-followup suite and individual remote regressions, fixed two outdated test arrangements, then demonstrated the route-aware brief, Bash 3.2 staging, successful pull collection, staged-copy retirement, and fail-loud unreachable-route behavior in a reviewer-visible CLI transcript; all final targeted checks succeeded.

<details>
<summary>Evidence: Remote public-followup end-to-end and unreachable-route CLI transcript</summary>

Source: [Remote public-followup end-to-end and unreachable-route CLI transcript](https://github.com/kunchenguid/firstmate/blob/61f212e7f3b1b5c63cc0268a9644fffce01e70a3/.no-mistakes/evidence/fm/fm-public-followup-emit-remote-home-r1/remote-followup-cli-transcript.txt)

```text
=== Remote worker brief (end-user surface) ===
When this work reaches its promised terminal outcome, report it as typed data
(never as a sentence for someone to parse) by running exactly:

  /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-public-followup.ODCTky/remote-root/bin/fm-public-followup-emit.sh \
    --stage-in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-public-followup.ODCTky/evidence-remote-remote-mini-default \
    --obligation pf-evidence \
    --relation rel-code \
    --source-home secondmate:mini-default \
    --work-id work-evidence \
    --generation 1 \
    --outcome report-ready \
    --deliverable report_path=<value> \
    --outcome-text '<one bounded public-safe sentence>'

Do not post anything publicly yourself and do not look for the public thread:
the home that owes that reply is on another machine and owns it. Leave the
result exactly where the command above puts it; that home collects it over the
same route it reaches you on, and nothing here needs a path back to it.

=== Worker runs the printed route-aware command ===
$   /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-public-followup.ODCTky/remote-root/bin/fm-public-followup-emit.sh \
    --stage-in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-public-followup.ODCTky/evidence-remote-remote-mini-default \
    --obligation pf-evidence \
    --relation rel-code \
    --source-home secondmate:mini-default \
    --work-id work-evidence \
    --generation 1 \
    --outcome report-ready \
    --deliverable report_path=data/work-evidence/report.md \
    --outcome-text 'The remote lane finished its investigation.'
6192d0b6dae35f16c598c13b5ac698ab7735818ae07734b2a45d5e9a0494da6b
staged outbox entries before collection: 1

=== Owning home runs consume ===
ready pf-evidence req-evidence discord
owning-loop state: ready
staged outbox entries after collection: 0

=== Owning home consumes while route is unreachable ===
unreached pf-unreachable: the work home mini-default never answered, so its terminal result stays retained there for reconciliation
consume exit: 1
owning-loop state: pending-work
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5dfa3a7e2742e2b2dd6ae6f1122a36dd764c0bc4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (8) ✅</summary>

- 🚨 `bin/fm-public-followup.sh:362` - Required criterion 3 says an unreachable/refusing remote route must be named and consume must exit non-zero, while criterion 1 requires a route-aware brief. The new `if ! public_followup_route_is_remote ... --home` fallback conflates a local route with a missing or unreadable route. Concrete sequence: register/brief a remote obligation, stage its result, then remove or corrupt its `secondmates.md` record; collection skips it at line 500 and `consume` exits successfully with an empty inbox. If the record is unavailable before `brief`, lines 362-364 recreate the original bug by printing this machine&#39;s `--home` path. Also, paths containing `..` or `//` pass lines 368-372 but are later refused by `fm-on.sh`. Use a route resolution boundary that distinguishes local, valid remote, and unresolved/invalid remote states, and fail loudly for the latter. Because this corrects explicit route behavior required by the author, the remedy needs user review.
- 🚨 `bin/fm-public-followup-emit.sh:207` - Required criterion 3 says `--stage-in` &#34;refuses a path that is not a firstmate home.&#34; The added check accepts any ordinary directory containing a real `state/` subdirectory. For example, `/tmp/unrelated/state` passes and the event is successfully written into `/tmp/unrelated/state/public-followup/outbox`, where the owning route will never collect it. Validate the established Firstmate/secondmate identity markers—ideally matching `.fm-secondmate-home` to `--source-home`—rather than treating `state/` alone as proof. This contradicts an explicit acceptance requirement, so the behavioral remedy requires user review.

🔧 Fix: Fail loudly on unresolved routes and invalid staging homes
2 errors still open:

- 🚨 `bin/fm-public-followup.sh:355` - Any current remote record with the same secondmate id is accepted without proving it is the route used when the obligation was registered. Concrete sequence: register and brief against remote route A, let the worker stage its result in A, then reassign that id to route B; `consume` drains B, receives nothing, and exits 0 while the result remains indefinitely in A. This violates the required same-route delivery and fail-loud invariant. The earliest durable boundary is registration/route resolution: retain enough route identity to detect reassignment before briefing or collecting. Because that remedy adds durable registration state, it requires authorization.
- 🚨 `bin/fm-public-followup-collect.sh:79` - An existing but unreadable or unsafe outbox is treated like an empty one. For example, if `state/public-followup/outbox` loses search/read permission, the glob yields no readable files, `drain` exits 0, and owning `consume` reports no failure although a staged result may remain there. Distinguish an absent outbox from an existing invalid/unreadable outbox and return non-zero for the latter so the owning obligation is reported as unreached.

🔧 Fix: Fail collection when remote outbox is unreadable
1 error still open:

- 🚨 `bin/fm-public-followup.sh:355` - Remote resolution trusts any current record with the same secondmate id, without proving it is the route used when the obligation was registered. If work stages its result on route A and that id is reassigned to route B before consume, collection drains B, finds nothing, exits successfully, and leaves the result stranded on A. This violates the required same-route, fail-loud delivery invariant. Persisting and checking the registered remote route identity adds durable registration state, so the remedy requires authorization.

🔧 Fix: Surface reassigned remote routes during empty collection
2 errors still open:

- 🚨 `bin/fm-public-followup.sh:559` - Every reachable remote obligation still in `pending-work` is reported as reassigned whenever its worker has not staged a result yet. A normal sequence—register remote work, then run `consume` before completion—now prints a false retained-result claim and exits non-zero, contradicting the command&#39;s silent-empty behavior. This heuristic also misses the claimed reassignment case when `obligation_json` is unavailable because `delivery` becomes empty. Distinguishing reassignment from an ordinarily empty route requires durable route identity, which the authorized fix explicitly forbids; revert this heuristic and ask the user to choose between accepting that limitation or authorizing durable identity state.
- 🚨 `bin/fm-public-followup.sh:514` - A missing, unreadable, or corrupt `work_home` field makes the new collector silently `continue`. If a result is staged remotely and the owning registration becomes unreadable or loses that field, `consume` finds no local event and exits 0 while the result remains stranded. Validate each registration before selecting its route and report the obligation as unreached with a non-zero result when its route-bearing registration is invalid.

🔧 Fix: Fail remote collection on invalid registrations
2 errors still open:

- 🚨 `bin/fm-public-followup.sh:566` - A normal unfinished remote obligation is reported as reassigned whenever `consume` reaches its valid route before the worker stages a result: delivery is `pending-work`, the remote payload and local inbox are empty, so consume prints a false retained-result claim and exits non-zero. Empty output cannot distinguish ordinary pending work from reassignment without the durable route identity that was explicitly forbidden. Revert this pipeline-added heuristic and ask the user to choose between accepting the documented reassignment limitation or authorizing durable identity state.
- 🚨 `bin/fm-public-followup.sh:510` - The loop skips symlinked or otherwise non-regular registration entries before the new registration validation runs. If a valid remote result is staged and its local registration is replaced by a symlink, the registration presence gate remains active, collection silently skips it, and `consume` exits 0 with the result stranded remotely. Report such named registry entries as invalid and return non-zero instead of continuing silently.

🔧 Fix: Reject unsafe registration entries during remote collection
1 error still open:

- 🚨 `bin/fm-public-followup.sh:570` - A normal unfinished remote obligation is reported as reassigned whenever `consume` runs before the worker stages a result: delivery is `pending-work`, the reachable route returns an empty payload, and no local event exists, so consume falsely claims a retained result and exits non-zero. Empty output cannot distinguish this ordinary state from reassignment without the durable route identity explicitly forbidden by the authorized remedy. Revert the pipeline-added empty-response heuristic and ask whether to accept the documented rare reassignment limitation or authorize route identity state.

🔧 Fix: Restore healthy empty remote collection behavior
1 error still open:

- 🚨 `bin/fm-public-followup.sh:537` - Collection contacts the remote route for every retained remote registration, including obligations whose terminal event is already accepted or whose loop is `state=delivered`. Concrete sequence: collect and deliver a remote result, retain the delivered registration as required, then run `consume` while that secondmate is offline; consume falsely reports an unreached retained result and exits non-zero even though no result remains to deliver. Restrict remote collection to obligations still awaiting their terminal work event; because this changes user-visible collection semantics and may require consulting tasks-axi state, confirm the intended selection boundary.

🔧 Fix: Skip remote collection for delivered registrations
1 error still open:

- 🚨 `bin/fm-public-followup.sh:523` - The required delivered-state skip occurs only after full registration validation. A retained record with `state=delivered` but a missing or invalid relation/work field fails at line 516, prints `unreached`, and makes `consume` non-zero despite owing no result. This contradicts the criterion that an already-delivered registration must not produce a false unreached line. Read the existing loop state and skip delivered records before route-bearing validation; authorization is required because this is an intent-conformance finding.

🔧 Fix: Skip delivered registrations before route validation
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-public-followup.test.sh` — initial runs exposed stale test assumptions; final focused-suite rerun completed successfully</code>
- <code>`FM_TEST_ONLY=&lt;remote regression&gt; bash tests/fm-public-followup.test.sh` for remote delivery, offline delivered registrations, transport failure, unreadable outbox, invalid registration, route loss, empty collection, path safety, duplicate collection, staging refusal, and unchanged local delivery</code>
- <code>End-to-end hermetic CLI exercise: generated a remote brief, ran its printed `--stage-in` command with macOS `/bin/bash` 3.2, collected into the owning home, and verified ready state plus staged-copy retirement</code>
- `Hermetic unreachable-route exercise: ran consume against a fake unreachable SSH route and verified retained-for-reconciliation output, exit 1, and pending-work state`
- `Inspected the target diff and final worktree status; removed the transient evidence driver`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
