### PR TITLE
fix: refuse publication after stale-base validation

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -36,8 +36,8 @@ document:
 # would duplicate CI and defeat the targeted Test contract.
 commands:
   lint: 'bin/fm-lint.sh'
-  # no-mistakes runs commands.format as Push's first action after validation.
-  # Use that supported slot to refuse publication when the validated head is not based on current upstream main.
+  # Run the upstream-base check from no-mistakes' supported commands.format slot.
+  # The helper's header owns its mechanics and the command-to-publication boundary.
   format: 'bin/fm-nm-publish-guard.sh'
 
 # Publish each run's test evidence to the orphan no-mistakes/evidence branch linked from the PR.

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -36,6 +36,9 @@ document:
 # would duplicate CI and defeat the targeted Test contract.
 commands:
   lint: 'bin/fm-lint.sh'
+  # no-mistakes runs commands.format as Push's first action after validation.
+  # Use that supported slot to refuse publication when the validated head is not based on current upstream main.
+  format: 'bin/fm-nm-publish-guard.sh'
 
 # Publish each run's test evidence to the orphan no-mistakes/evidence branch linked from the PR.
 # The evidence is not committed to the feature or default branch.

--- a/bin/fm-nm-publish-guard.sh
+++ b/bin/fm-nm-publish-guard.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Refuse a no-mistakes publication unless the validated head contains the
+# current upstream default-branch tip.
+#
+# firstmate wires this executable into no-mistakes' trusted commands.format
+# slot, which runs after validation and immediately before the Push step's
+# commit and remote mutation.
+# The guard deliberately chooses refusal instead of another rebase because the
+# pipeline already owns branch custody and validation; rewriting here would
+# publish a head the completed validation steps never exercised.
+#
+# The current base comes from one live `git ls-remote --symref origin HEAD`
+# observation, then an exact fetch of that advertised branch into FETCH_HEAD.
+# The branch is not moved and no named ref is written.
+# If the remote default, its commit, the fetch, or ancestry cannot be proved,
+# publication is refused.
+# A default branch that moves between observation and fetch is also refused so
+# a racing read cannot certify either tip.
+#
+# Usage: fm-nm-publish-guard.sh
+set -eu
+
+refuse() {
+  printf 'fm-nm-publish-guard: REFUSED: %s\n' "$*" >&2
+  exit 1
+}
+
+[ "$#" -eq 0 ] || refuse "this guard accepts no arguments"
+[ "$(git rev-parse --is-inside-work-tree 2>/dev/null || true)" = true ] \
+  || refuse "the publication directory is not a Git worktree"
+
+remote_view=$(LC_ALL=C git ls-remote --symref origin HEAD 2>/dev/null) \
+  || refuse "could not read origin's current default branch"
+
+default_ref=$(printf '%s\n' "$remote_view" | awk '
+  $1 == "ref:" && $3 == "HEAD" { count++; value=$2 }
+  END { if (count == 1 && value != "") print value; else exit 1 }
+') || refuse "could not determine origin's current default branch"
+advertised_head=$(printf '%s\n' "$remote_view" | awk '
+  $2 == "HEAD" { count++; value=$1 }
+  END { if (count == 1 && value != "") print value; else exit 1 }
+') || refuse "could not determine origin's current default-branch commit"
+
+case "$default_ref" in
+  refs/heads/*) ;;
+  *) refuse "origin's advertised default branch is not a branch ref" ;;
+esac
+git check-ref-format "$default_ref" >/dev/null 2>&1 \
+  || refuse "origin's advertised default branch is invalid"
+
+if ! git fetch --no-tags --quiet origin "$default_ref"; then
+  refuse "could not fetch origin's current default branch"
+fi
+fetched_head=$(git rev-parse --verify 'FETCH_HEAD^{commit}' 2>/dev/null) \
+  || refuse "the fetched default-branch tip is not a commit"
+[ "$fetched_head" = "$advertised_head" ] \
+  || refuse "origin's default branch moved while publication safety was being checked"
+validated_head=$(git rev-parse --verify 'HEAD^{commit}' 2>/dev/null) \
+  || refuse "the validated publication head is not a commit"
+
+if ! git merge-base --is-ancestor "$fetched_head" "$validated_head" 2>/dev/null; then
+  refuse "the validated publication head does not contain origin/${default_ref#refs/heads/}"
+fi
+
+printf 'fm-nm-publish-guard: verified: validated head contains current origin/%s\n' \
+  "${default_ref#refs/heads/}"

--- a/bin/fm-nm-publish-guard.sh
+++ b/bin/fm-nm-publish-guard.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
-# Refuse a no-mistakes publication unless the validated head contains the
+# Check whether the current no-mistakes publication candidate contains the
 # current upstream default-branch tip.
 #
 # firstmate wires this executable into no-mistakes' trusted commands.format
-# slot, which runs after validation and immediately before the Push step's
-# commit and remote mutation.
-# The guard deliberately chooses refusal instead of another rebase because the
-# pipeline already owns branch custody and validation; rewriting here would
-# publish a head the completed validation steps never exercised.
+# slot after validation and before the Push step's commit and remote mutation.
+# This helper exits nonzero when the proof fails; installed no-mistakes owns
+# whether a failing formatter blocks the surrounding publication.
+# The helper deliberately exits instead of rebasing because the pipeline
+# already owns branch custody and validation; rewriting here would publish a
+# head the completed validation steps never exercised.
 #
 # The current base comes from one live `git ls-remote --symref origin HEAD`
 # observation, then an exact fetch of that advertised branch into FETCH_HEAD.
 # The branch is not moved and no named ref is written.
 # If the remote default, its commit, the fetch, or ancestry cannot be proved,
-# publication is refused.
+# the check exits nonzero.
 # A default branch that moves between observation and fetch is also refused so
 # a racing read cannot certify either tip.
 #
@@ -48,7 +49,7 @@ esac
 git check-ref-format "$default_ref" >/dev/null 2>&1 \
   || refuse "origin's advertised default branch is invalid"
 
-if ! git fetch --no-tags --quiet origin "$default_ref"; then
+if ! git fetch --refmap= --no-tags --quiet origin "$default_ref"; then
   refuse "could not fetch origin's current default branch"
 fi
 fetched_head=$(git rev-parse --verify 'FETCH_HEAD^{commit}' 2>/dev/null) \

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -287,7 +287,7 @@ family_for_basename() {
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;
-    fm-check-unregister.test.sh|fm-pr-check-security.test.sh|fm-pr-merge.test.sh|\
+    fm-check-unregister.test.sh|fm-nm-publish-guard.test.sh|fm-pr-check-security.test.sh|fm-pr-merge.test.sh|\
     fm-review-diff.test.sh|fm-teardown.test.sh|fm-x-mode.test.sh)
       printf '%s\n' pr-forge
       ;;
@@ -565,6 +565,7 @@ tests/fm-kimi-harness.test.sh 18015
 tests/fm-lint-workflows.test.sh 855
 tests/fm-muse-harness.test.sh 55572
 tests/fm-muse-signals-live-e2e.test.sh 23
+tests/fm-nm-publish-guard.test.sh 400
 tests/fm-no-mistakes-required.test.sh 370
 tests/fm-on.test.sh 11692
 tests/fm-opencode-primary-live-e2e.test.sh 21
@@ -1238,6 +1239,9 @@ families_for_changed_path() {
     bin/fm-x-*|bin/fm-check*)
       printf '%s\n' pr-forge
       ;;
+    bin/fm-nm-publish-guard.sh)
+      printf '%s\n' "__script__:fm-nm-publish-guard.test.sh"
+      ;;
     bin/fm-nm-run-lib.sh)
       # Shared no-mistakes run-attribution primitives, sourced by both
       # bin/fm-crew-state.sh (pure-contract-unit) and bin/fm-teardown.sh's
@@ -1302,7 +1306,12 @@ families_for_changed_path() {
     .agents/skills/*/SKILL.md)
       printf '%s\n' pure-contract-unit
       ;;
-    .github/workflows/ci.yml|.no-mistakes.yaml)
+    .no-mistakes.yaml)
+      printf '%s\n' "__script__:fm-nm-publish-guard.test.sh"
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' real-herdr-gated
+      ;;
+    .github/workflows/ci.yml)
       printf '%s\n' pure-contract-unit
       printf '%s\n' real-herdr-gated
       ;;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -288,7 +288,7 @@ A ship brief records its mode as a fixed machine-readable line and the spawn ref
 When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
 Where a no-mistakes pipeline stores evidence in the repo, it publishes that PR-viewable validation evidence to an orphan evidence branch that shares no history with code branches, so it never enters the crew branch or the default branch.
 This repo uses that setting, and its own `.no-mistakes/` directory remains local state that stays gitignored and is rejected by CI if tracked; [`configuration.md`](configuration.md) owns the setting.
