### PR TITLE
fix: bind Claude footer to composer boundary

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2684,6 +2684,17 @@ fm_backend_herdr_rendered_busy_state() {  # <target> [harness] -> busy|idle|unkn
   cap=$(fm_backend_herdr_capture "$target" 40) || { printf 'unknown'; return 0; }
   visible=$(printf '%s' "$cap" | grep -v '^[[:space:]]*$' | tail -12)
   [ -n "$visible" ] || { printf 'unknown'; return 0; }
+  if [ "$harness" = claude ]; then
+    if printf '%s' "$visible" | fm_claude_current_footer_busy; then
+      printf 'busy'
+    else
+      case "$?" in
+        1) printf 'idle' ;;
+        *) printf 'unknown' ;;
+      esac
+    fi
+    return 0
+  fi
   if printf '%s' "$visible" | fm_busy_lines_match "$harness"; then
     printf 'busy'
   else

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -313,6 +313,7 @@ fm_composer_strip_ghost() {
 # outside its composer and the composer verdict is therefore always `unknown`.
 FM_DELIVERY_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop'
 FM_DELIVERY_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]'
+FM_DELIVERY_CLAUDE_CURRENT_FOOTER_REGEX='^[[:space:]]*(esc to interrupt|thinking\.\.\.[[:space:]]+esc to interrupt|[^[:space:]]+[[:space:]]+[^[:space:]]+…[[:space:]]+\([0-9]+[smh]([[:space:]]+[·•][^)]*)?\))[[:space:]]*$'
 FM_DELIVERY_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_DELIVERY_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_DELIVERY_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
@@ -350,6 +351,38 @@ fm_busy_lines_match() {  # [harness]
     esac
   fi
   [ -n "$regex" ] && printf '%s' "$lines" | grep -qiE "$regex"
+}
+
+# fm_claude_current_footer_busy returns 0 for busy, 1 for idle, and 2 for
+# unreadable or structurally ambiguous state.
+fm_claude_current_footer_busy() {
+  local lines plain footer footer_row composer caps verdict
+  IFS= read -r -d '' lines || true
+  [ -n "$lines" ] || return 2
+  plain=$(printf '%s' "$lines" | fm_composer_strip_ansi) || return 2
+  footer=$(printf '%s\n' "$plain" | awk 'NF { row=$0 } END { if (row != "") print row }')
+  footer_row=$(printf '%s\n' "$plain" | awk 'NF { row=NR - 1 } END { if (row != "") print row }')
+  fm_composer_normalize_trim_var footer
+  [ -n "$footer" ] && [ -n "$footer_row" ] || return 2
+  composer=$(printf '%s\n' "$plain" | awk '
+    { rows[NR]=$0 }
+    NF { last=NR }
+    END { for (row=1; row < last; row++) print rows[row] }
+  ')
+  caps=$(printf '%s\n' 'styled=0' 'cursor=0' 'identity=0' 'rows=12')
+  verdict=$(fm_composer_classify_screen "$caps" "$composer")
+  [ "$verdict" = empty ] || return 2
+  _fm_composer_scan_screen "$composer" ''
+  _fm_composer_select_cursorless "$composer" || return 2
+  [ "$footer_row" -eq $((FM_COMPOSER_SELECTED_BOUNDARY + 1)) ] || return 2
+  if [ -n "${FM_BUSY_REGEX:-}" ]; then
+    if printf '%s\n' "$footer" | fm_busy_lines_match claude; then
+      return 0
+    fi
+  elif printf '%s\n' "$footer" | grep -qE "$FM_DELIVERY_CLAUDE_CURRENT_FOOTER_REGEX"; then
+    return 0
+  fi
+  return 1
 }
 
 # The prompt glyphs, each declared exactly once (see THE SAFETY RULE above).
@@ -1024,11 +1057,12 @@ _fm_composer_leftbar_floor_row() {  # <trimmed-row>
 }
 
 _fm_composer_select_cursorless() {
-  local plain=$1 generic=-1 next boundary raw trimmed
+  local plain=$1 generic=-1 next boundary=-1 raw trimmed
   FM_COMPOSER_SELECTED_KIND=
   FM_COMPOSER_SELECTED_FIRST=-1
   FM_COMPOSER_SELECTED_LAST=-1
   FM_COMPOSER_SELECTED_AMBIG=0
+  FM_COMPOSER_SELECTED_BOUNDARY=-1
   if [ "$FM_COMPOSER_SCAN_BOX_BOTTOM" -ge 0 ]; then
     generic=$FM_COMPOSER_SCAN_BOX_BOTTOM
     FM_COMPOSER_SELECTED_KIND=box
@@ -1104,6 +1138,19 @@ _fm_composer_select_cursorless() {
       return 1
     fi
   fi
+  case "$FM_COMPOSER_SELECTED_KIND" in
+    box|leftbar) ;;
+    bare)
+      boundary=$FM_COMPOSER_SELECTED_LAST
+      next=$((boundary + 1))
+      raw=$(_fm_composer_screen_row "$next" "$plain")
+      trimmed=$raw
+      fm_composer_normalize_trim_var trimmed
+      if [ -n "$trimmed" ] && fm_composer_row_has_edge "$trimmed"; then boundary=$next; fi
+      ;;
+    pi) boundary=$FM_COMPOSER_SCAN_PI_CLOSE ;;
+  esac
+  FM_COMPOSER_SELECTED_BOUNDARY=$boundary
   [ -n "$FM_COMPOSER_SELECTED_KIND" ]
 }
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -228,6 +228,8 @@ Herdr reports a Cursor pane `blocked` in every state, and Cursor's mid-turn comp
 That fallback alone reported every delivered steer as unconfirmed, so it is paired with a rendered-footer transition: the pane's verified busy footer is read once before the first Enter, and an idle-to-busy transition across that Enter confirms the submit.
 It is the same semantic signal the native path uses and the same one the tmux submit core reads.
 A pane already mid-turn cannot borrow a rendered-footer transition as proof of this delivery; after retries, only proven pending text plus native `working` can establish that its Enter was accepted and queued.
