### PR TITLE
fix(herdr): recover worker relaunches after agent exit

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2600,15 +2600,18 @@ fm_backend_herdr_current_path() {  # <target>
     | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null
 }
 
-# fm_backend_herdr_prepare_relaunch_path: restore an agent-free endpoint shell
-# only to the exact recorded worktree already validated by the control plane.
-# Herdr's atomic `pane run` executes `cd` non-persistently, so this uses the
-# interactive shell's literal-input path and submits only after a second exact
-# shell-owner check. The single-quote transform is data-only shell quoting; no
-# byte from the path can become syntax. Success requires the live foreground cwd
-# to converge to the physical recorded path while the endpoint remains
-# positively agent-free and owned by the same shell pid. Repeated calls are a
-# verified no-op once the path already matches.
+# fm_backend_herdr_prepare_relaunch_path: prepare an agent-free endpoint shell
+# for the exact recorded worktree already validated by the launch caller.
+# It first cancels any pending input while the same idle shell owns the pane,
+# including when the cwd already matches. Herdr's atomic `pane run` executes
+# `cd` non-persistently, so a mismatched cwd uses the interactive shell's
+# literal-input path and submits only after a second exact shell-owner check.
+# The single-quote transform is data-only shell quoting; no byte from the path
+# can become syntax. Every pre-Enter failure attempts to cancel this function's
+# buffered command only while that same idle shell still owns the pane. Success
+# requires the live foreground cwd to converge to the physical recorded path
+# while the endpoint remains positively agent-free and owned by the same shell
+# pid. Repeated calls converge safely and never append to pending input.
 fm_backend_herdr_clear_idle_shell_input() {  # <target> <shell-pid>
   local target=$1 shell_pid=$2 resampled
   [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || return 1

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2637,13 +2637,6 @@ fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
     echo "error: herdr endpoint does not hold one provably idle shell; refusing to restore its relaunch path" >&2
     return 1
   }
-  current=$(fm_backend_herdr_current_path "$target" || true)
-  current_real=
-  [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
-  if [ "$current_real" = "$expected_real" ]; then
-    return 0
-  fi
-
   fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" || {
     echo "error: herdr endpoint changed before its shell input could be cleared" >&2
     return 1
@@ -2658,6 +2651,12 @@ fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
     echo "error: herdr endpoint shell identity changed after clearing shell input" >&2
     return 1
   }
+  current=$(fm_backend_herdr_current_path "$target" || true)
+  current_real=
+  [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
+  if [ "$current_real" = "$expected_real" ]; then
+    return 0
+  fi
 
   quoted=${expected_real//\'/\'"\'"\'}
   command="cd -- '$quoted'"

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1928,11 +1928,11 @@ fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
   esac
 }
 
-# fm_backend_herdr_agent_state: recovery-grade state for the same session-start
-# sweep as the tmux classifier. It reuses the husk classifier rather than
-# creating a second Herdr state machine: a structurally gone pane is `missing`,
-# a confirmed agent-less pane is `dead`, a registered agent is `alive`, and an
-# unexpected or failed API read is `unreadable`.
+# fm_backend_herdr_agent_state: ordinary recovery-grade state for the same
+# session-start sweep as the tmux classifier. It reuses the husk classifier
+# rather than creating a second Herdr state machine: a structurally gone pane
+# is `missing`, a confirmed agent-less pane is `dead`, a registered agent is
+# `alive`, and an unexpected or failed API read is `unreadable`.
 fm_backend_herdr_agent_state() {  # <target>
   local target=$1
   fm_backend_herdr_parse_target "$target" || { printf 'unreadable'; return 0; }
@@ -1940,6 +1940,69 @@ fm_backend_herdr_agent_state() {  # <target>
     dead) printf 'missing' ;;
     no-agent) printf 'dead' ;;
     live) printf 'alive' ;;
+    *) printf 'unreadable' ;;
+  esac
+}
+
+# fm_backend_herdr_registered_process_state: independently corroborate one
+# registered agent against the exact pane's foreground process. Herdr can retain
+# an idle/done Pi registration after Pi exits and the pane returns to its shell.
+# A different foreground process group proves the registered process is still
+# live enough that lifecycle recovery must refuse to replace it. Only the
+# existing strict lone-idle-shell proof can establish the stale-registration
+# counterfactual. Prompt helpers may transiently share the shell's group, so
+# ambiguous shell-group samples retry for the same bounded window as that proof.
+# Prints live|shell|unknown and never mutates Herdr's registry.
+fm_backend_herdr_registered_process_state() {  # <session> <pane-id>
+  local session=$1 pane=$2 attempt=0 max_attempts=${FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS:-10}
+  local info shell_pid foreground_pgid count
+  while :; do
+    info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null) || { printf 'unknown'; return 0; }
+    if ! printf '%s' "$info" | jq -e --arg pane "$pane" '
+      .result.type == "pane_process_info"
+      and .result.process_info.pane_id == $pane
+    ' >/dev/null 2>&1; then
+      printf 'unknown'
+      return 0
+    fi
+    shell_pid=$(printf '%s' "$info" | jq -er ".result.process_info.shell_pid | select(type == \"number\" and . > 1) | floor" 2>/dev/null) || { printf 'unknown'; return 0; }
+    foreground_pgid=$(printf '%s' "$info" | jq -er ".result.process_info.foreground_process_group_id | select(type == \"number\" and . > 1) | floor" 2>/dev/null) || { printf 'unknown'; return 0; }
+    count=$(printf '%s' "$info" | jq -er ".result.process_info.foreground_processes | select(type == \"array\") | length" 2>/dev/null) || { printf 'unknown'; return 0; }
+    if [ "$foreground_pgid" != "$shell_pid" ] && [ "$count" -gt 0 ]; then
+      printf 'live'
+      return 0
+    fi
+    if [ "$foreground_pgid" = "$shell_pid" ] \
+       && fm_backend_herdr_pane_idle_shell_sample "$session" "$pane" >/dev/null; then
+      printf 'shell'
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    [ "$attempt" -lt "$max_attempts" ] || { printf 'unknown'; return 0; }
+    sleep 0.1
+  done
+}
+
+# fm_backend_herdr_recovery_agent_state: lifecycle-only strengthening of the
+# ordinary state read. A positive registry entry remains alive unless the exact
+# pane independently proves that only its lone idle shell remains. An unreadable
+# or contradictory process surface stays unreadable rather than turning either
+# a live agent or an arbitrary foreground command into a recovery candidate.
+fm_backend_herdr_recovery_agent_state() {  # <target>
+  local target=$1 pane_state process_state
+  fm_backend_herdr_parse_target "$target" || { printf 'unreadable'; return 0; }
+  pane_state=$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
+  case "$pane_state" in
+    dead) printf 'missing' ;;
+    no-agent) printf 'dead' ;;
+    live)
+      process_state=$(fm_backend_herdr_registered_process_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
+      case "$process_state" in
+        live) printf 'alive' ;;
+        shell) printf 'dead' ;;
+        *) printf 'unreadable' ;;
+      esac
+      ;;
     *) printf 'unreadable' ;;
   esac
 }
