### PR TITLE
feat(merge-local): refuse local-only landing without current slug context record

### DIFF
--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -90,19 +90,78 @@ slug_for_repo() {
   esac
 }
 
+project_code_diff() {
+  git -C "$PROJ" diff --name-only "$DEFAULT...$BRANCH" -- \
+    . \
+    ':(exclude)README*' \
+    ':(exclude)**/README*' \
+    ':(exclude)docs/**' \
+    ':(exclude)**/docs/**'
+}
+
+detail_frontmatter_has_key() {
+  local detail_file=$1 key=$2
+  awk -v key="$key" '
+    NR >= 2 && NR <= 5 && $0 ~ ("^" key ":[[:space:]]+") { found=1 }
+    END { exit(found ? 0 : 1) }
+  ' "$detail_file"
+}
+
+detail_record_is_current() {
+  local detail_file=$1
+  [ -f "$detail_file" ] || return 1
+  awk '
+    BEGIN {
+      valid = 1
+      double_quote = sprintf("%c", 34)
+      single_quote = sprintf("%c", 39)
+    }
+    function field_is_valid(line, key, value, prefix) {
+      prefix = "^" key ":[[:space:]]+"
+      if (line !~ prefix) return 0
+      value = line
+      sub(prefix, "", value)
+      return value != "" && value != double_quote double_quote && value != single_quote single_quote
+    }
+    NR == 1 { if ($0 != "---") valid=0; next }
+    NR == 2 { if (!field_is_valid($0, "milestone")) valid=0; next }
+    NR == 3 { if (!field_is_valid($0, "focus")) valid=0; next }
+    NR == 4 { if (!field_is_valid($0, "blocker")) valid=0; next }
+    NR == 5 { if (!field_is_valid($0, "next_move")) valid=0; next }
+    NR == 6 { if ($0 != "---") valid=0; next }
+    NR == 7 {
+      if ($0 ~ /^(milestone|focus|blocker|next_move):([[:space:]]|$)/ ||
+          ($0 !~ /(^|[[:space:]])(https?|file):\/\/[^[:space:]]+/ &&
+          $0 !~ /(^|[[:space:]])(~\/|\/|\.\/|\.\.\/)[^[:space:]]+/ &&
+          $0 !~ /(^|[[:space:]])[^[:space:]]+\/[^[:space:]]+/ &&
+          $0 !~ /(^|[[:space:]])[^[:space:]]+\.(md|mdx|rst|txt|json|ya?ml|toml|ini|cfg|conf|ts|tsx|js|jsx|mjs|cjs|py|sh|go|rs|java|rb|php|c|h)([[:space:]]|$)/ &&
+          $0 !~ /\]\([^[:space:]]+\)/)) valid=0
+      next
+    }
+    { valid=0 }
+    END { if (NR != 7) valid=0; exit(valid ? 0 : 1) }
+  ' "$detail_file"
+}
+
 DETAIL_DIR="${FM_DETAIL_DIR_OVERRIDE:-$FM_HOME/data/projects}"
 repo=${PROJ##*/}
 if slug=$(slug_for_repo "$repo"); then
-  touched=$(git -C "$PROJ" diff --name-only "$DEFAULT...$BRANCH" -- || true)
+  if ! touched=$(project_code_diff); then
+    echo "error: cannot inspect the project diff for $BRANCH in $PROJ; refusing to merge." >&2
+    exit 1
+  fi
   if [ -n "$touched" ]; then
     detail="$DETAIL_DIR/$slug.md"
     missing=""
     [ -f "$detail" ] || missing="missing file"
-    for key in milestone focus blocker next_move; do
-      if [ -f "$detail" ] && ! grep -q "^$key:" "$detail"; then
-        missing="${missing:+$missing, }missing frontmatter key '$key'"
-      fi
-    done
+    if [ -f "$detail" ] && ! detail_record_is_current "$detail"; then
+      missing="invalid frontmatter/detail record"
+      for key in milestone focus blocker next_move; do
+        if ! detail_frontmatter_has_key "$detail" "$key"; then
+          missing="${missing:+$missing, }missing frontmatter key '$key'"
+        fi
+      done
+    fi
     if [ -n "$missing" ]; then
       echo "REFUSED: $BRANCH touches project code under projects/$repo without a current detail record." >&2
       echo "Update $detail ($missing), then retry." >&2

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -13,9 +13,14 @@
 #
 # Context-contract gate (landing-only): when the branch carries project-code
 # changes for a KNOWN slug (explicit repo->slug map below), the slug's detail
-# record must exist in the home's data/projects/ dir with its 4-key YAML
-# frontmatter (milestone/focus/blocker/next_move); otherwise the landing is
-# REFUSED. The record lives in FM_HOME, outside the project repo, so it can
+# record must exist in the home's data/projects/ dir as exactly 7 lines: YAML
+# frontmatter with the 4 keys (milestone/focus/blocker/next_move) as plain
+# scalars, then one body line carrying an authoritative source pointer - a
+# URL (http/https/file) or a path token that resolves to an existing file
+# (relative candidates are checked under the record dir, FM_HOME, and the
+# project repo); otherwise the landing is REFUSED. Non-code assets (README,
+# docs, LICENSE, metadata dotfiles, lockfiles, images) do not count as
+# project-code touches. The record lives in FM_HOME, outside the project repo, so it can
 # never appear in the branch diff itself: the worker refreshes that record
 # before landing and this gate verifies its presence here. Repos outside the
 # map warn and proceed. Teardown/cleanup paths are never gated by this script:
@@ -96,7 +101,30 @@ project_code_diff() {
     ':(exclude)README*' \
     ':(exclude)**/README*' \
     ':(exclude)docs/**' \
-    ':(exclude)**/docs/**'
+    ':(exclude)**/docs/**' \
+    ':(exclude)LICENSE*' \
+    ':(exclude)CONTRIBUTING*' \
+    ':(exclude)CODE_OF_CONDUCT*' \
+    ':(exclude)SECURITY*' \
+    ':(exclude)CODEOWNERS' \
+    ':(exclude).gitignore' \
+    ':(exclude).gitattributes' \
+    ':(exclude).editorconfig' \
+    ':(exclude).gitkeep' \
+    ':(exclude)*.lock' \
+    ':(exclude)*.lockb' \
+    ':(exclude)package-lock.json' \
+    ':(exclude)pnpm-lock.yaml' \
+    ':(exclude)go.sum' \
+    ':(exclude)*.png' \
+    ':(exclude)*.jpg' \
+    ':(exclude)*.jpeg' \
+    ':(exclude)*.gif' \
+    ':(exclude)*.svg' \
+    ':(exclude)*.ico' \
+    ':(exclude)*.webp' \
+    ':(exclude)*.avif' \
+    ':(exclude)*.bmp'
 }
 
 detail_frontmatter_has_key() {
@@ -113,15 +141,25 @@ detail_record_is_current() {
   awk '
     BEGIN {
       valid = 1
+      body_ok = 0
       double_quote = sprintf("%c", 34)
       single_quote = sprintf("%c", 39)
+      non_plain_leaders = "[{>|&*!%@`,]"
     }
-    function field_is_valid(line, key, value, prefix) {
+    function field_is_valid(line, key, value, prefix, c) {
       prefix = "^" key ":[[:space:]]+"
       if (line !~ prefix) return 0
       value = line
       sub(prefix, "", value)
-      return value != "" && value != double_quote double_quote && value != single_quote single_quote
+      if (value == "") return 0
+      if (value == double_quote double_quote || value == single_quote single_quote) return 0
+      c = substr(value, 1, 1)
+      if (c == double_quote || c == single_quote) {
+        return length(value) >= 2 && substr(value, length(value), 1) == c
+      }
+      if (c == "#") return 0
+      if (index(non_plain_leaders, c)) return 0
+      return 1
     }
     NR == 1 { if ($0 != "---") valid=0; next }
     NR == 2 { if (!field_is_valid($0, "milestone")) valid=0; next }
@@ -130,17 +168,53 @@ detail_record_is_current() {
     NR == 5 { if (!field_is_valid($0, "next_move")) valid=0; next }
     NR == 6 { if ($0 != "---") valid=0; next }
     NR == 7 {
-      if ($0 ~ /^(milestone|focus|blocker|next_move):([[:space:]]|$)/ ||
-          ($0 !~ /(^|[[:space:]])(https?|file):\/\/[^[:space:]]+/ &&
-          $0 !~ /(^|[[:space:]])(~\/|\/|\.\/|\.\.\/)[^[:space:]]+/ &&
-          $0 !~ /(^|[[:space:]])[^[:space:]]+\/[^[:space:]]+/ &&
-          $0 !~ /(^|[[:space:]])[^[:space:]]+\.(md|mdx|rst|txt|json|ya?ml|toml|ini|cfg|conf|ts|tsx|js|jsx|mjs|cjs|py|sh|go|rs|java|rb|php|c|h)([[:space:]]|$)/ &&
-          $0 !~ /\]\([^[:space:]]+\)/)) valid=0
+      if ($0 != "" && $0 !~ /^(milestone|focus|blocker|next_move):([[:space:]]|$)/) body_ok=1
+      else valid=0
       next
     }
     { valid=0 }
-    END { if (NR != 7) valid=0; exit(valid ? 0 : 1) }
-  ' "$detail_file"
+    END { if (NR != 7 || !body_ok) valid=0; exit(valid ? 0 : 1) }
+  ' "$detail_file" || return 1
+  detail_body_has_source "$detail_file"
+}
+
+# The body line must carry an authoritative source pointer: a URL (http,
+# https, or file), or a path token that resolves to an existing file -
+# relative candidates are checked under the detail dir, FM_HOME, and the
+# project repo, so a slash-bearing token alone is not accepted.
+detail_body_has_source() {
+  local detail_file=$1 body candidates token found=1 had_glob_off=0
+  body=$(awk 'NR==7{print; exit}' "$detail_file")
+  if printf '%s\n' "$body" | grep -Eq '(^|[[:space:]])(https?|file)://[^[:space:]]+'; then
+    return 0
+  fi
+  candidates=$(printf '%s\n' "$body" | awk -v sq="'" -v dq='"' '
+    BEGIN {
+      junk_lead = "<([{" dq "`" sq
+      junk_trail = ".,;:!?)]>" dq "`" sq
+    }
+    {
+      n = split($0, tok, /[[:space:]]+/)
+      for (i = 1; i <= n; i++) {
+        t = tok[i]
+        if (match(t, /\]\([^)]+\)/)) t = substr(t, RSTART + 2, RLENGTH - 3)
+        while (length(t) > 0 && index(junk_lead, substr(t, 1, 1))) t = substr(t, 2)
+        while (length(t) > 0 && index(junk_trail, substr(t, length(t), 1))) t = substr(t, 1, length(t) - 1)
+        if (length(t) > 0) print t
+      }
+    }
+  ')
+  case $- in *f*) ;; *) had_glob_off=1; set -f ;; esac
+  while IFS= read -r token; do
+    [ -n "$token" ] || continue
+    case $token in "~"/*) token="$HOME${token#~}" ;; esac
+    if [ -e "$token" ] || [ -e "$DETAIL_DIR/$token" ] || [ -e "$FM_HOME/$token" ] || [ -e "$PROJ/$token" ]; then
+      found=0
+      break
+    fi
+  done <<< "$candidates"
+  if [ "$had_glob_off" -eq 1 ]; then set +f; fi
+  return "$found"
 }
 
 DETAIL_DIR="${FM_DETAIL_DIR_OVERRIDE:-$FM_HOME/data/projects}"

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -18,7 +18,9 @@
 # scalars, then one body line carrying an authoritative source pointer - a
 # URL (http/https/file) or a path token that resolves to an existing file
 # (relative candidates are checked under the record dir, FM_HOME, and the
-# project repo); otherwise the landing is REFUSED. Non-code assets (README,
+# project repo). http/https URLs are accepted on shape; file URLs must
+# resolve to an existing file like path tokens do; otherwise the landing
+# is REFUSED. Non-code assets (README,
 # docs, LICENSE, metadata dotfiles, lockfiles, images) do not count as
 # project-code touches. The record lives in FM_HOME, outside the project repo, so it can
 # never appear in the branch diff itself: the worker refreshes that record
@@ -178,14 +180,15 @@ detail_record_is_current() {
   detail_body_has_source "$detail_file"
 }
 
-# The body line must carry an authoritative source pointer: a URL (http,
-# https, or file), or a path token that resolves to an existing file -
-# relative candidates are checked under the detail dir, FM_HOME, and the
-# project repo, so a slash-bearing token alone is not accepted.
+# The body line must carry an authoritative source pointer: an http/https
+# URL (accepted on shape), or a file URL or path token that resolves to an
+# existing file - relative path candidates are checked under the detail
+# dir, FM_HOME, and the project repo, so a slash-bearing token alone is
+# not accepted.
 detail_body_has_source() {
   local detail_file=$1 body candidates token found=1 had_glob_off=0
   body=$(awk 'NR==7{print; exit}' "$detail_file")
-  if printf '%s\n' "$body" | grep -Eq '(^|[[:space:]])(https?|file)://[^[:space:]]+'; then
+  if printf '%s\n' "$body" | grep -Eq '(^|[[:space:]])https?://[^[:space:]]+'; then
     return 0
   fi
   candidates=$(printf '%s\n' "$body" | awk -v sq="'" -v dq='"' '
@@ -207,7 +210,17 @@ detail_body_has_source() {
   case $- in *f*) ;; *) had_glob_off=1; set -f ;; esac
   while IFS= read -r token; do
     [ -n "$token" ] || continue
-    case $token in "~"/*) token="$HOME${token#~}" ;; esac
+    case $token in
+      "~"/*) token="$HOME${token#~}" ;;
+      file://*)
+        token=${token#file://}
+        case $token in
+          /*) ;;
+          */*) token=/${token#*/} ;;
+          *) continue ;;
+        esac
+        ;;
+    esac
     if [ -e "$token" ] || [ -e "$DETAIL_DIR/$token" ] || [ -e "$FM_HOME/$token" ] || [ -e "$PROJ/$token" ]; then
       found=0
       break

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -10,6 +10,18 @@
 # and tells you to have the crewmate rebase. See AGENTS.md prime directives,
 # project management, and task lifecycle.
 # Usage: fm-merge-local.sh <task-id>
