### PR TITLE
fix(bin): recreate missing endpoints during task relaunch

### DIFF
--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -34,7 +34,13 @@
 #   relaunch   Transactionally replace the running agent with a new one, in the
 #              SAME endpoint and SAME worktree, on the same or a newly chosen
 #              harness/model/effort - so switching harness is one ordinary use
-#              of this verb. An explicit `default` model or effort clears that
+#              of this verb. When the recorded endpoint has vanished ENTIRELY
+#              (positively `missing`: its terminal is gone, not merely
+#              unreadable), the stop step is skipped and the launch owner
+#              recreates a fresh endpoint in the recorded worktree instead of
+#              dead-ending, so a lost pane no longer strands an intact task. An
+#              ambiguous or unreadable endpoint is not `missing` and still
+#              refuses. An explicit `default` model or effort clears that
 #              axis for the replacement. With no explicit axis, a secondmate
 #              re-resolves its durable config/secondmate-harness pin (harness
 #              plus its optional model and effort tokens) exactly as any other
@@ -511,6 +517,7 @@ BRIEF_PRIOR="$JOURNAL.brief-prior"
 NOTE_FILE="$JOURNAL.note"
 RELAUNCH_META_PUBLISHED=0
 RELAUNCH_AGENT_CONFIRMED=0
+RELAUNCH_ENDPOINT_MISSING=0
 RELAUNCH_TX=
 RELAUNCH_BRIEF=
 PRIOR_HARNESS=$HARNESS
@@ -822,7 +829,17 @@ do_relaunch() {
   journal_write noted "${CHECKPOINT_LINES[@]}" "$note_line"
 
   journal_write stopping "${CHECKPOINT_LINES[@]}" "$note_line"
-  exit_result=$(do_exit)
+  if [ "$(agent_state)" = missing ]; then
+    # The recorded endpoint vanished entirely: no agent and no terminal remain
+    # to stop, so skip the stop step and let the launch owner recreate a fresh
+    # endpoint in the recorded worktree. Only a positively `missing` endpoint
+    # takes this path; an ambiguous or unreadable one is NOT `missing` and still
+    # goes through do_exit, which refuses to act on an unattributed endpoint.
+    RELAUNCH_ENDPOINT_MISSING=1
+    exit_result="endpoint-missing"
+  else
+    exit_result=$(do_exit)
+  fi
   journal_write exited "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"
 
   # The launch owner (fm-spawn --relaunch) clears the previous incarnation's
@@ -839,6 +856,17 @@ do_relaunch() {
     [ "$(fm_meta_get "$META" control_relaunch_tx)" != "$RELAUNCH_TX" ] \
       || RELAUNCH_META_PUBLISHED=1
     die "the replacement agent for $ID could not be launched on $TARGET_HARNESS"
+  fi
+
+  if [ "$RELAUNCH_ENDPOINT_MISSING" = 1 ]; then
+    # The launch owner recreated the vanished endpoint and republished the
+    # record, so the endpoint this plane verifies against has changed (a herdr
+    # pane id is unique per pane, and a recreated tmux window can land in a
+    # different session). Refresh it from the republished record before proving
+    # the replacement came up.
+    fm_backend_validate_task_endpoint "$META" "$ID" \
+      || die "$ID was relaunched onto a recreated endpoint whose record is unreadable"
+    T=$FM_BACKEND_VALIDATED_TARGET
   fi
 
   state=$(wait_agent_state "$LAUNCH_WAIT" alive) || {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -24,21 +24,24 @@
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
-#   --relaunch launches a replacement agent for an EXISTING task into that
-#   task's own recorded endpoint and worktree instead of creating either. It is
+#   --relaunch launches a replacement agent for an EXISTING task in that
+#   task's own recorded worktree. It reuses a positively agent-free endpoint;
+#   for a ship or scout whose endpoint is positively missing, it recreates an
+#   endpoint on tmux or herdr and republishes that identity. It is
 #   the launch half of the control plane (bin/fm-control.sh relaunch), which
 #   owns the checkpoint, the progress note, stopping the previous agent, and the
 #   transaction; call fm-control rather than this flag directly unless you are
 #   deliberately re-launching an already-stopped task. Every identity axis -
-#   backend, kind, project or home, worktree, endpoint - comes from the task's
-#   validated state/<id>.meta, so --backend, --scout, --secondmate, a project
+#   backend, kind, project or home, and worktree - comes from the task's
+#   validated state/<id>.meta, while only a recreated endpoint receives a new
+#   identity, so --backend, --scout, --secondmate, a project
 #   positional, and batch pairs are all refused alongside it; only harness,
 #   model, and effort may change, which is what makes a harness switch one
 #   ordinary relaunch. It refuses unless the recorded endpoint is positively
-#   agent-free on a backend with a recovery-grade agent-state classifier (tmux
-#   or herdr), refuses unless the endpoint's shell is sitting in the recorded
-#   worktree, and clears the previous harness's per-task wiring before arming
-#   the new incarnation.
+#   agent-free or missing on a backend with a recovery-grade agent-state
+#   classifier (tmux or herdr), refuses missing secondmate endpoints, verifies
+#   the reused or recreated endpoint is in the recorded worktree, and clears
+#   the previous harness's per-task wiring before arming the new incarnation.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -346,6 +346,7 @@ MODE_SET=0
 YOLO_SET=0
 TRACEPARENT_SET=0
 RELAUNCH=0
+RELAUNCH_RECREATE=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -1159,13 +1160,32 @@ if [ "$RELAUNCH" -eq 1 ]; then
     exit 1
   }
   RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
-  [ "$RELAUNCH_STATE" = dead ] || {
-    echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
-    exit 1
-  }
+  case "$RELAUNCH_STATE" in
+    dead) ;;
+    missing)
+      # The recorded endpoint is authoritatively gone (its terminal vanished),
+      # not merely unreadable, so recreate a fresh one in the recorded worktree
+      # rather than dead-ending. fm_backend_agent_state reports `missing` only
+      # from a recovery-grade classifier and only for a positively absent
+      # endpoint; `ambiguous` and `unreadable` are distinct states that refuse
+      # below, so recreation never lands on a live or unattributed endpoint.
+      RELAUNCH_RECREATE=1
+      ;;
+    *)
+      echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
+      exit 1
+      ;;
+  esac
   RELAUNCH_PRIOR_HARNESS=$(fm_meta_get "$RELAUNCH_META" harness)
   KIND=$(fm_meta_get "$RELAUNCH_META" kind)
   [ -n "$KIND" ] || KIND=ship
