### PR TITLE
fix(bin): guard worker Git commands from primary checkouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -525,7 +525,8 @@ Use its scaffold as the contract, then fill `## Captain's intent` (`{TASK}`) wit
 `bin/fm-dod-lib.sh` owns what a no-mistakes worker may pass as `--intent` and its rule that the string must be self-sufficient.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
-Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.
+Every ship brief must retain both the worktree-path assertion and the launch-installed Git guard assertion, and every scout brief must retain the Git guard assertion.
+The assertions stop the worker when its assigned isolation cannot be verified.
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -352,8 +352,11 @@ EOF
 TASK_SECTION=${TASK_SECTION%$'\n'}
 
 IFS= read -r -d '' GIT_ISOLATION_SECTION <<'EOF' || true
-## Continuous Git isolation
-The worker launch places a task-frozen Git guard first on `PATH` for this process tree, so Git remains bound after setup rather than relying only on the initial directory check.
+## Best-effort Git isolation
+The worker launch places a task-frozen Git guard first on `PATH` as a speed bump against accidental Git invocations whose working directory drifts into the primary checkout.
+The guard catches that incident class plus basic explicit targets, but it is deliberately not an evasion-resistant Git parser because the planned D2 delivery cutover retires the shared-primary-landing premise.
+Known bypasses are an absolute Git binary; a login shell that resets `PATH`; `core.worktree` through `-c`, `--config-env`, or `GIT_CONFIG_*`; unknown global-option arity; non-shell alias injection; an unrecognized linked-primary Git directory; and `GIT_INDEX_FILE` or related file-target redirection.
+The guard also shares the legacy `/tmp/fm-<task-id>` parent, so the same task id in another home can collide and its cleanup can remove this guard while this worker remains alive.
 Run `git fm-isolation-check` now; it must report the assigned worktree and its distinct primary checkout before any task work begins.
 If that assertion is unavailable or refuses the binding, append `blocked: worker Git isolation guard is not active` to the status file and stop.
 Do not replace `PATH` or invoke Git by an absolute binary path, because either would bypass the task guard.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -47,7 +47,8 @@
 # "Delivery contract: mode=<mode>" line. bin/fm-spawn.sh reads that line and refuses
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
-# Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Ship and scout briefs assert the launch-installed Git isolation guard before work begins.
+# Ship briefs keep the filesystem path assertion before their branch step too.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns merge decisions, so yolo is
@@ -350,6 +351,16 @@ IFS= read -r -d '' TASK_SECTION <<'EOF' || true
 EOF
 TASK_SECTION=${TASK_SECTION%$'\n'}
 
+IFS= read -r -d '' GIT_ISOLATION_SECTION <<'EOF' || true
+## Continuous Git isolation
+The worker launch places a task-frozen Git guard first on `PATH` for this process tree, so Git remains bound after setup rather than relying only on the initial directory check.
+Run `git fm-isolation-check` now; it must report the assigned worktree and its distinct primary checkout before any task work begins.
+If that assertion is unavailable or refuses the binding, append `blocked: worker Git isolation guard is not active` to the status file and stop.
+Do not replace `PATH` or invoke Git by an absolute binary path, because either would bypass the task guard.
+Run any test that creates, deletes, or switches its own Git refs only against a disposable fixture repository, never against the task worktree or primary checkout.
+EOF
+GIT_ISOLATION_SECTION=${GIT_ISOLATION_SECTION%$'\n'}
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -360,6 +371,9 @@ $HERDR_SECTION
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
+
+$GIT_ISOLATION_SECTION
+
 This is a SCOUT task: the deliverable is a written report, not a PR.
 The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
 The report is the only thing that survives, so anything worth keeping must be in it.
@@ -439,6 +453,8 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 **Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
+
+$GIT_ISOLATION_SECTION
 
 1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2641,6 +2641,7 @@ mkdir -p "$TASK_TMP/gotmp"
 # The legacy /tmp/fm-<task-id> root can collide across homes, so the guard header and generated brief disclose that cleanup lifetime gap.
 # bin/fm-worker-git-guard.sh owns the invocation-time decision and fails closed when these spawn-validated bindings cannot be re-established.
 WORKER_GIT_GUARD_DIR=
+WORKER_GIT_GUARD_READY=
 if [ "$KIND" != secondmate ]; then
   WORKER_GIT_GUARD_SOURCE="$FM_ROOT/bin/fm-worker-git-guard.sh"
   [ -f "$WORKER_GIT_GUARD_SOURCE" ] || {
@@ -2709,6 +2710,7 @@ if [ "$KIND" != secondmate ]; then
   } > "$WORKER_GIT_CONFIG_TMP"
   umask "$old_umask"
   mv "$WORKER_GIT_CONFIG_TMP" "$WORKER_GIT_GUARD_DIR/git.conf"
+  WORKER_GIT_GUARD_READY="$WORKER_GIT_GUARD_DIR/.path-verified"
 fi
 
 # Per-harness turn-end hook where enabled: a file that touches
@@ -3316,8 +3318,18 @@ spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 # A ship/scout gets the frozen Git guard first on PATH before the harness starts.
 # Existing workers are untouched because this export reaches only this launch.
 # The pane-level export is the same cross-backend inheritance boundary GOTMPDIR already uses, so descendants that preserve PATH inherit one binding.
+# The worker shell publishes proof only after resolving and executing that exact frozen guard, so a dropped export cannot silently launch an unguarded worker.
 if [ -n "$WORKER_GIT_GUARD_DIR" ]; then
-  spawn_send_text_line "$T" "export PATH=$(shell_quote "$WORKER_GIT_GUARD_DIR"):\"\$PATH\""
+  spawn_send_text_line "$T" "export PATH=$(shell_quote "$WORKER_GIT_GUARD_DIR"):\"\$PATH\"; if [ \"\$(command -v git 2>/dev/null)\" = $(shell_quote "$WORKER_GIT_GUARD_DIR/git") ] && git fm-isolation-check >/dev/null; then : > $(shell_quote "$WORKER_GIT_GUARD_READY"); else printf '%s\\n' 'error: worker Git isolation guard is not active on PATH; refusing launch' >&2; false; fi"
+  WORKER_GIT_VERIFY_ATTEMPT=0
+  while [ ! -f "$WORKER_GIT_GUARD_READY" ] && [ "$WORKER_GIT_VERIFY_ATTEMPT" -lt 20 ]; do
+    sleep 0.1
+    WORKER_GIT_VERIFY_ATTEMPT=$((WORKER_GIT_VERIFY_ATTEMPT + 1))
+  done
+  [ -f "$WORKER_GIT_GUARD_READY" ] || {
+    echo "error: worker Git isolation guard could not be verified first on PATH; refusing to append the launch command" >&2
+    exit 1
+  }
 fi
 # Send through the exact channel that already ships GOTMPDIR, so every backend
 # and harness - ship, scout, and secondmate - gets it before launch. Skipped

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -142,6 +142,11 @@
 #   configured host for a remote home. Skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
+#   Every ship/scout spawn also freezes bin/fm-worker-git-guard.sh under the
+#   task temp root and places that copy first on the worker's PATH before launch.
+#   The guard refuses any PATH-resolved Git invocation whose effective cwd,
+#   -C target, work tree, or git dir resolves into the primary checkout.
+#   Existing running workers are untouched, and secondmates remain unwrapped.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
@@ -2629,6 +2634,86 @@ fi
 TASK_TMP="/tmp/fm-$ID"
 mkdir -p "$TASK_TMP/gotmp"
 
