### PR TITLE
fix(bin): prevent false missed-reply escalations

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -263,7 +263,8 @@ You must distinguish who it is from, because the answer goes to a different plac
 A request relayed to you by the main firstmate is tagged with a leading \`$FM_FROMFIRST_LABEL\` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
 When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
 Marked requests also carry a privacy-safe \`corr=<id>\` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
-Optional helper: \`bin/fm-secondmate-report.sh\` can append a correlated status line for you, but a plain \`echo\` that includes the same \`corr=<id>\` is equally valid - do not depend on the helper being present.
+Optional helper: \`bin/fm-secondmate-report.sh <verb> <corr_id> <note>\` appends that correlated line to the parent channel itself - do not pass a status path, and do not write a hand path under this home.
+A plain \`echo\` that includes the same \`corr=<id>\` on this parent channel is equally valid; do not depend on the helper being present.
 For a terse result, a status line is the whole answer.
 For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's \`data/\` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
 Before treating an investigation or visual review as complete, load \`captain-hold-lifecycle\` from this home's \`.agents/skills/\` and pass its shared completion gate.

--- a/bin/fm-parent-channel-lib.sh
+++ b/bin/fm-parent-channel-lib.sh
@@ -24,6 +24,8 @@
 #   - bin/fm-merge-outcome-lib.sh    a merged PR
 #   - bin/fm-teardown.sh             the child's final ledger line, refusing to
 #                                    remove the child while it is undelivered
+#   - bin/fm-secondmate-report.sh     a marked request's correlated answer,
+#                                    with this resolver choosing its destination
 # The mate's own appends are reserved for judgement (bin/fm-brief.sh charter).
 # docs/secondmate-parent-channel.md records the design and its coverage.
 #

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -55,6 +55,7 @@
 #   resolved_epoch=
 #   resolved_via=           status | document | helper | empty
 #   wrong_home_hits=        count of corr sightings under the secondmate home
+#   wrong_home_first_sighting= readable path:line identity of the first sighting
 #   wrong_home_sightings=   comma-separated path:line identities of those sightings
 #   wrong_home_scan_signature=
 #   grace_secs=             bounded grace before recovery is eligible
@@ -293,6 +294,7 @@ escalated_epoch=
 resolved_epoch=
 resolved_via=
 wrong_home_hits=0
+wrong_home_first_sighting=
 wrong_home_sightings=
 wrong_home_scan_signature=
 grace_secs=$(fm_pending_reply_grace_secs)
@@ -1126,7 +1128,7 @@ fm_pending_reply_maybe_escalate() {  # <state-dir> <corr_id>
 
 _fm_pending_reply_maybe_escalate_locked() {  # <state-dir> <corr_id>
   local state=$1 corr=$2
-  local rec phase completed now payload parent_status line kind sightings first
+  local rec phase completed now payload parent_status line kind first
   local delivered task_id meta sm_home remote_host
   rec=$(fm_pending_reply_path "$state" "$corr")
   [ -f "$rec" ] || return 1
@@ -1171,8 +1173,7 @@ _fm_pending_reply_maybe_escalate_locked() {  # <state-dir> <corr_id>
   esac
   payload=$(fm_pending_reply_escalation_payload "$rec" "$kind") || return 1
   if [ "$kind" = missed ]; then
-    sightings=$(fm_pending_reply_get "$rec" wrong_home_sightings)
-    first=${sightings%%,*}
+    first=$(fm_pending_reply_get "$rec" wrong_home_first_sighting)
     if [ -n "$first" ]; then
       payload="$payload token seen in $first; parent channel has no corr="
     fi
@@ -1194,7 +1195,7 @@ _fm_pending_reply_maybe_escalate_locked() {  # <state-dir> <corr_id>
 # parent-replies.status is its parent channel, not a stranded self-home file.
 fm_pending_reply_detect_wrong_home() {  # <state-dir> <corr_id> <secondmate-home>
   local state=$1 corr=$2 sm_home=$3
-  local rec delivered hits sightings snapshot previous status_file line line_no sighting_id phase changed=0
+  local rec delivered hits first sightings snapshot previous status_file line line_no sighting_id phase changed=0
   local remote_parent_channel=0
   rec=$(fm_pending_reply_path "$state" "$corr")
   [ -f "$rec" ] || return 1
@@ -1205,9 +1206,12 @@ fm_pending_reply_detect_wrong_home() {  # <state-dir> <corr_id> <secondmate-home
   [ -n "$delivered" ] || return 0
   snapshot=$(fm_pending_reply_status_set_signature "$sm_home/state")
   previous=$(fm_pending_reply_get "$rec" wrong_home_scan_signature)
-  [ "$snapshot" != "$previous" ] || return 0
   hits=$(fm_pending_reply_get "$rec" wrong_home_hits)
   case "$hits" in ''|*[!0-9]*) hits=0 ;; esac
+  first=$(fm_pending_reply_get "$rec" wrong_home_first_sighting)
+  if [ "$snapshot" = "$previous" ] && { [ "$hits" = 0 ] || [ -n "$first" ]; }; then
+    return 0
+  fi
   sightings=$(fm_pending_reply_get "$rec" wrong_home_sightings)
   # shellcheck source=bin/fm-parent-channel-lib.sh
   . "$_FM_PENDING_REPLY_LIB_DIR/fm-parent-channel-lib.sh"
@@ -1227,6 +1231,7 @@ fm_pending_reply_detect_wrong_home() {  # <state-dir> <corr_id> <secondmate-home
       fm_pending_reply_line_resolves "$line" "$corr" || continue
       sighting_id=$(printf '%s:%s' "$status_file" "$line_no")
       [ -n "$sighting_id" ] || continue
+      [ -n "$first" ] || first=$sighting_id
       case ",$sightings," in
         *",$sighting_id,"*) continue ;;
       esac
@@ -1239,6 +1244,9 @@ fm_pending_reply_detect_wrong_home() {  # <state-dir> <corr_id> <secondmate-home
       changed=1
     done < "$status_file"
   done
+  if [ -n "$first" ] && [ -z "$(fm_pending_reply_get "$rec" wrong_home_first_sighting)" ]; then
+    fm_pending_reply_set "$rec" wrong_home_first_sighting "$first" || return 1
+  fi
   if [ "$changed" = 1 ]; then
     fm_pending_reply_set "$rec" wrong_home_sightings "$sightings" || return 1
     fm_pending_reply_set "$rec" wrong_home_hits "$hits" || return 1

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -55,8 +55,8 @@
 #   resolved_epoch=
 #   resolved_via=           status | document | helper | empty
 #   wrong_home_hits=        count of corr sightings under the secondmate home
-#   wrong_home_first_sighting= readable path:line identity of the first sighting
-#   wrong_home_sightings=   comma-separated path:line identities of those sightings
+#   wrong_home_first_sighting= encoded path:line identity of the first sighting
+#   wrong_home_sightings=   comma-separated encoded path:line identities
 #   wrong_home_scan_signature=
 #   grace_secs=             bounded grace before recovery is eligible
 #
@@ -178,6 +178,33 @@ fm_pending_reply_get() {  # <record-path> <key>
   local rec=$1 key=$2
   [ -f "$rec" ] || return 0
   grep "^${key}=" "$rec" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+fm_pending_reply_sighting_encode() {  # <path> <line-number>
+  local path=$1 line_no=$2 encoded
+  case "$line_no" in ''|*[!0-9]*) return 1 ;; esac
+  encoded=$(printf '%s' "$path" | LC_ALL=C od -An -v -tx1 | tr -d ' \n') || return 1
+  [ -n "$encoded" ] || return 1
+  printf 'hex:%s:%s' "$encoded" "$line_no"
+}
+
+fm_pending_reply_sighting_display() {  # <encoded-sighting>
+  local sighting=$1 body encoded line_no path='' pair byte escaped
+  case "$sighting" in hex:*:*) ;; *) return 1 ;; esac
+  body=${sighting#hex:}
+  line_no=${body##*:}
+  encoded=${body%:*}
+  case "$line_no" in ''|*[!0-9]*) return 1 ;; esac
+  [ -n "$encoded" ] && [ $(( ${#encoded} % 2 )) -eq 0 ] || return 1
+  while [ -n "$encoded" ]; do
+    pair=${encoded:0:2}
+    case "$pair" in *[!0-9a-fA-F]*) return 1 ;; esac
+    printf -v byte '%b' "\\x$pair"
+    path=$path$byte
+    encoded=${encoded:2}
+  done
+  printf -v escaped '%q' "$path"
+  printf '%s:%s' "$escaped" "$line_no"
 }
 
 fm_pending_reply_corr_reusable() {  # <state-dir> <corr_id> <task_id>
@@ -1128,7 +1155,7 @@ fm_pending_reply_maybe_escalate() {  # <state-dir> <corr_id>
 
 _fm_pending_reply_maybe_escalate_locked() {  # <state-dir> <corr_id>
   local state=$1 corr=$2
-  local rec phase completed now payload parent_status line kind first
+  local rec phase completed now payload parent_status line kind first display
   local delivered task_id meta sm_home remote_host
   rec=$(fm_pending_reply_path "$state" "$corr")
   [ -f "$rec" ] || return 1
@@ -1174,8 +1201,8 @@ _fm_pending_reply_maybe_escalate_locked() {  # <state-dir> <corr_id>
   payload=$(fm_pending_reply_escalation_payload "$rec" "$kind") || return 1
   if [ "$kind" = missed ]; then
     first=$(fm_pending_reply_get "$rec" wrong_home_first_sighting)
-    if [ -n "$first" ]; then
-      payload="$payload token seen in $first; parent channel has no corr="
+    if display=$(fm_pending_reply_sighting_display "$first"); then
+      payload="$payload token seen in $display; parent channel has no corr="
     fi
   fi
   [ -n "$parent_status" ] || return 1
@@ -1229,8 +1256,7 @@ fm_pending_reply_detect_wrong_home() {  # <state-dir> <corr_id> <secondmate-home
     while IFS= read -r line || [ -n "$line" ]; do
       line_no=$((line_no + 1))
       fm_pending_reply_line_resolves "$line" "$corr" || continue
-      sighting_id=$(printf '%s:%s' "$status_file" "$line_no")
-      [ -n "$sighting_id" ] || continue
+      sighting_id=$(fm_pending_reply_sighting_encode "$status_file" "$line_no") || continue
       [ -n "$first" ] || first=$sighting_id
       case ",$sightings," in
         *",$sighting_id,"*) continue ;;

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -1190,11 +1190,12 @@ _fm_pending_reply_maybe_escalate_locked() {  # <state-dir> <corr_id>
 }
 
 # Detect a correlated report written under the secondmate home (wrong home)
-# without treating it as acknowledgement. parent-replies.status is the remote
-# parent channel, not a stranded self-home file, so it is skipped.
+# without treating it as acknowledgement. A remote route's
+# parent-replies.status is its parent channel, not a stranded self-home file.
 fm_pending_reply_detect_wrong_home() {  # <state-dir> <corr_id> <secondmate-home>
   local state=$1 corr=$2 sm_home=$3
   local rec delivered hits sightings snapshot previous status_file line line_no sighting_id phase changed=0
+  local remote_parent_channel=0
   rec=$(fm_pending_reply_path "$state" "$corr")
   [ -f "$rec" ] || return 1
   [ -n "$sm_home" ] && [ -d "$sm_home" ] || return 0
@@ -1208,11 +1209,18 @@ fm_pending_reply_detect_wrong_home() {  # <state-dir> <corr_id> <secondmate-home
   hits=$(fm_pending_reply_get "$rec" wrong_home_hits)
   case "$hits" in ''|*[!0-9]*) hits=0 ;; esac
   sightings=$(fm_pending_reply_get "$rec" wrong_home_sightings)
+  # shellcheck source=bin/fm-parent-channel-lib.sh
+  . "$_FM_PENDING_REPLY_LIB_DIR/fm-parent-channel-lib.sh"
+  if fm_parent_channel_destination "$sm_home" "$sm_home/state" >/dev/null 2>&1 \
+    && [ "$FM_PARENT_CHANNEL_ROUTE" = remote ]; then
+    remote_parent_channel=1
+  fi
   for status_file in "$sm_home"/state/*.status; do
     [ -e "$status_file" ] || continue
-    case "$(basename "$status_file")" in
-      parent-replies.status) continue ;;
-    esac
+    if [ "$remote_parent_channel" = 1 ] \
+      && [ "$(basename "$status_file")" = parent-replies.status ]; then
+      continue
+    fi
     line_no=0
     while IFS= read -r line || [ -n "$line" ]; do
       line_no=$((line_no + 1))

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -1222,7 +1222,7 @@ _fm_pending_reply_maybe_escalate_locked() {  # <state-dir> <corr_id>
 # parent-replies.status is its parent channel, not a stranded self-home file.
 fm_pending_reply_detect_wrong_home() {  # <state-dir> <corr_id> <secondmate-home>
   local state=$1 corr=$2 sm_home=$3
-  local rec delivered hits first sightings snapshot previous status_file line line_no sighting_id phase changed=0
+  local rec delivered hits first sightings snapshot previous status_file line line_no sighting_base sighting_id phase changed=0
   local remote_parent_channel=0
   rec=$(fm_pending_reply_path "$state" "$corr")
   [ -f "$rec" ] || return 1
@@ -1252,11 +1252,13 @@ fm_pending_reply_detect_wrong_home() {  # <state-dir> <corr_id> <secondmate-home
       && [ "$(basename "$status_file")" = parent-replies.status ]; then
       continue
     fi
+    sighting_base=$(fm_pending_reply_sighting_encode "$status_file" 0) || continue
+    sighting_base=${sighting_base%:0}
     line_no=0
     while IFS= read -r line || [ -n "$line" ]; do
       line_no=$((line_no + 1))
       fm_pending_reply_line_resolves "$line" "$corr" || continue
-      sighting_id=$(fm_pending_reply_sighting_encode "$status_file" "$line_no") || continue
+      sighting_id="$sighting_base:$line_no"
       [ -n "$first" ] || first=$sighting_id
       case ",$sightings," in
         *",$sighting_id,"*) continue ;;

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -15,7 +15,9 @@
 # and escalate once if the recovery turn also completes without a correlated
 # report. Never loop, never repeatedly inject, never silently expire unresolved
 # records, and never treat wrong-home or structured-home heuristics as
-# acknowledgement.
+# acknowledgement. A same-basename restatement-copy of the mate home's
+# state/<task_id>.status onto the parent channel is a repair of the
+# FM_HOME-relative mixup, not acknowledgement of an arbitrary mate-home file.
 #
 # Record location (parent FM_HOME):
 #   state/pending-replies/<corr_id>
@@ -53,7 +55,7 @@
 #   resolved_epoch=
 #   resolved_via=           status | document | helper | empty
 #   wrong_home_hits=        count of corr sightings under the secondmate home
-#   wrong_home_sightings=   comma-separated identities of counted sightings
+#   wrong_home_sightings=   comma-separated path:line identities of those sightings
 #   wrong_home_scan_signature=
 #   grace_secs=             bounded grace before recovery is eligible
 #
@@ -1025,6 +1027,7 @@ fm_pending_reply_escalation_line() {  # <status-file> <record-path> <corr_id>
       payload=$(fm_pending_reply_escalation_payload "$rec" "$kind") || continue
       case "$line" in
         "blocked [key=$own_key]: $payload"|"blocked: $payload") found=$line; break ;;
+        "blocked [key=$own_key]: $payload "*|"blocked: $payload "*) found=$line; break ;;
       esac
     done
   done < "$status_file"
@@ -1123,7 +1126,7 @@ fm_pending_reply_maybe_escalate() {  # <state-dir> <corr_id>
 
 _fm_pending_reply_maybe_escalate_locked() {  # <state-dir> <corr_id>
   local state=$1 corr=$2
-  local rec phase completed now payload parent_status line kind
+  local rec phase completed now payload parent_status line kind sightings first
   rec=$(fm_pending_reply_path "$state" "$corr")
   [ -f "$rec" ] || return 1
   phase=$(fm_pending_reply_get "$rec" phase)
@@ -1155,6 +1158,13 @@ _fm_pending_reply_maybe_escalate_locked() {  # <state-dir> <corr_id>
     *) kind=missed ;;
   esac
   payload=$(fm_pending_reply_escalation_payload "$rec" "$kind") || return 1
+  if [ "$kind" = missed ]; then
+    sightings=$(fm_pending_reply_get "$rec" wrong_home_sightings)
+    first=${sightings%%,*}
+    if [ -n "$first" ]; then
+      payload="$payload token seen in $first; parent channel has no corr="
+    fi
+  fi
   [ -n "$parent_status" ] || return 1
   mkdir -p "$(dirname "$parent_status")" 2>/dev/null || return 1
   line="blocked [key=$(fm_pending_reply_escalation_key "$corr")]: $payload"
@@ -1168,7 +1178,8 @@ _fm_pending_reply_maybe_escalate_locked() {  # <state-dir> <corr_id>
 }
 
 # Detect a correlated report written under the secondmate home (wrong home)
-# without treating it as acknowledgement.
+# without treating it as acknowledgement. parent-replies.status is the remote
+# parent channel, not a stranded self-home file, so it is skipped.
 fm_pending_reply_detect_wrong_home() {  # <state-dir> <corr_id> <secondmate-home>
   local state=$1 corr=$2 sm_home=$3
   local rec delivered hits sightings snapshot previous status_file line line_no sighting_id phase changed=0
@@ -1187,12 +1198,14 @@ fm_pending_reply_detect_wrong_home() {  # <state-dir> <corr_id> <secondmate-home
   sightings=$(fm_pending_reply_get "$rec" wrong_home_sightings)
   for status_file in "$sm_home"/state/*.status; do
     [ -e "$status_file" ] || continue
+    case "$(basename "$status_file")" in
+      parent-replies.status) continue ;;
+    esac
     line_no=0
     while IFS= read -r line || [ -n "$line" ]; do
       line_no=$((line_no + 1))
       fm_pending_reply_line_resolves "$line" "$corr" || continue
-      sighting_id=$(printf '%s:%s:%s:%s' "${#status_file}" "$status_file" "$line_no" "$line" \
-        | cksum 2>/dev/null | awk '{printf "%s-%s", $1, $2}')
+      sighting_id=$(printf '%s:%s' "$status_file" "$line_no")
       [ -n "$sighting_id" ] || continue
       case ",$sightings," in
         *",$sighting_id,"*) continue ;;
@@ -1212,6 +1225,28 @@ fm_pending_reply_detect_wrong_home() {  # <state-dir> <corr_id> <secondmate-home
   fi
   fm_pending_reply_set "$rec" wrong_home_scan_signature "$snapshot" || return 1
   return 0
+}
+
+# Restatement-copy a same-basename self-home corr= line onto the parent channel.
+# Only $sm_home/state/<task_id>.status is copied; arbitrary child status files
+# stay evidence, not acknowledgement.
+fm_pending_reply_restatement_copy_same_basename() {  # <state-dir> <corr_id> <secondmate-home>
+  local state=$1 corr=$2 sm_home=$3
+  local rec task_id parent_status stranded line
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  [ -f "$rec" ] || return 1
+  [ -n "$sm_home" ] && [ -d "$sm_home" ] || return 1
+  task_id=$(fm_pending_reply_get "$rec" task_id)
+  parent_status=$(fm_pending_reply_get "$rec" parent_status)
+  [ -n "$task_id" ] && [ -n "$parent_status" ] || return 1
+  stranded="$sm_home/state/${task_id}.status"
+  [ -f "$stranded" ] && [ ! -L "$stranded" ] || return 1
+  [ "$stranded" != "$parent_status" ] || return 1
+  line=$(fm_pending_reply_find_resolve_line "$stranded" "$corr")
+  [ -n "$line" ] || return 1
+  # shellcheck source=bin/fm-parent-channel-lib.sh
+  . "$_FM_PENDING_REPLY_LIB_DIR/fm-parent-channel-lib.sh"
+  fm_parent_channel_append_once "$parent_status" "$line"
 }
 
 # One reconciliation tick for a single record: resolve, observe, recover, escalate.
@@ -1251,6 +1286,11 @@ fm_pending_reply_tick_one() {  # <state-dir> <corr_id> <busy_state> [secondmate-
       # Unresolved durable record retained; never auto-delete.
       if [ -n "$sm_home" ]; then
         fm_pending_reply_detect_wrong_home "$state" "$corr" "$sm_home" || true
+        if fm_pending_reply_restatement_copy_same_basename "$state" "$corr" "$sm_home"; then
+          if fm_pending_reply_try_resolve "$state" "$corr"; then
+            return 0
+          fi
+        fi
       fi
       return 0
       ;;
@@ -1262,6 +1302,7 @@ fm_pending_reply_tick_one() {  # <state-dir> <corr_id> <busy_state> [secondmate-
   esac
   if [ -n "$sm_home" ]; then
     fm_pending_reply_detect_wrong_home "$state" "$corr" "$sm_home" || true
+    fm_pending_reply_restatement_copy_same_basename "$state" "$corr" "$sm_home" || true
   fi
   fm_pending_reply_observe_busy "$state" "$corr" "$busy_state" || true
   # Re-check resolve after observation in case a concurrent status write landed.
@@ -1333,6 +1374,11 @@ fm_pending_reply_tick() {  # <state-dir>
         sm_home=$(fm_meta_get "$meta" home)
         if [ -n "$sm_home" ]; then
           fm_pending_reply_detect_wrong_home "$state" "$corr" "$sm_home" || true
+          if fm_pending_reply_restatement_copy_same_basename "$state" "$corr" "$sm_home"; then
+            if fm_pending_reply_try_resolve "$state" "$corr"; then
+              continue
+            fi
+          fi
         fi
       fi
       continue

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -1127,6 +1127,7 @@ fm_pending_reply_maybe_escalate() {  # <state-dir> <corr_id>
 _fm_pending_reply_maybe_escalate_locked() {  # <state-dir> <corr_id>
   local state=$1 corr=$2
   local rec phase completed now payload parent_status line kind sightings first
+  local delivered task_id meta sm_home remote_host
   rec=$(fm_pending_reply_path "$state" "$corr")
   [ -f "$rec" ] || return 1
   phase=$(fm_pending_reply_get "$rec" phase)
@@ -1147,6 +1148,17 @@ _fm_pending_reply_maybe_escalate_locked() {  # <state-dir> <corr_id>
     delivery_unknown|recovery_failed|recovery_unknown) ;;
     *) return 1 ;;
   esac
+  delivered=$(fm_pending_reply_get "$rec" delivered_epoch)
+  task_id=$(fm_pending_reply_get "$rec" task_id)
+  meta="$state/${task_id}.meta"
+  if [ -n "$delivered" ] && [ -f "$meta" ]; then
+    remote_host=$(fm_meta_get "$meta" remote_host)
+    sm_home=$(fm_meta_get "$meta" home)
+    if [ -z "$remote_host" ] && [ -n "$sm_home" ]; then
+      fm_pending_reply_detect_wrong_home "$state" "$corr" "$sm_home" || true
+      fm_pending_reply_restatement_copy_same_basename "$state" "$corr" "$sm_home" || true
+    fi
+  fi
   # Resolve wins if a late report arrived between completion and this call.
   if _fm_pending_reply_try_resolve_locked "$state" "$corr"; then
     return 0

--- a/bin/fm-secondmate-report.sh
+++ b/bin/fm-secondmate-report.sh
@@ -23,6 +23,7 @@
 #   fm-secondmate-report.sh --doc done abcdef0123456789 data/x/report.md "see report"
 set -eu
 
+CALLER_FM_HOME=${FM_HOME:-}
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=bin/fm-pending-reply-lib.sh
 . "$SCRIPT_DIR/fm-pending-reply-lib.sh"
@@ -65,7 +66,7 @@ case "$CORR" in
     ;;
 esac
 
-HOME_DIR="${FM_HOME:-${FM_ROOT_OVERRIDE:-}}"
+HOME_DIR=$CALLER_FM_HOME
 case "$HOME_DIR" in
   '')
     echo "error: FM_HOME is required so the helper can resolve the parent channel" >&2

--- a/bin/fm-secondmate-report.sh
+++ b/bin/fm-secondmate-report.sh
@@ -7,30 +7,33 @@
 # status line that includes the same corr token is equally valid
 # (bin/fm-pending-reply-lib.sh).
 #
+# The write destination is mechanical: this helper never takes a status path.
+# It resolves the parent channel through fm_parent_channel_destination
+# (bin/fm-parent-channel-lib.sh): a local mate writes the parent home's
+# state/<id>.status, and a remote mate writes this home's
+# state/parent-replies.status. Call it from the secondmate home with FM_HOME
+# set to that home.
+#
 # Usage:
-#   fm-secondmate-report.sh <status-file> <verb> <corr_id> <note...>
-#   fm-secondmate-report.sh --doc <status-file> <verb> <corr_id> <doc-path> <note...>
+#   fm-secondmate-report.sh <verb> <corr_id> <note...>
+#   fm-secondmate-report.sh --doc <verb> <corr_id> <doc-path> <note...>
 #
 # Examples:
-#   fm-secondmate-report.sh "$STATUS" done abcdef0123456789 "audit clean"
-#   fm-secondmate-report.sh --doc "$STATUS" done abcdef0123456789 data/x/report.md "see report"
-#
-# The status file must be the absolute parent route from the secondmate charter
-# (state/<id>.status under the PARENT home), never a path relative to this
-# secondmate home. Writing under the wrong home is detected as supporting
-# evidence by the parent pending-reply guard and does not acknowledge the
-# request.
+#   fm-secondmate-report.sh done abcdef0123456789 "audit clean"
+#   fm-secondmate-report.sh --doc done abcdef0123456789 data/x/report.md "see report"
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=bin/fm-pending-reply-lib.sh
 . "$SCRIPT_DIR/fm-pending-reply-lib.sh"
+# shellcheck source=bin/fm-parent-channel-lib.sh
+. "$SCRIPT_DIR/fm-parent-channel-lib.sh"
 
 usage() {
   cat <<'EOF' >&2
 Usage:
-  fm-secondmate-report.sh <status-file> <verb> <corr_id> <note...>
-  fm-secondmate-report.sh --doc <status-file> <verb> <corr_id> <doc-path> <note...>
+  fm-secondmate-report.sh <verb> <corr_id> <note...>
+  fm-secondmate-report.sh --doc <verb> <corr_id> <doc-path> <note...>
 EOF
   exit 2
 }
@@ -41,11 +44,10 @@ if [ "${1:-}" = "--doc" ]; then
   shift
 fi
 
-[ $# -ge 4 ] || usage
-STATUS_FILE=$1
-VERB=$2
-CORR=$3
-shift 3
+[ $# -ge 2 ] || usage
+VERB=$1
+CORR=$2
+shift 2
 
 case "$CORR" in
   corr=*) CORR=${CORR#corr=} ;;
@@ -58,12 +60,25 @@ case "$CORR" in
     ;;
 esac
 
-case "$STATUS_FILE" in
-  '') usage ;;
+HOME_DIR="${FM_HOME:-${FM_ROOT_OVERRIDE:-}}"
+case "$HOME_DIR" in
+  '')
+    echo "error: FM_HOME is required so the helper can resolve the parent channel" >&2
+    exit 1
+    ;;
 esac
-mkdir -p "$(dirname "$STATUS_FILE")" 2>/dev/null || true
-if [ ! -d "$(dirname "$STATUS_FILE")" ]; then
-  echo "error: cannot create parent directory for status file '$STATUS_FILE'" >&2
+STATE_DIR="${FM_STATE_OVERRIDE:-$HOME_DIR/state}"
+
+DESTINATION=
+DEST_RC=0
+DESTINATION=$(fm_parent_channel_destination "$HOME_DIR" "$STATE_DIR") || DEST_RC=$?
+if [ "$DEST_RC" -ne 0 ] || [ -z "$DESTINATION" ]; then
+  echo "error: cannot resolve the parent channel from this home (not a seeded secondmate?)" >&2
+  exit 1
+fi
+mkdir -p "$(dirname "$DESTINATION")" 2>/dev/null || true
+if [ ! -d "$(dirname "$DESTINATION")" ]; then
+  echo "error: cannot create parent directory for status file '$DESTINATION'" >&2
   exit 1
 fi
 
@@ -74,15 +89,15 @@ if [ "$DOC_MODE" = 1 ]; then
   shift
   NOTE=$*
   if [ -n "$NOTE" ]; then
-    printf '%s [%s]: %s (%s via-helper)\n' "$VERB" "$token" "$NOTE" "$DOC_PATH" >> "$STATUS_FILE"
+    printf '%s [%s]: %s (%s via-helper)\n' "$VERB" "$token" "$NOTE" "$DOC_PATH" >> "$DESTINATION"
   else
-    printf '%s [%s]: %s (via-helper)\n' "$VERB" "$token" "$DOC_PATH" >> "$STATUS_FILE"
+    printf '%s [%s]: %s (via-helper)\n' "$VERB" "$token" "$DOC_PATH" >> "$DESTINATION"
   fi
 else
   NOTE=$*
   if [ -n "$NOTE" ]; then
-    printf '%s [%s]: %s (via-helper)\n' "$VERB" "$token" "$NOTE" >> "$STATUS_FILE"
+    printf '%s [%s]: %s (via-helper)\n' "$VERB" "$token" "$NOTE" >> "$DESTINATION"
   else
-    printf '%s [%s]: (via-helper)\n' "$VERB" "$token" >> "$STATUS_FILE"
+    printf '%s [%s]: (via-helper)\n' "$VERB" "$token" >> "$DESTINATION"
   fi
 fi

--- a/bin/fm-secondmate-report.sh
+++ b/bin/fm-secondmate-report.sh
@@ -48,6 +48,11 @@ fi
 VERB=$1
 CORR=$2
 shift 2
+if [ "$DOC_MODE" = 1 ]; then
+  [ $# -ge 1 ] && [ -n "$1" ] || usage
+else
+  [ $# -ge 1 ] && [ -n "$*" ] || usage
+fi
 
 case "$CORR" in
   corr=*) CORR=${CORR#corr=} ;;
@@ -84,7 +89,6 @@ fi
 
 token=$(fm_pending_reply_corr_token "$CORR")
 if [ "$DOC_MODE" = 1 ]; then
-  [ $# -ge 1 ] || usage
   DOC_PATH=$1
   shift
   NOTE=$*
@@ -95,9 +99,5 @@ if [ "$DOC_MODE" = 1 ]; then
   fi
 else
   NOTE=$*
-  if [ -n "$NOTE" ]; then
-    printf '%s [%s]: %s (via-helper)\n' "$VERB" "$token" "$NOTE" >> "$DESTINATION"
-  else
-    printf '%s [%s]: (via-helper)\n' "$VERB" "$token" >> "$DESTINATION"
-  fi
+  printf '%s [%s]: %s (via-helper)\n' "$VERB" "$token" "$NOTE" >> "$DESTINATION"
 fi

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -72,7 +72,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-task-inbox-lib.sh`   | Single owner of durable steering-inbox records, acknowledgement, doorbells, and the delivery-attempt ladder |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and keyed escalation lifecycle |
-| `fm-secondmate-report.sh` | Optional helper to append a correlated parent status or document-pointer report       |
+| `fm-secondmate-report.sh` | Optional helper that resolves the parent channel itself and appends a correlated status or document-pointer report |
 | `fm-extension.mjs`       | Bind, inspect, verify, and strictly invoke trusted external process-event adapter packages |
 | `fm-extension-launch-barrier.mjs` | Publish one exact static core-owned invocation group before package code runs |
 | `fm-extension.sh`        | Expose extension binding commands through the tracked shell and remote-home command boundary |

