### PR TITLE
fix(bin): validate Orca worktree ids by their real composite shape

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -388,6 +388,37 @@ fm_backend_endpoint_atom_valid() {  # <value>
   esac
 }
 
+# Orca is the one backend whose recorded worktree id is not a bare atom:
+# `orca worktree create --json` emits "<opaque id>::<absolute worktree path>", so
+# it always carries ':' and '/'. Validate that composite shape structurally here
+# rather than widening fm_backend_endpoint_atom_valid, whose narrow allowlist is
+# the injection guard for every other backend's endpoint atoms. Only the
+# structure is pinned: an id half that is non-empty and slash-free, and an
+# absolute path with no empty, trailing, or '..' segment. Orca's id format is
+# undocumented and worktree paths legitimately contain spaces and non-ASCII
+# characters, and the recorded value only ever reaches `orca` as a single quoted
+# argv element, so a character allowlist here would refuse real worktrees
+# without guarding anything.
+fm_backend_orca_worktree_id_valid() {  # <value>
+  local value=$1 worktree_id path
+  case "$value" in
+    *::*) ;;
+    *) return 1 ;;
+  esac
+  worktree_id=${value%%::*}
+  path=${value#*::}
+  case "$worktree_id" in
+    ''|*/*) return 1 ;;
+  esac
+  case "$path" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  case "$path" in
+    */|*//*|*/../*|*/..) return 1 ;;
+  esac
+}
+
 fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
   local meta=$1 id=$2 backend_count backend window worktree project binding_count binding
   local session pane recorded_session workspace tab terminal worktree_id surface
@@ -508,7 +539,7 @@ fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
       }
       if [ "$window" != "fm-$id" ] \
         || ! fm_backend_endpoint_atom_valid "$terminal" \
-        || ! fm_backend_endpoint_atom_valid "$worktree_id"; then
+        || ! fm_backend_orca_worktree_id_valid "$worktree_id"; then
         echo "REFUSED: Orca endpoint metadata for task $id is malformed or inconsistent; preserving task state." >&2
         return 1
       fi

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -43,6 +43,11 @@ worktree=<absolute Orca worktree path>
 `window=` remains the caller-facing Firstmate alias.
 `terminal=` and `orca_worktree_id=` are the backend authority used by operation and cleanup paths.
 
+`orca worktree create --json` emits a composite worktree id, and cleanup requires that shape: `<opaque id>::<absolute worktree path>`.
+The id half must be non-empty and contain no `/`, and the path half must be absolute with no empty segment, no trailing slash, and no `..` segment.
+Nothing else about the id half is assumed, and the path half is not character-filtered, so worktree paths containing spaces or non-ASCII characters are accepted.
+A recorded id that does not match this shape is refused by cleanup rather than passed to `orca`.
+
 ## Current lifecycle and safety
 
 Spawn registers the repository, creates an independent worktree, reuses only the verified `result.terminal.handle` returned by Orca or creates a terminal explicitly, installs harness hooks, records metadata, and launches the selected harness.

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -43,10 +43,10 @@ worktree=<absolute Orca worktree path>
 `window=` remains the caller-facing Firstmate alias.
 `terminal=` and `orca_worktree_id=` are the backend authority used by operation and cleanup paths.
 
-`orca worktree create --json` emits a composite worktree id, and cleanup requires that shape: `<opaque id>::<absolute worktree path>`.
+`orca worktree create --json` emits a composite worktree id, and the shared endpoint-identity validation requires that shape: `<opaque id>::<absolute worktree path>`.
 The id half must be non-empty and contain no `/`, and the path half must be absolute with no empty segment, no trailing slash, and no `..` segment.
 Nothing else about the id half is assumed, and the path half is not character-filtered, so worktree paths containing spaces or non-ASCII characters are accepted.
-A recorded id that does not match this shape is refused by cleanup rather than passed to `orca`.
+A recorded id that does not match this shape is refused before any `orca` command runs, for the [control-plane verbs](agent-control.md) as well as for cleanup.
 
 ## Current lifecycle and safety
 

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -85,6 +85,7 @@ It never raw-deletes an Orca worktree.
 tests/fm-backend-orca.test.sh
 tests/fm-backend.test.sh
 tests/fm-bootstrap.test.sh
+tests/fm-teardown-endpoint-safety.test.sh
 ```
 
 [`verification/runtime-backends.md`](verification/runtime-backends.md#orca) records the real readiness and response-shape smoke.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -181,7 +181,7 @@ Herdr's Claude idle-native submit confirmation is pinned by `tests/fm-backend-he
 The cleanup identity boundary was validated on 2026-07-28 with tmux 3.6a and metadata fixtures for every supported backend, and re-validated on 2026-09-02 after the Orca fixtures were corrected.
 Until then the Orca fixtures recorded bare tokens such as `wt-teardown`, which no real Orca deployment emits: `orca worktree create --json` returns a composite `<id>::<absolute worktree path>` id, so the pre-correction claim did not cover the value cleanup actually validates.
 The fixtures now carry that composite shape.
