### PR TITLE
fix(herdr): classify a proven-stale idle registration as agent-free

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1862,12 +1862,31 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
   [ "$presence" = dead ]
 }
 
+# fm_backend_herdr_idle_registration_is_stale: an `idle` registration is
+# agent-free only when the pane independently proves it has returned to its
+# one bare, idle shell and a second registry read is still `idle`. A pi
+# process that exits without emitting its end-of-session hook leaves exactly
+# this shape behind: herdr's "full_lifecycle_hook_authority" screen-detection
+# skip means it never re-reads the screen to notice the process is gone, so
+# the registration otherwise never clears (verified on herdr 0.8.2).
+# The shared idle-shell proof rejects foreground commands, children, active
+# jobs, unknown process identities, and unreadable process data - the exact
+# same proof fm_backend_herdr_pane_idle_shell_pid already provides for
+# session-start projection cleanup and pane-death close paths. This helper
+# only observes; it never signals or closes the pane.
+fm_backend_herdr_idle_registration_is_stale() {  # <session> <pane_id>
+  local session=$1 pane_id=$2
+  fm_backend_herdr_pane_idle_shell_pid "$session" "$pane_id" >/dev/null || return 1
+  [ "$(fm_backend_herdr_agent_status_raw "$session" "$pane_id")" = "idle" ]
+}
+
 # fm_backend_herdr_pane_agent_state: classify <pane_id> in <session> as one of
-# dead|no-agent|live|unknown, purely from the JSON body of two read-only
-# calls - never from process exit status, since a business-logic "not found"
-# response is a normal, expected outcome here, not a call failure (real herdr
-# 0.7.1 exits 1 for it; the canned-response test fakes exit 0; parsing only
-# the JSON keeps this function correct against either).
+# dead|no-agent|stale-idle|live|unknown, purely from the JSON body of two
+# read-only calls plus, for a candidate stale idle registration, the shared
+# process proof below - never from process exit status, since a business-logic
+# "not found" response is a normal, expected outcome here, not a call failure
+# (real herdr 0.7.1 exits 1 for it; the canned-response test fakes exit 0;
+# parsing only the JSON keeps this function correct against either).
 #
 #   dead     - `pane get` responds with error code pane_not_found: the pane
 #              itself is gone (closed, or its process died and herdr already
@@ -1883,10 +1902,19 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 #              stability across a server restart"), and what a future
 #              `resume_agents_on_restore = false` restore would produce too
 #              (a plain shell, never an agent).
-#   live     - `agent get` succeeds and reports a real agent_status (working,
-#              idle, done, or blocked - any registered value). An idle or
-#              blocked agent is still a genuine, still-registered agent, not
-#              a restored husk, so it is never a close-and-replace candidate.
+#   stale-idle - an `idle` registration proved agent-free by the strict
+#              bare-idle-shell proof and a second `agent get` that still
+#              reports `idle`. Kept distinct from no-agent so a relaunch can
+#              require the same proof again immediately before it sends any
+#              input (bin/fm-spawn.sh's --relaunch path).
+#   live     - `agent get` succeeds and reports working, done, or blocked, or
+#              reports idle without a proven-stale bare shell underneath it.
+#              Any of these remains a genuine, still-registered agent, not a
+#              restored husk, so it is never a close-and-replace candidate.
+#              An idle pane whose process evidence is merely unreadable or
+#              ambiguous - never proven bare-idle - stays live rather than
+#              stale-idle: a false agent-free verdict here risks launching a
+#              second agent onto live work, which is far worse than refusing.
 #   unknown  - anything else: an unparseable/unexpected response from either
 #              call, or a `pane get` success whose own echoed pane_id does not
 #              round-trip (guards against misreading a herdr response shape
@@ -1911,7 +1939,14 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   fi
   status=$(printf '%s' "$out" | jq -r '.result.agent.agent_status // empty' 2>/dev/null)
   case "$status" in
-    working|idle|done|blocked) printf 'live' ;;
+    working|done|blocked) printf 'live' ;;
+    idle)
+      if fm_backend_herdr_idle_registration_is_stale "$session" "$pane_id"; then
+        printf 'stale-idle'
+      else
+        printf 'live'
+      fi
+      ;;
     *) printf 'unknown' ;;
   esac
 }