+  if [ "$RELAUNCH_RECREATE" = 1 ] && [ "$KIND" = secondmate ]; then
+    # A secondmate is a whole home with its own workspace; recreating its
+    # endpoint needs the secondmate recovery path, not this crewmate/scout
+    # recreation. Refuse rather than land the endpoint in the wrong workspace.
+    echo "error: task $ID is a secondmate whose endpoint has vanished; recover it through the secondmate recovery path, not by recreating its endpoint here" >&2
+    exit 1
+  fi
   MODE=$(fm_meta_get "$RELAUNCH_META" mode)
   YOLO=$(fm_meta_get "$RELAUNCH_META" yolo)
   RELAUNCH_WT=$(fm_meta_get "$RELAUNCH_META" worktree)
@@ -2181,7 +2201,7 @@ if [ -e "$STATE/$ID.backlog-close" ] || [ -L "$STATE/$ID.backlog-close" ]; then
 fi
 
 W="fm-$ID"
-if [ "$RELAUNCH" -eq 1 ]; then
+if [ "$RELAUNCH" -eq 1 ] && [ "$RELAUNCH_RECREATE" -ne 1 ]; then
   # Adopt the recorded endpoint instead of creating one. This is what keeps a
   # relaunch a REPLACEMENT rather than a second copy of the task: no new
   # terminal, no second worktree, and every uncommitted change left exactly
@@ -2192,6 +2212,45 @@ if [ "$RELAUNCH" -eq 1 ]; then
   [ "$KIND" = secondmate ] || WT=$RELAUNCH_WT
   WT_TARGET=$T
   SES=${T%%:*}
+elif [ "$RELAUNCH_RECREATE" -eq 1 ]; then
+  # The recorded endpoint vanished entirely. Recreate a fresh one in the SAME
+  # recorded worktree (secondmate is refused above, so this is a ship/scout),
+  # then let the record republish below repoint window= at it. Flat layout only:
+  # a disposable presentation workspace, if any, died with the pane. This reuses
+  # the exact container-ensure + create-task calls a fresh crewmate uses,
+  # differing only in the pane cwd - the existing worktree, so no `treehouse
+  # get` is needed and the relaunch worktree check below confirms the recreated
+  # pane is already in it.
+  WT=$RELAUNCH_WT
+  case "$BACKEND" in
+    tmux)
+      SES=$(fm_backend_tmux_container_ensure)
+      T="$SES:$W"
+      WID=$(fm_backend_tmux_create_task "$SES" "$W" "$WT") || exit 1
+      WT_TARGET="$WID"
+      ;;
+    herdr)
+      HERDR_CONTAINER_RAW=$(fm_backend_herdr_container_ensure "$WT" launcher-home) || exit 1
+      CONTAINER=${HERDR_CONTAINER_RAW%%$'\t'*}
+      HERDR_SEEDED_DEFAULT_TAB_ID=${HERDR_CONTAINER_RAW#*$'\t'}
+      HERDR_SES=${CONTAINER%%:*}
+      HERDR_WORKSPACE_ID=${CONTAINER#*:}
+      HERDR_TASK_IDS=$(fm_backend_herdr_create_task "$CONTAINER" "$W" "$WT" "$HERDR_SEEDED_DEFAULT_TAB_ID") || exit 1
+      read -r HERDR_TAB_ID HERDR_PANE_ID <<EOF
+$HERDR_TASK_IDS
+EOF
+      if [ -z "$HERDR_TAB_ID" ] || [ -z "$HERDR_PANE_ID" ]; then
+        echo "error: herdr did not return a tab/pane id for $W" >&2
+        exit 1
+      fi
+      T="$HERDR_SES:$HERDR_PANE_ID"
+      WT_TARGET=$T
+      ;;
+    *)
+      echo "error: endpoint recreation is not supported on backend '$BACKEND'; recover task $ID another way" >&2
+      exit 1
+      ;;
+  esac
 else
 case "$BACKEND" in
   tmux)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -793,6 +793,11 @@ parse_orca_worktree_result() {
   fi
 }
 
