### PR TITLE
feat: add structural merge-front queue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ state/               runtime records and signals; gitignored
   .wake-queue        durable queued wakes retained until post-handling acknowledgement: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
   .watcher-down      private generation-bound recovery state coupling watcher downtime, durable wake presentation, and post-handling acknowledgement; never touch
   .<id>.open-decisions-cursor  per-task byte cursor and folded open-decision set bounding the OPEN DECISIONS scan's cost to new status-log appends; written only by fm-classify-lib.sh's status_open_decisions_incremental, removed by teardown, safe to delete (forces one full re-fold)
+  merge-front/      private per-project PR ordering state; bin/fm-merge-front.sh's header owns the schema, transitions, and update-branch/Greptile authority gate
   .status-presentation-cursor .status-presentation-lock  fleet-wide per-task status identity plus independent annotation and outcome-backstop byte offsets, with a serialization lock preventing already-presented lines from replaying while preserving delayed signal annotations; owned by fm-classify-lib.sh, with each task's row retired by teardown
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
   .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
@@ -374,6 +375,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
 Run `bin/fm-pr-check.sh <id> <PR url>` with the URL copied from that ready signal - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
+Before updating a PR branch from `main` or retriggering Greptile, consult `bin/fm-merge-front.sh`; its header owns the sole-front authority and gate.
 Tell the captain the PR's full `https://...` URL copied from the worker's ready line or the task's `pr=` metadata, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine merge authority.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.

--- a/bin/fm-merge-front-lib.sh
+++ b/bin/fm-merge-front-lib.sh
@@ -346,7 +346,7 @@ fm_merge_front_status() {  # <state> <project-key>
 }
 
 fm_merge_front_promote() {  # <state> <project-key>
-  local state=$1 project=$2 task url next_task=none next_url= rc
+  local state=$1 project=$2 task url next_task= next_url= has_next=0 rc
   local provider host path number merged
   fm_merge_front_project_key_valid "$project" || return 2
   if fm_merge_front_paths "$state" "$project" 0; then
@@ -398,12 +398,13 @@ fm_merge_front_promote() {  # <state> <project-key>
     return 1
   fi
   if [ "${#FM_MERGE_FRONT_TASKS[@]}" -gt 0 ]; then
+    has_next=1
     next_task=${FM_MERGE_FRONT_TASKS[0]}
     next_url=${FM_MERGE_FRONT_URLS[0]}
   fi
   fm_merge_front_unlock
   printf 'promoted=%s\t%s\n' "$task" "$url"
-  if [ "$next_task" = none ]; then
+  if [ "$has_next" -eq 0 ]; then
     printf 'front=none\n'
   else
     printf 'front=%s\t%s\n' "$next_task" "$next_url"
@@ -539,47 +540,30 @@ fm_merge_front_drop_anywhere() {  # <state> <task-id> <pr-url-or-empty>
   return 3
 }
 
-# Retire this task's row in its own project queue when the metadata still names
-# one, otherwise anywhere. Returns 0 on a drop, 3 when nothing matched, 1 on a
-# lock or state failure.
-_fm_merge_front_retire_scoped() {  # <state> <task-id> <pr-url-or-empty>
-  local state=$1 task=$2 url=$3 project rc=0
-  if project=$(fm_merge_front_project_key_from_meta "$state" "$task" 2>/dev/null); then
-    _fm_merge_front_drop_scoped "$state" "$project" "$task" "$url" || rc=$?
-    case "$rc" in
-      0|3) ;;
-      *) return 1 ;;
-    esac
-    [ "$rc" -eq 3 ] || return 0
-  fi
-  rc=0
-  fm_merge_front_drop_anywhere "$state" "$task" "$url" || rc=$?
-  return "$rc"
-}
-
 # The one identity-bound retirement entry point for a task leaving the queue -
 # a confirmed merge, or a teardown. A merge is a fact the queue may never veto:
-# only the matching row is retired, wherever it sits, so an out-of-order merge
+# only this task's row is retired, wherever it sits, so an out-of-order merge
 # leaves the current front untouched and an unqueued identity is nothing to do.
-# It prefers the task's own project key and
-# falls back to a scan of every project queue when the task metadata is already
-# gone, so a completed or torn-down front can never stay queued in front of the
-# live PRs behind it. The recorded URL is tried first; when it finds nothing the
-# trusted task identity alone retires the row, because a replacement
-# registration that committed the metadata but failed its enqueue leaves the
-# queue holding a stale URL for this very task. A task with no queued row at all
-# is nothing to do, never a failure.
-fm_merge_front_retire_task() {  # <state> <task-id> <pr-url>
-  local state=$1 task=$2 url=$3 rc=0
+# The row is identified by the trusted task identity alone, because a
+# replacement registration that committed the metadata but failed its enqueue
+# leaves the queue holding a stale URL for this very task; a task ID is unique
+# within a queue, so that still names at most one row. The task's own project
+# key resolves the queue in a single locked read, and only a task whose metadata
+# is already gone pays the cross-project scan, so a completed or torn-down front
+# can never stay queued in front of the live PRs behind it. A task with no
+# queued row is nothing to do, never a failure.
+fm_merge_front_retire_task() {  # <state> <task-id>
+  local state=$1 task=$2 project rc=0
   [ -e "$state/merge-front" ] || [ -L "$state/merge-front" ] || return 0
-  _fm_merge_front_retire_scoped "$state" "$task" "$url" || rc=$?
-  case "$rc" in
-    0) return 0 ;;
-    3) ;;
-    *) return 1 ;;
-  esac
+  if project=$(fm_merge_front_project_key_from_meta "$state" "$task" 2>/dev/null); then
+    _fm_merge_front_drop_scoped "$state" "$project" "$task" '' || rc=$?
+    case "$rc" in
+      0|3) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
   rc=0
-  _fm_merge_front_retire_scoped "$state" "$task" '' || rc=$?
+  fm_merge_front_drop_anywhere "$state" "$task" '' || rc=$?
   case "$rc" in
     0|3) return 0 ;;
     *) return 1 ;;

--- a/bin/fm-merge-front-lib.sh
+++ b/bin/fm-merge-front-lib.sh
@@ -11,6 +11,10 @@ if ! command -v fm_lock_acquire_wait >/dev/null 2>&1; then
   # shellcheck source=bin/fm-wake-lib.sh
   . "$_FM_MERGE_FRONT_LIB_DIR/fm-wake-lib.sh"
 fi
+if ! command -v fm_run_timed >/dev/null 2>&1; then
+  # shellcheck source=bin/fm-timeout-lib.sh
+  . "$_FM_MERGE_FRONT_LIB_DIR/fm-timeout-lib.sh"
+fi
 
 FM_MERGE_FRONT_ROOT=
 FM_MERGE_FRONT_FILE=
@@ -19,6 +23,8 @@ FM_MERGE_FRONT_STATE_DEVICE=
 FM_MERGE_FRONT_TASKS=()
 FM_MERGE_FRONT_URLS=()
 FM_MERGE_FRONT_EXISTS=0
