### PR TITLE
feat: add verified Gemini crewmate runtime

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -3,7 +3,7 @@ name: harness-adapters
 description: >-
   Agent-only reference for firstmate harness operations.
   Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
-  Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, and muse.
+  Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, gemini, and muse.
 user-invocable: false
 metadata:
   internal: true
@@ -35,7 +35,7 @@ For recovery and control, use the exact `harness=` in `state/<id>.meta`; never i
 Deliver lifecycle actions only through `../../../bin/fm-control.sh <task-id> interrupt|exit|relaunch`.
 Never type an interrupt key or exit command through `fm-send`, where routing-marked lifecycle text becomes chat.
 Trust handling is complete only when inspection proves the target started processing its instructions; delivery success alone is not proof.
-Muse is verified only for crewmate and scout work, never a secondmate or primary.
+Muse and Gemini are verified only for crewmate and scout work, never a secondmate or primary.
 
 ## Detection
 
@@ -52,7 +52,7 @@ A new adapter's verified marker and command name must land in `../../../bin/fm-h
 Every emitted plan appends the selected or recorded harness reference after the named common references.
 The `harness-adapter-routing-v1` object is the machine-readable and human-visible selection contract: choose the operation, choose the scenario within it, then append the selected harness reference.
 `default` is the normal scenario when no narrower scenario applies.
-Kimi establishes its unsupported primary boundary in its selected harness reference; Muse follows Non-negotiable safety above.
+Kimi establishes its unsupported primary boundary in its selected harness reference; Muse and Gemini follow Non-negotiable safety above.
 A new tool remains undispatchable until the `verify` plan, its harness entry, every named owner, and the live checks land.
 
 ```json harness-adapter-routing-v1
@@ -89,6 +89,7 @@ A new tool remains undispatchable until the `verify` plan, its harness entry, ev
     "grok": "references/harness/grok.md",
     "kimi": "references/harness/kimi.md",
     "cursor": "references/harness/cursor.md",
+    "gemini": "references/harness/gemini.md",
     "muse": "references/harness/muse.md"
   }
 }

--- a/.agents/skills/harness-adapters/references/harness/gemini.md
+++ b/.agents/skills/harness-adapters/references/harness/gemini.md
@@ -1,0 +1,107 @@
+# Gemini CLI
+
+Google's `gemini` TUI, verified end to end on 2026-09-04 with gemini-cli 0.58.0 on Linux.
+Launch shape: `GEMINI_CLI_TRUST_WORKSPACE=true gemini -y "$(cat <brief>)"`.
+Verified as a CREWMATE and SCOUT adapter only; `../../../../../bin/fm-spawn.sh` refuses a secondmate launch on it because `../../../../../docs/supervision-protocols/` carries no gemini wake protocol.
+
+## Operating facts
+
+| Fact | Value |
+|---|---|
+| Busy state | Semantic `gemini-hook`: `BeforeAgent` opens a turn, `AfterAgent` and `SessionEnd` close it. `AfterAgent` also fires on a manual interrupt, so a cancelled turn closes its own record. |
+| Rendered tail | Not a state source, but the running turn's status row is the one ASCII busy token: `(esc to cancel, <n>s)`, absent when idle. The phase text beside it is model-generated and varies per turn, and the spinner is braille; neither is ever a signal. |
+| Turn end | `AfterAgent` fires once per turn after the final response, carrying `cwd`, `session_id`, `prompt`, `prompt_response`, `stop_hook_active`, and `transcript_path`. On a cancelled turn `prompt_response` is `[no response text]`. |
+| Exit | `/quit` (alias `/exit`), one Enter, exit status 0; prints `To resume this session: gemini --resume <session-id>`. `Ctrl+C` cancels or quits on empty input and `Ctrl+D` exits on an empty buffer. |
+| Interrupt | Single `Escape`, which prints `ℹ Request cancelled.` and leaves the agent running. The composer does not repollute; it returns to its `Type your message or @path/to/file` placeholder. |
+| Skill | `/<skill>`, for example `/no-mistakes`; ONE Enter submits, with no popup swallow, and the turn opens with an `Activate Skill` tool call. |
+| Autonomy | `-y` / `--yolo`, footer ` YOLO Ctrl+Y`, verified unattended on a real file write with no approval gate; `--approval-mode yolo` is the equivalent long form. |
+| Marker | `GEMINI_CLI=1` on child and tool processes. `AI_AGENT` is NOT a Gemini identity - see Detection below. |
+| Resume | `gemini --resume <session-id>` restores full history; `--resume latest` and an index are also accepted, and `--list-sessions` enumerates them per project. |
+| Model | `-m` / `--model <model>`; discover through the interactive `/model` dialog. There is no `gemini models` subcommand, and the session's exit usage table also names the models actually used. |
+| Effort | None. `gemini --help` on 0.58.0 exposes no effort, reasoning, or thinking flag, so `references/common/model-and-effort.md`'s record-and-omit contract applies. `thinkingLevel` and `thinkingBudget` exist only as generation settings inside `settings.json` and are NOT a verified interactive axis. |
+
+## Trust, and why the two documented options are not equivalent
+
+Every task worktree is a path Gemini has never seen, so an unhandled launch refuses outright:
+`Gemini CLI is not running in a trusted directory. To proceed, either use --skip-trust, set the GEMINI_CLI_TRUST_WORKSPACE=true environment variable, or trust this directory in interactive mode.`
+Headless, that refusal exits 55.
+
+The CLI presents those two options as equivalents and they are not.
+A controlled A/B on one worktree - same config home, same prompt, only the trust mechanism changed - showed `--skip-trust` runs the turn while leaving PROJECT configuration unloaded, so the project's own hooks never fire and its `.agents/skills` are never discovered, while `GEMINI_CLI_TRUST_WORKSPACE=true` loads both.
+A firstmate-repo task needs exactly those workspace skills, so the spawn uses the environment variable and `--skip-trust` must not be substituted for it.
+Firstmate's OWN busy hooks do not depend on this, because they ride the system settings layer described below.
+Trusting the workspace loads that project's `.gemini/settings.json`, hooks, MCP servers, and skills, which is the same posture the other adapters already run under in a task worktree.
+
+The interactive trust dialog is `Do you trust the files in this folder?` with three choices.
+Unlike Claude's, its default selection is the SAFE one: `● 1. Trust folder (<name>)`, with `2. Trust parent folder (<parent>)` and `3. Don't trust` unselected.
+Accepting persists to `~/.gemini/trustedFolders.json`, so the spawn's environment variable is preferred: it is per-session and leaves no growing global record of disposable worktree paths.
+
+## Credential precondition, and the wedge it causes
+
+A Gemini worker needs a credential it can use without a dialog, and firstmate does not manage one.
+Export `GEMINI_API_KEY` into the environment BEFORE the session-provider daemon starts, or complete `gemini`'s own sign-in.
+The daemon matters: a long-lived tmux or Herdr server hands panes the environment it was started with, so a key exported after that server came up never reaches a worker.
+The headless probe `gemini --skip-trust -p '<prompt>'` exits 41 with `you must specify the GEMINI_API_KEY environment variable` when no credential is resolvable, which is the cheapest pre-dispatch confirmation.
+A first run also shows an auth-method picker (`How would you like to authenticate for this project?`, default `● 2. Use Gemini API Key`); answering it once writes `security.auth.selectedType` to the user `settings.json` and it does not return.
+
+With no credential the pane wedges on an `Enter Gemini API Key` dialog, and that dialog is dangerous in two distinct ways.
+It RENDERS THE KEY IN PLAINTEXT in the pane once a value is present, where any capture or debug log would retain it, and the launch brief fails behind it with `API Error: Content generator not initialized`.
+Worse, it is a credential field that accepts whatever is typed next: sending the ordinary exit command to a wedged pane submits `/quit` INTO it and persists it as a stored credential in `~/.gemini/gemini-credentials.json`.
+That poisons the machine for every later run - a credential-less run then stops failing cleanly with exit 41 and instead reaches the API and fails per request with `API key not valid` - and it is repairable only by clearing that stored credential.
+So never drive lifecycle text into a gemini pane that is showing this dialog.
+Treat it as a credential blocker under `../../../../../AGENTS.md` section 9, fix the environment, and retire the endpoint rather than typing into it.
+
+Do NOT give a worker an isolated `GEMINI_CLI_HOME`.
+It hides `~/.agents/skills`, so `/no-mistakes` and every other user skill silently disappear from that worker.
+
+## Detection
+
+`GEMINI_CLI=1` is load-bearing rather than a fast path, so `../../../../../bin/fm-harness.sh` checks it BEFORE `CLAUDECODE`.
+Gemini does not clear an inherited `CLAUDECODE`, so a gemini worker under a claude primary carries both markers and whichever is tested first wins; the spawn additionally clears the foreign markers at the launch boundary.
+
+Ancestry cannot cover the gap.
+The shipped CLI is a node bundle (`~/.local/bin/gemini` -> `@google/gemini-cli/bundle/gemini.js`) and modern Node on Linux reports `comm` as `MainThread` rather than `node` (measured on Node v24.20.0), so neither the command-name arm nor the interpreter arm matches a live gemini process.
+Do not close that by matching `MainThread`: it would make every node process's arguments searchable and let an unrelated command claim an identity.
+`../../../../../tests/fm-gemini-harness.test.sh` pins both the marker precedence and this ancestry boundary.
+
+`AI_AGENT` must never be promoted to a marker.
+The same verified tool process carried the CLAUDE primary's value (`claude-code_2-1-260_agent`), so it identifies the launcher, not the running harness.
+
+Pane liveness has the same problem and needs its own answer, because the marker is not visible to a process scan.
+A live gemini pane's foreground group reads `comm=MainThread` and `argv0=<node path>`, so neither of `bin/backends/tmux.sh`'s existing name sources can see it, and `bin/fm-control.sh` refused every lifecycle verb with `endpoint reads 'ambiguous'` until this was closed.
+`../../../../../bin/fm-gemini-lib.sh` owns the narrow structural rule that fixes it: identity comes from argv[1], the script argument, accepted only when it is named `gemini` or lives under `@google/gemini-cli/`.
+It is structural and runs no subprocess, for the same reason cursor's rule does not: probing a stranger's binary during a liveness poll is the hazard being avoided.
+A bare interpreter, an unrelated node script, and a gemini name appearing later on a command line are all rejected, so a stranger's node pane is never reported as a live agent.
+
+## Worker busy state and turn end
+
+`../../../../../bin/fm-spawn.sh` writes a firstmate-owned per-task settings file at `state/<id>.gemini-settings.json` with three hooks bound to the minted busy generation, and the launch reaches it through `GEMINI_CLI_SYSTEM_SETTINGS_PATH`.
+It is deliberately NOT the worktree's `.gemini/settings.json`: unlike Claude's `settings.local.json`, that path is the PROJECT's own committed settings file, so writing it would clobber a project's configuration and retiring it would delete a tracked file.
+Hook arrays MERGE across Gemini's settings layers rather than overriding, so a project's own hooks still run alongside firstmate's; both were observed firing for one turn.
+`../../../../../bin/fm-teardown.sh` removes the file, so nothing survives into a pooled worktree.
+`BeforeAgent` records busy, `AfterAgent` records idle and keeps the `state/<id>.turn-ended` touch as the watcher NOTIFICATION, and `SessionEnd` records idle so an abnormal end cannot strand a busy record.
+Each hook command prints the empty JSON object Gemini's hook contract requires and tolerates a refused event, so a stale-generation writer can never break Gemini's own lifecycle.
+
+Two quirks are wired for deliberately.
+`SessionEnd` was observed firing TWICE for one `/quit`; the repeated idle event is idempotent and is not de-duplicated.
+`AfterAgent` fires on a manual Escape interrupt as well as on normal completion, which is better than Claude, whose interrupt emits no hook and usually leaves `claude-hook` busy.
+
+The system settings layer also makes the busy contract independent of the trust decision: its hooks were verified firing under `--skip-trust` in an untrusted folder, and they need no entry in Gemini's per-workspace `~/.gemini/trusted_hooks.json`, which only records PROJECT hooks.
+Workspace trust therefore buys skills, not state.
+A guarded user-level hook in `~/.gemini/settings.json` was also proven to work, gated grok-style by a worktree pointer and a private token registry, and was rejected because it mutates the captain's own global settings for every session on the machine.
+
+While a hook runs, the status row shows `Executing Hook: <name>` and the `(esc to cancel,` token is already gone, so that brief window reads idle; the turn itself is genuinely over by then.
+
+## Skills
+
+Gemini discovers user skills from `~/.gemini/skills/` or `~/.agents/skills/` and workspace skills from `.gemini/skills/` or `.agents/skills/`.
+`~/.agents/skills/no-mistakes` is therefore discovered as a user skill and loads even in an untrusted folder, which is what keeps firstmate's delivery path available.
+Workspace skills need the workspace trust the launch already grants, which is what makes a firstmate-repo task's own `.agents/skills` reachable.
+Gemini does NOT read `.claude/skills`.
+
+## Primary integration
+
+Unsupported and unverified.
+`../../../../../docs/supervision-protocols/` carries no gemini protocol, no turn-end guard adapter exists for it, and this adapter verified only the crewmate-side launch, busy state, interrupt, and exit.
+`references/common/primary-hooks.md`'s unsupported-boundary rule applies: never invent a wake protocol from a similar TUI.
+Gemini's `BeforeAgent`/`AfterAgent` pair and its `gemini hooks migrate` command make a future primary integration plausible, but it remains unbuilt work, not a fact to rely on.

