### PR TITLE
feat(harness): add dormant OMP candidate adapter with proven tool containment

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -3,7 +3,7 @@ name: harness-adapters
 description: >-
   Agent-only reference for firstmate harness operations.
   Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
-  Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, gemini, and muse.
+  Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, gemini, and muse, plus the dormant OMP candidate boundary.
 user-invocable: false
 metadata:
   internal: true
@@ -36,6 +36,8 @@ Deliver lifecycle actions only through `../../../bin/fm-control.sh <task-id> int
 Never type an interrupt key or exit command through `fm-send`, where routing-marked lifecycle text becomes chat.
 Trust handling is complete only when inspection proves the target started processing its instructions; delivery success alone is not proof.
 Muse and Gemini are verified only for crewmate and scout work, never a secondmate or primary.
+OMP is an unverified crewmate/scout candidate and remains hard dormant.
+Never resolve, probe, execute, dispatch, or describe OMP as live-ready; its selected reference owns the bounded tmux-only development contract and independent activation gates.
 
 ## Detection
 
@@ -90,7 +92,8 @@ A new tool remains undispatchable until the `verify` plan, its harness entry, ev
     "kimi": "references/harness/kimi.md",
     "cursor": "references/harness/cursor.md",
     "gemini": "references/harness/gemini.md",
-    "muse": "references/harness/muse.md"
+    "muse": "references/harness/muse.md",
+    "omp": "references/harness/omp.md"
   }
 }
 ```

--- a/.agents/skills/harness-adapters/references/harness/omp.md
+++ b/.agents/skills/harness-adapters/references/harness/omp.md
@@ -1,0 +1,16 @@
+# OMP candidate
+
+Oh My Pi 17.2.9 is a review-only candidate for crewmate and scout work, not a verified worker.
+Every runnable selection remains refused until immutable executable provenance is established, a supported session-free consumer proves effective configuration and tool containment against that exact artifact, and ATX-2170 independently proves First Mate interrupt, exit, and relaunch control.
+No mandatory prerequisite substitutes for another.
+
+The candidate requires caller-explicit `--harness omp` selection and a structurally qualified `--model <provider>/<model>` value.
+It is never an implicit default, secondmate, coordinator, or primary.
+The bounded development exception permits only the tmux backend and changes no fleet default or other adapter's backend resolution.
+An Orca selection must refuse and name tmux.
+
+`../../../bin/fm-spawn.sh --help` owns selection, model and backend validation, dormancy, trace ordering, and the non-executing refusal.
+`../../../bin/fm-omp-candidate-artifacts.sh` owns the exact requested environment, isolated settings, narrower manifest, input policy, and lifecycle extension.
+The manifest accepts `<agent-dir> <cwd> <binary> <model> <extension>` and deliberately grants no additional project directory.
+Requested settings and release metadata establish neither effective behavior nor executable provenance.
+`../../../docs/verification/runtime-backends.md#omp-candidate-tool-containment` owns the current evidence and the credential-free failing guard.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
+`omp` is an unverified candidate and remains hard dormant; `harness-adapters` owns its complete contract and proof gates.
 The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `cursor`, plus `muse` and `gemini` for crewmates and scouts only; never dispatch on an unverified adapter.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 

