### PR TITLE
fix(bin): never report a live no-mistakes run as a terminal failure

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -27,7 +27,9 @@
 #      unreachable or unreadable remote reports unknown-remote, never a false
 #      gone/dead.
 #   2. Attribute an active or terminal no-mistakes run under the branch, head,
-#      pipeline-custody, and newest-first rules owned by bin/fm-nm-run-lib.sh.
+#      and pipeline-custody rules owned by bin/fm-nm-run-lib.sh; when the active
+#      run belongs to another branch, nm_runs_status_for_branch below owns the
+#      selection order across every matching runs-list row.
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -36,7 +36,10 @@
 #      the active step is ci, `axi status` alone cannot tell "still waiting on
 #      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
 #      a ci-step log-tail check overrides working -> done once checks read
-#      green, so a green PR is never silently read as still-validating.
+#      green, so a green PR is never silently read as still-validating. A
+#      coarse runs-list attribution has no step detail to read, so a row whose
+#      own status word is a live fix or CI phase never takes that override; the
+#      emit site below owns that narrower rule.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -377,8 +377,9 @@ nm_ci_checks_state() {
 # NON-TERMINAL matching row's status word, else the most recent terminal one
 # (running/completed/cancelled/failed), or empty when the branch has no
 # matching row within FM_CREW_STATE_RUNS_LIMIT rows. A same-branch row at an
-# unresolvable head stops the scan, but never discards an already
-# head-verified newer match.
+# unresolvable head stops the scan: an ACTIVE one answers empty, because a
+# live pipeline-owned run routinely has a lane head this worktree cannot
+# resolve, while a terminal one leaves a head-verified newer match standing.
 nm_runs_status_for_branch() {  # <branch>
   local branch=$1 out row st rest br sha newest_terminal=""
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
@@ -398,11 +399,15 @@ nm_runs_status_for_branch() {  # <branch>
       # short-sha does not match this worktree (rewritten or advanced tip).
       if ! nm_coarse_head_matches_worktree "$sha"; then
         # An UNRESOLVABLE head is unknown attribution, not a proven
-        # mismatch. Stop instead of surfacing an older, superseded row; with
-        # nothing matched yet the caller's pane/log fallback answers without
-        # misattribution, and an already head-verified NEWER row still stands.
+        # mismatch, so stop instead of surfacing an older, superseded row. An
+        # ACTIVE row at an unresolvable head is the routine shape of a live
+        # pipeline-owned run whose lane head never reached this worktree, so
+        # it must not be answered with a terminal verdict; only a terminal
+        # unknown row leaves an already head-verified newer match standing.
         if ! fm_nm_head_resolvable "$WT" "$sha"; then
-          printf '%s' "$newest_terminal"
+          case "$st" in
+            completed|failed|cancelled) printf '%s' "$newest_terminal" ;;
+          esac
           return 0
         fi
         continue

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -418,6 +418,9 @@ nm_runs_status_for_branch() {  # <branch>
     fi
     # A resolvable head that does not match is a PROVEN mismatch (historical or
     # diverged); it is skipped and cannot mask anything.
+    # A head-verified live row wins unconditionally, so once one is recorded no
+    # later row can change the verdict and the rest of the window is dead work.
+    [ -n "$newest_live" ] && break
   done <<< "$out"
   if [ -n "$newest_live" ]; then
     printf '%s' "$newest_live"
@@ -573,18 +576,24 @@ if [ "$HAVE_RUN" = 1 ]; then
 
   if [ "$RUN_STATE" = working ] && log_reports_ci_ready; then
     if [ "$RUN_SOURCE" = coarse ]; then
-      emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
-    fi
-    [ -n "$CI_STEP_STATUS" ] || CI_STEP_STATUS=$(nm_effective_ci_step_status)
-    if [ "$RUN_STATUS" = fixing ]; then
-      CI_LOG_STATE=not-ready
-    elif [ "$CI_STEP_STATUS" = running ] && [ -z "$CI_LOG_STATE" ]; then
-      CI_LOG_STATE=$(nm_ci_checks_state)
-    elif [ "$CI_STEP_STATUS" = fixing ]; then
-      CI_LOG_STATE=not-ready
-    fi
-    if [ "$CI_LOG_STATE" != not-ready ]; then
-      emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
+      # The coarse arm cannot read RUN_STATUS (RUN_OUT belongs to another
+      # branch), so the runs-list status word carries the same invariant the
+      # full path enforces below: a live fix round never satisfies checks-green,
+      # because the log line was written before the run re-entered fixing.
+      [ "$COARSE_STATUS" = fixing ] || \
+        emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
+    else
+      [ -n "$CI_STEP_STATUS" ] || CI_STEP_STATUS=$(nm_effective_ci_step_status)
+      if [ "$RUN_STATUS" = fixing ]; then
+        CI_LOG_STATE=not-ready
+      elif [ "$CI_STEP_STATUS" = running ] && [ -z "$CI_LOG_STATE" ]; then
+        CI_LOG_STATE=$(nm_ci_checks_state)
+      elif [ "$CI_STEP_STATUS" = fixing ]; then
+        CI_LOG_STATE=not-ready
+      fi
+      if [ "$CI_LOG_STATE" != not-ready ]; then
+        emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
+      fi
     fi
   fi
 

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -375,15 +375,19 @@ nm_ci_checks_state() {
 # is exact) - but branch + coarse status is exactly what this predicate needs:
 # is a run for THIS branch active right now. EVERY same-branch row is scanned
 # before anything is answered, because no single row can be known to be the
-# best match until the whole window has been read. The verdict is then: the
-# most recent head-verified NON-TERMINAL row wins; else empty when any
-# unresolvable-head row was itself non-terminal, since a live pipeline-owned
-# run routinely has a lane head this worktree cannot resolve and that is
-# unknown attribution rather than a terminal outcome; else the most recent
-# head-verified terminal row; else empty when the branch has no matching row
-# within FM_CREW_STATE_RUNS_LIMIT rows.
+# best match until the whole window has been read. ONE preference order scores
+# every row: a non-terminal row outranks a terminal one, and among rows of the
+# same class the more recent wins (rows arrive newest-first, so the first row
+# recorded in a class is that class's most recent). A row whose head this
+# worktree cannot resolve is UNKNOWN attribution, so it may only ever SUPPRESS
+# an answer, never supply one; a head-verified non-terminal row is never
+# suppressed, because nothing unknown can make live work not-live. The verdict
+# is therefore: the head-verified non-terminal row if there is one; else the
+# head-verified terminal row, but only when no unresolvable row outranks it;
+# else empty (which includes a branch with no matching row within
+# FM_CREW_STATE_RUNS_LIMIT rows).
 nm_runs_status_for_branch() {  # <branch>
-  local branch=$1 out row st rest br sha newest_live="" newest_terminal="" unknown_live=0
+  local branch=$1 out row st rest br sha newest_live="" newest_terminal="" suppress=0
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
   [ -n "$out" ] || return 0
   while IFS= read -r row; do
@@ -397,34 +401,30 @@ nm_runs_status_for_branch() {  # <branch>
     rest=$(trim "$rest")
     sha=${rest%% *}
     [ "$br" = "$branch" ] || continue
-    # Same code-identity rule as axi status. Rows are newest-first, so the
-    # first row recorded in each class is that class's most recent one.
+    # Same code-identity rule as axi status. A head-verified non-terminal row
+    # wins outright, so the rest of the window cannot change the verdict.
     if nm_coarse_head_matches_worktree "$sha"; then
       case "$st" in
         completed|failed|cancelled) [ -n "$newest_terminal" ] || newest_terminal=$st ;;
-        *)                          [ -n "$newest_live" ] || newest_live=$st ;;
+        *)                          newest_live=$st; break ;;
       esac
     elif ! fm_nm_head_resolvable "$WT" "$sha"; then
-      # An UNRESOLVABLE head is unknown attribution, not a proven mismatch. It
-      # only has to suppress a terminal answer when the unknown row is itself
-      # ALIVE: that is the routine shape of a live pipeline-owned run whose
-      # lane head never reached this worktree, and calling it terminal is the
-      # exact defect this selection order exists to prevent. A terminal
-      # unknown row hides no live work, so it leaves a verified match standing.
+      # Unknown attribution: this row can only outrank the best terminal
+      # candidate, never answer for it. Alive outranks terminal regardless of
+      # age; an unknown terminal row outranks only a terminal candidate not yet
+      # recorded, which newest-first ordering makes exactly "the unknown row is
+      # the newer of the two".
       case "$st" in
-        completed|failed|cancelled) ;;
-        *) unknown_live=1 ;;
+        completed|failed|cancelled) [ -n "$newest_terminal" ] || suppress=1 ;;
+        *)                          suppress=1 ;;
       esac
     fi
     # A resolvable head that does not match is a PROVEN mismatch (historical or
     # diverged); it is skipped and cannot mask anything.
