### PR TITLE
test: parse the CI workflow with python3 PyYAML instead of ruby

### DIFF
--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1298,27 +1298,29 @@ test_herdr_ci_family_run_has_a_step_timeout() {
   # The required Herdr lane's hang tripwire is the family-run *step* bound, not
   # the 75-minute job cap. Parse the workflow as YAML so nested `with.name`
   # artifact keys cannot masquerade as the step contract.
-  command -v ruby >/dev/null 2>&1 \
-    || fail "ruby is required to parse .github/workflows/ci.yml as YAML"
-  local json job_timeout step_timeout
-  json=$(ruby -ryaml -rjson -e '
-doc = YAML.load_file(ARGV[0])
-job = doc.fetch("jobs").fetch("tests-herdr")
-step = job.fetch("steps").find { |s|
-  s.is_a?(Hash) && s["name"] == "Run real-Herdr family (serial, required)"
-}
-raise "missing family-run step" if step.nil?
-raise "family-run step has no timeout-minutes" unless step.key?("timeout-minutes")
-puts JSON.generate(
-  "job_timeout" => job.fetch("timeout-minutes"),
-  "step_timeout" => step.fetch("timeout-minutes")
-)
-' "$ROOT/.github/workflows/ci.yml") \
-    || fail "could not parse tests-herdr timeouts from ci.yml"
-  job_timeout=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["job_timeout"])' <<<"$json") \
-    || fail "could not read job timeout from parsed workflow"
-  step_timeout=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["step_timeout"])' <<<"$json") \
-    || fail "could not read step timeout from parsed workflow"
+  if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+    echo "skip: python3 PyYAML not found (required to parse .github/workflows/ci.yml as YAML)"
+    return 0
+  fi
+  local timeouts job_timeout step_timeout
+  timeouts=$(python3 - "$ROOT/.github/workflows/ci.yml" <<'PY'
+import sys, yaml
+
+doc = yaml.safe_load(open(sys.argv[1]))
+job = doc["jobs"]["tests-herdr"]
+step = next((s for s in job["steps"]
+             if isinstance(s, dict)
+             and s.get("name") == "Run real-Herdr family (serial, required)"), None)
+if step is None:
+    raise SystemExit("missing family-run step")
+if "timeout-minutes" not in step:
+    raise SystemExit("family-run step has no timeout-minutes")
+print(job["timeout-minutes"], step["timeout-minutes"])
+PY
+  ) || fail "could not parse tests-herdr timeouts from ci.yml"
+  read -r job_timeout step_timeout <<<"$timeouts"
+  [ -n "$job_timeout" ] && [ -n "$step_timeout" ] \
+    || fail "could not read both timeouts from parsed workflow: $timeouts"
   [ "$job_timeout" = 75 ] \
     || fail "tests-herdr job backstop must stay 75 minutes, got $job_timeout"
   [ "$step_timeout" = 20 ] \

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1299,6 +1299,9 @@ test_herdr_ci_family_run_has_a_step_timeout() {
   # the 75-minute job cap. Parse the workflow as YAML so nested `with.name`
   # artifact keys cannot masquerade as the step contract.
   if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+    if [ "${GITHUB_ACTIONS:-}" = true ] || [ "${CI:-}" = true ]; then
+      fail "python3 PyYAML not found (required to parse .github/workflows/ci.yml as YAML)"
+    fi
     echo "skip: python3 PyYAML not found (required to parse .github/workflows/ci.yml as YAML)"
     return 0
   fi

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1298,6 +1298,15 @@ test_herdr_ci_family_run_has_a_step_timeout() {
   # The required Herdr lane's hang tripwire is the family-run *step* bound, not
   # the 75-minute job cap. Parse the workflow as YAML so nested `with.name`
   # artifact keys cannot masquerade as the step contract.
+  #
+  # PyYAML is not a declared prerequisite, so a contributor without it skips
+  # instead of being blocked. That skip must never stand under CI: the runner's
+  # detect_gate_skip only reads the *first* non-empty line of a script's output,
+  # so a skip printed by this case - one of the last in a long file - is
+  # invisible to it, and the run is still recorded gate_skip=false under a
+  # family whose expected class is none. The tripwire would go unchecked while
+  # the timing artifact called the script fully run, so a CI runner missing the
+  # parser is a hard failure rather than a quiet degradation.
   if ! python3 -c 'import yaml' >/dev/null 2>&1; then
     if [ "${GITHUB_ACTIONS:-}" = true ] || [ "${CI:-}" = true ]; then
       fail "python3 PyYAML not found (required to parse .github/workflows/ci.yml as YAML)"


### PR DESCRIPTION
## Intent

The captain asked, in his own words:

- "Can you check the firstmate repo for any other ruby references. Also can you check if there are any python plugins that can be used instead of what is being used for ruby?"
- then, on the finding: "Can you create a new branch with this change on my fork so we can submit it?"

Earlier in the same exchange, on discovering the dependency: "Does this repo actually have ruby in it?" and "when was the ruby dependency added?"

So: this repo has exactly one ruby reference, it is a redundant step in a function that already calls python3, and the captain wants that removed and offered upstream.

## What Changed

- `test_herdr_ci_family_run_has_a_step_timeout` in `tests/fm-test-run.test.sh` now parses `.github/workflows/ci.yml` with an inline `python3` + PyYAML heredoc instead of shelling out to `ruby -ryaml -rjson`, removing the repo's only ruby dependency; the parser prints both timeouts on one line, which the test reads with `read -r` rather than two follow-up `python3` JSON extractions.
- PyYAML is treated as optional rather than required: when `import yaml` fails the case prints `skip:` and returns, but under CI (`GITHUB_ACTIONS=true` or `CI=true`) the missing parser is a hard `fail` instead.
- Added a comment recording why that skip must fail closed under CI — `detect_gate_skip` only reads the first non-empty line of script output, so a skip emitted this late in the file would be recorded as `gate_skip=false` and the timeout tripwire would silently go unchecked.

## Risk Assessment

✅ Low: A 26-line change confined to one test function that swaps a redundant ruby parse for the python3 the function already used, with every failure branch verified to fail closed, the real ci.yml confirmed to parse to the exact asserted values, and no ruby reference left anywhere in the tree.

## Testing

Beyond the green baseline `--changed` run, I re-ran the changed script through the real runner (29/29 ok, including the Herdr CI-timeout guard) and then exercised the guard in isolation to prove behavior rather than passing counts: the base-commit version of the same test function hard-fails on this host because ruby is not installed, while the target version passes even with a hard-failing `ruby` stub on PATH; mutated ci.yml fixtures (step `timeout-minutes` deleted, and raised to 90 above the 75-min job cap) are both caught while an unmutated copy still passes; and with an ImportError-raising `yaml` shim on PYTHONPATH the test fails closed under both `GITHUB_ACTIONS=true` and `CI=true` and emits a named `skip:` with exit 0 locally, matching the recorded round-1 decision. A case-insensitive repo sweep shows zero ruby/Gemfile/rbenv references remain against the base commit's three, so the captain's stated goal is satisfied end to end. No visual evidence applies — this is a shell test-harness and CI-contract change with no rendered surface; the reviewer-visible artifact is the CLI transcript. Temp fixtures and shims were created only under /tmp and removed; the worktree is clean.

<details>
<summary>Evidence: Herdr CI-timeout guard: ruby-free proof, mutation kills, and both PyYAML-missing branches</summary>

Source: [Herdr CI-timeout guard: ruby-free proof, mutation kills, and both PyYAML-missing branches](https://github.com/aleytze/firstmate/blob/10dda0bbea5cb8379a2727b4486e32083c7d4aeb/.no-mistakes/evidence/drop-ruby-workflow-parse/herdr-ci-timeout-guard-transcript.txt)

<code>== 2. base commit 8f7b79c: the OLD ruby-based test on a machine without ruby ==&#10;not ok - ruby is required to parse .github/workflows/ci.yml as YAML&#10;exit=1&#10;&#10;== 3. target commit a2e19a7: same test, plus a &#39;ruby&#39; stub on PATH that hard-fails if invoked ==&#10;ok - Herdr CI family-run step times out at 20 min under a 75 min job backstop&#10;exit=0&#10;&#10;== 4. the guard is still live: mutate ci.yml, the test must catch it ==&#10;-- 4a. drop &#39;timeout-minutes&#39; from the &#39;Run real-Herdr family (serial, required)&#39; step --&#10;family-run step has no timeout-minutes&#10;not ok - could not parse tests-herdr timeouts from ci.yml&#10;exit=1&#10;-- 4b. raise that step&#39;s timeout to 90 (above the 75 min job cap) --&#10;not ok - family-run step timeout must be 20 minutes, got 90&#10;exit=1&#10;-- 4c. unmutated copy of the same fixture repo still passes --&#10;ok - Herdr CI family-run step times out at 20 min under a 75 min job backstop&#10;exit=0&#10;&#10;== 5. PyYAML unavailable (an &#39;import yaml&#39; that raises ImportError is shimmed onto PYTHONPATH) ==&#10;-- 5a. under GitHub Actions: must FAIL closed --&#10;not ok - python3 PyYAML not found (required to parse .github/workflows/ci.yml as YAML)&#10;exit=1&#10;-- 5b. under generic CI=true: must FAIL closed --&#10;not ok - python3 PyYAML not found (required to parse .github/workflows/ci.yml as YAML)&#10;exit=1&#10;-- 5c. local contributor (no CI env): named skip, exit 0 --&#10;skip: python3 PyYAML not found (required to parse .github/workflows/ci.yml as YAML)&#10;exit=0&#10;&#10;== 6. ruby inventory, before vs after ==&#10;$ git grep -In -iE &#39;ruby&#39; 8f7b79c # base commit&#10;8f7b79c:tests/fm-test-run.test.sh:1301: command -v ruby &gt;/dev/null 2&gt;&amp;1 \&#10;8f7b79c:tests/fm-test-run.test.sh:1302: || fail &#34;ruby is required to parse .github/workflows/ci.yml as YAML&#34;&#10;8f7b79c:tests/fm-test-run.test.sh:1304: json=$(ruby -ryaml -rjson -e &#39;&#10;&#10;$ grep -rIn -iE &#39;ruby|\.rb$|Gemfile|rbenv|bundle exec|gem install&#39; --exclude-dir=.git . # target commit&#10;(case-insensitive sweep: no matches - the repo&#39;s last ruby reference is gone)</code>

```text
\### Isolated exercise of test_herdr_ci_family_run_has_a_step_timeout (tests/fm-test-run.test.sh)
\### host: Linux 6.6.87.2-microsoft-standard-WSL2 | ruby: <not installed> | python3 PyYAML: 6.0.3

== 1. repo-wide scan for ruby references (user intent: zero remain) ==
$ grep -rInE "\bruby\b|\.rb\b|Gemfile|rbenv|bundler|gem install" --exclude-dir=.git .
(no matches -> repo has no ruby reference)

== 2. base commit 8f7b79c: the OLD ruby-based test on a machine without ruby ==
$ run-one.sh <repo> base-fm-test-run.test.sh
not ok - ruby is required to parse .github/workflows/ci.yml as YAML
exit=1

== 3. target commit a2e19a7: same test, plus a 'ruby' stub on PATH that hard-fails if invoked ==
$ PATH=$WORK/rubytrap:$PATH run-one.sh <repo> tests/fm-test-run.test.sh
ok - Herdr CI family-run step times out at 20 min under a 75 min job backstop
exit=0

== 4. the guard is still live: mutate ci.yml, the test must catch it ==
-- 4a. drop 'timeout-minutes' from the 'Run real-Herdr family (serial, required)' step --
family-run step has no timeout-minutes
not ok - could not parse tests-herdr timeouts from ci.yml
exit=1
-- 4b. raise that step's timeout to 90 (above the 75 min job cap) --
not ok - family-run step timeout must be 20 minutes, got 90
exit=1
-- 4c. unmutated copy of the same fixture repo still passes --
ok - Herdr CI family-run step times out at 20 min under a 75 min job backstop
exit=0

== 5. PyYAML unavailable (an 'import yaml' that raises ImportError is shimmed onto PYTHONPATH) ==
-- 5a. under GitHub Actions: must FAIL closed --
not ok - python3 PyYAML not found (required to parse .github/workflows/ci.yml as YAML)
exit=1
-- 5b. under generic CI=true: must FAIL closed --
not ok - python3 PyYAML not found (required to parse .github/workflows/ci.yml as YAML)
exit=1
-- 5c. local contributor (no CI env): named skip, exit 0 --
skip: python3 PyYAML not found (required to parse .github/workflows/ci.yml as YAML)
exit=0

== 6. ruby inventory, before vs after ==
$ git grep -In -iE 'ruby' 8f7b79c   # base commit
  8f7b79c:tests/fm-test-run.test.sh:1301:  command -v ruby >/dev/null 2>&1 \
  8f7b79c:tests/fm-test-run.test.sh:1302:    || fail "ruby is required to parse .github/workflows/ci.yml as YAML"
  8f7b79c:tests/fm-test-run.test.sh:1304:  json=$(ruby -ryaml -rjson -e '

$ grep -rIn -iE 'ruby|\.rb$|Gemfile|rbenv|bundle exec|gem install' --exclude-dir=.git .   # target commit
  (case-insensitive sweep: no matches - the repo's last ruby reference is gone)

== 7. host provenance of the replacement parser ==
$ dpkg -S $(python3 -c 'import yaml,os;print(os.path.dirname(yaml.__file__))')
  python3-yaml: /usr/lib/python3/dist-packages/yaml
  (PyYAML here is the distro python3-yaml dist-package, not a repo-installed dependency)
```
</details>
<details>
<summary>Evidence: bin/fm-test-run.sh tests/fm-test-run.test.sh — the changed script through the real runner</summary>

Source: [bin/fm-test-run.sh tests/fm-test-run.test.sh — the changed script through the real runner](https://github.com/aleytze/firstmate/blob/10dda0bbea5cb8379a2727b4486e32083c7d4aeb/.no-mistakes/evidence/drop-ruby-workflow-parse/fm-test-run-single-script.txt)

<code>FM_TEST_BEGIN 2026-09-04T15:13:18Z tests/fm-test-run.test.sh family=pure-contract-unit expected_gate_skip=none&#10;... (29 tests) ...&#10;ok - Herdr CI family-run step times out at 20 min under a 75 min job backstop&#10;ok - aggregate-json merges lane timing artifacts&#10;FM_TEST_END 2026-09-04T15:15:38Z tests/fm-test-run.test.sh exit=0 duration_ms=140076 gate_skip=false&#10;FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=140140</code>

```text
FM_TEST_BEGIN 2026-09-04T15:13:18Z tests/fm-test-run.test.sh family=pure-contract-unit expected_gate_skip=none
ok - exact suite coverage: --all lists every tests/*.test.sh once
ok - family selection returns a proper subset of the suite
ok - single-script selection lists exactly that path
ok - changed-file selection stays conservative (never silent full suite)
ok - runner and its documentation surfaces select their curated family, not just their contract owners
ok - changed selection covers dependents and fails closed for unmapped source
ok - a bin reference selects the referencing scripts, and consumers still select their curated families
ok - changed defaults to bounded automatic scheduling with serial override
ok - a plain script list defaults to bounded automatic concurrency without an automatic timeout
ok - family proofs run concurrently only within separate family phases
ok - empty changed selection emits deterministic text and JSON summaries
ok - timing markers and JSON artifact are valid
ok - aggregate exit reflects any script failure
ok - gate-skip accounting is honest and non-failing
ok - fail-on-gate-skip converts herdr-not-found into a hard failure
ok - exclude-family drops the named primary family after selection
ok - portable shard union, disjointness, and coverage guard hold
ok - portable serial shards are a deterministic disjoint cover of the serial lane
ok - coverage guard reports and bounds the unmeasured portable serial share
ok - portable serial shard lanes refuse mismatched, out-of-range, and countless names
ok - --jobs refuses non-proven / stateful selections
ok - --jobs admits and schedules a family with a recorded concurrent proof
ok - an unclassified new test stays serial while the proven residual family runs concurrently
ok - a concurrent run starts the longest-hint script first
ok - --per-script-timeout-secs turns a hung script into a bounded failure
ok - --max-wall-ms fails an over-budget run and refuses a malformed budget
ok - jobs scheduler runs proven scripts; failure propagates; non-proven refused
ok - Herdr CI family-run step times out at 20 min under a 75 min job backstop
ok - aggregate-json merges lane timing artifacts
FM_TEST_END 2026-09-04T15:15:38Z tests/fm-test-run.test.sh exit=0 duration_ms=140076 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=140140
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=140076 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-test-run.test.sh duration_ms=140076
exit=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f303c052f8cb65ad24862cf23c10798ace63ff17","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `tests/fm-test-run.test.sh:1301` - The Herdr CI step-timeout guard changed from fail-closed to silent skip. Previously a missing parser hard-failed (`fail &#34;ruby is required to parse .github/workflows/ci.yml as YAML&#34;`); now a missing PyYAML prints `skip:` and returns 0. PyYAML is a third-party module imported nowhere else in the repo, and no CI workflow installs it (`.github/workflows/ci.yml` only asserts `command -v python3`), while every other python3 call in this same file (lines 381, 476, 521, 559, 638, 706, 1236, 1361) is unguarded — so python3 is already treated as mandatory here and only the new yaml import is optional. Concrete path: on any runner or dev machine where `python3 -c &#39;import yaml&#39;` fails, this test returns green without ever reading ci.yml, so deleting `timeout-minutes: 20` from the `Run real-Herdr family (serial, required)` step is no longer caught. The skip is also invisible to the harness: `bin/fm-test-run.sh:1448 detect_gate_skip` only inspects the first non-empty output line, and this is the 28th of 29 tests in the file, so the run is recorded as `gate_skip=false` under family `pure-contract-unit` (whose `expected_gate_skip` is `none`) — the timing JSON labels the script as fully run when the contract was not checked. The remedy, not the defect, needs authorization: making it fail closed again is one line, but if the GitHub runner&#39;s system python3 lacks PyYAML that turns CI red, so the honest fix pairs fail-closed with an explicit dependency install step in ci.yml — a scope extension beyond &#34;remove the redundant ruby step&#34; that the author should decide.

🔧 Fix: fail closed on missing PyYAML under CI, skip locally
1 info still open:

- ℹ️ `tests/fm-test-run.test.sh:1301` - Tradeoff note, no action needed. The guard now hard-fails under CI when `python3 -c &#39;import yaml&#39;` fails, and `.github/workflows/ci.yml` installs ShellCheck, actionlint, tmux and tasks-axi but never PyYAML — so the lane carrying this script relies on the ubuntu-latest system python3 already providing it. That is exactly the fail-closed behavior the author asked for (&#34;Under CI the parser is present anyway and the guard must be live, so its absence there is a hard failure&#34;), and it is the correct direction: a green run that never read ci.yml was the defect being fixed. Recording it only because it is the single assumption in this change that cannot be settled from source; this run&#39;s CI step observes it directly. If it ever turns out false, the minimal remedy is one `pip install pyyaml` step, not a change to this function.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>baseline (already run): `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`</code>
- <code>`bin/fm-test-run.sh tests/fm-test-run.test.sh` — all 29 tests ok in 140s, gate_skip=false</code>
- <code>isolated single-test run of `test_herdr_ci_family_run_has_a_step_timeout` lifted from the target commit, with a hard-failing `ruby` stub prepended to PATH (passes, ruby never invoked)</code>
- <code>same function lifted from base commit 8f7b79c and run on this ruby-less host (fails: `ruby is required to parse .github/workflows/ci.yml as YAML`) — before/after proof the dependency was real</code>
- <code>mutation: fixture repo with `timeout-minutes` deleted from the `Run real-Herdr family (serial, required)` step → test fails</code>
- <code>mutation: fixture repo with that step&#39;s `timeout-minutes` raised to 90 (above the 75-min job cap) → `not ok - family-run step timeout must be 20 minutes, got 90`</code>
- `control: unmutated copy of the same fixture repo → ok`
- <code>`PYTHONPATH=&lt;yaml-shim-raising-ImportError&gt; GITHUB_ACTIONS=true` → fail closed, exit 1</code>
- <code>`PYTHONPATH=&lt;yaml-shim-raising-ImportError&gt; CI=true` → fail closed, exit 1</code>
- <code>`env -u CI -u GITHUB_ACTIONS PYTHONPATH=&lt;yaml-shim&gt;` → `skip: python3 PyYAML not found ...`, exit 0</code>
- <code>`grep -rIn -iE &#39;ruby|\.rb$|Gemfile|rbenv|bundle exec|gem install&#39; --exclude-dir=.git .` → no matches</code>
- <code>`git grep -In -iE &#39;ruby&#39; 8f7b79c` → the 3 removed lines, confirming the base had exactly one ruby reference</code>
- <code>`dpkg -S $(python3 -c &#39;import yaml,os;print(os.path.dirname(yaml.__file__))&#39;)` → distro `python3-yaml`, not a repo-installed dependency</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `CONTRIBUTING.md:121` - Judgment call, deliberately left unchanged. CONTRIBUTING.md:121 states that self-skipping tests are those needing &#34;a real optional backend or an explicit opt-in&#34; and that they &#34;skip themselves and print the tool or environment gate needed to enable them&#34;. This change adds a third, materially different skip class: a required contract test that skips on a missing python library locally but must fail closed under CI. The existing sentence is not false (it does not claim to be exhaustive, and it remains accurate for the classes it names), and extending it would push one test&#39;s mechanics into always-loaded contributor prose, against decision-tree tier 7 in .agents/skills/firstmate-coding-guidelines/SKILL.md (mechanics belong to the script&#39;s own header/comments). I therefore placed the invariant as a code comment in tests/fm-test-run.test.sh:1301 instead. If a future change adds a second CI-fail-closed skip, the general rule would earn a one-line home in CONTRIBUTING.md&#39;s testing section - worth a follow-up then, not now.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