+# Freeze a per-task Git guard before every ship/scout worker launches. The copy
+# is first on that worker's PATH for its whole process tree, so a later test or
+# tool that resolves Git from the project's primary checkout is refused before
+# it can switch the shared checkout's branch. The adjacent config binds the copy
+# to this exact task root, primary checkout, and real Git executable. Nothing is
+# installed into the project or the harness's global configuration, and a
+# secondmate remains unwrapped because its own home is intentionally primary.
+# bin/fm-worker-git-guard.sh owns the invocation-time decision and fails closed
+# when these spawn-validated bindings cannot be re-established.
+WORKER_GIT_GUARD_DIR=
+if [ "$KIND" != secondmate ]; then
+  WORKER_GIT_GUARD_SOURCE="$FM_ROOT/bin/fm-worker-git-guard.sh"
+  [ -f "$WORKER_GIT_GUARD_SOURCE" ] || {
+    echo "error: worker Git isolation guard is missing: $WORKER_GIT_GUARD_SOURCE" >&2
+    exit 1
+  }
+  WORKER_GIT_REAL=$(type -P git 2>/dev/null) || {
+    echo "error: worker Git isolation guard could not resolve the real Git executable" >&2
+    exit 1
+  }
+  case "$WORKER_GIT_REAL" in
+    /*) ;;
+    *)
+      WORKER_GIT_REAL_DIR=$(CDPATH='' cd -- "$(dirname -- "$WORKER_GIT_REAL")" 2>/dev/null && pwd -P) || {
+        echo "error: worker Git isolation guard could not resolve Git at $WORKER_GIT_REAL" >&2
+        exit 1
+      }
+      WORKER_GIT_REAL="$WORKER_GIT_REAL_DIR/$(basename -- "$WORKER_GIT_REAL")"
+      ;;
+  esac
+  WORKER_GIT_WORKTREE=$(CDPATH='' cd -- "$WT" 2>/dev/null && pwd -P) || {
+    echo "error: worker Git isolation guard could not resolve task worktree $WT" >&2
+    exit 1
+  }
+  WORKER_GIT_PRIMARY=$(CDPATH='' cd -- "$PROJ_ABS" 2>/dev/null && pwd -P) || {
+    echo "error: worker Git isolation guard could not resolve primary checkout $PROJ_ABS" >&2
+    exit 1
+  }
+  WORKER_GIT_TASK_DIR=$("$WORKER_GIT_REAL" -C "$WORKER_GIT_WORKTREE" rev-parse --absolute-git-dir 2>/dev/null) || {
+    echo "error: worker Git isolation guard could not resolve the task git dir" >&2
+    exit 1
+  }
+  WORKER_GIT_PRIMARY_DIR=$("$WORKER_GIT_REAL" -C "$WORKER_GIT_PRIMARY" rev-parse --absolute-git-dir 2>/dev/null) || {
+    echo "error: worker Git isolation guard could not resolve the primary git dir" >&2
+    exit 1
+  }
+  WORKER_GIT_TASK_DIR=$(CDPATH='' cd -- "$WORKER_GIT_TASK_DIR" 2>/dev/null && pwd -P) || {
+    echo "error: worker Git isolation guard task git dir is unavailable" >&2
+    exit 1
+  }
+  WORKER_GIT_PRIMARY_DIR=$(CDPATH='' cd -- "$WORKER_GIT_PRIMARY_DIR" 2>/dev/null && pwd -P) || {
+    echo "error: worker Git isolation guard primary git dir is unavailable" >&2
+    exit 1
+  }
+  [ "$WORKER_GIT_WORKTREE" != "$WORKER_GIT_PRIMARY" ] \
+    && [ "$WORKER_GIT_TASK_DIR" != "$WORKER_GIT_PRIMARY_DIR" ] || {
+      echo "error: worker Git isolation guard refused a task root that is not isolated from the primary checkout" >&2
+      exit 1
+    }
+  WORKER_GIT_GUARD_DIR=$(mktemp -d "$TASK_TMP/git-guard.XXXXXXXXXXXX") || {
+    echo "error: worker Git isolation guard could not allocate its private PATH directory" >&2
+    exit 1
+  }
+  chmod 0700 "$WORKER_GIT_GUARD_DIR"
+  cp "$WORKER_GIT_GUARD_SOURCE" "$WORKER_GIT_GUARD_DIR/git"
+  chmod 0700 "$WORKER_GIT_GUARD_DIR/git"
+  WORKER_GIT_CONFIG_TMP="$WORKER_GIT_GUARD_DIR/.git.conf.${BASHPID:-$$}"
+  old_umask=$(umask)
+  umask 077
+  {
+    printf 'worktree=%s\n' "$WORKER_GIT_WORKTREE"
+    printf 'primary=%s\n' "$WORKER_GIT_PRIMARY"
+    printf 'real_git=%s\n' "$WORKER_GIT_REAL"
+    printf 'task_git_dir=%s\n' "$WORKER_GIT_TASK_DIR"
+    printf 'primary_git_dir=%s\n' "$WORKER_GIT_PRIMARY_DIR"
+  } > "$WORKER_GIT_CONFIG_TMP"
+  umask "$old_umask"
+  mv "$WORKER_GIT_CONFIG_TMP" "$WORKER_GIT_GUARD_DIR/git.conf"
+fi
+
 # Per-harness turn-end hook where enabled: a file that touches
 # state/<id>.turn-ended when the agent finishes a turn. Worktree-resident hooks
 # and token pointers stay out of git's view so they never block teardown's dirty
@@ -3231,6 +3316,13 @@ spawn_record_traceparent() {
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.
 spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
+# A ship/scout gets the frozen Git guard first on PATH before the harness starts.
+# Existing workers are untouched because this export reaches only this launch.
+# The pane-level export is the same cross-backend inheritance boundary GOTMPDIR
+# already uses, so harness tools and test subprocesses inherit one binding.
+if [ -n "$WORKER_GIT_GUARD_DIR" ]; then
+  spawn_send_text_line "$T" "export PATH=$(shell_quote "$WORKER_GIT_GUARD_DIR"):\"\$PATH\""
+fi
 # Send through the exact channel that already ships GOTMPDIR, so every backend
 # and harness - ship, scout, and secondmate - gets it before launch. Skipped
 # entirely when trace context is off.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3327,7 +3327,12 @@ if [ -n "$WORKER_GIT_GUARD_DIR" ]; then
     WORKER_GIT_VERIFY_ATTEMPT=$((WORKER_GIT_VERIFY_ATTEMPT + 1))
   done
   [ -f "$WORKER_GIT_GUARD_READY" ] || {
-    echo "error: worker Git isolation guard could not be verified first on PATH; refusing to append the launch command" >&2
+    if [ "$RELAUNCH" -eq 0 ]; then
+      SPAWN_FRESH_COMMIT_PENDING=0
+      echo "error: worker Git isolation guard could not be verified first on PATH; refusing to append the launch command and preserving task record $STATE/$ID.meta for endpoint $T and local copy $WT recovery" >&2
+    else
+      echo "error: worker Git isolation guard could not be verified first on PATH; refusing to append the launch command" >&2
+    fi
     exit 1
   }
 fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -142,10 +142,9 @@
 #   configured host for a remote home. Skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
-#   Every ship/scout spawn also freezes bin/fm-worker-git-guard.sh under the
-#   task temp root and places that copy first on the worker's PATH before launch.
-#   The guard refuses any PATH-resolved Git invocation whose effective cwd,
-#   -C target, work tree, or git dir resolves into the primary checkout.
+#   Every ship/scout spawn also freezes bin/fm-worker-git-guard.sh under the task temp root and places that copy first on the worker's PATH before launch.
+#   The guard is a documented best-effort speed bump for accidental working-directory drift into the primary checkout, not an evasion-resistant Git parser.
+#   Its header and the generated brief name unsupported Git-routing forms and the legacy same-id cross-home temp-root collision.
 #   Existing running workers are untouched, and secondmates remain unwrapped.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
@@ -2634,15 +2633,13 @@ fi
 TASK_TMP="/tmp/fm-$ID"
 mkdir -p "$TASK_TMP/gotmp"
 
-# Freeze a per-task Git guard before every ship/scout worker launches. The copy
-# is first on that worker's PATH for its whole process tree, so a later test or
-# tool that resolves Git from the project's primary checkout is refused before
-# it can switch the shared checkout's branch. The adjacent config binds the copy
-# to this exact task root, primary checkout, and real Git executable. Nothing is
-# installed into the project or the harness's global configuration, and a
-# secondmate remains unwrapped because its own home is intentionally primary.
-# bin/fm-worker-git-guard.sh owns the invocation-time decision and fails closed
-# when these spawn-validated bindings cannot be re-established.
+# Freeze a per-task Git guard before every ship/scout worker launches.
+# The copy is first on that worker's initial PATH, so a later accidental Git invocation from the project's primary checkout is refused before it can switch the shared checkout's branch.
+# This is intentionally a best-effort guard rather than a complete Git-routing parser, and bin/fm-worker-git-guard.sh documents its known bypasses.
+# The adjacent config binds the copy to this exact task root, primary checkout, and real Git executable.
+# Nothing is installed into the project or the harness's global configuration, and a secondmate remains unwrapped because its own home is intentionally primary.
+# The legacy /tmp/fm-<task-id> root can collide across homes, so the guard header and generated brief disclose that cleanup lifetime gap.
+# bin/fm-worker-git-guard.sh owns the invocation-time decision and fails closed when these spawn-validated bindings cannot be re-established.
 WORKER_GIT_GUARD_DIR=
 if [ "$KIND" != secondmate ]; then
   WORKER_GIT_GUARD_SOURCE="$FM_ROOT/bin/fm-worker-git-guard.sh"
@@ -3318,8 +3315,7 @@ spawn_record_traceparent() {
 spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 # A ship/scout gets the frozen Git guard first on PATH before the harness starts.
 # Existing workers are untouched because this export reaches only this launch.
-# The pane-level export is the same cross-backend inheritance boundary GOTMPDIR
-# already uses, so harness tools and test subprocesses inherit one binding.
+# The pane-level export is the same cross-backend inheritance boundary GOTMPDIR already uses, so descendants that preserve PATH inherit one binding.
 if [ -n "$WORKER_GIT_GUARD_DIR" ]; then
   spawn_send_text_line "$T" "export PATH=$(shell_quote "$WORKER_GIT_GUARD_DIR"):\"\$PATH\""
 fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3311,6 +3311,12 @@ spawn_record_traceparent() {
   return "$status"
 }
 
+spawn_preserve_worker_git_guard_recovery() {
+  local reason=$1
+  SPAWN_FRESH_COMMIT_PENDING=0
+  echo "error: worker Git isolation guard $reason; refusing to append the launch command and preserving task record $STATE/$ID.meta for endpoint $T and local copy $WT recovery" >&2
+}
+
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.
@@ -3320,7 +3326,12 @@ spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 # The pane-level export is the same cross-backend inheritance boundary GOTMPDIR already uses, so descendants that preserve PATH inherit one binding.
 # The worker shell publishes proof only after resolving and executing that exact frozen guard, so a dropped export cannot silently launch an unguarded worker.
 if [ -n "$WORKER_GIT_GUARD_DIR" ]; then
-  spawn_send_text_line "$T" "export PATH=$(shell_quote "$WORKER_GIT_GUARD_DIR"):\"\$PATH\"; if [ \"\$(command -v git 2>/dev/null)\" = $(shell_quote "$WORKER_GIT_GUARD_DIR/git") ] && git fm-isolation-check >/dev/null; then : > $(shell_quote "$WORKER_GIT_GUARD_READY"); else printf '%s\\n' 'error: worker Git isolation guard is not active on PATH; refusing launch' >&2; false; fi"
+  if ! spawn_send_text_line "$T" "export PATH=$(shell_quote "$WORKER_GIT_GUARD_DIR"):\"\$PATH\"; if [ \"\$(command -v git 2>/dev/null)\" = $(shell_quote "$WORKER_GIT_GUARD_DIR/git") ] && git fm-isolation-check >/dev/null; then : > $(shell_quote "$WORKER_GIT_GUARD_READY"); else printf '%s\\n' 'error: worker Git isolation guard is not active on PATH; refusing launch' >&2; false; fi"; then
+    if [ "$RELAUNCH" -eq 0 ]; then
+      spawn_preserve_worker_git_guard_recovery "activation command could not be delivered"
+    fi
+    exit 1
+  fi
   WORKER_GIT_VERIFY_ATTEMPT=0
   while [ ! -f "$WORKER_GIT_GUARD_READY" ] && [ "$WORKER_GIT_VERIFY_ATTEMPT" -lt 20 ]; do
     sleep 0.1
@@ -3328,8 +3339,7 @@ if [ -n "$WORKER_GIT_GUARD_DIR" ]; then
   done
   [ -f "$WORKER_GIT_GUARD_READY" ] || {
     if [ "$RELAUNCH" -eq 0 ]; then
-      SPAWN_FRESH_COMMIT_PENDING=0
-      echo "error: worker Git isolation guard could not be verified first on PATH; refusing to append the launch command and preserving task record $STATE/$ID.meta for endpoint $T and local copy $WT recovery" >&2
+      spawn_preserve_worker_git_guard_recovery "could not be verified first on PATH"
     else
       echo "error: worker Git isolation guard could not be verified first on PATH; refusing to append the launch command" >&2
     fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -295,7 +295,7 @@ family_for_basename() {
     fm-control.test.sh|fm-control-relaunch.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|\
     fm-send-inbox.test.sh|fm-spawn-batch.test.sh|\
-    fm-spawn-dispatch-profile.test.sh|fm-claude-trust.test.sh|\
+    fm-spawn-dispatch-profile.test.sh|fm-worker-git-guard.test.sh|fm-claude-trust.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch

--- a/bin/fm-worker-git-guard.sh
+++ b/bin/fm-worker-git-guard.sh
@@ -3,7 +3,7 @@
 #
 # The copy is placed first on PATH before a ship or scout worker launches.
 # Ordinary descendants that preserve PATH pass through one task-frozen guard, including Git started by a test subprocess.
-# The guard catches the incident class: an accidental PATH-resolved Git invocation whose working directory resolves inside the project's primary checkout.
+# The guard catches the incident class: an accidental PATH-resolved Git invocation whose working directory resolves inside the project's primary checkout but outside its assigned worktree.
 # It also rejects the basic explicit -C, --work-tree, --git-dir, GIT_WORK_TREE, GIT_DIR, and GIT_COMMON_DIR forms it can classify cheaply.
 #
 # The adjacent git.conf is written by fm-spawn with exactly five

--- a/bin/fm-worker-git-guard.sh
+++ b/bin/fm-worker-git-guard.sh
@@ -2,11 +2,9 @@
 # Per-task Git guard copied to <tasktmp>/git-guard.<nonce>/git by bin/fm-spawn.sh.
 #
 # The copy is placed first on PATH before a ship or scout worker launches.
-# Every ordinary `git` child therefore passes through one task-frozen guard for
-# the lifetime of that worker, including Git started by a test subprocess.
-# The guard refuses when Git's effective cwd, -C target, work tree, or git dir
-# resolves into the project's primary checkout instead of the assigned task
-# worktree.
+# Ordinary descendants that preserve PATH pass through one task-frozen guard, including Git started by a test subprocess.
+# The guard catches the incident class: an accidental PATH-resolved Git invocation whose working directory resolves inside the project's primary checkout.
+# It also rejects the basic explicit -C, --work-tree, --git-dir, GIT_WORK_TREE, GIT_DIR, and GIT_COMMON_DIR forms it can classify cheaply.
 #
 # The adjacent git.conf is written by fm-spawn with exactly five
 # lines: worktree, primary, real_git, task_git_dir, and primary_git_dir.
@@ -18,9 +16,12 @@
 # It verifies the wrapper is still first on PATH, both configured Git roots and
 # git dirs remain bound, and the assigned root remains distinct from primary.
 #
-# This is a seatbelt against accidental path resolution, not a security sandbox.
-# An absolute Git binary or a process that replaces PATH can bypass it, so the
-# generated brief forbids both.
+# This is deliberately a best-effort seatbelt against accidental path drift, not a security sandbox or an evasion-resistant Git parser.
+# An absolute Git binary or a login shell that resets PATH bypasses it.
+# It does not fully interpret core.worktree supplied through -c, --config-env, or GIT_CONFIG_*; unknown global-option arity; or non-shell alias injection.
+# It can also miss an unrecognized linked-primary git dir and GIT_INDEX_FILE or related file-target redirection.
+# Its legacy /tmp/fm-<task-id> parent can collide with the same task id in another home, whose cleanup can remove this guard while the worker remains alive.
+# These limits are accepted because this mechanism guards mistakes rather than evasion, and the planned D2 delivery cutover retires the shared-primary-landing premise.
 set -u
 
 refuse_binding() {
@@ -69,6 +70,12 @@ inside_path() {
     "$2"|"$2"/*) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+inside_primary_outside_worktree() {
+  inside_path "$1" "$PRIMARY" || return 1
+  inside_path "$1" "$WORKTREE" && return 1
+  return 0
 }
 
 CONFIG=$0.conf
@@ -133,7 +140,7 @@ if [ "$#" -eq 1 ] && [ "$1" = fm-isolation-check ]; then
 fi
 
 CURRENT=$(pwd -P 2>/dev/null) || refuse_binding "cannot resolve the current directory."
-inside_path "$CURRENT" "$PRIMARY" && refuse_primary
+inside_primary_outside_worktree "$CURRENT" && refuse_primary
 
 TARGET=$CURRENT
 GIT_DIR_VALUE=${GIT_DIR:-}
@@ -176,23 +183,23 @@ while [ "$INDEX" -lt "${#ARGS[@]}" ]; do
   INDEX=$((INDEX + 1))
 done
 
-inside_path "$TARGET" "$PRIMARY" && refuse_primary
+inside_primary_outside_worktree "$TARGET" && refuse_primary
 if [ -n "$WORK_TREE_VALUE" ]; then
   WORK_TREE_TARGET=$(physical_path "$TARGET" "$WORK_TREE_VALUE") \
     || refuse_binding "cannot resolve Git's work-tree target."
-  inside_path "$WORK_TREE_TARGET" "$PRIMARY" && refuse_primary
+  inside_primary_outside_worktree "$WORK_TREE_TARGET" && refuse_primary
 fi
 if [ -n "$GIT_DIR_VALUE" ]; then
   GIT_DIR_TARGET=$(physical_path "$TARGET" "$GIT_DIR_VALUE") \
     || refuse_binding "cannot resolve Git's git-dir target."
-  if inside_path "$GIT_DIR_TARGET" "$PRIMARY" && [ "$GIT_DIR_TARGET" != "$TASK_GIT_DIR" ]; then
+  if inside_primary_outside_worktree "$GIT_DIR_TARGET" && [ "$GIT_DIR_TARGET" != "$TASK_GIT_DIR" ]; then
     refuse_primary
   fi
 fi
 if [ -n "${GIT_COMMON_DIR:-}" ]; then
   COMMON_DIR_TARGET=$(physical_path "$TARGET" "$GIT_COMMON_DIR") \
     || refuse_binding "cannot resolve Git's common-dir target."
-  if inside_path "$COMMON_DIR_TARGET" "$PRIMARY" \
+  if inside_primary_outside_worktree "$COMMON_DIR_TARGET" \
       && { [ "$COMMON_DIR_TARGET" != "$PRIMARY_GIT_DIR" ] || ! inside_path "$TARGET" "$WORKTREE"; }; then
     refuse_primary
   fi

--- a/bin/fm-worker-git-guard.sh
+++ b/bin/fm-worker-git-guard.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Per-task Git guard copied to <tasktmp>/git-guard.<nonce>/git by bin/fm-spawn.sh.
+#
+# The copy is placed first on PATH before a ship or scout worker launches.
+# Every ordinary `git` child therefore passes through one task-frozen guard for
+# the lifetime of that worker, including Git started by a test subprocess.
+# The guard refuses when Git's effective cwd, -C target, work tree, or git dir
+# resolves into the project's primary checkout instead of the assigned task
+# worktree.
+#
+# The adjacent git.conf is written by fm-spawn with exactly five
+# lines: worktree, primary, real_git, task_git_dir, and primary_git_dir.
+# Missing, malformed, moved, or unresolvable bindings refuse rather than running
+# an unguarded Git command.
+#
+# `git fm-isolation-check` is the executable setup assertion emitted in every
+# new ship and scout brief.
+# It verifies the wrapper is still first on PATH, both configured Git roots and
+# git dirs remain bound, and the assigned root remains distinct from primary.
+#
+# This is a seatbelt against accidental path resolution, not a security sandbox.
+# An absolute Git binary or a process that replaces PATH can bypass it, so the
+# generated brief forbids both.
+set -u
+
+refuse_binding() {
+  printf 'fm-worker-git-guard: refusing Git because the task isolation binding %s\n' "$1" >&2
+  exit 126
+}
+
+refuse_primary() {
+  printf "fm-worker-git-guard: refusing Git in primary checkout '%s'; use assigned worktree '%s'\n" "$PRIMARY" "$WORKTREE" >&2
+  exit 126
+}
+
+physical_dir() {
+  CDPATH='' cd -P -- "$1" 2>/dev/null && pwd -P
+}
+
+target_dir() {
+  local base=$1 path=$2
+  case "$path" in
+    '') physical_dir "$base" ;;
+    /*) physical_dir "$path" ;;
+    *) physical_dir "$base/$path" ;;
+  esac
+}
+
+physical_path() {
+  local base=$1 path=$2 candidate parent leaf parent_real
+  case "$path" in
+    /*) candidate=$path ;;
+    *) candidate=$base/$path ;;
+  esac
+  if [ -d "$candidate" ]; then
+    physical_dir "$candidate"
+    return
+  fi
+  parent=${candidate%/*}
+  leaf=${candidate##*/}
+  [ "$parent" != "$candidate" ] || parent=.
+  [ -n "$leaf" ] || return 1
+  parent_real=$(physical_dir "$parent") || return 1
+  printf '%s/%s\n' "${parent_real%/}" "$leaf"
+}
+
+inside_path() {
+  case "$1" in
+    "$2"|"$2"/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+CONFIG=$0.conf
+[ -f "$CONFIG" ] && [ ! -L "$CONFIG" ] && [ -O "$CONFIG" ] || refuse_binding "is unavailable at '$CONFIG'."
+exec 3< "$CONFIG" || refuse_binding "cannot be read from '$CONFIG'."
+IFS= read -r LINE1 <&3 || refuse_binding "is incomplete."
+IFS= read -r LINE2 <&3 || refuse_binding "is incomplete."
+IFS= read -r LINE3 <&3 || refuse_binding "is incomplete."
+IFS= read -r LINE4 <&3 || refuse_binding "is incomplete."
+IFS= read -r LINE5 <&3 || refuse_binding "is incomplete."
+if IFS= read -r _ <&3; then
+  refuse_binding "has unexpected extra data."
+fi
+exec 3<&-
+case "$LINE1" in worktree=*) WORKTREE=${LINE1#worktree=} ;; *) refuse_binding "has no worktree." ;; esac
+case "$LINE2" in primary=*) PRIMARY=${LINE2#primary=} ;; *) refuse_binding "has no primary checkout." ;; esac
+case "$LINE3" in real_git=*) REAL_GIT=${LINE3#real_git=} ;; *) refuse_binding "has no real Git executable." ;; esac
+case "$LINE4" in task_git_dir=*) TASK_GIT_DIR=${LINE4#task_git_dir=} ;; *) refuse_binding "has no task git dir." ;; esac
+case "$LINE5" in primary_git_dir=*) PRIMARY_GIT_DIR=${LINE5#primary_git_dir=} ;; *) refuse_binding "has no primary git dir." ;; esac
+[ -n "$WORKTREE" ] && [ -n "$PRIMARY" ] && [ -n "$REAL_GIT" ] \
+  && [ -n "$TASK_GIT_DIR" ] && [ -n "$PRIMARY_GIT_DIR" ] \
+  || refuse_binding "contains an empty value."
+case "$REAL_GIT" in /*) : ;; *) refuse_binding "contains a non-absolute real Git path." ;; esac
+[ -x "$REAL_GIT" ] || refuse_binding "points to an unavailable real Git executable."
+[ ! "$REAL_GIT" -ef "$0" ] || refuse_binding "points back to the guard instead of Git."
+
+WORKTREE_REAL=$(physical_dir "$WORKTREE") || refuse_binding "worktree cannot be resolved."
+PRIMARY_REAL=$(physical_dir "$PRIMARY") || refuse_binding "primary checkout cannot be resolved."
+TASK_GIT_DIR_REAL=$(physical_dir "$TASK_GIT_DIR") || refuse_binding "task git dir cannot be resolved."
+PRIMARY_GIT_DIR_REAL=$(physical_dir "$PRIMARY_GIT_DIR") || refuse_binding "primary git dir cannot be resolved."
+[ "$WORKTREE_REAL" = "$WORKTREE" ] || refuse_binding "worktree path has moved."
+[ "$PRIMARY_REAL" = "$PRIMARY" ] || refuse_binding "primary checkout path has moved."
+[ "$TASK_GIT_DIR_REAL" = "$TASK_GIT_DIR" ] || refuse_binding "task git dir path has moved."
+[ "$PRIMARY_GIT_DIR_REAL" = "$PRIMARY_GIT_DIR" ] || refuse_binding "primary git dir path has moved."
+[ "$WORKTREE" != "$PRIMARY" ] || refuse_binding "collapses the task onto the primary checkout."
+[ "$TASK_GIT_DIR" != "$PRIMARY_GIT_DIR" ] || refuse_binding "does not identify a distinct Git root."
+
+self_check() {
+  local path_git current task_top primary_top
+  path_git=$(command -v git 2>/dev/null || true)
+  [ "$path_git" = "$0" ] || refuse_binding "is no longer first on PATH."
+  current=$(pwd -P 2>/dev/null) || refuse_binding "cannot resolve the current directory."
+  [ "$current" = "$WORKTREE" ] || refuse_binding "setup assertion is not running from the assigned worktree."
+  task_top=$("$REAL_GIT" -C "$WORKTREE" rev-parse --show-toplevel 2>/dev/null) \
+    || refuse_binding "worktree is no longer a Git worktree."
+  primary_top=$("$REAL_GIT" -C "$PRIMARY" rev-parse --show-toplevel 2>/dev/null) \
+    || refuse_binding "primary checkout is no longer a Git checkout."
+  task_top=$(physical_dir "$task_top") || refuse_binding "worktree top level cannot be resolved."
+  primary_top=$(physical_dir "$primary_top") || refuse_binding "primary top level cannot be resolved."
+  [ "$task_top" = "$WORKTREE" ] || refuse_binding "worktree top level changed."
+  [ "$primary_top" = "$PRIMARY" ] || refuse_binding "primary top level changed."
+  [ "$("$REAL_GIT" -C "$WORKTREE" rev-parse --absolute-git-dir 2>/dev/null)" = "$TASK_GIT_DIR" ] \
+    || refuse_binding "task git dir changed."
+  [ "$("$REAL_GIT" -C "$PRIMARY" rev-parse --absolute-git-dir 2>/dev/null)" = "$PRIMARY_GIT_DIR" ] \
+    || refuse_binding "primary git dir changed."
+  printf "isolation guard active: worktree='%s' primary='%s'\n" "$WORKTREE" "$PRIMARY"
+}
+
+if [ "$#" -eq 1 ] && [ "$1" = fm-isolation-check ]; then
+  self_check
+  exit 0
+fi
+
+CURRENT=$(pwd -P 2>/dev/null) || refuse_binding "cannot resolve the current directory."
+inside_path "$CURRENT" "$PRIMARY" && refuse_primary
+
+TARGET=$CURRENT
+GIT_DIR_VALUE=${GIT_DIR:-}
+WORK_TREE_VALUE=${GIT_WORK_TREE:-}
+ARGS=("$@")
+INDEX=0
+while [ "$INDEX" -lt "${#ARGS[@]}" ]; do
+  ARG=${ARGS[$INDEX]}
+  case "$ARG" in
+    -C)
+      INDEX=$((INDEX + 1))
+      [ "$INDEX" -lt "${#ARGS[@]}" ] || refuse_binding "cannot classify a missing -C value."
+      TARGET=$(target_dir "$TARGET" "${ARGS[$INDEX]}") \
+        || refuse_binding "cannot resolve Git's -C target."
+      ;;
+    -C?*)
+      TARGET=$(target_dir "$TARGET" "${ARG#-C}") \
+        || refuse_binding "cannot resolve Git's -C target."
+      ;;
+    --git-dir)
+      INDEX=$((INDEX + 1))
+      [ "$INDEX" -lt "${#ARGS[@]}" ] || refuse_binding "cannot classify a missing --git-dir value."
+      GIT_DIR_VALUE=${ARGS[$INDEX]}
+      ;;
+    --git-dir=*) GIT_DIR_VALUE=${ARG#--git-dir=} ;;
+    --work-tree)
+      INDEX=$((INDEX + 1))
+      [ "$INDEX" -lt "${#ARGS[@]}" ] || refuse_binding "cannot classify a missing --work-tree value."
+      WORK_TREE_VALUE=${ARGS[$INDEX]}
+      ;;
+    --work-tree=*) WORK_TREE_VALUE=${ARG#--work-tree=} ;;
+    -c|--config-env|--namespace|--super-prefix)
+      INDEX=$((INDEX + 1))
+      [ "$INDEX" -lt "${#ARGS[@]}" ] || refuse_binding "cannot classify a missing global option value."
+      ;;
+    --) break ;;
+    -*) ;;
+    *) break ;;
+  esac
+  INDEX=$((INDEX + 1))
+done
+
+inside_path "$TARGET" "$PRIMARY" && refuse_primary
+if [ -n "$WORK_TREE_VALUE" ]; then
+  WORK_TREE_TARGET=$(physical_path "$TARGET" "$WORK_TREE_VALUE") \
+    || refuse_binding "cannot resolve Git's work-tree target."
+  inside_path "$WORK_TREE_TARGET" "$PRIMARY" && refuse_primary
+fi
+if [ -n "$GIT_DIR_VALUE" ]; then
+  GIT_DIR_TARGET=$(physical_path "$TARGET" "$GIT_DIR_VALUE") \
+    || refuse_binding "cannot resolve Git's git-dir target."
+  if inside_path "$GIT_DIR_TARGET" "$PRIMARY" && [ "$GIT_DIR_TARGET" != "$TASK_GIT_DIR" ]; then
+    refuse_primary
+  fi
+fi
+if [ -n "${GIT_COMMON_DIR:-}" ]; then
+  COMMON_DIR_TARGET=$(physical_path "$TARGET" "$GIT_COMMON_DIR") \
+    || refuse_binding "cannot resolve Git's common-dir target."
+  if inside_path "$COMMON_DIR_TARGET" "$PRIMARY" \
+      && { [ "$COMMON_DIR_TARGET" != "$PRIMARY_GIT_DIR" ] || ! inside_path "$TARGET" "$WORKTREE"; }; then
+    refuse_primary
+  fi
+fi
+
+exec "$REAL_GIT" "$@"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -202,7 +202,7 @@ For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved tas
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 Before each new ship or scout starts, `fm-spawn.sh` freezes `fm-worker-git-guard.sh` and its task binding under the task temp root, then places that copy first on the worker's initial `PATH`.
-The guard fails closed when its binding is unavailable and refuses accidental PATH-resolved Git operations that drift into the primary checkout, while ordinary Git in the assigned or another disposable worktree remains available.
+The guard fails closed when its binding is unavailable and refuses accidental PATH-resolved Git operations that drift into the primary checkout outside the assigned worktree, while ordinary Git in that worktree or an unrelated disposable repository remains available.
 It is intentionally a best-effort speed bump rather than a security boundary or complete Git command-line parser; the guard header owns its accepted routing bypasses and same-task-id `/tmp` cleanup-lifetime gap.
 Every generated ship and scout brief requires the worker to run `git fm-isolation-check` before task work and to use a disposable fixture repository for tests that mutate Git refs.
 `tests/fm-worker-git-guard.test.sh` owns the portable behavior coverage, including the legitimate nested-worktree case.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -201,6 +201,11 @@ Crewmates never intentionally touch your project clone; [treehouse](https://gith
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
+Before each new ship or scout starts, `fm-spawn.sh` freezes `fm-worker-git-guard.sh` and its task binding under the task temp root, then places that copy first on the worker's initial `PATH`.
+The guard fails closed when its binding is unavailable and refuses accidental PATH-resolved Git operations that drift into the primary checkout, while ordinary Git in the assigned or another disposable worktree remains available.
+It is intentionally a best-effort speed bump rather than a security boundary or complete Git command-line parser; the guard header owns its accepted routing bypasses and same-task-id `/tmp` cleanup-lifetime gap.
+Every generated ship and scout brief requires the worker to run `git fm-isolation-check` before task work and to use a disposable fixture repository for tests that mutate Git refs.
+`tests/fm-worker-git-guard.test.sh` owns the portable behavior coverage, including the legitimate nested-worktree case.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -50,7 +50,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-kimi-turnend-hook.sh` | Surgically install or remove Kimi's guarded global crew turn-end hook                |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |
 | `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |
-| `fm-worker-git-guard.sh` | Task-frozen PATH guard that refuses Git resolved into a project's primary checkout |
+| `fm-worker-git-guard.sh` | Best-effort task-frozen PATH guard for accidental Git working-directory drift into a project's primary checkout; its header owns known limits |
 | `fm-subagent-pretool-check.sh` | Primary-home delegation-shape PreToolUse guard (docs/subagent-guard.md) |
 | `fm-supervision-instructions.sh` | Render the session-start primary-harness supervision block or the one-line repair instruction |
 | `fm-home-seed.sh`        | Transactionally provision a local secondmate home and maintain `data/secondmates.md` |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -50,6 +50,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-kimi-turnend-hook.sh` | Surgically install or remove Kimi's guarded global crew turn-end hook                |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |
 | `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |
+| `fm-worker-git-guard.sh` | Task-frozen PATH guard that refuses Git resolved into a project's primary checkout |
 | `fm-subagent-pretool-check.sh` | Primary-home delegation-shape PreToolUse guard (docs/subagent-guard.md) |
 | `fm-supervision-instructions.sh` | Render the session-start primary-harness supervision block or the one-line repair instruction |
 | `fm-home-seed.sh`        | Transactionally provision a local secondmate home and maintain `data/secondmates.md` |

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -93,8 +93,9 @@ fm_test_fake_gh_axi() {
 
 # fm_test_fake_tmux_spawn <fakebin>
 # Spawn-world tmux: pane_current_path from FM_FAKE_PANE_PATH, session named
-# firstmate, window ops succeed, send-keys succeed. When FM_FAKE_LAUNCH_LOG is
-# set, each send-keys -l payload is appended one per line. Optional
+# firstmate, window ops succeed, and send-keys executes the worker Git guard
+# activation line just as the pane shell would. When FM_FAKE_LAUNCH_LOG is set,
+# each send-keys -l payload is appended one per line. Optional
 # FM_FAKE_DUPLICATE_WINDOW is printed from list-windows.
 #
 # The pane path defaults to empty when FM_FAKE_PANE_PATH is unset. Window
@@ -118,6 +119,13 @@ case "${1:-}" in
     ;;
   has-session|new-session|new-window|kill-window|set-window-option) exit 0 ;;
   send-keys)
+    for arg in "$@"; do
+      case "$arg" in
+        *"git fm-isolation-check"*)
+          (cd "${FM_FAKE_PANE_PATH:?}" && /bin/bash -c "$arg") || exit $?
+          ;;
+      esac
+    done
     if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
       prev=
       for a in "$@"; do

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -42,6 +42,13 @@ next=$(( $(cat "$COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
   for a in "$@"; do printf '\x1f%s' "$a"; done
   printf '\n'
 } >> "$LOG"
+for arg in "$@"; do
+  case "$arg" in
+    *"git fm-isolation-check"*)
+      (cd "${FM_FAKE_PANE_PATH:?}" && /bin/bash -c "$arg") || exit $?
+      ;;
+  esac
+done
 if [ "${1:-}" = status ] && [ "${FM_ORCA_STATUS_RESPONSE:-ready}" != sequence ]; then
   printf '{"ok":true,"result":{"runtime":{"reachable":true,"state":"ready"}}}\n'
   exit 0
@@ -524,6 +531,7 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   printf '{"ok":true,"result":{"repo":{"id":"repo-spawn"}}}\n' > "$RESP/2.out"
   printf '{"ok":true,"result":{"worktree":{"id":"wt-spawn","path":"%s"},"terminal":{"handle":"term-spawn"}}}\n' "$wt" > "$RESP/3.out"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_FAKE_PANE_PATH="$wt" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --mode no-mistakes --yolo off --backend orca 2>&1 )

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -803,6 +803,11 @@ case "\${1:-}" in
     for a in "\$@"; do case "\$a" in *pane_current_path*) printf '%s\\n' "$wt"; exit 0 ;; esac; done
     printf 'firstmate\\n'; exit 0 ;;
   list-windows) exit 0 ;;
+  send-keys)
+    for a in "\$@"; do case "\$a" in *"git fm-isolation-check"*)
+      (cd "$wt" && /bin/bash -c "\$a") || exit \$?
+    ;; esac; done
+    exit 0 ;;
 esac
 exit 0
 SH
@@ -873,6 +878,11 @@ case "\${1:-}" in
     ;; esac; done
     printf 'firstmate\\n'; exit 0 ;;
   list-windows) exit 0 ;;
+  send-keys)
+    for a in "\$@"; do case "\$a" in *"git fm-isolation-check"*)
+      (cd "$wt" && /bin/bash -c "\$a") || exit \$?
+    ;; esac; done
+    exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -73,7 +73,18 @@ EOF
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 case "$*" in *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;; esac
-case "${1:-}" in display-message) printf 'firstmate\n'; exit 0 ;; esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  send-keys)
+    for arg in "$@"; do
+      case "$arg" in
+        *"git fm-isolation-check"*)
+          (cd "${FM_FAKE_PANE_PATH:?}" && /bin/bash -c "$arg") || exit $?
+          ;;
+      esac
+    done
+    ;;
+esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -216,6 +216,10 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep 'never a bare number such as "PR 108"' "$brief" "$id: brief missing the full-PR-URL rule"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
+    assert_grep "git fm-isolation-check" "$brief" \
+      "$id: brief missing the executable continuous-isolation assertion"
+    assert_grep "Run any test that creates, deletes, or switches its own Git refs only against a disposable fixture repository" "$brief" \
+      "$id: brief missing the disposable Git-ref test rule"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
@@ -831,6 +835,10 @@ test_scout_and_secondmate_scaffold() {
   assert_grep "## Captain's intent" "$brief" "scout brief missing Captain's intent subsection"
   assert_grep "## Firstmate spec" "$brief" "scout brief missing Firstmate spec subsection"
   assert_grep "{FIRSTMATE_SPEC}" "$brief" "scout brief missing the spec placeholder"
+  assert_grep "git fm-isolation-check" "$brief" \
+    "scout brief missing the executable continuous-isolation assertion"
+  assert_grep "Do not replace \`PATH\` or invoke Git by an absolute binary path" "$brief" \
+    "scout brief missing the Git-guard bypass prohibition"
 
   FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
     FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-sm-q6 --secondmate alpha >/dev/null 2>&1 \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -217,7 +217,15 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
     assert_grep "git fm-isolation-check" "$brief" \
-      "$id: brief missing the executable continuous-isolation assertion"
+      "$id: brief missing the executable best-effort isolation assertion"
+    assert_grep "deliberately not an evasion-resistant Git parser" "$brief" \
+      "$id: brief overstates the best-effort Git guard"
+    assert_grep "Known bypasses are an absolute Git binary; a login shell that resets" "$brief" \
+      "$id: brief does not disclose PATH-replacement bypasses"
+    assert_grep "unknown global-option arity; non-shell alias injection; an unrecognized linked-primary Git directory" "$brief" \
+      "$id: brief does not disclose Git-routing bypasses"
+    assert_grep "same task id in another home can collide" "$brief" \
+      "$id: brief does not disclose the legacy task-temp collision"
     assert_grep "Run any test that creates, deletes, or switches its own Git refs only against a disposable fixture repository" "$brief" \
       "$id: brief missing the disposable Git-ref test rule"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
@@ -836,7 +844,7 @@ test_scout_and_secondmate_scaffold() {
   assert_grep "## Firstmate spec" "$brief" "scout brief missing Firstmate spec subsection"
   assert_grep "{FIRSTMATE_SPEC}" "$brief" "scout brief missing the spec placeholder"
   assert_grep "git fm-isolation-check" "$brief" \
-    "scout brief missing the executable continuous-isolation assertion"
+    "scout brief missing the executable best-effort isolation assertion"
   assert_grep "Do not replace \`PATH\` or invoke Git by an absolute binary path" "$brief" \
     "scout brief missing the Git-guard bypass prohibition"
 

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -365,7 +365,8 @@ test_relaunch_serializes_concurrent_durable_metadata_publication() {
     FM_FAKE_TRACE_RELEASE="$launch_release" \
     run_control "$dir" rl28 relaunch --note "continue after publication" > "$dir/control.out" &
   control_pid=$!
-  while [ ! -e "$prepare" ] && [ "$i" -lt 200 ]; do
+  # Relaunch now binds the worker Git guard before environment delivery, so allow that preflight five seconds to reach this synchronization point.
+  while [ ! -e "$prepare" ] && [ "$i" -lt 500 ]; do
     /bin/sleep 0.01
     i=$((i + 1))
   done

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -89,6 +89,9 @@ case "${1:-}" in
             while [ ! -e "$FM_FAKE_TRACE_RELEASE" ]; do /bin/sleep 0.01; done
           fi
           ;;
+        *'git fm-isolation-check'*)
+          (cd "$(cat "$D/cwd")" && /bin/bash -c "$payload") || exit $?
+          ;;
         'export TRACEPARENT='*)
           [ -z "${FM_FAKE_TRACE_EXPORTED:-}" ] || : > "$FM_FAKE_TRACE_EXPORTED"
           ;;

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -67,6 +67,13 @@ case "${1:-}" in
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
   send-keys)
+    for arg in "$@"; do
+      case "$arg" in
+        *"git fm-isolation-check"*)
+          (cd "${FM_FAKE_PANE_PATH:?}" && /bin/bash -c "$arg") || exit $?
+          ;;
+      esac
+    done
     prev=
     literal=
     for arg in "$@"; do

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -85,6 +85,13 @@ case "${1:-}" in
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
   send-keys)
+    for arg in "$@"; do
+      case "$arg" in
+        *"git fm-isolation-check"*)
+          (cd "${FM_FAKE_PANE_PATH:?}" && /bin/bash -c "$arg") || exit $?
+          ;;
+      esac
+    done
     prev=
     for arg in "$@"; do
       if [ "$prev" = -l ]; then

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -49,7 +49,16 @@ case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
-  send-keys) exit 0 ;;
+  send-keys)
+    for arg in "$@"; do
+      case "$arg" in
+        *"git fm-isolation-check"*)
+          (cd "${FM_FAKE_PANE_PATH:?}" && /bin/bash -c "$arg") || exit $?
+          ;;
+      esac
+    done
+    exit 0
+    ;;
 esac
 exit 0
 SH

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -5,10 +5,12 @@
 # secondmate homes all sit at a detached HEAD on the default branch, while the
 # PRIMARY checkout (FM_ROOT) is a normal checkout on a real branch. The "tangle"
 # is a crewmate branching/committing in the primary instead of its own worktree,
-# stranding the primary on a feature branch. Two guards cover it:
+# stranding the primary on a feature branch. Three guards cover it:
 #   GUARD 1 (prevention) - the brief asserts isolation before its branch step, and
 #            fm-spawn refuses to launch unless the resolved worktree is isolated.
-#   GUARD 2 (detection)  - fm-guard and fm-bootstrap alarm when the primary is on
+#   GUARD 2 (continuous) - fm-spawn puts a task-frozen Git guard first on each new
+#            worker's PATH, so a later Git process cannot target primary.
+#   GUARD 3 (detection)  - fm-guard and fm-bootstrap alarm when the primary is on
 #            a feature branch, and stay silent on the default branch or detached.
 # These cases pin: the shared lib's branch classification, the fm-guard banner,
 # the fm-bootstrap problem line, the brief assertion ordering, and the fm-spawn
@@ -125,7 +127,7 @@ test_bootstrap_line() {
 # The generated ship brief must carry the isolation assertion AHEAD of the
 # `git checkout -b` step, so the crewmate verifies its worktree before branching.
 test_brief_assertion_precedes_branch() {
-  local home brief iso br
+  local home brief iso continuous br
   home="$TMP_ROOT/brief-home"
   mkdir -p "$home/data"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" tangle-brief-cc3 alpha --mode no-mistakes >/dev/null 2>&1
@@ -140,12 +142,16 @@ test_brief_assertion_precedes_branch() {
   assert_no_grep "they are identical in the primary checkout" "$brief" \
     "brief must not claim the primary checkout has identical git dirs"
   iso=$(grep -n 'launched in primary checkout, not an isolated worktree' "$brief" | head -1 | cut -d: -f1)
+  continuous=$(grep -n 'git fm-isolation-check' "$brief" | head -1 | cut -d: -f1)
   br=$(grep -n 'git checkout -b fm/' "$brief" | head -1 | cut -d: -f1)
-  if [ -z "$iso" ] || [ -z "$br" ]; then
-    fail "brief missing assertion ($iso) or branch step ($br)"
+  if [ -z "$iso" ] || [ -z "$continuous" ] || [ -z "$br" ]; then
+    fail "brief missing start assertion ($iso), continuous assertion ($continuous), or branch step ($br)"
   fi
-  [ "$iso" -lt "$br" ] || fail "isolation assertion (line $iso) must precede the branch step (line $br)"
-  pass "fm-brief: ship brief asserts worktree isolation before the branch step"
+  [ "$iso" -lt "$continuous" ] \
+    || fail "start isolation assertion (line $iso) must precede the continuous assertion (line $continuous)"
+  [ "$continuous" -lt "$br" ] \
+    || fail "continuous isolation assertion (line $continuous) must precede the branch step (line $br)"
+  pass "fm-brief: ship brief asserts start and continuous isolation before the branch step"
 }
 
 # --- GUARD 1b: fm-spawn isolation abort -------------------------------------

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -8,8 +8,9 @@
 # stranding the primary on a feature branch. Three guards cover it:
 #   GUARD 1 (prevention) - the brief asserts isolation before its branch step, and
 #            fm-spawn refuses to launch unless the resolved worktree is isolated.
-#   GUARD 2 (continuous) - fm-spawn puts a task-frozen Git guard first on each new
-#            worker's PATH, so a later Git process cannot target primary.
+#   GUARD 2 (best effort) - fm-spawn puts a task-frozen Git guard first on each
+#            new worker's PATH as a speed bump against later accidental drift;
+#            fm-worker-git-guard.sh's header owns the accepted bypasses.
 #   GUARD 3 (detection)  - fm-guard and fm-bootstrap alarm when the primary is on
 #            a feature branch, and stay silent on the default branch or detached.
 # These cases pin: the shared lib's branch classification, the fm-guard banner,

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -223,7 +223,17 @@ case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   new-window) printf '%s\n' "@spawnwid"; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|send-keys|set-window-option) exit 0 ;;
+  send-keys)
+    for arg in "$@"; do
+      case "$arg" in
+        *"git fm-isolation-check"*)
+          (cd "${FM_FAKE_PANE_PATH:?}" && /bin/bash -c "$arg") || exit $?
+          ;;
+      esac
+    done
+    exit 0
+    ;;
+  has-session|new-session|set-window-option) exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -43,6 +43,13 @@ case "${1:-}" in
     ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
   send-keys)
+    for a in "$@"; do
+      case "$a" in
+        *"git fm-isolation-check"*)
+          (cd "${FM_FAKE_PANE_PATH:?}" && /bin/bash -c "$a") || exit $?
+          ;;
+      esac
+    done
     if [ "${FM_FAKE_TRACEPARENT_SEND_FAIL:-0}" = 1 ]; then
       for a in "$@"; do
         case "$a" in

--- a/tests/fm-worker-git-guard.test.sh
+++ b/tests/fm-worker-git-guard.test.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Behavior tests for the per-task Git guard installed by fm-spawn.sh.
+#
+# The incident regression is executable here: a test process starts in its
+# assigned worktree, resolves the project's primary checkout, changes into it,
+# and attempts to switch that shared checkout onto a fixture branch.
+# The PATH guard must refuse before the branch exists or primary HEAD moves.
+set -u
+
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-worker-git-guard)
+REAL_GIT=$(type -P git)
+BASE_PATH=$PATH
+fm_git_identity fmtest fmtest@example.invalid
+
+install_guard() {
+  local primary=$1 worktree=$2 guard_dir=$3 task_git_dir primary_git_dir
+  mkdir -p "$guard_dir"
+  cp "$ROOT/bin/fm-worker-git-guard.sh" "$guard_dir/git"
+  chmod 0700 "$guard_dir/git"
+  task_git_dir=$($REAL_GIT -C "$worktree" rev-parse --absolute-git-dir) || return 1
+  primary_git_dir=$($REAL_GIT -C "$primary" rev-parse --absolute-git-dir) || return 1
+  task_git_dir=$(cd "$task_git_dir" && pwd -P) || return 1
+  primary_git_dir=$(cd "$primary_git_dir" && pwd -P) || return 1
+  {
+    printf 'worktree=%s\n' "$(cd "$worktree" && pwd -P)"
+    printf 'primary=%s\n' "$(cd "$primary" && pwd -P)"
+    printf 'real_git=%s\n' "$REAL_GIT"
+    printf 'task_git_dir=%s\n' "$task_git_dir"
+    printf 'primary_git_dir=%s\n' "$primary_git_dir"
+  } > "$guard_dir/git.conf"
+  chmod 0600 "$guard_dir/git.conf"
+}
+
+PRIMARY="$TMP_ROOT/project"
+WORKTREE="$TMP_ROOT/worktree"
+GUARD_DIR="$TMP_ROOT/guard/bin"
+fm_git_worktree "$PRIMARY" "$WORKTREE" guard-task-base
+install_guard "$PRIMARY" "$WORKTREE" "$GUARD_DIR"
+PRIMARY_BRANCH=$($REAL_GIT -C "$PRIMARY" branch --show-current)
+
+run_guarded() {
+  local cwd=$1
+  shift
+  (cd "$cwd" && PATH="$GUARD_DIR:$BASE_PATH" "$@")
+}
+
+test_setup_assertion_and_worktree_git_succeed() {
+  local out rc
+  out=$(run_guarded "$WORKTREE" git fm-isolation-check 2>&1); rc=$?
+  expect_code 0 "$rc" "the executable isolation assertion should accept the assigned worktree"
+  assert_contains "$out" "isolation guard active" "the setup assertion did not report an active guard"
+  assert_contains "$out" "worktree='$WORKTREE'" "the setup assertion did not name the assigned worktree"
+  run_guarded "$WORKTREE" git switch -q -c guard-task-work \
+    || fail "ordinary Git in the disposable task worktree was refused"
+  [ "$($REAL_GIT -C "$WORKTREE" branch --show-current)" = guard-task-work ] \
+    || fail "the allowed worktree branch switch did not run"
+  [ "$($REAL_GIT -C "$PRIMARY" branch --show-current)" = "$PRIMARY_BRANCH" ] \
+    || fail "an allowed task worktree command moved primary HEAD"
+  pass "worker Git guard: setup assertion and task-worktree Git both succeed"
+}
+
+test_mid_task_resolved_primary_checkout_is_refused() {
+  local probe out rc
+  probe="$TMP_ROOT/ref-switch.sh"
+  cat > "$probe" <<EOF
+#!/usr/bin/env bash
+set -e
+cd '$PRIMARY'
+git switch -q -c pre-marker-lane
+git switch -q '$PRIMARY_BRANCH'
+EOF
+  chmod +x "$probe"
+  out=$(run_guarded "$WORKTREE" "$probe" 2>&1); rc=$?
+  expect_code 126 "$rc" "a test that changes into the primary checkout must be refused before switching branches"
+  assert_contains "$out" "refusing Git in primary checkout '$PRIMARY'" \
+    "the mid-task refusal did not identify the primary checkout"
+  [ "$($REAL_GIT -C "$PRIMARY" branch --show-current)" = "$PRIMARY_BRANCH" ] \
+    || fail "the refused test left primary HEAD on another branch"
+  if $REAL_GIT -C "$PRIMARY" show-ref --verify --quiet refs/heads/pre-marker-lane; then
+    fail "the refused test created its fixture branch in the primary checkout"
+  fi
+  pass "worker Git guard: a mid-task test cannot switch the shared primary checkout"
+}
+
+test_explicit_primary_targets_are_refused() {
+  local out rc
+  out=$(run_guarded "$WORKTREE" git -C "$PRIMARY" status 2>&1); rc=$?
+  expect_code 126 "$rc" "git -C primary must be refused"
+  assert_contains "$out" "refusing Git in primary checkout" "git -C refusal lacked its reason"
+
+  out=$(run_guarded "$WORKTREE" git --namespace fixture -C "$PRIMARY" status 2>&1); rc=$?
+  expect_code 126 "$rc" "a valued global option must not hide a later -C primary target"
+
+  out=$(run_guarded "$WORKTREE" git --work-tree="$PRIMARY" status 2>&1); rc=$?
+  expect_code 126 "$rc" "--work-tree=primary must be refused"
+
+  out=$(run_guarded "$WORKTREE" git --git-dir="$PRIMARY/.git" status 2>&1); rc=$?
+  expect_code 126 "$rc" "--git-dir=primary must be refused"
+
+  out=$(cd "$WORKTREE" && PATH="$GUARD_DIR:$BASE_PATH" GIT_WORK_TREE="$PRIMARY" git status 2>&1); rc=$?
+  expect_code 126 "$rc" "GIT_WORK_TREE=primary must be refused"
+  pass "worker Git guard: explicit cwd, work-tree, git-dir, and environment targets are refused"
+}
+
+test_disposable_fixture_git_remains_available() {
+  local fixture
+  fixture="$TMP_ROOT/disposable-fixture"
+  mkdir -p "$fixture"
+  run_guarded "$fixture" git init -q \
+    || fail "the guard refused Git in an unrelated disposable fixture"
+  run_guarded "$fixture" git status --short >/dev/null \
+    || fail "the guard refused ordinary Git after fixture initialization"
+  pass "worker Git guard: unrelated disposable fixture repositories remain available"
+}
+
+test_missing_binding_fails_closed() {
+  local bad_dir out rc
+  bad_dir="$TMP_ROOT/bad/bin"
+  mkdir -p "$bad_dir"
+  cp "$ROOT/bin/fm-worker-git-guard.sh" "$bad_dir/git"
+  chmod 0700 "$bad_dir/git"
+  printf 'worktree=%s\n' "$WORKTREE" > "$bad_dir/git.conf"
+  out=$(cd "$WORKTREE" && PATH="$bad_dir:$BASE_PATH" git status 2>&1); rc=$?
+  expect_code 126 "$rc" "an incomplete binding must refuse rather than delegate to Git"
+  assert_contains "$out" "task isolation binding is incomplete" "the incomplete binding refusal was not explicit"
+  pass "worker Git guard: missing configuration fails closed"
+}
+
+test_spawn_freezes_and_exports_guard() {
+  local id tasktmp guard_path guard_dir case_dir home primary worktree fakebin launch_log out rc path_line launch_line
+  id="worker-git-spawn-$$"
+  tasktmp="/tmp/fm-$id"
+  FM_TEST_CLEANUP_DIRS+=("$tasktmp")
+  rm -rf "$tasktmp"
+  case_dir="$TMP_ROOT/spawn"
+  home="$case_dir/home"
+  primary="$case_dir/project"
+  worktree="$case_dir/worktree"
+  launch_log="$case_dir/launch.log"
+  fm_test_spawn_home "$home" codex
+  fm_test_spawn_brief "$home" "$id"
+  fm_git_worktree "$primary" "$worktree" guard-spawn-base
+  fakebin=$(fm_test_make_spawn_fakebin "$case_dir/fake" codex)
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows|has-session|new-session|new-window|kill-window|set-window-option) exit 0 ;;
+  send-keys)
+    shift
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -t) shift 2 ;;
+        -l) shift ;;
+        *) break ;;
+      esac
+    done
+    [ "$#" -gt 0 ] && printf '%s\n' "$1" >> "${FM_FAKE_LAUNCH_LOG:-/dev/null}"
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  : > "$launch_log"
+  out=$(FM_FAKE_LAUNCH_LOG="$launch_log" \
+    fm_test_run_spawn "$home" "$worktree" "$fakebin" \
+    "$id" "$primary" --harness codex --mode no-mistakes --yolo off)
+  rc=$?
+  expect_code 0 "$rc" "spawn should arm the per-task Git guard"
+  assert_contains "$out" "spawned $id harness=codex" "spawn did not report success"
+  guard_path=$(find "$tasktmp" -mindepth 2 -maxdepth 2 -type f -name git -path '*/git-guard.*/git' -print)
+  [ -n "$guard_path" ] || fail "spawn did not freeze the guard executable under tasktmp"
+  guard_dir=$(dirname "$guard_path")
+  assert_present "$guard_dir/git.conf" "spawn did not freeze the guard binding under tasktmp"
+  assert_grep "worktree=$worktree" "$guard_dir/git.conf" "spawn binding lost the assigned worktree"
+  assert_grep "primary=$primary" "$guard_dir/git.conf" "spawn binding lost the primary checkout"
+  assert_grep "export PATH='$guard_dir':\"\$PATH\"" "$launch_log" \
+    "spawn did not put the frozen guard first on the worker PATH: $(cat "$launch_log")"
+  path_line=$(grep -nF "export PATH='$guard_dir':\"\$PATH\"" "$launch_log" | cut -d: -f1)
+  launch_line=$(grep -n 'encode launch-brief' "$launch_log" | cut -d: -f1)
+  [ -n "$path_line" ] && [ -n "$launch_line" ] && [ "$path_line" -lt "$launch_line" ] \
+    || fail "the worker launch was sent before its Git guard PATH export"
+
+  out=$(cd "$worktree" && PATH="$guard_dir:$BASE_PATH" git fm-isolation-check 2>&1); rc=$?
+  expect_code 0 "$rc" "the spawn-produced executable assertion should accept its worktree"
+  out=$(cd "$primary" && PATH="$guard_dir:$BASE_PATH" git switch -q -c spawn-stray 2>&1); rc=$?
+  expect_code 126 "$rc" "the spawn-produced guard must refuse a primary branch switch"
+  if $REAL_GIT -C "$primary" show-ref --verify --quiet refs/heads/spawn-stray; then
+    fail "the spawn-produced guard allowed a stray branch in primary"
+  fi
+  pass "fm-spawn: every new ship/scout process tree receives a frozen Git guard before launch"
+}
+
+test_setup_assertion_and_worktree_git_succeed
+test_mid_task_resolved_primary_checkout_is_refused
+test_explicit_primary_targets_are_refused
+test_disposable_fixture_git_remains_available
+test_missing_binding_fails_closed
+test_spawn_freezes_and_exports_guard

