### PR TITLE
fix(spawn): refuse an inconclusive Pi TUI capability probe

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -109,10 +109,12 @@
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. For pi and pi-signed, fm-spawn resolves the selected executable
 #   name from PATH once, probes that concrete path with --help, and launches the
-#   same path. It adds --tui-mode regular only when that help advertises the flag;
-#   a failed or inconclusive probe omits it so older Pi versions remain launchable.
-#   A missing selected executable refuses before endpoint creation, and pi-signed
-#   never falls back to pi.
+#   same path. Recognizable help that advertises --tui-mode gets exactly one
+#   --tui-mode regular; recognizable single-mode help gets no mode flag. A failed,
+#   empty, unrecognizable, malformed, or mode-ambiguous probe refuses before
+#   endpoint or authoritative metadata creation rather than reading an inconclusive
+#   answer as "the flag is absent". A missing selected executable refuses before
+#   endpoint creation, and pi-signed never falls back to pi.
 #   config/secondmate-harness may also carry an optional model and effort as extra
 #   whitespace-separated tokens ("<harness> [<model>] [<effort>]"). For a
 #   --secondmate spawn, those tokens apply only when this spawn also resolves its
@@ -1208,12 +1210,60 @@ resolve_pi_executable() {
 }
 
 # Pi's CLI surface is version-dependent, so probe the resolved executable's help
-# before composing the optional regular-TUI flag. An absent or inconclusive probe
-# omits the flag so older Pi versions can still spawn.
-pi_supports_tui_mode() {
-  local executable=$1 help
-  help=$("$executable" --help 2>&1) || return 1
-  printf '%s\n' "$help" | grep -Eq -- '(^|[[:space:]])--tui-mode([[:space:]=]|$)'
+# before composing the optional regular-TUI flag. Prints one of two CONCLUSIVE
+# capabilities and refuses otherwise:
+#   flag         recognizable Pi help that advertises --tui-mode -> pass
+#                --tui-mode regular, because Pi's experimental fullscreen
+#                rendering can bury a steer above the visible region and the
+#                explicit regular override is the safeguard against that.
+#   single-mode  recognizable Pi help with no --tui-mode and no fullscreen or
+#                alternate-screen surface at all -> one normal interactive TUI,
+#                so omitting the flag is correct rather than merely tolerated.
+# A failed, empty, unrecognizable, structurally malformed, or mode-ambiguous help
+# answer is NOT evidence the flag is absent - it is evidence the probe did not
+# work - so it refuses here, before any endpoint or authoritative metadata
+# exists, instead of launching a flag-capable Pi without its safeguard.
+# Read only on a refusal, so the loud failure names the release that produced
+# the unrecognized help without costing every conclusive launch a process.
+pi_probe_version() {  # <executable>
+  local version
+  version=$("$1" --version 2>/dev/null | head -1 | tr -d '\r')
+  printf '%s' "${version:-unknown}"
+}
+
+probe_pi_tui_mode() {
+  local executable=$1 adapter=$2 help compact
+  if ! help=$("$executable" --help 2>&1); then
+    echo "error: $adapter --help probe failed for '$executable' (version $(pi_probe_version "$executable")); refusing to launch without conclusive Pi TUI capability evidence" >&2
+    return 1
+  fi
+  compact=$(printf '%s' "$help" | tr -d '[:space:]')
+  if [ -z "$compact" ]; then
+    echo "error: $adapter --help returned empty help from '$executable' (version $(pi_probe_version "$executable")); refusing to launch without conclusive Pi TUI capability evidence" >&2
+    return 1
+  fi
+  if ! printf '%s\n' "$help" | grep -Eq '^pi - AI coding assistant([[:space:]]|$)'; then
+    echo "error: $adapter --help did not return recognizable Pi help from '$executable' (version $(pi_probe_version "$executable")); refusing to launch" >&2
+    return 1
+  fi
+  if ! printf '%s\n' "$help" | grep -Eq '^Usage:$' \
+    || ! printf '%s\n' "$help" | grep -Eq '^[[:space:]]+pi \[options\]' \
+    || ! printf '%s\n' "$help" | grep -Eq '^Options:$' \
+    || ! printf '%s\n' "$help" | grep -Eq '^[[:space:]]+--thinking([[:space:]=]|$)' \
+    || ! printf '%s\n' "$help" | grep -Eq '^[[:space:]]+--extension([[:space:],=]|$)' \
+    || ! printf '%s\n' "$help" | grep -Eq '^[[:space:]]+--help([[:space:],=]|$)'; then
+    echo "error: $adapter --help returned malformed Pi help from '$executable' (version $(pi_probe_version "$executable")); refusing to launch" >&2
+    return 1
+  fi
+  if printf '%s\n' "$help" | grep -Eq -- '(^|[[:space:]])--tui-mode([[:space:]=]|$)'; then
+    printf '%s\n' flag
+    return 0
+  fi
+  if printf '%s\n' "$help" | grep -Eiq -- 'full[[:space:]-]*screen|alternate[[:space:]-]*(screen|tui|mode)|tui[[:space:]-]*mode'; then
+    echo "error: $adapter --help advertises fullscreen or alternate-mode behavior without --tui-mode in '$executable' (version $(pi_probe_version "$executable")); refusing an ambiguous TUI launch" >&2
+    return 1
+  fi
+  printf '%s\n' single-mode
 }
 
 # The verified launch command per adapter. The knowledge half of each adapter
@@ -1353,10 +1403,11 @@ case "$HARNESS" in
       echo "error: $HARNESS executable not found on PATH; install it or select a different verified harness" >&2
       exit 1
     }
