### PR TITLE
fix(control): refuse an undispatchable relaunch before stopping the agent

### DIFF
--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -48,6 +48,9 @@
 # Set by fm_backlog_transition_applies for a return-1 exemption.
 # shellcheck disable=SC2034 # Output global, read by the sourcing caller.
 FM_BACKLOG_TRANSITION_SKIP=
+# Set by fm_backlog_dispatch_preflight: 1 when the gate applies to the call.
+# shellcheck disable=SC2034 # Output global, read by the sourcing caller.
+FM_BACKLOG_PREFLIGHT_APPLIES=0
 # Set by the mutating helpers when they return non-zero.
 FM_BACKLOG_TRANSITION_ERROR=
 FM_BACKLOG_ROW_RESULT=
@@ -400,6 +403,43 @@ fm_backlog_row_dispatchable() {
     in_flight\ no\ no|queued\ no\ no) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+# fm_backlog_dispatch_preflight <config-dir> <data-dir> <kind> <id>: the one
+# pre-mutation dispatch check, shared by bin/fm-spawn.sh (before any endpoint,
+# worktree, or record exists) and bin/fm-control.sh relaunch (before the running
+# agent is stopped), so a row the transition would refuse is refused while
+# nothing has been touched. Returns 0 with FM_BACKLOG_PREFLIGHT_APPLIES=1 and
+# FM_BACKLOG_ROW_STATE set when the row is dispatchable, 0 with
+# FM_BACKLOG_PREFLIGHT_APPLIES=0 when the gate does not apply to this home or
+# kind, and 1 with the refusal in FM_BACKLOG_TRANSITION_ERROR otherwise.
+fm_backlog_dispatch_preflight() {  # <config-dir> <data-dir> <kind> <id>
+  local config=$1 data=$2 kind=$3 id=$4 gate_status=0
+  FM_BACKLOG_PREFLIGHT_APPLIES=0
+  fm_backlog_transition_applies "$config" "$data" "$kind" || gate_status=$?
+  case "$gate_status" in
+    0) ;;
+    2)
+      FM_BACKLOG_TRANSITION_ERROR="task $id cannot be dispatched because its backlog data directory is inaccessible: $data ($FM_BACKLOG_TRANSITION_ERROR)"
+      return 1
+      ;;
+    *) return 0 ;;
+  esac
+  FM_BACKLOG_PREFLIGHT_APPLIES=1
+  if fm_backlog_row_probe "$data" "$id"; then
+    :
+  elif [ "$FM_BACKLOG_ROW_RESULT" = not_found ]; then
+    FM_BACKLOG_TRANSITION_ERROR="task $id has no backlog item in this home, so dispatching it would leave a worker no record owns; add it first (tasks-axi add $id '<title>' --kind $kind) and re-run"
+    return 1
+  else
+    FM_BACKLOG_TRANSITION_ERROR="task $id's backlog item could not be read before dispatch ($FM_BACKLOG_ROW_ERROR)"
+    return 1
+  fi
+  if ! fm_backlog_row_dispatchable "$FM_BACKLOG_ROW_STATE"; then
+    FM_BACKLOG_TRANSITION_ERROR="this home's backlog item $id is not dispatchable in state $FM_BACKLOG_ROW_STATE; refusing before any endpoint, local copy, or agent is touched"
+    return 1
+  fi
+  return 0
 }
 
 fm_backlog_dispatch_transition() {

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -44,12 +44,15 @@
 #              inherits the local copy but none of the conversation; a
 #              secondmate reconciles its own home's records at startup, so its
 #              standing charter is never rewritten.
-#              Records a durable checkpoint and that note, exits the old agent,
-#              then delegates the launch to its single owner,
-#              bin/fm-spawn.sh --relaunch. A failure before publication keeps
-#              the prior durable record in place and reports the concrete
-#              state; it never leaves a half-transitioned task claiming to be
-#              running.
+#              Runs the launch owner's backlog dispatch preflight while the
+#              old agent is still running, records a durable checkpoint and
+#              that note, exits the old agent, then delegates the launch to
+#              its single owner, bin/fm-spawn.sh --relaunch. A failure before
+#              publication keeps the prior durable record in place, names the
+#              launch owner's own refusal on this plane's summary line, the
+#              rollback line, and the journal's launch_error= field, and
+#              reports the concrete state; it never leaves a half-transitioned
+#              task claiming to be running.
 #
 # Teardown and discard are NOT verbs here and never will be. `exit` stops an
 # agent and preserves everything else; removing a worktree, killing an
@@ -119,6 +122,7 @@ fi
 }
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 [ -d "$STATE" ] || {
   echo "error: state dir '$STATE' is missing; fm-control cannot resolve tasks for FM_HOME '$FM_HOME'" >&2
   exit 1
@@ -134,6 +138,10 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-tasks-axi-lib.sh
+. "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-backlog-transition-lib.sh
+. "$SCRIPT_DIR/fm-backlog-transition-lib.sh"
 
 POLL=${FM_CONTROL_POLL:-0.5}
 SETTLE_WAIT=${FM_CONTROL_SETTLE_WAIT:-5}
@@ -507,6 +515,8 @@ JOURNAL="$STATE/$ID.control-relaunch"
 META_PRIOR="$JOURNAL.meta-prior"
 BRIEF_PRIOR="$JOURNAL.brief-prior"
 NOTE_FILE="$JOURNAL.note"
+LAUNCH_STDERR="$JOURNAL.launch-stderr"
+RELAUNCH_LAUNCH_ERROR=
 RELAUNCH_META_PUBLISHED=0
 RELAUNCH_AGENT_CONFIRMED=0
 RELAUNCH_TX=
@@ -553,6 +563,7 @@ journal_write() {  # <phase> [extra-line]...
 
 relaunch_rollback() {
   local state
+  local -a launch_lines
   [ "$RELAUNCH_ACTIVE" = 1 ] || return 0
   [ "$RELAUNCH_PHASE" != complete ] || return 0
   RELAUNCH_ACTIVE=0
@@ -587,6 +598,10 @@ relaunch_rollback() {
       esac
       ;;
     exited|launching)
+      # The launch owner's reason, when it failed, rides every line a caller
+      # might read last, and the journal.
+      launch_lines=()
+      [ -z "$RELAUNCH_LAUNCH_ERROR" ] || launch_lines=("launch_error=$RELAUNCH_LAUNCH_ERROR")
       if [ "$RELAUNCH_AGENT_CONFIRMED" = 1 ]; then
         journal_write "failed:$RELAUNCH_PHASE" "rollback=none-new-agent-confirmed" || true
         echo "error: $ID's replacement is running on $TARGET_HARNESS, but transaction completion could not be persisted; its published record was retained for reconciliation" >&2
@@ -598,11 +613,13 @@ relaunch_rollback() {
         # harness with no agent confirmed, which is exactly what recovery
         # reconciles. Rewriting it back to the old harness would be a second,
         # worse inaccuracy.
-        journal_write "failed:$RELAUNCH_PHASE" "rollback=none-new-record-kept" || true
-        echo "error: $ID was relaunched on $TARGET_HARNESS but no running agent could be confirmed; its work is preserved at $WT" >&2
+        journal_write "failed:$RELAUNCH_PHASE" "rollback=none-new-record-kept" \
+          "${launch_lines[@]+"${launch_lines[@]}"}" || true
+        echo "error: $ID was relaunched on $TARGET_HARNESS but no running agent could be confirmed${RELAUNCH_LAUNCH_ERROR:+ ($RELAUNCH_LAUNCH_ERROR)}; its work is preserved at $WT" >&2
       else
-        journal_write "failed:$RELAUNCH_PHASE" "rollback=prior-record-kept" || true
-        echo "error: $ID's agent was stopped but the replacement did not launch; no agent is running, and its work plus the recorded progress note are preserved at $WT" >&2
+        journal_write "failed:$RELAUNCH_PHASE" "rollback=prior-record-kept" \
+          "${launch_lines[@]+"${launch_lines[@]}"}" || true
+        echo "error: $ID's agent was stopped but the replacement did not launch${RELAUNCH_LAUNCH_ERROR:+ ($RELAUNCH_LAUNCH_ERROR)}; no agent is running, and its work plus the recorded progress note are preserved at $WT" >&2
       fi
       ;;
   esac
@@ -781,8 +798,21 @@ record_note() {
   esac
 }
 
+# launch_error_line <stderr-file> <exit-code>: the one line that names why the
+# launch owner failed - its last error or REFUSED line, else its last non-empty
+# line that is not a guard banner, else the bare exit code.
+launch_error_line() {  # <stderr-file> <exit-code>
+  local line
+  line=$(grep -E '^(error|REFUSED): ' "$1" 2>/dev/null | tail -1)
+  [ -n "$line" ] || line=$(grep -v -e '^[[:space:]]*$' -e '^●' "$1" 2>/dev/null | tail -1)
+  line=${line#error: }
+  line=${line#REFUSED: }
+  [ -n "$line" ] || line="fm-spawn exited $2 without a diagnostic"
+  printf '%s' "$line"
+}
+
 do_relaunch() {
-  local exit_result state note_line
+  local exit_result state note_line launch_rc
   local -a spawn_args
 
   require_state_verified_backend relaunch
@@ -805,6 +835,13 @@ do_relaunch() {
       die "task $ID records kind '$KIND', which has no defined relaunch shape"
       ;;
   esac
+
+  # The launch owner refuses a backlog item its dispatch transition cannot own,
+  # and left to itself it would do so only AFTER the old agent was stopped -
+  # the one relaunch outcome that leaves a task with no agent at all. Run the
+  # same shared preflight here, while the agent is still running.
+  fm_backlog_dispatch_preflight "$CONFIG" "$DATA" "$KIND" "$ID" \
+    || die "refusing to relaunch $ID before its agent is touched: $FM_BACKLOG_TRANSITION_ERROR"
 
   if [ -n "$NOTE" ]; then
     note_line="note_file=$NOTE_FILE"
@@ -830,13 +867,24 @@ do_relaunch() {
   spawn_args=("$ID" --relaunch --harness "$TARGET_HARNESS")
   [ "$TARGET_MODEL" = default ] || spawn_args+=(--model "$TARGET_MODEL")
   [ "$TARGET_EFFORT" = default ] || spawn_args+=(--effort "$TARGET_EFFORT")
-  if FM_CONTROL_RELAUNCH_TX="$RELAUNCH_TX" \
-      "$SCRIPT_DIR/fm-spawn.sh" "${spawn_args[@]}" >/dev/null; then
+  # The launch owner's stderr is captured so the failing step it names survives
+  # into this plane's own summary line, the rollback line, and the journal: a
+  # caller reading only the last line or two must still learn WHY the
+  # replacement did not start, never just that it did not.
+  launch_rc=0
+  FM_CONTROL_RELAUNCH_TX="$RELAUNCH_TX" \
+    "$SCRIPT_DIR/fm-spawn.sh" "${spawn_args[@]}" >/dev/null 2>"$LAUNCH_STDERR" \
+    || launch_rc=$?
+  cat "$LAUNCH_STDERR" >&2 2>/dev/null || true
+  if [ "$launch_rc" -eq 0 ]; then
+    rm -f "$LAUNCH_STDERR"
     RELAUNCH_META_PUBLISHED=1
   else
+    RELAUNCH_LAUNCH_ERROR=$(launch_error_line "$LAUNCH_STDERR" "$launch_rc")
+    rm -f "$LAUNCH_STDERR"
     [ "$(fm_meta_get "$META" control_relaunch_tx)" != "$RELAUNCH_TX" ] \
       || RELAUNCH_META_PUBLISHED=1
-    die "the replacement agent for $ID could not be launched on $TARGET_HARNESS"
+    die "the replacement agent for $ID could not be launched on $TARGET_HARNESS: $RELAUNCH_LAUNCH_ERROR"
   fi
 
   state=$(wait_agent_state "$LAUNCH_WAIT" alive) || {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2020,28 +2020,11 @@ herdr_projection_existing_meta_allows_flat() {  # <meta>
 # costs nothing to unwind, while the same refusal after publication would strand
 # a live pane. The authoritative mutation still runs under the meta lock below.
 BACKLOG_TRANSITION=0
-BACKLOG_ROW_STATE=
-if fm_backlog_transition_applies "$CONFIG" "$DATA" "$KIND"; then
-  BACKLOG_TRANSITION=1
-  if fm_backlog_row_probe "$DATA" "$ID"; then
-    BACKLOG_ROW_STATE=$FM_BACKLOG_ROW_STATE
-  elif [ "$FM_BACKLOG_ROW_RESULT" = not_found ]; then
-    echo "error: task $ID has no backlog item in this home, so dispatching it would leave a worker no record owns; add it first (tasks-axi add $ID '<title>' --kind $KIND) and re-run" >&2
-    exit 1
-  else
-    echo "error: task $ID's backlog item could not be read before dispatch ($FM_BACKLOG_ROW_ERROR)" >&2
-    exit 1
-  fi
-  if ! fm_backlog_row_dispatchable "$BACKLOG_ROW_STATE"; then
-    echo "error: this home's backlog item $ID is not dispatchable in state $BACKLOG_ROW_STATE; refusing before creating its endpoint or local copy" >&2
-    exit 1
-  fi
+if fm_backlog_dispatch_preflight "$CONFIG" "$DATA" "$KIND" "$ID"; then
+  BACKLOG_TRANSITION=$FM_BACKLOG_PREFLIGHT_APPLIES
 else
-  BACKLOG_GATE_STATUS=$?
-  if [ "$BACKLOG_GATE_STATUS" -eq 2 ]; then
-    echo "error: task $ID cannot be dispatched because its backlog data directory is inaccessible: $DATA ($FM_BACKLOG_TRANSITION_ERROR)" >&2
-    exit 1
-  fi
+  echo "error: $FM_BACKLOG_TRANSITION_ERROR" >&2
+  exit 1
 fi
 
 if [ "$SPAWN_META_LOCK_HELD" != 1 ]; then
@@ -3034,10 +3017,20 @@ spawn_record_traceparent() {
   return "$status"
 }
 
+# A delivery step that fails must name itself: this script runs under set -e,
+# and a bare backend send that returns non-zero (the adapters swallow the
+# CLI's own stderr) would otherwise end the spawn with no diagnostic at all,
+# which a relaunch caller then reports as a launch that failed for no reason.
+spawn_delivery_fail() {  # <what>
+  echo "error: could not deliver $1 to $ID's endpoint $T on $BACKEND; the agent was not started" >&2
+  exit 1
+}
+
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.
-spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
+spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp" \
+  || spawn_delivery_fail "the GOTMPDIR export"
 # Send through the exact channel that already ships GOTMPDIR, so every backend
 # and harness - ship, scout, and secondmate - gets it before launch. Skipped
 # entirely when trace context is off.
@@ -3056,13 +3049,13 @@ if [ -n "$SPAWN_TRACEPARENT" ]; then
   fi
 fi
 sleep 0.3
-spawn_send_literal "$T" "$LAUNCH"
+spawn_send_literal "$T" "$LAUNCH" || spawn_delivery_fail "the launch command"
 sleep 0.3
 if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   HERDR_PROJECTION_ABORT_CLEANUP=0
   spawn_herdr_presentation_order_lock_release
 fi
-spawn_send_key "$T" Enter
+spawn_send_key "$T" Enter || spawn_delivery_fail "the launch command's Enter"
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -61,22 +61,26 @@ It is not deterministic across the verified adapters: codex and grok resume only
    A ship or scout keeps the harness already recorded for it, because that harness comes from firstmate's dispatch-profile judgment at intake and must not be silently re-read from configuration.
    A recorded raw-command basename that differs from its resolved adapter cannot reproduce the command actually running, so relaunch refuses before the checkpoint unless the caller passes an explicit `--harness` to choose the replacement runtime deliberately.
    A harness change resets model and effort unless they are named too, because a model chosen for one adapter does not transfer to another.
-2. **Safe checkpoint.**
+2. **Backlog preflight.**
+   The launch owner refuses a task whose backlog item its dispatch transition cannot own (closed, held, blocked, or missing), and on its own it would do so only after the old agent had been stopped.
+   `relaunch` runs that same shared preflight (`fm_backlog_dispatch_preflight` in `bin/fm-backlog-transition-lib.sh`) first, so such a task is refused while its agent is still running and the refusal names the backlog state.
+3. **Safe checkpoint.**
    The recorded worktree must exist and be a worktree root; its head and dirty state are recorded.
    For a `kind=secondmate` task, the home's identity marker must match and its child records must be readable, so a relaunch can never strand child work behind an unreadable home.
    A secondmate's own crewmates run in their own endpoints and outlive its relaunch; the relaunched secondmate reconciles them from its home's durable records at startup.
-3. **Record the note.**
+4. **Record the note.**
    A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation; the note is appended to the instructions it reads.
    A secondmate relaunch does not require one and never rewrites its standing charter.
-4. **Stop the old agent** through the `exit` verb, with its postcondition.
-5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+5. **Stop the old agent** through the `exit` verb, with its postcondition.
+6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
 
 ### Failure and rollback
 
 - A refusal **before** the agent is stopped leaves the durable record and the instructions byte-identical.
-- A launch failure **after** the agent is stopped restores the prior durable record, keeps the progress note so a later recovery still has it, marks the journal `failed:launching`, and reports plainly that no agent is running and where the work is preserved.
+- A launch failure **after** the agent is stopped restores the prior durable record, keeps the progress note so a later recovery still has it, marks the journal `failed:launching` with the launch owner's own refusal in `launch_error=`, and reports plainly that no agent is running and where the work is preserved.
+  That refusal is repeated on the summary line and on the final rollback line, so a caller that keeps only the last line or two still learns which step failed rather than only that the replacement did not start.
 - If the launch owner already published the new record but no running agent can be confirmed, the new record is kept: the task is recorded on the new harness with no agent confirmed, which is exactly what recovery reconciles.
   Rewriting it back to the old harness would be a second, worse inaccuracy.
 

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -967,6 +967,16 @@ test_launch_failure_keeps_the_prior_record_and_reports_it() {
   expect_code 1 "$rc" "a failed launch should fail closed"$'\n'"$out"
   assert_contains "$out" "no agent is running" "the failure should say no agent is running"
   assert_contains "$out" "$dir/wt" "the failure should say where the work is preserved"
+  # The launch owner's own refusal must survive into every line a caller might
+  # read last - the summary line, and the rollback line that ends the output -
+  # and into the journal, so a caller keeping only the tail still learns WHY.
+  assert_contains "$(printf '%s\n' "$out" | grep 'could not be launched')" \
+    "not its recorded worktree" \
+    "the summary line should carry the launch owner's refusal"
+  assert_contains "$(printf '%s\n' "$out" | tail -1)" "not its recorded worktree" \
+    "the last line should carry the launch owner's refusal"
+  assert_contains "$(journal_field "$dir" rl13 launch_error)" "not its recorded worktree" \
+    "the journal should record the launch owner's refusal"
   [ "$(cat "$dir/home/state/rl13.meta")" = "$before" ] \
     || fail "a failed launch must keep the prior durable record"
   [ "$(journal_field "$dir" rl13 phase)" = "failed:launching" ] \
@@ -1019,6 +1029,10 @@ test_post_publication_launch_failure_keeps_the_new_record() {
   out=$(FM_FAKE_LAUNCH_TRANSPORT_FAIL_AFTER_START=1 \
     run_control "$dir" rl24 relaunch --harness codex --note "keep the published record"); rc=$?
   expect_code 1 "$rc" "a post-publication launch failure should fail closed"$'\n'"$out"
+  # fm-spawn runs under set -e; a backend send that fails must still name the
+  # step instead of ending the launch owner with no diagnostic at all.
+  assert_contains "$out" "could not deliver the launch command" \
+    "a failed launch delivery should name the step that failed"
   [ "$(meta_field "$dir" rl24 harness)" = codex ] \
     || fail "a published replacement record must not be rewritten to the prior harness"
   [ -n "$(meta_field "$dir" rl24 control_relaunch_tx)" ] \
@@ -1477,6 +1491,39 @@ test_relaunch_moves_a_drifted_item_back_in_flight() {
   pass "relaunch heals an item that drifted out of In flight while the task stayed live"
 }
 
+# The 2026-09-01 field failure: the item had already been closed, so the launch
+# owner refused it - but only after fm-control had stopped the agent, leaving
+# the task with no agent at all, and the refusal line sat above the two lines
+# the caller's `tail -2` kept. The preflight must now run while the agent is
+# still up, and the refusal must name the backlog state.
+test_undispatchable_backlog_item_refuses_before_stopping_anything() {
+  local dir out rc=0 before
+  command -v tasks-axi >/dev/null 2>&1 || {
+    pass "skipped: tasks-axi is not installed, so the backlog transition is inert"
+    return 0
+  }
+  dir=$(new_case closed-item rl42)
+  add_ship_task "$dir" rl42 claude
+  seed_backlog "$dir" rl42 in_flight
+  tasks-axi 'done' rl42 --file "$dir/home/data/backlog.md" >/dev/null
+  before=$(cat "$dir/home/state/rl42.meta")
+
+  out=$(run_control "$dir" rl42 relaunch --note "relaunching a closed item") || rc=$?
+  expect_code 1 "$rc" "a relaunch of a closed backlog item must refuse"$'\n'"$out"
+  assert_contains "$out" "not dispatchable in state done" \
+    "the refusal should name the backlog state that blocks the relaunch"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "a relaunch refused by the backlog preflight must not stop the agent"
+  [ -z "$(cat "$dir/fake/literal")" ] || fail "a refused relaunch must send nothing"
+  [ "$(cat "$dir/home/state/rl42.meta")" = "$before" ] \
+    || fail "a refused relaunch must leave the durable record byte-identical"
+  [ ! -e "$dir/home/state/rl42.control-relaunch" ] \
+    || fail "a refusal before the checkpoint must open no relaunch transaction"
+  ! grep -q "relaunching a closed item" "$dir/home/data/rl42/brief.md" \
+    || fail "a refused relaunch must not rewrite the instructions"
+  pass "fm-control relaunch: a backlog item the dispatch cannot own refuses before the agent is stopped"
+}
+
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_serializes_concurrent_durable_metadata_publication
@@ -1528,3 +1575,4 @@ test_spawn_relaunch_refuses_an_unrecorded_task
 test_spawn_relaunch_refuses_a_pane_outside_the_worktree
 test_relaunch_reverifies_an_already_in_flight_item_instead_of_rewriting_it
 test_relaunch_moves_a_drifted_item_back_in_flight
+test_undispatchable_backlog_item_refuses_before_stopping_anything


### PR DESCRIPTION
`fm-control relaunch` stopped the old agent and only then called `fm-spawn --relaunch`, which runs the backlog dispatch preflight. A task whose backlog item is closed, held, blocked, or missing was therefore refused after its agent was gone, leaving it with no agent at all, and fm-control's own summary line ("could not be launched on <harness>") carried no reason, so a caller keeping only the last lines saw a launch that failed for nothing. Observed live on 2026-09-01 (Herdr 0.8.2, pi 0.84.2) relaunching a task whose item was already Done; reproduced in an isolated Herdr lab with a real pi worker.

- Extract the dispatch preflight into fm_backlog_dispatch_preflight (bin/fm-backlog-transition-lib.sh) and run it in fm-control before the checkpoint and the stop; fm-spawn calls the same function.
- Capture fm-spawn's stderr in fm-control and repeat its last error line on the summary line, the final rollback line, and the journal's launch_error= field.
- Name a failed launch delivery in fm-spawn (GOTMPDIR export, launch literal, Enter) instead of exiting silently under set -e.
- tests/fm-control-relaunch.test.sh: a closed item refuses before the agent is touched; the reason survives to the last line and the journal; a failed send names its step.
- docs/agent-control.md: backlog preflight step and surfaced reason.