### PR TITLE
fix(bin): launch into a repository that has no remote

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -138,6 +138,11 @@
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
+#   A repository with no origin remote configured instead skips the fetch,
+#   resolves its local default branch, resets the slot to that branch's tip, and
+#   prints a notice naming the local branch and commit it launched from.
+#   That stand-aside is keyed on the absence of an origin remote only, so a
+#   configured origin that cannot be fetched still refuses exactly as before.
 #   A slot whose only deviation is a stale submodule gitlink is refused by that
 #   same clean check, but is reported as a stale checkout naming each submodule
 #   and both pins; nothing is converged or removed, and no remedy is suggested.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1892,24 +1892,55 @@ EOF
   printf '%s' "$lines" >&2
 }
 
+# The freshness guard exists to stop a worker launching from an out-of-date copy
+# of a remote, so a repository that HAS no remote is not a stale base - it is a
+# base with no upstream to be stale against, and the guard resolves it from local
+# refs instead of refusing.
+#
+# That stand-aside is deliberately narrow, because widening it would cost the
+# guard its whole point. It fires only when `origin` is absent from the
+# repository's own remote list. A repository that HAS an origin still refuses on
+# every fetch failure - an unreachable network, a bad credential, a deleted
+# remote - because there the failed fetch IS the stale-base risk this gate was
+# written to catch. A remote list that cannot be read is not proof of absence and
+# refuses too.
+#
+# With no upstream, the local default branch is the base, and every other
+# assertion is unchanged: the same clean-worktree gate, the same reset, and the
+# same verification that HEAD really landed on the resolved commit.
 freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual status
-  if ! git -C "$worktree" fetch --quiet origin; then
-    echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+  local worktree=$1 default target expected actual status remotes upstream=1
+  if ! remotes=$(git -C "$worktree" remote 2>/dev/null); then
+    echo "error: could not read the remotes of pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
   fi
-  if ! git -C "$worktree" remote set-head origin --auto >/dev/null 2>&1; then
-    echo "error: could not resolve origin's current default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
+  printf '%s\n' "$remotes" | grep -qxF origin || upstream=0
+  if [ "$upstream" -eq 1 ]; then
+    if ! git -C "$worktree" fetch --quiet origin; then
+      echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+    if ! git -C "$worktree" remote set-head origin --auto >/dev/null 2>&1; then
+      echo "error: could not resolve origin's current default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
   fi
   default=$(default_branch "$worktree") || {
-    echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    if [ "$upstream" -eq 1 ]; then
+      echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    else
+      echo "error: could not determine the local default branch of pooled worktree '$worktree', which has no origin remote; refusing to launch from an unverified base" >&2
+    fi
     return 1
   }