--- a/docs/secondmate-parent-channel.md
+++ b/docs/secondmate-parent-channel.md
@@ -29,12 +29,16 @@ Every captain-facing outcome that leaves durable evidence in the mate home is pu
 | PR merged | the merge poll or the mate's own merge | `bin/fm-merge-outcome-lib.sh` |
 | Child leaving the home | its final ledger line | `bin/fm-teardown.sh`, which refuses to remove the child while that line is undelivered |
 | Child ended silently | terminal current state with a silent ledger | the existing inactive-outcome scan in `bin/fm-inactive-reconcile.sh` |
-| Answer to a marked request | a correlated line guarded by the pending-reply record | the existing pending-reply recovery and escalation |
+| Answer to a marked request | a correlated line guarded by the pending-reply record | `bin/fm-secondmate-report.sh`, which resolves the parent channel from the mate home; the pending-reply guard repairs a line stranded in the local mate's same-basename status file before recovery or escalation |
 | An outcome that exists only in the mate's reasoning | none | the charter and the `AGENTS.md` carve-outs only |
 
 The ledger delivery reads files only: it calls no harness, no forge, and no current-state reader, so it is identical for every harness and runtime backend.
 Each delivery is keyed with the first eight hexadecimal characters of its receipt fingerprint and appended at most once by exact line, and the ledger path reuses the inactive scan's per-fingerprint receipts, so a replayed poll or restart cannot deliver an event twice while a genuinely new terminal event is delivered again.
 A duplicate line is harmless and a missed one is not, so the mate may still append its own judgement about a delivered outcome, and the parent reads the script's line as the fact and the mate's line as commentary.