@@ -2535,6 +2598,74 @@ fm_backend_herdr_current_path() {  # <target>
   fm_backend_herdr_target_ready "$1" || return 0
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane get "$FM_BACKEND_HERDR_PANE" 2>/dev/null \
     | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null
+}
+
+# fm_backend_herdr_prepare_relaunch_path: restore an agent-free endpoint shell
+# only to the exact recorded worktree already validated by the control plane.
+# Herdr's atomic `pane run` executes `cd` non-persistently, so this uses the
+# interactive shell's literal-input path and submits only after a second exact
+# shell-owner check. The single-quote transform is data-only shell quoting; no
+# byte from the path can become syntax. Success requires the live foreground cwd
+# to converge to the physical recorded path while the endpoint remains
+# positively agent-free and owned by the same shell pid. Repeated calls are a
+# verified no-op once the path already matches.
+fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
+  local target=$1 expected=$2 expected_real current current_real shell_pid resampled command quoted
+  local attempt=0 max_attempts=${FM_BACKEND_HERDR_RELAUNCH_PATH_POLLS:-20}
+  case "$expected" in
+    /*) ;;
+    *) echo "error: herdr relaunch path must be an absolute recorded worktree" >&2; return 1 ;;
+  esac
+  case "$expected" in *$'\n'*|*$'\r'*|*$'\t'*) echo "error: herdr relaunch path contains unsupported control whitespace" >&2; return 1 ;; esac
+  [ -d "$expected" ] || { echo "error: herdr relaunch path '$expected' is unavailable" >&2; return 1; }
+  expected_real=$(CDPATH='' cd -- "$expected" 2>/dev/null && pwd -P) || return 1
+  [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || {
+    echo "error: herdr endpoint is not positively agent-free; refusing to restore its relaunch path" >&2
+    return 1
+  }
+  fm_backend_herdr_parse_target "$target" || return 1
+  shell_pid=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || {
+    echo "error: herdr endpoint does not hold one provably idle shell; refusing to restore its relaunch path" >&2
+    return 1
+  }
+  current=$(fm_backend_herdr_current_path "$target" || true)
+  current_real=
+  [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
+  if [ "$current_real" = "$expected_real" ]; then
+    return 0
+  fi
+
+  quoted=${expected_real//\'/\'"\'"\'}
+  command="cd -- '$quoted'"
+  fm_backend_herdr_parse_target "$target" || return 1
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-text "$FM_BACKEND_HERDR_PANE" "$command" >/dev/null 2>&1 || return 1
+  [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || {
+    echo "error: herdr endpoint agent state changed before relaunch path submission; refusing to submit" >&2
+    return 1
+  }
+  fm_backend_herdr_parse_target "$target" || return 1
+  resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
+  [ "$resampled" = "$shell_pid" ] || {
+    echo "error: herdr endpoint shell identity changed before relaunch path submission; refusing to submit" >&2
+    return 1
+  }
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-keys "$FM_BACKEND_HERDR_PANE" enter >/dev/null 2>&1 || return 1
+  while [ "$attempt" -lt "$max_attempts" ]; do
+    current=$(fm_backend_herdr_current_path "$target" || true)
+    current_real=
+    [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
+    if [ "$current_real" = "$expected_real" ] \
+       && [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ]; then
+      fm_backend_herdr_parse_target "$target" || return 1
+      resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
+      [ "$resampled" = "$shell_pid" ] || return 1
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    [ "$attempt" -ge "$max_attempts" ] || sleep 0.1
+  done
+  echo "error: herdr endpoint did not converge to its exact recorded worktree '$expected_real'" >&2
+  return 1
 }
 
 # fm_backend_herdr_send_text_line: send one line of TEXT then submit,

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2609,6 +2609,15 @@ fm_backend_herdr_current_path() {  # <target>
 # to converge to the physical recorded path while the endpoint remains
 # positively agent-free and owned by the same shell pid. Repeated calls are a
 # verified no-op once the path already matches.
+fm_backend_herdr_clear_idle_shell_input() {  # <target> <shell-pid>
+  local target=$1 shell_pid=$2 resampled
+  [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || return 1
+  fm_backend_herdr_parse_target "$target" || return 1
+  resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
+  [ "$resampled" = "$shell_pid" ] || return 1
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-keys "$FM_BACKEND_HERDR_PANE" ctrl+c >/dev/null 2>&1
+}
+
 fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
   local target=$1 expected=$2 expected_real current current_real shell_pid resampled command quoted
   local attempt=0 max_attempts=${FM_BACKEND_HERDR_RELAUNCH_PATH_POLLS:-20}
@@ -2635,21 +2644,49 @@ fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
     return 0
   fi
 
-  quoted=${expected_real//\'/\'"\'"\'}
-  command="cd -- '$quoted'"
-  fm_backend_herdr_parse_target "$target" || return 1
-  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-text "$FM_BACKEND_HERDR_PANE" "$command" >/dev/null 2>&1 || return 1
+  fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" || {
+    echo "error: herdr endpoint changed before its shell input could be cleared" >&2
+    return 1
+  }
   [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || {
-    echo "error: herdr endpoint agent state changed before relaunch path submission; refusing to submit" >&2
+    echo "error: herdr endpoint agent state changed after clearing shell input" >&2
     return 1
   }
   fm_backend_herdr_parse_target "$target" || return 1
   resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
   [ "$resampled" = "$shell_pid" ] || {
-    echo "error: herdr endpoint shell identity changed before relaunch path submission; refusing to submit" >&2
+    echo "error: herdr endpoint shell identity changed after clearing shell input" >&2
     return 1
   }
-  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-keys "$FM_BACKEND_HERDR_PANE" enter >/dev/null 2>&1 || return 1
+
+  quoted=${expected_real//\'/\'"\'"\'}
+  command="cd -- '$quoted'"
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-text "$FM_BACKEND_HERDR_PANE" "$command" >/dev/null 2>&1 || {
+    fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" >/dev/null 2>&1 || true
+    return 1
+  }
+  [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || {
+    echo "error: herdr endpoint agent state changed before relaunch path submission; refusing to submit" >&2
+    fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" >/dev/null 2>&1 || true
+    return 1
+  }
+  fm_backend_herdr_parse_target "$target" || {
+    fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" >/dev/null 2>&1 || true
+    return 1
+  }
+  resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || {
+    fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" >/dev/null 2>&1 || true
+    return 1
+  }
+  [ "$resampled" = "$shell_pid" ] || {
+    echo "error: herdr endpoint shell identity changed before relaunch path submission; refusing to submit" >&2
+    fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" >/dev/null 2>&1 || true
+    return 1
+  }
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-keys "$FM_BACKEND_HERDR_PANE" enter >/dev/null 2>&1 || {
+    fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" >/dev/null 2>&1 || true
+    return 1
+  }
   while [ "$attempt" -lt "$max_attempts" ]; do
     current=$(fm_backend_herdr_current_path "$target" || true)
     current_real=

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2625,6 +2625,7 @@ fm_backend_herdr_clear_idle_shell_input() {  # <target> <shell-pid>
 fm_backend_herdr_prepare_relaunch_path_serialized() {  # <target> <validated-worktree>
   local target=$1 expected=$2 expected_real current current_real shell_pid resampled command quoted
   local attempt=0 max_attempts=${FM_BACKEND_HERDR_RELAUNCH_PATH_POLLS:-20}
+  FM_BACKEND_HERDR_RELAUNCH_SHELL_PID=
   case "$expected" in
     /*) ;;
     *) echo "error: herdr relaunch path must be an absolute recorded worktree" >&2; return 1 ;;
@@ -2659,6 +2660,7 @@ fm_backend_herdr_prepare_relaunch_path_serialized() {  # <target> <validated-wor
   current_real=
   [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
   if [ "$current_real" = "$expected_real" ]; then
+    FM_BACKEND_HERDR_RELAUNCH_SHELL_PID=$shell_pid
     return 0
   fi
 
@@ -2699,6 +2701,7 @@ fm_backend_herdr_prepare_relaunch_path_serialized() {  # <target> <validated-wor
       fm_backend_herdr_parse_target "$target" || return 1
       resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
       [ "$resampled" = "$shell_pid" ] || return 1
+      FM_BACKEND_HERDR_RELAUNCH_SHELL_PID=$shell_pid
       return 0
     fi
     attempt=$((attempt + 1))
@@ -2706,6 +2709,28 @@ fm_backend_herdr_prepare_relaunch_path_serialized() {  # <target> <validated-wor
   done
   echo "error: herdr endpoint did not converge to its exact recorded worktree '$expected_real'" >&2
   return 1
+}
+
+fm_backend_herdr_relaunch_prepared_shell_pid() {
+  printf '%s' "${FM_BACKEND_HERDR_RELAUNCH_SHELL_PID:-}"
+}
+
+# Revalidate the exact shell and cwd established by preparation immediately
+# before each subsequent relaunch input boundary. The session mutation lock
+# excludes other Firstmate operations, while this check also catches an
+# uncoordinated foreground-owner change before input is sent.
+fm_backend_herdr_relaunch_shell_owned() {  # <target> <shell-pid> <validated-worktree>
+  local target=$1 expected_pid=$2 expected=$3 expected_real current current_real resampled
+  [ -n "$expected_pid" ] || return 1
+  expected_real=$(CDPATH='' cd -- "$expected" 2>/dev/null && pwd -P) || return 1
+  [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || return 1
+  fm_backend_herdr_parse_target "$target" || return 1
+  resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
+  [ "$resampled" = "$expected_pid" ] || return 1
+  current=$(fm_backend_herdr_current_path "$target" || true)
+  [ -n "$current" ] || return 1
+  current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || return 1
+  [ "$current_real" = "$expected_real" ]
 }
 
 fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2600,9 +2600,10 @@ fm_backend_herdr_current_path() {  # <target>
     | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null
 }
 
-# fm_backend_herdr_prepare_relaunch_path: prepare an agent-free endpoint shell
-# for the exact recorded worktree already validated by the launch caller.
-# It first cancels any pending input while the same idle shell owns the pane,
+# fm_backend_herdr_prepare_relaunch_path: serialize shell preparation with every
+# other Firstmate mutation in the same Herdr session, then prepare an agent-free
+# endpoint shell for the exact recorded worktree already validated by the launch
+# caller. It first cancels any pending input while the same idle shell owns the pane,
 # including when the cwd already matches. Herdr's atomic `pane run` executes
 # `cd` non-persistently, so a mismatched cwd uses the interactive shell's
 # literal-input path and submits only after a second exact shell-owner check.
@@ -2621,7 +2622,7 @@ fm_backend_herdr_clear_idle_shell_input() {  # <target> <shell-pid>
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-keys "$FM_BACKEND_HERDR_PANE" ctrl+c >/dev/null 2>&1
 }
 
-fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
+fm_backend_herdr_prepare_relaunch_path_serialized() {  # <target> <validated-worktree>
   local target=$1 expected=$2 expected_real current current_real shell_pid resampled command quoted
   local attempt=0 max_attempts=${FM_BACKEND_HERDR_RELAUNCH_PATH_POLLS:-20}
   case "$expected" in
@@ -2705,6 +2706,32 @@ fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
   done
   echo "error: herdr endpoint did not converge to its exact recorded worktree '$expected_real'" >&2
   return 1
+}
+
+fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
+  local target=$1 expected=$2 session lock_path attempt=0 result
+  fm_backend_herdr_parse_target "$target" || return 1
+  session=$FM_BACKEND_HERDR_SESSION
+  if ! declare -F fm_lock_try_acquire >/dev/null 2>&1; then
+    # shellcheck source=bin/fm-wake-lib.sh
+    . "$FM_BACKEND_HERDR_ROOT/bin/fm-wake-lib.sh"
+  fi
+  lock_path=$(fm_backend_herdr_presentation_session_lock_path "$session") || {
+    echo "error: herdr relaunch could not resolve its session mutation lock; refusing unlocked shell input" >&2
+    return 1
+  }
+  while ! fm_lock_try_acquire "$lock_path"; do
+    attempt=$((attempt + 1))
+    [ "$attempt" -lt 50 ] || {
+      echo "error: herdr relaunch could not acquire its session mutation lock; refusing unlocked shell input" >&2
+      return 1
+    }
+    sleep 0.1
+  done
+  fm_backend_herdr_prepare_relaunch_path_serialized "$target" "$expected"
+  result=$?
+  fm_lock_release "$lock_path" || true
+  return "$result"
 }
 
 # fm_backend_herdr_send_text_line: send one line of TEXT then submit,

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -900,6 +900,35 @@ fm_backend_agent_state() {  # <backend> <target>
   esac
 }
 
+# fm_backend_recovery_agent_state: lifecycle-only state strong enough to stop
+# or replace an agent. Herdr cross-checks a retained native registration against
+# the exact foreground process, while tmux's ordinary classifier already owns
+# both process sources. Unsupported backends remain unverified.
+fm_backend_recovery_agent_state() {  # <backend> <target>
+  local backend=$1 target=$2
+  fm_backend_source "$backend" || { printf 'unverified'; return 0; }
+  case "$backend" in
+    tmux) fm_backend_tmux_agent_state "$target" ;;
+    herdr) fm_backend_herdr_recovery_agent_state "$target" ;;
+    *) printf 'unverified' ;;
+  esac
+}
+
+# fm_backend_prepare_relaunch_path: backend-owned preparation after the old
+# agent is positively stopped and before the launch owner reuses its endpoint.
+# Only Herdr needs repair because its restored shell can drift after an agent
+# exits; tmux keeps its existing strict path refusal unchanged.
+fm_backend_prepare_relaunch_path() {  # <backend> <target> <validated-worktree>
+  local backend=$1
+  shift
+  fm_backend_source "$backend" || return 1
+  case "$backend" in
+    herdr) fm_backend_herdr_prepare_relaunch_path "$@" ;;
+    tmux) return 0 ;;
+    *) echo "error: backend '$backend' has no verified relaunch-path preparation" >&2; return 1 ;;
+  esac
+}
+
 # Backward-compatible three-state view for existing callers. An
 # authoritatively missing endpoint is confidently not a live agent, while every
 # ambiguous, unreadable, or unverified result stays unknown.

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -316,7 +316,7 @@ fm_backend_validate "$BACKEND" || exit 1
 # --- shared helpers ---------------------------------------------------------
 
 agent_state() {
-  fm_backend_agent_state "$BACKEND" "$T"
+  fm_backend_recovery_agent_state "$BACKEND" "$T"
 }
 
 busy_verdict() {
@@ -690,7 +690,7 @@ resolve_relaunch_profile() {
 # refuses outright when any of it cannot be established.
 CHECKPOINT_LINES=()
 safe_checkpoint() {
-  local wt_real wt_top wt_top_real head head_ref head_ref_status status_output dirty children marker child_meta
+  local wt_real wt_top wt_top_real project project_real head head_ref head_ref_status status_output dirty children marker child_meta
   CHECKPOINT_LINES=()
   [ -n "$WT" ] || die "task $ID has no recorded worktree; refusing to relaunch without a recorded local copy to preserve"
   [ -d "$WT" ] || die "task $ID's recorded worktree $WT is missing; refusing to relaunch and lose track of its work"
@@ -700,6 +700,15 @@ safe_checkpoint() {
   wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P) || wt_top_real=$wt_top
   [ "$wt_real" = "$wt_top_real" ] \
     || die "task $ID's recorded worktree $WT is not a worktree root (root is $wt_top); refusing to relaunch against an ambiguous checkout"
+  if [ "$KIND" != secondmate ]; then
+    project=$(fm_meta_get "$META" project)
+    [ -n "$project" ] && [ -d "$project" ] \
+      || die "task $ID's recorded project '${project:-none}' is unavailable; refusing to relaunch without proving its isolated worktree"
+    project_real=$(CDPATH='' cd -- "$project" 2>/dev/null && pwd -P) \
+      || die "task $ID's recorded project $project cannot be resolved"
+    [ "$wt_real" != "$project_real" ] \
+      || die "task $ID's recorded worktree is the primary project checkout; refusing to relaunch an agent there"
+  fi
   if head=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null); then
     :
   elif head_ref=$(git -C "$WT" symbolic-ref -q HEAD 2>/dev/null); then
@@ -824,6 +833,9 @@ do_relaunch() {
   journal_write stopping "${CHECKPOINT_LINES[@]}" "$note_line"
   exit_result=$(do_exit)
   journal_write exited "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"
+
+  fm_backend_prepare_relaunch_path "$BACKEND" "$T" "$WT" \
+    || die "task $ID's agent stopped, but its endpoint could not be restored to the exact recorded worktree; refusing replacement launch"
 
   # The launch owner (fm-spawn --relaunch) clears the previous incarnation's
   # per-task harness wiring before arming the new one, so nothing to do here.

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -834,11 +834,11 @@ do_relaunch() {
   exit_result=$(do_exit)
   journal_write exited "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"
 
-  fm_backend_prepare_relaunch_path "$BACKEND" "$T" "$WT" \
-    || die "task $ID's agent stopped, but its endpoint could not be restored to the exact recorded worktree; refusing replacement launch"
-
-  # The launch owner (fm-spawn --relaunch) clears the previous incarnation's
-  # per-task harness wiring before arming the new one, so nothing to do here.
+  # The launch owner holds Herdr's session mutation lock continuously from
+  # endpoint preparation through replacement command submission. Preparing here
+  # would create an unlocked gap before that transaction begins.
+  # It also clears the previous incarnation's per-task harness wiring before
+  # arming the new one, so nothing to do here.
   RELAUNCH_TX="${BASHPID:-$$}.$(date -u +%Y%m%dT%H%M%SZ).$RANDOM"
   journal_write launching "${CHECKPOINT_LINES[@]}" "$note_line" "relaunch_tx=$RELAUNCH_TX"
   spawn_args=("$ID" --relaunch --harness "$TARGET_HARNESS")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2480,10 +2480,21 @@ kimi_spawn_fail() {  # <detail>
 
 if [ "$RELAUNCH" -eq 1 ]; then
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
-  fm_backend_prepare_relaunch_path "$BACKEND" "$WT_TARGET" "$WT" || {
-    echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
-    exit 1
-  }
+  if [ "$BACKEND" = herdr ]; then
+    spawn_herdr_presentation_order_lock_acquire "$SES" || {
+      echo "error: herdr relaunch could not acquire its session mutation lock; refusing unlocked replacement delivery" >&2
+      exit 1
+    }
+    fm_backend_herdr_prepare_relaunch_path_serialized "$WT_TARGET" "$WT" || {
+      echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
+      exit 1
+    }
+  else
+    fm_backend_prepare_relaunch_path "$BACKEND" "$WT_TARGET" "$WT" || {
+      echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
+      exit 1
+    }
+  fi
   # No worktree is acquired: the recorded one is reused as-is. What must be
   # proven instead is that the adopted endpoint's shell is actually sitting in
   # that worktree, so the replacement agent starts where the work is rather
@@ -3140,9 +3151,12 @@ spawn_send_literal "$T" "$LAUNCH"
 sleep 0.3
 if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   HERDR_PROJECTION_ABORT_CLEANUP=0
-  spawn_herdr_presentation_order_lock_release
 fi
 spawn_send_key "$T" Enter
+# A Herdr create or relaunch keeps the session mutation lock through command
+# submission, so no competing lifecycle input can separate launch bytes from
+# their Enter or redirect them after endpoint preparation.
+spawn_herdr_presentation_order_lock_release
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2479,6 +2479,7 @@ kimi_spawn_fail() {  # <detail>
 }
 
 if [ "$RELAUNCH" -eq 1 ]; then
+  [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
   fm_backend_prepare_relaunch_path "$BACKEND" "$WT_TARGET" "$WT" || {
     echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
     exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -733,6 +733,7 @@ HERDR_PROJECTION_ABORT_TASK_PANE=
 HERDR_PROJECTION_ABORT_SEEDED_PANE=
 HERDR_PRESENTATION_ORDER_LOCK=
 HERDR_PRESENTATION_ORDER_LOCK_HELD=0
+RELAUNCH_HERDR_SHELL_PID=
 SPAWN_TASK_LOCK=
 SPAWN_TASK_LOCK_HELD=0
 SPAWN_CONTROL_LOCK=
@@ -911,6 +912,12 @@ spawn_herdr_presentation_order_lock_acquire() {
     attempt=$((attempt + 1))
   done
   return 1
+}
+
+verify_herdr_relaunch_owner() {
+  [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ] || return 0
+  fm_backend_herdr_relaunch_shell_owned \
+    "$WT_TARGET" "$RELAUNCH_HERDR_SHELL_PID" "$WT"
 }
 
 clear_relaunch_harness_wiring() {
@@ -2489,6 +2496,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
       echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
       exit 1
     }
+    RELAUNCH_HERDR_SHELL_PID=$(fm_backend_herdr_relaunch_prepared_shell_pid)
   else
     fm_backend_prepare_relaunch_path "$BACKEND" "$WT_TARGET" "$WT" || {
       echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
@@ -3125,37 +3133,62 @@ spawn_record_traceparent() {
   return "$status"
 }
 
-# Export GOTMPDIR into the crewmate's pane shell so the agent and every child
-# process (go build, go test, ...) inherit it. Sent before the launch command so
-# the env is set when the agent starts; the brief sleep lets the export land.
-spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
-# Send through the exact channel that already ships GOTMPDIR, so every backend
-# and harness - ship, scout, and secondmate - gets it before launch. Skipped
-# entirely when trace context is off.
-if [ -n "$SPAWN_TRACEPARENT" ]; then
-  if spawn_send_text_line "$T" "export TRACEPARENT=$SPAWN_TRACEPARENT"; then
-    if ! spawn_record_traceparent; then
+# A reused Herdr shell gets its environment on the replacement command itself.
+# This leaves one owner-checked, atomic input operation after path preparation
+# instead of exposing separate export and launch boundaries to foreground drift.
+if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
+  LAUNCH="export GOTMPDIR=$(shell_quote "$TASK_TMP/gotmp"); $LAUNCH"
+  if [ -n "$SPAWN_TRACEPARENT" ]; then
+    if spawn_record_traceparent; then
+      LAUNCH="export TRACEPARENT=$(shell_quote "$SPAWN_TRACEPARENT"); $LAUNCH"
+    else
       LAUNCH="unset TRACEPARENT; $LAUNCH"
     fi
-  else
-    TRACE_SEND_STATUS=$?
-    if [ "$TRACE_SEND_STATUS" -eq 2 ]; then
-      echo "error: trace-context input could not be cleared for $W; refusing to append the launch command" >&2
-      exit 1
+  fi
+else
+  # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
+  # process (go build, go test, ...) inherit it. Sent before the launch command
+  # so the env is set when the agent starts.
+  spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
+  # Send through the exact channel that already ships GOTMPDIR, so every backend
+  # and harness gets trace context before launch when it is enabled.
+  if [ -n "$SPAWN_TRACEPARENT" ]; then
+    if spawn_send_text_line "$T" "export TRACEPARENT=$SPAWN_TRACEPARENT"; then
+      if ! spawn_record_traceparent; then
+        LAUNCH="unset TRACEPARENT; $LAUNCH"
+      fi
+    else
+      TRACE_SEND_STATUS=$?
+      if [ "$TRACE_SEND_STATUS" -eq 2 ]; then
+        echo "error: trace-context input could not be cleared for $W; refusing to append the launch command" >&2
+        exit 1
+      fi
+      LAUNCH="unset TRACEPARENT; $LAUNCH"
     fi
-    LAUNCH="unset TRACEPARENT; $LAUNCH"
   fi
 fi
 sleep 0.3
-spawn_send_literal "$T" "$LAUNCH"
-sleep 0.3
-if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
-  HERDR_PROJECTION_ABORT_CLEANUP=0
+verify_herdr_relaunch_owner || {
+  echo "error: task $ID's Herdr shell owner changed before launch delivery; refusing replacement launch" >&2
+  exit 1
+}
+if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
+  # pane run submits one command atomically, so an owner change cannot strand
+  # replacement bytes between the literal write and a later Enter.
+  spawn_send_text_line "$T" "$LAUNCH" || {
+    echo "error: task $ID's replacement launch command could not be submitted" >&2
+    exit 1
+  }
+else
+  spawn_send_literal "$T" "$LAUNCH"
+  sleep 0.3
+  if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
+    HERDR_PROJECTION_ABORT_CLEANUP=0
+  fi
+  spawn_send_key "$T" Enter
 fi
-spawn_send_key "$T" Enter
 # A Herdr create or relaunch keeps the session mutation lock through command
-# submission, so no competing lifecycle input can separate launch bytes from
-# their Enter or redirect them after endpoint preparation.
+# submission, so no competing lifecycle input can redirect prepared input.
 spawn_herdr_presentation_order_lock_release
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1147,7 +1147,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
     echo "error: backend '$BACKEND' has no recovery-grade agent-state classifier, so a relaunch cannot prove the previous agent exited; refusing rather than risking two agents in one endpoint" >&2
     exit 1
   }
-  RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
+  RELAUNCH_STATE=$(fm_backend_recovery_agent_state "$BACKEND" "$RELAUNCH_TARGET")
   [ "$RELAUNCH_STATE" = dead ] || {
     echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
     exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2479,6 +2479,10 @@ kimi_spawn_fail() {  # <detail>
 }
 
 if [ "$RELAUNCH" -eq 1 ]; then
+  fm_backend_prepare_relaunch_path "$BACKEND" "$WT_TARGET" "$WT" || {
+    echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
+    exit 1
+  }
   # No worktree is acquired: the recorded one is reused as-is. What must be
   # proven instead is that the adopted endpoint's shell is actually sitting in
   # that worktree, so the replacement agent starts where the work is rather

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -293,7 +293,8 @@ family_for_basename() {
     fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
     fm-tmux-agent-liveness.test.sh|\
     fm-control.test.sh|fm-control-relaunch.test.sh|\
-    fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|\
+    fm-herdr-relaunch-recovery.test.sh|fm-herdr-session-cleanup.test.sh|\
+    fm-send-resolve-key.test.sh|fm-send-strict.test.sh|\
     fm-send-inbox.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
@@ -589,6 +590,7 @@ tests/fm-guard-stale-banner.test.sh 11218
 tests/fm-harness-adapter-instructions-live-e2e.test.sh 20
 tests/fm-harness-adapter-references.test.sh 55
 tests/fm-harness-liveness-drift-live-e2e.test.sh 21
+tests/fm-herdr-relaunch-recovery.test.sh 1000
 tests/fm-herdr-session-cleanup.test.sh 6704
 tests/fm-herdr-submit-confirm-live-e2e.test.sh 23
 tests/fm-herdr-version-floor-live-e2e.test.sh 23
@@ -690,7 +692,7 @@ portable_serial_unhinted() {
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-unhinted.XXXXXX") || return 1
   portable_serial_weight_hints | awk 'NF { print $1 }' | LC_ALL=C sort -u >"$tmp/hinted"
   list_portable_serial | LC_ALL=C sort -u >"$tmp/serial"
-  comm -23 "$tmp/serial" "$tmp/hinted"
+  LC_ALL=C comm -23 "$tmp/serial" "$tmp/hinted"
   rm -rf "$tmp"
 }
 
@@ -838,8 +840,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -883,8 +885,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/serial_shards_raw" >"$tmp/serial_shards"
-  missing=$(comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
-  extra=$(comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable serial shards must equal the portable serial lane"
     [ -z "$missing" ] || { log "missing from serial shards:"; printf '%s\n' "$missing" >&2; }
@@ -896,7 +898,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -914,8 +916,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -945,7 +947,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -62,7 +62,7 @@ It is not deterministic across the verified adapters: codex and grok resume only
    A recorded raw-command basename that differs from its resolved adapter cannot reproduce the command actually running, so relaunch refuses before the checkpoint unless the caller passes an explicit `--harness` to choose the replacement runtime deliberately.
    A harness change resets model and effort unless they are named too, because a model chosen for one adapter does not transfer to another.
 2. **Safe checkpoint.**
-   The recorded worktree must exist and be a worktree root; its head and dirty state are recorded.
+   The recorded worktree must exist and be a worktree root; for a ship or scout it must also differ physically from the recorded primary project checkout, and its head and dirty state are recorded.
    For a `kind=secondmate` task, the home's identity marker must match and its child records must be readable, so a relaunch can never strand child work behind an unreadable home.
    A secondmate's own crewmates run in their own endpoints and outlive its relaunch; the relaunched secondmate reconciles them from its home's durable records at startup.
 3. **Record the note.**
@@ -70,10 +70,11 @@ It is not deterministic across the verified adapters: codex and grok resume only
    A secondmate relaunch does not require one and never rewrites its standing charter.
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
    Herdr lifecycle recovery corroborates a retained native registration against the exact foreground process, so a lone idle shell proves an exited agent while a non-shell process remains alive and an ambiguous process read refuses.
-5. **Restore the endpoint path where required.**
-   A Herdr pane can return to another directory after its agent exits, so the backend moves only its proved agent-free shell to the physical recorded worktree with literal quoted input, rechecks the same shell before submission, and verifies the resulting path.
-   Tmux needs no restoration and keeps its existing path check.
-6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+5. **Prepare the endpoint where required.**
+   A Herdr pane can retain unsubmitted shell input or return to another directory after its agent exits, so the backend first cancels pending input while the same proved agent-free shell owns the pane, even when its path already matches.
+   If the path differs, it then sends a literal quoted `cd`, rechecks the same shell before submission, clears its own buffered command on a pre-submission failure only while that shell still owns the pane, and verifies the resulting physical path.
+   Tmux needs no preparation and keeps its existing path check.
+6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which independently validates a ship or scout's recorded isolated worktree and repeats endpoint preparation before its first pane command, adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
 
@@ -103,8 +104,9 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
   zellij, orca, and cmux are refused rather than reported as successful blind.
 - An ambiguous or unreadable endpoint state refuses.
   Only a positively classified state acts.
-- `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
-- Herdr path restoration is reachable only after the recorded endpoint identity, isolated worktree root, project separation, and stopped-agent proof all pass; another path, a primary project checkout, a live foreground process, or an ambiguous process read refuses before launch.
+- `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell can be prepared and verified in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
+- Herdr endpoint preparation is reachable only after the recorded endpoint identity and stopped-agent proof pass, plus isolated-worktree-root and project-separation checks for a ship or scout; a direct `fm-spawn --relaunch` applies the same gates before sending any pane input.
+  A primary project checkout, live foreground process, ambiguous process read, or changed shell owner refuses before launch.
 
 ## Capability matrix
 
@@ -125,5 +127,5 @@ The empirical basis for each adapter's value is the `harness-adapters` skill's v
 
 - `tests/fm-control.test.sh` - the adapter contract for every verified harness, the backend capability matrix, exact-id scoping, the closed verb list, the busy, idle, dead, and idempotent lifecycle cases, and marker non-regression, all against a stubbed session provider.
 - `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, the progress note, checkpoint refusals, and rollback after a failed launch.
-- `tests/fm-herdr-relaunch-recovery.test.sh` - portable stale-registration, process-state, exact-path, quoting, idempotence, and cross-backend coverage.
+- `tests/fm-herdr-relaunch-recovery.test.sh` - portable stale-registration, process-state, exact-path, input-clearing, retry-cleanup, direct-launch validation, quoting, idempotence, and cross-backend coverage.
 - `tests/fm-control-herdr-smoke.test.sh` - stale-registration reconciliation and persistent path restoration against the real Herdr binary, on an isolated throwaway lab session.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -69,7 +69,11 @@ It is not deterministic across the verified adapters: codex and grok resume only
    A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation; the note is appended to the instructions it reads.
    A secondmate relaunch does not require one and never rewrites its standing charter.
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
-5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+   Herdr lifecycle recovery corroborates a retained native registration against the exact foreground process, so a lone idle shell proves an exited agent while a non-shell process remains alive and an ambiguous process read refuses.
+5. **Restore the endpoint path where required.**
+   A Herdr pane can return to another directory after its agent exits, so the backend moves only its proved agent-free shell to the physical recorded worktree with literal quoted input, rechecks the same shell before submission, and verifies the resulting path.
+   Tmux needs no restoration and keeps its existing path check.
+6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
 
@@ -100,6 +104,7 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
 - An ambiguous or unreadable endpoint state refuses.
   Only a positively classified state acts.
 - `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
+- Herdr path restoration is reachable only after the recorded endpoint identity, isolated worktree root, project separation, and stopped-agent proof all pass; another path, a primary project checkout, a live foreground process, or an ambiguous process read refuses before launch.
 
 ## Capability matrix
 
@@ -120,4 +125,5 @@ The empirical basis for each adapter's value is the `harness-adapters` skill's v
 
 - `tests/fm-control.test.sh` - the adapter contract for every verified harness, the backend capability matrix, exact-id scoping, the closed verb list, the busy, idle, dead, and idempotent lifecycle cases, and marker non-regression, all against a stubbed session provider.
 - `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, the progress note, checkpoint refusals, and rollback after a failed launch.
-- `tests/fm-control-herdr-smoke.test.sh` - the second state-verified backend against the real herdr binary, on an isolated throwaway lab session.
+- `tests/fm-herdr-relaunch-recovery.test.sh` - portable stale-registration, process-state, exact-path, quoting, idempotence, and cross-backend coverage.
+- `tests/fm-control-herdr-smoke.test.sh` - stale-registration reconciliation and persistent path restoration against the real Herdr binary, on an isolated throwaway lab session.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -71,10 +71,10 @@ It is not deterministic across the verified adapters: codex and grok resume only
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
    Herdr lifecycle recovery corroborates a retained native registration against the exact foreground process, so a lone idle shell proves an exited agent while a non-shell process remains alive and an ambiguous process read refuses.
 5. **Prepare the endpoint where required.**
-   A Herdr pane can retain unsubmitted shell input or return to another directory after its agent exits, so the backend first cancels pending input while the same proved agent-free shell owns the pane, even when its path already matches.
-   If the path differs, it then sends a literal quoted `cd`, rechecks the same shell before submission, clears its own buffered command on a pre-submission failure only while that shell still owns the pane, and verifies the resulting physical path.
+   A Herdr pane can retain unsubmitted shell input or return to another directory after its agent exits, so the launch owner takes the named-session mutation lock, cancels pending input while the same proved agent-free shell owns the pane, and keeps that lock through replacement command submission.
+   If the path differs, it sends a literal quoted `cd`, rechecks the same shell before submission, clears its own buffered command on a pre-submission failure only while that shell still owns the pane, and verifies the resulting physical path.
    Tmux needs no preparation and keeps its existing path check.
-6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which independently validates a ship or scout's recorded isolated worktree and repeats endpoint preparation before its first pane command, adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which independently validates a ship or scout's recorded isolated worktree, adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -275,8 +275,9 @@ Unlike tmux process-name inspection, native registration can classify Pi without
 Lifecycle control adds one process-level reconciliation because Herdr can retain Pi's native registration after Pi exits.
 A registered pane becomes agent-free for exit or replacement only when `pane process-info` and the operating-system process table prove the exact pane contains one lone idle recognized shell.
 A distinct foreground process group remains alive, and any contradictory or unreadable process evidence refuses recovery.
-After that proof, relaunch may return the same shell to the physical recorded worktree by sending a quoted `cd` through literal input, rechecking the same shell before Enter, and verifying the exact resulting foreground path.
-This backend-owned repair is idempotent and never selects a path itself; the control plane supplies the worktree only after validating the task endpoint, worktree root, and separation from the primary project copy.
+After that proof, relaunch cancels any pending input while that same idle shell owns the pane, including when its path already matches the recorded worktree.
+For a mismatched path it then sends a quoted `cd` through literal input, rechecks the same shell before Enter, clears its own buffered command after a pre-Enter failure only if that shell still owns the pane, and verifies the exact resulting foreground path.
+This backend-owned preparation is idempotent and never selects a path itself; both the control transaction and the shared launch owner validate the task endpoint, plus a ship or scout's worktree root and separation from the primary project copy, before any pane input.
 
 The session-start sweep uses the ordinary probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -275,8 +275,8 @@ Unlike tmux process-name inspection, native registration can classify Pi without
 Lifecycle control adds one process-level reconciliation because Herdr can retain Pi's native registration after Pi exits.
 A registered pane becomes agent-free for exit or replacement only when `pane process-info` and the operating-system process table prove the exact pane contains one lone idle recognized shell.
 A distinct foreground process group remains alive, and any contradictory or unreadable process evidence refuses recovery.
-After that proof, relaunch cancels any pending input while that same idle shell owns the pane, including when its path already matches the recorded worktree.
-For a mismatched path it then sends a quoted `cd` through literal input, rechecks the same shell before Enter, clears its own buffered command after a pre-Enter failure only if that shell still owns the pane, and verifies the exact resulting foreground path.
+After that proof, the launch owner takes the named-session mutation lock and cancels any pending input while that same idle shell owns the pane, including when its path already matches the recorded worktree.
+For a mismatched path it then sends a quoted `cd` through literal input, rechecks the same shell before Enter, clears its own buffered command after a pre-Enter failure only if that shell still owns the pane, verifies the exact resulting foreground path, and keeps the lock until the replacement launch command is submitted.
 This backend-owned preparation is idempotent and never selects a path itself; both the control transaction and the shared launch owner validate the task endpoint, plus a ship or scout's worktree root and separation from the primary project copy, before any pane input.
 
 The session-start sweep uses the ordinary probe.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -272,7 +272,13 @@ The generic Herdr agent-liveness probe reuses the same classifier.
 A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
 Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
 
-The session-start sweep uses this probe.
+Lifecycle control adds one process-level reconciliation because Herdr can retain Pi's native registration after Pi exits.
+A registered pane becomes agent-free for exit or replacement only when `pane process-info` and the operating-system process table prove the exact pane contains one lone idle recognized shell.
+A distinct foreground process group remains alive, and any contradictory or unreadable process evidence refuses recovery.
+After that proof, relaunch may return the same shell to the physical recorded worktree by sending a quoted `cd` through literal input, rechecking the same shell before Enter, and verifying the exact resulting foreground path.
+This backend-owned repair is idempotent and never selects a path itself; the control plane supplies the worktree only after validating the task endpoint, worktree root, and separation from the primary project copy.
+
+The session-start sweep uses the ordinary probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.
 
 ## Push events and polling fallback
@@ -331,6 +337,8 @@ Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never 
 
 ```sh
 tests/fm-backend-herdr.test.sh
+tests/fm-herdr-relaunch-recovery.test.sh
+tests/fm-control-herdr-smoke.test.sh
 tests/fm-composer-lib.test.sh
 tests/fm-herdr-submit-confirm-live-e2e.test.sh
 tests/fm-backend-herdr-smoke.test.sh

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -638,10 +638,11 @@ Polling remained active and is covered as the fallback for capability, connect, 
 
 ### Agent lifecycle control
 
-Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-08-08 on Herdr 0.8.0, and first measured 2026-08-02 on Herdr 0.7.5 with identical results:
+Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary.
+The retained-registration and path-restoration behavior was verified on 2026-09-04 with Herdr 0.8.2; the original registry-only lifecycle behavior was first measured on 2026-08-02 with Herdr 0.7.5.
 
 ```sh
-tests/fm-control-herdr-smoke.test.sh
+HERDR_LAB_HELPER=bin/fm-herdr-lab.sh tests/fm-control-herdr-smoke.test.sh
 ```
 
 Observed output:
@@ -649,13 +650,16 @@ Observed output:
 ```text
 ok - real herdr: exit on a pane with no registered agent is idempotent success
 ok - real herdr: interrupt refuses when herdr's own agent registry reports no agent
-ok - real herdr: interrupt delivers the harness's key and proves the agent survived it
+ok - real herdr: lifecycle recovery reconciles a retained registration after the agent process exits
+ok - real herdr: an agent-free pane shell returns persistently to the exact recorded worktree
+ok - real herdr: a non-shell foreground process remains live and cannot be replaced
 ok - real herdr: no control verb removed the endpoint or the task's local copy
-ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
+ok - real herdr: an agent process that does not stop fails closed instead of being reported as stopped
 ```
 
-The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
-That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
+The smoke test registers a stale Pi lifecycle report over a real idle shell, drives a persistent path mismatch and restoration, then places a real non-shell process group in the pane to prove that the same registration remains live and refuses replacement.
+`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable quoting, injection, idempotence, ambiguous-state, live-process, and non-Herdr regression coverage.
+The smoke command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
 ### Away-mode transport
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -658,7 +658,7 @@ ok - real herdr: an agent process that does not stop fails closed instead of bei
 ```
 
 The smoke test registers a stale Pi lifecycle report over a real idle shell, drives a persistent path mismatch and restoration, then places a real non-shell process group in the pane to prove that the same registration remains live and refuses replacement.
-`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable quoting, injection, pending-input cancellation, pre-Enter retry cleanup, direct-launch validation, idempotence, ambiguous-state, live-process, and non-Herdr regression coverage.
+`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable quoting, injection, pending-input cancellation, pre-Enter retry cleanup, direct-launch validation, preparation-through-launch mutation serialization, idempotence, ambiguous-state, live-process, and non-Herdr regression coverage.
 The smoke command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
 ### Away-mode transport

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -658,7 +658,7 @@ ok - real herdr: an agent process that does not stop fails closed instead of bei
 ```
 
 The smoke test registers a stale Pi lifecycle report over a real idle shell, drives a persistent path mismatch and restoration, then places a real non-shell process group in the pane to prove that the same registration remains live and refuses replacement.
-`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable quoting, injection, idempotence, ambiguous-state, live-process, and non-Herdr regression coverage.
+`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable quoting, injection, pending-input cancellation, pre-Enter retry cleanup, direct-launch validation, idempotence, ambiguous-state, live-process, and non-Herdr regression coverage.
 The smoke command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
 ### Away-mode transport

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -155,7 +155,7 @@ pass "real herdr: an agent-free pane shell returns persistently to the exact rec
 # A different foreground process group makes the same registration live again.
 # This is the structural refusal that prevents a genuine agent process from
 # being mistaken for the shell-only stale-registration case.
-lab pane send-text "$PANE_ID" 'sleep 30' >/dev/null 2>&1 \
+lab pane send-text "$PANE_ID" "sh -c 'trap \"\" INT; while :; do sleep 1; done'" >/dev/null 2>&1 \
   || fail "could not type the foreground-process fixture"
 lab pane send-keys "$PANE_ID" enter >/dev/null 2>&1 \
   || fail "could not start the foreground-process fixture"

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -9,9 +9,9 @@
 # an agent is running, and therefore whether a lifecycle verb may act at all,
 # comes from herdr's own agent registry.
 #
-# No real agent is launched. herdr's `pane report-agent` is the same registry
-# the adapter reads, so registering and not registering an agent on a plain
-# shell pane exercises exactly the classification the control plane gates on.
+# No real harness is launched. Herdr's `pane report-agent` models the retained
+# registry entry left after Pi exits, while a real foreground process group
+# independently models the non-shell ownership that must remain live.
 #
 # Always runs on a private, named, throwaway lab session, never the default
 # one (tests/herdr-test-safety.sh; the 2026-07-02 incident). Skips cleanly
@@ -30,15 +30,26 @@ command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the her
 . "$ROOT/tests/herdr-test-safety.sh"
 herdr_forget_inherited_pane
 
-SESSION="fm-lab-control-smoke-$$"
-export HERDR_SESSION="$SESSION"
+HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+SESSION=
 SCRATCH=
+PROVISIONED=0
 cleanup_all() {
   [ -n "$SCRATCH" ] && rm -rf "$SCRATCH"
-  herdr_safe_stop_and_delete "$SESSION"
+  if [ "$PROVISIONED" -ne 0 ]; then
+    PROVISIONED=0
+    "$HERDR_LAB_HELPER" teardown "$SESSION"
+  fi
 }
 trap cleanup_all EXIT
-fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+SESSION=$("$HERDR_LAB_HELPER" name control-herdr-smoke) || fail "could not name isolated Herdr lab session"
+export HERDR_SESSION="$SESSION"
+"$HERDR_LAB_HELPER" provision "$SESSION" || fail "could not provision isolated Herdr lab session"
+PROVISIONED=1
+
+lab() {
+  "$HERDR_LAB_HELPER" run "$SESSION" "$@"
+}
 
 SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-control-herdr.XXXXXX")
 SCRATCH=$(cd "$SCRATCH" && pwd)
@@ -113,37 +124,65 @@ case "$OUT" in
 esac
 pass "real herdr: interrupt refuses when herdr's own agent registry reports no agent"
 
-# --- a registered agent: classification flips, and the verbs follow ---------
+# --- a retained registration over the shell is stale for lifecycle recovery -
 
-herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-smoke-agent \
-  --state idle --session "$SESSION" >/dev/null 2>&1 \
-  || fail "could not register a live agent on the task pane"
+lab pane report-agent "$PANE_ID" --source fm-control-smoke --agent pi \
+  --state idle >/dev/null 2>&1 \
+  || fail "could not register the retained-agent fixture on the task pane"
 
 STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
-[ "$STATE" = alive ] || fail "herdr should classify a registered agent as alive, got '$STATE'"
+[ "$STATE" = alive ] || fail "the ordinary registry view should preserve the registered state, got '$STATE'"
+STATE=$(fm_backend_recovery_agent_state herdr "$SESSION:$PANE_ID")
+[ "$STATE" = dead ] || fail "lifecycle recovery should reconcile a retained registration over an idle shell, got '$STATE'"
+OUT=$(run_control hsmoke exit) || fail "exit should reconcile the stale registration as already stopped: $OUT"
+case "$OUT" in
+  "already-stopped hsmoke"*) : ;;
+  *) fail "a stale registered-agent report over the shell should be already stopped, got: $OUT" ;;
+esac
+pass "real herdr: lifecycle recovery reconciles a retained registration after the agent process exits"
 
-OUT=$(run_control hsmoke interrupt) || fail "interrupt against a registered agent should succeed: $OUT"
+lab pane send-text "$PANE_ID" 'cd /' >/dev/null 2>&1 \
+  || fail "could not drift the agent-free pane for path-restoration coverage"
+lab pane send-keys "$PANE_ID" enter >/dev/null 2>&1 \
+  || fail "could not submit the path-drift fixture"
+sleep 0.2
+fm_backend_prepare_relaunch_path herdr "$SESSION:$PANE_ID" "$WT" \
+  || fail "the backend could not restore the agent-free pane to its recorded worktree"
+SEEN=$(fm_backend_herdr_current_path "$SESSION:$PANE_ID")
+[ "$SEEN" = "$WT" ] || fail "the restored pane path should be '$WT', got '$SEEN'"
+pass "real herdr: an agent-free pane shell returns persistently to the exact recorded worktree"
+
+# A different foreground process group makes the same registration live again.
+# This is the structural refusal that prevents a genuine agent process from
+# being mistaken for the shell-only stale-registration case.
+lab pane send-text "$PANE_ID" 'sleep 30' >/dev/null 2>&1 \
+  || fail "could not type the foreground-process fixture"
+lab pane send-keys "$PANE_ID" enter >/dev/null 2>&1 \
+  || fail "could not start the foreground-process fixture"
+sleep 0.5
+STATE=$(fm_backend_recovery_agent_state herdr "$SESSION:$PANE_ID")
+[ "$STATE" = alive ] || fail "a registered non-shell foreground process should remain alive, got '$STATE'"
+
+OUT=$(run_control hsmoke interrupt) || fail "interrupt against a registered foreground process should succeed: $OUT"
 case "$OUT" in
   *"interrupt-delivered hsmoke harness=claude backend=herdr verified=agent-alive cancel=unconfirmed"*) : ;;
   *) fail "interrupt should report the agent-alive proof on herdr, got: $OUT" ;;
 esac
-pass "real herdr: interrupt delivers the harness's key and proves the agent survived it"
+pass "real herdr: a non-shell foreground process remains live and cannot be replaced"
 
-herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
+lab pane get "$PANE_ID" >/dev/null 2>&1 \
   || fail "the control plane must never remove the endpoint it was operating on"
 [ -d "$WT" ] || fail "the control plane must never remove the task's local copy"
 pass "real herdr: no control verb removed the endpoint or the task's local copy"
 
-# Last, because it deliberately types a harness command into a pane that hosts
-# a plain shell: the registered agent cannot actually be stopped that way, and
-# the control plane must say so rather than report a stop it did not achieve.
+# The registered process is not a harness and cannot consume the exit command.
+# The control plane must therefore report that it did not stop rather than
+# converting the still-live foreground process into success.
 if OUT=$(run_control hsmoke exit 2>&1); then
-  fail "exit should fail closed when the agent does not stop: $OUT"
+  fail "exit should fail closed when the foreground process does not stop: $OUT"
 fi
 case "$OUT" in
   *"did not stop"*) : ;;
-  *) fail "the exit failure should say the agent did not stop, got: $OUT" ;;
+  *) fail "the exit failure should say the foreground process did not stop, got: $OUT" ;;
 esac
-pass "real herdr: an agent that does not stop fails closed instead of being reported as stopped"
-
-fm_backend_herdr_kill "$SESSION:$PANE_ID" 2>/dev/null || true
+pass "real herdr: an agent process that does not stop fails closed instead of being reported as stopped"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -912,6 +912,22 @@ test_missing_worktree_refuses_before_stopping_anything() {
   pass "fm-control relaunch: an unaccountable local copy refuses before the agent is touched"
 }
 
+test_primary_checkout_refuses_before_stopping_anything() {
+  local dir out rc
+  dir=$(new_case primary-checkout rl36)
+  add_ship_task "$dir" rl36 claude
+  awk -v wt="$dir/proj" '/^worktree=/{print "worktree=" wt; next} {print}' \
+    "$dir/home/state/rl36.meta" > "$dir/home/state/rl36.meta.tmp"
+  mv "$dir/home/state/rl36.meta.tmp" "$dir/home/state/rl36.meta"
+  printf '%s' "$dir/proj" > "$dir/fake/cwd"
+  out=$(run_control "$dir" rl36 relaunch --note "x"); rc=$?
+  expect_code 1 "$rc" "the primary checkout must refuse before any lifecycle action"
+  assert_contains "$out" "primary project checkout" "the refusal should name the unsafe launch location"
+  [ "$(cat "$dir/fake/command")" = claude ] || fail "a primary-checkout refusal must not stop the agent"
+  [ -z "$(cat "$dir/fake/literal")" ] || fail "a primary-checkout refusal must send nothing"
+  pass "fm-control relaunch: the checkpoint refuses a primary-checkout launch before touching the agent"
+}
+
 test_missing_instructions_refuse_before_stopping_anything() {
   local dir out rc
   dir=$(new_case nobrief rl11)
@@ -1510,6 +1526,7 @@ test_prefixed_prior_harness_wiring_is_still_retired
 test_muse_session_binding_is_retired_on_a_harness_switch
 test_cursor_session_binding_is_retired_on_a_harness_switch
 test_missing_worktree_refuses_before_stopping_anything
+test_primary_checkout_refuses_before_stopping_anything
 test_missing_instructions_refuse_before_stopping_anything
 test_checkpoint_refusal_leaves_the_record_byte_identical
 test_checkpoint_refuses_uninspectable_head_and_status

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -54,6 +54,11 @@ case "${1:-} ${2:-}" in
       if [ "$1" = --pane ]; then pane=${2:-}; break; fi
       shift
     done
+    if [ "$(jq -r '.process_info_failures // 0' "$state")" -gt 0 ]; then
+      jq '.process_info_failures -= 1' "$state" | save_state
+      printf '{"id":"cli:pane:process_info","result":{"type":"pane_process_info","process_info":{"pane_id":"wrong"}}}\n'
+      exit 0
+    fi
     mode=$(jq -r '.process' "$state")
     case "$mode" in
       shell)
@@ -67,11 +72,17 @@ case "${1:-} ${2:-}" in
     ;;
   "pane send-text")
     text=${4:-}
-    jq --arg text "$text" '.pending=$text' "$state" | save_state
+    jq --arg text "$text" '
+      .pending=((.pending // "") + $text)
+      | if .fail_after_send_once then .fail_after_send_once=false | .process_info_failures=1 else . end
+      | if ((.process_after_send // "") != "") then .process=.process_after_send else . end
+    ' "$state" | save_state
     ;;
   "pane send-keys")
     key=${4:-}
-    if [ "$key" = enter ]; then
+    if [ "$key" = ctrl+c ]; then
+      jq '.pending=""' "$state" | save_state
+    elif [ "$key" = enter ]; then
       pending=$(jq -r '.pending // empty' "$state")
       cwd=$(jq -r '.cwd' "$state")
       if [ -n "$pending" ]; then
@@ -97,7 +108,7 @@ chmod +x "$TMP_ROOT/fakebin/ps"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
-    '{cwd:$cwd,process:$process,registered:$registered,pending:""}' > "$STATE"
+    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:""}' > "$STATE"
   : > "$LOG"
 }
 
@@ -144,6 +155,34 @@ run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
 count_after=$(grep -c $'\x1fpane\x1fsend-text\x1f' "$LOG" || true)
 [ "$count_after" -eq "$count_before" ] || fail "idempotent path preparation submitted a second cd command"
 pass "Herdr relaunch recovery: exact path restoration is persistent, quoted, and idempotent"
+
+BUFFERED_MARKER="$TMP_ROOT/buffered-marker"
+write_state "$OLD" shell true
+jq --arg pending "touch '$BUFFERED_MARKER'; " '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
+  || fail "path restoration should clear preexisting idle-shell input before submitting"
+[ ! -e "$BUFFERED_MARKER" ] || fail "path restoration executed preexisting buffered shell input"
+[ "$(jq -r '.cwd' "$STATE")" = "$TARGET" ] || fail "path restoration lost the recorded path after clearing buffered input"
+pass "Herdr relaunch recovery: preexisting shell input is cancelled before path restoration"
+
+write_state "$OLD" shell true
+jq '.fail_after_send_once=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then
+  fail "a transient post-send process inspection failure should abort path restoration"
+fi
+[ -z "$(jq -r '.pending // empty' "$STATE")" ] || fail "failed path restoration left its command buffered for a retry"
+run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
+  || fail "path restoration should retry cleanly after post-send cleanup"
+[ "$(jq -r '.cwd' "$STATE")" = "$TARGET" ] || fail "the clean retry did not restore the recorded path"
+pass "Herdr relaunch recovery: pre-submit failures clean their buffered command for retry"
+
+write_state "$OLD" shell true
+jq '.process_after_send="live"' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then
+  fail "path restoration should refuse when the shell owner changes after typing"
+fi
+[ -n "$(jq -r '.pending // empty' "$STATE")" ] || fail "cleanup sent input after the pane stopped belonging to the exact idle shell"
+pass "Herdr relaunch recovery: cleanup refuses a changed shell owner"
 
 write_state "$OLD" live true
 if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -84,6 +84,7 @@ case "${1:-} ${2:-}" in
     ;;
   "pane run")
     text=${4:-}
+    sleep "${FM_FAKE_HERDR_RUN_DELAY:-0}"
     pending=$(jq -r '.pending // empty' "$state")
     cwd=$(jq -r '.cwd' "$state")
     new_cwd=$(cd "$cwd" && bash -c "$pending$text; pwd -P") || exit 1
@@ -272,6 +273,44 @@ DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR
 [ ! -e "$DIRECT_MARKER" ] || fail "direct Herdr relaunch executed buffered shell input before launch"
 case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "direct Herdr relaunch did not complete: $DIRECT_OUT" ;; esac
 pass "fm-spawn relaunch: direct Herdr entry prepares buffered shell input"
+
+write_state "$DIRECT_WT" shell true
+DIRECT_CONCURRENT_OUT="$TMP_ROOT/direct-concurrent.out"
+PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+  FM_FAKE_HERDR_RUN_DELAY=0.5 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude > "$DIRECT_CONCURRENT_OUT" 2>&1 &
+direct_pid=$!
+direct_started=0
+for _ in {1..100}; do
+  if grep -q $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG"; then
+    direct_started=1
+    break
+  fi
+  sleep 0.01
+done
+[ "$direct_started" -eq 1 ] || fail "the direct relaunch did not reach endpoint preparation"
+session_reads_before=$(grep -c $'\x1fsession\x1flist\x1f' "$LOG" || true)
+run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$DIRECT_WT" &
+competitor_pid=$!
+competitor_started=0
+for _ in {1..100}; do
+  session_reads=$(grep -c $'\x1fsession\x1flist\x1f' "$LOG" || true)
+  if [ "$session_reads" -gt "$session_reads_before" ]; then
+    competitor_started=1
+    break
+  fi
+  sleep 0.01
+done
+[ "$competitor_started" -eq 1 ] || fail "the competing pane mutation did not reach the session lock"
+sleep 0.05
+clear_count=$(grep -c $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG" || true)
+[ "$clear_count" -eq 1 ] || fail "a competing pane mutation entered between relaunch preparation and command submission"
+wait "$direct_pid" || fail "the serialized direct relaunch failed: $(cat "$DIRECT_CONCURRENT_OUT")"
+wait "$competitor_pid" || fail "the competing path preparation did not resume after launch submission"
+clear_count=$(grep -c $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG" || true)
+[ "$clear_count" -eq 2 ] || fail "the competing pane mutation did not run after relaunch submission"
+pass "fm-spawn relaunch: Herdr session mutation lock spans preparation through launch submission"
 
 awk -v wt="$DIRECT_PROJECT" '/^worktree=/{print "worktree=" wt; next} {print}' \
   "$DIRECT_HOME/state/direct.meta" > "$DIRECT_HOME/state/direct.meta.tmp"

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -245,6 +245,22 @@ DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR
 case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "direct Herdr relaunch did not complete: $DIRECT_OUT" ;; esac
 pass "fm-spawn relaunch: direct Herdr entry prepares buffered shell input"
 
+awk -v wt="$DIRECT_PROJECT" '/^worktree=/{print "worktree=" wt; next} {print}' \
+  "$DIRECT_HOME/state/direct.meta" > "$DIRECT_HOME/state/direct.meta.tmp"
+mv "$DIRECT_HOME/state/direct.meta.tmp" "$DIRECT_HOME/state/direct.meta"
+INVALID_PENDING="touch '$TMP_ROOT/invalid-primary-marker'; "
+write_state "$DIRECT_PROJECT" shell true
+jq --arg pending "$INVALID_PENDING" '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    FM_SPAWN_NO_GUARD=1 "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1); then
+  fail "direct Herdr relaunch should reject the primary checkout: $DIRECT_OUT"
+fi
+[ "$(jq -r '.pending' "$STATE")" = "$INVALID_PENDING" ] || fail "invalid-worktree relaunch sent input before refusing"
+! awk -F '\x1f' '$2 == "pane" && ($3 == "send-text" || $3 == "send-keys" || $3 == "run") {found=1} END {exit !found}' "$LOG" \
+  || fail "invalid-worktree relaunch issued a pane input command"
+pass "fm-spawn relaunch: invalid recorded worktrees refuse before pane input"
+
 write_state "$OLD" live true
 if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then
   fail "path restoration must refuse while a real foreground agent remains"

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -36,6 +36,10 @@ case "${1:-} ${2:-}" in
   "status --json")
     printf '{"client":{"version":"0.8.0","protocol":19},"server":{"running":true}}\n'
     ;;
+  "session list")
+    socket=${FM_FAKE_HERDR_SOCKET:-$(dirname "$state")/herdr.sock}
+    jq -n --arg socket "$socket" '{sessions:[{name:"fmtest",running:true,socket_path:$socket}]}'
+    ;;
   "pane get")
     pane=${3:-}
     jq --arg pane "$pane" '{id:"cli:pane:get",result:{type:"pane_info",pane:{pane_id:$pane,foreground_cwd:.cwd}}}' "$state"
@@ -88,6 +92,7 @@ case "${1:-} ${2:-}" in
   "pane send-keys")
     key=${4:-}
     if [ "$key" = ctrl+c ]; then
+      sleep "${FM_FAKE_HERDR_CLEAR_DELAY:-0}"
       jq '.pending=""' "$state" | save_state
     elif [ "$key" = enter ]; then
       pending=$(jq -r '.pending // empty' "$state")
@@ -127,7 +132,8 @@ write_state() {
 
 run_backend() {
   PATH="$TMP_ROOT/fakebin:$PATH" \
-    FM_FAKE_HERDR_STATE="$STATE" FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" \
+    FM_FAKE_HERDR_STATE="$STATE" FM_FAKE_HERDR_LOG="$LOG" FM_FAKE_HERDR_SOCKET="$TMP_ROOT/herdr.sock" \
+    FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" \
     FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
     bash -c '. "$0/bin/fm-backend.sh"; "$@"' "$ROOT" "$@"
 }
@@ -186,6 +192,28 @@ run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
 [ ! -e "$BUFFERED_MARKER" ] || fail "path restoration executed preexisting buffered shell input"
 [ "$(jq -r '.cwd' "$STATE")" = "$TARGET" ] || fail "path restoration lost the recorded path after clearing buffered input"
 pass "Herdr relaunch recovery: preexisting shell input is cancelled before path restoration"
+
+write_state "$OLD" shell true
+FM_FAKE_HERDR_CLEAR_DELAY=0.2 run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" &
+first_pid=$!
+first_started=0
+for _ in {1..100}; do
+  if grep -q $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG"; then
+    first_started=1
+    break
+  fi
+  sleep 0.01
+done
+[ "$first_started" -eq 1 ] || fail "the first concurrent path preparation did not reach its mutation boundary"
+FM_FAKE_HERDR_CLEAR_DELAY=0.2 run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" &
+second_pid=$!
+wait "$first_pid" || fail "the first concurrent path preparation failed"
+wait "$second_pid" || fail "the second concurrent path preparation failed"
+mutation_order=$(awk -F '\x1f' '$2 == "pane" && $3 == "send-text" {print "send-text"; next} $2 == "pane" && $3 == "send-keys" {print $3 ":" $5}' "$LOG")
+expected_order=$'send-keys:ctrl+c\nsend-text\nsend-keys:enter\nsend-keys:ctrl+c'
+[ "$mutation_order" = "$expected_order" ] \
+  || fail "concurrent path preparations interleaved their pane mutations: $mutation_order"
+pass "Herdr relaunch recovery: concurrent preparation is serialized at the pane mutation boundary"
 
 write_state "$OLD" shell true
 jq '.fail_after_send_once=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -43,6 +43,10 @@ case "${1:-} ${2:-}" in
   "pane get")
     pane=${3:-}
     jq --arg pane "$pane" '{id:"cli:pane:get",result:{type:"pane_info",pane:{pane_id:$pane,foreground_cwd:.cwd}}}' "$state"
+    jq '
+      .pane_gets=((.pane_gets // 0) + 1)
+      | if .pane_gets == (.take_over_after_pane_get // -1) then .process="live" else . end
+    ' "$state" | save_state
     ;;
   "agent get")
     pane=${3:-}
@@ -121,13 +125,16 @@ chmod +x "$TMP_ROOT/fakebin/ps"
 
 cat > "$TMP_ROOT/fakebin/claude" <<'SH'
 #!/usr/bin/env bash
+if [ -n "${FM_FAKE_CLAUDE_ENV_LOG:-}" ]; then
+  printf 'GOTMPDIR=%s\n' "${GOTMPDIR:-}" > "$FM_FAKE_CLAUDE_ENV_LOG"
+fi
 exit 0
 SH
 chmod +x "$TMP_ROOT/fakebin/claude"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
-    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:""}' > "$STATE"
+    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1}' > "$STATE"
   : > "$LOG"
 }
 
@@ -239,6 +246,7 @@ DIRECT_HOME="$TMP_ROOT/direct-home"
 DIRECT_PROJECT="$TMP_ROOT/direct-project"
 DIRECT_WT="$TMP_ROOT/direct-worktree"
 DIRECT_MARKER="$TMP_ROOT/direct-marker"
+DIRECT_ENV_LOG="$TMP_ROOT/direct-env.log"
 fm_git_worktree "$DIRECT_PROJECT" "$DIRECT_WT" direct-relaunch
 mkdir -p "$DIRECT_HOME/state" "$DIRECT_HOME/data/direct"
 cat > "$DIRECT_HOME/data/direct/brief.md" <<'EOF'
@@ -268,11 +276,26 @@ write_state "$DIRECT_WT" shell true
 jq --arg pending "touch '$DIRECT_MARKER'; " '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
   FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+  FM_FAKE_CLAUDE_ENV_LOG="$DIRECT_ENV_LOG" \
   FM_SPAWN_NO_GUARD=1 "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1) \
   || fail "direct Herdr relaunch should prepare its endpoint before launch: $DIRECT_OUT"
 [ ! -e "$DIRECT_MARKER" ] || fail "direct Herdr relaunch executed buffered shell input before launch"
+[ "$(cat "$DIRECT_ENV_LOG" 2>/dev/null)" = "GOTMPDIR=/tmp/fm-direct/gotmp" ] \
+  || fail "direct Herdr relaunch did not deliver its environment with the atomic launch command"
 case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "direct Herdr relaunch did not complete: $DIRECT_OUT" ;; esac
 pass "fm-spawn relaunch: direct Herdr entry prepares buffered shell input"
+
+write_state "$DIRECT_WT" shell true
+jq '.take_over_after_pane_get=6' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    FM_SPAWN_NO_GUARD=1 "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1); then
+  fail "direct Herdr relaunch should refuse after foreground ownership changes: $DIRECT_OUT"
+fi
+run_count=$(grep -c $'\x1fpane\x1frun\x1f' "$LOG" || true)
+[ "$run_count" -eq 0 ] || fail "owner-change refusal sent input after foreground ownership changed"
+case "$DIRECT_OUT" in *"shell owner changed before launch delivery"*) : ;; *) fail "owner-change refusal was not explicit: $DIRECT_OUT" ;; esac
+pass "fm-spawn relaunch: foreground-owner change before launch delivery fails closed"
 
 write_state "$DIRECT_WT" shell true
 DIRECT_CONCURRENT_OUT="$TMP_ROOT/direct-concurrent.out"

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -78,6 +78,13 @@ case "${1:-} ${2:-}" in
       | if ((.process_after_send // "") != "") then .process=.process_after_send else . end
     ' "$state" | save_state
     ;;
+  "pane run")
+    text=${4:-}
+    pending=$(jq -r '.pending // empty' "$state")
+    cwd=$(jq -r '.cwd' "$state")
+    new_cwd=$(cd "$cwd" && bash -c "$pending$text; pwd -P") || exit 1
+    jq --arg cwd "$new_cwd" '.cwd=$cwd | .pending=""' "$state" | save_state
+    ;;
   "pane send-keys")
     key=${4:-}
     if [ "$key" = ctrl+c ]; then
@@ -105,6 +112,12 @@ case "$*" in
 esac
 SH
 chmod +x "$TMP_ROOT/fakebin/ps"
+
+cat > "$TMP_ROOT/fakebin/claude" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$TMP_ROOT/fakebin/claude"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
@@ -156,6 +169,15 @@ count_after=$(grep -c $'\x1fpane\x1fsend-text\x1f' "$LOG" || true)
 [ "$count_after" -eq "$count_before" ] || fail "idempotent path preparation submitted a second cd command"
 pass "Herdr relaunch recovery: exact path restoration is persistent, quoted, and idempotent"
 
+EXACT_MARKER="$TMP_ROOT/exact-cwd-marker"
+write_state "$TARGET" shell true
+jq --arg pending "touch '$EXACT_MARKER'; " '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
+  || fail "exact-cwd preparation should still clear pending shell input"
+[ ! -e "$EXACT_MARKER" ] || fail "exact-cwd preparation executed preexisting buffered shell input"
+[ -z "$(jq -r '.pending // empty' "$STATE")" ] || fail "exact-cwd preparation left shell input buffered"
+pass "Herdr relaunch recovery: exact-cwd preparation still clears shell input"
+
 BUFFERED_MARKER="$TMP_ROOT/buffered-marker"
 write_state "$OLD" shell true
 jq --arg pending "touch '$BUFFERED_MARKER'; " '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
@@ -183,6 +205,45 @@ if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/d
 fi
 [ -n "$(jq -r '.pending // empty' "$STATE")" ] || fail "cleanup sent input after the pane stopped belonging to the exact idle shell"
 pass "Herdr relaunch recovery: cleanup refuses a changed shell owner"
+
+DIRECT_HOME="$TMP_ROOT/direct-home"
+DIRECT_PROJECT="$TMP_ROOT/direct-project"
+DIRECT_WT="$TMP_ROOT/direct-worktree"
+DIRECT_MARKER="$TMP_ROOT/direct-marker"
+fm_git_worktree "$DIRECT_PROJECT" "$DIRECT_WT" direct-relaunch
+mkdir -p "$DIRECT_HOME/state" "$DIRECT_HOME/data/direct"
+cat > "$DIRECT_HOME/data/direct/brief.md" <<'EOF'
+# Task
+## Captain's intent
+Resume the existing worker safely.
+
+## Firstmate spec
+Relaunch in the recorded worktree.
+EOF
+cat > "$DIRECT_HOME/state/direct.meta" <<EOF
+window=fmtest:w1:p1
+endpoint_task_id=direct
+worktree=$DIRECT_WT
+project=$DIRECT_PROJECT
+harness=claude
+kind=ship
+mode=no-mistakes
+yolo=off
+backend=herdr
+herdr_session=fmtest
+herdr_workspace_id=w1
+herdr_tab_id=w1:t1
+herdr_pane_id=w1:p1
+EOF
+write_state "$DIRECT_WT" shell true
+jq --arg pending "touch '$DIRECT_MARKER'; " '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+  FM_SPAWN_NO_GUARD=1 "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1) \
+  || fail "direct Herdr relaunch should prepare its endpoint before launch: $DIRECT_OUT"
+[ ! -e "$DIRECT_MARKER" ] || fail "direct Herdr relaunch executed buffered shell input before launch"
+case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "direct Herdr relaunch did not complete: $DIRECT_OUT" ;; esac
+pass "fm-spawn relaunch: direct Herdr entry prepares buffered shell input"
 
 write_state "$OLD" live true
 if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Portable regression coverage for Herdr lifecycle recovery after an agent exits.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-herdr-relaunch-recovery)
+mkdir -p "$TMP_ROOT/fakebin"
+STATE="$TMP_ROOT/herdr.json"
+LOG="$TMP_ROOT/herdr.log"
+: > "$LOG"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+cat > "$TMP_ROOT/fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+state=${FM_FAKE_HERDR_STATE:?}
+log=${FM_FAKE_HERDR_LOG:?}
+{
+  printf 'call'
+  for arg in "$@"; do printf '\x1f%s' "$arg"; done
+  printf '\n'
+} >> "$log"
+
+save_state() {
+  local tmp="$state.tmp.$$"
+  cat > "$tmp" && mv "$tmp" "$state"
+}
+
+case "${1:-} ${2:-}" in
+  "status --json")
+    printf '{"client":{"version":"0.8.0","protocol":19},"server":{"running":true}}\n'
+    ;;
+  "pane get")
+    pane=${3:-}
+    jq --arg pane "$pane" '{id:"cli:pane:get",result:{type:"pane_info",pane:{pane_id:$pane,foreground_cwd:.cwd}}}' "$state"
+    ;;
+  "agent get")
+    pane=${3:-}
+    if [ "$(jq -r '.registered' "$state")" = true ]; then
+      jq --arg pane "$pane" '{id:"cli:agent:get",result:{type:"agent_info",agent:{pane_id:$pane,agent:"pi",agent_status:"idle"}}}' "$state"
+    else
+      printf '{"id":"cli:agent:get","error":{"code":"agent_not_found"}}\n'
+    fi
+    ;;
+  "pane process-info")
+    pane=
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = --pane ]; then pane=${2:-}; break; fi
+      shift
+    done
+    mode=$(jq -r '.process' "$state")
+    case "$mode" in
+      shell)
+        jq -n --arg pane "$pane" '{id:"cli:pane:process_info",result:{type:"pane_process_info",process_info:{pane_id:$pane,shell_pid:41001,foreground_process_group_id:41001,foreground_processes:[{pid:41001,name:"bash",argv:["/bin/bash"]}]}}}'
+        ;;
+      live)
+        jq -n --arg pane "$pane" '{id:"cli:pane:process_info",result:{type:"pane_process_info",process_info:{pane_id:$pane,shell_pid:41001,foreground_process_group_id:41002,foreground_processes:[{pid:41002,name:"pi",argv:["/opt/pi/bin/pi"]}]}}}'
+        ;;
+      *) printf '{"id":"cli:pane:process_info","result":{"type":"pane_process_info","process_info":{"pane_id":"wrong"}}}\n' ;;
+    esac
+    ;;
+  "pane send-text")
+    text=${4:-}
+    jq --arg text "$text" '.pending=$text' "$state" | save_state
+    ;;
+  "pane send-keys")
+    key=${4:-}
+    if [ "$key" = enter ]; then
+      pending=$(jq -r '.pending // empty' "$state")
+      cwd=$(jq -r '.cwd' "$state")
+      if [ -n "$pending" ]; then
+        new_cwd=$(cd "$cwd" && bash -c "$pending; pwd -P") || exit 1
+        jq --arg cwd "$new_cwd" '.cwd=$cwd | .pending=""' "$state" | save_state
+      fi
+    fi
+    ;;
+esac
+SH
+chmod +x "$TMP_ROOT/fakebin/herdr"
+
+cat > "$TMP_ROOT/fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  "-axo pid=,ppid=") printf '41001 1\n' ;;
+  "-p 41001 -o stat=") printf 'S\n' ;;
+  "-p 41001 -o comm=") printf 'bash\n' ;;
+  *) exit 1 ;;
+esac
+SH
+chmod +x "$TMP_ROOT/fakebin/ps"
+
+write_state() {
+  jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
+    '{cwd:$cwd,process:$process,registered:$registered,pending:""}' > "$STATE"
+  : > "$LOG"
+}
+
+run_backend() {
+  PATH="$TMP_ROOT/fakebin:$PATH" \
+    FM_FAKE_HERDR_STATE="$STATE" FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/fm-backend.sh"; "$@"' "$ROOT" "$@"
+}
+
+OLD="$TMP_ROOT/old"
+mkdir -p "$OLD"
+
+write_state "$OLD" shell true
+ordinary=$(run_backend fm_backend_agent_state herdr fmtest:w1:p1)
+recovery=$(run_backend fm_backend_recovery_agent_state herdr fmtest:w1:p1)
+[ "$ordinary" = alive ] || fail "the ordinary Herdr registry read should remain alive, got '$ordinary'"
+[ "$recovery" = dead ] || fail "a retained registration over one lone idle shell should be dead for lifecycle recovery, got '$recovery'"
+pass "Herdr relaunch recovery: a provably stale registered-agent report reconciles to agent-free"
+
+write_state "$OLD" live true
+recovery=$(run_backend fm_backend_recovery_agent_state herdr fmtest:w1:p1)
+[ "$recovery" = alive ] || fail "a registered agent with a distinct foreground process group must remain alive, got '$recovery'"
+pass "Herdr relaunch recovery: a real foreground agent remains alive and cannot be replaced"
+
+write_state "$OLD" ambiguous true
+recovery=$(run_backend fm_backend_recovery_agent_state herdr fmtest:w1:p1)
+[ "$recovery" = unreadable ] || fail "an ambiguous registered process surface must remain unreadable, got '$recovery'"
+pass "Herdr relaunch recovery: ambiguous process evidence refuses rather than becoming agent-free"
+
+TARGET="$TMP_ROOT/recorded ' ; touch PWNED ; #"
+mkdir -p "$TARGET"
+write_state "$OLD" shell true
+run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
+  || fail "an agent-free Herdr shell should restore to its exact recorded path"
+seen=$(jq -r '.cwd' "$STATE")
+[ "$seen" = "$TARGET" ] || fail "the restored foreground cwd should equal the quoted recorded path, got '$seen'"
+[ ! -e "$OLD/PWNED" ] || fail "recorded-path bytes escaped shell quoting and executed as syntax"
+command=$(awk -F '\x1f' '$2 == "pane" && $3 == "send-text" {print $5}' "$LOG")
+case "$command" in "cd -- "*) ;; *) fail "path restoration did not submit a cd command: $command" ;; esac
+count_before=$(grep -c $'\x1fpane\x1fsend-text\x1f' "$LOG" || true)
+run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
+  || fail "repeated exact-path preparation should be an idempotent success"
+count_after=$(grep -c $'\x1fpane\x1fsend-text\x1f' "$LOG" || true)
+[ "$count_after" -eq "$count_before" ] || fail "idempotent path preparation submitted a second cd command"
+pass "Herdr relaunch recovery: exact path restoration is persistent, quoted, and idempotent"
+
+write_state "$OLD" live true
+if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then
+  fail "path restoration must refuse while a real foreground agent remains"
+fi
+! grep -q $'\x1fpane\x1fsend-text\x1f' "$LOG" || fail "live-agent refusal typed a shell command"
+pass "Herdr relaunch recovery: live-agent refusal sends no path-changing input"
+
+write_state "$OLD" ambiguous true
+if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then
+  fail "path restoration must refuse ambiguous endpoint evidence"
+fi
+! grep -q $'\x1fpane\x1fsend-text\x1f' "$LOG" || fail "ambiguous-state refusal typed a shell command"
+pass "Herdr relaunch recovery: ambiguous-state refusal sends no path-changing input"
+
+run_backend fm_backend_prepare_relaunch_path tmux ignored "$TARGET" \
+  || fail "tmux relaunch path preparation should retain its existing no-op behavior"
+if run_backend fm_backend_prepare_relaunch_path zellij ignored "$TARGET" >/dev/null 2>&1; then
+  fail "a backend without verified lifecycle recovery must not gain path-changing behavior"
+fi
+pass "Relaunch path recovery: tmux remains unchanged and unverified backends refuse"


### PR DESCRIPTION
## Intent

Recover Herdr worker relaunches safely when an exited agent leaves a stale registration and the pane shell is no longer in the recorded isolated working directory.

## What changed

- Reconcile stale Herdr agent registrations with foreground-process evidence.
- Clear pending shell input and restore only the validated recorded working directory.
- Reject unsafe primary-copy and changed-owner cases.
- Add portable and real-Herdr regression coverage.

## Current status

This PR is not ready to merge. Automated review identified a remaining race between final foreground-owner validation and replacement-command submission. The implementation must establish an owner-checked mutation boundary and pass the resulting concurrency regressions before approval.

## Validation

Focused Herdr and runtime regression tests pass. The full validation run also exposed unrelated host prerequisites and fixture-permission failures; those were investigated separately and are not being used to waive the remaining relaunch-safety finding.
