### PR TITLE
fix(bin): relaunch panes after Herdr agents exit

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1933,7 +1933,7 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   # agent left behind, so corroborate against the pane's own foreground
   # process: a provable lone idle bare shell has no agent process, so the pane
   # is agent-free and relaunchable rather than a live-or-unknown husk.
-  if fm_backend_herdr_pane_idle_shell_pid "$session" "$pane_id" >/dev/null 2>&1; then
+  if fm_backend_herdr_pane_idle_shell_sample "$session" "$pane_id" >/dev/null 2>&1; then
     printf 'no-agent'
     return 0
   fi

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1925,17 +1925,21 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   # A generating agent is trusted as-is: never probe it, both to keep this hot
   # path cheap and to avoid racing a busy pane's process table.
   [ "$status" = working ] && { printf 'live'; return 0; }
-  # Any other status can be a stale record a cleanly exited agent left behind,
-  # so corroborate against the pane's own foreground process: a provable lone
-  # idle bare shell has no agent process, so the pane is agent-free and
-  # relaunchable rather than a live-or-unknown husk.
-  if fm_backend_herdr_pane_idle_shell_sample "$session" "$pane_id" >/dev/null 2>&1; then
+  case "$status" in
+    idle|done|blocked|unknown) ;;
+    *) printf 'unknown'; return 0 ;;
+  esac
+  # A recognized non-working status can be a stale record a cleanly exited
+  # agent left behind, so corroborate against the pane's own foreground
+  # process: a provable lone idle bare shell has no agent process, so the pane
+  # is agent-free and relaunchable rather than a live-or-unknown husk.
+  if fm_backend_herdr_pane_idle_shell_pid "$session" "$pane_id" >/dev/null 2>&1; then
     printf 'no-agent'
     return 0
   fi
   case "$status" in
     idle|done|blocked) printf 'live' ;;
-    *) printf 'unknown' ;;
+    unknown) printf 'unknown' ;;
   esac
 }
 

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1874,25 +1874,37 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 #              reaped it - verified empirically: killing a pane's shell pid
 #              on a live server makes herdr immediately drop both the pane
 #              and its tab from `pane get`/`tab list`).
-#   no-agent - `pane get` succeeds (the pane structurally exists) but `agent
-#              get` responds with error code agent_not_found: nothing is
-#              registered in it - exactly what a herdr session-layout restore
+#   no-agent - the pane structurally exists but holds no agent process. Two
+#              shapes reach this. First, `agent get` responds agent_not_found:
+#              nothing is registered - what a herdr session-layout restore
 #              produces (verified empirically: `session stop` + fresh `herdr
 #              server` restart leaves the pane alive, agent_status "unknown",
 #              agent get -> agent_not_found - docs/herdr-backend.md "ID
 #              stability across a server restart"), and what a future
 #              `resume_agents_on_restore = false` restore would produce too
-#              (a plain shell, never an agent).
-#   live     - `agent get` succeeds and reports a real agent_status (working,
-#              idle, done, or blocked - any registered value). An idle or
-#              blocked agent is still a genuine, still-registered agent, not
-#              a restored husk, so it is never a close-and-replace candidate.
+#              (a plain shell, never an agent). Second, `agent get` still
+#              returns a non-working status (done, idle, blocked, or unknown)
+#              that is a STALE record a cleanly exited agent left behind, yet
+#              the pane's foreground process is a provable lone idle bare
+#              shell. herdr keeps the agent entry after the process dropped to
+#              a bash prompt (this repo's issue #3639, and the exited claude
+#              pane that motivated this corroboration), so agent_status alone
+#              cannot be trusted; the foreground process is the kernel-side
+#              truth, corroborated exactly as the tmux classifier trusts its
+#              own foreground process group for the agent-free verdict.
+#   live     - `agent get` reports agent_status working (trusted outright, never
+#              probed), or reports idle/done/blocked while the pane still runs
+#              the agent process (the bare-shell corroboration did NOT fire). A
+#              still-registered idle or blocked agent is genuine, not a restored
+#              husk, so it is never a close-and-replace candidate.
 #   unknown  - anything else: an unparseable/unexpected response from either
