### PR TITLE
feat(harness): add opt-in local Claude worker runtime

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -3,7 +3,7 @@ name: harness-adapters
 description: >-
   Agent-only reference for firstmate harness operations.
   Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
-  Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, gemini, and muse.
+  Contains verified facts for claude, claude-local, codex, opencode, pi, pi-signed, grok, kimi, cursor, gemini, and muse.
 user-invocable: false
 metadata:
   internal: true
@@ -25,6 +25,7 @@ Operational paths keep the context named by their owner: `config/` and active-ho
 ## Non-negotiable safety
 
 Never dispatch a crewmate or secondmate on an unverified adapter.
+`claude-local` is verified for short, ATTENDED crewmate and scout work only, and its own reference owns that boundary; never offer it for unattended or no-mistakes work.
 If `config/crew-harness` or `config/secondmate-harness` names one, tell the captain under `../../../AGENTS.md` section 9 that the requested worker runtime is not verified, use firstmate's own verified runtime for current work, and ask only whether to verify the requested runtime for future work.
 Do not pause current work for that choice.
 
@@ -82,6 +83,7 @@ A new tool remains undispatchable until the `verify` plan, its harness entry, ev
   },
   "harnesses": {
     "claude": "references/harness/claude.md",
+    "claude-local": "references/harness/claude-local.md",
     "codex": "references/harness/codex.md",
     "opencode": "references/harness/opencode.md",
     "pi": "references/harness/pi.md",

--- a/.agents/skills/harness-adapters/references/harness/claude-local.md
+++ b/.agents/skills/harness-adapters/references/harness/claude-local.md
@@ -37,7 +37,7 @@ Offer it for short, attended, local work the captain has asked to keep on his ow
 | Exit | **UNESTABLISHED.** `fm-control exit` did not return within two minutes. |
 | Resume | **UNESTABLISHED.** Not exercised. |
 | Skill | **UNESTABLISHED.** Not exercised. |
-| Model | `ANTHROPIC_MODEL`, not `--model`: the endpoint's catalog id selects the served model. Discover with `bin/fm-local-model.sh probe`. |
+| Model | `ANTHROPIC_MODEL`, not `--model`: the endpoint's catalog id selects the served model. Discover with `bin/fm-local-model.sh list`, which prints each served id and its load state; `probe` only confirms the endpoint answers. |
 | Effort | None. The record-and-omit contract in `../common/model-and-effort.md` applies: effort is recorded in task metadata and no flag is emitted. |
 
 ## The endpoint

--- a/.agents/skills/harness-adapters/references/harness/claude-local.md
+++ b/.agents/skills/harness-adapters/references/harness/claude-local.md
@@ -4,7 +4,8 @@ The verified `claude` CLI pinned to a locally served OpenAI/Anthropic-compatible
 Verified 2026-09-01 against LM Studio serving `qwen3-coder-next-mlx` on an Apple M1 Max (64 GB).
 
 **Not a second harness implementation.**
-It is the same binary, so its composer shape, trust dialog, lifecycle hooks, control family, and semantic busy source are claude's, reached through the `claude*` prefix rule that `../../../../../bin/fm-control-lib.sh` owns.
+It is the same binary, so its trust dialog, lifecycle hooks, control family, and semantic busy source are claude's, reached through the `claude*` prefix rule that `../../../../../bin/fm-control-lib.sh` owns.
+Its composer busy signature is explicitly mapped to claude's shared signature in `../../../../../bin/fm-composer-lib.sh`.
 Never give it a private copy of a shape the shared classifier owns.
 
 ## Standing boundary
@@ -55,7 +56,7 @@ A window the harness prompt alone fills is refused outright, naming the one acti
 
 LM Studio unloads an idle model on its own TTL and auto-evict settings, so the model can vanish under a running worker, and the server can simply be off.
 Both are silent to the worker - Claude Code retries rather than exiting, and was observed sitting in a multi-minute retry backoff with no request reaching the server at all.
-Arm `bin/fm-local-model.sh check <model>` as the task's custom watcher check (register it with `bin/fm-check-register.sh`, retire it with `bin/fm-check-unregister.sh`).
+`bin/fm-spawn.sh` automatically arms `bin/fm-local-model.sh check <model>` as the task's registered custom watcher check and teardown retires it through `bin/fm-check-unregister.sh`.
 It prints one actionable line for a stopped server and a different one for an evicted model, and nothing while the runtime is healthy.
 
 ## Latency

--- a/.agents/skills/harness-adapters/references/harness/claude-local.md
+++ b/.agents/skills/harness-adapters/references/harness/claude-local.md
@@ -58,7 +58,7 @@ LM Studio unloads an idle model on its own TTL and auto-evict settings, so the m
 Both are silent to the worker - Claude Code retries rather than exiting, and was observed sitting in a multi-minute retry backoff with no request reaching the server at all.
 `bin/fm-spawn.sh` automatically arms `bin/fm-local-model.sh check <model>` as the task's registered custom watcher check and teardown retires it through `bin/fm-check-unregister.sh`.
 It prints one actionable line for a stopped server and a different one for an evicted model, and nothing while the runtime is healthy.
-The check is silent once the task's recorded endpoint reads confidently dead, so an idle unload after the worker has finished is not a wake, while a live or unreadable endpoint keeps the alarm loud.
+The check is silent only once the task's recorded endpoint is gone or the agent process has exited, so a finished worker still sitting at its prompt is not silenced, and a live or unreadable endpoint keeps the alarm loud.
 `state/<id>.check.sh` is a single slot, so `bin/fm-pr-check.sh` on a claude-local task refuses until `bin/fm-check-unregister.sh <id>` hands the slot over, after which the worker runs without eviction detection.
 
 ## Latency

--- a/.agents/skills/harness-adapters/references/harness/claude-local.md
+++ b/.agents/skills/harness-adapters/references/harness/claude-local.md
@@ -58,6 +58,8 @@ LM Studio unloads an idle model on its own TTL and auto-evict settings, so the m
 Both are silent to the worker - Claude Code retries rather than exiting, and was observed sitting in a multi-minute retry backoff with no request reaching the server at all.
 `bin/fm-spawn.sh` automatically arms `bin/fm-local-model.sh check <model>` as the task's registered custom watcher check and teardown retires it through `bin/fm-check-unregister.sh`.
 It prints one actionable line for a stopped server and a different one for an evicted model, and nothing while the runtime is healthy.
+The check is silent once the task's recorded endpoint reads confidently dead, so an idle unload after the worker has finished is not a wake, while a live or unreadable endpoint keeps the alarm loud.
+`state/<id>.check.sh` is a single slot, so `bin/fm-pr-check.sh` on a claude-local task refuses until `bin/fm-check-unregister.sh <id>` hands the slot over, after which the worker runs without eviction detection.
 
 ## Latency
 

--- a/.agents/skills/harness-adapters/references/harness/claude-local.md
+++ b/.agents/skills/harness-adapters/references/harness/claude-local.md
@@ -18,7 +18,7 @@ Offer it for short, attended, local work the captain has asked to keep on his ow
 
 | Gate | Refuses |
 |---|---|
-| Opt-in | Selection from `config/crew-harness` or `config/secondmate-harness`; only an explicit per-spawn harness or a dispatch profile reaches it. |
+| Opt-in | Selection from `config/crew-harness`, `config/secondmate-harness`, or a `config/crew-dispatch.json` default; only an explicit per-task harness or a matched rule profile reaches it. |
 | Kind | `--secondmate`, in the spawn and in the control plane that decides a relaunch before stopping the running agent. |
 | Mode | `--mode no-mistakes`. |
 | Model | An omitted `--model`; the id is the endpoint's own catalog id and is never guessed. |

--- a/.agents/skills/harness-adapters/references/harness/claude-local.md
+++ b/.agents/skills/harness-adapters/references/harness/claude-local.md
@@ -1,0 +1,65 @@
+# Claude-local
+
+The verified `claude` CLI pinned to a locally served OpenAI/Anthropic-compatible endpoint, LM Studio by default.
+Verified 2026-09-01 against LM Studio serving `qwen3-coder-next-mlx` on an Apple M1 Max (64 GB).
+
+**Not a second harness implementation.**
+It is the same binary, so its composer shape, trust dialog, lifecycle hooks, control family, and semantic busy source are claude's, reached through the `claude*` prefix rule that `../../../../../bin/fm-control-lib.sh` owns.
+Never give it a private copy of a shape the shared classifier owns.
+
+## Standing boundary
+
+**Opt-in, short-context, crewmate/scout only, and NOT trustworthy for unattended work.**
+No supervised turn was ever observed completing on this runtime.
+Offer it for short, attended, local work the captain has asked to keep on his own machine; never route ordinary shipping here.
+
+`../../../../../bin/fm-spawn.sh` enforces the boundary rather than documenting it, and each refusal names its own reason:
+
+| Gate | Refuses |
+|---|---|
+| Opt-in | Selection from `config/crew-harness` or `config/secondmate-harness`; only an explicit per-spawn harness or a dispatch profile reaches it. |
+| Kind | `--secondmate`, in the spawn and in the control plane that decides a relaunch before stopping the running agent. |
+| Mode | `--mode no-mistakes`. |
+| Model | An omitted `--model`; the id is the endpoint's own catalog id and is never guessed. |
+| Endpoint | An endpoint that is not answering, or a model that is not loaded. |
+| Context | A brief beyond the usable headroom. |
+
+## Operating facts
+
+| Fact | Value |
+|---|---|
+| Busy | **Established.** claude's own hooks fire unchanged: `claude-hook` `user-prompt-submit` was observed opening a turn on this runtime. |
+| Trust | **Established.** A trust dialog appears on each fresh worktree, and its default selection is **`No, exit`** - bare Enter exits the agent. Accept with Down, then Enter. |
+| Interrupt | **Established.** Delivered through the control plane, reporting `cancel=unconfirmed`, matching claude's documented no-hook interrupt. A pending request-retry timer did not clear. |
+| Tool use | **Established.** Survives the Anthropic-compatible endpoint end to end: a forced file read returned the correct sentinel. |
+| Turn end | **UNESTABLISHED.** No supervised turn ever completed, so neither the `Stop` hook nor the turn-ended marker was ever observed firing here. |
+| Exit | **UNESTABLISHED.** `fm-control exit` did not return within two minutes. |
+| Resume | **UNESTABLISHED.** Not exercised. |
+| Skill | **UNESTABLISHED.** Not exercised. |
+| Model | `ANTHROPIC_MODEL`, not `--model`: the endpoint's catalog id selects the served model. Discover with `bin/fm-local-model.sh probe`. |
+| Effort | None. The record-and-omit contract in `../common/model-and-effort.md` applies: effort is recorded in task metadata and no flag is emitted. |
+
+## The endpoint
+
+`../../../../../bin/fm-local-model.sh` is the one owner of every endpoint fact; its header owns the exact commands and exit codes.
+Three findings drive its design, and none of them is safe to re-derive by intuition:
+
+- **The catalog is the only model-identity source.** A request naming a model that is not loaded returned HTTP 200 and was answered by whatever *was* loaded, with the response naming the loaded model. The request path can therefore never report an eviction; `GET /api/v0/models` and its per-model `state` can.
+- **`POST /v1/messages/count_tokens` is not implemented** ("Unexpected endpoint or method"), so no exact token count is available without spending a full prefill.
+- **The harness prompt is the dominant context consumer.** Captured from the server's own request log, a single `claude -p` turn carrying a one-sentence prompt sent ~250 KB - roughly 60k tokens of system prompt and tool schema - before any task content. Against the 65,536-token window the reference model had loaded, that is ~96% of the window, leaving 5,536 tokens of headroom.
+
+The short-context boundary is enforced against that **headroom**, not the window, because the window number alone would be theatre.
+A window the harness prompt alone fills is refused outright, naming the one action that fixes it: raise the model's loaded context length.
+
+## When the model goes away
+
+LM Studio unloads an idle model on its own TTL and auto-evict settings, so the model can vanish under a running worker, and the server can simply be off.
+Both are silent to the worker - Claude Code retries rather than exiting, and was observed sitting in a multi-minute retry backoff with no request reaching the server at all.
+Arm `bin/fm-local-model.sh check <model>` as the task's custom watcher check (register it with `bin/fm-check-register.sh`, retire it with `bin/fm-check-unregister.sh`).
+It prints one actionable line for a stopped server and a different one for an evicted model, and nothing while the runtime is healthy.
+
+## Latency
+
+Measured on the reference machine: a trivial single turn 153s, a two-turn tool-using exchange 309s.
+A later, identical trivial turn did not complete in 20 minutes.
+Treat per-turn latency as minutes and as **not stable**; two concurrent clients against one local model starve each other.

--- a/.agents/skills/harness-adapters/references/harness/claude-local.md
+++ b/.agents/skills/harness-adapters/references/harness/claude-local.md
@@ -23,7 +23,7 @@ Offer it for short, attended, local work the captain has asked to keep on his ow
 | Mode | `--mode no-mistakes`. |
 | Model | An omitted `--model`; the id is the endpoint's own catalog id and is never guessed. |
 | Endpoint | An endpoint that is not answering, or a model that is not loaded. |
-| Context | A brief beyond the usable headroom. |
+| Context | A brief exceeding the configured share of usable headroom. |
 
 ## Operating facts
 

--- a/.agents/skills/harness-adapters/references/harness/claude-local.md
+++ b/.agents/skills/harness-adapters/references/harness/claude-local.md
@@ -43,7 +43,7 @@ Offer it for short, attended, local work the captain has asked to keep on his ow
 ## The endpoint
 
 `../../../../../bin/fm-local-model.sh` is the one owner of every endpoint fact; its header owns the exact commands and exit codes.
-Three findings drive its design, and none of them is safe to re-derive by intuition:
+Four findings drive its design, and none of them is safe to re-derive by intuition:
 
 - **The catalog is the only model-identity source.** A request naming a model that is not loaded returned HTTP 200 and was answered by whatever *was* loaded, with the response naming the loaded model. The request path can therefore never report an eviction; `GET /api/v0/models` and its per-model `state` can.
 - **The endpoint host must be loopback.** `FM_LOCAL_MODEL_ENDPOINT` becomes the worker's `ANTHROPIC_BASE_URL`, so it decides where the brief, the files the worker reads, and its tool transcript are sent; a host outside `127.0.0.0/8`, `::1`, or `localhost` is refused rather than quietly making this a remote runtime.

--- a/.agents/skills/harness-adapters/references/harness/claude-local.md
+++ b/.agents/skills/harness-adapters/references/harness/claude-local.md
@@ -46,6 +46,7 @@ Offer it for short, attended, local work the captain has asked to keep on his ow
 Three findings drive its design, and none of them is safe to re-derive by intuition:
 
 - **The catalog is the only model-identity source.** A request naming a model that is not loaded returned HTTP 200 and was answered by whatever *was* loaded, with the response naming the loaded model. The request path can therefore never report an eviction; `GET /api/v0/models` and its per-model `state` can.
+- **The endpoint host must be loopback.** `FM_LOCAL_MODEL_ENDPOINT` becomes the worker's `ANTHROPIC_BASE_URL`, so it decides where the brief, the files the worker reads, and its tool transcript are sent; a host outside `127.0.0.0/8`, `::1`, or `localhost` is refused rather than quietly making this a remote runtime.
 - **`POST /v1/messages/count_tokens` is not implemented** ("Unexpected endpoint or method"), so no exact token count is available without spending a full prefill.
 - **The harness prompt is the dominant context consumer.** Captured from the server's own request log, a single `claude -p` turn carrying a one-sentence prompt sent ~250 KB - roughly 60k tokens of system prompt and tool schema - before any task content. Against the 65,536-token window the reference model had loaded, that is ~96% of the window, leaving 5,536 tokens of headroom.
 

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -59,3 +59,26 @@ commands:
 test:
   evidence:
     store_in_repo: true
+
+# Raise the Review-stage agent bound from its 30m default.
+#
+# Measured on this branch, 2026-09-01. The Review step for run
+# 01M1E1CQ2S1PYQKGVMKZ35QVJP recorded 2,236,972 ms total (37.3 min): the initial
+# review completed and gated in roughly 7.3 min, and the review-fix turn then
+# consumed the entire remaining 30m0s bound and was KILLED while still producing
+# output 1 second earlier ("agent fix timed out after 30m0s ... agent last
+# produced output 1s ago (122 observed)"). So the fix turn dominates this stage,
+# and 30m is a hard cut through live work rather than a stalled-agent backstop.
+# For contrast, a healthy fix turn on the preceding run was still progressing at
+# 630,675 ms (10.5 min) and did complete, so the default is adequate on a
+# responsive machine and only fails when the machine degrades.
+#
+# 60m is twice the observed hard cut and roughly six times a healthy fix turn.
+# The true requirement of the killed turn is UNMEASURED - it was cut off, not
+# finished - so this is sized against the cut, not against a completion.
+#
+# Repo-local and deliberately not global: this compensates for slow local
+# hardware on this repository's runs, and the stalled-agent protection the
+# default provides is preserved, just at a bound that does not sever work in
+# progress.
+review_agent_timeout: "60m"

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -59,26 +59,3 @@ commands:
 test:
   evidence:
     store_in_repo: true
-
-# Raise the Review-stage agent bound from its 30m default.
-#
-# Measured on this branch, 2026-09-01. The Review step for run
-# 01M1E1CQ2S1PYQKGVMKZ35QVJP recorded 2,236,972 ms total (37.3 min): the initial
-# review completed and gated in roughly 7.3 min, and the review-fix turn then
-# consumed the entire remaining 30m0s bound and was KILLED while still producing
-# output 1 second earlier ("agent fix timed out after 30m0s ... agent last
-# produced output 1s ago (122 observed)"). So the fix turn dominates this stage,
-# and 30m is a hard cut through live work rather than a stalled-agent backstop.
-# For contrast, a healthy fix turn on the preceding run was still progressing at
-# 630,675 ms (10.5 min) and did complete, so the default is adequate on a
-# responsive machine and only fails when the machine degrades.
-#
-# 60m is twice the observed hard cut and roughly six times a healthy fix turn.
-# The true requirement of the killed turn is UNMEASURED - it was cut off, not
-# finished - so this is sized against the cut, not against a completion.
-#
-# Repo-local and deliberately not global: this compensates for slow local
-# hardware on this repository's runs, and the stalled-agent protection the
-# default provides is preserved, just at a bound that does not sever work in
-# progress.
-review_agent_timeout: "60m"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,8 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `cursor`, plus `muse` and `gemini` for crewmates and scouts only; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `cursor`, plus `muse`, `gemini`, and `claude-local` for crewmates and scouts only; never dispatch on an unverified adapter.
+`claude-local` is a locally served model, opt-in only, bounded to short-context attended work and refused for no-mistakes shipping; `harness-adapters` owns its boundary and `bin/fm-local-model.sh` owns its endpoint facts.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1104,7 +1104,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","cursor","muse"] | index($h);
+    def verified($h): ["claude","claude-local","codex","opencode","pi","pi-signed","grok","kimi","cursor","muse"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -334,7 +334,7 @@ fm_busy_lines_match() {  # [harness]
     regex=$FM_BUSY_REGEX
   else
     case "$harness" in
-      claude) regex=$FM_DELIVERY_CLAUDE_BUSY_REGEX_DEFAULT ;;
+      claude|claude-local) regex=$FM_DELIVERY_CLAUDE_BUSY_REGEX_DEFAULT ;;
       codex) regex=$FM_DELIVERY_CODEX_BUSY_REGEX_DEFAULT ;;
       opencode) regex=$FM_DELIVERY_OPENCODE_BUSY_REGEX_DEFAULT ;;
       pi|pi-signed) regex=$FM_DELIVERY_PI_BUSY_REGEX_DEFAULT ;;

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -63,7 +63,7 @@ fm_control_verb_allowed() {  # <verb>
 # than guessed at, exactly as a spawn on it would be.
 fm_control_harness_supported() {  # <harness>
   case "${1-}" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse) return 0 ;;
+    claude|claude-local|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse) return 0 ;;
   esac
   return 1
 }
