### PR TITLE
fix(bin): scrub Claude child-session markers

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1448,15 +1448,21 @@ fm_backend_herdr_projection_order_best_effort() {  # <session> <created-workspac
 # NOT auto-start the server, so this must run before any workspace/tab/pane
 # call. The server outlives its launcher and passes its startup environment to
 # every later pane, so remove home, harness identity, and supervision selection
-# inherited from whichever agent happened to start it. Bounded poll for the
-# server to report running.
+# inherited from whichever agent happened to start it - including
+# CLAUDE_CODE_CHILD_SESSION and CLAUDECODE, the markers a server started from
+# inside a Claude Code session inherits and hands down to every later pane
+# (first observed 2026-08-03, Claude Code 2.1.220; reproduced and this fix
+# verified 2026-09-04, Claude Code 2.1.260 -
+# docs/verification/runtime-backends.md "Claude Code"): a pane inheriting
+# either one treats itself as a nested child session and runs with
+# transcripts off. Bounded poll for the server to report running.
 fm_backend_herdr_server_ensure() {  # <session>
   local session=$1 running out i
   running=$(fm_backend_herdr_cli "$session" status --json 2>/dev/null | jq -r '.server.running // false' 2>/dev/null)
   [ "$running" = "true" ] && return 0
   (
     unset FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE \
-      CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT FM_SUPERVISION_MODEL
+      CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE CLAUDE_CODE_CHILD_SESSION PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT FM_SUPERVISION_MODEL
     fm_backend_herdr_cli "$session" server >/dev/null 2>&1 &
   ) || return 1
   for i in $(seq 1 20); do

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1451,10 +1451,8 @@ fm_backend_herdr_projection_order_best_effort() {  # <session> <created-workspac
 # inherited from whichever agent happened to start it - including
 # CLAUDE_CODE_CHILD_SESSION and CLAUDECODE, the markers a server started from
 # inside a Claude Code session inherits and hands down to every later pane
-# (first observed 2026-08-03, Claude Code 2.1.220; reproduced and this fix
-# verified 2026-09-04, Claude Code 2.1.260 -
-# docs/verification/runtime-backends.md "Claude Code"): a pane inheriting
-# either one treats itself as a nested child session and runs with
+# (see docs/verification/runtime-backends.md "Claude Code"): a pane
+# inheriting either one treats itself as a nested child session and runs with
 # transcripts off. Bounded poll for the server to report running.
 fm_backend_herdr_server_ensure() {  # <session>
   local session=$1 running out i

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -64,11 +64,22 @@ fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> 
 # firstmate itself runs inside tmux, else ensure a dedicated detached
 # "firstmate" session exists. Mirrors fm-spawn.sh's container-ensure block;
 # prints the resolved session name.
+#
+# tmux has no explicit server-start command: the first client call implicitly
+# starts the server if none is running, and every later pane inherits that
+# server's initial environment. `new-session` is that first call here, so
+# env -u scrubs CLAUDE_CODE_CHILD_SESSION and CLAUDECODE on this exact command,
+# the same markers a server started from inside a Claude session would
+# otherwise hand down to every worker pane later launched under it (first
+# observed 2026-08-03, Claude Code 2.1.220; reproduced on tmux and this fix
+# verified 2026-09-04, Claude Code 2.1.260 -
+# docs/verification/runtime-backends.md "Claude Code"). The reused-session
+# branch starts no server and needs no scrub.
 fm_backend_tmux_container_ensure() {
   if [ -n "${TMUX:-}" ]; then
     tmux display-message -p '#S'
   else
-    tmux has-session -t firstmate 2>/dev/null || tmux new-session -d -s firstmate
+    tmux has-session -t firstmate 2>/dev/null || env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDECODE tmux new-session -d -s firstmate
     printf 'firstmate'
   fi
 }

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -70,9 +70,7 @@ fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> 
 # server's initial environment. `new-session` is that first call here, so
 # env -u scrubs CLAUDE_CODE_CHILD_SESSION and CLAUDECODE on this exact command,
 # the same markers a server started from inside a Claude session would
-# otherwise hand down to every worker pane later launched under it (first
-# observed 2026-08-03, Claude Code 2.1.220; reproduced on tmux and this fix
-# verified 2026-09-04, Claude Code 2.1.260 -
+# otherwise hand down to every worker pane later launched under it (see
 # docs/verification/runtime-backends.md "Claude Code"). The reused-session
 # branch starts no server and needs no scrub.
 fm_backend_tmux_container_ensure() {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1277,7 +1277,20 @@ launch_template() {
     # alone disables the feature; keep both so a managed override of one still
     # leaves the other in force. Both are per-launch, scoped to this invocation only,
     # and never touch the captain's global ~/.claude/settings.json.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '\''{"feedbackDrafts":"off"}'\'' __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDECODE clears the markers Claude Code
+    # stamps on its own process and that a multiplexer server started from inside a
+    # Claude session then hands down to every later pane (first observed 2026-08-03,
+    # Claude Code 2.1.220; reproduced and this fix verified 2026-09-04, Claude Code
+    # 2.1.260 - docs/verification/runtime-backends.md "Claude Code"): a worker
+    # inheriting either one treats itself as a nested child session and runs
+    # with transcripts off, so it writes no ~/.claude/projects/<slug>/*.jsonl,
+    # the context tracker reads 0, and the session cannot be resumed. Scrubbing
+    # here makes every Claude worker launch clean regardless of what its server
+    # happened to inherit; fm_backend_herdr_server_ensure (bin/backends/herdr.sh)
+    # and fm_backend_tmux_container_ensure (bin/backends/tmux.sh) additionally
+    # scrub both markers at the point each backend starts its own server, so a
+    # freshly started server is clean at the source too.
+    claude) printf '%s' 'env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDECODE CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '\''{"feedbackDrafts":"off"}'\'' __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1279,17 +1279,15 @@ launch_template() {
     # and never touch the captain's global ~/.claude/settings.json.
     # env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDECODE clears the markers Claude Code
     # stamps on its own process and that a multiplexer server started from inside a
-    # Claude session then hands down to every later pane (first observed 2026-08-03,
-    # Claude Code 2.1.220; reproduced and this fix verified 2026-09-04, Claude Code
-    # 2.1.260 - docs/verification/runtime-backends.md "Claude Code"): a worker
-    # inheriting either one treats itself as a nested child session and runs
-    # with transcripts off, so it writes no ~/.claude/projects/<slug>/*.jsonl,
-    # the context tracker reads 0, and the session cannot be resumed. Scrubbing
-    # here makes every Claude worker launch clean regardless of what its server
-    # happened to inherit; fm_backend_herdr_server_ensure (bin/backends/herdr.sh)
-    # and fm_backend_tmux_container_ensure (bin/backends/tmux.sh) additionally
-    # scrub both markers at the point each backend starts its own server, so a
-    # freshly started server is clean at the source too.
+    # Claude session then hands down to every later pane: a worker inheriting either
+    # one treats itself as a nested child session and runs with transcripts off.
+    # docs/verification/runtime-backends.md "Claude Code" owns the versioned
+    # evidence. Scrubbing here makes every Claude worker launch clean regardless of
+    # what its server happened to inherit; fm_backend_herdr_server_ensure
+    # (bin/backends/herdr.sh) and fm_backend_tmux_container_ensure
+    # (bin/backends/tmux.sh) additionally scrub both markers at the point each
+    # backend starts its own server, so a freshly started server is clean at the
+    # source too.
     claude) printf '%s' 'env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDECODE CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '\''{"feedbackDrafts":"off"}'\'' __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -205,8 +205,8 @@ Workspace and tab ids support verification and cleanup but are not inferred from
 The adapter starts and polls a named server before workspace, tab, pane, or agent calls.
 Every Herdr invocation goes through `fm_backend_herdr_cli`, which sets the environment and passes an explicit trailing `--session <name>`.
 An environment variable alone is not reliable when another Herdr server is running.
-When the selected named server is not running, the adapter launches it without inherited Firstmate home and directory overrides, harness identity markers, or the supervision-model override.
-Herdr passes its server startup environment to every later pane, so retaining those values could misroute panes for another Firstmate home or harness.
+When the selected named server is not running, the adapter launches it without inherited Firstmate home and directory overrides, harness identity markers, the supervision-model override, or the Claude Code child-session markers `CLAUDE_CODE_CHILD_SESSION` and `CLAUDECODE`.
+Herdr passes its server startup environment to every later pane, so retaining those values could misroute panes for another Firstmate home or harness, or - for the Claude Code markers - make a worker pane run as a nested child session with transcripts off.
 An already-running server is reused without restart or environment changes.
 Explicit named-session routing and unrelated launch environment remain intact.
 

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -14,6 +14,9 @@ An explicit selection is also the opt-out from Herdr or cmux runtime auto-detect
 
 No provisioning is required before the first task.
 
+A pane's inherited environment is fixed when the tmux server process itself first starts, not by any later `new-session` call against an already-running server.
+Because a server started from inside a Claude Code session inherits `CLAUDE_CODE_CHILD_SESSION` and `CLAUDECODE`, which make every Claude worker later launched under that server run as a nested child session with transcripts off, the server-starting `new-session` call in `fm_backend_tmux_container_ensure` (`bin/backends/tmux.sh`) scrubs both with `env -u` before it runs.
+
 ## Watching the crew
 
 For the best visible experience, launch the primary harness inside a tmux session:

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -228,7 +228,7 @@ claude --help | grep -A 5 'workspace trust dialog'
 Firstmate cannot answer it either, because its key plane carries only Enter, Escape, and C-c with no arrow navigation.
 Suppression itself was then observed directly on the same date and version, with a control arm and a treatment arm.
 
-The control arm launched a fresh linked worktree with no pre-registration, the way `bin/fm-spawn.sh` launches one.
+The control arm launched a fresh linked worktree with no pre-registration, matching the trust-relevant shape of a Claude launch from `bin/fm-spawn.sh`.
 
 ```sh
 tmux new-session -d -s tp-a -c /tmp/trustproof/wt-a \
@@ -1263,21 +1263,21 @@ FM_HARNESS_LIVENESS_DRIFT=1 bin/fm-test-run.sh tests/fm-harness-liveness-drift-l
 A herdr or tmux server started from inside a Claude Code session inherits `CLAUDE_CODE_CHILD_SESSION` and `CLAUDECODE`.
 Every `claude` process later launched under that server inherits them too, treats itself as a nested child session, and runs with transcripts off: it writes no `~/.claude/projects/<slug>/*.jsonl`, the context tracker reads 0, and the session cannot be resumed.
 First observed 2026-08-03 on Claude Code 2.1.220.
-The fix - the claude launch template in `bin/fm-spawn.sh`, plus the server-start scrubs in `bin/backends/tmux.sh` and `bin/backends/herdr.sh` - was verified end to end on 2026-08-30 with Claude Code 2.1.251, tmux 3.7c, on macOS 26.6.2 arm64: a base-commit reproduction confirmed both markers reaching a worker pane, and a fixed spawn through `bin/fm-spawn.sh` produced a Claude worker that answered its launch brief and wrote a fresh session transcript despite both markers being set in the spawning shell's own environment.
+The claude launch-template fix in `bin/fm-spawn.sh` was verified end to end on 2026-08-30 with Claude Code 2.1.251, tmux 3.7c, on macOS 26.6.2 arm64: a base-commit reproduction confirmed both markers reaching a worker pane, and a fixed spawn produced a Claude worker that answered its launch brief and wrote a fresh session transcript despite both markers being set in the spawning shell's own environment.
 
 ### 2026-09-04 tmux server-start scrub re-verified live
 
 `fm_backend_tmux_container_ensure` (`bin/backends/tmux.sh`) scrubs both markers on the `new-session` call that starts a fresh tmux server, since a pane's inherited environment is fixed at server start, not by any later client call against an already-running one.
-Re-verified live on real tmux 3.7c, macOS 26.6.2 arm64, isolated on a private `-L` socket:
+Re-verified live on real tmux 3.7c, macOS 26.6.2 arm64, isolated on the regression's private `-L` socket:
 
 ```sh
-TMUX='' CLAUDE_CODE_CHILD_SESSION=1 CLAUDECODE=1 fm_backend_tmux_container_ensure
-tmux send-keys -t firstmate -l 'printf "CCS=%s CC=%s\n" "${CLAUDE_CODE_CHILD_SESSION-<unset>}" "${CLAUDECODE-<unset>}"'
-tmux send-keys -t firstmate Enter
-tmux capture-pane -t firstmate -p
+claude --version
+tmux -V
+tests/fm-backend-tmux-smoke.test.sh
 ```
 
-Observed output: `CCS=<unset> CC=<unset>`.
+The version commands printed `2.1.260 (Claude Code)` and `tmux 3.7c`.
+The relevant test output was `ok - real tmux: fm_backend_tmux_container_ensure's server start clears inherited Claude child-session markers` after the pane printed `CCS=<unset> CC=<unset>`.
 Both markers were absent from the worker pane despite being set in the calling shell, confirming the scrub reaches every later pane; this reproduction is now the pinned regression `tests/fm-backend-tmux-smoke.test.sh` ("container_ensure clears inherited Claude child-session markers").
 
 `fm_backend_herdr_server_ensure` (`bin/backends/herdr.sh`) scrubs the same two markers by adding them to the `unset` block it already runs ahead of its server-start call, alongside the Firstmate home, harness-identity, and supervision-model variables removed there for an unrelated reason; this is pinned at the unit level against a fake herdr CLI stub in `tests/fm-backend-herdr.test.sh` ("scrubs home and harness identity ..."), consistent with the rest of that function's coverage, but no live herdr server reproduction was run for this record.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1256,6 +1256,35 @@ Refresh this harness-dependent proof before accepting a cursor upgrade:
 FM_HARNESS_LIVENESS_DRIFT=1 bin/fm-test-run.sh tests/fm-harness-liveness-drift-live-e2e.test.sh
 ```
 
+## Claude Code
+
+### Child-session markers inherited by nested launches
+
+A herdr or tmux server started from inside a Claude Code session inherits `CLAUDE_CODE_CHILD_SESSION` and `CLAUDECODE`.
+Every `claude` process later launched under that server inherits them too, treats itself as a nested child session, and runs with transcripts off: it writes no `~/.claude/projects/<slug>/*.jsonl`, the context tracker reads 0, and the session cannot be resumed.
+First observed 2026-08-03 on Claude Code 2.1.220.
+The fix - the claude launch template in `bin/fm-spawn.sh`, plus the server-start scrubs in `bin/backends/tmux.sh` and `bin/backends/herdr.sh` - was verified end to end on 2026-08-30 with Claude Code 2.1.251, tmux 3.7c, on macOS 26.6.2 arm64: a base-commit reproduction confirmed both markers reaching a worker pane, and a fixed spawn through `bin/fm-spawn.sh` produced a Claude worker that answered its launch brief and wrote a fresh session transcript despite both markers being set in the spawning shell's own environment.
+
+### 2026-09-04 tmux server-start scrub re-verified live
+
+`fm_backend_tmux_container_ensure` (`bin/backends/tmux.sh`) scrubs both markers on the `new-session` call that starts a fresh tmux server, since a pane's inherited environment is fixed at server start, not by any later client call against an already-running one.
+Re-verified live on real tmux 3.7c, macOS 26.6.2 arm64, isolated on a private `-L` socket:
+
+```sh
+TMUX='' CLAUDE_CODE_CHILD_SESSION=1 CLAUDECODE=1 fm_backend_tmux_container_ensure
+tmux send-keys -t firstmate -l 'printf "CCS=%s CC=%s\n" "${CLAUDE_CODE_CHILD_SESSION-<unset>}" "${CLAUDECODE-<unset>}"'
+tmux send-keys -t firstmate Enter
+tmux capture-pane -t firstmate -p
+```
+
+Observed output: `CCS=<unset> CC=<unset>`.
+Both markers were absent from the worker pane despite being set in the calling shell, confirming the scrub reaches every later pane; this reproduction is now the pinned regression `tests/fm-backend-tmux-smoke.test.sh` ("container_ensure clears inherited Claude child-session markers").
+
+`fm_backend_herdr_server_ensure` (`bin/backends/herdr.sh`) scrubs the same two markers by adding them to the `unset` block it already runs ahead of its server-start call, alongside the Firstmate home, harness-identity, and supervision-model variables removed there for an unrelated reason; this is pinned at the unit level against a fake herdr CLI stub in `tests/fm-backend-herdr.test.sh` ("scrubs home and harness identity ..."), consistent with the rest of that function's coverage, but no live herdr server reproduction was run for this record.
+The claude launch template's `env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDECODE` prefix is pinned exactly in `tests/fm-spawn-dispatch-profile.test.sh`; the transcript-writing causal link itself (that Claude Code resumes normal transcript behavior once these markers are absent) is the 2026-08-30 evidence above and was not re-run today, since a live re-check needs real Claude Code credentials that this record's isolated-scratch, no-keychain-reads verification constraints put out of reach.
+
+Refresh this record after a Claude Code, tmux, or Herdr upgrade that touches launch or server-start environment handling; the portable regression is `tests/fm-spawn-dispatch-profile.test.sh`, `tests/fm-backend-tmux-smoke.test.sh`, and `tests/fm-backend-herdr.test.sh`.
+
 ## Pi supervision branch
 
 The supervision-branch extension (`.pi/extensions/fm-branch-supervision.ts`, [docs/pi-supervision-branch.md](../pi-supervision-branch.md)) builds its second session through the Pi SDK surface: `createAgentSession` (including its `model`, `modelRuntime`, and `thinkingLevel` options), `DefaultResourceLoader` with `extensionFactories`, `SessionManager`, `createBashToolDefinition` with a `spawnHook`, `sendCustomMessage` for routine notes, `appendEntry` and `registerEntryRenderer` for captain outcomes, the `before_provider_request` hook, the command context's model registry for picker candidates, a fresh `ModelRuntime` for isolated-branch resolution, and Pi's own `getSupportedThinkingLevels`/`clampThinkingLevel` plus its `getThinkingLevel` and `thinking_level_select` extension surface for effort.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -81,7 +81,7 @@ case "${1:-}" in
     ;;
   server)
     {
-      for name in FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT FM_SUPERVISION_MODEL FM_HERDR_SENTINEL HERDR_SESSION; do
+      for name in FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE CLAUDE_CODE_CHILD_SESSION PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT FM_SUPERVISION_MODEL FM_HERDR_SENTINEL HERDR_SESSION; do
         eval 'value=${'"$name"'-<unset>}'
         printf '%s=%s\n' "$name" "$value"
       done
@@ -563,12 +563,12 @@ test_server_ensure_scrubs_home_and_harness_identity() {
   PATH="$fb:$PATH" FM_HERDR_SERVER_ENV_LOG="$log" FM_HERDR_SERVER_MARKER="$marker" FM_HERDR_SENTINEL=kept \
     FM_HOME=/tmp/wrong-home FM_ROOT_OVERRIDE=/tmp/wrong-root FM_STATE_OVERRIDE=/tmp/wrong-state \
     FM_DATA_OVERRIDE=/tmp/wrong-data FM_PROJECTS_OVERRIDE=/tmp/wrong-projects FM_CONFIG_OVERRIDE=/tmp/wrong-config \
-    CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent CLAUDECODE=1 PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed GROK_AGENT=1 FM_SUPERVISION_MODEL=autoarm \
+    CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent CLAUDECODE=1 CLAUDE_CODE_CHILD_SESSION=1 PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed GROK_AGENT=1 FM_SUPERVISION_MODEL=autoarm \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_server_ensure fmtest' "$ROOT"
   expect_code 0 $? "server_ensure should start under a polluted launcher environment"
   output=$(cat "$log")
   for name in FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE \
-    CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT FM_SUPERVISION_MODEL; do
+    CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE CLAUDE_CODE_CHILD_SESSION PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT FM_SUPERVISION_MODEL; do
     assert_contains "$output" "$name=<unset>" "server_ensure leaked $name into the long-lived Herdr server"
   done
   assert_contains "$output" "FM_HERDR_SENTINEL=kept" "server_ensure removed an unrelated environment variable"

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -53,6 +53,45 @@ export PATH
 . "$ROOT/bin/fm-backend.sh"
 fm_backend_source tmux || fail "fm_backend_source tmux failed"
 
+# --- container_ensure clears inherited Claude child-session markers ---------
+#
+# A pane's inherited environment comes from the tmux SERVER process's own
+# environment at the moment the server itself starts, not from whatever env a
+# later client command against an already-running server happens to carry
+# (verified empirically: a later `new-session` under an existing server never
+# changes what earlier or later panes inherit). So this must be the FIRST tmux
+# command against this private socket, before the "smoke" session below starts
+# the server with its own (unscrubbed) environment. A server started from
+# inside a Claude Code session inherits CLAUDE_CODE_CHILD_SESSION and
+# CLAUDECODE, and every claude worker later launched under that server would
+# inherit them and run with transcripts off (first observed 2026-08-03, Claude
+# Code 2.1.220; reproduced and this fix verified 2026-09-04, Claude Code
+# 2.1.260 - docs/verification/runtime-backends.md "Claude Code").
+CCS_TARGET="firstmate"
+CCS_READY=false
+TMUX='' CLAUDE_CODE_CHILD_SESSION=1 CLAUDECODE=1 fm_backend_tmux_container_ensure >/dev/null \
+  || fail "fm_backend_tmux_container_ensure failed while Claude child-session markers were set"
+tmux has-session -t firstmate 2>/dev/null \
+  || fail "fm_backend_tmux_container_ensure did not create the firstmate session"
+for _ in $(seq 1 100); do
+  tmux send-keys -t "$CCS_TARGET" C-c
+  # shellcheck disable=SC2016  # single quotes are deliberate: this expands in the pane's shell, not here.
+  tmux send-keys -t "$CCS_TARGET" -l 'printf "ccsprobe-%s CCS=%s CC=%s\n" done "${CLAUDE_CODE_CHILD_SESSION-<unset>}" "${CLAUDECODE-<unset>}"'
+  tmux send-keys -t "$CCS_TARGET" Enter
+  if wait_for_capture_text "$CCS_TARGET" "ccsprobe-done" 10; then
+    CCS_READY=true
+    break
+  fi
+done
+[ "$CCS_READY" = true ] || fail "the firstmate session shell did not become ready"
+ccs_out=$(fm_backend_tmux_capture "$CCS_TARGET" 20) || fail "fm_backend_tmux_capture failed on the firstmate session"
+case "$ccs_out" in
+  *"CCS=<unset> CC=<unset>"*) : ;;
+  *) fail "fm_backend_tmux_container_ensure's server start must not hand inherited Claude child-session markers down to worker panes"$'\n'"$ccs_out" ;;
+esac
+tmux kill-session -t firstmate 2>/dev/null || true
+pass "real tmux: fm_backend_tmux_container_ensure's server start clears inherited Claude child-session markers"
+
 SESSION="smoke"
 WINDOW="fm-smoke1"
 TARGET="$SESSION:$WINDOW"

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -64,9 +64,8 @@ fm_backend_source tmux || fail "fm_backend_source tmux failed"
 # the server with its own (unscrubbed) environment. A server started from
 # inside a Claude Code session inherits CLAUDE_CODE_CHILD_SESSION and
 # CLAUDECODE, and every claude worker later launched under that server would
-# inherit them and run with transcripts off (first observed 2026-08-03, Claude
-# Code 2.1.220; reproduced and this fix verified 2026-09-04, Claude Code
-# 2.1.260 - docs/verification/runtime-backends.md "Claude Code").
+# inherit them and run with transcripts off. The "Claude Code" section of
+# docs/verification/runtime-backends.md owns the versioned evidence.
 CCS_TARGET="firstmate"
 CCS_READY=false
 TMUX='' CLAUDE_CODE_CHILD_SESSION=1 CLAUDECODE=1 fm_backend_tmux_container_ensure >/dev/null \

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -131,7 +131,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '{\"feedbackDrafts\":\"off\"}' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/launch-brief.md')\""
+  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDECODE CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '{\"feedbackDrafts\":\"off\"}' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/launch-brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -739,7 +739,7 @@ test_claude_forwards_firstmate_config_dir_when_set() {
   status=$?
   expect_code 0 "$status" "claude spawn with CLAUDE_CONFIG_DIR set should succeed"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "CLAUDE_CONFIG_DIR='$CASE_DIR/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '{\"feedbackDrafts\":\"off\"}'" \
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='$CASE_DIR/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDECODE CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '{\"feedbackDrafts\":\"off\"}'" \
     "claude launch did not forward firstmate's CLAUDE_CONFIG_DIR to the crewmate pane"
   pass "claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store"
 }


### PR DESCRIPTION
## Intent

Send the Claude child-session marker scrub upstream as a PR to kunchenguid/firstmate.

Bug: a herdr or tmux server started from inside a Claude Code session inherits
CLAUDE_CODE_CHILD_SESSION and CLAUDECODE. Every claude worker later launched
under that server inherits them too, treats itself as a nested child session,
and runs with transcripts off: it writes no ~/.claude/projects/<slug>/*.jsonl,
the context tracker reads 0, and the session cannot be resumed. First observed
2026-08-03 on Claude Code 2.1.220; reproduced and the fix verified 2026-08-30
on Claude Code 2.1.251; re-verified live on real tmux 2026-09-04 on Claude
Code 2.1.260.

Fix: scrub both markers in the claude launch template in bin/fm-spawn.sh, and
again at the exact point each backend starts its own server in
bin/backends/herdr.sh and bin/backends/tmux.sh, adapted onto upstream's
current versions of those files rather than pasted from a fork copy of this
fix. Upstream had independently added CLAUDE_CODE_SEND_FEEDBACK=0 and
--settings '{"feedbackDrafts":"off"}' to the same claude launch line, and had
independently added an unset-based scrub for FM_HOME/harness-identity/
CLAUDECODE ahead of herdr's server start for an unrelated reason (home and
harness-identity leak prevention); both existing behaviors are preserved, with
the marker scrub layered on top. Includes tests in
tests/fm-backend-herdr.test.sh, tests/fm-backend-tmux-smoke.test.sh (a real
live tmux regression), and tests/fm-spawn-dispatch-profile.test.sh, plus the
verification record in docs/verification/runtime-backends.md and notes in
docs/herdr-backend.md and docs/tmux-backend.md.

This is written as an outside contribution per CONTRIBUTING.md, from a
dedicated clone whose origin is kunchenguid/firstmate and whose fork-url is
raywest/firstmate, kept free of fork-private context in the diff and PR body.
Commit trailers never name an agent as co-author, per AGENTS.md.

--skip rebase: this branch is deliberately based directly on origin/main
(kunchenguid/firstmate's main, via this dedicated clone) with exactly one
commit ahead; skipping rebase avoids any replay risk against an unrelated
branch and keeps that single-commit history exact.

## What Changed

- Scrub `CLAUDE_CODE_CHILD_SESSION` and `CLAUDECODE` from Claude worker launches and new Herdr/tmux server environments.
- Add Herdr, live tmux, and spawn-template regression coverage for marker removal.
- Document the backend behavior and versioned Claude Code verification evidence.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped, preserves existing launch behavior, and enforces the required marker scrub at both worker-launch and owned server-start boundaries with behavioral regression coverage.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (16m8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6529d378c86065f82b451cc447e551083b88e760","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"skipped"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

Step was skipped.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