--- a/bin/fm-omp-candidate-artifacts.sh
+++ b/bin/fm-omp-candidate-artifacts.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Render the dormant OMP candidate's isolated settings and launch artifacts.
+# Usage:
+#   fm-omp-candidate-artifacts.sh prepare <agent-dir> <cwd>
+#   fm-omp-candidate-artifacts.sh manifest <agent-dir> <cwd> <binary> <model> <extension>
+#   fm-omp-candidate-artifacts.sh launch-template
+#   fm-omp-candidate-artifacts.sh validate-submission <text>
+#   fm-omp-candidate-artifacts.sh extension <output> <busy-event> <state> <task-id> <generation> <turn-ended>
+# `prepare` creates a new agent directory containing config.yml and a new,
+# empty launch cwd. `manifest` emits the requested environment boundary and argv
+# as JSON, including the flags that request disabled built-in tools and LSP;
+# `launch-template` emits the same boundary with spawn-time placeholders.
+# `validate-submission` rejects text whose first non-whitespace character would
+# enter OMP's slash-command or bang-command parser.
+# `extension` writes the First Mate busy-state adapter to <output>. Persistent
+# config and extension files are rendered beside their destinations and renamed
+# atomically. No mode starts OMP, opens a session, or calls a provider.
+set -eu
+
+OMP_RETRY_JSON='{"modelFallback":false,"usageAwareFallback":false,"fallbackChains":{}}'
+OMP_AST_EDIT_JSON='{"enabled":false}'
+
+usage() {
+  echo "usage: fm-omp-candidate-artifacts.sh prepare <agent-dir> <cwd> | manifest <agent-dir> <cwd> <binary> <model> <extension> | launch-template | validate-submission <text> | extension <output> <busy-event> <state> <task-id> <generation> <turn-ended>" >&2
+  exit 2
+}
+
+atomic_publish() {
+  local destination=$1 temporary=$2
+  mv -f -- "$temporary" "$destination"
+}
+
+javascript_literal() {
+  node -e 'process.stdout.write(JSON.stringify(process.argv[1]))' "$1"
+}
+
+render_config() {
+  local destination=$1 temporary
+  temporary=$(mktemp "${destination}.tmp.XXXXXX") || exit 1
+  if ! printf '%s\n' "{\"retry\":$OMP_RETRY_JSON,\"astEdit\":$OMP_AST_EDIT_JSON}" > "$temporary"; then
+    rm -f -- "$temporary"
+    exit 1
+  fi
+  atomic_publish "$destination" "$temporary"
+}
+
+prepare_isolated_settings() {
+  local agent_dir=$1 cwd=$2
+  if [ -e "$agent_dir" ] || [ -L "$agent_dir" ] || [ -e "$cwd" ] || [ -L "$cwd" ]; then
+    echo "error: candidate OMP isolation directories already exist" >&2
+    return 1
+  fi
+  mkdir -p "$agent_dir" "$cwd" || return 1
+  if ! render_config "$agent_dir/config.yml"; then
+    rmdir "$cwd" "$agent_dir" 2>/dev/null || true
+    return 1
+  fi
+}
+
+render_manifest() {
+  local agent_dir=$1 cwd=$2 binary=$3 model=$4 extension=$5
+  OMP_AGENT_DIR=$agent_dir OMP_CWD=$cwd OMP_BINARY=$binary \
+    OMP_MODEL=$model OMP_EXTENSION=$extension node <<'NODE'
+const manifest = {
+  unsetEnvironment: [
+    "CLAUDECODE", "PI_CODING_AGENT", "PI_CONFIG_FILES", "OMP_PROFILE", "PI_PROFILE", "GROK_AGENT",
+    "FM_PI_HARNESS", "CURSOR_AGENT", "CURSOR_INVOKED_AS", "TRACEPARENT",
+  ],
+  environment: {
+    FM_OMP_HARNESS: "1",
+    PI_CODING_AGENT_DIR: process.env.OMP_AGENT_DIR,
+  },
+  argv: [
+    process.env.OMP_BINARY,
+    "--cwd", process.env.OMP_CWD,
+    "--approval-mode", "yolo",
+    "--no-title",
+    "--no-extensions",
+    "--no-skills",
+    "--no-lsp",
+    "--no-tools",
+    "--model", process.env.OMP_MODEL,
+    "-e", process.env.OMP_EXTENSION,
+  ],
+};
+process.stdout.write(JSON.stringify(manifest));
+NODE
+}
+
+render_launch_template() {
+  render_manifest __OMPAGENTDIR__ __OMPCWD__ __OMPBIN__ __OMPMODEL__ __OMPEXT__ \
+    | node -e '
+const fs = require("node:fs");
+const manifest = JSON.parse(fs.readFileSync(0, "utf8"));
+const words = ["env"];
+for (const name of manifest.unsetEnvironment) words.push("-u", name);
+for (const [name, value] of Object.entries(manifest.environment)) words.push(name + "=" + value);
+words.push(...manifest.argv);
+const dollar = String.fromCharCode(36);
+process.stdout.write(words.join(" ") + " \"" + dollar + "(__OPINPUT__ encode launch-brief < __BRIEF__)\"");
+'
+}
+
+validate_submission() {
+  OMP_SUBMISSION=$1 node <<'NODE'
+const input = process.env.OMP_SUBMISSION || "";
+const command = input.trimStart();
+if (command.startsWith("/") || command.startsWith("!")) {
+  process.stderr.write("error: OMP candidate refuses slash and bang command input; use First Mate control for lifecycle actions\n");
+  process.exit(1);
+}
+NODE
+}
+
+render_extension() {
+  local destination=$1 busy_event=$2 state=$3 task_id=$4 generation=$5 turn_ended=$6
+  local temporary busy_event_js state_js task_id_js generation_js turn_ended_js
+  busy_event_js=$(javascript_literal "$busy_event") || exit 1
+  state_js=$(javascript_literal "$state") || exit 1
+  task_id_js=$(javascript_literal "$task_id") || exit 1
+  generation_js=$(javascript_literal "$generation") || exit 1
+  turn_ended_js=$(javascript_literal "$turn_ended") || exit 1
+  temporary=$(mktemp "${destination}.tmp.XXXXXX") || exit 1
+  if ! cat > "$temporary" <<EOF
+import { execFile } from "node:child_process";
+const busyEvent = (state: string, event: string) =>
+  new Promise<void>((resolve) => {
+    execFile($busy_event_js, [
+      "apply", $state_js, $task_id_js, state,
+      "--gen", $generation_js, "--source", "omp-ext", "--event", event,
+    ], () => resolve());
+  });
+export default function (omp: any) {
+  omp.on("agent_start", () => busyEvent("busy", "agent-start"));
+  const settled = (event: any, ctx: any) => {
+    if (event && event.willContinue === true) return;
+    if (ctx && typeof ctx.isIdle === "function" && !ctx.isIdle()) return;
+    return busyEvent("idle", "agent-end");
+  };
+  for (const name of ["agent_end", "agent_settled"]) {
+    try {
+      omp.on(name, settled);
+    } catch (_err) {
+    }
+  }
+  omp.on("turn_end", () => execFile("touch", [$turn_ended_js]));
+}
+EOF
+  then
+    rm -f -- "$temporary"
+    exit 1
+  fi
+  atomic_publish "$destination" "$temporary"
+}
+
+case "${1:-}" in
+  prepare)
+    [ "$#" -eq 3 ] || usage
+    prepare_isolated_settings "$2" "$3"
+    ;;
+  manifest)
+    [ "$#" -eq 6 ] || usage
+    render_manifest "$2" "$3" "$4" "$5" "$6"
+    ;;
+  launch-template)
+    [ "$#" -eq 1 ] || usage
+    render_launch_template
+    ;;
+  validate-submission)
+    [ "$#" -eq 2 ] || usage
+    validate_submission "$2"
+    ;;
+  extension)
+    [ "$#" -eq 7 ] || usage
+    render_extension "$2" "$3" "$4" "$5" "$6" "$7"
+    ;;
+  *) usage ;;
+esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -111,7 +111,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|omp)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. For pi and pi-signed, fm-spawn resolves the selected executable
@@ -175,6 +175,10 @@
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
+#     __OMPEXT__   absolute path to state/<task-id>.omp-ext.ts
+#     __OMPAGENTDIR__ isolated OMP agent directory under the task temp root
+#     __OMPCWD__   isolated OMP project-settings directory under the task temp root
+#     __OMPMODEL__ quoted explicit provider/model selected for the OMP candidate
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 #     __WORKTREE__  absolute path to the task worktree
 #     __CURSORBIN__ resolved, cursor-verified executable for a cursor launch
@@ -203,6 +207,15 @@
 # and every refusal; a failed registration stops this spawn rather than launching
 # a worker that would wedge on the dialog. A --secondmate launch never runs it,
 # so a claude secondmate home keeps its own one-time trust decision.
+# omp (Oh My Pi) is a dormant candidate for crewmate and scout work only.
+# Every runnable selection is refused until a supported session-free consumer
+# proves exact 17.2.9 configuration and tool containment and ATX-2170 separately
+# proves First Mate interrupt, exit, and relaunch control.
+# The candidate requires an explicit --harness omp, an explicit qualified
+# provider/model, and backend=tmux; it never resolves or probes an executable
+# while dormant, never runs as a secondmate, and never inherits trace context.
+# bin/fm-omp-candidate-artifacts.sh owns its review-only manifest, isolated
+# settings, input policy, and lifecycle extension.
 # Publishing the record and moving this home's backlog item to In flight are one
 # step, not two: bin/fm-backlog-transition-lib.sh owns that invariant, and this
 # script performs the transition under the task's own meta lock before it reports
