### PR TITLE
fix(bearings): keep active children underway during captain holds

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -138,9 +138,10 @@ Rules that keep the contract unambiguous:
 - Every section ALWAYS renders, even when empty, with its short empty-state sentence; never omit a section.
 - Every chat digest and file-mode report is a complete current snapshot, never a delta against a prior report.
 - Recently Landed always renders the bounded current baseline, even when the same completions appeared in an earlier report.
-- The four buckets are mutually exclusive, so every item is forced into exactly one: needs-your-action is Captain's Call, done is Recently Landed, self-progressing is Underway, and not-yet-started work or an action-free fleet-integrity warning is Charted Next.
+- The four buckets are mutually exclusive per item: needs-your-action is Captain's Call, done is Recently Landed, self-progressing is Underway, and not-yet-started work or an action-free fleet-integrity warning is Charted Next.
+- A secondmate home can contribute to more than one section at once. Each active child is an Underway row regardless of the home-level `bearings_state`, while that same home's due captain hold is Captain's Call and its queued or external holds stay Charted Next. Do not hide active children because the home also has an open captain hold.
 - The strict boundary keeps action-free items OUT of Captain's Call: a working or validating task, a queued item blocked on another task or a date, landed work, a completed scout's report pointer, a declared `paused:` external wait, and a bare recorded PR with no merge-ready signal each belong to one of the other three sections, never Captain's Call.
