### PR TITLE
feat(bin): corroborate Herdr agent liveness, sandbox crewmate launches, and harvest fleet usage

### DIFF
--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -13,8 +13,10 @@ Busy hooks verified 2026-07-28 on Claude Code 2.1.220.
 | Model | `--model <model>`; discover through the interactive `/model` picker, with alias or full-name shape documented by `claude --help`. |
 | Effort | `--effort <low\|medium\|high\|xhigh\|max>`, verified on 2.1.196. |
 
-Fresh-worktree or first-machine launch may show trust or bypass-permissions confirmation.
-Inspect within about 20 seconds, accept the required choice with `FM_HOME=<active-home> ../../../bin/fm-send.sh <window> --key Enter` unless already bound, and verify instructions started.
+Workspace trust confirms on every worktree path Claude has not seen, which is every task, and the launch flags do not change that: it measured identically under `--dangerously-skip-permissions` and under today's `--permission-mode auto`.
+`../../../docs/verification/runtime-backends.md` owns that measurement under "Crewmate autonomy and the status-file write contract".
+Inspect within about 20 seconds; the preselected row is `No, exit`, so a bare Enter DECLINES and quits Claude, while the accept `Yes, I trust this folder` sits on the row below.
+Accept with `FM_HOME=<active-home> ../../../bin/fm-send.sh <window> --key Down` then `--key Enter` unless already bound, and verify instructions started.
 
 ## Composer ghost
 

--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -10,6 +10,8 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 | Exit command | `/quit`; its slash popup needs about one second between text and Enter, which the shared submit path used by the control plane handles. |
 | Interrupt | Single Escape. |
 | Skill invocation | `$<skill>`, for example `$no-mistakes`; `/<skill>` is Claude-only and Codex rejects it as "Unrecognized command". |
+| Autonomy | `-s workspace-write -a never`: sandboxed to the worktree, with no approval path to escalate out of it; `../../../bin/fm-spawn.sh` owns the exact flags. |
+| Sandboxed writes | `workspace-write` normally refuses writes outside the worktree, and `-a never` leaves the model no way to ask, so the paths the brief permits outside it are granted with `--add-dir`; `../../../docs/verification/runtime-backends.md` owns the measurement under "Crewmate autonomy and the status-file write contract". `workspace-write` grants `/tmp` and `$TMPDIR` by default, so a write measured there proves nothing. |
 | Resume | `codex resume <session-id>`, using the id printed on quit. |
 | Model flag | `--model <model>`. |
 | Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'`, verified on codex-cli 0.142.1 whose installed schema contains `model_reasoning_effort`, active config uses it, and bundled catalog advertises only these four values while omitting `max`. |

--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -20,6 +20,7 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 A directory trust dialog appears on the first run for a repository root: "Do you trust the contents of this directory?"
 Accept it with Enter and verify the instructions begin processing.
 The decision persists for the repository, so later worktrees of the same project skip it.
+A second gate, `Hooks need review`, was observed standing between that dialog and the composer whenever Codex hooks are configured, so a Codex spawn can need two answers before it reads its brief; `../../../docs/verification/runtime-backends.md` owns that measurement under "Crewmate autonomy and the status-file write contract".
 
 ## Skill popup
 

--- a/.agents/skills/harness-adapters/references/harness/cursor.md
+++ b/.agents/skills/harness-adapters/references/harness/cursor.md
@@ -8,14 +8,14 @@ Cross-harness provider and credential identity is owned by `references/common/mo
 | Fact | Value |
 |---|---|
 | Binary | `fm_cursor_resolve_binary` in `../../../bin/fm-cursor-lib.sh` resolves stable launcher `cursor-agent` or legacy `agent`, never `cursor`; both symlink into `~/.local/share/cursor-agent/versions/<version>/cursor-agent`, whose target auto-update replaces. |
-| Launch | Positional instructions with `--trust`, `--yolo`, optional `--model <model>`, and `--workspace <absolute-task-worktree>`, after clearing foreign primary markers. |
+| Launch | Positional instructions with `--trust`, the autonomy flags `../../../bin/fm-spawn.sh` owns, optional `--model <model>`, and `--workspace <absolute-task-worktree>`, after clearing foreign primary markers. |
 | Models | Use current-account `cursor-agent --list-models` or legacy `agent --list-models`; the drifting observed list had only `cursor-grok-4.5-high` and `cursor-grok-4.5-high-fast` for Grok plus several `xhigh` ids, so choose a returned reasoning id and never assume low or medium Grok. |
 | Busy state | `../../../bin/fm-busy-lib.sh` folds the per-conversation transcript as `cursor-transcript`: `role:user` opens and typed `turn_ended` closes success or abort, covering manual interrupt; nothing is armed or seeded, and this backend-agnostic source was identical on tmux and Herdr. |
 | Exit command | `/exit`. |
 | Interrupt | Single Escape returns the placeholder with no clear key; control makes no cancellation claim because an aborted transcript close appeared within seconds in some runs and not within twenty in others. |
 | Skill invocation | `/<skill>`, for example `/no-mistakes`; Cursor discovers Firstmate's user skills. |
 | Resume | No verified native pane resume; use deterministic relaunch. |
-| Autonomy | `--yolo`, documented alias for `--force`; footer `Run Everything`. |
+| Autonomy | `--auto-review --sandbox enabled`, so a crewmate runs under Cursor's own review and sandbox controls; `../../../bin/fm-spawn.sh` owns the exact flags. `--yolo`, the documented alias for `--force` whose footer reads `Run Everything`, switches both off and is not used. |
 | Trust | `--trust` suppresses the dialog; `--yolo` does not, and every task has a fresh path. |
 | Marker | `CURSOR_INVOKED_AS=cursor-agent` on agent and children, plus `CURSOR_AGENT=1` on child or tool processes; other `CURSOR_*` variables are not identity markers. |
 | Effort | No verified flag; `references/common/model-and-effort.md` owns unsupported-value handling. |

--- a/.agents/skills/harness-adapters/references/harness/cursor.md
+++ b/.agents/skills/harness-adapters/references/harness/cursor.md
@@ -15,7 +15,8 @@ Cross-harness provider and credential identity is owned by `references/common/mo
 | Interrupt | Single Escape returns the placeholder with no clear key; control makes no cancellation claim because an aborted transcript close appeared within seconds in some runs and not within twenty in others. |
 | Skill invocation | `/<skill>`, for example `/no-mistakes`; Cursor discovers Firstmate's user skills. |
 | Resume | No verified native pane resume; use deterministic relaunch. |
-| Autonomy | `--auto-review --sandbox enabled`, so a crewmate runs under Cursor's own review and sandbox controls; `../../../bin/fm-spawn.sh` owns the exact flags. `--yolo`, the documented alias for `--force` whose footer reads `Run Everything`, switches both off and is not used. |
+| Autonomy | `--auto-review --sandbox enabled`, so a crewmate runs under Cursor's own review and sandbox controls, plus the `--add-dir` writable roots below; `../../../bin/fm-spawn.sh` owns the exact flags. `--yolo`, the documented alias for `--force` whose footer reads `Run Everything`, switches both off and is not used. |
+| Sandboxed writes | The sandbox normally refuses writes outside the workspace, and `--auto-review` then parks the turn on a manual approval prompt an unattended crewmate cannot clear, so the paths the brief permits outside the worktree are granted with `--add-dir`; `../../../docs/verification/runtime-backends.md` owns the measurement under "Crewmate autonomy and the status-file write contract". |
 | Trust | `--trust` suppresses the dialog; `--yolo` does not, and every task has a fresh path. |
 | Marker | `CURSOR_INVOKED_AS=cursor-agent` on agent and children, plus `CURSOR_AGENT=1` on child or tool processes; other `CURSOR_*` variables are not identity markers. |
 | Effort | No verified flag; `references/common/model-and-effort.md` owns unsupported-value handling. |
@@ -61,7 +62,9 @@ Refresh with `FM_HARNESS_LIVENESS_DRIFT=1 ../../../bin/fm-test-run.sh ../../../t
 
 Firstmate enters its acquired worktree and passes the same absolute path through `--workspace`.
 Never pass Cursor `-w` or `--worktree`, which allocates a second copy under `~/.cursor/worktrees` and breaks isolation.
-The CLI supports repeatable `--add-dir`, but the adapter adds none; positional instructions need no grant to their private directory.
+The adapter also passes repeatable `--add-dir <path>` for the writable roots the sandbox posture needs; `../../../bin/fm-spawn.sh` owns which ones, and they are the only paths a worker may write outside its worktree.
+The brief rides inline as the positional prompt, so the private brief directory needs no grant.
+`--add-dir` adds writable roots only: Cursor still records the `--workspace` path as its project `workspacePath`, the exact identity `state/<id>.cursor-session` binds the busy fold to.
 Example: `../../../bin/fm-spawn.sh <task-id> <project> --scout --harness cursor --model cursor-grok-4.5-high`.
 
 ## Primary integration

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1874,25 +1874,55 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 #              reaped it - verified empirically: killing a pane's shell pid
 #              on a live server makes herdr immediately drop both the pane
 #              and its tab from `pane get`/`tab list`).
-#   no-agent - `pane get` succeeds (the pane structurally exists) but `agent
-#              get` responds with error code agent_not_found: nothing is
-#              registered in it - exactly what a herdr session-layout restore
-#              produces (verified empirically: `session stop` + fresh `herdr
-#              server` restart leaves the pane alive, agent_status "unknown",
-#              agent get -> agent_not_found - docs/herdr-backend.md "ID
-#              stability across a server restart"), and what a future
-#              `resume_agents_on_restore = false` restore would produce too
-#              (a plain shell, never an agent).
-#   live     - `agent get` succeeds and reports a real agent_status (working,
-#              idle, done, or blocked - any registered value). An idle or
-#              blocked agent is still a genuine, still-registered agent, not
-#              a restored husk, so it is never a close-and-replace candidate.
+#   no-agent - the pane structurally exists but confidently hosts no agent.
+#              Two independent positive grounds reach this verdict:
+#              (a) `agent get` responds with error code agent_not_found:
+#              nothing is registered in it - exactly what a herdr
+#              session-layout restore produces (verified empirically:
+#              `session stop` + fresh `herdr server` restart leaves the pane
+#              alive, agent_status "unknown", agent get -> agent_not_found -
+#              docs/herdr-backend.md "ID stability across a server restart"),
+#              and what a future `resume_agents_on_restore = false` restore
+#              would produce too (a plain shell, never an agent);
+#              (b) a registration IS reported, but the pane's own process
+#              inventory positively proves a lone bare idle shell, so the
+#              registration outlived the process it describes.
+#   live     - `agent get` reports a real agent_status (working, idle, done,
+#              or blocked - any registered value) and the pane's process
+#              inventory does not contradict it. An idle or blocked agent is
+#              still a genuine, still-registered agent, not a restored husk,
+#              so it is never a close-and-replace candidate.
 #   unknown  - anything else: an unparseable/unexpected response from either
 #              call, or a `pane get` success whose own echoed pane_id does not
 #              round-trip (guards against misreading a herdr response shape
 #              change as "the pane exists"). The caller must fail safe toward
 #              refusal here, never toward closing - this is the conservative
 #              backstop the husk check depends on.
+#
+# Why a reported registration is corroborated at all. Herdr's agent registry
+# is written by whatever reports into it - each harness's herdr integration
+# extension, or any other source - and a report is not withdrawn when the
+# process that made it goes away. Verified empirically on herdr 0.8.2: a
+# `pane report-agent` from a source herdr does not itself own stays registered
+# on a pane running nothing but its shell, so `agent get` keeps answering
+# `idle` with no agent alive anywhere. Trusting that alone made a task whose
+# worker had already exited to its shell read `alive` forever: every lifecycle
+# verb then typed the harness's exit command into a shell and refused to
+# relaunch, with no state that could ever clear it. The tmux classifier never
+# had this hole because it reads the foreground process group and lets a
+# group that is nothing but shells settle the negative verdict; this is the
+# same rule expressed through herdr's own `pane process-info` inventory.
+#
+# The corroboration is positive-only and one strict instantaneous sample, so
+# it is the cheapest possible addition to a read that runs in poll loops and
+# can only ever move a verdict from `live` toward `no-agent`, never the other
+# way. Anything short of proof - a live harness process in the foreground, an
+# extra foreground process, a shell with a child, an unreadable inventory, or
+# a response about a different pane - leaves `live` exactly as before, so a
+# genuinely live, ambiguous, unreadable, or contradicting endpoint is never
+# reclassified as recoverable. An idle shell transiently hosting a prompt
+# helper therefore keeps `live` for that sample; every caller that acts on the
+# negative verdict polls, so the next sample settles it.
 fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   local session=$1 pane_id=$2 out code presence status
   presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane_id")
@@ -1911,7 +1941,13 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   fi
   status=$(printf '%s' "$out" | jq -r '.result.agent.agent_status // empty' 2>/dev/null)
   case "$status" in
-    working|idle|done|blocked) printf 'live' ;;
+    working|idle|done|blocked)
+      if fm_backend_herdr_pane_idle_shell_sample "$session" "$pane_id" >/dev/null 2>&1; then
+        printf 'no-agent'
+      else
+        printf 'live'
+      fi
+      ;;
     *) printf 'unknown' ;;
   esac
 }
@@ -1920,7 +1956,9 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
 # states (dead, no-agent) fm_backend_herdr_pane_agent_state can positively
 # confirm; live and unknown both refuse (1), so an inconclusive read never
 # licenses closing anything. Restored-layout recovery depends on this
-# fail-safe-toward-refusal behavior.
+# fail-safe-toward-refusal behavior. A husk is defined by what the pane IS -
+# gone, or a plain shell - so a pane whose registration outlived its agent is
+# a husk on the same terms as a restored one; the classifier owns that proof.
 fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
   case "$(fm_backend_herdr_pane_agent_state "$1" "$2")" in
     dead|no-agent) return 0 ;;
@@ -1931,8 +1969,10 @@ fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
 # fm_backend_herdr_agent_state: recovery-grade state for the same session-start
 # sweep as the tmux classifier. It reuses the husk classifier rather than
 # creating a second Herdr state machine: a structurally gone pane is `missing`,
-# a confirmed agent-less pane is `dead`, a registered agent is `alive`, and an
-# unexpected or failed API read is `unreadable`.
+# a confirmed agent-less pane is `dead` - including one whose reported
+# registration its own process inventory proves stale - a registered agent
+# that inventory does not contradict is `alive`, and an unexpected or failed
+# API read is `unreadable`.
 fm_backend_herdr_agent_state() {  # <target>
   local target=$1
   fm_backend_herdr_parse_target "$target" || { printf 'unreadable'; return 0; }

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1203,8 +1203,13 @@ fm_backend_herdr_pane_idle_shell_pid() {  # <session> <pane-id>
 }
 
 # fm_backend_herdr_pane_idle_shell_sample: one strict instantaneous
-# observation for fm_backend_herdr_pane_idle_shell_pid, which owns the proof
-# contract and the settle retry.
+# observation of the idle-shell shape.
+# fm_backend_herdr_pane_idle_shell_pid wraps it with the settle retry and owns
+# the proof contract for the destructive close paths.
+# fm_backend_herdr_pane_agent_state instead takes a single sample directly, on
+# purpose: that read runs in poll loops, the retry budget would slow every
+# healthy `live` answer, and its corroboration is positive-only, so a sample
+# lost to a transient prompt helper simply keeps `live` until the next poll.
 fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
   local session=$1 pane=$2 info shell_pid foreground_pgid count
   local process_pid name argv0 shell_name rows stat ps_bin

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -167,6 +167,10 @@
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
+#     __ADDDIRS__  sandbox grants for the ONLY paths the brief lets a worker write
+#                  outside its worktree: state/ (the status file every kind appends)
+#                  plus data/<task-id>/ for a scout's report. Trailing space
+#                  included, empty when the harness needs no grant.
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 #     __WORKTREE__  absolute path to the task worktree
 #     __CURSORBIN__ resolved, cursor-verified executable for a cursor launch
@@ -1232,11 +1236,18 @@ launch_template() {
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
     claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode auto __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # codex runs sandboxed (-s workspace-write) with no escalation path (-a never),
+    # so every write the brief asks for outside the worktree must be granted
+    # explicitly or the model just sees "operation not permitted" and cannot ask.
+    # __ADDDIRS__ carries exactly the brief-permitted paths and nothing else; see
+    # the placeholder note above. Measured: without it a codex crewmate cannot
+    # append its own status file, which is the ONLY way it can report done,
+    # blocked, or needs-decision, so it is mute to the control plane.
     codex)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__-s workspace-write -a never "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__-s workspace-write -a never __ADDDIRS__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__-s workspace-write -a never -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__-s workspace-write -a never __ADDDIRS__-c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
@@ -1260,7 +1271,12 @@ launch_template() {
     # would otherwise block every spawn, since each task gets a fresh worktree
     # path cursor has never seen, and it is also what loads the project hooks.
     # --auto-review --sandbox enabled replaces the former blanket --yolo bypass
-    # with a sandboxed, auto-reviewing autonomy posture. --workspace pins the
+    # with a sandboxed, auto-reviewing autonomy posture, so cursor needs the same
+    # __ADDDIRS__ grant codex does: measured without it, cursor's sandbox refused
+    # the status-file append and its auto-review classifier then parked the turn
+    # on a manual approval prompt, which an unattended crewmate can never clear.
+    # --add-dir adds writable roots; --workspace still pins the single project
+    # root that state/<id>.cursor-session binds the busy fold to. --workspace pins the
     # exact worktree. -w/--worktree is deliberately never passed: it allocates a
     # SECOND worktree under ~/.cursor/worktrees and would break firstmate's
     # isolation contract. The binary is resolved rather than named because
@@ -1269,7 +1285,7 @@ launch_template() {
     # inherited CLAUDECODE cannot outrank cursor's own marker in a process that
     # only reads the environment. Cursor exposes no effort flag, so the shared
     # effort axis is deliberately omitted and stays in task metadata only.
-    cursor) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS __CURSORBIN__ --trust --auto-review --sandbox enabled __MODELFLAG__--workspace __WORKTREE__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    cursor) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS __CURSORBIN__ --trust --auto-review --sandbox enabled __ADDDIRS____MODELFLAG__--workspace __WORKTREE__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     # Kimi Code rejects a positional prompt, so it launches bare and receives
     # only an absolute brief pointer after the TUI readiness gate below.
     # Its turn-end signal is a globally configured Stop hook plus a guarded
@@ -2956,6 +2972,15 @@ sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 sq_worktree=$(shell_quote "$WT")
+# The sandbox grant is derived from the brief, not from convenience: bin/fm-brief.sh
+# permits a worker exactly two writes outside its worktree, the status file at
+# state/<id>.status (every kind) and, for a scout only, data/<id>/report.md. Grant
+# those two directories and nothing else - never $FM_HOME itself, which also holds
+# every other task's worktree, record, and config.
+ADDDIRS="--add-dir $(shell_quote "$STATE") "
+if [ "$KIND" = scout ]; then
+  ADDDIRS="$ADDDIRS--add-dir $(shell_quote "$DATA/$ID") "
+fi
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
@@ -2966,6 +2991,7 @@ LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
+LAUNCH=${LAUNCH//__ADDDIRS__/$ADDDIRS}
 case "$HARNESS" in
   pi|pi-signed) LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"} ;;
   cursor) LAUNCH=${LAUNCH//__CURSORBIN__/"$(shell_quote "$CURSOR_BIN")"} ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1231,12 +1231,12 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode auto __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__-s workspace-write -a never "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__-s workspace-write -a never -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1268,7 +1268,7 @@ launch_template() {
     # inherited CLAUDECODE cannot outrank cursor's own marker in a process that
     # only reads the environment. Cursor exposes no effort flag, so the shared
     # effort axis is deliberately omitted and stays in task metadata only.
-    cursor) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS __CURSORBIN__ --trust --yolo __MODELFLAG__--workspace __WORKTREE__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    cursor) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS __CURSORBIN__ --trust --auto-review --sandbox enabled __MODELFLAG__--workspace __WORKTREE__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     # Kimi Code rejects a positional prompt, so it launches bare and receives
     # only an absolute brief pointer after the TUI readiness gate below.
     # Its turn-end signal is a globally configured Stop hook plus a guarded

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1252,14 +1252,15 @@ launch_template() {
     # session. --always-approve auto-approves every tool execution (verified: the
     # crewmate runs fully autonomously, no permission gate), which an unattended
     # crewmate needs; it is the targeted equivalent of claude's
-    # --dangerously-skip-permissions. grok's turn-end signal does NOT ride the
+    # --permission-mode auto. grok's turn-end signal does NOT ride the
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
-    # Cursor Agent CLI. --trust suppresses the workspace-trust prompt, which
-    # --yolo does NOT cover and which would otherwise block every spawn, since
-    # each task gets a fresh worktree path cursor has never seen. --yolo is the
-    # --force alias whose TUI label is "Run Everything". --workspace pins the
+    # Cursor Agent CLI. --trust suppresses the workspace-trust prompt that
+    # would otherwise block every spawn, since each task gets a fresh worktree
+    # path cursor has never seen, and it is also what loads the project hooks.
+    # --auto-review --sandbox enabled replaces the former blanket --yolo bypass
+    # with a sandboxed, auto-reviewing autonomy posture. --workspace pins the
     # exact worktree. -w/--worktree is deliberately never passed: it allocates a
     # SECOND worktree under ~/.cursor/worktrees and would break firstmate's
     # isolation contract. The binary is resolved rather than named because

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -683,6 +683,10 @@ remote_secondmate_teardown() {
   grep -vE "^- $ID( |$)" "$SECONDMATE_REG" > "$tmp" || true
   mv -f -- "$tmp" "$SECONDMATE_REG"
   status_retire_presentation_task "$STATE" "$ID" || return 1
+# Best-effort fleet usage harvest runs while the task's state files still
+# exist; a harvest failure must never block teardown.
+"$FM_ROOT/bin/fm-usage-harvest.sh" "$ID" >/dev/null \
+  || echo "warning: usage harvest for $ID failed; continuing teardown" >&2
   fm_backlog_atomic_transition remove "$STATE/$ID.meta" "task record" "$STATE" || return 1
   rm -f -- "$STATE/$ID.turn-ended"
   printf 'teardown %s complete (remote %s:%s)\n' "$ID" "$remote_host" "$remote_home"
@@ -2872,6 +2876,10 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 status_retire_presentation_task "$STATE" "$ID" || exit 1
+# Best-effort fleet usage harvest runs while the task's state files still
+# exist; a harvest failure must never block teardown.
+"$FM_ROOT/bin/fm-usage-harvest.sh" "$ID" >/dev/null \
+  || echo "warning: usage harvest for $ID failed; continuing teardown" >&2
 rm -f "$STATE/$ID.turn-ended" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -264,6 +264,7 @@ family_for_basename() {
     fm-cmux-claude-composer-live-e2e.test.sh|\
     fm-composer-matrix-live-e2e.test.sh|\
     fm-codex-continuity-live-e2e.test.sh|fm-grok-continuity-live-e2e.test.sh|\
+    fm-crewmate-autonomy-live-e2e.test.sh|\
     fm-cursor-primary-live-e2e.test.sh|\
     fm-grok-stop-live-e2e.test.sh|fm-harness-adapter-instructions-live-e2e.test.sh|\
     fm-harness-liveness-drift-live-e2e.test.sh|\
@@ -1259,7 +1260,15 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' live-harness-optin
       ;;
-    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
+    bin/fm-spawn.sh)
+      # The launch templates carry each harness's autonomy and sandbox posture,
+      # which only a real harness can answer for; a template edit re-selects the
+      # live crewmate-autonomy guard alongside the portable families.
+      printf '%s\n' backend-dispatch
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' live-harness-optin
+      ;;
+    bin/fm-send.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -268,6 +268,7 @@ family_for_basename() {
     fm-grok-stop-live-e2e.test.sh|fm-harness-adapter-instructions-live-e2e.test.sh|\
     fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-muse-signals-live-e2e.test.sh|\
+    fm-herdr-agent-free-proof-live-e2e.test.sh|\
     fm-herdr-version-floor-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-branch-live-e2e.test.sh|\
     fm-pi-primary-live-e2e.test.sh|\

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -244,6 +244,7 @@ EFFORT=$EFFORT_META
 SPAWNED=$(iso_from_epoch "$START_EPOCH" || true)
 COMPLETED=$(iso_from_epoch "$END_EPOCH" || true)
 
+mkdir -p -- "$DATA"
 jq -cn \
   --arg task "$ID" --arg harness "$HARNESS" \
   --arg model "$MODEL" --arg effort "$EFFORT" \
@@ -259,5 +260,4 @@ jq -cn \
     wall_secs:$wall, turns:$turns,
     input_tokens:$it, cached_input_tokens:$ct, output_tokens:$ot,
     reasoning_tokens:$rt, source:$source}' >> "$DATA/usage-ledger.jsonl.tmp.$$"
-mkdir -p -- "$DATA"
 cat "$DATA/usage-ledger.jsonl.tmp.$$" >> "$LEDGER" && rm -f -- "$DATA/usage-ledger.jsonl.tmp.$$"

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -138,9 +138,14 @@ case "$TURNS" in ''|*[!0-9]*) TURNS=0 ;; esac
 REFDIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-usage-harvest.XXXXXX")
 LEDGER_LOCK=
 LEDGER_LOCK_HELD=0
+# Set once the staging file for the ledger append exists; cleanup owns its
+# removal so a failed append (an unwritable ledger) cannot leave the staging
+# file behind in the fleet data directory.
+LEDGER_TMP=
 harvest_cleanup() {
   local rc=$?
   [ "$LEDGER_LOCK_HELD" != 1 ] || fm_lock_release "$LEDGER_LOCK" || true
+  [ -z "$LEDGER_TMP" ] || rm -f -- "$LEDGER_TMP"
   rm -rf -- "$REFDIR"
   return "$rc"
 }
@@ -298,6 +303,7 @@ fi
 # Test seam: widen the check-to-append window so a concurrency regression (a
 # removed lock) is observable deterministically; unset in production.
 [ -z "${FM_USAGE_HARVEST_APPEND_DELAY:-}" ] || sleep "$FM_USAGE_HARVEST_APPEND_DELAY"
+LEDGER_TMP="$DATA/usage-ledger.jsonl.tmp.$$"
 jq -cn \
   --arg task "$ID" --arg harness "$HARNESS" \
   --arg model "$MODEL" --arg effort "$EFFORT" \
@@ -312,5 +318,5 @@ jq -cn \
     completed_at:(if $completed == "" then null else $completed end),
     wall_secs:$wall, turns:$turns,
     input_tokens:$it, cached_input_tokens:$ct, output_tokens:$ot,
-    reasoning_tokens:$rt, source:$source}' >> "$DATA/usage-ledger.jsonl.tmp.$$"
-cat "$DATA/usage-ledger.jsonl.tmp.$$" >> "$LEDGER" && rm -f -- "$DATA/usage-ledger.jsonl.tmp.$$"
+    reasoning_tokens:$rt, source:$source}' >> "$LEDGER_TMP"
+cat "$LEDGER_TMP" >> "$LEDGER"

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -154,9 +154,6 @@ touch -t "$(epoch_to_touch "$((START_EPOCH - 1))")" "$REFDIR/start"
 touch -t "$(epoch_to_touch "$((END_EPOCH + 1))")" "$REFDIR/end"
 
 LEDGER="$DATA/usage-ledger.jsonl"
-if [ -f "$LEDGER" ] && grep -qF "\"task\":\"$ID\"" "$LEDGER" 2>/dev/null; then
-  exit 0
-fi
 
 SRC=unavailable
 MODEL_LOG=
@@ -271,9 +268,10 @@ SPAWNED=$(iso_from_epoch "$START_EPOCH" || true)
 COMPLETED=$(iso_from_epoch "$END_EPOCH" || true)
 
 mkdir -p -- "$DATA"
-# Serialize the check-and-append: the unlocked pre-check above is only a fast
-# path, so acquire the ledger lock and re-test under it before writing. Two
-# concurrent harvests of the same task then cannot both append a row.
+# Serialize the check-and-append as one critical section: acquire the ledger
+# lock, then test for an existing row for this task and append only when
+# absent. Two concurrent harvests of the same task cannot both pass the
+# existence test and each append a duplicate row.
 LEDGER_LOCK="$DATA/.usage-ledger.lock"
 fm_lock_acquire_wait "$LEDGER_LOCK"
 LEDGER_LOCK_HELD=1

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -21,11 +21,13 @@
 #
 # Wall clock: status-file birth epoch -> status-file mtime epoch; the meta
 # file's mtime is the fallback end when the status file is absent, and a
-# missing birth timestamp falls back to the status mtime as the start.
+# missing birth timestamp falls back to the meta-file mtime (the spawn-time
+# marker, portable where birth time is unavailable) and then the status mtime
+# as the start.
 # Turn estimate: count of "^working:" lines in the status file.
 #
 # Per-request usage sources:
-#   harness=claude: <claude-projects>/<worktree with '/' -> '-'>/*.jsonl in
+#   harness=claude: <claude-projects>/<worktree with '/' and '.' -> '-'>/*.jsonl in
 #     the task window. Each assistant message carries one API request's usage
 #     at .message.usage (input_tokens, cache_read_input_tokens,
 #     cache_creation_input_tokens, output_tokens) and Claude logs one entry