-    PI_TUI_MODE=
-    if pi_supports_tui_mode "$PI_BIN"; then
-      PI_TUI_MODE=' --tui-mode regular'
-    fi
+    PI_TUI_CAPABILITY=$(probe_pi_tui_mode "$PI_BIN" "$HARNESS") || exit 1
+    case "$PI_TUI_CAPABILITY" in
+      flag) PI_TUI_MODE=' --tui-mode regular' ;;
+      single-mode) PI_TUI_MODE= ;;
+    esac
     LAUNCH=${LAUNCH//__PITUIMODE__/$PI_TUI_MODE}
     LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH"
     ;;

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -271,6 +271,7 @@ family_for_basename() {
     fm-herdr-version-floor-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-branch-live-e2e.test.sh|\
     fm-pi-primary-live-e2e.test.sh|\
+    fm-pi-spawn-probe-live-e2e.test.sh|\
     fm-sessionstart-hook-live-e2e.test.sh|fm-sessionstart-instruction-refresh-live-e2e.test.sh|\
     fm-quota-array-dispatch-live-e2e.test.sh|fm-send-secondmate-marker-herdr-e2e.test.sh|\
     fm-send-inbox-doorbell-live-e2e.test.sh|\
@@ -574,6 +575,7 @@ tests/fm-pending-reply.test.sh 24679
 tests/fm-pi-branch-extension.test.sh 22239
 tests/fm-pi-branch-live-e2e.test.sh 56
 tests/fm-pi-primary-live-e2e.test.sh 20
+tests/fm-pi-spawn-probe-live-e2e.test.sh 21
 tests/fm-pi-watch-extension.test.sh 42970
 tests/fm-pr-check-security.test.sh 160475
 tests/fm-procevent-quota.test.sh 1949

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -30,6 +30,26 @@ zsh
 A persistent parent shell waiting for a child remained reported as the parent process, while a shell that directly execed a simple command changed identity with the process itself.
 Pi and pi-signed 0.82.0 were reverified on 2026-07-27 through real isolated `fm-spawn.sh` launches.
 
+### Pi TUI capability probe
+
+`bin/fm-spawn.sh` reads the selected Pi executable's own `--help` to decide whether the launch carries `--tui-mode regular`, and refuses a failed, empty, unrecognizable, malformed, or mode-ambiguous answer before any endpoint or metadata exists.
+That verdict comes from vendor-rendered text, so `tests/fm-pi-spawn-probe-live-e2e.test.sh` is the opt-in guard that refreshes this record: it runs the real `bin/fm-spawn.sh` against every installed `pi` and `pi-signed` with a recording tmux stub, requires the spawn's conclusive verdict to agree with an independent read of the same help, reports an absent executable explicitly, and names the harness and version when they disagree.
+Run it after every Pi upgrade.
+
+Verified on 2026-09-02 with Pi 0.84.2 on macOS 26.6.2 arm64; `pi-signed` was not installed, so its probe remains unverified here.
+
+```sh
+FM_PI_SPAWN_PROBE_LIVE=1 bash tests/fm-pi-spawn-probe-live-e2e.test.sh
+```
+
+```text
+# pi 0.84.2 at .../bin/pi: --tui-mode regular x1
+ok - spawn probe: pi 0.84.2 reaches a conclusive verdict that agrees with its own help
+# skip: pi-signed is not installed on this machine, so its spawn probe is unverified here
+# unverified on this machine (not installed): pi-signed
+# checked 1 installed Pi-family executable(s)
+```
+
 ### Agent liveness name sources
 
 The earlier record that every harness is observed under its own `#{pane_current_command}` no longer holds and has been replaced by the per-harness evidence below.

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -23,7 +23,10 @@ make_spawn_case() {  # <name> <harness> <id>
   home="$case_dir/home"
   proj="$case_dir/project"
   wt="$case_dir/wt"
-  fakebin=$(make_spawn_fakebin "$case_dir/fake" pi opencode claude codex)
+  fakebin=$(make_spawn_fakebin "$case_dir/fake" opencode claude codex)
+  # Pi needs the recognizable-help stub, not a silent exit-0 one: the spawn
+  # preflight refuses an inconclusive capability probe by design.
+  fm_fake_pi "$fakebin" pi
   fm_test_spawn_home "$home" "$harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
   fm_test_spawn_brief "$home" "$id"

--- a/tests/fm-pi-spawn-probe-live-e2e.test.sh
+++ b/tests/fm-pi-spawn-probe-live-e2e.test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# tests/fm-pi-spawn-probe-live-e2e.test.sh - opt-in guard proving that
+# bin/fm-spawn.sh's Pi TUI capability probe reaches a conclusive verdict against
+# every INSTALLED Pi-family executable (pi, pi-signed).
+#
+# Why this file exists: probe_pi_tui_mode decides from the vendor's own --help
+# text whether to pass --tui-mode regular, and refuses to launch when that text
+# is failed, empty, unrecognizable, malformed, or mode-ambiguous. A Pi release
+# that rewords its banner or restructures its help therefore makes every Pi
+# spawn refuse until the probe is re-verified. tests/fm-spawn-dispatch-profile.test.sh
+# pins the classifier against a stub whose help was transcribed from one
+# release; only the real executable can show that the transcription still
+# holds. This guard runs the real bin/fm-spawn.sh against the real executable
+# with a recording tmux stub, so no Pi process is started and no model tokens
+# are spent: the launch command is captured, never typed into a pane.
+#
+# Two independent readings decide each verdict: the spawn's own conclusive
+# result (exit 0 with a composed launch naming the probed executable), and this
+# guard's own read of the same --help for the --tui-mode option. They must agree
+# on whether exactly one --tui-mode regular is present, so a probe that drifted
+# to the wrong conclusive branch is caught as well as one that refuses.
+#
+# Standard CI has no harness binaries, so this real-harness guard is opt-in and
+# on-demand. Run it after every Pi upgrade and before trusting refreshed
+# evidence in docs/verification/runtime-backends.md.
+set -u
+
+if [ "${FM_PI_SPAWN_PROBE_LIVE:-0}" != 1 ]; then
+  echo "skip: set FM_PI_SPAWN_PROBE_LIVE=1 to run the installed-Pi spawn probe guard"
+  exit 0
+fi
+
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-pi-spawn-probe-live)
+
+note() { printf '# %s\n' "$1"; }
+
+CHECKED=0
+SKIPPED=
+
+for harness in pi pi-signed; do
+  bin_path=$(type -P -- "$harness" 2>/dev/null || true)
+  if [ -z "$bin_path" ] || [ ! -x "$bin_path" ]; then
+    SKIPPED="$SKIPPED $harness"
+    note "skip: $harness is not installed on this machine, so its spawn probe is unverified here"
+    continue
+  fi
+  version=$("$bin_path" --version 2>/dev/null | head -1 | tr -d '\r')
+  [ -n "$version" ] || version=unknown
+
+  # The guard's own reading of the vendor surface the probe reads.
+  if ! help=$("$bin_path" --help 2>&1); then
+    fail "$harness $version: --help exited non-zero, so no conclusive verdict is possible: $(printf '%s' "$help" | head -3 | tr '\n' ' ')"
+  fi
+  if printf '%s\n' "$help" | grep -Eq -- '(^|[[:space:]])--tui-mode([[:space:]=]|$)'; then
+    expected=1
+  else
+    expected=0
+  fi
+
+  id="probe-live-$harness"
+  case_dir="$TMP_ROOT/$harness"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  launchlog="$case_dir/launch.log"
+  fakebin=$(fm_fakebin "$case_dir/fake")
+  fm_test_fake_tmux_spawn "$fakebin"
+  fm_fake_exit0 "$fakebin" treehouse
+  fm_test_spawn_home "$home" "$harness"
+  fm_git_worktree "$proj" "$wt" "wt-$harness"
+  fm_test_spawn_brief "$home" "$id"
+  : > "$launchlog"
+
+  out=$(FM_FAKE_LAUNCH_LOG="$launchlog" \
+    fm_test_run_spawn "$home" "$wt" "$fakebin" "$id" "$proj" --mode no-mistakes --yolo off)
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    fail "PROBE DRIFT: $harness $version: bin/fm-spawn.sh refused the launch (exit $status): $(printf '%s\n' "$out" | grep -E '^error:' | tail -1). Teach probe_pi_tui_mode the help shape this release prints, then refresh tests/lib.sh's fm_fake_pi."
+  fi
+  launch=$(cat "$launchlog")
+  [ -n "$launch" ] || fail "$harness $version: spawn exited 0 but typed no launch command"
+  case "$launch" in
+    *"'$bin_path'"*) ;;
+    *) fail "$harness $version: the launch does not name the probed executable '$bin_path': $launch" ;;
+  esac
+  count=$(printf '%s\n' "$launch" | grep -o -- '--tui-mode regular' | wc -l | tr -d ' ')
+  if [ "$count" -ne "$expected" ]; then
+    if [ "$expected" -eq 1 ]; then
+      fail "PROBE DRIFT: $harness $version: its help advertises --tui-mode but the launch carries $count '--tui-mode regular' flag(s): $launch"
+    fi
+    fail "PROBE DRIFT: $harness $version: its help does not advertise --tui-mode but the launch carries $count '--tui-mode regular' flag(s): $launch"
+  fi
+
+  note "$harness $version at $bin_path: --tui-mode regular x$count"
+  pass "spawn probe: $harness $version reaches a conclusive verdict that agrees with its own help"
+  CHECKED=$((CHECKED + 1))
+done
+
+[ "$CHECKED" -gt 0 ] || fail \
+  "no Pi-family executable is installed here, so this run proved nothing; install pi or pi-signed before trusting a pass"
+
+if [ -n "$SKIPPED" ]; then
+  note "unverified on this machine (not installed):$SKIPPED"
+fi
+note "checked $CHECKED installed Pi-family executable(s)"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -660,7 +660,8 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" pi
+  # Recognizable Pi help: a spawned relaunch runs the capability preflight.
+  fm_fake_pi "$fakebin" pi
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -206,7 +206,10 @@ test_agent_state_dispatcher_and_compatibility() {
 make_toolchain() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
-  fm_fake_exit0 "$fakebin" node chrome-devtools-axi pi-signed
+  fm_fake_exit0 "$fakebin" node chrome-devtools-axi
+  # A relaunch spawns through the Pi capability preflight, so the signed Pi stub
+  # must answer --help with recognizable Pi help rather than silence.
+  fm_fake_pi "$fakebin" pi-signed
   fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
   cat > "$fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -569,7 +569,8 @@ EOF
   ln -s "$ROOT/bin" "$root/bin"
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  fm_fake_exit0 "$fakebin" pi
+  # Recognizable Pi help: secondmate recovery spawns through the Pi preflight.
+  fm_fake_pi "$fakebin" pi
   make_fake_tmux_secondmate_recovery "$fakebin"
   : > "$log"
   printf '%s|%s|%s|%s|%s|%s\n' "$root" "$home" "$fakebin" "$mate" "$log" "$spawned"
@@ -616,7 +617,8 @@ EOF
   ln -s "$ROOT/bin" "$root/bin"
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  fm_fake_exit0 "$fakebin" pi
+  # Recognizable Pi help: secondmate recovery spawns through the Pi preflight.
+  fm_fake_pi "$fakebin" pi
   make_fake_herdr_secondmate_recovery "$fakebin"
   : > "$log"
   printf '%s|%s|%s|%s|%s|%s\n' "$root" "$home" "$fakebin" "$mate" "$log" "$state"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -13,21 +13,11 @@ set -u
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-dispatch-profile)
 