-Cleanup checks that structure only, and deliberately applies no character allowlist to either half, because the recorded value only ever reaches `orca` as a single quoted argv element and its path half is never used as a filesystem path.
+[`orca-backend.md`](../orca-backend.md#task-shape-and-metadata) owns the shape cleanup enforces, and the `fm_backend_orca_worktree_id_valid` comment in `bin/fm-backend.sh` owns why the shared endpoint-atom allowlist was not widened for it.
 
 ```sh
 tests/fm-teardown-endpoint-safety.test.sh

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -178,7 +178,10 @@ Herdr's Claude idle-native submit confirmation is pinned by `tests/fm-backend-he
 
 ### Cleanup endpoint identity
 
-The cleanup identity boundary was validated on 2026-07-28 with tmux 3.6a and metadata fixtures for every supported backend.
+The cleanup identity boundary was validated on 2026-07-28 with tmux 3.6a and metadata fixtures for every supported backend, and re-validated on 2026-09-02 after the Orca fixtures were corrected.
+Until then the Orca fixtures recorded bare tokens such as `wt-teardown`, which no real Orca deployment emits: `orca worktree create --json` returns a composite `<id>::<absolute worktree path>` id, so the pre-correction claim did not cover the value cleanup actually validates.
+The fixtures now carry that composite shape.
+Cleanup checks that structure only, and deliberately applies no character allowlist to either half, because the recorded value only ever reaches `orca` as a single quoted argv element and its path half is never used as a filesystem path.
 
 ```sh
 tests/fm-teardown-endpoint-safety.test.sh
@@ -194,6 +197,7 @@ Bounded output from the incident regression:
 ```text
 ok - fm-teardown: missing, empty, malformed, ambiguous, and task-mismatched endpoints refuse before every mutation or runtime call
 ok - cleanup identity: valid tmux, Herdr, Zellij, Orca, and cmux records validate while every empty backend target refuses
+ok - cleanup identity: Orca worktree ids are shape-validated while other backends' endpoint atoms stay strict
 ok - tmux backend: direct empty target returns nonzero without invoking tmux
 ok - process cleanup: creation-time PID identity removes only the exact child and preserves the control child
 ok - fm-teardown: dedicated-socket invalid cleanup preserves target/control and valid cleanup removes only the exact target

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -380,7 +380,7 @@ test_remove_worktree_rejects_orca_error_json() {
   orca_case remove-error-json
   printf '{"ok":false,"error":{"code":"worktree_not_found","message":"worktree not found"}}\n' > "$RESP/1.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
-    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_remove_worktree wt-gone' "$ROOT" 2>&1 )
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_remove_worktree 4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-gone' "$ROOT" 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "remove_worktree should fail on Orca ok:false JSON"
   assert_contains "$out" "worktree not found" "remove_worktree should surface the Orca removal error"
@@ -390,11 +390,11 @@ test_remove_worktree_rejects_orca_error_json() {
 test_worktree_path_resolves_id() {
   local out
   orca_case path-resolve
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-123","path":"/tmp/orca-wt"}}}\n' > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-123","path":"/tmp/orca-wt"}}}\n' > "$RESP/1.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
-    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_path wt-123' "$ROOT" )
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_path 4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-123' "$ROOT" )
   [ "$out" = /tmp/orca-wt ] || fail "worktree path helper should print the resolved path, got '$out'"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-123'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-123'$'\x1f''--json' \
     "worktree path helper did not call orca worktree show"
   pass "fm_backend_orca_worktree_path: resolves an Orca worktree id to its path"
 }
@@ -412,14 +412,14 @@ test_json_get_ignores_undocumented_terminal_id_shapes() {
 
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-123"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-123","path":"/tmp/orca-wt","terminal":{"handle":"term-nested"}}}}\n' > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-123","path":"/tmp/orca-wt","terminal":{"handle":"term-nested"}}}}\n' > "$RESP/3.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_create /repo/path fm-task' "$ROOT" )
   wt_id=${out%%$'\t'*}
   wt_path=${out#*$'\t'}
   term=${wt_path#*$'\t'}
   wt_path=${wt_path%%$'\t'*}
-  [ "$wt_id" = wt-123 ] || fail "worktree helper should still print worktree id, got '$wt_id'"
+  [ "$wt_id" = 4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-123 ] || fail "worktree helper should still print worktree id, got '$wt_id'"
   [ "$wt_path" = /tmp/orca-wt ] || fail "worktree helper should still print worktree path, got '$wt_path'"
   [ "$term" = "$wt_path" ] || fail "worktree helper should ignore undocumented result.worktree.terminal and omit an implicit terminal, got '$out'"
   pass "fm_backend_orca_json_get: ignores undocumented terminal id shapes"
@@ -430,16 +430,16 @@ test_worktree_and_terminal_helpers_parse_json() {
   orca_case lifecycle-helpers
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-123"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-123","path":"/tmp/orca-wt"}}}\n' > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-123","path":"/tmp/orca-wt"}}}\n' > "$RESP/3.out"
   printf '{"ok":true,"result":{"terminal":{"handle":"term-123"}}}\n' > "$RESP/4.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_create /repo/path fm-task' "$ROOT" )
   wt_id=${out%%$'\t'*}
   wt_path=${out#*$'\t'}
-  [ "$wt_id" = wt-123 ] || fail "worktree helper should print worktree id, got '$wt_id'"
+  [ "$wt_id" = 4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-123 ] || fail "worktree helper should print worktree id, got '$wt_id'"
   [ "$wt_path" = /tmp/orca-wt ] || fail "worktree helper should print worktree path, got '$wt_path'"
   term=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
-    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_terminal_create wt-123 fm-task' "$ROOT" )
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_terminal_create 4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-123 fm-task' "$ROOT" )
   [ "$term" = term-123 ] || fail "terminal helper should print terminal handle, got '$term'"
   assert_contains "$(cat "$LOG")" $'orca\x1f''repo'$'\x1f''show'$'\x1f''--repo'$'\x1f''path:/repo/path'$'\x1f''--json' \
     "worktree helper should first check repo registration"
@@ -447,7 +447,7 @@ test_worktree_and_terminal_helpers_parse_json() {
     "worktree helper should register an absent repo"
   assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''create'$'\x1f''--repo'$'\x1f''id:repo-123'$'\x1f''--name'$'\x1f''fm-task'$'\x1f''--no-parent'$'\x1f''--setup'$'\x1f''skip'$'\x1f''--json' \
     "worktree helper did not create an independent no-hook worktree"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''create'$'\x1f''--worktree'$'\x1f''id:wt-123'$'\x1f''--title'$'\x1f''fm-task'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''create'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-123'$'\x1f''--title'$'\x1f''fm-task'$'\x1f''--json' \
     "terminal helper did not create a titled terminal for the worktree"
   pass "Orca lifecycle helpers: register repo, create worktree, create terminal, parse stable ids"
 }
@@ -457,7 +457,7 @@ test_worktree_create_removes_worktree_when_path_missing() {
   orca_case lifecycle-missing-path
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-no-path"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-no-path"},"terminal":{"handle":"term-no-path"}}}\n' > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-no-path"},"terminal":{"handle":"term-no-path"}}}\n' > "$RESP/3.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_create /repo/path fm-task' "$ROOT" 2>&1 )
   status=$?
