### PR TITLE
feat(update): route inquiry and intentional divergence through updatefirstmate

### DIFF
--- a/.agents/skills/updatefirstmate/SKILL.md
+++ b/.agents/skills/updatefirstmate/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: updatefirstmate
 description: >-
-  Self-update a running firstmate and its secondmates to the latest from origin.
-  Use when the captain invokes /updatefirstmate (e.g. "/updatefirstmate", "update firstmate", "pull the latest firstmate").
-  Fast-forwards this firstmate repo's default branch and every local or remote secondmate through its guarded update path (never forced, never disruptive), then re-reads AGENTS.md and nudges each updated secondmate to do the same, so the whole tree runs the latest bin/ and instructions.
+  Audit or self-update a running firstmate and its secondmates from origin.
+  Use when the captain invokes /updatefirstmate (e.g. "/updatefirstmate", "update firstmate", "pull the latest firstmate"), or asks what an upstream update contains and whether firstmate should take it.
+  Inquiry is read-only; a clean update fast-forwards this firstmate repo's default branch and every local or remote secondmate through its guarded update path (never forced, never disruptive), then re-reads AGENTS.md and nudges each updated secondmate; intentional inventoried local divergence routes to separately authorized controlled adoption and landing instead.
 user-invocable: true
 metadata:
   internal: true
@@ -51,6 +51,30 @@ This touches only the firstmate repo and its own worktrees, never anything under
    Summarize what landed under `AGENTS.md` section 9 without firstmate's internal vocabulary: which parts of the fleet are now on the latest, and which were left as-is and why.
    For example: "Captain, firstmate and both second mates are now on the latest."
    Surface any skipped target whose reason needs the captain's attention - for instance a home with its own un-landed changes (diverged) or local edits (dirty), which were left untouched on purpose.
+
+## Read-only update inquiry
+
+A request that asks what changed, whether firstmate should update, or what the update contains authorizes **inspection only**.
+Record the exact clean local default-branch SHA and resolve the exact live upstream default SHA through read-only remote inspection, without running the updater, fetching into the active repository, or moving any ref.
+Compare that exact upstream tree against `data/firstmate-local-fixes.md`, current tool dependencies, supported worker tools, runtime backends, and maintained documentation owners.
+If either baseline moved since an earlier audit, refresh every changed-path conclusion before recommending adoption.
+An inquiry never becomes an update, and an approved update never becomes an implementation.
+
+## Controlled adoption after intentional divergence
+
+The native updater above is unchanged and still stops on divergence.
+When the divergence is clean, fully inventoried in `data/firstmate-local-fixes.md`, and the captain gives a current explicit concrete implementation instruction under `AGENTS.md`'s precedence rule, build one isolated `local-only` candidate rather than writing a second updater.
+
+1. Record exact old local `main`, the exact audited upstream commit, the merge base, the active local fixes, current dependency identities, and home-propagation limits.
+2. Create the candidate from exact upstream, then create one ancestry bridge whose parents include exact upstream and exact old local `main` while its tree still equals exact upstream.
+3. Reimplement only still-required behaviors on the current upstream owners; take upstream directly for anything that retired, and never replay an old local commit as proof it is still needed.
+4. Run every retained regression plus the complete portable tests, lint, documentation audience checks, supported-shell syntax, affected native runtime checks, and `git diff --check`.
+5. Record bridge parents, candidate tip, retained and retired mapping, dependency gaps, rollback plan, and the proposed inventory entries **without** writing landed state - exact landed SHAs exist only after a landing.
+6. Stop if local `main` advances, or if any baseline, dependency, or required check no longer matches the audit.
+
+A validated candidate still requires the current concrete landing authority `AGENTS.md` demands.
+Only `bin/fm-merge-local.sh <id>` may move local `main`, and `data/firstmate-local-fixes.md` must receive the exact landed tip before cleanup.
+Tool installation, upstream publication, rollback-reference retirement, discard, and any destructive or security-sensitive action each remain a separate explicit decision.
 
 ## Safety
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
   captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
+  firstmate-local-fixes.md  captain-private inventory of intentional local fixes; when present, self-repo local-only cleanup waits for the exact landed tip to appear in it (bin/fm-teardown.sh)
   projects.md        thin fleet navigation registry recording each project's standing delivery posture; firstmate-private, parsed for mechanical sync and seeding by fm-project-mode.sh (section 6)
   secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