@@ -1921,6 +1956,11 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
 # confirm; live and unknown both refuse (1), so an inconclusive read never
 # licenses closing anything. Restored-layout recovery depends on this
 # fail-safe-toward-refusal behavior.
+# A separately proven `stale-idle` pane deliberately refuses here (1) too:
+# this duplicate-tab close path has no revalidation immediately before the
+# close, unlike the relaunch path that requires a fresh proof right before it
+# sends any input (bin/fm-spawn.sh's --relaunch path), so it stays out of the
+# husk set this function grants close authority for.
 fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
   case "$(fm_backend_herdr_pane_agent_state "$1" "$2")" in
     dead|no-agent) return 0 ;;
@@ -1931,7 +1971,8 @@ fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
 # fm_backend_herdr_agent_state: recovery-grade state for the same session-start
 # sweep as the tmux classifier. It reuses the husk classifier rather than
 # creating a second Herdr state machine: a structurally gone pane is `missing`,
-# a confirmed agent-less pane is `dead`, a registered agent is `alive`, and an
+# a confirmed agent-less pane is `dead`, a strictly proved stale idle
+# registration is `stale-idle`, a registered agent is `alive`, and an
 # unexpected or failed API read is `unreadable`.
 fm_backend_herdr_agent_state() {  # <target>
   local target=$1
@@ -1939,6 +1980,7 @@ fm_backend_herdr_agent_state() {  # <target>
   case "$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")" in
     dead) printf 'missing' ;;
     no-agent) printf 'dead' ;;
+    stale-idle) printf 'stale-idle' ;;
     live) printf 'alive' ;;
     *) printf 'unreadable' ;;
   esac

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -876,12 +876,16 @@ fm_backend_target_exists() {  # <backend> <target> [expected-label]
 #   alive      - a verified harness agent is running.
 #   dead       - the endpoint exists but confidently has no agent.
 #   missing    - the recorded endpoint is authoritatively absent.
+#   stale-idle - herdr only: an idle registration strictly proved detached
+#                from its agent. Not one of the two values that license
+#                generic recovery; bin/fm-spawn.sh's --relaunch path owns its
+#                dedicated, revalidated replacement flow.
 #   ambiguous  - the endpoint exists but its process cannot be attributed.
 #   unreadable - a target or inventory read failed or contradicted itself.
 #   unverified - this backend has no recovery classifier.
-# Only `dead` and `missing` license recovery. The tmux adapter requires a
-# successful session inventory and returns `missing` only when it omits the
-# exact window; the Herdr adapter reuses its husk
+# Only `dead` and `missing` license generic recovery. The tmux adapter
+# requires a successful session inventory and returns `missing` only when it
+# omits the exact window; the Herdr adapter reuses its husk
 # classifier. Zellij remains unverified because its secondmate ghost-tab and
 # agent-process recovery path has not been empirically validated. Orca and cmux
 # do not support secondmate spawns.

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -449,7 +449,7 @@ do_exit() {
   require_state_verified_backend exit
   state=$(agent_state)
   case "$state" in
-    dead)
+    dead|stale-idle)
       printf 'already-stopped'
       return 0
       ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1089,6 +1089,7 @@ FIRSTMATE_HOME=
 # validation teardown uses, so a malformed, ambiguous, or foreign record
 # refuses here exactly as it refuses there.
 RELAUNCH_PRIOR_HARNESS=
+RELAUNCH_HERDR_PANE_STATE=
 if [ "$RELAUNCH" -eq 1 ]; then
   [ "${#POS[@]}" -eq 1 ] || {
     echo "error: --relaunch takes the task id only; its project or home comes from the task's own record" >&2
@@ -1122,7 +1123,24 @@ if [ "$RELAUNCH" -eq 1 ]; then
     echo "error: backend '$BACKEND' has no recovery-grade agent-state classifier, so a relaunch cannot prove the previous agent exited; refusing rather than risking two agents in one endpoint" >&2
     exit 1
   }