-    # A head-verified live row wins unconditionally, so once one is recorded no
-    # later row can change the verdict and the rest of the window is dead work.
-    [ -n "$newest_live" ] && break
   done <<< "$out"
   if [ -n "$newest_live" ]; then
     printf '%s' "$newest_live"
-  elif [ "$unknown_live" = 0 ]; then
+  elif [ "$suppress" = 0 ]; then
     printf '%s' "$newest_terminal"
   fi
   return 0

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -375,8 +375,10 @@ nm_ci_checks_state() {
 # is exact) - but branch + coarse status is exactly what this predicate needs:
 # is a run for THIS branch active right now. Echoes the most recent
 # NON-TERMINAL matching row's status word, else the most recent terminal one
-# (running/completed/cancelled/failed), or empty when the branch has no run
-# within FM_CREW_STATE_RUNS_LIMIT rows.
+# (running/completed/cancelled/failed), or empty when the branch has no
+# matching row within FM_CREW_STATE_RUNS_LIMIT rows. A same-branch row at an
+# unresolvable head stops the scan, but never discards an already
+# head-verified newer match.
 nm_runs_status_for_branch() {  # <branch>
   local branch=$1 out row st rest br sha newest_terminal=""
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
@@ -396,9 +398,13 @@ nm_runs_status_for_branch() {  # <branch>
       # short-sha does not match this worktree (rewritten or advanced tip).
       if ! nm_coarse_head_matches_worktree "$sha"; then
         # An UNRESOLVABLE head is unknown attribution, not a proven
-        # mismatch. Stop instead of surfacing an older, superseded row;
-        # the caller's pane/log fallback can answer without misattribution.
-        fm_nm_head_resolvable "$WT" "$sha" || return 0
+        # mismatch. Stop instead of surfacing an older, superseded row; with
+        # nothing matched yet the caller's pane/log fallback answers without
+        # misattribution, and an already head-verified NEWER row still stands.
+        if ! fm_nm_head_resolvable "$WT" "$sha"; then
+          printf '%s' "$newest_terminal"
+          return 0
+        fi
         continue
       fi
       # Several rows can match one worktree: a TERMINAL run left at the exact

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -373,15 +373,17 @@ nm_ci_checks_state() {
 # "<status> <branch> <short-sha> <date> [<pr-url>]" separated by runs of
 # spaces (verified: no quoting, so splitting on the first two whitespace runs
 # is exact) - but branch + coarse status is exactly what this predicate needs:
-# is a run for THIS branch active right now. Echoes the most recent
-# NON-TERMINAL matching row's status word, else the most recent terminal one
-# (running/completed/cancelled/failed), or empty when the branch has no
-# matching row within FM_CREW_STATE_RUNS_LIMIT rows. A same-branch row at an
-# unresolvable head stops the scan: an ACTIVE one answers empty, because a
-# live pipeline-owned run routinely has a lane head this worktree cannot
-# resolve, while a terminal one leaves a head-verified newer match standing.
+# is a run for THIS branch active right now. EVERY same-branch row is scanned
+# before anything is answered, because no single row can be known to be the
+# best match until the whole window has been read. The verdict is then: the
+# most recent head-verified NON-TERMINAL row wins; else empty when any
+# unresolvable-head row was itself non-terminal, since a live pipeline-owned
+# run routinely has a lane head this worktree cannot resolve and that is
+# unknown attribution rather than a terminal outcome; else the most recent
+# head-verified terminal row; else empty when the branch has no matching row
+# within FM_CREW_STATE_RUNS_LIMIT rows.
 nm_runs_status_for_branch() {  # <branch>
-  local branch=$1 out row st rest br sha newest_terminal=""
+  local branch=$1 out row st rest br sha newest_live="" newest_terminal="" unknown_live=0
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
   [ -n "$out" ] || return 0
   while IFS= read -r row; do
@@ -394,39 +396,34 @@ nm_runs_status_for_branch() {  # <branch>
     rest=${rest#* }
     rest=$(trim "$rest")
     sha=${rest%% *}
-    if [ "$br" = "$branch" ]; then
-      # Same code-identity rule as axi status: skip a same-branch row whose
-      # short-sha does not match this worktree (rewritten or advanced tip).
-      if ! nm_coarse_head_matches_worktree "$sha"; then
-        # An UNRESOLVABLE head is unknown attribution, not a proven
-        # mismatch, so stop instead of surfacing an older, superseded row. An
-        # ACTIVE row at an unresolvable head is the routine shape of a live
-        # pipeline-owned run whose lane head never reached this worktree, so
-        # it must not be answered with a terminal verdict; only a terminal
-        # unknown row leaves an already head-verified newer match standing.
-        if ! fm_nm_head_resolvable "$WT" "$sha"; then
-          case "$st" in
-            completed|failed|cancelled) printf '%s' "$newest_terminal" ;;
-          esac
-          return 0
-        fi
-        continue
-      fi
-      # Several rows can match one worktree: a TERMINAL run left at the exact
-      # head and a LIVE run whose pipeline commits advanced past it both
-      # satisfy the head rule. The live run is the current truth, so take the
-      # first (most recent) non-terminal match and keep only the most recent
-      # terminal one as the answer for a branch with no live run at all.
+    [ "$br" = "$branch" ] || continue
+    # Same code-identity rule as axi status. Rows are newest-first, so the
+    # first row recorded in each class is that class's most recent one.
+    if nm_coarse_head_matches_worktree "$sha"; then
       case "$st" in
-        completed|failed|cancelled)
-          [ -n "$newest_terminal" ] || newest_terminal=$st ;;
-        *)
-          printf '%s' "$st"
-          return 0 ;;
+        completed|failed|cancelled) [ -n "$newest_terminal" ] || newest_terminal=$st ;;
+        *)                          [ -n "$newest_live" ] || newest_live=$st ;;
+      esac
+    elif ! fm_nm_head_resolvable "$WT" "$sha"; then
+      # An UNRESOLVABLE head is unknown attribution, not a proven mismatch. It
+      # only has to suppress a terminal answer when the unknown row is itself
+      # ALIVE: that is the routine shape of a live pipeline-owned run whose
+      # lane head never reached this worktree, and calling it terminal is the
+      # exact defect this selection order exists to prevent. A terminal
+      # unknown row hides no live work, so it leaves a verified match standing.
+      case "$st" in
+        completed|failed|cancelled) ;;
+        *) unknown_live=1 ;;
       esac
     fi
+    # A resolvable head that does not match is a PROVEN mismatch (historical or
+    # diverged); it is skipped and cannot mask anything.
   done <<< "$out"
