### PR TITLE
feat(pi): show provider and thinking effort in status area

### DIFF
--- a/.pi/extensions/fm-model-status-badge.ts
+++ b/.pi/extensions/fm-model-status-badge.ts
@@ -1,0 +1,38 @@
+// Firstmate's additive stock-Pi provider and effort badge.
+//
+// This extension deliberately owns only its keyed footer status. It does not replace
+// Pi's footer or title, read configuration, register commands or tools, make model
+// calls, or participate in any Firstmate lifecycle behavior.
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+const STATUS_KEY = "firstmate-model-status-badge";
+
+function renderBadge(ctx: ExtensionContext): void {
+  if (!ctx.hasUI) return;
+
+  const provider = ctx.model?.provider;
+  if (!provider) {
+    ctx.ui.setStatus(STATUS_KEY, undefined);
+    return;
+  }
+
+  ctx.ui.setStatus(STATUS_KEY, `${provider} · ${ctx.thinkingLevel}`);
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", (_event, ctx) => {
+    renderBadge(ctx);
+  });
+
+  pi.on("model_select", (_event, ctx) => {
+    renderBadge(ctx);
+  });
+
+  pi.on("thinking_level_select", (_event, ctx) => {
+    renderBadge(ctx);
+  });
+
+  pi.on("session_shutdown", (_event, ctx) => {
+    if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
+  });
+}

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ FM_PI_HARNESS=pi-signed pi-signed
 
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
 For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
+Firstmate adds the active provider and thinking effort to Pi's status area without replacing Pi's stock footer or changing its terminal title.
 Pi's `/calm` toggle hides supported transcript chrome, including canonically classified Firstmate operational user rows, and uses a Calm-only animated working boat during active runs while preserving all model context and session data.
 Those Calm-hidden operational inputs remain ordinary user-role messages with unchanged delivery, ordering, authority, persistence, and exports.
 The preference persists for the effective Firstmate home, and toggling it off restores ordinary rendering.

--- a/tests/fm-model-status-badge.test.sh
+++ b/tests/fm-model-status-badge.test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Focused lifecycle contract checks for Firstmate's additive Pi model-status badge.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+EXT="$ROOT/.pi/extensions/fm-model-status-badge.ts"
+PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
+TMP_ROOT=$(fm_test_tmproot fm-model-status-badge)
+
+cleanup() {
+  fm_test_cleanup
+}
+trap cleanup EXIT
+
+if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+  echo "skip: node or npm not found for Pi model-status badge test"
+  exit 0
+fi
+if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+  echo "skip: installed @earendil-works/pi-coding-agent package not found"
+  exit 0
+fi
+
+mkdir -p "$TMP_ROOT/project/node_modules/@earendil-works"
+cp "$EXT" "$TMP_ROOT/project/fm-model-status-badge.ts"
+ln -s "$PI_PACKAGE_DIR" "$TMP_ROOT/project/node_modules/@earendil-works/pi-coding-agent"
+printf '%s\n' '{"type":"module"}' >"$TMP_ROOT/project/package.json"
+
+out=$(cd "$TMP_ROOT/project" && node --input-type=module 2>&1 <<'JS'
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+};
+const extension = await import(`${pathToFileURL("./fm-model-status-badge.ts").href}?test=${Date.now()}`);
+extension.default(pi);
+
+for (const event of ["session_start", "model_select", "thinking_level_select", "session_shutdown"]) {
+  if (!handlers.has(event)) throw new Error(`badge did not register ${event}`);
+}
+if (handlers.size !== 4) throw new Error(`badge registered unexpected lifecycle hooks: ${[...handlers.keys()].join(", ")}`);
+
+const statuses = [];
+const ui = {
+  setStatus(key, value) {
+    statuses.push([key, value]);
+  },
+};
+const context = {
+  hasUI: true,
+  ui,
+  model: { provider: "openrouter", id: "openai/gpt-4.1-nano" },
+  thinkingLevel: "medium",
+};
+
+handlers.get("session_start")({}, context);
+if (JSON.stringify(statuses.pop()) !== JSON.stringify(["firstmate-model-status-badge", "openrouter · medium"])) {
+  throw new Error("session start did not render only provider and effort");
+}
+
+context.model = { provider: "ollama-cloud", id: "qwen3.5:cloud" };
+context.thinkingLevel = "off";
+handlers.get("model_select")({}, context);
+if (JSON.stringify(statuses.pop()) !== JSON.stringify(["firstmate-model-status-badge", "ollama-cloud · off"])) {
+  throw new Error("model change did not refresh provider and effort");
+}
+
+context.thinkingLevel = "xhigh";
+handlers.get("thinking_level_select")({}, context);
+if (JSON.stringify(statuses.pop()) !== JSON.stringify(["firstmate-model-status-badge", "ollama-cloud · xhigh"])) {
+  throw new Error("thinking-level change did not refresh the badge");
+}
+
+context.model = undefined;
+handlers.get("model_select")({}, context);
+if (JSON.stringify(statuses.pop()) !== JSON.stringify(["firstmate-model-status-badge", undefined])) {
+  throw new Error("missing model did not clear the badge");
+}
+
+handlers.get("session_shutdown")({}, context);
+if (JSON.stringify(statuses.pop()) !== JSON.stringify(["firstmate-model-status-badge", undefined])) {
+  throw new Error("session shutdown did not clear the badge");
+}
+
+const noUiContext = {
+  ...context,
+  hasUI: false,
+  ui: {
+    setStatus() {
+      throw new Error("badge touched UI without one");
+    },
+  },
+};
+for (const event of ["session_start", "model_select", "thinking_level_select", "session_shutdown"]) {
+  handlers.get(event)({}, noUiContext);
+}
+JS
+)
+status=$?
+[ "$status" -eq 0 ] || fail "Pi model-status badge lifecycle contract failed: $out"
+[ -z "$out" ] || fail "Pi model-status badge lifecycle contract printed output: $out"
+pass "Pi model-status badge is an additive provider and effort status only, refreshes on model and effort changes, clears on shutdown, and is inert without UI"