-#              call, or a `pane get` success whose own echoed pane_id does not
-#              round-trip (guards against misreading a herdr response shape
-#              change as "the pane exists"). The caller must fail safe toward
-#              refusal here, never toward closing - this is the conservative
-#              backstop the husk check depends on.
+#              call, a non-working status whose pane could not be proven to be a
+#              lone idle bare shell (fail-safe: not proven agent-free), or a
+#              `pane get` success whose own echoed pane_id does not round-trip
+#              (guards against misreading a herdr response shape change as "the
+#              pane exists"). The caller must fail safe toward refusal here,
+#              never toward closing - this is the conservative backstop the husk
+#              check depends on.
 fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   local session=$1 pane_id=$2 out code presence status
   presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane_id")
@@ -1910,8 +1922,19 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
     return 0
   fi
   status=$(printf '%s' "$out" | jq -r '.result.agent.agent_status // empty' 2>/dev/null)
+  # A generating agent is trusted as-is: never probe it, both to keep this hot
+  # path cheap and to avoid racing a busy pane's process table.
+  [ "$status" = working ] && { printf 'live'; return 0; }
+  # Any other status can be a stale record a cleanly exited agent left behind,
+  # so corroborate against the pane's own foreground process: a provable lone
+  # idle bare shell has no agent process, so the pane is agent-free and
+  # relaunchable rather than a live-or-unknown husk.
+  if fm_backend_herdr_pane_idle_shell_sample "$session" "$pane_id" >/dev/null 2>&1; then
+    printf 'no-agent'
+    return 0
+  fi
   case "$status" in
-    working|idle|done|blocked) printf 'live' ;;
+    idle|done|blocked) printf 'live' ;;
     *) printf 'unknown' ;;
   esac
 }

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1863,11 +1863,10 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 }
 
 # fm_backend_herdr_pane_agent_state: classify <pane_id> in <session> as one of
-# dead|no-agent|live|unknown, purely from the JSON body of two read-only
-# calls - never from process exit status, since a business-logic "not found"
-# response is a normal, expected outcome here, not a call failure (real herdr
-# 0.7.1 exits 1 for it; the canned-response test fakes exit 0; parsing only
-# the JSON keeps this function correct against either).
+# dead|no-agent|live|unknown from fail-safe read-only evidence. Parse Herdr's
+# structured responses rather than trusting process exit status, since a
+# business-logic "not found" response is a normal, expected outcome here
+# (real herdr 0.7.1 exits 1 for it; the canned-response test fakes exit 0).
 #
 #   dead     - `pane get` responds with error code pane_not_found: the pane
 #              itself is gone (closed, or its process died and herdr already
@@ -1893,18 +1892,17 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 #              truth, corroborated exactly as the tmux classifier trusts its
 #              own foreground process group for the agent-free verdict.
 #   live     - `agent get` reports agent_status working (trusted outright, never
-#              probed), or reports idle/done/blocked while the pane still runs
-#              the agent process (the bare-shell corroboration did NOT fire). A
-#              still-registered idle or blocked agent is genuine, not a restored
-#              husk, so it is never a close-and-replace candidate.
+#              probed), or reports idle/done/blocked and the single bare-shell
+#              sample does not prove the pane agent-free. The latter is treated
+#              conservatively as live, so it is never a close-and-replace
+#              candidate.
 #   unknown  - anything else: an unparseable/unexpected response from either
-#              call, a non-working status whose pane could not be proven to be a
-#              lone idle bare shell (fail-safe: not proven agent-free), or a
-#              `pane get` success whose own echoed pane_id does not round-trip
-#              (guards against misreading a herdr response shape change as "the
-#              pane exists"). The caller must fail safe toward refusal here,
-#              never toward closing - this is the conservative backstop the husk
-#              check depends on.
+#              Herdr read, a literal unknown status without positive bare-shell
+#              proof, or a `pane get` success whose own echoed pane_id does not
+#              round-trip (guards against misreading a herdr response shape
+#              change as "the pane exists"). The caller must fail safe toward
+#              refusal here, never toward closing - this is the conservative
+#              backstop the husk check depends on.
 fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   local session=$1 pane_id=$2 out code presence status
   presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane_id")