-  printf '%s' "$newest_terminal"
+  if [ -n "$newest_live" ]; then
+    printf '%s' "$newest_live"
+  elif [ "$unknown_live" = 0 ]; then
+    printf '%s' "$newest_terminal"
+  fi
   return 0
 }
 
@@ -504,12 +501,15 @@ if [ "$HAVE_RUN" = 1 ]; then
     # surfaced by each supervisor's span classification (fm-classify-lib.sh's
     # status_span_first_actionable) regardless of this coarse-vs-full
     # distinction, so a real gate is never silently missed.
+    # Live status words mirror the full-status mapping below, so a run in its
+    # fix or CI phase reads as working rather than as an unrecognized word.
     case "$COARSE_STATUS" in
-      running)   RUN_STATE=working; RUN_DETAIL="validating (background run)" ;;
-      completed) RUN_STATE="done";  RUN_DETAIL="run completed" ;;
-      failed)    RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
-      cancelled) RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
-      *)         RUN_STATE=unknown; RUN_DETAIL="runs list status: $COARSE_STATUS" ;;
+      running|fixing) RUN_STATE=working; RUN_DETAIL="validating (background run)" ;;
+      ci)             RUN_STATE=working; RUN_DETAIL="ci running" ;;
+      completed)      RUN_STATE="done";  RUN_DETAIL="run completed" ;;
+      failed)         RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
+      cancelled)      RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
+      *)              RUN_STATE=unknown; RUN_DETAIL="runs list status: $COARSE_STATUS" ;;
     esac
   else
     status=$(strip_quotes "$(nm_field status)")

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -580,10 +580,21 @@ if [ "$HAVE_RUN" = 1 ]; then
     if [ "$RUN_SOURCE" = coarse ]; then
       # The coarse arm cannot read RUN_STATUS (RUN_OUT belongs to another
       # branch), so the runs-list status word carries the same invariant the
-      # full path enforces below: a live fix round never satisfies checks-green,
-      # because the log line was written before the run re-entered fixing.
-      [ "$COARSE_STATUS" = fixing ] || \
-        emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
+      # full path enforces below: a live fix or CI round never satisfies
+      # checks-green, because the log line was written before the run re-entered
+      # that phase. A re-armed ci run would otherwise emit a done that
+      # bin/fm-inactive-reconcile.sh hardens into a durable terminal outcome.
+      #
+      # This is a deliberately NARROW exclusion, not the general rule. The
+      # coarse arm cannot establish that a checks-green log line still speaks
+      # for the CURRENT run in any live state, `running` included, while the
+      # full arm below emits unless a not-ready CI state is proven - the
+      # opposite polarity. Task coarse-emit-currency-polarity owns that contract
+      # question; take it there rather than widening this list.
+      case "$COARSE_STATUS" in
+        fixing|ci) ;;
+        *) emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR" ;;
+      esac
     else
       [ -n "$CI_STEP_STATUS" ] || CI_STEP_STATUS=$(nm_effective_ci_step_status)
       if [ "$RUN_STATUS" = fixing ]; then

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -373,11 +373,12 @@ nm_ci_checks_state() {
 # "<status> <branch> <short-sha> <date> [<pr-url>]" separated by runs of
 # spaces (verified: no quoting, so splitting on the first two whitespace runs
 # is exact) - but branch + coarse status is exactly what this predicate needs:
-# is a run for THIS branch active right now. Echoes the first (most recent)
-# matching row's status word (running/completed/cancelled/failed), or empty
-# when the branch has no run within FM_CREW_STATE_RUNS_LIMIT rows.
+# is a run for THIS branch active right now. Echoes the most recent
+# NON-TERMINAL matching row's status word, else the most recent terminal one
+# (running/completed/cancelled/failed), or empty when the branch has no run
+# within FM_CREW_STATE_RUNS_LIMIT rows.
 nm_runs_status_for_branch() {  # <branch>
-  local branch=$1 out row st rest br sha
+  local branch=$1 out row st rest br sha newest_terminal=""
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
   [ -n "$out" ] || return 0
   while IFS= read -r row; do
@@ -400,10 +401,21 @@ nm_runs_status_for_branch() {  # <branch>
         fm_nm_head_resolvable "$WT" "$sha" || return 0
         continue
       fi
-      printf '%s' "$st"
-      return 0
+      # Several rows can match one worktree: a TERMINAL run left at the exact
+      # head and a LIVE run whose pipeline commits advanced past it both
+      # satisfy the head rule. The live run is the current truth, so take the
+      # first (most recent) non-terminal match and keep only the most recent
+      # terminal one as the answer for a branch with no live run at all.
+      case "$st" in
+        completed|failed|cancelled)
+          [ -n "$newest_terminal" ] || newest_terminal=$st ;;
+        *)
+          printf '%s' "$st"
+          return 0 ;;
+      esac
     fi
   done <<< "$out"
+  printf '%s' "$newest_terminal"
   return 0
 }
 

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -377,19 +377,28 @@ nm_ci_checks_state() {
 # is exact) - but branch + coarse status is exactly what this predicate needs:
 # is a run for THIS branch active right now. EVERY same-branch row is scanned
 # before anything is answered, because no single row can be known to be the
-# best match until the whole window has been read. ONE preference order scores
-# every row: a non-terminal row outranks a terminal one, and among rows of the
-# same class the more recent wins (rows arrive newest-first, so the first row
-# recorded in a class is that class's most recent). A row whose head this
-# worktree cannot resolve is UNKNOWN attribution, so it may only ever SUPPRESS
-# an answer, never supply one; a head-verified non-terminal row is never
-# suppressed, because nothing unknown can make live work not-live. The verdict
-# is therefore: the head-verified non-terminal row if there is one; else the
-# head-verified terminal row, but only when no unresolvable row outranks it;
-# else empty (which includes a branch with no matching row within
+# best match until the whole window has been read. Every row's status word is
+# classified by nm_coarse_run_state, the sole owner of this vocabulary: LIVE if
+# that mapping renders it working, TERMINAL if it renders done or failed, and
+# otherwise UNMAPPABLE - a word this crew cannot read, whose liveness is
+# therefore unknown. ONE preference order scores the classified rows: a live
+# row outranks a terminal one, and among rows of the same class the more recent
+# wins (rows arrive newest-first, so the first row recorded in a class is that
+# class's most recent). Two kinds of row are NOT evidence and may only ever
+# SUPPRESS an answer, never supply one: a row whose head this worktree cannot
+# resolve (unknown attribution), and a row carrying an unmappable status word
+# (unknown liveness - it could be a live run, and reporting live work as
+# terminal is the defect this ordering exists to prevent). A head-verified live
+# row is never suppressed, because nothing unknown can make live work not-live.
+# The verdict is therefore: the head-verified live row if there is one; else the
+# head-verified terminal row, but only when nothing unknown outranks it; else
+# empty (which includes a branch with no matching row within
 # FM_CREW_STATE_RUNS_LIMIT rows).
 nm_runs_status_for_branch() {  # <branch>
   local branch=$1 out row st rest br sha newest_live="" newest_terminal="" suppress=0
+  # Shadow the globals nm_coarse_run_state writes, so classifying rows here
+  # cannot disturb the crew state the coarse run-step arm sets from it later.
+  local RUN_STATE="" RUN_DETAIL=""
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
   [ -n "$out" ] || return 0
   while IFS= read -r row; do
@@ -403,22 +412,25 @@ nm_runs_status_for_branch() {  # <branch>
     rest=$(trim "$rest")
     sha=${rest%% *}
     [ "$br" = "$branch" ] || continue
-    # Same code-identity rule as axi status. A head-verified non-terminal row
-    # wins outright, so the rest of the window cannot change the verdict.
+    nm_coarse_run_state "$st"
+    # Same code-identity rule as axi status. A head-verified live row wins
+    # outright, so the rest of the window cannot change the verdict; a
+    # head-verified unmappable word answers for nothing and only suppresses.
     if nm_coarse_head_matches_worktree "$sha"; then
-      case "$st" in
-        completed|failed|cancelled) [ -n "$newest_terminal" ] || newest_terminal=$st ;;
-        *)                          newest_live=$st; break ;;
+      case "$RUN_STATE" in
+        working)     newest_live=$st; break ;;
+        done|failed) [ -n "$newest_terminal" ] || newest_terminal=$st ;;
+        *)           suppress=1 ;;
       esac
     elif ! fm_nm_head_resolvable "$WT" "$sha"; then
       # Unknown attribution: this row can only outrank the best terminal