-The trusted no-mistakes config invokes [`bin/fm-nm-publish-guard.sh`](../bin/fm-nm-publish-guard.sh) as Push's first action, so this repo refuses publication unless the current upstream default tip is proven in the validated head.
+The trusted no-mistakes config runs [`bin/fm-nm-publish-guard.sh`](../bin/fm-nm-publish-guard.sh) from `commands.format` as an upstream-base check; the helper's header owns its mechanics and the command-to-publication boundary.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling the forge CLI.
 The helper requires a full canonical URL and rejects malformed URLs or repo override flags before recording merge state.
 A `https://github.com/<owner>/<repo>/pull/<n>` URL invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, and preserves explicit merge-method flags.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -288,6 +288,7 @@ A ship brief records its mode as a fixed machine-readable line and the spawn ref
 When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
 Where a no-mistakes pipeline stores evidence in the repo, it publishes that PR-viewable validation evidence to an orphan evidence branch that shares no history with code branches, so it never enters the crew branch or the default branch.
 This repo uses that setting, and its own `.no-mistakes/` directory remains local state that stays gitignored and is rejected by CI if tracked; [`configuration.md`](configuration.md) owns the setting.
+The trusted no-mistakes config invokes [`bin/fm-nm-publish-guard.sh`](../bin/fm-nm-publish-guard.sh) as Push's first action, so this repo refuses publication unless the current upstream default tip is proven in the validated head.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling the forge CLI.
 The helper requires a full canonical URL and rejects malformed URLs or repo override flags before recording merge state.
 A `https://github.com/<owner>/<repo>/pull/<n>` URL invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, and preserves explicit merge-method flags.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -90,7 +90,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, guard injection by the detected primary harness, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
 | `fm-nm-run-lib.sh`       | Single owner of shared no-mistakes run-attribution primitives and rules             |
