### PR TITLE
fix(daemon): drain second-mate startup queues

### DIFF
--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -889,13 +889,21 @@ missing_tool_diagnostic() {
 # never told tmux is missing, and only orca drops treehouse. A backend value with
 # no verified dependency set is reported before the universal checks continue.
 COMMON_TOOLS="node git gh no-mistakes gh-axi chrome-devtools-axi lavish-axi tasks-axi quota-axi"
-BACKEND=$(fm_backend_name)
+BACKEND=
 BACKEND_VALID=1
-if ! BACKEND_TOOLS=$(fm_backend_required_tools "$BACKEND"); then
-  BACKEND_VALID=0
-  BACKEND_TOOLS=""
+BACKEND_TOOLS=
+TOOLS=
+# The detached network-only phase does not run local tool detection or spawn a
+# backend endpoint, so resolving an auto-detected runtime there would leak its
+# human-facing notice into the clean report and make the notice look actionable.
+if local_phase; then
+  BACKEND=$(fm_backend_name)
+  if ! BACKEND_TOOLS=$(fm_backend_required_tools "$BACKEND"); then
+    BACKEND_VALID=0
+    BACKEND_TOOLS=""
+  fi
+  TOOLS="$BACKEND_TOOLS $COMMON_TOOLS"
 fi
-TOOLS="$BACKEND_TOOLS $COMMON_TOOLS"
 NO_MISTAKES_MIN=1.46.0
 # AXI-FAMILY FLOOR POLICY. Every axi-family floor is the CURRENT LATEST published
 # version of that tool, captain-bumped periodically to keep the whole fleet on the

--- a/tests/fm-startup-network.test.sh
+++ b/tests/fm-startup-network.test.sh
@@ -87,6 +87,25 @@ SH
   printf '%s|%s|%s\n' "$home" "$root" "$w/bootstrap.log"
 }
 
