### PR TITLE
feat(bootstrap): report no-mistakes gate-remote drift at session start

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, HOME_SUMMARY, BACKLOG_RECONCILE, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or reports that an interrupted backlog cleanup may have left an endpoint or local copy, or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, NO_MISTAKES_MIRROR, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, HOME_SUMMARY, BACKLOG_RECONCILE, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or reports that an interrupted backlog cleanup may have left an endpoint or local copy, or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
   A silent bootstrap section, or any other BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -32,6 +32,9 @@ When any diagnostic needs captain attention, report the plain consequence and re
 - `TANGLE: <remediation>` - the primary checkout is stranded on a feature branch instead of its default branch; `AGENTS.md` section 8 explains why this guard exists and what it protects.
   The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> checkout <default>`, then re-validate that branch in a proper worktree.
   This is the only sanctioned firstmate-initiated git write to the primary, and it is a non-destructive branch switch that strands nothing.
+- `NO_MISTAKES_MIRROR: <project> remote=<url>|absent expected-root=<root>` - the named no-mistakes-posture project clone, or this home's own firstmate checkout, has a `no-mistakes` gate remote that is absent or lives outside the data root the installed CLI resolves (`$NM_HOME` when set non-empty, else `~/.no-mistakes`), so its pipeline pushes go to a mirror root no daemon serves.
+  The line's clone path is the operator's fix site: rerun `no-mistakes init` inside that clone (it repairs the remote and re-records the repo) when work on that project authorizes touching it, then rerun session start to confirm the line is gone.
+  Bootstrap itself never modifies a clone and never runs init; do not silence the line by hand-editing a clone's git remote, which would desync the no-mistakes database record `no-mistakes init` maintains.
 - `STARTUP_MEMORY_BUDGET: invalid config/startup-memory-budget - <reason>` - the visible startup-memory budget is not a safe one-line positive decimal file; do not infer the default or propagate it.
   Correct the local primary file, then rerun session start so the normal convergence path can deliver the validated value to secondmate homes.
 - `CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>` - the optional dispatch profile file exists but failed low-cost bootstrap validation; stop profile-based dispatch, report the actionable error, and require correction of the malformed schema, unverified harness name, or invalid harness/effort pair rather than falling back around it or selecting a bad profile.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -545,7 +545,7 @@ The skill owns the guarded fleet update and restart procedure; it never touches 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `HOME_SUMMARY:`, `BACKLOG_RECONCILE:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`), or when `BOOTSTRAP_INFO:` says an interrupted backlog cleanup may have left an endpoint or local copy; silence and other `BOOTSTRAP_INFO:` facts need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `NO_MISTAKES_MIRROR:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `HOME_SUMMARY:`, `BACKLOG_RECONCILE:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`), or when `BOOTSTRAP_INFO:` says an interrupted backlog cleanup may have left an endpoint or local copy; silence and other `BOOTSTRAP_INFO:` facts need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi default TOON.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1473,8 +1473,9 @@ detect_no_mistakes_mirror() {
   root=${NM_HOME:-}
   [ -n "$root" ] || root=$HOME/.no-mistakes
   # init canonicalizes NM_HOME when it writes the remote, so a trailing-slash
-  # NM_HOME must not poison the <root>/repos/* prefix match below.
-  while [ "$root" != "${root%/}" ]; do root=${root%/}; done
+  # NM_HOME must not poison the <root>/repos/* prefix match below. A bare "/"
+  # root is already canonical and must survive the strip.
+  while [ "$root" != "/" ] && [ "$root" != "${root%/}" ]; do root=${root%/}; done
   check_no_mistakes_mirror_one firstmate "$FM_ROOT" "$root"
   [ -f "$DATA/projects.md" ] || return 0
   while IFS= read -r name; do

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1457,8 +1457,12 @@ check_no_mistakes_mirror_one() {  # <label> <clone> <root>
   local label=$1 clone=$2 root=$3 url
   git -C "$clone" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
   url=$(git -C "$clone" remote get-url no-mistakes 2>/dev/null || true)
-  case "$url" in
-    "$root"/repos/*) return 0 ;;
+  # A bare "/" root must not double the leading slash: "$root"/repos/* would
+  # become //repos/* and never match a healthy /repos/<repo>.git remote, and
+  # re-running no-mistakes init against the same root could never clear it.
+  case "$root" in
+    /) case "$url" in /repos/*) return 0 ;; esac ;;
+    *) case "$url" in "$root"/repos/*) return 0 ;; esac ;;
   esac
   [ -n "$url" ] || url=absent
   echo "NO_MISTAKES_MIRROR: $label remote=$url expected-root=$root (run no-mistakes init inside $clone to point its gate at the active root)"

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1472,6 +1472,9 @@ detect_no_mistakes_mirror() {
   local root name mode clone
   root=${NM_HOME:-}
   [ -n "$root" ] || root=$HOME/.no-mistakes
+  # init canonicalizes NM_HOME when it writes the remote, so a trailing-slash
+  # NM_HOME must not poison the <root>/repos/* prefix match below.
+  while [ "$root" != "${root%/}" ]; do root=${root%/}; done
   check_no_mistakes_mirror_one firstmate "$FM_ROOT" "$root"
   [ -f "$DATA/projects.md" ] || return 0
   while IFS= read -r name; do

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -15,6 +15,8 @@
 #                 <stamp>>; <n> failed attempt(s) ... last: <recorded failure>",
 #                 "BACKLOG_RECONCILE: <id>: <what this home could not reconcile>",
 #                 "TANGLE: <remediation>",
+#                 "NO_MISTAKES_MIRROR: <project> remote=<url>|absent
+#                 expected-root=<root>",
 #                 "SECONDMATE_SYNC: secondmate <id>: skipped: <reason>",
 #                 "NUDGE_SECONDMATES: secondmate <id>: send failed: <reason>",
 #                 "BOOTSTRAP_INFO: nudged fm-<id> with '<message>'",
@@ -65,6 +67,19 @@
 #          quota-axi is required for the agent-owned dispatch-profile array
 #          procedure in AGENTS.md section 4 and
 #          .agents/skills/quota-array-dispatch/SKILL.md.
+#          NO_MISTAKES_MIRROR is detect-only drift reporting (never a repair):
+#          a no-mistakes-posture project clone, or this home's own firstmate
+#          checkout, whose "no-mistakes" gate remote is absent or lives outside
+#          <root>/repos/ is pushing its gates to a mirror root no daemon serves.
+#          <root> is resolved exactly as the installed CLI resolves it from
+#          that clone: $NM_HOME when set (non-empty), else ~/.no-mistakes
+#          (verified against no-mistakes v1.60.2: `NM_HOME=/x no-mistakes
+#          doctor` prints "data directory /x", empty NM_HOME falls back to the
+#          default, and `no-mistakes init --help` documents that init sets up a
+#          local bare gate repo and adds or repairs the "no-mistakes" remote).
+#          The operator fix, named in the printed line, is rerunning
+#          `no-mistakes init` inside that clone; bootstrap itself never modifies
+#          a clone and never runs init.
 #          On a primary home, the locked mutable path materializes the visible
 #          default config/startup-memory-budget=7500 when absent. It never
 #          guesses at malformed or unsafe existing files, and secondmate homes
@@ -1434,6 +1449,45 @@ detect_local_tools() {
   fi
 }
 
+# One checkout's no-mistakes gate-remote placement. Silent when the remote
+# sits under <root>/repos/ or the path is not a git work tree (so a non-git
+# FM_ROOT fixture or a plain directory stays inert); one diagnostic line
+# otherwise. The header's NO_MISTAKES_MIRROR paragraph owns the contract.
+check_no_mistakes_mirror_one() {  # <label> <clone> <root>
+  local label=$1 clone=$2 root=$3 url
+  git -C "$clone" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+  url=$(git -C "$clone" remote get-url no-mistakes 2>/dev/null || true)
+  case "$url" in
+    "$root"/repos/*) return 0 ;;
+  esac
+  [ -n "$url" ] || url=absent
+  echo "NO_MISTAKES_MIRROR: $label remote=$url expected-root=$root (run no-mistakes init inside $clone to point its gate at the active root)"
+}
+
+# Detect-only no-mistakes mirror drift for this home: every registered
+# no-mistakes-posture project clone (bin/fm-project-mode.sh owns the registry
+# posture parse), plus this home's own firstmate checkout, must carry a
+# "no-mistakes" remote under the root the installed CLI would resolve.
+detect_no_mistakes_mirror() {
+  local root name mode clone
+  root=${NM_HOME:-}
+  [ -n "$root" ] || root=$HOME/.no-mistakes
+  check_no_mistakes_mirror_one firstmate "$FM_ROOT" "$root"
+  [ -f "$DATA/projects.md" ] || return 0
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    mode=$("$SCRIPT_DIR/fm-project-mode.sh" --raw "$name" 2>/dev/null || true)
+    mode=${mode%% *}
+    case "$mode" in
+      no-mistakes|no-mistakes-prod-only) ;;
+      *) continue ;;
+    esac
+    clone="$PROJECTS/$name"
+    [ -d "$clone" ] || continue
+    check_no_mistakes_mirror_one "$name" "$clone" "$root"
+  done < <(awk '$1=="-" && $2!="" { print $2 }' "$DATA/projects.md" 2>/dev/null)
+}
+
 detect_local_config() {
   # Worktree-tangle check: the firstmate primary checkout (FM_ROOT) must sit on its
   # default branch, not a feature branch (see fm-tangle-lib.sh). Scoped to the
@@ -1466,6 +1520,7 @@ detect_local_config() {
     echo "BOOTSTRAP_INFO: tasks-axi available"
   fi
   detect_home_summary_publication
+  detect_no_mistakes_mirror
 }
 
 # This home's ledger publication is deliberately best-effort: every lifecycle

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -401,6 +401,7 @@ An absent or incompatible `gh-axi` reports `MISSING: gh-axi (install: npm instal
 An absent or incompatible `lavish-axi` reports `MISSING: lavish-axi (install: npm install -g lavish-axi && lavish-axi setup hooks)`.
 An absent or too-old `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; firstmate cannot resolve a profile array without a compatible binary.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
+Bootstrap also reports one `NO_MISTAKES_MIRROR:` line per no-mistakes-posture project clone, and for the home's own firstmate checkout, whose `no-mistakes` gate remote is absent or outside the data root the installed CLI resolves (`NM_HOME` when set non-empty, else `~/.no-mistakes`); the printed `no-mistakes init` fix inside the affected clone is the operator's to run, never bootstrap's.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
 The locked session-start deferred network stage runs bootstrap's best-effort project clone refresh through `fm-fleet-sync.sh`; [`fm-bootstrap.sh`'s header](../bin/fm-bootstrap.sh) owns the exact clone-refresh overlap, liveness-before-convergence, per-mate concurrency, ordered diagnostic replay, and sequential-fallback contract.
 It emits `FLEET_SYNC:` for skipped refreshes that may matter, recovered self-heals, and `STUCK:` alarms.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -1231,6 +1231,14 @@ NO_MISTAKES_MIRROR: absent remote=absent expected-root=$root_a (run no-mistakes 
   expect="NO_MISTAKES_MIRROR: firstmate remote=$root_b/repos/fm.git expected-root=/ (run no-mistakes init inside $case_dir/fm-root to point its gate at the active root)"
   [ "$out" = "$expect" ] \
     || fail "mirror check: a bare / NM_HOME must survive normalization, got: $out"
+  # With a bare / root the healthy prefix is /repos/*, not //repos/*: a remote
+  # already under it must stay silent (re-init could never produce a //repos
+  # URL, so the warning would be unfixable).
+  git -C "$case_dir/fm-root" remote set-url no-mistakes /repos/fm.git
+  out=$(PATH="$fakebin:$BASE_PATH" NM_HOME=/ FM_HOME="$home" \
+    FM_ROOT_OVERRIDE="$case_dir/fm-root" FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+    "$ROOT/bin/fm-bootstrap.sh")
+  [ -z "$out" ] || fail "mirror check: a bare / root should accept a /repos/* remote, got: $out"
 
   # The default resolution leg: with NM_HOME unset, the root is
   # ~/.no-mistakes, so a remote under it stays silent. The URL is a string

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -1217,6 +1217,21 @@ NO_MISTAKES_MIRROR: absent remote=absent expected-root=$root_a (run no-mistakes 
   [ "$out" = "$expect" ] \
     || fail "mirror check: expected the firstmate drift line, got: $out"
 
+  # Trailing-slash NM_HOME must normalize to the canonical root, and a bare
+  # "/" root must survive the slash-strip instead of collapsing to empty.
+  out=$(PATH="$fakebin:$BASE_PATH" NM_HOME="$root_a///" FM_HOME="$home" \
+    FM_ROOT_OVERRIDE="$case_dir/fm-root" FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+    "$ROOT/bin/fm-bootstrap.sh")
+  expect="NO_MISTAKES_MIRROR: firstmate remote=$root_b/repos/fm.git expected-root=$root_a (run no-mistakes init inside $case_dir/fm-root to point its gate at the active root)"
+  [ "$out" = "$expect" ] \
+    || fail "mirror check: trailing-slash NM_HOME should normalize to the root, got: $out"
+  out=$(PATH="$fakebin:$BASE_PATH" NM_HOME=/ FM_HOME="$home" \
+    FM_ROOT_OVERRIDE="$case_dir/fm-root" FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+    "$ROOT/bin/fm-bootstrap.sh")
+  expect="NO_MISTAKES_MIRROR: firstmate remote=$root_b/repos/fm.git expected-root=/ (run no-mistakes init inside $case_dir/fm-root to point its gate at the active root)"
+  [ "$out" = "$expect" ] \
+    || fail "mirror check: a bare / NM_HOME must survive normalization, got: $out"
+
   # The default resolution leg: with NM_HOME unset, the root is
   # ~/.no-mistakes, so a remote under it stays silent. The URL is a string
   # only; nothing under the real home is read or written.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -17,6 +17,9 @@
 # Dedicated fleet-sync cases pin the computed bootstrap timeout, explicit
 # override, blank-env defaulting, partial-output relay, and pre-launch timeout
 # scan.
+# Dedicated NO_MISTAKES_MIRROR cases pin gate-remote drift reporting across
+# registry postures, the NM_HOME-resolved root, absent remotes, and the home's
+# own firstmate checkout.
 # Dedicated network-phase cases pin FM_BOOTSTRAP_NETWORK as a true partition of
 # one run into its local and network halves, and the one-hop tasks-axi
 # compatibility handoff that keeps a session start from paying for that verdict
@@ -813,6 +816,10 @@ make_routine_bootstrap_fixture() {
   printf '%s\n' '{"rules":[{"when":"normal work","use":{"harness":"codex"}}],"default":{"harness":"claude","effort":"low"}}' \
     > "$home/config/crew-dispatch.json"
   git init -q -b main "$root"
+  # A healthy firstmate checkout carries its no-mistakes gate remote under the
+  # root NM_HOME resolves to; run_routine_bootstrap_fixture pins NM_HOME to
+  # $case_dir/nm-root so this stays hermetic.
+  git -C "$root" remote add no-mistakes "$case_dir/nm-root/repos/firstmate.git"
   {
     printf '%s\n' '.fm-secondmate-home'
     printf '%s\n' 'config/crew-harness'
@@ -862,7 +869,7 @@ run_routine_bootstrap_fixture() {
   home=${fixture%%|*}
   fakebin=${fixture#*|}
   PATH="$fakebin:$BASE_PATH" FM_BACKEND=tmux FM_HOME="$home" FM_ROOT_OVERRIDE="$root" \
-    FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+    NM_HOME="$2/nm-root" FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
     "$shell" "$ROOT/bin/fm-bootstrap.sh"
 }
 
@@ -893,8 +900,10 @@ test_network_phase_partitions_the_run() {
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   fakebin=$(make_fake_toolchain "$case_dir")
   # Break the two diagnostics that stand for the two halves: a local tool floor
-  # and the network GitHub-auth probe.
-  rm -f "$fakebin/node"
+  # and the network GitHub-auth probe. chrome-devtools-axi is the removed tool
+  # because it cannot exist under BASE_PATH on a host (unlike node, which a
+  # distro installs into /usr/bin), so the local half stays hermetic.
+  rm -f "$fakebin/chrome-devtools-axi"
   cat > "$fakebin/gh" <<'SH'
 #!/usr/bin/env bash
 exit 1
@@ -903,18 +912,18 @@ SH
 
   all_out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
-  assert_contains "$all_out" "MISSING: node (install:" "the unsplit run lost its local diagnostic"
+  assert_contains "$all_out" "MISSING: chrome-devtools-axi (install:" "the unsplit run lost its local diagnostic"
   assert_contains "$all_out" "NEEDS_GH_AUTH" "the unsplit run lost its network diagnostic"
 
   skip_out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_BOOTSTRAP_NETWORK=skip "$ROOT/bin/fm-bootstrap.sh")
-  assert_contains "$skip_out" "MISSING: node (install:" "the local half lost its own diagnostic"
+  assert_contains "$skip_out" "MISSING: chrome-devtools-axi (install:" "the local half lost its own diagnostic"
   assert_not_contains "$skip_out" "NEEDS_GH_AUTH" "the local half still made a network call"
 
   only_out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_BOOTSTRAP_NETWORK=only "$ROOT/bin/fm-bootstrap.sh")
   assert_contains "$only_out" "NEEDS_GH_AUTH" "the network half lost its own diagnostic"
-  assert_not_contains "$only_out" "MISSING: node" "the network half repeated the local half's work"
+  assert_not_contains "$only_out" "MISSING: chrome-devtools-axi" "the network half repeated the local half's work"
 
   combined=$(printf '%s\n%s\n' "$skip_out" "$only_out" | LC_ALL=C sort)
   [ "$combined" = "$(printf '%s\n' "$all_out" | LC_ALL=C sort)" ] \
@@ -1148,6 +1157,79 @@ ROWS
   pass "bootstrap validates crew-dispatch.json and reports malformed or unverified configs"
 }
 
+test_no_mistakes_mirror_check() {
+  local case_dir home fakebin root_a root_b out expect
+
+  # Registry fixtures across every posture: only the no-mistakes legs are
+  # mirror-checked, and only clones that exist under projects/.
+  case_dir="$TMP_ROOT/no-mistakes-mirror"
+  home="$case_dir/home"
+  root_a="$case_dir/root-a"
+  root_b="$case_dir/root-b"
+  mkdir -p "$home/config" "$home/data" "$home/projects"
+  printf '%s\n' manual > "$home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  cat > "$home/data/projects.md" <<'REG'
+- macro [no-mistakes] - drift fixture (added 2026-09-04)
+- portal [no-mistakes-prod-only] - drift fixture (added 2026-09-04)
+- quick [direct-PR] - drift fixture (added 2026-09-04)
+- vault [local-only] - drift fixture (added 2026-09-04)
+- ghost [no-mistakes] - registered but never cloned (added 2026-09-04)
+- well [no-mistakes] - healthy fixture (added 2026-09-04)
+- absent [no-mistakes] - uninitialized fixture (added 2026-09-04)
+REG
+  for name in macro portal quick vault; do
+    git init -q -b main "$home/projects/$name"
+    git -C "$home/projects/$name" remote add no-mistakes "$root_b/repos/$name.git"
+  done
+  git init -q -b main "$home/projects/well"
+  git -C "$home/projects/well" remote add no-mistakes "$root_a/repos/well.git"
+  git init -q -b main "$home/projects/absent"
+
+  mkdir -p "$case_dir/non-git-root"
+
+  # NM_HOME pins the resolved root hermetically; the non-git FM_ROOT keeps
+  # the tangle and firstmate checks inert so only registry lines can print.
+  out=$(PATH="$fakebin:$BASE_PATH" NM_HOME="$root_a" FM_HOME="$home" \
+    FM_ROOT_OVERRIDE="$case_dir/non-git-root" FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+    "$ROOT/bin/fm-bootstrap.sh")
+  expect="NO_MISTAKES_MIRROR: macro remote=$root_b/repos/macro.git expected-root=$root_a (run no-mistakes init inside $home/projects/macro to point its gate at the active root)
+NO_MISTAKES_MIRROR: portal remote=$root_b/repos/portal.git expected-root=$root_a (run no-mistakes init inside $home/projects/portal to point its gate at the active root)
+NO_MISTAKES_MIRROR: absent remote=absent expected-root=$root_a (run no-mistakes init inside $home/projects/absent to point its gate at the active root)"
+  [ "$out" = "$expect" ] \
+    || fail "mirror check: expected exactly the macro/portal/absent drift lines, got: $out"
+
+  # This home's own firstmate checkout is checked too, under the same root.
+  case_dir="$TMP_ROOT/no-mistakes-mirror-root"
+  home="$case_dir/home"
+  root_a="$case_dir/root-a"
+  root_b="$case_dir/root-b"
+  mkdir -p "$home/config"
+  printf '%s\n' manual > "$home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  git init -q -b main "$case_dir/fm-root"
+  git -C "$case_dir/fm-root" commit --allow-empty -m fixture >/dev/null
+  git -C "$case_dir/fm-root" remote add no-mistakes "$root_b/repos/fm.git"
+  out=$(PATH="$fakebin:$BASE_PATH" NM_HOME="$root_a" FM_HOME="$home" \
+    FM_ROOT_OVERRIDE="$case_dir/fm-root" FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+    "$ROOT/bin/fm-bootstrap.sh")
+  expect="NO_MISTAKES_MIRROR: firstmate remote=$root_b/repos/fm.git expected-root=$root_a (run no-mistakes init inside $case_dir/fm-root to point its gate at the active root)"
+  [ "$out" = "$expect" ] \
+    || fail "mirror check: expected the firstmate drift line, got: $out"
+
+  # The default resolution leg: with NM_HOME unset, the root is
+  # ~/.no-mistakes, so a remote under it stays silent. The URL is a string
+  # only; nothing under the real home is read or written.
+  git -C "$case_dir/fm-root" remote set-url no-mistakes "$HOME/.no-mistakes/repos/fm.git"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" \
+    FM_ROOT_OVERRIDE="$case_dir/fm-root" FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+    env -u NM_HOME "$ROOT/bin/fm-bootstrap.sh")
+  [ -z "$out" ] || fail "mirror check: default-root resolution should stay silent, got: $out"
+
+  pass "bootstrap reports no-mistakes gate-remote drift outside the resolved root"
+}
+
+
 test_bootstrap_reporting
 test_no_mistakes_min_version
 test_gh_axi_min_version
@@ -1176,3 +1258,4 @@ test_network_phases_record_per_step_elapsed_times
 test_tasks_axi_verdict_handoff_is_consumed_once
 test_crew_dispatch_active_rules_are_verbose_bootstrap_info
 test_crew_dispatch_validation
+test_no_mistakes_mirror_check

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -42,6 +42,9 @@ BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 fm_git_identity fmtest fmtest@example.com
 
 TMP_ROOT=$(fm_test_tmproot fm-secondmate-sync)
+# Pin the no-mistakes data root the bootstrap mirror check resolves, so the
+# fixture firstmate roots below can carry a healthy gate remote hermetically.
+export NM_HOME="$TMP_ROOT/nm-root"
 export FM_BACKEND=tmux
 
 # --- world builders --------------------------------------------------------
@@ -57,6 +60,8 @@ new_world() {
   touch "$w/home/state/.last-watcher-beat"
 
   git init -q -b main "$w/main"
+  # Healthy no-mistakes gate remote under the hermetic NM_HOME above.
+  git -C "$w/main" remote add no-mistakes "$NM_HOME/repos/firstmate.git"
   # Mirror the real repo: the gitignored operational dirs never dirty a worktree,
   # so a secondmate home's data/state/projects can never block its fast-forward.
   printf 'projects/\nstate/\ndata/\n.no-mistakes/\nconfig/crew-harness\nscratchpad*\n' > "$w/main/.gitignore"
@@ -915,6 +920,7 @@ new_remote_world() {
   w="$TMP_ROOT/$name"
   mkdir -p "$w/home/state" "$w/home/data"
   git init -q -b main "$w/main"
+  git -C "$w/main" remote add no-mistakes "$NM_HOME/repos/firstmate.git"
   printf 'projects/\nstate/\ndata/\nconfig/\n.no-mistakes/\n.fm-secondmate-home\n' > "$w/main/.gitignore"
   printf 'v1\n' > "$w/main/AGENTS.md"
   mkdir -p "$w/main/bin" "$w/main/.agents/skills"

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -8,6 +8,9 @@ set -u
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 TMP_ROOT=$(fm_test_tmproot fm-startup-memory-budget)
+# Pin the no-mistakes data root the bootstrap mirror check resolves, so the
+# fixture firstmate roots below can carry a healthy gate remote hermetically.
+export NM_HOME="$TMP_ROOT/nm-root"
 BUDGET="$ROOT/bin/fm-startup-memory-budget.sh"
 BOOTSTRAP="$ROOT/bin/fm-bootstrap.sh"
 CONFIG_PUSH="$ROOT/bin/fm-config-push.sh"
@@ -77,6 +80,7 @@ new_bootstrap_world() {
   home="$world/home"
   mkdir -p "$home/config" "$home/data" "$home/state" "$root/bin"
   git init -q -b main "$root"
+  git -C "$root" remote add no-mistakes "$NM_HOME/repos/firstmate.git"
   printf '%s\n' 'config/' > "$root/.gitignore"
   printf '%s\n' '# Firstmate test root' > "$root/AGENTS.md"
   printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$root/bin/placeholder.sh"
@@ -209,6 +213,7 @@ new_propagation_world() {
   mkdir -p "$home/config" "$home/data" "$home/state" "$root/bin"
   touch "$home/state/.last-watcher-beat"
   git init -q -b main "$root"
+  git -C "$root" remote add no-mistakes "$NM_HOME/repos/firstmate.git"
   printf '%s\n' 'config/' > "$root/.gitignore"
   printf '%s\n' '# Firstmate test root' > "$root/AGENTS.md"
   printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$root/bin/placeholder.sh"


### PR DESCRIPTION
## Intent

MAIN's fleet word, 2026-09-04 (corr fb87b3426f875489), on the advisor's finding that no-mistakes was split across two data roots (~/.no-mistakes served by one daemon, ~/.no-mistakes-b by another) with macro, crm, and portal initialized against the second: "add the session-start NO_MISTAKES_MIRROR check". Make the drift visible at every session start so it cannot recur silently.

## What Changed
- Add a detect-only `NO_MISTAKES_MIRROR` check to `bin/fm-bootstrap.sh` that, at session start, reports any no-mistakes-posture project clone (plus the home's own firstmate checkout) whose `no-mistakes` gate remote is absent or lives outside the data root the installed CLI resolves (`$NM_HOME` when set non-empty, else `~/.no-mistakes`, trailing slashes stripped); the printed remediation is rerunning `no-mistakes init` inside the affected clone — bootstrap never modifies clones or runs init itself.
- Document the new diagnostic in the `bootstrap-diagnostics` skill, `AGENTS.md` skill-load triggers, `docs/configuration.md`, and the `fm-bootstrap.sh` header contract.
- Add dedicated bootstrap tests covering registry postures (only no-mistakes/no-mistakes-prod-only clones are checked, uncloned entries skipped), drift across alternate roots, absent remotes, the firstmate checkout, and silent default-root resolution; pin hermetic `NM_HOME` roots and healthy remotes in the secondmate-sync and startup-memory-budget fixtures, and swap the network-partition local diagnostic from `node` to `chrome-devtools-axi` for host hermeticity.

## Risk Assessment

✅ Low: The fix round is the exact minimal normalization prescribed in round 1, verified against the installed CLI's actual behavior, and the surrounding detect-only diagnostic has no write path and no remaining reachable false-positive sequence.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (4m55s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"61a8d6702b5e64d664a317eb6c730694d5e2c254","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-bootstrap.sh:1461` - check_no_mistakes_mirror_one matches the remote URL against the raw &#34;$root&#34;/repos/* prefix without normalizing root spelling. Verified against no-mistakes v1.60.2: init canonicalizes NM_HOME when it writes the remote (NM_HOME=/x/no-mistakes/ stores /x/no-mistakes/repos/&lt;hash&gt;.git), but a bootstrap run with the same trailing-slash NM_HOME builds the pattern /x/no-mistakes//repos/*, which never matches. Concrete failure: a user with a trailing-slash NM_HOME gets a NO_MISTAKES_MIRROR line for every healthy clone at every session start, and the printed remediation (rerun no-mistakes init inside the clone) rewrites the identical canonical URL, so the line can never be cleared - a permanent false positive that erodes trust in the diagnostic. Fix at the shared boundary: strip trailing slashes from root in detect_no_mistakes_mirror (e.g. loop root=${root%/}) before passing it to check_no_mistakes_mirror_one; do NOT resolve symlinks (init preserves the NM_HOME spelling, so cd/pwd-style canonicalization would introduce the opposite false positive).
- ℹ️ `bin/fm-bootstrap.sh:1473` - The resolved root inherits the bootstrap process&#39;s environment (NM_HOME when non-empty, else ~/.no-mistakes). If a no-mistakes daemon was started under a different NM_HOME than the session that runs the check, clone-vs-daemon drift remains invisible because the check deliberately answers &#39;does the clone agree with the CLI as this session resolves it&#39; (the header documents exactly this contract, and that is the failure mode the fleet word reported: clones initialized against a second root while the CLI resolves the first). Noting the boundary only; closing it would require daemon-registry cross-checks beyond the stated intent.

🔧 Fix: fix(bootstrap): strip trailing slashes from NM_HOME in mirror check
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
