### PR TITLE
fix(bin): root per-task temp under TMPDIR and keep test scratch out of the system temp tree

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2473,12 +2473,22 @@ if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1
 fi
 
-# Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
-# create GOTMPDIR, so mkdir before it is used; fm-teardown removes the whole root.
-# Nested (not a bare /tmp/fm-<id>/gotmp) so other per-task temp can live alongside
-# later, and teardown cleans one deterministic path. GOTMPDIR (not TMPDIR) is the
-# targeted knob: TMPDIR is too broad (affects every program's temp, not just Go's).
-TASK_TMP="/tmp/fm-$ID"
+# Per-task temp root: ${TMPDIR:-/tmp}/fm-<id>/ with Go's build temp nested at
+# gotmp/. Go won't create GOTMPDIR, so mkdir before it is used; fm-teardown removes
+# the whole root through the tasktmp= line recorded below. Nested (not a bare
+# fm-<id>/gotmp) so other per-task temp can live alongside later, and teardown
+# cleans one deterministic path. The root honours the caller's TMPDIR like every
+# other mktemp site in bin/, so a test suite's private TMPDIR collects it instead
+# of the system temp tree; GOTMPDIR (not TMPDIR) stays the knob exported into the
+# pane, because TMPDIR is too broad (every program's temp, not just Go's). A
+# relaunch keeps the recorded root so the task never strands one under an older
+# TMPDIR.
+TASK_TMP=
+[ "$RELAUNCH" -eq 0 ] || TASK_TMP=$(fm_meta_get "$RELAUNCH_META" tasktmp)
+if [ -z "$TASK_TMP" ]; then
+  TASK_TMP=${TMPDIR:-/tmp}
+  TASK_TMP="${TASK_TMP%/}/fm-$ID"
+fi
 mkdir -p "$TASK_TMP/gotmp"
 
 # Per-harness turn-end hook where enabled: a file that touches

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -733,7 +733,8 @@ fi
 HOME_PATH=$(grep '^home=' "$META" | cut -d= -f2- || true)
 PR_URL=$(grep '^pr=' "$META" | tail -1 | cut -d= -f2- || true)
 # tasktmp is recorded by fm-spawn for tasks that set up a per-task temp root
-# (/tmp/fm-<id>/); absent for tasks spawned before that change, so tolerate empty.
+# (fm-<id>/ under spawn's TMPDIR); absent for tasks spawned before that change, so
+# tolerate empty.
 TASK_TMP=$(grep '^tasktmp=' "$META" | cut -d= -f2- || true)
 BUSY_GEN=$(fm_meta_get "$META" busy_gen)
 if [ -z "$BUSY_GEN" ]; then
@@ -2866,7 +2867,7 @@ fi
 remove_grok_turnend_auth "$STATE" "$ID" || exit 1
 remove_kimi_turnend_auth "$STATE" "$ID" || exit 1
 fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
-# Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
+# Remove the per-task temp root (fm-<id>/, incl. its gotmp/) recorded by spawn.
 # Read before the state-file rm below; empty (pre-fix tasks without tasktmp=) is a no-op.
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1

--- a/tests/fm-afk-pi-herdr-return-e2e.test.sh
+++ b/tests/fm-afk-pi-herdr-return-e2e.test.sh
@@ -57,6 +57,7 @@ cleanup() {
     rc=1
   fi
   rm -rf "$TMP_ROOT"
+  fm_test_cleanup
   exit "$rc"
 }
 trap cleanup EXIT

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -518,11 +518,10 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   assert_grep "worktree=$wt" "$state/$id.meta" "meta missing Orca worktree path"
   assert_not_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''create' \
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
-  assert_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-spawn'$'\x1f''--text'$'\x1f''export GOTMPDIR=/tmp/fm-orcaspawnz1/gotmp'$'\x1f''--enter'$'\x1f''--json' \
+  assert_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-spawn'$'\x1f''--text'$'\x1f'"export GOTMPDIR=${TMPDIR:-/tmp}/fm-$id/gotmp"$'\x1f''--enter'$'\x1f''--json' \
     "spawn did not export GOTMPDIR through the Orca terminal"
   assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions" \
     "spawn did not send the selected harness launch command through Orca"
