### PR TITLE
fix(bin): relaunch Herdr tasks after worker exits

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -3048,52 +3048,46 @@ fm_backend_herdr_agent_status_raw() {  # <session> <pane_id>
 # fm_backend_herdr_classify_agent_status for the status->busy/idle/unknown
 # mapping.
 #
-# A `busy` verdict is corroborated against the pane's own process inventory
-# through fm_backend_herdr_pane_idle_shell_sample, the SAME proof
-# fm_backend_herdr_pane_agent_state uses, so neither verdict can ever downgrade
-# a pane on a rule the other does not apply. Only a REPORTED-BUSY state needs
-# that corroboration, because `busy` is the only native verdict that can wedge a
-# pane: bin/fm-busy-lib.sh's record-free fallthrough and
-# bin/fm-supervise-daemon.sh's pane_is_busy both act on `busy` alone and treat a
-# native `idle` as no evidence at all, falling back to their own. So the two
-# verdicts do still differ for a stale registration last reported idle - that
-# pane reads `dead` from the classifier and `idle` here - which is deliberate:
-# corroborating the idle branch would pay an inventory read on every poll of
-# every healthy pane (a live Claude reports idle through a whole turn) to change
-# an answer nothing is wedged by. The registry is written by
-# whatever reports into it and a report is not withdrawn when the process that
-# made it goes away, so a harness killed mid-turn leaves `agent get` answering
-# `working` forever. Nothing else clears that: bin/fm-busy-lib.sh's record-free
-# fallthrough would print `busy herdr-native` on every poll and suppress watcher
-# stale-pane escalation, and bin/fm-supervise-daemon.sh's pane_is_busy would
-# defer away-mode injection forever - the same "no state that could ever clear
-# it" failure the liveness classifier fixes, in the watcher lane.
+# EVERY reported agent state, `busy` and `idle` alike, is corroborated against
+# the pane's own process inventory through fm_backend_herdr_pane_idle_shell_sample,
+# the SAME proof fm_backend_herdr_pane_agent_state uses, so the two verdicts
+# always agree about what the pane is. The registry is written by whatever
+# reports into it and a report is not withdrawn when the process that made it
+# goes away, so a harness that dies mid-turn leaves `agent get` answering its
+# last report forever, and nothing else ever clears that.
+#
+# Both reported states are acted on positively by a consumer, which is why
+# neither can be trusted alone. A stale `working` makes bin/fm-busy-lib.sh's
+# record-free fallthrough print `busy herdr-native` on every poll and suppress
+# watcher stale-pane escalation, and makes bin/fm-supervise-daemon.sh's
+# pane_is_busy defer away-mode injection forever. A stale `idle` is taken by
+# fm_pending_reply_backend_observation (bin/fm-pending-reply-lib.sh), which
+# short-circuits on it without consulting anything else and stamps a secondmate
+# turn completed for an endpoint whose harness is gone.
 #
 # The corroboration is positive-only and identical in shape to the classifier's:
-# only a pane that positively proves a lone bare idle shell loses `busy`, while
-# a live process, an extra foreground process, a shell with a child, an
+# only a pane that positively proves a lone bare idle shell loses its verdict,
+# while a live process, an extra foreground process, a shell with a child, an
 # unreadable inventory, and an inventory answering about a different pane all
 # leave the verdict exactly as before.
 #
-# It resolves to `unknown`, never `idle`: a pane with no agent has no native
-# agent state at all, and `unknown` is every consumer's documented cue to fall
-# back to its own evidence, so no caller gains a fabricated positive idle (a
-# secondmate delivery confirmation in bin/fm-pending-reply-lib.sh would read
-# one as a completed turn).
+# A proved-agent-free pane resolves to `unknown`, never to `idle`: a pane with
+# no agent has no native agent state at all, and `unknown` is every consumer's
+# documented cue to fall back to its own evidence, so no caller gains a
+# fabricated positive from a registration that outlived its agent.
 #
-# The inventory read is taken ONLY on the `busy` branch, where it can change
-# the answer. `idle` and `unknown` verdicts pay nothing, and the submit
-# confirmation loop does not come through here at all: it polls
+# An already-`unknown` verdict skips the inventory read, which cannot change it.
+# The submit-confirmation loop does not come through here at all: it polls
 # fm_backend_herdr_agent_status_raw directly (fm_backend_herdr_wait_for_working,
 # fm_backend_herdr_send_text_submit, fm_backend_herdr_queued_enter_busy), so no
-# tight loop pays for this. Measured cost on the busy branch:
+# tight loop pays for this. Measured cost:
 # docs/verification/runtime-backends.md "Native busy-state corroboration cost".
 fm_backend_herdr_busy_state() {  # <target>
   local verdict
   fm_backend_herdr_target_ready "$1" || { printf 'unknown'; return 0; }
   verdict=$(fm_backend_herdr_classify_agent_status \
     "$(fm_backend_herdr_agent_status_raw "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")")
-  if [ "$verdict" = busy ] && fm_backend_herdr_pane_idle_shell_sample \
+  if [ "$verdict" != unknown ] && fm_backend_herdr_pane_idle_shell_sample \
     "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE" >/dev/null 2>&1; then
     printf 'unknown'
     return 0

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1206,10 +1206,11 @@ fm_backend_herdr_pane_idle_shell_pid() {  # <session> <pane-id>
 # observation of the idle-shell shape.
 # fm_backend_herdr_pane_idle_shell_pid wraps it with the settle retry and owns
 # the proof contract for the destructive close paths.
-# fm_backend_herdr_pane_agent_state instead takes a single sample directly, on
-# purpose: that read runs in poll loops, the retry budget would slow every
-# healthy `live` answer, and its corroboration is positive-only, so a sample
-# lost to a transient prompt helper simply keeps `live` until the next poll.
+# fm_backend_herdr_pane_agent_state and fm_backend_herdr_busy_state instead
+# take a single sample directly, on purpose: both reads run in poll loops, the
+# retry budget would slow every healthy answer, and their corroboration is
+# positive-only, so a sample lost to a transient prompt helper simply keeps the
+# uncorroborated verdict until the next poll.
 fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
   local session=$1 pane=$2 info shell_pid foreground_pgid count
   local process_pid name argv0 shell_name rows stat ps_bin
@@ -3046,10 +3047,49 @@ fm_backend_herdr_agent_status_raw() {  # <session> <pane_id>
 # gets real semantics" per the design report. See
 # fm_backend_herdr_classify_agent_status for the status->busy/idle/unknown
 # mapping.
+#
+# A `busy` verdict is corroborated against the pane's own process inventory
+# through fm_backend_herdr_pane_idle_shell_sample - the SAME proof
+# fm_backend_herdr_pane_agent_state uses, so the liveness verdict and the busy
+# verdict can never disagree about what the pane is. The registry is written by
+# whatever reports into it and a report is not withdrawn when the process that
+# made it goes away, so a harness killed mid-turn leaves `agent get` answering
+# `working` forever. Nothing else clears that: bin/fm-busy-lib.sh's record-free
+# fallthrough would print `busy herdr-native` on every poll and suppress watcher
+# stale-pane escalation, and bin/fm-supervise-daemon.sh's pane_is_busy would
+# defer away-mode injection forever - the same "no state that could ever clear
+# it" failure the liveness classifier fixes, in the watcher lane.
+#
+# The corroboration is positive-only and identical in shape to the classifier's:
+# only a pane that positively proves a lone bare idle shell loses `busy`, while
+# a live process, an extra foreground process, a shell with a child, an
+# unreadable inventory, and an inventory answering about a different pane all
+# leave the verdict exactly as before.
+#
+# It resolves to `unknown`, never `idle`: a pane with no agent has no native
+# agent state at all, and `unknown` is every consumer's documented cue to fall
+# back to its own evidence, so no caller gains a fabricated positive idle (a
+# secondmate delivery confirmation in bin/fm-pending-reply-lib.sh would read
+# one as a completed turn).
+#
+# The inventory read is taken ONLY on the `busy` branch, where it can change
+# the answer. `idle` and `unknown` verdicts pay nothing, and the submit
+# confirmation loop does not come through here at all: it polls
+# fm_backend_herdr_agent_status_raw directly (fm_backend_herdr_wait_for_working,
+# fm_backend_herdr_send_text_submit, fm_backend_herdr_queued_enter_busy), so no
+# tight loop pays for this. Measured cost on the busy branch:
+# docs/verification/runtime-backends.md "Native busy-state corroboration cost".
 fm_backend_herdr_busy_state() {  # <target>
+  local verdict
   fm_backend_herdr_target_ready "$1" || { printf 'unknown'; return 0; }
-  fm_backend_herdr_classify_agent_status \
-    "$(fm_backend_herdr_agent_status_raw "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")"
+  verdict=$(fm_backend_herdr_classify_agent_status \
+    "$(fm_backend_herdr_agent_status_raw "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")")
+  if [ "$verdict" = busy ] && fm_backend_herdr_pane_idle_shell_sample \
+    "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE" >/dev/null 2>&1; then
+    printf 'unknown'
+    return 0
+  fi
+  printf '%s' "$verdict"
 }
 
 # fm_backend_herdr_wait_for_working: poll <session>:<pane_id>'s NATIVE

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1203,8 +1203,13 @@ fm_backend_herdr_pane_idle_shell_pid() {  # <session> <pane-id>
 }
 
 # fm_backend_herdr_pane_idle_shell_sample: one strict instantaneous
-# observation for fm_backend_herdr_pane_idle_shell_pid, which owns the proof
-# contract and the settle retry.
+# observation of the idle-shell shape.
+# fm_backend_herdr_pane_idle_shell_pid wraps it with the settle retry and owns
+# the proof contract for the destructive close paths.
+# fm_backend_herdr_pane_agent_state instead takes a single sample directly, on
+# purpose: that read runs in poll loops, the retry budget would slow every
+# healthy `live` answer, and its corroboration is positive-only, so a sample
+# lost to a transient prompt helper simply keeps `live` until the next poll.
 fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
   local session=$1 pane=$2 info shell_pid foreground_pgid count
   local process_pid name argv0 shell_name rows stat ps_bin
@@ -1874,25 +1879,55 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 #              reaped it - verified empirically: killing a pane's shell pid
 #              on a live server makes herdr immediately drop both the pane
 #              and its tab from `pane get`/`tab list`).
-#   no-agent - `pane get` succeeds (the pane structurally exists) but `agent
-#              get` responds with error code agent_not_found: nothing is
-#              registered in it - exactly what a herdr session-layout restore
-#              produces (verified empirically: `session stop` + fresh `herdr
-#              server` restart leaves the pane alive, agent_status "unknown",
-#              agent get -> agent_not_found - docs/herdr-backend.md "ID
-#              stability across a server restart"), and what a future
-#              `resume_agents_on_restore = false` restore would produce too
-#              (a plain shell, never an agent).
-#   live     - `agent get` succeeds and reports a real agent_status (working,
-#              idle, done, or blocked - any registered value). An idle or
-#              blocked agent is still a genuine, still-registered agent, not
-#              a restored husk, so it is never a close-and-replace candidate.
+#   no-agent - the pane structurally exists but confidently hosts no agent.
+#              Two independent positive grounds reach this verdict:
+#              (a) `agent get` responds with error code agent_not_found:
+#              nothing is registered in it - exactly what a herdr
+#              session-layout restore produces (verified empirically:
+#              `session stop` + fresh `herdr server` restart leaves the pane
+#              alive, agent_status "unknown", agent get -> agent_not_found -
+#              docs/herdr-backend.md "ID stability across a server restart"),
+#              and what a future `resume_agents_on_restore = false` restore
+#              would produce too (a plain shell, never an agent);
+#              (b) a registration IS reported, but the pane's own process
+#              inventory positively proves a lone bare idle shell, so the
+#              registration outlived the process it describes.
+#   live     - `agent get` reports a real agent_status (working, idle, done,
+#              or blocked - any registered value) and the pane's process
+#              inventory does not contradict it. An idle or blocked agent is
+#              still a genuine, still-registered agent, not a restored husk,
+#              so it is never a close-and-replace candidate.
 #   unknown  - anything else: an unparseable/unexpected response from either
 #              call, or a `pane get` success whose own echoed pane_id does not
 #              round-trip (guards against misreading a herdr response shape
 #              change as "the pane exists"). The caller must fail safe toward
 #              refusal here, never toward closing - this is the conservative
 #              backstop the husk check depends on.
+#
+# Why a reported registration is corroborated at all. Herdr's agent registry
+# is written by whatever reports into it - each harness's herdr integration
+# extension, or any other source - and a report is not withdrawn when the
+# process that made it goes away. Verified empirically on herdr 0.8.2: a
+# `pane report-agent` from a source herdr does not itself own stays registered
+# on a pane running nothing but its shell, so `agent get` keeps answering
+# `idle` with no agent alive anywhere. Trusting that alone made a task whose
+# worker had already exited to its shell read `alive` forever: every lifecycle
+# verb then typed the harness's exit command into a shell and refused to
+# relaunch, with no state that could ever clear it. The tmux classifier never
+# had this hole because it reads the foreground process group and lets a
+# group that is nothing but shells settle the negative verdict; this is the
+# same rule expressed through herdr's own `pane process-info` inventory.
+#
+# The corroboration is positive-only and one strict instantaneous sample, so
+# it is the cheapest possible addition to a read that runs in poll loops and
+# can only ever move a verdict from `live` toward `no-agent`, never the other
+# way. Anything short of proof - a live harness process in the foreground, an
+# extra foreground process, a shell with a child, an unreadable inventory, or
+# a response about a different pane - leaves `live` exactly as before, so a
+# genuinely live, ambiguous, unreadable, or contradicting endpoint is never
+# reclassified as recoverable. An idle shell transiently hosting a prompt
+# helper therefore keeps `live` for that sample; every caller that acts on the
+# negative verdict polls, so the next sample settles it.
 fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   local session=$1 pane_id=$2 out code presence status
   presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane_id")
@@ -1911,7 +1946,13 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   fi
   status=$(printf '%s' "$out" | jq -r '.result.agent.agent_status // empty' 2>/dev/null)
   case "$status" in
-    working|idle|done|blocked) printf 'live' ;;
+    working|idle|done|blocked)
+      if fm_backend_herdr_pane_idle_shell_sample "$session" "$pane_id" >/dev/null 2>&1; then
+        printf 'no-agent'
+      else
+        printf 'live'
+      fi
+      ;;
     *) printf 'unknown' ;;
   esac
 }
@@ -1920,7 +1961,9 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
 # states (dead, no-agent) fm_backend_herdr_pane_agent_state can positively
 # confirm; live and unknown both refuse (1), so an inconclusive read never
 # licenses closing anything. Restored-layout recovery depends on this
-# fail-safe-toward-refusal behavior.
+# fail-safe-toward-refusal behavior. A husk is defined by what the pane IS -
+# gone, or a plain shell - so a pane whose registration outlived its agent is
+# a husk on the same terms as a restored one; the classifier owns that proof.
 fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
   case "$(fm_backend_herdr_pane_agent_state "$1" "$2")" in
     dead|no-agent) return 0 ;;
@@ -1931,8 +1974,10 @@ fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
 # fm_backend_herdr_agent_state: recovery-grade state for the same session-start
 # sweep as the tmux classifier. It reuses the husk classifier rather than
 # creating a second Herdr state machine: a structurally gone pane is `missing`,
