### PR TITLE
fix: restart every live second mate after updates

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -225,7 +225,7 @@ If the secondmate is already running and only inherited local material changed, 
 To move a live LOCAL secondmate onto a newly pinned harness, model, or effort without a full recovery, set `config/secondmate-harness` and then relaunch it with `bin/fm-control.sh <id> relaunch`, which re-resolves that pin, stops the agent, and launches the replacement in the same home ([`docs/agent-control.md`](../../../docs/agent-control.md)).
 That plane refuses a remotely placed secondmate by name, because its agent runs on another host where none of the plane's postconditions can be read.
 Move a REMOTE one with `bin/fm-on.sh <id> fm-remote-secondmate-control.sh relaunch <id> <harness> <model|default|-> <effort|default|->`, which runs that same control-plane relaunch on its host; pass the profile explicitly and use `default` for an absent pin, because `config/secondmate-harness` is not inherited and the copy on that host belongs to a different home ([`docs/remote-secondmates.md`](../../../docs/remote-secondmates.md)).
-An instruction-surface update restarts eligible mates of both placements on its own; the `/updatefirstmate` skill owns that pass, and `bin/fm-secondmate-restart.sh` owns its persist gate and failure vocabulary.
+A successful update restarts every live mate of both placements on its own, including one already on the target commit; the `/updatefirstmate` skill owns that pass, and `bin/fm-secondmate-restart.sh` owns its persist gate and failure vocabulary.
 
 Do not reconstruct a secondmate's whole tree from the main home.
 The main firstmate reconciles only direct reports.

--- a/.agents/skills/updatefirstmate/SKILL.md
+++ b/.agents/skills/updatefirstmate/SKILL.md
@@ -3,7 +3,7 @@ name: updatefirstmate
 description: >-
   Self-update a running firstmate and its secondmates to the latest from origin.
   Use when the captain invokes /updatefirstmate (e.g. "/updatefirstmate", "update firstmate", "pull the latest firstmate").
-  Fast-forwards this firstmate repo's default branch and every local or remote secondmate through its guarded update path (never forced, never disruptive), then re-reads AGENTS.md and reloads changed second-mate instructions through persist-gated restarts or fallback re-read nudges.
+  Fast-forwards this firstmate repo's default branch and every local or remote secondmate through its guarded update path (never forced, never disruptive), then re-reads AGENTS.md and restarts every live second mate through the persist-gated restart, with a fallback re-read nudge only where a restart cannot be proven.
 user-invocable: true
 metadata:
   internal: true
@@ -18,10 +18,14 @@ This skill performs that pull for the running main firstmate and every secondmat
 
 Pulling the files is only half of it.
 A running agent holds `AGENTS.md` and every skill it has already loaded frozen from the moment it launched, and no verified harness offers a reload, so new bytes on disk change nothing for it until it starts a fresh conversation.
-That is why a second mate whose `AGENTS.md` or `.agents/skills/` changed is restarted rather than asked to re-read: a re-read appends a second copy of the mate's own job description with no defined precedence, and cannot reach a skill that is already loaded.
-A `bin/` change needs none of this, because every helper is executed fresh on each call.
+A re-read cannot substitute: it appends a second copy of the mate's own job description with no defined precedence, and it cannot reach a skill that is already loaded.
+Replacing the agent is also the only thing that re-resolves the launch-time wiring - turn-end hooks, harness flags, per-harness feature switches - which the mate froze when it started and which nothing on disk describes.
 
-**One-time rollout note:** the first update that carries this restart design is still executed by the previous release, so eligible second mates receive its re-read message on that pass instead of a restart. After that update completes, run `bin/fm-secondmate-restart.sh <fm-id>...` once with those mate IDs; this change already ships that command, and later updates follow the normal flow below.
+That is why **every live second mate is restarted after a successful update, including one that was already on the target commit.**
+Launch-time wiring is not derivable from a file diff, so an unchanged tracked surface is not evidence the running agent is already on the current behavior.
+The only live mates that do not restart are the ones whose home the update pass had to skip, and the ones whose runtime cannot prove a restart; the updater keeps both cases honest and neither is reported as a reload.
+
+**One-time rollout note:** the update that carries this change is still executed by the previous release, which restarts only the mates whose `AGENTS.md` or `.agents/skills/` moved on that pass. After it completes, run `bin/fm-secondmate-restart.sh <fm-id>...` once with every live second mate ID, not only the ones that release named; later updates follow the normal flow below.
 
 The update is **fast-forward only** - the same sanctioned self-write as the fleet sync firstmate already runs.
 For a remote route, it updates the configured Firstmate code root on that host from its own origin, then guardedly fast-forwards the persistent home to that code-root commit.
@@ -42,14 +46,15 @@ This touches only the firstmate repo and its own worktrees, never anything under
    - `nudge-secondmates: fm-<id>...|none`
 
    The two second-mate sets are disjoint and the script owns the split; do not re-derive it.
-   A mate reaches neither set because it was skipped, was already current, advanced without changing anything it reads or runs, or had an endpoint positively classified as dead or missing - none of those need any action from you.
+   `restart-secondmates:` carries every live mate the pass left on the latest commit, whether it advanced or was already there.
+   A mate reaches neither set only because its home was skipped, because it has no live endpoint recorded here, or because its endpoint was positively classified as dead or missing - none of those need any action from you.
 
 2. **Re-read AGENTS.md if your own instructions changed.**
    When the updater printed `reread-firstmate: yes`, the tracked instruction surface (`AGENTS.md`, `bin/`, or `.agents/skills/`) just advanced under you.
    **Read `AGENTS.md` now** (CLAUDE.md is a real `@AGENTS.md` pointer to it) to refresh your operating instructions before doing anything else, so you are acting on the new instructions rather than the stale ones you were started with.
    When it printed `reread-firstmate: no`, nothing changed for you - skip the re-read.
 
