### PR TITLE
feat: structure no-mistakes ask-user escalations

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -181,6 +181,8 @@ BRIEF="$DATA/$ID/brief.md"
 [ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
 mkdir -p "$DATA/$ID"
 
+ASK_USER_BLOCK=$(fm_ask_user_escalation_block "$DATA" "$ID")
+
 shell_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
@@ -375,8 +377,10 @@ The report is the only thing that survives, so anything worth keeping must be in
    firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs to a human (product choices, destructive actions),
+6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+   The ask-user format below applies only if this task is later promoted to a ship task; a scout never runs no-mistakes on its own.
+$ASK_USER_BLOCK
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
@@ -458,6 +462,7 @@ $RULE1
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+$ASK_USER_BLOCK
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -181,7 +181,10 @@ BRIEF="$DATA/$ID/brief.md"
 [ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
 mkdir -p "$DATA/$ID"
 
-ASK_USER_BLOCK=$(fm_ask_user_escalation_block "$DATA" "$ID")
+ASK_USER_BLOCK=
+if [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; then
+  ASK_USER_BLOCK=$(fm_ask_user_escalation_block "$DATA" "$ID")
+fi
 
 shell_quote() {
   printf "'"
@@ -379,8 +382,6 @@ The report is the only thing that survives, so anything worth keeping must be in
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
-   The ask-user format below applies only if this task is later promoted to a ship task; a scout never runs no-mistakes on its own.
-$ASK_USER_BLOCK
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -380,7 +380,7 @@ The report is the only thing that survives, so anything worth keeping must be in
    firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
+6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
@@ -461,7 +461,7 @@ $RULE1
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
+6. If a decision belongs above the implementation worker (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
 $ASK_USER_BLOCK
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -215,7 +215,7 @@ This replaces the no-mistakes skill's advice to enrich \`--intent\` with decisio
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are never yours to answer: escalate the whole gate to firstmate using rule 6's ask-user format (one \`needs-decision\` event naming every finding id, plus a snapshot file holding those findings verbatim - the same shape even for a single finding) and stop.
+- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format (one \`needs-decision\` event naming every finding id, plus a snapshot file holding those findings verbatim - the same shape even for a single finding) and stop.
   Firstmate applies \`ask-user-authority\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - NEVER pass \`--yes\` (or \`-y\`) to \`no-mistakes axi run\` or \`no-mistakes axi respond\`. It is banned fleet-wide.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -160,6 +160,20 @@ fm_brief_task_content_valid() {  # <file>
   [ -n "$(printf '%s' "$task" | tr -d '[:space:]')" ]
 }
 
+# Single owner of the ask-user escalation format referenced as "rule 6" by the
+# no-mistakes Definition of done below. Rendered into both the scout and ship
+# rule 6 in bin/fm-brief.sh so a promoted scout - whose rule 6 stays the scout
+# brief's rule 6 per bin/fm-promote.sh - carries the identical format a
+# freshly-spawned no-mistakes ship worker gets.
+fm_ask_user_escalation_block() {  # <data-dir> <task-id>
+  local data=$1 id=$2
+  cat <<EOF
+   For a no-mistakes ask-user gate specifically, escalate the whole gate as one event plus one snapshot file, using that same shape even when the gate holds only a single finding: write every finding the gate reported, verbatim and unparaphrased (id, severity, file, line, description, authority), to \`$data/$id/nm-<run>-findings.txt\`, then report the gate with
+   \`needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=$data/$id/nm-<run>-findings.txt\`
+   naming every finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
+EOF
+}
+
 fm_dod_block() {  # <mode> <task-id>
   local mode=$1 id=$2
   case "$mode" in
@@ -201,7 +215,7 @@ This replaces the no-mistakes skill's advice to enrich \`--intent\` with decisio
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
+- ask-user findings are never yours to answer: escalate the whole gate to firstmate using rule 6's ask-user format (one \`needs-decision\` event naming every finding id, plus a snapshot file holding those findings verbatim - the same shape even for a single finding) and stop.
   Firstmate applies \`ask-user-authority\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - NEVER pass \`--yes\` (or \`-y\`) to \`no-mistakes axi run\` or \`no-mistakes axi respond\`. It is banned fleet-wide.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -160,17 +160,12 @@ fm_brief_task_content_valid() {  # <file>
   [ -n "$(printf '%s' "$task" | tr -d '[:space:]')" ]
 }
 
-# Single owner of the ask-user escalation format referenced as "rule 6" by the
-# no-mistakes Definition of done below. Rendered into both the scout and ship
-# rule 6 in bin/fm-brief.sh so a promoted scout - whose rule 6 stays the scout
-# brief's rule 6 per bin/fm-promote.sh - carries the identical format a
-# freshly-spawned no-mistakes ship worker gets.
 fm_ask_user_escalation_block() {  # <data-dir> <task-id>
   local data=$1 id=$2
   cat <<EOF
-   For a no-mistakes ask-user gate specifically, escalate the whole gate as one event plus one snapshot file, using that same shape even when the gate holds only a single finding: write every finding the gate reported, verbatim and unparaphrased (id, severity, file, line, description, authority), to \`$data/$id/nm-<run>-findings.txt\`, then report the gate with
+   For a no-mistakes ask-user gate specifically, escalate all ask-user findings as one event plus one snapshot file, using that same shape even when the gate holds only a single ask-user finding: write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority), to \`$data/$id/nm-<run>-findings.txt\`, then report the gate with
    \`needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=$data/$id/nm-<run>-findings.txt\`
-   naming every finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
+   naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
 EOF
 }
 
@@ -215,7 +210,7 @@ This replaces the no-mistakes skill's advice to enrich \`--intent\` with decisio
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format (one \`needs-decision\` event naming every finding id, plus a snapshot file holding those findings verbatim - the same shape even for a single finding) and stop.
+- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format and stop.
   Firstmate applies \`ask-user-authority\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - NEVER pass \`--yes\` (or \`-y\`) to \`no-mistakes axi run\` or \`no-mistakes axi respond\`. It is banned fleet-wide.

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -159,6 +159,10 @@ fi
 # promoted no-mistakes worker that never received the ask-user escalation rule or
 # the --yes ban is the delivery hole this file used to leave open.
 INSTRUCTIONS="$DATA/$ID/ship-instructions.md"
+PROMOTION_ASK_USER_BLOCK=
+if [ "$MODE" = no-mistakes ]; then
+  PROMOTION_ASK_USER_BLOCK=$(fm_ask_user_escalation_block "$DATA" "$ID")
+fi
 mkdir -p "$DATA/$ID"
 [ ! -d "$INSTRUCTIONS" ] || { echo "error: ship instructions path is a directory: $INSTRUCTIONS" >&2; exit 1; }
 TMP="$DATA/$ID/.ship-instructions.md.${BASHPID:-$$}"
@@ -179,6 +183,7 @@ EOF
 4. Carry over only the intended fix changes. Leave scratch commits, debug edits, and experiment files behind.
 5. If you reproduced a bug, turn that reproduction into a regression test.
 6. These ship instructions supersede the scout delivery rules and report-based Definition of done. Everything else in your original instructions carries over unchanged: the status protocol; the instruction inbox and its acknowledgement; the escalation rules, including ask-user; and every safety rule.
+$PROMOTION_ASK_USER_BLOCK
 7. Treat the scout-time Firstmate spec and any unmarked legacy \`# Task\` text as investigation context, not captain intent or ship-time instructions.
 EOF
   printf '\n'

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -393,7 +393,7 @@ test_ask_user_escalation_format() {
 
   # The DOD's own ask-user paragraph must point back at rule 6's format
   # (one-owner rule) rather than restating or bare-citing it.
-  assert_grep "escalate the whole gate to firstmate using rule 6's ask-user format" "$brief" \
+  assert_grep "escalate to firstmate using rule 6's ask-user format" "$brief" \
     "no-mistakes DOD ask-user paragraph must point at rule 6's format instead of a bare citation"
   assert_no_grep "escalate to firstmate (rule 6) and stop." "$brief" \
     "no-mistakes DOD ask-user paragraph still uses the old bare rule-6 pointer"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -366,7 +366,7 @@ test_no_mistakes_dod_wording() {
 }
 
 test_ask_user_escalation_format() {
-  local home id brief scout_id scout_brief
+  local home id brief mode other_id other_brief
   home="$TMP_ROOT/ask-user-home"
   mkdir -p "$home/data"
   id="brief-ask-user-d1"
@@ -374,15 +374,15 @@ test_ask_user_escalation_format() {
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
 
-  # A no-mistakes ask-user gate must escalate as one status event plus one
-  # verbatim findings snapshot file, using that same shape even for a single
-  # finding, never paraphrased into the status line.
-  assert_grep "escalate the whole gate as one event plus one snapshot file" "$brief" \
+  # A no-mistakes ask-user gate must escalate its ask-user findings as one status
+  # event plus one verbatim findings snapshot file, using that same shape even
+  # for a single finding, never paraphrased into the status line.
+  assert_grep "escalate all ask-user findings as one event plus one snapshot file" "$brief" \
     "ship rule 6 lost the one-event-plus-snapshot-file ask-user contract"
-  assert_grep "using that same shape even when the gate holds only a single finding" "$brief" \
+  assert_grep "using that same shape even when the gate holds only a single ask-user finding" "$brief" \
     "ship rule 6 must require the same shape for a single finding"
-  assert_grep "verbatim and unparaphrased (id, severity, file, line, description, authority)" "$brief" \
-    "ship rule 6 must require the verbatim axi finding fields"
+  assert_grep "write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority)" "$brief" \
+    "ship rule 6 must limit the verbatim axi slice to ask-user findings"
   # shellcheck disable=SC2016  # single quotes are deliberate: backticks and the key/findings/file tokens must stay literal
   assert_grep 'needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file='"$home/data/$id/nm-<run>-findings.txt" "$brief" \
     "ship rule 6 must render the exact needs-decision ask-user status line"
@@ -398,19 +398,15 @@ test_ask_user_escalation_format() {
   assert_no_grep "escalate to firstmate (rule 6) and stop." "$brief" \
     "no-mistakes DOD ask-user paragraph still uses the old bare rule-6 pointer"
 
-  # fm-promote.sh's ship-instructions.md claims a promoted worker's original
-  # escalation rules, including ask-user, "carry over unchanged" - so the
-  # scout brief's own rule 6 must already carry this identical format.
-  scout_id="brief-ask-user-scout-d2"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$scout_id" some-proj --scout >/dev/null 2>&1
-  scout_brief="$home/data/$scout_id/brief.md"
-  assert_present "$scout_brief" "scout brief was not scaffolded"
-  assert_grep "escalate the whole gate as one event plus one snapshot file" "$scout_brief" \
-    "scout rule 6 must carry the same ask-user contract a promoted worker relies on"
-  assert_grep "$home/data/$scout_id/nm-<run>-findings.txt" "$scout_brief" \
-    "scout rule 6 must point the snapshot file under the scout's own task data directory"
+  for mode in direct-PR local-only; do
+    other_id="brief-no-ask-user-$(printf '%s' "$mode" | tr '[:upper:]' '[:lower:]')"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$other_id" some-proj --mode "$mode" >/dev/null 2>&1
+    other_brief="$home/data/$other_id/brief.md"
+    assert_no_grep "nm-<run>-findings.txt" "$other_brief" \
+      "$mode brief received a no-mistakes-only escalation format"
+  done
 
-  pass "fm-brief.sh: ask-user findings escalate as one gate event plus a verbatim snapshot file"
+  pass "fm-brief.sh: no-mistakes ask-user findings use one event plus a verbatim snapshot"
 }
 
 test_ship_project_memory_wording() {

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -398,12 +398,20 @@ test_ask_user_escalation_format() {
   assert_no_grep "escalate to firstmate (rule 6) and stop." "$brief" \
     "no-mistakes DOD ask-user paragraph still uses the old bare rule-6 pointer"
 
+  other_id="brief-no-ask-user-scout"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$other_id" some-proj --scout >/dev/null 2>&1
+  other_brief="$home/data/$other_id/brief.md"
+  assert_no_grep "destructive actions, ask-user findings" "$other_brief" \
+    "scout brief received a no-mistakes-only decision case"
+
   for mode in direct-PR local-only; do
     other_id="brief-no-ask-user-$(printf '%s' "$mode" | tr '[:upper:]' '[:lower:]')"
     FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$other_id" some-proj --mode "$mode" >/dev/null 2>&1
     other_brief="$home/data/$other_id/brief.md"
     assert_no_grep "nm-<run>-findings.txt" "$other_brief" \
       "$mode brief received a no-mistakes-only escalation format"
+    assert_no_grep "destructive actions, ask-user findings" "$other_brief" \
+      "$mode brief received a no-mistakes-only decision case"
   done
 
   pass "fm-brief.sh: no-mistakes ask-user findings use one event plus a verbatim snapshot"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -365,6 +365,54 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose and bans --yes outright"
 }
 
+test_ask_user_escalation_format() {
+  local home id brief scout_id scout_brief
+  home="$TMP_ROOT/ask-user-home"
+  mkdir -p "$home/data"
+  id="brief-ask-user-d1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+
+  # A no-mistakes ask-user gate must escalate as one status event plus one
+  # verbatim findings snapshot file, using that same shape even for a single
+  # finding, never paraphrased into the status line.
+  assert_grep "escalate the whole gate as one event plus one snapshot file" "$brief" \
+    "ship rule 6 lost the one-event-plus-snapshot-file ask-user contract"
+  assert_grep "using that same shape even when the gate holds only a single finding" "$brief" \
+    "ship rule 6 must require the same shape for a single finding"
+  assert_grep "verbatim and unparaphrased (id, severity, file, line, description, authority)" "$brief" \
+    "ship rule 6 must require the verbatim axi finding fields"
+  # shellcheck disable=SC2016  # single quotes are deliberate: backticks and the key/findings/file tokens must stay literal
+  assert_grep 'needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file='"$home/data/$id/nm-<run>-findings.txt" "$brief" \
+    "ship rule 6 must render the exact needs-decision ask-user status line"
+  assert_grep "$home/data/$id/nm-<run>-findings.txt" "$brief" \
+    "ship rule 6 must point the snapshot file under this task's own data directory"
+  assert_grep "The status line only points at the file; it never restates or summarizes a finding's content." "$brief" \
+    "ship rule 6 must forbid paraphrasing ask-user findings into the status line"
+
+  # The DOD's own ask-user paragraph must point back at rule 6's format
+  # (one-owner rule) rather than restating or bare-citing it.
+  assert_grep "escalate the whole gate to firstmate using rule 6's ask-user format" "$brief" \
+    "no-mistakes DOD ask-user paragraph must point at rule 6's format instead of a bare citation"
+  assert_no_grep "escalate to firstmate (rule 6) and stop." "$brief" \
+    "no-mistakes DOD ask-user paragraph still uses the old bare rule-6 pointer"
+
+  # fm-promote.sh's ship-instructions.md claims a promoted worker's original
+  # escalation rules, including ask-user, "carry over unchanged" - so the
+  # scout brief's own rule 6 must already carry this identical format.
+  scout_id="brief-ask-user-scout-d2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$scout_id" some-proj --scout >/dev/null 2>&1
+  scout_brief="$home/data/$scout_id/brief.md"
+  assert_present "$scout_brief" "scout brief was not scaffolded"
+  assert_grep "escalate the whole gate as one event plus one snapshot file" "$scout_brief" \
+    "scout rule 6 must carry the same ask-user contract a promoted worker relies on"
+  assert_grep "$home/data/$scout_id/nm-<run>-findings.txt" "$scout_brief" \
+    "scout rule 6 must point the snapshot file under the scout's own task data directory"
+
+  pass "fm-brief.sh: ask-user findings escalate as one gate event plus a verbatim snapshot file"
+}
+
 test_ship_project_memory_wording() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
@@ -792,6 +840,7 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_ask_user_escalation_format
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -371,6 +371,10 @@ STUB
   payload="$TMP_ROOT/promote-dod/payload-promote-dod-no-mistakes"
   assert_grep "ask-user findings are never yours to answer: escalate to firstmate" "$payload" \
     "promoted no-mistakes worker did not receive the ask-user escalation rule"
+  assert_grep "write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority)" "$payload" \
+    "promoted no-mistakes worker did not receive the ask-user-only snapshot contract"
+  assert_grep 'needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file='"$home/data/promote-dod-no-mistakes/nm-<run>-findings.txt" "$payload" \
+    "promoted no-mistakes worker did not receive the structured escalation event"
   assert_grep "NEVER pass \`--yes\` (or \`-y\`)" "$payload" \
     "promoted no-mistakes worker did not receive the --yes prohibition"
   assert_grep "It is banned fleet-wide" "$payload" \


### PR DESCRIPTION
## Intent

Be structured about how crewmates escalate no-mistakes findings for decisions. Pretty much preserve all metadata directly from no-mistakes. Multiple findings in one gate: one status event plus a snapshot file, and use that same format even if there is only one finding.

Do 2: one gate line plus a snapshot file. Status stays one event, like:
needs-decision [key=nm-<run>-<step>]: ask-user findings=id1,id2,id3 file=data/<task>/nm-<run>-findings.txt
The file is the verbatim axi findings slice (id, severity, file, line, description, authority). The status line does not paraphrase.

Do NOT change firstmate's instructions yet. Only change crewmate instructions about how to send these escalations.

## What Changed
- Require no-mistakes crewmates to store all ask-user findings from a gate in one verbatim snapshot and emit one keyed `needs-decision` event listing the finding IDs and file path, including single-finding gates.
- Apply the same escalation contract to standard ship briefs and promoted no-mistakes scouts without changing scout, direct-PR, or local-only instructions.
- Add regression coverage for brief generation and promoted-task delivery.

## Risk Assessment

✅ Low: The change is narrowly scoped to crewmate-generated instructions, matches the required ask-user event and snapshot format, and correctly covers both fresh and promoted no-mistakes workers.

## Testing

The successful baseline and focused tests were supplemented by end-to-end generation of fresh and promoted crewmate instructions; both no-mistakes paths expose the required single-event/verbatim-snapshot format, including single-finding handling, while direct-PR and local-only briefs do not.

<details>
<summary>Evidence: Generated brief and promoted-worker escalation contract with delivery-mode isolation</summary>

Source: [Generated brief and promoted-worker escalation contract with delivery-mode isolation](https://github.com/kunchenguid/firstmate/blob/ab9d2baf6cbd8a07c2e023d06a82e9ca8a901ca3/.no-mistakes/evidence/fm/fm-nm-ask-user-escalation-shape-r1/structured-ask-user-escalation.txt)

```text
# End-user generated instruction evidence

## Fresh no-mistakes ship brief: structured gate contract
   For a no-mistakes ask-user gate specifically, escalate all ask-user findings as one event plus one snapshot file, using that same shape even when the gate holds only a single ask-user finding: write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority), to `~/.no-mistakes/worktrees/016d88035d58/01M1MNSD12SARYH1TFWHZTYX57/.nm-test-evidence/home/data/demo-no-mistakes/nm-<run>-findings.txt`, then report the gate with
   `needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=~/.no-mistakes/worktrees/016d88035d58/01M1MNSD12SARYH1TFWHZTYX57/.nm-test-evidence/home/data/demo-no-mistakes/nm-<run>-findings.txt`
   naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.

## Promoted scout payload: same structured gate contract
   For a no-mistakes ask-user gate specifically, escalate all ask-user findings as one event plus one snapshot file, using that same shape even when the gate holds only a single ask-user finding: write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority), to `~/.no-mistakes/worktrees/016d88035d58/01M1MNSD12SARYH1TFWHZTYX57/.nm-test-evidence/home/data/promoted-demo/nm-<run>-findings.txt`, then report the gate with
   `needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=~/.no-mistakes/worktrees/016d88035d58/01M1MNSD12SARYH1TFWHZTYX57/.nm-test-evidence/home/data/promoted-demo/nm-<run>-findings.txt`
   naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.

## Mode isolation check
no-mistakes: structured no-mistakes snapshot instruction present=yes
direct-PR: structured no-mistakes snapshot instruction present=no
local-only: structured no-mistakes snapshot instruction present=no
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"744f5965ec3b8f91711e97b73ac535f10ead426d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (4) ✅</summary>

- 🚨 `bin/fm-dod-lib.sh:173` - The intent requires a status field shaped as `ask-user findings=id1,id2,...`, but this instruction says to name every finding ID from the gate. Mixed gates are supported and can contain auto-fix/no-op findings alongside ask-user findings, so those IDs would be falsely presented as requiring a decision. Please confirm whether the snapshot should contain the whole gate or only ask-user rows; the status ID list should identify only findings requiring a decision.
- 🚨 `bin/fm-dod-lib.sh:218` - This wording breaks the existing executable generated-output contract in `tests/fm-task-delivery.test.sh:372`, which still requires the contiguous text `ask-user findings are never yours to answer: escalate to firstmate`. Update that assertion to the newly intended generated wording, or preserve its required phrase while adding the new format details.

🔧 Fix: Preserve ask-user escalation output contract
4 issues (2 errors, 2 warnings) still open:

- 🚨 `bin/fm-dod-lib.sh:173` - A mixed gate can contain auto-fix/no-op findings alongside ask-user findings, but this instruction puts every gate ID under `ask-user findings=...`, falsely marking non-decision findings as requiring a decision. Please confirm whether the snapshot contains the whole gate or only ask-user rows; the status ID list should name only findings requiring a decision.
- 🚨 `tests/fm-brief.test.sh:396` - The generated DOD now says `escalate to firstmate`, but this fixed-string assertion still requires `escalate the whole gate to firstmate`, so the changed test deterministically fails. Update the assertion to the current generated-output contract.
- ⚠️ `bin/fm-brief.sh:184` - The ask-user block is rendered into direct-PR and local-only briefs even though those modes never run no-mistakes. No intent requirement needs this dead mode-specific instruction; render it only for no-mistakes briefs and scouts that may be promoted.
- ⚠️ `bin/fm-dod-lib.sh:218` - The DOD parenthetical repeats the event, ID-list, snapshot, and single-finding rules already owned by rule 6. The intent requires the format once, not this parallel definition; retain only the rule-6 pointer and remove the duplicated format summary.

🔧 Fix: Align escalation format test expectation
4 issues (2 errors, 2 warnings) still open:

- 🚨 `bin/fm-dod-lib.sh:171` - The required status shape is `ask-user findings=id1,id2,...`, but mixed gates may also contain auto-fix/no-op findings. Lines 171-173 instruct the worker to snapshot and name every finding in the gate, falsely presenting non-decision findings as ask-user decisions. The list and verbatim slice should contain only the gate&#39;s ask-user findings.
- 🚨 `bin/fm-dod-lib.sh:218` - A scout created before this change and later promoted to no-mistakes receives this new DOD referring to “rule 6&#39;s ask-user format,” while its preserved legacy rule 6 contains no such format. Thus the required event-plus-snapshot escalation remains unreachable for an intended promotion path. Deliver the format in no-mistakes promotion instructions themselves; the new scout-time fallback can then be removed.
- ⚠️ `bin/fm-brief.sh:465` - The common ship template renders the no-mistakes escalation block into direct-PR and local-only briefs, although those modes explicitly never run no-mistakes. No intent requirement needs this dead mode-specific instruction; render it only for no-mistakes ships.
- ⚠️ `bin/fm-dod-lib.sh:218` - This parenthetical duplicates the event, ID-list, snapshot, and single-finding rules already defined by rule 6. The intent requires one format, not a parallel summary that can drift; retain only the rule-6 reference.

🔧 Fix: Scope ask-user escalation instructions correctly
1 warning still open:

- ⚠️ `bin/fm-brief.sh:383` - The change adds “ask-user findings” to the generic decision rule emitted for scouts and, at line 464, direct-PR/local-only ships, although those modes do not run no-mistakes. No intent requirement needs this extra instruction outside no-mistakes; remove the added phrase from the generic rules and let the no-mistakes-only escalation block define that case.

🔧 Fix: Remove ask-user from generic decision rules
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>Baseline: `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`</code>
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-task-delivery.test.sh`
- <code>Generated no-mistakes, direct-PR, and local-only briefs through `bin/fm-brief.sh`; promoted a scout through `bin/fm-promote.sh`; captured the delivered worker payload and compared mode exposure.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