+spawn_relaunch_recreate_cleanup_disarm() {
+  TMUX_RECREATE_ABORT_CLEANUP=0
+  HERDR_PROJECTION_ABORT_CLEANUP=0
+}
+
 spawn_abort_cleanup() {
   local status=$?
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
@@ -801,6 +806,7 @@ spawn_abort_cleanup() {
      && [ ! -e "$SPAWN_META_TMP" ] \
      && [ ! -L "$SPAWN_META_TMP" ]; then
     RELAUNCH_REPLACEMENT_PENDING=0
+    spawn_relaunch_recreate_cleanup_disarm
   fi
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ]; then
     RELAUNCH_REPLACEMENT_PENDING=0
@@ -3226,8 +3232,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   RELAUNCH_REPLACEMENT_PENDING=0
   if [ "$RELAUNCH_RECREATE" -eq 1 ]; then
-    TMUX_RECREATE_ABORT_CLEANUP=0
-    HERDR_PROJECTION_ABORT_CLEANUP=0
+    spawn_relaunch_recreate_cleanup_disarm
   fi
   SPAWN_META_PUBLISH_STARTED=0
   SPAWN_META_TMP=

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -742,6 +742,8 @@ HERDR_PROJECTION_ABORT_CLEANUP=0
 HERDR_PROJECTION_ABORT_SESSION=
 HERDR_PROJECTION_ABORT_TASK_PANE=
 HERDR_PROJECTION_ABORT_SEEDED_PANE=
+TMUX_RECREATE_ABORT_CLEANUP=0
+TMUX_RECREATE_ABORT_TARGET=
 HERDR_PRESENTATION_ORDER_LOCK=
 HERDR_PRESENTATION_ORDER_LOCK_HELD=0
 SPAWN_TASK_LOCK=
@@ -830,6 +832,10 @@ spawn_abort_cleanup() {
       "$HERDR_PROJECTION_ABORT_SESSION" \
       "$HERDR_PROJECTION_ABORT_TASK_PANE" \
       "$HERDR_PROJECTION_ABORT_SEEDED_PANE" || true
+  fi
+  if [ "$TMUX_RECREATE_ABORT_CLEANUP" = 1 ]; then
+    TMUX_RECREATE_ABORT_CLEANUP=0
+    fm_backend_tmux_kill "$TMUX_RECREATE_ABORT_TARGET" || true
   fi
   if [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" = 1 ]; then
     HERDR_PRESENTATION_ORDER_LOCK_HELD=0
@@ -2213,36 +2219,75 @@ if [ "$RELAUNCH" -eq 1 ] && [ "$RELAUNCH_RECREATE" -ne 1 ]; then
   WT_TARGET=$T
   SES=${T%%:*}
 elif [ "$RELAUNCH_RECREATE" -eq 1 ]; then
-  # The recorded endpoint vanished entirely. Recreate a fresh one in the SAME
-  # recorded worktree (secondmate is refused above, so this is a ship/scout),
-  # then let the record republish below repoint window= at it. Flat layout only:
-  # a disposable presentation workspace, if any, died with the pane. This reuses
-  # the exact container-ensure + create-task calls a fresh crewmate uses,
-  # differing only in the pane cwd - the existing worktree, so no `treehouse
-  # get` is needed and the relaunch worktree check below confirms the recreated
-  # pane is already in it.
   WT=$RELAUNCH_WT
   case "$BACKEND" in
     tmux)
       SES=$(fm_backend_tmux_container_ensure)
       T="$SES:$W"
       WID=$(fm_backend_tmux_create_task "$SES" "$W" "$WT") || exit 1
+      TMUX_RECREATE_ABORT_CLEANUP=1
+      TMUX_RECREATE_ABORT_TARGET=$T
       WT_TARGET="$WID"
       ;;
     herdr)
-      HERDR_CONTAINER_RAW=$(fm_backend_herdr_container_ensure "$WT" launcher-home) || exit 1
-      CONTAINER=${HERDR_CONTAINER_RAW%%$'\t'*}
-      HERDR_SEEDED_DEFAULT_TAB_ID=${HERDR_CONTAINER_RAW#*$'\t'}
-      HERDR_SES=${CONTAINER%%:*}
-      HERDR_WORKSPACE_ID=${CONTAINER#*:}
-      HERDR_TASK_IDS=$(fm_backend_herdr_create_task "$CONTAINER" "$W" "$WT" "$HERDR_SEEDED_DEFAULT_TAB_ID") || exit 1
-      read -r HERDR_TAB_ID HERDR_PANE_ID <<EOF
+      HERDR_LABEL_HOME=$FM_HOME
+      HERDR_PRESENTATION_JOURNAL=$(fm_backend_herdr_projection_journal_path "$STATE" "$ID")
+      HERDR_PROJECTED=0
+      if [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; then
+        HERDR_PARENT_LABEL=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_workspace_label)
+        fm_backend_herdr_server_ensure "$HERDR_SES" || {
+          echo "error: herdr presentation recovery could not ensure its exact named session" >&2
+          exit 1
+        }
+        spawn_herdr_presentation_order_lock_acquire "$HERDR_SES" || {
+          echo "error: herdr presentation recovery could not acquire its session lock; refusing a concurrent resume" >&2
+          exit 1
+        }
+        herdr_projection_existing_meta_allows_flat "$RELAUNCH_META" || exit 1
+        fm_backend_herdr_projection_recovery_allows_flat \
+          "$HERDR_SES" "$HERDR_PRESENTATION_JOURNAL" "$ID" || exit 1
+        set +e
+        FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_projection_reclaim_task \
+          "$HERDR_SES" "$HERDR_PRESENTATION_JOURNAL" "$ID" "$HERDR_LABEL_HOME" \
+          "$HERDR_RECOVERY_WORKSPACE_ID" "$HERDR_RECOVERY_TAB_ID" "$HERDR_RECOVERY_PANE_ID" \
+          "$HERDR_PARENT_LABEL" "$W" "$WT"
+        HERDR_RECLAIM_STATUS=$?
+        set -e
+        case "$HERDR_RECLAIM_STATUS" in
+          0)
+            HERDR_PROJECTED=1
+            HERDR_WORKSPACE_ID=$HERDR_RECOVERY_WORKSPACE_ID
+            HERDR_SEEDED_DEFAULT_TAB_ID=""
+            HERDR_TAB_ID=$FM_BACKEND_HERDR_PROJECTION_TAB_ID
+            HERDR_PANE_ID=$FM_BACKEND_HERDR_PROJECTION_PANE_ID
+            HERDR_PROJECTION_ABORT_CLEANUP=1
+            HERDR_PROJECTION_ABORT_SESSION=$HERDR_SES
+            HERDR_PROJECTION_ABORT_TASK_PANE=$HERDR_PANE_ID
+            HERDR_PROJECTION_ABORT_SEEDED_PANE=""
+            ;;
+          2) spawn_herdr_presentation_order_lock_release ;;
+          *) exit 1 ;;
+        esac
+      fi
+      if [ "$HERDR_PROJECTED" -ne 1 ]; then
+        HERDR_CONTAINER_RAW=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_container_ensure "$WT" launcher-home) || exit 1
+        CONTAINER=${HERDR_CONTAINER_RAW%%$'\t'*}
+        HERDR_SEEDED_DEFAULT_TAB_ID=${HERDR_CONTAINER_RAW#*$'\t'}
+        HERDR_SES=${CONTAINER%%:*}
+        HERDR_WORKSPACE_ID=${CONTAINER#*:}
+        HERDR_TASK_IDS=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_create_task "$CONTAINER" "$W" "$WT" "$HERDR_SEEDED_DEFAULT_TAB_ID") || exit 1
+        read -r HERDR_TAB_ID HERDR_PANE_ID <<EOF
 $HERDR_TASK_IDS
 EOF
+      fi
       if [ -z "$HERDR_TAB_ID" ] || [ -z "$HERDR_PANE_ID" ]; then
         echo "error: herdr did not return a tab/pane id for $W" >&2
         exit 1
       fi
+      HERDR_PROJECTION_ABORT_CLEANUP=1
+      HERDR_PROJECTION_ABORT_SESSION=$HERDR_SES
+      HERDR_PROJECTION_ABORT_TASK_PANE=$HERDR_PANE_ID
+      [ "$HERDR_PROJECTED" -eq 1 ] || HERDR_PROJECTION_ABORT_SEEDED_PANE=""
       T="$HERDR_SES:$HERDR_PANE_ID"
       WT_TARGET=$T
       ;;
@@ -3180,6 +3225,10 @@ if [ "$RELAUNCH" -eq 1 ]; then
     exit 1
   fi
   RELAUNCH_REPLACEMENT_PENDING=0
+  if [ "$RELAUNCH_RECREATE" -eq 1 ]; then
+    TMUX_RECREATE_ABORT_CLEANUP=0
+    HERDR_PROJECTION_ABORT_CLEANUP=0
+  fi
   SPAWN_META_PUBLISH_STARTED=0
   SPAWN_META_TMP=
 fi

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -32,7 +32,7 @@ A recorded `harness=` is not always an exact adapter name: a task launched from 
 | --- | --- | --- |
 | `interrupt` | Deliver the harness's verified interrupt sequence while leaving the agent running. | Delivery succeeds while the endpoint still exists and the agent is still alive where the backend can classify that; cancellation is confirmed only from an adapter-owned acknowledgement and otherwise reports `cancel=unconfirmed`. |
 | `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone. Already-stopped is idempotent success. |
-| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, and effort. | The new agent is alive on the recorded endpoint, and the durable record names the harness that is actually running. |
+| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, and effort; when the recorded endpoint has vanished entirely, recreate a fresh one in the recorded worktree instead of dead-ending. | The new agent is alive on the recorded or recreated endpoint, and the durable record names the harness that is actually running. |
 
 An exit that delivers lifecycle input but cannot prove the agent stopped fails with `exit=unconfirmed`, reports the observed agent state and any interrupt cancellation claim, and never claims that nothing changed.
 Interrupt never rewrites busy state as proof of its own success.
@@ -69,9 +69,11 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
    A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation; the note is appended to the instructions it reads.
    A secondmate relaunch does not require one and never rewrites its standing charter.
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
+   When the recorded endpoint is positively `missing` - its terminal is gone, not merely unreadable - there is no agent and no terminal to stop, so this step is skipped and the launch owner recreates the endpoint below.
 5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+   For a positively `missing` endpoint it instead recreates a fresh endpoint in that same recorded worktree - a flat-layout terminal opened directly in the worktree, so no `treehouse get` runs and no second worktree is allocated - and republishes the record so it points at the new endpoint.
 
-Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
+Switching harness is therefore one ordinary relaunch rather than a separate mechanism, and a vanished terminal no longer strands an otherwise intact task.
 
 ### Failure and rollback
 
@@ -98,8 +100,10 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
 - `exit` and `relaunch` require a backend with a recovery-grade agent-state classifier - tmux and herdr - because without one the "the agent stopped" postcondition cannot be proven.
   zellij, orca, and cmux are refused rather than reported as successful blind.
 - An ambiguous or unreadable endpoint state refuses.
-  Only a positively classified state acts.
-- `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
+  Only a positively classified state acts: a positively agent-free endpoint is reused, and a positively `missing` one is recreated, while `ambiguous` and `unreadable` refuse rather than guess.
+- Endpoint recreation on a `missing` endpoint is a ship or scout recovery only.
+  A secondmate is a whole home with its own workspace, so a vanished secondmate endpoint is routed to the secondmate recovery path rather than recreated here.
+- `fm-spawn --relaunch` independently reclassifies the endpoint: it recreates only a positively `missing` one and otherwise refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree, so a replacement can never join a live agent, act on an unattributed endpoint, or start outside the copy holding the work.
 
 ## Capability matrix
 

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -72,14 +72,16 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
    When the recorded endpoint is positively `missing` - its terminal is gone, not merely unreadable - there is no agent and no terminal to stop, so this step is skipped and the launch owner recreates the endpoint below.
 5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
    For a positively `missing` endpoint it instead recreates a fresh endpoint in that same recorded worktree - a flat-layout terminal opened directly in the worktree, so no `treehouse get` runs and no second worktree is allocated - and republishes the record so it points at the new endpoint.
+   A Herdr recreation with an existing presentation journal first reconciles that journal under the named-session presentation lock and refuses if any token-matched pane is live or unreadable; [`herdr-backend.md`](herdr-backend.md#presentation-spaces) owns the projection recovery and safe flat-fallback contract.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism, and a vanished terminal no longer strands an otherwise intact task.
 
 ### Failure and rollback
 
 - A refusal **before** the agent is stopped leaves the durable record and the instructions byte-identical.
-- A launch failure **after** the agent is stopped restores the prior durable record, keeps the progress note so a later recovery still has it, marks the journal `failed:launching`, and reports plainly that no agent is running and where the work is preserved.
+- A launch failure **after** the agent is stopped but before metadata publication restores the prior durable record, removes an endpoint created by this attempt, keeps the progress note so a later recovery still has it, marks the journal `failed:launching`, and reports plainly that no agent is running and where the work is preserved.
 - If the launch owner already published the new record but no running agent can be confirmed, the new record is kept: the task is recorded on the new harness with no agent confirmed, which is exactly what recovery reconciles.
+  A recreated endpoint is kept with that published record rather than removed from underneath its new durable identity.
   Rewriting it back to the old harness would be a second, worse inaccuracy.
 
 ## Fail-closed boundaries
@@ -123,5 +125,5 @@ The empirical basis for each adapter's value is the `harness-adapters` skill's v
 ## Verification
 
 - `tests/fm-control.test.sh` - the adapter contract for every verified harness, the backend capability matrix, exact-id scoping, the closed verb list, the busy, idle, dead, and idempotent lifecycle cases, and marker non-regression, all against a stubbed session provider.
-- `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, the progress note, checkpoint refusals, and rollback after a failed launch.
+- `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, endpoint recreation, publication-boundary cleanup, the progress note, checkpoint refusals, and rollback after a failed launch.
 - `tests/fm-control-herdr-smoke.test.sh` - the second state-verified backend against the real herdr binary, on an isolated throwaway lab session.

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -125,6 +125,21 @@ case "${1:-}" in
     printf 'zsh' > "$D/command"
     printf '@%s\n' "$wname"
     exit 0 ;;
+  kill-window)
+    shift
+    target=
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -t) target=${2:-}; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    target=${target#=}
+    wname=${target#*:=}
+    grep -Fvx "$wname" "$D/windows" > "$D/windows.next" || true
+    mv "$D/windows.next" "$D/windows"
+    printf '%s\n' "$target" >> "$D/killed"
+    exit 0 ;;
   list-windows)
     if [ -n "${FM_FAKE_LIST_WINDOWS_ERROR:-}" ]; then
       printf '%s\n' "$FM_FAKE_LIST_WINDOWS_ERROR" >&2
@@ -217,6 +232,7 @@ run_spawn() {  # <case-dir> <args...>
   env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_FAKE_DIR="$dir/fake" \
     HOME="$dir/user-home" CLAUDE_CONFIG_DIR='' \
     FM_SPAWN_NO_GUARD=1 GROK_HOME="$dir/grokhome" \
+    FM_REAL_MV="${FM_REAL_MV:-}" FM_FAKE_META_PUBLISH_MV_FAIL="${FM_FAKE_META_PUBLISH_MV_FAIL:-}" \
     "$SPAWN" "$@" 2>&1
 }
 
@@ -1590,6 +1606,26 @@ test_spawn_relaunch_recreates_a_vanished_endpoint() {
   pass "fm-spawn --relaunch: recreates a positively-missing endpoint in the recorded worktree"
 }
 
+test_spawn_relaunch_cleans_an_unpublished_recreated_endpoint() {
+  local dir out rc real_mv meta
+  dir=$(new_case recreateabort rl45)
+  add_ship_task "$dir" rl45 claude
+  meta="$dir/home/state/rl45.meta"
+  : > "$dir/fake/windows"
+  real_mv=$(command -v mv)
+  make_mv_failure_stub "$dir"
+  out=$(FM_REAL_MV="$real_mv" FM_FAKE_META_PUBLISH_MV_FAIL="$meta" \
+    run_spawn "$dir" rl45 --relaunch --harness claude); rc=$?
+  expect_code 1 "$rc" "a failed recreation publication should fail closed"$'\n'"$out"
+  [ ! -s "$dir/fake/windows" ] \
+    || fail "an unpublished recreated endpoint must be removed"
+  assert_grep "firstmate:=fm-rl45" "$dir/fake/killed" \
+    "abort cleanup should target the exact recreated endpoint"
+  out=$(FM_REAL_MV="$real_mv" run_spawn "$dir" rl45 --relaunch --harness claude); rc=$?
+  expect_code 0 "$rc" "cleanup should leave recreation retryable"$'\n'"$out"
+  pass "fm-spawn --relaunch: abort removes an unpublished recreated endpoint"
+}
+
 test_spawn_relaunch_refuses_to_recreate_a_secondmate_endpoint() {
   local dir home out rc
   dir=$(new_case smrecreate sm8)
@@ -1676,4 +1712,5 @@ test_relaunch_moves_a_drifted_item_back_in_flight
 test_relaunch_recreates_a_vanished_endpoint
 test_relaunch_refuses_to_recreate_an_unreadable_endpoint
 test_spawn_relaunch_recreates_a_vanished_endpoint
+test_spawn_relaunch_cleans_an_unpublished_recreated_endpoint
 test_spawn_relaunch_refuses_to_recreate_a_secondmate_endpoint

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -110,7 +110,27 @@ case "${1:-}" in
     done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
-  list-windows) [ -f "$D/windows" ] && cat "$D/windows"; exit 0 ;;
+  new-window)
+    # Model endpoint recreation: register the created window so a later
+    # agent_state read finds it, seed it as an agent-free shell, and echo a
+    # stable window id. Parse only the -n <name> pair; ignore every other flag.
+    shift
+    prev=
+    wname=win
+    for a in "$@"; do
+      [ "$prev" = -n ] && { wname=$a; break; }
+      prev=$a
+    done
+    printf '%s\n' "$wname" >> "$D/windows"
+    printf 'zsh' > "$D/command"
+    printf '@%s\n' "$wname"
+    exit 0 ;;
+  list-windows)
+    if [ -n "${FM_FAKE_LIST_WINDOWS_ERROR:-}" ]; then
+      printf '%s\n' "$FM_FAKE_LIST_WINDOWS_ERROR" >&2
+      exit 1
+    fi
+    [ -f "$D/windows" ] && cat "$D/windows"; exit 0 ;;
 esac
 exit 0
 SH
