### PR TITLE
fix(bin): require self-sufficient no-mistakes intent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -520,8 +520,8 @@ Preserve durable structured identifiers, dependencies, and completion artifact l
 ## 11. Crewmate briefs
 
 `bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, delivery-mode definitions of done, and exact safety mechanics.
-Use its scaffold as the contract, then fill `## Captain's intent` (`{TASK}`) with the captain's own ask plus only the context needed to read it, and fill `## Firstmate spec` (`{FIRSTMATE_SPEC}`) with Firstmate's build instructions.
-`bin/fm-dod-lib.sh` owns what a no-mistakes worker may pass as `--intent`.
+Use its scaffold as the contract, then fill `## Captain's intent` (`{TASK}`) with the captain's own ask plus the context needed to read it, including the substance of any report, decision, or PR the ask refers to, and fill `## Firstmate spec` (`{FIRSTMATE_SPEC}`) with Firstmate's build instructions.
+`bin/fm-dod-lib.sh` owns what a no-mistakes worker may pass as `--intent` and its rule that the string must be self-sufficient.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -4,7 +4,8 @@
 # For ordinary tasks, the standard Setup/Rules/Definition-of-done contract is
 # filled in. Ship and scout `# Task` sections have two subsections Firstmate
 # fills before dispatch: `{TASK}` under `## Captain's intent` (the captain's
-# own ask plus only the context needed to read it) and `{FIRSTMATE_SPEC}`
+# own ask plus the context needed to read it, including the substance of any
+# report, decision, or PR the ask refers to) and `{FIRSTMATE_SPEC}`
 # under `## Firstmate spec` (build instructions, which are never the captain's
 # intent). bin/fm-dod-lib.sh owns the no-mistakes `--intent` contract those
 # subsections feed; bin/fm-spawn.sh refuses leftover placeholders. Secondmate

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -12,10 +12,14 @@
 # line that bin/fm-spawn.sh checks a ship brief against.
 # This file is the one owner of the no-mistakes `--intent` contract: only the
 # brief's `## Captain's intent` subsection plus later captain words, never
-# `## Firstmate spec` and never the worker's own tradeoffs. bin/fm-brief.sh
-# scaffolds those two `# Task` subsections; bin/fm-spawn.sh and bin/fm-promote.sh
-# refuse leftover `{TASK}` / `{FIRSTMATE_SPEC}` placeholders through the helpers
-# below. Other mentions of `--intent` point here rather than restating the rule.
+# `## Firstmate spec` and never the worker's own tradeoffs.
+# The string passed must be self-sufficient - it plus the codebase reconstructs
+# roughly the same specification - so a report, decision, or PR the intent
+# refers to is written into it as substance, never left as a pointer.
+# bin/fm-brief.sh scaffolds those two `# Task` subsections; bin/fm-spawn.sh and
+# bin/fm-promote.sh refuse leftover `{TASK}` / `{FIRSTMATE_SPEC}` placeholders
+# through the helpers below. Other mentions of `--intent` point here rather than
+# restating the rule.
 # Every heredoc here stays outside a command substitution: `VAR=$(cat <<EOF ...)`
 # breaks parsing of the whole file on Bash 3.2 (tests/fm-brief.test.sh).
 
@@ -138,6 +142,7 @@ EOF
   cat <<'EOF'
 
 Firstmate-authored constraints, acceptance criteria, implementation details, decisions, and tradeoffs are specification, not captain intent.
+The Definition of done's rule that `--intent` must be self-sufficient still governs the string you pass: resolve any report, decision, or PR the intent above refers to into its substance rather than passing the pointer.
 EOF
 }
 
