### PR TITLE
fix(watch): skip empty rearm-resurface wakes and stop wedge-nagging a done: worker's idle pane

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -126,6 +126,17 @@ status_is_terminal_verb() {
   esac
 }
 
+# 0 if the given (last) status line's leading verb is the terminal done verb.
+# A crew that reported done and then idles is waiting on merge authority, which
+# the PR poll owns, so the watcher's stale path gives that idle pane the declared
+# pause cadence instead of a wedge escalation (fm-watch.sh owns the idle-only
+# scope). The other terminal verbs keep their immediate surface.
+status_is_done() {  # <status-line>
+  local line=$1
+  [ -n "$line" ] || return 1
+  [ "$(status_line_verb "$line")" = 'done' ]
+}
+
 # 0 if the given (last) status line matches a captain-relevant verb.
 # Verb-aware by default: terminal verbs always match; nonterminal progress verbs
 # (working, resolved, captain-held) and paused never match from free-text prose;

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -426,6 +426,10 @@ if [ "$mode" = restart ]; then
         echo "watcher: FAILED - stale watcher recovery state could not be persisted" >&2
         exit 1
       fi
+      # The fresh child inherits this so its recovery wake is delivered even to
+      # an empty drain, exactly as when the watcher reclaims a dead-pid lock
+      # itself (bin/fm-watch.sh, WATCHER_LOCK_RECOVERED).
+      export FM_WATCH_LOCK_RECLAIMED=1
     fi
   fi
 fi

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -24,8 +24,14 @@
 #                          external-wait pause or verified captain-held transfer is
 #                          absorbed instead with its own long re-surface cadence,
 #                          never as a wedge, and that recheck reason names which
-#                          human the wait is on. Only when neither absorb class
-#                          applies does the log's last line decide:
+#                          human the wait is on. A crew whose last status event
+#                          is a terminal done: and whose pane is IDLE takes that
+#                          same declared-pause cadence (the merge wait belongs to
+#                          the PR poll), except that a new hash still lets an
+#                          active run-step override the log exactly as below;
+#                          a done: crew whose pane is busy again, and every other
+#                          terminal verb, keep the ordinary paths. Only when no
+#                          absorb class applies does the log's last line decide:
 #                          terminal (captain-relevant) or non-terminal (no verb),
 #                          both surfaced at once. A provably-working stale past the
 #                          wedge threshold also surfaces, with an "escalation N"
@@ -800,8 +806,9 @@ busy_turn_over_age() {  # <task>
   [ "$(age_of "$f")" -ge "$BUSY_TURN_MAX_SECS" ]
 }
 
-# Absorb a stale pane under a declared external-wait pause (paused:) or a
-# dead-agent captain-held transfer, and re-surface it once every
+# Absorb a stale pane under a declared external-wait pause (paused:), a
+# dead-agent captain-held transfer, or a finished crew's idle wait for merge
+# authority (done:), and re-surface it once every
 # PAUSE_RESURFACE_SECS for a recheck so it cannot rot invisibly. Called on any
 # stale poll once pause_state_class permits the bounded cadence, so it must be
 # cheap: it NEVER re-reads crew state. The re-surface age is anchored on the
