### PR TITLE
fix(bin): avoid fleet snapshot argument limits

### DIFF
--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -85,6 +85,13 @@
 # Human views must render this output instead of parsing state files again.
 set -u
 
+BACKLOG_JSON_FILE=
+TASKS_JSON_FILE=
+cleanup_json_files() {
+  [ -z "$BACKLOG_JSON_FILE" ] || rm -f -- "$BACKLOG_JSON_FILE"
+  [ -z "$TASKS_JSON_FILE" ] || rm -f -- "$TASKS_JSON_FILE"
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
@@ -825,13 +832,12 @@ task_json_lines() {
 # used by secondmate_home_summary_json, without inventing live task rows.
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
-main_inventory_json() {  # <backlog-json> <tasks-json>
-  # Feed potentially large inventories through stdin. Linux limits each exec
-  # argument to 128 KiB even when ARG_MAX is larger, so --argjson can reject a
-  # valid large backlog before jq starts.
-  printf '%s\n%s\n' "$1" "$2" | jq -s '
-    .[0] as $backlog
-    | .[1] as $tasks
+main_inventory_json() {  # <backlog-json-file> <tasks-json-file>
+  jq -n \
+    --slurpfile backlog "$1" \
+    --slurpfile tasks "$2" '
+    ($backlog[0]) as $backlog
+    | ($tasks[0]) as $tasks
     | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
@@ -856,17 +862,19 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # validated parent read needs.
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
-secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
-  printf '%s\n%s\n' "$1" "$2" | jq -s \
+secondmate_home_summary_json() {  # <backlog-json-file> <tasks-json-file>
+  jq -n \
     --arg generated "$SNAPSHOT_NOW" \
     --argjson generated_epoch "$SNAPSHOT_EPOCH" \
     --arg home "$FM_HOME" \
     --argjson child_n "$FM_SNAPSHOT_SECONDMATE_CHILDREN" \
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
-    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '
-    .[0] as $backlog
-    | .[1] as $tasks
+    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
+    --slurpfile backlog "$1" \
+    --slurpfile tasks "$2" '
+    ($backlog[0]) as $backlog
+    | ($tasks[0]) as $tasks
     | def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
@@ -1353,9 +1361,11 @@ snapshot_collection_cleanup() {
   SNAPSHOT_COLLECT_DIR=
   SNAPSHOT_SUMMARY_FILTER=
 }
+<<<<<<< ours
 snapshot_cleanup() {
   snapshot_task_cleanup
   snapshot_collection_cleanup
+  cleanup_json_files
 }
 trap snapshot_cleanup EXIT
 
@@ -1571,17 +1581,17 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
        inconclusive:any(($activity_results + $decision_results)[]; .verdict == "inconclusive")}'
 }
 
-secondmate_current_json() {  # <parent-tasks-json>
-  local tasks=$1 registry union rows total_registered total shown truncated
+secondmate_current_json() {  # <parent-tasks-json-file>
+  local tasks_file=$1 registry union rows total_registered total shown truncated
   local row id home host remote registered registry_error task sampled_spawn_gen status_file status_observation_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(printf '%s\n%s\n' "$registry" "$tasks" | jq -s '
-    .[0] as $registry
-    | .[1] as $tasks
-    | ($registry.records // []) as $registered
+  union=$(jq -n --argjson registry "$registry" --slurpfile tasks "$tasks_file" '
+    ($tasks[0]) as $tasks
+    |
+    ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
          | $r + {parent_task:([$tasks[] | select(.id == $r.id)][0] // null)} ]
@@ -1827,16 +1837,25 @@ BACKLOG_JSON=$(backlog_json) || { echo "fm-fleet-snapshot: backlog read failed" 
 prefetch_task_current_states || { echo "fm-fleet-snapshot: task observation failed" >&2; exit 1; }
 TASKS_JSON=$(task_json_lines) || { echo "fm-fleet-snapshot: task snapshot failed" >&2; exit 1; }
 
+BACKLOG_JSON_FILE=$(mktemp "$STATE/.fm-fleet-snapshot-backlog.XXXXXX") \
+  || { echo "fm-fleet-snapshot: temporary backlog file creation failed" >&2; exit 1; }
+TASKS_JSON_FILE=$(mktemp "$STATE/.fm-fleet-snapshot-tasks.XXXXXX") \
+  || { echo "fm-fleet-snapshot: temporary task file creation failed" >&2; exit 1; }
+printf '%s\n' "$BACKLOG_JSON" > "$BACKLOG_JSON_FILE" \
+  || { echo "fm-fleet-snapshot: temporary backlog file write failed" >&2; exit 1; }
+printf '%s\n' "$TASKS_JSON" > "$TASKS_JSON_FILE" \
+  || { echo "fm-fleet-snapshot: temporary task file write failed" >&2; exit 1; }
+
 if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
-  secondmate_home_summary_json "$BACKLOG_JSON" "$TASKS_JSON" \
+  secondmate_home_summary_json "$BACKLOG_JSON_FILE" "$TASKS_JSON_FILE" \
     || { echo "fm-fleet-snapshot: secondmate home summary failed" >&2; exit 1; }
   exit 0
 fi
 
 SCOUT_REPORTS_JSON=$(scout_report_lines)
-MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_JSON" "$TASKS_JSON") \
+MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_JSON_FILE" "$TASKS_JSON_FILE") \
   || { echo "fm-fleet-snapshot: main inventory summary failed" >&2; exit 1; }
-SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
+SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON_FILE") \
   || { echo "fm-fleet-snapshot: registered secondmate aggregation failed" >&2; exit 1; }
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
@@ -1854,12 +1873,14 @@ printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  '.[0] as $backlog
-   | .[1] as $tasks
-   | .[2] as $main_inventory
-   | .[3] as $scout_reports
-   | .[4] as $secondmate_current
-   | .[5] as $secondmate_landed
+  --slurpfile backlog "$BACKLOG_JSON_FILE" \
+  --slurpfile tasks "$TASKS_JSON_FILE" \
+  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
+  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
+  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
+  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
+  '($backlog[0]) as $backlog
+   | ($tasks[0]) as $tasks
    | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -88,16 +88,7 @@ set -u
 JSON_TRANSPORT_DIR=
 cleanup_json_files() {
   [ -n "$JSON_TRANSPORT_DIR" ] || return 0
-  rm -f -- "$JSON_TRANSPORT_DIR/backlog.json" \
-    "$JSON_TRANSPORT_DIR/tasks.json" \
-    "$JSON_TRANSPORT_DIR/main-inventory.json" \
-    "$JSON_TRANSPORT_DIR/scout-reports.json" \
-    "$JSON_TRANSPORT_DIR/secondmate-registry.json" \
-    "$JSON_TRANSPORT_DIR/secondmate-union.json" \
-    "$JSON_TRANSPORT_DIR/secondmate-records.jsonl" \
-    "$JSON_TRANSPORT_DIR/secondmate-current.json" \
-    "$JSON_TRANSPORT_DIR/secondmate-landed.json"
-  rmdir -- "$JSON_TRANSPORT_DIR"
+  rm -rf -- "$JSON_TRANSPORT_DIR"
 }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -90,7 +90,13 @@ cleanup_json_files() {
   [ -n "$JSON_TRANSPORT_DIR" ] || return 0
   rm -f -- "$JSON_TRANSPORT_DIR/backlog.json" \
     "$JSON_TRANSPORT_DIR/tasks.json" \
-    "$JSON_TRANSPORT_DIR/main-inventory.json"
+    "$JSON_TRANSPORT_DIR/main-inventory.json" \
+    "$JSON_TRANSPORT_DIR/scout-reports.json" \
+    "$JSON_TRANSPORT_DIR/secondmate-registry.json" \
+    "$JSON_TRANSPORT_DIR/secondmate-union.json" \
+    "$JSON_TRANSPORT_DIR/secondmate-records.jsonl" \
+    "$JSON_TRANSPORT_DIR/secondmate-current.json" \
+    "$JSON_TRANSPORT_DIR/secondmate-landed.json"
   rmdir -- "$JSON_TRANSPORT_DIR"
 }
 
@@ -1165,8 +1171,8 @@ SNAPSHOT_SUMMARY_FILTER=
 SNAPSHOT_CACHE_AVAILABLE=0
 SNAPSHOT_COLLECTION_TIMED_OUT=0
 
-summary_file_read() {  # <file> <expected-home>
-  local file=$1 home=$2 captured bytes
+summary_file_read() {  # <file> <expected-home> <output-file>
+  local file=$1 home=$2 output=$3 captured bytes rc
   [ -f "$file" ] && [ ! -L "$file" ] || return 1
   captured=$(umask 077; mktemp "$SNAPSHOT_COLLECT_DIR/.selected-summary.XXXXXX") || return 1
   if ! LC_ALL=C head -c "$((FM_SNAPSHOT_SECONDMATE_MAX_BYTES + 1))" "$file" > "$captured"; then
@@ -1182,10 +1188,14 @@ summary_file_read() {  # <file> <expected-home>
     rm -f -- "$captured"
     return 1
   fi
-  jq -c -s '.[0]' "$captured"
-  bytes=$?
+  jq -c -s '.[0]' "$captured" > "$output"
+  rc=$?
   rm -f -- "$captured"
-  return "$bytes"
+  if [ "$rc" -ne 0 ]; then
+    rm -f -- "$output"
+    return "$rc"
+  fi
+  return 0
 }
 
 summary_file_oversized() {  # <file>
@@ -1227,13 +1237,13 @@ snapshot_route_cache_path() {  # <id> <host> <home>
   printf '%s/%s.json\n' "$FM_SNAPSHOT_CACHE_DIR" "$key"
 }
 
-snapshot_cache_store() {  # <summary-json> <destination>
-  local summary=$1 destination=$2 tmp
+snapshot_cache_store() {  # <summary-json-file> <destination>
+  local summary_file=$1 destination=$2 tmp
   [ "$SNAPSHOT_CACHE_AVAILABLE" -eq 1 ] || return 1
   case "$destination" in "$FM_SNAPSHOT_CACHE_DIR"/*) ;; *) return 1 ;; esac
   [ ! -L "$destination" ] || return 1
   tmp=$(umask 077; mktemp "$FM_SNAPSHOT_CACHE_DIR/.summary.XXXXXX") || return 1
-  if printf '%s\n' "$summary" > "$tmp" && chmod 600 "$tmp" && mv -f -- "$tmp" "$destination"; then
+  if cp -- "$summary_file" "$tmp" && chmod 600 "$tmp" && mv -f -- "$tmp" "$destination"; then
     return 0
   fi
   rm -f -- "$tmp"
@@ -1349,9 +1359,9 @@ BASH
   return 0
 }
 
-snapshot_summary_age() {  # <summary-json>
+snapshot_summary_age() {  # <summary-json-file>
   local generated age
-  generated=$(printf '%s' "$1" | jq -r '.generated_epoch' 2>/dev/null || true)
+  generated=$(jq -r '.generated_epoch' "$1" 2>/dev/null || true)
   case "$generated" in ''|*[!0-9]*) printf 'null\n'; return ;; esac
   age=$((SNAPSHOT_EPOCH - generated))
   [ "$age" -lt 0 ] && age=0
@@ -1363,7 +1373,6 @@ snapshot_collection_cleanup() {
   SNAPSHOT_COLLECT_DIR=
   SNAPSHOT_SUMMARY_FILTER=
 }
-<<<<<<< ours
 snapshot_cleanup() {
   snapshot_task_cleanup
   snapshot_collection_cleanup
@@ -1523,8 +1532,10 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
     '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:true,observed_at:$observed,freshness:"fresh",reason:null,lines:$lines,bytes:$bytes,event_note_seen:$seen,contradiction:$contradiction}'
 }
 
-parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
+parent_evidence_reconciliation_json() {  # <summary-json-file> <activities-json> <decisions-json>
+  jq -n --slurpfile summary "$1" --argjson activities "$2" --argjson decisions "$3" '
+    ($summary[0]) as $summary
+    |
     def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
@@ -1583,14 +1594,19 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
        inconclusive:any(($activity_results + $decision_results)[]; .verdict == "inconclusive")}'
 }
 
-secondmate_current_json() {  # <parent-tasks-json-file>
-  local tasks_file=$1 registry union rows total_registered total shown truncated
+secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
+  local tasks_file=$1 output_file=$2 registry_file union_file records_file rows total_registered total shown truncated
   local row id home host remote registered registry_error task sampled_spawn_gen status_file status_observation_file event_raw event_note event_epoch event_age
-  local activity_scan activities decisions reconciliation provenance freshness reason summary summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
-  local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot
-  local records='[]' seen_homes=''
-  registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --slurpfile tasks "$tasks_file" '
+  local activity_scan activities decisions reconciliation provenance freshness reason summary_file summary_sampled summary_valid summary_invalidity state terminal terminal_contradiction contradiction
+  local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot summary_index=0
+  local seen_homes=''
+  registry_file="$JSON_TRANSPORT_DIR/secondmate-registry.json"
+  union_file="$JSON_TRANSPORT_DIR/secondmate-union.json"
+  records_file="$JSON_TRANSPORT_DIR/secondmate-records.jsonl"
+  registry_secondmates_json > "$registry_file" || return 1
+  jq -n --slurpfile registry "$registry_file" --slurpfile tasks "$tasks_file" '
+    ($registry[0]) as $registry
+    |
     ($tasks[0]) as $tasks
     |
     ($registry.records // []) as $registered
@@ -1606,12 +1622,13 @@ secondmate_current_json() {  # <parent-tasks-json-file>
                               else "secondmate registration is unknown because the registry read is incomplete or unavailable" end),
               parent_task:$t} ])
     | sort_by(.id)
-    | {registry:$registry,records:.}') || return 1
-  total_registered=$(printf '%s' "$union" | jq '[.records[] | select(.registered)] | length')
-  total=$(printf '%s' "$union" | jq '.records | length')
-  rows=$(printf '%s' "$union" | jq -c --argjson cap "$FM_SNAPSHOT_SECONDMATES" '(if $cap == 0 then .records else .records[:$cap] end)[]')
+    | {registry:$registry,records:.}' > "$union_file" || return 1
+  total_registered=$(jq '[.records[] | select(.registered)] | length' "$union_file")
+  total=$(jq '.records | length' "$union_file")
+  rows=$(jq -c --argjson cap "$FM_SNAPSHOT_SECONDMATES" '(if $cap == 0 then .records else .records[:$cap] end)[]' "$union_file")
   shown=$(printf '%s\n' "$rows" | grep -c . || true)
   truncated=$((total - shown))
+  : > "$records_file"
   if [ -n "$rows" ]; then
     prepare_remote_summary_collection "$rows" || return 1
   fi
@@ -1642,7 +1659,9 @@ secondmate_current_json() {  # <parent-tasks-json-file>
     fi
 
     reason=$registry_error
-    summary='{}'
+    summary_index=$((summary_index + 1))
+    summary_file="$SNAPSHOT_COLLECT_DIR/selected-summary-$summary_index.json"
+    printf '{}\n' > "$summary_file" || return 1
     summary_sampled=false
     summary_valid=false
     if [ -z "$reason" ] && [ -z "$home" ]; then reason="no recorded secondmate home"; fi
@@ -1678,10 +1697,10 @@ secondmate_current_json() {  # <parent-tasks-json-file>
         cache_path=$(snapshot_route_cache_path "$id" "$host" "$home" 2>/dev/null || true)
         collection_slot=$(jq -r --arg id "$id" 'select(.id == $id) | .slot' "$SNAPSHOT_COLLECT_DIR/manifest.jsonl" 2>/dev/null | head -1)
         collection_status=$(cat "$SNAPSHOT_COLLECT_DIR/$collection_slot.status" 2>/dev/null || true)
-        if summary=$(summary_file_read "$SNAPSHOT_COLLECT_DIR/$collection_slot.fetch" "$home"); then
+        if summary_file_read "$SNAPSHOT_COLLECT_DIR/$collection_slot.fetch" "$home" "$summary_file"; then
           summary_source='remote-ledger'
-          [ -z "$cache_path" ] || snapshot_cache_store "$summary" "$cache_path" || true
-        elif [ -n "$cache_path" ] && summary=$(summary_file_read "$cache_path" "$home"); then
+          [ -z "$cache_path" ] || snapshot_cache_store "$summary_file" "$cache_path" || true
+        elif [ -n "$cache_path" ] && summary_file_read "$cache_path" "$home" "$summary_file"; then
           summary_source='remote-ledger-cache'
           summary_freshness=cached
         elif summary_file_oversized "$SNAPSHOT_COLLECT_DIR/$collection_slot.fetch"; then
@@ -1691,7 +1710,7 @@ secondmate_current_json() {  # <parent-tasks-json-file>
         else
           reason="structured home ledger is missing, unreadable, or invalid and no valid cached copy is available"
         fi
-      elif summary=$(summary_file_read "$home/state/home-summary.json" "$home"); then
+      elif summary_file_read "$home/state/home-summary.json" "$home" "$summary_file"; then
         summary_source='local-ledger'
       elif summary_file_oversized "$home/state/home-summary.json"; then
         reason="structured home ledger exceeded byte limit"
@@ -1699,34 +1718,25 @@ secondmate_current_json() {  # <parent-tasks-json-file>
         reason="structured home ledger is missing, unreadable, or invalid"
       fi
       if [ -z "$reason" ]; then
-        summary_age=$(snapshot_summary_age "$summary")
-        summary_observed=$(printf '%s' "$summary" | jq -r '.generated')
+        summary_age=$(snapshot_summary_age "$summary_file")
+        summary_observed=$(jq -r '.generated' "$summary_file")
       fi
     fi
-    # Failed command substitutions clear their assignment target. Keep the
-    # unsampled record's --argjson input valid without retaining any rejected
-    # or oversized summary fragment.
-    if [ -n "$reason" ]; then summary='{}'; fi
     if [ -z "$reason" ]; then
       summary_sampled=true
-      summary_valid=$(printf '%s' "$summary" | jq -r '.valid')
+      summary_valid=$(jq -r '.valid' "$summary_file")
       if [ "$summary_valid" != true ]; then
-        summary_reason=$(printf '%s' "$summary" | jq -r '.reason // "unknown reason"')
-        summary_invalidity=$(printf '%s' "$summary" | jq -r '.invalidity.kind // "unknown"')
+        summary_invalidity=$(jq -r '.invalidity.kind // "unknown"' "$summary_file")
         case "$summary_invalidity" in
           child_current_unavailable|orphan_in_flight|unowned_current|terminal_in_flight) : ;;
-          *) reason="structured home state invalid: $summary_reason" ;;
+          *) reason="structured home state invalid" ;;
         esac
       fi
     fi
 
     if [ -z "$reason" ]; then
-      state=$(printf '%s' "$summary" | jq -r '.state')
-      current_reason=
-      if [ "$summary_valid" != true ]; then
-        current_reason="structured home state invalid: $(printf '%s' "$summary" | jq -r '.reason // "unknown reason"')"
-      fi
-      reconciliation=$(parent_evidence_reconciliation_json "$summary" "$activities" "$decisions")
+      state=$(jq -r '.state' "$summary_file")
+      reconciliation=$(parent_evidence_reconciliation_json "$summary_file" "$activities" "$decisions")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
       terminal_contradiction=$(printf '%s' "$reconciliation" | jq -r --arg note "$event_note" '
         any(.activities[]; .verdict == "contradicts" and .summary == $note)')
@@ -1737,17 +1747,19 @@ secondmate_current_json() {  # <parent-tasks-json-file>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
-      record=$(jq -n \
-        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$summary_observed" \
+      jq -n \
+        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg observed "$summary_observed" \
         --arg summary_source "$summary_source" --arg summary_freshness "$summary_freshness" --argjson summary_age "$summary_age" \
         --arg spawn_gen "$sampled_spawn_gen" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
+        --argjson registered "$registered" --slurpfile summary "$summary_file" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
         --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
         --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
         --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
+        ($summary[0]) as $summary
+        |
         {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
-         current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
+         current:{state:$state,reason:(if $summary_valid then null else "structured home state invalid: " + ($summary.reason // "unknown reason") end)},invalidity:$summary.invalidity,
          reconcile_inventory:$summary.invalidity,
          provenance:{selected:"structured-home",structured_home:$home,summary_source:$summary_source,summary_valid:$summary_valid,
            trust:(if $summary_valid then "complete" else "partial-structured" end),parent_event_role:"historical-only"},
@@ -1756,7 +1768,7 @@ secondmate_current_json() {  # <parent-tasks-json-file>
          decisions_open:$summary.decisions_open,holds:$summary.holds,queued:$summary.queued,
          landed:$summary.landed,endpoints:$summary.endpoints,counts:$summary.counts,omitted:$summary.omitted,
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan,reconciliation:$reconciliation},
-         terminal_evidence:$terminal,contradiction:$contradiction}')
+         terminal_evidence:$terminal,contradiction:$contradiction}' >> "$records_file" || return 1
     else
       if [ -n "$event_raw" ]; then
         provenance='parent-event-fallback'
@@ -1771,39 +1783,42 @@ secondmate_current_json() {  # <parent-tasks-json-file>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
-      record=$(jq -n \
+      jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
         --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
         --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" --argjson summary "$summary" --argjson summary_sampled "$summary_sampled" '
+        --argjson decisions "$decisions" --argjson terminal "$terminal" --slurpfile summary "$summary_file" --argjson summary_sampled "$summary_sampled" '
+        ($summary[0]) as $summary
+        |
         {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
-         current:{state:"unknown",reason:$reason},invalidity:null,
+         current:{state:"unknown",reason:(if $summary_sampled then "structured home state invalid: " + ($summary.reason // "unknown reason") else $reason end)},invalidity:null,
          reconcile_inventory:(if $summary_sampled then $summary.invalidity else null end),
          provenance:{selected:$provenance,structured_home:($home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
          freshness:{status:$freshness,observed_at:$observed,age_seconds:$event_age},
          active_children:[],decisions_open:[],holds:[],queued:[],landed:[],endpoints:[],counts:{active_children:0,decisions_open:0,holds:0,queued:0,landed:0,endpoints:0},omitted:[],
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
-         terminal_evidence:$terminal,contradiction:false}')
+         terminal_evidence:$terminal,contradiction:false}' >> "$records_file" || return 1
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
   done <<EOF
 $rows
 EOF
   snapshot_collection_cleanup
-  jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+  jq -s \
+    --slurpfile registry "$registry_file" \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
     --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    '{registry:$registry[0],records:.,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}' \
+    "$records_file" > "$output_file"
 }
 
-secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
+secondmate_landed_from_current_json() {  # <secondmate-current-json-file> <output-file>
+  jq -n --slurpfile current "$1" '
+    ($current[0]) as $current
+    |
     {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
@@ -1817,7 +1832,7 @@ secondmate_landed_from_current_json() {  # <secondmate-current-json>
      partial:[ $current.records[]
        | select(.provenance.selected == "structured-home" and .provenance.trust == "partial-structured")
        | .home // ("<" + .id + ": partial>")]}
-    | .records |= sort_by([(.completion.date // ""), .id]) | .records |= reverse'
+    | .records |= sort_by([(.completion.date // ""), .id]) | .records |= reverse' > "$2"
 }
 
 scout_report_lines() {
@@ -1844,6 +1859,9 @@ JSON_TRANSPORT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-fleet-snapshot.XXXXXX") \
 BACKLOG_JSON_FILE="$JSON_TRANSPORT_DIR/backlog.json"
 TASKS_JSON_FILE="$JSON_TRANSPORT_DIR/tasks.json"
 MAIN_INVENTORY_JSON_FILE="$JSON_TRANSPORT_DIR/main-inventory.json"
+SCOUT_REPORTS_JSON_FILE="$JSON_TRANSPORT_DIR/scout-reports.json"
+SECONDMATE_CURRENT_JSON_FILE="$JSON_TRANSPORT_DIR/secondmate-current.json"
+SECONDMATE_LANDED_JSON_FILE="$JSON_TRANSPORT_DIR/secondmate-landed.json"
 printf '%s\n' "$BACKLOG_JSON" > "$BACKLOG_JSON_FILE" \
   || { echo "fm-fleet-snapshot: temporary backlog file write failed" >&2; exit 1; }
 printf '%s\n' "$TASKS_JSON" > "$TASKS_JSON_FILE" \
@@ -1855,20 +1873,16 @@ if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
   exit 0
 fi
 
-SCOUT_REPORTS_JSON=$(scout_report_lines)
+scout_report_lines > "$SCOUT_REPORTS_JSON_FILE" \
+  || { echo "fm-fleet-snapshot: scout report snapshot failed" >&2; exit 1; }
 main_inventory_json "$BACKLOG_JSON_FILE" "$TASKS_JSON_FILE" > "$MAIN_INVENTORY_JSON_FILE" \
   || { echo "fm-fleet-snapshot: main inventory summary failed" >&2; exit 1; }
-SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON_FILE") \
+secondmate_current_json "$TASKS_JSON_FILE" "$SECONDMATE_CURRENT_JSON_FILE" \
   || { echo "fm-fleet-snapshot: registered secondmate aggregation failed" >&2; exit 1; }
-SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
+secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON_FILE" "$SECONDMATE_LANDED_JSON_FILE" \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
-# Stream fleet-sized JSON values through stdin rather than argv: Linux applies
-# a much smaller per-argument limit than ARG_MAX, including to --argjson.
-printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
-  "$BACKLOG_JSON" "$TASKS_JSON" "$MAIN_INVENTORY_JSON" "$SCOUT_REPORTS_JSON" \
-  "$SECONDMATE_CURRENT_JSON" "$SECONDMATE_LANDED_JSON" \
-| jq -s \
+jq -n \
   --arg generated "$SNAPSHOT_NOW" \
   --arg fm_home "$FM_HOME" \
   --arg fm_root "$FM_ROOT" \
@@ -1879,12 +1893,15 @@ printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
   --slurpfile backlog "$BACKLOG_JSON_FILE" \
   --slurpfile tasks "$TASKS_JSON_FILE" \
   --slurpfile main_inventory "$MAIN_INVENTORY_JSON_FILE" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
+  --slurpfile scout_reports "$SCOUT_REPORTS_JSON_FILE" \
+  --slurpfile secondmate_current "$SECONDMATE_CURRENT_JSON_FILE" \
+  --slurpfile secondmate_landed "$SECONDMATE_LANDED_JSON_FILE" \
   '($backlog[0]) as $backlog
    | ($tasks[0]) as $tasks
    | ($main_inventory[0]) as $main_inventory
+   | ($scout_reports[0]) as $scout_reports
+   | ($secondmate_current[0]) as $secondmate_current
+   | ($secondmate_landed[0]) as $secondmate_landed
    | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -85,11 +85,13 @@
 # Human views must render this output instead of parsing state files again.
 set -u
 
-BACKLOG_JSON_FILE=
-TASKS_JSON_FILE=
+JSON_TRANSPORT_DIR=
 cleanup_json_files() {
-  [ -z "$BACKLOG_JSON_FILE" ] || rm -f -- "$BACKLOG_JSON_FILE"
-  [ -z "$TASKS_JSON_FILE" ] || rm -f -- "$TASKS_JSON_FILE"
+  [ -n "$JSON_TRANSPORT_DIR" ] || return 0
+  rm -f -- "$JSON_TRANSPORT_DIR/backlog.json" \
+    "$JSON_TRANSPORT_DIR/tasks.json" \
+    "$JSON_TRANSPORT_DIR/main-inventory.json"
+  rmdir -- "$JSON_TRANSPORT_DIR"
 }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -1837,10 +1839,11 @@ BACKLOG_JSON=$(backlog_json) || { echo "fm-fleet-snapshot: backlog read failed" 
 prefetch_task_current_states || { echo "fm-fleet-snapshot: task observation failed" >&2; exit 1; }
 TASKS_JSON=$(task_json_lines) || { echo "fm-fleet-snapshot: task snapshot failed" >&2; exit 1; }
 
-BACKLOG_JSON_FILE=$(mktemp "$STATE/.fm-fleet-snapshot-backlog.XXXXXX") \
-  || { echo "fm-fleet-snapshot: temporary backlog file creation failed" >&2; exit 1; }
-TASKS_JSON_FILE=$(mktemp "$STATE/.fm-fleet-snapshot-tasks.XXXXXX") \
-  || { echo "fm-fleet-snapshot: temporary task file creation failed" >&2; exit 1; }
+JSON_TRANSPORT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-fleet-snapshot.XXXXXX") \
+  || { echo "fm-fleet-snapshot: temporary transport directory creation failed" >&2; exit 1; }
+BACKLOG_JSON_FILE="$JSON_TRANSPORT_DIR/backlog.json"
+TASKS_JSON_FILE="$JSON_TRANSPORT_DIR/tasks.json"
+MAIN_INVENTORY_JSON_FILE="$JSON_TRANSPORT_DIR/main-inventory.json"
 printf '%s\n' "$BACKLOG_JSON" > "$BACKLOG_JSON_FILE" \
   || { echo "fm-fleet-snapshot: temporary backlog file write failed" >&2; exit 1; }
 printf '%s\n' "$TASKS_JSON" > "$TASKS_JSON_FILE" \
@@ -1853,7 +1856,7 @@ if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
 fi
 
 SCOUT_REPORTS_JSON=$(scout_report_lines)
-MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_JSON_FILE" "$TASKS_JSON_FILE") \
+main_inventory_json "$BACKLOG_JSON_FILE" "$TASKS_JSON_FILE" > "$MAIN_INVENTORY_JSON_FILE" \
   || { echo "fm-fleet-snapshot: main inventory summary failed" >&2; exit 1; }
 SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON_FILE") \
   || { echo "fm-fleet-snapshot: registered secondmate aggregation failed" >&2; exit 1; }
@@ -1875,12 +1878,13 @@ printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
   --arg projects "$PROJECTS" \
   --slurpfile backlog "$BACKLOG_JSON_FILE" \
   --slurpfile tasks "$TASKS_JSON_FILE" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
+  --slurpfile main_inventory "$MAIN_INVENTORY_JSON_FILE" \
   --argjson scout_reports "$SCOUT_REPORTS_JSON" \
   --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
   --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
   '($backlog[0]) as $backlog
    | ($tasks[0]) as $tasks
+   | ($main_inventory[0]) as $main_inventory
    | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");

--- a/tests/fm-home-summary-refresh.test.sh
+++ b/tests/fm-home-summary-refresh.test.sh
@@ -14,6 +14,7 @@ TMP_ROOT=$(fm_test_tmproot fm-home-summary-refresh)
 HOME_DIR="$TMP_ROOT/mate-home"
 CADENCE_HOME="$TMP_ROOT/cadence-home"
 PARENT_HOME="$TMP_ROOT/parent-home"
+LARGE_HOME="$TMP_ROOT/large-home"
 FAKEBIN=$(fm_fakebin "$TMP_ROOT")
 WATCH_PID=
 SLOW_WRITER_PID=
@@ -157,6 +158,44 @@ jq -S 'del(.generated, .generated_epoch)' "$TMP_ROOT/fresh-summary.json" \
 cmp -s "$TMP_ROOT/published-normalized.json" "$TMP_ROOT/fresh-normalized.json" \
   || fail "the status-triggered ledger differed from the real fresh producer"
 pass "watcher-carried status append publishes the real home summary"
+
+# A structured backlog above Linux MAX_ARG_STRLEN must remain publishable through
+# both fleet snapshot modes and the real home-summary writer.
+mkdir -p "$LARGE_HOME/state" "$LARGE_HOME/data" "$LARGE_HOME/config" \
+  "$LARGE_HOME/projects"
+printf '# Seeded Firstmate home\n' > "$LARGE_HOME/AGENTS.md"
+printf 'large\n' > "$LARGE_HOME/.fm-secondmate-home"
+{
+  printf '%s\n' '## In flight' '' '## Queued'
+  i=1
+  while [ "$i" -le 2200 ]; do
+    printf '%s\n' "- [ ] large-task-$i - $(printf 'x%.0s' $(seq 1 70)) (repo: firstmate) (kind: ship)"
+    i=$((i + 1))
+  done
+  printf '%s\n' '' '## Done'
+} > "$LARGE_HOME/data/backlog.md"
+[ "$(wc -c < "$LARGE_HOME/data/backlog.md")" -gt 131072 ] \
+  || fail "large backlog fixture did not exceed the per-argument limit"
+PATH="$FAKEBIN:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$LARGE_HOME" \
+  FM_SNAPSHOT_NOW="$NOW_ONE" FM_SNAPSHOT_NOW_EPOCH="$EPOCH_ONE" \
+  "$SNAPSHOT" --json > "$TMP_ROOT/large-snapshot.json" \
+  || fail "fleet snapshot json mode failed for a large backlog"
+jq -e '.schema == "fm-fleet-snapshot.v1" and (.backlog.records | length) == 2200' \
+  "$TMP_ROOT/large-snapshot.json" >/dev/null \
+  || fail "large fleet snapshot did not preserve the backlog records"
+PATH="$FAKEBIN:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$LARGE_HOME" \
+  FM_SNAPSHOT_NOW="$NOW_ONE" FM_SNAPSHOT_NOW_EPOCH="$EPOCH_ONE" \
+  "$SNAPSHOT" --secondmate-home-summary > "$TMP_ROOT/large-summary.json" \
+  || fail "secondmate home-summary mode failed for a large backlog"
+jq -e '.schema == "fm-secondmate-home-summary.v1"' "$TMP_ROOT/large-summary.json" \
+  >/dev/null || fail "large secondmate home-summary output was not valid"
+PATH="$FAKEBIN:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$LARGE_HOME" \
+  FM_SNAPSHOT_NOW="$NOW_ONE" FM_SNAPSHOT_NOW_EPOCH="$EPOCH_ONE" \
+  "$WRITER" || fail "home-summary writer failed for a large backlog"
+jq -e '.schema == "fm-secondmate-home-summary.v1"' \
+  "$LARGE_HOME/state/home-summary.json" >/dev/null \
+  || fail "large secondmate home-summary was not published"
+pass "large backlog snapshots and home-summary publication stay within exec limits"
 
 mkdir -p "$CADENCE_HOME/state" "$CADENCE_HOME/data" "$CADENCE_HOME/config" \
   "$CADENCE_HOME/projects"

--- a/tests/fm-home-summary-refresh.test.sh
+++ b/tests/fm-home-summary-refresh.test.sh
@@ -15,6 +15,7 @@ HOME_DIR="$TMP_ROOT/mate-home"
 CADENCE_HOME="$TMP_ROOT/cadence-home"
 PARENT_HOME="$TMP_ROOT/parent-home"
 LARGE_HOME="$TMP_ROOT/large-home"
+STATELESS_HOME="$TMP_ROOT/stateless-home"
 FAKEBIN=$(fm_fakebin "$TMP_ROOT")
 WATCH_PID=
 SLOW_WRITER_PID=
@@ -159,30 +160,33 @@ cmp -s "$TMP_ROOT/published-normalized.json" "$TMP_ROOT/fresh-normalized.json" \
   || fail "the status-triggered ledger differed from the real fresh producer"
 pass "watcher-carried status append publishes the real home summary"
 
-# A structured backlog above Linux MAX_ARG_STRLEN must remain publishable through
-# both fleet snapshot modes and the real home-summary writer.
+# A structured in-flight inventory above Linux MAX_ARG_STRLEN must remain
+# publishable through both fleet snapshot modes and the real home-summary writer.
 mkdir -p "$LARGE_HOME/state" "$LARGE_HOME/data" "$LARGE_HOME/config" \
   "$LARGE_HOME/projects"
 printf '# Seeded Firstmate home\n' > "$LARGE_HOME/AGENTS.md"
 printf 'large\n' > "$LARGE_HOME/.fm-secondmate-home"
+large_id_suffix=$(printf 'i%.0s' $(seq 1 110))
 {
-  printf '%s\n' '## In flight' '' '## Queued'
+  printf '%s\n' '## In flight'
   i=1
-  while [ "$i" -le 2200 ]; do
-    printf '%s\n' "- [ ] large-task-$i - $(printf 'x%.0s' $(seq 1 70)) (repo: firstmate) (kind: ship)"
+  while [ "$i" -le 1200 ]; do
+    printf '%s\n' "- [ ] orphan-$i-$large_id_suffix - Missing metadata (repo: firstmate) (kind: ship)"
     i=$((i + 1))
   done
-  printf '%s\n' '' '## Done'
+  printf '%s\n' '' '## Queued' '' '## Done'
 } > "$LARGE_HOME/data/backlog.md"
 [ "$(wc -c < "$LARGE_HOME/data/backlog.md")" -gt 131072 ] \
-  || fail "large backlog fixture did not exceed the per-argument limit"
+  || fail "large in-flight fixture did not exceed the per-argument limit"
 PATH="$FAKEBIN:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$LARGE_HOME" \
   FM_SNAPSHOT_NOW="$NOW_ONE" FM_SNAPSHOT_NOW_EPOCH="$EPOCH_ONE" \
   "$SNAPSHOT" --json > "$TMP_ROOT/large-snapshot.json" \
   || fail "fleet snapshot json mode failed for a large backlog"
-jq -e '.schema == "fm-fleet-snapshot.v1" and (.backlog.records | length) == 2200' \
+jq -e '.schema == "fm-fleet-snapshot.v1"
+  and (.backlog.records | length) == 1200
+  and (.main_inventory.orphan_in_flight | length) == 1200' \
   "$TMP_ROOT/large-snapshot.json" >/dev/null \
-  || fail "large fleet snapshot did not preserve the backlog records"
+  || fail "large fleet snapshot did not preserve the orphan inventory"
 PATH="$FAKEBIN:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$LARGE_HOME" \
   FM_SNAPSHOT_NOW="$NOW_ONE" FM_SNAPSHOT_NOW_EPOCH="$EPOCH_ONE" \
   "$SNAPSHOT" --secondmate-home-summary > "$TMP_ROOT/large-summary.json" \
@@ -196,6 +200,21 @@ jq -e '.schema == "fm-secondmate-home-summary.v1"' \
   "$LARGE_HOME/state/home-summary.json" >/dev/null \
   || fail "large secondmate home-summary was not published"
 pass "large backlog snapshots and home-summary publication stay within exec limits"
+
+mkdir -p "$STATELESS_HOME/data" "$STATELESS_HOME/config" \
+  "$STATELESS_HOME/projects"
+printf '%s\n' '## In flight' '' '## Queued' '' '## Done' \
+  > "$STATELESS_HOME/data/backlog.md"
+PATH="$FAKEBIN:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$STATELESS_HOME" \
+  FM_SNAPSHOT_NOW="$NOW_ONE" FM_SNAPSHOT_NOW_EPOCH="$EPOCH_ONE" \
+  "$SNAPSHOT" --json > "$TMP_ROOT/stateless-snapshot.json" \
+  || fail "fleet snapshot json mode failed without a state directory"
+jq -e '.schema == "fm-fleet-snapshot.v1" and (.tasks | length) == 0' \
+  "$TMP_ROOT/stateless-snapshot.json" >/dev/null \
+  || fail "stateless fleet snapshot output was not valid"
+[ ! -e "$STATELESS_HOME/state" ] \
+  || fail "fleet snapshot created operational state for transport files"
+pass "fleet snapshot transport does not require or mutate operational state"
 
 mkdir -p "$CADENCE_HOME/state" "$CADENCE_HOME/data" "$CADENCE_HOME/config" \
   "$CADENCE_HOME/projects"

--- a/tests/fm-home-summary-refresh.test.sh
+++ b/tests/fm-home-summary-refresh.test.sh
@@ -16,6 +16,8 @@ CADENCE_HOME="$TMP_ROOT/cadence-home"
 PARENT_HOME="$TMP_ROOT/parent-home"
 LARGE_HOME="$TMP_ROOT/large-home"
 STATELESS_HOME="$TMP_ROOT/stateless-home"
+LARGE_CHILD_HOME="$TMP_ROOT/large-child-home"
+LARGE_PARENT_HOME="$TMP_ROOT/large-parent-home"
 FAKEBIN=$(fm_fakebin "$TMP_ROOT")
 WATCH_PID=
 SLOW_WRITER_PID=
@@ -215,6 +217,45 @@ jq -e '.schema == "fm-fleet-snapshot.v1" and (.tasks | length) == 0' \
 [ ! -e "$STATELESS_HOME/state" ] \
   || fail "fleet snapshot created operational state for transport files"
 pass "fleet snapshot transport does not require or mutate operational state"
+
+mkdir -p "$LARGE_CHILD_HOME/state" "$LARGE_CHILD_HOME/data" \
+  "$LARGE_CHILD_HOME/config" "$LARGE_CHILD_HOME/projects" "$LARGE_CHILD_HOME/bin"
+printf '# Seeded Firstmate home\n' > "$LARGE_CHILD_HOME/AGENTS.md"
+printf 'large-child\n' > "$LARGE_CHILD_HOME/.fm-secondmate-home"
+{
+  printf '%s\n' '## In flight'
+  i=1
+  while [ "$i" -le 600 ]; do
+    printf '%s\n' "- [ ] orphan-$i-$large_id_suffix - Missing metadata (repo: firstmate) (kind: ship)"
+    i=$((i + 1))
+  done
+  printf '%s\n' '' '## Queued' '' '## Done'
+} > "$LARGE_CHILD_HOME/data/backlog.md"
+PATH="$FAKEBIN:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$LARGE_CHILD_HOME" \
+  FM_SNAPSHOT_NOW="$NOW_ONE" FM_SNAPSHOT_NOW_EPOCH="$EPOCH_ONE" \
+  "$WRITER" || fail "large child home-summary publication failed"
+large_child_bytes=$(wc -c < "$LARGE_CHILD_HOME/state/home-summary.json")
+[ "$large_child_bytes" -gt 131072 ] && [ "$large_child_bytes" -le 262144 ] \
+  || fail "large child ledger did not cross only the per-argument limit: $large_child_bytes"
+mkdir -p "$LARGE_PARENT_HOME/state" "$LARGE_PARENT_HOME/data" \
+  "$LARGE_PARENT_HOME/config" "$LARGE_PARENT_HOME/projects"
+printf -- '- large-child - fixture domain (home: %s; scope: fixture work; projects: firstmate; added 2026-08-28)\n' \
+  "$LARGE_CHILD_HOME" > "$LARGE_PARENT_HOME/data/secondmates.md"
+printf '%s\n' '## In flight' '' '## Queued' '' '## Done' \
+  > "$LARGE_PARENT_HOME/data/backlog.md"
+fm_write_secondmate_meta "$LARGE_PARENT_HOME/state/large-child.meta" \
+  "$LARGE_CHILD_HOME" "fmtest:fm-large-child" firstmate claude
+PATH="$FAKEBIN:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$LARGE_PARENT_HOME" \
+  FM_SNAPSHOT_NOW="$NOW_ONE" FM_SNAPSHOT_NOW_EPOCH="$EPOCH_ONE" \
+  "$SNAPSHOT" --json > "$TMP_ROOT/large-parent-snapshot.json" \
+  || fail "parent fleet snapshot failed for a large child ledger"
+jq -e '.secondmate_current.records[0]
+  | .provenance.summary_source == "local-ledger"
+    and .invalidity.kind == "orphan_in_flight"
+    and (.invalidity.ids | length) == 600' \
+  "$TMP_ROOT/large-parent-snapshot.json" >/dev/null \
+  || fail "parent fleet snapshot did not preserve the large child invalidity"
+pass "parent snapshot consumes large child ledgers without argument transport"
 
 mkdir -p "$CADENCE_HOME/state" "$CADENCE_HOME/data" "$CADENCE_HOME/config" \
   "$CADENCE_HOME/projects"


### PR DESCRIPTION
## Intent

The captain, 2026-09-03, after the analytics second mate reported it again at startup: "WTF, we had our backlog fixed yesterday. Again!? One diagnostic, cause found, not fixable here: this home's structured summary for the main firstmate has failed to publish since 2026-09-01. The fleet snapshot script passes the whole backlog document to jq as a command-line argument, and this backlog is now large enough to exceed the OS argument limit."

Context needed to read it: every firstmate home publishes a structured home summary (state/home-summary.json) for the main firstmate through bin/fm-home-summary-refresh.sh, which calls bin/fm-fleet-snapshot.sh. In any home whose backlog grows past roughly 128 KiB once structured, that publish has silently failed since 2026-09-01: the analytics second mate's home is dark to the main firstmate, the HOME_SUMMARY bootstrap line repeats every session start, and bearings and PR-board snapshot modes fail the same way. The captain wants it fixed for good, upstream, so it never recurs in any home.

## What Changed

- Route fleet-sized backlog, task, home-summary, and derived JSON through private temporary files consumed with `jq --slurpfile`, with recursive cleanup on exit.
- Add behavioral coverage for backlogs over 128 KiB, both snapshot modes, home-summary publication, stateless homes, and parent aggregation of large child summaries.

## Risk Assessment

✅ Low: The change consistently file-backs every backlog-derived or secondmate-summary aggregate that could exceed OS argument limits, preserves existing snapshot semantics, and adds behavioral coverage for direct publication, parent aggregation, and stateless homes.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 2 runs (4m8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3feb419ce27de1189062d23da79295487358b0d5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-fleet-snapshot.sh:1681` - The durable argument-limit invariant still fails for large in-flight backlogs. `main_inventory_json` preserves every missing worker ID in `orphan_in_flight`, but the final jq invocation passes that unbounded backlog-derived object through `--argjson`. A sufficiently large set of in-flight rows without metadata therefore still reaches E2BIG even though the original backlog and tasks are file-backed. File-back this aggregate at the same boundary and extend the behavioral regression with large in-flight rows, since the new queued-only fixture produces a small inventory object.
- ⚠️ `bin/fm-fleet-snapshot.sh:1648` - The snapshot now unconditionally creates temporary files inside `$STATE`. A home with a missing or read-only state directory previously returned a structured snapshot with empty task state, but now fails at `mktemp`; this also contradicts the header contract that remote-summary cache refreshes are the command&#39;s only fleet-state mutation. Store transport files in a private temporary directory that does not require mutating operational state.

🔧 Fix: Captain: file-back fleet snapshot transport safely
1 error still open:

- 🚨 `bin/fm-fleet-snapshot.sh:1669` - The durable argument-limit invariant remains reachable through registered secondmate summaries. A child home with roughly 600 long orphan IDs can publish a valid summary below the 262144-byte ledger limit but above Linux MAX_ARG_STRLEN because `invalidity.ids` and its reason repeat those IDs. The parent then reads that summary and passes it through `--argjson summary` inside `secondmate_current_json`; multiple smaller summaries can likewise make the final `secondmate_current` argument exceed aggregate ARG_MAX. The new regression only snapshots the large home directly, so it does not exercise this parent aggregation path. File-back accepted home summaries and the resulting aggregate through final assembly, then cover a parent registered to a large child home.

🔧 Fix: Captain: file-back parent summary aggregation
✅ Re-checked - no issues remain.

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>
