### PR TITLE
test: fix environment-dependent test gate failures

### DIFF
--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -271,18 +271,22 @@ test_matrix_herdr_halfblock_rule_bounds_bare_wrap() {
   # footer, whose real content turns an idle pane into a false `pending`.
   # Captured live from a herdr cursor pane.
   local screen plain out
-  plain=$'transcript\n \u2584\u2584\u2584\u2584\u2584\u2584\u2584\u2584\n  \u2192 Add a follow-up\n \u2580\u2580\u2580\u2580\u2580\u2580\u2580\u2580\n  Cursor Grok 4.5 High \u00b7 6.7%   Run Everything\n  ~/wt \u00b7 64cdd3a'
+  # \x byte escapes, not \u: stock macOS bash 3.2 does not interpret \uHHHH in
+  # printf or $'', so a \u fixture stays the literal text "\u2580" and this
+  # regression goes falsely red even though the library is correct. \x produces
+  # the same UTF-8 bytes on every bash. \xe2\x96\x84 = U+2584 (herdr's upper
+  # rule), \xe2\x96\x80 = U+2580 (lower rule), \xe2\x86\x92 = U+2192 cursor glyph.
+  plain=$'transcript\n \xe2\x96\x84\xe2\x96\x84\xe2\x96\x84\xe2\x96\x84\xe2\x96\x84\xe2\x96\x84\xe2\x96\x84\xe2\x96\x84\n  \xe2\x86\x92 Add a follow-up\n \xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\n  Cursor Grok 4.5 High \xc2\xb7 6.7%   Run Everything\n  ~/wt \xc2\xb7 64cdd3a'
   # The closing rule must bound the region, so the footer below is not input.
-  fm_composer_row_has_edge " $(printf '\u2580\u2580\u2580')" \
+  fm_composer_row_has_edge " $(printf '\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80')" \
     || fail "a half-block rule row must count as a structural edge"
-  fm_composer_row_has_edge " $(printf '\u2584\u2584\u2584')" \
+  fm_composer_row_has_edge " $(printf '\xe2\x96\x84\xe2\x96\x84\xe2\x96\x84')" \
     || fail "the upper half-block rule must count as a structural edge"
   # Non-vacuousness: the footer rows really are non-blank content that would be
   # swallowed if the rule did not bound the region.
   case "$plain" in *"Run Everything"*) : ;; *) fail "fixture lost its footer content" ;; esac
-  ESC_LOCAL=$(printf '\033')
-  screen=$'transcript\n \u2584\u2584\u2584\u2584\u2584\u2584\u2584\u2584\n'"  ${ESC_LOCAL}[2m\u2192 ${ESC_LOCAL}[0;7mA${ESC_LOCAL}[0;2mdd a follow-up${ESC_LOCAL}[0m"$'\n \u2580\u2580\u2580\u2580\u2580\u2580\u2580\u2580\n  Cursor Grok 4.5 High \u00b7 6.7%   Run Everything\n  ~/wt \u00b7 64cdd3a'
-  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$(printf '%b' "$screen")")
+  screen=$'transcript\n \xe2\x96\x84\xe2\x96\x84\xe2\x96\x84\xe2\x96\x84\xe2\x96\x84\xe2\x96\x84\xe2\x96\x84\xe2\x96\x84\n'"  ${ESC}[2m$(printf '\xe2\x86\x92') ${ESC}[0;7mA${ESC}[0;2mdd a follow-up${ESC}[0m"$'\n \xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\n  Cursor Grok 4.5 High \xc2\xb7 6.7%   Run Everything\n  ~/wt \xc2\xb7 64cdd3a'
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen")
   [ "$out" = empty ] \
     || fail "an idle cursor composer inside herdr half-block rules must read empty, got '$out'"
   pass "matrix: herdr half-block rules bound a bare composer's wrap region"

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -15,6 +15,16 @@ LINT="$ROOT/bin/fm-lint.sh"
 INSTALLER="$ROOT/bin/fm-install-actionlint.sh"
 REQUIRED=$("$LINT_WF" --required-version)
 
