### PR TITLE
feat(bin): ban Parallel-routed research in fleet briefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,7 @@ For one-off or infrequent operational work, start with the simplest direct end-t
 Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.
 
 Before commissioning an investigation, consult existing reports and established evidence.
+For all external research, no Firstmate agent, secondmate, crewmate, or scout may use Parallel, `parallel-cli`, the Parallel API, or any research skill or backend that routes queries through Parallel; use ordinary web search instead.
 Classify the deliverable:
 
 - **Ship** is the default and produces a project change through the selected delivery mode; once implementation is authorized, dispatch a ship and keep any remaining bounded research inside it unless unresolved uncertainty could materially change whether or what to build.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -203,6 +203,12 @@ The move IS the acknowledgement: without it firstmate rings again and eventually
 EOF
 INBOX_SECTION=${INBOX_SECTION%$'\n'}
 
+# AGENTS.md owns the fleet-wide external-research policy. This one-line
+# reinforcement is rendered in every brief because a newly launched worker
+# must receive the prohibition before it can load that durable owner.
+# shellcheck disable=SC2016 # Backticks are literal Markdown in the generated brief.
+EXTERNAL_RESEARCH_SECTION='Do not use Parallel, `parallel-cli`, the Parallel API, or any research skill or backend that routes queries through Parallel. Use ordinary web search for external research.'
+
 if [ "$KIND" = secondmate ]; then
 SECONDMATE_PROJECTS=""
 idx=1
@@ -229,6 +235,9 @@ You are a persistent second mate managed by the main firstmate. Work on your own
 
 # Charter
 $SECONDMATE_CHARTER
+
+# External research
+$EXTERNAL_RESEARCH_SECTION
 
 # Routing scope
 $SECONDMATE_SCOPE
@@ -349,6 +358,9 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 $TASK_SECTION
 
+# External research
+$EXTERNAL_RESEARCH_SECTION
+
 $HERDR_SECTION
 
 # Setup
@@ -420,6 +432,9 @@ cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
 $TASK_SECTION
+
+# External research
+$EXTERNAL_RESEARCH_SECTION
 
 $HERDR_SECTION
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -782,6 +782,35 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+# The fleet-wide research ban is owned by AGENTS.md and reinforced at the one
+# shared scaffold boundary so every newly launched worker receives the same
+# unambiguous prohibition and replacement without maintaining a second policy.
+test_every_scaffold_reinforces_parallel_research_ban() {
+  local home id args brief
+  home="$TMP_ROOT/parallel-research-ban-home"
+  mkdir -p "$home/data"
+  while IFS='|' read -r id args; do
+    [ -n "$id" ] || continue
+    # shellcheck disable=SC2086 # args is an intentional word-split argument list.
+    FM_HOME="$home" FM_SECONDMATE_CHARTER='policy fixture' \
+      "$ROOT/bin/fm-brief.sh" "$id" $args >/dev/null 2>&1 \
+      || fail "$id: scaffold should succeed"
+    brief="$home/data/$id/brief.md"
+    # shellcheck disable=SC2016 # Backticks are literal Markdown asserted from the generated brief.
+    assert_grep 'Do not use Parallel, `parallel-cli`, the Parallel API, or any research skill or backend that routes queries through Parallel.' "$brief" \
+      "$id: scaffold did not prohibit every Parallel research route"
+    assert_grep 'Use ordinary web search for external research.' "$brief" \
+      "$id: scaffold did not name ordinary web search as the required replacement"
+  done <<'ROWS'
+policy-ship-no-mistakes|alpha --mode no-mistakes
+policy-ship-direct-pr|alpha --mode direct-PR
+policy-ship-local-only|alpha --mode local-only
+policy-scout|alpha --scout
+policy-secondmate|--secondmate --no-projects
+ROWS
+  pass "fm-brief.sh: every worker and secondmate scaffold reinforces the Parallel research ban"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -803,3 +832,4 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_every_scaffold_reinforces_parallel_research_ban


### PR DESCRIPTION
## Intent

Implement the captain’s permanent fleet-wide policy: no Firstmate agent, secondmate, crewmate, or scout may use Parallel, parallel-cli, the Parallel API, or a research skill/backend that routes queries through Parallel. Ordinary web search is the required external research path. Put the always-on rule in its correct single owner and ensure every newly scaffolded ordinary worker and secondmate receives an explicit, unambiguous prohibition and replacement without duplicating the full contract. Cover all supported brief variants and relevant harness surfaces with executable behavioral tests. Do not install, configure, authorize, or invoke Parallel while implementing or verifying the ban. Commit only this task’s changes, create a PR, and do not merge it.

## What Changed

- Add the fleet-wide policy to `AGENTS.md`: no firstmate agent, secondmate, crewmate, or scout may use Parallel, `parallel-cli`, the Parallel API, or any research skill/backend that routes through Parallel — ordinary web search is required instead.
- Add a shared `EXTERNAL_RESEARCH_SECTION` constant in `bin/fm-brief.sh` and inject it as an `# External research` section into the secondmate brief template and both crewmate/worker brief templates, so every newly scaffolded worker gets the prohibition and replacement without duplicating the full policy text.
- Add `tests/fm-brief.test.sh::test_every_scaffold_reinforces_parallel_research_ban`, which scaffolds every supported brief variant (ship modes `no-mistakes`, `direct-PR`, `local-only`, plus `--scout` and `--secondmate`) and asserts the generated brief contains both the prohibition and the required web-search replacement.

## Risk Assessment

✅ Low: Small, additive, well-bounded change: one policy line in AGENTS.md as the single owner, a one-line reinforcement string inserted at the single shared brief-generation site (covering all ship modes, scout, and secondmate paths without duplicating the full contract), and a new test that exercises all five brief variants; no other code path generates agent-facing briefs, so no coverage gap.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (7m30s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
