### PR TITLE
feat(skill): add new-brand-onboarding router skill

### DIFF
--- a/.agents/skills/new-brand-onboarding/SKILL.md
+++ b/.agents/skills/new-brand-onboarding/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: new-brand-onboarding
+description: >-
+  Route a Studio v2 Brand onboarding to the home that executes it.
+  Use when the captain asks to onboard, add, set up, or resume a Brand in Studio v2, including requests such as "Onboard Whoa Tea" and the explicit /skill:new-brand-onboarding command.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# new-brand-onboarding
+
+Route a Studio v2 Brand onboarding request to the home that executes it.
+This skill owns recognition and routing only.
+The execution procedure is the project-local skill in the Studio v2 clone, `projects/studio-v2/.agents/skills/new-brand-onboarding/SKILL.md`; load it where the run happens and never copy its steps here.
+
+## Recognize
+
+Treat each of these as this skill's trigger:
+
+- The captain invokes `/skill:new-brand-onboarding`.
+- The captain asks to onboard, add, set up, or resume a Brand in Studio v2, by name or generically, for example "Onboard Whoa Tea".
+
+## Choose the home
+
+Read the home you are in from durable records, never from conversation memory.
+
+- `data/secondmates.md` registers `studio-v2-mate`: you are the primary Firstmate home; take the primary branch.
+- This home's `data/charter.md` names the Studio v2 second-mate domain: you are `studio-v2-mate`; take the mate branch.
+- Neither matches: stop and tell the captain the concrete blocker - Brand onboarding runs only in the primary home or the `studio-v2-mate` home.
+
+## Primary branch: route to studio-v2-mate
+
+Send the captain's request, with the Brand name and any stated scope, to the registered `studio-v2-mate` through the ordinary secondmate routing (`bin/fm-send.sh`; AGENTS.md section 7 owns the transport and the routed-reply contract).
+Brand onboarding never executes in the primary home and never routes to the legacy Studio Pi domain (`studio-pi-mate`, `whoa-tea-brand-mate`).
+When `studio-v2-mate` is not registered or is unreachable, stop and report that blocker instead of improvising an onboard elsewhere.
+
+## Mate branch: commission one per-Brand worker
+
+Create one ordinary task worker for this Brand through the standard lifecycle (`bin/fm-brief.sh`, `bin/fm-spawn.sh`; AGENTS.md sections 7 and 11 own them).
+The brief states that the worker loads and follows the project-local `new-brand-onboarding` skill before running the engine, and that a Brand onboarding is an operational run of the Studio v2 engine: the worker changes no Studio code and places no runtime Brand data in the repository.
+If the Studio v2 clone or the project-local skill is missing in this home, stop and report that concrete blocker.
+Keep one persistent `studio-v2-mate` for every Brand; ordinary per-Brand workers stay the default, and a separate Brand-domain second mate is a captain decision made only when sustained volume justifies it.
+
+## Isolation and approvals
+
+- One worker per Brand; never mix two Brands' sources, evidence, decisions, or outputs in one worker or one report.
+- The project skill owns the conversational contract: ask one missing-input question at a time, and keep raw CLI commands, record identifiers, and worker mechanics out of Captain-facing chat.
+- Manifest approval and Brand Truth approval each require a fresh captain reply after the exact review packet is shown; an earlier or bundled approval cannot authorize either gate.
+- When the request began in the primary home, route those approval packets and the captain's decisions back through the primary Firstmate; on direct mate contact, use the mate's normal Captain-facing route.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,7 @@ Send in-scope work to the fitting secondmate unless it is blocked or the captain
 If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.
 For one-off or infrequent operational work, start with the simplest direct end-to-end path.
 Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.
+Load the `new-brand-onboarding` skill when the captain asks to onboard, add, set up, or resume a Brand in Studio v2 or invokes `/skill:new-brand-onboarding`; the skill owns the routing between this home, `studio-v2-mate`, and the per-Brand worker.
 
 Before commissioning an investigation, consult existing reports and established evidence.
 Classify the deliverable:

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -209,6 +209,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/new-brand-onboarding/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/process-event-sources/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

Add the shared Firstmate new-brand-onboarding router skill that makes Studio v2 Brand onboarding fleet-native from either the main Firstmate or direct studio-v2-mate contact.

The project-local execution owner already exists at projects/studio-v2/.agents/skills/new-brand-onboarding/SKILL.md (merged on Studio v2 main) and must not be duplicated: the shared skill owns only recognition, routing, and the boundary between the primary Firstmate, the persistent Studio v2 second mate (studio-v2-mate), and the task-specific per-Brand Studio v2 worker.

Requirements:
- Create .agents/skills/new-brand-onboarding/SKILL.md as a model-invoked skill that also supports explicit /skill:new-brand-onboarding use; recognize both direct requests such as Onboard Whoa Tea and the explicit skill command.
- In the primary Firstmate home, route the request to the registered studio-v2-mate through ordinary secondmate routing; never perform Brand onboarding in the primary home and never route it to legacy Studio Pi.
- In the studio-v2-mate home, create an isolated task-specific per-Brand Studio v2 worker through the standard lifecycle and require that worker to load and follow the project-local new-brand-onboarding skill.
- Keep one persistent Studio v2 second mate for all Brands; ordinary per-Brand workers stay the default unless sustained volume later justifies a separate second mate (a captain decision).
- Preserve per-Brand source, evidence, decision, and output isolation.
- Preserve the project skill's conversational UX: one missing-input question at a time; keep raw CLI commands, internal IDs, and worker mechanics out of Captain-facing chat.
- Manifest approval and Brand Truth approval each require a fresh Captain response after the exact review packet is shown; blanket or advance approval must be rejected.
- Return Captain decisions through the primary Firstmate when the request began there; direct mate contact may use the mate's normal Captain-facing route.
- Stop safely and report the concrete blocker if studio-v2-mate, Studio v2, or the project-local skill is unavailable.
- Keep the implementation minimal: one shared skill plus only the smallest existing validation surface; no router script, framework, or duplicated workflow. The AGENTS.md section 7 trigger line and the docs/documentation-audiences.json classification entry are part of the minimal change set.
- Follow firstmate-coding-guidelines and writing-for-agents conventions: one sentence per line, plain dash, trigger hygiene, one-owner rule.
- Validation evidence goes to PR/status only; no task chronology in maintained documentation.

## What Changed
- Added a shared `.agents/skills/new-brand-onboarding/SKILL.md` that recognizes Brand-onboarding requests (including `/skill:new-brand-onboarding`) and routes them: the primary Firstmate forwards to `studio-v2-mate` via ordinary secondmate routing, while the mate commissions one per-Brand worker that loads the project-local Studio v2 skill, with isolation rules and fresh-captain approval gates preserved.
- Registered the skill's trigger line in AGENTS.md section 7 so agents load the router on Brand onboarding requests.
- Classified the new skill as `agent-runtime` in `docs/documentation-audiences.json`.

## Risk Assessment

✅ Low: The change is three additive prose/config files with no executable logic, all referenced scripts and validators exist, and every intent requirement maps to a present, fail-safe line in the skill.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (6m36s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6784d00c6055996af3a5c07c2fe636ded406fa30","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `.agents/skills/new-brand-onboarding/SKILL.md:27` - Mate-home detection depends on data/charter.md prose literally naming the Studio v2 second-mate domain, so a charter seeded without that phrasing makes every direct mate contact fall through to the stop-and-report branch. The failure is safe (concrete blocker, per intent) and the charter text is provisioned outside this change, so no action here; just ensure the studio-v2-mate charter names Studio v2 when provisioned.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