@@ -102,7 +102,11 @@ fm_control_harness_supports_kind() {  # <harness> <kind>
   local harness=${1-} kind=${2-}
   fm_control_harness_supported "$harness" || return 1
   case "$harness" in
-    muse|gemini) [ "$kind" != secondmate ] || return 1 ;;
+    # These adapters are not verified for a secondmate: they lack a primary
+    # supervision protocol, and claude-local also has a short crewmate context.
+    # bin/fm-spawn.sh refuses the same launch; this is what refuses the RELAUNCH
+    # before the current agent is stopped.
+    muse|gemini|claude-local) [ "$kind" != secondmate ] || return 1 ;;
   esac
   return 0
 }

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -797,11 +797,25 @@ record_note() {
 }
 
 do_relaunch() {
-  local exit_result state note_line
+  local exit_result state note_line local_model_endpoint
   local -a spawn_args
 
   require_state_verified_backend relaunch
   resolve_relaunch_profile
+
+  if { [ "$PRIOR_HARNESS" = claude-local ] || [ "$TARGET_HARNESS" = claude-local ]; } \
+     && fm_pr_poll_artifacts_valid "$STATE" "$ID" "$SCRIPT_DIR/fm-pr-poll.sh"; then
+    die "task $ID has an active PR poll in state/$ID.check.sh, the single custom-check slot a claude-local eviction watcher also needs; finish or retire that poll before relaunching so neither watcher is silently replaced (the running worker was left in place)"
+  fi
+  if [ "$TARGET_HARNESS" = claude-local ]; then
+    [ "$TARGET_MODEL" != default ] \
+      || die "claude-local requires an explicit model id and task $ID records none; pass --model <exact-model-id> (list them with: bin/fm-local-model.sh list) rather than stopping the running worker for a launch that must be refused"
+    local_model_endpoint=${FM_LOCAL_MODEL_ENDPOINT:-}
+    [ -n "$local_model_endpoint" ] || local_model_endpoint=$(fm_meta_get "$META" local_model_endpoint)
+    [ -n "$local_model_endpoint" ] || local_model_endpoint=http://127.0.0.1:1234
+    FM_LOCAL_MODEL_ENDPOINT="$local_model_endpoint" "$SCRIPT_DIR/fm-local-model.sh" preflight "$TARGET_MODEL" >/dev/null \
+      || die "the local-model preflight for claude-local failed (see above), so relaunching $ID would stop the running worker for a launch that must be refused; the worker was left in place"
+  fi
 
   case "$KIND" in
     ship|scout)

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -799,7 +799,7 @@ record_note() {
 }
 
 do_relaunch() {
-  local exit_result state note_line local_model_endpoint brief_preview brief_fits_status
+  local exit_result state note_line local_model_endpoint brief_preview brief_fits_status task_mode
   local -a spawn_args
 
   require_state_verified_backend relaunch
@@ -812,6 +812,9 @@ do_relaunch() {
   if [ "$TARGET_HARNESS" = claude-local ]; then
     [ "$TARGET_MODEL" != default ] \
       || die "claude-local requires an explicit model id and task $ID records none; pass --model <exact-model-id> (list them with: bin/fm-local-model.sh list) rather than stopping the running worker for a launch that must be refused"
+    task_mode=$(fm_meta_get "$META" mode)
+    [ "$task_mode" != no-mistakes ] \
+      || die "task $ID records mode=no-mistakes and claude-local is not verified for no-mistakes shipping work, so relaunching it there would stop the running worker for a launch that must be refused; ship this task on a hosted runtime, or re-spawn it under --mode direct-PR/local-only if the captain has approved the lower rigor (the running worker was left in place)"
     local_model_endpoint=${FM_LOCAL_MODEL_ENDPOINT:-}
     [ -n "$local_model_endpoint" ] || local_model_endpoint=$(fm_meta_get "$META" local_model_endpoint)
     [ -n "$local_model_endpoint" ] || local_model_endpoint=http://127.0.0.1:1234
@@ -839,7 +842,8 @@ do_relaunch() {
   if [ "$TARGET_HARNESS" = claude-local ] && [ -n "$RELAUNCH_BRIEF" ]; then
     brief_preview=$(mktemp "${TMPDIR:-/tmp}/fm-control-brief.XXXXXX") \
       || die "could not stage task $ID's instructions for the claude-local brief check"
-    if ! { cat "$RELAUNCH_BRIEF" && progress_note_block "$(date -u +%Y-%m-%dT%H:%M:%SZ)"; } > "$brief_preview"; then
+    if ! { cat "$RELAUNCH_BRIEF" \
+        && { [ -z "$NOTE" ] || progress_note_block "$(date -u +%Y-%m-%dT%H:%M:%SZ)"; }; } > "$brief_preview"; then
       rm -f -- "$brief_preview"
       die "could not stage task $ID's instructions for the claude-local brief check"
     fi

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -614,6 +614,19 @@ relaunch_rollback() {
 resolve_relaunch_profile() {
   PRIOR_HARNESS=$HARNESS
   PRIOR_RECORDED_HARNESS=$RECORDED_HARNESS
+  # $HARNESS is the control FAMILY, which is what the interrupt/exit tables and
+  # wiring retirement are keyed by. For the relaunch PROFILE we want the exact
+  # adapter instead, whenever the recorded value is itself a verified adapter:
+  # such a value can be reconstructed exactly, so the alias guard below must not
+  # fire for it and the model/effort carry-over must compare like with like.
+  # Only a raw-command basename - which resolves to a family but is not itself
+  # an adapter - is genuinely unreconstructable. claude-local is what makes this
+  # visible: its family is claude, but it is a real adapter with its own launch
+  # template and its own model axis, so canonicalizing it to claude would both
+  # refuse an ordinary relaunch and reset the recorded model to default.
+  if fm_control_harness_supported "$PRIOR_RECORDED_HARNESS"; then
+    PRIOR_HARNESS=$PRIOR_RECORDED_HARNESS
+  fi
   PRIOR_MODEL=$(fm_meta_get "$META" model)
   PRIOR_EFFORT=$(fm_meta_get "$META" effort)
   [ -n "$PRIOR_MODEL" ] || PRIOR_MODEL=default

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -769,6 +769,20 @@ safe_checkpoint() {
 # actually reads. A secondmate's charter is a durable standing document and is
 # never rewritten: a secondmate reconciles its own home's records at startup,
 # so the note stays parent-side audit evidence.
+progress_note_block() {  # <stamp>
+  echo
+  echo "## Progress note ($1)"
+  echo
+  echo "This task was relaunched. Continue from here; the local copy and every"
+  echo "uncommitted change are exactly as the previous worker left them."
+  echo
+  echo "First, check your instruction inbox: list $STATE/$ID.inbox/*.msg, act on"
+  echo "each message in numeric order, then mv each handled file into"
+  echo "$STATE/$ID.inbox/handled/. A steer sent before the relaunch survives there."
+  echo
+  printf '%s\n' "$NOTE"
+}
+
 record_note() {
   local stamp
   [ -n "$NOTE" ] || return 0
@@ -778,26 +792,14 @@ record_note() {
     ship|scout)
       cp -p "$RELAUNCH_BRIEF" "$BRIEF_PRIOR" \
         || die "could not preserve task $ID's instructions before recording the progress note"
-      {
-        echo
-        echo "## Progress note ($stamp)"
-        echo
-        echo "This task was relaunched. Continue from here; the local copy and every"
-        echo "uncommitted change are exactly as the previous worker left them."
-        echo
-        echo "First, check your instruction inbox: list $STATE/$ID.inbox/*.msg, act on"
-        echo "each message in numeric order, then mv each handled file into"
-        echo "$STATE/$ID.inbox/handled/. A steer sent before the relaunch survives there."
-        echo
-        printf '%s\n' "$NOTE"
-      } >> "$RELAUNCH_BRIEF" \
+      progress_note_block "$stamp" >> "$RELAUNCH_BRIEF" \
         || die "could not append the progress note to task $ID's instructions"
       ;;
   esac
 }
 
 do_relaunch() {
-  local exit_result state note_line local_model_endpoint
+  local exit_result state note_line local_model_endpoint brief_preview brief_fits_status
   local -a spawn_args
 
   require_state_verified_backend relaunch
@@ -834,6 +836,20 @@ do_relaunch() {
       die "task $ID records kind '$KIND', which has no defined relaunch shape"
       ;;
   esac
+  if [ "$TARGET_HARNESS" = claude-local ] && [ -n "$RELAUNCH_BRIEF" ]; then
+    brief_preview=$(mktemp "${TMPDIR:-/tmp}/fm-control-brief.XXXXXX") \
+      || die "could not stage task $ID's instructions for the claude-local brief check"
+    if ! { cat "$RELAUNCH_BRIEF" && progress_note_block "$(date -u +%Y-%m-%dT%H:%M:%SZ)"; } > "$brief_preview"; then
+      rm -f -- "$brief_preview"
+      die "could not stage task $ID's instructions for the claude-local brief check"
+    fi
+    brief_fits_status=0
+    FM_LOCAL_MODEL_ENDPOINT="$local_model_endpoint" "$SCRIPT_DIR/fm-local-model.sh" brief-fits "$TARGET_MODEL" "$brief_preview" >/dev/null \
+      || brief_fits_status=$?
+    rm -f -- "$brief_preview"
+    [ "$brief_fits_status" -eq 0 ] \
+      || die "task $ID's instructions plus this progress note exceed the local model's usable headroom (see above), so relaunching would stop the running worker for a launch that must be refused; the worker was left in place"
+  fi
 
   if [ -n "$NOTE" ]; then
     note_line="note_file=$NOTE_FILE"

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -134,6 +134,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 . "$SCRIPT_DIR/fm-control-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-check-lib.sh
+. "$SCRIPT_DIR/fm-check-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
@@ -808,6 +810,13 @@ do_relaunch() {
   if { [ "$PRIOR_HARNESS" = claude-local ] || [ "$TARGET_HARNESS" = claude-local ]; } \
      && fm_pr_poll_artifacts_valid "$STATE" "$ID" "$SCRIPT_DIR/fm-pr-poll.sh"; then
     die "task $ID has an active PR poll in state/$ID.check.sh, the single custom-check slot a claude-local eviction watcher also needs; finish or retire that poll before relaunching so neither watcher is silently replaced (the running worker was left in place)"
+  fi
+  if [ "$TARGET_HARNESS" = claude-local ] \
+     && { [ -e "$STATE/$ID.check.sh" ] || [ -L "$STATE/$ID.check.sh" ]; } \
+     && ! { [ "$PRIOR_HARNESS" = claude-local ] \
+            && ! fm_pr_poll_artifacts_valid "$STATE" "$ID" "$SCRIPT_DIR/fm-pr-poll.sh" \
+            && fm_custom_check_registered "$STATE" "$ID"; }; then
+    die "task $ID has an occupied custom-check slot in state/$ID.check.sh that cannot be proved to be its incumbent claude-local eviction watcher; retire or repair that check before relaunching so the running worker is not stopped for a replacement that fm-spawn will refuse (the running worker was left in place)"
   fi
   if [ "$TARGET_HARNESS" = claude-local ]; then
     [ "$TARGET_MODEL" != default ] \

--- a/bin/fm-local-model.sh
+++ b/bin/fm-local-model.sh
@@ -106,36 +106,62 @@ is_loopback_ipv4() {  # <host>
   [ "$o1" = 127 ]
 }
 
-# The host portion of the configured endpoint, with scheme, userinfo, port and
-# path removed. A bracketed IPv6 literal is unwrapped. An endpoint with no
-# authority at all (file:///path) yields the empty string.
-# The authority ends at the FIRST '/', '?' or '#', all three of which terminate
-# it per RFC 3986. Stopping at '/' alone would read the host out of the query
-# or fragment instead: in http://evil.example?@127.0.0.1 the '@' that follows
-# the '?' is query text, not userinfo, and the host every client resolves is
-# evil.example.
+# The host portion of the configured endpoint. Prints the host and returns 0
+# for an endpoint whose authority is a plain host, [IPv6] literal, or either
+# with a numeric port; an endpoint with no authority at all (file:///path)
+# prints the empty string. ANY other shape returns 1 without printing.
+#
+# The authority ends at the FIRST '/', '?', '#' or '\'. RFC 3986 gives the
+# first three; the WHATWG parser Node and undici use for ANTHROPIC_BASE_URL
+# also ends it at a backslash, so in http://evil.example\@127.0.0.1 the host
+# every client resolves is evil.example, not the loopback address after the
+# '@'.
+#
+# Naming the delimiters is not enough on its own, because each one only has to
+# be missed once for a remote host to read as loopback. So this refuses
+# anything it cannot account for rather than stripping userinfo and trusting
+# the remainder: a surviving '@' or '\', or any character outside a plain host
+# or a bracketed IPv6 literal, is a shape no caller here has any reason to
+# configure, and it is rejected instead of parsed.
 endpoint_host() {
-  local rest
+  local rest host port
   rest=${ENDPOINT#*://}
   rest=${rest%%/*}
   rest=${rest%%\?*}
   rest=${rest%%#*}
-  rest=${rest##*@}
+  rest=${rest%%\\*}
+  if [ -z "$rest" ]; then
+    printf '\n'
+    return 0
+  fi
   case "$rest" in
-    \[*\]*) rest=${rest#\[}; printf '%s\n' "${rest%%\]*}" ;;
-    *) printf '%s\n' "${rest%%:*}" ;;
+    \[*\])   host=${rest#\[}; host=${host%\]}; port= ;;
+    \[*\]:*) host=${rest#\[}; host=${host%%\]*}; port=${rest##*\]:} ;;
+    \[*|*\]*) return 1 ;;
+    *:*)     host=${rest%%:*}; port=${rest#*:} ;;
+    *)       host=$rest; port= ;;
   esac
+  case "$rest" in
+    \[*) case "$host" in ''|*[!0-9A-Fa-f:]*) return 1 ;; esac ;;
+    *)   case "$host" in ''|*[!0-9A-Za-z._-]*) return 1 ;; esac ;;
+  esac
+  case "$port" in *[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$host"
 }
 
 # The local-only invariant, enforced once for every command that touches the
 # endpoint. See "Local means loopback" above.
 require_loopback_endpoint() {
-  local host
-  host=$(endpoint_host)
-  case "$host" in
-    ''|localhost|::1|0:0:0:0:0:0:0:1) return 0 ;;
-  esac
-  is_loopback_ipv4 "$host" && return 0
+  local host status=0
+  host=$(endpoint_host) || status=$?
+  if [ "$status" -eq 0 ]; then
+    case "$host" in
+      ''|localhost|::1|0:0:0:0:0:0:0:1) return 0 ;;
+    esac
+    is_loopback_ipv4 "$host" && return 0
+  else
+    host='unreadable, not a plain host or host:port'
+  fi
   cat >&2 <<EOF
 error: the local model endpoint '$ENDPOINT' is not on this machine (host: $host).
        claude-local is a LOCAL runtime: the endpoint receives the task brief,

--- a/bin/fm-local-model.sh
+++ b/bin/fm-local-model.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# fm-local-model.sh - the ONE owner of local OpenAI/Anthropic-compatible
+# endpoint facts for the claude-local adapter (an LM Studio server by default).
+#
+# Usage: fm-local-model.sh probe
+#        fm-local-model.sh model-state <model>
+#        fm-local-model.sh context-budget <model>
+#        fm-local-model.sh headroom <model>
+#        fm-local-model.sh preflight <model>
+#        fm-local-model.sh check <model>
+#        fm-local-model.sh brief-fits <model> <brief-path>
+#
+# Endpoint: $FM_LOCAL_MODEL_ENDPOINT, default http://127.0.0.1:1234.
+# Ceiling:  $FM_LOCAL_MODEL_MAX_CONTEXT, default 131072 tokens (see "Why a
+#           ceiling" below). A value of 0 or a non-integer is refused rather
+#           than silently treated as unbounded.
+# Baseline: $FM_LOCAL_MODEL_HARNESS_BASELINE, default 60000 tokens - what the
+#           harness itself occupies before any task content (see "The baseline
+#           is the real boundary").
+#
+# Exit codes are the contract every caller reads:
+#   0  ok
+#   2  usage error
+#   3  endpoint unreachable (server off, wrong port, or not answering)
+#   4  model absent from the endpoint's catalog, or present but not loaded
+#   5  the endpoint answered but its catalog could not be parsed
+#   6  the brief exceeds the enforced context budget (brief-fits only)
+#   7  the model's window has no usable headroom above the harness baseline
+#
+# WHY THE CATALOG IS THE ONLY MODEL-IDENTITY SOURCE
+# Verified against LM Studio 2026-09-01: a POST to /v1/messages carrying a model
+# id that is NOT loaded ("definitely-not-loaded-xyz") returned HTTP 200 and was
+# answered by the loaded model, with the response's own "model" field naming the
+# loaded model rather than the requested one. The request path therefore cannot
+# tell "my model is serving" from "some other model is serving", and it can never
+# report an eviction. GET /api/v0/models is the authoritative source: it reports a
+# per-model "state" of loaded|not-loaded plus the loaded context length. Every
+# health verdict here reads that catalog and nothing else.
+#
+# WHY A CEILING
+# The captain's constraint is short-context work only. On the reference machine
+# (Apple M1 Max, 64 GB) the model occupies ~41.7 GiB, context memory is charged on
+# top of that, and prefill is compute-bound: a single trivial Claude Code turn
+# measured 153s wall clock, and a two-turn tool-using exchange measured 309s
+# (docs/verification/runtime-backends.md, "claude-local"). Cost grows with the
+# prompt, so an unbounded window on this runtime degrades into minutes-per-turn
+# rather than failing. The ceiling is a hard bound firstmate applies on top of
+# whatever the server reports, so loading a very wide window can never by itself
+# turn this into a long-context runtime.
+#
+# THE BASELINE IS THE REAL BOUNDARY
+# The ceiling alone would be theatre, because the dominant consumer of this
+# window is not the task - it is the harness. Captured from LM Studio's own
+# request log on 2026-09-01, a single `claude -p` turn carrying a one-sentence
+# prompt sent ~250 KB of prompt, roughly 60k tokens, before any task content:
+# Claude Code's system prompt and full tool schema. Against the 65,536-token
+# window the reference model had loaded, that baseline is ~96% of the window.
+# So the number that decides whether a task can run here is the HEADROOM above
+# that baseline, not the window. `headroom` computes it and `brief-fits` spends
+# a bounded share of it; a window with no headroom is refused outright with the
+# one action that fixes it, rather than accepted and then silently compacted.
+set -u
+
+ENDPOINT=${FM_LOCAL_MODEL_ENDPOINT:-http://127.0.0.1:1234}
+DEFAULT_CEILING=131072
+
+die_usage() { echo "usage: fm-local-model.sh probe|model-state|context-budget|headroom|preflight|check|brief-fits [args]" >&2; exit 2; }
+
+# Print the configured ceiling, refusing a value that is not a positive integer
+# so a typo can never read as "no limit".
+ceiling() {
+  local c=${FM_LOCAL_MODEL_MAX_CONTEXT:-$DEFAULT_CEILING}
+  case "$c" in
+    ''|*[!0-9]*) echo "error: FM_LOCAL_MODEL_MAX_CONTEXT must be a positive integer (got '$c')" >&2; exit 2 ;;
+  esac
+  [ "$c" -gt 0 ] || { echo "error: FM_LOCAL_MODEL_MAX_CONTEXT must be greater than zero" >&2; exit 2; }
+  printf '%s\n' "$c"
+}
+
+# Fetch the endpoint catalog. Prints the raw body on success; exit 3 when the
+# endpoint does not answer within the bounded timeout.
+catalog() {
+  command -v curl >/dev/null 2>&1 || { echo "error: curl is required to reach the local model endpoint" >&2; exit 3; }
+  local body
+  body=$(curl -fsS -m "${FM_LOCAL_MODEL_TIMEOUT:-10}" "$ENDPOINT/api/v0/models" 2>/dev/null) || exit 3
+  [ -n "$body" ] || exit 3
+  printf '%s' "$body"
+}
+
+# Print "<state> <loaded_context_length>" for one model id, read from the
+# catalog. Prints "absent 0" when the catalog does not list the id at all.
+# python3 parses the JSON because the catalog is nested and a grep would
+# mis-attribute a field to the wrong model once more than one is listed.
+catalog_lookup() {  # <model> <catalog-json>
+  command -v python3 >/dev/null 2>&1 || { echo "error: python3 is required to read the endpoint catalog" >&2; exit 5; }
+  FM_LM_MODEL=$1 python3 -c '
+import json, os, sys
+want = os.environ["FM_LM_MODEL"]
+try:
+    doc = json.load(sys.stdin)
+    entries = doc["data"]
+except Exception:
+    sys.exit(5)
+for e in entries:
+    if not isinstance(e, dict) or e.get("id") != want:
+        continue
+    state = e.get("state") or "unknown"
+    ctx = e.get("loaded_context_length") or e.get("max_context_length") or 0
+    try:
+        ctx = int(ctx)
+    except (TypeError, ValueError):
+        ctx = 0
+    print(state, ctx)
+    sys.exit(0)
+print("absent", 0)
+' <<EOF
+$2
+EOF
+}
+
+cmd_probe() {
+  catalog >/dev/null
+  printf 'ok: %s is answering\n' "$ENDPOINT"
+}
+
+cmd_model_state() {  # <model>
+  local body row
+  body=$(catalog) || exit $?
+  row=$(catalog_lookup "$1" "$body") || exit $?
+  printf '%s\n' "${row%% *}"
+}
+
+# The enforced budget: the smaller of what the server actually loaded and the
+# firstmate ceiling. Refuses rather than guessing when the model is not loaded,
+# because an unloaded model reports no meaningful window.
+cmd_context_budget() {  # <model>
+  local body row state ctx cap
+  body=$(catalog) || exit $?
+  row=$(catalog_lookup "$1" "$body") || exit $?
+  state=${row%% *}; ctx=${row##* }
+  [ "$state" = loaded ] || exit 4
+  cap=$(ceiling) || exit $?
+  if [ "$ctx" -gt 0 ] && [ "$ctx" -lt "$cap" ]; then printf '%s\n' "$ctx"; else printf '%s\n' "$cap"; fi
+}
+
+cmd_preflight() {  # <model>
+  local body row state budget room
+  if ! body=$(catalog); then
+    cat >&2 <<EOF
+error: the local model endpoint at $ENDPOINT is not answering.
+       Start the server (LM Studio Developer tab, or 'lms server start') and retry.
+       Set FM_LOCAL_MODEL_ENDPOINT to point at a different host or port.
+EOF
+    exit 3
+  fi
+  row=$(catalog_lookup "$1" "$body") || exit $?
+  state=${row%% *}
+  case "$state" in
+    loaded) : ;;
+    absent)
+      echo "error: the local model endpoint at $ENDPOINT does not list a model named '$1'." >&2
+      echo "       Load it first ('lms load $1'), or pass the exact id the endpoint reports." >&2
+      exit 4 ;;
+    *)
+      cat >&2 <<EOF
+error: the local model '$1' is listed but not loaded (state: $state).
+       LM Studio unloads an idle model on its own TTL and auto-evict settings, so
+       this is the expected state after the model has been idle. Load it with
+       'lms load $1' and retry.
+EOF
+      exit 4 ;;
+  esac
+  budget=$(cmd_context_budget "$1") || exit $?
+  room=$(cmd_headroom "$1") || exit $?
+  printf 'ok: %s loaded at %s, enforced context budget %s tokens, %s usable after the harness prompt\n' "$1" "$ENDPOINT" "$budget" "$room"
+}
+
+# The watcher poll body. Prints exactly one line when firstmate should wake and
+# nothing at all otherwise, per the custom-check contract in AGENTS.md section 7.
+# Both wake conditions are the failure class this adapter exists to make loud:
+# a worker pointed at a dead endpoint or an evicted model otherwise stalls
+# silently, because Claude Code retries rather than exiting.
+cmd_check() {  # <model>
+  local body row state
+  if ! body=$(catalog 2>/dev/null); then
+    printf 'blocked: the local model server at %s stopped answering; the worker cannot make progress until it is running again\n' "$ENDPOINT"
+    return 0
+  fi
+  row=$(catalog_lookup "$1" "$body" 2>/dev/null) || return 0
+  state=${row%% *}
+  [ "$state" = loaded ] && return 0
+  printf 'blocked: the local model %s is no longer loaded at %s (state: %s); the worker cannot make progress until it is loaded again\n' "$1" "$ENDPOINT" "$state"
+}
+
+# The tokens the harness itself occupies before any task content. Configurable
+# because it is a measured property of the harness version, not a constant.
+baseline() {
+  local b=${FM_LOCAL_MODEL_HARNESS_BASELINE:-60000}
+  case "$b" in
+    ''|*[!0-9]*) echo "error: FM_LOCAL_MODEL_HARNESS_BASELINE must be a non-negative integer (got '$b')" >&2; exit 2 ;;
+  esac
+  printf '%s\n' "$b"
+}
+
+# Usable tokens = budget - harness baseline. Exits 7 when the window cannot even
+# hold the harness, which is a real configuration this runtime hits by default.
+cmd_headroom() {  # <model>
+  local budget base room
+  budget=$(cmd_context_budget "$1") || exit $?
+  base=$(baseline) || exit $?
+  room=$(( budget - base ))
+  if [ "$room" -le 0 ]; then
+    cat >&2 <<EOF
+error: the local model '$1' has no usable context headroom.
+       Its enforced budget is $budget tokens and the harness itself occupies about
+       $base before any task content, leaving $room.
+       Raise the model's loaded context length in LM Studio (its maximum is well
+       above what is loaded now) and retry, or run this task on a hosted runtime.
+EOF
+    exit 7
+  fi
+  printf '%s\n' "$room"
+}
+
+# Refuse a brief that obviously exceeds what is left for the task. The estimate
+# is deliberately crude - bytes/4 - because the endpoint implements no
+# token-counting route (POST /v1/messages/count_tokens returned "Unexpected
+# endpoint or method", verified 2026-09-01), so no exact count is available
+# without spending a full prefill. It is compared against
+# FM_LOCAL_MODEL_BRIEF_SHARE percent of the HEADROOM (default 25) rather than
+# the whole window, because the brief is only the first turn's input: every file
+# the worker reads and every later turn is charged against the same headroom.
+cmd_brief_fits() {  # <model> <brief-path>
+  local model=$1 path=$2 room share bytes est allowed
+  [ -f "$path" ] || { echo "error: brief '$path' is not a readable file" >&2; exit 2; }
+  room=$(cmd_headroom "$model") || exit $?
+  share=${FM_LOCAL_MODEL_BRIEF_SHARE:-25}
+  case "$share" in ''|*[!0-9]*) echo "error: FM_LOCAL_MODEL_BRIEF_SHARE must be an integer percent (got '$share')" >&2; exit 2 ;; esac
+  { [ "$share" -gt 0 ] && [ "$share" -le 100 ]; } || { echo "error: FM_LOCAL_MODEL_BRIEF_SHARE must be between 1 and 100" >&2; exit 2; }
+  bytes=$(wc -c < "$path" | tr -d '[:space:]')
+  est=$(( bytes / 4 ))
+  allowed=$(( room * share / 100 ))
+  if [ "$est" -gt "$allowed" ]; then
+    cat >&2 <<EOF
+error: this brief is too large for the local model runtime.
+       Brief is ~$est tokens; the limit is $allowed (${share}% of the $room tokens
+       left after the harness's own prompt).
+       claude-local is verified for SHORT-CONTEXT work only. Give this task to a
+       hosted runtime, or split it into a smaller brief.
+EOF
+    exit 6
+  fi
+  printf 'ok: brief ~%s tokens, within the %s-token allowance\n' "$est" "$allowed"
+}
+
+[ "$#" -ge 1 ] || die_usage
+CMD=$1; shift
+case "$CMD" in
+  probe)          [ "$#" -eq 0 ] || die_usage; cmd_probe ;;
+  model-state)    [ "$#" -eq 1 ] || die_usage; cmd_model_state "$1" ;;
+  context-budget) [ "$#" -eq 1 ] || die_usage; cmd_context_budget "$1" ;;
+  headroom)       [ "$#" -eq 1 ] || die_usage; cmd_headroom "$1" ;;
+  preflight)      [ "$#" -eq 1 ] || die_usage; cmd_preflight "$1" ;;
+  check)          [ "$#" -eq 1 ] || die_usage; cmd_check "$1" ;;
+  brief-fits)     [ "$#" -eq 2 ] || die_usage; cmd_brief_fits "$1" "$2" ;;
+  *) die_usage ;;
+esac

--- a/bin/fm-local-model.sh
+++ b/bin/fm-local-model.sh
@@ -11,9 +11,11 @@
 #        fm-local-model.sh check <model>
 #        fm-local-model.sh brief-fits <model> <brief-path>
 #
-# Endpoint: $FM_LOCAL_MODEL_ENDPOINT, default http://127.0.0.1:1234. Its host
-#           must be a loopback address (127.0.0.0/8, ::1, localhost) or an empty
-#           authority; a remote host is refused (see "Local means loopback").
+# Endpoint: $FM_LOCAL_MODEL_ENDPOINT, default http://127.0.0.1:1234. It must
+#           use an explicit http:// or https:// scheme with a non-empty loopback
+#           authority (127.0.0.0/8, ::1, localhost); a remote or unreadable host
+#           is refused. An empty authority is accepted only for file:// catalog
+#           fixtures, which reach no host (see "Local means loopback").
 # Ceiling:  $FM_LOCAL_MODEL_MAX_CONTEXT, default 131072 tokens (see "Why a
 #           ceiling" below). A value of 0 or a non-integer is refused rather
 #           than silently treated as unbounded.

--- a/bin/fm-local-model.sh
+++ b/bin/fm-local-model.sh
@@ -125,14 +125,26 @@ is_loopback_ipv4() {  # <host>
 # configure, and it is rejected instead of parsed.
 endpoint_host() {
   local rest host port
+  # An explicit scheme is required. Without one, ${ENDPOINT#*://} is a no-op and
+  # a protocol-relative //evil.example:1234 truncates to an empty authority,
+  # making "no authority" and "an authority this parser never reached"
+  # indistinguishable. An empty authority is accepted ONLY under file://, which
+  # addresses a path on this machine and reaches no host at all; that is the
+  # scheme the portable catalog fixtures in tests/ serve from.
+  case "$ENDPOINT" in
+    http://*|https://*|file://*) : ;;
+    *) return 1 ;;
+  esac
   rest=${ENDPOINT#*://}
   rest=${rest%%/*}
   rest=${rest%%\?*}
   rest=${rest%%#*}
   rest=${rest%%\\*}
   if [ -z "$rest" ]; then
-    printf '\n'
-    return 0
+    case "$ENDPOINT" in
+      file://*) printf '\n'; return 0 ;;
+    esac
+    return 1
   fi
   case "$rest" in
     \[*\])   host=${rest#\[}; host=${host%\]}; port= ;;

--- a/bin/fm-local-model.sh
+++ b/bin/fm-local-model.sh
@@ -109,10 +109,17 @@ is_loopback_ipv4() {  # <host>
 # The host portion of the configured endpoint, with scheme, userinfo, port and
 # path removed. A bracketed IPv6 literal is unwrapped. An endpoint with no
 # authority at all (file:///path) yields the empty string.
+# The authority ends at the FIRST '/', '?' or '#', all three of which terminate
+# it per RFC 3986. Stopping at '/' alone would read the host out of the query
+# or fragment instead: in http://evil.example?@127.0.0.1 the '@' that follows
+# the '?' is query text, not userinfo, and the host every client resolves is
+# evil.example.
 endpoint_host() {
   local rest
   rest=${ENDPOINT#*://}
   rest=${rest%%/*}
+  rest=${rest%%\?*}
+  rest=${rest%%#*}
   rest=${rest##*@}
   case "$rest" in
     \[*\]*) rest=${rest#\[}; printf '%s\n' "${rest%%\]*}" ;;

--- a/bin/fm-local-model.sh
+++ b/bin/fm-local-model.sh
@@ -3,6 +3,7 @@
 # endpoint facts for the claude-local adapter (an LM Studio server by default).
 #
 # Usage: fm-local-model.sh probe
+#        fm-local-model.sh list
 #        fm-local-model.sh model-state <model>
 #        fm-local-model.sh context-budget <model>
 #        fm-local-model.sh headroom <model>
@@ -64,7 +65,7 @@ set -u
 ENDPOINT=${FM_LOCAL_MODEL_ENDPOINT:-http://127.0.0.1:1234}
 DEFAULT_CEILING=131072
 
-die_usage() { echo "usage: fm-local-model.sh probe|model-state|context-budget|headroom|preflight|check|brief-fits [args]" >&2; exit 2; }
+die_usage() { echo "usage: fm-local-model.sh probe|list|model-state|context-budget|headroom|preflight|check|brief-fits [args]" >&2; exit 2; }
 
 # Print the configured ceiling, refusing a value that is not a positive integer
 # so a typo can never read as "no limit".
@@ -101,6 +102,13 @@ try:
     entries = doc["data"]
 except Exception:
     sys.exit(5)
+# A body that parses but is not shaped like a catalog must take the unreadable
+# path, NOT the absent-model path. Without this, {"data":{}} iterates an empty
+# dict, returns "absent", and check reports "no longer loaded" - a confidently
+# wrong diagnosis that sends the operator to reload a model when the real fault
+# is that something other than the model server is answering on that port.
+if not isinstance(entries, list):
+    sys.exit(5)
 for e in entries:
     if not isinstance(e, dict) or e.get("id") != want:
         continue
@@ -121,6 +129,32 @@ EOF
 cmd_probe() {
   catalog >/dev/null
   printf 'ok: %s is answering\n' "$ENDPOINT"
+}
+
+# Print every model id the endpoint serves, one per line, each with its load
+# state. This exists because `probe` only proves the endpoint answers and emits
+# no ids, so a refusal that points an operator at `probe` to find a model id is
+# not actionable. Keeping the listing here keeps this script the single owner of
+# endpoint facts.
+cmd_list() {
+  local body
+  body=$(catalog) || exit $?
+  command -v python3 >/dev/null 2>&1 || { echo "error: python3 is required to read the endpoint catalog" >&2; exit 5; }
+  python3 -c '
+import json, sys
+try:
+    doc = json.load(sys.stdin)
+    entries = doc["data"]
+except Exception:
+    sys.exit(5)
+if not isinstance(entries, list):
+    sys.exit(5)
+for e in entries:
+    if isinstance(e, dict) and e.get("id"):
+        print("%s\t%s" % (e["id"], e.get("state") or "unknown"))
+' <<EOF
+$body
+EOF
 }
 
 cmd_model_state() {  # <model>
@@ -164,7 +198,7 @@ EOF
     loaded) : ;;
     absent)
       echo "error: the local model endpoint at $ENDPOINT does not list a model named '$1'." >&2
-      echo "       Load it first ('lms load $1'), or pass the exact id the endpoint reports." >&2
+      echo "       Load it first ('lms load $1'), or pass an id from: fm-local-model.sh list" >&2
       exit 4 ;;
     *)
       cat >&2 <<EOF
@@ -265,6 +299,7 @@ EOF
 CMD=$1; shift
 case "$CMD" in
   probe)          [ "$#" -eq 0 ] || die_usage; cmd_probe ;;
+  list)           [ "$#" -eq 0 ] || die_usage; cmd_list ;;
   model-state)    [ "$#" -eq 1 ] || die_usage; cmd_model_state "$1" ;;
   context-budget) [ "$#" -eq 1 ] || die_usage; cmd_context_budget "$1" ;;
   headroom)       [ "$#" -eq 1 ] || die_usage; cmd_headroom "$1" ;;

--- a/bin/fm-local-model.sh
+++ b/bin/fm-local-model.sh
@@ -11,7 +11,9 @@
 #        fm-local-model.sh check <model>
 #        fm-local-model.sh brief-fits <model> <brief-path>
 #
-# Endpoint: $FM_LOCAL_MODEL_ENDPOINT, default http://127.0.0.1:1234.
+# Endpoint: $FM_LOCAL_MODEL_ENDPOINT, default http://127.0.0.1:1234. Its host
+#           must be a loopback address (127.0.0.0/8, ::1, localhost) or an empty
+#           authority; a remote host is refused (see "Local means loopback").
 # Ceiling:  $FM_LOCAL_MODEL_MAX_CONTEXT, default 131072 tokens (see "Why a
 #           ceiling" below). A value of 0 or a non-integer is refused rather
 #           than silently treated as unbounded.
@@ -21,7 +23,7 @@
 #
 # Exit codes are the contract every caller reads:
 #   0  ok
-#   2  usage error
+#   2  usage error, including an endpoint whose host is not loopback
 #   3  endpoint unreachable (server off, wrong port, or not answering)
 #   4  model absent from the endpoint's catalog, or present but not loaded
 #   5  the endpoint answered but its catalog could not be parsed
@@ -60,6 +62,16 @@
 # that baseline, not the window. `headroom` computes it and `brief-fits` spends
 # a bounded share of it; a window with no headroom is refused outright with the
 # one action that fixes it, rather than accepted and then silently compacted.
+#
+# LOCAL MEANS LOOPBACK
+# The captain's constraint is LOCAL work. Every caller bakes this endpoint into
+# a worker launch as ANTHROPIC_BASE_URL, so the endpoint decides where the task
+# brief, the file contents the worker reads, and its whole tool transcript are
+# sent. A hostname pointing off the machine would make "local model" a name for
+# shipping the repository to a third party, silently and without error. This
+# script resolves the endpoint for every caller, so this is where the invariant
+# is enforced: the host must be loopback, or an empty authority (a file:// URL,
+# which reaches no host at all).
 set -u
 
 ENDPOINT=${FM_LOCAL_MODEL_ENDPOINT:-http://127.0.0.1:1234}
@@ -76,6 +88,56 @@ ceiling() {
   esac
   [ "$c" -gt 0 ] || { echo "error: FM_LOCAL_MODEL_MAX_CONTEXT must be greater than zero" >&2; exit 2; }
   printf '%s\n' "$c"
+}
+
+# True when the argument is a dotted-quad address in 127.0.0.0/8. Every octet
+# is checked so a hostname that merely starts with "127." - 127.evil.example -
+# can never pass as loopback.
+is_loopback_ipv4() {  # <host>
+  local ip=$1 rest o1 o2 o3 o4 part
+  case "$ip" in *.*.*.*) ;; *) return 1 ;; esac
+  o1=${ip%%.*}; rest=${ip#*.}
+  o2=${rest%%.*}; rest=${rest#*.}
+  o3=${rest%%.*}; o4=${rest#*.}
+  for part in "$o1" "$o2" "$o3" "$o4"; do
+    case "$part" in ''|*[!0-9]*) return 1 ;; esac
+    [ "$part" -le 255 ] || return 1
+  done
+  [ "$o1" = 127 ]
+}
+
+# The host portion of the configured endpoint, with scheme, userinfo, port and
+# path removed. A bracketed IPv6 literal is unwrapped. An endpoint with no
+# authority at all (file:///path) yields the empty string.
+endpoint_host() {
+  local rest
+  rest=${ENDPOINT#*://}
+  rest=${rest%%/*}
+  rest=${rest##*@}
+  case "$rest" in
+    \[*\]*) rest=${rest#\[}; printf '%s\n' "${rest%%\]*}" ;;
+    *) printf '%s\n' "${rest%%:*}" ;;
+  esac
+}
+
+# The local-only invariant, enforced once for every command that touches the
+# endpoint. See "Local means loopback" above.
+require_loopback_endpoint() {
+  local host
+  host=$(endpoint_host)
+  case "$host" in
+    ''|localhost|::1|0:0:0:0:0:0:0:1) return 0 ;;
+  esac
+  is_loopback_ipv4 "$host" && return 0
+  cat >&2 <<EOF
+error: the local model endpoint '$ENDPOINT' is not on this machine (host: $host).
+       claude-local is a LOCAL runtime: the endpoint receives the task brief,
+       every file the worker reads, and its whole tool transcript, so it may only
+       be a loopback address - 127.0.0.0/8, ::1, or localhost.
+       Point FM_LOCAL_MODEL_ENDPOINT at a loopback address (default
+       http://127.0.0.1:1234), or run this task on a hosted runtime.
+EOF
+  exit 2
 }
 
 # Fetch the endpoint catalog. Prints the raw body on success; exit 3 when the
@@ -188,7 +250,7 @@ cmd_preflight() {  # <model>
     cat >&2 <<EOF
 error: the local model endpoint at $ENDPOINT is not answering.
        Start the server (LM Studio Developer tab, or 'lms server start') and retry.
-       Set FM_LOCAL_MODEL_ENDPOINT to point at a different host or port.
+       Set FM_LOCAL_MODEL_ENDPOINT to a different loopback port if it serves elsewhere.
 EOF
     exit 3
   fi
@@ -297,6 +359,11 @@ EOF
 
 [ "$#" -ge 1 ] || die_usage
 CMD=$1; shift
+# Every command below reads the endpoint, so the local-only invariant is checked
+# once here rather than inside catalog(): `check` swallows catalog failures to
+# print its own wake line, and a misconfigured endpoint must not be reported to
+# the operator as a server that stopped answering.
+require_loopback_endpoint
 case "$CMD" in
   probe)          [ "$#" -eq 0 ] || die_usage; cmd_probe ;;
   list)           [ "$#" -eq 0 ] || die_usage; cmd_list ;;

--- a/bin/fm-local-model.sh
+++ b/bin/fm-local-model.sh
@@ -105,7 +105,7 @@ for e in entries:
     if not isinstance(e, dict) or e.get("id") != want:
         continue
     state = e.get("state") or "unknown"
-    ctx = e.get("loaded_context_length") or e.get("max_context_length") or 0
+    ctx = e.get("loaded_context_length") or 0
     try:
         ctx = int(ctx)
     except (TypeError, ValueError):
@@ -131,14 +131,19 @@ cmd_model_state() {  # <model>
 }
 
 # The enforced budget: the smaller of what the server actually loaded and the
-# firstmate ceiling. Refuses rather than guessing when the model is not loaded,
-# because an unloaded model reports no meaningful window.
+# firstmate ceiling. Refuses rather than guessing when the model is not loaded
+# or does not report a positive loaded window.
 cmd_context_budget() {  # <model>
   local body row state ctx cap
   body=$(catalog) || exit $?
   row=$(catalog_lookup "$1" "$body") || exit $?
   state=${row%% *}; ctx=${row##* }
   [ "$state" = loaded ] || exit 4
+  if [ "$ctx" -le 0 ]; then
+    echo "error: the local model '$1' is loaded but reports no positive loaded context length." >&2
+    echo "       Reload it in LM Studio with a positive context length, then retry." >&2
+    exit 4
+  fi
   cap=$(ceiling) || exit $?
   if [ "$ctx" -gt 0 ] && [ "$ctx" -lt "$cap" ]; then printf '%s\n' "$ctx"; else printf '%s\n' "$cap"; fi
 }
@@ -186,7 +191,10 @@ cmd_check() {  # <model>
     printf 'blocked: the local model server at %s stopped answering; the worker cannot make progress until it is running again\n' "$ENDPOINT"
     return 0
   fi
-  row=$(catalog_lookup "$1" "$body" 2>/dev/null) || return 0
+  if ! row=$(catalog_lookup "$1" "$body" 2>/dev/null); then
+    printf 'blocked: the local model endpoint at %s answered with an unreadable catalog; verify that LM Studio is serving /api/v0/models before the worker can make progress\n' "$ENDPOINT"
+    return 0
+  fi
   state=${row%% *}
   [ "$state" = loaded ] && return 0
   printf 'blocked: the local model %s is no longer loaded at %s (state: %s); the worker cannot make progress until it is loaded again\n' "$1" "$ENDPOINT" "$state"

--- a/bin/fm-local-model.sh
+++ b/bin/fm-local-model.sh
@@ -19,6 +19,8 @@
 # Ceiling:  $FM_LOCAL_MODEL_MAX_CONTEXT, default 131072 tokens (see "Why a
 #           ceiling" below). A value of 0 or a non-integer is refused rather
 #           than silently treated as unbounded.
+# Timeout:  $FM_LOCAL_MODEL_TIMEOUT, default 10 seconds. It must be a positive
+#           integer so curl's zero value can never disable the endpoint bound.
 # Baseline: $FM_LOCAL_MODEL_HARNESS_BASELINE, default 60000 tokens - what the
 #           harness itself occupies before any task content (see "The baseline
 #           is the real boundary").
@@ -90,6 +92,19 @@ ceiling() {
   esac
   [ "$c" -gt 0 ] || { echo "error: FM_LOCAL_MODEL_MAX_CONTEXT must be greater than zero" >&2; exit 2; }
   printf '%s\n' "$c"
+}
+
+# Print the endpoint deadline, refusing values that curl would interpret as an
+# unbounded or malformed timeout. Validate this before dispatch so every public
+# command reports a bad local-runtime configuration as such, rather than
+# recasting it as an unreachable endpoint or a blocked worker.
+timeout_seconds() {
+  local t=${FM_LOCAL_MODEL_TIMEOUT:-10}
+  case "$t" in
+    ''|*[!0-9]*) echo "error: FM_LOCAL_MODEL_TIMEOUT must be a positive integer (got '$t')" >&2; return 2 ;;
+  esac
+  [ "$t" -gt 0 ] || { echo "error: FM_LOCAL_MODEL_TIMEOUT must be greater than zero" >&2; return 2; }
+  printf '%s\n' "$t"
 }
 
 # True when the argument is a dotted-quad address in 127.0.0.0/8. Every octet
@@ -192,7 +207,7 @@ EOF
 catalog() {
   command -v curl >/dev/null 2>&1 || { echo "error: curl is required to reach the local model endpoint" >&2; exit 3; }
   local body
-  body=$(curl -fsS -m "${FM_LOCAL_MODEL_TIMEOUT:-10}" "$ENDPOINT/api/v0/models" 2>/dev/null) || exit 3
+  body=$(curl -fsS -m "$TIMEOUT" "$ENDPOINT/api/v0/models" 2>/dev/null) || exit 3
   [ -n "$body" ] || exit 3
   printf '%s' "$body"
 }
@@ -411,6 +426,7 @@ CMD=$1; shift
 # print its own wake line, and a misconfigured endpoint must not be reported to
 # the operator as a server that stopped answering.
 require_loopback_endpoint
+TIMEOUT=$(timeout_seconds) || exit $?
 case "$CMD" in
   probe)          [ "$#" -eq 0 ] || die_usage; cmd_probe ;;
   list)           [ "$#" -eq 0 ] || die_usage; cmd_list ;;

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -15,6 +15,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-check-lib.sh
+. "$SCRIPT_DIR/fm-check-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-parent-channel-lib.sh
@@ -104,6 +106,11 @@ META_LOCK_HELD=1
 META_DEVICE=$(fm_pr_file_device "$META") || exit 1
 STATE_DEVICE=$(fm_pr_file_device "$STATE") || exit 1
 [ "$META_DEVICE" = "$STATE_DEVICE" ] || { echo "error: task metadata is unavailable" >&2; exit 1; }
+if [ "$(grep '^harness=' "$META" | tail -n 1 | cut -d= -f2-)" = claude-local ] \
+   && fm_custom_check_registered "$STATE" "$ID"; then
+  echo "error: task $ID has a claude-local local-model eviction watcher armed in state/$ID.check.sh, the only custom-check slot; retire it first (bin/fm-check-unregister.sh $ID) if the merge poll should replace it, then re-run this command" >&2
+  exit 1
+fi
 META_TMP=$(mktemp "$STATE/.fm-pr-meta.XXXXXX") || exit 1
 while IFS= read -r line || [ -n "$line" ]; do
   case "$line" in

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -993,6 +993,22 @@ spawn_herdr_presentation_order_lock_release() {
   fm_lock_release "$HERDR_PRESENTATION_ORDER_LOCK" || true
 }
 
+crew_dispatch_default_uses_claude_local() {  # <config>
+  command -v jq >/dev/null 2>&1 || return 1
+  jq -e '
+    def profiles: if type == "array" then . else [.] end;
+    (.default? | profiles | any(.harness? == "claude-local"))
+  ' "$1" >/dev/null 2>&1
+}
+
+dispatch_harness_required_error() {  # <config>
+  if crew_dispatch_default_uses_claude_local "$1"; then
+    echo "error: config/crew-dispatch.json default cannot select claude-local; it is opt-in only. Use a matched rule profile, or pass --harness claude-local --model <exact-model-id> for one explicit task." >&2
+  else
+    echo "error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped)." >&2
+  fi
+}
+
 # Batch dispatch (see header): when the first positional is an `id=repo` pair, treat every
 # positional as one and spawn each by re-execing this script in single-task mode. We use
 # the FM_ROOT path (not $0) so it works whatever cwd or relative path invoked us, and reuse
@@ -1007,7 +1023,7 @@ if [ "$RELAUNCH" -eq 1 ] && [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart"
 fi
 if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in */*) false ;; *) true ;; esac; then
   if [ "$KIND" != secondmate ] && [ -z "$HARNESS_ARG" ] && [ -f "$CONFIG/crew-dispatch.json" ]; then
-    echo "error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped)." >&2
+    dispatch_harness_required_error "$CONFIG/crew-dispatch.json"
     exit 1
   fi
   rc=0
@@ -1448,7 +1464,21 @@ raw_launch_uses_claude_local() {  # <raw-launch>
       shift
       while [ "$#" -gt 0 ]; do
         case "$1" in
-          --) shift; break ;;
+          --)
+            shift
+            while [ "$#" -gt 0 ]; do
+              case "$1" in [A-Za-z_]*=*) shift ;; *) break ;; esac
+            done
+            break
+            ;;
+          -S|--split-string)
+            shift
+            while [ "$#" -gt 0 ]; do
+              case "$1" in *claude-local*) return 0 ;; esac
+              shift
+            done
+            return 1
+            ;;
           -u|--unset|-C|--chdir) shift; [ "$#" -gt 0 ] || return 1; shift ;;
           -u?*|--unset=*|-C?*|--chdir=*|-i|--ignore-environment|-0|--null) shift ;;
           -*) shift ;;
@@ -1499,7 +1529,7 @@ case "$ARG3" in
       harness_src='config/secondmate-harness (falling back to config/crew-harness)'
     else
       if [ -f "$CONFIG/crew-dispatch.json" ]; then
-        echo "error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped)." >&2
+        dispatch_harness_required_error "$CONFIG/crew-dispatch.json"
         exit 1
       fi
       HARNESS=$("$FM_ROOT/bin/fm-harness.sh" crew)
@@ -1521,10 +1551,14 @@ esac
 # These three run BEFORE home, project, and brief resolution, so the caller gets
 # the refusal that explains the boundary rather than an unrelated earlier error.
 if [ "$HARNESS" = claude-local ]; then
-  # 1. Reachable only through an explicit per-spawn harness argument. A dispatch
-  #    profile always supplies one (fm-spawn requires an explicit harness whenever
-  #    config/crew-dispatch.json exists), and so does a per-task captain
-  #    instruction; config/crew-harness and config/secondmate-harness must not.
+  if [ -z "$HARNESS_ARG" ] && [ -f "$CONFIG/crew-dispatch.json" ] \
+     && crew_dispatch_default_uses_claude_local "$CONFIG/crew-dispatch.json"; then
+    dispatch_harness_required_error "$CONFIG/crew-dispatch.json"
+    exit 1
+  fi
+  # 1. Reachable only through an explicit per-spawn harness argument. A matched
+  #    dispatch profile supplies one, and so does a per-task captain instruction;
+  #    config/crew-harness, config/secondmate-harness, and a dispatch default must not.
   if [ "$HARNESS_EXPLICIT" -ne 1 ]; then
     echo "error: claude-local is opt-in only and cannot be selected by a home-wide default ($harness_src). Pass it explicitly for one task, or select it from a config/crew-dispatch.json profile." >&2
     exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1347,7 +1347,7 @@ launch_template() {
     # Claude Code names it as the control for an unrecognized model's real
     # window, and without it Claude Code assumes 200k and auto-compacts against
     # a window the local server does not have (verified 2026-09-01).
-    claude-local) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false ANTHROPIC_BASE_URL=__LOCALENDPOINT__ ANTHROPIC_AUTH_TOKEN=__LOCALTOKEN__ ANTHROPIC_MODEL=__LOCALMODEL__ ANTHROPIC_SMALL_FAST_MODEL=__LOCALMODEL__ CLAUDE_CODE_MAX_CONTEXT_TOKENS=__LOCALCTX__ CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 claude --dangerously-skip-permissions "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    claude-local) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 ANTHROPIC_BASE_URL=__LOCALENDPOINT__ ANTHROPIC_AUTH_TOKEN=__LOCALTOKEN__ ANTHROPIC_MODEL=__LOCALMODEL__ ANTHROPIC_SMALL_FAST_MODEL=__LOCALMODEL__ CLAUDE_CODE_MAX_CONTEXT_TOKENS=__LOCALCTX__ CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 claude --dangerously-skip-permissions --settings '\''{"feedbackDrafts":"off"}'\'' "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1202,7 +1202,11 @@ if [ "$RELAUNCH" -eq 1 ]; then
   }
 elif [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse)
+    ''|claude|claude-local|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse)
+      # claude-local is listed even though a secondmate on it is refused below:
+      # without it, a bare `claude-local` positional is read as a FIRSTMATE HOME
+      # path and the caller gets "home does not exist" instead of the refusal
+      # that actually explains the boundary.
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -1278,6 +1282,19 @@ launch_template() {
     # leaves the other in force. Both are per-launch, scoped to this invocation only,
     # and never touch the captain's global ~/.claude/settings.json.
     claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '\''{"feedbackDrafts":"off"}'\'' __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # claude-local: the verified `claude` CLI pinned to a local
+    # OpenAI/Anthropic-compatible endpoint (an LM Studio server by default),
+    # NOT a second harness implementation. It deliberately reuses claude's
+    # binary, composer shape, trust dialog, and lifecycle hooks so the shared
+    # classifier keeps its single owner; the `claude*` prefix rule stated in
+    # bin/fm-control-lib.sh is what routes it to those verified tables.
+    # ANTHROPIC_MODEL rather than --model is the model axis here, because the
+    # endpoint's own catalog id is what selects the served model.
+    # CLAUDE_CODE_MAX_CONTEXT_TOKENS is the short-context enforcement point:
+    # Claude Code names it as the control for an unrecognized model's real
+    # window, and without it Claude Code assumes 200k and auto-compacts against
+    # a window the local server does not have (verified 2026-09-01).
+    claude-local) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false ANTHROPIC_BASE_URL=__LOCALENDPOINT__ ANTHROPIC_AUTH_TOKEN=__LOCALTOKEN__ ANTHROPIC_MODEL=__LOCALMODEL__ ANTHROPIC_SMALL_FAST_MODEL=__LOCALMODEL__ CLAUDE_CODE_MAX_CONTEXT_TOKENS=__LOCALCTX__ CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 claude --dangerously-skip-permissions "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
@@ -1381,6 +1398,11 @@ launch_template() {
   esac
 }
 