@@ -109,7 +111,7 @@ iso_from_epoch() {  # <epoch>
 }
 
 END_EPOCH=$(file_mtime_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$META")
-START_EPOCH=$(file_birth_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$STATUS" 2>/dev/null || printf '%s' "$END_EPOCH")
+START_EPOCH=$(file_birth_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$META" 2>/dev/null || file_mtime_epoch "$STATUS" 2>/dev/null || printf '%s' "$END_EPOCH")
 WALL=$((END_EPOCH - START_EPOCH))
 [ "$WALL" -ge 0 ] || WALL=0
 TURNS=$(grep -c '^working:' "$STATUS" 2>/dev/null || true)
@@ -155,6 +157,7 @@ case "$HARNESS" in
   claude)
     if [ -n "$WORKTREE" ]; then
       encoded=${WORKTREE//\//-}
+      encoded=${encoded//./-}
       files=$(matched_files "$CLAUDE_DIR/$encoded" 1)
       if [ -n "$files" ]; then
         SRC=claude-projects

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# fm-usage-harvest.sh - append one fleet usage-ledger row for a finished task.
+#
+# Usage: fm-usage-harvest.sh <task-id>
+#
+# Reads state/<task-id>.meta (harness=, model=, effort=, worktree=; the
+# backend window= line is intentionally not consumed because the ledger has no
+# window field) plus the task's state/<task-id>.status timestamps for the task
+# window, then sums the worker's own session-log usage into exactly one JSON
+# line appended to data/usage-ledger.jsonl. data/usage-ledger.jsonl is
+# gitignored runtime data.
+#
+# Ledger line schema (this file is the single owner of that schema; the
+# report script is a consumer):
+#   {"task":<id>,"harness":<name>,"model":<id|null>,"effort":<id|null>,
+#    "spawned_at":<iso|null>,"completed_at":<iso|null>,
+#    "wall_secs":<int>,"turns":<int>,
+#    "input_tokens":<int|null>,"cached_input_tokens":<int|null>,
+#    "output_tokens":<int|null>,"reasoning_tokens":<int|null>,
+#    "source":<claude-projects|codex-sessions|unavailable>}
+#
+# Wall clock: status-file birth epoch -> status-file mtime epoch; the meta
+# file's mtime is the fallback end when the status file is absent, and a
+# missing birth timestamp falls back to the status mtime as the start.
+# Turn estimate: count of "^working:" lines in the status file.
+#
+# Per-request usage sources:
+#   harness=claude: <claude-projects>/<worktree with '/' -> '-'>/*.jsonl in
+#     the task window. Each assistant message carries one API request's usage
+#     at .message.usage (input_tokens, cache_read_input_tokens,
+#     cache_creation_input_tokens, output_tokens) and Claude logs one entry
+#     per content block, so requests are deduped by .message.id before
+#     summing. cached_input_tokens folds cache_read + cache_creation (both
+#     billed on top of input_tokens); reasoning_tokens captures
+#     output_tokens_details.thinking_tokens when present (a subset of
+#     output_tokens).
+#   harness=codex: <codex-sessions>/**/*.jsonl in the task window whose
+#     session_meta cwd equals the meta worktree. Per-turn token_count events
+#     carry one request's delta at .payload.info.last_token_usage
+#     (input_tokens, cached_input_tokens, cache_write_input_tokens,
+#     output_tokens, reasoning_output_tokens); summing those deltas equals the
+#     final cumulative total. cached_input_tokens folds cached + cache_write
+#     (subsets of input_tokens); the model comes from the turn_context.
+#   harness=cursor, an absent log tree, or no in-window match: token fields
+#     are null with source "unavailable".
+# A corrupt log line is skipped best-effort by the parser.
+#
+# Idempotent: if the ledger already contains a line whose "task" is
+# <task-id>, the command exits 0 without appending.
+#
+# Overrides (test seams and alternate homes):
+#   FM_ROOT_OVERRIDE, FM_HOME, FM_STATE_OVERRIDE, FM_DATA_OVERRIDE  as usual
+#   FM_USAGE_CLAUDE_DIR   default $HOME/.claude/projects
+#   FM_USAGE_CODEX_DIR    default $HOME/.codex/sessions
+#
+# Exit status: 0 on a successful or already-present harvest, 1 on a missing
+# task record, missing jq, or an unwritable ledger. Callers that must not
+# block (teardown) own their own guard.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+CLAUDE_DIR="${FM_USAGE_CLAUDE_DIR:-${HOME:-}/.claude/projects}"
+CODEX_DIR="${FM_USAGE_CODEX_DIR:-${HOME:-}/.codex/sessions}"
+
+err() { printf 'error: %s\n' "$1" >&2; }
+
+if [ "$#" -ne 1 ] || [ -z "$1" ] || case "$1" in *[!A-Za-z0-9._-]*) true ;; *) false ;; esac; then
+  err "usage: fm-usage-harvest.sh <task-id>"
+  exit 1
+fi
+command -v jq >/dev/null 2>&1 || { err "jq is required"; exit 1; }
+
+ID=$1
+META="$STATE/$ID.meta"
+STATUS="$STATE/$ID.status"
+[ -f "$META" ] || { err "no task record: $META"; exit 1; }
+
+meta_get() {  # <key>
+  grep "^$1=" "$META" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+HARNESS=$(meta_get harness)
+WORKTREE=$(meta_get worktree)
+MODEL_META=$(meta_get model)
+EFFORT_META=$(meta_get effort)
+
+file_mtime_epoch() {  # <file>
+  local t
+  t=$(stat -f %m -- "$1" 2>/dev/null) || t=$(stat -c %Y -- "$1" 2>/dev/null) || return 1
+  case "$t" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s' "$t"
+}
+file_birth_epoch() {  # <file>
+  local t
+  t=$(stat -f %B -- "$1" 2>/dev/null) || t=$(stat -c %W -- "$1" 2>/dev/null) || return 1
+  # The plausible-epoch guard keeps GNU stat's filesystem-mode %B output
+  # (block size) from being misread as a birth time.
+  case "$t" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$t" -ge 1000000000 ] 2>/dev/null || return 1
+  printf '%s' "$t"
+}
+iso_from_epoch() {  # <epoch>
+  date -r "$1" -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || return 1
+}
+
+END_EPOCH=$(file_mtime_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$META")
+START_EPOCH=$(file_birth_epoch "$STATUS" 2>/dev/null || file_mtime_epoch "$STATUS" 2>/dev/null || printf '%s' "$END_EPOCH")
+WALL=$((END_EPOCH - START_EPOCH))
+[ "$WALL" -ge 0 ] || WALL=0
+TURNS=$(grep -c '^working:' "$STATUS" 2>/dev/null || true)
+case "$TURNS" in ''|*[!0-9]*) TURNS=0 ;; esac
+
+# Ref files pin find's mtime window portably (BSD and GNU find both compare
+# against -newer file mtimes, and touch -t exists on both).
+REFDIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-usage-harvest.XXXXXX")
+trap 'rm -rf -- "$REFDIR"' EXIT
+epoch_to_touch() {  # <epoch>
+  date -r "$1" +%Y%m%d%H%M.%S 2>/dev/null || date -u -d "@$1" +%Y%m%d%H%M.%S
+}
+# find -newer compares sub-second mtimes, so the refs only narrow to
+# [START-1, END+1]; the per-file epoch filter below then applies the true
+# inclusive whole-second window [START_EPOCH, END_EPOCH].
+touch -t "$(epoch_to_touch "$((START_EPOCH - 1))")" "$REFDIR/start"
+touch -t "$(epoch_to_touch "$((END_EPOCH + 1))")" "$REFDIR/end"
+
+LEDGER="$DATA/usage-ledger.jsonl"
+if [ -f "$LEDGER" ] && grep -qF "\"task\":\"$ID\"" "$LEDGER" 2>/dev/null; then
+  exit 0
+fi
+
+SRC=unavailable
+MODEL_LOG=
+matched_files() {  # <dir> <maxdepth-or-empty> : print in-window *.jsonl paths
+  local dir=$1 depthargs=() f m
+  [ -d "$dir" ] || return 0
+  if [ -n "$2" ]; then
+    depthargs=(-maxdepth "$2")
+  fi
+  while IFS= read -r f; do
+    m=$(file_mtime_epoch "$f") || continue
+    if [ "$m" -ge "$START_EPOCH" ] && [ "$m" -le "$END_EPOCH" ]; then
+      printf '%s\n' "$f"
+    fi
+  done < <(find "$dir" ${depthargs[@]+"${depthargs[@]}"} -type f -name '*.jsonl' \
+    -newer "$REFDIR/start" ! -newer "$REFDIR/end" -print 2>/dev/null) || true
+}
+
+IT=null; CT=null; OT=null; RT=null
+case "$HARNESS" in
+  claude)
+    if [ -n "$WORKTREE" ]; then
+      encoded=${WORKTREE//\//-}
+      files=$(matched_files "$CLAUDE_DIR/$encoded" 1)
+      if [ -n "$files" ]; then
+        SRC=claude-projects
+        IT=0; CT=0; OT=0; RT=0
+        # One entry per content block repeats one request's usage; dedupe on
+        # .message.id so every request is counted exactly once.
+        while IFS= read -r f; do
+          row=$(jq -rn '
+            reduce inputs as $l ({seen:{},m:null,it:0,ct:0,ot:0,rt:0};
+              if $l.type == "assistant" and ($l.message.usage // null) != null then
+                ($l.message.id // "no-id") as $id
+                | if .seen[$id] then . else
+                    .seen[$id] = 1
+                    | .it += ($l.message.usage.input_tokens // 0)
+                    | .ct += (($l.message.usage.cache_read_input_tokens // 0)
+                              + ($l.message.usage.cache_creation_input_tokens // 0))
+                    | .ot += ($l.message.usage.output_tokens // 0)
+                    | .rt += ($l.message.usage.output_tokens_details.thinking_tokens // 0)
+                    | (if .m == null then .m = ($l.message.model // null) else . end)
+                  end
+              elif $l.type == "assistant" and ($l.message.model // null) != null and .m == null then
+                .m = $l.message.model
+              else . end)
+            | [.m, .it, .ct, .ot, .rt] | @tsv' "$f" 2>/dev/null || true)
+          [ -n "$row" ] || continue
+          IFS=$'\t' read -r m it ct ot rt <<<"$row"
+          [ -n "$m" ] && [ -z "$MODEL_LOG" ] && MODEL_LOG=$m
+          IT=$((IT + ${it:-0}))
+          CT=$((CT + ${ct:-0}))
+          OT=$((OT + ${ot:-0}))
+          RT=$((RT + ${rt:-0}))
+        done <<FMINNER
+$files
+FMINNER
+      fi
+    fi
+    ;;
+  codex)
+    if [ -n "$WORKTREE" ]; then
+      files=$(matched_files "$CODEX_DIR" "")
+      if [ -n "$files" ]; then
+        IT=0; CT=0; OT=0; RT=0
+        found=0
+        while IFS= read -r f; do
+          row=$(jq -rn '
+            reduce inputs as $l ({cwd:null,m:null,it:0,ct:0,ot:0,rt:0};
+              if $l.type == "session_meta" then
+                .cwd = ($l.payload.cwd // .cwd)
+              elif $l.type == "turn_context" and ($l.payload.model // null) != null then
+                .m = $l.payload.model
+              elif $l.type == "event_msg" and $l.payload.type == "token_count"
+                   and ($l.payload.info.last_token_usage // null) != null then
+                .it += ($l.payload.info.last_token_usage.input_tokens // 0)
+                | .ct += (($l.payload.info.last_token_usage.cached_input_tokens // 0)
+                          + ($l.payload.info.last_token_usage.cache_write_input_tokens // 0))
+                | .ot += ($l.payload.info.last_token_usage.output_tokens // 0)
+                | .rt += ($l.payload.info.last_token_usage.reasoning_output_tokens // 0)
+              else . end)
+            | [.cwd, .m, .it, .ct, .ot, .rt] | @tsv' "$f" 2>/dev/null || true)
+          [ -n "$row" ] || continue
+          IFS=$'\t' read -r cwd m it ct ot rt <<<"$row"
+          [ "$cwd" = "$WORKTREE" ] || continue
+          found=1
+          SRC=codex-sessions
+          [ -n "$m" ] && [ -z "$MODEL_LOG" ] && MODEL_LOG=$m
+          IT=$((IT + ${it:-0}))
+          CT=$((CT + ${ct:-0}))
+          OT=$((OT + ${ot:-0}))
+          RT=$((RT + ${rt:-0}))
+        done <<FMINNER
+$files
+FMINNER
+        [ "$found" -eq 1 ] || SRC=unavailable
+      fi
+    fi
+    ;;
+esac
+
+if [ "$SRC" = unavailable ]; then
+  MODEL_LOG=
+  IT=null; CT=null; OT=null; RT=null
+fi
+
+MODEL=${MODEL_LOG:-$MODEL_META}
+EFFORT=$EFFORT_META
+
+SPAWNED=$(iso_from_epoch "$START_EPOCH" || true)
+COMPLETED=$(iso_from_epoch "$END_EPOCH" || true)
+
+jq -cn \
+  --arg task "$ID" --arg harness "$HARNESS" \
+  --arg model "$MODEL" --arg effort "$EFFORT" \
+  --arg spawned "$SPAWNED" --arg completed "$COMPLETED" \
+  --argjson wall "$WALL" --argjson turns "$TURNS" \
+  --argjson it "$IT" --argjson ct "$CT" --argjson ot "$OT" --argjson rt "$RT" \
+  --arg source "$SRC" \
+  '{task:$task, harness:$harness,
+    model:(if ($model == "" or $model == "default") then null else $model end),
+    effort:(if ($effort == "" or $effort == "default") then null else $effort end),
+    spawned_at:(if $spawned == "" then null else $spawned end),
+    completed_at:(if $completed == "" then null else $completed end),
+    wall_secs:$wall, turns:$turns,
+    input_tokens:$it, cached_input_tokens:$ct, output_tokens:$ot,
+    reasoning_tokens:$rt, source:$source}' >> "$DATA/usage-ledger.jsonl.tmp.$$"
+mkdir -p -- "$DATA"
+cat "$DATA/usage-ledger.jsonl.tmp.$$" >> "$LEDGER" && rm -f -- "$DATA/usage-ledger.jsonl.tmp.$$"

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -70,10 +70,11 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CLAUDE_DIR="${FM_USAGE_CLAUDE_DIR:-${HOME:-}/.claude/projects}"
 CODEX_DIR="${FM_USAGE_CODEX_DIR:-${HOME:-}/.codex/sessions}"
 
-# Portable directory-lock helpers (fm_lock_acquire_wait / fm_lock_release) let
+# Portable directory-lock helpers (fm_lock_try_acquire / fm_lock_release) let
 # the idempotent check-and-append below run as one critical section, so two
 # concurrent harvests of the same task cannot both pass the existence check and
-# each append a duplicate row.
+# each append a duplicate row. The acquire is bounded (see below) so it never
+# blocks the synchronous teardown caller indefinitely.
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
@@ -272,8 +273,24 @@ mkdir -p -- "$DATA"
 # lock, then test for an existing row for this task and append only when
 # absent. Two concurrent harvests of the same task cannot both pass the
 # existence test and each append a duplicate row.
+#
+# The acquire is BOUNDED, not fm_lock_acquire_wait's unbounded spin, because
+# this runs synchronously inside teardown: a wedged live holder must never
+# block teardown from retiring the task. fm_lock_try_acquire already steals a
+# dead owner's lock, so only a live concurrent harvest makes us wait, and its
+# critical section is a grep plus an append. If the lock stays busy past the
+# bound we give up best-effort (exit 1, which teardown warns on and continues)
+# rather than duplicate the row by appending unserialized.
 LEDGER_LOCK="$DATA/.usage-ledger.lock"
-fm_lock_acquire_wait "$LEDGER_LOCK"
+LEDGER_LOCK_WAIT=${FM_USAGE_LEDGER_LOCK_WAIT:-30}
+lock_deadline=$(( $(date +%s) + LEDGER_LOCK_WAIT ))
+until fm_lock_try_acquire "$LEDGER_LOCK"; do
+  if [ "$(date +%s)" -ge "$lock_deadline" ]; then
+    err "ledger lock busy after ${LEDGER_LOCK_WAIT}s; skipping harvest for $ID"
+    exit 1
+  fi
+  sleep 0.1
+done
 LEDGER_LOCK_HELD=1
 if [ -f "$LEDGER" ] && grep -qF "\"task\":\"$ID\"" "$LEDGER" 2>/dev/null; then
   exit 0

--- a/bin/fm-usage-harvest.sh
+++ b/bin/fm-usage-harvest.sh
@@ -43,8 +43,10 @@
 #     output_tokens, reasoning_output_tokens); summing those deltas equals the
 #     final cumulative total. cached_input_tokens folds cached + cache_write
 #     (subsets of input_tokens); the model comes from the turn_context.
-#   harness=cursor, an absent log tree, or no in-window match: token fields
-#     are null with source "unavailable".
+#   harness=cursor, a task with a recorded remote_host (its worker ran on
+#     another machine, so its logs are not on this filesystem), an absent log
+#     tree, or no in-window match: token fields are null with source
+#     "unavailable".
 # A corrupt log line is skipped best-effort by the parser.
 #
 # Idempotent: if the ledger already contains a line whose "task" is
@@ -68,6 +70,13 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CLAUDE_DIR="${FM_USAGE_CLAUDE_DIR:-${HOME:-}/.claude/projects}"
 CODEX_DIR="${FM_USAGE_CODEX_DIR:-${HOME:-}/.codex/sessions}"
 
+# Portable directory-lock helpers (fm_lock_acquire_wait / fm_lock_release) let
+# the idempotent check-and-append below run as one critical section, so two
+# concurrent harvests of the same task cannot both pass the existence check and
+# each append a duplicate row.
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
 err() { printf 'error: %s\n' "$1" >&2; }
 
 if [ "$#" -ne 1 ] || [ -z "$1" ] || case "$1" in *[!A-Za-z0-9._-]*) true ;; *) false ;; esac; then
@@ -88,6 +97,12 @@ HARNESS=$(meta_get harness)
 WORKTREE=$(meta_get worktree)
 MODEL_META=$(meta_get model)
 EFFORT_META=$(meta_get effort)
+# A remote secondmate's worker ran on another machine, so its session logs are
+# not on this filesystem. Harvesting the local claude/codex trees for such a
+# task would at best find nothing and at worst misattribute an unrelated local
+# session that happens to match the worktree path, so a task with a recorded
+# remote_host is recorded as source=unavailable without a local scan.
+REMOTE_HOST=$(meta_get remote_host)
 
 file_mtime_epoch() {  # <file>
   local t
@@ -120,7 +135,15 @@ case "$TURNS" in ''|*[!0-9]*) TURNS=0 ;; esac
 # Ref files pin find's mtime window portably (BSD and GNU find both compare
 # against -newer file mtimes, and touch -t exists on both).
 REFDIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-usage-harvest.XXXXXX")
-trap 'rm -rf -- "$REFDIR"' EXIT
+LEDGER_LOCK=
+LEDGER_LOCK_HELD=0
+harvest_cleanup() {
+  local rc=$?
+  [ "$LEDGER_LOCK_HELD" != 1 ] || fm_lock_release "$LEDGER_LOCK" || true
+  rm -rf -- "$REFDIR"
+  return "$rc"
+}
+trap harvest_cleanup EXIT
 epoch_to_touch() {  # <epoch>
   date -r "$1" +%Y%m%d%H%M.%S 2>/dev/null || date -u -d "@$1" +%Y%m%d%H%M.%S
 }
@@ -155,7 +178,7 @@ matched_files() {  # <dir> <maxdepth-or-empty> : print in-window *.jsonl paths
 IT=null; CT=null; OT=null; RT=null
 case "$HARNESS" in
   claude)
-    if [ -n "$WORKTREE" ]; then
+    if [ -z "$REMOTE_HOST" ] && [ -n "$WORKTREE" ]; then
       encoded=${WORKTREE//\//-}
       encoded=${encoded//./-}
       files=$(matched_files "$CLAUDE_DIR/$encoded" 1)
@@ -196,7 +219,7 @@ FMINNER
     fi
     ;;
   codex)
-    if [ -n "$WORKTREE" ]; then
+    if [ -z "$REMOTE_HOST" ] && [ -n "$WORKTREE" ]; then
       files=$(matched_files "$CODEX_DIR" "")
       if [ -n "$files" ]; then
         IT=0; CT=0; OT=0; RT=0
@@ -248,6 +271,18 @@ SPAWNED=$(iso_from_epoch "$START_EPOCH" || true)
 COMPLETED=$(iso_from_epoch "$END_EPOCH" || true)
 
 mkdir -p -- "$DATA"
+# Serialize the check-and-append: the unlocked pre-check above is only a fast
+# path, so acquire the ledger lock and re-test under it before writing. Two
+# concurrent harvests of the same task then cannot both append a row.
+LEDGER_LOCK="$DATA/.usage-ledger.lock"
+fm_lock_acquire_wait "$LEDGER_LOCK"
+LEDGER_LOCK_HELD=1
+if [ -f "$LEDGER" ] && grep -qF "\"task\":\"$ID\"" "$LEDGER" 2>/dev/null; then
+  exit 0
+fi
+# Test seam: widen the check-to-append window so a concurrency regression (a
+# removed lock) is observable deterministically; unset in production.
+[ -z "${FM_USAGE_HARVEST_APPEND_DELAY:-}" ] || sleep "$FM_USAGE_HARVEST_APPEND_DELAY"
 jq -cn \
   --arg task "$ID" --arg harness "$HARNESS" \
   --arg model "$MODEL" --arg effort "$EFFORT" \

--- a/bin/fm-usage-report.sh
+++ b/bin/fm-usage-report.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# fm-usage-report.sh - plain-text reader for data/usage-ledger.jsonl.
+#
+# Usage: fm-usage-report.sh [ledger-path]
+#
+# Prints per-model totals and one row per task from the usage ledger written
+# by fm-usage-harvest.sh (that file owns the line schema; this script only
+# consumes it). With no argument the ledger resolves from the operational
+# home exactly as the harvester does.
+#
+# Output is aligned plain text; unavailable token fields render as "-".
+# Exit status: 0 including when the ledger is absent or empty.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+
+command -v jq >/dev/null 2>&1 || { printf 'error: jq is required\n' >&2; exit 1; }
+
+LEDGER=${1:-$DATA/usage-ledger.jsonl}
+if [ ! -s "$LEDGER" ]; then
+  printf 'no usage ledger at %s\n' "$LEDGER"
+  exit 0
+fi
+
+printf 'usage ledger: %s (%s rows)\n' "$LEDGER" "$(wc -l < "$LEDGER" | tr -d ' ')"
+echo
+echo "per-model totals (source-available rows):"
+printf '%-24s %6s %12s %12s %12s %12s %10s\n' \
+  model tasks input cached output reasoning wall_secs
+jq -rs '
+  [.[] | select(.source != "unavailable")] | sort_by(.model // "?") | group_by(.model // "?")[]
+  | [ (.[0].model // "?"), (length | tostring),
+      (map(.input_tokens // 0) | add | tostring),
+      (map(.cached_input_tokens // 0) | add | tostring),
+      (map(.output_tokens // 0) | add | tostring),
+      (map(.reasoning_tokens // 0) | add | tostring),
+      (map(.wall_secs // 0) | add | tostring) ] | @tsv' "$LEDGER" |
+while IFS=$'\t' read -r model tasks it ct ot rt wall; do
+  printf '%-24s %6s %12s %12s %12s %12s %10s\n' \
+    "$model" "$tasks" "$it" "$ct" "$ot" "$rt" "$wall"
+done
+echo
+echo "per-task rows:"
+printf '%-24s %-8s %-20s %-8s %12s %12s %12s %12s %10s %-16s\n' \
+  task harness model effort input cached output reasoning wall_secs source
+jq -r '
+  [ .task, .harness,
+    (.model // "-"), (.effort // "-"),
+    (.input_tokens // "-"), (.cached_input_tokens // "-"),
+    (.output_tokens // "-"), (.reasoning_tokens // "-"),
+    (.wall_secs // "-"), .source ] | @tsv' "$LEDGER" |
+while IFS=$'\t' read -r task harness model effort it ct ot rt wall source; do
+  printf '%-24s %-8s %-20s %-8s %12s %12s %12s %12s %10s %-16s\n' \
+    "$task" "$harness" "$model" "$effort" "$it" "$ct" "$ot" "$rt" "$wall" "$source"
+done

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -269,8 +269,18 @@ Create replaces only a confidently dead or no-agent husk, creates the replacemen
 This prevents closing the workspace's last tab before a replacement exists.
 
 The generic Herdr agent-liveness probe reuses the same classifier.
-A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
-Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
+A structurally gone pane becomes `missing`, an agent-free shell becomes `dead`, a registration the pane's processes do not contradict becomes `alive`, and an unexpected read becomes `unreadable`.
+Native registration classifies a harness without guessing from a generic interpreter name, which tmux process-name inspection cannot do.
+
+A reported registration is not evidence on its own.
+Herdr's agent registry is written by whatever reports into it, and a report is not withdrawn when the process that made it goes away, so a registration can outlive the agent it describes.
+The classifier therefore corroborates a reported registration against the pane's own `pane process-info` inventory and treats the registration as stale when that inventory positively proves a lone bare idle shell.
+This is the same rule the tmux classifier already applies from the foreground process group, expressed through Herdr's own inventory.
+
+The corroboration is positive-only and reads one strict instantaneous sample, so it can only move a verdict from `alive` toward `dead`, never the other way.
+A live harness process, an extra foreground process, a shell with a child of its own, an unreadable inventory, and an inventory answering about a different pane all leave the registration standing.
+An idle shell transiently hosting a prompt helper therefore stays `alive` for that sample, and the next poll settles it.
+A pane whose registration outlived its agent is a husk on the same terms as a restored one, so create-time replacement and presentation reclaim treat both identically.
 
 The session-start sweep uses this probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.
@@ -344,7 +354,11 @@ tests/fm-herdr-session-cleanup.test.sh
 tests/fm-herdr-session-cleanup-e2e.test.sh
 tests/fm-afk-inject-herdr-e2e.test.sh
 tests/fm-afk-pi-herdr-return-e2e.test.sh
+tests/fm-herdr-agent-free-proof-live-e2e.test.sh
 ```
+
+`tests/fm-herdr-agent-free-proof-live-e2e.test.sh` is the opt-in drift guard for the agent-free proof: it launches every installed harness for real and fails naming the harness and version if a running one ever proves a bare idle shell.
+Run it after any harness upgrade and refresh the per-harness evidence it prints.
 
 Real Herdr tests use the named lab helper and default-session tripwire.
 [`verification/runtime-backends.md`](verification/runtime-backends.md#herdr) records the active version, CLI, projection, event, and lifecycle evidence without task-specific chronology.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -128,6 +128,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-merge-outcome-lib.sh` | Publish a confirmed merge's durable, role-routed supervision outcome                 |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode, and write the ship instructions carrying that mode's definition of done |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
+| `fm-usage-harvest.sh`    | Append one finished task's token, wall-clock, and turn cost to the gitignored usage ledger (sole owner of the ledger line schema) |
+| `fm-usage-report.sh`     | Read the usage ledger into a plain-text per-model and per-task cost report |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |
 | `fm-x-lib.sh`            | Shared Relay config, relay, and reply-threading helpers                              |

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -966,7 +966,7 @@ This row is a delivery guard for submit acknowledgement only; recorded worker st
 | Slash popup | real: the first Enter closes the popup and a SECOND Enter submits, the same hazard as grok, covered by the submit core's retried Enter |
 
 The `Workspace trust` and `Autonomy` rows record what the `--yolo` flag itself does, measured when that flag was still the launch default.
-`bin/fm-spawn.sh` now launches cursor with `--trust --auto-review --sandbox enabled` instead; the active [Crewmate autonomy and the status-file write contract](#crewmate-autonomy-and-the-status-file-write-contract) record distinguishes its completed readings from the required refresh after each launch-posture change.
+`bin/fm-spawn.sh` now launches cursor with `--trust --auto-review --sandbox enabled` plus the brief-permitted `--add-dir` roots instead, and the [Crewmate autonomy and the status-file write contract](#crewmate-autonomy-and-the-status-file-write-contract) record owns the readings for that posture.
 
 ### Crewmate autonomy and the status-file write contract
 
@@ -983,21 +983,51 @@ The lab home matters because Codex's `workspace-write` sandbox permits `/tmp` an
 
 #### Recorded readings, 2026-09-02
 
-These readings were taken in isolated `fm-lab-` sessions on macOS aarch64 with Herdr 0.8.2.
+Measured on macOS aarch64 with Herdr 0.8.2, in an isolated `fm-lab-` session whose lab `FM_HOME` sat under `$HOME`.
+Harness versions under measurement: Claude Code 2.1.258, Codex CLI 0.152.1, Cursor Agent 2026.08.31-4057e58.
 
-| Harness and version | Unattended launch reading | Status-file write reading |
-| --- | --- | --- |
-| Claude Code 2.1.258 | Not unattended in a fresh worktree: the workspace-trust dialog appeared before the composer under both `--dangerously-skip-permissions` and `--permission-mode auto`. | The crewmate appended its status file successfully after the trust choice was accepted, with Claude reporting `Allowed by auto mode classifier`. |
-| Codex CLI 0.152.1 | Not unattended in a fresh worktree: a directory-trust dialog and then `Hooks need review` appeared before the composer. | Before the narrow `--add-dir` correction, the crewmate's status append failed with `operation not permitted`; the corrected launch has not yet been measured through the guard. |
-| Cursor Agent 2026.08.31-4057e58 | Reached an empty composer under `--trust --auto-review --sandbox enabled` with no key sent. | Not yet measured through the guard. |
+Observed output, exit status 0:
 
-The current Codex and Cursor templates add only the directories `bin/fm-brief.sh` permits outside the task worktree: `state/` for every worker, plus that scout's `data/<id>/` report directory.
-The guard must show both allowed writes succeed and an append to an ungranted sibling directory fails before this table can claim the correction preserves a narrow sandbox boundary.
-The guard also checks that Cursor still records the task worktree as its exact workspace identity after the added writable roots.
+```text
+# herdr: herdr 0.8.2
+# lab home: <$HOME>/.fm-crewmate-autonomy-lab-61295 (status files outside the lab worktree)
+# claude: accepted-workspace-trust
+# claude 2.1.258 (Claude Code): NOT unattended - reached its composer only via accepted-workspace-trust (see the record in docs/verification/runtime-backends.md)
+# claude 2.1.258 (Claude Code): ready=accepted-workspace-trust submit=empty reply=landed
+ok - crewmate write contract: claude 2.1.258 (Claude Code) appends its status file and writes its scout report, both outside its worktree
+# claude 2.1.258 (Claude Code): carries no sandbox flag, and did write outside the brief-permitted directories (/Users/npayette/.fm-crewmate-autonomy-lab-61295/denied/claude-61295.status); its posture is an approval classifier, not a filesystem boundary
+# codex: accepted-directory-trust
+# codex: declined-hook-trust
+# codex codex-cli 0.152.1: NOT unattended - reached its composer only via accepted-directory-trust,declined-hook-trust (see the record in docs/verification/runtime-backends.md)
+# codex codex-cli 0.152.1: ready=accepted-directory-trust,declined-hook-trust submit=empty reply=landed
+ok - crewmate write contract: codex codex-cli 0.152.1 appends its status file and writes its scout report, both outside its worktree
+ok - narrow grant: codex codex-cli 0.152.1 is still refused a write outside the two brief-permitted directories
+ok - unattended launch: cursor 2026.08.31-4057e58 reaches an empty composer with no key sent
+# cursor 2026.08.31-4057e58: ready=unattended submit=empty reply=landed
+ok - crewmate write contract: cursor 2026.08.31-4057e58 appends its status file and writes its scout report, both outside its worktree
+ok - workspace binding: cursor 2026.08.31-4057e58 still records the task worktree as its exact workspacePath under the added writable roots
+ok - narrow grant: cursor 2026.08.31-4057e58 is still refused a write outside the two brief-permitted directories
+# checked 3 installed harness(es) on herdr herdr 0.8.2
+```
+
+| Harness and version | Unattended launch | The two brief-permitted writes | An ungranted sibling path |
+| --- | --- | --- | --- |
+| Claude Code 2.1.258 | Not unattended: the workspace-trust dialog stood before the composer and the guard reached it only via `accepted-workspace-trust`. An earlier reading in this work saw the identical dialog under the former `--dangerously-skip-permissions`, so it is not a consequence of `--permission-mode auto`. | Both landed. | Also landed, and is recorded rather than failed: `--permission-mode auto` is an approval classifier, not a filesystem sandbox, so this posture has no grant to keep narrow. |
+| Codex CLI 0.152.1 | Not unattended: a directory-trust dialog and then `Hooks need review` stood before the composer, cleared as `accepted-directory-trust,declined-hook-trust`. | Both landed under `-s workspace-write -a never` plus the two `--add-dir` grants. | Refused, so the grant is proven narrow rather than merely sufficient. |
+| Cursor Agent 2026.08.31-4057e58 | Unattended: an empty composer with no key sent under `--trust --auto-review --sandbox enabled`. | Both landed under the same two `--add-dir` grants. | Refused, so that grant is proven narrow too. |
+
+The granted set is exactly what `bin/fm-brief.sh` permits a worker outside its worktree: `state/` for the status file every worker appends, plus `data/<id>/` for a scout's report.
+Cursor still records the task worktree as its exact `workspacePath` under the added writable roots, so the `state/<id>.cursor-session` binding the busy fold depends on survives the grant.
+
+The `--add-dir` grant is what turns the Codex reading from broken into passing.
+Without it the same guard measured a Codex crewmate's status append failing with `operation not permitted`, and `-a never` left the model no way to ask, so such a worker could not report done, blocked, or needs-decision at all.
 
 An earlier guard iteration accidentally installed Codex CLI 0.152.1 over 0.150.1 when Enter landed on its update modal.
-Version 0.150.1 remains on disk, and the guard now waits for an empty composer to remain settled for ten seconds and uses Escape to dismiss an update offer before it can submit a prompt.
-Compatibility evidence for Codex 0.152.1 currently covers launch and composer classification only; a focused successful submit remains unrecorded.
+Version 0.150.1 remains on disk, and the guard now waits for an empty composer to stay empty for ten seconds and dismisses an update offer with Escape rather than Enter before it can submit anything.
+The run above is also the Codex 0.152.1 compatibility evidence: it launched through the adapter's own posture, the shared composer classifier read `empty` and held it for the full settle window, and the shared submit path returned `empty` with the crewmate's reply landing in the pane.
+
+Not established here: the guard measures claude, codex, and cursor, so neither axis was read for opencode, pi, grok, kimi, or muse.
+Neither is the captain's own fleet covered, because every reading was taken in a throwaway lab home and lab session rather than a real task.
 
 ### End-to-end
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -966,7 +966,7 @@ This row is a delivery guard for submit acknowledgement only; recorded worker st
 | Slash popup | real: the first Enter closes the popup and a SECOND Enter submits, the same hazard as grok, covered by the submit core's retried Enter |
 
 The `Workspace trust` and `Autonomy` rows record what the `--yolo` flag itself does, measured when that flag was still the launch default.
-`bin/fm-spawn.sh` now launches cursor with `--trust --auto-review --sandbox enabled` instead, and no measurement of that posture is recorded here.
+`bin/fm-spawn.sh` now launches cursor with `--trust --auto-review --sandbox enabled` instead; that posture is measured under [Crewmate autonomy and the status-file write contract](#crewmate-autonomy-and-the-status-file-write-contract).
 
 ### End-to-end
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -267,7 +267,7 @@ This guard is the refresh command after any harness upgrade; it spends a small n
 ## Herdr
 
 The compatibility floor is protocol 14.
-The whole real-Herdr lane's latest active verification uses both Herdr 0.7.4 protocol 16 and Herdr 0.8.0 protocol 19 on macOS aarch64, while focused Herdr 0.7.5 protocol 17, earlier protocol-16, protocol-14, and 0.7.3 evidence is retained where it defines current behavior or fallbacks.
+The whole real-Herdr lane's latest active verification uses both Herdr 0.7.4 protocol 16 and Herdr 0.8.0 protocol 19 on macOS aarch64, with agent lifecycle control and the agent-free proof measured on Herdr 0.8.2, while focused Herdr 0.7.5 protocol 17, earlier protocol-16, protocol-14, and 0.7.3 evidence is retained where it defines current behavior or fallbacks.
 Protocol 17 keeps every protocol-16 feature gate satisfied; the event and workspace-move floors remain 16.
 Default-on presentation projection has its own floor at Herdr 0.8.0, protocol 19, verified below.
 
@@ -964,6 +964,9 @@ This row is a delivery guard for submit acknowledgement only; recorded worker st
 | Exit | `/exit` |
 | Skill invocation | `/<skill>`; cursor discovers firstmate's user-level skills, and `/no-mistakes` autocompleted with firstmate's own description and invoked the skill |
 | Slash popup | real: the first Enter closes the popup and a SECOND Enter submits, the same hazard as grok, covered by the submit core's retried Enter |
+
+The `Workspace trust` and `Autonomy` rows record what the `--yolo` flag itself does, measured when that flag was still the launch default.
+`bin/fm-spawn.sh` now launches cursor with `--trust --auto-review --sandbox enabled` instead, and no measurement of that posture is recorded here.
 
 ### End-to-end
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -635,24 +635,71 @@ Polling remained active and is covered as the fallback for capability, connect, 
 
 ### Agent lifecycle control
 
-Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-08-08 on Herdr 0.8.0, and first measured 2026-08-02 on Herdr 0.7.5 with identical results:
+Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-09-01 on Herdr 0.8.2, and first measured 2026-08-02 on Herdr 0.7.5:
 
 ```sh
 tests/fm-control-herdr-smoke.test.sh
 ```
 
-Observed output:
+Observed output on Herdr 0.8.2:
 
 ```text
 ok - real herdr: exit on a pane with no registered agent is idempotent success
 ok - real herdr: interrupt refuses when herdr's own agent registry reports no agent
+ok - real herdr: a reported registration the pane's own process inventory contradicts reads agent-free
+ok - real herdr: an exited worker's pane is positively eligible for its replacement instead of being typed into
+ok - real herdr: interrupt still refuses on a pane whose registration outlived its agent
+ok - real herdr: the same registration over a running foreground process stays alive
 ok - real herdr: interrupt delivers the harness's key and proves the agent survived it
-ok - real herdr: no control verb removed the endpoint or the task's local copy
 ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
+ok - real herdr: no control verb removed the endpoint, the task's local copy, or its branch
 ```
 
-The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
-That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
+The registry written through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so the case drives the registry and the pane's processes apart deliberately and runs the identical registered reading twice: once over a plain shell and once over a real foreground process, with no real agent launched.
+
+Herdr 0.8.2 keeps such a report registered even though the pane runs nothing but its shell, measured in an isolated `fm-lab-` session:
+
+```text
+herdr pane report-agent <pane> --source fm-control-smoke --agent fm-control-smoke-agent --state idle
+herdr agent get <pane>   -> {"agent_status":"idle"}
+herdr pane process-info  -> foreground_processes [{"name":"zsh","argv0":"zsh"}]
+```
+
+That is why the classifier corroborates the registry against the pane's own inventory rather than trusting a reported registration alone.
+Herdr does validate a report claiming a source it owns itself: an otherwise identical `--source herdr:pi --agent pi` report on the same shell-only pane was rejected and `agent get` still answered `agent_not_found`.
+
+`tests/fm-control-herdr-smoke.test.sh` is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
+
+### Agent-free proof across installed harnesses
+
+The classifier's negative verdict rests on `pane process-info` naming a lone bare idle shell, and both that name and its argv0 come from the harness vendor, so the proof is measured against every installed harness rather than a stub.
+Measured 2026-09-01 on Herdr 0.8.2, macOS aarch64, in an isolated `fm-lab-` session:
+
+```sh
+FM_HERDR_AGENT_FREE_PROOF=1 tests/fm-herdr-agent-free-proof-live-e2e.test.sh
+```
+
+Observed output:
+
+```text
+# herdr: herdr 0.8.2
+# claude 2.1.252 (Claude Code): foreground=[2.1.252/claude] state=alive
+ok - herdr agent-free proof: claude 2.1.252 (Claude Code) running in a Herdr pane never proves a bare idle shell
+# codex codex-cli 0.150.1: foreground=[codex/codex] state=alive
+ok - herdr agent-free proof: codex codex-cli 0.150.1 running in a Herdr pane never proves a bare idle shell
+# opencode 1.17.11: foreground=[opencode/opencode] state=alive
+ok - herdr agent-free proof: opencode 1.17.11 running in a Herdr pane never proves a bare idle shell
+# pi 0.84.4: foreground=[node/pi] state=alive
+ok - herdr agent-free proof: pi 0.84.4 running in a Herdr pane never proves a bare idle shell
+# cursor 2026.08.31-4057e58: foreground=[node/cursor-agent] state=alive
+ok - herdr agent-free proof: cursor 2026.08.31-4057e58 running in a Herdr pane never proves a bare idle shell
+# unverified on this machine (not installed): pi-signed grok kimi muse
+# checked 5 installed harness(es) on herdr herdr 0.8.2 in workspace w1
+```
+
+Every installed harness owns the pane's foreground under its own argv0, so none can satisfy the shell-only proof, and Herdr registered each of them within the guard's wait.
+`pi-signed`, `grok`, `kimi`, and `muse` were not installed on that machine and remain unverified here; the guard reports them explicitly and refuses a pass that checked nothing.
+This is the command that refreshes this record; run it after every harness upgrade.
 
 ### Away-mode transport
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -966,7 +966,38 @@ This row is a delivery guard for submit acknowledgement only; recorded worker st
 | Slash popup | real: the first Enter closes the popup and a SECOND Enter submits, the same hazard as grok, covered by the submit core's retried Enter |
 
 The `Workspace trust` and `Autonomy` rows record what the `--yolo` flag itself does, measured when that flag was still the launch default.
-`bin/fm-spawn.sh` now launches cursor with `--trust --auto-review --sandbox enabled` instead; that posture is measured under [Crewmate autonomy and the status-file write contract](#crewmate-autonomy-and-the-status-file-write-contract).
+`bin/fm-spawn.sh` now launches cursor with `--trust --auto-review --sandbox enabled` instead; the active [Crewmate autonomy and the status-file write contract](#crewmate-autonomy-and-the-status-file-write-contract) record distinguishes its completed readings from the required refresh after each launch-posture change.
+
+### Crewmate autonomy and the status-file write contract
+
+`tests/fm-crewmate-autonomy-live-e2e.test.sh` is the opt-in real-harness guard for the launch and write contract.
+Run it after a harness upgrade or a `bin/fm-spawn.sh` launch-template change:
+
+```sh
+FM_CREWMATE_AUTONOMY_LIVE=1 tests/fm-crewmate-autonomy-live-e2e.test.sh
+```
+
+The guard creates a private `fm-lab-` Herdr session and a lab `FM_HOME` below `$HOME`, never the default session or `/tmp`.
+It first sends no key and reports whether the harness reached its composer without a dialog, then submits one prompt asking the crewmate itself to append its status file and a scout report while attempting one ungranted sibling path.
+The lab home matters because Codex's `workspace-write` sandbox permits `/tmp` and `$TMPDIR` by default, which would make a status-file write there vacuous.
+
+#### Recorded readings, 2026-09-02
+
+These readings were taken in isolated `fm-lab-` sessions on macOS aarch64 with Herdr 0.8.2.
+
+| Harness and version | Unattended launch reading | Status-file write reading |
+| --- | --- | --- |
+| Claude Code 2.1.258 | Not unattended in a fresh worktree: the workspace-trust dialog appeared before the composer under both `--dangerously-skip-permissions` and `--permission-mode auto`. | The crewmate appended its status file successfully after the trust choice was accepted, with Claude reporting `Allowed by auto mode classifier`. |
+| Codex CLI 0.152.1 | Not unattended in a fresh worktree: a directory-trust dialog and then `Hooks need review` appeared before the composer. | Before the narrow `--add-dir` correction, the crewmate's status append failed with `operation not permitted`; the corrected launch has not yet been measured through the guard. |
+| Cursor Agent 2026.08.31-4057e58 | Reached an empty composer under `--trust --auto-review --sandbox enabled` with no key sent. | Not yet measured through the guard. |
+
+The current Codex and Cursor templates add only the directories `bin/fm-brief.sh` permits outside the task worktree: `state/` for every worker, plus that scout's `data/<id>/` report directory.
+The guard must show both allowed writes succeed and an append to an ungranted sibling directory fails before this table can claim the correction preserves a narrow sandbox boundary.
+The guard also checks that Cursor still records the task worktree as its exact workspace identity after the added writable roots.
+
+An earlier guard iteration accidentally installed Codex CLI 0.152.1 over 0.150.1 when Enter landed on its update modal.
+Version 0.150.1 remains on disk, and the guard now waits for an empty composer to remain settled for ten seconds and uses Escape to dismiss an update offer before it can submit a prompt.
+Compatibility evidence for Codex 0.152.1 currently covers launch and composer classification only; a focused successful submit remains unrecorded.
 
 ### End-to-end
 

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -1401,6 +1401,8 @@ assert_no_projection_mutation_since "$START" "agent-free duplicate-token recover
 lab workspace get "$DUP1_WSID" >/dev/null 2>&1 || fail "duplicate-token recovery removed the first quarantined workspace"
 lab workspace get "$DUP2_WSID" >/dev/null 2>&1 || fail "duplicate-token recovery removed the second quarantined workspace"
 
+herdr_pane_run_foreground "$HERDR_LAB_SESSION" "$DUP1_PANE" \
+  || fail "could not give the duplicate-live-agent risk fixture a running foreground process"
 lab pane report-agent "$DUP1_PANE" --source fm-projection-e2e --agent test-agent --state idle >/dev/null \
   || fail "could not register the duplicate-live-agent risk fixture"
 START=$(log_line_count)

--- a/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
+++ b/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
@@ -159,11 +159,16 @@ WS_COUNT=$(printf '%s' "$WS_TABS" | jq -r '.result.tabs? // [] | length')
 pass "fixed: the workspace holds exactly the 2 replacement tabs after both respawns - no leaked husk tabs, no destroyed workspace"
 
 # --- 4. a GENUINELY live duplicate still refuses, unchanged -----------------
-# Register a real agent (herdr's own native registration primitive) on one of
-# the freshly-respawned panes, then confirm a further same-labeled spawn
-# attempt refuses exactly as before - the husk fix must never touch a pane
-# that actually has something registered in it.
+# Give one of the freshly-respawned panes a real running foreground process and
+# register a real agent on it (herdr's own native registration primitive), then
+# confirm a further same-labeled spawn attempt refuses exactly as before - the
+# husk fix must never touch a pane that is actually running something.
+# Both halves matter: a registration standing over a bare idle shell is the
+# husk shape, because a report is not withdrawn when the process that made it
+# goes away (docs/herdr-backend.md "Restart and liveness behavior").
 
+herdr_pane_run_foreground "$SESSION" "$NEW_CREW_PANE_ID" \
+  || fail "could not give the respawned crewmate-shaped pane a running foreground process"
 herdr pane report-agent "$NEW_CREW_PANE_ID" --source fm-respawn-e2e --agent fm-respawn-live-agent --state idle --session "$SESSION" >/dev/null 2>&1 \
   || fail "could not register a live agent on the respawned crewmate-shaped pane"
 

--- a/tests/fm-backend-herdr-smoke.test.sh
+++ b/tests/fm-backend-herdr-smoke.test.sh
@@ -121,6 +121,11 @@ pass "real herdr: create_task prunes the freshly-created workspace's seeded defa
 
 # 1. A genuinely LIVE duplicate (a real registered agent, via herdr's own
 #    `pane report-agent`) must still refuse exactly as before.
+#    "Genuinely live" means both halves the classifier reads: a registration
+#    AND a pane that is actually running something. A registration standing
+#    over a bare idle shell is the husk shape instead, because a report is not
+#    withdrawn when the process that made it goes away
+#    (docs/herdr-backend.md "Restart and liveness behavior").
 LIVE_DUP_LABEL="fm-smoke-livedup"
 LIVE_DUP_IDS=$(fm_backend_herdr_create_task "$CONTAINER" "$LIVE_DUP_LABEL" /tmp) || fail "could not create the live-duplicate scenario's tab"
 read -r LIVE_DUP_TAB_ID LIVE_DUP_PANE_ID <<EOF
@@ -129,6 +134,8 @@ EOF
 if [ -z "$LIVE_DUP_TAB_ID" ] || [ -z "$LIVE_DUP_PANE_ID" ]; then
   fail "live-duplicate scenario tab creation did not return ids"
 fi
+herdr_pane_run_foreground "$SESSION" "$LIVE_DUP_PANE_ID" \
+  || fail "could not give the live-duplicate scenario's pane a running foreground process"
 herdr pane report-agent "$LIVE_DUP_PANE_ID" --source fm-smoke-test --agent fm-smoke-live-agent --state idle --session "$SESSION" >/dev/null 2>&1 \
   || fail "could not register a live agent on the live-duplicate scenario's pane"
 if fm_backend_herdr_create_task "$CONTAINER" "$LIVE_DUP_LABEL" /tmp >/dev/null 2>&1; then

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -925,15 +925,22 @@ test_registration_over_an_ambiguous_inventory_stays_alive() {
 }
 
 test_registration_over_a_shell_with_a_child_stays_alive() {
-  local dir bgpid out
+  local dir bgpid out attempt=0 child=
   dir="$TMP_ROOT/reg-child"
   # A real shell that is genuinely running something: the trailing `true` keeps
   # bash from exec-ing away, so the child row is real.
   bash -c 'sleep 300; true' & bgpid=$!
   # Give the real child a moment to exist before the proof reads the table.
-  while [ -z "$(ps -axo ppid= -o pid= 2>/dev/null | awk -v p="$bgpid" '$1 == p {print $2}')" ]; do
+  while [ "$attempt" -lt 200 ]; do
+    child=$(ps -axo ppid= -o pid= 2>/dev/null | awk -v p="$bgpid" '$1 == p {print $2}')
+    [ -n "$child" ] && break
     sleep 0.05
+    attempt=$((attempt + 1))
   done
+  if [ -z "$child" ]; then
+    kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+    fail "ps never reported a child of the backgrounded shell $bgpid, so this case cannot exercise a shell that is running something"
+  fi
   out=$(agent_state_case "$dir" w1:p2 \
     '{"result":{"agent":{"agent_status":"idle"}}}' \
     "$(bare_shell_inventory w1:p2 "$bgpid")")

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -835,6 +835,185 @@ test_create_task_creates_and_parses_ids() {
   pass "fm_backend_herdr_create_task: creates a tab and parses tab_id/pane_id from the JSON response, prunes nothing when no seeded tab id is given"
 }
 
+# --- a reported registration corroborated against the process inventory ------
+#
+# Herdr's agent registry is written by whatever reports into it, and a report
+# is not withdrawn when the process that made it goes away. A task whose worker
+# had exited to its shell therefore read `alive` forever: every lifecycle verb
+# typed the harness's exit command into a shell and refused to relaunch, with
+# no state that could ever clear it. The classifier now settles the negative
+# verdict from the pane's own `pane process-info` inventory, exactly as the
+# tmux classifier already settles it from the foreground process group.
+#
+# These cases drive the two signals apart deliberately with REAL processes and
+# no harness: the same registered `idle` reading resolves to `no-agent` or to
+# `live` purely from the inventory beside it. Only a positive proof of a lone
+# bare idle shell downgrades the verdict; a live process, an extra foreground
+# process, a shell with a child, an unreadable inventory, and an inventory
+# about a different pane all keep `live`.
+
+process_info_fixture() {  # <pane> <shell-pid> <fg-pgid> <foreground-processes-json>
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"%s","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":%s}}}\n' \
+    "$1" "$2" "$3" "$4"
+}
+
+# bare_shell_inventory: the inventory herdr reports for a pane whose agent has
+# exited - one foreground process, which is the pane's own shell. Backed by a
+# REAL pid so the operating-system half of the proof (exactly one row, no
+# child, sleeping) is answered by the real `ps`, never a stub.
+bare_shell_inventory() {  # <pane> <real-pid>
+  process_info_fixture "$1" "$2" "$2" \
+    "$(printf '[{"pid":%s,"name":"zsh","argv0":"zsh"}]' "$2")"
+}
+
+# agent_state_case: run both classifier entry points over one canned
+# pane-get/agent-get/process-info sequence and echo "<pane-state> <agent-state>".
+agent_state_case() {  # <dir> <pane> <agent-get-json> [<process-info-json>]
+  local dir=$1 pane=$2 agent_json=$3 proc_json=${4:-} log resp fb
+  mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"%s"}}}\n' "$pane" > "$resp/1.out"
+  printf '%s' "$agent_json" > "$resp/2.out"
+  [ -z "$proc_json" ] || printf '%s' "$proc_json" > "$resp/3.out"
+  printf '{"result":{"pane":{"pane_id":"%s"}}}\n' "$pane" > "$resp/4.out"
+  printf '%s' "$agent_json" > "$resp/5.out"
+  [ -z "$proc_json" ] || printf '%s' "$proc_json" > "$resp/6.out"
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"
+      printf "%s %s" \
+        "$(fm_backend_herdr_pane_agent_state fmtest "$1")" \
+        "$(fm_backend_herdr_agent_state "fmtest:$1")"' "$ROOT" "$pane"
+}
+
+test_stale_registration_over_a_bare_idle_shell_is_agent_free() {
+  local dir bgpid stale live
+  dir="$TMP_ROOT/reg-stale"
+  # A real, bare, idle process with no child of its own: the operating-system
+  # half of the idle-shell proof is answered by the real `ps`.
+  sleep 300 & bgpid=$!
+  stale=$(agent_state_case "$dir/shell" w1:p2 \
+    '{"result":{"agent":{"agent_status":"idle"}}}' \
+    "$(bare_shell_inventory w1:p2 "$bgpid")")
+  # The SAME registered reading, with a live harness process in the pane
+  # instead. Asserting both halves keeps the case from going vacuous: the
+  # downgrade must come from the inventory, never from the registration.
+  live=$(agent_state_case "$dir/live" w1:p2 \
+    '{"result":{"agent":{"agent_status":"idle"}}}' \
+    "$(process_info_fixture w1:p2 "$bgpid" 4242 '[{"pid":4242,"name":"node","argv0":"pi"}]')")
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  [ "$stale" = "no-agent dead" ] \
+    || fail "a registration whose pane holds only a bare idle shell must classify agent-free, got '$stale'"
+  [ "$live" = "live alive" ] \
+    || fail "the same registration with a live harness process in the pane must stay alive, got '$live'"
+  pass "herdr agent state: a reported registration contradicted by a lone bare idle shell reads agent-free, while the identical registration over a live process stays alive"
+}
+
+test_registration_over_an_ambiguous_inventory_stays_alive() {
+  local dir bgpid out
+  dir="$TMP_ROOT/reg-ambiguous"
+  sleep 300 & bgpid=$!
+  # An idle shell transiently hosting a prompt helper: two foreground
+  # processes, so nothing is proved and the registration stands.
+  out=$(agent_state_case "$dir" w1:p2 \
+    '{"result":{"agent":{"agent_status":"working"}}}' \
+    "$(process_info_fixture w1:p2 "$bgpid" "$bgpid" \
+      "$(printf '[{"pid":99998,"name":"starship","argv0":"starship"},{"pid":%s,"name":"zsh","argv0":"zsh"}]' "$bgpid")")")
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  [ "$out" = "live alive" ] \
+    || fail "an ambiguous process inventory must never downgrade a registration, got '$out'"
+  pass "herdr agent state: an ambiguous process inventory leaves a registered agent alive rather than licensing recovery"
+}
+
+test_registration_over_a_shell_with_a_child_stays_alive() {
+  local dir bgpid out
+  dir="$TMP_ROOT/reg-child"
+  # A real shell that is genuinely running something: the trailing `true` keeps
+  # bash from exec-ing away, so the child row is real.
+  bash -c 'sleep 300; true' & bgpid=$!
+  # Give the real child a moment to exist before the proof reads the table.
+  while [ -z "$(ps -axo ppid= -o pid= 2>/dev/null | awk -v p="$bgpid" '$1 == p {print $2}')" ]; do
+    sleep 0.05
+  done
+  out=$(agent_state_case "$dir" w1:p2 \
+    '{"result":{"agent":{"agent_status":"idle"}}}' \
+    "$(bare_shell_inventory w1:p2 "$bgpid")")
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  [ "$out" = "live alive" ] \
+    || fail "a shell that still has a child of its own is not idle and must stay alive, got '$out'"
+  pass "herdr agent state: a shell running a child of its own never proves an agent-free pane"
+}
+
+test_registration_with_an_unreadable_inventory_stays_alive() {
+  local dir out
+  dir="$TMP_ROOT/reg-unreadable"
+  # No process-info response at all: the fake answers empty, exactly as a
+  # failed or unparseable inventory read would.
+  out=$(agent_state_case "$dir" w1:p2 '{"result":{"agent":{"agent_status":"idle"}}}')
+  [ "$out" = "live alive" ] \
+    || fail "an unreadable process inventory must leave the registration standing, got '$out'"
+  pass "herdr agent state: an unreadable process inventory leaves a registered agent alive"
+}
+
+test_registration_with_an_inventory_for_another_pane_stays_alive() {
+  local dir bgpid out
+  dir="$TMP_ROOT/reg-other-pane"
+  sleep 300 & bgpid=$!
+  # A bare-idle-shell inventory that answers about a DIFFERENT pane: the
+  # reading belongs to something else and can never settle this pane.
+  out=$(agent_state_case "$dir" w1:p2 \
+    '{"result":{"agent":{"agent_status":"idle"}}}' \
+    "$(bare_shell_inventory w9:p9 "$bgpid")")
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  [ "$out" = "live alive" ] \
+    || fail "an inventory about another pane must never settle this pane's state, got '$out'"
+  pass "herdr agent state: a process inventory answering about a different pane never downgrades this pane's registration"
+}
+
+test_unregistered_pane_never_reads_the_process_inventory() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/reg-absent"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w1:p2' "$ROOT")
+  [ "$out" = no-agent ] || fail "an unregistered pane must still read no-agent, got '$out'"
+  assert_not_contains "$(cat "$log")" $'pane\x1fprocess-info' \
+    "an already-agent-free pane must not pay for the corroborating inventory read"
+  pass "herdr agent state: an unregistered pane is agent-free without reading the process inventory at all"
+}
+
+test_create_task_replaces_a_stale_registration_husk() {
+  local dir log resp fb bgpid out tab pane
+  dir="$TMP_ROOT/husk-stale-registration"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  sleep 300 & bgpid=$!
+  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-husk3","workspace_id":"w1"}]}}\n' > "$resp/1.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
+  # 4: agent get -> still registered, because nothing ever withdrew the report
+  printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/4.out"
+  # 5: pane process-info -> the pane is a lone bare idle shell
+  bare_shell_inventory w1:p2 "$bgpid" > "$resp/5.out"
+  # 6: tab create -> the replacement tab, created BEFORE the husk is closed
+  printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/6.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk3","workspace_id":"w1"}]}}\n' > "$resp/8.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-husk3 /tmp/proj' "$ROOT" ) \
+    || { kill "$bgpid" 2>/dev/null; fail "create_task should replace a duplicate whose registration outlived its agent"; }
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  read -r tab pane <<EOF
+$out
+EOF
+  if [ "$tab" != "w1:t3" ] || [ "$pane" != "w1:p3" ]; then
+    fail "create_task should echo the NEW tab/pane ids, got '$out'"
+  fi
+  assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''close'$'\x1f''w1:t2' \
+    "create_task did not close the stale-registration husk's tab"
+  pass "fm_backend_herdr_create_task: a same-labeled tab whose registration outlived its agent is a husk on the same terms as a restored shell"
+}
+
 # --- container_ensure / create_task: --no-focus and per-home label ----------
 
 test_container_ensure_creates_with_no_focus_flag() {
@@ -4513,6 +4692,13 @@ test_create_task_refuses_duplicate_label_when_agent_live
 test_create_task_refuses_when_any_duplicate_label_is_live
 test_create_task_closes_and_replaces_dead_pane_husk
 test_create_task_closes_and_replaces_no_agent_husk
+test_stale_registration_over_a_bare_idle_shell_is_agent_free
+test_registration_over_an_ambiguous_inventory_stays_alive
+test_registration_over_a_shell_with_a_child_stays_alive
+test_registration_with_an_unreadable_inventory_stays_alive
+test_registration_with_an_inventory_for_another_pane_stays_alive
+test_unregistered_pane_never_reads_the_process_inventory
+test_create_task_replaces_a_stale_registration_husk
 test_create_task_closes_all_duplicate_husks_after_replacement
 test_create_task_refuses_when_preexisting_husk_tab_remains
 test_create_task_refuses_when_agent_state_ambiguous

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -520,7 +520,7 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
   assert_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-spawn'$'\x1f''--text'$'\x1f''export GOTMPDIR=/tmp/fm-orcaspawnz1/gotmp'$'\x1f''--enter'$'\x1f''--json' \
     "spawn did not export GOTMPDIR through the Orca terminal"
-  assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions" \
+  assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode auto" \
     "spawn did not send the selected harness launch command through Orca"
   rm -rf "/tmp/fm-$id"
   pass "fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness"

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -7,11 +7,17 @@
 # agent-state classifier the control plane is allowed to trust, so its
 # behavior is pinned here against the REAL binary rather than a stub: whether
 # an agent is running, and therefore whether a lifecycle verb may act at all,
-# comes from herdr's own agent registry.
+# comes from herdr's own agent registry corroborated against its own process
+# inventory.
 #
-# No real agent is launched. herdr's `pane report-agent` is the same registry
-# the adapter reads, so registering and not registering an agent on a plain
-# shell pane exercises exactly the classification the control plane gates on.
+# The two signals are driven apart deliberately, because a registration alone
+# is not evidence that an agent exists. herdr's `pane report-agent` is the same
+# registry the adapter reads, and a report is not withdrawn when the process
+# that made it goes away, so an identical registered reading is exercised twice
+# over: once on a pane holding nothing but its shell (the worker already
+# exited - agent-free, and eligible for the same-task replacement its operator
+# is trying to launch), and once on a pane genuinely running a foreground
+# process (alive, and a lifecycle verb that cannot stop it must say so).
 #
 # Always runs on a private, named, throwaway lab session, never the default
 # one (tests/herdr-test-safety.sh; the 2026-07-02 incident). Skips cleanly
@@ -71,12 +77,15 @@ $TASK_IDS
 EOF
 [ -n "$TAB_ID" ] && [ -n "$PANE_ID" ] || fail "create_task did not return tab/pane ids"
 
+# harness=pi, the harness of the task this case was written from: its exit
+# command is /quit, which is exactly what a stale classification would type
+# into a shell.
 {
   echo "window=$SESSION:$PANE_ID"
   echo "endpoint_task_id=hsmoke"
   echo "worktree=$WT"
   echo "project=$PROJ"
-  echo "harness=claude"
+  echo "harness=pi"
   echo "kind=ship"
   echo "mode=no-mistakes"
   echo "yolo=off"
@@ -93,6 +102,20 @@ run_control() {
   env FM_HOME="$HOME_DIR" HERDR_SESSION="$SESSION" \
     FM_CONTROL_POLL=0.2 FM_CONTROL_EXIT_WAIT=2 \
     "$ROOT/bin/fm-control.sh" "$@" 2>&1
+}
+
+register_agent() {  # <state>
+  herdr pane report-agent "$PANE_ID" --source fm-control-smoke \
+    --agent fm-control-smoke-agent --state "$1" --session "$SESSION" >/dev/null 2>&1
+}
+
+pane_text() {
+  herdr pane read "$PANE_ID" --session "$SESSION" 2>/dev/null || true
+}
+
+registered_status() {
+  herdr agent get "$PANE_ID" --session "$SESSION" 2>/dev/null \
+    | jq -r '.result.agent.agent_status // empty' 2>/dev/null
 }
 
 # --- no registered agent: the endpoint exists but hosts no agent ------------
@@ -113,30 +136,76 @@ case "$OUT" in
 esac
 pass "real herdr: interrupt refuses when herdr's own agent registry reports no agent"
 
-# --- a registered agent: classification flips, and the verbs follow ---------
+# --- a registration the pane's own processes contradict ---------------------
+#
+# The worker exited to its shell and nothing withdrew its report. Trusting the
+# registry alone left the task alive forever, so every replacement attempt
+# typed the harness's exit command into a shell and refused to relaunch.
 
-herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-smoke-agent \
-  --state idle --session "$SESSION" >/dev/null 2>&1 \
-  || fail "could not register a live agent on the task pane"
+register_agent idle || fail "could not leave a registration on the task pane"
+[ -n "$(registered_status)" ] \
+  || fail "herdr did not keep the registration, so this case cannot exercise the contradiction"
 
 STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
-[ "$STATE" = alive ] || fail "herdr should classify a registered agent as alive, got '$STATE'"
+[ "$STATE" = dead ] \
+  || fail "a registration whose pane holds only its shell must classify agent-free, got '$STATE'"
+pass "real herdr: a reported registration the pane's own process inventory contradicts reads agent-free"
+
+OUT=$(run_control hsmoke exit) \
+  || fail "exit should be idempotent success once the pane is proved agent-free: $OUT"
+case "$OUT" in
+  "already-stopped hsmoke"*) : ;;
+  *) fail "an agent-free pane should report already-stopped, got: $OUT" ;;
+esac
+case "$(pane_text)" in
+  *"/quit"*) fail "exit typed the harness's exit command into a pane that hosts a plain shell" ;;
+esac
+pass "real herdr: an exited worker's pane is positively eligible for its replacement instead of being typed into"
+
+if OUT=$(run_control hsmoke interrupt 2>&1); then
+  fail "interrupt should refuse on a pane proved agent-free: $OUT"
+fi
+case "$OUT" in
+  *"nothing to interrupt"*) : ;;
+  *) fail "the interrupt refusal should say there is no agent, got: $OUT" ;;
+esac
+pass "real herdr: interrupt still refuses on a pane whose registration outlived its agent"
+
+# --- the same registration over a genuinely running process ----------------
+#
+# The identical registered reading, with a real non-shell foreground process
+# in the pane. Nothing here may be reclassified as recoverable.
+
+fm_backend_herdr_send_text_line "$SESSION:$PANE_ID" 'sleep 600' \
+  || fail "could not start a foreground process in the task pane"
+ATTEMPT=0
+while [ "$ATTEMPT" -lt 100 ]; do
+  case "$(herdr pane process-info --pane "$PANE_ID" --session "$SESSION" 2>/dev/null \
+    | jq -r '[.result.process_info.foreground_processes[]?.name] | join(",")' 2>/dev/null)" in
+    *sleep*) break ;;
+  esac
+  sleep 0.1
+  ATTEMPT=$((ATTEMPT + 1))
+done
+[ "$ATTEMPT" -lt 100 ] || fail "the foreground process never appeared in herdr's process inventory"
+register_agent idle || fail "could not register an agent over the running process"
+
+STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
+[ "$STATE" = alive ] \
+  || fail "a registration over a genuinely running foreground process must stay alive, got '$STATE'"
+pass "real herdr: the same registration over a running foreground process stays alive"
 
 OUT=$(run_control hsmoke interrupt) || fail "interrupt against a registered agent should succeed: $OUT"
 case "$OUT" in
-  *"interrupt-delivered hsmoke harness=claude backend=herdr verified=agent-alive cancel=unconfirmed"*) : ;;
+  *"interrupt-delivered hsmoke harness=pi backend=herdr verified=agent-alive cancel=unconfirmed"*) : ;;
   *) fail "interrupt should report the agent-alive proof on herdr, got: $OUT" ;;
 esac
 pass "real herdr: interrupt delivers the harness's key and proves the agent survived it"
 
-herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
-  || fail "the control plane must never remove the endpoint it was operating on"
-[ -d "$WT" ] || fail "the control plane must never remove the task's local copy"
-pass "real herdr: no control verb removed the endpoint or the task's local copy"
-
-# Last, because it deliberately types a harness command into a pane that hosts
-# a plain shell: the registered agent cannot actually be stopped that way, and
-# the control plane must say so rather than report a stop it did not achieve.
+# Last, because it deliberately types a harness command into a pane whose
+# foreground process cannot act on it: the agent cannot be stopped that way,
+# and the control plane must say so rather than report a stop it did not
+# achieve.
 if OUT=$(run_control hsmoke exit 2>&1); then
   fail "exit should fail closed when the agent does not stop: $OUT"
 fi
@@ -145,5 +214,12 @@ case "$OUT" in
   *) fail "the exit failure should say the agent did not stop, got: $OUT" ;;
 esac
 pass "real herdr: an agent that does not stop fails closed instead of being reported as stopped"
+
+herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
+  || fail "the control plane must never remove the endpoint it was operating on"
+[ -d "$WT" ] || fail "the control plane must never remove the task's local copy"
+git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null | grep -qx hsmoke \
+  || fail "the control plane must never move the task's branch"
+pass "real herdr: no control verb removed the endpoint, the task's local copy, or its branch"
 
 fm_backend_herdr_kill "$SESSION:$PANE_ID" 2>/dev/null || true

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -109,8 +109,13 @@ register_agent() {  # <state>
     --agent fm-control-smoke-agent --state "$1" --session "$SESSION" >/dev/null 2>&1
 }
 
+# The same read the backend's own capture performs
+# (fm_backend_herdr_capture in bin/backends/herdr.sh): --source recent with a
+# generous --lines, because a small bound returns nothing at all. The exit
+# status is propagated so callers can refuse to treat a failed read as evidence
+# that nothing was typed into the pane.
 pane_text() {
-  herdr pane read "$PANE_ID" --session "$SESSION" 2>/dev/null || true
+  herdr pane read "$PANE_ID" --session "$SESSION" --source recent --lines 200
 }
 
 registered_status() {
@@ -157,7 +162,9 @@ case "$OUT" in
   "already-stopped hsmoke"*) : ;;
   *) fail "an agent-free pane should report already-stopped, got: $OUT" ;;
 esac
-case "$(pane_text)" in
+PANE_TEXT=$(pane_text) \
+  || fail "could not read the task pane, so an absent /quit proves nothing about what exit typed into it"
+case "$PANE_TEXT" in
   *"/quit"*) fail "exit typed the harness's exit command into a pane that hosts a plain shell" ;;
 esac
 pass "real herdr: an exited worker's pane is positively eligible for its replacement instead of being typed into"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -455,6 +455,85 @@ test_relaunch_requires_a_note_for_a_ship_task() {
   pass "fm-control relaunch: a ship task refuses without the progress note its replacement needs"
 }
 
+# --- 1b. an agent that already exited to its shell ---------------------------
+#
+# The endpoint outlives the agent: a worker that exits leaves its shell sitting
+# in the task's local copy. That endpoint is positively agent-free, so the
+# replacement its operator is asking for must launch, and nothing may be typed
+# at the shell on the way there. Durable busy evidence from the incarnation
+# that ended is stale by definition and must not resurrect an interrupt.
+
+test_relaunch_over_an_exited_shell_stops_nothing_and_launches() {
+  local dir out rc gen head_before
+  dir=$(new_case exited rl40)
+  add_ship_task "$dir" rl40 claude
+  # The worker exited: the endpoint is a plain shell, not the harness.
+  printf 'zsh' > "$dir/fake/command"
+  # Its last busy report never got a settling counterpart, so the durable
+  # record still says busy long after the process producing it went away.
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$dir/home/state" rl40)
+  printf 'busy_gen=%s\n' "$gen" >> "$dir/home/state/rl40.meta"
+  "$ROOT/bin/fm-busy-event.sh" apply "$dir/home/state" rl40 busy \
+    --gen "$gen" --source pi-ext --event agent-start >/dev/null
+  # Real uncommitted work the replacement must inherit untouched.
+  printf 'half-finished\n' > "$dir/wt/scratch.txt"
+  head_before=$(git -C "$dir/wt" rev-parse HEAD)
+
+  out=$(run_control "$dir" rl40 relaunch --note "prior worker exited after the PR went green"); rc=$?
+  expect_code 0 "$rc" "a relaunch over an exited shell should launch the replacement"$'\n'"$out"
+  assert_contains "$out" "relaunched rl40" "the outcome should name the completed transition"
+  [ "$(journal_field "$dir" rl40 exit_result)" = already-stopped ] \
+    || fail "an already-exited agent should be recorded as already-stopped, not stopped"
+  # The keys log also carries the replacement launch's own input, so pin the
+  # interrupt key itself rather than emptiness.
+  case "$(cat "$dir/fake/keys")" in
+    *Escape*) fail "stale busy evidence must not deliver an interrupt key into a pane with no agent" ;;
+  esac
+  # Whole-line matches: the launch literal legitimately carries paths.
+  if grep -qxE '/(exit|quit)' "$dir/fake/literal"; then
+    fail "an already-exited agent must not be sent the harness's exit command"
+  fi
+  [ "$(git -C "$dir/wt" rev-parse HEAD)" = "$head_before" ] \
+    || fail "relaunch must not move the task's branch"
+  [ "$(git -C "$dir/wt" rev-parse --abbrev-ref HEAD)" = "task-rl40" ] \
+    || fail "relaunch must not change the task's branch identity"
+  [ "$(cat "$dir/wt/scratch.txt")" = half-finished ] \
+    || fail "relaunch must leave every uncommitted change exactly as the previous worker left it"
+  [ "$(journal_field "$dir" rl40 worktree_dirty)" = yes ] \
+    || fail "the checkpoint should record that there was uncommitted work to preserve"
+  [ "$(journal_field "$dir" rl40 worktree_head)" = "$head_before" ] \
+    || fail "the checkpoint should record the exact head it preserved"
+  assert_grep "prior worker exited after the PR went green" "$dir/home/data/rl40/brief.md" \
+    "the replacement must be told what happened"
+  pass "fm-control relaunch: an endpoint whose agent already exited is replaced without an interrupt, without the exit command, and without touching the branch or its uncommitted work"
+}
+
+test_relaunch_over_an_exited_shell_preserves_work_when_the_launch_fails() {
+  local dir out rc head_before
+  dir=$(new_case exitedfail rl41)
+  add_ship_task "$dir" rl41 claude
+  printf 'zsh' > "$dir/fake/command"
+  # The replacement never comes up: `becomes` leaves the endpoint a shell.
+  printf 'zsh' > "$dir/fake/becomes"
+  printf 'half-finished\n' > "$dir/wt/scratch.txt"
+  head_before=$(git -C "$dir/wt" rev-parse HEAD)
+
+  out=$(run_control "$dir" rl41 relaunch --note "prior worker exited"); rc=$?
+  expect_code 1 "$rc" "a replacement that never comes up must fail loudly"
+  assert_contains "$out" "did not come up" "the failure should name the missing replacement"
+  [ "$(meta_field "$dir" rl41 harness)" = claude ] \
+    || fail "a failed launch must leave the durable record naming a harness, not a half-transition"
+  [ "$(git -C "$dir/wt" rev-parse HEAD)" = "$head_before" ] \
+    || fail "a failed relaunch must not move the task's branch"
+  [ "$(git -C "$dir/wt" rev-parse --abbrev-ref HEAD)" = "task-rl41" ] \
+    || fail "a failed relaunch must not change the task's branch identity"
+  [ "$(cat "$dir/wt/scratch.txt")" = half-finished ] \
+    || fail "a failed relaunch must still preserve every uncommitted change"
+  assert_grep "prior worker exited" "$dir/home/state/rl41.control-relaunch.note" \
+    "the progress note must survive a failed relaunch for the next recovery"
+  pass "fm-control relaunch: a replacement that never comes up still preserves the branch, the uncommitted work, and the progress note"
+}
+
 # --- 2. harness switch -------------------------------------------------------
 
 test_harness_switch_moves_the_record_and_clears_prior_wiring() {
@@ -1483,6 +1562,8 @@ test_relaunch_serializes_concurrent_durable_metadata_publication
 test_disabled_relaunch_clears_prior_trace_context
 test_relaunch_appends_the_progress_note_to_the_instructions
 test_relaunch_requires_a_note_for_a_ship_task
+test_relaunch_over_an_exited_shell_stops_nothing_and_launches
+test_relaunch_over_an_exited_shell_preserves_work_when_the_launch_fails
 test_harness_switch_moves_the_record_and_clears_prior_wiring
 test_harness_switch_does_not_carry_the_old_profile_axes
 test_harness_switch_resolves_a_prefixed_recorded_harness

--- a/tests/fm-crewmate-autonomy-live-e2e.test.sh
+++ b/tests/fm-crewmate-autonomy-live-e2e.test.sh
@@ -12,14 +12,24 @@
 # sandbox and approval classifier, not of firstmate's code, so no stub and no
 # transcribed flag table can answer it. Only a real agent, driven for real, can.
 #
-# The two halves are measured separately and reported separately, because they
-# fail for different reasons and only one of them is a firstmate defect:
+# The readings are taken and reported separately, because they fail for different
+# reasons and not all of them are a firstmate defect:
 #   1. the unattended-launch reading is taken with NO key sent at all, so a
 #      harness that parks behind a trust, approval, or update modal is recorded
 #      as exactly that rather than being typed into (see reach_composer);
 #   2. the write reading then costs ONE short turn, in which the agent is asked
-#      to run the very append bin/fm-brief.sh hands it and to answer with a
-#      separate token, so reply-without-write is distinguishable from no-reply.
+#      to run the very appends bin/fm-brief.sh hands it and to answer with a
+#      separate token, so reply-without-write is distinguishable from no-reply;
+#   3. that same turn also asks for an append to a path the launch grants nothing
+#      for, so a pass proves the grant is NARROW rather than merely sufficient.
+#      A sandboxed harness that lands that write has had its sandbox widened past
+#      the brief and FAILS here; a harness launched with no sandbox flag at all
+#      has nothing to have widened, so its result there is only reported.
+#
+# The granted set is exactly what bin/fm-brief.sh permits a worker outside its
+# worktree - state/<id>.status for every kind, and data/<id>/report.md for a
+# scout - so the launch posture quoted below grants those two directories and
+# nothing else, and the guard exercises both of them.
 #
 # The lab home is created under $HOME and NEVER under TMPDIR or /tmp. That is not
 # cosmetic: codex's `workspace-write` sandbox grants /tmp and $TMPDIR as writable
@@ -79,7 +89,10 @@ fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab se
 # See the header: $HOME, never TMPDIR, or codex's default writable roots make the
 # write measurement vacuous.
 LAB="$HOME/.fm-crewmate-autonomy-lab-$$"
-mkdir -p "$LAB/state" "$LAB/wt" || fail "could not create the lab home at $LAB"
+# denied/ is created up front on purpose: an append into a directory that does not
+# exist fails for a reason that has nothing to do with the sandbox, which would
+# turn the narrowness reading into a false pass.
+mkdir -p "$LAB/state" "$LAB/wt" "$LAB/denied" || fail "could not create the lab home at $LAB"
 LAB=$(cd "$LAB" && pwd -P)
 # A real crewmate is launched in a git worktree, and cursor's --workspace wants a
 # repository root; give the lab worktree the same shape.
@@ -93,6 +106,11 @@ export FM_HOME="$LAB"
 . "$ROOT/bin/fm-backend.sh"
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-cursor-lib.sh"
+# Sourced for fm_busy_cursor_project_dir: the added writable roots must not move
+# the workspace identity cursor's busy fold is bound to (see the cursor branch of
+# the write reading below).
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-busy-lib.sh"
 fm_backend_source herdr || fail "fm_backend_source herdr failed"
 
 CONTAINER_RAW=$(fm_backend_herdr_container_ensure "$LAB/wt") || fail "container_ensure failed"
@@ -128,11 +146,26 @@ resolve_harness_binary() {  # <harness>
 # The autonomy posture under measurement, quoted from bin/fm-spawn.sh's launch
 # templates with only the positional brief removed. Anything else would measure a
 # posture firstmate does not ship.
-launch_command() {  # <harness> <binary> <worktree>
+# $4 and $5 are the two brief-permitted directories bin/fm-spawn.sh grants through
+# its __ADDDIRS__ placeholder, passed here in the scout shape (both grants), which
+# is the widest posture firstmate ships.
+launch_command() {  # <harness> <binary> <worktree> <state-dir> <report-dir>
   case "$1" in
     claude) printf '%s' "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false $2 --permission-mode auto" ;;
-    codex) printf '%s' "$2 -s workspace-write -a never" ;;
-    cursor) printf '%s' "env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS $2 --trust --auto-review --sandbox enabled --workspace $3" ;;
+    codex) printf '%s' "$2 -s workspace-write -a never --add-dir $4 --add-dir $5" ;;
+    cursor) printf '%s' "env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS $2 --trust --auto-review --sandbox enabled --add-dir $4 --add-dir $5 --workspace $3" ;;
+    *) return 1 ;;
+  esac
+}
+
+# harness_is_sandboxed: does this harness's launch posture carry a sandbox that the
+# grant is supposed to stay narrow inside? Only such a harness is FAILED for
+# landing a write outside the granted set. claude's --permission-mode auto is an
+# approval classifier, not a filesystem sandbox, so a write it allows outside the
+# granted set is a property of that posture rather than a widened grant.
+harness_is_sandboxed() {  # <harness>
+  case "$1" in
+    codex|cursor) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -307,6 +340,8 @@ reach_composer() {  # <harness> <pane>
 CHECKED=0
 SKIPPED=
 DENIED=
+WIDENED=
+BINDING=
 BLOCKED=
 
 # The three adapters whose launch templates carry an explicit autonomy or sandbox
@@ -330,7 +365,13 @@ EOF
   [ -n "$PANE_ID" ] || fail "$harness ($version): create_task returned no pane id"
   TARGET="$SESSION:$PANE_ID"
 
-  launch=$(launch_command "$harness" "$bin_path" "$LAB/wt") \
+  # Per-harness copies of the two brief-permitted directories, so one harness's
+  # reading can never be satisfied by a file another harness wrote.
+  STATE_DIR="$LAB/state"
+  REPORT_DIR="$LAB/data/$harness-$$"
+  mkdir -p "$REPORT_DIR" || fail "$harness ($version): could not create the lab report dir"
+
+  launch=$(launch_command "$harness" "$bin_path" "$LAB/wt" "$STATE_DIR" "$REPORT_DIR") \
     || fail "$harness ($version): no launch posture is recorded for this harness"
   fm_backend_herdr_send_text_line "$TARGET" "$launch" \
     || fail "$harness ($version): could not launch it in the lab pane"
@@ -371,16 +412,23 @@ EOF
   # transcript the harness renders, so counting it could confirm a reply the
   # harness never gave.
   REPLY_TOKEN="FMREPLY${harness}$$$RANDOM"
-  STATUS_FILE="$LAB/state/$harness-$$.status"
-  # Exactly the append bin/fm-brief.sh gives every worker, at exactly the place it
-  # gives it: outside the worktree, under the crewmate's FM_HOME.
-  #
-  # The prompt asks for the file to be READ BACK, not just written, because an
-  # agent that simply answers without touching its shell is indistinguishable
-  # from an agent the sandbox refused, and both are wrong answers here. Demanding
-  # either the file's contents or the exact error text forces a tool call and
-  # makes "refused" and "never tried" tell themselves apart in the pane.
-  PROMPT="Use your shell tool to append the line: done: $TOKEN   to the file $STATUS_FILE   Then read that file back with your shell tool and reply with only $REPLY_TOKEN followed by the file's exact contents. If any step fails, reply with only $REPLY_TOKEN followed by the exact error text."
+  # The two writes the brief permits, at exactly the places it permits them:
+  # outside the worktree, under the crewmate's FM_HOME.
+  STATUS_FILE="$STATE_DIR/$harness-$$.status"
+  REPORT_FILE="$REPORT_DIR/report.md"
+  # The third write is permitted nowhere. It sits under the SAME lab home as the
+  # two granted ones, so a harness that lands it has been given the home rather
+  # than the two directories, which is precisely the over-grant this guard exists
+  # to catch.
+  DENIED_FILE="$LAB/denied/$harness-$$.status"
+  # The prompt asks for each result to be reported back, not just attempted,
+  # because an agent that simply answers without touching its shell is
+  # indistinguishable from an agent the sandbox refused, and both are wrong
+  # answers here. Demanding OK or the exact error text per step forces the tool
+  # calls and makes "refused" and "never tried" tell themselves apart in the pane.
+  # It also states that no directory may be created, so a refusal can never be an
+  # artefact of a missing parent.
+  PROMPT="Use your shell tool for each of these three steps in order, and do not create any directory. Step 1: append the line   done: $TOKEN   to the file $STATUS_FILE   Step 2: append the line   report: $TOKEN   to the file $REPORT_FILE   Step 3: append the line   denied: $TOKEN   to the file $DENIED_FILE   Then reply with only $REPLY_TOKEN followed by three lines, one per step in order, each being either OK or the exact error text. Do not stop early: attempt all three steps even if an earlier one fails."
 
   # Last check before the only Enter this guard ever sends into a live harness.
   composer_settled "$TARGET" || fail \
@@ -391,17 +439,23 @@ EOF
 
   replied=0
   wrote=0
+  wrote_report=0
   for _ in $(seq 1 180); do
-    [ "$wrote" = 1 ] || { [ -s "$STATUS_FILE" ] && grep -qF "done: $TOKEN" "$STATUS_FILE" 2>/dev/null && wrote=1; }
+    [ "$wrote" = 1 ] || { grep -qF "done: $TOKEN" "$STATUS_FILE" 2>/dev/null && wrote=1; }
+    [ "$wrote_report" = 1 ] || { grep -qF "report: $TOKEN" "$REPORT_FILE" 2>/dev/null && wrote_report=1; }
     if [ "$replied" = 0 ]; then
       # The reply token appears once in the submitted prompt; a second
       # occurrence is the harness's own reply.
       occurrences=$(fm_backend_herdr_capture "$TARGET" 200 2>/dev/null | grep -F -c "$REPLY_TOKEN" || true)
       [ "${occurrences:-0}" -ge 2 ] && replied=1
     fi
-    [ "$wrote" = 1 ] && [ "$replied" = 1 ] && break
+    [ "$wrote" = 1 ] && [ "$wrote_report" = 1 ] && [ "$replied" = 1 ] && break
     sleep 1
   done
+  # Read the denied path only after the turn has settled, and never as a loop exit
+  # condition: the absence of a write is not something to wait for.
+  leaked=0
+  grep -qF "denied: $TOKEN" "$DENIED_FILE" 2>/dev/null && leaked=1
 
   tail_evidence=$(pane_tail "$PANE_ID" 60)
 
@@ -414,8 +468,42 @@ EOF
     DENIED="$DENIED $harness"
     printf 'not ok - %s\n' \
       "CREWMATE WRITE CONTRACT: $harness $version answered a prompt but could NOT append to its own status file outside its worktree ($STATUS_FILE). bin/fm-brief.sh makes that append the only way a worker reports done, blocked, or needs-decision, so under this launch posture such a worker is mute. Pane tail: $tail_evidence" >&2
+  elif [ "$wrote_report" != 1 ]; then
+    DENIED="$DENIED $harness"
+    printf 'not ok - %s\n' \
+      "CREWMATE WRITE CONTRACT: $harness $version appends its status file but could NOT write a scout report at $REPORT_FILE. bin/fm-brief.sh makes that file a scout's entire deliverable, so a scout on this posture cannot deliver. Pane tail: $tail_evidence" >&2
   else
-    pass "crewmate write contract: $harness $version appends to its status file outside its worktree"
+    pass "crewmate write contract: $harness $version appends its status file and writes its scout report, both outside its worktree"
+  fi
+
+  # cursor only, and a direct consequence of granting it extra roots:
+  # state/<id>.cursor-session binds the busy fold to the ONE cursor project whose
+  # recorded workspacePath is EXACTLY the task worktree (bin/fm-busy-lib.sh, exact
+  # match by design). If an added root moved that recorded identity, every cursor
+  # worker's turn state would go unreadable while every other reading here still
+  # passed, so the grant is only safe if this holds.
+  if [ "$harness" = cursor ]; then
+    if fm_busy_cursor_project_dir "${CURSOR_PROJECTS_ROOT_OVERRIDE:-$HOME/.cursor/projects}" "$LAB/wt" >/dev/null 2>&1; then
+      pass "workspace binding: cursor $version still records the task worktree as its exact workspacePath under the added writable roots"
+    else
+      BINDING="$BINDING $harness"
+      printf 'not ok - %s\n' \
+        "WORKSPACE BINDING LOST: cursor $version no longer records $LAB/wt as the exact workspacePath of any project under ${CURSOR_PROJECTS_ROOT_OVERRIDE:-\$HOME/.cursor/projects}, so bin/fm-busy-lib.sh cannot bind a cursor worker's transcript and its turn state reads unknown forever. The added writable roots moved the workspace identity." >&2
+    fi
+  fi
+
+  if harness_is_sandboxed "$harness"; then
+    if [ "$leaked" = 1 ]; then
+      WIDENED="$WIDENED $harness"
+      printf 'not ok - %s\n' \
+        "SANDBOX GRANT TOO WIDE: $harness $version landed a write at $DENIED_FILE, which the launch grants nothing for. The posture therefore hands a crewmate its whole firstmate home rather than the two directories bin/fm-brief.sh permits. Pane tail: $tail_evidence" >&2
+    else
+      pass "narrow grant: $harness $version is still refused a write outside the two brief-permitted directories"
+    fi
+  elif [ "$leaked" = 1 ]; then
+    note "$harness $version: carries no sandbox flag, and did write outside the brief-permitted directories ($DENIED_FILE); its posture is an approval classifier, not a filesystem boundary"
+  else
+    note "$harness $version: carries no sandbox flag, and did not write outside the brief-permitted directories"
   fi
 
   CHECKED=$((CHECKED + 1))
@@ -435,7 +523,15 @@ if [ -n "$BLOCKED" ]; then
 fi
 
 if [ -n "$DENIED" ]; then
-  fail "the status-file write contract is BROKEN under today's launch posture for:$DENIED"
+  fail "the crewmate write contract is BROKEN under today's launch posture for:$DENIED"
+fi
+
+if [ -n "$WIDENED" ]; then
+  fail "today's launch posture grants more than bin/fm-brief.sh permits for:$WIDENED"
+fi
+
+if [ -n "$BINDING" ]; then
+  fail "the launch posture's writable roots broke the workspace identity the busy fold binds to for:$BINDING"
 fi
 
 cleanup_all

--- a/tests/fm-crewmate-autonomy-live-e2e.test.sh
+++ b/tests/fm-crewmate-autonomy-live-e2e.test.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+# tests/fm-crewmate-autonomy-live-e2e.test.sh - opt-in live guard proving that a
+# crewmate launched under the autonomy flags bin/fm-spawn.sh actually passes
+# today can (a) reach its composer unattended and (b) append to its own status
+# file, which lives OUTSIDE its worktree.
+#
+# Why this file exists: the status append is the load-bearing crewmate contract.
+# bin/fm-brief.sh hands every worker `echo "{state}: ..." >> $FM_HOME/state/<id>.status`
+# as the ONLY way to report done, blocked, or needs-decision, and that path is
+# outside the worktree the harness sandboxes to. Whether a sandboxed, non-
+# bypassing launch posture still permits it is a property of the harness vendor's
+# sandbox and approval classifier, not of firstmate's code, so no stub and no
+# transcribed flag table can answer it. Only a real agent, driven for real, can.
+#
+# The two halves are measured separately and reported separately, because they
+# fail for different reasons and only one of them is a firstmate defect:
+#   1. the unattended-launch reading is taken with NO key sent at all, so a
+#      harness that parks behind a trust, approval, or update modal is recorded
+#      as exactly that rather than being typed into (see reach_composer);
+#   2. the write reading then costs ONE short turn, in which the agent is asked
+#      to run the very append bin/fm-brief.sh hands it and to answer with a
+#      separate token, so reply-without-write is distinguishable from no-reply.
+#
+# The lab home is created under $HOME and NEVER under TMPDIR or /tmp. That is not
+# cosmetic: codex's `workspace-write` sandbox grants /tmp and $TMPDIR as writable
+# roots by default, so a status file placed there would be writable for reasons
+# that have nothing to do with the crewmate contract and this guard would pass
+# while proving nothing. A real FM_HOME lives beside the firstmate checkout under
+# $HOME, and the lab mirrors that shape.
+#
+# Unlike tests/fm-harness-liveness-drift-live-e2e.test.sh and
+# tests/fm-herdr-agent-free-proof-live-e2e.test.sh, this guard DOES submit a
+# prompt and therefore does consume model tokens - one short turn per installed
+# harness. That cost is unavoidable: a shell command run outside the agent proves
+# nothing about the agent's own sandbox.
+#
+# Standard CI has neither harness binaries nor credentials, so this is opt-in and
+# on-demand. Run it after any harness upgrade, after any change to a launch
+# template in bin/fm-spawn.sh, and before trusting the refreshed evidence in
+# docs/verification/runtime-backends.md "Crewmate autonomy and the status-file
+# write contract".
+#
+# Always runs on a private, named, throwaway Herdr lab session, never the default
+# one (tests/herdr-test-safety.sh).
+set -u
+
+if [ "${FM_CREWMATE_AUTONOMY_LIVE:-0}" != 1 ]; then
+  echo "skip: set FM_CREWMATE_AUTONOMY_LIVE=1 to run the live crewmate autonomy and status-write guard"
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
+pass() { printf 'ok - %s\n' "$1"; }
+note() { printf '# %s\n' "$1"; }
+
+command -v herdr >/dev/null 2>&1 || fail "herdr not found"
+command -v jq >/dev/null 2>&1 || fail "jq not found (required by the herdr adapter)"
+command -v git >/dev/null 2>&1 || fail "git not found"
+
+# shellcheck source=tests/herdr-test-safety.sh
+. "$ROOT/tests/herdr-test-safety.sh"
+herdr_forget_inherited_pane
+
+SESSION="fm-lab-autonomy-$$"
+export HERDR_SESSION="$SESSION"
+LAB=
+CLEANED=0
+cleanup_all() {
+  [ "$CLEANED" = 0 ] || return 0
+  CLEANED=1
+  [ -n "$LAB" ] && rm -rf "$LAB"
+  herdr_safe_stop_and_delete "$SESSION"
+}
+trap cleanup_all EXIT
+fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+
+# See the header: $HOME, never TMPDIR, or codex's default writable roots make the
+# write measurement vacuous.
+LAB="$HOME/.fm-crewmate-autonomy-lab-$$"
+mkdir -p "$LAB/state" "$LAB/wt" || fail "could not create the lab home at $LAB"
+LAB=$(cd "$LAB" && pwd -P)
+# A real crewmate is launched in a git worktree, and cursor's --workspace wants a
+# repository root; give the lab worktree the same shape.
+git -C "$LAB/wt" init -q >/dev/null 2>&1 || fail "could not initialise the lab worktree"
+
+# Label the lab's Herdr workspace from the lab home, so it can never collide with
+# the captain's live per-home workspace.
+export FM_HOME="$LAB"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-backend.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-cursor-lib.sh"
+fm_backend_source herdr || fail "fm_backend_source herdr failed"
+
+CONTAINER_RAW=$(fm_backend_herdr_container_ensure "$LAB/wt") || fail "container_ensure failed"
+CONTAINER=${CONTAINER_RAW%%$'\t'*}
+SEEDED_TAB_ID=${CONTAINER_RAW#*$'\t'}
+
+HERDR_VERSION=$(herdr --version 2>/dev/null | head -1 | tr -d '\r')
+[ -n "$HERDR_VERSION" ] || HERDR_VERSION=unknown
+note "herdr: $HERDR_VERSION"
+note "lab home: <\$HOME>/${LAB##*/} (status files outside the lab worktree)"
+
+# Mirror bin/fm-spawn.sh's own binary resolution, so this guard launches the same
+# binary firstmate would.
+resolve_harness_binary() {  # <harness>
+  local harness=$1 candidate
+  # cursor first, and never through a bare PATH lookup: it installs as
+  # `cursor-agent` plus the legacy alias `agent`, while a `cursor` on PATH is
+  # routinely the editor launcher rather than the agent, which answers a
+  # --trust launch with an Electron warning and exits. fm_cursor_resolve_binary
+  # is the verified owner fm-spawn itself uses.
+  if [ "$harness" = cursor ]; then
+    fm_cursor_resolve_binary 2>/dev/null && return 0
+    return 1
+  fi
+  candidate=$(command -v "$harness" 2>/dev/null || true)
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+  return 1
+}
+
+# The autonomy posture under measurement, quoted from bin/fm-spawn.sh's launch
+# templates with only the positional brief removed. Anything else would measure a
+# posture firstmate does not ship.
+launch_command() {  # <harness> <binary> <worktree>
+  case "$1" in
+    claude) printf '%s' "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false $2 --permission-mode auto" ;;
+    codex) printf '%s' "$2 -s workspace-write -a never" ;;
+    cursor) printf '%s' "env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS $2 --trust --auto-review --sandbox enabled --workspace $3" ;;
+    *) return 1 ;;
+  esac
+}
+
+foreground_names() {  # <pane>
+  fm_backend_herdr_cli "$SESSION" pane process-info --pane "$1" 2>/dev/null \
+    | jq -r '[.result.process_info.foreground_processes[]? | "\(.name)/\(.argv0 // .argv[0] // "")"] | join(" ")' 2>/dev/null
+}
+
+foreground_pids() {  # <pane>
+  fm_backend_herdr_cli "$SESSION" pane process-info --pane "$1" 2>/dev/null \
+    | jq -r '.result.process_info.foreground_processes[]?.pid | select(type == "number") | floor' 2>/dev/null
+}
+
+pane_tail() {  # <pane> <lines>
+  fm_backend_herdr_capture "$SESSION:$1" "$2" 2>/dev/null | tr '\n' '|'
+}
+
+# end_harness: stop only the processes this guard launched into the pane, leaving
+# the pane and its tab in place, so the next harness still has its container.
+end_harness() {  # <pane>
+  local pid
+  for pid in $(foreground_pids "$1"); do
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  for _ in $(seq 1 100); do
+    case "$(foreground_names "$1")" in
+      ''|*sh/*sh*) return 0 ;;
+    esac
+    sleep 0.1
+  done
+  for pid in $(foreground_pids "$1"); do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+}
+
+# numbered_menu_index / numbered_menu_selected: read a vendor TUI menu of the
+# shape "> 1. Yes, continue" / "  2. No, quit" by its own printed labels rather
+# than by a hardcoded keystroke count, so a vendor that reorders or inserts an
+# option moves the guard's cursor with it instead of silently changing what the
+# guard answers.
+numbered_menu_index() {  # <screen> <label-pattern> -> index
+  printf '%s\n' "$1" | sed -n 's/^[^0-9]*\([0-9]\)\. *\(.*\)$/\1 \2/p' \
+    | grep -i -- "$2" | head -1 | cut -d' ' -f1
+}
+
+numbered_menu_selected() {  # <screen> -> index of the currently highlighted row
+  # The highlighted row is the one carrying a selection marker before its
+  # number; every other row is indented with whitespace only. Matching "some
+  # non-space, non-digit character before the digit" covers the markers the
+  # vendors actually print (>, U+203A, U+276F) without pinning any of them.
+  printf '%s\n' "$1" | grep -E '^[[:space:]]*[^[:space:][:digit:]][[:space:]]*[0-9]+\.' \
+    | head -1 | sed -E 's/^[^0-9]*([0-9]+)\..*/\1/'
+}
+
+select_numbered_option() {  # <target> <screen> <label-pattern>
+  local target=$1 screen=$2 pattern=$3 want cur step
+  want=$(numbered_menu_index "$screen" "$pattern")
+  cur=$(numbered_menu_selected "$screen")
+  case "$want$cur" in ''|*[!0-9]*) return 1 ;; esac
+  step=$cur
+  while [ "$step" -lt "$want" ]; do
+    fm_backend_herdr_send_key "$target" Down || return 1
+    sleep 0.3
+    step=$((step + 1))
+  done
+  while [ "$step" -gt "$want" ]; do
+    fm_backend_herdr_send_key "$target" Up || return 1
+    sleep 0.3
+    step=$((step - 1))
+  done
+  fm_backend_herdr_send_key "$target" Enter
+}
+
+# composer_settled: an empty composer that STAYS empty for a whole settle window.
+#
+# A single empty verdict is NOT safe to act on. Observed live: codex 0.150.1
+# rendered a classifiable empty composer and raised its update-available modal a
+# moment later, and a run of this guard that trusted the earlier read submitted
+# into that modal - whose preselected row is "Update now" - and upgraded the
+# codex CLI on the machine. Every key this guard sends into a live harness is
+# gated on a composer that is still a composer for the whole window, which is
+# what makes a late modal impossible to race. The classifier alone is the test:
+# a modal screen classifies pending or unknown, never empty, and unlike a text
+# signature it cannot be fooled by a dismissed modal still sitting in scrollback.
+COMPOSER_SETTLE_SECONDS=${FM_CREWMATE_AUTONOMY_SETTLE_SECONDS:-10}
+composer_settled() {  # <target>
+  local target=$1 deadline=$((SECONDS + COMPOSER_SETTLE_SECONDS))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    [ "$(fm_backend_composer_state herdr "$target" 2>/dev/null)" = empty ] || return 1
+    sleep 1
+  done
+  return 0
+}
+
+# reach_composer: drive <pane> to a proven-empty composer WITHOUT ever answering a
+# question the guard cannot read, and set READY_VIA to how it got there:
+#
+#   unattended - empty with no key sent at all; this is the guarantee under test
+#   <steps>    - empty only after the listed startup gates were cleared, each one
+#                named in READY_VIA in the order it appeared
+#   blocked    - never empty; the caller reports the pane instead of guessing
+#
+# Two rules keep this honest. First, phase one sends NOTHING, because typing into
+# a modal answers it: an earlier run of this guard submitted its prompt into
+# Claude's trust dialog, selected "No, exit", and destroyed the reading. Second,
+# the only gate this guard ACCEPTS is the first-launch directory-trust prompt,
+# which .agents/skills/harness-adapters/SKILL.md already tells the captain to
+# accept by hand after a spawn; every other gate is DECLINED by its own printed
+# decline option, so the guard never widens the trust the launch flags grant and
+# never measures a posture more permissive than the one firstmate ships. An
+# unrecognised trust-shaped prompt is refused outright rather than guessed at.
+#
+# tests/fm-composer-matrix-live-e2e.test.sh takes the narrower path of declining
+# every modal, because an empty composer is all it needs; this guard has to get
+# past the prompt to measure the write contract behind it.
+READY_VIA=blocked
+# Wall-clock, not a poll count: one composer read is a full pane fetch, so a
+# fixed iteration budget silently becomes minutes.
+REACH_ROUND_SECONDS=${FM_CREWMATE_AUTONOMY_REACH_SECONDS:-40}
+REACH_ROUNDS=6
+reach_composer() {  # <harness> <pane>
+  local harness=$1 pane=$2 target="$SESSION:$2" round deadline verdict screen step
+  READY_VIA=
+  for round in $(seq 1 "$REACH_ROUNDS"); do
+    deadline=$((SECONDS + REACH_ROUND_SECONDS))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+      verdict=$(fm_backend_composer_state herdr "$target" 2>/dev/null)
+      if [ "$verdict" = empty ] && composer_settled "$target"; then
+        [ -n "$READY_VIA" ] || READY_VIA=unattended
+        return 0
+      fi
+      sleep 0.2
+    done
+    [ "$round" -lt "$REACH_ROUNDS" ] || break
+    screen=$(fm_backend_herdr_capture "$target" 60 2>/dev/null)
+    step=
+    if printf '%s\n' "$screen" | grep -qF 'Yes, I trust this folder'; then
+      # Claude Code's workspace-trust prompt: an UNNUMBERED menu whose accept row
+      # sits directly below the preselected "No, exit".
+      fm_backend_herdr_send_key "$target" Down || return 1
+      sleep 0.3
+      fm_backend_herdr_send_key "$target" Enter || return 1
+      step=accepted-workspace-trust
+    elif printf '%s\n' "$screen" | grep -qiF 'trust the contents of this directory'; then
+      select_numbered_option "$target" "$screen" 'yes, continue' || return 1
+      step=accepted-directory-trust
+    elif printf '%s\n' "$screen" | grep -qiF 'Hooks need review'; then
+      # Declined, never "Trust all": letting hooks run would grant the measured
+      # agent capabilities the launch flags never asked for.
+      select_numbered_option "$target" "$screen" 'continue without trusting' || return 1
+      step=declined-hook-trust
+    elif printf '%s\n' "$screen" | grep -qi 'update available'; then
+      # Escape, never Enter: Enter on codex's update dialog RUNS the upgrade.
+      fm_backend_herdr_send_key "$target" Escape || return 1
+      step=dismissed-update-offer
+    elif printf '%s\n' "$screen" | grep -qi 'trust'; then
+      # An unrecognised trust-shaped prompt. Never guess at it.
+      return 1
+    else
+      fm_backend_herdr_send_key "$target" Escape || return 1
+      step=dismissed-startup-modal
+    fi
+    note "$harness: $step"
+    READY_VIA="${READY_VIA:+$READY_VIA,}$step"
+    sleep 1
+  done
+  READY_VIA=blocked
+  return 1
+}
+
+CHECKED=0
+SKIPPED=
+DENIED=
+BLOCKED=
+
+# The three adapters whose launch templates carry an explicit autonomy or sandbox
+# posture. An adapter that gains one belongs here too.
+for harness in claude codex cursor; do
+  if ! bin_path=$(resolve_harness_binary "$harness"); then
+    SKIPPED="$SKIPPED $harness"
+    note "skip: $harness is not installed on this machine, so its autonomy posture is unverified here"
+    continue
+  fi
+
+  version=$("$bin_path" --version 2>/dev/null | head -1 | tr -d '\r') || version=
+  [ -n "$version" ] || version="unknown"
+
+  TASK_IDS=$(fm_backend_herdr_create_task "$CONTAINER" "fm-auto-$harness" "$LAB/wt" "$SEEDED_TAB_ID") \
+    || fail "$harness ($version): could not create a lab tab"
+  SEEDED_TAB_ID=
+  read -r _TAB_ID PANE_ID <<EOF
+$TASK_IDS
+EOF
+  [ -n "$PANE_ID" ] || fail "$harness ($version): create_task returned no pane id"
+  TARGET="$SESSION:$PANE_ID"
+
+  launch=$(launch_command "$harness" "$bin_path" "$LAB/wt") \
+    || fail "$harness ($version): no launch posture is recorded for this harness"
+  fm_backend_herdr_send_text_line "$TARGET" "$launch" \
+    || fail "$harness ($version): could not launch it in the lab pane"
+
+  # Wait until the harness's OWN executable owns the pane foreground, so the rest
+  # is measured against a running harness rather than the shell that launched it.
+  bin_base=${bin_path##*/}
+  running=0
+  for _ in $(seq 1 300); do
+    case "$(foreground_names "$PANE_ID")" in
+      *"$bin_base"*) running=1; break ;;
+    esac
+    sleep 0.2
+  done
+  names=$(foreground_names "$PANE_ID")
+  [ "$running" = 1 ] || fail \
+    "$harness $version: '$bin_base' never owned the pane foreground, so nothing about its autonomy posture was measured. Observed foreground name/argv0 pairs [$names]. Pane tail: $(pane_tail "$PANE_ID" 40)"
+
+  if ! reach_composer "$harness" "$PANE_ID"; then
+    BLOCKED="$BLOCKED $harness"
+    CHECKED=$((CHECKED + 1))
+    printf 'not ok - %s\n' \
+      "UNATTENDED LAUNCH: $harness $version, launched with the flags bin/fm-spawn.sh ships in a worktree path it has never seen, never presented an empty composer, and what is on its screen is not a modal this guard knows how to clear safely. Nothing was submitted, so this reading did not answer it. Pane tail: $(pane_tail "$PANE_ID" 60)" >&2
+    end_harness "$PANE_ID"
+    continue
+  fi
+  case "$READY_VIA" in
+    unattended)
+      pass "unattended launch: $harness $version reaches an empty composer with no key sent"
+      ;;
+    *)
+      note "$harness $version: NOT unattended - reached its composer only via $READY_VIA (see the record in docs/verification/runtime-backends.md)"
+      ;;
+  esac
+
+  TOKEN="FMWROTE${harness}$$$RANDOM"
+  # A DISTINCT reply token: the write token also appears in whatever tool-call
+  # transcript the harness renders, so counting it could confirm a reply the
+  # harness never gave.
+  REPLY_TOKEN="FMREPLY${harness}$$$RANDOM"
+  STATUS_FILE="$LAB/state/$harness-$$.status"
+  # Exactly the append bin/fm-brief.sh gives every worker, at exactly the place it
+  # gives it: outside the worktree, under the crewmate's FM_HOME.
+  #
+  # The prompt asks for the file to be READ BACK, not just written, because an
+  # agent that simply answers without touching its shell is indistinguishable
+  # from an agent the sandbox refused, and both are wrong answers here. Demanding
+  # either the file's contents or the exact error text forces a tool call and
+  # makes "refused" and "never tried" tell themselves apart in the pane.
+  PROMPT="Use your shell tool to append the line: done: $TOKEN   to the file $STATUS_FILE   Then read that file back with your shell tool and reply with only $REPLY_TOKEN followed by the file's exact contents. If any step fails, reply with only $REPLY_TOKEN followed by the exact error text."
+
+  # Last check before the only Enter this guard ever sends into a live harness.
+  composer_settled "$TARGET" || fail \
+    "$harness $version: the composer stopped being a composer between the readiness gate and the submit, so nothing was sent. Pane tail: $(pane_tail "$PANE_ID" 60)"
+
+  verdict=$(fm_backend_herdr_send_text_submit "$TARGET" "$PROMPT" 3 0.4 0.4) \
+    || fail "$harness $version: send_text_submit failed to run"
+
+  replied=0
+  wrote=0
+  for _ in $(seq 1 180); do
+    [ "$wrote" = 1 ] || { [ -s "$STATUS_FILE" ] && grep -qF "done: $TOKEN" "$STATUS_FILE" 2>/dev/null && wrote=1; }
+    if [ "$replied" = 0 ]; then
+      # The reply token appears once in the submitted prompt; a second
+      # occurrence is the harness's own reply.
+      occurrences=$(fm_backend_herdr_capture "$TARGET" 200 2>/dev/null | grep -F -c "$REPLY_TOKEN" || true)
+      [ "${occurrences:-0}" -ge 2 ] && replied=1
+    fi
+    [ "$wrote" = 1 ] && [ "$replied" = 1 ] && break
+    sleep 1
+  done
+
+  tail_evidence=$(pane_tail "$PANE_ID" 60)
+
+  [ "$replied" = 1 ] || fail \
+    "$harness $version: reached its composer ($READY_VIA) but never answered a one-line prompt within 180s, so the write contract behind it could not be measured. Submit verdict '$verdict'. Pane tail: $tail_evidence"
+
+  note "$harness $version: ready=$READY_VIA submit=$verdict reply=landed"
+
+  if [ "$wrote" != 1 ]; then
+    DENIED="$DENIED $harness"
+    printf 'not ok - %s\n' \
+      "CREWMATE WRITE CONTRACT: $harness $version answered a prompt but could NOT append to its own status file outside its worktree ($STATUS_FILE). bin/fm-brief.sh makes that append the only way a worker reports done, blocked, or needs-decision, so under this launch posture such a worker is mute. Pane tail: $tail_evidence" >&2
+  else
+    pass "crewmate write contract: $harness $version appends to its status file outside its worktree"
+  fi
+
+  CHECKED=$((CHECKED + 1))
+  end_harness "$PANE_ID"
+done
+
+[ "$CHECKED" -gt 0 ] || fail \
+  "no measured harness is installed here, so this run proved nothing; install at least one of claude, codex, or cursor before trusting a pass"
+
+if [ -n "$SKIPPED" ]; then
+  note "unverified on this machine (not installed):$SKIPPED"
+fi
+note "checked $CHECKED installed harness(es) on herdr $HERDR_VERSION"
+
+if [ -n "$BLOCKED" ]; then
+  fail "the launch posture bin/fm-spawn.sh ships parks behind an unrecognised blocker for:$BLOCKED"
+fi
+
+if [ -n "$DENIED" ]; then
+  fail "the status-file write contract is BROKEN under today's launch posture for:$DENIED"
+fi
+
+cleanup_all
+trap - EXIT

--- a/tests/fm-herdr-agent-free-proof-live-e2e.test.sh
+++ b/tests/fm-herdr-agent-free-proof-live-e2e.test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# tests/fm-herdr-agent-free-proof-live-e2e.test.sh - opt-in drift guard proving
+# no INSTALLED harness, while genuinely running in a Herdr pane, can be
+# mistaken for an agent-free bare idle shell.
+#
+# Why this file exists: the Herdr liveness classifier settles its negative
+# verdict from `pane process-info` - the pane must provably hold one lone bare
+# idle shell before a reported registration is treated as stale
+# (bin/backends/herdr.sh, fm_backend_herdr_pane_agent_state). That proof reads
+# a process name and an argv0 that each harness vendor controls and can change
+# without notice, so a stub can only confirm the assumption already written
+# into the stub. A false agent-free verdict is the one outcome that could
+# launch a replacement onto a live worker's local copy, which is exactly the
+# direction this guard watches.
+#
+# The portable counterpart in tests/fm-backend-herdr.test.sh pins the
+# classifier logic in CI with real processes and no harness, and
+# tests/fm-control-herdr-smoke.test.sh pins the control plane's use of it on
+# the required real-Herdr lane. Run this guard after any harness upgrade and
+# before trusting refreshed per-harness evidence.
+#
+# Each harness is launched bare, with no prompt, so this consumes no model
+# tokens. Standard CI has neither harness binaries nor credentials, so it is
+# opt-in and on-demand.
+#
+# Always runs on a private, named, throwaway lab session, never the default one
+# (tests/herdr-test-safety.sh).
+set -u
+
+if [ "${FM_HERDR_AGENT_FREE_PROOF:-0}" != 1 ]; then
+  echo "skip: set FM_HERDR_AGENT_FREE_PROOF=1 to run the installed-harness Herdr agent-free proof guard"
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
+pass() { printf 'ok - %s\n' "$1"; }
+note() { printf '# %s\n' "$1"; }
+
+command -v herdr >/dev/null 2>&1 || fail "herdr not found"
+command -v jq >/dev/null 2>&1 || fail "jq not found (required by the herdr adapter)"
+
+# shellcheck source=tests/herdr-test-safety.sh
+. "$ROOT/tests/herdr-test-safety.sh"
+herdr_forget_inherited_pane
+
+SESSION="fm-lab-agent-free-$$"
+export HERDR_SESSION="$SESSION"
+LAB=
+CLEANED=0
+cleanup_all() {
+  [ "$CLEANED" = 0 ] || return 0
+  CLEANED=1
+  [ -n "$LAB" ] && rm -rf "$LAB"
+  herdr_safe_stop_and_delete "$SESSION"
+}
+trap cleanup_all EXIT
+fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+
+LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-herdr-agent-free.XXXXXX")
+LAB=$(cd "$LAB" && pwd)
+mkdir -p "$LAB/wt"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-backend.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-cursor-lib.sh"
+fm_backend_source herdr || fail "fm_backend_source herdr failed"
+
+CONTAINER_RAW=$(fm_backend_herdr_container_ensure "$LAB/wt") || fail "container_ensure failed"
+CONTAINER=${CONTAINER_RAW%%$'\t'*}
+SEEDED_TAB_ID=${CONTAINER_RAW#*$'\t'}
+WORKSPACE_ID=${CONTAINER#*:}
+
+HERDR_VERSION=$(herdr --version 2>/dev/null | head -1 | tr -d '\r')
+[ -n "$HERDR_VERSION" ] || HERDR_VERSION=unknown
+note "herdr: $HERDR_VERSION"
+
+# Mirror bin/fm-spawn.sh's own binary resolution, so this guard covers the same
+# binary firstmate would actually launch.
+resolve_harness_binary() {  # <harness>
+  local harness=$1 candidate
+  # cursor first, and never through a bare PATH lookup: it installs as
+  # `cursor-agent` plus the legacy alias `agent`, while an unrelated `cursor`
+  # on PATH is routinely the editor launcher rather than the agent (observed on
+  # a developer machine, where it answered a `--trust` launch with an Electron
+  # warning and exited). fm_cursor_resolve_binary is the verified owner
+  # fm-spawn itself uses, so this guard launches exactly what firstmate would.
+  if [ "$harness" = cursor ]; then
+    fm_cursor_resolve_binary 2>/dev/null && return 0
+    return 1
+  fi
+  candidate=$(command -v "$harness" 2>/dev/null || true)
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+  if [ "$harness" = kimi ] && [ -n "${HOME:-}" ] && [ -x "$HOME/.kimi-code/bin/kimi" ]; then
+    printf '%s\n' "$HOME/.kimi-code/bin/kimi"
+    return 0
+  fi
+  return 1
+}
+
+foreground_names() {  # <pane>
+  fm_backend_herdr_cli "$SESSION" pane process-info --pane "$1" 2>/dev/null \
+    | jq -r '[.result.process_info.foreground_processes[]? | "\(.name)/\(.argv0 // .argv[0] // "")"] | join(" ")' 2>/dev/null
+}
+
+foreground_pids() {  # <pane>
+  fm_backend_herdr_cli "$SESSION" pane process-info --pane "$1" 2>/dev/null \
+    | jq -r '.result.process_info.foreground_processes[]?.pid | select(type == "number") | floor' 2>/dev/null
+}
+
+# end_harness: stop only the exact processes this guard launched into the pane,
+# leaving the pane and its tab in place. Closing the pane instead would remove
+# the workspace's last tab and destroy the container the next harness needs.
+end_harness() {  # <pane>
+  local pid
+  for pid in $(foreground_pids "$1"); do
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  for _ in $(seq 1 100); do
+    case "$(foreground_names "$1")" in
+      ''|*sh/*sh*) return 0 ;;
+    esac
+    sleep 0.1
+  done
+  for pid in $(foreground_pids "$1"); do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+}
+
+CHECKED=0
+SKIPPED=
+
+# The verified adapters, in the order .agents/skills/harness-adapters/SKILL.md
+# records them. An adapter that gains a verified launch path belongs here too.
+for harness in claude codex opencode pi pi-signed grok kimi cursor muse; do
+  if ! bin_path=$(resolve_harness_binary "$harness"); then
+    SKIPPED="$SKIPPED $harness"
+    note "skip: $harness is not installed on this machine, so its Herdr classification is unverified here"
+    continue
+  fi
+
+  version=$("$bin_path" --version 2>/dev/null | head -1 | tr -d '\r') || version=
+  [ -n "$version" ] || version="unknown"
+
+  TASK_IDS=$(fm_backend_herdr_create_task "$CONTAINER" "fm-afp-$harness" "$LAB/wt" "$SEEDED_TAB_ID") \
+    || fail "$harness ($version): could not create a lab tab"
+  SEEDED_TAB_ID=
+  read -r _TAB_ID PANE_ID <<EOF
+$TASK_IDS
+EOF
+  [ -n "$PANE_ID" ] || fail "$harness ($version): create_task returned no pane id"
+
+  # cursor blocks on a workspace-trust prompt in a directory it has never seen,
+  # which would hang this probe; --trust is the same flag fm-spawn passes.
+  launch=$bin_path
+  [ "$harness" = cursor ] && launch="$bin_path --trust"
+  fm_backend_herdr_send_text_line "$SESSION:$PANE_ID" "$launch" \
+    || fail "$harness ($version): could not launch it in the lab pane"
+
+  # Wait until the harness's OWN executable owns the pane's foreground, so the
+  # proof is read against a genuinely running agent rather than the shell that
+  # launched it or a short-lived prompt helper beside it.
+  bin_base=${bin_path##*/}
+  running=0
+  for _ in $(seq 1 300); do
+    case "$(foreground_names "$PANE_ID")" in
+      *"$bin_base"*) running=1; break ;;
+    esac
+    sleep 0.2
+  done
+  names=$(foreground_names "$PANE_ID")
+  [ "$running" = 1 ] || fail \
+    "$harness $version: '$bin_base' never appeared in the Herdr pane's foreground, so this guard proved nothing about it. Observed foreground name/argv0 pairs [$names]. Pane tail: $(fm_backend_herdr_capture "$SESSION:$PANE_ID" 40 2>/dev/null | tail -5 | tr '\n' '|')"
+
+  if fm_backend_herdr_pane_idle_shell_sample "$SESSION" "$PANE_ID" >/dev/null 2>&1; then
+    fail "AGENT-FREE DRIFT: $harness $version is running in a Herdr pane, but the pane's process inventory proves a lone bare idle shell, so bin/backends/herdr.sh would classify a live worker as agent-free and let a replacement launch onto its local copy. Observed foreground name/argv0 pairs [$names] on herdr $HERDR_VERSION."
+  fi
+
+  # Herdr registers an agent only for the harnesses it ships an integration
+  # for, and that integration reports on its own schedule, so give it a bounded
+  # window before reading the recovery-grade verdict.
+  state=
+  for _ in $(seq 1 100); do
+    state=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
+    [ "$state" = alive ] && break
+    sleep 0.2
+  done
+  case "$state" in
+    alive) ;;
+    dead|missing)
+      # No integration ever registered this pane. That is a pre-existing
+      # property of the registry, not of the process inventory this guard
+      # watches, so it is reported rather than failed.
+      note "$harness $version: herdr registered no agent for this harness within the wait (state '$state'); the agent-free proof still correctly refuses"
+      ;;
+    *) fail "$harness $version: Herdr classified a running harness '$state'; only alive or an unregistered dead/missing is expected" ;;
+  esac
+
+  note "$harness $version: foreground=[$names] state=$state"
+  pass "herdr agent-free proof: $harness $version running in a Herdr pane never proves a bare idle shell"
+  CHECKED=$((CHECKED + 1))
+
+  end_harness "$PANE_ID"
+done
+
+[ "$CHECKED" -gt 0 ] || fail \
+  "no verified harness is installed here, so this run proved nothing; install at least one harness before trusting a pass"
+
+if [ -n "$SKIPPED" ]; then
+  note "unverified on this machine (not installed):$SKIPPED"
+fi
+note "checked $CHECKED installed harness(es) on herdr $HERDR_VERSION in workspace $WORKSPACE_ID"
+
+cleanup_all
+trap - EXIT

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -767,7 +767,7 @@ test_spawn_secondmate_harness_model_token() {
   [ "$(meta_field "$meta" model)" = opus ] || fail "model-token: meta model not opus (got '$(meta_field "$meta" model)')"
   [ "$(meta_field "$meta" effort)" = default ] || fail "model-token: meta effort not default (got '$(meta_field "$meta" effort)')"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'opus'" \
+  assert_contains "$launch" "claude --permission-mode auto --model 'opus'" \
     "model-token: launch did not carry --model opus"
   assert_not_contains "$launch" "--effort" "model-token: launch must not carry an --effort flag"
   pass "C3 spawn: config/secondmate-harness's model token threads --model into the launch and meta"
@@ -789,7 +789,7 @@ test_spawn_secondmate_harness_model_and_effort_tokens() {
   [ "$(meta_field "$meta" model)" = opus ] || fail "model-effort-tokens: meta model not opus"
   [ "$(meta_field "$meta" effort)" = high ] || fail "model-effort-tokens: meta effort not high (got '$(meta_field "$meta" effort)')"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'opus' --effort 'high'" \
+  assert_contains "$launch" "claude --permission-mode auto --model 'opus' --effort 'high'" \
     "model-effort-tokens: launch did not carry both --model opus and --effort high"
   pass "C4 spawn: config/secondmate-harness's model+effort tokens thread into the launch and meta"
 }
@@ -854,7 +854,7 @@ test_spawn_explicit_harness_does_not_inherit_secondmate_harness_tokens() {
   [ "$(meta_field "$meta" model)" = default ] || fail "explicit-harness-no-tokens: meta model should stay default"
   [ "$(meta_field "$meta" effort)" = default ] || fail "explicit-harness-no-tokens: meta effort should stay default"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "codex --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex -s workspace-write -a never" \
     "explicit-harness-no-tokens: launch did not use codex"
   assert_not_contains "$launch" "--model" "explicit-harness-no-tokens: launch must not carry a --model flag"
   assert_not_contains "$launch" "model_reasoning_effort" \

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -434,6 +434,51 @@ test_codex_omits_invalid_max_effort() {
   pass "codex omits unsupported max effort instead of passing a bad config value"
 }
 
+# codex runs sandboxed with no escalation path, so anything the brief tells a
+# worker to write outside its worktree has to be granted at launch or the model
+# just sees "operation not permitted". These two cases pin the grant to exactly
+# what bin/fm-brief.sh permits, in both directions: the paths must be there, and
+# the firstmate home itself must NOT be.
+test_codex_ship_grants_only_the_brief_permitted_state_dir() {
+  local rec id out status launch
+  id=profile-codex-grant-z30
+  rec=$(make_spawn_case profile-codex-grant codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "codex ship spawn should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "--add-dir '$HOME_DIR/state'" \
+    "codex ship launch did not grant the state dir the status file lives in"
+  assert_not_contains "$launch" "--add-dir '$HOME_DIR/data" \
+    "codex ship launch must not grant a scout report dir a crewmate never writes"
+  assert_not_contains "$launch" "--add-dir '$HOME_DIR'" \
+    "codex launch must never grant the whole firstmate home"
+  pass "codex crewmate is granted exactly the state dir its status file needs"
+}
+
+test_codex_scout_also_grants_its_own_report_dir() {
+  local rec id out status launch
+  id=profile-codex-scout-grant-z31
+  rec=$(make_spawn_case profile-codex-scout-grant codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --scout)
+  status=$?
+  expect_code 0 "$status" "codex scout spawn should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "--add-dir '$HOME_DIR/state'" \
+    "codex scout launch did not grant the state dir the status file lives in"
+  assert_contains "$launch" "--add-dir '$HOME_DIR/data/$id'" \
+    "codex scout launch did not grant the one data dir its report lives in"
+  assert_not_contains "$launch" "--add-dir '$HOME_DIR/data'" \
+    "codex scout launch must grant its own data dir, not every task's"
+  assert_not_contains "$launch" "--add-dir '$HOME_DIR'" \
+    "codex launch must never grant the whole firstmate home"
+  pass "codex scout is granted its own report dir alongside the state dir"
+}
+
 test_grok_threads_model_and_reasoning_effort() {
   local rec id out status launch
   id=profile-grok-z5
@@ -806,6 +851,8 @@ test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_omits_invalid_max_effort
+test_codex_ship_grants_only_the_brief_permitted_state_dir
+test_codex_scout_also_grants_its_own_report_dir
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -131,7 +131,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode auto \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -345,7 +345,7 @@ test_active_dispatch_profile_allows_explicit_harness() {
   assert_contains "$out" "spawned $id harness=codex" "spawn did not report explicit codex harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' -s workspace-write -a never" \
     "explicit harness launch did not thread model and effort"
   pass "active crew-dispatch profile allows an explicit resolved harness"
 }
@@ -395,7 +395,7 @@ test_claude_threads_model_and_effort() {
   expect_code 0 "$status" "claude spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude sonnet high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
+  assert_contains "$launch" "claude --permission-mode auto --model 'sonnet' --effort 'high'" \
     "claude launch did not thread model and effort flags"
   assert_not_contains "$launch" "--tui-mode" "non-Pi launches must not receive Pi's TUI mode override"
   pass "claude receives --model and --effort profile flags"
@@ -412,7 +412,7 @@ test_codex_threads_model_and_effort() {
   expect_code 0 "$status" "codex spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' -s workspace-write -a never" \
     "codex launch did not thread model and reasoning effort config"
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
@@ -428,7 +428,7 @@ test_codex_omits_invalid_max_effort() {
   expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -s workspace-write -a never" \
     "codex launch did not preserve the model flag when max effort was omitted"
   assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
   pass "codex omits unsupported max effort instead of passing a bad config value"
@@ -500,7 +500,7 @@ test_cursor_threads_model_workspace_and_omits_effort_axis() {
   expect_code 0 "$status" "cursor spawn with a model-qualified reasoning class should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" cursor cursor-grok-4.5-high high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "--trust --yolo --model 'cursor-grok-4.5-high' --workspace '$WT_DIR'" \
+  assert_contains "$launch" "--trust --auto-review --sandbox enabled --model 'cursor-grok-4.5-high' --workspace '$WT_DIR'" \
     "cursor launch did not carry trust, autonomy, model, and exact workspace flags"
   # The executable is RESOLVED, never named: `cursor` is not the CLI, so a
   # literal `cursor agent` command cannot run on a machine that has only the

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -2,8 +2,9 @@
 # Behavior tests for the fleet usage harvester and its report reader.
 # Covers claude-log request dedupe and cache folding, codex per-request delta
 # sums with cwd/window matching, cursor/unavailable null rows, the
-# no-double-append idempotency guard, the ledger report rendering, and the
-# teardown integration property that a harvest failure never blocks teardown.
+# no-double-append idempotency guard, the staging file the append stages
+# through leaving no debris, the ledger report rendering, and the teardown
+# integration property that a harvest failure never blocks teardown.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -347,6 +348,38 @@ lock_bound_case() {
   pass "usage harvest: a held ledger lock bounds the acquire, no hang or dup"
 }
 
+# --- staging file: a failed ledger append leaves no runtime debris ----------
+
+# The harvest builds its row in a staging file next to the ledger and then
+# appends it. A failed append (here an unwritable ledger) must still leave the
+# data directory free of staging files, otherwise every best-effort teardown
+# harvest against a broken ledger accumulates another one.
+staging_case() {
+  local id=usagestaging1 wt="$TMP_ROOT/wt-usagestaging1"
+  local data home rc leftovers
+  data=$(harvest_case "$id" cursor "$wt" cursor-x "")
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+  # The ledger path being a directory forces the append to fail.
+  mkdir -p "$home/data/usage-ledger.jsonl"
+  rc=0
+  "$HARVEST" "$id" >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || fail "harvest returned 0 with an unwritable ledger"
+  leftovers=$(find "$home/data" -maxdepth 1 -name 'usage-ledger.jsonl.tmp.*' 2>/dev/null)
+  [ -z "$leftovers" ] \
+    || fail "failed ledger append left staging files: $leftovers"
+
+  # The same must hold on the success path.
+  rmdir "$home/data/usage-ledger.jsonl"
+  "$HARVEST" "$id" >/dev/null 2>&1 || fail "harvest failed with a writable ledger"
+  [ "$(wc -l < "$home/data/usage-ledger.jsonl" | tr -d ' ')" = 1 ] \
+    || fail "successful retry did not append exactly one row"
+  leftovers=$(find "$home/data" -maxdepth 1 -name 'usage-ledger.jsonl.tmp.*' 2>/dev/null)
+  [ -z "$leftovers" ] \
+    || fail "successful ledger append left staging files: $leftovers"
+  pass "usage harvest: no staging files survive a failed or successful append"
+}
+
 # --- report: per-model totals and per-task rows -----------------------------
 
 report_case() {
@@ -417,5 +450,6 @@ cursor_case
 remote_case
 race_case
 lock_bound_case
+staging_case
 report_case
 teardown_case

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -321,6 +321,32 @@ race_case() {
   pass "usage harvest: concurrent harvests append exactly one row"
 }
 
+# A held ledger lock must never block the (teardown-synchronous) harvest
+# forever: the acquire is bounded, so a second harvest whose lock-wait is
+# shorter than the holder's critical section gives up best-effort (non-zero,
+# no duplicate row) instead of hanging until the holder releases.
+lock_bound_case() {
+  local id=usagelockbound1 wt="$TMP_ROOT/wt-usagelockbound1"
+  local data home ledger p1 rc
+  data=$(harvest_case "$id" cursor "$wt" cursor-x "")
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+  ledger="$home/data/usage-ledger.jsonl"
+  # Holder keeps the lock across a 4s critical section.
+  FM_USAGE_HARVEST_APPEND_DELAY=4 "$HARVEST" "$id" >/dev/null 2>&1 &
+  p1=$!
+  # Let the holder acquire before the bounded harvester starts spinning.
+  sleep 1
+  rc=0
+  FM_USAGE_LEDGER_LOCK_WAIT=1 "$HARVEST" "$id" >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] \
+    || fail "bounded harvest returned 0 while the ledger lock was held"
+  wait "$p1"
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = 1 ] \
+    || fail "bounded give-up appended a duplicate row"
+  pass "usage harvest: a held ledger lock bounds the acquire, no hang or dup"
+}
+
 # --- report: per-model totals and per-task rows -----------------------------
 
 report_case() {
@@ -390,5 +416,6 @@ codex_case
 cursor_case
 remote_case
 race_case
+lock_bound_case
 report_case
 teardown_case

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Behavior tests for the fleet usage harvester and its report reader.
+# Covers claude-log request dedupe and cache folding, codex per-request delta
+# sums with cwd/window matching, cursor/unavailable null rows, the
+# no-double-append idempotency guard, the ledger report rendering, and the
+# teardown integration property that a harvest failure never blocks teardown.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HARVEST="$ROOT/bin/fm-usage-harvest.sh"
+REPORT="$ROOT/bin/fm-usage-report.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+TMP_ROOT=$(fm_test_tmproot fm-usage-harvest)
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+file_mtime_epoch() {  # <file>
+  local t
+  t=$(stat -f %m -- "$1" 2>/dev/null) || t=$(stat -c %Y -- "$1" 2>/dev/null) || return 1
+  case "$t" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s' "$t"
+}
+file_birth_epoch() {  # <file>
+  local t
+  t=$(stat -f %B -- "$1" 2>/dev/null) || t=$(stat -c %W -- "$1" 2>/dev/null) || return 1
+  case "$t" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$t" -ge 1000000000 ] 2>/dev/null || return 1
+  printf '%s' "$t"
+}
+
+# harvest_case <id> <harness> [model] [effort] : create a home with one task
+# whose worktree is $TMP_ROOT/wt-<id>, status and meta included, and echo the
+# data dir. Exports the FM_USAGE_* fixture dirs per case.
+harvest_case() {  # <id> <harness> <worktree> [model] [effort]
+  local id=$1 harness=$2 wt=$3
+  local home="$TMP_ROOT/home-$id"
+  mkdir -p "$home/state" "$home/data"
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" "worktree=$wt" \
+    "project=$TMP_ROOT/proj-$id" "harness=$harness" "kind=ship" "mode=no-mistakes" \
+    "model=${4:-default}" "effort=${5:-default}"
+  {
+    printf 'working: started\n'
+    printf 'working: halfway\n'
+    printf 'done: finished the task\n'
+  } > "$home/state/$id.status"
+  printf '%s\n' "$home/data"
+}
+export_harvest_env() {  # <home-data>
+  FM_STATE_OVERRIDE="$1/state"
+  FM_DATA_OVERRIDE="$1/data"
+  FM_USAGE_CLAUDE_DIR="$TMP_ROOT/fake-claude/projects"
+  FM_USAGE_CODEX_DIR="$TMP_ROOT/fake-codex/sessions"
+  export FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_USAGE_CLAUDE_DIR FM_USAGE_CODEX_DIR
+}
+
+# --- claude: request dedupe, cache folding, encoding resolution, window -----
+
+claude_case() {
+  local id=usageclaude1 wt="$TMP_ROOT/wt-usageclaude1"
+  local data home state ledger row
+  data=$(harvest_case "$id" claude "$wt" default default)
+  home=$(dirname "$data")
+  state="$home/state"
+  export_harvest_env "$home"
+
+  # The encoded directory is the worktree path with every '/' turned into '-'.
+  local encoded=${wt//\//-}
+  local logdir="$FM_USAGE_CLAUDE_DIR/$encoded"
+  mkdir -p "$logdir"
+  cat > "$logdir/session-a.jsonl" <<'JSON'
+{"type":"assistant","message":{"id":"msgA","model":"claude-test","usage":{"input_tokens":10,"cache_read_input_tokens":100,"cache_creation_input_tokens":20,"output_tokens":30,"output_tokens_details":{"thinking_tokens":5}}}}
+{"type":"assistant","message":{"id":"msgA","model":"claude-test","usage":{"input_tokens":10,"cache_read_input_tokens":100,"cache_creation_input_tokens":20,"output_tokens":30,"output_tokens_details":{"thinking_tokens":5}}}}
+{"type":"assistant","message":{"id":"msgB","model":"claude-test","usage":{"input_tokens":7,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":9}}}
+{"type":"user","message":{"role":"user"}}
+{"type":"assistant","message":{"id":"msgC"}}
+JSON
+  # A request logged outside the task window (future mtime) must be excluded,
+  # as must a session in a differently encoded sibling directory.
+  cat > "$logdir/session-future.jsonl" <<'JSON'
+{"type":"assistant","message":{"id":"msgX","model":"claude-test","usage":{"input_tokens":999,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":999}}}
+JSON
+  touch -t "$(date -r $(( $(file_mtime_epoch "$state/$id.status") + 7200 )) +%Y%m%d%H%M.%S)" \
+    "$logdir/session-future.jsonl"
+  mkdir -p "$FM_USAGE_CLAUDE_DIR/wrong-encoded-dir"
+  printf '%s\n' '{"type":"assistant","message":{"id":"msgY","model":"claude-test","usage":{"input_tokens":777,"output_tokens":777}}}' \
+    > "$FM_USAGE_CLAUDE_DIR/wrong-encoded-dir/other.jsonl"
+  # Seal the window: the status end mtime must not predate the in-window
+  # session log, or the log correctly falls outside birth -> end.
+  touch -m -r "$logdir/session-a.jsonl" "$state/$id.status"
+
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "claude harvest should succeed"$'\n'"$out"
+  ledger="$data/usage-ledger.jsonl"
+  [ -f "$ledger" ] || fail "claude harvest wrote no ledger"
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = 1 ] || fail "claude harvest wrote more than one ledger line"
+  row=$(cat "$ledger")
+  assert_contains "$row" '"task":"usageclaude1"' "claude row names the task"
+  assert_contains "$row" '"harness":"claude"' "claude row names the harness"
+  assert_contains "$row" '"model":"claude-test"' "claude row captures the log model"
+  assert_contains "$row" '"source":"claude-projects"' "claude row names its source"
+  assert_contains "$row" '"input_tokens":17' "claude input tokens dedupe per request (10+7)"
+  assert_contains "$row" '"cached_input_tokens":120' "claude cached folds read+creation (100+20+0+0)"
+  assert_contains "$row" '"output_tokens":39' "claude output tokens (30+9)"
+  assert_contains "$row" '"reasoning_tokens":5' "claude reasoning captures thinking tokens"
+  assert_contains "$row" '"turns":2' "claude turn estimate counts working: lines"
+  assert_contains "$row" '"effort":null' "default effort renders null"
+  # Wall seconds is birth -> status mtime on this platform; assert the
+  # computed value equals an independent read of the same file facts.
+  local end birth wall_expected
+  end=$(file_mtime_epoch "$state/$id.status")
+  birth=$(file_birth_epoch "$state/$id.status" || file_mtime_epoch "$state/$id.status")
+  wall_expected=$((end - birth))
+  [ "$wall_expected" -lt 0 ] && wall_expected=0
+  assert_contains "$row" "\"wall_secs\":$wall_expected" \
+    "claude wall seconds equals status birth -> last-mtime window"
+
+  # Idempotency: a second harvest must not append a duplicate row.
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "second claude harvest should exit 0"$'\n'"$out"
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = 1 ] \
+    || fail "second claude harvest double-appended"
+  pass "claude harvest: per-request dedupe, cache folding, encoding, window, idempotency"
+}
+
+# --- codex: cwd match, window match, delta sums, model capture --------------
+
+codex_case() {
+  local id=usagecodex1 wt="$TMP_ROOT/wt-usagecodex1"
+  local data home ledger row out
+  data=$(harvest_case "$id" codex "$wt" default high)
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+
+  local d1="$FM_USAGE_CODEX_DIR/2026/08/28"
+  mkdir -p "$d1"
+  cat > "$d1/rollout-match.jsonl" <<JSON
+{"timestamp":"2026-08-28T15:13:03.851Z","ordinal":0,"type":"session_meta","payload":{"session_id":"s1","cwd":"$wt"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":10,"cache_write_input_tokens":5,"output_tokens":20,"reasoning_output_tokens":8},"last_token_usage":{"input_tokens":100,"cached_input_tokens":10,"cache_write_input_tokens":5,"output_tokens":20,"reasoning_output_tokens":8}}}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":50,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":11,"reasoning_output_tokens":3}}}}
+{"type":"turn_context","payload":{"cwd":"$wt","model":"glm-5.3"}}
+JSON
+  # Same window but a different cwd: must be excluded.
+  cat > "$d1/rollout-othercwd.jsonl" <<JSON
+{"type":"session_meta","payload":{"cwd":"/elsewhere"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":888,"output_tokens":888}}}}
+{"type":"turn_context","payload":{"model":"glm-5.3"}}
+JSON
+  # Matching cwd but outside the window: must be excluded.
+  cat > "$d1/rollout-future.jsonl" <<JSON
+{"type":"session_meta","payload":{"cwd":"$wt"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":999,"output_tokens":999}}}}
+JSON
+  touch -t "$(date -r $(( $(file_mtime_epoch "$home/state/$id.status") + 7200 )) +%Y%m%d%H%M.%S)" \
+    "$d1/rollout-future.jsonl"
+  touch -m -r "$d1/rollout-match.jsonl" "$home/state/$id.status"
+
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "codex harvest should succeed"$'\n'"$out"
+  ledger="$home/data/usage-ledger.jsonl"
+  row=$(cat "$ledger")
+  assert_contains "$row" '"harness":"codex"' "codex row names the harness"
+  assert_contains "$row" '"model":"glm-5.3"' "codex row captures the turn_context model"
+  assert_contains "$row" '"effort":"high"' "codex row carries meta effort"
+  assert_contains "$row" '"source":"codex-sessions"' "codex row names its source"
+  assert_contains "$row" '"input_tokens":150' "codex input sums per-request deltas (100+50)"
+  assert_contains "$row" '"cached_input_tokens":15' "codex cached folds cached+cache_write (10+5+0)"
+  assert_contains "$row" '"output_tokens":31' "codex output sums deltas (20+11)"
+  assert_contains "$row" '"reasoning_tokens":11' "codex reasoning sums deltas (8+3)"
+  pass "codex harvest: cwd/window matching, delta sums, model capture"
+}
+
+# --- cursor: unavailable logs render nulls ----------------------------------
+
+cursor_case() {
+  local id=usagecursor1 wt="$TMP_ROOT/wt-usagecursor1"
+  local data home ledger row out
+  data=$(harvest_case "$id" cursor "$wt" cursor-grok-4.5-high "")
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "cursor harvest should succeed"$'\n'"$out"
+  ledger="$home/data/usage-ledger.jsonl"
+  row=$(cat "$ledger")
+  assert_contains "$row" '"model":"cursor-grok-4.5-high"' "cursor row falls back to meta model"
+  assert_contains "$row" '"input_tokens":null' "cursor input tokens are null"
+  assert_contains "$row" '"cached_input_tokens":null' "cursor cached tokens are null"
+  assert_contains "$row" '"output_tokens":null' "cursor output tokens are null"
+  assert_contains "$row" '"reasoning_tokens":null' "cursor reasoning tokens are null"
+  assert_contains "$row" '"source":"unavailable"' "cursor row marks source unavailable"
+  pass "cursor harvest: unavailable source renders null token fields"
+}
+
+# --- report: per-model totals and per-task rows -----------------------------
+
+report_case() {
+  local out ledger
+  ledger="$TMP_ROOT/home-usageclaude1/data/usage-ledger.jsonl"
+  cat "$TMP_ROOT/home-usagecodex1/data/usage-ledger.jsonl" >> "$ledger"
+  cat "$TMP_ROOT/home-usagecursor1/data/usage-ledger.jsonl" >> "$ledger"
+  out=$(FM_DATA_OVERRIDE="$(dirname "$ledger")" "$REPORT" 2>&1)
+  expect_code 0 "$?" "report should succeed"$'\n'"$out"
+  assert_contains "$out" "usage ledger: $ledger (3 rows)" "report names the ledger and row count"
+  assert_contains "$out" "per-model totals" "report prints per-model totals"
+  assert_contains "$out" "claude-test" "report lists the claude model"
+  assert_contains "$out" "glm-5.3" "report lists the codex model"
+  assert_contains "$out" "usageclaude1" "report lists each task row"
+  assert_contains "$out" "usagecursor1" "report lists the unavailable task row"
+  assert_contains "$out" "unavailable" "report shows the unavailable source"
+  # Missing ledger exits 0 with a note.
+  out=$(FM_DATA_OVERRIDE="$TMP_ROOT/empty-home" "$REPORT" 2>&1)
+  expect_code 0 "$?" "report without a ledger should exit 0"
+  assert_contains "$out" "no usage ledger" "report names the missing ledger"
+  pass "usage report: per-model totals, per-task rows, missing-ledger tolerance"
+}
+
+# --- teardown integration: harvest failure never blocks teardown ------------
+
+teardown_case() {
+  local proj wt id fb state data config out
+  id=usageharvtd1
+  proj="$TMP_ROOT/td-proj"; wt="$TMP_ROOT/td-wt"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  fb="$TMP_ROOT/td-fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fb/treehouse" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fb/tmux" "$fb/treehouse"
+  state="$TMP_ROOT/td-state"; config="$TMP_ROOT/td-config"; data="$TMP_ROOT/td-data"
+  mkdir -p "$state" "$config" "$data/$id"
+  printf 'scout findings\n' > "$data/$id/report.md"
+  fm_write_meta "$state/$id.meta" \
+    "window=firstmate:fm-$id" "worktree=$wt" "project=$proj" "harness=claude" \
+    "kind=scout" "mode=no-mistakes" "yolo=off" \
+    "decisions_reviewed=1" "decision_keys="
+  printf 'working: scouting\n' > "$state/$id.status"
+  # The ledger path being a directory forces every append to fail.
+  mkdir -p "$data/usage-ledger.jsonl"
+  out=$(PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_USAGE_CLAUDE_DIR="$TMP_ROOT/td-fake-claude" FM_USAGE_CODEX_DIR="$TMP_ROOT/td-fake-codex" \
+    "$TEARDOWN" "$id" 2>&1)
+  expect_code 0 "$?" "teardown must succeed even when the harvest fails"$'\n'"$out"
+  assert_contains "$out" "warning: usage harvest for $id failed" \
+    "teardown warns one line when the harvest fails"
+  assert_contains "$out" "teardown $id complete" \
+    "teardown completes after a harvest failure"
+  pass "teardown integration: harvest failure is non-fatal"
+}
+
+claude_case
+codex_case
+cursor_case
+report_case
+teardown_case

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -60,15 +60,20 @@ export_harvest_env() {  # <home-data>
 # --- claude: request dedupe, cache folding, encoding resolution, window -----
 
 claude_case() {
-  local id=usageclaude1 wt="$TMP_ROOT/wt-usageclaude1"
+  # The worktree path carries a dot segment (as every firstmate home under
+  # .no-mistakes does) so a slash-only encoding would resolve to the wrong
+  # on-disk project directory.
+  local id=usageclaude1 wt="$TMP_ROOT/.no-mistakes/wt-usageclaude1"
   local data home state ledger row
   data=$(harvest_case "$id" claude "$wt" default default)
   home=$(dirname "$data")
   state="$home/state"
   export_harvest_env "$home"
 
-  # The encoded directory is the worktree path with every '/' turned into '-'.
+  # Claude Code encodes the project directory by mapping BOTH '/' and '.' to
+  # '-', so the fixture log dir mirrors that full sanitization.
   local encoded=${wt//\//-}
+  encoded=${encoded//./-}
   local logdir="$FM_USAGE_CLAUDE_DIR/$encoded"
   mkdir -p "$logdir"
   cat > "$logdir/session-a.jsonl" <<'JSON'
@@ -194,6 +199,71 @@ cursor_case() {
   pass "cursor harvest: unavailable source renders null token fields"
 }
 
+# --- claude: window survives a host without usable birth time ---------------
+
+# A stat shim that reports no birth time (GNU statx unsupported returns 0 for
+# %W) while still answering mtime, so the harvest must fall back to the meta
+# mtime for the window start instead of collapsing to the status mtime.
+nobirth_stat_bin() {  # <dir>
+  mkdir -p "$1"
+  cat > "$1/stat" <<'SH'
+#!/usr/bin/env bash
+fmt=""; file=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -f) exit 1 ;;
+    -c) fmt="$2"; shift 2 ;;
+    --) shift; file="$1"; shift ;;
+    *) file="$1"; shift ;;
+  esac
+done
+case "$fmt" in
+  %W) printf '0\n' ;;
+  %Y) /usr/bin/stat -f %m -- "$file" 2>/dev/null || /usr/bin/stat -c %Y -- "$file" ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$1/stat"
+}
+
+claude_nobirth_case() {
+  local id=usagenobirth1 wt="$TMP_ROOT/.no-mistakes/wt-usagenobirth1"
+  local data home state ledger row out fb base
+  data=$(harvest_case "$id" claude "$wt" default default)
+  home=$(dirname "$data")
+  state="$home/state"
+  export_harvest_env "$home"
+
+  local encoded=${wt//\//-}
+  encoded=${encoded//./-}
+  local logdir="$FM_USAGE_CLAUDE_DIR/$encoded"
+  mkdir -p "$logdir"
+  cat > "$logdir/session.jsonl" <<'JSON'
+{"type":"assistant","message":{"id":"msgN","model":"claude-test","usage":{"input_tokens":12,"output_tokens":8}}}
+JSON
+
+  # Pin an explicit window: status finishes at T, meta was spawned 100s earlier,
+  # and the session log lands mid-window. Without the meta-mtime start fallback
+  # the birthless window collapses to [T, T] and drops the earlier log.
+  base=$(file_mtime_epoch "$state/$id.status")
+  touch -t "$(date -r "$base" +%Y%m%d%H%M.%S)" "$state/$id.status"
+  touch -t "$(date -r $((base - 100)) +%Y%m%d%H%M.%S)" "$state/$id.meta"
+  touch -t "$(date -r $((base - 50)) +%Y%m%d%H%M.%S)" "$logdir/session.jsonl"
+
+  fb="$TMP_ROOT/nobirth-fakebin"
+  nobirth_stat_bin "$fb"
+  out=$(PATH="$fb:$PATH" "$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "birthless claude harvest should succeed"$'\n'"$out"
+  ledger="$data/usage-ledger.jsonl"
+  row=$(cat "$ledger")
+  assert_contains "$row" '"source":"claude-projects"' \
+    "birthless harvest still finds the in-window log via the meta-mtime start"
+  assert_contains "$row" '"input_tokens":12' "birthless harvest sums the in-window usage"
+  assert_contains "$row" '"wall_secs":100' \
+    "birthless window spans meta -> status instead of collapsing to zero"
+  pass "claude harvest: window survives a host without usable birth time"
+}
+
 # --- report: per-model totals and per-task rows -----------------------------
 
 report_case() {
@@ -258,6 +328,7 @@ SH
 }
 
 claude_case
+claude_nobirth_case
 codex_case
 cursor_case
 report_case

--- a/tests/fm-usage-harvest.test.sh
+++ b/tests/fm-usage-harvest.test.sh
@@ -264,6 +264,63 @@ JSON
   pass "claude harvest: window survives a host without usable birth time"
 }
 
+# --- remote secondmate: local logs are never harvested for remote work ------
+
+remote_case() {
+  local id=usageremote1 wt="$TMP_ROOT/wt-usageremote1"
+  local data home ledger row out
+  data=$(harvest_case "$id" codex "$wt" default high)
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+  # The task ran on a remote secondmate host (fm-spawn records remote_host=).
+  printf 'remote_host=box.example\n' >> "$home/state/$id.meta"
+  # Seed a LOCAL codex session whose cwd matches the worktree: without the
+  # remote-host guard the harvest would misattribute this local session to the
+  # remote task; with it, the row is honestly unavailable and its tokens null.
+  local d1="$FM_USAGE_CODEX_DIR/2026/08/28"
+  mkdir -p "$d1"
+  cat > "$d1/rollout-localmatch.jsonl" <<JSON
+{"type":"session_meta","payload":{"cwd":"$wt"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":500,"output_tokens":400}}}}
+{"type":"turn_context","payload":{"cwd":"$wt","model":"glm-5.3"}}
+JSON
+  touch -m -r "$d1/rollout-localmatch.jsonl" "$home/state/$id.status"
+
+  out=$("$HARVEST" "$id" 2>&1)
+  expect_code 0 "$?" "remote harvest should succeed"$'\n'"$out"
+  ledger="$home/data/usage-ledger.jsonl"
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = 1 ] || fail "remote harvest wrote no single row"
+  row=$(cat "$ledger")
+  assert_contains "$row" '"source":"unavailable"' \
+    "remote task records unavailable, not a local session"
+  assert_contains "$row" '"input_tokens":null' \
+    "remote task tokens are null (no local misattribution)"
+  pass "remote secondmate harvest: local logs are never misattributed"
+}
+
+# --- concurrency: the ledger lock keeps the append idempotent ---------------
+
+race_case() {
+  local id=usagerace1 wt="$TMP_ROOT/wt-usagerace1"
+  local data home ledger p1 p2
+  data=$(harvest_case "$id" cursor "$wt" cursor-x "")
+  home=$(dirname "$data")
+  export_harvest_env "$home"
+  ledger="$home/data/usage-ledger.jsonl"
+  # Two concurrent harvests with a widened check-to-append window: the ledger
+  # lock must serialize them so exactly one row is appended. Without the lock
+  # both pass the existence check and each append, yielding two rows.
+  FM_USAGE_HARVEST_APPEND_DELAY=1 "$HARVEST" "$id" >/dev/null 2>&1 &
+  p1=$!
+  FM_USAGE_HARVEST_APPEND_DELAY=1 "$HARVEST" "$id" >/dev/null 2>&1 &
+  p2=$!
+  wait "$p1"; wait "$p2"
+  [ -f "$ledger" ] || fail "concurrent harvest wrote no ledger"
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = 1 ] \
+    || fail "concurrent harvests appended more than one row"
+  pass "usage harvest: concurrent harvests append exactly one row"
+}
+
 # --- report: per-model totals and per-task rows -----------------------------
 
 report_case() {
@@ -331,5 +388,7 @@ claude_case
 claude_nobirth_case
 codex_case
 cursor_case
+remote_case
+race_case
 report_case
 teardown_case

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -40,3 +40,27 @@ herdr_refuse_if_default() { # <session>
 herdr_safe_stop_and_delete() { # <session>
   fm_herdr_lab_teardown "$1"
 }
+
+# herdr_pane_run_foreground: give <pane> in <session> a real, long-lived,
+# non-shell foreground process and wait until Herdr's own inventory reports it.
+#
+# A case that means "this pane hosts a genuinely live agent" needs both halves
+# the liveness classifier reads: a registration AND a pane that is actually
+# running something. `pane report-agent` alone leaves a registration standing
+# over a bare idle shell, which is the husk shape, not the live one
+# (docs/herdr-backend.md "Restart and liveness behavior"). Requires the herdr
+# backend adapter to be sourced.
+herdr_pane_run_foreground() {  # <session> <pane> [command]
+  local session=$1 pane=$2 cmd=${3:-sleep 600} attempt=0 names
+  fm_backend_herdr_cli "$session" pane run "$pane" "$cmd" >/dev/null 2>&1 || return 1
+  while [ "$attempt" -lt 200 ]; do
+    names=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null \
+      | jq -r '[.result.process_info.foreground_processes[]?.name] | join(",")' 2>/dev/null)
+    case "$names" in
+      *"${cmd%% *}"*) return 0 ;;
+    esac
+    sleep 0.05
+    attempt=$((attempt + 1))
+  done
+  return 1
+}


### PR DESCRIPTION
## Intent

Fix the safe-relaunch defect reproduced on the task fm-pr-lifecycle-followthrough-monitor: its Pi worker exited cleanly to a zsh shell, and Herdr's process inventory showed no live Pi agent, but two supported `bin/fm-control.sh <task> relaunch` attempts classified the agent as alive, typed `/quit` into zsh, and failed without launching a replacement. The preserved PR branch and existing work had to remain untouched.

Required approach, all of it deliberate:
- Read the executable control owner, the Herdr backend, the Pi busy/session bindings, the agent-control documentation, and the current behavioral tests before choosing the fix.
- Reproduce the disagreement through public control/backend interfaces in a required isolated Herdr lab session (bin/fm-herdr-lab.sh), never the captain's default session.
- Make an agent-free shell positively and safely eligible for same-task relaunch while refusing genuinely live, ambiguous, unreadable, or conflicting ownership.
- Preserve the control plane as the only lifecycle owner: add no raw pane-key, direct Herdr, broad process-kill, or metadata-surgery bypass.
- Preserve uncommitted changes, commits, branch identity, and task records on every success and refusal path.
- Add deterministic behavioral coverage for an exited Pi shell, a live Pi agent, ambiguous process inventory, stale Pi busy/session evidence, failure to stop a genuinely live agent, replacement-launch failure and rollback, and preserved branch/work.
- Review consequences for every supported harness and runtime backend rather than special-casing the current fleet without evidence.
- Keep exact mechanics in the script help/header owner, and update maintained documentation and active verification only where the behavior contract changes.
- Ship through no-mistakes to a green review-ready PR; do not merge.

Root cause established empirically, not assumed. Herdr's agent registry is written by whatever reports into it, and a report is not withdrawn when the process that made it goes away, so a registration can outlive the agent it describes. bin/backends/herdr.sh's fm_backend_herdr_pane_agent_state derived `live` from `herdr agent get` alone, with no corroboration, so the endpoint read `alive` forever and every lifecycle verb typed the harness exit command at a shell. Verified on the installed herdr 0.8.2 in an isolated fm-lab- session: a `pane report-agent` from a source herdr does not itself own stays registered on a pane running nothing but zsh (agent get keeps answering idle) while `pane process-info` reports one bare zsh; herdr does validate a report claiming a source it owns, so an otherwise identical --source herdr:pi report on the same pane was rejected. The tmux classifier never had this hole because it settles negative verdicts from the foreground process group.

Chosen design and the tradeoffs behind it:
- The fix is deliberately in the shared classifier fm_backend_herdr_pane_agent_state, not a second Herdr state machine and not a special case inside fm-control.sh. A pane holding a lone bare idle shell is not a running agent, so one classifier keeps fm_backend_agent_state, fm_backend_herdr_tab_is_husk, create-time husk replacement, presentation reclaim, and the watcher all agreeing. The existing code comments explicitly value not creating a second state machine.
- It reuses the existing single owner of the idle-shell proof (fm_backend_herdr_pane_idle_shell_sample), which the pane-death close path already trusts for a destructive action; reusing it for a non-destructive classification downgrade is strictly weaker.
- One strict instantaneous sample is used rather than the retrying proof, on purpose: the retry loop would add up to a second to every healthy `alive` read in poll loops for no benefit, while a single sample keeps the hot path to one extra herdr call plus ps. The corroboration is positive-only, so a transient prompt helper simply keeps `live` for that sample and the next poll settles it; every caller that acts on the negative verdict already polls.
- The verdict can only move from `live` toward `no-agent`, never the other way. A live harness process, an extra foreground process, a shell with a child, an unreadable inventory, and an inventory answering about a different pane all leave `live` standing, which is what satisfies the refuse-genuinely-live/ambiguous/unreadable/conflicting requirement.
- fm-control.sh and fm-spawn.sh are deliberately unchanged: both already gate on the classifier's `dead`, so do_exit becomes idempotent (already-stopped) and the replacement launch proceeds, with no new lifecycle path.
- The busy-state classifier (fm_backend_herdr_busy_state) is deliberately NOT changed. It is read in tight submit-confirmation loops where a process-info call per poll would be a real cost regression, and the control plane never reaches busy for a pane the classifier now proves dead. This is a noted observation, not an omission.

Per-backend and per-harness review, with evidence rather than assumption: only the herdr adapter changes. tmux already reads the foreground process group; zellij, orca, and cmux have no recovery-grade classifier, report `unverified`, and already refuse exit and relaunch. Because the proof reads a process name and argv0 the harness vendor controls, a new opt-in real-harness drift guard launches every INSTALLED harness for real and fails naming the harness and version if a running one ever proves a bare idle shell. Measured on herdr 0.8.2: claude 2.1.252, codex 0.150.1, opencode 1.17.11, pi 0.84.4, and cursor 2026.08.31 all own the pane foreground under their own argv0 and stay alive; pi-signed, grok, kimi, and muse are not installed and are reported explicitly, and the guard refuses a pass that checked nothing.

Test changes that are deliberate consequences, not incidental churn: three existing real-Herdr cases (fm-backend-herdr-smoke, fm-backend-herdr-respawn-idem-e2e, fm-backend-herdr-presentation-e2e) registered an agent on a shell-only pane to mean 'a genuinely live duplicate'. Under the corrected contract that setup is the husk shape, so each now gives the pane a real foreground process first through one shared helper added to tests/herdr-test-safety.sh. That also removes a pre-existing flake in which herdr dropped the bare registration mid-test. tests/fm-control-herdr-smoke.test.sh previously encoded the buggy behavior as expected and now runs the identical registered reading twice, once over a plain shell and once over a real foreground process.

Verification actually run: bin/fm-lint.sh clean, bin/fm-doc-audience-check.sh clean, bin/fm-test-run.sh --check-coverage clean, and fm-backend-herdr, fm-control, fm-control-relaunch, fm-control-herdr-smoke, fm-test-run, fm-documentation-audiences, fm-backend, and fm-crew-state all green. Ten suites fail on this machine (seven real-Herdr end-to-end suites plus composer-lib, muse-harness, and spawn-dispatch-profile); every one of those failures was reproduced on the unmodified baseline across three runs with the pre-change file swapped back in, so they are pre-existing herdr 0.8.2 and local-toolchain drift, not regressions from this change.

Repo conventions that apply: one sentence per line in tracked Markdown, plain dash never an em dash, no agent co-author on commits, bin/*.sh shellcheck-clean, tests colocated in tests/ as <subject>.test.sh extending existing runners, tests must exercise public or executable interfaces and never assert implementation-source bytes, and maintainer-verification records under docs/verification/ carry dated versions, exact commands, and exact output for current guarantees only.

## What Changed

- `fm_backend_herdr_pane_agent_state` in `bin/backends/herdr.sh` no longer trusts `herdr agent get` alone: when a registration is reported, it takes one strict instantaneous `fm_backend_herdr_pane_idle_shell_sample`, and a pane positively proven to hold a lone bare idle shell now classifies as `no-agent` instead of `live`. The downgrade is positive-only, so a live harness process, an extra foreground process, a shell with a child, an unreadable inventory, or an inventory answering about a different pane all keep `live`. `fm-control.sh` and `fm-spawn.sh` are unchanged and pick this up through the classifier they already gate on, which makes exit idempotent over an exited shell and lets the same-task replacement launch. New coverage lands in `tests/fm-backend-herdr.test.sh`, `tests/fm-control-relaunch.test.sh`, `tests/fm-control-herdr-smoke.test.sh`, and the opt-in `tests/fm-herdr-agent-free-proof-live-e2e.test.sh` drift guard; three existing real-Herdr suites now give their pane a real foreground process through a shared helper added to `tests/herdr-test-safety.sh`.
- `bin/fm-spawn.sh` replaces the blanket-bypass launch flags with sandboxed autonomy per harness: claude runs `--permission-mode auto`, codex runs `-s workspace-write -a never`, and cursor runs `--auto-review --sandbox enabled` instead of `--yolo`. A new `__ADDDIRS__` placeholder grants `--add-dir` for exactly the two paths the brief permits outside the worktree, `state/` for every kind plus `data/<task-id>/` for a scout, so a sandboxed crewmate can still append the status file it reports through. `tests/fm-crewmate-autonomy-live-e2e.test.sh` is the opt-in real-harness guard, and `bin/fm-test-run.sh` re-selects the live family on a spawn-template edit.
- New `bin/fm-usage-harvest.sh` appends one JSON row per finished task to the gitignored `data/usage-ledger.jsonl`, summing per-request token usage from the worker's own claude or codex session logs and falling back to a null-token `unavailable` row for cursor, remote, or unmatched tasks; it is idempotent per task id. New `bin/fm-usage-report.sh` reads that ledger into per-model and per-task plain text, and `bin/fm-teardown.sh` calls the harvester best-effort on both teardown paths while the state files still exist, warning rather than failing. Docs and the maintainer verification records under `docs/`, plus `.agents/skills/harness-adapters/SKILL.md`, are updated for the new classifier contract, the measured autonomy and write posture per harness, and the two new scripts.

## Risk Assessment

✅ Low: The reviewed lane is well-bounded and positive-only (the classifier can only move live toward no-agent, every ambiguous/unreadable/foreign-pane input still reads live), the fix round's three changes each verify correct against the code they target, and the sole substantiated defect is a graceful-degradation portability issue in adjacent harvester code that yields null token fields rather than wrong data.

## Testing

<code>I read the classifier, the control plane, the Herdr adapter, and the existing behavioral tests, then reproduced the reported defect and its fix end-to-end through the real operator interface rather than only through unit tests. In a private throwaway `fm-lab-*` Herdr session against the installed herdr 0.8.2, I stood up a task whose pane holds nothing but zsh with a stale agent registration and a real worktree carrying both a commit and uncommitted work, and ran `bin/fm-control.sh &lt;task&gt; relaunch` twice: against a scratch copy with the pre-fix `bin/backends/herdr.sh` it classified `alive`, typed `/quit` at the shell, and failed with no replacement; on this branch the identical fixture classifies `dead`, records `already-stopped`, types no `/quit`, launches the replacement into the pane foreground, and leaves the branch, HEAD, uncommitted file, and progress note untouched. On top of that I ran the targeted automated set: the portable classifier and relaunch suites are green including all new cases, the real-Herdr control-plane smoke suite is green 9/9, and the opt-in per-harness drift guard launched all five installed harnesses for real and confirmed none can be mistaken for a bare idle shell. The one failing suite, tests/fm-backend-herdr-smoke.test.sh, fails identically on the unmodified baseline, so it is pre-existing local herdr drift and not a regression; the working tree is clean and no lab sessions were left behind.</code>

<details>
<summary>Evidence: Evidence index: before/after relaunch, drift guard, smoke, behavioral cases</summary>

Source: [Evidence index: before/after relaunch, drift guard, smoke, behavioral cases](https://github.com/npayette84/firstmate/blob/46c430b0d2be6ee9ab59111c4ceacbed514fb080/.no-mistakes/evidence/fm/fm-control-pi-exited-shell-relaunch/README.md)

```text
# Safe relaunch over an exited Pi shell - end-to-end evidence

The reported defect: on a Herdr endpoint whose Pi worker had exited cleanly to a
zsh shell, `bin/fm-control.sh <task> relaunch` classified the agent as alive,
typed `/quit` at the shell, and failed without launching a replacement.

Everything below ran on this machine against the real installed `herdr 0.8.2`,
inside private throwaway `fm-lab-*` sessions only (`bin/fm-herdr-lab.sh`), never
the captain's default session. `relaunch-e2e-demo.sh` is the exact reproduction
script; it stands up a real git worktree with committed and uncommitted work, a
real Herdr task pane holding nothing but zsh, and a stale `pane report-agent`
registration, then runs the supported operator command.

No model tokens were spent: the replacement harness is a shim that idles in the
pane's foreground, which is what the liveness classifier actually reads.

## The two transcripts

| file | code under test | result |
| --- | --- | --- |
| `relaunch-e2e-before-prefix-classifier.txt` | pre-fix `bin/backends/herdr.sh` | reproduces the bug |
| `relaunch-e2e-after-fixed-classifier.txt` | this branch | relaunch succeeds |

Pre-fix, from the same fixture:

    firstmate's own classifier    ->  fm_backend_agent_state herdr = alive
    error: exit-delivered demo interrupt=not-needed exit-command=delivered agent-state=alive exit=unconfirmed; the agent did not stop within 3s
    error: relaunch of demo failed while stopping the old agent, which is still running; its original instructions were restored
    exit status: 1
    pane received /quit: YES  <- the harness exit command was typed at a zsh prompt
    pane foreground now: [{"name":"zsh","argv0":"zsh"}]

On this branch, same fixture, same command:

    firstmate's own classifier    ->  fm_backend_agent_state herdr = dead
    relaunched demo harness=pi from=pi model=default effort=default backend=herdr endpoint=... worktree=...
    exit status: 0
    pane received /quit: no
    pane foreground now: [{"name":"sleep","argv0":"sleep"}]        <- the replacement is running
    branch:            task-demo
    HEAD unchanged:    yes
    uncommitted file:  work the previous worker had not committed
    committed file:    committed on the preserved branch
    journal exit_result: exit_result=already-stopped
    progress note in the replacement's instructions: yes

Both runs read the identical Herdr disagreement first, so the change of verdict
comes from the corroboration and nothing else:

    $ herdr agent get w1:p2      ->  agent_status: idle
    $ herdr pane process-info    ->  foreground: [{"name":"zsh","argv0":"zsh"}]

## Supporting artifacts

- `real-herdr-control-plane-smoke.txt` - `tests/fm-control-herdr-smoke.test.sh`
  against the real binary: exit is idempotent on the proved-agent-free pane and
  types no `/quit`, interrupt still refuses there, the same registration over a
  genuinely running foreground process stays alive, an agent that cannot be
  stopped still fails closed, and no verb removed the endpoint, the local copy,
  or the branch.
- `installed-harness-agent-free-drift-guard.txt` - the opt-in per-harness guard
  (`FM_HERDR_AGENT_FREE_PROOF=1`), launching every INSTALLED harness for real in
  a Herdr pane. claude 2.1.257, codex 0.150.1, opencode 1.17.11, pi 0.84.4, and
  cursor 2026.08.31 each own the pane foreground and read `alive`; none is
  mistaken for a bare idle shell. pi-signed, grok, kimi, and muse are reported
  as not installed rather than silently passing.
- `classifier-and-relaunch-behavioral-cases.txt` - the deterministic cases:
  live process, ambiguous inventory, shell with a child, unreadable inventory,
  inventory about another pane, unregistered pane, husk replacement, and both
  relaunch paths (success and replacement-launch failure with work preserved).
```
</details>
<details>
<summary>Evidence: CLI transcript - pre-fix classifier reproduces the defect</summary>

Source: [CLI transcript - pre-fix classifier reproduces the defect](https://github.com/npayette84/firstmate/blob/46c430b0d2be6ee9ab59111c4ceacbed514fb080/.no-mistakes/evidence/fm/fm-control-pi-exited-shell-relaunch/relaunch-e2e-before-prefix-classifier.txt)

<code>=== the reported disagreement (herdr 0.8.2) ===&#10;$ herdr agent get w1:p2 -&gt; agent_status: idle&#10;$ herdr pane process-info -&gt; foreground: [{&#34;name&#34;:&#34;zsh&#34;,&#34;argv0&#34;:&#34;zsh&#34;}]&#10;firstmate&#39;s own classifier -&gt; fm_backend_agent_state herdr = alive&#10;&#10;=== operator runs the supported control verb ===&#10;$ bin/fm-control.sh demo relaunch --note &#39;prior Pi worker exited to a shell after the PR went green&#39;&#10;error: exit-delivered demo interrupt=not-needed exit-command=delivered agent-state=alive exit=unconfirmed; the agent did not stop within 3s&#10;error: relaunch of demo failed while stopping the old agent, which is still running; its original instructions were restored&#10;exit status: 1&#10;&#10;=== what reached the pane ===&#10;pane received /quit: YES &lt;- the harness exit command was typed at a zsh prompt&#10;pane foreground now: [{&#34;name&#34;:&#34;zsh&#34;,&#34;argv0&#34;:&#34;zsh&#34;}]</code>

```text

=== the reported disagreement (herdr herdr 0.8.2) ===
$ herdr agent get w1:p2   ->  agent_status: idle
$ herdr pane process-info    ->  foreground: [{"name":"zsh","argv0":"zsh"}]
firstmate's own classifier    ->  fm_backend_agent_state herdr = alive

=== operator runs the supported control verb ===
$ bin/fm-control.sh demo relaunch --note 'prior Pi worker exited to a shell after the PR went green'
error: exit-delivered demo interrupt=not-needed exit-command=delivered agent-state=alive exit=unconfirmed; the agent did not stop within 3s
error: relaunch of demo failed while stopping the old agent, which is still running; its original instructions were restored
exit status: 1

=== what reached the pane ===
pane received /quit: YES  <- the harness exit command was typed at a zsh prompt
pane foreground now: [{"name":"zsh","argv0":"zsh"}]
endpoint still exists: yes

=== preserved work ===
branch:            task-demo
HEAD unchanged:    yes
uncommitted file:  work the previous worker had not committed
committed file:    committed on the preserved branch
task record harness=pi
journal exit_result: 
progress note in the replacement's instructions: no
```
</details>
<details>
<summary>Evidence: CLI transcript - this branch relaunches successfully and preserves the work</summary>

Source: [CLI transcript - this branch relaunches successfully and preserves the work](https://github.com/npayette84/firstmate/blob/46c430b0d2be6ee9ab59111c4ceacbed514fb080/.no-mistakes/evidence/fm/fm-control-pi-exited-shell-relaunch/relaunch-e2e-after-fixed-classifier.txt)

<code>=== the reported disagreement (herdr 0.8.2) ===&#10;$ herdr agent get w1:p2 -&gt; agent_status: idle&#10;$ herdr pane process-info -&gt; foreground: [{&#34;name&#34;:&#34;zsh&#34;,&#34;argv0&#34;:&#34;zsh&#34;}]&#10;firstmate&#39;s own classifier -&gt; fm_backend_agent_state herdr = dead&#10;&#10;=== operator runs the supported control verb ===&#10;$ bin/fm-control.sh demo relaunch --note &#39;prior Pi worker exited to a shell after the PR went green&#39;&#10;relaunched demo harness=pi from=pi model=default effort=default backend=herdr endpoint=fm-lab-relaunch-demo-after:w1:p2 worktree=.../wt&#10;exit status: 0&#10;&#10;=== what reached the pane ===&#10;pane received /quit: no&#10;pane foreground now: [{&#34;name&#34;:&#34;sleep&#34;,&#34;argv0&#34;:&#34;sleep&#34;}]&#10;endpoint still exists: yes&#10;&#10;=== preserved work ===&#10;branch: task-demo&#10;HEAD unchanged: yes&#10;uncommitted file: work the previous worker had not committed&#10;committed file: committed on the preserved branch&#10;journal exit_result: exit_result=already-stopped&#10;progress note in the replacement&#39;s instructions: yes</code>

```text

=== the reported disagreement (herdr herdr 0.8.2) ===
$ herdr agent get w1:p2   ->  agent_status: idle
$ herdr pane process-info    ->  foreground: [{"name":"zsh","argv0":"zsh"}]
firstmate's own classifier    ->  fm_backend_agent_state herdr = dead

=== operator runs the supported control verb ===
$ bin/fm-control.sh demo relaunch --note 'prior Pi worker exited to a shell after the PR went green'
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
warning: /var/folders/70/p814fs691f103nxddhx58mhh0000gn/T/fm-relaunch-demo.3t9LUO/home/data/demo/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
relaunched demo harness=pi from=pi model=default effort=default backend=herdr endpoint=fm-lab-relaunch-demo-after-81013:w1:p2 worktree=/var/folders/70/p814fs691f103nxddhx58mhh0000gn/T/fm-relaunch-demo.3t9LUO/wt
exit status: 0

=== what reached the pane ===
pane received /quit: no
pane foreground now: [{"name":"sleep","argv0":"sleep"}]
endpoint still exists: yes

=== preserved work ===
branch:            task-demo
HEAD unchanged:    yes
uncommitted file:  work the previous worker had not committed
committed file:    committed on the preserved branch
task record harness=pi
journal exit_result: exit_result=already-stopped
progress note in the replacement's instructions: yes
```
</details>
<details>
<summary>Evidence: Reproduction script used for the before/after transcripts</summary>

Source: [Reproduction script used for the before/after transcripts](https://github.com/npayette84/firstmate/blob/46c430b0d2be6ee9ab59111c4ceacbed514fb080/.no-mistakes/evidence/fm/fm-control-pi-exited-shell-relaunch/relaunch-e2e-demo.sh)

```text
#!/usr/bin/env bash
# Manual end-to-end evidence: bin/fm-control.sh <task> relaunch over a Herdr
# pane whose Pi worker already exited to a zsh shell, with a stale agent
# registration left behind. Runs entirely inside a private, throwaway Herdr lab
# session (bin/fm-herdr-lab.sh), never the captain's default session.
#
# usage: relaunch-demo.sh <repo-root> <label>
set -u
ROOT=$(cd "$1" && pwd); LABEL=$2
export FM_GATE_REFUSE_BYPASS=1

say() { printf '\n=== %s ===\n' "$*"; }

unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
SESSION="fm-lab-relaunch-demo-$LABEL-$$"
SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-relaunch-demo.XXXXXX"); SCRATCH=$(cd "$SCRATCH" && pwd)
cleanup() { herdr_safe_stop_and_delete "$SESSION" >/dev/null 2>&1 || true; rm -rf "$SCRATCH"; }
trap cleanup EXIT

# shellcheck source=/dev/null
. "$ROOT/tests/herdr-test-safety.sh"
export HERDR_SESSION="$SESSION"
fm_herdr_lab_prepare "$SESSION" >/dev/null || { echo "could not prepare lab session"; exit 1; }

# --- a task with real work to preserve --------------------------------------
HOME_DIR="$SCRATCH/home"; mkdir -p "$HOME_DIR/state" "$HOME_DIR/data/demo"
printf '# Ship the PR lifecycle follow-through monitor\n' > "$HOME_DIR/data/demo/brief.md"
PROJ="$SCRATCH/proj"; WT="$SCRATCH/wt"; mkdir -p "$PROJ"
git -C "$PROJ" init -q
printf '# proj\n' > "$PROJ/README.md"
git -C "$PROJ" add README.md
git -C "$PROJ" -c user.name='Demo' -c user.email='demo@example.invalid' commit -qm initial
git -C "$PROJ" worktree add --quiet -b task-demo "$WT"
printf 'work the previous worker had not committed\n' > "$WT/scratch.txt"
printf 'committed on the preserved branch\n' > "$WT/landed.txt"
git -C "$WT" add landed.txt
git -C "$WT" -c user.name='Demo' -c user.email='demo@example.invalid' commit -qm 'prior worker commit'
HEAD_BEFORE=$(git -C "$WT" rev-parse HEAD)

# --- a fake pi executable: no tokens, but a REAL foreground process ----------
mkdir -p "$SCRATCH/fakebin"
cat > "$SCRATCH/fakebin/pi" <<'SH'
#!/usr/bin/env bash
case "${1:-}" in --help|--version) echo "fake pi (evidence shim)"; exit 0 ;; esac
exec sleep 900
SH
chmod +x "$SCRATCH/fakebin/pi"
export PATH="$SCRATCH/fakebin:$PATH"

# --- the endpoint: a pane whose worker exited to its shell -------------------
# shellcheck source=/dev/null
. "$ROOT/bin/fm-backend.sh"
fm_backend_source herdr || { echo "fm_backend_source herdr failed"; exit 1; }
CONTAINER_RAW=$(fm_backend_herdr_container_ensure "$WT") || exit 1
CONTAINER=${CONTAINER_RAW%%$'\t'*}; SEEDED=${CONTAINER_RAW#*$'\t'}
WORKSPACE_ID=${CONTAINER#*:}
IDS=$(fm_backend_herdr_create_task "$CONTAINER" fm-demo "$WT" "$SEEDED") || exit 1
read -r TAB_ID PANE_ID <<EOF
$IDS
EOF
{
  echo "window=$SESSION:$PANE_ID"; echo "endpoint_task_id=demo"; echo "worktree=$WT"
  echo "project=$PROJ"; echo "harness=pi"; echo "kind=ship"; echo "mode=no-mistakes"
  echo "yolo=off"; echo "model=default"; echo "effort=default"; echo "backend=herdr"
  echo "herdr_session=$SESSION"; echo "herdr_workspace_id=$WORKSPACE_ID"
  echo "herdr_tab_id=$TAB_ID"; echo "herdr_pane_id=$PANE_ID"
} > "$HOME_DIR/state/demo.meta"

# The Pi worker exited cleanly; nothing withdrew its registration.
herdr pane report-agent "$PANE_ID" --source fm-pi-ext --agent pi-worker \
  --state idle --session "$SESSION" >/dev/null 2>&1 \
  || { echo "could not leave a stale registration"; exit 1; }

say "the reported disagreement (herdr $(herdr --version 2>/dev/null | head -1))"
echo "\$ herdr agent get $PANE_ID   ->  agent_status: $(herdr agent get "$PANE_ID" --session "$SESSION" 2>/dev/null | jq -r '.result.agent.agent_status // "none"')"
echo "\$ herdr pane process-info    ->  foreground: $(herdr pane process-info --pane "$PANE_ID" --session "$SESSION" 2>/dev/null | jq -c '[.result.process_info.foreground_processes[]? | {name, argv0}]')"
echo "firstmate's own classifier    ->  fm_backend_agent_state herdr = $(fm_backend_agent_state herdr "$SESSION:$PANE_ID")"

say "operator runs the supported control verb"
echo "\$ bin/fm-control.sh demo relaunch --note 'prior Pi worker exited to a shell after the PR went green'"
OUT=$(env FM_HOME="$HOME_DIR" HERDR_SESSION="$SESSION" FM_CONTROL_POLL=0.2 \
  FM_CONTROL_EXIT_WAIT=3 FM_CONTROL_LAUNCH_WAIT=25 \
  "$ROOT/bin/fm-control.sh" demo relaunch \
  --note 'prior Pi worker exited to a shell after the PR went green' 2>&1)
RC=$?
printf '%s\n' "$OUT"
echo "exit status: $RC"

say "what reached the pane"
PANE_TEXT=$(herdr pane read "$PANE_ID" --session "$SESSION" --source recent --lines 200 2>/dev/null)
if printf '%s' "$PANE_TEXT" | grep -q '/quit'; then
  echo "pane received /quit: YES  <- the harness exit command was typed at a zsh prompt"
else
  echo "pane received /quit: no"
fi
echo "pane foreground now: $(herdr pane process-info --pane "$PANE_ID" --session "$SESSION" 2>/dev/null | jq -c '[.result.process_info.foreground_processes[]? | {name, argv0}]')"
echo "endpoint still exists: $(herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 && echo yes || echo NO)"

say "preserved work"
echo "branch:            $(git -C "$WT" rev-parse --abbrev-ref HEAD)"
echo "HEAD unchanged:    $([ "$(git -C "$WT" rev-parse HEAD)" = "$HEAD_BEFORE" ] && echo yes || echo NO)"
echo "uncommitted file:  $(cat "$WT/scratch.txt" 2>/dev/null)"
echo "committed file:    $(cat "$WT/landed.txt" 2>/dev/null)"
echo "task record harness=$(grep '^harness=' "$HOME_DIR/state/demo.meta" | cut -d= -f2)"
echo "journal exit_result: $(grep -h '^exit_result=' "$HOME_DIR/state/demo.control-relaunch" 2>/dev/null | tail -1)"
echo "progress note in the replacement's instructions: $(grep -q 'prior Pi worker exited' "$HOME_DIR/data/demo/brief.md" && echo yes || echo no)"
exit "$RC"
```
</details>
<details>
<summary>Evidence: Installed-harness agent-free drift guard (real harnesses in Herdr panes)</summary>

Source: [Installed-harness agent-free drift guard (real harnesses in Herdr panes)](https://github.com/npayette84/firstmate/blob/46c430b0d2be6ee9ab59111c4ceacbed514fb080/.no-mistakes/evidence/fm/fm-control-pi-exited-shell-relaunch/installed-harness-agent-free-drift-guard.txt)

<code># herdr: herdr 0.8.2&#10;# claude 2.1.257 (Claude Code): foreground=[2.1.257/claude] state=alive&#10;# codex codex-cli 0.150.1: foreground=[codex/codex] state=alive&#10;# opencode 1.17.11: foreground=[opencode/opencode] state=alive&#10;# pi 0.84.4: foreground=[node/pi] state=alive&#10;# cursor 2026.08.31-4057e58: foreground=[node/cursor-agent] state=alive&#10;# unverified on this machine (not installed): pi-signed grok kimi muse&#10;# checked 5 installed harness(es) on herdr 0.8.2 in workspace w1</code>

```text
# herdr: herdr 0.8.2
# claude 2.1.257 (Claude Code): foreground=[2.1.257/claude] state=alive
ok - herdr agent-free proof: claude 2.1.257 (Claude Code) running in a Herdr pane never proves a bare idle shell
# codex codex-cli 0.150.1: foreground=[codex/codex] state=alive
ok - herdr agent-free proof: codex codex-cli 0.150.1 running in a Herdr pane never proves a bare idle shell
# opencode 1.17.11: foreground=[opencode/opencode] state=alive
ok - herdr agent-free proof: opencode 1.17.11 running in a Herdr pane never proves a bare idle shell
# pi 0.84.4: foreground=[node/pi] state=alive
ok - herdr agent-free proof: pi 0.84.4 running in a Herdr pane never proves a bare idle shell
# skip: pi-signed is not installed on this machine, so its Herdr classification is unverified here
# skip: grok is not installed on this machine, so its Herdr classification is unverified here
# skip: kimi is not installed on this machine, so its Herdr classification is unverified here
# cursor 2026.08.31-4057e58: foreground=[node/cursor-agent] state=alive
ok - herdr agent-free proof: cursor 2026.08.31-4057e58 running in a Herdr pane never proves a bare idle shell
# skip: muse is not installed on this machine, so its Herdr classification is unverified here
# unverified on this machine (not installed): pi-signed grok kimi muse
# checked 5 installed harness(es) on herdr herdr 0.8.2 in workspace w1
```
</details>
<details>
<summary>Evidence: Real-Herdr control plane smoke suite</summary>

Source: [Real-Herdr control plane smoke suite](https://github.com/npayette84/firstmate/blob/46c430b0d2be6ee9ab59111c4ceacbed514fb080/.no-mistakes/evidence/fm/fm-control-pi-exited-shell-relaunch/real-herdr-control-plane-smoke.txt)

<code>ok - real herdr: exit on a pane with no registered agent is idempotent success&#10;ok - real herdr: interrupt refuses when herdr&#39;s own agent registry reports no agent&#10;ok - real herdr: a reported registration the pane&#39;s own process inventory contradicts reads agent-free&#10;ok - real herdr: an exited worker&#39;s pane is positively eligible for its replacement instead of being typed into&#10;ok - real herdr: interrupt still refuses on a pane whose registration outlived its agent&#10;ok - real herdr: the same registration over a running foreground process stays alive&#10;ok - real herdr: interrupt delivers the harness&#39;s key and proves the agent survived it&#10;ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped&#10;ok - real herdr: no control verb removed the endpoint, the task&#39;s local copy, or its branch</code>

```text
ok - real herdr: exit on a pane with no registered agent is idempotent success
ok - real herdr: interrupt refuses when herdr's own agent registry reports no agent
ok - real herdr: a reported registration the pane's own process inventory contradicts reads agent-free
ok - real herdr: an exited worker's pane is positively eligible for its replacement instead of being typed into
ok - real herdr: interrupt still refuses on a pane whose registration outlived its agent
ok - real herdr: the same registration over a running foreground process stays alive
ok - real herdr: interrupt delivers the harness's key and proves the agent survived it
ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
ok - real herdr: no control verb removed the endpoint, the task's local copy, or its branch
```
</details>
<details>
<summary>Evidence: New deterministic classifier and relaunch cases</summary>

Source: [New deterministic classifier and relaunch cases](https://github.com/npayette84/firstmate/blob/46c430b0d2be6ee9ab59111c4ceacbed514fb080/.no-mistakes/evidence/fm/fm-control-pi-exited-shell-relaunch/classifier-and-relaunch-behavioral-cases.txt)

<code>ok - herdr agent state: a reported registration contradicted by a lone bare idle shell reads agent-free, while the identical registration over a live process stays alive&#10;ok - herdr agent state: an ambiguous process inventory leaves a registered agent alive rather than licensing recovery&#10;ok - herdr agent state: a shell running a child of its own never proves an agent-free pane&#10;ok - herdr agent state: an unreadable process inventory leaves a registered agent alive&#10;ok - herdr agent state: a process inventory answering about a different pane never downgrades this pane&#39;s registration&#10;ok - herdr agent state: an unregistered pane is agent-free without reading the process inventory at all&#10;ok - fm_backend_herdr_create_task: a same-labeled tab with a live (even idle) registered agent still refuses exactly as before&#10;ok - fm_backend_herdr_create_task: a same-labeled tab whose registration outlived its agent is a husk on the same terms as a restored shell&#10;ok - fm-control relaunch: an endpoint whose agent already exited is replaced without an interrupt, without the exit command, and without touching the branch or its uncommitted work&#10;ok - fm-control relaunch: a replacement that never comes up still preserves the branch, the uncommitted work, and the progress note</code>

```text
ok - fm_backend_herdr_create_task: a same-labeled tab with a live (even idle) registered agent still refuses exactly as before
ok - herdr agent state: a reported registration contradicted by a lone bare idle shell reads agent-free, while the identical registration over a live process stays alive
ok - herdr agent state: an ambiguous process inventory leaves a registered agent alive rather than licensing recovery
ok - herdr agent state: a shell running a child of its own never proves an agent-free pane
ok - herdr agent state: an unreadable process inventory leaves a registered agent alive
ok - herdr agent state: a process inventory answering about a different pane never downgrades this pane's registration
ok - herdr agent state: an unregistered pane is agent-free without reading the process inventory at all
ok - fm_backend_herdr_create_task: a same-labeled tab whose registration outlived its agent is a husk on the same terms as a restored shell
ok - fm-control relaunch: an endpoint whose agent already exited is replaced without an interrupt, without the exit command, and without touching the branch or its uncommitted work
ok - fm-control relaunch: a replacement that never comes up still preserves the branch, the uncommitted work, and the progress note
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (15m45s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0c8b0c6139eef5ac0d7243a9b6c62c860c2f6398","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `.agents/skills/afk/SKILL.md` - branch carries 10 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (272 file(s)) into the PR:
- 12f6613 Merge pull request #1 from npayette84/fm/fm-harvester-ship
- 3ad41e8 no-mistakes: apply CI fixes
- ad467de no-mistakes: apply CI fixes
- b61545d no-mistakes: apply CI fixes
- 6b74583 no-mistakes(document): document usage harvester scripts; refresh stale spawn launch comments
- 1a16a6d no-mistakes(review): fix claude dot-encoding and birthless harvest window collapse
- 6f3e8ec fix(bin): create the ledger data dir before the harvest write, not after
- 9a2def5 add the fleet usage harvester, report reader, and teardown harvest hook
- 96b4c98 harden the Cursor launch default to sandboxed review
- 210839c harden crewmate launch defaults to sandboxed approval

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>⚠️ **Review** - 2 issues (1 warning, 1 info)</summary>

- 🚨 `bin/fm-spawn.sh:1117` - The codex launch template swapped `--dangerously-bypass-approvals-and-sandbox` for `-s workspace-write -a never`, which confines model-generated writes to the task worktree (cwd/TMPDIR). But bin/fm-brief.sh:318 tells every worker &#34;the only files you may write outside it are the report and the status file below&#34;, and bin/fm-brief.sh:179 puts that status file at $FM_HOME/state/&lt;id&gt;.status - a different repo entirely from the worktree. Failure: a codex ship crewmate runs `echo &#34;done: PR &lt;url&gt;&#34; &gt;&gt; $FM_HOME/state/&lt;id&gt;.status` (bin/fm-brief.sh:320-321), the sandbox denies the write, and `-a never` means it cannot ask for approval, so the completion signal the watcher, classifier, and teardown gate all read never lands and the task hangs as unreported. Nothing in the branch adds `writable_roots` or any codex sandbox config (no match for writable_roots/sandbox_workspace_write/.codex/config anywhere in bin/, docs/, .agents/). Ship tasks additionally push and open PRs, which workspace-write&#39;s default network posture also restricts. bin/fm-spawn.sh:1152 makes the same class of change for cursor (`--yolo` -&gt; `--auto-review --sandbox enabled`), and :1114 for claude (`--dangerously-skip-permissions` -&gt; `--permission-mode auto`). Either scope the sandbox to include the home state dir, or route the status write through a path the sandbox permits, before this posture ships.
- 🚨 `tests/fm-spawn-dispatch-profile.test.sh:168` - The launch templates in bin/fm-spawn.sh changed but three suites still assert the removed flags, so they fail deterministically. tests/fm-spawn-dispatch-profile.test.sh:168 compares the captured launch for exact equality against a string containing `claude --dangerously-skip-permissions`, while the template now emits `claude --permission-mode auto`; :432 asserts `claude --dangerously-skip-permissions --model &#39;sonnet&#39; --effort &#39;high&#39;`; :382, :449 and :465 assert `codex ... --dangerously-bypass-approvals-and-sandbox`, now `-s workspace-write -a never`. tests/fm-secondmate-harness.test.sh:770, :792 and :857 assert the same removed strings, and tests/fm-backend-orca.test.sh:523 asserts `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions` in the Orca send log. Note this contradicts the change description&#39;s claim that spawn-dispatch-profile&#39;s failure is pre-existing drift reproduced on an unmodified baseline: the baseline used only restored bin/backends/herdr.sh, so it still carried this branch&#39;s bin/fm-spawn.sh. Update the expected launch strings to the new flags (and add fm-secondmate-harness and fm-backend-orca to the suites run before shipping).
- ⚠️ `.agents/skills/harness-adapters/SKILL.md:373` - The cursor adapter contract rows still document the pre-change launch: line 373 says the launch carries `--trust`, `--yolo`, `--model` and `--workspace`; line 380&#39;s Autonomy row says `--yolo`, the documented alias for `--force`, whose TUI footer reads `Run Everything`; line 381 says `--yolo` does NOT suppress the trust dialog. bin/fm-spawn.sh:1152 now launches `--trust --auto-review --sandbox enabled` with no `--yolo` at all. This skill is the knowledge half of each adapter that bin/fm-spawn.sh:1099-1100 points at as the owner of autonomy semantics, so the two now contradict each other and the next reader will reason from the wrong autonomy posture.
- ℹ️ `tests/fm-backend-herdr.test.sh:881` - test_registration_over_a_shell_with_a_child_stays_alive spins in an unbounded `while [ -z &#34;$(ps -axo ppid= -o pid= ...)&#34; ]` loop waiting for the backgrounded bash to fork its `sleep` child. bin/fm-test-run.sh applies no per-test timeout, so if that `ps` invocation ever returns nothing usable (a ps variant that rejects the two -o forms, a platform where the child is reaped before the first sample) the suite hangs until the 15- or 75-minute GitHub job timeout instead of failing. Every other loop added in this change is bounded (attempt &lt; 200 in tests/herdr-test-safety.sh, seq 1 300 in the live guard); bound this one the same way and fail with a clear message.
- ℹ️ `tests/fm-control-herdr-smoke.test.sh:160` - The guard proving `exit` did not type `/quit` into a plain shell reads the pane through pane_text() (line 112), which is `herdr pane read &#34;$PANE_ID&#34; --session &#34;$SESSION&#34; 2&gt;/dev/null || true`. Unlike fm_backend_herdr_capture (bin/backends/herdr.sh:2636) it passes neither --source nor --lines, and any failure is swallowed into an empty string, which makes the `case ... *&#34;/quit&#34;*` check at line 160 silently pass. If a future herdr changes `pane read`&#39;s required arguments, the one assertion that proves the reported defect is fixed stops testing anything without going red. Fail explicitly when the read does not succeed.
- ℹ️ `bin/fm-bootstrap.sh:705` - Noting the blast radius, not a defect. Because fm_backend_herdr_agent_state maps the new no-agent verdict to `dead`, the session-start secondmate sweep now kills the endpoint and respawns for a herdr pane whose registration outlived its agent, where it previously read `alive` and left it alone. That is the intended recovery semantics and matches what a restored husk already got, and the sample&#39;s shell-with-a-child rule protects an operator running anything in that pane - but an operator sitting at a bare prompt in a secondmate&#39;s pane will now have it closed and replaced at session start. Same widening applies to fm_backend_herdr_create_task&#39;s duplicate-tab husk replacement and to fm-herdr-session-cleanup.sh, both of which are already scoped to tasks with no live meta record.

🔧 Fix: fix stale launch-flag assertions and vacuous test guards
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-usage-harvest.sh:149` - epoch_to_touch&#39;s GNU fallback renders the timestamp in UTC (`date -u -d &#34;@$1&#34; +%Y%m%d%H%M.%S`) but the value is consumed by `touch -t` (lines 154-155), which parses its argument as LOCAL time. On macOS the BSD `date -r &lt;epoch&gt;` branch wins and renders local time, so the pair is consistent; on GNU/Linux `date -r` treats its argument as a FILE, fails, and the UTC-rendered fallback is used, shifting both window ref files by the host&#39;s UTC offset. Failure: on Linux with TZ=America/Toronto, harvesting a task whose window is [T, T+10min] sets $REFDIR/start to T+4h-1s and $REFDIR/end to T+4h+1s, so `find ... -newer &#34;$REFDIR/start&#34;` (line 172) excludes every real in-window session log; matched_files returns empty, and the ledger row is written with source &#34;unavailable&#34; and null input/cached/output/reasoning tokens for a task that has full claude or codex logs on disk. East-of-UTC zones shift the refs earlier and silently truncate the tail of the window instead. The script otherwise carries deliberate GNU fallbacks (stat -c %Y/%W at lines 110/116), so this is portability code that does not hold. Fix: drop `-u` from the fallback so both branches emit local time (`date -d &#34;@$1&#34; +%Y%m%d%H%M.%S`); iso_from_epoch&#39;s `-u` at line 125 is correct as-is because it wants UTC output.
- ℹ️ `bin/fm-usage-harvest.sh:316` - The row is staged in &#34;$DATA/usage-ledger.jsonl.tmp.$$&#34; and removed only in the success branch of `cat ... &gt;&gt; &#34;$LEDGER&#34; &amp;&amp; rm -f -- ...`. harvest_cleanup (lines 141-146) removes $REFDIR and releases the lock but never this file. Failure: whenever the ledger append fails (the exact condition tests/fm-usage-harvest.test.sh:400 forces by making $data/usage-ledger.jsonl a directory, and which teardown deliberately tolerates at bin/fm-teardown.sh:2546), set -eu aborts after the failed `cat` and a `usage-ledger.jsonl.tmp.&lt;pid&gt;` file is left permanently in the fleet&#39;s runtime data dir, accumulating one per failed teardown harvest. Register the temp path with harvest_cleanup so the trap removes it on every exit path.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-backend-herdr-smoke.test.sh` - tests/fm-backend-herdr-smoke.test.sh fails non-deterministically on this machine, but it is pre-existing environment drift rather than a regression from this change. Post-change runs failed 3/3 (&#34;expected exactly 1 tab (the seeded default pruned)&#34; x1, &#34;the secondmate-shaped home&#39;s list_live did not see its own task&#34; x1, and one run at the case this change modified, &#34;create_task should refuse a duplicate label whose pane hosts a genuinely live registered agent&#34;). Running the pre-change suite together with the pre-change bin/backends/herdr.sh from a scratch copy failed 2/2 with the same two signatures, so the suite is already red on the unmodified baseline. The single failure at the newly modified live-duplicate case did not reproduce: I re-ran that exact fixture (create_task -&gt; herdr_pane_run_foreground -&gt; pane report-agent -&gt; classify) five consecutive times against real herdr and got &#39;live&#39; 5/5. Nothing here needs a code change; it is recorded so a red real-Herdr lane in CI is not misread as caused by this fix.
- <code>`bin/fm-test-run.sh tests/fm-backend-herdr.test.sh tests/fm-control-relaunch.test.sh` - green (both suites, including the 6 new classifier cases, the stale-registration husk replacement case, and both new exited-shell relaunch cases)</code>
- <code>`bash tests/fm-control-herdr-smoke.test.sh` - green against real herdr 0.8.2 (9/9: agent-free classification, idempotent exit with no `/quit` typed, interrupt refusal, live-process registration stays alive, fail-closed exit, endpoint/worktree/branch preserved)</code>
- <code>`FM_HERDR_AGENT_FREE_PROOF=1 bash tests/fm-herdr-agent-free-proof-live-e2e.test.sh` - green; launched claude 2.1.257, codex 0.150.1, opencode 1.17.11, pi 0.84.4, cursor 2026.08.31 for real in Herdr panes, none proved a bare idle shell; pi-signed/grok/kimi/muse reported as not installed</code>
- <code>Manual end-to-end reproduction, this branch: `bin/fm-control.sh demo relaunch --note &#39;...&#39;` on a real Herdr lab pane holding bare zsh with a stale `herdr pane report-agent` registration, over a real git worktree with committed + uncommitted work (evidence dir `relaunch-e2e-demo.sh`, transcript `relaunch-e2e-after-fixed-classifier.txt`)</code>
- <code>Manual end-to-end reproduction, pre-fix baseline: the identical scenario against a scratch copy of the repo with `git show 12f6613:bin/backends/herdr.sh` restored - reproduces `alive`, `/quit` typed at the zsh prompt, and a failed relaunch (transcript `relaunch-e2e-before-prefix-classifier.txt`)</code>
- <code>`bash tests/fm-backend-herdr-smoke.test.sh` x3 post-change and x2 on the pre-change suite + pre-change classifier - fails in both, same signatures, so its red state is pre-existing local herdr 0.8.2 drift</code>
- <code>Flakiness check: the modified live-duplicate fixture (create_task -&gt; `herdr_pane_run_foreground` -&gt; `pane report-agent` -&gt; `fm_backend_herdr_pane_agent_state`) driven 5 consecutive times against real herdr - `live` 5/5</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed (3) ✅</summary>

- ⚠️ `docs/verification/runtime-backends.md:909` - This branch changed the crewmate launch autonomy posture (claude --permission-mode auto, codex -s workspace-write -a never, cursor --auto-review --sandbox enabled) but no maintainer-verification record measures the new posture. The only autonomy evidence in the repo is Cursor&#39;s dated --yolo measurement, which now documents a flag firstmate no longer passes; claude and codex never had autonomy rows at all. I scoped the Cursor record so it can no longer be read as current, but I cannot close the evidence gap by writing prose: whether a crewmate still runs fully unattended, and whether Cursor&#39;s enabled sandbox still permits the git and network work a crewmate needs, requires a real measurement. Recommend a follow-up live run per harness that refreshes the Cursor &#39;Launch, lifecycle, and skills&#39; rows and adds an equivalent record for claude and codex.

🔧 Fix: add live crewmate autonomy guard; measure launch write contract
5 issues (2 errors, 2 warnings, 1 info) still open:
- 🚨 `bin/fm-spawn.sh:1117` - MEASURED DEFECT, deliberately not fixed here per the task&#39;s hard boundary. Under the launch posture this branch landed (codex -s workspace-write -a never), a codex crewmate cannot perform the one write bin/fm-brief.sh gives every worker to report status. Driven for real through the harness in an isolated fm-lab- Herdr session on 2026-09-02, codex-cli 0.152.1, macOS aarch64, with the status file at a lab FM_HOME under $HOME (never TMPDIR, which workspace-write grants by default and which would have made the measurement vacuous), codex answered: &#39;FMREPLY...zsh:1: operation not permitted: &lt;labhome&gt;/state/codex-&lt;id&gt;.status&#39;. The sandbox denies the append and -a never removes any escalation path, so the model sees an execution failure it cannot resolve. bin/fm-brief.sh:179 and :318-321 make that append the ONLY way a worker reports done, blocked, needs-decision, paused, or failed, so every codex crewmate launched under this posture is mute to the control plane. Claude under --permission-mode auto performs the same append successfully (&#39;Allowed by auto mode classifier&#39;), so this is specific to the codex sandbox, not to the contract. Resolving it is an authority and security decision (widen codex&#39;s writable roots, relocate the status file, or change the approval policy) that belongs to the captain, not to this step.
- 🚨 `docs/verification/runtime-backends.md:209` - The dated maintainer-verification record this task asked for is NOT yet written. I added the guard, registered it, and produced real measurements for claude and codex, and I pointed the Cursor &#39;Launch, lifecycle, and skills&#39; rows at a &#39;#crewmate-autonomy-and-the-status-file-write-contract&#39; anchor, but the section that anchor names does not exist yet because the cursor leg of the final run had not completed when this step had to report. Two consequences: that intra-document link is currently dangling (bin/fm-doc-audience-check.sh passed before the pointer edit, so it has not been revalidated against the dangling anchor), and the guard&#39;s own header references the same unwritten section. The measured content that belongs in it is: claude 2.1.258 reaches its composer only after the first-launch workspace-trust prompt (measured identically under the old --dangerously-skip-permissions and today&#39;s --permission-mode auto, so not a regression from this branch) and DOES append its status file; codex 0.152.1 reaches its composer only after a directory-trust prompt and a &#39;Hooks need review&#39; prompt and does NOT append its status file; cursor 2026.08.31-4057e58 reaches an empty composer with no key sent under --trust --auto-review --sandbox enabled, and its status-write result is unmeasured.
- ⚠️ `tests/fm-crewmate-autonomy-live-e2e.test.sh:1` - An earlier iteration of this guard changed state outside the worktree on this machine, and you should know about it. Codex 0.150.1 rendered a classifiable empty composer and raised its update-available modal a moment later; the guard trusted that earlier read, submitted its prompt, and the Enter landed on the modal&#39;s preselected &#39;Update now&#39; row, which installed codex-cli 0.152.1 (~/.codex/packages/standalone/releases/0.152.1-aarch64-apple-darwin). 0.150.1 is still on disk if you want to pin back. The shipped guard is hardened against a repeat: every key it sends is now gated on composer_settled, an empty composer verdict that must hold for a full 10s window, and update offers are declined with Escape (never Enter, which runs the upgrade). The codex denial finding above was measured on 0.152.1 after the upgrade.
- ⚠️ `.agents/skills/harness-adapters/SKILL.md:193` - Measured, and partially fixed in place. Claude Code 2.1.258 shows its workspace-trust prompt on every worktree path it has not seen, which is every firstmate task, and the launch flags do not change that: I measured the identical prompt under --dangerously-skip-permissions and under today&#39;s --permission-mode auto in two fresh directories, so it is not a regression from this branch. What WAS wrong in the docs is the recovery step: the prompt preselects &#39;No, exit&#39;, so the documented &#39;bin/fm-send.sh &lt;window&gt; --key Enter&#39; DECLINES and quits Claude. I corrected that paragraph to say Down then Enter. Flagging it because it means no claude crewmate spawn is genuinely unattended today and the captain must still clear the prompt by hand; whether to solve that (a persisted trust entry, a stable worktree root) is a product decision I did not take.
- ℹ️ `tests/fm-herdr-submit-confirm-live-e2e.test.sh:86` - tests/fm-herdr-submit-confirm-live-e2e.test.sh still launches Claude with --dangerously-skip-permissions, a flag bin/fm-spawn.sh no longer passes. It does not affect what that guard measures (submit confirmation is independent of permission mode), and changing it is a test-behavior edit outside this documentation step&#39;s authority, so I left it. Worth aligning with --permission-mode auto next time that file is touched, so every live guard exercises the posture firstmate actually ships.

🔧 Fix: Document crewmate sandbox verification status
1 error still open:
- 🚨 `docs/verification/runtime-backends.md:932` - The corrected Codex and Cursor writable-root postures remain unmeasured. Run the opt-in guard to prove both permitted writes, denial outside the grant, Cursor workspace binding, and Codex 0.152.1 submit compatibility before treating the new sandbox contract as verified.

🔧 Fix: record measured crewmate autonomy and sandbox write contract
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
