### PR TITLE
fix(bin): land only the verified commit for local-only merges

### DIFF
--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -64,16 +64,34 @@ git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { e
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
 
+# The shared object store a checkout belongs to: two paths with the same value
+# are worktrees of one repository, so a same-named branch elsewhere is not this
+# task's evidence.
+common_git_dir() {
+  local d
+  d=$(git -C "$1" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+  [ -n "$d" ] || return 1
+  (cd "$d" && pwd -P)
+}
+
 # The recorded task worktree is the readiness evidence. Refuse if it cannot be
-# inspected as a distinct root, is not on the expected branch, has moved off the
-# shared branch ref, or still holds tracked or untracked work.
-[ -n "$WT" ] && [ -d "$WT" ] || { echo "error: task $ID has no inspectable recorded worktree at ${WT:-<missing>}" >&2; exit 1; }
+# inspected as a distinct root of this project's repository, is not on the
+# expected branch, has moved off the shared branch ref, or still holds work
+# firstmate did not write itself.
+if [ -z "$WT" ] || [ ! -d "$WT" ]; then
+  echo "error: task $ID has no inspectable recorded worktree at ${WT:-<missing>}" >&2
+  echo "Restore that worktree on $BRANCH (or point the task meta's worktree= at the checkout that holds it), then retry." >&2
+  exit 1
+fi
 WT_REAL=$(cd "$WT" && pwd -P) || { echo "error: cannot resolve task worktree $WT" >&2; exit 1; }
 PROJ_REAL=$(cd "$PROJ" && pwd -P) || { echo "error: cannot resolve project $PROJ" >&2; exit 1; }
 WT_TOP=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
 [ -n "$WT_TOP" ] || { echo "error: recorded worktree $WT is not an inspectable git worktree" >&2; exit 1; }
 WT_TOP_REAL=$(cd "$WT_TOP" && pwd -P) || { echo "error: cannot resolve recorded worktree root $WT_TOP" >&2; exit 1; }
-if [ "$WT_REAL" != "$WT_TOP_REAL" ] || [ "$WT_REAL" = "$PROJ_REAL" ]; then
+WT_COMMON=$(common_git_dir "$WT" || true)
+PROJ_COMMON=$(common_git_dir "$PROJ" || true)
+if [ "$WT_REAL" != "$WT_TOP_REAL" ] || [ "$WT_REAL" = "$PROJ_REAL" ] \
+  || [ -z "$WT_COMMON" ] || [ "$WT_COMMON" != "$PROJ_COMMON" ]; then
   echo "error: recorded worktree $WT is not an isolated task worktree for $PROJ" >&2
   exit 1
 fi
@@ -90,7 +108,11 @@ if ! task_status=$(git -C "$WT" status --porcelain 2>/dev/null); then
   echo "error: cannot inspect task worktree $WT for uncommitted changes" >&2
   exit 1
 fi
-if [ -n "$task_status" ]; then
+# firstmate writes its own harness wiring into the task worktree and only
+# best-effort excludes it (bin/fm-spawn.sh), so ignore exactly what the sibling
+# gate in bin/fm-teardown.sh ignores; everything else is the crewmate's work.
+task_dirt=$(printf '%s\n' "$task_status" | grep -vE '^\?\? (\.claude/|\.fm-(grok|kimi)-turnend$)' | head -1 || true)
+if [ -n "$task_dirt" ]; then
   echo "REFUSED: task worktree $WT has uncommitted or untracked changes; local main was not moved" >&2
   exit 1
 fi

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -6,9 +6,17 @@
 # locally instead of via a GitHub PR). It is the one sanctioned exception to hard
 # rule #1 "never run state-changing git in projects/", and it is narrow: it only
 # runs for mode=local-only tasks, only after the captain approves (or yolo=on
-# auto-approves), and only as a clean fast-forward - it refuses a diverged branch
-# and tells you to have the crewmate rebase. See AGENTS.md prime directives,
-# project management, and task lifecycle.
+# auto-approves), and only for a clean recorded SHIP worktree whose HEAD is the
+# exact fm/<id> branch tip. It then requires a clean primary default branch and a
+# clean fast-forward - it refuses a diverged branch and tells you to have the
+# crewmate rebase. See AGENTS.md prime directives, project management, and task
+# lifecycle.
+#
+# Why the task worktree is inspected at all: the branch ref alone cannot tell a
+# finished ship from one whose last edits were never committed. Landing on the
+# ref would silently publish an older tip while the real work sat uncommitted in
+# the isolated copy, and cleanup would then refuse it as unlanded. Every refusal
+# below therefore runs BEFORE local main moves.
 # Usage: fm-merge-local.sh <task-id>
 set -eu
 
@@ -28,8 +36,12 @@ META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
 
 PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
+WT=$(grep '^worktree=' "$META" | cut -d= -f2- || true)
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
+KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
+[ -n "$KIND" ] || KIND=ship
 [ "$MODE" = local-only ] || { echo "error: task $ID is mode=$MODE, not local-only; merge PR tasks with bin/fm-pr-merge.sh <id> <PR url> after approval" >&2; exit 1; }
+[ "$KIND" = ship ] || { echo "error: task $ID is kind=$KIND, not a ship; refusing local merge" >&2; exit 1; }
 
 default_branch() {
   local ref branch
@@ -51,6 +63,37 @@ BRANCH="fm/$ID"
 git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $PROJ" >&2; exit 1; }
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
+
+# The recorded task worktree is the readiness evidence. Refuse if it cannot be
+# inspected as a distinct root, is not on the expected branch, has moved off the
+# shared branch ref, or still holds tracked or untracked work.
+[ -n "$WT" ] && [ -d "$WT" ] || { echo "error: task $ID has no inspectable recorded worktree at ${WT:-<missing>}" >&2; exit 1; }
+WT_REAL=$(cd "$WT" && pwd -P) || { echo "error: cannot resolve task worktree $WT" >&2; exit 1; }
+PROJ_REAL=$(cd "$PROJ" && pwd -P) || { echo "error: cannot resolve project $PROJ" >&2; exit 1; }
+WT_TOP=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$WT_TOP" ] || { echo "error: recorded worktree $WT is not an inspectable git worktree" >&2; exit 1; }
+WT_TOP_REAL=$(cd "$WT_TOP" && pwd -P) || { echo "error: cannot resolve recorded worktree root $WT_TOP" >&2; exit 1; }
+if [ "$WT_REAL" != "$WT_TOP_REAL" ] || [ "$WT_REAL" = "$PROJ_REAL" ]; then
+  echo "error: recorded worktree $WT is not an isolated task worktree for $PROJ" >&2
+  exit 1
+fi
+
+wt_branch=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+[ "$wt_branch" = "$BRANCH" ] || { echo "error: task worktree is on '${wt_branch:-detached}', expected '$BRANCH'" >&2; exit 1; }
+wt_head=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null || true)
+branch_head=$(git -C "$PROJ" rev-parse --verify "refs/heads/$BRANCH" 2>/dev/null || true)
+if [ -z "$wt_head" ] || [ -z "$branch_head" ] || [ "$wt_head" != "$branch_head" ]; then
+  echo "error: task worktree HEAD does not match refs/heads/$BRANCH; refusing to merge an unverified tip" >&2
+  exit 1
+fi
+if ! task_status=$(git -C "$WT" status --porcelain 2>/dev/null); then
+  echo "error: cannot inspect task worktree $WT for uncommitted changes" >&2
+  exit 1
+fi
+if [ -n "$task_status" ]; then
+  echo "REFUSED: task worktree $WT has uncommitted or untracked changes; local main was not moved" >&2
+  exit 1
+fi
 
 # The project's main checkout must be on its default branch and clean, so the
 # fast-forward lands predictably (firstmate never writes here otherwise).

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -104,14 +104,28 @@ if [ -n "$(git -C "$PROJ" status --porcelain 2>/dev/null | head -1)" ]; then
   exit 1
 fi
 
-# Clean fast-forward only: DEFAULT must be an ancestor of BRANCH.
-if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$BRANCH"; then
+# Clean fast-forward only: DEFAULT must be an ancestor of the exact tip the
+# readiness checks inspected, not of whatever the mutable branch name resolves
+# to by the time this line runs.
+if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$branch_head"; then
   echo "REFUSED: $BRANCH is not a fast-forward of $DEFAULT (it has diverged)." >&2
   echo "Have the crewmate rebase $BRANCH onto $DEFAULT, then retry." >&2
   exit 1
 fi
 
+# Every refusal above is evidence about one commit. A worker that advanced
+# fm/<id> since then holds work this run never inspected, and neither tip is
+# safe to land: the captured one silently publishes an older head, the new one
+# is unverified. Refuse instead, and land the captured SHA rather than the
+# branch name so the name cannot resolve to something else under us.
+now_head=$(git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" 2>/dev/null || true)
+if [ "$now_head" != "$branch_head" ]; then
+  echo "REFUSED: $BRANCH advanced from $branch_head to ${now_head:-<missing>} while this landing was validating; local $DEFAULT was not moved" >&2
+  echo "Re-run this landing once the crewmate has stopped writing to $BRANCH." >&2
+  exit 1
+fi
+
 before=$(git -C "$PROJ" rev-parse --short "$DEFAULT")
-git -C "$PROJ" merge --ff-only "$BRANCH" >/dev/null
+git -C "$PROJ" merge --ff-only "$branch_head" >/dev/null
 after=$(git -C "$PROJ" rev-parse --short "$DEFAULT")
 echo "merged $BRANCH into local $DEFAULT ($before -> $after) in $PROJ"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -287,7 +287,8 @@ family_for_basename() {
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;
-    fm-check-unregister.test.sh|fm-pr-check-security.test.sh|fm-pr-merge.test.sh|\
+    fm-check-unregister.test.sh|fm-merge-local.test.sh|\
+    fm-pr-check-security.test.sh|fm-pr-merge.test.sh|\
     fm-review-diff.test.sh|fm-teardown.test.sh|fm-x-mode.test.sh)
       printf '%s\n' pr-forge
       ;;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -301,6 +301,9 @@ An auto-merge request is held to the same standard: `--auto` that leaves the pul
 Every GitHub refusal states what it could not observe as plainly as what it did, so an unreadable branch-rule response, an unrecognised queue method, and a merge queue no available read can see are each named rather than left to look like a base branch with no queue at all.
 A confirmed merge leaves a durable role-routed outcome instead of living only in the merging agent's memory, and [`bin/fm-merge-outcome-lib.sh`](../bin/fm-merge-outcome-lib.sh)'s header owns its destination, shape, identity, normal-case deduplication, and at-least-once recovery.
 The same emitter handles a merge firstmate performed and one its poll detected, while the watcher immediately delivers the emitter's local actionable poll row.
+An approved `local-only` landing is bound to one verified commit in the same way: `bin/fm-merge-local.sh` reads the recorded ship worktree as the readiness evidence and fast-forwards to the exact commit it inspected there rather than to the branch name, so a missing, foreign, off-branch, moved, or dirty worktree refuses the landing before the local default branch moves.
+That makes the task worktree required at landing time, and [`bin/fm-merge-local.sh`](../bin/fm-merge-local.sh)'s header owns the complete refusal list and the firstmate-written artifacts it ignores.
+
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
 [`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
 

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Direct behavior tests for bin/fm-merge-local.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+MERGE_LOCAL="$ROOT/bin/fm-merge-local.sh"
+TMP_ROOT=$(fm_test_tmproot fm-merge-local-tests)
+fm_git_identity fmtest fmtest@example.invalid
+
+make_case() {
+  local case_dir="$TMP_ROOT/$1" id=task-x1
+  mkdir -p "$case_dir/home/state" "$case_dir/root/bin"
+  cat > "$case_dir/root/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$case_dir/root/bin/fm-guard.sh"
+  touch "$case_dir/home/state/.last-watcher-beat"
+  git init -q "$case_dir/project"
+  git -C "$case_dir/project" config user.name fmtest
+  git -C "$case_dir/project" config user.email fmtest@example.invalid
+  printf 'base\n' > "$case_dir/project/base.txt"
+  git -C "$case_dir/project" add base.txt
+  git -C "$case_dir/project" commit -qm base
+  git -C "$case_dir/project" branch -M main
+  git -C "$case_dir/project" worktree add -q -b "fm/$id" "$case_dir/wt" main
+  fm_write_meta "$case_dir/home/state/$id.meta" \
+    "window=fake" "endpoint_task_id=$id" "worktree=$case_dir/wt" \
+    "project=$case_dir/project" "kind=ship" "mode=local-only" "yolo=off"
+  printf '%s\n' "$case_dir"
+}
+
+run_merge() {
+  local case_dir=$1
+  FM_ROOT_OVERRIDE="$case_dir/root" FM_HOME="$case_dir/home" \
+    FM_STATE_OVERRIDE="$case_dir/home/state" "$MERGE_LOCAL" task-x1
+}
+
+commit_task_change() {
+  local case_dir=$1
+  printf 'fix\n' > "$case_dir/wt/fix.txt"
+  git -C "$case_dir/wt" add fix.txt
+  git -C "$case_dir/wt" commit -qm fix
+}
+
+assert_refused_unchanged() {  # <case> <expected-error>
+  local case_dir=$1 expected=$2 before rc=0
+  before=$(git -C "$case_dir/project" rev-parse main)
+  run_merge "$case_dir" >"$case_dir/out" 2>"$case_dir/err" || rc=$?
+  expect_code 1 "$rc" "$expected"
+  assert_grep "$expected" "$case_dir/err" "refusal did not name failed invariant: $(cat "$case_dir/err")"
+  [ "$(git -C "$case_dir/project" rev-parse main)" = "$before" ] \
+    || fail "refused local merge moved main"
+}
+
+test_clean_exact_tip_succeeds() {
+  local case_dir tip
+  case_dir=$(make_case clean)
+  commit_task_change "$case_dir"
+  tip=$(git -C "$case_dir/wt" rev-parse HEAD)
+  run_merge "$case_dir" >/dev/null || fail "clean local merge refused"
+  [ "$(git -C "$case_dir/project" rev-parse main)" = "$tip" ] \
+    || fail "clean local merge did not fast-forward main"
+  pass "clean recorded ship worktree fast-forwards local main"
+}
+
+test_dirty_worktree_refuses() {
+  local case_dir
+  case_dir=$(make_case dirty)
+  commit_task_change "$case_dir"
+  printf 'untracked\n' > "$case_dir/wt/untracked.tmp"
+  assert_refused_unchanged "$case_dir" 'has uncommitted or untracked changes'
+  assert_present "$case_dir/wt/untracked.tmp" "refusal discarded untracked work"
+  pass "tracked or untracked task dirt refuses before main moves"
+}
+
+test_wrong_branch_and_tip_refuse() {
+  local case_dir
+  case_dir=$(make_case wrong-branch)
+  commit_task_change "$case_dir"
+  git -C "$case_dir/wt" checkout -q -b other
+  assert_refused_unchanged "$case_dir" "expected 'fm/task-x1'"
+
+  case_dir=$(make_case wrong-tip)
+  commit_task_change "$case_dir"
+  git clone -q "$case_dir/project" "$case_dir/impostor"
+  git -C "$case_dir/impostor" checkout -q -b fm/task-x1 main
+  awk -v wt="$case_dir/impostor" '
+    /^worktree=/ { print "worktree=" wt; next }
+    { print }
+  ' "$case_dir/home/state/task-x1.meta" > "$case_dir/meta.tmp"
+  mv "$case_dir/meta.tmp" "$case_dir/home/state/task-x1.meta"
+  assert_refused_unchanged "$case_dir" 'HEAD does not match'
+  pass "wrong task branch or branch-ref tip refuses before main moves"
+}
+
+test_non_ship_and_divergence_refuse() {
+  local case_dir
+  case_dir=$(make_case non-ship)
+  commit_task_change "$case_dir"
+  printf '\nkind=scout\n' >> "$case_dir/home/state/task-x1.meta"
+  assert_refused_unchanged "$case_dir" 'not a ship'
+
+  case_dir=$(make_case diverged)
+  commit_task_change "$case_dir"
+  printf 'main advance\n' > "$case_dir/project/main.txt"
+  git -C "$case_dir/project" add main.txt
+  git -C "$case_dir/project" commit -qm main-advance
+  assert_refused_unchanged "$case_dir" 'not a fast-forward'
+  pass "non-ship and divergent branch refuse before main moves"
+}
+
+# The readiness checks LAYER OVER the role partition rather than replacing it:
+# landing stays main-owned, and the supervision branch is still refused first,
+# before any worktree is even inspected.
+test_branch_actor_is_still_refused_first() {
+  local case_dir before rc=0
+  case_dir=$(make_case branch-actor)
+  commit_task_change "$case_dir"
+  before=$(git -C "$case_dir/project" rev-parse main)
+  FM_SUPERVISION_ACTOR=branch run_merge "$case_dir" >"$case_dir/out" 2>"$case_dir/err" || rc=$?
+  expect_code 6 "$rc" "the supervision branch was not refused the local landing"
+  assert_grep 'never performs this action' "$case_dir/err" \
+    "the role-partition refusal was lost: $(cat "$case_dir/err")"
+  [ "$(git -C "$case_dir/project" rev-parse main)" = "$before" ] \
+    || fail "a branch-actor landing moved main"
+  pass "the supervision-branch role partition still refuses local landing ahead of the readiness checks"
+}
+
+test_clean_exact_tip_succeeds
+test_branch_actor_is_still_refused_first
+test_dirty_worktree_refuses
+test_wrong_branch_and_tip_refuse
+test_non_ship_and_divergence_refuse
+
+echo '# all fm-merge-local tests passed'

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -129,10 +129,63 @@ test_branch_actor_is_still_refused_first() {
   pass "the supervision-branch role partition still refuses local landing ahead of the readiness checks"
 }
 
+# The readiness checks certify ONE commit. Everything between them and the
+# merge used to re-resolve the mutable branch name, so a worker that committed
+# in that window had its uninspected tip landed. The shim below advances
+# fm/task-x1 exactly when the script reaches its fast-forward check.
+install_racing_git() {  # <fakebin> <task-worktree> <marker>
+  cat > "$1/git" <<'SH'
+#!/usr/bin/env bash
+real=${FM_TEST_REAL_GIT:?}
+for arg in "$@"; do
+  [ "$arg" = merge-base ] || continue
+  if [ ! -e "${FM_TEST_RACE_MARK:?}" ]; then
+    : > "$FM_TEST_RACE_MARK"
+    printf 'late\n' > "${FM_TEST_RACE_WT:?}/late.txt"
+    "$real" -C "$FM_TEST_RACE_WT" add late.txt >/dev/null 2>&1
+    "$real" -C "$FM_TEST_RACE_WT" commit -qm late-work >/dev/null 2>&1
+  fi
+  break
+done
+exec "$real" "$@"
+SH
+  chmod +x "$1/git"
+  FM_TEST_REAL_GIT=$(command -v git)
+  FM_TEST_RACE_WT=$2
+  FM_TEST_RACE_MARK=$3
+  export FM_TEST_REAL_GIT FM_TEST_RACE_WT FM_TEST_RACE_MARK
+}
+
+test_branch_advanced_during_validation_refuses() {
+  local case_dir fakebin inspected before raced rc=0
+  case_dir=$(make_case racing-branch)
+  commit_task_change "$case_dir"
+  inspected=$(git -C "$case_dir/wt" rev-parse HEAD)
+  before=$(git -C "$case_dir/project" rev-parse main)
+  fakebin=$(fm_fakebin "$case_dir")
+  install_racing_git "$fakebin" "$case_dir/wt" "$case_dir/raced"
+
+  PATH="$fakebin:$PATH" run_merge "$case_dir" >"$case_dir/out" 2>"$case_dir/err" || rc=$?
+  unset FM_TEST_REAL_GIT FM_TEST_RACE_WT FM_TEST_RACE_MARK
+
+  # Without a real divergence this case would pass vacuously on any script.
+  assert_present "$case_dir/raced" "the shim never fired, so this case proves nothing"
+  raced=$(git -C "$case_dir/wt" rev-parse HEAD)
+  [ "$raced" != "$inspected" ] || fail "the task branch did not move during validation"
+
+  expect_code 1 "$rc" "a branch that advanced during validation was not refused"
+  assert_grep 'advanced from' "$case_dir/err" \
+    "the refusal did not name the moved branch: $(cat "$case_dir/err")"
+  [ "$(git -C "$case_dir/project" rev-parse main)" = "$before" ] \
+    || fail "a refused landing moved main (uninspected tip $raced)"
+  pass "a task branch that advances during validation refuses instead of landing an uninspected commit"
+}
+
 test_clean_exact_tip_succeeds
 test_branch_actor_is_still_refused_first
 test_dirty_worktree_refuses
 test_wrong_branch_and_tip_refuse
 test_non_ship_and_divergence_refuse
+test_branch_advanced_during_validation_refuses
 
 echo '# all fm-merge-local tests passed'

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -76,31 +76,53 @@ test_dirty_worktree_refuses() {
   pass "tracked or untracked task dirt refuses before main moves"
 }
 
-test_wrong_branch_and_tip_refuse() {
+test_wrong_branch_and_foreign_repo_refuse() {
   local case_dir
   case_dir=$(make_case wrong-branch)
   commit_task_change "$case_dir"
   git -C "$case_dir/wt" checkout -q -b other
   assert_refused_unchanged "$case_dir" "expected 'fm/task-x1'"
 
-  case_dir=$(make_case wrong-tip)
+  # A second checkout of the same repo can carry fm/<id> at the identical SHA,
+  # so branch name and tip alone prove nothing about whose tree was inspected.
+  case_dir=$(make_case foreign-repo)
   commit_task_change "$case_dir"
   git clone -q "$case_dir/project" "$case_dir/impostor"
-  git -C "$case_dir/impostor" checkout -q -b fm/task-x1 main
+  git -C "$case_dir/impostor" checkout -q -b fm/task-x1 origin/fm/task-x1
+  [ "$(git -C "$case_dir/impostor" rev-parse HEAD)" = "$(git -C "$case_dir/project" rev-parse fm/task-x1)" ] \
+    || fail "the impostor checkout is not at the task branch tip, so this case proves nothing"
   awk -v wt="$case_dir/impostor" '
     /^worktree=/ { print "worktree=" wt; next }
     { print }
   ' "$case_dir/home/state/task-x1.meta" > "$case_dir/meta.tmp"
   mv "$case_dir/meta.tmp" "$case_dir/home/state/task-x1.meta"
-  assert_refused_unchanged "$case_dir" 'HEAD does not match'
-  pass "wrong task branch or branch-ref tip refuses before main moves"
+  assert_refused_unchanged "$case_dir" 'not an isolated task worktree'
+  pass "wrong task branch or a foreign same-named checkout refuses before main moves"
+}
+
+test_harness_artifacts_do_not_block_landing() {
+  local case_dir tip
+  case_dir=$(make_case harness-artifacts)
+  commit_task_change "$case_dir"
+  mkdir -p "$case_dir/wt/.claude"
+  printf '{}\n' > "$case_dir/wt/.claude/settings.local.json"
+  printf '{}\n' > "$case_dir/wt/.claude/other.json"
+  printf 'token=t\n' > "$case_dir/wt/.fm-grok-turnend"
+  tip=$(git -C "$case_dir/wt" rev-parse HEAD)
+  run_merge "$case_dir" >/dev/null \
+    || fail "firstmate's own harness artifacts blocked an approved landing"
+  [ "$(git -C "$case_dir/project" rev-parse main)" = "$tip" ] \
+    || fail "landing with harness artifacts present did not fast-forward main"
+  pass "firstmate-written harness artifacts are not crewmate dirt"
 }
 
 test_non_ship_and_divergence_refuse() {
   local case_dir
   case_dir=$(make_case non-ship)
   commit_task_change "$case_dir"
-  printf '\nkind=scout\n' >> "$case_dir/home/state/task-x1.meta"
+  fm_write_meta "$case_dir/home/state/task-x1.meta" \
+    "window=fake" "endpoint_task_id=task-x1" "worktree=$case_dir/wt" \
+    "project=$case_dir/project" "kind=scout" "mode=local-only" "yolo=off"
   assert_refused_unchanged "$case_dir" 'not a ship'
 
   case_dir=$(make_case diverged)
@@ -184,7 +206,8 @@ test_branch_advanced_during_validation_refuses() {
 test_clean_exact_tip_succeeds
 test_branch_actor_is_still_refused_first
 test_dirty_worktree_refuses
-test_wrong_branch_and_tip_refuse
+test_harness_artifacts_do_not_block_landing
+test_wrong_branch_and_foreign_repo_refuse
 test_non_ship_and_divergence_refuse
 test_branch_advanced_during_validation_refuses
 


### PR DESCRIPTION
## Intent

Make the approved local-only landing publish only the exact task-branch commit its readiness checks inspected.

## What Changed

- `bin/fm-merge-local.sh` now validates the task's recorded worktree before touching local main: it refuses a missing/foreign/non-isolated worktree, a worktree off `fm/<id>`, a HEAD that disagrees with `refs/heads/<branch>`, and any uncommitted or untracked work beyond the firstmate-written artifacts (`.claude/`, `.fm-{grok,kimi}-turnend`), and additionally refuses tasks that are not `kind=ship`.
- The fast-forward is now bound to the captured SHA instead of the branch name: the ancestry check and `git merge --ff-only` both use the inspected commit, and the merge is refused if `fm/<id>` advanced while the checks were running.
- Added `tests/fm-merge-local.test.sh` and registered it in the `pr-forge` family in `bin/fm-test-run.sh`; documented the verified-commit binding and refusal ownership in `docs/architecture.md`.

## Risk Assessment

✅ Low: The change is narrow and fail-closed: it captures fm/<id> once, merges that exact SHA, refuses if the ref moved during validation, and adds worktree-identity gates that cannot pass anything the previous code rejected except the two firstmate-written artifact classes that the sibling teardown gate already ignores; the accompanying tests execute the script and assert observable state (main moved or unmoved, exit code, stderr), with the race case guarded against vacuous passes.

## Testing

`I exercised the approved local-only landing end-to-end as an operator would run it rather than relying on unit assertions alone: with the base script, a crewmate commit that lands during validation was silently published to local main (main tip became "UNINSPECTED late commit"), while the changed script refuses with "fm/task-x1 advanced from <sha> to <sha> while this landing was validating" and leaves main untouched — the exact intent that only the inspected tip may be published. The happy path still fast-forwards main to precisely the worktree HEAD the readiness checks examined, the dirt gate distinguishes firstmate's own harness files from real crewmate work without discarding it, and the foreign same-named checkout is rejected. The new suite passes both with and without the host's global gitignore, the branch-supervision role partition is intact, and the changed test-selection map now really pulls tests/fm-merge-local.test.sh into the pr-forge family per the runner itself. No failures, no flakes; scratch dirs were removed and the worktree is clean. This is a CLI/git-plumbing change with no rendered UI surface, so evidence is command transcripts rather than screenshots.`

<details>
<summary>Evidence: Core intent, before vs after: an uninspected commit reaches local main on the base script and is refused on the change</summary>

Source: [Core intent, before vs after: an uninspected commit reaches local main on the base script and is refused on the change](https://github.com/kuan0808/firstmate/blob/b22a433619f11572ce6098df8cff7b74f6c3c539/.no-mistakes/evidence/fm/up-03-merge-local-worktree/uninspected-tip-repro.txt)

<code>################ BEFORE (base 5fb0ce7) ################&#10;== approved landing: readiness checks inspected fm/task-x1 @ a2c8dd7 ==&#10;merged fm/task-x1 into local main (3c82b0b -&gt; 51a513b)&#10;[exit 0]&#10;== what local main now publishes ==&#10;main 51a513b UNINSPECTED late commit&#10;main a2c8dd7 reviewed work&#10;main 3c82b0b base&#10;&#10;################ AFTER (3e17282) ################&#10;== approved landing: readiness checks inspected fm/task-x1 @ e449862 ==&#10;REFUSED: fm/task-x1 advanced from e4498627... to 0d0051fa... while this landing was validating; local main was not moved&#10;Re-run this landing once the crewmate has stopped writing to fm/task-x1.&#10;[exit 1]&#10;== what local main now publishes ==&#10;main e32de4d base</code>

```text
################ BEFORE (base 5fb0ce7 bin/fm-merge-local.sh) ################
== approved landing: readiness checks inspected fm/task-x1 @ a2c8dd7 ==
merged fm/task-x1 into local main (3c82b0b -> 51a513b) in /tmp/fm-repro.IkFeLt/project
   [exit 0]

== crewmate's branch after the race ==
   fm/task-x1  51a513b UNINSPECTED late commit

== what local main now publishes ==
   main        51a513b UNINSPECTED late commit
   main        a2c8dd7 reviewed work
   main        3c82b0b base

################ AFTER (3e17282 bin/fm-merge-local.sh) ################
== approved landing: readiness checks inspected fm/task-x1 @ e449862 ==
REFUSED: fm/task-x1 advanced from e4498627a1b7ce55a6479d25bf6b8b77505d05be to 0d0051fa362c04d27e5358ad0c4487945cc552a7 while this landing was validating; local main was not moved
Re-run this landing once the crewmate has stopped writing to fm/task-x1.
   [exit 1]

== crewmate's branch after the race ==
   fm/task-x1  0d0051f UNINSPECTED late commit

== what local main now publishes ==
   main        e32de4d base
```
</details>
<details>
<summary>Evidence: Approved landing transcript: local main ends up at exactly the inspected worktree HEAD</summary>

Source: [Approved landing transcript: local main ends up at exactly the inspected worktree HEAD](https://github.com/kuan0808/firstmate/blob/b22a433619f11572ce6098df8cff7b74f6c3c539/.no-mistakes/evidence/fm/up-03-merge-local-worktree/approved-landing-transcript.txt)

```text
== task worktree state the readiness checks inspect ==
   ?? .fm-grok-turnend
   HEAD 62ed26f885f846162781cbd5f6ee542302a0fdb4

== main before ==
   0d4155d base

$ bin/fm-merge-local.sh task-x1
merged fm/task-x1 into local main (0d4155d -> 62ed26f) in /tmp/fm-happy.IdWS21/project
   [exit 0]

== main after: published tip == inspected tip? ==
   62ed26f crewmate: reviewed work
   0d4155d base
   YES: local main == the exact commit the readiness checks inspected
```
</details>
<details>
<summary>Evidence: Worktree dirt gate transcript: harness artifacts land, real crewmate work refuses and is preserved</summary>

Source: [Worktree dirt gate transcript: harness artifacts land, real crewmate work refuses and is preserved](https://github.com/kuan0808/firstmate/blob/b22a433619f11572ce6098df8cff7b74f6c3c539/.no-mistakes/evidence/fm/up-03-merge-local-worktree/worktree-dirt-gate-transcript.txt)

<code>=== CASE A: only firstmate&#39;s own harness files are untracked ===&#10;?? .claude/&#10;?? .fm-grok-turnend&#10;$ bin/fm-merge-local.sh task-x1&#10;merged fm/task-x1 into local main (f6e4474 -&gt; 3544fe3)&#10;[exit 0]&#10;&#10;=== CASE B: the crewmate left real uncommitted work ===&#10;?? notes.md&#10;$ bin/fm-merge-local.sh task-x1&#10;REFUSED: task worktree .../wt has uncommitted or untracked changes; local main was not moved&#10;[exit 1]&#10;main now: 6bafa4e base (unmoved)&#10;crewmate file still on disk: yes</code>

```text
=== CASE A: only firstmate's own harness files are untracked ===
git status --porcelain in task worktree:
   ?? .claude/
   ?? .fm-grok-turnend
$ bin/fm-merge-local.sh task-x1
merged fm/task-x1 into local main (f6e4474 -> 3544fe3) in /tmp/fm-dirt.Wcu7VL/project
   [exit 0]
main now: 3544fe3 crewmate: reviewed work

=== CASE B: the crewmate left real uncommitted work ===
git status --porcelain in task worktree:
   ?? notes.md
$ bin/fm-merge-local.sh task-x1
REFUSED: task worktree /tmp/fm-dirt.ncnhTM/wt has uncommitted or untracked changes; local main was not moved
   [exit 1]
main now: 6bafa4e base   (unmoved)
crewmate file still on disk: yes
```
</details>
<details>
<summary>Evidence: New behavior suite on the change (all cases pass)</summary>

Source: [New behavior suite on the change (all cases pass)](https://github.com/kuan0808/firstmate/blob/b22a433619f11572ce6098df8cff7b74f6c3c539/.no-mistakes/evidence/fm/up-03-merge-local-worktree/fm-merge-local-test.log)

```text
ok - clean recorded ship worktree fast-forwards local main
ok - the supervision-branch role partition still refuses local landing ahead of the readiness checks
ok - tracked or untracked task dirt refuses before main moves
ok - firstmate-written harness artifacts are not crewmate dirt
ok - wrong task branch or a foreign same-named checkout refuses before main moves
ok - non-ship and divergent branch refuse before main moves
ok - a task branch that advances during validation refuses instead of landing an uninspected commit
# all fm-merge-local tests passed
```
</details>
<details>
<summary>Evidence: Same suite against the base commit&#39;s script: fails, proving the regression is reproduced</summary>

Source: [Same suite against the base commit&#39;s script: fails, proving the regression is reproduced](https://github.com/kuan0808/firstmate/blob/b22a433619f11572ce6098df8cff7b74f6c3c539/.no-mistakes/evidence/fm/up-03-merge-local-worktree/fm-merge-local-test-BEFORE-fix.log)

<code>ok - clean recorded ship worktree fast-forwards local main&#10;ok - the supervision-branch role partition still refuses local landing ahead of the readiness checks&#10;not ok - has uncommitted or untracked changes: expected exit 1, got 0&#10;(isolated race case vs base) not ok - a branch that advanced during validation was not refused: expected exit 1, got 0</code>

```text
ok - clean recorded ship worktree fast-forwards local main
ok - the supervision-branch role partition still refuses local landing ahead of the readiness checks
not ok - has uncommitted or untracked changes: expected exit 1, got 0
```
</details>
<details>
<summary>Evidence: bin/fm-test-run.sh --list --family pr-forge now selects the new test</summary>

Source: [bin/fm-test-run.sh --list --family pr-forge now selects the new test](https://github.com/kuan0808/firstmate/blob/b22a433619f11572ce6098df8cff7b74f6c3c539/.no-mistakes/evidence/fm/up-03-merge-local-worktree/pr-forge-selection.txt)

```text
tests/fm-check-unregister.test.sh
tests/fm-merge-local.test.sh
tests/fm-pr-check-security.test.sh
tests/fm-pr-merge.test.sh
tests/fm-review-diff.test.sh
tests/fm-teardown.test.sh
tests/fm-x-mode.test.sh
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ee8ba291c1570423d1217cc779a30e52630ae6d8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ⚠️ `bin/fm-merge-local.sh:93` - New dirty gate refuses on ANY porcelain output, including firstmate&#39;s own harness artifacts. The sibling gate for the same worktrees, bin/fm-teardown.sh:1430, deliberately filters `?? .claude/` and `?? .fm-(grok|kimi)-turnend` before judging dirt, because fm-spawn itself writes `$WT/.claude/settings.local.json` (fm-spawn.sh:2560-2567) and `$WT/.fm-grok-turnend` / `.fm-kimi-turnend` (2714, 2780) and their info/exclude registration is best-effort (`exclude_path` returns 0 silently when `git rev-parse --git-path` fails, fm-spawn.sh:2493-2494). Concrete sequence: claude-harness local-only ship, worker commits everything, `.claude/` holds a second untracked file so status prints `?? .claude/` -&gt; merge-local exits 1 &#39;has uncommitted or untracked changes&#39;; teardown then still refuses removal because the branch is unlanded and not on a remote (fm-teardown.sh:1444-1458), and AGENTS.md:341 forbids reaching around these guards with a lower-level merge. Approved work has no sanctioned landing path until an operator hand-deletes firstmate&#39;s own files. Remedy is to apply teardown&#39;s same benign-artifact filter here (it narrows a refusal the author wrote intentionally, so it needs the author&#39;s OK).
- ℹ️ `bin/fm-merge-local.sh:76` - The refusal message claims the worktree is &#39;not an isolated task worktree for $PROJ&#39;, but the four conditions checked (resolvable, is a toplevel, not equal to project) never verify the recorded worktree belongs to PROJ&#39;s repository - it is the same block as fm-spawn.sh:1836-1852, which also omits it. A meta whose `worktree=` points at a second checkout of the same repo that has fm/&lt;id&gt; at the identical SHA passes lines 70-88, so the uncommitted-work evidence at line 89 is read from the wrong tree while the real task worktree&#39;s uncommitted edits go unseen - the exact failure the new header comment claims to close. fm-spawn.sh:2437-2444 documents that a pane can report &#39;another real git checkout entirely&#39;, which is how such a path gets recorded. One-line tightening: compare `git -C &#34;$WT&#34; rev-parse --path-format=absolute --git-common-dir` with the same value for $PROJ.
- ℹ️ `tests/fm-merge-local.test.sh:103` - `printf &#39;\nkind=scout\n&#39; &gt;&gt; meta` appends to a meta that already carries `kind=ship`, and the script reads kind with `grep &#39;^kind=&#39; | cut -d= -f2-`, so KIND becomes the two-line string &#39;ship\nscout&#39;. The case therefore refuses because KIND is multi-line, not because the task is a scout; a real scout/promote meta has exactly one kind line (bin/fm-promote.sh:163-168 strips old kind/mode/yolo before rewriting). Rewrite the meta with a single `kind=scout` (e.g. re-run fm_write_meta) so the case exercises the invariant it names.
- ℹ️ `bin/fm-test-run.sh:290` - `families_for_changed_path` maps bin/fm-merge-local.sh to family `pr-forge` (line 1237), but `family_for_basename` has no entry for fm-merge-local.test.sh, so the new file resolves to `unclassified` (line 311). A future change to bin/fm-merge-local.sh alone selects pr-forge and never runs the behavior test that covers it; the test only runs in full-suite runs or when the test file itself changes. Add fm-merge-local.test.sh to the pr-forge basename list, or emit `__script__:fm-merge-local.test.sh` from the bin/fm-merge-local.sh case.
- ℹ️ `bin/fm-merge-local.sh:70` - Landing now hard-requires the recorded worktree to exist and still sit on fm/&lt;id&gt;. If the pooled worktree is recycled or removed out of band while the branch still lives in the project, the sanctioned landing path is gone entirely (no override flag), and AGENTS.md:341 bars the lower-level merge that would otherwise close it. The header comment argues this tradeoff deliberately, so this is a note on the operational corner rather than a defect; if it should stay, consider printing the recovery step in the refusal.

🔧 Fix: harden local-only landing worktree gates; fix test selection
3 infos still open:

- ℹ️ `bin/fm-merge-local.sh:101` - With the new common-git-dir equality gate (lines 91-96) plus the `symbolic-ref --short HEAD` == fm/&lt;id&gt; gate (line 100), `git -C &#34;$WT&#34; rev-parse HEAD` and `git -C &#34;$PROJ&#34; rev-parse refs/heads/fm/&lt;id&gt;` read the same shared ref by construction, so the `wt_head != branch_head` branch at 103-106 can no longer fire. Its old regression case (the `wrong-tip` impostor at a different commit) was replaced in this round by `foreign-repo`, which the common-dir gate now catches first, so the branch is both dead and untested. Harmless belt-and-braces; noting it as the one simplification available, not a defect.
- ℹ️ `bin/fm-merge-local.sh:114` - The new benign-artifact filter mirrors bin/fm-teardown.sh:1430 exactly (verified: same regex, same two markers, and fm-spawn.sh only writes .claude/settings.local.json, .fm-grok-turnend, .fm-kimi-turnend under $WT). Tradeoff worth recording: for a local-only ship whose deliverable is untracked content under .claude/, status prints `?? .claude/...`, merge-local now lands the older tip instead of refusing, and teardown - which filters the same lines and then sees `unmerged` empty - removes the worktree, so that content is gone. Previously the pair deadlocked instead (round 1&#39;s finding). This is the deliberate, human-approved alignment with the sibling gate, so no action; recorded only so the loss window is visible.
- ℹ️ `bin/fm-merge-local.sh:114` - Defense asymmetry, inherited from teardown rather than introduced here: fm-spawn.sh:2560-2567 writes $WT/.claude/settings.local.json AND fm-spawn.sh:2573-2574 writes $WT/.opencode/plugins/fm-busy-state.js, both registered via `exclude_path` (fm-spawn.sh:2623 for the opencode one). The filter carries a whole-prefix backstop for `?? .claude/` but nothing for `.opencode/`, so only the claude harness is protected if anything else ever appears untracked under its wiring directory. I could not prove a reachable path today (the exclude entry covers the one file firstmate writes), so this is a note, not a request; closing it would mean editing bin/fm-teardown.sh too, which is outside this change&#39;s scope.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-merge-local.test.sh` (all 7 cases: clean tip lands, branch-actor partition, dirty worktree refusal, harness-artifact allowance, wrong-branch/foreign-checkout refusal, non-ship + divergence refusal, mid-validation branch advance refusal)</code>
- <code>`GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null bash tests/fm-merge-local.test.sh` (confirms the `?? .claude/` harness-artifact case is not passing vacuously via the host&#39;s global gitignore)</code>
- <code>Regression fail-before/pass-after: ran the new suite against the base commit&#39;s `bin/fm-merge-local.sh` (`git show 5fb0ce7:bin/fm-merge-local.sh` into a scratch root) — the race case reported `not ok - a branch that advanced during validation was not refused: expected exit 1, got 0`</code>
- <code>Manual end-to-end repro of the intent: real `bin/fm-merge-local.sh` run against a project + task worktree with a PATH-shimmed git that commits to `fm/task-x1` during validation; compared published `main` on base vs change</code>
- <code>Manual operator transcript of the approved happy path: clean ship worktree with firstmate harness files present → landing succeeds and `main == inspected worktree HEAD`</code>
- <code>Manual operator transcript of the dirt gate: `?? .claude/` + `?? .fm-grok-turnend` lands, `?? notes.md` refuses with `main` unmoved and the crewmate file preserved</code>
- <code>`bash tests/fm-branch-supervision.test.sh` (the other caller-facing contract for this script: branch actor exit 6, main actor unaffected)</code>
- <code>`bash tests/fm-test-run.test.sh` and `bin/fm-test-run.sh --list --family pr-forge` (real consumer of the changed family map; confirms `tests/fm-merge-local.test.sh` is now selected by the pr-forge family that `bin/fm-merge-local.sh` maps to)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