@@ -459,6 +472,47 @@ else
   fi
 fi
 
+# The OMP candidate's model value must be caller-explicit and fully qualified.
+# Validation is structural only; this never queries a model catalog or candidate.
+require_omp_launch_model() {
+  if [ "$MODEL_SET" -ne 1 ] || [ -z "$MODEL" ] || [ "$MODEL" = default ]; then
+    echo "error: omp requires an explicit --model <provider>/<model> flag on every spawn; without one omp would resolve the provider itself" >&2
+    return 1
+  fi
+  if [[ ! $MODEL =~ ^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    echo "error: omp --model must be exactly '<provider>/<model>' - one slash between two identifier segments of letters, digits, dot, underscore, or dash (got '$MODEL')" >&2
+    return 1
+  fi
+}
+
+refuse_omp_secondmate() {
+  echo "error: omp is a candidate crewmate/scout adapter only and cannot run a secondmate; it has no primary supervision protocol. Select a harness verified for secondmates." >&2
+  return 1
+}
+
+refuse_omp_unverified_gates() {
+  echo "error: omp is dormant until a supported session-free omp/17.2.9 consumer proves effective configuration and tool containment, immutable executable provenance is established, and ATX-2170 independently verifies First Mate interrupt, exit, and relaunch control; no mandatory gate substitutes for another; refusing every runnable OMP launch" >&2
+  return 1
+}
+
+# The bounded development exception is adapter-local: OMP requires tmux while
+# dormant, without changing the fleet default or any other adapter's resolution.
+require_omp_tmux_backend() {
+  if [ "$BACKEND" != tmux ]; then
+    echo "error: omp requires backend=tmux for bounded candidate development; resolved backend '$BACKEND' is not authorized for this adapter" >&2
+    return 1
+  fi
+}
+
+# Raw launch text is never executed to classify this candidate.
+# Any whitespace-delimited word whose basename is the candidate command claims
+# the OMP identity and must use the named adapter path instead.
+raw_launch_selects_omp() {
+  local raw=$1
+  local pattern='(^|[[:space:];|&()])([^[:space:];|&()]*/)?omp([[:space:];|&()]|$)'
+  [[ $raw =~ $pattern ]]
+}
+
 spawn_remote_secondmate() {
   local id=$1 remote host root home harness positional model effort backend out rc meta tmp
   local remote_backend remote_target remote_harness remote_herdr_session registry_lock remote_lock remote_generation
@@ -500,6 +554,12 @@ spawn_remote_secondmate() {
     harness=$positional
   else
     harness=$("$FM_ROOT/bin/fm-harness.sh" secondmate)
+  fi
+  if [ "$harness" = omp ]; then
+    fm_lock_release "$registry_lock" || true
+    fm_lock_release "$SPAWN_TASK_LOCK" || true
+    refuse_omp_secondmate
+    return 1
   fi
   case "$harness" in
     claude|codex|opencode|pi|pi-signed|grok|kimi|cursor) ;;
@@ -1012,6 +1072,23 @@ elif [ "$RELAUNCH" -eq 1 ]; then
   echo "error: spawn refused: state directory does not exist at $STATE" >&2
   exit 1
 fi
+# A caller-explicit fresh OMP selection is completely classifiable before any
+# backend validation or task lock, so an Orca request names the tmux exception
+# instead of contacting the rejected backend.
+if [ "$RELAUNCH" -eq 0 ] && [ "$HARNESS_ARG" = omp ]; then
+  if [ "$KIND" = secondmate ]; then
+    refuse_omp_secondmate
+    exit 1
+  fi
+  require_omp_launch_model || exit 1
+  if [ "$BACKEND_SET" -eq 1 ]; then
+    BACKEND=$BACKEND_ARG
+  else
+    BACKEND=$(fm_backend_name)
+  fi
+  require_omp_tmux_backend || exit 1
+  refuse_omp_unverified_gates || exit 1
+fi
 # Role partition: spawning NEW work is MAIN-owned. A relaunch of an existing
 # task is legitimate branch recovery (fm-control drives it through this same
 # entrypoint), so only a fresh spawn refuses the branch actor (contract:
@@ -1202,7 +1279,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   }
 elif [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse)
+    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|omp)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -1377,12 +1454,17 @@ launch_template() {
     # written below. Nothing to place in the template for it.
     # codex, opencode, and kimi are also markerless and share this inherited-marker hazard; changing their verified launch boundaries belongs in follow-up work.
     muse) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS XDG_CONFIG_HOME=__MUSECONFIG__ XDG_DATA_HOME=__MUSEDATA__ MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on __MUSEBIN__ --yolo __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    omp) "$FM_ROOT/bin/fm-omp-candidate-artifacts.sh" launch-template ;;
     *) return 1 ;;
   esac
 }
 
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
+    if raw_launch_selects_omp "$ARG3"; then
+      echo "error: every omp spawn and relaunch requires an explicit --harness omp selection; raw, positional, and inherited paths never select it" >&2
+      exit 1
+    fi
     RAW_LAUNCH=1
     LAUNCH=$ARG3
     HARNESS=""
@@ -1418,6 +1500,22 @@ case "$ARG3" in
     ;;
 esac
 
+if [ "$HARNESS" = omp ]; then
+  if [ "$HARNESS_SET" -ne 1 ]; then
+    echo "error: every omp spawn and relaunch requires an explicit --harness omp selection; raw, positional, configured, and recorded omp selections are not allowed" >&2
+    exit 1
+  fi
+  if [ "$KIND" = secondmate ]; then
+    refuse_omp_secondmate
+    exit 1
+  fi
+  require_omp_launch_model || exit 1
+  require_omp_tmux_backend || exit 1
+  refuse_omp_unverified_gates || exit 1
+fi
+
+# muse is verified as a CREWMATE/SCOUT adapter only. A secondmate is a firstmate
+# instance, so it needs a primary supervision protocol; muse has none, and its
 # muse and gemini are verified as CREWMATE/SCOUT adapters only. A secondmate is
 # a firstmate instance, so it needs a primary supervision protocol.
 # gemini has none: docs/supervision-protocols/ carries no gemini wake protocol
