### PR TITLE
fix(bin): bound shellcheck memory per lint shard

### DIFF
--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -31,6 +31,9 @@
 # Each shard writes separate diagnostics, and the parent replays those outputs in
 # deterministic shard and root order after every worker finishes. FM_LINT_JOBS=1
 # runs the same shards serially with byte-identical diagnostics and exit selection.
+# Each shard's ShellCheck runs under a virtual-address-space cap of
+# FM_LINT_SHELLCHECK_MAX_MB (default 4096) so a pathological analysis fails that
+# shard instead of triggering the kernel OOM killer machine-wide.
 #
 # Optional quiet telemetry writes one bounded TSV snapshot of content and source
 # graph identity, wall/CPU/RSS, shard load, and competing ShellCheck processes.
@@ -79,7 +82,12 @@ fm_lint_worker() {  # <manifest> <output-dir> <shard-index>
     if [ "${FM_LINT_INTERNAL_FAST:-0}" -eq 1 ]; then
       shellcheck_args+=(--extended-analysis=false)
     fi
-    "$FM_LINT_SHELLCHECK" "${shellcheck_args[@]}" -- "${roots[@]}" > "$output.out" 2>&1 &
+    # Bound shellcheck's address space so a pathological analysis fails this
+    # shard loudly instead of triggering the kernel OOM killer machine-wide.
+    (
+      ulimit -v "$(( ${FM_LINT_SHELLCHECK_MAX_MB:-4096} * 1024 ))" 2>/dev/null || true
+      exec "$FM_LINT_SHELLCHECK" "${shellcheck_args[@]}" -- "${roots[@]}"
+    ) > "$output.out" 2>&1 &
     FM_LINT_WORKER_SHELLCHECK_PID=$!
     wait "$FM_LINT_WORKER_SHELLCHECK_PID" || rc=$?
     FM_LINT_WORKER_SHELLCHECK_PID=

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -31,9 +31,11 @@
 # Each shard writes separate diagnostics, and the parent replays those outputs in
 # deterministic shard and root order after every worker finishes. FM_LINT_JOBS=1
 # runs the same shards serially with byte-identical diagnostics and exit selection.
-# Each shard's ShellCheck runs under a virtual-address-space cap of
+# Each shard's ShellCheck runs under a best-effort virtual-address-space cap of
 # FM_LINT_SHELLCHECK_MAX_MB (default 4096) so a pathological analysis fails that
-# shard instead of triggering the kernel OOM killer machine-wide.
+# shard instead of triggering the kernel OOM killer machine-wide. The cap is
+# only enforced where the platform honors RLIMIT_AS (Linux); on macOS bash
+# accepts ulimit -v but the kernel does not enforce it, so lint still runs.
 #
 # Optional quiet telemetry writes one bounded TSV snapshot of content and source
 # graph identity, wall/CPU/RSS, shard load, and competing ShellCheck processes.
@@ -84,8 +86,9 @@ fm_lint_worker() {  # <manifest> <output-dir> <shard-index>
     fi
     # Bound shellcheck's address space so a pathological analysis fails this
     # shard loudly instead of triggering the kernel OOM killer machine-wide.
+    # The parent validated FM_LINT_SHELLCHECK_MAX_MB and passes it in KiB.
     (
-      ulimit -v "$(( ${FM_LINT_SHELLCHECK_MAX_MB:-4096} * 1024 ))" 2>/dev/null || true
+      ulimit -v "$FM_LINT_INTERNAL_SHELLCHECK_MAX_KIB" 2>/dev/null || true
       exec "$FM_LINT_SHELLCHECK" "${shellcheck_args[@]}" -- "${roots[@]}"
     ) > "$output.out" 2>&1 &
     FM_LINT_WORKER_SHELLCHECK_PID=$!
@@ -105,7 +108,8 @@ if [ "${1:-}" = "--internal-worker" ]; then
     printf 'fm-lint.sh: --internal-worker is private to the lint owner.\n' >&2
     exit 2
   }
-  [ "$#" -eq 4 ] && [ -n "${FM_LINT_SHELLCHECK:-}" ] || exit 2
+  [ "$#" -eq 4 ] && [ -n "${FM_LINT_SHELLCHECK:-}" ] \
+    && [ -n "${FM_LINT_INTERNAL_SHELLCHECK_MAX_KIB:-}" ] || exit 2
   fm_lint_worker "$2" "$3" "$4"
   exit $?
 fi
@@ -131,6 +135,7 @@ fm_lint_run_workflows() {
 }
 
 JOBS=${FM_LINT_JOBS:-2}
+SHELLCHECK_MAX_MB=${FM_LINT_SHELLCHECK_MAX_MB:-4096}
 TELEMETRY=${FM_LINT_TELEMETRY:-}
 FAST=0
 ANALYSIS_MODE=full
@@ -180,6 +185,15 @@ case "$JOBS" in
   1|2) ;;
   *) printf 'fm-lint.sh: jobs must be 1 or 2, got %s.\n' "$JOBS" >&2; exit 2 ;;
 esac
