### PR TITLE
fix(bearings): make clipped board row text reachable

### DIFF
--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -543,13 +543,19 @@ __FM_BEARINGS_BOARD_DATA__
 
   var measureEnabled = false;
   var measureTimer;
+  /* An element with no layout reads zero or undefined for both metrics, which
+     is not evidence that it fits, so it fails open with the throwing shape. */
+  function hidesText(e) {
+    var box = e.clientHeight, full = e.scrollHeight;
+    if (!(box > 0) || !(full > 0)) throw new Error("the row cannot be measured");
+    return full - box > 1;
+  }
   function measureClippedRows() {
     /* every read first, so one layout serves the whole pass rather than each
        row's writes forcing the next row's measurement to reflow */
     var clipped = discloseRows.map(function (r) {
       if (r.row.classList.contains("is-open")) return null;
-      return r.title.scrollHeight - r.title.clientHeight > 1 ||
-             r.sub.scrollHeight - r.sub.clientHeight > 1;
+      return hidesText(r.title) || hidesText(r.sub);
     });
     discloseRows.forEach(function (r, i) {
       if (clipped[i] !== null) {

--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -289,8 +289,9 @@ a { color: inherit; text-decoration: none; }
 .bb-row.is-open .bb-row__more-chip { transform: rotate(180deg); }
 /* Before the clip measurement runs - and anywhere it cannot - every row keeps
    its affordance, so the text is never unreachable. Once measured, only rows
-   that actually hide something advertise it. */
-body.bb-measured .bb-row:not(.bb-row--clip) .bb-row__more { visibility: hidden; }
+   that actually hide something advertise it, and the rest leave the layout so
+   no chevron column is reserved against their text. */
+body.bb-measured .bb-row:not(.bb-row--clip) .bb-row__more { display: none; }
 .bb-row__id { font-family: var(--font-mono); font-size: var(--fs-2xs); color: var(--text-faint); white-space: nowrap; }
 .bb-row__pr { font-family: var(--font-mono); font-size: var(--fs-xs); font-weight: 600; color: var(--ocean-600); white-space: nowrap; }
 .bb-row__pr:hover { text-decoration: underline; }

--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -544,12 +544,18 @@ __FM_BEARINGS_BOARD_DATA__
   var measureEnabled = false;
   var measureTimer;
   function measureClippedRows() {
-    discloseRows.forEach(function (r) {
-      if (r.row.classList.contains("is-open")) { syncRowTooltip(r); return; }
-      var clipped = r.title.scrollHeight - r.title.clientHeight > 1 ||
-                    r.sub.scrollHeight - r.sub.clientHeight > 1;
-      r.row.classList.toggle("bb-row--clip", clipped);
-      r.more.disabled = !clipped;
+    /* every read first, so one layout serves the whole pass rather than each
+       row's writes forcing the next row's measurement to reflow */
+    var clipped = discloseRows.map(function (r) {
+      if (r.row.classList.contains("is-open")) return null;
+      return r.title.scrollHeight - r.title.clientHeight > 1 ||
+             r.sub.scrollHeight - r.sub.clientHeight > 1;
+    });
+    discloseRows.forEach(function (r, i) {
+      if (clipped[i] !== null) {
+        r.row.classList.toggle("bb-row--clip", clipped[i]);
+        r.more.disabled = !clipped[i];
+      }
       syncRowTooltip(r);
     });
   }

--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -234,17 +234,63 @@ a { color: inherit; text-decoration: none; }
 .bb-freeform:focus { outline: none; border-color: var(--rust-400); box-shadow: var(--focus-ring); }
 
 /* ---- compact rows (Underway / Landed / Charted) ---- */
+/* Half-width column, so this text routinely overflows: the collapsed row clamps
+   to two wrapped lines and a chevron opens the rest in place. The clamp is
+   visual only - the full string stays in the DOM. */
 .bb-rows { display: flex; flex-direction: column; }
 .bb-row {
   display: flex; align-items: center; gap: 12px; padding: 11px 18px;
   border-top: 1px solid var(--border-soft); min-width: 0;
 }
 .bb-row:first-child { border-top: none; }
-.bb-row__main { min-width: 0; flex: 1 1 auto; }
-.bb-row__title { font-size: var(--fs-sm); font-weight: 700; color: var(--text-strong); line-height: 1.3;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.bb-row__sub { font-size: var(--fs-xs); color: var(--text-muted); line-height: 1.3; margin-top: 1px;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bb-row.is-open { align-items: flex-start; }
+
+/* The disclosure is the chevron beside the text, not the text itself, so a drag
+   across a row still selects and copies it. */
+.bb-row__main {
+  min-width: 0; flex: 1 1 auto;
+  display: grid; grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas: "title more" "sub more";
+  align-items: start;
+}
+.bb-row__title, .bb-row__sub {
+  display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; line-clamp: 2;
+  overflow: hidden; min-width: 0; overflow-wrap: anywhere;
+}
+.bb-row__title { grid-area: title; font-size: var(--fs-sm); font-weight: 700; color: var(--text-strong); line-height: 1.3; }
+.bb-row__sub { grid-area: sub; font-size: var(--fs-xs); color: var(--text-muted); line-height: 1.3; margin-top: 1px; }
+.bb-row.is-open .bb-row__title, .bb-row.is-open .bb-row__sub {
+  display: block; -webkit-line-clamp: none; line-clamp: none; overflow: visible;
+}
+/* A 44px touch target wrapping a 22px chip: an overlay reaching the same 44px
+   would overflow its own column, which nothing here may do, and the negative
+   margins keep the taller target from growing every row. */
+.bb-row__more {
+  grid-area: more; align-self: start;
+  display: inline-grid; place-items: center;
+  width: 44px; height: 44px; margin: -11px 0; flex: none; padding: 0;
+  color: var(--text-faint); background: none; border: 0; cursor: pointer;
+  -webkit-appearance: none; appearance: none;
+}
+.bb-row__more-chip {
+  display: grid; place-items: center; width: 22px; height: 22px;
+  background: var(--surface-card-warm); border: 1px solid var(--border-soft);
+  border-radius: var(--radius-xs);
+  transition: transform 120ms, color 120ms, border-color 120ms, box-shadow 120ms;
+}
+.bb-row__more svg { width: 13px; height: 13px; }
+.bb-row__more:not(:disabled):hover { color: var(--text-body); }
+.bb-row__more:not(:disabled):hover .bb-row__more-chip { border-color: var(--ink-300); }
+.bb-row__more:focus-visible { outline: none; }
+.bb-row__more:focus-visible .bb-row__more-chip { box-shadow: var(--focus-ring); }
+/* a row with nothing hidden is not a disclosure: it leaves the tab order and
+   drops its affordance rather than offering an expand that reveals nothing */
+.bb-row__more:disabled { cursor: default; }
+.bb-row.is-open .bb-row__more-chip { transform: rotate(180deg); }
+/* Before the clip measurement runs - and anywhere it cannot - every row keeps
+   its affordance, so the text is never unreachable. Once measured, only rows
+   that actually hide something advertise it. */
+body.bb-measured .bb-row:not(.bb-row--clip) .bb-row__more { visibility: hidden; }
 .bb-row__id { font-family: var(--font-mono); font-size: var(--fs-2xs); color: var(--text-faint); white-space: nowrap; }
 .bb-row__pr { font-family: var(--font-mono); font-size: var(--fs-xs); font-weight: 600; color: var(--ocean-600); white-space: nowrap; }
 .bb-row__pr:hover { text-decoration: underline; }
@@ -443,6 +489,87 @@ __FM_BEARINGS_BOARD_DATA__
   var chartedMoreWarnings = data.charted_warning_more || 0;
   function utf8ByteLength(text) { return new TextEncoder().encode(text).length; }
   var CHECK_SVG = '<svg class="fm-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>';
+  var CHEVRON_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>';
+
+  var discloseRows = [];
+  /* minted here, not from a per-section index, so no two sections can collide */
+  var rowTextSeq = 0;
+  function addRowText(row, titleText, subText) {
+    var main = el("div", "bb-row__main");
+    var full = subText ? titleText + "\n" + subText : titleText;
+    /* A mouse convenience, not an accessibility mechanism: the whole string is
+       already ordinary DOM text and only visually clamped, so nothing needs it. */
+    main.setAttribute("title", full);
+    var seq = "bb-rowtext-" + (++rowTextSeq);
+    var title = el("span", "bb-row__title", titleText);
+    title.id = seq + "-title";
+    var sub = el("span", "bb-row__sub", subText);
+    sub.id = seq + "-sub";
+    var more = el("button", "bb-row__more");
+    more.type = "button";
+    more.setAttribute("aria-expanded", "false");
+    /* the chevron carries no text of its own, so it names the row it opens */
+    more.setAttribute("aria-label", "Show the full text of " + titleText);
+    /* the two spans are what un-clamps, so the button names both rather than the
+       block that would also contain the button itself */
+    more.setAttribute("aria-controls", title.id + " " + sub.id);
+    var chip = el("span", "bb-row__more-chip");
+    chip.innerHTML = CHEVRON_SVG;
+    more.appendChild(chip);
+    main.appendChild(title);
+    main.appendChild(sub);
+    main.appendChild(more);
+    var entry = { row: row, main: main, more: more, title: title, sub: sub, full: full };
+    more.addEventListener("click", function () {
+      var open = !row.classList.contains("is-open");
+      row.classList.toggle("is-open", open);
+      more.setAttribute("aria-expanded", open ? "true" : "false");
+      syncRowTooltip(entry);
+      /* opening a row changes every row's width the moment a scrollbar appears,
+         so what still clips is re-decided rather than left as it was measured */
+      requestMeasure();
+    });
+    row.appendChild(main);
+    discloseRows.push(entry);
+    return main;
+  }
+
+  /* The tooltip belongs to exactly one state: collapsed and still clipping. The
+     chevron's enabled state already records whether a row hides anything. */
+  function syncRowTooltip(r) {
+    if (r.more.disabled || r.row.classList.contains("is-open")) r.main.removeAttribute("title");
+    else r.main.setAttribute("title", r.full);
+  }
+
+  var measureEnabled = false;
+  var measureTimer;
+  function measureClippedRows() {
+    discloseRows.forEach(function (r) {
+      if (r.row.classList.contains("is-open")) { syncRowTooltip(r); return; }
+      var clipped = r.title.scrollHeight - r.title.clientHeight > 1 ||
+                    r.sub.scrollHeight - r.sub.clientHeight > 1;
+      r.row.classList.toggle("bb-row--clip", clipped);
+      r.more.disabled = !clipped;
+      syncRowTooltip(r);
+    });
+  }
+  function measureFailOpen() {
+    measureEnabled = false;
+    try {
+      document.body.classList.remove("bb-measured");
+      discloseRows.forEach(function (r) {
+        r.more.disabled = false;
+        syncRowTooltip(r);
+      });
+    } catch (openError) { /* nothing further to fall back to */ }
+  }
+  function requestMeasure() {
+    if (!measureEnabled) return;
+    clearTimeout(measureTimer);
+    measureTimer = setTimeout(function () {
+      try { measureClippedRows(); } catch (measureError) { measureFailOpen(); }
+    }, 120);
+  }
 
   document.getElementById("bb-provenance").textContent = data.schema + " · " + data.generated;
 
@@ -612,12 +739,9 @@ __FM_BEARINGS_BOARD_DATA__
   data.underway.forEach(function (t) {
     var row = el("div", "bb-row");
     row.appendChild(badge(t.state === "working" ? "online" : "info", t.state));
-    var main = el("div", "bb-row__main");
-    main.appendChild(el("div", "bb-row__title", t.doing));
     /* captain-facing rows name the repo; the internal task id shows only when
        no repo is known */
-    main.appendChild(el("div", "bb-row__sub", t.kind + " · " + (t.repo || t.id)));
-    row.appendChild(main);
+    addRowText(row, t.doing, t.kind + " · " + (t.repo || t.id));
     uw.appendChild(row);
   });
 
@@ -629,10 +753,7 @@ __FM_BEARINGS_BOARD_DATA__
     var chk = el("span", "bb-row__check");
     chk.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>';
     row.appendChild(chk);
-    var main = el("div", "bb-row__main");
-    main.appendChild(el("div", "bb-row__title", t.what));
-    main.appendChild(el("div", "bb-row__sub", (t.repo || t.id) + " · " + t.owner));
-    row.appendChild(main);
+    addRowText(row, t.what, (t.repo || t.id) + " · " + t.owner);
     if (t.pr_url) {
       var a = el("a", "bb-row__pr", "#" + t.pr_url.split("/").pop());
       a.href = t.pr_url; a.title = t.pr_url; a.target = "_blank"; a.rel = "noopener";
@@ -679,12 +800,10 @@ __FM_BEARINGS_BOARD_DATA__
     } else {
       row.appendChild(el("span", "bb-pick-spacer"));
     }
-    var main = el("div", "bb-row__main");
-    main.appendChild(el("div", "bb-row__title", t.title));
-    /* second line keeps the title uncrowded in the half-width column */
+    /* second line keeps the title uncrowded in the half-width column; the
+       reason leads it, because why work waits is what the captain reads for */
     var chSub = t.repo || t.id;
-    main.appendChild(el("div", "bb-row__sub", t.reason ? t.reason + " · " + chSub : chSub));
-    row.appendChild(main);
+    addRowText(row, t.title, t.reason ? t.reason + " · " + chSub : chSub);
     if (isWarning(t)) row.appendChild(badge("danger", "needs repair"));
     else if (t.reason) row.appendChild(badge("warn", "waiting"));
     ch.appendChild(row);
@@ -721,6 +840,32 @@ __FM_BEARINGS_BOARD_DATA__
       }
       bar.classList.add("is-queued");
     });
+  }
+
+  /* Measured before the first paint, so a row never flashes an affordance it
+     does not need. The row containers are watched for size rather than the
+     window, because a scrollbar arriving as a row opens, a text-only zoom, or a
+     late webfont each move where text stops fitting with no resize event. */
+  if (discloseRows.length && document.body && document.body.classList) {
+    try {
+      measureClippedRows();
+      measureEnabled = true;
+      document.body.classList.add("bb-measured");
+      if (window.addEventListener) window.addEventListener("resize", requestMeasure);
+      if (typeof window.ResizeObserver === "function") {
+        var rowsObserver = new window.ResizeObserver(requestMeasure);
+        var seenContainers = [];
+        discloseRows.forEach(function (r) {
+          var box = r.row.parentNode;
+          if (!box || seenContainers.indexOf(box) !== -1) return;
+          seenContainers.push(box);
+          rowsObserver.observe(box);
+        });
+      }
+      if (document.fonts && document.fonts.ready && document.fonts.ready.then) {
+        document.fonts.ready.then(requestMeasure, function () {});
+      }
+    } catch (measureError) { measureFailOpen(); }
   }
   } catch (e) {
     renderBoardError("The board data could not be rendered");

--- a/tests/assets/board-render-harness.mjs
+++ b/tests/assets/board-render-harness.mjs
@@ -3,7 +3,14 @@
 // asserted through the real template rather than by reading its source.
 //
 // Usage: node board-render-harness.mjs <built-board.html>
-// Prints one JSON document: { stats:[{n,label}], charted:[{title,sub,badges,pickable}] }
+// Prints one JSON document:
+//   { stats:[{n,label}],
+//     underway|landed|charted:[{title,sub,badges,pickable,textTag,tooltip,textIds,disclosure}],
+//     presses:[{open,expanded,tooltip}], empty, more, error }
+// The shim has no layout, so it reports what the renderer builds unconditionally
+// and never what a real browser measures: the clamp and the clipped-row pass are
+// verified in a browser, not here. Pressing the disclosure needs no layout, so
+// the shim does dispatch it and reports what the row became.
 import { readFileSync } from "node:fs";
 
 const html = readFileSync(process.argv[2], "utf8");
@@ -11,6 +18,7 @@ const html = readFileSync(process.argv[2], "utf8");
 class Node {
   constructor(tag) {
     this.tagName = tag;
+    this.id = "";
     this.className = "";
     this.children = [];
     this.attributes = {};
@@ -22,9 +30,18 @@ class Node {
     this.type = "";
     this.value = "";
     this.checked = false;
+    this.listeners = {};
     this.classList = {
-      add: (c) => { this.className = (this.className + " " + c).trim(); },
+      add: (c) => { if (!this.classList.contains(c)) this.className = (this.className + " " + c).trim(); },
+      remove: (c) => {
+        this.className = this.className.split(/\s+/).filter((x) => x && x !== c).join(" ");
+      },
       contains: (c) => this.className.split(/\s+/).includes(c),
+      toggle: (c, force) => {
+        const on = force === undefined ? !this.classList.contains(c) : !!force;
+        if (on) this.classList.add(c); else this.classList.remove(c);
+        return on;
+      },
     };
   }
   get textContent() {
@@ -35,7 +52,11 @@ class Node {
   set textContent(v) { this._text = String(v); this.children = []; }
   appendChild(n) { n.parentNode = this; this.children.push(n); return n; }
   setAttribute(k, v) { this.attributes[k] = v; }
-  addEventListener() {}
+  getAttribute(k) { return Object.prototype.hasOwnProperty.call(this.attributes, k) ? this.attributes[k] : null; }
+  removeAttribute(k) { delete this.attributes[k]; }
+  addEventListener(type, fn) { (this.listeners[type] ||= []).push(fn); }
+  // no event system, just the handlers this node registered for itself
+  dispatch(type) { for (const fn of this.listeners[type] || []) fn({ target: this }); }
   querySelectorAll(sel) {
     const want = sel.replace(/^\./, "").replace(/:checked$/, "");
     const checkedOnly = sel.endsWith(":checked");
@@ -93,18 +114,59 @@ const stats = strip.children.map((t) => ({
   label: t.children.find((c) => c.className.includes("bb-stat__label"))?.textContent,
 }));
 
+const rowNodesOf = (containerId) =>
+  (byId.get(containerId) || new Node("div")).children
+    .filter((r) => r.className.split(/\s+/).includes("bb-row"));
+
+const mainOf = (row) => row.children.find((c) => c.className.includes("bb-row__main"));
+const chevronOf = (row) => mainOf(row)?.children.find((c) => c.className.includes("bb-row__more"));
+
+const reportRow = (row) => {
+  const main = mainOf(row);
+  const more = chevronOf(row);
+  const titleNode = main?.children.find((c) => c.className.includes("bb-row__title"));
+  const subNode = main?.children.find((c) => c.className.includes("bb-row__sub"));
+  return {
+    title: titleNode?.textContent ?? "",
+    sub: subNode?.textContent ?? "",
+    badges: badgesOf(row),
+    pickable: row.children.some((c) => c.className.includes("bb-pick") && !c.className.includes("spacer")),
+    // the text block itself: plain, selectable, and carrying the whole string
+    // for a mouse hover
+    textTag: main?.tagName ?? null,
+    tooltip: main?.getAttribute("title") ?? null,
+    // the ids of the two spans the row actually expands, so a caller can check
+    // what the button points at and that no two rows were given the same name
+    textIds: [titleNode?.id ?? "", subNode?.id ?? ""],
+    // the separate control a keyboard and a touch tap reach the rest through
+    disclosure: more
+      ? { tag: more.tagName, type: more.type,
+          expanded: more.getAttribute("aria-expanded"),
+          label: more.getAttribute("aria-label"),
+          controls: more.getAttribute("aria-controls") }
+      : null,
+  };
+};
+
 const ch = byId.get("bb-charted") || new Node("div");
-const charted = ch.children
-  .filter((r) => r.className.split(/\s+/).includes("bb-row"))
-  .map((row) => {
-    const main = row.children.find((c) => c.className.includes("bb-row__main"));
-    return {
-      title: main?.children.find((c) => c.className.includes("bb-row__title"))?.textContent ?? "",
-      sub: main?.children.find((c) => c.className.includes("bb-row__sub"))?.textContent ?? "",
-      badges: badgesOf(row),
-      pickable: row.children.some((c) => c.className.includes("bb-pick") && !c.className.includes("spacer")),
-    };
-  });
+const chartedNodes = rowNodesOf("bb-charted");
+const underwayNodes = rowNodesOf("bb-underway");
+const landedNodes = rowNodesOf("bb-landed");
+const charted = chartedNodes.map(reportRow);
+const underway = underwayNodes.map(reportRow);
+const landed = landedNodes.map(reportRow);
+
+// Opening a row needs no layout engine, so the shim presses the chevron twice
+// and reports what the row, the button and the hover tooltip became each time.
+const pressDisclosure = (row) => {
+  const more = chevronOf(row);
+  if (!more) return null;
+  more.dispatch("click");
+  return { open: row.classList.contains("is-open"), expanded: more.getAttribute("aria-expanded"),
+    tooltip: mainOf(row).getAttribute("title") };
+};
+const firstRow = chartedNodes[0] ?? underwayNodes[0] ?? landedNodes[0];
+const presses = firstRow ? [pressDisclosure(firstRow), pressDisclosure(firstRow)] : [];
 // A fail-closed render replaces the page body instead of the board sections, so
 // surface it rather than reporting an empty board as a successful render.
 const errorText = [...byId.entries()]
@@ -114,4 +176,5 @@ const errorText = [...byId.entries()]
 const empty = ch.children.filter((c) => c.className.includes("bb-empty")).map((c) => c.textContent);
 const more = ch.children.filter((c) => c.className.includes("bb-morechip")).map((c) => c.textContent);
 
-process.stdout.write(JSON.stringify({ stats, charted, empty, more, error: errorText }) + "\n");
+process.stdout.write(
+  JSON.stringify({ stats, charted, underway, landed, presses, empty, more, error: errorText }) + "\n");

--- a/tests/assets/board-render-harness.mjs
+++ b/tests/assets/board-render-harness.mjs
@@ -12,14 +12,17 @@
 // two-line clamp - which is enough for the renderer's clipped-row pass to run
 // and decide the same way it does in a browser. How wide a real glyph is stays
 // a browser question; that a row hiding text keeps its disclosure is decided
-// here. Setting FM_BOARD_HARNESS_MEASURE=off makes every measurement throw, to
-// stand for an environment where the pass cannot run at all.
+// here. Setting FM_BOARD_HARNESS_MEASURE=off makes every measurement throw and
+// =zero makes every measurement read zero, the two shapes of an environment
+// where the pass cannot run at all.
 import { readFileSync } from "node:fs";
 
 const WRAP_COLS = 48;
 const CLAMP_LINES = 2;
 const LINE_PX = 20;
-const MEASURABLE = process.env.FM_BOARD_HARNESS_MEASURE !== "off";
+const MEASURE_MODE = process.env.FM_BOARD_HARNESS_MEASURE || "on";
+const MEASURABLE = MEASURE_MODE !== "off";
+const NO_LAYOUT = MEASURE_MODE === "zero";
 
 const html = readFileSync(process.argv[2], "utf8");
 
@@ -56,9 +59,10 @@ class Node {
     if (!MEASURABLE) throw new Error("layout is unavailable");
     return Math.max(1, Math.ceil(this.textContent.length / WRAP_COLS));
   }
-  get scrollHeight() { return this._lines * LINE_PX; }
+  get scrollHeight() { return NO_LAYOUT ? 0 : this._lines * LINE_PX; }
   // clamped like the stylesheet, except inside a row the renderer has opened
   get clientHeight() {
+    if (NO_LAYOUT) return 0;
     const lines = this._lines;
     let clamp = true;
     for (let n = this.parentNode; n; n = n.parentNode) {

--- a/tests/assets/board-render-harness.mjs
+++ b/tests/assets/board-render-harness.mjs
@@ -4,14 +4,22 @@
 //
 // Usage: node board-render-harness.mjs <built-board.html>
 // Prints one JSON document:
-//   { stats:[{n,label}],
-//     underway|landed|charted:[{title,sub,badges,pickable,textTag,tooltip,textIds,disclosure}],
+//   { stats:[{n,label}], measured,
+//     underway|landed|charted:[{title,sub,badges,pickable,textTag,tooltip,textIds,clip,disclosure}],
 //     presses:[{open,expanded,tooltip}], empty, more, error }
-// The shim has no layout, so it reports what the renderer builds unconditionally
-// and never what a real browser measures: the clamp and the clipped-row pass are
-// verified in a browser, not here. Pressing the disclosure needs no layout, so
-// the shim does dispatch it and reports what the row became.
+// There is no layout engine here, so text is modeled as a monospace paragraph
+// wrapped at WRAP_COLS and clamped to CLAMP_LINES - the stylesheet's own
+// two-line clamp - which is enough for the renderer's clipped-row pass to run
+// and decide the same way it does in a browser. How wide a real glyph is stays
+// a browser question; that a row hiding text keeps its disclosure is decided
+// here. Setting FM_BOARD_HARNESS_MEASURE=off makes every measurement throw, to
+// stand for an environment where the pass cannot run at all.
 import { readFileSync } from "node:fs";
+
+const WRAP_COLS = 48;
+const CLAMP_LINES = 2;
+const LINE_PX = 20;
+const MEASURABLE = process.env.FM_BOARD_HARNESS_MEASURE !== "off";
 
 const html = readFileSync(process.argv[2], "utf8");
 
@@ -44,6 +52,20 @@ class Node {
       },
     };
   }
+  get _lines() {
+    if (!MEASURABLE) throw new Error("layout is unavailable");
+    return Math.max(1, Math.ceil(this.textContent.length / WRAP_COLS));
+  }
+  get scrollHeight() { return this._lines * LINE_PX; }
+  // clamped like the stylesheet, except inside a row the renderer has opened
+  get clientHeight() {
+    const lines = this._lines;
+    let clamp = true;
+    for (let n = this.parentNode; n; n = n.parentNode) {
+      if (n.classList.contains("is-open")) { clamp = false; break; }
+    }
+    return (clamp ? Math.min(lines, CLAMP_LINES) : lines) * LINE_PX;
+  }
   get textContent() {
     return this.children.length
       ? this.children.map((c) => c.textContent).join("")
@@ -56,7 +78,10 @@ class Node {
   removeAttribute(k) { delete this.attributes[k]; }
   addEventListener(type, fn) { (this.listeners[type] ||= []).push(fn); }
   // no event system, just the handlers this node registered for itself
-  dispatch(type) { for (const fn of this.listeners[type] || []) fn({ target: this }); }
+  dispatch(type) {
+    if (this.disabled) return;
+    for (const fn of this.listeners[type] || []) fn({ target: this });
+  }
   querySelectorAll(sel) {
     const want = sel.replace(/^\./, "").replace(/:checked$/, "");
     const checkedOnly = sel.endsWith(":checked");
@@ -79,7 +104,11 @@ dataNode.textContent = html
   .split("</script>")[0];
 byId.set("bearings-data", dataNode);
 
+const body = new Node("body");
 globalThis.document = {
+  // the clipped-row pass is gated on a body carrying a classList, and marks it
+  // once it has measured, so the shim supplies a real one
+  body,
   createElement: (tag) => new Node(tag),
   // Lazily mint any element the page asks for: the shim tracks whatever ids
   // the shipped template actually uses instead of pinning a fixed list.
@@ -138,12 +167,15 @@ const reportRow = (row) => {
     // the ids of the two spans the row actually expands, so a caller can check
     // what the button points at and that no two rows were given the same name
     textIds: [titleNode?.id ?? "", subNode?.id ?? ""],
+    // what the measurement pass concluded this row hides
+    clip: row.classList.contains("bb-row--clip"),
     // the separate control a keyboard and a touch tap reach the rest through
     disclosure: more
       ? { tag: more.tagName, type: more.type,
           expanded: more.getAttribute("aria-expanded"),
           label: more.getAttribute("aria-label"),
-          controls: more.getAttribute("aria-controls") }
+          controls: more.getAttribute("aria-controls"),
+          disabled: more.disabled }
       : null,
   };
 };
@@ -177,4 +209,5 @@ const empty = ch.children.filter((c) => c.className.includes("bb-empty")).map((c
 const more = ch.children.filter((c) => c.className.includes("bb-morechip")).map((c) => c.textContent);
 
 process.stdout.write(
-  JSON.stringify({ stats, charted, underway, landed, presses, empty, more, error: errorText }) + "\n");
+  JSON.stringify({ stats, measured: body.classList.contains("bb-measured"),
+    charted, underway, landed, presses, empty, more, error: errorText }) + "\n");

--- a/tests/fm-bearings-board-render.test.sh
+++ b/tests/fm-bearings-board-render.test.sh
@@ -27,8 +27,9 @@ make_home() {  # <name>
 }
 
 # Build the board from the payload already written to <home>/payload.json and
-# return what the renderer produced. With measure=off the harness makes every
-# text measurement throw, standing for a browser where the pass cannot run.
+# return what the renderer produced. With measure=off every text measurement
+# throws and with measure=zero every one reads zero, the two shapes of a
+# browser where the pass cannot run.
 build_and_render() {  # <home> [measure]
   local home=$1 measure=${2:-on}
   PATH="$home/fakebin:$PATH" FM_HOME="$home" \
@@ -283,6 +284,22 @@ test_rows_stay_expandable_where_the_clip_measurement_cannot_run() {
   pass "every row stays expandable and keeps its tooltip where the clip measurement cannot run"
 }
 
+# Zero is the other shape of an absent layout engine, and reading it as "this
+# row fits" would strip every disclosure and tooltip the fix exists to keep.
+test_rows_stay_expandable_where_layout_metrics_read_zero() {
+  local home out
+  home=$(make_home clip-zero-metrics)
+  out=$(render_payload "$home" "$(mixed_payload)" zero)
+  printf '%s' "$out" | jq -e '.error == "" and .measured == false' >/dev/null \
+    || fail "a board whose layout metrics read zero did not fall back cleanly: $out"
+  printf '%s' "$out" | jq -e --arg t "$LONG_TITLE" '
+    (.charted | length) == 2
+      and all(.charted[]; .disclosure.disabled == false and .tooltip != null)
+      and (.charted[0].tooltip | contains($t))
+  ' >/dev/null || fail "a board whose layout metrics read zero took rows out of reach: $out"
+  pass "every row stays expandable and keeps its tooltip where layout metrics read zero"
+}
+
 test_the_charted_reason_survives_the_row_in_full() {
   local home out
   home=$(make_home disclosure-reason)
@@ -306,4 +323,5 @@ test_pressing_the_disclosure_opens_and_closes_the_row
 test_expanding_a_row_drops_its_now_redundant_tooltip
 test_only_a_row_that_hides_text_keeps_its_disclosure
 test_rows_stay_expandable_where_the_clip_measurement_cannot_run
+test_rows_stay_expandable_where_layout_metrics_read_zero
 test_the_charted_reason_survives_the_row_in_full

--- a/tests/fm-bearings-board-render.test.sh
+++ b/tests/fm-bearings-board-render.test.sh
@@ -27,14 +27,15 @@ make_home() {  # <name>
 }
 
 # Build the board from the payload already written to <home>/payload.json and
-# return what the renderer produced.
-build_and_render() {  # <home>
-  local home=$1
+# return what the renderer produced. With measure=off the harness makes every
+# text measurement throw, standing for a browser where the pass cannot run.
+build_and_render() {  # <home> [measure]
+  local home=$1 measure=${2:-on}
   PATH="$home/fakebin:$PATH" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
     "$BOARD" build "$home/payload.json" >/dev/null || fail "the board did not build"
-  node "$HARNESS" "$home/.lavish/bearings-board.html" \
+  FM_BOARD_HARNESS_MEASURE="$measure" node "$HARNESS" "$home/.lavish/bearings-board.html" \
     || fail "the built board could not be rendered"
 }
 
@@ -49,10 +50,10 @@ render() {  # <home> <charted-json> [charted_more] [charted_warning_more]
 }
 
 # Build the board from a whole payload, for assertions that span every section.
-render_payload() {  # <home> <payload-json>
+render_payload() {  # <home> <payload-json> [measure]
   local home=$1
   printf '%s' "$2" > "$home/payload.json"
-  build_and_render "$home"
+  build_and_render "$home" "${3:-on}"
 }
 
 charted_next_count() {  # <render-json>
@@ -240,6 +241,48 @@ test_expanding_a_row_drops_its_now_redundant_tooltip() {
   pass "expanding a row drops its redundant tooltip, and collapsing restores it"
 }
 
+# An expand that reveals nothing is noise, so the measurement pass takes the
+# rows that fit back out of the tab order - but it must never take out a row
+# that really is hiding text, which is the bug this whole change repairs.
+mixed_payload() {
+  jq -n --arg t "$LONG_TITLE" --arg r "$LONG_REASON" '{
+    schema:"fm-bearings-board.v1", home:"clip-home", generated:"2026-08-26T00:00Z",
+    prs_live:false, captains_call:[], underway:[], landed:[],
+    charted:[{id:"c1", repo:"sample", title:$t, reason:$r, dispatchable:true},
+             {id:"c2", repo:"sample", title:"Short", reason:"gated", dispatchable:true}]}'
+}
+
+test_only_a_row_that_hides_text_keeps_its_disclosure() {
+  local home out
+  home=$(make_home clip-measure)
+  out=$(render_payload "$home" "$(mixed_payload)")
+  printf '%s' "$out" | jq -e '.measured == true' >/dev/null \
+    || fail "the board never measured which rows clip: $out"
+  printf '%s' "$out" | jq -e --arg t "$LONG_TITLE" '
+    (.charted[0] | .clip == true and .disclosure.disabled == false
+       and (.tooltip | contains($t)))
+      and (.charted[1] | .clip == false and .disclosure.disabled == true
+       and .tooltip == null)
+  ' >/dev/null || fail "the disclosure did not follow which rows actually hide text: $out"
+  pass "a row that hides text keeps an enabled disclosure, and a row that fits loses it"
+}
+
+# Where the pass cannot run there is no way to tell which rows hide text, so
+# every row must stay reachable rather than every row losing its way in.
+test_rows_stay_expandable_where_the_clip_measurement_cannot_run() {
+  local home out
+  home=$(make_home clip-fail-open)
+  out=$(render_payload "$home" "$(mixed_payload)" off)
+  printf '%s' "$out" | jq -e '.error == "" and .measured == false' >/dev/null \
+    || fail "an unmeasurable board did not fall back cleanly: $out"
+  printf '%s' "$out" | jq -e --arg t "$LONG_TITLE" '
+    (.charted | length) == 2
+      and all(.charted[]; .disclosure.disabled == false and .tooltip != null)
+      and (.charted[0].tooltip | contains($t))
+  ' >/dev/null || fail "an unmeasurable board took rows out of reach: $out"
+  pass "every row stays expandable and keeps its tooltip where the clip measurement cannot run"
+}
+
 test_the_charted_reason_survives_the_row_in_full() {
   local home out
   home=$(make_home disclosure-reason)
@@ -261,4 +304,6 @@ test_every_compact_row_reaches_its_full_text_through_one_disclosure
 test_each_disclosure_names_the_text_it_opens_with_a_page_unique_id
 test_pressing_the_disclosure_opens_and_closes_the_row
 test_expanding_a_row_drops_its_now_redundant_tooltip
+test_only_a_row_that_hides_text_keeps_its_disclosure
+test_rows_stay_expandable_where_the_clip_measurement_cannot_run
 test_the_charted_reason_survives_the_row_in_full

--- a/tests/fm-bearings-board-render.test.sh
+++ b/tests/fm-bearings-board-render.test.sh
@@ -3,8 +3,8 @@
 # (.agents/skills/bearings/assets/board-template.html), exercised through a real
 # `fm-bearings-board.sh build` and then executed under the minimal DOM shim in
 # tests/assets/board-render-harness.mjs. The assertions are on what the page
-# renders - row badges, the stat strip, the empty state - never on the
-# template's source text.
+# renders - row badges, the stat strip, the empty state, and the row text
+# disclosure the shim can press - never on the template's source text.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -26,19 +26,33 @@ make_home() {  # <name>
   printf '%s\n' "$home"
 }
 
-# Build the board from <charted-json> and return what the renderer produced.
-render() {  # <home> <charted-json> [charted_more] [charted_warning_more]
-  local home=$1 charted=$2 more=${3:-0} warning_more=${4:-0} data="$1/payload.json"
-  jq -n --argjson charted "$charted" --argjson more "$more" --argjson warning_more "$warning_more" '{
-    schema:"fm-bearings-board.v1", home:"render-home", generated:"2026-08-26T00:00Z",
-    prs_live:false, captains_call:[], underway:[], landed:[],
-    charted:$charted, charted_more:$more, charted_warning_more:$warning_more}' > "$data"
+# Build the board from the payload already written to <home>/payload.json and
+# return what the renderer produced.
+build_and_render() {  # <home>
+  local home=$1
   PATH="$home/fakebin:$PATH" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
-    "$BOARD" build "$data" >/dev/null || fail "the board did not build"
+    "$BOARD" build "$home/payload.json" >/dev/null || fail "the board did not build"
   node "$HARNESS" "$home/.lavish/bearings-board.html" \
     || fail "the built board could not be rendered"
+}
+
+# Build the board from <charted-json> and return what the renderer produced.
+render() {  # <home> <charted-json> [charted_more] [charted_warning_more]
+  local home=$1 charted=$2 more=${3:-0} warning_more=${4:-0}
+  jq -n --argjson charted "$charted" --argjson more "$more" --argjson warning_more "$warning_more" '{
+    schema:"fm-bearings-board.v1", home:"render-home", generated:"2026-08-26T00:00Z",
+    prs_live:false, captains_call:[], underway:[], landed:[],
+    charted:$charted, charted_more:$more, charted_warning_more:$warning_more}' > "$home/payload.json"
+  build_and_render "$home"
+}
+
+# Build the board from a whole payload, for assertions that span every section.
+render_payload() {  # <home> <payload-json>
+  local home=$1
+  printf '%s' "$2" > "$home/payload.json"
+  build_and_render "$home"
 }
 
 charted_next_count() {  # <render-json>
@@ -128,8 +142,123 @@ test_an_omitted_kind_keeps_the_existing_queued_rendering() {
   pass "an omitted kind renders exactly as queued work always did"
 }
 
+
+# The captain could not read a row's title or its waiting reason because both
+# were clipped to one line. What makes the rest reachable is that the row keeps
+# the complete strings as ordinary selectable text carrying a tooltip for a
+# mouse, and puts a chevron button beside them that a keyboard and a touch tap
+# can press to open the row in place. The clamp itself is CSS, so a browser -
+# not this shim - is where the visual truncation is checked.
+LONG_TITLE="Rework the charted next column so that the reason a task is waiting survives the half-width layout it is rendered into"
+LONG_REASON="waiting on the upstream release that carries the presentation-space version floor, because dispatching before it lands would strand the lab"
+
+long_payload() {
+  jq -n --arg t "$LONG_TITLE" --arg r "$LONG_REASON" '{
+    schema:"fm-bearings-board.v1", home:"disclosure-home", generated:"2026-08-26T00:00Z",
+    prs_live:false, captains_call:[],
+    underway:[{id:"u1", repo:"sample", state:"working", kind:"ship", doing:$t}],
+    landed:[{id:"l1", repo:"sample", what:$t, owner:"crew"}],
+    charted:[{id:"c1", repo:"sample", title:$t, reason:$r, dispatchable:true}]}'
+}
+
+test_every_compact_row_reaches_its_full_text_through_one_disclosure() {
+  local home out
+  home=$(make_home disclosure)
+  out=$(render_payload "$home" "$(long_payload)")
+  printf '%s' "$out" | jq -e '.error == ""' >/dev/null \
+    || fail "the board rendered its fail-closed error instead of the fleet: $out"
+  printf '%s' "$out" | jq -e --arg t "$LONG_TITLE" '
+    [.underway[0], .landed[0], .charted[0]] | all(
+      .textTag == "div"
+        and .disclosure.tag == "button" and .disclosure.type == "button"
+        and .disclosure.expanded == "false"
+        and (.disclosure.label | contains($t))
+        and .title == $t
+        and (.tooltip | contains($t))
+        and (.sub as $s | .tooltip | contains($s)))
+  ' >/dev/null || fail "a section's rows are not a disclosure carrying their full text: $out"
+  pass "underway, landed and charted rows each expose their full text through one disclosure button"
+}
+
+# A disclosure that reports only "expanded" leaves a screen reader announcing a
+# state with no subject, so the button must name the text it opens. Every section
+# builds its rows through the same helper, so a per-section index would hand two
+# sections the same name and point one button at another section's row.
+multi_row_payload() {
+  jq -n --arg t "$LONG_TITLE" --arg r "$LONG_REASON" '{
+    schema:"fm-bearings-board.v1", home:"controls-home", generated:"2026-08-26T00:00Z",
+    prs_live:false, captains_call:[],
+    underway:[{id:"u1", repo:"sample", state:"working", kind:"ship", doing:$t},
+              {id:"u2", repo:"sample", state:"working", kind:"ship", doing:($t + " two")}],
+    landed:[{id:"l1", repo:"sample", what:$t, owner:"crew"},
+            {id:"l2", repo:"sample", what:($t + " two"), owner:"crew"}],
+    charted:[{id:"c1", repo:"sample", title:$t, reason:$r, dispatchable:true},
+             {id:"c2", repo:"sample", title:($t + " two"), reason:$r, dispatchable:true}]}'
+}
+
+test_each_disclosure_names_the_text_it_opens_with_a_page_unique_id() {
+  local home out
+  home=$(make_home disclosure-controls)
+  out=$(render_payload "$home" "$(multi_row_payload)")
+  printf '%s' "$out" | jq -e '.error == ""' >/dev/null \
+    || fail "the board rendered its fail-closed error instead of the fleet: $out"
+  printf '%s' "$out" | jq -e '
+    [.underway[], .landed[], .charted[]]
+      | (length == 6)
+        and all(.textIds | all(length > 0))
+        and all(.disclosure.controls == (.textIds | join(" ")))
+        and ([.[].textIds[]] | length == (unique | length))
+  ' >/dev/null || fail "the row disclosures do not name their own text by a page-unique id: $out"
+  pass "every row's disclosure names the text it opens, by ids unique across all three sections"
+}
+
+# A row that renders a chevron but never opens leaves the clamped text just as
+# unreachable as before the fix, so the press itself is exercised.
+test_pressing_the_disclosure_opens_and_closes_the_row() {
+  local home out
+  home=$(make_home disclosure-toggle)
+  out=$(render_payload "$home" "$(long_payload)")
+  printf '%s' "$out" | jq -e '
+    (.presses[0] | .open == true and .expanded == "true")
+      and (.presses[1] | .open == false and .expanded == "false")
+  ' >/dev/null || fail "pressing the disclosure did not open and then close the row: $out"
+  pass "pressing a row's disclosure opens it, and pressing again closes it"
+}
+
+# A tooltip repeating text that is already fully on screen is noise, and the
+# hover panel can cover the very content it duplicates, so the tooltip belongs
+# to a collapsed row only.
+test_expanding_a_row_drops_its_now_redundant_tooltip() {
+  local home out
+  home=$(make_home disclosure-tooltip)
+  out=$(render_payload "$home" "$(long_payload)")
+  printf '%s' "$out" | jq -e --arg t "$LONG_TITLE" '
+    (.charted[0].tooltip | contains($t))
+      and (.presses[0] | .open == true and .tooltip == null)
+      and (.presses[1] | .open == false and (.tooltip | contains($t)))
+  ' >/dev/null || fail "the tooltip did not follow the row open and closed again: $out"
+  pass "expanding a row drops its redundant tooltip, and collapsing restores it"
+}
+
+test_the_charted_reason_survives_the_row_in_full() {
+  local home out
+  home=$(make_home disclosure-reason)
+  out=$(render_payload "$home" "$(long_payload)")
+  printf '%s' "$out" | jq -e --arg r "$LONG_REASON" '
+    .charted[0]
+      | (.sub | startswith($r)) and (.sub | endswith("\u00b7 sample"))
+        and (.tooltip | contains($r))
+  ' >/dev/null || fail "the waiting reason did not survive the charted row in full: $out"
+  pass "the charted waiting reason is carried whole by the row and its tooltip"
+}
+
 test_a_warning_row_reads_as_a_repair_not_as_queued_work
 test_warnings_are_excluded_from_the_charted_next_count
 test_a_board_of_only_warnings_still_reports_nothing_queued
 test_omitted_warnings_never_count_as_more_queued
 test_an_omitted_kind_keeps_the_existing_queued_rendering
+test_every_compact_row_reaches_its_full_text_through_one_disclosure
+test_each_disclosure_names_the_text_it_opens_with_a_page_unique_id
+test_pressing_the_disclosure_opens_and_closes_the_row
+test_expanding_a_row_drops_its_now_redundant_tooltip
+test_the_charted_reason_survives_the_row_in_full


### PR DESCRIPTION
Row text on the Bearings fleet board was cut off with no way to read the rest. Titles and waiting reasons were clamped to a single ellipsised line, and because the board renders these rows in a half-width column, text was hidden almost all the time.

Charted Next was the worst case: its second line is `<reason> · <repo>`, so the reason a task is waiting - the thing you read that column for - was the first thing the ellipsis ate.

## Affected sections

All three sections that share the `.bb-row` style, not just the one where it was reported:

- **Charted Next**
- **Underway**
- **Recently Landed**

They render through one shared row-text builder, so the fix applies to all three at once.

## What changed

**Collapsed rows clamp to two wrapped lines instead of one truncated line.** This recovers most hidden text at ordinary widths at no cost to rows that already fit - a row whose text fits keeps its original height. `overflow-wrap: anywhere` means an unbreakable URL wraps instead of widening the column.

**Anything still hidden opens in place.** Each row gets a small chevron button beside its text. Pressing it expands that row and drops the clamp; pressing again collapses it. One control covers mouse, touch and keyboard, so there is no hover-only path - a hover-only fix would have failed on half the devices this board is read on.

**Row text stays selectable.** The text block is a plain `div`; the disclosure is a separate button next to it, never wrapping the text. You can still drag across a row to select and copy a repo name, a title or a reason.

**A hover tooltip carries the full string while collapsed,** and is dropped while a row is expanded, since a tooltip repeating text already on screen is noise and can cover the content it duplicates. It returns on collapse if that row still hides something.

**Only rows that genuinely hide text become expandable.** A measurement pass marks them; rows that fit get no chevron and stay out of the tab order, so the board never offers an expand that reveals nothing. The pass re-runs on resize, when webfonts settle, and after every toggle.

**Accessibility:** the chevron is a real focusable button carrying `aria-expanded` and an `aria-controls` relationship naming the text it opens, with a 44x44 touch target. Because the clamp is purely visual, a screen reader receives the complete untruncated strings whether or not the row is expanded.

## What to look at closely

- **The measurement fails open by design.** If layout metrics are unavailable or the measurement throws, every row stays expandable and keeps its tooltip. Failing closed there would leave clipped text with no path at all - worse than the original bug - so this is the invariant most worth scrutinising. Both failure shapes (throwing, and zero/undefined metrics) are covered by tests.
- **Rows that reveal nothing reserve no space.** Their chevron is `display: none`, not `visibility: hidden`. Reserving the column on every row narrowed the text column enough to wrap titles that previously fit at 480px and below, growing those rows - the fix degrading rows that were never the problem.
- **Density.** Two lines was chosen deliberately over one (hides text) and over three (spends the scannability these compact rows exist for).

## Verification

Verified end-to-end in a real browser, not by reasoning about the CSS. Two boards were generated from the same payload through the shipped build script - one against the base template, one against this branch - and both were driven in Chrome:

- Before: 357-1302px of text unreachable across the three sections.
- After: mouse click, `Tab`+`Enter` with a visible focus ring, and a touch tap on a 390px phone profile where `(hover: hover)` is false each expand a row to zero clipped pixels.
- Range selection over row text still returns that text; the chevron holds the same 44x44 box across a toggle; forcing layout metrics to zero confirmed the fail-open path.
- Horizontal overflow and collapsed row heights match the pre-change template at 360, 480, 768 and 1280.

`tests/fm-bearings-board-render.test.sh` covers the disclosure across all three sections, page-unique `aria-controls` ids, the open/close cycle, the tooltip drop and restore, measured clipping, and both fail-open shapes.

## Deliberately out of scope

- **The payload contract is untouched.** No change to the board build script's validation or to the `fm-bearings-board.v1` schema. This is a rendering fix.
- **The Captain's Call cards** use a different structure and were left alone. A milder instance of the same clipping does exist there - the PR URL on a merge card is single-line clipped with no tooltip - and is reported rather than changed here.
- **The board's webfont import.** The template pulls fonts from Google Fonts, which sits awkwardly with its goal of being a single self-contained file. That predates this change, is untouched by it, and falls back to system fonts. Inlining the fonts is a separate piece of work.
- No board redesign, and no change to the colour system or layout.

## Known tradeoff

A re-measure can disable the chevron that currently holds keyboard focus - widen the window while a chevron is focused and that row may stop clipping, moving focus to the document body. It needs a resize to land while a chevron is focused, and guarding it costs more complexity than it saves, so it is accepted and recorded rather than worked around.
