### PR TITLE
fix(bin): deliver secondmate outcomes to the parent channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This file is your entire job description.
 Address the user as "captain" at least once in every response.
 This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as "Captain, the build broke - ...".
 Do not force it into every sentence, but never send a response with zero direct address.
+In a secondmate home that address is form only: section 9's parent-channel rule is the only way the captain is reached from there.
 Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally.
 Keep that seasoning optional and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.
 For captain-facing escalation style and outcome phrasing, see section 9.
@@ -485,6 +486,7 @@ Reach the captain immediately for:
 - Anything destructive, irreversible, or security-sensitive.
 - A needed credential or login.
 
+In a secondmate home, reaching the captain means appending the outcome to the parent channel your charter names; a captain-facing sentence in that home's chat has not been sent, and [`docs/secondmate-parent-channel.md`](docs/secondmate-parent-channel.md) owns which outcomes the home's own scripts deliver there without you.
 Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
 When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
 Batch non-urgent updates into the next natural reply.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -239,6 +239,12 @@ You do not generate your own work.
 Act only on tasks the main firstmate routes to you.
 Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.
 
+# The captain and the parent channel
+Nobody reads this chat: the captain and the main firstmate see only what is appended to $STATUS_FILE, and a captain-facing sentence that is not appended there has not been sent.
+That file is your parent channel, and in this home it IS the captain: every sentence you would say to the captain, and every outcome the local AGENTS.md tells a firstmate to bring to the captain, is one appended line there, never chat.
+Your own machinery publishes the durable facts about your crew's work for you (\`bin/fm-parent-channel-lib.sh\`): a child's terminal done or failed line with its note and PR on every supervision poll, a PR-ready line when you register a PR, a task you hold for the captain and its answer, a merge, and a child's final line at cleanup all reach the parent channel from the scripts that record them, whether or not you append anything.
+What only you can append is judgement: the answer to a marked request below, a recommendation or caveat on a delivered outcome, a blocker or failure of your own, and anything else you would otherwise say to the captain.
+
 # Requests from the main firstmate
 You are a firstmate in your own home, so an incoming message reaches you in your own chat.
 You must distinguish who it is from, because the answer goes to a different place.

--- a/bin/fm-captain-hold.sh
+++ b/bin/fm-captain-hold.sh
@@ -123,6 +123,19 @@
 # Records written by the retired fm-decision-hold.sh (routed, declined,
 # answered, repaired) are recognized everywhere a record is read, so nothing
 # already closed needs rewriting.
+#
+# Parent channel: inside a secondmate home a task held for the captain, and its
+# answer, are captain-facing facts the moment they are recorded, so `hold`
+# publishes `needs-decision [key=captain-hold-<task>-<n>]` and `answer` (and
+# `answers`) the matching `resolved` line on the parent channel through
+# bin/fm-parent-channel-lib.sh, whether or not the mate model appends anything.
+# <n> is the count of resolution records the body already carries plus one, so
+# a released and re-held task opens and closes a distinct parent decision with
+# no new persisted state, and an exact retry republishes the same line, which
+# the channel deduplicates. A main home has no channel and publishes nothing.
+# The hold or answer is already durable in the backlog, so a channel that
+# cannot be written is reported as `actionable:` on stderr rather than undoing
+# the record; bin/fm-inactive-reconcile.sh's diagnostics name a broken binding.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -140,6 +153,19 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 # shellcheck source=bin/fm-wake-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-parent-channel-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-parent-channel-lib.sh"
+
+publish_parent_hold() {  # <task-id> <occurrence> <verb> <note>
+  local id=$1 occurrence=$2 verb=$3 note=$4 rc=0
+  fm_parent_channel_report "$FM_HOME" "$STATE" \
+    "$verb [key=captain-hold-$id-$occurrence]: captain hold $id: $(fm_parent_channel_clean_note "$note")" || rc=$?
+  case "$rc" in
+    0|1) ;;
+    *) printf 'actionable: task %s is held for the captain in this home but that did not reach the parent channel (rc=%s)\n' "$id" "$rc" >&2 ;;
+  esac
+}
 
 CAPTAIN_META_LOCK=
 CAPTAIN_META_LOCK_HELD=0
@@ -323,6 +349,11 @@ recorded_decision_digest() {  # <task-body>
   printf '%s' "$rest"
 }
 
