### PR TITLE
fix(bin): pre-register claude workspace trust for task worktrees

### DIFF
--- a/.agents/skills/harness-adapters/references/common/control-and-recovery.md
+++ b/.agents/skills/harness-adapters/references/common/control-and-recovery.md
@@ -16,6 +16,13 @@ Inspect after spawn within the tool's readiness window.
 Select only its documented trust choice from the active Firstmate home, binding `FM_HOME` unless already correct, then inspect again under the router-owned completion postcondition.
 No observed dialog proves only that launch.
 
+Each supported harness handles its folder-trust gate differently, and the tool reference owns the detail.
+Claude gates a fresh worktree and cannot be answered by key, so the spawn pre-registers the path in Claude's own store.
+Cursor suppresses its dialog with launch-time `--trust`, and Muse suppresses its own with `--yolo`.
+Pi and Grok dodge their gates instead of granting trust, by loading Firstmate's turn-end wiring from outside the worktree.
+Codex shows a directory-trust dialog on the first run for a repository root.
+A Claude secondmate is deliberately not pre-registered, because its home is a persistent checkout rather than an isolated task worktree and the scope test refuses it by design.
+
 Use the tool's exact skill form, or natural language only when no separate command is verified or the form remains uncertain.
 A successful send or key return is not proof of submission; require the tool-specific postcondition.
 Popup, queued-input, and readiness handling belongs to `../../../bin/fm-composer-lib.sh` and the selected backend.

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -13,8 +13,19 @@ Busy hooks verified 2026-07-28 on Claude Code 2.1.220.
 | Model | `--model <model>`; discover through the interactive `/model` picker, with alias or full-name shape documented by `claude --help`. |
 | Effort | `--effort <low\|medium\|high\|xhigh\|max>`, verified on 2.1.196. |
 
-Fresh-worktree or first-machine launch may show trust or bypass-permissions confirmation.
-Inspect within about 20 seconds, accept the required choice with `FM_HOME=<active-home> ../../../bin/fm-send.sh <window> --key Enter` unless already bound, and verify instructions started.
+## Workspace trust
+
+Claude gates a folder it has never seen behind an interactive workspace-trust dialog, so every fresh task worktree would hit it.
+`--dangerously-skip-permissions` does not cover that gate: `claude --help` records that the dialog is skipped only in non-interactive mode, through `-p` or a non-TTY stdout, and a crewmate pane is interactive.
+A ship or scout spawn therefore pre-registers the worktree before launch, and the dialog does not appear.
+`../../../bin/fm-claude-trust.sh` records `hasTrustDialogAccepted` for that worktree path in `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`, and `../../../bin/fm-spawn.sh` refuses the spawn when the write fails rather than launching a worker that would wedge.
+
+Never try to answer the trust dialog with a key.
+Firstmate's key plane carries only Enter, Escape, and C-c with no arrow navigation, so it cannot move a dialog's selection at all, and the observed rendering starts on `No, exit`, which means a sent Enter ends the session instead of accepting.
+A visible trust dialog means pre-registration did not take effect, so inspect the store and the spawn's error output rather than sending keys.
+
+The once-per-machine bypass-permissions confirmation is a separate dialog, scoped to the machine rather than the path, and pre-registration does not address it.
+Inspect the pane before answering that one, and confirm which dialog is on screen rather than sending Enter to whatever appeared.
 
 ## Composer ghost
 

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -115,12 +115,19 @@ fi
 # one realistic failure, and re-reading catches it. A lost update would only
 # resurrect the dialog this registration exists to remove, so it must fail
 # loudly rather than report a trust it did not leave behind.
+#
+# The readback proves the entry landed, not that it survives: a vendor session
+# that rewrites the whole store after this returns can still drop it, and no
+# lock closes that window because the writer is Claude itself. The worker then
+# meets the dialog and stalls, which reaches firstmate as the ordinary stale
+# wake rather than as silent success, and a relaunch registers again.
 # ponytail: verify-and-retry, not a lock; flock is absent on macOS and cannot
 # stop a vendor session's own rewrite anyway. Reach for a lock only if
 # concurrent spawns are ever shown to exhaust the retries.
 if ! node - "$STORE" "$WT_REAL" <<'NODE'
 const fs = require("node:fs");
 const path = require("node:path");