@@ -197,6 +202,8 @@ Follow the guidance no-mistakes itself provides for the mechanics: it loads when
 When starting no-mistakes, pass \`--intent\` as only this brief's \`## Captain's intent\` subsection plus any later words the captain actually said.
 For a legacy brief with no such subsection, include only words explicitly labeled \`Captain:\`, \`Captain's words:\`, \`Captain's ask:\`, or \`Captain's intent:\`; never copy its mixed \`# Task\` wholesale. If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
 Do not include \`## Firstmate spec\`, later Firstmate build constraints, or your own decisions and tradeoffs.
+The \`--intent\` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
+When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into \`--intent\` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
 This replaces the no-mistakes skill's advice to enrich \`--intent\` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -351,9 +351,9 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must keep worker tradeoffs out of --intent"
   assert_grep "This replaces the no-mistakes skill's advice to enrich \`--intent\`" "$brief" \
     "no-mistakes DOD must override the external skill's enrich-with-decisions guidance"
-  # The passed string must be self-sufficient (PR #3604 shipped with an intent that
-  # was only "do 1, 2, 3, 7 from the report"), so the rendered DOD states the rule
-  # and tells the worker to resolve referenced material into its substance.
+  # A bare reference cannot preserve the captain's ask, so the rendered DOD states
+  # the self-sufficiency rule and requires referenced material to be resolved into
+  # its substance.
   assert_grep "The \`--intent\` string you pass must be self-sufficient" "$brief" \
     "no-mistakes DOD must require a self-sufficient --intent string"
   assert_grep "write the substance of the referenced items into \`--intent\`" "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -351,6 +351,13 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must keep worker tradeoffs out of --intent"
   assert_grep "This replaces the no-mistakes skill's advice to enrich \`--intent\`" "$brief" \
     "no-mistakes DOD must override the external skill's enrich-with-decisions guidance"
+  # The passed string must be self-sufficient (PR #3604 shipped with an intent that
+  # was only "do 1, 2, 3, 7 from the report"), so the rendered DOD states the rule
+  # and tells the worker to resolve referenced material into its substance.
+  assert_grep "The \`--intent\` string you pass must be self-sufficient" "$brief" \
+    "no-mistakes DOD must require a self-sufficient --intent string"
+  assert_grep "write the substance of the referenced items into \`--intent\`" "$brief" \
+    "no-mistakes DOD must tell the worker to resolve report, decision, and PR references into substance"
 
   # The --yes ban is a fleet-wide prohibition, not a preference, and it must not
   # claim an enforcement the tool does not provide: this is instruction only.

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -540,6 +540,9 @@ EOF
   assert_grep "plus any later words the captain actually supplied" \
     "$home/data/$id/launch-brief.md" \
     "migrated launch contract excluded later captain clarifications"
+  assert_grep "The Definition of done's rule that \`--intent\` must be self-sufficient still governs" \
+    "$home/data/$id/launch-brief.md" \
+    "migrated launch contract's overlay dropped the self-sufficiency pointer"
 
   id=delivery-legacy-unmarked-no-mistakes
   mkdir -p "$home/data/$id"


### PR DESCRIPTION
## Intent

Captain (2026-09-03): tweak Firstmate instructions so a crewmate's no-mistakes `--intent` is SELF-SUFFICIENT. Anyone holding that intent string plus the codebase should independently arrive at roughly the same specification - no hidden contract living only in a separate report.

NEGATIVE EXAMPLE: https://github.com/kunchenguid/firstmate/pull/3604. Its intent was only "For the refused-ack loop and other errors in the supervision transcript, hand the report to a Fable crewmate and do 1, 2, 3, 7 in one PR." Too thin - the real contract lived in data/fm-supervision-ghost-retrigger-s1/report.md section 6 items 1, 2, 3, 7 and was NEVER in the intent string. A stranger with only that intent could not have reconstructed the spec.

Captain's later decision (2026-09-03, relayed by firstmate): a first implementation that added spawn-side and promotion-side refusal checks for brief headings outside the two Task subsections is REJECTED as a whole, not narrowed. It overfits PR 3604: a brief can have zero extra subsections and still carry a non-self-sufficient --intent, so a refusal check is the wrong shape. Do NOT add ANY spawn-side or promotion-side refusal check or any executable refusal. Rebuild as PURE INSTRUCTIONS only. The single rule to express: when a crewmate specifies --intent for a no-mistakes run, that --intent STRING must be self-sufficient - the intent plus the codebase should let a reader reconstruct roughly the same spec, without depending on a separate report or hidden context. Put the wording where it belongs: the worker-side --intent guidance in bin/fm-dod-lib.sh, the brief Definition-of-done text, and/or an AGENTS.md pointer - whichever is the right owner; prefer a pointer over duplicated prose. The exact wording was proposed for review first and the captain approved it as-is: "ok those words are good."

The approved wording, in substance: (1) in bin/fm-dod-lib.sh's generated no-mistakes Definition of done, after the line excluding Firstmate spec and the worker's own decisions, two new lines: the --intent string you pass must be self-sufficient (that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in the conversation), and when the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into --intent in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and the worker's own decisions still stay out. (2) In the spawn-time intent overlay, one added line pointing back at that Definition-of-done rule so the overlay's "supersedes" wording cannot cancel it. (3) In the fm-dod-lib.sh header's owner statement, one sentence stating the same rule. (4) In AGENTS.md section 11, "plus only the context needed to read it" becomes "plus the context needed to read it, including the substance of any report, decision, or PR the ask refers to", and the pointer line adds "and its rule that the string must be self-sufficient". (5) The same one-phrase change in bin/fm-brief.sh's header. Tests assert the generated brief and the launch contract carry the new lines. No executable check anywhere.

## What Changed
- Require no-mistakes `--intent` strings to include the substance of referenced reports, decisions, or PRs while excluding Firstmate specifications and worker decisions.
- Preserve the self-sufficiency rule in generated briefs, spawn-time intent overlays, and Firstmate guidance without adding executable refusal checks.
- Add coverage for generated brief wording and migrated launch contracts.

## Risk Assessment

✅ Low: The change is narrowly limited to approved instructional wording and generated-contract assertions, with no executable refusal logic or unrelated behavior added.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (15m35s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d60dd986e431199c3a3b59a136e2f92f52f6a9fa","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
