### PR TITLE
fix: restore stock macOS Bash compatibility

### DIFF
--- a/bin/fm-remote-home-seed.sh
+++ b/bin/fm-remote-home-seed.sh
@@ -157,7 +157,7 @@ done < "$BRIEF" > "$TMP/charter.remote"
 PROJECTS_CSV=
 : > "$TMP/project.records"
 PROJECT_INDEX=0
-for project in "${PROJECT_NAMES[@]}"; do
+for project in "${PROJECT_NAMES[@]+"${PROJECT_NAMES[@]}"}"; do
   ORIGIN=${PROJECT_ORIGINS[$PROJECT_INDEX]}
   PROJECT_INDEX=$((PROJECT_INDEX + 1))
   MODE_LINE=$(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" "$SCRIPT_DIR/fm-project-mode.sh" "$project")

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -271,18 +271,18 @@ test_matrix_herdr_halfblock_rule_bounds_bare_wrap() {
   # footer, whose real content turns an idle pane into a false `pending`.
   # Captured live from a herdr cursor pane.
   local screen plain out
-  plain=$'transcript\n \u2584\u2584\u2584\u2584\u2584\u2584\u2584\u2584\n  \u2192 Add a follow-up\n \u2580\u2580\u2580\u2580\u2580\u2580\u2580\u2580\n  Cursor Grok 4.5 High \u00b7 6.7%   Run Everything\n  ~/wt \u00b7 64cdd3a'
+  plain=$'transcript\n ▄▄▄▄▄▄▄▄\n  → Add a follow-up\n ▀▀▀▀▀▀▀▀\n  Cursor Grok 4.5 High · 6.7%   Run Everything\n  ~/wt · 64cdd3a'
   # The closing rule must bound the region, so the footer below is not input.
-  fm_composer_row_has_edge " $(printf '\u2580\u2580\u2580')" \
+  fm_composer_row_has_edge ' ▀▀▀' \
     || fail "a half-block rule row must count as a structural edge"
-  fm_composer_row_has_edge " $(printf '\u2584\u2584\u2584')" \
+  fm_composer_row_has_edge ' ▄▄▄' \
     || fail "the upper half-block rule must count as a structural edge"
   # Non-vacuousness: the footer rows really are non-blank content that would be
   # swallowed if the rule did not bound the region.
   case "$plain" in *"Run Everything"*) : ;; *) fail "fixture lost its footer content" ;; esac
   ESC_LOCAL=$(printf '\033')
-  screen=$'transcript\n \u2584\u2584\u2584\u2584\u2584\u2584\u2584\u2584\n'"  ${ESC_LOCAL}[2m\u2192 ${ESC_LOCAL}[0;7mA${ESC_LOCAL}[0;2mdd a follow-up${ESC_LOCAL}[0m"$'\n \u2580\u2580\u2580\u2580\u2580\u2580\u2580\u2580\n  Cursor Grok 4.5 High \u00b7 6.7%   Run Everything\n  ~/wt \u00b7 64cdd3a'
-  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$(printf '%b' "$screen")")
+  screen=$'transcript\n ▄▄▄▄▄▄▄▄\n'"  ${ESC_LOCAL}[2m→ ${ESC_LOCAL}[0;7mA${ESC_LOCAL}[0;2mdd a follow-up${ESC_LOCAL}[0m"$'\n ▀▀▀▀▀▀▀▀\n  Cursor Grok 4.5 High · 6.7%   Run Everything\n  ~/wt · 64cdd3a'
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen")
   [ "$out" = empty ] \
     || fail "an idle cursor composer inside herdr half-block rules must read empty, got '$out'"
   pass "matrix: herdr half-block rules bound a bare composer's wrap region"


### PR DESCRIPTION
## Intent

Four tests fail on stock macOS Bash 3.2 at pristine upstream main and pass on the same host and tree when only Bash on `PATH` changes to modern Bash. They are two distinct defects, one in a test fixture and one in product code.

**1. Composer fixture (test-only).** `tests/fm-composer-lib.test.sh` builds its half-block fixture with ANSI-C `\u` escapes, which Bash 3.2 emits literally because Unicode escapes require Bash 4.2 or newer. `fm_composer_row_has_edge` therefore receives the ASCII text `\u2580` instead of the `▀` glyph. The product matcher is correct; only the fixture is wrong. Replaced with literal UTF-8 glyphs, matching every other fixture in the file. No product code changes.

