### PR TITLE
fix(bin): self-heal outcome indexes on first drain

### DIFF
--- a/bin/fm-branch-outcome.sh
+++ b/bin/fm-branch-outcome.sh
@@ -44,6 +44,9 @@
 #     before append and published only after the cache update; processed-init
 #     rebuilds every cache before publishing it, so interruption or upgrade
 #     fails closed without making each drain scan lifetime history.
+#     Main-actor drain calls processed-init under the outcome lock when that
+#     ready marker is absent or invalid, on every harness; only a genuine store
+#     fault keeps the lost-wake backstop skipped.
 #   - Every mutation runs under $STATE/.branch-outcomes.lock so the branch
 #     extension and a concurrent session-start replay cannot interleave.
 #   - The store is written BEFORE the outcome is delivered to main
@@ -65,10 +68,12 @@
 #     Advance the processed marker after main acknowledged the captain rows
 #     through <seq>; the target itself must be a currently unprocessed captain
 #     row at or below the read cursor.
-#   fm-branch-outcome.sh processed-init
+#   fm-branch-outcome.sh processed-init [--held-lock]
 #     Rebuild the bounded per-task outcome indexes, then create the processed
 #     marker at the current read cursor when it does not exist yet; validate a
-#     present marker without changing it.
+#     present marker without changing it. --held-lock is only for a caller that
+#     already holds $STATE/.branch-outcomes.lock (fm-wake-drain.sh); it skips
+#     the nested acquire so drain's bounded lock wait remains the deadline.
 #   fm-branch-outcome.sh list [--recent <n>]
 #     Print the last n records (default 20), read or not.
 #   fm-branch-outcome.sh startup-replay
@@ -97,7 +102,7 @@ OUTCOME_INDEX_MAX_BYTES=512
 OUTCOME_INDEX_READY="$STATE/.branch-outcome-index-ready"
 
 usage() {
-  echo "usage: fm-branch-outcome.sh append --task <id> --verdict routine|captain --summary <text> [--wake <text>] [--silent true|false] | unread | mark-read --through <seq> | unprocessed | mark-processed --through <seq> | processed-init | list [--recent <n>] | startup-replay" >&2
+  echo "usage: fm-branch-outcome.sh append --task <id> --verdict routine|captain --summary <text> [--wake <text>] [--silent true|false] | unread | mark-read --through <seq> | unprocessed | mark-processed --through <seq> | processed-init [--held-lock] | list [--recent <n>] | startup-replay" >&2
   exit 2
 }
 
@@ -344,6 +349,38 @@ print_unprocessed() {
     'select(.verdict == "captain" and .seq > $processed and .seq <= $cursor)' "$STORE"
 }
 
+# Assumes $LOCK is already held. Callers that do not already hold it use the
+# processed-init command, which acquires and releases around this body.
+processed_init_locked() {
+  local store_last cursor_seq processed_seq
+  if ! store_last=$(last_seq); then
+    echo "error: refusing processed initialization because the outcome store is malformed or non-sequential" >&2
+    return 1
+  fi
+  if ! cursor_seq=$(read_cursor); then
+    return 1
+  fi
+  if [ "$cursor_seq" -gt "$store_last" ]; then
+    echo "error: refusing processed initialization because the outcome cursor is ahead of the store" >&2
+    return 1
+  fi
+  if [ -e "$PROCESSED" ]; then
+    if ! processed_seq=$(read_processed); then
+      return 1
+    fi
+    if [ "$processed_seq" -gt "$cursor_seq" ]; then
+      echo "error: refusing processed initialization because the processed marker is ahead of the read cursor" >&2
+      return 1
+    fi
+  else
+    write_processed "$cursor_seq"
+  fi
+  if ! rebuild_outcome_indexes; then
+    echo "error: outcome index migration could not be completed safely" >&2
+    return 1
+  fi
+}
+
 CMD=${1:-}
 shift 2>/dev/null || true
 
@@ -489,41 +526,24 @@ case "$CMD" in
     fm_lock_release "$LOCK"
     ;;
   processed-init)
+    HELD_LOCK=0
+    if [ "${1:-}" = --held-lock ]; then
+      HELD_LOCK=1
+      shift
+    fi
     [ "$#" -eq 0 ] || usage
-    fm_lock_acquire_wait "$LOCK"
-    if ! LAST_SEQ=$(last_seq); then
-      fm_lock_release "$LOCK"
-      echo "error: refusing processed initialization because the outcome store is malformed or non-sequential" >&2
-      exit 1
+    if [ "$HELD_LOCK" -eq 0 ]; then
+      fm_lock_acquire_wait "$LOCK"
     fi