-- A secondmate's own row appears Underway only for `active_child_work`; `externally_held` belongs in Charted Next, and `unknown` belongs there as an unavailable-state gate unless its reason requires the captain's action.
+- A secondmate's own home-level row is not an Underway unit: `externally_held` belongs in Charted Next, and `unknown` belongs there as an unavailable-state gate unless its reason requires the captain's action.
 - Do not suppress separately projected decisions, landed records, or gates from a `partial-structured` home merely because that secondmate's own row is `unknown` or its `invalidity` reports an inventory mismatch.
 - Include the required direct address to the captain inside one item or empty-state sentence.
 - Every PR appears as the full `https://...` URL; a shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same digest.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,8 +385,8 @@ jobs:
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 44 ] || {
-            echo "::error::expected 44 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 45 ] || {
+            echo "::error::expected 45 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -120,7 +120,7 @@ Default collection performs bounded concurrent remote-ledger reads for registere
 remote homes under one shared snapshot budget and may refresh the parent-side cache.
 --include-prs additionally performs live GitHub discovery and checks.
 
-Default fields: schema, home, generated, prs, in_flight{id,kind,state,doing},
+Default fields: schema, home, generated, prs, in_flight{id,kind,state,repo,doing},
   secondmates{id,state,doing,provenance,freshness,age_seconds,contradiction,reason},
   secondmate_reconcile{id,spawn_gen,host,kind,ids},
   decisions_open{id,key,verb,summary,owner}, landed{id,what,artifact,owner},
@@ -397,6 +397,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
        | select(.backlog.current_role != "held" or .current_state.state == "working")
        | {id, kind,
         state: .current_state.state,
+        repo:(.backlog.repo // null),
         doing: ((.current_state.detail // "") as $d
                 | (if $d != "" then $d else (.hints.last_event_text // "") end) | trunc(90))
       } ]
@@ -405,6 +406,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
          | {id:($m.id + "/" + .id),
             kind:(.kind // "secondmate"),
             state:(.state // "working"),
+            repo:(.repo // null),
             doing:((.doing // .state) | trunc(90))} ]) as $in_flight_all
   | ([ .backlog.records[]
          | select(.structured and .captain_actionable == true)
@@ -499,6 +501,9 @@ MODEL=$(printf '%s' "$SNAP" | jq \
         ((($snap.main_inventory.unstructured_current_count // 0)) as $n
          | if $n > 0 then {surface:("main unstructured current backlog row(s): \($n)"), reveal:"inspect main data/backlog.md In flight and Queued free-form rows"} else empty end),
         (if $all_in_flight == 0 and ($in_flight_all | length) > $in_flight_n then {surface:("in_flight showing \($in_flight_n) of \($in_flight_all | length)"), reveal:"--all-in-flight"} else empty end),
+        (($snap.secondmate_current.records // [])[] as $m
+         | ([($m.omitted // [])[] | select(.surface == "active_children") | .count] | add // 0) as $n
+         | if $n > 0 then {surface:("secondmate " + $m.id + " active children omitted by snapshot bound: \($n)"), reveal:"raise FM_SNAPSHOT_SECONDMATE_CHILDREN"} else empty end),
         (if $all_secondmates == 0 and ($secondmates_all | length) > $secondmates_n then {surface:("secondmates showing \($secondmates_n) of \($secondmates_all | length)"), reveal:"--all-secondmates"} else empty end),
         (if (($snap.secondmate_current.truncated // 0) > 0) then {surface:("registered secondmates omitted by snapshot bound: \($snap.secondmate_current.truncated)"), reveal:"raise FM_SNAPSHOT_SECONDMATES"} else empty end),
         (if $snap.secondmate_current.registry.input_truncated == true then {surface:"secondmate registry input truncated by bounded read", reveal:"raise FM_SNAPSHOT_REGISTRY_LINES or FM_SNAPSHOT_REGISTRY_BYTES"} else empty end),

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -29,6 +29,11 @@
 # gate with its date; a row the canonical snapshot marks prose-deferred
 # (deferred_marker) leaves the default decisions and gates views and is
 # disclosed in omitted[], revealed by --all-decisions / --all-queued.
+# Underway (in_flight) projects every main live worker plus every active child
+# from every readable secondmate ledger, independently of that home's
+# bearings_state. A home classified captain_decision because it has an open
+# captain hold still contributes each working child as its own Underway row;
+# the home row on secondmates[] keeps the decision and gate classification.
 #
 # Main-home inventory validity comes from the canonical snapshot's main_inventory
 # object (orphan structured in-flight without meta, unstructured current rows).
@@ -395,10 +400,12 @@ MODEL=$(printf '%s' "$SNAP" | jq \
         doing: ((.current_state.detail // "") as $d
                 | (if $d != "" then $d else (.hints.last_event_text // "") end) | trunc(90))
       } ]
-     + [ $secondmate_views[]
-         | select(.bearings_state == "active_child_work")
-         | {id,kind:"secondmate",state:.bearings_state,
-            doing:([.active_children[] | .id + ": " + (.doing // .state)] | join("; ") | trunc(90))} ]) as $in_flight_all
+     + [ $secondmate_views[] as $m
+         | $m.active_children[]?
+         | {id:($m.id + "/" + .id),
+            kind:(.kind // "secondmate"),
+            state:(.state // "working"),
+            doing:((.doing // .state) | trunc(90))} ]) as $in_flight_all
   | ([ .backlog.records[]
          | select(.structured and .captain_actionable == true)
          | select(($all_decisions == 1) or (.deferred_marker != true))

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -397,7 +397,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
        | select(.backlog.current_role != "held" or .current_state.state == "working")
        | {id, kind,
         state: .current_state.state,
-        repo:(.backlog.repo // null),
+        repo:(.backlog.repo // .project // null),
         doing: ((.current_state.detail // "") as $d
                 | (if $d != "" then $d else (.hints.last_event_text // "") end) | trunc(90))
       } ]

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -751,7 +751,7 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
          | $tasks[]
          | select(.id == $work.id and .current_state.state == "working")
          | {id,kind,state:.current_state.state,
-            repo:(($work.repo // null) | if . == null then null else trunc(120) end),
+            repo:(($work.repo // .project // null) | if . == null then null else trunc(120) end),
             source:.current_state.source,
             doing:((.current_state.detail // "") | trunc(120))} ]) as $active_all
     | ($captain_holds_all

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -750,7 +750,9 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
          | select($work.current_role != "program")
          | $tasks[]
          | select(.id == $work.id and .current_state.state == "working")
-         | {id,kind,state:.current_state.state,source:.current_state.source,
+         | {id,kind,state:.current_state.state,
+            repo:(($work.repo // null) | if . == null then null else trunc(120) end),
+            source:.current_state.source,
             doing:((.current_state.detail // "") | trunc(120))} ]) as $active_all
     | ($captain_holds_all
        + ([ $tasks[] as $t | ($t.hints.open_decisions // [])[]

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -1010,8 +1010,11 @@ EOF
 }
 
 test_default_is_bounded_and_local_only() {
-  local home fakebin toon json
+  local home fakebin toon json backlog
   home=$(make_home bounded); write_fixture "$home"
+  backlog="$home/data/backlog.md"
+  awk '{if ($0 ~ /^- \[ \] ship-task /) sub(/ \(repo: firstmate\)/, ""); print}' \
+    "$backlog" > "$backlog.tmp" && mv "$backlog.tmp" "$backlog"
   fakebin=$(make_fakebin "$home"); : > "$home/net.log"
   toon=$(run "$home" "$fakebin")
   json=$(run "$home" "$fakebin" --json)
@@ -1744,11 +1747,12 @@ EOF
   pass "counterfactual meta clears main inventory warning and projects the live task"
 }
 
-seed_working_child() {  # <mate-home> <id> <doing>
-  local mate=$1 id=$2 doing=$3
+seed_working_child() {  # <mate-home> <id> <doing> [repo]
+  local mate=$1 id=$2 doing=$3 repo=${4-sample} repo_field=
   mkdir -p "$mate/projects/$id"
-  printf -- '- [ ] %s - %s (repo: sample) (kind: ship) (since 2026-07-13)\n' \
-    "$id" "$doing" >> "$mate/data/backlog.md"
+  [ -z "$repo" ] || repo_field=" (repo: $repo)"
+  printf -- '- [ ] %s - %s%s (kind: ship) (since 2026-07-13)\n' \
+    "$id" "$doing" "$repo_field" >> "$mate/data/backlog.md"
   fm_write_meta "$mate/state/$id.meta" \
     "window=firstmate:fm-$id" "worktree=$mate/projects/$id" "project=sample" \
     "harness=claude" "kind=ship" "mode=no-mistakes"
@@ -1768,7 +1772,7 @@ test_active_children_project_independent_of_home_captain_hold() {
   cat > "$mate/data/backlog.md" <<'EOF'
 ## In flight
 EOF
-  seed_working_child "$mate" child-a "first live child"
+  seed_working_child "$mate" child-a "first live child" ""
   seed_working_child "$mate" child-b "second live child"
   cat >> "$mate/data/backlog.md" <<'EOF'
 

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -684,9 +684,11 @@ test_secondmate_and_child_bounds_are_disclosed() {
     run "$home" "$fakebin" --json)
   printf '%s' "$json" | jq -e '
     (.secondmates | length) == 1
+      and ([.in_flight[].id] | sort) == ["a/child-1", "a/child-2"]
+      and ([.omitted[].surface] | any(test("secondmate a active children omitted by snapshot bound: 1")))
       and ([.omitted[].surface] | any(test("secondmates showing 1 of 2")))
       and ([.omitted[].surface] | any(test("registered secondmates omitted by snapshot bound: 1")))
-  ' >/dev/null || fail "bearings secondmate bound was not disclosed: $json"
+  ' >/dev/null || fail "bearings secondmate or child bound was not disclosed: $json"
   expanded=$(FM_SNAPSHOT_SECONDMATE_CHILDREN=2 FM_BEARINGS_SECONDMATES=1 \
     run "$home" "$fakebin" --json --all-secondmates)
   printf '%s' "$expanded" | jq -e '
@@ -1024,7 +1026,10 @@ test_default_is_bounded_and_local_only() {
   assert_contains "$toon" 'prs: "not_requested' "default must state PR checks were not requested"
   assert_contains "$toon" "live PR discovery + checks,\"--include-prs\"" "omitted must mark the dropped live-PR surface"
   # Valid JSON, correct schema.
-  printf '%s' "$json" | jq -e '.schema == "fm-bearings.v1"' >/dev/null || fail "json schema wrong"
+  printf '%s' "$json" | jq -e '
+    .schema == "fm-bearings.v1"
+      and (.in_flight | any(.id == "ship-task" and .repo == "firstmate"))
+  ' >/dev/null || fail "json schema or main Underway repository wrong: $json"
   pass "default output is bounded, local-only, and marks omitted surfaces"
 }
 
@@ -1776,6 +1781,7 @@ EOF
   printf '%s' "$json" | jq -e '
     ([.in_flight[].id] | sort) == ["busy-hold/child-a", "busy-hold/child-b"]
       and ([.in_flight[].state] | unique) == ["working"]
+      and ([.in_flight[].repo] | unique) == ["sample"]
       and ([.in_flight[] | select(.id == "busy-hold")] | length) == 0
       and ([.decisions_open[] | select(.id == "busy-hold/release-call"
         and .verb == "captain-hold")] | length) == 1

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -1739,6 +1739,86 @@ EOF
   pass "counterfactual meta clears main inventory warning and projects the live task"
 }
 
+seed_working_child() {  # <mate-home> <id> <doing>
+  local mate=$1 id=$2 doing=$3
+  mkdir -p "$mate/projects/$id"
+  printf -- '- [ ] %s - %s (repo: sample) (kind: ship) (since 2026-07-13)\n' \
+    "$id" "$doing" >> "$mate/data/backlog.md"
+  fm_write_meta "$mate/state/$id.meta" \
+    "window=firstmate:fm-$id" "worktree=$mate/projects/$id" "project=sample" \
+    "harness=claude" "kind=ship" "mode=no-mistakes"
+  record_claude_state "$mate/state" "$id" busy
+  printf 'working: %s\n' "$doing" > "$mate/state/$id.status"
+}
+
+test_active_children_project_independent_of_home_captain_hold() {
+  local home mate fakebin json
+  home=$(make_home underway-hold-parent)
+  : > "$home/data/secondmates.md"
+  mate="$TMP_ROOT/underway-hold-home"
+  make_valid_secondmate_home busy-hold "$mate"
+  append_secondmate_registry "$home" busy-hold "$mate"
+  fakebin=$(make_fakebin "$home")
+
+  cat > "$mate/data/backlog.md" <<'EOF'
+## In flight
+EOF
+  seed_working_child "$mate" child-a "first live child"
+  seed_working_child "$mate" child-b "second live child"
+  cat >> "$mate/data/backlog.md" <<'EOF'
+
+## Queued
+- [ ] release-call - Choose release route (repo: sample) (kind: captain) (hold: pick route A or B) (hold-kind: captain)
+
+## Done
+EOF
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    ([.in_flight[].id] | sort) == ["busy-hold/child-a", "busy-hold/child-b"]
+      and ([.in_flight[].state] | unique) == ["working"]
+      and ([.in_flight[] | select(.id == "busy-hold")] | length) == 0
+      and ([.decisions_open[] | select(.id == "busy-hold/release-call"
+        and .verb == "captain-hold")] | length) == 1
+      and (.secondmates | any(.id == "busy-hold" and .state == "captain_decision"))
+  ' >/dev/null || fail "a captain hold hid active children from Underway: $json"
+
+  cat > "$mate/data/backlog.md" <<'EOF'
+## In flight
+
+## Queued
+- [ ] release-call - Choose release route (repo: sample) (kind: captain) (hold: pick route A or B) (hold-kind: captain)
+
+## Done
+EOF
+  rm -f "$mate/state/child-a.meta" "$mate/state/child-a.status" \
+    "$mate/state/child-b.meta" "$mate/state/child-b.status"
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    ([.in_flight[] | select(.id | startswith("busy-hold/"))] | length) == 0
+      and ([.decisions_open[] | select(.id == "busy-hold/release-call")] | length) == 1
+      and (.secondmates | any(.id == "busy-hold" and .state == "captain_decision"))
+  ' >/dev/null || fail "a hold-only home invented Underway rows: $json"
+
+  cat > "$mate/data/backlog.md" <<'EOF'
+## In flight
+EOF
+  seed_working_child "$mate" child-a "first live child"
+  seed_working_child "$mate" child-b "second live child"
+  cat >> "$mate/data/backlog.md" <<'EOF'
+
+## Queued
+
+## Done
+EOF
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    ([.in_flight[].id] | sort) == ["busy-hold/child-a", "busy-hold/child-b"]
+      and ([.decisions_open[] | select(.owner == "busy-hold")] | length) == 0
+      and (.secondmates | any(.id == "busy-hold" and .state == "active_child_work"))
+  ' >/dev/null || fail "active-children-only Underway projection changed: $json"
+  pass "active children reach Underway independently of a home captain hold"
+}
+
 test_mixed_secondmate_roles_partial_state_and_captain_readiness() {
   local home fakebin hibit wheel sshhip ha canonical json
   home=$(make_home mixed-domain-regressions)
@@ -1862,7 +1942,7 @@ EOF
   ' >/dev/null || fail "canonical mixed-domain classification was wrong: $canonical"
   json=$(run "$home" "$fakebin" --json --fields bodies --all-landed)
   printf '%s' "$json" | jq -e '
-    ([.in_flight[].id] | sort) == ["hibit", "home-assistant", "wheel"]
+    ([.in_flight[].id] | sort) == ["hibit/hibit-worker", "home-assistant/prep", "wheel/wheel-worker"]
       and (.decisions_open | any(.id == "sshhip/reviewer-decision"))
       and (.decisions_open | any(.id == "home-assistant/captain-run") | not)
       and (.gates | any(.id == "production-observation" and .owner == "wheel"
@@ -2223,6 +2303,7 @@ test_captains_call_anti_leak
 test_main_orphan_in_flight_is_disclosed_not_invented
 test_main_unstructured_current_is_disclosed_with_structured_sibling
 test_main_orphan_counterfactual_meta_clears_inventory_warning
+test_active_children_project_independent_of_home_captain_hold
 test_mixed_secondmate_roles_partial_state_and_captain_readiness
 test_main_captain_readiness_matches_secondmate_projection
 test_completed_scout_report_not_pending


### PR DESCRIPTION
## Intent

Project every active child from every readable secondmate home ledger into Bearings in_flight/Underway independently of that home's bearings_state, so an open captain hold no longer drops live children from Underway. Keep the home-level row for decisions and gates: a home with an open captain hold and two active children must yield two Underway rows plus its decision in Captain's Call; a hold-only home still shows the decision and no Underway rows; a children-only home still shows those Underway rows. Update the bearings skill contract if it still describes the old home-state precedence that hid children. Keep the change bash-3.2-safe. Cover it with a behavioral regression through the real snapshot path that asserts observable board output, never implementation-source matching. The stock macOS Bash CI job must expect 45 Bearings tests (the new regression plus the prior 44). Behavior portable serial 1 already passed on the first CI run of this PR; a later cancelled serial-1 check was a provider cancellation, not a failed assertion against the old Underway precedence.

## What Changed
- Project each active secondmate child as its own Underway row regardless of the home-level Bearings state, while preserving home decisions and gates.
- Carry repository metadata into in-flight rows and disclose active children omitted by snapshot bounds.
- Update the Bearings contract and behavioral regression coverage, including the macOS Bash CI expectation of 45 tests.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves bounded-output disclosures and repository metadata, updates the skill contract, and adds an end-to-end regression through the real snapshot path.

## Testing

Executed the targeted Bearings suite under stock macOS Bash 3.2 and confirmed its expected 45 tests, then captured and validated real snapshot output showing a captain-held home simultaneously contributing its decision to Captain's Call and both active children to Underway; the worktree remained clean.

<details>
<summary>Evidence: Bearings snapshot: captain hold with two active children</summary>

Source: [Bearings snapshot: captain hold with two active children](https://github.com/kunchenguid/firstmate/blob/a40646f99fc3e6b6a30c5b6ceb9f042955ee0583/.no-mistakes/evidence/fm/fm-bearings-underway-precedence-r1/bearings-hold-with-active-children.json)

```text
{
  "schema": "fm-bearings.v1",
  "home": "fm-bearings.aKKuiY/underway-hold-parent",
  "generated": "2026-07-11T18:00:00Z",
  "prs": "not_requested (run: /bearings include PRs)",
  "in_flight": [
    {
      "id": "busy-hold/child-a",
      "kind": "ship",
      "state": "working",
      "repo": "sample",
      "doing": "harness busy (claude-hook)"
    },
    {
      "id": "busy-hold/child-b",
      "kind": "ship",
      "state": "working",
      "repo": "sample",
      "doing": "harness busy (claude-hook)"
    }
  ],
  "secondmates": [
    {
      "id": "busy-hold",
      "state": "captain_decision",
      "doing": "Choose release route",
      "provenance": "structured-home",
      "freshness": "fresh",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "-"
    }
  ],
  "secondmate_reconcile": [
    {
      "id": "busy-hold",
      "spawn_gen": null,
      "host": null,
      "kind": null,
      "ids": []
    }
  ],
  "decisions_open": [
    {
      "id": "busy-hold/release-call",
      "key": "release-call",
      "verb": "captain-hold",
      "summary": "Choose release route: pick route A or B",
      "owner": "busy-hold"
    }
  ],
  "landed": [],
  "gates": [],
  "reports": [],
  "recorded_prs": [],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded or prose-deferred queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9e1f8bd9aa1b31cdee7bd62380eb383108cd2e64","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`/bin/bash tests/fm-bearings-snapshot.test.sh` with an exact assertion that 45 `ok -` results were emitted</code>
- <code>Focused execution of `test_active_children_project_independent_of_home_captain_hold` through the real snapshot path under `/bin/bash` 3.2</code>
- <code>`jq` validation of the captured `fm-bearings.v1` output for two Underway children, one Captain&#39;s Call decision, and the home-level `captain_decision` state</code>
- <code>`git status --short` after cleanup to confirm no transient worktree artifacts remained</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