+# Whether this spawn's harness came from an EXPLICIT per-spawn argument (a
+# positional name, --harness, or a raw launch command) rather than from
+# config resolution. The claude-local opt-in gate below is the only consumer:
+# that adapter must never be reachable by a home-wide default.
+HARNESS_EXPLICIT=1
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
     RAW_LAUNCH=1
@@ -1391,6 +1413,7 @@ case "$ARG3" in
     done
     ;;
   '')
+    HARNESS_EXPLICIT=0
     # No explicit harness: resolve from config. A secondmate AGENT launches on the
     # secondmate harness (config/secondmate-harness -> config/crew-harness -> own);
     # every other kind uses the crew harness only when no dispatch profile file is
@@ -1418,12 +1441,42 @@ case "$ARG3" in
     ;;
 esac
 
+# claude-local runs on the captain's own machine against a model sized for
+# short-context work, so it is opt-in only and is refused for the uses its
+# verification does not support. Each refusal is a hard gate rather than a
+# warning, because the failure it prevents is silent: a task routed here by a
+# home-wide default would simply be slow and worse, not visibly broken.
+# These three run BEFORE home, project, and brief resolution, so the caller gets
+# the refusal that explains the boundary rather than an unrelated earlier error.
+if [ "$HARNESS" = claude-local ]; then
+  # 1. Reachable only through an explicit per-spawn harness argument. A dispatch
+  #    profile always supplies one (fm-spawn requires an explicit harness whenever
+  #    config/crew-dispatch.json exists), and so does a per-task captain
+  #    instruction; config/crew-harness and config/secondmate-harness must not.
+  if [ "$HARNESS_EXPLICIT" -ne 1 ]; then
+    echo "error: claude-local is opt-in only and cannot be selected by a home-wide default ($harness_src). Pass it explicitly for one task, or select it from a config/crew-dispatch.json profile." >&2
+    exit 1
+  fi
+  # 2. Crewmate/scout only. A secondmate is a firstmate instance needing a primary
+  #    supervision protocol; claude-local has no verified primary evidence and is
+  #    not sized for one.
+  if [ "$KIND" = secondmate ]; then
+    echo "error: claude-local is a verified crewmate/scout adapter only and cannot run a secondmate. Select a harness verified for secondmates." >&2
+    exit 1
+  fi
+  # 3. Never the no-mistakes pipeline. That path is firstmate's highest-rigor
+  #    shipping route and runs long, repeated, large-context review and fix turns -
+  #    exactly the shape this runtime is bounded away from.
+  if [ "$MODE" = no-mistakes ]; then
+    echo "error: claude-local is not verified for no-mistakes shipping work; that pipeline needs long-context review and fix turns this runtime is bounded away from. Ship this task on a hosted runtime, or select --mode direct-PR/local-only if the captain has approved the lower rigor." >&2
+    exit 1
+  fi
+fi
+
 # muse and gemini are verified as CREWMATE/SCOUT adapters only. A secondmate is
-# a firstmate instance, so it needs a primary supervision protocol.
-# gemini has none: docs/supervision-protocols/ carries no gemini wake protocol
-# and this task verified only crewmate-side launch, busy state, interrupt, and
-# exit, so a gemini secondmate is refused rather than stood up on an unverified
-# supervision path. muse has none either, and its
+# a firstmate instance, so it needs a primary supervision protocol. Gemini has
+# none: its verification covers crewmate-side launch, busy state, interrupt, and
+# exit only. Muse has none either, and its
 # Claude-compatible hook dialect explicitly rejects the model-reawakening and
 # asyncRewake handlers that firstmate's primary turn-end supervision is built on
 # (muse 0.1.0-R708.1). Refusing here keeps that gap loud instead of standing up a
@@ -1892,6 +1945,33 @@ if [ "$KIND" = ship ] || [ "$KIND" = scout ]; then
     fi
   fi
 fi
+
+# claude-local's remaining gates need the resolved brief, so they run here rather
+# than with the scope refusals above. This is still before any endpoint,
+# worktree, or record exists, so a refusal leaves nothing behind to clean up.
+if [ "$HARNESS" = claude-local ]; then
+  # 4. The model id is the endpoint's own catalog id and is never guessed. A
+  #    relaunch reuses the id already recorded for the task, the same way it
+  #    reuses the recorded harness, so recovering a worker never needs the caller
+  #    to remember which local model it was launched on.
+  if [ "$RELAUNCH" -eq 1 ] && [ "$MODEL_SET" -eq 0 ]; then
+    RELAUNCH_MODEL=$(fm_meta_get "$RELAUNCH_META" model)
+    [ -z "$RELAUNCH_MODEL" ] || [ "$RELAUNCH_MODEL" = default ] || MODEL=$RELAUNCH_MODEL
+  fi
+  if [ -z "$MODEL" ] || [ "$MODEL" = default ]; then
+    echo "error: claude-local requires an explicit --model naming the exact model id the local endpoint serves (list them with: bin/fm-local-model.sh probe)." >&2
+    exit 1
+  fi
+  # 5. The endpoint must be answering and the model actually loaded.
+  #    fm-local-model.sh owns the verdict and prints the actionable refusal.
+  "$SCRIPT_DIR/fm-local-model.sh" preflight "$MODEL" >/dev/null || exit 1
+  LOCAL_CTX=$("$SCRIPT_DIR/fm-local-model.sh" context-budget "$MODEL") || exit 1
+  # 6. A brief that obviously exceeds the usable headroom is refused loudly here
+  #    rather than silently degrading into auto-compaction against a window the
+  #    server does not have.
+  "$SCRIPT_DIR/fm-local-model.sh" brief-fits "$MODEL" "$BRIEF" >/dev/null || exit 1
+fi
+
 
 delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task mode
   case "$1" in
@@ -3161,10 +3241,21 @@ case "$HARNESS" in
   pi|pi-signed) LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"} ;;
   cursor) LAUNCH=${LAUNCH//__CURSORBIN__/"$(shell_quote "$CURSOR_BIN")"} ;;
   gemini) LAUNCH=${LAUNCH//__GEMINISETTINGS__/"$(shell_quote "$STATE_REAL/$ID.gemini-settings.json")"} ;;
+  # The endpoint, model, and context bound are baked into the launch rather than
+  # inherited, because the pane is created by a long-lived backend daemon that
+  # does not carry firstmate's environment. LOCAL_CTX was resolved from the live
+  # endpoint above, so the bound the worker runs under is the one the server
+  # actually loaded, capped by the firstmate ceiling.
+  claude-local)
+    LAUNCH=${LAUNCH//__LOCALENDPOINT__/"$(shell_quote "${FM_LOCAL_MODEL_ENDPOINT:-http://127.0.0.1:1234}")"}
+    LAUNCH=${LAUNCH//__LOCALTOKEN__/"$(shell_quote "${FM_LOCAL_MODEL_TOKEN:-local}")"}
+    LAUNCH=${LAUNCH//__LOCALMODEL__/"$(shell_quote "$MODEL")"}
+    LAUNCH=${LAUNCH//__LOCALCTX__/"$(shell_quote "$LOCAL_CTX")"}
+    ;;
 esac
 LAUNCH=${LAUNCH//__WORKTREE__/$sq_worktree}
 case "$HARNESS" in
-  claude|codex|opencode|pi|pi-signed|grok|kimi|gemini|muse)
+  claude|claude-local|codex|opencode|pi|pi-signed|grok|kimi|gemini|muse)
     LAUNCH="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI $LAUNCH"
     ;;
 esac
@@ -3175,7 +3266,11 @@ esac
 # Forward firstmate's own resolved store onto the claude launch so the crewmate
 # uses the same credential/config firstmate is authenticated with. Only when set;
 # an unset value is the single-store default and needs no prefix.
-if [ "$HARNESS" = claude ] && [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
+# claude-local shares this: it is the same binary reading the same store, and
+# only its endpoint differs, so a captain running a non-default config directory
+# gets the same settings in a local worker as in a hosted one.
+case "$HARNESS" in claude|claude-local) FM_FORWARD_CLAUDE_CONFIG=1 ;; *) FM_FORWARD_CLAUDE_CONFIG=0 ;; esac
+if [ "$FM_FORWARD_CLAUDE_CONFIG" = 1 ] && [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
   LAUNCH="CLAUDE_CONFIG_DIR=$(shell_quote "$CLAUDE_CONFIG_DIR") $LAUNCH"
 fi
 if [ "$KIND" = secondmate ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -760,6 +760,8 @@ RELAUNCH_REPLACEMENT_BUSY_GEN=
 RELAUNCH_REPLACEMENT_HARNESS=
 RELAUNCH_REPLACEMENT_STATE=
 RELAUNCH_REPLACEMENT_WT=
+LOCAL_MODEL_CHECK_PENDING=0
+LOCAL_MODEL_CHECK_STATE=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
 
@@ -807,6 +809,8 @@ spawn_abort_cleanup() {
         "$RELAUNCH_REPLACEMENT_STATE" \
         "$ID"; then
       echo "warning: could not remove replacement wiring after aborted relaunch of $ID" >&2
+    else
+      LOCAL_MODEL_CHECK_PENDING=0
     fi
     if [ -n "$RELAUNCH_REPLACEMENT_BUSY_GEN" ]; then
       if ! "$FM_ROOT/bin/fm-busy-event.sh" retire \
@@ -815,6 +819,13 @@ spawn_abort_cleanup() {
         echo "warning: could not retire replacement busy generation after aborted relaunch of $ID" >&2
       fi
     fi
+  fi
+  if [ "$LOCAL_MODEL_CHECK_PENDING" = 1 ]; then
+    if ! FM_STATE_OVERRIDE="$LOCAL_MODEL_CHECK_STATE" \
+        "$SCRIPT_DIR/fm-check-unregister.sh" "$ID" >/dev/null; then
+      echo "warning: could not remove local-model check after aborted spawn of $ID" >&2
+    fi
+    LOCAL_MODEL_CHECK_PENDING=0
   fi
   if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ] \
      && [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" != 1 ]; then
@@ -924,7 +935,7 @@ spawn_herdr_presentation_order_lock_acquire() {
 }
 
 clear_relaunch_harness_wiring() {
-  local harness=$1 wt=$2 state=$3 id=$4 token_path token auth_path path
+  local harness=$1 wt=$2 state=$3 id=$4 original_harness token_path token auth_path path
   # The wiring arms above match on harness PREFIXES, because a task launched
   # from a raw command records that command's basename rather than the exact
   # adapter name. The retirement tables are keyed by the exact adapter, so the
@@ -932,7 +943,11 @@ clear_relaunch_harness_wiring() {
   # as, say, `grok-2` would have wiring armed and never retired. An
   # unrecognized value resolves to no adapter, which is also the case in which
   # no wiring was armed to begin with.
+  original_harness=$harness
   harness=$(fm_control_harness_family "$harness") || harness=
+  if [ "$original_harness" = claude-local ]; then
+    FM_STATE_OVERRIDE="$state" "$SCRIPT_DIR/fm-check-unregister.sh" "$id" >/dev/null || return 1
+  fi
   token_path=$(fm_control_harness_turnend_token_path "$harness" "$state" "$id") || return 1
   token=
   if [ -n "$token_path" ] && [ -f "$token_path" ]; then
@@ -948,6 +963,24 @@ clear_relaunch_harness_wiring() {
   done <<EOF
 $(fm_control_harness_wiring_paths "$harness" "$wt" "$state" "$id")
 EOF
+}
+
+arm_local_model_check() {  # <state> <id> <endpoint> <model>
+  local state=$1 id=$2 endpoint=$3 model=$4 check tmp
+  check="$state/$id.check.sh"
+  [ ! -e "$check" ] && [ ! -L "$check" ] || return 1
+  tmp=$(mktemp "$state/.$id.check.XXXXXX") || return 1
+  if ! {
+    printf '#!/usr/bin/env bash\n'
+    printf 'export FM_LOCAL_MODEL_ENDPOINT=%s\n' "$(shell_quote "$endpoint")"
+    printf 'exec %s check %s\n' "$(shell_quote "$SCRIPT_DIR/fm-local-model.sh")" "$(shell_quote "$model")"
+  } > "$tmp" || ! chmod 0700 "$tmp" || ! mv -- "$tmp" "$check"; then
+    rm -f -- "$tmp"
+    return 1
+  fi
+  LOCAL_MODEL_CHECK_PENDING=1
+  LOCAL_MODEL_CHECK_STATE=$state
+  FM_STATE_OVERRIDE="$state" "$SCRIPT_DIR/fm-check-register.sh" "$id" >/dev/null
 }
 
 spawn_herdr_presentation_order_lock_release() {
@@ -1964,12 +1997,13 @@ if [ "$HARNESS" = claude-local ]; then
   fi
   # 5. The endpoint must be answering and the model actually loaded.
   #    fm-local-model.sh owns the verdict and prints the actionable refusal.
-  "$SCRIPT_DIR/fm-local-model.sh" preflight "$MODEL" >/dev/null || exit 1
-  LOCAL_CTX=$("$SCRIPT_DIR/fm-local-model.sh" context-budget "$MODEL") || exit 1
+  LOCAL_MODEL_ENDPOINT=${FM_LOCAL_MODEL_ENDPOINT:-http://127.0.0.1:1234}
+  FM_LOCAL_MODEL_ENDPOINT="$LOCAL_MODEL_ENDPOINT" "$SCRIPT_DIR/fm-local-model.sh" preflight "$MODEL" >/dev/null || exit 1
+  LOCAL_CTX=$(FM_LOCAL_MODEL_ENDPOINT="$LOCAL_MODEL_ENDPOINT" "$SCRIPT_DIR/fm-local-model.sh" context-budget "$MODEL") || exit 1
   # 6. A brief that obviously exceeds the usable headroom is refused loudly here
   #    rather than silently degrading into auto-compaction against a window the
   #    server does not have.
-  "$SCRIPT_DIR/fm-local-model.sh" brief-fits "$MODEL" "$BRIEF" >/dev/null || exit 1
+  FM_LOCAL_MODEL_ENDPOINT="$LOCAL_MODEL_ENDPOINT" "$SCRIPT_DIR/fm-local-model.sh" brief-fits "$MODEL" "$BRIEF" >/dev/null || exit 1
 fi
 
 
@@ -2738,6 +2772,12 @@ if [ "$RELAUNCH" -eq 1 ]; then
   RELAUNCH_REPLACEMENT_STATE=$STATE_REAL
   RELAUNCH_REPLACEMENT_WT=$WT
 fi
+if [ "$HARNESS" = claude-local ]; then
+  arm_local_model_check "$STATE_REAL" "$ID" "$LOCAL_MODEL_ENDPOINT" "$MODEL" || {
+    echo "error: could not arm the local-model watcher check for $ID" >&2
+    exit 1
+  }
+fi
 if [ "$KIND" != secondmate ]; then
   # Arm the semantic busy-state contract (bin/fm-busy-lib.sh) for every
   # adapter with a verified semantic source. The launch brief sent below IS a
@@ -3247,7 +3287,7 @@ case "$HARNESS" in
   # endpoint above, so the bound the worker runs under is the one the server
   # actually loaded, capped by the firstmate ceiling.
   claude-local)
-    LAUNCH=${LAUNCH//__LOCALENDPOINT__/"$(shell_quote "${FM_LOCAL_MODEL_ENDPOINT:-http://127.0.0.1:1234}")"}
+    LAUNCH=${LAUNCH//__LOCALENDPOINT__/"$(shell_quote "$LOCAL_MODEL_ENDPOINT")"}
     LAUNCH=${LAUNCH//__LOCALTOKEN__/"$(shell_quote "${FM_LOCAL_MODEL_TOKEN:-local}")"}
     LAUNCH=${LAUNCH//__LOCALMODEL__/"$(shell_quote "$MODEL")"}
     LAUNCH=${LAUNCH//__LOCALCTX__/"$(shell_quote "$LOCAL_CTX")"}
@@ -3439,3 +3479,4 @@ fi
 SPAWN_DELIVERY=
 [ -z "$MODE" ] || SPAWN_DELIVERY=" mode=$MODE yolo=$YOLO"
 echo "spawned $ID harness=$HARNESS kind=$KIND$SPAWN_DELIVERY window=$META_WINDOW worktree=$WT"
+LOCAL_MODEL_CHECK_PENDING=0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3562,11 +3562,13 @@ if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -ne 0 ]; then
     echo "error: task $ID was republished but its backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); fix the backlog and re-run the relaunch" >&2
   fi
 fi
+if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -eq 0 ]; then
+  LOCAL_MODEL_CHECK_PENDING=0
+fi
 trap - HUP INT TERM
 if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -ne 0 ]; then
   exit "$SPAWN_BACKLOG_COMMIT_STATUS"
 fi
-LOCAL_MODEL_CHECK_PENDING=0
 fm_lock_release "$SPAWN_META_LOCK"
 SPAWN_META_LOCK_HELD=0
 if [ -n "$SPAWN_DEFERRED_SIGNAL" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1435,6 +1435,37 @@ launch_template() {
   esac
 }
 
+raw_launch_uses_claude_local() {  # <raw-launch>
+  local launch=$1
+  # shellcheck disable=SC2086
+  set -- $launch
+  while [ "$#" -gt 0 ]; do
+    case "$1" in [A-Za-z_]*=*) shift ;; *) break ;; esac
+  done
+  case "${1:-}" in
+    claude-local|*/claude-local) return 0 ;;
+    env|*/env)
+      shift
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --) shift; break ;;
+          -u|--unset|-C|--chdir) shift; [ "$#" -gt 0 ] || return 1; shift ;;
+          -u?*|--unset=*|-C?*|--chdir=*|-i|--ignore-environment|-0|--null) shift ;;
+          -*) shift ;;
+          [A-Za-z_]*=*) shift ;;
+          *) break ;;
+        esac
+      done
+      ;;
+    command|*/command)
+      shift
+      case "${1:-}" in -p|--) shift ;; esac
+      ;;
+    *) return 1 ;;
+  esac
+  case "${1:-}" in claude-local|*/claude-local) return 0 ;; *) return 1 ;; esac
+}
+
 # Whether this spawn's harness came from an EXPLICIT per-spawn argument (a
 # positional name, --harness, or a raw launch command) rather than from
 # config resolution. The claude-local opt-in gate below is the only consumer:
@@ -1448,7 +1479,7 @@ case "$ARG3" in
     for word in $LAUNCH; do
       case "$word" in [A-Za-z_]*=*) continue ;; *) HARNESS=$(basename "$word"); break ;; esac
     done
-    if [ "$HARNESS" = claude-local ]; then
+    if raw_launch_uses_claude_local "$LAUNCH"; then
       echo "error: a raw claude-local command is refused because it bypasses the bounded local-model launch context; use --harness claude-local --model <exact-model-id>." >&2
       exit 1
     fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -965,14 +965,18 @@ $(fm_control_harness_wiring_paths "$harness" "$wt" "$state" "$id")
 EOF
 }
 
-arm_local_model_check() {  # <state> <id> <endpoint> <model>
-  local state=$1 id=$2 endpoint=$3 model=$4 check tmp
+arm_local_model_check() {  # <state> <id> <endpoint> <model> <backend> <target>
+  local state=$1 id=$2 endpoint=$3 model=$4 backend=$5 target=$6 check tmp
   check="$state/$id.check.sh"
   [ ! -e "$check" ] && [ ! -L "$check" ] || return 1
   tmp=$(mktemp "$state/.$id.check.XXXXXX") || return 1
   if ! {
     printf '#!/usr/bin/env bash\n'
     printf 'export FM_LOCAL_MODEL_ENDPOINT=%s\n' "$(shell_quote "$endpoint")"
+    printf '. %s\n' "$(shell_quote "$SCRIPT_DIR/fm-backend.sh")"
+    # shellcheck disable=SC2016
+    printf '[ "$(fm_backend_agent_alive %s %s)" != dead ] || exit 0\n' \
+      "$(shell_quote "$backend")" "$(shell_quote "$target")"
     printf 'exec %s check %s\n' "$(shell_quote "$SCRIPT_DIR/fm-local-model.sh")" "$(shell_quote "$model")"
   } > "$tmp" || ! chmod 0700 "$tmp" || ! mv -- "$tmp" "$check"; then
     rm -f -- "$tmp"
@@ -1444,6 +1448,10 @@ case "$ARG3" in
     for word in $LAUNCH; do
       case "$word" in [A-Za-z_]*=*) continue ;; *) HARNESS=$(basename "$word"); break ;; esac
     done
+    if [ "$HARNESS" = claude-local ]; then
+      echo "error: a raw claude-local command is refused because it bypasses the bounded local-model launch context; use --harness claude-local --model <exact-model-id>." >&2
+      exit 1
+    fi
     ;;
   '')
     HARNESS_EXPLICIT=0
@@ -1997,7 +2005,11 @@ if [ "$HARNESS" = claude-local ]; then
   fi
   # 5. The endpoint must be answering and the model actually loaded.
   #    fm-local-model.sh owns the verdict and prints the actionable refusal.
