### PR TITLE
fix(fleet): handle oversized snapshot inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,8 +377,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 16 ] || {
-            echo "::error::expected 16 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 21 ] || {
+            echo "::error::expected 21 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -225,6 +225,20 @@ esac
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-snapshot: jq not found" >&2; exit 1; }
 
+SNAPSHOT_TMP_DIR=
+# shellcheck disable=SC2329 # Invoked by the signal and EXIT traps below.
+snapshot_cleanup() {
+  [ -z "$SNAPSHOT_TMP_DIR" ] || rm -rf -- "$SNAPSHOT_TMP_DIR" 2>/dev/null || true
+}
+SNAPSHOT_TMP_DIR=$(umask 077; mktemp -d "${TMPDIR:-/tmp}/fm-fleet-snapshot.XXXXXX") || {
+  echo "fm-fleet-snapshot: could not create temporary JSON storage" >&2
+  exit 1
+}
+trap snapshot_cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
@@ -654,11 +668,13 @@ task_json_lines() {
 # used by secondmate_home_summary_json, without inventing live task rows.
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
-main_inventory_json() {  # <backlog-json> <tasks-json>
+main_inventory_json() {  # <backlog-json-file> <tasks-json-file>
   jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    ([ $backlog.records[]?
+    --slurpfile backlog_documents "$1" \
+    --slurpfile task_documents "$2" '
+    ($backlog_documents[0]) as $backlog
+    | ($task_documents[0]) as $tasks
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
          | select(.state == "in_flight" and .structured and .requires_child_metadata) ]) as $owned_in_flight
@@ -682,7 +698,7 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # validated parent read needs.
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
-secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
+secondmate_home_summary_json() {  # <backlog-json-file> <tasks-json-file>
   jq -n \
     --arg generated "$SNAPSHOT_NOW" \
     --argjson generated_epoch "$SNAPSHOT_EPOCH" \
@@ -691,9 +707,11 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    def trunc($n):
+    --slurpfile backlog_documents "$1" \
+    --slurpfile task_documents "$2" '
+    ($backlog_documents[0]) as $backlog
+    | ($task_documents[0]) as $tasks
+    | def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
     ([ $backlog.records[]?
@@ -1179,7 +1197,9 @@ snapshot_collection_cleanup() {
   SNAPSHOT_COLLECT_DIR=
   SNAPSHOT_SUMMARY_FILTER=
 }
-trap snapshot_collection_cleanup EXIT
+# The ledger collector registers after the temporary-JSON cleanup above, and a
+# second EXIT trap replaces the first, so run both from one handler.
+trap 'snapshot_collection_cleanup; snapshot_cleanup' EXIT
 
 bounded_parent_activities_json() {  # <status-file>
   local f=$1 out rc reason script
@@ -1381,15 +1401,16 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
        inconclusive:any(($activity_results + $decision_results)[]; .verdict == "inconclusive")}'
 }
 
-secondmate_current_json() {  # <parent-tasks-json>
-  local tasks=$1 registry union rows total_registered total shown truncated
+secondmate_current_json() {  # <parent-tasks-json-file>
+  local tasks_file=$1 registry union rows total_registered total shown truncated
   local row id home host remote registered registry_error task sampled_spawn_gen status_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
-    ($registry.records // []) as $registered
+  union=$(jq -n --argjson registry "$registry" --slurpfile task_documents "$tasks_file" '
+    ($task_documents[0]) as $tasks
+    | ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
          | $r + {parent_task:([$tasks[] | select(.id == $r.id)][0] // null)} ]
@@ -1629,19 +1650,23 @@ scout_report_lines() {
     | jq -s 'sort_by(.id)'
 }
 
-BACKLOG_JSON=$(backlog_json) || { echo "fm-fleet-snapshot: backlog read failed" >&2; exit 1; }
-TASKS_JSON=$(task_json_lines) || { echo "fm-fleet-snapshot: task snapshot failed" >&2; exit 1; }
+BACKLOG_JSON_FILE="$SNAPSHOT_TMP_DIR/backlog.json"
+TASKS_JSON_FILE="$SNAPSHOT_TMP_DIR/tasks.json"
+backlog_json > "$BACKLOG_JSON_FILE" \
+  || { echo "fm-fleet-snapshot: backlog read failed" >&2; exit 1; }
+task_json_lines > "$TASKS_JSON_FILE" \
+  || { echo "fm-fleet-snapshot: task snapshot failed" >&2; exit 1; }
 
 if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
-  secondmate_home_summary_json "$BACKLOG_JSON" "$TASKS_JSON" \
+  secondmate_home_summary_json "$BACKLOG_JSON_FILE" "$TASKS_JSON_FILE" \
     || { echo "fm-fleet-snapshot: secondmate home summary failed" >&2; exit 1; }
   exit 0
 fi
 
 SCOUT_REPORTS_JSON=$(scout_report_lines)
-MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_JSON" "$TASKS_JSON") \
+MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_JSON_FILE" "$TASKS_JSON_FILE") \
   || { echo "fm-fleet-snapshot: main inventory summary failed" >&2; exit 1; }
-SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
+SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON_FILE") \
   || { echo "fm-fleet-snapshot: registered secondmate aggregation failed" >&2; exit 1; }
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
@@ -1654,13 +1679,15 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
+  --slurpfile backlog_documents "$BACKLOG_JSON_FILE" \
+  --slurpfile task_documents "$TASKS_JSON_FILE" \
   --argjson main_inventory "$MAIN_INVENTORY_JSON" \
   --argjson scout_reports "$SCOUT_REPORTS_JSON" \
   --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
   --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  '($backlog_documents[0]) as $backlog
+   | ($task_documents[0]) as $tasks
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1545,9 +1545,8 @@ secondmate_current_json() {  # <parent-tasks-json-file>
         summary_observed=$(printf '%s' "$summary" | jq -r '.generated')
       fi
     fi
-    # Failed command substitutions clear their assignment target. Keep the
-    # unsampled record's --argjson input valid without retaining any rejected
-    # or oversized summary fragment.
+    # Failed command substitutions clear their assignment target, so a rejected
+    # sample can leave $summary empty or holding the text this home refused.
     if [ -n "$reason" ]; then summary='{}'; fi
     if [ -z "$reason" ]; then
       summary_sampled=true
@@ -1562,6 +1561,12 @@ secondmate_current_json() {  # <parent-tasks-json-file>
       fi
     fi
 
+    # $summary is untrusted producer output: a remote login shell can prepend a
+    # banner, print nothing, or repeat the document while ssh still exits 0.
+    # Only a summary this home accepted reaches $summary_file, so the file
+    # readers below keep failing loudly on a genuine internal projection fault
+    # while an unusable home degrades to its own unknown record instead of
+    # aborting the whole fleet snapshot.
     [ "$summary_sampled" = true ] || summary='{}'
     printf '%s' "$summary" > "$summary_file" || return 1
 

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -239,6 +239,19 @@ trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
+# Every file-sized JSON projection travels between jq invocations as a file in
+# $SNAPSHOT_TMP_DIR, so a producer that writes nothing, writes several
+# documents, or writes the wrong shape has to fail loudly instead of binding
+# null into the published contract.
+SNAPSHOT_JQ_PRELUDE='def snapshot_document($label; $documents; $expected):
+  if ($documents | length) != 1 then
+    error("fm-fleet-snapshot: \($label) JSON must be exactly one document, found \($documents | length)")
+  elif ($documents[0] | type) != $expected then
+    error("fm-fleet-snapshot: \($label) JSON must be an \($expected), found \($documents[0] | type)")
+  else $documents[0]
+  end;
+'
+
 bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
@@ -671,9 +684,9 @@ task_json_lines() {
 main_inventory_json() {  # <backlog-json-file> <tasks-json-file>
   jq -n \
     --slurpfile backlog_documents "$1" \
-    --slurpfile task_documents "$2" '
-    ($backlog_documents[0]) as $backlog
-    | ($task_documents[0]) as $tasks
+    --slurpfile task_documents "$2" "$SNAPSHOT_JQ_PRELUDE"'
+    snapshot_document("backlog"; $backlog_documents; "object") as $backlog
+    | snapshot_document("tasks"; $task_documents; "array") as $tasks
     | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
@@ -708,9 +721,9 @@ secondmate_home_summary_json() {  # <backlog-json-file> <tasks-json-file>
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
     --slurpfile backlog_documents "$1" \
-    --slurpfile task_documents "$2" '
-    ($backlog_documents[0]) as $backlog
-    | ($task_documents[0]) as $tasks
+    --slurpfile task_documents "$2" "$SNAPSHOT_JQ_PRELUDE"'
+    snapshot_document("backlog"; $backlog_documents; "object") as $backlog
+    | snapshot_document("tasks"; $task_documents; "array") as $tasks
     | def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
@@ -1341,9 +1354,11 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
     '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:true,observed_at:$observed,freshness:"fresh",reason:null,lines:$lines,bytes:$bytes,event_note_seen:$seen,contradiction:$contradiction}'
 }
 
-parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
-    def keyed: . != null and . != "" and . != "default";
+parent_evidence_reconciliation_json() {  # <summary-json-file> <activities-json> <decisions-json>
+  jq -n --slurpfile summary_documents "$1" --argjson activities "$2" --argjson decisions "$3" \
+    "$SNAPSHOT_JQ_PRELUDE"'
+    snapshot_document("secondmate home summary"; $summary_documents; "object") as $summary
+    | def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
         verdict:(if ($e.key | keyed | not) then "inconclusive"
@@ -1406,10 +1421,14 @@ secondmate_current_json() {  # <parent-tasks-json-file>
   local row id home host remote registered registry_error task sampled_spawn_gen status_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot
-  local records='[]' seen_homes=''
+  local seen_homes='' records_file summary_file
+  records_file="$SNAPSHOT_TMP_DIR/secondmate-records.json"
+  summary_file="$SNAPSHOT_TMP_DIR/secondmate-summary.json"
+  : > "$records_file" || return 1
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --slurpfile task_documents "$tasks_file" '
-    ($task_documents[0]) as $tasks
+  union=$(jq -n --argjson registry "$registry" --slurpfile task_documents "$tasks_file" \
+    "$SNAPSHOT_JQ_PRELUDE"'
+    snapshot_document("tasks"; $task_documents; "array") as $tasks
     | ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
@@ -1535,13 +1554,15 @@ secondmate_current_json() {  # <parent-tasks-json-file>
       fi
     fi
 
+    printf '%s' "$summary" > "$summary_file" || return 1
+
     if [ -z "$reason" ]; then
       state=$(printf '%s' "$summary" | jq -r '.state')
       current_reason=
       if [ "$summary_valid" != true ]; then
         current_reason="structured home state invalid: $(printf '%s' "$summary" | jq -r '.reason // "unknown reason"')"
       fi
-      reconciliation=$(parent_evidence_reconciliation_json "$summary" "$activities" "$decisions")
+      reconciliation=$(parent_evidence_reconciliation_json "$summary_file" "$activities" "$decisions")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
       terminal_contradiction=$(printf '%s' "$reconciliation" | jq -r --arg note "$event_note" '
         any(.activities[]; .verdict == "contradicts" and .summary == $note)')
@@ -1552,15 +1573,17 @@ secondmate_current_json() {  # <parent-tasks-json-file>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
-      record=$(jq -n \
+      jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$summary_observed" \
         --arg summary_source "$summary_source" --arg summary_freshness "$summary_freshness" --argjson summary_age "$summary_age" \
         --arg spawn_gen "$sampled_spawn_gen" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
+        --argjson registered "$registered" --slurpfile summary_documents "$summary_file" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
         --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
         --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
-        --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
-        {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" \
+        "$SNAPSHOT_JQ_PRELUDE"'
+        snapshot_document("secondmate home summary"; $summary_documents; "object") as $summary
+        | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
          reconcile_inventory:$summary.invalidity,
@@ -1571,7 +1594,8 @@ secondmate_current_json() {  # <parent-tasks-json-file>
          decisions_open:$summary.decisions_open,holds:$summary.holds,queued:$summary.queued,
          landed:$summary.landed,endpoints:$summary.endpoints,counts:$summary.counts,omitted:$summary.omitted,
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan,reconciliation:$reconciliation},
-         terminal_evidence:$terminal,contradiction:$contradiction}')
+         terminal_evidence:$terminal,contradiction:$contradiction}' >> "$records_file" \
+        || return 1
     else
       if [ -n "$event_raw" ]; then
         provenance='parent-event-fallback'
@@ -1586,13 +1610,15 @@ secondmate_current_json() {  # <parent-tasks-json-file>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
-      record=$(jq -n \
+      jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
         --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
         --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" --argjson summary "$summary" --argjson summary_sampled "$summary_sampled" '
-        {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        --argjson decisions "$decisions" --argjson terminal "$terminal" --slurpfile summary_documents "$summary_file" --argjson summary_sampled "$summary_sampled" \
+        "$SNAPSHOT_JQ_PRELUDE"'
+        snapshot_document("secondmate home summary"; $summary_documents; "object") as $summary
+        | {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:"unknown",reason:$reason},invalidity:null,
          reconcile_inventory:(if $summary_sampled then $summary.invalidity else null end),
@@ -1600,26 +1626,32 @@ secondmate_current_json() {  # <parent-tasks-json-file>
          freshness:{status:$freshness,observed_at:$observed,age_seconds:$event_age},
          active_children:[],decisions_open:[],holds:[],queued:[],landed:[],endpoints:[],counts:{active_children:0,decisions_open:0,holds:0,queued:0,landed:0,endpoints:0},omitted:[],
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
-         terminal_evidence:$terminal,contradiction:false}')
+         terminal_evidence:$terminal,contradiction:false}' >> "$records_file" \
+        || return 1
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
   done <<EOF
 $rows
 EOF
   snapshot_collection_cleanup
   jq -n \
     --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+    --slurpfile records "$records_file" \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
     --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    '(if any($records[]; type != "object") then
+        error("fm-fleet-snapshot: secondmate record JSON must be an object")
+      elif ($records | length) != $shown then
+        error("fm-fleet-snapshot: secondmate records lost a sampled home")
+      else $records end) as $records
+     | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
-secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
-    {records:[ $current.records[]
+secondmate_landed_from_current_json() {  # <secondmate-current-json-file>
+  jq -n --slurpfile current_documents "$1" "$SNAPSHOT_JQ_PRELUDE"'
+    snapshot_document("secondmate current"; $current_documents; "object") as $current
+    | {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
       | . + {home:$mate.home,home_id:$mate.id}],
@@ -1663,12 +1695,17 @@ if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
   exit 0
 fi
 
-SCOUT_REPORTS_JSON=$(scout_report_lines)
-MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_JSON_FILE" "$TASKS_JSON_FILE") \
+SCOUT_REPORTS_JSON_FILE="$SNAPSHOT_TMP_DIR/scout-reports.json"
+MAIN_INVENTORY_JSON_FILE="$SNAPSHOT_TMP_DIR/main-inventory.json"
+SECONDMATE_CURRENT_JSON_FILE="$SNAPSHOT_TMP_DIR/secondmate-current.json"
+SECONDMATE_LANDED_JSON_FILE="$SNAPSHOT_TMP_DIR/secondmate-landed.json"
+scout_report_lines > "$SCOUT_REPORTS_JSON_FILE" \
+  || { echo "fm-fleet-snapshot: scout report scan failed" >&2; exit 1; }
+main_inventory_json "$BACKLOG_JSON_FILE" "$TASKS_JSON_FILE" > "$MAIN_INVENTORY_JSON_FILE" \
   || { echo "fm-fleet-snapshot: main inventory summary failed" >&2; exit 1; }
-SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON_FILE") \
+secondmate_current_json "$TASKS_JSON_FILE" > "$SECONDMATE_CURRENT_JSON_FILE" \
   || { echo "fm-fleet-snapshot: registered secondmate aggregation failed" >&2; exit 1; }
-SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
+secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON_FILE" > "$SECONDMATE_LANDED_JSON_FILE" \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
 jq -n \
@@ -1681,12 +1718,17 @@ jq -n \
   --arg projects "$PROJECTS" \
   --slurpfile backlog_documents "$BACKLOG_JSON_FILE" \
   --slurpfile task_documents "$TASKS_JSON_FILE" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  '($backlog_documents[0]) as $backlog
-   | ($task_documents[0]) as $tasks
+  --slurpfile main_inventory_documents "$MAIN_INVENTORY_JSON_FILE" \
+  --slurpfile scout_report_documents "$SCOUT_REPORTS_JSON_FILE" \
+  --slurpfile secondmate_current_documents "$SECONDMATE_CURRENT_JSON_FILE" \
+  --slurpfile secondmate_landed_documents "$SECONDMATE_LANDED_JSON_FILE" \
+  "$SNAPSHOT_JQ_PRELUDE"'
+   snapshot_document("backlog"; $backlog_documents; "object") as $backlog
+   | snapshot_document("tasks"; $task_documents; "array") as $tasks
+   | snapshot_document("main inventory"; $main_inventory_documents; "object") as $main_inventory
+   | snapshot_document("scout reports"; $scout_report_documents; "array") as $scout_reports
+   | snapshot_document("secondmate current"; $secondmate_current_documents; "object") as $secondmate_current
+   | snapshot_document("secondmate landed"; $secondmate_landed_documents; "object") as $secondmate_landed
    | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1554,6 +1554,7 @@ secondmate_current_json() {  # <parent-tasks-json-file>
       fi
     fi
 
+    [ "$summary_sampled" = true ] || summary='{}'
     printf '%s' "$summary" > "$summary_file" || return 1
 
     if [ -z "$reason" ]; then

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1561,9 +1561,10 @@ secondmate_current_json() {  # <parent-tasks-json-file>
       fi
     fi
 
-    # $summary is untrusted producer output: a remote login shell can prepend a
-    # banner, print nothing, or repeat the document while ssh still exits 0.
-    # Only a summary this home accepted reaches $summary_file, so the file
+    # $summary carries another home's published ledger, foreign input this
+    # snapshot never produced: that file can be empty, hold rc-file noise ahead
+    # of the document, repeat it, or carry the wrong shape. Only a ledger the
+    # reads above accepted and canonicalized reaches $summary_file, so the file
     # readers below keep failing loudly on a genuine internal projection fault
     # while an unusable home degrades to its own unknown record instead of
     # aborting the whole fleet snapshot.

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -7,7 +7,10 @@
 # mutate backlog state, or write reports. Its default ledger collector may
 # atomically refresh parent-side cached copies of remote home summaries under
 # state/secondmate-summary-cache; those observational cache writes are its only
-# fleet-state mutation.
+# fleet-state mutation. It also needs a writable TMPDIR: it keeps a private
+# mode-0700 temporary directory that carries file-sized JSON projections
+# between jq invocations and is removed on every success, failure, and signal
+# path, so no snapshot leaves storage behind.
 #
 # Top-level fields:
 #   schema: stable schema id.
@@ -240,9 +243,13 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 # Every file-sized JSON projection travels between jq invocations as a file in
-# $SNAPSHOT_TMP_DIR, so a producer that writes nothing, writes several
-# documents, or writes the wrong shape has to fail loudly instead of binding
-# null into the published contract.
+# $SNAPSHOT_TMP_DIR rather than as an --argjson value, because an ordinarily
+# accumulated backlog, scout-report set, or registered-home summary outgrows
+# execve's single-argument ceiling (131072 bytes on Linux) and would abort the
+# whole snapshot with E2BIG. A file handoff carries no such bound, so these
+# reads must reject a producer that writes nothing, writes several documents,
+# or writes the wrong shape instead of binding null into the published
+# contract.
 SNAPSHOT_JQ_PRELUDE='def snapshot_document($label; $documents; $expected):
   if ($documents | length) != 1 then
     error("fm-fleet-snapshot: \($label) JSON must be exactly one document, found \($documents | length)")

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -250,6 +250,7 @@ trap 'exit 143' TERM
 # reads must reject a producer that writes nothing, writes several documents,
 # or writes the wrong shape instead of binding null into the published
 # contract.
+# shellcheck disable=SC2016 # jq variables expand inside jq, not in this shell.
 SNAPSHOT_JQ_PRELUDE='def snapshot_document($label; $documents; $expected):
   if ($documents | length) != 1 then
     error("fm-fleet-snapshot: \($label) JSON must be exactly one document, found \($documents | length)")

--- a/bin/fm-home-summary-refresh.sh
+++ b/bin/fm-home-summary-refresh.sh
@@ -137,7 +137,7 @@ home_summary_refresh_once() {
     producer_rc=$?
   fi
   if [ "$producer_rc" -ne 0 ]; then
-    producer_error=$(tail -n 1 "$HOME_SUMMARY_ERR_TMP" 2>/dev/null \
+    producer_error=$(LC_ALL=C head -c 2000 "$HOME_SUMMARY_ERR_TMP" 2>/dev/null \
       | tr '\t\r\n' '   ' | cut -c1-500)
     if [ -n "$producer_error" ]; then
       home_summary_fail "summary producer failed with exit $producer_rc: $producer_error"

--- a/bin/fm-home-summary-refresh.sh
+++ b/bin/fm-home-summary-refresh.sh
@@ -137,6 +137,10 @@ home_summary_refresh_once() {
     producer_rc=$?
   fi
   if [ "$producer_rc" -ne 0 ]; then
+    # Keep the head of the producer's stderr: the underlying tool error is
+    # written before the producer's own generic stage line, so a tail would
+    # report "backlog read failed" and lose the diagnostic that names the
+    # real failure.
     producer_error=$(LC_ALL=C head -c 2000 "$HOME_SUMMARY_ERR_TMP" 2>/dev/null \
       | tr '\t\r\n' '   ' | cut -c1-500)
     if [ -n "$producer_error" ]; then

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -282,6 +282,10 @@ for arg in "\$@"; do
       exec "$real_env" "\$@"
       ;;
     empty) exit 0 ;;
+    duplicate)
+      "$real_env" "\$@" || exit \$?
+      exec "$real_env" "\$@"
+      ;;
     document)
       printf '%s' "\${FM_TEST_SUMMARY_OUTPUT:-}"
       exit 0
@@ -294,7 +298,7 @@ SH
 }
 
 test_unusable_secondmate_summary_degrades_that_home_only() {
-  local home mate fakebin out mode oversized
+  local home mate fakebin out mode oversized doubled
   home=$(make_home degraded-mate-parent)
   mate="$TMP_ROOT/degraded-mate-home"
   seed_secondmate_home "$mate" degraded-mate 3
@@ -317,7 +321,17 @@ test_unusable_secondmate_summary_degrades_that_home_only() {
       and .secondmate_current.records[0].counts.landed == 3
   ' >/dev/null || fail "the secondmate fixture did not sample cleanly: $out"
 
-  for mode in banner empty document; do
+  doubled=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$mate" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    FM_TEST_SUMMARY_MODE=duplicate \
+    env "$SNAPSHOT" --secondmate-home-summary) \
+    || fail "the duplicate-producer shim did not run"
+  printf '%s' "$doubled" | jq -e -s '
+    length == 2 and all(.[]; .schema == "fm-secondmate-home-summary.v1"
+      and (.counts | type) == "object" and (.landed | type) == "array")
+  ' >/dev/null || fail "the duplicate shim did not emit two shape-valid summaries: $doubled"
+
+  for mode in banner empty duplicate document; do
     out=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
       FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
       FM_TEST_SUMMARY_MODE="$mode" FM_TEST_SUMMARY_OUTPUT='["not an object"]' \

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -207,6 +207,166 @@ PY
   pass "snapshot, fleet view, and home-summary publication survive a large backlog"
 }
 
+seed_secondmate_home() {  # <home-dir> <id> <done-rows>
+  local mate=$1 id=$2 rows=$3 index=0
+  mkdir -p "$mate/state" "$mate/data" "$mate/config" "$mate/projects" "$mate/bin"
+  printf '# Synthetic secondmate home\n' > "$mate/AGENTS.md"
+  printf '%s\n' "$id" > "$mate/.fm-secondmate-home"
+  {
+    printf '## In flight\n\n## Queued\n\n## Done\n'
+    while [ "$index" -lt "$rows" ]; do
+      printf -- '- [x] archived-%04d - Accumulated completed work %04d (repo: firstmate) (kind: ship) (done 2026-08-31)\n' \
+        "$index" "$index"
+      index=$((index + 1))
+    done
+  } > "$mate/data/backlog.md"
+}
+
+# bin/fm-bearings-snapshot.sh --all-landed lifts the per-home landed cap, so a
+# registered home with ordinary accumulated work publishes a summary far past
+# Linux's 131072-byte single-argument ceiling while staying inside the byte
+# limit the parent explicitly accepts.
+test_registered_secondmate_summary_survives_argv_ceiling() {
+  local home mate fakebin summary_bytes out
+  home=$(make_home oversized-mate-parent)
+  mate="$TMP_ROOT/oversized-mate-home"
+  seed_secondmate_home "$mate" sample-mate 700
+  printf '## In flight\n\n## Queued\n\n## Done\n' > "$home/data/backlog.md"
+  printf -- '- sample-mate - synthetic scope (home: %s; scope: sample reviews; projects: sample; added 2026-07-14)\n' \
+    "$mate" > "$home/data/secondmates.md"
+  fm_write_secondmate_meta "$home/state/sample-mate.meta" "$mate"
+  printf 'working: watching delegated scope\n' > "$home/state/sample-mate.status"
+  fakebin=$(make_fakebin "$home")
+
+  summary_bytes=$(FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$mate" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 \
+    "$SNAPSHOT" --secondmate-home-summary | LC_ALL=C wc -c | tr -d '[:space:]') \
+    || fail "uncapped secondmate home summary failed"
+  [ "$summary_bytes" -gt 131072 ] \
+    || fail "secondmate summary fixture was only $summary_bytes bytes"
+  [ "$summary_bytes" -le 262144 ] \
+    || fail "secondmate summary fixture of $summary_bytes bytes exceeds the accepted byte limit"
+
+  out=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 \
+    "$SNAPSHOT" --json) \
+    || fail "snapshot failed aggregating a $summary_bytes-byte secondmate summary"
+  printf '%s' "$out" | jq -e '
+    (.secondmate_current.records | length) == 1
+      and .secondmate_current.records[0].provenance.selected == "structured-home"
+      and .secondmate_current.records[0].counts.landed == 700
+      and (.secondmate_landed.records | length) == 700
+      and (.secondmate_landed.truncated | length) == 0
+  ' >/dev/null || fail "oversized secondmate summary was not aggregated: $out"
+  pass "an oversized registered secondmate summary still aggregates into the fleet snapshot"
+}
+
+# Scout reports accumulate monotonically and carry no FM_SNAPSHOT_* bound, so
+# their projection has to reach the final assembly without argv.
+test_many_scout_reports_survive_argv_ceiling() {
+  local home fakebin index out projection_bytes
+  home=$(make_home many-scout-reports)
+  printf '## In flight\n\n## Queued\n\n## Done\n' > "$home/data/backlog.md"
+  index=0
+  while [ "$index" -lt 800 ]; do
+    mkdir -p "$home/data/archived-review-with-a-deliberately-long-identifier-$(printf '%04d' "$index")"
+    printf '# Report\n' \
+      > "$home/data/archived-review-with-a-deliberately-long-identifier-$(printf '%04d' "$index")/report.md"
+    index=$((index + 1))
+  done
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    "$SNAPSHOT" --json) \
+    || fail "snapshot failed on 800 accumulated scout reports"
+  printf '%s' "$out" | jq -e '
+    (.scout_reports | length) == 800
+      and (.scout_reports | all(.kind == "scout"))
+  ' >/dev/null || fail "accumulated scout reports were not projected: ${out:0:400}"
+  projection_bytes=$(printf '%s' "$out" | jq '{records:.scout_reports}' | LC_ALL=C wc -c | tr -d '[:space:]')
+  [ "$projection_bytes" -gt 131072 ] \
+    || fail "scout report fixture projected only $projection_bytes bytes"
+  pass "an unbounded scout report projection survives the single-argument ceiling"
+}
+
+# A producer that loses its stdout while still exiting 0 must not publish a
+# null-bearing snapshot; it must fail loudly and leave no temporary storage.
+test_lost_producer_output_fails_loudly_and_cleans_up() {
+  local home fakebin shimbin tmpdir status out err real_jq
+  real_jq=$(command -v jq)
+  home=$(make_home lost-producer)
+  write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  shimbin="$home/shimbin"
+  mkdir -p "$shimbin"
+  cat > "$shimbin/jq" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ -n "${FM_TEST_JQ_MATCH:-}" ]; then
+  for arg in "$@"; do
+    case $arg in
+      *"$FM_TEST_JQ_MATCH"*)
+        printf '%s' "${FM_TEST_JQ_OUTPUT:-}"
+        exit 0
+        ;;
+    esac
+  done
+fi
+exec "$FM_TEST_REAL_JQ" "$@"
+SH
+  chmod +x "$shimbin/jq"
+  tmpdir="$home/tmp"
+  mkdir -p "$tmpdir"
+
+  status=0
+  out=$(PATH="$shimbin:$fakebin:$PATH" TMPDIR="$tmpdir" \
+    FM_TEST_REAL_JQ="$real_jq" FM_TEST_JQ_MATCH='def section_state:' \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    "$SNAPSHOT" --json 2> "$home/lost-empty.err") || status=$?
+  [ "$status" -ne 0 ] \
+    || fail "snapshot published a snapshot from an empty backlog document: $out"
+  printf '%s' "$out" | jq -e '.backlog == null' >/dev/null 2>&1 \
+    && fail "snapshot published a null backlog instead of failing"
+  [ -s "$home/lost-empty.err" ] || fail "empty backlog document failed silently"
+
+  status=0
+  out=$(PATH="$shimbin:$fakebin:$PATH" TMPDIR="$tmpdir" \
+    FM_TEST_REAL_JQ="$real_jq" FM_TEST_JQ_MATCH='def section_state:' \
+    FM_TEST_JQ_OUTPUT='{"path":"a","present":true,"records":[]}
+{"path":"b","present":true,"records":[]}' \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    "$SNAPSHOT" --json 2> "$home/lost-multi.err") || status=$?
+  [ "$status" -ne 0 ] \
+    || fail "snapshot accepted a multi-document backlog projection: $out"
+
+  status=0
+  out=$(PATH="$shimbin:$fakebin:$PATH" TMPDIR="$tmpdir" \
+    FM_TEST_REAL_JQ="$real_jq" FM_TEST_JQ_MATCH='def section_state:' \
+    FM_TEST_JQ_OUTPUT='null' \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    "$SNAPSHOT" --json 2> "$home/lost-null.err") || status=$?
+  [ "$status" -ne 0 ] \
+    || fail "snapshot accepted a null backlog projection: $out"
+
+  err=$(cat "$home/lost-null.err")
+  assert_contains "$err" "backlog" "the failed read did not name the backlog projection"
+
+  PATH="$shimbin:$fakebin:$PATH" TMPDIR="$tmpdir" \
+    FM_TEST_REAL_JQ="$real_jq" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    "$SNAPSHOT" --json > /dev/null \
+    || fail "snapshot failed with an unshimmed producer"
+  [ -z "$(find "$tmpdir" -mindepth 1 -print -quit)" ] \
+    || fail "snapshot leaked temporary JSON storage into TMPDIR"
+  pass "a lost, multi-document, or null intermediate projection fails loudly and cleans up"
+}
+
 test_fixture_snapshot_json() {
   local home fakebin out ids
   home=$(make_home fixture)
@@ -954,6 +1114,9 @@ EOF
 
 test_empty_fleet_json
 test_large_backlog_snapshot_view_and_summary_publication
+test_registered_secondmate_summary_survives_argv_ceiling
+test_many_scout_reports_survive_argv_ceiling
+test_lost_producer_output_fails_loudly_and_cleans_up
 test_fixture_snapshot_json
 test_home_summary_excludes_secondmate_from_child_inventory
 test_main_inventory_orphan_and_unstructured_disclosure

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -266,8 +266,8 @@ test_registered_secondmate_summary_survives_argv_ceiling() {
 # A registered secondmate is sampled by running an external producer - fm-on.sh
 # over ssh for a remote home - whose stdout carries whatever the remote login
 # shell prints. The shim reproduces that at the sampling boundary: the producer
-# still exits 0 while its stdout is prefixed with rc-file noise, is empty, or is
-# a non-object document.
+# still exits 0 while its stdout is prefixed with rc-file noise, is empty,
+# repeats the whole document, or is a non-object document.
 install_secondmate_summary_shim() {  # <fakebin>
   local fakebin=$1 real_env
   real_env=$(command -v env)

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -227,11 +227,14 @@ test_registered_secondmate_summary_survives_argv_ceiling() {
   printf 'working: watching delegated scope\n' > "$home/state/sample-mate.status"
   fakebin=$(make_fakebin "$home")
 
-  summary_bytes=$(FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$mate" \
+  # The parent samples a registered home by reading the ledger that home
+  # published, so the fixture publishes it the same way a real secondmate does.
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$mate" \
     FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
     FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 \
-    "$SNAPSHOT" --secondmate-home-summary | LC_ALL=C wc -c | tr -d '[:space:]') \
-    || fail "uncapped secondmate home summary failed"
+    "$SUMMARY_REFRESH" \
+    || fail "uncapped secondmate home summary publication failed"
+  summary_bytes=$(LC_ALL=C wc -c < "$mate/state/home-summary.json" | tr -d '[:space:]')
   [ "$summary_bytes" -gt 131072 ] \
     || fail "secondmate summary fixture was only $summary_bytes bytes"
   [ "$summary_bytes" -le 262144 ] \
@@ -252,42 +255,13 @@ test_registered_secondmate_summary_survives_argv_ceiling() {
   pass "an oversized registered secondmate summary still aggregates into the fleet snapshot"
 }
 
-# A registered secondmate is sampled by running an external producer - fm-on.sh
-# over ssh for a remote home - whose stdout carries whatever the remote login
-# shell prints. The shim reproduces that at the sampling boundary: the producer
-# still exits 0 while its stdout is prefixed with rc-file noise, is empty,
-# repeats the whole document, or is a non-object document.
-install_secondmate_summary_shim() {  # <fakebin>
-  local fakebin=$1 real_env
-  real_env=$(command -v env)
-  cat > "$fakebin/env" <<SH
-#!/usr/bin/env bash
-set -u
-for arg in "\$@"; do
-  [ "\$arg" = --secondmate-home-summary ] || continue
-  case "\${FM_TEST_SUMMARY_MODE:-}" in
-    banner)
-      printf 'bash: /etc/bashrc: line 1: warning\\n'
-      exec "$real_env" "\$@"
-      ;;
-    empty) exit 0 ;;
-    duplicate)
-      "$real_env" "\$@" || exit \$?
-      exec "$real_env" "\$@"
-      ;;
-    document)
-      printf '%s' "\${FM_TEST_SUMMARY_OUTPUT:-}"
-      exit 0
-      ;;
-  esac
-done
-exec "$real_env" "\$@"
-SH
-  chmod +x "$fakebin/env"
-}
-
+# The parent samples a registered home by reading the ledger that home
+# published, and that file is foreign input the parent never produced: a home
+# can leave rc-file noise ahead of the document, an empty file, a repeated
+# document, or a document of the wrong shape behind. Each one has to degrade
+# only that home.
 test_unusable_secondmate_summary_degrades_that_home_only() {
-  local home mate fakebin out mode oversized doubled
+  local home mate fakebin ledger out mode clean doubled
   home=$(make_home degraded-mate-parent)
   mate="$TMP_ROOT/degraded-mate-home"
   seed_secondmate_home "$mate" degraded-mate 3
@@ -297,7 +271,13 @@ test_unusable_secondmate_summary_degrades_that_home_only() {
   fm_write_secondmate_meta "$home/state/degraded-mate.meta" "$mate"
   printf 'working: watching delegated scope\n' > "$home/state/degraded-mate.status"
   fakebin=$(make_fakebin "$home")
-  install_secondmate_summary_shim "$fakebin"
+  ledger="$mate/state/home-summary.json"
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$mate" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    "$SUMMARY_REFRESH" \
+    || fail "the secondmate fixture could not publish its ledger"
+  clean=$(cat "$ledger")
 
   out=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
     FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
@@ -310,20 +290,25 @@ test_unusable_secondmate_summary_degrades_that_home_only() {
       and .secondmate_current.records[0].counts.landed == 3
   ' >/dev/null || fail "the secondmate fixture did not sample cleanly: $out"
 
-  doubled=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$mate" \
-    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
-    FM_TEST_SUMMARY_MODE=duplicate \
-    env "$SNAPSHOT" --secondmate-home-summary) \
-    || fail "the duplicate-producer shim did not run"
+  # A repeated document is the corruption whose every document is individually
+  # shape-valid, so only counting the whole stream rejects it.
+  doubled=$(printf '%s\n%s\n' "$clean" "$clean")
   printf '%s' "$doubled" | jq -e -s '
     length == 2 and all(.[]; .schema == "fm-secondmate-home-summary.v1"
       and (.counts | type) == "object" and (.landed | type) == "array")
-  ' >/dev/null || fail "the duplicate shim did not emit two shape-valid summaries: $doubled"
+  ' >/dev/null || fail "the duplicated ledger was not two shape-valid summaries: $doubled"
 
   for mode in banner empty duplicate document; do
+    case "$mode" in
+      banner)
+        { printf 'bash: /etc/bashrc: line 1: warning\n'; printf '%s\n' "$clean"; } > "$ledger"
+        ;;
+      empty) : > "$ledger" ;;
+      duplicate) printf '%s' "$doubled" > "$ledger" ;;
+      document) printf '%s\n' '["not an object"]' > "$ledger" ;;
+    esac
     out=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
       FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
-      FM_TEST_SUMMARY_MODE="$mode" FM_TEST_SUMMARY_OUTPUT='["not an object"]' \
       "$SNAPSHOT" --json) \
       || fail "snapshot aborted the whole fleet on a $mode secondmate summary"
     printf '%s' "$out" | jq -e '
@@ -341,17 +326,16 @@ test_unusable_secondmate_summary_degrades_that_home_only() {
     ' >/dev/null || fail "a $mode secondmate summary did not degrade to an unknown record: $out"
   done
 
-  oversized=$(printf '["%s"]' "$(printf 'x%.0s' $(seq 1 200))")
+  printf '%s\n' "$clean" > "$ledger"
   out=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
     FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
     FM_SNAPSHOT_SECONDMATE_MAX_BYTES=64 \
-    FM_TEST_SUMMARY_MODE=document FM_TEST_SUMMARY_OUTPUT="$oversized" \
     "$SNAPSHOT" --json) \
     || fail "snapshot aborted the whole fleet on an oversized secondmate summary"
   printf '%s' "$out" | jq -e '
     (.secondmate_current.records | length) == 1
       and .secondmate_current.records[0].current.state == "unknown"
-      and .secondmate_current.records[0].current.reason == "structured home snapshot exceeded byte limit"
+      and .secondmate_current.records[0].current.reason == "structured home ledger exceeded byte limit"
       and .secondmate_current.records[0].reconcile_inventory == null
       and (.secondmate_landed.unreadable | length) == 1
   ' >/dev/null || fail "an oversized secondmate summary did not degrade to an unknown record: $out"

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -153,27 +153,16 @@ test_empty_fleet_json() {
 }
 
 test_large_backlog_snapshot_view_and_summary_publication() {
-  local home backlog_size out
+  local home backlog_size out index=0
   home=$(make_home large-backlog)
-  python3 - "$home/data/backlog.md" <<'PY'
-from pathlib import Path
-import sys
-
-path = Path(sys.argv[1])
-rows = [
-    "## In flight\n",
-    "\n",
-    "## Queued\n",
-    "\n",
-    "## Done\n",
-]
-for index in range(2400):
-    rows.append(
-        f"- [x] archived-{index:04d} - Accumulated completed work {index:04d} "
-        "(repo: firstmate) (kind: ship) (done 2026-08-31)\n"
-    )
-path.write_text("".join(rows))
-PY
+  {
+    printf '## In flight\n\n## Queued\n\n## Done\n'
+    while [ "$index" -lt 2400 ]; do
+      printf -- '- [x] archived-%04d - Accumulated completed work %04d (repo: firstmate) (kind: ship) (done 2026-08-31)\n' \
+        "$index" "$index"
+      index=$((index + 1))
+    done
+  } > "$home/data/backlog.md"
   backlog_size=$(wc -c < "$home/data/backlog.md" | tr -d '[:space:]')
   [ "$backlog_size" -ge 204800 ] \
     || fail "large-backlog fixture was only $backlog_size bytes"

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -8,6 +8,7 @@ set -u
 
 SNAPSHOT="$ROOT/bin/fm-fleet-snapshot.sh"
 VIEW="$ROOT/bin/fm-fleet-view.sh"
+SUMMARY_REFRESH="$ROOT/bin/fm-home-summary-refresh.sh"
 TMP_ROOT=$(fm_test_tmproot fm-fleet-snapshot)
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
@@ -149,6 +150,61 @@ test_empty_fleet_json() {
   view=$(FM_HOME="$home" "$VIEW")
   assert_contains "$view" "No live task metadata found." "empty fleet view should say no live metadata"
   pass "empty fleet snapshot and view use explicit absence markers"
+}
+
+test_large_backlog_snapshot_view_and_summary_publication() {
+  local home backlog_size out
+  home=$(make_home large-backlog)
+  python3 - "$home/data/backlog.md" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+rows = [
+    "## In flight\n",
+    "\n",
+    "## Queued\n",
+    "\n",
+    "## Done\n",
+]
+for index in range(2400):
+    rows.append(
+        f"- [x] archived-{index:04d} - Accumulated completed work {index:04d} "
+        "(repo: firstmate) (kind: ship) (done 2026-08-31)\n"
+    )
+path.write_text("".join(rows))
+PY
+  backlog_size=$(wc -c < "$home/data/backlog.md" | tr -d '[:space:]')
+  [ "$backlog_size" -ge 204800 ] \
+    || fail "large-backlog fixture was only $backlog_size bytes"
+  out=$(FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    "$SNAPSHOT" --json) \
+    || fail "snapshot failed on a $backlog_size-byte backlog"
+  printf '%s' "$out" | jq -e '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.backlog.records | length) == 2400
+      and .main_inventory.valid == true
+      and (.tasks | length) == 0
+  ' >/dev/null || fail "large-backlog snapshot shape was wrong"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    "$VIEW" > "$home/fleet-view.txt" \
+    || fail "fleet view failed on a $backlog_size-byte backlog"
+  assert_contains "$(cat "$home/fleet-view.txt")" "| archived-2399 |" \
+    "fleet view omitted the tail of the large backlog"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    "$SUMMARY_REFRESH" \
+    || fail "home-summary publication failed on a $backlog_size-byte backlog"
+  jq -e '
+    .schema == "fm-secondmate-home-summary.v1"
+      and .valid == true
+      and .counts.landed == 2400
+      and (.landed | length) == 10
+  ' "$home/state/home-summary.json" >/dev/null \
+    || fail "large-backlog home summary was not published with the expected shape"
+  pass "snapshot, fleet view, and home-summary publication survive a large backlog"
 }
 
 test_fixture_snapshot_json() {
@@ -897,6 +953,7 @@ EOF
 }
 
 test_empty_fleet_json
+test_large_backlog_snapshot_view_and_summary_publication
 test_fixture_snapshot_json
 test_home_summary_excludes_secondmate_from_child_inventory
 test_main_inventory_orphan_and_unstructured_disclosure

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -263,6 +263,98 @@ test_registered_secondmate_summary_survives_argv_ceiling() {
   pass "an oversized registered secondmate summary still aggregates into the fleet snapshot"
 }
 
+# A registered secondmate is sampled by running an external producer - fm-on.sh
+# over ssh for a remote home - whose stdout carries whatever the remote login
+# shell prints. The shim reproduces that at the sampling boundary: the producer
+# still exits 0 while its stdout is prefixed with rc-file noise, is empty, or is
+# a non-object document.
+install_secondmate_summary_shim() {  # <fakebin>
+  local fakebin=$1 real_env
+  real_env=$(command -v env)
+  cat > "$fakebin/env" <<SH
+#!/usr/bin/env bash
+set -u
+for arg in "\$@"; do
+  [ "\$arg" = --secondmate-home-summary ] || continue
+  case "\${FM_TEST_SUMMARY_MODE:-}" in
+    banner)
+      printf 'bash: /etc/bashrc: line 1: warning\\n'
+      exec "$real_env" "\$@"
+      ;;
+    empty) exit 0 ;;
+    document)
+      printf '%s' "\${FM_TEST_SUMMARY_OUTPUT:-}"
+      exit 0
+      ;;
+  esac
+done
+exec "$real_env" "\$@"
+SH
+  chmod +x "$fakebin/env"
+}
+
+test_unusable_secondmate_summary_degrades_that_home_only() {
+  local home mate fakebin out mode oversized
+  home=$(make_home degraded-mate-parent)
+  mate="$TMP_ROOT/degraded-mate-home"
+  seed_secondmate_home "$mate" degraded-mate 3
+  printf '## In flight\n\n## Queued\n\n## Done\n' > "$home/data/backlog.md"
+  printf -- '- degraded-mate - synthetic scope (home: %s; scope: sample reviews; projects: sample; added 2026-07-14)\n' \
+    "$mate" > "$home/data/secondmates.md"
+  fm_write_secondmate_meta "$home/state/degraded-mate.meta" "$mate"
+  printf 'working: watching delegated scope\n' > "$home/state/degraded-mate.status"
+  fakebin=$(make_fakebin "$home")
+  install_secondmate_summary_shim "$fakebin"
+
+  out=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    "$SNAPSHOT" --json) \
+    || fail "snapshot failed sampling a clean secondmate summary"
+  printf '%s' "$out" | jq -e '
+    (.secondmate_current.records | length) == 1
+      and .secondmate_current.records[0].provenance.selected == "structured-home"
+      and .secondmate_current.records[0].current.state != "unknown"
+      and .secondmate_current.records[0].counts.landed == 3
+  ' >/dev/null || fail "the secondmate fixture did not sample cleanly: $out"
+
+  for mode in banner empty document; do
+    out=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+      FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+      FM_TEST_SUMMARY_MODE="$mode" FM_TEST_SUMMARY_OUTPUT='["not an object"]' \
+      "$SNAPSHOT" --json) \
+      || fail "snapshot aborted the whole fleet on a $mode secondmate summary"
+    printf '%s' "$out" | jq -e '
+      .schema == "fm-fleet-snapshot.v1"
+        and (.backlog | type) == "object"
+        and (.secondmate_current.records | length) == 1
+        and .secondmate_current.records[0].id == "degraded-mate"
+        and .secondmate_current.records[0].current.state == "unknown"
+        and (.secondmate_current.records[0].current.reason | type) == "string"
+        and .secondmate_current.records[0].provenance.selected != "structured-home"
+        and .secondmate_current.records[0].invalidity == null
+        and .secondmate_current.records[0].reconcile_inventory == null
+        and .secondmate_current.records[0].counts.landed == 0
+        and (.secondmate_landed.records | length) == 0
+    ' >/dev/null || fail "a $mode secondmate summary did not degrade to an unknown record: $out"
+  done
+
+  oversized=$(printf '["%s"]' "$(printf 'x%.0s' $(seq 1 200))")
+  out=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-09-01T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788264000 \
+    FM_SNAPSHOT_SECONDMATE_MAX_BYTES=64 \
+    FM_TEST_SUMMARY_MODE=document FM_TEST_SUMMARY_OUTPUT="$oversized" \
+    "$SNAPSHOT" --json) \
+    || fail "snapshot aborted the whole fleet on an oversized secondmate summary"
+  printf '%s' "$out" | jq -e '
+    (.secondmate_current.records | length) == 1
+      and .secondmate_current.records[0].current.state == "unknown"
+      and .secondmate_current.records[0].current.reason == "structured home snapshot exceeded byte limit"
+      and .secondmate_current.records[0].reconcile_inventory == null
+      and (.secondmate_landed.unreadable | length) == 1
+  ' >/dev/null || fail "an oversized secondmate summary did not degrade to an unknown record: $out"
+  pass "an unusable secondmate summary degrades that home instead of the whole fleet snapshot"
+}
+
 # Scout reports accumulate monotonically and carry no FM_SNAPSHOT_* bound, so
 # their projection has to reach the final assembly without argv.
 test_many_scout_reports_survive_argv_ceiling() {
@@ -1115,6 +1207,7 @@ EOF
 test_empty_fleet_json
 test_large_backlog_snapshot_view_and_summary_publication
 test_registered_secondmate_summary_survives_argv_ceiling
+test_unusable_secondmate_summary_degrades_that_home_only
 test_many_scout_reports_survive_argv_ceiling
 test_lost_producer_output_fails_loudly_and_cleans_up
 test_fixture_snapshot_json

--- a/tests/fm-home-summary-refresh.test.sh
+++ b/tests/fm-home-summary-refresh.test.sh
@@ -337,11 +337,14 @@ FAILBIN="$TMP_ROOT/failbin"
 mkdir -p "$FAILBIN"
 cat > "$FAILBIN/jq" <<'SH'
 #!/usr/bin/env bash
+printf 'jq-fixture: diagnostic survives producer failure\n' >&2
 exit 7
 SH
 chmod +x "$FAILBIN/jq"
+FAIL_TMPDIR="$HOME_DIR/tmp"
+mkdir -p "$FAIL_TMPDIR"
 cp "$HOME_DIR/state/home-summary.json" "$TMP_ROOT/before-best-effort.json"
-PATH="$FAILBIN:$FAKEBIN:$PATH" \
+PATH="$FAILBIN:$FAKEBIN:$PATH" TMPDIR="$FAIL_TMPDIR" \
   FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME_DIR" \
   "$WRITER" --best-effort \
   || fail "best-effort refresh propagated its producer failure"
@@ -349,7 +352,12 @@ cmp -s "$TMP_ROOT/before-best-effort.json" "$HOME_DIR/state/home-summary.json" \
   || fail "failed best-effort refresh changed the prior ledger"
 grep -F 'summary producer failed' "$HOME_DIR/state/.home-summary-refresh.log" >/dev/null \
   || fail "best-effort refresh did not log its failure"
-pass "best-effort publication logs and continues"
+grep -F 'jq-fixture: diagnostic survives producer failure' \
+  "$HOME_DIR/state/.home-summary-refresh.log" >/dev/null \
+  || fail "best-effort refresh discarded the producer diagnostic"
+[ -z "$(find "$FAIL_TMPDIR" -mindepth 1 -print -quit)" ] \
+  || fail "failed producer leaked temporary JSON storage into TMPDIR"
+pass "best-effort publication logs the producer diagnostic, cleans up, and continues"
 
 LOCK_MARKER="$TMP_ROOT/lock-held"
 rm -f "$HOME_DIR/state/.home-summary-refresh.log"


### PR DESCRIPTION
## Summary

- Move unbounded fleet snapshot JSON between jq processes through validated temporary files instead of command-line arguments.
- Preserve per-home fallback behavior and surface producer stderr in summary publication failures.
- Add behavioral coverage for large backlogs, secondmate summaries, scout report accumulation, malformed intermediate JSON, and cleanup.

## Validation

- A 247,233-byte backlog fails on the old producer with E2BIG and succeeds through the fixed fleet view and home-summary publisher.
- `bin/fm-test-run.sh tests/fm-fleet-snapshot-view.test.sh`
- `bin/fm-test-run.sh tests/fm-home-summary-refresh.test.sh tests/fm-secondmate-reconcile.test.sh`
- `bin/fm-test-run.sh tests/fm-bearings-snapshot.test.sh`
- `bin/fm-lint.sh`
- Automated review, test, documentation, and lint steps passed.
