### PR TITLE
test(tests): build renamed muse fixtures via symlink instead of binary copy

### DIFF
--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -64,6 +64,51 @@ write_session_log() {
   printf '%s\n' "$path"
 }
 
+# --- real renamed processes -------------------------------------------------
+
+# The detection cases need a REAL running process carrying the name under
+# test, because bin/fm-harness.sh reads `ps -o comm=` off the live parent
+# chain. A copy of the system bash supplied that until macOS stopped executing
+# one: a copy of an Apple platform binary keeps Apple's signature at a
+# non-system path, the exec is refused, and the process is SIGKILLed before it
+# runs (verified macOS 26.5.1, arm64: `cp /bin/bash x; x -c 'echo ran'` exits
+# 137, while the same copy re-signed ad hoc with `codesign -f -s -` runs).
+#
+# A symlink execs the real interpreter while the kernel takes the process name
+# from the path used to launch it, so it presents exactly the name under test:
+# macOS reports the symlink path from `ps -o comm=`, and Linux reports its
+# basename in /proc/<pid>/comm, truncated to the kernel's 15-byte limit exactly
+# as a copy was. Ad-hoc re-signing was rejected as the repair because it would
+# make a portable test depend on a macOS-only signing toolchain.
+named_executable() {  # <dir> <name>
+  ln -sf "$(command -v bash)" "$1/$2"
+}
+
+# The command substitution around the probe is load-bearing for the same
+# reason it is in test_detects_versioned_process_ancestor below.
+presented_process_name() {  # <executable> -> basename of the name its process presents
+  local out
+  # The probe must stay single-quoted: $$ has to expand in the launched shell,
+  # not in this one.
+  # shellcheck disable=SC2016
+  out=$("$1" -c 'r=$(ps -o comm= -p $$); printf "%s" "$r"' 2>/dev/null) || return 1
+  basename -- "$out"
+}
+
+# Guard against a silently vacuous case: if the construction above ever stops
+# naming the process, a negative assertion would pass while checking nothing.
+# Linux truncates the name to 15 bytes, so a prefix is the honest match.
+assert_process_presents_name() {  # <executable> <intended-name>
+  local observed
+  observed=$(presented_process_name "$1") \
+    || fail "could not launch the renamed executable '$2' to read its process name"
+  [ -n "$observed" ] || fail "renamed executable '$2' presented an empty process name"
+  case "$2" in
+    "$observed"*) ;;
+    *) fail "renamed executable '$2' presented process name '$observed'; the construction no longer names the process, so every case built on it is vacuous" ;;
+  esac
+}
+
 # --- spawn scaffolding ------------------------------------------------------
 
 make_spawn_fakebin() {
@@ -104,7 +149,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  cp "$(command -v bash)" "$fakebin/muse-bin-test-version"
+  named_executable "$fakebin" muse-bin-test-version
   cat > "$fakebin/muse" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -174,7 +219,8 @@ test_detects_versioned_process_ancestor() {
   dir="$TMP_ROOT/detect"
   mkdir -p "$dir"
   for bin in muse-bin-0.1.0-R708.1 muse-bin-9.9.9-RZZZ.9 muse; do
-    cp "$(command -v bash)" "$dir/$bin"
+    named_executable "$dir" "$bin"
+    assert_process_presents_name "$dir/$bin" "$bin"
     out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
       -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
       "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
@@ -190,7 +236,8 @@ test_detection_is_anchored() {
   dir="$TMP_ROOT/detect-neg"
   mkdir -p "$dir"
   for bin in musescore amuse notmuse-bin muse-binary muse-bind; do
-    cp "$(command -v bash)" "$dir/$bin"
+    named_executable "$dir" "$bin"
+    assert_process_presents_name "$dir/$bin" "$bin"
     out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
       -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
       "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")


### PR DESCRIPTION
## Intent

Fix tests/fm-muse-harness.test.sh so its renamed-process detection fixtures work on current macOS. The fixtures built a fake muse-bin-<version> process by copying the system bash; on current macOS a copy of an Apple platform binary keeps the code signature bound to its original path, so the exec is refused and the process is SIGKILLed (exit 137) before it runs, and fm-harness.sh then reported an empty harness instead of muse. Build the renamed process without copying a signed system binary so the fixture runs on macOS and stays equivalent on Linux. The branch is based on upstream main and is contributed from a fork; the validation pipeline was run against the fork remote with the CI step skipped, because this repository's CI runs on the upstream pull request rather than on the fork.

Note for maintainers: docs/fm-test-isolation-proof.md records tests/fm-muse-harness.test.sh as a known failure under stock macOS Bash 3.2.57, dated 2026-08-28. That note may now be obsolete, since it plausibly shares this root cause, but it is frozen dated evidence that would need the isolation-proof harness re-run to re-measure, so it is deliberately left untouched here.

## What Changed

- Added a `named_executable` helper that symlinks to the system `bash` rather than copying it, so renamed-process test fixtures no longer carry an Apple code signature bound to the original path (a copy is SIGKILLed with exit 137 on current macOS before it can run).
- Added `presented_process_name` and `assert_process_presents_name` helpers that read back the process name each renamed executable presents via `ps -o comm=`, guarding against the test silently passing without actually exercising the renamed-process detection path.
- Updated `make_spawn_fakebin`, `test_detects_versioned_process_ancestor`, and `test_detection_is_anchored` to build their `muse-bin-*` and negative-case fixtures with `named_executable`, adding presentation assertions to the two test functions.

## Risk Assessment

✅ Low: Single-file, test-only change that replaces a signed-binary copy with a symlink to fix the documented macOS SIGKILL/exit-137 fixture failure; I empirically verified on this macOS host that `ps -o comm=` reports the symlink's invocation path (not the SIGKILL'd copy behavior) and that `basename` correctly recovers the intended process name for both short and 21-char (Linux-truncation-length) names, and confirmed no other `cp`-of-signed-binary instances remain in this file or need parallel fixing (sibling test files already used `ln -s`/`ln -sf`). The added `assert_process_presents_name` guard is a genuine behavioral check (execs the real interpreter and reads its live process name) rather than a source-content assertion, and correctly handles Linux's 15-byte comm truncation via prefix matching.

## Testing

Reproduced the pre-fix failure (copied signed bash gets SIGKILLed on exec, exit 137, harness reports empty instead of muse) against the base commit, then ran the full fm-muse-harness.test.sh suite against the target commit where all 25 tests pass, confirming the symlink-based renamed-process fixture (`named_executable`) fixes the macOS regression while the added `assert_process_presents_name` guard exercises the same code path on Linux equivalence. This is a CLI-only shell test suite with no rendered UI surface, so a test-transcript CLI artifact is the appropriate evidence rather than a screenshot.

<details>
<summary>Evidence: Target commit: full fm-muse-harness.test.sh run (25/25 pass)</summary>

```text
ok - muse is detected through any versioned muse-bin ancestor
ok - muse detection does not claim unrelated muse-containing commands
... (23 more ok lines) ...
ok - muse trusts no busy record source
EXIT_CODE=0
```
</details>
<details>
<summary>Evidence: Base commit: reproduced pre-fix failure matching reported symptom</summary>

```text
not ok - fm-harness.sh under process 'muse-bin-0.1.0-R708.1' reported '', expected muse
```
</details>
<details>
<summary>Evidence: Root-cause repro: copying signed system bash gets SIGKILLed on macOS</summary>

```text
cp "$(command -v bash)" x; x -c 'echo ran' -> exit=137 (codesign shows Identifier=com.apple.bash bound to original path)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6839b2035ace8a689ddb7e6ce91c318aa7b19dce","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"skipped"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-muse-harness.test.sh` on target commit 6839b20 — all 25 tests pass (`ok`), including `test_detects_versioned_process_ancestor` and `test_detection_is_anchored`</code>
- <code>Manual repro: `cp $(command -v bash) x; x -c &#39;echo ran&#39;` on macOS arm64 26.5.1 exits 137, confirming the code-signature/SIGKILL root cause described in the intent</code>
- <code>`git archive` export of base commit 77ee3c8 + `bash tests/fm-muse-harness.test.sh` — fails with `not ok - fm-harness.sh under process &#39;muse-bin-0.1.0-R708.1&#39; reported &#39;&#39;, expected muse`, matching the exact regression symptom described in the user intent</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/fm-test-isolation-proof.md:127` - docs/fm-test-isolation-proof.md:127 records tests/fm-muse-harness.test.sh as a known failure alongside tests/fm-composer-lib.test.sh under stock macOS Bash 3.2.57 (dated 2026-08-28 admission evidence for the pure-contract-unit scheduler pool). That failure plausibly shares this exact root cause (copying the Apple-signed system bash triggers exec refusal/SIGKILL), so it may no longer reproduce after this fix. It&#39;s frozen dated verification evidence for an unrelated admission decision, not a living contract, and confirming/re-dating it would require rerunning the isolation-proof harness, which is outside this doc-only phase&#39;s scope. Flagging as a follow-up: maintainers may want to rerun bin/fm-test-isolation-proof.sh and annotate or retire that line if the failure no longer reproduces.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