-  LOCAL_MODEL_ENDPOINT=${FM_LOCAL_MODEL_ENDPOINT:-http://127.0.0.1:1234}
+  LOCAL_MODEL_ENDPOINT=${FM_LOCAL_MODEL_ENDPOINT:-}
+  if [ -z "$LOCAL_MODEL_ENDPOINT" ] && [ "$RELAUNCH" -eq 1 ]; then
+    LOCAL_MODEL_ENDPOINT=$(fm_meta_get "$RELAUNCH_META" local_model_endpoint)
+  fi
+  [ -n "$LOCAL_MODEL_ENDPOINT" ] || LOCAL_MODEL_ENDPOINT=http://127.0.0.1:1234
   FM_LOCAL_MODEL_ENDPOINT="$LOCAL_MODEL_ENDPOINT" "$SCRIPT_DIR/fm-local-model.sh" preflight "$MODEL" >/dev/null || exit 1
   LOCAL_CTX=$(FM_LOCAL_MODEL_ENDPOINT="$LOCAL_MODEL_ENDPOINT" "$SCRIPT_DIR/fm-local-model.sh" context-budget "$MODEL") || exit 1
   # 6. A brief that obviously exceeds the usable headroom is refused loudly here
@@ -2773,7 +2785,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   RELAUNCH_REPLACEMENT_WT=$WT
 fi
 if [ "$HARNESS" = claude-local ]; then
-  arm_local_model_check "$STATE_REAL" "$ID" "$LOCAL_MODEL_ENDPOINT" "$MODEL" || {
+  arm_local_model_check "$STATE_REAL" "$ID" "$LOCAL_MODEL_ENDPOINT" "$MODEL" "$BACKEND" "$T" || {
     echo "error: could not arm the local-model watcher check for $ID" >&2
     exit 1
   }
@@ -3158,7 +3170,7 @@ SPAWN_META_PATH=$SPAWN_META_TMP
 preserve_relaunch_meta() {
   awk -F= '
     BEGIN {
-      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen spawn_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
+      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort local_model_endpoint busy_gen spawn_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
       for (i in keys) owned[keys[i]] = 1
     }
     !($1 in owned)
@@ -3176,6 +3188,7 @@ preserve_relaunch_meta() {
   echo "tasktmp=$TASK_TMP"
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"
+  [ "$HARNESS" != claude-local ] || echo "local_model_endpoint=$LOCAL_MODEL_ENDPOINT"
   [ -z "${BUSY_GEN:-}" ] || echo "busy_gen=$BUSY_GEN"
   echo "spawn_gen=$SPAWN_GEN"
   # Default-off writes no traceparent= line.
@@ -3425,6 +3438,8 @@ if [ "$KIND" = secondmate ] && [ "${FM_SKIP_SECONDMATE_INHERIT:-0}" != 1 ]; then
   fi
 fi
 
+LOCAL_MODEL_CHECK_PENDING=0
+
 # This is the commit point: all endpoint and harness delivery that can reject
 # the spawn has succeeded. Re-read and transition while holding the same
 # per-task lock as metadata publication, then and only then report success.
@@ -3479,4 +3494,3 @@ fi
 SPAWN_DELIVERY=
 [ -z "$MODE" ] || SPAWN_DELIVERY=" mode=$MODE yolo=$YOLO"
 echo "spawned $ID harness=$HARNESS kind=$KIND$SPAWN_DELIVERY window=$META_WINDOW worktree=$WT"
-LOCAL_MODEL_CHECK_PENDING=0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -317,6 +317,8 @@ fm_backlog_directory_present "$STATE" "state directory" || {
 . "$SCRIPT_DIR/fm-cursor-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-check-lib.sh
+. "$SCRIPT_DIR/fm-check-lib.sh"
 # shellcheck source=bin/fm-dod-lib.sh
 . "$SCRIPT_DIR/fm-dod-lib.sh"
 # shellcheck source=bin/fm-trace-context-lib.sh
@@ -945,7 +947,17 @@ clear_relaunch_harness_wiring() {
   # no wiring was armed to begin with.
   original_harness=$harness
   harness=$(fm_control_harness_family "$harness") || harness=
-  if [ "$original_harness" = claude-local ]; then
+  # state/<id>.check.sh is a single slot the local-model eviction watcher and a
+  # merge poll both want. Retire it only when it still holds THIS adapter's
+  # watcher: an operator who handed the slot over (bin/fm-pr-check.sh names that
+  # handover) leaves a poll whose registration is present and whose trust
+  # binding is not the watcher's, and removing that shim would strand
+  # <id>.pr-poll and <id>.pr-poll-registration with merge detection silently
+  # gone.
+  if [ "$original_harness" = claude-local ] \
+     && [ ! -e "$state/$id.pr-poll-registration" ] \
+     && [ ! -L "$state/$id.pr-poll-registration" ] \
+     && fm_custom_check_registered "$state" "$id"; then
     FM_STATE_OVERRIDE="$state" "$SCRIPT_DIR/fm-check-unregister.sh" "$id" >/dev/null || return 1
   fi
   token_path=$(fm_control_harness_turnend_token_path "$harness" "$state" "$id") || return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1451,8 +1451,21 @@ launch_template() {
   esac
 }
 
+env_split_string_uses_claude_local() {
+  local word
+  while [ "$#" -gt 0 ]; do
+    word=$1
+    word=${word#\'}
+    word=${word#\"}
+    word=${word%\'}
+    word=${word%\"}
+    case "$word" in [A-Za-z_]*=*) shift ;; *) break ;; esac
+  done
+  case "${word:-}" in claude-local|*/claude-local) return 0 ;; *) return 1 ;; esac
+}
+
 raw_launch_uses_claude_local() {  # <raw-launch>
-  local launch=$1
+  local launch=$1 word
   # shellcheck disable=SC2086
   set -- $launch
   while [ "$#" -gt 0 ]; do
@@ -1473,11 +1486,20 @@ raw_launch_uses_claude_local() {  # <raw-launch>
             ;;
           -S|--split-string)
             shift
-            while [ "$#" -gt 0 ]; do
-              case "$1" in *claude-local*) return 0 ;; esac
-              shift
-            done
-            return 1
+            env_split_string_uses_claude_local "$@"
+            return $?
+            ;;
+          -S?*)
+            word=${1#-S}
+            shift
+            env_split_string_uses_claude_local "$word" "$@"
+            return $?
+            ;;
+          --split-string=*)
+            word=${1#--split-string=}
+            shift
+            env_split_string_uses_claude_local "$word" "$@"
+            return $?
             ;;
           -u|--unset|-C|--chdir) shift; [ "$#" -gt 0 ] || return 1; shift ;;
           -u?*|--unset=*|-C?*|--chdir=*|-i|--ignore-environment|-0|--null) shift ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1992,7 +1992,7 @@ if [ "$HARNESS" = claude-local ]; then
     [ -z "$RELAUNCH_MODEL" ] || [ "$RELAUNCH_MODEL" = default ] || MODEL=$RELAUNCH_MODEL
   fi
   if [ -z "$MODEL" ] || [ "$MODEL" = default ]; then
-    echo "error: claude-local requires an explicit --model naming the exact model id the local endpoint serves (list them with: bin/fm-local-model.sh probe)." >&2
+    echo "error: claude-local requires an explicit --model naming the exact model id the local endpoint serves (list them with: bin/fm-local-model.sh list)." >&2
     exit 1
   fi
   # 5. The endpoint must be answering and the model actually loaded.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -811,8 +811,6 @@ spawn_abort_cleanup() {
         "$RELAUNCH_REPLACEMENT_STATE" \
         "$ID"; then
       echo "warning: could not remove replacement wiring after aborted relaunch of $ID" >&2
-    else
-      LOCAL_MODEL_CHECK_PENDING=0
     fi
     if [ -n "$RELAUNCH_REPLACEMENT_BUSY_GEN" ]; then
       if ! "$FM_ROOT/bin/fm-busy-event.sh" retire \
@@ -939,13 +937,17 @@ spawn_herdr_presentation_order_lock_acquire() {
 # state/<id>.check.sh is a single slot the local-model eviction watcher and a
 # merge poll both want. True only when it still holds THIS adapter's watcher:
 # an operator who handed the slot over (bin/fm-pr-check.sh names that handover)
-# leaves a poll whose registration is present and whose trust binding is not
-# the watcher's. Retiring that shim would strand <id>.pr-poll and
-# <id>.pr-poll-registration with merge detection silently gone, and arming over
-# it would replace the poll just as silently.
+# leaves a LIVE poll there, and retiring that shim would strand <id>.pr-poll
+# and <id>.pr-poll-registration with merge detection silently gone, while
+# arming over it would replace the poll just as silently.
+# The poll is identified by the same detector bin/fm-control.sh uses, which
+# re-verifies the shim against fm-pr-poll.sh and the registration's own
+# recorded hashes. A bare <id>.pr-poll-registration left behind by an operator
+# who already retired the poll therefore does not answer for a slot the poll no
+# longer occupies.
 local_model_check_slot_is_ours() {  # <state> <id>
   local state=$1 id=$2
-  [ ! -e "$state/$id.pr-poll-registration" ] && [ ! -L "$state/$id.pr-poll-registration" ] || return 1
+  ! fm_pr_poll_artifacts_valid "$state" "$id" "$SCRIPT_DIR/fm-pr-poll.sh" || return 1
   fm_custom_check_registered "$state" "$id"
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1573,7 +1573,11 @@ esac
 # These three run BEFORE home, project, and brief resolution, so the caller gets
 # the refusal that explains the boundary rather than an unrelated earlier error.
 if [ "$HARNESS" = claude-local ]; then
-  if [ -z "$HARNESS_ARG" ] && [ -f "$CONFIG/crew-dispatch.json" ] \
+  # A relaunch with no --harness takes its harness from the task's own durable
+  # record, never from config, so the dispatch default it never consulted must
+  # not refuse it. Only a fresh spawn can arrive here carrying a default's
+  # choice as a positional harness.
+  if [ "$RELAUNCH" -eq 0 ] && [ -z "$HARNESS_ARG" ] && [ -f "$CONFIG/crew-dispatch.json" ] \
      && crew_dispatch_default_uses_claude_local "$CONFIG/crew-dispatch.json"; then
     dispatch_harness_required_error "$CONFIG/crew-dispatch.json"
     exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3469,7 +3469,6 @@ if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -ne 0 ]; then
     if spawn_fresh_commit_rollback; then
       echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); its record was removed so no worker is left that the backlog does not own - close out endpoint $T and local copy $WT by hand, then re-run the spawn" >&2
     else
-      LOCAL_MODEL_CHECK_PENDING=0
       echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR), and failed-dispatch cleanup is incomplete; the provisional record may remain at $STATE/$ID.meta - close out endpoint $T and local copy $WT by hand, then remove the record and busy state before retrying" >&2
     fi
   else

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3438,7 +3438,7 @@ if [ "$KIND" = secondmate ] && [ "${FM_SKIP_SECONDMATE_INHERIT:-0}" != 1 ]; then
   fi
 fi
 
-LOCAL_MODEL_CHECK_PENDING=0
+[ "$RELAUNCH" -eq 0 ] || LOCAL_MODEL_CHECK_PENDING=0
 
 # This is the commit point: all endpoint and harness delivery that can reject
 # the spawn has succeeded. Re-read and transition while holding the same
@@ -3469,6 +3469,7 @@ if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -ne 0 ]; then
     if spawn_fresh_commit_rollback; then
       echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR); its record was removed so no worker is left that the backlog does not own - close out endpoint $T and local copy $WT by hand, then re-run the spawn" >&2
     else
+      LOCAL_MODEL_CHECK_PENDING=0
       echo "error: task $ID's backlog item could not be moved to In flight ($FM_BACKLOG_TRANSITION_ERROR), and failed-dispatch cleanup is incomplete; the provisional record may remain at $STATE/$ID.meta - close out endpoint $T and local copy $WT by hand, then remove the record and busy state before retrying" >&2
     fi
   else
@@ -3479,6 +3480,7 @@ trap - HUP INT TERM
 if [ "$SPAWN_BACKLOG_COMMIT_STATUS" -ne 0 ]; then
   exit "$SPAWN_BACKLOG_COMMIT_STATUS"
 fi
+LOCAL_MODEL_CHECK_PENDING=0
 fm_lock_release "$SPAWN_META_LOCK"
 SPAWN_META_LOCK_HELD=0
 if [ -n "$SPAWN_DEFERRED_SIGNAL" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -936,6 +936,19 @@ spawn_herdr_presentation_order_lock_acquire() {
   return 1
 }
 
+# state/<id>.check.sh is a single slot the local-model eviction watcher and a
+# merge poll both want. True only when it still holds THIS adapter's watcher:
+# an operator who handed the slot over (bin/fm-pr-check.sh names that handover)
+# leaves a poll whose registration is present and whose trust binding is not
+# the watcher's. Retiring that shim would strand <id>.pr-poll and
+# <id>.pr-poll-registration with merge detection silently gone, and arming over
+# it would replace the poll just as silently.
+local_model_check_slot_is_ours() {  # <state> <id>
+  local state=$1 id=$2
+  [ ! -e "$state/$id.pr-poll-registration" ] && [ ! -L "$state/$id.pr-poll-registration" ] || return 1
+  fm_custom_check_registered "$state" "$id"
+}
+
 clear_relaunch_harness_wiring() {
   local harness=$1 wt=$2 state=$3 id=$4 original_harness token_path token auth_path path
   # The wiring arms above match on harness PREFIXES, because a task launched
@@ -947,17 +960,7 @@ clear_relaunch_harness_wiring() {
   # no wiring was armed to begin with.
   original_harness=$harness
   harness=$(fm_control_harness_family "$harness") || harness=
-  # state/<id>.check.sh is a single slot the local-model eviction watcher and a
-  # merge poll both want. Retire it only when it still holds THIS adapter's
-  # watcher: an operator who handed the slot over (bin/fm-pr-check.sh names that
-  # handover) leaves a poll whose registration is present and whose trust
-  # binding is not the watcher's, and removing that shim would strand
-  # <id>.pr-poll and <id>.pr-poll-registration with merge detection silently
-  # gone.
-  if [ "$original_harness" = claude-local ] \
-     && [ ! -e "$state/$id.pr-poll-registration" ] \
-     && [ ! -L "$state/$id.pr-poll-registration" ] \
-     && fm_custom_check_registered "$state" "$id"; then
+  if [ "$original_harness" = claude-local ] && local_model_check_slot_is_ours "$state" "$id"; then
     FM_STATE_OVERRIDE="$state" "$SCRIPT_DIR/fm-check-unregister.sh" "$id" >/dev/null || return 1
   fi
   token_path=$(fm_control_harness_turnend_token_path "$harness" "$state" "$id") || return 1
@@ -2873,6 +2876,18 @@ exclude_path() {
   grep -qxF "$rel" "$EXCL" 2>/dev/null || echo "$rel" >> "$EXCL"
 }
 if [ "$RELAUNCH" -eq 1 ]; then
+  # A check slot this relaunch cannot claim is decided BEFORE any wiring is
+  # retired. Retiring first and discovering the conflict at the arm below would
+  # leave a still-running worker with its hook files already deleted and no
+  # replacement, so the launch that cannot finish is refused while everything
+  # the previous incarnation depends on is still in place.
+  if [ "$HARNESS" = claude-local ] \
+     && { [ -e "$STATE_REAL/$ID.check.sh" ] || [ -L "$STATE_REAL/$ID.check.sh" ]; } \
+     && ! { [ "$RELAUNCH_PRIOR_HARNESS" = claude-local ] \
+            && local_model_check_slot_is_ours "$STATE_REAL" "$ID"; }; then
+    echo "error: could not arm the local-model watcher check for $ID" >&2
+    exit 1
+  fi
   # Retire the previous incarnation's per-task harness wiring before arming the
   # new one. Without this, a harness switch would leave the old adapter's hook
   # files and turn-end token registry entries behind, and even a same-harness

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1042,9 +1042,12 @@ remove_pr_poll_artifacts() {
   validate_pr_poll_cleanup "$state_dir" "$id" || return 1
   fm_pr_poll_retirement_recover_one "$state_dir" "$id" "$SCRIPT_DIR/fm-pr-poll.sh" || return 1
   fm_pr_poll_merge_notified_remove "$state_dir" "$id" || return 1
-  rm -f "$state_dir/$id.check.sh" "$state_dir/$id.pr-poll" \
-    "$state_dir/$id.pr-poll-registration" "$state_dir/$id.pr-poll-retirement" \
-    "$state_dir/$id.check-trust" || return 1
+  if [ -e "$state_dir/$id.check.sh" ] || [ -L "$state_dir/$id.check.sh" ] \
+     || [ -e "$state_dir/$id.check-trust" ] || [ -L "$state_dir/$id.check-trust" ]; then
+    FM_STATE_OVERRIDE="$state_dir" "$SCRIPT_DIR/fm-check-unregister.sh" "$id" >/dev/null || return 1
+  fi
+  rm -f "$state_dir/$id.pr-poll" "$state_dir/$id.pr-poll-registration" \
+    "$state_dir/$id.pr-poll-retirement" || return 1
 }
 
 # Resolve the PR number for a worktree branch via gh-axi. Echoes the number on a

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -181,6 +181,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/harness-adapters/references/harness/claude-local.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/harness-adapters/references/harness/codex.md",
       "audience": "agent-runtime"
     },

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1484,7 +1484,7 @@ Two concurrent clients against one local model starve each other.
 
 ### What a supervised run established, and what it did not
 
-One supervised scout task was launched through `bin/fm-spawn.sh`'s raw-launch escape hatch on the tmux backend against this endpoint.
+One supervised scout task exercised the `claude` CLI through an `fm-spawn.sh` launch on the tmux backend against this endpoint.
 
 Established:
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1398,3 +1398,111 @@ The live probe loads the tracked watcher extension through Pi's real resource lo
 It proved that a follow-up the extension sends while main is streaming raises no `before_agent_start` at queue time or when the run reaches it, joins the run as a user `message_start` carrying the exact wake text in its own model turn, and is followed by a verified successor and delivery of the next close; a follow-up sent to the idle main raises `before_agent_start` with the exact text before its user `message_start`.
 The portable regression drives the same shape with a fake main that never raises `before_agent_start` while streaming, then proves a replacement replays only the follow-up Pi had not consumed and that an exhausted restoration delivers its typed failure without launching a further arm.
 A second regression holds a branch settlement open while the verified successor exits with a failure, and proves that failure takes the ordinary bounded retry once the delivery settles rather than leaving the generation with no watcher and no retry.
+
+## claude-local
+
+Verified 2026-09-01 against LM Studio serving `qwen3-coder-next-mlx` (MLX 4-bit, `lmstudio-community`) at `http://127.0.0.1:1234` on an Apple M1 Max, 64 GB, with Claude Code 2.1.x.
+`claude-local` is the `claude` CLI pinned to that endpoint, so this record covers only what the LOCAL endpoint changes; every other claude fact stays in the claude evidence above.
+
+### Endpoint catalog and the model-identity finding
+
+The catalog reports per-model load state and the loaded window:
+
+```
+$ curl -s http://127.0.0.1:1234/api/v0/models
+{"data":[{"id":"qwen3-coder-next-mlx","type":"llm","arch":"qwen3_next","compatibility_type":"mlx",
+  "quantization":"4bit","state":"loaded","max_context_length":262144,"loaded_context_length":65536,
+  "capabilities":["tool_use"]},
+ {"id":"text-embedding-nomic-embed-text-v1.5","type":"embeddings","state":"not-loaded","max_context_length":2048}]}
+```
+
+The request path does NOT honor the model id it is given, which is why the catalog is the only identity source:
+
+```
+$ curl -s -w 'HTTP %{http_code}\n' http://127.0.0.1:1234/v1/messages \
+    -H 'content-type: application/json' -H 'anthropic-version: 2023-06-01' -H 'x-api-key: lmstudio' \
+    -d '{"model":"definitely-not-loaded-xyz","max_tokens":8,"messages":[{"role":"user","content":"hi"}]}'
+HTTP 200
+{"id":"msg_al35oo54q6i1us46zilr5q","type":"message","role":"assistant",
+ "content":[{"type":"text","text":"Hello! How can I help you"}],
+ "model":"qwen3-coder-next-mlx","stop_reason":"max_tokens",
+ "usage":{"input_tokens":9,"output_tokens":7,"cache_read_input_tokens":0}}
+```
+
+A model that is not loaded is answered by the one that is, and the response names the loaded model rather than the requested one.
+No request can therefore report an eviction.
+
+Token counting is absent, so no exact count is available without spending a full prefill:
+
+```
+$ curl -s -w 'HTTP %{http_code}\n' http://127.0.0.1:1234/v1/messages/count_tokens ...
+HTTP 200
+{"error":"Unexpected endpoint or method. (POST /v1/messages/count_tokens)"}
+```
+
+An unreachable endpoint is distinct and fast: `curl` exit 7, `HTTP 000`.
+
+### The context boundary
+
+The dominant consumer of this window is the harness, not the task.
+Captured from LM Studio's own request log, one `claude -p` turn carrying a one-sentence prompt sent Claude Code's system prompt and full tool schema:
+
+```
+$ wc -c < lmstudio-request-log
+253572          # ~63k tokens at bytes/4, before any task content
+```
+
+Against the 65,536-token window the model had loaded, that baseline is ~96% of the window.
+The enforced boundary is therefore the HEADROOM above it, which `bin/fm-local-model.sh` computes and refuses against:
+
+```
+$ bin/fm-local-model.sh probe
+ok: http://127.0.0.1:1234 is answering
+$ bin/fm-local-model.sh model-state qwen3-coder-next-mlx
+loaded
+$ bin/fm-local-model.sh context-budget qwen3-coder-next-mlx
+65536
+$ bin/fm-local-model.sh headroom qwen3-coder-next-mlx
+5536
+```
+
+`CLAUDE_CODE_MAX_CONTEXT_TOKENS` is the control Claude Code itself names for an unrecognized model's real window; without it Claude Code assumes 200k and auto-compacts against a window the server does not have.
+Setting it also silenced that warning.
+
+### Latency, and the reliability limit
+
+| Exchange | Wall clock |
+|---|---|
+| Raw Anthropic endpoint, 14 input tokens, warm | 0.35s |
+| Raw OpenAI endpoint, same prompt, cold | 17.7s |
+| `claude -p`, trivial single turn | 153s |
+| `claude -p`, two turns with one tool call | 309s |
+| `claude -p`, trivial single turn, later attempt | did not complete in 20 minutes |
+
+Per-turn latency is minutes and is NOT stable.
+Two concurrent clients against one local model starve each other.
+
+### What a supervised run established, and what it did not
+
+One supervised scout task was launched through `bin/fm-spawn.sh`'s raw-launch escape hatch on the tmux backend against this endpoint.
+
+Established:
+
+- Tool use survives the Anthropic-compatible endpoint end to end: a forced `Read` returned the correct sentinel from a file the model had never seen.
+- The semantic busy source works unchanged. claude's own hooks fired on the local runtime, producing a real record rather than a guess:
+  `v1 gen=g1788235566.4619.24610 seq=2 state=busy source=claude-hook event=user-prompt-submit ts=1788235647`
+- A trust dialog appears on each fresh worktree, and its default selection is `No, exit`; bare Enter exits the agent, so acceptance needs Down then Enter.
+- Interrupt is delivered through the control plane, reporting `cancel=unconfirmed`, matching claude's documented no-hook interrupt. It did not clear a pending request-retry timer.
+- A stalled worker is silent: Claude Code sat in a multi-minute retry backoff ("will retry in 4m 34s") with no request reaching the server, which is why the endpoint check exists.
+
+UNESTABLISHED, recorded as such rather than assumed:
+
+- Turn-end signal. No supervised turn ever completed, so neither the `Stop` hook nor the turn-ended marker was observed firing here.
+- Exit. `bin/fm-control.sh exit` did not return within two minutes.
+- Resume and skill invocation. Not exercised.
+- Whether LM Studio JIT-loads an evicted model on request.
+
+**Conclusion: `claude-local` is not trustworthy for unattended work.**
+No supervised turn was observed completing, and the harness baseline leaves 5,536 usable tokens on the reference configuration.
+It ships opt-in, short-context, crewmate/scout only, and refused for no-mistakes shipping.
+Refresh this record by re-running `tests/fm-local-model.test.sh` and `tests/fm-claude-local-harness.test.sh` for the logic, and the probes above against a live endpoint for the version-scoped facts.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -1118,6 +1118,7 @@ test_crew_dispatch_validation() {
   done <<'ROWS'
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
+matched claude-local rule is accepted^{"rules":[{"when":"short local task","use":{"harness":"claude-local","model":"local-coder"}}]}^empty^
 unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh

--- a/tests/fm-claude-local-harness.test.sh
+++ b/tests/fm-claude-local-harness.test.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# tests/fm-claude-local-harness.test.sh - the portable regression for the
+# claude-local adapter's OPT-IN and SCOPE gates.
+#
+# claude-local is the verified `claude` CLI pinned to a locally served model. It
+# is deliberately NOT a second harness implementation: it reuses claude's binary,
+# composer shape, trust dialog, and lifecycle hooks, and reaches the verified
+# tables through the `claude*` prefix rule that bin/fm-control-lib.sh already
+# owns. What is new, and what this suite pins, is the set of refusals - because
+# every failure they prevent is SILENT. A task that reaches this runtime by
+# accident is not visibly broken, it is just slow and worse, which is exactly
+# the class of failure a gate has to catch instead of a reviewer.
+#
+# The load-bearing contracts:
+#   1. Opt-in only: a home-wide default (config/crew-harness) must NEVER select
+#      it, while an explicit per-spawn argument may.
+#   2. It is a crewmate/scout adapter: a secondmate launch is refused, in the
+#      spawn AND in the control plane that decides a relaunch before stopping
+#      the running agent.
+#   3. It is never the no-mistakes pipeline.
+#   4. The model id is the endpoint's own catalog id and is never guessed.
+#   5. It inherits, rather than re-implements, claude's verified control family
+#      and semantic busy source.
+set -u
+
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+# shellcheck source=bin/fm-control-lib.sh
+. "$ROOT/bin/fm-control-lib.sh"
+# shellcheck source=bin/fm-busy-lib.sh
+. "$ROOT/bin/fm-busy-lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-claude-local-harness)
+
+# A world whose fm-local-model endpoint is a real file:// catalog, so the spawn
+# gates run against a reachable endpoint rather than being skipped. The suite is
+# about the REFUSALS, so the endpoint is deliberately healthy: a gate that only
+# fires because the endpoint is down would prove nothing.
+make_world() {  # <name> -> echoes "<home> <fakebin> <endpoint> <case-dir>"
+  local name=$1 case_dir home fakebin dir
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  dir="$case_dir/endpoint/api/v0"
+  mkdir -p "$dir"
+  cat > "$dir/models" <<'EOF'
+{"object":"list","data":[
+ {"id":"local-coder","object":"model","type":"llm","state":"loaded","max_context_length":262144,"loaded_context_length":131072}
+]}
+EOF
+  printf '%s %s file://%s %s\n' "$home" "$fakebin" "$case_dir/endpoint" "$case_dir"
+}
+
+# run_spawn <home> <fakebin> <endpoint> [args...]
+# Captures combined output into the file named by RUN_OUT and RETURNS the
+# spawn's exit status. It deliberately does not print to stdout: a caller that
+# wrote `out=$(run_spawn ...)` would run this in a subshell, where an exit
+# status assigned to a variable never reaches the caller and every refusal
+# silently reads as success.
+# FM_LOCAL_MODEL_HARNESS_BASELINE is pinned low so the headroom check is
+# satisfied and the gate under test is the one that fires.
+RUN_OUT=
+run_spawn() {
+  local home=$1 fakebin=$2 endpoint=$3
+  shift 3
+  RUN_OUT="$TMP_ROOT/spawn-out.$$"
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_LOCAL_MODEL_ENDPOINT="$endpoint" FM_LOCAL_MODEL_HARNESS_BASELINE=1000 \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$@" > "$RUN_OUT" 2>&1
+}
+
+# The gate that matters most: a home-wide crew default must not be able to put
+# every crewmate on the captain's laptop. The contrast is the assertion - the
+# SAME home, the SAME task, refused when the harness comes from config and
+# accepted past that gate when it is named explicitly.
+test_home_default_cannot_select_it() {
+  local home fakebin endpoint case_dir id out
+  read -r home fakebin endpoint case_dir <<<"$(make_world default)"
+  id="cl-default-x1"
+  fm_test_spawn_brief "$home" "$id" "tiny brief"
+  printf 'claude-local\n' > "$home/config/crew-harness"
+
+  run_spawn "$home" "$fakebin" "$endpoint" "$id" "$home/projects" --scout \
+    && fail "config/crew-harness was allowed to select claude-local"
+  out=$(cat "$RUN_OUT")
+  case "$out" in
+    *"opt-in only"*) : ;;
+    *) fail "the home-default refusal did not name the opt-in boundary: $out" ;;
+  esac
+  case "$out" in
+    *crew-harness*) : ;;
+    *) fail "the refusal did not name the default that tried to select it: $out" ;;
+  esac
+
+  # Same home, same config, same task - but named explicitly. This must get PAST
+  # the opt-in gate. The project path is deliberately one that does not exist, so
+  # the spawn stops at the next check instead of running a real launch: the
+  # assertion is only that the opt-in refusal is gone, and the run still has to
+  # end for the suite to finish.
+  run_spawn "$home" "$fakebin" "$endpoint" "$id" "$case_dir/no-such-project" --scout \
+    --harness claude-local --model local-coder || true
+  out=$(cat "$RUN_OUT")
+  case "$out" in
+    *"opt-in only"*) fail "an explicit per-spawn harness was still refused as a default: $out" ;;
+  esac
+
+  pass "a home-wide default cannot select claude-local, while an explicit per-spawn harness can"
+}
+
+# A secondmate is a firstmate instance needing a primary supervision protocol.
+# claude-local has no primary evidence, so both the spawn and the control plane
+# refuse it - the control plane matters because it decides a RELAUNCH before the
+# running agent has been stopped.
+test_secondmate_is_refused_in_both_planes() {
+  local home fakebin endpoint case_dir id out
+  read -r home fakebin endpoint case_dir <<<"$(make_world secondmate)"
+  id="cl-secondmate-x1"
+  fm_test_spawn_brief "$home" "$id" "charter"
+
+  run_spawn "$home" "$fakebin" "$endpoint" "$id" claude-local --secondmate --model local-coder \
+    && fail "claude-local was accepted as a secondmate harness"
+  out=$(cat "$RUN_OUT")
+  case "$out" in
+    *"crewmate/scout adapter only"*) : ;;
+    *) fail "the secondmate refusal did not explain the boundary: $out" ;;
+  esac
+
+  fm_control_harness_supports_kind claude-local secondmate \
+    && fail "the control plane let claude-local claim a secondmate relaunch"
+  fm_control_harness_supports_kind claude-local ship \
+    || fail "the control plane must still allow claude-local for ordinary work"
+
+  pass "claude-local is refused as a secondmate by both the spawn and the control plane"
+}
+
+# no-mistakes is firstmate's highest-rigor route and runs long, repeated,
+# large-context review and fix turns. The other two delivery modes are not
+# blocked, so the assertion is that the refusal is specific to no-mistakes
+# rather than a blanket ban on shipping.
+test_no_mistakes_mode_is_refused() {
+  local home fakebin endpoint case_dir id out
+  read -r home fakebin endpoint case_dir <<<"$(make_world nomistakes)"
+  id="cl-nm-x1"
+  fm_test_spawn_brief "$home" "$id" "tiny brief"
+
+  run_spawn "$home" "$fakebin" "$endpoint" "$id" "$home/projects" \
+    --mode no-mistakes --yolo off --harness claude-local --model local-coder \
+    && fail "claude-local was accepted for no-mistakes shipping work"
+  out=$(cat "$RUN_OUT")
+  case "$out" in
+    *"not verified for no-mistakes"*) : ;;
+    *) fail "the no-mistakes refusal did not name the boundary: $out" ;;
+  esac
+
+  run_spawn "$home" "$fakebin" "$endpoint" "$id" "$case_dir/no-such-project" \
+    --mode direct-PR --yolo off --harness claude-local --model local-coder || true
+  out=$(cat "$RUN_OUT")
+  case "$out" in
+    *"not verified for no-mistakes"*) fail "direct-PR was wrongly caught by the no-mistakes gate: $out" ;;
+  esac
+
+  pass "claude-local is refused for no-mistakes work and only for it"
+}
+
+# The endpoint serves whatever model is loaded regardless of the id a request
+# names (verified against LM Studio 2026-09-01), so an omitted model id cannot
+# be quietly filled in from a default - it has to be refused.
+test_missing_model_is_refused() {
+  local home fakebin endpoint case_dir id out
+  read -r home fakebin endpoint case_dir <<<"$(make_world model)"
+  id="cl-model-x1"
+  fm_test_spawn_brief "$home" "$id" "tiny brief"
+
+  run_spawn "$home" "$fakebin" "$endpoint" "$id" "$home/projects" --scout --harness claude-local \
+    && fail "claude-local launched without an explicit model id"
+  out=$(cat "$RUN_OUT")
+  case "$out" in
+    *"requires an explicit --model"*) : ;;
+    *) fail "the missing-model refusal was not actionable: $out" ;;
+  esac
+  pass "claude-local refuses to guess which local model it is talking to"
+}
+
+# The whole design rests on claude-local INHERITING claude's verified tables
+# rather than carrying its own copy of them. If either of these stops holding,
+# the adapter has silently grown a second implementation of a shape the shared
+# owner is supposed to own.
+test_it_inherits_claudes_verified_tables() {
+  local family sources
+  family=$(fm_control_harness_family claude-local) \
+    || fail "claude-local resolved to no control family at all"
+  [ "$family" = claude ] \
+    || fail "claude-local must resolve to the claude control family, got '$family'"
+
+  fm_control_harness_supported claude-local \
+    || fail "claude-local must be a supported control adapter"
+
+  sources=$(fm_busy_sources_for_harness claude-local)
+  case "$sources" in
+    *claude-hook*) : ;;
+    *) fail "claude-local must trust claude's semantic busy source, got '$sources'" ;;
+  esac
+  # And it must not have been handed a source that belongs to another adapter.
+  case "$sources" in
+    *opencode-plugin*|*pi-ext*) fail "claude-local trusts a foreign adapter's source: $sources" ;;
+  esac
+
+  pass "claude-local inherits claude's control family and semantic busy source"
+}
+
+test_home_default_cannot_select_it
+test_secondmate_is_refused_in_both_planes
+test_no_mistakes_mode_is_refused
+test_missing_model_is_refused
+test_it_inherits_claudes_verified_tables

