### PR TITLE
fix: disable repository evidence publication

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -37,8 +37,9 @@ document:
 commands:
   lint: 'bin/fm-lint.sh'
 
-# Publish each run's test evidence to the orphan no-mistakes/evidence branch linked from the PR.
+# Publishing each run's test evidence to the orphan no-mistakes/evidence branch linked from the PR is off by captain order of 2026-09-02 until the upstream redaction fix lands.
+# Turn it back on deliberately when that fix lands rather than leaving it off by accident.
 # The evidence is not committed to the feature or default branch.
 test:
   evidence:
-    store_in_repo: true
+    store_in_repo: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,8 @@ When supervising live crewmates, keep firstmate's own long validation or build c
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
 Firstmate's wrapper still matters: crewmates route every `ask-user` finding to firstmate, which applies `ask-user-authority`, and crewmates never pass `--yes` or `-y` because either flag bypasses that check and any required captain escalation.
 `.no-mistakes.yaml` has test-evidence publication to the orphan `no-mistakes/evidence` branch off by captain order of 2026-09-02 until the upstream redaction fix lands, and it is expected to be restored deliberately at that point.
-When enabled, that branch shares no history with code branches, and the configuration pins the gate's lint command to `bin/fm-lint.sh`, matching the Linux CI lint job.
+When enabled, that branch shares no history with code branches.
+The configuration independently pins the gate's lint command to `bin/fm-lint.sh`, matching the Linux CI lint job.
 Local no-mistakes Test is intent-targeted and must not re-run every `tests/*.test.sh`; `.github/workflows/ci.yml` owns the broad behavior suite plus platform-specific compatibility lanes.
 When enabled, the pipeline publishes that evidence itself, so never hand-commit `.no-mistakes/` paths onto a feature branch; CI rejects them as tracked personal fleet paths.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,9 +69,10 @@ A crewmate picking up such a brief should load the skill even if the brief preda
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
 Firstmate's wrapper still matters: crewmates route every `ask-user` finding to firstmate, which applies `ask-user-authority`, and crewmates never pass `--yes` or `-y` because either flag bypasses that check and any required captain escalation.
-`.no-mistakes.yaml` publishes test evidence to the orphan `no-mistakes/evidence` branch, which shares no history with code branches, and pins the gate's lint command to `bin/fm-lint.sh`, matching the Linux CI lint job.
+`.no-mistakes.yaml` has test-evidence publication to the orphan `no-mistakes/evidence` branch off by captain order of 2026-09-02 until the upstream redaction fix lands, and it is expected to be restored deliberately at that point.
+When enabled, that branch shares no history with code branches, and the configuration pins the gate's lint command to `bin/fm-lint.sh`, matching the Linux CI lint job.
 Local no-mistakes Test is intent-targeted and must not re-run every `tests/*.test.sh`; `.github/workflows/ci.yml` owns the broad behavior suite plus platform-specific compatibility lanes.
-The pipeline publishes that evidence itself, so never hand-commit `.no-mistakes/` paths onto a feature branch; CI rejects them as tracked personal fleet paths.
+When enabled, the pipeline publishes that evidence itself, so never hand-commit `.no-mistakes/` paths onto a feature branch; CI rejects them as tracked personal fleet paths.
 
 Check and test the toolbelt before pushing:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -287,7 +287,8 @@ A ship brief records its mode as a fixed machine-readable line and the spawn ref
 `bin/fm-project-mode.sh` remains the one registry parser for the mechanical consumers that have no task in hand: fleet sync's `local-only` skip and home seeding's refusal and no-mistakes initialization.
 When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
 Where a no-mistakes pipeline stores evidence in the repo, it publishes that PR-viewable validation evidence to an orphan evidence branch that shares no history with code branches, so it never enters the crew branch or the default branch.
-This repo uses that setting, and its own `.no-mistakes/` directory remains local state that stays gitignored and is rejected by CI if tracked; [`configuration.md`](configuration.md) owns the setting.
+This repo has that publication off by captain order of 2026-09-02 until the upstream redaction fix lands, and it is expected to be restored deliberately at that point.
+Its own `.no-mistakes/` directory remains local state that stays gitignored and is rejected by CI if tracked; [`configuration.md`](configuration.md) owns the setting.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling the forge CLI.
 The helper requires a full canonical URL and rejects malformed URLs or repo override flags before recording merge state.
 A `https://github.com/<owner>/<repo>/pull/<n>` URL invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, and preserves explicit merge-method flags.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,8 +200,9 @@ The flag is a home-local supervision-noise preference and is not inherited by se
 
 ## Gate defaults (.no-mistakes.yaml)
 