**2. Remote home seed (product defect).** `bin/fm-remote-home-seed.sh` runs under `set -eu`, initialises `PROJECT_NAMES` as an empty array for `--no-projects`, then expands `"${PROJECT_NAMES[@]}"`. Bash 3.2 treats that empty expansion as an unbound variable and aborts the seed; Bash 4.4+ treats it as a no-op. The script's own usage header documents `--no-projects` as a supported way to seed with an empty project list, so on stock macOS Bash that documented path cannot complete. Fixed with the repository's existing guarded-array form; sibling arrays were checked for the same exposure. The remote trace-context and lifecycle test failures are two symptoms of this one defect, not independent confirmations.

`bash -n` parses the defective seed script clean under Bash 3.2, so the existing macOS parse sweep cannot catch this: it is a runtime failure, not a syntax error. Both changes are proven red-before / green-after on Apple's `/bin/bash` 3.2.57 and green-before / green-after on Bash 5.3, with logs linked below.

## What Changed

- Guard empty `PROJECT_NAMES` iteration with the repository’s Bash 3.2-safe array expansion so `--no-projects` remote seeding does not fail under `set -u`.
- Replace Bash 4.2-only Unicode escapes in the Herdr composer fixture with literal UTF-8 glyphs, ensuring the existing edge matcher receives the intended half-block characters on stock macOS Bash.

## Risk Assessment

✅ Low: Both changes are narrowly scoped, add no behavior, and leave no sibling empty-array path exposed.

## Testing

The supplied changed-test baseline passed; focused automated and end-to-end checks reproduced both base failures under Bash 3.2, stayed green on base Bash 5.3, passed the target under both shells, and produced five reviewer-visible CLI evidence logs. No screenshot was applicable because the changed surfaces are shell-runtime behavior and terminal fixtures rather than rendered UI.

<details>
<summary>Evidence: Pre-fix Bash 3.2 reproduction</summary>