@@ -830,6 +837,9 @@ handle_paused_stale() {  # <window> <task> <hash>
   if status_is_captain_held "$(last_status_line "$statusf")"; then
     detail="captain-held, awaiting the captain"
     reason="captain-held ${age}s, awaiting the captain - verified hold transfer, rechecked on a long cadence not a wedge; answer the held decision or release the hold"
+  elif status_is_done "$(last_status_line "$statusf")"; then
+    detail="done, awaiting merge authority"
+    reason="done ${age}s, awaiting merge authority - finished worker idle on its reported result, rechecked on a long cadence not a wedge; the PR poll owns the merge outcome"
   else
     detail="paused, awaiting external"
     reason="paused ${age}s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds"
@@ -1796,7 +1806,10 @@ EOF
     [ -z "$task" ] || inbox_steer_check "$w" "$task"
     key=$(window_key "$w")
     last=$(last_status_line "$STATE/$task.status")
-    if ! status_is_paused_or_captain_held "$last" && [ -e "$STATE/.paused-$key" ]; then
+    # A done: crew's idle wait rides the same pause bookkeeping (below), so its
+    # markers survive this reset too; the busy branch still clears them.
+    if ! status_is_paused_or_captain_held "$last" && ! status_is_done "$last" \
+      && [ -e "$STATE/.paused-$key" ]; then
       clear_pause_tracking "$key"
     fi
     # An idle secondmate endpoint is healthy by design, so a mate is admitted to
@@ -1841,6 +1854,32 @@ EOF
             fm_wake_append stale "$w" "stale: $w" || exit 1
             printf '%s' "$h" > "$sf"
             wake "stale: $w"
+          fi
+        elif status_is_done "$last"; then
+          # A finished crew waiting on merge authority. Its done: event already
+          # woke firstmate through the signal path and the PR poll owns the
+          # merge outcome, so an idle pane here is expected, not a wedge: give
+          # it the declared-pause cadence, so a TUI that re-renders its idle
+          # footer cannot re-surface the same finished worker once per new
+          # hash. The one exception mirrors the terminal path below: on a NEW
+          # hash an actively running run-step (a validation firstmate started
+          # after the done: line) still outranks the log and keeps the wedge
+          # timer, because a frozen pipeline must still escalate. A busy pane
+          # never reaches this branch.
+          if [ "$(cat "$sf" 2>/dev/null || true)" != "$h" ]; then
+            if crew_is_provably_working "$task"; then
+              clear_pause_state "$key"
+              printf '%s' "$h" > "$sf"
+              date +%s > "$ssf"
+              clear_write_tracking "$key"
+              triage_log "absorbed stale (provably working, overriding a done status): $w"
+            else
+              handle_paused_stale "$w" "$task" "$h"
+            fi
+          elif [ -e "$ssf" ]; then
+            wedge_timer_check "$w" "$ssf" "stale (overridden done status)" "$ewf" "$task"
+          else
+            handle_paused_stale "$w" "$task" "$h"
           fi
         elif stale_is_terminal "$w" "$STATE"; then
           # The log's last line is captain-relevant - but that alone is not
@@ -1950,7 +1989,7 @@ EOF
         # is cleared - but not in the same poll the declared-pause cadence just
         # recorded it, or the re-surface throttle it depends on would be erased and
         # the pause would re-surface every poll instead of once per long cadence.
-        if [ "$paused_bound" -ne 0 ] && [ -e "$pf" ] && { [ "$n" -ge 2 ] || ! status_is_paused_or_captain_held "$(last_status_line "$STATE/$(window_to_task "$w" "$STATE").status")"; }; then
+        if [ "$paused_bound" -ne 0 ] && [ -e "$pf" ] && { [ "$n" -ge 2 ] || { ! status_is_paused_or_captain_held "$last" && ! status_is_done "$last"; }; }; then
           clear_pause_tracking "$key"
         fi
       fi
@@ -1970,6 +2009,12 @@ EOF
           paused) handle_paused_stale "$w" "$task" "$h" ;;
           *)      clear_pause_tracking "$key" ;;
         esac
+      elif ! afk_present && status_is_done "$last" && [ "$busy_now" -ne 0 ]; then
+        # A finished crew's idle pane re-rendered: keep its pause bookkeeping
+        # (and the re-surface throttle it carries) until the hash settles and
+        # the stale branch classifies it; clearing here would let a churny
+        # idle footer re-surface the same finished worker on every re-render.
+        :
       elif [ "$paused_bound" -ne 0 ] && [ -e "$pf" ]; then
         # Same rule as the stable-hash branch: never clear pause bookkeeping the
         # declared-pause cadence recorded on this very poll.

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1352,8 +1352,17 @@ if ! fm_lock_try_acquire "$WATCH_LOCK"; then
   exit 0
 fi
 WATCHER_RECOVERY_PENDING=0
+# A reclaimed stale lock is a watcher that died without cleanup, so its recovery
+# wake is delivered even to an empty drain; the routine marker-driven recovery
+# below is gated on presentable work instead (resurface_after_downtime). The
+# lock library reports its own dead-pid reclaim, and bin/fm-watch-arm.sh sets
+# FM_WATCH_LOCK_RECLAIMED for the child it starts after clearing a reused-pid lock.
+WATCHER_LOCK_RECOVERED=0
 if [ -n "${FM_LOCK_RECOVERED_PID:-}" ]; then
   WATCHER_RECOVERY_PENDING=1
+  WATCHER_LOCK_RECOVERED=1
+elif [ "${FM_WATCH_LOCK_RECLAIMED:-0}" = 1 ]; then
+  WATCHER_LOCK_RECOVERED=1
 fi
 if [ "${FM_WATCH_HANDLING_SUCCESSOR:-0}" != 1 ]; then
   if ! fm_recovery_marker_reopen_announced "$WATCHER_DOWNTIME_MARKER"; then
@@ -1483,6 +1492,16 @@ retire_merged_pr_poll() {  # <id>
   fi
 }
 
