### PR TITLE
fix(bin): scrub inherited fleet-home overrides in the serial test lane

### DIFF
--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -2002,6 +2002,23 @@ record_script_result() {
   TOTAL=$((TOTAL + 1))
 }
 
+# The fleet-home overrides a test script must never inherit from whoever
+# invoked the runner. A test builds its own home; an inherited one is a
+# second, invisible input that can decide a verdict - bin/fm-arm-pretool-
+# check.sh, for one, reads FM_HOME as a classification input. The serial
+# lane below and the parallel worker subshell further down both scrub this
+# same list so a script's verdict cannot depend on the lane it was
+# scheduled into.
+FM_TEST_INHERITED_OVERRIDES=(
+  FM_HOME
+  FM_STATE_OVERRIDE
+  FM_DATA_OVERRIDE
+  FM_ROOT_OVERRIDE
+  FM_PROJECTS_OVERRIDE
+  FM_CONFIG_OVERRIDE
+  FM_BACKEND
+)
+
 # Run <script>, capturing output to <out>. <stream> 1 also echoes it live.
 # <id> only has to be unique within this run. When PER_SCRIPT_TIMEOUT_SECS is
 # positive, a script that outruns it is terminated and reported as exit 124: a
@@ -2009,18 +2026,25 @@ record_script_result() {
 # because an unbounded suite is what silently outruns its caller's budget.
 run_script_bounded() {  # <script> <out> <stream> <id>
   local script=$1 out=$2 stream=$3 id=$4
-  local rc
+  local rc name
+  local -a scrub=()
   : "$id"
   set +e
   if [ "$stream" -eq 1 ]; then
+    # The serial lane runs the script from this shell, so the scrub is an
+    # env -u prefix on the child rather than the parallel worker subshell's
+    # unset of its own environment.
+    for name in "${FM_TEST_INHERITED_OVERRIDES[@]}"; do
+      scrub+=(-u "$name")
+    done
     if [ "$PER_SCRIPT_TIMEOUT_SECS" -gt 0 ]; then
       # Expansion is intentionally deferred to the child bash passed to -c.
       # shellcheck disable=SC2016
-      fm_run_timed "$PER_SCRIPT_TIMEOUT_SECS" bash -c \
+      fm_run_timed "$PER_SCRIPT_TIMEOUT_SECS" env "${scrub[@]}" bash -c \
         'bash "$1" 2>&1 | tee "$2"; exit "${PIPESTATUS[0]}"' _ "$script" "$out"
       rc=$?
     else
-      bash "$script" 2>&1 | tee "$out"
+      env "${scrub[@]}" bash "$script" 2>&1 | tee "$out"
       rc=${PIPESTATUS[0]}
     fi
   elif [ "$PER_SCRIPT_TIMEOUT_SECS" -gt 0 ]; then
@@ -2154,8 +2178,7 @@ else
       set +e
       export TMPDIR="$work/tmp"
       export TMP="$work/tmp"
-      unset FM_HOME FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_ROOT_OVERRIDE \
-        FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND 2>/dev/null || true
+      unset "${FM_TEST_INHERITED_OVERRIDES[@]}" 2>/dev/null || true
       cd "$ROOT" || exit 1
       begin_ms=$(now_ms)
       set +e

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1118,6 +1118,91 @@ SH
   pass "jobs scheduler runs proven scripts; failure propagates; non-proven refused"
 }
 
+# A test script builds its own fleet home, so an FM_HOME (or any other
+# override) inherited from whoever invoked the runner is a second, invisible
+# input that can decide a verdict - bin/fm-arm-pretool-check.sh reads FM_HOME
+# as a classification input. The parallel worker subshell has always scrubbed
+# those; this pins that the serial path scrubs the identical list, so a
+# script cannot pass in one lane and fail in the other. The passthrough
+# marker proves the scrub is targeted and not a blanket wipe of the
+# environment a test still needs.
+test_fleet_home_overrides_are_scrubbed_in_both_lanes() {
+  local tmp repo runner evidence fake_bin a b rc lane name seen
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-scrub.XXXXXX")
+  repo="$tmp/repo"
+  runner="$repo/bin/fm-test-run.sh"
+  evidence="$tmp/evidence"
+  fake_bin="$tmp/fake-bin"
+  a=tests/fm-brief.test.sh
+  b=tests/fm-composer-lib.test.sh
+  mkdir -p "$repo/bin" "$repo/tests" "$evidence" "$fake_bin"
+  cp "$RUNNER" "$runner"
+  cat >"$fake_bin/stat" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = "-c" ] && [ "$2" = "%a" ]; then
+  printf '700\n'
+  exit 0
+fi
+if [ "$1" = "-f" ] && [ "$2" = "%Lp" ]; then
+  printf '  File: "%s"\n    ID: fake Namelen: 255 Type: ext2/ext3\n700\n' "$3"
+  exit 0
+fi
+exit 1
+SH
+  cat >"$repo/$a" <<'SH'
+#!/usr/bin/env bash
+out="$SCRUB_EVIDENCE/$SCRUB_LANE"
+: >"$out"
+for name in FM_HOME FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_ROOT_OVERRIDE \
+  FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND; do
+  eval "value=\${$name:-absent}"
+  printf '%s=%s\n' "$name" "$value" >>"$out"
+done
+printf 'PASSTHROUGH=%s\n' "${SCRUB_PASSTHROUGH:-absent}" >>"$out"
+echo "ok - scrub fixture"
+SH
+  cat >"$repo/$b" <<'SH'
+#!/usr/bin/env bash
+echo "ok - filler fixture"
+SH
+  chmod +x "$runner" "$repo/$a" "$repo/$b" "$fake_bin/stat"
+
+  set +e
+  env FM_HOME="$tmp/leaked-home" FM_STATE_OVERRIDE="$tmp/leaked-state" \
+    FM_DATA_OVERRIDE="$tmp/leaked-data" FM_ROOT_OVERRIDE="$tmp/leaked-root" \
+    FM_PROJECTS_OVERRIDE="$tmp/leaked-projects" FM_CONFIG_OVERRIDE="$tmp/leaked-config" \
+    FM_BACKEND=leaked-backend SCRUB_EVIDENCE="$evidence" SCRUB_LANE=serial \
+    SCRUB_PASSTHROUGH=kept "$runner" "$a" >"$tmp/out-serial" 2>"$tmp/err-serial"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || { cat "$tmp/out-serial" "$tmp/err-serial"; rm -rf "$tmp"; fail "serial scrub fixture run failed"; }
+
+  set +e
+  env FM_HOME="$tmp/leaked-home" FM_STATE_OVERRIDE="$tmp/leaked-state" \
+    FM_DATA_OVERRIDE="$tmp/leaked-data" FM_ROOT_OVERRIDE="$tmp/leaked-root" \
+    FM_PROJECTS_OVERRIDE="$tmp/leaked-projects" FM_CONFIG_OVERRIDE="$tmp/leaked-config" \
+    FM_BACKEND=leaked-backend SCRUB_EVIDENCE="$evidence" SCRUB_LANE=parallel \
+    SCRUB_PASSTHROUGH=kept PATH="$fake_bin:$PATH" \
+    "$runner" --jobs 2 "$a" "$b" >"$tmp/out-parallel" 2>"$tmp/err-parallel"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || { cat "$tmp/out-parallel" "$tmp/err-parallel"; rm -rf "$tmp"; fail "parallel scrub fixture run failed"; }
+
+  for lane in serial parallel; do
+    seen="$evidence/$lane"
+    [ -s "$seen" ] || { rm -rf "$tmp"; fail "$lane lane produced no scrub evidence"; }
+    for name in FM_HOME FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_ROOT_OVERRIDE \
+      FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND; do
+      grep -qx "$name=absent" "$seen" \
+        || { rm -rf "$tmp"; fail "$lane lane leaked $name into the test script: $(grep "^$name=" "$seen")"; }
+    done
+    grep -qx 'PASSTHROUGH=kept' "$seen" \
+      || { rm -rf "$tmp"; fail "$lane lane wiped an unrelated variable the test still needs"; }
+  done
+  rm -rf "$tmp"
+  pass "both lanes scrub the same inherited fleet-home overrides and keep the rest of the environment"
+}
+
 test_herdr_ci_family_run_has_a_step_timeout() {
   # The required Herdr lane's hang tripwire is the family-run *step* bound, not
   # the 75-minute job cap. Parse the workflow as YAML so nested `with.name`
@@ -1218,5 +1303,6 @@ test_concurrent_runs_are_ordered_longest_first
 test_per_script_timeout_bounds_a_hang
 test_max_wall_ms_is_a_result_not_advice
 test_jobs_parallel_scheduler_and_failure_propagation
+test_fleet_home_overrides_are_scrubbed_in_both_lanes
 test_herdr_ci_family_run_has_a_step_timeout
 test_aggregate_json


### PR DESCRIPTION
## Intent

Make bin/fm-test-run.sh scrub the same inherited fleet-home overrides (FM_HOME, FM_STATE_OVERRIDE, FM_DATA_OVERRIDE, FM_ROOT_OVERRIDE, FM_PROJECTS_OVERRIDE, FM_CONFIG_OVERRIDE, FM_BACKEND) in the serial lane that the parallel worker subshell already scrubbed. A test script builds its own fleet home, so an inherited one is a second invisible input that can decide a verdict - bin/fm-arm-pretool-check.sh reads FM_HOME as a classification input - which meant a script's result could depend on which lane it was scheduled into. Define the list once and apply it to both lanes: an env -u prefix on the serial branch's child process, and the same list in the parallel worker's existing unset. Add a regression test that runs a fixture script in both lanes under leaked overrides and asserts neither lane lets one through while an unrelated variable still passes. The branch is based on upstream main and is contributed from a fork; this is a hand adaptation of the fix onto upstream's restructured runner rather than a cherry-pick, because upstream now routes both lanes through a shared run_script_bounded helper. The validation pipeline was run against the fork remote with the CI step skipped, because this repository's CI runs on the upstream pull request rather than on the fork.

Note on the earlier CI result for this pull request: the `Behavior portable serial 1` shard did not fail an assertion, it hung and was stopped by the job's 20-minute cap. The last output was a shell error from `bin/fm-wake-lib.sh` (`trap: line 2: unexpected EOF while looking for matching ')'`) inside `tests/fm-watch-triage.test.sh`, followed by 18 minutes of silence, which points at the signal defer/restore path in `fm-wake-lib.sh` rather than at this change. That suite passes locally on this branch (90 assertions, 0 failures), the full `portable-serial-1of5` lane was run locally on this branch with only two failures that reproduce identically on the unmodified base commit, and the same lane passed on three sibling pull requests from the same base. None of the scrubbed variables are set in this repository's CI environment, so the scrub is a no-op there and cannot change what that shard does. Re-running that shard would confirm it, but re-running workflows needs write access this contributor does not have.

