### PR TITLE
test: keep composer fixtures Bash 3.2-clean and align relaunch startup waits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,16 @@ jobs:
             exit 1
           }
 
+          # The composer classifier runs under stock /bin/bash on every macOS
+          # fleet, and its fixtures must be pure UTF-8 (Bash 3.2 has no \u).
+          composer_output=$(/bin/bash tests/fm-composer-lib.test.sh)
+          printf '%s\n' "$composer_output"
+          composer_count=$(printf '%s\n' "$composer_output" | grep -c '^ok - ')
+          [ "$composer_count" -eq 33 ] || {
+            echo "::error::expected 33 composer classifier tests, got $composer_count"
+            exit 1
+          }
+
           command -v npm >/dev/null || { echo "::error::npm is required to install tasks-axi"; exit 1; }
           npm install -g tasks-axi@0.2.5 >/dev/null
           PATH="$(npm prefix -g)/bin:$PATH"

--- a/docs/fm-test-isolation-proof.md
+++ b/docs/fm-test-isolation-proof.md
@@ -125,6 +125,7 @@ Admitting the family moves that tail into the bounded concurrent group.
 Current runner-file selection was verified on 2026-08-28 with the runner and its tests bound to each measured Bash version.
 Because the runner uses `#!/usr/bin/env bash` and invokes each test with `bash` from `PATH`, the stock macOS measurement used `PATH=/bin:$PATH bin/fm-test-run.sh --changed --max-wall-ms 300000` so both resolved to `/bin/bash` 3.2.57.
 Two runs selected all 33 scripts, passed the five-minute result check in 153.5s and 166.8s, and reported the same two failures as `main`: `tests/fm-muse-harness.test.sh` and `tests/fm-composer-lib.test.sh`.