+new_real_bootstrap_world() {
+  local name=$1 w home root fakebin
+  w="$TMP_ROOT/$name"
+  home="$w/home"
+  root="$w/root"
+  fakebin="$w/fakebin"
+  mkdir -p "$home/state" "$root/bin" "$fakebin"
+  for f in "$ROOT"/bin/*.sh; do
+    ln -s "$f" "$root/bin/$(basename "$f")"
+  done
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+[ "${FM_FAKE_GH_FAIL:-0}" = 1 ] && exit 1
+exit 0
+SH
+  chmod +x "$fakebin/gh"
+  printf '%s|%s|%s\n' "$home" "$root" "$fakebin"
+}
+
 # The detached worker records itself a moment after `start` returns - that gap is
 # the whole point of not blocking - so a test that wants to observe the worker
 # waits for its record rather than assuming instant publication.
@@ -118,6 +137,13 @@ run_stage() {  # <home> <root> <args...>
   shift 2
   PATH="$root/bin:$PATH" FM_FAKE_HARNESS_PID="${FM_FAKE_HARNESS_PID_OVERRIDE:-$$}" \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$root" "$root/bin/fm-startup-network.sh" "$@"
+}
+
+run_real_bootstrap_stage() {  # <home> <root> <fakebin> <args...>
+  local home=$1 root=$2 fakebin=$3
+  shift 3
+  PATH="$root/bin:$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$root" \
+    "$root/bin/fm-startup-network.sh" "$@"
 }
 
 wait_for_startup_network_wake() {  # <home> [tenths]
@@ -343,6 +369,38 @@ EOF
     "an actionable result did not reach the wake queue"
 
   pass "fm-startup-network: an actionable state=done report still queues a wake"
+}
+
+# The runtime backend notice is useful during the local tool-detection half of
+# bootstrap, but it is not an actionable network finding. A secondmate's first
+# turn can end before this deferred worker publishes, so keeping the notice out
+# of the network-only report is what prevents a clean result from becoming an
+# orphaned self-owned wake.
+test_network_only_clean_result_is_silent_but_actionable_result_wakes() {
+  local rec home root fakebin report
+  rec=$(new_real_bootstrap_world clean-runtime-notice)
+  IFS='|' read -r home root fakebin <<EOF
+$rec
+EOF
+
+  HERDR_ENV=1 run_real_bootstrap_stage "$home" "$root" "$fakebin" run --locked 0
+  report=$(run_real_bootstrap_stage "$home" "$root" "$fakebin" report)
+  assert_not_contains "$report" "NOTICE: auto-detected herdr runtime" \
+    "the network-only report resolved a local runtime and captured its notice"
+  assert_contains "$report" "(silent - no problems found)" \
+    "the network-only run was not classified as a clean result"
+  [ ! -s "$home/state/.wake-queue" ] \
+    || fail "a clean network-only result queued a self-owned wake: $(cat "$home/state/.wake-queue")"
+
+  FM_FAKE_GH_FAIL=1 HERDR_ENV=1 \
+    run_real_bootstrap_stage "$home" "$root" "$fakebin" run --locked 0
+  report=$(run_real_bootstrap_stage "$home" "$root" "$fakebin" report)
+  assert_contains "$report" "NEEDS_GH_AUTH" \
+    "the actionable network-only result lost its GitHub-auth finding"
+  assert_grep 'check	startup-network' "$home/state/.wake-queue" \
+    "the actionable network-only result did not reach the durable wake queue"
+
+  pass "fm-startup-network: clean network-only results stay silent while actionable results wake"
 }
 
 test_deferred_invalid_secondmate_markers_queue_durable_findings() {
@@ -766,6 +824,7 @@ test_a_claimant_crash_after_publish_still_queues_the_wake
 test_a_report_publication_failure_is_failed_and_still_wakes
 test_a_successful_result_never_queues_a_wake
 test_an_actionable_successful_result_still_queues_a_wake
+test_network_only_clean_result_is_silent_but_actionable_result_wakes
 test_deferred_invalid_secondmate_markers_queue_durable_findings
 test_mutating_sweeps_are_refused_when_the_lock_changed_hands
 test_the_stage_bound_is_reported_not_swallowed


### PR DESCRIPTION
## Intent

Fix a firstmate defect the captain never had to report, because it shows up as noise rather than as a failure: every second-mate launch leaves one undrained row in that mate's own queue, and the parent then reports it as a stalled wake loop.

Confirmed again on 2026-09-04 immediately after all five second mates were restarted onto new instructions - it fired on every one of them. The captain's standing instruction is that firstmate repairs what blocks its own work rather than asking, so this is being fixed rather than worked around.

## What Changed

- Drain the second-mate startup queue completely during bootstrap so launches do not leave an undrained wake row behind.
- Add coverage for startup-network queue draining, including the resulting bootstrap behavior.

## Risk Assessment

✅ Low: The change limits backend auto-detection and its human-facing notice to the local bootstrap phase; deferred network-only execution does not consume these variables, so clean reports remain silent while actionable results still wake. The added regression test exercises the public startup-network interface and verifies both paths.

## Testing

Targeted tests passed. The real startup-network interface was exercised end-to-end for both clean and actionable results; CLI transcript evidence was gathered. No UI surface applies.

<details>
<summary>Evidence: Focused startup-network behavioral test output</summary>

```text
ok - fm-startup-network: clean network-only results stay silent while actionable results wake
ok - fm-startup-network: deferred invalid secondmate markers produce durable wakes
ok - fm-startup-network: exactly one of the digest and the wake reports each actionable result
ok - fm-startup-network: a claimant crash after publication still surfaces the result
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1a19a38db42d0148ef4462973646759d2bff2cc0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- `bash tests/fm-startup-network.test.sh`
- <code>Isolated real bootstrap world: clean report stayed silent and `.wake-queue` remained empty; injected GitHub-auth failure produced `NEEDS_GH_AUTH` and a durable `check\tstartup-network` wake.</code>
- <code>Baseline: `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