+# How many resolution records the shown body carries, in either record format.
+resolution_record_count() {  # <task-body>
+  printf '%s' "$1" | grep -oE 'Resolution recorded by fm-(captain|decision)-hold\.' | wc -l | tr -d ' '
+}
+
 # The newest record's `Resolution mode:` value; empty for a record predating it.
 recorded_resolution_mode() {  # <task-body>
   local rest=$1
@@ -377,7 +408,7 @@ resolve_entry() {  # <origin-or-empty> <entry>; prints the resolved id or fails
 }
 
 command_hold() {
-  local id=${1:-} title='' reason='' repo='' origin='' until='' show state existing_title body='' hold_kind
+  local id=${1:-} title='' reason='' repo='' origin='' until='' show state existing_title body='' hold_kind occurrence
   [ "$#" -ge 1 ] || { usage >&2; exit 2; }
   shift
   while [ "$#" -gt 0 ]; do
@@ -441,6 +472,12 @@ command_hold() {
   show=$(task_show "$id") || fail "task $id disappeared while holding it"
   hold_kind=$(show_field_value "$show" hold_kind)
   [ "$hold_kind" = captain ] || fail "task $id did not retain its captain hold"
+  occurrence=$(( $(resolution_record_count "$(show_field "$show" body)") + 1 ))
+  if [ -n "$origin" ]; then
+    publish_parent_hold "$id" "$occurrence" needs-decision "$reason (origin $origin)"
+  else
+    publish_parent_hold "$id" "$occurrence" needs-decision "$reason"
+  fi
   printf '%s\n' "$id"
 }
 
@@ -476,7 +513,7 @@ close_answered() {  # <task-id> <release-0-or-1>
 }
 
 command_answer() {
-  local id=${1:-} decision_file='' release=0 show state hold_kind body outcome recorded_mode
+  local id=${1:-} decision_file='' release=0 show state hold_kind body outcome recorded_mode occurrence
   [ "$#" -ge 1 ] || { usage >&2; exit 2; }
   shift
   while [ "$#" -gt 0 ]; do
@@ -495,6 +532,9 @@ command_answer() {
   hold_kind=$(show_field_value "$show" hold_kind)
   body=$(show_field "$show" body)
   if [ "$release" = 1 ]; then outcome=released; else outcome=answered; fi
+  # The occurrence the parent line names: the record about to be written is
+  # one past those already in the body, and a retry names the newest one.
+  occurrence=$(( $(resolution_record_count "$body") + 1 ))
 
   if [ "$state" = "done" ]; then
     if body_has_resolution_record "$body"; then
@@ -506,6 +546,11 @@ command_answer() {
         || fail "task $id records this answer with mode released; a closed task cannot replay that release"
       [ "$release" = 0 ] \
         || fail "task $id records this answer with mode ${recorded_mode:-unknown}; --release cannot reopen a closed task"
+      if [ "$recorded_mode" = repaired ]; then
+        publish_parent_hold "$id" $((occurrence - 1)) resolved "answered (repaired)"
+      else
+        publish_parent_hold "$id" $((occurrence - 1)) resolved answered
+      fi
       printf 'answered: %s\n' "$id"
       return 0
     fi
@@ -520,6 +565,7 @@ command_answer() {
     [ "$(show_field "$show" state)" = "done" ] || fail "recording the answer reopened closed task $id"
     body_has_resolution_record "$(show_field "$show" body)" \
       || fail "captain-held task $id did not retain its durable resolution record"
+    publish_parent_hold "$id" "$occurrence" resolved "answered (repaired)"
     printf 'repaired: %s\n' "$id"
     return 0
   fi
@@ -539,6 +585,7 @@ command_answer() {
         answered) [ "$release" = 0 ] || fail "task $id records this answer as a close; retry without --release" ;;
       esac
       close_answered "$id" "$release"
+      publish_parent_hold "$id" $((occurrence - 1)) resolved "$outcome"
       printf '%s: %s\n' "$outcome" "$id"
       return 0
     fi
@@ -547,6 +594,7 @@ command_answer() {
     show=$(task_show "$id") || fail "task $id disappeared after closing"
     body_has_resolution_record "$(show_field "$show" body)" \
       || fail "captain-held task $id did not retain its durable resolution record"
+    publish_parent_hold "$id" "$occurrence" resolved "$outcome"
     printf '%s: %s\n' "$outcome" "$id"
     return 0
   fi
@@ -558,6 +606,7 @@ command_answer() {
       || fail "task $id records a different captain decision with mode ${recorded_mode:-unknown}"
     [ "$recorded_mode" = released ] && [ "$release" = 1 ] \
       || fail "task $id records this answer with mode ${recorded_mode:-unknown}; replay requires matching --release"
+    publish_parent_hold "$id" $((occurrence - 1)) resolved released
     printf 'released: %s\n' "$id"
     return 0
   fi
@@ -753,6 +802,9 @@ command_answers() {
     fi
     # shellcheck disable=SC2086  # release_flag is empty or a single literal flag.
     if "$0" answer "$id" --decision-file "$tmp" $release_flag </dev/null >/dev/null 2>"$err"; then
+      # A parent-channel delivery problem is reported on stderr by the answer
+      # path even when the close succeeded; keep it visible.
+      [ ! -s "$err" ] || cat "$err" >&2
       printf 'closed: %s\n' "$id"
       closed=$((closed + 1))
     else

--- a/bin/fm-captain-hold.sh
+++ b/bin/fm-captain-hold.sh
@@ -706,7 +706,7 @@ sanitize_field() {  # <text>
 
 command_answers() {
   local origin='' source='' row rest key answer label mode id show state hold_kind body digest legacy_digest legacy_key
-  local recorded_digest recorded_mode tmp err closed=0 skipped=0 reason release_flag tab=$'\t'
+  local recorded_digest recorded_mode occurrence tmp err closed=0 skipped=0 reason release_flag tab=$'\t'
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --source) shift; source=${1:-} ;;
@@ -785,6 +785,12 @@ command_answers() {
       if { [ -z "$release_flag" ] && [ "$state" = "done" ] && [ "$recorded_mode" != released ]; } \
         || { [ "$release_flag" = --release ] && [ "$state" != "done" ] \
           && [ "$hold_kind" != captain ] && [ "$recorded_mode" = released ]; }; then
+        occurrence=$(resolution_record_count "$body")
+        case "$recorded_mode" in
+          repaired) publish_parent_hold "$id" "$occurrence" resolved "answered (repaired)" ;;
+          released) publish_parent_hold "$id" "$occurrence" resolved released ;;
+          *) publish_parent_hold "$id" "$occurrence" resolved answered ;;
+        esac
         printf 'closed: %s\n' "$id"
         closed=$((closed + 1))
         continue

--- a/bin/fm-captain-hold.sh
+++ b/bin/fm-captain-hold.sh
@@ -476,11 +476,7 @@ command_hold() {
   hold_kind=$(show_field_value "$show" hold_kind)
   [ "$hold_kind" = captain ] || fail "task $id did not retain its captain hold"
   occurrence=$(( $(resolution_record_count "$(show_field "$show" body)") + 1 ))
-  if [ -n "$origin" ]; then
-    publish_parent_hold "$id" "$occurrence" needs-decision "$reason (origin $origin)"
-  else
-    publish_parent_hold "$id" "$occurrence" needs-decision "$reason"
-  fi
+  publish_parent_hold "$id" "$occurrence" needs-decision "$reason"
   printf '%s\n' "$id"
 }
 

--- a/bin/fm-captain-hold.sh
+++ b/bin/fm-captain-hold.sh
@@ -351,7 +351,10 @@ recorded_decision_digest() {  # <task-body>
 
 # How many resolution records the shown body carries, in either record format.
 resolution_record_count() {  # <task-body>
-  printf '%s' "$1" | grep -oE 'Resolution recorded by fm-(captain|decision)-hold\.' | wc -l | tr -d ' '
+  local body
+  body=$(decode_shown_value "$1") || return 1
+  printf '%s\n' "$body" \
+    | grep -Ec '^Resolution recorded by fm-(captain|decision)-hold\.$' || true
 }
 
 # The newest record's `Resolution mode:` value; empty for a record predating it.

--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -56,15 +56,17 @@
 # receipt is durable.
 # In a secondmate home, that receipt is an idempotent parent-channel append
 # through bin/fm-parent-channel-lib.sh; the ledger-first path and the inactive
-# path share the same receipt store and fingerprint shape.
+# path share the same receipt store.
 # In a main home, a presentation-stage record is acknowledged by fm-wake-drain
 # only after its corresponding inactive-outcome wake is handled.
 # A receipt is intentionally independent of .hb-surfaced-* bookkeeping.
 #
 # New fm-terminal-outcome.v1 receipts contain schema, fingerprint, task_id,
 # incarnation, state, outcome_key, origin, phase, pr, created_epoch, and
-# notice_emitted; the fingerprint binds the spawn incarnation, task id, terminal
-# state, PR text, and sanitized last status.
+# notice_emitted. The inactive-path fingerprint binds the spawn incarnation,
+# task id, terminal state, PR text, and sanitized last status; the ledger-path
+# fingerprint instead binds the incarnation, task id, terminal state, literal
+# `ledger` origin, and complete terminal ledger line.
 # Pending atomically becomes reported after parent append or presented after
 # main-home acknowledgement. The atomic epoch/cursor marker's mtime gates scans,
 # and its cursor records the last child visited within the aggregate budget.

--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -396,7 +396,7 @@ ledger_pass() {
     valid_id "$id" || continue
     [ "$(meta_field "$meta" kind)" != secondmate ] || continue
     lock=$(fm_meta_lock_path "$meta") || continue
-    fm_lock_acquire_wait "$lock" || continue
+    fm_lock_try_acquire "$lock" || continue
     report_child_ledger_locked "$id" "$meta" || true
     fm_lock_release "$lock"
   done

--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -344,10 +344,12 @@ notice_parent_report_failed() { # <record> <fingerprint> <payload>
 # is absent, unusable, still being appended (no trailing newline yet), or does
 # not end in a done or failed line.
 child_terminal_ledger_line() { # <status>
-  local status=$1 last
+  local status=$1 snapshot last marker='__FM_LEDGER_SNAPSHOT_END__'
   [ -f "$status" ] && [ ! -L "$status" ] && [ -s "$status" ] || return 1
-  [ "$(tail -c 1 "$status" | od -An -tu1 | tr -d '[:space:]')" = 10 ] || return 1
-  last=$(last_status_line "$status")
+  snapshot=$(cat "$status"; printf '%s' "$marker") || return 1
+  case "$snapshot" in *$'\n'"$marker") ;; *) return 1 ;; esac
+  snapshot=${snapshot%"$marker"}
+  last=$(printf '%s' "$snapshot" | grep -v '^[[:space:]]*$' | tail -1)
   case "$(status_line_verb "$last")" in
     done|failed) printf '%s\n' "$last" ;;
     *) return 1 ;;
@@ -441,6 +443,9 @@ reconcile_direct_child_locked() { # <id> <meta> <secondmate-id-or-empty> <timeou
   state_line=$(fm_run_timed "$timeout" env FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" \
     "$CREW_STATE_BIN" "$id" 2>/dev/null) || state_rc=$?
   [ "$state_rc" -ne 124 ] || return 3
+  if [ -n "$self" ] && child_terminal_ledger_line "$status" >/dev/null; then
+    return 0
+  fi
   case "$state_line" in
     'state: done '*) state='done' ;;
     'state: failed '*) state='failed' ;;

--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -13,7 +13,7 @@
 # ledger ends in a whole `done:` or `failed:` line has stated its own outcome,
 # so that line is published on the parent channel at once through
 # bin/fm-parent-channel-lib.sh as
-#   <state> [key=child-outcome-<child>-<state>]: child <child> <state>: <note> [pr=<url>] [mode=<mode>] [yolo=<posture>] [report=data/<child>/report.md]
+#   <state> [key=child-outcome-<child>-<state>-<fp8>]: child <child> <state>: <note> [pr=<url>] [mode=<mode>] [yolo=<posture>] [report=data/<child>/report.md]
 # carrying the child's recorded PR, delivery mode, merge posture, and scout
 # report pointer, without consulting fm-crew-state.sh and without waiting for
 # the inactive cadence. A line still being appended (no trailing newline yet)
@@ -366,7 +366,7 @@ report_child_ledger_locked() { # <id> <meta>
   pr=$(pr_for_task "$meta" "$status" "$last")
   incarnation=$(meta_incarnation "$meta")
   fingerprint=$(sha256_text "$incarnation|$id|$state|ledger|$last")
-  outcome_key="child-outcome-$id-$state"
+  outcome_key="child-outcome-$id-$state-${fingerprint:0:8}"
   ensure_record "$fingerprint" "$id" "$incarnation" "$state" "$outcome_key" direct upstream "$pr" || return 1
   [ -n "$RECORD_PENDING" ] || return 0
   note=$(clean_field "$(status_line_note "$last")")

--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -361,7 +361,7 @@ report_child_ledger_locked() { # <id> <meta>
   state=$(status_line_verb "$last")
   pr=$(pr_for_task "$meta" "$status")
   incarnation=$(meta_incarnation "$meta")
-  fingerprint=$(sha256_text "$incarnation|$id|$state|ledger|$(clean_field "$last")")
+  fingerprint=$(sha256_text "$incarnation|$id|$state|ledger|$last")
   outcome_key="child-outcome-$id-$state"
   ensure_record "$fingerprint" "$id" "$incarnation" "$state" "$outcome_key" direct upstream "$pr" || return 1
   [ -n "$RECORD_PENDING" ] || return 0
@@ -594,8 +594,6 @@ case "$mode" in
       printf 'usage: fm-inactive-reconcile.sh report <task-id>\n' >&2
       exit 2
     fi
-    fm_lock_acquire_wait "$SCAN_LOCK" || exit 1
-    trap 'fm_lock_release "$SCAN_LOCK"' EXIT
     report_child "$2"
     ;;
   acknowledge)

--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -3,14 +3,34 @@
 #
 # Usage:
 #   fm-inactive-reconcile.sh scan [--startup]
+#   fm-inactive-reconcile.sh report <task-id>
 #   fm-inactive-reconcile.sh acknowledge <fingerprint>
 #
 # This is an adjunct to the existing watcher poll loop and session-start path,
 # not a watcher, daemon, PR poll, or forge client of its own.
-# `scan` evaluates at most once per FM_INACTIVE_RECONCILE_SECS (default 900,
-# valid 60..1800) per home, except that --startup performs the same scan
-# immediately in the locked session start's deferred worker. Each scan uses an
-# aggregate FM_INACTIVE_RECONCILE_BUDGET_SECS deadline (default 10, valid 1..30) and
+# In a secondmate home every `scan` invocation, which is every watcher poll,
+# first runs the LEDGER-FIRST parent delivery: a direct child whose status
+# ledger ends in a whole `done:` or `failed:` line has stated its own outcome,
+# so that line is published on the parent channel at once through
+# bin/fm-parent-channel-lib.sh as
+#   <state> [key=child-outcome-<child>-<state>]: child <child> <state>: <note> [pr=<url>] [mode=<mode>] [yolo=<posture>] [report=data/<child>/report.md]
+# carrying the child's recorded PR, delivery mode, merge posture, and scout
+# report pointer, without consulting fm-crew-state.sh and without waiting for
+# the inactive cadence. A line still being appended (no trailing newline yet)
+# is left for the next poll. This is what keeps a mate's PR-ready, finding,
+# and failure outcomes from depending on the mate model appending them
+# (docs/secondmate-parent-channel.md). A main home has no parent channel and
+# skips this path: its watcher already signals every child status line.
+# `report <task-id>` runs that same delivery for one child on behalf of a
+# caller that already holds the child's meta lock, which bin/fm-teardown.sh
+# does before it removes the child's record; it exits 0 when the line is
+# delivered or nothing is owed, and non-zero when the parent channel could not
+# be written, so teardown refuses instead of discarding an undelivered outcome.
+# The cadence-gated scan below then evaluates at most once per
+# FM_INACTIVE_RECONCILE_SECS (default 900, valid 60..1800) per home, except
+# that --startup performs the same scan immediately in the locked session
+# start's deferred worker. Each scan uses an aggregate
+# FM_INACTIVE_RECONCILE_BUDGET_SECS deadline (default 10, valid 1..30) and
 # resumes after its last visited child on the next scan.
 # The scan enforces that budget itself through a whole-second deadline, and the
 # first due child of every scan is always visited with at least a one-second
@@ -23,7 +43,10 @@
 #
 # It considers only a direct ordinary crewmate whose newest meta, status, or
 # turn-ended mtime is older than that interval and whose last status is not
-# captain-held. It then uses fm-crew-state.sh as the sole current-state source.
+# captain-held. In a secondmate home a child whose ledger already ends in a
+# terminal done or failed line belongs to the ledger-first path above and is
+# skipped here, so one outcome is never reported twice. It then uses
+# fm-crew-state.sh as the sole current-state source.
 # Only a done or failed state is suspicious enough to create a durable terminal
 # outcome record or wake the supervisor.
 # Working, paused, parked, blocked, unknown, persistent secondmates, and
@@ -31,8 +54,9 @@
 #
 # A terminal-outcomes/<fingerprint>.pending record remains until its upstream
 # receipt is durable.
-# In a secondmate home, that receipt is an idempotent parent-channel status
-# append.
+# In a secondmate home, that receipt is an idempotent parent-channel append
+# through bin/fm-parent-channel-lib.sh; the ledger-first path and the inactive
+# path share the same receipt store and fingerprint shape.
 # In a main home, a presentation-stage record is acknowledged by fm-wake-drain
 # only after its corresponding inactive-outcome wake is handled.
 # A receipt is intentionally independent of .hb-surfaced-* bookkeeping.
@@ -62,8 +86,8 @@ CREW_STATE_BIN="${FM_INACTIVE_CREW_STATE_BIN:-$SCRIPT_DIR/fm-crew-state.sh}"
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
-# shellcheck source=bin/fm-secondmate-parent-lib.sh
-. "$SCRIPT_DIR/fm-secondmate-parent-lib.sh"
+# shellcheck source=bin/fm-parent-channel-lib.sh
+. "$SCRIPT_DIR/fm-parent-channel-lib.sh"
 # shellcheck source=bin/fm-timeout-lib.sh
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
 
@@ -290,44 +314,104 @@ pr_for_task() { # <meta> <status>
 }
 
 home_secondmate_id() {
-  local marker="$FM_HOME/.fm-secondmate-home" id
-  if [ ! -e "$marker" ] && [ ! -L "$marker" ]; then
-    return 1
-  fi
-  [ -f "$marker" ] && [ ! -L "$marker" ] || return 2
-  [ "$(wc -c < "$marker")" -eq "$(LC_ALL=C tr -d '\0' < "$marker" | wc -c)" ] || return 2
-  id=$(cat "$marker" 2>/dev/null) || return 2
-  valid_id "$id" || return 2
-  printf '%s\n' "$id"
+  fm_parent_channel_home_id "$FM_HOME"
 }
 
-append_once() { # <path> <line>
-  local path=$1 line=$2
-  [ ! -L "$path" ] || return 1
-  mkdir -p "$(dirname "$path")" || return 1
-  if grep -Fqx -- "$line" "$path" 2>/dev/null; then
-    return 0
-  fi
-  printf '%s\n' "$line" >> "$path"
-}
-
-report_to_parent() { # <self-id> <task> <state> <outcome-key> <fingerprint> <pr>
-  local self=$1 task=$2 state=$3 outcome_key=$4 fingerprint=$5 pr=$6 parent_record destination line
-  parent_record="$FM_HOME/.fm-secondmate-parent"
-  fm_secondmate_parent_record_parse "$parent_record" || return 1
-  case "$FM_SECONDMATE_PARENT_ROUTE" in
-    local)
-      [ -n "$FM_SECONDMATE_PARENT_HOME" ] || return 1
-      destination="$FM_SECONDMATE_PARENT_HOME/state/$self.status"
-      ;;
-    remote)
-      destination="$STATE/parent-replies.status"
-      ;;
-    *) return 1 ;;
-  esac
+report_to_parent() { # <task> <state> <outcome-key> <fingerprint> <pr>
+  local task=$1 state=$2 outcome_key=$3 fingerprint=$4 pr=$5 line
   line="$state [key=$outcome_key]: inactive terminal child=$task fingerprint=$fingerprint"
   [ -z "$pr" ] || line="$line pr=$pr"
-  append_once "$destination" "$line"
+  fm_parent_channel_report "$FM_HOME" "$STATE" "$line"
+}
+
+# Queue the once-per-record notice that a parent report could not be written.
+# A home seeded without its parent binding cannot report upward at all, and
+# every later terminal outcome fails the same way for the same reason, so the
+# binding is named when it is the cause.
+notice_parent_report_failed() { # <record> <fingerprint> <payload>
+  local record=$1 fingerprint=$2 payload=$3
+  if ! fm_secondmate_parent_record_parse "$FM_HOME/.fm-secondmate-parent"; then
+    payload="$payload (missing or unreadable parent binding .fm-secondmate-parent)"
+  fi
+  queue_notice_once "$record" "inactive-reconcile:$fingerprint" "$payload" || true
+}
+
+# The whole terminal line a child's ledger ends in, or non-zero when the ledger
+# is absent, unusable, still being appended (no trailing newline yet), or does
+# not end in a done or failed line.
+child_terminal_ledger_line() { # <status>
+  local status=$1 last
+  [ -f "$status" ] && [ ! -L "$status" ] && [ -s "$status" ] || return 1
+  [ "$(tail -c 1 "$status" | od -An -tu1 | tr -d '[:space:]')" = 10 ] || return 1
+  last=$(last_status_line "$status")
+  case "$(status_line_verb "$last")" in
+    done|failed) printf '%s\n' "$last" ;;
+    *) return 1 ;;
+  esac
+}
+
+# The ledger-first parent delivery for one direct child, for a caller holding
+# the child's meta lock. Returns 0 when the line is delivered, already
+# delivered, or nothing is owed, and 1 when it is owed but the parent channel
+# could not be written (the notice is queued once per record).
+report_child_ledger_locked() { # <id> <meta>
+  local id=$1 meta=$2 status last state note pr mode yolo data incarnation fingerprint outcome_key line
+  status="$STATE/$id.status"
+  last=$(child_terminal_ledger_line "$status") || return 0
+  state=$(status_line_verb "$last")
+  pr=$(pr_for_task "$meta" "$status")
+  incarnation=$(meta_incarnation "$meta")
+  fingerprint=$(sha256_text "$incarnation|$id|$state|ledger|$(clean_field "$last")")
+  outcome_key="child-outcome-$id-$state"
+  ensure_record "$fingerprint" "$id" "$incarnation" "$state" "$outcome_key" direct upstream "$pr" || return 1
+  [ -n "$RECORD_PENDING" ] || return 0
+  note=$(clean_field "$(status_line_note "$last")")
+  mode=$(clean_field "$(meta_field "$meta" mode)")
+  yolo=$(clean_field "$(meta_field "$meta" yolo)")
+  data="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+  line="$state [key=$outcome_key]: child $id $state: $note"
+  [ -z "$pr" ] || line="$line pr=$pr"
+  [ -z "$mode" ] || line="$line mode=$mode"
+  [ -z "$yolo" ] || line="$line yolo=$yolo"
+  if [ -f "$data/$id/report.md" ] && [ ! -L "$data/$id/report.md" ]; then
+    line="$line report=data/$id/report.md"
+  fi
+  if fm_parent_channel_report "$FM_HOME" "$STATE" "$line"; then
+    mark_reported "$RECORD_PENDING" || return 1
+    return 0
+  fi
+  notice_parent_report_failed "$RECORD_PENDING" "$fingerprint" \
+    "child outcome needs parent report: child=$id state=$state"
+  return 1
+}
+
+# Every direct child's ledger, under its meta lock. Cheap file reads only, so
+# it runs on every poll in a secondmate home; a delivery failure is already
+# queued as a notice and never fails the scan.
+ledger_pass() {
+  local meta id lock
+  for meta in "$STATE"/*.meta; do
+    [ -f "$meta" ] || continue
+    id=$(basename "$meta" .meta)
+    valid_id "$id" || continue
+    [ "$(meta_field "$meta" kind)" != secondmate ] || continue
+    lock=$(fm_meta_lock_path "$meta") || continue
+    fm_lock_acquire_wait "$lock" || continue
+    report_child_ledger_locked "$id" "$meta" || true
+    fm_lock_release "$lock"
+  done
+}
+
+# The `report <task-id>` entry point: the caller holds the child's meta lock.
+report_child() { # <id>
+  local id=$1 meta rc=0
+  mkdir -p "$STATE" "$OUTCOME_DIR" || return 1
+  [ ! -L "$OUTCOME_DIR" ] || return 1
+  home_secondmate_id >/dev/null || { rc=$?; [ "$rc" -eq 1 ] && return 0; return 1; }
+  meta="$STATE/$id.meta"
+  [ -f "$meta" ] && [ ! -L "$meta" ] || return 0
+  [ "$(meta_field "$meta" kind)" != secondmate ] || return 0
+  report_child_ledger_locked "$id" "$meta"
 }
 
 reconcile_direct_child_locked() { # <id> <meta> <secondmate-id-or-empty> <timeout>
@@ -339,6 +423,10 @@ reconcile_direct_child_locked() { # <id> <meta> <secondmate-id-or-empty> <timeou
   turn="$STATE/$id.turn-ended"
   last=$(last_status_line "$status")
   status_line_verb "$last" | grep -Fx captain-held >/dev/null 2>&1 && return 0
+  # A ledger that states its own outcome is the ledger-first path's to deliver.
+  if [ -n "$self" ] && child_terminal_ledger_line "$status" >/dev/null; then
+    return 0
+  fi
   age=$(last_activity_age "$meta" "$status" "$turn")
   [ "$age" -ge "$FM_INACTIVE_RECONCILE_SECS" ] || return 0
   state_line=$(fm_run_timed "$timeout" env FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" \
@@ -360,18 +448,11 @@ reconcile_direct_child_locked() { # <id> <meta> <secondmate-id-or-empty> <timeou
   ensure_record "$fingerprint" "$id" "$incarnation" "$state" "$outcome_key" direct "upstream" "$pr" || return 1
   [ -n "$RECORD_PENDING" ] || return 0
   if [ -n "$self" ]; then
-    if report_to_parent "$self" "$id" "$state" "$outcome_key" "$fingerprint" "$pr"; then
+    if report_to_parent "$id" "$state" "$outcome_key" "$fingerprint" "$pr"; then
       mark_reported "$RECORD_PENDING" || return 1
     else
-      payload="inactive terminal outcome needs parent report: child=$id state=$state"
-      # A home seeded without its parent binding cannot report upward at all,
-      # and every later terminal outcome fails the same way for the same
-      # reason. Name the missing binding so the diagnostic points at the repair
-      # instead of reading as one report that happened to fail.
-      if ! fm_secondmate_parent_record_parse "$FM_HOME/.fm-secondmate-parent"; then
-        payload="$payload (missing or unreadable parent binding .fm-secondmate-parent)"
-      fi
-      queue_notice_once "$RECORD_PENDING" "inactive-reconcile:$fingerprint" "$payload" || true
+      notice_parent_report_failed "$RECORD_PENDING" "$fingerprint" \
+        "inactive terminal outcome needs parent report: child=$id state=$state"
     fi
     return 0
   fi
@@ -431,22 +512,23 @@ scan() {
   local startup=${1:-0} self='' cursor deadline rc=0 marker_rc=0
   mkdir -p "$STATE" "$OUTCOME_DIR" || return 1
   [ ! -L "$OUTCOME_DIR" ] || return 1
+  if self=$(home_secondmate_id); then
+    # The ledger-first delivery is per poll, not per cadence.
+    ledger_pass
+  else
+    marker_rc=$?
+    self=''
+  fi
   if [ "$startup" != 1 ] && [ "$(scan_marker_age)" -lt "$FM_INACTIVE_RECONCILE_SECS" ]; then
     return 0
   fi
   cursor=$(scan_marker_cursor)
   valid_id "$cursor" || cursor=''
   write_scan_marker "$cursor" || return 1
-  if self=$(home_secondmate_id); then
-    :
-  else
-    marker_rc=$?
-    self=''
-    if [ "$marker_rc" -ne 1 ]; then
-      publish_actionable "inactive-reconcile-diagnostic:invalid-secondmate-home" \
-        "inactive terminal outcomes remain unreconciled: invalid .fm-secondmate-home marker" || true
-      return 0
-    fi
+  if [ -z "$self" ] && [ "$marker_rc" -ne 1 ]; then
+    publish_actionable "inactive-reconcile-diagnostic:invalid-secondmate-home" \
+      "inactive terminal outcomes remain unreconciled: invalid .fm-secondmate-home marker" || true
+    return 0
   fi
   deadline=$(( $(date +%s) + FM_INACTIVE_RECONCILE_BUDGET_SECS ))
   SCAN_FIRST_VISIT_PENDING=1
@@ -506,6 +588,15 @@ case "$mode" in
     fm_lock_acquire_wait "$SCAN_LOCK" || exit 1
     trap 'fm_lock_release "$SCAN_LOCK"' EXIT
     scan "$2"
+    ;;
+  report)
+    if [ "$#" -ne 2 ] || ! valid_id "$2"; then
+      printf 'usage: fm-inactive-reconcile.sh report <task-id>\n' >&2
+      exit 2
+    fi
+    fm_lock_acquire_wait "$SCAN_LOCK" || exit 1
+    trap 'fm_lock_release "$SCAN_LOCK"' EXIT
+    report_child "$2"
     ;;
   acknowledge)
     [ "$#" -eq 2 ] || { printf 'usage: fm-inactive-reconcile.sh acknowledge <fingerprint>\n' >&2; exit 2; }

--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -304,11 +304,15 @@ meta_incarnation() { # <meta>
   printf 'legacy-%s\n' "$(sha256_text "$identity")"
 }
 
-pr_for_task() { # <meta> <status>
-  local pr=$1 status=$2 value
-  value=$(meta_field "$pr" pr)
+pr_for_task() { # <meta> <status> [preferred-line]
+  local meta=$1 status=$2 preferred=${3:-} value
+  value=$(meta_field "$meta" pr)
+  if [ -z "$value" ] && [ -n "$preferred" ]; then
+    value=$(printf '%s\n' "$preferred" \
+      | grep -Eo 'https?://[^[:space:])"]+/pull/[0-9]+' | head -1 || true)
+  fi
   if [ -z "$value" ] && [ -f "$status" ]; then
-    value=$(grep -Eo 'https?://[^[:space:])"]+/pull/[0-9]+' "$status" 2>/dev/null | head -1 || true)
+    value=$(grep -Eo 'https?://[^[:space:])"]+/pull/[0-9]+' "$status" 2>/dev/null | tail -1 || true)
   fi
   clean_field "$value"
 }
@@ -359,7 +363,7 @@ report_child_ledger_locked() { # <id> <meta>
   status="$STATE/$id.status"
   last=$(child_terminal_ledger_line "$status") || return 0
   state=$(status_line_verb "$last")
-  pr=$(pr_for_task "$meta" "$status")
+  pr=$(pr_for_task "$meta" "$status" "$last")
   incarnation=$(meta_incarnation "$meta")
   fingerprint=$(sha256_text "$incarnation|$id|$state|ledger|$last")
   outcome_key="child-outcome-$id-$state"
@@ -397,6 +401,11 @@ ledger_pass() {
     [ "$(meta_field "$meta" kind)" != secondmate ] || continue
     lock=$(fm_meta_lock_path "$meta") || continue
     fm_lock_try_acquire "$lock" || continue
+    if [ ! -f "$meta" ] || [ -L "$meta" ] \
+      || [ "$(meta_field "$meta" kind)" = secondmate ]; then
+      fm_lock_release "$lock"
+      continue
+    fi
     report_child_ledger_locked "$id" "$meta" || true
     fm_lock_release "$lock"
   done

--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -63,10 +63,14 @@
 #
 # New fm-terminal-outcome.v1 receipts contain schema, fingerprint, task_id,
 # incarnation, state, outcome_key, origin, phase, pr, created_epoch, and
-# notice_emitted. The inactive-path fingerprint binds the spawn incarnation,
-# task id, terminal state, PR text, and sanitized last status; the ledger-path
-# fingerprint instead binds the incarnation, task id, terminal state, literal
-# `ledger` origin, and complete terminal ledger line.
+# notice_emitted, plus optional status_head and ledger_claim fields. The
+# inactive-path fingerprint binds the spawn incarnation, task id, terminal
+# state, PR text, and sanitized last status; the ledger-path fingerprint instead
+# binds the incarnation, task id, terminal state, literal `ledger` origin, and
+# complete terminal ledger line.
+# When a terminal ledger append races just after the inactive path's final read,
+# ledger_claim binds that one ledger fingerprint to the already-delivered
+# inactive receipt so the two publishers cannot report one completion twice.
 # Pending atomically becomes reported after parent append or presented after
 # main-home acknowledgement. The atomic epoch/cursor marker's mtime gates scans,
 # and its cursor records the last child visited within the aggregate budget.
@@ -182,8 +186,8 @@ record_field_set() {
   mv -f "$tmp" "$record"
 }
 
-ensure_record() { # <fingerprint> <task> <incarnation> <state> <outcome-key> <origin> <phase> <pr>
-  local fingerprint=$1 task=$2 incarnation=$3 state=$4 outcome_key=$5 origin=$6 phase=$7 pr=$8 tmp
+ensure_record() { # <fingerprint> <task> <incarnation> <state> <outcome-key> <origin> <phase> <pr> [status-head]
+  local fingerprint=$1 task=$2 incarnation=$3 state=$4 outcome_key=$5 origin=$6 phase=$7 pr=$8 status_head=${9:-} tmp
   RECORD_PENDING=$(record_path "$fingerprint" pending)
   RECORD_PRESENTED=$(record_path "$fingerprint" presented)
   RECORD_REPORTED=$(record_path "$fingerprint" reported)
@@ -209,6 +213,7 @@ ensure_record() { # <fingerprint> <task> <incarnation> <state> <outcome-key> <or
     printf 'pr=%s\n' "$pr"
     printf 'created_epoch=%s\n' "$(reconcile_now)"
     printf 'notice_emitted=0\n'
+    [ -z "$status_head" ] || printf 'status_head=%s\n' "$status_head"
   } > "$tmp" || { rm -f "$tmp"; return 1; }
   chmod 600 "$tmp" 2>/dev/null || true
   mv -f "$tmp" "$RECORD_PENDING" || { rm -f "$tmp"; return 1; }
@@ -358,21 +363,58 @@ child_terminal_ledger_line() { # <status>
   esac
 }
 
+# Claim one already-delivered inactive fallback as the delivery of this ledger
+# event. Both reconciliation paths hold the child's meta lock, so this receipt
+# update serializes their decision even though the child appends its ledger
+# without that lock. The claim stores the exact ledger fingerprint: a retry of
+# this event stays suppressed, while a later terminal line remains a new event.
+claim_inactive_report_for_ledger() { # <task> <incarnation> <state> <ledger-fingerprint> <predecessor-head>
+  local task=$1 incarnation=$2 state=$3 ledger_fingerprint=$4 predecessor_head=$5 record key claim
+  for record in "$OUTCOME_DIR"/*.reported; do
+    [ -f "$record" ] && [ ! -L "$record" ] || continue
+    [ "$(record_value "$record" task_id)" = "$task" ] || continue
+    [ "$(record_value "$record" incarnation)" = "$incarnation" ] || continue
+    [ "$(record_value "$record" state)" = "$state" ] || continue
+    key=$(record_value "$record" outcome_key)
+    case "$key" in inactive-outcome-*) ;; *) continue ;; esac
+    [ "$(record_value "$record" status_head)" = "$predecessor_head" ] || continue
+    claim=$(record_value "$record" ledger_claim)
+    if [ "$claim" = "$ledger_fingerprint" ]; then
+      return 0
+    fi
+    [ -z "$claim" ] || continue
+    record_field_set "$record" ledger_claim "$ledger_fingerprint" || return 2
+    return 0
+  done
+  return 1
+}
+
 # The ledger-first parent delivery for one direct child, for a caller holding
 # the child's meta lock. Returns 0 when the line is delivered, already
 # delivered, or nothing is owed, and 1 when it is owed but the parent channel
 # could not be written (the notice is queued once per record).
 report_child_ledger_locked() { # <id> <meta>
-  local id=$1 meta=$2 status last state note pr mode yolo data incarnation fingerprint outcome_key line
+  local id=$1 meta=$2 status last previous state note pr mode yolo data incarnation fingerprint predecessor_head outcome_key line
   status="$STATE/$id.status"
   last=$(child_terminal_ledger_line "$status") || return 0
   state=$(status_line_verb "$last")
   pr=$(pr_for_task "$meta" "$status" "$last")
   incarnation=$(meta_incarnation "$meta")
   fingerprint=$(sha256_text "$incarnation|$id|$state|ledger|$last")
+  previous=$(grep -v '^[[:space:]]*$' "$status" 2>/dev/null \
+    | tail -2 | awk 'NR == 1 { first = $0 } NR == 2 { print first }' || true)
+  predecessor_head=$(sha256_text "$previous")
   outcome_key="child-outcome-$id-$state-${fingerprint:0:8}"
   ensure_record "$fingerprint" "$id" "$incarnation" "$state" "$outcome_key" direct upstream "$pr" || return 1
   [ -n "$RECORD_PENDING" ] || return 0
+  if claim_inactive_report_for_ledger "$id" "$incarnation" "$state" "$fingerprint" "$predecessor_head"; then
+    # The fallback line is already on the parent channel. This reported ledger
+    # receipt records that its richer rendering owes no second publication.
+    mark_reported "$RECORD_PENDING" || return 1
+    return 0
+  elif [ "$?" -eq 2 ]; then
+    return 1
+  fi
   note=$(clean_field "$(status_line_note "$last")")
   mode=$(clean_field "$(meta_field "$meta" mode)")
   yolo=$(clean_field "$(meta_field "$meta" yolo)")
@@ -445,8 +487,9 @@ reconcile_direct_child_locked() { # <id> <meta> <secondmate-id-or-empty> <timeou
   state_line=$(fm_run_timed "$timeout" env FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" \
     "$CREW_STATE_BIN" "$id" 2>/dev/null) || state_rc=$?
   [ "$state_rc" -ne 124 ] || return 3
-  if [ -n "$self" ] && child_terminal_ledger_line "$status" >/dev/null; then
-    return 0
+  last=$(last_status_line "$status")
+  if [ -n "$self" ]; then
+    case "$(status_line_verb "$last")" in done|failed) return 0 ;; esac
   fi
   case "$state_line" in
     'state: done '*) state='done' ;;
@@ -461,7 +504,7 @@ reconcile_direct_child_locked() { # <id> <meta> <secondmate-id-or-empty> <timeou
   else
     outcome_key="inactive-outcome-main-$id-$state"
   fi
-  ensure_record "$fingerprint" "$id" "$incarnation" "$state" "$outcome_key" direct "upstream" "$pr" || return 1
+  ensure_record "$fingerprint" "$id" "$incarnation" "$state" "$outcome_key" direct "upstream" "$pr" "$(sha256_text "$last")" || return 1
   [ -n "$RECORD_PENDING" ] || return 0
   if [ -n "$self" ]; then
     if report_to_parent "$id" "$state" "$outcome_key" "$fingerprint" "$pr"; then

--- a/bin/fm-merge-outcome-lib.sh
+++ b/bin/fm-merge-outcome-lib.sh
@@ -8,8 +8,8 @@
 # path.
 #
 # The destination is the home's role, never the caller's choice:
-#   - a secondmate home reports upward to its parent on the same reply channel
-#     bin/fm-inactive-reconcile.sh's report_to_parent already uses, in the same
+#   - a secondmate home reports upward on its parent channel, resolved and
+#     appended through bin/fm-parent-channel-lib.sh in the same
 #     "<state> [key=<slug>]: <note>" shape the charter contract defines;
 #   - a main home reports to the captain through the durable wake queue.
 # A poll observed in a secondmate home also receives a local durable wake after
@@ -29,37 +29,8 @@
 _FM_MERGE_OUTCOME_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$_FM_MERGE_OUTCOME_LIB_DIR/fm-pr-lib.sh"
-# shellcheck source=bin/fm-secondmate-parent-lib.sh
-. "$_FM_MERGE_OUTCOME_LIB_DIR/fm-secondmate-parent-lib.sh"
-
-# The secondmate identity of the home reporting, or non-zero when this home is
-# a main home (1) or carries an unusable identity marker (2). Mirrors
-# bin/fm-inactive-reconcile.sh's home_secondmate_id, which owns the same
-# marker's contract.
-fm_merge_outcome_home_id() {  # <home>
-  local home=$1 marker id
-  marker="$home/.fm-secondmate-home"
-  if [ ! -e "$marker" ] && [ ! -L "$marker" ]; then
-    return 1
-  fi
-  [ -f "$marker" ] && [ ! -L "$marker" ] || return 2
-  [ "$(wc -c < "$marker")" -eq "$(LC_ALL=C tr -d '\0' < "$marker" | wc -c)" ] || return 2
-  id=$(cat "$marker" 2>/dev/null) || return 2
-  fm_pr_task_id_valid "$id" || return 2
-  printf '%s\n' "$id"
-}
-
-# Append <line> to <path> unless that exact line is already there, so a repeat
-# report of the same merge cannot duplicate it.
-fm_merge_outcome_append_once() {  # <path> <line>
-  local path=$1 line=$2
-  [ ! -L "$path" ] || return 1
-  mkdir -p "$(dirname "$path")" || return 1
-  if grep -Fqx -- "$line" "$path" 2>/dev/null; then
-    return 0
-  fi
-  printf '%s\n' "$line" >> "$path"
-}
+# shellcheck source=bin/fm-parent-channel-lib.sh
+. "$_FM_MERGE_OUTCOME_LIB_DIR/fm-parent-channel-lib.sh"
 
 # shellcheck disable=SC2034 # Public result consumed by sourcing callers.
 FM_MERGE_OUTCOME_ALREADY_RECORDED=false
@@ -79,7 +50,7 @@ FM_MERGE_OUTCOME_ALREADY_RECORDED=false
 # than treat it as success: the merge landed and the record did not.
 fm_merge_outcome_report() {  # <home> <state> <task-id> <pr-url> <origin>
   local home=$1 state=$2 id=$3 url=$4 origin=$5
-  local self='' self_rc=0 destination='' line lock status=0
+  local self_rc=0 destination='' line lock status=0
   local provider host path number
   # shellcheck disable=SC2034 # Sourced wake helpers consume these scoped globals.
   local STATE FM_WAKE_QUEUE FM_WAKE_QUEUE_LOCK
@@ -93,20 +64,12 @@ fm_merge_outcome_report() {  # <home> <state> <task-id> <pr-url> <origin>
   number=$FM_PR_NUMBER
   [ -d "$state" ] && [ ! -L "$state" ] || return 1
 
-  if self=$(fm_merge_outcome_home_id "$home"); then
-    fm_secondmate_parent_record_parse "$home/.fm-secondmate-parent" || return 3
-    case "$FM_SECONDMATE_PARENT_ROUTE" in
-      local)
-        [ -n "$FM_SECONDMATE_PARENT_HOME" ] || return 3
-        destination="$FM_SECONDMATE_PARENT_HOME/state/$self.status"
-        ;;
-      remote) destination="$state/parent-replies.status" ;;
-      *) return 3 ;;
-    esac
+  if destination=$(fm_parent_channel_destination "$home" "$state"); then
     line="done [key=merged-$id]: merged $id $FM_PR_URL"
   else
     self_rc=$?
     [ "$self_rc" -eq 1 ] || return 3
+    destination=''
   fi
 
   STATE=$state
@@ -123,7 +86,7 @@ fm_merge_outcome_report() {  # <home> <state> <task-id> <pr-url> <origin>
   fi
 
   if [ -n "$destination" ]; then
-    fm_merge_outcome_append_once "$destination" "$line" || status=1
+    fm_parent_channel_append_once "$destination" "$line" || status=1
   fi
   if [ "$status" -eq 0 ] && { [ "$origin" = poll ] || [ -z "$destination" ]; }; then
     fm_wake_append check "merged-$id-$FM_PR_URL" \

--- a/bin/fm-parent-channel-lib.sh
+++ b/bin/fm-parent-channel-lib.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# fm-parent-channel-lib.sh - the one owner of a secondmate home's parent channel.
+#
+# WHY THIS EXISTS. A secondmate is a firstmate in its own home, and nobody reads
+# its chat: the captain and the main firstmate see only what is appended to the
+# parent channel. AGENTS.md tells every firstmate to reach the captain and to
+# address the captain in every response, so a mate model reliably "reports" a
+# PR-ready result, a finding, a decision, a blocker, or a failure in its own
+# chat and skips the one status-file append that would actually deliver it.
+# Four such misses were observed on 2026-09-02 across two mate homes; the
+# watcher had delivered the parent's request each time and the work was done.
+# The problem is therefore not one missed PR notice but every captain-facing
+# outcome that depends on the model remembering to write to the channel.
+# The fix is structural: every script that RECORDS a captain-facing outcome in a
+# mate home publishes it on the parent channel itself, so delivery never
+# depends on the model. This library owns where that channel lives and how a
+# line is appended to it. The publishers are:
+#   - bin/fm-inactive-reconcile.sh   a direct child's terminal done or failed
+#                                    ledger line, on every watcher poll, plus
+#                                    the silent-ledger inactive-outcome fallback
+#   - bin/fm-pr-check.sh             a registered PR-ready line carrying the
+#                                    canonical URL
+#   - bin/fm-captain-hold.sh         a task held for the captain and its answer
+#   - bin/fm-merge-outcome-lib.sh    a merged PR
+#   - bin/fm-teardown.sh             the child's final ledger line, refusing to
+#                                    remove the child while it is undelivered
+# The mate's own appends are reserved for judgement (bin/fm-brief.sh charter).
+# docs/secondmate-parent-channel.md records the design and its coverage.
+#
+# THE CHANNEL. It is resolved from the home's own durable identity and parent
+# binding, never from a caller's choice:
+#   - the .fm-secondmate-home marker names the mate's id in its parent home;
+#   - the .fm-secondmate-parent record (bin/fm-secondmate-parent-lib.sh) names
+#     the route: a local route reports into the parent home's
+#     state/<mate-id>.status, a remote route into this home's own
+#     state/parent-replies.status, which the parent's remote reply adapter
+#     mirrors line for line into that same parent file
+#     (docs/remote-secondmates.md).
+# The parent watcher classifies lines there exactly as it classifies any
+# crewmate's status stream, so a captain-relevant line becomes a parent wake.
+#
+# Lines follow the charter's "<state> [key=<slug>]: <note>" shape and are
+# appended at most once by exact content, so a retried publication cannot
+# duplicate a delivered event. An existing destination must be a regular,
+# non-symlinked file; a missing one is created with its directory.
+#
+# Return codes, shared by every entry point that resolves the channel:
+#   0  resolved, or appended / already present
+#   1  this is a main home (no .fm-secondmate-home marker): nothing to report
+#   2  the identity marker exists but is unusable (symlink, NUL, bad id)
+#   3  the parent binding is missing or unreadable
+#   4  the append itself failed
+# A caller that has already recorded the outcome locally must surface a
+# non-zero return rather than treat it as delivered.
+#
+# Sourced by the publishers above and by tests. No side effects on source.
+
+_FM_PARENT_CHANNEL_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-secondmate-parent-lib.sh
+. "$_FM_PARENT_CHANNEL_LIB_DIR/fm-secondmate-parent-lib.sh"
+
+# shellcheck disable=SC2034 # Output globals read by sourcing callers.
+FM_PARENT_CHANNEL_ID=
+# shellcheck disable=SC2034 # Output globals read by sourcing callers.
+FM_PARENT_CHANNEL_ROUTE=
+
+# A mate id is used as a file-name component in the parent home, so it is
+# accepted only when it is path-safe: no empty value, leading dot, slash, or
+# character outside [A-Za-z0-9._-].
+_fm_parent_channel_id_valid() {  # <id>
+  local id=${1-}
+  local LC_ALL=C
+  case "$id" in
+    ''|.*|*/*|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+}
+
+# The secondmate identity of <home>, printed, or non-zero for a main home (1)
+# or an unusable identity marker (2).
+fm_parent_channel_home_id() {  # <home>
+  local home=$1 marker id
+  marker="$home/.fm-secondmate-home"
+  if [ ! -e "$marker" ] && [ ! -L "$marker" ]; then
+    return 1
+  fi
+  [ -f "$marker" ] && [ ! -L "$marker" ] || return 2
+  [ "$(wc -c < "$marker")" -eq "$(LC_ALL=C tr -d '\0' < "$marker" | wc -c)" ] || return 2
+  id=$(cat "$marker" 2>/dev/null) || return 2
+  _fm_parent_channel_id_valid "$id" || return 2
+  printf '%s\n' "$id"
+}
+
+# Resolve the channel destination for <home> whose state dir is <state>.
+# Prints the destination path and sets FM_PARENT_CHANNEL_ID and
+# FM_PARENT_CHANNEL_ROUTE. Returns 1 for a main home, 2 for an unusable
+# marker, 3 for a missing or unreadable parent binding.
+fm_parent_channel_destination() {  # <home> <state>
+  local home=$1 state=$2 id rc=0
+  FM_PARENT_CHANNEL_ID=
+  FM_PARENT_CHANNEL_ROUTE=
+  id=$(fm_parent_channel_home_id "$home") || rc=$?
+  [ "$rc" -eq 0 ] || return "$rc"
+  fm_secondmate_parent_record_parse "$home/.fm-secondmate-parent" || return 3
+  case "$FM_SECONDMATE_PARENT_ROUTE" in
+    local)
+      [ -n "$FM_SECONDMATE_PARENT_HOME" ] || return 3
+      # shellcheck disable=SC2034 # Output globals read by sourcing callers.
+      FM_PARENT_CHANNEL_ID=$id
+      # shellcheck disable=SC2034 # Output globals read by sourcing callers.
+      FM_PARENT_CHANNEL_ROUTE=local
+      printf '%s/state/%s.status\n' "$FM_SECONDMATE_PARENT_HOME" "$id"
+      ;;
+    remote)
+      # shellcheck disable=SC2034 # Output globals read by sourcing callers.
+      FM_PARENT_CHANNEL_ID=$id
+      # shellcheck disable=SC2034 # Output globals read by sourcing callers.
+      FM_PARENT_CHANNEL_ROUTE=remote
+      printf '%s/parent-replies.status\n' "$state"
+      ;;
+    *) return 3 ;;
+  esac
+}
+
+# Fold <text> onto one bounded line, so a note copied from a child ledger or a
+# hold reason cannot break the channel's line framing.
+fm_parent_channel_clean_note() {  # <text>
+  printf '%s' "$1" | LC_ALL=C tr '\t\r\n' '   ' | cut -c1-1200
+}
+
+# Append <line> to <path> unless that exact line is already there.
+fm_parent_channel_append_once() {  # <path> <line>
+  local path=$1 line=$2
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    [ -f "$path" ] && [ ! -L "$path" ] || return 1
+  else
+    mkdir -p "$(dirname "$path")" || return 1
+  fi
+  if grep -Fqx -- "$line" "$path" 2>/dev/null; then
+    return 0
+  fi
+  printf '%s\n' "$line" >> "$path"
+}
+
+# Publish one parent-facing line from <home>. See the return codes above.
+fm_parent_channel_report() {  # <home> <state> <line>
+  local home=$1 state=$2 line=$3 destination rc=0
+  destination=$(fm_parent_channel_destination "$home" "$state") || rc=$?
+  [ "$rc" -eq 0 ] || return "$rc"
+  fm_parent_channel_append_once "$destination" "$line" || return 4
+}

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -17,6 +17,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-parent-channel-lib.sh
+. "$SCRIPT_DIR/fm-parent-channel-lib.sh"
 
 if [ "$#" -ne 2 ]; then
   echo "error: invalid PR check request" >&2
@@ -132,4 +134,22 @@ fm_pr_poll_publish_prepared || {
   echo "error: could not publish PR poll" >&2
   exit 1
 }
+# In a secondmate home the registration itself is a captain-facing fact:
+# publish the child's PR-ready line with the canonical URL just recorded, so it
+# reaches the parent whether or not the mate model appends anything
+# (bin/fm-parent-channel-lib.sh). A main home has no channel and this is a
+# silent no-op there. The poll is armed either way; a channel that cannot be
+# written is reported as actionable, and bin/fm-inactive-reconcile.sh still
+# delivers the child's own ready line on the next supervision poll.
+READY_LINE="done [key=child-pr-$ID]: child $ID PR ready: $URL"
+PR_MODE=$(grep '^mode=' "$META" | tail -1 | cut -d= -f2- || true)
+PR_YOLO=$(grep '^yolo=' "$META" | tail -1 | cut -d= -f2- || true)
+[ -z "$PR_MODE" ] || READY_LINE="$READY_LINE mode=$(fm_parent_channel_clean_note "$PR_MODE")"
+[ -z "$PR_YOLO" ] || READY_LINE="$READY_LINE yolo=$(fm_parent_channel_clean_note "$PR_YOLO")"
+READY_RC=0
+fm_parent_channel_report "$FM_HOME" "$STATE" "$READY_LINE" || READY_RC=$?
+case "$READY_RC" in
+  0|1) ;;
+  *) printf 'actionable: PR %s is registered but its ready line did not reach the parent channel (rc=%s)\n' "$URL" "$READY_RC" >&2 ;;
+esac
 printf 'armed: state/%s.check.sh\n' "$ID"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2869,6 +2869,21 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 # Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
 # Read before the state-file rm below; empty (pre-fix tasks without tasktmp=) is a no-op.
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
+# In a secondmate home, deliver whatever terminal line this child's ledger
+# still owes the parent before the ledger and record disappear below
+# (bin/fm-inactive-reconcile.sh report; docs/secondmate-parent-channel.md).
+# The endpoint is already gone, so the ledger cannot change under the read.
+# Refuse, retaining every durable record, when the parent channel cannot be
+# written: a rerun retries the delivery, while proceeding would discard the
+# one copy of a captain-facing outcome. A main home has no channel and this is
+# a silent no-op there.
+if [ "$KIND" != secondmate ]; then
+  if ! FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+      "$SCRIPT_DIR/fm-inactive-reconcile.sh" report "$ID"; then
+    echo "error: $ID's final outcome has not reached the parent channel; retaining every durable task record so a rerun can retry the delivery" >&2
+    exit 1
+  fi
+fi
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 status_retire_presentation_task "$STATE" "$ID" || exit 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2847,6 +2847,13 @@ if [ "$BACKEND" = herdr ]; then
     exit 1
   fi
 fi