@@ -466,7 +466,7 @@ test_worktree_create_removes_worktree_when_path_missing() {
     "worktree helper did not explain the missing path"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-no-path'$'\x1f''--json' \
     "worktree helper did not close the implicit terminal when path parsing failed"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-no-path'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-no-path'$'\x1f''--force'$'\x1f''--json' \
     "worktree helper did not remove the pathless Orca worktree"
   pass "fm_backend_orca_worktree_create: removes created worktree when path is missing"
 }
@@ -485,7 +485,7 @@ test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails() {
   orca_case pathless-cleanup-fail
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-pathless-cleanup"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-pathless-cleanup"}}}\n' > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-pathless-cleanup"}}}\n' > "$RESP/3.out"
   printf '{"ok":false,"error":{"code":"worktree_not_removed","message":"worktree not removed"}}\n' > "$RESP/4.out"
   printf '{"ok":false,"error":{"code":"worktree_not_removed","message":"worktree not removed"}}\n' > "$RESP/5.out"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -496,12 +496,12 @@ test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails() {
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when path parsing and cleanup fail"
   assert_contains "$out" "orca worktree create did not return a path" \
     "pathless worktree failure should explain the missing path"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-pathless-cleanup'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-pathless-cleanup'$'\x1f''--force'$'\x1f''--json' \
     "pathless cleanup should attempt helper-backed worktree removal"
   assert_present "$state/$id.meta" "failed pathless cleanup should preserve metadata"
   assert_grep "window=fm-$id" "$state/$id.meta" "preserved pathless metadata missing stable window alias"
   assert_grep "backend=orca" "$state/$id.meta" "preserved pathless metadata missing backend=orca"
-  assert_grep "orca_worktree_id=wt-pathless-cleanup" "$state/$id.meta" "preserved pathless metadata missing Orca worktree id"
+  assert_grep "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-pathless-cleanup" "$state/$id.meta" "preserved pathless metadata missing Orca worktree id"
   assert_no_grep "terminal=" "$state/$id.meta" "preserved pathless metadata should not invent a terminal handle"
   pass "fm-spawn.sh --backend orca: preserves metadata when pathless cleanup fails"
 }
@@ -522,7 +522,7 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   log="$LOG"
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-spawn"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-spawn","path":"%s"},"terminal":{"handle":"term-spawn"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-spawn","path":"%s"},"terminal":{"handle":"term-spawn"}}}\n' "$wt" > "$RESP/3.out"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
@@ -533,7 +533,7 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   assert_grep "backend=orca" "$state/$id.meta" "meta missing backend=orca"
   assert_grep "window=fm-$id" "$state/$id.meta" "meta missing stable Orca window alias"
   assert_grep "terminal=term-spawn" "$state/$id.meta" "meta missing terminal handle"
-  assert_grep "orca_worktree_id=wt-spawn" "$state/$id.meta" "meta missing Orca worktree id"
+  assert_grep "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-spawn" "$state/$id.meta" "meta missing Orca worktree id"
   assert_grep "worktree=$wt" "$state/$id.meta" "meta missing Orca worktree path"
   assert_not_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''create' \
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
@@ -615,7 +615,7 @@ test_spawn_refuses_orca_nonisolated_worktree() {
   orca_case bad-spawn
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-bad"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-bad","path":"%s"},"terminal":{"handle":"term-bad"}}}\n' "$proj" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-bad","path":"%s"},"terminal":{"handle":"term-bad"}}}\n' "$proj" > "$RESP/3.out"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
@@ -629,7 +629,7 @@ test_spawn_refuses_orca_nonisolated_worktree() {
     "Orca spawn should validate the worktree before creating a terminal"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-bad'$'\x1f''--json' \
     "Orca spawn should close the implicit terminal after validation aborts"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-bad'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-bad'$'\x1f''--force'$'\x1f''--json' \
     "Orca spawn should remove the worktree after validation aborts"
   pass "fm-spawn.sh --backend orca: refuses non-isolated worktrees and closes implicit terminals"
 }
