### PR TITLE
fix: converge cleanup after Treehouse already returned a copy

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -242,7 +242,7 @@ SSH exit 255 preserves the route and local records because remote completion is 
 When safe, teardown kills the direct endpoint, removes the `data/secondmates.md` route, clears the main home metadata, and removes the retired secondmate home.
 Removing a leased home releases its durable treehouse lease via `treehouse return`, so the pool slot is freed for reuse rather than left leased forever.
 A plain-clone home with no pool slot is simply removed.
-If `treehouse return` fails for a leased home, teardown stops with state intact rather than raw-removing the directory and hiding a held lease.
+If `treehouse return` fails for a leased home and the pool cannot prove that home's slot is already free, teardown stops with state intact rather than raw-removing the directory and hiding a held lease.
 Before either return or direct removal, teardown asks the target home's process-event runner to retire its registrations and physically owned machine-wide claims through the safe generation-bound path.
 It refuses retirement while that cleanup is uncertain or unavailable, preserving the home and retirement records for a later retry.
 Raw deletion is unsupported because a blocking process-event child can outlive its home.

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -140,9 +140,16 @@
 # relaxes a landed-work, dirty-tree, process, lock, endpoint, or ownership refusal -
 # it runs only after all of those have already passed. It is not a `--force` path.
 # The convergence lives in the backend-independent worktree-return step, so it is
-# shared by every treehouse-backed backend (tmux, herdr, zellij, cmux) and by the
-# secondmate-home lease release; `backend=orca` never reaches it, because Orca owns
-# its own worktrees and is removed through `orca worktree rm` instead.
+# shared by every treehouse-backed backend (tmux, herdr, zellij, cmux), by the
+# secondmate-home lease release, and by the forced-secondmate child-worktree return;
+# `backend=orca` never reaches it, because Orca owns its own worktrees and is removed
+# through `orca worktree rm` instead. The child-worktree site is the one place where
+# the convergence decides more than abort-versus-continue: a failed return there falls
+# through to safe_rm_rf_child_worktree, which `rm -rf`s the copy, so a child slot
+# treehouse had already auto-returned used to be erased out from under the pool. A
+# child copy proven back in the pool is now left alone instead. A child worktree that
+# is NOT a pool slot never appears in the listing, so it still refuses and still falls
+# through to that same fallback.
 #
 # Pre-teardown cleanup sequence (runs once every landed/discard-work safety
 # refusal above has already passed, and BEFORE any worktree return, branch