-  rm -rf "/tmp/fm-$id"
   pass "fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness"
 }
 

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -30,21 +30,8 @@ CONTROL="$ROOT/bin/fm-control.sh"
 SPAWN="$ROOT/bin/fm-spawn.sh"
 PROMOTE="$ROOT/bin/fm-promote.sh"
 X_LINK="$ROOT/bin/fm-x-link.sh"
-# fm_test_tmproot's own cleanup trap fires when its command substitution exits,
-# so recreate the root before resolving it and clean it up from this file's trap.
 TMP_ROOT=$(fm_test_tmproot fm-control-relaunch)
-mkdir -p "$TMP_ROOT"
 TMP_ROOT=$(cd "$TMP_ROOT" && pwd)
-TASK_TMPS=()
-
-relaunch_cleanup() {
-  local d
-  for d in "${TASK_TMPS[@]:-}"; do
-    [ -n "$d" ] && rm -rf "$d"
-  done
-  rm -rf "$TMP_ROOT"
-}
-trap relaunch_cleanup EXIT
 
 # The same lifecycle-modelling tmux stub as tests/fm-control.test.sh: the
 # harness's exit command stops the agent, and a launch-brief literal starts the
@@ -152,13 +139,12 @@ add_ship_task() {
     echo "kind=ship"
     echo "mode=no-mistakes"
     echo "yolo=off"
-    echo "tasktmp=/tmp/fm-$id"
+    echo "tasktmp=$dir/fm-$id"
     echo "model=default"
     echo "effort=default"
   } > "$home/state/$id.meta"
   printf '%s\n' "fm-$id" > "$dir/fake/windows"
   printf '%s' "$wt" > "$dir/fake/cwd"