--- a/tests/fm-worker-git-guard.test.sh
+++ b/tests/fm-worker-git-guard.test.sh
@@ -116,6 +116,23 @@ test_disposable_fixture_git_remains_available() {
   pass "worker Git guard: unrelated disposable fixture repositories remain available"
 }
 
+test_nested_task_worktree_is_allowed() {
+  local nested_primary nested_worktree nested_guard out rc
+  nested_primary="$TMP_ROOT/nested-project"
+  nested_worktree="$nested_primary/task-worktree"
+  nested_guard="$TMP_ROOT/nested-guard/bin"
+  fm_git_worktree "$nested_primary" "$nested_worktree" nested-task-base
+  install_guard "$nested_primary" "$nested_worktree" "$nested_guard"
+
+  out=$(cd "$nested_worktree" && PATH="$nested_guard:$BASE_PATH" git status --short 2>&1); rc=$?
+  expect_code 0 "$rc" "a legitimate task worktree nested below primary must not be mistaken for primary"
+  out=$(cd "$TMP_ROOT" && PATH="$nested_guard:$BASE_PATH" git -C "$nested_worktree" status --short 2>&1); rc=$?
+  expect_code 0 "$rc" "an explicit target inside a nested task worktree must remain available"
+  out=$(cd "$nested_worktree" && PATH="$nested_guard:$BASE_PATH" git -C "$nested_primary" status 2>&1); rc=$?
+  expect_code 126 "$rc" "the nested-worktree exception must not allow the primary checkout itself"
+  pass "worker Git guard: a nested assigned worktree is allowed without exposing its primary checkout"
+}
+
 test_missing_binding_fails_closed() {
   local bad_dir out rc
   bad_dir="$TMP_ROOT/bad/bin"
@@ -203,5 +220,6 @@ test_setup_assertion_and_worktree_git_succeed
 test_mid_task_resolved_primary_checkout_is_refused
 test_explicit_primary_targets_are_refused
 test_disposable_fixture_git_remains_available
+test_nested_task_worktree_is_allowed
 test_missing_binding_fails_closed
 test_spawn_freezes_and_exports_guard

--- a/tests/fm-worker-git-guard.test.sh
+++ b/tests/fm-worker-git-guard.test.sh
@@ -148,6 +148,7 @@ test_missing_binding_fails_closed() {
 
 test_spawn_freezes_and_exports_guard() {
   local id tasktmp guard_path guard_dir case_dir home primary worktree fakebin launch_log out rc path_line launch_line
+  local dropped_id dropped_tasktmp dropped_home dropped_primary dropped_worktree dropped_log
   id="worker-git-spawn-$$"
   tasktmp="/tmp/fm-$id"
   FM_TEST_CLEANUP_DIRS+=("$tasktmp")
@@ -179,7 +180,16 @@ case "${1:-}" in
         *) break ;;
       esac
     done
-    [ "$#" -gt 0 ] && printf '%s\n' "$1" >> "${FM_FAKE_LAUNCH_LOG:-/dev/null}"
+    if [ "$#" -gt 0 ]; then
+      printf '%s\n' "$1" >> "${FM_FAKE_LAUNCH_LOG:-/dev/null}"
+      case "$1" in
+        *"git fm-isolation-check"*)
+          if [ "${FM_FAKE_DROP_GIT_GUARD_EXPORT:-0}" != 1 ]; then
+            (cd "${FM_FAKE_PANE_PATH:?}" && /bin/bash -c "$1") || exit $?
+          fi
+          ;;
+      esac
+    fi
     exit 0
     ;;
 esac
@@ -213,7 +223,30 @@ SH
   if $REAL_GIT -C "$primary" show-ref --verify --quiet refs/heads/spawn-stray; then
     fail "the spawn-produced guard allowed a stray branch in primary"
   fi
-  pass "fm-spawn: every new ship/scout process tree receives a frozen Git guard before launch"
+
+  dropped_id="worker-git-dropped-export-$$"
+  dropped_tasktmp="/tmp/fm-$dropped_id"
+  FM_TEST_CLEANUP_DIRS+=("$dropped_tasktmp")
+  rm -rf "$dropped_tasktmp"
+  dropped_home="$case_dir/dropped-home"
+  dropped_primary="$case_dir/dropped-project"
+  dropped_worktree="$case_dir/dropped-worktree"
+  dropped_log="$case_dir/dropped-launch.log"
+  fm_test_spawn_home "$dropped_home" codex
+  fm_test_spawn_brief "$dropped_home" "$dropped_id"
+  fm_git_worktree "$dropped_primary" "$dropped_worktree" guard-dropped-base
+  : > "$dropped_log"
+  out=$(FM_FAKE_DROP_GIT_GUARD_EXPORT=1 FM_FAKE_LAUNCH_LOG="$dropped_log" \
+    fm_test_run_spawn "$dropped_home" "$dropped_worktree" "$fakebin" \
+    "$dropped_id" "$dropped_primary" --harness codex --mode no-mistakes --yolo off)
+  rc=$?
+  expect_code 1 "$rc" "spawn must refuse when the worker shell does not activate its Git guard"
+  assert_contains "$out" "worker Git isolation guard could not be verified first on PATH" \
+    "the dropped guard export did not report its launch refusal"
+  if grep -q 'encode launch-brief' "$dropped_log"; then
+    fail "spawn appended the worker launch after its Git guard activation was unverified"
+  fi
+  pass "fm-spawn: every new ship/scout process tree verifies its frozen Git guard before launch"
 }
 
 test_setup_assertion_and_worktree_git_succeed

