### PR TITLE
fix(backends): make a missing adapter file a guardable refusal under set -e

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -595,6 +595,13 @@ fm_backend_expected_label_of_selector() {  # <raw-target> <state-dir>
 fm_backend_source() {  # <name>
   local name=$1
   fm_backend_validate "$name" || return 1
+  # A missing adapter file must be a guardable refusal, never a fatal source
+  # error: under `set -e` (fm-teardown.sh and other lifecycle consumers) a
+  # failed `.` on a nonexistent file exits the shell even inside `||`/`if`
+  # guards on bash 3.2, which silently reports success instead of reaching the
+  # caller's "prerequisites unavailable" refusal. Precheck existence so the
+  # source only ever runs on a present file.
+  [ -f "$FM_BACKEND_LIB_DIR/backends/$name.sh" ] || return 1
   case "$name" in
     tmux)
       if [ -z "${_FM_BACKEND_TMUX_SOURCED:-}" ]; then

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -503,6 +503,29 @@ test_backend_source_shell_portable() {
   pass "bash: fm_backend_source recognizes known backends and rejects unknown ones"
 }
 
+test_backend_source_missing_adapter_refuses_guardably() {
+  local out rc tmpbin
+  # The teardown preflight relies on fm_backend_source returning 1 when an
+  # adapter file is absent. Under `set -e`, a failed `.` on a nonexistent file
+  # is a fatal special-builtin error on bash 3.2, even inside `||`/`if` guards,
+  # so the refusal must come from an existence precheck instead of the source
+  # itself failing - otherwise lifecycle callers silently exit as if they
+  # succeeded. This mirrors the missing-adapter teardown fixture at the
+  # library boundary for every backend and caller.
+  tmpbin="$TMP_ROOT/missing-adapter-lib/backends"
+  mkdir -p "$tmpbin"
+  rc=0
+  out=$(set -eu; cd "$ROOT" \
+    && . bin/fm-backend.sh \
+    && FM_BACKEND_LIB_DIR="$tmpbin" \
+    && if fm_backend_source herdr; then echo sourced; else echo refused; fi) || rc=$?
+  [ "$rc" -eq 0 ] \
+    || fail "fm_backend_source missing adapter: the caller shell died (rc=$rc) instead of refusing"
+  [ "$out" = "refused" ] \
+    || fail "fm_backend_source missing adapter: expected 'refused', got: $out"
+  pass "fm_backend_source refuses a missing adapter guardably under set -e instead of exiting the caller"
+}
+
 test_backend_validate_spawn_accepts_orca() {
   local out
   fm_backend_validate_spawn tmux 2>/dev/null || fail "fm_backend_validate_spawn should accept tmux"
@@ -1126,6 +1149,7 @@ test_backend_name_autodetect_notice
 test_backend_name_explicit_beats_detection
 test_backend_validate_refuses_unknown
 test_backend_source_shell_portable
+test_backend_source_missing_adapter_refuses_guardably
 test_backend_validate_spawn_accepts_orca
 test_meta_get_and_backend_of_meta
 test_resolve_selector_three_forms


### PR DESCRIPTION
## Intent

Ship the independently selected correction for the pre-existing macOS Bash 3.2 herdr-preflight-missing-adapter teardown fixture failure: fm_backend_source on stock bash 3.2 under set -e made a failed source of a missing adapter file fatal to the caller shell even inside ||/if guards, so fm-teardown.sh's herdr preflight exited 0 silently through its EXIT trap instead of printing the 'prerequisites are unavailable; nothing was changed' refusal, which is the herdr-preflight-missing-adapter fixture failure in tests/fm-teardown.test.sh. The fix is exactly the judge-selected candidate B (commit e0b5d224): a seven-line existence precheck ([ -f "$FM_BACKEND_LIB_DIR/backends/$name.sh" ] || return 1) inserted in fm_backend_source right after fm_backend_validate, plus its focused library-boundary regression test in tests/fm-backend.test.sh (under set -eu, sourcing with the adapter absent must refuse instead of killing the caller). Requirements and exclusions: do not import candidate A's errexit bracket helper (fm_backend_source_file) because it can misreport a half-loaded adapter as successfully sourced and let destructive teardown cleanup proceed; do not broaden into corrupt, unreadable, or partial-install adapter handling; preserve the existing fail-stop behavior for every non-missing-file failure class; base must be the fresh current upstream/main and the PR targets upstream/main without merging. Already verified before this run: the patch bytes match candidate B exactly; the new regression test is red on the unmodified upstream base (caller shell died rc=1) and green on the branch; and the full prescribed validation set passed on macOS stock bash 3.2.57 (teardown 58 ok including all four preflight refusal modes, backend suite with the new regression, herdr backend suite, afk-launch suite, tmux/cmux smoke rc 0, fm-lint clean, doc-audience-check ok, bash -n parse coverage over bin/*.sh and bin/backends/*.sh).

## What Changed

- `fm_backend_source` in `bin/fm-backend.sh` now checks that `$FM_BACKEND_LIB_DIR/backends/$name.sh` exists and returns 1 if it does not, right after `fm_backend_validate` and before any `.` of the adapter. On bash 3.2 a failed `.` on a nonexistent file is a fatal special-builtin error even inside `||` and `if` guards, so callers running under `set -e` were exiting instead of taking their refusal path. The precheck means the source only ever runs against a file that is present.
- Added `test_backend_source_missing_adapter_refuses_guardably` to `tests/fm-backend.test.sh`, registered in the suite runner. It sources the library under `set -eu`, points `FM_BACKEND_LIB_DIR` at an empty backends directory, and asserts two things: the caller shell survives (rc 0) and the guard reports `refused`.
- Behavior for every other failure class is untouched. Only the missing-file case changed.

## Risk Assessment

✅ Low: A single guarded existence precheck whose only behavioral delta is turning a fatal missing-file source into a returnable refusal — every known backend has its adapter present so normal paths are unchanged, fail-stop is preserved for all other failure classes, and the change is accompanied by a behavior-level regression test on an unmodified upstream base.

## Testing

Ran the two targeted suites on macOS stock bash 3.2.57 - tests/fm-teardown.test.sh (58 ok, rc 0, all four herdr preflight refusal modes including the previously failing missing-adapter fixture) and tests/fm-backend.test.sh (29 ok, rc 0, including the new library-boundary regression) - then produced the end-user evidence by invoking the real bin/fm-teardown.sh --force against an install with the herdr adapter deleted, once with the pre-fix base fm-backend.sh and once with the branch's: pre-fix exits 0 with only a raw "No such file or directory" line, post-fix exits 1 with the visible "prerequisites are unavailable ... nothing was changed" refusal and every record, the task branch and the isolated copy intact with no treehouse return or pane close attempted. A base-vs-branch failure-class probe confirms the change is confined to the missing-file case, with syntax-error, unreadable and nonzero-return adapters retaining identical fail-stop behavior. No UI surface is involved, so the reviewer-visible artifacts are CLI transcripts; the worktree was left clean.

<details>
<summary>Evidence: Teardown CLI transcript: missing herdr adapter, pre-fix vs post-fix</summary>

Source: [Teardown CLI transcript: missing herdr adapter, pre-fix vs post-fix](https://github.com/npayette84/firstmate/blob/f601966d48f56f88820ea38879ef664506eb4739/.no-mistakes/evidence/fm/fm-herdr-preflight-missing-adapter-fixture/teardown-missing-adapter-cli-transcript.txt)

<code>CASE: before-fix (bin/backends/herdr.sh deleted; fm-backend.sh from 763f597)&#10;$ bin/fm-teardown.sh task-x1 --force&#10;--- stderr ---&#10;.../bin/fm-backend.sh: line 609: .../bin/backends/herdr.sh: No such file or directory&#10;--- exit code: 0&#10;exit status : 0 (operator is told teardown succeeded)&#10;refusal explained : NO (silent)&#10;&#10;CASE: after-fix (bin/backends/herdr.sh deleted; fm-backend.sh from the branch)&#10;$ bin/fm-teardown.sh task-x1 --force&#10;--- stderr ---&#10;error: herdr teardown prerequisites are unavailable for task-x1; nothing was changed - restore the adapter and rerun teardown&#10;--- exit code: 1&#10;exit status : NON-ZERO (operator sees a failure)&#10;refusal explained : yes (&#39;nothing was changed&#39; printed)&#10;endpoint metadata : preserved&#10;task status record : preserved&#10;isolated copy (wt) : preserved on fm/task-x1&#10;treehouse return run : no&#10;herdr pane close : no</code>

```text
==================================================================
CASE: before-fix   (bin/backends/herdr.sh deleted from the install)
      bin/fm-backend.sh taken from 763f5979a7eb988397292faac372c15d2416ed43 (pre-fix)
$ bin/fm-teardown.sh task-x1 --force
--- stdout ---
--- stderr ---
/private/var/folders/70/p814fs691f103nxddhx58mhh0000gn/T/fm-teardown-tests.DozZtg/manual-before-fix/test-root/bin/fm-backend.sh: line 609: /private/var/folders/70/p814fs691f103nxddhx58mhh0000gn/T/fm-teardown-tests.DozZtg/manual-before-fix/test-root/bin/backends/herdr.sh: No such file or directory
--- exit code: 0
--- observable state after the command ---
  exit status          : 0 (operator is told teardown succeeded)
  refusal explained    : NO (silent)
  endpoint metadata    : preserved
  task status record   : preserved
  isolated copy (wt)   : preserved on fm/task-x1
  treehouse return run : no
  herdr pane close     : no

==================================================================
CASE: after-fix   (bin/backends/herdr.sh deleted from the install)
      bin/fm-backend.sh from the branch under test (fixed)
$ bin/fm-teardown.sh task-x1 --force
--- stdout ---
--- stderr ---
error: herdr teardown prerequisites are unavailable for task-x1; nothing was changed - restore the adapter and rerun teardown
--- exit code: 1
--- observable state after the command ---
  exit status          : NON-ZERO (operator sees a failure)
  refusal explained    : yes ('nothing was changed' printed)
  endpoint metadata    : preserved
  task status record   : preserved
  isolated copy (wt)   : preserved on fm/task-x1
  treehouse return run : no
  herdr pane close     : no
```
</details>
<details>
<summary>Evidence: Failure-class parity under set -eu on bash 3.2.57 (base vs branch)</summary>

Source: [Failure-class parity under set -eu on bash 3.2.57 (base vs branch)](https://github.com/npayette84/firstmate/blob/f601966d48f56f88820ea38879ef664506eb4739/.no-mistakes/evidence/fm/fm-herdr-preflight-missing-adapter-fixture/failure-class-parity-base-vs-branch.txt)

<code>bash: 3.2.57(1)-release&#10;base ok caller-rc=0 guarded-result=sourced&#10;branch ok caller-rc=0 guarded-result=sourced&#10;base missing caller-rc=1 guarded-result=&lt;caller shell died before the guard&gt;&#10;branch missing caller-rc=0 guarded-result=refused&#10;base nonzero caller-rc=0 guarded-result=refused&#10;branch nonzero caller-rc=0 guarded-result=refused&#10;base syntax caller-rc=2 guarded-result=&lt;caller shell died before the guard&gt;&#10;branch syntax caller-rc=2 guarded-result=&lt;caller shell died before the guard&gt;&#10;base unreadable caller-rc=1 guarded-result=&lt;caller shell died before the guard&gt;&#10;branch unreadable caller-rc=1 guarded-result=&lt;caller shell died before the guard&gt;</code>

```text
bash: 3.2.57(1)-release
base    ok          caller-rc=0   guarded-result=sourced
branch  ok          caller-rc=0   guarded-result=sourced
base    missing     caller-rc=1   guarded-result=<caller shell died before the guard>
branch  missing     caller-rc=0   guarded-result=refused
base    nonzero     caller-rc=0   guarded-result=refused
branch  nonzero     caller-rc=0   guarded-result=refused
base    syntax      caller-rc=2   guarded-result=<caller shell died before the guard>
branch  syntax      caller-rc=2   guarded-result=<caller shell died before the guard>
base    unreadable  caller-rc=1   guarded-result=<caller shell died before the guard>
branch  unreadable  caller-rc=1   guarded-result=<caller shell died before the guard>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1481bdbb28517a6a373e75d6348f8875644fccaf","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `tests/fm-backend.test.sh:515` - The regression test sets FM_BACKEND_LIB_DIR to a directory it created and named `backends`, so the path fm_backend_source actually consults is `$TMP_ROOT/missing-adapter-lib/backends/backends/herdr.sh` — the mkdir&#39;d directory is the lib dir, not the adapter dir. The case therefore exercises &#34;adapter parent directory absent&#34; rather than the fixture&#39;s real shape (populated `backends/` dir with only `herdr.sh` removed). Both fail `[ -f ]` identically, so the test is valid and still red-before/green-after, but `tmpbin=&#34;$TMP_ROOT/missing-adapter-lib&#34;; mkdir -p &#34;$tmpbin/backends&#34;` would mirror tests/fm-teardown.test.sh:1560 exactly and prove the precheck keys on the file rather than on the missing directory.
- ℹ️ `bin/backends/herdr.sh:79` - The same silent-exit-0 class remains reachable one level down: bin/backends/herdr.sh:79 and :87 source fm-composer-lib.sh and fm-transition-lib.sh unguarded, so a partial install where the adapter is present but a sibling lib is missing still kills the caller shell under set -e before teardown&#39;s refusal prints. This is explicitly excluded by the intent (&#34;do not broaden into corrupt, unreadable, or partial-install adapter handling&#34;) and the change correctly preserves fail-stop for that class, so no action is expected here — noting it only as the known remaining boundary of this fix.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-teardown.test.sh` (58 ok, rc 0; includes herdr-preflight-missing-adapter, missing-parser, missing-explicit-close-helper, unresolvable-lock)</code>
- <code>`bash tests/fm-backend.test.sh` (29 ok, rc 0; includes `test_backend_source_missing_adapter_refuses_guardably`)</code>
- <code>Manual CLI reproduction: real `bin/fm-teardown.sh task-x1 --force` run against an install with `bin/backends/herdr.sh` removed, executed twice - once with base 763f597 `bin/fm-backend.sh` (pre-fix) and once with the branch&#39;s - capturing stdout/stderr, exit code, record survival, treehouse-return and herdr pane-close side effects</code>
- <code>Failure-class parity probe under `set -eu` on bash 3.2.57 comparing base vs branch `fm_backend_source herdr` for present/missing/nonzero-return/syntax-error/unreadable adapter files</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