-  target="origin/$default"
-  if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
-    echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
+  if [ "$upstream" -eq 1 ]; then
+    target="origin/$default"
+    if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
+      echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+  else
+    target="refs/heads/$default"
   fi
   expected=$(git -C "$worktree" rev-parse --verify --quiet "$target^{commit}" 2>/dev/null) || {
     echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
@@ -1936,6 +1967,7 @@ freshen_spawn_worktree_base() {  # <worktree>
     echo "error: pooled worktree '$worktree' is at '${actual:-unknown}', not current '$target' ('$expected'); refusing to launch" >&2
     return 1
   fi
+  [ "$upstream" -eq 1 ] || echo "notice: pooled worktree '$worktree' has no origin remote; starting from its local '$default' base ($expected) rather than freshening from origin" >&2
 }
 
 herdr_projection_meta_field_exact() {  # <meta> <key>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,6 +198,8 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
+A repository with no origin remote configured has no upstream to be stale against, so the spawn resolves the local default branch, resets the slot to its tip, and says so in a notice.
+That stand-aside is keyed on the absence of an origin remote only, so a configured origin that cannot be fetched still stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -6,6 +6,9 @@
 # These tests drive the real spawn path with a fake terminal, then prove it
 # starts the worker from the fetched origin/main tip or stops when origin is
 # unreachable.
+# A repository with no remote at all has no upstream to be stale against, so they
+# also prove that case launches from a verified current copy of its local default
+# branch while a configured origin that cannot be fetched still refuses.
 set -u
 
 # shellcheck source=tests/fixtures.sh
@@ -425,6 +428,145 @@ test_stale_pin_beside_other_dirt_reports_one_verdict() {
   pass "a stale pin beside other dirt yields the conservative refusal alone, with no stale-pin line"
 }
 
+# A repository with no remote at all is a real, supported case: a purely local
+# repo has no upstream to be stale against, so the freshness guard must resolve
+# its base from local refs instead of refusing to launch into it. The fixture
+# advances the project's own default branch after the slot was allocated, so a
+# guard that merely skipped the fetch and left the slot alone would still fail
+# here - the slot has to land on the current local tip.
+make_remoteless_case() {  # <name> <id> [default-branch]
+  local name=$1 id=$2 default=${3:-master} case_dir home project pool fakebin initial advanced
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  pool="$case_dir/pool"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b "$default" "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+
+  printf 'must survive a newly spawned branch\n' > "$project/advanced-local.txt"
+  git -C "$project" add advanced-local.txt
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-local
+  advanced=$(git -C "$project" rev-parse HEAD)
+
+  [ -z "$(git -C "$pool" remote)" ] || fail "fixture left a remote configured on a remote-less pool"
+
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default|$advanced"
+}
+
+read_remoteless_case() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJECT_DIR POOL_DIR FAKEBIN_DIR INITIAL_SHA DEFAULT_BRANCH ADVANCED_SHA <<EOF
+$1
+EOF
+}
+
+test_remoteless_repo_launches_from_its_local_base() {
+  local rec id out status head
+  id='pool-no-remote-r12'
+  rec=$(make_remoteless_case no-remote "$id")
+  read_remoteless_case "$rec"
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should launch into a repository that has no remote at all"
+  assert_contains "$out" "spawned $id" "spawn did not report success for a remote-less repository"
+  assert_not_contains "$out" "could not fetch origin" \
+    "a repository with no remote was refused as an unfetchable origin"
+  assert_contains "$out" "has no origin remote" \
+    "spawn did not say it started from a local base rather than freshening from origin"
+  assert_contains "$out" "local '$DEFAULT_BRANCH' base" \
+    "the no-upstream notice did not name the local base branch it started from"
+  head=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$head" = "$ADVANCED_SHA" ] \
+    || fail "spawn did not refresh the remote-less pool to its current local $DEFAULT_BRANCH tip"
+  [ "$ADVANCED_SHA" != "$INITIAL_SHA" ] \
+    || fail "fixture did not prove the local $DEFAULT_BRANCH advanced past the pool base"
+  assert_grep 'must survive a newly spawned branch' "$POOL_DIR/advanced-local.txt" \
+    "the remote-less spawn started from history that predates the current local base"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed no-remote notice: %s\n' "$(printf '%s\n' "$out" | grep 'has no origin remote')"
+    printf '# observed no-remote base: HEAD=%s local-%s=%s\n' \
+      "$head" "$DEFAULT_BRANCH" "$ADVANCED_SHA"
+  fi
+  pass "a repository with no remote launches from a verified current copy of its local default branch"
+}
+
+test_remoteless_repo_refuses_a_dirty_pool() {
+  local rec id out status before
+  id='pool-no-remote-dirty-r13'
+  # main rather than master here, so the local-base path is proven against both
+  # default-branch names the resolver falls back through when no origin/HEAD exists.
+  rec=$(make_remoteless_case no-remote-dirty "$id" main)
+  read_remoteless_case "$rec"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  printf 'keep this local work\n' > "$POOL_DIR/uncommitted.txt"
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a remote-less repository skipped the uncommitted-work gate"
+  assert_contains "$out" "is not clean" \
+    "a dirty remote-less pool was not refused with the unchanged uncommitted-work wording"
+  assert_not_contains "$out" "could not determine the local default branch" \
+    "the local-base path did not resolve a default branch named main"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD while refusing a dirty remote-less pool"
+  assert_grep 'keep this local work' "$POOL_DIR/uncommitted.txt" \
+    "spawn discarded uncommitted work in a remote-less pool"
+  pass "having no upstream stands the freshness fetch aside and nothing else: a dirty pool is still refused"
+}
+
+# The whole safety property of the no-upstream stand-aside is that it reads
+# absence, never failure. A configured origin that cannot be fetched is exactly
+# the stale-base risk the guard exists for, so it must keep refusing with its
+# original wording and must never be quietly rerouted onto the local base.
+test_unfetchable_origin_is_never_treated_as_no_remote() {
+  local rec id out status before
+  id='pool-origin-not-absent-r14'
+  rec=$(make_case origin-not-absent "$id")
+  read_case_record "$rec"
+  git -C "$POOL_DIR" remote set-url origin "file://$CASE_DIR/missing-origin.git"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ -n "$(git -C "$POOL_DIR" remote)" ] || fail "fixture removed the origin it was supposed to keep"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a configured but unfetchable origin was allowed to launch"
+  assert_contains "$out" "could not fetch origin" \
+    "an unfetchable origin lost its original refusal wording"
+  assert_not_contains "$out" "has no origin remote" \
+    "an unfetchable origin was rerouted onto the no-upstream local base"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD while refusing a configured but unfetchable origin"
+  pass "a configured origin that cannot be fetched still refuses and is never mistaken for having no remote"
+}
+
+test_reachable_origin_never_takes_the_local_base_path() {
+  local rec id out status current
+  id='pool-origin-present-r15'
+  rec=$(make_case origin-present "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should still refresh a remote-backed pooled worktree"
+  assert_not_contains "$out" "has no origin remote" \
+    "a remote-backed spawn reported itself as having no upstream"
+  current=$(git -C "$POOL_DIR" rev-parse "origin/$DEFAULT_BRANCH")
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$current" ] \
+    || fail "a remote-backed spawn did not start at current origin/$DEFAULT_BRANCH"
+  pass "a reachable origin still freshens from origin and never reports a missing upstream"
+}
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
@@ -436,5 +578,9 @@ test_unpushed_submodule_commit_is_still_uncommitted_work
 test_work_inside_submodule_is_still_uncommitted_work
 test_stale_pin_carrying_real_work_is_not_called_stale
 test_stale_pin_beside_other_dirt_reports_one_verdict
+test_remoteless_repo_launches_from_its_local_base
+test_remoteless_repo_refuses_a_dirty_pool
+test_unfetchable_origin_is_never_treated_as_no_remote
+test_reachable_origin_never_takes_the_local_base_path
 
 echo "# all fm-spawn-pool-base-freshen tests passed"


### PR DESCRIPTION
## Problem

`bin/fm-spawn.sh` calls `freshen_spawn_worktree_base()` for every pooled worktree, and its first action was an unconditional `git -C "$worktree" fetch --quiet origin`.
In a repository with no `origin` remote that fetch fails and the spawn aborts:

```
error: could not fetch origin for pooled worktree '<path>'; refusing to launch from a potentially stale base
```

That made it impossible to dispatch a crewmate into a purely local repository.
The concrete case is a real, actively used, deliberately remote-less local repo: `git remote -v` prints nothing and it has a single commit on `master`.

A repository with no remote is not a stale base.
It is a base with no upstream to be stale against.

## Fix

`freshen_spawn_worktree_base()` now enumerates the repository's own remotes and stands aside only when `origin` is genuinely absent, resolving the base from the local default branch instead.

The detection is by **absence**, never by **failure**, and that distinction is the whole safety property of the change:

- Origin configured but unfetchable - unreachable network, bad credential, deleted remote - still refuses on the original path, with the original wording and the original exit behaviour. There the failed fetch *is* the stale-base risk this gate was written to catch.
- `git remote` itself exiting non-zero refuses with a dedicated message. An unreadable remote list is not proof of absence, so that path stays closed.
- The membership test is `grep -qxF origin`, so a remote named `myorigin` or `origin-mirror` is not mistaken for `origin`.

No new default-branch resolution code was added.
`default_branch()` in `bin/fm-ff-lib.sh` already prefers `refs/remotes/origin/HEAD` and falls back to local `refs/heads/main` then `refs/heads/master`, which is exactly the local resolution required.

Every other assertion is preserved on the no-upstream path: the same clean-worktree gate, the same stale-submodule-pin discrimination, the same `git reset --hard`, and the same verification that `HEAD` actually landed on the resolved commit.
The pooled slot still has to end up on the current local tip - skipping the fetch and leaving the slot alone would not be enough.

Exactly one error string differs on the no-origin path: the `default_branch` failure message.
Every other message is byte-identical.

A spawn that proceeds without an upstream says so once on stderr, so an operator can tell the two cases apart:

```
notice: pooled worktree '<path>' has no origin remote; starting from its local 'master' base (<sha>) rather than freshening from origin
```

`notice:` rather than `warning:` matches the existing precedent in this script and keeps it visible but non-alarming.

## Tests

Four cases added to the existing colocated suite `tests/fm-spawn-pool-base-freshen.test.sh`:

- No remote launches from a **current** local base. The fixture advances the project's default branch *after* the pool slot is allocated, so a fix that skipped the fetch without resetting would still fail here.
- No remote still refuses a dirty pool. Deliberately on `main`, so both fallback branch names in `default_branch()` are exercised.
- A configured-but-unfetchable origin is never mistaken for no-remote.
- A reachable origin never takes the local-base path.

The new test was proven non-vacuous: restoring the unmodified `bin/fm-spawn.sh` makes it fail, while all 11 pre-existing tests in that suite still pass.

## Verification

- Acceptance proven against a faithful replica of the reported repository (same commit, branch `master`, origin removed) using the reporter's exact flags: exit 0, launched into an isolated worktree, with the expected notice.
- `bin/fm-lint.sh` exits 0 with the pinned ShellCheck 0.11.0 and actionlint 1.7.12, and 3 workflow files valid.
- Two unrelated suite failures in the local environment were confirmed pre-existing, reproducing identically with both changed files reverted: `tests/fm-teardown.test.sh`'s `herdr-preflight-missing-adapter` case, and `tests/fm-backend-herdr-presentation-e2e.test.sh`'s concurrent secondmate recovery case.

## Known consequence

The stand-aside triggers on the absence of a remote literally named `origin`, so a repository configured with only a differently-named remote such as `upstream` is also treated as having no upstream.
This matches the requirement as written and the notice text stays accurate, so it is recorded as an accepted consequence rather than a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ae32m5tijE2h4UbucVKXZ