-  RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
+  # herdr's stale-idle registration needs its own branch here: it is provably
+  # agent-free right now, but the proof is a point-in-time process read rather
+  # than the hard, permanent fact no-agent is, so fm_backend_agent_state's
+  # generic dead cannot absorb it without losing the ability to require a
+  # fresh proof again immediately before the first launch input (the recheck
+  # right before send below).
+  if [ "$BACKEND" = herdr ]; then
+    fm_backend_herdr_parse_target "$RELAUNCH_TARGET" || exit 1
+    RELAUNCH_HERDR_PANE_STATE=$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
+    case "$RELAUNCH_HERDR_PANE_STATE" in
+      no-agent|stale-idle) RELAUNCH_STATE=dead ;;
+      dead) RELAUNCH_STATE=missing ;;
+      live) RELAUNCH_STATE=alive ;;
+      *) RELAUNCH_STATE=unreadable ;;
+    esac
+  else
+    RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
+  fi
   [ "$RELAUNCH_STATE" = dead ] || {
     echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
     exit 1
@@ -3034,6 +3052,21 @@ spawn_record_traceparent() {
   return "$status"
 }
 
+# A herdr relaunch's classified pane state may be minutes old by this point
+# (worktree checks, traceparent resolution, and everything else above run in
+# between), so require the exact same proof again right before the first
+# input reaches the pane rather than trusting the earlier snapshot.
+if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
+  fm_backend_herdr_parse_target "$T" || {
+    echo "error: task $ID's herdr endpoint became malformed before replacement input; refusing relaunch" >&2
+    exit 1
+  }
+  RELAUNCH_RECHECK_STATE=$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
+  if [ "$RELAUNCH_RECHECK_STATE" != "$RELAUNCH_HERDR_PANE_STATE" ]; then
+    echo "error: task $ID's herdr endpoint changed from '$RELAUNCH_HERDR_PANE_STATE' to '$RELAUNCH_RECHECK_STATE' before replacement input; refusing relaunch" >&2
+    exit 1
+  fi
+fi
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -272,6 +272,11 @@ The generic Herdr agent-liveness probe reuses the same classifier.
 A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
 Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
 
+A pi process that exits without emitting its end-of-session hook leaves a different kind of husk: Herdr's screen-detection defers entirely to Pi's own lifecycle hooks, so an `agent get` still reports the last status it was told (`idle`) forever, with no fallback screen read to notice the process is gone.
+The classifier proves this case with the same strict bare-idle-shell proof used elsewhere in this file, plus a second `agent get` still reporting `idle`, and reports it as `stale-idle` rather than folding it into `dead` or `alive`.
+`stale-idle` is not a husk `fm_backend_herdr_create_task` will replace, because that close path has no revalidation immediately before the close; it is a dedicated relaunch case instead.
+`bin/fm-spawn.sh --relaunch` accepts a `stale-idle` endpoint as agent-free and requires the identical proof again immediately before it sends the replacement's first input, so a registration that resolves back to a genuine agent between the initial check and the send still refuses.
+
 The session-start sweep uses this probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -792,6 +792,180 @@ test_create_task_refuses_when_agent_state_ambiguous() {
   pass "fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently"
 }
 
+# A registered `idle` status alone is not enough to treat a pane as
+# agent-free: a real pi process sitting idle between turns reports the exact
+# same status. Only the shared strict idle-shell proof (already used for
+# session-start projection cleanup and pane-death close), plus a second
+# registry read still reporting idle, can promote it to stale-idle. This
+# models the husk a pi process leaves behind when it exits without emitting
+# its end-of-session hook (reproduced on real herdr 0.8.2).
+test_pane_agent_state_classifies_a_stale_idle_registration() {
+  local dir log resp fb out status pid=4242
+  dir="$TMP_ROOT/stale-idle-pane-state"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"idle"}}}' > "$resp/2.out"
+  death_process_info_fixture w2:p2 "$pid" > "$resp/3.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"idle"}}}' > "$resp/4.out"
+  make_death_lab "$dir" "$pid"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w2:p2' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] && [ "$out" = stale-idle ] \
+    || fail "a stale idle registration over a proved bare shell should classify stale-idle, got '$out'"
+  [ "$(grep -c $'agent\x1fget\x1fw2:p2' "$log")" -eq 2 ] \
+    || fail "stale idle recovery did not re-read the agent registration after proving the shell"
+  assert_contains "$(cat "$log")" $'pane\x1fprocess-info\x1f--pane\x1fw2:p2' \
+    "stale idle recovery did not prove the pane had returned to its bare shell"
+  pass "fm_backend_herdr_pane_agent_state: a proven stale idle registration classifies distinctly from live"
+}
+
+test_pane_agent_state_keeps_idle_live_with_active_process() {
+  local dir log resp fb out status pid=4242
+  dir="$TMP_ROOT/idle-active-process"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"idle"}}}' > "$resp/2.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w2:p2","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"zsh","argv0":"zsh"},{"pid":4243,"name":"pi","argv0":"pi"}]}}}\n' \
+    "$pid" "$pid" "$pid" > "$resp/3.out"
+  make_death_lab "$dir" "$pid"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w2:p2' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] && [ "$out" = live ] \
+    || fail "an idle registration with a real foreground process must remain live, got '$out'"
+  [ "$(grep -c $'agent\x1fget\x1fw2:p2' "$log")" -eq 1 ] \
+    || fail "a genuinely busy idle pane should not be reclassified after its shell proof failed"
+  pass "fm_backend_herdr_pane_agent_state: idle with an active foreground process remains live, not stale-idle or unknown"
+}
+
+test_pane_agent_state_keeps_idle_live_on_unreadable_process_info() {
+  # Conservatism is mandatory: unreadable process evidence must never promote
+  # an idle registration to stale-idle, only ever leave it live.
+  local dir log resp fb out status
+  dir="$TMP_ROOT/idle-unreadable-process-info"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"idle"}}}' > "$resp/2.out"
+  printf '%s\n' '{"error":{"code":"internal_error","message":"transient failure"}}' > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w2:p2' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] && [ "$out" = live ] \
+    || fail "an unreadable process-info read for an idle pane must remain live, got '$out'"
+  [ "$(grep -c $'agent\x1fget\x1fw2:p2' "$log")" -eq 1 ] \
+    || fail "an unreadable process-info read should never reach a second agent-registration recheck"
+  pass "fm_backend_herdr_pane_agent_state: an unreadable process-info read for an idle pane stays live, never stale-idle"
+}
+
+test_pane_agent_state_keeps_idle_live_when_registration_changes_before_recheck() {
+  # The shell can prove bare-idle a moment after the agent itself resumed
+  # (a genuinely busy pi about to redraw its prompt). Refuse to trust the
+  # first read alone; the second agent get must still agree.
+  local dir log resp fb out status pid=4242
+  dir="$TMP_ROOT/idle-changed-before-recheck"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"idle"}}}' > "$resp/2.out"
+  death_process_info_fixture w2:p2 "$pid" > "$resp/3.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"working"}}}' > "$resp/4.out"
+  make_death_lab "$dir" "$pid"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w2:p2' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] && [ "$out" = live ] \
+    || fail "an idle registration that changed to working before the recheck must remain live, got '$out'"
+  pass "fm_backend_herdr_pane_agent_state: an idle registration that changes before its recheck stays live, never falsely stale-idle"
+}
+
+test_tab_is_husk_refuses_a_stale_idle_pane() {
+  # A proven stale-idle pane deliberately stays out of the husk set this
+  # function grants close authority for: relaunch has its own revalidated
+  # replacement flow, while this duplicate-tab close path has no revalidation
+  # immediately before the close.
+  local dir log resp fb pid=4242
+  dir="$TMP_ROOT/husk-stale-idle-refuses"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"idle"}}}' > "$resp/2.out"
+  death_process_info_fixture w2:p2 "$pid" > "$resp/3.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"idle"}}}' > "$resp/4.out"
+  make_death_lab "$dir" "$pid"
+  fb=$(make_herdr_fakebin "$dir")
+  if PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_tab_is_husk fmtest w2:p2' "$ROOT"; then
+    fail "tab_is_husk must not grant close authority for a stale-idle pane; that has its own revalidated relaunch path"
+  fi
+  pass "fm_backend_herdr_tab_is_husk: a proven stale-idle pane still refuses (1), deliberately out of the duplicate-tab close path"
+}
+
+test_agent_state_reports_stale_idle_for_a_proven_bare_shell() {
+  local dir log resp fb out status pid=4242
+  dir="$TMP_ROOT/stale-idle-agent-state"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"idle"}}}' > "$resp/2.out"
+  death_process_info_fixture w2:p2 "$pid" > "$resp/3.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"idle"}}}' > "$resp/4.out"
+  make_death_lab "$dir" "$pid"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state fmtest:w2:p2' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] && [ "$out" = stale-idle ] \
+    || fail "task-level agent_state should report stale-idle for a proven bare-shell idle registration, got '$out'"
+  pass "fm_backend_herdr_agent_state: a strictly proved stale idle registration reports stale-idle, distinct from dead"
+}
+
+test_agent_state_keeps_a_healthy_idle_registration_alive() {
+  local dir log resp fb out status pid=4242
+  dir="$TMP_ROOT/healthy-idle-agent-state"; mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
+  printf '%s\n' '{"result":{"agent":{"agent_status":"idle"}}}' > "$resp/2.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w2:p2","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"zsh","argv0":"zsh"},{"pid":4243,"name":"pi","argv0":"pi"}]}}}\n' \
+    "$pid" "$pid" "$pid" > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state fmtest:w2:p2' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] && [ "$out" = alive ] \
+    || fail "task-level agent_state should keep a healthy idle registration alive, got '$out'"
+  pass "fm_backend_herdr_agent_state: a healthy idle registration with a live process remains alive"
+}
+
+test_agent_state_keeps_working_done_and_blocked_alive_without_proof() {
+  # working/done/blocked never enter the process-proof path at all - only a
+  # candidate idle registration does.
+  local candidate dir log resp fb out status
+  for candidate in working "done" blocked; do
+    dir="$TMP_ROOT/agent-state-$candidate"; mkdir -p "$dir/responses"
+    log="$dir/log"; resp="$dir/responses"; : > "$log"
+    printf '%s\n' '{"result":{"pane":{"pane_id":"w2:p2"}}}' > "$resp/1.out"
+    printf '{"result":{"agent":{"agent_status":"%s"}}}\n' "$candidate" > "$resp/2.out"
+    fb=$(make_herdr_fakebin "$dir")
+    out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state fmtest:w2:p2' "$ROOT" 2>&1)
+    status=$?
+    [ "$status" -eq 0 ] && [ "$out" = alive ] \
+      || fail "registered agent_status=$candidate must remain alive with no proof attempt, got '$out'"
+    assert_not_contains "$(cat "$log")" $'pane\x1fprocess-info' \
+      "registered agent_status=$candidate should never enter stale-idle recovery"
+  done
+  pass "fm_backend_herdr_agent_state: working, done, and blocked registrations remain alive without a process proof"
+}
+
 test_create_task_husk_replacement_creates_before_closing() {
   # Safety-critical ordering: the replacement tab must be created BEFORE the
   # husk tab is closed, never the reverse - closing a workspace's LAST
@@ -4516,6 +4690,14 @@ test_create_task_closes_and_replaces_no_agent_husk
 test_create_task_closes_all_duplicate_husks_after_replacement
 test_create_task_refuses_when_preexisting_husk_tab_remains
 test_create_task_refuses_when_agent_state_ambiguous
+test_pane_agent_state_classifies_a_stale_idle_registration
+test_pane_agent_state_keeps_idle_live_with_active_process
+test_pane_agent_state_keeps_idle_live_on_unreadable_process_info
+test_pane_agent_state_keeps_idle_live_when_registration_changes_before_recheck
+test_tab_is_husk_refuses_a_stale_idle_pane
+test_agent_state_reports_stale_idle_for_a_proven_bare_shell
+test_agent_state_keeps_a_healthy_idle_registration_alive
+test_agent_state_keeps_working_done_and_blocked_alive_without_proof
 test_create_task_husk_replacement_creates_before_closing
 test_create_task_creates_and_parses_ids
 test_create_task_creates_with_no_focus_flag


### PR DESCRIPTION
## Problem

A `pi` worker's pane can exit — process gone, pane back at its interactive shell prompt — while Herdr's agent registry still reports `agent_status: idle` forever.

Herdr defers entirely to each agent's own lifecycle hooks for detection (`herdr agent explain` on such a pane reports `screen_detection_skipped: true`, `screen_detection_skip_reason: full_lifecycle_hook_authority`), so it never falls back to reading the screen to notice the process is actually gone. If `pi` exits without emitting its end-of-session hook, the stale `idle` registration never clears on its own.

`fm_backend_herdr_pane_agent_state` folded every registered `agent_status` (`working`, `idle`, `done`, `blocked`) into a blind `live`, with no way to distinguish a genuinely busy idle agent from this stale husk. That made `fm_backend_herdr_agent_state` report `alive`, so `bin/fm-spawn.sh --relaunch`'s "positively agent-free endpoint" precondition could never be satisfied for this pane, and `bin/fm-control.sh <id> exit` (the refusal's own suggested remediation) had nothing real to stop. The task's endpoint was permanently stuck — no relaunch, no operator escape, since Herdr's own `herdr agent start ... --pane <id>` also refuses with `agent_pane_busy` on that exact pane.