@@ -1567,7 +1665,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse)
+    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|omp)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -2677,7 +2775,7 @@ if [ "$KIND" != secondmate ]; then
       ;;
   esac
   case "$HARNESS" in
-    claude*|opencode*|pi|pi-signed)
+    claude*|opencode*|pi|pi-signed|omp)
       BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
         echo "error: failed to arm the busy-state contract for $ID" >&2
         exit 1
@@ -2847,6 +2945,15 @@ export default function (pi: any) {
 }
 EOF
       ;;
+    omp)
+      "$FM_ROOT/bin/fm-omp-candidate-artifacts.sh" prepare \
+        "$TASK_TMP/omp-agent" "$TASK_TMP/omp-cwd" || exit 1
+      "$FM_ROOT/bin/fm-omp-candidate-artifacts.sh" extension \
+        "$STATE/$ID.omp-ext.ts" "$FM_ROOT/bin/fm-busy-event.sh" \
+        "$STATE_REAL" "$ID" "$BUSY_GEN" "$TURNEND" || exit 1
+      OMP_AGENT_DIR="$TASK_TMP/omp-agent"
+      OMP_CWD="$TASK_TMP/omp-cwd"
+      ;;
     codex*)
       # Semantic busy-state source negotiation (bin/fm-busy-lib.sh owns the
       # probes and the evidence). Neither Codex path is usable on the
@@ -3007,7 +3114,10 @@ fi
 # carrier, and this host only delivers it. The validated --traceparent value
 # then IS the decision, so the enablement snapshot handed to the new Secondmate
 # agrees with the carrier it receives exactly as on the local path.
-if [ "$TRACEPARENT_SET" -eq 1 ]; then
+if [ "$HARNESS" = omp ]; then
+  SPAWN_TRACE_EFFECTIVE=off
+  SPAWN_TRACEPARENT=
+elif [ "$TRACEPARENT_SET" -eq 1 ]; then
   SPAWN_TRACE_EFFECTIVE=on
   SPAWN_TRACEPARENT=$TRACEPARENT_ARG
 else