-      # candidate, never answer for it. Alive outranks terminal regardless of
-      # age; an unknown terminal row outranks only a terminal candidate not yet
-      # recorded, which newest-first ordering makes exactly "the unknown row is
-      # the newer of the two".
-      case "$st" in
-        completed|failed|cancelled) [ -n "$newest_terminal" ] || suppress=1 ;;
-        *)                          suppress=1 ;;
+      # candidate, never answer for it. Anything that is not a known terminal
+      # word outranks terminal regardless of age; an unknown terminal row
+      # outranks only a terminal candidate not yet recorded, which newest-first
+      # ordering makes exactly "the unknown row is the newer of the two".
+      case "$RUN_STATE" in
+        done|failed) [ -n "$newest_terminal" ] || suppress=1 ;;
+        *)           suppress=1 ;;
       esac
     fi
     # A resolvable head that does not match is a PROVEN mismatch (historical or
@@ -450,6 +462,26 @@ nm_run_head_matches_worktree() {
 # nm_run_head_matches_worktree (equal, or local is ancestor of run tip).
 nm_coarse_head_matches_worktree() {  # <short-sha>
   fm_nm_head_matches_worktree "$WT" "$1"
+}
+
+# Sole owner of the runs-list status vocabulary: maps one coarse status word to
+# the crew state and detail it renders as. Both the row scan in
+# nm_runs_status_for_branch, which classifies a row by what this renders for it,
+# and the coarse run-step arm below read that word set from here, so there is no
+# second copy of it to drift.
+nm_coarse_run_state() {  # <status-word>; sets RUN_STATE and RUN_DETAIL
+  case "$1" in
+    running|fixing) RUN_STATE=working; RUN_DETAIL="validating (background run)" ;;
+    ci)             RUN_STATE=working; RUN_DETAIL="ci running" ;;
+    completed)      RUN_STATE="done";  RUN_DETAIL="run completed" ;;
+    failed)         RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
+    cancelled)      RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
+    # Unreachable from the coarse run-step arm by construction: a word this case
+    # cannot render is classified unmappable by the scan, which suppresses
+    # rather than answering with it. Kept as a defensive default so any future
+    # caller reaching here cannot read a stale state instead.
+    *)              RUN_STATE=unknown; RUN_DETAIL="runs list status: $1" ;;
+  esac
 }
 
 HAVE_RUN=0
@@ -506,16 +538,10 @@ if [ "$HAVE_RUN" = 1 ]; then
     # surfaced by each supervisor's span classification (fm-classify-lib.sh's
     # status_span_first_actionable) regardless of this coarse-vs-full
     # distinction, so a real gate is never silently missed.
-    # Live status words mirror the full-status mapping below, so a run in its
-    # fix or CI phase reads as working rather than as an unrecognized word.
-    case "$COARSE_STATUS" in
-      running|fixing) RUN_STATE=working; RUN_DETAIL="validating (background run)" ;;
-      ci)             RUN_STATE=working; RUN_DETAIL="ci running" ;;
-      completed)      RUN_STATE="done";  RUN_DETAIL="run completed" ;;
-      failed)         RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
-      cancelled)      RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
-      *)              RUN_STATE=unknown; RUN_DETAIL="runs list status: $COARSE_STATUS" ;;
-    esac
+    # nm_coarse_run_state owns this word set; its live words mirror the
+    # full-status mapping below, so a run in its fix or CI phase reads as
+    # working rather than as an unrecognized word.
+    nm_coarse_run_state "$COARSE_STATUS"
   else
     status=$(strip_quotes "$(nm_field status)")
     RUN_STATUS=$status

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -79,8 +79,8 @@ fm_nm_head_matches_worktree() {  # <worktree> <run_head>
 # distinguishes a PROVEN mismatch (resolvable but not current: a historical or
 # diverged head fm_nm_head_matches_worktree correctly rejects) from UNKNOWN
 # attribution (unresolvable: e.g. a pipeline-owned lane head that never
-# reached this worktree). A caller scanning run rows newest-first must stop on
-# unknown attribution rather than surface an older, superseded run.
+# reached this worktree). It classifies only; what an unknown row suppresses is
+# the caller's decision.
 fm_nm_head_resolvable() {  # <worktree> <head>
   [ -n "$2" ] || return 1
   git -C "$1" rev-parse --verify --quiet "$2^{commit}" >/dev/null 2>&1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,7 +69,7 @@ This home's answerer close, pending-reply escalation close, and captain-held tra
 A turn-ended-only queue row omits its historical status annotation when that status file exactly matches the same seen marker.
 Any direct or remaining historical annotation prints every status line unread at the presentation cursor instead of replaying only the latest line.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes an active or terminal no-mistakes run under the shared run-attribution contract, then keeps that run-step authoritative even if the pane has closed.
-[`bin/fm-nm-run-lib.sh`](../bin/fm-nm-run-lib.sh)'s header owns the exact branch, head, pipeline-custody, and newest-first attribution rules.
+[`bin/fm-nm-run-lib.sh`](../bin/fm-nm-run-lib.sh)'s header owns the exact branch, head, and pipeline-custody attribution rules, while `nm_runs_status_for_branch` in [`bin/fm-crew-state.sh`](../bin/fm-crew-state.sh) owns the selection order applied when several newest-first runs-list rows match the same branch.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
 Only when no matching run exists does it consult semantic busy state; exact busy reports working, exact idle permits fallback to a status-log event whose verb maps to a recognized run-state, and unknown or a dead pane stays unknown instead of trusting a stale log.

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1703,6 +1703,37 @@ EOF
   pass "an older unresolvable LIVE row is never reported as the newer terminal failure"
 }
 
+# A runs-list status word the coarse mapping cannot render is not evidence: its
+# liveness is unknown, so the row could be a live run, and answering from any
+# other row would risk reporting live work as terminal. An unmappable row
+# therefore suppresses exactly as an unresolvable head does, leaving the crew
+# its pane and status-log fallback rather than a sticky unknown that both masks
+# the terminal row's verdict and blocks that fallback.
+test_coarse_unmappable_status_word_suppresses_instead_of_answering() {
+  reset_fakes
+  local d short; d=$(new_case coarse-unmappable-word)
+  make_repo_on_branch "$d/wt" fm/feat-unmapped
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-unmapped.meta" "window=fm:fm-feat-unmapped" "worktree=$d/wt" "kind=ship" "harness=claude"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  completed  fm/feat-unmapped ${short}  2026-09-03 13:55
+  awaiting_approval fm/feat-unmapped ${short}  2026-09-03 13:50
+EOF
+)"
+  FM_FAKE_BUSY=1
+  local gen; gen=$("$ROOT/bin/fm-busy-event.sh" arm "$d/state" feat-unmapped)
+  "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-unmapped busy --gen "$gen" \
+    --source claude-hook --event user-prompt-submit
+  local out; out=$(run_crew_state "$d" feat-unmapped)
+  assert_not_contains "$out" "state: unknown" "an unmappable status word must never be rendered as a state"
+  assert_not_contains "$out" "source: run-step" "a row of unknown liveness must not bind a run"
+  assert_contains "$out" "state: working" "the busy crew still reads working through the pane fallback"
+  assert_contains "$out" "source: pane" "an unmappable word falls to the pane, not a sticky unknown"
+  pass "an unmappable runs-list status word suppresses instead of answering"
+}
+
 # Negative control: the exemption is gated on pipeline_owned specifically - any
 # other branch_sync state keeps the strict head rule.
 test_non_pipeline_owned_unresolvable_head_not_attributed() {
@@ -1825,6 +1856,7 @@ test_coarse_live_ci_row_with_stale_green_log_is_not_done
 test_coarse_fixing_row_does_not_satisfy_stale_checks_green_log
 test_coarse_newer_unresolvable_terminal_row_suppresses_older_completed
 test_coarse_older_unresolvable_live_row_never_reports_failed
+test_coarse_unmappable_status_word_suppresses_instead_of_answering
 test_non_pipeline_owned_unresolvable_head_not_attributed
 test_pipeline_owned_terminal_run_not_exempt
 test_missing_run_head_falls_back_to_current_state

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1548,6 +1548,57 @@ EOF
   pass "an older terminal unresolvable row does not discard a newer head-verified match"
 }
 