@@ -1958,8 +1956,9 @@ fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
 # fm_backend_herdr_agent_state: recovery-grade state for the same session-start
 # sweep as the tmux classifier. It reuses the husk classifier rather than
 # creating a second Herdr state machine: a structurally gone pane is `missing`,
-# a confirmed agent-less pane is `dead`, a registered agent is `alive`, and an
-# unexpected or failed API read is `unreadable`.
+# a confirmed agent-less pane is `dead`, a positively working or conservatively
+# retained registered agent is `alive`, and an unexpected or failed read is
+# `unreadable`.
 fm_backend_herdr_agent_state() {  # <target>
   local target=$1
   fm_backend_herdr_parse_target "$target" || { printf 'unreadable'; return 0; }

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -265,12 +265,14 @@ No Herdr-specific copy of that protocol exists.
 
 Stopping and restarting a named Herdr server preserves workspace, tab, pane, and label ids, but the underlying harness processes and live agent registrations do not survive.
 A restored same-labeled tab with a missing pane or no registered agent is a husk.
-A pane still carrying a stale agent record from a cleanly exited agent, where herdr keeps the entry as done or unknown after the process drops to a bash prompt, is also agent-free when its foreground process is a proven lone idle bare shell, so the classifier corroborates any non-working agent status against that process proof rather than trusting the record alone.
+A pane still carrying a stale agent record from a cleanly exited agent is also agent-free when its foreground process is a proven lone idle bare shell.
+The classifier checks recognized non-working statuses (`idle`, `done`, `blocked`, or literal `unknown`) against one strict process sample rather than trusting the record alone.
 Create replaces only a confidently dead or no-agent husk, creates the replacement before closing the old tab, and refuses live or unknown states.
 This prevents closing the workspace's last tab before a replacement exists.
 
 The generic Herdr agent-liveness probe reuses the same classifier.
-A structurally gone pane becomes `missing`, a restored or exited-agent shell proven agent-free becomes `dead`, a registered agent still running its process becomes `alive`, and an unexpected read becomes `unreadable`.
+A structurally gone pane becomes `missing`, and a restored or exited-agent shell proven agent-free becomes `dead`.
+A `working` record is `alive` without a process probe; `idle`, `done`, or `blocked` also stays `alive` unless that sample proves a bare shell, while a literal `unknown` without that proof and every malformed response becomes `unreadable`.
 Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
 
 The session-start sweep uses this probe.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -265,11 +265,12 @@ No Herdr-specific copy of that protocol exists.
 
 Stopping and restarting a named Herdr server preserves workspace, tab, pane, and label ids, but the underlying harness processes and live agent registrations do not survive.
 A restored same-labeled tab with a missing pane or no registered agent is a husk.
+A pane still carrying a stale agent record from a cleanly exited agent, where herdr keeps the entry as done or unknown after the process drops to a bash prompt, is also agent-free when its foreground process is a proven lone idle bare shell, so the classifier corroborates any non-working agent status against that process proof rather than trusting the record alone.
 Create replaces only a confidently dead or no-agent husk, creates the replacement before closing the old tab, and refuses live or unknown states.
 This prevents closing the workspace's last tab before a replacement exists.
 
 The generic Herdr agent-liveness probe reuses the same classifier.
-A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
+A structurally gone pane becomes `missing`, a restored or exited-agent shell proven agent-free becomes `dead`, a registered agent still running its process becomes `alive`, and an unexpected read becomes `unreadable`.
 Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
 
 The session-start sweep uses this probe.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -917,7 +917,8 @@ Polling remained active and is covered as the fallback for capability, connect, 
 
 ### Agent lifecycle control
 
-Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-08-08 on Herdr 0.8.0, and first measured 2026-08-02 on Herdr 0.7.5 with identical results:
+Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary.
+The output below was reverified 2026-08-08 on Herdr 0.8.0, and first measured 2026-08-02 on Herdr 0.7.5 with identical results; it predates the clean-exit stale-record corroboration added to the current guard.
 
 ```sh
 tests/fm-control-herdr-smoke.test.sh
@@ -933,8 +934,9 @@ ok - real herdr: no control verb removed the endpoint or the task's local copy
 ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
 ```
 
-The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
-That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
+The current guard also retains a literal `unknown` registration over a bare shell, requires the recovery-grade state to become `dead`, then starts a deterministic foreground process before exercising the live-agent lifecycle assertions.
+The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, and no real harness is launched.
+Run the command to refresh the full record for the clean-exit behavior and after every Herdr upgrade rather than trusting the older output above.
 
 ### Away-mode transport
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -812,7 +812,8 @@ test_create_task_refuses_when_agent_state_ambiguous() {
 # agent get -> the stale <status>, and a bare idle-shell process-info sample,
 # plus the fake ps the idle-shell proof reads. Echoes the fakebin dir.
 exited_agent_pane_probes() {  # <dir> <status> <shell-pid>
-  local dir=$1 status=$2 pid=$3 resp="$dir/responses"
+  local dir=$1 status=$2 pid=$3
+  local resp="$dir/responses"
   mkdir -p "$resp"
   printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent_status":"%s"}}}\n' "$status" > "$resp/2.out"
@@ -824,7 +825,7 @@ exited_agent_pane_probes() {  # <dir> <status> <shell-pid>
 test_pane_agent_state_exited_agent_stale_done_status_is_no_agent() {
   local dir log resp fb out
   dir="$TMP_ROOT/exited-done"; log="$dir/log"; resp="$dir/responses"
-  fb=$(exited_agent_pane_probes "$dir" done 4242); : > "$log"
+  fb=$(exited_agent_pane_probes "$dir" 'done' 4242); : > "$log"
   out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_PS_BIN="$dir/ps" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w1:p2' "$ROOT")
   [ "$out" = no-agent ] || fail "an exited agent (stale agent_status=done, bare-shell pane) must classify no-agent, got '$out'"
@@ -869,7 +870,7 @@ test_agent_state_exited_agent_is_dead_relaunchable() {
   # `alive` that stalls exit forever or the `unreadable` that refuses recovery.
   local dir log resp fb out
   dir="$TMP_ROOT/exited-recovery"; log="$dir/log"; resp="$dir/responses"
-  fb=$(exited_agent_pane_probes "$dir" done 4242); : > "$log"
+  fb=$(exited_agent_pane_probes "$dir" 'done' 4242); : > "$log"
   out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_PS_BIN="$dir/ps" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state fmtest:w1:p2' "$ROOT")
   [ "$out" = dead ] || fail "the recovery-grade state of an exited-agent pane must be dead (relaunchable), got '$out'"

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -792,6 +792,108 @@ test_create_task_refuses_when_agent_state_ambiguous() {
   pass "fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently"
 }
 
+# --- exited-agent corroboration (stale agent record vs bare-shell foreground) -
+#
+# A cleanly exited agent leaves herdr's agent record behind: `agent get` still
+# succeeds and reports a non-working status (this repo's issue #3639 saw an
+# exited pi report agent_status=done; the exited claude pane that motivated
+# this fix reported agent_status=unknown), yet the pane holds only a bare
+# shell. Before this fix the classifier trusted agent_status alone, so a
+# provably agent-free pane read as `live` (done/blocked/idle) or `unknown`,
+# and fm-control exit/relaunch refused to recover it. The classifier now
+# corroborates any non-working status against the pane's own foreground
+# process - two independent signals - and only the process proof carries the
+# agent-free verdict, mirroring the tmux classifier. These fixtures drive the
+# two signals apart: a stale record plus a bare-shell foreground must classify
+# no-agent, while a real idle agent (whose foreground is still the harness
+# process) must survive as live.
+
+# exited_agent_pane_probes <dir> <status> <shell-pid>: seed pane get -> present,
+# agent get -> the stale <status>, and a bare idle-shell process-info sample,
+# plus the fake ps the idle-shell proof reads. Echoes the fakebin dir.
+exited_agent_pane_probes() {  # <dir> <status> <shell-pid>
+  local dir=$1 status=$2 pid=$3 resp="$dir/responses"
+  mkdir -p "$resp"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent_status":"%s"}}}\n' "$status" > "$resp/2.out"
+  death_process_info_fixture w1:p2 "$pid" > "$resp/3.out"
+  make_death_lab "$dir" "$pid"
+  make_herdr_fakebin "$dir"
+}
+
+test_pane_agent_state_exited_agent_stale_done_status_is_no_agent() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/exited-done"; log="$dir/log"; resp="$dir/responses"
+  fb=$(exited_agent_pane_probes "$dir" done 4242); : > "$log"
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_PS_BIN="$dir/ps" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w1:p2' "$ROOT")
+  [ "$out" = no-agent ] || fail "an exited agent (stale agent_status=done, bare-shell pane) must classify no-agent, got '$out'"
+  # Assert the process-proof signal is load-bearing, not vacuous: the classifier
+  # must actually consult the foreground process to override the stale record.
+  assert_contains "$(cat "$log")" $'pane\x1fprocess-info' "the classifier did not corroborate the stale record against the pane's foreground process"
+  pass "fm_backend_herdr_pane_agent_state: a stale agent_status=done over a bare idle shell (issue #3639) classifies no-agent"
+}
+
+test_pane_agent_state_exited_agent_stale_unknown_status_is_no_agent() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/exited-unknown"; log="$dir/log"; resp="$dir/responses"
+  fb=$(exited_agent_pane_probes "$dir" unknown 4242); : > "$log"
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_PS_BIN="$dir/ps" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w1:p2' "$ROOT")
+  [ "$out" = no-agent ] || fail "an exited agent (stale agent_status=unknown, bare-shell pane) must classify no-agent, not unknown, got '$out'"
+  assert_contains "$(cat "$log")" $'pane\x1fprocess-info' "the classifier did not corroborate the stale unknown status against the pane's foreground process"
+  pass "fm_backend_herdr_pane_agent_state: a stale agent_status=unknown over a bare idle shell classifies no-agent, not unknown"
+}
+
+test_agent_state_exited_agent_is_dead_relaunchable() {
+  # The recovery-grade view fm-control and the session-start sweep read: an
+  # exited-agent pane must reach `dead` (agent-free, relaunchable), never the
+  # `alive` that stalls exit forever or the `unreadable` that refuses recovery.
+  local dir log resp fb out
+  dir="$TMP_ROOT/exited-recovery"; log="$dir/log"; resp="$dir/responses"
+  fb=$(exited_agent_pane_probes "$dir" done 4242); : > "$log"
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_PS_BIN="$dir/ps" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state fmtest:w1:p2' "$ROOT")
+  [ "$out" = dead ] || fail "the recovery-grade state of an exited-agent pane must be dead (relaunchable), got '$out'"
+  pass "fm_backend_herdr_agent_state: an exited-agent pane is dead (relaunchable), not alive or unreadable"
+}
+
+test_pane_agent_state_live_idle_agent_stays_live() {
+  # The other side of the divergence: a genuinely idle registered agent still
+  # runs its harness process in the foreground, so the bare-shell proof fails
+  # and the verdict must stay live - the corroboration must never demote a real
+  # idle agent to agent-free.
+  local dir log resp fb out
+  dir="$TMP_ROOT/live-idle"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
+  # A live idle agent: its foreground process group is the harness (node), a
+  # distinct pid from the pane shell, so the idle-shell proof rejects it.
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":4242,"foreground_process_group_id":5000,"foreground_processes":[{"pid":5000,"name":"node","argv0":"node"}]}}}\n' > "$resp/3.out"
+  make_death_lab "$dir" 4242
+  fb=$(make_herdr_fakebin "$dir"); : > "$log"
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_PS_BIN="$dir/ps" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w1:p2' "$ROOT")
+  [ "$out" = live ] || fail "a genuinely idle registered agent (harness still in the foreground) must stay live, got '$out'"
+  assert_contains "$(cat "$log")" $'pane\x1fprocess-info' "the classifier skipped corroborating the idle agent, so the guard is vacuous"
+  pass "fm_backend_herdr_pane_agent_state: a live idle agent whose harness still runs stays live"
+}
+
+test_pane_agent_state_working_agent_trusted_without_process_probe() {
+  # A generating agent is trusted outright: never probed, both to keep the hot
+  # path cheap and to avoid racing a busy pane's process table.
+  local dir log resp fb out
+  dir="$TMP_ROOT/working-agent"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir"); : > "$log"
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w1:p2' "$ROOT")
+  [ "$out" = live ] || fail "a working agent must classify live, got '$out'"
+  assert_not_contains "$(cat "$log")" $'pane\x1fprocess-info' "a working agent must be trusted without a foreground-process probe"
+  pass "fm_backend_herdr_pane_agent_state: a working agent is trusted live without a foreground-process probe"
+}
+
 test_create_task_husk_replacement_creates_before_closing() {
   # Safety-critical ordering: the replacement tab must be created BEFORE the
   # husk tab is closed, never the reverse - closing a workspace's LAST
@@ -4516,6 +4618,11 @@ test_create_task_closes_and_replaces_no_agent_husk
 test_create_task_closes_all_duplicate_husks_after_replacement
 test_create_task_refuses_when_preexisting_husk_tab_remains
 test_create_task_refuses_when_agent_state_ambiguous
+test_pane_agent_state_exited_agent_stale_done_status_is_no_agent
+test_pane_agent_state_exited_agent_stale_unknown_status_is_no_agent
+test_agent_state_exited_agent_is_dead_relaunchable
+test_pane_agent_state_live_idle_agent_stays_live
+test_pane_agent_state_working_agent_trusted_without_process_probe
 test_create_task_husk_replacement_creates_before_closing
 test_create_task_creates_and_parses_ids
 test_create_task_creates_with_no_focus_flag

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -845,6 +845,24 @@ test_pane_agent_state_exited_agent_stale_unknown_status_is_no_agent() {
   pass "fm_backend_herdr_pane_agent_state: a stale agent_status=unknown over a bare idle shell classifies no-agent, not unknown"
 }
 
+test_pane_agent_state_malformed_status_stays_unknown() {
+  local shape dir log resp fb out
+  for shape in missing unrecognized; do
+    dir="$TMP_ROOT/malformed-status-$shape"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"
+    printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+    case "$shape" in
+      missing) printf '{"result":{"agent":{}}}\n' > "$resp/2.out" ;;
+      unrecognized) printf '{"result":{"agent":{"agent_status":"paused"}}}\n' > "$resp/2.out" ;;
+    esac
+    fb=$(make_herdr_fakebin "$dir"); : > "$log"
+    out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w1:p2' "$ROOT")
+    [ "$out" = unknown ] || fail "a $shape agent status must remain unknown, got '$out'"
+    assert_not_contains "$(cat "$log")" $'pane\x1fprocess-info' "a $shape agent status must not reach bare-shell corroboration"
+  done
+  pass "fm_backend_herdr_pane_agent_state: missing and unrecognized statuses fail safe without a process probe"
+}
+
 test_agent_state_exited_agent_is_dead_relaunchable() {
   # The recovery-grade view fm-control and the session-start sweep read: an
   # exited-agent pane must reach `dead` (agent-free, relaunchable), never the
@@ -4620,6 +4638,7 @@ test_create_task_refuses_when_preexisting_husk_tab_remains
 test_create_task_refuses_when_agent_state_ambiguous
 test_pane_agent_state_exited_agent_stale_done_status_is_no_agent
 test_pane_agent_state_exited_agent_stale_unknown_status_is_no_agent
+test_pane_agent_state_malformed_status_stays_unknown
 test_agent_state_exited_agent_is_dead_relaunchable
 test_pane_agent_state_live_idle_agent_stays_live
 test_pane_agent_state_working_agent_trusted_without_process_probe

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -118,8 +118,19 @@ herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-
   --state unknown --session "$SESSION" >/dev/null 2>&1 \
   || fail "could not register the stale agent record on the task pane"
 
-STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
+STATE=
+for _ in $(seq 1 50); do
+  STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
+  [ "$STATE" = dead ] && break
+  [ "$STATE" = unreadable ] \
+    || fail "herdr returned an unexpected stale registration state '$STATE'"
+  sleep 0.1
+done
 [ "$STATE" = dead ] || fail "herdr should classify a stale unknown record over a bare shell as dead, got '$STATE'"
+REGISTERED_STATE=$(herdr agent get "$PANE_ID" --session "$SESSION" 2>/dev/null \
+  | jq -r '.result.agent.agent_status // empty')
+[ "$REGISTERED_STATE" = unknown ] \
+  || fail "the dead verdict must retain agent_status=unknown, got '${REGISTERED_STATE:-<missing>}'"
 pass "real herdr: a stale unknown registration over a bare shell is dead and relaunchable"
 
 # --- a registered foreground agent: classification flips, and verbs follow --

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -9,9 +9,8 @@
 # an agent is running, and therefore whether a lifecycle verb may act at all,
 # comes from herdr's own agent registry.
 #
-# No real agent is launched. herdr's `pane report-agent` is the same registry
-# the adapter reads, so registering and not registering an agent on a plain
-# shell pane exercises exactly the classification the control plane gates on.
+# A deterministic foreground process stands in for the harness while herdr's
+# `pane report-agent` drives the same registry the adapter reads.
 #
 # Always runs on a private, named, throwaway lab session, never the default
 # one (tests/herdr-test-safety.sh; the 2026-07-02 incident). Skips cleanly
@@ -113,7 +112,34 @@ case "$OUT" in
 esac
 pass "real herdr: interrupt refuses when herdr's own agent registry reports no agent"
 
-# --- a registered agent: classification flips, and the verbs follow ---------
+# --- a stale registration over a bare shell is relaunchable ------------------
+
+herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-smoke-agent \
+  --state unknown --session "$SESSION" >/dev/null 2>&1 \
+  || fail "could not register the stale agent record on the task pane"
+
+STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
+[ "$STATE" = dead ] || fail "herdr should classify a stale unknown record over a bare shell as dead, got '$STATE'"
+pass "real herdr: a stale unknown registration over a bare shell is dead and relaunchable"
+
+# --- a registered foreground agent: classification flips, and verbs follow --
+
+fm_backend_herdr_send_text_line "$SESSION:$PANE_ID" "sleep 300" \
+  || fail "could not start the foreground agent process"
+for _ in $(seq 1 20); do
+  PROCESS_INFO=$(herdr pane process-info --pane "$PANE_ID" --session "$SESSION" 2>/dev/null) || PROCESS_INFO=
+  if printf '%s' "$PROCESS_INFO" | jq -e '
+    .result.process_info as $p
+    | $p.foreground_process_group_id != $p.shell_pid
+  ' >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+printf '%s' "$PROCESS_INFO" | jq -e '
+  .result.process_info as $p
+  | $p.foreground_process_group_id != $p.shell_pid
+' >/dev/null 2>&1 || fail "the foreground agent process did not become observable"
 
 herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-smoke-agent \
   --state idle --session "$SESSION" >/dev/null 2>&1 \


### PR DESCRIPTION
## Intent

Verbatim captain 2026-09-04: "fix the firstmate bugs" - this is bug 1 of 3: the Herdr worker-state reader treats a cleanly exited agent as unreadable, so the control plane refuses to relaunch a provably agent-free pane.

## What Changed

- Classify Herdr panes with stale non-working agent records as agent-free when a foreground-process check proves only an idle bare shell remains, allowing the control plane to relaunch them.
- Preserve fail-safe behavior for working, genuinely idle, malformed, and otherwise ambiguous agent states.
- Add fixture and real-Herdr smoke coverage for stale-record recovery, live-agent protection, and the documented lifecycle contract.

## Risk Assessment

✅ Low: The change is narrowly scoped and safely requires both a recognized non-working Herdr status and strict bare-shell process evidence before declaring the pane agent-free; malformed, conflicting, and genuinely live states remain conservative.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (24m26s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"bee9c712de3976ab51c6197e7786c69ea450c365","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
