### PR TITLE
fix(spawn): refuse a pooled worktree still claimed by another task

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -105,6 +105,8 @@
 #   even when they select different backends. A fresh spawn first takes the
 #   per-home task-set lock and refuses rather than waits when forced teardown owns
 #   it; relaunch is exempt because the existing task's control lock covers it.
+#   While that lock is held, a pooled worktree is refused when another task's
+#   metadata still claims it; only teardown or recovery releases that claim.
 #   With no harness arg, a crewmate/scout spawn resolves the CREW harness only when
 #   config/crew-dispatch.json is absent. When that file exists, crewmate/scout
 #   spawns require an explicit harness so firstmate cannot silently skip dispatch
@@ -1926,6 +1928,28 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+refuse_claimed_spawn_worktree() {  # <worktree>
+  local worktree=$1 worktree_real meta claimed claimed_real claimant
+  worktree_real=$(real_path_or_raw "$worktree")
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || [ -L "$meta" ] || continue
+    [ "$meta" != "$STATE/$ID.meta" ] || continue
+    if ! fm_backlog_record_present "$meta" "task record" "$STATE"; then
+      echo "error: cannot safely inspect pooled-worktree claims: $FM_BACKLOG_TRANSITION_ERROR" >&2
+      return 1
+    fi
+    claimed=$(sed -n 's/^worktree=//p' "$meta" | head -n 1)
+    [ -n "$claimed" ] || continue
+    claimed_real=$(real_path_or_raw "$claimed")
+    [ "$claimed_real" != "$worktree_real" ] || {
+      claimant=${meta##*/}
+      claimant=${claimant%.meta}
+      echo "error: pooled worktree '$worktree' is still claimed by task $claimant in '$meta'; refusing to reuse it until teardown or recovery releases that task record" >&2
+      return 1
+    }
+  done
+}
+
 # A pooled slot whose only deviation is a submodule gitlink is stale, not dirty:
 # an earlier refresh moved the superproject and left the submodule checkout on
 # the pin the previous base recorded. The refusal still stands and this gate
@@ -2543,6 +2567,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   fi
 
   validate_spawn_worktree "treehouse get" "$T"
+  refuse_claimed_spawn_worktree "$WT" || exit 1
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -148,7 +148,35 @@ test_already_settled_pane_costs_one_confirm_sleep() {
   pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"
 }
 
+# A task record owns its pooled worktree until teardown or recovery removes the
+# record, even when the task endpoint is dead.
+test_recorded_worktree_claim_refuses_reuse() {
+  local rec id claimant out status
+  id=settle-colliding-claim-z3
+  claimant=dead-owner-z0
+  rec=$(make_settle_case settle-colliding-claim "$id" 0)
+  read_settle_record "$rec"
+  printf '%s\n' "window=fm-$claimant" "worktree=$WT_DIR" 'kind=ship' \
+    > "$HOME_DIR/state/$claimant.meta"
+
+  set +e
+  out=$(run_settle_spawn "$id")
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "spawn silently reused a pooled worktree claimed by $claimant"
+  assert_contains "$out" "claimed by task $claimant" \
+    "collision refusal did not identify the task that owns the worktree"
+  assert_contains "$out" "teardown or recovery" \
+    "collision refusal did not name the supported claim-release path"
+  [ ! -e "$HOME_DIR/state/$id.meta" ] \
+    || fail "refused spawn published a second task record for the claimed worktree"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$claimant.meta" \
+    "collision refusal altered the existing owner's task record"
+  pass "a pooled worktree claimed by another task record is refused"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
+test_recorded_worktree_claim_refuses_reuse
 
 echo "# all fm-spawn-worktree-settle tests passed"


### PR DESCRIPTION
## What

Before accepting a pooled treehouse worktree, `fm-spawn` now checks every `state/*.meta` in the home for a matching `worktree=` and refuses to reuse a slot another task record still claims. Adds a regression test.

## Why

`fm-spawn` could hand a live spawn a worktree slot that a dead task's `state/<id>.meta` still recorded, with no refusal — two task records claiming one worktree. Tearing down the dead task would then hard-reset and kill the live task sharing the slot. Only teardown/recovery should release a claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
