### PR TITLE
fix(fleet-snapshot): stream backlog JSON into jq to avoid argv limit

### DIFF
--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -655,10 +655,10 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
-  jq -n \
-    --argjson backlog "$1" \
+  printf '%s\n' "$1" | jq -n \
     --argjson tasks "$2" '
-    ([ $backlog.records[]?
+    input as $backlog
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
          | select(.state == "in_flight" and .structured and .requires_child_metadata) ]) as $owned_in_flight
@@ -683,7 +683,7 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
-  jq -n \
+  printf '%s\n' "$1" | jq -n \
     --arg generated "$SNAPSHOT_NOW" \
     --argjson generated_epoch "$SNAPSHOT_EPOCH" \
     --arg home "$FM_HOME" \
@@ -691,9 +691,9 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
     --argjson tasks "$2" '
-    def trunc($n):
+    input as $backlog
+    | def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
     ([ $backlog.records[]?
@@ -1646,7 +1646,7 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
-jq -n \
+printf '%s\n' "$BACKLOG_JSON" | jq -n \
   --arg generated "$SNAPSHOT_NOW" \
   --arg fm_home "$FM_HOME" \
   --arg fm_root "$FM_ROOT" \
@@ -1654,13 +1654,13 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
   --argjson tasks "$TASKS_JSON" \
   --argjson main_inventory "$MAIN_INVENTORY_JSON" \
   --argjson scout_reports "$SCOUT_REPORTS_JSON" \
   --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
   --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  'input as $backlog
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -2283,6 +2283,39 @@ test_a_remote_home_without_any_ledger_is_explicitly_unreadable_without_remote_co
   pass "a missing remote ledger stays explicitly unreadable without remote summary computation"
 }
 
+test_oversized_backlog_reaches_snapshot_without_argv_limit() {
+  local home backlog long_reason small large normalized i
+  home=$(make_home oversized-backlog)
+  backlog="$home/data/backlog.md"
+  small="$home/small.json"
+  large="$home/large.json"
+  normalized="$home/large-normalized.json"
+  long_reason=$(printf '%4096s' '' | tr ' ' x)
+  {
+    printf '%s\n' '## In flight' '' '## Queued'
+    printf -- '- [ ] held-1 - Held item 1 (repo: firstmate) (kind: ship) (hold: %s) (hold-kind: external)\n' "$long_reason"
+  } > "$backlog"
+  FM_HOME="$home" FM_SNAPSHOT_NOW=2026-09-03T00:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788393600 \
+    "$ROOT/bin/fm-fleet-snapshot.sh" --json > "$small" \
+    || fail "small backlog snapshot failed"
+  i=2
+  while [ "$i" -le 61 ]; do
+    printf -- '- [ ] held-%s - Held item %s (repo: firstmate) (kind: ship) (hold: %s) (hold-kind: external)\n' \
+      "$i" "$i" "$long_reason" >> "$backlog"
+    i=$((i + 1))
+  done
+  FM_HOME="$home" FM_SNAPSHOT_NOW=2026-09-03T00:00:00Z FM_SNAPSHOT_NOW_EPOCH=1788393600 \
+    "$ROOT/bin/fm-fleet-snapshot.sh" --json > "$large" \
+    || fail "oversized backlog snapshot failed"
+  jq -e '(.backlog.records | length) == 61 and all(.backlog.records[]; .state == "queued" and .structured)' \
+    "$large" >/dev/null || fail "oversized backlog rows were not preserved"
+  jq '.backlog.records = .backlog.records[:1]' "$large" > "$normalized"
+  cmp -s "$small" "$normalized" \
+    || fail "oversized backlog changed snapshot bytes beyond its additional rows"
+  pass "oversized backlog reaches jq outside argv and preserves snapshot output"
+}
+
+test_oversized_backlog_reaches_snapshot_without_argv_limit
 test_remote_ledgers_share_one_concurrent_budget_and_fall_back_to_cache
 test_a_remote_home_without_any_ledger_is_explicitly_unreadable_without_remote_compute
 test_domain_alpha_stale_parent_event_does_not_become_current_work


### PR DESCRIPTION
## What

`fm-fleet-snapshot.sh` now streams backlog JSON into `jq` via stdin instead of passing it as command-line arguments. Adds a regression test with an oversized backlog.

## Why

On a large backlog (observed with 61 held items with long reasons), the snapshot failed with `jq: Argument list too long` because backlog data was passed on the argv, which is length-bounded. Streaming avoids the limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