-    if ! CURSOR_SEQ=$(read_cursor); then
-      fm_lock_release "$LOCK"
-      exit 1
-    fi
-    if [ "$CURSOR_SEQ" -gt "$LAST_SEQ" ]; then
-      fm_lock_release "$LOCK"
-      echo "error: refusing processed initialization because the outcome cursor is ahead of the store" >&2
-      exit 1
-    fi
-    if [ -e "$PROCESSED" ]; then
-      if ! PROCESSED_SEQ=$(read_processed); then
+    if ! processed_init_locked; then
+      if [ "$HELD_LOCK" -eq 0 ]; then
         fm_lock_release "$LOCK"
-        exit 1
       fi
-      if [ "$PROCESSED_SEQ" -gt "$CURSOR_SEQ" ]; then
-        fm_lock_release "$LOCK"
-        echo "error: refusing processed initialization because the processed marker is ahead of the read cursor" >&2
-        exit 1
-      fi
-    else
-      write_processed "$CURSOR_SEQ"
-    fi
-    if ! rebuild_outcome_indexes; then
-      fm_lock_release "$LOCK"
-      echo "error: outcome index migration could not be completed safely" >&2
       exit 1
     fi
-    fm_lock_release "$LOCK"
+    if [ "$HELD_LOCK" -eq 0 ]; then
+      fm_lock_release "$LOCK"
+    fi
     ;;
   list)
     RECENT=20

--- a/bin/fm-branch-outcome.sh
+++ b/bin/fm-branch-outcome.sh
@@ -71,10 +71,10 @@
 #   fm-branch-outcome.sh processed-init [--held-lock]
 #     Rebuild the bounded per-task outcome indexes, then create the processed
 #     marker at the current read cursor when it does not exist yet; validate a
-#     present marker without changing it. --held-lock is only for the direct
-#     child of the process holding $STATE/.branch-outcomes.lock
-#     (fm-wake-drain.sh); it skips the nested acquire so drain's bounded lock
-#     wait remains the deadline.
+#     present marker without changing it. --held-lock is only for a descendant
+#     of the process holding $STATE/.branch-outcomes.lock (fm-wake-drain.sh may
+#     run its redirected presentation body in a subshell on Bash 3.2); it skips
+#     the nested acquire so drain's bounded lock wait remains the deadline.
 #   fm-branch-outcome.sh list [--recent <n>]
 #     Print the last n records (default 20), read or not.
 #   fm-branch-outcome.sh startup-replay
@@ -382,8 +382,8 @@ processed_init_locked() {
   fi
 }
 
