### PR TITLE
feat(codex): route managed launches through multi-auth

### DIFF
--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -11,6 +11,7 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 | Interrupt | Single Escape. |
 | Skill invocation | `$<skill>`, for example `$no-mistakes`; `/<skill>` is Claude-only and Codex rejects it as "Unrecognized command". |
 | Resume | `codex resume <session-id>`, using the id printed on quit. |
+| Managed launch | `codex-multi-auth-codex`, forwarding to the official `codex` executable while metadata remains `harness=codex`. |
 | Model flag | `--model <model>`. |
 | Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'`, verified on codex-cli 0.142.1 whose installed schema contains `model_reasoning_effort`, active config uses it, and bundled catalog advertises only these four values while omitting `max`. |
 | Model discovery | Open the current interactive session's `/model` picker. |
@@ -18,6 +19,14 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 A directory trust dialog appears on the first run for a repository root: "Do you trust the contents of this directory?"
 Accept it with Enter and verify the instructions begin processing.
 The decision persists for the repository, so later worktrees of the same project skip it.
+
+## Managed launch boundary
+
+Every Firstmate-managed Codex ship worker, scout, and secondmate launches through `codex-multi-auth-codex`.
+`bin/fm-spawn.sh` resolves both the wrapper and the official `codex` executable before creating an endpoint, pins the official executable through the wrapper's documented per-process `CODEX_MULTI_AUTH_REAL_CODEX_BIN`, and refuses rather than falling back to unwrapped Codex when either executable is absent.
+The wrapper receives the existing Codex model, reasoning-effort, sandbox, prompt, hook, and turn-end arguments unchanged, while task metadata and all control-plane behavior continue to use `harness=codex`.
+Firstmate invokes no multi-auth login, logout, switch, pin, repair, or other account-management command at this boundary.
+`docs/configuration.md` owns operator setup, and `bin/fm-spawn.sh --help` owns the exact launch mechanics.
 
 ## Skill popup
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 ### Requirements
 
 - A verified primary agent harness: Claude Code, Grok, Pi, `pi-signed`, Codex, OpenCode, or Cursor Agent CLI.