--- a/.agents/skills/harness-adapters/references/harness/gemini.md
+++ b/.agents/skills/harness-adapters/references/harness/gemini.md
@@ -76,6 +76,8 @@ A bare interpreter, an unrelated node script, and a gemini name appearing later 
 ## Worker busy state and turn end
 
 `../../../../../bin/fm-spawn.sh` writes a firstmate-owned per-task settings file at `state/<id>.gemini-settings.json` with three hooks bound to the minted busy generation, and the launch reaches it through `GEMINI_CLI_SYSTEM_SETTINGS_PATH`.
+This wiring belongs only to the canonical exact `gemini` adapter template, which receives busy-state wiring, the turn-end hook, and trusted busy state together.
+A raw Gemini-shaped launch is an unverified escape hatch: it receives no busy-state wiring or turn-end hook and therefore has no trusted busy state.
 It is deliberately NOT the worktree's `.gemini/settings.json`: unlike Claude's `settings.local.json`, that path is the PROJECT's own committed settings file, so writing it would clobber a project's configuration and retiring it would delete a tracked file.
 Hook arrays MERGE across Gemini's settings layers rather than overriding, so a project's own hooks still run alongside firstmate's; both were observed firing for one turn.
 `../../../../../bin/fm-teardown.sh` removes the file, so nothing survives into a pooled worktree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ state/               runtime records and signals; gitignored
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
   <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
+  <id>.gemini-settings.json  firstmate-owned per-task Gemini settings carrying the busy-state and turn-end hooks, reached through GEMINI_CLI_SYSTEM_SETTINGS_PATH so nothing is written into the project's own .gemini/; removed by teardown
   <id>.muse-session  muse busy-source binding (sessions root plus task worktree) written by fm-spawn; removed by teardown
   <id>.cursor-session  cursor busy-source binding (projects root, task worktree, prior conversations) written by fm-spawn; removed by teardown
   <id>.reconcile-nudged  epoch second of the last inventory-reconcile nudge sent to this secondmate; bin/fm-secondmate-reconcile.sh owns its per-home cooldown window
@@ -198,7 +199,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `cursor`, plus `muse` for crewmates and scouts only; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `cursor`, plus `muse` and `gemini` for crewmates and scouts only; never dispatch on an unverified adapter.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -24,6 +24,8 @@
 . "$FM_BACKEND_LIB_DIR/fm-session-lock-lib.sh"
 # shellcheck source=bin/fm-cursor-lib.sh
 . "$FM_BACKEND_LIB_DIR/fm-cursor-lib.sh"
+# shellcheck source=bin/fm-gemini-lib.sh
+. "$FM_BACKEND_LIB_DIR/fm-gemini-lib.sh"
 
 # fm_backend_tmux_resolve_bare_selector: the live-window-listing fallback for a
 # selector that is neither an explicit target nor a task selector routed
@@ -231,6 +233,22 @@ fm_backend_tmux_foreground_comms() {  # <target>
       done
 }
 
+# The foreground group's full command lines. Needed because a node-bundle
+# harness carries its identity in argv[1] rather than in its command name or
+# argv[0]; bin/fm-gemini-lib.sh owns what counts as evidence inside one.
+fm_backend_tmux_foreground_args() {  # <target>
+  local target=$1 tty pid pgid tpgid comm args
+  tty=$(tmux display-message -p -t "$target" '#{pane_tty}' 2>/dev/null) || return 0
+  [ -n "$tty" ] || return 0
+  LC_ALL=C ps -t "${tty#/dev/}" -o pid=,pgid=,tpgid=,comm= 2>/dev/null \
+    | while read -r pid pgid tpgid comm; do
+        [ -n "$comm" ] || continue
+        [ "$pgid" = "$tpgid" ] || continue
+        args=$(LC_ALL=C ps -p "$pid" -o args= 2>/dev/null) || continue
+        [ -n "$args" ] && printf '%s\n' "$args"
+      done
+}
+
 fm_backend_tmux_foreground_argv0s() {  # <target>
   local target=$1 tty pid pgid tpgid comm args argv0
   tty=$(tmux display-message -p -t "$target" '#{pane_tty}' 2>/dev/null) || return 0
@@ -315,6 +333,20 @@ EOF
     fi
   done <<EOF
 $argv0s
+EOF
+
+  # A node-bundle harness is invisible to both name sources above: its comm is
+  # MainThread and its argv[0] is the interpreter, so gemini is identified from
+  # the script argument instead. Positive evidence only - a bare interpreter
+  # still falls through to the negative verdicts below.
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    if fm_gemini_args_are_gemini "$name"; then
+      printf 'alive'
+      return 0
+    fi
+  done <<EOF
+$(fm_backend_tmux_foreground_args "$target")
 EOF
 
   comm=$(fm_backend_tmux_current_command "$target") || {

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -249,6 +249,18 @@ fm_backend_tmux_foreground_args() {  # <target>
       done
 }
 
+fm_backend_tmux_foreground_pids() {  # <target>
+  local target=$1 tty pid pgid tpgid comm
+  tty=$(tmux display-message -p -t "$target" '#{pane_tty}' 2>/dev/null) || return 0
+  [ -n "$tty" ] || return 0
+  LC_ALL=C ps -t "${tty#/dev/}" -o pid=,pgid=,tpgid=,comm= 2>/dev/null \
+    | while read -r pid pgid tpgid comm; do
+        [ -n "$comm" ] || continue
+        [ "$pgid" = "$tpgid" ] || continue
+        printf '%s\n' "$pid"
+      done
+}
+
 fm_backend_tmux_foreground_argv0s() {  # <target>
   local target=$1 tty pid pgid tpgid comm args argv0
   tty=$(tmux display-message -p -t "$target" '#{pane_tty}' 2>/dev/null) || return 0
@@ -282,7 +294,7 @@ fm_backend_tmux_foreground_argv0s() {  # <target>
 # distinguish a truly idle pane from a rewritten process title.
 fm_backend_tmux_agent_state() {  # <target>
   local target=$1 comm session window windows inventory_status
-  local foreground argv0s name fg_seen=0 fg_shell=0 fg_other=0
+  local foreground argv0s name pid fg_seen=0 fg_shell=0 fg_other=0
   case "$target" in
     *:*:*|'':*|*:'') printf 'unreadable'; return 0 ;;
     *:*) ;;
@@ -335,10 +347,21 @@ EOF
 $argv0s
 EOF
 
-  # A node-bundle harness is invisible to both name sources above: its comm is
-  # MainThread and its argv[0] is the interpreter, so gemini is identified from
-  # the script argument instead. Positive evidence only - a bare interpreter
-  # still falls through to the negative verdicts below.
+  # Preserve argv boundaries where the platform exposes them. This is needed
+  # when the Gemini script path contains whitespace, which flattened ps output
+  # cannot represent unambiguously.
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    if fm_gemini_pid_is_gemini "$pid"; then
+      printf 'alive'
+      return 0
+    fi
+  done <<EOF
+$(fm_backend_tmux_foreground_pids "$target")
+EOF
+
+  # Fall back to flattened arguments on platforms without /proc. Positive
+  # evidence only - a bare interpreter still reaches the negative verdicts.
   while IFS= read -r name; do
     [ -n "$name" ] || continue
     if fm_gemini_args_are_gemini "$name"; then

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -31,6 +31,8 @@
 #   pi-ext           Pi/pi-signed per-task extension (agent_start/agent_settled)
 #   opencode-plugin  OpenCode per-task plugin (session.status)
 #   claude-hook      Claude lifecycle hooks (UserPromptSubmit/Stop/StopFailure/SessionEnd)
+#   gemini-hook      Gemini agent hooks (BeforeAgent opens; AfterAgent and
+#                    SessionEnd close)
 #   codex-hook, codex-appserver  reserved: Codex, gated by
 #                    fm_busy_codex_semantic_source
 #   kimi-wire, kimi-hook  reserved: standalone Kimi, gated by fm_busy_kimi_verified
@@ -191,6 +193,7 @@ fm_busy_sources_for_harness() {  # <harness>
       adapter='codex-hook codex-appserver'
       ;;
     opencode*) adapter=opencode-plugin ;;
+    gemini*) adapter=gemini-hook ;;
     pi|pi-signed) adapter=pi-ext ;;
     kimi*)
       fm_busy_kimi_verified || { printf ''; return 0; }

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -63,7 +63,7 @@ fm_control_verb_allowed() {  # <verb>
 # than guessed at, exactly as a spawn on it would be.
 fm_control_harness_supported() {  # <harness>
   case "${1-}" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse) return 0 ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse) return 0 ;;
   esac
   return 1
 }
@@ -86,14 +86,15 @@ fm_control_harness_family() {  # <recorded-harness>
     grok*) printf 'grok' ;;
     kimi*) printf 'kimi' ;;
     cursor*) printf 'cursor' ;;
+    gemini*) printf 'gemini' ;;
     muse*) printf 'muse' ;;
     *) return 1 ;;
   esac
 }
 
-# Which task kinds an adapter is verified to run. muse is a crewmate/scout
-# adapter only: it has no primary supervision protocol, and bin/fm-spawn.sh
-# refuses a --secondmate launch on it. The control plane
+# Which task kinds an adapter is verified to run. muse and gemini are
+# crewmate/scout adapters only: neither has a primary supervision protocol,
+# and bin/fm-spawn.sh refuses a --secondmate launch on either. The control plane
 # asks this BEFORE it stops anything, so an incompatible relaunch target is
 # refused while the current agent is still running rather than after it has
 # been stopped.
@@ -101,16 +102,18 @@ fm_control_harness_supports_kind() {  # <harness> <kind>
   local harness=${1-} kind=${2-}
   fm_control_harness_supported "$harness" || return 1
   case "$harness" in
-    muse) [ "$kind" != secondmate ] || return 1 ;;
+    muse|gemini) [ "$kind" != secondmate ] || return 1 ;;
   esac
   return 0
 }
 
 # The key that cancels a running turn. Escape for every adapter except grok,
 # whose Esc only moves focus to the scrollback; grok cancels on Ctrl+C.
+# gemini names its own key in the running turn's status row
+# (`(esc to cancel, <n>s)`), and a single Escape was verified to cancel it.
 fm_control_interrupt_key() {  # <harness>
   case "${1-}" in
-    claude|codex|opencode|pi|pi-signed|kimi|cursor|muse) printf 'Escape' ;;
+    claude|codex|opencode|pi|pi-signed|kimi|cursor|gemini|muse) printf 'Escape' ;;
     grok) printf 'C-c' ;;
     *) return 1 ;;
   esac
@@ -121,7 +124,7 @@ fm_control_interrupt_key() {  # <harness>
 fm_control_interrupt_repeat() {  # <harness>
   case "${1-}" in
     opencode) printf '2' ;;
-    claude|codex|pi|pi-signed|grok|kimi|cursor|muse) printf '1' ;;
+    claude|codex|pi|pi-signed|grok|kimi|cursor|gemini|muse) printf '1' ;;
     *) return 1 ;;
   esac
 }
