### PR TITLE
feat: require Ponytail for development flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,7 +350,7 @@ For a no-mistakes ship, trigger validation on the same worker after its implemen
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 When the captain adds or changes an ask mid-task, append the captain's words to that brief's `## Captain's intent` and steer the worker; Firstmate build constraints stay in `## Firstmate spec` or the steer.
-`bin/fm-dod-lib.sh` owns the worker-side `--intent` contract.
+When starting validation, the worker follows the no-mistakes handoff rendered from the ship contract owner named in section 11.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.
 
 Only a current, explicit captain instruction that completely invalidates the work being validated keeps the task with the same worker instead of routing it to follow-up work or handing it to a replacement.
@@ -520,9 +520,8 @@ Preserve durable structured identifiers, dependencies, and completion artifact l
 
 ## 11. Crewmate briefs
 
-`bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, delivery-mode definitions of done, and exact safety mechanics.
+`bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, and exact scaffold safety mechanics, while `bin/fm-dod-lib.sh` owns the generated ship's Ponytail development contract, delivery-mode definitions of done, and no-mistakes intent and handoff contracts.
 Use its scaffold as the contract, then fill `## Captain's intent` (`{TASK}`) with the captain's own ask plus the context needed to read it, including the substance of any report, decision, or PR the ask refers to, and fill `## Firstmate spec` (`{FIRSTMATE_SPEC}`) with Firstmate's build instructions.
-`bin/fm-dod-lib.sh` owns what a no-mistakes worker may pass as `--intent` and its rule that the string must be self-sufficient.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -59,6 +59,9 @@
 # Every scaffold also carries the steering-inbox receive-and-ack section:
 # process state/<id>.inbox/*.msg in order and acknowledge each by moving it to
 # handled/ (record, doorbell, and ladder owned by bin/fm-task-inbox-lib.sh).
+# Every ship brief receives the compact Ponytail full development contract from
+# bin/fm-dod-lib.sh. Scout and secondmate briefs do not, so unrelated read-only
+# and prose-only work never inherits coding discipline merely by being delegated.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -25,7 +25,7 @@
 # than a copied ruleset. New ship briefs receive it from fm_dod_block; spawn adds
 # it to legacy ship briefs before launch and validates the final worker-facing
 # artifact. No-mistakes treats --intent as sanitized acceptance data, so spawn
-# and promotion require an enabled host lifecycle plugin for its pipeline agent.
+# and promotion require its operational --require-ponytail handoff.
 # Every heredoc here stays outside a command substitution: `VAR=$(cat <<EOF ...)`
 # breaks parsing of the whole file on Bash 3.2 (tests/fm-brief.test.sh).
 
@@ -58,53 +58,20 @@ fm_brief_ponytail_contract_present() {  # <file>
 }
 
 fm_no_mistakes_ponytail_ready() {
-  local doctor agent plugins mode config_root config_file
+  local help
   FM_PONYTAIL_PIPELINE_ERROR=
   command -v no-mistakes >/dev/null 2>&1 || {
     FM_PONYTAIL_PIPELINE_ERROR="no-mistakes is unavailable"
     return 1
   }
-  doctor=$(NO_MISTAKES_NO_UPDATE_CHECK=1 no-mistakes doctor 2>&1) || {
-    FM_PONYTAIL_PIPELINE_ERROR="no-mistakes doctor could not resolve a pipeline agent"
+  help=$(NO_MISTAKES_NO_UPDATE_CHECK=1 no-mistakes axi run --help 2>&1) || {
+    FM_PONYTAIL_PIPELINE_ERROR="no-mistakes axi run --help failed"
     return 1
   }
-  agent=$(printf '%s\n' "$doctor" | awk '/gate validation/ && / is runnable$/ { print $(NF - 2); exit }')
-  case "$agent" in
-    codex|claude) ;;
-    *)
-      FM_PONYTAIL_PIPELINE_ERROR="no supported Ponytail lifecycle boundary was reported for pipeline agent ${agent:-unknown}"
-      return 1 ;;
-  esac
-  command -v "$agent" >/dev/null 2>&1 || {
-    FM_PONYTAIL_PIPELINE_ERROR="pipeline agent $agent is unavailable"
+  printf '%s\n' "$help" | grep -Eq '^[[:space:]]*--require-ponytail([[:space:]]|$)' || {
+    FM_PONYTAIL_PIPELINE_ERROR="installed no-mistakes does not expose axi run --require-ponytail; update no-mistakes"
     return 1
   }
-  plugins=$("$agent" plugin list --json 2>/dev/null) || {
-    FM_PONYTAIL_PIPELINE_ERROR="pipeline agent $agent could not report its plugins"
-    return 1
-  }
-  printf '%s\n' "$plugins" | awk '
-    /"(pluginId|id)"[[:space:]]*:[[:space:]]*"ponytail@/ { ponytail = 1 }
-    ponytail && /"enabled"[[:space:]]*:[[:space:]]*true/ { enabled = 1; exit }
-    END { exit enabled ? 0 : 1 }
-  ' || {
-    FM_PONYTAIL_PIPELINE_ERROR="pipeline agent $agent has no enabled Ponytail plugin"
-    return 1
-  }
-  mode=$(printf '%s' "${PONYTAIL_DEFAULT_MODE:-full}" | tr '[:upper:]' '[:lower:]')
-  [ "$mode" = full ] || {
-    FM_PONYTAIL_PIPELINE_ERROR="Ponytail defaults to $mode instead of full"
-    return 1
-  }
-  config_root=${XDG_CONFIG_HOME:-$HOME/.config}
-  config_file="$config_root/ponytail/config.json"
-  if [ -r "$config_file" ]; then
-    mode=$(sed -n 's/.*"defaultMode"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$config_file" | head -n 1 | tr '[:upper:]' '[:lower:]')
-    [ -z "$mode" ] || [ "$mode" = full ] || {
-      FM_PONYTAIL_PIPELINE_ERROR="Ponytail config defaults to $mode instead of full"
-      return 1
-    }
-  fi
 }
 
 # Return 0 when a Task subsection still consists only of its scaffold
@@ -228,6 +195,10 @@ EOF
 
 Firstmate-authored constraints, acceptance criteria, implementation details, decisions, and tradeoffs are specification, not captain intent.
 The Definition of done's rule that `--intent` must be self-sufficient still governs the string you pass: resolve any report, decision, or PR the intent above refers to into its substance rather than passing the pointer.
+
+## Required no-mistakes handoff
+
+Store that exact string in `captain_intent`, then start the run with `no-mistakes axi run --require-ponytail --intent "$captain_intent"`; `--require-ponytail` is mandatory for every Firstmate no-mistakes handoff.
 EOF
 }
 

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Single owner of a ship task's mode-specific "Definition of done" block.
+# Single owner of a ship task's Ponytail development contract and mode-specific
+# "Definition of done" block.
 # Sourced by bin/fm-brief.sh, which renders it into a generated ship brief, and by
 # bin/fm-promote.sh, which renders it into the ship instructions a promoted scout
 # receives. Both paths must hand the worker the same contract: a promoted
@@ -20,8 +21,42 @@
 # bin/fm-promote.sh refuse leftover `{TASK}` / `{FIRSTMATE_SPEC}` placeholders
 # through the helpers below. Other mentions of `--intent` point here rather than
 # restating the rule.
+# The Ponytail contract is deliberately one compact generated instruction rather
+# than a copied ruleset. New ship briefs receive it from fm_dod_block; spawn adds
+# it to legacy ship briefs before launch and validates the final worker-facing
+# artifact. For no-mistakes, the current intent overlay carries the same compact
+# discipline into every pipeline agent invocation because --intent is the only
+# versioned prompt surface no-mistakes exposes at run start.
 # Every heredoc here stays outside a command substitution: `VAR=$(cat <<EOF ...)`
 # breaks parsing of the whole file on Bash 3.2 (tests/fm-brief.test.sh).
