### PR TITLE
fix(bin): classify progress updates on requested work as routine

### DIFF
--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -902,7 +902,7 @@ export default function (pi: ExtensionAPI) {
         task: Type.String({ description: "The task id the event belongs to (or 'fleet' for fleet-wide events)" }),
         verdict: Type.Union([Type.Literal("routine"), Type.Literal("captain")], {
           description:
-            "Use captain unconditionally for an outcome that directly answers an explicit captain request, regardless of whether it is healthy, routine, measured, actionable, or requires a decision. Also use captain for work ready for review, captain-only decisions, blockers or failures after recovery is exhausted, needed credentials, and destructive, irreversible, or security-sensitive actions; use routine otherwise.",
+            "Use captain or routine exactly as the \"Verdict: routine or captain\" section of your system prompt decides; that section is the one owner of the rule.",
         }),
         summary: Type.String({
           description:

--- a/bin/fm-branch-prompt.sh
+++ b/bin/fm-branch-prompt.sh
@@ -63,8 +63,8 @@ For anything it tells you to escalate, or any failure that survives the playbook
 
 # Verdict: routine or captain
 
-Report verdict captain for any outcome that directly answers an explicit captain request.
-This rule is unconditional: do not qualify it by whether the result is healthy, routine, measured, actionable, or requires a decision.
+Report verdict captain for the finished result of work the captain requested, even when that result is healthy.
+A start or still-working update on requested work that brings no new artifact, finding, or decision is verdict routine.
 Also report verdict captain for:
 - work ready for review - always include the full https:// PR URL in the summary;
 - a decision only the captain can make, including every ask-user finding from a validation gate;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ The branch's role stays bounded exactly as the captain-approved architecture set
 Homes on any other primary harness never load this feature and are entirely unaffected.
 `AGENTS.md`'s `state/` inventory routes the branch's runtime files to their format and lifecycle owners.
 A captain-facing (verdict `captain`) branch outcome persists as one exact, sequence-keyed visible transcript entry and then opens one sequence-keyed processing turn on main, which stays open until main acknowledges that sequence through its `fm_branch_processed` tool.
-The branch prompt owns the unconditional explicit-request rule and the distinction between captain-facing, unsolicited routine, and unchanged-review outcomes.
+The branch prompt's "Verdict: routine or captain" section owns the distinction between captain-facing, unsolicited routine, and unchanged-review outcomes.
 The generated [Pi supervision protocol](supervision-protocols/pi.md) owns main's event ownership, acknowledgement duty, and conversational treatment for merged outcomes, while the persisted entry itself owns captain visibility.
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is delivered silently with no rendered note, while every other routine outcome still appends a rendered, sailboat-prefixed note.
 

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -88,7 +88,7 @@ Routine outcomes never enter this path and stay turn-free.
 A home upgraded with outcomes already delivered treats those rows as processed once, at the first reconciliation that finds no processed marker, so its history is not re-presented.
 The generated [Pi supervision protocol](supervision-protocols/pi.md) owns event ownership for merged outcomes and main's acknowledgement duty, while deterministic entry delivery owns captain visibility.
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is also delivered silently with no rendered note, while every other `routine` outcome stays rendered with its sailboat prefix.
-The branch prompt owns the verdict criteria, including its unconditional explicit-request rule; unsolicited routine outcomes remain routine sailboat notes, unchanged fleet reviews remain silent, and doubt escalates.
+The branch prompt's "Verdict: routine or captain" section owns the verdict criteria, including how requested work's finished results and its mere progress updates are classified; unsolicited routine outcomes remain routine sailboat notes, unchanged fleet reviews remain silent, and doubt escalates.
 Main can read the durable outcome store on demand through its `fm_branch_outcomes` tool.
 
 ## Heartbeat routing

--- a/tests/fm-branch-supervision.test.sh
+++ b/tests/fm-branch-supervision.test.sh
@@ -50,8 +50,8 @@ test_branch_prompt_is_byte_stable_and_above_cache_floor() {
     *) fail "branch prompt lost the inlined recovery playbook" ;;
   esac
   case "$out_a" in
-    *"Report verdict captain for any outcome that directly answers an explicit captain request."*"This rule is unconditional"*"Keep an unsolicited routine outcome as verdict routine"*"Keep an unchanged fleet review silent"*) ;;
-    *) fail "branch prompt lost the unconditional requested-outcome or routine-silence rules" ;;
+    *"Report verdict captain for the finished result of work the captain requested, even when that result is healthy."*"A start or still-working update on requested work that brings no new artifact, finding, or decision is verdict routine."*"Keep an unsolicited routine outcome as verdict routine"*"Keep an unchanged fleet review silent"*) ;;
+    *) fail "branch prompt lost the requested-result, progress-routine, or routine-silence rules" ;;
   esac
   pass "branch prompt is byte-stable across homes, cwd, timezone, and time, above the cache floor"
 }

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -938,9 +938,9 @@ globalThis.__fmOnBranchPrompt = async ({ session }) => {
   if (!ack) throw new Error(`drain did not return its acknowledgement command: ${drained.stderr}`);
   const report = session.options.customTools.find((tool) => tool.name === "fm_branch_report");
   const verdictDescription = report.parameters.properties.verdict.description;
-  if (!verdictDescription.includes("unconditionally") ||
-      !verdictDescription.includes("directly answers an explicit captain request") ||
-      !verdictDescription.includes("regardless of whether it is healthy, routine, measured, actionable, or requires a decision")) {
+  if (!verdictDescription.includes("Verdict: routine or captain") ||
+      !verdictDescription.includes("one owner of the rule") ||
+      verdictDescription.includes("unconditionally")) {
     throw new Error(`branch provider received conflicting verdict semantics: ${verdictDescription}`);
   }
   const result = await report.execute(


### PR DESCRIPTION
## Summary

The supervision branch's verdict rule escalated every outcome that answered a captain request, so "the work started" and "still working" notes reached the captain with nothing to look at.

This PR tightens the owner of that rule, the "Verdict: routine or captain" section of `bin/fm-branch-prompt.sh`:

- a finished result of requested work stays captain-facing, even when healthy;
- a start or still-working update on requested work that brings no new artifact, finding, or decision is routine;
- the existing captain list (review-ready PRs with the full https URL, ask-user findings, exhausted blockers, credentials, destructive/irreversible/security-sensitive cases), the unsolicited-routine rule, silent unchanged fleet reviews, doubt-chooses-captain, and captain-outcome language are unchanged.

The `fm_branch_report` tool description in `.pi/extensions/fm-branch-supervision.ts`, `docs/pi-supervision-branch.md`, and `docs/configuration.md` restated the old unconditional rule; each now points at the prompt section as the one owner instead of carrying a second copy.

No supervision architecture, tools, or wake routing changed.

## Verification

- `bin/fm-lint.sh`: clean.
- `bin/fm-doc-audience-check.sh`: ok.
- `tests/fm-branch-supervision.test.sh`: all pass.
- `tests/fm-pi-branch-extension.test.sh`: 33 of 34 subtests pass. The first subtest, "Pi outcomes rendering consumers must preserve stock behavior", fails identically on the base commit with the locally installed Pi 0.84.3 ("Calm-off ToolExecutionComponent rendering differs from Pi stock") and is unrelated to this change; the remaining subtests, including the requested-vs-unsolicited outcome delivery test, were run with that subtest skipped locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDcZFAWpJ9kriWEjv2E6Ny
