### PR TITLE
test: make permission-guard fixtures hold up under a root test runner

### DIFF
--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -2491,15 +2491,21 @@ test_inject_wedge_alarm_throttles_when_marker_cannot_be_written() {
   dir=$(make_wedge_case wedge-unwritable-marker)
   state="$dir/state"; log="$dir/alert.log"; daemon_log="$dir/daemon.log"
   escalate_add "$state" "needs-decision: pick A"
-  chmod u-w "$state"
-  WEDGE_ALARM_LAST_EPOCH=0
-  LOG="$daemon_log" FM_WEDGE_ALARM_LOG="$log" FM_MAX_DEFER_SECS=600 \
-    FM_WEDGE_ALARM_CHANNEL=osascript FM_SUPERVISOR_BACKEND=herdr \
-    inject_wedge_alarm "$state" 30600
-  LOG="$daemon_log" FM_WEDGE_ALARM_LOG="$log" FM_MAX_DEFER_SECS=600 \
-    FM_WEDGE_ALARM_CHANNEL=osascript FM_SUPERVISOR_BACKEND=herdr \
-    inject_wedge_alarm "$state" 30615
-  chmod u+w "$state"
+  # Both calls run inside one fm_run_dir_readonly child so WEDGE_ALARM_LAST_EPOCH
+  # (the throttle's in-memory state) stays shared between them exactly as it
+  # does when this runs unprotected; re-sourcing DAEMON gives that child the
+  # same inject_wedge_alarm this test file sourced at the top.
+  # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
+  fm_run_dir_readonly "$state" bash -c '
+    . "$1"
+    WEDGE_ALARM_LAST_EPOCH=0
+    LOG="$3" FM_WEDGE_ALARM_LOG="$4" FM_MAX_DEFER_SECS=600 \
+      FM_WEDGE_ALARM_CHANNEL=osascript FM_SUPERVISOR_BACKEND=herdr \
+      inject_wedge_alarm "$2" 30600
+    LOG="$3" FM_WEDGE_ALARM_LOG="$4" FM_MAX_DEFER_SECS=600 \
+      FM_WEDGE_ALARM_CHANNEL=osascript FM_SUPERVISOR_BACKEND=herdr \
+      inject_wedge_alarm "$2" 30615
+  ' _ "$DAEMON" "$state" "$daemon_log" "$log"
   [ ! -e "$state/.subsuper-inject-wedged" ] || fail "wedge marker unexpectedly persisted in an unwritable state directory"
   alerts=$(grep -c 'osascript' "$log" 2>/dev/null || true)
   [ "$alerts" -eq 1 ] || fail "unwritable marker emitted $alerts active alerts instead of one"

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -182,7 +182,10 @@ test_home_seed_refuses_unreadable_registry() {
   mkdir -p "$home/data" "$home/state" "$home/projects"
   printf '%s\n' '- design - design domain (home: /tmp/design; scope: design; projects: alpha; added 2026-07-30)' > "$registry"
   chmod 000 "$registry"
-  if FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null 2>"$err"; then
+  # A root reader (a CI runner running as root) walks straight past
+  # mode 000 via CAP_DAC_OVERRIDE; fm_run_without_dac_override drops it so
+  # fm-home-seed.sh's read is checked against the mode bits like anyone else.
+  if fm_run_without_dac_override env FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null 2>"$err"; then
     chmod 600 "$registry"
     fail "home-seed validation accepted an unreadable registry"
   fi
@@ -190,7 +193,7 @@ test_home_seed_refuses_unreadable_registry() {
     chmod 600 "$registry"
     fail "home-seed validation did not explain the unreadable registry"
   }
-  if FM_HOME="$home" FM_SECONDMATE_CHARTER='design domain' \
+  if fm_run_without_dac_override env FM_HOME="$home" FM_SECONDMATE_CHARTER='design domain' \
     "$ROOT/bin/fm-home-seed.sh" design "$sub" alpha >/dev/null 2>"$err"; then
     chmod 600 "$registry"
     fail "home seeding accepted an unreadable registry"
@@ -812,7 +815,11 @@ test_home_seed_refuses_projectless_home_with_uninspectable_registry() {
   registry_before=$(cat "$sub/data/projects.md")
   chmod 000 "$sub/data/projects.md"
 
-  if FM_HOME="$home" FM_SECONDMATE_CHARTER='firstmate self-development' \
+  # A root reader (a CI runner running as root) walks straight past
+  # mode 000 via CAP_DAC_OVERRIDE; fm_run_without_dac_override drops it so
+  # fm-home-seed.sh's inspection is checked against the mode bits like anyone
+  # else.
+  if fm_run_without_dac_override env FM_HOME="$home" FM_SECONDMATE_CHARTER='firstmate self-development' \
     FM_SECONDMATE_SCOPE='firstmate repo work' \
     "$ROOT/bin/fm-home-seed.sh" fdev "$sub" --no-projects >/dev/null 2>"$err"; then
     chmod 600 "$sub/data/projects.md"

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -717,7 +717,11 @@ test_home_seed_refuses_projectless_home_with_uninspectable_projects() {
   fm_git_init_commit "$sub/projects/hidden-clone"
   chmod 311 "$sub/projects"
 
-  if FM_HOME="$home" FM_SECONDMATE_CHARTER='firstmate self-development' \
+  # A root reader (a CI runner running as root) lists straight past mode 311
+  # via CAP_DAC_READ_SEARCH; fm_run_without_dac_override drops it so
+  # fm-home-seed.sh's inspection is checked against the mode bits like anyone
+  # else.
+  if fm_run_without_dac_override env FM_HOME="$home" FM_SECONDMATE_CHARTER='firstmate self-development' \
     FM_SECONDMATE_SCOPE='firstmate repo work' \
     "$ROOT/bin/fm-home-seed.sh" fdev "$sub" --no-projects >/dev/null 2>"$err"; then
     chmod 700 "$sub/projects"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -521,6 +521,9 @@ run_session_start() {
       "$SESSION_START"
   fi
 }
+# Exported so fm_run_without_dac_override's dropped-capability `bash -c` can
+# resolve it as a function rather than an external command.
+export -f run_session_start
 
 run_pi_session_start() {  # <home> <root> <path> [fm-session-start args...]
   local home=$1 root=$2 path=$3
@@ -829,11 +832,9 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   append_wake "$home/state" signal task-a "done: must remain queued" || fail "seed wake failed"
-  chmod 0500 "$home/state"
 
   status=0
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH") || status=$?
-  chmod 0700 "$home/state"
+  out=$(fm_run_dir_readonly "$home/state" run_session_start "$home" "$root" "$fakebin:$BASE_PATH") || status=$?
 
   expect_code 0 "$status" "fm-session-start.sh must exit 0 when lock publication fails"
   assert_contains "$out" "cannot write session lock" "lock publication failure was not surfaced"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -37,6 +37,10 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
 
 SESSION_START="$ROOT/bin/fm-session-start.sh"
+# Exported so run_session_start still resolves it when fm_run_dir_readonly
+# runs the function as a child of setpriv's fresh `bash -c`, which only
+# inherits the environment, not this script's plain shell variables.
+export SESSION_START
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 TMP_ROOT=$(fm_test_tmproot fm-session-start-tests)
 SESSION_START_TEST_HARNESS_PID=$$

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -31,6 +31,10 @@ unset NO_MISTAKES_GATE
 TMP_ROOT=$(fm_test_tmproot fm-sessionstart-nudge)
 NUDGE="$ROOT/bin/fm-sessionstart-nudge.sh"
 RUN="$ROOT/bin/fm-sessionstart-run.sh"
+# Exported so run_hook still resolves it when fm_run_dir_readonly runs the
+# function as a child of a fresh `unshare -rm bash -c`, which only inherits
+# the environment, not this script's plain shell variables.
+export RUN
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-operational-input.sh"
 NUDGE_TEXT="Run \`bin/fm-session-start.sh\` now, exactly once, before executing any other instructions."
@@ -178,6 +182,8 @@ EOF
 # PATH keeps every bootstrap probe fast and hermetic - it reports missing tools
 # instead of reaching the host's real gh/tmux/tasks-axi.
 RUN_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+# Exported for the same reason as RUN above.
+export RUN_PATH
 
 make_run_primary() {
   local dir=$1
@@ -193,6 +199,9 @@ run_hook() {  # <root> [args...]
   env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
     FM_GATE_REFUSE_BYPASS=0 FM_ROOT_OVERRIDE="$root" FM_HOME="$root" PATH="$RUN_PATH" "$RUN" "$@"
 }
+# Exported so fm_run_dir_readonly's inner `unshare -rm bash -c` can resolve it
+# as a function rather than an external command.
+export -f run_hook
 
 run_hook_pi() {  # <root> [args...]
   local root=$1
@@ -1006,9 +1015,7 @@ test_run_gate_and_scope_are_silent() {
 test_run_reports_a_failed_session_start_as_digest_text() {
   local root="$TMP_ROOT/run-unwritable" out status=0
   make_run_primary "$root"
-  chmod 0500 "$root/state"
-  out=$(run_hook "$root" --source startup </dev/null) || status=$?
-  chmod 0700 "$root/state"
+  out=$(fm_run_dir_readonly "$root/state" run_hook "$root" --source startup </dev/null) || status=$?
   expect_code 0 "$status" "run wrapper with an unwritable state directory"
   assert_contains "$out" "READ-ONLY SESSION" "a failed lock did not reach the agent as digest text"
   pass "run wrapper: a session start that cannot take the lock still opens the session and says so"

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -32,7 +32,7 @@ TMP_ROOT=$(fm_test_tmproot fm-sessionstart-nudge)
 NUDGE="$ROOT/bin/fm-sessionstart-nudge.sh"
 RUN="$ROOT/bin/fm-sessionstart-run.sh"
 # Exported so run_hook still resolves it when fm_run_dir_readonly runs the
-# function as a child of a fresh `unshare -rm bash -c`, which only inherits
+# function as a child of setpriv's fresh `bash -c`, which only inherits
 # the environment, not this script's plain shell variables.
 export RUN
 # shellcheck source=/dev/null
@@ -199,7 +199,7 @@ run_hook() {  # <root> [args...]
   env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
     FM_GATE_REFUSE_BYPASS=0 FM_ROOT_OVERRIDE="$root" FM_HOME="$root" PATH="$RUN_PATH" "$RUN" "$@"
 }
-# Exported so fm_run_dir_readonly's inner `unshare -rm bash -c` can resolve it
+# Exported so fm_run_dir_readonly's inner setpriv `bash -c` can resolve it
 # as a function rather than an external command.
 export -f run_hook
 

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -61,7 +61,11 @@ assert_shared_readonly() {
 
 assert_secondmate_write_fails() {
   local path=$1
-  if ( printf '%s\n' "secondmate edit" >> "$path" ) 2>/dev/null; then
+  # A root writer (a CI runner running as root) walks straight past
+  # the file's read-only mode via CAP_DAC_OVERRIDE; fm_run_without_dac_override
+  # drops it so this write is checked against the mode bits like anyone else.
+  # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
+  if fm_run_without_dac_override bash -c 'printf "%s\n" "secondmate edit" >> "$1"' _ "$path" 2>/dev/null; then
     fail "ordinary write unexpectedly succeeded for read-only shared captain file"
   fi
 }

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -198,7 +198,8 @@ test_unsafe_artifacts_and_failure_restore_readonly_mode() {
   before_mode=$(file_mode "$second/data/captain-shared.md")
   chmod 500 "$second/data"
   err="$TMP_ROOT/restore-readonly.err"
-  propagate_secondmate_inheritance "$primary" "$second" >/dev/null 2>"$err"; rc=$?
+  # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
+  fm_run_without_dac_override bash -c '. "$1/bin/fm-config-inherit-lib.sh"; propagate_secondmate_inheritance "$2" "$3"' _ "$ROOT" "$primary" "$second" >/dev/null 2>"$err"; rc=$?
   chmod 700 "$second/data"
   [ "$rc" -ne 0 ] || fail "unwritable destination directory should make quarantine fail"
   [ "$(file_mode "$second/data/captain-shared.md")" = "$before_mode" ] \

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -65,7 +65,7 @@ assert_secondmate_write_fails() {
   # the file's read-only mode via CAP_DAC_OVERRIDE; fm_run_without_dac_override
   # drops it so this write is checked against the mode bits like anyone else.
   # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
-  if fm_run_without_dac_override bash -c 'printf "%s\n" "secondmate edit" >> "$1"' _ "$path" 2>/dev/null; then
+  if fm_run_without_dac_override bash -c '{ printf "%s\n" "secondmate edit" >> "$1"; } 2>/dev/null' _ "$path"; then
     fail "ordinary write unexpectedly succeeded for read-only shared captain file"
   fi
 }

--- a/tests/fm-startup-network.test.sh
+++ b/tests/fm-startup-network.test.sh
@@ -271,7 +271,10 @@ EOF
     FM_SESSION_START_TIMEOUT=4 FM_FAKE_BOOTSTRAP_LOG="$1" FM_FAKE_BOOTSTRAP_OUT="unpublishable result" \
       run_stage "$2" "$3" start --locked 0 --harvest-pid "$4"
   ' _ "$log" "$home" "$root" "$claimant"
-  run_stage "$home" "$root" wait 30 >/dev/null || fail "the report-publication failure never settled"
+  if ! run_stage "$home" "$root" wait 30 >/dev/null; then
+    fm_dir_unblock_writes "$home/state/.startup-network.report"
+    fail "the report-publication failure never settled"
+  fi
   fm_dir_unblock_writes "$home/state/.startup-network.report"
   state=$(sed -n 's/^state=//p' "$home/state/.startup-network.status")
   [ "$state" = failed ] || fail "a report-publication failure was published as $state"

--- a/tests/fm-startup-network.test.sh
+++ b/tests/fm-startup-network.test.sh
@@ -119,7 +119,7 @@ run_stage() {  # <home> <root> <args...>
   PATH="$root/bin:$PATH" FM_FAKE_HARNESS_PID="${FM_FAKE_HARNESS_PID_OVERRIDE:-$$}" \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$root" "$root/bin/fm-startup-network.sh" "$@"
 }
-# Exported so fm_run_dir_readonly's inner `unshare -rm bash -c` can resolve it
+# Exported so fm_run_dir_readonly's inner setpriv `bash -c` can resolve it
 # as a function rather than an external command.
 export -f run_stage
 

--- a/tests/fm-startup-network.test.sh
+++ b/tests/fm-startup-network.test.sh
@@ -119,6 +119,9 @@ run_stage() {  # <home> <root> <args...>
   PATH="$root/bin:$PATH" FM_FAKE_HARNESS_PID="${FM_FAKE_HARNESS_PID_OVERRIDE:-$$}" \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$root" "$root/bin/fm-startup-network.sh" "$@"
 }
+# Exported so fm_run_dir_readonly's inner `unshare -rm bash -c` can resolve it
+# as a function rather than an external command.
+export -f run_stage
 
 wait_for_startup_network_wake() {  # <home> [tenths]
   local home=$1 limit=${2:-50} waited=0
@@ -249,13 +252,27 @@ test_a_report_publication_failure_is_failed_and_still_wakes() {
 $rec
 EOF
   mkdir "$home/state/.startup-network.report"
-  chmod 500 "$home/state/.startup-network.report"
   sleep 10 &
   claimant=$!
 
-  FM_SESSION_START_TIMEOUT=4 FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_OUT='unpublishable result' \
-    run_stage "$home" "$root" start --locked 0 --harvest-pid "$claimant"
+  # The deferred worker `start` launches (via nohup ... &) is forked from
+  # inside fm_run_without_dac_override's dropped-capability process, so it
+  # inherits that same capability set and stays subject to the block below
+  # for its own lifetime - the whole reason this wraps `start` rather than
+  # the write itself. fm_run_dir_readonly cannot be used here: it restores
+  # write access the instant `start` returns, which is immediate by design,
+  # long before this worker gets to publish() moments later. The block must
+  # outlive this call and is lifted explicitly below, once `wait` proves the
+  # worker actually ran.
+  fm_dir_block_writes "$home/state/.startup-network.report" \
+    || fail "could not verify a write-block for root on the report directory"
+  # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
+  fm_run_without_dac_override bash -c '
+    FM_SESSION_START_TIMEOUT=4 FM_FAKE_BOOTSTRAP_LOG="$1" FM_FAKE_BOOTSTRAP_OUT="unpublishable result" \
+      run_stage "$2" "$3" start --locked 0 --harvest-pid "$4"
+  ' _ "$log" "$home" "$root" "$claimant"
   run_stage "$home" "$root" wait 30 >/dev/null || fail "the report-publication failure never settled"
+  fm_dir_unblock_writes "$home/state/.startup-network.report"
   state=$(sed -n 's/^state=//p' "$home/state/.startup-network.status")
   [ "$state" = failed ] || fail "a report-publication failure was published as $state"
 
@@ -273,7 +290,6 @@ EOF
 
   kill "$claimant" 2>/dev/null || true
   wait "$claimant" 2>/dev/null || true
-  chmod 700 "$home/state/.startup-network.report"
   pass "fm-startup-network: a report-publication failure is failed, diagnosed, and still wakes"
 }
 

--- a/tests/fm-startup-network.test.sh
+++ b/tests/fm-startup-network.test.sh
@@ -271,10 +271,7 @@ EOF
     FM_SESSION_START_TIMEOUT=4 FM_FAKE_BOOTSTRAP_LOG="$1" FM_FAKE_BOOTSTRAP_OUT="unpublishable result" \
       run_stage "$2" "$3" start --locked 0 --harvest-pid "$4"
   ' _ "$log" "$home" "$root" "$claimant"
-  if ! run_stage "$home" "$root" wait 30 >/dev/null; then
-    fm_dir_unblock_writes "$home/state/.startup-network.report"
-    fail "the report-publication failure never settled"
-  fi
+  run_stage "$home" "$root" wait 30 >/dev/null || fail "the report-publication failure never settled"
   fm_dir_unblock_writes "$home/state/.startup-network.report"
   state=$(sed -n 's/^state=//p' "$home/state/.startup-network.status")
   [ "$state" = failed ] || fail "a report-publication failure was published as $state"

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -9,7 +9,12 @@ set -u
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-trace-context-lib.sh"
 
+# Exported so fm_run_without_dac_override's dropped-capability `bash -c` child
+# (a fresh bash process with no inherited unexported variables) can still
+# resolve it inside run_spawn, which is exported as a function but closes
+# over this variable rather than taking it as a parameter.
 SPAWN="$ROOT/bin/fm-spawn.sh"
+export SPAWN
 TMP_ROOT=$(fm_test_tmproot fm-trace-context-spawn)
 
 write_ship_brief() {  # <file> <id>
@@ -136,6 +141,9 @@ run_spawn() {
     FM_FAKE_LAUNCH_LOG="$launchlog" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" --mode no-mistakes --yolo off 2>&1
 }
+# Exported so fm_run_without_dac_override's dropped-capability `bash -c` can
+# resolve it as a function rather than an external command.
+export -f run_spawn
 
 # Same, but with an explicit FM_TRACE_CONTEXT override, to prove the env decides.
 run_spawn_tc() {
@@ -354,8 +362,13 @@ test_failed_metadata_append_unsets_carrier_and_still_launches() {
   : > "$HOME_DIR/config/trace-context"
   start_trace_session "$HOME_DIR"
 
+  # The fake tmux chmod a-w's the meta file mid-run (FM_FAKE_TRACE_METADATA_
+  # APPEND_FAIL=1 above); a root writer (a CI runner running as root)
+  # walks straight past that via CAP_DAC_OVERRIDE, so fm-spawn.sh's later
+  # append would silently succeed instead of exercising the failure path this
+  # test targets. fm_run_without_dac_override drops it for the whole spawn.
   out=$(FM_FAKE_TRACE_METADATA_APPEND_FAIL=1 \
-    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$CASE_ID" "$PROJ_DIR")
+    fm_run_without_dac_override run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$CASE_ID" "$PROJ_DIR")
   status=$?
   expect_code 0 "$status" "failed traceparent metadata append must not abort spawn"
   assert_contains "$out" "spawned $CASE_ID" "spawn should report success after failed metadata append"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -7,12 +7,13 @@
 #
 # It provides the boilerplate every test file used to re-roll: ok/not-ok
 # reporters, a self-cleaning temp root, fakebin/PATH-shim helpers, deterministic
-# git identity and fixture builders, state/<id>.meta writers, and the common
-# string/exit-code/file assertions. Shared fake-toolchain and spawn-world
-# builders live in tests/fixtures.sh; wake-queue mocks in wake-helpers.sh;
-# secondmate-lifecycle mocks in secondmate-helpers.sh. Suite-specific fakes
-# that encode a single test's terminal or lifecycle assumptions still belong
-# with the tests that own them.
+# git identity and fixture builders, state/<id>.meta writers, root-safe
+# unwritable/unreadable-path simulation (fm_run_dir_readonly and friends), and
+# the common string/exit-code/file assertions. Shared fake-toolchain and
+# spawn-world builders live in tests/fixtures.sh; wake-queue mocks in
+# wake-helpers.sh; secondmate-lifecycle mocks in secondmate-helpers.sh.
+# Suite-specific fakes that encode a single test's terminal or lifecycle
+# assumptions still belong with the tests that own them.
 #
 # ROOT is exported as the firstmate repo root (this file lives in tests/), so a
 # sourcing test can use "$ROOT/bin/..." without recomputing it.

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -427,8 +427,8 @@ fm_touch_epoch() {
 #
 # chmod alone (the obvious way to simulate "this path cannot be written or
 # read") only blocks a non-root caller: a root process holding
-# CAP_DAC_OVERRIDE - the default for a container's root user, and how CI
-# a CI runner running this suite as root does - walks
+# CAP_DAC_OVERRIDE and/or CAP_DAC_READ_SEARCH - the default for a container's
+# root user, and how a CI runner running this suite as root does - walks
 # straight past permission bits and the simulated failure never happens, so
 # the behavior it was meant to exercise silently goes untested.
 #
@@ -457,10 +457,15 @@ fm_touch_epoch() {
 # mistake this whole rewrite exists to correct.
 
 # fm_run_without_dac_override <command...>: run <command...> normally when
-# not root (plain DAC checks already apply). As root, run it with
-# CAP_DAC_OVERRIDE removed from the capability bounding set, so any file mode
-# bits <command...> encounters (including ones it sets up itself, like a fake
-# tool chmod'ing a path mid-run) are enforced against it instead of bypassed.
+# not root (plain DAC checks already apply). As root, run it with both
+# CAP_DAC_OVERRIDE and CAP_DAC_READ_SEARCH removed from the capability
+# bounding set, so any file mode bits <command...> encounters (including ones
+# it sets up itself, like a fake tool chmod'ing a path mid-run) are enforced
+# against it instead of bypassed. Both capabilities independently let a
+# process bypass a file's read permission bits, so a read-denial fixture
+# (e.g. chmod 000) that dropped only CAP_DAC_OVERRIDE would still be read via
+# CAP_DAC_READ_SEARCH alone - dropping just one leaves the other capability
+# free to defeat the simulated failure.
 # <command...> is looked up as a shell function first (via the exported
 # BASH_FUNC_ mechanism), then as an external command, exactly as bash
 # ordinarily resolves a simple command.
@@ -470,7 +475,7 @@ fm_run_without_dac_override() {
     return $?
   fi
   # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
-  setpriv --bounding-set=-dac_override -- bash -c '"$@"' _ "$@"
+  setpriv --bounding-set=-dac_override,-dac_read_search -- bash -c '"$@"' _ "$@"
 }
 
 # _fm_dac_override_drop_blocks_write <dir>: true only if

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -86,6 +86,13 @@ pass() {
 FM_TEST_CLEANUP_DIRS=()
 FM_TEST_CLEANUP_REGISTRY=$(mktemp "${TMPDIR:-/tmp}/.fm-test-cleanup.$$.XXXXXX") || return 1
 
+# Directories currently write-blocked via fm_dir_block_writes, so
+# fm_test_cleanup can unblock them if a signal cuts a test off before its
+# matching fm_dir_unblock_writes runs. Lives in-process (not the registry
+# file $$-keyed subshells need): every caller of fm_dir_block_writes runs
+# directly in the test process, never in a captured subshell.
+FM_TEST_BLOCKED_DIRS=()
+
 fm_test_pid_identity() {
   local pid=$1
   FM_STATE_OVERRIDE="${TMPDIR:-/tmp}" bash -c \
@@ -150,6 +157,14 @@ export FM_TEST_STUB_MAX_BLOCK_SECONDS
 fm_test_cleanup() {
   local d
   fm_test_reap_procevent_homes
+  # Restore write access to any directory a test left blocked via
+  # fm_dir_block_writes before removing it below: a signal landing between
+  # fm_dir_block_writes and its matching fm_dir_unblock_writes would otherwise
+  # reach this trap while the directory is still unwritable, and a non-root
+  # `rm -rf` cannot unlink entries from a write-blocked directory.
+  for d in "${FM_TEST_BLOCKED_DIRS[@]:-}"; do
+    [ -n "$d" ] && chmod u+w "$d" 2>/dev/null
+  done
   for d in "${FM_TEST_CLEANUP_DIRS[@]:-}"; do
     [ -n "$d" ] && rm -rf "$d"
   done
@@ -513,6 +528,7 @@ fm_dir_block_writes() {
     chmod u+w "$dir"
     return 97
   fi
+  FM_TEST_BLOCKED_DIRS+=("$dir")
   return 0
 }
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -86,13 +86,6 @@ pass() {
 FM_TEST_CLEANUP_DIRS=()
 FM_TEST_CLEANUP_REGISTRY=$(mktemp "${TMPDIR:-/tmp}/.fm-test-cleanup.$$.XXXXXX") || return 1
 
-# Directories currently write-blocked via fm_dir_block_writes, so
-# fm_test_cleanup can unblock them if a signal cuts a test off before its
-# matching fm_dir_unblock_writes runs. Lives in-process (not the registry
-# file $$-keyed subshells need): every caller of fm_dir_block_writes runs
-# directly in the test process, never in a captured subshell.
-FM_TEST_BLOCKED_DIRS=()
-
 fm_test_pid_identity() {
   local pid=$1
   FM_STATE_OVERRIDE="${TMPDIR:-/tmp}" bash -c \
@@ -154,23 +147,30 @@ fm_test_reap_procevent_homes() {
 FM_TEST_STUB_MAX_BLOCK_SECONDS=${FM_TEST_STUB_MAX_BLOCK_SECONDS:-120}
 export FM_TEST_STUB_MAX_BLOCK_SECONDS
 
+# fm_test_remove_tree <dir>: rm -rf <dir> after restoring owner access to
+# every directory under it. A fixture directory can still be chmod'd
+# unwritable when its tree is removed - fm_dir_block_writes run inside a
+# command substitution that a signal cut off before fm_dir_unblock_writes, or
+# a killed prior run - and a non-root `rm -rf` cannot unlink entries from
+# it. Restoring access here, from the tree itself, covers every such caller
+# without having to track which directories were blocked or in which shell.
+fm_test_remove_tree() {
+  local dir=$1
+  if [ -d "$dir" ] && [ ! -L "$dir" ]; then
+    find "$dir" -type d -exec chmod u+rwx {} + 2>/dev/null || true
+  fi
+  rm -rf "$dir"
+}
+
 fm_test_cleanup() {
   local d
   fm_test_reap_procevent_homes
-  # Restore write access to any directory a test left blocked via
-  # fm_dir_block_writes before removing it below: a signal landing between
-  # fm_dir_block_writes and its matching fm_dir_unblock_writes would otherwise
-  # reach this trap while the directory is still unwritable, and a non-root
-  # `rm -rf` cannot unlink entries from a write-blocked directory.
-  for d in "${FM_TEST_BLOCKED_DIRS[@]:-}"; do
-    [ -n "$d" ] && chmod u+w "$d" 2>/dev/null
-  done
   for d in "${FM_TEST_CLEANUP_DIRS[@]:-}"; do
-    [ -n "$d" ] && rm -rf "$d"
+    [ -n "$d" ] && fm_test_remove_tree "$d"
   done
   if [ -f "$FM_TEST_CLEANUP_REGISTRY" ]; then
     while IFS= read -r d; do
-      [ -n "$d" ] && rm -rf "$d"
+      [ -n "$d" ] && fm_test_remove_tree "$d"
     done < "$FM_TEST_CLEANUP_REGISTRY"
     rm -f "$FM_TEST_CLEANUP_REGISTRY"
   fi
@@ -224,10 +224,7 @@ fm_test_reap_orphans() {
     mtime=$(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null) || continue
     [ $((now - mtime)) -ge "$FM_TEST_ORPHAN_MAX_AGE_SECONDS" ] || continue
     dir=$(dirname "$marker")
-    if [ -d "$dir" ] && [ ! -L "$dir" ]; then
-      find "$dir" -type d -exec chmod u+rwx {} + 2>/dev/null || true
-    fi
-    rm -rf "$dir"
+    fm_test_remove_tree "$dir"
   done
 }
 
@@ -462,8 +459,9 @@ fm_touch_epoch() {
 #
 # Dropping CAP_DAC_OVERRIDE itself needs no namespace: CAP_SETPCAP (also
 # ordinary for a container's root user) lets setpriv shrink the capability
-# bounding set for one exec'd command, so <command...> ends up subject to
-# plain file-mode checks like anyone else, while the calling shell (and
+# bounding and inheritable sets for one exec'd command, so <command...> ends
+# up subject to plain file-mode checks like anyone else, while the calling
+# shell (and
 # every path <command...> is not meant to touch) keeps root's normal access -
 # no uid change, so no separate traversal/ownership setup for the rest of the
 # fixture tree. fm_run_without_dac_override is the primitive; the two
@@ -475,9 +473,10 @@ fm_touch_epoch() {
 # fm_run_without_dac_override <command...>: run <command...> normally when
 # not root (plain DAC checks already apply). As root, run it with both
 # CAP_DAC_OVERRIDE and CAP_DAC_READ_SEARCH removed from the capability
-# bounding set, so any file mode bits <command...> encounters (including ones
-# it sets up itself, like a fake tool chmod'ing a path mid-run) are enforced
-# against it instead of bypassed. Both capabilities independently let a
+# bounding and inheritable sets (a root exec regains any capability left in
+# the inheritable set, whatever the bounding set says), so any file mode bits
+# <command...> encounters (including ones it sets up itself, like a fake tool
+# chmod'ing a path mid-run) are enforced against it instead of bypassed. Both capabilities independently let a
 # process bypass a file's read permission bits, so a read-denial fixture
 # (e.g. chmod 000) that dropped only CAP_DAC_OVERRIDE would still be read via
 # CAP_DAC_READ_SEARCH alone - dropping just one leaves the other capability
@@ -485,13 +484,19 @@ fm_touch_epoch() {
 # <command...> is looked up as a shell function first (via the exported
 # BASH_FUNC_ mechanism), then as an external command, exactly as bash
 # ordinarily resolves a simple command.
+# As root, fails the test outright when setpriv is missing or cannot apply the
+# drop: a nonzero status there would read as "the command was denied" to a
+# caller asserting a denial, which would then pass without running anything.
 fm_run_without_dac_override() {
+  local drop=(setpriv '--bounding-set=-dac_override,-dac_read_search' '--inh-caps=-dac_override,-dac_read_search')
   if [ "$(id -u)" != 0 ]; then
     "$@"
     return $?
   fi
+  "${drop[@]}" -- true 2>/dev/null \
+    || fail "fm_run_without_dac_override: setpriv cannot drop CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH for root; refusing to run $1 with root's permission bypass"
   # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
-  setpriv --bounding-set=-dac_override,-dac_read_search -- bash -c '"$@"' _ "$@"
+  "${drop[@]}" -- bash -c '"$@"' _ "$@"
 }
 
 # _fm_dac_override_drop_blocks_write <dir>: true only if
@@ -501,9 +506,8 @@ fm_run_without_dac_override() {
 _fm_dac_override_drop_blocks_write() {
   local dir=$1 probe rc
   probe="$dir/.fm-run-dir-readonly-probe.$$"
-  command -v setpriv >/dev/null 2>&1 || return 1
   # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
-  fm_run_without_dac_override bash -c '>"$1"' _ "$probe" 2>/dev/null
+  fm_run_without_dac_override bash -c '{ : >"$1"; } 2>/dev/null' _ "$probe"
   rc=$?
   rm -f "$probe" 2>/dev/null
   [ "$rc" -ne 0 ]
@@ -528,7 +532,6 @@ fm_dir_block_writes() {
     chmod u+w "$dir"
     return 97
   fi
-  FM_TEST_BLOCKED_DIRS+=("$dir")
   return 0
 }
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -423,6 +423,115 @@ fm_touch_epoch() {
     || fail "fm_touch_epoch: touch -t $stamp failed for $*"
 }
 
+# --- unwritable/unreadable-path simulation -----------------------------------
+#
+# chmod alone (the obvious way to simulate "this path cannot be written or
+# read") only blocks a non-root caller: a root process holding
+# CAP_DAC_OVERRIDE - the default for a container's root user, and how CI
+# a CI runner running this suite as root does - walks
+# straight past permission bits and the simulated failure never happens, so
+# the behavior it was meant to exercise silently goes untested.
+#
+# A read-only bind mount (this suite's first attempt at a fix) is enforced by
+# the kernel regardless of DAC checks, but building one needs a mount
+# namespace with CAP_SYS_ADMIN inside it, normally obtained via
+# `unshare -rm` (a fresh user+mount namespace maps the caller to root inside
+# it, which grants CAP_SYS_ADMIN there even when the real process lacks it).
+# That in turn needs the kernel to allow creating unprivileged user
+# namespaces at all, which some hosts disable - and it silently disabled
+# itself right where it was needed most: CI's self-hosted runner refuses
+# `unshare -rm` too, so every caller fell back to running fully unprotected
+# and the assertions it was meant to gate on started failing outright instead
+# of catching a real regression.
+#
+# Dropping CAP_DAC_OVERRIDE itself needs no namespace: CAP_SETPCAP (also
+# ordinary for a container's root user) lets setpriv shrink the capability
+# bounding set for one exec'd command, so <command...> ends up subject to
+# plain file-mode checks like anyone else, while the calling shell (and
+# every path <command...> is not meant to touch) keeps root's normal access -
+# no uid change, so no separate traversal/ownership setup for the rest of the
+# fixture tree. fm_run_without_dac_override is the primitive; the two
+# wrappers below add the chmod and, for the directory form, an empirical
+# proof the drop actually holds before trusting it with the real command,
+# because assuming a namespace or capability trick works is exactly the
+# mistake this whole rewrite exists to correct.
+
+# fm_run_without_dac_override <command...>: run <command...> normally when
+# not root (plain DAC checks already apply). As root, run it with
+# CAP_DAC_OVERRIDE removed from the capability bounding set, so any file mode
+# bits <command...> encounters (including ones it sets up itself, like a fake
+# tool chmod'ing a path mid-run) are enforced against it instead of bypassed.
+# <command...> is looked up as a shell function first (via the exported
+# BASH_FUNC_ mechanism), then as an external command, exactly as bash
+# ordinarily resolves a simple command.
+fm_run_without_dac_override() {
+  if [ "$(id -u)" != 0 ]; then
+    "$@"
+    return $?
+  fi
+  # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
+  setpriv --bounding-set=-dac_override -- bash -c '"$@"' _ "$@"
+}
+
+# _fm_dac_override_drop_blocks_write <dir>: true only if
+# fm_run_without_dac_override actually stops a throwaway write inside <dir>
+# (which the caller must already have chmod a-w'd), proven empirically
+# rather than assumed.
+_fm_dac_override_drop_blocks_write() {
+  local dir=$1 probe rc
+  probe="$dir/.fm-run-dir-readonly-probe.$$"
+  command -v setpriv >/dev/null 2>&1 || return 1
+  # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
+  fm_run_without_dac_override bash -c '>"$1"' _ "$probe" 2>/dev/null
+  rc=$?
+  rm -f "$probe" 2>/dev/null
+  [ "$rc" -ne 0 ]
+}
+
+# fm_dir_block_writes <dir>: chmod <dir> unwritable and, as root, prove the
+# block actually holds before returning success. Leaves <dir> writable again
+# and refuses (nonzero, no diagnostic needed - the caller decides how loud to
+# be) when running as root and the block cannot be proven.
+#
+# Split out from fm_run_dir_readonly for the one shape that wrapper cannot
+# cover: a caller whose protected write happens after the command that
+# triggers it has already returned, e.g. fm-startup-network.sh's `start`
+# forks a detached worker and returns immediately, so the block has to
+# outlive that call and be lifted explicitly later with fm_dir_unblock_writes
+# once the worker has actually run - not the instant the launching command
+# exits.
+fm_dir_block_writes() {
+  local dir=$1
+  chmod a-w "$dir"
+  if [ "$(id -u)" = 0 ] && ! _fm_dac_override_drop_blocks_write "$dir"; then
+    chmod u+w "$dir"
+    return 97
+  fi
+  return 0
+}
+
+fm_dir_unblock_writes() {
+  chmod u+w "$1"
+}
+
+# fm_run_dir_readonly <dir> <command...>: fm_dir_block_writes <dir>, run
+# <command...>, then fm_dir_unblock_writes <dir>. Use this when <command...>
+# itself performs (or fails to perform) the protected write before returning;
+# use fm_dir_block_writes/fm_dir_unblock_writes directly when the write
+# happens later, off a background worker <command...> only launches.
+fm_run_dir_readonly() {
+  local dir=$1
+  shift
+  if ! fm_dir_block_writes "$dir"; then
+    printf 'fm_run_dir_readonly: cannot verify a write-block for root on %s; refusing to run %s unprotected\n' "$dir" "$1" >&2
+    return 97
+  fi
+  fm_run_without_dac_override "$@"
+  local rc=$?
+  fm_dir_unblock_writes "$dir"
+  return $rc
+}
+
 # --- deterministic git identity and fixtures --------------------------------
 
 # fm_git_identity [name] [email]: export a fixed author/committer identity so

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -487,16 +487,23 @@ fm_touch_epoch() {
 # As root, fails the test outright when setpriv is missing or cannot apply the
 # drop: a nonzero status there would read as "the command was denied" to a
 # caller asserting a denial, which would then pass without running anything.
+# That refusal is probed once here, while stderr is still the test's own, and
+# reported on a copy of it: callers asserting a denial redirect the call's
+# stderr to a scratch file their cleanup deletes.
+FM_TEST_DAC_DROP=(setpriv '--bounding-set=-dac_override,-dac_read_search' '--inh-caps=-dac_override,-dac_read_search')
+if [ "$(id -u)" = 0 ] && ! "${FM_TEST_DAC_DROP[@]}" -- true 2>/dev/null; then
+  exec {FM_TEST_DAC_DROP_REFUSAL_FD}>&2
+fi
 fm_run_without_dac_override() {
-  local drop=(setpriv '--bounding-set=-dac_override,-dac_read_search' '--inh-caps=-dac_override,-dac_read_search')
   if [ "$(id -u)" != 0 ]; then
     "$@"
     return $?
   fi
-  "${drop[@]}" -- true 2>/dev/null \
-    || fail "fm_run_without_dac_override: setpriv cannot drop CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH for root; refusing to run $1 with root's permission bypass"
+  if [ -n "${FM_TEST_DAC_DROP_REFUSAL_FD:-}" ]; then
+    fail "fm_run_without_dac_override: setpriv cannot drop CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH for root; refusing to run $1 with root's permission bypass" 2>&"$FM_TEST_DAC_DROP_REFUSAL_FD"
+  fi
   # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
-  "${drop[@]}" -- bash -c '"$@"' _ "$@"
+  "${FM_TEST_DAC_DROP[@]}" -- bash -c '"$@"' _ "$@"
 }
 
 # _fm_dac_override_drop_blocks_write <dir>: true only if

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -523,7 +523,9 @@ _fm_dac_override_drop_blocks_write() {
 # fm_dir_block_writes <dir>: chmod <dir> unwritable and, as root, prove the
 # block actually holds before returning success. Leaves <dir> writable again
 # and refuses (nonzero, no diagnostic needed - the caller decides how loud to
-# be) when running as root and the block cannot be proven.
+# be) when running as root and the block cannot be proven; a setpriv that
+# cannot apply the drop at all fails the test outright instead (see
+# fm_run_without_dac_override).
 #
 # Split out from fm_run_dir_readonly for the one shape that wrapper cannot
 # cover: a caller whose protected write happens after the command that


### PR DESCRIPTION
## Intent

Captain's go (2026-09-11): "go fuer alle4". This task is point 2 of that go.
Refresh the two open pull requests from the fork `MLA82/firstmate` to `kunchenguid/firstmate` through a clean no-mistakes run on no-mistakes v1.68.0 or newer, so the repository's required check `PR must be raised via no-mistakes` receives a fresh, valid attestation bound to each PR's current head:
- https://github.com/kunchenguid/firstmate/pull/3722 - branch `publish/r1-root-safe-test-guards`: root-safe test fixture guards (tests keep working when run as root, and a signal during cleanup no longer leaves a write-blocked directory behind).
- https://github.com/kunchenguid/firstmate/pull/3726 - branch `publish/r7-locale-completion`: run `comm` under `LC_ALL=C` in the test-run coverage guard so it is independent of the shell locale.
The code change of each PR stays as it is. Both PRs failed the check because they were first opened without no-mistakes and later updated by a no-mistakes version that pushed before writing the attestation. No hand-edited attestation, no re-run of the old failed workflow attempts, no force-push; local state is reconciled to the real PR head first.

Captain 2026-09-11: "1. mach force" - a lease-guarded force-push through the no-mistakes pipeline is authorized for exactly publish/r1-root-safe-test-guards (PR 3722) on MLA82/firstmate, leased against fork head d22b82fac13b82248eab915e74da2f3de62b6374; no other branch.

## What Changed

- Added root-safe helpers for simulating unwritable or unreadable paths to `tests/lib.sh`. `fm_run_without_dac_override` uses `setpriv` to drop `CAP_DAC_OVERRIDE` and `CAP_DAC_READ_SEARCH` from the command it runs when the tests run as root, and fails the test outright if `setpriv` can't apply the drop. `fm_dir_block_writes` and `fm_dir_unblock_writes` check that a write-block really stops writes as root before relying on it. `fm_run_dir_readonly` wraps a command with the block and unblock steps.
- Switched the chmod-based denial fixtures in `fm-daemon`, `fm-secondmate-safety`, `fm-session-start`, `fm-sessionstart-nudge`, `fm-shared-captain-inheritance`, `fm-startup-network` and `fm-trace-context-spawn` over to these helpers, so the denials they simulate still happen when root runs the suite. The helper functions and variables these tests use are now exported so the `bash -c` child can still find them. In the `fm-startup-network` report-publication test, the block now lasts until its detached worker has finished.
- Added `fm_test_remove_tree`, which restores owner access to every directory in a fixture tree before running `rm -rf`. Both `fm_test_cleanup` and orphan reaping now use it, so a directory left write-blocked by a signal or a killed run no longer stays behind after cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Risk Assessment

✅ Low: The fix round is a small, test-only change that does what the captain asked: with a working setpriv, and on non-root runners, it behaves as before, and on a root runner where setpriv refuses, the diagnostic now reaches the test's own stderr and the test still fails. The only defect found is on a rare root-on-stock-bash-3.2 runner, where the suite still fails loudly but with a misleading message.

## Testing

I ran the changed harness as a normal user and as a simulated root (`unshare -r`, uid 0 with full capabilities). Each fix was run against the commit before it. The signal-cleanup gap reproduces on d7c10c1 (a 555 state dir is left behind) and is fixed at HEAD. The inheritable-capability bypass forces a refusal (97) on d7c10c1, while at HEAD the write is denied. With stderr redirected, the setpriv-refusal diagnostic is silent on d337c52 and visible at HEAD. fm-shared-captain-inheritance and fm-secondmate-safety fail as root at base and pass as root at HEAD (8/8 and 77/77). The full non-root run of all 7 changed test files passed with exit 0. The root run of the other 5 files had not finished and is reported as untested. This is a test-harness-only change with no UI, so the evidence is CLI transcripts rather than screenshots. I removed the /tmp scratch comparison trees, and the worktree has no changes.

- Live validation: ✅ go - 5 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A per-script timeout or Ctrl-C TERM that lands while fm_dir_block_writes has a fixture dir blocked inside $(...) no longer leaves the write-blocked temp root behind | ✅ pass | live | signal-cleanup-transcript.txt: d7c10c1 left /tmp/fm-sigrepro-fixture.* with dr-xr-xr-x state/ (rm: Keine Berechtigung). HEAD: &#39;fixture root removed by fm_test_cleanup&#39;, exit 143 |
| Adversarial: on a root runner whose inheritable set holds CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH, fm_run_dir_readonly still blocks the write | ✅ pass | live | inheritable-caps-transcript.txt: a bounding-set-only drop lets the write through. d7c10c1 helper refuses with 97. HEAD helper denies the write (rc=1, file not created) |
| Adversarial: on a root runner where setpriv cannot drop the caps, a denial-asserting test that redirects stderr fails with a visible `not ok` diagnostic instead of silently or vacuously | ✅ pass | live | refusal-caller-shape-transcript.txt: d337c52 exits 1 with no output. HEAD prints &#39;not ok - fm_run_without_dac_override: setpriv cannot drop ...&#39; and exits 1. setpriv-refusal-secondmate-safety-transcri… |
| Permission-guard tests keep working when run as root: fm-shared-captain-inheritance and fm-secondmate-safety fail as root at base and pass as root at HEAD | ✅ pass | live | base-under-root-transcript.txt (&#39;ordinary write unexpectedly succeeded...&#39;, &#39;home-seed validation accepted an unreadable registry&#39;, exit 1). head-under-root-fast-transcript.txt (8/8 and 77/77 ok, exit… |
| All 7 changed test files still pass for a non-root runner | ✅ pass | live | nonroot-changed-tests.log: 318 ok, 0 not ok, exit=0 across the 7 files |
| fm-daemon, fm-session-start, fm-sessionstart-nudge, fm-startup-network, fm-trace-context-spawn pass under a root runner | ⏸️ untested | no | The run had not finished when structured output was required. Re-run `unshare -r bin/fm-test-run.sh --jobs 1 &lt;those 5 files&gt;` to completion (unprivileged user namespaces are available on this host), o… |

<details>
<summary>Evidence: Signal during cleanup: d7c10c1 leaves write-blocked fixture, HEAD removes it</summary>

Source: [Signal during cleanup: d7c10c1 leaves write-blocked fixture, HEAD removes it](https://github.com/MLA82/firstmate/blob/cac97fb55a75a477a1aace6c60f1e3a7323a66cc/.no-mistakes/evidence/publish/r1-root-safe-test-guards/signal-cleanup-transcript.txt)

```text
=== BEFORE (d7c10c1: in-process FM_TEST_BLOCKED_DIRS) ===
lib.sh under test: /tmp/fm-cmp-d7c10c1/tests/lib.sh (uid 2008)
fixture root: /tmp/fm-sigrepro-fixture.lYlluU
state dir mode while blocked: 555
rm: das Entfernen von '/tmp/fm-sigrepro-fixture.lYlluU/home/state/entry' ist nicht möglich: Keine Berechtigung
test process exit after group TERM: 143
RESULT: fixture root LEFT BEHIND after cleanup:
  drwx------ /tmp/fm-sigrepro-fixture.lYlluU
  drwxr-xr-x /tmp/fm-sigrepro-fixture.lYlluU/home
  dr-xr-xr-x /tmp/fm-sigrepro-fixture.lYlluU/home/state
  -rw-r--r-- /tmp/fm-sigrepro-fixture.lYlluU/home/state/entry

=== AFTER (HEAD 17210fd: fm_test_remove_tree sweep) ===
lib.sh under test: ~/.no-mistakes/worktrees/c9a671237ef3/01M28DPZ7CXAHVT2NBTC56S9VQ/tests/lib.sh (uid 2008)
fixture root: /tmp/fm-sigrepro-fixture.5sWMej
state dir mode while blocked: 555
test process exit after group TERM: 143
RESULT: fixture root removed by fm_test_cleanup
```
</details>
<details>
<summary>Evidence: Signal-cleanup repro driver</summary>

Source: [Signal-cleanup repro driver](https://github.com/MLA82/firstmate/blob/cac97fb55a75a477a1aace6c60f1e3a7323a66cc/.no-mistakes/evidence/publish/r1-root-safe-test-guards/sig-cleanup-repro.sh)

```text
#!/usr/bin/env bash
# sig-cleanup-repro.sh <repo-root>
# Drives a real test process sourcing <repo-root>/tests/lib.sh that blocks a
# fixture directory with fm_dir_block_writes inside a command substitution
# (the shape of fm-session-start.test.sh:841 / fm-sessionstart-nudge.test.sh:1018),
# then delivers TERM to the whole process group - what fm-test-run.sh's
# per-script timeout (bin/fm-timeout-lib.sh) does - before fm_dir_unblock_writes
# runs. Reports whether the fixture temp root survived cleanup.
set -u
repo=$1
work=$(mktemp -d /tmp/fm-sigrepro.XXXXXX)
cat > "$work/victim.test.sh" <<'EOF'
#!/usr/bin/env bash
. "$1/tests/lib.sh"
TMP_ROOT=$(fm_test_tmproot fm-sigrepro-fixture)
printf '%s\n' "$TMP_ROOT" > "$2/tmproot"
mkdir -p "$TMP_ROOT/home/state"
echo data > "$TMP_ROOT/home/state/entry"
out=$(fm_dir_block_writes "$TMP_ROOT/home/state"; : > "$2/blocked"; sleep 30; fm_dir_unblock_writes "$TMP_ROOT/home/state")
pass "unreachable: signal should have landed first"
EOF
setsid bash "$work/victim.test.sh" "$repo" "$work" &
pid=$!
for _ in $(seq 200); do [ -f "$work/blocked" ] && break; sleep 0.05; done
root=$(cat "$work/tmproot")
echo "lib.sh under test: $repo/tests/lib.sh (uid $(id -u))"
echo "fixture root: $root"
echo "state dir mode while blocked: $(stat -c %a "$root/home/state")"
kill -TERM -- "-$pid"
wait "$pid"
echo "test process exit after group TERM: $?"
if [ -e "$root" ]; then
  echo "RESULT: fixture root LEFT BEHIND after cleanup:"
  find "$root" -printf '  %M %p\n' 2>&1
  chmod -R u+w "$root"; rm -rf "$root"
else
  echo "RESULT: fixture root removed by fm_test_cleanup"
fi
rm -rf "$work"
```
</details>
<details>
<summary>Evidence: Root with inheritable DAC caps: d7c10c1 refuses (97), HEAD&#39;s drop holds</summary>

Source: [Root with inheritable DAC caps: d7c10c1 refuses (97), HEAD&#39;s drop holds](https://github.com/MLA82/firstmate/blob/cac97fb55a75a477a1aace6c60f1e3a7323a66cc/.no-mistakes/evidence/publish/r1-root-safe-test-guards/inheritable-caps-transcript.txt)

```text
=== BEFORE (d7c10c1: bounding-set-only drop) ===
lib.sh under test: /tmp/fm-cmp-d7c10c1/tests/lib.sh
runner: uid 0; CapInh: 0000000000000006
plain bounding-set-only drop: write into a-w dir SUCCEEDED (root regained the caps from the inheritable set)
fm_run_dir_readonly: cannot verify a write-block for root on /tmp/fm-inhprobe.HhcOIq/d; refusing to run bash unprotected
fm_run_dir_readonly write attempt: rc=97; file created: no
RESULT: helper refused (97) - drop cannot be proven on this runner, protection unavailable

=== AFTER (HEAD 17210fd: bounding + inheritable drop) ===
lib.sh under test: ~/.no-mistakes/worktrees/c9a671237ef3/01M28DPZ7CXAHVT2NBTC56S9VQ/tests/lib.sh
runner: uid 0; CapInh: 0000000000000006
plain bounding-set-only drop: write into a-w dir SUCCEEDED (root regained the caps from the inheritable set)
_: Zeile 1: /tmp/fm-inhprobe.uBH6uL/d/via-helper: Keine Berechtigung
fm_run_dir_readonly write attempt: rc=1; file created: no
RESULT: write denied under the helper - drop holds on this runner
```
</details>
<details>
<summary>Evidence: Inheritable-caps probe driver</summary>

Source: [Inheritable-caps probe driver](https://github.com/MLA82/firstmate/blob/cac97fb55a75a477a1aace6c60f1e3a7323a66cc/.no-mistakes/evidence/publish/r1-root-safe-test-guards/inh-caps-probe.sh)

```text
#!/usr/bin/env bash
# inh-caps-probe.sh <repo-root>
# Run as a root runner whose inheritable set already holds CAP_DAC_OVERRIDE and
# CAP_DAC_READ_SEARCH (e.g. older Docker engines):
#   unshare -r setpriv --inh-caps=+dac_override,+dac_read_search -- bash inh-caps-probe.sh <repo>
set -u
repo=$1
echo "lib.sh under test: $repo/tests/lib.sh"
echo "runner: uid $(id -u); $(grep -E 'CapInh' /proc/self/status | tr '\t' ' ')"
. "$repo/tests/lib.sh"
T=$(fm_test_tmproot fm-inhprobe)
mkdir "$T/d"
chmod a-w "$T/d"
# shellcheck disable=SC2016
if setpriv --bounding-set=-dac_override,-dac_read_search -- bash -c ': > "$1/bounding-only"' _ "$T/d" 2>/dev/null; then
  echo "plain bounding-set-only drop: write into a-w dir SUCCEEDED (root regained the caps from the inheritable set)"
else
  echo "plain bounding-set-only drop: write denied"
fi
chmod u+w "$T/d"
# shellcheck disable=SC2016
fm_run_dir_readonly "$T/d" bash -c ': > "$1/via-helper"' _ "$T/d"
rc=$?
echo "fm_run_dir_readonly write attempt: rc=$rc; file created: $([ -e "$T/d/via-helper" ] && echo yes || echo no)"
case $rc in
  0) echo "RESULT: helper let root write into a write-blocked dir (guard defeated)" ;;
  97) echo "RESULT: helper refused (97) - drop cannot be proven on this runner, protection unavailable" ;;
  *) echo "RESULT: write denied under the helper - drop holds on this runner" ;;
esac
```
</details>
<details>
<summary>Evidence: setpriv refusal with redirected stderr: silent on d337c52, visible at HEAD</summary>

Source: [setpriv refusal with redirected stderr: silent on d337c52, visible at HEAD](https://github.com/MLA82/firstmate/blob/cac97fb55a75a477a1aace6c60f1e3a7323a66cc/.no-mistakes/evidence/publish/r1-root-safe-test-guards/refusal-caller-shape-transcript.txt)

```text
=== d337c52 ===
test exit: 1

=== HEAD 17210fd ===
not ok - fm_run_without_dac_override: setpriv cannot drop CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH for root; refusing to run bash with root's permission bypass
test exit: 1
```
</details>
<details>
<summary>Evidence: Caller-shape refusal driver</summary>

Source: [Caller-shape refusal driver](https://github.com/MLA82/firstmate/blob/cac97fb55a75a477a1aace6c60f1e3a7323a66cc/.no-mistakes/evidence/publish/r1-root-safe-test-guards/refusal-caller-shape.sh)

```text
#!/usr/bin/env bash
# refusal-caller-shape.sh <repo-root>: a denial-asserting test in the exact
# caller shape of fm-secondmate-safety.test.sh:188 / fm-shared-captain-inheritance.test.sh:202
# (`fm_run_without_dac_override ... >/dev/null 2>"$err"`), run as a root runner
# whose setpriv cannot drop the capabilities.
. "$1/tests/lib.sh"
TMP_ROOT=$(fm_test_tmproot fm-refusal-shape)
err="$TMP_ROOT/denied.err"
if fm_run_without_dac_override bash -c ': >/dev/null' >/dev/null 2>"$err"; then
  fail "write unexpectedly succeeded"
fi
pass "write correctly denied (VACUOUS if reached: nothing ran)"
```
</details>
<details>
<summary>Evidence: fm-secondmate-safety on refusing root runner (HEAD shows diagnostic)</summary>

Source: [fm-secondmate-safety on refusing root runner (HEAD shows diagnostic)](https://github.com/MLA82/firstmate/blob/cac97fb55a75a477a1aace6c60f1e3a7323a66cc/.no-mistakes/evidence/publish/r1-root-safe-test-guards/setpriv-refusal-secondmate-safety-transcript.txt)

```text
=== d337c52 - tests/fm-secondmate-safety.test.sh on root runner without CAP_SETPCAP ===
ok - fm-lock status is scoped per home
fatal: Repository »/tmp/fm-cmp-d337c52« existiert nicht
error: /tmp/fm-secondmate-safety.mwJBQb/overlap-design is not a firstmate home (missing AGENTS.md)
not ok - initial seed failed
test file exit: 1

=== HEAD 17210fd - tests/fm-secondmate-safety.test.sh on root runner without CAP_SETPCAP ===
ok - seed allows overlapping project clone lists and drops the owns/owner routing
ok - home-seed validation rejects registry records no operational parser can consume
ok - home seeding refuses broken registry symlinks before provisioning
not ok - fm_run_without_dac_override: setpriv cannot drop CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH for root; refusing to run env with root's permission bypass
test file exit: 1
```
</details>
<details>
<summary>Evidence: fm-shared-captain-inheritance on refusing root runner</summary>

Source: [fm-shared-captain-inheritance on refusing root runner](https://github.com/MLA82/firstmate/blob/cac97fb55a75a477a1aace6c60f1e3a7323a66cc/.no-mistakes/evidence/publish/r1-root-safe-test-guards/setpriv-refusal-transcript.txt)

```text
=== d337c52 - root runner without CAP_SETPCAP (setpriv cannot drop caps) ===
runner: uid 0; CapBnd: 000001fffffffeff
not ok - fm_run_without_dac_override: setpriv cannot drop CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH for root; refusing to run bash with root's permission bypass
test file exit: 1

=== HEAD 17210fd - root runner without CAP_SETPCAP (setpriv cannot drop caps) ===
runner: uid 0; CapBnd: 000001fffffffeff
not ok - fm_run_without_dac_override: setpriv cannot drop CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH for root; refusing to run bash with root's permission bypass
test file exit: 1
```
</details>
<details>
<summary>Evidence: Base 869ae90 guard tests fail under simulated root</summary>

Source: [Base 869ae90 guard tests fail under simulated root](https://github.com/MLA82/firstmate/blob/cac97fb55a75a477a1aace6c60f1e3a7323a66cc/.no-mistakes/evidence/publish/r1-root-safe-test-guards/base-under-root-transcript.txt)

```text
=== BASE 869ae90 (plain chmod guards) - simulated root runner (unshare -r, full caps) ===
--- tests/fm-shared-captain-inheritance.test.sh ---
not ok - ordinary write unexpectedly succeeded for read-only shared captain file
test file exit: 1
--- tests/fm-secondmate-safety.test.sh ---
ok - home-seed validation rejects registry records no operational parser can consume
ok - home seeding refuses broken registry symlinks before provisioning
not ok - home-seed validation accepted an unreadable registry
test file exit: 1
```
</details>
<details>
<summary>Evidence: HEAD guard tests pass under simulated root</summary>

Source: [HEAD guard tests pass under simulated root](https://github.com/MLA82/firstmate/blob/cac97fb55a75a477a1aace6c60f1e3a7323a66cc/.no-mistakes/evidence/publish/r1-root-safe-test-guards/head-under-root-fast-transcript.txt)

```text
=== HEAD 17210fd (root-safe guards) - simulated root runner (unshare -r, full caps) ===
runner: uid 0; CapEff: 000001ffffffffff
--- tests/fm-shared-captain-inheritance.test.sh ---
ok - bootstrap convergence point propagates data/captain-shared.md from FM_DATA_OVERRIDE
ok - fm-config-push convergence point updates changed shared captain source bytes from FM_DATA_OVERRIDE
ok - session-start digest renders data/captain-shared.md with the shared read-only label
ok lines: 8  not-ok lines: 0
test file exit: 0
--- tests/fm-secondmate-safety.test.sh ---
ok - secondmate charter brief is idle by default and does not self-initiate work
ok - fm-backlog-handoff aborts atomically on unmatched, in-flight, and unregistered targets
ok - fm-backlog-handoff refuses Done items under whitespace section headings and unsafe homes
ok lines: 77  not-ok lines: 0
test file exit: 0
```
</details>
<details>
<summary>Evidence: Non-root run of 7 changed test files (318 ok, exit 0)</summary>

Source: [Non-root run of 7 changed test files (318 ok, exit 0)](https://github.com/MLA82/firstmate/blob/cac97fb55a75a477a1aace6c60f1e3a7323a66cc/.no-mistakes/evidence/publish/r1-root-safe-test-guards/nonroot-changed-tests.log)

```text
FM_TEST_BEGIN 2026-09-11T14:56:13Z tests/fm-daemon.test.sh family=watcher-wake-lock expected_gate_skip=none
ok - fm-afk-start.sh fails before daemon startup when the afk flag cannot be written
ok - fm-afk-start.sh ignores stale pidfile-only live pids
ok - fm-afk-start.sh reclaims stale daemon locks whose live pid identity no longer matches
ok - supervise daemon state root is scoped by FM_HOME
ok - routine signal self-handles
ok - captain-relevant status verbs escalate
ok - check + unknown escalate; heartbeat self-handles
ok - transient stale self-handles and records a persistence marker
ok - enriched stale wedges bypass status absorption except under a declared wait, without disturbing busy workers
ok - an enriched wedge under a declared wait uses the pause cadence and restores wedge detection on resume
ok - stale + terminal status escalates immediately
ok - stale escalation and current wait cadence remain independent
ok - paused reasons with captain phrases remain pause-classified
ok - a captain-held transfer classifies as pause, not as a wedge candidate
ok - handle_wake on a paused stale records a pause marker, drops the wedge marker, and does not escalate
ok - handle_wake records a declared pause from a routine signal for long-cadence rechecks
ok - a terminal signal clears pause and stale tracking across both supervisors
ok - housekeeping migrates a normal-watcher's declared pause into daemon tracking
ok - housekeeping clears an already-resumed watcher pause across both supervisors
ok - housekeeping seeds pause tracking from status without a watcher marker
ok - persistent stale escalates after threshold and clears its marker
ok - resumed (busy) stale clears its marker without escalating
ok - housekeeping re-surfaces a stale declared pause on the long cadence and resets its window
ok - housekeeping re-surfaces a forgotten captain hold on the long cadence and resets its window
ok - a busy pane cannot gate the pause clear once its crew's status no longer declares the wait
ok - housekeeping matures a busy pane's declared-wait window into exactly one recheck per window
ok - housekeeping bounds a distant declared time, defers to a near one, and rechecks a passed one at once
ok - housekeeping clears a paused marker once the crew is no longer declaring the pause
ok - housekeeping clears the pause marker once a captain hold is answered
ok - housekeeping moves an existing stale marker to pause before wedge escalation
ok - housekeeping moves a captain hold's existing stale marker to pause before wedge escalation
ok - housekeeping clears tracking when a crew leaves pause
ok - persistent herdr stale resolves the target from metadata and escalates
ok - herdr idle busy-footer stale clears through capture corroboration
ok - resumed herdr stale clears through backend-aware busy state
ok - persistent Orca stale resolves the terminal from metadata
ok - multiple escalations flush as a single batched digest
ok - batch flush measures max-delay from the first append, not the last
ok - catch-all scan escalates a missed terminal once, not twice
ok - handle_wake routes routine->self and captain->escalate
ok - a decision-owned queued row escalates once as the decision, then suppresses until the status changes
ok - a captain-held decision-owned row is self-handled without escalation, now and on repeat
ok - INJECT_SKIP forces self-handle, bypassing captain-relevant classification
ok - is_wake_reason distinguishes watcher wake reasons from singleton-status stdout
ok - terminal-stale escalate removes its marker so housekeeping does not re-escalate
ok - captain signal escalate marks seen so the catch-all scan does not re-fire
ok - _collapse_newlines replaces newlines with literal separator
ok - afk flag absent: daemon does not inject, buffer preserved
ok - busy-guard defers injection when supervisor pane is busy
ok - marker detection: marker -> stay afk, no marker -> exit afk
ok - /afk invocation is exempt from afk exit (no self-cancel)
ok - should_exit_afk returns false when afk is not active
ok - strip_injection_marker removes the sentinel marker cleanly
ok - pane_input_pending detects partial input on the cursor line
ok - pane_input_pending: a blank unidentified cursor row defers (strict container-proof rule)
ok - pane_input_pending: only proven empty agent prompts pass
ok - fm_tmux_composer_state: a bare shell prompt ($/%/#/>) reads unknown, never empty (dead-shell injection safety)
ok - fm_tmux_composer_state: a bordered composer box and bare agent glyphs (❯/›) still read empty
ok - fm_tmux_composer_state: only matching edge borders form a composer box
ok - pane_input_pending preserves bright placeholder-like drafts in styled captures
ok - classify_signal dedupes against the catch-all scan seen marker
ok - turn-end markers stay routine while mixed actionable status batches escalate
ok - an actionable event is escalated to an away captain despite later routine appends
ok - the daemon commits exactly the endpoint captured by classification
ok - a stale wake escalates a blocker hidden by later progress
ok - a stale span read failure surfaces without advancing its marker
ok - a recreated status rejects the old captured identity
ok - an unverifiable status identity surfaces without advancing markers
ok - a status read failure surfaces without advancing the daemon suppressor
ok - catch-all routine scans advance before later actionable appends
ok - failed escalation writes retain durable wakes and classification positions
ok - catch-all markers advance only after escalation buffering succeeds
ok - classification failure retains the complete durable wake batch
ok - missing-status stale wakes remain ordinary and acknowledgeable
ok - transient unreadable signals recover without advancing their position
ok - daemon catch-all reclassifies permission-recovered status content
ok - a permanent classification failure is reported, acknowledged, and never advances its position
ok - the away-mode catch-all scan surfaces a masked event once
ok - classify_stale dedupes against the signal path seen marker
ok - AFK nonterminal working:+merged keeps wedge aging and re-escalates at bound
ok - genuine done: and merge-check events still escalate
ok - pane_input_pending: an idle bordered composer is NOT pending (afk-invx-i5)
ok - pane_input_pending: text inside a bordered composer is still pending
ok - submit-ACK confirms a submit when the composer returns to a bordered-empty box
ok - submit-ACK reports pending on a persistently swallowed Enter (type-once)
ok - max-defer on an empty stuck pane types once, alarms, and preserves the buffer
ok - max-defer flushes and clears the buffer on an empty bordered pane
ok - max-defer on a pending composer alarms without typing
ok - normal flush clears a stale wedge marker
ok - below MAX_DEFER: no inject, no alarm, buffer preserved
ok - max-defer does not flush or alarm while afk is inactive
ok - library mode: sourcing the daemon defaults FM_WEDGE_ALARM_EXEC to discard (no test can fire a real notification)
ok - wake helpers replace inherited notifier overrides with the safe recorder
ok - the discard seam suppresses every notifier, including command: (fires nothing)
ok - direct notifier helpers honor the discard seam, including command:
ok - osascript channel routes through the notifier seam with the summary (never a real notification)
ok - herdr channel routes through the notifier seam with the summary (never a real notification)
ok - command channel runs the captain command with the summary on $1 and on stdin
ok - command channel failures redact configured commands while logging their exit status
ok - unknown channel directives are redacted while the alarm keeps running
ok - off disables every active alert regardless of directive position (marker and tmux flash are unaffected)
ok - auto resolves to the macOS osascript notifier on Darwin (default-on)
ok - auto on a non-macOS platform selects no built-in OS channel (the marker or a configured command carries it)
ok - config/wedge-alarm selects every configured channel and skips comment and blank lines
ok - a failing channel logs and falls back to the next channel, never crashing the alarm
ok - a 

... [36298 bytes truncated] ...

 current contract
ok - read-only Pi compact refreshes against the rebuilding session identity without mutation
ok - Codex reset sources do not claim an unavailable instruction-refresh channel
ok - instruction baselines require SHA-256 and successful startup completion
ok - --reemit re-verifies lock ownership and keeps repair ownership with whoever holds it
# fm-session-start.test.sh: all assertions passed
FM_TEST_END 2026-09-11T15:04:32Z tests/fm-session-start.test.sh exit=0 duration_ms=313032 gate_skip=false
FM_TEST_BEGIN 2026-09-11T15:04:32Z tests/fm-sessionstart-nudge.test.sh family=session-bootstrap expected_gate_skip=none
ok - fm-sessionstart-nudge: a genuine primary gets one explicitly marked instruction line
ok - fm-sessionstart-nudge: NO_MISTAKES_GATE is silent
ok - fm-sessionstart-nudge: .no-mistakes gate common-dir is silent
ok - fm-sessionstart-nudge: an unmarked linked task worktree is silent
ok - fm-sessionstart-nudge: a marked linked secondmate home is a primary
ok - fm-sessionstart-nudge: a checkout without state is silent
ok - fm-sessionstart-nudge: a lock holder in process ancestry is already run
ok - OpenCode session.created delivers the exact wrapper nudge once per session
ok - run wrapper: startup runs the full digest and never also nudges
ok - run wrapper: clear and compact re-emit the digest without repeating startup sweeps
ok - run wrapper forwards only stale-cache rebuild sources to immutable-baseline instruction refresh
ok - run wrapper refreshes a compact even when startup completion is unproven
ok - run wrapper: clear falls back to full startup when completion is unproven
ok - run wrapper: clear accepts completion only from the current harness
ok - run wrapper: resume delegates to the nudge instead of re-running the digest
ok - run wrapper: the hook payload's source field drives routing with no explicit argument
ok - run wrapper: an unrecognized or absent source takes the helm rather than skipping it
ok - run wrapper: ordinary ineligible opens stay silent-zero and Pi preflight gets an explicit silent stand-down
ok - run wrapper: a session start that cannot take the lock still opens the session and says so
ok - Pi distinguishes header-proven restored CLI sessions from named create-if-missing startups
ok - Pi provider preflight owns one generation-bound startup prerequisite with deterministic fallback, replacement, cancellation, timeout, and truncation
ok - Pi reload shutdown releases its exit listener and stale startup generation
ok - Pi retains a bounded digest prefix and loudly marks oversized preflight delivery
FM_TEST_END 2026-09-11T15:06:16Z tests/fm-sessionstart-nudge.test.sh exit=0 duration_ms=103973 gate_skip=false
FM_TEST_BEGIN 2026-09-11T15:06:16Z tests/fm-shared-captain-inheritance.test.sh family=secondmate expected_gate_skip=none
ok - shared captain first copy converges, is read-only, and preserves local captain/learnings files
ok - shared captain drift is quarantined collision-safely and repeated convergence is idempotent
ok - missing primary shared file mirrors absence only after quarantining a local copy
ok - unsafe shared captain artifacts are rejected and failure restores read-only mode
ok - spawn convergence point propagates data/captain-shared.md from FM_DATA_OVERRIDE
ok - bootstrap convergence point propagates data/captain-shared.md from FM_DATA_OVERRIDE
ok - fm-config-push convergence point updates changed shared captain source bytes from FM_DATA_OVERRIDE
ok - session-start digest renders data/captain-shared.md with the shared read-only label
# all fm-shared-captain-inheritance tests passed
FM_TEST_END 2026-09-11T15:06:27Z tests/fm-shared-captain-inheritance.test.sh exit=0 duration_ms=10679 gate_skip=false
FM_TEST_BEGIN 2026-09-11T15:06:27Z tests/fm-startup-network.test.sh family=session-bootstrap expected_gate_skip=none
ok - fm-startup-network: wait fails when no deferred stage publishes before its deadline
ok - fm-startup-network: start returns immediately and never holds the caller's stdout open
ok - fm-startup-network: exactly one of the digest and the wake reports each actionable result
ok - fm-startup-network: a claimant crash after publication still surfaces the result
ok - fm-startup-network: a report-publication failure is failed, diagnosed, and still wakes
ok - fm-startup-network: silent and explicitly informational successes never queue a main-blocking wake
ok - fm-startup-network: an actionable state=done report still queues a wake
ok - fm-startup-network: deferred invalid secondmate markers produce durable wakes
ok - fm-startup-network: manual callers cannot forge mutation authority
ok - fm-startup-network: an aggregate bound turns a wedged sweep into an actionable line
ok - fm-startup-network: an abandoned run reports as needing a rerun, never as in progress forever
ok - fm-startup-network: locked requests supersede in-flight probe-only workers
ok - fm-startup-network: a second start never launches a competing worker
ok - fm-startup-network: start atomically reserves the generation harvest observes
ok - fm-startup-network: a new lock owner gets a distinct worker generation
ok - fm-startup-network: fleet-lock takeover cannot overlap a mutating sweep
ok - fm-startup-network: timing records share one origin so their offsets form a timeline
ok - fm-startup-network: timings are durable and printed only on demand
ok - fm-startup-network: a timed-out run still publishes the partial timings it recorded
ok - fm-startup-network: the timing artifact cannot carry a command line or forge records
# fm-startup-network.test.sh: all assertions passed
FM_TEST_END 2026-09-11T15:07:56Z tests/fm-startup-network.test.sh exit=0 duration_ms=89015 gate_skip=false
FM_TEST_BEGIN 2026-09-11T15:07:56Z tests/fm-trace-context-spawn.test.sh family=backend-dispatch expected_gate_skip=none
ok - enabled: one resolved carrier is recorded in meta and the identical TRACEPARENT is exported before launch
ok - disabled: neither traceparent= in meta nor a TRACEPARENT export is produced
ok - failed TRACEPARENT delivery omits metadata while the source task still launches
ok - uncleared TRACEPARENT input stops before the launch command is appended
ok - failed traceparent metadata append removes the carrier from the launched task
ok - duplicate secondmate preflight leaves trace-context unchanged
ok - relaunch reuses the recorded carrier verbatim for both the meta record and the injected export
ok - session start freezes the env override and later config or environment edits do not alter spawns
ok - two-level: env-on/file-absent keeps the nested worker enabled, rooting its own per-task trace
ok - two-level: env-off/file-present keeps the nested worker disabled even though the config file was copied into the secondmate home
ok - two unrelated routed tasks through one persistent Secondmate root distinct traces, adopt nothing from its environment, and keep per-task identity across relaunch
ok - secondmate carrier and FM_TRACE_CONTEXT snapshot always agree, both derived from one frozen decision (file-decided path)
# all fm-trace-context-spawn tests passed
FM_TEST_END 2026-09-11T15:10:31Z tests/fm-trace-context-spawn.test.sh exit=0 duration_ms=155012 gate_skip=false
FM_TEST_SUMMARY total=7 failed=0 skipped_gate=0 duration_ms=858372
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=155012 failed=0
FM_TEST_SUMMARY_FAMILY family=secondmate count=2 duration_ms=105330 failed=0
FM_TEST_SUMMARY_FAMILY family=session-bootstrap count=3 duration_ms=506020 failed=0
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=91540 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-session-start.test.sh duration_ms=313032
FM_TEST_SLOWEST rank=2 script=tests/fm-trace-context-spawn.test.sh duration_ms=155012
FM_TEST_SLOWEST rank=3 script=tests/fm-sessionstart-nudge.test.sh duration_ms=103973
FM_TEST_SLOWEST rank=4 script=tests/fm-secondmate-safety.test.sh duration_ms=94651
FM_TEST_SLOWEST rank=5 script=tests/fm-daemon.test.sh duration_ms=91540
FM_TEST_SLOWEST rank=6 script=tests/fm-startup-network.test.sh duration_ms=89015
FM_TEST_SLOWEST rank=7 script=tests/fm-shared-captain-inheritance.test.sh duration_ms=10679
exit=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3affe5a9b32ced7ae715ef689c057d15ff5880bc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-session-start.test.sh` - merge conflict rebasing onto refs/remotes/no-mistakes-push/publish/r1-root-safe-test-guards

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `tests/lib.sh:157` - The change contradicts the intent. The intent says &#34;The code change of each PR stays as it is&#34; and &#34;local state is reconciled to the real PR head first&#34;. A range-diff of the fork head (8f7b79c..d22b82f) against the target (869ae90..d337c52) shows the PR&#39;s 6 commits matching 1-6 here, apart from the main integration (node_free_base_path replaced by main&#39;s helper). Commits 7-10 have no counterpart in PR 3722: 65999c6 (collapses the unblock on wait failure in fm-startup-network.test.sh:274), 6dd3afe (wraps fm-home-seed in fm_run_without_dac_override at fm-secondmate-safety.test.sh:724), d7c10c1 (wraps the quarantine call in fm-shared-captain-inheritance.test.sh:202 and moves the stderr redirect at :68), and d337c52. d337c52 replaces FM_TEST_BLOCKED_DIRS with the new fm_test_remove_tree chmod sweep in fm_test_cleanup, adds `--inh-caps=-dac_override,-dac_read_search` and a setpriv positive-control `fail` to fm_run_without_dac_override, and drops the `command -v setpriv` guard from _fm_dac_override_drop_blocks_write. The same commits (6fefe12, ba8017e, db9d191) sit on the unpushed local ref refs/heads/publish/r1-root-safe-test-guards, so this is leftover local state, not the real PR head. They also re-apply the four fixes the latest recorded decision on this branch declined (blocked-dirs-subshell-gap, captain-write-vacuous-pass, setpriv-inheritable-caps, redundant-unblock-on-fail). The authorized lease-guarded force-push would therefore change PR 3722&#39;s code, not just refresh its attestation. Decision needed: drop 65999c6..d337c52 so the branch is only the PR-head commits rebased onto main, or explicitly approve widening the PR.
- ⚠️ `tests/lib.sh:491` - This component goes beyond the intent and should be removed (it is part of d337c52). It covers three things: the fm_test_remove_tree sweep replacing the FM_TEST_BLOCKED_DIRS unblock in fm_test_cleanup (lib.sh:157-176, 227), the `--inh-caps` drop plus the setpriv positive-control `fail` in fm_run_without_dac_override (lib.sh:491-499), and removal of the setpriv presence check in _fm_dac_override_drop_blocks_write. The logic itself checks out: registered roots are chmod-restored before `rm -rf` whichever shell blocked them, and the `--inh-caps` syntax is valid. No requirement in the intent needs any of it, though: the intent is attestation-only, with PR code unchanged. The latest branch decision declined exactly these fixes. Recommended remedy: remove them from this run and leave PR 3722&#39;s lib.sh as it is at d22b82f.
- ⚠️ `tests/fm-startup-network.test.sh:274` - This component goes beyond the intent and should be removed (commit 65999c6). It collapses `if ! run_stage ... wait 30; then fm_dir_unblock_writes ...; fail ...; fi` back to `run_stage ... || fail ...` followed by one unblock. There is no behavior change, since cleanup now restores access anyway. But the intent requires the PR code to stay as it is, and the latest decision declined this simplification. Recommended remedy: drop the commit.
- ⚠️ `tests/fm-shared-captain-inheritance.test.sh:202` - This component goes beyond the intent and should be removed (commits 6dd3afe and d7c10c1). They add new root-safe wrapping that PR 3722 does not contain: fm-home-seed under fm_run_without_dac_override at tests/fm-secondmate-safety.test.sh:724, and propagate_secondmate_inheritance re-sourced in a dropped-capability `bash -c` at tests/fm-shared-captain-inheritance.test.sh:202. The quarantine call now also runs in a fresh child bash for non-root runners, not in the test process. That is functionally equivalent here, since fm-config-inherit-lib.sh needs no FM_* setup, but it changes the PR&#39;s test code. No intent requirement needs these. Recommended remedy: drop both commits, or get explicit approval to add them to PR 3722.
- ℹ️ `tests/lib.sh:497` - This defect lives inside the unrequired setpriv positive-control component. On a root runner where setpriv is missing or cannot drop the capabilities, fm_run_without_dac_override calls `fail`, which prints `not ok - ...` to stderr and exits the test process. Every direct caller that asserts a denial redirects stderr to a temp err file: fm-secondmate-safety.test.sh:188, 196, 724, 826 and fm-shared-captain-inheritance.test.sh:202. That applies to the whole command, including the function call that runs `fail`. So the test file exits 1 with no visible `not ok` line, the diagnostic lands in `$err`, and fm_test_cleanup deletes it. The run fails, so nothing passes vacuously, but the failure cannot be diagnosed. The smallest honest remedy is to remove this component, per the intent finding.

🔧 No changes applied.
1 info still open:

- ℹ️ `tests/lib.sh:495` - The fix round&#39;s source-time `exec {FM_TEST_DAC_DROP_REFUSAL_FD}&gt;&amp;2` needs bash 4.1 or newer. The repo explicitly supports stock macOS bash 3.2: CI has a bash 3.2 parse sweep, and fm-test-run.sh and several libraries carry 3.2 workarounds. Bash 3.2 has no `{varname}` redirection, so it parses this line as `exec` of a command literally named `{FM_TEST_DAC_DROP_REFUSAL_FD}`. The parse sweep does not catch that, because the line is only a word. Concrete sequence: someone runs a test as root on macOS with /bin/bash 3.2, for example `sudo bin/fm-test-run.sh` or `sudo bash tests/fm-fleet-snapshot-view.test.sh`. setpriv does not exist on macOS, so the source-time probe fails and the exec runs. The exec cannot find that command, and a non-interactive bash exits on a failed exec. Every test file that sources tests/lib.sh then dies at source time with `exec: {FM_TEST_DAC_DROP_REFUSAL_FD}: not found`, not only the five files that call fm_run_without_dac_override. The intended refusal diagnostic is never printed. At the parent commit d337c52, only the callers failed, each with a clear message, and every other test file ran normally. Nothing passes vacuously, but the fix round turns a targeted, readable refusal into a suite-wide, misleading source-time crash on that runner. Smallest fix, which keeps the approved dedicated-descriptor approach: record the refusal in a plain flag, and open the stderr copy with a portable fixed high fd that no test uses. Tests already use fds 3-9, so pick one above that, for example `exec 19&gt;&amp;2`. Alternatively, use the `{var}` form only when `BASH_VERSINFO` is 4.1 or newer and fall back to the fixed fd otherwise. The call-time `fail` must still run in either case.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 5 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A per-script timeout or Ctrl-C TERM that lands while fm_dir_block_writes has a fixture dir blocked inside $(...) no longer leaves the write-blocked temp root behind | ✅ pass | live | signal-cleanup-transcript.txt: d7c10c1 left /tmp/fm-sigrepro-fixture.* with dr-xr-xr-x state/ (rm: Keine Berechtigung). HEAD: &#39;fixture root removed by fm_test_cleanup&#39;, exit 143 |
| Adversarial: on a root runner whose inheritable set holds CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH, fm_run_dir_readonly still blocks the write | ✅ pass | live | inheritable-caps-transcript.txt: a bounding-set-only drop lets the write through. d7c10c1 helper refuses with 97. HEAD helper denies the write (rc=1, file not created) |
| Adversarial: on a root runner where setpriv cannot drop the caps, a denial-asserting test that redirects stderr fails with a visible `not ok` diagnostic instead of silently or vacuously | ✅ pass | live | refusal-caller-shape-transcript.txt: d337c52 exits 1 with no output. HEAD prints &#39;not ok - fm_run_without_dac_override: setpriv cannot drop ...&#39; and exits 1. setpriv-refusal-secondmate-safety-transcri… |
| Permission-guard tests keep working when run as root: fm-shared-captain-inheritance and fm-secondmate-safety fail as root at base and pass as root at HEAD | ✅ pass | live | base-under-root-transcript.txt (&#39;ordinary write unexpectedly succeeded...&#39;, &#39;home-seed validation accepted an unreadable registry&#39;, exit 1). head-under-root-fast-transcript.txt (8/8 and 77/77 ok, exit… |
| All 7 changed test files still pass for a non-root runner | ✅ pass | live | nonroot-changed-tests.log: 318 ok, 0 not ok, exit=0 across the 7 files |
| fm-daemon, fm-session-start, fm-sessionstart-nudge, fm-startup-network, fm-trace-context-spawn pass under a root runner | ⏸️ untested | no | The run had not finished when structured output was required. Re-run `unshare -r bin/fm-test-run.sh --jobs 1 &lt;those 5 files&gt;` to completion (unprivileged user namespaces are available on this host), o… |

- <code>`bash sig-cleanup-repro.sh /tmp/fm-cmp-d7c10c1` vs `bash sig-cleanup-repro.sh &lt;worktree&gt;`: a real lib.sh test process blocks a fixture dir inside $(...), then the whole process group gets TERM before the unblock</code>
- <code>`unshare -r setpriv --inh-caps=+dac_override,+dac_read_search -- bash inh-caps-probe.sh &lt;repo&gt;` against d7c10c1 and HEAD</code>
- <code>`unshare -r setpriv --bounding-set=-setpcap -- bash refusal-caller-shape.sh &lt;repo&gt;` against d337c52 and HEAD (the redirected-stderr caller shape used at fm-secondmate-safety.test.sh:188 and fm-shared-captain-inheritance.test.sh:202)</code>
- <code>`unshare -r setpriv --bounding-set=-setpcap -- bash tests/fm-secondmate-safety.test.sh` and `tests/fm-shared-captain-inheritance.test.sh` at HEAD (and d337c52)</code>
- <code>`unshare -r bash tests/fm-shared-captain-inheritance.test.sh` and `tests/fm-secondmate-safety.test.sh` at base 869ae90 (scratch git repo) vs HEAD</code>
- <code>`bin/fm-test-run.sh --jobs 1 tests/fm-daemon.test.sh tests/fm-secondmate-safety.test.sh tests/fm-session-start.test.sh tests/fm-sessionstart-nudge.test.sh tests/fm-shared-captain-inheritance.test.sh tests/fm-startup-network.test.sh tests/fm-trace-context-spawn.test.sh` as the non-root user (318 ok, 0 not ok, exit 0)</code>
- <code>`unshare -r bin/fm-test-run.sh --jobs 1 tests/fm-daemon.test.sh tests/fm-session-start.test.sh tests/fm-sessionstart-nudge.test.sh tests/fm-startup-network.test.sh tests/fm-trace-context-spawn.test.sh` (started, not finished at report time)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