-held_lock_owned_by_parent() {
-  local owner pid
+held_lock_owned_by_ancestor() {
+  local owner owner_pid pid parent depth=0
   case "$PPID" in ''|*[!0-9]*|0|1) return 1 ;; esac
   if [ -L "$LOCK" ]; then
     owner=$(fm_lock_link_owner "$LOCK" 2>/dev/null) || return 1
@@ -393,8 +393,24 @@ held_lock_owned_by_parent() {
   else
     return 1
   fi
-  pid=$(cat "$owner/pid" 2>/dev/null) || return 1
-  [ "$pid" = "$PPID" ] && fm_pid_alive "$pid"
+  owner_pid=$(cat "$owner/pid" 2>/dev/null) || return 1
+  fm_pid_alive "$owner_pid" || return 1
+
+  # Bash 3.2 keeps $$ unchanged in a redirected subshell while that subshell's
+  # real pid becomes this script's parent. Walk the bounded live ancestry so
+  # that legitimate drain shape is accepted without trusting an arbitrary
+  # caller merely because it can name or observe the lock owner.
+  pid=$PPID
+  while [ "$depth" -lt 64 ]; do
+    [ "$pid" = "$owner_pid" ] && return 0
+    parent=$(ps -o ppid= -p "$pid" 2>/dev/null) || return 1
+    parent=${parent//[[:space:]]/}
+    case "$parent" in ''|*[!0-9]*|0|1) return 1 ;; esac
+    [ "$parent" != "$pid" ] || return 1
+    pid=$parent
+    depth=$((depth + 1))
+  done
+  return 1
 }
 
 CMD=${1:-}
@@ -550,8 +566,8 @@ case "$CMD" in
     [ "$#" -eq 0 ] || usage
     if [ "$HELD_LOCK" -eq 0 ]; then
       fm_lock_acquire_wait "$LOCK"
-    elif ! held_lock_owned_by_parent; then
-      echo "error: --held-lock requires the parent process to own the outcome lock" >&2
+    elif ! held_lock_owned_by_ancestor; then
+      echo "error: --held-lock requires an ancestor process to own the outcome lock" >&2
       exit 1
     fi
     if ! processed_init_locked; then

--- a/bin/fm-branch-outcome.sh
+++ b/bin/fm-branch-outcome.sh
@@ -71,9 +71,10 @@
 #   fm-branch-outcome.sh processed-init [--held-lock]
 #     Rebuild the bounded per-task outcome indexes, then create the processed
 #     marker at the current read cursor when it does not exist yet; validate a
-#     present marker without changing it. --held-lock is only for a caller that
-#     already holds $STATE/.branch-outcomes.lock (fm-wake-drain.sh); it skips
-#     the nested acquire so drain's bounded lock wait remains the deadline.
+#     present marker without changing it. --held-lock is only for the direct
+#     child of the process holding $STATE/.branch-outcomes.lock
+#     (fm-wake-drain.sh); it skips the nested acquire so drain's bounded lock
+#     wait remains the deadline.
 #   fm-branch-outcome.sh list [--recent <n>]
 #     Print the last n records (default 20), read or not.
 #   fm-branch-outcome.sh startup-replay
@@ -373,12 +374,27 @@ processed_init_locked() {
       return 1
     fi
   else
-    write_processed "$cursor_seq"
+    write_processed "$cursor_seq" || return 1
   fi
   if ! rebuild_outcome_indexes; then
     echo "error: outcome index migration could not be completed safely" >&2
     return 1
   fi
+}
+
+held_lock_owned_by_parent() {
+  local owner pid
+  case "$PPID" in ''|*[!0-9]*|0|1) return 1 ;; esac
+  if [ -L "$LOCK" ]; then
+    owner=$(fm_lock_link_owner "$LOCK" 2>/dev/null) || return 1
+    fm_lock_points_to_owner "$LOCK" "$owner" || return 1
+  elif [ -d "$LOCK" ]; then
+    owner=$LOCK
+  else
+    return 1
+  fi
+  pid=$(cat "$owner/pid" 2>/dev/null) || return 1
+  [ "$pid" = "$PPID" ] && fm_pid_alive "$pid"
 }
 
 CMD=${1:-}
@@ -534,6 +550,9 @@ case "$CMD" in
     [ "$#" -eq 0 ] || usage
     if [ "$HELD_LOCK" -eq 0 ]; then
       fm_lock_acquire_wait "$LOCK"
+    elif ! held_lock_owned_by_parent; then
+      echo "error: --held-lock requires the parent process to own the outcome lock" >&2
+      exit 1
     fi
     if ! processed_init_locked; then
       if [ "$HELD_LOCK" -eq 0 ]; then

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -206,6 +206,14 @@ BRANCH_OUTCOME_INDEX_STATE=ok
 BRANCH_OUTCOME_INDEX_ENDPOINT=
 BRANCH_OUTCOME_INDEX_IDENT=
 STATUS_OUTCOME_BACKSTOP_ACKNOWLEDGED=