+# The shape that defeated a per-row decision: the scan must read the WHOLE
+# window before answering. A newer terminal row at the exact worktree head and
+# a terminal row at an unresolvable head sit above an OLDER live row whose head
+# is a verified descendant of this worktree. Answering at either earlier row
+# reports live work as failed.
+test_coarse_full_scan_finds_live_row_below_terminal_rows() {
+  reset_fakes
+  local d base advanced; d=$(new_case coarse-full-scan)
+  make_repo_on_branch "$d/wt" fm/feat-scan
+  git -C "$d/wt" commit -q --allow-empty -m advance
+  advanced=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  git -C "$d/wt" reset -q --hard HEAD~1
+  base=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-scan.meta" "window=fm:fm-feat-scan" "worktree=$d/wt" "kind=ship" "harness=claude"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  failed     fm/feat-scan ${base}  2026-09-03 13:55
+  cancelled  fm/feat-scan f0f0f0f0  2026-09-03 13:50
+  running    fm/feat-scan ${advanced}  2026-09-03 13:40
+EOF
+)"
+  local out; out=$(run_crew_state "$d" feat-scan)
+  assert_not_contains "$out" "state: failed" "an unread live row below two terminal rows must not report failed"
+  assert_contains "$out" "state: working" "the full scan reaches the live row and it wins"
+  assert_contains "$out" "source: run-step" "the live row binds as run-step"
+  pass "the scan reads every row before answering, so a live row below terminal rows still wins"
+}
+
+# The coarse mapping must recognize every live run status word the full-status
+# mapping does, or a preferred live row renders as an unrecognized word.
+test_coarse_live_fixing_row_reads_working_not_unknown() {
+  reset_fakes
+  local d short; d=$(new_case coarse-live-fixing)
+  make_repo_on_branch "$d/wt" fm/feat-fixing
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-fixing.meta" "window=fm:fm-feat-fixing" "worktree=$d/wt" "kind=ship" "harness=claude"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  failed     fm/feat-fixing ${short}  2026-09-03 13:55
+  fixing     fm/feat-fixing ${short}  2026-09-03 13:50
+EOF
+)"
+  local out; out=$(run_crew_state "$d" feat-fixing)
+  assert_not_contains "$out" "state: unknown" "a live fixing row must not render as an unknown status word"
+  assert_not_contains "$out" "state: failed" "a live fixing row must not be reported as the newer failed run"
+  assert_contains "$out" "state: working" "a run in its fix phase reads as working"
+  pass "a live fixing row reads working rather than unknown"
+}
+
 # The same stop, with the older row ALIVE: a live pipeline-owned run's lane head
 # is routinely not a git object in the task worktree (rebase and fix commits
 # never pushed back), so an unresolvable ACTIVE row is genuine unknown
@@ -1694,6 +1745,8 @@ test_failed_run_with_no_later_run_still_surfaces
 test_coarse_unresolvable_active_row_never_falls_to_older_row
 test_coarse_live_run_beats_terminal_run_at_exact_head
 test_coarse_older_unresolvable_row_keeps_newer_terminal_match
+test_coarse_full_scan_finds_live_row_below_terminal_rows
+test_coarse_live_fixing_row_reads_working_not_unknown
 test_coarse_older_unresolvable_live_row_never_reports_failed
 test_non_pipeline_owned_unresolvable_head_not_attributed
 test_pipeline_owned_terminal_run_not_exempt

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1625,6 +1625,30 @@ EOF
   pass "a coarse fixing row does not satisfy a stale checks-green log line"
 }
 
+# The false-green direction of the same rule. The NEWEST row ended badly at a
+# head this worktree cannot resolve, so it outranks the older head-verified
+# `completed` row beneath it and must suppress the answer. Reporting done here
+# is not cosmetic: bin/fm-inactive-reconcile.sh records a durable terminal
+# outcome and wakes the supervisor on a done verdict.
+test_coarse_newer_unresolvable_terminal_row_suppresses_older_completed() {
+  reset_fakes
+  local d short; d=$(new_case coarse-unresolvable-false-green)
+  make_repo_on_branch "$d/wt" fm/feat-falsegreen
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-falsegreen.meta" "window=fm:fm-feat-falsegreen" "worktree=$d/wt" "kind=ship" "harness=claude"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  cancelled  fm/feat-falsegreen f0f0f0f0  2026-09-03 14:10
+  completed  fm/feat-falsegreen ${short}  2026-09-03 13:40
+EOF
+)"
+  local out; out=$(run_crew_state "$d" feat-falsegreen)
+  assert_not_contains "$out" "state: done" "an older completed row must not answer for a newer unresolvable terminal row"
+  assert_not_contains "$out" "source: run-step" "the suppressed scan must not bind a run-step verdict"
+  pass "a newer unresolvable terminal row suppresses an older completed row"
+}
+
 # The same stop, with the older row ALIVE: a live pipeline-owned run's lane head
 # is routinely not a git object in the task worktree (rebase and fix commits
 # never pushed back), so an unresolvable ACTIVE row is genuine unknown
@@ -1774,6 +1798,7 @@ test_coarse_older_unresolvable_row_keeps_newer_terminal_match
 test_coarse_full_scan_finds_live_row_below_terminal_rows
 test_coarse_live_fixing_row_reads_working_not_unknown
 test_coarse_fixing_row_does_not_satisfy_stale_checks_green_log
+test_coarse_newer_unresolvable_terminal_row_suppresses_older_completed
 test_coarse_older_unresolvable_live_row_never_reports_failed
 test_non_pipeline_owned_unresolvable_head_not_attributed
 test_pipeline_owned_terminal_run_not_exempt

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1599,6 +1599,32 @@ EOF
   pass "a live fixing row reads working rather than unknown"
 }
 