-3. **Restart every second mate whose own instructions changed.**
+3. **Restart every second mate the updater named.**
    Pass the whole `restart-secondmates:` list to one command (skip this step entirely when it says `none`):
    ```sh
    FM_HOME=<this-firstmate-home> bin/fm-secondmate-restart.sh <fm-id>...
@@ -64,8 +69,8 @@ This touches only the firstmate repo and its own worktrees, never anything under
    Its header owns the request, the bound, and the two knobs that change them.
 
    Read its per-mate lines and its closing `summary:` line as the outcome:
-   - `restarted: <id>` - that mate is now genuinely running the new instructions.
-   - `nudged: <id>: <reason>` - the restart was not safe, so the mate got the older re-read message instead and is still running the previous instructions.
+   - `restarted: <id>` - that mate is now genuinely running the current instructions and launch-time settings.
+   - `nudged: <id>: <reason>` - the restart was not safe, so the mate got the older re-read message instead and is still running the conversation and launch-time settings it started with.
      Never report one of these as a clean reload.
    - `unreached: <id>: <reason>` - no safe running outcome could be confirmed, including an ambiguous relaunch result.
 
@@ -74,8 +79,9 @@ This touches only the firstmate repo and its own worktrees, never anything under
    ```sh
    FM_HOME=<this-firstmate-home> bin/fm-send.sh <id> 'firstmate was updated to the latest - please re-read your AGENTS.md to pick up the new instructions.'
    ```
-   These are the mates whose advance does not need a fresh conversation, or that could not be restarted provably.
+   These are the mates that are on the latest bytes but could not be restarted provably, so the steer is the most this pass can honestly do for them.
    It is a gentle steer, not an interruption: the mate already got a safe tracked-files fast-forward, and the steer never forces, tears down, or discards its work.
+   Never describe one of these as reloaded; its agent is still running the wiring it launched with.
 
 5. **Report to the captain in plain outcomes, in one line where you can.**
    Summarize what landed under `AGENTS.md` section 9 without firstmate's internal vocabulary: which parts of the fleet are now on the latest, and which were left as-is and why.
@@ -91,7 +97,7 @@ This touches only the firstmate repo and its own worktrees, never anything under
 - **Only the firstmate repo and its worktrees** are touched, never `projects/`.
   It is the same sanctioned self-write as the fleet sync.
 - **Nothing with work in it is disrupted.**
-  A local or remote second mate gets a tracked-files fast-forward only when its own checkout is safe to advance.
+  A local or remote second mate gets a tracked-files fast-forward only when its own checkout is safe to advance, and a mate whose home was skipped is not restarted either.
   A restart replaces that mate's agent in the same home and endpoint after its open work is written down; it is never a teardown and never forced.
   Its crewmates keep running in their own endpoints, and every durable record - backlog, held captain calls, unread status, unhandled instructions - is re-presented to the replacement at startup.
   A restart refused before it is attempted leaves that mate on the re-read path; once a relaunch is attempted, any failed or ambiguous result is reported as unknown rather than attributed to either incarnation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -538,7 +538,7 @@ The scaffold is a safety contract, not a suggestion.
 Firstmate's shared instruction surface reaches running homes only after it lands on the default branch and those homes fast-forward.
 Only `AGENTS.md`, `bin/`, and `.agents/skills/` are loaded by a running firstmate; public `skills/` is an installer-facing surface.
 When the captain invokes `/updatefirstmate` or asks to update firstmate, load the `/updatefirstmate` skill.
-It performs guarded fast-forward updates of firstmate and registered secondmate homes, restarts every live second mate through a persist-gated replacement so launch-time harness wiring reloads too, falls back to a re-read nudge only where a restart cannot be proven, and never touches anything under `projects/`.
+The skill owns the guarded fleet update and restart procedure; it never touches anything under `projects/`.
 
 ## 13. Agent-only reference skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -538,7 +538,7 @@ The scaffold is a safety contract, not a suggestion.
 Firstmate's shared instruction surface reaches running homes only after it lands on the default branch and those homes fast-forward.
 Only `AGENTS.md`, `bin/`, and `.agents/skills/` are loaded by a running firstmate; public `skills/` is an installer-facing surface.
 When the captain invokes `/updatefirstmate` or asks to update firstmate, load the `/updatefirstmate` skill.
-It performs guarded fast-forward updates of firstmate and registered secondmate homes, refreshes changed second-mate instructions through persist-gated restarts or fallback re-read nudges, and never touches anything under `projects/`.
+It performs guarded fast-forward updates of firstmate and registered secondmate homes, restarts every live second mate through a persist-gated replacement so launch-time harness wiring reloads too, falls back to a re-read nudge only where a restart cannot be proven, and never touches anything under `projects/`.
 
 ## 13. Agent-only reference skills
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
 | `/ahoy`            | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, then guide the captain through any open decisions one at a time in agent-judged impact order; fall back to Bearings when invoked as the session's first real captain message |
 | `/bearings`        | Generate a concise four-section chat digest from bounded fleet state, including registered remote-home ledgers; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` for live GitHub enrichment |
-| `/updatefirstmate` | Self-update the running firstmate and its secondmates with fast-forward-only pulls, then reload changed second-mate instructions through persist-gated restarts or fallback re-read nudges |
+| `/updatefirstmate` | Fast-forward the running firstmate and its secondmates, then persist and restart every live mate successfully left on the target commit - including already-current homes - with an honest re-read nudge only when restart cannot be proven |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, persist the open work records this session knows are unfiled or now wrong, curate tiered startup memory with decay and cold archival, enforce each home's budget or surface the required decision, cascade to registered second mates, and report what is safe to reset |
 
 Bearings invocation examples:

--- a/bin/fm-ff-lib.sh
+++ b/bin/fm-ff-lib.sh
@@ -232,20 +232,6 @@ changed_instr() {
   printf '%s' "$out"
 }
 
-# Whether a changed_instr list names a surface a RUNNING agent still holds from
-# its launch, so picking the new bytes up needs a fresh conversation rather than
-# just the next command. AGENTS.md is read once at startup and a loaded skill
-# under .agents/skills/ is frozen for the rest of that conversation, while every
-# helper under bin/ is executed fresh on each call and therefore reloads itself.
-# This is deliberately STRICTER than "changed_instr found something": a bin/-only
-# advance changes the tooling without changing anything the agent is holding.
-ff_instr_needs_reload() {  # <changed_instr-list>
-  case "$1" in
-    *AGENTS.md*|*.agents/skills*) return 0 ;;
-  esac
-  return 1
-}
-
 # Translate one remote home sync leg's failure into an operator-actionable
 # reason. The remote leg refuses a command shape it does not recognize with this
 # status, which on this leg can only mean that host's Firstmate copy predates the
@@ -411,6 +397,20 @@ FF_SEEN_HOMES=""
 # whose only change was non-instruction tracked files, is left undisturbed. The
 # firstmate repo itself (FM_ROOT) is never processed as its own secondmate, and
 # each resolved home is processed at most once.
