### PR TITLE
fix(herdr): preserve captain focus on supported releases

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -754,8 +754,8 @@ fm_backend_herdr_presentation_session_lock_path() {  # <session>
 
 # fm_backend_herdr_projection_focus_snapshot: print the exact active
 # workspace and tab ids as one tab-separated record.
-# Presentation mutations use this read-only snapshot as their sole focus
-# restoration authority.
+# Below-floor or release-indeterminate presentation mutations use this read-only
+# snapshot as their sole focus restoration authority.
 # Labels, workspace order, and ambient client state are never focus authority.
 fm_backend_herdr_projection_focus_snapshot() {  # <session>
   local session=$1 list snapshot workspace tab tabs
@@ -782,14 +782,14 @@ fm_backend_herdr_projection_focus_snapshot() {  # <session>
   printf '%s\t%s' "$workspace" "$tab"
 }
 
-# fm_backend_herdr_projection_focus_restore: verify that one presentation
-# mutation preserved the exact active workspace and tab captured immediately
-# before it.
+# fm_backend_herdr_projection_focus_restore: below the presentation release
+# floor, verify that one presentation mutation preserved the exact active
+# workspace and tab captured immediately before it.
 # This is the backstop for every focus-unsafe instant: on Herdr 0.7.5 an
 # explicit pane.close that empties a non-focused workspace moves focus to
 # that workspace's neighbor (upstream #1328/#1877), and a pane-death removal
 # before a non-last focused workspace moves focus to the focused workspace's
-# right neighbor (upstream #1621/#1912); both fixes are unreleased.
+# right neighbor (upstream #1621/#1912); both fixes shipped in Herdr 0.8.0.
 # A single tab.focus on the exact response-independent pre-operation tab id
 # restores both the workspace and tab atomically.
 #

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -792,8 +792,17 @@ fm_backend_herdr_projection_focus_snapshot() {  # <session>
 # right neighbor (upstream #1621/#1912); both fixes are unreleased.
 # A single tab.focus on the exact response-independent pre-operation tab id
 # restores both the workspace and tab atomically.
+#
+# At/above the presentation release floor those bugs are fixed and every
+# presentation op is focus-clean (verified on 0.8.2), so the only thing this
+# comparison can catch is the captain changing focus during the op window -
+# which the restore would then silently revert. Skip it there. Below the floor,
+# or when the release cannot be confirmed, keep the backstop.
 fm_backend_herdr_projection_focus_restore() {  # <session> <snapshot> <operation>
   local session=$1 before=$2 operation=$3 workspace tab after info restored
+  if fm_backend_herdr_presentation_release_supported "$session"; then
+    return 0
+  fi
   [ -n "$before" ] || {
     echo "warning: herdr presentation $operation had no unambiguous pre-operation focus snapshot" >&2
     return 1

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -121,8 +121,8 @@ The repositioning move-to-last preserves every surviving workspace's relative or
 If that rollback cannot restore the verified original order, cleanup warns loudly and leaves the retained records for inspection rather than retrying the shared-layout mutation.
 The pane-death signals are pid-exact: the escalation re-reads the pane's process information and refuses unless the same shell pid still passes the strict bare-idle ownership proof, so an exited and reused pid is never signaled.
 Any ambiguity, unsupported or failed move, or unproved shell falls back to the plain explicit close.
-Below the release floor the exact prior-tab restore remains the backstop behind every close, so degraded behavior is never worse than the pre-mitigation sub-second restore.
-At or above the floor, where every removal primitive already preserves focus, that restore is skipped entirely, so it can never revert a captain focus change made during the operation.
+Below the release floor, or when the release cannot be confirmed, the exact prior-tab restore remains the backstop after every presentation operation, so degraded behavior is never worse than the pre-mitigation sub-second restore.
+At or above the floor, where every presentation primitive already preserves focus, that restore is skipped entirely, so it can never revert a captain focus change made during the operation.
 Ordinary non-projected task removal serializes through the same session lock, applies the same focus-safe plan when its close would empty a non-focused workspace, keeps the legitimate plain close when the target is the active tab, and refuses an unlocked close if the lock cannot be acquired.
 Task cleanup acquires that session lock before the task's isolated copy is returned, so a contended lock refuses up front while the copy, every durable record, and the endpoint are all intact for a plain rerun.
 Forced secondmate cleanup recursively preflights every Herdr child endpoint and acquires every affected named-session lock before mutating any child, then retains each child's durable identity unless that exact pane returns structured not-found after its close.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -100,7 +100,7 @@ The owning parent is the launcher's own exact workspace, resolved from the same 
 Projected children are never collapsed back into that parent; it is the placement and ordering reference the projection is bound under.
 The normal `fm-<id>` task tab is created in the exact new workspace returned by Herdr.
 Only the exact seeded default tab returned by the same workspace-create response can be pruned.
-Before and after create, prune, order, abort cleanup, and normal cleanup, Firstmate verifies exact workspace, tab, pane, and active-focus ids.
+Before and after create, prune, order, abort cleanup, and normal cleanup, Firstmate verifies exact workspace, tab, and pane ids, and captures active focus before each operation to drive the below-floor restore backstop described under cleanup.
 An ambiguous response grants no mutation or cleanup authority.
 
 Protocol 16 exposes `workspace.move` over the named session socket but no CLI subcommand.
@@ -120,7 +120,9 @@ Projected cleanup therefore runs under the same session lock, captures the exact
 The repositioning move-to-last preserves every surviving workspace's relative order, and removal is confirmed against the exact moved workspace rather than inferred from pane disappearance before an unconfirmed removal makes one verified attempt under the same session lock to roll the doomed workspace back to its exact original position.
 If that rollback cannot restore the verified original order, cleanup warns loudly and leaves the retained records for inspection rather than retrying the shared-layout mutation.
 The pane-death signals are pid-exact: the escalation re-reads the pane's process information and refuses unless the same shell pid still passes the strict bare-idle ownership proof, so an exited and reused pid is never signaled.
-Any ambiguity, unsupported or failed move, or unproved shell falls back to the plain explicit close, and the exact prior-tab restore remains the backstop behind every close, so degraded behavior is never worse than the pre-mitigation sub-second restore.
+Any ambiguity, unsupported or failed move, or unproved shell falls back to the plain explicit close.
+Below the release floor the exact prior-tab restore remains the backstop behind every close, so degraded behavior is never worse than the pre-mitigation sub-second restore.
+At or above the floor, where every removal primitive already preserves focus, that restore is skipped entirely, so it can never revert a captain focus change made during the operation.
 Ordinary non-projected task removal serializes through the same session lock, applies the same focus-safe plan when its close would empty a non-focused workspace, keeps the legitimate plain close when the target is the active tab, and refuses an unlocked close if the lock cannot be acquired.
 Task cleanup acquires that session lock before the task's isolated copy is returned, so a contended lock refuses up front while the copy, every durable record, and the endpoint are all intact for a plain rerun.
 Forced secondmate cleanup recursively preflights every Herdr child endpoint and acquires every affected named-session lock before mutating any child, then retains each child's durable identity unless that exact pane returns structured not-found after its close.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -267,7 +267,7 @@ This guard is the refresh command after any harness upgrade; it spends a small n
 ## Herdr
 
 The compatibility floor is protocol 14.
-The whole real-Herdr lane's latest active verification uses both Herdr 0.7.4 protocol 16 and Herdr 0.8.0 protocol 19 on macOS aarch64, while focused Herdr 0.7.5 protocol 17, earlier protocol-16, protocol-14, and 0.7.3 evidence is retained where it defines current behavior or fallbacks.
+The whole real-Herdr lane's latest active verification uses both Herdr 0.7.4 protocol 16 and Herdr 0.8.0 protocol 19 on macOS aarch64, while focused Herdr 0.8.2 protocol 20, Herdr 0.7.5 protocol 17, earlier protocol-16, protocol-14, and 0.7.3 evidence is retained where it defines current behavior or fallbacks.
 Protocol 17 keeps every protocol-16 feature gate satisfied; the event and workspace-move floors remain 16.
 Default-on presentation projection has its own floor at Herdr 0.8.0, protocol 19, verified below.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -509,6 +509,19 @@ ok - version floor: an unconfigured home stays projected on herdr 0.8.0 and the 
 evidence: herdr=0.8.0 protocol=19 steal_live=0 floor_verdict=0 default-session-tripwire=armed
 ```
 
+The suite re-ran on 2026-09-03 against Herdr 0.8.2 protocol 20 on macOS aarch64, adding Part D, which reproduces the restore-race (a captain focus change during an operation window) deterministically and asserts the version-gated restore no longer reverts it at or above the floor:
+
+```text
+ok - old path note: this Herdr release preserves focus across the explicit close; continuing with outcome-only assertions
+ok - mitigation: every in-operation sample preserved exact focus while the doomed workspace was removed
+ok - fallback: a doomed pane holding a persistent child exhausts the proof and takes the plain explicit close
+ok - fallback on a focus-preserving release: the plain explicit close preserved exact focus throughout
+ok - version floor: herdr 0.8.2 protocol 20 is at or above the floor and preserves focus
+ok - version floor: an unconfigured home stays projected on herdr 0.8.2 and the explicit opt-in agrees
+ok - restore gate: at or above the floor a captain focus change during the op window survives
+evidence: herdr=0.8.2 protocol=20 steal_live=0 floor_verdict=0 default-session-tripwire=armed
+```
+
 Part C is the case the suite could not reach before: a doomed pane whose shell holds a persistent background child fails the lone-idle-shell proof on every sample, so the plan takes the plain explicit close, in the geometry where the closing workspace's right neighbour is a spacer rather than the focused anchor.
 On 0.7.5 that fallback exposed a bounded four-sample wrong-focus window and restored the anchor exactly; on 0.8.0 the same fallback exposed none, which is why default-on projection is floored at 0.8.0 rather than mitigated further below it.
 The suite also cross-checks its own Part A measurement against the floor classifier on whatever release it runs, so a drifted protocol-to-release mapping fails there rather than silently gating on the wrong thing.

--- a/tests/fm-backend-herdr-focus-flash-e2e.test.sh
+++ b/tests/fm-backend-herdr-focus-flash-e2e.test.sh
@@ -14,6 +14,9 @@
 # against what Part A measured about this very release.
 # On a future release whose explicit close preserves focus, Part A records
 # that and Parts B and C keep outcome-only assertions, so no version is guessed.
+# Part D reproduces the restore-race (herdr-focus-steal-s1) deterministically:
+# a captain focus change during an op window must survive at or above the floor,
+# where the ops are focus-clean, and must still be reclaimed below it.
 # Every CLI operation is routed through one guarded named non-default lab, and
 # lab teardown verifies that the default fleet session is byte-identical.
 set -u
@@ -403,6 +406,35 @@ else
   [ ! -s "$GATE_ERR" ] \
     || fail "a supported release must warn about nothing: $(cat "$GATE_ERR")"
   pass "version floor: an unconfigured home stays projected on herdr $LIVE_VERSION and the explicit opt-in agrees"
+fi
+
+# --- Part D: the restore backstop must not revert the captain's own focus ----
+# Deterministic version of the report's restore-race probe: snapshot the anchor
+# focus, then have the captain move focus (what would happen mid-op), then run
+# focus_restore directly. At or above the floor the presentation ops are
+# focus-clean, so the only detected change is the captain's own and the gate must
+# leave it; below the floor the pre-floor backstop must still reclaim it.
+read -r _ D_ANCHOR_TAB _ <<<"$(mkws flash-d-anchor)" || fail 'could not create the Part D anchor workspace'
+read -r D_CAPTAIN_WS D_CAPTAIN_TAB _ <<<"$(mkws flash-d-captain)" || fail 'could not create the Part D captain workspace'
+lab tab focus "$D_ANCHOR_TAB" >/dev/null || fail 'could not focus the Part D anchor'
+D_BEFORE=$(focus_snapshot) || fail 'could not capture the Part D pre-op focus'
+# The captain changes focus during the op window.
+lab tab focus "$D_CAPTAIN_TAB" >/dev/null || fail 'could not simulate the Part D captain focus change'
+D_CAPTAIN_FOCUS=$(printf '%s\t%s' "$D_CAPTAIN_WS" "$D_CAPTAIN_TAB")
+PATH="$FAKEBIN:$HERDR_ORIGINAL_PATH" bash -c '
+  . "$1/bin/backends/herdr.sh"
+  fm_backend_herdr_cli() { local session=$1; shift; HERDR_SESSION="$session" herdr "$@" --session "$session"; }
+  fm_backend_herdr_projection_focus_restore "$2" "$3" "spawn cleanup"
+' "$ROOT" "$HERDR_LAB_SESSION" "$D_BEFORE" >/dev/null 2>&1 || true
+D_AFTER=$(focus_snapshot) || fail 'could not capture the Part D post-restore focus'
+if [ "$FLOOR_VERDICT" = 0 ]; then
+  [ "$D_AFTER" = "$D_CAPTAIN_FOCUS" ] \
+    || fail "at or above the floor the restore reverted the captain's focus change ($D_CAPTAIN_FOCUS -> $D_AFTER)"
+  pass "restore gate: at or above the floor a captain focus change during the op window survives"
+else
+  [ "$D_AFTER" = "$D_BEFORE" ] \
+    || fail "below the floor the restore backstop did not reclaim focus ($D_BEFORE -> $D_AFTER after $D_CAPTAIN_FOCUS)"
+  pass "restore gate: below the floor the backstop still reclaims the captain's pre-op focus"
 fi
 
 printf 'evidence: herdr=%s protocol=%s steal_live=%s floor_verdict=%s default-session-tripwire=armed\n' \

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1415,6 +1415,68 @@ test_projection_close_restores_exact_prior_focus() {
   pass "herdr presentation focus: exact pane close restores the exact prior workspace and tab"
 }
 
+# At/above the presentation release floor every presentation op is focus-clean,
+# so a post-op focus difference can only be the captain's own change; the
+# restore must not revert it. These two cases pin the gate decision and prove it
+# is load-bearing: the same divergent inputs flip the verdict when only the
+# release changes.
+test_focus_restore_is_a_noop_at_or_above_the_release_floor() {
+  local dir log out
+  dir="$TMP_ROOT/focus-restore-gate-above"; mkdir -p "$dir"
+  log="$dir/log"; : > "$log"
+  out=$(ROOT="$ROOT" LOG="$log" bash -c '
+    . "$ROOT/bin/backends/herdr.sh"
+    fm_backend_herdr_presentation_release_supported() { return 0; }
+    # A post-op focus that differs from the snapshot: below the floor this would
+    # trigger a revert, so a no-op here can only come from the gate.
+    fm_backend_herdr_projection_focus_snapshot() { printf "w2\tw2:t1"; }
+    fm_backend_herdr_cli() { printf "%s\n" "$*" >> "$LOG"; }
+    before=$(printf "w1\tw1:t1")
+    set +e
+    fm_backend_herdr_projection_focus_restore fmtest "$before" "workspace create"
+    printf "rc=%s" "$?"
+    set -e
+  ')
+  [ "$out" = "rc=0" ] || fail "focus restore must succeed as a no-op at/above the floor, got '$out'"
+  assert_not_contains "$(cat "$log")" "tab focus" \
+    "focus restore must not re-focus at/above the floor even when post-op focus differs from the snapshot"
+  pass "herdr presentation focus: restore is a no-op at/above the release floor"
+}
+
+test_focus_restore_still_restores_below_the_release_floor() {
+  local dir log out
+  dir="$TMP_ROOT/focus-restore-gate-below"; mkdir -p "$dir"
+  log="$dir/log"; : > "$log"
+  # A file counter, because each focus snapshot runs in a command-substitution
+  # subshell where an in-memory counter would not persist.
+  out=$(ROOT="$ROOT" LOG="$log" CNT="$dir/cnt" bash -c '
+    . "$ROOT/bin/backends/herdr.sh"
+    printf 0 > "$CNT"
+    fm_backend_herdr_presentation_release_supported() { return 1; }
+    fm_backend_herdr_projection_focus_snapshot() {
+      local n; n=$(($(cat "$CNT") + 1)); printf "%s" "$n" > "$CNT"
+      # First read is the post-op focus (the captain moved), second is the
+      # restored focus that must match the pre-op snapshot.
+      if [ "$n" -eq 1 ]; then printf "w2\tw2:t1"; else printf "w1\tw1:t1"; fi
+    }
+    fm_backend_herdr_cli() {
+      printf "%s\n" "$*" >> "$LOG"
+      case "$2 $3" in
+        "tab get") printf "{\"result\":{\"tab\":{\"tab_id\":\"w1:t1\",\"workspace_id\":\"w1\"}}}\n" ;;
+      esac
+    }
+    before=$(printf "w1\tw1:t1")
+    set +e
+    fm_backend_herdr_projection_focus_restore fmtest "$before" "workspace create"
+    printf "rc=%s" "$?"
+    set -e
+  ')
+  [ "$out" = "rc=0" ] || fail "below-floor restore must succeed when it re-focuses the exact prior tab, got '$out'"
+  assert_contains "$(cat "$log")" "tab focus w1:t1" \
+    "below-floor restore must re-focus the exact prior tab, keeping the pre-floor backstop"
+  pass "herdr presentation focus: restore still runs below the release floor"
+}
+
 test_projection_close_refuses_active_tab() {
   local dir log resp fb out status
   dir="$TMP_ROOT/projection-focus-active-refusal"; mkdir -p "$dir/responses"
@@ -1586,8 +1648,12 @@ test_projection_close_emptying_before_focus_repositions_then_uses_pane_death() {
   death_process_info_fixture w1:p1 "$bgpid" > "$resp/10.out"
   printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/11.out"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w2","active_tab_id":"w2:t1","focused":true},{"workspace_id":"w3","active_tab_id":"w3:t1","focused":false}]}}' > "$resp/12.out"
-  cp "$resp/12.out" "$resp/13.out"
-  printf '%s\n' '{"result":{"tabs":[{"tab_id":"w2:t1","focused":true}]}}' > "$resp/14.out"
+  # The version-floor gate in focus_restore reads status first; this below-floor
+  # release keeps the pre-floor backstop active, so the after-snapshot (14/15)
+  # still runs and confirms focus was preserved without a re-focus.
+  printf '%s\n' '{"client":{"version":"0.7.5","protocol":16},"server":{"running":true}}' > "$resp/13.out"
+  cp "$resp/12.out" "$resp/14.out"
+  printf '%s\n' '{"result":{"tabs":[{"tab_id":"w2:t1","focused":true}]}}' > "$resp/15.out"
   make_death_lab "$dir" "$bgpid"
   printf '%s\n' '{"id":"fm-workspace-move","result":{"type":"workspace_list","workspaces":[{"workspace_id":"w2","focused":true},{"workspace_id":"w3","focused":false},{"workspace_id":"w1","focused":false}]}}' > "$dir/mover-response"
   fb=$(make_herdr_fakebin "$dir")
@@ -1772,8 +1838,11 @@ test_projection_close_move_failure_falls_back_to_plain_close() {
   printf '%s\n' '{"sessions":[{"name":"fmtest","running":true,"socket_path":"/tmp/fmtest.sock"}]}' > "$resp/9.out"
   printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/11.out"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w2","active_tab_id":"w2:t1","focused":true},{"workspace_id":"w3","active_tab_id":"w3:t1","focused":false}]}}' > "$resp/12.out"
-  cp "$resp/12.out" "$resp/13.out"
-  printf '%s\n' '{"result":{"tabs":[{"tab_id":"w2:t1","focused":true}]}}' > "$resp/14.out"
+  # The version-floor gate in focus_restore reads status first; this below-floor
+  # release keeps the backstop active for the after-snapshot (14/15) below.
+  printf '%s\n' '{"client":{"version":"0.7.5","protocol":16},"server":{"running":true}}' > "$resp/13.out"
+  cp "$resp/12.out" "$resp/14.out"
+  printf '%s\n' '{"result":{"tabs":[{"tab_id":"w2:t1","focused":true}]}}' > "$resp/15.out"
   sleep 300 & bgpid=$!
   make_death_lab "$dir" "$bgpid"
   fb=$(make_herdr_fakebin "$dir")
@@ -4537,6 +4606,8 @@ test_projection_create_uses_exact_response_ids_and_leaves_one_task_pane
 test_projection_create_never_closes_a_concurrent_same_label_tab
 test_projection_focus_snapshot_requires_exact_workspace_and_tab
 test_projection_close_restores_exact_prior_focus
+test_focus_restore_is_a_noop_at_or_above_the_release_floor
+test_focus_restore_still_restores_below_the_release_floor
 test_projection_close_refuses_active_tab
 test_projection_close_reports_focus_restore_failure
 test_projection_close_rechecks_required_agent_state_at_boundary


### PR DESCRIPTION
## Intent

Stop firstmate's Herdr presentation focus-restore from reverting the captain's own focus changes.

Root cause (diagnosed in scout report herdr-focus-steal-s1, lab-reproduced on Herdr 0.8.2): fm_backend_herdr_projection_focus_restore in bin/backends/herdr.sh snapshots focus before a presentation op and re-focuses the pre-op tab when the post-op focus differs. On Herdr 0.8.2 every presentation op firstmate performs (workspace create --no-focus, task-tab create, seeded-tab prune, workspace-move ordering, husk replacement, emptying pane close, task kill) is focus-clean, so the only change the comparison can catch is the captain changing focus DURING the op window - which the restore then silently reverts. This is called from all 11 presentation call sites.

Fix (the report's primary recommendation): version-gate the restore. At or above the presentation release floor - detected with the adapter's existing fm_backend_herdr_presentation_release_supported - return early without snapshotting or re-focusing, because the ops are focus-clean and any detected change is the captain's own. Below the floor, OR when the release cannot be confirmed (indeterminate), keep today's backstop unchanged (fail-safe). This is one guard in the shared function, covering every call site.

Acceptance criteria: on 0.8.2+ no presentation op invokes the focus-restore revert and a captain focus change during a spawn/teardown/cleanup window survives; below the gate version existing restore behavior is unchanged; regression tests for the gate decision in both directions, plus a guarded-lab check mirroring the report's restore-race reproduction; bin/fm-lint.sh and relevant suites pass.

Decisions and tradeoffs made: chose the report's primary one-function fix over the more invasive per-call-site verdict-threading alternative; the gate falls through (keeps the backstop) below-floor AND on indeterminate release reads; accepted one extra 'herdr status --json' per restore call (report-acknowledged; memoization deliberately skipped as premature/YAGNI); updated two existing below-floor fixture tests (emptying-before-focus pane-death, and move-failure fallback) to account for the gate's added status read; added Part D to the focus-flash live e2e as a deterministic (non-flaky) reproduction of the restore-race; updated docs/herdr-backend.md to reflect the floor-gated restore and recorded the 2026-09-03 Herdr 0.8.2 verification run in docs/verification/runtime-backends.md.

Constraint: this changes firstmate's shared tracked material, so firstmate-coding-guidelines were followed (one sentence per line, plain dash, shellcheck-clean, colocated behavior tests, no agent co-author). Two sibling tasks also touch bin/backends/herdr.sh (herdr-spawn-readiness-f1, herdr-agentstate-unknown-f2); reconcile by rebase rather than blocking.

## What Changed

- Skip Herdr presentation focus restoration at or above the supported release floor so captain focus changes made during an operation survive, while retaining the existing backstop below the floor or when release detection is indeterminate.
- Add regression coverage for both gate outcomes and a guarded live restore-race check.
- Document the floor-gated restore behavior and the Herdr 0.8.2 verification results.

## Risk Assessment

✅ Low: The shared version gate cleanly preserves the existing below-floor and indeterminate fallback while preventing focus restoration on supported releases, with behavioral coverage for both gate outcomes and the live race scenario.

## Testing

Completed 1 recorded test check.

- Outcome: ⏭️ skipped across 1 run (24m24s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8a58e886afed519748abeb16f93e9b40d28f5a65","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"skipped"},{"step":"document","status":"completed"},{"step":"lint","status":"skipped"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>


## Validation notes (skipped local steps are pre-existing / environmental, unrelated to this change)

This change touches only `bin/backends/herdr.sh`, its tests, and docs (5 files). The no-mistakes local test and lint steps were skipped by decision because their failures are pre-existing and unrelated to this diff, each verified by reproducing it at the untouched base commit:

- The target Herdr suite `tests/fm-backend-herdr.test.sh` passes, including both new gate directions, and the guarded Herdr 0.8.2 live restore-race test (focus-flash e2e Part D) passes. Review found 0 findings.
- `tests/fm-composer-lib.test.sh` ("a half-block rule row must count as a structural edge"): deterministic, but its implementation and test blobs are byte-identical at the base and target commits, proving it predates and is unrelated to this PR.
- `tests/fm-muse-harness.test.sh`: ambient Muse process-name detection in the environment, not a code failure.
- `tests/fm-lint-workflows.test.sh` and `bin/fm-lint.sh`: `actionlint` and the pinned `ShellCheck 0.11.0` are absent in this environment, so the lint scripts refuse to run; the changed shell files were separately verified clean against the pinned ShellCheck 0.11.0.

None of these four failures overlaps the five files changed by this PR.

CI status: the required GitHub workflows report `action_required` (not run) because this is a fork PR; a maintainer must approve the workflow runs before they can go green.