+#
+# Context-contract gate (landing-only): when the branch carries project-code
+# changes for a KNOWN slug (explicit repo->slug map below), the slug's detail
+# record must exist in the home's data/projects/ dir with its 4-key YAML
+# frontmatter (milestone/focus/blocker/next_move); otherwise the landing is
+# REFUSED. The record lives in FM_HOME, outside the project repo, so it can
+# never appear in the branch diff itself: the worker refreshes that record
+# before landing and this gate verifies its presence here. Repos outside the
+# map warn and proceed. Teardown/cleanup paths are never gated by this script:
+# it only lands, it never cleans up.
+# Detail-dir override for tests: FM_DETAIL_DIR_OVERRIDE (default
+# "$FM_HOME/data/projects").
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -66,6 +78,39 @@ if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$BRANCH"; then
   echo "REFUSED: $BRANCH is not a fast-forward of $DEFAULT (it has diverged)." >&2
   echo "Have the crewmate rebase $BRANCH onto $DEFAULT, then retry." >&2
   exit 1
+fi
+
+# Context-contract gate: repo basename -> known slug. Unknown repos warn only.
+slug_for_repo() {
+  case "$1" in
+    lia) printf 'lia-core' ;;
+    lia-mascot) printf 'lia-mascot' ;;
+    kg-hpmor) printf 'kg-hpmor' ;;
+    *) return 1 ;;
+  esac
+}
+
+DETAIL_DIR="${FM_DETAIL_DIR_OVERRIDE:-$FM_HOME/data/projects}"
+repo=${PROJ##*/}
+if slug=$(slug_for_repo "$repo"); then
+  touched=$(git -C "$PROJ" diff --name-only "$DEFAULT...$BRANCH" -- || true)
+  if [ -n "$touched" ]; then
+    detail="$DETAIL_DIR/$slug.md"
+    missing=""
+    [ -f "$detail" ] || missing="missing file"
+    for key in milestone focus blocker next_move; do
+      if [ -f "$detail" ] && ! grep -q "^$key:" "$detail"; then
+        missing="${missing:+$missing, }missing frontmatter key '$key'"
+      fi
+    done
+    if [ -n "$missing" ]; then
+      echo "REFUSED: $BRANCH touches project code under projects/$repo without a current detail record." >&2
+      echo "Update $detail ($missing), then retry." >&2
+      exit 1
+    fi
+  fi
+else
+  echo "warning: projects/$repo has no known slug; skipping the context-contract check." >&2
 fi
 
 before=$(git -C "$PROJ" rev-parse --short "$DEFAULT")

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -65,7 +65,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `backends/cmux.sh`       | Experimental cmux session-provider adapter                                           |
 | `fm-config-push.sh`      | Push declared inherited local material to live local or remote secondmates and send the placement-specific config reread when changed |
 | `fm-project-mode.sh`     | Resolve a project's registered delivery posture from `data/projects.md` for fleet sync and home seeding |
-| `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
+| `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval, refusing a project-code landing without a current slug context record |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-task-inbox-lib.sh`   | Single owner of durable steering-inbox records, acknowledgement, doorbells, and the delivery-attempt ladder |

--- a/tests/fm-merge-local-context-gate.test.sh
+++ b/tests/fm-merge-local-context-gate.test.sh
@@ -11,6 +11,7 @@
 #   (c) code change with a complete frontmatter record lands (exit 0, merged)
 #   (d) code change in an unknown repo warns and lands (warn-only, exit 0)
 #   (e) a branch with no code changes lands without needing any record
+#   (f) a failed diff probe refuses before the landing
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -100,7 +101,7 @@ test_refuses_when_frontmatter_incomplete() {
 test_lands_when_record_current() {
   local case_dir rc
   case_dir=$(make_case record-current lia-mascot)
-  printf '%s\n' '---' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'body' \
+  printf '%s\n' '---' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'Source: code.txt' \
     > "$case_dir/home/data/projects/lia-mascot.md"
 
   set +e
@@ -129,6 +130,125 @@ test_unknown_repo_warns_and_lands() {
   [ "$(git -C "$case_dir/something-else" rev-parse main)" = "$(git -C "$case_dir/something-else" rev-parse fm/task-x1)" ] \
     || fail "unknown-repo: main was not fast-forwarded to the branch"
   pass "fm-merge-local warns once and lands for an unknown repo"
+}
+
+test_docs_only_diff_needs_no_record() {
+  local case_dir rc repo
+  case_dir="$TMP_ROOT/docs-only"
+  mkdir -p "$case_dir/state" "$case_dir/home/data/projects"
+  repo="$case_dir/lia-mascot"
+  git init -q -b main "$repo"
+  mkdir -p "$repo/docs"
+  printf '# project\n' > "$repo/README.md"
+  printf 'base docs\n' > "$repo/docs/guide.md"
+  git -C "$repo" add README.md docs/guide.md
+  git -C "$repo" commit -qm base
+  git -C "$repo" checkout -qb fm/task-x1
+  printf 'updated docs\n' >> "$repo/docs/guide.md"
+  git -C "$repo" commit -qam docs
+  git -C "$repo" checkout -q main
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=fm-task-x1" \
+    "worktree=$case_dir/wt" \
+    "project=$repo" \
+    "kind=ship" \
+    "mode=local-only"
+
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "docs-only: documentation changes should not require a detail record"
+  [ "$(git -C "$repo" rev-parse main)" = "$(git -C "$repo" rev-parse fm/task-x1)" ] \
+    || fail "docs-only: main was not fast-forwarded to the branch"
+  pass "fm-merge-local ignores README/docs-only changes for the context gate"
+}
+
+test_refuses_malformed_record_shapes() {
+  local shape case_dir rc
+  for shape in missing-delimiters extra-key duplicate-key empty-value key-in-body extra-body; do
+    case_dir=$(make_case "malformed-$shape" lia-mascot)
+    case "$shape" in
+      missing-delimiters)
+        printf '%s\n' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'Source: code.txt' \
+          > "$case_dir/home/data/projects/lia-mascot.md" ;;
+      extra-key)
+        printf '%s\n' '---' 'milestone: m1' 'extra: nope' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'Source: code.txt' \
+          > "$case_dir/home/data/projects/lia-mascot.md" ;;
+      duplicate-key)
+        printf '%s\n' '---' 'milestone: m1' 'milestone: m2' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'Source: code.txt' \
+          > "$case_dir/home/data/projects/lia-mascot.md" ;;
+      empty-value)
+        printf '%s\n' '---' 'milestone:' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'Source: code.txt' \
+          > "$case_dir/home/data/projects/lia-mascot.md" ;;
+      key-in-body)
+        printf '%s\n' '---' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'blocker: stale at code.txt' \
+          > "$case_dir/home/data/projects/lia-mascot.md" ;;
+      extra-body)
+        printf '%s\n' '---' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'Source: code.txt' 'extra' \
+          > "$case_dir/home/data/projects/lia-mascot.md" ;;
+    esac
+
+    set +e
+    run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+    rc=$?
+    set -e
+
+    expect_code 1 "$rc" "malformed-$shape: malformed detail record should be refused"
+    assert_grep 'invalid frontmatter/detail record' "$case_dir/stderr" \
+      "malformed-$shape: refusal did not identify the invalid record"
+  done
+  pass "fm-merge-local refuses non-strict detail record shapes"
+}
+
+test_refuses_when_body_is_not_source_pointer() {
+  local case_dir rc
+  case_dir=$(make_case body-not-source lia-mascot)
+  printf '%s\n' '---' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'body' \
+    > "$case_dir/home/data/projects/lia-mascot.md"
+
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "body-not-source: a body without a source pointer should be refused"
+  assert_grep 'invalid frontmatter/detail record' "$case_dir/stderr" \
+    "body-not-source: refusal did not identify the invalid record"
+  pass "fm-merge-local rejects a body without an authoritative source pointer"
+}
+
+test_refuses_when_diff_probe_fails() {
+  local case_dir rc real_git fake_bin
+  case_dir=$(make_case diff-probe-failure lia-mascot)
+  real_git=$(command -v git)
+  fake_bin="$case_dir/fake-bin"
+  mkdir -p "$fake_bin"
+  cat > "$fake_bin/git" <<EOF
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  if [ "\$arg" = diff ]; then
+    for diff_arg in "\$@"; do
+      [ "\$diff_arg" = --name-only ] && exit 73
+    done
+  fi
+done
+exec "$real_git" "\$@"
+EOF
+  chmod +x "$fake_bin/git"
+
+  set +e
+  PATH="$fake_bin:$PATH" run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "diff-probe-failure: a diff inspection failure should refuse the landing"
+  assert_grep 'cannot inspect the project diff' "$case_dir/stderr" \
+    "diff-probe-failure: refusal did not report the failed diff probe"
+  [ "$(git -C "$case_dir/lia-mascot" rev-parse main)" != "$(git -C "$case_dir/lia-mascot" rev-parse fm/task-x1)" ] \
+    || fail "diff-probe-failure: refused landing still moved main"
+  pass "fm-merge-local propagates project diff probe failures"
 }
 
 test_empty_diff_needs_no_record() {
@@ -162,4 +282,8 @@ test_refuses_when_record_missing
 test_refuses_when_frontmatter_incomplete
 test_lands_when_record_current
 test_unknown_repo_warns_and_lands
+test_docs_only_diff_needs_no_record
+test_refuses_malformed_record_shapes
+test_refuses_when_body_is_not_source_pointer
+test_refuses_when_diff_probe_fails
 test_empty_diff_needs_no_record

--- a/tests/fm-merge-local-context-gate.test.sh
+++ b/tests/fm-merge-local-context-gate.test.sh
@@ -12,6 +12,11 @@
 #   (d) code change in an unknown repo warns and lands (warn-only, exit 0)
 #   (e) a branch with no code changes lands without needing any record
 #   (f) a failed diff probe refuses before the landing
+#   (g) non-code-only changes (LICENSE, lockfile, image, metadata) land
+#       without needing any record
+#   (h) comment-valued or non-plain-scalar frontmatter values are REFUSED
+#   (i) the body pointer must be a URL or an existing path; a slash-bearing
+#       token that resolves nowhere is REFUSED, while a URL body lands
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -60,6 +65,107 @@ run_merge_local() {
   FM_HOME="$case_dir/home" \
   FM_STATE_OVERRIDE="$case_dir/state" \
     "$MERGE_LOCAL" task-x1
+}
+
+test_lands_when_body_is_url() {
+  local case_dir rc
+  case_dir=$(make_case body-url lia-mascot)
+  printf '%s\n' '---' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'Source: https://example.com/evidence.md' \
+    > "$case_dir/home/data/projects/lia-mascot.md"
+
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "body-url: a body with a URL source pointer should be accepted"
+  pass "fm-merge-local accepts a URL body pointer"
+}
+
+test_refuses_when_body_token_resolves_nowhere() {
+  local case_dir rc
+  case_dir=$(make_case body-fake-slash-token lia-mascot)
+  printf '%s\n' '---' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'Source: fm/task-x1/notes' \
+    > "$case_dir/home/data/projects/lia-mascot.md"
+
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "body-fake-slash-token: a slash token that resolves nowhere should be refused"
+  assert_grep 'invalid frontmatter/detail record' "$case_dir/stderr" \
+    "body-fake-slash-token: refusal did not identify the invalid record"
+  pass "fm-merge-local refuses a slash token that resolves to no existing file"
+}
+
+test_lands_when_body_path_exists_in_repo() {
+  local case_dir rc repo
+  case_dir="$TMP_ROOT/body-existing-path"
+  mkdir -p "$case_dir/state" "$case_dir/home/data/projects"
+  repo="$case_dir/lia-mascot"
+  git init -q -b main "$repo"
+  mkdir -p "$repo/evidence"
+  printf 'base\n' > "$repo/code.txt"
+  printf 'notes\n' > "$repo/evidence/notes.md"
+  git -C "$repo" add -A
+  git -C "$repo" commit -qm base
+  git -C "$repo" checkout -qb fm/task-x1
+  printf 'change\n' >> "$repo/code.txt"
+  git -C "$repo" commit -qam change
+  git -C "$repo" checkout -q main
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=fm-task-x1" \
+    "worktree=$case_dir/wt" \
+    "project=$repo" \
+    "kind=ship" \
+    "mode=local-only"
+  printf '%s\n' '---' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'Source: evidence/notes.md' \
+    > "$case_dir/home/data/projects/lia-mascot.md"
+
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "body-existing-path: a body pointing at an existing repo file should be accepted"
+  pass "fm-merge-local accepts a body pointer that resolves to an existing file"
+}
+
+test_non_code_only_diff_needs_no_record() {
+  local case_dir rc repo
+  case_dir="$TMP_ROOT/non-code-only"
+  mkdir -p "$case_dir/state" "$case_dir/home/data/projects"
+  repo="$case_dir/lia-mascot"
+  git init -q -b main "$repo"
+  printf 'base\n' > "$repo/code.txt"
+  printf 'MIT\n' > "$repo/LICENSE"
+  printf 'lock\n' > "$repo/package-lock.json"
+  printf 'logs/\n' > "$repo/.gitignore"
+  git -C "$repo" add -A
+  git -C "$repo" commit -qm base
+  git -C "$repo" checkout -qb fm/task-x1
+  printf 'year\n' > "$repo/LICENSE"
+  printf 'lock2\n' > "$repo/package-lock.json"
+  printf 'dist/\n' > "$repo/.gitignore"
+  git -C "$repo" commit -qam metadata
+  git -C "$repo" checkout -q main
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=fm-task-x1" \
+    "worktree=$case_dir/wt" \
+    "project=$repo" \
+    "kind=ship" \
+    "mode=local-only"
+
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "non-code-only: LICENSE/lockfile/metadata-only changes should not require a detail record"
+  [ "$(git -C "$repo" rev-parse main)" = "$(git -C "$repo" rev-parse fm/task-x1)" ] \
+    || fail "non-code-only: main was not fast-forwarded to the branch"
+  pass "fm-merge-local lands non-code-only changes without demanding a record"
 }
 
 test_refuses_when_record_missing() {
@@ -185,6 +291,12 @@ test_refuses_malformed_record_shapes() {
       key-in-body)
         printf '%s\n' '---' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'blocker: stale at code.txt' \
           > "$case_dir/home/data/projects/lia-mascot.md" ;;
+      comment-value)
+        printf '%s\n' '---' 'milestone: # unknown' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'Source: code.txt' \
+          > "$case_dir/home/data/projects/lia-mascot.md" ;;
+      flow-value)
+        printf '%s\n' '---' 'milestone: m1' 'focus: [' 'blocker: none' 'next_move: ship' '---' 'Source: code.txt' \
+          > "$case_dir/home/data/projects/lia-mascot.md" ;;
       extra-body)
         printf '%s\n' '---' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'Source: code.txt' 'extra' \
           > "$case_dir/home/data/projects/lia-mascot.md" ;;
@@ -285,5 +397,9 @@ test_unknown_repo_warns_and_lands
 test_docs_only_diff_needs_no_record
 test_refuses_malformed_record_shapes
 test_refuses_when_body_is_not_source_pointer
+test_lands_when_body_is_url
+test_refuses_when_body_token_resolves_nowhere
+test_lands_when_body_path_exists_in_repo
+test_non_code_only_diff_needs_no_record
 test_refuses_when_diff_probe_fails
 test_empty_diff_needs_no_record

--- a/tests/fm-merge-local-context-gate.test.sh
+++ b/tests/fm-merge-local-context-gate.test.sh
@@ -17,6 +17,8 @@
 #   (h) comment-valued or non-plain-scalar frontmatter values are REFUSED
 #   (i) the body pointer must be a URL or an existing path; a slash-bearing
 #       token that resolves nowhere is REFUSED, while a URL body lands
+#   (j) a file:// URL must resolve to an existing file like a path token;
+#       a file:// URL that resolves nowhere is REFUSED
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -80,6 +82,41 @@ test_lands_when_body_is_url() {
 
   expect_code 0 "$rc" "body-url: a body with a URL source pointer should be accepted"
   pass "fm-merge-local accepts a URL body pointer"
+}
+
+test_refuses_when_file_url_resolves_nowhere() {
+  local case_dir rc
+  case_dir=$(make_case body-fake-file-url lia-mascot)
+  printf '%s\n' '---' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' "Source: file://$case_dir/home/data/projects/no-such-evidence.md" \
+    > "$case_dir/home/data/projects/lia-mascot.md"
+
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "body-fake-file-url: a file:// URL that resolves nowhere should be refused"
+  assert_grep 'invalid frontmatter/detail record' "$case_dir/stderr" \
+    "body-fake-file-url: refusal did not identify the invalid record"
+  pass "fm-merge-local refuses a file:// URL that resolves to no existing file"
+}
+
+test_lands_when_file_url_exists() {
+  local case_dir rc
+  case_dir=$(make_case body-file-url lia-mascot)
+  printf 'notes\n' > "$case_dir/home/data/projects/evidence.md"
+  printf '%s\n' '---' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' "Source: file://$case_dir/home/data/projects/evidence.md" \
+    > "$case_dir/home/data/projects/lia-mascot.md"
+
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "body-file-url: a file:// URL pointing at an existing file should be accepted"
+  [ "$(git -C "$case_dir/lia-mascot" rev-parse main)" = "$(git -C "$case_dir/lia-mascot" rev-parse fm/task-x1)" ] \
+    || fail "body-file-url: main was not fast-forwarded to the branch"
+  pass "fm-merge-local accepts a file:// URL that resolves to an existing file"
 }
 
 test_refuses_when_body_token_resolves_nowhere() {
@@ -398,6 +435,8 @@ test_docs_only_diff_needs_no_record
 test_refuses_malformed_record_shapes
 test_refuses_when_body_is_not_source_pointer
 test_lands_when_body_is_url
+test_refuses_when_file_url_resolves_nowhere
+test_lands_when_file_url_exists
 test_refuses_when_body_token_resolves_nowhere
 test_lands_when_body_path_exists_in_repo
 test_non_code_only_diff_needs_no_record

--- a/tests/fm-merge-local-context-gate.test.sh
+++ b/tests/fm-merge-local-context-gate.test.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Tests for the context-contract gate in bin/fm-merge-local.sh: a local-only
+# landing whose branch carries project-code changes for a KNOWN slug (explicit
+# repo->slug map: lia=>lia-core, lia-mascot=>lia-mascot, kg-hpmor=>kg-hpmor)
+# must have that slug's detail record with its 4-key frontmatter
+# (milestone/focus/blocker/next_move) in the home's data/projects/ dir.
+#
+# Matrix (each case drives the real script against a fixture project repo):
+#   (a) code change with no detail record at all is REFUSED, naming the file
+#   (b) code change with a detail record missing frontmatter keys is REFUSED
+#   (c) code change with a complete frontmatter record lands (exit 0, merged)
+#   (d) code change in an unknown repo warns and lands (warn-only, exit 0)
+#   (e) a branch with no code changes lands without needing any record
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+MERGE_LOCAL="$ROOT/bin/fm-merge-local.sh"
+TMP_ROOT=$(fm_test_tmproot fm-merge-local-ctx-tests)
+
+# make_repo <case-dir> <repo-name>: fixture project repo with a base commit on
+# main and a fm/task-x1 branch carrying one code change. Leaves the checkout
+# on main and clean, the way the merge gate expects. Echoes the repo path.
+make_repo() {
+  local case_dir=$1 name=$2 repo
+  repo="$case_dir/$name"
+  git init -q -b main "$repo"
+  printf 'base\n' > "$repo/code.txt"
+  git -C "$repo" add code.txt
+  git -C "$repo" commit -qm base
+  git -C "$repo" checkout -qb fm/task-x1
+  printf 'change\n' >> "$repo/code.txt"
+  git -C "$repo" commit -qam change
+  git -C "$repo" checkout -q main
+  printf '%s\n' "$repo"
+}
+
+# make_case <name> <repo-name>: state dir with a local-only task meta pointing
+# at the fixture repo, plus an empty home detail dir. Echoes the case dir.
+make_case() {
+  local name=$1 repo_name=$2 case_dir repo
+  case_dir="$TMP_ROOT/$name"
+  mkdir -p "$case_dir/state" "$case_dir/home/data/projects"
+  repo=$(make_repo "$case_dir" "$repo_name")
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=fm-task-x1" \
+    "worktree=$case_dir/wt" \
+    "project=$repo" \
+    "kind=ship" \
+    "mode=local-only"
+  printf '%s\n' "$case_dir"
+}
+
+run_merge_local() {
+  local case_dir=$1
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_HOME="$case_dir/home" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+    "$MERGE_LOCAL" task-x1
+}
+
+test_refuses_when_record_missing() {
+  local case_dir rc
+  case_dir=$(make_case record-missing lia-mascot)
+
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "record-missing: landing without a detail record should be refused"
+  assert_grep 'REFUSED' "$case_dir/stderr" "record-missing: refusal did not say REFUSED"
+  assert_grep "$case_dir/home/data/projects/lia-mascot.md" "$case_dir/stderr" \
+    "record-missing: refusal did not name the missing detail file"
+  [ "$(git -C "$case_dir/lia-mascot" rev-parse main)" != "$(git -C "$case_dir/lia-mascot" rev-parse fm/task-x1)" ] \
+    || fail "record-missing: refused landing still moved main"
+  pass "fm-merge-local refuses code-without-record and names the detail file"
+}
+
+test_refuses_when_frontmatter_incomplete() {
+  local case_dir rc
+  case_dir=$(make_case frontmatter-incomplete lia-mascot)
+  printf '%s\n' '---' 'milestone: m1' 'focus: things' '---' 'body' > "$case_dir/home/data/projects/lia-mascot.md"
+
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "frontmatter-incomplete: landing with a stale record should be refused"
+  assert_grep 'lia-mascot.md' "$case_dir/stderr" \
+    "frontmatter-incomplete: refusal did not name the detail file"
+  assert_grep "blocker" "$case_dir/stderr" \
+    "frontmatter-incomplete: refusal did not name the missing frontmatter key"
+  pass "fm-merge-local refuses code-without-frontmatter and names the missing key"
+}
+
+test_lands_when_record_current() {
+  local case_dir rc
+  case_dir=$(make_case record-current lia-mascot)
+  printf '%s\n' '---' 'milestone: m1' 'focus: things' 'blocker: none' 'next_move: ship' '---' 'body' \
+    > "$case_dir/home/data/projects/lia-mascot.md"
+
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "record-current: landing with a current record should succeed"
+  [ "$(git -C "$case_dir/lia-mascot" rev-parse main)" = "$(git -C "$case_dir/lia-mascot" rev-parse fm/task-x1)" ] \
+    || fail "record-current: main was not fast-forwarded to the branch"
+  pass "fm-merge-local lands code-with-frontmatter"
+}
+
+test_unknown_repo_warns_and_lands() {
+  local case_dir rc
+  case_dir=$(make_case unknown-repo something-else)
+
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "unknown-repo: landing for an unmapped repo should succeed"
+  assert_grep 'warning' "$case_dir/stderr" "unknown-repo: warn-only path printed no warning"
+  assert_grep 'something-else' "$case_dir/stderr" "unknown-repo: warning did not name the repo"
+  [ "$(git -C "$case_dir/something-else" rev-parse main)" = "$(git -C "$case_dir/something-else" rev-parse fm/task-x1)" ] \
+    || fail "unknown-repo: main was not fast-forwarded to the branch"
+  pass "fm-merge-local warns once and lands for an unknown repo"
+}
+
+test_empty_diff_needs_no_record() {
+  local case_dir rc repo
+  case_dir="$TMP_ROOT/empty-diff"
+  mkdir -p "$case_dir/state" "$case_dir/home/data/projects"
+  repo="$case_dir/lia-mascot"
+  git init -q -b main "$repo"
+  printf 'base\n' > "$repo/code.txt"
+  git -C "$repo" add code.txt
+  git -C "$repo" commit -qm base
+  git -C "$repo" checkout -qb fm/task-x1
+  git -C "$repo" checkout -q main
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=fm-task-x1" \
+    "worktree=$case_dir/wt" \
+    "project=$repo" \
+    "kind=ship" \
+    "mode=local-only"
+
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "empty-diff: a branch with no changes should land without a record"
+  pass "fm-merge-local lands an empty branch diff without demanding a record"
+}
+
+test_refuses_when_record_missing
+test_refuses_when_frontmatter_incomplete
+test_lands_when_record_current
+test_unknown_repo_warns_and_lands
+test_empty_diff_needs_no_record


### PR DESCRIPTION
Gate local-only landings in bin/fm-merge-local.sh: a branch diff touching project code for a known slug (lia maps to lia-core, plus lia-mascot and kg-hpmor) without that slug's current detail record (4-key frontmatter in the home data/projects dir) is refused; unknown repos warn and proceed; teardown paths untouched. Adds tests/fm-merge-local-context-gate.test.sh covering refuse on code-without-frontmatter, pass on code-with-frontmatter, and warn-only on unknown repo.