+#
+# Two optional caller hooks fire from here, each at most once per resolved home:
+#   fm_ff_after_instruction_update <id> <home> <window> <instr>
+#     the nudge-shaped hook: only for an advance that changed the instruction
+#     surface, and only under nudge_requires_instr=yes.
+#   fm_ff_after_secondmate_settled <id> <home> <window> <status> <instr>
+#     the settled-state hook: for every home this sweep left AT the base with a
+#     live window, whether it advanced (status=updated) or was already there
+#     (status=current). A home that was SKIPPED is never settled, so a dirty,
+#     diverged, offline, or unsafe home never reaches this hook and nothing here
+#     forces, stashes, or discards its work. /updatefirstmate uses this hook to
+#     reach every live mate that is genuinely on the new bytes, including the
+#     ones that needed no advance to get there.
+# An undefined hook is simply not called.
 process_secondmate() {
   local id=$1 home=$2 window=${3:-} base_mode=$4 nudge_requires_instr=${5:-no} home_real fm_root_real
   [ -n "$id" ] || return 0
@@ -429,6 +429,10 @@ process_secondmate() {
   FF_SEEN_HOMES="$FF_SEEN_HOMES $home_real"
 
   ff_target "$home_real" "secondmate $id" "$base_mode" yes yes
+  if [ -n "$window" ] && { [ "$FF_STATUS" = "updated" ] || [ "$FF_STATUS" = "current" ]; } \
+    && type fm_ff_after_secondmate_settled >/dev/null 2>&1; then
+    fm_ff_after_secondmate_settled "$id" "$home_real" "$window" "$FF_STATUS" "$FF_INSTR"
+  fi
   if [ "$FF_STATUS" = "updated" ] && [ -n "$window" ]; then
     if [ "$nudge_requires_instr" = yes ] && [ -z "$FF_INSTR" ]; then
       return 0

--- a/bin/fm-secondmate-restart-lib.sh
+++ b/bin/fm-secondmate-restart-lib.sh
@@ -1,10 +1,10 @@
 # shellcheck shell=bash disable=SC2034
 # fm-secondmate-restart-lib.sh - the shared contract for restarting a second
-# mate onto a freshly advanced instruction surface. Source only.
+# mate onto the current instruction surface and launch-time wiring. Source only.
 #
 # Two consumers, one owner:
-#   - bin/fm-update.sh decides WHICH advanced mates belong in the restart set,
-#     so it needs the capability test before it prints its action lines.
+#   - bin/fm-update.sh decides WHICH live mates belong in the restart set, so it
+#     needs the capability test before it prints its action lines.
 #   - bin/fm-secondmate-restart.sh performs the pass, so it needs the same test
 #     again on its own argv rather than trusting a caller's list.
 #
@@ -35,7 +35,7 @@ _FM_SECONDMATE_RESTART_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # The mate answers through its parent channel, which is what resolves the
 # parent-owned reply expectation fm-send arms for a marked request; that
 # correlated answer, never the wall clock, is what releases the restart.
-FM_SECONDMATE_PERSIST_REQUEST='Firstmate instructions changed and I am about to restart your agent so it reloads them, which drops your conversation but keeps every durable record. Before that, persist the open work you are holding only in this conversation, following the /stow skill'"'"'s "Open-record persistence" section and nothing else from that skill: file a task for each open record that exists only in this conversation, including any captain call you had formed but never registered, and correct any task whose status no longer reflects what you now know. Do NOT run the memory, learnings, or captain-preference sweeps. Then reply on your parent channel saying it is done, or saying what you deliberately left alone and why.'
+FM_SECONDMATE_PERSIST_REQUEST='Firstmate was updated and I am about to restart your agent so it comes up on the current instructions and launch-time settings, which drops your conversation but keeps every durable record. Before that, persist the open work you are holding only in this conversation, following the /stow skill'"'"'s "Open-record persistence" section and nothing else from that skill: file a task for each open record that exists only in this conversation, including any captain call you had formed but never registered, and correct any task whose status no longer reflects what you now know. Do NOT run the memory, learnings, or captain-preference sweeps. Then reply on your parent channel saying it is done, or saying what you deliberately left alone and why.'
 
 # Resolve one mate's restart capability from its durable record alone.
 # Publishes, on success:

--- a/bin/fm-secondmate-restart.sh
+++ b/bin/fm-secondmate-restart.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Restart second mates onto a freshly advanced instruction surface, persisting
-# their open records first.
+# Restart second mates onto the current instruction surface and launch-time
+# wiring, persisting their open records first.
 #
 # Usage: fm-secondmate-restart.sh <secondmate-id>... [--help]
 #
@@ -9,8 +9,12 @@
 # verified harness offers a reload, so a re-read steer cannot replace either -
 # it appends a second copy of the mate's own job description with no defined
 # precedence. Replacing the agent is the only mechanism that guarantees the new
-# bytes are the ones read, and it re-resolves the launch-time wiring (harness,
-# model, effort, turn-end hooks) at the same time.
+# bytes are the ones read, and the only one that re-resolves the launch-time
+# wiring - harness, model, effort, turn-end hooks, and every other flag a harness
+# reads once at startup. That second half is why the update pass sends every live
+# mate here, including one already on the target commit: launch-time wiring is
+# not derivable from a git diff, so an unchanged tracked surface does not mean
+# the running agent is already on the current behavior.
 #
 # The cost of that guarantee is the conversation, which is why this command runs
 # in two phases and why the first one is a GATE, not a courtesy:
@@ -49,8 +53,8 @@
 # before the agent is stopped leaves the mate running exactly as it was.
 #
 # Restart candidacy itself belongs to bin/fm-update.sh, which knows which homes
-# advanced and what changed; this command re-checks capability on its own argv
-# rather than trusting a caller's list.
+# the update pass actually left on the target commit; this command re-checks
+# capability on its own argv rather than trusting a caller's list.
 #
 # Environment knobs:
 #   FM_SECONDMATE_PERSIST_WAIT  seconds to wait for one mate's persist answer (900)
@@ -65,7 +69,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 
 usage() {
-  sed -n '2,60{s/^# \{0,1\}//;p;}' "$0"
+  sed -n '2,65{s/^# \{0,1\}//;p;}' "$0"
 }
 
 case "${1:-}" in

--- a/bin/fm-update.sh
+++ b/bin/fm-update.sh
@@ -25,22 +25,31 @@
 # plus a parseable summary telling the caller what to do next:
 #   - one status line per target (updated/already current/skipped)
 #   - reread-firstmate: yes|no    (did the running firstmate's instructions change)
-#   - restart-secondmates: fm-<id>...|none (advanced live secondmates whose
-#     AGENTS.md or .agents/skills/ changed AND whose recorded runtime can prove a
-#     restart, so their agents must be replaced to actually reload)
-#   - nudge-secondmates: fm-<id>...|none   (the residual: advanced live
-#     secondmates that changed instructions but cannot be restarted provably, so
-#     the older re-read steer is all that is honest for them; a legacy remote
-#     advance that cannot report its instruction diff also lands here because
-#     the unknown surface cannot safely authorize a restart)
+#   - restart-secondmates: fm-<id>...|none (every live secondmate this pass left
+#     on origin's tip - advanced OR already there - whose recorded runtime can
+#     prove a restart)
+#   - nudge-secondmates: fm-<id>...|none   (the residual: live secondmates on
+#     that same tip whose runtime CANNOT prove a restart, so the older re-read
+#     steer is all that is honest for them)
 #
-# The two sets are disjoint. Normally both require a CHANGED INSTRUCTION SURFACE,
-# which is stricter than this command's older "any advance" nudge and matches what
-# the session-start sweep has always used; the one compatibility exception is the
-# legacy remote unknown above. Restart is stricter again: a bin/-only advance
-# reloads itself on the next call and never costs a conversation
-# (bin/fm-ff-lib.sh's ff_instr_needs_reload), and bin/fm-secondmate-restart-lib.sh
-# owns the capability half.
+# The two sets are disjoint, and restart is UNCONDITIONAL on a successful update
+# of that home. It is deliberately not gated on the git diff: replacing the agent
+# is the only thing that re-resolves the launch-time wiring - turn-end hooks,
+# harness flags, per-harness feature switches - which a running agent froze when
+# it started and which no changed_instr list describes. An unchanged tracked
+# surface therefore is NOT evidence that the running agent is already on the
+# current behavior, so an ALREADY-CURRENT home restarts too.
+#
+# Only two things keep a live mate out of the restart set, and neither is papered
+# over as a reload:
+#   - its home was SKIPPED (dirty, diverged, offline, unsafe). It is not on the
+#     new bytes, nothing here forces, stashes, or discards it, and it gets no
+#     action at all.
+#   - its runtime cannot prove the old agent stopped and a replacement came up
+#     (bin/fm-secondmate-restart-lib.sh owns that test), so it falls to the
+#     honest re-read steer and is reported as a nudge, never as a reload.
+# A positively dead or missing endpoint has no agent to replace and is left to
+# the ordinary startup recovery.
 #
 # Usage: fm-update.sh [--help]
 set -eu
@@ -74,26 +83,18 @@ if [ "$FF_STATUS" = "updated" ] && [ -n "$FF_INSTR" ]; then
 fi
 
 # --- secondmates -----------------------------------------------------------
-# An advanced live secondmate is reached only when its INSTRUCTION SURFACE moved
-# (nudge_requires_instr is "yes" on every sweep below), the same threshold the
-# session-start sweep uses: an advance that touched only README.md, docs/, or the
-# installer-facing skills/ changes nothing the agent is running on.
-#
-# Of those, the ones whose AGENTS.md or .agents/skills/ changed need a restart
-# rather than a steer, because a running agent holds both frozen from launch and
-# no harness offers a reload. The rest keep the re-read nudge.
+# Every live secondmate this pass leaves on origin's tip is restarted, whether it
+# advanced or was already there. The header above owns why the git diff does not
+# gate that, and which two conditions - a skipped home, an unprovable runtime -
+# are the only ways a live mate stays out of the restart set.
 
+# FF_NUDGE_WINDOWS and FF_SEEN_HOMES are the sweep's own accumulators and are
+# reset here per its contract; the instruction-gated nudge set is the session-start
+# sweep's threshold, not this command's, so only the two sets below are read.
 FF_NUDGE_WINDOWS=""
 FF_SEEN_HOMES=""
 FF_RESTART_WINDOWS=""
-
-remove_secondmate_action() {  # <id>
-  local id=$1 selector next=""
-  for selector in $FF_NUDGE_WINDOWS; do
-    [ "$selector" = "fm-$id" ] || next="$next $selector"
-  done
-  FF_NUDGE_WINDOWS=$next
-}
+FF_STEER_WINDOWS=""
 
 secondmate_agent_may_be_alive() {  # <id>
   local id=$1 meta="$STATE/$1.meta" remote_host state=unreadable
@@ -111,17 +112,32 @@ secondmate_agent_may_be_alive() {  # <id>
   esac
 }
 
-# Classify one advanced local secondmate. bin/fm-ff-lib.sh calls this for each
-# home that advanced with a changed instruction surface and a live endpoint.
-fm_ff_after_instruction_update() {  # <id> <home> <window> <instr>
-  local id=$1 instr=$4
-  if ! secondmate_agent_may_be_alive "$id"; then
-    remove_secondmate_action "$id"
-    return 0
+selector_claimed() {  # <selector>
+  case " $FF_RESTART_WINDOWS $FF_STEER_WINDOWS " in
+    *" $1 "*) return 0 ;;
+  esac
+  return 1
+}
+
+# Route one secondmate whose home this pass left on the target commit. Restart is
+# the outcome unless its runtime cannot prove one, in which case it keeps the
+# re-read steer and is reported as a nudge rather than as a reload. A stopped
+# endpoint has no agent to replace and is left to startup recovery.
+claim_settled_secondmate() {  # <id>
+  local id=$1
+  selector_claimed "fm-$id" && return 0
+  secondmate_agent_may_be_alive "$id" || return 0
+  if fm_secondmate_restart_capable "$STATE/$id.meta"; then
+    FF_RESTART_WINDOWS="$FF_RESTART_WINDOWS fm-$id"
+  else
+    FF_STEER_WINDOWS="$FF_STEER_WINDOWS fm-$id"
   fi
-  ff_instr_needs_reload "$instr" || return 0
-  fm_secondmate_restart_capable "$STATE/$id.meta" || return 0
-  FF_RESTART_WINDOWS="$FF_RESTART_WINDOWS fm-$id"
+}
+
+# bin/fm-ff-lib.sh calls this for each local home it left AT the base with a live
+# endpoint - status "updated" or "current" alike. A skipped home never gets here.
+fm_ff_after_secondmate_settled() {  # <id> <home> <window> <status> <instr>
+  claim_settled_secondmate "$1"
 }
 
 # Live direct reports first: state/<id>.meta with kind=secondmate carries the
@@ -148,38 +164,35 @@ if [ -f "$SECONDMATES_MD" ]; then
         case "$remote_result" in
           synced:*)
             remote_detail=${remote_result#synced: }
-            # The host reports its advance as "<commit> instr=<paths>". A host
-            # whose Firstmate copy predates that suffix reports the commit alone,
-            # which is UNKNOWN rather than "nothing changed" and therefore earns
-            # the safe re-read steer rather than an unprovable restart.
+            # The host reports its advance as "<commit> instr=<paths>"; a host
+            # whose Firstmate copy predates that suffix reports the commit alone.
+            # The suffix is now reporting detail only: the routing below no longer
+            # reads it, so an older host's silence can no longer downgrade a
+            # restartable mate to a steer.
             case "$remote_detail" in
               *' instr='*)
                 remote_instr=${remote_detail##* instr=}
                 remote_commit=${remote_detail%% instr=*}
-                remote_instr_known=1
                 ;;
-              *) remote_instr=""; remote_commit=$remote_detail; remote_instr_known=0 ;;
+              *) remote_instr=""; remote_commit=$remote_detail ;;
             esac
             if [ -n "$remote_instr" ]; then
               echo "remote secondmate $id: updated on $SECONDMATE_REGISTRY_HOST ($remote_commit, instructions changed: $remote_instr)"
             else
               echo "remote secondmate $id: updated on $SECONDMATE_REGISTRY_HOST ($remote_commit)"
             fi
-            if [ -f "$STATE/$id.meta" ] && grep -qx 'kind=secondmate' "$STATE/$id.meta" \
-              && secondmate_agent_may_be_alive "$id"; then
-              if [ "$remote_instr_known" -eq 0 ]; then
-                FF_NUDGE_WINDOWS="$FF_NUDGE_WINDOWS fm-$id"
-              elif [ -n "$remote_instr" ]; then
-                if ff_instr_needs_reload "$remote_instr" \
-                  && fm_secondmate_restart_capable "$STATE/$id.meta"; then
-                  FF_RESTART_WINDOWS="$FF_RESTART_WINDOWS fm-$id"
-                else
-                  FF_NUDGE_WINDOWS="$FF_NUDGE_WINDOWS fm-$id"
-                fi
-              fi
+            if [ -f "$STATE/$id.meta" ] && grep -qx 'kind=secondmate' "$STATE/$id.meta"; then
+              claim_settled_secondmate "$id"
             fi
             ;;
-          current:*) echo "remote secondmate $id: already current on $SECONDMATE_REGISTRY_HOST (${remote_result#current: })" ;;
+          current:*)
+            echo "remote secondmate $id: already current on $SECONDMATE_REGISTRY_HOST (${remote_result#current: })"
+            # Already on the target commit is a SUCCESSFUL update of that home,
+            # so it earns the same restart as one that had to advance.
+            if [ -f "$STATE/$id.meta" ] && grep -qx 'kind=secondmate' "$STATE/$id.meta"; then
+              claim_settled_secondmate "$id"
+            fi
+            ;;
           *) echo "remote secondmate $id: skipped on $SECONDMATE_REGISTRY_HOST: malformed update result" >&2 ;;
         esac
       else
