### PR TITLE
fix(bin): stream snapshot JSON into jq on stdin instead of argv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,8 +377,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 16 ] || {
-            echo "::error::expected 16 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 20 ] || {
+            echo "::error::expected 20 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -269,7 +269,7 @@ EOF
       cnt=$(printf '%s' "$repo_rows" | jq 'length')
       [ "$returned" -gt "$FM_BEARINGS_PR_LIMIT" ] && ncapped=$((ncapped + 1))
       npr=$((npr + cnt))
-      rows=$(jq -n --argjson a "$rows" --argjson b "$repo_rows" '$a + $b')
+      rows=$(printf '%s\n' "$rows" "$repo_rows" | jq -s '.[0] + .[1]')
     done
     PR_REPOS_SHOWN=$nrepos
     PR_ROWS_CAPPED=$ncapped
@@ -293,7 +293,7 @@ case "$BEARINGS_TODAY" in
   [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) : ;;
   *) BEARINGS_TODAY=$(date -u +%Y-%m-%d) ;;
 esac
-MODEL=$(printf '%s' "$SNAP" | jq \
+MODEL=$(printf '%s\n' "$SNAP" "$CANDIDATE_PRS" | jq -s \
   --arg home "$HOME_LABEL" \
   --arg now "$NOW" \
   --arg today "$BEARINGS_TODAY" \
@@ -320,9 +320,11 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson pr_repos_total "$PR_REPOS_TOTAL" \
   --argjson pr_repos_shown "$PR_REPOS_SHOWN" \
   --argjson pr_rows_capped "$PR_ROWS_CAPPED" \
-  --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" \
-  --argjson candidate_prs "$CANDIDATE_PRS" '
-  def trunc($n): if . == null then null else
+  --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" '
+  .[0] as $snapshot
+  | .[1] as $candidate_prs
+  | $snapshot
+  | def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
   def round_robin_landed($n):
     . as $groups

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -204,6 +204,17 @@ PR_REPOS_SHOWN=0
 PR_ROWS_CAPPED=0
 PR_ROWS_MIN_TOTAL=0
 
+# Snapshot-sized JSON reaches jq on stdin rather than in argv, so `jq -s`
+# slurping is what validates it: an empty input is dropped silently and would
+# shift every later positional binding one slot. Prefix every slurping filter
+# with this guard so a missing, empty, or null input fails nonzero.
+jq_slurp_guard() {  # <expected-count>
+  printf 'if (length != %s) or any(.[]; . == null) then
+      error("fm-bearings-snapshot: expected %s non-null assembled json inputs, got \\(length) [\\([.[] | type] | join(","))]")
+    else . end | ' "$1" "$1"
+}
+JQ_SLURP_2=$(jq_slurp_guard 2)
+
 # Parse owner/repo from an https or ssh GitHub remote/PR URL; empty if not GitHub.
 repo_slug() {  # <url>
   printf '%s' "$1" | sed -n 's#.*github\.com[:/]\([^/]*/[^/]*\)#\1#p' | sed 's#\.git$##; s#/pull/.*$##; s#/$##'
@@ -269,7 +280,7 @@ EOF
       cnt=$(printf '%s' "$repo_rows" | jq 'length')
       [ "$returned" -gt "$FM_BEARINGS_PR_LIMIT" ] && ncapped=$((ncapped + 1))
       npr=$((npr + cnt))
-      rows=$(printf '%s\n' "$rows" "$repo_rows" | jq -s '.[0] + .[1]')
+      rows=$(printf '%s\n' "$rows" "$repo_rows" | jq -s "$JQ_SLURP_2"'.[0] + .[1]')
     done
     PR_REPOS_SHOWN=$nrepos
     PR_ROWS_CAPPED=$ncapped
@@ -320,7 +331,7 @@ MODEL=$(printf '%s\n' "$SNAP" "$CANDIDATE_PRS" | jq -s \
   --argjson pr_repos_total "$PR_REPOS_TOTAL" \
   --argjson pr_repos_shown "$PR_REPOS_SHOWN" \
   --argjson pr_rows_capped "$PR_ROWS_CAPPED" \
-  --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" '
+  --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" "$JQ_SLURP_2"'
   .[0] as $snapshot
   | .[1] as $candidate_prs
   | $snapshot

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -3,6 +3,8 @@
 #
 # Output contract: `--json` prints one object with schema
 # `fm-fleet-snapshot.v1`.
+# Internally assembled JSON is streamed into jq instead of crossing an exec
+# boundary in argv, so backlog growth cannot exceed the platform argument limit.
 # The command does not acquire the session lock, drain wakes, arm watchers,
 # mutate backlog state, or write reports. Its default ledger collector may
 # atomically refresh parent-side cached copies of remote home summaries under
@@ -573,38 +575,41 @@ task_json_lines() {
       home_json=$(jq -n '{path:null,present:false}')
     fi
 
-    jq -n \
-      --arg id "$id" \
-      --arg kind "$kind" \
-      --arg harness "$harness" \
-      --arg mode "$mode" \
-      --arg yolo "$yolo" \
-      --arg project "$project" \
-      --arg worktree "$worktree" \
-      --arg home "$home" \
-      --arg projects "$projects" \
-      --arg spawn_gen "$spawn_gen" \
-      --arg backend "$backend" \
-      --arg target "$target" \
-      --arg remote_host "$remote_host" \
-      --arg remote_root "$remote_root" \
-      --arg pr "$pr" \
-      --arg pr_source "$pr_source" \
-      --arg agent_alive "$agent_alive" \
-      --arg observed_at "$SNAPSHOT_NOW" \
-      --arg last_event_raw "$last_event_raw" \
-      --argjson current_state "$current_json" \
-      --argjson meta_path "$meta_json" \
-      --argjson status_log "$status_json" \
-      --argjson report "$report_json" \
-      --argjson worktree_path "$worktree_json" \
-      --argjson home_path "$home_json" \
-      --argjson endpoint_exists "$endpoint_exists" \
-      --argjson open_decisions "$open_decisions_json" \
-      --argjson pending_decision "$(bool_json "$pending_decision")" \
-      --argjson blocked_event "$(bool_json "$blocked_event")" \
-      --argjson report_present "$(bool_json "$report_present")" \
-      '{
+    printf '%s\n' \
+      "$current_json" "$meta_json" "$status_json" "$report_json" \
+      "$worktree_json" "$home_json" "$open_decisions_json" \
+      | jq -s \
+        --arg id "$id" \
+        --arg kind "$kind" \
+        --arg harness "$harness" \
+        --arg mode "$mode" \
+        --arg yolo "$yolo" \
+        --arg project "$project" \
+        --arg worktree "$worktree" \
+        --arg home "$home" \
+        --arg projects "$projects" \
+        --arg spawn_gen "$spawn_gen" \
+        --arg backend "$backend" \
+        --arg target "$target" \
+        --arg remote_host "$remote_host" \
+        --arg remote_root "$remote_root" \
+        --arg pr "$pr" \
+        --arg pr_source "$pr_source" \
+        --arg agent_alive "$agent_alive" \
+        --arg observed_at "$SNAPSHOT_NOW" \
+        --arg last_event_raw "$last_event_raw" \
+        --argjson endpoint_exists "$endpoint_exists" \
+        --argjson pending_decision "$(bool_json "$pending_decision")" \
+        --argjson blocked_event "$(bool_json "$blocked_event")" \
+        --argjson report_present "$(bool_json "$report_present")" \
+        '.[0] as $current_state
+        | .[1] as $meta_path
+        | .[2] as $status_log
+        | .[3] as $report
+        | .[4] as $worktree_path
+        | .[5] as $home_path
+        | .[6] as $open_decisions
+        | {
         id:$id,
         kind:$kind,
         harness:($harness // ""),
@@ -655,9 +660,10 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
-  jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+  printf '%s\n' "$1" "$2" | jq -s '
+    .[0] as $backlog
+    | .[1] as $tasks
+    |
     ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
@@ -683,16 +689,17 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
-  jq -n \
+  printf '%s\n' "$1" "$2" | jq -s \
     --arg generated "$SNAPSHOT_NOW" \
     --argjson generated_epoch "$SNAPSHOT_EPOCH" \
     --arg home "$FM_HOME" \
     --argjson child_n "$FM_SNAPSHOT_SECONDMATE_CHILDREN" \
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
-    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '
+    .[0] as $backlog
+    | .[1] as $tasks
+    |
     def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
@@ -1322,7 +1329,11 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
+  printf '%s\n' "$1" "$2" "$3" | jq -s '
+    .[0] as $summary
+    | .[1] as $activities
+    | .[2] as $decisions
+    |
     def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
@@ -1388,7 +1399,10 @@ secondmate_current_json() {  # <parent-tasks-json>
   local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
+  union=$(printf '%s\n' "$registry" "$tasks" | jq -s '
+    .[0] as $registry
+    | .[1] as $tasks
+    |
     ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
@@ -1498,8 +1512,8 @@ secondmate_current_json() {  # <parent-tasks-json>
       fi
     fi
     # Failed command substitutions clear their assignment target. Keep the
-    # unsampled record's --argjson input valid without retaining any rejected
-    # or oversized summary fragment.
+    # unsampled record's streamed JSON input valid without retaining any
+    # rejected or oversized summary fragment.
     if [ -n "$reason" ]; then summary='{}'; fi
     if [ -z "$reason" ]; then
       summary_sampled=true
@@ -1531,15 +1545,21 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
-      record=$(jq -n \
-        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$summary_observed" \
-        --arg summary_source "$summary_source" --arg summary_freshness "$summary_freshness" --argjson summary_age "$summary_age" \
-        --arg spawn_gen "$sampled_spawn_gen" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
-        --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
-        --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
-        {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+      record=$(printf '%s\n' \
+        "$summary" "$decisions" "$activities" "$activity_scan" "$reconciliation" "$terminal" \
+        | jq -s \
+          --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$summary_observed" \
+          --arg summary_source "$summary_source" --arg summary_freshness "$summary_freshness" --argjson summary_age "$summary_age" \
+          --arg spawn_gen "$sampled_spawn_gen" \
+          --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson contradiction "$contradiction" \
+          --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
+        .[0] as $summary
+        | .[1] as $decisions
+        | .[2] as $activities
+        | .[3] as $activity_scan
+        | .[4] as $reconciliation
+        | .[5] as $terminal
+        | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
          reconcile_inventory:$summary.invalidity,
@@ -1565,13 +1585,18 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
-      record=$(jq -n \
-        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
-        --arg spawn_gen "$sampled_spawn_gen" \
-        --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
-        --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" --argjson summary "$summary" --argjson summary_sampled "$summary_sampled" '
-        {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+      record=$(printf '%s\n' "$activities" "$activity_scan" "$decisions" "$terminal" "$summary" \
+        | jq -s \
+          --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
+          --arg spawn_gen "$sampled_spawn_gen" \
+          --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
+          --argjson registered "$registered" --argjson event_age "$event_age" --argjson summary_sampled "$summary_sampled" '
+        .[0] as $activities
+        | .[1] as $activity_scan
+        | .[2] as $decisions
+        | .[3] as $terminal
+        | .[4] as $summary
+        | {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:"unknown",reason:$reason},invalidity:null,
          reconcile_inventory:(if $summary_sampled then $summary.invalidity else null end),
@@ -1581,23 +1606,26 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    records=$(printf '%s\n' "$records" "$record" | jq -s '.[0] + [.[1]]')
   done <<EOF
 $rows
 EOF
   snapshot_collection_cleanup
-  jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
-    --argjson total_registered "$total_registered" \
-    --argjson total "$total" \
-    --argjson shown "$shown" \
-    --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+  printf '%s\n' "$(printf '%s' "$union" | jq '.registry')" "$records" \
+    | jq -s \
+      --argjson total_registered "$total_registered" \
+      --argjson total "$total" \
+      --argjson shown "$shown" \
+      --argjson truncated "$truncated" \
+      '.[0] as $registry
+      | .[1] as $records
+      | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
+  printf '%s\n' "$1" | jq '
+    . as $current
+    |
     {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
@@ -1646,21 +1674,24 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
-jq -n \
-  --arg generated "$SNAPSHOT_NOW" \
-  --arg fm_home "$FM_HOME" \
-  --arg fm_root "$FM_ROOT" \
-  --arg state "$STATE" \
-  --arg data "$DATA" \
-  --arg config "$CONFIG" \
-  --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+printf '%s\n' \
+  "$BACKLOG_JSON" "$TASKS_JSON" "$MAIN_INVENTORY_JSON" \
+  "$SCOUT_REPORTS_JSON" "$SECONDMATE_CURRENT_JSON" "$SECONDMATE_LANDED_JSON" \
+  | jq -s \
+    --arg generated "$SNAPSHOT_NOW" \
+    --arg fm_home "$FM_HOME" \
+    --arg fm_root "$FM_ROOT" \
+    --arg state "$STATE" \
+    --arg data "$DATA" \
+    --arg config "$CONFIG" \
+    --arg projects "$PROJECTS" \
+    '.[0] as $backlog
+   | .[1] as $tasks
+   | .[2] as $main_inventory
+   | .[3] as $scout_reports
+   | .[4] as $secondmate_current
+   | .[5] as $secondmate_landed
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -242,6 +242,7 @@ JQ_SLURP_2=$(jq_slurp_guard 2)
 JQ_SLURP_3=$(jq_slurp_guard 3)
 JQ_SLURP_6=$(jq_slurp_guard 6)
 JQ_SLURP_7=$(jq_slurp_guard 7)
+JQ_SLURP_8=$(jq_slurp_guard 8)
 
 bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
@@ -479,7 +480,7 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
 task_json_lines() {
   local meta id kind harness mode yolo project worktree home projects spawn_gen backend target status_log report_path
   local remote_host remote_root
-  local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
+  local pr pr_json pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
   local current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
@@ -518,6 +519,7 @@ task_json_lines() {
     if [ -z "$pr" ]; then
       pr_source=absent
     fi
+    pr_json=$(printf '%s' "$pr" | jq -Rs '.')
 
     if [ -n "$remote_host" ]; then
       # Remote endpoint liveness belongs to supervision. The snapshot never
@@ -593,7 +595,7 @@ task_json_lines() {
 
     printf '%s\n' \
       "$current_json" "$meta_json" "$status_json" "$report_json" \
-      "$worktree_json" "$home_json" "$open_decisions_json" \
+      "$worktree_json" "$home_json" "$open_decisions_json" "$pr_json" \
       | jq -s \
         --arg id "$id" \
         --arg kind "$kind" \
@@ -609,7 +611,6 @@ task_json_lines() {
         --arg target "$target" \
         --arg remote_host "$remote_host" \
         --arg remote_root "$remote_root" \
-        --arg pr "$pr" \
         --arg pr_source "$pr_source" \
         --arg agent_alive "$agent_alive" \
         --arg observed_at "$SNAPSHOT_NOW" \
@@ -617,13 +618,14 @@ task_json_lines() {
         --argjson pending_decision "$(bool_json "$pending_decision")" \
         --argjson blocked_event "$(bool_json "$blocked_event")" \
         --argjson report_present "$(bool_json "$report_present")" \
-        "$JQ_SLURP_7"'.[0] as $current_state
+        "$JQ_SLURP_8"'.[0] as $current_state
         | .[1] as $meta_path
         | .[2] as $status_log
         | .[3] as $report
         | .[4] as $worktree_path
         | .[5] as $home_path
         | .[6] as $open_decisions
+        | .[7] as $pr
         | {
         id:$id,
         kind:$kind,
@@ -1416,8 +1418,8 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
 secondmate_current_json() {  # <parent-tasks-json>
   local tasks=$1 registry union rows total_registered total shown truncated
   local row id home host remote registered registry_error task sampled_spawn_gen status_file event_raw event_note event_text event_epoch event_age
-  local activity_scan activities decisions reconciliation provenance freshness reason reason_json summary summary_sampled summary_valid summary_reason summary_invalidity state terminal terminal_contradiction contradiction
-  local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot
+  local activity_scan activities decisions reconciliation provenance freshness reason reason_json summary summary_sampled summary_valid summary_reason summary_invalidity terminal terminal_contradiction contradiction
+  local summary_source summary_age summary_freshness cache_path collection_status collection_slot
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
   union=$(printf '%s\n' "$registry" "$tasks" | jq -s "$JQ_SLURP_2"'
@@ -1501,7 +1503,6 @@ secondmate_current_json() {  # <parent-tasks-json>
     fi
     summary_source=
     summary_age=0
-    summary_observed=$SNAPSHOT_NOW
     summary_freshness=fresh
     if [ -z "$reason" ]; then
       if [ "$remote" = true ]; then
@@ -1530,7 +1531,6 @@ secondmate_current_json() {  # <parent-tasks-json>
       fi
       if [ -z "$reason" ]; then
         summary_age=$(snapshot_summary_age "$summary")
-        summary_observed=$(printf '%s' "$summary" | jq -r '.generated')
       fi
     fi
     # Failed command substitutions clear their assignment target. Keep the
@@ -1551,7 +1551,6 @@ secondmate_current_json() {  # <parent-tasks-json>
     fi
 
     if [ -z "$reason" ]; then
-      state=$(printf '%s' "$summary" | jq -r '.state')
       reconciliation=$(parent_evidence_reconciliation_json "$summary" "$activities" "$decisions")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
       terminal_contradiction=$(printf '%s\n' "$reconciliation" "$event_text" | jq -sr "$JQ_SLURP_2"'
@@ -1567,7 +1566,7 @@ secondmate_current_json() {  # <parent-tasks-json>
       record=$(printf '%s\n' \
         "$summary" "$decisions" "$activities" "$activity_scan" "$reconciliation" "$terminal" "$event_text" \
         | jq -s \
-          --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg observed "$summary_observed" \
+          --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" \
           --arg summary_source "$summary_source" --arg summary_freshness "$summary_freshness" --argjson summary_age "$summary_age" \
           --arg spawn_gen "$sampled_spawn_gen" \
           --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson contradiction "$contradiction" \
@@ -1582,13 +1581,13 @@ secondmate_current_json() {  # <parent-tasks-json>
         | .[6] as $event_text
         | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
-         current:{state:$state,
+         current:{state:$summary.state,
            reason:(if $summary_valid == true then null
                    else "structured home state invalid: " + (($summary.reason // "unknown reason") | tostring) end)},invalidity:$summary.invalidity,
          reconcile_inventory:$summary.invalidity,
          provenance:{selected:"structured-home",structured_home:$home,summary_source:$summary_source,summary_valid:$summary_valid,
            trust:(if $summary_valid then "complete" else "partial-structured" end),parent_event_role:"historical-only"},
-         freshness:{status:$summary_freshness,observed_at:$observed,age_seconds:$summary_age},
+         freshness:{status:$summary_freshness,observed_at:$summary.generated,age_seconds:$summary_age},
          active_children:$summary.active_children,
          decisions_open:$summary.decisions_open,holds:$summary.holds,queued:$summary.queued,
          landed:$summary.landed,endpoints:$summary.endpoints,counts:$summary.counts,omitted:$summary.omitted,

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -227,6 +227,23 @@ esac
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-snapshot: jq not found" >&2; exit 1; }
 
+# Assembled JSON reaches jq on stdin rather than in argv, so `jq -s` slurping is
+# what carries the validation --argjson used to enforce. A slurped stream drops
+# an empty input silently, which would shift every later positional binding one
+# slot and emit a structurally valid but wrong snapshot. Every slurping filter is
+# prefixed with this guard, so a missing, empty, or null input fails nonzero.
+jq_slurp_guard() {  # <expected-count>
+  printf 'if (length != %s) or any(.[]; . == null) then
+      error("fm-fleet-snapshot: expected %s non-null assembled json inputs, got \\(length) [\\([.[] | type] | join(","))]")
+    else . end | ' "$1" "$1"
+}
+JQ_SLURP_1=$(jq_slurp_guard 1)
+JQ_SLURP_2=$(jq_slurp_guard 2)
+JQ_SLURP_3=$(jq_slurp_guard 3)
+JQ_SLURP_5=$(jq_slurp_guard 5)
+JQ_SLURP_6=$(jq_slurp_guard 6)
+JQ_SLURP_7=$(jq_slurp_guard 7)
+
 bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
@@ -602,7 +619,7 @@ task_json_lines() {
         --argjson pending_decision "$(bool_json "$pending_decision")" \
         --argjson blocked_event "$(bool_json "$blocked_event")" \
         --argjson report_present "$(bool_json "$report_present")" \
-        '.[0] as $current_state
+        "$JQ_SLURP_7"'.[0] as $current_state
         | .[1] as $meta_path
         | .[2] as $status_log
         | .[3] as $report
@@ -651,8 +668,12 @@ task_json_lines() {
              steer:"bin/fm-send.sh fm-\($id) \u0027<instruction>\u0027",
              return_channel_note:null}
           end)
-      }'
+      }' || exit 1
   done | jq -s 'sort_by(.id)'
+  # The loop runs in the pipeline's subshell, so a rejected record would be
+  # dropped from the sorted stream while `jq -s` still exited 0. Report the
+  # producer's status instead of emitting an inventory that is silently short.
+  [ "${PIPESTATUS[0]}" -eq 0 ] || return 1
 }
 
 # Main-home current-inventory validity: same orphan / unstructured-current checks
@@ -660,7 +681,7 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
-  printf '%s\n' "$1" "$2" | jq -s '
+  printf '%s\n' "$1" "$2" | jq -s "$JQ_SLURP_2"'
     .[0] as $backlog
     | .[1] as $tasks
     |
@@ -696,7 +717,7 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson child_n "$FM_SNAPSHOT_SECONDMATE_CHILDREN" \
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
-    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '
+    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" "$JQ_SLURP_2"'
     .[0] as $backlog
     | .[1] as $tasks
     |
@@ -1329,7 +1350,7 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  printf '%s\n' "$1" "$2" "$3" | jq -s '
+  printf '%s\n' "$1" "$2" "$3" | jq -s "$JQ_SLURP_3"'
     .[0] as $summary
     | .[1] as $activities
     | .[2] as $decisions
@@ -1399,7 +1420,7 @@ secondmate_current_json() {  # <parent-tasks-json>
   local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(printf '%s\n' "$registry" "$tasks" | jq -s '
+  union=$(printf '%s\n' "$registry" "$tasks" | jq -s "$JQ_SLURP_2"'
     .[0] as $registry
     | .[1] as $tasks
     |
@@ -1552,7 +1573,8 @@ secondmate_current_json() {  # <parent-tasks-json>
           --arg summary_source "$summary_source" --arg summary_freshness "$summary_freshness" --argjson summary_age "$summary_age" \
           --arg spawn_gen "$sampled_spawn_gen" \
           --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson contradiction "$contradiction" \
-          --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
+          --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" \
+          "$JQ_SLURP_6"'
         .[0] as $summary
         | .[1] as $decisions
         | .[2] as $activities
@@ -1590,7 +1612,8 @@ secondmate_current_json() {  # <parent-tasks-json>
           --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
           --arg spawn_gen "$sampled_spawn_gen" \
           --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
-          --argjson registered "$registered" --argjson event_age "$event_age" --argjson summary_sampled "$summary_sampled" '
+          --argjson registered "$registered" --argjson event_age "$event_age" --argjson summary_sampled "$summary_sampled" \
+          "$JQ_SLURP_5"'
         .[0] as $activities
         | .[1] as $activity_scan
         | .[2] as $decisions
@@ -1606,7 +1629,7 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(printf '%s\n' "$records" "$record" | jq -s '.[0] + [.[1]]')
+    records=$(printf '%s\n' "$records" "$record" | jq -s "$JQ_SLURP_2"'.[0] + [.[1]]')
   done <<EOF
 $rows
 EOF
@@ -1617,14 +1640,14 @@ EOF
       --argjson total "$total" \
       --argjson shown "$shown" \
       --argjson truncated "$truncated" \
-      '.[0] as $registry
+      "$JQ_SLURP_2"'.[0] as $registry
       | .[1] as $records
       | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  printf '%s\n' "$1" | jq '
-    . as $current
+  printf '%s\n' "$1" | jq -s "$JQ_SLURP_1"'
+    .[0] as $current
     |
     {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
@@ -1685,7 +1708,7 @@ printf '%s\n' \
     --arg data "$DATA" \
     --arg config "$CONFIG" \
     --arg projects "$PROJECTS" \
-    '.[0] as $backlog
+    "$JQ_SLURP_6"'.[0] as $backlog
    | .[1] as $tasks
    | .[2] as $main_inventory
    | .[3] as $scout_reports

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1416,7 +1416,7 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
 secondmate_current_json() {  # <parent-tasks-json>
   local tasks=$1 registry union rows total_registered total shown truncated
   local row id home host remote registered registry_error task sampled_spawn_gen status_file event_raw event_note event_text event_epoch event_age
-  local activity_scan activities decisions reconciliation provenance freshness reason summary summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
+  local activity_scan activities decisions reconciliation provenance freshness reason reason_json summary summary_sampled summary_valid summary_reason summary_invalidity state terminal terminal_contradiction contradiction
   local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
@@ -1552,10 +1552,6 @@ secondmate_current_json() {  # <parent-tasks-json>
 
     if [ -z "$reason" ]; then
       state=$(printf '%s' "$summary" | jq -r '.state')
-      current_reason=
-      if [ "$summary_valid" != true ]; then
-        current_reason="structured home state invalid: $(printf '%s' "$summary" | jq -r '.reason // "unknown reason"')"
-      fi
       reconciliation=$(parent_evidence_reconciliation_json "$summary" "$activities" "$decisions")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
       terminal_contradiction=$(printf '%s\n' "$reconciliation" "$event_text" | jq -sr "$JQ_SLURP_2"'
@@ -1571,7 +1567,7 @@ secondmate_current_json() {  # <parent-tasks-json>
       record=$(printf '%s\n' \
         "$summary" "$decisions" "$activities" "$activity_scan" "$reconciliation" "$terminal" "$event_text" \
         | jq -s \
-          --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$summary_observed" \
+          --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg observed "$summary_observed" \
           --arg summary_source "$summary_source" --arg summary_freshness "$summary_freshness" --argjson summary_age "$summary_age" \
           --arg spawn_gen "$sampled_spawn_gen" \
           --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson contradiction "$contradiction" \
@@ -1586,7 +1582,9 @@ secondmate_current_json() {  # <parent-tasks-json>
         | .[6] as $event_text
         | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
-         current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
+         current:{state:$state,
+           reason:(if $summary_valid == true then null
+                   else "structured home state invalid: " + (($summary.reason // "unknown reason") | tostring) end)},invalidity:$summary.invalidity,
          reconcile_inventory:$summary.invalidity,
          provenance:{selected:"structured-home",structured_home:$home,summary_source:$summary_source,summary_valid:$summary_valid,
            trust:(if $summary_valid then "complete" else "partial-structured" end),parent_event_role:"historical-only"},
@@ -1610,19 +1608,21 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
-      record=$(printf '%s\n' "$activities" "$activity_scan" "$decisions" "$terminal" "$summary" "$event_text" \
+      reason_json=$(printf '%s' "$reason" | jq -Rs '.')
+      record=$(printf '%s\n' "$activities" "$activity_scan" "$decisions" "$terminal" "$summary" "$event_text" "$reason_json" \
         | jq -s \
-          --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
+          --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg observed "$SNAPSHOT_NOW" \
           --arg spawn_gen "$sampled_spawn_gen" \
           --arg provenance "$provenance" --arg freshness "$freshness" \
           --argjson registered "$registered" --argjson event_age "$event_age" --argjson summary_sampled "$summary_sampled" \
-          "$JQ_SLURP_6"'
+          "$JQ_SLURP_7"'
         .[0] as $activities
         | .[1] as $activity_scan
         | .[2] as $decisions
         | .[3] as $terminal
         | .[4] as $summary
         | .[5] as $event_text
+        | .[6] as $reason
         | {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:"unknown",reason:$reason},invalidity:null,

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -3,8 +3,10 @@
 #
 # Output contract: `--json` prints one object with schema
 # `fm-fleet-snapshot.v1`.
-# Internally assembled JSON is streamed into jq instead of crossing an exec
-# boundary in argv, so backlog growth cannot exceed the platform argument limit.
+# Assembled JSON, and every unbounded string derived from it - backlog rows,
+# status-log event text, a discovered PR url, and a secondmate's published home
+# summary - is streamed into jq instead of crossing an exec boundary in argv, so
+# growth in any of those inputs cannot exceed the platform argument limit.
 # The command does not acquire the session lock, drain wakes, arm watchers,
 # mutate backlog state, or write reports. Its default ledger collector may
 # atomically refresh parent-side cached copies of remote home summaries under

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -240,7 +240,6 @@ jq_slurp_guard() {  # <expected-count>
 JQ_SLURP_1=$(jq_slurp_guard 1)
 JQ_SLURP_2=$(jq_slurp_guard 2)
 JQ_SLURP_3=$(jq_slurp_guard 3)
-JQ_SLURP_5=$(jq_slurp_guard 5)
 JQ_SLURP_6=$(jq_slurp_guard 6)
 JQ_SLURP_7=$(jq_slurp_guard 7)
 
@@ -295,8 +294,9 @@ crew_state_json() {  # <id>
       esac
       ;;
   esac
-  jq -n --arg raw "$raw" --arg state "$state" --arg source "$source" --arg detail "$detail" \
-    '{state:$state,source:$source,detail:$detail,raw:$raw}'
+  printf '%s\n%s\n%s\n%s\n' "$state" "$source" "$detail" "$raw" \
+    | jq -Rs 'split("\n") as $f
+      | {state:$f[0],source:$f[1],detail:$f[2],raw:$f[3]}'
 }
 
 status_event_json() {  # <status-log>
@@ -307,13 +307,13 @@ status_event_json() {  # <status-log>
     verb=$(status_line_verb "$raw")
     note=$(status_line_note "$raw")
   fi
-  jq -n \
-    --arg path "$log" \
-    --arg raw "$raw" \
-    --arg verb "$verb" \
-    --arg note "$note" \
-    --argjson present "$(bool_json "$present")" \
-    '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw}}'
+  printf '%s\n%s\n%s\n' "$verb" "$note" "$raw" \
+    | jq -Rs \
+      --arg path "$log" \
+      --argjson present "$(bool_json "$present")" \
+      'split("\n") as $f
+       | {path:$path,present:$present,kind:"event_history",
+          last_event:{state:$f[0],note:$f[1],raw:$f[2]}}'
 }
 
 first_pr_url_in_file() {  # <file>
@@ -480,7 +480,7 @@ task_json_lines() {
   local meta id kind harness mode yolo project worktree home projects spawn_gen backend target status_log report_path
   local remote_host remote_root
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
-  local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
+  local current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
   for meta in "$STATE"/*.meta; do
@@ -527,7 +527,6 @@ task_json_lines() {
       current_json=$(crew_state_json "$id")
     fi
     event_json=$(status_event_json "$status_log")
-    last_event_raw=$(printf '%s' "$event_json" | jq -r '.last_event.raw // ""')
     current_state=$(printf '%s' "$current_json" | jq -r '.state // ""')
     current_source=$(printf '%s' "$current_json" | jq -r '.source // ""')
 
@@ -614,7 +613,6 @@ task_json_lines() {
         --arg pr_source "$pr_source" \
         --arg agent_alive "$agent_alive" \
         --arg observed_at "$SNAPSHOT_NOW" \
-        --arg last_event_raw "$last_event_raw" \
         --argjson endpoint_exists "$endpoint_exists" \
         --argjson pending_decision "$(bool_json "$pending_decision")" \
         --argjson blocked_event "$(bool_json "$blocked_event")" \
@@ -656,7 +654,7 @@ task_json_lines() {
           blocked_event:$blocked_event,
           open_decisions:$open_decisions,
           scout_report_present:$report_present,
-          last_event_text:$last_event_raw
+          last_event_text:($status_log.last_event.raw // "")
         },
         actions:(
           if $kind == "secondmate" then
@@ -671,9 +669,11 @@ task_json_lines() {
       }' || exit 1
   done | jq -s 'sort_by(.id)'
   # The loop runs in the pipeline's subshell, so a rejected record would be
-  # dropped from the sorted stream while `jq -s` still exited 0. Report the
-  # producer's status instead of emitting an inventory that is silently short.
-  [ "${PIPESTATUS[0]}" -eq 0 ] || return 1
+  # dropped from the sorted stream while `jq -s` still exited 0. Both stages
+  # must report, or the caller emits an inventory that is silently short.
+  local pipe_status=("${PIPESTATUS[@]}")
+  [ "${pipe_status[0]}" -eq 0 ] || return 1
+  [ "${pipe_status[1]}" -eq 0 ] || return 1
 }
 
 # Main-home current-inventory validity: same orphan / unstructured-current checks
@@ -1415,7 +1415,7 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
 
 secondmate_current_json() {  # <parent-tasks-json>
   local tasks=$1 registry union rows total_registered total shown truncated
-  local row id home host remote registered registry_error task sampled_spawn_gen status_file event_raw event_note event_epoch event_age
+  local row id home host remote registered registry_error task sampled_spawn_gen status_file event_raw event_note event_text event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot
   local records='[]' seen_homes=''
@@ -1460,6 +1460,7 @@ secondmate_current_json() {  # <parent-tasks-json>
     status_file=$(printf '%s' "$task" | jq -r '.paths.status_log.path // ""')
     event_raw=$(printf '%s' "$task" | jq -r '.paths.status_log.last_event.raw // ""')
     event_note=$(printf '%s' "$task" | jq -r '.paths.status_log.last_event.note // ""')
+    event_text=$(printf '%s' "$task" | jq -c '{raw:(.paths.status_log.last_event.raw // ""),note:(.paths.status_log.last_event.note // "")}')
     activity_scan=$(bounded_parent_activities_json "$status_file")
     activities=$(printf '%s' "$activity_scan" | jq -c '.records')
     decisions=$(printf '%s' "$task" | jq -c '.hints.open_decisions // []')
@@ -1557,8 +1558,9 @@ secondmate_current_json() {  # <parent-tasks-json>
       fi
       reconciliation=$(parent_evidence_reconciliation_json "$summary" "$activities" "$decisions")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
-      terminal_contradiction=$(printf '%s' "$reconciliation" | jq -r --arg note "$event_note" '
-        any(.activities[]; .verdict == "contradicts" and .summary == $note)')
+      terminal_contradiction=$(printf '%s\n' "$reconciliation" "$event_text" | jq -sr "$JQ_SLURP_2"'
+        .[1].note as $note
+        | any(.[0].activities[]; .verdict == "contradicts" and .summary == $note)')
       if [ "$terminal_contradiction" = true ]; then
         terminal=$(terminal_evidence_json "$task" "$event_note" true)
       else
@@ -1567,20 +1569,21 @@ secondmate_current_json() {  # <parent-tasks-json>
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
       record=$(printf '%s\n' \
-        "$summary" "$decisions" "$activities" "$activity_scan" "$reconciliation" "$terminal" \
+        "$summary" "$decisions" "$activities" "$activity_scan" "$reconciliation" "$terminal" "$event_text" \
         | jq -s \
           --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$summary_observed" \
           --arg summary_source "$summary_source" --arg summary_freshness "$summary_freshness" --argjson summary_age "$summary_age" \
           --arg spawn_gen "$sampled_spawn_gen" \
           --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson contradiction "$contradiction" \
-          --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" \
-          "$JQ_SLURP_6"'
+          --argjson event_age "$event_age" \
+          "$JQ_SLURP_7"'
         .[0] as $summary
         | .[1] as $decisions
         | .[2] as $activities
         | .[3] as $activity_scan
         | .[4] as $reconciliation
         | .[5] as $terminal
+        | .[6] as $event_text
         | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
@@ -1591,7 +1594,7 @@ secondmate_current_json() {  # <parent-tasks-json>
          active_children:$summary.active_children,
          decisions_open:$summary.decisions_open,holds:$summary.holds,queued:$summary.queued,
          landed:$summary.landed,endpoints:$summary.endpoints,counts:$summary.counts,omitted:$summary.omitted,
-         parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan,reconciliation:$reconciliation},
+         parent_event:{raw:$event_text.raw,note:$event_text.note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan,reconciliation:$reconciliation},
          terminal_evidence:$terminal,contradiction:$contradiction}')
     else
       if [ -n "$event_raw" ]; then
@@ -1607,18 +1610,19 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
-      record=$(printf '%s\n' "$activities" "$activity_scan" "$decisions" "$terminal" "$summary" \
+      record=$(printf '%s\n' "$activities" "$activity_scan" "$decisions" "$terminal" "$summary" "$event_text" \
         | jq -s \
           --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
           --arg spawn_gen "$sampled_spawn_gen" \
-          --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
+          --arg provenance "$provenance" --arg freshness "$freshness" \
           --argjson registered "$registered" --argjson event_age "$event_age" --argjson summary_sampled "$summary_sampled" \
-          "$JQ_SLURP_5"'
+          "$JQ_SLURP_6"'
         .[0] as $activities
         | .[1] as $activity_scan
         | .[2] as $decisions
         | .[3] as $terminal
         | .[4] as $summary
+        | .[5] as $event_text
         | {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:"unknown",reason:$reason},invalidity:null,
@@ -1626,7 +1630,7 @@ secondmate_current_json() {  # <parent-tasks-json>
          provenance:{selected:$provenance,structured_home:($home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
          freshness:{status:$freshness,observed_at:$observed,age_seconds:$event_age},
          active_children:[],decisions_open:[],holds:[],queued:[],landed:[],endpoints:[],counts:{active_children:0,decisions_open:0,holds:0,queued:0,landed:0,endpoints:0},omitted:[],
-         parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
+         parent_event:{raw:$event_text.raw,note:$event_text.note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
     records=$(printf '%s\n' "$records" "$record" | jq -s "$JQ_SLURP_2"'.[0] + [.[1]]')

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -662,7 +662,7 @@ portable_serial_unhinted() {
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-unhinted.XXXXXX") || return 1
   portable_serial_weight_hints | awk 'NF { print $1 }' | LC_ALL=C sort -u >"$tmp/hinted"
   list_portable_serial | LC_ALL=C sort -u >"$tmp/serial"
-  comm -23 "$tmp/serial" "$tmp/hinted"
+  LC_ALL=C comm -23 "$tmp/serial" "$tmp/hinted"
   rm -rf "$tmp"
 }
 
@@ -810,8 +810,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -855,8 +855,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/serial_shards_raw" >"$tmp/serial_shards"
-  missing=$(comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
-  extra=$(comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable serial shards must equal the portable serial lane"
     [ -z "$missing" ] || { log "missing from serial shards:"; printf '%s\n' "$missing" >&2; }
@@ -868,7 +868,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -886,8 +886,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -917,7 +917,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/tests/fm-bearings-board-render.test.sh
+++ b/tests/fm-bearings-board-render.test.sh
@@ -20,7 +20,10 @@ command -v node >/dev/null 2>&1 || { echo "skip: node not found"; exit 0; }
 
 make_home() {  # <name>
   local home="$TMP_ROOT/$1" fakebin
-  mkdir -p "$home/state" "$home/data"
+  # The board arms itself as a process-event source, which fails closed unless
+  # the state root is private; create it 0700 rather than at the caller's umask.
+  (umask 077; mkdir -p "$home/state") || fail "the home state root was not created"
+  mkdir -p "$home/data"
   fakebin=$(fm_fakebin "$home")
   fm_fake_exit0 "$fakebin" lavish-axi
   printf '%s\n' "$home"

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -234,6 +234,43 @@ test_large_backlog_bypasses_argv_limit() {
   pass "fleet and bearings snapshots accept backlog JSON larger than the argv limit"
 }
 
+# Assembled record JSON is slurped from stdin, and a slurped stream silently
+# drops an empty value. A producer that cannot run - the raw status line still
+# reaches its jq through argv, so an oversized event line makes that exec fail -
+# must therefore never leave the snapshot reporting one input's value under
+# another input's field.
+test_incomplete_record_input_never_shifts_bindings() {
+  local home out err
+  home=$(make_home short-record-input)
+  mkdir -p "$home/projects/alpha-worktree"
+  fm_write_meta "$home/state/big-event.meta" \
+    "window=firstmate:fm-big-event" \
+    "worktree=$home/projects/alpha-worktree" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship"
+  {
+    printf 'needs-decision: '
+    head -c 300000 /dev/zero | tr '\0' x
+    printf '\n'
+  } > "$home/state/big-event.status"
+
+  err=$TMP_ROOT/short-record-input.err
+  if out=$(FM_HOME="$home" "$SNAPSHOT" --json 2>"$err"); then
+    printf '%s' "$out" | jq -e --arg log "$home/state/big-event.status" '
+      .tasks[0].paths.status_log.path == $log
+        and (.tasks[0].paths.home | type) == "object"
+        and (.tasks[0].hints.open_decisions | type) == "array"
+    ' >/dev/null || fail "snapshot exited 0 with task fields bound to the wrong input: $out"
+  else
+    assert_contains "$(cat "$err")" "assembled json inputs" \
+      "a rejected record input must name the incomplete assembled input"
+    [ -z "$out" ] || fail "a failed snapshot must not emit a partial schema: $out"
+  fi
+  pass "an incomplete assembled record input never shifts snapshot bindings"
+}
+
 # R1 owner contract: main_inventory discloses orphan in-flight and unstructured
 # current rows without inventing task rows.
 test_main_inventory_orphan_and_unstructured_disclosure() {
@@ -936,6 +973,7 @@ EOF
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_home_summary_excludes_secondmate_from_child_inventory
+test_incomplete_record_input_never_shifts_bindings
 test_large_backlog_bypasses_argv_limit
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -274,6 +274,55 @@ test_oversized_status_line_keeps_the_snapshot_whole() {
   pass "an oversized status line still yields one complete, correctly bound task record"
 }
 
+# A secondmate publishes its own home summary, so the parent treats that file as
+# foreign input bounded only by FM_SNAPSHOT_SECONDMATE_MAX_BYTES (256 KiB), twice
+# the platform's per-argument limit. The invalidity reason is the one string that
+# schema never truncates, so it has to reach jq on stdin like the rest.
+test_oversized_home_summary_reason_keeps_the_snapshot_whole() {
+  local home mate out
+  home=$(make_home oversized-summary-reason)
+  mate=$TMP_ROOT/oversized-summary-reason-mate
+  mkdir -p "$mate/state" "$mate/data" "$mate/projects" "$mate/config" "$mate/bin"
+  printf '# Firstmate\n' > "$mate/AGENTS.md"
+  printf 'mate\n' > "$mate/.fm-secondmate-home"
+  {
+    printf '## In flight\n'
+    printf -- '- [ ] orphan-task - Orphan (repo: alpha) (kind: ship)\n'
+    printf '\n## Queued\n\n## Done\n'
+  } > "$mate/data/backlog.md"
+  printf -- '- mate - fixture domain (home: %s; scope: fixture; projects: sample; added 2026-08-26)\n' \
+    "$mate" > "$home/data/secondmates.md"
+  fm_write_meta "$home/state/mate.meta" \
+    "window=firstmate:fm-mate" \
+    "kind=secondmate" \
+    "harness=claude" \
+    "backend=tmux" \
+    "spawn_gen=spawn-mate" \
+    "home=$mate" \
+    "worktree=$mate"
+
+  FM_HOME="$mate" "$SNAPSHOT" --secondmate-home-summary > "$mate/state/published.json" \
+    || fail "could not publish the secondmate home-summary fixture"
+  jq -c '.reason = ("in-flight backlog item has no child metadata: " + ("x" * 200000))' \
+    "$mate/state/published.json" > "$mate/state/home-summary.json" \
+    || fail "could not widen the published invalidity reason"
+
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "snapshot must survive a home-summary reason larger than the argv limit"
+  printf '%s' "$out" | jq -e --arg home "$mate" '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.secondmate_current.records | length) == 1
+      and .secondmate_current.records[0].home == $home
+      and .secondmate_current.records[0].provenance.selected == "structured-home"
+      and .secondmate_current.records[0].invalidity.kind == "orphan_in_flight"
+      and (.secondmate_current.records[0].current.reason
+           | ltrimstr("structured home state invalid: in-flight backlog item has no child metadata: ")
+           | length) == 200000
+      and (.secondmate_landed | type) == "object"
+  ' >/dev/null || fail "an oversized summary reason shifted, truncated, or dropped secondmate fields"
+  pass "an oversized published home-summary reason still yields a complete secondmate record"
+}
+
 # R1 owner contract: main_inventory discloses orphan in-flight and unstructured
 # current rows without inventing task rows.
 test_main_inventory_orphan_and_unstructured_disclosure() {
@@ -977,6 +1026,7 @@ test_empty_fleet_json
 test_fixture_snapshot_json
 test_home_summary_excludes_secondmate_from_child_inventory
 test_large_backlog_bypasses_argv_limit
+test_oversized_home_summary_reason_keeps_the_snapshot_whole
 test_oversized_status_line_keeps_the_snapshot_whole
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -234,14 +234,13 @@ test_large_backlog_bypasses_argv_limit() {
   pass "fleet and bearings snapshots accept backlog JSON larger than the argv limit"
 }
 
-# Assembled record JSON is slurped from stdin, and a slurped stream silently
-# drops an empty value. A producer that cannot run - the raw status line still
-# reaches its jq through argv, so an oversized event line makes that exec fail -
-# must therefore never leave the snapshot reporting one input's value under
-# another input's field.
-test_incomplete_record_input_never_shifts_bindings() {
-  local home out err
-  home=$(make_home short-record-input)
+# Agents append uncapped status lines, so the last event text is unbounded and
+# must reach jq on stdin like every other assembled payload. A status line past
+# the platform's per-argument limit must still produce one complete task record
+# whose fields are each bound to their own input.
+test_oversized_status_line_keeps_the_snapshot_whole() {
+  local home out big
+  home=$(make_home oversized-status-line)
   mkdir -p "$home/projects/alpha-worktree"
   fm_write_meta "$home/state/big-event.meta" \
     "window=firstmate:fm-big-event" \
@@ -250,25 +249,29 @@ test_incomplete_record_input_never_shifts_bindings() {
     "harness=codex" \
     "kind=ship" \
     "mode=ship"
-  {
-    printf 'needs-decision: '
-    head -c 300000 /dev/zero | tr '\0' x
-    printf '\n'
-  } > "$home/state/big-event.status"
+  big=$(head -c 300000 /dev/zero | tr '\0' x)
+  printf 'needs-decision: %s\n' "$big" > "$home/state/big-event.status"
 
-  err=$TMP_ROOT/short-record-input.err
-  if out=$(FM_HOME="$home" "$SNAPSHOT" --json 2>"$err"); then
-    printf '%s' "$out" | jq -e --arg log "$home/state/big-event.status" '
-      .tasks[0].paths.status_log.path == $log
-        and (.tasks[0].paths.home | type) == "object"
-        and (.tasks[0].hints.open_decisions | type) == "array"
-    ' >/dev/null || fail "snapshot exited 0 with task fields bound to the wrong input: $out"
-  else
-    assert_contains "$(cat "$err")" "assembled json inputs" \
-      "a rejected record input must name the incomplete assembled input"
-    [ -z "$out" ] || fail "a failed snapshot must not emit a partial schema: $out"
-  fi
-  pass "an incomplete assembled record input never shifts snapshot bindings"
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "snapshot must survive a status line larger than the argv limit"
+  printf '%s' "$out" | jq -e --arg log "$home/state/big-event.status" '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.tasks | length) == 1
+      and .tasks[0].paths.status_log.path == $log
+      and .tasks[0].paths.status_log.kind == "event_history"
+      and .tasks[0].paths.status_log.last_event.state == "needs-decision"
+      and (.tasks[0].paths.status_log.last_event.note | length) == 300000
+      and (.tasks[0].paths.status_log.last_event.note | startswith("xxx"))
+      and (.tasks[0].paths.status_log.last_event.raw | length) == 300016
+      and .tasks[0].paths.home == {path:null,present:false}
+      and .tasks[0].paths.report.present == false
+      and .tasks[0].current_state.source == "none"
+      and .tasks[0].hints.pending_decision == true
+      and (.tasks[0].hints.open_decisions | length) == 1
+      and .tasks[0].hints.open_decisions[0].verb == "needs-decision"
+      and (.tasks[0].hints.last_event_text | length) == 300016
+  ' >/dev/null || fail "an oversized status line shifted, truncated, or dropped task fields"
+  pass "an oversized status line still yields one complete, correctly bound task record"
 }
 
 # R1 owner contract: main_inventory discloses orphan in-flight and unstructured
@@ -973,8 +976,8 @@ EOF
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_home_summary_excludes_secondmate_from_child_inventory
-test_incomplete_record_input_never_shifts_bindings
 test_large_backlog_bypasses_argv_limit
+test_oversized_status_line_keeps_the_snapshot_whole
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness
 test_event_hints_follow_reconciled_current_state

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -276,12 +276,12 @@ test_oversized_status_line_keeps_the_snapshot_whole() {
 
 # A secondmate publishes its own home summary, so the parent treats that file as
 # foreign input bounded only by FM_SNAPSHOT_SECONDMATE_MAX_BYTES (256 KiB), twice
-# the platform's per-argument limit. The invalidity reason is the one string that
-# schema never truncates, so it has to reach jq on stdin like the rest.
-test_oversized_home_summary_reason_keeps_the_snapshot_whole() {
-  local home mate out
-  home=$(make_home oversized-summary-reason)
-  mate=$TMP_ROOT/oversized-summary-reason-mate
+# the platform's per-argument limit. Its reason, state, and generated fields are
+# the strings that schema never truncates, so each has to reach jq on stdin.
+test_oversized_home_summary_fields_keep_the_snapshot_whole() {
+  local home mate out field
+  home=$(make_home oversized-summary-fields)
+  mate=$TMP_ROOT/oversized-summary-fields-mate
   mkdir -p "$mate/state" "$mate/data" "$mate/projects" "$mate/config" "$mate/bin"
   printf '# Firstmate\n' > "$mate/AGENTS.md"
   printf 'mate\n' > "$mate/.fm-secondmate-home"
@@ -303,24 +303,63 @@ test_oversized_home_summary_reason_keeps_the_snapshot_whole() {
 
   FM_HOME="$mate" "$SNAPSHOT" --secondmate-home-summary > "$mate/state/published.json" \
     || fail "could not publish the secondmate home-summary fixture"
-  jq -c '.reason = ("in-flight backlog item has no child metadata: " + ("x" * 200000))' \
-    "$mate/state/published.json" > "$mate/state/home-summary.json" \
-    || fail "could not widen the published invalidity reason"
+
+  # One field at a time: 200 KB each keeps every fixture inside the 256 KiB cap
+  # the parent enforces before it will read a published summary at all.
+  for field in reason state generated; do
+    jq -c --arg f "$field" '.[$f] = ("x" * 200000)' \
+      "$mate/state/published.json" > "$mate/state/home-summary.json" \
+      || fail "could not widen the published $field"
+
+    out=$(FM_HOME="$home" "$SNAPSHOT" --json) \
+      || fail "snapshot must survive a home-summary $field larger than the argv limit"
+    printf '%s' "$out" | jq -e --arg home "$mate" --arg f "$field" '
+      .secondmate_current.records[0] as $r
+      | (if $f == "reason" then ($r.current.reason | ltrimstr("structured home state invalid: "))
+         elif $f == "state" then $r.current.state
+         else $r.freshness.observed_at end) as $widened
+      | .schema == "fm-fleet-snapshot.v1"
+        and (.secondmate_current.records | length) == 1
+        and $r.home == $home
+        and $r.provenance.selected == "structured-home"
+        and $r.invalidity.kind == "orphan_in_flight"
+        and ($widened | length) == 200000
+        and ($widened | startswith("xxx"))
+        and (.secondmate_landed | type) == "object"
+    ' >/dev/null || fail "an oversized published $field shifted, truncated, or dropped secondmate fields"
+  done
+  pass "oversized published home-summary strings still yield a complete secondmate record"
+}
+
+# A task's PR url is discovered by scanning its status log, so its length is
+# bounded only by the longest unbroken non-whitespace run an agent ever appends.
+# The discovered url is user-visible, so it must survive whole.
+test_oversized_status_pr_url_keeps_the_snapshot_whole() {
+  local home out pad
+  home=$(make_home oversized-pr-url)
+  mkdir -p "$home/projects/alpha-worktree"
+  fm_write_meta "$home/state/pr-task.meta" \
+    "window=firstmate:fm-pr-task" \
+    "worktree=$home/projects/alpha-worktree" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship"
+  pad=$(head -c 200000 /dev/zero | tr '\0' x)
+  printf 'done: https://github.com/kunchenguid/%s/pull/7 shipped\n' "$pad" > "$home/state/pr-task.status"
 
   out=$(FM_HOME="$home" "$SNAPSHOT" --json) \
-    || fail "snapshot must survive a home-summary reason larger than the argv limit"
-  printf '%s' "$out" | jq -e --arg home "$mate" '
-    .schema == "fm-fleet-snapshot.v1"
-      and (.secondmate_current.records | length) == 1
-      and .secondmate_current.records[0].home == $home
-      and .secondmate_current.records[0].provenance.selected == "structured-home"
-      and .secondmate_current.records[0].invalidity.kind == "orphan_in_flight"
-      and (.secondmate_current.records[0].current.reason
-           | ltrimstr("structured home state invalid: in-flight backlog item has no child metadata: ")
-           | length) == 200000
-      and (.secondmate_landed | type) == "object"
-  ' >/dev/null || fail "an oversized summary reason shifted, truncated, or dropped secondmate fields"
-  pass "an oversized published home-summary reason still yields a complete secondmate record"
+    || fail "snapshot must survive a status-log PR url larger than the argv limit"
+  printf '%s' "$out" | jq -e '
+    (.tasks | length) == 1
+      and .tasks[0].id == "pr-task"
+      and .tasks[0].pr.source == "status_event"
+      and (.tasks[0].pr.url
+           | ltrimstr("https://github.com/kunchenguid/") | rtrimstr("/pull/7") | length) == 200000
+      and .tasks[0].paths.status_log.last_event.state == "done"
+      and .tasks[0].paths.home == {path:null,present:false}
+  ' >/dev/null || fail "an oversized status-log PR url shifted, truncated, or dropped task fields"
+  pass "an oversized status-log PR url still yields a complete task record"
 }
 
 # R1 owner contract: main_inventory discloses orphan in-flight and unstructured
@@ -1026,8 +1065,9 @@ test_empty_fleet_json
 test_fixture_snapshot_json
 test_home_summary_excludes_secondmate_from_child_inventory
 test_large_backlog_bypasses_argv_limit
-test_oversized_home_summary_reason_keeps_the_snapshot_whole
+test_oversized_home_summary_fields_keep_the_snapshot_whole
 test_oversized_status_line_keeps_the_snapshot_whole
+test_oversized_status_pr_url_keeps_the_snapshot_whole
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness
 test_event_hints_follow_reconciled_current_state

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -7,6 +7,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 SNAPSHOT="$ROOT/bin/fm-fleet-snapshot.sh"
+BEARINGS="$ROOT/bin/fm-bearings-snapshot.sh"
 VIEW="$ROOT/bin/fm-fleet-view.sh"
 TMP_ROOT=$(fm_test_tmproot fm-fleet-snapshot)
 
@@ -195,6 +196,42 @@ test_fixture_snapshot_json() {
     | .state == "done" and .pr_url == "https://github.com/kunchenguid/firstmate/pull/7"
   ' >/dev/null || fail "done backlog PR row missing"
   pass "fixture snapshot covers task rows, backlog rows, pointers, and stable ordering"
+}
+
+# Large parsed backlog JSON must cross jq process boundaries through stdin, not
+# argv, whose per-argument limit is commonly 128 KiB on Linux.
+test_large_backlog_bypasses_argv_limit() {
+  local home out summary bearings
+  home=$(make_home large-backlog)
+  {
+    printf '## In flight\n\n## Queued\n'
+    printf '%s' '- [ ] huge-task - Large body (repo: firstmate) (kind: ship)'
+    printf '\n  '
+    head -c 300000 /dev/zero | tr '\0' x
+    printf '\n\n## Done\n'
+  } > "$home/data/backlog.md"
+
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "snapshot rejected a backlog larger than the argv limit"
+  printf '%s' "$out" | jq -e '
+    .schema == "fm-fleet-snapshot.v1"
+      and .backlog.records[0].id == "huge-task"
+      and (.backlog.records[0].body_lines[0] | length) == 300000
+  ' >/dev/null || fail "large-backlog snapshot was not valid, complete JSON"
+
+  summary=$(FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary) \
+    || fail "home summary rejected a backlog larger than the argv limit"
+  printf '%s' "$summary" | jq -e '
+    .schema == "fm-secondmate-home-summary.v1"
+      and .valid == true
+      and .queued[0].id == "huge-task"
+  ' >/dev/null || fail "large-backlog home summary was not valid JSON"
+
+  bearings=$(FM_HOME="$home" "$BEARINGS" --json) \
+    || fail "bearings rejected a backlog larger than the argv limit"
+  printf '%s' "$bearings" | jq -e '.schema == "fm-bearings.v1"' >/dev/null \
+    || fail "large-backlog bearings output was not valid JSON"
+  pass "fleet and bearings snapshots accept backlog JSON larger than the argv limit"
 }
 
 # R1 owner contract: main_inventory discloses orphan in-flight and unstructured
@@ -899,6 +936,7 @@ EOF
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_home_summary_excludes_secondmate_from_child_inventory
+test_large_backlog_bypasses_argv_limit
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness
 test_event_hints_follow_reconciled_current_state

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -25,8 +25,8 @@ test_list_all_exact_suite_coverage() {
     done | LC_ALL=C sort
   )
   [ -n "$listed" ] || fail "--list --all printed nothing"
-  missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
-  extra=$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  missing=$(LC_ALL=C comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  extra=$(LC_ALL=C comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
   [ -z "$missing" ] || fail "--list --all missing scripts: $missing"
   [ -z "$extra" ] || fail "--list --all unexpected scripts: $extra"
   # No duplicates.
@@ -761,7 +761,7 @@ test_portable_shard_union_and_coverage_guard() {
   herdr=$("$RUNNER" --list --family real-herdr-gated)
   [ -n "$s1" ] && [ -n "$s2" ] || fail "portable parallel shards must be non-empty"
   # Shards disjoint.
-  overlap=$(comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
+  overlap=$(LC_ALL=C comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
   [ -z "$overlap" ] || fail "portable parallel shards overlap: $overlap"
   # Union of shards equals proven-isolated.
   [ "$(printf '%s\n' "$s1" "$s2" | LC_ALL=C sort -u)" = \


### PR DESCRIPTION
## Intent

LE CAPITAINE N'A PLUS DE POINT DE SITUATION: LE GENERATEUR DE DIGEST EST MORT.

Il l'a demande deux fois aujourd'hui, le 2026-09-03, et les deux fois j'ai du composer son etat a la
main en lisant le carnet. Sa question ensuite: "que faire si ton digest est en panne ? verifier si ya
une nouvelle update ou ?"

J'ai verifie: **le defaut est identique sur origin/main**, ce n'est pas une derive locale. Une mise a
jour n'y changerait rien. C'est donc a corriger en amont, et c'est ce lot.

Ce brief est en francais, ta livraison ne l'est pas: tout ce qui entre dans le depot s'ecrit en
ANGLAIS.

## What Changed

- `bin/fm-fleet-snapshot.sh` and `bin/fm-bearings-snapshot.sh` now pipe every assembled JSON payload and unbounded derived string — backlog records, status-log event text, a status-discovered PR url, and a secondmate's published home summary — into `jq -s` on stdin, replacing the `--argjson`/`--arg` bindings that pushed those values through argv and failed once they exceeded the platform's per-argument limit. Positional bindings (`.[0] as $backlog`, …) replace the named ones, and fields like `last_event_text`, `freshness.observed_at`, and the invalid-summary reason are now derived inside jq rather than pre-extracted in shell.
- Added a shared `jq_slurp_guard` helper in both scripts that prefixes each slurping filter with an arity/null check, so a missing, empty, or null input errors nonzero instead of silently shifting later positional bindings; `task_json_lines` additionally inspects `PIPESTATUS` for both pipeline stages so a rejected task record fails the run instead of yielding a silently short inventory.
- `tests/fm-fleet-snapshot-view.test.sh` gains four cases exercising a 300 KB backlog body, a 300 KB status line, a 200 KB status-log PR url, and 200 KB `reason`/`state`/`generated` fields in a published home summary, asserting complete and correctly bound snapshot, bearings, and home-summary output; `tests/fm-bearings-board-render.test.sh` now creates the fixture state root mode 0700 so the board's process-event arming does not fail closed under a permissive umask.

## Risk Assessment

✅ Low: The change is a well-bounded mechanical move of assembled JSON from argv to stdin: I confirmed the reported E2BIG failure reproduces on the base commit and is gone at HEAD, and that --json, --secondmate-home-summary, bearings JSON and bearings TOON (including the --include-prs path) are byte-identical between base and HEAD across fixtures exercising every rewritten filter, with shellcheck clean and behavior-based regression tests added.

## Testing

The configured changed-suite baseline had already passed; on top of it I ran the two directly affected suites (fleet snapshot/view and bearings board render, both green) and then demonstrated the actual user intent end to end by building a captain home whose backlog has simply grown to a real working size and asking both trees for a situation report: the base commit (verified identical to origin/main) dies with `jq: Argument list too long` and returns nothing, while this branch returns a complete fm-bearings.v1 digest with Captain's Call, Underway, Recently Landed and Charted Next populated plus a rendered human fleet view, captured as a before/after CLI transcript. I also proved the new tests are real regressions by running each against the base bin/ (all four fail there, all pass here) and checked that a malformed foreign secondmate summary still produces a complete schema with an explicit disclosure rather than a null field. No screenshot or rendered-UI artifact is included because this change is shell/JSON plumbing with no UI surface, and no browser is usable in this environment anyway (system Chrome is absent and the cached Playwright chromium is missing libnspr4, which I may not install); the captain-facing surface here is the CLI digest, which the transcript shows directly. No transient files were left in the worktree.

<details>
<summary>Evidence: Before/after CLI transcript: the captain&#39;s situation report dies on origin/main and comes back on this branch</summary>

Source: [Before/after CLI transcript: the captain&#39;s situation report dies on origin/main and comes back on this branch](https://github.com/cisrd/firstmate/blob/a38e95b83cbfea2a0990c74dedde78bc962b807f/.no-mistakes/evidence/fm/fm-snapshot-argv-too-long/digest-restored-transcript.txt)

```text
==============================================================================
 The captain asks for a situation report (/bearings).
 Captain home backlog: 52 items, 99884 bytes
 - the same shape and size as the real home whose digest died on 2026-09-03.
==============================================================================

########  BEFORE - base 75b2de2 (identical on origin/main)  ##################

$ FM_HOME=<captain-home> bash bin/fm-bearings-snapshot.sh --json
/tmp/fm-e2e/base/bin/fm-fleet-snapshot.sh: line 658: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed
[before] exit status = 1

$ FM_HOME=<captain-home> bash bin/fm-fleet-view.sh
/tmp/fm-e2e/base/bin/fm-fleet-snapshot.sh: line 658: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed
[before] exit status = 1

########  AFTER - 949c479 (this branch)  #####################################

$ FM_HOME=<captain-home> bin/fm-bearings-snapshot.sh --json > digest.json
[after] exit status = 0  (7148 bytes of digest JSON, stderr: 0 bytes)
[after] valid, complete fm-bearings.v1 JSON

--- the four sections the /bearings digest is composed from ---
generated: 2026-09-03T22:22:09Z

CAPTAIN'S CALL (decisions_open): 1
  - decision-pending-api: Captain call: pick the API shape before the cutover: Pick the API shape before t

UNDERWAY (in_flight): 6
  - task-live-01 [parked] choose an API shape before the cutover
  - task-live-02 [working] harness busy (claude-hook)
  - task-live-03 [working] harness busy (claude-hook)
  - task-live-04 [working] harness busy (claude-hook)
  - task-live-05 [working] harness busy (claude-hook)
  - task-live-06 [working] harness busy (claude-hook)

RECENTLY LANDED: 6
  - task-done-15: Landed work item 15: stabilise the nightly reconcile
  - task-done-11: Landed work item 11: stabilise the nightly reconcile
  - task-done-07: Landed work item 07: stabilise the nightly reconcile
  - task-done-03: Landed work item 03: stabilise the nightly reconcile
  - task-done-14: Landed work item 14: stabilise the nightly reconcile
  - task-done-10: Landed work item 10: stabilise the nightly reconcile

CHARTED NEXT (gates): 20
  - task-queued-01: Queued work item 01: reconcile the duplicated palette lists
  - task-queued-02: Queued work item 02: reconcile the duplicated palette lists
  - task-queued-03: Queued work item 03: reconcile the duplicated palette lists
  - task-queued-04: Queued work item 04: reconcile the duplicated palette lists
  - task-queued-05: Queued work item 05: reconcile the duplicated palette lists
  - task-queued-06: Queued work item 06: reconcile the duplicated palette lists
  ... 14 more

--- the human fleet view rendered over the same restored snapshot ---
$ FM_HOME=<captain-home> bash bin/fm-fleet-view.sh
# Fleet View

Schema: fm-fleet-snapshot.v1
Home: /tmp/fm-e2e/grown-home

## Under Way
| ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| task-live-01 | parked / status-log | ship | alpha | tmux | present | - | /tmp/fm-e2e/grown-home/projects/alpha-worktree-1 | bin/fm-peek.sh fm-task-live-01 |
| task-live-02 | working / pane | ship | alpha | tmux | present | - | /tmp/fm-e2e/grown-home/projects/alpha-worktree-2 | bin/fm-peek.sh fm-task-live-02 |
| task-live-03 | working / pane | ship | alpha | tmux | present | https://github.com/kunchenguid/firstmate/pull/9 | /tmp/fm-e2e/grown-home/projects/alpha-worktree-3 | bin/fm-peek.sh fm-task-live-03 |
| task-live-04 | working / pane | ship | alpha | tmux | present | - | /tmp/fm-e2e/grown-home/projects/alpha-worktree-4 | bin/fm-peek.sh fm-task-live-04 |
| task-live-05 | working / pane | ship | alpha | tmux | present | - | /tmp/fm-e2e/grown-home/projects/alpha-worktree-5 | bin/fm-peek.sh fm-task-live-05 |
| task-live-06 | working / pane | ship | alpha | tmux | present | - | /tmp/fm-e2e/grown-home/projects/alpha-worktree-6 | bin/fm-peek.sh fm-task-live-06 |

## Queued
| ID | Title | Repo | Kind | Blocked By | Artifact |
| --- | --- | --- | --- | --- | --- |
| decision-pending-api | Captain call: pick the API shape before the cutover |
[after] exit status = 0
```
</details>
<details>
<summary>Evidence: Restored /bearings digest payload (fm-bearings.v1) produced from the grown-backlog home</summary>

Source: [Restored /bearings digest payload (fm-bearings.v1) produced from the grown-backlog home](https://github.com/cisrd/firstmate/blob/a38e95b83cbfea2a0990c74dedde78bc962b807f/.no-mistakes/evidence/fm/fm-snapshot-argv-too-long/bearings-digest-restored.json)

```text
{
  "schema": "fm-bearings.v1",
  "home": "fm-e2e/grown-home",
  "generated": "2026-09-03T22:22:09Z",
  "prs": "not_requested (run: /bearings include PRs)",
  "in_flight": [
    {
      "id": "task-live-01",
      "kind": "ship",
      "state": "parked",
      "repo": "alpha",
      "doing": "choose an API shape before the cutover"
    },
    {
      "id": "task-live-02",
      "kind": "ship",
      "state": "working",
      "repo": "alpha",
      "doing": "harness busy (claude-hook)"
    },
    {
      "id": "task-live-03",
      "kind": "ship",
      "state": "working",
      "repo": "alpha",
      "doing": "harness busy (claude-hook)"
    },
    {
      "id": "task-live-04",
      "kind": "ship",
      "state": "working",
      "repo": "alpha",
      "doing": "harness busy (claude-hook)"
    },
    {
      "id": "task-live-05",
      "kind": "ship",
      "state": "working",
      "repo": "alpha",
      "doing": "harness busy (claude-hook)"
    },
    {
      "id": "task-live-06",
      "kind": "ship",
      "state": "working",
      "repo": "alpha",
      "doing": "harness busy (claude-hook)"
    }
  ],
  "secondmates": [],
  "secondmate_reconcile": [],
  "decisions_open": [
    {
      "id": "decision-pending-api",
      "key": "decision-pending-api",
      "verb": "captain-hold",
      "summary": "Captain call: pick the API shape before the cutover: Pick the API shape before the cutover…",
      "owner": "(main)"
    }
  ],
  "landed": [
    {
      "id": "task-done-15",
      "what": "Landed work item 15: stabilise the nightly reconcile",
      "artifact": "-",
      "owner": "(main)"
    },
    {
      "id": "task-done-11",
      "what": "Landed work item 11: stabilise the nightly reconcile",
      "artifact": "-",
      "owner": "(main)"
    },
    {
      "id": "task-done-07",
      "what": "Landed work item 07: stabilise the nightly reconcile",
      "artifact": "-",
      "owner": "(main)"
    },
    {
      "id": "task-done-03",
      "what": "Landed work item 03: stabilise the nightly reconcile",
      "artifact": "-",
      "owner": "(main)"
    },
    {
      "id": "task-done-14",
      "what": "Landed work item 14: stabilise the nightly reconcile",
      "artifact": "-",
      "owner": "(main)"
    },
    {
      "id": "task-done-10",
      "what": "Landed work item 10: stabilise the nightly reconcile",
      "artifact": "-",
      "owner": "(main)"
    }
  ],
  "gates": [
    {
      "id": "task-queued-01",
      "title": "Queued work item 01: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-02",
      "title": "Queued work item 02: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-03",
      "title": "Queued work item 03: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-04",
      "title": "Queued work item 04: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-05",
      "title": "Queued work item 05: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-06",
      "title": "Queued work item 06: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-07",
      "title": "Queued work item 07: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-08",
      "title": "Queued work item 08: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-09",
      "title": "Queued work item 09: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-10",
      "title": "Queued work item 10: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-11",
      "title": "Queued work item 11: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-12",
      "title": "Queued work item 12: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-13",
      "title": "Queued work item 13: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-14",
      "title": "Queued work item 14: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-15",
      "title": "Queued work item 15: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-16",
      "title": "Queued work item 16: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-17",
      "title": "Queued work item 17: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-18",
      "title": "Queued work item 18: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-19",
      "title": "Queued work item 19: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    },
    {
      "id": "task-queued-20",
      "title": "Queued work item 20: reconcile the duplicated palette lists",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    }
  ],
  "reports": [],
  "recorded_prs": [],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded or prose-deferred queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "landed per-home capped at 6 for 1 home(s)",
      "reveal": "--all-landed"
    },
    {
      "surface": "gates showing 20 of 29",
      "reveal": "--all-queued"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}
```
</details>
<details>
<summary>Evidence: New regression tests: fail against the base commit, pass on this branch (plus malformed-input fail-safe check)</summary>

Source: [New regression tests: fail against the base commit, pass on this branch (plus malformed-input fail-safe check)](https://github.com/cisrd/firstmate/blob/a38e95b83cbfea2a0990c74dedde78bc962b807f/.no-mistakes/evidence/fm/fm-snapshot-argv-too-long/argv-regression-before-after.txt)

```text
Regression coverage added by this branch, run against BOTH trees.
Each test was executed on its own so the run does not stop at the first failure.

  base 75b2de2 (== origin/main): the four new tests are run against the old
  bin/ by copying only the new test file into a checkout of the base commit.

    test_large_backlog_bypasses_argv_limit                     rc=1  not ok - snapshot rejected a backlog larger than the argv limit
    test_oversized_status_line_keeps_the_snapshot_whole        rc=1  not ok - an oversized status line shifted, truncated, or dropped task fields
    test_oversized_home_summary_fields_keep_the_snapshot_whole rc=1  not ok - snapshot must survive a home-summary reason larger than the argv limit
    test_oversized_status_pr_url_keeps_the_snapshot_whole      rc=1  not ok - an oversized status-log PR url shifted, truncated, or dropped task fields

  949c479 (this branch), full suite tests/fm-fleet-snapshot-view.test.sh, rc=0:

    ok - fleet and bearings snapshots accept backlog JSON larger than the argv limit
    ok - oversized published home-summary strings still yield a complete secondmate record
    ok - an oversized status line still yields one complete, correctly bound task record
    ok - an oversized status-log PR url still yields a complete task record
    (plus the 17 pre-existing snapshot/view tests, all ok)

Malformed foreign input still fails safe rather than emitting a partial schema
(registered secondmate whose published state/home-summary.json is not JSON):

  $ FM_HOME=<home> bin/fm-fleet-snapshot.sh --json   -> exit 0, empty stderr
  {"schema":"fm-fleet-snapshot.v1",
   "secondmate_landed": <object, not null>,
   "secondmate_current.records[0]": {"provenance":{"selected":"unknown"},
     "current":{"reason":"structured home ledger is missing, unreadable, or invalid"}}}
```
</details>
<details>
<summary>Evidence: Key excerpt of the before/after transcript</summary>

```text
######## BEFORE - base 75b2de2 (identical on origin/main) ##################
$ FM_HOME=<captain-home> bash bin/fm-bearings-snapshot.sh --json
/tmp/fm-e2e/base/bin/fm-fleet-snapshot.sh: line 658: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed
[before] exit status = 1

######## AFTER - 949c479 (this branch) #####################################
[after] exit status = 0 (7148 bytes of digest JSON, stderr: 0 bytes)
[after] valid, complete fm-bearings.v1 JSON

CAPTAIN'S CALL (decisions_open): 1
- decision-pending-api: Captain call: pick the API shape before the cutover
UNDERWAY (in_flight): 6
- task-live-01 [parked] choose an API shape before the cutover
- task-live-02 [working] harness busy (claude-hook)
RECENTLY LANDED: 6
CHARTED NEXT (gates): 20
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (16m51s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e5a1c0461318beaca11e595c0beb41d8951bf40f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-fleet-snapshot.sh:578` - Positional slurping drops the arity/validity check that --argjson enforced: if any streamed value is empty, jq silently binds every later index one position early and still exits 0. Concrete path: status_event_json (bin/fm-fleet-snapshot.sh:294-299) still builds its object with `jq -n --arg raw &#34;$raw&#34;`, so a status log whose last non-empty line exceeds MAX_ARG_STRLEN (~128 KiB on Linux) makes that exec fail with E2BIG and leaves $status_json empty. The stream then carries 6 values instead of 7, so `.[2] as $status_log` binds the report object, `.[3] as $report` binds the worktree object, `.[4]`/`.[5]` shift onto home/open-decisions, and `.[6] as $open_decisions` becomes null - the task record is emitted with wrong paths and no open decisions, exit 0. Verified: `printf &#39;%s\n&#39; &#39;&#39; &#39;{&#34;a&#34;:1}&#39; | jq -sc &#39;.&#39;` -&gt; `[{&#34;a&#34;:1}]`. Before this change `--argjson status_log &#34;&#34;` aborted jq and task_json_lines failed loudly into the `exit 1` guard at line 1661. The same hazard applies if a streamed value ever carries two top-level JSON values (shift in the other direction). Fix by asserting arity before the bindings, e.g. `if length != 7 then error(&#34;fm-fleet-snapshot: incomplete task json inputs&#34;) else . end |`, and apply the same guard at the other converted sites (lines 663, 692, 1332, 1402, 1548, 1588, 1614, 1677 and bin/fm-bearings-snapshot.sh:296).
- ⚠️ `bin/fm-fleet-snapshot.sh:1626` - secondmate_landed_from_current_json switched from `jq -n --argjson current &#34;$1&#34;` to `printf &#39;%s\n&#39; &#34;$1&#34; | jq ...`. With an empty $1 the filter runs zero times: jq prints nothing and exits 0, so the `|| { echo ...; exit 1; }` guard at line 1675 never fires. SECONDMATE_LANDED_JSON is then empty, the final `jq -s` at line 1677 slurps 5 values instead of 6, and `.[5] as $secondmate_landed` resolves to null - the command emits a schema-violating `&#34;secondmate_landed&#34;: null` in fm-fleet-snapshot.v1 with exit 0, and bearings&#39; landed roll-up plus its omitted[] disclosure silently vanish rather than erroring. Verified: `printf &#39;%s\n&#39; &#39;&#39; | jq -c &#39;. as $c | {r:$c}&#39;` prints nothing with rc=0, whereas the old `--argjson current &#34;&#34;` aborted. Fix by using `jq -s` with an explicit `if length != 1 then error(...) end` guard (or `jq -e` plus an emptiness check) so a missing input fails instead of producing a null field.
- ⚠️ `bin/fm-fleet-snapshot.sh:1609` - The two accumulator folds converted in this diff swallow a missing operand instead of failing. At bin/fm-fleet-snapshot.sh:1609, `printf &#39;%s\n&#39; &#34;$records&#34; &#34;$record&#34; | jq -s &#39;.[0] + [.[1]]&#39;` with an empty $record (any upstream record-building jq failure) slurps one value and evaluates `records + [null]`, appending a literal null secondmate record; downstream readers such as secondmate_landed_from_current_json and the bearings projection do `.records[] | select(.provenance.selected == ...)`, which drops null without error, so a secondmate silently disappears from the situation report - the exact class of missing-state symptom this branch is meant to eliminate. The same shape at bin/fm-bearings-snapshot.sh:272, `.[0] + .[1]` with an empty $repo_rows, evaluates to `rows + null == rows`, silently dropping a whole repository&#39;s open PRs while PR_STATUS still reports it as checked. Verified: `printf &#39;%s\n&#39; &#39;[1]&#39; &#39;&#39; | jq -sc &#39;.[0] + [.[1]]&#39;` -&gt; `[1,null]`; `... &#39;.[0] + .[1]&#39;` -&gt; `[1]`. Previously `--argjson` rejected the empty operand and the failure propagated. Guard both with `if length != 2 then error(...) else . end`.

🔧 Fix: Validate slurped jq input arity in fleet snapshots
3 issues (1 warning, 2 infos) still open:

- ⚠️ `bin/fm-fleet-snapshot.sh:312` - The argv conversion stops short of the last unbounded payload, so the dead-digest failure this branch exists to remove is still reachable - and the fix round made it worse. `status_event_json` still builds its object with `jq -n --arg raw &#34;$raw&#34; ... --arg note &#34;$note&#34;`, where `raw` is the last non-empty line of the status log (`last_nonempty_line`, line 261) and `note` is everything after its first colon. Both are unbounded: agents append status lines with a bare `echo &#34;{state}: {line}&#34; &gt;&gt; $STATUS_FILE` (bin/fm-brief.sh:272) and no writer caps line length. Concrete path, verified: `jq -n --arg raw &#34;$(300000 x&#39;s)&#34; ...` exits 126 with `Argument list too long` (MAX_ARG_STRLEN is 128 KiB per argument, independent of the 2 MB ARG_MAX). So `event_json` is empty -&gt; `status_json` is empty -&gt; the 7-value stream at line 597 carries 6 -&gt; `JQ_SLURP_7` errors -&gt; the new `|| exit 1` (line 671) kills the for-loop subshell -&gt; `task_json_lines` returns 1 -&gt; `TASKS_JSON=$(task_json_lines) || { ...; exit 1; }` (line 1684) aborts the whole snapshot. Before this branch the same input silently dropped one task and the digest still rendered; now the digest is dead, which is exactly the symptom the intent requires eliminating. The change&#39;s own new test (tests/fm-fleet-snapshot-view.test.sh:243) constructs precisely this 300 KB status line, and only its else-branch is reachable, so it currently asserts that the snapshot dies. Fix at the same stdin boundary already adopted: stream the raw line and note into that jq (e.g. `printf &#39;%s&#39; &#34;$raw&#34; | jq -Rs ...`, or `--rawfile raw &lt;(printf &#39;%s&#39; &#34;$raw&#34;)`) instead of argv. The same status text is re-passed via argv at line 617 (`--arg last_event_raw`) and lines 1576/1614 (`--arg event_raw`/`--arg event_note`), so all four sites must move together or the E2BIG just relocates.
- ℹ️ `bin/fm-fleet-snapshot.sh:676` - The new `[ &#34;${PIPESTATUS[0]}&#34; -eq 0 ] || return 1` is now the last command in `task_json_lines`, so it replaces the pipeline&#39;s exit status as the function&#39;s return value and only covers stage 0. Before the fix round the function ended with `done | jq -s &#39;sort_by(.id)&#39;`, so a failure of the aggregating jq propagated; now if that jq fails (PIPESTATUS[1] != 0) while the producer loop succeeded, the function returns 0 with empty or partial stdout and the `|| { echo &#34;task snapshot failed&#34;; exit 1; }` guard at line 1684 never fires. The run still aborts downstream (empty TASKS_JSON trips `JQ_SLURP_2` in main_inventory_json), but under a misattributed &#34;main inventory summary failed&#34; message. Note that `[ ... ]` itself resets PIPESTATUS, so both stages must be captured first: `local st=(&#34;${PIPESTATUS[@]}&#34;); [ &#34;${st[0]}&#34; -eq 0 ] &amp;&amp; [ &#34;${st[1]}&#34; -eq 0 ] || return 1`.
- ℹ️ `tests/fm-fleet-snapshot-view.test.sh:260` - `test_incomplete_record_input_never_shifts_bindings` passes on either branch of `if out=$(... --json)`. On the current code only the else-branch executes (the 300 KB status line makes status_event_json&#39;s exec fail, so the snapshot exits 1), which means the then-branch - the actual anti-shift assertions on `paths.status_log.path`, `paths.home`, and `hints.open_decisions` - is dead code today, and the test&#39;s effective assertion is &#34;a large status line kills the digest&#34;. That is the outcome flagged in the argv finding above, so as written the test locks in the residual outage rather than exposing it. Once the raw/note transport moves to stdin, the else-branch should be dropped so the test pins the success path it was written to protect.

🔧 Fix: Stream unbounded status text into jq instead of argv
2 issues (1 warning, 1 info) still open:

- ⚠️ `bin/fm-fleet-snapshot.sh:1574` - Two snapshot-derived strings still reach jq through argv, so the invariant this branch asserts at bin/fm-fleet-snapshot.sh:6-7 (&#34;Internally assembled JSON is streamed into jq instead of crossing an exec boundary in argv, so backlog growth cannot exceed the platform argument limit&#34;) is not fully held, and the same dead-digest symptom stays reachable. At line 1557 `current_reason=&#34;structured home state invalid: $(... jq -r &#39;.reason // &#34;unknown reason&#34;&#39;)&#34;` is built from a registered home&#39;s summary and passed at line 1574 as `--arg current_reason &#34;$current_reason&#34;`; the sibling unsampled branch does the same at line 1615 with `--arg reason &#34;$reason&#34;` (which is also set to &#34;structured home state invalid: $summary_reason&#34; at line 1550). That `.reason` is the ONLY string field secondmate_home_summary_json does not pass through its own `trunc(...)` helper: at bin/fm-fleet-snapshot.sh:813-816 it is emitted verbatim as `$strict_invalidities[0].reason`, e.g. &#34;in-flight backlog item has no child metadata: &#34; + ($orphan_in_flight | map(.id) | join(&#34;, &#34;)) or &#34;live child state has no in-flight backlog item: &#34; + ($unowned_children | map(.id + &#34;=&#34; + .state) | join(&#34;, &#34;)). Its only bound is the whole-file cap FM_SNAPSHOT_SECONDMATE_MAX_BYTES=262144 enforced by summary_file_read (line 1024), which is double the 128 KiB per-argument MAX_ARG_STRLEN. Concrete path: a registered secondmate home whose backlog accumulates enough orphan in-flight rows (or unowned children) that the joined id list exceeds ~128 KiB -&gt; summary_valid != true with invalidity.kind in {orphan_in_flight, unowned_current, terminal_in_flight, child_current_unavailable}, so the case at lines 1545-1548 leaves $reason empty and control enters the sampled branch -&gt; `--arg current_reason` execs jq with a &gt;128 KiB argument -&gt; exec fails with E2BIG (verified on this host: `jq -n --arg a &#34;$(200000 x&#39;s)&#34;` -&gt; &#34;Argument list too long&#34;; 120000 succeeds) -&gt; $record is empty -&gt; the JQ_SLURP_2 fold at line 1636 errors -&gt; the final slurp at line 1640 errors -&gt; secondmate_current_json returns 1 -&gt; &#34;fm-fleet-snapshot: registered secondmate aggregation failed&#34;, exit 1, digest dead. Fix at the stdin boundary already adopted everywhere else: fold current_reason/reason into the streamed payload (they can ride the same object as event_text, or be their own slurped value with the count bumped to 8/7) rather than argv. Truncating .reason in secondmate_home_summary_json would also close it but changes user-visible message text, so it is the author&#39;s call rather than a mechanical fix.
- ℹ️ `bin/fm-bearings-snapshot.sh:211` - `jq_slurp_guard` is a byte-for-byte copy of bin/fm-fleet-snapshot.sh:235-239 apart from the error prefix, and both scripts already source a common library (`. &#34;$SCRIPT_DIR/fm-timeout-lib.sh&#34;` at bin/fm-bearings-snapshot.sh:78 and bin/fm-fleet-snapshot.sh:176), so a shared home exists. Not a defect - the two copies are currently identical in behavior - but the guard is the single load-bearing piece of validation for this whole change, and a future correction (e.g. adding the type check the fix instructions asked for, or changing the error text) has to be made twice to stay consistent. Worth folding into one helper that takes the script prefix as a second argument.

🔧 Fix: Stream secondmate invalidity reasons into jq off argv
2 issues (1 warning, 1 info) still open:

- ⚠️ `bin/fm-fleet-snapshot.sh:1570` - The sampled secondmate record still passes two foreign-controlled, unbounded strings through argv, so the dead-digest failure this branch removes stays reachable in the very jq call the last fix round rewrote. Line 1554 sets `state=$(printf &#39;%s&#39; &#34;$summary&#34; | jq -r &#39;.state&#39;)` and line 1518 sets `summary_observed=$(printf &#39;%s&#39; &#34;$summary&#34; | jq -r &#39;.generated&#39;)`; both are handed to jq at line 1570 as `--arg state &#34;$state&#34;` and `--arg observed &#34;$summary_observed&#34;`. `$summary` is a secondmate&#39;s published `state/home-summary.json` (fetched over ssh for remote homes), and SNAPSHOT_SUMMARY_FILTER (bin/fm-fleet-snapshot.sh:1097-1110) only checks `(.state | type) == &#34;string&#34;` and `(.generated | type) == &#34;string&#34;` - no length bound. The only cap is FM_SNAPSHOT_SECONDMATE_MAX_BYTES=262144, double the 128 KiB per-argument MAX_ARG_STRLEN. Reproduced on this host with the exact fixture from tests/fm-fleet-snapshot-view.test.sh:281: setting `.state` (or `.generated`) to a 200000-char string yields `line 1596: /usr/bin/jq: Argument list too long` -&gt; `$record` empty -&gt; `JQ_SLURP_2` fires at line 1636 and again at 1642 -&gt; `fm-fleet-snapshot: registered secondmate aggregation failed`, exit 1, digest dead. The fix is mechanical and needs no new plumbing: `.[0]` in that filter is already `$summary`, and in this branch `$reason` is empty by construction, so `state` == `$summary.state` and `summary_observed` == `$summary.generated` unconditionally. Drop `--arg state` / `--arg observed` and read `$summary.state` and `$summary.generated` inside the filter. (`--arg home`/`--arg host` at the same site come from data/secondmates.md and are operator-local, so lower priority.)
- ℹ️ `bin/fm-fleet-snapshot.sh:612` - `--arg pr &#34;$pr&#34;` is the last status-log-derived string still crossing argv in task_json_lines. When the meta has no `pr=` key, `pr` comes from `first_pr_url_in_file &#34;$status_log&#34;` (line 511, grep -Eo &#39;https?://[^[:space:])&#34;]+/pull/[0-9]+&#39;), whose match length is bounded only by the length of an unbroken non-whitespace run in the status log - and agents append status lines with no length cap. Reproduced: a status line `done: https://github.com/a/b&lt;200000 x&#39;s&gt;/pull/1` gives `line 597: /usr/bin/jq: Argument list too long` -&gt; the `|| exit 1` at line 669 kills the loop subshell -&gt; `task_json_lines` returns 1 -&gt; `fm-fleet-snapshot: task snapshot failed`, exit 1, digest dead - the same total outage the branch exists to remove. The trigger is contrived (128 KiB of non-whitespace ending in /pull/N), hence info rather than warning, but the fix is mechanical at the boundary already adopted: carry `pr` in the streamed payload (e.g. an eighth slurped input built with `printf &#39;%s&#39; &#34;$pr&#34; | jq -Rs &#39;.&#39;`, count bumped to 8) rather than truncating it, since the URL is user-visible. The sibling `--arg worktree`/`--arg home`/`--arg projects`/`--arg target` at lines 604-609 come from .meta files and are practically PATH_MAX-bounded, so they do not need to move.

🔧 Fix: Stream remaining unbounded snapshot strings off argv
1 info still open:

- ℹ️ `bin/fm-fleet-snapshot.sh:677` - Trade-off note, not a defect. The new `|| exit 1` (line 671) plus the PIPESTATUS check (lines 676-678) escalate any per-record jq failure in task_json_lines from &#34;drop that one task&#34; to &#34;fail the entire snapshot&#34;. The only remaining reachable trigger is a `.meta` value larger than the ~128 KiB per-argument limit, since meta-derived scalars still cross argv: `path_present_json &#34;$worktree&#34;` (line 254 via line 700-ish call site `worktree_json=$(path_present_json &#34;$worktree&#34;)`), `--arg worktree/home/projects/target` (lines 606-611), and `--arg home/host` in the secondmate records (lines 1569, 1613). Verified on this host with a meta containing a 200 KB `worktree=` value plus one healthy task: base commit 75b2de2 printed a snapshot containing 1 of 2 tasks with exit 0 (silently short inventory, two `Argument list too long` messages on stderr); HEAD exits 1 with no output at all. The escalation is the correct direction given the file&#39;s own contract that meta inventory is the sole source of live workers, and fm itself never writes a meta value that large (registry input is capped at FM_SNAPSHOT_REGISTRY_BYTES=65536, and worktree/home are filesystem paths), so no action is needed - recording it so the behavior change is not a surprise if a corrupt meta ever appears. Round 4 already concluded these meta-derived argv sites do not need to move.
</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Create board-render fixture state root mode 0700
✅ Re-checked - no issues remain.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>`bash tests/fm-fleet-snapshot-view.test.sh` (21 tests, rc=0, includes the four new oversized-input regressions)</code>
- <code>`bash tests/fm-bearings-board-render.test.sh` (rc=0, covers the 0700 state-root fixture fix in 949c479)</code>
- <code>Manual end-to-end before/after: `git archive 75b2de2 | tar -x` into a temp tree, then `FM_HOME=&lt;grown-home&gt; bin/fm-bearings-snapshot.sh --json` and `bin/fm-fleet-view.sh` run from both trees against the same fixture home (52 backlog items, 99884 bytes)</code>
- `First reproduced the base failure against a copy of the real home's data/backlog.md (77311 bytes, 52 items), then switched to an equivalent synthetic backlog so no real captain data is published`
- <code>Regression proof: each of `test_large_backlog_bypasses_argv_limit`, `test_oversized_status_line_keeps_the_snapshot_whole`, `test_oversized_home_summary_fields_keep_the_snapshot_whole`, `test_oversized_status_pr_url_keeps_the_snapshot_whole` run individually against the base commit&#39;s bin/ - all four fail there, all four pass on the branch</code>
- <code>Manual fail-safe check: registered secondmate whose published state/home-summary.json is not JSON -&gt; `bin/fm-fleet-snapshot.sh --json` returns exit 0, empty stderr, `secondmate_landed` an object (not null), and an explicit `structured home ledger is missing, unreadable, or invalid` reason</code>
- <code>`git rev-parse origin/main` to confirm the base commit is exactly origin/main, matching the intent&#39;s claim that the defect is upstream</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