--- a/tests/fm-worker-git-guard.test.sh
+++ b/tests/fm-worker-git-guard.test.sh
@@ -148,7 +148,7 @@ test_missing_binding_fails_closed() {
 
 test_spawn_freezes_and_exports_guard() {
   local id tasktmp guard_path guard_dir case_dir home primary worktree fakebin launch_log out rc path_line launch_line
-  local dropped_id dropped_tasktmp dropped_home dropped_primary dropped_worktree dropped_log
+  local dropped_id dropped_tasktmp dropped_home dropped_primary dropped_worktree dropped_log dropped_meta endpoint_state
   id="worker-git-spawn-$$"
   tasktmp="/tmp/fm-$id"
   FM_TEST_CLEANUP_DIRS+=("$tasktmp")
@@ -170,7 +170,18 @@ case "$*" in
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
-  list-windows|has-session|new-session|new-window|kill-window|set-window-option) exit 0 ;;
+  list-windows)
+    [ -z "${FM_FAKE_ENDPOINT_STATE:-}" ] || cat "$FM_FAKE_ENDPOINT_STATE" 2>/dev/null || true
+    exit 0
+    ;;
+  new-window)
+    if [ -n "${FM_FAKE_ENDPOINT_STATE:-}" ]; then
+      printf '%s\n' "${FM_FAKE_ENDPOINT_WINDOW:?}" > "$FM_FAKE_ENDPOINT_STATE"
+    fi
+    printf '@1\n'
+    exit 0
+    ;;
+  has-session|new-session|kill-window|set-window-option) exit 0 ;;
   send-keys)
     shift
     while [ "$#" -gt 0 ]; do