+# One shared Pi stub (tests/lib.sh) whose help is structurally recognizable, so
+# the spawn preflight reaches a real capability verdict here. FM_FAKE_PI_VERSION
+# still selects the 0.82.0 single-mode shape for the version matrix below.
 make_spawn_pi_probe() {
-  local fakebin=$1 tool=$2
-  cat > "$fakebin/$tool" <<'SH'
-#!/usr/bin/env bash
-set -u
-if [ "${1:-}" = --help ]; then
-  if [ "${FM_FAKE_PI_VERSION:-0.84.0}" = 0.82.0 ]; then
-    printf '%s\n' 'Pi 0.82.0' 'Options: --help'
-  else
-    printf '%s\n' "Pi ${FM_FAKE_PI_VERSION:-0.84.0}" 'Options: --help --tui-mode <mode>'
-  fi
-fi
-exit 0
-SH
-  chmod +x "$fakebin/$tool"
+  fm_fake_pi "$1" "$2"
 }
 
 make_spawn_fakebin() {
@@ -661,6 +651,40 @@ test_pi_tui_mode_probe_is_safe_for_old_and_new_pi() {
   pass "Pi launch probing omits --tui-mode on older Pi and preserves it on supporting Pi"
 }
 
+# An INCONCLUSIVE capability probe is not evidence the flag is absent - it is
+# evidence the probe did not work. Launching anyway silently drops the regular-TUI
+# override on a Pi that does support it, and a fullscreen surface can then bury a
+# steer above the visible region. Every inconclusive shape must refuse BEFORE an
+# endpoint or authoritative metadata exists, while both conclusive shapes still
+# launch (the version matrix above covers those).
+test_pi_probe_refuses_every_inconclusive_help_before_publication() {
+  local mode rec id out status expected
+  for mode in failed empty malformed non-pi ambiguous; do
+    id="profile-pi-probe-${mode//-/}-z8e"
+    rec=$(make_spawn_case "profile-pi-probe-$mode" pi "$id")
+    read_case_record "$rec"
+    : > "$LAUNCH_LOG"
+
+    out=$(FM_FAKE_PI_HELP_MODE="$mode" \
+      run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+    status=$?
+    expect_code 1 "$status" "an inconclusive '$mode' Pi probe should refuse the spawn"
+    case "$mode" in
+      failed)    expected='probe failed' ;;
+      empty)     expected='returned empty help' ;;
+      malformed) expected='returned malformed Pi help' ;;
+      non-pi)    expected='did not return recognizable Pi help' ;;
+      ambiguous) expected='advertises fullscreen or alternate-mode behavior' ;;
+    esac
+    assert_contains "$out" "$expected" \
+      "the '$mode' probe refusal did not name what was inconclusive"
+    assert_not_contains "$out" 'spawned' "the '$mode' probe still reported a spawn"
+    assert_absent "$HOME_DIR/state/$id.meta" "the '$mode' probe refusal wrote task metadata"
+    [ ! -s "$LAUNCH_LOG" ] || fail "the '$mode' probe refusal typed a launch command"
+  done
+  pass "every failed, empty, malformed, non-Pi, or mode-ambiguous probe refuses before endpoint or metadata publication"
+}
+
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata() {
   local rec id out status
   id=profile-pi-signed-missing-z8c
@@ -816,6 +840,7 @@ test_opencode_threads_model_and_ignores_effort_axis
 test_pi_threads_model_and_max_effort
 test_pi_tui_mode_probe_is_safe_for_old_and_new_pi
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
+test_pi_probe_refuses_every_inconclusive_help_before_publication
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata
 test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity
 test_batch_forwards_shared_profile_flags

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -182,6 +182,84 @@ SH
   done
 }
 