+if [ "$KIND" != secondmate ]; then
+  if ! FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+      "$SCRIPT_DIR/fm-inactive-reconcile.sh" report "$ID"; then
+    echo "error: $ID's final outcome has not reached the parent channel; retaining every durable task record so a rerun can retry the delivery" >&2
+    exit 1
+  fi
+fi
 if [ "$KIND" = secondmate ]; then
   [ -n "$HOME_PATH" ] || HOME_PATH=$WT
   handoff_wake_retire_stage \
@@ -2869,21 +2876,6 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 # Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
 # Read before the state-file rm below; empty (pre-fix tasks without tasktmp=) is a no-op.
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
-# In a secondmate home, deliver whatever terminal line this child's ledger
-# still owes the parent before the ledger and record disappear below
-# (bin/fm-inactive-reconcile.sh report; docs/secondmate-parent-channel.md).
-# The endpoint is already gone, so the ledger cannot change under the read.
-# Refuse, retaining every durable record, when the parent channel cannot be
-# written: a rerun retries the delivery, while proceeding would discard the
-# one copy of a captain-facing outcome. A main home has no channel and this is
-# a silent no-op there.
-if [ "$KIND" != secondmate ]; then
-  if ! FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
-      "$SCRIPT_DIR/fm-inactive-reconcile.sh" report "$ID"; then
-    echo "error: $ID's final outcome has not reached the parent channel; retaining every durable task record so a rerun can retry the delivery" >&2
-    exit 1
-  fi
-fi
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 status_retire_presentation_task "$STATE" "$ID" || exit 1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,7 @@ No-change heartbeats are also benign.
 Separately from heartbeat backoff and wedge handling, the watcher poll runs `bin/fm-inactive-reconcile.sh` on its own bounded cadence, while locked session start sends the same bounded local scan through `bin/fm-startup-network.sh`'s deferred worker so current-state reads never block the digest.
 In each home the scan considers only that home's long-inactive direct ordinary crewmates, excludes captain-held work, and accepts only `done` or `failed` from `bin/fm-crew-state.sh`.
 A secondmate retains a durable receipt for its idempotent report through the established parent route, and main-home captain presentation retains a separate receipt; neither path performs a forge or PR check.
+A secondmate home's terminal child ledger lines, PR registrations, captain holds, and merges are published on that same parent route by the scripts that record them, so no captain-facing outcome depends on the mate model appending it ([secondmate-parent-channel.md](secondmate-parent-channel.md)).
 Absorbed wakes advance their suppression markers, log to `state/.watch-triage.log`, and keep the watcher blocking without a queue record or LLM turn.
 Each `fm-wake-drain.sh` presentation runs the same liveness guard as the supervision scripts, so a lapsed watcher chain surfaces even on a turn that only handles queued wakes.
 Routine watcher polling, supervision no-ops, elapsed waiting time, and absorbed benign wakes stay silent.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -361,6 +361,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/secondmate-parent-channel.md",
+      "audience": "maintainer-architecture"
+    },
+    {
       "path": "docs/scripts.md",
       "audience": "operator-current"
     },