+- Codex workers and secondmates additionally require the `codex-multi-auth-codex` forwarding wrapper; [Harness support](docs/configuration.md#harness-support) owns setup and fail-closed behavior.
 - Git and the GitHub CLI, authenticated through `gh auth login`.
 - The CLI and dependencies for your selected runtime backend; tmux is the reference default.
 
@@ -73,6 +74,7 @@ All three have verified turn-end guard paths when launched with their documented
 Pick whichever one matches your subscription and workflow.
 
 Codex and OpenCode are also verified and supported as primary harnesses; Codex uses bounded foreground checkpoints, and OpenCode uses a TUI plugin, so both carry more harness-specific supervision tradeoffs than the three co-primaries.
+When starting Firstmate itself under Codex and the same multi-account routing is wanted, launch `codex-multi-auth-codex` instead of the stock `codex` entrypoint.
 Cursor Agent CLI is verified as a primary too, using a tracked project-scope `.cursor/hooks.json` whose `stop` hook parks on the watcher between turns, closest in shape to Claude Code's.
 Launch it with `--trust`, or none of its project hooks load; it also has no turn-end hook in headless `cursor-agent -p`, so run the primary session interactively.
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -120,6 +120,12 @@
 #   a failed or inconclusive probe omits it so older Pi versions remain launchable.
 #   A missing selected executable refuses before endpoint creation, and pi-signed
 #   never falls back to pi.
+#   Every verified harness=codex launch resolves both codex-multi-auth-codex and
+#   the official codex executable before endpoint creation. It launches the
+#   absolute wrapper path with the official binary pinned through
+#   CODEX_MULTI_AUTH_REAL_CODEX_BIN, and never falls back to bare codex. A raw
+#   launch command whose executable is codex is refused because it would bypass
+#   that required boundary; use --harness codex and the ordinary profile flags.
 #   config/secondmate-harness may also carry an optional model and effort as extra
 #   whitespace-separated tokens ("<harness> [<model>] [<effort>]"). For a
 #   --secondmate spawn, those tokens apply only when this spawn also resolves its
@@ -167,6 +173,8 @@
 #   $vars and silently breaks ad-hoc `for ... in $pairs` loops).
 #   Launch templates live in launch_template() below; placeholders replaced before launch:
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
+#     __CODEXWRAPPER__ quoted absolute codex-multi-auth-codex forwarding wrapper
+#     __CODEXBIN__ quoted absolute official Codex CLI selected as its vendor binary
 #     __PIBIN__    quoted concrete Pi-family executable path resolved from PATH
 #     __PITUIMODE__ optional --tui-mode regular when that executable advertises it
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
@@ -1230,7 +1238,7 @@ shell_quote() {
   printf "'"
 }
 
-resolve_pi_executable() {
+resolve_executable() {
   local candidate dir
   candidate=$(type -P -- "$1" 2>/dev/null) || return 1
   [ -x "$candidate" ] || return 1
@@ -1280,9 +1288,9 @@ launch_template() {
     claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '\''{"feedbackDrafts":"off"}'\'' __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'CODEX_MULTI_AUTH_REAL_CODEX_BIN=__CODEXBIN__ __CODEXWRAPPER__ __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'CODEX_MULTI_AUTH_REAL_CODEX_BIN=__CODEXBIN__ __CODEXWRAPPER__ __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
@@ -1418,6 +1426,11 @@ case "$ARG3" in
     ;;
 esac
 
+if [ "$RAW_LAUNCH" -eq 1 ] && [ "$HARNESS" = codex ]; then
+  echo "error: a raw codex launch would bypass the required codex-multi-auth-codex wrapper; use --harness codex with ordinary model and effort flags" >&2
+  exit 1
+fi
+
 # muse and gemini are verified as CREWMATE/SCOUT adapters only. A secondmate is
 # a firstmate instance, so it needs a primary supervision protocol.
 # gemini has none: docs/supervision-protocols/ carries no gemini wake protocol
@@ -1434,8 +1447,18 @@ if [ "$KIND" = secondmate ] && { [ "$HARNESS" = muse ] || [ "$HARNESS" = gemini 
 fi
 
 case "$HARNESS" in
+  codex)
+    CODEX_MULTI_AUTH_BIN=$(resolve_executable codex-multi-auth-codex) || {
+      echo "error: harness=codex requires codex-multi-auth-codex on PATH; install codex-multi-auth or select a different verified harness" >&2
+      exit 1
+    }
+    CODEX_BIN=$(resolve_executable codex) || {
+      echo "error: harness=codex requires the official codex CLI on PATH; install @openai/codex or select a different verified harness" >&2
+      exit 1
+    }
+    ;;
   pi|pi-signed)
-    PI_BIN=$(resolve_pi_executable "$HARNESS") || {
+    PI_BIN=$(resolve_executable "$HARNESS") || {
       echo "error: $HARNESS executable not found on PATH; install it or select a different verified harness" >&2
       exit 1
     }
@@ -3158,6 +3181,10 @@ LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 case "$HARNESS" in
+  codex)
+    LAUNCH=${LAUNCH//__CODEXWRAPPER__/"$(shell_quote "$CODEX_MULTI_AUTH_BIN")"}
+    LAUNCH=${LAUNCH//__CODEXBIN__/"$(shell_quote "$CODEX_BIN")"}
+    ;;
   pi|pi-signed) LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"} ;;
   cursor) LAUNCH=${LAUNCH//__CURSORBIN__/"$(shell_quote "$CURSOR_BIN")"} ;;
   gemini) LAUNCH=${LAUNCH//__GEMINISETTINGS__/"$(shell_quote "$STATE_REAL/$ID.gemini-settings.json")"} ;;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -297,6 +297,10 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 ## Harness support
 
 claude, codex, opencode, pi, pi-signed, grok, kimi, and cursor are empirically verified for crewmate and secondmate launches; gemini is verified for crewmate and scout launches only, and [README requirements](../README.md#requirements) own the set supported for the primary session.
+Firstmate-managed `harness=codex` launches require both the official `codex` CLI and the `codex-multi-auth-codex` forwarding wrapper from [`codex-multi-auth`](https://github.com/ndycode/codex-multi-auth) on `PATH`.
+Install the official CLI and `codex-multi-auth` on every local or remote host that may run a Codex worker or secondmate; if the wrapper is absent, `fm-spawn.sh` refuses before endpoint creation and never falls back to an unwrapped session.
+The operator still starts a Codex primary session explicitly, so use `codex-multi-auth-codex` there when the same account-routing behavior is wanted.
+The [Codex adapter reference](../.agents/skills/harness-adapters/references/harness/codex.md#managed-launch-boundary) owns the managed-launch invariant, while `fm-spawn.sh --help` owns exact command construction.
 A cursor secondmate or primary runs the tracked project-scope `.cursor/hooks.json` in its own home and must be launched with `--trust`, or no project hook loads; [`docs/supervision-protocols/cursor.md`](supervision-protocols/cursor.md) owns its supervision protocol.
 Cursor typed-submit confirmation is verified on tmux and Herdr only.
 On Zellij, cmux, and Orca a typed-plane Cursor send (a harness-native invocation or an explicit backend target; ordinary text steers ride the durable inbox and exit 0 at enqueue) lands, but `fm-send` reports delivery unconfirmed and exits non-zero because their shared submit core does not consult the busy footer; [runtime backend verification](verification/runtime-backends.md#cursor-agent-cli) owns the evidence and transcript-state boundary.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -107,7 +107,7 @@ These steps are never automated and are always reported rather than silently att
 - The first console login on that Mac, and automatic login in System Settings > Users & Groups when the machine runs headless and must come back on its own after a reboot.
 - FileVault, which holds a reboot at pre-boot authentication before any login session exists.
 - Installing any missing required tool that no safe wrapper can resolve.
-- The required remote tool set is `git`, `jq`, `herdr`, compatible `tasks-axi`, `treehouse`, and at least one of `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, or `kimi`.
+- The required remote tool set is `git`, `jq`, `herdr`, compatible `tasks-axi`, `treehouse`, and at least one of `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, or `kimi`; selecting `codex` additionally requires `codex-multi-auth-codex` as described in [Harness support](configuration.md#harness-support).
 - Each worker runtime's own `/login`, and any keychain password prompt that login needs.
 
 Firstmate never writes an auto-login password, never changes FileVault, and never stores an account password.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -87,6 +87,35 @@ Run the live guard after any harness upgrade and before trusting or refreshing t
 FM_HARNESS_LIVENESS_DRIFT=1 bin/fm-test-run.sh tests/fm-harness-liveness-drift-live-e2e.test.sh
 ```
 
+The Codex forwarding boundary was refreshed on 2026-09-04 with `codex-multi-auth` 2.12.0 and official `codex-cli` 0.153.2.
+The safe installed-wrapper check runs only version and help surfaces in an empty disposable directory, pins the official executable through `CODEX_MULTI_AUTH_REAL_CODEX_BIN`, and disables wrapper startup sync and app-bind setup.
+It neither sends a model request nor prints or changes account identity, selection, or credentials.
+
+Exact safe verification command:
+
+```sh
+scratch=$(mktemp -d ./scratchpad-codex-multi-auth.XXXXXX)
+codex_bin=$(command -v codex)
+(
+  cd "$scratch" || exit 1
+  CODEX_MULTI_AUTH_APP_BIND_INSTALL=0 CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL=0 CODEX_MULTI_AUTH_SYNC_CODEX_CLI=0 CODEX_MULTI_AUTH_AUTO_SYNC_ON_STARTUP=0 codex-multi-auth --version
+  CODEX_MULTI_AUTH_REAL_CODEX_BIN="$codex_bin" CODEX_MULTI_AUTH_APP_BIND_INSTALL=0 CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL=0 CODEX_MULTI_AUTH_SYNC_CODEX_CLI=0 CODEX_MULTI_AUTH_AUTO_SYNC_ON_STARTUP=0 codex-multi-auth-codex --version
+  CODEX_MULTI_AUTH_REAL_CODEX_BIN="$codex_bin" CODEX_MULTI_AUTH_APP_BIND_INSTALL=0 CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL=0 CODEX_MULTI_AUTH_SYNC_CODEX_CLI=0 CODEX_MULTI_AUTH_AUTO_SYNC_ON_STARTUP=0 codex-multi-auth-codex exec --help | sed -n '1p'
+)
+rmdir "$scratch"
+```
+
+Observed Codex result:
+
+```text
+2.12.0
+codex-cli 0.153.2
+Run Codex non-interactively
+```
+
+`tests/fm-tmux-agent-liveness.test.sh` separately runs real foreground processes in the wrapper-parent plus official-Codex-child shape and proves the existing foreground-process-group classifier still returns `alive`.
+Herdr uses registered-agent state rather than process names, while Zellij, Orca, and cmux have no recovery-grade process classifier, so no backend-specific identity branch changes.
+
 Bounded output from the run that produced the table:
 
 ```text

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -258,7 +258,11 @@ fm_test_make_spawn_fakebin() {
   shift
   fakebin=$(fm_fakebin "$dir")
   fm_test_fake_tmux_spawn "$fakebin"
-  fm_fake_exit0 "$fakebin" treehouse "$@"
+  # Every Firstmate-managed Codex launch requires the forwarding wrapper.
+  # Supplying it in the shared spawn fixture keeps unrelated suites isolated
+  # from the developer machine's installed package; missing-wrapper cases
+  # remove this stub explicitly and narrow PATH.
+  fm_fake_exit0 "$fakebin" treehouse codex codex-multi-auth-codex "$@"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -426,6 +426,7 @@ make_noop_tmux() {
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" codex codex-multi-auth-codex
   printf '%s\n' "$fakebin"
 }
 
@@ -660,7 +661,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" pi
+  fm_fake_exit0 "$fakebin" pi codex codex-multi-auth-codex
   printf '%s\n' "$fakebin"
 }
 
@@ -856,8 +857,8 @@ test_spawn_explicit_harness_does_not_inherit_secondmate_harness_tokens() {
   [ "$(meta_field "$meta" model)" = default ] || fail "explicit-harness-no-tokens: meta model should stay default"
   [ "$(meta_field "$meta" effort)" = default ] || fail "explicit-harness-no-tokens: meta effort should stay default"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "codex --dangerously-bypass-approvals-and-sandbox" \
-    "explicit-harness-no-tokens: launch did not use codex"
+  assert_contains "$launch" "codex-multi-auth-codex' --dangerously-bypass-approvals-and-sandbox" \
+    "explicit-harness-no-tokens: launch did not use the codex forwarding wrapper"
   assert_not_contains "$launch" "--model" "explicit-harness-no-tokens: launch must not carry a --model flag"
   assert_not_contains "$launch" "model_reasoning_effort" \
     "explicit-harness-no-tokens: launch must not carry a codex effort flag"
@@ -913,6 +914,13 @@ test_spawned_secondmate_uses_its_harness_supervision_model() {
 FM_ROOT_OVERRIDE="$sm" "$ROOT/bin/fm-guard.sh"
 SH
     chmod +x "$fakebin/$harness"
+    if [ "$harness" = codex ]; then
+      cat > "$fakebin/codex-multi-auth-codex" <<'SH'
+#!/usr/bin/env bash
+exec "${CODEX_MULTI_AUTH_REAL_CODEX_BIN:?}" "$@"
+SH
+      chmod +x "$fakebin/codex-multi-auth-codex"
+    fi
     launch=$(cat "$launchlog")
     out=$(PATH="$fakebin:$BASE_PATH" CLAUDECODE=1 bash -c "$launch" 2>&1)
     case "$harness" in

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -345,7 +345,7 @@ test_active_dispatch_profile_allows_explicit_harness() {
   assert_contains "$out" "spawned $id harness=codex" "spawn did not report explicit codex harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "'$FAKEBIN_DIR/codex-multi-auth-codex' --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
     "explicit harness launch did not thread model and effort"
   pass "active crew-dispatch profile allows an explicit resolved harness"
 }
@@ -412,9 +412,11 @@ test_codex_threads_model_and_effort() {
   expect_code 0 "$status" "codex spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not thread model and reasoning effort config"
-  pass "codex receives --model and model_reasoning_effort profile flags"
+  assert_contains "$launch" "CODEX_MULTI_AUTH_REAL_CODEX_BIN='$FAKEBIN_DIR/codex' '$FAKEBIN_DIR/codex-multi-auth-codex' --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not use the forwarding wrapper with the official CLI, model, and reasoning effort config"
+  assert_grep 'harness=codex' "$HOME_DIR/state/$id.meta" \
+    "the forwarding wrapper replaced codex's durable harness identity"
+  pass "codex uses the forwarding wrapper while preserving its vendor binary, profile, and identity"
 }
 
 test_codex_omits_invalid_max_effort() {
@@ -428,10 +430,79 @@ test_codex_omits_invalid_max_effort() {
   expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "'$FAKEBIN_DIR/codex-multi-auth-codex' --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
     "codex launch did not preserve the model flag when max effort was omitted"
   assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
   pass "codex omits unsupported max effort instead of passing a bad config value"
+}
+
+test_codex_wrapper_covers_scout_and_secondmate_launches() {
+  local rec scout_id secondmate_id sm out status launch
+  scout_id=profile-codex-scout-z4b
+  secondmate_id=profile-codex-secondmate-z4c
+  rec=$(make_spawn_case profile-codex-all-kinds codex "$scout_id" "$secondmate_id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$scout_id" "$PROJ_DIR" --scout)
+  status=$?
+  expect_code 0 "$status" "codex scout spawn through the forwarding wrapper should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "CODEX_MULTI_AUTH_REAL_CODEX_BIN='$FAKEBIN_DIR/codex' '$FAKEBIN_DIR/codex-multi-auth-codex'" \
+    "codex scout launch bypassed the forwarding wrapper"
+  assert_contains "$launch" "notify=[\\\"bash\\\",\\\"-c\\\",\\\"touch " \
+    "codex scout launch lost its turn-end notification config"
+
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$secondmate_id"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$secondmate_id" "$sm" --secondmate)
+  status=$?
+  expect_code 0 "$status" "codex secondmate spawn through the forwarding wrapper should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "CODEX_MULTI_AUTH_REAL_CODEX_BIN='$FAKEBIN_DIR/codex' '$FAKEBIN_DIR/codex-multi-auth-codex'" \
+    "codex secondmate launch bypassed the forwarding wrapper"
+  assert_not_contains "$launch" "notify=[" \
+    "codex secondmate launch gained the worker-only turn-end notification config"
+  assert_meta_profile "$HOME_DIR/state/$secondmate_id.meta" codex default default
+  pass "codex scouts and secondmates use the same required forwarding wrapper"
+}
+
+test_codex_missing_wrapper_refuses_before_endpoint_or_metadata() {
+  local rec id out status
+  id=profile-codex-wrapper-missing-z4d
+  rec=$(make_spawn_case profile-codex-wrapper-missing codex "$id")
+  read_case_record "$rec"
+  rm -f "$FAKEBIN_DIR/codex-multi-auth-codex"
+
+  out=$(PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 1 "$status" "codex spawn without the forwarding wrapper should fail closed"
+  assert_contains "$out" "harness=codex requires codex-multi-auth-codex on PATH" \
+    "missing-wrapper refusal did not name the required forwarding binary"
+  assert_contains "$out" "install codex-multi-auth" \
+    "missing-wrapper refusal did not provide the smallest recovery action"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "missing-wrapper refusal wrote task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "missing-wrapper refusal typed a launch command"
+  pass "codex refuses before endpoint creation when its forwarding wrapper is missing"
+}
+
+test_raw_codex_command_cannot_bypass_required_wrapper() {
+  local rec id out status
+  id=profile-codex-raw-bypass-z4e
+  rec=$(make_spawn_case profile-codex-raw-bypass codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" "codex --dangerously-bypass-approvals-and-sandbox")
+  status=$?
+  expect_code 1 "$status" "a raw codex command should not bypass the required forwarding wrapper"
+  assert_contains "$out" "raw codex launch would bypass the required codex-multi-auth-codex wrapper" \
+    "raw codex refusal did not identify the unsafe bypass"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "raw codex bypass refusal wrote task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "raw codex bypass refusal typed a launch command"
+  pass "raw codex commands cannot bypass the required forwarding wrapper"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -809,6 +880,9 @@ test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_omits_invalid_max_effort
+test_codex_wrapper_covers_scout_and_secondmate_launches
+test_codex_missing_wrapper_refuses_before_endpoint_or_metadata
+test_raw_codex_command_cannot_bypass_required_wrapper
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -53,6 +53,7 @@ export PATH
 # the executable identity, which is exactly the signal under test.
 ln -s "$SLEEP_BIN" "$LAB/bin/claude-link"
 ln -s "$SLEEP_BIN" "$LAB/bin/pi"
+ln -s "$SLEEP_BIN" "$LAB/bin/codex"
 ln -s "$SLEEP_BIN" "$LAB/bin/notaharness"
 # muse's installed binary is muse-bin-<version>: the launcher execs it, so the
 # version is the LIVE process name and it changes on every auto-update. Unlike
@@ -76,6 +77,16 @@ cat > "$LAB/bin/agent-launcher" <<SH
 wait
 SH
 chmod +x "$LAB/bin/agent-launcher"
+
+# codex-multi-auth-codex can remain as a parent while the official Codex CLI
+# runs as its child. The wrapper may therefore look like a generic Node or shell
+# process even though the same foreground process group still contains Codex.
+cat > "$LAB/bin/codex-multi-auth-codex" <<SH
+#!/bin/sh
+"$LAB/bin/codex" 900 &
+wait
+SH
+chmod +x "$LAB/bin/codex-multi-auth-codex"
 
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
@@ -215,6 +226,13 @@ wait_for_state "$SESSION:launcher" alive \
 comms_classify_agent "$SESSION:launcher" \
   || fail "the launcher's harness child must be visible in the foreground process group"
 pass "tmux liveness: a launcher whose own identity reads as a bare shell classifies alive from its harness child"
+
+new_window codex-wrapper "$LAB/bin/codex-multi-auth-codex"
+wait_for_state "$SESSION:codex-wrapper" alive \
+  || fail "a forwarding wrapper running the official Codex child must classify alive"
+comms_classify_agent "$SESSION:codex-wrapper" \
+  || fail "the official Codex child must remain visible in the wrapper's foreground process group"
+pass "tmux liveness: the codex-multi-auth parent plus official Codex child classifies alive"
 
 # --- an idle shell is still confidently dead --------------------------------
 


### PR DESCRIPTION
Route every Firstmate-managed Codex ship, scout, and secondmate launch through `codex-multi-auth-codex`, while keeping the official `codex` binary underneath and failing closed when the wrapper is missing.

This lets Firstmate-launched Codex sessions honor multi-account routing without changing durable harness identity or authentication state.