### PR TITLE
fix(session-lock): identify a harness session on Windows/Git Bash

### DIFF
--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -47,6 +47,16 @@ State all five of these elements in one concise, evidence-first escalation:
 
 Do not relay reviewer labels or gate output as if they settled the decision.
 
+## Deliver the decision
+
+This skill also owns how a decided finding reaches the worker, because the delivery step is what makes the decision stick.
+
+Send the same worker one exact decision naming the decision key, the step, the action, the affected finding IDs, instructions where they are needed, and the exact response command to run.
+Pass `fm-send`'s `--resolve-key` so the worker's open decision record closes at answer time rather than staying open behind a later `working:` or `done:` line.
+Require the matching `resolved` event before treating the decision as landed.
+Forbid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.
+Require the worker to process every synchronous return until completion or a genuinely new escalation, rather than stopping at the first gate response.
+
 ## Classification examples
 
 - Fixing a concrete defect that violates an original acceptance criterion is firstmate's to decide, regardless of implementation difficulty.

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -41,7 +41,7 @@ Choose that posture when adding or creating the project:
 - `no-mistakes` runs the full validation pipeline before a PR.
 - `direct-PR` pushes and opens a PR without the no-mistakes pipeline.
 - `local-only` has no required remote or PR and lands only through the approved local fast-forward path.
-- `no-mistakes-prod-only` is a conditional policy rather than one flat mode: genuinely internal-only tooling, automation, contributor or operator process, and release or submission work ships `direct-PR`, while product-facing, mixed, and uncertain work ships `no-mistakes`.
+- `no-mistakes-prod-only` is a conditional policy rather than one flat mode: some of its work ships `no-mistakes` and some ships `direct-PR`, and `AGENTS.md` section 7 owns which surface takes which.
 
 `no-mistakes-prod-only` is the default for a newly added or created remote-backed project when the captain specifies nothing, and a project with no remote defaults to `local-only`.
 State that resolved default while confirming the source, local name, and posture instead of asking the captain to choose from scratch, and record a flat mode instead whenever they ask for one.

--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 # quota-array-dispatch
 
 This skill is the single owner of the completion-aware profile-array selection procedure.
-`AGENTS.md` section 4 owns the always-loaded intake boundary, load trigger, malformed-config refusal, every-candidate accounting, and strongest-reasoning/tie safety rules.
+`AGENTS.md` section 4 owns the always-loaded intake boundary, this skill's load trigger, and the malformed-config refusal that fires before any array is resolved; the every-candidate accounting, strongest-reasoning-class, and tie rules are owned here.
 `harness-adapters` owns harness verification, model/provider discovery, and effort fallback.
 `quota-axi` remains data-only: it publishes `spendPriority` as a comparable scalar and never recommends, selects, ranks, or infers a route.
 Do not add a daemon, opaque composite score, routing wrapper, hard-coded model-specific policy, or producer-side route recommendation.

--- a/.agents/skills/validation-run-changes/SKILL.md
+++ b/.agents/skills/validation-run-changes/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: validation-run-changes
+description: >-
+  Agent-only contract for changing a task while its no-mistakes validation run is active.
+  Load before expanding a task under an active run, and before acting on a captain instruction that invalidates work being validated.
+  Owns the in-scope boundary during validation and the abort-settle-replace-revalidate sequence that is the only supported way to supersede a run.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# validation-run-changes
+
+Load this once a no-mistakes validation run is active and something wants to change the work under it.
+`AGENTS.md` section 7 owns the always-loaded facts: the worker that starts a run drives it, firstmate never calls `no-mistakes axi respond` for a crew-owned run, and nothing outside this skill authorizes hand-editing, committing, aborting, or restarting while a run owns the branch.
+`ask-user-authority` owns gate findings; this skill covers requirement changes arriving from outside the pipeline.
+
+## In-scope boundary during validation
+
+Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated.
+The following stay within the current task even when they touch files not named at intake:
+
+- The smallest downstream changes needed to keep already accepted product or engineering behavior correct.
+- Behavioral tests added where an executable contract exists.
+- Documentation kept accurate for the accepted behavior.
+
+Corrections required to satisfy already accepted intent are not new requirements.
+
+## Superseding a run
+
+Only a current, explicit captain instruction that completely invalidates the work being validated keeps the task with the same worker instead of routing it to follow-up work or handing it to a replacement.
+When that happens, the worker follows this sequence exactly and in order.
+
+1. **Abort.**
+   Cancel the active run through no-mistakes axi's supported abort command, and confirm through axi status that the run has stopped before changing any code.
+   That single supported abort is the only permitted intervention: do not hand-edit, commit, restart, or start a second validation run while the obsolete run still owns the branch.
+2. **Settle ownership.**
+   Follow `branch_sync.next_action` from structured axi status.
+   Use axi sync's supported guarded recovery only when its code is `recover_custody`.
+   Otherwise proceed only when structured status confirms that branch ownership is already returned and no recovery is required.
+3. **Replace, do not build on.**
+   Custody recovery settles branch ownership, not content.
+   Replace the obsolete work from the correct pre-invalidation base rather than building on top of the recovered-but-obsolete head, keeping the obsolete run's own pipeline-fix commits out of what gets validated and shipped.
+4. **Revalidate once.**
+   Once ownership is settled, validate exactly once against that final head so no obsolete or intermediate head is ever treated as authoritative.
+
+## Duplicated pipeline ownership
+
+A worker hand-editing, committing, aborting, or restarting during an active validation run outside the sequence above has duplicated pipeline ownership.
+Steer it back to the gate response flow rather than letting a second owner accumulate commits under the run.

--- a/.agents/skills/validation-run-changes/SKILL.md
+++ b/.agents/skills/validation-run-changes/SKILL.md
@@ -44,7 +44,4 @@ When that happens, the worker follows this sequence exactly and in order.
 4. **Revalidate once.**
    Once ownership is settled, validate exactly once against that final head so no obsolete or intermediate head is ever treated as authoritative.
 
-## Duplicated pipeline ownership
-
-A worker hand-editing, committing, aborting, or restarting during an active validation run outside the sequence above has duplicated pipeline ownership.
-Steer it back to the gate response flow rather than letting a second owner accumulate commits under the run.
+A worker that hand-edits, commits, aborts, or restarts outside this exact sequence while a run still owns the branch has duplicated pipeline ownership; `AGENTS.md` section 7 owns the steer-back-to-gate-flow response.

