### PR TITLE
fix(bin): absorb fresh replacement waits before resurfacing

### DIFF
--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -705,9 +705,19 @@ FM_WEDGE_DEMAND_INSPECT_COUNT=${FM_WEDGE_DEMAND_INSPECT_COUNT:-3}
 # window; wake() itself exits the cycle, exactly as it does inline.
 resurface_absorbed() {  # <window> <throttle-marker> <age> <reason> [scope]
   local win=$1 throttle=$2 age=$3 reason=$4 scope=${5-}
+  # The absorb age always gates: a freshly declared wait is absorbed while it is
+  # fresh, which is this path's whole contract, and a REPLACEMENT wait is no
+  # different from the first one - the status append that declared it already woke
+  # firstmate through the signal path, so firing here as well would nag twice for
+  # one event, on the path that exists not to nag.
+  [ "$age" -ge "$PAUSE_RESURFACE_SECS" ] || return 0
+  # The throttle, by contrast, bounds ONE declared wait. A caller that passes a
+  # scope names the declaration its marker was written for, so a marker written
+  # for a DIFFERENT declaration must not suppress this one: the replacement serves
+  # its own window instead of the remainder of the previous wait's. A scope-less
+  # caller keeps the pure timestamp cadence it always had.
   if [ -z "$scope" ] || [ ! -e "$throttle" ] \
     || [ "$(cat "$throttle" 2>/dev/null || true)" = "$scope" ]; then
-    [ "$age" -ge "$PAUSE_RESURFACE_SECS" ] || return 0
     [ "$(age_of "$throttle")" -ge "$PAUSE_RESURFACE_SECS" ] || return 0   # 999999 when no prior re-surface
   fi
   fm_wake_append stale "$win" "$reason" || exit 1

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -2055,9 +2055,14 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
 }
 
 # A dead worker reaches handle_paused_stale rather than the live fallback above.