+outcome_index_ready_ok() { # <ready-path>
+  local seq
+  [ -f "$1" ] && [ -r "$1" ] && [ ! -L "$1" ] || return 1
+  seq=$(LC_ALL=C command cat "$1" 2>/dev/null) || return 1
+  case "$seq" in ''|*[!0-9]*) return 1 ;; esac
+  return 0
+}
+
 load_branch_outcome_index() { # <task>
   local task=$1 path data version seq endpoint ident extra size
   BRANCH_OUTCOME_INDEX_STATE=ok
@@ -245,7 +253,7 @@ EOF
 }
 
 print_status_outcome_backstop_section() {  # <task-and-endpoint-snapshot>
-  local snapshot=$1 task endpoint ident event event_endpoint line verb key receipt store lock ready ready_seq
+  local snapshot=$1 task endpoint ident event event_endpoint line verb key receipt store lock ready
   local output='' used=0 shown=0 omitted=0 bytes item_bytes=220 global_bytes=4000 rc=0
   [ "$ACTOR" = main ] || return 0
 
@@ -261,18 +269,14 @@ print_status_outcome_backstop_section() {  # <task-and-endpoint-snapshot>
       return 0
     fi
     ready="$STATE/.branch-outcome-index-ready"
-    if [ ! -f "$ready" ] || [ ! -r "$ready" ] || [ -L "$ready" ]; then
-      fm_lock_release "$lock"
-      printf 'STATUS OUTCOME BACKSTOP SKIPPED: bounded outcome indexes need recovery; restart Pi supervision to repair them.\n'
-      return 0
+    if ! outcome_index_ready_ok "$ready"; then
+      if ! "$SCRIPT_DIR/fm-branch-outcome.sh" processed-init --held-lock >/dev/null 2>&1 \
+        || ! outcome_index_ready_ok "$ready"; then
+        fm_lock_release "$lock"
+        printf 'STATUS OUTCOME BACKSTOP SKIPPED: bounded outcome indexes could not be rebuilt because the outcome store is unsafe; repair it before relying on drain recovery.\n'
+        return 0
+      fi
     fi
-    ready_seq=$(LC_ALL=C command cat "$ready" 2>/dev/null) || ready_seq=
-    case "$ready_seq" in ''|*[!0-9]*)
-      fm_lock_release "$lock"
-      printf 'STATUS OUTCOME BACKSTOP SKIPPED: bounded outcome indexes need recovery; restart Pi supervision to repair them.\n'
-      return 0
-      ;;
-    esac
   fi
 
   STATUS_OUTCOME_BACKSTOP_ACKNOWLEDGED=

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -57,7 +57,8 @@ The drain reads one fixed-size per-task outcome index instead of scanning append
 Status provenance added to new outcome rows distinguishes covered and genuinely later events even within one timestamp second.
 Legacy outcomes predate that causal position, so equal-second migration cannot prove order and deliberately favors surfacing a plausibly later event; this can rarely duplicate an already handled legacy event.
 A pathological latest status line that crosses the 64 KiB window is unclassifiable and remains silent rather than risking presentation of routine content; this is an accepted limit, not a status-line size contract.
-Interrupted or missing outcome indexes fail closed with a repair diagnostic and are rebuilt from the authoritative outcome rows by `processed-init` during Pi reconciliation.
+A missing or invalid outcome-index ready marker is rebuilt from the authoritative outcome rows by `processed-init` under the outcome lock on the next main drain, on every harness.
+Only a genuine store fault keeps that backstop skipped.
 
 ## How the branch knows what the captain said
 

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -12,10 +12,11 @@ An unresolvable row makes the scan unsafe and returns the whole wake to main, an
 Captain-relevant branch outcomes persist as exact, sequence-keyed visible transcript entries and then open one sequence-keyed processing turn on main, which stays open until main acknowledges that sequence.
 The design source is the captain-approved forked-supervision architecture board, a captain-private fleet record (a self-contained HTML explainer with the measured cache and judgment evidence); this document records the shape it landed as, and the delivering PR cites the board artifact itself.
 
-This feature is Pi-only by construction and changes nothing anywhere else:
+The supervision branch itself is Pi-only by construction:
 
-- The branch lives in `.pi/extensions/fm-branch-supervision.ts`, which only a Pi primary ever loads; no other harness gains or loses behavior.
-- The bash-side additions (leases, the outcome store, session-start recovery) are inert in a home that never runs the branch: no lease files exist, no actor variable is set, every guard passes silently, and no new state appears (`tests/fm-branch-supervision.test.sh` holds this).
+- The branch lives in `.pi/extensions/fm-branch-supervision.ts`, which only a Pi primary ever loads; no other harness gains branch supervision behavior.
+- The bash-side additions (leases, the outcome store, session-start recovery) are inert in a home with no branch state: no lease files exist, no actor variable is set, every guard passes silently, and no new state appears (`tests/fm-branch-supervision.test.sh` holds this).
+  A home on any harness that already has an outcome store still receives the shared drain compatibility recovery described in [Lost-wake outcome backstop](#lost-wake-outcome-backstop).
 - It does not change which harness is primary and never moves a home to Pi.
 
 ## Components and their owners
@@ -120,7 +121,7 @@ What is new is only the attended path: outside away mode, the branch absorbs the
 
 Portable regressions: `tests/fm-pi-branch-extension.test.sh` covers dispatch, requested-versus-unsolicited delivery, exact visible entry content, no unkeyed model turn, the sequence-keyed processing request and its acknowledgement, re-presentation after an empty reply and after an unrelated prior answer, the triggered-then-next-turn pacing, session-start re-presentation, routine outcomes staying turn-free, the processed-marker migration, idle and busy main state, incident-shaped compaction and unrelated-assistant context, cold-start post-lock recovery, crash-before-cursor reload recovery, repeated-reload idempotency, mirroring, post-construction provider-error and no-report fallback, the consecutive-error latch, cooldown probe, exponential backoff, report-plus-settlement recovery, report-before-error re-latch, cache key, persistence, and model and effort selection.
 `tests/fm-branch-supervision.test.sh` covers prompt stability, store append-only behavior, the captain cursor barrier, the processed marker's sequence bounds, leases, guards, and non-branch-home invariance.
-`tests/fm-wake-drain-outcome-backstop.test.sh` covers keyless resurfacing, causal suppression, same-second ordering, one-shot presentation, index recovery, bounded history cost and output, and the oversized-line limit.
+`tests/fm-wake-drain-outcome-backstop.test.sh` covers keyless resurfacing, causal suppression, same-second ordering, one-shot presentation, first-drain index self-healing under the outcome lock, store-fault fail-closed behavior, bounded history cost and output, and the oversized-line limit.
 The branch-offer, heartbeat-offer, heartbeat-not-ridden-by-a-check, and main-only-check-class tests remain in `tests/fm-pi-watch-extension.test.sh`, the recovery test remains in `tests/fm-session-start.test.sh`, and the per-actor consume regression remains in `tests/fm-wake-queue.test.sh`.
 Live guard: `FM_PI_BRANCH_LIVE_E2E=1 tests/fm-pi-branch-live-e2e.test.sh` exercises the real installed Pi SDK's immediate active-transcript appendEntry rendering, persistence, custom-entry model exclusion, branch-session surfaces, and watcher-owned fallback after rejected branch settlement.
 Record dated current results in [docs/verification/runtime-backends.md](verification/runtime-backends.md).

--- a/tests/fm-wake-drain-outcome-backstop.test.sh
+++ b/tests/fm-wake-drain-outcome-backstop.test.sh
@@ -396,7 +396,28 @@ test_held_lock_mode_rejects_an_unlocked_caller() {
     || fail "unowned held-lock mode mutated the processed marker"
   [ ! -e "$state/.branch-outcome-index-ready" ] \
     || fail "unowned held-lock mode published the outcome index"
-  pass "held-lock initialization requires parent ownership of the outcome lock"
+  pass "held-lock initialization rejects callers outside the lock owner's process tree"
+}
+
+test_held_lock_mode_accepts_a_lock_owner_descendant() {
+  local dir state
+  dir=$(make_case index-selfheal-held-lock-descendant)
+  state="$dir/state"
+
+  printf '%s\n' '{"seq":1,"epoch":1,"task":"other","wake":"","verdict":"captain","summary":"unrelated"}' \
+    > "$state/branch-outcomes.jsonl"
+
+  FM_STATE_OVERRIDE="$state" bash -c '
+    # shellcheck source=bin/fm-wake-lib.sh
+    . "$1"
+    fm_lock_acquire_wait "$STATE/.branch-outcomes.lock" || exit 1
+    trap "fm_lock_release \"$STATE/.branch-outcomes.lock\"" EXIT
+    sh -c '"'"'$1 processed-init --held-lock'"'"' _ "$2"
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$OUTCOMES" \
+    || fail "processed-init rejected a descendant of the outcome lock owner"
+  [ -f "$state/.branch-outcome-index-ready" ] \
+    || fail "descendant held-lock initialization did not publish the outcome index"
+  pass "held-lock initialization accepts a descendant of the outcome lock owner"
 }
 
 test_index_self_heal_runs_under_the_outcome_lock() {
@@ -498,6 +519,7 @@ test_missing_index_self_heals_on_first_drain
 test_uncovered_event_surfaces_on_first_drain_without_index
 test_malformed_outcome_store_fails_closed_without_pi_advice
 test_held_lock_mode_rejects_an_unlocked_caller
+test_held_lock_mode_accepts_a_lock_owner_descendant
 test_index_self_heal_runs_under_the_outcome_lock
 test_overbound_routine_event_stays_silent
 test_backstop_output_is_bounded

--- a/tests/fm-wake-drain-outcome-backstop.test.sh
+++ b/tests/fm-wake-drain-outcome-backstop.test.sh
@@ -303,12 +303,11 @@ test_rejected_decision_line_surfaces_once_through_backstop() {
   pass "captain-facing decisions rejected by the fold surface once"
 }
 
-test_outcome_index_recovery_is_fail_closed_and_migratable() {
-  local dir state before after old
-  dir=$(make_case index-recovery)
+test_missing_index_self_heals_on_first_drain() {
+  local dir state out old
+  dir=$(make_case index-selfheal-covered)
   state="$dir/state"
-  before="$dir/before.out"
-  after="$dir/after.out"
+  out="$dir/drain.out"
 
   printf 'done: handled before cache interruption\n' > "$state/recovered.status"
   old=$(( $(date +%s) - 20 ))
@@ -317,20 +316,114 @@ test_outcome_index_recovery_is_fail_closed_and_migratable() {
     > "$state/branch-outcomes.jsonl"
   printf '1\n' > "$state/.branch-outcomes-cursor"
 
-  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$before" \
-    || fail "fail-closed drain failed with interrupted index publication"
-  grep -F 'bounded outcome indexes need recovery' "$before" >/dev/null \
-    || fail "missing index readiness re-presented or hid recovery state: $(cat "$before")"
-  grep -F 'recovered done:' "$before" >/dev/null \
-    && fail "interrupted index publication re-presented a handled outcome"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
+    || fail "first drain failed while self-healing a missing outcome index"
+  [ ! -s "$out" ] \
+    || fail "self-healed index re-presented a handled outcome: $(cat "$out")"
+  [ -f "$state/.branch-outcome-index-ready" ] \
+    || fail "first drain did not publish the outcome-index ready marker"
+  if grep -F 'Pi supervision' "$out" >/dev/null; then
+    fail "self-heal drain still mentioned Pi supervision: $(cat "$out")"
+  fi
+  pass "a missing outcome index self-heals on the first drain and suppresses its handled status"
+}
 
-  FM_STATE_OVERRIDE="$state" "$OUTCOMES" processed-init \
-    || fail "processed-init did not rebuild outcome indexes"
-  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$after" \
-    || fail "drain failed after index recovery"
-  [ ! -s "$after" ] \
-    || fail "recovered index did not suppress its handled status: $(cat "$after")"
-  pass "authoritative outcome rows recover interrupted bounded indexes"
+test_uncovered_event_surfaces_on_first_drain_without_index() {
+  local dir state out body
+  dir=$(make_case index-selfheal-uncovered)
+  state="$dir/state"
+  out="$dir/drain.out"
+
+  printf 'done: uncovered completion with no index\n' > "$state/fresh.status"
+  printf '%s\n' '{"seq":1,"epoch":1,"task":"other","wake":"","verdict":"captain","summary":"unrelated"}' \
+    > "$state/branch-outcomes.jsonl"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
+    || fail "first drain failed for an uncovered status with no outcome index"
+  grep -F 'STATUS OUTCOME BACKSTOP (' "$out" >/dev/null \
+    || fail "first drain skipped the backstop instead of self-healing: $(cat "$out")"
+  body=$(backstop_body "$out")
+  case "$body" in *'fresh done: uncovered completion with no index'*) ;; *)
+    fail "uncovered status did not surface after index self-heal: $body"
+    ;;
+  esac
+  [ -f "$state/.branch-outcome-index-ready" ] \
+    || fail "first drain did not publish the outcome-index ready marker"
+  if grep -F 'Pi supervision' "$out" >/dev/null; then
+    fail "uncovered self-heal drain mentioned Pi supervision: $(cat "$out")"
+  fi
+  pass "a fresh home with a status log and no index surfaces the backstop on its first drain"
+}
+
+test_malformed_outcome_store_fails_closed_without_pi_advice() {
+  local dir state out
+  dir=$(make_case index-selfheal-store-fault)
+  state="$dir/state"
+  out="$dir/drain.out"
+
+  printf 'done: must not surface over a corrupt outcome store\n' > "$state/unsafe.status"
+  printf 'not-json\n' > "$state/branch-outcomes.jsonl"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
+    || fail "drain failed closed incorrectly on a malformed outcome store"
+  grep -F 'STATUS OUTCOME BACKSTOP SKIPPED:' "$out" >/dev/null \
+    || fail "malformed store did not fail closed: $(cat "$out")"
+  grep -F 'outcome store is unsafe' "$out" >/dev/null \
+    || fail "store-fault skip lost its repair wording: $(cat "$out")"
+  if grep -F 'Pi supervision' "$out" >/dev/null; then
+    fail "store-fault skip still advised restarting Pi supervision: $(cat "$out")"
+  fi
+  grep -F 'unsafe done:' "$out" >/dev/null \
+    && fail "malformed store still presented a backstop event: $(cat "$out")"
+  [ ! -f "$state/.branch-outcome-index-ready" ] \
+    || fail "a store fault published a ready marker"
+  pass "a genuine outcome-store fault fails closed without Pi-specific restart advice"
+}
+
+test_index_self_heal_runs_under_the_outcome_lock() {
+  local dir state busy_out healed_out holder i
+  dir=$(make_case index-selfheal-lock)
+  state="$dir/state"
+  busy_out="$dir/busy.out"
+  healed_out="$dir/healed.out"
+
+  printf 'done: uncovered while the outcome lock is contested\n' > "$state/locked.status"
+  printf '%s\n' '{"seq":1,"epoch":1,"task":"other","wake":"","verdict":"captain","summary":"unrelated"}' \
+    > "$state/branch-outcomes.jsonl"
+
+  FM_STATE_OVERRIDE="$state" bash -c '
+    # shellcheck source=bin/fm-wake-lib.sh
+    . "$1"
+    fm_lock_try_acquire "$STATE/.branch-outcomes.lock" || exit 1
+    trap "fm_lock_release \"$STATE/.branch-outcomes.lock\"" EXIT
+    sleep 30
+  ' _ "$ROOT/bin/fm-wake-lib.sh" &
+  holder=$!
+  i=0
+  while [ "$i" -lt 50 ]; do
+    [ -e "$state/.branch-outcomes.lock" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$state/.branch-outcomes.lock" ] \
+    || { kill "$holder" 2>/dev/null || true; fail "test lock holder did not publish the outcome lock"; }
+
+  FM_STATUS_PRESENTATION_LOCK_TIMEOUT=1 FM_STATE_OVERRIDE="$state" "$DRAIN" > "$busy_out" \
+    || fail "drain failed while the outcome lock was held"
+  grep -F 'branch outcome history is busy' "$busy_out" >/dev/null \
+    || fail "contested lock did not skip the backstop: $(cat "$busy_out")"
+  [ ! -f "$state/.branch-outcome-index-ready" ] \
+    || fail "self-heal published a ready marker without holding the outcome lock"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$healed_out" \
+    || fail "drain failed after the outcome lock was released"
+  grep -F 'locked done: uncovered while the outcome lock is contested' "$healed_out" >/dev/null \
+    || fail "self-heal under the lock did not surface the uncovered event: $(cat "$healed_out")"
+  [ -f "$state/.branch-outcome-index-ready" ] \
+    || fail "self-heal under the lock did not publish the ready marker"
+  pass "index self-heal runs only while the outcome lock is held"
 }
 
 test_overbound_routine_event_stays_silent() {
@@ -382,6 +475,9 @@ test_successful_backstop_is_idempotent_without_consuming_delayed_annotation
 test_output_failure_does_not_commit_the_backstop_receipt
 test_receipt_commit_failure_repeats_the_already_presented_backstop
 test_rejected_decision_line_surfaces_once_through_backstop
-test_outcome_index_recovery_is_fail_closed_and_migratable
+test_missing_index_self_heals_on_first_drain
+test_uncovered_event_surfaces_on_first_drain_without_index
+test_malformed_outcome_store_fails_closed_without_pi_advice
+test_index_self_heal_runs_under_the_outcome_lock
 test_overbound_routine_event_stays_silent
 test_backstop_output_is_bounded

--- a/tests/fm-wake-drain-outcome-backstop.test.sh
+++ b/tests/fm-wake-drain-outcome-backstop.test.sh
@@ -380,6 +380,25 @@ test_malformed_outcome_store_fails_closed_without_pi_advice() {
   pass "a genuine outcome-store fault fails closed without Pi-specific restart advice"
 }
 
+test_held_lock_mode_rejects_an_unlocked_caller() {
+  local dir state out
+  dir=$(make_case index-selfheal-held-lock-guard)
+  state="$dir/state"
+  out="$dir/processed-init.out"
+
+  printf '%s\n' '{"seq":1,"epoch":1,"task":"other","wake":"","verdict":"captain","summary":"unrelated"}' \
+    > "$state/branch-outcomes.jsonl"
+
+  if FM_STATE_OVERRIDE="$state" "$OUTCOMES" processed-init --held-lock > "$out" 2>&1; then
+    fail "processed-init accepted --held-lock without parent lock ownership"
+  fi
+  [ ! -e "$state/.branch-outcomes-processed" ] \
+    || fail "unowned held-lock mode mutated the processed marker"
+  [ ! -e "$state/.branch-outcome-index-ready" ] \
+    || fail "unowned held-lock mode published the outcome index"
+  pass "held-lock initialization requires parent ownership of the outcome lock"
+}
+
 test_index_self_heal_runs_under_the_outcome_lock() {
   local dir state busy_out healed_out holder i
   dir=$(make_case index-selfheal-lock)
@@ -478,6 +497,7 @@ test_rejected_decision_line_surfaces_once_through_backstop
 test_missing_index_self_heals_on_first_drain
 test_uncovered_event_surfaces_on_first_drain_without_index
 test_malformed_outcome_store_fails_closed_without_pi_advice
+test_held_lock_mode_rejects_an_unlocked_caller
 test_index_self_heal_runs_under_the_outcome_lock
 test_overbound_routine_event_stays_silent
 test_backstop_output_is_bounded


### PR DESCRIPTION
## Intent

Fix a cross-harness bug that silently disables the status-outcome backstop added in #3495 on every non-Pi home. After fast-forward to 56b4c15c, every drain printed "STATUS OUTCOME BACKSTOP SKIPPED: bounded outcome indexes need recovery; restart Pi supervision to repair them" because state/.branch-outcome-index-ready was absent while state/branch-outcomes.jsonl existed. That marker is created by fm-branch-outcome.sh processed-init, which only the Pi branch extension runs, so Claude/Cursor/Codex homes never create it and the backstop stays off until someone runs processed-init by hand.

Make the drain (or session-start startup-replay) run processed-init under the outcome lock when the ready marker is absent or invalid, on every harness. Fail closed only on a real store fault. Drop the Pi-specific "restart Pi supervision" wording from the skipped message.

Acceptance: a behavioral test exercising the real drain path; a fresh home with a status log and a branch-outcomes store but no ready marker gets the backstop working on its first drain (the index self-heals, no manual processed-init). The self-heal runs under the outcome lock; a genuine store fault still fails closed. Non-Pi homes no longer see the Pi-specific restart advice.

Constraints: edits firstmate shared tracked material (bin/, drain / fm-branch-outcome.sh / session-start replay); bash-3.2-safe; tests behavioral through the real executable path, never source-text; bin/fm-timeout-lib.sh stays the single owner of bounded execution; author every commit with no co-author / Co-Authored-By trailer.

## What Changed
- Rebuild missing or invalid outcome indexes during the first main drain while holding the outcome lock.
- Fail closed only when the outcome store is unsafe, with harness-neutral recovery guidance.
- Add behavioral coverage for first-drain recovery, lock ownership, and malformed-store handling.

## Risk Assessment

✅ Low: The change is well-bounded, restores first-drain index recovery under the existing outcome lock, preserves fail-closed behavior, and adds behavioral coverage through the real executable path.

## Testing

Inspected the baseline diff and commit metadata, ran the focused backstop suite, reproduced and fixed a Bash 3.2 subshell ancestry failure, reran the suite with production executables forced onto Bash 3.2, and captured a real first-drain transcript showing index self-healing plus genuine-store-fault fail-closed behavior; all targeted checks now pass.

<details>
<summary>Evidence: Bash 3.2 first-drain self-heal and malformed-store fail-closed transcript</summary>

Source: [Bash 3.2 first-drain self-heal and malformed-store fail-closed transcript](https://github.com/kunchenguid/firstmate/blob/3d8cd0723a3872432005d2d5d8ea70633dadaa06/.no-mistakes/evidence/fm/fm-outcome-backstop-index-selfheal-r1/first-drain-self-heal-transcript.txt)

```text
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ verify fresh non-Pi-style home before first drain
ready marker before: absent
$ FM_STATE_OVERRIDE=<fresh-state> bin/fm-wake-drain.sh
STATUS OUTCOME BACKSTOP (newest captain-facing task event has no covering branch outcome):
fresh done: first-drain recovery is visible
ready marker after: 1
generated task index: fm-branch-outcome-index-v1	1	0	-
$ verify genuine malformed-store fault
STATUS OUTCOME BACKSTOP SKIPPED: bounded outcome indexes could not be rebuilt because the outcome store is unsafe; repair it before relying on drain recovery.
ready marker after fault: absent
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"779027c54ecbd70b884a0f9019c33963dffed345","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-branch-outcome.sh:376` - `processed_init_locked` is invoked through `if !`, which disables `set -e` within the function. If `write_processed` fails, execution continues, successful index rebuilding masks the failure, and drain reports self-healing despite the processed marker not being persisted. Explicitly use `write_processed &#34;$cursor_seq&#34; || return 1` so storage faults fail closed.
- ⚠️ `bin/fm-branch-outcome.sh:530` - The newly documented `processed-init --held-lock` option trusts any caller and performs mutations without acquiring or verifying the outcome lock. A direct invocation concurrent with append can rebuild indexes over an in-progress transition, violating the store&#39;s locking invariant. Reject this mode unless the lock record proves the parent caller owns the lock.

🔧 Fix: Guard held-lock initialization and fail marker writes
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./tests/fm-wake-drain-outcome-backstop.test.sh`
- `PATH=<bash-3.2-shim> /bin/bash ./tests/fm-wake-drain-outcome-backstop.test.sh`
- `Manual real-drain verification under Bash 3.2 using a fresh state with a status log, outcome store, and no ready marker`
- `Manual malformed-store drain verification confirming fail-closed behavior and no Pi-specific advice`
- `git diff --check 56b4c15c2d98efb3c74f78fe3b73da477466d08a..2ee7f8611cbad7ae99cb6292f496203c68fba204`
- `Inspected commit authorship and trailers across the target commit range`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