@@ -1405,7 +1412,7 @@ teardown_treehouse_already_returned() {  # <dir> <cd_dir> <label>
   local entry_line entry_index path
   local hit_index="" hit_fields=""
   local hit_state="" hit_lease_id="" hit_lease_holder="" hit_leased_at="" hit_procs=""
-  local entry_canon copy_repo project_canon project_repo
+  local entry_canon copy_repo project_canon project_repo leased_at_desc
 
   want=$(canonical_existing_dir "$dir") || {
     echo "teardown: $label return reported $dir is not managed by this pool, but $dir is not an inspectable directory, so it cannot be proven already returned; aborting" >&2
@@ -1488,7 +1495,8 @@ EOF
   if [ "$hit_state" != available ] \
      || [ -n "$hit_lease_id" ] || [ -n "$hit_lease_holder" ] || [ -n "$hit_leased_at" ] \
      || [ "$hit_procs" != 0 ]; then
-    echo "teardown: $label return reported $dir is not managed by this pool, but the pool still reports that copy as '${hit_state:-unknown}' (lease '${hit_lease_id:-}', holder '${hit_lease_holder:-}', ${hit_procs:-?} live processes), so it cannot be proven already returned; aborting" >&2
+    if [ -n "$hit_leased_at" ]; then leased_at_desc="a lease timestamp"; else leased_at_desc="no lease timestamp"; fi
+    echo "teardown: $label return reported $dir is not managed by this pool, but the pool still reports that copy as '${hit_state:-unknown}' (lease '${hit_lease_id:-}', holder '${hit_lease_holder:-}', $leased_at_desc, ${hit_procs:-?} live processes), so it cannot be proven already returned; aborting" >&2
     return 1
   fi
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -108,6 +108,40 @@
 # checks before any destructive return. Teardown output notes every wait, retry, and
 # removal so the operator can see what happened.
 #
+# Already-returned convergence (teardown-already-returned): killing the pool shell
+# that treehouse itself opened in the task copy (see Fix 2 below) makes treehouse
+# auto-return that copy on the shell's exit, BEFORE teardown issues its own
+# `treehouse return --force <path>`. That explicit return then fails with
+# treehouse's own `worktree <path> is not managed by treehouse`, and cleanup used
+# to abort and retain every durable task record for work that had already landed
+# and whose copy was already back in the pool.
+# teardown_treehouse_return_attempt therefore treats a return as satisfied when the
+# copy is POSITIVELY PROVEN to be back in the pool already. Both gates must hold:
+#   1. the failure carries treehouse's own already-returned line naming EXACTLY the
+#      path teardown asked it to return. Every other non-lock failure still aborts
+#      loudly, and the message alone never authorizes anything by itself.
+#   2. teardown_treehouse_already_returned proves it structurally from
+#      `treehouse status --json`, read in the same recorded project context the
+#      return ran from: exactly ONE pool entry whose CANONICAL path is the canonical
+#      recorded path (so a pool root reached through a symlink still matches, while
+#      a same-basename sibling slot, another pool slot, or another home never does),
+#      reported `available` with no lease id, no lease holder, no lease timestamp and
+#      no live process, on a copy whose git common dir is still the recorded
+#      project's own repository.
+# Anything weaker keeps the abort: a generic `not managed` with no matching listing
+# entry, a substring or basename resemblance, several matching entries, an `in-use`
+# or leased slot, a copy owned by another firstmate home's clone, a missing jq, or a
+# failed, empty, or malformed listing. Every one of those retains all task records.
+# The proof is read-only and, when it holds, authorizes exactly one thing: skipping a
+# return that already happened. It performs no further worktree mutation, never
+# retries the return, never resets, removes, prunes, or claims any copy, and never
+# relaxes a landed-work, dirty-tree, process, lock, endpoint, or ownership refusal -
+# it runs only after all of those have already passed. It is not a `--force` path.
+# The convergence lives in the backend-independent worktree-return step, so it is
+# shared by every treehouse-backed backend (tmux, herdr, zellij, cmux) and by the
+# secondmate-home lease release; `backend=orca` never reaches it, because Orca owns
+# its own worktrees and is removed through `orca worktree rm` instead.
+#
 # Pre-teardown cleanup sequence (runs once every landed/discard-work safety
 # refusal above has already passed, and BEFORE any worktree return, branch
 # delete, or backend kill below - a still-active run or a leaked process may
@@ -1333,19 +1367,170 @@ cleanup_stale_lock_for_safety_check() {
   return "$TEARDOWN_TREEHOUSE_LOCK_REFUSED"
 }
 
+# True when treehouse reported that EXACTLY the path we asked it to return is not
+# one of its own pool slots ("worktree <path> is not managed by treehouse").
+# This message is never proof of anything on its own - it is only the narrow
+# precondition for reading the pool listing below, so every other return failure
+# stays on the loud abort path.
+treehouse_return_is_unmanaged_error() {  # <output> <path>
+  local text=$1 path=$2
+  printf '%s\n' "$text" | grep -Fxq "worktree $path is not managed by treehouse"
+}
+
+# Canonical absolute git common dir of <canonical-dir>, i.e. the repository that
+# owns it. Empty/failure when the path is not inside a readable git repository.
+teardown_git_common_dir() {  # <canonical-dir>
+  local dir=$1 common
+  common=$( cd "$dir" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null ) || return 1
+  [ -n "$common" ] || return 1
+  case "$common" in
+    /*) ;;
+    *) common="$dir/$common" ;;
+  esac
+  canonical_existing_dir "$common"
+}
+
+# Positive structural proof that <dir> is ALREADY back in the pool, read from
+# treehouse's own supported `status --json` listing in the same pool context the
+# return itself used. The script header's teardown-already-returned section owns
+# the contract this enforces and every case that must keep the abort instead.
+# Read-only throughout: it mutates nothing, and its success authorizes exactly one
+# thing - skipping a return that has already happened. Each refusal below names
+# the specific missing proof, since that message is what an operator acts on.
+teardown_treehouse_already_returned() {  # <dir> <cd_dir> <label>
+  local dir=$1 cd_dir=$2 label=$3
+  local want listing entries rc=0 matches=0
+  local entry_line entry_index path
+  local hit_index="" hit_fields=""
+  local hit_state="" hit_lease_id="" hit_lease_holder="" hit_leased_at="" hit_procs=""
+  local entry_canon copy_repo project_canon project_repo
+
+  want=$(canonical_existing_dir "$dir") || {
+    echo "teardown: $label return reported $dir is not managed by this pool, but $dir is not an inspectable directory, so it cannot be proven already returned; aborting" >&2
+    return 1
+  }
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "teardown: $label return reported $dir is not managed by this pool, but jq is unavailable to read the pool listing, so it cannot be proven already returned; aborting" >&2
+    return 1
+  fi
+  listing=$( ( cd "$cd_dir" && treehouse status --json ) 2>/dev/null ) || rc=$?
+  if [ "$rc" -ne 0 ] || [ -z "$listing" ]; then
+    echo "teardown: $label return reported $dir is not managed by this pool, and the pool listing could not be read from $cd_dir, so it cannot be proven already returned; aborting" >&2
+    return 1
+  fi
+  if ! printf '%s' "$listing" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    echo "teardown: $label return reported $dir is not managed by this pool, and the pool listing from $cd_dir is not a readable slot array, so it cannot be proven already returned; aborting" >&2
+    return 1
+  fi
+  # Slot index plus raw path per entry. Only the FIRST tab separates them, so a
+  # path is never re-split or whitespace-trimmed on its way to canonicalization.
+  entries=$(printf '%s' "$listing" | jq -r '
+    to_entries[]
+    | select(.value | type == "object")
+    | "\(.key)\t\(.value.path // "")"') || {
+    echo "teardown: $label return reported $dir is not managed by this pool, and the pool listing from $cd_dir could not be parsed, so it cannot be proven already returned; aborting" >&2
+    return 1
+  }
+
+  while IFS= read -r entry_line; do
+    [ -n "$entry_line" ] || continue
+    entry_index=${entry_line%%$'\t'*}
+    path=${entry_line#*$'\t'}
+    [ -n "$path" ] && [ "$path" != "$entry_line" ] || continue
+    entry_canon=$(canonical_existing_dir "$path") || continue
+    [ "$entry_canon" = "$want" ] || continue
+    matches=$(( matches + 1 ))
+    hit_index=$entry_index
+  done <<EOF
+$entries
+EOF
+
+  if [ "$matches" -eq 1 ]; then
+    # One field per line: an empty lease id or holder must stay empty rather than
+    # collapse into its neighbour, which a tab-separated record would do.
+    hit_fields=$(printf '%s' "$listing" | jq -r --argjson slot "$hit_index" '
+      .[$slot]
+      | [ (.status // ""),
+          (.lease_id // ""),
+          (.lease_holder // ""),
+          (if .leased_at == null then "" else "leased-at" end),
+          ((.processes // []) | length | tostring) ]
+      | .[]') || hit_fields=
+    {
+      IFS= read -r hit_state
+      IFS= read -r hit_lease_id
+      IFS= read -r hit_lease_holder
+      IFS= read -r hit_leased_at
+      IFS= read -r hit_procs
+    } <<EOF
+$hit_fields
+EOF
+  fi
+
+  if [ "$matches" -ne 1 ]; then
+    echo "teardown: $label return reported $dir is not managed by this pool, and the pool listing from $cd_dir names that exact copy $matches times (exactly one is required), so it cannot be proven already returned; aborting" >&2
+    return 1
+  fi
+  if [ "$hit_state" != available ] \
+     || [ -n "$hit_lease_id" ] || [ -n "$hit_lease_holder" ] || [ -n "$hit_leased_at" ] \
+     || [ "$hit_procs" != 0 ]; then
+    echo "teardown: $label return reported $dir is not managed by this pool, but the pool still reports that copy as '${hit_state:-unknown}' (lease '${hit_lease_id:-}', holder '${hit_lease_holder:-}', ${hit_procs:-?} live processes), so it cannot be proven already returned; aborting" >&2
+    return 1
+  fi
+
+  project_canon=$(canonical_existing_dir "$cd_dir") || {
+    echo "teardown: $label return reported $dir is not managed by this pool, and the recorded project context $cd_dir is not an inspectable directory, so ownership of that copy cannot be proven; aborting" >&2
+    return 1
+  }
+  copy_repo=$(teardown_git_common_dir "$want") || copy_repo=
+  project_repo=$(teardown_git_common_dir "$project_canon") || project_repo=
+  if [ -z "$copy_repo" ] || [ -z "$project_repo" ] || [ "$copy_repo" != "$project_repo" ]; then
+    echo "teardown: $label return reported $dir is not managed by this pool, and that copy's repository ('${copy_repo:-unreadable}') is not the recorded project's repository ('${project_repo:-unreadable}'); refusing to treat another home's copy as this task's returned copy; aborting" >&2
+    return 1
+  fi
+
+  echo "teardown: $label was already returned before this cleanup ran - the pool lists exactly that copy as available, unleased, with no live process - so cleanup continues without a second return" >&2
+  return 0
+}
+
+TEARDOWN_TREEHOUSE_RETURN_OUT=
+TEARDOWN_TREEHOUSE_RETURN_ALREADY=0
+
+# One `treehouse return --force <dir>` attempt from <cd_dir>, with the
+# already-returned convergence folded in so every attempt is idempotent.
+# Publishes the attempt's combined output in TEARDOWN_TREEHOUSE_RETURN_OUT (echoed
+# to stdout on success, stderr on failure) so the caller can still match the
+# transient git-lock signature, and sets TEARDOWN_TREEHOUSE_RETURN_ALREADY=1 when
+# the copy was proven already returned rather than returned by this attempt.
+# Exit 0 means the copy is in the pool; exit 1 means it is not.
+teardown_treehouse_return_attempt() {  # <dir> <cd_dir> <label>
+  local dir=$1 cd_dir=$2 label=$3 out
+  TEARDOWN_TREEHOUSE_RETURN_ALREADY=0
+  # Capture stdout+stderr so non-lock failures stay visible and lock failures can
+  # be matched by signature even when the lock file is already gone mid-check.
+  if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
+    TEARDOWN_TREEHOUSE_RETURN_OUT=$out
+    if [ -n "$out" ]; then printf '%s\n' "$out"; fi
+    return 0
+  fi
+  TEARDOWN_TREEHOUSE_RETURN_OUT=$out
+  if [ -n "$out" ]; then printf '%s\n' "$out" >&2; fi
+  treehouse_return_is_unmanaged_error "$out" "$dir" || return 1
+  teardown_treehouse_already_returned "$dir" "$cd_dir" "$label" || return 1
+  TEARDOWN_TREEHOUSE_RETURN_ALREADY=1
+  return 0
+}
+
 # Return a worktree/home via `treehouse return --force`, tolerating a transient or
 # stale git index.lock left by a killed crew process. See the script header.
 teardown_treehouse_return() {
   local dir=$1 cd_dir=$2 label=$3 post_cleanup_check=${4:-}
   local out lock attempt=0 max_retries lock_desc
 
-  # Capture stdout+stderr so non-lock failures stay visible and lock failures can
-  # be matched by signature even when the lock file is already gone mid-check.
-  if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
-    [ -n "$out" ] && printf '%s\n' "$out"
+  if teardown_treehouse_return_attempt "$dir" "$cd_dir" "$label"; then
     return 0
   fi
-  [ -n "$out" ] && printf '%s\n' "$out" >&2
+  out=$TEARDOWN_TREEHOUSE_RETURN_OUT
 
   if ! treehouse_return_is_index_lock_error "$out"; then
     return 1
@@ -1366,12 +1551,13 @@ teardown_treehouse_return() {
     echo "teardown: $label return failed with transient git lock ($lock_desc); waiting ${TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS}s and retrying ($attempt/${max_retries})" >&2
     sleep "$TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS"
 
-    if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
-      [ -n "$out" ] && printf '%s\n' "$out"
-      echo "teardown: $label return succeeded on retry; lock cleared on its own" >&2
+    if teardown_treehouse_return_attempt "$dir" "$cd_dir" "$label"; then
+      if [ "$TEARDOWN_TREEHOUSE_RETURN_ALREADY" != 1 ]; then
+        echo "teardown: $label return succeeded on retry; lock cleared on its own" >&2
+      fi
       return 0
     fi
-    [ -n "$out" ] && printf '%s\n' "$out" >&2
+    out=$TEARDOWN_TREEHOUSE_RETURN_OUT
 
     if ! treehouse_return_is_index_lock_error "$out"; then
       echo "teardown: $label return failed with a non-lock error after retry; aborting" >&2
@@ -1393,12 +1579,12 @@ teardown_treehouse_return() {
           return 1
         fi
       fi
-      if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
-        [ -n "$out" ] && printf '%s\n' "$out"
-        echo "teardown: $label return succeeded after stale-lock cleanup" >&2
+      if teardown_treehouse_return_attempt "$dir" "$cd_dir" "$label"; then
+        if [ "$TEARDOWN_TREEHOUSE_RETURN_ALREADY" != 1 ]; then
+          echo "teardown: $label return succeeded after stale-lock cleanup" >&2
+        fi
         return 0
       fi
-      [ -n "$out" ] && printf '%s\n' "$out" >&2
       echo "teardown: $label return still failing after stale-lock cleanup" >&2
       return 1
     fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -131,7 +131,9 @@
 # Anything weaker keeps the abort: a generic `not managed` with no matching listing
 # entry, a substring or basename resemblance, several matching entries, an `in-use`
 # or leased slot, a copy owned by another firstmate home's clone, a missing jq, or a
-# failed, empty, or malformed listing. Every one of those retains all task records.
+# failed, empty, or malformed listing. An entry that omits any of those five fields,
+# or reports one with a type treehouse does not use, is malformed for this purpose
+# and proves nothing rather than reading as empty. Each retains all task records.
 # The proof is read-only and, when it holds, authorizes exactly one thing: skipping a
 # return that already happened. It performs no further worktree mutation, never
 # retries the return, never resets, removes, prunes, or claims any copy, and never
@@ -1445,32 +1447,44 @@ teardown_treehouse_already_returned() {  # <dir> <cd_dir> <label>
 $entries
 EOF
 
-  if [ "$matches" -eq 1 ]; then
-    # One field per line: an empty lease id or holder must stay empty rather than
-    # collapse into its neighbour, which a tab-separated record would do.
-    hit_fields=$(printf '%s' "$listing" | jq -r --argjson slot "$hit_index" '
-      .[$slot]
-      | [ (.status // ""),
-          (.lease_id // ""),
-          (.lease_holder // ""),
-          (if .leased_at == null then "" else "leased-at" end),
-          ((.processes // []) | length | tostring) ]
-      | .[]') || hit_fields=
-    {
-      IFS= read -r hit_state
-      IFS= read -r hit_lease_id
-      IFS= read -r hit_lease_holder
-      IFS= read -r hit_leased_at
-      IFS= read -r hit_procs
-    } <<EOF
-$hit_fields
-EOF
-  fi
-
   if [ "$matches" -ne 1 ]; then
     echo "teardown: $label return reported $dir is not managed by this pool, and the pool listing from $cd_dir names that exact copy $matches times (exactly one is required), so it cannot be proven already returned; aborting" >&2
     return 1
   fi
+
+  # Every field must be PRESENT and carry treehouse's own type, so an entry that
+  # never reports a lease or a process list proves nothing rather than reading as
+  # proven-empty. One field per line: an empty lease id or holder must stay empty
+  # rather than collapse into its neighbour, which a tab-separated record would do.
+  hit_fields=$(printf '%s' "$listing" | jq -r --argjson slot "$hit_index" '
+    .[$slot]
+    | select(has("status") and has("lease_id") and has("lease_holder")
+             and has("leased_at") and has("processes"))
+    | select((.status | type) == "string"
+             and (.lease_id | type) == "string"
+             and (.lease_holder | type) == "string"
+             and (.leased_at == null or (.leased_at | type) == "string")
+             and (.processes | type) == "array")
+    | [ .status,
+        .lease_id,
+        .lease_holder,
+        (if .leased_at == null then "" else "leased-at" end),
+        (.processes | length | tostring) ]
+    | .[]') || hit_fields=
+  if [ -z "$hit_fields" ]; then
+    echo "teardown: $label return reported $dir is not managed by this pool, and the pool listing from $cd_dir does not report that copy's status, lease and process fields in treehouse's own shape, so it cannot be proven already returned; aborting" >&2
+    return 1
+  fi
+  {
+    IFS= read -r hit_state
+    IFS= read -r hit_lease_id
+    IFS= read -r hit_lease_holder
+    IFS= read -r hit_leased_at
+    IFS= read -r hit_procs
+  } <<EOF
+$hit_fields
+EOF
+
   if [ "$hit_state" != available ] \
      || [ -n "$hit_lease_id" ] || [ -n "$hit_lease_holder" ] || [ -n "$hit_leased_at" ] \
      || [ "$hit_procs" != 0 ]; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -71,8 +71,10 @@
 # before preserving the route for retry. Teardown then discards child work, kills
 # child runtime endpoints, and removes the retired home. Removing a leased home
 # releases its durable treehouse lease so the pool slot is freed,
-# never left leased forever. If the treehouse return fails, teardown leaves the
-# leased home and state in place instead of hiding a still-held lease.
+# never left leased forever. If the treehouse return fails and the pool cannot
+# prove that home's slot is already back in it (see the already-returned
+# convergence below), teardown leaves the leased home and state in place instead
+# of hiding a still-held lease.
 # Usage: fm-teardown.sh <task-id> [--force]
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -245,7 +245,7 @@ The signal cannot be mixed with project names or omitted accidentally, and a pop
 Herdr secondmate and child placement follows the launcher-binding contract in [Watching and task containers](herdr-backend.md#watching-and-task-containers).
 When seeded with `-`, the home is a durable treehouse lease under the secondmate id, so it survives with no live process and is not recycled by later `treehouse get` or pruning.
 Retirement or seed rollback returns the leased home; normal restart/recovery keeps it leased.
-If returning the lease fails during teardown, firstmate leaves the route and home intact instead of hiding a still-held lease.
+If returning the lease fails during teardown and the pool cannot prove that home's slot is already free, firstmate leaves the route and home intact instead of hiding a still-held lease.
 Seeding is transactional: if validation, cloning, initialization, or registry update fails, generated briefs, new homes, new project clones, and registry edits are rolled back.
 `local-only` projects stay with the main first mate because they merge into the main local checkout instead of a remote-backed PR path.
 The same project may appear in multiple secondmate homes when their scopes differ, such as issue triage versus feature development.
@@ -302,7 +302,7 @@ Every GitHub refusal states what it could not observe as plainly as what it did,
 A confirmed merge leaves a durable role-routed outcome instead of living only in the merging agent's memory, and [`bin/fm-merge-outcome-lib.sh`](../bin/fm-merge-outcome-lib.sh)'s header owns its destination, shape, identity, normal-case deduplication, and at-least-once recovery.
 The same emitter handles a merge firstmate performed and one its poll detected, while the watcher immediately delivers the emitter's local actionable poll row.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
-[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
+[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, stale-lock recovery, and already-returned-copy convergence procedures, while [`verification/runtime-backends.md`](verification/runtime-backends.md#treehouse-worktree-pool) owns the dated Treehouse pool evidence that convergence rests on.
 
 ## Optional Relay
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -259,7 +259,7 @@ It cannot be combined with a project list, and omitting both still fails loudly.
 A project-less seed requires no existing project clones or `data/projects.md` entries in the home, so it refuses a populated-home conversion without changing that home.
 A preexisting project-bearing charter is also refused until it is re-scaffolded with `--no-projects` or removed.
 The lease is held under the secondmate id until explicit retirement or seed rollback returns it, so normal restarts do not free or recycle the home.
-Teardown of a leased home fails closed if `treehouse return` cannot release the lease; plain-clone homes with no treehouse pool slot are removed directly.
+Teardown of a leased home stops safely and leaves the home in place unless the lease is released or the pool proves that exact home slot is already free; plain-clone homes with no treehouse pool slot are removed directly.
 Secondmate routes cover `no-mistakes` and `direct-PR` projects; `local-only` projects remain main-firstmate work.
 For `no-mistakes` projects, seeding initializes only projects newly cloned into a secondmate home and refuses to mutate a preexisting clone that is not already initialized.
 After creating a secondmate, move existing main-backlog queued items that you have judged in-scope with `fm-backlog-handoff.sh <secondmate-id> <item-key>...`; it refuses In flight, Done, or non-secondmate homes, and a new move succeeds only after waking the recorded receiver.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -332,6 +332,7 @@ ok - an available slot that still lists a live process refuses cleanup
 ok - a pool listing that never names the recorded copy still refuses cleanup
 ok - an ambiguous pool listing naming the same copy twice still refuses cleanup
 ok - a malformed pool listing proves nothing and still refuses cleanup
+ok - a pool entry that never reports lease or process state proves nothing and refuses cleanup
 ok - an unreadable pool listing proves nothing and still refuses cleanup
 ok - an ordinary non-lock treehouse return failure still aborts even when the pool looks available
 ok - a copy whose repository is another home's clone is never treated as this task's returned copy

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -322,6 +322,8 @@ The portable half is enforced without Treehouse installed by the `teardown-alrea
 bin/fm-test-run.sh tests/fm-teardown.test.sh
 ```
 
+That file runs its whole teardown matrix; the `teardown-already-returned` lines excerpted from that run are:
+
 ```text
 ok - a copy proven already returned lets cleanup finish without a second worktree return
 ok - the already-returned proof matches the exact copy through a symlinked pool root

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -264,6 +264,81 @@ Two findings from the run shaped the shipped behavior: an OpenCode vendor update
 Kimi was not installed on the verification machine; its receive path is the same one-line-plus-shell contract, and the portable ladder and enqueue regressions in `tests/fm-task-inbox.test.sh` and `tests/fm-send-inbox.test.sh` cover every harness-independent half.
 This guard is the refresh command after any harness upgrade; it spends a small number of real tokens per installed harness, reports an absent harness explicitly, and refuses a run that verified nothing.
 
+## Treehouse worktree pool
+
+Treehouse is the shared worktree provider for every session-provider-only backend, so this section covers tmux, Herdr, Zellij, and cmux at once; `backend=orca` owns its own worktrees and never reaches these paths.
+
+### Already-returned convergence
+
+The two signals `bin/fm-teardown.sh`'s already-returned convergence depends on were observed on 2026-09-02 with Treehouse v2.3.0 on Linux x86_64, in a disposable pool over a throwaway repository.
+Long temporary prefixes below are shortened to `<pool>` and `<alt-pool>` (the same pool through its symlink) for readability; nothing else is altered.
+
+```sh
+treehouse --version
+WT=$(treehouse get --lease --no-fetch)
+treehouse return --force "$WT"
+treehouse status --json
+ln -sfn "$TREEHOUSE_ROOT" "$ALT_ROOT"          # same pool reached through a symlink
+treehouse return --force "${WT/$TREEHOUSE_ROOT/$ALT_ROOT}"
+```
+
+Observed output:
+
+```text
+v2.3.0
+🌳 Worktree returned to pool.
+[{"name":"1","path":"<pool>/.treehouse/repo-0ee1d9/1/repo","status":"available","flavor":"git","lease_id":"","lease_holder":"","leased_at":null,"processes":[]}]
+worktree <alt-pool>/.treehouse/repo-0ee1d9/1/repo is not managed by treehouse
+```
+
+Two facts hold this guarantee up.
+`treehouse status --json` is the supported structured pool listing, and a returned slot reads `available` with an empty lease id, an empty lease holder, a null `leased_at`, and an empty process list, which is the exact shape the convergence requires of one canonically matching entry.
+A copy addressed through a non-canonical spelling of its own pool root is reported `is not managed by treehouse` even while the pool lists that same copy as available, which is why the convergence compares canonical paths rather than the strings either side happens to use.
+
+That error string is the narrow precondition gate, never the proof.
+If a later Treehouse release rewords it, the convergence simply stops firing and cleanup returns to its previous loud refusal with the tool's own message printed, so the failure direction stays safe rather than silent.
+
+The whole path was then driven end to end against the real binary on the same date, in a disposable pool over a throwaway project clone, with only the runtime and forge CLIs stubbed.
+A leased copy was returned to simulate the pool shell's exit, the task record named that copy through the symlinked pool spelling, and `bin/fm-teardown.sh` ran on it before and after the change.
+
+```text
+# before
+worktree <alt-pool>/.treehouse/project-4d0e2d/1/project is not managed by treehouse
+error: treehouse return failed for worktree <alt-pool>/.treehouse/project-4d0e2d/1/project; teardown aborted
+exit 1, task record retained
+
+# after
+worktree <alt-pool>/.treehouse/project-4d0e2d/1/project is not managed by treehouse
+teardown: worktree was already returned before this cleanup ran - the pool lists exactly that copy as available, unleased, with no live process - so cleanup continues without a second return
+teardown task-x1 complete
+exit 0, task record retired
+```
+
+The pool read back one `available` slot before and after the converging run, and the copy stayed present on a detached clean head, so the convergence performed no further worktree mutation.
+
+The portable half is enforced without Treehouse installed by the `teardown-already-returned` cases in `tests/fm-teardown.test.sh`, which drive the pool listing through a double.
+
+```sh
+bin/fm-test-run.sh tests/fm-teardown.test.sh
+```
+
+```text
+ok - a copy proven already returned lets cleanup finish without a second worktree return
+ok - the already-returned proof matches the exact copy through a symlinked pool root
+ok - an available sibling slot with the same basename never proves this copy was returned
+ok - an in-use pool slot for the exact copy still refuses cleanup
+ok - a leased pool slot for the exact copy still refuses cleanup
+ok - an available slot that still lists a live process refuses cleanup
+ok - a pool listing that never names the recorded copy still refuses cleanup
+ok - an ambiguous pool listing naming the same copy twice still refuses cleanup
+ok - a malformed pool listing proves nothing and still refuses cleanup
+ok - an unreadable pool listing proves nothing and still refuses cleanup
+ok - an ordinary non-lock treehouse return failure still aborts even when the pool looks available
+ok - a copy whose repository is another home's clone is never treated as this task's returned copy
+```
+
+Rerun both halves after a Treehouse upgrade: the commands above refresh the version-scoped observation, and the regression file pins the decision logic.
+
 ## Herdr
 
 The compatibility floor is protocol 14.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -333,6 +333,7 @@ ok - a pool listing that never names the recorded copy still refuses cleanup
 ok - an ambiguous pool listing naming the same copy twice still refuses cleanup
 ok - a malformed pool listing proves nothing and still refuses cleanup
 ok - a pool entry that never reports lease or process state proves nothing and refuses cleanup
+ok - a pool entry reporting a lease or process field with the wrong type refuses cleanup
 ok - an unreadable pool listing proves nothing and still refuses cleanup
 ok - an ordinary non-lock treehouse return failure still aborts even when the pool looks available
 ok - a copy whose repository is another home's clone is never treated as this task's returned copy

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -49,6 +49,24 @@
 #   (w) index.lock mtime read failure                         -> lock kept, REFUSE
 #   (x) transient lock cleared after first failed return      -> retry ALLOW
 #   (y) persistent lock (never clears, not provably stale)    -> REFUSE loudly
+#
+# Also covers teardown-already-returned: treehouse auto-returns the task copy when
+# the pool shell it opened there exits, so teardown's own return then reports
+# "worktree <path> is not managed by treehouse". Cleanup converges only on positive
+# structural proof from `treehouse status --json` (bin/fm-teardown.sh's
+# teardown_treehouse_already_returned).
+#   (z)  exact copy available, unleased, no process -> ALLOW, one return attempt
+#   (aa) same copy through a symlinked pool root    -> ALLOW  (canonical match)
+#   (ab) another slot available, same basename      -> REFUSE (not this copy)
+#   (ac) exact copy reported in-use                 -> REFUSE
+#   (ad) exact copy still leased                    -> REFUSE
+#   (ae) available slot with a live process         -> REFUSE
+#   (af) copy absent from the pool listing          -> REFUSE
+#   (ag) same copy listed twice (ambiguous)         -> REFUSE
+#   (ah) malformed pool listing                     -> REFUSE
+#   (ai) unreadable pool listing                    -> REFUSE
+#   (aj) ordinary non-lock error, pool available    -> REFUSE (wrong signature)
+#   (ak) copy owned by another home's clone         -> REFUSE (cross-home)
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -421,6 +439,91 @@ fi
 exit 0
 SH
   chmod +x "$case_dir/fakebin/treehouse"
+}
+
+# treehouse double for the already-returned convergence cases. `return --force`
+# reports a configurable failure (default: treehouse's own already-returned line,
+# which names the exact path it was handed), while `status --json` prints the pool
+# listing staged in FM_FAKE_TH_STATUS_FILE. Every invocation is appended to
+# FM_FAKE_TH_LOG so a case can assert that no second return was ever attempted.
+add_status_aware_treehouse() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+[ -z "${FM_FAKE_TH_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_FAKE_TH_LOG"
+case "${1:-}" in
+  return)
+    shift
+    wt=""
+    for a in "$@"; do
+      case "$a" in
+        --force) ;;
+        *) wt=$a ;;
+      esac
+    done
+    case "${FM_FAKE_TH_RETURN:-unmanaged}" in
+      ok) exit 0 ;;
+      unmanaged) printf 'worktree %s is not managed by treehouse\n' "$wt" >&2 ; exit 1 ;;
+      *) printf '%s\n' "$FM_FAKE_TH_RETURN" >&2 ; exit 1 ;;
+    esac
+    ;;
+  status)
+    if [ "${FM_FAKE_TH_STATUS_RC:-0}" != 0 ]; then
+      echo "treehouse: pool state is unreadable" >&2
+      exit "${FM_FAKE_TH_STATUS_RC}"
+    fi
+    [ -z "${FM_FAKE_TH_STATUS_FILE:-}" ] || cat "$FM_FAKE_TH_STATUS_FILE"
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+}
+
+# Stage a `treehouse status --json` pool listing. Args: out-file, then one
+# "<path>|<status>|<lease-id>|<lease-holder>|<live-process-count>" per pool slot.
+write_th_pool_status() {
+  local out=$1; shift
+  local entry path state lease_id lease_holder procs leased_at proc_json sep=""
+  printf '[' > "$out"
+  for entry in "$@"; do
+    IFS='|' read -r path state lease_id lease_holder procs <<< "$entry"
+    if [ -n "$lease_id" ]; then leased_at='"2026-09-01T00:00:00Z"'; else leased_at=null; fi
+    proc_json='[]'
+    if [ "${procs:-0}" -gt 0 ]; then proc_json='[{"pid":424242,"name":"bash"}]'; fi
+    printf '%s{"name":"1","path":"%s","status":"%s","flavor":"git","lease_id":"%s","lease_holder":"%s","leased_at":%s,"processes":%s}' \
+      "$sep" "$path" "$state" "$lease_id" "$lease_holder" "$leased_at" "$proc_json" >> "$out"
+    sep=","
+  done
+  printf ']\n' >> "$out"
+}
+
+# Commit landed work on the task branch so every landed-work gate passes and the
+# case actually reaches the worktree-return step. Args: case_dir
+land_task_branch_on_origin() {
+  local case_dir=$1
+  wt_commit "$case_dir" "shippable work"
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/wt" fetch -q origin
+  git -C "$case_dir/project" fetch -q origin
+}
+
+# Re-create the task worktree from a SECOND clone of the same origin, so the copy's
+# git ownership resolves to another firstmate home's repository while the task
+# record still names this home's project clone. Args: case_dir
+repoint_worktree_to_another_home_clone() {
+  local case_dir=$1
+  git -C "$case_dir/project" worktree remove --force "$case_dir/wt"
+  git clone -q "$case_dir/origin.git" "$case_dir/other-home-project"
+  git -C "$case_dir/other-home-project" remote set-head origin main 2>/dev/null || true
+  git -C "$case_dir/other-home-project" worktree add -q -b fm/task-x1 "$case_dir/wt" main
+}
+
+# Count `treehouse return` invocations recorded by the status-aware double.
+th_return_attempts() {
+  local log=$1
+  grep -c '^return ' "$log" 2>/dev/null || true
 }
 
 git_index_lock_path() {
@@ -2605,6 +2708,306 @@ EOF
   pass "the run abort and the leaked-process reap both complete before the destructive worktree return"
 }
 
+# --- treehouse already-returned convergence (teardown-already-returned) --------
+#
+# Killing the pool shell treehouse opened in the task copy auto-returns that copy,
+# so teardown's own `treehouse return --force <path>` then reports
+# "worktree <path> is not managed by treehouse". Cleanup must converge when - and
+# only when - the pool positively proves that exact copy is already back.
+
+test_already_returned_copy_converges_without_a_second_return() {
+  local case_dir rc wt_canon
+  case_dir=$(make_case already-returned-exact)
+  write_meta "$case_dir" no-mistakes ship
+  land_task_branch_on_origin "$case_dir"
+  add_status_aware_treehouse "$case_dir"
+  wt_canon=$(cd "$case_dir/wt" && pwd -P)
+  write_th_pool_status "$case_dir/pool.json" "$wt_canon|available|||0"
+
+  set +e
+  FM_FAKE_TH_STATUS_FILE="$case_dir/pool.json" \
+  FM_FAKE_TH_LOG="$case_dir/treehouse.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "already-returned-exact: teardown should converge when the copy is proven already returned"
+  assert_absent "$case_dir/state/task-x1.meta" \
+    "already-returned-exact: teardown left the task record behind after converging"
+  assert_grep "already returned before this cleanup ran" "$case_dir/stderr" \
+    "already-returned-exact: teardown did not report why it converged"
+  [ "$(th_return_attempts "$case_dir/treehouse.log")" = 1 ] \
+    || fail "already-returned-exact: expected exactly one return attempt and no further worktree mutation, got $(th_return_attempts "$case_dir/treehouse.log")"
+  pass "a copy proven already returned lets cleanup finish without a second worktree return"
+}
+
+test_already_returned_copy_matches_through_a_symlinked_pool_root() {
+  local case_dir rc
+  case_dir=$(make_case already-returned-symlink)
+  write_meta "$case_dir" no-mistakes ship
+  land_task_branch_on_origin "$case_dir"
+  add_status_aware_treehouse "$case_dir"
+  # The production pool root is reached through a symlink, so treehouse spells the
+  # same copy differently from the recorded path. Only canonical paths may match.
+  ln -sfn "$case_dir" "$case_dir/poollink"
+  write_th_pool_status "$case_dir/pool.json" "$case_dir/poollink/wt|available|||0"
+
+  set +e
+  FM_FAKE_TH_STATUS_FILE="$case_dir/pool.json" \
+  FM_FAKE_TH_LOG="$case_dir/treehouse.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "already-returned-symlink: a symlinked pool spelling of the exact copy should still converge"
+  assert_absent "$case_dir/state/task-x1.meta" \
+    "already-returned-symlink: teardown left the task record behind after converging"
+  [ "$(th_return_attempts "$case_dir/treehouse.log")" = 1 ] \
+    || fail "already-returned-symlink: expected exactly one return attempt, got $(th_return_attempts "$case_dir/treehouse.log")"
+  pass "the already-returned proof matches the exact copy through a symlinked pool root"
+}
+
+test_available_sibling_slot_never_proves_this_copy_returned() {
+  local case_dir rc
+  case_dir=$(make_case already-returned-other-slot)
+  write_meta "$case_dir" no-mistakes ship
+  land_task_branch_on_origin "$case_dir"
+  add_status_aware_treehouse "$case_dir"
+  # Same repository, same basename, a different pool slot - and the recorded copy
+  # is absent from the listing entirely.
+  mkdir -p "$case_dir/slot2/wt"
+  write_th_pool_status "$case_dir/pool.json" "$case_dir/slot2/wt|available|||0"
+
+  set +e
+  FM_FAKE_TH_STATUS_FILE="$case_dir/pool.json" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "already-returned-other-slot: teardown should refuse when only another slot is available"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "already-returned-other-slot: teardown deleted task records without proof"
+  assert_grep "names that exact copy 0 times" "$case_dir/stderr" \
+    "already-returned-other-slot: teardown did not explain the refusal"
+  pass "an available sibling slot with the same basename never proves this copy was returned"
+}
+
+test_in_use_target_never_proves_this_copy_returned() {
+  local case_dir rc wt_canon
+  case_dir=$(make_case already-returned-in-use)
+  write_meta "$case_dir" no-mistakes ship
+  land_task_branch_on_origin "$case_dir"
+  add_status_aware_treehouse "$case_dir"
+  wt_canon=$(cd "$case_dir/wt" && pwd -P)
+  # The pool's own verdict decides on its own: an `in-use` slot refuses even when
+  # its process list happens to come back empty.
+  write_th_pool_status "$case_dir/pool.json" "$wt_canon|in-use|||0"
+
+  set +e
+  FM_FAKE_TH_STATUS_FILE="$case_dir/pool.json" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "already-returned-in-use: teardown should refuse while the pool still reports the copy in use"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "already-returned-in-use: teardown deleted task records for an in-use copy"
+  assert_grep "still reports that copy as 'in-use'" "$case_dir/stderr" \
+    "already-returned-in-use: teardown did not explain the refusal"
+  pass "an in-use pool slot for the exact copy still refuses cleanup"
+}
+
+test_leased_target_never_proves_this_copy_returned() {
+  local case_dir rc wt_canon
+  case_dir=$(make_case already-returned-leased)
+  write_meta "$case_dir" no-mistakes ship
+  land_task_branch_on_origin "$case_dir"
+  add_status_aware_treehouse "$case_dir"
+  wt_canon=$(cd "$case_dir/wt" && pwd -P)
+  write_th_pool_status "$case_dir/pool.json" "$wt_canon|leased|deadbeefdeadbeef|other-home|0"
+
+  set +e
+  FM_FAKE_TH_STATUS_FILE="$case_dir/pool.json" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "already-returned-leased: teardown should refuse while the copy is still leased"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "already-returned-leased: teardown deleted task records for a leased copy"
+  assert_grep "still reports that copy as 'leased'" "$case_dir/stderr" \
+    "already-returned-leased: teardown did not explain the refusal"
+  pass "a leased pool slot for the exact copy still refuses cleanup"
+}
+
+test_live_process_on_an_available_slot_refuses() {
+  local case_dir rc wt_canon
+  case_dir=$(make_case already-returned-live-process)
+  write_meta "$case_dir" no-mistakes ship
+  land_task_branch_on_origin "$case_dir"
+  add_status_aware_treehouse "$case_dir"
+  wt_canon=$(cd "$case_dir/wt" && pwd -P)
+  write_th_pool_status "$case_dir/pool.json" "$wt_canon|available|||1"
+
+  set +e
+  FM_FAKE_TH_STATUS_FILE="$case_dir/pool.json" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "already-returned-live-process: teardown should refuse while a live process remains in the copy"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "already-returned-live-process: teardown deleted task records for a copy with a live process"
+  assert_grep "1 live processes" "$case_dir/stderr" \
+    "already-returned-live-process: teardown did not explain the refusal"
+  pass "an available slot that still lists a live process refuses cleanup"
+}
+
+test_missing_target_in_pool_listing_refuses() {
+  local case_dir rc
+  case_dir=$(make_case already-returned-missing)
+  write_meta "$case_dir" no-mistakes ship
+  land_task_branch_on_origin "$case_dir"
+  add_status_aware_treehouse "$case_dir"
+  write_th_pool_status "$case_dir/pool.json"
+
+  set +e
+  FM_FAKE_TH_STATUS_FILE="$case_dir/pool.json" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "already-returned-missing: teardown should refuse when the pool lists no such copy"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "already-returned-missing: teardown deleted task records with no listing entry"
+  assert_grep "names that exact copy 0 times" "$case_dir/stderr" \
+    "already-returned-missing: teardown did not explain the refusal"
+  pass "a pool listing that never names the recorded copy still refuses cleanup"
+}
+
+test_duplicate_pool_entries_for_the_same_copy_refuse() {
+  local case_dir rc wt_canon
+  case_dir=$(make_case already-returned-ambiguous)
+  write_meta "$case_dir" no-mistakes ship
+  land_task_branch_on_origin "$case_dir"
+  add_status_aware_treehouse "$case_dir"
+  wt_canon=$(cd "$case_dir/wt" && pwd -P)
+  ln -sfn "$case_dir" "$case_dir/poollink"
+  # The same copy under two spellings: an ambiguous listing proves nothing, even
+  # though each entry on its own would satisfy every other gate.
+  write_th_pool_status "$case_dir/pool.json" \
+    "$wt_canon|available|||0" "$case_dir/poollink/wt|available|||0"
+
+  set +e
+  FM_FAKE_TH_STATUS_FILE="$case_dir/pool.json" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "already-returned-ambiguous: teardown should refuse an ambiguous pool listing"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "already-returned-ambiguous: teardown deleted task records on an ambiguous listing"
+  assert_grep "names that exact copy 2 times" "$case_dir/stderr" \
+    "already-returned-ambiguous: teardown did not explain the refusal"
+  pass "an ambiguous pool listing naming the same copy twice still refuses cleanup"
+}
+
+test_malformed_pool_listing_refuses() {
+  local case_dir rc
+  case_dir=$(make_case already-returned-malformed)
+  write_meta "$case_dir" no-mistakes ship
+  land_task_branch_on_origin "$case_dir"
+  add_status_aware_treehouse "$case_dir"
+  printf '%s\n' 'not a pool listing at all' > "$case_dir/pool.json"
+
+  set +e
+  FM_FAKE_TH_STATUS_FILE="$case_dir/pool.json" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "already-returned-malformed: teardown should refuse on a malformed pool listing"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "already-returned-malformed: teardown deleted task records on a malformed listing"
+  assert_grep "not a readable slot array" "$case_dir/stderr" \
+    "already-returned-malformed: teardown did not explain the refusal"
+  pass "a malformed pool listing proves nothing and still refuses cleanup"
+}
+
+test_unreadable_pool_listing_refuses() {
+  local case_dir rc
+  case_dir=$(make_case already-returned-unreadable)
+  write_meta "$case_dir" no-mistakes ship
+  land_task_branch_on_origin "$case_dir"
+  add_status_aware_treehouse "$case_dir"
+
+  set +e
+  FM_FAKE_TH_STATUS_RC=3 \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "already-returned-unreadable: teardown should refuse when the pool listing cannot be read"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "already-returned-unreadable: teardown deleted task records on an unreadable listing"
+  assert_grep "pool listing could not be read" "$case_dir/stderr" \
+    "already-returned-unreadable: teardown did not explain the refusal"
+  pass "an unreadable pool listing proves nothing and still refuses cleanup"
+}
+
+test_ordinary_treehouse_return_error_still_refuses() {
+  local case_dir rc wt_canon
+  case_dir=$(make_case already-returned-other-error)
+  write_meta "$case_dir" no-mistakes ship
+  land_task_branch_on_origin "$case_dir"
+  add_status_aware_treehouse "$case_dir"
+  # The pool would satisfy the structural proof, but this is an ordinary return
+  # failure rather than treehouse's already-returned signature.
+  wt_canon=$(cd "$case_dir/wt" && pwd -P)
+  write_th_pool_status "$case_dir/pool.json" "$wt_canon|available|||0"
+
+  set +e
+  FM_FAKE_TH_RETURN="error: failed to reset worktree" \
+  FM_FAKE_TH_STATUS_FILE="$case_dir/pool.json" \
+  FM_FAKE_TH_LOG="$case_dir/treehouse.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "already-returned-other-error: an ordinary return failure must still abort"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "already-returned-other-error: teardown deleted task records after an ordinary return failure"
+  assert_grep "failed to reset worktree" "$case_dir/stderr" \
+    "already-returned-other-error: teardown hid the underlying return failure"
+  assert_not_contains "$(cat "$case_dir/stderr")" "already returned before this cleanup ran" \
+    "already-returned-other-error: teardown converged on a failure that is not the already-returned signature"
+  pass "an ordinary non-lock treehouse return failure still aborts even when the pool looks available"
+}
+
+test_another_homes_copy_is_never_treated_as_returned() {
+  local case_dir rc wt_canon
+  case_dir=$(make_case already-returned-cross-home)
+  write_meta "$case_dir" no-mistakes ship
+  repoint_worktree_to_another_home_clone "$case_dir"
+  land_task_branch_on_origin "$case_dir"
+  add_status_aware_treehouse "$case_dir"
+  wt_canon=$(cd "$case_dir/wt" && pwd -P)
+  write_th_pool_status "$case_dir/pool.json" "$wt_canon|available|||0"
+
+  set +e
+  FM_FAKE_TH_STATUS_FILE="$case_dir/pool.json" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "already-returned-cross-home: teardown should refuse a copy owned by another home's clone"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "already-returned-cross-home: teardown deleted task records for another home's copy"
+  assert_grep "is not the recorded project's repository" "$case_dir/stderr" \
+    "already-returned-cross-home: teardown did not explain the ownership refusal"
+  pass "a copy whose repository is another home's clone is never treated as this task's returned copy"
+}
+
 test_local_only_fork_remote_allows
 test_teardown_closes_the_backlog_item_itself
 test_teardown_manual_backend_leaves_the_backlog_to_the_operator
@@ -2663,3 +3066,15 @@ test_process_spawned_during_grace_is_reaped_on_later_pass
 test_persistent_scan_refuses_after_bounded_retries
 test_process_exit_during_identity_lookup_does_not_refuse
 test_run_abort_precedes_process_reap_precedes_worktree_removal
+test_already_returned_copy_converges_without_a_second_return
+test_already_returned_copy_matches_through_a_symlinked_pool_root
+test_available_sibling_slot_never_proves_this_copy_returned
+test_in_use_target_never_proves_this_copy_returned
+test_leased_target_never_proves_this_copy_returned
+test_live_process_on_an_available_slot_refuses
+test_missing_target_in_pool_listing_refuses
+test_duplicate_pool_entries_for_the_same_copy_refuse
+test_malformed_pool_listing_refuses
+test_unreadable_pool_listing_refuses
+test_ordinary_treehouse_return_error_still_refuses
+test_another_homes_copy_is_never_treated_as_returned

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -66,6 +66,7 @@
 #   (ah) malformed pool listing                     -> REFUSE
 #   (ai) unreadable pool listing                    -> REFUSE
 #   (al) entry omitting the lease/process fields    -> REFUSE (proves nothing)
+#   (am) entry with a wrong-typed lease/process     -> REFUSE (proves nothing)
 #   (aj) ordinary non-lock error, pool available    -> REFUSE (wrong signature)
 #   (ak) copy owned by another home's clone         -> REFUSE (cross-home)
 set -u
@@ -2966,6 +2967,42 @@ test_pool_entry_without_lease_and_process_fields_refuses() {
   pass "a pool entry that never reports lease or process state proves nothing and refuses cleanup"
 }
 
+# Every required key is present, but a field carries a type treehouse never uses.
+# jq's has() is true for a key whose value is null, so key presence alone would let
+# "processes": null read as an empty process list; only the type gate refuses these.
+test_pool_entry_with_wrong_typed_fields_refuses() {
+  local shape name fields case_dir rc wt_canon
+  for shape in \
+    'null-processes|"lease_id":"","lease_holder":"","leased_at":null,"processes":null' \
+    'numeric-lease-id|"lease_id":0,"lease_holder":"","leased_at":null,"processes":[]'
+  do
+    name=${shape%%|*}
+    fields=${shape#*|}
+    case_dir=$(make_case "already-returned-$name")
+    write_meta "$case_dir" no-mistakes ship
+    land_task_branch_on_origin "$case_dir"
+    add_status_aware_treehouse "$case_dir"
+    wt_canon=$(cd "$case_dir/wt" && pwd -P)
+    printf '[{"name":"1","path":"%s","status":"available","flavor":"git",%s}]\n' "$wt_canon" "$fields" \
+      > "$case_dir/pool.json"
+
+    set +e
+    FM_FAKE_TH_STATUS_FILE="$case_dir/pool.json" \
+      run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+    rc=$?
+    set -e
+
+    expect_code 1 "$rc" "already-returned-$name: a wrong-typed lease or process field must refuse"
+    assert_present "$case_dir/state/task-x1.meta" \
+      "already-returned-$name: teardown deleted task records on a wrong-typed listing entry"
+    assert_grep "in treehouse's own shape" "$case_dir/stderr" \
+      "already-returned-$name: teardown did not explain the refusal"
+    assert_not_contains "$(cat "$case_dir/stderr")" "already returned before this cleanup ran" \
+      "already-returned-$name: teardown converged on a field type treehouse never reports"
+  done
+  pass "a pool entry reporting a lease or process field with the wrong type refuses cleanup"
+}
+
 test_unreadable_pool_listing_refuses() {
   local case_dir rc
   case_dir=$(make_case already-returned-unreadable)
@@ -3108,6 +3145,7 @@ test_missing_target_in_pool_listing_refuses
 test_duplicate_pool_entries_for_the_same_copy_refuse
 test_malformed_pool_listing_refuses
 test_pool_entry_without_lease_and_process_fields_refuses
+test_pool_entry_with_wrong_typed_fields_refuses
 test_unreadable_pool_listing_refuses
 test_ordinary_treehouse_return_error_still_refuses
 test_another_homes_copy_is_never_treated_as_returned

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -65,6 +65,7 @@
 #   (ag) same copy listed twice (ambiguous)         -> REFUSE
 #   (ah) malformed pool listing                     -> REFUSE
 #   (ai) unreadable pool listing                    -> REFUSE
+#   (al) entry omitting the lease/process fields    -> REFUSE (proves nothing)
 #   (aj) ordinary non-lock error, pool available    -> REFUSE (wrong signature)
 #   (ak) copy owned by another home's clone         -> REFUSE (cross-home)
 set -u
@@ -72,6 +73,8 @@ set -u
 # shellcheck source=tests/lib.sh disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 fm_git_identity fmtest fmtest@example.invalid
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
 
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 PR_CHECK="$ROOT/bin/fm-pr-check.sh"
@@ -2934,6 +2937,35 @@ test_malformed_pool_listing_refuses() {
   pass "a malformed pool listing proves nothing and still refuses cleanup"
 }
 
+# An entry that names the exact copy as available but never reports its lease and
+# process fields has not OBSERVED them empty - it has not reported them at all, so
+# it cannot prove the copy is unleased and idle.
+test_pool_entry_without_lease_and_process_fields_refuses() {
+  local case_dir rc wt_canon
+  case_dir=$(make_case already-returned-partial-entry)
+  write_meta "$case_dir" no-mistakes ship
+  land_task_branch_on_origin "$case_dir"
+  add_status_aware_treehouse "$case_dir"
+  wt_canon=$(cd "$case_dir/wt" && pwd -P)
+  printf '[{"name":"1","path":"%s","status":"available","flavor":"git"}]\n' "$wt_canon" \
+    > "$case_dir/pool.json"
+
+  set +e
+  FM_FAKE_TH_STATUS_FILE="$case_dir/pool.json" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "already-returned-partial-entry: an entry that never reports lease or process state must refuse"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "already-returned-partial-entry: teardown deleted task records on an entry that proved no lease or process state"
+  assert_grep "in treehouse's own shape" "$case_dir/stderr" \
+    "already-returned-partial-entry: teardown did not explain the refusal"
+  assert_not_contains "$(cat "$case_dir/stderr")" "already returned before this cleanup ran" \
+    "already-returned-partial-entry: teardown converged on an entry that never observed the required state"
+  pass "a pool entry that never reports lease or process state proves nothing and refuses cleanup"
+}
+
 test_unreadable_pool_listing_refuses() {
   local case_dir rc
   case_dir=$(make_case already-returned-unreadable)
@@ -3075,6 +3107,7 @@ test_live_process_on_an_available_slot_refuses
 test_missing_target_in_pool_listing_refuses
 test_duplicate_pool_entries_for_the_same_copy_refuse
 test_malformed_pool_listing_refuses
+test_pool_entry_without_lease_and_process_fields_refuses
 test_unreadable_pool_listing_refuses
 test_ordinary_treehouse_return_error_still_refuses
 test_another_homes_copy_is_never_treated_as_returned


### PR DESCRIPTION
## Summary

- make task cleanup converge when Treehouse has already returned the exact isolated copy
- require positive structural proof for `lease_id`, `lease_holder`, `leased_at`, and `processes`
- preserve refusal for dirty, active, ambiguous, malformed, cross-home, or unlanded cases
- keep genuinely unmanaged copies on the existing safe refusal path
- align the cleanup contract across the owning documentation

## Validation

Validated at exact head `93f1dbc84369c634c6866205652e4754f593872b` through intent, rebase, three review/fix rounds, tests, documentation, and lint review.

The branch includes 11 new regression cases covering exact already-returned convergence and malformed/cross-home/safety cases.
The teardown test family, repository lint, and documentation checks passed.
ShellCheck coverage was independently confirmed with pinned ShellCheck 0.11.0 and actionlint 1.7.12 because ShellCheck was unavailable in the original validation environment.

The original upstream push was rejected because the authenticated contributor account lacked write permission, so this identical validated head is submitted from the contributor fork without rewriting the upstream remote or changing the validated commit.