@@ -193,18 +206,10 @@ fi
 
 # --- caller action summary -------------------------------------------------
 
-# The local sweep accumulates every advanced instruction-surface change into
-# FF_NUDGE_WINDOWS and the classifier above promotes the restartable ones, so the
-# nudge line is the residual. Keeping the sets disjoint is what stops a mate from
-# being restarted and then steered about the instructions it just relaunched on.
-nudge_residual=""
-for selector in $FF_NUDGE_WINDOWS; do
-  case " $FF_RESTART_WINDOWS " in
-    *" $selector "*) continue ;;
-  esac
-  nudge_residual="$nudge_residual $selector"
-done
+# claim_settled_secondmate puts each live settled mate in exactly one set, so the
+# two lines below are disjoint by construction: no mate is ever restarted and
+# then also steered about the instructions it just relaunched on.
 
 echo "reread-firstmate: $reread_firstmate"
 echo "restart-secondmates:${FF_RESTART_WINDOWS:- none}"
-echo "nudge-secondmates:${nudge_residual:- none}"
+echo "nudge-secondmates:${FF_STEER_WINDOWS:- none}"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -384,7 +384,7 @@ The refresh also prunes local branches whose remote is gone and that no worktree
 ## Self-updates stay safe
 
 `/updatefirstmate` fast-forwards the running firstmate repo and registered secondmate homes from `origin` without touching project clones.