@@ -1494,6 +1514,114 @@ test_relaunch_moves_a_drifted_item_back_in_flight() {
   pass "relaunch heals an item that drifted out of In flight while the task stayed live"
 }
 
+# --- 7. endpoint recreation on a vanished pane -------------------------------
+#
+# When a task's terminal vanishes ENTIRELY (positively `missing`: gone from the
+# session inventory, not merely unreadable) while the task record and worktree
+# stay intact, a relaunch recreates a fresh endpoint in the recorded worktree
+# instead of dead-ending. An ambiguous or unreadable endpoint is NOT `missing`
+# and still refuses, so recreation never lands on a live or unattributed one.
+
+test_relaunch_recreates_a_vanished_endpoint() {
+  local dir out rc window_before window_after
+  dir=$(new_case recreate rl42)
+  add_ship_task "$dir" rl42 claude
+  window_before=$(meta_field "$dir" rl42 window)
+  printf 'scratch work\n' > "$dir/wt/uncommitted.txt"
+  # The pane vanished: its window is absent from the session inventory.
+  : > "$dir/fake/windows"
+  out=$(run_control "$dir" rl42 relaunch --note "pane vanished, pick the work back up"); rc=$?
+  expect_code 0 "$rc" "a vanished endpoint should be recreated, not dead-ended"$'\n'"$out"
+  assert_contains "$out" "relaunched rl42 harness=claude from=claude" "the outcome should name the transition"
+  window_after=$(meta_field "$dir" rl42 window)
+  [ "$window_after" != "$window_before" ] \
+    || fail "the recreated endpoint must republish a new window handle (was '$window_before')"
+  case "$window_after" in
+    *:fm-rl42) ;;
+    *) fail "the recreated endpoint should keep the task window name, got '$window_after'" ;;
+  esac
+  [ "$(meta_field "$dir" rl42 worktree)" = "$dir/wt" ] \
+    || fail "the recorded worktree must be reused, never reallocated or discarded"
+  [ -f "$dir/wt/uncommitted.txt" ] || fail "uncommitted work must survive endpoint recreation"
+  assert_grep "encode launch-brief" "$dir/fake/literal" "the replacement should have been launched"
+  assert_no_grep "/exit" "$dir/fake/literal" \
+    "there is no agent to stop when the pane has vanished, so no exit command should be sent"
+  [ "$(journal_field "$dir" rl42 phase)" = complete ] \
+    || fail "the transaction journal should end complete"
+  pass "fm-control relaunch: a vanished endpoint is recreated in the recorded worktree"
+}
+
+test_relaunch_refuses_to_recreate_an_unreadable_endpoint() {
+  local dir out rc before
+  dir=$(new_case unreadable rl43)
+  add_ship_task "$dir" rl43 claude
+  before=$(cat "$dir/home/state/rl43.meta")
+  # An inventory read that fails without a definitive missing-session signal is
+  # `unreadable`, not `missing` - that is the parallel unknown-state fix's
+  # territory, so recreation must refuse here.
+  out=$(FM_FAKE_LIST_WINDOWS_ERROR='protocol version mismatch' \
+    run_control "$dir" rl43 relaunch --note "do not recreate over an ambiguous endpoint"); rc=$?
+  expect_code 1 "$rc" "an unreadable endpoint must refuse recreation"$'\n'"$out"
+  assert_contains "$out" "rather than a positively classified state" \
+    "the refusal should name the unattributed endpoint"
+  [ "$(cat "$dir/home/state/rl43.meta")" = "$before" ] \
+    || fail "a refused recreation must leave the durable record untouched"
+  assert_no_grep "encode launch-brief" "$dir/fake/literal" \
+    "a refused recreation must launch no replacement"
+  pass "fm-control relaunch: an unreadable endpoint refuses recreation instead of guessing"
+}
+
+test_spawn_relaunch_recreates_a_vanished_endpoint() {
+  local dir out rc window_before window_after
+  dir=$(new_case spawnrecreate rl44)
+  add_ship_task "$dir" rl44 claude
+  window_before=$(meta_field "$dir" rl44 window)
+  : > "$dir/fake/windows"
+  out=$(run_spawn "$dir" rl44 --relaunch --harness claude); rc=$?
+  expect_code 0 "$rc" "fm-spawn --relaunch should recreate a vanished endpoint"$'\n'"$out"
+  assert_contains "$out" "spawned rl44 harness=claude" "the launch should report the recreated endpoint"
+  window_after=$(meta_field "$dir" rl44 window)
+  [ "$window_after" != "$window_before" ] \
+    || fail "fm-spawn should republish a new window handle for the recreated endpoint"
+  case "$window_after" in
+    *:fm-rl44) ;;
+    *) fail "the recreated endpoint should keep the task window name, got '$window_after'" ;;
+  esac
+  pass "fm-spawn --relaunch: recreates a positively-missing endpoint in the recorded worktree"
+}
+
+test_spawn_relaunch_refuses_to_recreate_a_secondmate_endpoint() {
+  local dir home out rc
+  dir=$(new_case smrecreate sm8)
+  home="$dir/home"
+  mkdir -p "$home/data/sm8"
+  printf '# secondmate brief\n' > "$home/data/sm8/brief.md"
+  fm_git_worktree "$dir/proj" "$dir/smhome" sm-branch
+  mkdir -p "$dir/smhome/state" "$dir/smhome/data"
+  printf 'sm8\n' > "$dir/smhome/.fm-secondmate-home"
+  printf '# agents\n' > "$dir/smhome/AGENTS.md"
+  {
+    echo "window=fmses:fm-sm8"
+    echo "endpoint_task_id=sm8"
+    echo "worktree=$dir/smhome"
+    echo "project=$dir/smhome"
+    echo "harness=claude"
+    echo "kind=secondmate"
+    echo "mode=secondmate"
+    echo "yolo=off"
+    echo "model=default"
+    echo "effort=default"
+    echo "home=$dir/smhome"
+  } > "$home/state/sm8.meta"
+  # The secondmate's endpoint has vanished from the inventory.
+  : > "$dir/fake/windows"
+  out=$(run_spawn "$dir" sm8 --relaunch --harness claude); rc=$?
+  expect_code 1 "$rc" "a secondmate endpoint recreation should be refused here"$'\n'"$out"
+  assert_contains "$out" "secondmate recovery path" \
+    "the refusal should route to the secondmate recovery path"
+  pass "fm-spawn --relaunch: a vanished secondmate endpoint is routed to secondmate recovery, not recreated here"
+}
+
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_serializes_concurrent_durable_metadata_publication
@@ -1545,3 +1673,7 @@ test_spawn_relaunch_refuses_an_unrecorded_task
 test_spawn_relaunch_refuses_a_pane_outside_the_worktree
 test_relaunch_reverifies_an_already_in_flight_item_instead_of_rewriting_it
 test_relaunch_moves_a_drifted_item_back_in_flight