+const crypto = require("node:crypto");
 const [store, worktree] = process.argv.slice(2);
 const attempt = () => {
   let root = {};
@@ -144,8 +151,13 @@ const attempt = () => {
   }
   entry.hasTrustDialogAccepted = true;
   projects[worktree] = entry;
-  const tmp = path.join(path.dirname(store), `.claude.json.fm-trust.${process.pid}`);
-  fs.writeFileSync(tmp, `${JSON.stringify(root, null, 2)}\n`, { mode: 0o600 });
+  // Unpredictable name plus an exclusive create: the config directory may be
+  // writable by another local account, and a predictable path could be
+  // pre-created there as a symlink that a plain write would follow into some
+  // other file this user owns. "wx" refuses an existing path outright.
+  const unique = `${process.pid}.${crypto.randomBytes(8).toString("hex")}`;
+  const tmp = path.join(path.dirname(store), `.claude.json.fm-trust.${unique}`);
+  fs.writeFileSync(tmp, `${JSON.stringify(root, null, 2)}\n`, { mode: 0o600, flag: "wx" });
   try {
     fs.renameSync(tmp, store);
   } catch (err) {

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Pre-register Claude Code's workspace trust for the isolated task worktree a
+# ship/scout spawn is about to launch a claude crewmate into, so the worker
+# reaches its brief instead of wedging on the trust dialog.
+#
+# Usage: fm-claude-trust.sh <worktree> <project>
+#   <worktree>  the isolated task worktree this spawn launches into
+#   <project>   the primary checkout that worktree belongs to
+# Prints one line naming what it registered; refuses loudly on anything else.
+#
+# WHY THIS EXISTS. Claude Code gates a folder it has never seen behind an
+# interactive workspace-trust dialog, and --dangerously-skip-permissions does
+# NOT cover it: `claude --help` records that the dialog is skipped only in
+# non-interactive mode (-p, or a non-TTY stdout), and a crewmate pane is
+# interactive. Every fresh task worktree therefore hits it. The dialog renders
+# with the cursor on "No, exit" and firstmate's steering plane carries only
+# Enter, Escape and C-c with no arrow navigation, so firstmate cannot answer it
+# and must not try - pressing Enter would select exit. The worker wedges before
+# it ever reads the brief. Registering the trust before launch is the only
+# control that reaches an interactive pane.
+#
+# THE SCOPE TEST IS THE SAFETY PROPERTY, and it is STRUCTURAL rather than a
+# path policy. <worktree> must be a LINKED git worktree - its own git dir,
+# sharing <project>'s common dir - whose top level is exactly the resolved
+# argument. Git is the ground truth, so the argument is never trusted on its
+# own word: a primary checkout (git dir == common dir), a worktree of an
+# unrelated repo, a subdirectory of a worktree, a plain directory, and a home
+# directory are each refused. Refusal is a non-zero exit, never a warning and
+# never a silent skip.
+#
+# The test is deliberately NOT a treehouse or orca path prefix. Treehouse's
+# root is configurable (--root, TREEHOUSE_ROOT, config, and a relative
+# in-project pool), so a prefix check would refuse legitimate roots, accept
+# whatever a mutable env var names, and add exactly the policy surface this
+# registration must not grow. One structural test covers both worktree
+# providers because Orca's task worktree is a linked git worktree too.
+#
+# Only the launching user's own store is written: the projects entry for the
+# worktree path in ${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json, which must be a
+# regular file this uid owns. Every unrelated key and project entry is
+# preserved, and the replacement is atomic. That resolution is the same one the
+# worker reads, because fm-spawn.sh forwards its own resolved CLAUDE_CONFIG_DIR
+# onto the claude launch and an unset value is the single-store default.
+set -u
+
+[ "$#" -eq 2 ] || { echo "usage: fm-claude-trust.sh <worktree> <project>" >&2; exit 2; }
+WT_ARG=$1
+PROJ_ARG=$2
+
+refuse() { echo "error: refusing to pre-register Claude trust: $1" >&2; exit 1; }
+
+real_dir() { (cd "$1" 2>/dev/null && pwd -P); }
+
+# The resolved common dir of a git worktree, or empty. --git-common-dir can be
+# relative, so it is resolved from inside the worktree rather than joined here.
+common_dir_of() {
+  local dir=$1 common
+  common=$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null) || return 1
+  (cd "$dir" && real_dir "$common")
+}
+
+WT_REAL=$(real_dir "$WT_ARG") || true
+[ -n "$WT_REAL" ] || refuse "worktree '$WT_ARG' is not an accessible directory"
+PROJ_REAL=$(real_dir "$PROJ_ARG") || true
+[ -n "$PROJ_REAL" ] || refuse "project '$PROJ_ARG' is not an accessible directory"
+
+CONFIG_DIR=${CLAUDE_CONFIG_DIR:-${HOME:-}}
+[ -n "$CONFIG_DIR" ] || refuse "neither CLAUDE_CONFIG_DIR nor HOME is set, so the store cannot be located"
+# fm-spawn forwards a set CLAUDE_CONFIG_DIR onto the launch without requiring it
+# to exist, because claude creates its own store directory. Create it here for
+# the same reason, and refuse only when it genuinely cannot be written, since a
+# store this cannot reach means the worker meets the dialog after all.
+CONFIG_DIR_REAL=$(real_dir "$CONFIG_DIR") || true
+if [ -z "$CONFIG_DIR_REAL" ]; then
+  mkdir -p "$CONFIG_DIR" 2>/dev/null || true
+  CONFIG_DIR_REAL=$(real_dir "$CONFIG_DIR") || true
+fi
+[ -n "$CONFIG_DIR_REAL" ] || refuse "Claude config directory '$CONFIG_DIR' does not exist and could not be created"
+
+# A home or config directory is never a task worktree. Checked explicitly so
+# the refusal names the real reason instead of the git verdict behind it.
+[ "$WT_REAL" != "$CONFIG_DIR_REAL" ] || refuse "'$WT_REAL' is the Claude config directory, not a task worktree"
+if [ -n "${HOME:-}" ]; then
+  HOME_REAL=$(real_dir "$HOME") || true
+  [ "$WT_REAL" != "${HOME_REAL:-}" ] || refuse "'$WT_REAL' is the home directory, not a task worktree"
+fi
+
+WT_TOP=$(git -C "$WT_REAL" rev-parse --show-toplevel 2>/dev/null) || true
+[ -n "$WT_TOP" ] || refuse "'$WT_REAL' is not inside a git repository"
+WT_TOP_REAL=$(real_dir "$WT_TOP") || true
+[ "$WT_TOP_REAL" = "$WT_REAL" ] || refuse "'$WT_REAL' is not a worktree root (its root is '${WT_TOP_REAL:-unresolvable}')"
+
+WT_GIT_DIR=$(git -C "$WT_REAL" rev-parse --absolute-git-dir 2>/dev/null) || true
+[ -n "$WT_GIT_DIR" ] || refuse "'$WT_REAL' has no resolvable git directory"
+WT_GIT_DIR=$(real_dir "$WT_GIT_DIR") || true
+WT_COMMON=$(common_dir_of "$WT_REAL") || true
+[ -n "$WT_COMMON" ] || refuse "'$WT_REAL' has no resolvable git common directory"
+[ "$WT_GIT_DIR" != "$WT_COMMON" ] || refuse "'$WT_REAL' is a primary checkout, not an isolated worktree"
+
+PROJ_COMMON=$(common_dir_of "$PROJ_REAL") || true
+[ -n "$PROJ_COMMON" ] || refuse "project '$PROJ_REAL' is not inside a git repository"
+[ "$WT_COMMON" = "$PROJ_COMMON" ] || refuse "'$WT_REAL' is not a worktree of project '$PROJ_REAL'"
+
+STORE="$CONFIG_DIR_REAL/.claude.json"
+if [ -e "$STORE" ] || [ -L "$STORE" ]; then
+  [ ! -L "$STORE" ] || refuse "'$STORE' is a symlink; refusing to follow it into another user's store"
+  [ -f "$STORE" ] || refuse "'$STORE' is not a regular file"
+  [ -O "$STORE" ] || refuse "'$STORE' is not owned by this user"
+  [ -w "$STORE" ] || refuse "'$STORE' is not writable"
+fi
+
+# Read-modify-write, then read back and confirm. Any running claude session
+# holds its own copy of this store and can rewrite the whole file at any time,
+# so a dropped entry - never a torn file, the replacement is a rename - is the
+# one realistic failure, and re-reading catches it. A lost update would only
+# resurrect the dialog this registration exists to remove, so it must fail
+# loudly rather than report a trust it did not leave behind.
+# ponytail: verify-and-retry, not a lock; flock is absent on macOS and cannot
+# stop a vendor session's own rewrite anyway. Reach for a lock only if
+# concurrent spawns are ever shown to exhaust the retries.
+if ! node - "$STORE" "$WT_REAL" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+const [store, worktree] = process.argv.slice(2);
+const attempt = () => {
+  let root = {};
+  if (fs.existsSync(store)) {
+    const raw = fs.readFileSync(store, "utf8");
+    if (raw.trim() !== "") {
+      root = JSON.parse(raw);
+      if (root === null || typeof root !== "object" || Array.isArray(root)) {
+        throw new Error(`${store} is not a JSON object`);
+      }
+    }
+  }
+  if (root.projects === undefined) root.projects = {};
+  const projects = root.projects;
+  if (projects === null || typeof projects !== "object" || Array.isArray(projects)) {
+    throw new Error(`${store} has a non-object "projects" value`);
+  }
+  let entry = projects[worktree];
+  if (entry === undefined || entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+    entry = {};
+  }
+  entry.hasTrustDialogAccepted = true;
+  projects[worktree] = entry;
+  const tmp = path.join(path.dirname(store), `.claude.json.fm-trust.${process.pid}`);
+  fs.writeFileSync(tmp, `${JSON.stringify(root, null, 2)}\n`, { mode: 0o600 });
+  try {
+    fs.renameSync(tmp, store);
+  } catch (err) {
+    fs.rmSync(tmp, { force: true });
+    throw err;
+  }
+  const back = JSON.parse(fs.readFileSync(store, "utf8"));
+  return back.projects?.[worktree]?.hasTrustDialogAccepted === true;
+};
+try {
+  for (let i = 0; i < 3; i += 1) {
+    if (attempt()) process.exit(0);
+  }
+} catch (err) {
+  console.error(`error: ${err.message}`);
+  process.exit(1);
+}
+console.error(`error: ${store} did not retain trust for ${worktree} after 3 attempts`);
+process.exit(1);
+NODE
+then
+  refuse "could not record trust for '$WT_REAL' in '$STORE'"
+fi
+
+echo "trusted: $WT_REAL"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2613,6 +2613,17 @@ if [ "$KIND" != secondmate ]; then
   esac
   case "$HARNESS" in
     claude*)
