### PR TITLE
fix(tests): scope fm-arm-pretool-check A13/E18 to the active home boundary

### DIFF
--- a/tests/fm-arm-pretool-check.test.sh
+++ b/tests/fm-arm-pretool-check.test.sh
@@ -14,6 +14,21 @@ set -u
 CHECK="$ROOT/bin/fm-arm-pretool-check.sh"
 POLICY="$ROOT/bin/fm-arm-command-policy.mjs"
 
+MATRIX_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-arm-policy-matrix.XXXXXX")
+FM_TEST_CLEANUP_DIRS+=("$MATRIX_TMP")
+trap fm_test_cleanup EXIT
+
+# The checker reads the active firstmate home from FM_HOME and falls back to its
+# own code root (docs/arm-pretool-check.md). Home is a real classification input:
+# an absolute x-mode setup path is approved only when it normalizes to the ACTIVE
+# HOME's config/x-mode.env. Pin that input to a home DISTINCT from the code root,
+# so the verdicts below are the policy's and never the ambient FM_HOME of
+# whatever fleet home happens to be running this suite, and so the two sides of
+# the home boundary can be asserted apart from each other.
+ACTIVE_HOME="$MATRIX_TMP/active-home"
+mkdir -p "$ACTIVE_HOME/config"
+export FM_HOME="$ACTIVE_HOME"
+
 # --- full cross-harness acceptance matrix ----------------------------------
 
 MATRIX_IDS=()
@@ -38,7 +53,7 @@ matrix_case A09 allow "export FM_HOME='$ROOT'; bin/fm-watch-checkpoint.sh --seco
 matrix_case A10 allow 'source config/x-mode.env; bin/fm-watch-checkpoint.sh --seconds 180'
 matrix_case A11 allow "source 'config/x-mode.env'; bin/fm-watch-checkpoint.sh --seconds 180"
 matrix_case A12 allow "source './config/x-mode.env'; bin/fm-watch-checkpoint.sh --seconds 180"
-matrix_case A13 allow "source '$ROOT/config/x-mode.env'; bin/fm-watch-checkpoint.sh --seconds 180"
+matrix_case A13 allow "source '$ACTIVE_HOME/config/x-mode.env'; bin/fm-watch-checkpoint.sh --seconds 180"
 matrix_case A14 allow "[ -f 'config/x-mode.env' ] && source 'config/x-mode.env'; exec bin/fm-watch-arm.sh"
 matrix_case A15 allow "cd $ROOT && exec bin/fm-watch-arm.sh"
 matrix_case A16 allow "export FM_HOME=$ROOT && bin/fm-watch-checkpoint.sh --seconds 180"
@@ -140,10 +155,7 @@ matrix_case E14 allow '$FM_HOME/bin/fm-teardown.sh &'
 matrix_case E15 allow '$FM_HOME/bin/fm-watch-arm.sh'
 matrix_case E16 allow '~/firstmate/bin/fm-watch-checkpoint.sh --seconds 180'
 matrix_case E17 allow 'for f in 1; do echo fm-watch; done'
-
-MATRIX_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-arm-policy-matrix.XXXXXX")
-FM_TEST_CLEANUP_DIRS+=("$MATRIX_TMP")
-trap fm_test_cleanup EXIT
+matrix_case E18 deny "source '$ROOT/config/x-mode.env'; bin/fm-watch-checkpoint.sh --seconds 180"
 
 run_matrix_entry() {
   local id=$1 expected=$2 entry=$3 cmd=$4 payload out_file err_file rc


### PR DESCRIPTION
## Intent

Fix tests/fm-arm-pretool-check.test.sh case A13 (and the matching E18 case) so they build their absolute config/x-mode.env source path from the ACTIVE fleet home resolved by FM_HOME, not from the code root. bin/fm-arm-pretool-check.sh approves an absolute watcher-command source only when it normalizes to the active home, so the test only passed when FM_HOME happened to be unset or equal to the checkout; with FM_HOME pointing anywhere else the case failed with a deny verdict. The branch is based on upstream main and is contributed from a fork; the validation pipeline is run against the fork remote with the CI step skipped, because this repository's CI runs on the upstream pull request rather than on the fork.

## What Changed
- `tests/fm-arm-pretool-check.test.sh` now creates a dedicated `FM_HOME` (`$MATRIX_TMP/active-home`, with a `config/` dir) at suite setup and exports it before the matrix runs, so the active fleet home used for validation is distinct from the checkout root (`$ROOT`).
- Case A13 now builds its absolute `config/x-mode.env` source path from the exported `$ACTIVE_HOME` instead of `$ROOT`, matching `bin/fm-arm-pretool-check.sh`'s rule that an absolute watcher-command source is approved only when it normalizes to the active home.
- Adds new case E18, which asserts the deny side of that boundary: sourcing `$ROOT/config/x-mode.env` (the code root, not the active home) is denied.
- Hoists the `MATRIX_TMP`/cleanup-trap setup earlier in the file so `$ACTIVE_HOME` is available before the matrix cases are defined.

## Risk Assessment

✅ Low: Small, well-scoped test-only change that pins FM_HOME to a controlled active-home distinct from the code root, fixes A13 to source from that home, and adds E18 to assert the code root is denied once it differs from home; verified against bin/fm-arm-pretool-check.sh and fm-arm-command-policy.mjs that context.home is used only for the x-mode.env check, so no other matrix case is affected.

## Testing

`Ran the focused tests/fm-arm-pretool-check.test.sh suite end-to-end (all matrix cases across all 5 harness entry forms plus direct policy, CLI, stdin, fail-open, and lint checks) and every case passed, including the fixed A13/E18 cases. To confirm this is a real regression fix and not a coincidentally-passing test, I manually invoked bin/fm-arm-pretool-check.sh directly with FM_HOME pointed at a directory distinct from the repo root and showed the old test's absolute-path form (rooted at $ROOT) is denied by the policy while the new form (rooted at the active FM_HOME) is allowed — matching exactly the behavior described in the user intent.</testing_summary>`

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d9f7ef36c7dda6ffa6fa00ea9cfafaa3d8afbcce","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"skipped"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-arm-pretool-check.test.sh (full targeted suite; matrix cases A13 and E18 both pass across codex/claude/grok/opencode/pi entry forms)`
- <code>Manual reproduction: piped Claude-schema JSON for `source $ROOT/config/x-mode.env; bin/fm-watch-checkpoint.sh --seconds 180` into bin/fm-arm-pretool-check.sh with FM_HOME set to a directory distinct from ROOT — confirmed deny (exit 2, [watcher-bundled]), reproducing the pre-fix failure mode</code>
- `Manual verification: same command form but sourcing $FM_HOME/config/x-mode.env instead of $ROOT/config/x-mode.env — confirmed allow (exit 0), matching the fixed test's expectation`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