--- a/tests/fm-claude-local-harness.test.sh
+++ b/tests/fm-claude-local-harness.test.sh
@@ -411,13 +411,21 @@ test_eviction_check_is_gated_on_worker_liveness() {
 
 # The watcher is provisional until the dispatch is committed. A fresh dispatch
 # whose backlog commit fails rolls its record back and tells the operator to
-# re-run the spawn, so the watcher must go with the record: left behind, it
-# keeps running against a task nothing owns, and the prescribed re-run is
-# refused because the slot is still taken.
-test_fresh_dispatch_rollback_retires_the_eviction_check() {
-  local home fakebin endpoint case_dir project worktree id out status real_tasks_axi
-  read -r home fakebin endpoint case_dir <<<"$(make_world rollback)"
-  id="cl-rollback-x1"
+# close out the endpoint by hand and re-run the spawn, so the watcher must go
+# with the record: left behind, it keeps running against a task nothing owns,
+# and the prescribed re-run is refused because the slot is still taken. That
+# holds whether the rollback itself succeeds or is left incomplete by a busy
+# record it could not retire: the record is removed first either way, so no
+# live worker is meant to survive this path.
+# run_rollback_dispatch <variant> where <variant> is clean or busy-retire-fails.
+# Sets ROLLBACK_HOME and ROLLBACK_ID; captures the spawn output in RUN_OUT and
+# returns the spawn's exit status.
+ROLLBACK_HOME=
+ROLLBACK_ID=
+run_rollback_dispatch() {
+  local variant=$1 home fakebin endpoint case_dir project worktree id real_tasks_axi real_rm
+  read -r home fakebin endpoint case_dir <<<"$(make_world "rollback-$variant")"
+  id="cl-rollback-$variant"
   project="$case_dir/project"
   worktree="$case_dir/worktree"
   fm_test_spawn_brief "$home" "$id" "tiny brief"
@@ -435,22 +443,58 @@ fi
 exec "$real_tasks_axi" "\$@"
 SH
   chmod +x "$fakebin/tasks-axi"
-
-  status=0
+  if [ "$variant" = busy-retire-fails ]; then
+    real_rm=$(command -v rm)
+    cat > "$fakebin/rm" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  case "\$arg" in */$id.busy-gen) exit 1 ;; esac
+done
+exec "$real_rm" "\$@"
+SH
+    chmod +x "$fakebin/rm"
+  fi
+  ROLLBACK_HOME=$home
+  ROLLBACK_ID=$id
   FM_FAKE_PANE_PATH="$worktree" run_spawn "$home" "$fakebin" "$endpoint" \
-    "$id" "$project" --scout --harness claude-local --model local-coder || status=$?
+    "$id" "$project" --scout --harness claude-local --model local-coder
+}
+
+assert_rollback_retired_the_watcher() {  # <status> <expected-message-fragment>
+  local out
   out=$(cat "$RUN_OUT")
-  [ "$status" -ne 0 ] || fail "a dispatch whose backlog commit failed reported success: $out"
+  [ "$1" -ne 0 ] || fail "a dispatch whose backlog commit failed reported success: $out"
   case "$out" in
     *"could not be moved to In flight"*) : ;;
     *) fail "the fixture did not reach the backlog-commit rollback: $out" ;;
   esac
-  [ ! -e "$home/state/$id.meta" ] \
+  case "$out" in
+    *"$2"*) : ;;
+    *) fail "the fixture did not reach the expected rollback outcome ($2): $out" ;;
+  esac
+  [ ! -e "$ROLLBACK_HOME/state/$ROLLBACK_ID.meta" ] \
     || fail "the failed dispatch left its task record behind"
-  [ ! -e "$home/state/$id.check.sh" ] && [ ! -e "$home/state/$id.check-trust" ] \
+  [ ! -e "$ROLLBACK_HOME/state/$ROLLBACK_ID.check.sh" ] \
+    && [ ! -e "$ROLLBACK_HOME/state/$ROLLBACK_ID.check-trust" ] \
     || fail "the failed dispatch left its eviction watcher registered with no record behind it"
+}
 
+test_fresh_dispatch_rollback_retires_the_eviction_check() {
+  local status
+  status=0
+  run_rollback_dispatch clean || status=$?
+  assert_rollback_retired_the_watcher "$status" "its record was removed"
   pass "a fresh dispatch whose backlog commit fails retires its eviction watcher with the record"
+}
+
+test_incomplete_dispatch_rollback_still_retires_the_eviction_check() {
+  local status
+  status=0
+  run_rollback_dispatch busy-retire-fails || status=$?
+  assert_rollback_retired_the_watcher "$status" "failed-dispatch cleanup is incomplete"
+  [ -e "$ROLLBACK_HOME/state/$ROLLBACK_ID.busy-gen" ] \
+    || fail "fixture: the busy generation was retired, so the incomplete-rollback path was not exercised"
+  pass "a fresh dispatch whose rollback is left incomplete still retires its eviction watcher"
 }
 
 test_home_default_cannot_select_it
@@ -463,3 +507,4 @@ test_spawn_arms_an_executable_eviction_check
 test_raw_claude_local_command_is_refused
 test_eviction_check_is_gated_on_worker_liveness
 test_fresh_dispatch_rollback_retires_the_eviction_check
+test_incomplete_dispatch_rollback_still_retires_the_eviction_check

--- a/tests/fm-claude-local-harness.test.sh
+++ b/tests/fm-claude-local-harness.test.sh
@@ -400,6 +400,52 @@ test_dispatch_rule_and_explicit_harness_can_select_it() {
   pass "matched dispatch rules and explicit harnesses can select claude-local"
 }
 
+# claude-local launches the same `claude` binary as the claude adapter, so it
+# inherits that adapter's fleet obligations too. The feedback-draft suppressors
+# are the ones that bite here: an unattended crewmate must not be able to offer
+# or create a Claude feedback draft. The launch command typed into the pane is
+# the generated interface this asserts, alongside the endpoint pin that makes it
+# claude-local at all - so a template that dropped either is caught here.
+test_launch_carries_the_bounded_local_context() {
+  local home fakebin endpoint case_dir project worktree id launch_log launch status
+  read -r home fakebin endpoint case_dir <<<"$(make_world launch-template)"
+  id="cl-launch-x1"
+  project="$case_dir/project"
+  worktree="$case_dir/worktree"
+  launch_log="$case_dir/launch.log"
+  fm_test_spawn_brief "$home" "$id" "tiny brief"
+  fm_git_worktree "$project" "$worktree" "fm/$id"
+
+  status=0
+  FM_FAKE_PANE_PATH="$worktree" FM_FAKE_LAUNCH_LOG="$launch_log" \
+    run_spawn "$home" "$fakebin" "$endpoint" "$id" "$project" \
+    --scout --harness claude-local --model local-coder || status=$?
+  [ "$status" -eq 0 ] || fail "the claude-local spawn did not launch: $(cat "$RUN_OUT")"
+  launch=$(cat "$launch_log")
+
+  case "$launch" in
+    *"CLAUDE_CODE_SEND_FEEDBACK=0"*) : ;;
+    *) fail "the claude-local launch did not suppress feedback sending: $launch" ;;
+  esac
+  case "$launch" in
+    *"--settings '{\"feedbackDrafts\":\"off\"}'"*) : ;;
+    *) fail "the claude-local launch did not turn feedback drafts off: $launch" ;;
+  esac
+  # The endpoint is quoted and the temp path may be symlink-resolved, so this
+  # pins the base URL to the fixture's own catalog directory rather than to a
+  # byte-identical path.
+  case "$launch" in
+    *"ANTHROPIC_BASE_URL='file://"*"/launch-template/endpoint'"*) : ;;
+    *) fail "the claude-local launch was not pinned to the local endpoint: $launch" ;;
+  esac
+  case "$launch" in
+    *"CLAUDE_CODE_MAX_CONTEXT_TOKENS="*) : ;;
+    *) fail "the claude-local launch did not bound the context window: $launch" ;;
+  esac
+
+  pass "the claude-local launch suppresses feedback drafts and stays pinned to the local endpoint"
+}
+
 # A tmux and ps pair that answers the endpoint's agent-state classifier with
 # exactly one verdict per FM_FAKE_AGENT value: `alive` shows the window with a
 # claude foreground process, `missing` reports the session gone, and
@@ -601,6 +647,7 @@ test_spawn_arms_an_executable_eviction_check
 test_raw_claude_local_commands_are_refused
 test_dispatch_profile_default_cannot_select_it
 test_dispatch_rule_and_explicit_harness_can_select_it
+test_launch_carries_the_bounded_local_context
 test_eviction_check_is_gated_on_worker_liveness
 test_fresh_dispatch_rollback_retires_the_eviction_check
 test_incomplete_dispatch_rollback_still_retires_the_eviction_check

--- a/tests/fm-claude-local-harness.test.sh
+++ b/tests/fm-claude-local-harness.test.sh
@@ -261,8 +261,9 @@ test_spawn_arms_an_executable_eviction_check() {
   assert_present "$home/state/$id.check-trust" "claude-local spawn did not bind its watcher check"
 
   set_model_state "$case_dir" not-loaded 0
-  out=$("$home/state/$id.check.sh")
-  status=$?
+  status=0
+  run_check "$home/state/$id.check.sh" alive "$id" || status=$?
+  out=$(cat "$CHECK_OUT")
   [ "$status" -eq 0 ] || fail "the registered watcher check did not run"
   case "$out" in
     blocked:*"no longer loaded"*) : ;;
@@ -274,6 +275,140 @@ test_spawn_arms_an_executable_eviction_check() {
   pass "a claude-local spawn registers an executable watcher check that reports eviction"
 }
 
+
+# The bounded launch context lives in the canonical template. A raw launch
+# command is the unverified-adapter escape hatch and would run whatever it
+# names verbatim, so a raw command whose executable is called claude-local
+# would pass the local-model gates and then launch with no endpoint pin, no
+# model pin, and no context bound. It is refused, and the refusal names the
+# form that does carry the bounds.
+test_raw_claude_local_command_is_refused() {
+  local home fakebin endpoint case_dir id out
+  read -r home fakebin endpoint case_dir <<<"$(make_world raw)"
+  id="cl-raw-x1"
+  fm_test_spawn_brief "$home" "$id" "tiny brief"
+
+  run_spawn "$home" "$fakebin" "$endpoint" "$id" "$home/projects" \
+    "claude-local --model local-coder" --scout \
+    && fail "a raw claude-local launch command was accepted"
+  out=$(cat "$RUN_OUT")
+  case "$out" in
+    *"bypasses the bounded local-model launch context"*) : ;;
+    *) fail "the raw-command refusal did not name the bound it protects: $out" ;;
+  esac
+  case "$out" in
+    *"--harness claude-local"*) : ;;
+    *) fail "the raw-command refusal did not name the harness form to use instead: $out" ;;
+  esac
+  [ ! -e "$home/state/$id.meta" ] && [ ! -e "$home/state/$id.check.sh" ] \
+    || fail "a refused raw claude-local command left task state behind"
+
+  pass "a raw launch command named claude-local is refused in favour of the harness form"
+}
+
+# A tmux and ps pair that answers the endpoint's agent-state classifier with
+# exactly one verdict per FM_FAKE_AGENT value: `alive` shows the window with a
+# claude foreground process, `missing` reports the session gone, and
+# `unreadable` fails the inventory with an unclassifiable error.
+make_agent_state_fakebin() {  # <dir> -> echoes the fakebin path
+  local fakebin
+  fakebin=$(fm_fakebin "$1")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  list-windows)
+    case "${FM_FAKE_AGENT:-}" in
+      alive) printf 'fm-%s\n' "$FM_FAKE_TASK"; exit 0 ;;
+      missing) printf "can't find session: firstmate\n" >&2; exit 1 ;;
+      *) printf 'inventory unavailable\n' >&2; exit 1 ;;
+    esac
+    ;;
+  display-message)
+    case "$*" in
+      *pane_tty*) printf '/dev/ttyfake\n' ;;
+      *pane_current_command*) printf 'claude\n' ;;
+      *) printf 'firstmate\n' ;;
+    esac
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" -t "*) printf '1 1 1 claude\n' ;;
+  *" -p "*) printf 'claude\n' ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux" "$fakebin/ps"
+  printf '%s\n' "$fakebin"
+}
+
+# run_check <check> <agent-verdict> <id>
+# Runs the registered check with the endpoint answering <agent-verdict>.
+# Captures its stdout into the file named by CHECK_OUT and RETURNS the check's
+# exit status, for the same reason run_spawn does not print.
+CHECK_OUT=
+run_check() {
+  local check=$1 verdict=$2 id=$3 agentbin
+  agentbin=$(make_agent_state_fakebin "$TMP_ROOT/agent-$verdict-$id")
+  CHECK_OUT="$TMP_ROOT/check-out.$$"
+  PATH="$agentbin:$PATH" FM_FAKE_AGENT="$verdict" FM_FAKE_TASK="$id" "$check" > "$CHECK_OUT"
+}
+
+# The watcher exists to make a stall under a LIVE worker loud. An ordinary
+# idle unload after the worker has finished is not a stall, and wake() has no
+# dedup, so that case must be silent. The asymmetry is deliberate: silence
+# needs a CONFIDENT dead verdict. An endpoint that cannot be read, combined
+# with an evicted model, is exactly when a silent stall is most likely, so the
+# unknown verdict stays loud. All three are asserted because a check that was
+# disabled outright would pass the silence half alone.
+test_eviction_check_is_gated_on_worker_liveness() {
+  local home fakebin endpoint case_dir project worktree id check out status
+  read -r home fakebin endpoint case_dir <<<"$(make_world liveness)"
+  id="cl-live-x1"
+  project="$case_dir/project"
+  worktree="$case_dir/worktree"
+  fm_test_spawn_brief "$home" "$id" "tiny brief"
+  fm_git_worktree "$project" "$worktree" "fm/$id"
+  status=0
+  FM_FAKE_PANE_PATH="$worktree" run_spawn "$home" "$fakebin" "$endpoint" \
+    "$id" "$project" --scout --harness claude-local --model local-coder || status=$?
+  [ "$status" -eq 0 ] || fail "claude-local spawn did not arm its watcher check: $(cat "$RUN_OUT")"
+  check="$home/state/$id.check.sh"
+  set_model_state "$case_dir" not-loaded 0
+
+  run_check "$check" alive "$id" || fail "the check did not run against a live worker"
+  out=$(cat "$CHECK_OUT")
+  case "$out" in
+    blocked:*"no longer loaded"*) : ;;
+    *) fail "an evicted model under a live worker must stay loud, got: '$out'" ;;
+  esac
+  [ "$(printf '%s\n' "$out" | wc -l | tr -d ' ')" = 1 ] \
+    || fail "the live-worker alarm must be exactly one line"
+
+  run_check "$check" missing "$id" || fail "the check must exit cleanly for a confidently dead worker"
+  out=$(cat "$CHECK_OUT")
+  [ -z "$out" ] || fail "an idle unload after the worker is gone must be silent, got: '$out'"
+
+  run_check "$check" unreadable "$id" || fail "the check did not run against an unreadable endpoint"
+  out=$(cat "$CHECK_OUT")
+  case "$out" in
+    blocked:*"no longer loaded"*) : ;;
+    *) fail "an evicted model under an unreadable endpoint must stay loud, got: '$out'" ;;
+  esac
+
+  set_model_state "$case_dir" loaded 131072
+  run_check "$check" alive "$id" || fail "the check did not run against a loaded model"
+  out=$(cat "$CHECK_OUT")
+  [ -z "$out" ] || fail "a loaded model under a live worker must be silent, got: '$out'"
+
+  pass "the eviction check is silent only for a confidently dead worker and loud for alive and unknown"
+}
+
 test_home_default_cannot_select_it
 test_secondmate_is_refused_in_both_planes
 test_no_mistakes_mode_is_refused
@@ -281,3 +416,5 @@ test_missing_model_is_refused
 test_it_inherits_claudes_verified_tables
 test_it_uses_claudes_shared_busy_signature
 test_spawn_arms_an_executable_eviction_check
+test_raw_claude_local_command_is_refused
+test_eviction_check_is_gated_on_worker_liveness

--- a/tests/fm-claude-local-harness.test.sh
+++ b/tests/fm-claude-local-harness.test.sh
@@ -409,6 +409,50 @@ test_eviction_check_is_gated_on_worker_liveness() {
   pass "the eviction check is silent only for a confidently dead worker and loud for alive and unknown"
 }
 
+# The watcher is provisional until the dispatch is committed. A fresh dispatch
+# whose backlog commit fails rolls its record back and tells the operator to
+# re-run the spawn, so the watcher must go with the record: left behind, it
+# keeps running against a task nothing owns, and the prescribed re-run is
+# refused because the slot is still taken.
+test_fresh_dispatch_rollback_retires_the_eviction_check() {
+  local home fakebin endpoint case_dir project worktree id out status real_tasks_axi
+  read -r home fakebin endpoint case_dir <<<"$(make_world rollback)"
+  id="cl-rollback-x1"
+  project="$case_dir/project"
+  worktree="$case_dir/worktree"
+  fm_test_spawn_brief "$home" "$id" "tiny brief"
+  fm_git_worktree "$project" "$worktree" "fm/$id"
+  printf '%s\n' '# Backlog' '' '## In flight' '' '## Queued' '' '## Done' > "$home/data/backlog.md"
+  tasks-axi add "$id" "rollback fixture" --kind scout --file "$home/data/backlog.md" >/dev/null \
+    || fail "fixture: the backlog row could not be added"
+  real_tasks_axi=$(command -v tasks-axi)
+  cat > "$fakebin/tasks-axi" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = start ]; then
+  echo 'error: "start refused"' >&2
+  exit 1
+fi
+exec "$real_tasks_axi" "\$@"
+SH
+  chmod +x "$fakebin/tasks-axi"
+
+  status=0
+  FM_FAKE_PANE_PATH="$worktree" run_spawn "$home" "$fakebin" "$endpoint" \
+    "$id" "$project" --scout --harness claude-local --model local-coder || status=$?
+  out=$(cat "$RUN_OUT")
+  [ "$status" -ne 0 ] || fail "a dispatch whose backlog commit failed reported success: $out"
+  case "$out" in
+    *"could not be moved to In flight"*) : ;;
+    *) fail "the fixture did not reach the backlog-commit rollback: $out" ;;
+  esac
+  [ ! -e "$home/state/$id.meta" ] \
+    || fail "the failed dispatch left its task record behind"
+  [ ! -e "$home/state/$id.check.sh" ] && [ ! -e "$home/state/$id.check-trust" ] \
+    || fail "the failed dispatch left its eviction watcher registered with no record behind it"
+
+  pass "a fresh dispatch whose backlog commit fails retires its eviction watcher with the record"
+}
+
 test_home_default_cannot_select_it
 test_secondmate_is_refused_in_both_planes
 test_no_mistakes_mode_is_refused
@@ -418,3 +462,4 @@ test_it_uses_claudes_shared_busy_signature
 test_spawn_arms_an_executable_eviction_check
 test_raw_claude_local_command_is_refused
 test_eviction_check_is_gated_on_worker_liveness
+test_fresh_dispatch_rollback_retires_the_eviction_check

--- a/tests/fm-claude-local-harness.test.sh
+++ b/tests/fm-claude-local-harness.test.sh
@@ -30,6 +30,8 @@ set -u
 . "$ROOT/bin/fm-control-lib.sh"
 # shellcheck source=bin/fm-busy-lib.sh
 . "$ROOT/bin/fm-busy-lib.sh"
+# shellcheck source=bin/fm-composer-lib.sh
+. "$ROOT/bin/fm-composer-lib.sh"
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-claude-local-harness)
@@ -43,7 +45,7 @@ make_world() {  # <name> -> echoes "<home> <fakebin> <endpoint> <case-dir>"
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
-  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  fakebin=$(make_spawn_fakebin "$case_dir/fake" gh gh-axi)
   dir="$case_dir/endpoint/api/v0"
   mkdir -p "$dir"
   cat > "$dir/models" <<'EOF'
@@ -52,6 +54,15 @@ make_world() {  # <name> -> echoes "<home> <fakebin> <endpoint> <case-dir>"
 ]}
 EOF
   printf '%s %s file://%s %s\n' "$home" "$fakebin" "$case_dir/endpoint" "$case_dir"
+}
+
+set_model_state() {  # <case-dir> <state> <loaded-context-length>
+  local case_dir=$1 state=$2 ctx=$3
+  cat > "$case_dir/endpoint/api/v0/models" <<EOF
+{"object":"list","data":[
+ {"id":"local-coder","object":"model","type":"llm","state":"$state","max_context_length":262144,"loaded_context_length":$ctx}
+]}
+EOF
 }
 
 # run_spawn <home> <fakebin> <endpoint> [args...]
@@ -214,8 +225,59 @@ test_it_inherits_claudes_verified_tables() {
   pass "claude-local inherits claude's control family and semantic busy source"
 }
 
+test_it_uses_claudes_shared_busy_signature() {
+  local busy_tail idle_tail
+  busy_tail='working  esc to interrupt'
+  idle_tail='ready for the next instruction'
+
+  printf '%s' "$busy_tail" | fm_busy_lines_match claude \
+    || fail "claude did not classify its known busy tail as busy"
+  printf '%s' "$busy_tail" | fm_busy_lines_match claude-local \
+    || fail "claude-local did not classify claude's known busy tail as busy"
+  if printf '%s' "$idle_tail" | fm_busy_lines_match claude; then
+    fail "claude classified an idle tail as busy"
+  fi
+  if printf '%s' "$idle_tail" | fm_busy_lines_match claude-local; then
+    fail "claude-local classified an idle tail as busy"
+  fi
+
+  pass "claude and claude-local classify the same busy and idle tails identically"
+}
+
+test_spawn_arms_an_executable_eviction_check() {
+  local home fakebin endpoint case_dir project worktree id out status
+  read -r home fakebin endpoint case_dir <<<"$(make_world watcher)"
+  id="cl-watcher-x1"
+  project="$case_dir/project"
+  worktree="$case_dir/worktree"
+  fm_test_spawn_brief "$home" "$id" "tiny brief"
+  fm_git_worktree "$project" "$worktree" "fm/$id"
+
+  status=0
+  FM_FAKE_PANE_PATH="$worktree" run_spawn "$home" "$fakebin" "$endpoint" \
+    "$id" "$project" --scout --harness claude-local --model local-coder || status=$?
+  [ "$status" -eq 0 ] || fail "claude-local spawn did not arm its watcher check: $(cat "$RUN_OUT")"
+  assert_present "$home/state/$id.check.sh" "claude-local spawn did not register a watcher check"
+  assert_present "$home/state/$id.check-trust" "claude-local spawn did not bind its watcher check"
+
+  set_model_state "$case_dir" not-loaded 0
+  out=$("$home/state/$id.check.sh")
+  status=$?
+  [ "$status" -eq 0 ] || fail "the registered watcher check did not run"
+  case "$out" in
+    blocked:*"no longer loaded"*) : ;;
+    *) fail "the registered watcher check did not report eviction: '$out'" ;;
+  esac
+  [ "$(printf '%s\n' "$out" | wc -l | tr -d ' ')" = 1 ] \
+    || fail "the registered watcher check must print exactly one wake line"
+
+  pass "a claude-local spawn registers an executable watcher check that reports eviction"
+}
+
 test_home_default_cannot_select_it
 test_secondmate_is_refused_in_both_planes
 test_no_mistakes_mode_is_refused
 test_missing_model_is_refused
 test_it_inherits_claudes_verified_tables
+test_it_uses_claudes_shared_busy_signature
+test_spawn_arms_an_executable_eviction_check

--- a/tests/fm-claude-local-harness.test.sh
+++ b/tests/fm-claude-local-harness.test.sh
@@ -309,6 +309,12 @@ test_raw_claude_local_commands_are_refused() {
     "cl-raw-bare-x1" "claude-local --model local-coder"
   assert_raw_claude_local_command_is_refused "$home" "$fakebin" "$endpoint" \
     "cl-raw-env-x1" "env -i LOCAL=1 claude-local --model local-coder"
+  fm_test_spawn_brief "$home" "cl-raw-env-delimiter-x1" "tiny brief"
+  assert_raw_claude_local_command_is_refused "$home" "$fakebin" "$endpoint" \
+    "cl-raw-env-delimiter-x1" "env -- LOCAL=1 claude-local --model local-coder"
+  fm_test_spawn_brief "$home" "cl-raw-env-split-x1" "tiny brief"
+  assert_raw_claude_local_command_is_refused "$home" "$fakebin" "$endpoint" \
+    "cl-raw-env-split-x1" "env -S 'claude-local --model local-coder'"
   assert_raw_claude_local_command_is_refused "$home" "$fakebin" "$endpoint" \
     "cl-raw-command-x1" "command claude-local --model local-coder"
 
@@ -325,6 +331,64 @@ test_raw_claude_local_commands_are_refused() {
     || fail "an ordinary raw env launch did not publish its task record"
 
   pass "bare, env, and command raw claude-local launches are refused without changing ordinary raw launches"
+}
+
+test_dispatch_profile_default_cannot_select_it() {
+  local home fakebin endpoint case_dir id project worktree out
+  read -r home fakebin endpoint case_dir <<<"$(make_world dispatch-default)"
+  id="cl-dispatch-default-x1"
+  project="$case_dir/project"
+  worktree="$case_dir/worktree"
+  fm_test_spawn_brief "$home" "$id" "tiny brief"
+  fm_git_worktree "$project" "$worktree" "fm/$id"
+  printf '%s\n' '{"default":{"harness":"claude-local","model":"local-coder"}}' \
+    > "$home/config/crew-dispatch.json"
+
+  FM_FAKE_PANE_PATH="$worktree" run_spawn "$home" "$fakebin" "$endpoint" "$id" "$project" \
+    claude-local --scout --model local-coder \
+    && fail "a dispatch default was allowed to select claude-local"
+  out=$(cat "$RUN_OUT")
+  case "$out" in
+    *"config/crew-dispatch.json default cannot select claude-local"*) : ;;
+    *) fail "the dispatch-default refusal did not name its config boundary: $out" ;;
+  esac
+  case "$out" in
+    *"matched rule profile"*"--harness claude-local"*) : ;;
+    *) fail "the dispatch-default refusal did not name the supported opt-in paths: $out" ;;
+  esac
+  assert_absent "$home/state/$id.meta" "the dispatch-default refusal wrote task metadata"
+
+  pass "a crew-dispatch default cannot select claude-local"
+}
+
+test_dispatch_rule_and_explicit_harness_can_select_it() {
+  local home fakebin endpoint case_dir project rule_wt explicit_wt out status
+  local rule_id="cl-dispatch-rule-x1" explicit_id="cl-dispatch-explicit-x1"
+  read -r home fakebin endpoint case_dir <<<"$(make_world dispatch-opt-in)"
+  project="$case_dir/project"
+  rule_wt="$case_dir/rule-wt"
+  explicit_wt="$case_dir/explicit-wt"
+  fm_test_spawn_brief "$home" "$rule_id" "tiny brief"
+  fm_test_spawn_brief "$home" "$explicit_id" "tiny brief"
+  fm_git_worktree "$project" "$rule_wt" "fm/$rule_id"
+  git -C "$project" worktree add --quiet -b "fm/$explicit_id" "$explicit_wt" \
+    || fail "could not create an explicit-harness worktree"
+  printf '%s\n' '{"rules":[{"when":"short local task","use":{"harness":"claude-local","model":"local-coder"}}],"default":{"harness":"codex"}}' \
+    > "$home/config/crew-dispatch.json"
+
+  status=0
+  FM_FAKE_PANE_PATH="$rule_wt" run_spawn "$home" "$fakebin" "$endpoint" "$rule_id" "$project" \
+    --scout --harness claude-local --model local-coder || status=$?
+  [ "$status" -eq 0 ] || fail "a matched dispatch rule could not select claude-local: $(cat "$RUN_OUT")"
+  assert_present "$home/state/$rule_id.meta" "matched dispatch rule did not publish metadata"
+
+  status=0
+  FM_FAKE_PANE_PATH="$explicit_wt" run_spawn "$home" "$fakebin" "$endpoint" "$explicit_id" "$project" \
+    --scout --harness claude-local --model local-coder || status=$?
+  [ "$status" -eq 0 ] || fail "an explicit per-task harness could not select claude-local: $(cat "$RUN_OUT")"
+  assert_present "$home/state/$explicit_id.meta" "explicit claude-local harness did not publish metadata"
+
+  pass "matched dispatch rules and explicit harnesses can select claude-local"
 }
 
 # A tmux and ps pair that answers the endpoint's agent-state classifier with
@@ -526,6 +590,8 @@ test_it_inherits_claudes_verified_tables
 test_it_uses_claudes_shared_busy_signature
 test_spawn_arms_an_executable_eviction_check
 test_raw_claude_local_commands_are_refused
+test_dispatch_profile_default_cannot_select_it
+test_dispatch_rule_and_explicit_harness_can_select_it
 test_eviction_check_is_gated_on_worker_liveness
 test_fresh_dispatch_rollback_retires_the_eviction_check
 test_incomplete_dispatch_rollback_still_retires_the_eviction_check