## What Changed

- `bin/fm-test-run.sh`: introduces a single `FM_TEST_INHERITED_OVERRIDES` list (`FM_HOME`, `FM_STATE_OVERRIDE`, `FM_DATA_OVERRIDE`, `FM_ROOT_OVERRIDE`, `FM_PROJECTS_OVERRIDE`, `FM_CONFIG_OVERRIDE`, `FM_BACKEND`) and applies it in both execution lanes of `run_script_bounded`: the serial lane now runs each script's child `bash` (both the timed and untimed branches) through an `env -u` prefix built from that list, while the parallel worker subshell's existing `unset` is rewritten to reference the same shared array instead of its own hardcoded list.
- `tests/fm-test-run.test.sh`: adds `test_fleet_home_overrides_are_scrubbed_in_both_lanes`, which runs a fixture script through both the serial and `--jobs`-parallel lanes with all seven overrides leaked into the runner's environment plus one unrelated passthrough variable, then asserts every override reads as absent in both lanes while the unrelated variable still comes through; the new test is registered in the suite's test list.

## Risk Assessment

✅ Low: The change is a small, symmetric, well-tested fix: it centralizes an existing 7-variable scrub list and applies it identically to the serial lane (via env -u on the child process) and the pre-existing parallel lane (via unset), with a regression test that executes the real runner in both lanes under leaked overrides and confirms an unrelated variable still passes through; all call sites of run_script_bounded were traced and are covered.

