### PR TITLE
fix(bin): keep a merge poll armed after a task record is written to

### DIFF
--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -508,7 +508,9 @@ fm_backlog_record_publish() {
 # backlog transitions above require. Keys and values are refused rather than
 # escaped: a key outside `[A-Za-z0-9._-]`, or a value carrying a line break,
 # would write a line the record's readers cannot attribute to the key it was
-# set under.
+# set under. The same key passed twice in one call is refused for the same
+# reason: the caller has stated no single value for it, and writing both would
+# reintroduce the duplicate line this helper exists to remove.
 #
 # Usage: fm_meta_set <meta> <state-root> <key> <value> [<key> <value>...]
 fm_meta_set() {
@@ -535,6 +537,12 @@ fm_meta_set() {
         return 1
         ;;
     esac
+    for ((i = 0; i < ${#mkeys[@]}; i++)); do
+      if [ "${mkeys[$i]}" = "$mkey" ]; then
+        FM_BACKLOG_TRANSITION_ERROR="task record key is set twice in one update: $mkey"
+        return 1
+      fi
+    done
     mkeys+=("$mkey")
     mvalues+=("$mvalue")
   done

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -512,7 +512,7 @@ fm_backlog_record_publish() {
 #
 # Usage: fm_meta_set <meta> <state-root> <key> <value> [<key> <value>...]
 fm_meta_set() {
-  local meta=$1 root=$2 tmp line mkey mvalue drop i rc=0
+  local meta=$1 root=$2 tmp dir base line mkey mvalue drop i rc=0
   local -a mkeys=() mvalues=()
   shift 2
   if [ "$#" -eq 0 ] || [ $(( $# % 2 )) -ne 0 ]; then
@@ -539,7 +539,13 @@ fm_meta_set() {
     mvalues+=("$mvalue")
   done
   fm_backlog_record_present "$meta" "task record" "$root" || return 1
-  tmp=$(mktemp "${meta%/*}/.$(basename "$meta").set.XXXXXX" 2>/dev/null) || {
+  # Staged beside the record so the publication below is a same-directory
+  # rename, and named by parameter expansion rather than basename because this
+  # library runs under the curated PATH the lifecycle scripts pin.
+  dir=${meta%/*}
+  base=${meta##*/}
+  [ "$dir" != "$meta" ] || dir=.
+  tmp=$(mktemp "$dir/.$base.set.XXXXXX" 2>/dev/null) || {
     FM_BACKLOG_TRANSITION_ERROR="task record update could not be staged beside $meta"
     return 1
   }

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -492,6 +492,84 @@ fm_backlog_record_publish() {
   return 0
 }
 
+# fm_meta_set: set one or more `key=value` lines in a task record, replacing
+# every prior line for those keys and preserving every other line, then publish
+# the result through the atomic path above. The write counterpart to
+# bin/fm-backend.sh's fm_meta_get, and it lives here because publishing a task
+# record safely is what this library owns.
+#
+# Reach for this rather than appending to a record with `>>`. A bare append is
+# not atomic even under the record's lock, so an interrupted write leaves a
+# truncated key line behind, and it grows the record without bound each time the
+# same key is set again, leaving every reader to disambiguate the duplicates
+# with `tail -1`.
+#
+# The caller must already hold the record's meta lock, exactly as the paired
+# backlog transitions above require. Keys and values are refused rather than
+# escaped: a key outside `[A-Za-z0-9._-]`, or a value carrying a line break,
+# would write a line the record's readers cannot attribute to the key it was
+# set under.
+#
+# Usage: fm_meta_set <meta> <state-root> <key> <value> [<key> <value>...]
+fm_meta_set() {
+  local meta=$1 root=$2 tmp line mkey mvalue drop i rc=0
+  local -a mkeys=() mvalues=()
+  shift 2
+  if [ "$#" -eq 0 ] || [ $(( $# % 2 )) -ne 0 ]; then
+    FM_BACKLOG_TRANSITION_ERROR="task record update needs whole key/value pairs"
+    return 1
+  fi
+  while [ "$#" -gt 0 ]; do
+    mkey=$1
+    mvalue=$2
+    shift 2
+    case "$mkey" in
+      ''|*[!A-Za-z0-9._-]*)
+        FM_BACKLOG_TRANSITION_ERROR="task record key is not a bare identifier: $mkey"
+        return 1
+        ;;
+    esac
+    case "$mvalue" in
+      *$'\n'*|*$'\r'*)
+        FM_BACKLOG_TRANSITION_ERROR="task record value for $mkey carries a line break"
+        return 1
+        ;;
+    esac
+    mkeys+=("$mkey")
+    mvalues+=("$mvalue")
+  done
+  fm_backlog_record_present "$meta" "task record" "$root" || return 1
+  tmp=$(mktemp "${meta%/*}/.$(basename "$meta").set.XXXXXX" 2>/dev/null) || {
+    FM_BACKLOG_TRANSITION_ERROR="task record update could not be staged beside $meta"
+    return 1
+  }
+  chmod 0600 "$tmp" 2>/dev/null || rc=1
+  if [ "$rc" -eq 0 ]; then
+    {
+      while IFS= read -r line || [ -n "$line" ]; do
+        drop=0
+        for mkey in "${mkeys[@]}"; do
+          case "$line" in "$mkey="*) drop=1; break ;; esac
+        done
+        [ "$drop" -eq 1 ] || printf '%s\n' "$line"
+      done < "$meta"
+      for ((i = 0; i < ${#mkeys[@]}; i++)); do
+        printf '%s=%s\n' "${mkeys[$i]}" "${mvalues[$i]}"
+      done
+    } > "$tmp" || rc=1
+  fi
+  if [ "$rc" -ne 0 ]; then
+    rm -f -- "$tmp"
+    FM_BACKLOG_TRANSITION_ERROR="task record update could not be written for $meta"
+    return 1
+  fi
+  if ! fm_backlog_record_publish "$tmp" "$meta" "task record" "$root"; then
+    rm -f -- "$tmp"
+    return 1
+  fi
+  return 0
+}
+
 fm_backlog_meta_spawn_gen() {
   local meta=$1 state=$2 count value
   FM_BACKLOG_META_SPAWN_GEN=

--- a/bin/fm-captain-hold.sh
+++ b/bin/fm-captain-hold.sh
@@ -913,7 +913,8 @@ EOF
 
   if [ "$has_meta" = 1 ]; then
     if [ "$(meta_value "$meta" decisions_reviewed)" != 1 ] || [ "$previous" != "$keys" ]; then
-      printf 'decisions_reviewed=1\ndecision_keys=%s\n' "$keys" >> "$meta"
+      fm_meta_set "$meta" "$STATE" decisions_reviewed 1 decision_keys "$keys" \
+        || fail "cannot record the completed captain-call inventory: $FM_BACKLOG_TRANSITION_ERROR"
     fi
     fm_lock_release "$CAPTAIN_META_LOCK"
     CAPTAIN_META_LOCK_HELD=0

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -104,6 +104,19 @@ META_LOCK_HELD=1
 META_DEVICE=$(fm_pr_file_device "$META") || exit 1
 STATE_DEVICE=$(fm_pr_file_device "$STATE") || exit 1
 [ "$META_DEVICE" = "$STATE_DEVICE" ] || { echo "error: task metadata is unavailable" >&2; exit 1; }
+# This script is the only writer of pr= and pr_head=, so it owns the guarantee
+# that neither value can smuggle a second key into the task record through an
+# embedded line break. fm_pr_url_parse and fm_pr_head_valid already refuse such
+# a value, and this restates the consequence at the point of the write rather
+# than leaving it implicit in two regular expressions: the identity reader
+# (bin/fm-pr-lib.sh) binds itself to these two keys wherever they sit and no
+# longer treats an unexpected trailing line as evidence of tampering.
+case "$URL$PR_HEAD" in
+  *$'\n'*|*$'\r'*)
+    echo "error: invalid PR check request" >&2
+    exit 1
+    ;;
+esac
 META_TMP=$(mktemp "$STATE/.fm-pr-meta.XXXXXX") || exit 1
 while IFS= read -r line || [ -n "$line" ]; do
   case "$line" in

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -285,8 +285,27 @@ fm_pr_regular_destination_on_device_or_absent() {
   [ ! -e "$path" ] || [ "$(fm_pr_file_device "$path")" = "$device" ]
 }
 
+# A task record's PR identity is the `pr=`/`pr_head=` pair alone, read wherever
+# those lines sit in the file. This function is the one owner of that rule.
+#
+# Position carries no meaning here, and binding the identity to it was a bug:
+# a task record has many writers, several of which legitimately rewrite or add
+# their own unrelated keys at the end of the record, and treating an unknown
+# trailing key as tampering silently disarmed a live merge poll the first time
+# one of them ran after the poll was armed. Ordering is not something a reader
+# can require of a shared record without every future writer knowing the rule.
+#
+# What the identity actually depends on is checked instead, from either side of
+# `pr=`: exactly one `pr=` that parses to a canonical URL, and at most one
+# `pr_head=`, always validated. Validating a head wherever it appears is
+# stronger than the positional rule it replaces, which skipped a `pr_head=`
+# written before `pr=` while every consumer reads that value with `tail -1`;
+# refusing a second `pr_head=` removes the same ambiguity for two valid but
+# differing heads. Newline injection through either value, which a positional
+# rule caught only by accident, is refused where those values are written
+# (bin/fm-pr-check.sh), the only path that records them.
 fm_pr_metadata_identity_parse() {
-  local file=$1 line value pr_count=0 seen_pr=0 post_pr_invalid=0
+  local file=$1 line value pr_count=0 head_count=0 head_invalid=0
   FM_PR_META_PROVIDER=
   FM_PR_META_URL=
   FM_PR_META_HOST=
@@ -307,23 +326,17 @@ fm_pr_metadata_identity_parse() {
           FM_PR_META_PATH=$FM_PR_PATH
           FM_PR_META_NUMBER=$FM_PR_NUMBER
         fi
-        seen_pr=1
         ;;
       pr_head=*)
-        if [ "$seen_pr" -eq 1 ]; then
-          value=${line#pr_head=}
-          fm_pr_head_valid "$value" || post_pr_invalid=1
-        fi
-        ;;
-      x_request=*|x_request_ts=*|x_followups=*|x_platform=*|x_reply_max_chars=*)
-        ;;
-      *)
-        [ "$seen_pr" -eq 0 ] || post_pr_invalid=1
+        head_count=$((head_count + 1))
+        value=${line#pr_head=}
+        fm_pr_head_valid "$value" || head_invalid=1
         ;;
     esac
   done < "$file"
   [ "$pr_count" -eq 1 ] || return 1
-  [ "$post_pr_invalid" -eq 0 ] || return 1
+  [ "$head_count" -le 1 ] || return 1
+  [ "$head_invalid" -eq 0 ] || return 1
   [ -n "$FM_PR_META_URL" ]
 }
 

--- a/docs/captain-hold-lifecycle.md
+++ b/docs/captain-hold-lifecycle.md
@@ -19,7 +19,7 @@ An exact retry is idempotent only when the requested close mode matches the newe
 On a task closed outside the script, `answer` records the missing block only when the captain-hold annotations tasks-axi preserves through a close prove the captain owned it, and it verifies the task stays closed.
 A hold whose `--until` date has passed keeps those annotations while tasks-axi reports it no longer held, so an expired deferral remains answerable.
 
-The `complete` subcommand unions the reviewed captain-held task ids into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
+The `complete` subcommand unions the reviewed captain-held task ids into `decision_keys=` and records `decisions_reviewed=1` while originating task metadata is live, setting both keys in place through the shared task-record writer in `bin/fm-backlog-transition-lib.sh` rather than appending them.
 A post-teardown visual review can complete against the surviving report and durable tasks without recreating volatile task metadata.
 It accepts `--none` as an explicit semantic inventory result, refused while the origin still has a lifecycle-open keyed status decision, and verifies every listed task against tasks-axi before recording completion.
 With a non-empty inventory it appends a `captain-held [key=<key>]: tracked by <inventory>` transfer event for every still-open keyed status decision, which `bin/fm-classify-lib.sh` recognizes as closing the live status copy without claiming that the captain has answered it.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -98,7 +98,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation and config-reread delivery |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
-| `fm-backlog-transition-lib.sh` | Pair task-record changes with their backlog transitions and replay interrupted closes |
+| `fm-backlog-transition-lib.sh` | Pair task-record changes with their backlog transitions, own the shared writer that sets a key in a task record, and replay interrupted closes |
 | `fm-quota-axi-lib.sh`    | Shared `quota-axi` compatibility floor and quota snapshot schema validation           |
 | `fm-quota-choose.sh`     | Choose the first candidate with known positive quota from an ordered harness:model list |
 | `fm-vendor-auth-probe.sh`| Run one hard-bounded, non-destructive authentication probe of a named vendor CLI and report the fact |

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -2404,6 +2404,12 @@ test_meta_set_replaces_keys_and_refuses_unattributable_lines() {
       || { echo "a value carrying a line break was accepted" >&2; exit 1; }
     ! fm_meta_set "$meta" "$state" note "$(printf 'one\rtwo')" \
       || { echo "a value carrying a carriage return was accepted" >&2; exit 1; }
+    ! fm_meta_set "$meta" "$state" decision_keys a decision_keys b \
+      || { echo "the same key twice in one update was accepted" >&2; exit 1; }
+    case "$FM_BACKLOG_TRANSITION_ERROR" in
+      *decision_keys*) ;;
+      *) echo "the repeated key refusal did not name the key" >&2; exit 1 ;;
+    esac
     [ "$(shasum -a 256 "$meta" | awk '{print $1}')" = "$before" ] \
       || { echo "a refused update changed the record" >&2; exit 1; }
     [ "$(find "$state" -name '.task-a.meta.set.*' | wc -l)" -eq 0 ] \

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -2355,7 +2355,72 @@ test_recovery_ignores_a_symlinked_worker_record
 test_recovery_replays_a_close_an_interrupted_cleanup_left_open
 test_recovery_backfills_a_recorded_link_on_an_already_done_item
 test_recovery_preserves_a_close_when_the_backlog_cannot_be_read
+# fm_meta_set is the library's answer to the bare `>>` that used to write keys
+# into a task record: it replaces every prior line for the keys it sets,
+# preserves the rest, publishes through the same atomic path a record change
+# already uses, and refuses a key or value that would write a line the record's
+# readers cannot attribute back to the key it was set under.
+test_meta_set_replaces_keys_and_refuses_unattributable_lines() {
+  local case_dir state meta rc
+  case_dir="$TMP_ROOT/meta-set"
+  state="$case_dir/state"
+  meta="$state/task-a.meta"
+  mkdir -p "$state"
+  (
+    # shellcheck source=/dev/null
+    . "$ROOT/bin/fm-tasks-axi-lib.sh"
+    # shellcheck source=/dev/null
+    . "$ROOT/bin/fm-backlog-transition-lib.sh"
+
+    fm_write_meta "$meta" 'window=fm-task-a' 'kind=ship' 'pr=https://github.com/o/r/pull/1'
+
+    fm_meta_set "$meta" "$state" decisions_reviewed 1 decision_keys some-call \
+      || { echo "setting two keys failed: $FM_BACKLOG_TRANSITION_ERROR" >&2; exit 1; }
+    grep -qxF 'window=fm-task-a' "$meta" || { echo "an unrelated key was dropped" >&2; exit 1; }
+    grep -qxF 'pr=https://github.com/o/r/pull/1' "$meta" || { echo "the PR line was dropped" >&2; exit 1; }
+    grep -qxF 'decisions_reviewed=1' "$meta" || { echo "the key was not set" >&2; exit 1; }
+    grep -qxF 'decision_keys=some-call' "$meta" || { echo "the second key was not set" >&2; exit 1; }
+
+    # Setting the same key again replaces its line rather than growing the record.
+    fm_meta_set "$meta" "$state" decision_keys other-call \
+      || { echo "resetting a key failed: $FM_BACKLOG_TRANSITION_ERROR" >&2; exit 1; }
+    [ "$(grep -c '^decision_keys=' "$meta")" = 1 ] \
+      || { echo "resetting a key duplicated its line" >&2; exit 1; }
+    grep -qxF 'decision_keys=other-call' "$meta" || { echo "the reset value did not land" >&2; exit 1; }
+    [ "$(grep -c '^decisions_reviewed=' "$meta")" = 1 ] \
+      || { echo "an untouched key was disturbed" >&2; exit 1; }
+
+    # An empty value is a legitimate setting, not an omission.
+    fm_meta_set "$meta" "$state" decision_keys '' \
+      || { echo "setting an empty value failed: $FM_BACKLOG_TRANSITION_ERROR" >&2; exit 1; }
+    grep -qxF 'decision_keys=' "$meta" || { echo "an empty value did not land" >&2; exit 1; }
+
+    # The record must be unchanged after each refusal.
+    before=$(shasum -a 256 "$meta" | awk '{print $1}')
+    ! fm_meta_set "$meta" "$state" decision_keys || { echo "an odd argument list was accepted" >&2; exit 1; }
+    ! fm_meta_set "$meta" "$state" 'bad key' value || { echo "a key with a space was accepted" >&2; exit 1; }
+    ! fm_meta_set "$meta" "$state" 'a=b' value || { echo "a key containing = was accepted" >&2; exit 1; }
+    ! fm_meta_set "$meta" "$state" note "$(printf 'one\ntwo=three')" \
+      || { echo "a value carrying a line break was accepted" >&2; exit 1; }
+    ! fm_meta_set "$meta" "$state" note "$(printf 'one\rtwo')" \
+      || { echo "a value carrying a carriage return was accepted" >&2; exit 1; }
+    [ "$(shasum -a 256 "$meta" | awk '{print $1}')" = "$before" ] \
+      || { echo "a refused update changed the record" >&2; exit 1; }
+    [ "$(find "$state" -name '.task-a.meta.set.*' | wc -l)" -eq 0 ] \
+      || { echo "a refused update left a staged record behind" >&2; exit 1; }
+
+    # An absent record is refused rather than created.
+    ! fm_meta_set "$state/absent.meta" "$state" kind ship \
+      || { echo "an absent record was written" >&2; exit 1; }
+    [ ! -e "$state/absent.meta" ] || { echo "an absent record was created" >&2; exit 1; }
+  )
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "the shared task-record writer did not hold its contract"
+  pass "the shared task-record writer replaces keys in place and refuses unattributable lines"
+}
+
 test_recovery_retry_preserves_incomplete_cleanup_warning
+test_meta_set_replaces_keys_and_refuses_unattributable_lines
 test_recovery_finishes_a_close_for_the_same_meta_incarnation
 test_recovery_preserves_a_close_for_ambiguous_incarnation_metadata
 test_recovery_preserves_both_records_when_meta_removal_fails

--- a/tests/fm-captain-hold-lifecycle.test.sh
+++ b/tests/fm-captain-hold-lifecycle.test.sh
@@ -8,6 +8,10 @@ set -u
 # shellcheck source=tests/lib.sh
 # shellcheck disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# The merge-poll identity predicates the watcher itself calls, so the
+# attestation's effect on a live poll is asserted through the real reader.
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-pr-lib.sh"
 
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 BEARINGS="$ROOT/bin/fm-bearings-snapshot.sh"
@@ -1523,8 +1527,86 @@ SH
   pass "cleanup refuses a ship row when its captain hold cannot be read"
 }
 
+# The two steps AGENTS.md section 7 requires of every no-mistakes ship task -
+# arm the merge poll when the PR opens, then attest the captain-call inventory -
+# must compose in either order and leave the merge poll working.
+#
+# They did not. The attestation wrote its two keys into the task record after
+# the PR line the poll had already recorded, and the poll's identity reader
+# treated any unexpected line in that trailing region as tampering. The armed,
+# legitimate poll was then refused as an unauthenticated check for the rest of
+# the task's life: the merge was never detected, and the operator got a
+# security-shaped notice naming the wrong problem instead of the merged PR.
+#
+# The watcher assertion is the whole point. The leaf predicate can be pinned
+# cheaply, but only the real watcher proves the merge still reaches the operator.
+test_completion_attestation_keeps_the_merge_poll_armed() {
+  local home id state fake_root fakebin rc
+  home=$(make_home poll-survives-attestation)
+  id=sample-shipped-work
+  state="$home/state"
+  fake_root="$home/fake-root"
+  fakebin="$home/fakebin"
+  mkdir -p "$fake_root/bin" "$home/wt"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$fake_root/bin/fm-guard.sh"
+  chmod +x "$fake_root/bin/fm-guard.sh"
+  # The forge stub answers the two fields this lifecycle reads: the head commit
+  # the arming step records, and the merge state the poll observes.
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" headRefOid "*) printf '%s\n' '0123456789abcdef0123456789abcdef01234567' ;;
+  *" state "*) printf '%s\n' "${FM_TEST_GH_STATE:-OPEN}" ;;
+esac
+SH
+  chmod +x "$fakebin/gh"
+
+  mkdir -p "$home/data/$id"
+  tasks_in "$home" add "$id" "Ship sample work" --kind ship --repo sample --start >/dev/null \
+    || fail "could not create the ship backlog fixture"
+  fm_write_meta "$state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "worktree=$home/wt" \
+    "project=$home/projects/sample" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "spawn_gen=fixture-$id"
+  printf 'working: implementation committed\n' > "$state/$id.status"
+
+  PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$fake_root" FM_HOME="$home" \
+    "$ROOT/bin/fm-pr-check.sh" "$id" https://github.com/o/r/pull/7 > "$home/arm.out" 2> "$home/arm.err" \
+    || fail "could not arm the merge poll: $(cat "$home/arm.err")"
+  fm_pr_poll_snapshot_capture "$state" "$id" "$ROOT/bin/fm-pr-poll.sh" \
+    || fail "the freshly armed merge poll did not authenticate"
+
+  run_captain "$home" complete "$id" --none > "$home/complete.out" 2> "$home/complete.err" \
+    || fail "completion attestation failed: $(cat "$home/complete.err")"
+  assert_grep "decisions_reviewed=1" "$state/$id.meta" "completion attestation missing"
+  assert_grep "pr=https://github.com/o/r/pull/7" "$state/$id.meta" \
+    "attestation dropped the recorded PR"
+
+  # The exact call bin/fm-watch.sh makes to decide whether a check is authentic.
+  fm_pr_poll_snapshot_capture "$state" "$id" "$ROOT/bin/fm-pr-poll.sh" \
+    || fail "the captain-call attestation disarmed the armed merge poll"
+
+  set +e
+  perl -e 'my $pid=fork; die unless defined $pid; if (!$pid) { exec @ARGV } local $SIG{ALRM}=sub { kill "TERM", $pid; waitpid $pid, 0; exit 124 }; alarm 20; waitpid $pid, 0; alarm 0; exit($? >> 8)' \
+    env FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_CHECK_INTERVAL=0 FM_CHECK_TIMEOUT=5 \
+      FM_POLL=0.02 FM_HEARTBEAT=999999 FM_SIGNAL_GRACE=0 FM_TEST_GH_STATE=MERGED \
+      PATH="$fakebin:$PATH" "$ROOT/bin/fm-watch.sh" > "$home/watch.out" 2> "$home/watch.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "the supervision cycle did not complete: $(cat "$home/watch.err")"
+  assert_no_grep "rejected unauthenticated state checks" "$home/watch.out" \
+    "the armed merge poll was reported as an unauthenticated check"
+  assert_grep "$state/$id.check.sh: merged" "$home/watch.out" \
+    "the merge was never reported: $(cat "$home/watch.out")"
+  pass "arming a merge poll and attesting the captain-call inventory compose without losing the merge"
+}
+
 test_uninventoried_report_decision_refuses_completion
 test_completion_gate_attests_and_transfers
+test_completion_attestation_keeps_the_merge_poll_armed
 test_answer_records_and_closes
 test_release_frees_held_work
 test_deferral_leaves_captains_call_until_due

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -2246,7 +2246,6 @@ test_recorded_pr_values_refuse_embedded_line_breaks() {
   local dir before
   dir=$(make_case pr-value-line-breaks)
   write_task_meta "$dir"
-  before=$(shasum -a 256 "$dir/home/state/task-a.meta" | awk '{print $1}')
   FM_TEST_GH_HEAD=$'0123456789abcdef0123456789abcdef01234567\nwindow=unexpected' \
     run_check_entry "$dir" task-a https://github.com/o/r/pull/2 >/dev/null 2>/dev/null \
     || fail "a valid check with a malformed remote head failed"
@@ -2254,13 +2253,16 @@ test_recorded_pr_values_refuse_embedded_line_breaks() {
     "a newline in the forge head injected a second record key"
   assert_no_grep 'pr_head=' "$dir/home/state/task-a.meta" \
     "a multiline head reached the record"
+  before=$(shasum -a 256 "$dir/home/state/task-a.meta" | awk '{print $1}')
+  [ -n "$before" ] || fail "could not fingerprint the record"
   if run_check_entry "$dir" task-a $'https://github.com/o/r/pull/3\nwindow=unexpected' \
     >/dev/null 2>/dev/null; then
     fail "a PR URL carrying a line break was accepted"
   fi
   assert_no_grep 'window=unexpected' "$dir/home/state/task-a.meta" \
     "a newline in the PR URL injected a second record key"
-  [ -n "$before" ] || fail "could not fingerprint the record"
+  [ "$(shasum -a 256 "$dir/home/state/task-a.meta" | awk '{print $1}')" = "$before" ] \
+    || fail "a refused PR URL altered the record"
   pass "recorded PR values refuse an embedded line break at the writer"
 }
 

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -2121,7 +2121,153 @@ test_gitlab_merged_poll_retires() {
   pass "GitHub and GitLab exact merged results share one retirement path"
 }
 
+# The task record's PR identity binds to the pr=/pr_head= pair, not to where
+# those lines sit. The reader used to treat any unrecognised line after `pr=` as
+# tampering, which is not a property a shared record can hold: several
+# legitimate writers rewrite or add their own keys at the end of a record, and
+# the first one to run after a poll was armed silently disarmed it.
+#
+# Position-independence is a relaxation in one direction and a tightening in
+# two: a head written before `pr=` used to escape validation entirely while
+# every consumer reads it back with `tail -1`, and two valid but differing heads
+# used to be accepted with no way to say which one the record meant.
+test_pr_identity_binds_to_the_pr_pair_not_line_order() {
+  local dir state meta
+
+  dir=$(make_case identity-line-order)
+  state="$dir/home/state"
+  meta="$state/task-a.meta"
+
+  # Accepted: unrelated keys after the PR pair. This is the shape the ordinary
+  # lifecycle produces, and the shape live records were repaired into by hand.
+  fm_write_meta "$meta" \
+    'window=fm-task-a' \
+    'pr=https://github.com/o/r/pull/1' \
+    'pr_head=0123456789abcdef0123456789abcdef01234567' \
+    'decisions_reviewed=1' \
+    'decision_keys=some-call'
+  fm_pr_metadata_identity_parse "$meta" \
+    || fail "a record with unrelated keys after the PR pair was refused"
+  [ "$FM_PR_META_URL" = https://github.com/o/r/pull/1 ] \
+    || fail "trailing keys changed the parsed PR identity"
+
+  # Accepted: the same keys before the PR pair, which must read identically.
+  fm_write_meta "$meta" \
+    'window=fm-task-a' \
+    'decisions_reviewed=1' \
+    'decision_keys=some-call' \
+    'pr=https://github.com/o/r/pull/1' \
+    'pr_head=0123456789abcdef0123456789abcdef01234567'
+  fm_pr_metadata_identity_parse "$meta" \
+    || fail "a record with unrelated keys before the PR pair was refused"
+  [ "$FM_PR_META_URL" = https://github.com/o/r/pull/1 ] \
+    || fail "leading keys changed the parsed PR identity"
+
+  # Accepted: a valid head recorded before its URL.
+  fm_write_meta "$meta" \
+    'pr_head=0123456789abcdef0123456789abcdef01234567' \
+    'pr=https://github.com/o/r/pull/1'
+  fm_pr_metadata_identity_parse "$meta" || fail "a valid head before its URL was refused"
+
+  # Refused: a malformed head, whichever side of the URL it sits on. Consumers
+  # read the head with `tail -1` from either side, so validating only one side
+  # left the other reachable and unchecked.
+  fm_write_meta "$meta" \
+    'pr=https://github.com/o/r/pull/1' \
+    'pr_head=not-a-commit'
+  ! fm_pr_metadata_identity_parse "$meta" || fail "a malformed head after the URL was accepted"
+  fm_write_meta "$meta" \
+    'pr_head=not-a-commit' \
+    'pr=https://github.com/o/r/pull/1'
+  ! fm_pr_metadata_identity_parse "$meta" || fail "a malformed head before the URL was accepted"
+
+  # Refused: two heads, even when both are well formed, because the record then
+  # states no single head.
+  fm_write_meta "$meta" \
+    'pr=https://github.com/o/r/pull/1' \
+    'pr_head=0123456789abcdef0123456789abcdef01234567' \
+    'pr_head=89abcdef0123456789abcdef0123456789abcdef'
+  ! fm_pr_metadata_identity_parse "$meta" || fail "two recorded heads were accepted"
+
+  # Refused, unchanged: two URLs, no URL, and an unparseable URL.
+  fm_write_meta "$meta" \
+    'pr=https://github.com/o/r/pull/1' \
+    'pr=https://github.com/o/r/pull/2'
+  ! fm_pr_metadata_identity_parse "$meta" || fail "two recorded PRs were accepted"
+  fm_write_meta "$meta" 'window=fm-task-a'
+  ! fm_pr_metadata_identity_parse "$meta" || fail "a record with no PR was accepted"
+  fm_write_meta "$meta" 'pr=https://github.com/o/r/issues/1'
+  ! fm_pr_metadata_identity_parse "$meta" || fail "an unparseable PR URL was accepted"
+
+  pass "PR identity binds to the pr=/pr_head= pair from either side and refuses an ambiguous head"
+}
+
+# The whole chain, through the real arming script and the real watcher: the
+# record's trailing region belongs to whoever writes there, and an armed poll
+# survives a later writer. A poll refused here is refused as an unauthenticated
+# state check, which reports a security problem the record does not have and
+# loses the merge the poll was armed to catch.
+test_armed_poll_survives_a_later_record_writer() {
+  local dir state rc
+  dir=$(make_case poll-survives-later-writer)
+  state="$dir/home/state"
+  write_task_meta "$dir"
+  run_check_entry "$dir" task-a https://github.com/o/r/pull/1 >/dev/null 2>/dev/null \
+    || fail "could not arm the merge poll"
+  fm_pr_poll_snapshot_capture "$state" task-a "$POLL" \
+    || fail "the freshly armed poll did not authenticate"
+
+  # Exactly what bin/fm-captain-hold.sh's completion attestation records.
+  printf 'decisions_reviewed=1\ndecision_keys=\n' >> "$state/task-a.meta"
+  fm_pr_poll_artifacts_valid "$state" task-a "$POLL" \
+    || fail "a later record writer invalidated the armed poll's artifacts"
+  fm_pr_poll_snapshot_capture "$state" task-a "$POLL" \
+    || fail "a later record writer disarmed the poll the watcher reads"
+
+  set +e
+  FM_TEST_GH_STATE=MERGED run_watcher_bounded "$dir/home" "$dir/fakebin" > "$dir/watch.out" 2> "$dir/watch.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "the watcher cycle failed: $(cat "$dir/watch.err")"
+  assert_no_grep 'rejected unauthenticated state checks' "$dir/watch.out" \
+    "the armed poll was reported as an unauthenticated check"
+  case "$(cat "$dir/watch.out")" in
+    check:*task-a.check.sh:*merged) ;;
+    *) fail "the merge was never reported: $(cat "$dir/watch.out")" ;;
+  esac
+  pass "an armed merge poll survives a later writer appending to the task record"
+}
+
+# bin/fm-pr-check.sh is the only writer of pr= and pr_head=, so it owns the
+# refusal of a value carrying an embedded line break. Without that refusal a
+# forge-supplied head could smuggle a second, attacker-chosen key into the task
+# record, where keys name worktrees and backend endpoints.
+test_recorded_pr_values_refuse_embedded_line_breaks() {
+  local dir before
+  dir=$(make_case pr-value-line-breaks)
+  write_task_meta "$dir"
+  before=$(shasum -a 256 "$dir/home/state/task-a.meta" | awk '{print $1}')
+  FM_TEST_GH_HEAD=$'0123456789abcdef0123456789abcdef01234567\nwindow=unexpected' \
+    run_check_entry "$dir" task-a https://github.com/o/r/pull/2 >/dev/null 2>/dev/null \
+    || fail "a valid check with a malformed remote head failed"
+  assert_no_grep 'window=unexpected' "$dir/home/state/task-a.meta" \
+    "a newline in the forge head injected a second record key"
+  assert_no_grep 'pr_head=' "$dir/home/state/task-a.meta" \
+    "a multiline head reached the record"
+  if run_check_entry "$dir" task-a $'https://github.com/o/r/pull/3\nwindow=unexpected' \
+    >/dev/null 2>/dev/null; then
+    fail "a PR URL carrying a line break was accepted"
+  fi
+  assert_no_grep 'window=unexpected' "$dir/home/state/task-a.meta" \
+    "a newline in the PR URL injected a second record key"
+  [ -n "$before" ] || fail "could not fingerprint the record"
+  pass "recorded PR values refuse an embedded line break at the writer"
+}
+
 test_parser_matrix
+test_pr_identity_binds_to_the_pr_pair_not_line_order
+test_armed_poll_survives_a_later_record_writer
+test_recorded_pr_values_refuse_embedded_line_breaks
 test_gitlab_merge_watch
 test_merged_poll_retires_once
 test_merged_poll_reregistration_after_notification_is_absorbed


### PR DESCRIPTION
## The bug

`bin/fm-captain-hold.sh complete` appended its two bookkeeping keys to the end of `state/<id>.meta`:

```sh
printf 'decisions_reviewed=1\ndecision_keys=%s\n' "$keys" >> "$meta"
```

When the task already carried a `pr=` line - armed earlier by `bin/fm-pr-check.sh` - those keys landed after it. `fm_pr_metadata_identity_parse` in `bin/fm-pr-lib.sh` treated any line after `pr=` that was not `pr_head=` or one of the whitelisted `x_*` keys as evidence of tampering and returned 1. `fm_pr_poll_artifacts_valid` then failed, and `bin/fm-watch.sh` classified the task's own armed merge poll as an unauthenticated check:

```
check: rejected unauthenticated state checks: /path/state/<id>.check.sh
```

The merge poll stayed disarmed for the rest of that task's life, so the merge was never detected or reported, and the operator was handed a security-shaped wake naming the wrong problem.

The ordinary documented lifecycle produces this every time: arm the poll when the PR opens, then attest the captain-call inventory. Both are required by `AGENTS.md` section 7. Reproduced in the field on two consecutive tasks before this fix.

## The fix

`fm_pr_metadata_identity_parse` no longer binds a task record's PR identity to line position. Position carries no meaning in that file: a task record has several legitimate writers that add or rewrite their own unrelated keys at the end, and no reader can require an ordering that every future writer would have to know about.

What the identity actually depends on is checked instead, from either side of `pr=`: exactly one `pr=` that parses to a canonical URL, and at most one `pr_head=`, always validated.

That is stronger than the rule it replaces, not weaker:

- the positional rule skipped a `pr_head=` written *before* `pr=`, while every consumer reads that value with `tail -1`; the new rule validates it wherever it appears
- a second, differing `pr_head=` was previously accepted; it is now refused
- newline injection through either value - which the positional rule caught only by accident - is refused at `bin/fm-pr-check.sh`, the only path that writes them

`fm_meta_set` is added as the shared, tested writer for task records, replacing the last bare append. It sets keys in place atomically, so a re-attestation no longer grows the record. `bin/fm-promote.sh` and `bin/fm-x-lib.sh` have the same append shape; with the reader fixed, neither can reproduce this.

No recovery path is needed, and that is the point: records carrying the keys after `pr=` were never invalid, the reader was wrong. They read correctly now, so nothing exists that could be tricked into accepting a genuinely untrusted check.

## Tests

- `tests/fm-captain-hold-lifecycle.test.sh` - the two-step lifecycle through the real watcher, red before this change and green after (verified by reverting the fix, both with and without the writer change)
- `tests/fm-pr-check-security.test.sh` - the parser's semantics in both directions, and the write path's refusals
- `tests/fm-backlog-atomicity.test.sh` - `fm_meta_set`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VY412eng1vpDbK3Kv2vgKg