+
+fm_ponytail_instruction() {
+  cat <<'EOF'
+For code generation or development edits, use Ponytail `full` for the entire task.
+Prefer the host's installed Ponytail plugin, skill, and lifecycle hooks when they are available.
+Otherwise apply this compact fallback: reuse existing code and standard or native features, make the shortest correct change, add no speculative abstraction or dependency, and keep required validation, error handling, security, accessibility, and tests.
+Do not apply this coding discipline to unrelated prose-only or read-only work.
+EOF
+}
+
+fm_ponytail_contract_block() {
+  cat <<'EOF'
+# Development discipline
+Development contract: ponytail=full
+EOF
+  fm_ponytail_instruction
+  cat <<'EOF'
+Keep this contract active through implementation and, for no-mistakes delivery, through every review and fix invocation.
+EOF
+}
+
+fm_brief_ponytail_contract_present() {  # <file>
+  local actual expected
+  [ -f "$1" ] || return 1
+  actual=$(fm_brief_heading_body "$1" "# Development discipline")
+  expected=$(fm_ponytail_contract_block | sed '1d')
+  [ "$actual" = "$expected" ]
+}
 
 # Return 0 when a Task subsection still consists only of its scaffold
 # placeholder. A missing file and legacy briefs carry no such placeholders.
@@ -134,7 +169,8 @@ fm_brief_intent_overlay() {  # <captain-intent>
 
 # Current no-mistakes intent contract
 This section supersedes every earlier brief instruction about constructing `--intent`, but not later clarifications actually supplied by the captain.
-Use the serialized captain intent below plus any later words the captain actually supplied as `--intent`; never include Firstmate specification or other mixed Task content.
+Pass the serialized captain intent below plus any later words the captain actually supplied, followed by the exact `## Required pipeline discipline` text below, as `--intent`.
+Never include Firstmate specification or other mixed Task content.
 
 ## Captain intent authorized for --intent
 EOF
@@ -143,6 +179,13 @@ EOF
 
 Firstmate-authored constraints, acceptance criteria, implementation details, decisions, and tradeoffs are specification, not captain intent.
 The Definition of done's rule that `--intent` must be self-sufficient still governs the string you pass: resolve any report, decision, or PR the intent above refers to into its substance rather than passing the pointer.
+
+## Required pipeline discipline
+EOF
+  fm_ponytail_instruction
+  cat <<'EOF'
+
+This fixed execution directive is the only non-captain text authorized in `--intent`; it keeps Ponytail active in every no-mistakes review and fix agent without admitting task-specific Firstmate specification.
 EOF
 }
 
@@ -176,6 +219,8 @@ EOF
 
 fm_dod_block() {  # <mode> <task-id>
   local mode=$1 id=$2
+  fm_ponytail_contract_block
+  printf '\n'
   case "$mode" in
     direct-PR)
       cat <<EOF
@@ -208,9 +253,10 @@ Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
-When starting no-mistakes, pass \`--intent\` as only this brief's \`## Captain's intent\` subsection plus any later words the captain actually said.
+When starting no-mistakes, construct \`--intent\` exactly as the appended \`# Current no-mistakes intent contract\` directs: the authorized captain intent plus its fixed Ponytail pipeline discipline.
+Include any later words the captain actually supplied as that overlay directs.
 For a legacy brief with no such subsection, include only words explicitly labeled \`Captain:\`, \`Captain's words:\`, \`Captain's ask:\`, or \`Captain's intent:\`; never copy its mixed \`# Task\` wholesale. If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
-Do not include \`## Firstmate spec\`, later Firstmate build constraints, or your own decisions and tradeoffs.
+Do not include \`## Firstmate spec\`, later Firstmate build constraints, or your own decisions and tradeoffs; the fixed Ponytail pipeline discipline is the sole non-captain exception.
 The \`--intent\` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
 When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into \`--intent\` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
 This replaces the no-mistakes skill's advice to enrich \`--intent\` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -24,9 +24,8 @@
 # The Ponytail contract is deliberately one compact generated instruction rather
 # than a copied ruleset. New ship briefs receive it from fm_dod_block; spawn adds
 # it to legacy ship briefs before launch and validates the final worker-facing
-# artifact. For no-mistakes, the current intent overlay carries the same compact
-# discipline into every pipeline agent invocation because --intent is the only
-# versioned prompt surface no-mistakes exposes at run start.
+# artifact. No-mistakes treats --intent as sanitized acceptance data, so spawn
+# and promotion require an enabled host lifecycle plugin for its pipeline agent.
 # Every heredoc here stays outside a command substitution: `VAR=$(cat <<EOF ...)`
 # breaks parsing of the whole file on Bash 3.2 (tests/fm-brief.test.sh).
 
@@ -56,6 +55,56 @@ fm_brief_ponytail_contract_present() {  # <file>
   actual=$(fm_brief_heading_body "$1" "# Development discipline")
   expected=$(fm_ponytail_contract_block | sed '1d')
   [ "$actual" = "$expected" ]
+}
+
+fm_no_mistakes_ponytail_ready() {
+  local doctor agent plugins mode config_root config_file
+  FM_PONYTAIL_PIPELINE_ERROR=
+  command -v no-mistakes >/dev/null 2>&1 || {
+    FM_PONYTAIL_PIPELINE_ERROR="no-mistakes is unavailable"
+    return 1
+  }
+  doctor=$(NO_MISTAKES_NO_UPDATE_CHECK=1 no-mistakes doctor 2>&1) || {
+    FM_PONYTAIL_PIPELINE_ERROR="no-mistakes doctor could not resolve a pipeline agent"
+    return 1
+  }
+  agent=$(printf '%s\n' "$doctor" | awk '/gate validation/ && / is runnable$/ { print $(NF - 2); exit }')
+  case "$agent" in
+    codex|claude) ;;
+    *)
+      FM_PONYTAIL_PIPELINE_ERROR="no supported Ponytail lifecycle boundary was reported for pipeline agent ${agent:-unknown}"
+      return 1 ;;
+  esac
+  command -v "$agent" >/dev/null 2>&1 || {
+    FM_PONYTAIL_PIPELINE_ERROR="pipeline agent $agent is unavailable"
+    return 1
+  }
+  plugins=$("$agent" plugin list --json 2>/dev/null) || {
+    FM_PONYTAIL_PIPELINE_ERROR="pipeline agent $agent could not report its plugins"
+    return 1
+  }
+  printf '%s\n' "$plugins" | awk '
+    /"(pluginId|id)"[[:space:]]*:[[:space:]]*"ponytail@/ { ponytail = 1 }
+    ponytail && /"enabled"[[:space:]]*:[[:space:]]*true/ { enabled = 1; exit }
+    END { exit enabled ? 0 : 1 }
+  ' || {
+    FM_PONYTAIL_PIPELINE_ERROR="pipeline agent $agent has no enabled Ponytail plugin"
+    return 1
+  }
+  mode=$(printf '%s' "${PONYTAIL_DEFAULT_MODE:-full}" | tr '[:upper:]' '[:lower:]')
+  [ "$mode" = full ] || {
+    FM_PONYTAIL_PIPELINE_ERROR="Ponytail defaults to $mode instead of full"
+    return 1
+  }
+  config_root=${XDG_CONFIG_HOME:-$HOME/.config}
+  config_file="$config_root/ponytail/config.json"
+  if [ -r "$config_file" ]; then
+    mode=$(sed -n 's/.*"defaultMode"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$config_file" | head -n 1 | tr '[:upper:]' '[:lower:]')
+    [ -z "$mode" ] || [ "$mode" = full ] || {
+      FM_PONYTAIL_PIPELINE_ERROR="Ponytail config defaults to $mode instead of full"
+      return 1
+    }
+  fi
 }
 
 # Return 0 when a Task subsection still consists only of its scaffold
@@ -169,7 +218,7 @@ fm_brief_intent_overlay() {  # <captain-intent>
 
 # Current no-mistakes intent contract
 This section supersedes every earlier brief instruction about constructing `--intent`, but not later clarifications actually supplied by the captain.
-Pass the serialized captain intent below plus any later words the captain actually supplied, followed by the exact `## Required pipeline discipline` text below, as `--intent`.
+Pass the serialized captain intent below plus any later words the captain actually supplied as `--intent`.
 Never include Firstmate specification or other mixed Task content.
 
 ## Captain intent authorized for --intent