--- a/tests/fm-claude-local-harness.test.sh
+++ b/tests/fm-claude-local-harness.test.sh
@@ -315,6 +315,15 @@ test_raw_claude_local_commands_are_refused() {
   fm_test_spawn_brief "$home" "cl-raw-env-split-x1" "tiny brief"
   assert_raw_claude_local_command_is_refused "$home" "$fakebin" "$endpoint" \
     "cl-raw-env-split-x1" "env -S 'claude-local --model local-coder'"
+  fm_test_spawn_brief "$home" "cl-raw-env-split-attached-x1" "tiny brief"
+  assert_raw_claude_local_command_is_refused "$home" "$fakebin" "$endpoint" \
+    "cl-raw-env-split-attached-x1" "env -S'claude-local --model local-coder'"
+  fm_test_spawn_brief "$home" "cl-raw-env-long-split-x1" "tiny brief"
+  assert_raw_claude_local_command_is_refused "$home" "$fakebin" "$endpoint" \
+    "cl-raw-env-long-split-x1" "env --split-string 'claude-local --model local-coder'"
+  fm_test_spawn_brief "$home" "cl-raw-env-long-split-equals-x1" "tiny brief"
+  assert_raw_claude_local_command_is_refused "$home" "$fakebin" "$endpoint" \
+    "cl-raw-env-long-split-equals-x1" "env --split-string='claude-local --model local-coder'"
   assert_raw_claude_local_command_is_refused "$home" "$fakebin" "$endpoint" \
     "cl-raw-command-x1" "command claude-local --model local-coder"
 
@@ -323,7 +332,7 @@ test_raw_claude_local_commands_are_refused() {
   fm_test_spawn_brief "$home" "cl-raw-ordinary-x1" "tiny brief"
   fm_git_worktree "$project" "$worktree" "fm/cl-raw-ordinary-x1"
   FM_FAKE_PANE_PATH="$worktree" run_spawn "$home" "$fakebin" "$endpoint" "cl-raw-ordinary-x1" "$project" \
-    "env -i SAFE=1 unverified-runner --flag" --scout || {
+    "env -S 'echo claude-local'" --scout || {
       out=$(cat "$RUN_OUT")
       fail "an ordinary raw env launch was changed by the claude-local guard: $out"
     }

--- a/tests/fm-claude-local-harness.test.sh
+++ b/tests/fm-claude-local-harness.test.sh
@@ -278,19 +278,14 @@ test_spawn_arms_an_executable_eviction_check() {
 
 # The bounded launch context lives in the canonical template. A raw launch
 # command is the unverified-adapter escape hatch and would run whatever it
-# names verbatim, so a raw command whose executable is called claude-local
+# names verbatim, so a raw command whose effective executable is claude-local
 # would pass the local-model gates and then launch with no endpoint pin, no
 # model pin, and no context bound. It is refused, and the refusal names the
 # form that does carry the bounds.
-test_raw_claude_local_command_is_refused() {
-  local home fakebin endpoint case_dir id out
-  read -r home fakebin endpoint case_dir <<<"$(make_world raw)"
-  id="cl-raw-x1"
-  fm_test_spawn_brief "$home" "$id" "tiny brief"
-
-  run_spawn "$home" "$fakebin" "$endpoint" "$id" "$home/projects" \
-    "claude-local --model local-coder" --scout \
-    && fail "a raw claude-local launch command was accepted"
+assert_raw_claude_local_command_is_refused() {  # <home> <fakebin> <endpoint> <id> <command>
+  local home=$1 fakebin=$2 endpoint=$3 id=$4 command=$5 out
+  run_spawn "$home" "$fakebin" "$endpoint" "$id" "$home/projects" "$command" --scout \
+    && fail "a raw claude-local launch command was accepted: $command"
   out=$(cat "$RUN_OUT")
   case "$out" in
     *"bypasses the bounded local-model launch context"*) : ;;
@@ -302,8 +297,34 @@ test_raw_claude_local_command_is_refused() {
   esac
   [ ! -e "$home/state/$id.meta" ] && [ ! -e "$home/state/$id.check.sh" ] \
     || fail "a refused raw claude-local command left task state behind"
+}
 
-  pass "a raw launch command named claude-local is refused in favour of the harness form"
+test_raw_claude_local_commands_are_refused() {
+  local home fakebin endpoint case_dir project worktree out
+  read -r home fakebin endpoint case_dir <<<"$(make_world raw)"
+  fm_test_spawn_brief "$home" "cl-raw-bare-x1" "tiny brief"
+  fm_test_spawn_brief "$home" "cl-raw-env-x1" "tiny brief"
+  fm_test_spawn_brief "$home" "cl-raw-command-x1" "tiny brief"
+  assert_raw_claude_local_command_is_refused "$home" "$fakebin" "$endpoint" \
+    "cl-raw-bare-x1" "claude-local --model local-coder"
+  assert_raw_claude_local_command_is_refused "$home" "$fakebin" "$endpoint" \
+    "cl-raw-env-x1" "env -i LOCAL=1 claude-local --model local-coder"
+  assert_raw_claude_local_command_is_refused "$home" "$fakebin" "$endpoint" \
+    "cl-raw-command-x1" "command claude-local --model local-coder"
+
+  project="$case_dir/project"
+  worktree="$case_dir/worktree"
+  fm_test_spawn_brief "$home" "cl-raw-ordinary-x1" "tiny brief"
+  fm_git_worktree "$project" "$worktree" "fm/cl-raw-ordinary-x1"
+  FM_FAKE_PANE_PATH="$worktree" run_spawn "$home" "$fakebin" "$endpoint" "cl-raw-ordinary-x1" "$project" \
+    "env -i SAFE=1 unverified-runner --flag" --scout || {
+      out=$(cat "$RUN_OUT")
+      fail "an ordinary raw env launch was changed by the claude-local guard: $out"
+    }
+  [ -e "$home/state/cl-raw-ordinary-x1.meta" ] \
+    || fail "an ordinary raw env launch did not publish its task record"
+
+  pass "bare, env, and command raw claude-local launches are refused without changing ordinary raw launches"
 }
 
 # A tmux and ps pair that answers the endpoint's agent-state classifier with
@@ -504,7 +525,7 @@ test_missing_model_is_refused
 test_it_inherits_claudes_verified_tables
 test_it_uses_claudes_shared_busy_signature
 test_spawn_arms_an_executable_eviction_check
-test_raw_claude_local_command_is_refused
+test_raw_claude_local_commands_are_refused
 test_eviction_check_is_gated_on_worker_liveness
 test_fresh_dispatch_rollback_retires_the_eviction_check
 test_incomplete_dispatch_rollback_still_retires_the_eviction_check

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -1835,22 +1835,29 @@ test_bare_relaunch_is_not_a_claude_local_dispatch_default() {
 # and no message at all. The slot is left alone and the arming failure is the
 # loud part.
 test_bare_relaunch_keeps_a_merge_poll_it_did_not_arm() {
-  local dir state out
+  local dir state hooks out
   dir=$(new_case spawn-relaunch-poll rl48)
   add_claude_local_task "$dir" rl48 loaded
   state="$dir/home/state"
   arm_pr_poll "$dir" rl48 https://github.com/my-org/repo/pull/7
   fm_pr_poll_artifacts_valid "$state" rl48 "$ROOT/bin/fm-pr-poll.sh" \
     || fail "the PR poll fixture was not valid before the relaunch"
+  # The claude family's hook file: the running worker's semantic busy and
+  # turn-end source. A relaunch that cannot finish must not have removed it.
+  hooks="$dir/wt/.claude/settings.local.json"
+  mkdir -p "$dir/wt/.claude"
+  printf '{"hooks":"prior incarnation"}\n' > "$hooks"
   printf 'zsh' > "$dir/fake/command"
   out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 run_spawn "$dir" rl48 --relaunch) || true
   fm_pr_poll_artifacts_valid "$state" rl48 "$ROOT/bin/fm-pr-poll.sh" \
     || fail "a bare relaunch deleted the merge poll occupying the check slot: $out"
+  [ "$(cat "$hooks" 2>/dev/null)" = '{"hooks":"prior incarnation"}' ] \
+    || fail "a refused relaunch retired the running worker's hook wiring: $out"
   case "$out" in
     *"could not arm the local-model watcher check"*) : ;;
     *) fail "the occupied check slot was not reported: $out" ;;
   esac
-  pass "fm-spawn --relaunch: a merge poll holding the check slot is left intact, not silently replaced"
+  pass "fm-spawn --relaunch: a merge poll holding the check slot leaves both the poll and the prior wiring intact"
 }
 
 # The other half of the same slot rule: a genuine eviction watcher this adapter

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -1540,8 +1540,49 @@ test_spawn_relaunch_refuses_a_live_agent
 test_spawn_relaunch_refuses_a_symlinked_task_record_before_inspection
 test_spawn_relaunch_keeps_its_early_meta_lock_continuous
 test_spawn_relaunch_refuses_a_pending_authoritative_close
+# claude-local records an adapter whose control FAMILY is claude. That split is
+# deliberate - the interrupt/exit tables and wiring retirement are keyed by the
+# family - but the relaunch PROFILE must keep the exact recorded adapter, or an
+# ordinary relaunch is refused as an unreconstructable alias and an explicit
+# --harness silently resets the recorded model to default. Both failures land on
+# the wrong side of the transaction: fm-control stops the running agent before
+# fm-spawn refuses, so the operator loses a live worker and only then sees an
+# error.
+test_relaunch_keeps_the_exact_recorded_claude_local_profile() {
+  local dir out
+  dir=$(new_case claude-local rl40)
+  add_ship_task "$dir" rl40 claude-local
+  # The recorded model is the endpoint's own catalog id; claude-local never
+  # guesses it, so losing it on relaunch is a hard failure rather than a default.
+  sed -i.bak 's/^model=default$/model=local-coder/' "$dir/home/state/rl40.meta"
+  rm -f "$dir/home/state/rl40.meta.bak"
+
+  # No explicit axes: this is the ordinary relaunch that must not be refused as
+  # an alias. The launch itself is expected to fail in this fixture; the
+  # assertion is that the ALIAS refusal is gone and the recorded profile stands.
+  out=$(run_control "$dir" rl40 relaunch --note "resume after restart" 2>&1) || true
+  case "$out" in
+    *"cannot be reconstructed from its recorded basename"*)
+      fail "an ordinary claude-local relaunch was refused as an unreconstructable alias: $out" ;;
+  esac
+  [ "$(meta_field "$dir" rl40 harness)" = claude-local ] \
+    || fail "the recorded harness must stay claude-local, got '$(meta_field "$dir" rl40 harness)'"
+  [ "$(meta_field "$dir" rl40 model)" = local-coder ] \
+    || fail "the recorded model must survive a relaunch, got '$(meta_field "$dir" rl40 model)'"
+
+  # The family split must still hold: control mechanics resolve to claude.
+  [ "$(fm_control_harness_family claude-local)" = claude ] \
+    || fail "claude-local must still resolve to the claude control family"
+  # And the pre-stop capability refusal must still be exact, not widened.
+  fm_control_harness_supports_kind claude-local secondmate \
+    && fail "claude-local must still be refused for a secondmate before anything is stopped"
+
+  pass "a recorded claude-local task relaunches on its exact adapter and keeps its model"
+}
+
 test_spawn_relaunch_refuses_contradicting_flags
 test_spawn_relaunch_refuses_an_unrecorded_task
 test_spawn_relaunch_refuses_a_pane_outside_the_worktree
 test_relaunch_reverifies_an_already_in_flight_item_instead_of_rewriting_it
 test_relaunch_moves_a_drifted_item_back_in_flight
+test_relaunch_keeps_the_exact_recorded_claude_local_profile

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -1879,8 +1879,69 @@ test_bare_relaunch_still_retires_a_real_eviction_watcher() {
   pass "fm-spawn --relaunch: a genuine eviction watcher is still retired when the task leaves claude-local"
 }
 
+# bin/fm-check-unregister.sh removes only <id>.check.sh and <id>.check-trust,
+# so the handover bin/fm-pr-check.sh documents leaves <id>.pr-poll and
+# <id>.pr-poll-registration behind. Slot ownership has to be decided by the
+# poll actually IN the slot, not by that leftover: reading the leftover as an
+# owner would mean the task can never arm its own watcher again, and can never
+# retire it when it moves to a hosted harness either.
+test_a_retired_polls_leftover_registration_does_not_own_the_slot() {
+  local dir state out
+  dir=$(new_case spawn-relaunch-stale-reg rl50)
+  add_claude_local_task "$dir" rl50 loaded
+  state="$dir/home/state"
+  arm_pr_poll "$dir" rl50 https://github.com/my-org/repo/pull/9
+  FM_STATE_OVERRIDE="$state" "$ROOT/bin/fm-check-unregister.sh" rl50 >/dev/null \
+    || fail "fixture: the documented slot handover could not be reversed"
+  [ -e "$state/rl50.pr-poll-registration" ] \
+    || fail "fixture: the retired poll left no stale registration to test against"
+
+  printf 'zsh' > "$dir/fake/command"
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 run_spawn "$dir" rl50 --relaunch)
+  fm_custom_check_registered "$state" rl50 \
+    || fail "the freed slot did not take this adapter's own watcher: $out"
+
+  printf 'zsh' > "$dir/fake/command"
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 run_spawn "$dir" rl50 --relaunch) \
+    || fail "a later claude-local relaunch was refused over a stale registration: $out"
+  fm_custom_check_registered "$state" rl50 \
+    || fail "the accepted relaunch did not re-arm the eviction watcher: $out"
+
+  printf 'zsh' > "$dir/fake/command"
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 run_spawn "$dir" rl50 --relaunch --harness claude)
+  [ ! -e "$state/rl50.check.sh" ] && [ ! -e "$state/rl50.check-trust" ] \
+    || fail "a relaunch onto a hosted harness left the eviction watcher armed: $out"
+  pass "fm-spawn --relaunch: a retired poll's leftover registration does not own the check slot"
+}
+
+# The same abort as above, with that leftover registration present. A relaunch
+# that produced no worker may never leave a registered check behind, whatever
+# else is sitting beside it in the state directory.
+test_claude_local_relaunch_abort_retires_the_watcher_beside_a_stale_registration() {
+  local dir state out rc real_mv
+  dir=$(new_case claude-local-abort-stale rl51)
+  add_claude_local_task "$dir" rl51 loaded
+  state="$dir/home/state"
+  arm_pr_poll "$dir" rl51 https://github.com/my-org/repo/pull/11
+  FM_STATE_OVERRIDE="$state" "$ROOT/bin/fm-check-unregister.sh" rl51 >/dev/null \
+    || fail "fixture: the documented slot handover could not be reversed"
+  [ -e "$state/rl51.pr-poll-registration" ] \
+    || fail "fixture: the retired poll left no stale registration to test against"
+  real_mv=$(command -v mv)
+  make_mv_failure_stub "$dir"
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 FM_REAL_MV="$real_mv" \
+    FM_FAKE_META_PUBLISH_MV_FAIL="$state/rl51.meta" \
+    run_control "$dir" rl51 relaunch --note "abort beside a stale registration"); rc=$?
+  expect_code 1 "$rc" "a failed metadata publication should fail closed"$'\n'"$out"
+  [ ! -e "$state/rl51.check.sh" ] && [ ! -e "$state/rl51.check-trust" ] \
+    || fail "an aborted relaunch left its eviction watcher armed beside a stale registration: $out"
+  pass "fm-spawn relaunch: an abort retires its watcher even beside a retired poll's registration"
+}
+
 test_claude_local_relaunch_refuses_before_stop_when_the_model_is_unloaded
 test_claude_local_relaunch_refuses_before_stop_when_the_task_ships_no_mistakes
+test_a_retired_polls_leftover_registration_does_not_own_the_slot
+test_claude_local_relaunch_abort_retires_the_watcher_beside_a_stale_registration
 test_bare_relaunch_keeps_a_merge_poll_it_did_not_arm
 test_bare_relaunch_still_retires_a_real_eviction_watcher
 test_bare_relaunch_is_not_a_claude_local_dispatch_default

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -1730,7 +1730,46 @@ test_claude_local_relaunch_preserved_after_delivery_keeps_the_watcher() {
   pass "fm-spawn relaunch: a preserving exit after delivery keeps the eviction watcher armed"
 }
 
+# The brief-fits gate is the third launch gate fm-spawn runs after the agent is
+# stopped, and record_note grows the brief on every relaunch, so a brief near
+# the allowance crosses it on the relaunch itself. The pre-stop gate therefore
+# judges the brief PLUS the note it is about to append: the brief alone still
+# fits (the contrast), and the relaunch refuses with the brief untouched.
+test_claude_local_relaunch_refuses_before_stop_when_the_note_overflows_the_brief() {
+  local dir brief out rc before
+  dir=$(new_case claude-local-brief rl45)
+  add_claude_local_task "$dir" rl45 loaded
+  brief="$dir/home/data/rl45/brief.md"
+  # Headroom is pinned to 800 tokens, so the 25% allowance is 200 tokens (800
+  # bytes at the bytes/4 estimate): 600 bytes of brief fit alone, and the
+  # progress note block pushes the pair past it.
+  head -c 600 /dev/zero | tr '\0' 'x' > "$brief"
+  FM_LOCAL_MODEL_ENDPOINT="file://$dir/endpoint" FM_LOCAL_MODEL_HARNESS_BASELINE=130272 \
+    "$ROOT/bin/fm-local-model.sh" brief-fits local-coder "$brief" >/dev/null \
+    || fail "fixture: the brief alone must fit the allowance"
+  before=$(cat "$brief")
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=130272 \
+    run_control "$dir" rl45 relaunch --note "one more note on an already full brief"); rc=$?
+  expect_code 1 "$rc" "a relaunch whose note overflows the brief allowance should refuse"$'\n'"$out"
+  case "$out" in
+    *"too large for the local model runtime"*) : ;;
+    *) fail "the refusal did not carry the brief-fits diagnosis: $out" ;;
+  esac
+  case "$out" in
+    *"left in place"*) : ;;
+    *) fail "the refusal did not say the worker was kept: $out" ;;
+  esac
+  ! grep -qx '/exit' "$dir/fake/literal" \
+    || fail "a refused claude-local relaunch stopped the running worker"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "the running worker did not survive a refused relaunch"
+  [ "$(cat "$brief")" = "$before" ] \
+    || fail "a refused relaunch appended its progress note to the instructions"
+  pass "fm-control relaunch: a note that overflows the brief allowance refuses before the worker is stopped"
+}
+
 test_claude_local_relaunch_refuses_before_stop_when_the_model_is_unloaded
 test_claude_local_relaunch_refuses_an_armed_pr_poll_before_stop
+test_claude_local_relaunch_refuses_before_stop_when_the_note_overflows_the_brief
 test_claude_local_relaunch_abort_before_the_worker_exists_retires_the_watcher
 test_claude_local_relaunch_preserved_after_delivery_keeps_the_watcher

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -1660,6 +1660,39 @@ test_claude_local_relaunch_refuses_before_stop_when_the_model_is_unloaded() {
   pass "fm-control relaunch: an unavailable local model refuses before the worker is stopped"
 }
 
+# fm-spawn refuses every occupied custom-check slot unless it can prove the
+# incumbent claude-local watcher owns it. The control path must judge the same
+# condition before it sends /exit, including an unclaimed check script that
+# cannot be proved to be the incumbent watcher: otherwise the replacement
+# refuses only after the healthy worker has stopped.
+test_claude_local_relaunch_refuses_an_occupied_custom_check_before_stop() {
+  local dir state out rc check
+  dir=$(new_case claude-local-custom-check rl52)
+  add_claude_local_task "$dir" rl52 loaded
+  state="$dir/home/state"
+  check="$state/rl52.check.sh"
+  cat > "$check" <<'SH'
+#!/usr/bin/env bash
+printf 'waiting: an unclaimed custom check owns this slot\n'
+SH
+  chmod 0700 "$check"
+
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 \
+    run_control "$dir" rl52 relaunch --note "worker looked stuck"); rc=$?
+  expect_code 1 "$rc" "a claude-local relaunch over another custom check should refuse"$'\n'"$out"
+  case "$out" in
+    *"custom-check slot"*) : ;;
+    *) fail "the refusal did not name the occupied custom-check slot: $out" ;;
+  esac
+  ! grep -qx '/exit' "$dir/fake/literal" \
+    || fail "a refused custom-check relaunch stopped the running worker"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "the running worker did not survive a custom-check refusal"
+  [ -e "$check" ] \
+    || fail "the occupied custom check was disturbed by a refused relaunch"
+  pass "fm-control relaunch: an occupied custom check refuses before the worker is stopped"
+}
+
 # The same slot the eviction watcher needs is the one an armed PR poll owns.
 # Neither may silently replace the other, so a claude-local relaunch that
 # finds a live poll refuses before the worker is stopped and leaves the poll
@@ -1939,6 +1972,7 @@ test_claude_local_relaunch_abort_retires_the_watcher_beside_a_stale_registration
 }
 
 test_claude_local_relaunch_refuses_before_stop_when_the_model_is_unloaded
+test_claude_local_relaunch_refuses_an_occupied_custom_check_before_stop
 test_claude_local_relaunch_refuses_before_stop_when_the_task_ships_no_mistakes
 test_a_retired_polls_leftover_registration_does_not_own_the_slot
 test_claude_local_relaunch_abort_retires_the_watcher_beside_a_stale_registration

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -25,6 +25,10 @@ set -u
 . "$ROOT/bin/fm-control-lib.sh"
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-trace-context-lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-pr-lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-check-lib.sh"
 
 CONTROL="$ROOT/bin/fm-control.sh"
 SPAWN="$ROOT/bin/fm-spawn.sh"
@@ -1586,3 +1590,147 @@ test_spawn_relaunch_refuses_a_pane_outside_the_worktree
 test_relaunch_reverifies_an_already_in_flight_item_instead_of_rewriting_it
 test_relaunch_moves_a_drifted_item_back_in_flight
 test_relaunch_keeps_the_exact_recorded_claude_local_profile
+
+# --- claude-local: pre-stop gates and watcher ownership ---------------------
+
+# A claude-local ship task whose recorded endpoint is a file:// catalog, so the
+# local-model gates run against a real, controllable endpoint. <state> is the
+# catalog's model state (loaded or not-loaded).
+add_claude_local_task() {  # <case-dir> <id> <state>
+  local dir=$1 id=$2 state=$3 meta
+  meta="$dir/home/state/$id.meta"
+  add_ship_task "$dir" "$id" claude-local
+  sed -i.bak -e 's/^model=default$/model=local-coder/' -e 's/^mode=no-mistakes$/mode=direct-PR/' "$meta"
+  rm -f "$meta.bak"
+  printf 'local_model_endpoint=file://%s/endpoint\n' "$dir" >> "$meta"
+  set_local_model_state "$dir" "$state"
+}
+
+# Arm a merge poll through the real entrypoint. The guard is stubbed the way
+# tests/fm-pr-check-security.test.sh stubs it, and gh is absent so no PR head
+# is looked up.
+arm_pr_poll() {  # <case-dir> <id> <url>
+  local dir=$1 id=$2 url=$3
+  mkdir -p "$dir/root/bin"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$dir/root/bin/fm-guard.sh"
+  chmod +x "$dir/root/bin/fm-guard.sh"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$dir/fakebin/gh"
+  chmod +x "$dir/fakebin/gh"
+  FM_ROOT_OVERRIDE="$dir/root" FM_HOME="$dir/home" PATH="$dir/fakebin:$PATH" \
+    "$ROOT/bin/fm-pr-check.sh" "$id" "$url" >/dev/null 2>"$dir/pr-check.err" \
+    || fail "the PR poll fixture could not be armed: $(cat "$dir/pr-check.err")"
+}
+
+set_local_model_state() {  # <case-dir> <state>
+  mkdir -p "$1/endpoint/api/v0"
+  cat > "$1/endpoint/api/v0/models" <<EOF
+{"object":"list","data":[
+ {"id":"local-coder","object":"model","type":"llm","state":"$2","max_context_length":262144,"loaded_context_length":131072}
+]}
+EOF
+}
+
+# The endpoint and model gates lived only in fm-spawn, which fm-control reaches
+# after the running agent has been stopped: a relaunch prompted by the eviction
+# watcher itself would stop a healthy worker and then fail to replace it. The
+# same preflight now answers on the pre-stop side, so an unloaded model refuses
+# with nothing changed.
+test_claude_local_relaunch_refuses_before_stop_when_the_model_is_unloaded() {
+  local dir out rc
+  dir=$(new_case claude-local-unloaded rl41)
+  add_claude_local_task "$dir" rl41 not-loaded
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 \
+    run_control "$dir" rl41 relaunch --note "model was evicted"); rc=$?
+  expect_code 1 "$rc" "a relaunch onto an unloaded local model should refuse"$'\n'"$out"
+  case "$out" in
+    *"not loaded"*) : ;;
+    *) fail "the refusal did not carry the preflight's diagnosis: $out" ;;
+  esac
+  case "$out" in
+    *"left in place"*) : ;;
+    *) fail "the refusal did not say the worker was kept: $out" ;;
+  esac
+  ! grep -qx '/exit' "$dir/fake/literal" \
+    || fail "a refused claude-local relaunch stopped the running worker"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "the running worker did not survive a refused relaunch"
+  [ "$(meta_field "$dir" rl41 harness)" = claude-local ] \
+    && [ "$(meta_field "$dir" rl41 model)" = local-coder ] \
+    || fail "a refused relaunch changed the durable record"
+  pass "fm-control relaunch: an unavailable local model refuses before the worker is stopped"
+}
+
+# The same slot the eviction watcher needs is the one an armed PR poll owns.
+# Neither may silently replace the other, so a claude-local relaunch that
+# finds a live poll refuses before the worker is stopped and leaves the poll
+# exactly as it was.
+test_claude_local_relaunch_refuses_an_armed_pr_poll_before_stop() {
+  local dir state out rc
+  dir=$(new_case claude-local-poll rl42)
+  add_claude_local_task "$dir" rl42 loaded
+  state="$dir/home/state"
+  arm_pr_poll "$dir" rl42 https://github.com/my-org/repo/pull/5
+  fm_pr_poll_artifacts_valid "$state" rl42 "$ROOT/bin/fm-pr-poll.sh" \
+    || fail "the PR poll fixture was not valid before the relaunch"
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 \
+    run_control "$dir" rl42 relaunch --note "worker looked stuck"); rc=$?
+  expect_code 1 "$rc" "a claude-local relaunch over an armed PR poll should refuse"$'\n'"$out"
+  case "$out" in
+    *"active PR poll"*) : ;;
+    *) fail "the refusal did not name the PR poll occupying the slot: $out" ;;
+  esac
+  ! grep -qx '/exit' "$dir/fake/literal" \
+    || fail "a refused claude-local relaunch stopped the running worker"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "the running worker did not survive a refused relaunch"
+  fm_pr_poll_artifacts_valid "$state" rl42 "$ROOT/bin/fm-pr-poll.sh" \
+    || fail "the armed PR poll was disturbed by a refused relaunch"
+  pass "fm-control relaunch: an armed PR poll refuses a claude-local relaunch before the worker is stopped"
+}
+
+# The watcher is provisional only until the replacement record is published
+# and its launch delivered. A failure before that point must retire it (no
+# worker exists for it to watch); a failure after it that deliberately keeps
+# the record and the live worker must NOT, or the worker is left with no
+# eviction detection - the silent stall the watcher exists to make loud.
+test_claude_local_relaunch_abort_before_the_worker_exists_retires_the_watcher() {
+  local dir state out rc real_mv
+  dir=$(new_case claude-local-abort rl43)
+  add_claude_local_task "$dir" rl43 loaded
+  state="$dir/home/state"
+  real_mv=$(command -v mv)
+  make_mv_failure_stub "$dir"
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 FM_REAL_MV="$real_mv" \
+    FM_FAKE_META_PUBLISH_MV_FAIL="$state/rl43.meta" \
+    run_control "$dir" rl43 relaunch --note "abort before publication"); rc=$?
+  expect_code 1 "$rc" "a failed metadata publication should fail closed"$'\n'"$out"
+  [ ! -e "$state/rl43.check.sh" ] && [ ! -e "$state/rl43.check-trust" ] \
+    || fail "an aborted claude-local relaunch left its provisional eviction watcher armed"
+  pass "fm-spawn relaunch: an abort before the worker exists retires the provisional watcher"
+}
+
+test_claude_local_relaunch_preserved_after_delivery_keeps_the_watcher() {
+  local dir state out rc
+  dir=$(new_case claude-local-preserved rl44)
+  add_claude_local_task "$dir" rl44 loaded
+  state="$dir/home/state"
+  seed_backlog "$dir" rl44 queued
+  break_tasks_axi_start "$dir"
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 \
+    run_control "$dir" rl44 relaunch --note "backlog commit fails after delivery"); rc=$?
+  expect_code 1 "$rc" "a post-delivery backlog failure should be reported"$'\n'"$out"
+  case "$out" in
+    *"republished but its backlog item could not be moved"*) : ;;
+    *) fail "the fixture did not reach the preserving post-delivery exit: $out" ;;
+  esac
+  [ "$(meta_field "$dir" rl44 harness)" = claude-local ] \
+    || fail "the preserving exit did not keep the republished record"
+  fm_custom_check_registered "$state" rl44 \
+    || fail "a preserving exit after launch delivery disarmed the live worker's eviction watcher"
+  pass "fm-spawn relaunch: a preserving exit after delivery keeps the eviction watcher armed"
+}
+
+test_claude_local_relaunch_refuses_before_stop_when_the_model_is_unloaded
+test_claude_local_relaunch_refuses_an_armed_pr_poll_before_stop
+test_claude_local_relaunch_abort_before_the_worker_exists_retires_the_watcher
+test_claude_local_relaunch_preserved_after_delivery_keeps_the_watcher

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -1596,11 +1596,11 @@ test_relaunch_keeps_the_exact_recorded_claude_local_profile
 # A claude-local ship task whose recorded endpoint is a file:// catalog, so the
 # local-model gates run against a real, controllable endpoint. <state> is the
 # catalog's model state (loaded or not-loaded).
-add_claude_local_task() {  # <case-dir> <id> <state>
-  local dir=$1 id=$2 state=$3 meta
+add_claude_local_task() {  # <case-dir> <id> <state> [mode]
+  local dir=$1 id=$2 state=$3 mode=${4:-direct-PR} meta
   meta="$dir/home/state/$id.meta"
   add_ship_task "$dir" "$id" claude-local
-  sed -i.bak -e 's/^model=default$/model=local-coder/' -e 's/^mode=no-mistakes$/mode=direct-PR/' "$meta"
+  sed -i.bak -e 's/^model=default$/model=local-coder/' -e "s/^mode=no-mistakes\$/mode=$mode/" "$meta"
   rm -f "$meta.bak"
   printf 'local_model_endpoint=file://%s/endpoint\n' "$dir" >> "$meta"
   set_local_model_state "$dir" "$state"
@@ -1768,7 +1768,68 @@ test_claude_local_relaunch_refuses_before_stop_when_the_note_overflows_the_brief
   pass "fm-control relaunch: a note that overflows the brief allowance refuses before the worker is stopped"
 }
 
+# fm-spawn refuses claude-local for no-mistakes shipping (its gate 3), and a
+# relaunch reads that mode from the task's own record rather than the command
+# line - so with no pre-stop gate the control plane stops a healthy worker for
+# a launch that is then certain to be refused, leaving no agent at all. The
+# fixture records mode=no-mistakes rather than rewriting it away, so the gate
+# is judged against the state that actually reaches fm-spawn.
+test_claude_local_relaunch_refuses_before_stop_when_the_task_ships_no_mistakes() {
+  local dir out rc brief before
+  dir=$(new_case claude-local-no-mistakes rl46)
+  add_claude_local_task "$dir" rl46 loaded no-mistakes
+  [ "$(meta_field "$dir" rl46 mode)" = no-mistakes ] \
+    || fail "fixture: the task must record mode=no-mistakes"
+  brief="$dir/home/data/rl46/brief.md"
+  before=$(cat "$brief")
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 \
+    run_control "$dir" rl46 relaunch --note "worker looked stuck"); rc=$?
+  expect_code 1 "$rc" "a claude-local relaunch of a no-mistakes task should refuse"$'\n'"$out"
+  case "$out" in
+    *no-mistakes*) : ;;
+    *) fail "the refusal did not name the mode that blocks it: $out" ;;
+  esac
+  case "$out" in
+    *"left in place"*) : ;;
+    *) fail "the refusal did not say the worker was kept: $out" ;;
+  esac
+  ! grep -qx '/exit' "$dir/fake/literal" \
+    || fail "a refused claude-local relaunch stopped the running worker"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "the running worker did not survive a refused relaunch"
+  [ "$(cat "$brief")" = "$before" ] \
+    || fail "a refused relaunch appended its progress note to the instructions"
+  pass "fm-control relaunch: a no-mistakes task refuses claude-local before the worker is stopped"
+}
+
+# A bare `fm-spawn <id> --relaunch` takes its harness from the task's own
+# durable record, so a crew-dispatch DEFAULT naming claude-local is a config
+# this launch never consulted. Refusing it there would strand every existing
+# claude-local task the moment that default was written. The fresh-spawn side
+# of the same gate stays covered by tests/fm-claude-local-harness.test.sh.
+test_bare_relaunch_is_not_a_claude_local_dispatch_default() {
+  local dir out
+  dir=$(new_case spawn-relaunch-default rl47)
+  add_claude_local_task "$dir" rl47 loaded
+  mkdir -p "$dir/home/config"
+  printf '%s\n' '{"default":{"harness":"claude-local","model":"local-coder"}}' \
+    > "$dir/home/config/crew-dispatch.json"
+  printf 'zsh' > "$dir/fake/command"
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 run_spawn "$dir" rl47 --relaunch)
+  case "$out" in
+    *"cannot select claude-local"*)
+      fail "a bare relaunch was refused as a dispatch default: $out" ;;
+  esac
+  assert_contains "$out" "spawned rl47 harness=claude-local" \
+    "the bare relaunch did not launch on the recorded harness"
+  [ "$(meta_field "$dir" rl47 harness)" = claude-local ] \
+    || fail "the bare relaunch did not keep the recorded harness"
+  pass "fm-spawn --relaunch: a claude-local dispatch default cannot refuse a task's own recorded harness"
+}
+
 test_claude_local_relaunch_refuses_before_stop_when_the_model_is_unloaded
