### PR TITLE
fix: allow Herdr relaunch after worker exit

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1207,9 +1207,8 @@ fm_backend_herdr_pane_idle_shell_pid() {  # <session> <pane-id>
 # It prints the foreground shell pid. With <root-only>=1, that shell must also
 # be Herdr's pane root shell; presentation cleanup depends on that stronger
 # identity because it signals the returned pid to remove the pane. With
-# <root-only>=0, the root-to-foreground subtree may be one unbranched wrapper
-# chain (the normal spawn shape is root shell -> treehouse -> task shell), but
-# no sibling or descendant process may survive anywhere under the pane root.
+# <root-only>=0, the only accepted subtree is root shell -> treehouse -> task
+# shell, with no sibling or descendant process anywhere under the pane root.
 fm_backend_herdr_idle_shell_from_process_info() {  # <json> <pane-id> <root-only>
   local info=$1 pane=$2 root_only=$3 shell_pid foreground_pgid count
   local process_pid name argv0 shell_name rows stat ps_bin
@@ -1248,11 +1247,12 @@ fm_backend_herdr_idle_shell_from_process_info() {  # <json> <pane-id> <root-only
     fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$shell_pid" || return 1
     fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$process_pid" || return 1
   fi
-  rows=$(LC_ALL=C "$ps_bin" -axo pid=,ppid= 2>/dev/null) || return 1
+  rows=$(LC_ALL=C "$ps_bin" -axo pid=,ppid=,comm= 2>/dev/null) || return 1
   printf '%s\n' "$rows" | awk -v root="$shell_pid" -v foreground="$process_pid" '
     {
       pid[NR] = $1
       parent[$1] = $2
+      command[$1] = $3
       present[$1]++
     }
     END {
@@ -1264,6 +1264,12 @@ fm_backend_herdr_idle_shell_from_process_info() {  # <json> <pane-id> <root-only
         current = parent[current]
       }
       path[root] = 1
+      if (foreground != root) {
+        wrapper = parent[foreground]
+        if (wrapper == root || parent[wrapper] != root) exit 1
+        sub(/^.*\//, "", command[wrapper])
+        if (command[wrapper] != "treehouse") exit 1
+      }
       for (i = 1; i <= NR; i++) {
         current = pid[i]
         walk++

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1202,13 +1202,17 @@ fm_backend_herdr_pane_idle_shell_pid() {  # <session> <pane-id>
   done
 }
 
-# fm_backend_herdr_pane_idle_shell_sample: one strict instantaneous
-# observation for fm_backend_herdr_pane_idle_shell_pid, which owns the proof
-# contract and the settle retry.
-fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
-  local session=$1 pane=$2 info shell_pid foreground_pgid count
+# fm_backend_herdr_idle_shell_from_process_info: the single structural owner
+# for proving that a pane process snapshot contains one childless idle shell.
+# It prints the foreground shell pid. With <root-only>=1, that shell must also
+# be Herdr's pane root shell; presentation cleanup depends on that stronger
+# identity because it signals the returned pid to remove the pane. With
+# <root-only>=0, the root-to-foreground subtree may be one unbranched wrapper
+# chain (the normal spawn shape is root shell -> treehouse -> task shell), but
+# no sibling or descendant process may survive anywhere under the pane root.
+fm_backend_herdr_idle_shell_from_process_info() {  # <json> <pane-id> <root-only>
+  local info=$1 pane=$2 root_only=$3 shell_pid foreground_pgid count
   local process_pid name argv0 shell_name rows stat ps_bin
-  info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null) || return 1
   printf '%s' "$info" | jq -e --arg pane "$pane" '
     .result.type == "pane_process_info"
     and .result.process_info.pane_id == $pane
@@ -1217,13 +1221,13 @@ fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
     '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
   foreground_pgid=$(printf '%s' "$info" | jq -er \
     '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
-  [ "$foreground_pgid" = "$shell_pid" ] || return 1
   count=$(printf '%s' "$info" | jq -er \
     '.result.process_info.foreground_processes | select(type == "array") | length' 2>/dev/null) || return 1
   [ "$count" -eq 1 ] || return 1
   process_pid=$(printf '%s' "$info" | jq -er \
-    '.result.process_info.foreground_processes[0].pid | select(type == "number") | floor' 2>/dev/null) || return 1
-  [ "$process_pid" = "$shell_pid" ] || return 1
+    '.result.process_info.foreground_processes[0].pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
+  [ "$process_pid" = "$foreground_pgid" ] || return 1
+  [ "$root_only" != 1 ] || [ "$process_pid" = "$shell_pid" ] || return 1
   name=$(printf '%s' "$info" | jq -er \
     '.result.process_info.foreground_processes[0].name | select(type == "string" and length > 0)' 2>/dev/null) || return 1
   argv0=$(printf '%s' "$info" | jq -er '
@@ -1232,6 +1236,7 @@ fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
     | select(type == "string" and length > 0)
   ' 2>/dev/null) || return 1
   shell_name=${name##*/}
+  shell_name=${shell_name#-}
   argv0=${argv0#-}
   argv0=${argv0##*/}
   [ "$argv0" = "$shell_name" ] || return 1
@@ -1239,15 +1244,82 @@ fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
 
   ps_bin=${FM_HERDR_PS_BIN:-ps}
   command -v "$ps_bin" >/dev/null 2>&1 || return 1
-  rows=$("$ps_bin" -axo pid=,ppid= 2>/dev/null) || return 1
-  printf '%s\n' "$rows" | awk -v shell="$shell_pid" '
-    $1 == shell { found++ }
-    $2 == shell { child++ }
-    END { exit(found == 1 && child == 0 ? 0 : 1) }
+  if [ "$process_pid" != "$shell_pid" ]; then
+    fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$shell_pid" || return 1
+    fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$process_pid" || return 1
+  fi
+  rows=$(LC_ALL=C "$ps_bin" -axo pid=,ppid= 2>/dev/null) || return 1
+  printf '%s\n' "$rows" | awk -v root="$shell_pid" -v foreground="$process_pid" '
+    {
+      pid[NR] = $1
+      parent[$1] = $2
+      present[$1]++
+    }
+    END {
+      if (present[root] != 1 || present[foreground] != 1) exit 1
+      current = foreground
+      while (current != root) {
+        if (current == "" || seen[current]++ || !(current in parent)) exit 1
+        path[current] = 1
+        current = parent[current]
+      }
+      path[root] = 1
+      for (i = 1; i <= NR; i++) {
+        current = pid[i]
+        walk++
+        while (current != "" && current != 0 && walked[current] != walk) {
+          walked[current] = walk
+          if (current == root) {
+            if (!(pid[i] in path)) exit 1
+            break
+          }
+          current = parent[current]
+        }
+      }
+    }
   ' || return 1
-  stat=$("$ps_bin" -p "$shell_pid" -o stat= 2>/dev/null | tr -d '[:space:]') || return 1
+  stat=$(LC_ALL=C "$ps_bin" -p "$process_pid" -o stat= 2>/dev/null | tr -d '[:space:]') || return 1
   case "$stat" in S*|I*) ;; *) return 1 ;; esac
-  printf '%s\n' "$shell_pid"
+  printf '%s\n' "$process_pid"
+}
+
+# fm_backend_herdr_pane_idle_shell_sample: one strict instantaneous
+# observation for fm_backend_herdr_pane_idle_shell_pid, which owns the proof
+# contract and the settle retry.
+fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
+  local session=$1 pane=$2 info
+  info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null) || return 1
+  fm_backend_herdr_idle_shell_from_process_info "$info" "$pane" 1
+}
+
+# fm_backend_herdr_pane_process_state: classify the live foreground process
+# evidence as idle-shell|active|unknown. A stale native registration can be
+# overridden only by the complete root-to-foreground idle-shell proof above.
+# Every other well-formed nonempty foreground shape stays active, regardless
+# of harness executable names; malformed or contradictory evidence is unknown.
+fm_backend_herdr_pane_process_state() {  # <session> <pane-id>
+  local session=$1 pane=$2 info
+  info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null) \
+    || { printf 'unknown'; return 0; }
+  if fm_backend_herdr_idle_shell_from_process_info "$info" "$pane" 0 >/dev/null; then
+    printf 'idle-shell'
+    return 0
+  fi
+  if printf '%s' "$info" | jq -e --arg pane "$pane" '
+    .result.type == "pane_process_info"
+    and .result.process_info.pane_id == $pane
+    and (.result.process_info.shell_pid | type == "number" and . > 1)
+    and (.result.process_info.foreground_process_group_id | type == "number" and . > 1)
+    and (.result.process_info.foreground_processes | type == "array" and length > 0)
+    and all(.result.process_info.foreground_processes[];
+      (.pid | type == "number" and . > 1)
+      and (.name | type == "string" and length > 0)
+      and ((.argv0 // .argv[0]) | type == "string" and length > 0))
+  ' >/dev/null 2>&1; then
+    printf 'active'
+  else
+    printf 'unknown'
+  fi
 }
 
 # fm_backend_herdr_projection_order_best_effort: place the exact workspace id
@@ -1863,11 +1935,11 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 }
 
 # fm_backend_herdr_pane_agent_state: classify <pane_id> in <session> as one of
-# dead|no-agent|live|unknown, purely from the JSON body of two read-only
-# calls - never from process exit status, since a business-logic "not found"
-# response is a normal, expected outcome here, not a call failure (real herdr
-# 0.7.1 exits 1 for it; the canned-response test fakes exit 0; parsing only
-# the JSON keeps this function correct against either).
+# dead|no-agent|live|unknown from pane presence, native agent registration,
+# and live process evidence. Business-logic "not found" responses are normal,
+# expected outcomes rather than process failures (real herdr 0.7.1 exits 1 for
+# them; canned-response tests may fake exit 0), so their JSON bodies remain the
+# authority.
 #
 #   dead     - `pane get` responds with error code pane_not_found: the pane
 #              itself is gone (closed, or its process died and herdr already
@@ -1883,18 +1955,22 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 #              stability across a server restart"), and what a future
 #              `resume_agents_on_restore = false` restore would produce too
 #              (a plain shell, never an agent).
-#   live     - `agent get` succeeds and reports a real agent_status (working,
-#              idle, done, or blocked - any registered value). An idle or
-#              blocked agent is still a genuine, still-registered agent, not
-#              a restored husk, so it is never a close-and-replace candidate.
-#   unknown  - anything else: an unparseable/unexpected response from either
-#              call, or a `pane get` success whose own echoed pane_id does not
-#              round-trip (guards against misreading a herdr response shape
-#              change as "the pane exists"). The caller must fail safe toward
-#              refusal here, never toward closing - this is the conservative
-#              backstop the husk check depends on.
+#   live     - `agent get` reports a registered agent and process-info reports
+#              a well-formed nonempty foreground process shape. This does not
+#              depend on a harness executable name, so every supported worker
+#              runtime shares the same proof.
+#   unknown  - anything else: an unparseable/unexpected response, contradictory
+#              process evidence, or a `pane get` success whose echoed pane_id
+#              does not round-trip. The caller must fail safe toward refusal,
+#              never toward closing.
+#
+# Herdr 0.8.2 leaves Pi's last `idle` registration behind after `/quit`. The
+# task endpoint has already returned to its real root-shell -> treehouse ->
+# childless task-shell chain at that point. That complete process proof is the
+# only condition allowed to override a stale registration to no-agent; a
+# missing, branching, busy, or malformed process tree remains live or unknown.
 fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
-  local session=$1 pane_id=$2 out code presence status
+  local session=$1 pane_id=$2 out code presence status process_state
   presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane_id")
   if [ "$presence" != present ]; then
     case "$presence" in
@@ -1911,7 +1987,13 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   fi
   status=$(printf '%s' "$out" | jq -r '.result.agent.agent_status // empty' 2>/dev/null)
   case "$status" in
-    working|idle|done|blocked) printf 'live' ;;
+    working|idle|done|blocked) ;;
+    *) printf 'unknown'; return 0 ;;
+  esac
+  process_state=$(fm_backend_herdr_pane_process_state "$session" "$pane_id")
+  case "$process_state" in
+    idle-shell) printf 'no-agent' ;;
+    active) printf 'live' ;;
     *) printf 'unknown' ;;
   esac
 }
@@ -1931,8 +2013,9 @@ fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
 # fm_backend_herdr_agent_state: recovery-grade state for the same session-start
 # sweep as the tmux classifier. It reuses the husk classifier rather than
 # creating a second Herdr state machine: a structurally gone pane is `missing`,
-# a confirmed agent-less pane is `dead`, a registered agent is `alive`, and an
-# unexpected or failed API read is `unreadable`.
+# a confirmed agent-less or stale-registration idle-shell pane is `dead`, a
+# registered agent with active process evidence is `alive`, and an unexpected
+# or failed read is `unreadable`.
 fm_backend_herdr_agent_state() {  # <target>
   local target=$1
   fm_backend_herdr_parse_target "$target" || { printf 'unreadable'; return 0; }

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -281,7 +281,7 @@ family_for_basename() {
     fm-grok-stop-live-e2e.test.sh|fm-harness-adapter-instructions-live-e2e.test.sh|\
     fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-muse-signals-live-e2e.test.sh|\
-    fm-herdr-version-floor-live-e2e.test.sh|\
+    fm-herdr-version-floor-live-e2e.test.sh|fm-control-herdr-pi-exit-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-branch-live-e2e.test.sh|\
     fm-pi-primary-live-e2e.test.sh|\
     fm-sessionstart-hook-live-e2e.test.sh|fm-sessionstart-instruction-refresh-live-e2e.test.sh|\
@@ -292,7 +292,7 @@ family_for_basename() {
       ;;
     fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
     fm-tmux-agent-liveness.test.sh|\
-    fm-control.test.sh|fm-control-relaunch.test.sh|\
+    fm-control.test.sh|fm-control-herdr-agent-state.test.sh|fm-control-relaunch.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|\
     fm-send-inbox.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|fm-claude-trust.test.sh|\

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -269,8 +269,10 @@ Create replaces only a confidently dead or no-agent husk, creates the replacemen
 This prevents closing the workspace's last tab before a replacement exists.
 
 The generic Herdr agent-liveness probe reuses the same classifier.
-A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
-Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
+A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent with a well-formed active foreground process becomes `alive`, and an unexpected or contradictory read becomes `unreadable`.
+Herdr can retain Pi's last idle registration after Pi exits, so a complete live-process proof may override only that stale registration: the pane root's process subtree must be one unbranched chain ending in one childless sleeping foreground shell with no surviving sibling or descendant.
+Any malformed process response, extra branch, foreground job, unrecognized shell, or unreadable operating-system process row preserves the conservative refusal.
+Unlike tmux process-name inspection, positive Herdr liveness composes native registration with a nonempty foreground process shape and does not guess any worker runtime from a generic interpreter name.
 
 The session-start sweep uses this probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -270,7 +270,7 @@ This prevents closing the workspace's last tab before a replacement exists.
 
 The generic Herdr agent-liveness probe reuses the same classifier.
 A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent with a well-formed active foreground process becomes `alive`, and an unexpected or contradictory read becomes `unreadable`.
-Herdr can retain Pi's last idle registration after Pi exits, so a complete live-process proof may override only that stale registration: the pane root's process subtree must be one unbranched chain ending in one childless sleeping foreground shell with no surviving sibling or descendant.
+Herdr can retain Pi's last idle registration after Pi exits, so a complete live-process proof may override a registration only when the pane root's process subtree is exactly root shell -> `treehouse` -> childless sleeping task shell, with no surviving sibling or descendant.
 Any malformed process response, extra branch, foreground job, unrecognized shell, or unreadable operating-system process row preserves the conservative refusal.
 Unlike tmux process-name inspection, positive Herdr liveness composes native registration with a nonempty foreground process shape and does not guess any worker runtime from a generic interpreter name.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -581,6 +581,36 @@ The CLI matrix was checked directly:
 All destructive verification used `bin/fm-herdr-lab.sh` with a non-default `fm-lab-` name and a byte-identical default-session tripwire.
 No ambient `herdr server stop` command is a supported test operation.
 
+### Post-exit agent registration
+
+Measured 2026-09-04 against Herdr 0.8.2 and Pi 0.84.4 using OpenAI `gpt-5.6-sol` in a guarded named lab.
+The public exit command delivered Pi's `/quit`, after which `herdr agent get` still reported the old Pi registration as idle while `pane process-info` reported one foreground `/bin/zsh` and the real process table showed the pane root shell, `treehouse get`, and that childless sleeping task shell as one unbranched chain.
+The old registry-only classifier therefore returned alive and made the public relaunch deliver a second exit command into the shell before refusing that Pi had not stopped.
+The process-backed classifier returned dead for the same stale registration, while a registered non-shell foreground process remained alive and malformed process evidence became unreadable.
+The public relaunch then reused the exact endpoint and launched a new Pi agent successfully.
+
+Portable public-interface coverage uses real shell processes and a scripted Herdr protocol surface:
+
+```sh
+tests/fm-control-herdr-agent-state.test.sh
+```
+
+Refresh the credentialed real-harness proof without invoking Claude or Anthropic models:
+
+```sh
+FM_HERDR_PI_EXIT_LIVE=1 \
+  FM_HERDR_PI_EXIT_MODEL=gpt-5.6-sol \
+  tests/fm-control-herdr-pi-exit-live-e2e.test.sh
+```
+
+Observed output:
+
+```text
+ok - live Herdr/Pi: stale idle registration over the post-exit shell no longer blocks public relaunch (gpt-5.6-sol)
+```
+
+The classifier remains runtime-neutral: every supported worker runtime reaches the same native-registration plus process-shape composition, while tmux retains its independent process-name classifier and Zellij, Orca, and cmux remain without recovery-grade agent-state authority.
+
 ### Submit confirmation
 
 Measured 2026-08-19 against Herdr 0.8.0 and Claude Code 2.1.236 in an isolated `fm-lab-` session.
@@ -933,8 +963,9 @@ ok - real herdr: no control verb removed the endpoint or the task's local copy
 ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
 ```
 
-The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
-That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
+The smoke test composes `herdr pane report-agent` with a real foreground command so a registered agent has independent active process evidence, and leaves the no-registration pane at its real shell.
+No provider-backed agent is launched.
+That command is the uncredentialed guard that refreshes the base lifecycle record; use the GPT-only live guard under [Post-exit agent registration](#post-exit-agent-registration) to refresh the stale-registration boundary after a Herdr or Pi upgrade.
 
 ### Away-mode transport
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -169,7 +169,7 @@ Both recorded runtime identities now classify the exact `pi-launcher` foreground
 
 Backend applicability was reviewed across every spawn adapter.
 Tmux needs the exact `pi-launcher`, `pi-signed`, `pi`, and `Pi` process identities for recovery-grade liveness.
-Herdr uses native registered-agent state and needs no process-name branch.
+Herdr composes native registered-agent state with structural foreground-process evidence and needs no worker-runtime process-name branch.
 Zellij has no verified recovery-grade agent process probe, while Orca and cmux do not support secondmate spawns, so those three retain their existing generic ordinary-launch semantics without a new liveness matcher.
 
 The current classifier matrix and its refresh guard are recorded in [Composer classification matrix](#composer-classification-matrix), with portable shape coverage in `tests/fm-composer-lib.test.sh` and `tests/fm-composer-ghost.test.sh`.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1509,7 +1509,7 @@ make_death_lab() {  # <dir> <shell-pid>
   cat > "$dir/ps" <<SH
 #!/usr/bin/env bash
 case "\$*" in
-  "-axo pid=,ppid=") printf '1 0\n$pid 1\n' ;;
+  "-axo pid=,ppid=,comm=") printf '1 0 init\n$pid 1 zsh\n' ;;
   "-p $pid -o stat=") printf 'Ss+\n' ;;
   "-p $pid -o comm=") printf -- '-zsh\n' ;;
   *) exit 1 ;;

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -627,8 +627,10 @@ test_create_task_refuses_duplicate_label_when_agent_live() {
   printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
   # 3: pane get -> the pane structurally exists
   printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
-  # 4: agent get -> a genuinely registered, live agent (idle, not just working)
+  # 4: agent get -> a genuinely registered agent (idle, not just working)
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/4.out"
+  # 5: process-info -> a well-formed active foreground process
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":123,"foreground_process_group_id":456,"foreground_processes":[{"pid":456,"name":"node","argv0":"pi"}]}}}\n' > "$resp/5.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-dup1 /tmp/proj' "$ROOT" 2>&1 )
@@ -650,6 +652,7 @@ test_create_task_refuses_when_any_duplicate_label_is_live() {
   printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}\n' > "$resp/5.out"
   printf '{"result":{"pane":{"pane_id":"w1:p3"}}}\n' > "$resp/6.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/7.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p3","shell_pid":123,"foreground_process_group_id":456,"foreground_processes":[{"pid":456,"name":"node","argv0":"pi"}]}}}\n' > "$resp/8.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-mixed1 /tmp/proj' "$ROOT" 2>&1 )
@@ -2825,6 +2828,7 @@ test_projection_recovery_is_read_only_and_refuses_live_duplicate_risk() {
   printf '{"result":{"panes":[{"pane_id":"w1:p1","tab_id":"w1:t1"}]}}\n' > "$resp/2.out"
   printf '{"result":{"pane":{"pane_id":"w1:p1"}}}\n' > "$resp/3.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/4.out"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p1","shell_pid":123,"foreground_process_group_id":456,"foreground_processes":[{"pid":456,"name":"node","argv0":"pi"}]}}}\n' > "$resp/5.out"
   out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_recovery_allows_flat fmtest "$1" task-p3' "$ROOT" "$journal" 2>&1)
   status=$?

--- a/tests/fm-control-herdr-agent-state.test.sh
+++ b/tests/fm-control-herdr-agent-state.test.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Herdr lifecycle classification through the public control interface.
+# The fake CLI supplies native registry/process JSON while real shell processes
+# prove the stale-registration topology against the operating-system process table.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
+
+TMP_ROOT=$(fm_test_tmproot fm-control-herdr-agent-state)
+HOME_DIR="$TMP_ROOT/home"
+FAKEBIN="$TMP_ROOT/fakebin"
+PROC="$TMP_ROOT/process"
+mkdir -p "$HOME_DIR/state" "$HOME_DIR/data/hs" "$FAKEBIN" "$PROC/wt"
+printf '# lifecycle fixture\n' > "$HOME_DIR/data/hs/brief.md"
+: > "$TMP_ROOT/herdr.log"
+mkfifo "$PROC/hold"
+
+cat > "$PROC/leaf.sh" <<'SH'
+#!/usr/bin/env bash
+echo "$$" > "$1/leaf.pid"
+IFS= read -r _ < "$1/hold"
+SH
+cat > "$PROC/middle.sh" <<'SH'
+#!/usr/bin/env bash
+echo "$$" > "$1/middle.pid"
+bash "$1/leaf.sh" "$1" &
+wait
+SH
+cat > "$PROC/root.sh" <<'SH'
+#!/usr/bin/env bash
+echo "$$" > "$1/root.pid"
+bash "$1/middle.sh" "$1" &
+wait
+SH
+cat > "$PROC/active-root.sh" <<'SH'
+#!/usr/bin/env bash
+echo "$$" > "$1/active-root.pid"
+sleep 300 &
+echo "$!" > "$1/active.pid"
+wait
+SH
+chmod +x "$PROC/leaf.sh" "$PROC/middle.sh" "$PROC/root.sh" "$PROC/active-root.sh"
+bash "$PROC/root.sh" "$PROC" &
+TREE_PID=$!
+bash "$PROC/active-root.sh" "$PROC" 2>/dev/null &
+ACTIVE_TREE_PID=$!
+
+cleanup() {
+  local leaf_pid active_pid
+  leaf_pid=$(cat "$PROC/leaf.pid" 2>/dev/null || true)
+  if [ -n "$leaf_pid" ] && kill -0 "$leaf_pid" 2>/dev/null; then
+    printf 'release\n' > "$PROC/hold" 2>/dev/null || true
+  else
+    kill "$TREE_PID" 2>/dev/null || true
+  fi
+  active_pid=$(cat "$PROC/active.pid" 2>/dev/null || true)
+  [ -z "$active_pid" ] || kill "$active_pid" 2>/dev/null || true
+  wait "$TREE_PID" 2>/dev/null || true
+  wait "$ACTIVE_TREE_PID" 2>/dev/null || true
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+attempt=0
+while { [ ! -s "$PROC/root.pid" ] || [ ! -s "$PROC/leaf.pid" ] \
+  || [ ! -s "$PROC/active-root.pid" ] || [ ! -s "$PROC/active.pid" ]; } && [ "$attempt" -lt 100 ]; do
+  sleep 0.02
+  attempt=$((attempt + 1))
+done
+[ -s "$PROC/root.pid" ] && [ -s "$PROC/leaf.pid" ] \
+  && [ -s "$PROC/active-root.pid" ] && [ -s "$PROC/active.pid" ] \
+  || fail "could not start the real idle-shell and active-process trees"
+ROOT_PID=$(cat "$PROC/root.pid")
+LEAF_PID=$(cat "$PROC/leaf.pid")
+ACTIVE_ROOT_PID=$(cat "$PROC/active-root.pid")
+ACTIVE_PID=$(cat "$PROC/active.pid")
+
+cat > "$FAKEBIN/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "$FM_HERDR_LOG"
+case "${1:-} ${2:-}" in
+  "status --json")
+    printf '{"client":{"version":"0.8.2","protocol":19},"server":{"running":true}}\n'
+    ;;
+  "pane get")
+    printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n'
+    ;;
+  "agent get")
+    printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n'
+    ;;
+  "pane process-info")
+    case "$(cat "$FM_HERDR_MODE")" in
+      stale)
+        printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"bash","argv0":"bash"}]}}}\n' \
+          "$FM_HERDR_ROOT_PID" "$FM_HERDR_LEAF_PID" "$FM_HERDR_LEAF_PID"
+        ;;
+      alive)
+        printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"sleep","argv0":"sleep"}]}}}\n' \
+          "$FM_HERDR_ACTIVE_ROOT_PID" "$FM_HERDR_ACTIVE_PID" "$FM_HERDR_ACTIVE_PID"
+        ;;
+      ambiguous)
+        printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":%s,"foreground_processes":[]}}}\n' \
+          "$FM_HERDR_ROOT_PID"
+        ;;
+    esac
+    ;;
+  "pane send-keys") : ;;
+  *) : ;;
+esac
+SH
+chmod +x "$FAKEBIN/herdr"
+
+cat > "$HOME_DIR/state/hs.meta" <<EOF
+window=fmtest:w1:p2
+endpoint_task_id=hs
+worktree=$PROC/wt
+project=$PROC/wt
+harness=pi
+kind=ship
+mode=local-only
+yolo=off
+model=gpt-5.6-sol
+effort=low
+backend=herdr
+herdr_session=fmtest
+herdr_workspace_id=w1
+herdr_tab_id=w1:t2
+herdr_pane_id=w1:p2
+EOF
+
+run_control() {
+  env PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" HERDR_SESSION=fmtest \
+    FM_HERDR_LOG="$TMP_ROOT/herdr.log" FM_HERDR_MODE="$TMP_ROOT/mode" \
+    FM_HERDR_ROOT_PID="$ROOT_PID" FM_HERDR_LEAF_PID="$LEAF_PID" \
+    FM_HERDR_ACTIVE_ROOT_PID="$ACTIVE_ROOT_PID" FM_HERDR_ACTIVE_PID="$ACTIVE_PID" \
+    FM_CONTROL_POLL=0.01 FM_CONTROL_SETTLE_WAIT=0.01 \
+    "$ROOT/bin/fm-control.sh" "$@" 2>&1
+}
+
+printf 'stale\n' > "$TMP_ROOT/mode"
+: > "$TMP_ROOT/herdr.log"
+out=$(run_control hs exit) || fail "a stale Pi registration over a real idle shell should be already stopped: $out"
+assert_contains "$out" "already-stopped hs" "the public exit command did not recognize the post-Pi idle shell"
+assert_not_contains "$(cat "$TMP_ROOT/herdr.log")" "pane send-keys" "an agent-free shell must receive no lifecycle input"
+pass "fm-control herdr: a stale Pi registration over a real idle-shell process tree is already stopped"
+
+printf 'alive\n' > "$TMP_ROOT/mode"
+: > "$TMP_ROOT/herdr.log"
+out=$(run_control hs interrupt) || fail "a registered agent with an active foreground process should remain live: $out"
+assert_contains "$out" "interrupt-delivered hs" "the public interrupt command did not accept the proven-live shape"
+assert_contains "$(cat "$TMP_ROOT/herdr.log")" "pane send-keys w1:p2 escape" "the proven-live agent did not receive its interrupt key"
+pass "fm-control herdr: a registered agent with an active process remains live"
+
+printf 'ambiguous\n' > "$TMP_ROOT/mode"
+: > "$TMP_ROOT/herdr.log"
+if out=$(run_control hs exit); then
+  fail "ambiguous process evidence must refuse lifecycle input: $out"
+fi
+assert_contains "$out" "reads 'unreadable'" "the ambiguous-process refusal did not preserve the conservative verdict"
+assert_not_contains "$(cat "$TMP_ROOT/herdr.log")" "pane send-keys" "ambiguous process evidence must receive no lifecycle input"
+pass "fm-control herdr: ambiguous process evidence refuses instead of licensing a duplicate or lifecycle input"

--- a/tests/fm-control-herdr-agent-state.test.sh
+++ b/tests/fm-control-herdr-agent-state.test.sh
@@ -8,6 +8,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
+command -v cc >/dev/null 2>&1 || { echo "skip: cc not found (required by the process-topology fixture)"; exit 0; }
 
 TMP_ROOT=$(fm_test_tmproot fm-control-herdr-agent-state)
 HOME_DIR="$TMP_ROOT/home"
@@ -17,22 +18,28 @@ mkdir -p "$HOME_DIR/state" "$HOME_DIR/data/hs" "$FAKEBIN" "$PROC/wt"
 printf '# lifecycle fixture\n' > "$HOME_DIR/data/hs/brief.md"
 : > "$TMP_ROOT/herdr.log"
 mkfifo "$PROC/hold"
+mkfifo "$PROC/live-hold"
 
 cat > "$PROC/leaf.sh" <<'SH'
 #!/usr/bin/env bash
 echo "$$" > "$1/leaf.pid"
 IFS= read -r _ < "$1/hold"
 SH
-cat > "$PROC/middle.sh" <<'SH'
+cat > "$PROC/live-leaf.sh" <<'SH'
 #!/usr/bin/env bash
-echo "$$" > "$1/middle.pid"
-bash "$1/leaf.sh" "$1" &
-wait
+echo "$$" > "$1/live-leaf.pid"
+IFS= read -r _ < "$1/live-hold"
 SH
 cat > "$PROC/root.sh" <<'SH'
 #!/usr/bin/env bash
 echo "$$" > "$1/root.pid"
-bash "$1/middle.sh" "$1" &
+"$1/treehouse" "$1/leaf.sh" "$1" &
+wait
+SH
+cat > "$PROC/live-root.sh" <<'SH'
+#!/usr/bin/env bash
+echo "$$" > "$1/live-root.pid"
+"$1/treehouse" "$1/agent" "$1/live-leaf.sh" "$1" &
 wait
 SH
 cat > "$PROC/active-root.sh" <<'SH'
@@ -42,23 +49,47 @@ sleep 300 &
 echo "$!" > "$1/active.pid"
 wait
 SH
-chmod +x "$PROC/leaf.sh" "$PROC/middle.sh" "$PROC/root.sh" "$PROC/active-root.sh"
+cat > "$PROC/wrapper.c" <<'C'
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+int main(int argc, char **argv) {
+  pid_t child;
+  int status;
+  if (argc < 2 || (child = fork()) < 0) return 1;
+  if (child == 0) { execv(argv[1], argv + 1); return 1; }
+  return waitpid(child, &status, 0) < 0 ? 1 : status;
+}
+C
+cc "$PROC/wrapper.c" -o "$PROC/treehouse"
+cc "$PROC/wrapper.c" -o "$PROC/agent"
+chmod +x "$PROC/leaf.sh" "$PROC/live-leaf.sh" "$PROC/root.sh" \
+  "$PROC/live-root.sh" "$PROC/active-root.sh" "$PROC/treehouse" "$PROC/agent"
 bash "$PROC/root.sh" "$PROC" &
 TREE_PID=$!
+bash "$PROC/live-root.sh" "$PROC" &
+LIVE_TREE_PID=$!
 bash "$PROC/active-root.sh" "$PROC" 2>/dev/null &
 ACTIVE_TREE_PID=$!
 
 cleanup() {
-  local leaf_pid active_pid
+  local leaf_pid live_leaf_pid active_pid
   leaf_pid=$(cat "$PROC/leaf.pid" 2>/dev/null || true)
   if [ -n "$leaf_pid" ] && kill -0 "$leaf_pid" 2>/dev/null; then
     printf 'release\n' > "$PROC/hold" 2>/dev/null || true
   else
     kill "$TREE_PID" 2>/dev/null || true
   fi
+  live_leaf_pid=$(cat "$PROC/live-leaf.pid" 2>/dev/null || true)
+  if [ -n "$live_leaf_pid" ] && kill -0 "$live_leaf_pid" 2>/dev/null; then
+    printf 'release\n' > "$PROC/live-hold" 2>/dev/null || true
+  else
+    kill "$LIVE_TREE_PID" 2>/dev/null || true
+  fi
   active_pid=$(cat "$PROC/active.pid" 2>/dev/null || true)
   [ -z "$active_pid" ] || kill "$active_pid" 2>/dev/null || true
   wait "$TREE_PID" 2>/dev/null || true
+  wait "$LIVE_TREE_PID" 2>/dev/null || true
   wait "$ACTIVE_TREE_PID" 2>/dev/null || true
   rm -rf "$TMP_ROOT"
 }
@@ -66,17 +97,22 @@ trap cleanup EXIT
 
 attempt=0
 while { [ ! -s "$PROC/root.pid" ] || [ ! -s "$PROC/leaf.pid" ] \
+  || [ ! -s "$PROC/live-root.pid" ] || [ ! -s "$PROC/live-leaf.pid" ] \
   || [ ! -s "$PROC/active-root.pid" ] || [ ! -s "$PROC/active.pid" ]; } && [ "$attempt" -lt 100 ]; do
   sleep 0.02
   attempt=$((attempt + 1))
 done
-[ -s "$PROC/root.pid" ] && [ -s "$PROC/leaf.pid" ] \
+[ -s "$PROC/root.pid" ] && [ -s "$PROC/leaf.pid" ] && [ -s "$PROC/live-root.pid" ] \
+  && [ -s "$PROC/live-leaf.pid" ] \
   && [ -s "$PROC/active-root.pid" ] && [ -s "$PROC/active.pid" ] \
   || fail "could not start the real idle-shell and active-process trees"
 ROOT_PID=$(cat "$PROC/root.pid")
 LEAF_PID=$(cat "$PROC/leaf.pid")
 ACTIVE_ROOT_PID=$(cat "$PROC/active-root.pid")
 ACTIVE_PID=$(cat "$PROC/active.pid")
+LIVE_ROOT_PID=$(cat "$PROC/live-root.pid")
+LIVE_LEAF_PID=$(cat "$PROC/live-leaf.pid")
+AGENT_PID=$(ps -p "$LIVE_LEAF_PID" -o ppid= | tr -d '[:space:]')
 
 cat > "$FAKEBIN/herdr" <<'SH'
 #!/usr/bin/env bash
@@ -101,6 +137,10 @@ case "${1:-} ${2:-}" in
       alive)
         printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"sleep","argv0":"sleep"}]}}}\n' \
           "$FM_HERDR_ACTIVE_ROOT_PID" "$FM_HERDR_ACTIVE_PID" "$FM_HERDR_ACTIVE_PID"
+        ;;
+      live_agent_shell)
+        printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"bash","argv0":"bash"}]}}}\n' \
+          "$FM_HERDR_LIVE_ROOT_PID" "$FM_HERDR_LIVE_LEAF_PID" "$FM_HERDR_LIVE_LEAF_PID"
         ;;
       ambiguous)
         printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":%s,"foreground_processes":[]}}}\n' \
@@ -137,6 +177,8 @@ run_control() {
     FM_HERDR_LOG="$TMP_ROOT/herdr.log" FM_HERDR_MODE="$TMP_ROOT/mode" \
     FM_HERDR_ROOT_PID="$ROOT_PID" FM_HERDR_LEAF_PID="$LEAF_PID" \
     FM_HERDR_ACTIVE_ROOT_PID="$ACTIVE_ROOT_PID" FM_HERDR_ACTIVE_PID="$ACTIVE_PID" \
+    FM_HERDR_LIVE_ROOT_PID="$LIVE_ROOT_PID" FM_HERDR_AGENT_PID="$AGENT_PID" \
+    FM_HERDR_LIVE_LEAF_PID="$LIVE_LEAF_PID" \
     FM_CONTROL_POLL=0.01 FM_CONTROL_SETTLE_WAIT=0.01 \
     "$ROOT/bin/fm-control.sh" "$@" 2>&1
 }
@@ -154,6 +196,13 @@ out=$(run_control hs interrupt) || fail "a registered agent with an active foreg
 assert_contains "$out" "interrupt-delivered hs" "the public interrupt command did not accept the proven-live shape"
 assert_contains "$(cat "$TMP_ROOT/herdr.log")" "pane send-keys w1:p2 escape" "the proven-live agent did not receive its interrupt key"
 pass "fm-control herdr: a registered agent with an active process remains live"
+
+printf 'live_agent_shell\n' > "$TMP_ROOT/mode"
+: > "$TMP_ROOT/herdr.log"
+out=$(run_control hs interrupt) || fail "a live agent running a childless foreground shell should remain live: $out"
+assert_contains "$out" "interrupt-delivered hs" "the live-agent foreground shell was mistaken for a stale registration"
+assert_contains "$(cat "$TMP_ROOT/herdr.log")" "pane send-keys w1:p2 escape" "the live agent did not receive its interrupt key"
+pass "fm-control herdr: an arbitrary intermediate agent prevents stale-registration override"
 
 printf 'ambiguous\n' > "$TMP_ROOT/mode"
 : > "$TMP_ROOT/herdr.log"

--- a/tests/fm-control-herdr-pi-exit-live-e2e.test.sh
+++ b/tests/fm-control-herdr-pi-exit-live-e2e.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Live Herdr/Pi lifecycle guard (live-harness-optin family).
+# It spends one short OpenAI-backed Pi turn in a named non-default Herdr lab,
+# exits Pi through fm-control, proves Herdr retained the stale idle registration
+# over a real shell-only endpoint, and relaunches through the same public verb.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LAB_HELPER="$ROOT/bin/fm-herdr-lab.sh"
+
+fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
+pass() { printf 'ok - %s\n' "$1"; }
+
+if [ "${FM_HERDR_PI_EXIT_LIVE:-0}" != 1 ]; then
+  echo "skip: set FM_HERDR_PI_EXIT_LIVE=1 to run the real Herdr/Pi exit-and-relaunch guard"
+  exit 0
+fi
+for tool in herdr jq pi treehouse git; do
+  command -v "$tool" >/dev/null 2>&1 || fail "FM_HERDR_PI_EXIT_LIVE=1 but $tool is not installed"
+done
+[ -x "$LAB_HELPER" ] || fail "the Herdr lab helper is not executable at $LAB_HELPER"
+
+MODEL=${FM_HERDR_PI_EXIT_MODEL:-gpt-5.6-sol}
+case "$(printf '%s' "$MODEL" | tr '[:upper:]' '[:lower:]')" in
+  *claude*|*anthropic*) fail "the live guard requires a non-Claude model" ;;
+esac
+SESSION=$("$LAB_HELPER" name herdr-pi-exit)
+SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-herdr-pi-exit.XXXXXX")
+HOME_DIR="$SCRATCH/home"
+REMOTE="$SCRATCH/remote.git"
+PROJECT="$SCRATCH/project"
+TASK=pi-exit-live
+SANITIZED=(env -u HERDR_SESSION -u HERDR_PANE_ID -u HERDR_TAB_ID -u HERDR_WORKSPACE_ID -u HERDR_ENV)
+
+cleanup() {
+  if [ -f "$HOME_DIR/state/$TASK.meta" ]; then
+    "${SANITIZED[@]}" FM_GATE_REFUSE_BYPASS=1 FM_HOME="$HOME_DIR" HERDR_SESSION="$SESSION" \
+      FM_ROOT_OVERRIDE="$ROOT" FM_CONTROL_POLL=0.2 FM_CONTROL_EXIT_WAIT=20 \
+      "$ROOT/bin/fm-control.sh" "$TASK" exit >/dev/null 2>&1 || true
+    "${SANITIZED[@]}" FM_GATE_REFUSE_BYPASS=1 FM_HOME="$HOME_DIR" HERDR_SESSION="$SESSION" \
+      FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-teardown.sh" "$TASK" --force >/dev/null 2>&1 || true
+  fi
+  "$LAB_HELPER" teardown "$SESSION" >/dev/null 2>&1 || true
+  rm -rf "$SCRATCH"
+}
+trap cleanup EXIT
+"$LAB_HELPER" provision "$SESSION" || fail "could not provision the isolated Herdr lab"
+
+mkdir -p "$HOME_DIR/state" "$HOME_DIR/data/$TASK" "$HOME_DIR/config"
+printf 'manual\n' > "$HOME_DIR/config/backlog-backend"
+printf 'off\n' > "$HOME_DIR/config/herdr-presentation-spaces"
+git init --bare -q "$REMOTE"
+git clone -q "$REMOTE" "$PROJECT"
+git -C "$PROJECT" config user.name 'Firstmate Tests'
+git -C "$PROJECT" config user.email 'tests@example.invalid'
+git -C "$PROJECT" config commit.gpgsign false
+printf '# lifecycle fixture\n' > "$PROJECT/README.md"
+git -C "$PROJECT" add README.md
+git -C "$PROJECT" commit --no-gpg-sign -qm initial
+git -C "$PROJECT" push -q -u origin HEAD
+cat > "$HOME_DIR/data/$TASK/brief.md" <<'EOF'
+# Task
+## Captain's intent
+Reply once with ready, then wait quietly for lifecycle control.
+
+## Firstmate spec
+Do not modify files.
+
+Delivery contract: mode=local-only
+EOF
+
+"${SANITIZED[@]}" FM_GATE_REFUSE_BYPASS=1 FM_SPAWN_NO_GUARD=1 FM_HOME="$HOME_DIR" \
+  HERDR_SESSION="$SESSION" FM_ROOT_OVERRIDE="$ROOT" \
+  "$ROOT/bin/fm-spawn.sh" "$TASK" "$PROJECT" --mode local-only --yolo off \
+    --harness pi --model "$MODEL" --effort low --backend herdr >/dev/null 2>"$SCRATCH/spawn.err" \
+  || fail "Pi spawn failed: $(cat "$SCRATCH/spawn.err")"
+META="$HOME_DIR/state/$TASK.meta"
+PANE=$(sed -n 's/^herdr_pane_id=//p' "$META")
+[ -n "$PANE" ] || fail "spawn did not record the Herdr pane"
+
+agent_json=
+agent_status=
+attempt=0
+while [ "$attempt" -lt 120 ]; do
+  agent_json=$("$LAB_HELPER" run "$SESSION" agent get "$PANE" 2>/dev/null || true)
+  agent_status=$(printf '%s' "$agent_json" | jq -r '.result.agent.agent_status // empty' 2>/dev/null)
+  case "$agent_status" in idle|done) break ;; esac
+  sleep 0.5
+  attempt=$((attempt + 1))
+done
+case "$agent_status" in idle|done) ;; *) fail "Pi did not reach an idle lifecycle point" ;; esac
+
+exit_out=$("${SANITIZED[@]}" FM_GATE_REFUSE_BYPASS=1 FM_HOME="$HOME_DIR" HERDR_SESSION="$SESSION" \
+  FM_ROOT_OVERRIDE="$ROOT" FM_CONTROL_POLL=0.2 FM_CONTROL_EXIT_WAIT=20 \
+  "$ROOT/bin/fm-control.sh" "$TASK" exit 2>&1) \
+  || fail "public exit did not recognize Pi's transition to a shell: $exit_out"
+case "$exit_out" in stopped\ *) ;; *) fail "public exit returned an unexpected result: $exit_out" ;; esac
+
+agent_json=$("$LAB_HELPER" run "$SESSION" agent get "$PANE" 2>/dev/null || true)
+[ "$(printf '%s' "$agent_json" | jq -r '.result.agent.agent_status // empty')" = idle ] \
+  || fail "Herdr no longer retained the stale idle Pi registration; refresh this guard's expected divergence"
+process_json=$("$LAB_HELPER" run "$SESSION" pane process-info --pane "$PANE" 2>/dev/null) \
+  || fail "could not read the post-Pi process shape"
+printf '%s' "$process_json" | jq -e '
+  .result.type == "pane_process_info"
+  and (.result.process_info.foreground_processes | length == 1)
+  and (.result.process_info.foreground_processes[0].name | test("(^|/)(zsh|bash|sh|dash|ksh|fish)$"))
+' >/dev/null || fail "the post-Pi endpoint was not a real one-shell foreground shape"
+
+relaunch_out=$("${SANITIZED[@]}" FM_GATE_REFUSE_BYPASS=1 FM_HOME="$HOME_DIR" HERDR_SESSION="$SESSION" \
+  FM_ROOT_OVERRIDE="$ROOT" FM_CONTROL_POLL=0.2 FM_CONTROL_EXIT_WAIT=5 FM_CONTROL_LAUNCH_WAIT=30 \
+  "$ROOT/bin/fm-control.sh" "$TASK" relaunch --harness pi --model "$MODEL" --effort low \
+    --note 'continue after verified lifecycle replacement' 2>&1) \
+  || fail "public relaunch still refused the shell-only endpoint: $relaunch_out"
+case "$relaunch_out" in *"relaunched $TASK harness=pi"*) ;; *) fail "public relaunch returned an unexpected result: $relaunch_out" ;; esac
+
+pass "live Herdr/Pi: stale idle registration over the post-exit shell no longer blocks public relaunch ($MODEL)"

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -9,9 +9,10 @@
 # an agent is running, and therefore whether a lifecycle verb may act at all,
 # comes from herdr's own agent registry.
 #
-# No real agent is launched. herdr's `pane report-agent` is the same registry
-# the adapter reads, so registering and not registering an agent on a plain
-# shell pane exercises exactly the classification the control plane gates on.
+# No real agent is launched. herdr's `pane report-agent` supplies the native
+# registration while a real foreground command supplies independent active
+# process evidence, so the control plane sees the same two-signal composition
+# without spending a provider-backed harness turn.
 #
 # Always runs on a private, named, throwaway lab session, never the default
 # one (tests/herdr-test-safety.sh; the 2026-07-02 incident). Skips cleanly
@@ -30,15 +31,16 @@ command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the her
 . "$ROOT/tests/herdr-test-safety.sh"
 herdr_forget_inherited_pane
 
-SESSION="fm-lab-control-smoke-$$"
+HERDR_LAB_HELPER="$ROOT/bin/fm-herdr-lab.sh"
+SESSION=$("$HERDR_LAB_HELPER" name control-smoke)
 export HERDR_SESSION="$SESSION"
 SCRATCH=
 cleanup_all() {
   [ -n "$SCRATCH" ] && rm -rf "$SCRATCH"
-  herdr_safe_stop_and_delete "$SESSION"
+  "$HERDR_LAB_HELPER" teardown "$SESSION" >/dev/null 2>&1 || true
 }
 trap cleanup_all EXIT
-fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+"$HERDR_LAB_HELPER" provision "$SESSION" || fail "could not provision isolated Herdr lab session"
 
 SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-control-herdr.XXXXXX")
 SCRATCH=$(cd "$SCRATCH" && pwd)
@@ -113,14 +115,16 @@ case "$OUT" in
 esac
 pass "real herdr: interrupt refuses when herdr's own agent registry reports no agent"
 
-# --- a registered agent: classification flips, and the verbs follow ---------
+# --- a registered agent with active process evidence: verbs follow ----------
 
-herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-smoke-agent \
-  --state idle --session "$SESSION" >/dev/null 2>&1 \
+"$HERDR_LAB_HELPER" run "$SESSION" pane run "$PANE_ID" 'sleep 120' >/dev/null 2>&1 \
+  || fail "could not start active foreground work on the task pane"
+"$HERDR_LAB_HELPER" run "$SESSION" pane report-agent "$PANE_ID" \
+  --source fm-control-smoke --agent fm-control-smoke-agent --state idle >/dev/null 2>&1 \
   || fail "could not register a live agent on the task pane"
 
 STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
-[ "$STATE" = alive ] || fail "herdr should classify a registered agent as alive, got '$STATE'"
+[ "$STATE" = alive ] || fail "herdr should classify a registered agent with active process evidence as alive, got '$STATE'"
 
 OUT=$(run_control hsmoke interrupt) || fail "interrupt against a registered agent should succeed: $OUT"
 case "$OUT" in
@@ -129,7 +133,7 @@ case "$OUT" in
 esac
 pass "real herdr: interrupt delivers the harness's key and proves the agent survived it"
 
-herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
+"$HERDR_LAB_HELPER" run "$SESSION" pane get "$PANE_ID" >/dev/null 2>&1 \
   || fail "the control plane must never remove the endpoint it was operating on"
 [ -d "$WT" ] || fail "the control plane must never remove the task's local copy"
 pass "real herdr: no control verb removed the endpoint or the task's local copy"
@@ -145,5 +149,3 @@ case "$OUT" in
   *) fail "the exit failure should say the agent did not stop, got: $OUT" ;;
 esac
 pass "real herdr: an agent that does not stop fails closed instead of being reported as stopped"
-
-fm_backend_herdr_kill "$SESSION:$PANE_ID" 2>/dev/null || true

--- a/tests/fm-herdr-session-cleanup.test.sh
+++ b/tests/fm-herdr-session-cleanup.test.sh
@@ -32,7 +32,7 @@ FAKE_PS="$TMP_ROOT/fake-ps"
 cat > "$FAKE_PS" <<'SH'
 #!/usr/bin/env bash
 case "$*" in
-  "-axo pid=,ppid=") printf '1 0\n67 1\n' ;;
+  "-axo pid=,ppid=,comm=") printf '1 0 init\n67 1 sh\n' ;;
   "-p 67 -o stat=") printf 'Ss\n' ;;
   *) exit 1 ;;
 esac


### PR DESCRIPTION
## Intent

Captain: "Yes clean it up, I want to relaunch and get this setup for antigravity over with. Use GPT." Clean up the Herdr lifecycle issue that prevents relaunch after the cancelled worker has exited, so the antigravity setup can proceed. Captain: "I have cancelled it and we should no longer use claude." Use GPT and do not use Claude.

## What Changed

- Classify a stale Herdr agent registration as stopped when process evidence proves the pane has returned to its idle shell topology, allowing safe worker relaunch.
- Preserve fail-closed behavior for active, branching, malformed, or unreadable process states while sharing the stricter classifier across lifecycle and cleanup paths.
- Add portable classifier coverage, a GPT-only live Pi exit-and-relaunch guard, and updated Herdr verification documentation.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves fail-closed behavior for malformed or competing process topologies, and adds behavioral coverage for the durable stale-registration fix and live-agent counterexample.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (12m13s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2552938dc58d4d3eddfa8b9a5043c18786e9ace4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