+`tests/fm-composer-lib.test.sh` passes under that shell as of 2026-09-03: its failure was an escaped `\u` fixture that Bash 3.2 cannot decode, and the stock macOS Bash lane in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) now runs the suite under real `/bin/bash` 3.2 so the defect cannot return unnoticed.
 With Bash 5.3.9 on `PATH`, three runs of `bin/fm-test-run.sh --changed --max-wall-ms 300000` selected the same 33 scripts, completed with 0 failures, and reported 163.8s, 172.0s, and 166.9s.
 All five runs used plain `--changed` with no `--jobs` flag, exercised the production automatic scheduler, and completed under five minutes.
 

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -272,19 +272,19 @@ test_matrix_herdr_halfblock_rule_bounds_bare_wrap() {
   # Captured live from a herdr cursor pane. The glyphs are literal UTF-8 on
   # purpose: stock macOS Bash 3.2 has no `\u` escape in printf or $'...', so an
   # escaped fixture feeds the classifier the six ASCII bytes `\u2580` instead.
-  local screen plain out
-  plain=$'transcript\n ▄▄▄▄▄▄▄▄\n  → Add a follow-up\n ▀▀▀▀▀▀▀▀\n  Cursor Grok 4.5 High · 6.7%   Run Everything\n  ~/wt · 64cdd3a'
+  local screen esc out
   # The closing rule must bound the region, so the footer below is not input.
   fm_composer_row_has_edge ' ▀▀▀' \
     || fail "a half-block rule row must count as a structural edge"
   fm_composer_row_has_edge ' ▄▄▄' \
     || fail "the upper half-block rule must count as a structural edge"
-  # Non-vacuousness: the footer rows really are non-blank content that would be
-  # swallowed if the rule did not bound the region.
-  case "$plain" in *"Run Everything"*) : ;; *) fail "fixture lost its footer content" ;; esac
-  ESC_LOCAL=$(printf '\033')
-  screen=$'transcript\n ▄▄▄▄▄▄▄▄\n'"  ${ESC_LOCAL}[2m→ ${ESC_LOCAL}[0;7mA${ESC_LOCAL}[0;2mdd a follow-up${ESC_LOCAL}[0m"$'\n ▀▀▀▀▀▀▀▀\n  Cursor Grok 4.5 High · 6.7%   Run Everything\n  ~/wt · 64cdd3a'
-  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$(printf '%b' "$screen")")
+  esc=$(printf '\033')
+  screen=$'transcript\n ▄▄▄▄▄▄▄▄\n'"  ${esc}[2m→ ${esc}[0;7mA${esc}[0;2mdd a follow-up${esc}[0m"$'\n ▀▀▀▀▀▀▀▀\n  Cursor Grok 4.5 High · 6.7%   Run Everything\n  ~/wt · 64cdd3a'
+  # Non-vacuousness: the classified fixture really carries non-blank footer rows
+  # below the closing rule, which would be swallowed if the rule did not bound
+  # the region.
+  case "$screen" in *"Run Everything"*) : ;; *) fail "fixture lost its footer content" ;; esac
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen")
   [ "$out" = empty ] \
     || fail "an idle cursor composer inside herdr half-block rules must read empty, got '$out'"
   pass "matrix: herdr half-block rules bound a bare composer's wrap region"

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -269,19 +269,21 @@ test_matrix_herdr_halfblock_rule_bounds_bare_wrap() {
   # rather than the box-drawing family. Without treating those as edges, a bare
   # composer's WRAP region walks through its own closing rule and swallows the
   # footer, whose real content turns an idle pane into a false `pending`.
-  # Captured live from a herdr cursor pane.
+  # Captured live from a herdr cursor pane. The glyphs are literal UTF-8 on
+  # purpose: stock macOS Bash 3.2 has no `\u` escape in printf or $'...', so an
+  # escaped fixture feeds the classifier the six ASCII bytes `\u2580` instead.
   local screen plain out
-  plain=$'transcript\n \u2584\u2584\u2584\u2584\u2584\u2584\u2584\u2584\n  \u2192 Add a follow-up\n \u2580\u2580\u2580\u2580\u2580\u2580\u2580\u2580\n  Cursor Grok 4.5 High \u00b7 6.7%   Run Everything\n  ~/wt \u00b7 64cdd3a'
+  plain=$'transcript\n ▄▄▄▄▄▄▄▄\n  → Add a follow-up\n ▀▀▀▀▀▀▀▀\n  Cursor Grok 4.5 High · 6.7%   Run Everything\n  ~/wt · 64cdd3a'
   # The closing rule must bound the region, so the footer below is not input.
-  fm_composer_row_has_edge " $(printf '\u2580\u2580\u2580')" \
+  fm_composer_row_has_edge ' ▀▀▀' \
     || fail "a half-block rule row must count as a structural edge"
-  fm_composer_row_has_edge " $(printf '\u2584\u2584\u2584')" \
+  fm_composer_row_has_edge ' ▄▄▄' \
     || fail "the upper half-block rule must count as a structural edge"
   # Non-vacuousness: the footer rows really are non-blank content that would be
   # swallowed if the rule did not bound the region.
   case "$plain" in *"Run Everything"*) : ;; *) fail "fixture lost its footer content" ;; esac
   ESC_LOCAL=$(printf '\033')
-  screen=$'transcript\n \u2584\u2584\u2584\u2584\u2584\u2584\u2584\u2584\n'"  ${ESC_LOCAL}[2m\u2192 ${ESC_LOCAL}[0;7mA${ESC_LOCAL}[0;2mdd a follow-up${ESC_LOCAL}[0m"$'\n \u2580\u2580\u2580\u2580\u2580\u2580\u2580\u2580\n  Cursor Grok 4.5 High \u00b7 6.7%   Run Everything\n  ~/wt \u00b7 64cdd3a'
+  screen=$'transcript\n ▄▄▄▄▄▄▄▄\n'"  ${ESC_LOCAL}[2m→ ${ESC_LOCAL}[0;7mA${ESC_LOCAL}[0;2mdd a follow-up${ESC_LOCAL}[0m"$'\n ▀▀▀▀▀▀▀▀\n  Cursor Grok 4.5 High · 6.7%   Run Everything\n  ~/wt · 64cdd3a'
   out=$(fm_composer_classify_screen "$CAPS_STYLED" "$(printf '%b' "$screen")")
   [ "$out" = empty ] \
     || fail "an idle cursor composer inside herdr half-block rules must read empty, got '$out'"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -348,7 +348,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
     FM_FAKE_TRACE_RELEASE="$launch_release" \
     run_control "$dir" rl28 relaunch --note "continue after publication" > "$dir/control.out" &
   control_pid=$!
