### PR TITLE
fix(fleet-sync): fast-forward a checkout parked on a non-default tracking branch

### DIFF
--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -370,7 +370,20 @@ sync_project() {
     # non-default named branch, a detached HEAD with unique commits, a dirty tree,
     # or <default> already checked out elsewhere - may hold real work, so it is
     # reported loudly and left untouched.
-    if [ -z "$cur" ] && [ "$dirty" = no ] \
+    tracking=$(git -C "$PROJ" rev-parse --abbrev-ref --symbolic-full-name "$cur@{u}" 2>/dev/null || true)
+    if [ -n "$cur" ] && [ "$dirty" = no ] && [ -n "$tracking" ] \
+        && git -C "$PROJ" rev-parse --verify --quiet "$tracking^{commit}" >/dev/null; then
+      # On a clean NON-default named branch that tracks a remote (e.g. the
+      # checkout lives on `staging`, not the default). Fast-forward THAT branch
+      # to its OWN upstream, not just the default - otherwise a checkout parked
+      # off the default silently drifts behind while nothing ever syncs it. This
+      # is the bug that let a `staging` checkout fall dozens of commits behind
+      # while the "stuck" warning compared it to origin/<default> (0 behind) and
+      # masked the real drift. Retarget the fast-forward below at the current
+      # branch and its own upstream.
+      DEFAULT="$cur"
+      BASE="$tracking"
+    elif [ -z "$cur" ] && [ "$dirty" = no ] \
         && git -C "$PROJ" merge-base --is-ancestor HEAD "$BASE" 2>/dev/null \
         && ! default_checked_out_elsewhere \
         && local_default_safe_for_recovery; then

--- a/tests/fm-fleet-sync.test.sh
+++ b/tests/fm-fleet-sync.test.sh
@@ -332,6 +332,35 @@ test_non_default_branch_is_stuck_untouched() {
   pass "non-default named branch is reported STUCK and left untouched"
 }
 
+# Regression: a clean checkout parked on a NON-default named branch that TRACKS a
+# remote (the real firstmate layout - proj-ts lives on `staging`, not `main`) must
+# be fast-forwarded to its OWN upstream, not left to drift while the default is
+# the only branch that ever syncs. This is the bug that let a staging checkout
+# fall dozens of commits behind while nothing synced it.
+test_non_default_tracking_branch_fast_forwards() {
+  local home clone work out
+  home=$(new_home)
+  clone=$(build_pair "$home" omicron)
+  work="$home/work-omicron"
+  # Publish `staging` on origin and put the clone on it, tracking origin/staging.
+  git -C "$work" push -q origin main:refs/heads/staging
+  git -C "$clone" fetch -q origin
+  git -C "$clone" checkout -q -b staging origin/staging
+  # Advance origin/STAGING only (not the default), so the sole fast-forward
+  # available is on the non-default branch.
+  commit_file "$work" file.txt staging-advance "staging advance"
+  git -C "$work" push -q origin HEAD:refs/heads/staging
+
+  out=$(run_sync "$home" "$clone")
+
+  assert_contains "$out" "omicron: synced" "clean non-default tracking branch fast-forwards to its own upstream"
+  assert_not_contains "$out" "STUCK" "a clean branch that tracks a remote is not flagged STUCK for being off the default"
+  [ "$(git -C "$clone" rev-parse staging)" = "$(git -C "$clone" rev-parse origin/staging)" ] \
+    || fail "staging was not fast-forwarded to origin/staging"
+  [ "$(git -C "$clone" symbolic-ref --short HEAD)" = "staging" ] || fail "checkout branch was changed"
+  pass "clean non-default branch tracking a remote fast-forwards to its own upstream"
+}
+
 test_diverged_is_stuck_untouched() {
   local home clone out before
   home=$(new_home)
@@ -699,6 +728,7 @@ test_detached_unique_commit_is_stuck_untouched
 test_detached_clean_ancestor_with_diverged_local_default_is_stuck_untouched
 test_dirty_is_stuck_untouched
 test_non_default_branch_is_stuck_untouched
+test_non_default_tracking_branch_fast_forwards
 test_diverged_is_stuck_untouched
 test_on_default_clean_behind_fast_forwards
 test_already_current_unchanged


### PR DESCRIPTION
## Why
The primary `proj-ts` checkout drifted **43 commits behind origin/staging** because `fm-fleet-sync` only fast-forwards each clone's **default branch** (`main`), and the checkout lives on `staging`. It was reported "stuck" but quantified against `origin/main` (0 behind), masking the real drift — so firstmate analyzed weeks-stale code as truth. This is the recurring "stale build" bite.

## Fix
A clean checkout on a non-default named branch that **tracks a remote** is now fast-forwarded to its **own** upstream (e.g. `staging` -> `origin/staging`). No-upstream branches, dirty trees, and diverged branches still report STUCK loudly and are left untouched.

## Validation
- New regression test `test_non_default_tracking_branch_fast_forwards`; full `fm-fleet-sync.test.sh` suite green (26/26).
- Live: drifted the real proj-ts `staging` back 2 commits, ran the patched sync -> `synced`, checkout returned to origin/staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)