+test_claude_local_relaunch_refuses_before_stop_when_the_task_ships_no_mistakes
+test_bare_relaunch_is_not_a_claude_local_dispatch_default
 test_claude_local_relaunch_refuses_an_armed_pr_poll_before_stop
 test_claude_local_relaunch_refuses_before_stop_when_the_note_overflows_the_brief
 test_claude_local_relaunch_abort_before_the_worker_exists_retires_the_watcher

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -1827,8 +1827,55 @@ test_bare_relaunch_is_not_a_claude_local_dispatch_default() {
   pass "fm-spawn --relaunch: a claude-local dispatch default cannot refuse a task's own recorded harness"
 }
 
+# bin/fm-pr-check.sh tells an operator to hand the single check slot over
+# (bin/fm-check-unregister.sh <id>) before arming a merge poll, and the record
+# still says harness=claude-local afterwards. A later bare `fm-spawn <id>
+# --relaunch` must not silently delete the poll shim it finds there: that would
+# strand <id>.pr-poll and <id>.pr-poll-registration with merge detection gone
+# and no message at all. The slot is left alone and the arming failure is the
+# loud part.
+test_bare_relaunch_keeps_a_merge_poll_it_did_not_arm() {
+  local dir state out
+  dir=$(new_case spawn-relaunch-poll rl48)
+  add_claude_local_task "$dir" rl48 loaded
+  state="$dir/home/state"
+  arm_pr_poll "$dir" rl48 https://github.com/my-org/repo/pull/7
+  fm_pr_poll_artifacts_valid "$state" rl48 "$ROOT/bin/fm-pr-poll.sh" \
+    || fail "the PR poll fixture was not valid before the relaunch"
+  printf 'zsh' > "$dir/fake/command"
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 run_spawn "$dir" rl48 --relaunch) || true
+  fm_pr_poll_artifacts_valid "$state" rl48 "$ROOT/bin/fm-pr-poll.sh" \
+    || fail "a bare relaunch deleted the merge poll occupying the check slot: $out"
+  case "$out" in
+    *"could not arm the local-model watcher check"*) : ;;
+    *) fail "the occupied check slot was not reported: $out" ;;
+  esac
+  pass "fm-spawn --relaunch: a merge poll holding the check slot is left intact, not silently replaced"
+}
+
+# The other half of the same slot rule: a genuine eviction watcher this adapter
+# armed IS still retired when the task moves off claude-local, so the narrowed
+# retirement did not simply stop retiring.
+test_bare_relaunch_still_retires_a_real_eviction_watcher() {
+  local dir state out
+  dir=$(new_case spawn-relaunch-watcher rl49)
+  add_claude_local_task "$dir" rl49 loaded
+  state="$dir/home/state"
+  printf 'zsh' > "$dir/fake/command"
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 run_spawn "$dir" rl49 --relaunch)
+  fm_custom_check_registered "$state" rl49 \
+    || fail "fixture: the claude-local relaunch did not arm an eviction watcher: $out"
+  printf 'zsh' > "$dir/fake/command"
+  out=$(FM_LOCAL_MODEL_HARNESS_BASELINE=1000 run_spawn "$dir" rl49 --relaunch --harness claude)
+  [ ! -e "$state/rl49.check.sh" ] && [ ! -e "$state/rl49.check-trust" ] \
+    || fail "a relaunch off claude-local left its own eviction watcher armed: $out"
+  pass "fm-spawn --relaunch: a genuine eviction watcher is still retired when the task leaves claude-local"
+}
+
 test_claude_local_relaunch_refuses_before_stop_when_the_model_is_unloaded
 test_claude_local_relaunch_refuses_before_stop_when_the_task_ships_no_mistakes
+test_bare_relaunch_keeps_a_merge_poll_it_did_not_arm
+test_bare_relaunch_still_retires_a_real_eviction_watcher
 test_bare_relaunch_is_not_a_claude_local_dispatch_default
 test_claude_local_relaunch_refuses_an_armed_pr_poll_before_stop
 test_claude_local_relaunch_refuses_before_stop_when_the_note_overflows_the_brief

--- a/tests/fm-local-model.test.sh
+++ b/tests/fm-local-model.test.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# tests/fm-local-model.test.sh - the portable regression for the local
+# OpenAI/Anthropic-compatible endpoint owner behind the claude-local adapter.
+#
+# The endpoint is addressed through a real `curl` against a real `file://` URL
+# rather than a stubbed curl. That keeps the load-bearing parts genuine - the
+# real fetch, the real JSON parse, the real exit codes - while staying portable
+# to a CI runner that cannot bind a listening socket. It deliberately does NOT
+# claim to prove TCP behavior: the live evidence against a real HTTP endpoint,
+# including the request-path finding these contracts are built on, is recorded
+# in docs/verification/runtime-backends.md under "claude-local".
+#
+# The load-bearing contracts:
+#   1. The CATALOG is the only model-identity source. Verified against LM Studio
+#      2026-09-01, a request naming an unloaded model is answered by whatever IS
+#      loaded, so the request path can never report an eviction.
+#   2. An unreachable endpoint and an evicted model are DISTINCT, non-silent
+#      failures with distinct exit codes, and the watcher check prints one
+#      actionable line for each and nothing at all when the runtime is healthy.
+#   3. The context budget is the smaller of what the server loaded and the
+#      firstmate ceiling, so loading a very wide window can never by itself turn
+#      this into a long-context runtime.
+#   4. The boundary that actually bites is the HEADROOM above the harness's own
+#      prompt, measured at ~60k tokens on 2026-09-01. An oversized brief - and a
+#      window with no headroom at all - is REFUSED, not silently degraded.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LOCAL_MODEL="$ROOT/bin/fm-local-model.sh"
+TMP_ROOT=$(fm_test_tmproot fm-local-model)
+
+# endpoint <name> <state> <loaded_context_length> -> echoes a file:// endpoint
+# whose /api/v0/models is a real catalog document. The decoy first model is what
+# makes the lookup prove it reads the RIGHT entry rather than the first "state"
+# it happens to find.
+endpoint() {  # <name> <state> <ctx>
+  local name=$1 state=$2 ctx=$3 dir
+  dir="$TMP_ROOT/$name/api/v0"
+  mkdir -p "$dir"
+  cat > "$dir/models" <<EOF
+{"object":"list","data":[
+ {"id":"other-model","object":"model","type":"llm","state":"not-loaded","max_context_length":8192,"loaded_context_length":8192},
+ {"id":"local-coder","object":"model","type":"llm","state":"$state","max_context_length":262144,"loaded_context_length":$ctx}
+]}
+EOF
+  printf 'file://%s\n' "$TMP_ROOT/$name"
+}
+
+# An endpoint that answers nothing at all: the directory exists but the catalog
+# does not, so the same curl invocation that reaches a live server fails.
+dead_endpoint() {
+  mkdir -p "$TMP_ROOT/dead"
+  printf 'file://%s\n' "$TMP_ROOT/dead"
+}
+
+# A loaded model is reported loaded, and the budget is the smaller of the
+# server's own loaded window and the firstmate ceiling - in BOTH directions, so
+# neither side can be the only one that ever binds.
+test_loaded_model_and_budget() {
+  local url out
+  url=$(endpoint healthy loaded 65536)
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" model-state local-coder) \
+    || fail "model-state failed against a healthy endpoint"
+  [ "$out" = loaded ] || fail "expected state 'loaded', got '$out'"
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" FM_LOCAL_MODEL_MAX_CONTEXT=32768 \
+    "$LOCAL_MODEL" context-budget local-coder) || fail "context-budget failed"
+  [ "$out" = 32768 ] || fail "the firstmate ceiling must bind below the server window, got '$out'"
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" FM_LOCAL_MODEL_MAX_CONTEXT=200000 \
+    "$LOCAL_MODEL" context-budget local-coder) || fail "context-budget failed"
+  [ "$out" = 65536 ] || fail "the server window must bind below the ceiling, got '$out'"
+
+  FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" preflight local-coder >/dev/null \
+    || fail "preflight refused a loaded model on a reachable endpoint"
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" check local-coder) \
+    || fail "check exited nonzero on a healthy runtime"
+  [ -z "$out" ] || fail "check must print NOTHING when the runtime is healthy, got '$out'"
+
+  pass "a loaded model reports loaded, and the budget is the smaller of the server window and the ceiling"
+}
+
+# An evicted model is the failure LM Studio's idle TTL and auto-evict produce
+# under a running worker. It must be loud, and it must be distinguishable from
+# an unreachable endpoint.
+test_evicted_model_is_loud() {
+  local url out status
+  url=$(endpoint evicted not-loaded 0)
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" model-state local-coder) \
+    || fail "model-state failed against a reachable endpoint"
+  [ "$out" = not-loaded ] || fail "expected 'not-loaded', got '$out'"
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" preflight local-coder 2>&1)
+  status=$?
+  [ "$status" -eq 4 ] || fail "an evicted model must exit 4, got $status"
+  case "$out" in *"not loaded"*) : ;; *) fail "the eviction refusal did not name the state: $out" ;; esac
+
+  FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" context-budget local-coder >/dev/null 2>&1 \
+    && fail "context-budget must refuse rather than invent a window for an unloaded model"
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" check local-coder)
+  case "$out" in
+    blocked:*"no longer loaded"*) : ;;
+    *) fail "the watcher check did not report the eviction as blocked: '$out'" ;;
+  esac
+  [ "$(printf '%s\n' "$out" | wc -l | tr -d ' ')" = 1 ] \
+    || fail "the watcher check must print exactly one line"
+
+  pass "an evicted model exits 4 and wakes firstmate with one actionable line"
+}
+
+# A model the endpoint has never heard of is a different operator mistake than
+# an evicted one, and says so.
+test_absent_model_names_the_gap() {
+  local url out status
+  url=$(endpoint absent loaded 65536)
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" preflight no-such-model 2>&1)
+  status=$?
+  [ "$status" -eq 4 ] || fail "an absent model must exit 4, got $status"
+  case "$out" in *"does not list a model named"*) : ;; *) fail "absent-model refusal was not specific: $out" ;; esac
+  pass "a model absent from the catalog is refused with its own message"
+}
+
+# The other half of the going-away requirement: an endpoint that does not answer
+# must be its own exit code and its own wake line, never confused with an
+# eviction and never silent.
+test_unreachable_endpoint_is_loud_and_distinct() {
+  local url out status
+  url=$(dead_endpoint)
+
+  FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" probe >/dev/null 2>&1
+  status=$?
+  [ "$status" -eq 3 ] || fail "an unreachable endpoint must exit 3, got $status"
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" preflight local-coder 2>&1)
+  status=$?
+  [ "$status" -eq 3 ] || fail "preflight against an unreachable endpoint must exit 3, got $status"
+  case "$out" in *"is not answering"*) : ;; *) fail "the unreachable-endpoint refusal was not actionable: $out" ;; esac
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" check local-coder)
+  case "$out" in
+    blocked:*"stopped answering"*) : ;;
+    *) fail "the watcher check did not report the unreachable endpoint as blocked: '$out'" ;;
+  esac
+  case "$out" in
+    *"no longer loaded"*) fail "an unreachable endpoint must not be reported as an eviction" ;;
+  esac
+  pass "an unreachable endpoint exits 3 and wakes firstmate with its own distinct line"
+}
+
+# The short-context boundary is enforced, not documented. It is enforced against
+# the HEADROOM above the harness's own prompt, because that baseline - measured
+# at ~60k tokens on 2026-09-01 - is what actually consumes this window.
+test_oversized_brief_is_refused() {
+  local url brief out status n
+  url=$(endpoint oversize loaded 65536)
+
+  # Baseline 45536 against a 65536 window leaves 20000 tokens of headroom, so
+  # the default 25% share is a 5000-token allowance.
+  brief="$TMP_ROOT/small-brief.md"
+  printf 'do one small thing\n' > "$brief"
+  FM_LOCAL_MODEL_ENDPOINT="$url" FM_LOCAL_MODEL_HARNESS_BASELINE=45536 \
+    "$LOCAL_MODEL" brief-fits local-coder "$brief" >/dev/null \
+    || fail "a small brief was refused inside the headroom"
+
+  brief="$TMP_ROOT/big-brief.md"
+  : > "$brief"
+  n=0
+  while [ "$n" -lt 400 ]; do
+    printf 'this is a hundred bytes of brief text repeated to build an oversized brief for the refusal case aaa\n' >> "$brief"
+    n=$(( n + 1 ))
+  done
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" FM_LOCAL_MODEL_HARNESS_BASELINE=45536 \
+    "$LOCAL_MODEL" brief-fits local-coder "$brief" 2>&1)
+  status=$?
+  [ "$status" -eq 6 ] || fail "an oversized brief must exit 6, got $status"
+  case "$out" in *"too large for the local model runtime"*) : ;; *) fail "the oversize refusal was not explicit: $out" ;; esac
+  case "$out" in *"SHORT-CONTEXT"*) : ;; *) fail "the oversize refusal did not state the boundary: $out" ;; esac
+  case "$out" in *"after the harness"*) : ;; *) fail "the oversize refusal did not attribute the window to the harness prompt: $out" ;; esac
+
+  pass "a brief beyond the headroom is refused with the numbers behind the refusal"
+}
+
+# The failure this runtime actually hits by default: the harness's own prompt
+# nearly fills the loaded window, leaving nothing for the task. That is refused
+# outright, with the one action that fixes it, rather than accepted and then
+# silently compacted against a window the server does not have.
+test_no_headroom_is_refused_with_the_fix() {
+  local url out status
+  url=$(endpoint headroom loaded 65536)
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" FM_LOCAL_MODEL_HARNESS_BASELINE=60000 \
+    "$LOCAL_MODEL" headroom local-coder) || fail "a window with headroom was refused"
+  [ "$out" = 5536 ] || fail "headroom must be window minus baseline, got '$out'"
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" FM_LOCAL_MODEL_HARNESS_BASELINE=65536 \
+    "$LOCAL_MODEL" headroom local-coder 2>&1)
+  status=$?
+  [ "$status" -eq 7 ] || fail "a window with no headroom must exit 7, got $status"
+  case "$out" in *"no usable context headroom"*) : ;; *) fail "the no-headroom refusal was not explicit: $out" ;; esac
+  case "$out" in *"loaded context length"*) : ;; *) fail "the no-headroom refusal did not name the fix: $out" ;; esac
+
+  # A brief cannot slip through a window that has no room for the harness itself.
+  printf 'tiny\n' > "$TMP_ROOT/tiny.md"
+  FM_LOCAL_MODEL_ENDPOINT="$url" FM_LOCAL_MODEL_HARNESS_BASELINE=70000 \
+    "$LOCAL_MODEL" brief-fits local-coder "$TMP_ROOT/tiny.md" >/dev/null 2>&1
+  status=$?
+  [ "$status" -eq 7 ] || fail "even a tiny brief must be refused with exit 7 when there is no headroom, got $status"
+
+  pass "a window the harness prompt alone fills is refused with the action that fixes it"
+}
+
+# A ceiling that is present but not a positive integer is an operator mistake
+# that must never read as "no limit". An EMPTY value is deliberately not in that
+# set: it carries no number, so it means "unset" under ordinary environment
+# semantics and falls back to the compiled default ceiling - which is a bound,
+# not an absence of one. The asserted contrast is the point: every malformed
+# value is refused, and the one value that is merely absent still lands on a
+# real ceiling rather than opening the window.
+test_bad_ceiling_is_refused() {
+  local url status v out
+  url=$(endpoint ceiling loaded 65536)
+  for v in 0 abc -1 12.5 ' '; do
+    FM_LOCAL_MODEL_ENDPOINT="$url" FM_LOCAL_MODEL_MAX_CONTEXT="$v" \
+      "$LOCAL_MODEL" context-budget local-coder >/dev/null 2>&1
+    status=$?
+    [ "$status" -eq 2 ] || fail "ceiling '$v' must be refused with exit 2, got $status"
+  done
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" FM_LOCAL_MODEL_MAX_CONTEXT= \
+    "$LOCAL_MODEL" context-budget local-coder) \
+    || fail "an empty ceiling must fall back to the default, not refuse"
+  [ "$out" = 65536 ] || fail "an empty ceiling must land on a real bound, got '$out'"
+
+  pass "a malformed ceiling is refused, and an absent one falls back to a real bound"
+}
+
+test_loaded_model_and_budget
+test_evicted_model_is_loud
+test_absent_model_names_the_gap
+test_unreachable_endpoint_is_loud_and_distinct
+test_oversized_brief_is_refused
+test_no_headroom_is_refused_with_the_fix
+test_bad_ceiling_is_refused

--- a/tests/fm-local-model.test.sh
+++ b/tests/fm-local-model.test.sh
@@ -23,6 +23,9 @@
 #   4. The boundary that actually bites is the HEADROOM above the harness's own
 #      prompt, measured at ~60k tokens on 2026-09-01. An oversized brief - and a
 #      window with no headroom at all - is REFUSED, not silently degraded.
+#   5. LOCAL means loopback. The endpoint becomes the worker's
+#      ANTHROPIC_BASE_URL, so a remote host is refused before any request is
+#      made rather than quietly shipping the brief and transcript off the box.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -335,6 +338,73 @@ test_bad_ceiling_is_refused() {
   pass "a malformed ceiling is refused, and an absent one falls back to a real bound"
 }
 
+# The endpoint becomes the worker's ANTHROPIC_BASE_URL, so it decides where the
+# brief, every file the worker reads, and its whole tool transcript are sent. A
+# remote host would make "local model" a name for shipping the repository off
+# the machine, silently and with no error at all, so it is refused before any
+# request is made. The two halves are asserted together because a guard that
+# refused everything would pass the refusal half alone: a loopback endpoint must
+# still reach the network, and a loopback host that merely LOOKS like one
+# (127.0.0.1.evil.example) must not.
+test_remote_endpoint_is_refused() {
+  local url out status bad
+  url=$(endpoint loopback loaded 65536)
+
+  # Accepted: the empty-authority file:// fixture the rest of this suite uses,
+  # and a real loopback HOST in the authority, both fetched by the real curl.
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" model-state local-coder) \
+    || fail "an empty-authority endpoint was refused"
+  [ "$out" = loaded ] || fail "expected 'loaded' from the local endpoint, got '$out'"
+  out=$(FM_LOCAL_MODEL_ENDPOINT="file://localhost$TMP_ROOT/loopback" \
+    "$LOCAL_MODEL" model-state local-coder) \
+    || fail "a localhost endpoint was refused"
+  [ "$out" = loaded ] || fail "expected 'loaded' from the localhost endpoint, got '$out'"
+
+  # A loopback ADDRESS reaches the network: with nothing listening it must fail
+  # as unreachable (3), never as a refused configuration (2).
+  FM_LOCAL_MODEL_ENDPOINT=http://127.0.0.1:1 FM_LOCAL_MODEL_TIMEOUT=2 \
+    "$LOCAL_MODEL" probe >/dev/null 2>&1
+  status=$?
+  [ "$status" -eq 3 ] || fail "a loopback address must reach the endpoint check, got exit $status"
+
+  for bad in http://remote-host.example:1234 http://127.0.0.1.evil.example:1234 \
+    'http://[2001:db8::1]:1234' http://127.0.0.1@evil.example:1234 file://evil.example/catalog; do
+    FM_LOCAL_MODEL_ENDPOINT="$bad" FM_LOCAL_MODEL_TIMEOUT=2 \
+      "$LOCAL_MODEL" model-state local-coder >/dev/null 2>&1
+    status=$?
+    [ "$status" -eq 2 ] || fail "endpoint '$bad' must be refused with exit 2, got $status"
+  done
+
+  # The refusal has to be actionable on its own: it names the endpoint, the
+  # variable that sets it, and what is allowed instead.
+  out=$(FM_LOCAL_MODEL_ENDPOINT=http://remote-host.example:1234 \
+    "$LOCAL_MODEL" preflight local-coder 2>&1)
+  case "$out" in
+    *"http://remote-host.example:1234"*) : ;;
+    *) fail "the remote-endpoint refusal did not name the endpoint: $out" ;;
+  esac
+  case "$out" in
+    *FM_LOCAL_MODEL_ENDPOINT*) : ;;
+    *) fail "the remote-endpoint refusal did not name the variable: $out" ;;
+  esac
+  case "$out" in
+    *127.0.0.0/8*) : ;;
+    *) fail "the remote-endpoint refusal did not say what is allowed: $out" ;;
+  esac
+
+  # The watcher poll shares the same boundary. A remote endpoint must be a
+  # refusal there too, never a wake line blaming a server that stopped
+  # answering - that would send the operator to restart LM Studio when the real
+  # fault is the endpoint they configured.
+  out=$(FM_LOCAL_MODEL_ENDPOINT=http://remote-host.example:1234 \
+    "$LOCAL_MODEL" check local-coder 2>/dev/null)
+  status=$?
+  [ "$status" -eq 2 ] || fail "the watcher check must refuse a remote endpoint, got exit $status"
+  [ -z "$out" ] || fail "the watcher check misreported a remote endpoint as a wake: $out"
+
+  pass "the endpoint is confined to loopback, and a loopback endpoint still reaches the network"
+}
+
 test_loaded_model_and_budget
 test_evicted_model_is_loud
 test_absent_model_names_the_gap
@@ -345,3 +415,4 @@ test_oversized_brief_is_refused
 test_no_headroom_is_refused_with_the_fix
 test_wrong_shaped_catalog_is_not_reported_as_eviction
 test_bad_ceiling_is_refused
+test_remote_endpoint_is_refused

--- a/tests/fm-local-model.test.sh
+++ b/tests/fm-local-model.test.sh
@@ -55,6 +55,26 @@ dead_endpoint() {
   printf 'file://%s\n' "$TMP_ROOT/dead"
 }
 
+missing_loaded_window_endpoint() {
+  local dir
+  dir="$TMP_ROOT/missing-window/api/v0"
+  mkdir -p "$dir"
+  cat > "$dir/models" <<'EOF'
+{"object":"list","data":[
+ {"id":"local-coder","object":"model","type":"llm","state":"loaded","max_context_length":262144}
+]}
+EOF
+  printf 'file://%s\n' "$TMP_ROOT/missing-window"
+}
+
+unreadable_catalog_endpoint() {
+  local dir
+  dir="$TMP_ROOT/unreadable/api/v0"
+  mkdir -p "$dir"
+  printf '<html>another service</html>\n' > "$dir/models"
+  printf 'file://%s\n' "$TMP_ROOT/unreadable"
+}
+
 # A loaded model is reported loaded, and the budget is the smaller of the
 # server's own loaded window and the firstmate ceiling - in BOTH directions, so
 # neither side can be the only one that ever binds.
@@ -153,6 +173,41 @@ test_unreachable_endpoint_is_loud_and_distinct() {
   pass "an unreachable endpoint exits 3 and wakes firstmate with its own distinct line"
 }
 
+test_loaded_model_without_loaded_window_is_refused() {
+  local url out status
+  url=$(missing_loaded_window_endpoint)
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" context-budget local-coder 2>&1)
+  status=$?
+  [ "$status" -eq 4 ] || fail "a loaded model without a loaded window must exit 4, got $status"
+  case "$out" in *"no positive loaded context length"*) : ;; *) fail "missing loaded window did not explain the refusal: $out" ;; esac
+
+  FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" headroom local-coder >/dev/null 2>&1
+  status=$?
+  [ "$status" -eq 4 ] || fail "headroom must refuse a model without a loaded window, got $status"
+
+  pass "a loaded model without loaded_context_length is refused instead of using its maximum"
+}
+
+test_unreadable_catalog_wakes_once() {
+  local url out
+  url=$(unreadable_catalog_endpoint)
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" check local-coder) \
+    || fail "check exited nonzero for an unreadable catalog"
+  [ "$(printf '%s\n' "$out" | wc -l | tr -d ' ')" = 1 ] \
+    || fail "an unreadable catalog must print exactly one wake line"
+  case "$out" in
+    blocked:*"unreadable catalog"*) : ;;
+    *) fail "an unreadable catalog did not produce its own wake line: '$out'" ;;
+  esac
+  case "$out" in
+    *"no longer loaded"*|*"stopped answering"*) fail "an unreadable catalog was confused with another failure: '$out'" ;;
+  esac
+
+  pass "an unreadable catalog wakes firstmate with one distinct actionable line"
+}
+
 # The short-context boundary is enforced, not documented. It is enforced against
 # the HEADROOM above the harness's own prompt, because that baseline - measured
 # at ~60k tokens on 2026-09-01 - is what actually consumes this window.
@@ -244,6 +299,8 @@ test_loaded_model_and_budget
 test_evicted_model_is_loud
 test_absent_model_names_the_gap
 test_unreachable_endpoint_is_loud_and_distinct
+test_loaded_model_without_loaded_window_is_refused
+test_unreadable_catalog_wakes_once
 test_oversized_brief_is_refused
 test_no_headroom_is_refused_with_the_fix
 test_bad_ceiling_is_refused

--- a/tests/fm-local-model.test.sh
+++ b/tests/fm-local-model.test.sh
@@ -367,13 +367,17 @@ test_remote_endpoint_is_refused() {
   status=$?
   [ "$status" -eq 3 ] || fail "a loopback address must reach the endpoint check, got exit $status"
 
-  # The last three are the same trick through each delimiter that ends a URL
-  # authority: a loopback address placed after '@', '?' or '#' is userinfo or
-  # query/fragment text, never the host a client resolves.
+  # The tail of this table is the same trick through every delimiter that ends
+  # a URL authority: a loopback address placed after '@', '?', '#' or '\' is
+  # userinfo, query, fragment or path text, never the host a client resolves.
+  # The backslash forms matter because the WHATWG parser Node and undici use
+  # for ANTHROPIC_BASE_URL ends the authority there while RFC 3986 does not.
   for bad in http://remote-host.example:1234 http://127.0.0.1.evil.example:1234 \
     'http://[2001:db8::1]:1234' file://evil.example/catalog \
     http://127.0.0.1@evil.example:1234 \
-    'http://evil.example?@127.0.0.1' 'http://evil.example#@127.0.0.1'; do
+    'http://evil.example?@127.0.0.1' 'http://evil.example#@127.0.0.1' \
+    'http://evil.example\@127.0.0.1:1234' 'http://evil.example\a@127.0.0.1' \
+    'http://evil.example:80\@localhost' 'https://evil.example\@[::1]'; do
     FM_LOCAL_MODEL_ENDPOINT="$bad" FM_LOCAL_MODEL_TIMEOUT=2 \
       "$LOCAL_MODEL" model-state local-coder >/dev/null 2>&1
     status=$?

--- a/tests/fm-local-model.test.sh
+++ b/tests/fm-local-model.test.sh
@@ -372,12 +372,16 @@ test_remote_endpoint_is_refused() {
   # userinfo, query, fragment or path text, never the host a client resolves.
   # The backslash forms matter because the WHATWG parser Node and undici use
   # for ANTHROPIC_BASE_URL ends the authority there while RFC 3986 does not.
+  # The last four have no scheme or no authority at all: an empty authority
+  # means "reaches no host" only under file://, so under any other spelling it
+  # is a value this gate must not read as loopback.
   for bad in http://remote-host.example:1234 http://127.0.0.1.evil.example:1234 \
     'http://[2001:db8::1]:1234' file://evil.example/catalog \
     http://127.0.0.1@evil.example:1234 \
     'http://evil.example?@127.0.0.1' 'http://evil.example#@127.0.0.1' \
     'http://evil.example\@127.0.0.1:1234' 'http://evil.example\a@127.0.0.1' \
-    'http://evil.example:80\@localhost' 'https://evil.example\@[::1]'; do
+    'http://evil.example:80\@localhost' 'https://evil.example\@[::1]' \
+    //evil.example:1234 127.0.0.1:1234 http:/// 'http://'; do
     FM_LOCAL_MODEL_ENDPOINT="$bad" FM_LOCAL_MODEL_TIMEOUT=2 \
       "$LOCAL_MODEL" model-state local-coder >/dev/null 2>&1
     status=$?

--- a/tests/fm-local-model.test.sh
+++ b/tests/fm-local-model.test.sh
@@ -270,6 +270,46 @@ test_no_headroom_is_refused_with_the_fix() {
   pass "a window the harness prompt alone fills is refused with the action that fixes it"
 }
 
+# A body that PARSES but is not shaped like a catalog must take the unreadable
+# path, never the eviction path. This is the other half of the unreadable-catalog
+# distinction: the earlier case covers bodies that fail to parse, and without
+# this one a wrong-shaped body still yields a confident "no longer loaded",
+# sending an operator to reload a model when the real fault is that something
+# other than the model server is answering on that port.
+test_wrong_shaped_catalog_is_not_reported_as_eviction() {
+  local dir url out status shape
+  for shape in '{"data":{}}' '{"data":"nope"}' '{"data":null}'; do
+    dir="$TMP_ROOT/shaped$RANDOM/api/v0"
+    mkdir -p "$dir"
+    printf '%s' "$shape" > "$dir/models"
+    url="file://$(dirname "$(dirname "$dir")")"
+
+    out=$(FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" check local-coder)
+    case "$out" in
+      *"no longer loaded"*) fail "shape $shape was reported as an eviction: '$out'" ;;
+    esac
+    case "$out" in
+      blocked:*"unreadable catalog"*) : ;;
+      *) fail "shape $shape did not produce the unreadable-catalog line: '$out'" ;;
+    esac
+    [ "$(printf '%s\n' "$out" | wc -l | tr -d ' ')" = 1 ] \
+      || fail "the watcher check must print exactly one line for shape $shape"
+
+    FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" model-state local-coder >/dev/null 2>&1
+    status=$?
+    [ "$status" -eq 5 ] || fail "shape $shape must exit 5 (unreadable), got $status"
+  done
+
+  # The contrast that keeps this from going vacuous: a well-formed catalog that
+  # genuinely lacks the model still reports absent, not unreadable.
+  url=$(endpoint shaped-contrast loaded 65536)
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" "$LOCAL_MODEL" model-state no-such-model) \
+    || fail "a well-formed catalog missing the model must not be unreadable"
+  [ "$out" = absent ] || fail "expected 'absent' for a missing model, got '$out'"
+
+  pass "a parseable but wrong-shaped catalog reports unreadable, never a false eviction"
+}
+
 # A ceiling that is present but not a positive integer is an operator mistake
 # that must never read as "no limit". An EMPTY value is deliberately not in that
 # set: it carries no number, so it means "unset" under ordinary environment