--- a/tests/fm-model-status-badge.test.sh
+++ b/tests/fm-model-status-badge.test.sh
@@ -6,7 +6,6 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 EXT="$ROOT/.pi/extensions/fm-model-status-badge.ts"
-PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
 TMP_ROOT=$(fm_test_tmproot fm-model-status-badge)
 
 cleanup() {
@@ -14,21 +13,30 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
-  echo "skip: node or npm not found for Pi model-status badge test"
-  exit 0
-fi
-if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
-  echo "skip: installed @earendil-works/pi-coding-agent package not found"
+if ! command -v node >/dev/null 2>&1; then
+  echo "skip: node not found for Pi model-status badge test"
   exit 0
 fi
 
-mkdir -p "$TMP_ROOT/project/node_modules/@earendil-works"
+mkdir -p "$TMP_ROOT/project"
 cp "$EXT" "$TMP_ROOT/project/fm-model-status-badge.ts"
-ln -s "$PI_PACKAGE_DIR" "$TMP_ROOT/project/node_modules/@earendil-works/pi-coding-agent"
 printf '%s\n' '{"type":"module"}' >"$TMP_ROOT/project/package.json"
+cat >"$TMP_ROOT/project/typescript-loader.mjs" <<'JS'
+import { readFile } from "node:fs/promises";
 
-out=$(cd "$TMP_ROOT/project" && node --input-type=module 2>&1 <<'JS'
+export async function load(url, context, nextLoad) {
+  if (!new URL(url).pathname.endsWith(".ts")) return nextLoad(url, context);
+
+  let source = await readFile(new URL(url), "utf8");
+  source = source
+    .replace(/^import type .*;\r?\n/m, "")
+    .replace(/:\s*(?:ExtensionAPI|ExtensionContext)(?=\))/g, "")
+    .replace(/:\s*void(?=\s*\{)/g, "");
+  return { format: "module", shortCircuit: true, source };
+}
+JS
+
+out=$(cd "$TMP_ROOT/project" && node --no-warnings --experimental-loader ./typescript-loader.mjs --input-type=module 2>&1 <<'JS'
 import { pathToFileURL } from "node:url";
 
 const handlers = new Map();

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -29,6 +29,7 @@ trap cleanup EXIT
 mkdir -p "$TMP_ROOT/lib" "$TMP_ROOT/node_modules/@earendil-works" "$TMP_ROOT/node_modules/@types"
 cp "$ROOT/.pi/extensions/fm-branch-supervision.ts" "$TMP_ROOT/fm-branch-supervision.ts"
 cp "$ROOT/.pi/extensions/fm-calm.ts" "$TMP_ROOT/fm-calm.ts"
+cp "$ROOT/.pi/extensions/fm-model-status-badge.ts" "$TMP_ROOT/fm-model-status-badge.ts"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$TMP_ROOT/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$TMP_ROOT/fm-primary-turnend-guard.ts"
 cp "$ROOT/.pi/extensions/lib/fm-branch-dispatch.ts" "$TMP_ROOT/lib/fm-branch-dispatch.ts"


### PR DESCRIPTION
## Intent

Implement Phase 1 only of the approved stock-Pi status improvement: add an additive badge that shows the active Pi provider and thinking effort. Keep the existing terminal title and stock footer unchanged. Do not add role routing, commands, tools, model calls, global Pi configuration changes, provider/auth changes, filesystem reads, subprocesses, network calls, footer replacement, editor or working-row changes, watcher/supervision/turn-end/trust/worker-lifecycle behavior, or any installation. Add focused behavior tests and preserve compatibility with Firstmate Calm and the existing Pi extensions.

## What Changed

- Add an additive Pi status badge that displays the active provider and thinking effort, refreshes on selection changes, and clears when unavailable or on shutdown.
- Document the badge and add focused lifecycle coverage plus strict type-check inclusion for the new extension.

## Risk Assessment

✅ Low: The change is narrowly scoped to an additive keyed status, updates on the relevant Pi lifecycle events, remains inert without UI, preserves existing footer/title ownership, and now has hermetic behavioral coverage.

## Testing

The focused lifecycle test passed; the installed-Pi typecheck remained an opt-in skip because `tsc` was unavailable. Live Pi 0.84.4 testing showed the additive provider/effort status, dynamic thinking-level refresh, unchanged stock footer/title, and compatibility with Firstmate Calm, with rendered evidence captured.

<details>
<summary>Evidence: Live Pi badge, stock baseline, and thinking-level update comparison</summary>

Source: [Live Pi badge, stock baseline, and thinking-level update comparison](https://github.com/Kallas95/firstmate/blob/8c25e66abde62c60c733d33fef98869fe4a694c4/.no-mistakes/evidence/fm/srv-pi-extensions-provider-audit/pi-provider-effort-badge.html)

```text
<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Pi provider + effort badge evidence</title><style>
body{margin:0;padding:28px;background:#111827;color:#e5e7eb;font:15px ui-sans-serif,system-ui,sans-serif}h1{margin:0 0 8px;font-size:23px}p{color:#9ca3af;margin:0 0 24px}.grid{display:grid;grid-template-columns:1fr 1fr;gap:20px}figure{margin:0;min-width:0}figure.wide{grid-column:1/-1}figcaption{margin-bottom:8px;font-weight:700}.terminal{background:#071019;border:1px solid #374151;border-radius:10px;overflow:hidden;box-shadow:0 10px 24px #0008}.title{padding:8px 12px;background:#1f2937;text-align:center;color:#d1d5db}pre{margin:0;padding:14px;min-height:330px;overflow:auto;color:#e5e7eb;font:12px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace}.note{margin-top:20px;padding:12px 14px;border-left:4px solid #34d399;background:#052e2b;color:#d1fae5}.badge{color:#6ee7b7;font-weight:700}</style></head><body>
<h1>Live stock-Pi provider and thinking-effort badge</h1><p>Captured from Pi 0.84.4 in isolated 120×30 tmux terminals. No provider request was made.</p><div class="grid">
<figure><figcaption>Stock Pi (extension disabled)</figcaption><div class="terminal"><div class="title">π - 01M1HDKSNPYYRTASG810GZ1CQE</div><pre> This project is not trusted. Project .pi resources and packages are ignored. Use /trust to save a trust decision, then
 restart pi.

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf
 and restart tmux.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
~/.no-mistakes/worktrees/0e7dd249bdb3/01M1HDKSNPYYRTASG810GZ1CQE (detached)
$0.000 (sub) 0.0%/272k (auto)                                                              (openai-codex) gpt-5.4 • high</pre></div></figure>
<figure><figcaption>Stock Pi + Firstmate badge</figcaption><div class="terminal"><div class="title">π - 01M1HDKSNPYYRTASG810GZ1CQE</div><pre> This project is not trusted. Project .pi resources and packages are ignored. Use /trust to save a trust decision, then
 restart pi.

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf
 and restart tmux.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
~/.no-mistakes/worktrees/0e7dd249bdb3/01M1HDKSNPYYRTASG810GZ1CQE (detached)
$0.000 (sub) 0.0%/272k (auto)                                                              (openai-codex) gpt-5.4 • high
<span class="badge">openai-codex · high</span></pre></div></figure>
<figure class="wide"><figcaption>After the end user presses Shift+Tab</figcaption><div class="terminal"><div class="title">π - 01M1HDKSNPYYRTASG810GZ1CQE</div><pre> This project is not trusted. Project .pi resources and packages are ignored. Use /trust to save a trust decision, then
 restart pi.

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf
 and restart tmux.

 Thinking level: xhigh

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
~/.no-mistakes/worktrees/0e7dd249bdb3/01M1HDKSNPYYRTASG810GZ1CQE (detached)
$0.000 (sub) 0.0%/272k (auto)                                                             (openai-codex) gpt-5.4 • xhigh
<span class="badge">openai-codex · xhigh</span></pre></div></figure></div>
<div class="note">The stock footer and terminal title stay intact. The keyed status starts as <strong>openai-codex · high</strong>, then follows Pi's thinking control to <strong>openai-codex · xhigh</strong>. A separate live capture also loaded Firstmate Calm alongside the badge with the same result.</div></body></html>
```
</details>
<details>
<summary>Evidence: Live Pi with Firstmate Calm and provider/effort badge</summary>

Source: [Live Pi with Firstmate Calm and provider/effort badge](https://github.com/Kallas95/firstmate/blob/8c25e66abde62c60c733d33fef98869fe4a694c4/.no-mistakes/evidence/fm/srv-pi-extensions-provider-audit/pi-provider-effort-with-calm.txt)

```text
 This project is not trusted. Project .pi resources and packages are ignored. Use /trust to save a trust decision, then
 restart pi.

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf
 and restart tmux.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
~/.no-mistakes/worktrees/0e7dd249bdb3/01M1HDKSNPYYRTASG810GZ1CQE (detached)
$0.000 (sub) 0.0%/272k (auto)                                                              (openai-codex) gpt-5.4 • high
openai-codex · high
```
</details>
<details>
<summary>Evidence: Live Pi after Shift+Tab thinking-level change</summary>

Source: [Live Pi after Shift+Tab thinking-level change](https://github.com/Kallas95/firstmate/blob/8c25e66abde62c60c733d33fef98869fe4a694c4/.no-mistakes/evidence/fm/srv-pi-extensions-provider-audit/pi-provider-effort-after-thinking-cycle.txt)

```text
 This project is not trusted. Project .pi resources and packages are ignored. Use /trust to save a trust decision, then
 restart pi.

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf
 and restart tmux.

 Thinking level: xhigh

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
~/.no-mistakes/worktrees/0e7dd249bdb3/01M1HDKSNPYYRTASG810GZ1CQE (detached)
$0.000 (sub) 0.0%/272k (auto)                                                             (openai-codex) gpt-5.4 • xhigh
openai-codex · xhigh
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ecafcf81eefe7d093f7f477465b27a08e23a4480","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-model-status-badge.test.sh:21` - The focused behavior test exits successfully without exercising the extension whenever the globally installed Pi package is absent. The standard CI workflow does not provision that package, so this regression can silently receive no behavioral coverage. Make this test hermetic with a local stub/loader or ensure its dependency is explicitly available rather than treating absence as success.

🔧 Fix: Make Pi badge behavior test hermetic
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./tests/fm-model-status-badge.test.sh`
- <code>`./tests/fm-pi-primary-types.test.sh` (opt-in compatibility check skipped because `tsc` is unavailable)</code>
- <code>Launched Pi 0.84.4 in isolated tmux sessions with and without `fm-model-status-badge.ts`; compared stock footer lines and terminal titles</code>
- <code>Pressed Shift+Tab in live Pi and verified the badge updated from `openai-codex · high` to `openai-codex · xhigh`</code>
- <code>Loaded `fm-calm.ts` and `fm-model-status-badge.ts` together in live Pi and verified the stock footer, title, and badge remained intact</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