+# True only when a real actionlint at exactly the pinned version is resolvable,
+# mirroring fm-lint-workflows.sh's own gate (bin/fm-lint-workflows.sh version
+# check). The tests below that exercise actionlint's real YAML parsing cannot be
+# faked by a stub, so they run under CI parity and SKIP LOUDLY where the pinned
+# tool is genuinely absent - the same contract fm-lint.test.sh uses for ShellCheck.
+actionlint_ready() {
+  command -v actionlint >/dev/null 2>&1 || return 1
+  [ "$(actionlint -version 2>/dev/null | awk 'NR==1 {print; exit}')" = "$REQUIRED" ]
+}
+
 # Official sha256 values from actionlint_1.7.12_checksums.txt on the v1.7.12
 # release (https://github.com/rhysd/actionlint/releases/tag/v1.7.12). Tests
 # compare installer behavior against these published digests, not script source.
@@ -167,6 +177,10 @@ YAML
 }
 
 test_current_workflows_pass() {
+  if ! actionlint_ready; then
+    pass "SKIP (actionlint $REQUIRED not resolved): current workflows parse check"
+    return
+  fi
   local out rc
   rc=0
   out=$("$LINT_WF" 2>&1) || rc=$?
@@ -177,6 +191,10 @@ test_current_workflows_pass() {
 }
 
 test_col0_heredoc_fails_with_clear_error() {
+  if ! actionlint_ready; then
+    pass "SKIP (actionlint $REQUIRED not resolved): column-0 heredoc failure check"
+    return
+  fi
   local tmp out rc
   tmp=$(fm_test_tmproot fm-lint-wf-col0)
   mkdir -p "$tmp/.github/workflows"
@@ -192,6 +210,10 @@ test_col0_heredoc_fails_with_clear_error() {
 }
 
 test_valid_fixture_passes() {
+  if ! actionlint_ready; then
+    pass "SKIP (actionlint $REQUIRED not resolved): valid fixture workflow check"
+    return
+  fi
   local tmp out rc
   tmp=$(fm_test_tmproot fm-lint-wf-ok)
   mkdir -p "$tmp/.github/workflows"
@@ -217,6 +239,10 @@ test_empty_workflows_dir_fails() {
 }
 
 test_explicit_broken_path_fails() {
+  if ! actionlint_ready; then
+    pass "SKIP (actionlint $REQUIRED not resolved): explicit broken path check"
+    return
+  fi
   local tmp broken out rc
   tmp=$(fm_test_tmproot fm-lint-wf-path)
   broken="$tmp/broken.yml"
@@ -230,6 +256,10 @@ test_explicit_broken_path_fails() {
 }
 
 test_non_mapping_root_fails() {
+  if ! actionlint_ready; then
+    pass "SKIP (actionlint $REQUIRED not resolved): non-mapping YAML root check"
+    return
+  fi
   local tmp out rc
   tmp=$(fm_test_tmproot fm-lint-wf-scalar)
   mkdir -p "$tmp/.github/workflows"
@@ -463,6 +493,10 @@ test_installer_rejects_unsupported_platform() {
 # self-broken ci.yml. Copy the lint scripts into a fake repo so the default
 # workflow root is the fixture, not this worktree.
 test_fm_lint_default_path_catches_broken_ci_yml() {
+  if ! actionlint_ready; then
+    pass "SKIP (actionlint $REQUIRED not resolved): fm-lint.sh default-path broken ci.yml check"
+    return
+  fi
   local tmp fakebin log diff_file out rc
   tmp=$(fm_test_tmproot fm-lint-wf-default)
   mkdir -p "$tmp/bin" "$tmp/.github/workflows"

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -21,6 +21,12 @@ LINT="$ROOT/bin/fm-lint.sh"
 INSTALLER="$ROOT/bin/fm-install-shellcheck.sh"
 # The pinned version, read from the single source (the one owner itself).
 REQUIRED=$("$LINT" --required-version)
+# fm-lint.sh's default-path run also validates workflows via
+# bin/fm-lint-workflows.sh, so the changed-mode and zero-changed tests below -
+# which exercise ShellCheck file selection, not actionlint - stub a
+# pinned-version actionlint to stay hermetic and run without a real actionlint
+# installed. The pin is read from its owner rather than restated here.
+REQUIRED_ACTIONLINT=$("$ROOT/bin/fm-lint-workflows.sh" --required-version)
 
 # Official GitHub release asset sha256 values for shellcheck v0.11.0 .tar.xz
 # archives (https://github.com/koalaman/shellcheck/releases/tag/v0.11.0). Tests
@@ -265,6 +271,21 @@ SH
   chmod +x "$fakebin/shellcheck"
 }
 
+# fm_lint_stub_actionlint <fakebin-dir>: install an actionlint stub that reports
+# the pinned version and passes every workflow. fm-lint.sh's default-path run
+# validates workflows through bin/fm-lint-workflows.sh, so tests that invoke that
+# path to exercise ShellCheck selection would otherwise fail closed on a machine
+# without a real actionlint. This keeps them hermetic and about ShellCheck only.
+fm_lint_stub_actionlint() {
+  local fakebin=$1
+  cat > "$fakebin/actionlint" <<SH
+#!/usr/bin/env bash
+[ "\${1:-}" = -version ] && { printf '$REQUIRED_ACTIONLINT\n'; exit 0; }
+exit 0
+SH
+  chmod +x "$fakebin/actionlint"
+}
+
 test_fast_mode_disables_extended_analysis() {
   local tmp fakebin log mode_log telemetry fixture out
   tmp=$(fm_test_tmproot fm-lint-fast-mode)
@@ -367,6 +388,9 @@ test_changed_mode_lints_only_the_changed_file() {
   fm_lint_stub_git "$fakebin"
   log="$tmp/shellcheck.log"
   fm_lint_stub_shellcheck "$fakebin" "$log"
+  # fm-lint.sh's default path also validates workflows, so stub actionlint too or
+  # this ShellCheck-selection test fails closed where no real actionlint exists.
+  fm_lint_stub_actionlint "$fakebin"
   diff_file="$tmp/diff.nul"
   target="bin/fm-install-shellcheck.sh"
   fm_lint_write_diff_file "$diff_file" "$target" "README.md"
@@ -435,6 +459,11 @@ test_zero_changed_files_exits_clean() {
   tmp=$(fm_test_tmproot fm-lint-zero-changed)
   fakebin=$(fm_fakebin "$tmp")
   fm_lint_stub_git "$fakebin"
+  # The version gate resolves ShellCheck even with zero targets, and the default
+  # path then validates workflows; stub both so this stays hermetic without a
+  # real ShellCheck or actionlint installed.
+  fm_lint_stub_shellcheck "$fakebin" "$tmp/shellcheck.log"
+  fm_lint_stub_actionlint "$fakebin"
   diff_file="$tmp/diff.nul"
   : > "$diff_file"
 

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -104,7 +104,12 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  cp "$(command -v bash)" "$fakebin/muse-bin-test-version"
+  # Symlink, not cp: on Apple Silicon macOS the kernel SIGKILLs a COPY of the
+  # system bash because /bin/bash is an arm64e platform binary and the copy is
+  # not one. A symlink resolves to the real platform binary, so it runs, and the
+  # exec'd symlink still reports its own name as the process comm on macOS and
+  # Linux - which is exactly the muse-bin-<version> process name detection needs.
+  ln -s "$(command -v bash)" "$fakebin/muse-bin-test-version"
   cat > "$fakebin/muse" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -181,7 +186,7 @@ test_detects_versioned_process_ancestor() {
   dir="$TMP_ROOT/detect"
   mkdir -p "$dir"
   for bin in muse-bin-0.1.0-R708.1 muse-bin-9.9.9-RZZZ.9 muse; do
-    cp "$(command -v bash)" "$dir/$bin"
+    ln -s "$(command -v bash)" "$dir/$bin"
     out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
       -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI \
       "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
@@ -197,7 +202,7 @@ test_detection_is_anchored() {
   dir="$TMP_ROOT/detect-neg"
   mkdir -p "$dir"
   for bin in musescore amuse notmuse-bin muse-binary muse-bind; do
-    cp "$(command -v bash)" "$dir/$bin"
+    ln -s "$(command -v bash)" "$dir/$bin"
     out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
       -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI \
       "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")


### PR DESCRIPTION
## Intent

Verbatim captain 2026-09-04: "fix the firstmate bugs" - this is bug 3 of 3: every firstmate task's test gate trips on the same 4 pre-existing failures, forcing per-task skip decisions; the goal is a green base so skips stop being routine.

## What Changed

- Use portable UTF-8 byte escapes for composer fixtures and symlink Bash-based Muse test executables to avoid macOS-specific failures.
- Skip actionlint parsing checks when the exact pinned binary is unavailable.
- Stub pinned actionlint and ShellCheck dependencies in lint-selection tests to keep them hermetic.

## Risk Assessment

✅ Low: The test-only changes are well bounded, preserve behavioral coverage where dependencies are available, and appropriately isolate platform- and dependency-specific fixtures without changing production behavior.

## Testing

The supplied baseline was green; targeted regression testing reproduced all four pre-fix gate failures, then demonstrated the fixed changed-test gate end to end on Apple Silicon macOS with required Node present and optional actionlint/ShellCheck absent, including loud conditional skips and no remaining failures.

<details>
<summary>Evidence: Base regression on Apple Silicon macOS</summary>

Source: [Base regression on Apple Silicon macOS](https://github.com/ampcynthli/firstmate/blob/dec98c87e5a2a3463050c76b3e28bb4372aecb62/.no-mistakes/evidence/fm/firstmate-testenv-reds-f6/base-regression-stock-macos.txt)

<code>Pre-fix gate result: `FM_TEST_SUMMARY total=4 failed=4 skipped_gate=0`.</code>

```text
FM_TEST_BEGIN 2026-09-04T21:57:32Z tests/fm-composer-lib.test.sh family=pure-contract-unit expected_gate_skip=none
FM_TEST_BEGIN 2026-09-04T21:57:32Z tests/fm-lint.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm_composer_classify_content: a bare shell prompt glyph (>/$/%/#) reads unknown, never empty
ok - fm_composer_classify_content: stripped unbordered content is unknown except verified agent glyphs
ok - fm_composer_classify_content: a bare shell prompt carrying a command is not empty
ok - fm_composer_classify_content: a bare prompt glyph inside a bordered composer box reads empty (claude's own idle composer)
ok - fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex, ⟩ muse) read empty bordered or bare
ok - fm_composer_classify_content: an empty composer reads empty
ok - fm_composer_classify_content: idle matching is limited to proven placeholder positions
ok - fm_composer_classify_content: idle matching preserves the caller's case mode
ok - fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)
ok - matrix: claude's ❯+NBSP row reads empty on every profile in both locales (#1988)
ok - matrix: codex's dim hint is empty when styling proves it, unknown (never pending) when it cannot
ok - matrix: muse's ⟩ reads empty everywhere and survives losing the styled-glyph signal
ok - matrix: cursor's reverse-video placeholder remnant reads empty; real typed text stays pending
not ok - a half-block rule row must count as a structural edge
FM_TEST_END 2026-09-04T21:57:34Z tests/fm-composer-lib.test.sh exit=1 duration_ms=1856 gate_skip=false
ok - fm-lint.sh --help reports the complete executable interface
ok - fm-lint.sh --list-files reports the complete shell inventory
ok - fm-lint.sh --fast disables ShellCheck extended analysis
ok - fm-lint.sh keeps full ShellCheck analysis by default in CI
ok - fm-lint.sh rejects explicit --fast mode in CI
ok - SKIP (ShellCheck 0.11.0 not resolved): fast lint-defect regression check
ok - fm-lint.sh pins an explicit ShellCheck version (0.11.0)
ok - ShellCheck installer retries a transient download failure
ok - ShellCheck installer selects the official archive, URL, and checksum per OS/arch
ok - ShellCheck installer rejects a wrong checksum
ok - ShellCheck installer falls back to shasum -a 256 when sha256sum is absent
ok - ShellCheck installer prefers sha256sum when both hashers are present
ok - ShellCheck installer rejects an unsupported OS or architecture
ok - missing ShellCheck fails closed
ok - fm-lint.sh refuses to lint under a non-pinned ShellCheck version
ok - SKIP (ShellCheck 0.11.0 not resolved): lint-defect regression check
ok - SKIP (ShellCheck 0.11.0 not resolved): ambient options regression check
ok - SKIP (ShellCheck 0.11.0 not resolved): clean fixture check
ok - SKIP (ShellCheck 0.11.0 not resolved): deterministic bounded jobs check
ok - jobs=1 and jobs=2 stop complete worker trees with and without telemetry
ok - SKIP (ShellCheck 0.11.0 not resolved): seeded source-boundary parity check
not ok - changed-mode lint run failed
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
fm-lint.sh: full ShellCheck extended analysis enabled
fm-lint-workflows.sh: actionlint not found; install actionlint 1.7.12 with bin/fm-install-actionlint.sh <destination-directory> and put that directory on PATH.
FM_TEST_END 2026-09-04T21:57:41Z tests/fm-lint.test.sh exit=1 duration_ms=8485 gate_skip=false
FM_TEST_BEGIN 2026-09-04T21:57:41Z tests/fm-muse-harness.test.sh family=pure-contract-unit expected_gate_skip=none
FM_TEST_BEGIN 2026-09-04T21:57:41Z tests/fm-lint-workflows.test.sh family=pure-contract-unit expected_gate_skip=none
not ok - fm-harness.sh under process 'muse-bin-0.1.0-R708.1' reported '', expected muse
FM_TEST_END 2026-09-04T21:57:41Z tests/fm-muse-harness.test.sh exit=1 duration_ms=117 gate_skip=false
ok - fm-lint-workflows.sh pins an explicit actionlint version (1.7.12)
not ok - current workflows must parse, got 1
fm-lint-workflows.sh: actionlint not found; install actionlint 1.7.12 with bin/fm-install-actionlint.sh <destination-directory> and put that directory on PATH.
FM_TEST_END 2026-09-04T21:57:41Z tests/fm-lint-workflows.test.sh exit=1 duration_ms=120 gate_skip=false
FM_TEST_SUMMARY total=4 failed=4 skipped_gate=0 duration_ms=9097
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=4 duration_ms=10578 failed=4
FM_TEST_SLOWEST rank=1 script=tests/fm-lint.test.sh duration_ms=8485
FM_TEST_SLOWEST rank=2 script=tests/fm-composer-lib.test.sh duration_ms=1856
FM_TEST_SLOWEST rank=3 script=tests/fm-lint-workflows.test.sh duration_ms=120
FM_TEST_SLOWEST rank=4 script=tests/fm-muse-harness.test.sh duration_ms=117
```
</details>
<details>
<summary>Evidence: Green fixed gate without optional lint tools</summary>

Source: [Green fixed gate without optional lint tools](https://github.com/ampcynthli/firstmate/blob/dec98c87e5a2a3463050c76b3e28bb4372aecb62/.no-mistakes/evidence/fm/firstmate-testenv-reds-f6/fixed-gate-node-no-lint-tools.txt)

<code>Fixed gate with Node available and actionlint/ShellCheck absent: `FM_TEST_SUMMARY total=4 failed=0 skipped_gate=0`; unavailable-tool checks emitted explicit conditional `SKIP` messages.</code>

```text
FM_TEST_BEGIN 2026-09-04T22:00:29Z tests/fm-composer-lib.test.sh family=pure-contract-unit expected_gate_skip=none
FM_TEST_BEGIN 2026-09-04T22:00:29Z tests/fm-lint.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm_composer_classify_content: a bare shell prompt glyph (>/$/%/#) reads unknown, never empty
ok - fm_composer_classify_content: stripped unbordered content is unknown except verified agent glyphs
ok - fm_composer_classify_content: a bare shell prompt carrying a command is not empty
ok - fm_composer_classify_content: a bare prompt glyph inside a bordered composer box reads empty (claude's own idle composer)
ok - fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex, ⟩ muse) read empty bordered or bare
ok - fm_composer_classify_content: an empty composer reads empty
ok - fm_composer_classify_content: idle matching is limited to proven placeholder positions
ok - fm_composer_classify_content: idle matching preserves the caller's case mode
ok - fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)
ok - matrix: claude's ❯+NBSP row reads empty on every profile in both locales (#1988)
ok - matrix: codex's dim hint is empty when styling proves it, unknown (never pending) when it cannot
ok - matrix: muse's ⟩ reads empty everywhere and survives losing the styled-glyph signal
ok - matrix: cursor's reverse-video placeholder remnant reads empty; real typed text stays pending
ok - matrix: herdr half-block rules bound a bare composer's wrap region
ok - matrix: pi's separated composer needs identity + structure; the blank row alone never proves it
ok - matrix: opencode's left-bar composer reads empty everywhere and scans the full active run
ok - matrix: grok's titled bottom border is tolerated as a title, not read as ambiguity
ok - matrix: kimi's bordered shell-glyph box reads empty through the shared owner (spawn's fourth copy retired)
ok - matrix: the real claude-in-zellij --ansi dump reads empty in both locales
ok - strict posture: blank and unidentified rows are unknown, never injectable empty
ok - fm_composer_classify_screen: the bare composer's wrap region stays identified; structure breaks it
ok - fm_composer_classify_screen: a row-leading agent glyph reanchors the live composer
ok - fm_composer_classify_screen: a lower dead shell invalidates only cursorless stale composers
ok - fm_composer_classify_screen: cursorless bare wrap regions participate in verdicts
ok - fm_composer_classify_screen: cursorless containers reject only contiguous unclaimed activity
ok - fm_composer_classify_screen: the bottom-most candidate wins; stale banners cannot
ok - fm_composer_classify_screen: incomplete lower structure invalidates stale boxes
ok - fm_composer_classify_screen: titled bottoms retain full box geometry
ok - fm_composer_classify_screen: a proven box tolerates a bottom-border cursor
ok - fm_composer_extract_selected_content: scopes user content and excludes furniture
ok - fm_composer_queued_enter_verdict: pending + busy returns empty (queued Enter)
ok - fm_composer_queued_enter_verdict: pending + idle/unknown stays pending
ok - fm_composer_queued_enter_verdict: only proven pending is converted
FM_TEST_END 2026-09-04T22:00:40Z tests/fm-composer-lib.test.sh exit=0 duration_ms=10197 gate_skip=false
ok - fm-lint.sh --help reports the complete executable interface
ok - fm-lint.sh --list-files reports the complete shell inventory
ok - fm-lint.sh --fast disables ShellCheck extended analysis
ok - fm-lint.sh keeps full ShellCheck analysis by default in CI
ok - fm-lint.sh rejects explicit --fast mode in CI
ok - SKIP (ShellCheck 0.11.0 not resolved): fast lint-defect regression check
ok - fm-lint.sh pins an explicit ShellCheck version (0.11.0)
ok - ShellCheck installer retries a transient download failure
ok - ShellCheck installer selects the official archive, URL, and checksum per OS/arch
ok - ShellCheck installer rejects a wrong checksum
ok - ShellCheck installer falls back to shasum -a 256 when sha256sum is absent
ok - ShellCheck installer prefers sha256sum when both hashers are present
ok - ShellCheck installer rejects an unsupported OS or architecture
ok - missing ShellCheck fails closed
ok - fm-lint.sh refuses to lint under a non-pinned ShellCheck version
ok - SKIP (ShellCheck 0.11.0 not resolved): lint-defect regression check
ok - SKIP (ShellCheck 0.11.0 not resolved): ambient options regression check
ok - SKIP (ShellCheck 0.11.0 not resolved): clean fixture check
ok - SKIP (ShellCheck 0.11.0 not resolved): deterministic bounded jobs check
ok - jobs=1 and jobs=2 stop complete worker trees with and without telemetry
ok - SKIP (ShellCheck 0.11.0 not resolved): seeded source-boundary parity check
ok - fm-lint.sh changed mode lints only the changed canonical file
ok - fm-lint.sh forces a full lint in CI even when the local diff would be empty
ok - fm-lint.sh forces a full lint when HEAD is on main
ok - fm-lint.sh explicit paths bypass changed-file mode selection
ok - fm-lint.sh exits 0 with a note when the local branch has no changed lint targets
ok - fm-lint.sh --list-files reports the would-be changed set in changed mode
FM_TEST_END 2026-09-04T22:00:40Z tests/fm-lint.test.sh exit=0 duration_ms=10923 gate_skip=false
FM_TEST_BEGIN 2026-09-04T22:00:40Z tests/fm-muse-harness.test.sh family=pure-contract-unit expected_gate_skip=none
FM_TEST_BEGIN 2026-09-04T22:00:40Z tests/fm-lint-workflows.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm-lint-workflows.sh pins an explicit actionlint version (1.7.12)
ok - SKIP (actionlint 1.7.12 not resolved): current workflows parse check
ok - SKIP (actionlint 1.7.12 not resolved): column-0 heredoc failure check
ok - SKIP (actionlint 1.7.12 not resolved): valid fixture workflow check
ok - empty workflows directory fails closed
ok - SKIP (actionlint 1.7.12 not resolved): explicit broken path check
ok - SKIP (actionlint 1.7.12 not resolved): non-mapping YAML root check
ok - missing actionlint fails closed
ok - fm-lint-workflows.sh refuses to lint under a non-pinned actionlint version
ok - actionlint installer retries a transient download failure
ok - actionlint installer selects the official archive, URL, and checksum per OS/arch
ok - actionlint installer rejects a wrong checksum
ok - actionlint installer falls back to shasum -a 256 when sha256sum is absent
ok - actionlint installer prefers sha256sum when both hashers are present
ok - actionlint installer rejects an unsupported OS or architecture
ok - SKIP (actionlint 1.7.12 not resolved): fm-lint.sh default-path broken ci.yml check
FM_TEST_END 2026-09-04T22:00:47Z tests/fm-lint-workflows.test.sh exit=0 duration_ms=5968 gate_skip=false
ok - muse is detected through any versioned muse-bin ancestor
ok - muse detection does not claim unrelated muse-containing commands
ok - muse launch clears foreign harness markers before ancestry detection
ok - muse spawn launches with autonomy, privacy control, and a positional brief
ok - muse maps the shared effort vocabulary and reaches ultra only via explicit max
ok - muse spawn refuses when no credential can reach the provider
ok - muse spawn refuses a META_API_KEY that cannot reach the worker
ok - muse spawn accepts a stored credential without META_API_KEY
ok - muse resolves relative XDG roots before preflight and launch
ok - muse is refused as a secondmate harness
ok - muse spawn writes a session binding that teardown removes
ok - every accepted muse Escape alias clears the restored composer
ok - the composer clear is scoped to muse and does not touch other adapters
ok - a failed muse composer clear fails loudly instead of leaving stale input
ok - the run fold tracks open, settled, interrupted, reopened, and run-free logs
ok - a nested terminal record never settles an in-flight run
ok - the session binding folds only the log matching this task's worktree
ok - workspace bindings compare decoded paths literally
ok - spawn-time exclusions select the current session across equal mtimes
ok - the Muse session cache avoids rescans and refreshes safely across incarnations
ok - a changed Muse namespace revalidates cached session uniqueness
ok - sub-agent session logs are excluded from the parent's busy fold
ok - every unproven muse binding classifies unknown rather than idle
ok - a settled session log reads idle for both completed and interrupted turns
ok - muse trusts no busy record source
FM_TEST_END 2026-09-04T22:01:47Z tests/fm-muse-harness.test.sh exit=0 duration_ms=66167 gate_skip=false
FM_TEST_SUMMARY total=4 failed=0 skipped_gate=0 duration_ms=77742
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=4 duration_ms=93255 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-muse-harness.test.sh duration_ms=66167
FM_TEST_SLOWEST rank=2 script=tests/fm-lint.test.sh duration_ms=10923
FM_TEST_SLOWEST rank=3 script=tests/fm-composer-lib.test.sh duration_ms=10197
FM_TEST_SLOWEST rank=4 script=tests/fm-lint-workflows.test.sh duration_ms=5968
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ad6bd6a4dfd455a7acbcc8ac766bc4b6d890192f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>Pre-supplied baseline: `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`</code>
- `bin/fm-test-run.sh --list --changed --base 8f7b79c77c2198a71a01082215227a64500015e3 --exclude-family real-herdr-gated`
- <code>Temporarily restored the four base test files and ran `PATH=/usr/bin:/bin:/usr/sbin:/sbin bin/fm-test-run.sh tests/fm-composer-lib.test.sh tests/fm-lint-workflows.test.sh tests/fm-lint.test.sh tests/fm-muse-harness.test.sh`, then restored the target files</code>
- <code>`PATH=/usr/bin:/bin:/usr/sbin:/sbin bin/fm-test-run.sh tests/fm-muse-harness.test.sh` (identified missing Node as a test-environment setup issue)</code>
- `PATH=~/.nvm/versions/node/v24.16.0/bin:/usr/bin:/bin:/usr/sbin:/sbin bin/fm-test-run.sh --changed --base 8f7b79c77c2198a71a01082215227a64500015e3 --exclude-family real-herdr-gated`
- <code>Verified `git status --short` was empty and `HEAD` was `ad6bd6a4dfd455a7acbcc8ac766bc4b6d890192f`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
