### PR TITLE
fix(tests): reap leaked treehouse-get processes before removing test fixture roots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 - Helper scripts in `bin/` are plain bash.
   Each starts with a usage header comment; keep it accurate when you change behavior.
   Test scripts and helpers in `tests/` are plain bash too.
+  A fixture root from `fm_test_tmproot` is swept for processes still running inside it before it is removed, so a test cannot leak a worker past its own cleanup and must not expect one to survive it; `tests/lib.sh` ("leaked-process sweep") owns that contract and `bin/fm-proc-cwd-lib.sh` owns the boundary it shares with teardown's equivalent reap.
   `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, pinned shellcheck version, and pinned actionlint workflow lint), and both CI and the no-mistakes pre-push gate run its no-argument full-analysis path.
   Its header and `--help` output own the exact local lint modes and flags.
   A malformed `.github/workflows/*.yml`, including a self-broken `ci.yml`, fails that local lint path before merge because a broken workflow cannot report its own breakage.

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -598,6 +598,13 @@ fm_backend_source() {  # <name>
   case "$name" in
     tmux)
       if [ -z "${_FM_BACKEND_TMUX_SOURCED:-}" ]; then
+        # A missing adapter must return 1 through the ordinary command-failure
+        # path, not through `.` itself: under `set -e` with an EXIT trap
+        # installed, some bash versions (stock macOS 3.2) exit the whole
+        # script with status 0 when `.` fails to open its target, so this
+        # readability check - not the `|| return 1` after it - is what makes
+        # a missing adapter refuse rather than silently succeed.
+        [ -r "$FM_BACKEND_LIB_DIR/backends/tmux.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/tmux.sh" || return 1
         _FM_BACKEND_TMUX_SOURCED=1
@@ -605,6 +612,7 @@ fm_backend_source() {  # <name>
       ;;
     herdr)
       if [ -z "${_FM_BACKEND_HERDR_SOURCED:-}" ]; then
+        [ -r "$FM_BACKEND_LIB_DIR/backends/herdr.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/herdr.sh" || return 1
         _FM_BACKEND_HERDR_SOURCED=1
@@ -612,6 +620,7 @@ fm_backend_source() {  # <name>
       ;;
     zellij)
       if [ -z "${_FM_BACKEND_ZELLIJ_SOURCED:-}" ]; then
+        [ -r "$FM_BACKEND_LIB_DIR/backends/zellij.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/zellij.sh" || return 1
         _FM_BACKEND_ZELLIJ_SOURCED=1
@@ -619,6 +628,7 @@ fm_backend_source() {  # <name>
       ;;
     orca)
       if [ -z "${_FM_BACKEND_ORCA_SOURCED:-}" ]; then
+        [ -r "$FM_BACKEND_LIB_DIR/backends/orca.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/orca.sh" || return 1
         _FM_BACKEND_ORCA_SOURCED=1
@@ -626,6 +636,7 @@ fm_backend_source() {  # <name>
       ;;
     cmux)
       if [ -z "${_FM_BACKEND_CMUX_SOURCED:-}" ]; then
+        [ -r "$FM_BACKEND_LIB_DIR/backends/cmux.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/cmux.sh" || return 1
         _FM_BACKEND_CMUX_SOURCED=1

--- a/bin/fm-proc-cwd-lib.sh
+++ b/bin/fm-proc-cwd-lib.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# fm-proc-cwd-lib.sh - "which processes are rooted under this directory?" (one owner).
+#
+# WHY. Two independent reapers need the same question answered before they
+# delete a directory tree, and both are dangerous if the answer is too wide:
+#   - bin/fm-teardown.sh's Fix 2 reaps processes leaked under a task's own
+#     worktree or per-task tasktmp before returning the worktree.
+#   - tests/lib.sh's fixture cleanup reaps processes leaked under a test's own
+#     temp root before removing it. Firstmate's own spawn-exercising tests type
+#     `treehouse get` into a pane; when that pane belongs to a real runtime
+#     rather than a stub, the real `treehouse get` runs, opens its subshell
+#     inside the test's temp tree, and survives the tree's removal.
+# Keying on the CURRENT WORKING DIRECTORY, rather than walking a process tree,
+# is what makes the answer both complete and safe. Complete, because a leaked
+# process is typically already reparented to init and so has no tree left to
+# walk back to its owner. Safe, because the roots callers pass are unique and
+# unshared - one task's worktree, one test's temp root - so a process rooted
+# there belongs to that caller by construction, and nothing outside that
+# subtree can ever match.
+#
+# This file owns only that boundary computation, deliberately not the reaping
+# policy on top of it: teardown is fail-closed (an unreadable process list
+# refuses destructive teardown and preserves the worktree for inspection),
+# while a test fixture is best-effort (it must never turn a leaked process into
+# a suite failure). Sharing the boundary keeps the dangerous half from drifting
+# between two hand-written copies; leaving the policy with each caller keeps a
+# test-only need from reshaping a production safety path.
+#
+# Pure and side-effect free at source time, so the test fixture's EXIT trap can
+# source it as cheaply as a long-lived script does.
+
+# fm_pids_with_cwd_under <dir>
+# Prints the pid of every process whose current working directory is <dir>
+# itself or anything beneath it, one per line, excluding this shell.
+#
+# Returns 1 - printing nothing usable - if the process list cannot be read or
+# parsed, so a caller can tell "nothing is rooted there" apart from "I could
+# not find out". Callers must not treat the latter as the former.
+#
+# An absent or non-directory <dir> is not an error: there is nothing to protect
+# and so nothing to reap. Note the corollary - a tree that has ALREADY been
+# deleted can no longer be scanned, because the processes it leaked are the
+# only remaining trace of it. The sweep must therefore run before the delete.
+#
+# <dir> is resolved to its physical path first: `lsof` reports physical paths,
+# so comparing against an unresolved path would silently miss every match
+# whenever any path component is a symlink - which is the default on macOS,
+# where TMPDIR lives under /var -> /private/var.
+#
+# The `"$dir"|"$dir"/*` match is a whole-path-component test, not a string
+# prefix: it deliberately does not match a sibling that merely starts with the
+# same characters (/tmp/fm-x must never sweep /tmp/fm-x-other).
+fm_pids_with_cwd_under() {  # <dir>
+  local dir=$1 out pid path line
+  [ -n "$dir" ] && [ -d "$dir" ] || return 0
+  dir=$(cd "$dir" && pwd -P) || return 1
+  out=$(lsof -a -d cwd -Fpn 2>/dev/null) || return 1
+  [ -n "$out" ] || return 0
+  pid=
+  # lsof -F emits one field per line, tagged by its first character: `p<pid>`
+  # opens a process record, `f<fd>` opens a file record within it, `n<name>`
+  # gives that file's path. Anything else on a line means the format is not
+  # what this parser was written against, so refuse rather than guess.
+  while IFS= read -r line; do
+    case "$line" in
+      p*)
+        pid=${line#p}
+        case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+        ;;
+      fcwd) [ -n "$pid" ] || return 1 ;;
+      n*)
+        [ -n "$pid" ] || return 1
+        path=${line#n}
+        case "$path" in
+          "$dir"|"$dir"/*)
+            [ -n "$pid" ] && [ "$pid" != "$$" ] && printf '%s\n' "$pid"
+            ;;
+        esac
+        ;;
+      '') ;;
+      *) return 1 ;;
+    esac
+  done <<EOF
+$out
+EOF
+}

--- a/bin/fm-proc-cwd-lib.sh
+++ b/bin/fm-proc-cwd-lib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# fm-proc-cwd-lib.sh - "which processes are rooted under this directory?" (one owner).
+# fm-proc-cwd-lib.sh - "which processes may this reaper signal?" (one owner).
 #
 # WHY. Two independent reapers need the same question answered before they
 # delete a directory tree, and both are dangerous if the answer is too wide:
@@ -18,13 +18,31 @@
 # there belongs to that caller by construction, and nothing outside that
 # subtree can ever match.
 #
-# This file owns only that boundary computation, deliberately not the reaping
-# policy on top of it: teardown is fail-closed (an unreadable process list
-# refuses destructive teardown and preserves the worktree for inspection),
-# while a test fixture is best-effort (it must never turn a leaked process into
-# a suite failure). Sharing the boundary keeps the dangerous half from drifting
-# between two hand-written copies; leaving the policy with each caller keeps a
-# test-only need from reshaping a production safety path.
+# A pid alone is not a safe reference to the process that was scanned, so this
+# file owns a second boundary: identity across time. A pid the scan reported may
+# exit before the signal is sent, and the kernel may hand that number to an
+# unrelated process - so both reapers must capture what the process WAS at scan
+# time and re-verify it immediately before every signal. fm_proc_safe_to_signal
+# composes the two questions ("still inside the boundary?" and "still the same
+# process?") into the single predicate a reaper must pass before it kills
+# anything, because omitting either one is the same bug.
+#
+# The identity here is deliberately BIRTH ONLY (start time), which is the right
+# semantics for a REAPER and not for an owner. It must survive `exec`: a leaked
+# process that exec'd between the scan and the signal is still the leak, and an
+# identity including the command line would silently spare it (verified against
+# real processes: an exec preserves start time while rewriting the command
+# line). Do not reach for bin/fm-wake-lib.sh's fm_pid_identity here - its
+# command-line-inclusive identity is correct for its own question, "does this
+# pid still own my lock?", where any change must read as a different process.
+#
+# What this file does NOT own is the reaping policy: teardown is fail-closed (an
+# unreadable process list refuses destructive teardown and preserves the
+# worktree for inspection), while a test fixture is best-effort (it must never
+# turn a leaked process into a suite failure). Sharing the two boundaries keeps
+# the dangerous half from drifting between hand-written copies; leaving the
+# policy with each caller keeps a test-only need from reshaping a production
+# safety path.
 #
 # Pure and side-effect free at source time, so the test fixture's EXIT trap can
 # source it as cheaply as a long-lived script does.
@@ -83,4 +101,63 @@ fm_pids_with_cwd_under() {  # <dir>
   done <<EOF
 $out
 EOF
+}
+
+# fm_proc_reap_identity <pid>
+# Prints a stable identity for the process currently holding <pid>, or returns
+# 1 if it cannot be read - which a caller must treat as "I could not find out",
+# never as "unchanged". See the header for why this is birth identity only.
+#
+# A Linux-compatible /proc is preferred where present: stat field 22 (start
+# time in clock ticks since boot) is immune to the wall-clock steps that
+# re-render the `ps lstart` fallback. FM_PROC_ROOT_OVERRIDE relocates that root
+# so a test can exercise the portable fallback on a machine that has /proc.
+fm_proc_reap_identity() {  # <pid>
+  local pid=$1 proc_root stat_line starttime value
+  local -a stat_fields
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  proc_root=${FM_PROC_ROOT_OVERRIDE:-/proc}
+  if [ -r "$proc_root/$pid/stat" ]; then
+    stat_line=$(cat "$proc_root/$pid/stat" 2>/dev/null) || return 1
+    # After the final comm delimiter, array index 19 is proc stat field 22.
+    read -r -a stat_fields <<< "${stat_line##*)}"
+    [ "${#stat_fields[@]}" -ge 20 ] || return 1
+    starttime=${stat_fields[19]}
+    case "$starttime" in ''|*[!0-9]*) return 1 ;; esac
+    printf 'starttime=%s\n' "$starttime"
+    return 0
+  fi
+  value=$(LC_ALL=C ps -p "$pid" -o lstart= 2>/dev/null) || return 1
+  # Trimmed inline rather than through bin/fm-nm-run-lib.sh's fm_nm_trim: this
+  # file stays dependency-free so an EXIT trap can source it (see header).
+  value=${value#"${value%%[![:space:]]*}"}
+  value=${value%"${value##*[![:space:]]}"}
+  [ -n "$value" ] || return 1
+  case "$value" in *$'\n'*|*$'\r'*) return 1 ;; esac
+  printf 'lstart=%s\n' "$value"
+}
+
+# fm_proc_reap_identity_matches <pid> <identity>
+# True only if <pid> is readable AND still the process <identity> came from.
+fm_proc_reap_identity_matches() {  # <pid> <identity>
+  local current
+  current=$(fm_proc_reap_identity "$1") || return 1
+  [ "$current" = "$2" ]
+}
+
+# fm_proc_pid_in_list <pid-list> <pid>
+# True if newline-separated <pid-list> contains <pid> as a whole line.
+fm_proc_pid_in_list() {  # <pid-list> <pid>
+  printf '%s\n' "$1" | grep -Fxq "$2"
+}
+
+# fm_proc_safe_to_signal <pid> <identity> <current-pid-list>
+# The predicate every signal in this file's callers must pass: <pid> is still
+# inside the boundary according to a FRESH scan (<current-pid-list>), and is
+# still the same process whose <identity> was captured from that scan. Both
+# halves are required, and a caller that checks only one has the bug this
+# predicate exists to prevent.
+fm_proc_safe_to_signal() {  # <pid> <identity> <current-pid-list>
+  fm_proc_pid_in_list "$3" "$1" || return 1
+  fm_proc_reap_identity_matches "$1" "$2"
 }

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -146,10 +146,11 @@
 #     hours with no live task meta to attribute them to once teardown had
 #     already removed it). reap_task_worktree_processes finds every process
 #     whose CURRENT WORKING DIRECTORY is this task's own worktree or tasktmp
-#     root via `lsof -a -d cwd` (cheap: bounded by process count, not by
-#     walking the worktree's file tree) and sends TERM, then KILL after a short
-#     grace period to any survivor whose process identity still matches. Both
-#     roots are unique per task and never
+#     root via fm_pids_with_cwd_under (bin/fm-proc-cwd-lib.sh, which owns that
+#     boundary for both this reap and firstmate's own test-fixture cleanup, and
+#     explains why cwd rather than a process tree) and sends TERM, then KILL
+#     after a short grace period to any survivor whose process identity still
+#     matches. Both roots are unique per task and never
 #     shared, so this can never reach another task's or the primary's
 #     processes. Idempotent: nothing left to find is a silent no-op.
 #   Fix 3 - sweep abandoned remote job workers. A remote job worker started
@@ -199,6 +200,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-pending-reply-lib.sh"
 # shellcheck source=bin/fm-nm-run-lib.sh
 . "$SCRIPT_DIR/fm-nm-run-lib.sh"
+# shellcheck source=bin/fm-proc-cwd-lib.sh
+. "$SCRIPT_DIR/fm-proc-cwd-lib.sh"
 if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
   echo "error: invalid teardown request" >&2
   exit 2
@@ -1592,41 +1595,11 @@ conclude_task_no_mistakes_run() {  # <worktree>
   return 1
 }
 
-# Fix 2 (see script header): pids of every process whose CURRENT WORKING
-# DIRECTORY is exactly $1 or under it, from one bounded system-wide `lsof -a
-# -d cwd` scan (never the recursive +D file-tree walk, which lsof itself
-# documents as slow). Never $$ (this script's own pid). Empty output when
-# nothing matches; failure means the scan could not establish a safe result.
-pids_with_cwd_under() {  # <dir>
-  local dir=$1 out pid path line
-  [ -n "$dir" ] && [ -d "$dir" ] || return 0
-  dir=$(cd "$dir" && pwd -P) || return 1
-  out=$(lsof -a -d cwd -Fpn 2>/dev/null) || return 1
-  [ -n "$out" ] || return 0
-  pid=
-  while IFS= read -r line; do
-    case "$line" in
-      p*)
-        pid=${line#p}
-        case "$pid" in ''|*[!0-9]*) return 1 ;; esac
-        ;;
-      fcwd) [ -n "$pid" ] || return 1 ;;
-      n*)
-        [ -n "$pid" ] || return 1
-        path=${line#n}
-        case "$path" in
-          "$dir"|"$dir"/*)
-            [ -n "$pid" ] && [ "$pid" != "$$" ] && printf '%s\n' "$pid"
-            ;;
-        esac
-        ;;
-      '') ;;
-      *) return 1 ;;
-    esac
-  done <<EOF
-$out
-EOF
-}
+# Fix 2 (see script header) resolves "which processes are rooted under this
+# directory" through fm_pids_with_cwd_under (bin/fm-proc-cwd-lib.sh), the one
+# owner of that boundary; firstmate's own test-fixture cleanup shares it. The
+# fail-closed policy built on top of it - a scan that cannot establish a safe
+# result refuses destructive teardown - stays here.
 
 task_process_identity() {  # <pid>
   local pid=$1 proc_root stat_line starttime value
@@ -1664,7 +1637,7 @@ task_pids_under_roots() {  # <dir>...
   local dir dir_pids pids=""
   for dir in "$@"; do
     [ -n "$dir" ] || continue
-    if ! dir_pids=$(pids_with_cwd_under "$dir"); then
+    if ! dir_pids=$(fm_pids_with_cwd_under "$dir"); then
       TASK_PIDS_FAILED_DIR=$dir
       return 1
     fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -146,13 +146,14 @@
 #     hours with no live task meta to attribute them to once teardown had
 #     already removed it). reap_task_worktree_processes finds every process
 #     whose CURRENT WORKING DIRECTORY is this task's own worktree or tasktmp
-#     root via fm_pids_with_cwd_under (bin/fm-proc-cwd-lib.sh, which owns that
-#     boundary for both this reap and firstmate's own test-fixture cleanup, and
-#     explains why cwd rather than a process tree) and sends TERM, then KILL
-#     after a short grace period to any survivor whose process identity still
-#     matches. Both roots are unique per task and never
-#     shared, so this can never reach another task's or the primary's
-#     processes. Idempotent: nothing left to find is a silent no-op.
+#     root via fm_pids_with_cwd_under, then sends TERM - and KILL after a short
+#     grace period to any survivor - only to a pid that still passes
+#     fm_proc_safe_to_signal against a fresh scan. bin/fm-proc-cwd-lib.sh owns
+#     both boundaries for this reap and firstmate's own test-fixture cleanup,
+#     and explains why cwd rather than a process tree and why identity must be
+#     re-verified per signal. Both roots are unique per task and never shared,
+#     so this can never reach another task's or the primary's processes.
+#     Idempotent: nothing left to find is a silent no-op.
 #   Fix 3 - sweep abandoned remote job workers. A remote job worker started
 #     from a worktree's own bin/ outlives that worktree's removal without
 #     being reachable by Fix 2, because its working directory is wherever it
@@ -1595,41 +1596,13 @@ conclude_task_no_mistakes_run() {  # <worktree>
   return 1
 }
 
-# Fix 2 (see script header) resolves "which processes are rooted under this
-# directory" through fm_pids_with_cwd_under (bin/fm-proc-cwd-lib.sh), the one
-# owner of that boundary; firstmate's own test-fixture cleanup shares it. The
-# fail-closed policy built on top of it - a scan that cannot establish a safe
-# result refuses destructive teardown - stays here.
-
-task_process_identity() {  # <pid>
-  local pid=$1 proc_root stat_line starttime value
-  local -a stat_fields
-  proc_root=${FM_PROC_ROOT_OVERRIDE:-/proc}
-  if [ -r "$proc_root/$pid/stat" ]; then
-    stat_line=$(cat "$proc_root/$pid/stat" 2>/dev/null) || return 1
-    read -r -a stat_fields <<< "${stat_line##*)}"
-    [ "${#stat_fields[@]}" -ge 20 ] || return 1
-    starttime=${stat_fields[19]}
-    case "$starttime" in ''|*[!0-9]*) return 1 ;; esac
-    printf 'starttime=%s\n' "$starttime"
-    return 0
-  fi
-  value=$(LC_ALL=C ps -p "$pid" -o lstart= 2>/dev/null) || return 1
-  value=$(fm_nm_trim "$value")
-  [ -n "$value" ] || return 1
-  case "$value" in *$'\n'*|*$'\r'*) return 1 ;; esac
-  printf 'lstart=%s\n' "$value"
-}
-
-task_process_identity_matches() {  # <pid> <identity>
-  local current
-  current=$(task_process_identity "$1") || return 1
-  [ "$current" = "$2" ]
-}
-
-task_pid_list_contains() {  # <pid-list> <pid>
-  printf '%s\n' "$1" | grep -Fxq "$2"
-}
+# Fix 2 (see script header) resolves both of its safety boundaries - "which
+# processes are rooted under this directory" and "is this pid still the process
+# I scanned" - through bin/fm-proc-cwd-lib.sh, the one owner of both;
+# firstmate's own test-fixture cleanup shares them, so a reaper cannot be
+# written that checks only one. The fail-closed policy built on top of them - a
+# scan that cannot establish a safe result refuses destructive teardown - stays
+# here.
 
 task_pids_under_roots() {  # <dir>...
   TASK_PIDS=
@@ -1659,7 +1632,7 @@ reap_task_backend_process_group() {  # <label>
     return 0
     ;;
   esac
-  leader_start=$(task_process_identity "$leader") || {
+  leader_start=$(fm_proc_reap_identity "$leader") || {
     echo "warning: lsof is unavailable; cannot identify the tmux pane process group for $ID" >&2
     return 0
   }
@@ -1676,14 +1649,14 @@ reap_task_backend_process_group() {  # <label>
     echo "warning: lsof is unavailable; refusing to signal teardown's own process group for $ID" >&2
     return 0
   fi
-  task_process_identity_matches "$leader" "$leader_start" || return 0
+  fm_proc_reap_identity_matches "$leader" "$leader_start" || return 0
   current_pgid=$(ps -o pgid= -p "$leader" 2>/dev/null) || current_pgid=""
   current_pgid=$(printf '%s' "$current_pgid" | tr -d '[:space:]')
   [ "$current_pgid" = "$pgid" ] || return 0
   echo "teardown: reaping leaked $label process group for $ID: $pgid" >&2
   kill -TERM -- "-$pgid" 2>/dev/null || true
   sleep 1
-  if task_process_identity_matches "$leader" "$leader_start" \
+  if fm_proc_reap_identity_matches "$leader" "$leader_start" \
      && [ "$(ps -o pgid= -p "$leader" 2>/dev/null | tr -d '[:space:]')" = "$pgid" ] \
      && kill -0 -- "-$pgid" 2>/dev/null; then
     echo "teardown: force-killing leaked $label process group for $ID: $pgid" >&2
@@ -1716,12 +1689,12 @@ reap_task_worktree_processes() {  # <label> <dir>...
     tracked_identities=()
     while IFS= read -r pid; do
       [ -n "$pid" ] || continue
-      if ! identity=$(task_process_identity "$pid"); then
+      if ! identity=$(fm_proc_reap_identity "$pid"); then
         if ! task_pids_under_roots "$@"; then
           echo "REFUSED: cannot determine leaked processes under ${TASK_PIDS_FAILED_DIR:-<missing>} for $ID (lsof failed); preserving the worktree/tasktmp for manual inspection or retry." >&2
           return 1
         fi
-        if task_pid_list_contains "$TASK_PIDS" "$pid"; then
+        if fm_proc_pid_in_list "$TASK_PIDS" "$pid"; then
           echo "REFUSED: cannot verify leaked process $pid identity for $ID; preserving the worktree/tasktmp for manual inspection or retry." >&2
           return 1
         fi
@@ -1745,8 +1718,7 @@ EOF
     for i in "${!tracked_pids[@]}"; do
       pid=${tracked_pids[$i]}
       identity=${tracked_identities[$i]}
-      if task_pid_list_contains "$current_pids" "$pid" \
-         && task_process_identity_matches "$pid" "$identity"; then
+      if fm_proc_safe_to_signal "$pid" "$identity" "$current_pids"; then
         kill -TERM "$pid" 2>/dev/null || true
       fi
     done
@@ -1761,8 +1733,7 @@ EOF
     for i in "${!tracked_pids[@]}"; do
       pid=${tracked_pids[$i]}
       identity=${tracked_identities[$i]}
-      if task_pid_list_contains "$current_pids" "$pid" \
-         && task_process_identity_matches "$pid" "$identity"; then
+      if fm_proc_safe_to_signal "$pid" "$identity" "$current_pids"; then
         remaining_pids+=("$pid")
         remaining_identities+=("$identity")
       fi
@@ -1777,8 +1748,7 @@ EOF
       for i in "${!remaining_pids[@]}"; do
         pid=${remaining_pids[$i]}
         identity=${remaining_identities[$i]}
-        if task_pid_list_contains "$current_pids" "$pid" \
-           && task_process_identity_matches "$pid" "$identity"; then
+        if fm_proc_safe_to_signal "$pid" "$identity" "$current_pids"; then
           kill -KILL "$pid" 2>/dev/null || true
         fi
       done

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -98,6 +98,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and secondmate syncs             |
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |
+| `fm-proc-cwd-lib.sh`     | Shared "which processes are rooted under this directory" boundary used by teardown's leaked-process reap and the test fixtures' leaked-process sweep |
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation and config-reread delivery |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-backlog-transition-lib.sh` | Pair task-record changes with their backlog transitions and replay interrupted closes |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -98,7 +98,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and secondmate syncs             |
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |
-| `fm-proc-cwd-lib.sh`     | Shared "which processes are rooted under this directory" boundary used by teardown's leaked-process reap and the test fixtures' leaked-process sweep |
+| `fm-proc-cwd-lib.sh`     | Shared "which processes may this reaper signal" boundary (cwd scope plus pre-signal identity recheck) used by teardown's leaked-process reap and the test fixtures' leaked-process sweep |
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation and config-reread delivery |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-backlog-transition-lib.sh` | Pair task-record changes with their backlog transitions and replay interrupted closes |

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -60,6 +60,9 @@ SH
   ln -s "$ROOT/bin/fm-cursor-lib.sh" "$fake/bin/fm-cursor-lib.sh"
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"
+  # fm-proc-cwd-lib.sh: teardown sources it for the leaked-process reap's cwd
+  # boundary and per-signal identity recheck.
+  ln -s "$ROOT/bin/fm-proc-cwd-lib.sh" "$fake/bin/fm-proc-cwd-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # fm-lease-lib.sh: teardown sources it for the supervision lease guard.
@@ -161,6 +164,7 @@ SH
   ln -s "$ROOT/bin/fm-cursor-lib.sh" "$fake/bin/fm-cursor-lib.sh"
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"
+  ln -s "$ROOT/bin/fm-proc-cwd-lib.sh" "$fake/bin/fm-proc-cwd-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # fm-lease-lib.sh: teardown sources it for the supervision lease guard.
   ln -s "$ROOT/bin/fm-lease-lib.sh" "$fake/bin/fm-lease-lib.sh"

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -228,6 +228,20 @@ reap_sleeper() {  # <pid>
   kill -KILL "$1" 2>/dev/null || true
 }
 
+# proc_is_alive <pid>
+# `kill -0` is the wrong liveness test here: these sleepers are children of the
+# test shell, and a signalled child stays a ZOMBIE until the shell reaps it -
+# a state `kill -0` reports as success, which would read a successfully killed
+# process as a survivor. Ask for the process state instead and treat Z as dead.
+proc_is_alive() {  # <pid>
+  local state
+  [ -n "${1:-}" ] || return 1
+  state=$(ps -o state= -p "$1" 2>/dev/null | tr -d '[:space:]') || return 1
+  [ -n "$state" ] || return 1
+  case "$state" in Z*) return 1 ;; esac
+  return 0
+}
+
 test_cleanup_sweeps_processes_leaked_in_its_own_root() {
   local child_out child_dir pid alive
   # The owning process registers the root, leaves a process running inside it,
@@ -250,7 +264,7 @@ test_cleanup_sweeps_processes_leaked_in_its_own_root() {
   assert_absent "$child_dir" "the fixture root survived its owning process's exit"
 
   alive=0
-  if kill -0 "$pid" 2>/dev/null; then
+  if proc_is_alive "$pid"; then
     alive=1
     reap_sleeper "$pid"
   fi
@@ -292,13 +306,13 @@ test_sweep_cannot_reach_outside_its_own_root() {
   fm_test_sweep_leaked_processes "$swept" || rc=$?
   expect_code 0 "$rc" "the sweep did not succeed on a well-formed fixture root"
 
-  kill -0 "$swept_pid" 2>/dev/null \
+  proc_is_alive "$swept_pid" \
     && { reap_sleeper "$swept_pid"; fail "the sweep left a process running inside the root it was given"; }
-  kill -0 "$sibling_pid" 2>/dev/null \
+  proc_is_alive "$sibling_pid" \
     || fail "the sweep reached another fixture root's process"
-  kill -0 "$prefixed_pid" 2>/dev/null \
+  proc_is_alive "$prefixed_pid" \
     || fail "the sweep reached a sibling whose path is a string prefix of the swept root"
-  kill -0 "$outside_pid" 2>/dev/null \
+  proc_is_alive "$outside_pid" \
     || fail "the sweep reached a process outside the swept root entirely"
 
   reap_sleeper "$sibling_pid"
@@ -340,14 +354,51 @@ test_sweep_refuses_unmarked_and_non_tmpdir_roots() {
   ' _ "$LIB" "$outside_tmpdir" || rc=$?
   expect_code 0 "$rc" "the sweep failed rather than skipping a non-TMPDIR root"
 
-  kill -0 "$unmarked_pid" 2>/dev/null \
+  proc_is_alive "$unmarked_pid" \
     || fail "the sweep signalled into a TMPDIR directory carrying no fixture marker"
-  kill -0 "$outside_pid" 2>/dev/null \
+  proc_is_alive "$outside_pid" \
     || fail "the sweep signalled into a marked directory outside TMPDIR"
 
   reap_sleeper "$unmarked_pid"
   reap_sleeper "$outside_pid"
   pass "the sweep skips roots that are unmarked or outside TMPDIR instead of signalling into them"
+}
+
+test_sweep_kills_a_process_that_ignores_term() {
+  local harness root pid alive
+  # The shape that actually leaked is TERM-resistant: the pane shell holding the
+  # fixture tree is an interactive login shell, and every one of the 99 found on
+  # this machine survived SIGTERM and needed SIGKILL. A sweep that only TERMed
+  # and waited would look correct against a plain `sleep` while still leaking
+  # the real thing, so pin the KILL pass against a process that ignores TERM.
+  harness=$(fm_test_tmproot fm-test-cleanup-sweep-stubborn)
+  root="$harness/stubborn"
+  mkdir -p "$root"
+  : > "$root/.fm-test-fixture"
+  bash -c 'trap "" TERM; cd "$1" || exit 1; while :; do sleep 0.2; done' _ "$root" \
+    >/dev/null 2>&1 </dev/null &
+  pid=$!
+  disown
+  track_sleeper "$pid"
+  while ! kill -0 "$pid" 2>/dev/null; do sleep 0.05; done
+  # Confirm it really is TERM-resistant, so this case cannot pass vacuously
+  # against a process that would have died to the TERM pass anyway.
+  kill -TERM "$pid" 2>/dev/null
+  sleep 0.5
+  proc_is_alive "$pid" \
+    || fail "the fixture process died to SIGTERM, so this case cannot prove the KILL pass"
+
+  fm_test_sweep_leaked_processes "$root" \
+    || fail "the sweep failed on a root holding a TERM-resistant process"
+
+  alive=0
+  if proc_is_alive "$pid"; then
+    alive=1
+    reap_sleeper "$pid"
+  fi
+  [ "$alive" -eq 0 ] \
+    || fail "a TERM-resistant process inside the fixture root survived the sweep"
+  pass "the sweep escalates to KILL for a process that ignores TERM"
 }
 
 test_sweep_never_reaches_a_registered_repo_checkout_dir() {
@@ -374,7 +425,7 @@ test_sweep_never_reaches_a_registered_repo_checkout_dir() {
   fm_test_sweep_leaked_processes "$repo_dir" \
     || fail "the sweep failed rather than skipping a repo-checkout directory"
 
-  kill -0 "$pid" 2>/dev/null || fail "the sweep signalled a process inside the repo checkout"
+  proc_is_alive "$pid" || fail "the sweep signalled a process inside the repo checkout"
   reap_sleeper "$pid"
   rm -rf "$repo_dir"
   pass "the sweep never reaches a registered directory inside the repo checkout"
@@ -420,7 +471,7 @@ test_orphan_sweep_reaps_processes_left_in_a_stale_root() {
 
   assert_absent "$stale_dir" "the orphan reaper left the stale fixture root behind"
   alive=0
-  if kill -0 "$pid" 2>/dev/null; then
+  if proc_is_alive "$pid"; then
     alive=1
     reap_sleeper "$pid"
   fi
@@ -438,6 +489,7 @@ test_orphan_sweep_reaps_read_only_package_tree
 test_cleanup_sweeps_processes_leaked_in_its_own_root
 test_sweep_cannot_reach_outside_its_own_root
 test_sweep_refuses_unmarked_and_non_tmpdir_roots
+test_sweep_kills_a_process_that_ignores_term
 test_sweep_never_reaches_a_registered_repo_checkout_dir
 test_sweep_never_signals_the_sweeping_shell
 test_orphan_sweep_reaps_processes_left_in_a_stale_root

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -365,7 +365,7 @@ test_sweep_refuses_unmarked_and_non_tmpdir_roots() {
 }
 
 test_sweep_kills_a_process_that_ignores_term() {
-  local harness root pid alive
+  local harness root pid alive ready tries
   # The shape that actually leaked is TERM-resistant: the pane shell holding the
   # fixture tree is an interactive login shell, and every one of the 99 found on
   # this machine survived SIGTERM and needed SIGKILL. A sweep that only TERMed
@@ -375,12 +375,26 @@ test_sweep_kills_a_process_that_ignores_term() {
   root="$harness/stubborn"
   mkdir -p "$root"
   : > "$root/.fm-test-fixture"
-  bash -c 'trap "" TERM; cd "$1" || exit 1; while :; do sleep 0.2; done' _ "$root" \
-    >/dev/null 2>&1 </dev/null &
+  # `kill -0 "$pid"` only proves the process exists - not that it has reached
+  # `trap "" TERM` yet. Sending TERM as soon as the pid appears races the
+  # trap's installation: TERM can arrive first and kill the process with its
+  # default disposition, which would make this "TERM-resistant" case flaky
+  # rather than pinned. A marker written right after the trap is installed
+  # gives a deterministic readiness signal instead.
+  ready="$root/.term-trap-armed"
+  bash -c 'trap "" TERM; : > "$2"; cd "$1" || exit 1; while :; do sleep 0.2; done' \
+    _ "$root" "$ready" >/dev/null 2>&1 </dev/null &
   pid=$!
   disown
   track_sleeper "$pid"
-  while ! kill -0 "$pid" 2>/dev/null; do sleep 0.05; done
+  tries=0
+  while [ ! -e "$ready" ]; do
+    kill -0 "$pid" 2>/dev/null \
+      || fail "the TERM-resistant fixture process exited before arming its trap"
+    tries=$((tries + 1))
+    [ "$tries" -lt 200 ] || fail "the TERM-resistant fixture process never armed its trap"
+    sleep 0.05
+  done
   # Confirm it really is TERM-resistant, so this case cannot pass vacuously
   # against a process that would have died to the TERM pass anyway.
   kill -TERM "$pid" 2>/dev/null

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -350,6 +350,36 @@ test_sweep_refuses_unmarked_and_non_tmpdir_roots() {
   pass "the sweep skips roots that are unmarked or outside TMPDIR instead of signalling into them"
 }
 
+test_sweep_never_reaches_a_registered_repo_checkout_dir() {
+  local repo_dir pid
+  # Not hypothetical: tests/fm-lint.test.sh registers a cleanup dir created by
+  # `mktemp -d "$ROOT/.fm-lint-parity.XXXXXX"` - inside the repo checkout - and
+  # tests/fm-arm-pretool-check.test.sh registers a bare mktemp root with no
+  # fixture marker. A sweep driven off the registry alone would signal into the
+  # checkout, so both conditions are checked against that real shape here, with
+  # a marker planted to prove the TMPDIR condition carries it on its own.
+  repo_dir=$(mktemp -d "$ROOT/.fm-test-sweep-repo-guard.XXXXXX") \
+    || fail "could not create the repo-internal directory this case is about"
+  pid=$(start_cwd_sleeper "$repo_dir") || {
+    rm -rf "$repo_dir"
+    fail "the repo-internal sleeper never started"
+  }
+  track_sleeper "$pid"
+
+  fm_test_sweepable_root "$repo_dir" \
+    && fail "a directory inside the repo checkout was accepted as sweepable"
+  : > "$repo_dir/.fm-test-fixture"
+  fm_test_sweepable_root "$repo_dir" \
+    && fail "a marker file alone made a repo-checkout directory sweepable"
+  fm_test_sweep_leaked_processes "$repo_dir" \
+    || fail "the sweep failed rather than skipping a repo-checkout directory"
+
+  kill -0 "$pid" 2>/dev/null || fail "the sweep signalled a process inside the repo checkout"
+  reap_sleeper "$pid"
+  rm -rf "$repo_dir"
+  pass "the sweep never reaches a registered directory inside the repo checkout"
+}
+
 test_sweep_never_signals_the_sweeping_shell() {
   local harness root rc=0
   harness=$(fm_test_tmproot fm-test-cleanup-sweep-self)
@@ -408,5 +438,6 @@ test_orphan_sweep_reaps_read_only_package_tree
 test_cleanup_sweeps_processes_leaked_in_its_own_root
 test_sweep_cannot_reach_outside_its_own_root
 test_sweep_refuses_unmarked_and_non_tmpdir_roots
+test_sweep_never_reaches_a_registered_repo_checkout_dir
 test_sweep_never_signals_the_sweeping_shell
 test_orphan_sweep_reaps_processes_left_in_a_stale_root

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -8,8 +8,12 @@
 # that exact pattern and assert the fixture root is actually gone once the
 # owning process's guarded teardown has run - on a normal exit and on a
 # terminating signal - plus that a stale marked fixture from a killed prior
-# run gets reaped on the next source. Nothing here inspects tests/lib.sh's
-# source text; it only observes filesystem state around the real helper.
+# run gets reaped on the next source.
+#
+# The second half of the file covers the leaked-process sweep those helpers run
+# before removing a root, including the boundary it must never cross. Nothing
+# here inspects tests/lib.sh's source text; it only observes filesystem state
+# and real process liveness around the real helpers.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -164,9 +168,245 @@ test_orphan_sweep_reaps_read_only_package_tree() {
   pass "the orphan sweep reaps read-only package fixtures"
 }
 
+# --- leaked-process sweep ---------------------------------------------------
+#
+# Removing a fixture root does not stop what is still running inside it, so
+# fm_test_cleanup sweeps each registered root before removing it. These cases
+# pin both halves of that contract through the real helpers: that a process
+# left running inside a fixture root does not survive its owner, and - the
+# property that matters most - that the sweep cannot reach anything outside
+# the one root it was given.
+
+# These cases deliberately start processes that must SURVIVE a sweep, so a case
+# that fails early (fail exits immediately) would leak them - the exact class of
+# leak this file is here to pin. tests/lib.sh's documented extension point is an
+# own EXIT trap that still calls fm_test_cleanup, so sleeper pids are tracked and
+# reaped there rather than only on each success path.
+SLEEPER_PIDS=()
+
+sweep_test_cleanup() {
+  local p
+  for p in "${SLEEPER_PIDS[@]:-}"; do
+    [ -n "$p" ] && kill -KILL "$p" 2>/dev/null
+  done
+  fm_test_cleanup
+}
+trap sweep_test_cleanup EXIT
+trap 'sweep_test_cleanup; exit 130' INT
+trap 'sweep_test_cleanup; exit 143' TERM
+
+# Start a `sleep` whose cwd is <dir>, disowned so it is not the test shell's
+# job to reap, and echo its pid once it is confirmed running. Mirrors the shape
+# a leaked `treehouse get` subshell takes: reparented, cwd inside the tree.
+#
+# The sleeper's stdio must be detached. Callers use `$(start_cwd_sleeper ...)`,
+# and a command substitution reads until the write end of its pipe is closed by
+# EVERY holder - so a sleeper that inherited stdout would block the capture for
+# its full duration rather than for as long as this function runs.
+start_cwd_sleeper() {  # <dir>
+  local dir=$1 pid tries=0
+  ( cd "$dir" && exec sleep 300 ) >/dev/null 2>&1 </dev/null &
+  pid=$!
+  disown
+  while [ "$tries" -lt 100 ]; do
+    kill -0 "$pid" 2>/dev/null && break
+    sleep 0.05
+    tries=$((tries + 1))
+  done
+  kill -0 "$pid" 2>/dev/null || return 1
+  printf '%s\n' "$pid"
+}
+
+# Record a sleeper for the EXIT trap. Called in the parent shell (not inside the
+# command substitution that captures the pid), so the array append survives.
+track_sleeper() {  # <pid>
+  [ -n "${1:-}" ] && SLEEPER_PIDS+=("$1")
+}
+
+reap_sleeper() {  # <pid>
+  [ -n "${1:-}" ] || return 0
+  kill -KILL "$1" 2>/dev/null || true
+}
+
+test_cleanup_sweeps_processes_leaked_in_its_own_root() {
+  local child_out child_dir pid alive
+  # The owning process registers the root, leaves a process running inside it,
+  # publishes both, and exits - exercising the real EXIT-trap path rather than
+  # calling the sweep directly.
+  # The sleeper's stdio is detached so a regressed sweep fails this case
+  # instead of hanging the capture for the sleeper's full duration.
+  child_out=$(bash -c '
+    # shellcheck source=tests/lib.sh
+    . "'"$LIB"'"
+    d=$(fm_test_tmproot fm-test-cleanup-sweep)
+    ( cd "$d" && exec sleep 300 ) >/dev/null 2>&1 </dev/null &
+    pid=$!
+    disown
+    printf "%s\n%s\n" "$d" "$pid"
+  ')
+  child_dir=$(printf '%s\n' "$child_out" | sed -n '1p')
+  pid=$(printf '%s\n' "$child_out" | sed -n '2p')
+  [ -n "$pid" ] || fail "the child never published the pid of the process it leaked"
+  assert_absent "$child_dir" "the fixture root survived its owning process's exit"
+
+  alive=0
+  if kill -0 "$pid" 2>/dev/null; then
+    alive=1
+    reap_sleeper "$pid"
+  fi
+  [ "$alive" -eq 0 ] \
+    || fail "a process left running inside the fixture root survived fm_test_cleanup"
+  pass "fm_test_cleanup reaps a process leaked inside its own fixture root"
+}
+
+test_sweep_cannot_reach_outside_its_own_root() {
+  local harness swept sibling prefixed outside swept_pid sibling_pid prefixed_pid outside_pid rc=0
+  harness=$(fm_test_tmproot fm-test-cleanup-sweep-boundary)
+  # All four live under this suite's own registered root, so they are equally
+  # eligible on the TMPDIR condition alone and only the marker and the root
+  # argument may separate them - and so the suite's own cleanup reaps whatever
+  # an early failure leaves behind.
+  swept="$harness/swept"
+  sibling="$harness/sibling"
+  mkdir -p "$swept" "$sibling"
+  : > "$swept/.fm-test-fixture"
+  : > "$sibling/.fm-test-fixture"
+  # A sibling whose path is a STRING PREFIX of the swept root: the classic way
+  # a prefix comparison escapes its subtree. "$swept-prefixed" is not under
+  # "$swept", so it must be untouched.
+  prefixed="$swept-prefixed"
+  mkdir -p "$prefixed"
+  : > "$prefixed/.fm-test-fixture"
+  outside="$harness/outside"
+  mkdir -p "$outside"
+
+  swept_pid=$(start_cwd_sleeper "$swept") || fail "the in-root sleeper never started"
+  track_sleeper "$swept_pid"
+  sibling_pid=$(start_cwd_sleeper "$sibling") || fail "the sibling-root sleeper never started"
+  track_sleeper "$sibling_pid"
+  prefixed_pid=$(start_cwd_sleeper "$prefixed") || fail "the prefix-sibling sleeper never started"
+  track_sleeper "$prefixed_pid"
+  outside_pid=$(start_cwd_sleeper "$outside") || fail "the out-of-root sleeper never started"
+  track_sleeper "$outside_pid"
+
+  fm_test_sweep_leaked_processes "$swept" || rc=$?
+  expect_code 0 "$rc" "the sweep did not succeed on a well-formed fixture root"
+
+  kill -0 "$swept_pid" 2>/dev/null \
+    && { reap_sleeper "$swept_pid"; fail "the sweep left a process running inside the root it was given"; }
+  kill -0 "$sibling_pid" 2>/dev/null \
+    || fail "the sweep reached another fixture root's process"
+  kill -0 "$prefixed_pid" 2>/dev/null \
+    || fail "the sweep reached a sibling whose path is a string prefix of the swept root"
+  kill -0 "$outside_pid" 2>/dev/null \
+    || fail "the sweep reached a process outside the swept root entirely"
+
+  reap_sleeper "$sibling_pid"
+  reap_sleeper "$prefixed_pid"
+  reap_sleeper "$outside_pid"
+  pass "the leaked-process sweep reaches only processes inside the root it was given"
+}
+
+test_sweep_refuses_unmarked_and_non_tmpdir_roots() {
+  local harness unmarked elsewhere outside_tmpdir unmarked_pid outside_pid rc=0
+  harness=$(fm_test_tmproot fm-test-cleanup-sweep-refusals)
+  # Under TMPDIR but carrying no fixture marker: a path that reached the
+  # registry without fm_test_tmproot having created it must not be swept.
+  unmarked="$harness/unmarked"
+  # Marked but outside TMPDIR: a marker file alone must not license a sweep of
+  # an arbitrary directory - a real task worktree or the primary checkout could
+  # be handed a marker by anything. TMPDIR is repointed at a sibling for this
+  # half, so the marked root really is outside the TMPDIR the sweep will read.
+  elsewhere="$harness/effective-tmpdir"
+  outside_tmpdir="$harness/marked-outside-tmpdir"
+  mkdir -p "$elsewhere" "$outside_tmpdir" "$unmarked"
+  : > "$outside_tmpdir/.fm-test-fixture"
+
+  unmarked_pid=$(start_cwd_sleeper "$unmarked") || fail "the unmarked-root sleeper never started"
+  track_sleeper "$unmarked_pid"
+  outside_pid=$(start_cwd_sleeper "$outside_tmpdir") || fail "the non-TMPDIR sleeper never started"
+  track_sleeper "$outside_pid"
+
+  fm_test_sweep_leaked_processes "$unmarked" || rc=$?
+  expect_code 0 "$rc" "the sweep failed rather than skipping an unmarked root"
+  rc=0
+  # A child shell, so the redirected TMPDIR cannot reach this shell at all.
+  # Its own orphan scan is suppressed: it would otherwise sweep the redirected
+  # TMPDIR rather than the one this case is asserting about.
+  FM_TEST_SKIP_ORPHAN_REAP=1 TMPDIR="$elsewhere" bash -c '
+    # shellcheck source=tests/lib.sh
+    . "$1"
+    fm_test_sweep_leaked_processes "$2"
+  ' _ "$LIB" "$outside_tmpdir" || rc=$?
+  expect_code 0 "$rc" "the sweep failed rather than skipping a non-TMPDIR root"
+
+  kill -0 "$unmarked_pid" 2>/dev/null \
+    || fail "the sweep signalled into a TMPDIR directory carrying no fixture marker"
+  kill -0 "$outside_pid" 2>/dev/null \
+    || fail "the sweep signalled into a marked directory outside TMPDIR"
+
+  reap_sleeper "$unmarked_pid"
+  reap_sleeper "$outside_pid"
+  pass "the sweep skips roots that are unmarked or outside TMPDIR instead of signalling into them"
+}
+
+test_sweep_never_signals_the_sweeping_shell() {
+  local harness root rc=0
+  harness=$(fm_test_tmproot fm-test-cleanup-sweep-self)
+  root="$harness/self"
+  mkdir -p "$root"
+  : > "$root/.fm-test-fixture"
+  # A shell whose OWN cwd is inside the root it sweeps must survive: the child
+  # cd's in, sweeps, and only then reports. TMPDIR is pointed at the harness so
+  # the root qualifies while staying inside this test's own fixture tree.
+  TMPDIR="$harness" bash -c '
+    # shellcheck source=tests/lib.sh
+    . "'"$LIB"'"
+    cd "$1" || exit 9
+    fm_test_sweep_leaked_processes "$1" || exit 8
+    printf "survived\n"
+  ' _ "$root" > "$harness/out" 2>"$harness/err" || rc=$?
+
+  expect_code 0 "$rc" "a shell sweeping the root it is sitting in did not survive"
+  assert_grep survived "$harness/out" \
+    "the sweeping shell was signalled by its own sweep"
+  pass "the sweep never signals the shell performing it"
+}
+
+test_orphan_sweep_reaps_processes_left_in_a_stale_root() {
+  local stale_dir pid alive
+  # The accumulation path: a prior run killed hard enough to skip its traps
+  # leaves both a root and processes inside it. The next source must clear both.
+  stale_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-cleanup-stale-procs.XXXXXX")
+  printf '%s\n%s\n' "$$" reused-process-identity > "$stale_dir/.fm-test-fixture"
+  pid=$(start_cwd_sleeper "$stale_dir") || fail "the stale-root sleeper never started"
+  track_sleeper "$pid"
+  touch -t 202001010000 "$stale_dir/.fm-test-fixture"
+
+  bash -c '
+    # shellcheck source=tests/lib.sh
+    . "$1"
+  ' _ "$LIB"
+
+  assert_absent "$stale_dir" "the orphan reaper left the stale fixture root behind"
+  alive=0
+  if kill -0 "$pid" 2>/dev/null; then
+    alive=1
+    reap_sleeper "$pid"
+  fi
+  [ "$alive" -eq 0 ] \
+    || fail "the orphan reaper removed a stale fixture root but left its leaked process running"
+  pass "the orphan sweep reaps processes left inside a stale fixture root, not just the root"
+}
+
 test_fixture_root_gone_after_normal_exit
 test_fixture_root_gone_after_sigterm
 test_cleanup_registry_resists_precreation
 test_fixture_registration_failure_rolls_back_root
 test_orphan_sweep_respects_fixture_ownership
 test_orphan_sweep_reaps_read_only_package_tree
+test_cleanup_sweeps_processes_leaked_in_its_own_root
+test_sweep_cannot_reach_outside_its_own_root
+test_sweep_refuses_unmarked_and_non_tmpdir_roots
+test_sweep_never_signals_the_sweeping_shell
+test_orphan_sweep_reaps_processes_left_in_a_stale_root

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -420,7 +420,7 @@ test_sweep_leaves_a_pid_alone_once_its_identity_no_longer_matches() {
   # A cwd-only recheck closes the "left the subtree" case but not PID reuse:
   # if the pid the sweep scanned has already exited and the OS handed the
   # number to an unrelated process by the time the sweep is about to signal,
-  # a cwd-only recheck cannot tell the difference. fm_test_pid_identity is
+  # a cwd-only recheck cannot tell the difference. fm_proc_reap_identity is
   # overridden here, in a child shell, to return a different value on every
   # call - exactly what re-deriving identity for a reused pid would look like
   # - so the pre-signal identity recheck can never match what was captured at
@@ -432,7 +432,7 @@ test_sweep_leaves_a_pid_alone_once_its_identity_no_longer_matches() {
   pid=$(start_cwd_sleeper "$root") || fail "the identity-check sleeper never started"
   track_sleeper "$pid"
 
-  # A plain shell variable would not do: each call to fm_test_pid_identity runs
+  # A plain shell variable would not do: each call to fm_proc_reap_identity runs
   # inside the command substitution that captures its output, which is a
   # subshell, so an in-memory counter would never actually advance in the
   # caller. A counter file survives across that subshell boundary instead.
@@ -440,7 +440,7 @@ test_sweep_leaves_a_pid_alone_once_its_identity_no_longer_matches() {
     # shellcheck source=tests/lib.sh
     . "$1"
     counter="$2/identity-calls"
-    fm_test_pid_identity() {
+    fm_proc_reap_identity() {
       local n
       n=$(( $(cat "$counter" 2>/dev/null || echo 0) + 1 ))
       printf "%s\n" "$n" > "$counter"
@@ -450,12 +450,107 @@ test_sweep_leaves_a_pid_alone_once_its_identity_no_longer_matches() {
   ' _ "$LIB" "$harness" "$root" \
     || fail "the sweep failed rather than no-op'ing on an identity mismatch"
 
+  # The counter proves the override was actually consulted. Without it, a sweep
+  # that stopped asking for identity would pass this case vacuously: "the
+  # sleeper survived" is also what a sweep that signalled nothing looks like.
+  [ -s "$harness/identity-calls" ] \
+    || fail "the sweep never asked for a process identity, so this case proves nothing"
+
   alive=0
   proc_is_alive "$pid" && alive=1
   reap_sleeper "$pid"
   [ "$alive" -eq 1 ] \
     || fail "the sweep signalled a pid whose identity no longer matched what it captured at scan time"
   pass "the sweep leaves a pid alone once its identity no longer matches what was captured at scan time"
+}
+
+test_signal_guard_still_admits_a_leak_that_execd_since_the_scan() {
+  local harness root pid ready landed tries=0
+  local captured own_before own_after cmd_before cmd_after scan
+  # WHY THIS CASE EXISTS. The pre-signal recheck above stops the sweep
+  # signalling a recycled pid - but identity can be built two ways, and only
+  # one is correct for a REAPER. bin/fm-wake-lib.sh's fm_pid_identity (the
+  # OWNERSHIP identity, used for lock claims) folds in the command line, so it
+  # deliberately breaks on `exec`. Building the sweep on that would make it
+  # spare any leaked process that exec'd after the scan - reinstating the very
+  # leak this file pins, and silently, because sparing a process is
+  # indistinguishable from having had nothing to reap. fm_proc_reap_identity is
+  # birth-only for exactly that reason.
+  #
+  # This asserts the shared predicate directly rather than racing a signal into
+  # the sweep's grace window: the exec is driven by a marker file and confirmed
+  # landed before anything is asserted, so the case turns on the identity rule
+  # and never on scheduling. bin/fm-teardown.sh's reap passes through the same
+  # predicate, so this covers production too.
+  harness=$(fm_test_tmproot fm-test-cleanup-signal-guard)
+  root="$harness/leak"
+  mkdir -p "$root"
+  : > "$root/.fm-test-fixture"
+  ready="$harness/ready"
+  landed="$harness/landed"
+
+  # Waits for the marker, then execs - so the pid, its start time and its cwd
+  # all survive while the command line is rewritten. Mirrors a leaked
+  # `treehouse get` subshell handing off to the shell it opens.
+  ( cd "$root" && exec perl -e '
+      my ($ready, $landed) = @ARGV;
+      open my $fh, ">", $ready or die "ready";
+      close $fh;
+      until (-e $landed) { select undef, undef, undef, 0.01; }
+      exec "sleep", "313";
+    ' "$ready" "$landed" ) >/dev/null 2>&1 </dev/null &
+  pid=$!
+  disown
+  track_sleeper "$pid"
+  while [ "$tries" -lt 200 ]; do
+    [ -e "$ready" ] && break
+    sleep 0.05
+    tries=$((tries + 1))
+  done
+  [ -e "$ready" ] || fail "the exec fixture process never started"
+
+  captured=$(fm_proc_reap_identity "$pid") \
+    || fail "could not capture a reap identity for the fixture process"
+  own_before=$(fm_test_pid_identity "$pid") \
+    || fail "could not capture an ownership identity for the fixture process"
+  cmd_before=$(ps -p "$pid" -o command= 2>/dev/null)
+
+  # `sleep 313` is a signature no other process on the machine is running, so
+  # polling the command line for it is positive proof the exec landed - not the
+  # mere absence of the old one.
+  : > "$landed"
+  tries=0
+  while [ "$tries" -lt 400 ]; do
+    cmd_after=$(ps -p "$pid" -o command= 2>/dev/null)
+    case "$cmd_after" in *"sleep 313"*) break ;; esac
+    sleep 0.05
+    tries=$((tries + 1))
+  done
+  case "$cmd_after" in
+    *"sleep 313"*) ;;
+    *) fail "the fixture process never exec'd, so this case proves nothing" ;;
+  esac
+
+  scan=$(fm_pids_with_cwd_under "$root") \
+    || fail "the cwd scan failed against the exec fixture root"
+  fm_proc_pid_in_list "$scan" "$pid" \
+    || fail "the exec'd process left the fixture root, so this case proves nothing"
+
+  # The property: birth identity is unchanged, so the leak is still reapable.
+  fm_proc_safe_to_signal "$pid" "$captured" "$scan" \
+    || fail "the signal guard refused a leaked process that only exec'd since the scan"
+
+  # And the divergence that makes the property non-trivial: the ownership
+  # identity DID change, so a sweep built on it would have spared this leak.
+  own_after=$(fm_test_pid_identity "$pid") \
+    || fail "could not re-read the ownership identity after the exec"
+  [ "$cmd_after" != "$cmd_before" ] \
+    || fail "the exec did not rewrite the command line, so the identities cannot diverge"
+  [ "$own_after" != "$own_before" ] \
+    || fail "the ownership identity did not change across the exec, so this case pins nothing"
+
+  reap_sleeper "$pid"
+  pass "the signal guard still admits a leak that only exec'd since the scan"
 }
 
 test_sweep_never_reaches_a_registered_repo_checkout_dir() {
@@ -548,6 +643,7 @@ test_sweep_cannot_reach_outside_its_own_root
 test_sweep_refuses_unmarked_and_non_tmpdir_roots
 test_sweep_kills_a_process_that_ignores_term
 test_sweep_leaves_a_pid_alone_once_its_identity_no_longer_matches
+test_signal_guard_still_admits_a_leak_that_execd_since_the_scan
 test_sweep_never_reaches_a_registered_repo_checkout_dir
 test_sweep_never_signals_the_sweeping_shell
 test_orphan_sweep_reaps_processes_left_in_a_stale_root

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -401,6 +401,49 @@ test_sweep_kills_a_process_that_ignores_term() {
   pass "the sweep escalates to KILL for a process that ignores TERM"
 }
 
+test_sweep_leaves_a_pid_alone_once_its_identity_no_longer_matches() {
+  local harness root pid alive
+  # A cwd-only recheck closes the "left the subtree" case but not PID reuse:
+  # if the pid the sweep scanned has already exited and the OS handed the
+  # number to an unrelated process by the time the sweep is about to signal,
+  # a cwd-only recheck cannot tell the difference. fm_test_pid_identity is
+  # overridden here, in a child shell, to return a different value on every
+  # call - exactly what re-deriving identity for a reused pid would look like
+  # - so the pre-signal identity recheck can never match what was captured at
+  # scan time. The real sleeper must therefore survive untouched.
+  harness=$(fm_test_tmproot fm-test-cleanup-sweep-identity)
+  root="$harness/reused"
+  mkdir -p "$root"
+  : > "$root/.fm-test-fixture"
+  pid=$(start_cwd_sleeper "$root") || fail "the identity-check sleeper never started"
+  track_sleeper "$pid"
+
+  # A plain shell variable would not do: each call to fm_test_pid_identity runs
+  # inside the command substitution that captures its output, which is a
+  # subshell, so an in-memory counter would never actually advance in the
+  # caller. A counter file survives across that subshell boundary instead.
+  bash -c '
+    # shellcheck source=tests/lib.sh
+    . "$1"
+    counter="$2/identity-calls"
+    fm_test_pid_identity() {
+      local n
+      n=$(( $(cat "$counter" 2>/dev/null || echo 0) + 1 ))
+      printf "%s\n" "$n" > "$counter"
+      printf "identity-%s\n" "$n"
+    }
+    fm_test_sweep_leaked_processes "$3"
+  ' _ "$LIB" "$harness" "$root" \
+    || fail "the sweep failed rather than no-op'ing on an identity mismatch"
+
+  alive=0
+  proc_is_alive "$pid" && alive=1
+  reap_sleeper "$pid"
+  [ "$alive" -eq 1 ] \
+    || fail "the sweep signalled a pid whose identity no longer matched what it captured at scan time"
+  pass "the sweep leaves a pid alone once its identity no longer matches what was captured at scan time"
+}
+
 test_sweep_never_reaches_a_registered_repo_checkout_dir() {
   local repo_dir pid
   # Not hypothetical: tests/fm-lint.test.sh registers a cleanup dir created by
@@ -490,6 +533,7 @@ test_cleanup_sweeps_processes_leaked_in_its_own_root
 test_sweep_cannot_reach_outside_its_own_root
 test_sweep_refuses_unmarked_and_non_tmpdir_roots
 test_sweep_kills_a_process_that_ignores_term
+test_sweep_leaves_a_pid_alone_once_its_identity_no_longer_matches
 test_sweep_never_reaches_a_registered_repo_checkout_dir
 test_sweep_never_signals_the_sweeping_shell
 test_orphan_sweep_reaps_processes_left_in_a_stale_root

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -148,28 +148,56 @@ fm_test_sweepable_root() {
 # leak one process per spawning case.
 #
 # Re-deriving the pid set from the cwd boundary immediately before each signal
-# is what keeps the sweep scoped across the grace period: a pid that left the
-# subtree - or was recycled by a process outside it - is simply absent from the
-# next scan, so the boundary itself is the guard and no separate pid-identity
-# bookkeeping is needed to stay inside the fixture root.
+# keeps the sweep scoped across the grace period: a pid that left the subtree
+# is simply absent from the next scan. That alone does not close the window
+# between listing a pid and signalling it: if that pid has already exited and
+# the OS recycled the number for an unrelated process, a cwd-only recheck can
+# still find a match (the new process may itself sit under <dir>, or the
+# recheck may simply run before the kernel has reused it) and signal a process
+# this sweep never leaked. fm_test_pid_identity (shared with fm_pid_identity in
+# bin/fm-wake-lib.sh) is captured per pid alongside the scan and re-verified
+# immediately before every signal for the same reason production teardown's
+# reap_task_worktree_processes binds identity rather than trusting a pid number
+# alone; a pid whose identity has changed is left alone.
 fm_test_sweep_leaked_processes() {
-  local dir=$1 pids pid
+  local dir=$1 pids pid identity current i
+  local -a tracked_pids tracked_identities
   fm_test_sweepable_root "$dir" || return 0
   pids=$(fm_pids_with_cwd_under "$dir" 2>/dev/null) || return 0
   [ -n "$pids" ] || return 0
+  tracked_pids=()
+  tracked_identities=()
   while IFS= read -r pid; do
-    [ -n "$pid" ] && kill -TERM "$pid" 2>/dev/null
+    [ -n "$pid" ] || continue
+    identity=$(fm_test_pid_identity "$pid" 2>/dev/null) || continue
+    tracked_pids+=("$pid")
+    tracked_identities+=("$identity")
   done <<EOF
 $pids
 EOF
-  sleep "${FM_TEST_SWEEP_GRACE:-0.5}"
+  [ "${#tracked_pids[@]}" -gt 0 ] || return 0
+
   pids=$(fm_pids_with_cwd_under "$dir" 2>/dev/null) || return 0
-  [ -n "$pids" ] || return 0
-  while IFS= read -r pid; do
-    [ -n "$pid" ] && kill -KILL "$pid" 2>/dev/null
-  done <<EOF
-$pids
-EOF
+  for i in "${!tracked_pids[@]}"; do
+    pid=${tracked_pids[$i]}
+    if printf '%s\n' "$pids" | grep -qFx "$pid" \
+      && current=$(fm_test_pid_identity "$pid" 2>/dev/null) \
+      && [ "$current" = "${tracked_identities[$i]}" ]; then
+      kill -TERM "$pid" 2>/dev/null
+    fi
+  done
+
+  sleep "${FM_TEST_SWEEP_GRACE:-0.5}"
+
+  pids=$(fm_pids_with_cwd_under "$dir" 2>/dev/null) || return 0
+  for i in "${!tracked_pids[@]}"; do
+    pid=${tracked_pids[$i]}
+    if printf '%s\n' "$pids" | grep -qFx "$pid" \
+      && current=$(fm_test_pid_identity "$pid" 2>/dev/null) \
+      && [ "$current" = "${tracked_identities[$i]}" ]; then
+      kill -KILL "$pid" 2>/dev/null
+    fi
+  done
   return 0
 }
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -41,11 +41,12 @@ export FM_GATE_REFUSE_BYPASS=1
 # shellcheck disable=SC2034
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# The one owner of "which processes are rooted (by cwd) under this directory",
-# shared with bin/fm-teardown.sh's leaked-process reap. Safe to source here
-# because it is pure: unlike bin/fm-wake-lib.sh (which fm_test_pid_identity
-# below must therefore call in a subshell with FM_STATE_OVERRIDE set), it
-# creates no directories and resolves no home at source time.
+# The one owner of "which processes may this reaper signal" - both the cwd
+# boundary and the per-signal identity recheck - shared with
+# bin/fm-teardown.sh's leaked-process reap. Safe to source here because it is
+# pure: unlike bin/fm-wake-lib.sh (which fm_test_pid_identity below must
+# therefore call in a subshell with FM_STATE_OVERRIDE set), it creates no
+# directories and resolves no home at source time.
 # shellcheck source=bin/fm-proc-cwd-lib.sh
 . "$ROOT/bin/fm-proc-cwd-lib.sh"
 
@@ -83,6 +84,13 @@ pass() {
 FM_TEST_CLEANUP_DIRS=()
 FM_TEST_CLEANUP_REGISTRY=$(mktemp "${TMPDIR:-/tmp}/.fm-test-cleanup.$$.XXXXXX") || return 1
 
+# The OWNERSHIP identity - bin/fm-wake-lib.sh's fm_pid_identity, as the
+# watcher and the turn-end guards compute it - for tests that assert against a
+# real claim record, and for this file's own fixture-root owner marker. Any
+# change to the process must read as a different owner there, so it includes
+# the command line. A reaper needs the opposite (an identity that survives
+# `exec`) and must use fm_proc_reap_identity instead; bin/fm-proc-cwd-lib.sh's
+# header owns that distinction.
 fm_test_pid_identity() {
   local pid=$1
   FM_STATE_OVERRIDE="${TMPDIR:-/tmp}" bash -c \
@@ -147,20 +155,22 @@ fm_test_sweepable_root() {
 # this machine survived TERM and needed KILL - so a TERM-only sweep would still
 # leak one process per spawning case.
 #
-# Re-deriving the pid set from the cwd boundary immediately before each signal
-# keeps the sweep scoped across the grace period: a pid that left the subtree
-# is simply absent from the next scan. That alone does not close the window
-# between listing a pid and signalling it: if that pid has already exited and
-# the OS recycled the number for an unrelated process, a cwd-only recheck can
-# still find a match (the new process may itself sit under <dir>, or the
-# recheck may simply run before the kernel has reused it) and signal a process
-# this sweep never leaked. fm_test_pid_identity (shared with fm_pid_identity in
-# bin/fm-wake-lib.sh) is captured per pid alongside the scan and re-verified
-# immediately before every signal for the same reason production teardown's
-# reap_task_worktree_processes binds identity rather than trusting a pid number
-# alone; a pid whose identity has changed is left alone.
+# A pid is not a safe reference to the process that was scanned, so every
+# signal goes through fm_proc_safe_to_signal: the pid must still be inside the
+# cwd boundary according to a FRESH scan, and must still be the same process
+# whose identity was captured at scan time. Re-scanning alone would not close
+# the window between listing a pid and signalling it - once that pid has exited
+# and the OS has recycled the number, a cwd-only recheck cannot tell the
+# replacement apart from the leak - so the sweep would be able to signal a
+# process it never leaked. bin/fm-proc-cwd-lib.sh owns both halves of that
+# predicate and the reason its identity is birth-only, which is what keeps a
+# leaked process that exec'd in the meantime reapable rather than spared.
+#
+# Note the two remaining asymmetries with production teardown, both from the
+# best-effort policy: a pid whose identity cannot be read is skipped rather
+# than refused, and there is one TERM/KILL round rather than bounded retries.
 fm_test_sweep_leaked_processes() {
-  local dir=$1 pids pid identity current i
+  local dir=$1 pids pid identity i
   local -a tracked_pids tracked_identities
   fm_test_sweepable_root "$dir" || return 0
   pids=$(fm_pids_with_cwd_under "$dir" 2>/dev/null) || return 0
@@ -169,7 +179,7 @@ fm_test_sweep_leaked_processes() {
   tracked_identities=()
   while IFS= read -r pid; do
     [ -n "$pid" ] || continue
-    identity=$(fm_test_pid_identity "$pid" 2>/dev/null) || continue
+    identity=$(fm_proc_reap_identity "$pid" 2>/dev/null) || continue
     tracked_pids+=("$pid")
     tracked_identities+=("$identity")
   done <<EOF
@@ -179,11 +189,8 @@ EOF
 
   pids=$(fm_pids_with_cwd_under "$dir" 2>/dev/null) || return 0
   for i in "${!tracked_pids[@]}"; do
-    pid=${tracked_pids[$i]}
-    if printf '%s\n' "$pids" | grep -qFx "$pid" \
-      && current=$(fm_test_pid_identity "$pid" 2>/dev/null) \
-      && [ "$current" = "${tracked_identities[$i]}" ]; then
-      kill -TERM "$pid" 2>/dev/null
+    if fm_proc_safe_to_signal "${tracked_pids[$i]}" "${tracked_identities[$i]}" "$pids"; then
+      kill -TERM "${tracked_pids[$i]}" 2>/dev/null
     fi
   done
 
@@ -191,11 +198,8 @@ EOF
 
   pids=$(fm_pids_with_cwd_under "$dir" 2>/dev/null) || return 0
   for i in "${!tracked_pids[@]}"; do
-    pid=${tracked_pids[$i]}
-    if printf '%s\n' "$pids" | grep -qFx "$pid" \
-      && current=$(fm_test_pid_identity "$pid" 2>/dev/null) \
-      && [ "$current" = "${tracked_identities[$i]}" ]; then
-      kill -KILL "$pid" 2>/dev/null
+    if fm_proc_safe_to_signal "${tracked_pids[$i]}" "${tracked_identities[$i]}" "$pids"; then
+      kill -KILL "${tracked_pids[$i]}" 2>/dev/null
     fi
   done
   return 0

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -6,8 +6,9 @@
 #   . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 #
 # It provides the boilerplate every test file used to re-roll: ok/not-ok
-# reporters, a self-cleaning temp root, fakebin/PATH-shim helpers, deterministic
-# git identity and fixture builders, state/<id>.meta writers, and the common
+# reporters, a self-cleaning temp root that also reaps processes leaked inside
+# it, fakebin/PATH-shim helpers, deterministic git identity and fixture
+# builders, state/<id>.meta writers, and the common
 # string/exit-code/file assertions. Shared fake-toolchain and spawn-world
 # builders live in tests/fixtures.sh; wake-queue mocks in wake-helpers.sh;
 # secondmate-lifecycle mocks in secondmate-helpers.sh. Suite-specific fakes
@@ -40,6 +41,14 @@ export FM_GATE_REFUSE_BYPASS=1
 # shellcheck disable=SC2034
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# The one owner of "which processes are rooted (by cwd) under this directory",
+# shared with bin/fm-teardown.sh's leaked-process reap. Safe to source here
+# because it is pure: unlike bin/fm-wake-lib.sh (which fm_test_pid_identity
+# below must therefore call in a subshell with FM_STATE_OVERRIDE set), it
+# creates no directories and resolves no home at source time.
+# shellcheck source=bin/fm-proc-cwd-lib.sh
+. "$ROOT/bin/fm-proc-cwd-lib.sh"
+
 # --- reporters --------------------------------------------------------------
 
 fail() {
@@ -56,7 +65,9 @@ pass() {
 # fm_test_tmproot <prefix> echoes a fresh temp dir and registers it for removal
 # on EXIT/INT/TERM. A test file that needs extra teardown (e.g. killing a
 # daemon) should define its own EXIT trap and call fm_test_cleanup from inside
-# it so registered dirs are still removed.
+# it so registered dirs are still removed. Each registered dir is swept for
+# leaked processes before it is removed - see "leaked-process sweep" below for
+# why that has to happen before, not after.
 #
 # The call site is almost always `TMP_ROOT=$(fm_test_tmproot prefix)`, which
 # forks a subshell to capture stdout. Anything that function does to the
@@ -83,13 +94,89 @@ FM_TEST_OWNER_IDENTITY=$(fm_test_pid_identity "$$") || {
   return 1
 }
 
+# --- leaked-process sweep ---------------------------------------------------
+#
+# Removing a fixture root does not stop what is still running inside it. The
+# suites that drive the real bin/fm-spawn.sh type `treehouse get` into the
+# task's pane; whenever that pane belongs to a live runtime rather than a stub
+# (an ambient herdr server is the case seen in practice), the REAL
+# `treehouse get` runs, opens its subshell inside the fixture tree, and outlives
+# the tree - leaving a process pair per spawning case whose working directory is
+# a path that no longer exists. Observed 2026-09-03: 74 such `treehouse get`
+# processes plus a child shell each, the oldest 6d18h old, every one traceable to
+# a fixture root under TMPDIR.
+#
+# Production tasks already get this guarantee from bin/fm-teardown.sh's Fix 2.
+# The boundary computation is shared with it (fm_pids_with_cwd_under in
+# bin/fm-proc-cwd-lib.sh, which owns why cwd is the right key); the policy is
+# not, and deliberately differs: teardown is fail-closed because it is about to
+# destroy real work, while this sweep is best-effort because a leaked process
+# must never be able to fail a suite.
+#
+# SCOPE IS THE SAFETY PROPERTY. A sweep that could reach a real task's worktree,
+# another suite's tree, or the primary checkout would be worse than the leak it
+# fixes, so two independent conditions must hold before anything is signalled:
+# the directory must carry the .fm-test-fixture marker only fm_test_tmproot
+# writes, and it must sit under TMPDIR. Neither the registry file nor a caller
+# can widen that: an unmarked or non-TMPDIR path is skipped, not swept.
+
+# fm_test_sweepable_root <dir>
+# True only for a path this suite may sweep processes out of.
+fm_test_sweepable_root() {
+  local dir=$1 tmp_base
+  [ -n "$dir" ] || return 1
+  [ -d "$dir" ] && [ ! -L "$dir" ] || return 1
+  [ -f "$dir/.fm-test-fixture" ] || return 1
+  tmp_base=${TMPDIR:-/tmp}
+  tmp_base=${tmp_base%/}
+  tmp_base=$(cd -P -- "$tmp_base" 2>/dev/null && pwd -P) || return 1
+  dir=$(cd -P -- "$dir" 2>/dev/null && pwd -P) || return 1
+  # Whole-component test, so a sibling of TMPDIR sharing its prefix never
+  # qualifies. The root itself is never TMPDIR: it must be strictly beneath it.
+  case "$dir" in "$tmp_base"/?*) return 0 ;; esac
+  return 1
+}
+
+# fm_test_sweep_leaked_processes <dir>
+# TERMs, then KILLs, every process whose cwd is under <dir>. Best-effort and
+# always succeeds: an unsweepable path, an unreadable process list, or a
+# survivor is left for the next run's fm_test_reap_orphans rather than raised.
+#
+# Re-deriving the pid set from the cwd boundary immediately before each signal
+# is what keeps the sweep scoped across the grace period: a pid that left the
+# subtree - or was recycled by a process outside it - is simply absent from the
+# next scan, so the boundary itself is the guard and no separate pid-identity
+# bookkeeping is needed to stay inside the fixture root.
+fm_test_sweep_leaked_processes() {
+  local dir=$1 pids pid
+  fm_test_sweepable_root "$dir" || return 0
+  pids=$(fm_pids_with_cwd_under "$dir" 2>/dev/null) || return 0
+  [ -n "$pids" ] || return 0
+  while IFS= read -r pid; do
+    [ -n "$pid" ] && kill -TERM "$pid" 2>/dev/null
+  done <<EOF
+$pids
+EOF
+  sleep "${FM_TEST_SWEEP_GRACE:-0.5}"
+  pids=$(fm_pids_with_cwd_under "$dir" 2>/dev/null) || return 0
+  [ -n "$pids" ] || return 0
+  while IFS= read -r pid; do
+    [ -n "$pid" ] && kill -KILL "$pid" 2>/dev/null
+  done <<EOF
+$pids
+EOF
+  return 0
+}
+
 fm_test_cleanup() {
   local d
   for d in "${FM_TEST_CLEANUP_DIRS[@]:-}"; do
+    [ -n "$d" ] && fm_test_sweep_leaked_processes "$d"
     [ -n "$d" ] && rm -rf "$d"
   done
   if [ -f "$FM_TEST_CLEANUP_REGISTRY" ]; then
     while IFS= read -r d; do
+      [ -n "$d" ] && fm_test_sweep_leaked_processes "$d"
       [ -n "$d" ] && rm -rf "$d"
     done < "$FM_TEST_CLEANUP_REGISTRY"
     rm -f "$FM_TEST_CLEANUP_REGISTRY"
@@ -142,6 +229,12 @@ fm_test_reap_orphans() {
     mtime=$(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null) || continue
     [ $((now - mtime)) -ge "$FM_TEST_ORPHAN_MAX_AGE_SECONDS" ] || continue
     dir=$(dirname "$marker")
+    # A prior run killed hard enough to skip its traps leaked its processes as
+    # well as its root. The owner checks above have already established this
+    # root has no live owner and is older than the age floor, so anything still
+    # rooted in it is orphaned by definition - and sweeping it here is the only
+    # thing that stops those processes accumulating across runs.
+    fm_test_sweep_leaked_processes "$dir"
     if [ -d "$dir" ] && [ ! -L "$dir" ]; then
       find "$dir" -type d -exec chmod u+rwx {} + 2>/dev/null || true
     fi

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -142,6 +142,11 @@ fm_test_sweepable_root() {
 # always succeeds: an unsweepable path, an unreadable process list, or a
 # survivor is left for the next run's fm_test_reap_orphans rather than raised.
 #
+# The KILL pass is not a formality. Half of each leaked pair is the runtime's
+# pane shell, an interactive login shell that ignores SIGTERM - all 99 found on
+# this machine survived TERM and needed KILL - so a TERM-only sweep would still
+# leak one process per spawning case.
+#
 # Re-deriving the pid set from the cwd boundary immediately before each signal
 # is what keeps the sweep scoped across the grace period: a pid that left the
 # subtree - or was recycled by a process outside it - is simply absent from the


### PR DESCRIPTION
## Intent

Stop firstmate's own test suite leaking orphaned treehouse-get processes (and their child shells) per spawn-exercising test. Production tasks are already covered by bin/fm-teardown.sh's reap_task_worktree_processes, which finds every process whose current working directory is under the task's own worktree or tasktmp root (via lsof -a -d cwd), sends TERM, then KILL after a grace period, scoped so it can never reach another task's processes. The gap: test fixtures never did the equivalent, so a suite's temp root could be deleted out from under still-running subshells, orphaning them. Fix: give the test fixtures (tests/fixtures.sh and friends) the same guarantee by sweeping a test's own temp root for leaked processes before it is deleted, keyed strictly on cwd under that test's own temp root so the sweep can never reach a real task's worktree, another test's tree, or the primary checkout. The shared reap logic was extracted into bin/fm-proc-cwd-lib.sh so both fm-teardown.sh and the test fixtures use one implementation instead of two drifting copies; fm-teardown.sh's own behavior is unchanged and covered by its existing tests. Later accepted follow-up requirement (from code review): the original test-fixture sweep (fm_test_sweep_leaked_processes) scanned for PIDs via cwd, then signalled the raw PID list without re-verifying identity, so a PID that exited and was reused by an unrelated process in that window could be TERM'd or KILL'd by mistake - unlike reap_task_worktree_processes, which captures a process identity per PID, carries pids and identities in parallel arrays, and re-verifies identity immediately before signalling, refusing rather than proceeding when identity can't be determined. This PID-reuse race was fixed by moving identity capture and pre-signal revalidation into the shared bin/fm-proc-cwd-lib.sh so both callers (teardown and the test fixtures) get the same protection, rather than only bolting it onto the test path. A regression test pins the property that a PID present in an earlier scan but no longer the same process at signal time is not signalled. No change to bin/fm-spawn.sh's worktree-acquisition path (switching to 'treehouse get --lease' was explicitly considered and rejected: it strands whole worktrees against a small, non-expandable pool/quota instead of leaking a harmless process, and would require reworking load-bearing settle-detection logic).

## What Changed

- Extracted the cwd-based process-boundary logic (`fm_pids_with_cwd_under`, `fm_proc_reap_identity`, `fm_proc_reap_identity_matches`, `fm_proc_pid_in_list`, `fm_proc_safe_to_signal`) out of `bin/fm-teardown.sh` into a new shared library, `bin/fm-proc-cwd-lib.sh`, and updated `fm-teardown.sh`'s `reap_task_worktree_processes`/`reap_task_backend_process_group` to call the shared functions instead of the local copies it previously carried.
- Added a leaked-process sweep to `tests/lib.sh`'s fixture teardown (`fm_test_sweep_leaked_processes`, gated by a new `fm_test_sweepable_root` check requiring the `.fm-test-fixture` marker and a path strictly under `TMPDIR`) that TERMs then KILLs any process whose cwd is under a test's temp root before the root is deleted, wired into `fm_test_cleanup` and `fm_test_reap_orphans`.
- Made the sweep re-verify each pid's identity (via the shared `fm_proc_safe_to_signal`) against a fresh scan immediately before every TERM/KILL, closing a PID-reuse race where a pid that exited and was recycled by an unrelated process could otherwise be signalled by mistake; added regression coverage in `tests/fm-test-fixture-cleanup.test.sh` for this and the sweep/marker behavior, plus minor updates to `tests/fm-gotmp.test.sh`, `CONTRIBUTING.md`, and `docs/scripts.md`.

## Risk Assessment

✅ Low: The shared cwd-boundary/identity library is extracted cleanly, bin/fm-teardown.sh's reap logic is a mechanical repointing with no behavioral change, the test-fixture sweep mirrors production's fail-safe TERM-then-KILL-with-identity-reverification pattern (including the PID-reuse race fix moved into the shared bin/fm-proc-cwd-lib.sh, matching the intent's follow-up requirement), scope is provably bounded to TMPDIR + marker-carrying roots by dedicated tests, bin/fm-spawn.sh is untouched as required, and all new tests exercise real processes/behavior rather than asserting on source text.

## Testing

Completed 1 recorded test check.

- Outcome: ⏭️ skipped across 1 run (57m44s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c7f108543bdb2c55063b2a229d46db69455dcd68","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"skipped"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