@@ -179,13 +228,6 @@ EOF
 
 Firstmate-authored constraints, acceptance criteria, implementation details, decisions, and tradeoffs are specification, not captain intent.
 The Definition of done's rule that `--intent` must be self-sufficient still governs the string you pass: resolve any report, decision, or PR the intent above refers to into its substance rather than passing the pointer.
-
-## Required pipeline discipline
-EOF
-  fm_ponytail_instruction
-  cat <<'EOF'
-
-This fixed execution directive is the only non-captain text authorized in `--intent`; it keeps Ponytail active in every no-mistakes review and fix agent without admitting task-specific Firstmate specification.
 EOF
 }
 
@@ -253,10 +295,10 @@ Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
-When starting no-mistakes, construct \`--intent\` exactly as the appended \`# Current no-mistakes intent contract\` directs: the authorized captain intent plus its fixed Ponytail pipeline discipline.
+When starting no-mistakes, construct \`--intent\` exactly as the appended \`# Current no-mistakes intent contract\` directs: only the authorized captain intent.
 Include any later words the captain actually supplied as that overlay directs.
 For a legacy brief with no such subsection, include only words explicitly labeled \`Captain:\`, \`Captain's words:\`, \`Captain's ask:\`, or \`Captain's intent:\`; never copy its mixed \`# Task\` wholesale. If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
-Do not include \`## Firstmate spec\`, later Firstmate build constraints, or your own decisions and tradeoffs; the fixed Ponytail pipeline discipline is the sole non-captain exception.
+Do not include \`## Firstmate spec\`, later Firstmate build constraints, execution directives, or your own decisions and tradeoffs.
 The \`--intent\` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
 When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into \`--intent\` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
 This replaces the no-mistakes skill's advice to enrich \`--intent\` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -9,7 +9,7 @@
 # bin/fm-dod-lib.sh, the single owner an ordinary ship brief also uses - the
 # Ponytail full development contract and mode-specific Definition of done, so a
 # promoted worker receives exactly the same delivery contract as a briefed one,
-# including the no-mistakes mode's lifecycle-plugin preflight, ask-user
+# including the no-mistakes mode's --require-ponytail preflight, ask-user
 # escalation rule, and --yes ban. The instructions also carry `# Task` with
 # `## Captain's intent` preserved from the scout brief and promotion's ship-time
 # instructions under `## Firstmate spec`; the scout-time spec remains context but
@@ -162,7 +162,7 @@ fi
 # brief carries, so the mode-specific Definition of done is rendered from its
 # single owner (bin/fm-dod-lib.sh) rather than summarised into a hint line. A
 # promoted no-mistakes worker that never received the ask-user escalation rule,
-# the --yes ban, or the Ponytail pipeline preflight is the delivery hole this file
+# the --yes ban, or the Ponytail pipeline handoff is the delivery hole this file
 # used to leave open.
 INSTRUCTIONS="$DATA/$ID/ship-instructions.md"
 PROMOTION_ASK_USER_BLOCK=

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -9,8 +9,8 @@
 # bin/fm-dod-lib.sh, the single owner an ordinary ship brief also uses - the
 # Ponytail full development contract and mode-specific Definition of done, so a
 # promoted worker receives exactly the same delivery contract as a briefed one,
-# including the no-mistakes mode's pipeline-agent handoff, ask-user escalation
-# rule, and --yes ban. The instructions also carry `# Task` with
+# including the no-mistakes mode's lifecycle-plugin preflight, ask-user
+# escalation rule, and --yes ban. The instructions also carry `# Task` with
 # `## Captain's intent` preserved from the scout brief and promotion's ship-time
 # instructions under `## Firstmate spec`; the scout-time spec remains context but
 # is not relabeled as the ship spec. Promotion refuses leftover `{TASK}` /
@@ -153,12 +153,16 @@ if [ -z "$(printf '%s' "$INTENT_BODY" | tr -d '[:space:]')" ]; then
   echo "error: $SCOUT_BRIEF has no provenance-marked Captain's intent; add the captain's actual words before promotion" >&2
   exit 1
 fi
+if [ "$MODE" = no-mistakes ] && ! fm_no_mistakes_ponytail_ready; then
+  echo "error: Ponytail full guarantee cannot be established for no-mistakes pipeline: $FM_PONYTAIL_PIPELINE_ERROR; refusing to promote $ID" >&2
+  exit 1
+fi
 
 # The promoted worker must receive the same delivery contract an ordinary ship
 # brief carries, so the mode-specific Definition of done is rendered from its
 # single owner (bin/fm-dod-lib.sh) rather than summarised into a hint line. A
 # promoted no-mistakes worker that never received the ask-user escalation rule,
-# the --yes ban, or the Ponytail pipeline handoff is the delivery hole this file
+# the --yes ban, or the Ponytail pipeline preflight is the delivery hole this file
 # used to leave open.
 INSTRUCTIONS="$DATA/$ID/ship-instructions.md"
 PROMOTION_ASK_USER_BLOCK=

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -7,9 +7,10 @@
 # delivers them. Those instructions carry the scratch-state inventory, the clean
 # default-branch base, the fm/<task-id> branch, and - rendered from
 # bin/fm-dod-lib.sh, the single owner an ordinary ship brief also uses - the
-# mode-specific Definition of done, so a promoted worker receives exactly the same
-# delivery contract as a briefed one, including the no-mistakes mode's ask-user
-# escalation rule and --yes ban. The instructions also carry `# Task` with
+# Ponytail full development contract and mode-specific Definition of done, so a
+# promoted worker receives exactly the same delivery contract as a briefed one,
+# including the no-mistakes mode's pipeline-agent handoff, ask-user escalation
+# rule, and --yes ban. The instructions also carry `# Task` with
 # `## Captain's intent` preserved from the scout brief and promotion's ship-time
 # instructions under `## Firstmate spec`; the scout-time spec remains context but
 # is not relabeled as the ship spec. Promotion refuses leftover `{TASK}` /
@@ -156,8 +157,9 @@ fi
 # The promoted worker must receive the same delivery contract an ordinary ship
 # brief carries, so the mode-specific Definition of done is rendered from its
 # single owner (bin/fm-dod-lib.sh) rather than summarised into a hint line. A
-# promoted no-mistakes worker that never received the ask-user escalation rule or
-# the --yes ban is the delivery hole this file used to leave open.
+# promoted no-mistakes worker that never received the ask-user escalation rule,
+# the --yes ban, or the Ponytail pipeline handoff is the delivery hole this file
+# used to leave open.
 INSTRUCTIONS="$DATA/$ID/ship-instructions.md"
 PROMOTION_ASK_USER_BLOCK=
 if [ "$MODE" = no-mistakes ]; then
@@ -188,7 +190,14 @@ $PROMOTION_ASK_USER_BLOCK
 EOF
   printf '\n'
   fm_dod_block "$MODE" "$ID"
+  if [ "$MODE" = no-mistakes ]; then
+    fm_brief_intent_overlay "$INTENT_BODY"
+  fi
 } > "$TMP" || { echo "error: could not render ship instructions for mode=$MODE" >&2; exit 1; }
+fm_brief_ponytail_contract_present "$TMP" || {
+  echo "error: Ponytail full guarantee cannot be established for promoted task $ID" >&2
+  exit 1
+}
 mv "$TMP" "$INSTRUCTIONS"
 TMP=
 [ -f "$INSTRUCTIONS" ] && [ -r "$INSTRUCTIONS" ] || { echo "error: ship instructions were not published as a readable file: $INSTRUCTIONS" >&2; exit 1; }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -14,8 +14,11 @@
 #   scaffolded before that line existed warns once and launches on the flag. A
 #   ship or scout spawn also refuses leftover `{TASK}` / `{FIRSTMATE_SPEC}`
 #   placeholders, an empty Task, or an incomplete pair of Task subsections.