@@ -232,11 +243,14 @@ SH
   dropped_primary="$case_dir/dropped-project"
   dropped_worktree="$case_dir/dropped-worktree"
   dropped_log="$case_dir/dropped-launch.log"
+  dropped_meta="$dropped_home/state/$dropped_id.meta"
+  endpoint_state="$case_dir/dropped-endpoint"
   fm_test_spawn_home "$dropped_home" codex
   fm_test_spawn_brief "$dropped_home" "$dropped_id"
   fm_git_worktree "$dropped_primary" "$dropped_worktree" guard-dropped-base
   : > "$dropped_log"
   out=$(FM_FAKE_DROP_GIT_GUARD_EXPORT=1 FM_FAKE_LAUNCH_LOG="$dropped_log" \
+    FM_FAKE_ENDPOINT_STATE="$endpoint_state" FM_FAKE_ENDPOINT_WINDOW="fm-$dropped_id" \
     fm_test_run_spawn "$dropped_home" "$dropped_worktree" "$fakebin" \
     "$dropped_id" "$dropped_primary" --harness codex --mode no-mistakes --yolo off)
   rc=$?
@@ -246,6 +260,24 @@ SH
   if grep -q 'encode launch-brief' "$dropped_log"; then
     fail "spawn appended the worker launch after its Git guard activation was unverified"
   fi