+# A crew appends "done: PR <url> checks green" at the CI-ready return point and
+# stops, while the run keeps monitoring in the background and can re-enter
+# fixing later. The coarse arm cannot read the run status field (it belongs to
+# another branch), so the runs-list status word must carry the invariant: a
+# live fix round never satisfies the stale checks-green log line.
+test_coarse_fixing_row_does_not_satisfy_stale_checks_green_log() {
+  reset_fakes
+  local d short; d=$(new_case coarse-fixing-stale-green)
+  make_repo_on_branch "$d/wt" fm/feat-fixgreen
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-fixgreen.meta" "window=fm:fm-feat-fixgreen" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'done: PR https://github.com/o/r/pull/7 checks green\n' > "$d/state/feat-fixgreen.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  failed     fm/feat-fixgreen ${short}  2026-09-03 13:55
+  fixing     fm/feat-fixgreen ${short}  2026-09-03 13:50
+EOF
+)"
+  local out; out=$(run_crew_state "$d" feat-fixgreen)
+  assert_not_contains "$out" "state: done" "a live fix round must not be reported done by a stale checks-green log"
+  assert_not_contains "$out" "state: failed" "a live fix round must not be reported as the newer failed run"
+  assert_contains "$out" "state: working" "a live fix round reads working"
+  pass "a coarse fixing row does not satisfy a stale checks-green log line"
+}
+
 # The same stop, with the older row ALIVE: a live pipeline-owned run's lane head
 # is routinely not a git object in the task worktree (rebase and fix commits
 # never pushed back), so an unresolvable ACTIVE row is genuine unknown
@@ -1747,6 +1773,7 @@ test_coarse_live_run_beats_terminal_run_at_exact_head
 test_coarse_older_unresolvable_row_keeps_newer_terminal_match
 test_coarse_full_scan_finds_live_row_below_terminal_rows
 test_coarse_live_fixing_row_reads_working_not_unknown
+test_coarse_fixing_row_does_not_satisfy_stale_checks_green_log
 test_coarse_older_unresolvable_live_row_never_reports_failed
 test_non_pipeline_owned_unresolvable_head_not_attributed
 test_pipeline_owned_terminal_run_not_exempt

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1489,6 +1489,38 @@ EOF
   pass "coarse scan stops on an unresolvable active row instead of binding an older one"
 }
 
+# Two same-branch rows can BOTH satisfy the head rule for one worktree: a
+# terminal run left at the exact worktree head, and a live run whose pipeline
+# fix commits advanced its tip past that head. Taking the terminal one reports
+# live unlanded work as failed, which a supervision turn can act on by cleaning
+# it up, so a non-terminal match always outranks a terminal one.
+test_coarse_live_run_beats_terminal_run_at_exact_head() {
+  reset_fakes
+  local d base advanced; d=$(new_case coarse-live-beats-terminal)
+  make_repo_on_branch "$d/wt" fm/feat-live
+  # A descendant commit the worktree HEAD is an ancestor of - the live run's
+  # tip after its own pipeline fix commits, which never came back here.
+  git -C "$d/wt" commit -q --allow-empty -m advance
+  advanced=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  git -C "$d/wt" reset -q --hard HEAD~1
+  base=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-live.meta" "window=fm:fm-feat-live" "worktree=$d/wt" "kind=ship" "harness=claude"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  # Newest-first: the later-started run that already failed sits at the exact
+  # worktree head, above the still-running one that advanced past it.
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  failed     fm/feat-live ${base}  2026-09-03 13:55
+  running    fm/feat-live ${advanced}  2026-09-03 13:50
+EOF
+)"
+  local out; out=$(run_crew_state "$d" feat-live)
+  assert_not_contains "$out" "state: failed" "a live run must not be reported as the terminal run at the same head"
+  assert_contains "$out" "state: working" "the live run at the advanced head wins"
+  assert_contains "$out" "source: run-step" "the live run is run-step sourced"
+  pass "a live run beats a terminal run left at the exact worktree head"
+}
+
 # Negative control: the exemption is gated on pipeline_owned specifically - any
 # other branch_sync state keeps the strict head rule.
 test_non_pipeline_owned_unresolvable_head_not_attributed() {
@@ -1603,6 +1635,7 @@ test_local_advanced_past_run_head_invalidates
 test_pipeline_owned_active_run_beats_superseded_failed_row
 test_failed_run_with_no_later_run_still_surfaces
 test_coarse_unresolvable_active_row_never_falls_to_older_row
+test_coarse_live_run_beats_terminal_run_at_exact_head
 test_non_pipeline_owned_unresolvable_head_not_attributed
 test_pipeline_owned_terminal_run_not_exempt
 test_missing_run_head_falls_back_to_current_state

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1599,6 +1599,30 @@ EOF
   pass "a live fixing row reads working rather than unknown"
 }
 
+# A re-armed ci run carries a checks-green status line written before the
+# re-arm, and the coarse arm cannot read the ci log to notice. Emitting done
+# there is not cosmetic: bin/fm-inactive-reconcile.sh hardens a done verdict
+# into a durable terminal outcome and wakes the supervisor while validation is
+# still running. Narrow by design - see task coarse-emit-currency-polarity.
+test_coarse_live_ci_row_with_stale_green_log_is_not_done() {
+  reset_fakes
+  local d short; d=$(new_case coarse-live-ci-stale-green)
+  make_repo_on_branch "$d/wt" fm/feat-rearm
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-rearm.meta" "window=fm:fm-feat-rearm" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'done: PR https://github.com/o/r/pull/9 checks green\n' > "$d/state/feat-rearm.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  ci         fm/feat-rearm ${short}  2026-09-03 14:00
+EOF
+)"
+  local out; out=$(run_crew_state "$d" feat-rearm)
+  assert_not_contains "$out" "state: done" "a re-armed ci run must not answer done from a stale checks-green line"
+  assert_contains "$out" "state: working" "the live ci run reads working"
+  pass "a live ci row does not emit done from a stale checks-green log line"
+}
+
 # A crew appends "done: PR <url> checks green" at the CI-ready return point and
 # stops, while the run keeps monitoring in the background and can re-enter
 # fixing later. The coarse arm cannot read the run status field (it belongs to
@@ -1797,6 +1821,7 @@ test_coarse_live_run_beats_terminal_run_at_exact_head
 test_coarse_older_unresolvable_row_keeps_newer_terminal_match
 test_coarse_full_scan_finds_live_row_below_terminal_rows
 test_coarse_live_fixing_row_reads_working_not_unknown
+test_coarse_live_ci_row_with_stale_green_log_is_not_done
 test_coarse_fixing_row_does_not_satisfy_stale_checks_green_log
 test_coarse_newer_unresolvable_terminal_row_suppresses_older_completed
 test_coarse_older_unresolvable_live_row_never_reports_failed

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1521,6 +1521,33 @@ EOF
   pass "a live run beats a terminal run left at the exact worktree head"
 }
 
+# The unresolvable-head stop must not un-answer a row already verified as this
+# worktree's. A terminal run at the exact head sits ABOVE an older row whose
+# pipeline lane head never reached this worktree, so the scan reaches the stop
+# holding a proven answer; an older unknown row cannot supersede it.
+test_coarse_older_unresolvable_row_keeps_newer_terminal_match() {
+  reset_fakes
+  local d short; d=$(new_case coarse-older-unresolvable)
+  make_repo_on_branch "$d/wt" fm/feat-keep
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-keep.meta" "window=fm:fm-feat-keep" "worktree=$d/wt" "kind=ship" "harness=claude"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  failed     fm/feat-keep ${short}  2026-09-03 13:55
+  running    fm/feat-keep f0f0f0f0  2026-09-03 13:50
+EOF
+)"
+  FM_FAKE_BUSY=1
+  local gen; gen=$("$ROOT/bin/fm-busy-event.sh" arm "$d/state" feat-keep)
+  "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-keep busy --gen "$gen" \
+    --source claude-hook --event user-prompt-submit
+  local out; out=$(run_crew_state "$d" feat-keep)
+  assert_contains "$out" "state: failed" "the head-verified newer terminal row must still answer"
+  assert_contains "$out" "source: run-step" "the verified row binds as run-step"
+  pass "an older unresolvable row does not discard a newer head-verified match"
+}
+
 # Negative control: the exemption is gated on pipeline_owned specifically - any
 # other branch_sync state keeps the strict head rule.
 test_non_pipeline_owned_unresolvable_head_not_attributed() {
@@ -1636,6 +1663,7 @@ test_pipeline_owned_active_run_beats_superseded_failed_row
 test_failed_run_with_no_later_run_still_surfaces
 test_coarse_unresolvable_active_row_never_falls_to_older_row
 test_coarse_live_run_beats_terminal_run_at_exact_head
+test_coarse_older_unresolvable_row_keeps_newer_terminal_match
 test_non_pipeline_owned_unresolvable_head_not_attributed
 test_pipeline_owned_terminal_run_not_exempt
 test_missing_run_head_falls_back_to_current_state

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1522,9 +1522,9 @@ EOF
 }
 
 # The unresolvable-head stop must not un-answer a row already verified as this