-It reloads changed second-mate instructions through a persist-gated restart when the recorded runtime supports provable lifecycle control, and retains the re-read nudge as the fallback for changed live agents on other runtimes.
+It restarts every live second mate whose home the pass left on the target commit through a persist-gated replacement, including a home that needed no advance, because a restart is also the only thing that re-resolves launch-time harness wiring; the re-read nudge is retained only as the fallback for live agents whose runtime cannot prove a restart.
 For a remote route, the configured code root updates from its own origin on that host before the persistent home fast-forwards to the code-root commit.
 The update is fast-forward only: dirty, diverged, offline, and off-default targets are reported and left untouched.
 Local homes share the guarded fast-forward helper, while remote updates delegate the same safety decision to the configured host through the generic transport.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -20,7 +20,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-bearings-snapshot.sh` | Project the bounded remote-ledger fleet snapshot to compact TOON; `--include-prs` adds live GitHub enrichment |
 | `fm-bearings-board.sh`   | Build and arm the stable interactive `/bearings lavish` fleet board                  |
 | `fm-secondmate-reconcile.sh` | Queue Bearings reconcile requests for later supervision delivery and ask each mismatched home through its durable inbox with a per-home cooldown |
-| `fm-update.sh`           | Fast-forward-only self-update of firstmate and local or remote secondmate homes, naming every live second mate to restart |
+| `fm-update.sh`           | Fast-forward-only self-update of firstmate and local or remote secondmate homes, classifying every live mate left on the target commit for restart or fallback nudge |
 | `fm-secondmate-restart.sh` | Persist open conversational work, then restart eligible second mates or report the fallback outcome |
 | `fm-secondmate-restart-lib.sh` | Shared second-mate restart capability and persistence-request contract |
 | `fm-on.sh`               | Execute one tracked Firstmate command in a configured remote secondmate home, using its job worker except for the doctor bootstrap |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -20,7 +20,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-bearings-snapshot.sh` | Project the bounded remote-ledger fleet snapshot to compact TOON; `--include-prs` adds live GitHub enrichment |
 | `fm-bearings-board.sh`   | Build and arm the stable interactive `/bearings lavish` fleet board                  |
 | `fm-secondmate-reconcile.sh` | Queue Bearings reconcile requests for later supervision delivery and ask each mismatched home through its durable inbox with a per-home cooldown |
-| `fm-update.sh`           | Fast-forward-only self-update of firstmate and local or remote secondmate homes, with reload action classification |
+| `fm-update.sh`           | Fast-forward-only self-update of firstmate and local or remote secondmate homes, naming every live second mate to restart |
 | `fm-secondmate-restart.sh` | Persist open conversational work, then restart eligible second mates or report the fallback outcome |
 | `fm-secondmate-restart-lib.sh` | Shared second-mate restart capability and persistence-request contract |
 | `fm-on.sh`               | Execute one tracked Firstmate command in a configured remote secondmate home, using its job worker except for the doctor bootstrap |

--- a/tests/fm-secondmate-restart.test.sh
+++ b/tests/fm-secondmate-restart.test.sh
@@ -18,6 +18,10 @@
 #   5. A remote mate restarts by running the SAME local control-plane relaunch on
 #      its host, over the fm-on transport, with the profile resolved from the
 #      PARENT's own pin rather than the remote home's copy of it.
+#   6. End to end with bin/fm-update.sh: a live mate whose home needed no
+#      fast-forward is still named for restart and genuinely restarted, and one
+#      whose runtime cannot prove a restart keeps the honest re-read path with
+#      its agent left running.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -157,6 +161,64 @@ add_local_mate() {
   } > "$home/state/$id.meta"
   printf '%s\n' "fm-$id" > "$dir/fake/windows"
   printf '%s' "$smhome" > "$dir/fake/cwd"
