### PR TITLE
fix(bin): report a cancelled validation run as stopped, not failed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,7 +365,7 @@ Require the matching `resolved` event, forbid `--yes`, and require the worker to
 Resume fleet supervision immediately after the decision lands.
 
 Judge validation by the currently attributed run step through `bin/fm-crew-state.sh`, not by shell liveness or the last status event.
-Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed or checks-passed is done; failed or cancelled is failed.
+Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed or checks-passed is done; failed is failed; cancelled is stopped.
 A worker hand-editing, committing, aborting, or restarting during an active validation run duplicates pipeline ownership outside the supersession sequence above; steer it back to the gate response flow.
 The worker reports the PR when CI first becomes green rather than waiting for merge monitoring to finish.
 

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -35,9 +35,9 @@
 #      cancelled mapping below owns why that is its own terminal word).
 #      EXCEPT: while the active step is ci, `axi status` alone cannot tell
 #      "still waiting on checks" from "checks green, waiting on merge" (see
-#      nm_ci_checks_state) -
-#      a ci-step log-tail check overrides working -> done once checks read
-#      green, so a green PR is never silently read as still-validating.
+#      nm_ci_checks_state) - a ci-step log-tail check overrides working ->
+#      done once checks read green, so a green PR is never silently read as
+#      still-validating.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -477,8 +477,8 @@ if [ "$HAVE_RUN" = 1 ]; then
   RUN_STATUS=""
   if [ "$RUN_SOURCE" = coarse ]; then
     # No step/gate detail is available from the plain runs list - only ever
-    # true/working, done, or failed. A crew genuinely parked at a gate still
-    # gets full detail once `axi status` reports its own branch again (e.g.
+    # true/working, done, stopped, or failed. A crew genuinely parked at a gate
+    # still gets full detail once `axi status` reports its own branch again (e.g.
     # once its own step is the most-recently-touched one), and its own
     # needs-decision/blocked status-log append (a captain-relevant VERB) is
     # surfaced by each supervisor's span classification (fm-classify-lib.sh's
@@ -514,7 +514,13 @@ if [ "$HAVE_RUN" = 1 ]; then
     # genuinely did not complete - so a stopped run gets its own terminal word.
     # Nothing else narrows: fm-classify-lib.sh's crew_absorb_class absorbs a
     # wake only for `working`/`paused`, which a cancelled run was not before
-    # this and is not now, and every other reader renders the word verbatim.
+    # this and is not now, and bin/fm-fleet-snapshot.sh's in-flight inventory
+    # check counts `stopped` as terminal alongside `done`/`failed`; every other
+    # reader renders the word verbatim. Accepted consequence: a cancelled run
+    # that is then abandoned gets no durable outcome record and no captain
+    # presentation from bin/fm-inactive-reconcile.sh, and shows only in the
+    # fleet table as stopped / run-step - the deliberate price of not asserting
+    # a failure that did not happen.
     if [ -n "$outcome" ]; then
       case "$outcome" in
         passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR merged/closed" ;;

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -15,7 +15,7 @@
 # fixed mapping logic, no heuristics and no LLM. Output is one stable, parseable,
 # token-tight line firstmate can read every heartbeat:
 #
-#   state: <working|parked|done|blocked|paused|failed|unknown> · source: <run-step|pane|status-log|remote-endpoint|none> · <detail>
+#   state: <working|parked|done|blocked|paused|stopped|failed|unknown> · source: <run-step|pane|status-log|remote-endpoint|none> · <detail>
 #
 # Logic, in order:
 #   1. Resolve worktree + backend target + kind from state/<id>.meta. A meta
@@ -30,9 +30,12 @@
 #      pipeline-custody, and newest-first rules owned by bin/fm-nm-run-lib.sh.
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
-#      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
-#      the active step is ci, `axi status` alone cannot tell "still waiting on
-#      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
+#      passed/checks-passed -> done, failed -> failed, and cancelled -> stopped
+#      (a cancellation is somebody stopping the run, not the work failing; the
+#      cancelled mapping below owns why that is its own terminal word).
+#      EXCEPT: while the active step is ci, `axi status` alone cannot tell
+#      "still waiting on checks" from "checks green, waiting on merge" (see
+#      nm_ci_checks_state) -
 #      a ci-step log-tail check overrides working -> done once checks read
 #      green, so a green PR is never silently read as still-validating.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
@@ -485,7 +488,8 @@ if [ "$HAVE_RUN" = 1 ]; then
       running)   RUN_STATE=working; RUN_DETAIL="validating (background run)" ;;
       completed) RUN_STATE="done";  RUN_DETAIL="run completed" ;;
       failed)    RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
-      cancelled) RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
+      # cancelled -> stopped, not failed; the outcome mapping below owns why.
+      cancelled) RUN_STATE=stopped; RUN_DETAIL="run cancelled" ;;
       *)         RUN_STATE=unknown; RUN_DETAIL="runs list status: $COARSE_STATUS" ;;
     esac
   else
@@ -497,12 +501,26 @@ if [ "$HAVE_RUN" = 1 ]; then
     has_gate=0
     nm_has_gate && has_gate=1
 
+    # `cancelled` -> `stopped`, deliberately NOT `failed`. A failure means the
+    # work did not pass; a cancellation means somebody stopped the run, and
+    # `no-mistakes axi abort` exists precisely so an orphaned CI monitor can be
+    # reaped after its worker is gone. Collapsing the two asserted a failure the
+    # evidence did not support - and not only as a label: the one consumer that
+    # keys on this word as a captain-facing terminal outcome
+    # (bin/fm-inactive-reconcile.sh) records a durable outcome and wakes the
+    # supervisor for `done` or `failed` alone, so reaping the monitor of work
+    # whose checks were already green raised a failure escalation for an open,
+    # mergeable PR. `done` would be the opposite error - a cancelled run
+    # genuinely did not complete - so a stopped run gets its own terminal word.
+    # Nothing else narrows: fm-classify-lib.sh's crew_absorb_class absorbs a
+    # wake only for `working`/`paused`, which a cancelled run was not before
+    # this and is not now, and every other reader renders the word verbatim.
     if [ -n "$outcome" ]; then
       case "$outcome" in
         passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR merged/closed" ;;
         checks-passed) RUN_STATE="done"; RUN_DETAIL="checks green: PR ready for review" ;;
         failed)        RUN_STATE=failed; RUN_DETAIL="run failed" ;;
-        cancelled)     RUN_STATE=failed; RUN_DETAIL="run cancelled" ;;
+        cancelled)     RUN_STATE=stopped; RUN_DETAIL="run cancelled" ;;
         *)             RUN_STATE=unknown; RUN_DETAIL="outcome: $outcome" ;;
       esac
     elif [ -n "$awaiting" ] || [ "$status" = awaiting_approval ] || [ "$status" = fix_review ] || [ -n "$gate_status" ] || [ "$has_gate" = 1 ]; then