@@ -531,8 +532,8 @@ The scaffold is a safety contract, not a suggestion.
 
 Firstmate's shared instruction surface reaches running homes only after it lands on the default branch and those homes fast-forward.
 Only `AGENTS.md`, `bin/`, and `.agents/skills/` are loaded by a running firstmate; public `skills/` is an installer-facing surface.
-When the captain invokes `/updatefirstmate` or asks to update firstmate, load the `/updatefirstmate` skill.
-It performs guarded fast-forward updates of firstmate and registered secondmate homes, refreshes instructions, and never touches anything under `projects/`.
+When the captain invokes `/updatefirstmate`, asks what an upstream Firstmate update contains, asks whether to update, or asks to update Firstmate, load the `/updatefirstmate` skill.
+It owns read-only update inquiry, performs guarded fast-forward updates of firstmate and registered secondmate homes, refreshes instructions, routes intentional inventoried divergence to separately authorized controlled adoption and landing, and never touches anything under `projects/`.
 
 ## 13. Agent-only reference skills
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -19,6 +19,10 @@
 # home with a backlog but no compatible tasks-axi refuses before cleanup.
 # None of this loosens the landed-work gates below: the transition runs only on
 # the paths that already proceed to remove the record.
+# For a non-forced local-only ship whose physical project is this Firstmate repo,
+# an existing data/firstmate-local-fixes.md is an exact landing receipt: cleanup
+# waits until the full landed task tip appears literally in that regular readable
+# file (see require_self_repo_local_fix_receipt).
 # REFUSES if the worktree holds work that has not LANDED, because cleanup
 # hard-resets/removes the worktree and kills its processes. Work has landed when it is
 # reachable from any remote-tracking branch (a fork counts as a remote, so