+# fm_fake_pi <fakebin> <tool...>: a fake Pi-family executable whose --help is
+# STRUCTURALLY recognizable as Pi, so bin/fm-spawn.sh's capability preflight can
+# reach a genuine verdict instead of refusing an inconclusive probe. An exit-0
+# stub that prints nothing is not a usable Pi fixture: the preflight is supposed
+# to refuse that, and a fixture must not be the thing that proves it wrong.
+#
+# FM_FAKE_PI_HELP_MODE selects what the probe should conclude:
+#   flag         (default) advertises --tui-mode  -> launch with --tui-mode regular
+#   single-mode  no --tui-mode and no alternate-screen surface at all -> no flag
+#   failed       --help exits non-zero            -> refuse
+#   empty        --help prints nothing            -> refuse
+#   malformed    Pi banner without Pi's structure -> refuse
+#   non-pi       some other program's help        -> refuse
+#   ambiguous    fullscreen surface, no override  -> refuse
+# FM_FAKE_PI_VERSION is accepted for the version matrix: 0.82.0 means the
+# single-mode shape, anything else keeps the flag shape.
+# FM_FAKE_PI_PROBE_LOG records each --help invocation when set.
+fm_fake_pi() {
+  local fakebin=$1 tool
+  shift
+  for tool in "$@"; do
+    cat > "$fakebin/$tool" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" != --help ]; then
+  exit 0
+fi
+if [ -n "${FM_FAKE_PI_PROBE_LOG:-}" ]; then
+  printf '%s\t%s\n' "$(basename "$0")" "$*" >> "$FM_FAKE_PI_PROBE_LOG"
+fi
+mode=${FM_FAKE_PI_HELP_MODE:-}
+if [ -z "$mode" ]; then
+  case "${FM_FAKE_PI_VERSION:-0.84.0}" in
+    0.82.0) mode=single-mode ;;
+    *) mode=flag ;;
+  esac
+fi
+case "$mode" in
+  failed)
+    printf '%s\n' 'synthetic Pi help failure' >&2
+    exit 42
+    ;;
+  empty) exit 0 ;;
+  malformed)
+    printf '%s\n' 'pi - AI coding assistant with read, bash, edit, write tools' \
+      'Help is unavailable in this build'
+    exit 0
+    ;;
+  non-pi)
+    printf '%s\n' 'pico - unrelated editor' 'Usage:' '  pico [options]'
+    exit 0
+    ;;
+esac
+# Pi's real help shape (verified against installed Pi 0.84.2): a banner line, a
+# Usage: block, an Options: block, and the --thinking / --extension / --help
+# options fm-spawn.sh requires before trusting any capability conclusion.
+printf '%s\n' \
+  'pi - AI coding assistant with read, bash, edit, write tools' \
+  '' \
+  'Usage:' \
+  '  pi [options] [@files...] [messages...]' \
+  '' \
+  'Options:' \
+  '  --model <pattern>              Model pattern or ID' \
+  '  --thinking <level>             Set thinking level' \
+  '  --extension, -e <path>         Load an extension file'
+case "$mode" in
+  flag)        printf '%s\n' '  --tui-mode <mode>              TUI mode: regular (default) or fullscreen' ;;
+  ambiguous)   printf '%s\n' '  --fullscreen                   Use the experimental alternate screen' ;;
+  single-mode) ;;
+  *) exit 64 ;;
+esac
+printf '%s\n' '  --help, -h                     Show this help'
+SH
+    chmod +x "$fakebin/$tool"
+  done
+}
+
 # fm_fake_version_tool <fakebin> <tool> <override-env-var> <default-version>
 # The stub answers `--version` with <override-env-var> when that variable is set
 # and non-empty, and with <default-version> otherwise; every other invocation