+For marked replies, the report helper accepts no caller-selected destination and uses the channel resolver for both local and remote homes; its script header owns the exact invocation contract.
+The pending-reply guard may restate only the correlated line from a local mate's `state/<mate-id>.status` onto the parent channel, which repairs the common parent-home versus mate-home mixup without accepting arbitrary mate-home sightings as acknowledgement.
+Other correlated mate-home status lines remain wrong-home evidence, while a remote home's routed `state/parent-replies.status` is already the parent channel and is not classified as wrong-home.
+A missed-reply escalation includes the complete first sighting path and line number in readable shell-escaped form.
 
 ## What is deliberately not built
 
@@ -50,6 +54,7 @@ A duplicate line is harmless and a missed one is not, so the mate may still appe
 `tests/fm-pr-merge.test.sh` covers the PR-ready line at registration and the merge outcome's upward report.
 `tests/fm-teardown.test.sh` covers teardown delivering a child's final line and refusing when the channel cannot be written.
 `tests/fm-brief.test.sh` pins the charter's channel rule.
+`tests/fm-pending-reply.test.sh` covers helper-selected local routing, remote-channel classification, same-basename restatement before false escalation, readable wrong-home diagnostics, and the rule that arbitrary mate-home sightings never acknowledge a reply.
 
 ## Live verification
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -632,6 +632,10 @@ test_secondmate_marked_request_reporting_contract() {
 
   assert_grep 'include that exact token in your parent status reply' "$brief" \
     "secondmate charter lost correlated parent results"
+  assert_grep 'bin/fm-secondmate-report.sh <verb> <corr_id> <note>' "$brief" \
+    "secondmate charter lost the mechanical helper invocation"
+  assert_grep 'do not pass a status path' "$brief" \
+    "secondmate charter still tells the mate to pass a hand path to the helper"
   assert_grep 'For a terse result, a status line is the whole answer.' "$brief" \
     "secondmate charter lost terse result reporting"
   assert_grep 'append a status line that points to that doc' "$brief" \

--- a/tests/fm-classify-corr-token.test.sh
+++ b/tests/fm-classify-corr-token.test.sh
@@ -509,8 +509,19 @@ test_the_real_writers_produce_tokens_this_library_reads() {
   done
 
   # Writer 2: the optional secondmate report helper, whose bracketed shape must
-  # be read through just as completely. Drive the real script.
-  "$REPORT" "$state/pinned.status" "done" "$corr" "audit clean" \
+  # be read through just as completely. Drive the real script from a seeded
+  # mate home so it resolves the parent channel itself.
+  local parent mate
+  parent="$dir"
+  mate="$dir/mate"
+  mkdir -p "$mate/state"
+  printf 'pinned\n' > "$mate/.fm-secondmate-home"
+  cat > "$mate/.fm-secondmate-parent" <<EOF
+schema=fm-secondmate-parent.v1
+route=local
+parent_home=$parent
+EOF
+  FM_HOME="$mate" "$REPORT" "done" "$corr" "audit clean" \
     || fail "$REPORT failed writing a correlated report"
   helper_line=$(tail -1 "$state/pinned.status")
   verb=$(status_line_verb "$helper_line")
@@ -519,7 +530,7 @@ test_the_real_writers_produce_tokens_this_library_reads() {
   status_is_terminal_verb "$helper_line" \
     || fail "the helper's own line is not seen as a terminal captain verb"
 
-  "$REPORT" --doc "$state/pinned.status" needs-decision "$corr" data/x/report.md "see the report" \
+  FM_HOME="$mate" "$REPORT" --doc needs-decision "$corr" data/x/report.md "see the report" \
     || fail "$REPORT failed writing a correlated doc-pointer report"
   helper_line=$(tail -1 "$state/pinned.status")
   verb=$(status_line_verb "$helper_line")

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -23,7 +23,8 @@
 #      past the turn, so a mirrored reply is never nagged and a real miss still
 #      gets its one repost
 #  13. A same-basename self-home corr= line is restatement-copied onto the parent
-#      channel and resolves, instead of escalating as a false miss
+#      channel and resolves, including after recovery delivery fails, instead of
+#      escalating as a false miss
 #  14. The mechanical helper writes the parent channel from (verb, corr, note)
 #  15. Remote parent-replies.status is not classified as wrong-home
 set -u
@@ -1306,6 +1307,40 @@ test_same_basename_self_home_corr_resolves_on_tick() {
   pass "same-basename self-home corr= is restated onto the parent channel and resolves"
 }
 
+test_same_basename_reply_resolves_after_recovery_failure() {
+  local home state sm_home corr rec parent_status
+  home=$(setup_parent same-basename-after-recovery-failure)
+  state="$home/state"
+  sm_home=$(bind_local_mate "$home" mate)
+  export FM_PENDING_REPLY_NOW=11050
+  export FM_PENDING_REPLY_SEND_HOOK=false
+
+  corr=$(fm_pending_reply_create "$home" "$state" mate "status after failed recovery")
+  fm_pending_reply_mark_delivered "$state" "$corr"
+  fm_pending_reply_mark_turn_completed "$state" "$corr" request
+  if fm_pending_reply_send_recovery "$state" "$corr" 2>/dev/null; then
+    fail "recovery fixture must fail delivery"
+  fi
+  [ "$(phase_of "$state" "$corr")" = recovery_failed ] \
+    || fail "fixture should reach recovery_failed"
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  parent_status=$(fm_pending_reply_get "$rec" parent_status)
+  fm_write_secondmate_meta "$state/mate.meta" "$sm_home"
+  printf 'done [corr=%s]: answer landed after recovery failure\n' "$corr" \
+    > "$sm_home/state/mate.status"
+
+  fm_pending_reply_tick "$state"
+  [ "$(phase_of "$state" "$corr")" = resolved ] \
+    || fail "late same-basename reply must resolve before recovery failure escalation"
+  grep -Fq "corr=$corr" "$parent_status" \
+    || fail "late reply must be restated onto the parent channel"
+  if grep -Fq pending-reply-recovery-delivery "$parent_status"; then
+    fail "authorized late reply must prevent recovery delivery escalation"
+  fi
+  unset FM_PENDING_REPLY_SEND_HOOK
+  pass "same-basename reply resolves at the recovery failure boundary"
+}
+
 test_child_status_wrong_home_is_not_copied() {
   local home state sm_home corr rec hook_log
   home=$(setup_parent child-wrong-home)
@@ -1450,6 +1485,7 @@ test_failed_send_discards_undelivered_expectation
 test_remote_repost_waits_for_the_reply_channel
 test_mirrored_remote_reply_never_triggers_a_repost
 test_same_basename_self_home_corr_resolves_on_tick
+test_same_basename_reply_resolves_after_recovery_failure
 test_child_status_wrong_home_is_not_copied
 test_mechanical_helper_writes_parent_channel
 test_remote_parent_replies_is_not_wrong_home

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -1419,9 +1419,9 @@ test_mechanical_helper_writes_parent_channel() {
     fail "an empty helper report must not resolve an expectation"
   fi
   rc=0
-  FM_HOME= FM_ROOT_OVERRIDE="$sm_home" \
-    "$REPORT" "done" "$empty_corr" "must require FM_HOME" 2>/dev/null || rc=$?
-  [ "$rc" -ne 0 ] || fail "helper must not treat FM_ROOT_OVERRIDE as a mate home"
+  env -u FM_HOME "$REPORT" "done" "$empty_corr" "must require FM_HOME" \
+    2>/dev/null || rc=$?
+  [ "$rc" -ne 0 ] || fail "helper must require FM_HOME"
   rc=0
   FM_HOME="$home" "$REPORT" "done" "$corr" "from a main home" 2>/dev/null || rc=$?
   [ "$rc" -ne 0 ] || fail "helper must refuse a main home that has no parent channel"

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -1347,7 +1347,8 @@ test_child_status_wrong_home_is_not_copied() {
   local home state sm_home corr rec hook_log
   home=$(setup_parent child-wrong-home)
   state="$home/state"
-  sm_home=$(bind_local_mate "$home" mate)
+  sm_home="$TMP_ROOT/team,west-home-$RANDOM"
+  mkdir -p "$sm_home/state"
   hook_log="$TMP_ROOT/child-wrong-home.log"
   : > "$hook_log"
   # Invoked indirectly through FM_PENDING_REPLY_SEND_HOOK.
@@ -1372,8 +1373,10 @@ test_child_status_wrong_home_is_not_copied() {
     || fail "resolved_epoch must stay empty for a child-file sighting"
   grep -Fq pending-reply-missed "$state/mate.status" \
     || fail "a child-file miss should still escalate"
-  grep -Fq "token seen in $sm_home/state/child.status:" "$state/mate.status" \
-    || fail "missed payload must name the readable child-file path"$'\n'"$(cat "$state/mate.status")"
+  grep -Fq "token seen in $sm_home/state/child.status:1;" "$state/mate.status" \
+    || fail "missed payload must preserve the complete readable child-file path"$'\n'"$(cat "$state/mate.status")"
+  [ "$(fm_pending_reply_get "$rec" wrong_home_first_sighting)" = "$sm_home/state/child.status:1" ] \
+    || fail "first wrong-home sighting must preserve commas in its path"
   if grep -Fq "corr=$corr" "$state/mate.status"; then
     fail "a child status file must not be restatement-copied onto the parent channel"
   fi
@@ -1409,6 +1412,10 @@ test_mechanical_helper_writes_parent_channel() {
   if fm_pending_reply_try_resolve "$state" "$empty_corr"; then
     fail "an empty helper report must not resolve an expectation"
   fi
+  rc=0
+  FM_HOME= FM_ROOT_OVERRIDE="$sm_home" \
+    "$REPORT" "done" "$empty_corr" "must require FM_HOME" 2>/dev/null || rc=$?
+  [ "$rc" -ne 0 ] || fail "helper must not treat FM_ROOT_OVERRIDE as a mate home"
   rc=0
   FM_HOME="$home" "$REPORT" "done" "$corr" "from a main home" 2>/dev/null || rc=$?
   [ "$rc" -ne 0 ] || fail "helper must refuse a main home that has no parent channel"

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -22,6 +22,10 @@
 #  12. A remote mate's repost waits for its asynchronous reply mirror to be read
 #      past the turn, so a mirrored reply is never nagged and a real miss still
 #      gets its one repost
+#  13. A same-basename self-home corr= line is restatement-copied onto the parent
+#      channel and resolves, instead of escalating as a false miss
+#  14. The mechanical helper writes the parent channel from (verb, corr, note)
+#  15. Remote parent-replies.status is not classified as wrong-home
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -82,6 +86,20 @@ setup_parent() {  # <name> -> home
   local home="$TMP_ROOT/$1-$RANDOM"
   mkdir -p "$home/state"
   printf '%s\n' "$home"
+}
+
+# Seed a local secondmate home bound to <parent> with identity <id>.
+bind_local_mate() {  # <parent-home> <id> -> mate-home
+  local parent=$1 id=$2 mate
+  mate="$TMP_ROOT/${id}-home-$RANDOM"
+  mkdir -p "$mate/state"
+  printf '%s\n' "$id" > "$mate/.fm-secondmate-home"
+  cat > "$mate/.fm-secondmate-parent" <<EOF
+schema=fm-secondmate-parent.v1
+route=local
+parent_home=$parent
+EOF
+  printf '%s\n' "$mate"
 }
 
 run_send() {
@@ -688,7 +706,7 @@ test_delivery_confirmation_serializes_with_reconciliation() {
     release="$home/mark-delivered.release"
     fm_pending_reply_mark_delivered() {
       local pending_state=$1 pending_corr=$2 epoch=$3 pending_rec phase
-      printf '%s\n' "$BASHPID" >> "$calls"
+      printf '%s\n' "${BASHPID:-$$}" >> "$calls"
       : > "$entered"
       while [ ! -e "$release" ]; do /bin/sleep 0.01; done
       pending_rec=$(fm_pending_reply_path "$pending_state" "$pending_corr")
@@ -876,14 +894,19 @@ test_document_pointer_resolves() {
 }
 
 test_helper_report_resolves() {
-  local home state corr
+  local home state corr sm_home
   home=$(setup_parent helper)
   state="$home/state"
+  sm_home=$(bind_local_mate "$home" hibit)
   export FM_PENDING_REPLY_NOW=9100
   corr=$(fm_pending_reply_create "$home" "$state" "hibit" "quick answer")
   fm_pending_reply_mark_delivered "$state" "$corr"
-  "$REPORT" "$state/hibit.status" "done" "$corr" "all good" \
+  FM_HOME="$sm_home" "$REPORT" "done" "$corr" "all good" \
     || fail "helper report failed"
+  [ -f "$state/hibit.status" ] || fail "helper must write the parent channel"
+  if grep -Fq "corr=$corr" "$sm_home/state/hibit.status" 2>/dev/null; then
+    fail "helper must not write the mate home's own status file"
+  fi
   fm_pending_reply_try_resolve "$state" "$corr" || fail "helper report should resolve"
   [ "$(fm_pending_reply_get "$(fm_pending_reply_path "$state" "$corr")" resolved_via)" = helper ] \
     || fail "resolved_via should be helper"
@@ -1014,7 +1037,7 @@ test_tick_skips_terminal_and_reuses_target_observation() {
     rec=$(fm_pending_reply_path "$state" "$escalated")
     fm_pending_reply_set "$rec" phase escalated || fail "escalated fixture should transition"
     mkdir -p "$home/escalated/state"
-    printf 'done [corr=%s]: wrong home\n' "$escalated" > "$home/escalated/state/escalated.status"
+    printf 'done [corr=%s]: wrong home\n' "$escalated" > "$home/escalated/state/child.status"
     fm_write_secondmate_meta "$state/hibit.meta" "$home/hibit" "sess:fm-hibit"
     fm_write_secondmate_meta "$state/resolved.meta" "$home/resolved" "sess:fm-resolved"
     fm_write_secondmate_meta "$state/escalated.meta" "$home/escalated" "sess:fm-escalated"
@@ -1108,6 +1131,8 @@ test_tick_end_to_end_missed_then_escalate() {
   mkdir -p "$sm_home/state"
   hook_log="$TMP_ROOT/tick-hook.log"
   : > "$hook_log"
+  # Invoked indirectly through FM_PENDING_REPLY_SEND_HOOK.
+  # shellcheck disable=SC2329
   recovery_hook() { printf 'recovered\n' >> "$hook_log"; }
   export -f recovery_hook
   # Reset hook and clock fixtures after isolated subshell tests.
@@ -1230,6 +1255,146 @@ test_mirrored_remote_reply_never_triggers_a_repost() {
   pass "a mirrored correlated remote reply resolves without any repost"
 }
 
+test_same_basename_self_home_corr_resolves_on_tick() {
+  local home state sm_home corr rec parent_status hook_log
+  home=$(setup_parent same-basename-repair)
+  state="$home/state"
+  sm_home=$(bind_local_mate "$home" mate)
+  hook_log="$TMP_ROOT/same-basename-repair.log"
+  : > "$hook_log"
+  # Invoked indirectly through FM_PENDING_REPLY_SEND_HOOK.
+  # shellcheck disable=SC2329
+  recovery_hook() { printf 'recovered\n' >> "$hook_log"; }
+  export -f recovery_hook
+  export FM_PENDING_REPLY_SEND_HOOK=recovery_hook
+  export FM_PENDING_REPLY_NOW=11000
+
+  corr=$(fm_pending_reply_create "$home" "$state" mate "status of the audit")
+  fm_pending_reply_mark_delivered "$state" "$corr"
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  parent_status=$(fm_pending_reply_get "$rec" parent_status)
+  [ "$parent_status" = "$state/mate.status" ] \
+    || fail "parent_status should be the parent file, got $parent_status"
+  case "$parent_status" in
+    "$sm_home"/*) fail "parent_status must not live under the mate home" ;;
+  esac
+  printf 'done [corr=%s]: stranded in self-home\n' "$corr" > "$sm_home/state/mate.status"
+  [ ! -e "$parent_status" ] || fail "parent channel must start empty"
+  if fm_pending_reply_try_resolve "$state" "$corr"; then
+    fail "a mate-home sighting must not resolve through the parent path"
+  fi
+
+  fm_pending_reply_tick_one "$state" "$corr" busy "$sm_home"
+  fm_pending_reply_tick_one "$state" "$corr" idle "$sm_home"
+  [ "$(phase_of "$state" "$corr")" = resolved ] \
+    || fail "same-basename self-home corr must resolve, got $(phase_of "$state" "$corr")"
+  [ -n "$(fm_pending_reply_get "$rec" resolved_epoch)" ] \
+    || fail "resolved_epoch must be set after the restatement copy"
+  grep -Fq "corr=$corr" "$parent_status" \
+    || fail "parent channel must receive the restated corr= line"
+  if grep -Fq pending-reply-missed "$parent_status"; then
+    fail "same-basename self-home corr must not escalate as pending-reply-missed"
+  fi
+  [ ! -s "$hook_log" ] || fail "a restated same-basename reply must not trigger recovery"
+  [ "$(fm_pending_reply_get "$rec" wrong_home_hits)" = 1 ] \
+    || fail "the stranded file should still count as one wrong-home sighting"
+  case "$(fm_pending_reply_get "$rec" wrong_home_sightings)" in
+    "$sm_home/state/mate.status:"*) : ;;
+    *) fail "wrong_home_sightings must name the readable mate-home path and line" ;;
+  esac
+  unset FM_PENDING_REPLY_SEND_HOOK
+  pass "same-basename self-home corr= is restated onto the parent channel and resolves"
+}
+
+test_child_status_wrong_home_is_not_copied() {
+  local home state sm_home corr rec hook_log
+  home=$(setup_parent child-wrong-home)
+  state="$home/state"
+  sm_home=$(bind_local_mate "$home" mate)
+  hook_log="$TMP_ROOT/child-wrong-home.log"
+  : > "$hook_log"
+  # Invoked indirectly through FM_PENDING_REPLY_SEND_HOOK.
+  # shellcheck disable=SC2329
+  recovery_hook() { printf 'recovered\n' >> "$hook_log"; }
+  export -f recovery_hook
+  export FM_PENDING_REPLY_SEND_HOOK=recovery_hook
+  export FM_PENDING_REPLY_NOW=11100
+
+  corr=$(fm_pending_reply_create "$home" "$state" mate "status of the audit")
+  fm_pending_reply_mark_delivered "$state" "$corr"
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  printf 'done [corr=%s]: leaked into a child file\n' "$corr" > "$sm_home/state/child.status"
+
+  fm_pending_reply_tick_one "$state" "$corr" busy "$sm_home"
+  fm_pending_reply_tick_one "$state" "$corr" idle "$sm_home"
+  fm_pending_reply_tick_one "$state" "$corr" busy "$sm_home"
+  fm_pending_reply_tick_one "$state" "$corr" idle "$sm_home"
+  [ "$(phase_of "$state" "$corr")" = escalated ] \
+    || fail "a child-file sighting must not acknowledge, got $(phase_of "$state" "$corr")"
+  [ -z "$(fm_pending_reply_get "$rec" resolved_epoch)" ] \
+    || fail "resolved_epoch must stay empty for a child-file sighting"
+  grep -Fq pending-reply-missed "$state/mate.status" \
+    || fail "a child-file miss should still escalate"
+  grep -Fq "token seen in $sm_home/state/child.status:" "$state/mate.status" \
+    || fail "missed payload must name the readable child-file path"$'\n'"$(cat "$state/mate.status")"
+  if grep -Fq "corr=$corr" "$state/mate.status"; then
+    fail "a child status file must not be restatement-copied onto the parent channel"
+  fi
+  [ "$(fm_pending_reply_get "$rec" wrong_home_hits)" = 1 ] \
+    || fail "the child file should count as one wrong-home sighting"
+  unset FM_PENDING_REPLY_SEND_HOOK
+  pass "a child-file mate-home sighting is not copied and still escalates"
+}
+
+test_mechanical_helper_writes_parent_channel() {
+  local home state sm_home corr rc
+  home=$(setup_parent mechanical-helper)
+  state="$home/state"
+  sm_home=$(bind_local_mate "$home" mate)
+  export FM_PENDING_REPLY_NOW=11200
+  corr=$(fm_pending_reply_create "$home" "$state" mate "status of the audit")
+  fm_pending_reply_mark_delivered "$state" "$corr"
+  FM_HOME="$sm_home" "$REPORT" "done" "$corr" "audit clean" \
+    || fail "mechanical helper should succeed from a seeded mate home"
+  grep -Fq "corr=$corr" "$state/mate.status" \
+    || fail "mechanical helper must append to the parent channel"
+  if [ -e "$sm_home/state/mate.status" ]; then
+    fail "mechanical helper must not write the mate home's same-basename status file"
+  fi
+  fm_pending_reply_try_resolve "$state" "$corr" \
+    || fail "a mechanical helper line on the parent channel must resolve"
+  [ "$(phase_of "$state" "$corr")" = resolved ] || fail "phase should be resolved"
+  rc=0
+  FM_HOME="$home" "$REPORT" "done" "$corr" "from a main home" 2>/dev/null || rc=$?
+  [ "$rc" -ne 0 ] || fail "helper must refuse a main home that has no parent channel"
+  pass "mechanical helper writes the parent channel from verb, corr, and note"
+}
+
+test_remote_parent_replies_is_not_wrong_home() {
+  local home state sm_home corr rec hits
+  home=$(setup_parent remote-parent-replies)
+  state="$home/state"
+  sm_home="$TMP_ROOT/remote-replies-home-$RANDOM"
+  mkdir -p "$sm_home/state"
+  export FM_PENDING_REPLY_NOW=11300
+  corr=$(fm_pending_reply_create "$home" "$state" mate "did the build go green")
+  fm_pending_reply_mark_delivered "$state" "$corr"
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  printf 'done [corr=%s]: mirrored answer\n' "$corr" > "$sm_home/state/parent-replies.status"
+  fm_pending_reply_detect_wrong_home "$state" "$corr" "$sm_home" \
+    || fail "wrong-home detect should succeed over a remote channel file"
+  hits=$(fm_pending_reply_get "$rec" wrong_home_hits)
+  [ "$hits" = 0 ] || fail "parent-replies.status must not increment wrong_home_hits, got $hits"
+  printf 'done [corr=%s]: leaked into a child file\n' "$corr" > "$sm_home/state/child.status"
+  fm_pending_reply_detect_wrong_home "$state" "$corr" "$sm_home" \
+    || fail "wrong-home detect should succeed after a child-file leak"
+  hits=$(fm_pending_reply_get "$rec" wrong_home_hits)
+  [ "$hits" = 1 ] || fail "a sibling child status file should still count once, got $hits"
+  [ "$(phase_of "$state" "$corr")" = awaiting_report ] \
+    || fail "detect must not acknowledge a remote-channel or child-file sighting"
+  pass "remote parent-replies.status is not classified as wrong-home"
+}
+
 test_failed_send_discards_undelivered_expectation() {
   local home state corr
   home=$(setup_parent discard)
@@ -1284,5 +1449,9 @@ test_tick_end_to_end_missed_then_escalate
 test_failed_send_discards_undelivered_expectation
 test_remote_repost_waits_for_the_reply_channel
 test_mirrored_remote_reply_never_triggers_a_repost
+test_same_basename_self_home_corr_resolves_on_tick
+test_child_status_wrong_home_is_not_copied
+test_mechanical_helper_writes_parent_channel
+test_remote_parent_replies_is_not_wrong_home
 
 printf 'ok - all pending-reply tests passed\n'

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -1301,10 +1301,10 @@ test_same_basename_self_home_corr_resolves_on_tick() {
   [ ! -s "$hook_log" ] || fail "a restated same-basename reply must not trigger recovery"
   [ "$(fm_pending_reply_get "$rec" wrong_home_hits)" = 1 ] \
     || fail "the stranded file should still count as one wrong-home sighting"
-  case "$(fm_pending_reply_get "$rec" wrong_home_sightings)" in
-    "$sm_home/state/mate.status:"*) : ;;
-    *) fail "wrong_home_sightings must name the readable mate-home path and line" ;;
-  esac
+  [ "$(fm_pending_reply_sighting_display \
+    "$(fm_pending_reply_get "$rec" wrong_home_first_sighting)")" = \
+    "$sm_home/state/mate.status:1" ] \
+    || fail "first wrong-home sighting must display the readable mate-home path and line"
   unset FM_PENDING_REPLY_SEND_HOOK
   pass "same-basename self-home corr= is restated onto the parent channel and resolves"
 }
@@ -1344,7 +1344,7 @@ test_same_basename_reply_resolves_after_recovery_failure() {
 }
 
 test_child_status_wrong_home_is_not_copied() {
-  local home state sm_home corr rec hook_log
+  local home state sm_home corr rec hook_log status_file expected_display stored_first
   home=$(setup_parent child-wrong-home)
   state="$home/state"
   sm_home="$TMP_ROOT/team,west-home-$RANDOM"
@@ -1361,7 +1361,8 @@ test_child_status_wrong_home_is_not_copied() {
   corr=$(fm_pending_reply_create "$home" "$state" mate "status of the audit")
   fm_pending_reply_mark_delivered "$state" "$corr"
   rec=$(fm_pending_reply_path "$state" "$corr")
-  printf 'done [corr=%s]: leaked into a child file\n' "$corr" > "$sm_home/state/child.status"
+  status_file="$sm_home/state/"$'child\nphase=resolved\nteam,west.status'
+  printf 'done [corr=%s]: leaked into a child file\n' "$corr" > "$status_file"
 
   fm_pending_reply_tick_one "$state" "$corr" busy "$sm_home"
   fm_pending_reply_tick_one "$state" "$corr" idle "$sm_home"
@@ -1373,10 +1374,15 @@ test_child_status_wrong_home_is_not_copied() {
     || fail "resolved_epoch must stay empty for a child-file sighting"
   grep -Fq pending-reply-missed "$state/mate.status" \
     || fail "a child-file miss should still escalate"
-  grep -Fq "token seen in $sm_home/state/child.status:1;" "$state/mate.status" \
+  printf -v expected_display '%q' "$status_file"
+  expected_display="$expected_display:1"
+  grep -Fq "token seen in $expected_display;" "$state/mate.status" \
     || fail "missed payload must preserve the complete readable child-file path"$'\n'"$(cat "$state/mate.status")"
-  [ "$(fm_pending_reply_get "$rec" wrong_home_first_sighting)" = "$sm_home/state/child.status:1" ] \
-    || fail "first wrong-home sighting must preserve commas in its path"
+  stored_first=$(fm_pending_reply_get "$rec" wrong_home_first_sighting)
+  [ "$(fm_pending_reply_sighting_display "$stored_first")" = "$expected_display" ] \
+    || fail "encoded wrong-home sighting must reversibly preserve the crafted path"
+  [ "$(grep -c '^phase=' "$rec")" = 1 ] \
+    || fail "crafted filename must not inject a phase field into the pending record"
   if grep -Fq "corr=$corr" "$state/mate.status"; then
     fail "a child status file must not be restatement-copied onto the parent channel"
   fi
@@ -1454,7 +1460,7 @@ EOF
 }
 
 test_local_parent_replies_is_wrong_home_evidence() {
-  local home state sm_home corr rec hits sightings
+  local home state sm_home corr rec hits first
   home=$(setup_parent local-parent-replies)
   state="$home/state"
   sm_home=$(bind_local_mate "$home" mate)
@@ -1469,11 +1475,10 @@ test_local_parent_replies_is_wrong_home_evidence() {
     || fail "wrong-home detect should scan a local parent-replies alias"
   hits=$(fm_pending_reply_get "$rec" wrong_home_hits)
   [ "$hits" = 1 ] || fail "local parent-replies.status should count once, got $hits"
-  sightings=$(fm_pending_reply_get "$rec" wrong_home_sightings)
-  case "$sightings" in
-    "$sm_home/state/parent-replies.status:"*) : ;;
-    *) fail "local parent-replies sighting must retain its readable path" ;;
-  esac
+  first=$(fm_pending_reply_get "$rec" wrong_home_first_sighting)
+  [ "$(fm_pending_reply_sighting_display "$first")" = \
+    "$sm_home/state/parent-replies.status:1" ] \
+    || fail "local parent-replies sighting must retain its readable path"
   [ "$(phase_of "$state" "$corr")" = awaiting_report ] \
     || fail "local wrong-home evidence must not acknowledge the reply"
   pass "local parent-replies.status remains wrong-home evidence"

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -1287,6 +1287,8 @@ test_same_basename_self_home_corr_resolves_on_tick() {
 
   fm_pending_reply_tick_one "$state" "$corr" busy "$sm_home"
   fm_pending_reply_tick_one "$state" "$corr" idle "$sm_home"
+  fm_pending_reply_tick_one "$state" "$corr" busy "$sm_home"
+  fm_pending_reply_tick_one "$state" "$corr" idle "$sm_home"
   [ "$(phase_of "$state" "$corr")" = resolved ] \
     || fail "same-basename self-home corr must resolve, got $(phase_of "$state" "$corr")"
   [ -n "$(fm_pending_reply_get "$rec" resolved_epoch)" ] \
@@ -1382,7 +1384,7 @@ test_child_status_wrong_home_is_not_copied() {
 }
 
 test_mechanical_helper_writes_parent_channel() {
-  local home state sm_home corr rc
+  local home state sm_home corr empty_corr rc
   home=$(setup_parent mechanical-helper)
   state="$home/state"
   sm_home=$(bind_local_mate "$home" mate)
@@ -1399,6 +1401,14 @@ test_mechanical_helper_writes_parent_channel() {
   fm_pending_reply_try_resolve "$state" "$corr" \
     || fail "a mechanical helper line on the parent channel must resolve"
   [ "$(phase_of "$state" "$corr")" = resolved ] || fail "phase should be resolved"
+  empty_corr=$(fm_pending_reply_create "$home" "$state" mate "answer must not be empty")
+  fm_pending_reply_mark_delivered "$state" "$empty_corr"
+  rc=0
+  FM_HOME="$sm_home" "$REPORT" "done" "$empty_corr" "" 2>/dev/null || rc=$?
+  [ "$rc" -ne 0 ] || fail "helper must reject an empty status note"
+  if fm_pending_reply_try_resolve "$state" "$empty_corr"; then
+    fail "an empty helper report must not resolve an expectation"
+  fi
   rc=0
   FM_HOME="$home" "$REPORT" "done" "$corr" "from a main home" 2>/dev/null || rc=$?
   [ "$rc" -ne 0 ] || fail "helper must refuse a main home that has no parent channel"
@@ -1411,6 +1421,12 @@ test_remote_parent_replies_is_not_wrong_home() {
   state="$home/state"
   sm_home="$TMP_ROOT/remote-replies-home-$RANDOM"
   mkdir -p "$sm_home/state"
+  printf '%s\n' mate > "$sm_home/.fm-secondmate-home"
+  cat > "$sm_home/.fm-secondmate-parent" <<EOF
+schema=fm-secondmate-parent.v1
+route=remote
+parent_host=remote.example
+EOF
   export FM_PENDING_REPLY_NOW=11300
   corr=$(fm_pending_reply_create "$home" "$state" mate "did the build go green")
   fm_pending_reply_mark_delivered "$state" "$corr"
@@ -1428,6 +1444,32 @@ test_remote_parent_replies_is_not_wrong_home() {
   [ "$(phase_of "$state" "$corr")" = awaiting_report ] \
     || fail "detect must not acknowledge a remote-channel or child-file sighting"
   pass "remote parent-replies.status is not classified as wrong-home"
+}
+
+test_local_parent_replies_is_wrong_home_evidence() {
+  local home state sm_home corr rec hits sightings
+  home=$(setup_parent local-parent-replies)
+  state="$home/state"
+  sm_home=$(bind_local_mate "$home" mate)
+  export FM_PENDING_REPLY_NOW=11350
+  corr=$(fm_pending_reply_create "$home" "$state" mate "did the build go green")
+  fm_pending_reply_mark_delivered "$state" "$corr"
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  printf 'done [corr=%s]: written to a local alias\n' "$corr" \
+    > "$sm_home/state/parent-replies.status"
+
+  fm_pending_reply_detect_wrong_home "$state" "$corr" "$sm_home" \
+    || fail "wrong-home detect should scan a local parent-replies alias"
+  hits=$(fm_pending_reply_get "$rec" wrong_home_hits)
+  [ "$hits" = 1 ] || fail "local parent-replies.status should count once, got $hits"
+  sightings=$(fm_pending_reply_get "$rec" wrong_home_sightings)
+  case "$sightings" in
+    "$sm_home/state/parent-replies.status:"*) : ;;
+    *) fail "local parent-replies sighting must retain its readable path" ;;
+  esac
+  [ "$(phase_of "$state" "$corr")" = awaiting_report ] \
+    || fail "local wrong-home evidence must not acknowledge the reply"
+  pass "local parent-replies.status remains wrong-home evidence"
 }
 
 test_failed_send_discards_undelivered_expectation() {
@@ -1489,5 +1531,6 @@ test_same_basename_reply_resolves_after_recovery_failure
 test_child_status_wrong_home_is_not_copied
 test_mechanical_helper_writes_parent_channel
 test_remote_parent_replies_is_not_wrong_home
+test_local_parent_replies_is_wrong_home_evidence
 
 printf 'ok - all pending-reply tests passed\n'


### PR DESCRIPTION
## Intent

Fix the false "missed reply" escalations firstmate raises against a healthy secondmate. A user hit this: over one day, 51 pending-reply-missed decisions piled up against a live, responsive mate that had actually answered - because the mate's correlated corr= reply line was written to the mate's OWN home status file instead of the parent channel the resolver scans, so the reply never matched and each record escalated as missed and never resolved.

The captain reviewed the diagnosis and chose to ship the full fix, and requires a repro-first workflow. Captain's exact words: "for the finding 1 fix, do B then. make sure we create an e2e repro that produces the problem, then fix it, and then confirm the repro is gone."

So: build an end-to-end reproduction that actually produces a false pending-reply-missed escalation FIRST; then apply the fix; then confirm the same repro no longer produces the problem. The repro becomes the regression test.

Option B: make the mate's report helper pick the parent channel itself so the mate cannot hand it the wrong file; stop treating the remote parent-replies file as "wrote to the wrong home"; put a readable file path on the missed-reply notice instead of a checksum; and when the answer landed in the mate's own copy of the same status filename as the parent channel, copy that one line onto the parent channel so it can match.

The fix must stop the false misses without weakening the standing safety property that a sighting under the mate home is not by itself acknowledgement.

## What Changed
- Make the secondmate report helper resolve and write to the parent channel instead of accepting a caller-provided status path.
- Restate correlated replies stranded in the mate’s same-basename status file before escalation, while preserving the rule that arbitrary mate-home sightings are not acknowledgements.
- Exclude remote parent reply channels from wrong-home detection and include readable source paths in missed-reply notices, with updated documentation and regression coverage.

## Risk Assessment

✅ Low: The change now durably repairs same-basename wrong-home replies across normal and recovery escalation paths while preserving arbitrary mate-home sightings as non-acknowledgements, with bounded supporting changes and behavior-focused regression coverage.

## Testing

The successful changed-file baseline was supplemented with the focused pending-reply suite and end-to-end CLI checks: the historical implementation reproduced one recovery and a false pending-reply-missed escalation, while the target restated the reply onto the parent channel and resolved without recovery; the report helper also wrote only to the parent channel. All checks passed and the worktree was left clean.

<details>
<summary>Evidence: Historical repro versus fixed end-to-end behavior</summary>

Source: [Historical repro versus fixed end-to-end behavior](https://github.com/kunchenguid/firstmate/blob/38963ed55efc8c8019943e9ae3c0dfefc7e0130f/.no-mistakes/evidence/fm/fm-pending-reply-wrong-home-fix-r1/pending-reply-e2e-transcript.txt)

```text
=== Historical implementation (base commit) ===
implementation=base
final_phase=escalated
recovery_sends=1
pending_reply_missed=1
parent_channel:
  blocked [key=pending-reply-4a6e07efd7c46ded]: pending-reply-missed: task=mate pending-reply-id=4a6e07efd7c46ded request=status of healthy mate
=== Fixed implementation (target commit) ===
implementation=fixed
final_phase=resolved
recovery_sends=0
pending_reply_missed=0
parent_channel:
  done [corr=0963009433cf87e8]: healthy mate answered
```
</details>
<details>
<summary>Evidence: Reusable end-to-end reproduction script</summary>

Source: [Reusable end-to-end reproduction script](https://github.com/kunchenguid/firstmate/blob/38963ed55efc8c8019943e9ae3c0dfefc7e0130f/.no-mistakes/evidence/fm/fm-pending-reply-wrong-home-fix-r1/pending-reply-e2e-repro.sh)

```text
#!/usr/bin/env bash
set -eu
LIB=$1
LABEL=$2
ROOT=$3
SCRATCH="$ROOT/.pending-reply-e2e-$LABEL"
rm -rf "$SCRATCH"
mkdir -p "$SCRATCH/parent/state" "$SCRATCH/mate/state"
# shellcheck disable=SC1090
. "$LIB"
export FM_PENDING_REPLY_GRACE_SECS=0 FM_PENDING_REPLY_NOW=17000
STATE="$SCRATCH/parent/state"
MATE="$SCRATCH/mate"
RECOVERY_LOG="$SCRATCH/recovery.log"
: > "$RECOVERY_LOG"
recovery_hook() { printf 'recovery sent\n' >> "$RECOVERY_LOG"; }
export FM_PENDING_REPLY_SEND_HOOK=recovery_hook
corr=$(fm_pending_reply_create "$SCRATCH/parent" "$STATE" mate "status of healthy mate")
fm_pending_reply_mark_delivered "$STATE" "$corr"
cat > "$STATE/mate.meta" <<EOF
window=session:fm-mate
endpoint_task_id=mate
worktree=$MATE
project=$MATE
harness=echo
kind=secondmate
mode=secondmate
home=$MATE
projects=alpha
EOF
printf 'done [corr=%s]: healthy mate answered\n' "$corr" > "$MATE/state/mate.status"
# Exercise both original and recovery busy->idle turns: the historical
# implementation reaches pending-reply-missed; the fixed one repairs first.
fm_pending_reply_tick_one "$STATE" "$corr" busy "$MATE"
fm_pending_reply_tick_one "$STATE" "$corr" idle "$MATE"
fm_pending_reply_tick_one "$STATE" "$corr" busy "$MATE"
fm_pending_reply_tick_one "$STATE" "$corr" idle "$MATE"
rec=$(fm_pending_reply_path "$STATE" "$corr")
printf 'implementation=%s\n' "$LABEL"
printf 'final_phase=%s\n' "$(fm_pending_reply_get "$rec" phase)"
printf 'recovery_sends=%s\n' "$(wc -l < "$RECOVERY_LOG" | tr -d ' ')"
printf 'pending_reply_missed=%s\n' "$(grep -c 'pending-reply-missed' "$STATE/mate.status" 2>/dev/null || true)"
printf 'parent_channel:\n'
if [ -f "$STATE/mate.status" ]; then sed 's/^/  /' "$STATE/mate.status"; else printf '  <empty>\n'; fi
rm -rf "$SCRATCH"
```
</details>
<details>
<summary>Evidence: Secondmate report helper parent-channel CLI transcript</summary>

Source: [Secondmate report helper parent-channel CLI transcript](https://github.com/kunchenguid/firstmate/blob/38963ed55efc8c8019943e9ae3c0dfefc7e0130f/.no-mistakes/evidence/fm/fm-pending-reply-wrong-home-fix-r1/secondmate-report-cli-transcript.txt)

```text
$ FM_HOME=<mate-home> bin/fm-secondmate-report.sh done 0123456789abcdef "audit clean"
exit=0
parent_channel=done [corr=0123456789abcdef]: audit clean (via-helper)
mate_self_status=absent
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"340d5cf31bdd38a74f83d98e28dede1ae84f9003","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (4) ✅</summary>

- 🚨 `tests/fm-pending-reply.test.sh:1287` - The required repro does not actually produce the reported `pending-reply-missed` escalation on the pre-fix code. It drives only the original busy→idle turn; without the fix this reaches `recovery_sent`, not the second completed recovery turn that escalates. This contradicts the explicit criterion to “create an e2e repro that produces the problem” first. Extend this same-basename scenario through the recovery busy→idle transition so the old implementation emits `pending-reply-missed` while the fixed implementation resolves.
- 🚨 `bin/fm-pending-reply-lib.sh:1298` - Same-basename repair remains bypassed for `recovery_failed` and `recovery_unknown`. If no self-home answer exists during the first scan, recovery delivery fails or becomes unknown, and the answer then lands in `state/&lt;task_id&gt;.status`, the next watcher pass calls `tick_one` without `sm_home` and this branch escalates immediately. Thus an authorized answer can still produce a false recovery-delivery escalation. Resolve metadata and perform the same-basename copy before every delivered-record escalation boundary.
- ⚠️ `bin/fm-pending-reply-lib.sh:1201` - The new exclusion skips every file named `parent-replies.status`, although the intent requires excluding the remote parent-replies channel only. During normal local-mate scanning, a mate that mistakenly writes its correlated answer to its own `state/parent-replies.status` now loses even the wrong-home evidence and readable-path diagnostic. Narrow this exclusion to a home proven to use the remote parent route; the unconditional basename alias exceeds the required behavior.
- ⚠️ `bin/fm-secondmate-report.sh:47` - The changed argument check introduces an unrequested no-note acceptance path: `fm-secondmate-report.sh done &lt;corr&gt;` writes a terminal correlated line and resolves the expectation without an answer. The stated helper contract is `(verb, corr, note)`, and the previous interface required a note argument. Remove this fallback by requiring a non-empty note in status mode; document mode can continue using its required document path.

🔧 Fix: Resolve late replies before recovery escalation
3 issues (1 error, 2 warnings) still open:

- 🚨 `tests/fm-pending-reply.test.sh:1288` - The required repro still does not actually produce `pending-reply-missed` on the pre-fix implementation. It exercises only the original busy→idle turn, which previously entered `recovery_sent`; the separate recovery-failure test produces a recovery-delivery escalation instead. This contradicts the required “e2e repro that produces the problem” workflow. Extend the same-basename scenario through the recovery busy→idle turn and demonstrate that the old implementation emits `pending-reply-missed` while the fixed implementation resolves.
- ⚠️ `bin/fm-pending-reply-lib.sh:1213` - The new exclusion skips every file named `parent-replies.status`, while the intent requires excluding the remote parent-replies channel specifically. A local mate that mistakenly writes its correlated answer there now loses wrong-home evidence and the readable-path diagnostic. The accompanying test uses an unbound arbitrary directory rather than proving a remote route. Narrow the exclusion to a home proven to use the remote parent route.
- ⚠️ `bin/fm-secondmate-report.sh:47` - The changed argument check adds an unrequested no-note mode: `fm-secondmate-report.sh done &lt;corr&gt;` writes a terminal correlated line and resolves the expectation without an answer. The required helper contract is `(verb, corr, note)`. Require a non-empty note in status mode; document mode may continue using its required document path.

🔧 Fix: Tighten reply routing and regression coverage
2 warnings still open:

- ⚠️ `bin/fm-pending-reply-lib.sh:1175` - The required readable missed-reply path is truncated when a valid mate-home path contains a comma. For example, a sighting under `/tmp/team,west/state/child.status` is stored verbatim in the comma-separated field, then `${sightings%%,*}` reports only `/tmp/team`. This contradicts the requirement to “put a readable file path on the missed-reply notice instead of a checksum.” Use an unambiguous representation that preserves the complete first path.
- ⚠️ `bin/fm-secondmate-report.sh:68` - The change introduces an unnecessary `FM_ROOT_OVERRIDE` fallback for `FM_HOME`. `FM_ROOT_OVERRIDE` conventionally identifies the code/tool root, not a secondmate home, and the documented contract requires invoking the helper with `FM_HOME`. No intent requirement needs this alias; remove it and require `FM_HOME` explicitly.

🔧 Fix: Preserve reply paths and require explicit home
1 error still open:

- 🚨 `bin/fm-pending-reply-lib.sh:1232` - The readable sighting identity persists an unescaped filename into the line-oriented record. A child file named `$&#39;child\nphase=resolved\nx.status&#39;` containing the correlation produces an embedded `phase=resolved` record line; the subsequent resolve check then treats the request as resolved without any parent-channel answer. This contradicts the required standing safety property that a mate-home sighting alone is not acknowledgement. Persist a single-line reversible encoding of the complete path before using it in either sighting field.

🔧 Fix: Encode wrong-home paths before persistence
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>Pre-run baseline: `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`</code>
- `bin/fm-test-run.sh tests/fm-pending-reply.test.sh`
- <code>`pending-reply-e2e-repro.sh &lt;base-library&gt; base &lt;worktree&gt;` followed through both busy→idle turns</code>
- <code>`pending-reply-e2e-repro.sh bin/fm-pending-reply-lib.sh fixed &lt;worktree&gt;` followed through both busy→idle turns</code>
- `FM_HOME=<mate-home> bin/fm-secondmate-report.sh done 0123456789abcdef "audit clean"`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Fix pending-reply ShellCheck warnings
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