-# When one declared wait directly replaces another, the existing
-# throttle belongs to the old declaration and must not suppress the new wait's
-# first inspection merely because its timestamp is still young.
+# When one declared wait directly replaces another, the existing throttle belongs
+# to the OLD declaration and must not make the new wait serve out the remainder of
+# the old window. But the replacement is still a freshly declared wait, so this
+# path absorbs it while it is fresh exactly as it absorbs a first declaration: the
+# status append that declared it already woke firstmate through the signal path,
+# and firing here too would nag twice for one event. The contract pinned here is
+# therefore: absorbed while fresh, then re-surfaced once its OWN age crosses the
+# window, regardless of how recently the previous declaration re-surfaced.
 test_absorbed_replacement_wait_does_not_inherit_the_old_throttle() {
   local spec name initial replacement expected dir state fakebin out capture_file
   local statusf window key sig back pid wakes
@@ -2091,9 +2096,36 @@ test_absorbed_replacement_wait_does_not_inherit_the_old_throttle() {
     wait_for_exit "$pid" 100 || fail "[$name] initial declared wait did not re-surface"
     ack_stopped_cycle "$state" || fail "[$name] could not acknowledge the initial declared wait"
 
+    # The replacement is FRESH. The seen marker is advanced to its signature so the
+    # status-signal path stays quiet and this asserts the stale path alone -
+    # without that isolation the signal wake would satisfy any "was told" check and
+    # the assertion would pass whatever this path did.
     printf '%s\n' "$replacement" >> "$statusf"
     sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
     printf 'idle after replacement wait\n' > "$capture_file"
+    PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+      FM_FAKE_TMUX_CURRENT_COMMAND=zsh FM_FAKE_CREW_STATE='state: stopped · source: pane · bare shell' \
+      FM_WATCH_HANDLING_SUCCESSOR=1 \
+      FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+      FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+      FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
+    pid=$!
+    if ! wait_poll_cycle "$state" "$pid"; then
+      reap "$pid"; fail "[$name] a freshly declared replacement wait was alarmed instead of absorbed"
+    fi
+    reap "$pid"
+    wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' \
+      "$state/.wake-queue" 2>/dev/null || echo 0)
+    [ "$wakes" -eq 0 ] \
+      || fail "[$name] a freshly declared replacement wait produced $wakes stale wakes while still fresh"
+
+    # Age the replacement past its OWN window while the previous declaration's
+    # throttle is still young. Inheriting that throttle would hold the new wait
+    # silent for the remainder of the old window; it must re-surface on its own.
+    back=$(( $(date +%s) - 500 ))
+    if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$statusf"
+    else touch -m -d "@$back" "$statusf"; fi
+    sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
     PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
       FM_FAKE_TMUX_CURRENT_COMMAND=zsh FM_FAKE_CREW_STATE='state: stopped · source: pane · bare shell' \
       FM_WATCH_HANDLING_SUCCESSOR=1 \
@@ -2109,7 +2141,7 @@ test_absorbed_replacement_wait_does_not_inherit_the_old_throttle() {
     grep -F "$expected" "$state/.wake-queue" >/dev/null \
       || fail "[$name] replacement declared wait used the wrong recheck reason: $(cat "$state/.wake-queue")"
   done
-  pass "absorbed paused and captain-held replacements each start their own re-surface cadence"
+  pass "absorbed paused and captain-held replacements are absorbed while fresh, then start their own re-surface cadence"
 }
 
 # Run one watcher round against a parked-worker fixture, so a round differs only

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -2110,7 +2110,12 @@ test_absorbed_replacement_wait_does_not_inherit_the_old_throttle() {
       FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
       FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
     pid=$!
-    if ! wait_poll_cycle "$state" "$pid"; then
+    # A changed pane hash needs three polls to become stable stale: first sight
+    # records the new hash, second sight increments its stability count, and the
+    # third reaches handle_paused_stale. Each wait proves one whole intervening
+    # cycle, so require two to make the fresh-age assertion non-vacuous even when
+    # the helper removes the beacon before the watcher's first poll.
+    if ! wait_poll_cycle "$state" "$pid" || ! wait_poll_cycle "$state" "$pid"; then
       reap "$pid"; fail "[$name] a freshly declared replacement wait was alarmed instead of absorbed"
     fi
     reap "$pid"


### PR DESCRIPTION
## Intent

Follow-up to the merged change that bounded repeat stale wakes for a parked worker (PR 3532, d22318e).

That change made the re-surface throttle declaration-scoped so a replacement declared wait would not
serve out the previous wait's window. It went one step too far: the scope check wrapped the absorb AGE
gate as well as the throttle gate, so on a scope mismatch both were skipped and a replacement declared
wait was alarmed IMMEDIATELY instead of being absorbed while fresh.

That crosses two contracts. handle_paused_stale absorbs a freshly declared wait and re-surfaces it once
per window, and a replacement is still a freshly declared wait. The status append that declared it has
already woken the supervisor through the status-signal path, so firing on the absorbed path as well
reports one event twice - on the path whose entire purpose is not to nag. It is also asymmetric: a
first declaration is absorbed while fresh, a replacement is not, decided only by whether a throttle
marker happens to exist.

The fix: apply the absorb age gate unconditionally, and keep only the throttle gate scoped to the
declaration. A replacement is absorbed while fresh, then re-surfaces once its OWN age crosses the
window rather than serving out the remainder of the previous wait's window. The reviewer's original
concern - that a new wait must not inherit the old wait's active throttle - is preserved exactly.

This is noise avoidance, not a missing wake: nothing here can silence a wait. Verify that boundary.

Constraints carried forward from the original work, all still in force:
Do NOT change pause_state_class. Returning none for a live agent is deliberate, so a worker genuinely
waiting on a decision is never silenced; trading a noise bug for a silence bug is far worse.
bin/fm-watch.sh is live supervision infrastructure, so prefer the smallest change that closes the defect.
bin/fm-lint.sh must pass. Markdown uses one sentence per line and a plain dash.

Tests: extend tests/fm-watch-triage.test.sh, exercise behaviour through an executable interface, never
assert implementation source bytes. The test must BITE in both directions and was confirmed to: it
fails with "alarmed instead of absorbed" when the age gate is skipped on a scope mismatch, and with
"inherited the old throttle" when scope awareness is removed entirely - both proven by breaking the
code deliberately and restoring it. Its seen-marker priming is deliberate isolation: the status-signal
path independently reports the same event, so without that priming the assertion would pass whatever
the path under test did.

Commit messages and the PR description are written for this project's maintainers and its future
readers - never as status reports to a supervisor, and never carrying agent identity, session links,
or internal process narration. Check every commit message on the branch before any push.

## What Changed

- Apply the absorb-age gate before declaration-scoped throttle checks so replacement waits stay absorbed while fresh without inheriting the previous wait’s throttle window.
- Extend executable watcher triage coverage to verify fresh replacements remain quiet and aged replacements re-surface independently for both paused and captain-held waits.

## Risk Assessment

✅ Low: Captain, the narrowly scoped age-gate correction preserves declaration-scoped throttling and introduces no substantiated source risk.

## Testing

No prior baseline result was supplied. Four focused executable watcher scenarios passed for replacement, live, ordinary paused, and scope-less write-deferral waits; the CLI transcript was captured and the worktree remained clean. The out-of-phase full lint and repository-wide suite were not run.

<details>
<summary>Evidence: Replacement-wait executable behavior transcript</summary>

Source: [Replacement-wait executable behavior transcript](https://github.com/mremond/firstmate/blob/4cd653a6f7abf2f3a55ad2069ef6bccb95a4dd56/.no-mistakes/evidence/fm/fm-absorbed-replacement-wait-fresh/replacement-wait-executable-transcript.log)

<code>ok - absorbed paused and captain-held replacements are absorbed while fresh, then start their own re-surface cadence&#10;ok - a parked live worker surfaces once, absorbs pane churn for the whole re-surface window, then re-surfaces when it elapses&#10;ok - a declared pause is absorbed on first sight, then re-surfaced as a recheck past the threshold, never wedge-escalated&#10;ok - a write deferral re-surfaces once on the bounded pause cadence, so a churning worktree cannot stay invisible</code>

```text
Focused executable regression: replacement waits and live declared-wait throttling
Interface under test: bin/fm-watch.sh via tests/fm-watch-triage.test.sh fixtures
Expected: fresh replacements are absorbed; aged replacements resurface on their own cadence; live waits still surface once and remain bounded.
ok - absorbed paused and captain-held replacements are absorbed while fresh, then start their own re-surface cadence
ok - a parked live worker surfaces once, absorbs pane churn for the whole re-surface window, then re-surfaces when it elapses

Focused shared-helper compatibility checks

Expected: an ordinary paused wait and the scope-less worktree-write deferral remain absorbed then boundedly resurface.
ok - a declared pause is absorbed on first sight, then re-surfaced as a recheck past the threshold, never wedge-escalated
ok - a write deferral re-surfaces once on the bounded pause cadence, so a churning worktree cannot stay invisible
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a9f1329cf30f3dd0e24c4d3eb0e550c0edae0bbb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected branch commits with `git log --format=&#39;%H%n%s%n%b%n---&#39; d22318ea1e61927769b9eee18e35bfbe4a41eb56..029541aa77f1133bfdeeab2fc7aecfe4976788dd` and reviewed the targeted diff.</code>
- <code>Executed `test_absorbed_replacement_wait_does_not_inherit_the_old_throttle` against the real `bin/fm-watch.sh` subprocess interface.</code>
- <code>Executed `test_live_declared_wait_churn_honors_the_resurface_throttle`.</code>
- <code>Executed `test_nonterminal_stale_paused_absorbed_then_resurfaced` and `test_write_deferral_resurfaces_on_the_bounded_cadence`.</code>
- <code>Captured and reread the evidence transcript; confirmed the worktree remained clean with `git status --short`.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