## Testing

Ran the targeted contract-test file for bin/fm-test-run.sh (27/27 passing) and additionally isolated the new regression test to run it against both the pre-fix and post-fix runner binaries: it fails on the base commit (reproducing the reported serial-lane FM_HOME leak) and passes on the target commit, giving direct evidence the fix closes the lane-dependent verdict gap described in the intent.

<details>
<summary>Evidence: Fleet-home scrub regression: pre-fix failure vs post-fix pass, plus full contract-suite run</summary>

Source: [Fleet-home scrub regression: pre-fix failure vs post-fix pass, plus full contract-suite run](https://github.com/zeeshaanahmad/firstmate/blob/167a93248edef579623fadc519e86992b3dc42a6/.no-mistakes/evidence/up-test-run-serial-scrub-fleet-home/fleet-home-scrub-regression.txt)

```text
# Regression evidence: fleet-home override scrubbing, serial vs parallel lane
# bin/fm-test-run.sh / tests/fm-test-run.test.sh
#
# The new test `test_fleet_home_overrides_are_scrubbed_in_both_lanes` launches
# a fixture test script through both the serial lane and the `--jobs 2`
# parallel lane of bin/fm-test-run.sh, with FM_HOME/FM_STATE_OVERRIDE/
# FM_DATA_OVERRIDE/FM_ROOT_OVERRIDE/FM_PROJECTS_OVERRIDE/FM_CONFIG_OVERRIDE/
# FM_BACKEND leaked into the runner's own environment, plus one unrelated
# passthrough variable that must survive the scrub.

## Run against the pre-fix runner (base commit 77ee3c82, before the change)
$ bash /tmp/run-single-test-prefix.sh
not ok - serial lane leaked FM_HOME into the test script:
EXIT=1
# -> Confirms the bug: before the fix, the serial lane let the invoking
#    shell's FM_HOME leak into the test script's environment, while the
#    parallel worker subshell already scrubbed it. Same script, different
#    verdict depending on which lane it ran in.

## Run against the fixed runner (target commit 1c5cee7)
$ bash /tmp/run-single-test.sh
ok - both lanes scrub the same inherited fleet-home overrides and keep the rest of the environment
EXIT=0

## Full contract-test file (tests/fm-test-run.test.sh), fixed runner, 27/27 passing
$ bash tests/fm-test-run.test.sh
ok - exact suite coverage: --all lists every tests/*.test.sh once
ok - family selection returns a proper subset of the suite
ok - single-script selection lists exactly that path
ok - changed-file selection stays conservative (never silent full suite)
ok - runner and its documentation surfaces select their curated family, not just their contract owners
ok - changed selection covers dependents and fails closed for unmapped source
ok - a bin reference selects the referencing scripts, and consumers still select their curated families
ok - changed defaults to bounded automatic scheduling with serial override
ok - empty changed selection emits deterministic text and JSON summaries
ok - timing markers and JSON artifact are valid
ok - aggregate exit reflects any script failure
ok - gate-skip accounting is honest and non-failing
ok - fail-on-gate-skip converts herdr-not-found into a hard failure
ok - exclude-family drops the named primary family after selection
ok - portable shard union, disjointness, and coverage guard hold
ok - portable serial shards are a deterministic disjoint cover of the serial lane
ok - coverage guard reports and bounds the unmeasured portable serial share
ok - portable serial shard lanes refuse mismatched, out-of-range, and countless names
ok - --jobs refuses non-proven / stateful selections
ok - --jobs admits and schedules a family with a recorded concurrent proof
ok - a concurrent run starts the longest-hint script first
ok - --per-script-timeout-secs turns a hung script into a bounded failure
ok - --max-wall-ms fails an over-budget run and refuses a malformed budget
ok - jobs scheduler runs proven scripts; failure propagates; non-proven refused
ok - both lanes scrub the same inherited fleet-home overrides and keep the rest of the environment
ok - Herdr CI family-run step times out at 20 min under a 75 min job backstop
ok - aggregate-json merges lane timing artifacts
[exited with code 0]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1c5cee79edf02555cfcc5abb5c8c2437ccb0b7b3","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"skipped"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Extracted and ran the new `test_fleet_home_overrides_are_scrubbed_in_both_lanes` in isolation against the pre-fix runner (base commit 77ee3c82) — it fails as expected: `not ok - serial lane leaked FM_HOME into the test script`</code>
- <code>Same isolated test against the fixed runner (target commit 1c5cee7) — passes: `ok - both lanes scrub the same inherited fleet-home overrides and keep the rest of the environment`</code>
- <code>Full `bash tests/fm-test-run.test.sh` (27 tests, the runner&#39;s complete contract suite) against the fixed worktree — all 27 pass, including the new regression test, with no other lane/scheduler behavior regressed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