-The tracked `.no-mistakes.yaml` sets `test.evidence.store_in_repo: true` and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
-Storing evidence in the repo publishes each run's test artifacts to the orphan `no-mistakes/evidence` branch and links them from the PR body, instead of keeping them on local disk under the no-mistakes home.
+The tracked `.no-mistakes.yaml` sets `test.evidence.store_in_repo: false` and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
+Repository evidence publication is off by captain order of 2026-09-02 until the upstream redaction fix lands, and it is expected to be restored deliberately at that point.
+When enabled, storing evidence in the repo publishes each run's test artifacts to the orphan `no-mistakes/evidence` branch and links them from the PR body, instead of keeping them on local disk under the no-mistakes home.
 That branch shares no history with code branches, so evidence never enters a pushed feature branch or the default branch; the worktree's `.no-mistakes/` stays local and CI rejects tracked entries under that path.
 It does not set `commands.test` to a complete `tests/*.test.sh` walk.
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the firstmate-specific local test policy and entry points.


### PR DESCRIPTION
## Intent

For firstmate itself, stop publishing no-mistakes gate evidence to the shared fork by setting the repository-level test.evidence.store_in_repo behavior off on the captain's explicit order of 2026-09-02 until the upstream redaction fix lands. Record in the configuration comment and the existing configuration, architecture, and contributor documentation that publication is currently off and must be restored deliberately when that fix lands, while preserving the explanation of what orphan-branch publication does when enabled. Do not alter or delete the existing no-mistakes/evidence branch. Validate and ship this through pull request 3585 without merging, and confirm that the remote evidence branch does not advance during this run.

## What Changed

- Set `test.evidence.store_in_repo` to `false`, stopping gate evidence publication to the orphan `no-mistakes/evidence` branch.
- Document the temporary captain-ordered pause and deliberate restoration requirement while preserving how orphan-branch publication works when enabled.

## Risk Assessment

✅ Low: The change is a narrowly scoped configuration toggle with consistent documentation and no source-verifiable defects.

## Testing

Earlier rebase and review phases completed without tests; after correcting one setup-only lookup, targeted semantic configuration validation, GitHub-rendered documentation checks, active-run and PR inspection, and repeated remote-ref checks passed, with no worktree artifacts left and the evidence branch unchanged through this phase.

<details>
<summary>Evidence: Semantic configuration, PR state, and remote evidence-branch verification</summary>

```text
{
  "repository_config": {
    "test.evidence.store_in_repo": false,
    "parsed_type": "bool",
    "commands.lint": "bin/fm-lint.sh"
  },
  "remote_evidence_branch": {
    "ref": "refs/heads/no-mistakes/evidence",
    "head_before": "3a084891737c4187504ae142592b295166e7c9f3",
    "head_after": "3a084891737c4187504ae142592b295166e7c9f3",
    "unchanged_during_check": true,
    "tip_committed_at": "2026-09-02T22:52:59Z",
    "tip_message": "no-mistakes: evidence for fm/fm-secondmate-parent-channel-structural-r1 (run 01M1GNCKDYFTYJ7WNEGZAHA4VJ)",
    "target_commit": "bcc3d0b2764ab0ac1a9bbe7793465e6a11bc7b59",
    "target_committed_at": "2026-09-02T22:26:02-04:00",
    "tip_predates_target": true,
    "head_at_end_of_test_phase": "3a084891737c4187504ae142592b295166e7c9f3",
    "unchanged_through_end_of_test_phase": true,
    "end_of_test_phase_checked_at": "2026-09-03T02:32:16.348410+00:00"
  },
  "pull_request": {
    "headRefName": "fm/fm-nm-evidence-off-e9",
    "isDraft": false,
    "mergedAt": null,
    "number": 3585,
    "state": "OPEN",
    "url": "https://github.com/kunchenguid/firstmate/pull/3585"
  },
  "result": "PASS: repository publication is disabled semantically; the existing remote evidence branch remained present and unchanged; PR 3585 is open and unmerged.",
  "checked_at": "2026-09-03T02:31:28.585455+00:00"
}
```
</details>
<details>
<summary>Evidence: GitHub-GFM-rendered changed documentation</summary>