-#   For a no-mistakes ship, spawn renders `launch-brief.md` with the current
-#   `--intent` contract and the extracted captain intent. A legacy mixed Task is
+#   Every ship spawn validates that the worker-facing brief carries the Ponytail
+#   full development contract, adding the compact contract to a legacy brief
+#   through `launch-brief.md` when needed. For a no-mistakes ship, that artifact
+#   also carries the current `--intent` contract, the extracted captain intent,
+#   and the Ponytail pipeline-agent handoff. A legacy mixed Task is
 #   accepted there only under bin/fm-dod-lib.sh's provenance-marking rules;
 #   unmarked legacy Tasks stop for migration rather than becoming intent. That
 #   library owns the parsing and intent rules. When the explicit mode carries
@@ -1878,18 +1881,38 @@ if [ "$KIND" = ship ] || [ "$KIND" = scout ]; then
         exit 1
       fi
     fi
+  fi
+  if [ "$KIND" = ship ] && { [ "$MODE" = no-mistakes ] || ! fm_brief_ponytail_contract_present "$BRIEF"; }; then
     SOURCE_BRIEF=$BRIEF
     BRIEF="$DATA/$ID/launch-brief.md"
     BRIEF_TMP="$DATA/$ID/.launch-brief.md.${BASHPID:-$$}"
+    [ ! -d "$BRIEF" ] || {
+      echo "error: Ponytail full guarantee cannot be established for $ID: launch brief path is a directory: $BRIEF" >&2
+      exit 1
+    }
     {
       cat "$SOURCE_BRIEF"
-      fm_brief_intent_overlay "$CAPTAIN_INTENT"
-    } > "$BRIEF_TMP" || { rm -f -- "$BRIEF_TMP"; echo "error: could not render current intent contract for $SOURCE_BRIEF" >&2; exit 1; }
+      if ! fm_brief_ponytail_contract_present "$SOURCE_BRIEF"; then
+        printf '\n'
+        fm_ponytail_contract_block
+      fi
+      if [ "$MODE" = no-mistakes ]; then
+        fm_brief_intent_overlay "$CAPTAIN_INTENT"
+      fi
+    } > "$BRIEF_TMP" || {
+      rm -f -- "$BRIEF_TMP"
+      echo "error: Ponytail full guarantee cannot be rendered for $ID from $SOURCE_BRIEF" >&2
+      exit 1
+    }
     if ! mv "$BRIEF_TMP" "$BRIEF"; then
       rm -f -- "$BRIEF_TMP"
-      echo "error: could not publish current intent contract for $SOURCE_BRIEF" >&2
+      echo "error: Ponytail full guarantee cannot be published for $ID at $BRIEF" >&2
       exit 1
     fi
+  fi
+  if [ "$KIND" = ship ] && ! fm_brief_ponytail_contract_present "$BRIEF"; then
+    echo "error: Ponytail full guarantee cannot be established for $ID: worker-facing brief lacks Development contract: ponytail=full" >&2
+    exit 1
   fi
 fi
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -17,8 +17,8 @@
 #   Every ship spawn validates that the worker-facing brief carries the Ponytail
 #   full development contract, adding the compact contract to a legacy brief
 #   through `launch-brief.md` when needed. For a no-mistakes ship, that artifact
-#   also carries the current `--intent` contract, the extracted captain intent,
-#   and the Ponytail pipeline-agent handoff. A legacy mixed Task is
+#   also carries the current `--intent` contract and the extracted captain intent.
+#   The pipeline agent's Ponytail lifecycle plugin is verified before launch. A legacy mixed Task is
 #   accepted there only under bin/fm-dod-lib.sh's provenance-marking rules;
 #   unmarked legacy Tasks stop for migration rather than becoming intent. That
 #   library owns the parsing and intent rules. When the explicit mode carries
@@ -1880,6 +1880,10 @@ if [ "$KIND" = ship ] || [ "$KIND" = scout ]; then
         echo "error: legacy mixed # Task brief has no provenance-marked captain words for no-mistakes --intent; add Captain: lines or migrate to ## Captain's intent and ## Firstmate spec" >&2
         exit 1
       fi
+    fi
+    if ! fm_no_mistakes_ponytail_ready; then
+      echo "error: Ponytail full guarantee cannot be established for no-mistakes pipeline: $FM_PONYTAIL_PIPELINE_ERROR; refusing to launch $ID" >&2
+      exit 1
     fi
   fi
   if [ "$KIND" = ship ] && { [ "$MODE" = no-mistakes ] || ! fm_brief_ponytail_contract_present "$BRIEF"; }; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1896,11 +1896,11 @@ if [ "$KIND" = ship ] || [ "$KIND" = scout ]; then
       exit 1
     }
     {
-      cat "$SOURCE_BRIEF"
       if ! fm_brief_ponytail_contract_present "$SOURCE_BRIEF"; then
-        printf '\n'
         fm_ponytail_contract_block
+        printf '\n\n# Original brief\n'
       fi
+      cat "$SOURCE_BRIEF"
       if [ "$MODE" = no-mistakes ]; then
         fm_brief_intent_overlay "$CAPTAIN_INTENT"
       fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -18,7 +18,8 @@
 #   full development contract, adding the compact contract to a legacy brief
 #   through `launch-brief.md` when needed. For a no-mistakes ship, that artifact
 #   also carries the current `--intent` contract and the extracted captain intent.
-#   The pipeline agent's Ponytail lifecycle plugin is verified before launch. A legacy mixed Task is
+#   The selected no-mistakes CLI's --require-ponytail support is verified before
+#   launch. A legacy mixed Task is
 #   accepted there only under bin/fm-dod-lib.sh's provenance-marking rules;
 #   unmarked legacy Tasks stop for migration rather than becoming intent. That
 #   library owns the parsing and intent rules. When the explicit mode carries

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -285,8 +285,10 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 Each task's mode and `yolo` merge posture are firstmate's decision at intake.
 The mode is passed explicitly to `bin/fm-brief.sh`, and both values are passed explicitly to `bin/fm-spawn.sh` and `bin/fm-promote.sh`; each command refuses to guess the values it consumes.
 A ship brief records its mode as a fixed machine-readable line and the spawn refuses to launch on a different one, so the worker's instructions and the recorded task delivery cannot diverge.
-`bin/fm-dod-lib.sh` is the one owner of that mode's definition of done, rendered both into a generated ship brief and into the ship instructions a promoted scout receives, so a promoted worker cannot be handed a weaker contract than a briefed one.
-It is also the one owner of the no-mistakes `--intent` contract those workers follow.
+`bin/fm-dod-lib.sh` is the one owner of the ship's Ponytail development contract and mode-specific definition of done, rendered into both a generated ship brief and the ship instructions a promoted scout receives.
+`bin/fm-spawn.sh` adds that same contract to legacy ship briefs and refuses any worker-facing ship artifact that does not reproduce it exactly.
+The development contract is ship-only and self-scopes to code generation and development edits, so scout and secondmate briefs remain unaffected.
+For no-mistakes mode, `bin/fm-dod-lib.sh` also owns the `--intent` contract and operational Ponytail handoff, while spawn and promotion refuse a selected no-mistakes CLI that lacks that capability.
 `data/projects.md` records each project's standing posture and optional `+yolo` merge flag as the captain's default and as context for that decision, including the conditional `no-mistakes-prod-only` policy; a ship spawn that drops below the registered rigor prints a deviation notice and continues.
 `bin/fm-project-mode.sh` remains the one registry parser for the mechanical consumers that have no task in hand: fleet sync's `local-only` skip and home seeding's refusal and no-mistakes initialization.
 When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -384,6 +384,7 @@ On session start the first mate detects what its required toolchain is missing o
 It installs automatically supported tools only after you say go; manual-only tools remain for you to install from the printed instructions.
 Required tools come in two parts: a universal toolchain every home needs regardless of backend, and a per-backend delta that follows the runtime backend actually resolved for this home.
 The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.46.0 or newer, compatible gh-axi, chrome-devtools-axi, compatible lavish-axi, compatible tasks-axi per "Backlog backend" above, and compatible quota-axi.
+The v1.46.0 floor covers structured attestation only; a `no-mistakes` ship also requires a build whose `axi run --help` exposes `--require-ponytail`, and spawn or promotion refuses before changing worker lifecycle state when it does not.
 [`bin/fm-bootstrap.sh`](../bin/fm-bootstrap.sh) owns the axi-family floor policy and the gh-axi and lavish-axi floors, while [`bin/fm-tasks-axi-lib.sh`](../bin/fm-tasks-axi-lib.sh) and [`bin/fm-quota-axi-lib.sh`](../bin/fm-quota-axi-lib.sh) hold their own tools' floor constants.
 This section is the single owner of that universal toolchain list; backend guides' prerequisites point here and add only their backend-specific tools.
 In that list, no-mistakes runs the validation pipeline, gh-axi, chrome-devtools-axi, and lavish-axi cover GitHub, browser, and rich-review operations, and tasks-axi plus quota-axi back backlog mutations and quota-aware array dispatch.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -32,8 +32,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-captain-hold.sh`     | Hold tasks for the captain, record the captain's answers, gate investigation completion, and report record divergence between the status log and the backlog |
 | `fm-decision-hold.sh`    | One-release compatibility shim mapping the retired decision commands onto fm-captain-hold.sh |
-| `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs, with Captain's intent and Firstmate spec subsections on ship/scout |
-| `fm-dod-lib.sh`          | One owner of the ship definition of done and of the no-mistakes `--intent` contract |
+| `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs; ship briefs receive the shared Ponytail development contract |
+| `fm-dod-lib.sh`          | One owner of the ship's Ponytail development contract, definition of done, and no-mistakes intent and handoff contracts |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |
@@ -56,7 +56,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-home-seed.sh` | Register and provision a whole secondmate home on an SSH-reachable host              |
 | `fm-remote-readiness-lib.sh` | Shared remote second-mate readiness gate: check and, when needed, repair then re-check through `fm-remote-doctor.sh` |
 | [`fm-project-origin-lib.sh`](../bin/fm-project-origin-lib.sh) | Accepted origin-form owner shared by both remote provisioning boundaries |
-| `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
+| `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates while enforcing worker-facing ship contracts |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer shapes, capability-aware screen classification, and verdicts |
@@ -129,7 +129,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-merge.sh`         | Record PR metadata, merge a task's canonical full GitHub or GitLab URL, then refuse an outcome it cannot prove landed or queued |
 | `fm-merge-outcome-lib.sh` | Publish a confirmed merge's durable, role-routed supervision outcome                 |
 | `fm-parent-channel-lib.sh` | Resolve a secondmate home's parent channel and append a captain-facing outcome line to it at most once |
-| `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode, and write the ship instructions carrying that mode's definition of done |
+| `fm-promote.sh`          | Promote a scout task in place to a protected ship task and write the shared development and delivery contracts |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -258,7 +258,7 @@ fm_test_make_spawn_fakebin() {
   shift
   fakebin=$(fm_fakebin "$dir")
   fm_test_fake_tmux_spawn "$fakebin"
-  fm_fake_exit0 "$fakebin" treehouse "$@"
+  fm_fake_exit0 "$fakebin" treehouse no-mistakes "$@"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -55,6 +55,7 @@ fi
 exit 0
 SH
   chmod +x "$fb/orca"
+  fm_fake_exit0 "$fb" no-mistakes
   printf '%s\n' "$fb"
 }
 

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -807,7 +807,7 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  fm_fake_exit0 "$fb" treehouse no-mistakes
   printf '%s\n' "$fb"
 }
 