## Fix

Extends the *same* strict process proof already established for stale-`done` recovery (`fm_backend_herdr_pane_idle_shell_pid`, the bare/sole/childless/sleeping-shell check) rather than adding a second mechanism. A candidate `idle` registration is only promoted to a new `stale-idle` classification when that shared proof succeeds *and* a second `agent get` still reports `idle`. Any unreadable, ambiguous, or contradictory process evidence conservatively keeps the pane `live` — a false agent-free verdict here would risk launching a second agent onto live work, which is worse than refusing a relaunch.

- `bin/backends/herdr.sh`: `fm_backend_herdr_idle_registration_is_stale` (the proof) and the `stale-idle` state in `fm_backend_herdr_pane_agent_state` / `fm_backend_herdr_agent_state`. Deliberately excluded from `fm_backend_herdr_tab_is_husk`'s husk set (that duplicate-tab close path has no revalidation immediately before the close; relaunch does).
- `bin/fm-spawn.sh`: `--relaunch` accepts `stale-idle` as agent-free, and re-proves it again immediately before sending the replacement's first input, so a registration that resolves back to a real agent between the initial check and the send still refuses.
- `bin/fm-control.sh`: `exit` reports a `stale-idle` endpoint as `already-stopped` rather than refusing (otherwise the relaunch refusal's own suggested remediation, "stop the agent first", would dead-end).
- `bin/fm-backend.sh`, `docs/herdr-backend.md`: contract docs.

## Tests

8 new colocated tests in `tests/fm-backend-herdr.test.sh`: the positive stale-idle classification, three conservative negative cases that must stay `live` (an active foreground process, an unreadable process-info read, and a registration that changes to `working` before the second recheck), the `tab_is_husk` exclusion, the task-level `stale-idle` report, and a `working`/`done`/`blocked` regression guard confirming they never enter the process-proof path. Full suite: 190/190 passing. `shellcheck`-clean.

## Verification

Reproduced the exact husk against a real installed **herdr 0.8.2** in an isolated `fm-herdr-lab.sh` session: `herdr pane report-agent --state idle` with no underlying process reproduces the registry-says-idle/no-process shape, and a manual `herdr agent start` on that pane does refuse with `agent_pane_busy`, matching the reported defect. Replayed the captured real JSON through the unmodified classifier and the new `fm-spawn.sh` relaunch-precondition logic, confirming both now resolve `stale-idle`/`dead` where they previously resolved `live`/`alive`.

## Related

#3461 is prior, related work: it recovers a stale-`done` registration the same way, with the same shared process proof. This PR extends that pattern to the `idle` case rather than duplicating it.