@@ -1252,6 +1256,54 @@ canonical_existing_dir() {
   [ -n "$target" ] || return 1
   [ -d "$target" ] || return 1
   ( cd "$target" && pwd -P )
+}
+
+# One extra landed-work gate, ONLY for a non-forced local-only ship whose physical
+# project is this Firstmate repo itself. Such work has no PR and no remote to
+# prove it landed, so the exact landed tip appearing in the local-fix inventory IS
+# the receipt - and it is a receipt that is worth nothing if it can be written
+# after the branch, worktree, and metadata are already gone. Cleanup therefore
+# waits for it. Deliberately narrow: ordinary projects, non-local-only ships, an
+# absent inventory, and explicit --force keep their established behavior, and this
+# never parses or writes inventory prose - it only asks whether the full 40-char
+# tip is literally present in a regular readable file.
+require_self_repo_local_fix_receipt() {
+  local proj_abs root_abs inventory tip default
+  [ "$FORCE" != --force ] || return 0
+  [ "$KIND" = ship ] || return 0
+  [ "$MODE" = local-only ] || return 0
+  proj_abs=$(canonical_existing_dir "$PROJ" 2>/dev/null || true)
+  root_abs=$(canonical_existing_dir "$FM_ROOT" 2>/dev/null || true)
+  [ -n "$proj_abs" ] && [ "$proj_abs" = "$root_abs" ] || return 0
+
+  inventory="$DATA/firstmate-local-fixes.md"
+  if [ ! -e "$inventory" ] && [ ! -L "$inventory" ]; then
+    return 0
+  fi
+  if [ -L "$inventory" ] || [ ! -f "$inventory" ] || [ ! -r "$inventory" ]; then
+    echo "REFUSED: self-repo local-fix inventory is not a regular readable file: $inventory" >&2
+    return 1
+  fi
+
+  tip=$(git -C "$WT" rev-parse --verify 'HEAD^{commit}' 2>/dev/null || true)
+  [ -n "$tip" ] || {
+    echo "REFUSED: cannot read the landed task tip from $WT; preserving task evidence" >&2
+    return 1
+  }
+  default=$(default_branch) || {
+    echo "REFUSED: cannot determine the self-repo default branch for inventory verification" >&2
+    return 1
+  }
+  # Not landed yet is not this gate's business: the landed-work checks above own
+  # that refusal, and a prospective SHA must never be demanded before a landing.
+  if ! git -C "$PROJ" merge-base --is-ancestor "$tip" "$default" 2>/dev/null; then
+    return 0
+  fi
+  if ! grep -Fq -- "$tip" "$inventory"; then
+    echo "REFUSED: landed self-repo task tip $tip is not recorded in $inventory" >&2
+    echo "Update and verify the canonical local-fix inventory before cleanup." >&2
+    return 1
+  fi
 }
 
 retry_wait_secs_is_valid() {
@@ -2677,6 +2729,8 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
     fi
   fi
 fi
+
+require_self_repo_local_fix_receipt || exit 1
 
 # A Herdr close may reposition shared workspace order, so the whole
 # destructive sequence below (worktree return, pane close, record removal)

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -664,6 +664,52 @@ test_local_only_merged_to_local_main_allows() {
   pass "local-only worktree with work merged into local main is torn down (no regression)"
 }
 
+# Self-repo local-only work has no PR and no remote to prove it landed, so the
+# exact landed tip appearing in the local-fix inventory IS the receipt - and a
+# receipt written after the branch, worktree and records are gone is worth
+# nothing. A prefix-only entry must therefore refuse and preserve everything,
+# and the exact full tip must release cleanup.
+test_self_repo_inventory_receipt_blocks_cleanup_until_exact_tip() {
+  local case_dir rc=0 tip prefix
+  case_dir=$(make_case self-repo-receipt)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" 'landed local fix'
+  tip=$(git -C "$case_dir/wt" rev-parse HEAD)
+  prefix=$(printf '%s' "$tip" | cut -c1-12)
+  git -C "$case_dir/project" update-ref refs/heads/main "$tip"
+
+  # The gate fires only when the physical project IS this Firstmate root, so the
+  # fixture makes the project double as the code root.
+  mkdir -p "$case_dir/project/bin" "$case_dir/home" "$case_dir/data"
+  cat > "$case_dir/project/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$case_dir/project/bin/fm-guard.sh"
+  printf '# Firstmate local fix inventory\n- Prefix only: %s\n' "$prefix" \
+    > "$case_dir/data/firstmate-local-fixes.md"
+
+  FM_ROOT_OVERRIDE="$case_dir/project" FM_HOME="$case_dir/home" \
+    FM_STATE_OVERRIDE="$case_dir/state" FM_DATA_OVERRIDE="$case_dir/data" \
+    FM_CONFIG_OVERRIDE="$case_dir/config" PATH="$case_dir/fakebin:$PATH" \
+    "$TEARDOWN" task-x1 >"$case_dir/missing.out" 2>"$case_dir/missing.err" || rc=$?
+  expect_code 1 "$rc" "a prefix-only inventory receipt must refuse cleanup"
+  assert_grep "landed self-repo task tip $tip is not recorded" "$case_dir/missing.err" \
+    "the receipt refusal did not name the exact missing tip: $(cat "$case_dir/missing.err")"
+  assert_present "$case_dir/state/task-x1.meta" "the receipt refusal removed task metadata"
+  git -C "$case_dir/project" show-ref --verify --quiet refs/heads/fm/task-x1 \
+    || fail "the receipt refusal removed the task branch"
+
+  printf -- '- Exact landed tip: %s\n' "$tip" >> "$case_dir/data/firstmate-local-fixes.md"
+  FM_ROOT_OVERRIDE="$case_dir/project" FM_HOME="$case_dir/home" \
+    FM_STATE_OVERRIDE="$case_dir/state" FM_DATA_OVERRIDE="$case_dir/data" \
+    FM_CONFIG_OVERRIDE="$case_dir/config" PATH="$case_dir/fakebin:$PATH" \
+    "$TEARDOWN" task-x1 >"$case_dir/recorded.out" 2>"$case_dir/recorded.err" \
+    || fail "self-repo cleanup failed after the exact tip receipt: $(cat "$case_dir/recorded.err")"
+  assert_absent "$case_dir/state/task-x1.meta" "successful receipt cleanup retained task metadata"
+  pass "self-repo local-only cleanup waits for the exact full landed-tip inventory receipt"
+}
+
 test_no_mistakes_origin_remote_allows() {
   local case_dir rc
   case_dir=$(make_case nm-origin)
@@ -2610,6 +2656,7 @@ test_teardown_closes_the_backlog_item_itself
 test_teardown_manual_backend_leaves_the_backlog_to_the_operator
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
+test_self_repo_inventory_receipt_blocks_cleanup_until_exact_tip
 test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed

--- a/tests/fm-update.test.sh
+++ b/tests/fm-update.test.sh
@@ -23,6 +23,8 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 UPDATE="$ROOT/bin/fm-update.sh"
+UPDATE_SKILL="$ROOT/.agents/skills/updatefirstmate/SKILL.md"
+AGENTS="$ROOT/AGENTS.md"
 
 # Deterministic, isolated git identity for fixture commits.
 fm_git_identity fmtest fmtest@example.com
@@ -269,6 +271,28 @@ test_firstmate_detached_head_skipped() {
   pass "T10 firstmate detached HEAD is skipped"
 }
 
+# The updater itself is unchanged and still stops on divergence; what must not
+# be lost is the PROCEDURE that takes over there. Without one discoverable
+# owner, an inquiry silently becomes an update, an update silently becomes an
+# implementation, and intentional inventoried divergence gets discarded as an
+# obstacle instead of routed through separately authorized adoption and landing.
+test_update_policy_owner_is_discoverable() {
+  assert_grep 'asks what an upstream Firstmate update contains' "$AGENTS" \
+    "AGENTS.md does not load updatefirstmate for a read-only inquiry"
+  assert_grep '## Read-only update inquiry' "$UPDATE_SKILL" \
+    "updatefirstmate does not own read-only inquiry"
+  assert_grep '## Controlled adoption after intentional divergence' "$UPDATE_SKILL" \
+    "updatefirstmate does not own intentional-divergence adoption"
+  assert_grep 'never replay an old local commit as proof' "$UPDATE_SKILL" \
+    "updatefirstmate lost the fresh-reimplementation rule"
+  assert_grep 'exact landed SHAs exist only after a landing' "$UPDATE_SKILL" \
+    "updatefirstmate lost the no-prospective-landed-state rule"
+  # shellcheck disable=SC2016 # The literal Markdown command IS the owner pointer under test.
+  assert_grep 'Only `bin/fm-merge-local.sh <id>` may move local `main`' "$UPDATE_SKILL" \
+    "updatefirstmate does not preserve the single guarded landing path"
+  pass "read-only inquiry, intentional divergence, and guarded landing have one discoverable owner"
+}
+
 test_unsafe_secondmate_home_skipped_before_git_update() {
   local w out bad before
   w=$(new_world t11)
@@ -300,5 +324,6 @@ test_registry_backstop_dedup_and_self_exclusion
 test_firstmate_wrong_branch_skipped
 test_firstmate_detached_head_skipped
 test_unsafe_secondmate_home_skipped_before_git_update
+test_update_policy_owner_is_discoverable
 
 echo "# all fm-update tests passed"


### PR DESCRIPTION
fm-update.sh is unchanged: it still fast-forwards a clean home and still stops on divergence. What was missing is the procedure that takes over at that stop. Without one discoverable owner, a question about what an update contains turned into an update, an approved update turned into an implementation, and committed local fixes were treated as an obstacle to discard rather than divergence to adopt deliberately.

The updatefirstmate skill now owns three things, and AGENTS.md section 12 loads it for all of them:

- Read-only inquiry: what changed and whether to take it, without running the updater, fetching into the active repository, or moving a ref.
- Controlled adoption after intentional divergence: one isolated local-only candidate built from exact upstream, bridged to the old local main by ancestry, with still-required behaviors reimplemented on the current owners and everything retired taken from upstream directly. A validated candidate still needs the current landing authority AGENTS.md demands, and only bin/fm-merge-local.sh moves local main.
- The receipt before cleanup: for a non-forced local-only ship whose physical project is this repository itself, fm-teardown.sh waits until the exact 40-character landed tip appears literally in data/firstmate-local-fixes.md, which AGENTS.md section 2 now lists as the captain-private inventory of intentional local fixes. Such work has no PR and no remote to prove it landed, and a receipt that can be written after the branch, worktree, and metadata are gone is worth nothing. Ordinary projects, other delivery modes, an absent inventory, and --force keep their behavior; the gate never parses or writes the inventory.

tests/fm-update.test.sh pins the owner pointers; tests/fm-teardown.test.sh covers cleanup refusing on a missing or prefix-only receipt and proceeding on the exact tip. On the previous script a prefix-only receipt let cleanup proceed.