### PR TITLE
fix(bin): prevent duplicate wakes for fresh replacement waits

### DIFF
--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -705,9 +705,19 @@ FM_WEDGE_DEMAND_INSPECT_COUNT=${FM_WEDGE_DEMAND_INSPECT_COUNT:-3}
 # window; wake() itself exits the cycle, exactly as it does inline.
 resurface_absorbed() {  # <window> <throttle-marker> <age> <reason> [scope]
   local win=$1 throttle=$2 age=$3 reason=$4 scope=${5-}
+  # The absorb age always gates: a freshly declared wait is absorbed while it is
+  # fresh, which is this path's whole contract, and a REPLACEMENT wait is no
+  # different from the first one - the status append that declared it already woke
+  # firstmate through the signal path, so firing here as well would nag twice for
+  # one event, on the path that exists not to nag.
+  [ "$age" -ge "$PAUSE_RESURFACE_SECS" ] || return 0
+  # The throttle, by contrast, bounds ONE declared wait. A caller that passes a
+  # scope names the declaration its marker was written for, so a marker written
+  # for a DIFFERENT declaration must not suppress this one: the replacement serves
+  # its own window instead of the remainder of the previous wait's. A scope-less
+  # caller keeps the pure timestamp cadence it always had.
   if [ -z "$scope" ] || [ ! -e "$throttle" ] \
     || [ "$(cat "$throttle" 2>/dev/null || true)" = "$scope" ]; then
-    [ "$age" -ge "$PAUSE_RESURFACE_SECS" ] || return 0
     [ "$(age_of "$throttle")" -ge "$PAUSE_RESURFACE_SECS" ] || return 0   # 999999 when no prior re-surface
   fi
   fm_wake_append stale "$win" "$reason" || exit 1

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -833,24 +833,27 @@ busy_turn_over_age() {  # <task>
 # wording; a caller that reached the bounded cadence off pause tracking alone, with
 # no declaring verb left on the log, keeps the external-wait wording it always had.
 handle_paused_stale() {  # <window> <task> <hash>
-  local win=$1 task=$2 h=$3 key statusf mtime age detail reason declaration
+  local win=$1 task=$2 h=$3 key statusf mtime age last detail reason declaration
   key=$(window_key "$win")
   printf '%s' "$h" > "$STATE/.stale-$key"
   : > "$STATE/.paused-$key"
   rm -f "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
   clear_write_tracking "$key"
   statusf="$STATE/$task.status"
+  declaration="declared:$(fm_wake_signal_sig "$statusf" || true)"
+  last=$(last_status_line "$statusf")
+  # This read order is load-bearing: taking mtime last means a concurrent append
+  # can pair an old declaration only with a fresher age, never the reverse.
   mtime=$(stat_mtime "$statusf")
   case "$mtime" in ''|*[!0-9]*) mtime=$(date +%s) ;; esac
   age=$(( $(date +%s) - mtime ))
-  if status_is_captain_held "$(last_status_line "$statusf")"; then
+  if status_is_captain_held "$last"; then
     detail="captain-held, awaiting the captain"
     reason="captain-held ${age}s, awaiting the captain - verified hold transfer, rechecked on a long cadence not a wedge; answer the held decision or release the hold"
   else
     detail="paused, awaiting external"
     reason="paused ${age}s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds"
   fi
-  declaration="declared:$(fm_wake_signal_sig "$statusf" || true)"
   resurface_absorbed "$win" "$STATE/.paused-resurfaced-$key" "$age" "stale: $win ($reason)" "$declaration"
   triage_log "absorbed stale ($detail, age ${age}s): $win"
 }

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -2055,9 +2055,14 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
 }
 
 # A dead worker reaches handle_paused_stale rather than the live fallback above.