+  assert_present "$dropped_meta" "the refused fresh spawn discarded its endpoint recovery record"
+  assert_grep "window=firstmate:fm-$dropped_id" "$dropped_meta" \
+    "the recovery record lost the exact refused endpoint"
+  assert_grep "endpoint_task_id=$dropped_id" "$dropped_meta" \
+    "the recovery record lost its task identity binding"
+  assert_grep "worktree=$dropped_worktree" "$dropped_meta" \
+    "the recovery record lost the exact local copy"
+  assert_grep "project=$dropped_primary" "$dropped_meta" \
+    "the recovery record lost the exact primary checkout"
+
+  out=$(FM_FAKE_LAUNCH_LOG="$dropped_log" \
+    FM_FAKE_ENDPOINT_STATE="$endpoint_state" FM_FAKE_ENDPOINT_WINDOW="fm-$dropped_id" \
+    fm_test_run_spawn "$dropped_home" "$dropped_worktree" "$fakebin" \
+    "$dropped_id" "$dropped_primary" --harness codex --mode no-mistakes --yolo off)
+  rc=$?
+  expect_code 1 "$rc" "a retry must refuse the retained fresh endpoint"
+  assert_contains "$out" "window firstmate:fm-$dropped_id already exists" \
+    "the retry did not refuse the exact retained endpoint"
   pass "fm-spawn: every new ship/scout process tree verifies its frozen Git guard before launch"
 }
 