-# worktree's. A terminal run at the exact head sits ABOVE an older row whose
-# pipeline lane head never reached this worktree, so the scan reaches the stop
-# holding a proven answer; an older unknown row cannot supersede it.
+# worktree's. A terminal run at the exact head sits ABOVE an older TERMINAL row
+# whose head this worktree cannot resolve, so the scan reaches the stop holding
+# a proven answer; an older dead unknown row cannot supersede it.
 test_coarse_older_unresolvable_row_keeps_newer_terminal_match() {
   reset_fakes
   local d short; d=$(new_case coarse-older-unresolvable)
@@ -1535,7 +1535,7 @@ test_coarse_older_unresolvable_row_keeps_newer_terminal_match() {
   FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
   FM_FAKE_RUNS_LIST="$(cat <<EOF
   failed     fm/feat-keep ${short}  2026-09-03 13:55
-  running    fm/feat-keep f0f0f0f0  2026-09-03 13:50
+  cancelled  fm/feat-keep f0f0f0f0  2026-09-03 13:50
 EOF
 )"
   FM_FAKE_BUSY=1
@@ -1545,7 +1545,37 @@ EOF
   local out; out=$(run_crew_state "$d" feat-keep)
   assert_contains "$out" "state: failed" "the head-verified newer terminal row must still answer"
   assert_contains "$out" "source: run-step" "the verified row binds as run-step"
-  pass "an older unresolvable row does not discard a newer head-verified match"
+  pass "an older terminal unresolvable row does not discard a newer head-verified match"
+}
+
+# The same stop, with the older row ALIVE: a live pipeline-owned run's lane head
+# is routinely not a git object in the task worktree (rebase and fix commits
+# never pushed back), so an unresolvable ACTIVE row is genuine unknown
+# attribution. Answering it with the newer terminal row would report live work
+# as failed - the exact safety defect this selection order exists to prevent.
+test_coarse_older_unresolvable_live_row_never_reports_failed() {
+  reset_fakes
+  local d short; d=$(new_case coarse-older-unresolvable-live)
+  make_repo_on_branch "$d/wt" fm/feat-alive
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-alive.meta" "window=fm:fm-feat-alive" "worktree=$d/wt" "kind=ship" "harness=claude"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  failed     fm/feat-alive ${short}  2026-09-03 13:55
+  running    fm/feat-alive f0f0f0f0  2026-09-03 13:50
+EOF
+)"
+  FM_FAKE_BUSY=1
+  local gen; gen=$("$ROOT/bin/fm-busy-event.sh" arm "$d/state" feat-alive)
+  "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-alive busy --gen "$gen" \
+    --source claude-hook --event user-prompt-submit
+  local out; out=$(run_crew_state "$d" feat-alive)
+  assert_not_contains "$out" "state: failed" "a live unresolvable row must not be answered with the newer failed row"
+  assert_not_contains "$out" "source: run-step" "unknown attribution must not bind a run"
+  assert_contains "$out" "state: working" "the busy crew reads working through the pane fallback"
+  assert_contains "$out" "source: pane" "unknown attribution falls to the pane, not the newer terminal row"
+  pass "an older unresolvable LIVE row is never reported as the newer terminal failure"
 }
 
 # Negative control: the exemption is gated on pipeline_owned specifically - any
@@ -1664,6 +1694,7 @@ test_failed_run_with_no_later_run_still_surfaces
 test_coarse_unresolvable_active_row_never_falls_to_older_row
 test_coarse_live_run_beats_terminal_run_at_exact_head
 test_coarse_older_unresolvable_row_keeps_newer_terminal_match
+test_coarse_older_unresolvable_live_row_never_reports_failed
 test_non_pipeline_owned_unresolvable_head_not_attributed
 test_pipeline_owned_terminal_run_not_exempt
 test_missing_run_head_falls_back_to_current_state


### PR DESCRIPTION
## Intent

Fix a safety defect in bin/fm-crew-state.sh: it could report a LIVE, actively-running no-mistakes validation as a terminal failure. AGENTS.md treats run-step state as authoritative over the status log, so a supervision turn trusting that verdict would treat live unlanded work as failed and could clean it up.

Reproduced in the field: worktree HEAD 1194e28, a FAILED run sitting at exactly 1194e28, and a LIVE run advanced to 725877ed with its agent alive. nm_runs_status_for_branch answered from the first row whose head satisfied the shared head rule, and that rule matches both an equal head and one the worktree HEAD is an ancestor of, so the dead row won by sitting higher in the newest-first listing. axi status resolved the live run correctly from the same data, proving the data was fine and the selection was wrong.

ACCEPTED REQUIREMENT. Scan every same-branch row before deciding anything, then apply one preference order: a non-terminal row outranks a terminal one, and among rows of the same class the more recent wins. A row whose head this worktree cannot resolve is unknown attribution, so it may only ever SUPPRESS an answer, never supply one; a head-verified non-terminal row is never suppressed, because nothing unknown can make live work not-live. Verdict: the head-verified non-terminal row if there is one; else the head-verified terminal row, but only when no unresolvable row outranks it; else empty.

That single principle replaced four ad-hoc conditions earlier rounds had accumulated on the unresolvable-head case, which are now consequences rather than rules: an unknown terminal row OLDER than a head-verified terminal row does not outrank it, so that row still answers; an unknown LIVE row outranks any terminal candidate regardless of age; an unknown terminal row NEWER than the terminal candidate supersedes it, closing a false-green path where an older completed row answered done for a branch whose newest run ended badly at an unreadable head. A resolvable head that does not match stays a proven mismatch and masks nothing.

ALSO ACCEPTED. The coarse status mapping recognized only the literal word running as live, so a preferred row in its fix or CI phase rendered as unknown; it now mirrors the full-status mapping for fixing and ci, with the checks-green short-circuit gated so a live fix round can never satisfy it. fm_nm_head_resolvable's header in bin/fm-nm-run-lib.sh claimed a newest-first caller must stop on unknown attribution, which its only caller no longer does, so it now describes what the helper actually promises. docs/architecture.md attributed the selection order to that shared helper and now points at the function that owns it.

SCOPE. Bounded to nm_runs_status_for_branch, its coarse call site, and that one helper comment. No new abstraction, run-state model, config knob, or parallel resolver.

TESTS. Five regressions in tests/fm-crew-state.test.sh, each verified directly to fail against the preceding commit with the exact wrong verdict it prevents, not assumed: dead-run-at-exact-head versus live-run-at-advanced-head fails with "state: failed"; live row below two terminal rows fails with "state: failed"; newer unresolvable terminal row above an older completed row fails with "state: done"; live fixing row fails with "state: unknown"; older unresolvable live row versus newer verified terminal row fails with "state: failed". Behavior is unchanged when only one row matches. bin/fm-lint.sh exits 0 and the change is shellcheck-clean. Repo rules applied per firstmate-coding-guidelines: one sentence per line in tracked Markdown, plain dash, no agent co-author, tests colocated in the existing runner, behavior exercised through the executable interface, and the function header patched in place as the one owner of the selection contract.