@@ -287,7 +327,7 @@ test_bad_ceiling_is_refused() {
     [ "$status" -eq 2 ] || fail "ceiling '$v' must be refused with exit 2, got $status"
   done
 
-  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" FM_LOCAL_MODEL_MAX_CONTEXT= \
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" FM_LOCAL_MODEL_MAX_CONTEXT='' \
     "$LOCAL_MODEL" context-budget local-coder) \
     || fail "an empty ceiling must fall back to the default, not refuse"
   [ "$out" = 65536 ] || fail "an empty ceiling must land on a real bound, got '$out'"
@@ -303,4 +343,5 @@ test_loaded_model_without_loaded_window_is_refused
 test_unreadable_catalog_wakes_once
 test_oversized_brief_is_refused
 test_no_headroom_is_refused_with_the_fix
+test_wrong_shaped_catalog_is_not_reported_as_eviction
 test_bad_ceiling_is_refused

--- a/tests/fm-local-model.test.sh
+++ b/tests/fm-local-model.test.sh
@@ -367,8 +367,13 @@ test_remote_endpoint_is_refused() {
   status=$?
   [ "$status" -eq 3 ] || fail "a loopback address must reach the endpoint check, got exit $status"
 
+  # The last three are the same trick through each delimiter that ends a URL
+  # authority: a loopback address placed after '@', '?' or '#' is userinfo or
+  # query/fragment text, never the host a client resolves.
   for bad in http://remote-host.example:1234 http://127.0.0.1.evil.example:1234 \
-    'http://[2001:db8::1]:1234' http://127.0.0.1@evil.example:1234 file://evil.example/catalog; do
+    'http://[2001:db8::1]:1234' file://evil.example/catalog \
+    http://127.0.0.1@evil.example:1234 \
+    'http://evil.example?@127.0.0.1' 'http://evil.example#@127.0.0.1'; do
     FM_LOCAL_MODEL_ENDPOINT="$bad" FM_LOCAL_MODEL_TIMEOUT=2 \
       "$LOCAL_MODEL" model-state local-coder >/dev/null 2>&1
     status=$?

--- a/tests/fm-local-model.test.sh
+++ b/tests/fm-local-model.test.sh
@@ -338,6 +338,27 @@ test_bad_ceiling_is_refused() {
   pass "a malformed ceiling is refused, and an absent one falls back to a real bound"
 }
 
+# curl treats a zero max-time as no timeout at all. The endpoint owner must
+# refuse that configuration before the request path so a stalled LM Studio
+# server cannot make preflight or watcher polling wait indefinitely.
+test_bad_timeout_is_refused() {
+  local url status v out
+  url=$(endpoint timeout loaded 65536)
+  for v in 0 abc -1 1.5 ' '; do
+    out=$(FM_LOCAL_MODEL_ENDPOINT="$url" FM_LOCAL_MODEL_TIMEOUT="$v" \
+      "$LOCAL_MODEL" probe 2>&1)
+    status=$?
+    [ "$status" -eq 2 ] || fail "timeout '$v' must be refused with exit 2, got $status"
+    case "$out" in *FM_LOCAL_MODEL_TIMEOUT*) : ;; *) fail "timeout '$v' refusal did not name its setting: $out" ;; esac
+  done
+
+  out=$(FM_LOCAL_MODEL_ENDPOINT="$url" FM_LOCAL_MODEL_TIMEOUT='' \
+    "$LOCAL_MODEL" probe) || fail "an empty timeout must fall back to the bounded default"
+  case "$out" in ok:*) : ;; *) fail "an empty timeout did not reach the healthy endpoint: $out" ;; esac
+
+  pass "a zero or malformed endpoint timeout is refused, and an absent one remains bounded"
+}
+
 # The endpoint becomes the worker's ANTHROPIC_BASE_URL, so it decides where the
 # brief, every file the worker reads, and its whole tool transcript are sent. A
 # remote host would make "local model" a name for shipping the repository off
@@ -428,4 +449,5 @@ test_oversized_brief_is_refused
 test_no_headroom_is_refused_with_the_fix
 test_wrong_shaped_catalog_is_not_reported_as_eviction
 test_bad_ceiling_is_refused
+test_bad_timeout_is_refused
 test_remote_endpoint_is_refused

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -2148,3 +2148,56 @@ test_bootstrap_leaves_unauthenticated_checks
 test_custom_snapshot_cleanup_on_signal
 test_returned_custom_check_descendants_are_drained
 test_teardown_removes_poll_artifacts
+
+# state/<id>.check.sh is a single slot. A claude-local task keeps its
+# local-model eviction watcher there, so arming a merge poll on such a task
+# would silently replace the watcher and leave the worker's stall detection
+# gone. The poll is refused instead, before the record is touched, and the
+# refusal names the retirement command that hands the slot over deliberately.
+test_claude_local_eviction_watcher_is_not_overwritten() {
+  local dir state before after rc
+  dir=$(make_case claude-local-slot)
+  state="$dir/home/state"
+  fm_write_meta "$state/task-a.meta" \
+    "window=firstmate:fm-task-a" \
+    "endpoint_task_id=task-a" \
+    "worktree=$dir/wt" \
+    "project=$dir/project" \
+    "harness=claude-local" \
+    "kind=scout"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$state/task-a.check.sh"
+  chmod 0700 "$state/task-a.check.sh"
+  FM_HOME="$dir/home" "$REGISTER" task-a >/dev/null 2>&1 \
+    || fail "the eviction watcher fixture could not be registered"
+  fm_custom_check_registered "$state" task-a || fail "the fixture watcher was not registered"
+  before=$(state_snapshot "$state")
+
+  rc=0
+  run_check_entry "$dir" task-a https://github.com/my-org/repo/pull/7 \
+    > "$dir/stdout" 2> "$dir/stderr" || rc=$?
+  [ "$rc" -eq 1 ] || fail "arming a poll over a claude-local eviction watcher should be refused, got exit $rc"
+  grep -q 'eviction watcher' "$dir/stderr" \
+    || fail "the refusal did not say what occupies the slot: $(cat "$dir/stderr")"
+  grep -q 'fm-check-unregister.sh task-a' "$dir/stderr" \
+    || fail "the refusal did not name the retirement command: $(cat "$dir/stderr")"
+  after=$(state_snapshot "$state")
+  [ "$before" = "$after" ] \
+    || fail "a refused poll changed task state:"$'\n'"$before"$'\n---\n'"$after"
+  fm_custom_check_registered "$state" task-a \
+    || fail "the eviction watcher was not left registered after the refusal"
+  ! grep -q '^pr=' "$state/task-a.meta" \
+    || fail "a refused poll recorded a pr= line for a poll that was never armed"
+
+  # Deliberate hand-over: once the watcher is retired the same command arms.
+  FM_HOME="$dir/home" "$ROOT/bin/fm-check-unregister.sh" task-a >/dev/null 2>&1 \
+    || fail "the fixture watcher could not be retired"
+  run_check_entry "$dir" task-a https://github.com/my-org/repo/pull/7 \
+    > "$dir/stdout" 2> "$dir/stderr" || fail "the poll did not arm once the slot was free: $(cat "$dir/stderr")"
+  cmp -s "$POLL" "$state/task-a.check.sh" || fail "the armed poll was not the static template"
+  fm_pr_poll_artifacts_valid "$state" task-a "$POLL" \
+    || fail "the poll armed after hand-over was not valid"
+
+  pass "fm-pr-check refuses to overwrite a claude-local eviction watcher and arms once it is retired"
+}
+
+test_claude_local_eviction_watcher_is_not_overwritten


### PR DESCRIPTION
## Intent

Make the captain local model usable as a firstmate worker runtime for explicit, short-context, local work, verified empirically before adapter code rather than assumed. Use the claude CLI against LM Studio at http://127.0.0.1:1234 with model qwen3-coder-next-mlx, and record observed launch, trust, semantic busy or honest unknown, turn-end, interrupt, exit, resume, skill invocation, and end-to-end Anthropic-compatible tool use, marking anything unestablished rather than guessing. Wire only the harness-adapter owners for detection, launch, semantic busy, shared composer classification, control, hooks, model discovery, and verification evidence, without changing existing harness dispatch or duplicating shared classifier shapes. Enforce the captain constraint of local and short-context work only with a bounded launch context and a loud refusal when the harness baseline, brief, or task exceeds usable headroom. Detect both a stopped LM Studio server and an unloaded or evicted model with clear actionable failures instead of silent stalls. Keep claude-local explicit opt-in only, unavailable from static defaults, unavailable for secondmates, and refused for no-mistakes shipping; ordinary shipping behavior must remain unchanged. Provide behavioral tests proving opt-in, context refusal, endpoint and model disappearance diagnostics, and public adapter behavior, with colocated tests and shellcheck-clean scripts. Preserve the empirical conclusion that no supervised local-model turn completed: claude-local is not trustworthy for unattended work, and unestablished turn-end, exit, resume, and skill behavior remain labeled unestablished rather than overstated. Let the no-mistakes pipeline perform the rebase onto current main and land the branch without changing global review timeout configuration or retrying if the review stage again reaches its 30-minute bound.

## What Changed

- Add the opt-in `claude-local` harness, which launches Claude CLI against a loopback LM Studio endpoint, validates the selected loaded model, and enforces a bounded local-context budget.
- Integrate the adapter with dispatch validation, shared Claude busy classification, lifecycle control and relaunch safeguards; refuse static-default, secondmate, no-mistakes, non-loopback, unavailable-model, and insufficient-headroom use.
- Document the empirically established and unestablished runtime behavior, and add coverage for local-model diagnostics, dispatch/control boundaries, watcher handling, and PR-check safety.

## Risk Assessment

⚠️ Medium: The implementation is well-contained and its lifecycle safeguards are extensively covered, but an accepted zero timeout can defeat the runtime's bounded failure handling.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 3 runs (3h52m32s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2f4e03466d841d2d28a037fc0ea0d509f0a1ebea","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-spawn.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- 🚨 `bin/fm-spawn.sh:1402` - The raw-alias guard only examines the first non-assignment word. `env claude-local --model local-coder` (or `command claude-local ...`) sets `HARNESS=env` and is accepted as a generic raw launch, then executes `claude-local` without the canonical endpoint, model, or context-bound template. This contradicts the required “bounded launch context” / claude-local opt-in constraint; broaden the rejection to raw wrapper forms that execute `claude-local`, or explicitly authorize this escape hatch.

🔧 Fix: Reject wrapped raw claude-local launches
2 errors still open:

- 🚨 `bin/fm-spawn.sh:1405` - Required intent says claude-local must have a “bounded launch context.” The new wrapper guard still accepts effective local launches: `env -- LOCAL=1 claude-local --model local-coder` breaks at `--` and treats `LOCAL=1` as the executable, while `env -S &#39;claude-local --model local-coder&#39;` is swallowed by the generic `-*` branch. Both execute raw claude-local without the endpoint/model/context template. Conservatively reject these env forms through the existing refusal path (rather than adding general shell parsing) and exercise them through fm-spawn.
- 🚨 `bin/fm-spawn.sh:1427` - Required intent says claude-local is “explicit opt-in only, unavailable from static defaults.” A configured crew-dispatch default can resolve claude-local and pass it as a concrete positional harness; `HARNESS_EXPLICIT=1` then classifies it as explicit. The added adapter reference explicitly codifies the conflicting rule: “only an explicit per-spawn harness or a dispatch profile reaches it.” Deciding whether a dispatch-profile default is an authorized opt-in needs clarification; otherwise preserve selection provenance or reject claude-local from profile defaults.

🔧 Fix: Harden claude-local dispatch safeguards
1 error still open:

- 🚨 `bin/fm-spawn.sh:1428` - The new raw-wrapper guard still misses supported env split-string syntax: `env --split-string=&#39;claude-local --model local-coder&#39;` is consumed by the generic `-*` branch, so the original raw command is sent to the pane and launches `claude-local` outside the canonical endpoint/model/context template. Conversely, `env -S &#39;echo claude-local&#39;` is rejected just because a later argument contains the substring, changing an ordinary raw launch. This contradicts the required bounded, explicit-only claude-local path; recognize env’s attached/`=` split-string forms and identify only its effective executable.

🔧 Fix: Parse env split-string claude-local launches
2 issues (1 error, 1 warning) still open:

- 🚨 `bin/fm-spawn.sh:1408` - Required bounded launch context remains bypassable through env’s supported split-string grammar. `env -S &#34;X=&#39;two words&#39; claude-local --model local-coder&#34;` is tokenized by line 1424 into a partial assignment and `words&#39;`; line 1416 stops before `claude-local`, so the raw command is accepted and then the shell correctly runs claude-local unbounded. This contradicts the required “bounded launch context”; parse quoted assignment values within env split strings and add this observable refusal case.
- ⚠️ `bin/fm-spawn.sh:1535` - Matched claude-local dispatch profiles are advertised as an allowed opt-in at line 1535, but bootstrap’s shared profile validator still omits it from `verified()` (bin/fm-bootstrap.sh:1107). A rule profile selecting claude-local is therefore labeled `CREW_DISPATCH: invalid ... unverified harness`, while the added “matched rule” test merely passes `--harness` directly and misses the real consumer. Add claude-local to that validator and exercise the validator with a matched profile; static defaults remain refused by fm-spawn.

🔧 Fix: Validate matched claude-local dispatch profiles
1 warning still open:

- ⚠️ `bin/fm-spawn.sh:3453` - After a successful fresh backlog commit, `trap - HUP INT TERM` restores terminating signal behavior before `LOCAL_MODEL_CHECK_PENDING` is cleared. A SIGTERM in that window runs the EXIT cleanup, unregistering the watcher even though the task record and delivered worker are preserved; the worker can then silently stall on endpoint/model eviction. Clear the flag after the successful-status check but before restoring those signal traps.

🔧 Fix: Preserve watcher after successful fresh dispatch
2 errors still open:

- 🚨 `bin/fm-spawn.sh:1339` - `claude-local` launches the same `claude` fleet worker but omits the two feedback-draft suppressors retained for `claude` from incoming main commit 3034912c. A local worker can therefore offer/create Claude feedback drafts, contrary to the selected rebase requirement to keep that incoming change. Apply `CLAUDE_CODE_SEND_FEEDBACK=0` and the `feedbackDrafts=off` settings argument to this template too.
- 🚨 `bin/fm-spawn.sh:2046` - The required intent says local work only and specifies LM Studio at `http://127.0.0.1:1234`, but this hunk accepts any `FM_LOCAL_MODEL_ENDPOINT` and bakes it into the worker launch. For example, `FM_LOCAL_MODEL_ENDPOINT=http://remote-host:1234` passes preflight and sends the task brief and tool traffic to that remote server without error. Decide whether remote endpoints are intentionally supported; otherwise enforce the local-only invariant at the shared `fm-local-model.sh` endpoint boundary (with an explicit test fixture allowance if needed).

🔧 Fix: Confine local-model endpoint to loopback, suppress feedback drafts
4 issues (1 warning, 3 infos) still open:

- ⚠️ `bin/fm-control.sh:814` - The pre-stop claude-local gates in `do_relaunch` cover kind, model, endpoint/model-loaded, and brief-fits, but not the `--mode no-mistakes` refusal that fm-spawn gate 3 enforces (bin/fm-spawn.sh:1546). Concrete sequence: a ship task recorded `mode=no-mistakes` with a live worker; `fm-control &lt;id&gt; relaunch --harness claude-local --model local-coder` passes `fm_control_harness_supports_kind` (kind is ship), passes the model gate (--model given), passes the preflight (endpoint healthy) and brief-fits, so fm-control records the note, stops the healthy worker, and only then fm-spawn reads `MODE` from the record (bin/fm-spawn.sh:1211) and refuses with &#34;not verified for no-mistakes&#34; - leaving no agent running. This is the same ordering hazard the user already ruled closed on the endpoint/model axis and the brief axis, left open on the mode axis; the new relaunch fixture even has to rewrite `mode=no-mistakes` to `direct-PR` (tests/fm-control-relaunch.test.sh, add_claude_local_task) to get past it, so the case is unexercised. The remedy is a new pre-stop gate in the control plane reading the recorded mode, which extends the change rather than correcting what it already does, so it needs authorization.
- ℹ️ `bin/fm-control.sh:842` - The pre-stop brief-fits preview always concatenates `progress_note_block`, but `record_note` (bin/fm-control.sh:795) returns early when `$NOTE` is empty, so a relaunch without `--note` is measured against ~400 bytes (~100 tokens) of boilerplate that will never be appended to the brief. On the reference configuration the allowance is 25% of ~5.5k headroom (~1.4k tokens), so a brief sitting in the top ~7% of the allowance is refused with &#34;instructions plus this progress note exceed the local model&#39;s usable headroom&#34; when the launch it predicts would in fact have fit - and there is no note. Gate the preview&#39;s note block on `[ -n &#34;$NOTE&#34; ]` so it measures exactly what record_note will write.
- ℹ️ `bin/fm-bootstrap.sh:1107` - Adding claude-local to the shared `verified()` list fixes the matched-rule case, but it also makes `crew_dispatch_validate` report a config whose DEFAULT profile names claude-local as valid, while every spawn that reaches that default is unconditionally refused (bin/fm-spawn.sh:1529 and 1013). The captain therefore gets a clean bootstrap for a configuration that can never dispatch, and the same config additionally turns a bare `fm-spawn &lt;id&gt; --relaunch` of an existing claude-local task (harness taken from the record, not from config) into a dispatch-default refusal. The smallest honest remedy is a new validator rule that distinguishes default from rule profiles, which extends the change beyond its stated intent and contradicts the standing ruling that only fm-spawn refuses static defaults, so the remedy - not the defect - is what needs authorization.
- ℹ️ `.agents/skills/harness-adapters/references/harness/claude-local.md:46` - &#34;Three findings drive its design&#34; now introduces four bullets: the loopback-host finding was inserted in the latest commit without updating the count. Say &#34;Four findings&#34; (or drop the count) so the reference does not misstate its own contents.

🔧 Fix: Gate claude-local relaunch on recorded mode and provenance
3 issues (1 warning, 2 infos) still open:

- ⚠️ `bin/fm-local-model.sh:115` - endpoint_host() ends the URL authority only at &#39;/&#39;, not at &#39;?&#39; or &#39;#&#39;, so the loopback confinement added in commit bab0e43 is bypassable. Verified by simulating the parser: ENDPOINT=&#39;http://evil.example?@127.0.0.1&#39; and &#39;http://evil.example#@127.0.0.1&#39; both yield host &#39;127.0.0.1&#39; and pass require_loopback_endpoint, while curl and Claude Code resolve the authority as evil.example. The value is then baked into the worker&#39;s ANTHROPIC_BASE_URL (bin/fm-spawn.sh:3277), so the brief, every file the worker reads, and its whole tool transcript are sent to the remote host with no error - the exact outcome the ruling &#39;fm-local-model.sh refuses any endpoint whose host is not loopback&#39; required to be impossible. tests/fm-local-model.test.sh covers the userinfo form (http://127.0.0.1@evil.example) but neither delimiter. Remedy is a correction inside the existing helper: truncate rest at the first &#39;/&#39;, &#39;?&#39;, or &#39;#&#39; before the &#39;##*@&#39; userinfo strip, and extend the refused-endpoint table with both forms.
- ℹ️ `bin/fm-spawn.sh:938` - clear_relaunch_harness_wiring runs fm-check-unregister.sh unconditionally when the PRIOR recorded harness is claude-local, and that script removes &lt;id&gt;.check.sh whatever occupies it (bin/fm-check-unregister.sh:48). Concrete reachable sequence: fm-pr-check now refuses a claude-local task while the eviction watcher is registered and tells the operator to run bin/fm-check-unregister.sh &lt;id&gt;; they do, arm the merge poll, and the record still says harness=claude-local. A later `bin/fm-spawn.sh &lt;id&gt; --relaunch` (a directly reachable entry point - tests/fm-control-relaunch.test.sh:1800 exercises exactly this form) deletes the poll shim, leaving &lt;id&gt;.pr-poll and &lt;id&gt;.pr-poll-registration orphaned and merge detection silently gone, then arms a fresh eviction watcher in the freed slot. fm-control&#39;s new pre-stop refusal (bin/fm-control.sh:808) covers only the control-plane path, so the accepted &#39;make the collision loud, nothing is silently overwritten&#39; ruling does not hold on this one. The smallest honest remedy - retiring only a trust-registered custom check, the narrower retirement a prior round already named as the follow-up - changes shared retirement semantics rather than correcting what this hunk does, so the remedy, not the defect, is what needs authorization.
- ℹ️ `bin/fm-control.sh:846` - The latest commit gates the pre-stop brief preview&#39;s progress-note block on [ -z &#34;$NOTE&#34; ], but the preview only runs when RELAUNCH_BRIEF is non-empty, and RELAUNCH_BRIEF is set only in the ship|scout branch (bin/fm-control.sh:826), which dies at line 830 unless --note (or --note-file) supplied a non-empty NOTE. So NOTE is never empty where the guard is evaluated: the added condition is inert, and the accompanying instruction to &#39;cover a no-note relaunch near the allowance&#39; has no reachable case to test (none was added). No functional risk - the preview still measures exactly what record_note writes - but the round-7 finding it answered rested on a premise the code does not permit, so no behavior actually changed.

🔧 Fix: Terminate endpoint authority and narrow check-slot retirement
2 issues (1 warning, 1 info) still open:

- ⚠️ `bin/fm-local-model.sh:120` - The loopback confinement is still bypassable. endpoint_host() now ends the URL authority at &#39;/&#39;, &#39;?&#39; and &#39;#&#39;, but not at &#39;\&#39;, which the WHATWG URL parser also treats as an authority terminator for special schemes - and that is the parser Node/undici (Claude Code) uses for ANTHROPIC_BASE_URL. Verified by simulating both parsers: ENDPOINT=&#39;http://evil.example\@127.0.0.1:1234&#39; yields host &#39;127.0.0.1&#39; from endpoint_host and passes require_loopback_endpoint, while `new URL(...)` resolves hostname &#39;evil.example&#39;. The same divergence holds for &#39;http://evil.example\a@127.0.0.1&#39;, &#39;http://evil.example:80\@localhost&#39; and &#39;https://evil.example\@[::1]&#39;. The value is then baked verbatim into the worker&#39;s ANTHROPIC_BASE_URL (bin/fm-spawn.sh:3287), so the brief, every file the worker reads and its whole tool transcript are sent to the remote host with no error - the outcome the ruling &#39;fm-local-model.sh refuses any endpoint whose host is not loopback&#39; required to be impossible. tests/fm-local-model.test.sh covers the userinfo, &#39;?&#39; and &#39;#&#39; forms but no backslash form. Remedy is a correction inside the existing helper, and it should stop the delimiter whack-a-mole rather than add a fourth one: after truncating at the first of &#39;/&#39;, &#39;?&#39;, &#39;#&#39; and &#39;\&#39;, refuse the endpoint outright when the remaining authority still contains &#39;@&#39; or &#39;\&#39; or any character outside [A-Za-z0-9.:_-] plus bracketed IPv6, instead of stripping userinfo and trusting whatever is left. Extend the refused-endpoint table with the backslash forms.
- ℹ️ `bin/fm-spawn.sh:2820` - The narrowed retirement correctly leaves a merge poll in state/&lt;id&gt;.check.sh alone, but the refusal that results is reached only after the prior incarnation&#39;s wiring has already been destroyed. Concrete reachable sequence: a claude-local task whose operator followed bin/fm-pr-check.sh:111 and ran fm-check-unregister to hand the slot to a merge poll (the record still says harness=claude-local); a later `bin/fm-spawn.sh &lt;id&gt; --relaunch` (a directly reachable entry point, exercised by tests/fm-control-relaunch.test.sh) runs clear_relaunch_harness_wiring at line 2810, which skips the poll as intended but then rm&#39;s $WT/.claude/settings.local.json (fm_control_harness_wiring_paths for the claude family - the semantic busy and turn-end hook source), and only then does arm_local_model_check at line 2820 fail on the occupied slot and exit 1. spawn_abort_cleanup clears the REPLACEMENT wiring; nothing restores the prior wiring, so a still-running worker is left with no hooks, and the operator sees only &#39;could not arm the local-model watcher check for &lt;id&gt;&#39; - which names neither the merge poll that holds the slot nor the retry that would recover it. This is materially different from the round-8 finding (the poll now survives; what is lost is the prior worker&#39;s supervision wiring). The smallest remedy is ordering - test the slot before clear_relaunch_harness_wiring, or make the arm failure explain the poll - but the round-8 instruction for this hunk said &#39;add no new refusal or message&#39;, so the remedy, not the defect, is what needs authorization.

🔧 Fix: Validate endpoint authority shape and order slot conflict check
3 warnings still open:

- ⚠️ `bin/fm-local-model.sh:133` - endpoint_host() treats a scheme-less protocol-relative endpoint as having NO authority and accepts it. Verified by executing the function body: FM_LOCAL_MODEL_ENDPOINT=&#39;//evil.example:1234&#39; prints an empty host and returns 0, so require_loopback_endpoint&#39;s &#39;&#39;-passes-as-file:// branch admits it. Root cause: ${ENDPOINT#*://} is a no-op when the value contains no &#39;://&#39;, and ${rest%%/*} on a leading &#39;//&#39; then empties the string, so &#39;no authority&#39; and &#39;authority the parser could not reach&#39; are indistinguishable. The round-9 ruling for this helper was &#39;only a clean loopback host (127.0.0.0/8, ::1, localhost) with an optional port passes&#39;; this shape passes without being one, and the refused-endpoint table in tests/fm-local-model.test.sh:370 covers no scheme-less form. This is not proven exfiltration - Node&#39;s URL constructor throws on &#39;//host&#39; as a base, so Claude Code fails rather than dialing out - but the whole point of the gate is that the verdict must not depend on each consumer&#39;s parser. Remedy is a correction inside the same helper: refuse an ENDPOINT that contains no &#39;://&#39; before the authority is parsed (case &#34;$ENDPOINT&#34; in *://*) ;; *) return 1 ;; esac). file:///path still passes, so the file:// catalog fixtures in tests/fm-claude-local-harness.test.sh keep working; a scheme-less 127.0.0.1:1234 would now be refused, which is correct since it is not a usable ANTHROPIC_BASE_URL either. Extend the refused table with &#39;//evil.example:1234&#39;.
- ⚠️ `bin/fm-spawn.sh:938` - local_model_check_slot_is_ours decides ownership of state/&lt;id&gt;.check.sh from the mere PRESENCE of &lt;id&gt;.pr-poll-registration, but bin/fm-check-unregister.sh:48 removes only &lt;id&gt;.check.sh and &lt;id&gt;.check-trust, so that registration can outlive the poll it described. Concrete reachable sequence: a claude-local task has a merge poll in the slot; the new pre-stop gate (bin/fm-spawn.sh:2813) refuses the relaunch with &#39;could not arm the local-model watcher check for &lt;id&gt;&#39; and names no alternative, so the operator runs the documented bin/fm-check-unregister.sh &lt;id&gt; to free the slot; &lt;id&gt;.pr-poll and &lt;id&gt;.pr-poll-registration are left behind; the relaunch now arms the watcher. From that point local_model_check_slot_is_ours is permanently false for the task, with two wrong outcomes: (a) every later claude-local relaunch is refused at line 2813 even though the slot holds this adapter&#39;s own watcher, each one requiring another manual unregister; (b) a relaunch onto a hosted harness (--harness claude, the natural recovery when the local model is gone) reaches clear_relaunch_harness_wiring at line 953, skips the unregister, and leaves the eviction watcher registered for a task no longer using the local endpoint - fm-watch then prints &#39;blocked: the local model server ... stopped answering&#39; every FM_CHECK_INTERVAL for the rest of the run. bin/fm-control.sh:773 already answers the identical question with fm_pr_poll_artifacts_valid, which returns false in exactly this state (it cmp&#39;s check.sh against fm-pr-poll.sh and re-verifies the registration&#39;s recorded hashes and identities), and fm-pr-lib.sh is already sourced in fm-spawn. The remedy - replacing the presence test with `! fm_pr_poll_artifacts_valid &#34;$state&#34; &#34;$id&#34; &#34;$SCRIPT_DIR/fm-pr-poll.sh&#34;` so both planes share one detector - deviates from the round-8 instruction&#39;s literal wording (&#39;detected by a PR-poll registration being present&#39;), so it is the remedy, not the defect, that needs authorization.
- ⚠️ `bin/fm-spawn.sh:805` - In spawn_abort_cleanup the `else LOCAL_MODEL_CHECK_PENDING=0` fires whenever clear_relaunch_harness_wiring returns 0, but that function returns 0 both when it retired the watcher and when it SKIPPED the retirement because local_model_check_slot_is_ours was false (line 953). Concrete sequence, reachable via the stale &lt;id&gt;.pr-poll-registration described in the ownership finding: a claude-local relaunch finds the slot empty, arms the watcher (LOCAL_MODEL_CHECK_PENDING=1 at line 990), then aborts before the commit point; clear_relaunch_harness_wiring skips the unregister because the stale registration is present, returns 0, line 805 clears the flag, and the unconditional retirement block at lines 814-821 is skipped - so state/&lt;id&gt;.check.sh and .check-trust stay registered after a relaunch that never produced a worker, the exact orphan class rounds 3-5 were required to make impossible. The flag clear is only an optimization: a second fm-check-unregister after a successful retirement finds no files, rm -f succeeds and it exits 0. Remedy is a correction within the existing flag machinery: drop the `else` and its assignment (lines 804-805) so the unconditional block always decides retirement, independent of whichever ownership detector clear_relaunch_harness_wiring used. Cover it with an aborted claude-local relaunch that leaves no registered check behind.

🔧 Fix: Require endpoint scheme and share live-poll slot detector
1 warning still open:

- ⚠️ `bin/fm-control.sh:809` - The pre-stop slot gate and the post-stop slot gate test different predicates, so a slot occupant that is neither a valid poll nor this adapter&#39;s registered watcher is only discovered after the worker has been stopped. fm-control asks `fm_pr_poll_artifacts_valid` (line 809); fm-spawn asks `check.sh exists &amp;&amp; ! local_model_check_slot_is_ours` (bin/fm-spawn.sh:2814), which additionally requires `fm_custom_check_registered`. Concrete reachable sequence: a claude-local direct-PR task hands its slot over as bin/fm-pr-check.sh documents, so state/&lt;id&gt;.check.sh holds a byte-copy of bin/fm-pr-poll.sh; bin/fm-pr-poll.sh is then changed by an ordinary firstmate update, so `cmp -s &#34;$template&#34; &#34;$check&#34;` in fm_pr_poll_artifacts_valid (bin/fm-pr-lib.sh:594) fails and the poll reads as invalid. The captain runs `fm-control relaunch &lt;id&gt; --note ...`: the line-809 gate passes (no valid poll), preflight and brief-fits pass, safe_checkpoint runs, record_note appends, do_exit STOPS the healthy worker - and then fm-spawn refuses at bin/fm-spawn.sh:2814 because check.sh exists and slot_is_ours is false (poll invalid, but no check-trust either), so fm-control dies with &#39;the replacement agent for &lt;id&gt; could not be launched&#39; and no worker is running. This is exactly the ordering hazard the accepted ruling closed for the poll and endpoint axes, left open for any other occupant of the slot. Remedy: have the pre-stop gate ask the same composite question fm-spawn&#39;s gate asks - refuse when state/&lt;id&gt;.check.sh exists and is not this adapter&#39;s own registered watcher. fm-control sources fm-pr-lib.sh but NOT fm-check-lib.sh, so the honest fix is to move local_model_check_slot_is_ours into a shared lib (fm-check-lib.sh) and call it from both planes rather than writing a second copy of the predicate. That widens the pre-stop refusal to a new class of state and moves a helper across an owner boundary, so it is the remedy, not the defect, that needs authorization.

- ⚠️ `bin/fm-local-model.sh:195` - `FM_LOCAL_MODEL_TIMEOUT` is passed directly to `curl -m` without validation. With `FM_LOCAL_MODEL_TIMEOUT=0`, curl disables its maximum-time limit, so a reachable but hung LM Studio endpoint can block preflight or the eviction watcher indefinitely—the silent-stall class this adapter is meant to surface. Validate a strictly positive bounded timeout before invoking curl.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Classify claude-local harness documentation
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>
