### PR TITLE
fix(bin): exclude secondmates from home-summary validity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,8 +377,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 16 ] || {
+            echo "::error::expected 16 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -186,6 +186,8 @@ refreshes only its parent-side remote-summary cache as an observational side eff
 validated registered-home handoff. It is local-only, skips nested secondmate
 aggregation, includes generated_epoch for freshness arithmetic, and marks
 inventory contradictions or unavailable child state invalid.
+kind=secondmate meta records are not child inventory for unowned_current or
+terminal_in_flight; they never have backlog rows.
 Its invalidity object names the normalized failure kind and affected ids.
 Actionable tasks-axi captain holds appear as decisions_open and stay visible in
 queued with hold_reason, hold_kind, hold_until, deferred_marker, and plural
@@ -720,10 +722,12 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
          | select(.requires_child_metadata)
          | select(.id as $id | [$tasks[].id] | index($id) | not) ]) as $orphan_in_flight
     | ([ $tasks[]
+         | select(.kind != "secondmate")
          | select(.id as $id | [$owned_in_flight[].id] | index($id) | not)
          | {id,state:.current_state.state} ]) as $unowned_children
     | ([ $owned_in_flight[] as $work
          | $tasks[]
+         | select(.kind != "secondmate")
          | select(.id == $work.id and (.current_state.state == "done" or .current_state.state == "failed"))
          | {id,state:.current_state.state} ]) as $terminal_in_flight
     | ([if $backlog.present != true then

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -799,8 +799,89 @@ test_parked_scout_decision_stays_pending() {
   pass "a scout still parked at a decision stays pending (terminal clear does not over-fire)"
 }
 
+# Home-summary validity treats persistent secondmates as registered homes, not
+# in-flight children. They have no backlog rows, so they must not produce
+# unowned_current or terminal_in_flight. Ordinary crew/ship metas still do.
+test_home_summary_excludes_secondmate_from_child_inventory() {
+  local home fakebin out
+  home=$(make_home summary-secondmate-only)
+  mkdir -p "$home/secondmate-home" "$home/projects/unowned" "$home/projects/terminal"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+
+## Queued
+
+## Done
+EOF
+  fm_write_meta "$home/state/mate.meta" \
+    "window=firstmate:fm-mate" \
+    "worktree=$home/secondmate-home" \
+    "project=$home/secondmate-home" \
+    "harness=codex" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "home=$home/secondmate-home" \
+    "projects=alpha"
+  printf 'working: watching delegated scope\n' > "$home/state/mate.status"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary)
+  printf '%s' "$out" | jq -e '
+    .schema == "fm-secondmate-home-summary.v1"
+      and .valid == true
+      and .reason == null
+      and .invalidity == {kind:null,ids:[]}
+      and (.invalidity.kind != "unowned_current")
+      and (.invalidity.kind != "terminal_in_flight")
+  ' >/dev/null || fail "secondmate-only home with a clean backlog must be VALID: $out"
+
+  fm_write_meta "$home/state/unowned-ship.meta" \
+    "window=firstmate:fm-unowned-ship" \
+    "worktree=$home/projects/unowned" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  record_claude_idle "$home/state" unowned-ship
+  printf 'needs-decision [key=unowned-ship]: choose a route\n' > "$home/state/unowned-ship.status"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary)
+  printf '%s' "$out" | jq -e '
+    .valid == false
+      and .invalidity == {kind:"unowned_current",ids:["unowned-ship"]}
+      and (.reason | contains("unowned-ship=parked"))
+      and (.reason | contains("mate=") | not)
+  ' >/dev/null || fail "ordinary unowned ship must still produce unowned_current without listing the secondmate: $out"
+
+  rm -f "$home/state/unowned-ship.meta" "$home/state/unowned-ship.status"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] terminal-ship - Done child still in flight (repo: alpha) (kind: ship) (since 2026-07-11)
+
+## Queued
+
+## Done
+EOF
+  fm_write_meta "$home/state/terminal-ship.meta" \
+    "window=firstmate:fm-terminal-ship" \
+    "worktree=$home/projects/terminal" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  record_claude_idle "$home/state" terminal-ship
+  printf 'done: complete\n' > "$home/state/terminal-ship.status"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary)
+  printf '%s' "$out" | jq -e '
+    .valid == false
+      and .invalidity == {kind:"terminal_in_flight",ids:["terminal-ship"]}
+      and (.reason | contains("terminal-ship=done"))
+      and (.reason | contains("mate=") | not)
+  ' >/dev/null || fail "ordinary terminal in-flight ship must still produce terminal_in_flight without listing the secondmate: $out"
+  pass "home-summary excludes kind=secondmate from unowned_current and terminal_in_flight"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
+test_home_summary_excludes_secondmate_from_child_inventory
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness
 test_event_hints_follow_reconciled_current_state

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -834,6 +834,23 @@ EOF
       and (.invalidity.kind != "terminal_in_flight")
   ' >/dev/null || fail "secondmate-only home with a clean backlog must be VALID: $out"
 
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] mate - Registered secondmate home (repo: alpha) (kind: secondmate) (since 2026-07-11)
+
+## Queued
+
+## Done
+EOF
+  printf 'done: delegated scope complete\n' > "$home/state/mate.status"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary)
+  printf '%s' "$out" | jq -e '
+    .valid == true
+      and .reason == null
+      and .invalidity == {kind:null,ids:[]}
+      and (.invalidity.kind != "terminal_in_flight")
+  ' >/dev/null || fail "terminal secondmate with a matching in-flight row must not produce terminal_in_flight: $out"
+
   fm_write_meta "$home/state/unowned-ship.meta" \
     "window=firstmate:fm-unowned-ship" \
     "worktree=$home/projects/unowned" \