-  TASK_TMPS+=("/tmp/fm-$id")
 }
 
 run_control() {  # <case-dir> <args...>

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -33,7 +33,6 @@ SEND="$ROOT/bin/fm-send.sh"
 TMP_ROOT=$(fm_test_tmproot fm-control)
 mkdir -p "$TMP_ROOT"
 TMP_ROOT=$(cd "$TMP_ROOT" && pwd)
-trap 'rm -rf "$TMP_ROOT"' EXIT
 
 VERIFIED_HARNESSES="claude codex opencode pi pi-signed grok kimi cursor muse"
 

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -32,7 +32,6 @@ set -u
 
 HARNESS="$ROOT/bin/fm-harness.sh"
 TMP_ROOT=$(fm_test_tmproot fm-cursor-harness)
-trap 'rm -rf "$TMP_ROOT"' EXIT
 
 # A fake cursor install tree with BOTH installed names, shaped exactly like the
 # real one: ~/.local/share/cursor-agent/versions/<version>/cursor-agent with

--- a/tests/fm-cursor-primary-live-e2e.test.sh
+++ b/tests/fm-cursor-primary-live-e2e.test.sh
@@ -54,6 +54,7 @@ MARKER="FM_CURSOR_LIVE_MARKER_$$"
 cleanup_all() {
   "$REAL_TMUX" -L "$SOCKET" kill-server >/dev/null 2>&1 || true
   [ -n "${LAB:-}" ] && rm -rf "$LAB"
+  fm_test_cleanup
 }
 trap cleanup_all EXIT
 

--- a/tests/fm-documentation-audiences.test.sh
+++ b/tests/fm-documentation-audiences.test.sh
@@ -8,7 +8,7 @@ set -u
 CHECK="$ROOT/bin/fm-doc-audience-check.sh"
 INVENTORY="$ROOT/docs/documentation-audiences.json"
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-doc-audiences.XXXXXX")
-trap 'rm -rf "$TMP_ROOT"' EXIT
+trap 'rm -rf "$TMP_ROOT"; fm_test_cleanup' EXIT
 
 run_expect_failure() {
   local expected=$1

--- a/tests/fm-grok-stop-live-e2e.test.sh
+++ b/tests/fm-grok-stop-live-e2e.test.sh
@@ -74,6 +74,8 @@ preserve_on_failure() {
   local rc=$?
   if [ "$rc" -ne 0 ] && [ -n "$ACTIVE_LAB" ]; then
     echo "blocked: preserving failed isolated Grok cell at $ACTIVE_LAB" >&2
+  else
+    fm_test_cleanup
   fi
   exit "$rc"
 }
@@ -215,5 +217,6 @@ EOF
 
 run_cell native "$NATIVE_BIN"
 run_cell legacy "$LEGACY_BIN"
+fm_test_cleanup
 trap - EXIT
 echo "ok - Grok adaptive Stop real-process matrix passed with exact target cleanup and control-window survival"

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -24,6 +24,7 @@ BASE_PATH=${FM_TEST_BASE_PATH:-$PYTHON_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin}
 cleanup_kimi_harness() {
   [ -z "$KIMI_RUNTIME_TASK_TMP" ] || rm -rf "$KIMI_RUNTIME_TASK_TMP"
   rm -rf "$TMP_ROOT"
+  fm_test_cleanup
 }
 trap cleanup_kimi_harness EXIT
 
@@ -185,7 +186,7 @@ EOF
 test_kimi_launch_then_send_is_verified() {
   local id rec out rc launch pointer brief_real meta task_tmp
   id="kimi-success-z1-$$"
-  task_tmp="/tmp/fm-$id"
+  task_tmp="${TMPDIR:-/tmp}/fm-$id"
   KIMI_RUNTIME_TASK_TMP=$task_tmp
   rm -rf "$task_tmp"
   rec=$(make_spawn_case success "$id")

--- a/tests/fm-on.test.sh
+++ b/tests/fm-on.test.sh
@@ -22,6 +22,7 @@ cleanup() {
     FM_REMOTE_JOB_STATE="$TMP_ROOT/remote-jobs"
     fm_remote_job_stop_worker_tree "$pid" 2>/dev/null || true
   fi
+  fm_test_cleanup
   rm -rf -- "$TMP_ROOT"
 }
 trap cleanup EXIT

--- a/tests/fm-remote-backlog-handoff.test.sh
+++ b/tests/fm-remote-backlog-handoff.test.sh
@@ -48,7 +48,7 @@ fm_remote_handoff_teardown() {
   done
   rm -rf -- "$TMP_ROOT" 2>/dev/null || true
 }
-trap fm_remote_handoff_teardown EXIT
+trap 'fm_remote_handoff_teardown; fm_test_cleanup' EXIT
 printf 'fixture\n' > "$REMOTE_ROOT/AGENTS.md"
 cp "$ROOT/bin/fm-remote-entrypoint.sh" "$ROOT/bin/fm-remote-job-lib.sh" \
   "$ROOT/bin/fm-remote-job-worker.sh" "$ROOT/bin/fm-remote-file.sh" \

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -33,6 +33,7 @@ cleanup_remote_job_fixture() {
     fm_remote_job_stop_worker_tree "$(cat "$STATE_ROOT/worker.pid")" || true
   fi
   rm -rf -- "$TMP_ROOT"
+  fm_test_cleanup
 }
 trap cleanup_remote_job_fixture EXIT
 

--- a/tests/fm-remote-reply.test.sh
+++ b/tests/fm-remote-reply.test.sh
@@ -28,6 +28,7 @@ cleanup() {
     fm_remote_job_stop_worker_tree "$worker_pid" || true
   fi
   rm -rf -- "$TMP_ROOT"
+  fm_test_cleanup
 }
 trap cleanup EXIT
 

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -40,6 +40,7 @@ cleanup() {
     done
   fi
   rm -rf -- "$TMP_ROOT"
+  fm_test_cleanup
 }
 trap cleanup EXIT
 

--- a/tests/fm-remote-secondmate-parent-binding.test.sh
+++ b/tests/fm-remote-secondmate-parent-binding.test.sh
@@ -63,6 +63,7 @@ cleanup() {
     kill "$worker_pid" 2>/dev/null || true
   fi
   rm -rf -- "$TMP_ROOT"
+  fm_test_cleanup
 }
 trap cleanup EXIT
 

--- a/tests/fm-remote-secondmate-trace-context.test.sh
+++ b/tests/fm-remote-secondmate-trace-context.test.sh
@@ -33,7 +33,7 @@ TMUX_LOG="$TMP_ROOT/remote-tmux.log"
 TMUX_STATE="$TMP_ROOT/remote-tmux.state"
 CLAIMS="$TMP_ROOT/claims"
 mkdir -p "$PARENT/data" "$PARENT/state" "$PARENT/config" "$PARENT/projects" "$REMOTE_ROOT" "$CLAIMS"
-trap 'FM_HOME="$PARENT" FM_PROCEVENT_CLAIM_ROOT="$CLAIMS" "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true; if [ -f "$TMP_ROOT/remote-jobs/worker.pid" ]; then kill "$(cat "$TMP_ROOT/remote-jobs/worker.pid")" 2>/dev/null || true; fi; rm -rf -- "$TMP_ROOT"' EXIT
+trap 'FM_HOME="$PARENT" FM_PROCEVENT_CLAIM_ROOT="$CLAIMS" "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true; if [ -f "$TMP_ROOT/remote-jobs/worker.pid" ]; then kill "$(cat "$TMP_ROOT/remote-jobs/worker.pid")" 2>/dev/null || true; fi; rm -rf -- "$TMP_ROOT"; fm_test_cleanup' EXIT
 
 # The remote host's tracked code root is this branch, as a real git repository:
 # fm-on and the remote entrypoint both require the dispatched command to be

--- a/tests/fm-remote-transport-lanes.test.sh
+++ b/tests/fm-remote-transport-lanes.test.sh
@@ -44,6 +44,7 @@ cleanup_lane_fixture() {
     fm_remote_job_stop_worker_tree "$(cat "$STATE_ROOT/worker.pid")" || true
   fi
   rm -rf -- "$TMP_ROOT"
+  fm_test_cleanup
 }
 trap cleanup_lane_fixture EXIT
 

--- a/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
+++ b/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
@@ -51,6 +51,7 @@ cleanup() {
     rc=1
   fi
   rm -rf "$TMP_ROOT"
+  fm_test_cleanup
   exit "$rc"
 }
 trap cleanup EXIT

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -164,9 +164,37 @@ test_orphan_sweep_reaps_read_only_package_tree() {
   pass "the orphan sweep reaps read-only package fixtures"
 }
 
+test_suite_private_tmpdir_is_exported_and_gone_after_exit() {
+  local harness ambient child_out suite_tmpdir exported
+  harness=$(fm_test_tmproot fm-test-cleanup-tmpdir-harness)
+  ambient="$harness/ambient"
+  mkdir -p "$ambient"
+  child_out=$(TMPDIR="$ambient" bash -c '
+    # shellcheck source=tests/lib.sh
+    . "'"$LIB"'"
+    printf "%s\n" "$TMPDIR"
+    sh -c '"'"'printf "%s\n" "$TMPDIR"'"'"'
+    scratch=$(mktemp -d)
+    if [ -d "$scratch" ]; then printf "mid:present\n"; else printf "mid:missing\n"; fi
+  ')
+  suite_tmpdir=$(printf '%s\n' "$child_out" | sed -n '1p')
+  exported=$(printf '%s\n' "$child_out" | sed -n '2p')
+  case "$suite_tmpdir" in
+    "$ambient"/*) ;;
+    *) fail "sourcing lib.sh did not move TMPDIR under the ambient one (got '$suite_tmpdir')" ;;
+  esac
+  [ "$exported" = "$suite_tmpdir" ] || fail "the suite's private TMPDIR was not exported to child processes"
+  assert_contains "$child_out" "mid:present" \
+    "plain mktemp did not land in the suite's private TMPDIR while the suite was alive"
+  assert_absent "$suite_tmpdir" \
+    "the suite's private TMPDIR survived its owning process's normal exit"
+  pass "sourcing lib.sh exports a private TMPDIR that leaves with the suite"
+}
+
 test_fixture_root_gone_after_normal_exit
 test_fixture_root_gone_after_sigterm
 test_cleanup_registry_resists_precreation
 test_fixture_registration_failure_rolls_back_root
 test_orphan_sweep_respects_fixture_ownership
 test_orphan_sweep_reaps_read_only_package_tree
+test_suite_private_tmpdir_is_exported_and_gone_after_exit

--- a/tests/fm-tmux-submit-busy.test.sh
+++ b/tests/fm-tmux-submit-busy.test.sh
@@ -10,7 +10,7 @@ set -u
 . "$ROOT/bin/fm-tmux-lib.sh"
 
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-tmux-submit-busy.XXXXXX")
-trap 'rm -rf "$TMP_ROOT"' EXIT
+trap 'rm -rf "$TMP_ROOT"; fm_test_cleanup' EXIT
 
 # Override fm_pane_is_busy for testing: FM_FAKE_PANE_BUSY=1 means busy.
 fm_pane_is_busy() {

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -156,6 +156,22 @@ if [ "${FM_TEST_SKIP_ORPHAN_REAP:-0}" != 1 ]; then
   fm_test_reap_orphans
 fi
 
+# Every suite runs under a private TMPDIR of its own: a registered fixture root
+# under the ambient one, exported so the suite and every bin script it drives
+# (fm-spawn's per-task temp root among them) put their scratch where the same
+# EXIT/INT/TERM cleanup removes it, instead of piling up in the system temp
+# tree. A suite that arms its own EXIT trap must call fm_test_cleanup from it
+# (see the fixture-root note above), or this root outlives the suite. The
+# orphan sweep above already ran against the ambient TMPDIR, so a hard-killed
+# suite's private root is reaped on a later source like any other marked
+# fixture. Herdr lab state stays in the ambient location: bin/fm-herdr-lab.sh
+# refuses to stop or tear down a lab whose fleet-state tripwire is missing, so
+# that record must outlive a suite that dies with a lab still running.
+FM_HERDR_LAB_STATE_DIR=${FM_HERDR_LAB_STATE_DIR:-${TMPDIR:-/tmp}/fm-herdr-lab-${UID}}
+export FM_HERDR_LAB_STATE_DIR
+TMPDIR=$(fm_test_tmproot fm-suite) || return 1
+export TMPDIR
+
 # --- fakebin / PATH shims ---------------------------------------------------
 #
 # fm_fakebin <dir> creates <dir>/fakebin and echoes it; prepend it to PATH to


### PR DESCRIPTION
Every suite that drives the real bin/fm-spawn.sh left a /tmp/fm-<id>/gotmp directory behind, because spawn hard-coded /tmp for the per-task temp root while nothing but fm-teardown ever removes it. On a machine that runs the suite the system temp tree fills with fixture ids that no task owns.

- bin/fm-spawn.sh roots the per-task temp directory under ${TMPDIR:-/tmp}, the same override every other mktemp site in bin/ honours, and a relaunch keeps the root recorded in the task's meta instead of computing a new one.
- tests/lib.sh exports a private per-suite TMPDIR, itself a registered fixture root, so the suite and every script it runs put their scratch where the existing EXIT/INT/TERM cleanup removes it. The Herdr lab state dir is pinned to the ambient location first, because bin/fm-herdr-lab.sh refuses to tear down a lab whose fleet-state tripwire is missing.
- Suites that arm their own EXIT trap now call fm_test_cleanup from it, as lib.sh's fixture-root contract already required; the ones whose trap only removed a registered root drop the redundant trap instead.
- Tests that pinned /tmp/fm-<id> now follow TMPDIR, and tests/fm-test-fixture-cleanup.test.sh covers the exported private TMPDIR.