-# When one declared wait directly replaces another, the existing
-# throttle belongs to the old declaration and must not suppress the new wait's
-# first inspection merely because its timestamp is still young.
+# When one declared wait directly replaces another, the existing throttle belongs
+# to the OLD declaration and must not make the new wait serve out the remainder of
+# the old window. But the replacement is still a freshly declared wait, so this
+# path absorbs it while it is fresh exactly as it absorbs a first declaration: the
+# status append that declared it already woke firstmate through the signal path,
+# and firing here too would nag twice for one event. The contract pinned here is
+# therefore: absorbed while fresh, then re-surfaced once its OWN age crosses the
+# window, regardless of how recently the previous declaration re-surfaced.
 test_absorbed_replacement_wait_does_not_inherit_the_old_throttle() {
   local spec name initial replacement expected dir state fakebin out capture_file
   local statusf window key sig back pid wakes
@@ -2091,9 +2096,41 @@ test_absorbed_replacement_wait_does_not_inherit_the_old_throttle() {
     wait_for_exit "$pid" 100 || fail "[$name] initial declared wait did not re-surface"
     ack_stopped_cycle "$state" || fail "[$name] could not acknowledge the initial declared wait"
 
+    # The replacement is FRESH. The seen marker is advanced to its signature so the
+    # status-signal path stays quiet and this asserts the stale path alone -
+    # without that isolation the signal wake would satisfy any "was told" check and
+    # the assertion would pass whatever this path did.
     printf '%s\n' "$replacement" >> "$statusf"
     sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
     printf 'idle after replacement wait\n' > "$capture_file"
+    PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+      FM_FAKE_TMUX_CURRENT_COMMAND=zsh FM_FAKE_CREW_STATE='state: stopped · source: pane · bare shell' \
+      FM_WATCH_HANDLING_SUCCESSOR=1 \
+      FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+      FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+      FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
+    pid=$!
+    # A changed pane hash needs three polls to become stable stale: first sight
+    # records the new hash, second sight increments its stability count, and the
+    # third reaches handle_paused_stale. Each wait proves one whole intervening
+    # cycle, so require two to make the fresh-age assertion non-vacuous even when
+    # the helper removes the beacon before the watcher's first poll.
+    if ! wait_poll_cycle "$state" "$pid" || ! wait_poll_cycle "$state" "$pid"; then
+      reap "$pid"; fail "[$name] a freshly declared replacement wait was alarmed instead of absorbed"
+    fi
+    reap "$pid"
+    wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' \
+      "$state/.wake-queue" 2>/dev/null || echo 0)
+    [ "$wakes" -eq 0 ] \
+      || fail "[$name] a freshly declared replacement wait produced $wakes stale wakes while still fresh"
+
+    # Age the replacement past its OWN window while the previous declaration's
+    # throttle is still young. Inheriting that throttle would hold the new wait
+    # silent for the remainder of the old window; it must re-surface on its own.
+    back=$(( $(date +%s) - 500 ))
+    if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$statusf"
+    else touch -m -d "@$back" "$statusf"; fi
+    sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
     PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
       FM_FAKE_TMUX_CURRENT_COMMAND=zsh FM_FAKE_CREW_STATE='state: stopped · source: pane · bare shell' \
       FM_WATCH_HANDLING_SUCCESSOR=1 \
@@ -2109,7 +2146,7 @@ test_absorbed_replacement_wait_does_not_inherit_the_old_throttle() {
     grep -F "$expected" "$state/.wake-queue" >/dev/null \
       || fail "[$name] replacement declared wait used the wrong recheck reason: $(cat "$state/.wake-queue")"
   done
-  pass "absorbed paused and captain-held replacements each start their own re-surface cadence"
+  pass "absorbed paused and captain-held replacements are absorbed while fresh, then start their own re-surface cadence"
 }
 
 # Run one watcher round against a parked-worker fixture, so a round differs only

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -2065,7 +2065,7 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
 # window, regardless of how recently the previous declaration re-surfaced.
 test_absorbed_replacement_wait_does_not_inherit_the_old_throttle() {
   local spec name initial replacement expected dir state fakebin out capture_file
-  local statusf window key sig back pid wakes
+  local statusf window key sig back pid wakes real_grep new_hash ready release once i
   for spec in \
     'paused-replacement|paused: waiting on validation run one|paused: waiting on validation run two|awaiting external' \
     'captain-held-replacement|captain-held [key=route]: awaiting the routing call|captain-held [key=release]: awaiting the release call|awaiting the captain'
@@ -2096,20 +2096,68 @@ test_absorbed_replacement_wait_does_not_inherit_the_old_throttle() {
     wait_for_exit "$pid" 100 || fail "[$name] initial declared wait did not re-surface"
     ack_stopped_cycle "$state" || fail "[$name] could not acknowledge the initial declared wait"
 
-    # The replacement is FRESH. The seen marker is advanced to its signature so the
-    # status-signal path stays quiet and this asserts the stale path alone -
-    # without that isolation the signal wake would satisfy any "was told" check and
-    # the assertion would pass whatever this path did.
-    printf '%s\n' "$replacement" >> "$statusf"
-    sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
+    # Pause the executable watcher after it reads the old declaration but before
+    # it reads the status mtime, then append the replacement concurrently.
+    # Correct ordering can pair the old declaration only with the replacement's
+    # fresh age. Reading the mtime first instead pairs a stale age with the new
+    # declaration signature and incorrectly alarms on the scope mismatch.
+    real_grep=$(command -v grep)
+    new_hash=$(hash_text 'idle after replacement wait')
+    ready="$state/concurrent-status-read-ready"
+    release="$state/concurrent-status-read-release"
+    once="$state/concurrent-status-read-once"
+    cat > "$fakebin/grep" <<'SH'
+#!/usr/bin/env bash
+set -u
+matched=1
+for arg in "$@"; do
+  [ "$arg" = "${FM_CONCURRENT_STATUS_FILE:-}" ] && matched=0
+done
+if [ "$matched" -eq 0 ] \
+  && [ "$(cat "${FM_CONCURRENT_STALE_MARKER:-/dev/null}" 2>/dev/null || true)" = "${FM_CONCURRENT_STALE_VALUE:-}" ] \
+  && [ ! -e "${FM_CONCURRENT_READ_ONCE:-/dev/null}" ]; then
+  snapshot="${FM_CONCURRENT_READ_READY}.snapshot"
+  "${FM_CONCURRENT_REAL_GREP:?}" "$@" > "$snapshot"
+  status=$?
+  : > "$FM_CONCURRENT_READ_ONCE"
+  : > "$FM_CONCURRENT_READ_READY"
+  i=0
+  while [ ! -e "$FM_CONCURRENT_READ_RELEASE" ] && [ "$i" -lt 1000 ]; do
+    sleep 0.01
+    i=$((i + 1))
+  done
+  [ -e "$FM_CONCURRENT_READ_RELEASE" ] || exit 124
+  cat "$snapshot"
+  exit "$status"
+fi
+exec "${FM_CONCURRENT_REAL_GREP:?}" "$@"
+SH
+    chmod +x "$fakebin/grep"
     printf 'idle after replacement wait\n' > "$capture_file"
     PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
       FM_FAKE_TMUX_CURRENT_COMMAND=zsh FM_FAKE_CREW_STATE='state: stopped · source: pane · bare shell' \
       FM_WATCH_HANDLING_SUCCESSOR=1 \
+      FM_CONCURRENT_REAL_GREP="$real_grep" FM_CONCURRENT_STATUS_FILE="$statusf" \
+      FM_CONCURRENT_STALE_MARKER="$state/.stale-$key" FM_CONCURRENT_STALE_VALUE="$new_hash" \
+      FM_CONCURRENT_READ_READY="$ready" FM_CONCURRENT_READ_RELEASE="$release" \
+      FM_CONCURRENT_READ_ONCE="$once" \
       FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
       FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
       FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
     pid=$!
+    i=0
+    while [ ! -e "$ready" ] && kill -0 "$pid" 2>/dev/null && [ "$i" -lt 100 ]; do
+      sleep 0.1
+      i=$((i + 1))
+    done
+    if [ ! -e "$ready" ]; then
+      : > "$release"
+      reap "$pid"
+      fail "[$name] watcher did not reach the concurrent status-read boundary"
+    fi
+    printf '%s\n' "$replacement" >> "$statusf"
+    sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
+    : > "$release"
     # A changed pane hash needs three polls to become stable stale: first sight
     # records the new hash, second sight increments its stability count, and the
     # third reaches handle_paused_stale. Each wait proves one whole intervening
@@ -2119,6 +2167,7 @@ test_absorbed_replacement_wait_does_not_inherit_the_old_throttle() {
       reap "$pid"; fail "[$name] a freshly declared replacement wait was alarmed instead of absorbed"
     fi
     reap "$pid"
+    rm -f "$fakebin/grep"
     wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' \
       "$state/.wake-queue" 2>/dev/null || echo 0)
     [ "$wakes" -eq 0 ] \


### PR DESCRIPTION
## Intent

Clear the merge conflict that blocks the already-open pull request https://github.com/kunchenguid/firstmate/pull/3605, and do nothing else.

SCOPE, AND WHY IT IS THIS NARROW. A development pause has been deliberately in force in this fleet since 2026-09-09 to stop saturating the upstream maintainer with open requests. It has been lifted for exactly one purpose: clearing merge conflicts on requests that are ALREADY OPEN. No new deliveries. Six of eleven open requests fell into conflict as the trunk advanced; 3605 is one of them. Clearing the conflict is the entire deliverable.

Therefore the following are deliberately NOT in this change and must not be treated as omissions or as incomplete work: any fix noticed in passing, any stale value refreshed while in the file, any tidier neighbouring line, any generalization, consistency sweep or extra hardening. Those were explicitly ruled out by the captain and are to be reported as follow-up work, never folded in here. The change is intentionally minimal by order.

WHAT WAS DONE. An INCOMING MERGE of main (b182d0f9) into the existing published branch fm/fm-absorb-fresh-replacement-wait (head b8e02ef9, merge base 3d2a08b2). A rebase was explicitly ruled out because it rewrites published history; the captain ordered a rebase for one other branch by name, not this one. The result is signed merge commit 67dab27b with parents b8e02ef9 and b182d0f9.

Exactly one file conflicted: bin/fm-watch.sh. tests/fm-watch-triage.test.sh auto-merged; everything else auto-merged.

HOW THE CONFLICT WAS RESOLVED, and why it is a reconciliation rather than a choice between the two sides. Both sides had changed the same absorb-age gate in resurface_absorbed() for orthogonal reasons:
- The branch (this PR's own fix) hoists that age gate OUT of the scope conditional so it always applies, so that a freshly declared REPLACEMENT wait is absorbed while it is still fresh instead of waking the supervisor twice for one event.
- The trunk kept the gate inside the conditional but made its threshold an overridable sixth parameter, min_age (default PAUSE_RESURFACE_SECS, and 0 when a declared 'until' time has just passed, so such a wait re-surfaces at once).
The resolution keeps BOTH: the gate is hoisted (branch intent) AND uses min_age (trunk intent). That is the only combination that preserves each side - hoisting the constant PAUSE_RESURFACE_SECS instead would have silently reverted the trunk's just-passed-'until' behaviour. All four quadrants (scope match/mismatch x min_age 0/default) were checked and behave as each side intended.
The second hunk keeps the branch's load-bearing read order in handle_paused_stale (declaration and last read BEFORE mtime, so a concurrent status append can pair an old declaration only with a fresher age, never the reverse) and therefore drops the trunk's now-duplicate re-reads of the same two variables below mtime, while keeping all of the trunk's new logic: now, min_age, the away-posture early return, and the declared-'until' branch. The locals line is the union of both sides.

VERIFICATION ALREADY RUN LOCALLY on the merge result: syntax check clean, shellcheck -x clean, and the full tests/fm-watch-triage.test.sh suite passes (226 cases, exit 0). That suite is the direct proof of the resolution because both sides' decisive tests coexist in it after the merge: the branch's test_absorbed_replacement_wait_does_not_inherit_the_old_throttle and the trunk's test_paused_until_that_passed_is_rechecked_before_the_cadence. Choosing either side alone would fail one of them.

DELIVERY CONSTRAINTS. Do NOT open a new pull request: 3605 already exists and stays as it is; this validation publishes onto its existing branch. Do NOT merge - merging belongs to the captain and the upstream maintainer, and our access to this repository is pull-only. The pull request's published body ties its validation attestation to the old head and will not match the new head; that is true of every branch being cleared today and is being settled once for all of them, so it is out of scope here.

A document-stage commit that brings a file's description into line with behaviour this delivery already changed is in scope and should stand - that is the delivery keeping its own description true. Anything that changes BEHAVIOUR beyond the conflict resolution is out of scope.

## What Changed

- Apply the absorb-age gate to fresh replacement waits regardless of declaration scope, preserving the `min_age` override for expired `until` times.
- Read the declaration and latest status before file mtime so concurrent appends cannot pair a new declaration with a stale age.
- Extend regression coverage for fresh and aged replacements, including concurrent status appends, and update architecture documentation to reference the recheck timing owners.

## Risk Assessment

⚠️ Medium: The merge preserves both parents’ intended behavior, but their interaction introduces a rare duplicate-notification race suitable for a separately authorized follow-up.

## Testing

The unchanged triage suite and six live tmux scenarios passed after correcting test-driver setup errors. CLI and persisted-state evidence was captured, temporary files removed, and source files left unchanged.

- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Replace an external wait: absorb it while fresh, resurface on its own age, then suppress repeats. | ✅ pass | live | Live watcher transcript: external-replacement |
| Replace a captain-held wait: preserve fresh absorption and independent recheck cadence. | ✅ pass | live | Live watcher transcript: captain-held-replacement |
| Declare or replace an expired wait: recheck immediately, then suppress acknowledged repeats. | ✅ pass | live | Live watcher transcript: expired-deadline-replacement |
| Declare a far-future deadline: remain quiet while fresh without extending the ordinary recheck cadence. | ✅ pass | live | Live watcher transcript: future-deadline-cadence-cap |
| Record away posture: suppress captain-held reminders until the posture is archived. | ✅ pass | live | Live watcher transcript: captain-held-away-boundary |
| Wait across a deadline: the running watcher rechecks when real time reaches it and suppresses repeats. | ✅ pass | live | Live deadline crossing |

<details>
<summary>Evidence: Production behavior excerpts</summary>

Source: [Production behavior excerpts](https://github.com/mremond/firstmate/blob/1db61170e06448dacac7350ae8589be79a1b9c61/.no-mistakes/evidence/fm/fm-absorb-fresh-replacement-wait/live-behavior-excerpts.txt)

```text
Production watcher behavior at 67dab27bdd07cfd3d7b077bb043936872bd1111c

live-watch.log
WATCH OUTPUT signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status
TEST DATA: persisted status mtime aged 500s; production clock unchanged
WATCH OUTPUT stale: phase:wait (paused 501s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)
WATCH OUTPUT signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status
[2026-09-14T12:56:55+0200] absorbed stale (paused, awaiting external, age 4s): phase:wait
[2026-09-14T12:56:58+0200] absorbed stale (paused, awaiting external, age 7s): phase:wait
TEST DATA: persisted status mtime aged 500s; production clock unchanged
WATCH OUTPUT stale: phase:wait (paused 501s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)
[2026-09-14T12:56:55+0200] absorbed stale (paused, awaiting external, age 4s): phase:wait
[2026-09-14T12:56:58+0200] absorbed stale (paused, awaiting external, age 7s): phase:wait
[2026-09-14T12:57:02+0200] absorbed stale (paused, awaiting external, age 503s): phase:wait
[2026-09-14T12:57:03+0200] absorbed stale (paused, awaiting external, age 504s): phase:wait
SCENARIO PASS external-replacement
WATCH OUTPUT signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/captain-held-replacement-verified/state/wait.status
TEST DATA: persisted status mtime aged 500s; production clock unchanged
WATCH OUTPUT stale: phase:wait (captain-held 501s, awaiting the captain - verified hold transfer, rechecked on a long cadence not a wedge; answer the held decision or release the hold)
WATCH OUTPUT signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/captain-held-replacement-verified/state/wait.status
[2026-09-14T12:57:12+0200] absorbed stale (captain-held, awaiting the captain, age 4s): phase:wait
[2026-09-14T12:57:14+0200] absorbed stale (captain-held, awaiting the captain, age 6s): phase:wait
TEST DATA: persisted status mtime aged 500s; production clock unchanged
WATCH OUTPUT stale: phase:wait (captain-held 501s, awaiting the captain - verified hold transfer, rechecked on a long cadence not a wedge; answer the held decision or release the hold)
[2026-09-14T12:57:12+0200] absorbed stale (captain-held, awaiting the captain, age 4s): phase:wait
[2026-09-14T12:57:14+0200] absorbed stale (captain-held, awaiting the captain, age 6s): phase:wait
[2026-09-14T12:57:17+0200] absorbed stale (captain-held, awaiting the captain, age 503s): phase:wait
[2026-09-14T12:57:19+0200] absorbed stale (captain-held, awaiting the captain, age 505s): phase:wait
SCENARIO PASS captain-held-replacement
WATCH OUTPUT signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/expired-deadline-replacement-verified/state/wait.status
WATCH OUTPUT stale: phase:wait (paused 4s, awaiting external - the declared clearing time has passed, rechecked on a long cadence not a wedge; confirm the wait cleared)
[2026-09-14T12:57:28+0200] absorbed stale (paused, declared time reached, age 7s): phase:wait
[2026-09-14T12:57:30+0200] absorbed stale (paused, declared time reached, age 9s): phase:wait
WATCH OUTPUT signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/expired-deadline-replacement-verified/state/wait.status
WATCH OUTPUT stale: phase:wait (paused 3s, awaiting external - the declared clearing time has passed, rechecked on a long cadence not a wedge; confirm the wait cleared)
[2026-09-14T12:57:28+0200] absorbed stale (paused, declared time reached, age 7s): phase:wait
[2026-09-14T12:57:30+0200] absorbed stale (paused, declared time reached, age 9s): phase:wait
[2026-09-14T12:57:38+0200] absorbed stale (paused, declared time reached, age 7s): phase:wait
[2026-09-14T12:57:39+0200] absorbed stale (paused, declared time reached, age 8s): phase:wait
SCENARIO PASS expired-deadline-replacement
WATCH OUTPUT signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/future-deadline-cadence-cap-verified/state/wait.status
[2026-09-14T12:57:45+0200] absorbed stale (paused until 31535996s from now, declared time not reached): phase:wait
[2026-09-14T12:57:48+0200] absorbed stale (paused until 31535993s from now, declared time not reached): phase:wait
TEST DATA: persisted status mtime aged 500s; production clock unchanged
WATCH OUTPUT stale: phase:wait (paused 501s, awaiting external - the declared time is beyond the recheck cadence; confirm the wait still holds)
SCENARIO PASS future-deadline-cadence-cap
WATCH OUTPUT signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/captain-held-away-boundary-verified/state/wait.status
TEST DATA: persisted status mtime aged 500s; production clock unchanged
[2026-09-14T12:57:55+0200] absorbed stale (captain-held, never rechecked while the away-posture record exists): phase:wait
[2026-09-14T12:57:58+0200] absorbed stale (captain-held, never rechecked while the away-posture record exists): phase:wait
WATCH OUTPUT stale: phase:wait (captain-held 506s, awaiting the captain - verified hold transfer, rechecked on a long cadence not a wedge; answer the held decision or release the hold)
SCENARIO PASS captain-held-away-boundary

live-deadline-transition.log
WATCH OUTPUT signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/deadline-crosses-while-watching-verified/state/wait.status
[2026-09-14T12:58:46+0200] absorbed stale (paused until 17s from now, declared time not reached): phase:wait
[2026-09-14T12:58:49+0200] absorbed stale (paused until 14s from now, declared time not reached): phase:wait
DEADLINE TRANSITION: real wall clock crosses 2026-09-14T10:59:03Z with the same watcher running
WATCH OUTPUT stale: phase:wait (paused 20s, awaiting external - the declared clearing time has passed, rechecked on a long cadence not a wedge; confirm the wait cleared)
[2026-09-14T12:58:57+0200] absorbed stale (paused until 6s from now, declared time not reached): phase:wait
[2026-09-14T12:58:58+0200] absorbed stale (paused until 5s from now, declared time not reached): phase:wait
[2026-09-14T12:59:00+0200] absorbed stale (paused until 3s from now, declared time not reached): phase:wait
[2026-09-14T12:59:01+0200] absorbed stale (paused until 2s from now, declared time not reached): phase:wait
[2026-09-14T12:59:05+0200] absorbed stale (paused, declared time reached, age 22s): phase:wait
[2026-09-14T12:59:06+0200] absorbed stale (paused, declared time reached, age 23s): phase:wait
SCENARIO PASS deadline-crosses-while-watching
```
</details>
<details>
<summary>Evidence: Live watcher transcript</summary>

Source: [Live watcher transcript](https://github.com/mremond/firstmate/blob/1db61170e06448dacac7350ae8589be79a1b9c61/.no-mistakes/evidence/fm/fm-absorb-fresh-replacement-wait/live-watch.log)

```text
$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-crew-state.sh wait
state: unknown · source: none · no current-state source available

$ tmux send-keys -t phase:wait -l printf "%s\n" 'paused: waiting for validation one' >> ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status

$ tmux send-keys -t phase:wait Enter

STATUS paused: waiting for validation one
START production bin/fm-watch.sh external-replacement round=1
WATCH OUTPUT signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status
PERSISTED WAKE QUEUE
1789383408	1	signal	wait.status	signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status
1789383408	2	signal	wait.status	signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh
1789383408	2	signal	wait.status	signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status
wake annotation: latest wake-EVENT observed at drain, not current state: wait.status: paused: waiting for validation one
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 2 --recovery-generation 10028.1789383408.87ShmX
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 3s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  After draining queued wakes, repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds 180.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh --ack-through 2 --recovery-generation 10028.1789383408.87ShmX

TEST DATA: persisted status mtime aged 500s; production clock unchanged
$ bash -c . "$1"; fm_wake_status_mark_current "$2" "$3" _ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-lib.sh ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status

START production bin/fm-watch.sh external-replacement round=2
WATCH OUTPUT stale: phase:wait (paused 501s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)
PERSISTED WAKE QUEUE
1789383410	3	stale	phase:wait	stale: phase:wait (paused 501s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh
1789383410	3	stale	phase:wait	stale: phase:wait (paused 501s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 3 --recovery-generation 15766.1789383410.HNNi7y
WARNING: watcher still down (same stale episode; last beat: 2s ago, grace 300s) - full banner already printed this episode.
WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh --ack-through 3 --recovery-generation 15766.1789383410.HNNi7y

$ tmux send-keys -t phase:wait -l printf "%s\n" 'paused: waiting for validation two' >> ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status

$ tmux send-keys -t phase:wait Enter

STATUS paused: waiting for validation one
paused: waiting for validation two
START production bin/fm-watch.sh external-replacement round=3
WATCH OUTPUT signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status
PERSISTED WAKE QUEUE
1789383413	4	signal	wait.status	signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status
1789383413	5	signal	wait.status	signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh
1789383413	5	signal	wait.status	signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status
wake annotation: unread wake-EVENT since last drain, not current state: wait.status: paused: waiting for validation one
wake annotation: latest wake-EVENT observed at drain, not current state: wait.status: paused: waiting for validation two
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 5 --recovery-generation 22286.1789383413.a8jo33
WARNING: watcher still down (same stale episode; last beat: 3s ago, grace 300s) - full banner already printed this episode.
WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh --ack-through 5 --recovery-generation 22286.1789383413.a8jo33

START production bin/fm-watch.sh external-replacement round=4
PRODUCTION TRIAGE (two completed matching observations)
[2026-09-14T12:56:55+0200] absorbed stale (paused, awaiting external, age 4s): phase:wait
[2026-09-14T12:56:58+0200] absorbed stale (paused, awaiting external, age 7s): phase:wait
THROTTLE declared:r1:3335007374726f6e673a31363737373233343a36353039333735303a313738393338323930392e35373934373339373200526567756c61722046696c653a313030363434002d007265616461626c65007265616461626c65
TEST DATA: persisted status mtime aged 500s; production clock unchanged
$ bash -c . "$1"; fm_wake_status_mark_current "$2" "$3" _ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-lib.sh ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/external-replacement-verified/state/wait.status

START production bin/fm-watch.sh external-replacement round=5
WATCH OUTPUT stale: phase:wait (paused 501s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)
PERSISTED WAKE QUEUE
1789383420	6	stale	phase:wait	stale: phase:wait (paused 501s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh
1789383420	6	stale	phase:wait	stale: phase:wait (paused 501s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 6 --recovery-generation 34248.17893834

... [23571 bytes truncated] ...

.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh
1789383470	3	stale	phase:wait	stale: phase:wait (paused 501s, awaiting external - the declared time is beyond the recheck cadence; confirm the wait still holds)
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 3 --recovery-generation 16940.1789383469.5SnO9E
WARNING: watcher still down (same stale episode; last beat: 1s ago, grace 300s) - full banner already printed this episode.
WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh --ack-through 3 --recovery-generation 16940.1789383469.5SnO9E

SCENARIO PASS future-deadline-cadence-cap
$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-crew-state.sh wait
state: unknown · source: none · no current-state source available

$ tmux send-keys -t phase:wait -l printf "%s\n" 'captain-held [key=hold]: awaiting user choice' >> ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/captain-held-away-boundary-verified/state/wait.status

$ tmux send-keys -t phase:wait Enter

STATUS captain-held [key=hold]: awaiting user choice
START production bin/fm-watch.sh captain-held-away-boundary round=1
WATCH OUTPUT signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/captain-held-away-boundary-verified/state/wait.status
PERSISTED WAKE QUEUE
1789383473	1	signal	wait.status	needs-decision: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/captain-held-away-boundary-verified/state/wait.status
1789383473	2	signal	wait.status	needs-decision: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/captain-held-away-boundary-verified/state/wait.status

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh
1789383473	2	signal	wait.status	needs-decision: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/captain-held-away-boundary-verified/state/wait.status
wake annotation: latest wake-EVENT observed at drain, not current state: wait.status: captain-held [key=hold]: awaiting user choice
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 2 --recovery-generation 24582.1789383473.avtMBG
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 3s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  After draining queued wakes, repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds 180.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh --ack-through 2 --recovery-generation 24582.1789383473.avtMBG

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-afk-contract.sh propose
Away posture read-back (proposed, not yet confirmed):
  entered: 2026-09-14T10:57:54Z
  expected return: not given
  spend cap: 4 concurrent workers
  merge when green (task ids): (none)
  reach: hold-for-return only. No phone channel is configured; anything that needs you waits for your return.
  your words: (none)
  accepted clauses:
    (none)
  refused clauses:
    (none)
  everything else waits for your return: no red merge without its named check, no discard without a named object and condition, never credentials, legal, financial, or attended prompts, nothing by analogy, and every clause expires at return.
  hard rule: forbidden, destructive, irreversible, and security-sensitive actions are never pre-authorizable regardless of clause text; no recorded clause is authority by itself.
  recorded clauses are held for the return brief and are not executed by this release.
Say go to confirm; restate any refused clause first if you want it recorded.

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-afk-contract.sh confirm
Away posture confirmed at 2026-09-14T10:57:54Z: hold-for-return only. No phone channel is configured; anything that needs you waits for your return. No mandate clauses recorded. Forbidden, destructive, irreversible, and security-sensitive actions are never pre-authorizable regardless of clause text, and no recorded clause is authority by itself. Expected return: not given. Spend cap: 4 concurrent workers.

TEST DATA: persisted status mtime aged 500s; production clock unchanged
$ bash -c . "$1"; fm_wake_status_mark_current "$2" "$3" _ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-lib.sh ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/captain-held-away-boundary-verified/state ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/captain-held-away-boundary-verified/state/wait.status

START production bin/fm-watch.sh captain-held-away-boundary round=2
PRODUCTION TRIAGE (two completed matching observations)
[2026-09-14T12:57:55+0200] absorbed stale (captain-held, never rechecked while the away-posture record exists): phase:wait
[2026-09-14T12:57:58+0200] absorbed stale (captain-held, never rechecked while the away-posture record exists): phase:wait
THROTTLE 
$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-afk-contract.sh archive
~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/captain-held-away-boundary-verified/state/afk-contracts/1789383474.afk-contract

START production bin/fm-watch.sh captain-held-away-boundary round=3
WATCH OUTPUT stale: phase:wait (captain-held 506s, awaiting the captain - verified hold transfer, rechecked on a long cadence not a wedge; answer the held decision or release the hold)
PERSISTED WAKE QUEUE
1789383480	3	stale	phase:wait	stale: phase:wait (captain-held 506s, awaiting the captain - verified hold transfer, rechecked on a long cadence not a wedge; answer the held decision or release the hold)

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh
1789383480	3	stale	phase:wait	stale: phase:wait (captain-held 506s, awaiting the captain - verified hold transfer, rechecked on a long cadence not a wedge; answer the held decision or release the hold)
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 3 --recovery-generation 32979.1789383479.fH9d56
WARNING: watcher still down (same stale episode; last beat: 1s ago, grace 300s) - full banner already printed this episode.
WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh --ack-through 3 --recovery-generation 32979.1789383479.fH9d56

SCENARIO PASS captain-held-away-boundary
[
  {
    "name": "external-replacement",
    "result": "pass",
    "live": true
  },
  {
    "name": "captain-held-replacement",
    "result": "pass",
    "live": true
  },
  {
    "name": "expired-deadline-replacement",
    "result": "pass",
    "live": true
  },
  {
    "name": "future-deadline-cadence-cap",
    "result": "pass",
    "live": true
  },
  {
    "name": "captain-held-away-boundary",
    "result": "pass",
    "live": true
  }
]
```
</details>
<details>
<summary>Evidence: Live deadline crossing</summary>

Source: [Live deadline crossing](https://github.com/mremond/firstmate/blob/1db61170e06448dacac7350ae8589be79a1b9c61/.no-mistakes/evidence/fm/fm-absorb-fresh-replacement-wait/live-deadline-transition.log)

```text
$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-crew-state.sh wait
state: unknown · source: none · no current-state source available

$ tmux send-keys -t phase:wait -l printf "%s\n" 'paused: waiting for reset, until 2026-09-14T10:59:03Z' >> ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/deadline-crosses-while-watching-verified/state/wait.status

$ tmux send-keys -t phase:wait Enter

STATUS paused: waiting for reset, until 2026-09-14T10:59:03Z
START production bin/fm-watch.sh deadline-crosses-while-watching round=1
WATCH OUTPUT signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/deadline-crosses-while-watching-verified/state/wait.status
PERSISTED WAKE QUEUE
1789383524	1	signal	wait.status	signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/deadline-crosses-while-watching-verified/state/wait.status
1789383524	2	signal	wait.status	signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/deadline-crosses-while-watching-verified/state/wait.status

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh
1789383524	2	signal	wait.status	signal: ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/.phase-test/deadline-crosses-while-watching-verified/state/wait.status
wake annotation: latest wake-EVENT observed at drain, not current state: wait.status: paused: waiting for reset, until 2026-09-14T10:59:03Z
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 2 --recovery-generation 82102.1789383524.qaU9zZ
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 2s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  After draining queued wakes, repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds 180.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh --ack-through 2 --recovery-generation 82102.1789383524.qaU9zZ

START production bin/fm-watch.sh deadline-crosses-while-watching round=2
PRODUCTION TRIAGE (two completed matching observations)
[2026-09-14T12:58:46+0200] absorbed stale (paused until 17s from now, declared time not reached): phase:wait
[2026-09-14T12:58:49+0200] absorbed stale (paused until 14s from now, declared time not reached): phase:wait
THROTTLE 
DEADLINE TRANSITION: real wall clock crosses 2026-09-14T10:59:03Z with the same watcher running
WATCH OUTPUT stale: phase:wait (paused 20s, awaiting external - the declared clearing time has passed, rechecked on a long cadence not a wedge; confirm the wait cleared)
PERSISTED WAKE QUEUE
1789383543	3	stale	phase:wait	stale: phase:wait (paused 20s, awaiting external - the declared clearing time has passed, rechecked on a long cadence not a wedge; confirm the wait cleared)

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh
1789383543	3	stale	phase:wait	stale: phase:wait (paused 20s, awaiting external - the declared clearing time has passed, rechecked on a long cadence not a wedge; confirm the wait cleared)
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 3 --recovery-generation 4487.1789383543.dLQLHY
WARNING: watcher still down (same stale episode; last beat: 1s ago, grace 300s) - full banner already printed this episode.
WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.

$ ~/.no-mistakes/worktrees/acf4a767348a/01M2FR2HYYDP8NP8HDDX4D1MXS/bin/fm-wake-drain.sh --ack-through 3 --recovery-generation 4487.1789383543.dLQLHY

START production bin/fm-watch.sh deadline-crosses-while-watching round=3
PRODUCTION TRIAGE (two completed matching observations)
[2026-09-14T12:58:57+0200] absorbed stale (paused until 6s from now, declared time not reached): phase:wait
[2026-09-14T12:58:58+0200] absorbed stale (paused until 5s from now, declared time not reached): phase:wait
[2026-09-14T12:59:00+0200] absorbed stale (paused until 3s from now, declared time not reached): phase:wait
[2026-09-14T12:59:01+0200] absorbed stale (paused until 2s from now, declared time not reached): phase:wait
[2026-09-14T12:59:05+0200] absorbed stale (paused, declared time reached, age 22s): phase:wait
[2026-09-14T12:59:06+0200] absorbed stale (paused, declared time reached, age 23s): phase:wait
THROTTLE declared:r1:3534007374726f6e673a31363737373233343a36353130303838353a313738393338333532332e30303332313334313500526567756c61722046696c653a313030363434002d007265616461626c65007265616461626c65:due
SCENARIO PASS deadline-crosses-while-watching
[
  {
    "name": "external-replacement",
    "result": "pass",
    "live": true
  },
  {
    "name": "captain-held-replacement",
    "result": "pass",
    "live": true
  },
  {
    "name": "expired-deadline-replacement",
    "result": "pass",
    "live": true
  },
  {
    "name": "future-deadline-cadence-cap",
    "result": "pass",
    "live": true
  },
  {
    "name": "captain-held-away-boundary",
    "result": "pass",
    "live": true
  },
  {
    "name": "deadline-crosses-while-watching",
    "result": "pass",
    "live": true
  }
]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"710425358d8965144af14cba38aa5ab20d0e45e1","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"skipped"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

- ⚠️ `bin/fm-watch.sh` - merge conflict rebasing onto origin/main
</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `bin/fm-watch.sh:1008` - A concurrent deadline replacement can resurface twice. After reading ordinary wait A’s signature here, a replacement B can arrive before last_status_line reads it, with B’s `until` already due. The deadline branch combines B’s line with A’s signature, sets min_age=0, and records A:due. After acknowledgement and rearm, unchanged B produces B:due, bypasses the fresh throttle, and emits another stale notification. Taking mtime last does not protect this zero-age path. A follow-up should revalidate that the signature and deadline line describe the same declaration in handle_paused_stale, while retaining mtime-last ordering. The remedy needs authorization because it exceeds the explicit conflict-only scope; keep it out of this delivery.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Replace an external wait: absorb it while fresh, resurface on its own age, then suppress repeats. | ✅ pass | live | Live watcher transcript: external-replacement |
| Replace a captain-held wait: preserve fresh absorption and independent recheck cadence. | ✅ pass | live | Live watcher transcript: captain-held-replacement |
| Declare or replace an expired wait: recheck immediately, then suppress acknowledged repeats. | ✅ pass | live | Live watcher transcript: expired-deadline-replacement |
| Declare a far-future deadline: remain quiet while fresh without extending the ordinary recheck cadence. | ✅ pass | live | Live watcher transcript: future-deadline-cadence-cap |
| Record away posture: suppress captain-held reminders until the posture is archived. | ✅ pass | live | Live watcher transcript: captain-held-away-boundary |
| Wait across a deadline: the running watcher rechecks when real time reaches it and suppresses repeats. | ✅ pass | live | Live deadline crossing |

- <code>`git diff b182d0f908b78d08c7ccb8dce3775bdca8c5d657..HEAD -- bin/fm-watch.sh tests/fm-watch-triage.test.sh` and merge-parent inspection.</code>
- <code>`TMPDIR=&#34;$PWD/.phase-test/tmp&#34; FM_HOME=&#34;$PWD/.phase-test/home&#34; bin/fm-test-run.sh tests/fm-watch-triage.test.sh` — unchanged suite exited 0.</code>
- <code>`python3 ~/.no-mistakes/evidence/01M2FR2HYYDP8NP8HDDX4D1MXS/live-watch.py` — real isolated tmux, production watcher, wake drain, acknowledgements, and away-record commands; corrected driver setup and reran successfully.</code>
- <code>`FM_LIVE_SELECT=deadline-crosses-while-watching python3 ~/.no-mistakes/evidence/01M2FR2HYYDP8NP8HDDX4D1MXS/live-watch.py` — natural deadline crossing.</code>
- <code>Captured production CLI output and persisted state; stopped isolated tmux, removed `.phase-test`, and verified clean Git status.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