+
+case "$SHELLCHECK_MAX_MB" in
+  0*|*[!0-9]*)
+    printf 'fm-lint.sh: FM_LINT_SHELLCHECK_MAX_MB must be a positive integer (MB), got %s.\n' \
+      "$SHELLCHECK_MAX_MB" >&2
+    exit 2
+    ;;
+esac
+SHELLCHECK_MAX_KIB=$(( SHELLCHECK_MAX_MB * 1024 ))
 
 if [ "$FAST" -eq 1 ] && { [ "${GITHUB_ACTIONS:-}" = true ] || [ "${CI:-}" = true ]; }; then
   printf 'fm-lint.sh: --fast is local-only; CI uses full ShellCheck analysis.\n' >&2
@@ -417,17 +431,20 @@ fm_lint_run_worker() {  # <worker-index>
       exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
         /usr/bin/time -lp -o "$timing" \
         env FM_LINT_INTERNAL=1 FM_LINT_INTERNAL_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+        FM_LINT_INTERNAL_SHELLCHECK_MAX_KIB="$SHELLCHECK_MAX_KIB" \
         "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
     else
       exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
         /usr/bin/time -f 'wall_seconds=%e\nuser_seconds=%U\nsystem_seconds=%S\nmax_rss_kib=%M' -o "$timing" \
         env FM_LINT_INTERNAL=1 FM_LINT_INTERNAL_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+        FM_LINT_INTERNAL_SHELLCHECK_MAX_KIB="$SHELLCHECK_MAX_KIB" \
         "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
     fi
   else
     [ -z "$TELEMETRY" ] || printf 'timing_unavailable=1\n' > "$timing"
     exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
       env FM_LINT_INTERNAL=1 FM_LINT_INTERNAL_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+      FM_LINT_INTERNAL_SHELLCHECK_MAX_KIB="$SHELLCHECK_MAX_KIB" \
       "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
   fi
 }

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -328,6 +328,30 @@ SH
   pass "fm-lint.sh bounds ShellCheck memory (default 4096 MB, FM_LINT_SHELLCHECK_MAX_MB override)"
 }
 