```text
<!doctype html>
<html lang="en"><head><meta charset="utf-8"><title>Rendered evidence-publication documentation</title>
<style>body{max-width:980px;margin:2rem auto;padding:0 1rem;font-family:system-ui,sans-serif;line-height:1.5}.artifact-file{border-bottom:3px solid #0969da;padding-bottom:.4rem}section+section{margin-top:4rem;border-top:1px solid #d0d7de;padding-top:2rem}code{background:#f6f8fa;padding:.15rem .3rem;border-radius:4px}</style>
</head><body><section><h1 class="artifact-file">CONTRIBUTING.md</h1><h1 dir="auto">Contributing</h1>
<p dir="auto">Thanks for wanting to contribute.<br>
One rule up front:</p>
<p dir="auto"><strong>Human-authored pull requests targeting <code class="notranslate">main</code> must be raised through <a href="https://github.com/kunchenguid/no-mistakes"><code class="notranslate">no-mistakes</code></a>.</strong><br>
We require this to reduce the maintainer's burden of reviewing and merging contributions.</p>
<p dir="auto"><code class="notranslate">no-mistakes</code> puts a local git proxy in front of your real remote.<br>
Pushing through it runs an AI-driven review/test/lint pipeline in an isolated worktree, forwards the push upstream only after every check passes, and opens a clean PR automatically.</p>
<p dir="auto">A GitHub Actions check (<code class="notranslate">Require no-mistakes</code>) runs on PRs targeting <code class="notranslate">main</code> and requires both the deterministic signature and a parseable structured attestation from no-mistakes v1.46.0 or newer.<br>
The attestation must bind to the current PR head commit and report the review, test, and document steps as completed, so a stale attestation, a missing <code class="notranslate">head_sha</code>, or a skipped required step fails.<br>
It evaluates every PR opening and body edit independently, reruns after head synchronization or reopening, and prevents a later edit from replacing an earlier pending compliance check.<br>
GitHub Actions and Dependabot are exempt so their automation keeps working, but other contributor PRs that do not satisfy the attestation contract will not be reviewed or merged.</p>
<h2 dir="auto">Workflow</h2>
<ol dir="auto">
<li>
<p dir="auto">Fork the repo, then clone the parent repo or set your local <code class="notranslate">origin</code> back to the parent (<code class="notranslate">git@github.com:kunchenguid/firstmate.git</code>).</p>
</li>
<li>
<p dir="auto">Create a branch and make your changes.</p>
</li>
<li>
<p dir="auto">Initialize the gate with your fork as the push target: <code class="notranslate">no-mistakes init --fork-url git@github.com:&lt;you&gt;/firstmate.git</code> (contributing to firstmate requires <strong>no-mistakes v1.46.0+</strong> for structured attestation; without a fork, plain <code class="notranslate">no-mistakes init</code> still works for maintainers with push access).</p>
</li>
<li>
<p dir="auto">Commit your changes.</p>
</li>
<li>
<p dir="auto">Push through the gate instead of pushing to <code class="notranslate">origin</code>:</p>
<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">git push no-mistakes</pre></div>
</li>
<li>
<p dir="auto">Run <code class="notranslate">no-mistakes</code> to attach to the pipeline, watch findings, authorize auto-fixes, and review ask-user findings as needed.<br>
Follow the installed no-mistakes version's SKILL.md and live <code class="notranslate">axi</code> help for gate mechanics.</p>
</li>
<li>
<p dir="auto">Once the pipeline passes, it pushes the branch to your fork and opens the PR against the parent repo for you.</p>
</li>
</ol>
<p dir="auto">See the <a href="https://kunchenguid.github.io/no-mistakes/start-here/quick-start/" rel="nofollow">no-mistakes quick start</a> for the full first-run walkthrough.</p>
<h2 dir="auto">Repo conventions</h2>
<ul dir="auto">
<li>This repo is a template for running a firstmate orchestrator agent.<br>
<code class="notranslate">AGENTS.md</code> is the agent's main job description and names when to load bundled firstmate skills; <code class="notranslate">CLAUDE.md</code> is a real <code class="notranslate">@AGENTS.md</code> pointer to it, and <code class="notranslate">.claude/skills</code> is a symlink to <code class="notranslate">.agents/skills</code>.</li>
<li>Only shared material is tracked: <code class="notranslate">AGENTS.md</code>, <code class="notranslate">README.md</code>, <code class="notranslate">CONTRIBUTING.md</code>, <code class="notranslate">.tasks.toml</code>, <code class="notranslate">.github/workflows/</code>, <code class="notranslate">bin/</code>, <code class="notranslate">.agents/skills/</code>, and <code class="notranslate">skills/</code>.<br>
<code class="notranslate">.agents/skills/</code> holds agent-loaded skills that assume a live firstmate home and carry <code class="notranslate">metadata.internal: true</code> so installers such as <a href="https://skills.sh" rel="nofollow">skills.sh</a> hide them from discovery; <code class="notranslate">skills/</code> holds standalone, installer-facing public skills with no firstmate dependency (see the README's "Two-tier skill layout").<br>
Everything personal to one captain's fleet (<code class="notranslate">.env</code>, <code class="notranslate">data/</code>, <code class="notranslate">state/</code>, <code class="notranslate">config/</code>, <code class="notranslate">projects/</code>, <code class="notranslate">.no-mistakes/</code>) is gitignored; never commit it.<br>
The root <code class="notranslate">.tasks.toml</code> is tracked <code class="notranslate">tasks-axi</code> config for <code class="notranslate">data/backlog.md</code>; compatible <code class="notranslate">tasks-axi</code> is the default backend for routine backlog mutations, with the compatibility definition owned by <a href="docs/configuration.md"><code class="notranslate">docs/configuration.md</code></a> ("Backlog backend").<br>
A local <code class="notranslate">config/backlog-backend=manual</code> opt-out forces firstmate's routine backlog updates to hand-editing and stays gitignored; validated secondmate handoffs still delegate through <code class="notranslate">tasks-axi mv</code>.<br>
A local <code class="notranslate">config/backend</code> file explicitly overrides runtime auto-detection for new task endpoints and stays gitignored; spawn-supported values are <code class="notranslate">tmux</code> plus experimental <code class="notranslate">herdr</code>, <code class="notranslate">zellij</code>, <code class="notranslate">orca</code>, and <code class="notranslate">cmux</code>, while <code class="notranslate">codex-app</code> is documented only in <code class="notranslate">docs/codex-app-backend.md</code>.<br>
It does not make <code class="notranslate">data/</code> tracked.</li>
<li>Helper scripts in <code class="notranslate">bin/</code> are plain bash.<br>
Each starts with a usage header comment; keep it accurate when you change behavior.<br>
Test scripts and helpers in <code class="notranslate">tests/</code> are plain bash too.<br>
<code class="notranslate">bin/fm-lint.sh</code> must pass: it is the single owner of the lint definition (the shellcheck file set, config, pinned shellcheck version, and pinned actionlint workflow lint), and both CI and the no-mistakes pre-push gate run its no-argument full-analysis path.<br>
Its header and <code class="notranslate">--help</code> output own the exact local lint modes and flags.<br>
A malformed <code class="notranslate">.github/workflows/*.yml</code>, including a self-broken <code class="notranslate">ci.yml</code>, fails that local lint path before merge because a broken workflow cannot report its own breakage.<br>
It pins one exact shellcheck version and one exact actionlint version and refuses to run under any other.<br>
Print the shellcheck pin with <code class="notranslate">bin/fm-lint.sh --required-version</code> and the actionlint pin with <code class="notranslate">bin/fm-lint-workflows.sh --required-version</code>.<br>
Use <code class="notranslate">bin/fm-install-shellcheck.sh</code> and <code class="notranslate">bin/fm-install-actionlint.sh</code> to install those exact builds locally; each installer's head

... [268908 bytes truncated] ...

 the procedure.</p>
<h2 dir="auto">Project memory belongs to projects</h2>
<p dir="auto">Durable project-intrinsic agent knowledge lives in each project's committed <code class="notranslate">AGENTS.md</code>, with <code class="notranslate">CLAUDE.md</code> as a real <code class="notranslate">@AGENTS.md</code> import pointer.<br>
Ship briefs prompt crewmates to create or update those files through the normal delivery path; <code class="notranslate">data/projects.md</code> stays a thin private registry.<br>
Each project <code class="notranslate">AGENTS.md</code> carries a short <code class="notranslate">## Maintaining this file</code> self-governance section; <code class="notranslate">bin/fm-ensure-agents-md.sh</code> owns the canonical wording and injects it idempotently when creating the skeleton, promoting an existing <code class="notranslate">CLAUDE.md</code>, or reconciling an existing <code class="notranslate">AGENTS.md</code> that still lacks it.<br>
It refuses a case-variant real memory file such as a lowercase <code class="notranslate">agents.md</code>, so the pointer's <code class="notranslate">@AGENTS.md</code> import resolves to a real <code class="notranslate">AGENTS.md</code> on a case-sensitive filesystem, and surfaces the mismatch for manual reconciliation.<br>
The full ownership rule - what is project-intrinsic versus fleet-private, and how firstmate keeps the two apart without writing into project clones - is owned by <a href="../AGENTS.md"><code class="notranslate">AGENTS.md</code></a> (project and knowledge management).</p>
<h2 dir="auto">Operational memory routing</h2>
<p dir="auto"><code class="notranslate">/stow</code> sweeps the current session for durable knowledge that only exists in conversation and routes each finding to the most specific disk home.<br>
Home-domain captain preferences go to <code class="notranslate">data/captain.md</code>, cross-domain shared captain preferences go to the primary home's <code class="notranslate">data/captain-shared.md</code>, fleet-local operational facts and gotchas go to home-local <code class="notranslate">data/learnings.md</code>, project-intrinsic knowledge goes through normal crewmate delivery into that project's committed <code class="notranslate">AGENTS.md</code>, and task-scoped notes or undone next steps go to the backlog.<br>
Memory writes use inspect-then-update rather than blind append; the internal <a href="../.agents/skills/stow/SKILL.md"><code class="notranslate">stow</code> skill</a> owns tier markers, decay, cold archival, and offload.<br>
The same pass also persists open-work record state the session is holding - filing a thread that was never recorded and correcting one the session knows went stale - bounded to the open work that session is actually holding.<br>
It is deliberately not a reconciliation of durable records against repository or PR reality: its input is the volatile context, so it can only preserve what the session still knows, and no reconciliation that outlives a session exists today.<br>
Task-scoped notes use <code class="notranslate">tasks-axi show &lt;id&gt; --full</code> followed by <code class="notranslate">tasks-axi update &lt;id&gt; --body-file &lt;path&gt;</code>, adding <code class="notranslate">--archive-body</code> when the prior body should remain recoverable.<br>
The stow pass never writes a skill, but a separately executed, captain-approved migration may move conditional knowledge into a user-owned local skill excluded from the Firstmate clone; changes to Firstmate's tracked skills remain deliberate repository work through the normal PR pipeline.<br>
Invoked in a primary home, <code class="notranslate">/stow</code> then cascades the same sweep to every registered secondmate, enumerated through <code class="notranslate">bin/fm-stow-cascade.sh</code>: each home is accounted and curated against its own startup-memory allowance, a live secondmate sweeps its own session, and a slow or unreachable home is reported as an exception rather than blocking the primary.</p>
<h2 dir="auto">Local clones stay fresh</h2>
<p dir="auto">The locked session-start deferred network stage, PR-based teardown, and merged-PR wake handling refresh remote-backed project clones when the clone is safe to move.<br>
Wake-time refreshes can target a single clone by project name, so the primary home also catches up when a secondmate reports a merge from its own home.<br>
Clean default-branch clones fast-forward to <code class="notranslate">origin/&lt;default&gt;</code>, and a clean detached HEAD that holds no unique commits is re-attached to the default branch before the same fast-forward path runs.<br>
Dirty clones, non-default branches, detached HEADs with unique commits, diverged defaults, and default branches checked out in another worktree are reported as <code class="notranslate">STUCK:</code> with their behind count and left untouched.<br>
Fetches blocked by an orphaned <code class="notranslate">.git/packed-refs.lock</code> use bounded retries and remove the lock only when the shared staleness proof can prove it abandoned; <a href="configuration.md#toolchain">configuration.md</a> owns the recovery details and tuning knobs.<br>
Local-only projects, clones without an origin remote, and fetch failures remain benign skips.<br>
The refresh also prunes local branches whose remote is gone and that no worktree still needs.</p>
<h2 dir="auto">Self-updates stay safe</h2>
<p dir="auto"><code class="notranslate">/updatefirstmate</code> fast-forwards the running firstmate repo and registered secondmate homes from <code class="notranslate">origin</code>, then re-reads updated instructions and nudges updated secondmates without touching project clones.<br>
For a remote route, the configured code root updates from its own origin on that host before the persistent home fast-forwards to the code-root commit.<br>
The update is fast-forward only: dirty, diverged, offline, and off-default targets are reported and left untouched.<br>
Local homes share the guarded fast-forward helper, while remote updates delegate the same safety decision to the configured host through the generic transport.<br>
The mechanics are owned by the <code class="notranslate">/updatefirstmate</code> skill and firstmate's operating manual in <a href="../AGENTS.md"><code class="notranslate">AGENTS.md</code></a> (self-update).</p>
<h2 dir="auto">Restart-proof</h2>
<p dir="auto">Fleet state lives in each task's session-provider backend (tmux by hard default, herdr or cmux when selected or auto-detected, zellij/orca when explicitly selected), no-mistakes run records, status event logs, local markdown under <code class="notranslate">data/</code> including <code class="notranslate">data/captain.md</code>, <code class="notranslate">data/captain-shared.md</code>, and <code class="notranslate">data/learnings.md</code>, and persistent secondmate homes.<br>
For herdr, respawning after a server-restored layout closes and replaces confirmed no-agent or dead task-tab husks instead of requiring manual tab cleanup.<br>
At session start, confirmed-dead secondmate agent endpoints are closed and relaunched through the same secondmate spawn path, while ambiguous liveness reads are left untouched to avoid duplicate supervisors.<br>
Use <code class="notranslate">/stow</code> before an intentional reset when the conversation may hold durable knowledge that has not yet been written to disk; after that, the next firstmate session can reconcile and carry on.</p>
<h2 dir="auto">Development notes</h2>
<p dir="auto">The current watcher reliability work combines always-on bash triage with a durable queue for actionable wakes, generation-bound post-handling acknowledgement, deterministic re-arm recovery after watcher downtime, a race-proof singleton lock, duplicate self-eviction, drain-time liveness assertion, and a self-verifying tracked-child arm wrapper.<br>
The presence-gated sub-supervisor (<code class="notranslate">bin/fm-supervise-daemon.sh</code>) provides walk-away supervision via the <code class="notranslate">/afk</code> skill while reusing the same shared wake classifier as the always-on watcher.</p></section></body></html>
```
</details>

