### PR TITLE
fix(pr): preserve PR poll across relaunches

### DIFF
--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -294,6 +294,8 @@ fm_pr_metadata_identity_parse() {
   FM_PR_META_NUMBER=
   [ -f "$file" ] && [ ! -L "$file" ] || return 1
   [ "$(fm_pr_file_link_count "$file")" = 1 ] || return 1
+  # Recognized metadata keys may be written on either side of pr= as writers evolve.
+  # Unknown keys after pr= remain invalid so trailing record data cannot bypass this binding.
   while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       pr=*)
@@ -310,12 +312,10 @@ fm_pr_metadata_identity_parse() {
         seen_pr=1
         ;;
       pr_head=*)
-        if [ "$seen_pr" -eq 1 ]; then
-          value=${line#pr_head=}
-          fm_pr_head_valid "$value" || post_pr_invalid=1
-        fi
+        value=${line#pr_head=}
+        fm_pr_head_valid "$value" || post_pr_invalid=1
         ;;
-      x_request=*|x_request_ts=*|x_followups=*|x_platform=*|x_reply_max_chars=*)
+      x_request=*|x_request_ts=*|x_followups=*|x_platform=*|x_reply_max_chars=*|control_relaunch_tx=*)
         ;;
       *)
         [ "$seen_pr" -eq 0 ] || post_pr_invalid=1

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -315,7 +315,7 @@ fm_pr_metadata_identity_parse() {
         value=${line#pr_head=}
         fm_pr_head_valid "$value" || post_pr_invalid=1
         ;;
-      x_request=*|x_request_ts=*|x_followups=*|x_platform=*|x_reply_max_chars=*|control_relaunch_tx=*)
+      x_request=*|x_request_ts=*|x_followups=*|x_platform=*|x_reply_max_chars=*|control_relaunch_tx=*|traceparent=*)
         ;;
       *)
         [ "$seen_pr" -eq 0 ] || post_pr_invalid=1

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -65,6 +65,7 @@ It is not deterministic across the verified adapters: codex and grok resume only
    The recorded worktree must exist and be a worktree root; its head and dirty state are recorded.
    For a `kind=secondmate` task, the home's identity marker must match and its child records must be readable, so a relaunch can never strand child work behind an unreadable home.
    A secondmate's own crewmates run in their own endpoints and outlive its relaunch; the relaunched secondmate reconciles them from its home's durable records at startup.
+   An armed PR or merge poll is part of the task's durable supervision state and remains valid through the replacement publication, so relaunch cannot silently lose merge detection.
 3. **Record the note.**
    A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation; the note is appended to the instructions it reads.
    A secondmate relaunch does not require one and never rewrites its standing charter.
@@ -119,5 +120,5 @@ The empirical basis for each adapter's value is the `harness-adapters` skill's v
 ## Verification
 
 - `tests/fm-control.test.sh` - the adapter contract for every verified harness, the backend capability matrix, exact-id scoping, the closed verb list, the busy, idle, dead, and idempotent lifecycle cases, and marker non-regression, all against a stubbed session provider.