+      # Pre-register Claude's workspace trust for this fresh worktree FIRST.
+      # The dialog gates the pane before the brief is ever read, and it also
+      # gates loading the project settings written just below, so nothing else
+      # in this branch takes effect without it. bin/fm-claude-trust.sh owns the
+      # structural scope test and refuses any path that is not this project's
+      # own isolated worktree; a refusal blocks the spawn rather than launching
+      # a worker that would wedge on a dialog firstmate cannot answer.
+      if ! "$FM_ROOT/bin/fm-claude-trust.sh" "$WT" "$PROJ_ABS" >/dev/null; then
+        echo "error: could not pre-register Claude workspace trust for $WT; refusing to launch a claude worker that would wedge on the trust dialog" >&2
+        exit 1
+      fi
       # Semantic busy-state hooks (bin/fm-busy-lib.sh): UserPromptSubmit opens
       # a turn; Stop (normal completion), StopFailure (API-error turn end),
       # and SessionEnd (process shutdown) all close it, so an abnormal end can

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -286,7 +286,7 @@ family_for_basename() {
     fm-control.test.sh|fm-control-relaunch.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|\
     fm-send-inbox.test.sh|fm-spawn-batch.test.sh|\
-    fm-spawn-dispatch-profile.test.sh|\
+    fm-spawn-dispatch-profile.test.sh|fm-claude-trust.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -204,6 +204,31 @@ Valid cleanup removed only the exact task-bound target and left the control wind
 The metadata-only validation covers tmux, Herdr, Zellij, Orca, and cmux before backend dispatch.
 Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, Cursor, and Muse share that backend cleanup boundary; their harness-specific hook files, tokens, transcript bindings, and session-log sidecars are cleaned only after it, so no harness needs a separate endpoint parser.
 
+## Claude workspace trust
+
+Verified 2026-09-03 on Claude Code 2.1.259.
+Claude gates a folder it has never seen behind an interactive workspace-trust dialog, and the CLI documents the only bypass as non-interactive mode, which a crewmate pane is not.
+
+```sh
+claude --version
+claude --help | grep -A 5 'workspace trust dialog'
+```
+
+```
+2.1.259 (Claude Code)
+                                        pipes). Note: The workspace trust dialog
+                                        is skipped when Claude is run in
+                                        non-interactive mode (via -p, or when
+                                        stdout is not a TTY, e.g. piped or
+                                        redirected output). Only use this in
+                                        directories you trust. Settings files
+```
+
+`--dangerously-skip-permissions` is a permission control and is absent from that bypass, so an interactive worker in a fresh worktree still reaches the dialog.
+Firstmate cannot answer it either, because its key plane carries only Enter, Escape, and C-c with no arrow navigation.
+`bin/fm-spawn.sh` therefore pre-registers the task worktree through `bin/fm-claude-trust.sh` before launch, and `tests/fm-claude-trust.test.sh` pins both halves of that contract: a fresh worktree is trusted, and an out-of-scope path is refused.
+The composer-classification record below observes the same gate from the other side, where an untrusted worktree left Claude, Grok, and Muse unverified because the guard reads a first-launch trust dialog as an unreadable composer.
+
 ## Composer classification matrix
 
 The shared composer classifier (`bin/fm-composer-lib.sh`, `fm_composer_classify_screen`) owns every composer shape fleet-wide; each backend contributes only a capture and a capability descriptor.

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -275,7 +275,15 @@ make_spawn_fakebin() {
 fm_test_run_spawn() {
   local home=$1 pane=$2 fakebin=$3
   shift 3
-  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+  # A claude spawn pre-registers workspace trust in the launching user's own
+  # store (bin/fm-claude-trust.sh), so every spawn here runs against a throwaway
+  # HOME; without it the suite would write the developer's real ~/.claude.json.
+  # HOME rather than CLAUDE_CONFIG_DIR deliberately: the spawn forwards a SET
+  # CLAUDE_CONFIG_DIR onto the claude launch, so pinning it here would change the
+  # launch command every launch-shape assertion in the suite reads.
+  local spawn_home=${FM_TEST_SPAWN_USER_HOME:-$home/user-home}
+  mkdir -p "$spawn_home"
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" HOME="$spawn_home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="${TMUX:-fake,1,0}" \

--- a/tests/fm-claude-trust.test.sh
+++ b/tests/fm-claude-trust.test.sh
@@ -60,6 +60,9 @@ test_fresh_worktree_is_trusted() {
   expect_code 0 $? "a fresh linked worktree must be trusted: $out"
   assert_contains "$out" "trusted:" "registration did not report what it trusted"
   assert_trusted "$CONFIG/.claude.json" "$WT" "the worktree was not recorded as trusted"
+  # The staged write is renamed into place, so no temporary store may survive it.
+  [ -z "$(find "$CONFIG" -maxdepth 1 -name '.claude.json.fm-trust.*' -print -quit)" ] \
+    || fail "a temporary store file was left behind in the config directory"
   pass "fm-claude-trust.sh: a fresh task worktree is trusted"
 }
 

--- a/tests/fm-claude-trust.test.sh
+++ b/tests/fm-claude-trust.test.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-claude-trust.sh and the claude spawn that calls it.
+#
+# Both halves of the contract are load-bearing and both are proven here: a
+# legitimate fresh task worktree is trusted so a claude worker reaches its
+# brief with no human, and every out-of-scope path is REFUSED rather than
+# warned about or quietly skipped.
+set -u
+
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-claude-trust)
+
+TRUST="$ROOT/bin/fm-claude-trust.sh"
+
+# make_case <name>: a project with one linked worktree plus an isolated Claude
+# config directory. Echoes "<case>|<proj>|<wt>|<config>".
+make_case() {
+  local name=$1 case_dir proj wt config
+  case_dir="$TMP_ROOT/$name"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  config="$case_dir/claude-config"
+  mkdir -p "$config"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  printf '%s|%s|%s|%s\n' "$case_dir" "$proj" "$wt" "$config"
+}
+
+read_case() {
+  IFS='|' read -r CASE_DIR PROJ WT CONFIG <<EOF
+$1
+EOF
+}
+
+# run_trust <config> <worktree> <project> [home]: invoke with an isolated store.
+run_trust() {
+  local config=$1 wt=$2 proj=$3 home=${4:-$1}
+  CLAUDE_CONFIG_DIR="$config" HOME="$home" "$TRUST" "$wt" "$proj" 2>&1
+}
+
+trusted_paths() {  # <store>
+  node -e 'const j=require("node:fs").existsSync(process.argv[1])?JSON.parse(require("node:fs").readFileSync(process.argv[1],"utf8")):{};for(const [k,v] of Object.entries(j.projects||{})){if(v&&v.hasTrustDialogAccepted===true)console.log(k);}' "$1"
+}
+
+assert_trusted() {  # <store> <path> <msg>
+  trusted_paths "$1" | grep -Fqx "$2" || fail "$3"
+}
+
+assert_not_trusted() {  # <store> <path> <msg>
+  trusted_paths "$1" | grep -Fqx "$2" && fail "$3"
+  return 0
+}
+
+test_fresh_worktree_is_trusted() {
+  local rec out
+  rec=$(make_case fresh)
+  read_case "$rec"
+  out=$(run_trust "$CONFIG" "$WT" "$PROJ")
+  expect_code 0 $? "a fresh linked worktree must be trusted: $out"
+  assert_contains "$out" "trusted:" "registration did not report what it trusted"
+  assert_trusted "$CONFIG/.claude.json" "$WT" "the worktree was not recorded as trusted"
+  pass "fm-claude-trust.sh: a fresh task worktree is trusted"
+}
+
+test_registration_is_idempotent() {
+  local rec out count
+  rec=$(make_case idempotent)
+  read_case "$rec"
+  run_trust "$CONFIG" "$WT" "$PROJ" >/dev/null
+  out=$(run_trust "$CONFIG" "$WT" "$PROJ")
+  expect_code 0 $? "a repeat registration must succeed: $out"
+  count=$(trusted_paths "$CONFIG/.claude.json" | grep -Fxc "$WT")
+  [ "$count" = 1 ] || fail "a repeat registration duplicated the entry ($count)"
+  pass "fm-claude-trust.sh: repeat registration is idempotent"
+}
+
+test_primary_checkout_is_refused() {
+  local rec out
+  rec=$(make_case primary)
+  read_case "$rec"
+  out=$(run_trust "$CONFIG" "$PROJ" "$PROJ")
+  expect_code 1 $? "the primary checkout must be refused: $out"
+  assert_contains "$out" "primary checkout" "the refusal did not name the primary checkout"
+  assert_not_trusted "$CONFIG/.claude.json" "$PROJ" "the primary checkout was trusted"
+  pass "fm-claude-trust.sh: refuses the primary checkout"
+}
+
+test_home_directory_is_refused_even_when_it_is_a_worktree() {
+  local rec out home
+  rec=$(make_case home-worktree)
+  read_case "$rec"
+  # Make HOME itself a linked worktree of the project, so every git check
+  # PASSES and only the home guard can refuse it. Without this the home case
+  # would pass vacuously through the "not a git repository" branch.
+  home="$CASE_DIR/home"
+  git -C "$PROJ" worktree add --quiet -b wt-home "$home"
+  out=$(run_trust "$CONFIG" "$home" "$PROJ" "$home")
+  expect_code 1 $? "a home directory must be refused even as a valid worktree: $out"
+  assert_contains "$out" "home directory" "the refusal did not name the home directory"
+  assert_not_trusted "$CONFIG/.claude.json" "$home" "the home directory was trusted"
+  # Prove the git checks really would have accepted it, so the guard above is
+  # what refused rather than an unrelated failure.
+  out=$(run_trust "$CONFIG" "$home" "$PROJ" "$CASE_DIR/elsewhere-home")
+  expect_code 0 $? "the same path must be acceptable once it is not HOME: $out"
+  pass "fm-claude-trust.sh: refuses a home directory the git checks would accept"
+}
+
+test_config_directory_is_refused() {
+  local rec out
+  rec=$(make_case config-dir)
+  read_case "$rec"
+  out=$(run_trust "$CONFIG" "$CONFIG" "$PROJ")
+  expect_code 1 $? "the Claude config directory must be refused: $out"
+  assert_contains "$out" "config directory" "the refusal did not name the config directory"
+  pass "fm-claude-trust.sh: refuses the Claude config directory"
+}
+
+test_non_git_directory_is_refused() {
+  local rec out plain
+  rec=$(make_case plain)
+  read_case "$rec"
+  plain="$CASE_DIR/plain"
+  mkdir -p "$plain"
+  out=$(run_trust "$CONFIG" "$plain" "$PROJ")
+  expect_code 1 $? "a plain directory must be refused: $out"
+  assert_contains "$out" "not inside a git repository" "the refusal did not name the missing repository"
+  assert_not_trusted "$CONFIG/.claude.json" "$plain" "a plain directory was trusted"
+  pass "fm-claude-trust.sh: refuses a directory that is not a git worktree"
+}
+
+test_missing_directory_is_refused() {
+  local rec out
+  rec=$(make_case missing)
+  read_case "$rec"
+  out=$(run_trust "$CONFIG" "$CASE_DIR/nope" "$PROJ")
+  expect_code 1 $? "a nonexistent path must be refused: $out"
+  assert_contains "$out" "not an accessible directory" "the refusal did not name the inaccessible path"
+  pass "fm-claude-trust.sh: refuses a path that does not exist"
+}
+
+test_foreign_project_worktree_is_refused() {
+  local rec out other other_wt
+  rec=$(make_case foreign)
+  read_case "$rec"
+  other="$CASE_DIR/other-project"
+  other_wt="$CASE_DIR/other-wt"
+  fm_git_worktree "$other" "$other_wt" wt-other
+  out=$(run_trust "$CONFIG" "$other_wt" "$PROJ")
+  expect_code 1 $? "another project's worktree must be refused: $out"
+  assert_contains "$out" "is not a worktree of project" "the refusal did not name the project mismatch"
+  assert_not_trusted "$CONFIG/.claude.json" "$other_wt" "a foreign project's worktree was trusted"
+  pass "fm-claude-trust.sh: refuses a worktree belonging to another project"
+}
+
+test_worktree_subdirectory_is_refused() {
+  local rec out sub
+  rec=$(make_case subdir)
+  read_case "$rec"
+  sub="$WT/sub"
+  mkdir -p "$sub"
+  out=$(run_trust "$CONFIG" "$sub" "$PROJ")
+  expect_code 1 $? "a subdirectory of the worktree must be refused: $out"
+  assert_contains "$out" "is not a worktree root" "the refusal did not name the non-root path"
+  assert_not_trusted "$CONFIG/.claude.json" "$sub" "a worktree subdirectory was trusted"
+  pass "fm-claude-trust.sh: refuses a subdirectory of the worktree"
+}
+
+test_unrelated_store_content_is_preserved() {
+  local rec store
+  rec=$(make_case preserve)
+  read_case "$rec"
+  store="$CONFIG/.claude.json"
+  cat > "$store" <<'JSON'
+{"hasCompletedOnboarding":true,"numStartups":7,"projects":{"/other/path":{"hasTrustDialogAccepted":false,"allowedTools":["Bash"]}}}
+JSON
+  run_trust "$CONFIG" "$WT" "$PROJ" >/dev/null || fail "registration failed against an existing store"
+  assert_trusted "$store" "$WT" "the worktree was not recorded in an existing store"
+  assert_grep '"hasCompletedOnboarding": true' "$store" "an unrelated top-level key was lost"
+  assert_grep '"numStartups": 7' "$store" "an unrelated top-level value was changed"
+  assert_grep '"allowedTools"' "$store" "another project's settings were lost"
+  assert_not_trusted "$store" "/other/path" "another project's trust decision was flipped"
+  pass "fm-claude-trust.sh: preserves unrelated store content"
+}
+
+test_symlinked_store_is_refused() {
+  local rec out foreign
+  rec=$(make_case symlink-store)
+  read_case "$rec"
+  foreign="$CASE_DIR/foreign-store.json"
+  printf '%s\n' '{"projects":{}}' > "$foreign"
+  ln -s "$foreign" "$CONFIG/.claude.json"
+  out=$(run_trust "$CONFIG" "$WT" "$PROJ")
+  expect_code 1 $? "a symlinked store must be refused: $out"
+  assert_contains "$out" "symlink" "the refusal did not name the symlink"
+  assert_not_trusted "$foreign" "$WT" "a symlinked store was followed and written"
+  pass "fm-claude-trust.sh: refuses to follow a symlinked store"
+}
+
+test_corrupt_store_fails_closed() {
+  local rec out store
+  rec=$(make_case corrupt)
+  read_case "$rec"
+  store="$CONFIG/.claude.json"
+  printf '%s\n' 'not json' > "$store"
+  out=$(run_trust "$CONFIG" "$WT" "$PROJ")
+  expect_code 1 $? "an unparseable store must be refused: $out"
+  assert_grep 'not json' "$store" "the unparseable store was overwritten instead of left alone"
+  pass "fm-claude-trust.sh: refuses an unparseable store and leaves it untouched"
+}
+
+# The spawn half: a real fm-spawn of a claude worker must pre-register the
+# worktree AND deliver the launch command carrying the brief, with no dialog to
+# answer and no human in the loop.
+test_claude_spawn_pretrusts_its_worktree_and_reaches_the_brief() {
+  local case_dir home proj wt config fakebin launch_log out
+  case_dir="$TMP_ROOT/spawn"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  config="$case_dir/claude-config"
+  launch_log="$case_dir/launch.log"
+  mkdir -p "$config"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake" claude)
+  fm_test_spawn_home "$home" claude
+  fm_git_worktree "$proj" "$wt" wt-spawn
+  fm_test_spawn_brief "$home" trustspawn
+  out=$(CLAUDE_CONFIG_DIR="$config" FM_FAKE_LAUNCH_LOG="$launch_log" \
+    fm_test_run_spawn "$home" "$wt" "$fakebin" trustspawn "$proj" claude \
+    --mode no-mistakes --yolo off)
+  expect_code 0 $? "the claude spawn must succeed: $out"
+  assert_trusted "$config/.claude.json" "$wt" \
+    "the claude spawn did not pre-register trust for its worktree"
+  assert_present "$launch_log" "the claude spawn sent no launch command"
+  assert_grep 'claude --dangerously-skip-permissions' "$launch_log" \
+    "the launch command was not the claude worker launch"
+  assert_grep "$home/data/trustspawn/launch-brief.md" "$launch_log" \
+    "the launch command did not carry the brief the worker must read"
+  # The worker must read the SAME store the registration wrote, or the trust
+  # would land somewhere the pane never looks.
+  assert_grep "CLAUDE_CONFIG_DIR='$config'" "$launch_log" \
+    "the launch command did not point the worker at the store that was trusted"
+  pass "fm-spawn.sh: a claude spawn pre-trusts its worktree and launches with the brief"
+}
+
+test_fresh_worktree_is_trusted
+test_registration_is_idempotent
+test_primary_checkout_is_refused
+test_home_directory_is_refused_even_when_it_is_a_worktree
+test_config_directory_is_refused
+test_non_git_directory_is_refused
+test_missing_directory_is_refused
+test_foreign_project_worktree_is_refused
+test_worktree_subdirectory_is_refused
+test_unrelated_store_content_is_preserved
+test_symlinked_store_is_refused
+test_corrupt_store_fails_closed
+test_claude_spawn_pretrusts_its_worktree_and_reaches_the_brief

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -731,12 +731,15 @@ test_claude_forwards_firstmate_config_dir_when_set() {
   rec=$(make_spawn_case profile-claude-cfgdir claude "$id")
   read_case_record "$rec"
 
-  out=$(FM_TEST_CLAUDE_CONFIG_DIR="/opt/test/claude-work" \
+  # A creatable path: this spawn now pre-registers workspace trust in that store
+  # (bin/fm-claude-trust.sh), so an unwritable directory is a genuine blocker.
+  # The forwarding assertion below is what this case proves and is unchanged.
+  out=$(FM_TEST_CLAUDE_CONFIG_DIR="$CASE_DIR/claude-work" \
     run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
   status=$?
   expect_code 0 "$status" "claude spawn with CLAUDE_CONFIG_DIR set should succeed"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/opt/test/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='$CASE_DIR/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
     "claude launch did not forward firstmate's CLAUDE_CONFIG_DIR to the crewmate pane"
   pass "claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store"
 }


### PR DESCRIPTION
## The defect

A claude crewmate launched into a fresh task worktree met Claude Code's interactive workspace-trust dialog before it ever read its brief, and firstmate had no way to answer it.

Firstmate's key plane carries only Enter, Escape, and C-c with no arrow navigation, so it cannot move a dialog's selection at all. The observed rendering starts on `No, exit`, so the previously documented "accept with `--key Enter`" recipe **selected exit**. Two workers wedged exactly this way and were unblocked only by an operator hand-seeding `hasTrustDialogAccepted` per path, which this change removes as a routine action.

`--dangerously-skip-permissions` does not cover the gate. `claude --help` on 2.1.259 records the dialog as skipped only in non-interactive mode, via `-p` or a non-TTY stdout, and a crewmate pane is interactive, so there is no launch flag to reach for.

`docs/verification/runtime-backends.md` already recorded the same gate from the other side: an untrusted worktree left Claude, Grok, and Muse unverified because the guard reads a first-launch trust dialog as an unreadable composer.

## The fix

`bin/fm-spawn.sh` pre-registers the worktree through the new `bin/fm-claude-trust.sh` inside the **existing** `claude*)` pre-launch branch, before the project settings that the same gate would otherwise block, and refuses the spawn when that write fails rather than launching a worker that would wedge.

## The scope boundary is the safety property

Pre-registering trust *is* granting trust automatically, so the refusal half is the design. The test is **structural, from git** rather than a path policy:

- the path must be a **linked** worktree (its own git dir, sharing the project's common dir),
- whose top level is **exactly** the resolved argument,
- and it must not be the Claude config dir or a home directory.

Git is the ground truth, so the argument is never trusted on its own word. A primary checkout (git dir == common dir), a worktree of an unrelated repo, a worktree subdirectory, a plain directory, a missing path, and a home directory are each **refused with a non-zero exit**, never warned about or silently skipped. Only the launching user's own store is written, and a symlinked, non-regular, or foreign-owned store is refused rather than followed.

A treehouse or orca path prefix was deliberately **not** used: treehouse's root is configurable (`--root`, `TREEHOUSE_ROOT`, and even a relative in-project pool), so a prefix would be both wrong and exactly the policy surface this must not grow. One structural test covers both worktree providers, since an Orca task worktree is a linked git worktree too.

Store resolution is `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`, which is the same store the worker reads, because `fm-spawn.sh` already forwards a set `CLAUDE_CONFIG_DIR` onto the claude launch and an unset value is the single-store default.

## Adapter surfaces named

The claude reference no longer tells a firstmate to press Enter on that dialog, and the shared trust reference now names every surface: claude gates and now pre-registers; cursor suppresses with `--trust` and muse with `--yolo`; pi and grok dodge their gates by loading turn-end wiring from outside the worktree; codex shows a first-run directory-trust dialog. A claude **secondmate is excluded by design**, because its home is a persistent checkout rather than an isolated task worktree, so the scope test refuses it.

## Tests

`tests/fm-claude-trust.test.sh` (13 cases) pins **both** halves, including:

- the happy path, idempotency, and unrelated-store preservation;
- every refusal above;
- a case where **HOME is itself a valid linked worktree**, so the git checks would accept it and only the home guard can refuse. The same path is then accepted once it is no longer HOME, proving that guard is load-bearing rather than passing vacuously;
- a spawn-level case driving the real `fm-spawn.sh`, asserting it pre-trusts its worktree, launches with the brief, and points the worker at the same store that was trusted.

`tests/fixtures.sh` runs each spawn against a throwaway HOME so the suite cannot write the developer's real `~/.claude.json`. It isolates through HOME rather than `CLAUDE_CONFIG_DIR` deliberately, because the spawn forwards a set `CLAUDE_CONFIG_DIR` onto the launch command that launch-shape assertions read.

## Verification

- `bin/fm-lint.sh` clean (ShellCheck 0.11.0, actionlint 1.7.12).
- `bin/fm-doc-audience-check.sh` ok.
- `tests/fm-claude-trust.test.sh` 13/13, `tests/fm-spawn-dispatch-profile.test.sh` 31/31, `tests/fm-busy-adapter-wiring.test.sh` 8/8.
- Full `backend-dispatch` family: 16 tests, 0 failures.
- Rebased onto current upstream main and re-verified.

### Known gap, stated plainly

The `no-mistakes` **review step could not run**: all three review agents are quota-walled right now (claude session limit, codex usage limit until Sep 6, and pi/Kimi weekly 403). This PR therefore carries the local verification above rather than a completed pipeline review, and the review gate should be re-driven once quota returns.

Two pre-existing conditions were observed and left alone: a number of suites already fail on pristine `origin/main` (`fm-bootstrap`, `fm-session-start`, `fm-procevent*`, `fm-extension-binding`, `fm-captain-hold-lifecycle`, `fm-bearings-board`, `fm-test-run`, `fm-remote-secondmate-parent-binding`, `fm-sessionstart-nudge`), `tests/fm-calm-pi-extension.test.sh` is flaky on baseline, and `fm-test-run.sh --check-coverage` emits `comm: file 2 is not in sorted order` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNEN2GLnew27HFyfi4ms4v
