### PR TITLE
fix(bin): never let a skipped live run hand a branch to older history

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -375,9 +375,11 @@ nm_ci_checks_state() {
 # is exact) - but branch + coarse status is exactly what this predicate needs:
 # is a run for THIS branch active right now. Echoes the first (most recent)
 # matching row's status word (running/completed/cancelled/failed), or empty
-# when the branch has no run within FM_CREW_STATE_RUNS_LIMIT rows.
+# when the branch has no run within FM_CREW_STATE_RUNS_LIMIT rows, when a head
+# is unresolvable, or when a live row was skipped and only OLDER terminal
+# history would otherwise answer.
 nm_runs_status_for_branch() {  # <branch>
-  local branch=$1 out row st rest br sha
+  local branch=$1 out row st rest br sha active_unmatched=0
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
   [ -n "$out" ] || return 0
   while IFS= read -r row; do
@@ -398,7 +400,18 @@ nm_runs_status_for_branch() {  # <branch>
         # mismatch. Stop instead of surfacing an older, superseded row;
         # the caller's pane/log fallback can answer without misattribution.
         fm_nm_head_resolvable "$WT" "$sha" || return 0
+        # A resolvable-but-mismatched head keeps the historical reused-branch
+        # skip, but a LIVE row skipped that way is still current work: remember
+        # it so the skip below cannot hand this crew's current state to an
+        # OLDER terminal row and report a superseded failure as the truth.
+        [ "$st" != running ] || active_unmatched=1
         continue
+      fi
+      # Newer live run present, this matching row is terminal history: neither
+      # can be asserted, so answer nothing and let the pane/log fallback decide.
+      # Non-terminal ambiguity beats a false `failed`.
+      if [ "$active_unmatched" = 1 ] && [ "$st" != running ]; then
+        return 0
       fi
       printf '%s' "$st"
       return 0

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1489,6 +1489,57 @@ EOF
   pass "coarse scan stops on an unresolvable active row instead of binding an older one"
 }
 
+# The coarse fallback's reused-branch skip must not hand this crew's current
+# state to an OLDER terminal row after skipping a LIVE one. Upstream's own
+# behaviors are held fixed around it: a newest matching terminal row still wins
+# when nothing live was skipped, and an unresolvable head still stops the scan.
+test_live_coarse_row_is_not_replaced_by_older_terminal_history() {
+  reset_fakes
+  local d base pipeline_head pipeline_short local_short out
+  d=$(new_case live-coarse-row)
+  make_repo_on_branch "$d/wt" fm/feat-current-run
+  base=$(git -C "$d/wt" rev-parse HEAD)
+  git -C "$d/wt" commit -q --allow-empty -m 'pipeline fix history'
+  pipeline_head=$(git -C "$d/wt" rev-parse HEAD)
+  git -C "$d/wt" reset -q --hard "$base"
+  git -C "$d/wt" commit -q --allow-empty -m 'local validation history'
+  pipeline_short=$(git -C "$d/wt" rev-parse --short=8 "$pipeline_head")
+  local_short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/current-run.meta" "window=fm:fm-current-run" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_RUN_HEAD="$pipeline_head"
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-current-run)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running  fm/feat-current-run ${pipeline_short}  2026-07-26 02:00
+  failed   fm/feat-current-run ${local_short}  2026-07-26 01:00
+EOF
+)"
+  out=$(run_crew_state "$d" current-run)
+  assert_not_contains "$out" "state: failed" \
+    "an older same-branch failure was asserted after a live row was skipped"
+
+  # Upstream behavior held: with no live row skipped, the newest matching
+  # terminal row still answers.
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="failed  fm/feat-current-run ${local_short}  2026-07-26 01:00"
+  out=$(run_crew_state "$d" current-run)
+  assert_contains "$out" "state: failed" \
+    "the newest matching failure stopped surfacing when no live row was skipped"
+
+  # Upstream behavior held: an unresolvable head still stops the scan instead of
+  # falling through onto older history.
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  completed  fm/feat-current-run deadbee1  2026-07-26 03:00
+  failed     fm/feat-current-run ${local_short}  2026-07-26 01:00
+EOF
+)"
+  out=$(run_crew_state "$d" current-run)
+  assert_not_contains "$out" "state: failed" \
+    "an unresolvable newest head no longer stops the coarse scan"
+  pass "a live same-branch row is never replaced by older terminal history in the coarse scan"
+}
+
+
 # Negative control: the exemption is gated on pipeline_owned specifically - any
 # other branch_sync state keeps the strict head rule.
 test_non_pipeline_owned_unresolvable_head_not_attributed() {
@@ -1603,6 +1654,7 @@ test_local_advanced_past_run_head_invalidates
 test_pipeline_owned_active_run_beats_superseded_failed_row
 test_failed_run_with_no_later_run_still_surfaces
 test_coarse_unresolvable_active_row_never_falls_to_older_row
+test_live_coarse_row_is_not_replaced_by_older_terminal_history
 test_non_pipeline_owned_unresolvable_head_not_attributed
 test_pipeline_owned_terminal_run_not_exempt
 test_missing_run_head_falls_back_to_current_state


### PR DESCRIPTION
nm_runs_status_for_branch answers "is a run for this branch active right now" from the newest-first `no-mistakes runs` list. A row whose recorded head does not match the worktree is skipped as a reused-branch mismatch. When that skipped row was the LIVE run (the shape right after the local branch advanced past the run's head), the walk continued to an older terminal row for the same branch and reported its `failed` as this crew's current state.

Remember that a live row was skipped. When only older terminal history would then answer, answer nothing, so the caller's pane and log fallback decides. A genuine newest failure with no live run still reports failed, and exact-head attribution is unchanged.

tests/fm-crew-state.test.sh covers the live-plus-older-failed shape. On the previous script it asserted `state: failed`.