+test_relaunch_recreates_a_vanished_endpoint
+test_relaunch_refuses_to_recreate_an_unreadable_endpoint
+test_spawn_relaunch_recreates_a_vanished_endpoint
+test_spawn_relaunch_refuses_to_recreate_a_secondmate_endpoint


### PR DESCRIPTION
## Intent

Verbatim captain 2026-09-04: "fix the firstmate bugs" - this is bug 2 of 3: when a task's Herdr pane vanishes entirely, the control plane dead-ends instead of offering a guarded way to recreate the endpoint.

## What Changed

- Recreate positively missing tmux or Herdr endpoints in the task’s recorded worktree during ship and scout relaunches, then publish and verify the replacement endpoint.
- Continue refusing ambiguous, unreadable, and missing secondmate endpoints, and remove newly created endpoints when metadata publication fails.
- Document the recovery behavior and add coverage for recreation, refusal, cleanup, and retry paths.

## Risk Assessment

✅ Low: Captain, the change is well-bounded: missing endpoints are recreated only after positive classification, Herdr presentation conflicts are reconciled under the existing session lock, and cleanup now respects the metadata publication boundary.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (1h17m54s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6749f068f51f3f831ac15834e637c836a4e6ad78","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-spawn.sh:2233` - A missing projected Herdr pane can still have another live pane in its token-bound presentation workspace. This branch bypasses the existing journal recovery checks and creates a flat endpoint, allowing two agents to use the same task/worktree. Reuse the presentation-journal inspection under its session lock before recreating.
- 🚨 `bin/fm-spawn.sh:2229` - The recreated tmux window is not owned by abort cleanup before metadata publication. If a later pre-publication step fails after recreation in a different session, metadata retains the missing old endpoint while the new `fm-&lt;id&gt;` window remains; retry then refuses because that window already exists. Track the exact new endpoint for cleanup immediately after creation and disarm cleanup only once its metadata is published.

🔧 Fix: Guard recreated endpoints through safe publication
1 error still open:

- 🚨 `bin/fm-spawn.sh:803` - Abort cleanup recognizes a crossed publication boundary by the staged metadata file disappearing, but only disarms replacement-wiring rollback. If `mv` installs the new record and the subsequent target validation fails, the trap still deletes the recreated tmux/Herdr endpoint, leaving published metadata pointing to a missing endpoint. Disarm both recreation-cleanup flags in this crossed-publication branch, matching the normal successful-publication path.

🔧 Fix: Disarm recreated endpoint cleanup after publication
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