@@ -133,13 +136,16 @@ fm_control_interrupt_repeat() {  # <harness>
 # make the next submitted line - a steer, or this plane's own exit command -
 # concatenate onto it. cursor was checked for exactly that behaviour and does
 # NOT repollute: after a single Escape its composer shows only the `Add a
-# follow-up` placeholder, so it needs no clear key. Prints the key or nothing;
+# follow-up` placeholder, so it needs no clear key. gemini was checked the
+# same way and also does not repollute: after a single Escape it prints
+# `Request cancelled.` and its composer shows only the `Type your message
+# or @path/to/file` placeholder. Prints the key or nothing;
 # a harness with no verified mechanics returns nonzero, matching the tables
 # above.
 fm_control_interrupt_clear_key() {  # <harness>
   case "${1-}" in
     muse) printf 'C-u' ;;
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor) ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini) ;;
     *) return 1 ;;
   esac
 }
@@ -151,7 +157,7 @@ fm_control_interrupt_ack_source() {  # <harness>
     # after an interrupt was measured as variable - sometimes seconds, sometimes
     # not within 20 - so a cancellation claim built on it would be unreliable.
     # Normal turn completion is prompt, which is what the busy fold depends on.
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor) printf 'none' ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini) printf 'none' ;;
     *) return 1 ;;
   esac
 }
@@ -160,7 +166,7 @@ fm_control_interrupt_ack_source() {  # <harness>
 fm_control_exit_command() {  # <harness>
   case "${1-}" in
     claude|opencode|grok|kimi|cursor|muse) printf '/exit' ;;
-    codex|pi|pi-signed) printf '/quit' ;;
+    codex|pi|pi-signed|gemini) printf '/quit' ;;
     *) return 1 ;;
   esac
 }
@@ -224,6 +230,12 @@ fm_control_harness_wiring_paths() {  # <harness> <worktree> <state-dir> <id>
       printf '%s\n' "$state/$id.muse-session-current"
       ;;
     cursor) printf '%s\n' "$state/$id.cursor-session" ;;
+    # gemini's busy-state and turn-end hooks live in a firstmate-owned
+    # settings file the launch reaches through GEMINI_CLI_SYSTEM_SETTINGS_PATH,
+    # so retiring that one file retires the whole incarnation's wiring. Nothing
+    # is written into the worktree, whose own .gemini/settings.json belongs to
+    # the project, and nothing global is installed.
+    gemini) printf '%s\n' "$state/$id.gemini-settings.json" ;;
   esac
 }
 

--- a/bin/fm-gemini-lib.sh
+++ b/bin/fm-gemini-lib.sh
@@ -20,9 +20,9 @@
 # because probing a stranger's binary during a liveness poll is exactly what
 # must not happen.
 #
-# Detection of firstmate's OWN harness does not come through here. That uses
-# the GEMINI_CLI=1 environment marker in bin/fm-harness.sh, which is a separate
-# and independent signal, so no single source is load-bearing on its own.
+# Detection of firstmate's OWN harness uses these structural rules for the
+# ancestry fallback. The GEMINI_CLI=1 environment marker in bin/fm-harness.sh
+# remains the load-bearing path for the installed bundle shape on modern Node.
 
 # True when path $1 carries Gemini's own structural evidence: the file is named
 # gemini, or it sits inside the published @google/gemini-cli package tree. A

--- a/bin/fm-gemini-lib.sh
+++ b/bin/fm-gemini-lib.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Gemini process identity.
+# Sourced by bin/backends/tmux.sh. This file is sourced by scripts and has no
+# side effects on source.
+#
+# Why one owner: the Gemini CLI ships as a node bundle, so a live gemini pane
+# presents as an interpreter and nothing about its command NAME says gemini.
+# Measured on gemini-cli 0.58.0 with Node v24.20.0 on Linux, one worker's
+# foreground process group read:
+#
+#   comm  : MainThread
+#   argv0 : /home/<user>/.local/node/bin/node
+#   args  : node /home/<user>/.local/bin/gemini -y
+#
+# `comm` is MainThread because modern Node renames its main thread, and argv[0]
+# is the interpreter. Only argv[1] - the script path - carries the identity, so
+# the liveness classifier has to read the arguments rather than the name. This
+# is the same hazard bin/fm-cursor-lib.sh exists to close for cursor-agent, and
+# the rule here is deliberately the same shape: structural only, no subprocess,
+# because probing a stranger's binary during a liveness poll is exactly what
+# must not happen.
+#
+# Detection of firstmate's OWN harness does not come through here. That uses
+# the GEMINI_CLI=1 environment marker in bin/fm-harness.sh, which is a separate
+# and independent signal, so no single source is load-bearing on its own.
+
+# True when path $1 carries Gemini's own structural evidence: the file is named
+# gemini, or it sits inside the published @google/gemini-cli package tree. A
+# directory component merely named `gemini` is never enough on its own, and a
+# bare interpreter is always rejected.
+fm_gemini_path_is_gemini() {  # <path>
+  local path=$1
+  [ -n "$path" ] || return 1
+  case "$path" in
+    -*) return 1 ;;
+  esac
+  case "${path##*/}" in
+    gemini) return 0 ;;
+  esac
+  case "$path" in
+    */@google/gemini-cli/*) return 0 ;;
+  esac
+  return 1
+}
+
+# True when the whitespace-separated command line $1 is a Gemini process.
+#
+# Accepted: a command whose own argv[0] is gemini (a future natively-named
+# binary), and an interpreter whose first non-flag argument is Gemini's script
+# or package path.
+#
+# Rejected: a bare interpreter with no gemini argument, and any command line
+# whose only mention of gemini is a later flag value, a working directory, or a
+# prompt string - only argv[0] and the script argument are ever consulted, so
+# an unrelated command that merely TALKS about gemini never matches.
+fm_gemini_args_are_gemini() {  # <args>
+  local args=$1 argv0 rest token
+  [ -n "$args" ] || return 1
+  args=${args#"${args%%[![:space:]]*}"}
+  argv0=${args%%[[:space:]]*}
+  fm_gemini_path_is_gemini "$argv0" && return 0
+  case "${argv0##*/}" in
+    node|node-*|node[0-9]*|MainThread) ;;
+    *) return 1 ;;
+  esac
+  rest=${args#"$argv0"}
+  # The first non-flag token after the interpreter is the script it runs.
+  # Node's own options are skipped so `node --max-old-space-size=10000 <script>`
+  # - the exact shape the installed launcher execs - still resolves.
+  while [ -n "$rest" ]; do
+    rest=${rest#"${rest%%[![:space:]]*}"}
+    [ -n "$rest" ] || break
+    token=${rest%%[[:space:]]*}
+    rest=${rest#"$token"}
+    case "$token" in
+      -*) continue ;;
+    esac
+    fm_gemini_path_is_gemini "$token" && return 0
+    return 1
+  done
+  return 1
+}

--- a/bin/fm-gemini-lib.sh
+++ b/bin/fm-gemini-lib.sh
@@ -43,6 +43,31 @@ fm_gemini_path_is_gemini() {  # <path>
   return 1
 }
 
+# True when process $1 has Gemini's structural argv evidence. Linux exposes
+# argv as NUL-delimited fields, which preserves a script path containing spaces
+# that `ps -o args=` necessarily flattens into an ambiguous string.
+fm_gemini_pid_is_gemini() {  # <pid>
+  local pid=$1 token argv0='' index=0
+  [ -r "/proc/$pid/cmdline" ] || return 1
+  while IFS= read -r -d '' token; do
+    if [ "$index" -eq 0 ]; then
+      argv0=$token
+      fm_gemini_path_is_gemini "$argv0" && return 0
+      case "${argv0##*/}" in
+        node|node-*|node[0-9]*|MainThread) ;;
+        *) return 1 ;;
+      esac
+    else
+      case "$token" in
+        -*) ;;
+        *) fm_gemini_path_is_gemini "$token" && return 0; return 1 ;;
+      esac
+    fi
+    index=$((index + 1))
+  done < "/proc/$pid/cmdline"
+  return 1
+}
+
 # True when the whitespace-separated command line $1 is a Gemini process.
 #
 # Accepted: a command whose own argv[0] is gemini (a future natively-named

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -29,6 +29,8 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
 # shellcheck source=bin/fm-cursor-lib.sh
 . "$SCRIPT_DIR/fm-cursor-lib.sh"
+# shellcheck source=bin/fm-gemini-lib.sh
+. "$SCRIPT_DIR/fm-gemini-lib.sh"
 
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
@@ -94,6 +96,10 @@ detect_own() {
       echo cursor
       return
     fi
+    if fm_gemini_path_is_gemini "$comm"; then
+      echo gemini
+      return
+    fi
     case "$(basename -- "$comm")" in
       # gemini precedes claude here for the same precedence reason as the
       # marker layer above, so a gemini worker under a claude primary is never
@@ -108,7 +114,6 @@ detect_own() {
       # MainThread to the interpreter arm to close this: that would make the
       # args of EVERY node process searchable and let an unrelated node
       # command carrying a harness name in its arguments claim an identity.
-      *gemini*) echo gemini; return ;;
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
@@ -125,8 +130,11 @@ detect_own() {
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
+        if fm_gemini_args_are_gemini "$args"; then
+          echo gemini
+          return
+        fi
         case "$args" in
-          *gemini*) echo gemini; return ;;
           *claude*) echo claude; return ;;
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -50,6 +50,19 @@ detect_own() {
   # CURSOR_AGENT=1 is set for the child/tool processes this script runs as.
   [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
   [ "${CURSOR_INVOKED_AS:-}" = "cursor-agent" ] && { echo cursor; return; }
+  # Gemini is checked BEFORE claude for exactly cursor's reason above: the
+  # Gemini CLI does NOT clear an inherited CLAUDECODE, so a gemini worker
+  # launched from a claude primary carries BOTH markers and whichever is
+  # tested first wins. Verified live on gemini-cli 0.58.0: a tool process
+  # spawned by a gemini worker under a claude primary reported GEMINI_CLI=1
+  # AND CLAUDECODE=1 together. GEMINI_CLI is gemini's own and is unset in the
+  # launching environment, so ordering it first is what makes the verdict
+  # correct; bin/fm-spawn.sh additionally clears the foreign markers at the
+  # launch boundary. Both are kept for the same reason cursor keeps both.
+  # AI_AGENT is deliberately NOT used: it was present in that same process
+  # carrying the claude primary's value (claude-code_2-1-260_agent), so it is
+  # an inherited launcher marker, not a Gemini identity.
+  [ "${GEMINI_CLI:-}" = "1" ] && { echo gemini; return; }
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   if [ "${PI_CODING_AGENT:-}" = "true" ]; then
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
@@ -82,6 +95,20 @@ detect_own() {
       return
     fi
     case "$(basename -- "$comm")" in
+      # gemini precedes claude here for the same precedence reason as the
+      # marker layer above, so a gemini worker under a claude primary is never
+      # read as claude. This arm covers a natively-named gemini binary only.
+      # It does NOT reach the currently installed CLI, which is a node bundle
+      # (~/.local/bin/gemini -> @google/gemini-cli/bundle/gemini.js): modern
+      # Node on Linux reports `comm` as MainThread rather than node (measured
+      # on Node v24.20.0), so neither this arm nor the node interpreter arm
+      # below matches a live gemini process. GEMINI_CLI above is therefore
+      # load-bearing for gemini rather than a fast path, which is why gemini
+      # is not offered as a primary or secondmate harness. Do NOT add
+      # MainThread to the interpreter arm to close this: that would make the
+      # args of EVERY node process searchable and let an unrelated node
+      # command carrying a harness name in its arguments claim an identity.
+      *gemini*) echo gemini; return ;;
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
@@ -99,6 +126,7 @@ detect_own() {
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
         case "$args" in
+          *gemini*) echo gemini; return ;;
           *claude*) echo claude; return ;;
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -111,7 +111,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. For pi and pi-signed, fm-spawn resolves the selected executable
@@ -178,6 +178,7 @@
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 #     __WORKTREE__  absolute path to the task worktree
 #     __CURSORBIN__ resolved, cursor-verified executable for a cursor launch
+#     __GEMINISETTINGS__ firstmate-owned per-task gemini settings file (busy-state hooks)
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
@@ -185,7 +186,7 @@
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
 # muse installs no hook at all - its plugin engine is off in the default build - so
 # it writes state/<id>.muse-session to bind the pane to muse's own session event
-# log; muse is crewmate/scout only and is refused for --secondmate.
+# log; muse and gemini are crewmate/scout only and are refused for --secondmate.
 # cursor installs no per-task hook either: it writes state/<id>.cursor-session to
 # bind the pane to cursor's own conversation transcript (projects root, the exact
 # workspace path cursor records in .workspace-trusted, and the conversations that
@@ -1200,7 +1201,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   }
 elif [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse)