--- a/tests/fm-worker-git-guard.test.sh
+++ b/tests/fm-worker-git-guard.test.sh
@@ -149,6 +149,7 @@ test_missing_binding_fails_closed() {
 test_spawn_freezes_and_exports_guard() {
   local id tasktmp guard_path guard_dir case_dir home primary worktree fakebin launch_log out rc path_line launch_line
   local dropped_id dropped_tasktmp dropped_home dropped_primary dropped_worktree dropped_log dropped_meta endpoint_state
+  local transport_id transport_tasktmp transport_home transport_primary transport_worktree transport_log transport_meta transport_endpoint
   id="worker-git-spawn-$$"
   tasktmp="/tmp/fm-$id"
   FM_TEST_CLEANUP_DIRS+=("$tasktmp")
@@ -195,6 +196,7 @@ case "${1:-}" in
       printf '%s\n' "$1" >> "${FM_FAKE_LAUNCH_LOG:-/dev/null}"
       case "$1" in
         *"git fm-isolation-check"*)
+          [ "${FM_FAKE_GIT_GUARD_SEND_FAIL:-0}" != 1 ] || exit 1
           if [ "${FM_FAKE_DROP_GIT_GUARD_EXPORT:-0}" != 1 ]; then
             (cd "${FM_FAKE_PANE_PATH:?}" && /bin/bash -c "$1") || exit $?
           fi
@@ -278,6 +280,44 @@ SH
   expect_code 1 "$rc" "a retry must refuse the retained fresh endpoint"
   assert_contains "$out" "window firstmate:fm-$dropped_id already exists" \
     "the retry did not refuse the exact retained endpoint"
+
+  transport_id="worker-git-transport-failure-$$"
+  transport_tasktmp="/tmp/fm-$transport_id"
+  FM_TEST_CLEANUP_DIRS+=("$transport_tasktmp")
+  rm -rf "$transport_tasktmp"
+  transport_home="$case_dir/transport-home"
+  transport_primary="$case_dir/transport-project"
+  transport_worktree="$case_dir/transport-worktree"
+  transport_log="$case_dir/transport-launch.log"
+  transport_meta="$transport_home/state/$transport_id.meta"
+  transport_endpoint="$case_dir/transport-endpoint"
+  fm_test_spawn_home "$transport_home" codex
+  fm_test_spawn_brief "$transport_home" "$transport_id"
+  fm_git_worktree "$transport_primary" "$transport_worktree" guard-transport-base
+  : > "$transport_log"
+  out=$(FM_FAKE_GIT_GUARD_SEND_FAIL=1 FM_FAKE_LAUNCH_LOG="$transport_log" \
+    FM_FAKE_ENDPOINT_STATE="$transport_endpoint" FM_FAKE_ENDPOINT_WINDOW="fm-$transport_id" \
+    fm_test_run_spawn "$transport_home" "$transport_worktree" "$fakebin" \
+    "$transport_id" "$transport_primary" --harness codex --mode no-mistakes --yolo off)
+  rc=$?
+  expect_code 1 "$rc" "spawn must refuse when the Git guard activation command cannot be delivered"
+  assert_contains "$out" "worker Git isolation guard activation command could not be delivered" \
+    "the guard transport failure did not report its launch refusal"
+  assert_grep "git fm-isolation-check" "$transport_log" \
+    "spawn did not attempt to deliver the Git guard activation command"
+  if grep -q 'encode launch-brief' "$transport_log"; then
+    fail "spawn appended the worker launch after its Git guard activation command failed"
+  fi
+  assert_present "$transport_endpoint" "the guard transport failure did not retain its fresh endpoint"
+  assert_present "$transport_meta" "the guard transport refusal discarded its endpoint recovery record"
+  assert_grep "window=firstmate:fm-$transport_id" "$transport_meta" \
+    "the transport-failure recovery record lost the exact refused endpoint"
+  assert_grep "endpoint_task_id=$transport_id" "$transport_meta" \
+    "the transport-failure recovery record lost its task identity binding"
+  assert_grep "worktree=$transport_worktree" "$transport_meta" \
+    "the transport-failure recovery record lost the exact local copy"
+  assert_grep "project=$transport_primary" "$transport_meta" \
+    "the transport-failure recovery record lost the exact primary checkout"
   pass "fm-spawn: every new ship/scout process tree verifies its frozen Git guard before launch"
 }
 