### PR DESCRIPTION
## Intent

Fix a home-summary ledger validity bug in bin/fm-fleet-snapshot.sh: it builds unowned_children from every state/*.meta record including kind=secondmate ones. Secondmates never have backlog rows by contract (AGENTS.md section 10), so once earlier invalidity kinds are cleared the main home ledger wrongly reports unowned_current listing all registered secondmates.

Exclude kind=secondmate meta records from unowned_children AND from terminal_in_flight in the home-summary validity computation. Keep this the specified one-line-class classifier exclusion; keep it minimal.

Acceptance / regression:
- kind=secondmate meta records are excluded from unowned_children and from terminal_in_flight.
- Behavioral regression exercising the real executable path: a home whose only meta records are kind=secondmate, with a clean backlog, computes as VALID (no unowned_current and no terminal_in_flight arising from secondmate records).
- Non-secondmate records are still counted exactly as before: ordinary crew/ship metas continue to contribute to unowned_children/terminal_in_flight unchanged.

Constraints: bash-3.2-safe (macOS default). Tests must be behavioral (assert observable ledger output via the real snapshot path, never source-text matching). Author every commit with no co-author / Co-Authored-By trailer.

## What Changed
- Exclude `kind=secondmate` metadata from `unowned_current` and `terminal_in_flight` home-summary validity checks while preserving checks for ordinary crew and ship records.
- Document the secondmate inventory exception and add behavioral regression coverage through the snapshot executable.

## Risk Assessment

✅ Low: The change is narrowly scoped, excludes secondmates at both required validity classifiers, preserves ordinary worker behavior, and adds behavioral regression coverage through the executable path.

## Testing

Inspected the focused change and commit metadata, passed the targeted snapshot/view behavioral suite under both Bash 5 and macOS Bash 3.2, and captured real executable output proving secondmates are excluded while ordinary ship invalidities remain unchanged.

<details>
<summary>Evidence: Home-summary ledger behavior for secondmate and ordinary ship scenarios</summary>

Source: [Home-summary ledger behavior for secondmate and ordinary ship scenarios](https://github.com/kunchenguid/firstmate/blob/270c6ce3fd62b870c3e96151a2ee3085c53cdcc8/.no-mistakes/evidence/fm/fm-home-summary-secondmate-unowned-r1/home-summary-ledger-behavior.json)

```text
{
  "evidence_contract": "Observable output from bin/fm-fleet-snapshot.sh --secondmate-home-summary",
  "scenarios": {
    "secondmate_only_clean_backlog": {
      "schema": "fm-secondmate-home-summary.v1",
      "generated": "2026-09-02T06:48:00Z",
      "generated_epoch": 1788331680,
      "home": "~/.no-mistakes/evidence/01M1GDQZTMD8MV4H6MA6YN9Q29/home-summary-fixture.8zLvAV",
      "valid": true,
      "reason": null,
      "invalidity": {
        "kind": null,
        "ids": []
      },
      "state": "no_active_work",
      "active_children": [],
      "decisions_open": [],
      "holds": [],
      "queued": [],
      "landed": [],
      "endpoints": [
        {
          "id": "mate",
          "state": "working",
          "source": "status-log",
          "endpoint": {
            "target": "firstmate:fm-mate",
            "exists": true,
            "agent_alive": "alive",
            "status": "alive",
            "observed_at": "2026-09-02T06:48:00Z",
            "freshness": "fresh"
          }
        }
      ],
      "counts": {
        "active_children": 0,
        "decisions_open": 0,
        "holds": 0,
        "queued": 0,
        "landed": 0,
        "endpoints": 1
      },
      "omitted": []
    },
    "terminal_secondmate_in_flight": {
      "schema": "fm-secondmate-home-summary.v1",
      "generated": "2026-09-02T06:48:00Z",
      "generated_epoch": 1788331680,
      "home": "~/.no-mistakes/evidence/01M1GDQZTMD8MV4H6MA6YN9Q29/home-summary-fixture.8zLvAV",
      "valid": true,
      "reason": null,
      "invalidity": {
        "kind": null,
        "ids": []
      },
      "state": "no_active_work",
      "active_children": [],
      "decisions_open": [],
      "holds": [],
      "queued": [],
      "landed": [],
      "endpoints": [
        {
          "id": "mate",
          "state": "done",
          "source": "status-log",
          "endpoint": {
            "target": "firstmate:fm-mate",
            "exists": true,
            "agent_alive": "alive",
            "status": "alive",
            "observed_at": "2026-09-02T06:48:00Z",
            "freshness": "fresh"
          }
        }
      ],
      "counts": {
        "active_children": 0,
        "decisions_open": 0,
        "holds": 0,
        "queued": 0,
        "landed": 0,
        "endpoints": 1
      },
      "omitted": []
    },
    "ordinary_unowned_ship": {
      "schema": "fm-secondmate-home-summary.v1",
      "generated": "2026-09-02T06:48:01Z",
      "generated_epoch": 1788331681,
      "home": "~/.no-mistakes/evidence/01M1GDQZTMD8MV4H6MA6YN9Q29/home-summary-fixture.8zLvAV",
      "valid": false,
      "reason": "live child state has no in-flight backlog item: unowned-ship=parked",
      "invalidity": {
        "kind": "unowned_current",
        "ids": [
          "unowned-ship"
        ]
      },
      "state": "captain_decision",
      "active_children": [],
      "decisions_open": [
        {
          "id": "unowned-ship",
          "key": "unowned-ship",
          "verb": "needs-decision",
          "summary": "choose a route",
          "reason": null,
          "source": "status"
        }
      ],
      "holds": [],
      "queued": [],
      "landed": [],
      "endpoints": [
        {
          "id": "mate",
          "state": "done",
          "source": "status-log",
          "endpoint": {
            "target": "firstmate:fm-mate",
            "exists": true,
            "agent_alive": "alive",
            "status": "alive",
            "observed_at": "2026-09-02T06:48:01Z",
            "freshness": "fresh"
          }
        },
        {
          "id": "unowned-ship",
          "state": "parked",
          "source": "status-log",
          "endpoint": {
            "target": "firstmate:fm-unowned-ship",
            "exists": true,
            "agent_alive": "not_checked",
            "status": "unknown",
            "observed_at": "2026-09-02T06:48:01Z",
            "freshness": "fresh"
          }
        }
      ],
      "counts": {
        "active_children": 0,
        "decisions_open": 1,
        "holds": 0,
        "queued": 0,
        "landed": 0,
        "endpoints": 2
      },
      "omitted": []
    },
    "ordinary_terminal_ship": {
      "schema": "fm-secondmate-home-summary.v1",
      "generated": "2026-09-02T06:48:01Z",
      "generated_epoch": 1788331681,
      "home": "~/.no-mistakes/evidence/01M1GDQZTMD8MV4H6MA6YN9Q29/home-summary-fixture.8zLvAV",
      "valid": false,
      "reason": "in-flight backlog item has terminal child state: terminal-ship=done",
      "invalidity": {
        "kind": "terminal_in_flight",
        "ids": [
          "terminal-ship"
        ]
      },
      "state": "no_active_work",
      "active_children": [],
      "decisions_open": [],
      "holds": [],
      "queued": [],
      "landed": [],
      "endpoints": [
        {
          "id": "mate",
          "state": "done",
          "source": "status-log",
          "endpoint": {
            "target": "firstmate:fm-mate",
            "exists": true,
            "agent_alive": "alive",
            "status": "alive",
            "observed_at": "2026-09-02T06:48:01Z",
            "freshness": "fresh"
          }
        },
        {
          "id": "terminal-ship",
          "state": "done",
          "source": "status-log",
          "endpoint": {
            "target": "firstmate:fm-terminal-ship",
            "exists": true,
            "agent_alive": "not_checked",
            "status": "unknown",
            "observed_at": "2026-09-02T06:48:01Z",
            "freshness": "fresh"
          }
        }
      ],
      "counts": {
        "active_children": 0,
        "decisions_open": 0,
        "holds": 0,
        "queued": 0,
        "landed": 0,
        "endpoints": 2
      },
      "omitted": []
    }
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a6955c77c110e0278b5fb3d91aef0cf391ab848e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-fleet-snapshot-view.test.sh:825` - The secondmate remains `working` throughout the test, so deleting the new terminal-in-flight filter at bin/fm-fleet-snapshot.sh:730 would not fail this regression. Exercise a terminal-state secondmate through the executable path with a matching in-flight row to verify the separately required `terminal_in_flight` exclusion.

🔧 Fix: Cover terminal secondmate in-flight exclusion
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-fleet-snapshot-view.test.sh`
- <code>`/bin/bash tests/fm-fleet-snapshot-view.test.sh` using macOS Bash 3.2.57</code>
- <code>Executed `bin/fm-fleet-snapshot.sh --secondmate-home-summary` against secondmate-only, terminal-secondmate, ordinary-unowned-ship, and ordinary-terminal-ship fixtures and captured the JSON ledger outputs</code>
- <code>`git log -1 --format=&#39;%H%n%an &lt;%ae&gt;%n%B&#39; b778db86346c2e6b03e6606606b3a176c50da5d8` confirmed no co-author trailer</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