+    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -1312,7 +1313,42 @@ launch_template() {
     # inherited CLAUDECODE cannot outrank cursor's own marker in a process that
     # only reads the environment. Cursor exposes no effort flag, so the shared
     # effort axis is deliberately omitted and stays in task metadata only.
-    cursor) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS __CURSORBIN__ --trust --yolo __MODELFLAG__--workspace __WORKTREE__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    cursor) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u GEMINI_CLI -u CURSOR_INVOKED_AS __CURSORBIN__ --trust --yolo __MODELFLAG__--workspace __WORKTREE__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # gemini (Google Gemini CLI): a positional query starts the supervised
+    # interactive session and auto-submits it, so the brief rides the launch
+    # command exactly as it does for claude and grok (verified: a multi-line
+    # brief submitted itself with no extra Enter, gemini-cli 0.58.0).
+    # -y (--yolo) auto-approves every tool call, which an unattended crewmate
+    # needs; the footer renders ` YOLO Ctrl+Y` while it is on and a WriteFile
+    # was verified to land with no approval gate.
+    # Every task worktree is a fresh path, so gemini refuses to start at all
+    # without a trust control. GEMINI_CLI_TRUST_WORKSPACE=true - NOT
+    # --skip-trust - is the one used, and the difference is load-bearing
+    # rather than cosmetic: the CLI's refusal message offers the two as
+    # equivalents, but a controlled A/B on one worktree (same config home,
+    # same prompt) showed --skip-trust runs the turn while leaving PROJECT
+    # configuration unloaded, so the project's own .agents/skills are never
+    # discovered. A firstmate-repo task needs exactly those, so the workspace
+    # is trusted.
+    # GEMINI_CLI_SYSTEM_SETTINGS_PATH points gemini at the firstmate-owned
+    # per-task settings file written below. It is deliberately NOT the
+    # worktree's .gemini/settings.json: unlike claude's settings.local.json,
+    # that path is the PROJECT's own committed settings file, so writing it
+    # would clobber a project's configuration and removing it at teardown
+    # would delete a tracked file. The system layer also makes the busy
+    # contract independent of the trust decision above (its hooks were
+    # verified firing under --skip-trust in an untrusted folder), and hook
+    # arrays MERGE across settings layers rather than overriding, so a
+    # project's own hooks still run alongside firstmate's.
+    # The foreign primary markers are cleared for the same reason cursor
+    # clears them: gemini does not clear an inherited CLAUDECODE, and
+    # bin/fm-harness.sh must not read a gemini worker as its launcher.
+    # gemini exposes no reasoning-effort flag (checked against 0.58.0
+    # --help), so the shared effort axis is deliberately omitted here and
+    # stays in task metadata only, per the record-and-omit contract.
+    # Its turn-end and busy-state signals do NOT ride the launch command:
+    # they are project hooks written into the worktree below.
+    gemini) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS GEMINI_CLI_TRUST_WORKSPACE=true GEMINI_CLI_SYSTEM_SETTINGS_PATH=__GEMINISETTINGS__ gemini -y __MODELFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     # Kimi Code rejects a positional prompt, so it launches bare and receives
     # only an absolute brief pointer after the TUI readiness gate below.
     # Its turn-end signal is a globally configured Stop hook plus a guarded
@@ -1380,14 +1416,18 @@ case "$ARG3" in
     ;;
 esac
 
-# muse is verified as a CREWMATE/SCOUT adapter only. A secondmate is a firstmate
-# instance, so it needs a primary supervision protocol; muse has none, and its
+# muse and gemini are verified as CREWMATE/SCOUT adapters only. A secondmate is
+# a firstmate instance, so it needs a primary supervision protocol.
+# gemini has none: docs/supervision-protocols/ carries no gemini wake protocol
+# and this task verified only crewmate-side launch, busy state, interrupt, and
+# exit, so a gemini secondmate is refused rather than stood up on an unverified
+# supervision path. muse has none either, and its
 # Claude-compatible hook dialect explicitly rejects the model-reawakening and
 # asyncRewake handlers that firstmate's primary turn-end supervision is built on
 # (muse 0.1.0-R708.1). Refusing here keeps that gap loud instead of standing up a
 # secondmate whose supervision cycle could never be armed.
-if [ "$KIND" = secondmate ] && [ "$HARNESS" = muse ]; then
-  echo "error: muse is a verified crewmate/scout adapter only and cannot run a secondmate; it has no primary supervision protocol. Select a harness verified for secondmates." >&2
+if [ "$KIND" = secondmate ] && { [ "$HARNESS" = muse ] || [ "$HARNESS" = gemini ]; }; then
+  echo "error: $HARNESS is a verified crewmate/scout adapter only and cannot run a secondmate; it has no primary supervision protocol. Select a harness verified for secondmates." >&2
   exit 1
 fi
 
@@ -1525,7 +1565,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse)
+    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -2623,7 +2663,8 @@ if [ "$KIND" != secondmate ]; then
   # embedded into each adapter's wiring so an event from a superseded
   # incarnation is rejected as stale. Grok stays on its isolated rendered-tail
   # fallback and standalone Kimi stays unknown until fm_busy_kimi_verified
-  # opens, so neither is armed here.
+  # opens, so neither is armed here. Gemini IS armed: its BeforeAgent /
+  # AfterAgent / SessionEnd hooks are a verified open-close pair.
   BUSY_GEN=
   case "$HARNESS" in
     codex*)
@@ -2634,7 +2675,7 @@ if [ "$KIND" != secondmate ]; then
       ;;
   esac
   case "$HARNESS" in
-    claude*|opencode*|pi|pi-signed)
+    claude*|opencode*|gemini*|pi|pi-signed)
       BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
         echo "error: failed to arm the busy-state contract for $ID" >&2
         exit 1
@@ -2674,6 +2715,38 @@ if [ "$KIND" != secondmate ]; then
 {"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]}}
 EOF
       exclude_path '.claude/settings.local.json'
+      ;;
+    gemini*)
+      # Semantic busy-state hooks (bin/fm-busy-lib.sh): BeforeAgent opens a
+      # turn and AfterAgent closes it, with SessionEnd closing on process
+      # shutdown so an abnormal end can never leave a stale busy record.
+      # Verified live on gemini-cli 0.58.0 as a clean open/close pair:
+      # mid-turn only BeforeAgent had fired, and AfterAgent followed at turn
+      # end. AfterAgent ALSO fires on a manual Escape interrupt (carrying
+      # prompt_response "[no response text]"), so unlike Claude a cancelled
+      # gemini turn closes its own record instead of leaving it busy.
+      # SessionEnd was observed firing TWICE for one /quit; the busy writer is
+      # idempotent for a repeated idle event, so the duplicate is harmless and
+      # deliberately not de-duplicated here.
+      # These are written into a FIRSTMATE-OWNED settings file under state/,
+      # reached through GEMINI_CLI_SYSTEM_SETTINGS_PATH on the launch command,
+      # never into the worktree's own .gemini/settings.json - that path is the
+      # PROJECT's committed settings file, so writing it would clobber a
+      # project's configuration and retiring it would delete a tracked file.
+      # Hook arrays MERGE across gemini's settings layers rather than
+      # overriding, so a project's own hooks still run alongside these.
+      # AfterAgent keeps the turn-ended NOTIFICATION touch for the watcher.
+      # Every hook command tolerates a refused event (|| true) so a stale-gen
+      # writer can never break gemini's own lifecycle, and each prints the
+      # empty JSON object gemini's hook contract requires on stdout.
+      busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
+      busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source gemini-hook"
+      g_before=$(json_escape "$busy_cmd_prefix busy $busy_suffix --event before-agent >/dev/null 2>&1 || true; printf '{}'")
+      g_after=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event after-agent >/dev/null 2>&1 || true; printf '{}'")
+      g_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end >/dev/null 2>&1 || true; printf '{}'")
+      cat > "$STATE_REAL/$ID.gemini-settings.json" <<EOF
+{"hooks":{"BeforeAgent":[{"hooks":[{"type":"command","command":"$g_before"}]}],"AfterAgent":[{"hooks":[{"type":"command","command":"$g_after"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$g_sessionend"}]}]}}
+EOF
       ;;
     opencode*)
       mkdir -p "$WT/.opencode/plugins"
@@ -3074,11 +3147,12 @@ LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 case "$HARNESS" in
   pi|pi-signed) LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"} ;;
   cursor) LAUNCH=${LAUNCH//__CURSORBIN__/"$(shell_quote "$CURSOR_BIN")"} ;;
+  gemini) LAUNCH=${LAUNCH//__GEMINISETTINGS__/"$(shell_quote "$STATE_REAL/$ID.gemini-settings.json")"} ;;
 esac
 LAUNCH=${LAUNCH//__WORKTREE__/$sq_worktree}
 case "$HARNESS" in
-  claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
-    LAUNCH="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS $LAUNCH"
+  claude|codex|opencode|pi|pi-signed|grok|kimi|gemini|muse)
+    LAUNCH="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI $LAUNCH"
     ;;
 esac
 # Crewmate panes are created by a long-lived tmux/herdr daemon that does not

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1117,6 +1117,7 @@ SPAWN_TASK_LOCK_HELD=1
 PROJ=
 ARG3=
 FIRSTMATE_HOME=
+RAW_LAUNCH=0
 
 # --relaunch adoption: every identity axis comes from the task's own validated
 # durable record, never from the command line, so a relaunch can only ever
@@ -1382,6 +1383,7 @@ launch_template() {
 
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
+    RAW_LAUNCH=1
     LAUNCH=$ARG3
     HARNESS=""
     for word in $LAUNCH; do
@@ -2675,12 +2677,21 @@ if [ "$KIND" != secondmate ]; then
       ;;
   esac
   case "$HARNESS" in
-    claude*|opencode*|gemini*|pi|pi-signed)
+    claude*|opencode*|pi|pi-signed)
       BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
         echo "error: failed to arm the busy-state contract for $ID" >&2
         exit 1
       }
       [ "$RELAUNCH" -ne 1 ] || RELAUNCH_REPLACEMENT_BUSY_GEN=$BUSY_GEN
+      ;;
+    gemini)
+      if [ "$RAW_LAUNCH" -eq 0 ]; then
+        BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
+          echo "error: failed to arm the busy-state contract for $ID" >&2
+          exit 1
+        }
+        [ "$RELAUNCH" -ne 1 ] || RELAUNCH_REPLACEMENT_BUSY_GEN=$BUSY_GEN
+      fi
       ;;
     kimi*)
       # Standalone Kimi stays unknown until fm_busy_kimi_verified opens on a
@@ -2716,7 +2727,8 @@ if [ "$KIND" != secondmate ]; then
 EOF
       exclude_path '.claude/settings.local.json'
       ;;
-    gemini*)
+    gemini)
+      if [ "$RAW_LAUNCH" -eq 0 ]; then
       # Semantic busy-state hooks (bin/fm-busy-lib.sh): BeforeAgent opens a
       # turn and AfterAgent closes it, with SessionEnd closing on process
       # shutdown so an abnormal end can never leave a stale busy record.