@@ -649,7 +649,7 @@ test_spawn_removes_orca_worktree_when_terminal_create_fails() {
   orca_case terminal-fail
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-terminal-fail"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-terminal-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-terminal-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
   printf '1\n' > "$RESP/4.exit"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
@@ -658,9 +658,9 @@ test_spawn_removes_orca_worktree_when_terminal_create_fails() {
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when terminal creation fails"
   assert_absent "$state/$id.meta" "terminal-create abort should not record metadata after successful cleanup"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''create'$'\x1f''--worktree'$'\x1f''id:wt-terminal-fail'$'\x1f''--title'$'\x1f'"fm-$id"$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''create'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-terminal-fail'$'\x1f''--title'$'\x1f'"fm-$id"$'\x1f''--json' \
     "Orca spawn should attempt terminal creation before abort cleanup"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-terminal-fail'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-terminal-fail'$'\x1f''--force'$'\x1f''--json' \
     "Orca spawn should remove the worktree when terminal creation fails"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
     "Orca spawn should not close a terminal when no handle was recorded"
@@ -682,7 +682,7 @@ test_spawn_preserves_orca_metadata_when_abort_cleanup_fails() {
   orca_case cleanup-fail
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-cleanup-fail"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-cleanup-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-cleanup-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
   printf '1\n' > "$RESP/4.exit"
   printf '1\n' > "$RESP/5.exit"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -691,12 +691,12 @@ test_spawn_preserves_orca_metadata_when_abort_cleanup_fails() {
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --mode no-mistakes --yolo off --backend orca 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when terminal creation and abort cleanup fail"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-cleanup-fail'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-cleanup-fail'$'\x1f''--force'$'\x1f''--json' \
     "Orca spawn should attempt helper cleanup before preserving metadata"
   assert_present "$state/$id.meta" "failed Orca abort cleanup should preserve metadata"
   assert_grep "window=fm-$id" "$state/$id.meta" "preserved metadata missing stable window alias"
   assert_grep "backend=orca" "$state/$id.meta" "preserved metadata missing backend=orca"
-  assert_grep "orca_worktree_id=wt-cleanup-fail" "$state/$id.meta" "preserved metadata missing Orca worktree id"
+  assert_grep "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-cleanup-fail" "$state/$id.meta" "preserved metadata missing Orca worktree id"
   assert_no_grep "terminal=" "$state/$id.meta" "preserved metadata should not invent a terminal handle"
   pass "fm-spawn.sh --backend orca: preserves metadata when abort cleanup fails"
 }
@@ -715,7 +715,7 @@ test_spawn_releases_orca_resources_when_metadata_write_fails() {
   orca_case meta-fail
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-meta-fail"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-meta-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-meta-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
   printf '{"ok":true,"result":{"terminal":{"handle":"term-meta-fail"}}}\n' > "$RESP/4.out"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
@@ -727,7 +727,7 @@ test_spawn_releases_orca_resources_when_metadata_write_fails() {
     "spawn should report metadata publication failure without relying on platform-specific mv output"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-meta-fail'$'\x1f''--json' \
     "Orca spawn should close the recorded terminal when a later abort occurs"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-meta-fail'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-meta-fail'$'\x1f''--force'$'\x1f''--json' \
     "Orca spawn should remove the recorded worktree when a later abort occurs"
   [ ! -f "$state/$id.meta" ] || fail "metadata-write abort should not publish a regular metadata file"
   pass "fm-spawn.sh --backend orca: releases terminal and worktree on later aborts"
@@ -831,10 +831,10 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-teardown" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-teardown" \
+    "backend=orca" "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-teardown" \
     "decisions_reviewed=1" "decision_keys="
   orca_case teardown
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-teardown","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-teardown","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -845,7 +845,7 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
   expect_code 0 "$rc" "Orca scout teardown should succeed once report exists"$'\n'"$out"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-teardown'$'\x1f''--json' \
     "teardown did not close the recorded Orca terminal"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-teardown'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-teardown'$'\x1f''--force'$'\x1f''--json' \
     "teardown did not remove the Orca worktree through orca worktree rm"
   assert_absent "$state/$id.meta" "teardown should remove task metadata"
   pass "fm-teardown.sh backend=orca: scout report gate then helper-backed worktree removal"
@@ -868,10 +868,10 @@ test_scout_teardown_refuses_orca_id_path_mismatch() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-scout-mismatch" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-scout-mismatch" \
+    "backend=orca" "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-scout-mismatch" \
     "decisions_reviewed=1" "decision_keys="
   orca_case scout-mismatch
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-scout-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-scout-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -904,7 +904,7 @@ test_teardown_removes_orca_worktree_when_path_missing() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-missing-path" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-missing-path" \
+    "backend=orca" "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-missing-path" \
     "decisions_reviewed=1" "decision_keys="
   orca_case missing-path
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -917,7 +917,7 @@ test_teardown_removes_orca_worktree_when_path_missing() {
   expect_code 0 "$rc" "Orca teardown should release helpers even when the path is absent"$'\n'"$out"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-missing-path'$'\x1f''--json' \
     "teardown did not close the recorded Orca terminal when the path was absent"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-missing-path'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-missing-path'$'\x1f''--force'$'\x1f''--json' \
     "teardown did not remove the recorded Orca worktree when the path was absent"
   assert_absent "$state/$id.meta" "successful helper cleanup should remove task metadata"
   pass "fm-teardown.sh backend=orca: releases terminal/worktree when path is absent"
@@ -937,7 +937,7 @@ test_teardown_preserves_metadata_when_orca_remove_error_json() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-remove-error" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-remove-error" \
+    "backend=orca" "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-remove-error" \
     "decisions_reviewed=1" "decision_keys="
   orca_case remove-error-teardown
   printf '{"ok":true,"result":{}}\n' > "$RESP/1.out"
@@ -968,7 +968,7 @@ test_scout_teardown_refuses_orca_missing_report_when_path_missing() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-missing-report" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-missing-report"
+    "backend=orca" "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-missing-report"
   orca_case missing-report
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
@@ -998,7 +998,7 @@ test_ship_teardown_refuses_orca_missing_worktree_path() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-missing-ship" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-missing-ship"
+    "backend=orca" "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-missing-ship"
   orca_case missing-ship-path
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
@@ -1029,9 +1029,9 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-match" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-match"
+    "backend=orca" "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-ship-match"
   orca_case ship-match
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-match","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-ship-match","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -1040,11 +1040,11 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
   rc=$?
   set -e
   expect_code 0 "$rc" "Orca ship teardown should succeed when the id path matches the inspected worktree"$'\n'"$out"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-match'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-ship-match'$'\x1f''--json' \
     "teardown did not resolve the Orca worktree id before removal"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-ship-match'$'\x1f''--json' \
     "teardown did not close the matched Orca terminal"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-ship-match'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-ship-match'$'\x1f''--force'$'\x1f''--json' \
     "teardown did not remove the matched Orca worktree"
   assert_absent "$state/$id.meta" "successful matched teardown should remove task metadata"
   pass "fm-teardown.sh backend=orca: ship teardown requires a matching Orca id path"
@@ -1064,7 +1064,7 @@ test_ship_teardown_refuses_orca_unresolvable_worktree_id() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-unresolved" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-unresolved"
+    "backend=orca" "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-ship-unresolved"
   orca_case ship-unresolved
   printf '1\n' > "$RESP/1.exit"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -1075,9 +1075,9 @@ test_ship_teardown_refuses_orca_unresolvable_worktree_id() {
   rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "Orca ship teardown should refuse when the worktree id cannot be resolved"
-  assert_contains "$out" "cannot resolve Orca worktree id wt-ship-unresolved" \
+  assert_contains "$out" "cannot resolve Orca worktree id 4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-ship-unresolved" \
     "unresolvable Orca worktree id refusal should explain the fail-closed check"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-unresolved'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-ship-unresolved'$'\x1f''--json' \
     "teardown did not attempt to resolve the Orca worktree id"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
     "refused unresolved Orca ship teardown should not close terminals"
@@ -1103,9 +1103,9 @@ test_ship_teardown_refuses_orca_id_path_mismatch() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-mismatch" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-mismatch"
+    "backend=orca" "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-ship-mismatch"
   orca_case ship-mismatch
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-ship-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -1116,7 +1116,7 @@ test_ship_teardown_refuses_orca_id_path_mismatch() {
   [ "$rc" -ne 0 ] || fail "Orca ship teardown should refuse when the id path differs from worktree="
   assert_contains "$out" "not inspected worktree" \
     "mismatched Orca worktree path refusal should name the mismatch"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-mismatch'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-ship-mismatch'$'\x1f''--json' \
     "teardown did not resolve the mismatched Orca worktree id"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
     "refused mismatched Orca ship teardown should not close terminals"
@@ -1172,7 +1172,7 @@ test_teardown_refuses_orca_worktree_without_terminal_handle() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-no-terminal" \
+    "backend=orca" "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-no-terminal" \
     "decisions_reviewed=1" "decision_keys="
   orca_case no-terminal
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -1209,10 +1209,10 @@ test_secondmate_force_teardown_removes_orca_child_via_orca() {
     "window=fm-$child_id" "endpoint_task_id=$child_id" \
     "terminal=term-child-cleanup" "worktree=$childwt" "project=$childproj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-child-cleanup"
+    "backend=orca" "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-child-cleanup"
   orca_case secondmate-child-cleanup
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/1.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/2.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/2.out"
   printf '{"ok":true,"result":{}}\n' > "$RESP/3.out"
   printf '{"ok":true,"result":{}}\n' > "$RESP/4.out"
   add_tmux_fake "$FB"
@@ -1225,7 +1225,7 @@ test_secondmate_force_teardown_removes_orca_child_via_orca() {
   expect_code 0 "$rc" "forced secondmate teardown should remove Orca child work through Orca"$'\n'"$out"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-child-cleanup'$'\x1f''--json' \
     "child cleanup did not close the recorded Orca terminal"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-child-cleanup'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-child-cleanup'$'\x1f''--force'$'\x1f''--json' \
     "child cleanup did not remove the Orca worktree through orca worktree rm"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f'"fm-$child_id" \
     "child cleanup closed the stable alias instead of the Orca terminal"
@@ -1255,9 +1255,9 @@ test_secondmate_force_teardown_refuses_orca_child_id_path_mismatch() {
     "window=fm-$child_id" "endpoint_task_id=$child_id" \
     "terminal=term-child-mismatch" "worktree=$childwt" "project=$childproj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-child-mismatch"
+    "backend=orca" "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-child-mismatch"
   orca_case secondmate-child-mismatch
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-child-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-child-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
   add_tmux_fake "$FB"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
@@ -1296,7 +1296,7 @@ test_secondmate_force_teardown_refuses_partial_orca_child() {
     "window=fm-$child_id" "endpoint_task_id=$child_id" \
     "worktree=$childwt" "project=$childproj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-partial-child"
+    "backend=orca" "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-partial-child"
   orca_case secondmate-partial-child-cleanup
   add_tmux_fake "$FB"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -392,7 +392,7 @@ test_orca_refuses_an_escape_harness_interrupt() {
   {
     cat "$dir/home/state/t1.meta"
     echo "terminal=term-1"
-    echo "orca_worktree_id=wt-1"
+    echo "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-1"
   } > "$dir/home/state/t1.meta.new"
   sed 's|^window=.*|window=fm-t1|' "$dir/home/state/t1.meta.new" > "$dir/home/state/t1.meta"
   out=$(run_control "$dir" t1 interrupt); rc=$?

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -257,6 +257,7 @@ test_orca_worktree_id_shape_is_validated_without_relaxing_other_backends() {
     "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::orca/workspaces/fm/wt" \
     "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::" \
     "/orca/workspaces/fm/wt::/orca/workspaces/fm/wt" \
+    "::/orca/workspaces/fm/wt" \
     "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt/" \
     "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces//fm/wt" \
     "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/../escape"; do

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -221,9 +221,12 @@ test_supported_backend_endpoint_records_validate() {
   fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" || fail "valid Zellij endpoint refused"
 
   id=orca-task
+  # Orca records the composite "<uuid>::<absolute worktree path>" id that
+  # `orca worktree create --json` actually emits, not a bare token.
   fm_write_meta "$dir/home/state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
-    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" "orca_worktree_id=worktree-9"
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/fm-$id"
   fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" || fail "valid Orca endpoint refused"
   [ "$FM_BACKEND_VALIDATED_TARGET" = term-7 ] || fail "Orca validation did not select its terminal"
 
@@ -241,6 +244,61 @@ test_supported_backend_endpoint_records_validate() {
     [ "$target" -ne 0 ] || fail "$backend generic kill accepted an empty target"
   done
   pass "cleanup identity: valid tmux, Herdr, Zellij, Orca, and cmux records validate while every empty backend target refuses"
+}
+
+test_orca_worktree_id_shape_is_validated_without_relaxing_other_backends() {
+  local dir id=orca-shape value rc
+
+  dir=$(make_case orca-shape)
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-backend.sh"
+  for value in \
+    "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3" \
+    "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::orca/workspaces/fm/wt" \
+    "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::" \
+    "/orca/workspaces/fm/wt::/orca/workspaces/fm/wt" \
+    "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt/" \
+    "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces//fm/wt" \
+    "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/../escape"; do
+    fm_write_meta "$dir/home/state/$id.meta" \
+      "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
+      "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+      "orca_worktree_id=$value"
+    set +e
+    fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" >/dev/null 2>&1
+    rc=$?
+    set -e
+    [ "$rc" -ne 0 ] || fail "malformed Orca worktree id accepted: '$value'"
+  done
+
+  # Orca's id format is undocumented and real worktree paths carry spaces and
+  # non-ASCII characters, so only the composite structure is required.
+  for value in \
+    "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/Users/Example User/orca/workspaces/fm/wt" \
+    "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/équipe/wt" \
+    "wt_20260902_01::/orca/workspaces/fm/wt"; do
+    fm_write_meta "$dir/home/state/$id.meta" \
+      "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
+      "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+      "orca_worktree_id=$value"
+    fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" \
+      || fail "well-formed Orca worktree id refused: '$value'"
+  done
+
+  if fm_backend_orca_worktree_id_valid ""; then
+    fail "Orca worktree id validation accepted an empty value"
+  fi
+
+  # The composite shape is accepted for Orca only; the shared atom validator that
+  # guards tmux, Herdr, Zellij, and cmux endpoint atoms still rejects ':' and '/'.
+  for value in "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt" "lab:w1" "/tmp/lab"; do
+    if fm_backend_endpoint_atom_valid "$value"; then
+      fail "shared endpoint atom validation was widened to accept '$value'"
+    fi
+  done
+  fm_backend_endpoint_atom_valid "lab-1" || fail "shared endpoint atom validation rejected a plain token"
+
+  pass "cleanup identity: Orca worktree ids are shape-validated while other backends' endpoint atoms stay strict"
 }
 
 test_tmux_empty_target_refuses_without_invocation() {
@@ -369,6 +427,7 @@ test_invalid_endpoint_records_refuse_before_mutation
 test_control_lock_contention_refuses_before_mutation
 test_metadata_lock_serializes_destructive_cleanup
 test_supported_backend_endpoint_records_validate
+test_orca_worktree_id_shape_is_validated_without_relaxing_other_backends
 test_tmux_empty_target_refuses_without_invocation
 test_recorded_process_identity_cleanup_is_exact
 test_isolated_tmux_invalid_and_valid_cleanup

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -259,6 +259,7 @@ test_orca_worktree_id_shape_is_validated_without_relaxing_other_backends() {
     "/orca/workspaces/fm/wt::/orca/workspaces/fm/wt" \
     "::/orca/workspaces/fm/wt" \
     "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt/" \
+    "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/" \
     "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces//fm/wt" \
     "4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/../escape"; do
     fm_write_meta "$dir/home/state/$id.meta" \


### PR DESCRIPTION
## Intent

The captain wants PR #3555 landed. His words: "Get a worker to sort it... Don't get the worker to write any more comments on the PR just get it to pass the tests and get the no-mistakes running properly somehow."

https://github.com/kunchenguid/firstmate/pull/3555 - "fix(bin): validate Orca worktree ids by their real composite shape", branch `fm/fm-orca-atom-r3b`, author Evaske, still open after ~24 hours.

Why it matters: without it, cleanup of every Orca-backed task refuses, because `fm_backend_validate_task_endpoint` applies a single-atom character rule to `orca_worktree_id`, which is deliberately a `<uuid>::<path>` composite. `config/backend` here is `orca`, so this blocks every task. Two finished investigations are waiting on it right now.

**The code is already written and already reviewed.** Do not rewrite it. An automated reviewer raised one objection about `opaque-id::/` slipping through; the author demonstrated with a shell reproduction that `*/` already matches a bare `/`, and the reviewer explicitly withdrew the finding. 14 of 15 checks pass.

## What Changed

- Added `fm_backend_orca_worktree_id_valid` in `bin/fm-backend.sh` and used it for `orca_worktree_id` in `fm_backend_validate_task_endpoint`, so Orca endpoints are checked against the composite `<opaque id>::<absolute worktree path>` shape that `orca worktree create --json` actually emits — a non-empty slash-free id half plus an absolute path with no empty, trailing, or `..` segment — instead of the single-atom allowlist that refused every real Orca id. `fm_backend_endpoint_atom_valid` is untouched, so tmux, Herdr, Zellij, and cmux atoms stay strict.
- Corrected the Orca fixtures across `tests/fm-backend-orca.test.sh`, `tests/fm-control.test.sh`, and `tests/fm-teardown-endpoint-safety.test.sh` to record composite ids rather than bare tokens like `wt-teardown`, and added a refusal/acceptance loop pinning malformed shapes (bare atom, relative or empty path, bare `/` root, `//`, `..`, slash-bearing id half) alongside accepted ids whose path carries spaces or non-ASCII characters.
- Documented the enforced shape and its ownership in `docs/orca-backend.md` (noting it gates control-plane verbs as well as cleanup) and recorded the fixture correction plus the new test line in `docs/verification/runtime-backends.md`.

## Risk Assessment

✅ Low: The change adds one structural validator at the single shared boundary that all seven endpoint-validation callers already route through, narrows behavior only for backend=orca, leaves the injection-guard allowlist for every other backend untouched, and the accompanying fixture and doc updates are consistent with the code (no bare Orca ids remain in tests, the referenced doc anchor exists, and the recorded pass line matches the new test's registration order).

## Testing

<code>The configured baseline (`bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`) had already passed; on top of it I ran the three test files this change touches — `fm-teardown-endpoint-safety`, `fm-backend-orca`, and `fm-control` — all green, with the new shape-validation test included and no repeat of the lsof stall noted in the earlier run. Because passing unit tests alone do not show the reported failure is gone, I also drove the real `bin/fm-teardown.sh` CLI on an Orca-backed task against a fake Orca runtime, comparing the base commit&#39;s `bin/` with this branch&#39;s on an identical task record: base refuses and preserves the task, this branch completes cleanup and passes the composite `&lt;id&gt;::&lt;path&gt;` through to `orca worktree rm --force` unmodified, and a traversal id is still refused before any Orca command runs. That before/after transcript is the artifact. No screenshot applies — this is a shell CLI change with no rendered surface. Working tree left clean; the only files written outside it are in the evidence directory.</code>

<details>
<summary>Evidence: Orca-backed task cleanup, before/after CLI transcript</summary>

Source: [Orca-backed task cleanup, before/after CLI transcript](https://github.com/Evaske/firstmate/blob/f4aad07e238c8f8e826be263a6d127a07b44857b/.no-mistakes/evidence/fm/fm-orca-atom-r3b/orca-cleanup-end-to-end.txt)

<code>### BEFORE - base 8f7b79c (every Orca cleanup refuses)&#10;orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-teardown&#10;$ bin/fm-teardown.sh orcacleanupdemo&#10;REFUSED: Orca endpoint metadata for task orcacleanupdemo is malformed or inconsistent; preserving task state.&#10;[exit code: 1]&#10;Orca CLI commands firstmate actually issued:&#10;(none - refused before touching the Orca runtime)&#10;Task record after the run:&#10;state/orcacleanupdemo.meta STILL PRESENT (task not cleaned up)&#10;&#10;### AFTER - PR #3555 at HEAD 7f64352 (same record, same command)&#10;orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-teardown&#10;$ bin/fm-teardown.sh orcacleanupdemo&#10;teardown orcacleanupdemo complete (window term-teardown, worktree .../worktree)&#10;[exit code: 0]&#10;Orca CLI commands firstmate actually issued:&#10;$ orca worktree show --worktree id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-teardown --json&#10;$ orca terminal close --terminal term-teardown --json&#10;$ orca worktree rm --worktree id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-teardown --force --json&#10;Task record after the run:&#10;state/orcacleanupdemo.meta removed (task cleaned up)&#10;&#10;### AFTER - a malformed id is still refused (path traversal in the path half)&#10;orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/../escape&#10;$ bin/fm-teardown.sh orcacleanupdemo&#10;REFUSED: Orca endpoint metadata for task orcacleanupdemo is malformed or inconsistent; preserving task state.&#10;[exit code: 1]&#10;Orca CLI commands firstmate actually issued:&#10;(none - refused before touching the Orca runtime)&#10;Task record after the run:&#10;state/orcacleanupdemo.meta STILL PRESENT (task not cleaned up)</code>

```text
Orca-backed task cleanup, end to end
====================================

Same task record, same fake Orca runtime, same command - only bin/ differs.
orca_worktree_id is the composite '<opaque id>::<absolute worktree path>' that
`orca worktree create --json` emits and fm-spawn records.

---

\### BEFORE - base 8f7b79c77c2198a71a01082215227a64500015e3 (every Orca cleanup refuses)

Recorded task record (state/orcacleanupdemo.meta), backend=orca:
    window=fm-orcacleanupdemo
    terminal=term-teardown
    backend=orca
    orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-teardown

$ bin/fm-teardown.sh orcacleanupdemo
    REFUSED: Orca endpoint metadata for task orcacleanupdemo is malformed or inconsistent; preserving task state.
    [exit code: 1]

Orca CLI commands firstmate actually issued:
    (none - refused before touching the Orca runtime)

Task record after the run:
    state/orcacleanupdemo.meta STILL PRESENT (task not cleaned up)

---

\### AFTER - PR #3555 at HEAD 7f64352 (same record, same command)

Recorded task record (state/orcacleanupdemo.meta), backend=orca:
    window=fm-orcacleanupdemo
    terminal=term-teardown
    backend=orca
    orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-teardown

$ bin/fm-teardown.sh orcacleanupdemo
    teardown orcacleanupdemo complete (window term-teardown, worktree /var/folders/h_/l_f50zkn4sg527hymkgqfz0r0000gn/T//orca-cleanup-e2e.R3LP7m/after/worktree)
    Backlog: orcacleanupdemo just finished (this home keeps no backlog at /private/var/folders/h_/l_f50zkn4sg527hymkgqfz0r0000gn/T/orca-cleanup-e2e.R3LP7m/after/data/backlog.md). Update /private/var/folders/h_/l_f50zkn4sg527hymkgqfz0r0000gn/T/orca-cleanup-e2e.R3LP7m/after/data/backlog.md - move orcacleanupdemo to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due.
    [exit code: 0]

Orca CLI commands firstmate actually issued:
    $ orca worktree show --worktree id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-teardown --json
    $ orca terminal close --terminal term-teardown --json
    $ orca worktree rm --worktree id:4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/wt-teardown --force --json

Task record after the run:
    state/orcacleanupdemo.meta removed (task cleaned up)

---

\### AFTER - a malformed id is still refused (path traversal in the path half)

Recorded task record (state/orcacleanupdemo.meta), backend=orca:
    window=fm-orcacleanupdemo
    terminal=term-teardown
    backend=orca
    orca_worktree_id=4a2f8e1c-9d3b-4f57-b0a6-2c7e15d9f8a3::/orca/workspaces/fm/../escape

$ bin/fm-teardown.sh orcacleanupdemo
    REFUSED: Orca endpoint metadata for task orcacleanupdemo is malformed or inconsistent; preserving task state.
    [exit code: 1]

Orca CLI commands firstmate actually issued:
    (none - refused before touching the Orca runtime)

Task record after the run:
    state/orcacleanupdemo.meta STILL PRESENT (task not cleaned up)

---
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7f643525ec0bb70e4f2f5bd66cfaa04466b10abd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-backend-orca.test.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-backend.sh:402` - Tradeoff note, no action required for this merge. The new composite contract `&lt;opaque id&gt;::&lt;absolute path&gt;` is now the sole accepted shape for `orca_worktree_id`, but it is enforced only on the read side (`fm_backend_validate_task_endpoint`). The write side, `bin/fm-spawn.sh:867` and `bin/fm-spawn.sh:3078`, records whatever `fm_backend_orca_json_get worktree-id` returned without checking it. Concretely: if an Orca build emits a bare id (the JSON getter already falls back through `wt.id || wt.worktreeId || r.worktreeId`), spawn succeeds and writes it, and every later `fm-teardown`, `fm-control`, and relaunch refuses for the life of the task, requiring manual metadata surgery to recover. Note this is a shape-drift hazard, not a defect in the change: the author verified the composite shape against three real recorded values, and the refusal is fail-closed (metadata and worktree preserved), which is strictly better than the pre-fix state where every Orca cleanup refused. I am not recommending a fix here because the smallest honest remedy would add spawn-time validation plus resource-release handling on the abort path, extending the change beyond its stated intent.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>`bash tests/fm-teardown-endpoint-safety.test.sh` — full file, all 8 tests including the new `test_orca_worktree_id_shape_is_validated_without_relaxing_other_backends` (the lsof stall reported in the previous run did not reproduce; file completed in ~7s)</code>
- <code>`bash tests/fm-backend-orca.test.sh` — full file, covers the Orca spawn/teardown lifecycle with the corrected composite-id fixtures</code>
- <code>`bash tests/fm-control.test.sh` — covers `test_orca_refuses_an_escape_harness_interrupt`, the other test touched by this change</code>
- <code>Manual end-to-end: ran the real `bin/fm-teardown.sh &lt;task&gt;` on a backend=orca scout task against a fake `orca` CLI that logs every argv, once with `bin/` extracted from base 8f7b79c (via `git archive`) and once at HEAD 7f64352, capturing stdout, exit code, the Orca commands issued, and whether the task record survived</code>
- <code>Manual end-to-end negative case: same run at HEAD with `orca_worktree_id=4a2f8e1c-...::/orca/workspaces/fm/../escape` to confirm a malformed id still refuses before any Orca invocation</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