DELIVERY. Publication is open and this run must push and raise the PR itself, so do not skip push, pr or ci. This branch is fm/crew-state-live-run-precedence-rebased, a deliberately renamed sibling of fm/crew-state-live-run-precedence carrying the identical commits. The rename is required infrastructure hygiene, not a content change: the branch was rebased onto current upstream main (7dcf0721) mid-task, which rewrote its commits, while the local no-mistakes gate repo still holds the old name at the pre-rebase head 054a4199. Every push under the old name was therefore non-fast-forward and failed, surfacing misleadingly as "signal: broken pipe" rather than a readable refusal. The gate is scratch validation infrastructure rather than a durable record, so a fresh name crosses nothing, whereas resetting its stale ref would mutate shared firstmate-managed state and force-pushing is forbidden.

An earlier hand-raised PR, https://github.com/kunchenguid/firstmate/pull/3646, carries the identical change but fails upstream's required "PR must be raised via no-mistakes" check, because a hand-raised body carries none of the deterministic Pipeline section, signature or attestation the gate verifies. It can never go green as it stands and is being superseded by the PR this run raises. It is deliberately being left open for now; disposing of it is the captain's decision, not this run's. Raise a new pull request for this branch against kunchenguid/firstmate.

DO NOT MERGE: raising the PR proposes the change and the captain merges it. Never force-push, never retarget a remote, never touch this home's diverged main. One unrelated modified file, CLAUDE.md, is present in the worktree from a code-intelligence auto-index hook; it is deliberately uncommitted and must stay out of this branch.

ALSO ACCEPTED, folded in this round. An external reviewer flagged that the coarse checks-green guard excluded only fixing, so a run that re-enters ci after a check flipped or the base advanced still answered done from the checks-green status line written before the re-arm, and bin/fm-inactive-reconcile.sh hardens a done verdict into a durable terminal outcome. ci reaches that path only because this change added it to the coarse live class. The guard now excludes ci alongside fixing, with a colocated regression test verified to fail without it with "state: done".

That exclusion is deliberately NARROW and is not a general rule, which is an accepted decision rather than an oversight. The coarse arm cannot establish that a checks-green line still speaks for the CURRENT run in any live state, running included, while the full arm emits unless a not-ready CI state is proven - the opposite polarity, pinned by test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status. Inverting that default would change accepted tested behaviour on a path used well beyond the reported defect, so it is filed as its own task, coarse-emit-currency-polarity, and the code comment points there. Do not widen the exclusion list or invert the polarity on this run's initiative.

## What Changed

- `nm_runs_status_for_branch` in `bin/fm-crew-state.sh` now scans every same-branch runs-list row before answering, instead of returning the first row whose head satisfied the shared head rule. One preference order decides the verdict: a head-verified live row wins outright, else the newest head-verified terminal row, and only when no row of unknown attribution or unmappable status word outranks it — otherwise it answers empty. Rows this worktree cannot resolve may only suppress an answer, never supply one.
- Added `nm_coarse_run_state` as the sole owner of the coarse status vocabulary, mapping `fixing` and `ci` to working alongside `running` so a live row no longer renders as unknown. The coarse checks-green short-circuit now excludes `fixing` and `ci`, so a stale green log line written before a re-armed fix or CI round can no longer emit `done`; a code comment points at the `coarse-emit-currency-polarity` task for the wider polarity question.
- Nine regression tests in `tests/fm-crew-state.test.sh` cover the selection order, the live `fixing`/`ci` mappings, and the stale-checks-green cases. Updated `fm_nm_head_resolvable`'s header in `bin/fm-nm-run-lib.sh` to describe what it actually promises, and repointed `docs/architecture.md` at the function that now owns the selection order.

## Risk Assessment

✅ Low: The change is tightly bounded to one selection function, its single coarse call site, and one helper comment; every new branch traces to a concrete failing sequence, the classification is exhaustive over all resolvable-by-mappable row combinations, the checks-green restructure is provably behavior-preserving for the full path, and each of the nine added tests exercises the executable interface and discriminates against the pre-fix code.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (6m49s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"80fbbff8f2efab4b8e100d135a4f000f69b917ea","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-crew-state.sh:411` - The new live/terminal classification treats EVERY status word outside completed|failed|cancelled as live (line 411), so such a row now wins outright over a newer head-verified terminal row - but the coarse mapping at line 511 only names running|fixing|ci, so any other live word falls to the `*)` arm and reports `state: unknown . source: run-step . runs list status: &lt;word&gt;`. The no-mistakes binary does emit `awaiting_approval` and `fix_review` as run statuses (both present in the installed binary&#39;s strings; the runs table format is `  %-12s %-20s %s  %s%s`, so they appear verbatim in the status column). Concrete failing sequence: rows newest-first `completed fm/x &lt;worktree-head&gt;` then `awaiting_approval fm/x &lt;worktree-head&gt;` (an abandoned earlier gate run on the same branch). Before this change the scan returned the first head-matching row and the crew read `state: done`; now the older non-terminal row outranks it, HAVE_RUN=1 binds, and the crew reads `state: unknown` on every heartbeat - which both suppresses the correct done verdict and blocks the pane/log fallback that line 517&#39;s `unknown` would otherwise have needed. Same shape with `failed` as the newest row silently drops a true failure signal that bin/fm-inactive-reconcile.sh would have recorded. The defect is mechanical but the remedy is not: either map awaiting_approval/fix_review to `parked` in the coarse arm, or exclude non-run phase words from the live class - both extend the change beyond the intent&#39;s stated scope (&#34;it now mirrors the full-status mapping for fixing and ci&#34;), so the remedy, not the defect, is what needs authorization.
- ℹ️ `bin/fm-crew-state.sh:594` - The checks-green guard is a deny-list over COARSE_STATUS, but the enclosing `RUN_STATE = working` condition already restricts COARSE_STATUS to exactly {running, fixing, ci}, so the `*)` emit arm is reachable only with `running` today. That makes the deny-list and an allow-list on `running` behaviourally identical now, and different only if the coarse live class at line 511 later grows - the exact widening hazard the adjacent comment warns about. Noting the tradeoff only: converting it to an allow-list would flip the emit default in live states, which is the polarity question the intent explicitly files as task coarse-emit-currency-polarity and forbids resolving on this run&#39;s initiative. No action.

🔧 Fix: suppress unmappable runs-list status words in coarse scan
1 info still open:

- ℹ️ `bin/fm-crew-state.sh:423` - The intent&#39;s ACCEPTED REQUIREMENT states the verdict as &#34;the head-verified non-terminal row if there is one; else the head-verified terminal row...&#34; and scopes SUPPRESS to &#34;a row whose head this worktree cannot resolve.&#34; The code at line 423 now also suppresses on a THIRD class the intent never names: a head-verified row whose status word nm_coarse_run_state cannot render (e.g. `awaiting_approval`, `fix_review`). Concrete divergence: a single row `awaiting_approval fm/x &lt;worktree-head&gt;` is head-verified and non-terminal, so the literal intent requires it to supply the verdict; the code returns empty instead and falls through to the pane/status-log fallback. This behavior is correct and was explicitly directed by this run&#39;s own prior review round (user_chose_to_fix on `coarse-unmapped-live-status-word`, whose instructions prescribed exactly this suppression using the existing flag). The gap is in the intent record, not the code: the intent folded in the earlier `ci`-exclusion decision under &#34;ALSO ACCEPTED, folded in this round&#34; but was not amended for this one, so the authoritative acceptance text and the shipped selection contract no longer agree. The remedy is to record the accepted decision in the intent (or confirm it), not to change code - which is why this needs the author rather than an auto-fix.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