-# a confirmed agent-less pane is `dead`, a registered agent is `alive`, and an
-# unexpected or failed API read is `unreadable`.
+# a confirmed agent-less pane is `dead` - including one whose reported
+# registration its own process inventory proves stale - a registered agent
+# that inventory does not contradict is `alive`, and an unexpected or failed
+# API read is `unreadable`.
 fm_backend_herdr_agent_state() {  # <target>
   local target=$1
   fm_backend_herdr_parse_target "$target" || { printf 'unreadable'; return 0; }

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -3049,9 +3049,18 @@ fm_backend_herdr_agent_status_raw() {  # <session> <pane_id>
 # mapping.
 #
 # A `busy` verdict is corroborated against the pane's own process inventory
-# through fm_backend_herdr_pane_idle_shell_sample - the SAME proof
-# fm_backend_herdr_pane_agent_state uses, so the liveness verdict and the busy
-# verdict can never disagree about what the pane is. The registry is written by
+# through fm_backend_herdr_pane_idle_shell_sample, the SAME proof
+# fm_backend_herdr_pane_agent_state uses, so neither verdict can ever downgrade
+# a pane on a rule the other does not apply. Only a REPORTED-BUSY state needs
+# that corroboration, because `busy` is the only native verdict that can wedge a
+# pane: bin/fm-busy-lib.sh's record-free fallthrough and
+# bin/fm-supervise-daemon.sh's pane_is_busy both act on `busy` alone and treat a
+# native `idle` as no evidence at all, falling back to their own. So the two
+# verdicts do still differ for a stale registration last reported idle - that
+# pane reads `dead` from the classifier and `idle` here - which is deliberate:
+# corroborating the idle branch would pay an inventory read on every poll of
+# every healthy pane (a live Claude reports idle through a whole turn) to change
+# an answer nothing is wedged by. The registry is written by
 # whatever reports into it and a report is not withdrawn when the process that
 # made it goes away, so a harness killed mid-turn leaves `agent get` answering
 # `working` forever. Nothing else clears that: bin/fm-busy-lib.sh's record-free

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -3060,10 +3060,10 @@ fm_backend_herdr_agent_status_raw() {  # <session> <pane_id>
 # neither can be trusted alone. A stale `working` makes bin/fm-busy-lib.sh's
 # record-free fallthrough print `busy herdr-native` on every poll and suppress
 # watcher stale-pane escalation, and makes bin/fm-supervise-daemon.sh's
-# pane_is_busy defer away-mode injection forever. A stale `idle` is taken by
-# fm_pending_reply_backend_observation (bin/fm-pending-reply-lib.sh), which
-# short-circuits on it without consulting anything else and stamps a secondmate
-# turn completed for an endpoint whose harness is gone.
+# pane_is_busy defer away-mode injection forever. A stale `idle` is taken
+# directly by fm_pending_reply_backend_observation
+# (bin/fm-pending-reply-lib.sh), which short-circuits on it without consulting
+# anything else.
 #
 # The corroboration is positive-only and identical in shape to the classifier's:
 # only a pane that positively proves a lone bare idle shell loses its verdict,
@@ -3071,10 +3071,21 @@ fm_backend_herdr_agent_status_raw() {  # <session> <pane_id>
 # unreadable inventory, and an inventory answering about a different pane all
 # leave the verdict exactly as before.
 #
-# A proved-agent-free pane resolves to `unknown`, never to `idle`: a pane with
-# no agent has no native agent state at all, and `unknown` is every consumer's
-# documented cue to fall back to its own evidence, so no caller gains a
-# fabricated positive from a registration that outlived its agent.
+# A proved-agent-free pane resolves to `unknown`, never to `busy` or `idle`: a
+# pane with no agent has no native agent state at all. What that buys is not
+# the same for every consumer, and the difference is worth stating exactly:
+#   - bin/fm-busy-lib.sh and bin/fm-supervise-daemon.sh act on `busy` alone, so
+#     `unknown` ends the wedge outright. The pane surfaces for stale-pane
+#     escalation instead of being suppressed, and away-mode injection stops
+#     deferring.
+#   - bin/fm-pending-reply-lib.sh is re-routed, not stopped. Losing the native
+#     short-circuit sends its observation to the rendered capture, where a dead
+#     pane matches no busy signature and yields `fallback-idle`; that becomes
+#     `idle` at once when the turn was already observed busy, and only after
+#     the grace window when it never was. So a secondmate delivery confirmation
+#     can still reach a completed turn, later and on independent evidence
+#     rather than instantly on a fabricated native positive. Closing that
+#     residual belongs to the observation contract in that file, not here.
 #
 # An already-`unknown` verdict skips the inventory read, which cannot change it.
 # The submit-confirmation loop does not come through here at all: it polls

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -268,6 +268,7 @@ family_for_basename() {
     fm-grok-stop-live-e2e.test.sh|fm-harness-adapter-instructions-live-e2e.test.sh|\
     fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-muse-signals-live-e2e.test.sh|\
+    fm-herdr-agent-free-proof-live-e2e.test.sh|\
     fm-herdr-version-floor-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-branch-live-e2e.test.sh|\
     fm-pi-primary-live-e2e.test.sh|\

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -241,9 +241,12 @@ A human-blocked permission dialog has no busy banner and still surfaces.
 
 Every reported agent state, `busy` and `idle` alike, is corroborated against the pane's own process inventory, through the same idle-shell proof the liveness classifier uses, so the two verdicts always agree about what the pane is.
 A registration is not withdrawn when the process that made it goes away, so a harness that dies mid-turn keeps reporting its last state forever, with nothing that could ever clear it.
-Both reported states are acted on positively by a consumer, which is why neither is trusted alone: a stale `working` suppresses this task's stale-pane escalation and defers away-mode injection indefinitely, and a stale `idle` is read as a completed turn when a secondmate delivery is confirmed.
+Both reported states are acted on positively by a consumer, which is why neither is trusted alone: a stale `working` suppresses this task's stale-pane escalation and defers away-mode injection indefinitely, and a stale `idle` is taken directly as evidence when a secondmate delivery is confirmed.
 The corroboration is positive-only: a live process, an extra foreground process, a shell with a child, an unreadable inventory, and an inventory answering about a different pane all leave the reported verdict standing.
-A pane the inventory positively proves to be a lone bare idle shell reads `unknown` rather than `busy` or `idle`, because a pane with no agent has no native agent state at all, and `unknown` is every consumer's cue to fall back to its own evidence.
+A pane the inventory positively proves to be a lone bare idle shell reads `unknown` rather than `busy` or `idle`, because a pane with no agent has no native agent state at all.
+For the watcher and the away-mode daemon that ends the problem, since both act on `busy` alone: the pane surfaces for stale-pane escalation instead of being suppressed, and injection stops deferring.
+For the secondmate delivery confirmation it narrows and delays the outcome rather than eliminating it: `unknown` costs that path its native short-circuit and sends it to independent rendered evidence, where a dead pane still reaches idle, at once if the turn was already observed busy and after the grace window if it was not.
+Closing that residual belongs to the pending-reply observation contract, not to this adapter.
 The submit-confirmation path never reads busy state at all, so no tight loop pays for the corroboration.
 [`verification/runtime-backends.md`](verification/runtime-backends.md#native-busy-state-corroboration-cost) records the measured per-poll cost.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -239,6 +239,14 @@ Herdr's native agent state can read idle while a harness waits on its own long f
 The shared crew-state path therefore accepts a native `busy` as evidence of activity but never a native `idle` as evidence that a worker has stopped; the task's own semantic busy state (`bin/fm-busy-lib.sh`) decides that.
 A human-blocked permission dialog has no busy banner and still surfaces.
 
+A native `busy` verdict is corroborated against the pane's own process inventory, through the same idle-shell proof the liveness classifier uses, so the two verdicts can never disagree about what the pane is.
+A registration is not withdrawn when the process that made it goes away, so a harness killed mid-turn would otherwise keep reporting `working` forever, with no state that could ever clear it.
+That stale report would suppress this task's stale-pane escalation through the record-free `busy herdr-native` fallthrough and defer away-mode injection indefinitely.
+The corroboration is positive-only in exactly the same way: a live process, an extra foreground process, a shell with a child, an unreadable inventory, and an inventory answering about a different pane all leave the busy verdict standing.
+A pane the inventory positively proves to be a lone bare idle shell reads `unknown` rather than `idle`, because a pane with no agent has no native agent state at all, and `unknown` is every consumer's cue to fall back to its own evidence.
+The inventory is read only on the busy branch, and the submit-confirmation path never reads busy state, so no tight loop pays for it.
+[`verification/runtime-backends.md`](verification/runtime-backends.md#native-busy-state-corroboration-cost) records the measured per-poll cost.
+
 ## Composer and injection safety
 
 Herdr has no direct cursor-row primitive.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -269,8 +269,18 @@ Create replaces only a confidently dead or no-agent husk, creates the replacemen
 This prevents closing the workspace's last tab before a replacement exists.
 
 The generic Herdr agent-liveness probe reuses the same classifier.
-A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
-Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
+A structurally gone pane becomes `missing`, an agent-free shell becomes `dead`, a registration the pane's processes do not contradict becomes `alive`, and an unexpected read becomes `unreadable`.
+Native registration classifies a harness without guessing from a generic interpreter name, which tmux process-name inspection cannot do.
+
+A reported registration is not evidence on its own.
+Herdr's agent registry is written by whatever reports into it, and a report is not withdrawn when the process that made it goes away, so a registration can outlive the agent it describes.
+The classifier therefore corroborates a reported registration against the pane's own `pane process-info` inventory and treats the registration as stale when that inventory positively proves a lone bare idle shell.
+This is the same rule the tmux classifier already applies from the foreground process group, expressed through Herdr's own inventory.
+
+The corroboration is positive-only and reads one strict instantaneous sample, so it can only move a verdict from `alive` toward `dead`, never the other way.
+A live harness process, an extra foreground process, a shell with a child of its own, an unreadable inventory, and an inventory answering about a different pane all leave the registration standing.
+An idle shell transiently hosting a prompt helper therefore stays `alive` for that sample, and the next poll settles it.
+A pane whose registration outlived its agent is a husk on the same terms as a restored one, so create-time replacement and presentation reclaim treat both identically.
 
 The session-start sweep uses this probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.
@@ -344,7 +354,11 @@ tests/fm-herdr-session-cleanup.test.sh
 tests/fm-herdr-session-cleanup-e2e.test.sh
 tests/fm-afk-inject-herdr-e2e.test.sh
 tests/fm-afk-pi-herdr-return-e2e.test.sh
+tests/fm-herdr-agent-free-proof-live-e2e.test.sh
 ```
+
+`tests/fm-herdr-agent-free-proof-live-e2e.test.sh` is the opt-in drift guard for the agent-free proof: it launches every installed harness for real and fails naming the harness and version if a running one ever proves a bare idle shell.
+Run it after any harness upgrade and refresh the per-harness evidence it prints.
 
 Real Herdr tests use the named lab helper and default-session tripwire.
 [`verification/runtime-backends.md`](verification/runtime-backends.md#herdr) records the active version, CLI, projection, event, and lifecycle evidence without task-specific chronology.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -288,9 +288,8 @@ Herdr's agent registry is written by whatever reports into it, and a report is n
 The classifier therefore corroborates a reported registration against the pane's own `pane process-info` inventory and treats the registration as stale when that inventory positively proves a lone bare idle shell.
 This is the same rule the tmux classifier already applies from the foreground process group, expressed through Herdr's own inventory.
 
-The corroboration is positive-only and reads one strict instantaneous sample, so it can only move a verdict from `alive` toward `dead`, never the other way.
-A live harness process, an extra foreground process, a shell with a child of its own, an unreadable inventory, and an inventory answering about a different pane all leave the registration standing.
-An idle shell transiently hosting a prompt helper therefore stays `alive` for that sample, and the next poll settles it.
+Only positive proof of an agent-free pane can move the verdict from `alive` to `dead`; an inconclusive inventory leaves the registration standing and recovery refuses until a later poll settles it.
+`bin/backends/herdr.sh` owns the exact proof and sampling mechanics.
 A pane whose registration outlived its agent is a husk on the same terms as a restored one, so create-time replacement and presentation reclaim treat both identically.
 
 The session-start sweep uses this probe.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -239,13 +239,11 @@ Herdr's native agent state can read idle while a harness waits on its own long f
 The shared crew-state path therefore accepts a native `busy` as evidence of activity but never a native `idle` as evidence that a worker has stopped; the task's own semantic busy state (`bin/fm-busy-lib.sh`) decides that.
 A human-blocked permission dialog has no busy banner and still surfaces.
 
-A native `busy` verdict is corroborated against the pane's own process inventory, through the same idle-shell proof the liveness classifier uses, and only a reported-busy state needs that corroboration.
-`busy` is the only native verdict that can wedge a pane, because it is what suppresses watcher stale-pane escalation and defers away-mode injection, while a reported `idle` is no evidence at all to any consumer and each falls back to its own.
-The liveness verdict and the busy verdict can therefore still differ for a stale registration last reported idle, which is deliberate and harmless because nothing acts on that difference.
-A registration is not withdrawn when the process that made it goes away, so a harness killed mid-turn would otherwise keep reporting `working` forever, with no state that could ever clear it.
-That stale report would suppress this task's stale-pane escalation through the record-free `busy herdr-native` fallthrough and defer away-mode injection indefinitely.
-The corroboration is positive-only in exactly the same way: a live process, an extra foreground process, a shell with a child, an unreadable inventory, and an inventory answering about a different pane all leave the busy verdict standing.
-A pane the inventory positively proves to be a lone bare idle shell reads `unknown` rather than `idle`, because a pane with no agent has no native agent state at all, and `unknown` is every consumer's cue to fall back to its own evidence.
+Every reported agent state, `busy` and `idle` alike, is corroborated against the pane's own process inventory, through the same idle-shell proof the liveness classifier uses, so the two verdicts always agree about what the pane is.
+A registration is not withdrawn when the process that made it goes away, so a harness that dies mid-turn keeps reporting its last state forever, with nothing that could ever clear it.
+Both reported states are acted on positively by a consumer, which is why neither is trusted alone: a stale `working` suppresses this task's stale-pane escalation and defers away-mode injection indefinitely, and a stale `idle` is read as a completed turn when a secondmate delivery is confirmed.
+The corroboration is positive-only: a live process, an extra foreground process, a shell with a child, an unreadable inventory, and an inventory answering about a different pane all leave the reported verdict standing.
+A pane the inventory positively proves to be a lone bare idle shell reads `unknown` rather than `busy` or `idle`, because a pane with no agent has no native agent state at all, and `unknown` is every consumer's cue to fall back to its own evidence.
 The submit-confirmation path never reads busy state at all, so no tight loop pays for the corroboration.
 [`verification/runtime-backends.md`](verification/runtime-backends.md#native-busy-state-corroboration-cost) records the measured per-poll cost.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -239,12 +239,14 @@ Herdr's native agent state can read idle while a harness waits on its own long f
 The shared crew-state path therefore accepts a native `busy` as evidence of activity but never a native `idle` as evidence that a worker has stopped; the task's own semantic busy state (`bin/fm-busy-lib.sh`) decides that.
 A human-blocked permission dialog has no busy banner and still surfaces.
 
-A native `busy` verdict is corroborated against the pane's own process inventory, through the same idle-shell proof the liveness classifier uses, so the two verdicts can never disagree about what the pane is.
+A native `busy` verdict is corroborated against the pane's own process inventory, through the same idle-shell proof the liveness classifier uses, and only a reported-busy state needs that corroboration.
+`busy` is the only native verdict that can wedge a pane, because it is what suppresses watcher stale-pane escalation and defers away-mode injection, while a reported `idle` is no evidence at all to any consumer and each falls back to its own.
+The liveness verdict and the busy verdict can therefore still differ for a stale registration last reported idle, which is deliberate and harmless because nothing acts on that difference.
 A registration is not withdrawn when the process that made it goes away, so a harness killed mid-turn would otherwise keep reporting `working` forever, with no state that could ever clear it.
 That stale report would suppress this task's stale-pane escalation through the record-free `busy herdr-native` fallthrough and defer away-mode injection indefinitely.
 The corroboration is positive-only in exactly the same way: a live process, an extra foreground process, a shell with a child, an unreadable inventory, and an inventory answering about a different pane all leave the busy verdict standing.
 A pane the inventory positively proves to be a lone bare idle shell reads `unknown` rather than `idle`, because a pane with no agent has no native agent state at all, and `unknown` is every consumer's cue to fall back to its own evidence.
-The inventory is read only on the busy branch, and the submit-confirmation path never reads busy state, so no tight loop pays for it.
+The submit-confirmation path never reads busy state at all, so no tight loop pays for the corroboration.
 [`verification/runtime-backends.md`](verification/runtime-backends.md#native-busy-state-corroboration-cost) records the measured per-poll cost.
 
 ## Composer and injection safety

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -710,9 +710,10 @@ This is the command that refreshes this record; run it after every harness upgra
 
 ### Native busy-state corroboration cost
 
-`fm_backend_herdr_busy_state` corroborates a `busy` verdict against the pane's own `pane process-info` inventory.
+`fm_backend_herdr_busy_state` corroborates every reported agent state against the pane's own `pane process-info` inventory.
 `bin/backends/herdr.sh` owns that contract and [`herdr-backend.md`](../herdr-backend.md#current-transport-behavior) states it; this record measures what it costs.
 Busy state is read on watcher and away-mode ticks, so the added read was measured rather than assumed.
+The last row runs the same read without the corroboration, so the added cost is derivable from this output rather than asserted beside it.
 Measured 2026-09-02 on Darwin arm64, Herdr 0.8.2, in an isolated `fm-lab-` session, 50 calls per row:
 
 ```sh
@@ -732,6 +733,13 @@ PANE=${IDS##* }
 report() { herdr pane report-agent "$PANE" --source fm-busy-cost \
   --agent fm-busy-cost-agent --state "$1" --session "$SESSION" >/dev/null; }
 verdict() { printf '%-52s -> %s\n' "$1" "$(fm_backend_herdr_busy_state "$SESSION:$PANE")"; }
+# The same read WITHOUT the corroboration, so the added cost is derivable from
+# this output rather than asserted beside it.
+uncorroborated() {  # <target>
+  fm_backend_herdr_target_ready "$1" || { printf 'unknown'; return 0; }
+  fm_backend_herdr_classify_agent_status \
+    "$(fm_backend_herdr_agent_status_raw "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")"
+}
 bench() {  # <label> <calls> <command...>
   local label=$1 n=$2 secs
   shift 2
@@ -741,18 +749,22 @@ bench() {  # <label> <calls> <command...>
 }
 
 printf '%s | %s\n' "$(uname -sm)" "$(herdr --version)"
+bench 'agent get (the existing per-poll read)' 50 fm_backend_herdr_agent_status_raw "$SESSION" "$PANE"
+bench 'pane process-info (the added read)' 50 fm_backend_herdr_cli "$SESSION" pane process-info --pane "$PANE"
 report working
 verdict 'working registration over a bare idle shell'
-bench 'agent get (existing per-poll read)' 50 fm_backend_herdr_agent_status_raw "$SESSION" "$PANE"
-bench 'pane process-info (added read)' 50 fm_backend_herdr_cli "$SESSION" pane process-info --pane "$PANE"
 bench 'busy_state, working over a bare idle shell' 50 fm_backend_herdr_busy_state "$SESSION:$PANE"
+report idle
+verdict 'idle registration over a bare idle shell'
+bench 'busy_state, idle over a bare idle shell' 50 fm_backend_herdr_busy_state "$SESSION:$PANE"
 herdr_pane_run_foreground "$SESSION" "$PANE" 'sleep 600'
 report working
 verdict 'working registration over a live foreground process'
 bench 'busy_state, working over a live process' 50 fm_backend_herdr_busy_state "$SESSION:$PANE"
 report idle
-verdict 'idle registration'
-bench 'busy_state, idle (no inventory read)' 50 fm_backend_herdr_busy_state "$SESSION:$PANE"
+verdict 'idle registration over a live foreground process'
+bench 'busy_state, idle over a live process' 50 fm_backend_herdr_busy_state "$SESSION:$PANE"
+bench 'the same read uncorroborated, live process' 50 uncorroborated "$SESSION:$PANE"
 fm_herdr_lab_teardown "$SESSION"
 ```
 
@@ -760,23 +772,30 @@ Observed output:
 
 ```text
 Darwin arm64 | herdr 0.8.2
+agent get (the existing per-poll read)                 19.2 ms/call (0.961 s / 50 calls)
+pane process-info (the added read)                     14.0 ms/call (0.702 s / 50 calls)
 working registration over a bare idle shell          -> unknown
-agent get (existing per-poll read)                     10.0 ms/call (0.499 s / 50 calls)
-pane process-info (added read)                          6.9 ms/call (0.344 s / 50 calls)
-busy_state, working over a bare idle shell             90.9 ms/call (4.546 s / 50 calls)
+busy_state, working over a bare idle shell            154.8 ms/call (7.741 s / 50 calls)
+idle registration over a bare idle shell             -> unknown
+busy_state, idle over a bare idle shell               148.5 ms/call (7.426 s / 50 calls)
 working registration over a live foreground process  -> busy
-busy_state, working over a live process                38.7 ms/call (1.933 s / 50 calls)
-idle registration                                    -> idle
-busy_state, idle (no inventory read)                   20.2 ms/call (1.010 s / 50 calls)
+busy_state, working over a live process                71.5 ms/call (3.574 s / 50 calls)
+idle registration over a live foreground process     -> idle
+busy_state, idle over a live process                   77.3 ms/call (3.867 s / 50 calls)
+the same read uncorroborated, live process             39.1 ms/call (1.954 s / 50 calls)
 ```
 
-The healthy path this branch actually runs on is a registration reported `working` over a live foreground process: 38.7 ms per call against the 20.2 ms of an `idle` verdict that reads no inventory, so the corroboration costs about 18 ms per poll where it can change the answer.
-An `idle` or `unknown` verdict pays nothing, because the inventory is read only on the `busy` branch.
-Only a pane that really is a lone bare idle shell runs the proof to the end (90.9 ms per call), since that is the one shape whose foreground process group is the shell and therefore reaches the operating-system process-table scan.
+On the healthy path, a pane running a real foreground process, the corroboration costs about 30 ms per call: 77.3 ms against the 39.1 ms the same read costs uncorroborated.
+The inventory read itself is 14.0 ms of that, and the rest is parsing it; the sample ends as soon as the foreground process group turns out not to be the shell, before the operating-system process table is scanned.
+Both reported states now pay it, `busy` and `idle` alike, because both are acted on positively by a consumer.
+An already-`unknown` verdict pays nothing, since no inventory reading can change it.
+
+Only a pane that really is a lone bare idle shell runs the proof to the end, around 150 ms per call, since that is the one shape whose foreground process group is the shell and therefore reaches the process-table scan.
 That pane is the husk this exists to catch, and it is read once per watcher tick rather than in a loop.
+The verdict rows show it resolving to `unknown` from both a stale `working` and a stale `idle`, which is the behavior this record exists to price.
 
 The tight submit-confirmation loops pay nothing at all, because they never call this function.
-`fm_backend_herdr_wait_for_working`, `fm_backend_herdr_send_text_submit`, and `fm_backend_herdr_queued_enter_busy` each poll `fm_backend_herdr_agent_status_raw` directly, measured unchanged at 10.0 ms per call above, and it deliberately skips even the server-ensure round trip that `fm_backend_herdr_busy_state` pays.
+`fm_backend_herdr_wait_for_working`, `fm_backend_herdr_send_text_submit`, and `fm_backend_herdr_queued_enter_busy` each poll `fm_backend_herdr_agent_status_raw` directly, measured unchanged at 19.2 ms per call above, and it deliberately skips even the server-ensure round trip that `fm_backend_herdr_busy_state` pays.
 The consumers that do read busy state are `bin/fm-busy-lib.sh`, `bin/fm-supervise-daemon.sh`, and `bin/fm-pending-reply-lib.sh`, all once per tick.
 
 Per-call figures move with machine load, so each row prints the raw elapsed seconds and call count it divided, and the verdict rows show which branch each measurement actually took.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -169,7 +169,7 @@ Both recorded runtime identities now classify the exact `pi-launcher` foreground
 
 Backend applicability was reviewed across every spawn adapter.
 Tmux needs the exact `pi-launcher`, `pi-signed`, `pi`, and `Pi` process identities for recovery-grade liveness.
-Herdr uses native registered-agent state and needs no process-name branch.
+Herdr combines native registered-agent state with backend-generic idle-shell corroboration and needs no Pi-specific process-name branch.
 Zellij has no verified recovery-grade agent process probe, while Orca and cmux do not support secondmate spawns, so those three retain their existing generic ordinary-launch semantics without a new liveness matcher.
 
 The current classifier matrix and its refresh guard are recorded in [Composer classification matrix](#composer-classification-matrix), with portable shape coverage in `tests/fm-composer-lib.test.sh` and `tests/fm-composer-ghost.test.sh`.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -635,7 +635,7 @@ Polling remained active and is covered as the fallback for capability, connect, 
 
 ### Agent lifecycle control
 
-Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-09-01 on Herdr 0.8.2, and first measured 2026-08-02 on Herdr 0.7.5:
+Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-09-02 on Herdr 0.8.2, macOS aarch64, and first measured 2026-08-02 on Herdr 0.7.5:
 
 ```sh
 tests/fm-control-herdr-smoke.test.sh
@@ -705,36 +705,76 @@ This is the command that refreshes this record; run it after every harness upgra
 
 ### Native busy-state corroboration cost
 
-`fm_backend_herdr_busy_state` corroborates a `busy` verdict against the same `pane process-info` inventory the liveness classifier uses, because a registration is not withdrawn when the process that made it goes away.
+`fm_backend_herdr_busy_state` corroborates a `busy` verdict against the pane's own `pane process-info` inventory.
+`bin/backends/herdr.sh` owns that contract and [`herdr-backend.md`](../herdr-backend.md#current-transport-behavior) states it; this record measures what it costs.
 Busy state is read on watcher and away-mode ticks, so the added read was measured rather than assumed.
-Measured 2026-09-02 on Herdr 0.8.2, macOS aarch64, against a pane in an isolated `fm-lab-` session carrying a registration reported with `herdr pane report-agent --state working`, 50 calls per row:
+Measured 2026-09-02 on Darwin arm64, Herdr 0.8.2, in an isolated `fm-lab-` session, 50 calls per row:
 
 ```sh
+# From the repo root. Isolated fm-lab- session only, never the default one.
+. tests/herdr-test-safety.sh
 . bin/fm-backend.sh
 fm_backend_source herdr
-for _ in $(seq 1 50); do fm_backend_herdr_agent_status_raw "$SESSION" "$PANE" >/dev/null; done
-for _ in $(seq 1 50); do fm_backend_herdr_cli "$SESSION" pane process-info --pane "$PANE" >/dev/null; done
-for _ in $(seq 1 50); do fm_backend_herdr_busy_state "$SESSION:$PANE" >/dev/null; done
+herdr_forget_inherited_pane
+SESSION=fm-lab-busycost-$$
+export HERDR_SESSION="$SESSION"
+fm_herdr_lab_prepare "$SESSION"
+WT=$(mktemp -d)/wt && mkdir -p "$WT"
+RAW=$(fm_backend_herdr_container_ensure "$WT")
+IDS=$(fm_backend_herdr_create_task "${RAW%%$'\t'*}" fm-busycost "$WT" "${RAW#*$'\t'}")
+PANE=${IDS##* }
+
+report() { herdr pane report-agent "$PANE" --source fm-busy-cost \
+  --agent fm-busy-cost-agent --state "$1" --session "$SESSION" >/dev/null; }
+verdict() { printf '%-52s -> %s\n' "$1" "$(fm_backend_herdr_busy_state "$SESSION:$PANE")"; }
+bench() {  # <label> <calls> <command...>
+  local label=$1 n=$2 secs
+  shift 2
+  secs=$( { TIMEFORMAT=%R; time ( for _ in $(seq 1 "$n"); do "$@" >/dev/null 2>&1; done ); } 2>&1 )
+  awk -v l="$label" -v s="$secs" -v n="$n" \
+    'BEGIN { printf "%-52s %6.1f ms/call (%s s / %d calls)\n", l, s * 1000 / n, s, n }'
+}
+
+printf '%s | %s\n' "$(uname -sm)" "$(herdr --version)"
+report working
+verdict 'working registration over a bare idle shell'
+bench 'agent get (existing per-poll read)' 50 fm_backend_herdr_agent_status_raw "$SESSION" "$PANE"
+bench 'pane process-info (added read)' 50 fm_backend_herdr_cli "$SESSION" pane process-info --pane "$PANE"
+bench 'busy_state, working over a bare idle shell' 50 fm_backend_herdr_busy_state "$SESSION:$PANE"
+herdr_pane_run_foreground "$SESSION" "$PANE" 'sleep 600'
+report working
+verdict 'working registration over a live foreground process'
+bench 'busy_state, working over a live process' 50 fm_backend_herdr_busy_state "$SESSION:$PANE"
+report idle
+verdict 'idle registration'
+bench 'busy_state, idle (no inventory read)' 50 fm_backend_herdr_busy_state "$SESSION:$PANE"
+fm_herdr_lab_teardown "$SESSION"
 ```
+
+Observed output:
 
 ```text
-agent get (existing per-poll read)                16.1 ms/call
-pane process-info (added read)                    10.6 ms/call
-busy_state, idle registration (no inventory)      42.7 ms/call
-busy_state, working registration over a live process   61.2 ms/call
-busy_state, working registration over a bare shell    157.9 ms/call
+Darwin arm64 | herdr 0.8.2
+working registration over a bare idle shell          -> unknown
+agent get (existing per-poll read)                     10.0 ms/call (0.499 s / 50 calls)
+pane process-info (added read)                          6.9 ms/call (0.344 s / 50 calls)
+busy_state, working over a bare idle shell             90.9 ms/call (4.546 s / 50 calls)
+working registration over a live foreground process  -> busy
+busy_state, working over a live process                38.7 ms/call (1.933 s / 50 calls)
+idle registration                                    -> idle
+busy_state, idle (no inventory read)                   20.2 ms/call (1.010 s / 50 calls)
 ```
 
-The inventory is read only on the `busy` branch, where it can change the answer, so an `idle` or `unknown` verdict pays nothing at all.
-A genuinely busy pane pays about 19 ms per poll: the inventory read plus its parsing, ending as soon as the foreground process group turns out not to be the shell, before the operating-system process table is scanned.
-Only a pane that really is a lone bare idle shell runs the whole proof, and that pane is the husk this exists to catch; it is read once per watcher tick, not in a loop.
+The healthy path this branch actually runs on is a registration reported `working` over a live foreground process: 38.7 ms per call against the 20.2 ms of an `idle` verdict that reads no inventory, so the corroboration costs about 18 ms per poll where it can change the answer.
+An `idle` or `unknown` verdict pays nothing, because the inventory is read only on the `busy` branch.
+Only a pane that really is a lone bare idle shell runs the proof to the end (90.9 ms per call), since that is the one shape whose foreground process group is the shell and therefore reaches the operating-system process-table scan.
+That pane is the husk this exists to catch, and it is read once per watcher tick rather than in a loop.
 
-No tight loop pays anything, because the submit-confirmation path does not read busy state at all.
-`fm_backend_herdr_wait_for_working`, `fm_backend_herdr_send_text_submit`, and `fm_backend_herdr_queued_enter_busy` each poll `fm_backend_herdr_agent_status_raw` directly, which is unchanged and deliberately skips even the server-ensure round trip that `fm_backend_herdr_busy_state` pays.
-The consumers that do read busy state are `bin/fm-busy-lib.sh`, `bin/fm-supervise-daemon.sh`, and `bin/fm-pending-reply-lib.sh`, all of which read it once per tick.
+The tight submit-confirmation loops pay nothing at all, because they never call this function.
+`fm_backend_herdr_wait_for_working`, `fm_backend_herdr_send_text_submit`, and `fm_backend_herdr_queued_enter_busy` each poll `fm_backend_herdr_agent_status_raw` directly, measured unchanged at 10.0 ms per call above, and it deliberately skips even the server-ensure round trip that `fm_backend_herdr_busy_state` pays.
+The consumers that do read busy state are `bin/fm-busy-lib.sh`, `bin/fm-supervise-daemon.sh`, and `bin/fm-pending-reply-lib.sh`, all once per tick.
 
-A contradicted verdict resolves to `unknown`, never `idle`, because a pane with no agent has no native agent state at all.
-`unknown` is every consumer's documented cue to fall back to its own evidence, so no caller gains a fabricated positive idle.
+Per-call figures move with machine load, so each row prints the raw elapsed seconds and call count it divided, and the verdict rows show which branch each measurement actually took.
 
 ### Away-mode transport
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -267,7 +267,7 @@ This guard is the refresh command after any harness upgrade; it spends a small n
 ## Herdr
 
 The compatibility floor is protocol 14.
-The whole real-Herdr lane's latest active verification uses both Herdr 0.7.4 protocol 16 and Herdr 0.8.0 protocol 19 on macOS aarch64, while focused Herdr 0.7.5 protocol 17, earlier protocol-16, protocol-14, and 0.7.3 evidence is retained where it defines current behavior or fallbacks.
+The whole real-Herdr lane's latest active verification uses both Herdr 0.7.4 protocol 16 and Herdr 0.8.0 protocol 19 on macOS aarch64, with agent lifecycle control and the agent-free proof measured on Herdr 0.8.2, while focused Herdr 0.7.5 protocol 17, earlier protocol-16, protocol-14, and 0.7.3 evidence is retained where it defines current behavior or fallbacks.
 Protocol 17 keeps every protocol-16 feature gate satisfied; the event and workspace-move floors remain 16.
 Default-on presentation projection has its own floor at Herdr 0.8.0, protocol 19, verified below.
 
@@ -635,24 +635,71 @@ Polling remained active and is covered as the fallback for capability, connect, 
 
 ### Agent lifecycle control
 
-Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-08-08 on Herdr 0.8.0, and first measured 2026-08-02 on Herdr 0.7.5 with identical results:
+Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-09-01 on Herdr 0.8.2, and first measured 2026-08-02 on Herdr 0.7.5:
 
 ```sh
 tests/fm-control-herdr-smoke.test.sh
 ```
 
-Observed output:
+Observed output on Herdr 0.8.2:
 
 ```text
 ok - real herdr: exit on a pane with no registered agent is idempotent success
 ok - real herdr: interrupt refuses when herdr's own agent registry reports no agent
+ok - real herdr: a reported registration the pane's own process inventory contradicts reads agent-free
+ok - real herdr: an exited worker's pane is positively eligible for its replacement instead of being typed into
+ok - real herdr: interrupt still refuses on a pane whose registration outlived its agent
+ok - real herdr: the same registration over a running foreground process stays alive
 ok - real herdr: interrupt delivers the harness's key and proves the agent survived it
-ok - real herdr: no control verb removed the endpoint or the task's local copy
 ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
+ok - real herdr: no control verb removed the endpoint, the task's local copy, or its branch
 ```
 
-The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
-That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
+The registry written through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so the case drives the registry and the pane's processes apart deliberately and runs the identical registered reading twice: once over a plain shell and once over a real foreground process, with no real agent launched.
+
+Herdr 0.8.2 keeps such a report registered even though the pane runs nothing but its shell, measured in an isolated `fm-lab-` session:
+
+```text
+herdr pane report-agent <pane> --source fm-control-smoke --agent fm-control-smoke-agent --state idle
+herdr agent get <pane>   -> {"agent_status":"idle"}
+herdr pane process-info  -> foreground_processes [{"name":"zsh","argv0":"zsh"}]
+```
+
+That is why the classifier corroborates the registry against the pane's own inventory rather than trusting a reported registration alone.
+Herdr does validate a report claiming a source it owns itself: an otherwise identical `--source herdr:pi --agent pi` report on the same shell-only pane was rejected and `agent get` still answered `agent_not_found`.
+
+`tests/fm-control-herdr-smoke.test.sh` is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
+
+### Agent-free proof across installed harnesses
+
+The classifier's negative verdict rests on `pane process-info` naming a lone bare idle shell, and both that name and its argv0 come from the harness vendor, so the proof is measured against every installed harness rather than a stub.
+Measured 2026-09-01 on Herdr 0.8.2, macOS aarch64, in an isolated `fm-lab-` session:
+
+```sh
+FM_HERDR_AGENT_FREE_PROOF=1 tests/fm-herdr-agent-free-proof-live-e2e.test.sh
+```
+
+Observed output:
+
+```text
+# herdr: herdr 0.8.2
+# claude 2.1.252 (Claude Code): foreground=[2.1.252/claude] state=alive
+ok - herdr agent-free proof: claude 2.1.252 (Claude Code) running in a Herdr pane never proves a bare idle shell
+# codex codex-cli 0.150.1: foreground=[codex/codex] state=alive
+ok - herdr agent-free proof: codex codex-cli 0.150.1 running in a Herdr pane never proves a bare idle shell
+# opencode 1.17.11: foreground=[opencode/opencode] state=alive
+ok - herdr agent-free proof: opencode 1.17.11 running in a Herdr pane never proves a bare idle shell
+# pi 0.84.4: foreground=[node/pi] state=alive
+ok - herdr agent-free proof: pi 0.84.4 running in a Herdr pane never proves a bare idle shell
+# cursor 2026.08.31-4057e58: foreground=[node/cursor-agent] state=alive
+ok - herdr agent-free proof: cursor 2026.08.31-4057e58 running in a Herdr pane never proves a bare idle shell
+# unverified on this machine (not installed): pi-signed grok kimi muse
+# checked 5 installed harness(es) on herdr herdr 0.8.2 in workspace w1
+```
+
+Every installed harness owns the pane's foreground under its own argv0, so none can satisfy the shell-only proof, and Herdr registered each of them within the guard's wait.
+`pi-signed`, `grok`, `kimi`, and `muse` were not installed on that machine and remain unverified here; the guard reports them explicitly and refuses a pass that checked nothing.
+This is the command that refreshes this record; run it after every harness upgrade.
 
 ### Away-mode transport
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -683,23 +683,28 @@ Observed output:
 
 ```text
 # herdr: herdr 0.8.2
-# claude 2.1.258 (Claude Code): foreground=[2.1.258/claude] state=alive
-ok - herdr agent-free proof: claude 2.1.258 (Claude Code) running in a Herdr pane never proves a bare idle shell
+# claude 2.1.259 (Claude Code): foreground=[security/security 2.1.259/claude] state=alive
+ok - herdr agent-free proof: claude 2.1.259 (Claude Code) running in a Herdr pane never proves a bare idle shell
 # codex codex-cli 0.152.1: foreground=[codex/codex] state=alive
 ok - herdr agent-free proof: codex codex-cli 0.152.1 running in a Herdr pane never proves a bare idle shell
 # opencode 1.17.11: foreground=[opencode/opencode] state=alive
 ok - herdr agent-free proof: opencode 1.17.11 running in a Herdr pane never proves a bare idle shell
 # pi 0.84.4: foreground=[node/pi] state=alive
 ok - herdr agent-free proof: pi 0.84.4 running in a Herdr pane never proves a bare idle shell
+# skip: pi-signed is not installed on this machine, so its Herdr classification is unverified here
+# skip: grok is not installed on this machine, so its Herdr classification is unverified here
+# skip: kimi is not installed on this machine, so its Herdr classification is unverified here
 # cursor 2026.08.31-4057e58: foreground=[node/cursor-agent] state=alive
 ok - herdr agent-free proof: cursor 2026.08.31-4057e58 running in a Herdr pane never proves a bare idle shell
+# skip: muse is not installed on this machine, so its Herdr classification is unverified here
 # unverified on this machine (not installed): pi-signed grok kimi muse
 # checked 5 installed harness(es) on herdr herdr 0.8.2 in workspace w1
 ```
 
-Both guards resolve the harness binary through one shared helper (`tests/harness-binary.sh`), which is also what `tests/fm-harness-liveness-drift-live-e2e.test.sh` launches through, so neither guard can measure a different binary than the other or than a real spawn.
+Both guards resolve the harness binary through one shared helper (`tests/harness-binary-helpers.sh`), which is also what `tests/fm-harness-liveness-drift-live-e2e.test.sh` launches through, so neither guard can measure a different binary than the other or than a real spawn.
 
-Every installed harness owns the pane's foreground under its own argv0, so none can satisfy the shell-only proof, and Herdr registered each of them within the guard's wait.
+No installed harness leaves the pane holding one lone bare shell, so none can satisfy the proof, and Herdr registered each of them within the guard's wait.
+Each owns the pane's foreground under its own argv0, and claude 2.1.259 additionally keeps a `security` helper in that foreground, which is a second process rather than a shell and so refuses the proof twice over.
 `pi-signed`, `grok`, `kimi`, and `muse` were not installed on that machine and remain unverified here; the guard reports them explicitly and refuses a pass that checked nothing.
 This is the command that refreshes this record; run it after every harness upgrade.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -713,7 +713,8 @@ This is the command that refreshes this record; run it after every harness upgra
 `fm_backend_herdr_busy_state` corroborates every reported agent state against the pane's own `pane process-info` inventory.
 `bin/backends/herdr.sh` owns that contract and [`herdr-backend.md`](../herdr-backend.md#current-transport-behavior) states it; this record measures what it costs.
 Busy state is read on watcher and away-mode ticks, so the added read was measured rather than assumed.
-The last row runs the same read without the corroboration, so the added cost is derivable from this output rather than asserted beside it.
+Each reported branch is measured twice, once through the shipped function and once through the same read without the corroboration, so the added cost is derivable from this output rather than asserted beside it.
+The agent is registered before the first row, so every read priced here is a registered read rather than the `agent_not_found` path, which short-circuits before jq.
 Measured 2026-09-02 on Darwin arm64, Herdr 0.8.2, in an isolated `fm-lab-` session, 50 calls per row:
 
 ```sh
@@ -749,9 +750,9 @@ bench() {  # <label> <calls> <command...>
 }
 
 printf '%s | %s\n' "$(uname -sm)" "$(herdr --version)"
+report working
 bench 'agent get (the existing per-poll read)' 50 fm_backend_herdr_agent_status_raw "$SESSION" "$PANE"
 bench 'pane process-info (the added read)' 50 fm_backend_herdr_cli "$SESSION" pane process-info --pane "$PANE"
-report working
 verdict 'working registration over a bare idle shell'
 bench 'busy_state, working over a bare idle shell' 50 fm_backend_herdr_busy_state "$SESSION:$PANE"
 report idle
@@ -761,10 +762,11 @@ herdr_pane_run_foreground "$SESSION" "$PANE" 'sleep 600'
 report working
 verdict 'working registration over a live foreground process'
 bench 'busy_state, working over a live process' 50 fm_backend_herdr_busy_state "$SESSION:$PANE"
+bench 'the same read uncorroborated, working' 50 uncorroborated "$SESSION:$PANE"
 report idle
 verdict 'idle registration over a live foreground process'
 bench 'busy_state, idle over a live process' 50 fm_backend_herdr_busy_state "$SESSION:$PANE"
-bench 'the same read uncorroborated, live process' 50 uncorroborated "$SESSION:$PANE"
+bench 'the same read uncorroborated, idle' 50 uncorroborated "$SESSION:$PANE"
 fm_herdr_lab_teardown "$SESSION"
 ```
 
@@ -772,30 +774,31 @@ Observed output:
 
 ```text
 Darwin arm64 | herdr 0.8.2
-agent get (the existing per-poll read)                 19.2 ms/call (0.961 s / 50 calls)
-pane process-info (the added read)                     14.0 ms/call (0.702 s / 50 calls)
+agent get (the existing per-poll read)                 11.8 ms/call (0.590 s / 50 calls)
+pane process-info (the added read)                      7.1 ms/call (0.353 s / 50 calls)
 working registration over a bare idle shell          -> unknown
-busy_state, working over a bare idle shell            154.8 ms/call (7.741 s / 50 calls)
+busy_state, working over a bare idle shell             97.0 ms/call (4.848 s / 50 calls)
 idle registration over a bare idle shell             -> unknown
-busy_state, idle over a bare idle shell               148.5 ms/call (7.426 s / 50 calls)
+busy_state, idle over a bare idle shell               111.8 ms/call (5.589 s / 50 calls)
 working registration over a live foreground process  -> busy
-busy_state, working over a live process                71.5 ms/call (3.574 s / 50 calls)
+busy_state, working over a live process                56.8 ms/call (2.841 s / 50 calls)
+the same read uncorroborated, working                  26.3 ms/call (1.313 s / 50 calls)
 idle registration over a live foreground process     -> idle
-busy_state, idle over a live process                   77.3 ms/call (3.867 s / 50 calls)
-the same read uncorroborated, live process             39.1 ms/call (1.954 s / 50 calls)
+busy_state, idle over a live process                   54.0 ms/call (2.699 s / 50 calls)
+the same read uncorroborated, idle                     31.0 ms/call (1.549 s / 50 calls)
 ```
 
-On the healthy path, a pane running a real foreground process, the corroboration costs about 30 ms per call: 77.3 ms against the 39.1 ms the same read costs uncorroborated.
-The inventory read itself is 14.0 ms of that, and the rest is parsing it; the sample ends as soon as the foreground process group turns out not to be the shell, before the operating-system process table is scanned.
-Both reported states now pay it, `busy` and `idle` alike, because both are acted on positively by a consumer.
+Both reported branches do identical added work, and this run prices it at 30.5 ms on the `working` branch (56.8 against 26.3) and 23.0 ms on the `idle` branch (54.0 against 31.0).
+The spread between those two is machine load across the run, not a difference between the branches; the added `pane process-info` read alone is 7.1 ms here and the rest is parsing it.
+The sample ends as soon as the foreground process group turns out not to be the shell, before the operating-system process table is scanned.
 An already-`unknown` verdict pays nothing, since no inventory reading can change it.
 
-Only a pane that really is a lone bare idle shell runs the proof to the end, around 150 ms per call, since that is the one shape whose foreground process group is the shell and therefore reaches the process-table scan.
+Only a pane that really is a lone bare idle shell runs the proof to the end, around 100 ms per call, since that is the one shape whose foreground process group is the shell and therefore reaches the process-table scan.
 That pane is the husk this exists to catch, and it is read once per watcher tick rather than in a loop.
 The verdict rows show it resolving to `unknown` from both a stale `working` and a stale `idle`, which is the behavior this record exists to price.
 
 The tight submit-confirmation loops pay nothing at all, because they never call this function.
-`fm_backend_herdr_wait_for_working`, `fm_backend_herdr_send_text_submit`, and `fm_backend_herdr_queued_enter_busy` each poll `fm_backend_herdr_agent_status_raw` directly, measured unchanged at 19.2 ms per call above, and it deliberately skips even the server-ensure round trip that `fm_backend_herdr_busy_state` pays.
+`fm_backend_herdr_wait_for_working`, `fm_backend_herdr_send_text_submit`, and `fm_backend_herdr_queued_enter_busy` each poll `fm_backend_herdr_agent_status_raw` directly, measured unchanged at 11.8 ms per call above on the same registered pane, and it deliberately skips even the server-ensure round trip that `fm_backend_herdr_busy_state` pays.
 The consumers that do read busy state are `bin/fm-busy-lib.sh`, `bin/fm-supervise-daemon.sh`, and `bin/fm-pending-reply-lib.sh`, all once per tick.
 
 Per-call figures move with machine load, so each row prints the raw elapsed seconds and call count it divided, and the verdict rows show which branch each measurement actually took.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -673,7 +673,7 @@ Herdr does validate a report claiming a source it owns itself: an otherwise iden
 ### Agent-free proof across installed harnesses
 
 The classifier's negative verdict rests on `pane process-info` naming a lone bare idle shell, and both that name and its argv0 come from the harness vendor, so the proof is measured against every installed harness rather than a stub.
-Measured 2026-09-01 on Herdr 0.8.2, macOS aarch64, in an isolated `fm-lab-` session:
+Reverified 2026-09-02 on Herdr 0.8.2, macOS aarch64, in an isolated `fm-lab-` session, and first measured 2026-09-01 on the same Herdr with the then-current claude 2.1.252 and codex 0.150.1:
 
 ```sh
 FM_HERDR_AGENT_FREE_PROOF=1 tests/fm-herdr-agent-free-proof-live-e2e.test.sh
@@ -683,10 +683,10 @@ Observed output:
 
 ```text
 # herdr: herdr 0.8.2
-# claude 2.1.252 (Claude Code): foreground=[2.1.252/claude] state=alive
-ok - herdr agent-free proof: claude 2.1.252 (Claude Code) running in a Herdr pane never proves a bare idle shell
-# codex codex-cli 0.150.1: foreground=[codex/codex] state=alive
-ok - herdr agent-free proof: codex codex-cli 0.150.1 running in a Herdr pane never proves a bare idle shell
+# claude 2.1.258 (Claude Code): foreground=[2.1.258/claude] state=alive
+ok - herdr agent-free proof: claude 2.1.258 (Claude Code) running in a Herdr pane never proves a bare idle shell
+# codex codex-cli 0.152.1: foreground=[codex/codex] state=alive
+ok - herdr agent-free proof: codex codex-cli 0.152.1 running in a Herdr pane never proves a bare idle shell
 # opencode 1.17.11: foreground=[opencode/opencode] state=alive
 ok - herdr agent-free proof: opencode 1.17.11 running in a Herdr pane never proves a bare idle shell
 # pi 0.84.4: foreground=[node/pi] state=alive
@@ -697,9 +697,44 @@ ok - herdr agent-free proof: cursor 2026.08.31-4057e58 running in a Herdr pane n
 # checked 5 installed harness(es) on herdr herdr 0.8.2 in workspace w1
 ```
 
+Both guards resolve the harness binary through one shared helper (`tests/harness-binary.sh`), which is also what `tests/fm-harness-liveness-drift-live-e2e.test.sh` launches through, so neither guard can measure a different binary than the other or than a real spawn.
+
 Every installed harness owns the pane's foreground under its own argv0, so none can satisfy the shell-only proof, and Herdr registered each of them within the guard's wait.
 `pi-signed`, `grok`, `kimi`, and `muse` were not installed on that machine and remain unverified here; the guard reports them explicitly and refuses a pass that checked nothing.
 This is the command that refreshes this record; run it after every harness upgrade.
+
+### Native busy-state corroboration cost
+
+`fm_backend_herdr_busy_state` corroborates a `busy` verdict against the same `pane process-info` inventory the liveness classifier uses, because a registration is not withdrawn when the process that made it goes away.
+Busy state is read on watcher and away-mode ticks, so the added read was measured rather than assumed.
+Measured 2026-09-02 on Herdr 0.8.2, macOS aarch64, against a pane in an isolated `fm-lab-` session carrying a registration reported with `herdr pane report-agent --state working`, 50 calls per row:
+
+```sh
+. bin/fm-backend.sh
+fm_backend_source herdr
+for _ in $(seq 1 50); do fm_backend_herdr_agent_status_raw "$SESSION" "$PANE" >/dev/null; done
+for _ in $(seq 1 50); do fm_backend_herdr_cli "$SESSION" pane process-info --pane "$PANE" >/dev/null; done
+for _ in $(seq 1 50); do fm_backend_herdr_busy_state "$SESSION:$PANE" >/dev/null; done
+```
+
+```text
+agent get (existing per-poll read)                16.1 ms/call
+pane process-info (added read)                    10.6 ms/call
+busy_state, idle registration (no inventory)      42.7 ms/call
+busy_state, working registration over a live process   61.2 ms/call
+busy_state, working registration over a bare shell    157.9 ms/call
+```
+
+The inventory is read only on the `busy` branch, where it can change the answer, so an `idle` or `unknown` verdict pays nothing at all.
+A genuinely busy pane pays about 19 ms per poll: the inventory read plus its parsing, ending as soon as the foreground process group turns out not to be the shell, before the operating-system process table is scanned.
+Only a pane that really is a lone bare idle shell runs the whole proof, and that pane is the husk this exists to catch; it is read once per watcher tick, not in a loop.
+
+No tight loop pays anything, because the submit-confirmation path does not read busy state at all.
+`fm_backend_herdr_wait_for_working`, `fm_backend_herdr_send_text_submit`, and `fm_backend_herdr_queued_enter_busy` each poll `fm_backend_herdr_agent_status_raw` directly, which is unchanged and deliberately skips even the server-ensure round trip that `fm_backend_herdr_busy_state` pays.
+The consumers that do read busy state are `bin/fm-busy-lib.sh`, `bin/fm-supervise-daemon.sh`, and `bin/fm-pending-reply-lib.sh`, all of which read it once per tick.
+
+A contradicted verdict resolves to `unknown`, never `idle`, because a pane with no agent has no native agent state at all.
+`unknown` is every consumer's documented cue to fall back to its own evidence, so no caller gains a fabricated positive idle.
 
 ### Away-mode transport
 

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -332,18 +332,29 @@ SH
   printf '%s\n' "$fb"
 }
 
+# herdr_process_info: the single owner of herdr's `pane process-info` response
+# shape.
+#
+# Every case that drives the idle-shell proof depends on this exact envelope
+# being what herdr reports, so it is built in one place: a field rename in a
+# future herdr release is then one edit here rather than a silent divergence
+# between the suites that would each still pass against their own stale copy.
+herdr_process_info() {  # <pane> <shell-pid> <fg-pgid> <foreground-processes-json>
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"%s","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":%s}}}\n' \
+    "$1" "$2" "$3" "$4"
+}
+
 # herdr_bare_shell_process_info: the inventory herdr reports for a pane whose
 # agent has exited - one foreground process, which is the pane's own shell.
 # <real-pid> must be a REAL live pid with no child, because the
 # operating-system half of the idle-shell proof is answered by the real `ps`.
 herdr_bare_shell_process_info() {  # <pane> <real-pid>
-  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"%s","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"zsh","argv0":"zsh"}]}}}\n' \
-    "$1" "$2" "$2" "$2"
+  herdr_process_info "$1" "$2" "$2" \
+    "$(printf '[{"pid":%s,"name":"zsh","argv0":"zsh"}]' "$2")"
 }
 
 # herdr_live_process_info: the same pane with a real harness process owning the
 # foreground instead of the shell. Nothing here may ever prove agent-free.
 herdr_live_process_info() {  # <pane> <shell-pid>
-  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"%s","shell_pid":%s,"foreground_process_group_id":4242,"foreground_processes":[{"pid":4242,"name":"node","argv0":"pi"}]}}}\n' \
-    "$1" "$2"
+  herdr_process_info "$1" "$2" 4242 '[{"pid":4242,"name":"node","argv0":"pi"}]'
 }

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -289,3 +289,61 @@ make_stubs() {
   fm_test_fake_sleep_noop "$fakebin"
   printf '%s\n' "$fakebin"
 }
+
+# --- herdr native agent-state stubs -----------------------------------------
+
+# make_herdr_agent_state_fakebin: a `herdr` stub for the NATIVE agent-state
+# lane, answering by SUBCOMMAND rather than by call order.
+#
+# The call-numbered stub in tests/fm-backend-herdr.test.sh pins an exact CLI
+# sequence, which is the wrong shape for a consumer test: bin/fm-busy-lib.sh
+# and bin/fm-supervise-daemon.sh decide for themselves how many reads to make,
+# and that decision is part of what those tests assert. This stub answers
+# whatever is asked, as often as it is asked.
+#
+# Read from the environment at call time, so one stub serves every case:
+#   FM_FAKE_HERDR_AGENT_STATUS - the agent_status `agent get` reports
+#   FM_FAKE_HERDR_PROCESS_INFO - file holding the `pane process-info` response
+#                                (absent or unset means an unreadable inventory)
+#   FM_FAKE_HERDR_PANE_READ    - file holding the `pane read` capture
+make_herdr_agent_state_fakebin() {  # <dir> -> echoes fakebin dir
+  local fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-} ${2:-}" in
+  "status --json")
+    printf '{"client":{"version":"0.8.2","protocol":19},"server":{"running":true}}\n'
+    ;;
+  "agent get")
+    printf '{"result":{"agent":{"agent_status":"%s"}}}\n' "${FM_FAKE_HERDR_AGENT_STATUS:-}"
+    ;;
+  "pane process-info")
+    if [ -f "${FM_FAKE_HERDR_PROCESS_INFO:-}" ]; then cat "$FM_FAKE_HERDR_PROCESS_INFO"; fi
+    ;;
+  "pane read")
+    if [ -f "${FM_FAKE_HERDR_PANE_READ:-}" ]; then cat "$FM_FAKE_HERDR_PANE_READ"; fi
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/herdr"
+  printf '%s\n' "$fb"
+}
+
+# herdr_bare_shell_process_info: the inventory herdr reports for a pane whose
+# agent has exited - one foreground process, which is the pane's own shell.
+# <real-pid> must be a REAL live pid with no child, because the
+# operating-system half of the idle-shell proof is answered by the real `ps`.
+herdr_bare_shell_process_info() {  # <pane> <real-pid>
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"%s","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"zsh","argv0":"zsh"}]}}}\n' \
+    "$1" "$2" "$2" "$2"
+}
+
+# herdr_live_process_info: the same pane with a real harness process owning the
+# foreground instead of the shell. Nothing here may ever prove agent-free.
+herdr_live_process_info() {  # <pane> <shell-pid>
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"%s","shell_pid":%s,"foreground_process_group_id":4242,"foreground_processes":[{"pid":4242,"name":"node","argv0":"pi"}]}}}\n' \
+    "$1" "$2"
+}

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -1401,6 +1401,8 @@ assert_no_projection_mutation_since "$START" "agent-free duplicate-token recover
 lab workspace get "$DUP1_WSID" >/dev/null 2>&1 || fail "duplicate-token recovery removed the first quarantined workspace"
 lab workspace get "$DUP2_WSID" >/dev/null 2>&1 || fail "duplicate-token recovery removed the second quarantined workspace"
 
+herdr_pane_run_foreground "$HERDR_LAB_SESSION" "$DUP1_PANE" \
+  || fail "could not give the duplicate-live-agent risk fixture a running foreground process"
 lab pane report-agent "$DUP1_PANE" --source fm-projection-e2e --agent test-agent --state idle >/dev/null \
   || fail "could not register the duplicate-live-agent risk fixture"
 START=$(log_line_count)

--- a/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
+++ b/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
@@ -159,11 +159,16 @@ WS_COUNT=$(printf '%s' "$WS_TABS" | jq -r '.result.tabs? // [] | length')
 pass "fixed: the workspace holds exactly the 2 replacement tabs after both respawns - no leaked husk tabs, no destroyed workspace"
 
 # --- 4. a GENUINELY live duplicate still refuses, unchanged -----------------
-# Register a real agent (herdr's own native registration primitive) on one of
-# the freshly-respawned panes, then confirm a further same-labeled spawn
-# attempt refuses exactly as before - the husk fix must never touch a pane
-# that actually has something registered in it.
+# Give one of the freshly-respawned panes a real running foreground process and
+# register a real agent on it (herdr's own native registration primitive), then
+# confirm a further same-labeled spawn attempt refuses exactly as before - the
+# husk fix must never touch a pane that is actually running something.
+# Both halves matter: a registration standing over a bare idle shell is the
+# husk shape, because a report is not withdrawn when the process that made it
+# goes away (docs/herdr-backend.md "Restart and liveness behavior").
 
+herdr_pane_run_foreground "$SESSION" "$NEW_CREW_PANE_ID" \
+  || fail "could not give the respawned crewmate-shaped pane a running foreground process"
 herdr pane report-agent "$NEW_CREW_PANE_ID" --source fm-respawn-e2e --agent fm-respawn-live-agent --state idle --session "$SESSION" >/dev/null 2>&1 \
   || fail "could not register a live agent on the respawned crewmate-shaped pane"
 

--- a/tests/fm-backend-herdr-smoke.test.sh
+++ b/tests/fm-backend-herdr-smoke.test.sh
@@ -121,6 +121,11 @@ pass "real herdr: create_task prunes the freshly-created workspace's seeded defa
 
 # 1. A genuinely LIVE duplicate (a real registered agent, via herdr's own
 #    `pane report-agent`) must still refuse exactly as before.
+#    "Genuinely live" means both halves the classifier reads: a registration
+#    AND a pane that is actually running something. A registration standing
+#    over a bare idle shell is the husk shape instead, because a report is not
+#    withdrawn when the process that made it goes away
+#    (docs/herdr-backend.md "Restart and liveness behavior").
 LIVE_DUP_LABEL="fm-smoke-livedup"
 LIVE_DUP_IDS=$(fm_backend_herdr_create_task "$CONTAINER" "$LIVE_DUP_LABEL" /tmp) || fail "could not create the live-duplicate scenario's tab"
 read -r LIVE_DUP_TAB_ID LIVE_DUP_PANE_ID <<EOF
@@ -129,6 +134,8 @@ EOF
 if [ -z "$LIVE_DUP_TAB_ID" ] || [ -z "$LIVE_DUP_PANE_ID" ]; then
   fail "live-duplicate scenario tab creation did not return ids"
 fi
+herdr_pane_run_foreground "$SESSION" "$LIVE_DUP_PANE_ID" \
+  || fail "could not give the live-duplicate scenario's pane a running foreground process"
 herdr pane report-agent "$LIVE_DUP_PANE_ID" --source fm-smoke-test --agent fm-smoke-live-agent --state idle --session "$SESSION" >/dev/null 2>&1 \
   || fail "could not register a live agent on the live-duplicate scenario's pane"
 if fm_backend_herdr_create_task "$CONTAINER" "$LIVE_DUP_LABEL" /tmp >/dev/null 2>&1; then

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -929,7 +929,9 @@ test_registration_over_a_shell_with_a_child_stays_alive() {
   dir="$TMP_ROOT/reg-child"
   # A real shell that is genuinely running something: the trailing `true` keeps
   # bash from exec-ing away, so the child row is real.
-  bash -c 'sleep 300; true' & bgpid=$!
+  bash -c 'sleep 300; true' &
+  # shellcheck disable=SC2031 # the & runs in THIS shell; the adapter's own backgrounded server launch is what ShellCheck saw
+  bgpid=$!
   # Give the real child a moment to exist before the proof reads the table.
   while [ "$attempt" -lt 200 ]; do
     child=$(ps -axo ppid= -o pid= 2>/dev/null | awk -v p="$bgpid" '$1 == p {print $2}')
@@ -3180,6 +3182,98 @@ test_current_path_reads_cwd() {
 
 # --- busy_state (semantic agent state) ---------------------------------------
 
+# --- busy_state corroborated against the pane's own processes ---------------
+#
+# The registry is written by whatever reports into it and a report is not
+# withdrawn when the process that made it goes away, so a harness killed
+# mid-turn leaves `agent get` answering `working` forever. The busy verdict
+# reuses the SAME idle-shell proof the liveness classifier uses, so the two can
+# never disagree about what the pane is, and it resolves to `unknown` rather
+# than `idle`: a pane with no agent has no native agent state at all, and
+# `unknown` is every consumer's cue to fall back to its own evidence.
+
+busy_state_case() {  # <dir> <pane> <agent-status> [<process-info-json>]
+  local dir=$1 pane=$2 status=$3 proc_json=${4:-} log resp fb
+  mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"agent":{"agent_status":"%s"}}}\n' "$status" > "$resp/1.out"
+  [ -z "$proc_json" ] || printf '%s' "$proc_json" > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_busy_state "fmtest:$1"' "$ROOT" "$pane"
+}
+
+test_busy_state_stale_registration_is_not_busy() {
+  local dir bgpid stale live
+  dir="$TMP_ROOT/busy-stale-registration"
+  sleep 300 &
+  # shellcheck disable=SC2031 # the & runs in THIS shell; the adapter's own backgrounded server launch is what ShellCheck saw
+  bgpid=$!
+  stale=$(busy_state_case "$dir/husk" w1:p2 working "$(bare_shell_inventory w1:p2 "$bgpid")")
+  # The IDENTICAL working reading, with a live harness process in the pane.
+  live=$(busy_state_case "$dir/live" w1:p2 working \
+    "$(process_info_fixture w1:p2 "$bgpid" 4242 '[{"pid":4242,"name":"node","argv0":"pi"}]')")
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  [ "$stale" = unknown ] \
+    || fail "a working registration whose pane holds only a bare idle shell must not read busy, got '$stale'"
+  [ "$live" = busy ] \
+    || fail "the same working registration over a live process must still read busy, got '$live'"
+  pass "fm_backend_herdr_busy_state: a working registration contradicted by a lone bare idle shell reads unknown, while the identical registration over a live process stays busy"
+}
+
+test_busy_state_keeps_busy_when_the_inventory_proves_nothing() {
+  local dir bgpid ambiguous unreadable other
+  dir="$TMP_ROOT/busy-inconclusive"
+  sleep 300 &
+  # shellcheck disable=SC2031 # the & runs in THIS shell; the adapter's own backgrounded server launch is what ShellCheck saw
+  bgpid=$!
+  # An idle shell transiently hosting a prompt helper: two foreground
+  # processes, so nothing is proved and the busy verdict stands.
+  ambiguous=$(busy_state_case "$dir/ambiguous" w1:p2 working \
+    "$(process_info_fixture w1:p2 "$bgpid" "$bgpid" \
+      "$(printf '[{"pid":99998,"name":"starship","argv0":"starship"},{"pid":%s,"name":"zsh","argv0":"zsh"}]' "$bgpid")")")
+  unreadable=$(busy_state_case "$dir/unreadable" w1:p2 working)
+  other=$(busy_state_case "$dir/other-pane" w1:p2 working "$(bare_shell_inventory w9:p9 "$bgpid")")
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  [ "$ambiguous" = busy ] || fail "an extra foreground process proves nothing and must leave busy standing, got '$ambiguous'"
+  [ "$unreadable" = busy ] || fail "an unreadable inventory must leave busy standing, got '$unreadable'"
+  [ "$other" = busy ] || fail "an inventory about another pane must leave busy standing, got '$other'"
+  pass "fm_backend_herdr_busy_state: an extra foreground process, an unreadable inventory, and an inventory about another pane all leave the busy verdict untouched"
+}
+
+test_busy_state_keeps_busy_for_a_shell_with_a_child() {
+  local dir bgpid child attempt=0 childpid=
+  dir="$TMP_ROOT/busy-shell-child"
+  # A real shell that is genuinely running something: the trailing `true` keeps
+  # bash from exec-ing away, so the child row is real.
+  bash -c 'sleep 300; true' &
+  # shellcheck disable=SC2031 # the & runs in THIS shell; the adapter's own backgrounded server launch is what ShellCheck saw
+  bgpid=$!
+  while [ "$attempt" -lt 200 ]; do
+    childpid=$(ps -axo ppid= -o pid= 2>/dev/null | awk -v p="$bgpid" '$1 == p {print $2}')
+    [ -n "$childpid" ] && break
+    sleep 0.05
+    attempt=$((attempt + 1))
+  done
+  if [ -z "$childpid" ]; then
+    kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+    fail "ps never reported a child of the backgrounded shell $bgpid, so this case cannot exercise a shell that is running something"
+  fi
+  child=$(busy_state_case "$dir" w1:p2 working "$(bare_shell_inventory w1:p2 "$bgpid")")
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  [ "$child" = busy ] || fail "a shell with a child of its own is not idle and must leave busy standing, got '$child'"
+  pass "fm_backend_herdr_busy_state: a shell running a child of its own never proves an agent-free pane, so its busy verdict stands"
+}
+
+test_busy_state_non_busy_verdicts_never_read_the_inventory() {
+  local dir out
+  dir="$TMP_ROOT/busy-idle-no-inventory"
+  out=$(busy_state_case "$dir" w1:p2 idle)
+  [ "$out" = idle ] || fail "an idle registration must still read idle, got '$out'"
+  assert_not_contains "$(cat "$dir/log")" $'pane\x1fprocess-info' \
+    "a verdict the inventory could not change must not pay for the inventory read"
+  pass "fm_backend_herdr_busy_state: only a busy verdict pays for the corroborating inventory read, so no non-busy poll gets slower"
+}
+
 test_busy_state_working_maps_to_busy() {
   local dir log resp fb out
   dir="$TMP_ROOT/busy-working"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -4781,6 +4875,10 @@ test_send_key_normalizes_and_targets_pane
 test_kill_is_best_effort
 test_current_path_reads_cwd
 test_busy_state_working_maps_to_busy
+test_busy_state_stale_registration_is_not_busy
+test_busy_state_keeps_busy_when_the_inventory_proves_nothing
+test_busy_state_keeps_busy_for_a_shell_with_a_child
+test_busy_state_non_busy_verdicts_never_read_the_inventory
 test_busy_state_done_and_blocked_map_to_idle
 test_busy_state_unknown_on_no_agent
 test_composer_state_bare_prompt_is_empty

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -835,6 +835,192 @@ test_create_task_creates_and_parses_ids() {
   pass "fm_backend_herdr_create_task: creates a tab and parses tab_id/pane_id from the JSON response, prunes nothing when no seeded tab id is given"
 }
 
+# --- a reported registration corroborated against the process inventory ------
+#
+# Herdr's agent registry is written by whatever reports into it, and a report
+# is not withdrawn when the process that made it goes away. A task whose worker
+# had exited to its shell therefore read `alive` forever: every lifecycle verb
+# typed the harness's exit command into a shell and refused to relaunch, with
+# no state that could ever clear it. The classifier now settles the negative
+# verdict from the pane's own `pane process-info` inventory, exactly as the
+# tmux classifier already settles it from the foreground process group.
+#
+# These cases drive the two signals apart deliberately with REAL processes and
+# no harness: the same registered `idle` reading resolves to `no-agent` or to
+# `live` purely from the inventory beside it. Only a positive proof of a lone
+# bare idle shell downgrades the verdict; a live process, an extra foreground
+# process, a shell with a child, an unreadable inventory, and an inventory
+# about a different pane all keep `live`.
+
+process_info_fixture() {  # <pane> <shell-pid> <fg-pgid> <foreground-processes-json>
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"%s","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":%s}}}\n' \
+    "$1" "$2" "$3" "$4"
+}
+
+# bare_shell_inventory: the inventory herdr reports for a pane whose agent has
+# exited - one foreground process, which is the pane's own shell. Backed by a
+# REAL pid so the operating-system half of the proof (exactly one row, no
+# child, sleeping) is answered by the real `ps`, never a stub.
+bare_shell_inventory() {  # <pane> <real-pid>
+  process_info_fixture "$1" "$2" "$2" \
+    "$(printf '[{"pid":%s,"name":"zsh","argv0":"zsh"}]' "$2")"
+}
+
+# agent_state_case: run both classifier entry points over one canned
+# pane-get/agent-get/process-info sequence and echo "<pane-state> <agent-state>".
+agent_state_case() {  # <dir> <pane> <agent-get-json> [<process-info-json>]
+  local dir=$1 pane=$2 agent_json=$3 proc_json=${4:-} log resp fb
+  mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"%s"}}}\n' "$pane" > "$resp/1.out"
+  printf '%s' "$agent_json" > "$resp/2.out"
+  [ -z "$proc_json" ] || printf '%s' "$proc_json" > "$resp/3.out"
+  printf '{"result":{"pane":{"pane_id":"%s"}}}\n' "$pane" > "$resp/4.out"
+  printf '%s' "$agent_json" > "$resp/5.out"
+  [ -z "$proc_json" ] || printf '%s' "$proc_json" > "$resp/6.out"
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"
+      printf "%s %s" \
+        "$(fm_backend_herdr_pane_agent_state fmtest "$1")" \
+        "$(fm_backend_herdr_agent_state "fmtest:$1")"' "$ROOT" "$pane"
+}
+
+test_stale_registration_over_a_bare_idle_shell_is_agent_free() {
+  local dir bgpid stale live
+  dir="$TMP_ROOT/reg-stale"
+  # A real, bare, idle process with no child of its own: the operating-system
+  # half of the idle-shell proof is answered by the real `ps`.
+  sleep 300 & bgpid=$!
+  stale=$(agent_state_case "$dir/shell" w1:p2 \
+    '{"result":{"agent":{"agent_status":"idle"}}}' \
+    "$(bare_shell_inventory w1:p2 "$bgpid")")
+  # The SAME registered reading, with a live harness process in the pane
+  # instead. Asserting both halves keeps the case from going vacuous: the
+  # downgrade must come from the inventory, never from the registration.
+  live=$(agent_state_case "$dir/live" w1:p2 \
+    '{"result":{"agent":{"agent_status":"idle"}}}' \
+    "$(process_info_fixture w1:p2 "$bgpid" 4242 '[{"pid":4242,"name":"node","argv0":"pi"}]')")
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  [ "$stale" = "no-agent dead" ] \
+    || fail "a registration whose pane holds only a bare idle shell must classify agent-free, got '$stale'"
+  [ "$live" = "live alive" ] \
+    || fail "the same registration with a live harness process in the pane must stay alive, got '$live'"
+  pass "herdr agent state: a reported registration contradicted by a lone bare idle shell reads agent-free, while the identical registration over a live process stays alive"
+}
+
+test_registration_over_an_ambiguous_inventory_stays_alive() {
+  local dir bgpid out
+  dir="$TMP_ROOT/reg-ambiguous"
+  sleep 300 & bgpid=$!
+  # An idle shell transiently hosting a prompt helper: two foreground
+  # processes, so nothing is proved and the registration stands.
+  out=$(agent_state_case "$dir" w1:p2 \
+    '{"result":{"agent":{"agent_status":"working"}}}' \
+    "$(process_info_fixture w1:p2 "$bgpid" "$bgpid" \
+      "$(printf '[{"pid":99998,"name":"starship","argv0":"starship"},{"pid":%s,"name":"zsh","argv0":"zsh"}]' "$bgpid")")")
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  [ "$out" = "live alive" ] \
+    || fail "an ambiguous process inventory must never downgrade a registration, got '$out'"
+  pass "herdr agent state: an ambiguous process inventory leaves a registered agent alive rather than licensing recovery"
+}
+
+test_registration_over_a_shell_with_a_child_stays_alive() {
+  local dir bgpid out attempt=0 child=
+  dir="$TMP_ROOT/reg-child"
+  # A real shell that is genuinely running something: the trailing `true` keeps
+  # bash from exec-ing away, so the child row is real.
+  bash -c 'sleep 300; true' & bgpid=$!
+  # Give the real child a moment to exist before the proof reads the table.
+  while [ "$attempt" -lt 200 ]; do
+    child=$(ps -axo ppid= -o pid= 2>/dev/null | awk -v p="$bgpid" '$1 == p {print $2}')
+    [ -n "$child" ] && break
+    sleep 0.05
+    attempt=$((attempt + 1))
+  done
+  if [ -z "$child" ]; then
+    kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+    fail "ps never reported a child of the backgrounded shell $bgpid, so this case cannot exercise a shell that is running something"
+  fi
+  out=$(agent_state_case "$dir" w1:p2 \
+    '{"result":{"agent":{"agent_status":"idle"}}}' \
+    "$(bare_shell_inventory w1:p2 "$bgpid")")
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  [ "$out" = "live alive" ] \
+    || fail "a shell that still has a child of its own is not idle and must stay alive, got '$out'"
+  pass "herdr agent state: a shell running a child of its own never proves an agent-free pane"
+}
+
+test_registration_with_an_unreadable_inventory_stays_alive() {
+  local dir out
+  dir="$TMP_ROOT/reg-unreadable"
+  # No process-info response at all: the fake answers empty, exactly as a
+  # failed or unparseable inventory read would.
+  out=$(agent_state_case "$dir" w1:p2 '{"result":{"agent":{"agent_status":"idle"}}}')
+  [ "$out" = "live alive" ] \
+    || fail "an unreadable process inventory must leave the registration standing, got '$out'"
+  pass "herdr agent state: an unreadable process inventory leaves a registered agent alive"
+}
+
+test_registration_with_an_inventory_for_another_pane_stays_alive() {
+  local dir bgpid out
+  dir="$TMP_ROOT/reg-other-pane"
+  sleep 300 & bgpid=$!
+  # A bare-idle-shell inventory that answers about a DIFFERENT pane: the
+  # reading belongs to something else and can never settle this pane.
+  out=$(agent_state_case "$dir" w1:p2 \
+    '{"result":{"agent":{"agent_status":"idle"}}}' \
+    "$(bare_shell_inventory w9:p9 "$bgpid")")
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  [ "$out" = "live alive" ] \
+    || fail "an inventory about another pane must never settle this pane's state, got '$out'"
+  pass "herdr agent state: a process inventory answering about a different pane never downgrades this pane's registration"
+}
+
+test_unregistered_pane_never_reads_the_process_inventory() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/reg-absent"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w1:p2' "$ROOT")
+  [ "$out" = no-agent ] || fail "an unregistered pane must still read no-agent, got '$out'"
+  assert_not_contains "$(cat "$log")" $'pane\x1fprocess-info' \
+    "an already-agent-free pane must not pay for the corroborating inventory read"
+  pass "herdr agent state: an unregistered pane is agent-free without reading the process inventory at all"
+}
+
+test_create_task_replaces_a_stale_registration_husk() {
+  local dir log resp fb bgpid out tab pane
+  dir="$TMP_ROOT/husk-stale-registration"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  sleep 300 & bgpid=$!
+  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-husk3","workspace_id":"w1"}]}}\n' > "$resp/1.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
+  # 4: agent get -> still registered, because nothing ever withdrew the report
+  printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/4.out"
+  # 5: pane process-info -> the pane is a lone bare idle shell
+  bare_shell_inventory w1:p2 "$bgpid" > "$resp/5.out"
+  # 6: tab create -> the replacement tab, created BEFORE the husk is closed
+  printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/6.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk3","workspace_id":"w1"}]}}\n' > "$resp/8.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-husk3 /tmp/proj' "$ROOT" ) \
+    || { kill "$bgpid" 2>/dev/null; fail "create_task should replace a duplicate whose registration outlived its agent"; }
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  read -r tab pane <<EOF
+$out
+EOF
+  if [ "$tab" != "w1:t3" ] || [ "$pane" != "w1:p3" ]; then
+    fail "create_task should echo the NEW tab/pane ids, got '$out'"
+  fi
+  assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''close'$'\x1f''w1:t2' \
+    "create_task did not close the stale-registration husk's tab"
+  pass "fm_backend_herdr_create_task: a same-labeled tab whose registration outlived its agent is a husk on the same terms as a restored shell"
+}
+
 # --- container_ensure / create_task: --no-focus and per-home label ----------
 
 test_container_ensure_creates_with_no_focus_flag() {
@@ -4513,6 +4699,13 @@ test_create_task_refuses_duplicate_label_when_agent_live
 test_create_task_refuses_when_any_duplicate_label_is_live
 test_create_task_closes_and_replaces_dead_pane_husk
 test_create_task_closes_and_replaces_no_agent_husk
+test_stale_registration_over_a_bare_idle_shell_is_agent_free
+test_registration_over_an_ambiguous_inventory_stays_alive
+test_registration_over_a_shell_with_a_child_stays_alive
+test_registration_with_an_unreadable_inventory_stays_alive
+test_registration_with_an_inventory_for_another_pane_stays_alive
+test_unregistered_pane_never_reads_the_process_inventory
+test_create_task_replaces_a_stale_registration_husk
 test_create_task_closes_all_duplicate_husks_after_replacement
 test_create_task_refuses_when_preexisting_husk_tab_remains
 test_create_task_refuses_when_agent_state_ambiguous

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3246,14 +3246,34 @@ test_busy_state_keeps_busy_for_a_shell_with_a_child() {
   pass "fm_backend_herdr_busy_state: a shell running a child of its own never proves an agent-free pane, so its busy verdict stands"
 }
 
-test_busy_state_non_busy_verdicts_never_read_the_inventory() {
+test_busy_state_stale_idle_registration_is_not_idle() {
+  local dir bgpid stale live
+  dir="$TMP_ROOT/busy-stale-idle-registration"
+  sleep 300 &
+  # shellcheck disable=SC2031 # the & runs in THIS shell; the adapter's own backgrounded server launch is what ShellCheck saw
+  bgpid=$!
+  stale=$(busy_state_case "$dir/husk" w1:p2 idle "$(herdr_bare_shell_process_info w1:p2 "$bgpid")")
+  # The IDENTICAL idle reading, with a live harness process in the pane.
+  live=$(busy_state_case "$dir/live" w1:p2 idle "$(herdr_live_process_info w1:p2 "$bgpid")")
+  kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
+  [ "$stale" = unknown ] \
+    || fail "an idle registration whose pane holds only a bare idle shell must not read idle, got '$stale'"
+  [ "$live" = idle ] \
+    || fail "the same idle registration over a live process must still read idle, got '$live'"
+  pass "fm_backend_herdr_busy_state: an idle registration contradicted by a lone bare idle shell reads unknown, so a secondmate delivery confirmation cannot read a fabricated completed turn"
+}
+
+test_busy_state_unknown_verdict_never_reads_the_inventory() {
   local dir out
-  dir="$TMP_ROOT/busy-idle-no-inventory"
-  out=$(busy_state_case "$dir" w1:p2 idle)
-  [ "$out" = idle ] || fail "an idle registration must still read idle, got '$out'"
+  dir="$TMP_ROOT/busy-unknown-no-inventory"; mkdir -p "$dir/responses"; : > "$dir/log"
+  printf '{"result":{"agent":{"agent_status":"bogus"}}}\n' > "$dir/responses/1.out"
+  out=$(PATH="$(make_herdr_fakebin "$dir"):$PATH" FM_HERDR_LOG="$dir/log" \
+    FM_HERDR_RESPONSES="$dir/responses" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_busy_state fmtest:w1:p2' "$ROOT")
+  [ "$out" = unknown ] || fail "an unrecognized agent state must still read unknown, got '$out'"
   assert_not_contains "$(cat "$dir/log")" $'pane\x1fprocess-info' \
     "a verdict the inventory could not change must not pay for the inventory read"
-  pass "fm_backend_herdr_busy_state: only a busy verdict pays for the corroborating inventory read, so no non-busy poll gets slower"
+  pass "fm_backend_herdr_busy_state: an already-unknown verdict skips the corroborating inventory read entirely"
 }
 
 test_busy_state_working_maps_to_busy() {
@@ -4860,7 +4880,8 @@ test_busy_state_working_maps_to_busy
 test_busy_state_stale_registration_is_not_busy
 test_busy_state_keeps_busy_when_the_inventory_proves_nothing
 test_busy_state_keeps_busy_for_a_shell_with_a_child
-test_busy_state_non_busy_verdicts_never_read_the_inventory
+test_busy_state_stale_idle_registration_is_not_idle
+test_busy_state_unknown_verdict_never_reads_the_inventory
 test_busy_state_done_and_blocked_map_to_idle
 test_busy_state_unknown_on_no_agent
 test_composer_state_bare_prompt_is_empty

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -10,8 +10,8 @@
 # gated on the herdr binary actually being installed.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 # shellcheck source=tests/herdr-test-safety.sh
 . "$(dirname "${BASH_SOURCE[0]}")/herdr-test-safety.sh"
 
@@ -852,20 +852,6 @@ test_create_task_creates_and_parses_ids() {
 # process, a shell with a child, an unreadable inventory, and an inventory
 # about a different pane all keep `live`.
 
-process_info_fixture() {  # <pane> <shell-pid> <fg-pgid> <foreground-processes-json>
-  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"%s","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":%s}}}\n' \
-    "$1" "$2" "$3" "$4"
-}
-
-# bare_shell_inventory: the inventory herdr reports for a pane whose agent has
-# exited - one foreground process, which is the pane's own shell. Backed by a
-# REAL pid so the operating-system half of the proof (exactly one row, no
-# child, sleeping) is answered by the real `ps`, never a stub.
-bare_shell_inventory() {  # <pane> <real-pid>
-  process_info_fixture "$1" "$2" "$2" \
-    "$(printf '[{"pid":%s,"name":"zsh","argv0":"zsh"}]' "$2")"
-}
-
 # agent_state_case: run both classifier entry points over one canned
 # pane-get/agent-get/process-info sequence and echo "<pane-state> <agent-state>".
 agent_state_case() {  # <dir> <pane> <agent-get-json> [<process-info-json>]
@@ -893,13 +879,13 @@ test_stale_registration_over_a_bare_idle_shell_is_agent_free() {
   sleep 300 & bgpid=$!
   stale=$(agent_state_case "$dir/shell" w1:p2 \
     '{"result":{"agent":{"agent_status":"idle"}}}' \
-    "$(bare_shell_inventory w1:p2 "$bgpid")")
+    "$(herdr_bare_shell_process_info w1:p2 "$bgpid")")
   # The SAME registered reading, with a live harness process in the pane
   # instead. Asserting both halves keeps the case from going vacuous: the
   # downgrade must come from the inventory, never from the registration.
   live=$(agent_state_case "$dir/live" w1:p2 \
     '{"result":{"agent":{"agent_status":"idle"}}}' \
-    "$(process_info_fixture w1:p2 "$bgpid" 4242 '[{"pid":4242,"name":"node","argv0":"pi"}]')")
+    "$(herdr_live_process_info w1:p2 "$bgpid")")
   kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
   [ "$stale" = "no-agent dead" ] \
     || fail "a registration whose pane holds only a bare idle shell must classify agent-free, got '$stale'"
@@ -916,7 +902,7 @@ test_registration_over_an_ambiguous_inventory_stays_alive() {
   # processes, so nothing is proved and the registration stands.
   out=$(agent_state_case "$dir" w1:p2 \
     '{"result":{"agent":{"agent_status":"working"}}}' \
-    "$(process_info_fixture w1:p2 "$bgpid" "$bgpid" \
+    "$(herdr_process_info w1:p2 "$bgpid" "$bgpid" \
       "$(printf '[{"pid":99998,"name":"starship","argv0":"starship"},{"pid":%s,"name":"zsh","argv0":"zsh"}]' "$bgpid")")")
   kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
   [ "$out" = "live alive" ] \
@@ -945,7 +931,7 @@ test_registration_over_a_shell_with_a_child_stays_alive() {
   fi
   out=$(agent_state_case "$dir" w1:p2 \
     '{"result":{"agent":{"agent_status":"idle"}}}' \
-    "$(bare_shell_inventory w1:p2 "$bgpid")")
+    "$(herdr_bare_shell_process_info w1:p2 "$bgpid")")
   kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
   [ "$out" = "live alive" ] \
     || fail "a shell that still has a child of its own is not idle and must stay alive, got '$out'"
@@ -971,7 +957,7 @@ test_registration_with_an_inventory_for_another_pane_stays_alive() {
   # reading belongs to something else and can never settle this pane.
   out=$(agent_state_case "$dir" w1:p2 \
     '{"result":{"agent":{"agent_status":"idle"}}}' \
-    "$(bare_shell_inventory w9:p9 "$bgpid")")
+    "$(herdr_bare_shell_process_info w9:p9 "$bgpid")")
   kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
   [ "$out" = "live alive" ] \
     || fail "an inventory about another pane must never settle this pane's state, got '$out'"
@@ -1003,7 +989,7 @@ test_create_task_replaces_a_stale_registration_husk() {
   # 4: agent get -> still registered, because nothing ever withdrew the report
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/4.out"
   # 5: pane process-info -> the pane is a lone bare idle shell
-  bare_shell_inventory w1:p2 "$bgpid" > "$resp/5.out"
+  herdr_bare_shell_process_info w1:p2 "$bgpid" > "$resp/5.out"
   # 6: tab create -> the replacement tab, created BEFORE the husk is closed
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/6.out"
   printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk3","workspace_id":"w1"}]}}\n' > "$resp/8.out"
@@ -1718,10 +1704,6 @@ SH
   : > "$dir/mover.log"
 }
 
-death_process_info_fixture() {  # <pane> <pid>
-  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"%s","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"zsh","argv0":"zsh"}]}}}\n' "$1" "$2" "$2" "$2"
-}
-
 test_projection_close_emptying_after_focus_uses_pane_death_without_move() {
   local dir log resp fb out status bgpid
   dir="$TMP_ROOT/close-death-after"; mkdir -p "$dir/responses"
@@ -1734,7 +1716,7 @@ test_projection_close_emptying_after_focus_uses_pane_death_without_move() {
   printf '%s\n' '{"result":{"panes":[{"pane_id":"w2:p2","tab_id":"w2:t2"}]}}' > "$resp/5.out"
   cp "$resp/1.out" "$resp/6.out"
   sleep 300 & bgpid=$!
-  death_process_info_fixture w2:p2 "$bgpid" > "$resp/7.out"
+  herdr_bare_shell_process_info w2:p2 "$bgpid" > "$resp/7.out"
   printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/8.out"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true},{"workspace_id":"w3","active_tab_id":"w3:t1","focused":false}]}}' > "$resp/9.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/10.out"
@@ -1771,7 +1753,7 @@ test_projection_close_emptying_before_focus_repositions_then_uses_pane_death() {
   printf '%s\n' '{"schemas":{"request":{"oneOf":[{"properties":{"method":{"const":"workspace.move"}}}],"$defs":{"WorkspaceMoveParams":{"required":["workspace_id","insert_index"],"properties":{"insert_index":{"type":"integer"}}}}}}}' > "$resp/8.out"
   printf '%s\n' '{"sessions":[{"name":"fmtest","running":true,"socket_path":"/tmp/fmtest.sock"}]}' > "$resp/9.out"
   sleep 300 & bgpid=$!
-  death_process_info_fixture w1:p1 "$bgpid" > "$resp/10.out"
+  herdr_bare_shell_process_info w1:p1 "$bgpid" > "$resp/10.out"
   printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/11.out"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w2","active_tab_id":"w2:t1","focused":true},{"workspace_id":"w3","active_tab_id":"w3:t1","focused":false}]}}' > "$resp/12.out"
   cp "$resp/12.out" "$resp/13.out"
@@ -1808,7 +1790,7 @@ test_projection_close_emptying_before_last_focus_needs_no_move() {
   printf '%s\n' '{"result":{"panes":[{"pane_id":"w1:p1","tab_id":"w1:t1"}]}}' > "$resp/5.out"
   cp "$resp/1.out" "$resp/6.out"
   sleep 300 & bgpid=$!
-  death_process_info_fixture w1:p1 "$bgpid" > "$resp/7.out"
+  herdr_bare_shell_process_info w1:p1 "$bgpid" > "$resp/7.out"
   printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/8.out"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w2","active_tab_id":"w2:t1","focused":false},{"workspace_id":"w3","active_tab_id":"w3:t1","focused":true}]}}' > "$resp/9.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w3:t1","focused":true}]}}' > "$resp/10.out"
@@ -1840,7 +1822,7 @@ test_projection_close_emptying_last_workspace_needs_no_move() {
   printf '%s\n' '{"result":{"panes":[{"pane_id":"w3:p1","tab_id":"w3:t1"}]}}' > "$resp/5.out"
   cp "$resp/1.out" "$resp/6.out"
   sleep 300 & bgpid=$!
-  death_process_info_fixture w3:p1 "$bgpid" > "$resp/7.out"
+  herdr_bare_shell_process_info w3:p1 "$bgpid" > "$resp/7.out"
   printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/8.out"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true},{"workspace_id":"w2","active_tab_id":"w2:t1","focused":false}]}}' > "$resp/9.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/10.out"
@@ -2027,7 +2009,7 @@ test_projection_close_transient_prompt_helper_settles_then_uses_pane_death() {
   # a helper such as starship rides along as a second foreground process).
   printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w2:p2","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":99998,"name":"starship","argv":["/usr/local/bin/starship","prompt","--continuation"]},{"pid":%s,"name":"zsh","argv0":"zsh"}]}}}\n' "$bgpid" "$bgpid" "$bgpid" > "$resp/7.out"
   # Sample 2: the helper finished; the shell is provably alone and idle.
-  death_process_info_fixture w2:p2 "$bgpid" > "$resp/8.out"
+  herdr_bare_shell_process_info w2:p2 "$bgpid" > "$resp/8.out"
   printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/9.out"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true}]}}' > "$resp/10.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/11.out"
@@ -2059,10 +2041,10 @@ test_projection_close_death_escalates_sigkill_after_sighup_survival() {
   printf '%s\n' '{"result":{"panes":[{"pane_id":"w2:p2","tab_id":"w2:t2"}]}}' > "$resp/5.out"
   cp "$resp/1.out" "$resp/6.out"
   bash -c 'trap "" HUP; sleep 300' & bgpid=$!
-  death_process_info_fixture w2:p2 "$bgpid" > "$resp/7.out"
+  herdr_bare_shell_process_info w2:p2 "$bgpid" > "$resp/7.out"
   printf '%s\n' '{"error":{"code":"internal_error","message":"transient failure"}}' > "$resp/8.out"
   printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/9.out"
-  death_process_info_fixture w2:p2 "$bgpid" > "$resp/10.out"
+  herdr_bare_shell_process_info w2:p2 "$bgpid" > "$resp/10.out"
   printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/11.out"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true}]}}' > "$resp/12.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/13.out"
@@ -2095,10 +2077,10 @@ test_projection_close_death_failure_falls_back_to_plain_close() {
   printf '%s\n' '{"result":{"panes":[{"pane_id":"w2:p2","tab_id":"w2:t2"}]}}' > "$resp/5.out"
   cp "$resp/1.out" "$resp/6.out"
   bash -c 'trap "" HUP; sleep 300' & bgpid=$!
-  death_process_info_fixture w2:p2 "$bgpid" > "$resp/7.out"
+  herdr_bare_shell_process_info w2:p2 "$bgpid" > "$resp/7.out"
   printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/8.out"
   printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/9.out"
-  death_process_info_fixture w2:p2 "$bgpid" > "$resp/10.out"
+  herdr_bare_shell_process_info w2:p2 "$bgpid" > "$resp/10.out"
   printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/11.out"
   printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/12.out"
   printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/14.out"
@@ -2129,7 +2111,7 @@ test_projection_close_death_still_restores_a_stolen_focus() {
   printf '%s\n' '{"result":{"panes":[{"pane_id":"w2:p2","tab_id":"w2:t2"}]}}' > "$resp/5.out"
   cp "$resp/1.out" "$resp/6.out"
   sleep 300 & bgpid=$!
-  death_process_info_fixture w2:p2 "$bgpid" > "$resp/7.out"
+  herdr_bare_shell_process_info w2:p2 "$bgpid" > "$resp/7.out"
   printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/8.out"
   # The backstop still fires when the post-close snapshot disagrees.
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":false},{"workspace_id":"w3","active_tab_id":"w3:t1","focused":true}]}}' > "$resp/9.out"
@@ -2164,10 +2146,10 @@ test_projection_close_death_never_sigkills_a_reused_pid() {
   # information shows a DIFFERENT shell pid, modeling the original pid having
   # been reused by an unrelated process the pane no longer owns.
   bash -c 'trap "" HUP; sleep 300' & bgpid=$!
-  death_process_info_fixture w2:p2 "$bgpid" > "$resp/7.out"
+  herdr_bare_shell_process_info w2:p2 "$bgpid" > "$resp/7.out"
   cp "$resp/3.out" "$resp/8.out"   # SIGHUP poll 1: pane still present
   cp "$resp/3.out" "$resp/9.out"   # SIGHUP poll 2: pane still present
-  death_process_info_fixture w2:p2 99997 > "$resp/10.out"
+  herdr_bare_shell_process_info w2:p2 99997 > "$resp/10.out"
   : > "$resp/11.out"               # fallback explicit close: pane close ok
   printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/12.out"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true}]}}' > "$resp/13.out"
@@ -2208,7 +2190,7 @@ assert_projection_close_failed_removal_rolls_back_the_reposition() {
   printf '%s\n' '{"schemas":{"request":{"oneOf":[{"properties":{"method":{"const":"workspace.move"}}}],"$defs":{"WorkspaceMoveParams":{"required":["workspace_id","insert_index"],"properties":{"insert_index":{"type":"integer"}}}}}}}' > "$resp/8.out"
   printf '%s\n' '{"sessions":[{"name":"fmtest","running":true,"socket_path":"/tmp/fmtest.sock"}]}' > "$resp/9.out"
   bash -c 'trap "" HUP; sleep 300' & bgpid=$!
-  death_process_info_fixture w1:p1 "$bgpid" > "$resp/10.out"
+  herdr_bare_shell_process_info w1:p1 "$bgpid" > "$resp/10.out"
   if [ "$mode" = pane-gone-workspace-present ]; then
     printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/11.out"
     printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w2","active_tab_id":"w2:t1","focused":true},{"workspace_id":"w3","active_tab_id":"w3:t1","focused":false},{"workspace_id":"w1","active_tab_id":"w1:t2","focused":false}]}}' > "$resp/12.out"
@@ -2217,7 +2199,7 @@ assert_projection_close_failed_removal_rolls_back_the_reposition() {
   else
     cp "$resp/3.out" "$resp/11.out"  # SIGHUP poll 1: pane still present
     cp "$resp/3.out" "$resp/12.out"  # SIGHUP poll 2: pane still present
-    death_process_info_fixture w1:p1 "$bgpid" > "$resp/13.out"  # escalation resample: same owner
+    herdr_bare_shell_process_info w1:p1 "$bgpid" > "$resp/13.out"  # escalation resample: same owner
     cp "$resp/3.out" "$resp/14.out"  # SIGKILL poll 1: pane still present
     cp "$resp/3.out" "$resp/15.out"  # SIGKILL poll 2: pane still present
   fi
@@ -2272,7 +2254,7 @@ test_kill_emptying_non_focused_uses_pane_death() {
   printf '%s\n' '{"result":{"panes":[{"pane_id":"w2:p2","tab_id":"w2:t2"}]}}' > "$resp/5.out"
   cp "$resp/1.out" "$resp/6.out"
   sleep 300 & bgpid=$!
-  death_process_info_fixture w2:p2 "$bgpid" > "$resp/7.out"
+  herdr_bare_shell_process_info w2:p2 "$bgpid" > "$resp/7.out"
   printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/8.out"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true}]}}' > "$resp/9.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/10.out"
@@ -3208,10 +3190,10 @@ test_busy_state_stale_registration_is_not_busy() {
   sleep 300 &
   # shellcheck disable=SC2031 # the & runs in THIS shell; the adapter's own backgrounded server launch is what ShellCheck saw
   bgpid=$!
-  stale=$(busy_state_case "$dir/husk" w1:p2 working "$(bare_shell_inventory w1:p2 "$bgpid")")
+  stale=$(busy_state_case "$dir/husk" w1:p2 working "$(herdr_bare_shell_process_info w1:p2 "$bgpid")")
   # The IDENTICAL working reading, with a live harness process in the pane.
   live=$(busy_state_case "$dir/live" w1:p2 working \
-    "$(process_info_fixture w1:p2 "$bgpid" 4242 '[{"pid":4242,"name":"node","argv0":"pi"}]')")
+    "$(herdr_live_process_info w1:p2 "$bgpid")")
   kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
   [ "$stale" = unknown ] \
     || fail "a working registration whose pane holds only a bare idle shell must not read busy, got '$stale'"
@@ -3229,10 +3211,10 @@ test_busy_state_keeps_busy_when_the_inventory_proves_nothing() {
   # An idle shell transiently hosting a prompt helper: two foreground
   # processes, so nothing is proved and the busy verdict stands.
   ambiguous=$(busy_state_case "$dir/ambiguous" w1:p2 working \
-    "$(process_info_fixture w1:p2 "$bgpid" "$bgpid" \
+    "$(herdr_process_info w1:p2 "$bgpid" "$bgpid" \
       "$(printf '[{"pid":99998,"name":"starship","argv0":"starship"},{"pid":%s,"name":"zsh","argv0":"zsh"}]' "$bgpid")")")
   unreadable=$(busy_state_case "$dir/unreadable" w1:p2 working)
-  other=$(busy_state_case "$dir/other-pane" w1:p2 working "$(bare_shell_inventory w9:p9 "$bgpid")")
+  other=$(busy_state_case "$dir/other-pane" w1:p2 working "$(herdr_bare_shell_process_info w9:p9 "$bgpid")")
   kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
   [ "$ambiguous" = busy ] || fail "an extra foreground process proves nothing and must leave busy standing, got '$ambiguous'"
   [ "$unreadable" = busy ] || fail "an unreadable inventory must leave busy standing, got '$unreadable'"
@@ -3258,7 +3240,7 @@ test_busy_state_keeps_busy_for_a_shell_with_a_child() {
     kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
     fail "ps never reported a child of the backgrounded shell $bgpid, so this case cannot exercise a shell that is running something"
   fi
-  child=$(busy_state_case "$dir" w1:p2 working "$(bare_shell_inventory w1:p2 "$bgpid")")
+  child=$(busy_state_case "$dir" w1:p2 working "$(herdr_bare_shell_process_info w1:p2 "$bgpid")")
   kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
   [ "$child" = busy ] || fail "a shell with a child of its own is not idle and must leave busy standing, got '$child'"
   pass "fm_backend_herdr_busy_state: a shell running a child of its own never proves an agent-free pane, so its busy verdict stands"

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -11,8 +11,8 @@
 # footer text. All hermetic over temp dirs; no real agent session is invoked.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-busy-lib.sh"
@@ -397,6 +397,45 @@ test_herdr_native_busy_only() {
   pass "herdr's native verdict is trusted for busy only, and records outrank it"
 }
 
+# The herdr-native fallthrough is the ONLY place a record-free herdr task can
+# still read busy, and herdr's registry is written by whatever reports into it:
+# a report is not withdrawn when the process that made it goes away, so a
+# harness killed mid-turn leaves `agent get` answering `working` forever. That
+# used to suppress this task's stale-pane escalation with no state that could
+# ever clear it. This case drives the REAL herdr adapter over a scripted herdr
+# CLI, so the corroboration itself runs; only the CLI is faked.
+test_herdr_native_busy_requires_a_live_pane() {
+  local state dir fb pid husk live
+  state=$(new_state_dir herdr-native-corroborated)
+  dir="$TMP_ROOT/herdr-native-corroborated"
+  mkdir -p "$dir"
+  fb=$(make_herdr_agent_state_fakebin "$dir")
+  # A real, bare, idle pid with no child of its own: the operating-system half
+  # of the idle-shell proof is answered by the real `ps`, never by a stub.
+  sleep 300 & pid=$!
+  herdr_bare_shell_process_info w1:p2 "$pid" > "$dir/husk.json"
+  herdr_live_process_info w1:p2 "$pid" > "$dir/live.json"
+  husk=$(PATH="$fb:$PATH" FM_FAKE_HERDR_AGENT_STATUS=working \
+    FM_FAKE_HERDR_PROCESS_INFO="$dir/husk.json" \
+    bash -c '. "$0/bin/fm-backend.sh"
+      fm_backend_source herdr >/dev/null || exit 1
+      . "$0/bin/fm-busy-lib.sh"
+      fm_busy_classify herdr fmtest:w1:p2 claude t1 "$1"' "$ROOT" "$state")
+  # The IDENTICAL registered reading, with a real harness process in the pane.
+  live=$(PATH="$fb:$PATH" FM_FAKE_HERDR_AGENT_STATUS=working \
+    FM_FAKE_HERDR_PROCESS_INFO="$dir/live.json" \
+    bash -c '. "$0/bin/fm-backend.sh"
+      fm_backend_source herdr >/dev/null || exit 1
+      . "$0/bin/fm-busy-lib.sh"
+      fm_busy_classify herdr fmtest:w1:p2 claude t1 "$1"' "$ROOT" "$state")
+  kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
+  [ "$husk" = "unknown missing" ] \
+    || fail "a registration whose pane holds only a bare idle shell must not classify 'busy herdr-native', got '$husk'"
+  [ "$live" = "busy herdr-native" ] \
+    || fail "the same registration over a live foreground process must still classify busy, got '$live'"
+  pass "herdr's native busy verdict is trusted only when the pane's own processes do not contradict it, so a registration that outlived its agent stops suppressing stale-pane escalation"
+}
+
 # The record parser runs inside sourcing callers (the watcher, the daemon, the
 # crew-state reader), so it must not disturb their shell: no clobbered
 # positional parameters and no changed glob setting.
@@ -459,6 +498,7 @@ test_kimi_unverified_gate
 test_cursor_ignores_rendered_and_native_signals
 test_dead_endpoint_overrides
 test_herdr_native_busy_only
+test_herdr_native_busy_requires_a_live_pane
 test_record_read_leaves_caller_shell_intact
 test_boolean_view_never_promotes_unknown
 

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -7,11 +7,17 @@
 # agent-state classifier the control plane is allowed to trust, so its
 # behavior is pinned here against the REAL binary rather than a stub: whether
 # an agent is running, and therefore whether a lifecycle verb may act at all,
-# comes from herdr's own agent registry.
+# comes from herdr's own agent registry corroborated against its own process
+# inventory.
 #
-# No real agent is launched. herdr's `pane report-agent` is the same registry
-# the adapter reads, so registering and not registering an agent on a plain
-# shell pane exercises exactly the classification the control plane gates on.
+# The two signals are driven apart deliberately, because a registration alone
+# is not evidence that an agent exists. herdr's `pane report-agent` is the same
+# registry the adapter reads, and a report is not withdrawn when the process
+# that made it goes away, so an identical registered reading is exercised twice
+# over: once on a pane holding nothing but its shell (the worker already
+# exited - agent-free, and eligible for the same-task replacement its operator
+# is trying to launch), and once on a pane genuinely running a foreground
+# process (alive, and a lifecycle verb that cannot stop it must say so).
 #
 # Always runs on a private, named, throwaway lab session, never the default
 # one (tests/herdr-test-safety.sh; the 2026-07-02 incident). Skips cleanly
@@ -71,12 +77,15 @@ $TASK_IDS
 EOF
 [ -n "$TAB_ID" ] && [ -n "$PANE_ID" ] || fail "create_task did not return tab/pane ids"
 
+# harness=pi, the harness of the task this case was written from: its exit
+# command is /quit, which is exactly what a stale classification would type
+# into a shell.
 {
   echo "window=$SESSION:$PANE_ID"
   echo "endpoint_task_id=hsmoke"
   echo "worktree=$WT"
   echo "project=$PROJ"
-  echo "harness=claude"
+  echo "harness=pi"
   echo "kind=ship"
   echo "mode=no-mistakes"
   echo "yolo=off"
@@ -93,6 +102,25 @@ run_control() {
   env FM_HOME="$HOME_DIR" HERDR_SESSION="$SESSION" \
     FM_CONTROL_POLL=0.2 FM_CONTROL_EXIT_WAIT=2 \
     "$ROOT/bin/fm-control.sh" "$@" 2>&1
+}
+
+register_agent() {  # <state>
+  herdr pane report-agent "$PANE_ID" --source fm-control-smoke \
+    --agent fm-control-smoke-agent --state "$1" --session "$SESSION" >/dev/null 2>&1
+}
+
+# The same read the backend's own capture performs
+# (fm_backend_herdr_capture in bin/backends/herdr.sh): --source recent with a
+# generous --lines, because a small bound returns nothing at all. The exit
+# status is propagated so callers can refuse to treat a failed read as evidence
+# that nothing was typed into the pane.
+pane_text() {
+  herdr pane read "$PANE_ID" --session "$SESSION" --source recent --lines 200
+}
+
+registered_status() {
+  herdr agent get "$PANE_ID" --session "$SESSION" 2>/dev/null \
+    | jq -r '.result.agent.agent_status // empty' 2>/dev/null
 }
 
 # --- no registered agent: the endpoint exists but hosts no agent ------------
@@ -113,30 +141,78 @@ case "$OUT" in
 esac
 pass "real herdr: interrupt refuses when herdr's own agent registry reports no agent"
 
-# --- a registered agent: classification flips, and the verbs follow ---------
+# --- a registration the pane's own processes contradict ---------------------
+#
+# The worker exited to its shell and nothing withdrew its report. Trusting the
+# registry alone left the task alive forever, so every replacement attempt
+# typed the harness's exit command into a shell and refused to relaunch.
 
-herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-smoke-agent \
-  --state idle --session "$SESSION" >/dev/null 2>&1 \
-  || fail "could not register a live agent on the task pane"
+register_agent idle || fail "could not leave a registration on the task pane"
+[ -n "$(registered_status)" ] \
+  || fail "herdr did not keep the registration, so this case cannot exercise the contradiction"
 
 STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
-[ "$STATE" = alive ] || fail "herdr should classify a registered agent as alive, got '$STATE'"
+[ "$STATE" = dead ] \
+  || fail "a registration whose pane holds only its shell must classify agent-free, got '$STATE'"
+pass "real herdr: a reported registration the pane's own process inventory contradicts reads agent-free"
+
+OUT=$(run_control hsmoke exit) \
+  || fail "exit should be idempotent success once the pane is proved agent-free: $OUT"
+case "$OUT" in
+  "already-stopped hsmoke"*) : ;;
+  *) fail "an agent-free pane should report already-stopped, got: $OUT" ;;
+esac
+PANE_TEXT=$(pane_text) \
+  || fail "could not read the task pane, so an absent /quit proves nothing about what exit typed into it"
+case "$PANE_TEXT" in
+  *"/quit"*) fail "exit typed the harness's exit command into a pane that hosts a plain shell" ;;
+esac
+pass "real herdr: an exited worker's pane is positively eligible for its replacement instead of being typed into"
+
+if OUT=$(run_control hsmoke interrupt 2>&1); then
+  fail "interrupt should refuse on a pane proved agent-free: $OUT"
+fi
+case "$OUT" in
+  *"nothing to interrupt"*) : ;;
+  *) fail "the interrupt refusal should say there is no agent, got: $OUT" ;;
+esac
+pass "real herdr: interrupt still refuses on a pane whose registration outlived its agent"
+
+# --- the same registration over a genuinely running process ----------------
+#
+# The identical registered reading, with a real non-shell foreground process
+# in the pane. Nothing here may be reclassified as recoverable.
+
+fm_backend_herdr_send_text_line "$SESSION:$PANE_ID" 'sleep 600' \
+  || fail "could not start a foreground process in the task pane"
+ATTEMPT=0
+while [ "$ATTEMPT" -lt 100 ]; do
+  case "$(herdr pane process-info --pane "$PANE_ID" --session "$SESSION" 2>/dev/null \
+    | jq -r '[.result.process_info.foreground_processes[]?.name] | join(",")' 2>/dev/null)" in
+    *sleep*) break ;;
+  esac
+  sleep 0.1
+  ATTEMPT=$((ATTEMPT + 1))
+done
+[ "$ATTEMPT" -lt 100 ] || fail "the foreground process never appeared in herdr's process inventory"
+register_agent idle || fail "could not register an agent over the running process"
+
+STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
+[ "$STATE" = alive ] \
+  || fail "a registration over a genuinely running foreground process must stay alive, got '$STATE'"
+pass "real herdr: the same registration over a running foreground process stays alive"
 
 OUT=$(run_control hsmoke interrupt) || fail "interrupt against a registered agent should succeed: $OUT"
 case "$OUT" in
-  *"interrupt-delivered hsmoke harness=claude backend=herdr verified=agent-alive cancel=unconfirmed"*) : ;;
+  *"interrupt-delivered hsmoke harness=pi backend=herdr verified=agent-alive cancel=unconfirmed"*) : ;;
   *) fail "interrupt should report the agent-alive proof on herdr, got: $OUT" ;;
 esac
 pass "real herdr: interrupt delivers the harness's key and proves the agent survived it"
 
-herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
-  || fail "the control plane must never remove the endpoint it was operating on"
-[ -d "$WT" ] || fail "the control plane must never remove the task's local copy"
-pass "real herdr: no control verb removed the endpoint or the task's local copy"
-
-# Last, because it deliberately types a harness command into a pane that hosts
-# a plain shell: the registered agent cannot actually be stopped that way, and
-# the control plane must say so rather than report a stop it did not achieve.
+# Last, because it deliberately types a harness command into a pane whose
+# foreground process cannot act on it: the agent cannot be stopped that way,
+# and the control plane must say so rather than report a stop it did not
+# achieve.
 if OUT=$(run_control hsmoke exit 2>&1); then
   fail "exit should fail closed when the agent does not stop: $OUT"
 fi
@@ -145,5 +221,12 @@ case "$OUT" in
   *) fail "the exit failure should say the agent did not stop, got: $OUT" ;;
 esac
 pass "real herdr: an agent that does not stop fails closed instead of being reported as stopped"
+
+herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
+  || fail "the control plane must never remove the endpoint it was operating on"
+[ -d "$WT" ] || fail "the control plane must never remove the task's local copy"
+git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null | grep -qx hsmoke \
+  || fail "the control plane must never move the task's branch"
+pass "real herdr: no control verb removed the endpoint, the task's local copy, or its branch"
 
 fm_backend_herdr_kill "$SESSION:$PANE_ID" 2>/dev/null || true

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -176,6 +176,13 @@ register_agent idle || fail "could not leave a registration on the task pane"
 STATE=$(wait_agent_state dead)
 [ "$STATE" = dead ] \
   || fail "a registration whose pane holds only its shell must classify agent-free within the settle window, got '$STATE'"
+# The classifier reaches agent-free by two independent grounds, and only the
+# process-inventory contradiction is this case's subject. herdr has been seen to
+# drop a bare registration mid-test, which would settle the verdict through
+# `agent get` answering agent_not_found instead and let this case pass without
+# ever consulting the corroboration.
+[ -n "$(registered_status)" ] \
+  || fail "herdr dropped the registration during the settle window, so the agent-free verdict came from an absent registration rather than from the process inventory contradicting a present one"
 pass "real herdr: a reported registration the pane's own process inventory contradicts reads agent-free"
 
 OUT=$(run_control hsmoke exit) \

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -123,6 +123,28 @@ registered_status() {
     | jq -r '.result.agent.agent_status // empty' 2>/dev/null
 }
 
+# wait_agent_state: poll the recovery-grade verdict for <want> across a bounded
+# settle window and echo the last verdict observed.
+#
+# The classifier settles its NEGATIVE verdict from one strict instantaneous
+# sample of the pane's process inventory, and an idle interactive shell
+# transiently hosts short-lived prompt helpers (a zsh prompt redraw spawning
+# starship as a second foreground process), so a single sample can legitimately
+# still read `alive` while one is in flight. That is the documented contract in
+# bin/backends/herdr.sh and docs/herdr-backend.md, and every production caller
+# that acts on the negative verdict polls, so this case polls too. It still
+# fails when the pane never reaches the verdict at all.
+wait_agent_state() {  # <want>
+  local want=$1 attempt=0 state=
+  while [ "$attempt" -lt 100 ]; do
+    state=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
+    [ "$state" = "$want" ] && break
+    sleep 0.1
+    attempt=$((attempt + 1))
+  done
+  printf '%s' "$state"
+}
+
 # --- no registered agent: the endpoint exists but hosts no agent ------------
 
 OUT=$(run_control hsmoke exit) || fail "exit against an agent-free herdr pane should be idempotent success: $OUT"
@@ -151,9 +173,9 @@ register_agent idle || fail "could not leave a registration on the task pane"
 [ -n "$(registered_status)" ] \
   || fail "herdr did not keep the registration, so this case cannot exercise the contradiction"
 
-STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
+STATE=$(wait_agent_state dead)
 [ "$STATE" = dead ] \
-  || fail "a registration whose pane holds only its shell must classify agent-free, got '$STATE'"
+  || fail "a registration whose pane holds only its shell must classify agent-free within the settle window, got '$STATE'"
 pass "real herdr: a reported registration the pane's own process inventory contradicts reads agent-free"
 
 OUT=$(run_control hsmoke exit) \

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -455,6 +455,85 @@ test_relaunch_requires_a_note_for_a_ship_task() {
   pass "fm-control relaunch: a ship task refuses without the progress note its replacement needs"
 }
 
+# --- 1b. an agent that already exited to its shell ---------------------------
+#
+# The endpoint outlives the agent: a worker that exits leaves its shell sitting
+# in the task's local copy. That endpoint is positively agent-free, so the
+# replacement its operator is asking for must launch, and nothing may be typed
+# at the shell on the way there. Durable busy evidence from the incarnation
+# that ended is stale by definition and must not resurrect an interrupt.
+
+test_relaunch_over_an_exited_shell_stops_nothing_and_launches() {
+  local dir out rc gen head_before
+  dir=$(new_case exited rl40)
+  add_ship_task "$dir" rl40 claude
+  # The worker exited: the endpoint is a plain shell, not the harness.
+  printf 'zsh' > "$dir/fake/command"
+  # Its last busy report never got a settling counterpart, so the durable
+  # record still says busy long after the process producing it went away.
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$dir/home/state" rl40)
+  printf 'busy_gen=%s\n' "$gen" >> "$dir/home/state/rl40.meta"
+  "$ROOT/bin/fm-busy-event.sh" apply "$dir/home/state" rl40 busy \
+    --gen "$gen" --source pi-ext --event agent-start >/dev/null
+  # Real uncommitted work the replacement must inherit untouched.
+  printf 'half-finished\n' > "$dir/wt/scratch.txt"
+  head_before=$(git -C "$dir/wt" rev-parse HEAD)
+
+  out=$(run_control "$dir" rl40 relaunch --note "prior worker exited after the PR went green"); rc=$?
+  expect_code 0 "$rc" "a relaunch over an exited shell should launch the replacement"$'\n'"$out"
+  assert_contains "$out" "relaunched rl40" "the outcome should name the completed transition"
+  [ "$(journal_field "$dir" rl40 exit_result)" = already-stopped ] \
+    || fail "an already-exited agent should be recorded as already-stopped, not stopped"
+  # The keys log also carries the replacement launch's own input, so pin the
+  # interrupt key itself rather than emptiness.
+  case "$(cat "$dir/fake/keys")" in
+    *Escape*) fail "stale busy evidence must not deliver an interrupt key into a pane with no agent" ;;
+  esac
+  # Whole-line matches: the launch literal legitimately carries paths.
+  if grep -qxE '/(exit|quit)' "$dir/fake/literal"; then
+    fail "an already-exited agent must not be sent the harness's exit command"
+  fi
+  [ "$(git -C "$dir/wt" rev-parse HEAD)" = "$head_before" ] \
+    || fail "relaunch must not move the task's branch"
+  [ "$(git -C "$dir/wt" rev-parse --abbrev-ref HEAD)" = "task-rl40" ] \
+    || fail "relaunch must not change the task's branch identity"
+  [ "$(cat "$dir/wt/scratch.txt")" = half-finished ] \
+    || fail "relaunch must leave every uncommitted change exactly as the previous worker left it"
+  [ "$(journal_field "$dir" rl40 worktree_dirty)" = yes ] \
+    || fail "the checkpoint should record that there was uncommitted work to preserve"
+  [ "$(journal_field "$dir" rl40 worktree_head)" = "$head_before" ] \
+    || fail "the checkpoint should record the exact head it preserved"
+  assert_grep "prior worker exited after the PR went green" "$dir/home/data/rl40/brief.md" \
+    "the replacement must be told what happened"
+  pass "fm-control relaunch: an endpoint whose agent already exited is replaced without an interrupt, without the exit command, and without touching the branch or its uncommitted work"
+}
+
+test_relaunch_over_an_exited_shell_preserves_work_when_the_launch_fails() {
+  local dir out rc head_before
+  dir=$(new_case exitedfail rl41)
+  add_ship_task "$dir" rl41 claude
+  printf 'zsh' > "$dir/fake/command"
+  # The replacement never comes up: `becomes` leaves the endpoint a shell.
+  printf 'zsh' > "$dir/fake/becomes"
+  printf 'half-finished\n' > "$dir/wt/scratch.txt"
+  head_before=$(git -C "$dir/wt" rev-parse HEAD)
+
+  out=$(run_control "$dir" rl41 relaunch --note "prior worker exited"); rc=$?
+  expect_code 1 "$rc" "a replacement that never comes up must fail loudly"
+  assert_contains "$out" "did not come up" "the failure should name the missing replacement"
+  [ "$(meta_field "$dir" rl41 harness)" = claude ] \
+    || fail "a failed launch must leave the durable record naming a harness, not a half-transition"
+  [ "$(git -C "$dir/wt" rev-parse HEAD)" = "$head_before" ] \
+    || fail "a failed relaunch must not move the task's branch"
+  [ "$(git -C "$dir/wt" rev-parse --abbrev-ref HEAD)" = "task-rl41" ] \
+    || fail "a failed relaunch must not change the task's branch identity"
+  [ "$(cat "$dir/wt/scratch.txt")" = half-finished ] \
+    || fail "a failed relaunch must still preserve every uncommitted change"
+  assert_grep "prior worker exited" "$dir/home/state/rl41.control-relaunch.note" \
+    "the progress note must survive a failed relaunch for the next recovery"
+  pass "fm-control relaunch: a replacement that never comes up still preserves the branch, the uncommitted work, and the progress note"
+}
+
 # --- 2. harness switch -------------------------------------------------------
 
 test_harness_switch_moves_the_record_and_clears_prior_wiring() {
@@ -1483,6 +1562,8 @@ test_relaunch_serializes_concurrent_durable_metadata_publication
 test_disabled_relaunch_clears_prior_trace_context
 test_relaunch_appends_the_progress_note_to_the_instructions
 test_relaunch_requires_a_note_for_a_ship_task
+test_relaunch_over_an_exited_shell_stops_nothing_and_launches
+test_relaunch_over_an_exited_shell_preserves_work_when_the_launch_fails
 test_harness_switch_moves_the_record_and_clears_prior_wiring
 test_harness_switch_does_not_carry_the_old_profile_axes
 test_harness_switch_resolves_a_prefixed_recorded_harness

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -9,6 +9,8 @@ set -u
 
 # shellcheck source=tests/wake-helpers.sh
 . "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 DAEMON="$ROOT/bin/fm-supervise-daemon.sh"
 AFK_START="$ROOT/bin/fm-afk-start.sh"
@@ -2466,7 +2468,9 @@ test_pane_is_busy_herdr_native_busy_state() {
 
 test_primary_busy_guard_is_harness_scoped() {
   (
+    # shellcheck disable=SC2329 # invoked indirectly through pane_is_busy
     fm_backend_busy_state() { printf 'unknown'; }
+    # shellcheck disable=SC2329 # invoked indirectly through pane_is_busy
     fm_backend_capture() { printf 'esc interrupt\n'; }
     if FM_DAEMON_PRIMARY_HARNESS=claude pane_is_busy "default:w1:p2" herdr; then
       fail "OpenCode's rendered signature must not classify a Claude primary busy"
@@ -2476,6 +2480,38 @@ test_primary_busy_guard_is_harness_scoped() {
   ) || fail "harness-scoped primary busy guard subshell failed"
   pass "primary busy guard isolates rendered signatures by detected harness"
 }
+
+# A herdr registration is not withdrawn when the process that made it goes
+# away, so a harness killed mid-turn keeps `agent get` answering `working`
+# forever. Away-mode injection defers while the pane reads busy, so that stale
+# report used to defer every escalation for good. Driven through the REAL herdr
+# adapter over a scripted herdr CLI: only the CLI is faked, so the adapter's own
+# corroboration is what decides here.
+test_pane_is_busy_herdr_registration_outlived_its_agent() {
+  local dir fb pid
+  dir=$(make_supercase primary-herdr-stale-registration)
+  fb=$(make_herdr_agent_state_fakebin "$dir")
+  sleep 300 & pid=$!
+  herdr_bare_shell_process_info w1:p2 "$pid" > "$dir/husk.json"
+  herdr_live_process_info w1:p2 "$pid" > "$dir/live.json"
+  # A bare shell prompt, so the rendered fallback cannot rescue the verdict
+  # either: not busy here has to mean the pane really is not busy.
+  printf 'wt %% \n' > "$dir/pane.txt"
+  (
+    if PATH="$fb:$PATH" FM_FAKE_HERDR_AGENT_STATUS=working \
+      FM_FAKE_HERDR_PROCESS_INFO="$dir/husk.json" FM_FAKE_HERDR_PANE_READ="$dir/pane.txt" \
+      FM_DAEMON_PRIMARY_HARNESS=claude pane_is_busy "fmtest:w1:p2" herdr; then
+      fail "a herdr registration whose pane holds only a bare idle shell must not defer injection as busy"
+    fi
+    PATH="$fb:$PATH" FM_FAKE_HERDR_AGENT_STATUS=working \
+      FM_FAKE_HERDR_PROCESS_INFO="$dir/live.json" FM_FAKE_HERDR_PANE_READ="$dir/pane.txt" \
+      FM_DAEMON_PRIMARY_HARNESS=claude pane_is_busy "fmtest:w1:p2" herdr \
+      || fail "the same registration over a live foreground process must still read busy"
+  ) || { kill "$pid" 2>/dev/null; fail "herdr stale-registration pane_is_busy subshell failed"; }
+  kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
+  pass "pane_is_busy: a herdr registration the pane's own processes contradict stops deferring away-mode injection, while the same registration over a live process still defers"
+}
+
 
 test_pane_is_busy_defaults_to_tmux_when_backend_omitted() {
   local dir fakebin capture
@@ -2729,6 +2765,7 @@ test_fm_send_exits_nonzero_on_unproven_submit
 test_discover_supervisor_backend_precedence
 test_discover_supervisor_target_herdr
 test_pane_is_busy_herdr_native_busy_state
+test_pane_is_busy_herdr_registration_outlived_its_agent
 test_primary_busy_guard_is_harness_scoped
 test_pane_is_busy_defaults_to_tmux_when_backend_omitted
 test_pane_input_pending_herdr_dispatch

--- a/tests/fm-harness-liveness-drift-live-e2e.test.sh
+++ b/tests/fm-harness-liveness-drift-live-e2e.test.sh
@@ -60,8 +60,8 @@ export PATH
 . "$ROOT/bin/fm-cursor-lib.sh"
 # The single resolver both real-harness drift guards launch through, so neither
 # can measure a different binary than the other or than a real spawn.
-# shellcheck source=tests/harness-binary.sh
-. "$ROOT/tests/harness-binary.sh"
+# shellcheck source=tests/harness-binary-helpers.sh
+. "$ROOT/tests/harness-binary-helpers.sh"
 fm_backend_source tmux || fail "fm_backend_source tmux failed"
 
 "$REAL_TMUX" -L "$SOCKET" new-session -d -s "$SESSION" -n control -c "$LAB/wt" \

--- a/tests/fm-harness-liveness-drift-live-e2e.test.sh
+++ b/tests/fm-harness-liveness-drift-live-e2e.test.sh
@@ -58,35 +58,14 @@ export PATH
 . "$ROOT/bin/fm-backend.sh"
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-cursor-lib.sh"
+# The single resolver both real-harness drift guards launch through, so neither
+# can measure a different binary than the other or than a real spawn.
+# shellcheck source=tests/harness-binary.sh
+. "$ROOT/tests/harness-binary.sh"
 fm_backend_source tmux || fail "fm_backend_source tmux failed"
 
 "$REAL_TMUX" -L "$SOCKET" new-session -d -s "$SESSION" -n control -c "$LAB/wt" \
   || fail "could not start the private tmux server"
-
-# Kimi is not required to be on PATH; mirror bin/fm-spawn.sh's own resolution
-# order so this guard covers the same binary firstmate would actually launch.
-resolve_harness_binary() {  # <harness>
-  local harness=$1 candidate
-  candidate=$(command -v "$harness" 2>/dev/null || true)
-  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
-    printf '%s\n' "$candidate"
-    return 0
-  fi
-  if [ "$harness" = kimi ] && [ -n "${HOME:-}" ] && [ -x "$HOME/.kimi-code/bin/kimi" ]; then
-    printf '%s\n' "$HOME/.kimi-code/bin/kimi"
-    return 0
-  fi
-  # cursor is never on PATH under the name `cursor`: it installs as
-  # `cursor-agent` plus the legacy alias `agent`, and its user-local install is
-  # routinely absent from a non-interactive PATH. Resolve it through the same
-  # verified owner fm-spawn uses, so an unrelated executable named `agent` is
-  # rejected here exactly as it would be at launch.
-  if [ "$harness" = cursor ]; then
-    fm_cursor_resolve_binary 2>/dev/null && return 0
-    return 1
-  fi
-  return 1
-}
 
 CHECKED=0
 SKIPPED=
@@ -101,7 +80,7 @@ SKIPPED=
 # runs as a bundled node script, so its pane title is a bare `node` that no name
 # pattern can own, and identity has to come from its install path or argv[0].
 for harness in claude codex opencode pi pi-signed grok kimi cursor muse; do
-  if ! bin_path=$(resolve_harness_binary "$harness"); then
+  if ! bin_path=$(fm_test_resolve_harness_binary "$harness"); then
     SKIPPED="$SKIPPED $harness"
     note "skip: $harness is not installed on this machine, so its classification is unverified here"
     continue

--- a/tests/fm-herdr-agent-free-proof-live-e2e.test.sh
+++ b/tests/fm-herdr-agent-free-proof-live-e2e.test.sh
@@ -68,8 +68,8 @@ mkdir -p "$LAB/wt"
 . "$ROOT/bin/fm-cursor-lib.sh"
 # The single resolver both real-harness drift guards launch through, so neither
 # can measure a different binary than the other or than a real spawn.
-# shellcheck source=tests/harness-binary.sh
-. "$ROOT/tests/harness-binary.sh"
+# shellcheck source=tests/harness-binary-helpers.sh
+. "$ROOT/tests/harness-binary-helpers.sh"
 fm_backend_source herdr || fail "fm_backend_source herdr failed"
 
 CONTAINER_RAW=$(fm_backend_herdr_container_ensure "$LAB/wt") || fail "container_ensure failed"
@@ -86,14 +86,24 @@ foreground_names() {  # <pane>
     | jq -r '[.result.process_info.foreground_processes[]? | "\(.name)/\(.argv0 // .argv[0] // "")"] | join(" ")' 2>/dev/null
 }
 
-foreground_pids() {  # <pane>
-  fm_backend_herdr_cli "$SESSION" pane process-info --pane "$1" 2>/dev/null \
-    | jq -r '.result.process_info.foreground_processes[]?.pid | select(type == "number") | floor' 2>/dev/null
-}
-
-pane_shell_pid() {  # <pane>
-  fm_backend_herdr_cli "$SESSION" pane process-info --pane "$1" 2>/dev/null \
-    | jq -r '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null
+# pane_process_info: ONE `pane process-info` read for <pane>, echoed raw.
+#
+# Returns 1 when herdr did not answer, answered something this guard cannot
+# parse, or answered about a different pane. Cleanup has to tell "herdr says
+# the pane holds only its shell" apart from "herdr did not say", so readability
+# is a separate outcome here rather than an empty result that reads like an
+# empty inventory.
+pane_process_info() {  # <pane>
+  local info
+  info=$(fm_backend_herdr_cli "$SESSION" pane process-info --pane "$1" 2>/dev/null) || return 1
+  printf '%s' "$info" | jq -e --arg pane "$1" '
+    .result.type == "pane_process_info"
+    and .result.process_info.pane_id == $pane
+    and (.result.process_info.shell_pid | type) == "number"
+    and .result.process_info.shell_pid > 1
+    and (.result.process_info.foreground_processes | type) == "array"
+  ' >/dev/null 2>&1 || return 1
+  printf '%s' "$info"
 }
 
 # harness_pids: every foreground pid in <pane> EXCEPT the pane's own shell.
@@ -107,13 +117,16 @@ pane_shell_pid() {  # <pane>
 # from destroying the lab and turning every remaining verdict into "could not
 # create a lab tab".
 #
-# An inventory that cannot be read names no shell, so nothing is signalled: this
-# never guesses which pid is safe to kill.
+# Exit 0 with no pids is a POSITIVE reading that the pane holds nothing but its
+# shell. Exit 2 means the inventory could not be read at all, which is not the
+# same thing and must never be reported as a clean pane; one read backs both, so
+# the shell and the foreground list can never come from different samples.
 harness_pids() {  # <pane>
-  local shell_pid pid
-  shell_pid=$(pane_shell_pid "$1")
-  [ -n "$shell_pid" ] || return 0
-  for pid in $(foreground_pids "$1"); do
+  local info shell_pid pid
+  info=$(pane_process_info "$1") || return 2
+  shell_pid=$(printf '%s' "$info" | jq -r '.result.process_info.shell_pid | floor')
+  for pid in $(printf '%s' "$info" \
+    | jq -r '.result.process_info.foreground_processes[]?.pid | select(type == "number") | floor'); do
     [ "$pid" = "$shell_pid" ] && continue
     printf '%s\n' "$pid"
   done
@@ -123,21 +136,26 @@ harness_pids() {  # <pane>
 # leaving the pane, its shell, and its tab in place. Closing the pane instead
 # would remove the workspace's last tab and destroy the container the next
 # harness needs.
+#
+# Every outcome except a proven-clean pane fails loudly: an unreadable
+# inventory, and a foreground this guard could not clear, both leave the next
+# harness measured in a pane whose state is unknown.
 end_harness() {  # <harness> <pane>
-  local pid
-  for pid in $(harness_pids "$2"); do
-    kill -TERM "$pid" 2>/dev/null || true
-  done
-  for _ in $(seq 1 100); do
-    [ -z "$(harness_pids "$2")" ] && return 0
-    sleep 0.1
-  done
-  for pid in $(harness_pids "$2"); do
-    kill -KILL "$pid" 2>/dev/null || true
-  done
-  for _ in $(seq 1 50); do
-    [ -z "$(harness_pids "$2")" ] && return 0
-    sleep 0.1
+  local pid pids rc signal unreadable
+  unreadable="$1: herdr's pane process-info for $2 could not be read or parsed during cleanup, so this pane cannot be reported clean and the harness this guard launched may still be running"
+  for signal in TERM KILL; do
+    pids=$(harness_pids "$2"); rc=$?
+    [ "$rc" -eq 0 ] || fail "$unreadable"
+    [ -n "$pids" ] || return 0
+    for pid in $pids; do
+      kill -"$signal" "$pid" 2>/dev/null || true
+    done
+    for _ in $(seq 1 100); do
+      pids=$(harness_pids "$2"); rc=$?
+      [ "$rc" -eq 0 ] || fail "$unreadable"
+      [ -n "$pids" ] || return 0
+      sleep 0.1
+    done
   done
   fail "$1: could not clear the lab pane's foreground after TERM and KILL (still [$(foreground_names "$2")]), so the next harness would be measured in a pane that is not clean"
 }

--- a/tests/fm-herdr-agent-free-proof-live-e2e.test.sh
+++ b/tests/fm-herdr-agent-free-proof-live-e2e.test.sh
@@ -66,6 +66,10 @@ mkdir -p "$LAB/wt"
 . "$ROOT/bin/fm-backend.sh"
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-cursor-lib.sh"
+# The single resolver both real-harness drift guards launch through, so neither
+# can measure a different binary than the other or than a real spawn.
+# shellcheck source=tests/harness-binary.sh
+. "$ROOT/tests/harness-binary.sh"
 fm_backend_source herdr || fail "fm_backend_source herdr failed"
 
 CONTAINER_RAW=$(fm_backend_herdr_container_ensure "$LAB/wt") || fail "container_ensure failed"
@@ -77,32 +81,6 @@ HERDR_VERSION=$(herdr --version 2>/dev/null | head -1 | tr -d '\r')
 [ -n "$HERDR_VERSION" ] || HERDR_VERSION=unknown
 note "herdr: $HERDR_VERSION"
 
-# Mirror bin/fm-spawn.sh's own binary resolution, so this guard covers the same
-# binary firstmate would actually launch.
-resolve_harness_binary() {  # <harness>
-  local harness=$1 candidate
-  # cursor first, and never through a bare PATH lookup: it installs as
-  # `cursor-agent` plus the legacy alias `agent`, while an unrelated `cursor`
-  # on PATH is routinely the editor launcher rather than the agent (observed on
-  # a developer machine, where it answered a `--trust` launch with an Electron
-  # warning and exited). fm_cursor_resolve_binary is the verified owner
-  # fm-spawn itself uses, so this guard launches exactly what firstmate would.
-  if [ "$harness" = cursor ]; then
-    fm_cursor_resolve_binary 2>/dev/null && return 0
-    return 1
-  fi
-  candidate=$(command -v "$harness" 2>/dev/null || true)
-  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
-    printf '%s\n' "$candidate"
-    return 0
-  fi
-  if [ "$harness" = kimi ] && [ -n "${HOME:-}" ] && [ -x "$HOME/.kimi-code/bin/kimi" ]; then
-    printf '%s\n' "$HOME/.kimi-code/bin/kimi"
-    return 0
-  fi
-  return 1
-}
-
 foreground_names() {  # <pane>
   fm_backend_herdr_cli "$SESSION" pane process-info --pane "$1" 2>/dev/null \
     | jq -r '[.result.process_info.foreground_processes[]? | "\(.name)/\(.argv0 // .argv[0] // "")"] | join(" ")' 2>/dev/null
@@ -113,23 +91,55 @@ foreground_pids() {  # <pane>
     | jq -r '.result.process_info.foreground_processes[]?.pid | select(type == "number") | floor' 2>/dev/null
 }
 
-# end_harness: stop only the exact processes this guard launched into the pane,
-# leaving the pane and its tab in place. Closing the pane instead would remove
-# the workspace's last tab and destroy the container the next harness needs.
-end_harness() {  # <pane>
-  local pid
+pane_shell_pid() {  # <pane>
+  fm_backend_herdr_cli "$SESSION" pane process-info --pane "$1" 2>/dev/null \
+    | jq -r '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null
+}
+
+# harness_pids: every foreground pid in <pane> EXCEPT the pane's own shell.
+#
+# The shell is the process herdr runs the pane on, so signalling it makes herdr
+# reap the pane, which removes its tab and - for the first harness, whose tab is
+# the workspace's only one after the seeded-tab prune - the container every
+# later harness needs. A harness that exits during the registration wait (a
+# failed auth, a declined trust prompt, a crash) leaves that shell as the pane's
+# SOLE foreground process, so excluding it is what keeps a per-harness failure
+# from destroying the lab and turning every remaining verdict into "could not
+# create a lab tab".
+#
+# An inventory that cannot be read names no shell, so nothing is signalled: this
+# never guesses which pid is safe to kill.
+harness_pids() {  # <pane>
+  local shell_pid pid
+  shell_pid=$(pane_shell_pid "$1")
+  [ -n "$shell_pid" ] || return 0
   for pid in $(foreground_pids "$1"); do
+    [ "$pid" = "$shell_pid" ] && continue
+    printf '%s\n' "$pid"
+  done
+}
+
+# end_harness: stop only the exact processes this guard launched into the pane,
+# leaving the pane, its shell, and its tab in place. Closing the pane instead
+# would remove the workspace's last tab and destroy the container the next
+# harness needs.
+end_harness() {  # <harness> <pane>
+  local pid
+  for pid in $(harness_pids "$2"); do
     kill -TERM "$pid" 2>/dev/null || true
   done
   for _ in $(seq 1 100); do
-    case "$(foreground_names "$1")" in
-      ''|*sh/*sh*) return 0 ;;
-    esac
+    [ -z "$(harness_pids "$2")" ] && return 0
     sleep 0.1
   done
-  for pid in $(foreground_pids "$1"); do
+  for pid in $(harness_pids "$2"); do
     kill -KILL "$pid" 2>/dev/null || true
   done
+  for _ in $(seq 1 50); do
+    [ -z "$(harness_pids "$2")" ] && return 0
+    sleep 0.1
+  done
+  fail "$1: could not clear the lab pane's foreground after TERM and KILL (still [$(foreground_names "$2")]), so the next harness would be measured in a pane that is not clean"
 }
 
 CHECKED=0
@@ -138,7 +148,7 @@ SKIPPED=
 # The verified adapters, in the order .agents/skills/harness-adapters/SKILL.md
 # records them. An adapter that gains a verified launch path belongs here too.
 for harness in claude codex opencode pi pi-signed grok kimi cursor muse; do
-  if ! bin_path=$(resolve_harness_binary "$harness"); then
+  if ! bin_path=$(fm_test_resolve_harness_binary "$harness"); then
     SKIPPED="$SKIPPED $harness"
     note "skip: $harness is not installed on this machine, so its Herdr classification is unverified here"
     continue
@@ -205,7 +215,7 @@ EOF
   pass "herdr agent-free proof: $harness $version running in a Herdr pane never proves a bare idle shell"
   CHECKED=$((CHECKED + 1))
 
-  end_harness "$PANE_ID"
+  end_harness "$harness $version" "$PANE_ID"
 done
 
 [ "$CHECKED" -gt 0 ] || fail \

--- a/tests/fm-herdr-agent-free-proof-live-e2e.test.sh
+++ b/tests/fm-herdr-agent-free-proof-live-e2e.test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# tests/fm-herdr-agent-free-proof-live-e2e.test.sh - opt-in drift guard proving
+# no INSTALLED harness, while genuinely running in a Herdr pane, can be
+# mistaken for an agent-free bare idle shell.
+#
+# Why this file exists: the Herdr liveness classifier settles its negative
+# verdict from `pane process-info` - the pane must provably hold one lone bare
+# idle shell before a reported registration is treated as stale
+# (bin/backends/herdr.sh, fm_backend_herdr_pane_agent_state). That proof reads
+# a process name and an argv0 that each harness vendor controls and can change
+# without notice, so a stub can only confirm the assumption already written
+# into the stub. A false agent-free verdict is the one outcome that could
+# launch a replacement onto a live worker's local copy, which is exactly the
+# direction this guard watches.
+#
+# The portable counterpart in tests/fm-backend-herdr.test.sh pins the
+# classifier logic in CI with real processes and no harness, and
+# tests/fm-control-herdr-smoke.test.sh pins the control plane's use of it on
+# the required real-Herdr lane. Run this guard after any harness upgrade and
+# before trusting refreshed per-harness evidence.
+#
+# Each harness is launched bare, with no prompt, so this consumes no model
+# tokens. Standard CI has neither harness binaries nor credentials, so it is
+# opt-in and on-demand.
+#
+# Always runs on a private, named, throwaway lab session, never the default one
+# (tests/herdr-test-safety.sh).
+set -u
+
+if [ "${FM_HERDR_AGENT_FREE_PROOF:-0}" != 1 ]; then
+  echo "skip: set FM_HERDR_AGENT_FREE_PROOF=1 to run the installed-harness Herdr agent-free proof guard"
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
+pass() { printf 'ok - %s\n' "$1"; }
+note() { printf '# %s\n' "$1"; }
+
+command -v herdr >/dev/null 2>&1 || fail "herdr not found"
+command -v jq >/dev/null 2>&1 || fail "jq not found (required by the herdr adapter)"
+
+# shellcheck source=tests/herdr-test-safety.sh
+. "$ROOT/tests/herdr-test-safety.sh"
+herdr_forget_inherited_pane
+
+SESSION="fm-lab-agent-free-$$"
+export HERDR_SESSION="$SESSION"
+LAB=
+CLEANED=0
+cleanup_all() {
+  [ "$CLEANED" = 0 ] || return 0
+  CLEANED=1
+  [ -n "$LAB" ] && rm -rf "$LAB"
+  herdr_safe_stop_and_delete "$SESSION"
+}
+trap cleanup_all EXIT
+fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+
+LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-herdr-agent-free.XXXXXX")
+LAB=$(cd "$LAB" && pwd)
+mkdir -p "$LAB/wt"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-backend.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-cursor-lib.sh"
+fm_backend_source herdr || fail "fm_backend_source herdr failed"
+
+CONTAINER_RAW=$(fm_backend_herdr_container_ensure "$LAB/wt") || fail "container_ensure failed"
+CONTAINER=${CONTAINER_RAW%%$'\t'*}
+SEEDED_TAB_ID=${CONTAINER_RAW#*$'\t'}
+WORKSPACE_ID=${CONTAINER#*:}
+
+HERDR_VERSION=$(herdr --version 2>/dev/null | head -1 | tr -d '\r')
+[ -n "$HERDR_VERSION" ] || HERDR_VERSION=unknown
+note "herdr: $HERDR_VERSION"
+
+# Mirror bin/fm-spawn.sh's own binary resolution, so this guard covers the same
+# binary firstmate would actually launch.
+resolve_harness_binary() {  # <harness>
+  local harness=$1 candidate
+  # cursor first, and never through a bare PATH lookup: it installs as
+  # `cursor-agent` plus the legacy alias `agent`, while an unrelated `cursor`
+  # on PATH is routinely the editor launcher rather than the agent (observed on
+  # a developer machine, where it answered a `--trust` launch with an Electron
+  # warning and exited). fm_cursor_resolve_binary is the verified owner
+  # fm-spawn itself uses, so this guard launches exactly what firstmate would.
+  if [ "$harness" = cursor ]; then
+    fm_cursor_resolve_binary 2>/dev/null && return 0
+    return 1
+  fi
+  candidate=$(command -v "$harness" 2>/dev/null || true)
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+  if [ "$harness" = kimi ] && [ -n "${HOME:-}" ] && [ -x "$HOME/.kimi-code/bin/kimi" ]; then
+    printf '%s\n' "$HOME/.kimi-code/bin/kimi"
+    return 0
+  fi
+  return 1
+}
+
+foreground_names() {  # <pane>
+  fm_backend_herdr_cli "$SESSION" pane process-info --pane "$1" 2>/dev/null \
+    | jq -r '[.result.process_info.foreground_processes[]? | "\(.name)/\(.argv0 // .argv[0] // "")"] | join(" ")' 2>/dev/null
+}
+
+foreground_pids() {  # <pane>
+  fm_backend_herdr_cli "$SESSION" pane process-info --pane "$1" 2>/dev/null \
+    | jq -r '.result.process_info.foreground_processes[]?.pid | select(type == "number") | floor' 2>/dev/null
+}
+
+# end_harness: stop only the exact processes this guard launched into the pane,
+# leaving the pane and its tab in place. Closing the pane instead would remove
+# the workspace's last tab and destroy the container the next harness needs.
+end_harness() {  # <pane>
+  local pid
+  for pid in $(foreground_pids "$1"); do
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  for _ in $(seq 1 100); do
+    case "$(foreground_names "$1")" in
+      ''|*sh/*sh*) return 0 ;;
+    esac
+    sleep 0.1
+  done
+  for pid in $(foreground_pids "$1"); do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+}
+
+CHECKED=0
+SKIPPED=
+
+# The verified adapters, in the order .agents/skills/harness-adapters/SKILL.md
+# records them. An adapter that gains a verified launch path belongs here too.
+for harness in claude codex opencode pi pi-signed grok kimi cursor muse; do
+  if ! bin_path=$(resolve_harness_binary "$harness"); then
+    SKIPPED="$SKIPPED $harness"
+    note "skip: $harness is not installed on this machine, so its Herdr classification is unverified here"
+    continue
+  fi
+
+  version=$("$bin_path" --version 2>/dev/null | head -1 | tr -d '\r') || version=
+  [ -n "$version" ] || version="unknown"
+
+  TASK_IDS=$(fm_backend_herdr_create_task "$CONTAINER" "fm-afp-$harness" "$LAB/wt" "$SEEDED_TAB_ID") \
+    || fail "$harness ($version): could not create a lab tab"
+  SEEDED_TAB_ID=
+  read -r _TAB_ID PANE_ID <<EOF
+$TASK_IDS
+EOF
+  [ -n "$PANE_ID" ] || fail "$harness ($version): create_task returned no pane id"
+
+  # cursor blocks on a workspace-trust prompt in a directory it has never seen,
+  # which would hang this probe; --trust is the same flag fm-spawn passes.
+  launch=$bin_path
+  [ "$harness" = cursor ] && launch="$bin_path --trust"
+  fm_backend_herdr_send_text_line "$SESSION:$PANE_ID" "$launch" \
+    || fail "$harness ($version): could not launch it in the lab pane"
+
+  # Wait until the harness's OWN executable owns the pane's foreground, so the
+  # proof is read against a genuinely running agent rather than the shell that
+  # launched it or a short-lived prompt helper beside it.
+  bin_base=${bin_path##*/}
+  running=0
+  for _ in $(seq 1 300); do
+    case "$(foreground_names "$PANE_ID")" in
+      *"$bin_base"*) running=1; break ;;
+    esac
+    sleep 0.2
+  done
+  names=$(foreground_names "$PANE_ID")
+  [ "$running" = 1 ] || fail \
+    "$harness $version: '$bin_base' never appeared in the Herdr pane's foreground, so this guard proved nothing about it. Observed foreground name/argv0 pairs [$names]. Pane tail: $(fm_backend_herdr_capture "$SESSION:$PANE_ID" 40 2>/dev/null | tail -5 | tr '\n' '|')"
+
+  if fm_backend_herdr_pane_idle_shell_sample "$SESSION" "$PANE_ID" >/dev/null 2>&1; then
+    fail "AGENT-FREE DRIFT: $harness $version is running in a Herdr pane, but the pane's process inventory proves a lone bare idle shell, so bin/backends/herdr.sh would classify a live worker as agent-free and let a replacement launch onto its local copy. Observed foreground name/argv0 pairs [$names] on herdr $HERDR_VERSION."
+  fi
+
+  # Herdr registers an agent only for the harnesses it ships an integration
+  # for, and that integration reports on its own schedule, so give it a bounded
+  # window before reading the recovery-grade verdict.
+  state=
+  for _ in $(seq 1 100); do
+    state=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
+    [ "$state" = alive ] && break
+    sleep 0.2
+  done
+  case "$state" in
+    alive) ;;
+    dead|missing)
+      # No integration ever registered this pane. That is a pre-existing
+      # property of the registry, not of the process inventory this guard
+      # watches, so it is reported rather than failed.
+      note "$harness $version: herdr registered no agent for this harness within the wait (state '$state'); the agent-free proof still correctly refuses"
+      ;;
+    *) fail "$harness $version: Herdr classified a running harness '$state'; only alive or an unregistered dead/missing is expected" ;;
+  esac
+
+  note "$harness $version: foreground=[$names] state=$state"
+  pass "herdr agent-free proof: $harness $version running in a Herdr pane never proves a bare idle shell"
+  CHECKED=$((CHECKED + 1))
+
+  end_harness "$PANE_ID"
+done
+
+[ "$CHECKED" -gt 0 ] || fail \
+  "no verified harness is installed here, so this run proved nothing; install at least one harness before trusting a pass"
+
+if [ -n "$SKIPPED" ]; then
+  note "unverified on this machine (not installed):$SKIPPED"
+fi
+note "checked $CHECKED installed harness(es) on herdr $HERDR_VERSION in workspace $WORKSPACE_ID"
+
+cleanup_all
+trap - EXIT

--- a/tests/harness-binary-helpers.sh
+++ b/tests/harness-binary-helpers.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# tests/harness-binary.sh - the single harness-binary resolver for the opt-in
+# tests/harness-binary-helpers.sh - the single harness-binary resolver for the opt-in
 # real-harness drift guards.
 #
 # Both guards launch every INSTALLED harness for real and fail naming the

--- a/tests/harness-binary.sh
+++ b/tests/harness-binary.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# tests/harness-binary.sh - the single harness-binary resolver for the opt-in
+# real-harness drift guards.
+#
+# Both guards launch every INSTALLED harness for real and fail naming the
+# harness and version, so both have to launch the SAME binary bin/fm-spawn.sh
+# would launch. Two copies of this resolution diverged once already and made
+# one guard report a drift the other could not see, so the resolution lives
+# here and each guard calls it.
+#
+# Sourcing it requires nothing but the repo root; it pulls in the verified
+# cursor resolver itself when the caller has not already sourced it.
+set -u
+
+FM_TEST_HARNESS_BINARY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if ! command -v fm_cursor_resolve_binary >/dev/null 2>&1; then
+  # shellcheck source=/dev/null
+  . "$FM_TEST_HARNESS_BINARY_DIR/bin/fm-cursor-lib.sh"
+fi
+
+# fm_test_resolve_harness_binary: echo the executable a real launch of
+# <harness> would run, or return 1 when it is not installed here.
+#
+# cursor is resolved FIRST and never through a bare PATH lookup. It installs as
+# `cursor-agent` plus the legacy alias `agent`, its user-local install is
+# routinely absent from a non-interactive PATH, and a `cursor` that IS on PATH
+# is routinely the editor launcher rather than the agent (observed on a
+# developer machine, where it answered a `--trust` launch with an Electron
+# warning and exited, which made the guard report a drift that did not exist).
+# fm_cursor_resolve_binary is the verified owner fm-spawn itself uses, so this
+# both rejects an unrelated executable named `agent` exactly as a real launch
+# would and never mistakes the editor launcher for the agent.
+#
+# kimi is not required to be on PATH: its installer drops a user-local binary,
+# which fm-spawn falls back to and so does this.
+fm_test_resolve_harness_binary() {  # <harness>
+  local harness=$1 candidate
+  if [ "$harness" = cursor ]; then
+    fm_cursor_resolve_binary 2>/dev/null && return 0
+    return 1
+  fi
+  candidate=$(command -v "$harness" 2>/dev/null || true)
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+  if [ "$harness" = kimi ] && [ -n "${HOME:-}" ] && [ -x "$HOME/.kimi-code/bin/kimi" ]; then
+    printf '%s\n' "$HOME/.kimi-code/bin/kimi"
+    return 0
+  fi
+  return 1
+}

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -40,3 +40,27 @@ herdr_refuse_if_default() { # <session>
 herdr_safe_stop_and_delete() { # <session>
   fm_herdr_lab_teardown "$1"
 }
+
+# herdr_pane_run_foreground: give <pane> in <session> a real, long-lived,
+# non-shell foreground process and wait until Herdr's own inventory reports it.
+#
+# A case that means "this pane hosts a genuinely live agent" needs both halves
+# the liveness classifier reads: a registration AND a pane that is actually
+# running something. `pane report-agent` alone leaves a registration standing
+# over a bare idle shell, which is the husk shape, not the live one
+# (docs/herdr-backend.md "Restart and liveness behavior"). Requires the herdr
+# backend adapter to be sourced.
+herdr_pane_run_foreground() {  # <session> <pane> [command]
+  local session=$1 pane=$2 cmd=${3:-sleep 600} attempt=0 names
+  fm_backend_herdr_cli "$session" pane run "$pane" "$cmd" >/dev/null 2>&1 || return 1
+  while [ "$attempt" -lt 200 ]; do
+    names=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null \
+      | jq -r '[.result.process_info.foreground_processes[]?.name] | join(",")' 2>/dev/null)
+    case "$names" in
+      *"${cmd%% *}"*) return 0 ;;
+    esac
+    sleep 0.05
+    attempt=$((attempt + 1))
+  done
+  return 1
+}


### PR DESCRIPTION
## Intent

Fix the safe-relaunch defect reproduced on the task fm-pr-lifecycle-followthrough-monitor: its Pi worker exited cleanly to a zsh shell, and Herdr's process inventory showed no live Pi agent, but two supported `bin/fm-control.sh <task> relaunch` attempts classified the agent as alive, typed `/quit` into zsh, and failed without launching a replacement. The preserved PR branch and existing work had to remain untouched.

Required approach, all of it deliberate:
- Read the executable control owner, the Herdr backend, the Pi busy/session bindings, the agent-control documentation, and the current behavioral tests before choosing the fix.
- Reproduce the disagreement through public control/backend interfaces in a required isolated Herdr lab session (bin/fm-herdr-lab.sh), never the captain's default session.
- Make an agent-free shell positively and safely eligible for same-task relaunch while refusing genuinely live, ambiguous, unreadable, or conflicting ownership.
- Preserve the control plane as the only lifecycle owner: add no raw pane-key, direct Herdr, broad process-kill, or metadata-surgery bypass.
- Preserve uncommitted changes, commits, branch identity, and task records on every success and refusal path.
- Add deterministic behavioral coverage for an exited Pi shell, a live Pi agent, ambiguous process inventory, stale Pi busy/session evidence, failure to stop a genuinely live agent, replacement-launch failure and rollback, and preserved branch/work.
- Review consequences for every supported harness and runtime backend rather than special-casing the current fleet without evidence.
- Keep exact mechanics in the script help/header owner, and update maintained documentation and active verification only where the behavior contract changes.
- Ship through no-mistakes to a green review-ready PR; do not merge.

SCOPE OF THIS BRANCH, decided by the captain. This is a deliberate re-cut replacement for an earlier PR that had bundled unrelated fork work. It carries ONLY the Herdr liveness fix and its tests and documentation, re-based on current upstream/main, with all usage-harvester and crewmate-launch-sandbox changes deliberately excluded and left to their own lanes. Do not reintroduce bin/fm-spawn.sh launch-flag changes, the fleet usage harvester, harness-adapters reference edits, or crewmate-autonomy verification content; their absence is intentional, not an oversight. In particular the stale launch-flag assertions in tests/fm-spawn-dispatch-profile.test.sh, tests/fm-secondmate-harness.test.sh, and tests/fm-backend-orca.test.sh are CORRECT on this base, because this base still ships the older permissive launch flags.

Root cause established empirically, not assumed. Herdr's agent registry is written by whatever reports into it, and a report is not withdrawn when the process that made it goes away, so a registration can outlive the agent it describes. bin/backends/herdr.sh's fm_backend_herdr_pane_agent_state derived `live` from `herdr agent get` alone, with no corroboration, so the endpoint read `alive` forever and every lifecycle verb typed the harness exit command at a shell. Verified on the installed herdr 0.8.2 in an isolated fm-lab- session: a `pane report-agent` from a source herdr does not itself own stays registered on a pane running nothing but zsh (agent get keeps answering idle) while `pane process-info` reports one bare zsh; herdr does validate a report claiming a source it owns, so an otherwise identical --source herdr:pi report on the same pane was rejected. The tmux classifier never had this hole because it settles negative verdicts from the foreground process group.

Chosen design and the tradeoffs behind it:
- The fix is deliberately in the shared classifier fm_backend_herdr_pane_agent_state, not a second Herdr state machine and not a special case inside fm-control.sh. A pane holding a lone bare idle shell is not a running agent, so one classifier keeps fm_backend_agent_state, fm_backend_herdr_tab_is_husk, create-time husk replacement, presentation reclaim, and the watcher all agreeing.
- It reuses the existing single owner of the idle-shell proof (fm_backend_herdr_pane_idle_shell_sample), which the pane-death close path already trusts for a destructive action; reusing it for a non-destructive classification downgrade is strictly weaker.
- One strict instantaneous sample is used rather than the retrying proof, on purpose: the retry loop would add up to a second to every healthy `alive` read in poll loops for no benefit. The corroboration is positive-only, so a transient prompt helper simply keeps `live` for that sample and the next poll settles it; every caller that acts on the negative verdict already polls.
- The verdict can only move from `live` toward `no-agent`, never the other way. A live harness process, an extra foreground process, a shell with a child, an unreadable inventory, and an inventory answering about a different pane all leave `live` standing, which is what satisfies the refuse-genuinely-live/ambiguous/unreadable/conflicting requirement.
- fm-control.sh and fm-spawn.sh are deliberately unchanged: both already gate on the classifier's `dead`, so do_exit becomes idempotent (already-stopped) and the replacement launch proceeds, with no new lifecycle path.
- The busy-state classifier (fm_backend_herdr_busy_state) is deliberately NOT changed. It is read in tight submit-confirmation loops where a process-info call per poll would be a real cost regression, and the control plane never reaches busy for a pane the classifier now proves dead.

Per-backend and per-harness review, with evidence rather than assumption: only the herdr adapter changes. tmux already reads the foreground process group; zellij, orca, and cmux have no recovery-grade classifier, report `unverified`, and already refuse exit and relaunch. Because the proof reads a process name and argv0 the harness vendor controls, a new opt-in real-harness drift guard launches every INSTALLED harness for real and fails naming the harness and version if a running one ever proves a bare idle shell. Measured on herdr 0.8.2: claude 2.1.252, codex 0.150.1, opencode 1.17.11, pi 0.84.4, and cursor 2026.08.31 all own the pane foreground under their own argv0 and stay alive; pi-signed, grok, kimi, and muse are not installed and are reported explicitly, and the guard refuses a pass that checked nothing.

Test changes that are deliberate consequences, not incidental churn: three existing real-Herdr cases (fm-backend-herdr-smoke, fm-backend-herdr-respawn-idem-e2e, fm-backend-herdr-presentation-e2e) registered an agent on a shell-only pane to mean 'a genuinely live duplicate'. Under the corrected contract that setup is the husk shape, so each now gives the pane a real foreground process first through one shared helper added to tests/herdr-test-safety.sh. That also removes a pre-existing flake in which herdr dropped the bare registration mid-test. tests/fm-control-herdr-smoke.test.sh previously encoded the buggy behavior as expected and now runs the identical registered reading twice, once over a plain shell and once over a real foreground process.

Verification already run on this exact re-cut base: bin/fm-lint.sh clean, bin/fm-doc-audience-check.sh clean, bin/fm-test-run.sh --check-coverage clean, and fm-backend-herdr, fm-control, fm-control-relaunch and fm-control-herdr-smoke all green. Some real-Herdr end-to-end suites and a few unrelated suites fail on this machine from pre-existing herdr 0.8.2 and local-toolchain drift; that was confirmed earlier by re-running them against the unmodified pre-change file.

Repo conventions that apply: one sentence per line in tracked Markdown, plain dash never an em dash, no agent co-author on commits, bin/*.sh shellcheck-clean, tests colocated in tests/ as <subject>.test.sh extending existing runners, tests must exercise public or executable interfaces and never assert implementation-source bytes, and maintainer-verification records under docs/verification/ carry dated versions, exact commands, and exact output for current guarantees only.

## What Changed

- Corroborates Herdr's registered liveness and native busy/idle states against strict pane process inventory, treating only positively proven bare idle shells as agent-free while live or inconclusive panes remain protected.
- Restores safe same-task relaunches.
- Documents the revised contract and adds deterministic backend/control coverage plus isolated real-Herdr and live-harness drift checks for stale registrations, refusal paths, failed replacement launches, and branch/worktree preservation.

## Risk Assessment

✅ Low: The shipped behavior change is small, positive-only, and can only move a verdict toward the conservative side; it is pinned by deterministic tests that pair each husk inventory with a byte-identical registration over a live process plus consumer-level cases in fm-busy-state and fm-daemon, the added per-poll cost is measured and reproducible, and the one remaining finding is a documentation/comment qualifier that does not affect behavior.

## Testing

The author-provided lint, documentation, coverage, and focused-test baseline was supplemented with targeted classifier, relaunch, stale-state, daemon, real-control, and installed-harness checks; isolated Herdr labs proved safe exited-shell recovery, live-agent refusal, rollback and work preservation, while Claude, Codex, OpenCode, Pi, and Cursor remained correctly live.

<details>
<summary>Evidence: Real Herdr control-plane smoke transcript</summary>

Source: [Real Herdr control-plane smoke transcript](https://github.com/npayette84/firstmate/blob/9c54cac96a2c1e9ba5d2380c29e39d8c29f31bb2/.no-mistakes/evidence/fm/herdr-exited-worker-relaunch/herdr-control-smoke.log)

```text
FM_TEST_BEGIN 2026-09-03T02:09:37Z tests/fm-control-herdr-smoke.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - real herdr: exit on a pane with no registered agent is idempotent success
ok - real herdr: interrupt refuses when herdr's own agent registry reports no agent
ok - real herdr: a reported registration the pane's own process inventory contradicts reads agent-free
ok - real herdr: an exited worker's pane is positively eligible for its replacement instead of being typed into
ok - real herdr: interrupt still refuses on a pane whose registration outlived its agent
ok - real herdr: the same registration over a running foreground process stays alive
ok - real herdr: interrupt delivers the harness's key and proves the agent survived it
ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
ok - real herdr: no control verb removed the endpoint, the task's local copy, or its branch
FM_TEST_END 2026-09-03T02:09:46Z tests/fm-control-herdr-smoke.test.sh exit=0 duration_ms=8903 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=8975
FM_TEST_SUMMARY_FAMILY family=real-herdr-gated count=1 duration_ms=8903 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-control-herdr-smoke.test.sh duration_ms=8903
```
</details>
<details>
<summary>Evidence: Installed-harness Herdr liveness transcript</summary>

Source: [Installed-harness Herdr liveness transcript](https://github.com/npayette84/firstmate/blob/9c54cac96a2c1e9ba5d2380c29e39d8c29f31bb2/.no-mistakes/evidence/fm/herdr-exited-worker-relaunch/herdr-installed-harness-liveness.log)

```text
FM_TEST_BEGIN 2026-09-03T02:09:56Z tests/fm-herdr-agent-free-proof-live-e2e.test.sh family=live-harness-optin expected_gate_skip=optin-env
# herdr: herdr 0.8.2
# claude 2.1.259 (Claude Code): foreground=[2.1.259/claude] state=alive
ok - herdr agent-free proof: claude 2.1.259 (Claude Code) running in a Herdr pane never proves a bare idle shell
# codex codex-cli 0.152.1: foreground=[codex/codex] state=alive
ok - herdr agent-free proof: codex codex-cli 0.152.1 running in a Herdr pane never proves a bare idle shell
# opencode 1.17.11: foreground=[opencode/opencode] state=alive
ok - herdr agent-free proof: opencode 1.17.11 running in a Herdr pane never proves a bare idle shell
# pi 0.84.4: foreground=[node/pi] state=alive
ok - herdr agent-free proof: pi 0.84.4 running in a Herdr pane never proves a bare idle shell
# skip: pi-signed is not installed on this machine, so its Herdr classification is unverified here
# skip: grok is not installed on this machine, so its Herdr classification is unverified here
# skip: kimi is not installed on this machine, so its Herdr classification is unverified here
# cursor 2026.08.31-4057e58: foreground=[node/cursor-agent] state=alive
ok - herdr agent-free proof: cursor 2026.08.31-4057e58 running in a Herdr pane never proves a bare idle shell
# skip: muse is not installed on this machine, so its Herdr classification is unverified here
# unverified on this machine (not installed): pi-signed grok kimi muse
# checked 5 installed harness(es) on herdr herdr 0.8.2 in workspace w1
FM_TEST_END 2026-09-03T02:10:17Z tests/fm-herdr-agent-free-proof-live-e2e.test.sh exit=0 duration_ms=21150 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=21224
FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=1 duration_ms=21150 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-herdr-agent-free-proof-live-e2e.test.sh duration_ms=21150
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b759f55e7d5abf03defc5e505c27aa2616297abc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/backends/herdr.sh:3049` - The intent deliberately leaves fm_backend_herdr_busy_state uncorroborated, justified by &#34;the control plane never reaches busy for a pane the classifier now proves dead&#34;. That holds for bin/fm-control.sh (do_exit at bin/fm-control.sh:451 consults busy_verdict only after agent_state returns alive), but two other consumers read fm_backend_busy_state with no agent-state gate: bin/fm-supervise-daemon.sh:638 (pane_is_busy returns 0 immediately on native busy) and bin/fm-busy-lib.sh:897 (fm_busy_classify falls through to &#39;busy herdr-native&#39; when no durable record exists). Concrete path with the same root cause this change fixes: a harness whose herdr integration last reported agent_status=working is SIGKILLed or crashes mid-turn; herdr never withdraws the report (the empirically established property in the intent), so agent get answers working forever. stale_window_is_busy (bin/fm-supervise-daemon.sh:676) then reads busy indefinitely and never surfaces the stale pane, and inject_msg&#39;s busy guard (bin/fm-supervise-daemon.sh:1232) defers every escalation forever - the same &#34;no state that could ever clear it&#34; symptom, in the watcher/daemon lane rather than the lifecycle lane. The stated cost rationale (a process-info call per poll in tight submit-confirmation loops) is legitimate, so this may well belong in its own lane rather than this branch; flagging so the captain decides explicitly rather than inheriting the gap under a rationale that does not cover these two call sites.
- ℹ️ `tests/fm-herdr-agent-free-proof-live-e2e.test.sh:116` - end_harness TERMs every pid returned by foreground_pids without excluding the pane&#39;s own shell. Between the drift assertion and this cleanup the guard polls up to 20s for a herdr registration (seq 1 100 with sleep 0.2); if the harness exits in that window (a failed auth, a declined trust prompt, a crash), the pane&#39;s sole foreground process is its shell, so end_harness signals the shell, herdr&#39;s pane-death path removes the pane, and - for the first harness, whose tab is the workspace&#39;s only one after the seeded-tab prune - the container disappears. The next iteration then fails with &#34;could not create a lab tab&#34; instead of a real per-harness verdict. process_info already exposes shell_pid, so skipping any pid equal to it (or bailing out when the only foreground process is a recognized shell) keeps cleanup scoped to what the guard launched.
- ℹ️ `tests/fm-herdr-agent-free-proof-live-e2e.test.sh:71` - resolve_harness_binary duplicates tests/fm-harness-liveness-drift-live-e2e.test.sh:68 and now diverges from it: the new copy resolves cursor through fm_cursor_resolve_binary BEFORE any PATH lookup, with a comment recording that a bare `cursor` on PATH is routinely the editor launcher (observed answering a --trust launch with an Electron warning and exiting). The older guard still does the PATH lookup first, so on such a machine it launches the editor launcher and reports a spurious &#34;LIVENESS DRIFT: cursor ... classifies &#39;dead&#39;&#34;. Extracting the corrected resolver into a shared test helper would fix the older guard and stop the two from drifting further; noted rather than fixed because the branch scope explicitly excludes work outside the Herdr liveness fix.

🔧 Fix: corroborate herdr native busy state, share harness resolver
4 infos still open:
- ℹ️ `bin/backends/herdr.sh:3082` - The supplied intent states as a deliberate design decision: &#34;The busy-state classifier (fm_backend_herdr_busy_state) is deliberately NOT changed. It is read in tight submit-confirmation loops where a process-info call per poll would be a real cost regression, and the control plane never reaches busy for a pane the classifier now proves dead.&#34; This change does modify it (bin/backends/herdr.sh:3082-3094 now takes a corroborating pane process-info sample on the busy branch). The captain explicitly authorized and requested exactly this in the round-1 fix instructions (&#34;corroborate Herdr native busy state with the same agent-free proof&#34;), and the implementation matches that instruction, so this is not a defect - but the --intent text and anything derived from it (PR description, the design rationale it carries) still assert the opposite and are now stale. Worth reconciling so the shipped rationale does not contradict the shipped code.
- ℹ️ `bin/fm-busy-lib.sh:880` - The busy-lane fix closes the record-free herdr-native fallthrough (bin/fm-busy-lib.sh:897) and pane_is_busy (bin/fm-supervise-daemon.sh:638), which is what was asked. A sibling path with the same symptom is still open: when the task HAS a durable busy record, fm_busy_classify returns &#34;&lt;r_state&gt; &lt;r_source&gt;&#34; at bin/fm-busy-lib.sh:881 and never reaches the native check at all. A herdr worker SIGKILLed mid-turn leaves its last record at state=busy under an unchanged busy_gen (fm_busy_record_read only rejects on gen-mismatch or malformed, bin/fm-busy-lib.sh:261), so stale_window_is_busy (bin/fm-supervise-daemon.sh:674-683) reads busy forever and the stale-pane marker is dropped at bin/fm-supervise-daemon.sh:1068 instead of escalating - the same &#34;no state that could ever clear it&#34; shape, one layer above the corroboration. This branch&#39;s own new test tests/fm-control-relaunch.test.sh:471-476 deliberately constructs exactly that stale record, so the state is known to be reachable; the control lane is safe because do_exit gates on agent_state first, but the watcher lane is not. This is pre-existing, backend-agnostic (the record contract is shared with tmux), and outside the boundary the captain drew for this branch, so it is raised for a decision rather than as a defect in the change. The earliest shared boundary that would close it is the record reader itself (cross-checking a busy record against fm_backend_agent_state, or expiring a record whose endpoint proves agent-free), not another consumer-side patch.
- ℹ️ `tests/fm-control-herdr-smoke.test.sh:155` - The real-Herdr smoke case asserts the agent-free verdict from a single unpolled read: STATE=$(fm_backend_agent_state herdr ...) at line 154, then [ &#34;$STATE&#34; = dead ] at line 155. The classifier&#39;s own documented contract is that one strict instantaneous sample can legitimately miss - bin/backends/herdr.sh:1926-1929 and docs/herdr-backend.md both state that an idle shell transiently hosting a prompt helper keeps &#39;alive&#39; for that sample and the next poll settles it, with the empirically observed trigger being a zsh prompt redraw spawning starship as a second foreground process. On a maintainer machine with a prompt helper, a redraw landing in this window makes the case fail with &#34;a registration whose pane holds only its shell must classify agent-free, got &#39;alive&#39;&#34;, and the /quit assertion just below would fail for the same reason. A bounded poll for &#39;dead&#39; (the same shape the neighbouring foreground-process wait at lines 185-193 already uses) would match the production contract instead of assuming a single sample always succeeds. Production callers are not exposed the same way: do_exit&#39;s transient false-&#39;alive&#39; path ends in wait_agent_state, which does poll.
- ℹ️ `docs/verification/runtime-backends.md:712` - The new &#34;Native busy-state corroboration cost&#34; record presents a ```sh block of three bare 50-iteration loops (lines 712-718) followed by a ```text block of ms/call figures (lines 720-726). The commands as written emit nothing measurable - there is no timing wrapper and no division by 50 - so a maintainer re-running them cannot reproduce or refute the table, which is what the repo convention the intent cites (&#34;exact commands, and exact output&#34;) and the round-1 instruction (&#34;record the measurement with its exact command and output&#34;) are for. The figures are internally consistent (61.2 - 42.7 = the ~19 ms the prose attributes to the busy branch), so this is a reproducibility gap in the record rather than a suspected wrong number; showing the actual timing invocation and its raw output would close it.

🔧 Fix: reproducible busy-state cost record, polled agent-free assertion
3 infos still open:
- ℹ️ `bin/backends/herdr.sh:3054` - The busy-state header states the contract as &#34;the SAME proof fm_backend_herdr_pane_agent_state uses, so the liveness verdict and the busy verdict can never disagree about what the pane is&#34;. The code applies the proof only on the `busy` branch (bin/backends/herdr.sh:3087-3092), so the two verdicts still disagree for a stale registration whose last reported status was idle/done/blocked: fm_backend_herdr_classify_agent_status maps those to `idle`, the inventory is never read, and fm_backend_herdr_busy_state returns a positive native `idle` for the same pane fm_backend_herdr_pane_agent_state now calls `dead`. That positive idle is consumed: fm_pending_reply_backend_observation short-circuits on idle (bin/fm-pending-reply-lib.sh:732-735) and fm_pending_reply_observe_busy then stamps &lt;field&gt;_completed (bin/fm-pending-reply-lib.sh:671-679) for a secondmate whose harness is gone. This is NOT a regression - that path behaved identically before this change, and it still lands in recovery/escalation rather than a false resolve - and extending the sample to the idle branch would add the measured ~18 ms to every idle poll on healthy panes (Claude&#39;s native status is idle through a whole turn), which the cost record argues against. So the code placement looks like the right call and the sentence is the part that overclaims: narrowing it to the busy verdict (which docs/herdr-backend.md:242 already does correctly) would keep the shipped rationale true. Flagged rather than fixed because it is the author&#39;s stated contract, and because the alternative reading - deliberately corroborating the idle branch too - is a cost decision only the captain should make.
- ℹ️ `tests/fm-backend-herdr.test.sh:864` - The bare-shell `pane_process_info` JSON payload is now emitted by three byte-identical builders: bare_shell_inventory (tests/fm-backend-herdr.test.sh:864, added here), death_process_info_fixture (tests/fm-backend-herdr.test.sh:1721, pre-existing in the SAME file), and herdr_bare_shell_process_info (tests/fixtures.sh:339, added here). The live-process variant is likewise duplicated between herdr_live_process_info (tests/fixtures.sh:346) and an inline process_info_fixture call in tests/fm-backend-herdr.test.sh:884. Since the whole point of the proof is that this exact response shape is what herdr reports, a shape change would now have to be edited in three places or the suites silently drift - which is the same failure mode this change fixed for the harness resolver. tests/fixtures.sh is idempotent (FM_TEST_FIXTURES_SOURCED) and already pulls in lib.sh, so tests/fm-backend-herdr.test.sh can source it and keep only the generic process_info_fixture for the non-bare shapes; worth a quick check for helper-name collisions with the fixtures&#39; spawn-world builders when doing so.
- ℹ️ `bin/backends/herdr.sh:3082` - Recording the intent deviation rather than re-raising it. The --intent text says &#34;The busy-state classifier (fm_backend_herdr_busy_state) is deliberately NOT changed&#34;, and this change does modify it. That deviation was surfaced in round 1, and the captain&#39;s round-1 instruction explicitly reversed the rationale (&#34;my original claim that the control plane never reaches busy for a pane proved dead is TRUE only for bin/fm-control.sh, and is FALSE for bin/fm-busy-lib.sh:897 and bin/fm-supervise-daemon.sh:638&#34;) and directed exactly this implementation, including the hot-path measurement. The round-2 instruction then required the code&#39;s own documentation to become the accurate owner of the new contract, which it is: bin/backends/herdr.sh:3050-3081 and docs/herdr-backend.md:242-248 both state the corroboration and why. Verified against the shipped code: the placement, the positive-only shape, and the `unknown`-not-`idle` resolution all match what was authorized. No action needed - this exists so the deviation is not mistaken for an unreviewed one.

🔧 Fix: narrow busy corroboration claim, one process-info fixture owner
2 issues (1 error, 1 info) still open:
- 🚨 `tests/harness-binary.sh:1` - The new shared helper is named `tests/harness-binary.sh`, which matches none of the arms in bin/fm-test-run.sh&#39;s changed-path map (bin/fm-test-run.sh:1318 recognizes only `tests/lib.sh`, `tests/*-helpers.sh`, and `tests/fixtures.sh`). Every other `tests/*` path falls to the catch-all at bin/fm-test-run.sh:1344, which emits `__unmapped__:`, and select_changed turns that into a hard `die` at bin/fm-test-run.sh:1374. Verified on this worktree: `bin/fm-test-run.sh --list --changed --base 8988af2` prints `fm-test-run: no changed-test mapping for source path: tests/harness-binary.sh` and exits 2, so the runner&#39;s changed-selection mode - the documented per-branch workflow (docs/fm-test-isolation-proof.md:99, docs/calm-mode-feasibility.md:323) - cannot run at all on this branch, and cannot run on any future branch that edits this helper. `--check-coverage` stays clean (it counts .test.sh scripts only), which is why the intent&#39;s verification did not catch it. Cheapest fix: rename to `tests/harness-binary-helpers.sh` so the existing `tests/*-helpers.sh` arm resolves it - both guards reference the basename, so families_for_test_reference maps it to the live-e2e family of each - or add the path explicitly to the case at bin/fm-test-run.sh:1318.
- ℹ️ `tests/fm-herdr-agent-free-proof-live-e2e.test.sh:112` - harness_pids returns 0 with no output whenever pane_shell_pid is empty (line 115), which happens for any failed or unparseable `pane process-info` read, not only for a pane with nothing but its shell. end_harness&#39;s first wait then sees an empty pid list at line 132 and returns success immediately, so a transient inventory failure makes cleanup a silent no-op that leaves the launched harness running while the guard reports the pane clean. The same shape hides a harness that is running but absent from foreground_processes. The round-1 instruction for this helper asked it to &#34;still fail loudly rather than silently continue if cleanup cannot leave the pane usable for the next harness&#34;; the loud path at line 142 is only reachable when the inventory IS readable. Impact is bounded - each harness gets a fresh pane via create_task, and cleanup_all tears the lab session down at the end - so this is a fidelity gap in the guard&#39;s own reporting rather than a correctness problem in the classifier it guards. Distinguishing &#34;inventory unreadable&#34; from &#34;no non-shell foreground process&#34; (a separate return code from harness_pids) would let end_harness fail on the former and succeed on the latter.

🔧 Fix: map shared harness helper, fail on unreadable cleanup inventory
2 issues (1 warning, 1 info) still open:
- ⚠️ `docs/herdr-backend.md:242` - The round-4 fix corrected the overclaiming busy-state contract sentence in bin/backends/herdr.sh but left the identical claim standing in the documentation. docs/herdr-backend.md:242 reads &#34;A native `busy` verdict is corroborated against the pane&#39;s own process inventory, through the same idle-shell proof the liveness classifier uses, so the two verdicts can never disagree about what the pane is.&#34; That is false and is directly refuted by the code it documents: bin/backends/herdr.sh:3087-3092 takes the inventory sample only when the classified verdict is `busy`, and the corrected header at bin/backends/herdr.sh:3056-3060 now says so explicitly - &#34;So the two verdicts do still differ for a stale registration last reported idle - that pane reads `dead` from the classifier and `idle` here - which is deliberate&#34;. The doc sentence also contradicts line 246 of its own paragraph (&#34;The inventory is read only on the busy branch&#34;). Concretely reachable: fm_backend_herdr_classify_agent_status (bin/backends/herdr.sh:3013-3020) maps idle/done/blocked to `idle`, so a registration last reported `done` over a pane whose agent has exited yields busy_state `idle` while fm_backend_herdr_pane_agent_state yields `no-agent`/`dead` for the same pane - the two verdicts disagreeing, exactly as the doc says they cannot. The round-3 finding that prompted the fix asserted this doc line &#34;already does correctly&#34; narrow the claim; it does not. Fix is the same one applied to the code: replace the trailing clause with the true statement (only a reported-busy verdict is corroborated, because only `busy` can wedge a pane; a stale registration last reported idle can still differ from the liveness verdict, deliberately, because no consumer is wedged by native idle).
- ℹ️ `bin/backends/herdr.sh:3091` - Recording the intent deviation for completeness rather than re-asking a settled question. The --intent states &#34;The busy-state classifier (fm_backend_herdr_busy_state) is deliberately NOT changed&#34;, and this change does modify it (bin/backends/herdr.sh:3091-3103 now corroborates a `busy` verdict against fm_backend_herdr_pane_idle_shell_sample). The deviation was surfaced in round 1; the captain&#39;s round-1 instruction explicitly reversed the intent&#39;s rationale (&#34;my original claim that the control plane never reaches busy for a pane proved dead is TRUE only for bin/fm-control.sh, and is FALSE for bin/fm-busy-lib.sh:897 and bin/fm-supervise-daemon.sh:638&#34;) and directed exactly this implementation including the hot-path measurement, and round 3&#39;s equivalent note was reviewed and closed. Verified against the shipped code: the placement is busy-branch-only (bin/backends/herdr.sh:3097-3102), the shape is positive-only (a live process, extra foreground process, shell with a child, unreadable inventory, and an inventory about another pane all leave the verdict untouched - pinned by tests/fm-backend-herdr.test.sh:3196-3241), and the resolution is `unknown` rather than `idle`, which keeps bin/fm-pending-reply-lib.sh:732 from reading a fabricated completed turn. No action needed; this exists so the deviation is not mistaken for an unreviewed one.

🔧 Fix: correct busy-corroboration overclaim in herdr documentation
2 issues (1 warning, 1 info) still open:
- ⚠️ `docs/herdr-backend.md:243` - The round-5 doc rewrite replaced one overclaim with another. Line 243 states that &#34;a reported `idle` is no evidence at all to any consumer and each falls back to its own&#34;. That is false for one of the three consumers this branch&#39;s own verification record names (docs/verification/runtime-backends.md: &#34;The consumers that do read busy state are bin/fm-busy-lib.sh, bin/fm-supervise-daemon.sh, and bin/fm-pending-reply-lib.sh&#34;). fm_pending_reply_backend_observation acts POSITIVELY on a native idle: bin/fm-pending-reply-lib.sh:733-735 short-circuits `case &#34;$native&#34; in busy|idle) printf &#39;%s&#39; &#34;$native&#34;; return 0 ;;` without ever reaching the rendered fallback, and fm_pending_reply_observe_busy then stamps &lt;field&gt;_completed from it (bin/fm-pending-reply-lib.sh:669-679). Concretely reachable on the exact state this branch exists to handle: fm_backend_herdr_classify_agent_status maps idle/done/blocked to `idle` (bin/backends/herdr.sh:3014-3019), so a secondmate whose harness exited after last reporting `done` yields busy_state `idle` for a pane fm_backend_herdr_pane_agent_state now calls `dead`, and the delivery-confirmation record marks the turn completed for an endpoint with no agent. The code header is the accurate owner here and already says so explicitly - bin/backends/herdr.sh:3057-3058 names only bin/fm-busy-lib.sh and bin/fm-supervise-daemon.sh as the consumers that treat native idle as no evidence, and bin/backends/herdr.sh:3080-3082 spells out the pending-reply consequence - so the doc now contradicts the code it documents. Behavior is correct and unchanged; only the sentence is wrong. Narrow it the same way the header does: name the two consumers whose fallback behavior makes the idle branch safe to leave uncorroborated, rather than generalizing to &#34;any consumer&#34;.
- ℹ️ `tests/fm-control-herdr-smoke.test.sh:176` - The real-Herdr case that pins the corroboration can now pass without exercising it. `registered_status` is asserted non-empty once at line 173, then `wait_agent_state dead` (line 176) polls fm_backend_agent_state for up to 10s. fm_backend_herdr_pane_agent_state reaches `no-agent` through two independent grounds (documented at bin/backends/herdr.sh:1883-1892): (a) `agent get` answering agent_not_found, and (b) a registration the inventory contradicts. Only (b) is this case&#39;s subject. If herdr drops the bare registration anywhere inside that 10s window - the exact pre-existing flake the intent cites as a reason the three sibling real-Herdr cases now give their panes a real foreground process (&#34;That also removes a pre-existing flake in which herdr dropped the bare registration mid-test&#34;) - the verdict settles via (a) and the case reports ok while the corroboration was never consulted. The round-2 fix that added the settle window widened this gap: before it, the single unpolled read left almost no time for a drop. Cheapest fix that keeps the round-2 outcome: after `wait_agent_state dead` returns, re-read `registered_status` and fail if it is empty, so the case proves the registration was still standing at the moment the pane classified agent-free. The deterministic sibling coverage in tests/fm-backend-herdr.test.sh:838-900 is unaffected and still fails if the corroboration is removed, which bounds the impact to this one guard&#39;s fidelity.

🔧 Fix: corroborate herdr idle verdict, non-vacuous smoke assertion
4 issues (2 warnings, 2 infos) still open:
- ⚠️ `bin/backends/herdr.sh:3090` - The round-6 change extends the inventory corroboration from the `busy` branch to every reported state (bin/backends/herdr.sh:3090, `[ &#34;$verdict&#34; != unknown ]`). Its stated justification, in the header at bin/backends/herdr.sh:3063 and repeated at docs/herdr-backend.md:244, is that a stale `idle` is &#34;taken by fm_pending_reply_backend_observation ... and stamps a secondmate turn completed for an endpoint whose harness is gone&#34;. Traced through, that outcome is not prevented. With the corroboration, native idle becomes `unknown`, so fm_pending_reply_backend_observation (bin/fm-pending-reply-lib.sh:733) no longer short-circuits and falls through to the rendered capture; a bare-shell pane does not match fm_busy_lines_match, so it returns `fallback-idle`. fm_pending_reply_busy_state_from_observation then hands that to fm_pending_reply_fallback_idle_eligible (bin/fm-pending-reply-lib.sh:688), which returns 0 IMMEDIATELY on `[ &#34;$seen&#34; = 1 ]` - and turn_seen_busy is exactly 1 in the case the header names, a harness that died mid-turn after being observed busy. fm_pending_reply_observe_busy then stamps &lt;field&gt;_completed just as before. The only behavior that actually changes is the turn_seen_busy=0 sub-case, where completion is delayed by grace_secs (default 120, bin/fm-pending-reply-lib.sh:95) instead of being stamped on the first observation. The cost is paid unconditionally: by the branch&#39;s own measurement (docs/verification/runtime-backends.md:781-784) a reported-idle read over a healthy live pane goes from 39.1 ms to 77.3 ms per call, and native idle is what a live Claude reports through a whole turn, so this is now on every watcher, away-mode, and pending-reply tick for every healthy herdr pane. Note also that the busy branch got consumer-level proof (tests/fm-busy-state.test.sh test_herdr_native_busy_requires_a_live_pane, tests/fm-daemon.test.sh test_pane_is_busy_herdr_registration_outlived_its_agent) while the idle branch is asserted only on the classifier in isolation (tests/fm-backend-herdr.test.sh test_busy_state_stale_idle_registration_is_not_idle); tests/fm-pending-reply.test.sh has no herdr case at all. This is captain-directed behavior from the round-6 instruction, so it is raised as a decision rather than a defect: either keep it and narrow the header/doc so they no longer imply the stamp is prevented, or drop the idle branch back to `busy`-only and stop paying the per-poll cost. If it is kept, the durable fix for the stated hazard is at fm_pending_reply_fallback_idle_eligible / the observation contract, not at the classifier.
- ⚠️ `docs/verification/runtime-backends.md:752` - In the reproducible cost block, `bench &#39;agent get (the existing per-poll read)&#39;` (line 752) now runs BEFORE the first `report working` (line 755). The pane is freshly created by fm_backend_herdr_create_task and has no registration at that point, so the 50 calls measure the agent_not_found path, not a registered read. On the herdr behavior this file&#39;s own adapter documents (bin/backends/herdr.sh:1878, &#34;real herdr 0.7.1 exits 1 for it&#34;), fm_backend_herdr_agent_status_raw short-circuits at `fm_backend_herdr_cli ... || { printf &#39;&#39;; return 0; }` and never runs jq, so the row excludes the parse a real poll pays. Line 798 then spends that number on a claim about a different path entirely: the submit-confirmation loops &#34;each poll fm_backend_herdr_agent_status_raw directly, measured unchanged at 19.2 ms per call above&#34; - but those loops poll a pane that IS registered, which is the state this row never measured. Round 5 ordered the benches after `report working` and did measure the registered path; round 6 moved them ahead of it. Fix by moving the two leading `bench` lines after the first `report working` (the `pane process-info` row is unaffected either way) and re-running the block, publishing whatever the commands then produce.
- ℹ️ `docs/verification/runtime-backends.md:788` - &#34;the corroboration costs about 30 ms per call: 77.3 ms against the 39.1 ms the same read costs uncorroborated&#34; - the two figures it cites differ by 38.2 ms, not about 30. The busy row gives 71.5 - 39.1 = 32.4 ms. Since this record exists so a maintainer can derive the conclusion from the printed output rather than take it on assertion, the prose should state the delta its own rows produce (roughly 32-38 ms depending on the reported state, or one number per branch).
- ℹ️ `bin/backends/herdr.sh:3090` - Recorded for completeness, not re-asked. The --intent states &#34;The busy-state classifier (fm_backend_herdr_busy_state) is deliberately NOT changed&#34;, and this change does modify it, now on both the busy and idle branches. The deviation was surfaced in round 1; the captain&#39;s round-1 instruction explicitly reversed the intent&#39;s rationale and directed the busy-branch corroboration with a hot-path measurement, and the round-6 instruction explicitly directed the idle branch (&#34;apply the SAME agent-free proof to the idle verdict as well ... resolving a proved-agent-free pane to unknown&#34;). Equivalent notes in rounds 3 and 5 were reviewed and closed. Verified against the shipped code: the sample is taken on exactly the four reported statuses fm_backend_herdr_pane_agent_state also samples (working/idle/done/blocked via fm_backend_herdr_classify_agent_status), an already-`unknown` verdict skips the read entirely, resolution is `unknown` rather than `idle`, and the positive-only shape is pinned by tests/fm-backend-herdr.test.sh (ambiguous inventory, unreadable inventory, other-pane inventory, shell-with-a-child all leave the verdict standing). No action needed; this exists so the deviation is not mistaken for an unreviewed one. See also the separate finding on whether the idle branch achieves its stated benefit.

🔧 Fix: state actual idle-corroboration guarantee, fix cost baseline
1 info still open:
- ℹ️ `bin/backends/herdr.sh:3078` - The busy-state header states the consumer benefit unqualified: &#34;bin/fm-busy-lib.sh and bin/fm-supervise-daemon.sh act on `busy` alone, so `unknown` ends the wedge outright. The pane surfaces for stale-pane escalation instead of being suppressed&#34; (bin/backends/herdr.sh:3078-3080), and docs/herdr-backend.md:247 repeats it (&#34;the pane surfaces for stale-pane escalation instead of being suppressed&#34;). That is true for bin/fm-supervise-daemon.sh, whose pane_is_busy calls fm_backend_busy_state directly with no record layer. It is true for bin/fm-busy-lib.sh ONLY on the record-free fallthrough, which the same header correctly names fifteen lines earlier (bin/backends/herdr.sh:3061, &#34;bin/fm-busy-lib.sh&#39;s record-free fallthrough&#34;) and which the corrected sentence then drops. When the task has a durable busy record, fm_busy_classify returns &#34;&lt;r_state&gt; &lt;r_source&gt;&#34; at bin/fm-busy-lib.sh:881 and never reaches the native check at bin/fm-busy-lib.sh:897, so stale_window_is_busy still reads busy and the pane is still suppressed - the stale-durable-record path the captain explicitly deferred to a follow-up. Reachable and known: this branch&#39;s own tests/fm-control-relaunch.test.sh:459-466 constructs exactly that record. Behavior is correct and unchanged; only the guarantee sentence overreaches, in the same paragraph that has now been narrowed twice (rounds 4 and 6), and it overreaches in both owners at once - which is how the round-5 miss happened. Minimal fix: carry the &#34;record-free fallthrough&#34; qualifier into the bin/fm-busy-lib.sh half of the bullet at bin/backends/herdr.sh:3078 and into docs/herdr-backend.md:247, in the same edit, leaving the bin/fm-supervise-daemon.sh half unqualified because it is unconditionally true. Do not touch fm_busy_classify or fm_busy_record_read; that lane stays deferred.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-backend-herdr.test.sh`
- `bin/fm-test-run.sh tests/fm-control-relaunch.test.sh`
- `bin/fm-test-run.sh tests/fm-busy-state.test.sh`
- `bin/fm-test-run.sh tests/fm-daemon.test.sh`
- `bin/fm-test-run.sh tests/fm-control-herdr-smoke.test.sh 2>&1 | tee /var/folders/70/p814fs691f103nxddhx58mhh0000gn/T/no-mistakes-evidence/01M1H3QS753EN7E3XFNY1H5PGH/herdr-control-smoke.log`
- `FM_HERDR_AGENT_FREE_PROOF=1 bin/fm-test-run.sh tests/fm-herdr-agent-free-proof-live-e2e.test.sh 2>&1 | tee /var/folders/70/p814fs691f103nxddhx58mhh0000gn/T/no-mistakes-evidence/01M1H3QS753EN7E3XFNY1H5PGH/herdr-installed-harness-liveness.log`

</details>

<details>
<summary>⚠️ **Document** - 1 error</summary>

- 🚨 `bin/backends/herdr.sh:3096` - The accepted scope explicitly leaves the Herdr busy-state classifier unchanged, but this function now performs process-inventory corroboration and adds related tests and documentation. Restore native-status-only busy classification and retain idle-shell corroboration solely in the liveness classifier.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