- Evidence: [Pull request 3585](https://github.com/kunchenguid/firstmate/pull/3585)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"bcc3d0b2764ab0ac1a9bbe7793465e6a11bc7b59","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `docs/configuration.md:204` - The intent requires the documentation to state publication &#34;must be restored deliberately when that fix lands,&#34; but this says only that restoration is &#34;expected&#34;; CONTRIBUTING.md:72 and docs/architecture.md:290 use the same weaker wording. Use mandatory wording in all three unless the captain authorizes weakening the requirement.
- ⚠️ `CONTRIBUTING.md:73` - The leading &#34;When enabled&#34; grammatically conditions both clauses, implying the lint command is pinned only when evidence publication is enabled. In the current concrete configuration, store_in_repo is false while commands.lint remains pinned independently. Split the lint statement into an unconditional sentence.

🔧 Fix: Clarify lint pin independently of evidence publication
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 353a8f0ff25d4f7f8404ded6ec5a84eab43158d3..bcc3d0b2764ab0ac1a9bbe7793465e6a11bc7b59` — manually reviewed the configuration and documentation changes against the accepted intent.</code>
- <code>Inline `python3`/PyYAML harness — parsed `.no-mistakes.yaml`, asserted `store_in_repo` is boolean `false`, and confirmed the independent lint command remains pinned.</code>
- <code>`git ls-remote --heads origin no-mistakes/evidence` — checked before, after, and at phase completion; the existing branch remained at `3a084891737c4187504ae142592b295166e7c9f3`.</code>
- <code>`gh pr view 3585 --repo kunchenguid/firstmate --json number,state,isDraft,mergedAt,url,headRefName` — confirmed PR 3585 is open and unmerged.</code>
- <code>`gh api markdown --method POST --input -` — rendered all three changed Markdown documents through GitHub GFM and verified the rendered publication-pause, restoration, orphan-branch, and independent lint-pin statements.</code>
- <code>`no-mistakes axi status --run 01M1JH4GXRDEF11JKYG9Q10GKM` — confirmed the active run targets commit `bcc3d0b2` without controlling the pipeline.</code>
- <code>The initial evidence harness used a GitHub lookup for the not-yet-pushed target commit and received HTTP 404; it was corrected to use local `git show` metadata and passed.</code>
- <code>`git status --short` — confirmed testing left no transient worktree changes.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