+}
+
+# add_repo_backed_mate <case-dir> <id> [harness] [backend-line]
+# Like add_local_mate, but the world is the one /updatefirstmate actually runs
+# against: a bare origin, a firstmate repo clone on its default branch, and the
+# mate's home as a DETACHED worktree of that repo already sitting on origin's tip.
+# That "already current" home is the shape the old classifier skipped entirely.
+add_repo_backed_mate() {  # <case-dir> <id> [harness] [backend]
+  local dir=$1 id=$2 harness=${3:-claude} backend=${4:-}
+  local home="$dir/home" repo="$dir/fmrepo" smhome="$dir/$id-home"
+  if [ ! -d "$repo" ]; then
+    git init -q --bare "$dir/origin.git"
+    git -C "$dir/origin.git" symbolic-ref HEAD refs/heads/main
+    git clone -q "$dir/origin.git" "$dir/seed" 2>/dev/null
+    mkdir -p "$dir/seed/bin" "$dir/seed/.agents/skills"
+    printf '# agents\n' > "$dir/seed/AGENTS.md"
+    printf 'echo a\n' > "$dir/seed/bin/tool.sh"
+    printf 's1\n' > "$dir/seed/.agents/skills/note.md"
+    # The operational dirs a live home carries are gitignored in a real firstmate
+    # checkout; without that the home would read as dirty and be skipped.
+    printf '/data/\n/state/\n/config/\n/projects/\n/.no-mistakes/\n.fm-secondmate-home\n' \
+      > "$dir/seed/.gitignore"
+    git -C "$dir/seed" add -A
+    git -C "$dir/seed" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm c1
+    git -C "$dir/seed" push -q origin main
+    git clone -q "$dir/origin.git" "$repo"
+    git -C "$repo" remote set-head origin main >/dev/null 2>&1 || true
+    touch "$home/state/.last-watcher-beat"
+  fi
+  git -C "$repo" worktree add -q --detach "$smhome" main
+  mkdir -p "$smhome/state" "$smhome/data" "$home/data/$id"
+  printf '%s\n' "$id" > "$smhome/.fm-secondmate-home"
+  printf '# charter\n' > "$home/data/$id/brief.md"
+  {
+    echo "window=fmses:fm-$id"
+    echo "endpoint_task_id=$id"
+    echo "worktree=$smhome"
+    echo "project=$smhome"
+    echo "harness=$harness"
+    echo "kind=secondmate"
+    echo "mode=secondmate"
+    echo "yolo=off"
+    echo "model=default"
+    echo "effort=default"
+    echo "home=$smhome"
+    [ -z "$backend" ] || echo "backend=$backend"
+  } > "$home/state/$id.meta"
+  printf '%s\n' "fm-$id" >> "$dir/fake/windows"
+  printf '%s' "$smhome" > "$dir/fake/cwd"
+}
+
+# run_update_in_case <case-dir>: the real /updatefirstmate mechanics over that world.
+run_update_in_case() {
+  local dir=$1
+  env PATH="$dir/fakebin:$PATH" FM_FAKE_DIR="$dir/fake" \
+    FM_ROOT_OVERRIDE="$dir/fmrepo" FM_HOME="$dir/home" \
+    FM_SSH_BIN="${FM_TEST_SSH_BIN:-ssh}" \
+    "$ROOT/bin/fm-update.sh" 2>/dev/null
 }
 
 # arm_answer <case-dir> <id>: make the modelled mate answer the persist request.
@@ -617,6 +679,88 @@ SH
   pass "T14 a result published during reaping is honored"
 }
 