### PR DESCRIPTION
## Intent

A firstmate worker once did its work in the PRIMARY CHECKOUT instead of its own isolated copy, and ran a test there that creates and switches Git branches. That run died partway through on an assertion. Firstmate confirmed afterwards that the shared copy happened to be back on its main branch with the stray branch gone - which was luck. A crash one step earlier would have left the shared checkout, the one every sibling copy resolves against and every landing merges into, sitting on a stray branch. The ship instructions asserted isolation only at the START of a task, so nothing re-checked afterwards.

Asked what the guard should be, the captain ruled, verbatim: "Go with the recommendation." The recommendation he accepted was to ACCEPT the guard as a documented best-effort speed bump, honest about its known evasion routes, and to treat moving the enforcement point to something Git cannot be argued out of as the durable answer IF airtightness is later wanted. He explicitly did NOT choose hardening the wrapper into a Git command-line parser.

His reasoning, which he accepted as recorded: the incident this guard exists to prevent was a worker DRIFTING into the wrong directory - an accident, not evasion - so a documented bump delivers nearly all the value, while a parser arms race buys defence against a threat model nobody has.

He also ruled that the seven evasion routes and the temp-collision gap "must be documented in the guard itself rather than silently fixed or silently ignored." The seven accepted, documented evasion routes are core.worktree via -c/--config-env/GIT_CONFIG_*, unknown global-option arity, non-shell alias injection, an unrecognized linked-primary git dir, GIT_INDEX_FILE and related file-target redirection, absolute Git binaries, and login shells that reset PATH. The /tmp same-task-id collision and its cleanup-lifetime gap must also remain documented. The nested-isolated-worktree false positive is a real bug that must be fixed. Do not harden the wrapper into a Git command-line parser.

A separate standing rule applies to this submission: "Double check and reproduce anything before submitting an upstream PR -- keep a very high standard for principles and correctness before submitting."

## What Changed

- Install and verify a task-frozen `PATH` Git guard before every ship and scout launch, refusing primary-checkout targets while allowing assigned worktrees, nested isolated worktrees, and disposable fixture repositories.
- Add executable isolation assertions to generated worker briefs and document the guard as best-effort, including its accepted bypasses and same-task-ID temporary-directory collision gap.
- Add regression coverage for directory drift, explicit Git targets, invalid bindings, nested worktrees, and spawn-time guard activation or delivery failures.

## Risk Assessment

✅ Low: The guard is well-bounded to ship/scout launches, preserves the explicitly accepted limitations, fixes nested-worktree handling, and retains recovery metadata on both guard-verification failure paths.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 3 runs (1h25m33s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"950b19775daf1d37cc9949a2410d27838901282d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-spawn.sh:3329` - A fresh spawn creates its endpoint/worktree and publishes provisional metadata before this timeout. If the backend accepts the PATH command but the shell never executes it, the EXIT rollback removes the metadata without closing most backends' endpoint/worktree; Orca cleanup is already disabled. The next spawn then refuses the duplicate endpoint, leaving manual recovery. Clean up the exact fresh endpoint before rolling back, or retain a durable recovery record.

🔧 Fix: Captain, preserve fresh-spawn recovery records
1 warning still open:

- ⚠️ `bin/fm-spawn.sh:3323` - `spawn_send_text_line` is a fallible transport boundary, but this call is unguarded under `set -e`. For example, Zellij/cmux can write the PATH command, fail to submit Enter, clear the partial input, and return nonzero while leaving the endpoint alive. Control then skips the preservation block below, and EXIT cleanup rolls back the published metadata while retaining the endpoint/worktree. A later spawn can refuse the duplicate without a recovery record. Route send failures through the same fresh-spawn metadata-preservation path before exiting.

🔧 Fix: Captain, preserve guard transport recovery records
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Fix spawn fixtures to publish guard activation proof
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Execute Git guard proof in backlog spawn fixture
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

## Verification limits

- **NOT VERIFIED:** `tests/fm-remote-secondmate-lifecycle-e2e.test.sh` and `tests/fm-remote-secondmate-trace-context.test.sh` were not run because the pipeline's changed-test selection omitted them. This is adjacent coverage: the change adds a PATH-resolved guard inside the spawn path, which secondmate spawns also traverse.
- The local test exit comprised three failures: the composer half-block fixture, the Muse detection fixture, and Kimi. The composer and Muse failures reproduce on unmodified main on this host, so they are pre-existing and were not caused by this change.
- The Kimi test failure reproduced only when the host selected system Python 3.9, which lacks `tomllib`; the identical tree passed with Python 3.14. This is a host-toolchain artifact, not a defect in this change.
- The pipeline was deliberately allowed to continue while recording these failures rather than re-running until green or suppressing them. The open test error above is therefore an intentional record of the measured result, not an omitted follow-up.
- The one red check-rollup entry is an apparent double-fire of `PR must be raised via no-mistakes` on the identical `950b1977` head: the successful run completed at 22:04:27Z and the failed run at 22:04:28Z after starting one second apart. The cause was not established.