@@ -426,6 +430,10 @@
     },
     {
       "path": "docs/verification/public-followup.md",
+      "audience": "maintainer-verification"
+    },
+    {
+      "path": "docs/verification/secondmate-parent-channel.md",
       "audience": "maintainer-verification"
     },
     {

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -185,6 +185,7 @@ An unreachable or unreadable remote read is unknown, not evidence that the endpo
 
 Marked requests keep the existing correlation contract.
 The remote charter appends replies to `state/parent-replies.status` in the remote home.
+The remote home's own outcome publishers append there too, through the channel contract in `bin/fm-parent-channel-lib.sh` ([secondmate-parent-channel.md](secondmate-parent-channel.md)).
 A process-event source performs a non-destructive, cursor-anchored delta read, fetches only referenced `data/*.md` documents through the confined reader, mirrors every content-bearing line at most once into the primary status channel, and does not carry blank separators.
 The channel carries the mate's status and decision model: an uncorrelated progress line and a newly raised `needs-decision` travel the same path as a correlated answer, and reach the parent's open-decision fold identically.
 Correlation is a per-line property that settles a pending request; it is never a gate on the stream, so no single line can stop or wedge the relay or hold the cursor back.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -126,6 +126,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
 | `fm-pr-merge.sh`         | Record PR metadata, merge a task's canonical full GitHub or GitLab URL, then refuse an outcome it cannot prove landed or queued |
 | `fm-merge-outcome-lib.sh` | Publish a confirmed merge's durable, role-routed supervision outcome                 |
+| `fm-parent-channel-lib.sh` | Resolve a secondmate home's parent channel and append a captain-facing outcome line to it at most once |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode, and write the ship instructions carrying that mode's definition of done |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |

--- a/docs/secondmate-parent-channel.md
+++ b/docs/secondmate-parent-channel.md
@@ -1,0 +1,56 @@
+# Secondmate parent channel
+
+This note records why a secondmate home's captain-facing outcomes are delivered by scripts instead of by the mate model, and which script delivers each one.
+`bin/fm-parent-channel-lib.sh` owns the channel contract: where the channel lives, how a line is appended, and the return codes every publisher shares.
+[`remote-secondmates.md`](remote-secondmates.md) owns the transport that carries the remote form of the channel back to the parent.
+
+## The problem
+
+A secondmate is a firstmate in its own home, and nobody reads its chat: the captain and the main firstmate see only what is appended to the parent channel.
+On 2026-09-02 four outcomes across two mate homes never reached the captain.
+The watcher had delivered the parent's request within a minute each time, the mate did the work, and then the mate addressed "captain" in its own chat instead of appending to the channel.
+The cause is structural rather than a one-off lapse: `AGENTS.md` tells every firstmate to reach the captain and to address the captain in every response, while the charter's return-channel rule is a smaller, later instruction.
+The captain's framing of the requirement was: "the root problem is not specific to PRs, right? it looks like any message or outcomes from second mates can miss. we need to make sure our fixes are addressing this in a principled, fundamental way, not surgically treating the symptoms of just this PR update miss."
+A PR-ready report was the observed symptom, but a finding, a decision, a blocker, and a failure all fail the same way, because every one of them depended on the mate model remembering to write one line.
+
+The design goal is therefore: the parent channel must not depend on the model remembering to write to it.
+
+## The design
+
+The delivery rule has one sentence: the scripts report facts, the mate reports judgement.
+Every captain-facing outcome that leaves durable evidence in the mate home is published on the channel by the script that records that evidence, at record time or on the next supervision poll, and the charter reserves the mate's own appends for judgement.
+
+| Outcome | Durable evidence in the mate home | Published by |
+|---|---|---|
+| Ship child PR ready | the child's `done: PR <url> ...` line; `pr=` in the child's record once registered | `bin/fm-inactive-reconcile.sh` on the next poll with the child's line; `bin/fm-pr-check.sh` at registration with the canonical URL |
+| Scout child findings | the child's `done:` line plus `data/<child>/report.md` | `bin/fm-inactive-reconcile.sh` on the next poll, with the report pointer |
+| Child failed | the child's `failed:` line | `bin/fm-inactive-reconcile.sh` on the next poll |
+| Child decision escalated to the captain | the task held for the captain in the mate backlog | `bin/fm-captain-hold.sh hold`, and its answer by `answer` |
+| PR merged | the merge poll or the mate's own merge | `bin/fm-merge-outcome-lib.sh` |
+| Child leaving the home | its final ledger line | `bin/fm-teardown.sh`, which refuses to remove the child while that line is undelivered |
+| Child ended silently | terminal current state with a silent ledger | the existing inactive-outcome scan in `bin/fm-inactive-reconcile.sh` |
+| Answer to a marked request | a correlated line guarded by the pending-reply record | the existing pending-reply recovery and escalation |
+| An outcome that exists only in the mate's reasoning | none | the charter and the `AGENTS.md` carve-outs only |
+
+The ledger delivery reads files only: it calls no harness, no forge, and no current-state reader, so it is identical for every harness and runtime backend.
+Each delivery is keyed and appended at most once by exact line, and the ledger path reuses the inactive scan's per-fingerprint receipts, so a replayed poll, a restart, or a relaunched child with the same terminal line cannot deliver an event twice while a genuinely new terminal line is delivered again.
+A duplicate line is harmless and a missed one is not, so the mate may still append its own judgement about a delivered outcome, and the parent reads the script's line as the fact and the mate's line as commentary.
+
+## What is deliberately not built
+
+- No mirror of the mate's chat: every firstmate turn contains captain-facing text by mandate, so choosing which sentence is an outcome would itself be model behavior, and every harness exposes turn text differently.
+- No threshold escalation of a child's open decision or blocker: a decision the mate escalates is a captain hold, which is published; a decision the mate neither answers nor escalates is a supervision-quality question, separable from channel delivery.
+- No second scanner: the ledger delivery lives in the inactive-outcome scan that already walks every child on every poll with a budget, a cursor, receipts, and the upstream append.
+- No orphan lifecycle: teardown refuses instead of removing an undelivered outcome, the same way it refuses on other unlanded conditions.
+
+## Regression coverage
+
+`tests/fm-inactive-reconcile.test.sh` covers the ledger delivery against real ledgers with no harness: immediate done and failed delivery with note, PR, mode, posture, and report pointer, once-only delivery across polls, a line still being appended, the remote route, the yield of the inactive path to a terminal ledger, and the real watcher poll driving it.
+`tests/fm-captain-hold-lifecycle.test.sh` covers a mate home publishing a hold, its answer, and a distinct occurrence on re-hold, and a main home publishing nothing.
+`tests/fm-pr-merge.test.sh` covers the PR-ready line at registration and the merge outcome's upward report.
+`tests/fm-teardown.test.sh` covers teardown delivering a child's final line and refusing when the channel cannot be written.
+`tests/fm-brief.test.sh` pins the charter's channel rule.
+
+## Live verification
+
+[`verification/secondmate-parent-channel.md`](verification/secondmate-parent-channel.md) records the dated live run: real tmux panes, both real watchers re-armed after each wake, and no model, with every delivered parent line and the parent wake it produced.

--- a/docs/secondmate-parent-channel.md
+++ b/docs/secondmate-parent-channel.md
@@ -40,7 +40,7 @@ A duplicate line is harmless and a missed one is not, so the mate may still appe
 
 - No mirror of the mate's chat: every firstmate turn contains captain-facing text by mandate, so choosing which sentence is an outcome would itself be model behavior, and every harness exposes turn text differently.
 - No threshold escalation of a child's open decision or blocker: a decision the mate escalates is a captain hold, which is published; a decision the mate neither answers nor escalates is a supervision-quality question, separable from channel delivery.
-- No second scanner: the ledger delivery lives in the inactive-outcome scan that already walks every child on every poll with a budget, a cursor, receipts, and the upstream append.
+- No second watcher or standalone scanner: a lightweight ledger pass runs inside the existing inactive-outcome command on every watcher poll and reuses its receipts and upstream append.
 - No orphan lifecycle: teardown refuses instead of removing an undelivered outcome, the same way it refuses on other unlanded conditions.
 
 ## Regression coverage

--- a/docs/secondmate-parent-channel.md
+++ b/docs/secondmate-parent-channel.md
@@ -33,7 +33,7 @@ Every captain-facing outcome that leaves durable evidence in the mate home is pu
 | An outcome that exists only in the mate's reasoning | none | the charter and the `AGENTS.md` carve-outs only |
 
 The ledger delivery reads files only: it calls no harness, no forge, and no current-state reader, so it is identical for every harness and runtime backend.
-Each delivery is keyed and appended at most once by exact line, and the ledger path reuses the inactive scan's per-fingerprint receipts, so a replayed poll, a restart, or a relaunched child with the same terminal line cannot deliver an event twice while a genuinely new terminal line is delivered again.
+Each delivery is keyed with the first eight hexadecimal characters of its receipt fingerprint and appended at most once by exact line, and the ledger path reuses the inactive scan's per-fingerprint receipts, so a replayed poll or restart cannot deliver an event twice while a genuinely new terminal event is delivered again.
 A duplicate line is harmless and a missed one is not, so the mate may still append its own judgement about a delivered outcome, and the parent reads the script's line as the fact and the mate's line as commentary.
 
 ## What is deliberately not built

--- a/docs/verification/secondmate-parent-channel.md
+++ b/docs/verification/secondmate-parent-channel.md
@@ -31,7 +31,7 @@ done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green
 
 $ cat $P/state/mate.status   (the parent channel)
 working: delegated scope
-done [key=child-outcome-child-done]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
+done [key=child-outcome-child-done-05b032a1]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
 
 $ mate watcher wakes so far
 signal: $M/state/child.status
@@ -46,7 +46,7 @@ armed: state/child.check.sh
 
 $ cat $P/state/mate.status
 working: delegated scope
-done [key=child-outcome-child-done]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
+done [key=child-outcome-child-done-05b032a1]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
 done [key=child-pr-child]: child child PR ready: https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
 
 $ parent watcher wakes so far (2 signals)
@@ -65,7 +65,7 @@ answered: child-call
 
 $ cat $P/state/mate.status   (final parent channel)
 working: delegated scope
-done [key=child-outcome-child-done]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
+done [key=child-outcome-child-done-05b032a1]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
 done [key=child-pr-child]: child child PR ready: https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
 needs-decision [key=captain-hold-child-call-1]: captain hold child-call: rollout window choice pending
 resolved [key=captain-hold-child-call-1]: captain hold child-call: answered

--- a/docs/verification/secondmate-parent-channel.md
+++ b/docs/verification/secondmate-parent-channel.md
@@ -1,0 +1,93 @@
+# Secondmate parent channel: live verification
+
+Maintainer-verification record for the guarantee in [`secondmate-parent-channel.md`](../secondmate-parent-channel.md): a captain-facing outcome recorded inside a secondmate home reaches the parent channel without the mate model writing it.
+Refresh it by rerunning the fixture below after changing any publisher named in `bin/fm-parent-channel-lib.sh`.
+
+## What was run
+
+Date: 2026-09-03.
+Tree: this change's branch on macOS with tmux 3.6a, bash 3.2 as `/bin/bash`, and the repo's own scripts.
+Fixture: two isolated homes under a scratch directory, `$P` (parent) and `$M` (mate), with `config/backend` set to `tmux` in both.
+The mate home carries `.fm-secondmate-home` (`mate`) and a local `.fm-secondmate-parent` binding to `$P`; the parent home carries `state/mate.meta` (`kind=secondmate`, `home=$M`).
+The mate's child task `child` is a real tmux pane (`fmlive:fm-child`) recorded in `$M/state/child.meta` with `mode=no-mistakes` and `yolo=off`; the mate itself is a second real pane (`fmlive:fm-mate`).
+Both homes run the real `bin/fm-watch.sh` (`FM_POLL=2`), re-armed after every wake through `bin/fm-wake-drain.sh` acknowledgement, exactly as fleet supervision re-arms a watcher after a handled turn.
+No agent harness and no model runs anywhere in the fixture.
+
+The child's only action is the ordinary crewmate status append, typed into its own pane with `tmux send-keys`.
+The mate's only actions are the scripts a firstmate runs when it registers a PR and when it holds a task for the captain and records the answer.
+
+## Transcript
+
+```text
+$ # Setup: mate home $M is a secondmate of parent home $P (local route); child task 'child' lives in a real tmux pane; both watchers are live
+
+$ # Step 1: the child appends its terminal line from inside its own real tmux pane
+
+$ tmux send-keys -t fmlive:fm-child "echo 'done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green' >> $M/state/child.status" Enter
+
+$ cat $M/state/child.status
+working: implementing the feature
+done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green
+
+$ cat $P/state/mate.status   (the parent channel)
+working: delegated scope
+done [key=child-outcome-child-done]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
+
+$ mate watcher wakes so far
+signal: $M/state/child.status
+
+$ parent watcher wakes so far
+signal: $P/state/mate.status
+
+$ # Step 2: the mate registers the PR with fm-pr-check; the ready line with the canonical URL reaches the parent from the script itself
+
+$ FM_HOME=$M FM_STATE_OVERRIDE=$M/state bin/fm-pr-check.sh child https://github.com/kunchenguid/firstmate/pull/9999
+armed: state/child.check.sh
+
+$ cat $P/state/mate.status
+working: delegated scope
+done [key=child-outcome-child-done]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
+done [key=child-pr-child]: child child PR ready: https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
+
+$ parent watcher wakes so far (2 signals)
+signal: $P/state/mate.status
+signal: $P/state/mate.status
+
+$ # Step 3: the mate holds a task for the captain; the hold reaches the parent from fm-captain-hold itself
+
+$ FM_HOME=$M bin/fm-captain-hold.sh hold child-call --title 'Pick the rollout window' --reason 'rollout window choice pending' --repo alpha
+child-call
+
+$ # Step 4: the captain's answer is recorded in the mate home; the close reaches the parent from fm-captain-hold itself
+
+$ FM_HOME=$M bin/fm-captain-hold.sh answer child-call --decision-file decision.txt   (decision: roll out on Monday)
+answered: child-call
+
+$ cat $P/state/mate.status   (final parent channel)
+working: delegated scope
+done [key=child-outcome-child-done]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
+done [key=child-pr-child]: child child PR ready: https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
+needs-decision [key=captain-hold-child-call-1]: captain hold child-call: rollout window choice pending
+resolved [key=captain-hold-child-call-1]: captain hold child-call: answered
+
+$ parent watcher wakes, one per delivered line (4 signals)
+signal: $P/state/mate.status
+signal: $P/state/mate.status
+signal: $P/state/mate.status
+signal: $P/state/mate.status
+
+$ mate watcher wakes
+signal: $M/state/child.status
+stale: fmlive:fm-child
+
+$ # Every line above beginning 'done [key=child-' or carrying 'captain-hold-' was written by a script, never by a model; each one woke the parent watcher.
+```
+
+## Why this proves the hole is closed
+
+- The observed defect was a mate model that handled its child's outcome and then addressed the captain in its own chat instead of appending to the parent channel.
+  In this run there is no model at all, and four captain-facing lines still appeared on `$P/state/mate.status`: the child's terminal done line with its note, canonical PR, mode, and posture; the PR-ready line at registration; the captain hold; and the hold's answer.
+- Each line was written by the script that recorded the underlying fact: `bin/fm-inactive-reconcile.sh` on the mate watcher's poll, `bin/fm-pr-check.sh`, and `bin/fm-captain-hold.sh`.
+- Each line produced one `signal:` wake in the real parent watcher, which is the event that starts the parent firstmate's turn and therefore the captain-facing report.
+- The mate watcher's own `signal:` on `child.status` shows the mate was woken as before; whatever the mate model would have said in its chat afterward is irrelevant to delivery.
+- The trailing `stale:` line in the mate watcher log is the idle real pane after the child's final line, ordinary liveness escalation unrelated to delivery.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -505,6 +505,12 @@ test_secondmate_no_projects_charter() {
     "project-less charter operating model lost the pooled-worktree note"
   assert_no_grep "The projects above are local clones" "$brief" \
     "project-less charter kept the with-projects operating-model line"
+  assert_grep '# The captain and the parent channel' "$brief" \
+    "secondmate charter lost the parent-channel section"
+  assert_grep 'Nobody reads this chat' "$brief" \
+    "secondmate charter no longer says the chat is unread"
+  assert_grep 'in this home it IS the captain' "$brief" \
+    "secondmate charter no longer names the parent channel as the captain"
   assert_grep 'working [key=<work-slug>]' "$brief" \
     "secondmate charter did not key material routed-work phases"
   assert_grep 'resolved [key=<work-slug>]' "$brief" \

--- a/tests/fm-captain-hold-lifecycle.test.sh
+++ b/tests/fm-captain-hold-lifecycle.test.sh
@@ -616,8 +616,9 @@ EOF
   run_teardown "$mate" "$origin" >/dev/null 2> "$mate/teardown.err" \
     || fail "secondmate investigation teardown failed: $(cat "$mate/teardown.err")"
   tasks_in "$mate" "done" "$origin" --report "data/$origin/report.md" --keep 0 >/dev/null
-  assert_grep "done [key=child-outcome-$origin-done]: child $origin done: report and visual review complete mode=scout report=data/$origin/report.md" \
-    "$parent/state/sample-mate.status" "the scout's final line did not reach the parent at teardown"
+  grep -Eq "^done \\[key=child-outcome-$origin-done-[0-9a-f]{8}\\]: child $origin done: report and visual review complete mode=scout report=data/$origin/report.md$" \
+    "$parent/state/sample-mate.status" \
+    || fail "the scout's final line did not reach the parent at teardown"
 
   json=$(run_bearings "$parent") || fail "parent Bearings could not read the secondmate captain call"
   printf '%s' "$json" | jq -e '
@@ -658,8 +659,8 @@ EOF
   tasks_in "$mate" add quoted-record-call "Choose quoted record handling" --kind ship --repo sample \
     --body 'Documentation quote: Resolution recorded by fm-captain-hold.' >/dev/null \
     || fail "could not create quoted-record captain call"
-  run_captain "$mate" hold quoted-record-call --reason "quoted record choice pending" >/dev/null \
-    || fail "quoted-record hold failed"
+  run_captain "$mate" hold quoted-record-call --reason "quoted record choice pending" \
+    --origin quoted-origin >/dev/null || fail "quoted-record hold failed"
   assert_grep 'needs-decision [key=captain-hold-quoted-record-call-1]: captain hold quoted-record-call: quoted record choice pending' \
     "$channel" "body prose was incorrectly counted as a resolution record"
 

--- a/tests/fm-captain-hold-lifecycle.test.sh
+++ b/tests/fm-captain-hold-lifecycle.test.sh
@@ -655,6 +655,14 @@ EOF
   channel="$parent/state/channel-mate.status"
   decision="$mate/decision.txt"
 
+  tasks_in "$mate" add quoted-record-call "Choose quoted record handling" --kind ship --repo sample \
+    --body 'Documentation quote: Resolution recorded by fm-captain-hold.' >/dev/null \
+    || fail "could not create quoted-record captain call"
+  run_captain "$mate" hold quoted-record-call --reason "quoted record choice pending" >/dev/null \
+    || fail "quoted-record hold failed"
+  assert_grep 'needs-decision [key=captain-hold-quoted-record-call-1]: captain hold quoted-record-call: quoted record choice pending' \
+    "$channel" "body prose was incorrectly counted as a resolution record"
+
   run_captain "$mate" hold mate-call --title "Choose the mate release" \
     --reason "release choice pending" --repo sample >/dev/null \
     || fail "mate hold failed"

--- a/tests/fm-captain-hold-lifecycle.test.sh
+++ b/tests/fm-captain-hold-lifecycle.test.sh
@@ -583,6 +583,10 @@ test_secondmate_hold_stays_in_authoritative_home() {
   cp "$ROOT/.tasks.toml" "$mate/.tasks.toml"
   printf '# Synthetic secondmate home\n' > "$mate/AGENTS.md"
   printf 'sample-mate\n' > "$mate/.fm-secondmate-home"
+  # A seeded home always carries its parent binding; teardown delivers the
+  # scout's final line through it before removing the record.
+  printf 'schema=fm-secondmate-parent.v1\nroute=local\nparent_home=%s\n' "$parent" \
+    > "$mate/.fm-secondmate-parent"
   cat > "$mate/data/backlog.md" <<'EOF'
 ## In flight
 
@@ -603,14 +607,18 @@ EOF
     || fail "secondmate-owned hold creation failed"
   run_captain "$mate" complete "$origin" sample-release-call >/dev/null \
     || fail "secondmate-owned completion failed"
-  run_teardown "$mate" "$origin" >/dev/null 2> "$mate/teardown.err" \
-    || fail "secondmate investigation teardown failed: $(cat "$mate/teardown.err")"
-  tasks_in "$mate" "done" "$origin" --report "data/$origin/report.md" --keep 0 >/dev/null
-
+  # The parent registers the mate before its children are ever torn down;
+  # teardown resolves that registration to deliver the scout's final line.
   printf -- '- sample-mate - synthetic scope (home: %s; scope: sample reviews; projects: sample; added 2026-07-14)\n' \
     "$mate" > "$parent/data/secondmates.md"
   fm_write_secondmate_meta "$parent/state/sample-mate.meta" "$mate" \
     "firstmate:fm-sample-mate" sample
+  run_teardown "$mate" "$origin" >/dev/null 2> "$mate/teardown.err" \
+    || fail "secondmate investigation teardown failed: $(cat "$mate/teardown.err")"
+  tasks_in "$mate" "done" "$origin" --report "data/$origin/report.md" --keep 0 >/dev/null
+  assert_grep "done [key=child-outcome-$origin-done]: child $origin done: report and visual review complete mode=scout report=data/$origin/report.md" \
+    "$parent/state/sample-mate.status" "the scout's final line did not reach the parent at teardown"
+
   json=$(run_bearings "$parent") || fail "parent Bearings could not read the secondmate captain call"
   printf '%s' "$json" | jq -e '
     .decisions_open | any(.owner == "sample-mate" and .verb == "captain-hold"
@@ -619,6 +627,71 @@ EOF
   assert_no_grep "sample-release-call" "$parent/data/backlog.md" "secondmate call leaked into the main backlog"
   assert_grep "sample-release-call" "$mate/data/backlog.md" "secondmate call left its authoritative backlog"
   pass "main-home and secondmate-home captain calls remain correctly routed"
+}
+
+# Inside a secondmate home a hold and its answer reach the parent channel from
+# the script itself, keyed per hold occurrence, so a re-held task opens and
+# closes a distinct parent decision and a retry never duplicates a line. A main
+# home publishes nothing anywhere.
+test_secondmate_home_publishes_holds_and_answers() {
+  local parent mate fakebin channel decision
+  parent=$(make_home parent-channel)
+  mate="$TMP_ROOT/channel-mate-home"
+  mkdir -p "$mate/data" "$mate/state" "$mate/config" "$mate/projects"
+  cp "$ROOT/.tasks.toml" "$mate/.tasks.toml"
+  printf '# Synthetic secondmate home\n' > "$mate/AGENTS.md"
+  printf 'channel-mate\n' > "$mate/.fm-secondmate-home"
+  printf 'schema=fm-secondmate-parent.v1\nroute=local\nparent_home=%s\n' "$parent" \
+    > "$mate/.fm-secondmate-parent"
+  cat > "$mate/data/backlog.md" <<'EOF'
+## In flight
+
+## Queued
+
+## Done
+EOF
+  fakebin=$(fm_fakebin "$mate")
+  fm_fake_exit0 "$fakebin" tmux treehouse no-mistakes gh gh-axi
+  channel="$parent/state/channel-mate.status"
+  decision="$mate/decision.txt"
+
+  run_captain "$mate" hold mate-call --title "Choose the mate release" \
+    --reason "release choice pending" --repo sample >/dev/null \
+    || fail "mate hold failed"
+  assert_grep 'needs-decision [key=captain-hold-mate-call-1]: captain hold mate-call: release choice pending' \
+    "$channel" "the mate's hold did not reach the parent channel"
+  run_captain "$mate" hold mate-call --reason "release choice pending" >/dev/null \
+    || fail "repeated mate hold failed"
+  [ "$(grep -c 'captain-hold-mate-call-1' "$channel")" = 1 ] \
+    || fail "a repeated hold duplicated the parent decision: $(cat "$channel")"
+
+  printf 'ship it later\n' > "$decision"
+  run_captain "$mate" answer mate-call --decision-file "$decision" --release >/dev/null \
+    || fail "mate release answer failed"
+  assert_grep 'resolved [key=captain-hold-mate-call-1]: captain hold mate-call: released' \
+    "$channel" "the released answer did not close the parent decision"
+
+  run_captain "$mate" hold mate-call --reason "second release choice" >/dev/null \
+    || fail "re-hold after release failed"
+  assert_grep 'needs-decision [key=captain-hold-mate-call-2]: captain hold mate-call: second release choice' \
+    "$channel" "a re-held task did not open a distinct parent decision"
+  printf 'ship it\n' > "$decision"
+  run_captain "$mate" answer mate-call --decision-file "$decision" >/dev/null \
+    || fail "mate close answer failed"
+  assert_grep 'resolved [key=captain-hold-mate-call-2]: captain hold mate-call: answered' \
+    "$channel" "the closing answer did not close the second parent decision"
+  run_captain "$mate" answer mate-call --decision-file "$decision" >/dev/null \
+    || fail "idempotent answer retry failed"
+  [ "$(grep -c 'captain-hold-mate-call-2' "$channel")" = 2 ] \
+    || fail "an answer retry duplicated a parent line: $(cat "$channel")"
+  [ "$(grep -c 'captain-hold-mate-call' "$channel")" = 4 ] \
+    || fail "unexpected parent channel contents: $(cat "$channel")"
+
+  run_captain "$parent" hold main-call --title "Choose the main release" \
+    --reason "main choice pending" --repo sample >/dev/null || fail "main hold failed"
+  [ ! -e "$parent/state/parent-replies.status" ] || fail "a main home wrote a parent reply"
+  assert_no_grep 'captain-hold-main-call' "$channel" "a main home's hold leaked onto a mate channel"
+  pass "a secondmate home publishes each hold occurrence and its answer on the parent channel"
 }
 
 # The one keyed-answer intake, fed through the real process-event runner by a
@@ -1178,6 +1251,7 @@ test_visual_review_uses_shared_completion_owner
 test_none_inventory_and_resolved_prose_do_not_create_holds
 test_terminal_single_owner_status_decision_does_not_block_empty_inventory
 test_secondmate_hold_stays_in_authoritative_home
+test_secondmate_home_publishes_holds_and_answers
 test_bound_channel_answers_close_at_answer_time
 test_unbound_source_closes_no_hold
 test_legacy_identities_keep_working

--- a/tests/fm-captain-hold-lifecycle.test.sh
+++ b/tests/fm-captain-hold-lifecycle.test.sh
@@ -634,7 +634,7 @@ EOF
 # closes a distinct parent decision and a retry never duplicates a line. A main
 # home publishes nothing anywhere.
 test_secondmate_home_publishes_holds_and_answers() {
-  local parent mate fakebin channel decision
+  local parent mate fakebin channel decision out
   parent=$(make_home parent-channel)
   mate="$TMP_ROOT/channel-mate-home"
   mkdir -p "$mate/data" "$mate/state" "$mate/config" "$mate/projects"
@@ -686,6 +686,24 @@ EOF
     || fail "an answer retry duplicated a parent line: $(cat "$channel")"
   [ "$(grep -c 'captain-hold-mate-call' "$channel")" = 4 ] \
     || fail "unexpected parent channel contents: $(cat "$channel")"
+
+  run_captain "$mate" hold batch-call --title "Choose the batch release" \
+    --reason "batch choice pending" --repo sample >/dev/null \
+    || fail "batch hold failed"
+  mv "$channel" "$channel.saved"
+  mkdir "$channel"
+  out=$(printf 'batch-call\tship now\t\n' \
+    | run_captain "$mate" answers --source "batch retry fixture" 2>&1) \
+    || fail "batch answer did not preserve its durable close: $out"
+  printf '%s\n' "$out" | grep -Fq 'actionable:' \
+    || fail "failed batch parent delivery was not actionable: $out"
+  rmdir "$channel"
+  mv "$channel.saved" "$channel"
+  printf 'batch-call\tship now\t\n' \
+    | run_captain "$mate" answers --source "batch retry fixture" >/dev/null \
+    || fail "idempotent batch answer retry failed"
+  [ "$(grep -c 'resolved \[key=captain-hold-batch-call-1\]' "$channel")" = 1 ] \
+    || fail "batch retry did not restore exactly one parent resolution: $(cat "$channel")"
 
   run_captain "$parent" hold main-call --title "Choose the main release" \
     --reason "main choice pending" --repo sample >/dev/null || fail "main hold failed"

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -50,12 +50,12 @@ make_fake_root() {
   mkdir -p "$fake/bin/backends" "$fake/state" "$fake/data"
   # Symlink the REAL teardown so the test exercises actual code, not a copy.
   ln -s "$TEARDOWN" "$fake/bin/fm-teardown.sh"
-  # fm-backend.sh + its tmux adapter: symlink the REAL files (teardown sources
-  # fm-backend.sh unconditionally, and dispatches the kill call through the
-  # tmux adapter; both are unchanged by this suite's fixture, just newly
-  # required siblings since the P1 backend extraction).
+  # fm-backend.sh is real, while its adapter is stubbed so this temp-cleanup
+  # test cannot depend on or mutate a host tmux server.
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
-  ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
+  cat > "$fake/bin/backends/tmux.sh" <<'SH'
+fm_backend_tmux_kill() { return 0; }
+SH
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   ln -s "$ROOT/bin/fm-cursor-lib.sh" "$fake/bin/fm-cursor-lib.sh"
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
@@ -89,6 +89,9 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-pending-reply-lib.sh" "$fake/bin/fm-pending-reply-lib.sh"
   ln -s "$ROOT/bin/fm-marker-lib.sh" "$fake/bin/fm-marker-lib.sh"
   ln -s "$ROOT/bin/fm-operational-input.sh" "$fake/bin/fm-operational-input.sh"
+  # Ordinary teardown reports any final ledger outcome before removing records.
+  ln -s "$ROOT/bin/fm-inactive-reconcile.sh" "$fake/bin/fm-inactive-reconcile.sh"
+  ln -s "$ROOT/bin/fm-parent-channel-lib.sh" "$fake/bin/fm-parent-channel-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -151,7 +154,9 @@ test_teardown_skips_gracefully_without_tasktmp() {
   mkdir -p "$fake/bin/backends" "$fake/state" "$fake/data"
   ln -s "$TEARDOWN" "$fake/bin/fm-teardown.sh"
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
-  ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
+  cat > "$fake/bin/backends/tmux.sh" <<'SH'
+fm_backend_tmux_kill() { return 0; }
+SH
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   ln -s "$ROOT/bin/fm-cursor-lib.sh" "$fake/bin/fm-cursor-lib.sh"
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
@@ -180,6 +185,8 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-pending-reply-lib.sh" "$fake/bin/fm-pending-reply-lib.sh"
   ln -s "$ROOT/bin/fm-marker-lib.sh" "$fake/bin/fm-marker-lib.sh"
   ln -s "$ROOT/bin/fm-operational-input.sh" "$fake/bin/fm-operational-input.sh"
+  ln -s "$ROOT/bin/fm-inactive-reconcile.sh" "$fake/bin/fm-inactive-reconcile.sh"
+  ln -s "$ROOT/bin/fm-parent-channel-lib.sh" "$fake/bin/fm-parent-channel-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
 exit 0

--- a/tests/fm-inactive-reconcile.test.sh
+++ b/tests/fm-inactive-reconcile.test.sh
@@ -256,6 +256,29 @@ test_secondmate_ledger_delivery_carries_report_and_failure() {
   pass "ledger delivery carries the report pointer, the failed verb, and each new terminal line"
 }
 
+# If a terminal ledger line lands while the authoritative state read is in
+# flight, the ledger path remains the single owner on the next poll.
+test_terminal_line_during_state_read_yields_to_ledger_delivery() {
+  make_world state-ledger-race; bind_secondmate local
+  write_child "$MATE" child 'working: finishing now'
+  cat > "$WORLD/fakebin/fm-crew-state.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'done: completed during state read\n' >> "$FM_STATE_OVERRIDE/$1.status"
+printf 'state: done · source: fake\n'
+SH
+  chmod +x "$WORLD/fakebin/fm-crew-state.sh"
+  run_reconcile "$MATE" --startup
+  [ ! -e "$MAIN/state/mate.status" ] \
+    || ! grep -q 'inactive-outcome-' "$MAIN/state/mate.status" \
+    || fail "inactive reconciliation claimed an outcome whose terminal ledger arrived during state read"
+  run_reconcile "$MATE"
+  [ "$(grep -c 'child-outcome-child-done-' "$MAIN/state/mate.status")" = 1 ] \
+    || fail "the next ledger pass did not deliver the raced terminal line exactly once"
+  ! grep -q 'inactive-outcome-' "$MAIN/state/mate.status" \
+    || fail "one raced terminal event was reported by both reconciliation paths"
+  pass "terminal lines arriving during state reads remain ledger-owned"
+}
+
 # Receipt identity covers the complete terminal ledger line even when the
 # captain-facing rendering truncates two long notes to the same text.
 test_long_terminal_lines_have_distinct_receipts() {
@@ -725,6 +748,7 @@ test_main_direct_terminal_presentation_receipt
 test_local_secondmate_delivers_terminal_ledger_line
 test_busy_child_does_not_starve_later_ledger_outcomes
 test_secondmate_ledger_delivery_carries_report_and_failure
+test_terminal_line_during_state_read_yields_to_ledger_delivery
 test_long_terminal_lines_have_distinct_receipts
 test_secondmate_partial_ledger_line_waits_for_newline
 test_secondmate_remote_route_ledger_delivery

--- a/tests/fm-inactive-reconcile.test.sh
+++ b/tests/fm-inactive-reconcile.test.sh
@@ -175,7 +175,7 @@ test_local_secondmate_delivers_terminal_ledger_line() {
   make_world local; bind_secondmate local
   write_child "$MATE" child 'done: PR https://example.test/owner/repo/pull/1 checks green'
   FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
-  key=$(reported_outcome_key "$MATE" child done) || fail "ledger receipt did not retain its collision-resistant key"
+  key=$(reported_outcome_key "$MATE" child 'done') || fail "ledger receipt did not retain its collision-resistant key"
   expected="done [key=$key]: child child done: PR https://example.test/owner/repo/pull/1 checks green pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off"
   grep -Fxq "$expected" "$MAIN/state/mate.status" \
     || fail "secondmate did not deliver the child's ledger line on a plain poll: $(cat "$MAIN/state/mate.status" 2>/dev/null)"
@@ -237,9 +237,9 @@ test_secondmate_ledger_delivery_carries_report_and_failure() {
   awk '$0 !~ /^pr=/' "$MATE/state/replaced-pr.meta" > "$MATE/state/replaced-pr.meta.tmp"
   mv "$MATE/state/replaced-pr.meta.tmp" "$MATE/state/replaced-pr.meta"
   FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
-  scout_key=$(reported_outcome_key "$MATE" scout done) || fail "scout receipt key missing"
+  scout_key=$(reported_outcome_key "$MATE" scout 'done') || fail "scout receipt key missing"
   boom_key=$(reported_outcome_key "$MATE" boom failed) || fail "failed receipt key missing"
-  replaced_key=$(reported_outcome_key "$MATE" replaced-pr done) || fail "replacement PR receipt key missing"
+  replaced_key=$(reported_outcome_key "$MATE" replaced-pr 'done') || fail "replacement PR receipt key missing"
   grep -Fxq "done [key=$scout_key]: child scout done: report written pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off report=data/scout/report.md" \
     "$MAIN/state/mate.status" || fail "scout delivery lost its report pointer: $(cat "$MAIN/state/mate.status")"
   grep -Fxq "failed [key=$boom_key]: child boom failed: build broke pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off" \
@@ -248,7 +248,7 @@ test_secondmate_ledger_delivery_carries_report_and_failure() {
     "$MAIN/state/mate.status" || fail "ledger fallback did not prefer the terminal line PR: $(cat "$MAIN/state/mate.status")"
   printf 'working: retrying\ndone: fixed on retry\n' >> "$MATE/state/boom.status"
   FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
-  boom_key=$(reported_outcome_key "$MATE" boom done) || fail "recovered receipt key missing"
+  boom_key=$(reported_outcome_key "$MATE" boom 'done') || fail "recovered receipt key missing"
   grep -Fq "done [key=$boom_key]: child boom done: fixed on retry" "$MAIN/state/mate.status" \
     || fail "a new terminal line after recovery was not delivered"
   [ "$(grep -c 'child-outcome-boom-' "$MAIN/state/mate.status")" = 2 ] \
@@ -307,7 +307,7 @@ test_secondmate_partial_ledger_line_waits_for_newline() {
     || fail "an unterminated ledger line was delivered: $(cat "$MAIN/state/mate.status")"
   printf 'ten\n' >> "$MATE/state/child.status"
   FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
-  key=$(reported_outcome_key "$MATE" child done) || fail "completed ledger receipt key missing"
+  key=$(reported_outcome_key "$MATE" child 'done') || fail "completed ledger receipt key missing"
   grep -Fq "done [key=$key]: child child done: half written" "$MAIN/state/mate.status" \
     || fail "the completed line was not delivered once its newline landed"
   pass "a ledger line still being appended waits for its newline"
@@ -332,7 +332,7 @@ test_report_subcommand_delivers_and_refuses() {
   make_world report; bind_secondmate local
   write_child "$MATE" child 'done: final word'
   run_report "$MATE" child || fail "report refused a deliverable ledger line"
-  key=$(reported_outcome_key "$MATE" child done) || fail "report receipt key missing"
+  key=$(reported_outcome_key "$MATE" child 'done') || fail "report receipt key missing"
   grep -Fq "done [key=$key]: child child done: final word" "$MAIN/state/mate.status" \
     || fail "report did not deliver the child's final line"
   run_report "$MATE" child || fail "report did not treat an already delivered line as owed nothing"
@@ -626,7 +626,7 @@ test_watcher_poll_delivers_child_ledger_line_to_parent() {
     i=$((i + 1))
   done
   reap "$pid"
-  key=$(reported_outcome_key "$MATE" child done) || fail "watcher ledger receipt key missing"
+  key=$(reported_outcome_key "$MATE" child 'done') || fail "watcher ledger receipt key missing"
   grep -Fxq "done [key=$key]: child child done: PR https://example.test/owner/repo/pull/1 checks green pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off" \
     "$MAIN/state/mate.status" \
     || fail "the watcher poll did not deliver the child's ledger line to the parent: $(cat "$MAIN/state/mate.status" 2>/dev/null; cat "$WORLD/mate-watch.out")"

--- a/tests/fm-inactive-reconcile.test.sh
+++ b/tests/fm-inactive-reconcile.test.sh
@@ -198,6 +198,21 @@ test_secondmate_ledger_delivery_carries_report_and_failure() {
   pass "ledger delivery carries the report pointer, the failed verb, and each new terminal line"
 }
 
+# Receipt identity covers the complete terminal ledger line even when the
+# captain-facing rendering truncates two long notes to the same text.
+test_long_terminal_lines_have_distinct_receipts() {
+  local prefix
+  make_world long-ledger; bind_secondmate local
+  prefix=$(awk 'BEGIN { for (i = 0; i < 1300; i++) printf "a" }')
+  write_child "$MATE" child "failed: ${prefix}one"
+  FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+  printf 'failed: %stwo\n' "$prefix" >> "$MATE/state/child.status"
+  FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+  [ "$(outcome_count "$MATE" reported)" = 2 ] \
+    || fail "distinct complete ledger lines collided in the receipt store"
+  pass "complete long ledger lines retain distinct receipt identities"
+}
+
 # A line still being appended has no trailing newline yet and must wait.
 test_secondmate_partial_ledger_line_waits_for_newline() {
   make_world partial; bind_secondmate local
@@ -247,6 +262,49 @@ test_report_subcommand_delivers_and_refuses() {
   run_report "$MAIN" child || fail "report failed in a main home"
   [ ! -e "$MAIN/state/parent-replies.status" ] || fail "a main home wrote a parent reply"
   pass "report delivers a child's final line, owes nothing twice, and refuses only an unwritable channel"
+}
+
+# Teardown calls report while holding the child's metadata lock. A concurrent
+# scan may hold the scan lock while waiting for that metadata lock, so report
+# must not wait for the scan lock in the opposite order.
+test_report_avoids_scan_meta_lock_inversion() {
+  local holder scan_pid report_pid i completed=0
+  make_world report-lock-order; bind_secondmate local
+  write_child "$MATE" child 'done: final word'
+  FM_HOME="$MATE" FM_STATE_OVERRIDE="$MATE/state" bash -c '
+    . "$1/bin/fm-wake-lib.sh"
+    lock=$(fm_meta_lock_path "$FM_STATE_OVERRIDE/child.meta")
+    fm_lock_acquire_wait "$lock"
+    : > "$2/meta-held"
+    while [ ! -e "$2/release-meta" ]; do sleep 0.05; done
+    fm_lock_release "$lock"
+  ' _ "$ROOT" "$WORLD" &
+  holder=$!
+  i=0
+  while [ "$i" -lt 40 ] && [ ! -e "$WORLD/meta-held" ]; do sleep 0.05; i=$((i + 1)); done
+  [ -e "$WORLD/meta-held" ] || { reap "$holder"; fail "metadata lock holder did not start"; }
+
+  FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE" --startup &
+  scan_pid=$!
+  i=0
+  while [ "$i" -lt 40 ] && [ ! -e "$MATE/state/.inactive-outcome-reconcile.lock" ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ -e "$MATE/state/.inactive-outcome-reconcile.lock" ] \
+    || { : > "$WORLD/release-meta"; reap "$holder"; reap "$scan_pid"; fail "scan lock holder did not start"; }
+
+  (run_report "$MATE" child && : > "$WORLD/report-complete") &
+  report_pid=$!
+  i=0
+  while [ "$i" -lt 40 ] && [ ! -e "$WORLD/report-complete" ]; do sleep 0.05; i=$((i + 1)); done
+  [ -e "$WORLD/report-complete" ] && completed=1
+  : > "$WORLD/release-meta"
+  reap "$holder"
+  reap "$report_pid"
+  reap "$scan_pid"
+  [ "$completed" -eq 1 ] || fail "report deadlocked behind a scan waiting for the caller's metadata lock"
+  pass "report preserves teardown's metadata-before-scan lock order"
 }
 
 test_local_secondmate_rejects_relative_parent_home() {
@@ -602,9 +660,11 @@ test_reconciliation_never_calls_forge() {
 test_main_direct_terminal_presentation_receipt
 test_local_secondmate_delivers_terminal_ledger_line
 test_secondmate_ledger_delivery_carries_report_and_failure
+test_long_terminal_lines_have_distinct_receipts
 test_secondmate_partial_ledger_line_waits_for_newline
 test_secondmate_remote_route_ledger_delivery
 test_report_subcommand_delivers_and_refuses
+test_report_avoids_scan_meta_lock_inversion
 test_local_secondmate_rejects_relative_parent_home
 test_invalid_secondmate_marker_blocks_routing
 test_remote_parent_reply_is_idempotent

--- a/tests/fm-inactive-reconcile.test.sh
+++ b/tests/fm-inactive-reconcile.test.sh
@@ -279,6 +279,48 @@ SH
   pass "terminal lines arriving during state reads remain ledger-owned"
 }
 
+# A terminal append can land after the inactive path's final ledger read but
+# before its already-selected outcome is observed on the next poll. The receipt
+# store reconciles that ledger event with the fallback delivery, while a later
+# same-state completion remains independently deliverable.
+test_terminal_line_after_inactive_delivery_is_not_reported_twice() {
+  make_world inactive-ledger-race; bind_secondmate local
+  write_child "$MATE" child 'working: finishing now'
+  FM_FAKE_CREW_STATE='done' run_reconcile "$MATE" --startup
+  [ "$(grep -c 'inactive-outcome-mate-child-done' "$MAIN/state/mate.status")" = 1 ] \
+    || fail "inactive fallback did not publish exactly once"
+
+  printf 'done: completion landed after reconciliation\n' >> "$MATE/state/child.status"
+  FM_FAKE_CREW_STATE='done' run_reconcile "$MATE"
+  [ "$(wc -l < "$MAIN/state/mate.status" | tr -d ' ')" = 1 ] \
+    || fail "one completion was published by both inactive and ledger paths: $(cat "$MAIN/state/mate.status")"
+  [ "$(outcome_count "$MATE" reported)" = 2 ] \
+    || fail "the raced ledger event was not durably reconciled with the fallback receipt"
+
+  printf 'working: retrying after completion\ndone: completed again\n' >> "$MATE/state/child.status"
+  FM_FAKE_CREW_STATE='done' run_reconcile "$MATE"
+  [ "$(wc -l < "$MAIN/state/mate.status" | tr -d ' ')" = 2 ] \
+    || fail "the inactive claim suppressed a later same-state terminal event: $(cat "$MAIN/state/mate.status")"
+  grep -Fq 'child child done: completed again' "$MAIN/state/mate.status" \
+    || fail "the later same-state terminal event was not delivered"
+  pass "inactive and ledger paths reconcile one raced completion without hiding later events"
+}
+
+# An intervening progress line means the next terminal line is a new completion,
+# not a late ledger rendering of the inactive fallback.
+test_progress_after_inactive_delivery_starts_a_new_event() {
+  make_world inactive-recovery; bind_secondmate local
+  write_child "$MATE" child 'working: first attempt finishing'
+  FM_FAKE_CREW_STATE='done' run_reconcile "$MATE" --startup
+  printf 'working: retry started\ndone: retry completed\n' >> "$MATE/state/child.status"
+  FM_FAKE_CREW_STATE='done' run_reconcile "$MATE"
+  [ "$(wc -l < "$MAIN/state/mate.status" | tr -d ' ')" = 2 ] \
+    || fail "an intervening progress event did not separate two completions: $(cat "$MAIN/state/mate.status")"
+  grep -Fq 'child child done: retry completed' "$MAIN/state/mate.status" \
+    || fail "the completion after recovery was not delivered"
+  pass "progress after an inactive fallback starts a distinct terminal event"
+}
+
 # Receipt identity covers the complete terminal ledger line even when the
 # captain-facing rendering truncates two long notes to the same text.
 test_long_terminal_lines_have_distinct_receipts() {
@@ -749,6 +791,8 @@ test_local_secondmate_delivers_terminal_ledger_line
 test_busy_child_does_not_starve_later_ledger_outcomes
 test_secondmate_ledger_delivery_carries_report_and_failure
 test_terminal_line_during_state_read_yields_to_ledger_delivery
+test_terminal_line_after_inactive_delivery_is_not_reported_twice
+test_progress_after_inactive_delivery_starts_a_new_event
 test_long_terminal_lines_have_distinct_receipts
 test_secondmate_partial_ledger_line_waits_for_newline
 test_secondmate_remote_route_ledger_delivery

--- a/tests/fm-inactive-reconcile.test.sh
+++ b/tests/fm-inactive-reconcile.test.sh
@@ -104,6 +104,16 @@ run_reconcile() { # <home> [--startup]
     FM_FORGE_LOG="$WORLD/forge.log" "$RECON" scan ${option:+"$option"}
 }
 
+# The teardown-side entry point: deliver one child's terminal ledger line for a
+# caller holding its meta lock.
+run_report() { # <home> <child>
+  local home=$1 child=$2
+  PATH="$WORLD/fakebin:$PATH" FM_ROOT_OVERRIDE="$WORLD/root" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_INACTIVE_CREW_STATE_BIN="$WORLD/fakebin/fm-crew-state.sh" \
+    FM_FORGE_LOG="$WORLD/forge.log" "$RECON" report "$child"
+}
+
 wake_count() { # <home> <key prefix>
   grep -c "$2" "$1/state/.wake-queue" 2>/dev/null || true
 }
@@ -140,14 +150,103 @@ test_main_direct_terminal_presentation_receipt() {
   pass "main direct terminal presentation has a durable receipt"
 }
 
-# A secondmate independently reports a genuinely terminal inactive child.
-test_local_secondmate_reports_terminal_child() {
-  make_world local; bind_secondmate local; write_child "$MATE" child 'done: PR https://example.test/owner/repo/pull/1 checks green'
+# A secondmate delivers a child's terminal ledger line to the parent on the
+# very next poll, from the ledger alone: no current-state read, no inactive
+# cadence, and no line appended by the mate model. The delivery carries the
+# child's note, recorded PR, delivery mode, and merge posture, happens once,
+# and takes the outcome away from the inactive path so it is never reported
+# twice.
+test_local_secondmate_delivers_terminal_ledger_line() {
+  local expected
+  make_world local; bind_secondmate local
+  write_child "$MATE" child 'done: PR https://example.test/owner/repo/pull/1 checks green'
+  expected='done [key=child-outcome-child-done]: child child done: PR https://example.test/owner/repo/pull/1 checks green pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off'
+  FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+  grep -Fxq "$expected" "$MAIN/state/mate.status" \
+    || fail "secondmate did not deliver the child's ledger line on a plain poll: $(cat "$MAIN/state/mate.status" 2>/dev/null)"
+  [ "$(outcome_count "$MATE" reported)" = 1 ] || fail "ledger delivery receipt was not durable"
+  FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+  [ "$(grep -c 'child-outcome-child-done' "$MAIN/state/mate.status")" = 1 ] \
+    || fail "a second poll delivered the same ledger line again"
   FM_FAKE_CREW_STATE='done' run_reconcile "$MATE" --startup
-  grep -Fq 'done [key=inactive-outcome-mate-child-done]:' "$MAIN/state/mate.status" \
-    || fail "secondmate did not append its durable parent report"
-  [ "$(outcome_count "$MATE" reported)" = 1 ] || fail "secondmate report receipt was not durable"
-  pass "secondmate reports its own inactive terminal child"
+  ! grep -q 'inactive-outcome-' "$MAIN/state/mate.status" \
+    || fail "the inactive path reported a child the ledger delivery already owned"
+  [ "$(outcome_count "$MATE" reported)" = 1 ] || fail "the inactive path minted a second receipt"
+  pass "secondmate delivers a child's terminal ledger line once, on the next poll, from the ledger alone"
+}
+
+# A scout's done line carries its report pointer, a failed line is delivered
+# under the failed verb, and a later terminal line after recovery is a new
+# delivery rather than a suppressed duplicate.
+test_secondmate_ledger_delivery_carries_report_and_failure() {
+  make_world ledger-shapes; bind_secondmate local
+  write_child "$MATE" scout 'done: report written'
+  mkdir -p "$MATE/data/scout"
+  printf '# findings\n' > "$MATE/data/scout/report.md"
+  write_child "$MATE" boom 'failed: build broke'
+  FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+  grep -Fxq 'done [key=child-outcome-scout-done]: child scout done: report written pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off report=data/scout/report.md' \
+    "$MAIN/state/mate.status" || fail "scout delivery lost its report pointer: $(cat "$MAIN/state/mate.status")"
+  grep -Fxq 'failed [key=child-outcome-boom-failed]: child boom failed: build broke pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off' \
+    "$MAIN/state/mate.status" || fail "failed line was not delivered under the failed verb: $(cat "$MAIN/state/mate.status")"
+  printf 'working: retrying\ndone: fixed on retry\n' >> "$MATE/state/boom.status"
+  FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+  grep -Fq 'done [key=child-outcome-boom-done]: child boom done: fixed on retry' "$MAIN/state/mate.status" \
+    || fail "a new terminal line after recovery was not delivered"
+  [ "$(grep -c 'child-outcome-boom-' "$MAIN/state/mate.status")" = 2 ] \
+    || fail "recovery delivered the wrong number of lines: $(cat "$MAIN/state/mate.status")"
+  pass "ledger delivery carries the report pointer, the failed verb, and each new terminal line"
+}
+
+# A line still being appended has no trailing newline yet and must wait.
+test_secondmate_partial_ledger_line_waits_for_newline() {
+  make_world partial; bind_secondmate local
+  write_child "$MATE" child 'working: nearly there'
+  printf 'done: half writ' >> "$MATE/state/child.status"
+  FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+  [ ! -e "$MAIN/state/mate.status" ] || ! grep -q 'child-outcome-' "$MAIN/state/mate.status" \
+    || fail "an unterminated ledger line was delivered: $(cat "$MAIN/state/mate.status")"
+  printf 'ten\n' >> "$MATE/state/child.status"
+  FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+  grep -Fq 'done [key=child-outcome-child-done]: child child done: half written' "$MAIN/state/mate.status" \
+    || fail "the completed line was not delivered once its newline landed"
+  pass "a ledger line still being appended waits for its newline"
+}
+
+# The remote route delivers the same line into this home's parent-replies
+# input, once.
+test_secondmate_remote_route_ledger_delivery() {
+  make_world remote-ledger; bind_secondmate remote
+  write_child "$MATE" child 'done: PR https://example.test/owner/repo/pull/1 checks green'
+  FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+  FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+  [ "$(grep -c 'child-outcome-child-done' "$MATE/state/parent-replies.status")" = 1 ] \
+    || fail "remote ledger delivery was not once-only: $(cat "$MATE/state/parent-replies.status" 2>/dev/null)"
+  pass "the remote route carries a child's ledger line once"
+}
+
+# `report <child>` is the teardown-side delivery: it delivers or says nothing
+# is owed with 0, and returns non-zero only when the channel cannot be written.
+test_report_subcommand_delivers_and_refuses() {
+  local rc
+  make_world report; bind_secondmate local
+  write_child "$MATE" child 'done: final word'
+  run_report "$MATE" child || fail "report refused a deliverable ledger line"
+  grep -Fq 'done [key=child-outcome-child-done]: child child done: final word' "$MAIN/state/mate.status" \
+    || fail "report did not deliver the child's final line"
+  run_report "$MATE" child || fail "report did not treat an already delivered line as owed nothing"
+  write_child "$MATE" quiet 'working: nothing terminal'
+  run_report "$MATE" quiet || fail "report refused a child that owes nothing"
+  printf 'schema=fm-secondmate-parent.v1\nroute=invalid\n' > "$MATE/.fm-secondmate-parent"
+  write_child "$MATE" stuck 'failed: cannot reach anyone'
+  rc=0
+  run_report "$MATE" stuck >/dev/null || rc=$?
+  [ "$rc" -ne 0 ] || fail "report claimed delivery through an unusable parent binding"
+  [ "$(wake_count "$MATE" 'inactive-reconcile:')" = 1 ] || fail "undeliverable report did not queue its notice"
+  write_child "$MAIN" child 'done: main home child'
+  run_report "$MAIN" child || fail "report failed in a main home"
+  [ ! -e "$MAIN/state/parent-replies.status" ] || fail "a main home wrote a parent reply"
+  pass "report delivers a child's final line, owes nothing twice, and refuses only an unwritable channel"
 }
 
 test_local_secondmate_rejects_relative_parent_home() {
@@ -199,7 +298,7 @@ test_invalid_secondmate_marker_blocks_routing() {
 
 # A remote child route writes the existing mirror input once even across restarts.
 test_remote_parent_reply_is_idempotent() {
-  make_world remote; bind_secondmate remote; write_child "$MATE" child 'done: green'
+  make_world remote; bind_secondmate remote; write_child "$MATE" child 'working: quiet since'
   FM_FAKE_CREW_STATE='done' run_reconcile "$MATE" --startup
   FM_FAKE_CREW_STATE='done' run_reconcile "$MATE" --startup
   [ "$(grep -c 'inactive-outcome-mate-child-done' "$MATE/state/parent-replies.status")" = 1 ] \
@@ -212,10 +311,10 @@ test_remote_parent_reply_is_idempotent() {
 # when its terminal state and status text match the retired worker exactly.
 test_reused_task_id_reports_each_incarnation() {
   make_world reused-id; bind_secondmate remote
-  write_child "$MATE" child 'failed: terminal' spawn-one
+  write_child "$MATE" child 'working: quiet since' spawn-one
   FM_FAKE_CREW_STATE='failed' run_reconcile "$MATE" --startup
   rm -f "$MATE/state/child.meta" "$MATE/state/child.status" "$MATE/state/child.turn-ended"
-  write_child "$MATE" child 'failed: terminal' spawn-two
+  write_child "$MATE" child 'working: quiet since' spawn-two
   FM_FAKE_CREW_STATE='failed' run_reconcile "$MATE" --startup
   [ "$(outcome_count "$MATE" reported)" = 2 ] \
     || fail "reused task id collided with the retired incarnation receipt"
@@ -229,7 +328,7 @@ test_reused_task_id_reports_each_incarnation() {
 test_legacy_metadata_rewrite_keeps_receipt_identity() {
   local meta tmp
   make_world legacy-rewrite; bind_secondmate remote
-  write_child "$MATE" child 'failed: terminal' spawn-old
+  write_child "$MATE" child 'working: quiet since' spawn-old
   meta="$MATE/state/child.meta"
   tmp="$MATE/state/.child.meta.legacy"
   awk '$0 !~ /^spawn_gen=/' "$meta" > "$tmp"
@@ -255,7 +354,7 @@ test_legacy_metadata_rewrite_keeps_receipt_identity() {
 test_relaunch_cannot_replace_metadata_during_state_snapshot() {
   local recon_pid update_pid record i
   make_world relaunch-race; bind_secondmate remote
-  write_child "$MATE" child 'failed: terminal' spawn-old
+  write_child "$MATE" child 'working: quiet since' spawn-old
   cat > "$WORLD/fakebin/fm-crew-state.sh" <<'SH'
 #!/usr/bin/env bash
 : > "${FM_RACE_WORLD:?}/state-started"
@@ -361,6 +460,35 @@ test_watcher_hook_and_idle_secondmate_exemption() {
   pass "watcher hook wakes for terminal loss and preserves idle secondmate exemption"
 }
 
+# The real watcher poll in a secondmate home delivers a child's terminal ledger
+# line to the parent channel on its first cycle, with no line appended by the
+# mate and no wake needed in the mate home for it.
+test_watcher_poll_delivers_child_ledger_line_to_parent() {
+  local pid i
+  make_world watcher-ledger; bind_secondmate local
+  write_child "$MATE" child 'done: PR https://example.test/owner/repo/pull/1 checks green'
+  prime_seen "$MATE/state" "$MATE/state/child.status"
+  PATH="$WORLD/fakebin:$PATH" FM_HOME="$MATE" FM_STATE_OVERRIDE="$MATE/state" FM_DATA_OVERRIDE="$MATE/data" \
+    FM_CONFIG_OVERRIDE="$MATE/config" FM_INACTIVE_RECONCILE_SECS=60 \
+    FM_INACTIVE_CREW_STATE_BIN="$WORLD/fakebin/fm-crew-state.sh" FM_FORGE_LOG="$WORLD/forge.log" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    FM_FAKE_CREW_STATE='unknown' "$WATCH" > "$WORLD/mate-watch.out" 2>&1 &
+  pid=$!
+  i=0
+  while [ "$i" -lt 100 ]; do
+    kill -0 "$pid" 2>/dev/null || break
+    grep -q 'child-outcome-child-done' "$MAIN/state/mate.status" 2>/dev/null && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  reap "$pid"
+  grep -Fxq 'done [key=child-outcome-child-done]: child child done: PR https://example.test/owner/repo/pull/1 checks green pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off' \
+    "$MAIN/state/mate.status" \
+    || fail "the watcher poll did not deliver the child's ledger line to the parent: $(cat "$MAIN/state/mate.status" 2>/dev/null; cat "$WORLD/mate-watch.out")"
+  [ ! -s "$WORLD/forge.log" ] || fail "ledger delivery invoked a forge command"
+  pass "the real watcher poll delivers a child's terminal ledger line to the parent channel"
+}
+
 # A stalled authoritative state read consumes only the aggregate scan budget.
 # The durable scan position lets the next invocation reach the following child.
 test_stalled_state_read_is_bounded_and_scan_progresses() {
@@ -423,10 +551,15 @@ test_missing_parent_binding_names_itself() {
   make_world missing-binding
   printf 'mate\n' > "$MATE/.fm-secondmate-home"
   write_child "$MATE" child 'done: PR merged'
+  write_child "$MATE" quiet 'working: quiet since'
   out=$(FM_FAKE_CREW_STATE='done' run_reconcile "$MATE" --startup)
   case "$out" in
-    *"actionable: inactive terminal outcome needs parent report"*".fm-secondmate-parent"*) ;;
-    *) fail "a missing parent binding did not name itself: $out" ;;
+    *"actionable: child outcome needs parent report: child=child"*".fm-secondmate-parent"*) ;;
+    *) fail "a missing parent binding did not name itself for a ledger delivery: $out" ;;
+  esac
+  case "$out" in
+    *"actionable: inactive terminal outcome needs parent report: child=quiet"*".fm-secondmate-parent"*) ;;
+    *) fail "a missing parent binding did not name itself for an inactive report: $out" ;;
   esac
   [ "$(outcome_count "$MATE" reported)" = 0 ] \
     || fail "an outcome that never reached a parent was recorded as reported"
@@ -437,7 +570,7 @@ test_notice_recovery_does_not_duplicate_wake() {
   local record err seq generation
   make_world notice-recovery; bind_secondmate remote
   printf 'schema=fm-secondmate-parent.v1\nroute=invalid\n' > "$MATE/.fm-secondmate-parent"
-  write_child "$MATE" child 'failed: terminal'
+  write_child "$MATE" child 'working: quiet since'
   FM_FAKE_CREW_STATE='failed' run_reconcile "$MATE" --startup
   [ "$(wake_count "$MATE" 'inactive-reconcile:')" = 1 ] || fail "parent-report failure did not queue one notice"
 
@@ -467,7 +600,11 @@ test_reconciliation_never_calls_forge() {
 }
 
 test_main_direct_terminal_presentation_receipt
-test_local_secondmate_reports_terminal_child
+test_local_secondmate_delivers_terminal_ledger_line
+test_secondmate_ledger_delivery_carries_report_and_failure
+test_secondmate_partial_ledger_line_waits_for_newline
+test_secondmate_remote_route_ledger_delivery
+test_report_subcommand_delivers_and_refuses
 test_local_secondmate_rejects_relative_parent_home
 test_invalid_secondmate_marker_blocks_routing
 test_remote_parent_reply_is_idempotent
@@ -478,6 +615,7 @@ test_heartbeat_cap_does_not_delay_reconciliation
 test_scan_marker_replaces_symlink_safely
 test_nonterminal_and_captain_held_states_do_not_report
 test_watcher_hook_and_idle_secondmate_exemption
+test_watcher_poll_delivers_child_ledger_line_to_parent
 test_stalled_state_read_is_bounded_and_scan_progresses
 test_full_scan_budget_includes_wake_lock_wait
 test_notice_recovery_does_not_duplicate_wake

--- a/tests/fm-inactive-reconcile.test.sh
+++ b/tests/fm-inactive-reconcile.test.sh
@@ -175,6 +175,39 @@ test_local_secondmate_delivers_terminal_ledger_line() {
   pass "secondmate delivers a child's terminal ledger line once, on the next poll, from the ledger alone"
 }
 
+# A busy child cannot keep later ledger outcomes from being visited, and is
+# retried on the next poll after its lifecycle lock becomes available.
+test_busy_child_does_not_starve_later_ledger_outcomes() {
+  local holder i delivered=0
+  make_world busy-ledger; bind_secondmate local
+  write_child "$MATE" a-busy 'done: busy child finished'
+  write_child "$MATE" b-ready 'done: later child finished'
+  printf 'epoch=%s\ncursor=\n' "$(date +%s)" > "$MATE/state/.inactive-outcome-reconcile"
+  FM_HOME="$MATE" FM_STATE_OVERRIDE="$MATE/state" bash -c '
+    . "$1/bin/fm-wake-lib.sh"
+    lock=$(fm_meta_lock_path "$FM_STATE_OVERRIDE/a-busy.meta")
+    fm_lock_acquire_wait "$lock"
+    : > "$2/busy-lock-held"
+    while [ ! -e "$2/release-busy-lock" ]; do sleep 0.05; done
+    fm_lock_release "$lock"
+  ' _ "$ROOT" "$WORLD" &
+  holder=$!
+  i=0
+  while [ "$i" -lt 40 ] && [ ! -e "$WORLD/busy-lock-held" ]; do sleep 0.05; i=$((i + 1)); done
+  if [ -e "$WORLD/busy-lock-held" ]; then
+    FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+    grep -Fq 'child-outcome-b-ready-done' "$MAIN/state/mate.status" 2>/dev/null && delivered=1
+  fi
+  : > "$WORLD/release-busy-lock"
+  reap "$holder"
+  [ "$delivered" -eq 1 ] \
+    || fail "a busy early child starved a later terminal ledger outcome"
+  FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+  grep -Fq 'child-outcome-a-busy-done' "$MAIN/state/mate.status" \
+    || fail "the skipped busy child was not retried on the next poll"
+  pass "busy child locks do not starve later ledger outcomes"
+}
+
 # A scout's done line carries its report pointer, a failed line is delivered
 # under the failed verb, and a later terminal line after recovery is a new
 # delivery rather than a suppressed duplicate.
@@ -659,6 +692,7 @@ test_reconciliation_never_calls_forge() {
 
 test_main_direct_terminal_presentation_receipt
 test_local_secondmate_delivers_terminal_ledger_line
+test_busy_child_does_not_starve_later_ledger_outcomes
 test_secondmate_ledger_delivery_carries_report_and_failure
 test_long_terminal_lines_have_distinct_receipts
 test_secondmate_partial_ledger_line_waits_for_newline

--- a/tests/fm-inactive-reconcile.test.sh
+++ b/tests/fm-inactive-reconcile.test.sh
@@ -217,11 +217,16 @@ test_secondmate_ledger_delivery_carries_report_and_failure() {
   mkdir -p "$MATE/data/scout"
   printf '# findings\n' > "$MATE/data/scout/report.md"
   write_child "$MATE" boom 'failed: build broke'
+  write_child "$MATE" replaced-pr $'working: old PR https://example.test/owner/repo/pull/11\ndone: replacement PR https://example.test/owner/repo/pull/22'
+  awk '$0 !~ /^pr=/' "$MATE/state/replaced-pr.meta" > "$MATE/state/replaced-pr.meta.tmp"
+  mv "$MATE/state/replaced-pr.meta.tmp" "$MATE/state/replaced-pr.meta"
   FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
   grep -Fxq 'done [key=child-outcome-scout-done]: child scout done: report written pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off report=data/scout/report.md' \
     "$MAIN/state/mate.status" || fail "scout delivery lost its report pointer: $(cat "$MAIN/state/mate.status")"
   grep -Fxq 'failed [key=child-outcome-boom-failed]: child boom failed: build broke pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off' \
     "$MAIN/state/mate.status" || fail "failed line was not delivered under the failed verb: $(cat "$MAIN/state/mate.status")"
+  grep -Fxq 'done [key=child-outcome-replaced-pr-done]: child replaced-pr done: replacement PR https://example.test/owner/repo/pull/22 pr=https://example.test/owner/repo/pull/22 mode=no-mistakes yolo=off' \
+    "$MAIN/state/mate.status" || fail "ledger fallback did not prefer the terminal line PR: $(cat "$MAIN/state/mate.status")"
   printf 'working: retrying\ndone: fixed on retry\n' >> "$MATE/state/boom.status"
   FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
   grep -Fq 'done [key=child-outcome-boom-done]: child boom done: fixed on retry' "$MAIN/state/mate.status" \

--- a/tests/fm-inactive-reconcile.test.sh
+++ b/tests/fm-inactive-reconcile.test.sh
@@ -122,6 +122,20 @@ outcome_count() { # <home> <suffix>
   find "$1/state/terminal-outcomes" -type f -name "*.$2" 2>/dev/null | wc -l | tr -d ' '
 }
 
+reported_outcome_key() { # <home> <id> <state>
+  local home=$1 id=$2 state=$3 record key
+  for record in "$home/state/terminal-outcomes"/*.reported; do
+    [ -f "$record" ] || continue
+    grep -Fxq "task_id=$id" "$record" || continue
+    grep -Fxq "state=$state" "$record" || continue
+    key=$(sed -n 's/^outcome_key=//p' "$record")
+    case "$key" in
+      "child-outcome-$id-$state-"[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) printf '%s\n' "$key"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
 prime_seen() { # <state> <status>
   FM_STATE_OVERRIDE="$1" bash -c '
     . "$1"
@@ -157,11 +171,12 @@ test_main_direct_terminal_presentation_receipt() {
 # and takes the outcome away from the inactive path so it is never reported
 # twice.
 test_local_secondmate_delivers_terminal_ledger_line() {
-  local expected
+  local expected key
   make_world local; bind_secondmate local
   write_child "$MATE" child 'done: PR https://example.test/owner/repo/pull/1 checks green'
-  expected='done [key=child-outcome-child-done]: child child done: PR https://example.test/owner/repo/pull/1 checks green pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off'
   FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+  key=$(reported_outcome_key "$MATE" child done) || fail "ledger receipt did not retain its collision-resistant key"
+  expected="done [key=$key]: child child done: PR https://example.test/owner/repo/pull/1 checks green pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off"
   grep -Fxq "$expected" "$MAIN/state/mate.status" \
     || fail "secondmate did not deliver the child's ledger line on a plain poll: $(cat "$MAIN/state/mate.status" 2>/dev/null)"
   [ "$(outcome_count "$MATE" reported)" = 1 ] || fail "ledger delivery receipt was not durable"
@@ -212,6 +227,7 @@ test_busy_child_does_not_starve_later_ledger_outcomes() {
 # under the failed verb, and a later terminal line after recovery is a new
 # delivery rather than a suppressed duplicate.
 test_secondmate_ledger_delivery_carries_report_and_failure() {
+  local scout_key boom_key replaced_key
   make_world ledger-shapes; bind_secondmate local
   write_child "$MATE" scout 'done: report written'
   mkdir -p "$MATE/data/scout"
@@ -221,15 +237,19 @@ test_secondmate_ledger_delivery_carries_report_and_failure() {
   awk '$0 !~ /^pr=/' "$MATE/state/replaced-pr.meta" > "$MATE/state/replaced-pr.meta.tmp"
   mv "$MATE/state/replaced-pr.meta.tmp" "$MATE/state/replaced-pr.meta"
   FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
-  grep -Fxq 'done [key=child-outcome-scout-done]: child scout done: report written pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off report=data/scout/report.md' \
+  scout_key=$(reported_outcome_key "$MATE" scout done) || fail "scout receipt key missing"
+  boom_key=$(reported_outcome_key "$MATE" boom failed) || fail "failed receipt key missing"
+  replaced_key=$(reported_outcome_key "$MATE" replaced-pr done) || fail "replacement PR receipt key missing"
+  grep -Fxq "done [key=$scout_key]: child scout done: report written pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off report=data/scout/report.md" \
     "$MAIN/state/mate.status" || fail "scout delivery lost its report pointer: $(cat "$MAIN/state/mate.status")"
-  grep -Fxq 'failed [key=child-outcome-boom-failed]: child boom failed: build broke pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off' \
+  grep -Fxq "failed [key=$boom_key]: child boom failed: build broke pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off" \
     "$MAIN/state/mate.status" || fail "failed line was not delivered under the failed verb: $(cat "$MAIN/state/mate.status")"
-  grep -Fxq 'done [key=child-outcome-replaced-pr-done]: child replaced-pr done: replacement PR https://example.test/owner/repo/pull/22 pr=https://example.test/owner/repo/pull/22 mode=no-mistakes yolo=off' \
+  grep -Fxq "done [key=$replaced_key]: child replaced-pr done: replacement PR https://example.test/owner/repo/pull/22 pr=https://example.test/owner/repo/pull/22 mode=no-mistakes yolo=off" \
     "$MAIN/state/mate.status" || fail "ledger fallback did not prefer the terminal line PR: $(cat "$MAIN/state/mate.status")"
   printf 'working: retrying\ndone: fixed on retry\n' >> "$MATE/state/boom.status"
   FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
-  grep -Fq 'done [key=child-outcome-boom-done]: child boom done: fixed on retry' "$MAIN/state/mate.status" \
+  boom_key=$(reported_outcome_key "$MATE" boom done) || fail "recovered receipt key missing"
+  grep -Fq "done [key=$boom_key]: child boom done: fixed on retry" "$MAIN/state/mate.status" \
     || fail "a new terminal line after recovery was not delivered"
   [ "$(grep -c 'child-outcome-boom-' "$MAIN/state/mate.status")" = 2 ] \
     || fail "recovery delivered the wrong number of lines: $(cat "$MAIN/state/mate.status")"
@@ -248,11 +268,14 @@ test_long_terminal_lines_have_distinct_receipts() {
   FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
   [ "$(outcome_count "$MATE" reported)" = 2 ] \
     || fail "distinct complete ledger lines collided in the receipt store"
+  [ "$(grep -c 'child-outcome-child-failed-' "$MAIN/state/mate.status")" = 2 ] \
+    || fail "distinct complete ledger lines collapsed into one parent delivery"
   pass "complete long ledger lines retain distinct receipt identities"
 }
 
 # A line still being appended has no trailing newline yet and must wait.
 test_secondmate_partial_ledger_line_waits_for_newline() {
+  local key
   make_world partial; bind_secondmate local
   write_child "$MATE" child 'working: nearly there'
   printf 'done: half writ' >> "$MATE/state/child.status"
@@ -261,7 +284,8 @@ test_secondmate_partial_ledger_line_waits_for_newline() {
     || fail "an unterminated ledger line was delivered: $(cat "$MAIN/state/mate.status")"
   printf 'ten\n' >> "$MATE/state/child.status"
   FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
-  grep -Fq 'done [key=child-outcome-child-done]: child child done: half written' "$MAIN/state/mate.status" \
+  key=$(reported_outcome_key "$MATE" child done) || fail "completed ledger receipt key missing"
+  grep -Fq "done [key=$key]: child child done: half written" "$MAIN/state/mate.status" \
     || fail "the completed line was not delivered once its newline landed"
   pass "a ledger line still being appended waits for its newline"
 }
@@ -281,11 +305,12 @@ test_secondmate_remote_route_ledger_delivery() {
 # `report <child>` is the teardown-side delivery: it delivers or says nothing
 # is owed with 0, and returns non-zero only when the channel cannot be written.
 test_report_subcommand_delivers_and_refuses() {
-  local rc
+  local rc key
   make_world report; bind_secondmate local
   write_child "$MATE" child 'done: final word'
   run_report "$MATE" child || fail "report refused a deliverable ledger line"
-  grep -Fq 'done [key=child-outcome-child-done]: child child done: final word' "$MAIN/state/mate.status" \
+  key=$(reported_outcome_key "$MATE" child done) || fail "report receipt key missing"
+  grep -Fq "done [key=$key]: child child done: final word" "$MAIN/state/mate.status" \
     || fail "report did not deliver the child's final line"
   run_report "$MATE" child || fail "report did not treat an already delivered line as owed nothing"
   write_child "$MATE" quiet 'working: nothing terminal'
@@ -560,7 +585,7 @@ test_watcher_hook_and_idle_secondmate_exemption() {
 # line to the parent channel on its first cycle, with no line appended by the
 # mate and no wake needed in the mate home for it.
 test_watcher_poll_delivers_child_ledger_line_to_parent() {
-  local pid i
+  local pid i key
   make_world watcher-ledger; bind_secondmate local
   write_child "$MATE" child 'done: PR https://example.test/owner/repo/pull/1 checks green'
   prime_seen "$MATE/state" "$MATE/state/child.status"
@@ -578,7 +603,8 @@ test_watcher_poll_delivers_child_ledger_line_to_parent() {
     i=$((i + 1))
   done
   reap "$pid"
-  grep -Fxq 'done [key=child-outcome-child-done]: child child done: PR https://example.test/owner/repo/pull/1 checks green pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off' \
+  key=$(reported_outcome_key "$MATE" child done) || fail "watcher ledger receipt key missing"
+  grep -Fxq "done [key=$key]: child child done: PR https://example.test/owner/repo/pull/1 checks green pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off" \
     "$MAIN/state/mate.status" \
     || fail "the watcher poll did not deliver the child's ledger line to the parent: $(cat "$MAIN/state/mate.status" 2>/dev/null; cat "$WORLD/mate-watch.out")"
   [ ! -s "$WORLD/forge.log" ] || fail "ledger delivery invoked a forge command"

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -1605,8 +1605,8 @@ test_self_merge_and_poll_publish_one_outcome() {
   set -e
   [ "$rc" -eq 0 ] \
     || fail "merge-outcome-committed: watcher failed: $(cat "$dir/watch.err")"
-  [ "$(grep -c -F "$url" "$replies")" -eq 1 ] \
-    || fail "merge-outcome-committed: self and poll reports produced duplicate outcomes"
+  [ "$(grep -c -F "done [key=merged-task-a]: merged task-a $url" "$replies")" -eq 1 ] \
+    || fail "merge-outcome-committed: self and poll reports produced duplicate merge outcomes"
   assert_no_grep "check: $state/task-a.check.sh: merged" "$state/.wake-queue" \
     "merge-outcome-committed: absorbed poll published a second outcome"
   assert_poll_absent "$state" task-a

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -1824,15 +1824,21 @@ test_secondmate_merge_reports_upward_once() {
 
   assert_grep "done [key=merged-task-x1]: merged task-x1 $url" "$replies" \
     "secondmate-merge-reports: the landed PR was not reported upward"
-  [ "$(wc -l <"$replies")" -eq 1 ] \
-    || fail "secondmate-merge-reports: one merge produced more than one upward line"
+  [ "$(grep -c 'merged-task-x1' "$replies")" -eq 1 ] \
+    || fail "secondmate-merge-reports: one merge produced more than one upward merge line"
+  # The merge path registers the PR first, and that registration publishes the
+  # child's ready line on the same channel from fm-pr-check itself.
+  assert_grep "done [key=child-pr-task-x1]: child task-x1 PR ready: $url" "$replies" \
+    "secondmate-merge-reports: the registration's ready line was not reported upward"
 
   # The same merge again: the forge accepts it in this fixture, so only the
   # at-most-once contract can keep the parent from being told twice.
   FM_TEST_HOME="$case_dir/home" run_pr_merge "$case_dir" task-x1 "$url" \
     >"$case_dir/stdout2" 2>"$case_dir/stderr2" || fail "secondmate-merge-reports: repeat merge failed"
-  [ "$(parent_reply_lines "$replies" "$url")" -eq 1 ] \
+  [ "$(grep -c 'merged-task-x1' "$replies")" -eq 1 ] \
     || fail "secondmate-merge-reports: a repeat merge of the same PR duplicated the upward line"
+  [ "$(parent_reply_lines "$replies" "$url")" -eq 2 ] \
+    || fail "secondmate-merge-reports: a repeat merge changed the upward lines: $(cat "$replies")"
   pass "a merge a secondmate home performs itself is reported upward exactly once"
 }
 
@@ -1868,7 +1874,9 @@ test_failed_merge_reports_nothing() {
   set -e
 
   expect_code 1 "$rc" "failed-merge-silent: a failed merge should propagate"
-  assert_absent "$case_dir/state/parent-replies.status" \
+  # The registration's ready line is a fact of its own; only a merge line
+  # would misreport the unlanded merge.
+  assert_no_grep 'merged-task-x1' "$case_dir/state/parent-replies.status" \
     "failed-merge-silent: a merge that never landed was reported as landed"
   pass "a refused or failed merge reports no outcome"
 }

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -1895,7 +1895,9 @@ test_gitlab_refusal_reports_nothing() {
   set -e
 
   expect_code 1 "$rc" "gitlab-refusal-silent: a refused GitLab merge should exit non-zero"
-  assert_absent "$case_dir/state/parent-replies.status" \
+  # Registration succeeds before the later GitLab pre-merge refusal, so the
+  # PR-ready fact is expected; only a merged outcome would be false.
+  assert_no_grep 'merged-task-x1' "$case_dir/state/parent-replies.status" \
     "gitlab-refusal-silent: a refused merge request was reported as landed"
   pass "a GitLab merge refused before the forge call reports no outcome"
 }

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1386,8 +1386,7 @@ test_secondmate_pr_registration_publishes_ready_line() {
 # every record) while the parent channel cannot be written; a rerun after the
 # repair delivers and completes.
 test_secondmate_home_teardown_delivers_final_line_or_refuses() {
-  local case_dir rc channel wt_head expected
-  expected='done [key=child-outcome-task-x1-done]: child task-x1 done: PR https://github.com/example/repo/pull/9 checks green pr=https://github.com/example/repo/pull/9 mode=local-only'
+  local case_dir rc channel wt_head
 
   case_dir=$(make_case mate-teardown-delivers)
   configure_secondmate_home "$case_dir" local "$case_dir/parent"
@@ -1404,7 +1403,7 @@ test_secondmate_home_teardown_delivers_final_line_or_refuses() {
   rc=$?
   set -e
   expect_code 0 "$rc" "mate-teardown-delivers: teardown should succeed: $(cat "$case_dir/stderr")"
-  grep -Fxq "$expected" "$channel" \
+  grep -Eq '^done \[key=child-outcome-task-x1-done-[0-9a-f]{8}\]: child task-x1 done: PR https://github.com/example/repo/pull/9 checks green pr=https://github.com/example/repo/pull/9 mode=local-only$' "$channel" \
     || fail "mate-teardown-delivers: the final ledger line did not reach the parent: $(cat "$channel" 2>/dev/null)"
   [ ! -e "$case_dir/state/task-x1.meta" ] || fail "mate-teardown-delivers: teardown left the task record"
 
@@ -1433,7 +1432,7 @@ test_secondmate_home_teardown_delivers_final_line_or_refuses() {
   rc=$?
   set -e
   expect_code 0 "$rc" "mate-teardown-refuses: rerun after repair should succeed: $(cat "$case_dir/stderr2")"
-  grep -Fq 'done [key=child-outcome-task-x1-done]: child task-x1 done: PR https://github.com/example/repo/pull/9 checks green' "$channel" \
+  grep -Eq '^done \[key=child-outcome-task-x1-done-[0-9a-f]{8}\]: child task-x1 done: PR https://github.com/example/repo/pull/9 checks green' "$channel" \
     || fail "mate-teardown-refuses: the rerun did not deliver the final line"
   [ ! -e "$case_dir/state/task-x1.meta" ] || fail "mate-teardown-refuses: rerun left the task record"
   pass "a secondmate home's teardown delivers the child's final line or refuses until it can"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1319,6 +1319,126 @@ test_local_only_force_overrides_unpushed() {
   pass "local-only worktree with unpushed work is torn down under --force (escape hatch)"
 }
 
+# Mark the case's home as a secondmate home bound to a parent: teardown and
+# fm-pr-check run with FM_HOME="$case_dir/home" so the parent-channel
+# publishers resolve that binding while the task state stays in $case_dir/state.
+configure_secondmate_home() {  # <case-dir> <local|remote> [<parent-home>]
+  local case_dir=$1 route=$2 parent=${3:-} home="$1/home"
+  mkdir -p "$home"
+  printf 'mate-x\n' > "$home/.fm-secondmate-home"
+  {
+    printf 'schema=fm-secondmate-parent.v1\nroute=%s\n' "$route"
+    [ "$route" != local ] || printf 'parent_home=%s\n' "$parent"
+  } > "$home/.fm-secondmate-parent"
+  if [ "$route" = local ]; then
+    # A local parent registers the mate; teardown resolves that registration.
+    mkdir -p "$parent/state" "$parent/data"
+    fm_write_secondmate_meta "$parent/state/mate-x.meta" "$home"
+    printf -- '- mate-x - fixture scope (home: %s; scope: fixture; projects: alpha; added 2026-07-14)\n' \
+      "$home" > "$parent/data/secondmates.md"
+  fi
+}
+
+# Registering a PR inside a secondmate home publishes the child's ready line
+# with the canonical URL on the parent channel from fm-pr-check itself, once;
+# a main home publishes nothing.
+test_secondmate_pr_registration_publishes_ready_line() {
+  local case_dir pr_head channel url
+  url=https://github.com/example/repo/pull/7
+  case_dir=$(make_case mate-pr-ready)
+  configure_secondmate_home "$case_dir" local "$case_dir/parent"
+  mkdir -p "$case_dir/parent/state"
+  channel="$case_dir/parent/state/mate-x.status"
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  pr_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  add_gh_pr_merged_for_head "$case_dir" "$pr_head"
+
+  FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" \
+    PATH="$case_dir/fakebin:$PATH" "$PR_CHECK" task-x1 "$url" > "$case_dir/pr-check.out" 2> "$case_dir/pr-check.err" \
+    || fail "mate-pr-ready: fm-pr-check failed: $(cat "$case_dir/pr-check.err")"
+  grep -q '^armed:' "$case_dir/pr-check.out" || fail "mate-pr-ready: poll was not armed"
+  assert_grep "done [key=child-pr-task-x1]: child task-x1 PR ready: $url mode=no-mistakes" "$channel" \
+    "mate-pr-ready: the ready line did not reach the parent channel"
+  ! grep -q '^actionable:' "$case_dir/pr-check.err" \
+    || fail "mate-pr-ready: registration reported a channel problem: $(cat "$case_dir/pr-check.err")"
+  FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" \
+    PATH="$case_dir/fakebin:$PATH" "$PR_CHECK" task-x1 "$url" >/dev/null 2>&1 \
+    || fail "mate-pr-ready: re-registration failed"
+  [ "$(grep -c 'child-pr-task-x1' "$channel")" -eq 1 ] \
+    || fail "mate-pr-ready: re-registration duplicated the ready line"
+
+  case_dir=$(make_case main-pr-ready)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  add_gh_pr_merged_for_head "$case_dir" "$(git -C "$case_dir/wt" rev-parse HEAD)"
+  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" \
+    PATH="$case_dir/fakebin:$PATH" "$PR_CHECK" task-x1 "$url" >/dev/null 2> "$case_dir/pr-check.err" \
+    || fail "main-pr-ready: fm-pr-check failed"
+  ! grep -q '^actionable:' "$case_dir/pr-check.err" \
+    || fail "main-pr-ready: a main home reported a channel problem"
+  [ ! -e "$case_dir/state/parent-replies.status" ] || fail "main-pr-ready: a main home wrote a parent reply"
+  pass "fm-pr-check publishes the PR-ready line on a secondmate's parent channel once"
+}
+
+# Tearing a child down inside a secondmate home delivers the child's final
+# ledger line to the parent before the record goes, and refuses (retaining
+# every record) while the parent channel cannot be written; a rerun after the
+# repair delivers and completes.
+test_secondmate_home_teardown_delivers_final_line_or_refuses() {
+  local case_dir rc channel wt_head expected
+  expected='done [key=child-outcome-task-x1-done]: child task-x1 done: PR https://github.com/example/repo/pull/9 checks green pr=https://github.com/example/repo/pull/9 mode=local-only'
+
+  case_dir=$(make_case mate-teardown-delivers)
+  configure_secondmate_home "$case_dir" local "$case_dir/parent"
+  mkdir -p "$case_dir/parent/state"
+  channel="$case_dir/parent/state/mate-x.status"
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "merged work"
+  wt_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  git -C "$case_dir/project" update-ref refs/heads/main "$wt_head"
+  printf 'working: shipping\ndone: PR https://github.com/example/repo/pull/9 checks green\n' \
+    > "$case_dir/state/task-x1.status"
+  set +e
+  FM_HOME="$case_dir/home" run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "mate-teardown-delivers: teardown should succeed: $(cat "$case_dir/stderr")"
+  grep -Fxq "$expected" "$channel" \
+    || fail "mate-teardown-delivers: the final ledger line did not reach the parent: $(cat "$channel" 2>/dev/null)"
+  [ ! -e "$case_dir/state/task-x1.meta" ] || fail "mate-teardown-delivers: teardown left the task record"
+
+  case_dir=$(make_case mate-teardown-refuses)
+  configure_secondmate_home "$case_dir" local "$case_dir/parent"
+  # The channel path is occupied by a directory, so no line can be appended.
+  mkdir -p "$case_dir/parent/state/mate-x.status"
+  channel="$case_dir/parent/state/mate-x.status"
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "merged work"
+  wt_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  git -C "$case_dir/project" update-ref refs/heads/main "$wt_head"
+  printf 'done: PR https://github.com/example/repo/pull/9 checks green\n' > "$case_dir/state/task-x1.status"
+  set +e
+  FM_HOME="$case_dir/home" run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "mate-teardown-refuses: teardown proceeded with an undelivered final line"
+  grep -q 'has not reached the parent channel' "$case_dir/stderr" \
+    || fail "mate-teardown-refuses: refusal did not name the parent channel: $(cat "$case_dir/stderr")"
+  [ -f "$case_dir/state/task-x1.meta" ] && [ -f "$case_dir/state/task-x1.status" ] \
+    || fail "mate-teardown-refuses: refusal did not retain the task records"
+  rmdir "$channel"
+  set +e
+  FM_HOME="$case_dir/home" run_teardown "$case_dir" > "$case_dir/stdout2" 2> "$case_dir/stderr2"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "mate-teardown-refuses: rerun after repair should succeed: $(cat "$case_dir/stderr2")"
+  grep -Fq 'done [key=child-outcome-task-x1-done]: child task-x1 done: PR https://github.com/example/repo/pull/9 checks green' "$channel" \
+    || fail "mate-teardown-refuses: the rerun did not deliver the final line"
+  [ ! -e "$case_dir/state/task-x1.meta" ] || fail "mate-teardown-refuses: rerun left the task record"
+  pass "a secondmate home's teardown delivers the child's final line or refuses until it can"
+}
+
 test_teardown_missing_busy_sidecar_completes() {
   local case_dir gen rc
   case_dir=$(make_case missing-busy-sidecar)
@@ -2613,6 +2733,8 @@ test_local_only_merged_to_local_main_allows
 test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
+test_secondmate_pr_registration_publishes_ready_line
+test_secondmate_home_teardown_delivers_final_line_or_refuses
 test_teardown_missing_busy_sidecar_completes
 test_herdr_teardown_clears_escalation_marker
 test_herdr_flat_teardown_refuses_orphaning_records_then_retry_completes

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1386,7 +1386,7 @@ test_secondmate_pr_registration_publishes_ready_line() {
 # every record) while the parent channel cannot be written; a rerun after the
 # repair delivers and completes.
 test_secondmate_home_teardown_delivers_final_line_or_refuses() {
-  local case_dir rc channel wt_head
+  local case_dir rc channel wt_head err seq generation
 
   case_dir=$(make_case mate-teardown-delivers)
   configure_secondmate_home "$case_dir" local "$case_dir/parent"
@@ -1413,6 +1413,10 @@ test_secondmate_home_teardown_delivers_final_line_or_refuses() {
   mkdir -p "$case_dir/parent/state/mate-x.status"
   channel="$case_dir/parent/state/mate-x.status"
   write_meta "$case_dir" local-only ship
+  mkdir -p "$case_dir/tasktmp"
+  printf '!\n' > "$case_dir/state/task-x1.grok-turnend-token"
+  printf '!\n' > "$case_dir/state/task-x1.kimi-turnend-token"
+  printf 'tasktmp=%s\n' "$case_dir/tasktmp" >> "$case_dir/state/task-x1.meta"
   wt_commit "$case_dir" "merged work"
   wt_head=$(git -C "$case_dir/wt" rev-parse HEAD)
   git -C "$case_dir/project" update-ref refs/heads/main "$wt_head"
@@ -1426,7 +1430,17 @@ test_secondmate_home_teardown_delivers_final_line_or_refuses() {
     || fail "mate-teardown-refuses: refusal did not name the parent channel: $(cat "$case_dir/stderr")"
   [ -f "$case_dir/state/task-x1.meta" ] && [ -f "$case_dir/state/task-x1.status" ] \
     || fail "mate-teardown-refuses: refusal did not retain the task records"
+  [ -f "$case_dir/state/task-x1.grok-turnend-token" ] \
+    && [ -f "$case_dir/state/task-x1.kimi-turnend-token" ] \
+    && [ -d "$case_dir/tasktmp" ] \
+    || fail "mate-teardown-refuses: refusal removed endpoint records before parent delivery"
   rmdir "$channel"
+  err=$(FM_HOME="$case_dir/home" FM_STATE_OVERRIDE="$case_dir/state" \
+    "$ROOT/bin/fm-wake-drain.sh" 2>&1 >/dev/null)
+  seq=$(printf '%s\n' "$err" | sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through \([0-9][0-9]*\) --recovery-generation .*/\1/p')
+  generation=$(printf '%s\n' "$err" | sed -n 's/^WAKE_ACK_REQUIRED:.*--recovery-generation \([A-Za-z0-9._-][A-Za-z0-9._-]*\)$/\1/p')
+  [ -z "$seq" ] || FM_HOME="$case_dir/home" FM_STATE_OVERRIDE="$case_dir/state" \
+    "$ROOT/bin/fm-wake-drain.sh" --ack-through "$seq" --recovery-generation "$generation" >/dev/null
   set +e
   FM_HOME="$case_dir/home" run_teardown "$case_dir" > "$case_dir/stdout2" 2> "$case_dir/stderr2"
   rc=$?


### PR DESCRIPTION
## Intent

Clean-slate, minimal-sufficient fix that supersedes https://github.com/kunchenguid/firstmate/pull/3569 (fix: guarantee secondmate outcomes reach the parent channel). Captain's order verbatim: "ok promote this crewmate to do the minimal sufficient fix as a clean slate implementation and have it supersede 3569". Start from origin/main; do not use PR 3569's branch, cherry-pick its commits, or port its third scanner, orphan lifecycle, hold-generation body format, bounded wake-queue family, or threshold-escalation clocks.

THE WHOLE PROBLEM (must stay the goal; do not shrink it to "PR URL landed"). Captain intent verbatim: "the root problem is not specific to PRs, right? it looks like any message or outcomes from second mates can miss. we need to make sure our fixes are addressing this in a principled, fundamental way, not surgically treating the symptoms of just this PR update miss." Observed failure (2026-09-02, four instances across two mate homes): watcher delivery to the secondmate worked, the mate did the work, then the mate addressed the captain in its own unread chat instead of appending to the parent channel; AGENTS.md tells every firstmate to reach the captain and address the captain in every response while the charter's return-channel rule was a smaller later instruction. PR-ready reports, findings, blockers, decisions, and failures all fail the same way. Design goal: the parent channel must not depend on the model remembering to write to it. The delivery rule: the scripts report facts, the mate reports judgement. This rationale is recorded in docs/secondmate-parent-channel.md (design note, maintainer-architecture) and in the header of bin/fm-parent-channel-lib.sh.

KEEP ONLY these mechanisms (the accepted scope from the audit report's "smallest set"):
1. Charter and AGENTS.md carve-outs: bin/fm-brief.sh's secondmate charter gains "# The captain and the parent channel" (nobody reads this chat; the parent channel IS the captain; the scripts deliver child facts; the mate appends judgement). AGENTS.md gains one line at the persona-address rule and one line after section 9's reach-the-captain list pointing at the design note.
2. bin/fm-parent-channel-lib.sh: the single owner of parent-channel resolution (marker .fm-secondmate-home + binding .fm-secondmate-parent; local route = parent home's state/<mate>.status, remote route = this home's state/parent-replies.status) and exact-line append-once with a regular-non-symlinked-file check. Deliberately NO hashed per-destination lock and NO unterminated-tail repair. Return codes 0/1 main home/2 unusable marker/3 unreadable binding/4 append failed. bin/fm-merge-outcome-lib.sh and bin/fm-inactive-reconcile.sh now use it instead of their two private copies (fm_merge_outcome_home_id, fm_merge_outcome_append_once, home_secondmate_id body, append_once were removed as duplicates).
3. bin/fm-pr-check.sh: after arming the poll, in a secondmate home append "done [key=child-pr-<id>]: child <id> PR ready: <canonical url> mode=<mode> yolo=<yolo>" to the parent channel; a main home is a silent no-op; a channel failure prints an actionable: line on stderr and the poll stays armed (exit 0). Consequence accepted: fm-pr-merge.sh calls fm-pr-check, so a secondmate merge now produces a ready line plus the merged line on the channel; tests/fm-pr-merge.test.sh assertions were updated accordingly.
4. bin/fm-captain-hold.sh: hold publishes "needs-decision [key=captain-hold-<task>-<n>]: captain hold <task>: <reason>" and answer/answers publish the matching "resolved [key=captain-hold-<task>-<n>]: captain hold <task>: answered|released|answered (repaired)", where <n> = count of resolution records already in the task body + 1 (resolution_record_count, counting "Resolution recorded by fm-captain-hold." and "fm-decision-hold." headers), so a released-and-re-held task gets a distinct occurrence with NO new persisted block or body format change. Gated on the secondmate marker through the lib (main home = rc 1 = no-op). A channel failure is reported as actionable on stderr and never undoes the durable hold/answer; the batch answers path now forwards a successful answer's stderr instead of dropping it. Idempotent retries republish the same line, which append-once deduplicates.
5. bin/fm-inactive-reconcile.sh ledger-first fast path: in a secondmate home every scan invocation (every watcher poll, before the cadence gate) runs ledger_pass: for each direct ordinary child (kind != secondmate) under its meta lock, if the ledger ends in a whole newline-terminated done: or failed: line, publish "<state> [key=child-outcome-<child>-<state>]: child <child> <state>: <note> [pr=<url>] [mode=<mode>] [yolo=<posture>] [report=data/<child>/report.md]" using the EXISTING terminal-outcomes receipt store (fingerprint = sha256(incarnation|id|state|ledger|last line)) so it is delivered once per terminal event and incarnation; no fm-crew-state.sh call, no forge; a line without its trailing newline waits for the next poll; the inactive (crew-state) path yields to a terminal-verb ledger in a secondmate home so one outcome is never reported twice; a failed append queues the existing once-per-record notice naming a missing binding. Main homes are unchanged. New subcommand "report <task-id>" runs the same delivery for a caller holding the child's meta lock: exit 0 when delivered or nothing owed, nonzero when the channel cannot be written.
6. bin/fm-teardown.sh: in a non-secondmate task teardown, after the endpoint is killed and before record removal, run fm-inactive-reconcile.sh report <id>; on failure print an error and exit 1 retaining every durable record (no orphan record, no presentation-retirement changes). Placed after the kill so the ledger cannot change under the read; a rerun retries.
7. Tests exercising executable interfaces only: tests/fm-inactive-reconcile.test.sh (ledger delivery with note/pr/mode/yolo/report, once-only, failed verb, new terminal line after recovery, unterminated line waits, remote route, report subcommand delivers/owes-nothing/refuses, real watcher poll delivers; slow-path fixtures changed to silent working: ledgers because terminal ledgers now belong to the ledger path), tests/fm-captain-hold-lifecycle.test.sh (mate home publishes hold occurrences 1 and 2 and their answers, retry does not duplicate, main home publishes nothing; the existing mate fixture gained the parent binding and parent registration that real seeded homes always have because teardown resolves that registration), tests/fm-teardown.test.sh (fm-pr-check ready line once in a mate home and nothing in a main home; teardown delivers the final line, refuses with records retained while the channel is a directory, then completes after repair), tests/fm-pr-merge.test.sh (ready line plus merged line, failed merge reports no merged line), tests/fm-brief.test.sh (charter section pinned on the generated charter output).
8. Docs: docs/secondmate-parent-channel.md (design, coverage table, what is deliberately not built), docs/verification/secondmate-parent-channel.md (dated live verification transcript), docs/scripts.md row, docs/architecture.md and docs/remote-secondmates.md one-line cross-references, docs/documentation-audiences.json registrations. bin/fm-lint.sh and bin/fm-doc-audience-check.sh pass. firstmate-coding-guidelines followed: one owner per contract (the lib header owns the channel; the reconcile header owns the ledger line format; the hold script header owns the occurrence rule), one sentence per line, plain dashes, no agent co-author.

EXCLUDED on purpose (do not flag as missing): no mirror of the mate's chat; no threshold escalation of open needs-decision/blocked lines (a decision the mate escalates is a captain hold, which is published; a decision it neither answers nor escalates is a separable supervision-quality question); no second scanner or state/parent-mirror records; no orphan lifecycle; no hold-generation block in task bodies; no bounded wake-queue variants; no per-destination locks (the meta and scan locks already serialize identical-line publishers). Duplicate lines on the channel are accepted by design (a duplicate is harmless, a miss is not); the mate may still append its own judgement about a delivered outcome.

LIVE VALIDATION already performed (captain requirement 2): two isolated homes with config/backend=tmux, real tmux panes for the child and the mate, the real bin/fm-watch.sh in both homes re-armed after every wake via bin/fm-wake-drain.sh acknowledgement, no model. The child typed "echo 'done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green' >> state/child.status" in its own pane; within one poll the parent channel gained "done [key=child-outcome-child-done]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off"; fm-pr-check added "done [key=child-pr-child]: child child PR ready: https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off"; fm-captain-hold added "needs-decision [key=captain-hold-child-call-1]: captain hold child-call: rollout window choice pending" and "resolved [key=captain-hold-child-call-1]: captain hold child-call: answered"; the real parent watcher woke with a signal: exactly four times, once per line. Recorded in docs/verification/secondmate-parent-channel.md.

Known pre-existing local failures unrelated to this change (fail identically on origin/main on this Mac, pass in CI): tests/fm-wake-queue.test.sh "a subshell reclaimed its parent's live hold (rc=13)" and tests/fm-teardown.test.sh herdr-preflight-missing-adapter; every other case in the touched suites passes locally.

## What Changed

- Add shared parent-channel resolution and append-once delivery for local and remote secondmate homes.
- Publish terminal child outcomes, PR readiness, merge results, and captain-hold transitions directly from the scripts that record them; retain teardown records when final delivery fails.
- Document the parent-channel contract and expand executable coverage for routing, retries, lifecycle events, and delivery failures.

## Risk Assessment

🚨 High: The change claims single-owner terminal outcome delivery, but a concrete concurrent sequence can still publish one completion through both outcome paths.

## Testing

Targeted executable suites covered ledger reconciliation, hold lifecycle, PR merge behavior, generated briefs, and teardown delivery/retention; the teardown suite reached only its documented pre-existing Herdr fixture failure. A real two-home tmux run then demonstrated end-to-end delivery of all four captain-facing facts with four parent watcher wakes. One stale test expectation was corrected and its suite passed on rerun.

<details>
<summary>Evidence: Normalized real-tmux secondmate parent-channel transcript</summary>

Source: [Normalized real-tmux secondmate parent-channel transcript](https://github.com/kunchenguid/firstmate/blob/8f30e29cdaf1296955c6796c19044895f547fc1f/.no-mistakes/evidence/fm/fm-pr3569-complexity-audit-s1/live-validation-transcript.txt)

```text

$ # Setup: mate home $M is a secondmate of parent home $P (local route); child task 'child' lives in a real tmux pane; both watchers are live

$ # Step 1: the child appends its terminal line from inside its own real tmux pane

$ tmux send-keys -t fmlive:fm-child "echo 'done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green' >> $M/state/child.status" Enter

$ cat $M/state/child.status
working: implementing the feature
done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green

$ cat $P/state/mate.status   (the parent channel)
working: delegated scope
done [key=child-outcome-child-done-05b032a1]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off

$ mate watcher wakes so far
signal: $M/state/child.status

$ parent watcher wakes so far
signal: $P/state/mate.status

$ # Step 2: the mate registers the PR with fm-pr-check; the ready line with the canonical URL reaches the parent from the script itself

$ FM_HOME=$M FM_STATE_OVERRIDE=$M/state bin/fm-pr-check.sh child https://github.com/kunchenguid/firstmate/pull/9999
armed: state/child.check.sh

$ cat $P/state/mate.status
working: delegated scope
done [key=child-outcome-child-done-05b032a1]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
done [key=child-pr-child]: child child PR ready: https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off

$ parent watcher wakes so far (2 signals)
signal: $P/state/mate.status
signal: $P/state/mate.status

$ # Step 3: the mate holds a task for the captain; the hold reaches the parent from fm-captain-hold itself

$ FM_HOME=$M bin/fm-captain-hold.sh hold child-call --title 'Pick the rollout window' --reason 'rollout window choice pending' --repo alpha
child-call

$ # Step 4: the captain's answer is recorded in the mate home; the close reaches the parent from fm-captain-hold itself

$ FM_HOME=$M bin/fm-captain-hold.sh answer child-call --decision-file decision.txt   (decision: roll out on Monday)
answered: child-call

$ cat $P/state/mate.status   (final parent channel)
working: delegated scope
done [key=child-outcome-child-done-05b032a1]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
done [key=child-pr-child]: child child PR ready: https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
needs-decision [key=captain-hold-child-call-1]: captain hold child-call: rollout window choice pending
resolved [key=captain-hold-child-call-1]: captain hold child-call: answered

$ parent watcher wakes, one per delivered line (4 signals)
signal: $P/state/mate.status
signal: $P/state/mate.status
signal: $P/state/mate.status
signal: $P/state/mate.status

$ mate watcher wakes
signal: $M/state/child.status
stale: fmlive:fm-child

$ # Every line above beginning 'done [key=child-' or carrying 'captain-hold-' was written by a script, never by a model; each one woke the parent watcher.
```
</details>
<details>
<summary>Evidence: Persisted final parent-channel status</summary>

Source: [Persisted final parent-channel status](https://github.com/kunchenguid/firstmate/blob/8f30e29cdaf1296955c6796c19044895f547fc1f/.no-mistakes/evidence/fm/fm-pr3569-complexity-audit-s1/live-fixture/parent/state/mate.status)

```text
working: delegated scope
done [key=child-outcome-child-done-05b032a1]: child child done: PR https://github.com/kunchenguid/firstmate/pull/9999 checks green pr=https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
done [key=child-pr-child]: child child PR ready: https://github.com/kunchenguid/firstmate/pull/9999 mode=no-mistakes yolo=off
needs-decision [key=captain-hold-child-call-1]: captain hold child-call: rollout window choice pending
resolved [key=captain-hold-child-call-1]: captain hold child-call: answered
```
</details>
<details>
<summary>Evidence: Real parent watcher wake log</summary>

Source: [Real parent watcher wake log](https://github.com/kunchenguid/firstmate/blob/8f30e29cdaf1296955c6796c19044895f547fc1f/.no-mistakes/evidence/fm/fm-pr3569-complexity-audit-s1/live-fixture/parent-watch.log)

```text
signal: ~/.no-mistakes/evidence/01M1JHTDWCXR9V406DBVQXBV3E/live-fixture/parent/state/mate.status
signal: ~/.no-mistakes/evidence/01M1JHTDWCXR9V406DBVQXBV3E/live-fixture/parent/state/mate.status
signal: ~/.no-mistakes/evidence/01M1JHTDWCXR9V406DBVQXBV3E/live-fixture/parent/state/mate.status
signal: ~/.no-mistakes/evidence/01M1JHTDWCXR9V406DBVQXBV3E/live-fixture/parent/state/mate.status
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"fd9ee3659b0dc6706ef14b64663909f2ab1d57ce","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `bin/fm-captain-hold.sh:477` - Intent requires `needs-decision ...: &lt;reason&gt;`, but the `--origin` path publishes `&lt;reason&gt; (origin &lt;origin&gt;)`. This changes the explicitly required parent-channel protocol for common origin-linked holds; confirm with the user before changing the deliberate output.
- 🚨 `bin/fm-captain-hold.sh:788` - An idempotent `answers` retry bypasses `command_answer` and therefore never republishes the resolved line. If the first answer durably closes the task while the channel is unwritable, repairing the channel and replaying the batch only prints `closed:` here, leaving the required parent outcome permanently missing. Republish the matching occurrence before continuing.
- 🚨 `bin/fm-inactive-reconcile.sh:364` - The receipt fingerprint hashes `clean_field &#34;$last&#34;`, which truncates the complete ledger line to 1200 bytes instead of hashing the required last line. Two failed lines in one incarnation that share the first 1200 total bytes but differ afterward produce the same receipt, while their separately cleaned notes can still produce different parent lines; the later outcome is silently suppressed. Hash the complete terminal line and sanitize only rendered fields.
- ⚠️ `bin/fm-inactive-reconcile.sh:597` - `report` is explicitly called while teardown holds the child meta lock, but it acquires `SCAN_LOCK`; watcher scans acquire `SCAN_LOCK` first and then the same meta lock. Concurrent teardown and scanning therefore deadlock until the scan&#39;s outer timeout kills it, delaying teardown by the full reconciliation timeout. Avoid taking the scan lock in this caller-held-meta-lock path or establish one consistent lock order.

🔧 Fix: Fix parent outcome retries and reconciliation locking
2 errors still open:

- 🚨 `bin/fm-captain-hold.sh:477` - Intent requires `needs-decision ...: &lt;reason&gt;`, but this changed hunk publishes `&lt;reason&gt; (origin &lt;origin&gt;)` whenever `--origin` is supplied. Confirm whether this deliberate protocol deviation is authorized before changing it.
- 🚨 `bin/fm-inactive-reconcile.sh:399` - The new ledger pass waits indefinitely on each metadata lock while the entire scan is killed after `FM_INACTIVE_RECONCILE_BUDGET_SECS + 1`, and every retry restarts from the first glob entry. A long-lived lock on an early child therefore prevents all later children from ever reaching `report_child_ledger_locked`, leaving their outcomes permanently undelivered. Use a nonblocking/bounded acquisition that skips the busy child and continues, while retrying it on a later poll.

🔧 Fix: Prevent busy children from starving ledger delivery
5 issues (2 errors, 3 warnings) still open:

- 🚨 `bin/fm-captain-hold.sh:477` - Intent requires `needs-decision ...: &lt;reason&gt;`, but the `--origin` path publishes `&lt;reason&gt; (origin &lt;origin&gt;)`. This deliberate parent-channel protocol deviation needs user authorization.
- 🚨 `bin/fm-inactive-reconcile.sh:379` - Distinct terminal lines that differ only after byte 1200 get distinct receipts but render to the same truncated channel line. `fm_parent_channel_report` then treats the second line as already present and marks its receipt reported without publishing that terminal outcome. Resolving this requires authorization to change the bounded output/protocol, such as retaining a collision-resistant event identity.
- ⚠️ `bin/fm-inactive-reconcile.sh:362` - When metadata has no `pr=`, `pr_for_task` selects the first PR URL from the entire ledger. For `working: old PR &lt;url1&gt;` followed by `done: replacement PR &lt;url2&gt;`, the new parent report describes URL2 but appends `pr=&lt;url1&gt;`. Prefer the terminal line&#39;s URL or otherwise the latest ledger URL.
- ⚠️ `bin/fm-inactive-reconcile.sh:397` - `ledger_pass` checks `kind` before acquiring the metadata lock and does not revalidate it afterward. If an ordinary task is retired and its ID is reused for a secondmate between those operations, the scanner can publish the replacement secondmate&#39;s status as an ordinary child outcome. Recheck the meta file and `kind != secondmate` after acquiring the lock.
- ⚠️ `bin/fm-captain-hold.sh:354` - The occurrence counter counts the record phrase anywhere in the task body rather than counting resolution-record headers. An initial body that quotes `Resolution recorded by fm-captain-hold.` makes its first real hold use occurrence 2, contrary to the required record-count rule. Count decoded, line-anchored headers instead.

🔧 Fix: Correct ledger metadata and hold occurrence handling
2 errors still open:

- 🚨 `bin/fm-captain-hold.sh:480` - Intent requires `needs-decision ...: &lt;reason&gt;`, but the `--origin` path deliberately publishes `&lt;reason&gt; (origin &lt;origin&gt;)`. This protocol deviation requires user authorization.
- 🚨 `bin/fm-inactive-reconcile.sh:383` - The required once-per-terminal-event guarantee remains false when distinct receipts render identically. For example, two incarnations of the same child ending with the same `done:` line receive different fingerprints, but the second publication matches the existing channel line exactly; append-once returns success and its receipt is marked reported without appending or waking the parent. Lines differing only beyond the 1200-byte rendered-note limit fail similarly. Resolving the conflict between per-event delivery and the required exact-line protocol needs user authorization, likely by adding collision-resistant event identity to the rendered line.

🔧 Fix: Disambiguate ledger outcomes and normalize hold reasons
4 issues (3 errors, 1 warning) still open:

- 🚨 `bin/fm-inactive-reconcile.sh:349` - The required rule that an unterminated line waits is racy: `tail -c 1` checks the live file, then `last_status_line` reads it again. If a writer begins appending `done: half` between those reads, the first check sees the previous newline and the second read publishes the incomplete terminal line. Read and validate one stable snapshot before publishing.
- 🚨 `bin/fm-inactive-reconcile.sh:436` - The required single-owner yield is checked only before the potentially slow `fm-crew-state.sh` call. A scan can read an old `working:` tail, the child can append `done:` and exit while the state read runs, and the slow path then publishes `inactive-outcome-*`; the next poll publishes the same event through `child-outcome-*`. Recheck the terminal ledger after the state read and before creating the inactive receipt.
- 🚨 `bin/fm-teardown.sh:2880` - Intent requires reporting after the endpoint is killed but before record removal, with every durable record retained on failure. The report currently runs after `remove_grok_turnend_auth`, `remove_kimi_turnend_auth`, transition clearing, and task-temp removal at lines 2866-2871, so an unwritable channel exits after records have already been discarded. Move the report gate immediately after endpoint-gone confirmation and before these removals.
- ⚠️ `docs/verification/secondmate-parent-channel.md:31` - The live-verification transcript still records `child-outcome-child-done` without the newly required fingerprint suffix, although it claims to verify this change&#39;s branch and instructs maintainers to refresh after publisher changes. The current implementation cannot produce the documented transcript; rerun and record live verification rather than editing the claimed evidence speculatively.

🔧 Fix: Close ledger races and preserve teardown records
1 error still open:

- 🚨 `bin/fm-inactive-reconcile.sh:446` - The required invariant that the inactive path yields to a terminal ledger so one outcome is never reported twice remains racy. Concrete sequence: `fm-crew-state.sh` returns `done`, the recheck at line 446 still sees `working:`, the child appends `done:` immediately afterward, and lines 462-466 publish an `inactive-outcome-*`; the next poll then publishes the same completion as `child-outcome-*`. The recheck narrows but does not close the unsynchronized window. A durable remedy needs authorization because it requires a shared ownership/serialization boundary between terminal-ledger appends and inactive publication, rather than another recheck.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-inactive-reconcile.test.sh`
- `bash tests/fm-captain-hold-lifecycle.test.sh`
- <code>`bash tests/fm-pr-merge.test.sh` before and after correcting the stale behavioral assertion</code>
- `bash tests/fm-brief.test.sh`
- <code>`bash tests/fm-teardown.test.sh` (new parent-channel cases passed before the documented pre-existing herdr-preflight-missing-adapter failure)</code>
- `ROOT="$PWD" LIVE="~/.no-mistakes/evidence/01M1JHTDWCXR9V406DBVQXBV3E/live-fixture" bash ~/github/kunchenguid/firstmate/data/fm-pr3569-complexity-audit-s1/live-validation.sh`
- `Verified the live parent channel contained ledger outcome, PR-ready, captain-hold, and resolution records and that the real parent watcher emitted one signal per delivered line.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Quote done arguments for ShellCheck compliance
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