+# 0 when the drain a recovery wake triggers has something to present: an
+# unacknowledged durable queue row, or a decision still open in a status log
+# (the buried-decision case docs/watcher-continuity.md's recovery episode
+# exists for). Both reads are pure; the open-decision fold is the whole-file
+# owner in fm-classify-lib.sh, so this never advances the drain's cursors.
+recovery_has_presentable_work() {
+  [ -s "$FM_WAKE_QUEUE" ] && return 0
+  [ -n "$(scan_open_decisions "$STATE")" ]
+}
+
 resurface_after_downtime() {
   # Handling successors already have a predecessor-delivered wake on the way.
   # Re-announcing from this cycle is what turned a lost handshake into an
@@ -1497,7 +1516,15 @@ resurface_after_downtime() {
     fi
     [ "$FM_RECOVERY_MARKER_ACTION" = recover ] || return 0
   fi
-  wake "check: rearm-resurface"
+  if [ "$WATCHER_LOCK_RECOVERED" -eq 1 ] || recovery_has_presentable_work; then
+    wake "check: rearm-resurface"
+  fi
+  # Nothing to present: the marker was consumed above exactly as before (the
+  # generation is already announced), so the routine re-arm gap a Cursor or
+  # Claude primary opens at every turn end costs no supervision turn. A later
+  # append reuses that announced generation and its drain acknowledges it.
+  WATCHER_RECOVERY_PENDING=0
+  triage_log "absorbed rearm-resurface (queue empty, no open decisions)"
 }
 
 while :; do

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -50,6 +50,7 @@ The turn-end guard remains the final backstop rather than the normal continuity 
 
 A recovery episode is one generation of `state/.watcher-down`, and it is retired only by the generation-bound acknowledgement the drain prints as `WAKE_ACK_REQUIRED`.
 An unacknowledged downtime generation is announced at most once: the first recovery marks that generation announced, and later arms wait until a new down stretch mints a new generation.
+The announcement itself is delivered as a `check: rearm-resurface` wake only when the drain it triggers has something to present - an unacknowledged durable queue row or a still-open decision in a status log - or when the watcher reclaimed a stale lock from a predecessor that died without cleanup; otherwise the generation is consumed silently with one `absorbed rearm-resurface` triage line, so a routine turn-end re-arm gap costs no supervision turn.
 A non-successor watcher start after an announced-but-unacked episode is a new down stretch and mints a fresh generation so buried decisions still resurface once.
 Every watcher close and every durable queue append publishes downtime, so a downtime republication of any pending episode reuses its generation instead of minting a new one, and an already-announced generation stays announced.
 That reuse keeps a watcher close inside the handling window from orphaning the acknowledgement already presented and trapping later arms in repeated recovery presentation.

--- a/tests/fm-watch-arm.test.sh
+++ b/tests/fm-watch-arm.test.sh
@@ -540,6 +540,12 @@ test_malformed_marker_is_quarantined_once() {
   fakebin="$dir/fakebin"
   mkdir -p "$home/data" "$state/.watcher-down"
   printf 'foreign state\n' > "$state/.watcher-down/payload"
+  # A durable row gives the quarantined marker's recovery something to present;
+  # with an empty queue the announcement is absorbed (fm-watch-triage covers that).
+  # Written directly because the production appender refuses to publish
+  # downtime while the marker path is a directory.
+  printf '1700000000\t7\tcheck\tstartup-network\tcheck: startup-network behind a malformed marker\n' \
+    > "$state/.wake-queue"
 
   start_rearm_arm "$home" "$state" "$fakebin" "$dir/recovery-arm.out"
   wait_for_exit "$ARM_PID" 80 || fail "malformed marker did not produce a bounded recovery wake"

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1686,9 +1686,11 @@ test_terminal_stale_surfaced() {
   dir=$(make_case terminal-stale); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; drain_out="$dir/drain.out"; capture_file="$dir/pane.txt"
   window="test:fm-done"
-  printf 'finished, awaiting review' > "$capture_file"
+  printf 'stopped, needs a hand' > "$capture_file"
   printf 'window=%s\nkind=ship\n' "$window" > "$state/done.meta"
-  printf 'done: PR https://example.test/pr/3\n' > "$state/done.status"
+  # A blocked: line, not done: - a finished crew's idle wait takes the pause
+  # cadence instead (test_done_idle_stale_takes_pause_cadence below).
+  printf 'blocked: cannot push, remote rejected the branch\n' > "$state/done.status"
   sig=$(seen_sig "$state/done.status"); printf '%s' "$sig" > "$state/.seen-done_status"
   key=$(printf '%s' "$window" | tr ':/.' '___')
   pane_hash=$(hash_text "finished, awaiting review")
@@ -3249,7 +3251,10 @@ test_terminal_first_sight_drops_a_finished_write_deferral_chain() {
   mkdir -p "$wt/src"
   printf 'no-mistakes axi run: validating...' > "$capture_file"
   printf 'window=%s\nkind=ship\nworktree=%s\n' "$window" "$wt" > "$state/chain-first.meta"
-  printf 'done: implementation complete, ready to validate\n' > "$state/chain-first.status"
+  # A captain-relevant line that is not done:, because a done: crew's idle wait
+  # takes the pause cadence (test_done_idle_stale_takes_pause_cadence) and so
+  # never reaches the plain-surface path this test exercises.
+  printf 'blocked: implementation complete, waiting on a decision before validating\n' > "$state/chain-first.status"
   sig=$(seen_sig "$state/chain-first.status"); printf '%s' "$sig" > "$state/.seen-chain-first_status"
   key=$(printf '%s' "$window" | tr ':/.' '___')
   pane_hash=$(hash_text "no-mistakes axi run: validating...")
@@ -3297,6 +3302,194 @@ test_terminal_first_sight_drops_a_finished_write_deferral_chain() {
     || fail "the first-sight surface kept a finished write-deferral chain"
   unset FM_FAKE_CREW_STATE
   pass "both first-sight paths through a captain-relevant status drop a finished write-deferral chain with the idle window"
+}
+
+# --- done: + idle pane: the merge wait takes the declared-pause cadence -------
+# The live 2026-09-01/02 case: a direct-PR worker opened its PR, appended
+# `done: PR <url>`, and idled for review. Its TUI re-rendered its idle footer now
+# and then, so every new pane hash re-ran the terminal stale path and woke
+# firstmate with another `stale: <window>` for the same finished worker, all day.
+# The done: event already surfaced through the signal path and the PR poll owns
+# the merge, so done + idle is now absorbed on the same bounded cadence as a
+# declared pause, and never fed to the wedge timer.
+
+seed_idle_stale_case() {  # <name> <window> <status-line> <capture-text>
+  local name=$1 window=$2 line=$3 text=$4 dir state key
+  dir=$(make_case "$name"); state="$dir/state"
+  printf '%s' "$text" > "$dir/pane.txt"
+  printf 'window=%s\nkind=ship\n' "$window" > "$state/$name.meta"
+  printf '%s\n' "$line" > "$state/$name.status"
+  printf '%s' "$(seen_sig "$state/$name.status")" > "$state/.seen-${name}_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  printf '%s' "$(hash_text "$text")" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  printf '%s\n' "$dir"
+}
+
+test_done_idle_stale_takes_pause_cadence() {
+  local dir state fakebin out drain_out window key pane_hash statusf pid back i
+  window="test:fm-merge-wait"
+  dir=$(seed_idle_stale_case merge-wait "$window" \
+    'done: PR https://example.test/pr/9' 'PR opened, idle at the prompt')
+  state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"; drain_out="$dir/drain.out"
+  statusf="$state/merge-wait.status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text 'PR opened, idle at the prompt')
+  # No run attributed and an idle pane: the authoritative read is the log's done.
+  export FM_FAKE_CREW_STATE='state: done · source: status-log · PR https://example.test/pr/9'
+
+  # Phase A: a 1s wedge threshold and several polls, so a wedge escalation
+  # would have fired many times over; the finished worker is absorbed instead.
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=zsh \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_STALE_ESCALATE_SECS=1 FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  i=0
+  while [ "$i" -lt 4 ]; do
+    if ! wait_poll_cycle "$state" "$pid"; then
+      reap "$pid"; fail "watcher exited for a finished worker idling on its PR (should absorb): $(cat "$out")"
+    fi
+    i=$((i + 1))
+  done
+  [ ! -s "$out" ] || fail "done + idle printed a wake reason during absorb: $(cat "$out")"
+  [ ! -s "$state/.wake-queue" ] || fail "done + idle enqueued a wake during absorb"
+  [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" = "$pane_hash" ] || fail "stale suppressor not advanced on the done absorb"
+  [ -e "$state/.paused-$key" ] || fail "done + idle did not record the pause cadence flag"
+  [ ! -e "$state/.stale-since-$key" ] || fail "done + idle started the wedge timer"
+  [ ! -e "$state/.wedge-escalations-$key" ] || fail "done + idle counted a wedge escalation"
+  grep -F 'absorbed stale (done, awaiting merge authority' "$state/.watch-triage.log" >/dev/null \
+    || fail "the done absorb was not logged as a merge-authority wait"
+  reap "$pid"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the intentional done phase-A stop"
+
+  # A re-rendered idle footer (new hash) must not re-surface the same finished
+  # worker: the fresh hash is classified onto the same cadence, silently.
+  printf 'PR opened, idle at the prompt (12m ago)' > "$dir/pane.txt"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=zsh \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_STALE_ESCALATE_SECS=1 FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  i=0
+  while [ "$i" -lt 4 ]; do
+    if ! wait_poll_cycle "$state" "$pid"; then
+      reap "$pid"; fail "a re-rendered idle footer re-surfaced a finished worker: $(cat "$out")"
+    fi
+    i=$((i + 1))
+  done
+  [ ! -s "$out" ] || fail "a re-rendered idle footer printed a wake reason: $(cat "$out")"
+  [ ! -s "$state/.wake-queue" ] || fail "a re-rendered idle footer enqueued a wake"
+  [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" = "$(hash_text 'PR opened, idle at the prompt (12m ago)')" ] \
+    || fail "the re-rendered hash was not classified onto the pause cadence"
+  [ ! -e "$state/.stale-since-$key" ] || fail "a re-rendered idle footer started the wedge timer"
+  reap "$pid"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the intentional re-render stop"
+
+  # Phase B: past the long cadence the wait is rechecked once, worded as the
+  # merge wait it is - never a possible wedge.
+  back=$(( $(date +%s) - 500 ))
+  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$statusf"
+  else touch -m -d "@$back" "$statusf"; fi
+  printf '%s' "$(seen_sig "$statusf")" > "$state/.seen-merge-wait_status"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=zsh \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_STALE_ESCALATE_SECS=1 FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 100 || fail "the merge wait was not rechecked past the long cadence: $(cat "$out")"
+  grep -F "stale: $window" "$out" >/dev/null || fail "the recheck did not print a stale wake"
+  grep -F "awaiting merge authority" "$out" >/dev/null || fail "the recheck was not worded as a merge wait: $(cat "$out")"
+  grep -F "possible wedge" "$out" >/dev/null && fail "a finished worker's merge wait was mislabeled a possible wedge"
+  [ -e "$state/.paused-resurfaced-$key" ] || fail "the recheck throttle marker was not recorded"
+  [ ! -e "$state/.stale-since-$key" ] || fail "the recheck used the wedge timer"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the merge-wait recheck failed"
+  grep "$(printf '\tstale\t')" "$drain_out" | grep -F "$window" >/dev/null || fail "the merge-wait recheck was not queued"
+  unset FM_FAKE_CREW_STATE
+  pass "a finished worker idling on its PR is absorbed like a declared pause and rechecked on the long cadence, never wedge-escalated"
+}
+
+test_working_idle_stale_still_wedge_escalates() {
+  local dir state fakebin out window key pane_hash pid
+  window="test:fm-went-quiet"
+  dir=$(seed_idle_stale_case went-quiet "$window" \
+    'working: icon updated, PR pushed' 'idle at the prompt after the push')
+  state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text 'idle at the prompt after the push')
+  export FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'
+
+  # The first stable sighting surfaces at once, exactly as before.
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=zsh \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 100 || fail "a working: worker that went quiet was not surfaced at once: $(cat "$out")"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "the quiet working: worker did not print the immediate stale wake"
+  [ ! -e "$state/.paused-$key" ] || fail "a working: worker was given the pause cadence"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the immediate stale wake"
+
+  # The same unchanged hash then runs the wedge timer and, past the threshold,
+  # escalates as a possible wedge - the done: exemption reaches none of this.
+  echo $(( $(date +%s) - 500 )) > "$state/.stale-since-$key"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=zsh \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_STALE_ESCALATE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 100 || fail "a quiet working: worker did not wedge-escalate past the threshold: $(cat "$out")"
+  grep -F "possible wedge" "$out" >/dev/null || fail "the quiet working: worker's escalation did not flag a possible wedge: $(cat "$out")"
+  [ ! -e "$state/.paused-$key" ] || fail "a working: worker's escalation recorded the pause cadence flag"
+  unset FM_FAKE_CREW_STATE
+  pass "a working: worker that goes quiet still surfaces at once and wedge-escalates past the threshold"
+}
+
+test_done_busy_pane_keeps_turn_bound_escalation() {
+  local dir state fakebin out capture_file window key pid
+  dir=$(make_case done-busy-turn-age); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-done-busy"
+  printf 'Working...' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=pi\n' "$window" > "$state/done-busy.meta"
+  record_pi_busy "$state" done-busy
+  # The worker reported done, then was steered and is busy again with no
+  # completed turn: the busy path, not the idle exemption, owns this pane.
+  printf 'done: PR https://example.test/pr/11\n' > "$state/done-busy.status"
+  printf '%s' "$(seen_sig "$state/done-busy.status")" > "$state/.seen-done-busy_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  printf '%s' "$(hash_text "Working...")" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  touch -t 200001010000 "$state/done-busy.meta"
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_BUSY_TURN_MAX_SECS=1 FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_poll_cycle "$state" "$pid"; then
+    reap "$pid"; fail "a busy done: pane past the turn-age bound escalated before the wedge threshold: $(cat "$out")"
+  fi
+  [ -s "$state/.stale-since-$key" ] || fail "a busy done: pane past the turn-age bound did not start the wedge timer"
+  [ ! -e "$state/.paused-$key" ] || fail "a busy done: pane was given the idle pause cadence"
+  reap "$pid"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the intentional busy done phase-A stop"
+
+  echo $(( $(date +%s) - 500 )) > "$state/.stale-since-$key"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_BUSY_TURN_MAX_SECS=1 FM_STALE_ESCALATE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 100 || fail "a busy done: pane did not wedge-escalate past the turn-age bound: $(cat "$out")"
+  grep -F "possible wedge" "$out" >/dev/null || fail "the busy done: pane's escalation did not flag a possible wedge: $(cat "$out")"
+  pass "a done: worker whose pane is busy again keeps the busy-pane turn-bound escalation unchanged"
 }
 
 # --- recovery re-surface is delivered only with something to present ----------
@@ -3945,6 +4138,9 @@ test_write_deferral_resurfaces_on_the_bounded_cadence
 test_secondmate_home_supervision_churn_is_not_write_evidence
 test_timer_repair_drops_a_finished_write_deferral_chain
 test_terminal_first_sight_drops_a_finished_write_deferral_chain
+test_done_idle_stale_takes_pause_cadence
+test_working_idle_stale_still_wedge_escalates
+test_done_busy_pane_keeps_turn_bound_escalation
 test_rearm_resurface_absorbed_when_nothing_to_present
 test_rearm_resurface_delivered_for_queued_row
 test_rearm_resurface_delivered_for_open_decision

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -3299,6 +3299,76 @@ test_terminal_first_sight_drops_a_finished_write_deferral_chain() {
   pass "both first-sight paths through a captain-relevant status drop a finished write-deferral chain with the idle window"
 }
 
+# --- recovery re-surface is delivered only with something to present ----------
+# The live 2026-09-02 case: a Cursor primary re-arms a watcher cycle at every
+# turn end, the new cycle reads the gap as downtime, and the recovery marker
+# said recover - so `check: rearm-resurface` woke firstmate into a drain that
+# printed `--ack-through 0` and nothing else, five times between 10:44 and
+# 12:08. The generation is still consumed exactly as before; only the wake is
+# gated on an unacknowledged queue row or a still-open decision.
+
+recovery_watch_bg() {  # <state> <fakebin> <out>
+  local state=$1 fakebin=$2 out=$3
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+}
+
+test_rearm_resurface_absorbed_when_nothing_to_present() {
+  local dir state fakebin out pid
+  dir=$(make_case rearm-resurface-empty); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  printf 'pending:downtime:fixture-gen\n' > "$state/.watcher-down"
+
+  recovery_watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  if ! wait_poll_cycle "$state" "$pid"; then
+    reap "$pid"; fail "an empty-queue recovery woke firstmate: $(cat "$out")"
+  fi
+  if ! wait_poll_cycle "$state" "$pid"; then
+    reap "$pid"; fail "an empty-queue recovery woke firstmate on a later poll: $(cat "$out")"
+  fi
+  [ ! -s "$out" ] || fail "an empty-queue recovery printed a wake reason: $(cat "$out")"
+  [ ! -s "$state/.wake-queue" ] || fail "an empty-queue recovery enqueued a wake"
+  [ "$(cat "$state/.watcher-down" 2>/dev/null || true)" = 'announced:downtime:fixture-gen' ] \
+    || fail "the recovery marker was not consumed to its announced state: $(cat "$state/.watcher-down" 2>/dev/null)"
+  [ "$(grep -cF 'absorbed rearm-resurface' "$state/.watch-triage.log" 2>/dev/null || true)" = 1 ] \
+    || fail "the silent recovery was not logged exactly once: $(cat "$state/.watch-triage.log" 2>/dev/null)"
+  reap "$pid"
+  pass "a recovery generation with an empty queue and no open decision is consumed silently"
+}
+
+test_rearm_resurface_delivered_for_queued_row() {
+  local dir state fakebin out drain_out pid
+  dir=$(make_case rearm-resurface-queued); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"
+  printf 'pending:downtime:fixture-gen\n' > "$state/.watcher-down"
+  append_wake "$state" check startup-network 'check: startup-network queued during downtime' \
+    || fail "could not seed the durable queue"
+
+  recovery_watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  wait_for_exit "$pid" 100 || fail "a recovery with a queued row did not wake firstmate: $(cat "$out")"
+  grep -Fx 'check: rearm-resurface' "$out" >/dev/null || fail "the queued row was not announced as a recovery wake: $(cat "$out")"
+  [ "$(cat "$state/.watcher-down" 2>/dev/null || true)" = 'announced:downtime:fixture-gen' ] \
+    || fail "the delivered recovery did not keep its announced generation: $(cat "$state/.watcher-down" 2>/dev/null)"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the recovery wake failed"
+  grep "$(printf '\tcheck\tstartup-network\t')" "$drain_out" >/dev/null || fail "the queued row was not drained"
+  pass "a recovery generation with an unacknowledged queue row is still announced and drained"
+}
+
+test_rearm_resurface_delivered_for_open_decision() {
+  local dir state fakebin out pid
+  dir=$(make_case rearm-resurface-decision); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  printf 'needs-decision [key=ship-it]: merge now or wait for the design review\n' > "$state/held.status"
+  printf '%s' "$(seen_sig "$state/held.status")" > "$state/.seen-held_status"
+  printf 'pending:downtime:fixture-gen\n' > "$state/.watcher-down"
+
+  recovery_watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  wait_for_exit "$pid" 100 || fail "a recovery over a still-open decision did not wake firstmate: $(cat "$out")"
+  grep -Fx 'check: rearm-resurface' "$out" >/dev/null || fail "the open decision was not announced as a recovery wake: $(cat "$out")"
+  pass "a recovery generation with an empty queue but a still-open decision is still announced"
+}
+
 # --- triage debug log stays size capped -------------------------------------
 
 test_triage_log_size_cap_accepts_spaced_wc_counts() {
@@ -3875,6 +3945,9 @@ test_write_deferral_resurfaces_on_the_bounded_cadence
 test_secondmate_home_supervision_churn_is_not_write_evidence
 test_timer_repair_drops_a_finished_write_deferral_chain
 test_terminal_first_sight_drops_a_finished_write_deferral_chain
+test_rearm_resurface_absorbed_when_nothing_to_present
+test_rearm_resurface_delivered_for_queued_row
+test_rearm_resurface_delivered_for_open_decision
 test_triage_log_size_cap_accepts_spaced_wc_counts
 test_procevent_captured_result_surfaces_proactively
 test_procevent_unacknowledged_result_redrains_until_handled


### PR DESCRIPTION
Two small watcher fixes that remove two classes of pointless wake-ups, one commit each with its colocated tests.

## Problem 1: empty `check: rearm-resurface` wakes

**Observed.** On a Cursor primary every turn end re-arms a watcher cycle. The fresh cycle reads the gap since the previous clean close as downtime, the recovery marker says `recover`, and `resurface_after_downtime` fired `wake "check: rearm-resurface"` unconditionally. The handling turn then drained an empty queue (the drain printed `--ack-through 0`) and did nothing. The home's delivery log records nine of these between 10:44 and 12:08 on 2026-09-02 (10:44, 11:12, 11:12, 11:16, 11:57, 11:57, 11:59, 12:03, 12:08), at least five of which the handling turn drained as `--ack-through 0`, and ten more on 2026-09-01.

**Change** (`bin/fm-watch.sh`, `bin/fm-watch-arm.sh`, `docs/watcher-continuity.md`). The recovery marker is consumed exactly as before (`pending:downtime` to `announced:downtime`, same token grammar, same generation-bound acknowledgement, same `release-lock` / `release-lock-existing` cleanup). Only the wake is now gated on the drain having something to present:

- an unacknowledged row in the durable wake queue, or
- a decision still open in a status log (`scan_open_decisions`, the pure whole-file fold owned by `bin/fm-classify-lib.sh`, so the watcher never advances the drain's incremental cursors) - this is the buried-decision case the recovery episode contract in `docs/watcher-continuity.md` already names and the existing `test_rearm_resurfaces_durable_queue_and_remote_open_decision` already requires, or
- the watcher reclaimed a stale lock from a predecessor that died without cleanup (`FM_LOCK_RECOVERED_PID` from the lock library, or `FM_WATCH_LOCK_RECLAIMED=1` which `bin/fm-watch-arm.sh --restart` now hands to the child it starts after clearing a reused-pid lock, so both stale-lock reclaim paths keep announcing as the existing arm and lock tests assert).

With none of those, the cycle writes one triage line, `absorbed rearm-resurface (queue empty, no open decisions)`, clears its in-process pending flag, and keeps supervising. A later append in that cycle reuses the announced generation and its drain acknowledges it, so no marker is left dangling; the next non-successor arm mints a fresh generation exactly as today.

**Guardrails preserved.** No change to the marker state machine, token grammar, or ack/generation format. A queue with records always wakes. Handling successors still never re-announce. `UNREAD STATUS` notes are deliberately not part of the gate: they are not in the `fm_recovery_*` contract, and a status append during downtime is caught by the signal scan on the next cycle anyway.

**Tests** (`tests/fm-watch-triage.test.sh`):
- `test_rearm_resurface_absorbed_when_nothing_to_present` - empty queue + `pending:downtime` marker: no wake across two full polls, no queue row, marker consumed to `announced:downtime:<same generation>`, exactly one triage line.
- `test_rearm_resurface_delivered_for_queued_row` - one unacknowledged row + the same marker: `check: rearm-resurface` delivered, generation kept announced, row drained.
- `test_rearm_resurface_delivered_for_open_decision` - empty queue but a still-open `needs-decision [key=...]`: wake still delivered.
- `tests/fm-watch-arm.test.sh` `test_malformed_marker_is_quarantined_once` now seeds one durable row, because a quarantined marker over an empty queue is now absorbed; its quarantine-exactly-once and no-loop assertions are unchanged.

## Problem 2: a worker that reported `done: PR <url>` is waiting, not stale

**Observed.** A `direct-PR` ship worker opened its PR, appended `done: PR https://...`, and idled for review. Its TUI re-rendered its idle footer now and then, so every new pane hash re-ran the terminal stale path and woke firstmate with another `stale: <window>` for the same finished worker. The home's delivery log shows this repeating on one finished worker's pane on 2026-08-31 (12:51, 13:56, 17:39) and 2026-09-01 (09:32, 09:54), and again at 11:42 on 2026-09-02 on another; the same log shows each reason was a plain `stale: <window>` re-surface on a new hash rather than a wedge escalation. Both workers' `state/<id>.meta` recorded `pr=` (corroborating, not required).

**Change** (`bin/fm-watch.sh`, `bin/fm-classify-lib.sh`). `status_is_done` is a new verb predicate in `bin/fm-classify-lib.sh`, next to `status_is_terminal_verb`; the watcher uses it rather than re-parsing the log. When a task's last status event is a terminal `done:` and its pane is idle (two identical hashes, no busy verdict), the stale path now classifies it like a declared `paused:` wait through the existing `handle_paused_stale`: absorbed on first sight, rechecked once per `PAUSE_RESURFACE_SECS` with a new wording (`done <age>s, awaiting merge authority - ... the PR poll owns the merge outcome`), never fed to the wedge timer. The pause bookkeeping (`.paused-*`, the re-surface throttle) now also survives a re-rendered idle footer, which is what made the noise repeat. Mirroring the terminal path, a NEW hash still lets an actively running run-step override the log and keep the wedge timer (`crew_is_provably_working`), so a frozen validation firstmate started after the `done:` line still escalates, as `test_stale_terminal_status_overridden_by_active_run` continues to assert.

**Guardrails preserved.** Anything that is not a terminal `done:` keeps today's stale behaviour exactly: `working:` followed by silence surfaces at once and wedge-escalates past `STALE_ESCALATE_SECS`; `needs-decision:`, `blocked:`, and `failed:` keep the immediate terminal surface. A `done:` worker whose pane is busy again never reaches the exemption: the busy path, `busy_turn_bound_check`, and its `status_is_paused_or_captain_held` gate are untouched, and a busy pane still clears the pause bookkeeping. Secondmate and away-mode branches run before the new branch and are unchanged.

**Tests** (`tests/fm-watch-triage.test.sh`):
- `test_done_idle_stale_takes_pause_cadence` - done + idle with a 1s wedge threshold across several polls: no wake, no wedge timer, pause flag recorded; a re-rendered footer (new hash) stays silent; past the long cadence one recheck worded `awaiting merge authority`, never `possible wedge`.
- `test_working_idle_stale_still_wedge_escalates` - `working:` + idle: immediate `stale: <window>`, then `possible wedge` past the threshold, no pause flag.
- `test_done_busy_pane_keeps_turn_bound_escalation` - done + busy pane past `BUSY_TURN_MAX_SECS`: wedge timer starts and escalates as today, no pause flag.
- Two existing fixtures (`test_terminal_stale_surfaced`, `test_terminal_first_sight_drops_a_finished_write_deferral_chain`) used a `done:` line to reach the plain terminal surface; they now use `blocked:`, which keeps the path they exercise.

## Docs

One sentence each at the single owner: the recovery-wake rule in `docs/watcher-continuity.md` "Recovery episode acknowledgement", and the done + idle rule in the `stale:` reason description of the `bin/fm-watch.sh` header. `AGENTS.md` and skills untouched (the guidelines' placement tree puts both rules at the mechanism owner).

## Maintainer verification (2026-09-02, macOS, stock `/bin/bash` 3.2.57(1)-release)

Every test below ran under stock bash 3.2.57, which is the only `bash` on the machine, so the whole run doubles as the 3.2 proof. `bin/fm-lint.sh` pinned ShellCheck 0.11.0 (`fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)`, full extended analysis).

```
bin/fm-lint.sh bin/fm-watch.sh bin/fm-watch-arm.sh bin/fm-classify-lib.sh tests/fm-watch-arm.test.sh tests/fm-watch-triage.test.sh
  -> lint rc=0
bin/fm-doc-audience-check.sh
  -> fm-doc-audience-check: ok surfaces=89 local_links=302
bin/fm-test-run.sh tests/fm-watch-triage.test.sh
  -> FM_TEST_SUMMARY total=1 failed=0 ... (96 ok, including the six new tests)
bin/fm-test-run.sh tests/fm-wake-queue.test.sh tests/fm-watcher-lock.test.sh tests/fm-watch-arm.test.sh
  -> fm-watcher-lock exit=0, fm-watch-arm exit=0, fm-wake-queue exit=1 (pre-existing, see below)
bin/fm-test-run.sh tests/fm-watch-recovery-loop.test.sh tests/fm-pr-check-security.test.sh
  -> both exit=0
bin/fm-test-run.sh --all --per-script-timeout-secs 900
  -> FM_TEST_SUMMARY total=176 failed=16 skipped_gate=26
```

The 16 `--all` failures were re-run against a pristine `git archive origin/main` copy in the same environment: 15 fail identically there (`fm-wake-queue` relies on `BASHPID`, which bash 3.2 lacks; `fm-lint-workflows` and `fm-lint` need `actionlint`; `fm-cursor-harness`, `fm-composer-lib`, `fm-muse-harness`, `fm-extension-binding`, `fm-gotmp`, `fm-on`, `fm-pending-reply`, `fm-public-followup`, `fm-teardown`, the two remote-secondmate suites and the Herdr presentation e2e are host-environment failures unrelated to the watcher). The sixteenth, `fm-bootstrap-network-parallel`, passed on `origin/main` and passes on this branch when run alone (`exit=0 duration_ms=13870`); it failed only under the full-suite load and touches no file this PR changes. Every watcher-related suite (`fm-watch-triage`, `fm-watch-arm`, `fm-watcher-lock`, `fm-watch-recovery-loop`, `fm-watch-checkpoint`, `fm-pr-check-security`, the `fm-wake-drain-*` suites) passed on this branch. Tests were run against temporary `FM_STATE_OVERRIDE` directories only; no watcher was run against a live home.

Note for reviewers: the tests ran with Cursor's own `CURSOR_AGENT` environment variables unset, because the harness-detection fixtures (`fm-watcher-lock`'s guard banner test) otherwise read the test runner's host as a Cursor primary.