@@ -526,7 +544,7 @@ if [ "$HAVE_RUN" = 1 ]; then
         running|fixing) RUN_STATE=working; RUN_DETAIL="validating ($status)" ;;
         completed)      RUN_STATE="done"; RUN_DETAIL="run completed" ;;
         failed)         RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
-        cancelled)      RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
+        cancelled)      RUN_STATE=stopped; RUN_DETAIL="run cancelled" ;;
         "")             RUN_STATE=working; RUN_DETAIL="run active" ;;
         *)              RUN_STATE=working; RUN_DETAIL="run active ($status)" ;;
       esac

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -728,7 +728,7 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     | ([ $owned_in_flight[] as $work
          | $tasks[]
          | select(.kind != "secondmate")
-         | select(.id == $work.id and (.current_state.state == "done" or .current_state.state == "failed"))
+         | select(.id == $work.id and (.current_state.state == "done" or .current_state.state == "failed" or .current_state.state == "stopped"))
          | {id,state:.current_state.state} ]) as $terminal_in_flight
     | ([if $backlog.present != true then
           {kind:"missing_backlog",ids:[],reason:"missing structured backlog"}

--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -49,8 +49,8 @@
 # fm-crew-state.sh as the sole current-state source.
 # Only a done or failed state is suspicious enough to create a durable terminal
 # outcome record or wake the supervisor.
-# Working, paused, parked, blocked, unknown, persistent secondmates, and
-# captain-held work retain their existing supervision semantics.
+# Working, paused, parked, blocked, stopped, unknown, persistent secondmates,
+# and captain-held work retain their existing supervision semantics.
 #
 # A terminal-outcomes/<fingerprint>.pending record remains until its upstream
 # receipt is durable.

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -291,6 +291,50 @@ outcome: failed
 EOF
 }
 
+# A run that was CANCELLED after its work had already succeeded: every step
+# completed through `pr`, a PR exists, and only the CI monitor was torn down by
+# the abort. Copied from a real aborted run's `axi status` (both `status:` and
+# `outcome:` read cancelled, with an `error:` naming the abort). Nothing here
+# failed review, tests, lint or docs - the run was stopped, not failed.
+run_cancelled_after_green() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: cancelled
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: "https://github.com/o/r/pull/3"
+  findings: none
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,4
+    rebase,completed,0,5241
+    review,completed,0,779029
+    test,completed,0,481032
+    document,completed,0,425469
+    lint,completed,0,8
+    push,completed,0,8235
+    pr,completed,0,39266
+    ci,failed,0,317773
+outcome: cancelled
+error: "cancelled: aborted by user"
+EOF
+}
+
+# The same cancellation seen before an `outcome:` line is written: only the
+# top-level `status:` says cancelled. This is the reader's other cancelled
+# branch and must map the same way.
+run_cancelled_status_only() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: cancelled
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: "https://github.com/o/r/pull/3"
+  findings: none
+EOF
+}
+
 run_ci_monitoring() {  # <branch>
   cat <<EOF
 run:
@@ -682,6 +726,86 @@ test_terminal_failed() {
   assert_contains "$out" "state: failed" "failed run -> failed"
   assert_contains "$out" "source: run-step" "failed -> run-step source"
   pass "terminal failed run is authoritative"
+}
+
+# A CANCELLED run is not a failed run. `no-mistakes axi abort` exists so an
+# orphaned CI monitor can be reaped after its worker is gone, and doing exactly
+# that on work whose checks were already green used to make this reader answer
+# `state: failed`. That is not a cosmetic mislabel: bin/fm-inactive-reconcile.sh
+# only records a durable terminal outcome and wakes the supervisor for a `done`
+# or `failed` state, so a deliberate abort of finished work manufactured a
+# failure escalation for a green, open, mergeable PR.
+#
+# `done` would be the opposite error - a cancelled run genuinely did not
+# complete - so the honest answer is a distinct terminal state, `stopped`,
+# whose detail says the run was cancelled.
+test_terminal_cancelled_after_green_is_stopped_not_failed() {
+  reset_fakes
+  local d; d=$(new_case cancelled-after-green)
+  make_repo_on_branch "$d/wt" fm/feat-cancel-a
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cancel-a.meta" "window=fm:fm-feat-cancel-a" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_cancelled_after_green fm/feat-cancel-a)"
+  local out; out=$(run_crew_state "$d" feat-cancel-a)
+  assert_not_contains "$out" "state: failed" "a cancelled run must not be reported as a failure"
+  assert_not_contains "$out" "state: done" "a cancelled run must not be reported as a success either"
+  assert_contains "$out" "state: stopped" "cancelled outcome -> stopped"
+  assert_contains "$out" "run cancelled" "the detail names the cancellation"
+  assert_contains "$out" "source: run-step" "cancelled -> run-step source"
+  pass "a cancelled run whose work had already passed is stopped, not failed"
+}
+
+# The other cancelled branch: top-level `status: cancelled` with no `outcome:`
+# line yet.
+test_terminal_cancelled_status_without_outcome_is_stopped() {
+  reset_fakes
+  local d; d=$(new_case cancelled-status-only)
+  make_repo_on_branch "$d/wt" fm/feat-cancel-b
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cancel-b.meta" "window=fm:fm-feat-cancel-b" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_cancelled_status_only fm/feat-cancel-b)"
+  local out; out=$(run_crew_state "$d" feat-cancel-b)
+  assert_not_contains "$out" "state: failed" "a cancelled status must not be reported as a failure"
+  assert_contains "$out" "state: stopped" "cancelled status -> stopped"
+  assert_contains "$out" "run cancelled" "the detail names the cancellation"
+  pass "a cancelled status without an outcome line is stopped, not failed"
+}
+
+# The coarse runs-list path maps the same way: `no-mistakes runs` prints a
+# `cancelled` row for the same run.
+test_coarse_cancelled_row_is_stopped_not_failed() {
+  reset_fakes
+  local d short; d=$(new_case cancelled-coarse)
+  make_repo_on_branch "$d/wt" fm/feat-cancel-c
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cancel-c.meta" "window=fm:fm-feat-cancel-c" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="  cancelled  fm/feat-cancel-c ${short}  2026-09-02 11:42  https://github.com/o/r/pull/3"
+  local out; out=$(run_crew_state "$d" feat-cancel-c)
+  assert_not_contains "$out" "state: failed" "a coarse cancelled row must not be reported as a failure"
+  assert_contains "$out" "state: stopped" "coarse cancelled row -> stopped"
+  assert_contains "$out" "run cancelled" "the detail names the cancellation"
+  pass "a coarse cancelled row is stopped, not failed"
+}
+
+# Negative control for the pair above: the distinction only means something if a
+# genuine FAILURE still reports `failed` on the same coarse path. If this ever
+# drifted to `stopped` too, the split would be cosmetic and a real failed run
+# would stop reaching the supervisor.
+test_coarse_failed_row_still_reports_failed() {
+  reset_fakes
+  local d short; d=$(new_case failed-coarse-control)
+  make_repo_on_branch "$d/wt" fm/feat-cancel-d
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cancel-d.meta" "window=fm:fm-feat-cancel-d" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="  failed     fm/feat-cancel-d ${short}  2026-09-02 11:42"
+  local out; out=$(run_crew_state "$d" feat-cancel-d)
+  assert_not_contains "$out" "state: stopped" "a failed run must not be softened into stopped"
+  assert_contains "$out" "state: failed" "a genuinely failed run still reports failed"
+  pass "a genuine coarse failure still reports failed"
 }
 
 # (e) cross-branch attribution: `axi status` returns ANOTHER branch's run (the
@@ -1568,6 +1692,10 @@ test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
 test_terminal_passed
 test_terminal_failed
+test_terminal_cancelled_after_green_is_stopped_not_failed
+test_terminal_cancelled_status_without_outcome_is_stopped
+test_coarse_cancelled_row_is_stopped_not_failed
+test_coarse_failed_row_still_reports_failed
 test_cross_branch_attribution_via_runs_list
 test_cross_branch_attribution_picks_most_recent_row
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status


### PR DESCRIPTION
## Intent

Fix a defect in bin/fm-crew-state.sh and contribute it upstream to this project (kunchenguid/firstmate), based on current main, kept small and obviously correct for a maintainer with none of the contributor's context.

THE BUG: bin/fm-crew-state.sh reports a task as FAILED when its validation run was CANCELLED. That is wrong whenever the cancellation was deliberate, and it does not merely mislabel a row - it manufactures a false escalation.

WHAT HAPPENED, TWICE IN ONE DAY: the tool provides 'no-mistakes axi abort --run <id>' specifically so an orphaned CI monitor can be reaped after its worker is gone; its own help says so. Doing exactly that, on work whose checks were already GREEN and whose pull request was open and mergeable, made the task read 'state: failed - source: run-step - run cancelled'. Supervision then surfaced it on its own as an inactive terminal outcome awaiting presentation, for a pull request that was open, mergeable and had zero failing checks. Had nobody been watching, a success would have been reported as a failure.

THE SITES: three mappings in bin/fm-crew-state.sh, all collapsing the same way (the coarse runs-list row, outcome: cancelled, and top-level status: cancelled), plus the contract comment in the file header stating the same intent.

WHAT IS WRONG AND WHAT IS NOT: cancelled is not failed. A failure means the work did not pass; a cancellation means somebody stopped the run. Those are different outcomes with different consequences, and collapsing them asserts something the evidence does not support - the same defect class as the merge claim already fixed in this file, where outcome=passed was rendered as 'PR merged/closed' for runs that merged nothing. It was explicitly ruled out to simply relabel it 'done': a cancelled run genuinely did not complete, and calling it success would be the opposite error. The accepted reading is a distinct terminal state meaning stopped, whose detail says the run was cancelled rather than that it failed.

DECISIONS MADE DELIBERATELY WHILE DOING THE WORK, all three of which were required to be decided and explained rather than assumed:
1. Terminal state: cancelled now maps to a new terminal word 'stopped', added to the file header's documented output vocabulary. Not 'done' (the run genuinely did not complete) and not 'unknown' (that word means no reliable current-state source exists, whereas here the source is authoritative and says exactly what happened). The detail string 'run cancelled' is deliberately unchanged, so only the state word moves.
2. Whether the status log should win when it records a declared wait: decided NO, deliberately. In both real cases a paused: line naming the wait was already in the status log and was lost to the run-step source. Granting the log precedence over an authoritative terminal run-step was rejected because it would reintroduce the exact staleness this reader exists to prevent - the status log is an append-only event log that goes stale, so a paused: line left behind by a wait that has since cleared would mask a genuinely dead task as a healthy declared wait. A stopped crew still surfaces normally, so nothing is lost by leaving precedence with the run-step. This is a deliberate non-change; do not flag the absence of log precedence as an oversight.
3. What keys on 'failed' downstream: every consumer of this reader's output was swept rather than assumed. Exactly two read the state word as a decision - bin/fm-inactive-reconcile.sh, whose allowlist is 'done' or 'failed' alone and which is the consumer that manufactured the false escalation, and fm-classify-lib.sh's crew_absorb_class, whose allowlist is 'working' or 'paused' with everything else defaulting to surfacing the wake. 'stopped' correctly falls outside the first allowlist (this is the fix) and behaves identically to 'failed' in the second (a cancelled run was in neither before and is in neither now, so a stopped crew still surfaces exactly as before). bin/fm-fleet-view.sh, bin/fm-fleet-snapshot.sh and bin/fm-bearings-snapshot.sh render the state word verbatim or test only for 'working', so all are unaffected. Their test suites were run and pass.

SCOPE CONSTRAINT AND ITS ONE DELIBERATE, APPROVED EXCEPTION: the change was scoped to two files, the reader and its tests, and must not widen beyond making this outcome honest or restructure the reader. A third file, AGENTS.md, was then explicitly approved after being escalated rather than taken unilaterally, because AGENTS.md's validation-judgment line stated this reader's contract as 'failed or cancelled is failed' - the defect at doctrine level. Shipping the reader fix while leaving that sentence asserting the opposite of the code would leave the next reader unable to tell which is authoritative. The approved edit was strictly ONE line, correcting the statement to match the behaviour and nothing else: no restructuring of the section, no added commentary, no explanation of the change there, because the explanation belongs in the pull request body. This three-file change is deliberate and approved, not scope drift.

TESTS: red then green, to the bar the existing tests in tests/fm-crew-state.test.sh already set, which includes a negative test proving a guard is real by making it fail without the guard. Required coverage was the case that actually bit: a run whose steps all succeeded and whose PR is green, cancelled afterwards, must not read as failed. The fixture for that case was copied from the real aborted run's actual axi status output rather than invented. Three cancelled tests were added (outcome-cancelled after green, status-cancelled without an outcome line, and the coarse runs-list row) and each was individually verified to FAIL against the old mapping. A fourth is a negative control pinning that a genuine failure still reports 'failed', verified to fail if 'failed' is ever softened into 'stopped', so the split cannot become cosmetic.

VERIFICATION ALREADY RUN LOCALLY: the full tests/fm-crew-state.test.sh suite passes; the adjacent consumer suites fm-inactive-reconcile, fm-classify-corr-token, fm-classify-decision-key, fm-fleet-snapshot-view and fm-bearings-snapshot pass; bin/fm-lint.sh is clean; bin/fm-doc-audience-check.sh is clean. The change is independent of any harness and any runtime backend - it sits in the no-mistakes run-status mapping, upstream of every harness or backend read, and is not a harness-dependent check in the sense of the repo's coding guideline, so no live-harness guard or runtime-backends evidence refresh is owed.

DELIVERY: this is an outside contribution, so the pull request body must be written for a maintainer who has never seen the contributor's environment - the symptom, how it reproduces, why cancelled and failed are different, what the tests prove, and one sentence saying AGENTS.md was touched and why. The body must not reference the contributor's internal task ids, operators, workers, or hosting. Do not merge; it is not the contributor's repository to merge into. This project requires maintainer approval before checks will run on a fork contribution, so green checks may not be reachable from the contributor's side.

## What Changed

- `bin/fm-crew-state.sh` maps a cancelled run to a new terminal state word `stopped` instead of `failed`, at all three mapping sites (the coarse runs-list row, `outcome: cancelled`, and top-level `status: cancelled`). The detail string stays `run cancelled` and a genuine failure still reads `failed`, so only the state word moves. This was not a cosmetic mislabel: `bin/fm-inactive-reconcile.sh` records a durable terminal outcome and wakes the supervisor for a `done` or `failed` state alone, so using `no-mistakes axi abort` to reap an orphaned CI monitor - which is exactly what that command is documented for - made finished work whose checks were already green surface as a failure escalation for an open, mergeable PR. `done` would be the opposite error, since a cancelled run genuinely did not complete, hence a distinct word.
- `bin/fm-fleet-snapshot.sh` now counts `stopped` alongside `done`/`failed` in its terminal in-flight inventory-drift check, so the new word does not silently drop out of that signal. The contract headers in `bin/fm-crew-state.sh` and `bin/fm-inactive-reconcile.sh` document `stopped` in their state vocabulary, and one line of `AGENTS.md` is corrected because its validation-judgment rule stated the old contract ("failed or cancelled is failed") and would otherwise assert the opposite of the code.
- `tests/fm-crew-state.test.sh` gains four cases: a run cancelled after every step passed and a PR exists (fixture copied from a real aborted run's `axi status` output rather than invented), a cancellation seen before an `outcome:` line is written, the coarse runs-list `cancelled` row, and a negative control pinning that a genuine coarse failure still reports `failed` so the split cannot drift into being cosmetic. Each cancelled case was verified to fail against the old mapping.

## Risk Assessment

✅ Low: A well-bounded relabel of one terminal outcome across three sibling mappings in a single reader, with every one of the four parsers of that reader's output independently traced and behaviour-preserving except the one deliberate change in bin/fm-inactive-reconcile.sh; the only finding is a comment-accuracy nit with no behavioural consequence.

## Testing

Exercised the fix end-to-end over the real CLIs, not just the unit suite: a hermetic home reproducing the reported incident shows `bin/fm-crew-state.sh` moving from `state: failed` to `state: stopped` on an identical cancelled-after-green run object, and `bin/fm-inactive-reconcile.sh` moving from queueing a captain failure escalation plus a durable terminal-outcome record for an open, green PR to queueing nothing — while a genuinely failed run in the same world still escalates unchanged. Swept the downstream consumers for real: the captain fleet table renders `stopped / run-step`, `crew_absorb_class` is byte-identical before and after so a stopped crew's wake still surfaces, and the `terminal_in_flight` inventory check keeps firing (I reproduced the review-round regression by running the pre-fix `fm-fleet-snapshot.sh` against the fixed reader, where the check went silent). Verified red-then-green by driving each of the three new cancelled tests alone against the base reader — all three fail with the exact pre-fix output — and mutation-checked the fourth negative control by softening the coarse `failed` arm, which makes it fail. `tests/fm-crew-state.test.sh` and the five consumer suites (inactive-reconcile, fleet-snapshot-view, bearings-snapshot, classify-corr-token, classify-decision-key) all pass with zero failures and no flakiness observed. Visual evidence is a rendered before/after of `bin/fm-fleet-view.sh`, the captain-facing surface this state word actually appears on; the remaining artifacts are CLI transcripts because that is the genuine end-user surface for this bash toolbelt. No linters or formatters were run, per the phase rules. Working tree left clean; all scratch was under /tmp and removed.

- Evidence: Captain&#39;s fleet table for a cancelled run, before vs after (rendered) (local file: <code>~/.no-mistakes/evidence/01M1KPETHB508TAFQJJD4TBJT5/fleet-view-before-after.png</code>)

<details>
<summary>Evidence: Same before/after comparison as rendered HTML</summary>

```text
<!doctype html><meta charset=utf-8>
<title>fm-fleet-view.sh - a cancelled validation run, before and after</title>
<style>
 html,body{height:auto}body{background:#12141a;color:#d7dae0;font:14px/1.55 ui-monospace,"JetBrains Mono","SF Mono",Menlo,monospace;margin:0;padding:30px 32px 26px}
 h1{font:600 20px/1.3 ui-sans-serif,system-ui;margin:0 0 6px;color:#f2f4f8}
 p.sub{font:13px/1.5 ui-sans-serif,system-ui;color:#9aa2b1;margin:0 0 26px;max-width:96ch}
 .cols{display:grid;grid-template-columns:1fr 1fr;gap:22px}
 .pane{background:#0b0d12;border:1px solid #262b36;border-radius:10px;overflow:hidden}
 .bar{display:flex;align-items:center;gap:8px;padding:9px 14px;background:#171b23;border-bottom:1px solid #262b36;
      font:12px/1 ui-sans-serif,system-ui;color:#aab2c0;letter-spacing:.02em}
 .dot{width:9px;height:9px;border-radius:50%}
 .r{background:#ff5f57}.y{background:#febc2e}.g{background:#28c840}
 .tag{margin-left:auto;font:11px/1 ui-sans-serif,system-ui;padding:3px 8px;border-radius:999px}
 .tag.before{background:#3a1d1f;color:#ff8f88;border:1px solid #5a2a2c}
 .tag.after{background:#12301d;color:#6ee787;border:1px solid #1f5233}
 pre{margin:0;padding:16px 18px;white-space:pre-wrap;overflow-wrap:anywhere;font-size:12.5px;color:#c9cdd6}
 .prompt{color:#6ee787}
 .bad{background:#4a1d20;color:#ff9b93;padding:1px 5px;border-radius:4px;font-weight:600}
 .good{background:#173b23;color:#7ee7a0;padding:1px 5px;border-radius:4px;font-weight:600}
 footer{margin-top:24px;font:12.5px/1.6 ui-sans-serif,system-ui;color:#8b93a3;max-width:110ch}
 code{background:#1b1f28;padding:1px 5px;border-radius:4px;color:#c9cdd6}
</style>
<h1>The captain's fleet table for a <em>cancelled</em> validation run</h1>
<p class="sub">Same crew, same <code>no-mistakes axi status</code> output: every step completed through <code>pr</code>,
the PR is open and green, and only the orphaned CI monitor was reaped with <code>no-mistakes axi abort</code>.
The only difference between the two panes is <code>bin/fm-crew-state.sh</code>.</p>
<div class="cols">
 <div class="pane">
  <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
   bin/fm-fleet-view.sh<span class="tag before">before &middot; 3d2a08b</span></div>
  <pre><span class="prompt">$</span> bin/fm-fleet-view.sh

# Fleet View

Schema: fm-fleet-snapshot.v1
Home: /tmp/fmev/w-fix

## Under Way
| ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| feat-green | <span class="bad">failed / run-step</span> | ship | firstmate | tmux | absent | https://github.com/kunchenguid/firstmate/pull/3 | /tmp/fmev/w-fix/projects/feat-green | bin/fm-peek.sh fm-feat-green |

## Queued
No queued backlog records found.

## Done
No done backlog records found.

## Secondmates
For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority.</pre>
 </div>
 <div class="pane">
  <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
   bin/fm-fleet-view.sh<span class="tag after">after &middot; 1220fa2</span></div>
  <pre><span class="prompt">$</span> bin/fm-fleet-view.sh

# Fleet View

Schema: fm-fleet-snapshot.v1
Home: /tmp/fmev/w-fix

## Under Way
| ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| feat-green | <span class="good">stopped / run-step</span> | ship | firstmate | tmux | absent | https://github.com/kunchenguid/firstmate/pull/3 | /tmp/fmev/w-fix/projects/feat-green | bin/fm-peek.sh fm-feat-green |

## Queued
No queued backlog records found.

## Done
No done backlog records found.

## Secondmates
For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority.</pre>
 </div>
</div>
<footer>The left pane asserts a failure that never happened. Worse than the label: <code>bin/fm-inactive-reconcile.sh</code>
records a durable terminal outcome and wakes the captain for <code>done</code> or <code>failed</code> alone, so the left
state raises a failure escalation for an open, mergeable PR with zero failing checks. The right pane states what actually
happened - somebody stopped the run - and the detail string is unchanged.</footer>
```
</details>
<details>
<summary>Evidence: The false escalation, reproduced and then gone (fm-inactive-reconcile.sh over the real reader)</summary>

<code>### BEFORE - bin/fm-crew-state.sh @ 3d2a08b&#10;$ bin/fm-inactive-reconcile.sh scan --startup&#10;actionable: inactive terminal outcome awaiting captain presentation: child=feat-green state=failed pr=https://github.com/kunchenguid/firstmate/pull/3&#10;$ ls state/terminal-outcomes/&#10;fdae3c5d2dbc679de6d3f051b55486d5.pending&#10;&#10;=&gt; a failure escalation raised for an open, mergeable PR with zero failing checks.&#10;&#10;### AFTER - bin/fm-crew-state.sh @ 1220fa2&#10;$ bin/fm-inactive-reconcile.sh scan --startup&#10;(no output - nothing actionable)&#10;$ cat state/.wake-queue&#10;(empty - no captain wake queued)&#10;$ ls state/terminal-outcomes/&#10;(empty - no durable failure record)&#10;&#10;### negative control: the run GENUINELY failed, same fixed reader&#10;$ bin/fm-crew-state.sh feat-green&#10;state: failed · source: run-step · run failed&#10;$ bin/fm-inactive-reconcile.sh scan --startup&#10;actionable: inactive terminal outcome awaiting captain presentation: child=feat-green state=failed pr=https://github.com/kunchenguid/firstmate/pull/3&#10;&#10;=&gt; a real failure still reaches the captain, unchanged.</code>

```text
----------------------------------------------------------------------------
STEP 2 - the symptom the intent reports: supervision escalating a green PR
----------------------------------------------------------------------------

bin/fm-inactive-reconcile.sh is the consumer that keys on this word. It
creates a durable terminal-outcome record and wakes the captain for a
'done' or 'failed' state alone. Run below against the REAL reader in a
main home whose only crew is the cancelled run above.

\### BEFORE - bin/fm-crew-state.sh @ 3d2a08b
$ bin/fm-inactive-reconcile.sh scan --startup
    actionable: inactive terminal outcome awaiting captain presentation: child=feat-green state=failed pr=https://github.com/kunchenguid/firstmate/pull/3
$ cat state/.wake-queue
    1788452362	1	check	inactive-outcome:fdae3c5d2dbc679de6d3f051b55486d5	inactive terminal outcome awaiting captain presentation: child=feat-green state=failed pr=https://github.com/kunchenguid/firstmate/pull/3
$ ls state/terminal-outcomes/
    fdae3c5d2dbc679de6d3f051b55486d5.pending

  => a failure escalation raised for an open, mergeable PR with zero
     failing checks. This is the false escalation described in the intent.

\### AFTER - bin/fm-crew-state.sh @ 1220fa2
$ bin/fm-inactive-reconcile.sh scan --startup
    (no output - nothing actionable)
$ cat state/.wake-queue
    (empty - no captain wake queued)
$ ls state/terminal-outcomes/
    (empty - no durable failure record)

----------------------------------------------------------------------------
STEP 3 - negative control: the split is not a blanket softening
----------------------------------------------------------------------------

Same world, same fixed reader, but the run GENUINELY failed
(review found 3 blocking findings; status/outcome: failed).

$ bin/fm-crew-state.sh feat-green
    state: failed · source: run-step · run failed
$ bin/fm-inactive-reconcile.sh scan --startup
    actionable: inactive terminal outcome awaiting captain presentation: child=feat-green state=failed pr=https://github.com/kunchenguid/firstmate/pull/3
$ ls state/terminal-outcomes/
    fdae3c5d2dbc679de6d3f051b55486d5.pending

  => a real failure still reaches the captain, unchanged.
```
</details>
<details>
<summary>Evidence: The reader&#39;s answer on the real aborted-run fixture, base vs target</summary>

<code>$ bin/fm-crew-state.sh feat-green # base 3d2a08b (before the fix)&#10;state: failed · source: run-step · run cancelled&#10;^^^^^^ a failure that never happened&#10;&#10;$ bin/fm-crew-state.sh feat-green # target 1220fa2 (after the fix)&#10;state: stopped · source: run-step · run cancelled&#10;^^^^^^^ its own terminal word; detail unchanged&#10;&#10;(status log carried `paused: waiting on CI checks` in both runs - the authoritative&#10;run-step still wins, which is decision 2 holding.)</code>

```text
============================================================================
 CANCELLED != FAILED - end-to-end reproduction over the real firstmate CLI
============================================================================

Scenario (the incident from the intent, rebuilt hermetically):
  a crew's validation run reached 'pr' with every step completed, its PR is
  open on GitHub, and only the orphaned CI monitor was reaped with
  'no-mistakes axi abort --run <id>'. Nothing failed review, test, lint or docs.

The run object the reader sees (`no-mistakes axi status`, verbatim):
    run:
      id: "01K9ABORTEDRUN"
      branch: fm/feat-green
      status: cancelled
      head: "c30026ae3e488c7229e571f4fc3f821ca9d442be"
      pr: "https://github.com/kunchenguid/firstmate/pull/3"
      findings: none
      steps[9]{step,status,findings,duration_ms}:
        intent,completed,0,4
        rebase,completed,0,5241
        review,completed,0,779029
        test,completed,0,481032
        document,completed,0,425469
        lint,completed,0,8
        push,completed,0,8235
        pr,completed,0,39266
        ci,failed,0,317773
    outcome: cancelled
    error: "cancelled: aborted by user"

The status log the worker left behind (decision 2: the run-step still wins):
    paused: waiting on CI checks

----------------------------------------------------------------------------
STEP 1 - what the reader answers
----------------------------------------------------------------------------

$ bin/fm-crew-state.sh feat-green          # base 3d2a08b (before the fix)
  state: failed · source: run-step · run cancelled
                                              ^^^^^^ a failure that never happened

$ bin/fm-crew-state.sh feat-green          # target 1220fa2 (after the fix)
  state: stopped · source: run-step · run cancelled
                                              ^^^^^^^ its own terminal word; detail unchanged
```
</details>
<details>
<summary>Evidence: Downstream consumers driven for real, including the review-round terminal_in_flight fix</summary>

<code>## fm-fleet-snapshot.sh --secondmate-home-summary (in-flight backlog row, cancelled child)&#10;&#10;# fleet-snapshot @95cfad7 (reader fix only, no review-round fix)&#10;{&#34;valid&#34;:true,&#34;invalidity&#34;:{&#34;kind&#34;:null,&#34;ids&#34;:[]},&#34;reason&#34;:null}&#10;=&gt; the drift signal went SILENT: &#39;stopped&#39; was outside the terminal set.&#10;&#10;# target 1220fa2&#10;{&#34;valid&#34;:false,&#34;invalidity&#34;:{&#34;kind&#34;:&#34;terminal_in_flight&#34;,&#34;ids&#34;:[&#34;feat-green&#34;]},&#34;reason&#34;:&#34;in-flight backlog item has terminal child state: feat-green=stopped&#34;}&#10;=&gt; the signal fires again, now naming the state honestly.&#10;&#10;## fm-classify-lib.sh wake absorption - unchanged in both directions&#10;base 3d2a08b -&gt; crew_absorb_class=none crew_is_provably_working=no (wake surfaces)&#10;target 1220fa2 -&gt; crew_absorb_class=none crew_is_provably_working=no (wake surfaces)</code>

```text
----------------------------------------------------------------------------
STEP 4 - every downstream consumer of the state word, exercised for real
----------------------------------------------------------------------------

## 4a. bin/fm-fleet-view.sh - the captain's fleet table
     (renders the word verbatim; this is the surface a captain actually reads)

$ bin/fm-fleet-view.sh                     # base 3d2a08b
    ## Under Way
    | ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
    | --- | --- | --- | --- | --- | --- | --- | --- | --- |
    | feat-green | failed / run-step | ship | firstmate | tmux | absent | https://github.com/kunchenguid/firstmate/pull/3 | /tmp/fmev/w-fix/projects/feat-green | bin/fm-peek.sh fm-feat-green |
    
$ bin/fm-fleet-view.sh                     # target 1220fa2
    ## Under Way
    | ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
    | --- | --- | --- | --- | --- | --- | --- | --- | --- |
    | feat-green | stopped / run-step | ship | firstmate | tmux | absent | https://github.com/kunchenguid/firstmate/pull/3 | /tmp/fmev/w-fix/projects/feat-green | bin/fm-peek.sh fm-feat-green |
    

## 4b. bin/fm-fleet-snapshot.sh --secondmate-home-summary
     The one consumer that tests the word rather than rendering it: an
     in-flight backlog row whose child has gone terminal is inventory drift.
     Same home, same cancelled run, in-flight backlog row for feat-green.

$ bin/fm-fleet-snapshot.sh --secondmate-home-summary   # fleet-snapshot @95cfad7 (reader fix only)
    {"valid":true,"invalidity":{"kind":null,"ids":[]},"reason":null}
     => the drift signal went SILENT: 'stopped' was outside the terminal set.

$ bin/fm-fleet-snapshot.sh --secondmate-home-summary   # target 1220fa2 (review-round fix)
    {"valid":false,"invalidity":{"kind":"terminal_in_flight","ids":["feat-green"]},"reason":"in-flight backlog item has terminal child state: feat-green=stopped"}
     => the signal fires again, now naming the state honestly.

## 4c. bin/fm-classify-lib.sh crew_absorb_class - the wake-absorption allowlist
     'working'/'paused' absorb a wake; anything else surfaces it. A cancelled
     run was in neither before and is in neither now, so a stopped crew still
     surfaces exactly as it used to.

    base   3d2a08b -> crew_absorb_class=none  crew_is_provably_working=no (wake surfaces)
    target 1220fa2 -> crew_absorb_class=none  crew_is_provably_working=no (wake surfaces)
```
</details>
<details>
<summary>Evidence: Red-then-green: each new test failing against the pre-fix reader, control mutation-checked</summary>

<code>RED test_terminal_cancelled_after_green_is_stopped_not_failed&#10;not ok - a cancelled run must not be reported as a failure (unexpected: &#39;state: failed&#39;)&#10;RED test_terminal_cancelled_status_without_outcome_is_stopped&#10;not ok - a cancelled status must not be reported as a failure (unexpected: &#39;state: failed&#39;)&#10;RED test_coarse_cancelled_row_is_stopped_not_failed&#10;not ok - a coarse cancelled row must not be reported as a failure (unexpected: &#39;state: failed&#39;)&#10;&#10;MUTANT failed) RUN_STATE=failed -&gt; failed) RUN_STATE=stopped&#10;not ok - a failed run must not be softened into stopped (unexpected: &#39;state: stopped&#39;)&#10;&#10;GREEN on target:&#10;ok - a cancelled run whose work had already passed is stopped, not failed&#10;ok - a cancelled status without an outcome line is stopped, not failed&#10;ok - a coarse cancelled row is stopped, not failed&#10;ok - a genuine coarse failure still reports failed&#10;FM_TEST_SUMMARY total=1 failed=0 (tests/fm-crew-state.test.sh)&#10;FM_TEST_SUMMARY total=5 failed=0 (the five consumer suites)</code>

```text
----------------------------------------------------------------------------
STEP 5 - red-then-green: each new test verified to FAIL against the old code
----------------------------------------------------------------------------

Each of the three cancelled cases below was run alone against
bin/fm-crew-state.sh as it stood at base 3d2a08b (the suite aborts on the
first failure, so they are driven one at a time).

RED  test_terminal_cancelled_after_green_is_stopped_not_failed
       not ok - a cancelled run must not be reported as a failure (unexpected: 'state: failed')
       --- output ---
       state: failed · source: run-step · run cancelled

RED  test_terminal_cancelled_status_without_outcome_is_stopped
       not ok - a cancelled status must not be reported as a failure (unexpected: 'state: failed')
       --- output ---
       state: failed · source: run-step · run cancelled

RED  test_coarse_cancelled_row_is_stopped_not_failed
       not ok - a coarse cancelled row must not be reported as a failure (unexpected: 'state: failed')
       --- output ---
       state: failed · source: run-step · run cancelled

The fourth added case is a negative control: a genuine failure must still
read 'failed'. It passes both before and after the fix (it pins a property
that must NOT move), so it was mutation-checked instead - the coarse
'failed' arm was softened to 'stopped' in the fixed reader:

MUTANT  failed) RUN_STATE=failed  ->  failed) RUN_STATE=stopped
        not ok - a failed run must not be softened into stopped (unexpected: 'state: stopped')
        --- output ---
        state: stopped · source: run-step · run failed

----------------------------------------------------------------------------
STEP 6 - GREEN: the suites, unmodified, on the target commit
----------------------------------------------------------------------------

$ bin/fm-test-run.sh tests/fm-crew-state.test.sh
    ok - terminal no-checks ci-monitor marker surfaces done
    ok - terminal passed run is authoritative
    ok - terminal failed run is authoritative
    ok - a cancelled run whose work had already passed is stopped, not failed
    ok - a cancelled status without an outcome line is stopped, not failed
    ok - a coarse cancelled row is stopped, not failed
    ok - a genuine coarse failure still reports failed
    ok - a genuinely failed run with no later run is not hidden
    all fm-crew-state tests passed
    FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=6193

$ bin/fm-test-run.sh tests/fm-inactive-reconcile.test.sh tests/fm-fleet-snapshot-view.test.sh \
      tests/fm-bearings-snapshot.test.sh tests/fm-classify-corr-token.test.sh tests/fm-classify-decision-key.test.sh
    FM_TEST_SUMMARY total=5 failed=0 skipped_gate=0 duration_ms=141730
```
</details>
<details>
<summary>Evidence: Evidence index</summary>

```text
# Evidence: a cancelled validation run reads as `stopped`, not `failed`

Base `3d2a08b` -> target `1220fa2`. Every transcript below was produced by
running the **real** `bin/fm-crew-state.sh`, `bin/fm-inactive-reconcile.sh`,
`bin/fm-fleet-view.sh` and `bin/fm-fleet-snapshot.sh` over a hermetic
throwaway home, with a fake `no-mistakes` serving the run object of an
aborted run: every step completed through `pr`, PR open and green, and only
the orphaned CI monitor reaped with `no-mistakes axi abort`.

| File | What it shows |
| --- | --- |
| `fleet-view-before-after.png` / `.html` | The captain's fleet table for that crew: `failed / run-step` before, `stopped / run-step` after. |
| `01-reader-before-after.txt` | The fixture, and the reader's answer at both commits. |
| `02-false-escalation-before-after.txt` | The reported symptom: `fm-inactive-reconcile.sh` queues a captain failure escalation + durable outcome record for a green PR before the fix, and nothing after. Ends with the negative control - a genuinely failed run still escalates. |
| `03-downstream-consumers.txt` | Each consumer of the state word driven for real: the fleet table, the `terminal_in_flight` inventory check (including the review-round `fm-fleet-snapshot.sh` fix, whose absence made that check go silent), and `crew_absorb_class` wake absorption (unchanged). |
| `04-red-then-green.txt` | Each of the three new cancelled tests failing against the pre-fix reader; the fourth (negative control) mutation-checked by softening `failed` to `stopped`; then the suites green on the target commit. |
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"bd0ade453c9af3f5e08b924c2ecfd24161b61936","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-fleet-snapshot.sh:731` - The consumer sweep missed a third reader that keys on the state WORD, not just renders it. `bin/fm-fleet-snapshot.sh:731` builds `$terminal_in_flight` with `select(.id == $work.id and (.current_state.state == &#34;done&#34; or .current_state.state == &#34;failed&#34;))`, which feeds `$strict_invalidities` (:748), `$valid` (:783), and `$invalidity` (:788). Concrete trace: a secondmate home with backlog row T = in_flight, structured; T is kind=ship; T&#39;s run is aborted, so `crew_state_json` (:251) now yields `{state:&#34;stopped&#34;,source:&#34;run-step&#34;}` instead of `&#34;failed&#34;`. T therefore drops out of `$terminal_in_flight`, and `--secondmate-home-summary` flips from `valid:false` / `invalidity.kind:&#34;terminal_in_flight&#34;` / `reason:&#34;in-flight backlog item has terminal child state: T=failed&#34;` to `valid:true` / `invalidity.kind:null` / `state:&#34;no_active_work&#34;`. The parent&#39;s `current_reason` note at :1517-1520 disappears with it, so an in-flight backlog row whose child the reader itself documents as terminal (`bin/fm-crew-state.sh:18` lists `stopped` in the terminal vocabulary; the added comment calls it &#34;its own terminal word&#34;) is now silent inventory drift instead of a named one. Existing coverage cannot catch this: `tests/fm-fleet-snapshot-view.test.sh:892` and `tests/fm-bearings-snapshot.test.sh:896` pin `terminal_in_flight` using stubbed `done`/`failed` states, so those suites passing does not evidence the claim. This also contradicts the intent&#39;s stated decision 3, which asserts &#34;every consumer of this reader&#39;s output was swept rather than assumed&#34; and &#34;bin/fm-fleet-view.sh, bin/fm-fleet-snapshot.sh and bin/fm-bearings-snapshot.sh render the state word verbatim or test only for &#39;working&#39;, so all are unaffected&#34; - line 731 tests for `done`/`failed`, and the in-file comment at bin/fm-crew-state.sh:517 repeats the same wrong claim (&#34;every other reader renders the word verbatim&#34;). Flagging rather than fixing because the smallest honest remedy edits a FOURTH file, past the intent&#39;s own boundary that &#34;the change was scoped to two files, the reader and its tests, and must not widen&#34; - so whether to add `stopped` to the :731 terminal test (or deliberately leave a stopped child out of the inventory check) is the author&#39;s call, not a mechanical correction. At minimum the comment at bin/fm-crew-state.sh:517 should stop asserting a sweep result that is not true.
- ℹ️ `bin/fm-crew-state.sh:523` - Noting the flip side of the fix, which the intent decided explicitly (decision 3: &#34;&#39;stopped&#39; correctly falls outside the first allowlist (this is the fix)&#34;). `bin/fm-inactive-reconcile.sh` is the path that exists precisely for a crew that has gone quiet and will emit no further wakes; it now returns 0 at :497 for `stopped`. So a run cancelled for a bad reason - machine died mid-review, no PR ever opened - and then abandoned gets no durable outcome record and no captain presentation from any path; it is visible only if someone reads the fleet table, where it renders as `stopped / run-step`. That is the correct trade for the reported deliberate-abort case and is authorized, but it is a genuinely new permanent silence for the abandoned-abort case, not merely a relabel. No action needed here.
- ℹ️ `bin/fm-crew-state.sh:479` - The comment directly above the changed coarse mapping still enumerates the coarse path&#39;s outcomes as &#34;No step/gate detail is available from the plain runs list - only ever true/working, done, or failed&#34; (:479-480), but the case block immediately below it (:489-494) now also yields `stopped` for a cancelled row. In a file where the header comment is treated as the contract - the change itself updated the header vocabulary at :18 and :33-35 - leaving this adjacent sentence enumerating a stale set is worth one word. Mechanical comment correction, no behavior involved.

🔧 Fix: count stopped as terminal in-flight; fix crew-state comments
1 info still open:

- ℹ️ `bin/fm-crew-state.sh:519` - The fix round&#39;s new comment clause overstates the consumer sweep. Lines 516-519 now read &#34;...and bin/fm-fleet-snapshot.sh&#39;s in-flight inventory check counts `stopped` as terminal alongside `done`/`failed`; every other reader renders the word verbatim.&#34; That last clause is false for a second reader in the same file: bin/fm-fleet-snapshot.sh:533-536 also KEYS on the state word (`[ &#34;$current_state&#34; = &#34;done&#34; ] || [ &#34;$current_state&#34; = &#34;failed&#34; ]`) to clear the durable open-decision fold. It is a no-op for `stopped` only because a stopped state is emitted exclusively through `emit &#34;$RUN_STATE&#34; run-step` (map_log_state at :129-142 has no `stopped` verb, so the status-log path can never produce it), which means the preceding `source = run-step` clause of that same condition already clears the set - so leaving :536 alone, as directed, is correct. The defect is purely the comment&#39;s accuracy: in a file whose header comment is treated as the contract, a maintainer adding the next terminal word will read &#34;every other reader renders the word verbatim&#34; and skip :536, where a word emitted with a source other than run-step or pane WOULD change behavior. Remedy is comment-only: name bin/fm-fleet-snapshot.sh:536 as a second word-keyed reader and record why it needs no change (a stopped state only ever carries source=run-step). No behavior change; the code as written is correct.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-crew-state.test.sh` — full suite green on target, including the four added cases</code>
- <code>`bin/fm-test-run.sh tests/fm-inactive-reconcile.test.sh tests/fm-fleet-snapshot-view.test.sh tests/fm-bearings-snapshot.test.sh tests/fm-classify-corr-token.test.sh tests/fm-classify-decision-key.test.sh` — the consumer suites, 5/5 pass, 0 failed</code>
- <code>Manual E2E: real `bin/fm-crew-state.sh` over a hermetic throwaway home + real git worktree + fake `no-mistakes` serving an aborted run&#39;s `axi status` — base `3d2a08b` reader vs target `1220fa2` reader on the identical fixture</code>
- <code>Manual E2E: `bin/fm-inactive-reconcile.sh scan --startup` with `FM_INACTIVE_CREW_STATE_BIN` pointed at the real reader — reproduced the queued captain wake + `terminal-outcomes/*.pending` record at base, and their absence at target</code>
- <code>Manual E2E negative control: same world with `status/outcome: failed` (review found 3 blocking findings) — target reader still reports `state: failed` and still escalates to the captain</code>
- <code>Manual E2E: `bin/fm-fleet-view.sh` rendered fleet table, base vs target (`failed / run-step` → `stopped / run-step`)</code>
- <code>Manual E2E: `bin/fm-fleet-snapshot.sh --secondmate-home-summary` with an in-flight backlog row for the cancelled child — `fm-fleet-snapshot.sh@95cfad7` (pre-review-fix) returns `valid:true` (signal silent) vs target returning `invalidity.kind:&#34;terminal_in_flight&#34;`, `reason:&#34;…feat-green=stopped&#34;`</code>
- <code>Manual E2E: `crew_absorb_class feat-green` / `crew_is_provably_working feat-green` from `bin/fm-classify-lib.sh` against both readers — `none` / `no` in both, wake absorption unchanged</code>
- <code>RED proof: `test_terminal_cancelled_after_green_is_stopped_not_failed`, `test_terminal_cancelled_status_without_outcome_is_stopped`, `test_coarse_cancelled_row_is_stopped_not_failed` each driven alone against `bin/fm-crew-state.sh@3d2a08b` — all three fail with `unexpected: &#39;state: failed&#39;`</code>
- <code>Mutation check: `test_coarse_failed_row_still_reports_failed` against a mutant target reader with the coarse `failed) RUN_STATE=failed` arm softened to `stopped` — fails with `unexpected: &#39;state: stopped&#39;`, proving the control is real</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/secondmate-parent-channel.md:31` - Judgment call, left unedited deliberately. The delivery table&#39;s &#34;Child ended silently&#34; row describes its trigger as &#34;terminal current state with a silent ledger&#34;, published by &#34;the existing inactive-outcome scan in bin/fm-inactive-reconcile.sh&#34;. Now that `stopped` is a terminal state word, that phrase is marginally overbroad: a child whose run was cancelled reads terminal but is not delivered on the parent channel, because the scan accepts `done` or `failed` alone. I did not edit it: the exact allowlist has one owner (bin/fm-inactive-reconcile.sh&#39;s header, which I corrected, restated in docs/architecture.md:53, both accurate), and spelling the allowlist into this table would create the second prose copy of a fact the placement policy says must live in one place. The row is a &#34;which script publishes which outcome&#34; index, not a statement of the allowlist. Flagging so the omission is a recorded reading rather than an oversight.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