-| `fm-nm-publish-guard.sh` | Refuse no-mistakes publication when the validated head lacks the current upstream default tip |
+| `fm-nm-publish-guard.sh` | Check whether the publication candidate contains the current upstream default tip |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution and its fallback watchdog |
 | `fm-timing-lib.sh`       | Single owner of the deferred network stage's per-step elapsed-time records, inert unless a run asks for them |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -90,6 +90,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, guard injection by the detected primary harness, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
 | `fm-nm-run-lib.sh`       | Single owner of shared no-mistakes run-attribution primitives and rules             |
+| `fm-nm-publish-guard.sh` | Refuse no-mistakes publication when the validated head lacks the current upstream default tip |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution and its fallback watchdog |
 | `fm-timing-lib.sh`       | Single owner of the deferred network stage's per-step elapsed-time records, inert unless a run asks for them |

--- a/tests/fm-nm-publish-guard.test.sh
+++ b/tests/fm-nm-publish-guard.test.sh
@@ -48,20 +48,24 @@ test_current_base_passes() {
 }
 
 test_stale_base_refuses() {
-  local world out rc
+  local world out rc refs_before refs_after
   world=$(make_world stale)
   printf 'main advanced\n' >> "$world/admin/value"
   git -C "$world/admin" add value
   git -C "$world/admin" commit -qm "advance main"
   git -C "$world/admin" push -q origin main
 
+  refs_before=$(git -C "$world/work" for-each-ref --format='%(refname) %(objectname)' | sort)
   rc=0
   out=$(run_guard "$world/work") || rc=$?
+  refs_after=$(git -C "$world/work" for-each-ref --format='%(refname) %(objectname)' | sort)
   [ "$rc" -ne 0 ] || fail "a stale-base head passed the publication guard"
   assert_contains "$out" "REFUSED" "the stale-base failure was not an explicit refusal"
   assert_contains "$out" "does not contain origin/main" \
     "the stale-base refusal did not identify the missing current base"
-  pass "fm-nm-publish-guard: a stale-base head is refused"
+  [ "$refs_before" = "$refs_after" ] \
+    || fail "the stale-base check moved a named ref"
+  pass "fm-nm-publish-guard: a stale-base head is refused without moving refs"
 }
 
 test_undeterminable_base_refuses() {

--- a/tests/fm-nm-publish-guard.test.sh
+++ b/tests/fm-nm-publish-guard.test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Behavior tests for the no-mistakes pre-publication base guard.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+GUARD="$ROOT/bin/fm-nm-publish-guard.sh"
+TMP_ROOT=$(fm_test_tmproot fm-nm-publish-guard)
+fm_git_identity
+
+make_world() { # <name>
+  local name=$1 world
+  world="$TMP_ROOT/$name"
+  mkdir -p "$world/admin"
+  git init -q --bare "$world/origin.git"
+  git -C "$world/origin.git" symbolic-ref HEAD refs/heads/main
+  git -C "$world/admin" init -q -b main
+  printf 'base\n' > "$world/admin/value"
+  git -C "$world/admin" add value
+  git -C "$world/admin" commit -qm base
+  git -C "$world/admin" remote add origin "$world/origin.git"
+  git -C "$world/admin" push -q -u origin main
+  git clone -q "$world/origin.git" "$world/work"
+  git -C "$world/work" checkout -q -b feature
+  printf 'feature\n' >> "$world/work/value"
+  git -C "$world/work" add value
+  git -C "$world/work" commit -qm feature
+  printf '%s\n' "$world"
+}
+
+run_guard() { # <worktree>
+  (
+    cd "$1" || exit 111
+    "$GUARD"
+  ) 2>&1
+}
+
+test_current_base_passes() {
+  local world out rc
+  world=$(make_world current)
+  rc=0
+  out=$(run_guard "$world/work") || rc=$?
+  expect_code 0 "$rc" "a head based on current main should pass"
+  assert_contains "$out" "verified: validated head contains current origin/main" \
+    "the passing result did not identify the proven current base"
+  pass "fm-nm-publish-guard: a current-base head passes"
+}
+
+test_stale_base_refuses() {
+  local world out rc
+  world=$(make_world stale)
+  printf 'main advanced\n' >> "$world/admin/value"
+  git -C "$world/admin" add value
+  git -C "$world/admin" commit -qm "advance main"
+  git -C "$world/admin" push -q origin main
+
+  rc=0
+  out=$(run_guard "$world/work") || rc=$?
+  [ "$rc" -ne 0 ] || fail "a stale-base head passed the publication guard"
+  assert_contains "$out" "REFUSED" "the stale-base failure was not an explicit refusal"
+  assert_contains "$out" "does not contain origin/main" \
+    "the stale-base refusal did not identify the missing current base"
+  pass "fm-nm-publish-guard: a stale-base head is refused"
+}
+
+test_undeterminable_base_refuses() {
+  local world out rc
+  world=$(make_world undeterminable)
+  git -C "$world/origin.git" symbolic-ref HEAD refs/heads/missing
+
+  rc=0
+  out=$(run_guard "$world/work") || rc=$?
+  [ "$rc" -ne 0 ] || fail "an undeterminable base passed the publication guard"
+  assert_contains "$out" "REFUSED" \
+    "the undeterminable-base failure was not an explicit refusal"
+  assert_contains "$out" "could not determine origin's current default branch" \
+    "the undeterminable-base refusal did not identify the missing base"
+  pass "fm-nm-publish-guard: an undeterminable base fails closed"
+}
+
+test_trusted_config_wires_the_guard() {
+  local configured
+  configured=$(awk '
+    /^commands:[[:space:]]*$/ { in_commands=1; next }
+    in_commands && /^[^[:space:]#]/ { in_commands=0 }
+    in_commands && $1 == "format:" {
+      count++
+      value=$0
+      sub(/^[[:space:]]*format:[[:space:]]*/, "", value)
+      quote=sprintf("%c", 39)
+      if (substr(value, 1, 1) != quote || substr(value, length(value), 1) != quote) exit 1
+      value=substr(value, 2, length(value) - 2)
+    }
+    END { if (count == 1 && value != "") print value; else exit 1 }
+  ' "$ROOT/.no-mistakes.yaml") || fail "trusted no-mistakes config has no unique commands.format"
+  [ "$configured" = "bin/fm-nm-publish-guard.sh" ] \
+    || fail "trusted no-mistakes config does not invoke the publication guard"
+  pass "no-mistakes trusted config invokes the base guard at Push entry"
+}
+
+test_current_base_passes
+test_stale_base_refuses
+test_undeterminable_base_refuses
+test_trusted_config_wires_the_guard


### PR DESCRIPTION
## Intent

Make a ship's final validation bind to the head that can land, or refuse publication. A production run validated a pre-rebase head and later landed test-contract fallout that left two tests in one suite red: one guard measured a tuple after a helper return-contract change, and one notice test retained its pre-change markup expectation. Choose between validating after rebase and refusing a stale-base publication from existing support; when comparable, prefer refusal because a rerun is safer than a false pass. Fail closed when the upstream base cannot be determined. Do not weaken branch-custody or non-descendant protections, never force-push, and never hand-move a ref. Add executable regressions proving a stale-base head is caught, a current-base head passes, and an undeterminable base refuses. Keep the fix proportionate and explain the selected design in the pull request.

## What Changed

- Add a fail-closed pre-publication guard that resolves and fetches the live upstream default tip, then refuses unless the validated HEAD contains it.
- Wire the guard through trusted `commands.format`, preferring a safe rerun over rebasing after validation or moving named refs.
- Add executable regressions for current, stale, and undeterminable upstream bases, plus targeted test-runner mappings and documentation.

## Risk Assessment

🚨 High: The selected hook does not block publication, bypasses a sibling publication path, and is not atomically bound to the base, so the central stale-base failure remains reachable.

## Testing

Captain, target-diff inspection and focused testing exposed a stale-check fetch updating `refs/remotes/origin/main`; I added a behavioral regression and disabled fetch ref mapping, then reran the targeted suite and captured an end-to-end transcript confirming current and rebased heads pass, stale and undeterminable bases refuse, and local and remote named refs remain unchanged.

<details>
<summary>Evidence: Publication guard end-to-end transcript</summary>

Source: [Publication guard end-to-end transcript](https://github.com/jleemcf/firstmate/blob/9e843779d3be17b925497b78cfa3808929a27520/.no-mistakes/evidence/fm/fm-gate-validate-rebased-head/publish-guard-e2e.txt)

```text
Firstmate no-mistakes publication guard end-to-end transcript
Guard: bin/fm-nm-publish-guard.sh

CASE current-base
exit=0
fm-nm-publish-guard: verified: validated head contains current origin/main
local_named_refs=unchanged
remote_refs=unchanged

CASE stale-base-after-upstream-advance
exit=1
fm-nm-publish-guard: REFUSED: the validated publication head does not contain origin/main
local_named_refs=unchanged
remote_refs=unchanged

CASE rebased-current-base
exit=0
fm-nm-publish-guard: verified: validated head contains current origin/main
local_named_refs=unchanged
remote_refs=unchanged

CASE undeterminable-default-base
exit=1
fm-nm-publish-guard: REFUSED: could not determine origin's current default branch
local_named_refs=unchanged
remote_refs=unchanged
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9636db7dea101ebd391aaebd8f2a2daadf6edd0a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 3 issues (2 errors, 1 warning)</summary>

- 🚨 `.no-mistakes.yaml:41` - The new `format: &#39;bin/fm-nm-publish-guard.sh&#39;` wiring contradicts the required “refusing a stale-base publication” and “Fail closed” behavior. no-mistakes v1.60.2 treats formatter errors and nonzero exits as warnings, then continues to `publishRunHead`; continuity-proven CI repairs also call that shared publisher without running the formatter. Thus an advanced `origin/main` makes this guard exit 1, but publication still proceeds. The check needs a fail-closed shared publication boundary covering every publisher; because that requires a no-mistakes capability/update rather than only correcting this script, the remedy needs authorization.
- 🚨 `bin/fm-nm-publish-guard.sh:56` - The guard closes only the race between `ls-remote` and `fetch`. After this comparison succeeds, no-mistakes still performs status, commit, branch-lease discovery, and push operations; if the base advances during that interval, a now-stale head publishes successfully. That leaves the required “bind to the head that can land, or refuse publication” invariant reachable. Eliminating it requires an atomic remote-side base lease/check at publication, which extends the supporting subsystem and therefore needs authorization.
- ⚠️ `tests/fm-nm-publish-guard.test.sh:84` - `test_trusted_config_wires_the_guard` parses implementation source with `awk` and asserts an exact YAML string, so it is a newly added source-content-only test. It cannot prove that no-mistakes executes the command or treats its failure as blocking. Replace it with executable consumer behavior or remove it.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 5fb0ce7628f240f9844f8b4bcd32ecd6155c3778..bacdc2c743b2b75761ad6b71caf96c6445435958` — inspected the target change and acceptance surface.</code>
- <code>`bin/fm-test-run.sh tests/fm-nm-publish-guard.test.sh` — exercised current-base success, stale-base refusal, undeterminable-base refusal, and named-ref preservation.</code>
- <code>Manual temporary bare-origin workflow invoking `bin/fm-nm-publish-guard.sh` before an upstream advance, after the advance, after rebase, and with a missing default branch; compared `git for-each-ref` snapshots around every invocation.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
