### PR TITLE
fix(bin): keep --no-projects remote seeding working on stock macOS bash

### DIFF
--- a/bin/fm-remote-home-seed.sh
+++ b/bin/fm-remote-home-seed.sh
@@ -157,7 +157,11 @@ done < "$BRIEF" > "$TMP/charter.remote"
 PROJECTS_CSV=
 : > "$TMP/project.records"
 PROJECT_INDEX=0
-for project in "${PROJECT_NAMES[@]}"; do
+# --no-projects leaves PROJECT_NAMES empty, and bash 3.2 - macOS's stock shell,
+# which `env bash` still resolves to on a Mac - treats "${ARR[@]}" of an empty
+# array as an unbound variable under set -u. Expand through the guarded form so
+# the loop is skipped instead of aborting the seed.
+for project in ${PROJECT_NAMES[@]+"${PROJECT_NAMES[@]}"}; do
   ORIGIN=${PROJECT_ORIGINS[$PROJECT_INDEX]}
   PROJECT_INDEX=$((PROJECT_INDEX + 1))
   MODE_LINE=$(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" "$SCRIPT_DIR/fm-project-mode.sh" "$project")


### PR DESCRIPTION
## Intent

Fix bin/fm-remote-home-seed.sh so --no-projects works on stock macOS bash 3.2. The project loop expands "${PROJECT_NAMES[@]}" unguarded; --no-projects leaves that array empty, and bash 3.2 treats an empty array's [@] expansion as an unbound variable under set -u, so the seed aborts with 'PROJECT_NAMES[@]: unbound variable' and the remote secondmate spawn fails. Guard the expansion so an empty project list is a valid no-op on bash 3.2 as well as on newer bash. The branch is based on upstream main and is contributed from a fork; the validation pipeline was run against the fork remote with the CI step skipped, because this repository's CI runs on the upstream pull request rather than on the fork.

## What Changed

- In `bin/fm-remote-home-seed.sh`, guard the `"${PROJECT_NAMES[@]}"` expansion in the project loop with the `${PROJECT_NAMES[@]+"${PROJECT_NAMES[@]}"}` idiom so an empty `PROJECT_NAMES` array (produced when `--no-projects` is passed) is a valid no-op instead of triggering an unbound-variable error.
- Adds a comment explaining that bash 3.2 (macOS's stock shell, which `env bash` resolves to on a Mac) treats `"${ARR[@]}"` on an empty array as unbound under `set -u`, unlike newer bash versions.

## Risk Assessment

✅ Low: Single-file, 5-line change applying the standard bash 3.2-safe empty-array guard exactly where the described unbound-variable failure occurs; verified against real bash 3.2 that the fix resolves the failure, preserves element quoting, and that the one other unguarded PROJECT_NAMES[@] use is unreachable when the array is empty.

## Testing

Reproduced the exact reported bash 3.2 failure in isolation (unguarded `"${PROJECT_NAMES[@]}"` on an empty array aborts with 'unbound variable' under set -u; the fixed guarded expansion `${PROJECT_NAMES[@]+"${PROJECT_NAMES[@]}"}` completes cleanly), then confirmed the fix end-to-end by running the existing tests/fm-remote-secondmate-trace-context.test.sh under this machine's actual stock bash 3.2.57 (both `bash` and `/bin/bash` resolve to it here), which invokes fm-remote-home-seed.sh with --no-projects twice and drives the full remote secondmate spawn afterward — all assertions passed. An initial run appeared to hang/time out at the 3-minute mark, but this was CPU contention from a concurrent shellcheck lint phase in the same outer pipeline (confirmed via `ps`), not a fix regression; a clean re-run after that contention cleared finished in ~2:39 with all tests passing. No source or test changes were needed; worktree is clean with no transient artifacts left behind.

<details>
<summary>Evidence: Isolated bash 3.2 before/after reproduction</summary>

```text
Pre-fix pattern for project in "${PROJECT_NAMES[@]}" on an empty array under set -eu (bash 3.2.57):
/bin/bash: line 5: PROJECT_NAMES[@]: unbound variable (exit=1)

Post-fix pattern for project in ${PROJECT_NAMES[@]+"${PROJECT_NAMES[@]}"} on an empty array under set -eu (bash 3.2.57):
no-op reached (expected with the fixed guarded expansion) (exit=0)
```
</details>
<details>
<summary>Evidence: tests/fm-remote-secondmate-trace-context.test.sh full run under bash 3.2.57</summary>

```text
ok - disabled: a remote-routed second mate records and receives no carrier and stays enabled-off end to end
ok - enabled: a remote-routed second mate receives one carrier in its pane, identical to the parent's recorded identity, before launch
ok - relaunch: a remote-routed second mate keeps one stable identity across restarts
ok - boundary: each remote-routed second mate roots its own trace and never adopts the spawning environment's carrier
ok - allowlist: the remote receiver accepts exactly the declared inherited-material set, including the enablement flag
ok - delivery: a parent-supplied carrier is accepted only for a secondmate launch and only as a strict W3C value
ALL TESTS PASSED
EXIT:0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e9e8e3c463928b09ce7ddffe742427a503d9d6ff","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"skipped"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Isolated bash 3.2.57 repro: pre-fix `for project in &#34;${PROJECT_NAMES[@]}&#34;` on an empty array under `set -eu` fails with `PROJECT_NAMES[@]: unbound variable`; post-fix `for project in ${PROJECT_NAMES[@]+&#34;${PROJECT_NAMES[@]}&#34;}` completes as a no-op (exit 0)</code>
- <code>`/bin/bash tests/fm-remote-secondmate-trace-context.test.sh` (this environment&#39;s default `bash` and `/bin/bash` are both stock macOS bash 3.2.57) — exercises `bin/fm-remote-home-seed.sh ... --no-projects` twice end-to-end (real script, `set -eu`) followed by real `fm-spawn.sh --secondmate` remote spawns; all 6 assertions passed, `ALL TESTS PASSED`, exit 0</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