--- a/.opencode/plugins/fm-primary-cd-check.js
+++ b/.opencode/plugins/fm-primary-cd-check.js
@@ -13,7 +13,16 @@ import { spawn } from "node:child_process";
 
 function runProcess(command, args) {
   return new Promise((resolvePromise) => {
-    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let child;
+    try {
+      // Same Windows fail-open guard as fm-primary-pretool-check.js: a
+      // synchronous spawn throw (EFTYPE/BAD_EXE_FORMAT for .sh targets) must
+      // never abort the agent's bash tool call.
+      child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    } catch {
+      resolvePromise({ code: 0, stdout: "", stderr: "" });
+      return;
+    }
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (chunk) => {

--- a/.opencode/plugins/fm-primary-pretool-check.js
+++ b/.opencode/plugins/fm-primary-pretool-check.js
@@ -13,7 +13,18 @@ import { spawn } from "node:child_process";
 
 function runProcess(command, args) {
   return new Promise((resolvePromise) => {
-    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let child;
+    try {
+      // On Windows, spawning a .sh file directly fails at spawn time. Bun
+      // surfaces that failure as a synchronous throw (EFTYPE/BAD_EXE_FORMAT)
+      // instead of an "error" event, which would otherwise reject this hook
+      // and abort every agent bash call. Fail open exactly like the
+      // asynchronous path below.
+      child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    } catch {
+      resolvePromise({ code: 0, stdout: "", stderr: "" });
+      return;
+    }
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (chunk) => {

--- a/.opencode/plugins/fm-primary-sessionstart-nudge.js
+++ b/.opencode/plugins/fm-primary-sessionstart-nudge.js
@@ -6,7 +6,16 @@ const handledSessions = new Set();
 
 function runProcess(command, args) {
   return new Promise((resolveResult) => {
-    const child = spawn(command, args, { stdio: ["ignore", "pipe", "ignore"] });
+    let child;
+    try {
+      // Same Windows fail-open guard as fm-primary-pretool-check.js: a
+      // synchronous spawn throw (EFTYPE/BAD_EXE_FORMAT for .sh targets) must
+      // never reject this hook.
+      child = spawn(command, args, { stdio: ["ignore", "pipe", "ignore"] });
+    } catch {
+      resolveResult({ code: 0, stdout: "" });
+      return;
+    }
     let stdout = "";
     child.stdout.on("data", (chunk) => {
       stdout += chunk.toString();

--- a/.opencode/plugins/fm-primary-turnend-guard.js
+++ b/.opencode/plugins/fm-primary-turnend-guard.js
@@ -9,9 +9,18 @@ let skipNextIdle = false;
 
 function runProcess(command, args, input = "") {
   return new Promise((resolve) => {
-    const child = spawn(command, args, {
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    let child;
+    try {
+      // Same Windows fail-open guard as fm-primary-pretool-check.js: a
+      // synchronous spawn throw (EFTYPE/BAD_EXE_FORMAT for .sh targets) must
+      // never reject this hook.
+      child = spawn(command, args, {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch {
+      resolve({ code: 0, stdout: "", stderr: "" });
+      return;
+    }
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (chunk) => {

--- a/.opencode/plugins/fm-primary-watch-arm.js
+++ b/.opencode/plugins/fm-primary-watch-arm.js
@@ -49,10 +49,19 @@ function waitForArmReady(armChild) {
 
 function runProcess(command, args, options = {}) {
   return new Promise((resolve) => {
-    const proc = spawn(command, args, {
-      stdio: ["ignore", "pipe", "pipe"],
-      ...options,
-    });
+    let proc;
+    try {
+      // Windows fail-open guard matching fm-primary-pretool-check.js: a
+      // synchronous spawn throw resolves exactly like the asynchronous
+      // "error" event below instead of rejecting the caller.
+      proc = spawn(command, args, {
+        stdio: ["ignore", "pipe", "pipe"],
+        ...options,
+      });
+    } catch (error) {
+      resolve({ code: 127, stdout: "", stderr: String(error?.message ?? error) });
+      return;
+    }
     let stdout = "";
     let stderr = "";
     proc.stdout.on("data", (chunk) => {
@@ -342,12 +351,6 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
     FM_CONFIG_OVERRIDE: paths.config,
     FM_WATCH_PREDECESSOR_ARM_PID: predecessorArmPid,
   };
-  const armChild = spawn("bash", ["-lc", 'config_dir="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"; [ -f "$config_dir/x-mode.env" ] && . "$config_dir/x-mode.env"; exec "$FM_ROOT_OVERRIDE/bin/fm-watch-arm.sh" --restart'], {
-    cwd: paths.root,
-    env,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  child = armChild;
   let stdout = "";
   let stderr = "";
   let settled = false;
@@ -357,7 +360,6 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
   const readiness = new Promise((resolve) => {
     resolveReadiness = resolve;
   });
-  armReadiness.set(armChild, readiness);
   const settleReadiness = (status) => {
     if (readinessSettled) return;
     readinessSettled = true;
@@ -366,10 +368,39 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
   const closed = new Promise((resolveClosedChild) => {
     resolveClosed = resolveClosedChild;
   });
-  armClose.set(armChild, closed);
-  const releaseChild = () => {
-    if (child === armChild) child = null;
+  const releaseChild = (finishedChild) => {
+    if (child === finishedChild) child = null;
   };
+  let armChild = null;
+  try {
+    // Windows fail-open guard matching fm-primary-pretool-check.js: a
+    // synchronous spawn throw routes through the same failure path as the
+    // asynchronous "error" handler below.
+    armChild = spawn("bash", ["-lc", 'config_dir="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"; [ -f "$config_dir/x-mode.env" ] && . "$config_dir/x-mode.env"; exec "$FM_ROOT_OVERRIDE/bin/fm-watch-arm.sh" --restart'], {
+      cwd: paths.root,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    settled = true;
+    resolveClosed();
+    settleReadiness("failed");
+    if (restorationInFlight) {
+      setArmStatus("failed");
+      return null;
+    }
+    void scheduleRetry(
+      paths,
+      sessionID,
+      client,
+      `watcher: FAILED - OpenCode arm child failed to launch: ${String(error?.message ?? error)}`,
+      "",
+    );
+    return null;
+  }
+  child = armChild;
+  armReadiness.set(armChild, readiness);
+  armClose.set(armChild, closed);
   const observeRecovery = () => {
     const recovery = `${stdout}\n${stderr}`.match(/^watcher: started pid=([0-9]+).* recovery-generation=([A-Za-z0-9._-]+)$/m);
     if (recovery) armRecovery.set(armChild, { watcherPid: recovery[1], generation: recovery[2] });
@@ -388,7 +419,7 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
     if (settled) return;
     settled = true;
     resolveClosed();
-    releaseChild();
+    releaseChild(armChild);
     const classification = classifyArmClose(stdout, stderr, code, signal);
     settleReadiness(classification.kind === "actionable" ? "wake" : "failed");
     const predecessor = String(armChild.pid ?? "");
@@ -426,7 +457,7 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
     if (settled) return;
     settled = true;
     resolveClosed();
-    releaseChild();
+    releaseChild(armChild);
     settleReadiness("failed");
     if (restorationInFlight) {
       setArmStatus("failed");

--- a/.opencode/plugins/lib/fm-operational-input.js
+++ b/.opencode/plugins/lib/fm-operational-input.js
@@ -13,9 +13,19 @@ export function encodeFirstmateOperationalInput(root, kind, content) {
     const script = existsSync(requested)
       ? requested
       : `${adapterRoot}/bin/fm-operational-input.sh`;
-    const child = spawn(script, ["encode", kind], {
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    let child;
+    try {
+      // Windows fail-open guard matching the fm-primary-* plugins: spawning a
+      // .sh directly can throw synchronously (EFTYPE/BAD_EXE_FORMAT) instead
+      // of emitting an "error" event; surface that through the same rejection
+      // path rather than crashing the calling hook.
+      child = spawn(script, ["encode", kind], {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (error) {
+      reject(error);
+      return;
+    }
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (chunk) => {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Never add an agent name as a commit co-author.
 
 ## 2. Layout and state
 
-`docs/configuration.md` is the single owner of the top-level operational-home layout and configuration schemas; each producing script's header and help own exact child fields and mutation mechanics.
+[`docs/configuration.md`](docs/configuration.md) is the single owner of the operational-home layout and of every configuration schema; each producing script's header and help own exact child fields and mutation mechanics.
 `FM_HOME` selects an instance's private `data/`, `state/`, `config/`, and `projects/`, while scripts continue to come from their tracked code root.
 Each secondmate has a persistent isolated `FM_HOME`, including its own state, backlog, projects, and session lock.
 `bin/fm-send.sh` fails closed unless `FM_HOME` is explicit, so a steer cannot silently resolve against another home.
@@ -58,132 +58,63 @@ AGENTS.md            this file (CLAUDE.md is a real @AGENTS.md pointer to it)
 CONTRIBUTING.md      contributor workflow and repo conventions
 README.md            public overview and development notes
 .github/workflows/   shared CI and PR enforcement, committed
-.tasks.toml          tracked tasks-axi markdown backend config for the default backlog backend (section 10)
+.tasks.toml          tracked tasks-axi config for the default backlog backend (section 10)
 .agents/skills/      firstmate-loaded internal skills, committed; each carries metadata.internal=true for installers
 .claude/skills       symlink to .agents/skills for claude compatibility
 skills/              standalone public installer-facing skills, committed; not loaded by firstmate
 bin/                 helper scripts, committed; read each script's header before first use
 .env                 optional Relay pairing token; LOCAL, gitignored; presence-gates section 14
-config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited as the literal file: a concrete primary adapter value also controls a secondmate home's own crewmates (section 4)
-config/crew-dispatch.json  optional crewmate dispatch profiles; LOCAL, gitignored; firstmate-maintained but human-editable natural-language rules that choose a per-task harness/model/effort profile (section 4). Inherited by secondmate homes
-config/secondmate-harness  harness the PRIMARY uses to launch SECONDMATE agents, optionally followed by a model and effort token on the same line ("<harness> [<model>] [<effort>]"; section 4); LOCAL, gitignored; absent or "default" harness falls back to config/crew-harness then firstmate's own. The primary's own setting; NOT inherited into secondmate homes (secondmates do not spawn secondmates)
-config/backlog-backend  backlog backend override; LOCAL, gitignored; absent or "tasks-axi" = default tasks-axi backend, "manual" = force routine backlog updates to hand-editing; inherited by secondmate homes (section 10)
-config/backend  runtime session-provider backend override for new tasks; LOCAL, gitignored; absent = falls through to runtime auto-detection (the runtime firstmate itself is executing inside), then tmux; tmux is the verified reference backend (docs/tmux-backend.md), while herdr, zellij, orca, and cmux are experimental spawn backends (docs/herdr-backend.md, docs/zellij-backend.md, docs/orca-backend.md, docs/cmux-backend.md) - herdr and cmux can also be selected by runtime auto-detection, zellij and orca never are (always explicit), and codex-app is not accepted; see docs/codex-app-backend.md; inherited by secondmate homes under the primary-authoritative contract in secondmate-provisioning
-config/calm     Pi Calm presentation preference; LOCAL, gitignored, and not inherited; see docs/configuration.md "Pi Calm preference"
-config/supervision-branch-model config/supervision-branch-effort  Pi supervision-branch model and reasoning-effort pins written by /supervision-model; LOCAL, gitignored, independently settable, and not inherited; see docs/configuration.md "Pi supervision branch model and effort"
-config/startup-memory-budget     primary-authoritative per-home startup-memory budget; LOCAL, gitignored, materialized as 7,500 estimated tokens by locked primary bootstrap and inherited into secondmate homes; see docs/configuration.md "Startup memory budget"
-config/stow-pass-horizon  optional presence flag opting this home in to /stow's default-off pass-count decay horizon; LOCAL, gitignored, and not inherited; see docs/configuration.md "Stow pass horizon"
-config/herdr-presentation-spaces  optional "off" opt-out from, or "on" opt-in to, Herdr's default-on disposable single-task visual projection, which is unconfigured-default-on only at or above a Herdr version floor; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Presentation spaces"
-config/trace-context  optional presence flag enabling default-off native W3C trace-context propagation to spawned agents; LOCAL, gitignored; inherited by secondmate homes; see docs/configuration.md "Trace context propagation" and docs/trace-context.md
-config/turnend-churn-absorb  optional presence flag opting this home into the default-off absorb of bare turn-end wakes on pane churn; LOCAL, gitignored, and not inherited; see docs/configuration.md "Turn-end pane-churn absorb"
-config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
-config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
-config/watched-tools.json  optional list of the tools this home depends on, read by the update check armed with bin/fm-tool-update-check.sh; LOCAL, gitignored, firstmate-maintained but human-editable, and NOT inherited by secondmate homes; see docs/configuration.md "Watched tool updates"
-config/x-mode.env    generated Relay watcher cadence; LOCAL, gitignored; source before arming watcher when present
+config/              local operating choices; LOCAL, gitignored; docs/configuration.md owns every option, its default, and whether a secondmate home inherits it
 data/                personal fleet records; LOCAL, gitignored as a whole
-  backlog.md         task queue, dependencies, history
-  captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
-  captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
-  learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
-  projects.md        thin fleet navigation registry recording each project's standing delivery posture; firstmate-private, parsed for mechanical sync and seeding by fm-project-mode.sh (section 6)
-  secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
+  backlog.md         task queue, dependencies, history (section 10)
+  captain.md         this home's domain-local captain preferences and working style
+  captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes
+  learnings.md       curated fleet-local operational facts; created lazily, absent until this home has one to store
+  projects.md        fleet navigation registry recording each project's standing delivery posture (section 6)
+  secondmates.md     local and remote secondmate routing table (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
 projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
 state/               runtime records and signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
-  <id>.turn-ended    touched by turn-end hooks
-  <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
-  <id>.muse-session  muse busy-source binding (sessions root plus task worktree) written by fm-spawn; removed by teardown
-  <id>.cursor-session  cursor busy-source binding (projects root, task worktree, prior conversations) written by fm-spawn; removed by teardown
-  <id>.reconcile-nudged  epoch second of the last inventory-reconcile nudge sent to this secondmate; bin/fm-secondmate-reconcile.sh owns its per-home cooldown window
-  <id>.backlog-close  the exact backlog close a teardown recorded before removing the task's record, so an interrupted cleanup can still be finished at the next session start; bin/fm-backlog-transition-lib.sh owns its format and replay, and a landed close removes it
-  <id>.inbox/          durable steering inbox: sequenced firstmate instruction records the worker acknowledges by moving them into its handled/ subdirectory; written by fm-send, with ordinary records re-rung and escalated by the watcher while explicit fire-and-forget records are excluded from that ladder, and removed by teardown (bin/fm-task-inbox-lib.sh)
-  <id>.meta          task metadata; each producer script's header owns its exact fields and mutation contract, with docs/configuration.md routing operator-facing backend and trace-context details
-  <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Presentation spaces"
-  <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified Relay shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
-  <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
-  <id>.pr-poll       private validated data sidecar for the byte-static PR merge poll
-  <id>.pr-poll-registration  private transactional provenance record binding the task, canonical metadata identity, sidecar, and static poll publication
-  <id>.pr-poll-retirement  private identity-bound crash-recovery receipt for one exact validated merged result; removed after its poll artifacts retire
-  <id>.pr-poll-merge-notified  canonical PR identity of the last merge outcome delivered for this task; bin/fm-pr-lib.sh owns the marker format and identity mechanics, while bin/fm-merge-outcome-lib.sh owns locked publication, duplicate suppression, and replacement
-  branch-outcomes.jsonl .branch-outcomes-cursor  Pi supervision-branch durable outcome store and its read cursor; bin/fm-branch-outcome.sh owns the format
-  branch-session/ .branch-session .branch-mirror-cursor  the branch's persistent conversation, its pointer, and the dialog-mirror cursor; extension-owned (docs/pi-supervision-branch.md)
-  .branch-eligible-rows .branch-eligible-owner .main-eligible-rows  per-actor wake-row claims and branch-owner evidence; docs/watcher-continuity.md owns the acknowledgement contract
-  .lease-<task>        per-task supervision lease naming which actor (main or branch) may change that task; bin/fm-lease-lib.sh owns the contract the guarded scripts enforce
-  x-watch.check.sh   generated Relay poll shim; present only when opted in (section 14)
-  tool-updates.check.sh  generated watched-tool update poll shim and its .check-trust binding; present only after bin/fm-tool-update-check.sh arm; its report record .tool-updates is what keeps one pending update from being reported on every poll
-  pending-replies/   parent-owned secondmate pending-reply records (correlation id, delivery vs reply, recovery, escalation); fm-pending-reply-lib.sh
-  procevent/         registered process-to-event sources, one private record per canonical source id; written only by bin/fm-procevent.sh, and their presence alone keeps supervision required (section 13)
-  procevent-inbox/   private captured results and their durable handled-acknowledgement markers; source output lives here and never in an event line
-  decision-bindings/ private records marking a captured-answer source as feeding the keyed-answer intake, with a legacy origin on pre-collapse records; written only by bin/fm-captain-hold.sh bind, dropped by unbind and by source retirement (section 13; docs/captain-hold-lifecycle.md)
-  when/              private condition->action watch specs, their trust bindings, and single-fire markers; written only by bin/fm-procevent-when.sh (section 13's process-event-sources trigger)
-  inbox/             captain notes captured out of band by bin/fm-inbox.sh, including the voice handover's queued requests; each note appends one `check` wake and stays pending until acknowledged with `bin/fm-inbox.sh drain --ack <id>`, which moves it to inbox/handled/ (docs/voice-relay.md)
-  x-inbox/           generated Relay pending mention payloads; fmx-respond drains it (section 14)
-  x-context/         generated Relay durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)
-  x-outbox/          generated Relay dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
-  public-followup/   generated private transport for promised public replies: retained open-loop registrations, typed terminal-result inbox, accepted/rejected ledgers, and retirement receipts (section 14; bin/fm-public-followup.sh)
-  x-poll.error x-poll.claim-error  generated Relay and offer-claim diagnostic dedupe markers
-  .startup-network.*  status, report, per-step elapsed timings, inline-print claim, and lock for the deferred network stage session start runs off its blocking path; bin/fm-startup-network.sh
-  .wake-queue        durable queued wakes retained until post-handling acknowledgement: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
-  .watcher-down      private generation-bound recovery state coupling watcher downtime, durable wake presentation, and post-handling acknowledgement; never touch
-  .<id>.open-decisions-cursor  per-task byte cursor and folded open-decision set bounding the OPEN DECISIONS scan's cost to new status-log appends; written only by fm-classify-lib.sh's status_open_decisions_incremental, removed by teardown, safe to delete (forces one full re-fold)
-  .status-presentation-cursor .status-presentation-lock  fleet-wide per-task status identity/byte-offset manifest and serialization lock preventing already-presented status lines from being replayed as new; owned by fm-classify-lib.sh, with each task's row retired by teardown
-  .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
-  .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
-  .claude-autoarm.lock .claude-autoarm-epoch .claude-autoarm-failure-notified .claude-autoarm-failure-alarmed .turnend-claude-blocks .turnend-claude-blocks.lock   Claude Stop auto-arm single-flight, epoch, failure-episode, attended-alarm, guard-budget, and budget-lock records; never touch
-  .cursor-park-owner .cursor-park-owner.lock .turnend-cursor-blocks   Cursor stop-hook owner record, publication and commit lock, and bounded repair-nag budget; never touch
-  .hash-* .count-* .stale-* .stale-since-* .churn-since-* .paused-* .wedge-escalations-* .writing-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
-  .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
-  .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
-  .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
+  <id>.meta          task metadata; each producer script's header owns its fields and mutation contract
+  <id>.check.sh      authenticated slow poll; the watcher runs trusted repository scripts, the byte-identified Relay shim, and hash-validated registered custom checks, and rejects every other state check without execution
+  .wake-queue        durable queued wakes retained until post-handling acknowledgement (section 8)
+  .afk               durable away-mode flag; present = sub-supervisor may inject escalations (section 8)
+  inbox/             captain notes captured out of band by bin/fm-inbox.sh (section 8)
+  procevent/         registered process-to-event sources (section 13)
 .no-mistakes/        local validation state and evidence; gitignored
 ```
 
-A `state/<id>.status` line is a wake event, not current-state truth; `bin/fm-crew-state.sh` owns current-state reconciliation.
-Treat `data/captain.md` as the domain-local record of captain preferences, optional `data/captain-shared.md` as the main-authoritative shared captain-preference file for secondmate inheritance, and `data/learnings.md` as curated home-local knowledge, regardless of harness memory.
+Everything else under `state/` - the watcher, wake, lease, supervision-branch, turn-end, PR-poll, steering-inbox, pending-reply, Relay, decision-binding, and away-mode records - is written and retired only by its owning script, and each script's header owns that record's format.
+Never hand-edit one and never hand-compose a removal against `$STATE`/`$ID`: retire a spawned task's records through `bin/fm-teardown.sh` and a custom check through `bin/fm-check-unregister.sh`.
+`data/captain.md`, `data/captain-shared.md`, and `data/learnings.md` are canonical regardless of what harness memory holds.
 
 ## 3. Session start (run once at every session start)
 
 Run `bin/fm-session-start.sh` exactly once at session start.
-Its header is the single owner of composed commands, ordering, and digest contents.
-`bin/fm-supervision-instructions.sh` renders the emitted supervision block from `docs/supervision-protocols/`.
+Its header is the single owner of the composed commands, stage ordering, and digest contents, and `bin/fm-supervision-instructions.sh` renders the emitted supervision block from `docs/supervision-protocols/`.
 Do not reimplement it by separately running its lock, bootstrap, initial wake-drain, or deferred-network components.
 Run-tier harness surfaces run this command for you at session open while the rest only nudge it, so confirm the digest is present in this session and run it yourself when it is not; `docs/sessionstart-nudge.md` owns adapter tiers, source routing, and compatibility.
 
 Read the complete digest once and trust it as this turn's startup and recovery input.
 If the harness shows only a preview and persists the full output to a file, read that file before acting.
 Do not separately re-read the context, backlog, metadata, or bulk status inputs it just printed unless a source was reported absent or corrupt, older history is specifically needed, or a targeted workflow must inspect before writing.
-An `ABSENT` captain, shared-captain, secondmate, or learnings file means the firstmate repo's built-in defaults, no shared captain preferences, no registered secondmates, or no captured learnings; rebuild an absent or stale project registry from the clones before dispatch.
+An `ABSENT` marker is meaningful and never means empty: an absent captain, shared-captain, secondmate, or learnings file means the firstmate repo's built-in defaults, no shared captain preferences, no registered secondmates, or no captured learnings, and an absent or stale project registry must be rebuilt from the clones under `projects/` before dispatch.
+The digest's per-task endpoint line is a cheap presence check only; read a crew's actual current state with `bin/fm-crew-state.sh <id>` whenever action depends on it.
 
 If the session lock cannot be acquired and verified, report its exact diagnostic and remain read-only; another active session is only one possible cause.
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.
+Every mutating startup sweep, and the wake-queue drain itself, therefore runs only when this session actually holds the lock; a read-only session still sees the guard's tangle and watcher-liveness alarms, as advisory text carrying no repair command.
+
+The digest presents the durable wake queue ahead of both digests and prints its raw records as this turn's first work queue.
+Section 8 owns how to handle, reconcile, and acknowledge everything that drain prints, and session start is the one exception to draining it yourself first.
+The digest never starts supervision; arm it through the emitted harness block under section 8.
 
 The digest itself makes no external-network call and never waits for one.
-Every network check a session start owes - GitHub auth, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh - runs off the digest's blocking path in a bounded worker owned by `bin/fm-startup-network.sh` and is reported in the digest's own `NETWORK CHECKS` section.
-When that section reports its checks still in progress it names exactly what is unconfirmed; treat none of those as passed until `bin/fm-startup-network.sh report` returns the finished result, while a failed or otherwise actionable result also arrives as a `check: startup-network` wake.
-
-1. **Lock** - acquires the per-home session lock first, before anything mutates shared state, then starts the deferred network stage above.
-2. **Bootstrap** - detect-only checks (tool/version problems, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
-   When the lock could not be acquired, the worktree-tangle check uses read-only advisory wording without a checkout repair command.
-   Home-local stale Herdr projection cleanup and the six bootstrap MUTATING sweeps - same-home backlog reconciliation, fleet sync, secondmate convergence, secondmate liveness, pending remote handoff retry, and Relay artifact writes - run only when this session actually holds the lock from step 1; the four network ones among them run in the deferred stage rather than in this section.
-   The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous, unreadable, or unreachable remote targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`; `docs/remote-secondmates.md`).
-3. **Wake queue** - when locked, presents the durable wake queue and prints the raw records prominently as this turn's first work queue; a clearly labeled status-event annotation may follow a valid `signal` record and includes every status line still unread at the presentation cursor, but never replaces the raw record or current-state reconciliation, and a lapsed watcher chain still surfaces here via the same guard alarm.
-   Presented records remain durable until the handling turn runs the generation-bound acknowledgement printed by the drain.
-   Every locked drain also prints a bounded fleet-wide `OPEN DECISIONS` section when durable decision records remain open, including when the queue itself is empty; reconcile those entries before continuing.
-   The same drain prints every still-unread `note:` line and pending-reply resolution since the last presentation in an unbounded `UNREAD STATUS` section, so an answer buried under a later routine line is not dropped; those lines are not re-printed after that presentation.
-   It also prints a bounded `RECORD DIVERGENCE` section naming every captain call the status log reads as resolved while its backlog task is still held; nothing is closed for you, and `captain-hold-lifecycle` owns the reconciliation.
-   When the lock could not be acquired and verified, the queue is left untouched because no session mutation is authorized, and the guard's tangle/watcher-liveness alarms still print in read-only advisory mode without drain, supervision repair, or checkout repair commands.
-4. **Supervision operating instructions** - after the wake queue and before both digests, the digest emits exactly one operating block for the detected primary harness, followed by the read-once contract that governs them.
-   The script itself never starts supervision; the emitted harness protocol owns the exact wait or wake mechanism.
-5. **Fleet-state digest** - after that read-once contract and ahead of the context digest, the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
-   That liveness line is a fast presence check only, not a full state read - when you need a crew's actual current state (a run-step, not just "is the pane there"), read it with `bin/fm-crew-state.sh <id>` as before; the digest deliberately skips that deeper, slower read for every task so it stays fast and bounded.
-6. **Network checks** - after the fleet-state digest, the deferred stage's result, or an explicit statement of what it has not confirmed yet.
-   A read-only session runs no network checks at all and says so.
-7. **Context digest and next step** - last of the bulk sections, the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited, followed by the closing reminder.
-   A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
-   The closing reminder points back to the emitted supervision block and preserves only the lock, afk, Relay, and read-once reminders.
+Every network check a session start owes runs off its blocking path in the bounded worker owned by `bin/fm-startup-network.sh`, whose header owns that check list, and is reported in the digest's own `NETWORK CHECKS` section.
+Treat nothing that section reports as still in progress as passed until `bin/fm-startup-network.sh report` returns the finished result; a failed or otherwise actionable result also arrives as a `check: startup-network` wake.
+A read-only session runs no network checks at all and says so.
 
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.
@@ -201,18 +132,9 @@ If static `config/crew-harness` or `config/secondmate-harness` names an unverifi
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.
 When dispatch profiles exist, consult them at every crewmate or scout intake and pass the resolved concrete profile required by `fm-spawn`.
 Routing precedence is an explicit per-task captain override, then the best-fit configured rule, then the configured default, then the static crewmate harness.
-Firstmate alone resolves a matched profile array: begin with `quota-axi`'s default TOON at that intake, using the skill's narrow TOON-then-`--json` fallback only for genuine ambiguity, evaluate every configured candidate against that current output, and choose with inspectable `spendPriority` as the one quota-perspective ranker after the skill's eligibility, reasoning-class, and runway-feasibility gates.
-Account for every candidate with the catalog evidence, provider relationship, applicable quota and authentication facts, remaining uncertainty, fit and reasoning class, and the spendPriority and runway evidence used in selection; never omit a candidate, guess, fall back silently, or call the result quota-informed without them.
-Establish model support and provider family from that harness's own authoritative catalog, then read `quota-axi` at the granularity the vendor actually supplies: provider-level or all-model evidence applies to every model established in that family, and a named-model window bounds only that model.
-Missing model-level quota, a missing authentication source, unmeasurable headroom, or unmodeled authentication is disclosed uncertainty that keeps a candidate eligible, never a credential or login escalation.
-Only concrete contradictory evidence blocks a candidate, such as an authoritative catalog proving the model unsupported or proof that the credential selected for that surface is unusable; never infer a credential store, provider family, or quota mapping from a harness, model, or source name, and never launch another harness's CLI to judge a candidate.
 Preserve malformed profile configuration as an actionable error rather than selecting around it.
-When every candidate is tight, preserve the captain's strongest-reasoning class rather than silently downgrading it solely to conserve quota; stop and report the tight choice if that class cannot proceed.
-Break genuine evidence ties without array-order or harness bias.
-`quota-axi` owns how model or product windows relate to bounding account windows and remains data-only.
-Load `quota-array-dispatch` before choosing among a matched profile array; that skill is the single owner of the TOON-first spendPriority selection procedure.
-The generic effort fallback and its precedence are owned by `harness-adapters`: explicit captain and standing configured effort win; otherwise use low for well-understood explicit work, xhigh for ambiguous investigation or design, intermediate levels proportionally, and never max without explicit captain preference.
-Do not add model-specific versions of that policy.
+Firstmate alone resolves a matched profile array: load `quota-array-dispatch`, the single owner of that selection procedure, and follow it rather than guessing, ranking by hand, or falling back silently.
+`harness-adapters` owns the generic effort fallback and its precedence; do not add model-specific versions of that policy.
 
 `secondmate-provisioning` owns secondmate harness pins and inherited local material, while `harness-adapters` owns the harness consequences.
 Dispatch only on a backend that `fm-spawn` validates as spawn-capable; pass an explicit per-spawn `--backend` only under that exact task's own authority, never as later-task precedent (selection contract: [`docs/configuration.md`](docs/configuration.md) "Runtime backend").
@@ -221,13 +143,11 @@ A missing dependency, authentication failure, unsupported backend, or version re
 ## 5. Recovery
 
 After the one session-start digest, reconcile reality with durable records before taking new work.
-Honor lock-refused read-only mode exactly as section 3 requires.
-Treat digest status tails as wake-event history and use targeted current-state reconciliation when the live state matters.
+Honor lock-refused read-only mode exactly as section 3 requires, and reconcile current state under section 8 wherever action depends on it.
 
 Reconcile only this home's recorded direct reports and their recorded backend inventory; never sweep a shared endpoint namespace for matching names or claim another home's work.
 For an ordinary direct report whose endpoint is dead or metadata has no window, load `stuck-crewmate-recovery` and preserve the recorded worktree and unlanded work while reconciling ownership.
 For a dead secondmate direct report, load `secondmate-provisioning` and reconcile only that secondmate, never its whole child tree from the main home.
-Each secondmate reconciles work already in its own home and then idles; recovery never authorizes it to invent work.
 
 If away mode is present, load `/afk` and let its daemon own supervision rather than arming another cycle.
 Surface only captain-relevant decisions, review-ready PRs, failures, and credential needs; otherwise resume the emitted supervision protocol silently.
@@ -241,8 +161,6 @@ That skill owns registry syntax, delivery-mode selection, outward-facing consent
 Project creation never authorizes an unmentioned remote, and project removal never bypasses that preflight or unlanded-work checks; hard rule 1's concrete captain-approved project operation exception remains available when its exact conditions are met.
 
 Load `secondmate-provisioning` before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
-Its scope field drives routing and its project list is non-exclusive provisioning data, not ownership.
-Keep `local-only` work in the main home.
 
 A secondmate is idle by default and acts only on work routed by the main firstmate.
 It reconciles its own work under way after restart, then waits silently; an empty queue never authorizes a survey, audit, or self-directed improvement sweep.
@@ -274,7 +192,7 @@ Proceed on one confident match while naming the project in plain language; ask o
 
 Route by the nature of the work against each registered secondmate scope, not by a non-exclusive clone list.
 Keep `local-only` work in the main home.
-Send in-scope work to the fitting secondmate unless it is blocked or the captain explicitly redirects it; do not read the secondmate's chat because marked routed replies return through its status or referenced document.
+Send in-scope work to the fitting secondmate unless it is blocked or the captain explicitly redirects it.
 If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.
 For one-off or infrequent operational work, start with the simplest direct end-to-end path.
 Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.
@@ -309,13 +227,12 @@ When the configured tasks-axi backlog gate applies, the spawn itself moves the w
 After spawning, confirm the worker is processing the brief and handle any trust dialog through `harness-adapters`.
 A persistent secondmate is recorded in the secondmate registry and runtime state, never as a backlog work item.
 
-Steer a worker with ordinary text through fail-closed `fm-send`: the message becomes a durable record in the task's steering inbox (multi-line text is legal, local and remote alike) and the worker's terminal receives only a constant doorbell line, with the watcher re-ringing an unacknowledged local message and escalating a stuck one (`bin/fm-task-inbox-lib.sh`; `bin/fm-send.sh` owns the typed-plane carve-outs).
-A remote secondmate steer rides the same durable-inbox model through the remote transport; after an unconfirmed delivery, only the exact `FM_PENDING_REPLY_EXISTING_CORR=<id>` resend command printed by `fm-send` is safe because it preserves the request body for remote enqueue deduplication (`bin/fm-send.sh` header).
-When a steer answers an open keyed decision or blocker, pass `fm-send`'s `--resolve-key` so the answer itself closes that decision record at answer time, identically for local and remote workers (contract: `bin/fm-send.sh` header).
+Steer a worker with ordinary text through fail-closed `fm-send`: the message becomes a durable record in the task's steering inbox and the worker's terminal gets only a doorbell line, for local and remote workers alike.
+`bin/fm-send.sh`'s header owns delivery, the re-ring ladder, the remote resend contract, and the typed-plane carve-outs; never improvise a resend around it.
+When a steer answers an open keyed decision or blocker, pass `fm-send`'s `--resolve-key` so the answer itself closes that decision record at answer time.
 `fm-send` is the data plane for text the worker should read; never use its key or text paths for interrupt, exit, or other lifecycle control, because routing-marked lifecycle text becomes chat the worker reasons about instead of executing.
 Drive a worker's lifecycle through `bin/fm-control.sh <task-id> interrupt|exit|relaunch`, which owns the per-runtime mechanics, verifies each action, and never tears down or discards anything ([`docs/agent-control.md`](docs/agent-control.md)).
-A secondmate's routed reply returns through status or a document pointer, not by firstmate peeking into its chat.
-For the parent-owned correlation, recovery, and escalation contract on marked secondmate requests, see `bin/fm-pending-reply-lib.sh`.
+A secondmate's routed reply returns through status or a document pointer, not by firstmate peeking into its chat; `bin/fm-pending-reply-lib.sh` owns the parent-side correlation, recovery, and escalation contract on marked requests.
 Supervise all live work under section 8.
 
 ### Selected delivery path and merge authority
@@ -335,7 +252,6 @@ Delivery mode and `yolo` are orthogonal.
 `yolo` governs merge authority only: with it off, the captain approves every PR merge and every local-only landing; with it on, firstmate merges green, in-scope work itself.
 Never merge a red PR under either setting; destructive, irreversible, and security-sensitive merges still escalate.
 Without a current explicit captain instruction that states the concrete merge, that default stands, and standing `yolo` cannot authorize a red merge; section 1 owns when such an instruction overrides a Firstmate-written standing rule within its exact scope.
-Load `ask-user-authority` before deciding any ask-user finding; the implementation worker never answers its own finding.
 Use `bin/fm-pr-merge.sh` for every task PR merge so merge metadata is recorded and an unproved merge is refused instead of reported as landed, and use `bin/fm-merge-local.sh` for approved local-only landing; never call a lower-level merge command around their guards.
 After an autonomous merge, give the captain a one-line full-URL or local-main outcome.
 
@@ -344,33 +260,21 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
-Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.
+Load `validation-run-changes` before expanding a task under an active validation run and before acting on a captain instruction that invalidates work being validated; nothing outside that skill's sequence authorizes hand-editing, committing, aborting, or restarting while a run still owns the branch, and a worker that does so has duplicated pipeline ownership and must be steered back to the gate response flow.
 
-Only a current, explicit captain instruction that completely invalidates the work being validated keeps the task with the same worker instead of routing it to follow-up work or handing it to a replacement.
-That worker cancels the active run through no-mistakes axi's supported abort command and confirms through axi status that the run has stopped before changing any code.
-The worker then follows `branch_sync.next_action` from structured axi status: use axi sync's supported guarded recovery only when its code is `recover_custody`, and otherwise proceed only when structured status confirms that branch ownership is already returned and no recovery is required.
-Custody recovery settles branch ownership, not content: the worker must replace the obsolete work from the correct pre-invalidation base rather than building on top of the recovered-but-obsolete head, keeping the obsolete run's own pipeline-fix commits out of what gets validated and shipped.
-Apart from that single supported abort, do not hand-edit, commit, restart, or start a second validation run while the obsolete run still owns the branch.
-Once ownership is settled, validate exactly once against that final head so no obsolete or intermediate head is ever treated as authoritative.
-
-An ask-user finding returns as `needs-decision`; firstmate loads `ask-user-authority` and either decides or escalates per that skill.
-Send the same worker one exact decision naming the decision key, step, action, affected finding IDs, instructions where needed, and exact response command, passing `--resolve-key` so the worker's open decision record closes at answer time.
-Require the matching `resolved` event, forbid `--yes`, and require the worker to process every synchronous return until completion or a genuinely new escalation.
+An ask-user finding returns as `needs-decision`; firstmate loads `ask-user-authority`, which owns both the decision itself and how it is delivered back to the worker.
 Resume fleet supervision immediately after the decision lands.
 
-Judge validation by the currently attributed run step through `bin/fm-crew-state.sh`, not by shell liveness or the last status event.
-Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed or checks-passed is done; failed or cancelled is failed.
-A worker hand-editing, committing, aborting, or restarting during an active validation run duplicates pipeline ownership outside the supersession sequence above; steer it back to the gate response flow.
+Judge validation by the currently attributed run step through `bin/fm-crew-state.sh`, whose header owns the run-step-to-state mapping, rather than by shell liveness or the last status event.
 The worker reports the PR when CI first becomes green rather than waiting for merge monitoring to finish.
 
 ### PR ready, landing, and teardown
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
-Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
+Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine merge authority.
-For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
-Retire a custom check only through `bin/fm-check-unregister.sh <id>` (or `bin/fm-teardown.sh` for a spawned task); never hand-compose an `rm` with `$STATE`/`$ID`.
+A custom `state/<id>.check.sh` you write yourself must satisfy the authoring contract in `bin/fm-check-register.sh`'s header and be registered with that script before it may run at all.
 
 Tear down a ship task only after landing is confirmed.
 A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.
@@ -386,15 +290,14 @@ A completed scout must leave a self-contained report before its scratch worktree
 A report may recommend implementation but does not authorize it.
 Before treating the investigation or any visual review as complete, load `captain-hold-lifecycle`; teardown enforces that shared completion gate.
 When a scout's deliverable is a visual artifact the captain will iterate on, prefer keeping that scout alive to host its own Lavish loop rather than tearing it down and mediating from firstmate, so the scout keeps its investigation context and the captain iterates in one continuous session.
-When implementation is separately authorized, promote the existing scout through `bin/fm-promote.sh` rather than creating a duplicate task.
-The promoted worker must inventory scratch state, return to a clean default-branch base, carry over only intended fix changes, create the ship branch, and follow the project's selected delivery path while leaving scratch commits and debug edits behind and turning a reproduced bug into the regression test.
+When implementation is separately authorized, promote the existing scout through `bin/fm-promote.sh` rather than creating a duplicate task; its header owns the ship instructions the promoted worker receives, including the scratch-state inventory, the clean default-branch base, the ship branch, and the mode-specific definition of done.
 
 ## 8. Supervision protocol
 
 Fleet supervision is an always-loaded operational contract; `docs/architecture.md`, `docs/turnend-guard.md`, the emitted session-start block, and script help own mechanisms and harness-specific recipes.
 
 Whenever work is under way, keep exactly one live supervision cycle using the emitted protocol for this primary harness.
-Relay may require that same live cycle with no fleet work.
+Relay, and any registered process-to-event source, requires that same live cycle even with no fleet work.
 Do not substitute another harness's wait shape, use shell `&`, or create a second cycle when a healthy one already exists.
 For every actionable wake, follow the ordinary-wake continuation in the emitted protocol; use its repair action only when the live cycle is missing or failed.
 No turn ends blind while work is under way, including turns described as holding or waiting.
@@ -405,7 +308,7 @@ Treat any `OPEN DECISIONS` section from the drain as actionable reconciliation i
 Treat any `UNREAD STATUS` section as newly surfaced status that must be read this turn; those lines are not re-printed after this presentation.
 Treat any `RECORD DIVERGENCE` section as a contradiction between two records of one captain call, never as proof the captain ruled; load `captain-hold-lifecycle` and reconcile it in whichever direction the evidence supports.
 After handling all emitted wakes and reconciling the OPEN DECISIONS and UNREAD STATUS sections, run the exact generation-bound `--ack-through` command printed as `WAKE_ACK_REQUIRED`; interruption before that acknowledgement deliberately leaves the work durable for idempotent re-handling.
-A status line is a wake event, not current state; use `bin/fm-crew-state.sh` when current state matters, especially before re-escalating an old decision, blocker, or pause.
+A status line is a wake event, not current-state truth; `bin/fm-crew-state.sh` owns current-state reconciliation, so confirm with it before re-escalating an old decision, blocker, or pause.
 A declared `paused:` event means a bounded external wait expected to clear on its own, while `blocked:` means firstmate action is needed.
 
 Handle actionable wakes as follows:
@@ -416,17 +319,16 @@ Handle actionable wakes as follows:
 4. For `heartbeat:`, review the whole fleet from the structured fleet view, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
 
 When any wake reports a merged PR for a project cloned in this home, refresh that clone through the guarded fleet-sync path.
-When Relay-linked work reaches a milestone or terminal state, load `fmx-respond`; before terminal teardown, use its promised-final reconciliation when a typed public commitment exists, otherwise post the final completion follow-up so the link clears even if earlier follow-ups were spent.
+A Relay-linked task's milestone and terminal wakes carry their own obligations; section 14 and the `fmx-respond` trigger in section 13 own them.
 
 A secondmate's idle endpoint is healthy, and parent supervision relies on its routed status rather than treating a quiet pane as stale.
 Waiting on a healthy supervision cycle is silent; empty polls, elapsed time, and no-change updates are not captain-facing progress.
 Never broadly kill watchers, especially never `pkill -f bin/fm-watch.sh`, because that can kill sibling firstmate homes.
 A forced repair must use the home-scoped owner path emitted by supervision instructions.
 
-Guard warnings do not replace the contract.
-Queued wakes must be presented before other action and acknowledged only after handling, stale liveness must be repaired through the emitted protocol, and the worktree-tangle warning must be resolved without touching unlanded work.
-The spawn assertion and generated ship brief must both enforce that project work starts in an isolated disposable worktree, never the primary checkout.
-Harness-aware turn-end guards are structural backstops, not permission to omit the live cycle.
+Guard warnings are structural backstops, not a replacement for the contract above.
+A tangle warning means the primary checkout is stranded on a feature branch: firstmate operates the fleet only from the default branch there, and the guard exists so that restoring it never touches the unlanded work sitting on that branch.
+Harness-aware turn-end guards are likewise no permission to omit the live cycle.
 
 ### Away-mode stub
 
@@ -440,10 +342,6 @@ The skill owns the daemon procedure; these safety facts remain inline:
 - Any other unmarked message means the captain returned; load `/afk`, run the return owner, and do not process that message as ordinary work until its durable catch-up gate clears.
 - Away mode never expands approval authority for merges, ask-user findings, destructive actions, irreversible actions, or security-sensitive choices.
 - Bias ambiguous input toward exit because a present captain takes precedence.
-
-### Stuck-worker trigger
-
-Load `stuck-crewmate-recovery` after a stale wake, looping or confused pane, answered-by-brief question, unresponsive worker, or failed steer.
 
 ## 9. Escalation and captain etiquette
 
@@ -536,9 +434,10 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `HOME_SUMMARY:`, `BACKLOG_RECONCILE:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`), or when `BOOTSTRAP_INFO:` says an interrupted backlog cleanup may have left an endpoint or local copy; silence and other `BOOTSTRAP_INFO:` facts need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints any actionable `PREFIX:` diagnostic line, such as `MISSING:`, `TANGLE:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, or any `SECONDMATE_*:` line, or when `BOOTSTRAP_INFO:` says an interrupted backlog cleanup may have left an endpoint or local copy; the skill's own description carries the full prefix list, and silence or any other `BOOTSTRAP_INFO:` fact needs no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
-- `ask-user-authority` - load before deciding any ask-user finding.
+- `ask-user-authority` - load before deciding any ask-user finding; it also owns how the decision is delivered back to the worker.
+- `validation-run-changes` - load before expanding a task under an active validation run, and before acting on a captain instruction that invalidates work being validated.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi default TOON.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
@@ -549,7 +448,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `captain-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a captain decision, when recording or routing the captain's answer, and on any `RECORD DIVERGENCE` line from the wake drain.
 - `process-event-sources` - load before arming a long-polling source, before registering a deterministic condition->action watch (do X as soon as Y is true), and on any `procevent <adapter> <source-id> <sequence>` check wake.
   Never run a registered source's blocking command yourself in a conversational turn.
-- `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
+- `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, before promising a final public reply, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
 
@@ -560,12 +459,9 @@ Relay ships inert and causes no behavior change until the home opts in by placin
 That token is consent for public replies and normal reversible lifecycle actions from eligible mentions, not authority for destructive, irreversible, or security-sensitive action; those still require trusted-channel confirmation.
 `docs/configuration.md` owns activation, generated state, cadence, wire protocol, and opt-out mechanics.
 
-A Relay-only home still requires the live supervision cycle so mentions can wake it without fleet work.
-On an `x-mention <request_id>` or `x-mode-error ...` check wake, load `fmx-respond`, which owns classification, public-safety policy, reply or dismissal, task linking, and follow-ups.
-For every Relay-linked terminal outcome, load that owner and use the promised-final reconciliation when a typed public commitment exists, otherwise post the final completion follow-up before teardown.
+`fmx-respond` owns mention classification, public-safety policy, reply or dismissal, task linking, and every follow-up, including the promised-final reconciliation before terminal teardown; section 13 owns its load triggers.
 
 A promised final public reply is durable state, never conversation memory.
-Load `fmx-respond` before promising one, on a `public-followup ...` check wake, and whenever the session-start digest lists a public commitment awaiting delivery or an open public loop.
 Only the home holding the relay consent and thread binding ever posts it, so never ask a secondmate or crewmate to find the thread or send the reply, and never recover a terminal result by reading a `done:` sentence.
 
 ## Captain instruction precedence

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2546,6 +2546,43 @@ fm_backend_herdr_send_text_line() {  # <target> <text>
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane run "$FM_BACKEND_HERDR_PANE" "$2" >/dev/null 2>&1
 }
 
+# fm_backend_herdr_treehouse_get: acquire a treehouse worktree and land the
+# pane's shell in it, WITHOUT typing plain `treehouse get` into the pane.
+#
+# Verified live (2026-08-20, herdr 0.8.2-preview, Windows): plain `treehouse
+# get` opens a NEW cmd.exe subshell for the worktree. That child process is
+# invisible to herdr's Windows foreground-process tracking on this build - the
+# terminal visibly shows the worktree prompt, but fm_backend_herdr_current_path
+# keeps reporting the ORIGINAL shell's own pid and cwd forever, so
+# fm-spawn.sh's worktree-discovery poll times out at 60s even though the
+# acquisition genuinely succeeded. `treehouse get --lease` sidesteps the whole
+# problem: it prints the leased worktree's absolute path to stdout (banners go
+# to stderr per its own --help) and returns control to the SAME shell instead
+# of opening a child console, so a plain `cd` into that path is an ordinary
+# same-process cwd change - exactly what process-info tracks correctly.
+#
+# Verified live (2026-08-29, herdr 0.8.2-preview, Windows): the path read must
+# come from an UNWRAPPED snapshot. A spawn pane can be narrower than the leased
+# path (44 columns observed), and the default `recent` source returns the
+# rendered grid, so the path arrives split across two physical rows. The
+# drive-letter match then captured only the first row and produced a truncated
+# directory whose trailing characters were missing, so its `cd` failed and
+# fm-spawn.sh's worktree-discovery poll timed out at 60s - the same visible
+# symptom as the two subshell-tracking variants above, from a different cause.
+# fm_backend_herdr_capture_unwrapped reads logical lines instead.
+fm_backend_herdr_treehouse_get() {  # <target>
+  local target=$1 holder out path
+  holder="fm-${FM_BACKEND_HERDR_PANE}-$$"
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane run "$FM_BACKEND_HERDR_PANE" \
+    "treehouse get --lease --lease-holder $holder" >/dev/null 2>&1 || return 1
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane wait-output "$FM_BACKEND_HERDR_PANE" \
+    --match 'Leased worktree at' --timeout 60000 >/dev/null 2>&1 || return 1
+  out=$(fm_backend_herdr_capture_unwrapped "$target" 200) || return 1
+  path=$(printf '%s\n' "$out" | grep -E '^[A-Za-z]:[\\/]' | tail -1)
+  [ -n "$path" ] || return 1
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane run "$FM_BACKEND_HERDR_PANE" "cd '$path'" >/dev/null 2>&1
+}
+
 # fm_backend_herdr_send_literal: send TEXT as literal, UNSUBMITTED input - the
 # caller sends Enter separately. Mirrors tmux's `send-keys -t T -l text`.
 # Verified: `pane send-text` does NOT auto-submit (contrary to the addendum's
@@ -2601,6 +2638,22 @@ fm_backend_herdr_capture() {  # <target> <lines>
   fetch=$lines
   case "$fetch" in ''|*[!0-9]*) fetch=200 ;; *) [ "$fetch" -ge 200 ] || fetch=200 ;; esac
   out=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane read "$FM_BACKEND_HERDR_PANE" --source recent --lines "$fetch" 2>/dev/null) || return 1
+  printf '%s' "$out" | tail -n "$lines"
+}
+
+# fm_backend_herdr_capture_unwrapped: same bounded capture, but from herdr's
+# `recent-unwrapped` source, which returns LOGICAL lines rather than the
+# rendered grid. Use this whenever the caller parses a single long token - a
+# path, a URL, a commit sha - that a narrow pane would otherwise split across
+# physical rows. Ordinary human-readable peeks keep using
+# fm_backend_herdr_capture so what firstmate reads matches what the pane shows.
+fm_backend_herdr_capture_unwrapped() {  # <target> <lines>
+  fm_backend_herdr_target_ready "$1" || return 1
+  local lines=${2:-200} fetch out
+  case "$lines" in ''|*[!0-9]*) lines=200 ;; esac
+  fetch=$lines
+  case "$fetch" in ''|*[!0-9]*) fetch=200 ;; *) [ "$fetch" -ge 200 ] || fetch=200 ;; esac
+  out=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane read "$FM_BACKEND_HERDR_PANE" --source recent-unwrapped --lines "$fetch" 2>/dev/null) || return 1
   printf '%s' "$out" | tail -n "$lines"
 }
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -180,6 +180,10 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 # deferred network stage sets, so an ordinary bootstrap run records nothing.
 # shellcheck source=bin/fm-timing-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-timing-lib.sh"
+# Sourced only for fm_session_pid_valid: the lock identity this script compares
+# is not always a local pid.
+# shellcheck source=bin/fm-session-lock-lib.sh disable=SC1091
+. "$SCRIPT_DIR/fm-session-lock-lib.sh"
 
 # Network-phase selection (see the header). An unrecognized value resolves to
 # `all` so a malformed override runs every step rather than silently dropping a
@@ -194,7 +198,7 @@ network_phase() { [ "$FM_BOOTSTRAP_NETWORK_PHASE" != skip ]; }
 network_mutation_authorized() {
   local expected=${FM_BOOTSTRAP_NETWORK_LOCK_PID:-} current
   [ -n "$expected" ] || return 0
-  case "$expected" in *[!0-9]*) return 1 ;; esac
+  fm_session_pid_valid "$expected" || return 1
   [ -f "$STATE/.lock" ] && [ ! -L "$STATE/.lock" ] || return 1
   current=$(cat "$STATE/.lock" 2>/dev/null) || return 1
   [ "$current" = "$expected" ]

--- a/bin/fm-check-lib.sh
+++ b/bin/fm-check-lib.sh
@@ -57,7 +57,7 @@ fm_custom_check_snapshot_prepare() {
   chmod 0600 "$FM_CUSTOM_CHECK_SNAPSHOT" || { fm_custom_check_snapshot_cleanup; return 1; }
   [ -f "$FM_CUSTOM_CHECK_SNAPSHOT" ] && [ ! -L "$FM_CUSTOM_CHECK_SNAPSHOT" ] \
     || { fm_custom_check_snapshot_cleanup; return 1; }
-  [ "$(fm_pr_file_mode "$FM_CUSTOM_CHECK_SNAPSHOT")" = 600 ] \
+  fm_pr_mode_matches "$FM_CUSTOM_CHECK_SNAPSHOT" 600 \
     || { fm_custom_check_snapshot_cleanup; return 1; }
   [ "$(fm_pr_file_device "$FM_CUSTOM_CHECK_SNAPSHOT")" = "$state_device" ] \
     || { fm_custom_check_snapshot_cleanup; return 1; }

--- a/bin/fm-check-register.sh
+++ b/bin/fm-check-register.sh
@@ -1,7 +1,30 @@
 #!/usr/bin/env bash
 # Bind an intentional custom watcher check to its current bytes.
+#
+# This header is the single owner of the authoring contract for a custom
+# state/<id>.check.sh that firstmate writes by hand. The watcher runs a state
+# check only when it is a trusted repository script, the byte-identified Relay
+# shim, or a custom check whose bytes still match the trust binding written
+# here; every other state check is rejected without execution.
+#
+# A custom check must be:
+#   - an ordinary single-link regular file at state/<id>.check.sh, mode 0700,
+#     directly under a non-symlinked state/ directory (a symlink, hardlink, or
+#     special file is refused rather than registered);
+#   - silent on the common path: it prints ONE line only when firstmate should
+#     wake, and prints nothing at all otherwise, because every line it prints
+#     becomes a wake;
+#   - finished inside FM_CHECK_TIMEOUT (default 30 seconds, owned by the
+#     watcher poll loop). A run the watcher kills prints nothing and records
+#     nothing, and would then repeat that silence on every poll.
+#
+# Registration is required BEFORE the watcher may execute the check, and it
+# binds the file's CURRENT bytes: edit the check and it stops running until it
+# is registered again.
+#
 # Usage: fm-check-register.sh <id>
-# Retire with fm-check-unregister.sh <id>; do not hand-compose an rm.
+# Retire with fm-check-unregister.sh <id>, or fm-teardown.sh for a spawned
+# task; do not hand-compose an rm against $STATE/$ID.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -585,6 +585,12 @@ EOF
 # persisted open-set carries every still-open key forward across calls
 # regardless of how much new unrelated log content has since been folded in.
 #
+# The cursor lives at state/.<id>.open-decisions-cursor, is written only here,
+# and is removed by fm-teardown.sh with the rest of the task's records. Because
+# any invalidation signal already falls back to a clean whole-file re-fold, the
+# cursor file is also safe to delete by hand: the only cost is one full re-fold
+# of that task's status log on the next call.
+#
 # The cursor format is `version`, `offset`, `ident`, then the folded open set.
 # FM_OPEN_DECISIONS_FOLD_VERSION must be bumped whenever
 # _fm_decision_fold_line semantics change, so persisted state from an older

--- a/bin/fm-claude-stop-autoarm.sh
+++ b/bin/fm-claude-stop-autoarm.sh
@@ -111,17 +111,17 @@ fm_hook_payload_is_foreign_host "$PAYLOAD" && exit 0
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
 # --- identity: only the lock-owning session's hooks may arm ------------------
-# A prior session may have died after leaving its numeric harness pid in .lock.
-# Use the shared liveness predicate to recognize only that stale-owner case.
+# A prior session may have died after leaving its harness identity in .lock.
+# Use the shared liveness predicate to recognize only that stale-owner case; it
+# resolves a tagged identity too, so a dead Windows session is still recoverable
+# rather than being read as a malformed lock nobody may ever clear.
 # Defer the mutating claim until after the unchanged AFK and need gates, so an
 # idle or away home remains byte-for-byte inert. Missing or malformed locks are
 # uncertainty rather than stale-owner evidence and remain inert.
 RECOVER_SESSION_LOCK=0
 if ! fm_session_lock_owned_by_self "$STATE"; then
   LOCK_PID=$(cat "$STATE/.lock" 2>/dev/null || true)
-  case "$LOCK_PID" in
-    ''|*[!0-9]*) exit 0 ;;
-  esac
+  fm_session_pid_valid "$LOCK_PID" || exit 0
   fm_harness_pid_alive "$LOCK_PID" && exit 0
   RECOVER_SESSION_LOCK=1
 fi

--- a/bin/fm-lease.sh
+++ b/bin/fm-lease.sh
@@ -121,10 +121,16 @@ case "$CMD" in
     # provides one (the Pi branch extension passes the session-lock holder),
     # else the session-lock holder (state/.lock is the harness pid), else this
     # shell; without a matching session lock the resulting lease is stale.
+    # This pid is checked with kill -0, so only a pid in THIS process table can
+    # serve. Take the lock's value whole and require it to be one: a lock holding
+    # an identity from another namespace must yield nothing and fall through to
+    # the shell below, never be reduced to its digits, because those digits name
+    # an unrelated local process rather than the holder.
     HOLDER_PID=${FM_LEASE_HOLDER_PID:-}
     case "$HOLDER_PID" in *[!0-9]*) HOLDER_PID= ;; esac
     if [ -z "$HOLDER_PID" ]; then
-      HOLDER_PID=$(head -n 1 "$STATE/.lock" 2>/dev/null | tr -cd '0-9' || true)
+      HOLDER_PID=$(head -n 1 "$STATE/.lock" 2>/dev/null || true)
+      case "$HOLDER_PID" in *[!0-9]*) HOLDER_PID= ;; esac
     fi
     [ -n "$HOLDER_PID" ] || HOLDER_PID=$$
     TMP=$(mktemp "$STATE/.fm-lease-tmp.XXXXXX")

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -33,7 +33,17 @@ if [ "${1:-}" = "status" ]; then
   exit 0
 fi
 
-me=$(fm_harness_ancestry_pid) || { echo "error: cannot locate harness process in ancestry" >&2; exit 1; }
+me=$(fm_harness_ancestry_pid) || {
+  if fm_win_boundary_applies; then
+    # Here the parent link does not reach the harness at all, so "not in the
+    # ancestry" would describe the wrong problem and send the reader hunting a
+    # process tree that can never contain the answer.
+    echo "error: cannot identify this harness session on Windows: it publishes no session pid this build recognizes (see FM_WIN_HARNESS_PID_VARS in bin/fm-session-lock-lib.sh); operate read-only until resolved" >&2
+  else
+    echo "error: cannot locate harness process in ancestry" >&2
+  fi
+  exit 1
+}
 probe=$(mktemp "$STATE/.lock-write.XXXXXX" 2>/dev/null) || {
   echo "error: cannot write session lock; operate read-only until resolved" >&2
   exit 1

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -89,6 +89,8 @@ FM_PR_RETIRE_REG_IDENTITY=
 FM_PR_RETIRE_RECEIPT_HASH=
 FM_PR_RETIRE_RECEIPT_IDENTITY=
 FM_PR_POLL_RETIREMENT_REJECTED=
+FM_PR_MODE_DEVICE=
+FM_PR_MODE_CAN_LOCK=1
 
 fm_task_id_path_safe() {
   local id=${1-}
@@ -263,10 +265,61 @@ fm_pr_sha256() {
   fi
 }
 
+fm_pr_mode_bits_enforced() {
+  # Probe whether chmod actually persists POSIX mode bits on the filesystem
+  # holding $1 (a file or directory). WSL's drvfs/9p bridge to a Windows drive
+  # ignores chmod entirely, so every file reports 0777 and the "no group/other
+  # access" property is really enforced by the Windows ACL, not Unix mode bits.
+  # Probed once per device and memoized; a probe that cannot complete defaults
+  # to "enforced" so a broken stat/mktemp can never loosen a real filesystem.
+  local target=$1 dir device probe mode
+  if [ -d "$target" ]; then
+    dir=$target
+  else
+    dir=$(dirname "$target")
+  fi
+  device=$(fm_pr_file_device "$dir") || return 0
+  if [ "$FM_PR_MODE_DEVICE" = "$device" ]; then
+    [ "$FM_PR_MODE_CAN_LOCK" = 1 ]
+    return
+  fi
+  FM_PR_MODE_DEVICE=$device
+  FM_PR_MODE_CAN_LOCK=1
+  probe=$(mktemp "$dir/.fm-mode-probe.XXXXXX") 2>/dev/null || return 0
+  chmod 0600 "$probe" 2>/dev/null
+  mode=$(fm_pr_file_mode "$probe") 2>/dev/null
+  rm -f "$probe" 2>/dev/null
+  if [ -n "$mode" ]; then
+    case "$mode" in
+      600|700) FM_PR_MODE_CAN_LOCK=1 ;;
+      *) FM_PR_MODE_CAN_LOCK=0 ;;
+    esac
+  fi
+  [ "$FM_PR_MODE_CAN_LOCK" = 1 ]
+}
+
+fm_pr_mode_matches() {
+  # True when $1 reports exactly mode $2, or when the platform cannot express
+  # or observe that exact mode. Git Bash/MSYS cannot clear the owner-execute
+  # bit (chmod 0600 reports 0700), and filesystems such as WSL drvfs/9p ignore
+  # chmod entirely (everything reports 0777). On those filesystems access
+  # control is ACL-based, not Unix-mode-based, so a mode that cannot be
+  # achieved or read carries no actual privacy loss: the property guarded here
+  # is no group/other access, and that never widens.
+  local path=$1 expected=$2 actual
+  actual=$(fm_pr_file_mode "$path") || return 1
+  [ "$actual" = "$expected" ] && return 0
+  case "$(uname)" in
+    MINGW*|MSYS*|CYGWIN*) [ "$expected" = 600 ] && [ "$actual" = 700 ] && return 0 ;;
+  esac
+  fm_pr_mode_bits_enforced "$path" && return 1
+  return 0
+}
+
 fm_pr_private_file_valid() {
   local path=$1 mode=$2 device=$3
   [ -f "$path" ] && [ ! -L "$path" ] || return 1
-  [ "$(fm_pr_file_mode "$path")" = "$mode" ] || return 1
+  fm_pr_mode_matches "$path" "$mode" || return 1
   [ "$(fm_pr_file_device "$path")" = "$device" ] || return 1
   [ "$(fm_pr_file_link_count "$path")" = 1 ]
 }

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -158,6 +158,20 @@ fm_win_untag_pid() {  # <pid>
   return 1
 }
 
+# True when $1 is a well-formed session-lock identity: a local pid, or a tagged
+# Windows pid. Every reader of state/.lock decides "is this value usable at all"
+# through this one predicate, because the readers are spread across several
+# scripts and a private numeric test in any one of them silently rejects a valid
+# holder - which reads as "startup never completed" and repeats the whole
+# sequence on every clear or compact.
+fm_session_pid_valid() {  # <value>
+  case "$1" in
+    "$FM_WIN_PID_PREFIX"[0-9]*) return 0 ;;
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  return 0
+}
+
 # Windows command paths are backslash-separated and .exe-suffixed, neither of
 # which the path-component matcher above understands. Normalizing here is what
 # keeps that matcher's whole-component safety intact: without it the harness
@@ -313,10 +327,7 @@ fm_harness_pid_alive() {
 fm_session_lock_owned_by_self() {
   local state=$1 lock_pid pids pid
   lock_pid=$(cat "$state/.lock" 2>/dev/null || true)
-  case "$lock_pid" in
-    "$FM_WIN_PID_PREFIX"[0-9]*) : ;;
-    ''|*[!0-9]*) return 1 ;;
-  esac
+  fm_session_pid_valid "$lock_pid" || return 1
   pids=$(fm_harness_ancestry_pids) || return 1
   while IFS= read -r pid; do
     [ "$pid" = "$lock_pid" ] && return 0

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -45,6 +45,41 @@ fm_harness_path_name() {  # <path>
   return 1
 }
 
+# Portable single-pid process introspection.
+#
+# procps/BSD `ps -o comm=/args=/ppid=` custom-format columns are the primary
+# path and cover Linux and macOS. Cygwin's ps, which Git for Windows ships, has
+# no -o option at all and exits with "unknown option -- o", so the primary path
+# fails outright there and the ancestry walk aborts on its first hop. The
+# fallbacks parse Cygwin's fixed columns instead:
+#   ps -p PID     PID PPID PGID WINPID TTY UID STIME COMMAND   (executable path)
+#   ps -f -p PID  UID PID PPID TTY STIME COMMAND               (full argv)
+# A genuinely dead or inaccessible pid still fails both paths, so this widens
+# nothing: it only stops a supported platform from failing on ps syntax alone.
+fm_ps_comm() {  # <pid> -> executable name or path
+  local pid=$1 out
+  out=$(ps -o comm= -p "$pid" 2>/dev/null) && [ -n "$out" ] && { printf '%s' "$out"; return 0; }
+  out=$(ps -p "$pid" 2>/dev/null | awk 'NR == 2 { for (i = 8; i <= NF; i++) printf "%s%s", (i > 8 ? " " : ""), $i; exit }')
+  [ -n "$out" ] || return 1
+  printf '%s' "$out"
+}
+
+fm_ps_args() {  # <pid> -> full command line
+  local pid=$1 out
+  out=$(ps -o args= -p "$pid" 2>/dev/null) && [ -n "$out" ] && { printf '%s' "$out"; return 0; }
+  out=$(ps -f -p "$pid" 2>/dev/null | awk 'NR == 2 { for (i = 6; i <= NF; i++) printf "%s%s", (i > 6 ? " " : ""), $i; exit }')
+  [ -n "$out" ] || return 1
+  printf '%s' "$out"
+}
+
+fm_ps_ppid() {  # <pid> -> parent pid
+  local pid=$1 out
+  out=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') && [ -n "$out" ] && { printf '%s' "$out"; return 0; }
+  out=$(ps -f -p "$pid" 2>/dev/null | awk 'NR == 2 { print $3; exit }')
+  [ -n "$out" ] || return 1
+  printf '%s' "$out"
+}
+
 # True when the process described by command name $1 and full argument string $2
 # is a verified harness. Sets FM_HARNESS_IS_CLAUDE for the ancestry walk.
 #
@@ -88,6 +123,105 @@ fm_harness_process_matches() {  # <comm> <args>
   return 1
 }
 
+# --- Windows process-boundary bridge -----------------------------------------
+#
+# On Cygwin (Git for Windows) the harness is a native Windows process, and the
+# parent link from a shell it spawns does NOT cross the Cygwin boundary: Cygwin
+# reports that shell's PPID as 1. So no amount of walking ppid can ever reach the
+# harness, and the contiguous-run model below cannot be satisfied by the Cygwin
+# process table alone. The Windows process table does hold the real parent chain,
+# and `ps -W` lists Windows processes keyed by WINPID, so identity is recovered
+# from there instead.
+#
+# Windows pids live in a DIFFERENT namespace from Cygwin pids: `kill -0` on a
+# Windows pid reports "No such process" even while that process is running, and a
+# Windows pid can collide with an unrelated live Cygwin pid. A bare number is
+# therefore ambiguous and unsafe to store. Every pid resolved through this bridge
+# is tagged, which makes the namespace explicit for readers and makes the value
+# non-numeric so that any consumer treating it as a Cygwin pid - including a
+# future `kill` - refuses it instead of acting on the wrong process.
+FM_WIN_PID_PREFIX='win:'
+
+# True on a Cygwin-family userspace, where the boundary above applies.
+fm_win_boundary_applies() {
+  case "$(uname -s 2>/dev/null)" in
+    CYGWIN*|MINGW*|MSYS*) return 0 ;;
+  esac
+  return 1
+}
+
+# Strip the namespace tag from $1, or return 1 when $1 is not a tagged pid.
+fm_win_untag_pid() {  # <pid>
+  case "$1" in
+    "$FM_WIN_PID_PREFIX"[0-9]*) printf '%s' "${1#"$FM_WIN_PID_PREFIX"}"; return 0 ;;
+  esac
+  return 1
+}
+
+# Windows command paths are backslash-separated and .exe-suffixed, neither of
+# which the path-component matcher above understands. Normalizing here is what
+# keeps that matcher's whole-component safety intact: without it the harness
+# regex would fall back to matching the entire unsplit path, so an unrelated
+# C:\claude-notes\tool.exe would read as a harness process.
+fm_win_normalize_command() {  # <windows path>
+  local path=${1//\\//}
+  printf '%s' "${path%.exe}"
+}
+
+# Print the normalized executable path of live Windows process $1, or return 1.
+# Presence in `ps -W` is also this bridge's liveness test, because kill -0 cannot
+# answer that question across the namespace boundary.
+fm_win_command() {  # <winpid>
+  local winpid=$1 out
+  case "$winpid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  out=$(ps -W 2>/dev/null | awk -v w="$winpid" '$4 == w { for (i = 8; i <= NF; i++) printf "%s%s", (i > 8 ? " " : ""), $i; exit }')
+  [ -n "$out" ] || return 1
+  fm_win_normalize_command "$out"
+}
+
+# Environment variables through which a verified harness publishes the pid of
+# its own session process. Extend only with a variable confirmed to name the
+# session-long harness process on Windows, because the identity check below is
+# only as narrow as this table.
+#
+# Walking the real Windows parent chain is deliberately NOT the fallback here.
+# Two properties of this platform make it unusable for identity:
+#   - MSYS emulates exec by spawning a fresh Windows process and exiting the old
+#     one, so intermediate shells vanish constantly and a child's recorded parent
+#     is routinely a pid that no longer exists. The chain simply breaks.
+#   - Windows never reparents an orphan, so that dangling parent id stays on the
+#     child and Windows is free to reissue it. Following it can therefore land on
+#     an unrelated live process and bind a home's session lock to it, which is
+#     the wrong-process-binding failure this file exists to prevent.
+# A harness that publishes nothing is reported as unresolved instead, which
+# leaves the session read-only exactly as before - the safe direction.
+FM_WIN_HARNESS_PID_VARS=(CLAUDE_PID)
+
+# Print this session's harness as one tagged Windows pid, or return 1.
+#
+# The published pid is a claim, not evidence, so it is never trusted on its own:
+# it is confirmed against the Windows process table, and accepted only when that
+# pid is still live AND its executable independently identifies a verified
+# harness by the same rules every other platform uses. A value that is absent,
+# malformed, stale, or naming a non-harness process is discarded rather than
+# used, so a wrong or recycled pid fails closed instead of binding the lock.
+fm_win_harness_ancestry_pids() {
+  local var winpid comm
+  for var in "${FM_WIN_HARNESS_PID_VARS[@]}"; do
+    winpid=${!var:-}
+    case "$winpid" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    comm=$(fm_win_command "$winpid") || continue
+    fm_harness_process_matches "$comm" "$comm" || continue
+    printf '%s%s\n' "$FM_WIN_PID_PREFIX" "$winpid"
+    return 0
+  done
+  return 1
+}
+
 # Walk the current process ancestry (up to 16 hops) and print this session's
 # contiguous verified-harness ancestry, innermost pid first.
 #
@@ -109,8 +243,8 @@ fm_harness_process_matches() {  # <comm> <args>
 fm_harness_ancestry_pids() {
   local pid=$$ comm args extending=0 printed=0
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
-    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
-    args=$(ps -o args= -p "$pid" 2>/dev/null)
+    comm=$(fm_ps_comm "$pid") || break
+    args=$(fm_ps_args "$pid")
     if fm_harness_process_matches "$comm" "$args"; then
       printf '%s\n' "$pid"
       printed=1
@@ -119,9 +253,17 @@ fm_harness_ancestry_pids() {
     elif [ "$extending" -eq 1 ]; then
       break
     fi
-    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    pid=$(fm_ps_ppid "$pid")
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
   done
+  # A harness living in the same process table is always preferred, so an
+  # ordinary POSIX ancestry keeps resolving to plain pids and nothing about the
+  # existing platforms changes. The Windows bridge is consulted only after that
+  # walk finds nothing, which on Cygwin is what the severed parent link
+  # guarantees it will do.
+  if [ "$printed" -eq 0 ] && fm_win_boundary_applies; then
+    fm_win_harness_ancestry_pids && return 0
+  fi
   [ "$printed" -eq 1 ]
 }
 
@@ -144,11 +286,19 @@ EOF
 }
 
 # True if $1 is a live process that looks like a verified harness.
+# A tagged Windows pid is answered from the Windows process table, because
+# kill -0 cannot see across that boundary and would report a live harness as
+# dead - which would hand a running session's home to a second one.
 fm_harness_pid_alive() {
-  local pid=$1 comm args
+  local pid=$1 comm args winpid
+  if winpid=$(fm_win_untag_pid "$pid"); then
+    comm=$(fm_win_command "$winpid") || return 1
+    fm_harness_process_matches "$comm" "$comm"
+    return
+  fi
   kill -0 "$pid" 2>/dev/null || return 1
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  args=$(ps -o args= -p "$pid" 2>/dev/null)
+  comm=$(fm_ps_comm "$pid") || return 1
+  args=$(fm_ps_args "$pid")
   fm_harness_process_matches "$comm" "$args"
 }
 
@@ -164,6 +314,7 @@ fm_session_lock_owned_by_self() {
   local state=$1 lock_pid pids pid
   lock_pid=$(cat "$state/.lock" 2>/dev/null || true)
   case "$lock_pid" in
+    "$FM_WIN_PID_PREFIX"[0-9]*) : ;;
     ''|*[!0-9]*) return 1 ;;
   esac
   pids=$(fm_harness_ancestry_pids) || return 1

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -948,9 +948,7 @@ EOF
 if [ "$READ_ONLY" -eq 0 ] && [ "$REEMIT" -eq 0 ]; then
   COMPLETION_RECORDED=0
   COMPLETION_PID=$(cat "$STATE/.lock" 2>/dev/null || true)
-  case "$COMPLETION_PID" in
-    ''|*[!0-9]*) COMPLETION_PID= ;;
-  esac
+  fm_session_pid_valid "$COMPLETION_PID" || COMPLETION_PID=
   COMPLETION_TMP=$(mktemp "$STATE/.session-start-complete.XXXXXX" 2>/dev/null || true)
   if [ -n "$COMPLETION_PID" ] && [ -n "$COMPLETION_TMP" ] \
     && printf '%s\n' "$COMPLETION_PID" > "$COMPLETION_TMP" 2>/dev/null \

--- a/bin/fm-sessionstart-nudge.sh
+++ b/bin/fm-sessionstart-nudge.sh
@@ -16,27 +16,18 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-primary-scope-lib.sh"
 # shellcheck source=bin/fm-operational-input.sh
 . "$SCRIPT_DIR/fm-operational-input.sh"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$SCRIPT_DIR/fm-session-lock-lib.sh"
 
 fm_is_gate_agent "$FM_ROOT" && exit 0
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
-lock_is_in_ancestry() {
-  local lock_pid pid=$$ _
-  [ -f "$STATE/.lock" ] || return 1
-  IFS= read -r lock_pid < "$STATE/.lock" 2>/dev/null || return 1
-  case "$lock_pid" in
-    ''|*[!0-9]*|1) return 1 ;;
-  esac
-  kill -0 "$lock_pid" 2>/dev/null || return 1
-  for _ in 1 2 3 4 5 6 7 8; do
-    [ "$pid" = "$lock_pid" ] && return 0
-    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
-  done
-  return 1
-}
-
-lock_is_in_ancestry && exit 0
+# "Has this session already acquired the home lock?" is one question with one
+# owner. Asking it here with a private ancestry walk kept a second copy of every
+# platform assumption that owner makes, so this script stayed wrong on Cygwin
+# after the owner itself was fixed - and nudged a session that already held the
+# lock to start over.
+fm_session_lock_owned_by_self "$STATE" && exit 0
 nudge=
 fm_operational_input_encode session-start \
   "Run \`bin/fm-session-start.sh\` now, exactly once, before executing any other instructions." \

--- a/bin/fm-sessionstart-nudge.sh
+++ b/bin/fm-sessionstart-nudge.sh
@@ -22,12 +22,27 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 fm_is_gate_agent "$FM_ROOT" && exit 0
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
-# "Has this session already acquired the home lock?" is one question with one
-# owner. Asking it here with a private ancestry walk kept a second copy of every
-# platform assumption that owner makes, so this script stayed wrong on Cygwin
-# after the owner itself was fixed - and nudged a session that already held the
-# lock to start over.
-fm_session_lock_owned_by_self "$STATE" && exit 0
+lock_is_in_ancestry() {
+  local lock_pid pid=$$ _
+  [ -f "$STATE/.lock" ] || return 1
+  IFS= read -r lock_pid < "$STATE/.lock" 2>/dev/null || return 1
+  case "$lock_pid" in
+    # A Windows-tagged holder is not in this process table at all, so a local
+    # ancestry comparison cannot answer for it. Defer to the owner of harness
+    # identity, which is the only thing that can read across that boundary.
+    "$FM_WIN_PID_PREFIX"[0-9]*) fm_session_lock_owned_by_self "$STATE"; return ;;
+    ''|*[!0-9]*|1) return 1 ;;
+  esac
+  kill -0 "$lock_pid" 2>/dev/null || return 1
+  for _ in 1 2 3 4 5 6 7 8; do
+    [ "$pid" = "$lock_pid" ] && return 0
+    pid=$(fm_ps_ppid "$pid")
+    [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
+  done
+  return 1
+}
+
+lock_is_in_ancestry && exit 0
 nudge=
 fm_operational_input_encode session-start \
   "Run \`bin/fm-session-start.sh\` now, exactly once, before executing any other instructions." \

--- a/bin/fm-sessionstart-run.sh
+++ b/bin/fm-sessionstart-run.sh
@@ -96,7 +96,7 @@ session_start_completed() {
   fm_session_lock_owned_by_self "$STATE" || return 1
   lock_pid=$(cat "$STATE/.lock" 2>/dev/null) || return 1
   completion_pid=$(cat "$COMPLETION_FILE" 2>/dev/null) || return 1
-  case "$lock_pid" in ''|*[!0-9]*) return 1 ;; esac
+  fm_session_pid_valid "$lock_pid" || return 1
   [ "$completion_pid" = "$lock_pid" ]
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1525,7 +1525,8 @@ effort_flag_for_harness() {
       # high|xhigh|ultra and defaults to high, so low..xhigh map straight across.
       # ultra is muse's max-CLASS level, so firstmate's max maps onto it - but
       # only ever as an EXPLICIT captain choice, never as a fallback, because
-      # AGENTS.md section 4 forbids selecting max without captain preference and
+      # harness-adapters' effort fallback forbids selecting max without captain
+      # preference (AGENTS.md section 4 delegates that policy to it) and
       # the omitted effort here leaves muse on its own high default. muse's extra
       # none/minimal levels sit below firstmate's shared vocabulary and are
       # deliberately unreachable rather than remapped onto low.

--- a/bin/fm-startup-network.sh
+++ b/bin/fm-startup-network.sh
@@ -295,7 +295,7 @@ EOF
 # fail closed to the read-only probe.
 lock_unchanged() {  # <expected-pid>
   local expected=$1 current
-  case "$expected" in ''|*[!0-9]*) return 1 ;; esac
+  fm_session_pid_valid "$expected" || return 1
   [ -f "$STATE/.lock" ] && [ ! -L "$STATE/.lock" ] || return 1
   current=$(cat "$STATE/.lock" 2>/dev/null) || return 1
   [ "$current" = "$expected" ]

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -997,6 +997,24 @@ validate_pr_poll_cleanup() {
       return 1
     }
   fi
+  [ -e "$quarantine" ] || [ -L "$quarantine" ] || return 0
+  if [ ! -d "$state_dir" ] || [ -L "$state_dir" ] \
+    || [ ! -d "$quarantine" ] || [ -L "$quarantine" ]; then
+    echo "REFUSED: unsafe PR-check quarantine path $quarantine; preserving task state." >&2
+    return 1
+  fi
+  if [ "$(fm_pr_file_device "$quarantine")" != "$state_device" ] \
+    || ! fm_pr_mode_matches "$quarantine" 700; then
+    echo "REFUSED: PR-check quarantine is not on the task state device; preserving task state." >&2
+    return 1
+  fi
+  for artifact in "$quarantine/$id."*; do
+    [ -e "$artifact" ] || [ -L "$artifact" ] || continue
+    if ! fm_pr_private_file_valid "$artifact" 600 "$state_device"; then
+      echo "REFUSED: unsafe task quarantine entry; preserving task state." >&2
+      return 1
+    fi
+  done
 }
 
 remove_pr_poll_artifacts() {

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -237,6 +237,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/validation-run-changes/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".greptile/rules.md",
       "audience": "maintainer-architecture"
     },

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -810,8 +810,118 @@ SH
   pass "concurrent watchers observe only complete private poll publications"
 }
 
-test_poll_publication_refuses_unsafe_destinations() {
-  local artifact kind dir state destination
+test_migration_excludes_older_watcher_before_scan() {
+  local dir state gate sentinel older_pid rc
+  dir=$(make_case migration-pause-before-scan)
+  state="$dir/home/state"
+  gate="$dir/scan-started"
+  sentinel="$dir/legacy-ran"
+  fm_write_meta "$state/task-a.meta" \
+    'window=fm-task-a' \
+    'pr=https://github.com/o/r/pull/9'
+  cat > "$state/task-a.check.sh" <<SH
+#!/usr/bin/env bash
+printf 'seen\n' > '$sentinel'
+SH
+  (
+    while [ ! -e "$gate" ]; do sleep 0.01; done
+    bash "$state/task-a.check.sh"
+    while :; do sleep 1; done
+  ) &
+  older_pid=$!
+  write_watcher_lock "$state" "$dir/home" "$older_pid"
+  cat > "$dir/fakebin/basename" <<SH
+#!/usr/bin/env bash
+: > '$gate'
+sleep 0.3
+exec '$REAL_BASENAME' "\$@"
+SH
+  chmod +x "$dir/fakebin/basename"
+
+  set +e
+  FM_HOME="$dir/home" PATH="$dir/fakebin:$BASE_PATH" "$MIGRATE" > "$dir/migrate.out" 2> "$dir/migrate.err"
+  rc=$?
+  set -e
+  wait "$older_pid" 2>/dev/null || true
+  [ "$rc" -eq 0 ] || fail "pause-before-scan migration failed"
+  [ ! -e "$sentinel" ] || fail "older watcher ran a legacy check during migration startup"
+  [ -e "$gate" ] || fail "migration never reached its under-lock check scan"
+  assert_valid_migration_marker "$state/.pr-check-migration-v1"
+  cmp -s "$POLL" "$state/task-a.check.sh" || fail "pause-before-scan migration did not rebuild the poll"
+
+  dir=$(make_case migration-pause-no-check)
+  state="$dir/home/state"
+  ( while :; do sleep 1; done ) &
+  older_pid=$!
+  write_watcher_lock "$state" "$dir/home" "$older_pid"
+  set +e
+  FM_HOME="$dir/home" PATH="$dir/fakebin:$BASE_PATH" "$MIGRATE" > "$dir/migrate.out" 2> "$dir/migrate.err"
+  rc=$?
+  set -e
+  wait "$older_pid" 2>/dev/null || true
+  [ "$rc" -eq 0 ] || fail "no-check older-watcher migration failed"
+  ! kill -0 "$older_pid" 2>/dev/null || fail "no-check migration left the older watcher running"
+  assert_valid_migration_marker "$state/.pr-check-migration-v1"
+  pass "migration pauses older watchers and acquires exclusion before its first scan or marker"
+}
+
+test_migration_initializes_fresh_state() {
+  local dir state rc
+  dir="$TMP_ROOT/migration-fresh-state"
+  state="$dir/home/state"
+  mkdir -p "$dir"
+
+  set +e
+  FM_HOME="$dir/home" PATH="$BASE_PATH" "$MIGRATE" > "$dir/migrate.out" 2> "$dir/migrate.err"
+  rc=$?
+  set -e
+
+  [ "$rc" -eq 0 ] || fail "fresh-state migration failed: $(cat "$dir/migrate.err")"
+  [ -d "$state" ] && [ ! -L "$state" ] || fail "fresh-state migration did not create an ordinary state directory"
+  [ "$(file_mode "$state")" = 700 ] || fail "fresh-state migration did not create state with mode 0700"
+  assert_valid_migration_marker "$state/.pr-check-migration-v1"
+  pass "migration creates and validates private state before watcher exclusion"
+}
+
+test_private_mode_check_tolerates_noop_chmod_filesystem() {
+  local dir state loose
+  dir=$(make_case mode-noop-chmod)
+  state="$dir/home/state"
+  loose="$state/loose"
+  printf 'x\n' > "$loose"
+  chmod 0644 "$loose"
+
+  # On a mode-enforcing filesystem, a group/other-readable file is not private.
+  if fm_pr_mode_matches "$loose" 600; then
+    fail "mode-enforcing filesystem accepted a 0644 file as private"
+  fi
+
+  # Simulate a filesystem where chmod is a no-op (WSL drvfs/9p): a no-op chmod
+  # and a stat that reports 0777 for every mode. The mode check must accept
+  # there, because access control is the host ACL, not Unix mode bits.
+  cat > "$dir/fakebin/chmod" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$dir/fakebin/stat" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" %a "*) printf '777\n'; exit 0 ;;
+esac
+exec "$FM_TEST_REAL_STAT" "$@"
+SH
+  chmod +x "$dir/fakebin/chmod" "$dir/fakebin/stat"
+
+  FM_TEST_REAL_STAT="$REAL_STAT" PATH="$dir/fakebin:$BASE_PATH" bash -c '
+    . "$1/bin/fm-pr-lib.sh"
+    fm_pr_mode_matches "$2" 600
+  ' _ "$ROOT" "$loose" \
+    || fail "no-op chmod filesystem refused a file whose mode cannot be set"
+  pass "private mode checks enforce on POSIX filesystems and tolerate no-op chmod filesystems"
+}
+
+test_private_artifact_paths_refuse_symlinks_and_directories() {
+  local artifact kind dir state destination rc
   for artifact in task-a.pr-poll task-a.pr-poll-registration task-a.check.sh; do
     for kind in regular dangling directory; do
       dir=$(make_case "poll-path-${artifact//./-}-$kind")
@@ -2145,6 +2255,24 @@ test_poll_publication_refuses_unsafe_destinations
 test_live_artifact_single_link_and_privacy_validation
 test_postrename_poll_validation_revokes_and_retries
 test_bootstrap_leaves_unauthenticated_checks
+test_migration_initializes_fresh_state
+test_private_mode_check_tolerates_noop_chmod_filesystem
+test_migration_excludes_older_watcher_before_scan
+test_private_artifact_paths_refuse_symlinks_and_directories
+test_marker_and_diagnostic_rename_fail_closed
+test_postrename_marker_and_diagnostic_validation_retries
+test_quarantine_validation_and_retry_contract
+test_failed_outcomes_block_every_retry_until_repaired
+test_ambiguous_failure_accepts_validated_replacement
+test_replacement_provenance_negative_matrix
+test_complete_single_link_validation
+test_canonical_publication_failure_recovers_only_on_retry
+test_obligation_namespace_compatibility
+test_nonexecuting_migration
+test_historical_x_shim_transition_matrix
+test_direct_registration_refreshes_v1_x_shim
+test_bootstrap_migrates_before_other_mutations
+test_bootstrap_isolates_incomplete_poll_migration
 test_custom_snapshot_cleanup_on_signal
 test_returned_custom_check_descendants_are_drained
 test_teardown_removes_poll_artifacts

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -337,6 +337,41 @@ test_windows_pid_is_never_resolved_as_a_cygwin_pid() {
   pass "session-lock: a tagged Windows pid is never resolved against the Cygwin process table"
 }
 
+test_a_published_identity_is_accepted_by_the_gates_that_read_the_lock() {
+  local dir fakebin identity
+  dir="$TMP_ROOT/win-identity-gates"
+  fakebin=$(cygwin_fakebin "$dir")
+  mkdir -p "$dir/state"
+
+  # The identity a session writes into the lock is read back by gates spread
+  # across several scripts - startup-completion recording and its clear/compact
+  # validation, the deferred network sweeps, and the Stop auto-arm. Each one
+  # asks only "is this value a usable identity", and each answered that with its
+  # own numeric test, so introducing a second identity shape made every one of
+  # them silently read a valid holder as malformed. The visible cost was a
+  # completion record that was never written, which reads as "startup never
+  # finished" and repeats the whole sequence on every clear or compact. One
+  # predicate owns the question so a third shape can never split them again.
+  identity=$(FM_TEST_WIN_TABLE="$WIN_TABLE" CLAUDE_PID=7204 lib_eval "$fakebin" 'fm_harness_ancestry_pid') \
+    || fail "fixture is vacuous: no identity was published to gate on"
+  lib_eval "$fakebin" "fm_session_pid_valid '$identity'" \
+    || fail "the identity '$identity' this session publishes is rejected by the gates that read it back"
+
+  # A local pid stays equally valid: the Windows shape is additional, not a
+  # replacement, and the same predicate serves both platforms.
+  lib_eval "$fakebin" 'fm_session_pid_valid 700' \
+    || fail "an ordinary local pid was rejected as an invalid lock identity"
+
+  # Still fail closed on the shapes a torn or hand-edited lock produces, and on
+  # a bare tag carrying no pid at all.
+  for bad in '' 'win:' 'win:abc' 'abc' '70 0' '-1'; do
+    if lib_eval "$fakebin" "fm_session_pid_valid '$bad'"; then
+      fail "the malformed lock value '$bad' was accepted as a usable identity"
+    fi
+  done
+  pass "session-lock: a published identity is accepted by every gate that reads the lock"
+}
+
 test_cygwin_ps_without_o_still_resolves_a_local_harness() {
   local dir fakebin got
   dir="$TMP_ROOT/cygwin-local"
@@ -496,6 +531,7 @@ test_competing_version_named_session_is_seen_as_live
 test_windows_session_is_identified_from_its_published_pid
 test_windows_published_pid_is_confirmed_before_it_is_trusted
 test_windows_pid_is_never_resolved_as_a_cygwin_pid
+test_a_published_identity_is_accepted_by_the_gates_that_read_the_lock
 test_cygwin_ps_without_o_still_resolves_a_local_harness
 test_e2e_version_named_session_claims_the_home
 test_e2e_daemon_parented_session_claims_the_home

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -220,6 +220,139 @@ SH
   pass "session-lock: a live version-named session holding the lock is not mistaken for a stale owner"
 }
 
+# --- Cygwin / Git-for-Windows layer ------------------------------------------
+#
+# Both of this platform's departures are reproduced here rather than assumed, so
+# these run identically on Linux and macOS CI: its ps rejects -o outright, and
+# every shell it reports has its parent link severed at 1 because the real parent
+# is a Windows process Cygwin cannot see.
+
+# A fakebin whose ps behaves like Cygwin's and whose uname reports MINGW.
+# The Windows-side table is supplied per case through FM_TEST_WIN_TABLE, in the
+# same column order the real `ps -W` prints.
+cygwin_fakebin() {  # <dir>
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'MINGW64_NT-10.0-26200'
+SH
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+for a in "$@"; do
+  # Cygwin's ps has no -o option at all; it fails the whole invocation.
+  [ "$a" = "-o" ] && { echo "ps: unknown option -- o" >&2; exit 1; }
+done
+mode=p full=0 pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -W) mode=W; shift ;;
+    -f) full=1; shift ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ "$mode" = W ]; then
+  printf '%s\n' '      PID    PPID    PGID     WINPID   TTY         UID    STIME COMMAND'
+  [ -n "${FM_TEST_WIN_TABLE:-}" ] && printf '%s\n' "$FM_TEST_WIN_TABLE"
+  exit 0
+fi
+# The Cygwin-side table. 700 is an MSYS-native harness; everything else is an
+# ordinary shell whose parent link is severed exactly as the real ps reports it.
+case "$pid" in
+  700) comm='/opt/claude/versions/2.1.220'; ppid=1 ;;
+  *)   comm='/usr/bin/bash'; ppid=${FM_TEST_CYG_PPID:-1} ;;
+esac
+if [ "$full" = 1 ]; then
+  printf '%s\n' '     UID     PID    PPID  TTY        STIME COMMAND'
+  printf 'u %s %s ? 00:00:00 %s\n' "$pid" "$ppid" "$comm"
+else
+  printf '%s\n' '      PID    PPID    PGID     WINPID   TTY         UID    STIME COMMAND'
+  printf '%s %s %s 9999 ? 0 00:00:00 %s\n' "$pid" "$ppid" "$pid" "$comm"
+fi
+SH
+  chmod +x "$fakebin/uname" "$fakebin/ps"
+  printf '%s\n' "$fakebin"
+}
+
+# WINPID 7204 is the session harness. 4321 is an ordinary desktop process, and
+# 5150 is the path-shaped lookalike that must never read as a harness.
+WIN_TABLE='  4201508       0       0       7204  ?              0 22:24:48 C:\Users\u\.local\bin\claude.exe
+  4198625       0       0       4321  ?              0 22:24:48 C:\Windows\explorer.exe
+  4199454       0       0       5150  ?              0 22:24:48 C:\tools\claude-notes\helper.exe'
+
+test_windows_session_is_identified_from_its_published_pid() {
+  local dir fakebin got
+  dir="$TMP_ROOT/win-published"
+  fakebin=$(cygwin_fakebin "$dir")
+  mkdir -p "$dir/state"
+  printf 'win:7204\n' > "$dir/state/.lock"
+
+  got=$(FM_TEST_WIN_TABLE="$WIN_TABLE" CLAUDE_PID=7204 lib_eval "$fakebin" 'fm_harness_ancestry_pid') \
+    || fail "the session was not identified at all on a severed Cygwin parent link"
+  [ "$got" = 'win:7204' ] || fail "expected the tagged Windows session pid win:7204, got '$got'"
+  FM_TEST_WIN_TABLE="$WIN_TABLE" CLAUDE_PID=7204 lib_eval "$fakebin" 'fm_harness_pid_alive win:7204' \
+    || fail "a live Windows-side session was classified as a dead lock owner"
+  FM_TEST_WIN_TABLE="$WIN_TABLE" CLAUDE_PID=7204 lib_eval "$fakebin" "fm_session_lock_owned_by_self '$dir/state'" \
+    || fail "the session holding the lock did not recognize itself as the owner"
+  pass "session-lock: a Windows session is identified from its published pid across the severed parent link"
+}
+
+test_windows_published_pid_is_confirmed_before_it_is_trusted() {
+  local dir fakebin
+  dir="$TMP_ROOT/win-unconfirmed"
+  fakebin=$(cygwin_fakebin "$dir")
+  mkdir -p "$dir/state"
+
+  # A published pid is a claim. Each of these shapes must be discarded rather
+  # than bound: a process that is gone, one that is not a harness at all, and a
+  # path that merely contains the harness name inside a longer component.
+  for claimed in 9999 4321 5150; do
+    if FM_TEST_WIN_TABLE="$WIN_TABLE" CLAUDE_PID="$claimed" lib_eval "$fakebin" 'fm_harness_ancestry_pid'; then
+      fail "published pid $claimed was bound as this session's harness without confirmation"
+    fi
+    if FM_TEST_WIN_TABLE="$WIN_TABLE" lib_eval "$fakebin" "fm_harness_pid_alive win:$claimed"; then
+      fail "published pid $claimed passed the harness-liveness predicate"
+    fi
+  done
+  pass "session-lock: a published Windows pid is confirmed against the process table before it is trusted"
+}
+
+test_windows_pid_is_never_resolved_as_a_cygwin_pid() {
+  local dir fakebin
+  dir="$TMP_ROOT/win-namespace"
+  fakebin=$(cygwin_fakebin "$dir")
+  mkdir -p "$dir/state"
+
+  # 700 is a harness in the CYGWIN table and absent from the Windows one. The
+  # two namespaces overlap numerically, so resolving a tagged pid through the
+  # local table would bind a home to whatever unrelated process holds that
+  # number - which is exactly what the tag exists to prevent.
+  FM_TEST_WIN_TABLE="$WIN_TABLE" lib_eval "$fakebin" 'fm_harness_pid_alive 700' \
+    || fail "fixture is vacuous: pid 700 must be a live harness in the Cygwin table"
+  if FM_TEST_WIN_TABLE="$WIN_TABLE" lib_eval "$fakebin" 'fm_harness_pid_alive win:700'; then
+    fail "a tagged Windows pid was resolved against the Cygwin process table"
+  fi
+  pass "session-lock: a tagged Windows pid is never resolved against the Cygwin process table"
+}
+
+test_cygwin_ps_without_o_still_resolves_a_local_harness() {
+  local dir fakebin got
+  dir="$TMP_ROOT/cygwin-local"
+  fakebin=$(cygwin_fakebin "$dir")
+  mkdir -p "$dir/state"
+
+  # An MSYS-native harness lives in the same process table as this shell, so it
+  # must resolve through the ordinary walk and stay an untagged pid. This is
+  # what proves the walk survives a ps with no -o option at all.
+  got=$(FM_TEST_CYG_PPID=700 FM_TEST_WIN_TABLE="$WIN_TABLE" CLAUDE_PID=7204 \
+    lib_eval "$fakebin" 'fm_harness_ancestry_pid') \
+    || fail "a harness in the local process table was not resolved when ps rejected -o"
+  [ "$got" = 700 ] || fail "expected the untagged local harness pid 700, got '$got'"
+  pass "session-lock: a harness in the local process table resolves untagged when ps has no -o option"
+}
+
 # --- end-to-end layer: the real Stop auto-arm in real process trees ----------
 
 install_autoarm_scripts() {
@@ -360,6 +493,10 @@ test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
+test_windows_session_is_identified_from_its_published_pid
+test_windows_published_pid_is_confirmed_before_it_is_trusted
+test_windows_pid_is_never_resolved_as_a_cygwin_pid
+test_cygwin_ps_without_o_still_resolves_a_local_harness
 test_e2e_version_named_session_claims_the_home
 test_e2e_daemon_parented_session_claims_the_home
 test_e2e_daemon_parented_version_named_session_keeps_its_lock


### PR DESCRIPTION
## What and why

Fixes the read-only wedge in #3396. On Cygwin (Git for Windows) every session start refused the fleet lock with `error: cannot locate harness process in ancestry`, so spawning, steering, merging, the wake-queue drain, and supervision repair were skipped on every start.

There are two independent causes on the identity path, and fixing only the first still leaves the session read-only.

**Cause 1 - `ps -o` does not exist on Cygwin.** Cygwin's `ps` accepts only `[-aefls] [-u UID] [-p PID]` and fails the whole invocation with `unknown option -- o`, so the ancestry walk aborted on hop one. `comm`, `args`, and `ppid` now go through accessors that fall back to Cygwin's fixed columns; the procps/BSD path is unchanged.

**Cause 2 - the parent link does not cross the Cygwin boundary.** The harness is a native Windows process, and Cygwin reports the PPID of a shell it spawns as `1`, so no walk can reach it. Identity now comes from the session pid the harness publishes, **confirmed against the Windows process table before use**: the pid must still be live *and* its executable must independently identify a verified harness by the same rules every other platform uses. An absent, stale, or non-harness value is discarded, not bound.

## A Windows parent-chain walk was implemented, then deliberately removed

The obvious fallback - walk the real Windows parent chain via `Win32_Process` - was built and tested, and it is **not safe on this platform**:

- MSYS emulates `exec` by spawning a fresh Windows process and exiting the old one, so intermediate shells vanish constantly and a child's recorded parent is routinely a pid that no longer exists. Measured directly: a parent id appeared in neither `ps -W` nor a full `Win32_Process` snapshot taken moments earlier. The chain simply breaks.
- Windows never reparents an orphan, so that dangling parent id stays on the child and Windows is free to reissue it. Following it can land on an unrelated live process and bind a home's session lock to it - the same wrong-process-binding class as #3451 and #3279.

A harness that publishes nothing is left unresolved instead, which keeps the session read-only exactly as before. That is the safe direction, and `bin/fm-lock.sh` now says so specifically rather than blaming an ancestry that could never contain the answer.

## Windows pids are tagged, not stored bare

They are a different namespace. `kill -0` reports a live Windows process as dead, and the number can collide with an unrelated live Cygwin pid. Storing a bare number would be indistinguishable from a local pid, so the value is tagged `win:<pid>`. That makes it non-numeric, so any consumer treating it as a local pid - including a future `kill` - refuses it instead of acting on the wrong process:

```
$ kill -0 win:7204
bash: kill: `win:7204': not a pid or valid job spec
```

Nothing signals the session lock today; the two `kill -TERM` sites read the *watcher* lock, a different file.

## Every gate that reads the lock accepts the tagged identity

Introducing a second identity shape into `state/.lock` was the risky part of this change, and the first revision got it wrong. Six gates read that field, and each answered "is this value usable at all" with its own inline numeric test, so every one of them read a valid Windows holder as malformed. Thanks to the review bot for catching the first two; auditing the field turned up four more.

The visible cost was concentrated in startup completion: the record was never written, and the clear/compact check that consumes it could never match, so **every clear or compact on Windows repeated the full startup sequence**. The deferred network sweeps reported ownership as changed when it had not, and the Stop auto-arm treated a dead Windows session as an unreadable lock rather than a recoverable one.

`bin/fm-lease.sh` was the outlier and the one worth calling out. Rather than refusing a value it could not use, `tr -cd '0-9'` reduced `win:7204` to `7204` - a number naming an unrelated process in the *local* table. It happened to fail closed downstream because the equality check against the untouched lock value could never match, but deriving a wrong-namespace pid is exactly what the tag exists to prevent, so it now takes the value whole and requires a local pid, falling through to the shell pid when the lock holds anything else.

`fm_session_pid_valid` is now the single owner of that question and all six gates delegate to it, so a third identity shape cannot silently split them again.

## `bin/fm-sessionstart-nudge.sh`

Its private ancestry walk had the same `ps -o` problem, so it now reads ppid through the portable accessor, and defers to `fm_session_lock_owned_by_self` for a Windows-tagged holder, which is not in the local process table at all.

Its own question is otherwise left alone. An earlier revision of this branch replaced the whole walk with `fm_session_lock_owned_by_self`; that was wrong. The nudge asks whether a process in this ancestry took the lock, while the ownership predicate additionally requires a *verified harness* in that ancestry, so a lock written by a plain shell started being nudged to run session start again. `tests/fm-sessionstart-nudge.test.sh` pins the looser contract deliberately and caught it.

## Relationship to #3551

#3551 fixes cause 1 only. I simulated its exact walk on the affected machine: `ps -f -p $$` returns parent `1`, so it stops on hop one and the session stays read-only. The accessors here are deliberately close to that PR's shape so whichever lands first, the other is a small merge. Credit to that author for the `-o` diagnosis.

## Verification

Windows 11 26200, Git Bash, Cygwin `ps` 3.4.10, harness `claude`:

| Case | Result |
| --- | --- |
| acquire | `lock acquired: harness pid win:7204` |
| stored value | `win:7204` (confirmed as the real `claude.exe`) |
| `status` | `lock: held by live harness pid win:7204` |
| re-acquire | idempotent |
| ownership recognized | yes |
| published pid that is dead | refused |
| published pid naming `explorer.exe` | refused |
| published pid naming `C:\tools\claude-notes\helper.exe` | refused (path-component safety survives backslashes) |
| no published pid | refused with a platform-specific diagnostic |
| nudge with our lock / another's lock / no lock | silent / nudges / nudges |

Each identity gate was then exercised against its **shipped bytes** with a tagged lock in place, comparing this branch to the same function on `main`:

| Gate | `main` | this branch |
| --- | --- | --- |
| `session_start_completed` (clear/compact) | reruns the full startup | re-emits only |
| startup completion record | not recorded | records `win:7204` |
| `lock_unchanged` (network sweeps) | sweeps downgraded | sweeps run |
| `network_mutation_authorized` | false "ownership changed" | authorized |
| lease holder pid from a tagged lock | `7204` (wrong namespace) | empty, falls back to this shell |

Five regressions added to `tests/fm-session-lock-ancestry.test.sh`. Both platform departures are reproduced behind a fake process table - the `-o` rejection and the severed parent link - so they run on Linux and macOS CI rather than only on Windows. They also pin the namespace separation (a tagged pid whose number *is* a live harness in the Cygwin table must still be refused) and that a published identity is accepted by the gates that read it back.

Run on Linux (WSL Ubuntu), since neither the pinned ShellCheck nor this suite's e2e layer can run on the Windows host. Note `tests/fm-session-start.test.sh` pins a minimal `FM_TEST_BASE_PATH`, so `jq` must be reachable from it or the home-summary assertions fail for environmental reasons on `main` too:

| Suite | Result |
| --- | --- |
| `fm-session-lock-ancestry` | 12/12, including the three e2e cases |
| `fm-session-start` | 49/49 (`main`: 47/47) |
| `fm-bootstrap` | 28/28 |
| `fm-bootstrap-network-parallel` | 2/2 |
| `fm-startup-network` | 18/18 |
| `fm-claude-stop-autoarm` | 39/39 |
| `fm-sessionstart-nudge` | 7/8; the failure is the pre-existing `OpenCode exact nudge delivery: expected exit 0, got 127`, identical on `main` (no `opencode` binary in that environment) |

`bin/fm-lint.sh` clean on the full tree with ShellCheck 0.11.0 (pinned 0.11.0), full extended analysis. Its only remark is that `actionlint` is absent in that environment; no workflow files are touched by this branch.

On the Windows host the e2e layer of the ancestry suite fails identically on `main` and on this branch - it cannot exec its symlinked fixture (the `ln -s` limitation of #3267) - so it is unchanged, not regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9T29YDqYSkQeDTC2Nfi7h