-- `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, the progress note, checkpoint refusals, and rollback after a failed launch.
+- `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, armed PR-poll preservation, harness switching, the progress note, checkpoint refusals, and rollback after a failed launch.
 - `tests/fm-control-herdr-smoke.test.sh` - the second state-verified backend against the real herdr binary, on an isolated throwaway lab session.

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -370,6 +370,7 @@ test_relaunch_keeps_an_armed_pr_poll_valid() {
   add_ship_task "$dir" rl42 claude
   url=https://github.com/example/repo/pull/42
   seed_armed_pr_poll "$dir" rl42 "$url"
+  printf '%s on\n' "$$" > "$dir/home/state/.trace-context-effective"
   fm_pr_poll_artifacts_valid "$dir/home/state" rl42 "$PR_POLL" \
     || fail "the regression fixture did not start with a valid PR poll"
 

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -25,11 +25,14 @@ set -u
 . "$ROOT/bin/fm-control-lib.sh"
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-trace-context-lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-pr-lib.sh"
 
 CONTROL="$ROOT/bin/fm-control.sh"
 SPAWN="$ROOT/bin/fm-spawn.sh"
 PROMOTE="$ROOT/bin/fm-promote.sh"
 X_LINK="$ROOT/bin/fm-x-link.sh"
+PR_POLL="$ROOT/bin/fm-pr-poll.sh"
 # fm_test_tmproot's own cleanup trap fires when its command substitution exits,
 # so recreate the root before resolving it and clean it up from this file's trap.
 TMP_ROOT=$(fm_test_tmproot fm-control-relaunch)
@@ -204,6 +207,19 @@ meta_field() {  # <case-dir> <id> <key>
   grep "^$3=" "$1/home/state/$2.meta" | tail -1 | cut -d= -f2-
 }
 
+seed_armed_pr_poll() {  # <case-dir> <id> <url>
+  local dir=$1 id=$2 url=$3 provider host path number
+  fm_pr_url_parse "$url" || fail "the regression fixture URL was invalid"
+  provider=$FM_PR_PROVIDER
+  host=$FM_PR_HOST
+  path=$FM_PR_PATH
+  number=$FM_PR_NUMBER
+  printf 'pr=%s\n' "$url" >> "$dir/home/state/$id.meta"
+  fm_pr_poll_prepare "$dir/home/state" "$id" "$provider" "$url" "$host" "$path" "$number" "$PR_POLL" \
+    || fail "could not prepare the regression poll"
+  fm_pr_poll_publish_prepared || fail "could not publish the regression poll"
+}
+
 journal_field() {  # <case-dir> <id> <key>
   grep "^$3=" "$1/home/state/$2.control-relaunch" | tail -1 | cut -d= -f2-
 }
@@ -346,6 +362,22 @@ test_relaunch_preserves_durable_task_metadata() {
   [ "$(meta_field "$dir" rl19 decisions_reviewed)" = 1 ] \
     || fail "the task decision state must survive relaunch"
   pass "fm-control relaunch: durable task metadata survives replacement launch publication"
+}
+
+test_relaunch_keeps_an_armed_pr_poll_valid() {
+  local dir out rc url
+  dir=$(new_case armed-pr-poll rl42)
+  add_ship_task "$dir" rl42 claude
+  url=https://github.com/example/repo/pull/42
+  seed_armed_pr_poll "$dir" rl42 "$url"
+  fm_pr_poll_artifacts_valid "$dir/home/state" rl42 "$PR_POLL" \
+    || fail "the regression fixture did not start with a valid PR poll"
+
+  out=$(run_control "$dir" rl42 relaunch --note "continue after recovery"); rc=$?
+  expect_code 0 "$rc" "relaunch should succeed with an armed PR poll"$'\n'"$out"
+  fm_pr_poll_artifacts_valid "$dir/home/state" rl42 "$PR_POLL" \
+    || fail "relaunch invalidated the armed PR poll"
+  pass "fm-control relaunch: an armed PR poll remains valid after replacement publication"
 }
 
 test_relaunch_serializes_concurrent_durable_metadata_publication() {
@@ -1496,6 +1528,7 @@ test_relaunch_moves_a_drifted_item_back_in_flight() {
 
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
+test_relaunch_keeps_an_armed_pr_poll_valid
 test_relaunch_serializes_concurrent_durable_metadata_publication
 test_disabled_relaunch_clears_prior_trace_context
 test_relaunch_appends_the_progress_note_to_the_instructions


### PR DESCRIPTION
## Intent

Fix a firstmate defect found on 2026-09-04 by the backoffice second mate while handling a wake that firstmate had wrongly told it to treat as an unregistered check. Every relaunched task with an armed PR poll silently loses merge detection.

This one matters more than its size: a merged PR is not reported wrongly, it is never noticed at all, and relaunch is an ordinary recovery action rather than an exotic one.

## What Changed

- Allow relaunch transaction metadata and valid PR-head records to coexist with PR metadata parsing.
- Preserve armed PR poll supervision state through task relaunch publication.
- Document PR-poll preservation and add a regression test covering relaunch with an armed poll.

## Risk Assessment

✅ Low: The change directly fixes relaunch metadata validation by accepting the preserved control transaction and optional PR-head fields regardless of their position, while retaining rejection of unknown post-PR keys; the added regression exercises the real relaunch and artifact-validation interfaces.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (8m45s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"21da00b2310864694884dabf0c155ec59e680885","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