+# --- T15: an already-current mate still restarts, end to end -----------------
+# The SSHHIP regression, driven through BOTH real commands rather than either
+# one's own idea of the other. The mate's home needs no fast-forward at all, so
+# the old instruction-diff classifier left it out of every action set and its
+# agent kept running the launch-time wiring it started with. The update pass must
+# now name it, and the restart pass must then persist its open records and only
+# afterwards replace the agent.
+test_already_current_mate_restarts_end_to_end() {
+  local dir out restart_line ids rc head_before head_after doorbell_line exit_line
+  dir=$(new_case already-current)
+  add_repo_backed_mate "$dir" sm1
+  arm_answer "$dir" sm1
+  head_before=$(git -C "$dir/sm1-home" rev-parse HEAD)
+
+  out=$(run_update_in_case "$dir")
+
+  assert_contains "$out" "secondmate sm1: already current" \
+    "the fixture must model a home that needs no advance"
+  restart_line=$(printf '%s\n' "$out" | grep '^restart-secondmates:')
+  assert_contains "$restart_line" "fm-sm1" \
+    "an already-current live second mate must still be named for restart"
+  assert_contains "$out" "nudge-secondmates: none" \
+    "a mate named for restart must not also be steered"
+
+  ids=${restart_line#restart-secondmates: }
+  # shellcheck disable=SC2086
+  out=$(run_restart "$dir" $ids); rc=$?
+
+  expect_code 0 "$rc" "the mate named by the update pass did not restart"$'\n'"$out"
+  assert_contains "$out" "restarted: sm1" "an already-current mate must actually be replaced"
+  assert_contains "$out" "summary: 1 of 1 restarted, 0 nudged, 0 unreached" \
+    "the pass must report the reload it performed"
+  # Persist strictly before replace, read off the pane transcript.
+  doorbell_line=$(grep -n '^Firstmate instruction waiting: ' "$dir/fake/literal" | head -1 | cut -d: -f1)
+  exit_line=$(grep -n '^/exit$' "$dir/fake/literal" | head -1 | cut -d: -f1)
+  [ -n "$doorbell_line" ] || fail "the persist request never reached the already-current mate"
+  [ -n "$exit_line" ] || fail "the already-current mate was never stopped, so it was not restarted"
+  [ "$doorbell_line" -lt "$exit_line" ] \
+    || fail "the agent was stopped before it was asked to persist (persist line $doorbell_line, exit line $exit_line)"
+  # Nothing about the home's git state was touched to buy that restart.
+  head_after=$(git -C "$dir/sm1-home" rev-parse HEAD)
+  [ "$head_after" = "$head_before" ] || fail "the already-current home's checkout moved"
+  [ -z "$(git -C "$dir/sm1-home" status --porcelain)" ] \
+    || fail "the restart left the mate's home dirty"
+  pass "T15 an already-current live mate is named by the update pass and genuinely restarted"
+}
+
+# --- T16: an already-current mate that cannot prove a restart stays honest ----
+# Same already-current home, a runtime with no recovery-grade state classifier.
+# Unconditional restart must not become an unconditional CLAIM of one: the update
+# pass routes it to the re-read steer, and the restart pass reports a nudge with
+# the agent still running.
+test_already_current_unprovable_mate_stays_on_the_nudge_path() {
+  local dir out rc restart_line nudge_line before
+  dir=$(new_case already-current-unprovable)
+  # zellij can never establish "the old agent stopped and the replacement came up".
+  add_repo_backed_mate "$dir" sm1 claude zellij
+  arm_answer "$dir" sm1
+  before=$(cat "$dir/fake/command")
+
+  out=$(run_update_in_case "$dir")
+
+  assert_contains "$out" "secondmate sm1: already current" \
+    "the fixture must model a home that needs no advance"
+  restart_line=$(printf '%s\n' "$out" | grep '^restart-secondmates:')
+  nudge_line=$(printf '%s\n' "$out" | grep '^nudge-secondmates:')
+  assert_not_contains "$restart_line" "sm1" \
+    "a mate whose restart cannot be proven must stay out of the restart set"
+  assert_contains "$nudge_line" "fm-sm1" \
+    "a live mate that cannot be restarted must keep the honest re-read steer"
+
+  out=$(run_restart "$dir" sm1); rc=$?
+
+  expect_code 3 "$rc" "an unprovable restart must not report success"$'\n'"$out"
+  assert_contains "$out" "nudged: sm1:" "the fallback must be reported as a nudge"
+  assert_not_contains "$out" "restarted: sm1" "an unprovable mate must never be reported as reloaded"
+  [ "$(cat "$dir/fake/command")" = "$before" ] \
+    || fail "the unprovable mate's agent was stopped anyway"
+  assert_no_grep '^/exit$' "$dir/fake/literal" "nothing may be stopped on the nudge path"
+  pass "T16 an already-current mate with an unprovable runtime keeps the honest nudge path"
+}
+
 test_persist_gates_and_asks_only_for_open_records
 test_persist_precedes_restart
 test_arrived_answer_precedes_deadline_check
@@ -632,5 +776,7 @@ test_post_stop_failure_is_reported_unreached
 test_relaunches_do_not_block_persist_polling
 test_unpublished_worker_result_is_accounted_for
 test_result_published_while_reaping_is_honored
+test_already_current_mate_restarts_end_to_end
+test_already_current_unprovable_mate_stays_on_the_nudge_path
 
 echo "# all fm-secondmate-restart tests passed"

--- a/tests/fm-update.test.sh
+++ b/tests/fm-update.test.sh
@@ -14,10 +14,12 @@
 #   - The caller-action summary is correct: reread-firstmate flips to yes only
 #     when the instruction surface (AGENTS.md / bin / .agents/skills) changed, and
 #     the two secondmate action sets are disjoint and correctly gated -
-#     restart-secondmates carries a live mate whose AGENTS.md or .agents/skills/
-#     changed AND whose recorded runtime can prove a restart, nudge-secondmates
-#     carries the residual, and an advance that changed no instruction surface,
-#     or only bin/, produces no restart at all.
+#     restart-secondmates carries EVERY live mate this pass left on origin's tip
+#     whose recorded runtime can prove a restart, INCLUDING one that was already
+#     there and one whose advance touched no instruction surface, because a
+#     restart is also what re-resolves launch-time harness wiring; a live mate
+#     whose runtime cannot prove a restart falls to nudge-secondmates; and a mate
+#     whose home was skipped or whose endpoint is stopped gets no action at all.
 #   - Secondmate homes resolve from both state/<id>.meta and the
 #     data/secondmates.md registry, deduped, and the firstmate repo is never
 #     re-processed as one of its own secondmates.
@@ -183,16 +185,19 @@ test_reread_gate_is_instruction_only() {
 
   assert_contains "$out" "firstmate: updated " "firstmate still advanced"
   assert_contains "$out" "reread-firstmate: no" "non-instruction change skips reread"
-  # Nothing the secondmate reads or runs moved, so neither action set names it.
-  assert_contains "$out" "restart-secondmates: none" "a README-only advance must not restart anything"
-  assert_contains "$out" "nudge-secondmates: none" "a README-only advance must not steer anything"
-  pass "T3 an advance that touched no instruction surface produces no secondmate action"
+  # The running firstmate reads nothing new, but the mate's agent still holds its
+  # launch-time wiring from before the pass, which only a restart re-resolves.
+  assert_contains "$out" "restart-secondmates: fm-sm1" \
+    "a live mate on the new tip must restart even when no instruction file moved"
+  assert_contains "$out" "nudge-secondmates: none" "a restarted secondmate must not also be nudged"
+  pass "T3 a non-instruction advance still restarts the live secondmate"
 }
 
-# --- T3b: a bin/-only advance is nudged but never restarted ----------------
-# Every helper under bin/ is executed fresh on each call, so that advance reaches
-# the mate without a new conversation; spending one would be pure cost.
-test_bin_only_advance_never_restarts() {
+# --- T3b: a bin/-only advance restarts too ---------------------------------
+# Helpers under bin/ do reload themselves on the next call, but the mate's agent
+# still froze its launch-time harness wiring before this pass, so the restart is
+# not redundant and the old bin/-only carve-out no longer applies.
+test_bin_only_advance_restarts() {
   local w out
   w=$(new_world t3b)
   add_sm "$w" sm1
@@ -201,9 +206,9 @@ test_bin_only_advance_never_restarts() {
   out=$(run_update "$w")
 
   assert_contains "$out" "reread-firstmate: yes" "a bin/ change is still an instruction-surface advance"
-  assert_contains "$out" "restart-secondmates: none" "a bin/-only advance must not cost a conversation"
-  assert_contains "$out" "nudge-secondmates: fm-sm1" "a bin/-only advance still steers the secondmate"
-  pass "T3b a bin/-only advance steers the secondmate instead of restarting it"
+  assert_contains "$out" "restart-secondmates: fm-sm1" "a bin/-only advance must still restart the live mate"
+  assert_contains "$out" "nudge-secondmates: none" "a restarted secondmate must not also be nudged"
+  pass "T3b a bin/-only advance restarts the secondmate"
 }
 
 # --- T3c: an unverifiable runtime receives the fallback nudge ----------------
@@ -238,8 +243,10 @@ test_dead_secondmate_gets_no_action() {
   pass "T3d an already-stopped secondmate is left to startup recovery"
 }
 
-# --- T3e: a legacy remote advance gets the safe fallback steer --------------
-test_legacy_remote_advance_is_nudged() {
+# --- T3e: a legacy remote advance still restarts ---------------------------
+# The host's instr= suffix is reporting detail; the parent no longer routes on it,
+# so an older host that cannot report a diff can no longer suppress the restart.
+test_legacy_remote_advance_restarts() {
   local w out fake_ssh
   w=$(new_world t3e)
   fake_ssh="$w/fakebin/fake-ssh"
@@ -280,11 +287,11 @@ EOF
 
   assert_contains "$out" "remote secondmate sm1: updated on remote-mac" \
     "the legacy remote advance was not accepted"
-  assert_contains "$out" "restart-secondmates: none" \
-    "an unknown remote instruction diff must not authorize restart"
-  assert_contains "$out" "nudge-secondmates: fm-sm1" \
-    "an unknown remote instruction diff must receive the safe re-read steer"
-  pass "T3e a legacy remote advance falls back to the re-read steer"
+  assert_contains "$out" "restart-secondmates: fm-sm1" \
+    "a live remote mate on the new tip must restart even when the host reports no instruction diff"
+  assert_contains "$out" "nudge-secondmates: none" \
+    "a restarted remote mate must not also be steered"
+  pass "T3e a legacy remote advance still restarts the live remote mate"
 }
 
 # --- T4: dirty secondmate is skipped, its edit preserved -------------------
@@ -325,21 +332,46 @@ test_diverged_secondmate_skipped() {
   pass "T5 diverged secondmate skipped, local commit preserved"
 }
 
-# --- T6: idempotent; second run reports already current --------------------
-test_idempotent_already_current() {
-  local w out
+# --- T6: the git side is idempotent; the restart set is not -----------------
+# This is the SSHHIP case: that mate's home was already at the target commit, so
+# the old classifier skipped it entirely and its agent kept running the launch-time
+# wiring it started with. An already-current live mate must still be restarted.
+test_already_current_secondmate_still_restarts() {
+  local w out restart_line
   w=$(new_world t6)
   add_sm "$w" sm1
   bump_origin "$w" instr
   run_update "$w" >/dev/null   # first run advances both
 
-  out=$(run_update "$w")       # second run: nothing to do
+  out=$(run_update "$w")       # second run: nothing left to fast-forward
 
   assert_contains "$out" "firstmate: already current" "firstmate already current"
   assert_contains "$out" "secondmate sm1: already current" "secondmate already current"
   assert_contains "$out" "reread-firstmate: no" "no reread when nothing changed"
-  assert_contains "$out" "nudge-secondmates: none" "no nudge when nothing advanced"
-  pass "T6 idempotent: a second run is a no-op"
+  restart_line=$(printf '%s\n' "$out" | grep '^restart-secondmates:')
+  assert_contains "$restart_line" "fm-sm1" \
+    "an already-current live secondmate must still be in the restart set"
+  assert_contains "$out" "nudge-secondmates: none" "a restarted secondmate must not also be nudged"
+  pass "T6 an already-current live secondmate is still restarted"
+}
+
+# --- T6b: an already-current mate that cannot be restarted stays honest -----
+# Unconditional restart must not become an unconditional CLAIM of one.
+test_already_current_unprovable_mate_is_nudged() {
+  local w out restart_line nudge_line
+  w=$(new_world t6b)
+  add_sm "$w" sm1 claude zellij
+  bump_origin "$w" instr
+  run_update "$w" >/dev/null   # first run advances both
+
+  out=$(run_update "$w")       # second run: the home is already on the tip
+
+  assert_contains "$out" "secondmate sm1: already current" "the mate must need no advance"
+  restart_line=$(printf '%s\n' "$out" | grep '^restart-secondmates:')
+  nudge_line=$(printf '%s\n' "$out" | grep '^nudge-secondmates:')
+  assert_not_contains "$restart_line" "sm1" "an unprovable runtime must stay out of the restart set"
+  assert_contains "$nudge_line" "fm-sm1" "an unprovable runtime must keep the honest re-read steer"
+  pass "T6b an already-current mate with an unprovable runtime is steered, not claimed as reloaded"
 }
 
 # --- T7: registry backstop + dedup + self-exclusion, one world -------------
@@ -441,13 +473,14 @@ test_unsafe_secondmate_home_skipped_before_git_update() {
 
 test_updates_main_and_secondmate
 test_reread_gate_is_instruction_only
-test_bin_only_advance_never_restarts
+test_bin_only_advance_restarts
 test_unprovable_runtime_gets_fallback_nudge
 test_dead_secondmate_gets_no_action
-test_legacy_remote_advance_is_nudged
+test_legacy_remote_advance_restarts
 test_dirty_secondmate_skipped
 test_diverged_secondmate_skipped
-test_idempotent_already_current
+test_already_current_secondmate_still_restarts
+test_already_current_unprovable_mate_is_nudged
 test_registry_backstop_dedup_and_self_exclusion
 test_firstmate_wrong_branch_skipped
 test_firstmate_detached_head_skipped


### PR DESCRIPTION
## Intent

Captain (2026-09-04, exact ask): every home must restart on /updatefirstmate even if it was already on the right commit, because some harness features do not get reloaded until a clean restart.

Current behavior (the gap): a live second mate is restarted only when that pass advanced AGENTS.md or .agents/skills and the runtime can prove a restart; already-current homes are skipped with no restart; a bin-only advance does not restart; a missing instruction-file list is treated as unknown and becomes a re-read, never a replace.

Required behavior:
- After a successful /updatefirstmate, EVERY live second mate home restarts (persist open records, then replace the agent), INCLUDING homes that were already on the target commit.
- Re-read is NOT a substitute: harness launch-time features (hooks, flags, composer/feedback disable, and similar) only apply on a clean restart.
- Keep persist-before-replace. Do NOT force, stash, or discard. A mate that cannot be restarted provably stays on the honest unreached/nudge path rather than being reported as reloaded.
- Add a regression that fails if an already-current live second mate is omitted from the restart set.

This supersedes an abandoned targeted classification fix on branch fm/fm-remote-update-first-reporter-r1; do not revive that approach. The grounding evidence is a second mate named SSHHIP that was the first remote mate on the mac-home firstmate: on a /updatefirstmate pass its home was already at the target commit and its host reported no instruction-file diff, so the old classifier left it out of both the restart set and the nudge set entirely, and its agent kept running the launch-time harness wiring it had started with.

Delivery: no-mistakes, yolo off (a Firstmate instruction-surface change; the captain owns the merge).

## What Changed

- Restart every live second mate successfully left on the target commit, including already-current homes and non-instruction-only updates.
- Preserve persist-before-replace behavior while routing unprovable restarts to the honest nudge path and leaving skipped or stopped mates untouched.
- Add regression coverage for already-current local and remote mates and document the updated restart contract.

## Risk Assessment

✅ Low: The change is well-bounded, satisfies the restart and fallback invariants, preserves persist-before-replace safety, and includes executable regressions for already-current and unprovable-runtime paths.

## Testing

The pre-run changed-test baseline and both focused behavior suites passed; an end-to-end already-current SSHHIP fixture was selected for restart, persisted before replacement, restarted successfully rather than nudged, and retained an unchanged clean checkout.

<details>
<summary>Evidence: Already-current second mate update-and-restart transcript</summary>

Source: [Already-current second mate update-and-restart transcript](https://github.com/kunchenguid/firstmate/blob/2fa5e2ec6627e52f555b32875ec72c0f416977a2/.no-mistakes/evidence/fm/fm-updatefirstmate-always-restart-r1/already-current-e2e-transcript.txt)

```text
=== 1. /updatefirstmate mechanical output ===
firstmate: already current
secondmate SSHHIP: already current
reread-firstmate: no
restart-secondmates: fm-SSHHIP
nudge-secondmates: none

=== 2. restart action consumed from update output ===
invocation: fm-secondmate-restart.sh fm-SSHHIP
restarted: SSHHIP (claude)
summary: 1 of 1 restarted, 0 nudged, 0 unreached
exit-status: 0

=== 3. end-user-visible terminal chronology (persist before replace) ===
1:Firstmate instruction waiting: list /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-secondmate-restart.DR6sOY/reviewer-e2e-24759/home/state/SSHHIP.inbox/*.msg and, in numeric order, read and act on each, then mv each handled file to /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-secondmate-restart.DR6sOY/reviewer-e2e-24759/home/state/SSHHIP.inbox/handled/.
2:/exit

=== 4. home safety checks ===
HEAD-before: c7d7f8be1584b0c1b0bc5ce4ac972c396071c993
HEAD-after:  c7d7f8be1584b0c1b0bc5ce4ac972c396071c993
working-tree-status: 
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"10f6a37656bfb1cb7fc764858b1acc39a595a826","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>Baseline (pre-run): `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`</code>
- `bin/fm-test-run.sh tests/fm-update.test.sh`
- `bin/fm-test-run.sh tests/fm-secondmate-restart.test.sh`
- <code>Executed an isolated end-to-end SSHHIP scenario through real `bin/fm-update.sh` output and `bin/fm-secondmate-restart.sh`, recording restart selection, persist-before-exit chronology, and unchanged clean home state.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