-  while [ ! -e "$prepare" ] && [ "$i" -lt 200 ]; do
+  while [ ! -e "$prepare" ] && [ "$i" -lt 1000 ]; do
     /bin/sleep 0.01
     i=$((i + 1))
   done
@@ -367,7 +367,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
       --carry-platform x --carry-max 280 > "$dir/link.out" 2>&1 &
   link_pid=$!
   i=0
-  while [ ! -e "$waiting" ] && [ "$i" -lt 200 ]; do
+  while [ ! -e "$waiting" ] && [ "$i" -lt 1000 ]; do
     /bin/sleep 0.01
     i=$((i + 1))
   done
@@ -380,7 +380,7 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
   }
   : > "$launch_release"
   i=0
-  while [ ! -e "$ready" ] && [ "$i" -lt 200 ]; do
+  while [ ! -e "$ready" ] && [ "$i" -lt 1000 ]; do
     /bin/sleep 0.01
     i=$((i + 1))
   done
@@ -987,7 +987,7 @@ test_prepublication_failure_keeps_concurrent_durable_metadata() {
     run_control "$dir" rl30 relaunch --harness codex --note "preserve concurrent metadata" \
       > "$dir/control.out" &
   control_pid=$!
-  while [ ! -e "$dir/cwd-race-ready" ] && [ "$i" -lt 200 ]; do
+  while [ ! -e "$dir/cwd-race-ready" ] && [ "$i" -lt 1000 ]; do
     /bin/sleep 0.01
     i=$((i + 1))
   done


### PR DESCRIPTION
## Intent

Keep the shared test fixtures runnable on stock macOS Bash 3.2, and give the relaunch startup waits the same 10s budget the rest of that file already uses.

## What Changed

- Rewrote the `matrix_herdr_halfblock_rule_bounds_bare_wrap` fixture in `tests/fm-composer-lib.test.sh` to use literal UTF-8 half-block, arrow, and middot glyphs instead of `\u` escapes that stock macOS Bash 3.2 cannot decode, and pointed the non-vacuousness footer check at the styled screen actually handed to `fm_composer_classify_screen`.
- Raised the four startup poll loops in `tests/fm-control-relaunch.test.sh` from 200 to 1000 iterations of `sleep 0.01`, matching the 10s budget the rest of that file already uses.
- Added a stock `/bin/bash` step to `.github/workflows/ci.yml` that runs the composer classifier suite and fails unless all 33 `ok - ` lines appear, and recorded the resolved Bash 3.2 failure in `docs/fm-test-isolation-proof.md`.

## Risk Assessment

✅ Low: Test-and-CI-only change that is well-bounded and matches its intent: the composer fixture now carries literal UTF-8 (verified by hexdump, no `\u` left outside a comment, and no bash-4-only constructs in tests/fm-composer-lib.test.sh, tests/lib.sh, or bin/fm-composer-lib.sh, whose `${!name}` indirections are 3.2-safe), the new macos-latest lane executes the real suite under stock /bin/bash 3.2 with a count pin matching the 33 defined-and-invoked tests, the non-vacuity guard now inspects the `$screen` fixture that is actually classified and is backed by the two explicit `fm_composer_row_has_edge` assertions so the case cannot silently retire, `printf '%b'` removal is byte-for-byte neutral on a fixture with no backslashes, and the relaunch waits move from 200x0.01s to 1000x0.01s = the same nominal 10s the file's existing 100x0.1s waits already use.

## Testing

Ran the composer classifier suite and the fm-control relaunch suite under this machine's stock /bin/bash 3.2.57: the branch fixture passes all 33 composer cases while the base-commit fixture fails on 3.2 with `not ok - a half-block rule row must count as a structural edge`, so the Bash 3.2 defect is reproduced before the fix and gone after it; the relaunch suite passes end to end, and a slow-start simulation (trace delivery marker arriving 8s late) shows the old 200-iteration wait aborting with `relaunch did not reach trace delivery` while the new 1000-iteration/10s wait completes, which is the file's existing 10s convention. The new CI lane was exercised by extracting the composer block from the `macos-stock-bash` job in ci.yml and running it for real: it passes on this branch and correctly errors when the suite drifts to 32 tests. No failures, flakes or setup problems; temp copies used for the before/after runs were deleted and the worktree is clean.

<details>
<summary>Evidence: Composer fixture on stock Bash 3.2: fails before the fix, passes after</summary>

Source: [Composer fixture on stock Bash 3.2: fails before the fix, passes after](https://github.com/kuan0808/firstmate/blob/2f9dd986c640c8337c6c2e7490a63202664b4360/.no-mistakes/evidence/fm/up-02-test-fixtures-bash32/composer-bash32-before.txt)

<code>$ /bin/bash --version | head -1&#10;GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)&#10;&#10;$ /bin/bash tests/fm-composer-lib.test.sh # BEFORE fix (base fixture, stock macOS Bash 3.2)&#10;not ok - a half-block rule row must count as a structural edge&#10;exit=1&#10;&#10;# AFTER (this branch, same interpreter): 33 ok lines, exit 0</code>

```text
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

$ /bin/bash tests/fm-composer-lib.test.sh   # BEFORE fix (base fixture, stock macOS Bash 3.2)
not ok - a half-block rule row must count as a structural edge
exit=1
```
</details>
<details>
<summary>Evidence: Full composer classifier run under stock Bash 3.2 (33 ok, exit 0)</summary>

Source: [Full composer classifier run under stock Bash 3.2 (33 ok, exit 0)](https://github.com/kuan0808/firstmate/blob/2f9dd986c640c8337c6c2e7490a63202664b4360/.no-mistakes/evidence/fm/up-02-test-fixtures-bash32/composer-bash32-after.txt)

```text
ok - fm_composer_classify_content: a bare shell prompt glyph (>/$/%/#) reads unknown, never empty
ok - fm_composer_classify_content: stripped unbordered content is unknown except verified agent glyphs
ok - fm_composer_classify_content: a bare shell prompt carrying a command is not empty
ok - fm_composer_classify_content: a bare prompt glyph inside a bordered composer box reads empty (claude's own idle composer)
ok - fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex, ⟩ muse) read empty bordered or bare
ok - fm_composer_classify_content: an empty composer reads empty
ok - fm_composer_classify_content: idle matching is limited to proven placeholder positions
ok - fm_composer_classify_content: idle matching preserves the caller's case mode
ok - fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)
ok - matrix: claude's ❯+NBSP row reads empty on every profile in both locales (#1988)
ok - matrix: codex's dim hint is empty when styling proves it, unknown (never pending) when it cannot
ok - matrix: muse's ⟩ reads empty everywhere and survives losing the styled-glyph signal
ok - matrix: cursor's reverse-video placeholder remnant reads empty; real typed text stays pending
ok - matrix: herdr half-block rules bound a bare composer's wrap region
ok - matrix: pi's separated composer needs identity + structure; the blank row alone never proves it
ok - matrix: opencode's left-bar composer reads empty everywhere and scans the full active run
ok - matrix: grok's titled bottom border is tolerated as a title, not read as ambiguity
ok - matrix: kimi's bordered shell-glyph box reads empty through the shared owner (spawn's fourth copy retired)
ok - matrix: the real claude-in-zellij --ansi dump reads empty in both locales
ok - strict posture: blank and unidentified rows are unknown, never injectable empty
ok - fm_composer_classify_screen: the bare composer's wrap region stays identified; structure breaks it
ok - fm_composer_classify_screen: a row-leading agent glyph reanchors the live composer
ok - fm_composer_classify_screen: a lower dead shell invalidates only cursorless stale composers
ok - fm_composer_classify_screen: cursorless bare wrap regions participate in verdicts
ok - fm_composer_classify_screen: cursorless containers reject only contiguous unclaimed activity
ok - fm_composer_classify_screen: the bottom-most candidate wins; stale banners cannot
ok - fm_composer_classify_screen: incomplete lower structure invalidates stale boxes
ok - fm_composer_classify_screen: titled bottoms retain full box geometry
ok - fm_composer_classify_screen: a proven box tolerates a bottom-border cursor
ok - fm_composer_extract_selected_content: scopes user content and excludes furniture
ok - fm_composer_queued_enter_verdict: pending + busy returns empty (queued Enter)
ok - fm_composer_queued_enter_verdict: pending + idle/unknown stays pending
ok - fm_composer_queued_enter_verdict: only proven pending is converted
```
</details>
<details>
<summary>Evidence: Relaunch startup wait: 8s-late start aborts on the old budget, completes on the new 10s budget</summary>

Source: [Relaunch startup wait: 8s-late start aborts on the old budget, completes on the new 10s budget](https://github.com/kuan0808/firstmate/blob/2f9dd986c640c8337c6c2e7490a63202664b4360/.no-mistakes/evidence/fm/up-02-test-fixtures-bash32/relaunch-startup-budget.txt)

<code>$ /bin/bash &lt;relaunch metadata-race test, BASE startup wait: 200 x 0.01s&gt;&#10;not ok - relaunch did not reach trace delivery&#10;exit=1&#10;&#10;$ /bin/bash &lt;same test, THIS BRANCH startup wait: 1000 x 0.01s = the 10s budget this file already uses&gt;&#10;ok - fm-control relaunch: delivery and concurrent task metadata publication serialize&#10;exit=0</code>

```text
# Slow-start simulation: the fake transport stub needs 8s to reach trace delivery,
# so the relaunch startup marker lands after the old 200-iteration poll budget.
# Only that delay is injected; everything else is the real fm-control relaunch test
# (test_relaunch_serializes_concurrent_durable_metadata_publication).

$ /bin/bash <relaunch metadata-race test, BASE startup wait: 200 x 0.01s>
not ok - relaunch did not reach trace delivery
exit=1

$ /bin/bash <same test, THIS BRANCH startup wait: 1000 x 0.01s = the 10s budget this file already uses>
ok - fm-control relaunch: delivery and concurrent task metadata publication serialize
exit=0
```
</details>
<details>
<summary>Evidence: New ci.yml macos-stock-bash composer gate executed for real (passes on branch, catches drift)</summary>

Source: [New ci.yml macos-stock-bash composer gate executed for real (passes on branch, catches drift)](https://github.com/kuan0808/firstmate/blob/2f9dd986c640c8337c6c2e7490a63202664b4360/.no-mistakes/evidence/fm/up-02-test-fixtures-bash32/ci-stock-bash-gate.txt)

<code>--- run against this branch under /bin/bash 3.2 ---&#10;ok - fm_composer_queued_enter_verdict: only proven pending is converted&#10;gate exit=0&#10;&#10;--- same gate against a drifted suite that reports only 32 tests ---&#10;::error::expected 33 composer classifier tests, got 32&#10;gate exit=1</code>

```text
# Composer block of the real CI step, extracted from .github/workflows/ci.yml
# job: macos-stock-bash   shell: /bin/bash {0}   (stock macOS Bash 3.2)
--- extracted script ---
composer_output=$(/bin/bash tests/fm-composer-lib.test.sh)
printf '%s\n' "$composer_output"
composer_count=$(printf '%s\n' "$composer_output" | grep -c '^ok - ')
[ "$composer_count" -eq 33 ] || {
  echo "::error::expected 33 composer classifier tests, got $composer_count"
  exit 1
}
--- run against this branch under /bin/bash 3.2 ---
ok - fm_composer_queued_enter_verdict: pending + busy returns empty (queued Enter)
ok - fm_composer_queued_enter_verdict: pending + idle/unknown stays pending
ok - fm_composer_queued_enter_verdict: only proven pending is converted
gate exit=0

--- same gate against a drifted suite that reports only 32 tests ---
ok - stub 32
::error::expected 33 composer classifier tests, got 32
gate exit=1
```
</details>
<details>
<summary>Evidence: Non-vacuity guard now refuses a footer-stripped classified fixture</summary>

Source: [Non-vacuity guard now refuses a footer-stripped classified fixture](https://github.com/kuan0808/firstmate/blob/2f9dd986c640c8337c6c2e7490a63202664b4360/.no-mistakes/evidence/fm/up-02-test-fixtures-bash32/composer-guard-nonvacuity.txt)

<code>$ /bin/bash tests/fm-composer-lib.test.sh # fixture with its footer removed&#10;not ok - fixture lost its footer content&#10;exit=1</code>

```text
# Guard check: strip the footer rows below the closing half-block rule from the
# classified fixture. The non-vacuousness guard must refuse the gutted fixture
# instead of passing trivially (the silent-retirement path from review round 1).

$ /bin/bash tests/fm-composer-lib.test.sh   # fixture with its footer removed
not ok - fixture lost its footer content
exit=1
```
</details>
<details>
<summary>Evidence: fm-control relaunch suite, 51 ok, exit 0</summary>

Source: [fm-control relaunch suite, 51 ok, exit 0](https://github.com/kuan0808/firstmate/blob/2f9dd986c640c8337c6c2e7490a63202664b4360/.no-mistakes/evidence/fm/up-02-test-fixtures-bash32/relaunch-after.txt)

```text
ok - fm-control relaunch: a same-harness relaunch replaces the agent in the same endpoint and worktree
ok - fm-control relaunch: durable task metadata survives replacement launch publication
ok - fm-control relaunch: delivery and concurrent task metadata publication serialize
ok - fm-control relaunch: disabling tracing clears metadata and pane context
ok - fm-control relaunch: the progress note lands in the instructions the replacement reads
ok - fm-control relaunch: a ship task refuses without the progress note its replacement needs
ok - fm-control relaunch: switching harness is one ordinary relaunch, and the old wiring goes with the old agent
ok - fm-control relaunch: a harness switch resets model and effort unless they are named too
ok - fm-control relaunch: a prefixed recorded harness can switch adapters transactionally
ok - fm-control relaunch: a prefixed command requires an explicit replacement harness
ok - fm-control relaunch: a same-harness relaunch keeps the profile axes it was running with
ok - fm-control relaunch: explicit model and effort win over the recorded ones
ok - fm-control relaunch: refuses to relaunch onto an adapter with no verified mechanics
ok - fm-control relaunch: the retired incarnation's global turn-end token is revoked
ok - fm-control relaunch: wiring cleanup failure refuses replacement arming
ok - fm-control-lib: one owner resolves each harness's turn-end registry entry, and refuses a malformed token
ok - fm-control relaunch: a secondmate relaunch re-resolves its durable configured harness pin
ok - fm-control relaunch: invalid configured effort is ignored before stop
ok - fm-control relaunch: an adapter unverified for this task kind refuses before the agent is stopped
ok - fm-control relaunch: explicit secondmate harness resets unnamed profile axes
ok - fm-control relaunch: a ship task keeps its recorded harness instead of re-reading crew config
ok - fm-spawn --relaunch: with no explicit harness it reuses the task's recorded one, never the crew default
ok - fm-spawn --relaunch: wiring armed under a prefixed harness name is still retired
ok - fm-spawn --relaunch: switching away from muse retires its session binding
ok - fm-spawn --relaunch: switching away from cursor retires its session binding
ok - fm-control relaunch: an unaccountable local copy refuses before the agent is touched
ok - fm-control relaunch: a worker with nothing to work from is never launched
ok - fm-control relaunch: a refusal before the agent is stopped leaves the durable record untouched
ok - fm-control relaunch: checkpoint inspection failures refuse before stopping
ok - fm-control relaunch: a launch failure after the stop keeps the prior record and reports the real state
ok - fm-control relaunch: unpublished rollback keeps concurrent durable metadata
ok - fm-control relaunch: post-publication failure keeps the new durable record
ok - fm-control relaunch: partial stop reconciles actual agent state
ok - fm-control relaunch: failed journal replacement preserves durable phase
ok - fm-spawn relaunch: prepublication abort removes replacement state
ok - fm-control relaunch: the checkpoint records the exact unlanded work it preserved
ok - fm-control relaunch: a secondmate's child work is accounted for and its charter is left alone
ok - fm-control relaunch: a secondmate home that is not this secondmate's is refused
ok - fm-control relaunch: unreadable and untraversable child state fails checkpoint
ok - fm-control relaunch: two control actions on one task serialize instead of interleaving
ok - fm-spawn relaunch: direct entry participates in lifecycle serialization
ok - fm-promote: promotion participates in lifecycle serialization
ok - fm-spawn --relaunch: refuses to launch a second agent into a live endpoint
ok - fm-spawn --relaunch: symlinked records refuse before inspection
ok - fm-spawn --relaunch: keeps its early meta lock continuous
ok - fm-spawn --relaunch: pending closes refuse before replacement begins
ok - fm-spawn --relaunch: every identity axis comes from the record, and a contradicting flag refuses
ok - fm-spawn --relaunch: an unrecorded task is refused
ok - fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work
ok - relaunch re-reads the backlog item instead of blindly re-running the transition
ok - relaunch heals an item that drifted out of In flight while the task stayed live
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c0bdf4390116866168f08f8b2bb5a6a7203d74c2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `tests/fm-composer-lib.test.sh:281` - `esc=$(printf &#39;\033&#39;)` re-derives a value the file already owns: `ESC=$(printf &#39;\033&#39;)` at line 155, used by 11 other fixtures in this same file (lines 196, 213, 231, 232, 256, 339, 398, 443, ...). The fix round renamed the base commit&#39;s leaked global `ESC_LOCAL` to a proper local, which was the right direction, but the simplest form is to drop `esc` from the `local` list on line 275, delete line 281, and use `${ESC}` in the fixture on line 282. Byte-identical output, two fewer lines, one fewer name for the same escape byte.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`/bin/bash tests/fm-composer-lib.test.sh` on stock macOS Bash 3.2.57 — 33 `ok -` lines, exit 0</code>
- <code>Pre-fix reproduction: `git show 5fb0ce7:tests/fm-composer-lib.test.sh` run under the same /bin/bash 3.2 → `not ok - a half-block rule row must count as a structural edge`, exit 1</code>
- <code>`/bin/bash tests/fm-control-relaunch.test.sh` — 51 `ok -` lines, exit 0 (~2m35s)</code>
- <code>Slow-start behavior check: real `test_relaunch_serializes_concurrent_durable_metadata_publication` with an 8s delay injected into the fake transport stub, run at the base 200-iteration wait (fails `relaunch did not reach trace delivery`) vs this branch&#39;s 1000-iteration/10s wait (passes)</code>
- <code>CI consumer check: parsed `.github/workflows/ci.yml` with a YAML loader, extracted the composer block from job `macos-stock-bash` (shell `/bin/bash {0}`), ran it against this branch (exit 0) and against a stubbed 32-test suite (`::error::expected 33 composer classifier tests, got 32`, exit 1)</code>
- <code>Guard non-vacuity check: stripped the footer rows below the closing half-block rule from the classified `$screen` fixture → `not ok - fixture lost its footer content`, exit 1</code>
- <code>`/bin/bash -n` syntax check of tests/fixtures.sh, tests/lib.sh and both changed test files under Bash 3.2</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