Source: [Pre-fix Bash 3.2 reproduction](https://github.com/3264studios/firstmate/blob/3967ba97b469239abd71eed4ab7ac9f4a05f0448/.no-mistakes/evidence/fm/fm-bash32-upstream-fixes/bash32-base-red.log)

<code>Reproduces the half-block assertion failure and the shared remote-seed failure, including `PROJECT_NAMES[@]: unbound variable`.</code>

```text
Interpreter: GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

Command: PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin /bin/bash tests/fm-composer-lib.test.sh
ok - fm_composer_classify_content: a bare shell prompt glyph (>/$/%/#) reads unknown, never empty
ok - fm_composer_classify_content: stripped unbordered content is unknown except verified agent glyphs
ok - fm_composer_classify_content: a bare shell prompt carrying a command is not empty
ok - fm_composer_classify_content: a bare prompt glyph inside a bordered composer box reads empty (claude's own idle composer)
ok - fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex, ⟩ muse) read empty bordered or bare
ok - fm_composer_classify_content: an empty composer reads empty
ok - fm_composer_classify_content: idle matching is limited to proven placeholder positions
ok - fm_composer_classify_content: idle matching preserves the caller's case mode
ok - fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)
ok - matrix: claude's ❯+NBSP row reads empty on every profile in both locales (#1988)
ok - matrix: codex's dim hint is empty when styling proves it, unknown (never pending) when it cannot
ok - matrix: muse's ⟩ reads empty everywhere and survives losing the styled-glyph signal
ok - matrix: cursor's reverse-video placeholder remnant reads empty; real typed text stays pending
not ok - a half-block rule row must count as a structural edge
Exit: 1

Command: PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin /bin/bash tests/fm-remote-secondmate-trace-context.test.sh
~/.no-mistakes/worktrees/9b0bfac143a1/01M1PZETF1QCTHCZAZPRG442DQ/.nm-base-bash32.WroJL8/bin/fm-remote-home-seed.sh: line 190: PROJECT_NAMES[@]: unbound variable
not ok - default-off remote secondmate spawn failed
Exit: 1

Command: PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin /bin/bash tests/fm-remote-secondmate-lifecycle-e2e.test.sh
ok - overlapping remote home provisioning serializes through publication and rollback
not ok - failing seed exited before remote provisioning
Exit: 1
```
</details>
<details>
<summary>Evidence: Pre-fix Bash 5.3 control</summary>

Source: [Pre-fix Bash 5.3 control](https://github.com/3264studios/firstmate/blob/3967ba97b469239abd71eed4ab7ac9f4a05f0448/.no-mistakes/evidence/fm/fm-bash32-upstream-fixes/bash53-base-green.log)

`All three focused suites pass on the base commit under Bash 5.3.`

```text
Interpreter: GNU bash, version 5.3.15(1)-release (aarch64-apple-darwin25.4.0)

Command: PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin /opt/homebrew/bin/bash tests/fm-composer-lib.test.sh
ok - fm_composer_classify_content: a bare shell prompt glyph (>/$/%/#) reads unknown, never empty
ok - fm_composer_classify_content: stripped unbordered content is unknown except verified agent glyphs
ok - fm_composer_classify_content: a bare shell prompt carrying a command is not empty
ok - fm_composer_classify_content: a bare prompt glyph inside a bordered composer box reads empty (claude's own idle composer)
ok - fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex, ⟩ muse) read empty bordered or bare
ok - fm_composer_classify_content: an empty composer reads empty
ok - fm_composer_classify_content: idle matching is limited to proven placeholder positions
ok - fm_composer_classify_content: idle matching preserves the caller's case mode
ok - fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)
ok - matrix: claude's ❯+NBSP row reads empty on every profile in both locales (#1988)
ok - matrix: codex's dim hint is empty when styling proves it, unknown (never pending) when it cannot
ok - matrix: muse's ⟩ reads empty everywhere and survives losing the styled-glyph signal
ok - matrix: cursor's reverse-video placeholder remnant reads empty; real typed text stays pending
ok - matrix: herdr half-block rules bound a bare composer's wrap region
ok - matrix: pi's separated composer needs identity + structure; the blank row alone never proves it
ok - matrix: opencode's left-bar composer reads empty everywhere and scans the full active run
ok - matrix: grok's titled bottom border is tolerated as a title, not read as ambiguity
ok - matrix: kimi's bordered shell-glyph box reads empty through the shared owner (spawn's fourth copy retired)
ok - matrix: the real claude-in-zellij --ansi dump reads empty in both locales
ok - strict posture: blank and unidentified rows are unknown, never injectable empty
ok - fm_composer_classify_screen: the bare composer's wrap region stays identified; structure breaks it
ok - fm_composer_classify_screen: a row-leading agent glyph reanchors the live composer
ok - fm_composer_classify_screen: a lower dead shell invalidates only cursorless stale composers
ok - fm_composer_classify_screen: cursorless bare wrap regions participate in verdicts
ok - fm_composer_classify_screen: cursorless containers reject only contiguous unclaimed activity
ok - fm_composer_classify_screen: the bottom-most candidate wins; stale banners cannot
ok - fm_composer_classify_screen: incomplete lower structure invalidates stale boxes
ok - fm_composer_classify_screen: titled bottoms retain full box geometry
ok - fm_composer_classify_screen: a proven box tolerates a bottom-border cursor
ok - fm_composer_extract_selected_content: scopes user content and excludes furniture
ok - fm_composer_queued_enter_verdict: pending + busy returns empty (queued Enter)
ok - fm_composer_queued_enter_verdict: pending + idle/unknown stays pending
ok - fm_composer_queued_enter_verdict: only proven pending is converted
Exit: 0

Command: PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin /opt/homebrew/bin/bash tests/fm-remote-secondmate-trace-context.test.sh
ok - disabled: a remote-routed second mate records and receives no carrier and stays enabled-off end to end
ok - enabled: a remote-routed second mate receives one carrier in its pane, identical to the parent's recorded identity, before launch
ok - relaunch: a remote-routed second mate keeps one stable identity across restarts
ok - boundary: each remote-routed second mate roots its own trace and never adopts the spawning environment's carrier
ok - allowlist: the remote receiver accepts exactly the declared inherited-material set, including the enablement flag
ok - delivery: a parent-supplied carrier is accepted only for a secondmate launch and only as a strict W3C value
ALL TESTS PASSED
Exit: 0

Command: PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin /opt/homebrew/bin/bash tests/fm-remote-secondmate-lifecycle-e2e.test.sh
ok - overlapping remote home provisioning serializes through publication and rollback
ok - remote seed rollback preserves serialized competing routes
ok - unknown readiness preserves its route and brief for reconciliation
ok - remote seeding checks, repairs, and re-checks readiness, then stops on a remaining gap
ok - remote seeding proceeds once the repair closes every gap
ok - remote seeding provisions a supplied origin without touching the primary project tree
ok - remote provisioning re-validates a supplied origin at the receiving host
ok - seeding carries bitbucket, self-hosted, and scp-like origins through to the remote clone
ok - remote seed registers the route and provisions the whole home and project clone on that host
ok - remote inheritance rejects incomplete and superseded payload generations
ok - mixed local and remote routes validate without migration
ok - remote spawn launches on the remote-local backend and records a host-qualified route
ok - legacy and mismatched remote endpoints fail closed before backend access
ok - non-herdr remote endpoints are refused without changing either route
ok - remote spawn serializes inheritance through launch publication
cannot retire terminal source; it remains registered: remote-reply-ios
ok - marked send and routed reply complete through the existing parent correlation owner
cannot retire terminal source; it remains registered: remote-reply-ios
ok - partial remote inheritance retains reread intent through bootstrap convergence
ok - config push and bootstrap serialize remote inheritance convergence
WARNING: watcher still down (same stale episode; last beat: 76s ago, grace 300s) - full banner already printed this episode.
cannot retire terminal source; it remains registered: remote-reply-ios
ok - remote inherited config retains and retries a failed live reread nudge
cannot retire terminal source; it remains registered: remote-reply-ios
cannot retire terminal source; it remains registered: remote-reply-ios
cannot retire terminal source; it remains registered: remote-reply-ios
ok - fleet snapshot projects mixed local and remote structured state
ok - remote update imports and fast-forwards the persistent home on its configured host
ok - the remote restart verb delegates to the host-local control plane and refuses before stopping anything
ok - startup repairs remote readiness before probing without relaunching
ok - startup reports alive legacy backends without changing their routes
ok - unreachable no-ledger remote state remains explicit with no local respawn or failover
cannot retire terminal source; it remains registered: remote-reply-ios
ok - remote retirement refuses child work, then removes only its own endpoint while a shared-session sibling survives
ALL TESTS PASSED
Exit: 0
```
</details>
<details>
<summary>Evidence: Post-fix Bash 3.2 result</summary>

Source: [Post-fix Bash 3.2 result](https://github.com/3264studios/firstmate/blob/3967ba97b469239abd71eed4ab7ac9f4a05f0448/.no-mistakes/evidence/fm/fm-bash32-upstream-fixes/bash32-target-green.log)

`All three focused suites pass on the target commit under Apple Bash 3.2.`

```text
Interpreter: GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

Command: PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin /bin/bash tests/fm-composer-lib.test.sh
ok - fm_composer_classify_content: a bare shell prompt glyph (>/$/%/#) reads unknown, never empty
ok - fm_composer_classify_content: stripped unbordered content is unknown except verified agent glyphs
ok - fm_composer_classify_content: a bare shell prompt carrying a command is not empty
ok - fm_composer_classify_content: a bare prompt glyph inside a bordered composer box reads empty (claude's own idle composer)
ok - fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex, ⟩ muse) read empty bordered or bare
ok - fm_composer_classify_content: an empty composer reads empty
ok - fm_composer_classify_content: idle matching is limited to proven placeholder positions
ok - fm_composer_classify_content: idle matching preserves the caller's case mode
ok - fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)
ok - matrix: claude's ❯+NBSP row reads empty on every profile in both locales (#1988)
ok - matrix: codex's dim hint is empty when styling proves it, unknown (never pending) when it cannot
ok - matrix: muse's ⟩ reads empty everywhere and survives losing the styled-glyph signal
ok - matrix: cursor's reverse-video placeholder remnant reads empty; real typed text stays pending
ok - matrix: herdr half-block rules bound a bare composer's wrap region
ok - matrix: pi's separated composer needs identity + structure; the blank row alone never proves it
ok - matrix: opencode's left-bar composer reads empty everywhere and scans the full active run
ok - matrix: grok's titled bottom border is tolerated as a title, not read as ambiguity
ok - matrix: kimi's bordered shell-glyph box reads empty through the shared owner (spawn's fourth copy retired)
ok - matrix: the real claude-in-zellij --ansi dump reads empty in both locales
ok - strict posture: blank and unidentified rows are unknown, never injectable empty
ok - fm_composer_classify_screen: the bare composer's wrap region stays identified; structure breaks it
ok - fm_composer_classify_screen: a row-leading agent glyph reanchors the live composer
ok - fm_composer_classify_screen: a lower dead shell invalidates only cursorless stale composers
ok - fm_composer_classify_screen: cursorless bare wrap regions participate in verdicts
ok - fm_composer_classify_screen: cursorless containers reject only contiguous unclaimed activity
ok - fm_composer_classify_screen: the bottom-most candidate wins; stale banners cannot
ok - fm_composer_classify_screen: incomplete lower structure invalidates stale boxes
ok - fm_composer_classify_screen: titled bottoms retain full box geometry
ok - fm_composer_classify_screen: a proven box tolerates a bottom-border cursor
ok - fm_composer_extract_selected_content: scopes user content and excludes furniture
ok - fm_composer_queued_enter_verdict: pending + busy returns empty (queued Enter)
ok - fm_composer_queued_enter_verdict: pending + idle/unknown stays pending
ok - fm_composer_queued_enter_verdict: only proven pending is converted
Exit: 0

Command: PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin /bin/bash tests/fm-remote-secondmate-trace-context.test.sh
ok - disabled: a remote-routed second mate records and receives no carrier and stays enabled-off end to end
ok - enabled: a remote-routed second mate receives one carrier in its pane, identical to the parent's recorded identity, before launch
ok - relaunch: a remote-routed second mate keeps one stable identity across restarts
ok - boundary: each remote-routed second mate roots its own trace and never adopts the spawning environment's carrier
ok - allowlist: the remote receiver accepts exactly the declared inherited-material set, including the enablement flag
ok - delivery: a parent-supplied carrier is accepted only for a secondmate launch and only as a strict W3C value
ALL TESTS PASSED
Exit: 0

Command: PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin /bin/bash tests/fm-remote-secondmate-lifecycle-e2e.test.sh
ok - overlapping remote home provisioning serializes through publication and rollback
ok - remote seed rollback preserves serialized competing routes
ok - unknown readiness preserves its route and brief for reconciliation
ok - remote seeding checks, repairs, and re-checks readiness, then stops on a remaining gap
ok - remote seeding proceeds once the repair closes every gap
ok - remote seeding provisions a supplied origin without touching the primary project tree
ok - remote provisioning re-validates a supplied origin at the receiving host
ok - seeding carries bitbucket, self-hosted, and scp-like origins through to the remote clone
ok - remote seed registers the route and provisions the whole home and project clone on that host
ok - remote inheritance rejects incomplete and superseded payload generations
ok - mixed local and remote routes validate without migration
ok - remote spawn launches on the remote-local backend and records a host-qualified route
ok - legacy and mismatched remote endpoints fail closed before backend access
ok - non-herdr remote endpoints are refused without changing either route
ok - remote spawn serializes inheritance through launch publication
cannot retire terminal source; it remains registered: remote-reply-ios
ok - marked send and routed reply complete through the existing parent correlation owner
cannot retire terminal source; it remains registered: remote-reply-ios
ok - partial remote inheritance retains reread intent through bootstrap convergence
ok - config push and bootstrap serialize remote inheritance convergence
WARNING: watcher still down (same stale episode; last beat: 64s ago, grace 300s) - full banner already printed this episode.
cannot retire terminal source; it remains registered: remote-reply-ios
ok - remote inherited config retains and retries a failed live reread nudge
cannot retire terminal source; it remains registered: remote-reply-ios
cannot retire terminal source; it remains registered: remote-reply-ios
cannot retire terminal source; it remains registered: remote-reply-ios
ok - fleet snapshot projects mixed local and remote structured state
ok - remote update imports and fast-forwards the persistent home on its configured host
ok - the remote restart verb delegates to the host-local control plane and refuses before stopping anything
ok - startup repairs remote readiness before probing without relaunching
ok - startup reports alive legacy backends without changing their routes
ok - unreachable no-ledger remote state remains explicit with no local respawn or failover
cannot retire terminal source; it remains registered: remote-reply-ios
ok - remote retirement refuses child work, then removes only its own endpoint while a shared-session sibling survives
ALL TESTS PASSED
Exit: 0
```
</details>
<details>
<summary>Evidence: Post-fix Bash 5.3 result</summary>

Source: [Post-fix Bash 5.3 result](https://github.com/3264studios/firstmate/blob/3967ba97b469239abd71eed4ab7ac9f4a05f0448/.no-mistakes/evidence/fm/fm-bash32-upstream-fixes/bash53-target-green.log)

`All three focused suites pass on the target commit under Bash 5.3.`

```text
Interpreter: GNU bash, version 5.3.15(1)-release (aarch64-apple-darwin25.4.0)

Command: PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin /opt/homebrew/bin/bash tests/fm-composer-lib.test.sh
ok - fm_composer_classify_content: a bare shell prompt glyph (>/$/%/#) reads unknown, never empty
ok - fm_composer_classify_content: stripped unbordered content is unknown except verified agent glyphs
ok - fm_composer_classify_content: a bare shell prompt carrying a command is not empty
ok - fm_composer_classify_content: a bare prompt glyph inside a bordered composer box reads empty (claude's own idle composer)
ok - fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex, ⟩ muse) read empty bordered or bare
ok - fm_composer_classify_content: an empty composer reads empty
ok - fm_composer_classify_content: idle matching is limited to proven placeholder positions
ok - fm_composer_classify_content: idle matching preserves the caller's case mode
ok - fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)
ok - matrix: claude's ❯+NBSP row reads empty on every profile in both locales (#1988)
ok - matrix: codex's dim hint is empty when styling proves it, unknown (never pending) when it cannot
ok - matrix: muse's ⟩ reads empty everywhere and survives losing the styled-glyph signal
ok - matrix: cursor's reverse-video placeholder remnant reads empty; real typed text stays pending
ok - matrix: herdr half-block rules bound a bare composer's wrap region
ok - matrix: pi's separated composer needs identity + structure; the blank row alone never proves it
ok - matrix: opencode's left-bar composer reads empty everywhere and scans the full active run
ok - matrix: grok's titled bottom border is tolerated as a title, not read as ambiguity
ok - matrix: kimi's bordered shell-glyph box reads empty through the shared owner (spawn's fourth copy retired)
ok - matrix: the real claude-in-zellij --ansi dump reads empty in both locales
ok - strict posture: blank and unidentified rows are unknown, never injectable empty
ok - fm_composer_classify_screen: the bare composer's wrap region stays identified; structure breaks it
ok - fm_composer_classify_screen: a row-leading agent glyph reanchors the live composer
ok - fm_composer_classify_screen: a lower dead shell invalidates only cursorless stale composers
ok - fm_composer_classify_screen: cursorless bare wrap regions participate in verdicts
ok - fm_composer_classify_screen: cursorless containers reject only contiguous unclaimed activity
ok - fm_composer_classify_screen: the bottom-most candidate wins; stale banners cannot
ok - fm_composer_classify_screen: incomplete lower structure invalidates stale boxes
ok - fm_composer_classify_screen: titled bottoms retain full box geometry
ok - fm_composer_classify_screen: a proven box tolerates a bottom-border cursor
ok - fm_composer_extract_selected_content: scopes user content and excludes furniture
ok - fm_composer_queued_enter_verdict: pending + busy returns empty (queued Enter)
ok - fm_composer_queued_enter_verdict: pending + idle/unknown stays pending
ok - fm_composer_queued_enter_verdict: only proven pending is converted
Exit: 0

Command: PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin /opt/homebrew/bin/bash tests/fm-remote-secondmate-trace-context.test.sh
ok - disabled: a remote-routed second mate records and receives no carrier and stays enabled-off end to end
ok - enabled: a remote-routed second mate receives one carrier in its pane, identical to the parent's recorded identity, before launch
ok - relaunch: a remote-routed second mate keeps one stable identity across restarts
ok - boundary: each remote-routed second mate roots its own trace and never adopts the spawning environment's carrier
ok - allowlist: the remote receiver accepts exactly the declared inherited-material set, including the enablement flag
ok - delivery: a parent-supplied carrier is accepted only for a secondmate launch and only as a strict W3C value
ALL TESTS PASSED
Exit: 0

Command: PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin /opt/homebrew/bin/bash tests/fm-remote-secondmate-lifecycle-e2e.test.sh
ok - overlapping remote home provisioning serializes through publication and rollback
ok - remote seed rollback preserves serialized competing routes
ok - unknown readiness preserves its route and brief for reconciliation
ok - remote seeding checks, repairs, and re-checks readiness, then stops on a remaining gap
ok - remote seeding proceeds once the repair closes every gap
ok - remote seeding provisions a supplied origin without touching the primary project tree
ok - remote provisioning re-validates a supplied origin at the receiving host
ok - seeding carries bitbucket, self-hosted, and scp-like origins through to the remote clone
ok - remote seed registers the route and provisions the whole home and project clone on that host
ok - remote inheritance rejects incomplete and superseded payload generations
ok - mixed local and remote routes validate without migration
ok - remote spawn launches on the remote-local backend and records a host-qualified route
ok - legacy and mismatched remote endpoints fail closed before backend access
ok - non-herdr remote endpoints are refused without changing either route
ok - remote spawn serializes inheritance through launch publication
cannot retire terminal source; it remains registered: remote-reply-ios
ok - marked send and routed reply complete through the existing parent correlation owner
cannot retire terminal source; it remains registered: remote-reply-ios
ok - partial remote inheritance retains reread intent through bootstrap convergence
ok - config push and bootstrap serialize remote inheritance convergence
WARNING: watcher still down (same stale episode; last beat: 59s ago, grace 300s) - full banner already printed this episode.
cannot retire terminal source; it remains registered: remote-reply-ios
ok - remote inherited config retains and retries a failed live reread nudge
cannot retire terminal source; it remains registered: remote-reply-ios
cannot retire terminal source; it remains registered: remote-reply-ios
cannot retire terminal source; it remains registered: remote-reply-ios
ok - fleet snapshot projects mixed local and remote structured state
ok - remote update imports and fast-forwards the persistent home on its configured host
ok - the remote restart verb delegates to the host-local control plane and refuses before stopping anything
ok - startup repairs remote readiness before probing without relaunching
ok - startup reports alive legacy backends without changing their routes
ok - unreachable no-ledger remote state remains explicit with no local respawn or failover
cannot retire terminal source; it remains registered: remote-reply-ios
ok - remote retirement refuses child work, then removes only its own endpoint while a shared-session sibling survives
ALL TESTS PASSED
Exit: 0
```
</details>
<details>
<summary>Evidence: Compatibility mechanism proof</summary>

Source: [Compatibility mechanism proof](https://github.com/3264studios/firstmate/blob/3967ba97b469239abd71eed4ab7ac9f4a05f0448/.no-mistakes/evidence/fm/fm-bash32-upstream-fixes/bash-compatibility-mechanisms.log)

<code>Shows Bash 3.2’s literal `\u2580` bytes, its unbound empty-array failure, the guarded expansion succeeding, Bash 5.3’s differing behavior, and the defective base seed script parsing cleanly under `bash -n`.</code>

```text
ANSI-C Unicode escape bytes under Bash 3.2 (expected literal backslash-u bytes):
           5c  75  32  35  38  30                                        

ANSI-C Unicode escape bytes under Bash 5.3 (expected UTF-8 U+2580 bytes):
           e2  96  80                                                    


Bash 3.2 unguarded empty-array loop:
/bin/bash: values[@]: unbound variable
Exit: 127
Bash 3.2 guarded empty-array loop:
reached
Exit: 0
Bash 5.3 unguarded empty-array loop:
reached
Exit: 0

Base seed script parse check under Bash 3.2:
Exit: 0 (parses cleanly despite the reproduced runtime failure)
Target seed script parse check under Bash 3.2:
Exit: 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"965bfa7dc92c860d83fefcefa7ffb86dadef1e27","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>Supplied baseline: `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated` (passed).</code>
- <code>Ran base-commit `tests/fm-composer-lib.test.sh`, `tests/fm-remote-secondmate-trace-context.test.sh`, and `tests/fm-remote-secondmate-lifecycle-e2e.test.sh` under Apple `/bin/bash` 3.2.57; all reproduced the expected failures.</code>
- <code>Ran the same three base-commit suites under `/opt/homebrew/bin/bash` 5.3.15; all passed.</code>
- `Ran the same three target-commit suites under Apple Bash 3.2.57; all passed.`
- `Ran the same three target-commit suites under Bash 5.3.15; all passed.`
- <code>Compared `$&#39;\u2580&#39;` byte output and empty-array loop behavior under both shells, including the Bash-3.2-safe guarded expansion.</code>
- <code>Ran `/bin/bash -n` against the base and target seed scripts; both parsed successfully, confirming the base defect was runtime-only.</code>
- <code>Inspected every `PROJECT_NAMES` and `PROJECT_ORIGINS` expansion; the sibling origin array is indexed only within the now-guarded loop, and the remaining project-name expansion is protected by the non-empty branch.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