+For a known Claude target, the rendered-busy predicate accepts an active-turn signature only when the final nonblank footer row is immediately below the selected composer boundary, including a structural closing edge the shared classifier proves for that screen shape.
+A footer-like row outside that boundary is structurally ambiguous and returns `unknown`, including a foreign `Working` row below an idle Claude composer.
 The composer verdict itself is deliberately unchanged: a right-aligned status token on the composer row stays content for every other caller, including the away-mode pre-injection guard.
 The poll density bounds the residual possibility of an extremely fast complete turn; a missed native transition falls through to the composer verdict rather than reporting a false swallow.
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3720,6 +3720,32 @@ test_rendered_busy_state_reads_the_cursor_busy_token() {
   pass "fm_backend_herdr_rendered_busy_state: busy/idle/unknown from the rendered footer, with an unreadable pane never reading idle"
 }
 
+test_rendered_busy_state_rejects_foreign_claude_footer() {
+  local dir log resp fb foreign_out genuine_out
+  dir="$TMP_ROOT/rendered-busy-claude-foreign-footer"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' \
+    '────────────────────────' \
+    '❯' \
+    '────────────────────────' \
+    'Claude 4.1' \
+    '✲ Working… (4s)' > "$resp/1.out"
+  printf '%s\n' \
+    '────────────────────────' \
+    '❯' \
+    '────────────────────────' \
+    '✲ Pollinating… (16s · ↓ 1.1k tokens)' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  foreign_out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_rendered_busy_state default:w1:p2 claude' "$ROOT" )
+  genuine_out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_rendered_busy_state default:w1:p2 claude' "$ROOT" )
+  [ "$foreign_out" = unknown ] \
+    || fail "a foreign Working row outside the selected Claude composer boundary must be unknown, got '$foreign_out'"
+  [ "$genuine_out" = busy ] \
+    || fail "a genuine Claude footer immediately below its composer must be busy, got '$genuine_out'"
+  pass "fm_backend_herdr_rendered_busy_state: scopes Claude busy proof to the selected composer boundary"
+}
+
 test_send_text_submit_confirms_never_idle_native_state_via_footer_transition() {
   local dir log resp fb out enter_count
   dir="$TMP_ROOT/submit-cursor-footer-transition"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -4629,6 +4655,7 @@ test_send_text_submit_idle_native_empty_composer_confirms_delivery
 test_send_text_submit_idle_native_pending_plus_rendered_busy_is_queued
 test_composer_state_cursor_midturn_row_reads_pending
 test_rendered_busy_state_reads_the_cursor_busy_token
+test_rendered_busy_state_rejects_foreign_claude_footer
 test_send_text_submit_confirms_never_idle_native_state_via_footer_transition
 test_send_text_submit_never_idle_native_state_keeps_pending_without_a_transition
 test_send_text_submit_confirms_despite_codex_idle_tip_composer

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -271,17 +271,17 @@ test_matrix_herdr_halfblock_rule_bounds_bare_wrap() {
   # footer, whose real content turns an idle pane into a false `pending`.
   # Captured live from a herdr cursor pane.
   local screen plain out
-  plain=$'transcript\n \u2584\u2584\u2584\u2584\u2584\u2584\u2584\u2584\n  \u2192 Add a follow-up\n \u2580\u2580\u2580\u2580\u2580\u2580\u2580\u2580\n  Cursor Grok 4.5 High \u00b7 6.7%   Run Everything\n  ~/wt \u00b7 64cdd3a'
+  plain=$'transcript\n ▄▄▄▄▄▄▄▄\n  → Add a follow-up\n ▀▀▀▀▀▀▀▀\n  Cursor Grok 4.5 High · 6.7%   Run Everything\n  ~/wt · 64cdd3a'
   # The closing rule must bound the region, so the footer below is not input.
-  fm_composer_row_has_edge " $(printf '\u2580\u2580\u2580')" \
+  fm_composer_row_has_edge " $(printf '▀▀▀')" \
     || fail "a half-block rule row must count as a structural edge"
-  fm_composer_row_has_edge " $(printf '\u2584\u2584\u2584')" \
+  fm_composer_row_has_edge " $(printf '▄▄▄')" \
     || fail "the upper half-block rule must count as a structural edge"
   # Non-vacuousness: the footer rows really are non-blank content that would be
   # swallowed if the rule did not bound the region.
   case "$plain" in *"Run Everything"*) : ;; *) fail "fixture lost its footer content" ;; esac
   ESC_LOCAL=$(printf '\033')