@@ -3145,6 +3255,10 @@ sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
+sq_ompext=$(shell_quote "$STATE/$ID.omp-ext.ts")
+sq_ompagentdir=$(shell_quote "${OMP_AGENT_DIR:-}")
+sq_ompcwd=$(shell_quote "${OMP_CWD:-}")
+sq_ompmodel=$(shell_quote "$MODEL")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 sq_worktree=$(shell_quote "$WT")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
@@ -3156,6 +3270,10 @@ LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
+LAUNCH=${LAUNCH//__OMPEXT__/$sq_ompext}
+LAUNCH=${LAUNCH//__OMPAGENTDIR__/$sq_ompagentdir}
+LAUNCH=${LAUNCH//__OMPCWD__/$sq_ompcwd}
+LAUNCH=${LAUNCH//__OMPMODEL__/$sq_ompmodel}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 case "$HARNESS" in
   pi|pi-signed) LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"} ;;
@@ -3164,7 +3282,7 @@ case "$HARNESS" in
 esac
 LAUNCH=${LAUNCH//__WORKTREE__/$sq_worktree}
 case "$HARNESS" in
-  claude|codex|opencode|pi|pi-signed|grok|kimi|gemini|muse)
+  claude|codex|opencode|pi|pi-signed|grok|kimi|gemini|muse|omp)
     LAUNCH="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI $LAUNCH"
     ;;
 esac
@@ -3199,6 +3317,11 @@ if [ "$KIND" = secondmate ]; then
 fi
 if [ -z "$SPAWN_TRACEPARENT" ] && [ "$RELAUNCH" -eq 1 ]; then
   LAUNCH="unset TRACEPARENT; $LAUNCH"
+fi
+
+if [ "$HARNESS" = omp ]; then
+  refuse_omp_unverified_gates
+  exit 1
 fi
 
 spawn_record_traceparent() {

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -281,6 +281,7 @@ family_for_basename() {
     fm-grok-stop-live-e2e.test.sh|fm-harness-adapter-instructions-live-e2e.test.sh|\
     fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-muse-signals-live-e2e.test.sh|\
+    fm-omp-tools-live-e2e.test.sh|\
     fm-herdr-version-floor-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-branch-live-e2e.test.sh|\
     fm-pi-primary-live-e2e.test.sh|\

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -303,10 +303,17 @@ On Zellij, cmux, and Orca a typed-plane Cursor send (a harness-native invocation
 muse is verified for crewmate and scout launches ONLY, and `fm-spawn.sh` refuses it for a secondmate, because muse ships no usable hook surface for a primary session's turn-end supervision; [`docs/verification/muse.md`](verification/muse.md) owns that evidence.
 muse also needs a worker-reachable credential before spawning, and the portable fleet path is the `<config>/muse/auth.json` credential stored by `muse login`, because a caller-only `META_API_KEY` does not cross a long-lived backend daemon.
 gemini is likewise refused for secondmates because it has no primary supervision protocol; [its adapter reference](../.agents/skills/harness-adapters/references/harness/gemini.md) owns the credential precondition, canonical-launch wiring, and raw-launch limitations.
+omp (Oh My Pi) is a candidate crewmate/scout adapter rather than a verified one.
+Its pinned 17.2.9 effective configuration and effective tool registry remain unproven because no supported matching session-free importable consumer artifact is available.
+Every runnable launch remains refused until immutable executable provenance, that consumer proof, and the separate ATX-2170 First Mate interrupt, exit, and relaunch proof all pass; no mandatory prerequisite substitutes for another.
+First Mate remains its sole supervisor, and tmux is the only backend allowed for bounded candidate development.
+The [`fm-spawn.sh` usage contract](../bin/fm-spawn.sh) owns explicit selection, hard dormancy, model, backend, relaunch, and trace ordering.
+[`fm-omp-candidate-artifacts.sh`](../bin/fm-omp-candidate-artifacts.sh) owns exact flags, environment isolation, requested tool containment, and input policy.
+The [harness-adapters skill](../.agents/skills/harness-adapters/SKILL.md) owns adapter capability and safety details, and [runtime backend verification](verification/runtime-backends.md#omp-candidate-tool-containment) owns current empirical evidence.
 New harnesses get verified through a supervised trial task before joining the set.
 The verified adapter evidence - each harness's busy-state source, interrupt and exit behavior, skill-invocation syntax, and per-harness quirks - lives in the skill tree rooted at [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 The executable interrupt and exit mechanics live in [`bin/fm-control-lib.sh`](../bin/fm-control-lib.sh), and [`docs/agent-control.md`](agent-control.md) owns their lifecycle-control architecture.
-Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
+Launch mechanics for verified adapters live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh), alongside the dormant candidate's non-runnable request template.
 Pi-family launches adapt the regular-TUI safeguard to the installed CLI's capabilities; [`fm-spawn.sh --help`](../bin/fm-spawn.sh) owns the exact version-safe launch mechanics.
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -205,6 +205,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/harness-adapters/references/harness/omp.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/harness-adapters/references/harness/opencode.md",
       "audience": "agent-runtime"
     },

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1398,3 +1398,34 @@ The live probe loads the tracked watcher extension through Pi's real resource lo
 It proved that a follow-up the extension sends while main is streaming raises no `before_agent_start` at queue time or when the run reaches it, joins the run as a user `message_start` carrying the exact wake text in its own model turn, and is followed by a verified successor and delivery of the next close; a follow-up sent to the idle main raises `before_agent_start` with the exact text before its user `message_start`.
 The portable regression drives the same shape with a fake main that never raises `before_agent_start` while streaming, then proves a replacement replays only the follow-up Pi had not consumed and that an exhausted restoration delivers its typed failure without launching a further arm.
 A second regression holds a branch settlement open while the verified successor exits with a failure, and proves that failure takes the ordinary bounded retry once the delivery settles rather than leaving the generation with no watcher and no retry.
+
+## OMP candidate tool containment
+
+The OMP adapter and manifest are review-only.
+They may report requested and rendered settings for exact `omp/17.2.9`, but those records are not effective consumer proof; effective configuration, fallback isolation, and effective tool construction remain explicitly unproven.
+No supported session-free consumer pinned to that exact artifact has been established.
+
+Two measured findings bound which consumer surfaces remain worth attempting.
+On 2026-08-24, source review invalidated an earlier RPC-based consumer result: OMP RPC mode constructs an agent session and may initialize a provider connection, so it falls outside this candidate's no-session and no-network verification authority.
+The unrelated Bun cache contains `@oh-my-pi/pi-coding-agent` 18.0.4, which cannot prove `omp/17.2.9` behavior.
+
+The opt-in proof gate fails closed without resolving or executing any OMP candidate:
+
+```sh
+FM_OMP_TOOLS_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-omp-tools-live-e2e.test.sh
+```
+
+```text
+not ok - requested omp/17.2.9 has no supported session-free configuration and tool consumer; executable provenance, version, and effective behavior remain unproven; candidate remains dormant without resolving or executing OMP
+```
+
+The requested release metadata does not establish immutable executable provenance, installed version, or any effective consumer behavior.
+OMP remains hard dormant and non-runnable.
+The tmux-only development exception does not lift dormancy or establish any missing proof.
+Before dormancy can be reconsidered, all three independent mandatory prerequisites must pass:
+
+1. Immutable executable provenance and exact `omp/17.2.9` version binding.
+2. Supported session-free consumer proof pinned to that same exact artifact, covering effective configuration, fallback isolation, and effective tool construction.
+3. Separately gated ATX-2170 First Mate interrupt, exit, and relaunch verification.
+
+No prerequisite substitutes for another.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1402,8 +1402,14 @@ A second regression holds a branch settlement open while the verified successor 
 ## OMP candidate tool containment
 
 The OMP adapter and manifest are review-only.
-They may report requested and rendered settings for exact `omp/17.2.9`, but those records are not effective consumer proof; effective configuration, fallback isolation, and effective tool construction remain explicitly unproven.
+The candidate contract and refusal gate are pinned to exact `omp/17.2.9`.
+`tests/fm-omp-harness.test.sh` proves that the adapter renders isolated settings, routes its rendered agent tool path to `/firstmate/isolated-agent/tools` instead of a present captain `~/.claude/tools` fixture, and requests the tool surface disabled with `--no-tools`.
+These are renderer and requested-settings proofs only.
+Effective configuration, fallback isolation, and effective tool construction remain explicitly unproven.
 No supported session-free consumer pinned to that exact artifact has been established.
+
+On 2026-09-03, an accidental ambient OMP run enumerated `~/.claude/tools` and attempted to load `agent-secrets-collect.py` and `rotate-pending-keys.sh` as tools.
+Both files failed format validation, but the attempted loads establish ambient tool inheritance as a measured hazard rather than a theoretical one.
 
 Two measured findings bound which consumer surfaces remain worth attempting.
 On 2026-08-24, source review invalidated an earlier RPC-based consumer result: OMP RPC mode constructs an agent session and may initialize a provider connection, so it falls outside this candidate's no-session and no-network verification authority.

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -57,6 +57,33 @@ NODE
   pass "OMP candidate renderer emits its requested argv and environment contract"
 }
 
+test_omp_manifest_routes_agent_tools_away_from_captain_claude_tools() {
+  local captain_home captain_tools manifest
+  captain_home="$TMP_ROOT/captain-home"
+  captain_tools="$captain_home/.claude/tools"
+  mkdir -p "$captain_tools"
+  printf '%s\n' 'captain-only' > "$captain_tools/agent-secrets-collect.py"
+  printf '%s\n' 'captain-only' > "$captain_tools/rotate-pending-keys.sh"
+  manifest=$(HOME="$captain_home" "$ROOT/bin/fm-omp-candidate-artifacts.sh" manifest \
+    /firstmate/isolated-agent /firstmate/isolated-cwd /opt/omp "$OMP_MODEL" \
+    /state/task.omp-ext.ts) || fail "candidate OMP manifest did not render"
+  MANIFEST=$manifest CAPTAIN_TOOLS=$captain_tools node <<'NODE' \
+    || fail "candidate OMP manifest inherited the captain Claude tools directory"
+const manifest = JSON.parse(process.env.MANIFEST);
+const expectedAgentDirectory = "/firstmate/isolated-agent";
+const expectedToolSurface = "/firstmate/isolated-agent/tools";
+const captainToolsDirectory = process.env.CAPTAIN_TOOLS;
+const renderedToolSurface = `${manifest.environment.PI_CODING_AGENT_DIR}/tools`;
+if (manifest.environment.PI_CODING_AGENT_DIR !== expectedAgentDirectory) process.exit(1);
+if (renderedToolSurface !== expectedToolSurface) process.exit(1);
+const rendered = JSON.stringify(manifest);
+if (rendered.includes(captainToolsDirectory)) process.exit(1);
+if (rendered.includes("agent-secrets-collect.py")) process.exit(1);
+if (rendered.includes("rotate-pending-keys.sh")) process.exit(1);
+NODE
+  pass "OMP candidate manifest routes agent tools away from the captain Claude tools directory"
+}
+
 test_omp_consumer_proof_gate_never_executes_candidate() {
   local dir fakebin log out status
   dir="$TMP_ROOT/omp-consumer-proof"
@@ -209,6 +236,7 @@ test_spawn_policy_matrix_stays_dormant_and_tmux_only() {
 }
 
 test_omp_launch_request_is_rendered
+test_omp_manifest_routes_agent_tools_away_from_captain_claude_tools
 test_omp_consumer_proof_gate_never_executes_candidate
 test_omp_candidate_artifacts_render_requested_settings_and_handle_continuation
 test_spawn_policy_matrix_stays_dormant_and_tmux_only

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Policy, artifact, and non-execution tests for the dormant OMP candidate.
+set -u
+
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+OMP_MODEL="anthropic/claude-sonnet-4-5"
+TMP_ROOT=$(fm_test_tmproot fm-omp-harness)
+
+test_omp_launch_request_is_rendered() {
+  local manifest template
+  manifest=$("$ROOT/bin/fm-omp-candidate-artifacts.sh" manifest \
+    /isolated/agent /isolated/cwd /opt/omp "$OMP_MODEL" /state/task.omp-ext.ts) \
+    || fail "candidate OMP manifest did not render"
+  template=$("$ROOT/bin/fm-omp-candidate-artifacts.sh" launch-template) \
+    || fail "candidate OMP launch template did not render"
+  MANIFEST=$manifest TEMPLATE=$template node <<'NODE' \
+    || fail "candidate OMP manifest or launch template drifted from its requested output contract"
+const manifest = JSON.parse(process.env.MANIFEST);
+if (JSON.stringify(Object.keys(manifest).sort()) !== JSON.stringify(["argv", "environment", "unsetEnvironment"])) process.exit(1);
+const expectedUnset = [
+  "CLAUDECODE", "PI_CODING_AGENT", "PI_CONFIG_FILES", "OMP_PROFILE", "PI_PROFILE", "GROK_AGENT",
+  "FM_PI_HARNESS", "CURSOR_AGENT", "CURSOR_INVOKED_AS", "TRACEPARENT",
+];
+const expectedArgv = [
+  "/opt/omp", "--cwd", "/isolated/cwd", "--approval-mode", "yolo",
+  "--no-title", "--no-extensions", "--no-skills",
+  "--no-lsp", "--no-tools", "--model", "anthropic/claude-sonnet-4-5",
+  "-e", "/state/task.omp-ext.ts",
+];
+if (JSON.stringify(manifest.unsetEnvironment) !== JSON.stringify(expectedUnset)) process.exit(1);
+if (manifest.environment.FM_OMP_HARNESS !== "1") process.exit(1);
+if (manifest.environment.PI_CODING_AGENT_DIR !== "/isolated/agent") process.exit(1);
+if (JSON.stringify(manifest.argv) !== JSON.stringify(expectedArgv)) process.exit(1);
+if (manifest.argv.includes("--tools")) process.exit(1);
+if (!manifest.argv.includes("--no-tools")) process.exit(1);
+if (manifest.argv.includes("--add-dir")) process.exit(1);
+if (manifest.argv.includes("/task/worktree")) process.exit(1);
+const templateManifest = {
+  ...manifest,
+  environment: { FM_OMP_HARNESS: "1", PI_CODING_AGENT_DIR: "__OMPAGENTDIR__" },
+  argv: manifest.argv.map((word) => ({
+    "/opt/omp": "__OMPBIN__",
+    "/isolated/cwd": "__OMPCWD__",
+    "anthropic/claude-sonnet-4-5": "__OMPMODEL__",
+    "/state/task.omp-ext.ts": "__OMPEXT__",
+  })[word] || word),
+};
+const words = ["env"];
+for (const name of templateManifest.unsetEnvironment) words.push("-u", name);
+for (const [name, value] of Object.entries(templateManifest.environment)) words.push(`${name}=${value}`);
+words.push(...templateManifest.argv);
+const expectedTemplate = words.join(" ") + ' "$(__OPINPUT__ encode launch-brief < __BRIEF__)"';
+if (process.env.TEMPLATE !== expectedTemplate) process.exit(1);
+NODE
+  pass "OMP candidate renderer emits its requested argv and environment contract"
+}
+
+test_omp_consumer_proof_gate_never_executes_candidate() {
+  local dir fakebin log out status
+  dir="$TMP_ROOT/omp-consumer-proof"
+  fakebin="$dir/fakebin"
+  log="$dir/omp-invocations"
+  mkdir -p "$fakebin"
+  : > "$log"
+  cat > "$fakebin/omp" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FM_OMP_PROOF_STUB_LOG"
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' "${FM_OMP_PROOF_STUB_VERSION:-omp/17.2.9}"
+  exit 0
+fi
+exit 97
+SH
+  chmod +x "$fakebin/omp"
+  out=$(PATH="$fakebin:$PATH" FM_OMP_PROOF_STUB_LOG="$log" FM_OMP_TOOLS_LIVE_E2E=1 \
+    "$ROOT/tests/fm-omp-tools-live-e2e.test.sh" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "the unavailable exact-version consumer proof must fail closed"
+  assert_contains "$out" "no supported session-free configuration and tool consumer" \
+    "the consumer proof gate did not name its unresolved prerequisite"
+  assert_contains "$out" "executable provenance, version, and effective behavior remain unproven" \
+    "the consumer proof gate overstated requested metadata as effective proof"
+  [ ! -s "$log" ] || fail "the unresolved consumer proof gate executed OMP: $(cat "$log")"
+  pass "OMP consumer proof gate fails closed without candidate execution"
+}
+
+test_omp_candidate_artifacts_render_requested_settings_and_handle_continuation() {
+  local state id gen agent_dir isolated_cwd ambient_agent ambient_project ambient_overlay manifest ext record turnend
+  state="$TMP_ROOT/candidate-artifacts/state"
+  id=omp-candidate-artifacts
+  agent_dir="$state/isolated-agent"
+  isolated_cwd="$state/isolated-cwd"
+  ambient_agent="$state/ambient-agent"
+  ambient_project="$state/ambient-project"
+  ambient_overlay="$state/ambient-overlay.json"
+  ext="$state/$id.omp-ext.ts"
+  record="$state/$id.busy-state"
+  turnend="$state/$id.turn-ended"
+  mkdir -p "$state"
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$state" "$id") || fail "could not arm the candidate artifact fixture"
+  mkdir -p "$ambient_agent" "$ambient_project/.omp"
+  printf '%s\n' '{"retry":{"modelFallback":true,"usageAwareFallback":true,"fallbackChains":{"ambient":["provider/model"]}}}' > "$ambient_agent/config.yml"
+  printf '%s\n' '{"retry":{"fallbackChains":{"project":["provider/model"]}}}' > "$ambient_project/.omp/config.yml"
+  printf '%s\n' '{"retry":{"fallbackChains":{"overlay":["provider/model"]}}}' > "$ambient_overlay"
+  "$ROOT/bin/fm-omp-candidate-artifacts.sh" prepare "$agent_dir" "$isolated_cwd" \
+    || fail "could not prepare isolated candidate OMP settings"
+  manifest=$("$ROOT/bin/fm-omp-candidate-artifacts.sh" manifest \
+    "$agent_dir" "$isolated_cwd" /opt/omp "$OMP_MODEL" "$ext") \
+    || fail "could not render the candidate OMP manifest"
+  MANIFEST=$manifest AGENT_DIR=$agent_dir ISOLATED_CWD=$isolated_cwd \
+    AMBIENT_AGENT=$ambient_agent AMBIENT_PROJECT=$ambient_project \
+    PI_CONFIG_FILES=$ambient_overlay node <<'NODE' \
+    || fail "candidate OMP settings artifacts drifted from their requested isolation contract"
+const fs = require("node:fs");
+const path = require("node:path");
+const manifest = JSON.parse(process.env.MANIFEST);
+if (!manifest.unsetEnvironment.includes("PI_CONFIG_FILES")) process.exit(1);
+if (!manifest.unsetEnvironment.includes("OMP_PROFILE") || !manifest.unsetEnvironment.includes("PI_PROFILE")) process.exit(1);
+if (manifest.environment.PI_CODING_AGENT_DIR === process.env.AMBIENT_AGENT) process.exit(1);
+if (manifest.environment.PI_CODING_AGENT_DIR !== process.env.AGENT_DIR) process.exit(1);
+const cwdIndex = manifest.argv.indexOf("--cwd");
+const cwd = manifest.argv[cwdIndex + 1];
+if (cwd === process.env.AMBIENT_PROJECT) process.exit(1);
+if (cwd !== process.env.ISOLATED_CWD) process.exit(1);
+if (manifest.argv.includes("--add-dir") || manifest.argv.includes("/task/worktree")) process.exit(1);
+if (!manifest.argv.includes("--no-lsp")) process.exit(1);
+const config = JSON.parse(fs.readFileSync(path.join(manifest.environment.PI_CODING_AGENT_DIR, "config.yml"), "utf8"));
+const retry = config.retry;
+if (!retry || retry.modelFallback !== false || retry.usageAwareFallback !== false) process.exit(1);
+if (!retry.fallbackChains || Array.isArray(retry.fallbackChains) || Object.keys(retry.fallbackChains).length !== 0) process.exit(1);
+if (!config.astEdit || config.astEdit.enabled !== false) process.exit(1);
+NODE
+  "$ROOT/bin/fm-omp-candidate-artifacts.sh" extension "$ext" \
+    "$ROOT/bin/fm-busy-event.sh" "$state" "$id" "$gen" "$turnend" \
+    || fail "could not render the candidate OMP extension"
+  EXT_PATH="$ext" node --experimental-strip-types --input-type=module <<'NODE' \
+    || fail "the candidate OMP continuation event did not execute"
+import { pathToFileURL } from "node:url";
+const handlers = new Map();
+const module = await import(pathToFileURL(process.env.EXT_PATH).href);
+module.default({ on(name, handler) { handlers.set(name, handler); } });
+await handlers.get("agent_start")();
+await handlers.get("agent_end")({ willContinue: true }, { isIdle: () => true });
+await new Promise((resolve) => setTimeout(resolve, 150));
+NODE
+  assert_grep 'state=busy source=omp-ext event=agent-start' "$record" \
+    "willContinue=true incorrectly settled the candidate extension"
+  EXT_PATH="$ext" node --experimental-strip-types --input-type=module <<'NODE' \
+    || fail "the final OMP settle event did not execute"
+import { pathToFileURL } from "node:url";
+const handlers = new Map();
+const module = await import(pathToFileURL(process.env.EXT_PATH).href);
+module.default({ on(name, handler) { handlers.set(name, handler); } });
+await handlers.get("agent_end")({ willContinue: false }, { isIdle: () => true });
+await new Promise((resolve) => setTimeout(resolve, 150));
+NODE
+  assert_grep 'state=idle source=omp-ext event=agent-end' "$record" \
+    "the final OMP settle event did not record idle"
+  pass "OMP candidate renders requested settings and preserves busy across willContinue"
+}
+
+
+make_refusal_case() {
+  local name=$1 configured=${2:-} case_dir home fakebin sentinel
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  sentinel="$case_dir/candidate-executed"
+  fakebin=$(fm_test_make_spawn_fakebin "$case_dir/fake")
+  fm_test_spawn_home "$home" "$configured"
+  cat > "$fakebin/omp" <<'SH'
+#!/usr/bin/env bash
+printf 'executed\n' >> "${FM_OMP_EXECUTION_SENTINEL:?}"
+exit 97
+SH
+  chmod +x "$fakebin/omp"
+  printf '%s|%s|%s\n' "$home" "$fakebin" "$sentinel"
+}
+
+run_spawn_refusal() {
+  local name=$1 configured=$2 expected=$3 record home fakebin sentinel out status
+  shift 3
+  record=$(make_refusal_case "$name" "$configured")
+  IFS='|' read -r home fakebin sentinel <<EOF
+$record
+EOF
+  out=$(FM_OMP_EXECUTION_SENTINEL="$sentinel" \
+    fm_test_run_spawn "$home" /not-a-pane "$fakebin" "$@" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "$name unexpectedly dispatched the candidate"
+  assert_contains "$out" "$expected" "$name did not reach the expected refusal: $out"
+  assert_absent "$sentinel" "$name executed the candidate"
+  if find "$home/state" -maxdepth 1 -name '*.meta' -print -quit | grep -q .; then
+    fail "$name published task metadata before refusing"
+  fi
+}
+
+test_spawn_policy_matrix_stays_dormant_and_tmux_only() {
+  run_spawn_refusal explicit-dormant '' 'session-free omp/17.2.9 consumer'     task-explicit /not-a-project --harness omp --model "$OMP_MODEL"     --backend tmux --mode no-mistakes --yolo off
+  run_spawn_refusal orca-refusal '' 'requires backend=tmux'     task-orca /not-a-project --harness omp --model "$OMP_MODEL"     --backend orca --mode no-mistakes --yolo off
+  run_spawn_refusal missing-model '' 'requires an explicit --model'     task-missing /not-a-project --harness omp --backend tmux     --mode no-mistakes --yolo off
+  run_spawn_refusal malformed-model '' 'must be exactly'     task-malformed /not-a-project --harness omp --model model-only     --backend tmux --mode no-mistakes --yolo off
+  run_spawn_refusal positional '' 'requires an explicit --harness omp'     task-positional /not-a-project omp --model "$OMP_MODEL"     --backend tmux --mode no-mistakes --yolo off
+  run_spawn_refusal configured omp 'requires an explicit --harness omp'     task-configured /not-a-project --model "$OMP_MODEL"     --backend tmux --mode no-mistakes --yolo off
+  run_spawn_refusal raw '' 'requires an explicit --harness omp'     task-raw /not-a-project 'env omp --version' --model "$OMP_MODEL"     --backend tmux --mode no-mistakes --yolo off
+  run_spawn_refusal secondmate '' 'candidate crewmate/scout adapter only'     task-secondmate --secondmate --harness omp --model "$OMP_MODEL"     --backend tmux
+  pass "OMP selection, model, backend, role, and dormancy gates refuse without execution"
+}
+
+test_omp_launch_request_is_rendered
+test_omp_consumer_proof_gate_never_executes_candidate
+test_omp_candidate_artifacts_render_requested_settings_and_handle_continuation
+test_spawn_policy_matrix_stays_dormant_and_tmux_only
+
+echo "all fm-omp-harness tests passed"

--- a/tests/fm-omp-tools-live-e2e.test.sh
+++ b/tests/fm-omp-tools-live-e2e.test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# tests/fm-omp-tools-live-e2e.test.sh - opt-in proof gate for the candidate
+# OMP adapter's empty tool and settings boundary.
+set -u
+
+if [ "${FM_OMP_TOOLS_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_OMP_TOOLS_LIVE_E2E=1 to require the session-free OMP consumer proof"
+  exit 0
+fi
+
+printf '%s\n' \
+  "not ok - requested omp/17.2.9 has no supported session-free configuration and tool consumer; executable provenance, version, and effective behavior remain unproven; candidate remains dormant without resolving or executing OMP" >&2
+exit 1


### PR DESCRIPTION
Adds the OMP candidate adapter, kept hard dormant, plus a regression guard proving its rendered tool surface cannot inherit the operator's Claude tools directory.

## What this contains

Two commits, replayed cleanly onto current `main`:

1. `feat(harness): re-land dormant OMP candidate` - the adapter itself, reconciled against the narrower non-executing contract.
2. `test(omp): prove rendered tool containment` - the containment regression guard.

## Dormancy is unchanged

OMP remains hard dormant. `refuse_omp_unverified_gates` still refuses every runnable launch. This PR waives nothing: executable provenance, effective configuration, and lifecycle proof all still gate activation. The binary is never executed by anything here.

The provenance guard refuses in ~20ms with `family=live-harness-optin` under `FM_OMP_TOOLS_LIVE_E2E=1`, and skips cleanly with `gate_skip=optin` without it. The refusal duration is itself evidence that no binary is resolved.

## Why the containment test exists

This is not a hypothetical. An accidental ambient OMP run enumerated `~/.claude/tools` and attempted to load two operator scripts as its own tools. Both failed on format, but the attempt proves the tool-inheritance hazard is real.

The test builds a fake operator home containing those two actual filenames, renders the manifest with `HOME` pointed at it, and asserts from known-good literals that `PI_CODING_AGENT_DIR` is the isolated directory and that neither the tools path nor either filename appears anywhere in the rendered output.

**Honest red-state note:** the adapter already isolated correctly, so no authentic pre-fix failure was observable without falsifying correct behavior. This is a regression guard over already-correct behavior, not a red-to-green fix, and no invented red state is claimed. That the guard *binds* was proven instead by controlled mutation: changing the expected literal made the suite exit 1 with `not ok - candidate OMP manifest inherited the captain Claude tools directory`, then it was reverted.

Isolation is argument-driven rather than `HOME`-derived, so if the renderer were ever changed to read `HOME`, the assertion fires.

## Documentation

`docs/verification/runtime-backends.md` states what is proven (isolated settings rendered, tool surface requested disabled, version pinned) and what is not (effective configuration, fallback isolation, effective tool construction). The 2026-08-24 RPC-invalidation finding and the Bun-cache `@oh-my-pi/pi-coding-agent` 18.0.4 finding are both preserved deliberately, so neither is re-attempted.

## Checks run locally

| Check | Result |
| --- | --- |
| `bin/fm-doc-audience-check.sh` | exit 0 |
| `bin/fm-lint.sh` over changed shell files | exit 0 |
| `bin/fm-test-run.sh tests/fm-omp-harness.test.sh` | exit 0, all passed |
| provenance guard, opt-in set | exit 1 in 20ms, designed refusal |
| provenance guard, opt-in absent | exit 0, `gate_skip=optin` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VneT4KxJB4wQCaK2FV6Ka1