@@ -877,7 +877,7 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  fm_fake_exit0 "$fb" treehouse no-mistakes
   printf '%s\n' "$fb"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -206,6 +206,18 @@ test_ship_modes_generate_clean_briefs() {
     expect_code 0 "$status" "fm-brief.sh $id --mode $mode should exit 0"
     brief="$home/data/$id/brief.md"
     assert_present "$brief" "$id: brief was not scaffolded"
+    grep -qx "Development contract: ponytail=full" "$brief" \
+      || fail "$id: ship brief did not require Ponytail full"
+    [ "$(grep -c '^Development contract: ponytail=full$' "$brief")" = 1 ] \
+      || fail "$id: ship brief duplicated the Ponytail contract"
+    assert_grep "Prefer the host's installed Ponytail plugin, skill, and lifecycle hooks" "$brief" \
+      "$id: ship brief did not prefer the installed host integration"
+    assert_grep "Otherwise apply this compact fallback" "$brief" \
+      "$id: ship brief omitted the instruction-level fallback"
+    assert_grep "keep required validation, error handling, security, accessibility, and tests" "$brief" \
+      "$id: Ponytail contract weakened correctness safeguards"
+    assert_grep "Do not apply this coding discipline to unrelated prose-only or read-only work" "$brief" \
+      "$id: Ponytail contract leaked onto unrelated non-development work"
     assert_grep "# Definition of done" "$brief" "$id: brief missing Definition of done section"
     grep -qx "Delivery contract: mode=$mode" "$brief" \
       || fail "$id: brief did not record its machine-readable delivery contract line"
@@ -341,9 +353,11 @@ test_no_mistakes_dod_wording() {
   # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
   assert_grep '`help`' "$brief" \
     "no-mistakes DOD must render literal backticks around help"
-  assert_grep "pass \`--intent\` as only this brief's \`## Captain's intent\`" "$brief" \
-    "no-mistakes DOD must require --intent to be the Captain's intent subsection"
-  assert_grep "plus any later words the captain actually said" "$brief" \
+  assert_grep "construct \`--intent\` exactly as the appended \`# Current no-mistakes intent contract\` directs" "$brief" \
+    "no-mistakes DOD must route --intent through the launch-time contract"
+  assert_grep "authorized captain intent plus its fixed Ponytail pipeline discipline" "$brief" \
+    "no-mistakes DOD did not hand Ponytail to pipeline agents"
+  assert_grep "Include any later words the captain actually supplied" "$brief" \
     "no-mistakes DOD must allow later captain words in --intent"
   assert_grep "Do not include \`## Firstmate spec\`" "$brief" \
     "no-mistakes DOD must keep Firstmate spec out of --intent"
@@ -831,6 +845,8 @@ test_scout_and_secondmate_scaffold() {
   assert_grep "## Captain's intent" "$brief" "scout brief missing Captain's intent subsection"
   assert_grep "## Firstmate spec" "$brief" "scout brief missing Firstmate spec subsection"
   assert_grep "{FIRSTMATE_SPEC}" "$brief" "scout brief missing the spec placeholder"
+  assert_no_grep "Development contract: ponytail=full" "$brief" \
+    "scout brief must not apply development discipline to read-only work"
 
   FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
     FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-sm-q6 --secondmate alpha >/dev/null 2>&1 \
@@ -843,6 +859,8 @@ test_scout_and_secondmate_scaffold() {
     "secondmate charter must not grow ship/scout Task subsections"
   assert_no_grep "{FIRSTMATE_SPEC}" "$brief" \
     "secondmate charter must not carry the Firstmate spec placeholder"
+  assert_no_grep "Development contract: ponytail=full" "$brief" \
+    "secondmate charter must not apply development discipline to supervision"
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -355,8 +355,8 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must render literal backticks around help"
   assert_grep "construct \`--intent\` exactly as the appended \`# Current no-mistakes intent contract\` directs" "$brief" \
     "no-mistakes DOD must route --intent through the launch-time contract"
-  assert_grep "authorized captain intent plus its fixed Ponytail pipeline discipline" "$brief" \
-    "no-mistakes DOD did not hand Ponytail to pipeline agents"
+  assert_grep "only the authorized captain intent" "$brief" \
+    "no-mistakes DOD mixed execution directives into sanitized intent"
   assert_grep "Include any later words the captain actually supplied" "$brief" \
     "no-mistakes DOD must allow later captain words in --intent"
   assert_grep "Do not include \`## Firstmate spec\`" "$brief" \

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -131,7 +131,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh no-mistakes
   fm_fake_exit0 "$fakebin" kimi
   ln -s "$JQ_BIN" "$fakebin/jq"
   printf '%s\n' "$fakebin"

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -112,7 +112,7 @@ set -u
 exec "$FM_FAKE_MUSE_VERSIONED" -c 'result=$($FM_FAKE_HARNESS_PROBE); printf "%s" "$result" > "$FM_FAKE_HARNESS_RESULT"'
 SH
   chmod +x "$fakebin/muse"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh no-mistakes
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -660,7 +660,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" pi
+  fm_fake_exit0 "$fakebin" pi no-mistakes
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -54,7 +54,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_exit0 "$fakebin" treehouse no-mistakes
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -221,7 +221,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_exit0 "$fakebin" treehouse no-mistakes
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -146,6 +146,8 @@ EOF
   write_brief "$home" delivery-agree-b2 direct-PR
   out=$(run_spawn "$home" "$fakebin" delivery-agree-b2 "$proj" claude --mode direct-PR --yolo off)
   assert_not_contains "$out" "delivery mismatch" "an agreeing mode was reported as a mismatch"
+  assert_grep "Development contract: ponytail=full" "$home/data/delivery-agree-b2/launch-brief.md" \
+    "legacy direct-PR brief was launched without the Ponytail contract"
 
   # A brief scaffolded before the contract line existed warns once and continues.
   write_brief "$home" delivery-legacy-b3
@@ -153,6 +155,27 @@ EOF
   assert_contains "$out" "records no delivery contract line" "a legacy brief did not warn about its missing contract"
   assert_not_contains "$out" "delivery mismatch" "a legacy brief was treated as a mismatch"
   pass "fm-spawn: the brief's recorded mode and the spawn's explicit mode must agree"
+}
+
+test_spawn_reports_when_ponytail_contract_cannot_be_published() {
+  local rec home proj fakebin out status id
+  rec=$(make_home ponytail-contract-refusal)
+  IFS='|' read -r home proj fakebin <<EOF
+$rec
+EOF
+  id=delivery-ponytail-refusal-b4
+  write_brief "$home" "$id" direct-PR
+  mkdir -p "$home/data/$id/launch-brief.md"
+  out=$(run_spawn "$home" "$fakebin" "$id" "$proj" claude --mode direct-PR --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn should refuse when the Ponytail launch contract cannot be published"
+  assert_contains "$out" "Ponytail full guarantee cannot be established for $id" \
+    "spawn did not clearly diagnose the missing Ponytail guarantee"
+  assert_contains "$out" "launch brief path is a directory" \
+    "spawn did not identify why the Ponytail contract could not be published"
+  assert_absent "$home/state/$id.meta" \
+    "Ponytail contract refusal still published task metadata"
+  pass "fm-spawn: a missing Ponytail guarantee fails before launch with a clear diagnostic"
 }
 
 # The registry is the captain's standing posture, so dropping below its rigor is
@@ -339,6 +362,8 @@ STUB
 
     grep -qx "Delivery contract: mode=$mode" "$payload" \
       || fail "$mode: promoted worker did not receive the machine-readable delivery contract"
+    grep -qx "Development contract: ponytail=full" "$payload" \
+      || fail "$mode: promoted worker did not receive the Ponytail development contract"
     assert_grep "# Definition of done" "$payload" \
       "$mode: promoted worker did not receive a Definition of done"
     assert_grep "pwd -P" "$payload" \
@@ -362,13 +387,17 @@ STUB
       || fail "$mode: ordinary ship brief generation should succeed"
     brief_dod="$TMP_ROOT/promote-dod/brief-dod-$id"
     delivered_dod="$TMP_ROOT/promote-dod/delivered-dod-$id"
-    awk '/^# Definition of done$/ { emit=1 } emit' "$home/data/$id/brief.md" > "$brief_dod"
-    awk '/^# Definition of done$/ { emit=1 } emit' "$payload" > "$delivered_dod"
+    awk '/^# Definition of done$/ { emit=1 } emit && /^# Current no-mistakes intent contract$/ { exit } emit' "$home/data/$id/brief.md" | sed '/^$/d' > "$brief_dod"
+    awk '/^# Definition of done$/ { emit=1 } emit && /^# Current no-mistakes intent contract$/ { exit } emit' "$payload" | sed '/^$/d' > "$delivered_dod"
     cmp -s "$brief_dod" "$delivered_dod" \
       || fail "$mode: promotion and ordinary brief generation delivered different Definitions of done"
   done
 
   payload="$TMP_ROOT/promote-dod/payload-promote-dod-no-mistakes"
+  assert_grep "## Required pipeline discipline" "$payload" \
+    "promoted no-mistakes worker did not receive the pipeline-agent Ponytail handoff"
+  assert_grep "the only non-captain text authorized in \`--intent\`" "$payload" \
+    "promoted no-mistakes worker lost the intent provenance boundary"
   assert_grep "ask-user findings are never yours to answer: escalate to firstmate" "$payload" \
     "promoted no-mistakes worker did not receive the ask-user escalation rule"
   assert_grep "write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority)" "$payload" \
@@ -504,6 +533,16 @@ EOF
     "legacy no-mistakes spawn rejected explicitly marked captain words"
   assert_present "$home/data/$id/launch-brief.md" \
     "marked legacy spawn did not render a current launch contract"
+  assert_grep "Development contract: ponytail=full" "$home/data/$id/launch-brief.md" \
+    "legacy no-mistakes launch omitted the implementation-time Ponytail contract"
+  assert_grep "## Required pipeline discipline" "$home/data/$id/launch-brief.md" \
+    "legacy no-mistakes launch omitted the pipeline-agent Ponytail handoff"
+  assert_grep "Prefer the host's installed Ponytail plugin, skill, and lifecycle hooks" \
+    "$home/data/$id/launch-brief.md" \
+    "pipeline-agent handoff did not prefer the installed host integration"
+  assert_grep "the only non-captain text authorized in \`--intent\`" \
+    "$home/data/$id/launch-brief.md" \
+    "pipeline-agent handoff did not preserve the intent provenance boundary"
   assert_grep "supersedes every earlier brief instruction about constructing \`--intent\`" \
     "$home/data/$id/launch-brief.md" \
     "marked legacy spawn did not override its stale intent instruction"
@@ -750,6 +789,7 @@ EOF
 test_ship_spawn_requires_a_valid_delivery_contract
 test_scout_and_secondmate_refuse_delivery_flags
 test_spawn_refuses_a_brief_mode_mismatch
+test_spawn_reports_when_ponytail_contract_cannot_be_published
 test_spawn_notices_a_rigor_downgrade_against_the_registry
 test_scout_records_no_delivery_posture
 test_promote_requires_and_records_the_delivery_contract

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -170,13 +170,28 @@ EOF
   pass "fm-spawn: the brief's recorded mode and the spawn's explicit mode must agree"
 }
 
-test_spawn_reports_when_ponytail_contract_cannot_be_published() {
-  local rec home proj fakebin out status id
+test_spawn_publishes_or_reports_the_ponytail_contract() {
+  local rec home proj fakebin out status id first_contract
   rec=$(make_home ponytail-contract-refusal)
   IFS='|' read -r home proj fakebin <<EOF
 $rec
 EOF
-  id=delivery-ponytail-refusal-b4
+  id=delivery-ponytail-custom-b4
+  write_brief "$home" "$id" direct-PR
+  cat >> "$home/data/$id/brief.md" <<'EOF'
+
+# Development discipline
+Keep the project's existing local conventions.
+EOF
+  out=$(run_spawn "$home" "$fakebin" "$id" "$proj" claude --mode direct-PR --yolo off)
+  assert_not_contains "$out" "Ponytail full guarantee cannot be established" \
+    "a custom legacy development section made the canonical overlay reject itself"
+  first_contract=$(awk '$0 == "# Development discipline" { emit=1; next } emit && /^# / { exit } emit' \
+    "$home/data/$id/launch-brief.md")
+  assert_contains "$first_contract" "Development contract: ponytail=full" \
+    "the canonical Ponytail overlay was not the authoritative first development section"
+
+  id=delivery-ponytail-refusal-b5
   write_brief "$home" "$id" direct-PR
   mkdir -p "$home/data/$id/launch-brief.md"
   out=$(run_spawn "$home" "$fakebin" "$id" "$proj" claude --mode direct-PR --yolo off)
@@ -188,7 +203,7 @@ EOF
     "spawn did not identify why the Ponytail contract could not be published"
   assert_absent "$home/state/$id.meta" \
     "Ponytail contract refusal still published task metadata"
-  pass "fm-spawn: a missing Ponytail guarantee fails before launch with a clear diagnostic"
+  pass "fm-spawn: the canonical Ponytail contract is published or launch fails clearly"
 }
 
 test_unsupported_no_mistakes_delivery_is_refused() {
@@ -853,7 +868,7 @@ EOF
 test_ship_spawn_requires_a_valid_delivery_contract
 test_scout_and_secondmate_refuse_delivery_flags
 test_spawn_refuses_a_brief_mode_mismatch
-test_spawn_reports_when_ponytail_contract_cannot_be_published
+test_spawn_publishes_or_reports_the_ponytail_contract
 test_unsupported_no_mistakes_delivery_is_refused
 test_spawn_notices_a_rigor_downgrade_against_the_registry
 test_scout_records_no_delivery_posture

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -22,6 +22,19 @@ BRIEF="$ROOT/bin/fm-brief.sh"
 PROMOTE="$ROOT/bin/fm-promote.sh"
 PROJECT_MODE="$ROOT/bin/fm-project-mode.sh"
 TMP_ROOT=$(fm_test_tmproot fm-task-delivery)
+PIPELINE_BIN="$TMP_ROOT/pipeline-bin"
+mkdir -p "$PIPELINE_BIN"
+cat > "$PIPELINE_BIN/no-mistakes" <<'STUB'
+#!/bin/sh
+printf '%s\n' '  ✓ gate validation  codex is runnable'
+STUB
+cat > "$PIPELINE_BIN/codex" <<'STUB'
+#!/bin/sh
+printf '%s\n' '{"installed":[{"pluginId":"ponytail@test","enabled":true}]}'
+STUB
+chmod +x "$PIPELINE_BIN/no-mistakes" "$PIPELINE_BIN/codex"
+PATH="$PIPELINE_BIN:$PATH"
+export PATH
 
 # A home with one registered project, one project directory, and a fake tmux that
 # refuses, so a spawn that clears the delivery checks still creates nothing.
@@ -176,6 +189,48 @@ EOF
   assert_absent "$home/state/$id.meta" \
     "Ponytail contract refusal still published task metadata"
   pass "fm-spawn: a missing Ponytail guarantee fails before launch with a clear diagnostic"
+}
+
+test_pluginless_no_mistakes_delivery_is_refused() {
+  local rec home proj fakebin out status id meta
+  rec=$(make_home pluginless-pipeline)
+  IFS='|' read -r home proj fakebin <<EOF
+$rec
+EOF
+  id=delivery-pluginless-refusal-b5
+  write_brief "$home" "$id" no-mistakes
+  cat > "$fakebin/codex" <<'STUB'
+#!/bin/sh
+printf '%s\n' '{"installed":[]}'
+STUB
+  chmod +x "$fakebin/codex"
+  out=$(run_spawn "$home" "$fakebin" "$id" "$proj" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "pluginless no-mistakes spawn should be refused"
+  assert_contains "$out" "pipeline agent codex has no enabled Ponytail plugin" \
+    "pluginless pipeline refusal did not identify the missing operational boundary"
+  assert_contains "$out" "refusing to launch $id" \
+    "pluginless pipeline refusal did not stop before worker launch"
+  assert_absent "$home/state/$id.meta" \
+    "pluginless pipeline refusal still published task metadata"
+
+  id=promote-pluginless-refusal-b6
+  write_brief "$home" "$id"
+  meta="$home/state/$id.meta"
+  printf 'window=fm-%s\nkind=scout\nworktree=/tmp/wt\n' "$id" > "$meta"
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" PATH="$fakebin:$PATH" \
+    "$PROMOTE" "$id" --mode no-mistakes --yolo off 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "pluginless no-mistakes promotion should be refused"
+  assert_contains "$out" "pipeline agent codex has no enabled Ponytail plugin" \
+    "pluginless promotion did not identify the missing operational boundary"
+  assert_contains "$out" "refusing to promote $id" \
+    "pluginless promotion did not stop before changing the task"
+  assert_grep 'kind=scout' "$meta" \
+    "pluginless promotion changed the task kind"
+  assert_absent "$home/data/$id/ship-instructions.md" \
+    "pluginless promotion published ship instructions"
+  pass "fm-spawn/fm-promote: pluginless no-mistakes delivery fails closed"
 }
 
 # The registry is the captain's standing posture, so dropping below its rigor is
@@ -394,9 +449,9 @@ STUB
   done
 
   payload="$TMP_ROOT/promote-dod/payload-promote-dod-no-mistakes"
-  assert_grep "## Required pipeline discipline" "$payload" \
-    "promoted no-mistakes worker did not receive the pipeline-agent Ponytail handoff"
-  assert_grep "the only non-captain text authorized in \`--intent\`" "$payload" \
+  assert_no_grep "## Required pipeline discipline" "$payload" \
+    "promoted no-mistakes worker put execution directives into sanitized intent"
+  assert_grep "only the authorized captain intent" "$payload" \
     "promoted no-mistakes worker lost the intent provenance boundary"
   assert_grep "ask-user findings are never yours to answer: escalate to firstmate" "$payload" \
     "promoted no-mistakes worker did not receive the ask-user escalation rule"
@@ -535,14 +590,14 @@ EOF
     "marked legacy spawn did not render a current launch contract"
   assert_grep "Development contract: ponytail=full" "$home/data/$id/launch-brief.md" \
     "legacy no-mistakes launch omitted the implementation-time Ponytail contract"
-  assert_grep "## Required pipeline discipline" "$home/data/$id/launch-brief.md" \
-    "legacy no-mistakes launch omitted the pipeline-agent Ponytail handoff"
+  assert_no_grep "## Required pipeline discipline" "$home/data/$id/launch-brief.md" \
+    "legacy no-mistakes launch put execution directives into sanitized intent"
   assert_grep "Prefer the host's installed Ponytail plugin, skill, and lifecycle hooks" \
     "$home/data/$id/launch-brief.md" \
-    "pipeline-agent handoff did not prefer the installed host integration"
-  assert_grep "the only non-captain text authorized in \`--intent\`" \
+    "development contract did not prefer the installed host integration"
+  assert_grep "Pass the serialized captain intent below plus any later words the captain actually supplied as \`--intent\`" \
     "$home/data/$id/launch-brief.md" \
-    "pipeline-agent handoff did not preserve the intent provenance boundary"
+    "launch contract did not preserve the intent provenance boundary"
   assert_grep "supersedes every earlier brief instruction about constructing \`--intent\`" \
     "$home/data/$id/launch-brief.md" \
     "marked legacy spawn did not override its stale intent instruction"
@@ -790,6 +845,7 @@ test_ship_spawn_requires_a_valid_delivery_contract
 test_scout_and_secondmate_refuse_delivery_flags
 test_spawn_refuses_a_brief_mode_mismatch
 test_spawn_reports_when_ponytail_contract_cannot_be_published
+test_pluginless_no_mistakes_delivery_is_refused
 test_spawn_notices_a_rigor_downgrade_against_the_registry
 test_scout_records_no_delivery_posture
 test_promote_requires_and_records_the_delivery_contract

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -26,13 +26,13 @@ PIPELINE_BIN="$TMP_ROOT/pipeline-bin"
 mkdir -p "$PIPELINE_BIN"
 cat > "$PIPELINE_BIN/no-mistakes" <<'STUB'
 #!/bin/sh
-printf '%s\n' '  ✓ gate validation  codex is runnable'
+if [ "$*" = 'axi run --help' ]; then
+  printf '%s\n' '      --require-ponytail   require Ponytail full for pipeline agents'
+  exit 0
+fi
+exit 2
 STUB
-cat > "$PIPELINE_BIN/codex" <<'STUB'
-#!/bin/sh
-printf '%s\n' '{"installed":[{"pluginId":"ponytail@test","enabled":true}]}'
-STUB
-chmod +x "$PIPELINE_BIN/no-mistakes" "$PIPELINE_BIN/codex"
+chmod +x "$PIPELINE_BIN/no-mistakes"
 PATH="$PIPELINE_BIN:$PATH"
 export PATH
 
@@ -191,28 +191,32 @@ EOF
   pass "fm-spawn: a missing Ponytail guarantee fails before launch with a clear diagnostic"
 }
 
-test_pluginless_no_mistakes_delivery_is_refused() {
+test_unsupported_no_mistakes_delivery_is_refused() {
   local rec home proj fakebin out status id meta
-  rec=$(make_home pluginless-pipeline)
+  rec=$(make_home unsupported-pipeline)
   IFS='|' read -r home proj fakebin <<EOF
 $rec
 EOF
   id=delivery-pluginless-refusal-b5
   write_brief "$home" "$id" no-mistakes
-  cat > "$fakebin/codex" <<'STUB'
+  cat > "$fakebin/no-mistakes" <<'STUB'
 #!/bin/sh
-printf '%s\n' '{"installed":[]}'
+if [ "$*" = 'axi run --help' ]; then
+  printf '%s\n' '      --intent string   what the user set out to accomplish'
+  exit 0
+fi
+exit 2
 STUB
-  chmod +x "$fakebin/codex"
+  chmod +x "$fakebin/no-mistakes"
   out=$(run_spawn "$home" "$fakebin" "$id" "$proj" claude --mode no-mistakes --yolo off)
   status=$?
-  [ "$status" -ne 0 ] || fail "pluginless no-mistakes spawn should be refused"
-  assert_contains "$out" "pipeline agent codex has no enabled Ponytail plugin" \
-    "pluginless pipeline refusal did not identify the missing operational boundary"
+  [ "$status" -ne 0 ] || fail "unsupported no-mistakes spawn should be refused"
+  assert_contains "$out" "does not expose axi run --require-ponytail" \
+    "unsupported CLI refusal did not identify the missing handoff"
   assert_contains "$out" "refusing to launch $id" \
-    "pluginless pipeline refusal did not stop before worker launch"
+    "unsupported CLI refusal did not stop before worker launch"
   assert_absent "$home/state/$id.meta" \
-    "pluginless pipeline refusal still published task metadata"
+    "unsupported CLI refusal still published task metadata"
 
   id=promote-pluginless-refusal-b6
   write_brief "$home" "$id"
@@ -221,16 +225,16 @@ STUB
   out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" PATH="$fakebin:$PATH" \
     "$PROMOTE" "$id" --mode no-mistakes --yolo off 2>&1)
   status=$?
-  [ "$status" -ne 0 ] || fail "pluginless no-mistakes promotion should be refused"
-  assert_contains "$out" "pipeline agent codex has no enabled Ponytail plugin" \
-    "pluginless promotion did not identify the missing operational boundary"
+  [ "$status" -ne 0 ] || fail "unsupported no-mistakes promotion should be refused"
+  assert_contains "$out" "does not expose axi run --require-ponytail" \
+    "unsupported CLI refusal did not identify the missing promotion handoff"
   assert_contains "$out" "refusing to promote $id" \
-    "pluginless promotion did not stop before changing the task"
+    "unsupported CLI refusal did not stop before changing the task"
   assert_grep 'kind=scout' "$meta" \
-    "pluginless promotion changed the task kind"
+    "unsupported CLI refusal changed the task kind"
   assert_absent "$home/data/$id/ship-instructions.md" \
-    "pluginless promotion published ship instructions"
-  pass "fm-spawn/fm-promote: pluginless no-mistakes delivery fails closed"
+    "unsupported CLI refusal published ship instructions"
+  pass "fm-spawn/fm-promote: unsupported no-mistakes delivery is refused"
 }
 
 # The registry is the captain's standing posture, so dropping below its rigor is
@@ -453,6 +457,8 @@ STUB
     "promoted no-mistakes worker put execution directives into sanitized intent"
   assert_grep "only the authorized captain intent" "$payload" \
     "promoted no-mistakes worker lost the intent provenance boundary"
+  assert_grep 'no-mistakes axi run --require-ponytail --intent "$captain_intent"' "$payload" \
+    "promoted no-mistakes worker lost the operational Ponytail handoff"
   assert_grep "ask-user findings are never yours to answer: escalate to firstmate" "$payload" \
     "promoted no-mistakes worker did not receive the ask-user escalation rule"
   assert_grep "write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority)" "$payload" \
@@ -598,6 +604,9 @@ EOF
   assert_grep "Pass the serialized captain intent below plus any later words the captain actually supplied as \`--intent\`" \
     "$home/data/$id/launch-brief.md" \
     "launch contract did not preserve the intent provenance boundary"
+  assert_grep 'no-mistakes axi run --require-ponytail --intent "$captain_intent"' \
+    "$home/data/$id/launch-brief.md" \
+    "legacy no-mistakes launch omitted the operational Ponytail handoff"
   assert_grep "supersedes every earlier brief instruction about constructing \`--intent\`" \
     "$home/data/$id/launch-brief.md" \
     "marked legacy spawn did not override its stale intent instruction"
@@ -845,7 +854,7 @@ test_ship_spawn_requires_a_valid_delivery_contract
 test_scout_and_secondmate_refuse_delivery_flags
 test_spawn_refuses_a_brief_mode_mismatch
 test_spawn_reports_when_ponytail_contract_cannot_be_published
-test_pluginless_no_mistakes_delivery_is_refused
+test_unsupported_no_mistakes_delivery_is_refused
 test_spawn_notices_a_rigor_downgrade_against_the_registry
 test_scout_records_no_delivery_posture
 test_promote_requires_and_records_the_delivery_contract

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -89,7 +89,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_exit0 "$fakebin" treehouse no-mistakes
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -176,10 +176,20 @@ fm_fake_exit0() {
   local fakebin=$1 tool
   shift
   for tool in "$@"; do
-    cat > "$fakebin/$tool" <<'SH'
+    if [ "$tool" = no-mistakes ]; then
+      cat > "$fakebin/$tool" <<'SH'
+#!/usr/bin/env bash
+if [ "$*" = 'axi run --help' ]; then
+  printf '%s\n' '      --require-ponytail   require Ponytail full for pipeline agents'
+fi
+exit 0
+SH
+    else
+      cat > "$fakebin/$tool" <<'SH'
 #!/usr/bin/env bash
 exit 0
 SH
+    fi
     chmod +x "$fakebin/$tool"
   done
 }


### PR DESCRIPTION
## Summary

- require Ponytail full in every generated or legacy ship/development handoff
- require the no-mistakes structured Ponytail handoff before spawn or scout promotion
- keep scout, secondmate, prose-only, and read-only work outside the coding discipline
- fail closed with a clear diagnostic when the selected no-mistakes build lacks the required capability

## Validation

- no-mistakes review completed with all findings resolved
- explicit ponytail-review: Lean already. Ship.
- focused fm-brief, fm-task-delivery, and fm-spawn-dispatch-profile suites pass
- full changed-suite run completed twice; remaining failures are unchanged/ambient test-environment failures
- local lint could not run because the pinned ShellCheck 0.11.0 binary is absent; CI uses the repository toolchain

## Dependency contract

The no-mistakes handoff currently exists on YiiiMeng/no-mistakes branch feat/ponytail-handoff-v1 at 0e2f1ec. This PR does not install or modify the host no-mistakes binary.