-  screen=$'transcript\n \u2584\u2584\u2584\u2584\u2584\u2584\u2584\u2584\n'"  ${ESC_LOCAL}[2m\u2192 ${ESC_LOCAL}[0;7mA${ESC_LOCAL}[0;2mdd a follow-up${ESC_LOCAL}[0m"$'\n \u2580\u2580\u2580\u2580\u2580\u2580\u2580\u2580\n  Cursor Grok 4.5 High \u00b7 6.7%   Run Everything\n  ~/wt \u00b7 64cdd3a'
+  screen=$'transcript\n ▄▄▄▄▄▄▄▄\n'"  ${ESC_LOCAL}[2m→ ${ESC_LOCAL}[0;7mA${ESC_LOCAL}[0;2mdd a follow-up${ESC_LOCAL}[0m"$'\n ▀▀▀▀▀▀▀▀\n  Cursor Grok 4.5 High · 6.7%   Run Everything\n  ~/wt · 64cdd3a'
   out=$(fm_composer_classify_screen "$CAPS_STYLED" "$(printf '%b' "$screen")")
   [ "$out" = empty ] \
     || fail "an idle cursor composer inside herdr half-block rules must read empty, got '$out'"
@@ -664,3 +664,22 @@ test_queued_enter_verdict_does_not_convert_other_states() {
 test_queued_enter_verdict_busy_pending_is_empty
 test_queued_enter_verdict_idle_pending_stays_pending
 test_queued_enter_verdict_does_not_convert_other_states
+
+test_claude_current_footer_requires_selected_composer_adjacency() {
+  local foreign genuine rc
+  foreign=$'────────────────────────\n❯\n────────────────────────\nClaude 4.1\n✲ Working… (4s)\n'
+  if printf '%s' "$foreign" | fm_claude_current_footer_busy; then
+    fail "a foreign Working row below an idle Claude composer must not read busy"
+  else
+    rc=$?
+  fi
+  [ "$rc" -eq 2 ] \
+    || fail "a foreign Working row outside the selected composer boundary must read unknown, got rc=$rc"
+
+  genuine=$'────────────────────────\n❯\n────────────────────────\n✲ Pollinating… (16s · ↓ 1.1k tokens)\n'
+  printf '%s' "$genuine" | fm_claude_current_footer_busy \
+    || fail "a genuine Claude mid-turn footer immediately below its composer must read busy"
+  pass "fm_claude_current_footer_busy: the footer belongs to the selected composer boundary"
+}
+
+test_claude_current_footer_requires_selected_composer_adjacency


### PR DESCRIPTION
## Problem

Claude output can contain a footer-like `Working` row below an idle composer.
The rendered-busy classifier matched that row without proving that it belonged to the selected composer, so an idle pane could be reported as busy.

The regression was reproduced on `upstream/main` at `353a8f0f` before applying the fix:

```text
FM_TEST_BEGIN 2026-09-03T02:56:10Z tests/fm-backend-herdr.test.sh family=backend-dispatch expected_gate_skip=none
not ok - a foreign Working row outside the selected Claude composer boundary must be unknown, got 'busy'
FM_TEST_END 2026-09-03T03:01:50Z tests/fm-backend-herdr.test.sh exit=1 duration_ms=340558 gate_skip=false
```

The current base, `1c00e86c`, changes unrelated supervision-branch files and leaves every file in this regression unchanged.

## Fix

The shared composer classifier now exposes the selected composer boundary.
Claude rendered-busy detection accepts a current footer only when it is immediately adjacent to that boundary, including a proven closing edge.
Rows outside the boundary fail closed as `unknown`, while a genuine adjacent Claude active-turn footer remains `busy`.
The existing half-block fixture uses literal Unicode so the touched composer suite also runs correctly on macOS Bash 3.2.

## Tests

- `bin/fm-test-run.sh tests/fm-composer-lib.test.sh`
  - `FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0`
- `bin/fm-test-run.sh --per-script-timeout-secs 900 tests/fm-backend-herdr.test.sh`
  - `FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0`
- `bin/fm-lint.sh`
  - ShellCheck 0.11.0 and actionlint 1.7.12 passed.
- `bin/fm-doc-audience-check.sh`
  - `fm-doc-audience-check: ok surfaces=89 local_links=302`

## Evidence

The behavioral fixtures use captured Claude screen shapes for both sides of the boundary:

```text
────────────────────────
❯
────────────────────────
Claude 4.1
✲ Working… (4s)
```

The fixture above now returns `unknown` because the apparent footer is separated from the composer boundary by `Claude 4.1`.

```text
────────────────────────
❯
────────────────────────
✲ Pollinating… (16s · ↓ 1.1k tokens)
```

The genuine adjacent active-turn footer above remains `busy`.