### PR DESCRIPTION
fm-spawn.sh probes the selected pi or pi-signed executable's --help before composing the launch, and adds --tui-mode regular when the help advertises the flag. That flag is the safeguard against Pi's experimental fullscreen rendering burying a steer above the visible region. The probe was a boolean: a failed, empty, or unrecognizable help answer was read as "the flag is absent" and the launch went ahead without the safeguard.

probe_pi_tui_mode replaces it with a tri-state verdict. Recognizable Pi help that advertises --tui-mode gets exactly one --tui-mode regular; recognizable Pi help with no --tui-mode and no fullscreen or alternate-screen surface at all launches without the flag; a failed, empty, non-Pi, structurally malformed, or mode-ambiguous answer refuses with a named reason before any endpoint or authoritative metadata exists. Exact-path pinning and the pi-signed identity boundary are unchanged.

tests/lib.sh gains fm_fake_pi, one shared Pi stub whose help is structurally recognizable, with FM_FAKE_PI_HELP_MODE selecting each probe outcome. The spawn, wiring, secondmate, and session-start fixtures that used a silent exit-0 pi stub now use it, because the preflight is supposed to refuse that stub and a fixture must not be the thing that proves it wrong. tests/fm-spawn-dispatch-profile.test.sh covers every refusal and both conclusive shapes. On the previous script a failed probe launched anyway.

Every refusal names the executable and its --version, so a Pi release that rewords its help fails loudly with the release that did it, and the launch site's unreachable fallback arm is gone. tests/fm-pi-spawn-probe-live-e2e.test.sh is the opt-in live guard (FM_PI_SPAWN_PROBE_LIVE=1) that runs the real bin/fm-spawn.sh against every installed pi and pi-signed with a recording tmux stub, requires the conclusive verdict to agree with an independent read of the same help, reports an absent executable explicitly, and refuses a pass that checked nothing; docs/verification/runtime-backends.md records the dated result.