@@ -2747,6 +2759,7 @@ EOF
       cat > "$STATE_REAL/$ID.gemini-settings.json" <<EOF
 {"hooks":{"BeforeAgent":[{"hooks":[{"type":"command","command":"$g_before"}]}],"AfterAgent":[{"hooks":[{"type":"command","command":"$g_after"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$g_sessionend"}]}]}}
 EOF
+      fi
       ;;
     opencode*)
       mkdir -p "$WT/.opencode/plugins"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2920,7 +2920,8 @@ rm -f "$STATE/$ID.turn-ended" \
   "$STATE/$ID.muse-session-current" "$STATE/$ID.cursor-session" \
   "$STATE/$ID.control-relaunch" "$STATE/$ID.control-relaunch.meta-prior" \
   "$STATE/$ID.control-relaunch.brief-prior" "$STATE/$ID.control-relaunch.note" \
-  "$STATE/$ID.reconcile-nudged" "$STATE/.$ID.branch-outcome-index"
+  "$STATE/$ID.reconcile-nudged" "$STATE/$ID.gemini-settings.json" \
+  "$STATE/.$ID.branch-outcome-index"
 # The steering inbox (bin/fm-task-inbox-lib.sh) is runtime state for the
 # retired endpoint; teardown only runs after landing is confirmed, so any
 # leftover unhandled steer here is moot rather than unlanded work.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -48,7 +48,7 @@ The clear is refused before anything is sent when the recorded backend cannot de
 Removing a worktree, closing an endpoint, or discarding work stays with [`bin/fm-teardown.sh`](../bin/fm-teardown.sh), which owns the landed-work test.
 
 **`resume` is not a verb.**
-It is not deterministic across the verified adapters: codex and grok resume only from a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, and kimi have no verified pane-resume contract.
+It is not deterministic across the verified adapters: codex, grok, and gemini resume only from a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, and kimi have no verified pane-resume contract.
 `relaunch` covers the same need on every adapter, because the brief on disk - not a harness-private session - is the durable instruction.
 
 ## Transactional relaunch

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,7 +234,7 @@ The session-start bootstrap step keeps valid dispatch configuration silent unles
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, and muse while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, gemini, and muse while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -296,12 +296,13 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, pi-signed, grok, kimi, and cursor are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
+claude, codex, opencode, pi, pi-signed, grok, kimi, and cursor are empirically verified for crewmate and secondmate launches; gemini is verified for crewmate and scout launches only, and [README requirements](../README.md#requirements) own the set supported for the primary session.
 A cursor secondmate or primary runs the tracked project-scope `.cursor/hooks.json` in its own home and must be launched with `--trust`, or no project hook loads; [`docs/supervision-protocols/cursor.md`](supervision-protocols/cursor.md) owns its supervision protocol.
 Cursor typed-submit confirmation is verified on tmux and Herdr only.
 On Zellij, cmux, and Orca a typed-plane Cursor send (a harness-native invocation or an explicit backend target; ordinary text steers ride the durable inbox and exit 0 at enqueue) lands, but `fm-send` reports delivery unconfirmed and exits non-zero because their shared submit core does not consult the busy footer; [runtime backend verification](verification/runtime-backends.md#cursor-agent-cli) owns the evidence and transcript-state boundary.
 muse is verified for crewmate and scout launches ONLY, and `fm-spawn.sh` refuses it for a secondmate, because muse ships no usable hook surface for a primary session's turn-end supervision; [`docs/verification/muse.md`](verification/muse.md) owns that evidence.
 muse also needs a worker-reachable credential before spawning, and the portable fleet path is the `<config>/muse/auth.json` credential stored by `muse login`, because a caller-only `META_API_KEY` does not cross a long-lived backend daemon.
+gemini is likewise refused for secondmates because it has no primary supervision protocol; [its adapter reference](../.agents/skills/harness-adapters/references/harness/gemini.md) owns the credential precondition, canonical-launch wiring, and raw-launch limitations.
 New harnesses get verified through a supervised trial task before joining the set.
 The verified adapter evidence - each harness's busy-state source, interrupt and exit behavior, skill-invocation syntax, and per-harness quirks - lives in the skill tree rooted at [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 The executable interrupt and exit mechanics live in [`bin/fm-control-lib.sh`](../bin/fm-control-lib.sh), and [`docs/agent-control.md`](agent-control.md) owns their lifecycle-control architecture.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -189,6 +189,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/harness-adapters/references/harness/gemini.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/harness-adapters/references/harness/grok.md",
       "audience": "agent-runtime"
     },

--- a/docs/trace-context.md
+++ b/docs/trace-context.md
@@ -23,7 +23,7 @@ When enabled, for each spawn Firstmate resolves one W3C `traceparent` carrier fo
 This feature parents no SDK span by itself.
 
 Because the injected carrier and the recorded carrier are the same string, an observer that reads the metadata reconstructs exactly the identity the child received.
-The injection sits at the unconditional pre-launch export site, so it covers ship and scout spawns across `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, `cursor`, and `muse`, plus Secondmate spawns across that same set except the deliberately crewmate-only `muse` adapter.
+The injection sits at the unconditional pre-launch export site, so it covers ship and scout spawns across `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, `cursor`, `gemini`, and `muse`, plus Secondmate spawns across that same set except the deliberately crewmate-only `gemini` and `muse` adapters.
 This is the same coverage `GOTMPDIR` already has and requires no trace-specific `launch_template()` behavior.
 Ship and scout spawns reach that site on every spawn backend (`tmux`, `herdr`, `zellij`, `orca`, `cmux`); a Secondmate reaches it on every backend that accepts a Secondmate spawn (`tmux`, `herdr`, `zellij`), because `bin/fm-spawn.sh` rejects a Secondmate on `orca` and `cmux`.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -338,6 +338,211 @@ Two findings from the run shaped the shipped behavior: an OpenCode vendor update
 Kimi was not installed on the verification machine; its receive path is the same one-line-plus-shell contract, and the portable ladder and enqueue regressions in `tests/fm-task-inbox.test.sh` and `tests/fm-send-inbox.test.sh` cover every harness-independent half.
 This guard is the refresh command after any harness upgrade; it spends a small number of real tokens per installed harness, reports an absent harness explicitly, and refuses a run that verified nothing.
 
+## Gemini
+
+The Gemini crewmate adapter was verified on 2026-09-04 with gemini-cli 0.58.0 on Linux, Node v24.20.0, tmux 3.4.
+Every check below ran in throwaway scratch worktrees against the real CLI; no task worktree was used and no agent was left running.
+The credential was supplied only through the `GEMINI_API_KEY` environment variable and its value appears nowhere in this record.
+
+### Trust options are not equivalent
+
+The refusal an untrusted launch produces, and its headless exit status:
+
+```sh
+gemini -p 'say OK'; echo "rc=$?"
+```
+
+```text
+Gemini CLI is not running in a trusted directory. To proceed, either use `--skip-trust`, set the `GEMINI_CLI_TRUST_WORKSPACE=true` environment variable, or trust this directory in interactive mode.
+rc=55
+```
+
+Both documented options clear that refusal, but only one loads project configuration.
+The A/B below ran twice in ONE worktree carrying a project `AfterAgent` hook, with the same config home and the same prompt, changing only the trust mechanism:
+
+```text
+--skip-trust                 project-hook-fired=NO   untrusted-warnings=0   turn=✦ ECHO
+TRUST_WORKSPACE=true         project-hook-fired=YES  untrusted-warnings=0   turn=✦ FOXTROT
+```
+
+`gemini skills list` names the cause directly in the untrusted case:
+
+```text
+Skipping project agents due to untrusted folder. To enable, ensure that the project root is trusted.
+Project hooks disabled because the folder is not trusted.
+```
+
+This is why `bin/fm-spawn.sh` launches with `GEMINI_CLI_TRUST_WORKSPACE=true` and why `--skip-trust` must not be substituted for it.
+
+### Busy signal
+
+A full turn was captured every two seconds. The status row above the separator carries the one ASCII token, and the phase text beside it is model-generated:
+
+```text
+busy_1 | 1 |  ⠸ Thinking... (esc to cancel, 1s)
+busy_5 | 1 |  ⠸ Begin Counting Methodically (esc to cancel, 9s)
+busy_6 | 1 |  ⠇ Continue Enumerating Concepts (esc to cancel, 11s)
+busy_7 | 0 |
+busy_12 | 0 |
+```
+
+The idle capture taken before the prompt also contained no `(esc to cancel,`.
+Because the phase text varies per turn and the spinner is braille, neither is usable; `(esc to cancel,` is the only stable rendered token, and the adapter uses the semantic hooks below as its actual state source.
+
+### Hook lifecycle
+
+`BeforeAgent`, `AfterAgent`, `SessionStart`, and `SessionEnd` were registered on one probe that appends its event name, then driven through a normal turn, an Escape interrupt, and `/quit`:
+
+```text
+--- after startup ---   SessionStart
+--- mid-turn ---        SessionStart, BeforeAgent
+--- after INTERRUPT --- SessionStart, BeforeAgent, AfterAgent
+--- after /quit ---     SessionStart, BeforeAgent, AfterAgent, SessionEnd, SessionEnd
+```
+
+Two facts the adapter depends on come from that run: `AfterAgent` closes a turn that was CANCELLED, not only one that completed, and `SessionEnd` fired TWICE for a single `/quit`, so the repeated idle event must be harmless.
+The `AfterAgent` payload carried the worktree as `cwd`, which is what binds a hook to its task:
+
+```text
+keys: ['cwd', 'hook_event_name', 'prompt', 'prompt_response', 'session_id', 'stop_hook_active', 'timestamp', 'transcript_path']
+hook_event_name = AfterAgent
+stop_hook_active = False
+prompt = 'Say the single word CEDAR and stop.'
+```
+
+On the cancelled turn the same payload carried `prompt_response = '[no response text]'`.
+
+### Autonomous end-to-end worker
+
+One throwaway worker was launched exactly as the spawn launches one - positional brief, `-y`, workspace trust - and observed from start to idle:
+
+```text
+t=5s   (esc to cancel, 2s)
+t=30s  busy marker present
+idle at ~34s, busy marker count 0
+worker-output.txt: DELIVERED
+turn-end hook fires: 1
+```
+
+Its pane showed `✓ WriteFile worker-output.txt → Accepted (+1, -0)` with no approval gate, confirming `-y` runs unattended, and `Executing Hook: fm-turn-end` in the status row after the turn.
+
+The adapter was then driven through the REAL `bin/fm-spawn.sh` and `bin/fm-control.sh` against a real Gemini pane in an isolated home:
+
+```text
+spawned gm-e2e harness=gemini kind=ship mode=no-mistakes yolo=off window=... worktree=...
+hooks installed by spawn (state/<id>.gemini-settings.json): ['BeforeAgent', 'AfterAgent', 'SessionEnd']
+t=4s   state: working · source: pane · harness busy (gemini-hook)
+t=8s   state: working · source: pane · harness busy (gemini-hook)
+after turn: v1 gen=... state=idle source=gemini-hook event=after-agent
+e2e-output.txt: SEAWORTHY
+interrupt-delivered gm-e2e harness=gemini backend=tmux verified=agent-alive cancel=unconfirmed
+after interrupt: v1 gen=... state=idle source=gemini-hook event=after-agent
+stopped gm-e2e harness=gemini backend=tmux endpoint=... worktree=...
+```
+
+The interrupt line is the one worth keeping: `AfterAgent` closed the record on a CANCELLED turn, which is why a gemini interrupt needs no `fm-interrupt` fallback event.
+A single Escape on a long turn printed `ℹ Request cancelled.`, dropped the busy token, and left the agent running; `/quit` then exited with status 0 and printed `To resume this session: gemini --resume <session-id>`, and resuming by that id restored the full transcript.
+
+### Identity markers
+
+Env var NAMES were read from a real Gemini tool process launched under a Claude primary; no value of `GEMINI_API_KEY` was read.
+
+```text
+GEMINI_CLI=[1]
+AI_AGENT=[claude-code_2-1-260_agent]
+TRUSTWS=[true]
+CLAUDECODE=[1]
+```
+
+`GEMINI_CLI` is unset in the launching environment, so it is Gemini's own; `CLAUDECODE` is inherited, which is why `bin/fm-harness.sh` tests `GEMINI_CLI` first.
+`AI_AGENT` carried the CLAUDE primary's value and is therefore an inherited launcher marker, never a Gemini identity.
+
+Ancestry cannot substitute for the marker on this platform:
+
+```sh
+node -e 'const{execSync}=require("child_process");console.log(execSync("ps -o comm= -p "+process.pid).toString().trim())'
+```
+
+```text
+MainThread
+```
+
+The shipped CLI is a node bundle, so its live process never presents as `node` and neither ancestry arm matches it.
+
+The same shape breaks pane liveness, which the end-to-end run surfaced as a hard refusal rather than a silent wrong answer:
+
+```text
+error: task gm-e2e's endpoint reads 'ambiguous' rather than a positively classified state; refusing to send a lifecycle key into an unattributed endpoint
+```
+
+A live gemini pane's foreground group read `comm=MainThread` and `argv0=/home/<user>/.local/node/bin/node`, so `bin/fm-gemini-lib.sh` now identifies it from argv[1] instead.
+After that change the same endpoint classified `alive` while the worker ran and `dead` once it exited, so the rule is not simply always positive.
+`tests/fm-gemini-harness.test.sh` pins that boundary so it is not later documented away, and `tests/fm-busy-adapter-wiring.test.sh` drives the generated hooks through the real writer and classifier.
+
+```sh
+bin/fm-test-run.sh tests/fm-gemini-harness.test.sh tests/fm-busy-adapter-wiring.test.sh
+```
+
+### Credential wedge and its blast radius
+
+With no resolvable credential the pane wedges on `Enter Gemini API Key` rather than failing.
+That dialog is a credential FIELD, so lifecycle text sent to a wedged pane is submitted into it and stored.
+Observed after an ordinary exit was delivered to such a pane: a `~/.gemini/gemini-credentials.json` (mode 0600) appeared that had not existed before, and a later credential-less run stopped refusing cleanly and instead reached the API:
+
+```text
+before: rc=41  When using Gemini API, you must specify the GEMINI_API_KEY environment variable.
+after : rc=1   API key not valid. Please pass a valid API key.  (API_KEY_INVALID)
+```
+
+Clearing that stored credential restored both behaviours:
+
+```text
+GEMINI_API_KEY=<from the operator's own store> gemini --skip-trust -p 'Reply with exactly the word NOVEMBER.'  ->  NOVEMBER  rc=0
+env -u GEMINI_API_KEY gemini --skip-trust -p hi                                                              ->  rc=41
+```
+
+The adapter reference records the operational rule this produces: never drive lifecycle text into a gemini pane showing that dialog; treat it as a credential blocker and retire the endpoint instead.
+The credential must also be present before the session-provider daemon starts, since a long-lived tmux or Herdr server hands panes the environment it was started with.
+
+### Settings placement
+
+Firstmate's hooks are NOT written into the worktree's `.gemini/settings.json`, because unlike Claude's `settings.local.json` that path is the project's own committed settings file.
+They go to a firstmate-owned `state/<id>.gemini-settings.json` reached through `GEMINI_CLI_SYSTEM_SETTINGS_PATH`.
+Two measurements support that choice.
+Hooks from the system layer fired under `--skip-trust` in an untrusted folder, so the busy contract does not depend on the trust decision:
+
+```text
+=== events (UNTRUSTED workspace, --skip-trust) ===
+BeforeAgent
+AfterAgent
+```
+
+And hook arrays MERGE across layers rather than overriding, so a project's own hooks keep running alongside firstmate's:
+
+```text
+=== which AfterAgent hooks ran (trusted workspace, both layers define AfterAgent) ===
+PROJECT
+SYSTEM
+```
+
+A second end-to-end spawn against a project that already committed its own `.gemini/settings.json` confirmed the file was untouched, that `git status` reported only the worker's own new output file, and that teardown removed firstmate's settings file:
+
+```text
+t=4s   state: working · source: pane · harness busy (gemini-hook)
+t=8s   state: working · source: pane · harness busy (gemini-hook)
+after turn: state=idle source=gemini-hook event=after-agent
+e2e2-output.txt: ANCHOR
+project .gemini/settings.json: {"context":{"fileName":"GEMINI.md"}}   (unchanged)
+interrupt-delivered gm2 harness=gemini backend=tmux verified=agent-alive cancel=unconfirmed
+stopped gm2 harness=gemini backend=tmux
+teardown gm2 complete; state/gm2.gemini-settings.json removed
+```
+
+### Not verified
+
+Gemini as a PRIMARY or SECONDMATE runtime is unverified and is refused by `bin/fm-spawn.sh`: no wake protocol exists under `docs/supervision-protocols/` and no turn-end guard adapter was built or exercised.
+No reasoning-effort axis was found; `gemini --help` on 0.58.0 exposes no effort, reasoning, or thinking flag, so the record-and-omit contract applies.
+
 ## Herdr
 
 The compatibility floor is protocol 14.

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -23,7 +23,7 @@ make_spawn_case() {  # <name> <harness> <id>
   home="$case_dir/home"
   proj="$case_dir/project"
   wt="$case_dir/wt"
-  fakebin=$(make_spawn_fakebin "$case_dir/fake" pi opencode claude codex)
+  fakebin=$(make_spawn_fakebin "$case_dir/fake" pi opencode claude codex gemini)
   fm_test_spawn_home "$home" "$harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
   fm_test_spawn_brief "$home" "$id"
@@ -297,6 +297,94 @@ test_codex_unverified_until_a_semantic_source_exists() {
   pass "codex classifies unknown until a semantic source is verified, never idle or footer-matched"
 }
 
+# Gemini's hooks are PROJECT hooks in the worktree's own .gemini/settings.json,
+# and gemini's hook contract requires each command to print a JSON object on
+# stdout and nothing else, so these drive the real command and check both the
+# classification and that stdout stays parseable JSON.
+run_gemini_hook() {  # <settings.json> <hook-event>
+  local cmd
+  cmd=$(jq -r ".hooks[\"$2\"][0].hooks[0].command" "$1")
+  [ -n "$cmd" ] && [ "$cmd" != null ] || fail "no $2 hook command in $1"
+  sh -c "$cmd"
+}
+
+test_gemini_hooks_semantic_lifecycle() {
+  local rec id=busy-gm-1 out state settings
+  rec=$(make_spawn_case gemini-lifecycle gemini "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
+  expect_code 0 $? "gemini spawn should succeed: $out"
+  state="$HOME_DIR/state"
+  settings="$state/$id.gemini-settings.json"
+  assert_present "$settings" "gemini spawn did not write hook settings"
+  jq -e . "$settings" >/dev/null || fail "gemini hook settings are not valid JSON"
+  for ev in BeforeAgent AfterAgent SessionEnd; do
+    jq -e ".hooks[\"$ev\"]" "$settings" >/dev/null || fail "gemini hook settings lack $ev"
+  done
+  # The worktree's own .gemini/settings.json is the PROJECT's committed file;
+  # firstmate must never write it, or a project's configuration is clobbered.
+  assert_absent "$WT_DIR/.gemini/settings.json" \
+    "gemini spawn must not write the project's own .gemini/settings.json"
+
+  out=$(classify gemini "$id" "$state")
+  [ "$out" = "busy fm-spawn" ] || fail "seed after spawn must be 'busy fm-spawn', got '$out'"
+
+  rm -f "$state/$id.turn-ended"
+  out=$(run_gemini_hook "$settings" AfterAgent) || fail "AfterAgent hook command failed"
+  printf '%s' "$out" | jq -e . >/dev/null \
+    || fail "AfterAgent must print only a JSON object on stdout, got '$out'"
+  [ -f "$state/$id.turn-ended" ] || fail "AfterAgent no longer touches the notification marker"
+  out=$(classify gemini "$id" "$state")
+  [ "$out" = "idle gemini-hook" ] || fail "AfterAgent must classify 'idle gemini-hook', got '$out'"
+
+  out=$(run_gemini_hook "$settings" BeforeAgent) || fail "BeforeAgent hook command failed"
+  printf '%s' "$out" | jq -e . >/dev/null \
+    || fail "BeforeAgent must print only a JSON object on stdout, got '$out'"
+  out=$(classify gemini "$id" "$state")
+  [ "$out" = "busy gemini-hook" ] || fail "BeforeAgent must classify 'busy gemini-hook', got '$out'"
+
+  # SessionEnd fires TWICE for one /quit on gemini-cli 0.58.0, so the second
+  # delivery must be a harmless no-op rather than a state change or a failure.
+  run_gemini_hook "$settings" SessionEnd >/dev/null || fail "SessionEnd hook command failed"
+  out=$(classify gemini "$id" "$state")
+  [ "$out" = "idle gemini-hook" ] || fail "SessionEnd must classify idle, got '$out'"
+  run_gemini_hook "$settings" SessionEnd >/dev/null || fail "a repeated SessionEnd must still exit 0"
+  out=$(classify gemini "$id" "$state")
+  [ "$out" = "idle gemini-hook" ] || fail "a repeated SessionEnd must stay idle, got '$out'"
+  pass "gemini hooks open on BeforeAgent and close on AfterAgent and a repeated SessionEnd"
+}
+
+test_gemini_hooks_stale_incarnation_harmless() {
+  local rec id=busy-gm-2 out state settings
+  rec=$(make_spawn_case gemini-stale gemini "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
+  expect_code 0 $? "gemini spawn should succeed: $out"
+  state="$HOME_DIR/state"
+  settings="$state/$id.gemini-settings.json"
+  "$ROOT/bin/fm-busy-event.sh" arm "$state" "$id" >/dev/null
+  run_gemini_hook "$settings" BeforeAgent >/dev/null \
+    || fail "a stale-gen hook must still exit 0 so gemini's lifecycle is never broken"
+  out=$(classify gemini "$id" "$state")
+  [ "$out" = "busy fm-spawn" ] || fail "a stale-gen hook event must not change state, got '$out'"
+  pass "gemini hook events from a superseded incarnation are rejected without breaking the hook"
+}
+
+test_gemini_is_refused_as_a_secondmate() {
+  local rec id=busy-gm-3 out
+  rec=$(make_spawn_case gemini-secondmate gemini "$id")
+  read_case_record "$rec"
+  # A secondmate spawn carries no delivery contract, so this one deliberately
+  # bypasses run_spawn's ship-only --mode/--yolo arguments.
+  out=$(GROK_HOME="$HOME_DIR/grok-home" \
+    fm_test_run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" --secondmate "$id" gemini) && {
+    fail "a gemini secondmate must be refused, it has no primary supervision protocol: $out"
+  }
+  assert_contains "$out" 'crewmate/scout adapter only' \
+    "refusing a gemini secondmate must name the crewmate/scout boundary: $out"
+  pass "gemini is refused as a secondmate because it has no primary supervision protocol"
+}
+
 test_kimi_and_grok_install_no_unverified_wiring() {
   local state out
   state="$TMP_ROOT/gates/state"
@@ -319,6 +407,9 @@ test_kimi_and_grok_install_no_unverified_wiring
 test_opencode_plugin_semantic_lifecycle
 test_claude_hooks_semantic_lifecycle
 test_claude_hooks_stale_incarnation_harmless
+test_gemini_hooks_semantic_lifecycle
+test_gemini_hooks_stale_incarnation_harmless
+test_gemini_is_refused_as_a_secondmate
 test_codex_unverified_until_a_semantic_source_exists
 
 echo "all fm-busy-adapter-wiring tests passed"

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -370,6 +370,20 @@ test_gemini_hooks_stale_incarnation_harmless() {
   pass "gemini hook events from a superseded incarnation are rejected without breaking the hook"
 }
 
+test_raw_gemini_launch_has_no_semantic_wiring() {
+  local rec id=busy-gm-raw out state
+  rec=$(make_spawn_case gemini-raw gemini "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR" 'gemini --debug')
+  expect_code 0 $? "raw gemini spawn should succeed: $out"
+  state="$HOME_DIR/state"
+  assert_absent "$state/$id.busy-gen" "raw gemini launch must not arm a busy generation"
+  assert_absent "$state/$id.gemini-settings.json" "raw gemini launch must not write hook settings"
+  out=$(classify gemini "$id" "$state")
+  [ "$out" = "unknown missing" ] || fail "raw gemini launch must classify unknown, got '$out'"
+  pass "raw gemini launch remains unwired and classifies unknown"
+}
+
 test_gemini_is_refused_as_a_secondmate() {
   local rec id=busy-gm-3 out
   rec=$(make_spawn_case gemini-secondmate gemini "$id")
@@ -409,6 +423,7 @@ test_claude_hooks_semantic_lifecycle
 test_claude_hooks_stale_incarnation_harmless
 test_gemini_hooks_semantic_lifecycle
 test_gemini_hooks_stale_incarnation_harmless
+test_raw_gemini_launch_has_no_semantic_wiring
 test_gemini_is_refused_as_a_secondmate
 test_codex_unverified_until_a_semantic_source_exists
 

--- a/tests/fm-gemini-harness.test.sh
+++ b/tests/fm-gemini-harness.test.sh
@@ -196,6 +196,32 @@ test_gemini_process_identity_reads_the_script_argument() {
   pass "fm-gemini-lib.sh: identity comes from the script argument, never a bare interpreter"
 }
 
+test_gemini_process_identity_preserves_whitespace_in_script_path() {
+  command -v node >/dev/null 2>&1 || return 0
+  [ -r /proc/self/cmdline ] || return 0
+  local dir="$TMP_ROOT/path with spaces" node_bin pid attempts=0
+  mkdir -p "$dir"
+  node_bin=$(command -v node)
+  ln -s "$node_bin" "$dir/node"
+  cat > "$dir/gemini" <<'JS'
+setTimeout(() => {}, 30000);
+JS
+  "$dir/node" "$dir/gemini" &
+  pid=$!
+  while ! fm_gemini_pid_is_gemini "$pid"; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 100 ]; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      fail "Gemini interpreter and script paths containing spaces must retain process identity"
+    fi
+    sleep 0.01
+  done
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  pass "fm-gemini-lib.sh: process argv preserves whitespace in interpreter and Gemini script paths"
+}
+
 test_gemini_control_mechanics_are_the_verified_ones() {
   local out
   fm_control_harness_supported gemini || fail "gemini must be a supported control harness"
@@ -239,6 +265,7 @@ test_gemini_ancestry_matches_only_a_native_command_name
 test_gemini_ancestry_rejects_unrelated_mentions
 test_gemini_node_bundle_is_not_ancestry_detectable
 test_gemini_process_identity_reads_the_script_argument
+test_gemini_process_identity_preserves_whitespace_in_script_path
 test_gemini_control_mechanics_are_the_verified_ones
 test_gemini_is_crewmate_and_scout_only
 test_gemini_wiring_stays_outside_the_worktree

--- a/tests/fm-gemini-harness.test.sh
+++ b/tests/fm-gemini-harness.test.sh
@@ -58,7 +58,7 @@ test_gemini_does_not_claim_inherited_ai_agent() {
   [ "$out" != gemini ] \
     || fail "AI_AGENT must never claim the gemini identity, got '$out'"
   # A non-1 GEMINI_CLI is not the verified marker value either.
-  out=$(env -u CLAUDECODE -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+  out=$(env -u CLAUDECODE -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI \
         -u PI_CODING_AGENT -u GROK_AGENT GEMINI_CLI=0 "$HARNESS")
   [ "$out" != gemini ] \
     || fail "GEMINI_CLI=0 must not claim the gemini identity, got '$out'"

--- a/tests/fm-gemini-harness.test.sh
+++ b/tests/fm-gemini-harness.test.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Behavior tests for the Gemini harness adapter.
+#
+# The facts pinned here are the ones a Gemini release could silently change and
+# the ones a wrong guess would make dangerous:
+#   1. GEMINI_CLI=1 is Gemini's own child/tool-process marker, and it outranks an
+#      inherited CLAUDECODE, because gemini does NOT clear one (verified live on
+#      gemini-cli 0.58.0 under a claude primary, where a gemini tool process
+#      carried GEMINI_CLI=1 and CLAUDECODE=1 together).
+#   2. AI_AGENT is NOT a Gemini identity. That same process carried the claude
+#      primary's AI_AGENT value, so it is an inherited launcher marker and must
+#      never be promoted to a detection source.
+#   3. The installed CLI is a node bundle whose live process reports comm as
+#      MainThread on modern Node/Linux, so ancestry does NOT reach it and the
+#      marker is the only detection path. The comm-name arm is pinned for a
+#      future natively-named binary.
+#   4. Gemini is a crewmate/scout adapter only: it has no primary supervision
+#      protocol, so its control mechanics are verified while a secondmate launch
+#      on it is refused.
+set -u
+
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-control-lib.sh"
+# shellcheck source=bin/fm-gemini-lib.sh
+. "$ROOT/bin/fm-gemini-lib.sh"
+
+HARNESS="$ROOT/bin/fm-harness.sh"
+TMP_ROOT=$(fm_test_tmproot fm-gemini-harness)
+
+test_gemini_marker_outranks_inherited_claudecode() {
+  local out
+  # This is the exact hazard: gemini does not clear an inherited CLAUDECODE, so
+  # a gemini worker under a claude primary carries both markers at once.
+  out=$(CLAUDECODE=1 GEMINI_CLI=1 "$HARNESS")
+  [ "$out" = gemini ] || fail "CLAUDECODE + GEMINI_CLI must detect gemini, got '$out'"
+  # Drive the two signals apart so the case above cannot go quietly vacuous:
+  # each marker alone must still produce its own verdict.
+  out=$(env -u CLAUDECODE GEMINI_CLI=1 "$HARNESS")
+  [ "$out" = gemini ] || fail "GEMINI_CLI alone must detect gemini, got '$out'"
+  out=$(env -u GEMINI_CLI CLAUDECODE=1 "$HARNESS")
+  [ "$out" = claude ] || fail "CLAUDECODE alone must still detect claude, got '$out'"
+  # Cursor's marker still outranks gemini's, preserving the documented order.
+  out=$(CURSOR_AGENT=1 GEMINI_CLI=1 "$HARNESS")
+  [ "$out" = cursor ] || fail "CURSOR_AGENT must still outrank GEMINI_CLI, got '$out'"
+  pass "fm-harness.sh: gemini's marker outranks an inherited CLAUDECODE"
+}
+
+test_gemini_does_not_claim_inherited_ai_agent() {
+  local out
+  # AI_AGENT was observed carrying the CLAUDE primary's value inside a gemini
+  # tool process, so it proves nothing about which harness is running. A session
+  # with AI_AGENT but no GEMINI_CLI must not be read as gemini.
+  out=$(env -u GEMINI_CLI -u CLAUDECODE -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+        -u PI_CODING_AGENT -u GROK_AGENT AI_AGENT=gemini-cli_0-58-0_agent "$HARNESS")
+  [ "$out" != gemini ] \
+    || fail "AI_AGENT must never claim the gemini identity, got '$out'"
+  # A non-1 GEMINI_CLI is not the verified marker value either.
+  out=$(env -u CLAUDECODE -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+        -u PI_CODING_AGENT -u GROK_AGENT GEMINI_CLI=0 "$HARNESS")
+  [ "$out" != gemini ] \
+    || fail "GEMINI_CLI=0 must not claim the gemini identity, got '$out'"
+  pass "fm-harness.sh: an inherited AI_AGENT never claims the gemini identity"
+}
+
+test_gemini_ancestry_matches_only_a_native_command_name() {
+  local fakebin out
+  # The comm-name arm is reachable only by a natively-named gemini binary. Pin
+  # it with a fake ps so the arm cannot rot, and clear every marker so ONLY
+  # ancestry can produce the verdict.
+  fakebin=$(fm_fakebin "$TMP_ROOT/anc-native")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' '/usr/local/bin/gemini'; exit 0 ;;
+  *"args="*) printf '%s\n' 'gemini -y'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(env -u GEMINI_CLI -u CLAUDECODE -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+        -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = gemini ] \
+    || fail "a natively-named gemini command must be detected by ancestry, got '$out'"
+  pass "fm-harness.sh: ancestry detects a natively-named gemini command"
+}
+
+test_gemini_node_bundle_is_not_ancestry_detectable() {
+  command -v node >/dev/null 2>&1 || return 0
+  local dir="$TMP_ROOT/ancestry" out comm
+  mkdir -p "$dir"
+  # This is the reason GEMINI_CLI is load-bearing for gemini rather than the
+  # fast path it is for grok: the shipped CLI is a node bundle, and modern Node
+  # on Linux reports comm as MainThread, so the interpreter arm never fires.
+  # Pin the actual behaviour rather than a hoped-for one, so nobody later
+  # documents ancestry as covering gemini or "fixes" it by matching MainThread.
+  comm=$(node -e 'const{execSync}=require("child_process");process.stdout.write(execSync("ps -o comm= -p "+process.pid).toString().trim())' 2>/dev/null)
+  [ -n "$comm" ] || return 0
+  if [ "$comm" = node ]; then
+    # A platform whose node DOES report `node` reaches the interpreter arm, and
+    # there the gemini script path must win.
+    cat > "$dir/gemini" <<'JS'
+const { spawnSync } = require('child_process');
+const env = { ...process.env };
+for (const k of ['GEMINI_CLI', 'CLAUDECODE', 'CURSOR_AGENT', 'CURSOR_INVOKED_AS',
+                 'PI_CODING_AGENT', 'GROK_AGENT']) delete env[k];
+const r = spawnSync(process.env.FM_HARNESS_BIN, { env, encoding: 'utf8' });
+process.stdout.write(r.stdout || '');
+JS
+    out=$(FM_HARNESS_BIN="$HARNESS" node "$dir/gemini" 2>/dev/null | tr -d '\n')
+    [ "$out" = gemini ] \
+      || fail "where node reports comm=node, a gemini script path must detect gemini, got '$out'"
+    pass "fm-harness.sh: this platform's node reports comm=node and ancestry reaches gemini"
+    return 0
+  fi
+  # The measured case: comm is not `node`, so ancestry cannot see the bundle and
+  # the marker is the only detection path.
+  cat > "$dir/gemini" <<'JS'
+const { spawnSync } = require('child_process');
+const env = { ...process.env };
+for (const k of ['GEMINI_CLI', 'CLAUDECODE', 'CURSOR_AGENT', 'CURSOR_INVOKED_AS',
+                 'PI_CODING_AGENT', 'GROK_AGENT']) delete env[k];
+const r = spawnSync(process.env.FM_HARNESS_BIN, { env, encoding: 'utf8' });
+process.stdout.write(r.stdout || '');
+JS
+  out=$(FM_HARNESS_BIN="$HARNESS" node "$dir/gemini" 2>/dev/null | tr -d '\n')
+  [ "$out" != gemini ] \
+    || fail "node reports comm=$comm here, so ancestry must not be claiming gemini; got '$out'"
+  # And the marker closes exactly that gap on the same process shape.
+  out=$(FM_HARNESS_BIN="$HARNESS" GEMINI_CLI=1 node -e '
+const { spawnSync } = require("child_process");
+const r = spawnSync(process.env.FM_HARNESS_BIN, { encoding: "utf8" });
+process.stdout.write(r.stdout || "");' 2>/dev/null | tr -d '\n')
+  [ "$out" = gemini ] \
+    || fail "GEMINI_CLI must identify a node-bundle gemini worker, got '$out'"
+  pass "fm-harness.sh: the node bundle is marker-detected, never ancestry-detected"
+}
+
+test_gemini_process_identity_reads_the_script_argument() {
+  # The live shape measured on gemini-cli 0.58.0 / Node v24.20.0: comm is
+  # MainThread and argv[0] is the interpreter, so only argv[1] identifies it.
+  fm_gemini_args_are_gemini 'node /home/u/.local/bin/gemini -y' \
+    || fail "the installed launcher shape must be recognized as gemini"
+  fm_gemini_args_are_gemini '/home/u/.local/node/bin/node --max-old-space-size=10000 /home/u/.local/bin/gemini --skip-trust -y' \
+    || fail "node option flags before the script must be skipped"
+  fm_gemini_args_are_gemini '/opt/node/lib/node_modules/@google/gemini-cli/bundle/gemini.js' \
+    || fail "the published package tree must be recognized as gemini"
+  fm_gemini_args_are_gemini 'gemini -y' \
+    || fail "a natively-named gemini command must be recognized"
+
+  # Divergence: the negatives are what keep the positives from being vacuous.
+  # A bare interpreter is the exact shape that must NOT be claimed, because
+  # claiming it would report a stranger's node pane as a live gemini agent.
+  ! fm_gemini_args_are_gemini '/home/u/.local/node/bin/node' \
+    || fail "a bare node process must not be claimed as gemini"
+  ! fm_gemini_args_are_gemini 'node /home/u/app/server.js' \
+    || fail "an unrelated node script must not be claimed as gemini"
+  # Only argv[0] and the script argument are consulted, so a command that
+  # merely mentions gemini later on its line proves nothing.
+  ! fm_gemini_args_are_gemini 'node /home/u/app/server.js --model gemini' \
+    || fail "a later flag value naming gemini must not claim the identity"
+  ! fm_gemini_args_are_gemini 'tail -f /var/log/gemini.log' \
+    || fail "an unrelated command reading a gemini-named file must not match"
+  # A directory component alone is not evidence.
+  ! fm_gemini_args_are_gemini 'node /home/u/gemini/other.js' \
+    || fail "a gemini directory component alone must not claim the identity"
+  pass "fm-gemini-lib.sh: identity comes from the script argument, never a bare interpreter"
+}
+
+test_gemini_control_mechanics_are_the_verified_ones() {
+  local out
+  fm_control_harness_supported gemini || fail "gemini must be a supported control harness"
+  out=$(fm_control_harness_family gemini-0.58.0)
+  [ "$out" = gemini ] || fail "a recorded gemini* harness must resolve to gemini, got '$out'"
+  out=$(fm_control_interrupt_key gemini)
+  [ "$out" = Escape ] || fail "gemini interrupts on Escape, got '$out'"
+  out=$(fm_control_interrupt_repeat gemini)
+  [ "$out" = 1 ] || fail "gemini interrupts on a single press, got '$out'"
+  out=$(fm_control_interrupt_clear_key gemini)
+  [ -z "$out" ] || fail "gemini needs no composer clear key, got '$out'"
+  out=$(fm_control_exit_command gemini)
+  [ "$out" = /quit ] || fail "gemini exits with /quit, got '$out'"
+  pass "fm-control-lib.sh: gemini carries its verified interrupt and exit mechanics"
+}
+
+test_gemini_is_crewmate_and_scout_only() {
+  fm_control_harness_supports_kind gemini ship \
+    || fail "gemini must be verified for ship work"
+  fm_control_harness_supports_kind gemini scout \
+    || fail "gemini must be verified for scout work"
+  ! fm_control_harness_supports_kind gemini secondmate \
+    || fail "gemini has no primary supervision protocol and must be refused for secondmates"
+  pass "fm-control-lib.sh: gemini is a crewmate/scout adapter only"
+}
+
+test_gemini_wiring_stays_outside_the_worktree() {
+  local out
+  out=$(fm_control_harness_wiring_paths gemini /wt /state task-1)
+  [ "$out" = "/state/task-1.gemini-settings.json" ] \
+    || fail "gemini's per-task wiring is its firstmate-owned settings file, got '$out'"
+  case "$out" in
+    /wt/*) fail "gemini must never claim a path inside the worktree: '$out'" ;;
+  esac
+  pass "fm-control-lib.sh: gemini's wiring stays outside the project worktree"
+}
+
+test_gemini_marker_outranks_inherited_claudecode
+test_gemini_does_not_claim_inherited_ai_agent
+test_gemini_ancestry_matches_only_a_native_command_name
+test_gemini_node_bundle_is_not_ancestry_detectable
+test_gemini_process_identity_reads_the_script_argument
+test_gemini_control_mechanics_are_the_verified_ones
+test_gemini_is_crewmate_and_scout_only
+test_gemini_wiring_stays_outside_the_worktree

--- a/tests/fm-gemini-harness.test.sh
+++ b/tests/fm-gemini-harness.test.sh
@@ -87,6 +87,33 @@ SH
   pass "fm-harness.sh: ancestry detects a natively-named gemini command"
 }
 
+test_gemini_ancestry_rejects_unrelated_mentions() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/anc-negatives")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' "${FAKE_PS_COMM:?}"; exit 0 ;;
+  *"args="*) printf '%s\n' "${FAKE_PS_ARGS:?}"; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(env -u GEMINI_CLI -u CLAUDECODE -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+        -u PI_CODING_AGENT -u GROK_AGENT FAKE_PS_COMM=gemini-helper \
+        FAKE_PS_ARGS='gemini-helper --serve' PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" != gemini ] \
+    || fail "an unrelated gemini-helper command must not detect gemini, got '$out'"
+
+  out=$(env -u GEMINI_CLI -u CLAUDECODE -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+        -u PI_CODING_AGENT -u GROK_AGENT FAKE_PS_COMM=node \
+        FAKE_PS_ARGS='node server.js --model gemini' PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" != gemini ] \
+    || fail "a later node argument naming gemini must not detect gemini, got '$out'"
+  pass "fm-harness.sh: ancestry rejects unrelated gemini mentions"
+}
+
 test_gemini_node_bundle_is_not_ancestry_detectable() {
   command -v node >/dev/null 2>&1 || return 0
   local dir="$TMP_ROOT/ancestry" out comm
@@ -209,6 +236,7 @@ test_gemini_wiring_stays_outside_the_worktree() {
 test_gemini_marker_outranks_inherited_claudecode
 test_gemini_does_not_claim_inherited_ai_agent
 test_gemini_ancestry_matches_only_a_native_command_name
+test_gemini_ancestry_rejects_unrelated_mentions
 test_gemini_node_bundle_is_not_ancestry_detectable
 test_gemini_process_identity_reads_the_script_argument
 test_gemini_control_mechanics_are_the_verified_ones

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -205,7 +205,7 @@ test_kimi_launch_then_send_is_verified() {
   assert_contains "$out" "spawned $id harness=kimi" "kimi spawn did not report success"
 
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS '$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
+  [ "$launch" = "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI '$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
     || fail "kimi launch did not use the absolute binary, model, and --auto only: $launch"
   assert_not_contains "$launch" "--effort" "kimi launch emitted a nonexistent effort flag"
   assert_not_contains "$launch" "turn-ended" "kimi launch embedded a turn-end path"
@@ -462,7 +462,7 @@ test_kimi_falls_back_to_expanded_home_binary() {
   rc=$?
   expect_code 0 "$rc" "Kimi HOME fallback spawn should succeed"
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS '$fallback' --auto" ] \
+  [ "$launch" = "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI '$fallback' --auto" ] \
     || fail "Kimi fallback did not expand HOME into an absolute executable: $launch"
   pass "fm-spawn: Kimi fallback expands the active HOME"
 }
@@ -547,10 +547,10 @@ SH
   chmod +x "$fakebin/ps"
 
   out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
-    -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+    -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI \
     PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
   [ "$out" = kimi ] || fail "kimi ancestry detection returned '$out'"
-  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI \
     CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
   [ "$out" = claude ] || fail "verified env-marker precedence changed, got '$out'"
   pass "fm-harness: markerless kimi is detected by ancestry after env-marker precedence"

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -183,7 +183,7 @@ test_detects_versioned_process_ancestor() {
   for bin in muse-bin-0.1.0-R708.1 muse-bin-9.9.9-RZZZ.9 muse; do
     cp "$(command -v bash)" "$dir/$bin"
     out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
-      -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+      -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI \
       "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
     [ "$out" = muse ] || fail "fm-harness.sh under process '$bin' reported '$out', expected muse"
   done
@@ -199,7 +199,7 @@ test_detection_is_anchored() {
   for bin in musescore amuse notmuse-bin muse-binary muse-bind; do
     cp "$(command -v bash)" "$dir/$bin"
     out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
-      -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+      -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI \
       "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
     [ "$out" != muse ] || fail "fm-harness.sh misdetected unrelated process '$bin' as muse"
   done

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -131,7 +131,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '{\"feedbackDrafts\":\"off\"}' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/launch-brief.md')\""
+  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '{\"feedbackDrafts\":\"off\"}' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/launch-brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -147,7 +147,7 @@ test_non_cursor_launch_clears_inherited_cursor_markers() {
   status=$?
   expect_code 0 "$status" "claude spawn under Cursor markers should succeed"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS" \
+  assert_contains "$launch" "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI" \
     "non-cursor launch must clear both inherited Cursor identity markers"
   pass "non-cursor launches clear inherited Cursor identity markers"
 }
@@ -739,7 +739,7 @@ test_claude_forwards_firstmate_config_dir_when_set() {
   status=$?
   expect_code 0 "$status" "claude spawn with CLAUDE_CONFIG_DIR set should succeed"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "CLAUDE_CONFIG_DIR='$CASE_DIR/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '{\"feedbackDrafts\":\"off\"}'" \
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='$CASE_DIR/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '{\"feedbackDrafts\":\"off\"}'" \
     "claude launch did not forward firstmate's CLAUDE_CONFIG_DIR to the crewmate pane"
   pass "claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store"
 }


### PR DESCRIPTION
## Intent

Verify Gemini as a runtime firstmate can dispatch crewmates onto, so it becomes a fourth option alongside claude, codex and grok.

The captain, 2026-09-03: "also gemini is in play as well", confirmed on a direct question as covering both the fleet-runtime destination (this task) and hivemind product inference (hivemind-gemini-inference, a separate item). He supplied the API key on 2026-09-04 and said to proceed.

WHY IT MATTERS RIGHT NOW: on 2026-09-03 grok exhausted its weekly allowance mid-task and stranded two workers, which firstmate had to move by hand. A fourth verified runtime is one more place to send work when a provider runs dry.

WHY THIS IS REAL WORK AND NOT A CONFIG LINE: firstmate has a hard rule against dispatching a crewmate on an unverified adapter, because an unverified runtime does not stop safely - it looks like it is working while the worker sits idle. Three such quirks bit this fleet in a single session on already-verified runtimes: a grok pane wedged behind a consent dialog, and a claude worker stalled on a trust prompt whose default selection was "No, exit".

## What Changed

- Add Gemini CLI as a verified crewmate and scout runtime, with trusted workspace launch, model selection, harness detection, lifecycle controls, and explicit secondmate refusal.
- Wire per-task Gemini hooks into semantic busy-state and turn-end reporting, including safe cleanup and narrow process detection for Node-bundled launches.
- Add adapter tests and operational documentation covering identity, credentials, trust, hooks, control behavior, and verification boundaries.

## Risk Assessment

✅ Low: The Gemini adapter is well-bounded, the prior ancestry and raw-launch busy-state defects are correctly closed, and no remaining material source risk was substantiated.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 2 runs (1h13m17s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2a37d1a7c8e8f9168e3257118bb74cb02ae06e0f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-spawn-dispatch-profile.test.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-spawn.sh:1351` - Gemini is launched without proving that the worker pane can authenticate. The adapter documentation says a missing worker-reachable credential opens an interactive API-key dialog, strands the launch brief, and can persist `/quit` as a bogus credential if lifecycle control is attempted—the exact silent-idle failure this change is intended to prevent. Add a fail-closed preflight at the earliest spawn boundary before creating/publishing the task, covering each supported credential path and the selected backend&#39;s environment. Because defining supported credential discovery/propagation may require new authentication machinery, the remedy needs authorization.
- 🚨 `bin/fm-harness.sh:111` - The new ancestry branches classify any command name or interpreter argument containing `gemini` as the Gemini harness. For example, an unrelated `gemini-helper` parent or `node server.js --model gemini` returns `gemini` without error, despite the new structural helper explicitly rejecting those cases. Route ancestry detection through the narrow `fm_gemini_path_is_gemini`/argument rule (at the shared harness-detection boundary) so only the executable or script identity can claim Gemini.

🔧 Fix: Narrow Gemini ancestry detection
1 warning still open:

- ⚠️ `bin/fm-spawn.sh:2678` - A raw launch command whose derived basename matches `gemini*` (for example `gemini --debug` or `gemini-helper`) enters the verified Gemini busy-state path: spawn seeds `busy fm-spawn` and writes a settings file, but the raw command never receives `GEMINI_CLI_SYSTEM_SETTINGS_PATH`, so no hook can clear that state and the worker can remain falsely busy without error. Either restrict Gemini wiring/family recognition to canonical template launches or inject the settings path into recognized raw Gemini launches. This needs authorization because raw-command behavior is an intentional escape hatch and the current tests deliberately accept version-suffixed Gemini family names.

🔧 Fix: Restrict Gemini hooks to canonical launches
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Confirm failures are timing and subreaper environment issues
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