+FM_MERGE_FRONT_DROPPED_TASK=
+FM_MERGE_FRONT_DROPPED_URL=
 
 fm_merge_front_project_key_valid() {
   local key=${1-}
@@ -32,8 +38,7 @@ fm_merge_front_root_prepare() {  # <state> <create: 0|1>
   FM_MERGE_FRONT_ROOT="$state/merge-front"
   if [ ! -e "$FM_MERGE_FRONT_ROOT" ] && [ ! -L "$FM_MERGE_FRONT_ROOT" ]; then
     [ "$create" -eq 1 ] || return 2
-    umask 077
-    if mkdir "$FM_MERGE_FRONT_ROOT" 2>/dev/null; then
+    if (umask 077; mkdir "$FM_MERGE_FRONT_ROOT" 2>/dev/null); then
       created=1
     fi
   fi
@@ -102,7 +107,6 @@ fm_merge_front_file_write() {  # <project-key>
   local project=$1 tmp='' index
   fm_pr_regular_destination_on_device_or_absent \
     "$FM_MERGE_FRONT_FILE" "$FM_MERGE_FRONT_STATE_DEVICE" || return 1
-  umask 077
   tmp=$(mktemp "$FM_MERGE_FRONT_ROOT/.$project.queue.XXXXXX") || return 1
   if ! {
       printf 'fm-merge-front-v1\nproject=%s\n' "$project"
@@ -134,6 +138,27 @@ fm_merge_front_file_write() {  # <project-key>
   fi
 }
 
+# Every queue lock wait is bounded. greptile-kick deliberately holds this lock
+# across live GitHub reads, and the shared merge-outcome path runs inside the
+# watcher, which must refuse rather than wedge behind a stuck holder.
+_fm_merge_front_bounded_seconds() {  # <value> <default>
+  local seconds=$1 fallback=$2
+  case "$seconds" in ''|*[!0-9]*|0) seconds=$fallback ;; esac
+  printf '%s\n' "$seconds"
+}
+
+_fm_merge_front_lock_acquire() {
+  local seconds
+  seconds=$(_fm_merge_front_bounded_seconds "${FM_MERGE_FRONT_LOCK_TIMEOUT:-30}" 30)
+  fm_lock_acquire_wait_bounded "$FM_MERGE_FRONT_LOCK" "$seconds"
+}
+
+_fm_merge_front_gh() {  # <gh-argument...>
+  local seconds
+  seconds=$(_fm_merge_front_bounded_seconds "${FM_MERGE_FRONT_GH_TIMEOUT:-60}" 60)
+  fm_run_timed "$seconds" env GH_PAGER=cat GH_PROMPT_DISABLED=1 "$@"
+}
+
 fm_merge_front_lock_and_load() {  # <state> <project-key> <create: 0|1>
   local state=$1 project=$2 create=$3 rc
   if fm_merge_front_paths "$state" "$project" "$create"; then
@@ -142,7 +167,7 @@ fm_merge_front_lock_and_load() {  # <state> <project-key> <create: 0|1>
     rc=$?
     return "$rc"
   fi
-  fm_lock_acquire_wait "$FM_MERGE_FRONT_LOCK" || return 1
+  _fm_merge_front_lock_acquire || return 1
   if ! fm_merge_front_file_load "$project"; then
     fm_lock_release "$FM_MERGE_FRONT_LOCK"
     return 1
@@ -177,6 +202,7 @@ fm_merge_front_project_key_from_meta() {  # <state> <task-id>
 
 fm_merge_front_enqueue() {  # <state> <project-key> <task-id> <pr-url>
   local state=$1 project=$2 task=$3 raw_url=$4 url index role
+  local task_index=-1 url_index=-1
   fm_merge_front_project_key_valid "$project" || return 2
   fm_pr_task_id_valid "$task" || return 2
   fm_pr_url_parse "$raw_url" || return 2
@@ -184,31 +210,35 @@ fm_merge_front_enqueue() {  # <state> <project-key> <task-id> <pr-url>
   fm_merge_front_lock_and_load "$state" "$project" 1 || return 1
   index=0
   while [ "$index" -lt "${#FM_MERGE_FRONT_TASKS[@]}" ]; do
-    if [ "${FM_MERGE_FRONT_TASKS[$index]}" = "$task" ] \
-      || [ "${FM_MERGE_FRONT_URLS[$index]}" = "$url" ]; then
-      if [ "${FM_MERGE_FRONT_TASKS[$index]}" != "$task" ] \
-        || [ "${FM_MERGE_FRONT_URLS[$index]}" != "$url" ]; then
-        printf 'error: merge-front queue conflict for project %s\n' "$project" >&2
-        fm_merge_front_unlock
-        return 1
-      fi
-      role=parked
-      [ "$index" -eq 0 ] && role=front
-      fm_merge_front_unlock
-      printf '%s=%s\t%s\n' "$role" "$task" "$url"
-      return 0
-    fi
+    [ "${FM_MERGE_FRONT_TASKS[$index]}" != "$task" ] || task_index=$index
+    [ "${FM_MERGE_FRONT_URLS[$index]}" != "$url" ] || url_index=$index
     index=$((index + 1))
   done
-  FM_MERGE_FRONT_TASKS+=("$task")
-  FM_MERGE_FRONT_URLS+=("$url")
-  if ! fm_merge_front_file_write "$project"; then
+  if [ "$url_index" -ge 0 ] && [ "$url_index" -ne "$task_index" ]; then
+    printf 'error: merge-front queue conflict for project %s\n' "$project" >&2
     fm_merge_front_unlock
     return 1
   fi
-  index=$((${#FM_MERGE_FRONT_TASKS[@]} - 1))
+  if [ "$task_index" -ge 0 ]; then
+    if [ "$url_index" -lt 0 ]; then
+      FM_MERGE_FRONT_URLS[$task_index]=$url
+      if ! fm_merge_front_file_write "$project"; then
+        fm_merge_front_unlock
+        return 1
+      fi
+    fi
+    index=$task_index
+  else
+    FM_MERGE_FRONT_TASKS+=("$task")
+    FM_MERGE_FRONT_URLS+=("$url")
+    if ! fm_merge_front_file_write "$project"; then
+      fm_merge_front_unlock
+      return 1
+    fi
+    index=$((${#FM_MERGE_FRONT_TASKS[@]} - 1))
+  fi
   role=parked
-  [ "$index" -eq 0 ] && role=front
+  [ "$index" -ne 0 ] || role=front
   fm_merge_front_unlock
   printf '%s=%s\t%s\n' "$role" "$task" "$url"
 }
@@ -224,7 +254,7 @@ fm_merge_front_status() {  # <state> <project-key>
     printf 'project=%s\nfront=none\n' "$project"
     return 0
   fi
-  fm_lock_acquire_wait "$FM_MERGE_FRONT_LOCK" || return 1
+  _fm_merge_front_lock_acquire || return 1
   if ! fm_merge_front_file_load "$project"; then
     fm_merge_front_unlock
     return 1
@@ -256,7 +286,7 @@ fm_merge_front_promote() {  # <state> <project-key>
     printf 'promoted=none\nfront=none\n'
     return 0
   fi
-  fm_lock_acquire_wait "$FM_MERGE_FRONT_LOCK" || return 1
+  _fm_merge_front_lock_acquire || return 1
   if ! fm_merge_front_file_load "$project"; then
     fm_merge_front_unlock
     return 1
@@ -302,65 +332,109 @@ fm_merge_front_promote() {  # <state> <project-key>
   fi
 }
 
-fm_merge_front_promote_exact() {  # <state> <project-key> <task-id> <pr-url>
-  local state=$1 project=$2 task=$3 raw_url=$4 url index found=-1 rc
+# Retire the queue entries bound to one task or one PR URL, wherever they sit.
+# Sets FM_MERGE_FRONT_DROPPED_* to the first retired identity and leaves the
+# loaded queue arrays holding the survivors. Returns 3 when nothing matched.
+_fm_merge_front_drop_locked() {  # <project-key> <task-id> <canonical-url>
+  local project=$1 task=$2 url=$3 index=0 removed=0
+  local tasks=() urls=()
+  FM_MERGE_FRONT_DROPPED_TASK=
+  FM_MERGE_FRONT_DROPPED_URL=
+  while [ "$index" -lt "${#FM_MERGE_FRONT_TASKS[@]}" ]; do
+    if [ "${FM_MERGE_FRONT_TASKS[$index]}" = "$task" ] \
+      || [ "${FM_MERGE_FRONT_URLS[$index]}" = "$url" ]; then
+      if [ "$removed" -eq 0 ]; then
+        FM_MERGE_FRONT_DROPPED_TASK=${FM_MERGE_FRONT_TASKS[$index]}
+        FM_MERGE_FRONT_DROPPED_URL=${FM_MERGE_FRONT_URLS[$index]}
+      fi
+      removed=$((removed + 1))
+    else
+      tasks+=("${FM_MERGE_FRONT_TASKS[$index]}")
+      urls+=("${FM_MERGE_FRONT_URLS[$index]}")
+    fi
+    index=$((index + 1))
+  done
+  [ "$removed" -ne 0 ] || return 3
+  # shellcheck disable=SC2206 # Validated slug and URL elements never split.
+  FM_MERGE_FRONT_TASKS=(${tasks[@]+"${tasks[@]}"})
+  # shellcheck disable=SC2206 # Validated slug and URL elements never split.
+  FM_MERGE_FRONT_URLS=(${urls[@]+"${urls[@]}"})
+  fm_merge_front_file_write "$project"
+}
+
+# Shared identity-bound retirement. Returns 0 when an entry was removed, 3 when
+# the identity is absent (including a project with no queue at all), 1 on a
+# lock or state failure, and 2 on an invalid request.
+fm_merge_front_drop() {  # <state> <project-key> <task-id> <pr-url>
+  local state=$1 project=$2 task=$3 raw_url=$4 url rc
   fm_merge_front_project_key_valid "$project" || return 2
   fm_pr_task_id_valid "$task" || return 2
   fm_pr_url_parse "$raw_url" || return 2
   url=$FM_PR_URL
+  FM_MERGE_FRONT_DROPPED_TASK=
+  FM_MERGE_FRONT_DROPPED_URL=
   if fm_merge_front_paths "$state" "$project" 0; then
     :
   else
     rc=$?
-    [ "$rc" -eq 2 ] && return 0
+    [ "$rc" -eq 2 ] && return 3
     return 1
   fi
-  fm_lock_acquire_wait "$FM_MERGE_FRONT_LOCK" || return 1
+  _fm_merge_front_lock_acquire || return 1
   if ! fm_merge_front_file_load "$project"; then
     fm_merge_front_unlock
     return 1
   fi
-  index=0
-  while [ "$index" -lt "${#FM_MERGE_FRONT_TASKS[@]}" ]; do
-    if [ "${FM_MERGE_FRONT_TASKS[$index]}" = "$task" ] \
-      || [ "${FM_MERGE_FRONT_URLS[$index]}" = "$url" ]; then
-      if [ "${FM_MERGE_FRONT_TASKS[$index]}" != "$task" ] \
-        || [ "${FM_MERGE_FRONT_URLS[$index]}" != "$url" ]; then
-        fm_merge_front_unlock
-        return 1
-      fi
-      found=$index
-      break
-    fi
-    index=$((index + 1))
-  done
-  if [ "$found" -eq -1 ]; then
-    fm_merge_front_unlock
-    return 0
-  fi
-  if [ "$found" -ne 0 ]; then
-    fm_merge_front_unlock
-    return 3
-  fi
-  FM_MERGE_FRONT_TASKS=("${FM_MERGE_FRONT_TASKS[@]:1}")
-  FM_MERGE_FRONT_URLS=("${FM_MERGE_FRONT_URLS[@]:1}")
-  if ! fm_merge_front_file_write "$project"; then
-    fm_merge_front_unlock
-    return 1
-  fi
+  rc=0
+  _fm_merge_front_drop_locked "$project" "$task" "$url" || rc=$?
   fm_merge_front_unlock
+  return "$rc"
+}
+
+# Reconcile one already-confirmed merged PR. A merge is a fact the queue may
+# never veto: the exact entry is removed wherever it sits, an out-of-order
+# merge leaves the current front untouched, and an identity that is not queued
+# is simply nothing to do.
+fm_merge_front_reconcile_merged() {  # <state> <project-key> <task-id> <pr-url>
+  local rc=0
+  fm_merge_front_drop "$@" || rc=$?
+  [ "$rc" -ne 3 ] || rc=0
+  return "$rc"
+}
+
+# Operator recovery for a front or parked PR that will never merge: a closed or
+# superseded PR, or a torn-down task. Removal never advances anything by itself;
+# it only retires the named entry, so a retired front simply exposes the next.
+fm_merge_front_remove() {  # <state> <project-key> <task-id> <pr-url>
+  local rc=0
+  fm_merge_front_drop "$@" || rc=$?
+  case "$rc" in
+    0) printf 'removed=%s\t%s\n' \
+         "$FM_MERGE_FRONT_DROPPED_TASK" "$FM_MERGE_FRONT_DROPPED_URL" ;;
+    3)
+      printf 'removed=none\n'
+      rc=0
+      ;;
+    *) return "$rc" ;;
+  esac
+  if [ "${#FM_MERGE_FRONT_TASKS[@]}" -eq 0 ]; then
+    printf 'front=none\n'
+  else
+    printf 'front=%s\t%s\n' "${FM_MERGE_FRONT_TASKS[0]}" "${FM_MERGE_FRONT_URLS[0]}"
+  fi
+  return "$rc"
 }
 
 fm_merge_front_promote_task() {  # <state> <task-id> <pr-url>
   local state=$1 task=$2 url=$3 project
   [ -e "$state/merge-front" ] || [ -L "$state/merge-front" ] || return 0
   project=$(fm_merge_front_project_key_from_meta "$state" "$task") || return 0
-  fm_merge_front_promote_exact "$state" "$project" "$task" "$url"
+  fm_merge_front_reconcile_merged "$state" "$project" "$task" "$url"
 }
 
 fm_merge_front_checks_json() {  # <github-check-command...>
   local output
-  if output=$(GH_PAGER=cat GH_PROMPT_DISABLED=1 "$@" 2>&1); then
+  if output=$(_fm_merge_front_gh "$@" 2>&1); then
     :
   fi
   if printf '%s\n' "$output" | jq -e \
@@ -401,7 +475,7 @@ fm_merge_front_greptile_kick() {  # <state> <project-key>
     fi
     return 1
   fi
-  fm_lock_acquire_wait "$FM_MERGE_FRONT_LOCK" || return 1
+  _fm_merge_front_lock_acquire || return 1
   if ! fm_merge_front_file_load "$project"; then
     fm_merge_front_unlock
     echo 'error: merge-front queue is invalid' >&2
@@ -427,7 +501,7 @@ fm_merge_front_greptile_kick() {  # <state> <project-key>
     echo 'error: greptile-kick supports GitHub pull requests only' >&2
     return 1
   fi
-  if ! pr_row=$(GH_PAGER=cat GH_PROMPT_DISABLED=1 gh pr view "$number" \
+  if ! pr_row=$(_fm_merge_front_gh gh pr view "$number" \
       --repo "$repo_path" --json state,baseRefName,headRefOid \
       --jq '[.state,.baseRefName,.headRefOid] | @tsv' 2>/dev/null); then
     fm_merge_front_unlock
@@ -450,7 +524,7 @@ fm_merge_front_greptile_kick() {  # <state> <project-key>
     echo 'error: merge-front PR head could not be validated' >&2
     return 1
   fi
-  if ! behind=$(GH_PAGER=cat GH_PROMPT_DISABLED=1 gh api \
+  if ! behind=$(_fm_merge_front_gh gh api \
       "repos/$repo_path/compare/main...$head" --jq .behind_by 2>/dev/null); then
     fm_merge_front_unlock
     echo 'error: merge-front PR freshness could not be read' >&2
@@ -489,7 +563,7 @@ fm_merge_front_greptile_kick() {  # <state> <project-key>
     return 1
   fi
   unknown=$(printf '%s\n' "$all_json" | jq -r \
-    '[.[] | select(.name | ascii_downcase | contains("greptile")) | .state | select(. as $state | ["PENDING","QUEUED","IN_PROGRESS","WAITING","REQUESTED","EXPECTED","SUCCESS","FAILURE","CANCELLED","SKIPPED","NEUTRAL","TIMED_OUT","ACTION_REQUIRED","STARTUP_FAILURE","STALE"] | index($state) | not)] | unique | join(", ")') || {
+    '[.[] | select(.name | ascii_downcase | contains("greptile")) | .state | select(. as $state | ["PENDING","QUEUED","IN_PROGRESS","WAITING","REQUESTED","EXPECTED","SUCCESS","FAILURE","ERROR","CANCELLED","SKIPPED","NEUTRAL","TIMED_OUT","ACTION_REQUIRED","STARTUP_FAILURE","STALE"] | index($state) | not)] | unique | join(", ")') || {
       fm_merge_front_unlock
       echo 'error: Greptile check state could not be evaluated' >&2
       return 1
@@ -510,7 +584,7 @@ fm_merge_front_greptile_kick() {  # <state> <project-key>
     echo 'error: Greptile review is already pending' >&2
     return 1
   fi
-  if ! GH_PAGER=cat GH_PROMPT_DISABLED=1 gh pr comment "$number" \
+  if ! _fm_merge_front_gh gh pr comment "$number" \
       --repo "$repo_path" --body '@greptile review'; then
     fm_merge_front_unlock
     echo 'error: Greptile review comment failed' >&2

--- a/bin/fm-merge-front-lib.sh
+++ b/bin/fm-merge-front-lib.sh
@@ -22,7 +22,6 @@ FM_MERGE_FRONT_LOCK=
 FM_MERGE_FRONT_STATE_DEVICE=
 FM_MERGE_FRONT_TASKS=()
 FM_MERGE_FRONT_URLS=()
-FM_MERGE_FRONT_EXISTS=0
 FM_MERGE_FRONT_DROPPED_TASK=
 FM_MERGE_FRONT_DROPPED_URL=
 FM_MERGE_FRONT_CONFLICT_TASK=
@@ -65,7 +64,6 @@ fm_merge_front_file_load() {  # <project-key>
   local line_number=0 bytes seen_tasks seen_urls
   FM_MERGE_FRONT_TASKS=()
   FM_MERGE_FRONT_URLS=()
-  FM_MERGE_FRONT_EXISTS=0
   [ -e "$FM_MERGE_FRONT_FILE" ] || [ -L "$FM_MERGE_FRONT_FILE" ] || return 0
   fm_pr_private_file_valid "$FM_MERGE_FRONT_FILE" 600 "$FM_MERGE_FRONT_STATE_DEVICE" || return 1
   bytes=$(wc -c < "$FM_MERGE_FRONT_FILE" 2>/dev/null | tr -d '[:space:]') || return 1
@@ -103,7 +101,6 @@ fm_merge_front_file_load() {  # <project-key>
   [ "$line_number" -ge 2 ] || return 1
   [ "$version" = fm-merge-front-v1 ] || return 1
   [ "$stored_project" = "$project" ] || return 1
-  FM_MERGE_FRONT_EXISTS=1
 }
 
 fm_merge_front_file_write() {  # <project-key>
@@ -413,20 +410,24 @@ fm_merge_front_promote() {  # <state> <project-key>
   fi
 }
 
-# Retire the one queue entry bound to exactly this task and this canonical URL.
-# Task IDs and URLs are each unique within a queue, so the pair identifies at
-# most one row: a stale or mismatched identity retires nothing rather than
-# silently dropping some other task's live entry. Sets FM_MERGE_FRONT_DROPPED_*
-# to the retired identity and leaves the loaded arrays holding the survivors.
-# Returns 3 when the pair is not queued.
-_fm_merge_front_drop_locked() {  # <project-key> <task-id> <canonical-url>
+# Retire the one queue entry bound to this task. With a canonical URL the task
+# and the URL must both match, so a stale or mismatched identity retires nothing
+# rather than silently dropping some other task's live entry; that is the only
+# mode the operator-facing remove command uses. With an empty URL the row is
+# identified by the trusted task identity alone, which the internal
+# teardown/missing-metadata retirement uses to clear a row whose recorded URL
+# has diverged. Task IDs and URLs are each unique within a queue, so either mode
+# identifies at most one row. Sets FM_MERGE_FRONT_DROPPED_* to the retired
+# identity and leaves the loaded arrays holding the survivors. Returns 3 when no
+# row matched.
+_fm_merge_front_drop_locked() {  # <project-key> <task-id> <canonical-url-or-empty>
   local project=$1 task=$2 url=$3 index=0 removed=0
   local tasks=() urls=()
   FM_MERGE_FRONT_DROPPED_TASK=
   FM_MERGE_FRONT_DROPPED_URL=
   while [ "$index" -lt "${#FM_MERGE_FRONT_TASKS[@]}" ]; do
     if [ "${FM_MERGE_FRONT_TASKS[$index]}" = "$task" ] \
-      && [ "${FM_MERGE_FRONT_URLS[$index]}" = "$url" ]; then
+      && { [ -z "$url" ] || [ "${FM_MERGE_FRONT_URLS[$index]}" = "$url" ]; }; then
       FM_MERGE_FRONT_DROPPED_TASK=${FM_MERGE_FRONT_TASKS[$index]}
       FM_MERGE_FRONT_DROPPED_URL=${FM_MERGE_FRONT_URLS[$index]}
       removed=$((removed + 1))
@@ -444,15 +445,18 @@ _fm_merge_front_drop_locked() {  # <project-key> <task-id> <canonical-url>
   fm_merge_front_file_write "$project"
 }
 
-# Shared identity-bound retirement. Returns 0 when an entry was removed, 3 when
-# the identity is absent (including a project with no queue at all), 1 on a
-# lock or state failure, and 2 on an invalid request.
-fm_merge_front_drop() {  # <state> <project-key> <task-id> <pr-url>
-  local state=$1 project=$2 task=$3 raw_url=$4 url rc
+# Shared identity-bound retirement. An empty URL selects the trusted task-scoped
+# mode described on _fm_merge_front_drop_locked. Returns 0 when an entry was
+# removed, 3 when the identity is absent (including a project with no queue at
+# all), 1 on a lock or state failure, and 2 on an invalid request.
+_fm_merge_front_drop_scoped() {  # <state> <project-key> <task-id> <pr-url-or-empty>
+  local state=$1 project=$2 task=$3 raw_url=$4 url='' rc
   fm_merge_front_project_key_valid "$project" || return 2
   fm_pr_task_id_valid "$task" || return 2
-  fm_pr_url_parse "$raw_url" || return 2
-  url=$FM_PR_URL
+  if [ -n "$raw_url" ]; then
+    fm_pr_url_parse "$raw_url" || return 2
+    url=$FM_PR_URL
+  fi
   FM_MERGE_FRONT_DROPPED_TASK=
   FM_MERGE_FRONT_DROPPED_URL=
   if fm_merge_front_paths "$state" "$project" 0; then
@@ -473,15 +477,10 @@ fm_merge_front_drop() {  # <state> <project-key> <task-id> <pr-url>
   return "$rc"
 }
 
-# Reconcile one already-confirmed merged PR. A merge is a fact the queue may
-# never veto: the exact entry is removed wherever it sits, an out-of-order
-# merge leaves the current front untouched, and an identity that is not queued
-# is simply nothing to do.
-fm_merge_front_reconcile_merged() {  # <state> <project-key> <task-id> <pr-url>
-  local rc=0
-  fm_merge_front_drop "$@" || rc=$?
-  [ "$rc" -ne 3 ] || rc=0
-  return "$rc"
+# The exact task-and-URL retirement every operator-facing path uses.
+fm_merge_front_drop() {  # <state> <project-key> <task-id> <pr-url>
+  [ -n "${4-}" ] || return 2
+  _fm_merge_front_drop_scoped "$@"
 }
 
 # Operator recovery for a front or parked PR that will never merge: a closed or
@@ -508,12 +507,14 @@ fm_merge_front_remove() {  # <state> <project-key> <task-id> <pr-url>
 }
 
 # Retire an identity from whichever project queue holds it when the task's own
-# project key is no longer derivable. One busy or unreadable queue never aborts
-# the scan: every queue is examined, and the failure only surfaces when no queue
-# yielded the drop. Returns 3 when nothing matched anywhere, 1 when the target
-# could not be safely retired.
-fm_merge_front_drop_anywhere() {  # <state> <task-id> <pr-url>
-  local state=$1 task=$2 url=$3 file project rc dropped=0 failed=0
+# project key is no longer derivable. The scan stops at the first queue that
+# yields the drop, so FM_MERGE_FRONT_DROPPED_* keeps the retired identity and no
+# unrelated project's lock is taken once the row is gone. One busy or unreadable
+# queue never aborts the scan: the remaining queues are still examined, and the
+# failure only surfaces when none of them yielded the drop. Returns 3 when
+# nothing matched anywhere, 1 when the target could not be safely retired.
+fm_merge_front_drop_anywhere() {  # <state> <task-id> <pr-url-or-empty>
+  local state=$1 task=$2 url=${3-} file project rc failed=0
   if fm_merge_front_root_prepare "$state" 0; then
     :
   else
@@ -527,33 +528,62 @@ fm_merge_front_drop_anywhere() {  # <state> <task-id> <pr-url>
     project=${project%.queue}
     fm_merge_front_project_key_valid "$project" || continue
     rc=0
-    fm_merge_front_drop "$state" "$project" "$task" "$url" || rc=$?
+    _fm_merge_front_drop_scoped "$state" "$project" "$task" "$url" || rc=$?
     case "$rc" in
-      0) dropped=1 ;;
+      0) return 0 ;;
       3) ;;
       *) failed=1 ;;
     esac
   done
-  [ "$dropped" -eq 0 ] || return 0
   [ "$failed" -eq 0 ] || return 1
   return 3
 }
 
+# Retire this task's row in its own project queue when the metadata still names
+# one, otherwise anywhere. Returns 0 on a drop, 3 when nothing matched, 1 on a
+# lock or state failure.
+_fm_merge_front_retire_scoped() {  # <state> <task-id> <pr-url-or-empty>
+  local state=$1 task=$2 url=$3 project rc=0
+  if project=$(fm_merge_front_project_key_from_meta "$state" "$task" 2>/dev/null); then
+    _fm_merge_front_drop_scoped "$state" "$project" "$task" "$url" || rc=$?
+    case "$rc" in
+      0|3) ;;
+      *) return 1 ;;
+    esac
+    [ "$rc" -eq 3 ] || return 0
+  fi
+  rc=0
+  fm_merge_front_drop_anywhere "$state" "$task" "$url" || rc=$?
+  return "$rc"
+}
+
 # The one identity-bound retirement entry point for a task leaving the queue -
-# a confirmed merge, or a teardown. It prefers the task's own project key and
+# a confirmed merge, or a teardown. A merge is a fact the queue may never veto:
+# only the matching row is retired, wherever it sits, so an out-of-order merge
+# leaves the current front untouched and an unqueued identity is nothing to do.
+# It prefers the task's own project key and
 # falls back to a scan of every project queue when the task metadata is already
 # gone, so a completed or torn-down front can never stay queued in front of the
-# live PRs behind it. A missing identity is nothing to do, never a failure.
+# live PRs behind it. The recorded URL is tried first; when it finds nothing the
+# trusted task identity alone retires the row, because a replacement
+# registration that committed the metadata but failed its enqueue leaves the
+# queue holding a stale URL for this very task. A task with no queued row at all
+# is nothing to do, never a failure.
 fm_merge_front_retire_task() {  # <state> <task-id> <pr-url>
-  local state=$1 task=$2 url=$3 project rc=0
+  local state=$1 task=$2 url=$3 rc=0
   [ -e "$state/merge-front" ] || [ -L "$state/merge-front" ] || return 0
-  if project=$(fm_merge_front_project_key_from_meta "$state" "$task" 2>/dev/null); then
-    fm_merge_front_reconcile_merged "$state" "$project" "$task" "$url" || return 1
-    [ -z "$FM_MERGE_FRONT_DROPPED_TASK" ] || return 0
-  fi
-  fm_merge_front_drop_anywhere "$state" "$task" "$url" || rc=$?
-  [ "$rc" -ne 3 ] || rc=0
-  return "$rc"
+  _fm_merge_front_retire_scoped "$state" "$task" "$url" || rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    3) ;;
+    *) return 1 ;;
+  esac
+  rc=0
+  _fm_merge_front_retire_scoped "$state" "$task" '' || rc=$?
+  case "$rc" in
+    0|3) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 fm_merge_front_checks_json() {  # <github-check-command...>

--- a/bin/fm-merge-front-lib.sh
+++ b/bin/fm-merge-front-lib.sh
@@ -25,6 +25,9 @@ FM_MERGE_FRONT_URLS=()
 FM_MERGE_FRONT_EXISTS=0
 FM_MERGE_FRONT_DROPPED_TASK=
 FM_MERGE_FRONT_DROPPED_URL=
+FM_MERGE_FRONT_CONFLICT_TASK=
+FM_MERGE_FRONT_SNAPSHOT_TASK=
+FM_MERGE_FRONT_SNAPSHOT_URL=
 
 fm_merge_front_project_key_valid() {
   local key=${1-}
@@ -138,9 +141,10 @@ fm_merge_front_file_write() {  # <project-key>
   fi
 }
 
-# Every queue lock wait is bounded. greptile-kick deliberately holds this lock
-# across live GitHub reads, and the shared merge-outcome path runs inside the
-# watcher, which must refuse rather than wedge behind a stuck holder.
+# Every queue lock wait is bounded and every hold is local: no path holds this
+# lock across a live GitHub call, so the longest hold is a state read plus an
+# atomic rewrite. The shared merge-outcome path runs inside the watcher, which
+# must refuse rather than wedge behind a stuck holder.
 _fm_merge_front_bounded_seconds() {  # <value> <default>
   local seconds=$1 fallback=$2
   case "$seconds" in ''|*[!0-9]*|0) seconds=$fallback ;; esac
@@ -178,8 +182,43 @@ fm_merge_front_unlock() {
   fm_lock_release "$FM_MERGE_FRONT_LOCK"
 }
 
+# Map a project checkout path onto its durable queue key. The key is the
+# path-safe remnant of the checkout basename joined to a digest of the whole
+# path, so an ordinary basename such as "my repo" or "app (v2)" registers
+# instead of refusing, while two checkouts that share a basename keep separate
+# queues. The mapping is pure and deterministic, so every caller that holds the
+# same project path resolves the same key without consulting shared state.
+fm_merge_front_project_key_from_path() {  # <project-path>
+  local project=${1-} base hash key
+  [ -n "$project" ] || return 1
+  while [ "$project" != "${project%/}" ]; do
+    project=${project%/}
+  done
+  [ -n "$project" ] || project=/
+  base=${project##*/}
+  base=$(printf '%s' "$base" | LC_ALL=C tr -c 'A-Za-z0-9._-' '-' | cut -c1-40) || return 1
+  while :; do
+    case "$base" in
+      ''|[A-Za-z0-9]*) break ;;
+      *) base=${base#?} ;;
+    esac
+  done
+  [ -n "$base" ] || base=project
+  if command -v shasum >/dev/null 2>&1; then
+    hash=$(printf '%s' "$project" | shasum -a 256 | awk '{print substr($1,1,12)}')
+  elif command -v sha256sum >/dev/null 2>&1; then
+    hash=$(printf '%s' "$project" | sha256sum | awk '{print substr($1,1,12)}')
+  else
+    hash=$(printf '%s' "$project" | cksum | awk '{printf "%08x-%s", $1, $2}')
+  fi
+  [ -n "$hash" ] || return 1
+  key="$base-$hash"
+  fm_merge_front_project_key_valid "$key" || return 1
+  printf '%s\n' "$key"
+}
+
 fm_merge_front_project_key_from_meta() {  # <state> <task-id>
-  local state=$1 id=$2 meta line project='' count=0 key
+  local state=$1 id=$2 meta line project='' count=0
   fm_pr_task_id_valid "$id" || return 1
   meta="$state/$id.meta"
   [ -f "$meta" ] && [ ! -L "$meta" ] && [ "$(fm_pr_file_link_count "$meta")" = 1 ] || return 1
@@ -192,12 +231,47 @@ fm_merge_front_project_key_from_meta() {  # <state> <task-id>
     esac
   done < "$meta"
   [ "$count" -eq 1 ] && [ -n "$project" ] || return 1
-  while [ "$project" != "${project%/}" ]; do
-    project=${project%/}
+  fm_merge_front_project_key_from_path "$project"
+}
+
+# Pure read of durable queue state: report whether this PR URL is already bound
+# to a different task in this project. PR registration consults it before it
+# rewrites task metadata or publishes a poll, so a conflict - which no retry can
+# clear - refuses over untouched state instead of over a half-applied
+# registration. Returns 0 when the URL is free or already this task's, 3 on a
+# conflict (with FM_MERGE_FRONT_CONFLICT_TASK naming the holder), 2 on an
+# invalid request, and 1 when the queue cannot be read.
+fm_merge_front_url_conflict() {  # <state> <project-key> <task-id> <pr-url>
+  local state=$1 project=$2 task=$3 raw_url=$4 url index rc=0
+  FM_MERGE_FRONT_CONFLICT_TASK=
+  fm_merge_front_project_key_valid "$project" || return 2
+  fm_pr_task_id_valid "$task" || return 2
+  fm_pr_url_parse "$raw_url" || return 2
+  url=$FM_PR_URL
+  if fm_merge_front_paths "$state" "$project" 0; then
+    :
+  else
+    rc=$?
+    [ "$rc" -eq 2 ] && return 0
+    return 1
+  fi
+  _fm_merge_front_lock_acquire || return 1
+  if ! fm_merge_front_file_load "$project"; then
+    fm_merge_front_unlock
+    return 1
+  fi
+  index=0
+  while [ "$index" -lt "${#FM_MERGE_FRONT_TASKS[@]}" ]; do
+    if [ "${FM_MERGE_FRONT_URLS[$index]}" = "$url" ] \
+      && [ "${FM_MERGE_FRONT_TASKS[$index]}" != "$task" ]; then
+      FM_MERGE_FRONT_CONFLICT_TASK=${FM_MERGE_FRONT_TASKS[$index]}
+      rc=3
+      break
+    fi
+    index=$((index + 1))
   done
-  key=${project##*/}
-  fm_merge_front_project_key_valid "$key" || return 1
-  printf '%s\n' "$key"
+  fm_merge_front_unlock
+  return "$rc"
 }
 
 fm_merge_front_enqueue() {  # <state> <project-key> <task-id> <pr-url>
@@ -425,11 +499,48 @@ fm_merge_front_remove() {  # <state> <project-key> <task-id> <pr-url>
   return "$rc"
 }
 
-fm_merge_front_promote_task() {  # <state> <task-id> <pr-url>
-  local state=$1 task=$2 url=$3 project
+# Retire an identity from whichever project queue holds it when the task's own
+# project key is no longer derivable. Returns 3 when nothing matched anywhere.
+fm_merge_front_drop_anywhere() {  # <state> <task-id> <pr-url>
+  local state=$1 task=$2 url=$3 file project rc dropped=0
+  if fm_merge_front_root_prepare "$state" 0; then
+    :
+  else
+    rc=$?
+    [ "$rc" -eq 2 ] && return 3
+    return 1
+  fi
+  for file in "$FM_MERGE_FRONT_ROOT"/*.queue; do
+    [ -f "$file" ] && [ ! -L "$file" ] || continue
+    project=${file##*/}
+    project=${project%.queue}
+    fm_merge_front_project_key_valid "$project" || continue
+    rc=0
+    fm_merge_front_drop "$state" "$project" "$task" "$url" || rc=$?
+    case "$rc" in
+      0) dropped=1 ;;
+      3) ;;
+      *) return 1 ;;
+    esac
+  done
+  [ "$dropped" -eq 1 ] || return 3
+}
+
+# The one identity-bound retirement entry point for a task leaving the queue -
+# a confirmed merge, or a teardown. It prefers the task's own project key and
+# falls back to a scan of every project queue when the task metadata is already
+# gone, so a completed or torn-down front can never stay queued in front of the
+# live PRs behind it. A missing identity is nothing to do, never a failure.
+fm_merge_front_retire_task() {  # <state> <task-id> <pr-url>
+  local state=$1 task=$2 url=$3 project rc=0
   [ -e "$state/merge-front" ] || [ -L "$state/merge-front" ] || return 0
-  project=$(fm_merge_front_project_key_from_meta "$state" "$task") || return 0
-  fm_merge_front_reconcile_merged "$state" "$project" "$task" "$url"
+  if project=$(fm_merge_front_project_key_from_meta "$state" "$task" 2>/dev/null); then
+    fm_merge_front_reconcile_merged "$state" "$project" "$task" "$url" || return 1
+    [ -z "$FM_MERGE_FRONT_DROPPED_TASK" ] || return 0
+  fi
+  fm_merge_front_drop_anywhere "$state" "$task" "$url" || rc=$?
+  [ "$rc" -ne 3 ] || rc=0
+  return "$rc"
 }
 
 fm_merge_front_checks_json() {  # <github-check-command...>
@@ -454,6 +565,29 @@ fm_merge_front_checks_json() {  # <github-check-command...>
   esac
 }
 
+# Snapshot the current front under the queue lock. The lock is never held
+# across a live GitHub call, so an ordinary enqueue or a confirmed-merge
+# retirement can never queue behind a slow forge read.
+_fm_merge_front_snapshot_front() {  # <project-key>
+  local project=$1
+  FM_MERGE_FRONT_SNAPSHOT_TASK=
+  FM_MERGE_FRONT_SNAPSHOT_URL=
+  _fm_merge_front_lock_acquire || return 1
+  if ! fm_merge_front_file_load "$project"; then
+    fm_merge_front_unlock
+    echo 'error: merge-front queue is invalid' >&2
+    return 1
+  fi
+  if [ "${#FM_MERGE_FRONT_TASKS[@]}" -eq 0 ]; then
+    fm_merge_front_unlock
+    printf 'error: project %s has no merge-front PR\n' "$project" >&2
+    return 1
+  fi
+  FM_MERGE_FRONT_SNAPSHOT_TASK=${FM_MERGE_FRONT_TASKS[0]}
+  FM_MERGE_FRONT_SNAPSHOT_URL=${FM_MERGE_FRONT_URLS[0]}
+  fm_merge_front_unlock
+}
+
 fm_merge_front_greptile_kick() {  # <state> <project-key>
   local state=$1 project=$2 task url provider repo_path number pr_row pr_state base head
   local behind required_json blocked all_json unknown pending rc
@@ -475,21 +609,10 @@ fm_merge_front_greptile_kick() {  # <state> <project-key>
     fi
     return 1
   fi
-  _fm_merge_front_lock_acquire || return 1
-  if ! fm_merge_front_file_load "$project"; then
-    fm_merge_front_unlock
-    echo 'error: merge-front queue is invalid' >&2
-    return 1
-  fi
-  if [ "${#FM_MERGE_FRONT_TASKS[@]}" -eq 0 ]; then
-    fm_merge_front_unlock
-    printf 'error: project %s has no merge-front PR\n' "$project" >&2
-    return 1
-  fi
-  task=${FM_MERGE_FRONT_TASKS[0]}
-  url=${FM_MERGE_FRONT_URLS[0]}
+  _fm_merge_front_snapshot_front "$project" || return 1
+  task=$FM_MERGE_FRONT_SNAPSHOT_TASK
+  url=$FM_MERGE_FRONT_SNAPSHOT_URL
   fm_pr_url_parse "$url" || {
-    fm_merge_front_unlock
     echo 'error: merge-front PR identity is invalid' >&2
     return 1
   }
@@ -497,99 +620,86 @@ fm_merge_front_greptile_kick() {  # <state> <project-key>
   repo_path=$FM_PR_PATH
   number=$FM_PR_NUMBER
   if [ "$provider" != github ]; then
-    fm_merge_front_unlock
     echo 'error: greptile-kick supports GitHub pull requests only' >&2
     return 1
   fi
   if ! pr_row=$(_fm_merge_front_gh gh pr view "$number" \
       --repo "$repo_path" --json state,baseRefName,headRefOid \
       --jq '[.state,.baseRefName,.headRefOid] | @tsv' 2>/dev/null); then
-    fm_merge_front_unlock
     echo 'error: merge-front PR state could not be read' >&2
     return 1
   fi
   IFS=$'\t' read -r pr_state base head <<< "$pr_row"
   if [ "$pr_state" != OPEN ]; then
-    fm_merge_front_unlock
     printf 'error: merge-front PR is not open (state=%s)\n' "${pr_state:-unknown}" >&2
     return 1
   fi
   if [ "$base" != main ]; then
-    fm_merge_front_unlock
     printf 'error: merge-front PR targets %s, not main\n' "${base:-unknown}" >&2
     return 1
   fi
   if ! fm_pr_head_valid "$head"; then
-    fm_merge_front_unlock
     echo 'error: merge-front PR head could not be validated' >&2
     return 1
   fi
   if ! behind=$(_fm_merge_front_gh gh api \
       "repos/$repo_path/compare/main...$head" --jq .behind_by 2>/dev/null); then
-    fm_merge_front_unlock
     echo 'error: merge-front PR freshness could not be read' >&2
     return 1
   fi
   case "$behind" in ''|*[!0-9]*)
-    fm_merge_front_unlock
     echo 'error: merge-front PR freshness was not numeric' >&2
     return 1
     ;;
   esac
   if [ "$behind" -ne 0 ]; then
-    fm_merge_front_unlock
     printf 'error: merge-front PR is behind main (behind_by=%s)\n' "$behind" >&2
     return 1
   fi
-  if ! required_json=$(fm_merge_front_checks_json gh pr checks "$number" \
-      --repo "$repo_path" --required --json name,state); then
-    fm_merge_front_unlock
-    return 1
-  fi
+  required_json=$(fm_merge_front_checks_json gh pr checks "$number" \
+    --repo "$repo_path" --required --json name,state) || return 1
   blocked=$(printf '%s\n' "$required_json" | jq -r \
     '[.[] | select(((.name | ascii_downcase | contains("greptile")) | not) and .state != "SUCCESS") | "\(.name)=\(.state)"] | join(", ")') || {
-      fm_merge_front_unlock
       echo 'error: required check state could not be evaluated' >&2
       return 1
     }
   if [ -n "$blocked" ]; then
-    fm_merge_front_unlock
     printf 'error: non-Greptile required checks are not green: %s\n' "$blocked" >&2
     return 1
   fi
-  if ! all_json=$(fm_merge_front_checks_json gh pr checks "$number" \
-      --repo "$repo_path" --json name,state); then
-    fm_merge_front_unlock
-    return 1
-  fi
+  all_json=$(fm_merge_front_checks_json gh pr checks "$number" \
+    --repo "$repo_path" --json name,state) || return 1
   unknown=$(printf '%s\n' "$all_json" | jq -r \
     '[.[] | select(.name | ascii_downcase | contains("greptile")) | .state | select(. as $state | ["PENDING","QUEUED","IN_PROGRESS","WAITING","REQUESTED","EXPECTED","SUCCESS","FAILURE","ERROR","CANCELLED","SKIPPED","NEUTRAL","TIMED_OUT","ACTION_REQUIRED","STARTUP_FAILURE","STALE"] | index($state) | not)] | unique | join(", ")') || {
-      fm_merge_front_unlock
       echo 'error: Greptile check state could not be evaluated' >&2
       return 1
     }
   if [ -n "$unknown" ]; then
-    fm_merge_front_unlock
     printf 'error: unrecognised Greptile check state: %s\n' "$unknown" >&2
     return 1
   fi
   pending=$(printf '%s\n' "$all_json" | jq -r \
     '[.[] | select(.name | ascii_downcase | contains("greptile")) | .state | select(. == "PENDING" or . == "QUEUED" or . == "IN_PROGRESS" or . == "WAITING" or . == "REQUESTED" or . == "EXPECTED")] | length') || {
-      fm_merge_front_unlock
       echo 'error: Greptile pending state could not be evaluated' >&2
       return 1
     }
   if [ "$pending" -ne 0 ]; then
-    fm_merge_front_unlock
     echo 'error: Greptile review is already pending' >&2
     return 1
   fi
+  # The structural gate is re-read under the lock immediately before the single
+  # side effect: the queue may have promoted, rebound, or retired this identity
+  # while the GitHub reads above ran, and only the current front may be kicked.
+  _fm_merge_front_snapshot_front "$project" || return 1
+  if [ "$FM_MERGE_FRONT_SNAPSHOT_TASK" != "$task" ] \
+    || [ "$FM_MERGE_FRONT_SNAPSHOT_URL" != "$url" ]; then
+    printf 'error: merge-front PR is no longer the front of project %s\n' "$project" >&2
+    return 1
+  fi
   if ! _fm_merge_front_gh gh pr comment "$number" \
-      --repo "$repo_path" --body '@greptile review'; then
-    fm_merge_front_unlock
+      --repo "$repo_path" --body '@greptile review' >/dev/null; then
     echo 'error: Greptile review comment failed' >&2
     return 1
   fi
-  fm_merge_front_unlock
   printf 'kicked=%s\t%s\n' "$task" "$url"
 }

--- a/bin/fm-merge-front-lib.sh
+++ b/bin/fm-merge-front-lib.sh
@@ -349,7 +349,7 @@ fm_merge_front_status() {  # <state> <project-key>
 }
 
 fm_merge_front_promote() {  # <state> <project-key>
-  local state=$1 project=$2 old_task old_url next_task=none next_url= rc
+  local state=$1 project=$2 task url next_task=none next_url= rc
   local provider host path number merged
   fm_merge_front_project_key_valid "$project" || return 2
   if fm_merge_front_paths "$state" "$project" 0; then
@@ -370,26 +370,33 @@ fm_merge_front_promote() {  # <state> <project-key>
     printf 'promoted=none\nfront=none\n'
     return 0
   fi
-  old_task=${FM_MERGE_FRONT_TASKS[0]}
-  old_url=${FM_MERGE_FRONT_URLS[0]}
-  fm_pr_url_parse "$old_url" || {
-    fm_merge_front_unlock
-    return 1
-  }
+  task=${FM_MERGE_FRONT_TASKS[0]}
+  url=${FM_MERGE_FRONT_URLS[0]}
+  fm_merge_front_unlock
+  fm_pr_url_parse "$url" || return 1
   provider=$FM_PR_PROVIDER
   host=$FM_PR_HOST
   path=$FM_PR_PATH
   number=$FM_PR_NUMBER
-  merged=$("$_FM_MERGE_FRONT_LIB_DIR/fm-pr-poll.sh" --validated \
-    "$provider" "$old_url" "$host" "$path" "$number" 2>/dev/null) || merged=
+  merged=$(_fm_merge_front_gh "$_FM_MERGE_FRONT_LIB_DIR/fm-pr-poll.sh" --validated \
+    "$provider" "$url" "$host" "$path" "$number" 2>/dev/null) || merged=
   if [ "$merged" != merged ]; then
-    fm_merge_front_unlock
-    printf 'error: merge-front PR is not confirmed merged: %s\n' "$old_url" >&2
+    printf 'error: merge-front PR is not confirmed merged: %s\n' "$url" >&2
     return 1
   fi
-  FM_MERGE_FRONT_TASKS=("${FM_MERGE_FRONT_TASKS[@]:1}")
-  FM_MERGE_FRONT_URLS=("${FM_MERGE_FRONT_URLS[@]:1}")
-  if ! fm_merge_front_file_write "$project"; then
+  _fm_merge_front_lock_acquire || return 1
+  if ! fm_merge_front_file_load "$project"; then
+    fm_merge_front_unlock
+    return 1
+  fi
+  if [ "${#FM_MERGE_FRONT_TASKS[@]}" -eq 0 ] \
+    || [ "${FM_MERGE_FRONT_TASKS[0]}" != "$task" ] \
+    || [ "${FM_MERGE_FRONT_URLS[0]}" != "$url" ]; then
+    fm_merge_front_unlock
+    printf 'error: merge-front PR is no longer the front of project %s\n' "$project" >&2
+    return 1
+  fi
+  if ! _fm_merge_front_drop_locked "$project" "$task" "$url"; then
     fm_merge_front_unlock
     return 1
   fi
@@ -398,7 +405,7 @@ fm_merge_front_promote() {  # <state> <project-key>
     next_url=${FM_MERGE_FRONT_URLS[0]}
   fi
   fm_merge_front_unlock
-  printf 'promoted=%s\t%s\n' "$old_task" "$old_url"
+  printf 'promoted=%s\t%s\n' "$task" "$url"
   if [ "$next_task" = none ]; then
     printf 'front=none\n'
   else
@@ -406,9 +413,12 @@ fm_merge_front_promote() {  # <state> <project-key>
   fi
 }
 
-# Retire the queue entries bound to one task or one PR URL, wherever they sit.
-# Sets FM_MERGE_FRONT_DROPPED_* to the first retired identity and leaves the
-# loaded queue arrays holding the survivors. Returns 3 when nothing matched.
+# Retire the one queue entry bound to exactly this task and this canonical URL.
+# Task IDs and URLs are each unique within a queue, so the pair identifies at
+# most one row: a stale or mismatched identity retires nothing rather than
+# silently dropping some other task's live entry. Sets FM_MERGE_FRONT_DROPPED_*
+# to the retired identity and leaves the loaded arrays holding the survivors.
+# Returns 3 when the pair is not queued.
 _fm_merge_front_drop_locked() {  # <project-key> <task-id> <canonical-url>
   local project=$1 task=$2 url=$3 index=0 removed=0
   local tasks=() urls=()
@@ -416,11 +426,9 @@ _fm_merge_front_drop_locked() {  # <project-key> <task-id> <canonical-url>
   FM_MERGE_FRONT_DROPPED_URL=
   while [ "$index" -lt "${#FM_MERGE_FRONT_TASKS[@]}" ]; do
     if [ "${FM_MERGE_FRONT_TASKS[$index]}" = "$task" ] \
-      || [ "${FM_MERGE_FRONT_URLS[$index]}" = "$url" ]; then
-      if [ "$removed" -eq 0 ]; then
-        FM_MERGE_FRONT_DROPPED_TASK=${FM_MERGE_FRONT_TASKS[$index]}
-        FM_MERGE_FRONT_DROPPED_URL=${FM_MERGE_FRONT_URLS[$index]}
-      fi
+      && [ "${FM_MERGE_FRONT_URLS[$index]}" = "$url" ]; then
+      FM_MERGE_FRONT_DROPPED_TASK=${FM_MERGE_FRONT_TASKS[$index]}
+      FM_MERGE_FRONT_DROPPED_URL=${FM_MERGE_FRONT_URLS[$index]}
       removed=$((removed + 1))
     else
       tasks+=("${FM_MERGE_FRONT_TASKS[$index]}")
@@ -500,9 +508,12 @@ fm_merge_front_remove() {  # <state> <project-key> <task-id> <pr-url>
 }
 
 # Retire an identity from whichever project queue holds it when the task's own
-# project key is no longer derivable. Returns 3 when nothing matched anywhere.
+# project key is no longer derivable. One busy or unreadable queue never aborts
+# the scan: every queue is examined, and the failure only surfaces when no queue
+# yielded the drop. Returns 3 when nothing matched anywhere, 1 when the target
+# could not be safely retired.
 fm_merge_front_drop_anywhere() {  # <state> <task-id> <pr-url>
-  local state=$1 task=$2 url=$3 file project rc dropped=0
+  local state=$1 task=$2 url=$3 file project rc dropped=0 failed=0
   if fm_merge_front_root_prepare "$state" 0; then
     :
   else
@@ -520,10 +531,12 @@ fm_merge_front_drop_anywhere() {  # <state> <task-id> <pr-url>
     case "$rc" in
       0) dropped=1 ;;
       3) ;;
-      *) return 1 ;;
+      *) failed=1 ;;
     esac
   done
-  [ "$dropped" -eq 1 ] || return 3
+  [ "$dropped" -eq 0 ] || return 0
+  [ "$failed" -eq 0 ] || return 1
+  return 3
 }
 
 # The one identity-bound retirement entry point for a task leaving the queue -
@@ -659,7 +672,7 @@ fm_merge_front_greptile_kick() {  # <state> <project-key>
   required_json=$(fm_merge_front_checks_json gh pr checks "$number" \
     --repo "$repo_path" --required --json name,state) || return 1
   blocked=$(printf '%s\n' "$required_json" | jq -r \
-    '[.[] | select(((.name | ascii_downcase | contains("greptile")) | not) and .state != "SUCCESS") | "\(.name)=\(.state)"] | join(", ")') || {
+    '[.[] | select(((.name | ascii_downcase | contains("greptile")) | not) and (.state as $satisfied | ["SUCCESS","SKIPPED","NEUTRAL"] | index($satisfied) | not)) | "\(.name)=\(.state)"] | join(", ")') || {
       echo 'error: required check state could not be evaluated' >&2
       return 1
     }

--- a/bin/fm-merge-front-lib.sh
+++ b/bin/fm-merge-front-lib.sh
@@ -1,0 +1,521 @@
+#!/usr/bin/env bash
+# Implementation helpers for the merge-front queue whose public contract and
+# private state schema are owned by bin/fm-merge-front.sh's header.
+
+_FM_MERGE_FRONT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if ! command -v fm_pr_url_parse >/dev/null 2>&1; then
+  # shellcheck source=bin/fm-pr-lib.sh
+  . "$_FM_MERGE_FRONT_LIB_DIR/fm-pr-lib.sh"
+fi
+if ! command -v fm_lock_acquire_wait >/dev/null 2>&1; then
+  # shellcheck source=bin/fm-wake-lib.sh
+  . "$_FM_MERGE_FRONT_LIB_DIR/fm-wake-lib.sh"
+fi
+
+FM_MERGE_FRONT_ROOT=
+FM_MERGE_FRONT_FILE=
+FM_MERGE_FRONT_LOCK=
+FM_MERGE_FRONT_STATE_DEVICE=
+FM_MERGE_FRONT_TASKS=()
+FM_MERGE_FRONT_URLS=()
+FM_MERGE_FRONT_EXISTS=0
+
+fm_merge_front_project_key_valid() {
+  local key=${1-}
+  fm_task_id_path_safe "$key" && [ "${#key}" -le 100 ]
+}
+
+fm_merge_front_root_prepare() {  # <state> <create: 0|1>
+  local state=$1 create=$2 mode created=0
+  [ -d "$state" ] && [ ! -L "$state" ] || return 1
+  FM_MERGE_FRONT_STATE_DEVICE=$(fm_pr_file_device "$state") || return 1
+  FM_MERGE_FRONT_ROOT="$state/merge-front"
+  if [ ! -e "$FM_MERGE_FRONT_ROOT" ] && [ ! -L "$FM_MERGE_FRONT_ROOT" ]; then
+    [ "$create" -eq 1 ] || return 2
+    umask 077
+    if mkdir "$FM_MERGE_FRONT_ROOT" 2>/dev/null; then
+      created=1
+    fi
+  fi
+  [ -d "$FM_MERGE_FRONT_ROOT" ] && [ ! -L "$FM_MERGE_FRONT_ROOT" ] || return 1
+  [ "$created" -eq 0 ] || chmod 0700 "$FM_MERGE_FRONT_ROOT" 2>/dev/null || return 1
+  mode=$(fm_pr_file_mode "$FM_MERGE_FRONT_ROOT") || return 1
+  [ "$mode" = 700 ] || return 1
+  [ "$(fm_pr_file_device "$FM_MERGE_FRONT_ROOT")" = "$FM_MERGE_FRONT_STATE_DEVICE" ]
+}
+
+fm_merge_front_paths() {  # <state> <project-key> <create: 0|1>
+  local state=$1 project=$2 create=$3
+  fm_merge_front_project_key_valid "$project" || return 1
+  fm_merge_front_root_prepare "$state" "$create" || return $?
+  FM_MERGE_FRONT_FILE="$FM_MERGE_FRONT_ROOT/$project.queue"
+  FM_MERGE_FRONT_LOCK="$FM_MERGE_FRONT_ROOT/.$project.lock"
+}
+
+fm_merge_front_file_load() {  # <project-key>
+  local project=$1 line version='' stored_project='' task url tab
+  local line_number=0 bytes seen_tasks seen_urls
+  FM_MERGE_FRONT_TASKS=()
+  FM_MERGE_FRONT_URLS=()
+  FM_MERGE_FRONT_EXISTS=0
+  [ -e "$FM_MERGE_FRONT_FILE" ] || [ -L "$FM_MERGE_FRONT_FILE" ] || return 0
+  fm_pr_private_file_valid "$FM_MERGE_FRONT_FILE" 600 "$FM_MERGE_FRONT_STATE_DEVICE" || return 1
+  bytes=$(wc -c < "$FM_MERGE_FRONT_FILE" 2>/dev/null | tr -d '[:space:]') || return 1
+  case "$bytes" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$bytes" -le 1048576 ] || return 1
+  tab=$'\t'
+  seen_tasks=$'\n'
+  seen_urls=$'\n'
+  while IFS= read -r line || [ -n "$line" ]; do
+    line_number=$((line_number + 1))
+    case "$line_number" in
+      1) version=$line ;;
+      2) stored_project=${line#project=} ;;
+      *)
+        case "$line" in
+          task=*"$tab"url=*) ;;
+          *) return 1 ;;
+        esac
+        task=${line%%"$tab"*}
+        task=${task#task=}
+        url=${line#*"$tab"}
+        url=${url#url=}
+        case "$url" in *"$tab"*) return 1 ;; esac
+        fm_pr_task_id_valid "$task" || return 1
+        fm_pr_url_parse "$url" || return 1
+        case "$seen_tasks" in *$'\n'"$task"$'\n'*) return 1 ;; esac
+        case "$seen_urls" in *$'\n'"$url"$'\n'*) return 1 ;; esac
+        seen_tasks="${seen_tasks}${task}"$'\n'
+        seen_urls="${seen_urls}${url}"$'\n'
+        FM_MERGE_FRONT_TASKS+=("$task")
+        FM_MERGE_FRONT_URLS+=("$url")
+        ;;
+    esac
+  done < "$FM_MERGE_FRONT_FILE"
+  [ "$line_number" -ge 2 ] || return 1
+  [ "$version" = fm-merge-front-v1 ] || return 1
+  [ "$stored_project" = "$project" ] || return 1
+  FM_MERGE_FRONT_EXISTS=1
+}
+
+fm_merge_front_file_write() {  # <project-key>
+  local project=$1 tmp='' index
+  fm_pr_regular_destination_on_device_or_absent \
+    "$FM_MERGE_FRONT_FILE" "$FM_MERGE_FRONT_STATE_DEVICE" || return 1
+  umask 077
+  tmp=$(mktemp "$FM_MERGE_FRONT_ROOT/.$project.queue.XXXXXX") || return 1
+  if ! {
+      printf 'fm-merge-front-v1\nproject=%s\n' "$project"
+      index=0
+      while [ "$index" -lt "${#FM_MERGE_FRONT_TASKS[@]}" ]; do
+        printf 'task=%s\turl=%s\n' \
+          "${FM_MERGE_FRONT_TASKS[$index]}" "${FM_MERGE_FRONT_URLS[$index]}"
+        index=$((index + 1))
+      done
+    } > "$tmp" \
+    || ! chmod 0600 "$tmp" \
+    || ! fm_pr_private_file_valid "$tmp" 600 "$FM_MERGE_FRONT_STATE_DEVICE"; then
+    rm -f -- "$tmp"
+    return 1
+  fi
+  FM_MERGE_FRONT_FILE=$tmp
+  if ! fm_merge_front_file_load "$project"; then
+    FM_MERGE_FRONT_FILE="$FM_MERGE_FRONT_ROOT/$project.queue"
+    rm -f -- "$tmp"
+    return 1
+  fi
+  FM_MERGE_FRONT_FILE="$FM_MERGE_FRONT_ROOT/$project.queue"
+  if ! fm_pr_regular_destination_on_device_or_absent \
+      "$FM_MERGE_FRONT_FILE" "$FM_MERGE_FRONT_STATE_DEVICE" \
+    || ! mv -f -- "$tmp" "$FM_MERGE_FRONT_FILE" \
+    || ! fm_merge_front_file_load "$project"; then
+    rm -f -- "$tmp"
+    return 1
+  fi
+}
+
+fm_merge_front_lock_and_load() {  # <state> <project-key> <create: 0|1>
+  local state=$1 project=$2 create=$3 rc
+  if fm_merge_front_paths "$state" "$project" "$create"; then
+    :
+  else
+    rc=$?
+    return "$rc"
+  fi
+  fm_lock_acquire_wait "$FM_MERGE_FRONT_LOCK" || return 1
+  if ! fm_merge_front_file_load "$project"; then
+    fm_lock_release "$FM_MERGE_FRONT_LOCK"
+    return 1
+  fi
+}
+
+fm_merge_front_unlock() {
+  fm_lock_release "$FM_MERGE_FRONT_LOCK"
+}
+
+fm_merge_front_project_key_from_meta() {  # <state> <task-id>
+  local state=$1 id=$2 meta line project='' count=0 key
+  fm_pr_task_id_valid "$id" || return 1
+  meta="$state/$id.meta"
+  [ -f "$meta" ] && [ ! -L "$meta" ] && [ "$(fm_pr_file_link_count "$meta")" = 1 ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      project=*)
+        count=$((count + 1))
+        project=${line#project=}
+        ;;
+    esac
+  done < "$meta"
+  [ "$count" -eq 1 ] && [ -n "$project" ] || return 1
+  while [ "$project" != "${project%/}" ]; do
+    project=${project%/}
+  done
+  key=${project##*/}
+  fm_merge_front_project_key_valid "$key" || return 1
+  printf '%s\n' "$key"
+}
+
+fm_merge_front_enqueue() {  # <state> <project-key> <task-id> <pr-url>
+  local state=$1 project=$2 task=$3 raw_url=$4 url index role
+  fm_merge_front_project_key_valid "$project" || return 2
+  fm_pr_task_id_valid "$task" || return 2
+  fm_pr_url_parse "$raw_url" || return 2
+  url=$FM_PR_URL
+  fm_merge_front_lock_and_load "$state" "$project" 1 || return 1
+  index=0
+  while [ "$index" -lt "${#FM_MERGE_FRONT_TASKS[@]}" ]; do
+    if [ "${FM_MERGE_FRONT_TASKS[$index]}" = "$task" ] \
+      || [ "${FM_MERGE_FRONT_URLS[$index]}" = "$url" ]; then
+      if [ "${FM_MERGE_FRONT_TASKS[$index]}" != "$task" ] \
+        || [ "${FM_MERGE_FRONT_URLS[$index]}" != "$url" ]; then
+        printf 'error: merge-front queue conflict for project %s\n' "$project" >&2
+        fm_merge_front_unlock
+        return 1
+      fi
+      role=parked
+      [ "$index" -eq 0 ] && role=front
+      fm_merge_front_unlock
+      printf '%s=%s\t%s\n' "$role" "$task" "$url"
+      return 0
+    fi
+    index=$((index + 1))
+  done
+  FM_MERGE_FRONT_TASKS+=("$task")
+  FM_MERGE_FRONT_URLS+=("$url")
+  if ! fm_merge_front_file_write "$project"; then
+    fm_merge_front_unlock
+    return 1
+  fi
+  index=$((${#FM_MERGE_FRONT_TASKS[@]} - 1))
+  role=parked
+  [ "$index" -eq 0 ] && role=front
+  fm_merge_front_unlock
+  printf '%s=%s\t%s\n' "$role" "$task" "$url"
+}
+
+fm_merge_front_status() {  # <state> <project-key>
+  local state=$1 project=$2 index rc
+  fm_merge_front_project_key_valid "$project" || return 2
+  if fm_merge_front_paths "$state" "$project" 0; then
+    :
+  else
+    rc=$?
+    [ "$rc" -eq 2 ] || return 1
+    printf 'project=%s\nfront=none\n' "$project"
+    return 0
+  fi
+  fm_lock_acquire_wait "$FM_MERGE_FRONT_LOCK" || return 1
+  if ! fm_merge_front_file_load "$project"; then
+    fm_merge_front_unlock
+    return 1
+  fi
+  printf 'project=%s\n' "$project"
+  if [ "${#FM_MERGE_FRONT_TASKS[@]}" -eq 0 ]; then
+    printf 'front=none\n'
+  else
+    printf 'front=%s\t%s\n' "${FM_MERGE_FRONT_TASKS[0]}" "${FM_MERGE_FRONT_URLS[0]}"
+    index=1
+    while [ "$index" -lt "${#FM_MERGE_FRONT_TASKS[@]}" ]; do
+      printf 'parked=%s\t%s\n' \
+        "${FM_MERGE_FRONT_TASKS[$index]}" "${FM_MERGE_FRONT_URLS[$index]}"
+      index=$((index + 1))
+    done
+  fi
+  fm_merge_front_unlock
+}
+
+fm_merge_front_promote() {  # <state> <project-key>
+  local state=$1 project=$2 old_task old_url next_task=none next_url= rc
+  local provider host path number merged
+  fm_merge_front_project_key_valid "$project" || return 2
+  if fm_merge_front_paths "$state" "$project" 0; then
+    :
+  else
+    rc=$?
+    [ "$rc" -eq 2 ] || return 1
+    printf 'promoted=none\nfront=none\n'
+    return 0
+  fi
+  fm_lock_acquire_wait "$FM_MERGE_FRONT_LOCK" || return 1
+  if ! fm_merge_front_file_load "$project"; then
+    fm_merge_front_unlock
+    return 1
+  fi
+  if [ "${#FM_MERGE_FRONT_TASKS[@]}" -eq 0 ]; then
+    fm_merge_front_unlock
+    printf 'promoted=none\nfront=none\n'
+    return 0
+  fi
+  old_task=${FM_MERGE_FRONT_TASKS[0]}
+  old_url=${FM_MERGE_FRONT_URLS[0]}
+  fm_pr_url_parse "$old_url" || {
+    fm_merge_front_unlock
+    return 1
+  }
+  provider=$FM_PR_PROVIDER
+  host=$FM_PR_HOST
+  path=$FM_PR_PATH
+  number=$FM_PR_NUMBER
+  merged=$("$_FM_MERGE_FRONT_LIB_DIR/fm-pr-poll.sh" --validated \
+    "$provider" "$old_url" "$host" "$path" "$number" 2>/dev/null) || merged=
+  if [ "$merged" != merged ]; then
+    fm_merge_front_unlock
+    printf 'error: merge-front PR is not confirmed merged: %s\n' "$old_url" >&2
+    return 1
+  fi
+  FM_MERGE_FRONT_TASKS=("${FM_MERGE_FRONT_TASKS[@]:1}")
+  FM_MERGE_FRONT_URLS=("${FM_MERGE_FRONT_URLS[@]:1}")
+  if ! fm_merge_front_file_write "$project"; then
+    fm_merge_front_unlock
+    return 1
+  fi
+  if [ "${#FM_MERGE_FRONT_TASKS[@]}" -gt 0 ]; then
+    next_task=${FM_MERGE_FRONT_TASKS[0]}
+    next_url=${FM_MERGE_FRONT_URLS[0]}
+  fi
+  fm_merge_front_unlock
+  printf 'promoted=%s\t%s\n' "$old_task" "$old_url"
+  if [ "$next_task" = none ]; then
+    printf 'front=none\n'
+  else
+    printf 'front=%s\t%s\n' "$next_task" "$next_url"
+  fi
+}
+
+fm_merge_front_promote_exact() {  # <state> <project-key> <task-id> <pr-url>
+  local state=$1 project=$2 task=$3 raw_url=$4 url index found=-1 rc
+  fm_merge_front_project_key_valid "$project" || return 2
+  fm_pr_task_id_valid "$task" || return 2
+  fm_pr_url_parse "$raw_url" || return 2
+  url=$FM_PR_URL
+  if fm_merge_front_paths "$state" "$project" 0; then
+    :
+  else
+    rc=$?
+    [ "$rc" -eq 2 ] && return 0
+    return 1
+  fi
+  fm_lock_acquire_wait "$FM_MERGE_FRONT_LOCK" || return 1
+  if ! fm_merge_front_file_load "$project"; then
+    fm_merge_front_unlock
+    return 1
+  fi
+  index=0
+  while [ "$index" -lt "${#FM_MERGE_FRONT_TASKS[@]}" ]; do
+    if [ "${FM_MERGE_FRONT_TASKS[$index]}" = "$task" ] \
+      || [ "${FM_MERGE_FRONT_URLS[$index]}" = "$url" ]; then
+      if [ "${FM_MERGE_FRONT_TASKS[$index]}" != "$task" ] \
+        || [ "${FM_MERGE_FRONT_URLS[$index]}" != "$url" ]; then
+        fm_merge_front_unlock
+        return 1
+      fi
+      found=$index
+      break
+    fi
+    index=$((index + 1))
+  done
+  if [ "$found" -eq -1 ]; then
+    fm_merge_front_unlock
+    return 0
+  fi
+  if [ "$found" -ne 0 ]; then
+    fm_merge_front_unlock
+    return 3
+  fi
+  FM_MERGE_FRONT_TASKS=("${FM_MERGE_FRONT_TASKS[@]:1}")
+  FM_MERGE_FRONT_URLS=("${FM_MERGE_FRONT_URLS[@]:1}")
+  if ! fm_merge_front_file_write "$project"; then
+    fm_merge_front_unlock
+    return 1
+  fi
+  fm_merge_front_unlock
+}
+
+fm_merge_front_promote_task() {  # <state> <task-id> <pr-url>
+  local state=$1 task=$2 url=$3 project
+  [ -e "$state/merge-front" ] || [ -L "$state/merge-front" ] || return 0
+  project=$(fm_merge_front_project_key_from_meta "$state" "$task") || return 0
+  fm_merge_front_promote_exact "$state" "$project" "$task" "$url"
+}
+
+fm_merge_front_checks_json() {  # <github-check-command...>
+  local output
+  if output=$(GH_PAGER=cat GH_PROMPT_DISABLED=1 "$@" 2>&1); then
+    :
+  fi
+  if printf '%s\n' "$output" | jq -e \
+      'type == "array" and all(.[]; type == "object" and (.name | type == "string") and (.state | type == "string"))' \
+      >/dev/null 2>&1; then
+    printf '%s\n' "$output"
+    return 0
+  fi
+  case "$output" in
+    "no required checks reported on "*" branch"|"no checks reported on "*" branch")
+      printf '[]\n'
+      ;;
+    *)
+      printf 'error: GitHub checks could not be read: %s\n' "${output:-no output}" >&2
+      return 1
+      ;;
+  esac
+}
+
+fm_merge_front_greptile_kick() {  # <state> <project-key>
+  local state=$1 project=$2 task url provider repo_path number pr_row pr_state base head
+  local behind required_json blocked all_json unknown pending rc
+  fm_merge_front_project_key_valid "$project" || return 2
+  command -v gh >/dev/null 2>&1 || {
+    echo 'error: greptile-kick requires gh on PATH' >&2
+    return 1
+  }
+  command -v jq >/dev/null 2>&1 || {
+    echo 'error: greptile-kick requires jq on PATH' >&2
+    return 1
+  }
+  if fm_merge_front_paths "$state" "$project" 0; then
+    :
+  else
+    rc=$?
+    if [ "$rc" -eq 2 ]; then
+      printf 'error: project %s has no merge-front queue\n' "$project" >&2
+    fi
+    return 1
+  fi
+  fm_lock_acquire_wait "$FM_MERGE_FRONT_LOCK" || return 1
+  if ! fm_merge_front_file_load "$project"; then
+    fm_merge_front_unlock
+    echo 'error: merge-front queue is invalid' >&2
+    return 1
+  fi
+  if [ "${#FM_MERGE_FRONT_TASKS[@]}" -eq 0 ]; then
+    fm_merge_front_unlock
+    printf 'error: project %s has no merge-front PR\n' "$project" >&2
+    return 1
+  fi
+  task=${FM_MERGE_FRONT_TASKS[0]}
+  url=${FM_MERGE_FRONT_URLS[0]}
+  fm_pr_url_parse "$url" || {
+    fm_merge_front_unlock
+    echo 'error: merge-front PR identity is invalid' >&2
+    return 1
+  }
+  provider=$FM_PR_PROVIDER
+  repo_path=$FM_PR_PATH
+  number=$FM_PR_NUMBER
+  if [ "$provider" != github ]; then
+    fm_merge_front_unlock
+    echo 'error: greptile-kick supports GitHub pull requests only' >&2
+    return 1
+  fi
+  if ! pr_row=$(GH_PAGER=cat GH_PROMPT_DISABLED=1 gh pr view "$number" \
+      --repo "$repo_path" --json state,baseRefName,headRefOid \
+      --jq '[.state,.baseRefName,.headRefOid] | @tsv' 2>/dev/null); then
+    fm_merge_front_unlock
+    echo 'error: merge-front PR state could not be read' >&2
+    return 1
+  fi
+  IFS=$'\t' read -r pr_state base head <<< "$pr_row"
+  if [ "$pr_state" != OPEN ]; then
+    fm_merge_front_unlock
+    printf 'error: merge-front PR is not open (state=%s)\n' "${pr_state:-unknown}" >&2
+    return 1
+  fi
+  if [ "$base" != main ]; then
+    fm_merge_front_unlock
+    printf 'error: merge-front PR targets %s, not main\n' "${base:-unknown}" >&2
+    return 1
+  fi
+  if ! fm_pr_head_valid "$head"; then
+    fm_merge_front_unlock
+    echo 'error: merge-front PR head could not be validated' >&2
+    return 1
+  fi
+  if ! behind=$(GH_PAGER=cat GH_PROMPT_DISABLED=1 gh api \
+      "repos/$repo_path/compare/main...$head" --jq .behind_by 2>/dev/null); then
+    fm_merge_front_unlock
+    echo 'error: merge-front PR freshness could not be read' >&2
+    return 1
+  fi
+  case "$behind" in ''|*[!0-9]*)
+    fm_merge_front_unlock
+    echo 'error: merge-front PR freshness was not numeric' >&2
+    return 1
+    ;;
+  esac
+  if [ "$behind" -ne 0 ]; then
+    fm_merge_front_unlock
+    printf 'error: merge-front PR is behind main (behind_by=%s)\n' "$behind" >&2
+    return 1
+  fi
+  if ! required_json=$(fm_merge_front_checks_json gh pr checks "$number" \
+      --repo "$repo_path" --required --json name,state); then
+    fm_merge_front_unlock
+    return 1
+  fi
+  blocked=$(printf '%s\n' "$required_json" | jq -r \
+    '[.[] | select(((.name | ascii_downcase | contains("greptile")) | not) and .state != "SUCCESS") | "\(.name)=\(.state)"] | join(", ")') || {
+      fm_merge_front_unlock
+      echo 'error: required check state could not be evaluated' >&2
+      return 1
+    }
+  if [ -n "$blocked" ]; then
+    fm_merge_front_unlock
+    printf 'error: non-Greptile required checks are not green: %s\n' "$blocked" >&2
+    return 1
+  fi
+  if ! all_json=$(fm_merge_front_checks_json gh pr checks "$number" \
+      --repo "$repo_path" --json name,state); then
+    fm_merge_front_unlock
+    return 1
+  fi
+  unknown=$(printf '%s\n' "$all_json" | jq -r \
+    '[.[] | select(.name | ascii_downcase | contains("greptile")) | .state | select(. as $state | ["PENDING","QUEUED","IN_PROGRESS","WAITING","REQUESTED","EXPECTED","SUCCESS","FAILURE","CANCELLED","SKIPPED","NEUTRAL","TIMED_OUT","ACTION_REQUIRED","STARTUP_FAILURE","STALE"] | index($state) | not)] | unique | join(", ")') || {
+      fm_merge_front_unlock
+      echo 'error: Greptile check state could not be evaluated' >&2
+      return 1
+    }
+  if [ -n "$unknown" ]; then
+    fm_merge_front_unlock
+    printf 'error: unrecognised Greptile check state: %s\n' "$unknown" >&2
+    return 1
+  fi
+  pending=$(printf '%s\n' "$all_json" | jq -r \
+    '[.[] | select(.name | ascii_downcase | contains("greptile")) | .state | select(. == "PENDING" or . == "QUEUED" or . == "IN_PROGRESS" or . == "WAITING" or . == "REQUESTED" or . == "EXPECTED")] | length') || {
+      fm_merge_front_unlock
+      echo 'error: Greptile pending state could not be evaluated' >&2
+      return 1
+    }
+  if [ "$pending" -ne 0 ]; then
+    fm_merge_front_unlock
+    echo 'error: Greptile review is already pending' >&2
+    return 1
+  fi
+  if ! GH_PAGER=cat GH_PROMPT_DISABLED=1 gh pr comment "$number" \
+      --repo "$repo_path" --body '@greptile review'; then
+    fm_merge_front_unlock
+    echo 'error: Greptile review comment failed' >&2
+    return 1
+  fi
+  fm_merge_front_unlock
+  printf 'kicked=%s\t%s\n' "$task" "$url"
+}

--- a/bin/fm-merge-front.sh
+++ b/bin/fm-merge-front.sh
@@ -14,12 +14,17 @@
 # and rebinds a task in place, keeping its queue position, when that same task
 # opens a replacement PR; it refuses only a URL already bound to another task.
 # promote reuses the canonical merge poll to fail closed until the front is
-# confirmed merged, then removes exactly that entry and exposes the next one.
+# confirmed merged, then removes exactly that entry and exposes the next one. It
+# snapshots the front under the lock, releases it for the bounded merge poll, and
+# reacquires it to confirm the same identity is still the front before removing
+# it, so a front that changed meanwhile is refused rather than mis-promoted.
 #
 # remove is the operator recovery path for a queued PR that will never merge -
-# a closed or superseded PR, or a torn-down task. It retires exactly the named
-# identity wherever it sits and advances nothing by itself, so retiring a stuck
-# front simply exposes the next entry and unblocks the project. Teardown and a
+# a closed or superseded PR, or a torn-down task. Every retirement is keyed on
+# the exact task and canonical URL together, never either alone, so at most the
+# one named row is retired and a stale identity retires nothing rather than
+# dropping another task's live entry. It advances nothing by itself, so retiring
+# a stuck front simply exposes the next entry and unblocks the project. Teardown and a
 # confirmed merge whose task metadata is already gone reach the same retirement
 # automatically (bin/fm-teardown.sh, bin/fm-merge-outcome-lib.sh), scanning every
 # project queue when the task's own project key can no longer be derived, so a
@@ -67,7 +72,9 @@
 # meanwhile is refused rather than kicked.
 # It refuses unless the queued PR is the first entry (therefore has no preceding
 # entry), is open against main, has behind_by=0 compared with main, has every
-# non-Greptile required check at SUCCESS, and has no pending Greptile check. Any
+# non-Greptile required check satisfied, and has no pending Greptile check. A
+# required check counts as satisfied at SUCCESS, SKIPPED, or NEUTRAL - the states
+# GitHub's own merge gate accepts - and blocks at every other state. Any
 # unreadable or unrecognised state fails closed. Its sole action is one explicit
 # `gh pr comment <number> --repo <owner/repo> --body "@greptile review"`.
 # Greploop's separate follow-up trigger remains unchanged: a finished Greptile

--- a/bin/fm-merge-front.sh
+++ b/bin/fm-merge-front.sh
@@ -6,15 +6,27 @@
 #   fm-merge-front.sh enqueue <project-key> <task-id> <pr-url>
 #   fm-merge-front.sh status <project-key>
 #   fm-merge-front.sh promote <project-key>
+#   fm-merge-front.sh remove <project-key> <task-id> <pr-url>
 #   fm-merge-front.sh greptile-kick <project-key>
 #
 # Each project has exactly one ordered queue. Its first entry is the front and
 # every later entry is parked. enqueue is idempotent for one exact task/URL pair
-# and refuses a task or URL rebound to another pair. promote reuses the canonical
-# merge poll to fail closed until the front is confirmed merged, then removes
-# exactly that entry and exposes the next one. The shared already-confirmed
-# merge-outcome path uses an identity-bound variant and refuses to remove an
-# out-of-order merged entry.
+# and rebinds a task in place, keeping its queue position, when that same task
+# opens a replacement PR; it refuses only a URL already bound to another task.
+# promote reuses the canonical merge poll to fail closed until the front is
+# confirmed merged, then removes exactly that entry and exposes the next one.
+#
+# remove is the operator recovery path for a queued PR that will never merge -
+# a closed or superseded PR, or a torn-down task. It retires exactly the named
+# identity wherever it sits and advances nothing by itself, so retiring a stuck
+# front simply exposes the next entry and unblocks the project.
+#
+# The shared already-confirmed merge-outcome path uses the same identity-bound
+# retirement. A confirmed merge is a fact the queue may never veto: an
+# out-of-order merged entry is removed where it sits with the current front left
+# untouched, and an unqueued identity is nothing to do. That path reports queue
+# reconciliation as advisory, so no queue state can suppress or replay a merge
+# already published to supervision.
 #
 # Durable private state lives at state/merge-front/<project-key>.queue under a
 # mode-0700 directory. Each single-link mode-0600 file has this schema:
@@ -27,6 +39,11 @@
 # and validate the result. Project keys and task IDs are confined path-safe
 # slugs; PR/MR URLs use bin/fm-pr-lib.sh's canonical parser. PR registration
 # derives the project key from the basename of the task metadata's project= path.
+#
+# Every wait for the per-project lock is bounded (FM_MERGE_FRONT_LOCK_TIMEOUT,
+# default 30s), and every live GitHub read or comment is bounded
+# (FM_MERGE_FRONT_GH_TIMEOUT, default 60s), so a stuck holder or a hung forge
+# call yields a refusal instead of wedging the watcher.
 #
 # status reports one front= row plus zero or more parked= rows. It never grants
 # authority by itself: only the front may be updated from main or retriggered.
@@ -69,12 +86,16 @@ case "${1:-}" in
     [ "$#" -eq 2 ] || { echo 'error: invalid merge-front promote request' >&2; exit 2; }
     fm_merge_front_promote "$STATE" "$2" || exit $?
     ;;
+  remove)
+    [ "$#" -eq 4 ] || { echo 'error: invalid merge-front remove request' >&2; exit 2; }
+    fm_merge_front_remove "$STATE" "$2" "$3" "$4" || exit $?
+    ;;
   greptile-kick)
     [ "$#" -eq 2 ] || { echo 'error: invalid merge-front Greptile request' >&2; exit 2; }
     fm_merge_front_greptile_kick "$STATE" "$2" || exit $?
     ;;
   *)
-    echo 'error: expected enqueue, status, promote, or greptile-kick' >&2
+    echo 'error: expected enqueue, status, promote, remove, or greptile-kick' >&2
     exit 2
     ;;
 esac

--- a/bin/fm-merge-front.sh
+++ b/bin/fm-merge-front.sh
@@ -19,7 +19,11 @@
 # remove is the operator recovery path for a queued PR that will never merge -
 # a closed or superseded PR, or a torn-down task. It retires exactly the named
 # identity wherever it sits and advances nothing by itself, so retiring a stuck
-# front simply exposes the next entry and unblocks the project.
+# front simply exposes the next entry and unblocks the project. Teardown and a
+# confirmed merge whose task metadata is already gone reach the same retirement
+# automatically (bin/fm-teardown.sh, bin/fm-merge-outcome-lib.sh), scanning every
+# project queue when the task's own project key can no longer be derived, so a
+# torn-down front cannot silently park the PRs behind it.
 #
 # The shared already-confirmed merge-outcome path uses the same identity-bound
 # retirement. A confirmed merge is a fact the queue may never veto: an
@@ -38,16 +42,29 @@
 # complete old state, publish a complete same-device temporary by atomic rename,
 # and validate the result. Project keys and task IDs are confined path-safe
 # slugs; PR/MR URLs use bin/fm-pr-lib.sh's canonical parser. PR registration
-# derives the project key from the basename of the task metadata's project= path.
+# derives the project key from the task metadata's project= path with a pure,
+# deterministic mapping: the checkout basename with every character outside
+# [A-Za-z0-9._-] replaced by "-", trimmed to 40 characters and to a leading
+# alphanumeric (or "project" when nothing survives), then "-" and a 12-hex-digit
+# SHA-256 prefix of the whole path. So an ordinary checkout named "my repo" or
+# "app (v2)" registers instead of refusing, and two checkouts sharing a basename
+# keep isolated queues. Registration also refuses a PR URL already bound to a
+# different task before it rewrites any task metadata or arms any poll, so that
+# unretryable conflict never lands on half-applied registration state.
 #
 # Every wait for the per-project lock is bounded (FM_MERGE_FRONT_LOCK_TIMEOUT,
 # default 30s), and every live GitHub read or comment is bounded
 # (FM_MERGE_FRONT_GH_TIMEOUT, default 60s), so a stuck holder or a hung forge
-# call yields a refusal instead of wedging the watcher.
+# call yields a refusal instead of wedging the watcher. No command holds the
+# lock across a GitHub call, so the longest hold is one state read plus one
+# atomic rewrite and a slow forge can never starve enqueue or merge retirement.
 #
 # status reports one front= row plus zero or more parked= rows. It never grants
 # authority by itself: only the front may be updated from main or retriggered.
-# greptile-kick holds the project lock through its live GitHub reads and comment.
+# greptile-kick snapshots the front under the lock, releases it for its live
+# GitHub reads, and reacquires it to re-read the structural gate immediately
+# before its single side effect, so a front that promoted, rebound, or retired
+# meanwhile is refused rather than kicked.
 # It refuses unless the queued PR is the first entry (therefore has no preceding
 # entry), is open against main, has behind_by=0 compared with main, has every
 # non-Greptile required check at SUCCESS, and has no pending Greptile check. Any

--- a/bin/fm-merge-front.sh
+++ b/bin/fm-merge-front.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Own the per-project structural merge-front queue and the only initial
+# Greptile retrigger gate.
+#
+# Commands:
+#   fm-merge-front.sh enqueue <project-key> <task-id> <pr-url>
+#   fm-merge-front.sh status <project-key>
+#   fm-merge-front.sh promote <project-key>
+#   fm-merge-front.sh greptile-kick <project-key>
+#
+# Each project has exactly one ordered queue. Its first entry is the front and
+# every later entry is parked. enqueue is idempotent for one exact task/URL pair
+# and refuses a task or URL rebound to another pair. promote reuses the canonical
+# merge poll to fail closed until the front is confirmed merged, then removes
+# exactly that entry and exposes the next one. The shared already-confirmed
+# merge-outcome path uses an identity-bound variant and refuses to remove an
+# out-of-order merged entry.
+#
+# Durable private state lives at state/merge-front/<project-key>.queue under a
+# mode-0700 directory. Each single-link mode-0600 file has this schema:
+#   fm-merge-front-v1
+#   project=<project-key>
+#   task=<task-id><TAB>url=<canonical-pr-url>
+#   ...
+# The task rows are queue order. Writers hold the per-project lock, validate the
+# complete old state, publish a complete same-device temporary by atomic rename,
+# and validate the result. Project keys and task IDs are confined path-safe
+# slugs; PR/MR URLs use bin/fm-pr-lib.sh's canonical parser. PR registration
+# derives the project key from the basename of the task metadata's project= path.
+#
+# status reports one front= row plus zero or more parked= rows. It never grants
+# authority by itself: only the front may be updated from main or retriggered.
+# greptile-kick holds the project lock through its live GitHub reads and comment.
+# It refuses unless the queued PR is the first entry (therefore has no preceding
+# entry), is open against main, has behind_by=0 compared with main, has every
+# non-Greptile required check at SUCCESS, and has no pending Greptile check. Any
+# unreadable or unrecognised state fails closed. Its sole action is one explicit
+# `gh pr comment <number> --repo <owner/repo> --body "@greptile review"`.
+# Greploop's separate follow-up trigger remains unchanged: a finished Greptile
+# review below 5/5 may ask this owner to attempt another gated kick.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-merge-front-lib.sh
+. "$SCRIPT_DIR/fm-merge-front-lib.sh"
+
+usage() {
+  sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  enqueue)
+    [ "$#" -eq 4 ] || { echo 'error: invalid merge-front enqueue request' >&2; exit 2; }
+    fm_merge_front_enqueue "$STATE" "$2" "$3" "$4" || exit $?
+    ;;
+  status)
+    [ "$#" -eq 2 ] || { echo 'error: invalid merge-front status request' >&2; exit 2; }
+    fm_merge_front_status "$STATE" "$2" || exit $?
+    ;;
+  promote)
+    [ "$#" -eq 2 ] || { echo 'error: invalid merge-front promote request' >&2; exit 2; }
+    fm_merge_front_promote "$STATE" "$2" || exit $?
+    ;;
+  greptile-kick)
+    [ "$#" -eq 2 ] || { echo 'error: invalid merge-front Greptile request' >&2; exit 2; }
+    fm_merge_front_greptile_kick "$STATE" "$2" || exit $?
+    ;;
+  *)
+    echo 'error: expected enqueue, status, promote, or greptile-kick' >&2
+    exit 2
+    ;;
+esac

--- a/bin/fm-merge-front.sh
+++ b/bin/fm-merge-front.sh
@@ -50,9 +50,11 @@
 #   project=<project-key>
 #   task=<task-id><TAB>url=<canonical-pr-url>
 #   ...
-# The task rows are queue order. Writers hold the per-project lock, validate the
-# complete old state, publish a complete same-device temporary by atomic rename,
-# and validate the result. Project keys and task IDs are confined path-safe
+# The task rows are queue order, and a drained queue keeps its two-line file
+# with no task rows: an existing empty queue and no queue at all both mean the
+# project has no front. Writers hold the per-project lock, validate the complete
+# old state, publish a complete same-device temporary by atomic rename, and
+# validate the result. Project keys and task IDs are confined path-safe
 # slugs; PR/MR URLs use bin/fm-pr-lib.sh's canonical parser. PR registration
 # derives the project key from the task metadata's project= path with a pure,
 # deterministic mapping: the checkout basename with every character outside

--- a/bin/fm-merge-front.sh
+++ b/bin/fm-merge-front.sh
@@ -20,11 +20,16 @@
 # it, so a front that changed meanwhile is refused rather than mis-promoted.
 #
 # remove is the operator recovery path for a queued PR that will never merge -
-# a closed or superseded PR, or a torn-down task. Every retirement is keyed on
+# a closed or superseded PR, or a torn-down task. The remove command is keyed on
 # the exact task and canonical URL together, never either alone, so at most the
 # one named row is retired and a stale identity retires nothing rather than
 # dropping another task's live entry. It advances nothing by itself, so retiring
-# a stuck front simply exposes the next entry and unblocks the project. Teardown and a
+# a stuck front simply exposes the next entry and unblocks the project. The
+# internal teardown and missing-metadata retirement tries that exact pair first
+# and then falls back to the trusted task identity alone, because a replacement
+# registration that committed the task metadata but failed its enqueue leaves
+# the queue holding a stale URL for that very task; without the fallback the row
+# would stay the project's front forever with nothing reported. Teardown and a
 # confirmed merge whose task metadata is already gone reach the same retirement
 # automatically (bin/fm-teardown.sh, bin/fm-merge-outcome-lib.sh), scanning every
 # project queue when the task's own project key can no longer be derived, so a

--- a/bin/fm-merge-front.sh
+++ b/bin/fm-merge-front.sh
@@ -25,15 +25,17 @@
 # one named row is retired and a stale identity retires nothing rather than
 # dropping another task's live entry. It advances nothing by itself, so retiring
 # a stuck front simply exposes the next entry and unblocks the project. The
-# internal teardown and missing-metadata retirement tries that exact pair first
-# and then falls back to the trusted task identity alone, because a replacement
-# registration that committed the task metadata but failed its enqueue leaves
-# the queue holding a stale URL for that very task; without the fallback the row
-# would stay the project's front forever with nothing reported. Teardown and a
-# confirmed merge whose task metadata is already gone reach the same retirement
-# automatically (bin/fm-teardown.sh, bin/fm-merge-outcome-lib.sh), scanning every
-# project queue when the task's own project key can no longer be derived, so a
-# torn-down front cannot silently park the PRs behind it.
+# internal teardown and missing-metadata retirement keys on the trusted task
+# identity alone, because a replacement registration that committed the task
+# metadata but failed its enqueue leaves the queue holding a stale URL for that
+# very task; keyed on the pair the row would stay the project's front forever
+# with nothing reported. A task ID is unique within a queue, so that still names
+# at most one row. Teardown and a confirmed merge whose task metadata is already
+# gone reach the same retirement automatically (bin/fm-teardown.sh,
+# bin/fm-merge-outcome-lib.sh): the task's own project key resolves the queue in
+# one locked read, and only a task whose project key can no longer be derived
+# pays a scan of every project queue, so a torn-down front cannot silently park
+# the PRs behind it.
 #
 # The shared already-confirmed merge-outcome path uses the same identity-bound
 # retirement. A confirmed merge is a fact the queue may never veto: an

--- a/bin/fm-merge-outcome-lib.sh
+++ b/bin/fm-merge-outcome-lib.sh
@@ -15,7 +15,10 @@
 # A poll observed in a secondmate home also receives a local durable wake after
 # the upward write, so the mate can handle its own poll observation.
 # Outcome publication adds no new state file or transport; after publication it
-# delegates exact-front queue promotion to bin/fm-merge-front.sh's contract.
+# delegates identity-bound queue retirement to bin/fm-merge-front.sh's contract.
+# That retirement is advisory: a merge already confirmed must reach supervision
+# exactly once whatever the queue's shape, so a reconciliation failure is
+# reported and never suppresses or replays the outcome.
 #
 # Normal operation deduplicates the task's latest canonical PR identity through
 # the merge-notification marker owned by bin/fm-pr-lib.sh. Main-home wake keys
@@ -82,10 +85,9 @@ fm_merge_outcome_report() {  # <home> <state> <task-id> <pr-url> <origin>
   fm_lock_acquire_wait "$lock" || return 1
   if fm_pr_poll_merge_already_notified "$state" "$id" \
     "$provider" "$host" "$path" "$number"; then
-    if ! fm_merge_front_promote_task "$state" "$id" "$FM_PR_URL"; then
-      fm_lock_release "$lock"
-      return 1
-    fi
+    fm_merge_front_promote_task "$state" "$id" "$FM_PR_URL" \
+      || printf 'actionable: merge-front queue could not retire %s %s\n' \
+           "$id" "$FM_PR_URL" >&2
     # shellcheck disable=SC2034 # Public result consumed by sourcing callers.
     FM_MERGE_OUTCOME_ALREADY_RECORDED=true
     fm_lock_release "$lock"
@@ -100,7 +102,9 @@ fm_merge_outcome_report() {  # <home> <state> <task-id> <pr-url> <origin>
       "check: merge landed: $id $FM_PR_URL" || status=1
   fi
   if [ "$status" -eq 0 ]; then
-    fm_merge_front_promote_task "$state" "$id" "$FM_PR_URL" || status=1
+    fm_merge_front_promote_task "$state" "$id" "$FM_PR_URL" \
+      || printf 'actionable: merge-front queue could not retire %s %s\n' \
+           "$id" "$FM_PR_URL" >&2
   fi
   if [ "$status" -eq 0 ]; then
     fm_pr_poll_merge_mark_notified "$state" "$id" \

--- a/bin/fm-merge-outcome-lib.sh
+++ b/bin/fm-merge-outcome-lib.sh
@@ -85,7 +85,7 @@ fm_merge_outcome_report() {  # <home> <state> <task-id> <pr-url> <origin>
   fm_lock_acquire_wait "$lock" || return 1
   if fm_pr_poll_merge_already_notified "$state" "$id" \
     "$provider" "$host" "$path" "$number"; then
-    fm_merge_front_promote_task "$state" "$id" "$FM_PR_URL" \
+    fm_merge_front_retire_task "$state" "$id" "$FM_PR_URL" \
       || printf 'actionable: merge-front queue could not retire %s %s\n' \
            "$id" "$FM_PR_URL" >&2
     # shellcheck disable=SC2034 # Public result consumed by sourcing callers.
@@ -102,7 +102,7 @@ fm_merge_outcome_report() {  # <home> <state> <task-id> <pr-url> <origin>
       "check: merge landed: $id $FM_PR_URL" || status=1
   fi
   if [ "$status" -eq 0 ]; then
-    fm_merge_front_promote_task "$state" "$id" "$FM_PR_URL" \
+    fm_merge_front_retire_task "$state" "$id" "$FM_PR_URL" \
       || printf 'actionable: merge-front queue could not retire %s %s\n' \
            "$id" "$FM_PR_URL" >&2
   fi

--- a/bin/fm-merge-outcome-lib.sh
+++ b/bin/fm-merge-outcome-lib.sh
@@ -85,7 +85,7 @@ fm_merge_outcome_report() {  # <home> <state> <task-id> <pr-url> <origin>
   fm_lock_acquire_wait "$lock" || return 1
   if fm_pr_poll_merge_already_notified "$state" "$id" \
     "$provider" "$host" "$path" "$number"; then
-    fm_merge_front_retire_task "$state" "$id" "$FM_PR_URL" \
+    fm_merge_front_retire_task "$state" "$id" \
       || printf 'actionable: merge-front queue could not retire %s %s\n' \
            "$id" "$FM_PR_URL" >&2
     # shellcheck disable=SC2034 # Public result consumed by sourcing callers.
@@ -102,7 +102,7 @@ fm_merge_outcome_report() {  # <home> <state> <task-id> <pr-url> <origin>
       "check: merge landed: $id $FM_PR_URL" || status=1
   fi
   if [ "$status" -eq 0 ]; then
-    fm_merge_front_retire_task "$state" "$id" "$FM_PR_URL" \
+    fm_merge_front_retire_task "$state" "$id" \
       || printf 'actionable: merge-front queue could not retire %s %s\n' \
            "$id" "$FM_PR_URL" >&2
   fi

--- a/bin/fm-merge-outcome-lib.sh
+++ b/bin/fm-merge-outcome-lib.sh
@@ -14,7 +14,8 @@
 #   - a main home reports to the captain through the durable wake queue.
 # A poll observed in a secondmate home also receives a local durable wake after
 # the upward write, so the mate can handle its own poll observation.
-# No new state file and no new transport are involved.
+# Outcome publication adds no new state file or transport; after publication it
+# delegates exact-front queue promotion to bin/fm-merge-front.sh's contract.
 #
 # Normal operation deduplicates the task's latest canonical PR identity through
 # the merge-notification marker owned by bin/fm-pr-lib.sh. Main-home wake keys
@@ -31,6 +32,8 @@ _FM_MERGE_OUTCOME_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$_FM_MERGE_OUTCOME_LIB_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-parent-channel-lib.sh
 . "$_FM_MERGE_OUTCOME_LIB_DIR/fm-parent-channel-lib.sh"
+# shellcheck source=bin/fm-merge-front-lib.sh
+. "$_FM_MERGE_OUTCOME_LIB_DIR/fm-merge-front-lib.sh"
 
 # shellcheck disable=SC2034 # Public result consumed by sourcing callers.
 FM_MERGE_OUTCOME_ALREADY_RECORDED=false
@@ -79,6 +82,10 @@ fm_merge_outcome_report() {  # <home> <state> <task-id> <pr-url> <origin>
   fm_lock_acquire_wait "$lock" || return 1
   if fm_pr_poll_merge_already_notified "$state" "$id" \
     "$provider" "$host" "$path" "$number"; then
+    if ! fm_merge_front_promote_task "$state" "$id" "$FM_PR_URL"; then
+      fm_lock_release "$lock"
+      return 1
+    fi
     # shellcheck disable=SC2034 # Public result consumed by sourcing callers.
     FM_MERGE_OUTCOME_ALREADY_RECORDED=true
     fm_lock_release "$lock"
@@ -91,6 +98,9 @@ fm_merge_outcome_report() {  # <home> <state> <task-id> <pr-url> <origin>
   if [ "$status" -eq 0 ] && { [ "$origin" = poll ] || [ -z "$destination" ]; }; then
     fm_wake_append check "merged-$id-$FM_PR_URL" \
       "check: merge landed: $id $FM_PR_URL" || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    fm_merge_front_promote_task "$state" "$id" "$FM_PR_URL" || status=1
   fi
   if [ "$status" -eq 0 ]; then
     fm_pr_poll_merge_mark_notified "$state" "$id" \

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Record a PR-ready task: store one validated canonical pr=<url> and the forge's
 # exact pr_head=<sha> when available, then atomically arm a static merge poll.
+# A successful registration also delegates project-queue enrollment to the
+# contract owned by bin/fm-merge-front.sh's header.
 # The watcher check source is byte-for-byte bin/fm-pr-poll.sh; task and PR data
 # live only in a private sidecar and are never interpolated into shell source.
 # A GitHub pull request URL and a GitLab merge request URL are both accepted,
@@ -19,6 +21,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-parent-channel-lib.sh
 . "$SCRIPT_DIR/fm-parent-channel-lib.sh"
+# shellcheck source=bin/fm-merge-front-lib.sh
+. "$SCRIPT_DIR/fm-merge-front-lib.sh"
 
 if [ "$#" -ne 2 ]; then
   echo "error: invalid PR check request" >&2
@@ -132,6 +136,14 @@ META_LOCK_HELD=0
 
 fm_pr_poll_publish_prepared || {
   echo "error: could not publish PR poll" >&2
+  exit 1
+}
+PROJECT_KEY=$(fm_merge_front_project_key_from_meta "$STATE" "$ID") || {
+  echo "error: task project cannot be resolved for the merge-front queue" >&2
+  exit 1
+}
+fm_merge_front_enqueue "$STATE" "$PROJECT_KEY" "$ID" "$URL" >/dev/null || {
+  echo "error: PR poll is armed but the merge-front queue could not be updated" >&2
   exit 1
 }
 # In a secondmate home the registration itself is a captain-facing fact:

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -2,7 +2,9 @@
 # Record a PR-ready task: store one validated canonical pr=<url> and the forge's
 # exact pr_head=<sha> when available, then atomically arm a static merge poll.
 # A successful registration also delegates project-queue enrollment to the
-# contract owned by bin/fm-merge-front.sh's header.
+# contract owned by bin/fm-merge-front.sh's header; the task's project key is
+# resolved before any state is mutated so an unresolvable project refuses the
+# whole registration rather than reporting failure over a rewritten meta.
 # The watcher check source is byte-for-byte bin/fm-pr-poll.sh; task and PR data
 # live only in a private sidecar and are never interpolated into shell source.
 # A GitHub pull request URL and a GitLab merge request URL are both accepted,
@@ -84,6 +86,14 @@ if [ "$PROVIDER" = github ] && [ -n "$WT" ] && [ -d "$WT" ] && command -v gh >/d
   fi
 fi
 
+# The merge-front project key comes from metadata this script never rewrites.
+# Resolve it before any mutation so an unresolvable project refuses here, while
+# the meta and the poll are still untouched.
+PROJECT_KEY=$(fm_merge_front_project_key_from_meta "$STATE" "$ID") || {
+  echo "error: task project cannot be resolved for the merge-front queue" >&2
+  exit 1
+}
+
 META_TMP=
 META_LOCK=
 META_LOCK_HELD=0
@@ -136,10 +146,6 @@ META_LOCK_HELD=0
 
 fm_pr_poll_publish_prepared || {
   echo "error: could not publish PR poll" >&2
-  exit 1
-}
-PROJECT_KEY=$(fm_merge_front_project_key_from_meta "$STATE" "$ID") || {
-  echo "error: task project cannot be resolved for the merge-front queue" >&2
   exit 1
 }
 fm_merge_front_enqueue "$STATE" "$PROJECT_KEY" "$ID" "$URL" >/dev/null || {

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -2,9 +2,11 @@
 # Record a PR-ready task: store one validated canonical pr=<url> and the forge's
 # exact pr_head=<sha> when available, then atomically arm a static merge poll.
 # A successful registration also delegates project-queue enrollment to the
-# contract owned by bin/fm-merge-front.sh's header; the task's project key is
-# resolved before any state is mutated so an unresolvable project refuses the
-# whole registration rather than reporting failure over a rewritten meta.
+# contract owned by bin/fm-merge-front.sh's header; the task's project key and
+# the only unretryable enqueue refusal - a PR URL already bound to another task -
+# are both resolved before any state is mutated, so a registration that cannot
+# succeed refuses over untouched state rather than over a rewritten meta and an
+# armed poll.
 # The watcher check source is byte-for-byte bin/fm-pr-poll.sh; task and PR data
 # live only in a private sidecar and are never interpolated into shell source.
 # A GitHub pull request URL and a GitLab merge request URL are both accepted,
@@ -93,6 +95,18 @@ PROJECT_KEY=$(fm_merge_front_project_key_from_meta "$STATE" "$ID") || {
   echo "error: task project cannot be resolved for the merge-front queue" >&2
   exit 1
 }
+# The one enqueue refusal no retry can clear is a URL already bound to another
+# task. Evaluate it here, over untouched state, so registration never reports
+# failure on top of a rewritten meta and an armed poll.
+MERGE_FRONT_RC=0
+fm_merge_front_url_conflict "$STATE" "$PROJECT_KEY" "$ID" "$URL" || MERGE_FRONT_RC=$?
+if [ "$MERGE_FRONT_RC" -eq 3 ]; then
+  echo "error: $URL is already registered to task $FM_MERGE_FRONT_CONFLICT_TASK in this project" >&2
+  exit 1
+elif [ "$MERGE_FRONT_RC" -ne 0 ]; then
+  echo "error: the merge-front queue could not be read for this project" >&2
+  exit 1
+fi
 
 META_TMP=
 META_LOCK=

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1042,14 +1042,14 @@ validate_pr_poll_cleanup() {
 # Retire this task's merge-front queue entry alongside its PR poll. The queue
 # entry outlives the task record otherwise, and a retired front that stays
 # queued parks every later PR in that project with no update-branch or Greptile
-# authority. Runs while the meta still exists, so the entry is retired by its
-# recorded identity; a failure is reported with the operator recovery command
-# rather than blocking a landed teardown.
+# authority. Runs while the meta still exists, so the entry is resolved through
+# the task's own project queue; a failure is reported with the operator recovery
+# command rather than blocking a landed teardown.
 retire_merge_front_entry() {
   local state_dir=$1 id=$2 url
   url=$(grep '^pr=' "$state_dir/$id.meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
   [ -n "$url" ] || return 0
-  fm_merge_front_retire_task "$state_dir" "$id" "$url" && return 0
+  fm_merge_front_retire_task "$state_dir" "$id" && return 0
   printf 'actionable: %s is torn down but its merge-front queue entry could not be retired; run bin/fm-merge-front.sh remove <project-key> %s %s\n' \
     "$id" "$id" "$url" >&2
   return 0

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -221,6 +221,8 @@ fm_backlog_directory_present "$STATE" "state directory" || {
 }
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-merge-front-lib.sh
+. "$SCRIPT_DIR/fm-merge-front-lib.sh"
 # Supervision lease guard: post-landing cleanup is overlap territory between
 # the two Pi supervision actors; refuse while the OTHER actor holds this
 # task's live lease (contract: bin/fm-lease-lib.sh; no-op in homes without
@@ -1037,9 +1039,26 @@ validate_pr_poll_cleanup() {
   fi
 }
 
+# Retire this task's merge-front queue entry alongside its PR poll. The queue
+# entry outlives the task record otherwise, and a retired front that stays
+# queued parks every later PR in that project with no update-branch or Greptile
+# authority. Runs while the meta still exists, so the entry is retired by its
+# recorded identity; a failure is reported with the operator recovery command
+# rather than blocking a landed teardown.
+retire_merge_front_entry() {
+  local state_dir=$1 id=$2 url
+  url=$(grep '^pr=' "$state_dir/$id.meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+  [ -n "$url" ] || return 0
+  fm_merge_front_retire_task "$state_dir" "$id" "$url" && return 0
+  printf 'actionable: %s is torn down but its merge-front queue entry could not be retired; run bin/fm-merge-front.sh remove <project-key> %s %s\n' \
+    "$id" "$id" "$url" >&2
+  return 0
+}
+
 remove_pr_poll_artifacts() {
   local state_dir=$1 id=$2
   validate_pr_poll_cleanup "$state_dir" "$id" || return 1
+  retire_merge_front_entry "$state_dir" "$id"
   fm_pr_poll_retirement_recover_one "$state_dir" "$id" "$SCRIPT_DIR/fm-pr-poll.sh" || return 1
   fm_pr_poll_merge_notified_remove "$state_dir" "$id" || return 1
   rm -f "$state_dir/$id.check.sh" "$state_dir/$id.pr-poll" \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -293,7 +293,8 @@ When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshe
 Where a no-mistakes pipeline stores evidence in the repo, it publishes that PR-viewable validation evidence to an orphan evidence branch that shares no history with code branches, so it never enters the crew branch or the default branch.
 This repo uses that setting, and its own `.no-mistakes/` directory remains local state that stays gitignored and is rejected by CI if tracked; [`configuration.md`](configuration.md) owns the setting.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling the forge CLI.
-The helper requires a full canonical URL and rejects malformed URLs or repo override flags before recording merge state.
+[`bin/fm-merge-front.sh`](../bin/fm-merge-front.sh)'s header owns per-project PR ordering, promotion after a confirmed front merge, and front-only update-branch and Greptile retrigger authority.
+The merge helper requires a full canonical URL and rejects malformed URLs or repo override flags before recording merge state.
 A `https://github.com/<owner>/<repo>/pull/<n>` URL invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, and preserves explicit merge-method flags.
 A `https://<host>/<path>/-/merge_requests/<n>` URL (see [docs/gitlab-merge-watch.md](gitlab-merge-watch.md)) invokes `glab mr merge <n> -R https://<host>/<path>`, so the instance comes from the URL, and adds no merge-method flag because the project's own merge method applies.
 That path merges only after one live read of the merge request confirms it is open, mergeable, conflict-free, with blocking discussions resolved and a successful pipeline at the current head, and it binds the merge to that verified head; recorded metadata is never the authority for those conditions because a rebase leaves it stale.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -126,6 +126,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-lib.sh`           | Own canonical task and PR validation plus private atomic PR-poll publication, merge-notification identity, and retirement |
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
+| `fm-merge-front.sh`      | Order each project's PRs and gate front-only branch updates and Greptile retriggers   |
 | `fm-pr-merge.sh`         | Record PR metadata, merge a task's canonical full GitHub or GitLab URL, then refuse an outcome it cannot prove landed or queued |
 | `fm-merge-outcome-lib.sh` | Publish a confirmed merge's durable, role-routed supervision outcome                 |
 | `fm-parent-channel-lib.sh` | Resolve a secondmate home's parent channel and append a captain-facing outcome line to it at most once |

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -76,6 +76,8 @@ SH
   ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
   # fm-pr-lib.sh: teardown uses its canonical task-ID validator for poll cleanup.
   ln -s "$ROOT/bin/fm-pr-lib.sh" "$fake/bin/fm-pr-lib.sh"
+  # fm-merge-front-lib.sh: teardown sources it to retire the task's queue entry.
+  ln -s "$ROOT/bin/fm-merge-front-lib.sh" "$fake/bin/fm-merge-front-lib.sh"
   # fm-public-followup-lib.sh (and the fm-x-lib.sh it sources): teardown sources
   # it for the relay-activation gate on the promised-public-reply check. Neither
   # does anything in this fixture, which has no .env, but both are real siblings
@@ -174,6 +176,8 @@ SH
   ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
   # fm-pr-lib.sh: teardown uses its canonical task-ID validator for poll cleanup.
   ln -s "$ROOT/bin/fm-pr-lib.sh" "$fake/bin/fm-pr-lib.sh"
+  # fm-merge-front-lib.sh: teardown sources it to retire the task's queue entry.
+  ln -s "$ROOT/bin/fm-merge-front-lib.sh" "$fake/bin/fm-merge-front-lib.sh"
   # fm-public-followup-lib.sh (and the fm-x-lib.sh it sources): teardown sources
   # it for the relay-activation gate on the promised-public-reply check. Neither
   # does anything in this fixture, which has no .env, but both are real siblings

--- a/tests/fm-merge-front.test.sh
+++ b/tests/fm-merge-front.test.sh
@@ -27,6 +27,9 @@ SH
   chmod +x "$dir/fake-root/bin/fm-guard.sh"
   cat > "$dir/fakebin/gh" <<SH
 #!/usr/bin/env bash
+if [ -n "\${FM_TEST_GH_HOOK:-}" ]; then
+  "\$FM_TEST_GH_HOOK" >/dev/null 2>&1
+fi
 case "\${1:-} \${2:-}" in
   "pr view")
     case " \$* " in
@@ -188,6 +191,63 @@ test_same_task_replacement_and_removal_recovery() {
   pass "same-task replacement rebinds in place and removal retires a stuck front"
 }
 
+# Removal is keyed on the exact task and canonical URL pair. A stale or
+# mismatched identity must retire nothing rather than dropping the row that
+# happens to share one half of it.
+test_removal_requires_the_exact_task_and_url_pair() {
+  local dir removed status
+  dir=$(make_home exact-identity)
+  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/3 >/dev/null \
+    || fail "exact-identity front enqueue failed"
+  run_front "$dir" enqueue project-alpha task-b https://github.com/o/r/pull/2 >/dev/null \
+    || fail "exact-identity parked enqueue failed"
+
+  removed=$(run_front "$dir" remove project-alpha task-a https://github.com/o/r/pull/2) \
+    || fail "mismatched removal was not reported"
+  assert_contains "$removed" 'removed=none' "a mismatched identity reported a removal"
+  status=$(run_front "$dir" status project-alpha) || fail "mismatched removal status failed"
+  assert_contains "$status" $'front=task-a\thttps://github.com/o/r/pull/3' \
+    "a mismatched removal disturbed the front"
+  assert_contains "$status" $'parked=task-b\thttps://github.com/o/r/pull/2' \
+    "a mismatched removal silently retired another task's live entry"
+
+  removed=$(run_front "$dir" remove project-alpha task-a https://github.com/o/r/pull/3) \
+    || fail "exact removal failed"
+  assert_contains "$removed" $'removed=task-a\thttps://github.com/o/r/pull/3' \
+    "exact removal did not report its own identity"
+  status=$(run_front "$dir" status project-alpha) || fail "exact removal status failed"
+  assert_contains "$status" $'front=task-b\thttps://github.com/o/r/pull/2' \
+    "exact removal did not leave the other entry queued"
+  pass "removal retires only the exact task and URL pair it was given"
+}
+
+# promote runs the same live merge poll the watcher does; holding the queue lock
+# across it would starve enqueue and confirmed-merge retirement behind a slow
+# forge exactly as the Greptile gate would.
+test_promote_leaves_the_queue_usable_during_its_merge_poll() {
+  local dir status
+  dir=$(make_home promote-lock)
+  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "promote-lock fixture enqueue failed"
+  cat > "$dir/hook.sh" <<SH
+#!/usr/bin/env bash
+FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" \
+  FM_MERGE_FRONT_LOCK_TIMEOUT=2 "$MERGE_FRONT" \
+  enqueue project-alpha task-b https://github.com/o/r/pull/2 >/dev/null 2>&1 \
+  && printf 'concurrent-enqueue=ok\n' > "$dir/hook.out" \
+  || printf 'concurrent-enqueue=blocked\n' > "$dir/hook.out"
+SH
+  chmod +x "$dir/hook.sh"
+  FM_TEST_GH_HOOK="$dir/hook.sh" run_front "$dir" promote project-alpha >/dev/null \
+    || fail "confirmed front promotion failed"
+  assert_grep 'concurrent-enqueue=ok' "$dir/hook.out" \
+    "the queue lock was held across promote's live merge poll"
+  status=$(run_front "$dir" status project-alpha) || fail "post-promote status failed"
+  assert_contains "$status" $'front=task-b\thttps://github.com/o/r/pull/2' \
+    "promotion did not expose the PR enqueued during its poll"
+  pass "promote never holds the queue lock across its live merge poll"
+}
+
 test_pr_check_enqueues_project_front() {
   local dir status key
   dir=$(make_home pr-check)
@@ -321,6 +381,28 @@ test_confirmed_merge_retires_front_without_task_metadata() {
   pass "a merged front is retired even when its task record is already gone"
 }
 
+# One unreadable project queue must not abandon the scan: the target entry lives
+# in another project and can still be safely retired.
+test_retirement_scan_survives_an_unreadable_project_queue() {
+  local dir status
+  dir=$(make_home scan-resilience)
+  write_meta "$dir" task-a
+  run_front "$dir" enqueue aaa task-x https://github.com/o/r/pull/5 >/dev/null \
+    || fail "scan fixture first-project enqueue failed"
+  run_front "$dir" enqueue zzz task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "scan fixture target enqueue failed"
+  printf 'not-a-merge-front-queue\n' > "$dir/home/state/merge-front/aaa.queue"
+  chmod 0600 "$dir/home/state/merge-front/aaa.queue"
+  rm -f "$dir/home/state/task-a.meta"
+
+  run_outcome "$dir" task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "merged PR could not publish its outcome past an unreadable queue"
+  status=$(run_front "$dir" status zzz) || fail "scan-resilience status failed"
+  assert_contains "$status" 'front=none' \
+    "an unreadable sibling queue aborted the scan before the target was retired"
+  pass "retirement scans every project queue past an unreadable one"
+}
+
 install_github_gate_fake() {  # <dir>
   local dir=$1
   cat > "$dir/fakebin/gh" <<'SH'
@@ -422,6 +504,37 @@ test_greptile_gate_refusals_and_single_action() {
   pass "Greptile kick fails closed at every gate and comments once for the front"
 }
 
+# GitHub's own merge gate accepts a required check that was skipped or neutral,
+# so treating either as blocking would refuse the initial Greptile trigger
+# forever and stall the whole project queue behind that front.
+test_greptile_gate_accepts_skipped_and_neutral_required_checks() {
+  local dir rc comment_count
+  dir=$(make_home greptile-skipped)
+  install_github_gate_fake "$dir"
+  : > "$dir/gh.log"
+  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "skipped-check fixture enqueue failed"
+
+  FM_TEST_REQUIRED_JSON='[{"name":"CI / e2e","state":"SKIPPED"},{"name":"CI / lint","state":"NEUTRAL"},{"name":"CI","state":"SUCCESS"}]' \
+    FM_TEST_ALL_JSON='[{"name":"CI","state":"SUCCESS"}]' \
+    run_kick "$dir" >/dev/null || fail "a skipped required check blocked the Greptile kick"
+  comment_count=$(grep -c '^\[<pr><comment>' "$dir/gh.log")
+  [ "$comment_count" -eq 1 ] \
+    || fail "satisfied required checks did not yield exactly one kick"
+
+  : > "$dir/gh.log"
+  set +e
+  FM_TEST_REQUIRED_JSON='[{"name":"CI","state":"CANCELLED"}]' \
+    FM_TEST_ALL_JSON='[{"name":"CI","state":"CANCELLED"}]' \
+    run_kick "$dir" >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "a cancelled required check received Greptile authority"
+  assert_no_grep '<pr><comment>' "$dir/gh.log" \
+    "a cancelled required check posted a Greptile comment"
+  pass "skipped and neutral required checks satisfy the gate; other states block"
+}
+
 # The gate's GitHub reads must not hold the per-project queue lock: a slow forge
 # would otherwise starve ordinary enqueue and confirmed-merge retirement, whose
 # waits are bounded far below the gate's total GitHub budget.
@@ -483,11 +596,15 @@ SH
 test_queue_order_and_promotion
 test_queue_conflicts_and_paths_fail_closed
 test_same_task_replacement_and_removal_recovery
+test_removal_requires_the_exact_task_and_url_pair
+test_promote_leaves_the_queue_usable_during_its_merge_poll
 test_pr_check_enqueues_project_front
 test_pr_check_registers_any_checkout_basename
 test_pr_check_refuses_bound_url_before_mutating
 test_confirmed_merge_reconciles_exact_identity
 test_confirmed_merge_retires_front_without_task_metadata
+test_retirement_scan_survives_an_unreadable_project_queue
 test_greptile_gate_refusals_and_single_action
+test_greptile_gate_accepts_skipped_and_neutral_required_checks
 test_greptile_kick_leaves_the_queue_usable_during_github_reads
 test_greptile_kick_refuses_when_the_front_changes_mid_gate

--- a/tests/fm-merge-front.test.sh
+++ b/tests/fm-merge-front.test.sh
@@ -248,6 +248,51 @@ SH
   pass "promote never holds the queue lock across its live merge poll"
 }
 
+# `none` is the empty-queue label promote prints, and it is also a valid task ID.
+# The promoted output must name the real next front rather than claim the queue
+# drained because the next task happens to be called none.
+test_promote_reports_a_next_front_named_none() {
+  local dir promoted status
+  dir=$(make_home promote-none)
+  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "promote-none fixture front enqueue failed"
+  run_front "$dir" enqueue project-alpha none https://github.com/o/r/pull/2 >/dev/null \
+    || fail "promote-none fixture parked enqueue failed"
+
+  promoted=$(run_front "$dir" promote project-alpha) || fail "promotion failed"
+  assert_contains "$promoted" $'front=none\thttps://github.com/o/r/pull/2' \
+    "promotion reported a drained queue while a task named none held the front"
+  status=$(run_front "$dir" status project-alpha) || fail "promote-none status failed"
+  assert_contains "$status" $'front=none\thttps://github.com/o/r/pull/2' \
+    "promotion did not leave the task named none as the front"
+  pass "promotion names a next front whose task ID is exactly none"
+}
+
+# The common retirement path - a task whose metadata still resolves its project
+# and whose row is already gone - is answered from that one project queue. An
+# unrelated project's unreadable queue must not turn it into a reported failure.
+test_retirement_of_an_absent_row_ignores_unrelated_queues() {
+  local dir key err
+  dir=$(make_home retire-absent)
+  write_meta "$dir" task-a
+  write_meta "$dir" task-b
+  key=$(project_key "$dir/project-alpha") || fail "project key could not be derived"
+  run_front "$dir" enqueue "$key" task-b https://github.com/o/r/pull/2 >/dev/null \
+    || fail "retire-absent own-project enqueue failed"
+  run_front "$dir" enqueue zzz task-x https://github.com/o/r/pull/5 >/dev/null \
+    || fail "retire-absent sibling enqueue failed"
+  printf 'not-a-merge-front-queue\n' > "$dir/home/state/merge-front/zzz.queue"
+  chmod 0600 "$dir/home/state/merge-front/zzz.queue"
+
+  err=$(run_outcome "$dir" task-a https://github.com/o/r/pull/1 2>&1 >/dev/null) \
+    || fail "a merge outcome for an unqueued task could not be published"
+  case "$err" in
+    *"could not retire"*)
+      fail "retiring an already-absent row reported a failure from an unrelated queue" ;;
+  esac
+  pass "retirement of an absent row never consults unrelated project queues"
+}
+
 test_pr_check_enqueues_project_front() {
   local dir status key
   dir=$(make_home pr-check)
@@ -648,6 +693,7 @@ test_queue_conflicts_and_paths_fail_closed
 test_same_task_replacement_and_removal_recovery
 test_removal_requires_the_exact_task_and_url_pair
 test_promote_leaves_the_queue_usable_during_its_merge_poll
+test_promote_reports_a_next_front_named_none
 test_pr_check_enqueues_project_front
 test_pr_check_registers_any_checkout_basename
 test_pr_check_refuses_bound_url_before_mutating
@@ -656,6 +702,7 @@ test_confirmed_merge_retires_front_without_task_metadata
 test_retirement_scan_survives_an_unreadable_project_queue
 test_retirement_clears_a_row_whose_recorded_url_diverged
 test_retirement_scan_reports_the_identity_it_retired
+test_retirement_of_an_absent_row_ignores_unrelated_queues
 test_greptile_gate_refusals_and_single_action
 test_greptile_gate_accepts_skipped_and_neutral_required_checks
 test_greptile_kick_leaves_the_queue_usable_during_github_reads

--- a/tests/fm-merge-front.test.sh
+++ b/tests/fm-merge-front.test.sh
@@ -403,6 +403,56 @@ test_retirement_scan_survives_an_unreadable_project_queue() {
   pass "retirement scans every project queue past an unreadable one"
 }
 
+# A replacement registration that commits the task metadata but fails its
+# enqueue leaves the queue holding a stale URL for that very task. Retirement
+# must still clear the row, or it stays the project's front forever with nothing
+# reported to name it.
+test_retirement_clears_a_row_whose_recorded_url_diverged() {
+  local dir status key
+  dir=$(make_home diverged-url)
+  write_meta "$dir" task-a
+  write_meta "$dir" task-b
+  key=$(project_key "$dir/project-alpha") || fail "project key could not be derived"
+  run_front "$dir" enqueue "$key" task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "diverged-url fixture front enqueue failed"
+  run_front "$dir" enqueue "$key" task-b https://github.com/o/r/pull/2 >/dev/null \
+    || fail "diverged-url fixture parked enqueue failed"
+
+  run_outcome "$dir" task-a https://github.com/o/r/pull/9 >/dev/null \
+    || fail "a diverged merge outcome could not be published"
+  status=$(run_front "$dir" status "$key") || fail "diverged-url status failed"
+  assert_contains "$status" $'front=task-b\thttps://github.com/o/r/pull/2' \
+    "the stale row for the retiring task stayed the project's front"
+  assert_no_grep 'task-a' "$dir/home/state/merge-front/$key.queue" \
+    "the diverged row was not retired"
+  pass "retirement clears a task's row whose recorded URL diverged"
+}
+
+run_drop_anywhere() {  # <dir> <task> <url>
+  local dir=$1 task=$2 url=$3
+  FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" FM_ROOT_OVERRIDE="$ROOT" \
+    bash -c '. "$1"; fm_merge_front_drop_anywhere "$2" "$3" "$4" \
+      && printf "dropped=%s\t%s\n" "$FM_MERGE_FRONT_DROPPED_TASK" "$FM_MERGE_FRONT_DROPPED_URL"' \
+      _ "$ROOT/bin/fm-merge-front-lib.sh" "$dir/home/state" "$task" "$url"
+}
+
+# The scan reports the identity it retired; a later unrelated queue must not
+# clear it, and must not be locked and parsed once the row is already gone.
+test_retirement_scan_reports_the_identity_it_retired() {
+  local dir dropped
+  dir=$(make_home scan-identity)
+  run_front "$dir" enqueue aaa task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "scan-identity target enqueue failed"
+  run_front "$dir" enqueue zzz task-z https://github.com/o/r/pull/9 >/dev/null \
+    || fail "scan-identity sibling enqueue failed"
+
+  dropped=$(run_drop_anywhere "$dir" task-a https://github.com/o/r/pull/1) \
+    || fail "the retirement scan did not retire the queued row"
+  assert_contains "$dropped" $'dropped=task-a\thttps://github.com/o/r/pull/1' \
+    "the retirement scan lost the identity it retired"
+  pass "the retirement scan reports the exact identity it retired"
+}
+
 install_github_gate_fake() {  # <dir>
   local dir=$1
   cat > "$dir/fakebin/gh" <<'SH'
@@ -604,6 +654,8 @@ test_pr_check_refuses_bound_url_before_mutating
 test_confirmed_merge_reconciles_exact_identity
 test_confirmed_merge_retires_front_without_task_metadata
 test_retirement_scan_survives_an_unreadable_project_queue
+test_retirement_clears_a_row_whose_recorded_url_diverged
+test_retirement_scan_reports_the_identity_it_retired
 test_greptile_gate_refusals_and_single_action
 test_greptile_gate_accepts_skipped_and_neutral_required_checks
 test_greptile_kick_leaves_the_queue_usable_during_github_reads

--- a/tests/fm-merge-front.test.sh
+++ b/tests/fm-merge-front.test.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Behavioral coverage for the structural merge-front queue, its PR-registration
+# and confirmed-merge integrations, and the front-only Greptile gate.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$ROOT/bin/fm-pr-lib.sh"
+
+MERGE_FRONT="$ROOT/bin/fm-merge-front.sh"
+PR_CHECK="$ROOT/bin/fm-pr-check.sh"
+MERGE_OUTCOME="$ROOT/bin/fm-merge-outcome-lib.sh"
+TMP_ROOT=$(fm_test_tmproot fm-merge-front)
+BASE_PATH=$PATH
+HEAD_SHA=0123456789abcdef0123456789abcdef01234567
+
+make_home() {  # <name>
+  local dir="$TMP_ROOT/$1"
+  mkdir -p "$dir/home/state" "$dir/home/data" "$dir/project-alpha" "$dir/fakebin" "$dir/fake-root/bin"
+  cat > "$dir/fake-root/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$dir/fake-root/bin/fm-guard.sh"
+  cat > "$dir/fakebin/gh" <<SH
+#!/usr/bin/env bash
+case "\${1:-} \${2:-}" in
+  "pr view")
+    case " \$* " in
+      *" state "*) printf '%s\n' "\${FM_TEST_GH_STATE:-MERGED}" ;;
+      *) printf '%s\n' '$HEAD_SHA' ;;
+    esac
+    ;;
+esac
+SH
+  chmod +x "$dir/fakebin/gh"
+  printf '%s\n' "$dir"
+}
+
+run_front() {  # <dir> <args...>
+  local dir=$1
+  shift
+  FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" \
+    PATH="$dir/fakebin:$BASE_PATH" "$MERGE_FRONT" "$@"
+}
+
+write_meta() {  # <dir> <task>
+  local dir=$1 task=$2
+  fm_write_meta "$dir/home/state/$task.meta" \
+    "window=fm-$task" \
+    "worktree=$dir/worktree-$task" \
+    "project=$dir/project-alpha" \
+    "kind=ship" \
+    "mode=no-mistakes"
+}
+
+test_queue_order_and_promotion() {
+  local dir status duplicate rc
+  dir=$(make_home queue)
+  status=$(run_front "$dir" status project-alpha) || fail "empty queue status failed"
+  assert_contains "$status" 'front=none' "empty queue did not report no front"
+
+  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "first enqueue failed"
+  run_front "$dir" enqueue project-alpha task-b https://github.com/o/r/pull/2 >/dev/null \
+    || fail "second enqueue failed"
+  duplicate=$(run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1) \
+    || fail "exact duplicate enqueue was not idempotent"
+  assert_contains "$duplicate" 'front=task-a' "duplicate front enqueue lost its role"
+
+  status=$(run_front "$dir" status project-alpha) || fail "populated queue status failed"
+  assert_contains "$status" $'front=task-a\thttps://github.com/o/r/pull/1' "first PR was not the front"
+  assert_contains "$status" $'parked=task-b\thttps://github.com/o/r/pull/2' "second PR was not parked"
+  [ "$(grep -c '^task=' "$dir/home/state/merge-front/project-alpha.queue")" -eq 2 ] \
+    || fail "duplicate enqueue changed queue cardinality"
+  [ "$(fm_pr_file_mode "$dir/home/state/merge-front")" = 700 ] \
+    || fail "merge-front directory was not private"
+  [ "$(fm_pr_file_mode "$dir/home/state/merge-front/project-alpha.queue")" = 600 ] \
+    || fail "merge-front queue was not private"
+
+  set +e
+  FM_TEST_GH_STATE=OPEN run_front "$dir" promote project-alpha >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "unmerged front was promoted"
+  status=$(run_front "$dir" status project-alpha) || fail "refused promotion status failed"
+  assert_contains "$status" 'front=task-a' "refused promotion changed the front"
+  run_front "$dir" promote project-alpha >/dev/null || fail "confirmed front promotion failed"
+  status=$(run_front "$dir" status project-alpha) || fail "promoted queue status failed"
+  assert_contains "$status" $'front=task-b\thttps://github.com/o/r/pull/2' "promotion did not expose the next PR"
+  assert_no_grep 'task-a' "$dir/home/state/merge-front/project-alpha.queue" \
+    "promotion retained the merged front"
+  pass "enqueue, status, and promote preserve one ordered front"
+}
+
+test_queue_conflicts_and_paths_fail_closed() {
+  local dir outside before rc
+  dir=$(make_home conflicts)
+  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "conflict fixture enqueue failed"
+  set +e
+  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/2 >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "one task was rebound to a different PR"
+  [ "$(grep -c '^task=' "$dir/home/state/merge-front/project-alpha.queue")" -eq 1 ] \
+    || fail "conflicting enqueue changed the queue"
+
+  before=$(find "$dir/home/state" -mindepth 1 -maxdepth 2 -print | sort)
+  set +e
+  run_front "$dir" enqueue ../escape task-z https://github.com/o/r/pull/9 >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "traversing project key was accepted"
+  [ "$(find "$dir/home/state" -mindepth 1 -maxdepth 2 -print | sort)" = "$before" ] \
+    || fail "invalid project key changed state"
+
+  outside="$dir/outside"
+  printf 'sentinel\n' > "$outside"
+  rm "$dir/home/state/merge-front/project-alpha.queue"
+  ln -s "$outside" "$dir/home/state/merge-front/project-alpha.queue"
+  set +e
+  run_front "$dir" status project-alpha >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "status accepted a queue symlink"
+  [ "$(cat "$outside")" = sentinel ] || fail "queue symlink target was changed"
+  pass "queue conflicts, traversal, and symlink destinations fail closed"
+}
+
+test_pr_check_enqueues_project_front() {
+  local dir status
+  dir=$(make_home pr-check)
+  write_meta "$dir" task-a
+  cat > "$dir/fakebin/gh" <<SH
+#!/usr/bin/env bash
+case "\${1:-} \${2:-}" in
+  "pr view") printf '%s\n' '$HEAD_SHA' ;;
+esac
+SH
+  chmod +x "$dir/fakebin/gh"
+  FM_ROOT_OVERRIDE="$dir/fake-root" FM_HOME="$dir/home" \
+    PATH="$dir/fakebin:$BASE_PATH" \
+    "$PR_CHECK" task-a https://github.com/o/r/pull/7 >/dev/null \
+    || fail "fm-pr-check could not register the queue entry"
+  status=$(run_front "$dir" status project-alpha) || fail "registered queue status failed"
+  assert_contains "$status" $'front=task-a\thttps://github.com/o/r/pull/7' \
+    "fm-pr-check did not enqueue by task project"
+  pass "PR registration structurally enrolls the task in its project queue"
+}
+
+run_outcome() {  # <dir> <task> <url>
+  local dir=$1 task=$2 url=$3
+  FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" FM_ROOT_OVERRIDE="$ROOT" \
+    bash -c '. "$1"; fm_merge_outcome_report "$2" "$3" "$4" "$5" poll' \
+      _ "$MERGE_OUTCOME" "$dir/home" "$dir/home/state" "$task" "$url"
+}
+
+test_confirmed_merge_promotes_only_exact_front() {
+  local dir status rc
+  dir=$(make_home merge-outcome)
+  write_meta "$dir" task-a
+  write_meta "$dir" task-b
+  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "first merge-outcome enqueue failed"
+  run_front "$dir" enqueue project-alpha task-b https://github.com/o/r/pull/2 >/dev/null \
+    || fail "second merge-outcome enqueue failed"
+
+  set +e
+  run_outcome "$dir" task-b https://github.com/o/r/pull/2 >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "out-of-order merged PR advanced the queue"
+  status=$(run_front "$dir" status project-alpha) || fail "out-of-order queue status failed"
+  assert_contains "$status" 'front=task-a' "out-of-order merge displaced the front"
+  assert_contains "$status" 'parked=task-b' "out-of-order merge removed the parked PR"
+
+  run_outcome "$dir" task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "confirmed front merge did not advance the queue"
+  status=$(run_front "$dir" status project-alpha) || fail "advanced queue status failed"
+  assert_contains "$status" 'front=task-b' "confirmed front merge did not promote its successor"
+  run_outcome "$dir" task-b https://github.com/o/r/pull/2 >/dev/null \
+    || fail "promoted successor merge did not advance the queue"
+  status=$(run_front "$dir" status project-alpha) || fail "empty promoted queue status failed"
+  assert_contains "$status" 'front=none' "second confirmed merge did not empty the queue"
+  pass "confirmed merge completion promotes only the exact current front"
+}
+
+install_github_gate_fake() {  # <dir>
+  local dir=$1
+  cat > "$dir/fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+{
+  printf '['
+  printf '<%s>' "$@"
+  printf ']\n'
+} >> "$FM_TEST_GH_LOG"
+case "${1:-} ${2:-}" in
+  "pr view")
+    printf 'OPEN\t%s\t%s\n' "${FM_TEST_BASE:-main}" "${FM_TEST_HEAD:?}"
+    ;;
+  "api repos"*)
+    printf '%s\n' "${FM_TEST_BEHIND:-0}"
+    ;;
+  "pr checks")
+    case " $* " in
+      *" --required "*) printf '%s\n' "${FM_TEST_REQUIRED_JSON:-[]}" ;;
+      *) printf '%s\n' "${FM_TEST_ALL_JSON:-[]}" ;;
+    esac
+    ;;
+  "pr comment")
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SH
+  chmod +x "$dir/fakebin/gh"
+}
+
+run_kick() {  # <dir>
+  local dir=$1
+  FM_TEST_GH_LOG="$dir/gh.log" FM_TEST_HEAD="$HEAD_SHA" \
+    FM_TEST_BASE="${FM_TEST_BASE:-main}" FM_TEST_BEHIND="${FM_TEST_BEHIND:-0}" \
+    FM_TEST_REQUIRED_JSON="${FM_TEST_REQUIRED_JSON:-[]}" \
+    FM_TEST_ALL_JSON="${FM_TEST_ALL_JSON:-[]}" \
+    PATH="$dir/fakebin:$BASE_PATH" run_front "$dir" greptile-kick project-alpha
+}
+
+test_greptile_gate_refusals_and_single_action() {
+  local dir rc comment_count
+  dir=$(make_home greptile)
+  install_github_gate_fake "$dir"
+  : > "$dir/gh.log"
+  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "Greptile front enqueue failed"
+  run_front "$dir" enqueue project-alpha task-b https://github.com/o/r/pull/2 >/dev/null \
+    || fail "Greptile parked enqueue failed"
+
+  set +e
+  FM_TEST_BEHIND=1 run_kick "$dir" >/dev/null 2> "$dir/behind.err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "behind front received Greptile authority"
+  assert_no_grep '<pr><comment>' "$dir/gh.log" "behind front posted a Greptile comment"
+
+  : > "$dir/gh.log"
+  set +e
+  FM_TEST_REQUIRED_JSON='[{"name":"CI","state":"PENDING"}]' run_kick "$dir" \
+    >/dev/null 2> "$dir/required.err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "front with a non-green required check received Greptile authority"
+  assert_no_grep '<pr><comment>' "$dir/gh.log" "non-green required check posted a Greptile comment"
+
+  : > "$dir/gh.log"
+  set +e
+  FM_TEST_REQUIRED_JSON='[{"name":"CI","state":"SUCCESS"}]' \
+    FM_TEST_ALL_JSON='[{"name":"Greptile Review","state":"IN_PROGRESS"}]' \
+    run_kick "$dir" >/dev/null 2> "$dir/pending.err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "already-pending Greptile review received another kick"
+  assert_no_grep '<pr><comment>' "$dir/gh.log" "pending Greptile review received a comment"
+
+  : > "$dir/gh.log"
+  FM_TEST_REQUIRED_JSON='[{"name":"CI","state":"SUCCESS"},{"name":"Greptile Review","state":"PENDING"}]' \
+    FM_TEST_ALL_JSON='[{"name":"CI","state":"SUCCESS"},{"name":"Greptile Review","state":"FAILURE"}]' \
+    run_kick "$dir" >/dev/null || fail "fully eligible front was not kicked"
+  comment_count=$(grep -c '^\[<pr><comment>' "$dir/gh.log")
+  [ "$comment_count" -eq 1 ] || fail "eligible kick did not post exactly one comment"
+  assert_grep '[<pr><comment><1><--repo><o/r><--body><@greptile review>]' "$dir/gh.log" \
+    "eligible kick did not use the explicit Greptile review comment"
+  assert_no_grep '<2>' "$dir/gh.log" "parked PR received GitHub authority"
+  assert_no_grep '<update-branch>' "$dir/gh.log" "Greptile gate updated a branch"
+  pass "Greptile kick fails closed at every gate and comments once for the front"
+}
+
+test_queue_order_and_promotion
+test_queue_conflicts_and_paths_fail_closed
+test_pr_check_enqueues_project_front
+test_confirmed_merge_promotes_only_exact_front
+test_greptile_gate_refusals_and_single_action

--- a/tests/fm-merge-front.test.sh
+++ b/tests/fm-merge-front.test.sh
@@ -100,10 +100,10 @@ test_queue_conflicts_and_paths_fail_closed() {
   run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1 >/dev/null \
     || fail "conflict fixture enqueue failed"
   set +e
-  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/2 >/dev/null 2>&1
+  run_front "$dir" enqueue project-alpha task-b https://github.com/o/r/pull/1 >/dev/null 2>&1
   rc=$?
   set -e
-  [ "$rc" -ne 0 ] || fail "one task was rebound to a different PR"
+  [ "$rc" -ne 0 ] || fail "one PR was rebound to a different task"
   [ "$(grep -c '^task=' "$dir/home/state/merge-front/project-alpha.queue")" -eq 1 ] \
     || fail "conflicting enqueue changed the queue"
 
@@ -129,6 +129,49 @@ test_queue_conflicts_and_paths_fail_closed() {
   pass "queue conflicts, traversal, and symlink destinations fail closed"
 }
 
+test_same_task_replacement_and_removal_recovery() {
+  local dir status rebound removed rc
+  dir=$(make_home recovery)
+  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "recovery fixture front enqueue failed"
+  run_front "$dir" enqueue project-alpha task-b https://github.com/o/r/pull/2 >/dev/null \
+    || fail "recovery fixture parked enqueue failed"
+
+  rebound=$(run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/3) \
+    || fail "same task could not register a replacement PR"
+  assert_contains "$rebound" $'front=task-a\thttps://github.com/o/r/pull/3' \
+    "replacement PR did not keep the task's queue position"
+  status=$(run_front "$dir" status project-alpha) || fail "rebound queue status failed"
+  assert_contains "$status" $'front=task-a\thttps://github.com/o/r/pull/3' \
+    "replacement PR did not become the recorded front"
+  assert_contains "$status" $'parked=task-b\thttps://github.com/o/r/pull/2' \
+    "replacement PR disturbed the parked entry"
+  [ "$(grep -c '^task=' "$dir/home/state/merge-front/project-alpha.queue")" -eq 2 ] \
+    || fail "replacement PR changed queue cardinality"
+
+  removed=$(run_front "$dir" remove project-alpha task-a https://github.com/o/r/pull/3) \
+    || fail "stuck front could not be retired"
+  assert_contains "$removed" $'removed=task-a\thttps://github.com/o/r/pull/3' \
+    "removal did not report the retired identity"
+  assert_contains "$removed" $'front=task-b\thttps://github.com/o/r/pull/2' \
+    "retiring the front did not expose the next PR"
+  status=$(run_front "$dir" status project-alpha) || fail "post-removal status failed"
+  assert_contains "$status" 'front=task-b' "retired front was not durably removed"
+  assert_no_grep 'task-a' "$dir/home/state/merge-front/project-alpha.queue" \
+    "removal retained the retired entry"
+
+  removed=$(run_front "$dir" remove project-alpha task-a https://github.com/o/r/pull/3) \
+    || fail "repeated removal was not idempotent"
+  assert_contains "$removed" 'removed=none' "absent identity reported a removal"
+
+  set +e
+  run_front "$dir" remove project-alpha task-b >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "removal without a PR identity was accepted"
+  pass "same-task replacement rebinds in place and removal retires a stuck front"
+}
+
 test_pr_check_enqueues_project_front() {
   local dir status
   dir=$(make_home pr-check)
@@ -147,6 +190,15 @@ SH
   status=$(run_front "$dir" status project-alpha) || fail "registered queue status failed"
   assert_contains "$status" $'front=task-a\thttps://github.com/o/r/pull/7' \
     "fm-pr-check did not enqueue by task project"
+  FM_ROOT_OVERRIDE="$dir/fake-root" FM_HOME="$dir/home" \
+    PATH="$dir/fakebin:$BASE_PATH" \
+    "$PR_CHECK" task-a https://github.com/o/r/pull/8 >/dev/null \
+    || fail "fm-pr-check could not register a replacement PR for the same task"
+  status=$(run_front "$dir" status project-alpha) || fail "replacement queue status failed"
+  assert_contains "$status" $'front=task-a\thttps://github.com/o/r/pull/8' \
+    "replacement registration did not rebind the queued PR"
+  [ "$(grep -c '^task=' "$dir/home/state/merge-front/project-alpha.queue")" -eq 1 ] \
+    || fail "replacement registration duplicated the task"
   pass "PR registration structurally enrolls the task in its project queue"
 }
 
@@ -157,34 +209,35 @@ run_outcome() {  # <dir> <task> <url>
       _ "$MERGE_OUTCOME" "$dir/home" "$dir/home/state" "$task" "$url"
 }
 
-test_confirmed_merge_promotes_only_exact_front() {
-  local dir status rc
+test_confirmed_merge_reconciles_exact_identity() {
+  local dir status
   dir=$(make_home merge-outcome)
   write_meta "$dir" task-a
   write_meta "$dir" task-b
+  write_meta "$dir" task-c
   run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1 >/dev/null \
     || fail "first merge-outcome enqueue failed"
   run_front "$dir" enqueue project-alpha task-b https://github.com/o/r/pull/2 >/dev/null \
     || fail "second merge-outcome enqueue failed"
 
-  set +e
-  run_outcome "$dir" task-b https://github.com/o/r/pull/2 >/dev/null 2>&1
-  rc=$?
-  set -e
-  [ "$rc" -ne 0 ] || fail "out-of-order merged PR advanced the queue"
+  run_outcome "$dir" task-b https://github.com/o/r/pull/2 >/dev/null \
+    || fail "out-of-order merged PR could not publish its outcome"
   status=$(run_front "$dir" status project-alpha) || fail "out-of-order queue status failed"
-  assert_contains "$status" 'front=task-a' "out-of-order merge displaced the front"
-  assert_contains "$status" 'parked=task-b' "out-of-order merge removed the parked PR"
+  assert_contains "$status" $'front=task-a\thttps://github.com/o/r/pull/1' \
+    "out-of-order merge displaced the front"
+  assert_no_grep 'task-b' "$dir/home/state/merge-front/project-alpha.queue" \
+    "out-of-order merge retained its own queued entry"
+
+  run_outcome "$dir" task-c https://github.com/o/r/pull/9 >/dev/null \
+    || fail "unqueued merged PR could not publish its outcome"
+  status=$(run_front "$dir" status project-alpha) || fail "unqueued outcome status failed"
+  assert_contains "$status" 'front=task-a' "unqueued merged PR changed the queue"
 
   run_outcome "$dir" task-a https://github.com/o/r/pull/1 >/dev/null \
     || fail "confirmed front merge did not advance the queue"
   status=$(run_front "$dir" status project-alpha) || fail "advanced queue status failed"
-  assert_contains "$status" 'front=task-b' "confirmed front merge did not promote its successor"
-  run_outcome "$dir" task-b https://github.com/o/r/pull/2 >/dev/null \
-    || fail "promoted successor merge did not advance the queue"
-  status=$(run_front "$dir" status project-alpha) || fail "empty promoted queue status failed"
-  assert_contains "$status" 'front=none' "second confirmed merge did not empty the queue"
-  pass "confirmed merge completion promotes only the exact current front"
+  assert_contains "$status" 'front=none' "confirmed front merge did not empty the queue"
+  pass "a confirmed merge always publishes and retires only its own queued entry"
 }
 
 install_github_gate_fake() {  # <dir>
@@ -265,6 +318,13 @@ test_greptile_gate_refusals_and_single_action() {
   assert_no_grep '<pr><comment>' "$dir/gh.log" "pending Greptile review received a comment"
 
   : > "$dir/gh.log"
+  FM_TEST_REQUIRED_JSON='[{"name":"CI","state":"SUCCESS"}]' \
+    FM_TEST_ALL_JSON='[{"name":"CI","state":"SUCCESS"},{"name":"Greptile Review","state":"ERROR"}]' \
+    run_kick "$dir" >/dev/null || fail "errored Greptile check could not be retriggered"
+  comment_count=$(grep -c '^\[<pr><comment>' "$dir/gh.log")
+  [ "$comment_count" -eq 1 ] || fail "errored Greptile check did not get exactly one kick"
+
+  : > "$dir/gh.log"
   FM_TEST_REQUIRED_JSON='[{"name":"CI","state":"SUCCESS"},{"name":"Greptile Review","state":"PENDING"}]' \
     FM_TEST_ALL_JSON='[{"name":"CI","state":"SUCCESS"},{"name":"Greptile Review","state":"FAILURE"}]' \
     run_kick "$dir" >/dev/null || fail "fully eligible front was not kicked"
@@ -279,6 +339,7 @@ test_greptile_gate_refusals_and_single_action() {
 
 test_queue_order_and_promotion
 test_queue_conflicts_and_paths_fail_closed
+test_same_task_replacement_and_removal_recovery
 test_pr_check_enqueues_project_front
-test_confirmed_merge_promotes_only_exact_front
+test_confirmed_merge_reconciles_exact_identity
 test_greptile_gate_refusals_and_single_action

--- a/tests/fm-merge-front.test.sh
+++ b/tests/fm-merge-front.test.sh
@@ -7,6 +7,8 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$ROOT/bin/fm-pr-lib.sh"
+# shellcheck source=bin/fm-merge-front-lib.sh
+. "$ROOT/bin/fm-merge-front-lib.sh"
 
 MERGE_FRONT="$ROOT/bin/fm-merge-front.sh"
 PR_CHECK="$ROOT/bin/fm-pr-check.sh"
@@ -45,14 +47,28 @@ run_front() {  # <dir> <args...>
     PATH="$dir/fakebin:$BASE_PATH" "$MERGE_FRONT" "$@"
 }
 
-write_meta() {  # <dir> <task>
-  local dir=$1 task=$2
+write_meta() {  # <dir> <task> [project-path]
+  local dir=$1 task=$2 project=${3:-$1/project-alpha}
   fm_write_meta "$dir/home/state/$task.meta" \
     "window=fm-$task" \
     "worktree=$dir/worktree-$task" \
-    "project=$dir/project-alpha" \
+    "project=$project" \
     "kind=ship" \
     "mode=no-mistakes"
+}
+
+# The durable queue key a registration derives from a project checkout path.
+# Callers that reach the queue through the CLI need the same mapping the
+# registration path used.
+project_key() {  # <project-path>
+  fm_merge_front_project_key_from_path "$1"
+}
+
+run_pr_check() {  # <dir> <task> <url>
+  local dir=$1 task=$2 url=$3
+  FM_ROOT_OVERRIDE="$dir/fake-root" FM_HOME="$dir/home" \
+    FM_STATE_OVERRIDE="$dir/home/state" \
+    PATH="$dir/fakebin:$BASE_PATH" "$PR_CHECK" "$task" "$url"
 }
 
 test_queue_order_and_promotion() {
@@ -173,9 +189,10 @@ test_same_task_replacement_and_removal_recovery() {
 }
 
 test_pr_check_enqueues_project_front() {
-  local dir status
+  local dir status key
   dir=$(make_home pr-check)
   write_meta "$dir" task-a
+  key=$(project_key "$dir/project-alpha") || fail "project key could not be derived"
   cat > "$dir/fakebin/gh" <<SH
 #!/usr/bin/env bash
 case "\${1:-} \${2:-}" in
@@ -183,23 +200,62 @@ case "\${1:-} \${2:-}" in
 esac
 SH
   chmod +x "$dir/fakebin/gh"
-  FM_ROOT_OVERRIDE="$dir/fake-root" FM_HOME="$dir/home" \
-    PATH="$dir/fakebin:$BASE_PATH" \
-    "$PR_CHECK" task-a https://github.com/o/r/pull/7 >/dev/null \
+  run_pr_check "$dir" task-a https://github.com/o/r/pull/7 >/dev/null \
     || fail "fm-pr-check could not register the queue entry"
-  status=$(run_front "$dir" status project-alpha) || fail "registered queue status failed"
+  status=$(run_front "$dir" status "$key") || fail "registered queue status failed"
   assert_contains "$status" $'front=task-a\thttps://github.com/o/r/pull/7' \
     "fm-pr-check did not enqueue by task project"
-  FM_ROOT_OVERRIDE="$dir/fake-root" FM_HOME="$dir/home" \
-    PATH="$dir/fakebin:$BASE_PATH" \
-    "$PR_CHECK" task-a https://github.com/o/r/pull/8 >/dev/null \
+  run_pr_check "$dir" task-a https://github.com/o/r/pull/8 >/dev/null \
     || fail "fm-pr-check could not register a replacement PR for the same task"
-  status=$(run_front "$dir" status project-alpha) || fail "replacement queue status failed"
+  status=$(run_front "$dir" status "$key") || fail "replacement queue status failed"
   assert_contains "$status" $'front=task-a\thttps://github.com/o/r/pull/8' \
     "replacement registration did not rebind the queued PR"
-  [ "$(grep -c '^task=' "$dir/home/state/merge-front/project-alpha.queue")" -eq 1 ] \
+  [ "$(grep -c '^task=' "$dir/home/state/merge-front/$key.queue")" -eq 1 ] \
     || fail "replacement registration duplicated the task"
   pass "PR registration structurally enrolls the task in its project queue"
+}
+
+# An ordinary checkout basename is a naming convention, not a registration
+# precondition: a project directory that is not slug-shaped must still register.
+test_pr_check_registers_any_checkout_basename() {
+  local dir status key
+  dir=$(make_home odd-basename)
+  mkdir -p "$dir/my repo (v2)"
+  write_meta "$dir" task-a "$dir/my repo (v2)"
+  key=$(project_key "$dir/my repo (v2)") || fail "odd basename yielded no queue key"
+  run_pr_check "$dir" task-a https://github.com/o/r/pull/7 >/dev/null \
+    || fail "a non-slug checkout basename blocked PR registration"
+  status=$(run_front "$dir" status "$key") || fail "odd-basename queue status failed"
+  assert_contains "$status" $'front=task-a\thttps://github.com/o/r/pull/7' \
+    "the odd-basename project did not get its own front"
+  pass "PR registration accepts any checkout basename and isolates its queue"
+}
+
+# The one enqueue refusal no retry can clear must land before any mutation:
+# neither the task meta nor the poll may be touched when the URL is taken.
+test_pr_check_refuses_bound_url_before_mutating() {
+  local dir key rc
+  dir=$(make_home bound-url)
+  write_meta "$dir" task-a
+  write_meta "$dir" task-b
+  key=$(project_key "$dir/project-alpha") || fail "project key could not be derived"
+  run_pr_check "$dir" task-a https://github.com/o/r/pull/7 >/dev/null \
+    || fail "bound-url fixture registration failed"
+
+  set +e
+  run_pr_check "$dir" task-b https://github.com/o/r/pull/7 >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "a PR bound to another task was re-registered"
+  assert_no_grep '^pr=' "$dir/home/state/task-b.meta" \
+    "refused registration still rewrote the task metadata"
+  [ ! -e "$dir/home/state/task-b.check.sh" ] \
+    || fail "refused registration still armed a merge poll"
+  [ ! -e "$dir/home/state/task-b.pr-poll" ] \
+    || fail "refused registration still published a poll"
+  [ "$(grep -c '^task=' "$dir/home/state/merge-front/$key.queue")" -eq 1 ] \
+    || fail "refused registration changed the queue"
+  pass "registration refuses an already-bound PR URL over untouched state"
 }
 
 run_outcome() {  # <dir> <task> <url>
@@ -210,34 +266,59 @@ run_outcome() {  # <dir> <task> <url>
 }
 
 test_confirmed_merge_reconciles_exact_identity() {
-  local dir status
+  local dir status key
   dir=$(make_home merge-outcome)
   write_meta "$dir" task-a
   write_meta "$dir" task-b
   write_meta "$dir" task-c
-  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1 >/dev/null \
+  key=$(project_key "$dir/project-alpha") || fail "project key could not be derived"
+  run_front "$dir" enqueue "$key" task-a https://github.com/o/r/pull/1 >/dev/null \
     || fail "first merge-outcome enqueue failed"
-  run_front "$dir" enqueue project-alpha task-b https://github.com/o/r/pull/2 >/dev/null \
+  run_front "$dir" enqueue "$key" task-b https://github.com/o/r/pull/2 >/dev/null \
     || fail "second merge-outcome enqueue failed"
 
   run_outcome "$dir" task-b https://github.com/o/r/pull/2 >/dev/null \
     || fail "out-of-order merged PR could not publish its outcome"
-  status=$(run_front "$dir" status project-alpha) || fail "out-of-order queue status failed"
+  status=$(run_front "$dir" status "$key") || fail "out-of-order queue status failed"
   assert_contains "$status" $'front=task-a\thttps://github.com/o/r/pull/1' \
     "out-of-order merge displaced the front"
-  assert_no_grep 'task-b' "$dir/home/state/merge-front/project-alpha.queue" \
+  assert_no_grep 'task-b' "$dir/home/state/merge-front/$key.queue" \
     "out-of-order merge retained its own queued entry"
 
   run_outcome "$dir" task-c https://github.com/o/r/pull/9 >/dev/null \
     || fail "unqueued merged PR could not publish its outcome"
-  status=$(run_front "$dir" status project-alpha) || fail "unqueued outcome status failed"
+  status=$(run_front "$dir" status "$key") || fail "unqueued outcome status failed"
   assert_contains "$status" 'front=task-a' "unqueued merged PR changed the queue"
 
   run_outcome "$dir" task-a https://github.com/o/r/pull/1 >/dev/null \
     || fail "confirmed front merge did not advance the queue"
-  status=$(run_front "$dir" status project-alpha) || fail "advanced queue status failed"
+  status=$(run_front "$dir" status "$key") || fail "advanced queue status failed"
   assert_contains "$status" 'front=none' "confirmed front merge did not empty the queue"
   pass "a confirmed merge always publishes and retires only its own queued entry"
+}
+
+# A front whose task record is already gone (teardown, or a merge observed after
+# the record was removed) must still be retired, or it parks every PR behind it.
+test_confirmed_merge_retires_front_without_task_metadata() {
+  local dir status key
+  dir=$(make_home merge-outcome-no-meta)
+  write_meta "$dir" task-a
+  write_meta "$dir" task-b
+  key=$(project_key "$dir/project-alpha") || fail "project key could not be derived"
+  run_front "$dir" enqueue "$key" task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "no-meta fixture front enqueue failed"
+  run_front "$dir" enqueue "$key" task-b https://github.com/o/r/pull/2 >/dev/null \
+    || fail "no-meta fixture parked enqueue failed"
+  rm -f "$dir/home/state/task-a.meta"
+
+  run_outcome "$dir" task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "merged front without task metadata could not publish its outcome"
+  status=$(run_front "$dir" status "$key") || fail "no-meta queue status failed"
+  assert_contains "$status" $'front=task-b\thttps://github.com/o/r/pull/2' \
+    "a front with no task metadata stayed queued in front of the next PR"
+  assert_no_grep 'task-a' "$dir/home/state/merge-front/$key.queue" \
+    "the metadata-less front was not retired"
+  pass "a merged front is retired even when its task record is already gone"
 }
 
 install_github_gate_fake() {  # <dir>
@@ -251,6 +332,9 @@ install_github_gate_fake() {  # <dir>
 } >> "$FM_TEST_GH_LOG"
 case "${1:-} ${2:-}" in
   "pr view")
+    if [ -n "${FM_TEST_GH_HOOK:-}" ]; then
+      "$FM_TEST_GH_HOOK" >> "$FM_TEST_GH_LOG" 2>&1
+    fi
     printf 'OPEN\t%s\t%s\n' "${FM_TEST_BASE:-main}" "${FM_TEST_HEAD:?}"
     ;;
   "api repos"*)
@@ -278,6 +362,7 @@ run_kick() {  # <dir>
     FM_TEST_BASE="${FM_TEST_BASE:-main}" FM_TEST_BEHIND="${FM_TEST_BEHIND:-0}" \
     FM_TEST_REQUIRED_JSON="${FM_TEST_REQUIRED_JSON:-[]}" \
     FM_TEST_ALL_JSON="${FM_TEST_ALL_JSON:-[]}" \
+    FM_TEST_GH_HOOK="${FM_TEST_GH_HOOK:-}" \
     PATH="$dir/fakebin:$BASE_PATH" run_front "$dir" greptile-kick project-alpha
 }
 
@@ -337,9 +422,72 @@ test_greptile_gate_refusals_and_single_action() {
   pass "Greptile kick fails closed at every gate and comments once for the front"
 }
 
+# The gate's GitHub reads must not hold the per-project queue lock: a slow forge
+# would otherwise starve ordinary enqueue and confirmed-merge retirement, whose
+# waits are bounded far below the gate's total GitHub budget.
+test_greptile_kick_leaves_the_queue_usable_during_github_reads() {
+  local dir
+  dir=$(make_home greptile-lock)
+  install_github_gate_fake "$dir"
+  : > "$dir/gh.log"
+  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "lock-hold fixture enqueue failed"
+  cat > "$dir/hook.sh" <<SH
+#!/usr/bin/env bash
+FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" \
+  FM_MERGE_FRONT_LOCK_TIMEOUT=2 "$MERGE_FRONT" \
+  enqueue project-alpha task-b https://github.com/o/r/pull/2 >/dev/null 2>&1 \
+  && printf 'concurrent-enqueue=ok\n' > "$dir/hook.out" \
+  || printf 'concurrent-enqueue=blocked\n' > "$dir/hook.out"
+SH
+  chmod +x "$dir/hook.sh"
+  FM_TEST_GH_HOOK="$dir/hook.sh" \
+    FM_TEST_REQUIRED_JSON='[{"name":"CI","state":"SUCCESS"}]' \
+    FM_TEST_ALL_JSON='[{"name":"CI","state":"SUCCESS"}]' \
+    run_kick "$dir" >/dev/null || fail "eligible front was not kicked"
+  assert_grep 'concurrent-enqueue=ok' "$dir/hook.out" \
+    "the queue lock was held across the gate's GitHub reads"
+  pass "the Greptile gate never holds the queue lock across GitHub calls"
+}
+
+# Releasing the lock means the front can change mid-gate, so the structural gate
+# is re-read before the single side effect.
+test_greptile_kick_refuses_when_the_front_changes_mid_gate() {
+  local dir rc
+  dir=$(make_home greptile-revalidate)
+  install_github_gate_fake "$dir"
+  : > "$dir/gh.log"
+  run_front "$dir" enqueue project-alpha task-a https://github.com/o/r/pull/1 >/dev/null \
+    || fail "revalidate fixture front enqueue failed"
+  run_front "$dir" enqueue project-alpha task-b https://github.com/o/r/pull/2 >/dev/null \
+    || fail "revalidate fixture parked enqueue failed"
+  cat > "$dir/hook.sh" <<SH
+#!/usr/bin/env bash
+FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" "$MERGE_FRONT" \
+  remove project-alpha task-a https://github.com/o/r/pull/1 >/dev/null 2>&1
+SH
+  chmod +x "$dir/hook.sh"
+  set +e
+  FM_TEST_GH_HOOK="$dir/hook.sh" \
+    FM_TEST_REQUIRED_JSON='[{"name":"CI","state":"SUCCESS"}]' \
+    FM_TEST_ALL_JSON='[{"name":"CI","state":"SUCCESS"}]' \
+    run_kick "$dir" >/dev/null 2> "$dir/revalidate.err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "a PR retired mid-gate was still kicked"
+  assert_no_grep '<pr><comment>' "$dir/gh.log" \
+    "a PR that stopped being the front still received a Greptile comment"
+  pass "the Greptile gate revalidates the front before its single side effect"
+}
+
 test_queue_order_and_promotion
 test_queue_conflicts_and_paths_fail_closed
 test_same_task_replacement_and_removal_recovery
 test_pr_check_enqueues_project_front
+test_pr_check_registers_any_checkout_basename
+test_pr_check_refuses_bound_url_before_mutating
 test_confirmed_merge_reconciles_exact_identity
+test_confirmed_merge_retires_front_without_task_metadata
 test_greptile_gate_refusals_and_single_action
+test_greptile_kick_leaves_the_queue_usable_during_github_reads
+test_greptile_kick_refuses_when_the_front_changes_mid_gate

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -753,6 +753,42 @@ test_squash_merged_branch_deleted_allows() {
   pass "squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)"
 }
 
+# Teardown retires the task's merge-front queue entry. Without it, a torn-down
+# front stays queued and parks every later PR in that project with no
+# update-branch or Greptile authority.
+test_teardown_retires_merge_front_queue_entry() {
+  local case_dir rc pr_head key status
+  case_dir=$(make_case merge-front-teardown)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  pr_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  add_gh_pr_merged_for_head "$case_dir" "$pr_head"
+  key=$(bash -c '. "$1"; fm_merge_front_project_key_from_path "$2"' \
+    _ "$ROOT/bin/fm-merge-front-lib.sh" "$case_dir/project") \
+    || fail "merge-front-teardown: project key could not be derived"
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" \
+    PATH="$case_dir/fakebin:$PATH" \
+    "$PR_CHECK" task-x1 https://github.com/example/repo/pull/7 >/dev/null \
+    || fail "merge-front-teardown: fm-pr-check could not register the PR"
+  status=$(FM_STATE_OVERRIDE="$case_dir/state" "$ROOT/bin/fm-merge-front.sh" status "$key") \
+    || fail "merge-front-teardown: queue status before teardown failed"
+  assert_contains "$status" 'front=task-x1' \
+    "merge-front-teardown: registration did not make the task the front"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "merge-front-teardown: teardown should succeed for a merged PR"
+
+  status=$(FM_STATE_OVERRIDE="$case_dir/state" "$ROOT/bin/fm-merge-front.sh" status "$key") \
+    || fail "merge-front-teardown: queue status after teardown failed"
+  assert_contains "$status" 'front=none' \
+    "merge-front-teardown: the torn-down task stayed queued as the front"
+  pass "teardown retires the task's merge-front queue entry"
+}
+
 test_squash_merged_pr_allows_when_head_ancestor_of_pr_head() {
   local case_dir rc local_head pr_head
   case_dir=$(make_case squash-ancestor)
@@ -3222,6 +3258,7 @@ test_herdr_projection_teardown_retires_journal_only_after_confirmed_close
 test_herdr_projection_teardown_retains_journal_when_close_unconfirmed
 test_herdr_projection_teardown_surfaces_restore_failure_without_blocking_cleanup
 test_squash_merged_branch_deleted_allows
+test_teardown_retires_merge_front_queue_entry
 test_squash_merged_pr_allows_when_head_ancestor_of_pr_head
 test_no_pr_recorded_discovers_merged_pr_by_branch_allows
 test_squash_merged_pr_allows_replayed_unpushed_patch


### PR DESCRIPTION
## Summary
Adds a structural per-project merge-front queue for Firstmate so only the front PR gets Greptile-kick / update authority, with promote-on-merge and recovery paths for out-of-order merges and torn-down fronts.

## Why
Captain-approved: soft merge-front process was burning Greptile reviews on parked PRs. This makes the queue durable and gateable.

## Notes
- Validated via no-mistakes; push to `kunchenguid/firstmate` failed (mikefwille READ-only), so this PR is from the mikefwille fork.
- Head: `d4bc1b2`

---
Closed and abandoned per captain instruction 2026-09-05: do not open or merge PRs against kunchenguid/firstmate from this fleet.