+test_rejects_malformed_memory_cap() {
+  local tmp fakebin log fixture value out rc
+  tmp=$(fm_test_tmproot fm-lint-memory-cap-invalid)
+  fakebin=$(fm_fakebin "$tmp")
+  fixture="$tmp/fixture.sh"
+  log="$tmp/shellcheck.log"
+  printf '#!/usr/bin/env bash\nprintf ok\n' > "$fixture"
+  chmod +x "$fixture"
+  fm_lint_stub_shellcheck "$fakebin" "$log"
+  for value in abc 4G 0 -1; do
+    rc=0
+    out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+      FM_LINT_SHELLCHECK_MAX_MB="$value" "$LINT" "$fixture" 2>&1) || rc=$?
+    [ "$rc" -eq 2 ] \
+      || fail "FM_LINT_SHELLCHECK_MAX_MB=$value should exit 2, got $rc"$'\n'"$out"
+    case "$out" in
+      *"FM_LINT_SHELLCHECK_MAX_MB must be a positive integer"*) ;;
+      *) fail "FM_LINT_SHELLCHECK_MAX_MB=$value did not report the memory cap clearly:"$'\n'"$out" ;;
+    esac
+    [ ! -s "$log" ] || fail "FM_LINT_SHELLCHECK_MAX_MB=$value still ran ShellCheck"
+  done
+  pass "fm-lint.sh rejects a malformed FM_LINT_SHELLCHECK_MAX_MB with a clear message"
+}
+
 test_ci_defaults_to_full_analysis() {
   local tmp fakebin log mode_log fixture out
   tmp=$(fm_test_tmproot fm-lint-ci-analysis)
@@ -1035,6 +1059,7 @@ test_help_reports_the_complete_interface
 test_list_files_reports_the_shell_inventory
 test_fast_mode_disables_extended_analysis
 test_shellcheck_runs_under_a_memory_cap
+test_rejects_malformed_memory_cap
 test_ci_defaults_to_full_analysis
 test_ci_rejects_explicit_fast_mode
 test_fast_mode_catches_a_real_lint_defect

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -240,7 +240,8 @@ fm_lint_write_diff_file() {
 # them, so changed-file mode tests can assert exactly which files fm-lint.sh
 # selected without depending on real ShellCheck findings. When
 # FM_TEST_MODE_LOG is set, it records the effective analysis mode, treating
-# ShellCheck's default as full analysis.
+# ShellCheck's default as full analysis. When FM_TEST_ULIMIT_LOG is set, it
+# records the virtual-address-space limit (ulimit -v, in KiB) it runs under.
 fm_lint_stub_shellcheck() {
   local fakebin=$1 log=$2
   : > "$log"
@@ -257,6 +258,9 @@ while [ "\$#" -gt 0 ] && [ "\$1" != -- ]; do
 done
 if [ -n "\${FM_TEST_MODE_LOG:-}" ]; then
   printf '%s\n' "\$mode" >> "\$FM_TEST_MODE_LOG"
+fi
+if [ -n "\${FM_TEST_ULIMIT_LOG:-}" ]; then
+  ulimit -v >> "\$FM_TEST_ULIMIT_LOG"
 fi
 [ "\$#" -eq 0 ] || shift
 printf '%s\n' "\$@" >> "$log"
@@ -289,6 +293,39 @@ SH
     || fail "fast lint mode did not lint the requested root"
   assert_grep $'analysis_mode\tfast' "$telemetry" "telemetry did not record fast analysis mode"
   pass "fm-lint.sh --fast disables ShellCheck extended analysis"
+}
+
+test_shellcheck_runs_under_a_memory_cap() {
+  local tmp fakebin log ulimit_log fixture out
+  tmp=$(fm_test_tmproot fm-lint-memory-cap)
+  fakebin=$(fm_fakebin "$tmp")
+  fixture="$tmp/fixture.sh"
+  log="$tmp/shellcheck.log"
+  ulimit_log="$tmp/ulimit.log"
+  cat > "$fixture" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-ok}"
+SH
+  chmod +x "$fixture"
+  fm_lint_stub_shellcheck "$fakebin" "$log"
+  if ! bash -c 'ulimit -v 8388608 && [ "$(ulimit -v)" = 8388608 ]' 2>/dev/null; then
+    pass "fm-lint.sh memory cap (skipped: ulimit -v unsupported on this platform)"
+    return 0
+  fi
+
+  out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_ULIMIT_LOG="$ulimit_log" "$LINT" "$fixture" 2>&1) \
+    || fail "lint under default memory cap failed"$'\n'"$out"
+  [ "$(cat "$ulimit_log")" = "$((4096 * 1024))" ] \
+    || fail "default ShellCheck memory cap was not 4096 MB: $(cat "$ulimit_log")"
+
+  : > "$ulimit_log"
+  out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_LINT_SHELLCHECK_MAX_MB=512 FM_TEST_ULIMIT_LOG="$ulimit_log" "$LINT" "$fixture" 2>&1) \
+    || fail "lint under explicit memory cap failed"$'\n'"$out"
+  [ "$(cat "$ulimit_log")" = "$((512 * 1024))" ] \
+    || fail "FM_LINT_SHELLCHECK_MAX_MB was not honored: $(cat "$ulimit_log")"
+  pass "fm-lint.sh bounds ShellCheck memory (default 4096 MB, FM_LINT_SHELLCHECK_MAX_MB override)"
 }
 
 test_ci_defaults_to_full_analysis() {
@@ -997,6 +1034,7 @@ SH
 test_help_reports_the_complete_interface
 test_list_files_reports_the_shell_inventory
 test_fast_mode_disables_extended_analysis
+test_shellcheck_runs_under_a_memory_cap
 test_ci_defaults_to_full_analysis
 test_ci_rejects_explicit_fast_mode
 test_fast_mode_catches_a_real_lint_defect


### PR DESCRIPTION
## Intent

The captain reported (2026-09-03): "we just suffered through three OOM crashes due to spellcheck being unbounded. There is a fix that landed locally but you are not tracking that fix yet." The linter bin/fm-lint.sh runs shellcheck per shard with no memory bound; a pathological analysis grew until the kernel OOM killer took down the machine three times. The fix already exists locally as an uncommitted change (bounding each shard's shellcheck with ulimit -v under FM_LINT_SHELLCHECK_MAX_MB, default 4096 MB) and must be shipped so every firstmate home gets it.

## What Changed

- `bin/fm-lint.sh` now runs each shard's ShellCheck inside a subshell under `ulimit -v`, capped at `FM_LINT_SHELLCHECK_MAX_MB` (default 4096 MB) so a pathological analysis fails that shard instead of triggering the kernel OOM killer machine-wide. The cap is best-effort: it is enforced where the platform honors RLIMIT_AS (Linux) and silently ignored elsewhere (macOS).
- The parent validates `FM_LINT_SHELLCHECK_MAX_MB` as a positive integer (exit 2 with a clear message on `abc`, `4G`, `0`, `-1`), converts it to KiB, and passes it to workers via `FM_LINT_INTERNAL_SHELLCHECK_MAX_KIB`, which the `--internal-worker` entry point now requires.
- `tests/fm-lint.test.sh` extends the ShellCheck stub to record its `ulimit -v`, and adds tests asserting the default 4096 MB cap, the `FM_LINT_SHELLCHECK_MAX_MB=512` override, and rejection of malformed values without running ShellCheck. The cap test self-skips on platforms where `ulimit -v` is unsupported.

## Risk Assessment

✅ Low: The change is a contained two-file hotfix: the ulimit wrapper preserves the worker's PID/trap semantics, the parent-side validation rejects every malformed input the prior round identified before any ShellCheck runs, and the new tests assert observable behavior through the real script.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (3m40s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a143e61c0b7b71efd619378e9197b0e03b5df924","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-lint.sh:88` - FM_LINT_SHELLCHECK_MAX_MB is fed straight into arithmetic and ulimit with no validation, unlike FM_LINT_JOBS which is validated with a clear message at bin/fm-lint.sh:179-181. Traced concrete inputs: FM_LINT_SHELLCHECK_MAX_MB=abc under `set -u` aborts the subshell with &#39;abc: unbound variable&#39; before ShellCheck runs (shard rc=1, message replayed as if it were a lint finding); FM_LINT_SHELLCHECK_MAX_MB=4G fails with &#39;value too great for base&#39; (rc=1); FM_LINT_SHELLCHECK_MAX_MB=0 sets `ulimit -v 0` so the exec itself dies (observed rc=139 segfault). None of these mention the memory cap, so a user who mistypes the override sees an opaque shard failure and every lint run fails. Fix: validate the value once in the parent alongside JOBS (digits only, greater than zero; reject or treat 0/unlimited explicitly with a clear &#39;fm-lint.sh: FM_LINT_SHELLCHECK_MAX_MB must be a positive integer&#39; message) and pass the validated KiB value to the worker.
- ℹ️ `bin/fm-lint.sh:34` - On platforms where RLIMIT_AS cannot be set (bash on macOS accepts `ulimit -v` but the kernel does not enforce it, and some containers pin a lower hard limit), the `|| true` and `2&gt;/dev/null` mean the cap is silently not applied. That is the right choice for keeping lint runnable, and the test correctly skips there, but the header comment at line 34-36 states the cap unconditionally. Consider wording it as best-effort so an operator on macOS does not assume they are protected. No code change required.

🔧 Fix: validate FM_LINT_SHELLCHECK_MAX_MB and document best-effort cap
1 info still open:

- ℹ️ `bin/fm-lint.sh:196` - The validation accepts any digit string, so a value beyond 64-bit range wraps silently in `$(( SHELLCHECK_MAX_MB * 1024 ))`. Traced: FM_LINT_SHELLCHECK_MAX_MB=99999999999999999999 passes the case guard, the arithmetic yields 2123646838278978560 KiB, `ulimit -v` accepts it, and ShellCheck runs effectively uncapped with no error. This only affects absurd operator input and the documented cases (abc, 4G, 0, -1) are all rejected correctly, so no change is required for this hotfix; an upper bound on the digit count would close it if desired.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
